### PR TITLE
Fixed the import of LINE_SEPARATOR which appears to have been renamed to __UNSTABLE_LINE_SEPARATOR

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -21,7 +21,7 @@ import {
 	create,
 	replace,
 	split,
-	LINE_SEPARATOR,
+	__UNSTABLE_LINE_SEPARATOR as LINE_SEPARATOR,
 	toHTMLString,
 	slice,
 } from '@wordpress/rich-text';


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

In the playground, pasting into a multiline block resulted in the following error:
```
src.e31bb0bc.js:79016 Uncaught TypeError: Cannot read property 'length' of undefined
    at src.e31bb0bc.js:79016
    at String.replace (<anonymous>)
    at replace (src.e31bb0bc.js:78997)
    at RichTextWrapper.onPaste (src.e31bb0bc.js:150608)
    at RichText.onPaste (src.e31bb0bc.js:81505)
    at HTMLUnknownElement.callCallback (src.e31bb0bc.js:23966)
    at Object.invokeGuardedCallbackDev (src.e31bb0bc.js:24015)
    at invokeGuardedCallback (src.e31bb0bc.js:24069)
    at invokeGuardedCallbackAndCatchFirstError (src.e31bb0bc.js:24084)
    at executeDispatch (src.e31bb0bc.js:24217)
```

`LINE_SEPARATOR` from `@wordpress/rich-text` appears to have been renamed `__UNSTABLE_LINE_SEPARATOR` but not updated in `@wordpress/block-editor` which was still importing `LINE_SEPARATOR`.

I've updated the import statement which seems to fix it.

Looks like this fixes: #17396 

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
I ran the playground and pasted some multiline text into a multiline block and no longer received the error.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
