### PR TITLE
Editor: Don't edit the post when autosaving.

### DIFF
--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -375,13 +375,16 @@ export function* savePost( options = {} ) {
 	if ( ! ( yield select( STORE_KEY, 'isEditedPostSaveable' ) ) ) {
 		return;
 	}
-	yield dispatch( STORE_KEY, 'editPost', {
+	let edits = {
 		content: yield select( STORE_KEY, 'getEditedPostContent' ),
-	} );
+	};
+	if ( ! options.isAutosave ) {
+		yield dispatch( STORE_KEY, 'editPost', edits );
+	}
 
 	yield __experimentalRequestPostUpdateStart( options );
 	const previousRecord = yield select( STORE_KEY, 'getCurrentPost' );
-	const edits = {
+	edits = {
 		id: previousRecord.id,
 		...( yield select(
 			'core',
@@ -390,6 +393,7 @@ export function* savePost( options = {} ) {
 			previousRecord.type,
 			previousRecord.id
 		) ),
+		...edits,
 	};
 	yield dispatch(
 		'core',

--- a/packages/editor/src/store/test/actions.js
+++ b/packages/editor/src/store/test/actions.js
@@ -92,12 +92,14 @@ describe( 'Post generator actions', () => {
 				},
 			],
 			[
-				"yields an action for editing the post entity's content",
+				"yields an action for editing the post entity's content if not an autosave",
 				() => true,
 				() => {
-					const edits = { content: currentPost().content };
-					const { value } = fulfillment.next( edits.content );
-					expect( value ).toEqual( dispatch( STORE_KEY, 'editPost', edits ) );
+					if ( ! isAutosave ) {
+						const edits = { content: currentPost().content };
+						const { value } = fulfillment.next( edits.content );
+						expect( value ).toEqual( dispatch( STORE_KEY, 'editPost', edits ) );
+					}
 				},
 			],
 			[
@@ -148,7 +150,7 @@ describe( 'Post generator actions', () => {
 							'saveEntityRecord',
 							'postType',
 							post.type,
-							post,
+							isAutosave ? { ...post, content: undefined } : post,
 							{
 								isAutosave,
 							}


### PR DESCRIPTION
## Description

This PR stops the editor from clearing redo levels when autosaving.

## How has this been tested?

It was verified that autosaves no longer clear the redo stack.

## Types of Changes

*Bug Fix:* Stop autosaves from clearing the redo stack.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
