### PR TITLE
add eslint 6.x as peer dependency to eslint-plugin

### DIFF
--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -33,6 +33,9 @@
 		"globals": "^12.0.0",
 		"requireindex": "^1.2.0"
 	},
+	"peerDependencies": {
+		"eslint": "6.x"
+  },
 	"publishConfig": {
 		"access": "public"
 	}


### PR DESCRIPTION
## Description
related https://github.com/WordPress/gutenberg/issues/17361#issuecomment-530796459

adss eslint 6.x as a peer dependency to `@wordpress/eslint-plugin` since it require that version to work  

