### PR TITLE
Rich Text: Add missing keep placeholder on focus prop.

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -336,6 +336,7 @@ class RichTextWrapper extends Component {
 			didAutomaticChange,
 			undo,
 			placeholder,
+			keepPlaceholderOnFocus,
 			// eslint-disable-next-line no-unused-vars
 			allowedFormats,
 			withoutInteractiveFormatting,
@@ -383,7 +384,10 @@ class RichTextWrapper extends Component {
 				selectionEnd={ selectionEnd }
 				onSelectionChange={ onSelectionChange }
 				tagName={ tagName }
-				className={ classnames( classes, className, { 'is-selected': originalIsSelected } ) }
+				className={ classnames( classes, className, {
+					'is-selected': originalIsSelected,
+					'keep-placeholder-on-focus': keepPlaceholderOnFocus,
+				} ) }
 				placeholder={ placeholder }
 				allowedFormats={ adjustedAllowedFormats }
 				withoutInteractiveFormatting={ withoutInteractiveFormatting }

--- a/packages/block-editor/src/components/rich-text/style.scss
+++ b/packages/block-editor/src/components/rich-text/style.scss
@@ -34,23 +34,21 @@
 		}
 	}
 
+	[data-rich-text-placeholder] {
+		pointer-events: none;
+		cursor: text;
+	}
+
 	[data-rich-text-placeholder]::after {
 		content: attr(data-rich-text-placeholder);
-		pointer-events: none;
 		// Use opacity to work in various editor styles.
 		// We don't specify the color here, because blocks or editor styles might provide their own.
 		opacity: 0.62;
 	}
 
 	// Could be unset for individual rich text instances.
-	&.is-selected {
-		&.keep-placeholder-on-focus [data-rich-text-placeholder] {
-			pointer-events: none;
-		}
-
-		&:not(.keep-placeholder-on-focus) [data-rich-text-placeholder]::after {
-			display: none;
-		}
+	&.is-selected:not(.keep-placeholder-on-focus) [data-rich-text-placeholder]::after {
+		display: none;
 	}
 }
 

--- a/packages/block-editor/src/components/rich-text/style.scss
+++ b/packages/block-editor/src/components/rich-text/style.scss
@@ -36,7 +36,6 @@
 
 	[data-rich-text-placeholder] {
 		pointer-events: none;
-		cursor: text;
 	}
 
 	[data-rich-text-placeholder]::after {

--- a/packages/block-editor/src/components/rich-text/style.scss
+++ b/packages/block-editor/src/components/rich-text/style.scss
@@ -43,8 +43,14 @@
 	}
 
 	// Could be unset for individual rich text instances.
-	&.is-selected [data-rich-text-placeholder]::after {
-		display: none;
+	&.is-selected {
+		&.keep-placeholder-on-focus [data-rich-text-placeholder] {
+			pointer-events: none;
+		}
+
+		&:not(.keep-placeholder-on-focus) [data-rich-text-placeholder]::after {
+			display: none;
+		}
 	}
 }
 


### PR DESCRIPTION
Closes #17405

## Description

This PR fixes backwards compatibility issues that came with the unintentional removal of the `keepPlaceholderOnFocus` prop in `RichText`.

It does this by adding the prop back in.

## How has this been tested?

It was verified that setting the `keepPlaceholderOnFocus` prop to true makes the placeholder still show when selected/focused without content.

## Types of Changes

*Bug Fix:* Fix backwards compatibility issues arising from accidentally removing the `keepPlaceholderOnFocus` prop from `RichText`.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
