### PR TITLE
Rich Text: Add missing keep placeholder on focus prop documentation.

### DIFF
--- a/packages/block-editor/src/components/rich-text/README.md
+++ b/packages/block-editor/src/components/rich-text/README.md
@@ -21,6 +21,10 @@ Render a rich [`contenteditable` input](https://developer.mozilla.org/en-US/docs
 *Optional.* Placeholder text to show when the field is empty, similar to the
   [`input` and `textarea` attribute of the same name](https://developer.mozilla.org/en-US/docs/Learn/HTML/Forms/HTML5_updates#The_placeholder_attribute).
 
+### `keepPlaceholderOnFocus: Boolean`
+
+*Optional.* Show placeholder even when selected/focused, as long as there is no content.
+
 ### `multiline: Boolean | String`
 
 *Optional.* By default, a line break will be inserted on <kbd>Enter</kbd>. If the editable field can contain multiple paragraphs, this property can be set to create new paragraphs on <kbd>Enter</kbd>.


### PR DESCRIPTION
## Description

This PR follows #17439 to add missing documentation for the `keepPlaceholderOnFocus` prop.

## How has this been tested?

It was read, haha.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
