### PR TITLE
Editor: Save post after deletion so that its status is refreshed and redirection happens.

### DIFF
--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -493,12 +493,9 @@ export function* trashPost() {
 			}
 		);
 
-		// TODO: This should be an updatePost action (updating subsets of post
-		// properties), but right now editPost is tied with change detection.
 		yield dispatch(
 			STORE_KEY,
-			'resetPost',
-			{ ...post, status: 'trash' }
+			'savePost'
 		);
 	} catch ( error ) {
 		yield dispatch(

--- a/packages/editor/src/store/test/actions.js
+++ b/packages/editor/src/store/test/actions.js
@@ -347,12 +347,11 @@ describe( 'Post generator actions', () => {
 					}
 				) );
 			} );
-			it( 'yields expected dispatch action for resetting the post', () => {
+			it( 'yields expected dispatch action for saving the post', () => {
 				const { value } = fulfillment.next();
 				expect( value ).toEqual( dispatch(
 					STORE_KEY,
-					'resetPost',
-					{ ...currentPost, status: 'trash' }
+					'savePost',
 				) );
 			} );
 		} );


### PR DESCRIPTION
Fixes #17426

## Description

This PR fixes the issue described in #17426.

## How has this been tested?

It was verified that moving a post to the trash works as expected.

## Types of Changes

*Bug Fix:* Redirect users after moving a post to the trash.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
