### PR TITLE
Fix: Broken link issue.

### DIFF
--- a/docs/designers-developers/developers/tutorials/block-tutorial/generate-blocks-with-wp-cli.md
+++ b/docs/designers-developers/developers/tutorials/block-tutorial/generate-blocks-with-wp-cli.md
@@ -5,7 +5,7 @@ It turns out that writing the simplest possible block which contains only static
 - [zgordon/gutenberg-course](https://github.com/zgordon/gutenberg-course) - a repository for Zac Gordon's Gutenberg Development Course
 - [ahmadawais/create-guten-block](https://github.com/ahmadawais/create-guten-block) - A zero-configuration developer toolkit for building WordPress Gutenberg block plugins
 
-It might be also a good idea to browse the folder with [all core blocks](/packages/block-library/src) to see how they are implemented.
+It might be also a good idea to browse the folder with [all core blocks](https://github.com/WordPress/gutenberg/tree/master/packages/block-library/src) to see how they are implemented.
 
 ## WP-CLI
 


### PR DESCRIPTION
While browsing the doc I got this link broken from doc https://developer.wordpress.org/block-editor/tutorials/block-tutorial/generate-blocks-with-wp-cli/.

It generates the links as `https://developer.wordpress.org/block-editor/designers-developers/developers/packages/packages-block-library/src/` which is broken.