### PR TITLE
Conditionally include the block styles functionality

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -48,75 +48,82 @@ function gutenberg_reregister_core_block_types() {
 }
 add_action( 'init', 'gutenberg_reregister_core_block_types' );
 
-/**
- * Registers a new block style.
- *
- * @param string $block_name       Block type name including namespace.
- * @param array  $style_properties Array containing the properties of the style name, label, style (name of the stylesheet to be enqueued), inline_style (string containing the CSS to be added).
- *
- * @return boolean True if the block style was registered with success and false otherwise.
- */
-function register_block_style( $block_name, $style_properties ) {
-	return WP_Block_Styles_Registry::get_instance()->register( $block_name, $style_properties );
+if ( ! function_exists( 'register_block_style' ) ) {
+	/**
+	 * Registers a new block style.
+	 *
+	 * @param string $block_name       Block type name including namespace.
+	 * @param array  $style_properties Array containing the properties of the style name, label, style (name of the stylesheet to be enqueued), inline_style (string containing the CSS to be added).
+	 *
+	 * @return boolean True if the block style was registered with success and false otherwise.
+	 */
+	function register_block_style( $block_name, $style_properties ) {
+		return WP_Block_Styles_Registry::get_instance()->register( $block_name, $style_properties );
+	}
 }
 
-/**
- * Unregisters a block style.
- *
- * @param string $block_name       Block type name including namespace.
- * @param array  $block_style_name Block style name.
- *
- * @return boolean True if the block style was unregistered with success and false otherwise.
- */
-function unregister_block_style( $block_name, $block_style_name ) {
-	return WP_Block_Styles_Registry::get_instance()->unregister( $block_name, $block_style_name );
+if ( ! function_exists( 'unregister_block_style' ) ) {
+	/**
+	 * Unregisters a block style.
+	 *
+	 * @param string $block_name       Block type name including namespace.
+	 * @param array  $block_style_name Block style name.
+	 *
+	 * @return boolean True if the block style was unregistered with success and false otherwise.
+	 */
+	function unregister_block_style( $block_name, $block_style_name ) {
+		return WP_Block_Styles_Registry::get_instance()->unregister( $block_name, $block_style_name );
+	}
 }
 
-/**
- * Function responsible for enqueuing the styles required for block styles functionality on the editor and on the frontend.
- */
-function enqueue_block_styles_assets() {
-	$block_styles = WP_Block_Styles_Registry::get_instance()->get_all_registered();
+if ( ! has_action( 'enqueue_block_assets', 'enqueue_block_styles_assets' ) ) {
+	/**
+	 * Function responsible for enqueuing the styles required for block styles functionality on the editor and on the frontend.
+	 */
+	function gutenberg_enqueue_block_styles_assets() {
+		$block_styles = WP_Block_Styles_Registry::get_instance()->get_all_registered();
 
-	foreach ( $block_styles as $styles ) {
-		foreach ( $styles as $style_properties ) {
-			if ( isset( $style_properties['style_handle'] ) ) {
-				wp_enqueue_style( $style_properties['style_handle'] );
-			}
-			if ( isset( $style_properties['inline_style'] ) ) {
-				wp_add_inline_style( 'wp-block-library', $style_properties['inline_style'] );
+		foreach ( $block_styles as $styles ) {
+			foreach ( $styles as $style_properties ) {
+				if ( isset( $style_properties['style_handle'] ) ) {
+					wp_enqueue_style( $style_properties['style_handle'] );
+				}
+				if ( isset( $style_properties['inline_style'] ) ) {
+					wp_add_inline_style( 'wp-block-library', $style_properties['inline_style'] );
+				}
 			}
 		}
 	}
+	add_action( 'enqueue_block_assets', 'gutenberg_enqueue_block_styles_assets', 30 );
 }
-add_action( 'enqueue_block_assets', 'enqueue_block_styles_assets', 30 );
+if ( ! has_action( 'enqueue_block_editor_assets', 'enqueue_editor_block_styles_assets' ) ) {
+	/**
+	 * Function responsible for enqueuing the assets required for block styles functionality on the editor.
+	 */
+	function gutenberg_enqueue_editor_block_styles_assets() {
+		$block_styles = WP_Block_Styles_Registry::get_instance()->get_all_registered();
 
-/**
- * Function responsible for enqueuing the assets required for block styles functionality on the editor.
- */
-function enqueue_editor_block_styles_assets() {
-	$block_styles = WP_Block_Styles_Registry::get_instance()->get_all_registered();
-
-	$register_script_lines = array( '( function() {' );
-	foreach ( $block_styles as $block_name => $styles ) {
-		foreach ( $styles as $style_properties ) {
-			$register_script_lines[] = sprintf(
-				'	wp.blocks.registerBlockStyle( \'%s\', %s );',
-				$block_name,
-				wp_json_encode(
-					array(
-						'name'  => $style_properties['name'],
-						'label' => $style_properties['label'],
+		$register_script_lines = array( '( function() {' );
+		foreach ( $block_styles as $block_name => $styles ) {
+			foreach ( $styles as $style_properties ) {
+				$register_script_lines[] = sprintf(
+					'	wp.blocks.registerBlockStyle( \'%s\', %s );',
+					$block_name,
+					wp_json_encode(
+						array(
+							'name'  => $style_properties['name'],
+							'label' => $style_properties['label'],
+						)
 					)
-				)
-			);
+				);
+			}
 		}
-	}
-	$register_script_lines[] = '} )();';
-	$inline_script           = implode( "\n", $register_script_lines );
+		$register_script_lines[] = '} )();';
+		$inline_script           = implode( "\n", $register_script_lines );
 
-	wp_register_script( 'wp-block-styles', false, array( 'wp-blocks' ), true, true );
-	wp_add_inline_script( 'wp-block-styles', $inline_script );
-	wp_enqueue_script( 'wp-block-styles' );
+		wp_register_script( 'wp-block-styles', false, array( 'wp-blocks' ), true, true );
+		wp_add_inline_script( 'wp-block-styles', $inline_script );
+		wp_enqueue_script( 'wp-block-styles' );
+	}
+	add_action( 'enqueue_block_editor_assets', 'gutenberg_enqueue_editor_block_styles_assets' );
 }
-add_action( 'enqueue_block_editor_assets', 'enqueue_editor_block_styles_assets' );

--- a/lib/load.php
+++ b/lib/load.php
@@ -28,8 +28,12 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	require dirname( __FILE__ ) . '/rest-api.php';
 }
 
+if ( ! class_exists( 'WP_Block_Styles_Registry' ) ) {
+	require dirname( __FILE__ ) . '/class-wp-block-styles-registry.php';
+}
+
 require dirname( __FILE__ ) . '/compat.php';
-require dirname( __FILE__ ) . '/class-wp-block-styles-registry.php';
+
 require dirname( __FILE__ ) . '/blocks.php';
 require dirname( __FILE__ ) . '/client-assets.php';
 require dirname( __FILE__ ) . '/demo.php';


### PR DESCRIPTION
## Description
This PR conditionally includes block styles server functionalityin the plugin.
This functionality will be added to core and also including it in the plugin would cause errors.

## How has this been tested?
I applied the WordPress patch available on https://core.trac.wordpress.org/ticket/47843 to the test environment.
I enabled the plugin in this branch and verified there are no errors.
I added the following code to the functions.php file of the enabled theme and verified styles were  registered as expected:
```
add_action(
	'enqueue_block_assets',
	function() {
		wp_register_style( 'myguten-style', get_template_directory_uri() . '/custom-style.css' );
	}
);

register_block_style(
	'core/quote',
	array(
		'name'         => 'fancy-quote',
		'label'        => 'Fancy Quote',
		'style_handle' => 'myguten-style',
	)
);

register_block_style(
	'core/quote',
	array(
		'name'         => 'not-fancy-quote',
		'label'        => 'Not Fancy Quote',
		'inline_style' => '.wp-block-quote.is-style-not-fancy-quote { color: blue; }',
	)
);

register_block_style(
	'core/quote',
	array(
		'name'         => 'unregistered-fancy-quote',
		'label'        => 'Unregistered Fancy Quote',
		'inline_style' => '.wp-block-quote.is-style-unregistered-fancy-quote { color: orange; }',
	)
);
unregister_block_style( 'core/quote', 'unregistered-fancy-quote' );
```

