### PR TITLE
RichText: fix invisible caret for placeholder on focus

### DIFF
--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -437,6 +437,16 @@ class RichText extends Component {
 		}
 
 		if ( start === value.start && end === value.end ) {
+			// If a placeholder is set, some browsers seems to place the
+			// selection after the placeholder instead of the text node that is
+			// padding the empty container element. The internal selection is
+			// set correctly to zero, but the caret is not visible. By
+			// reapplying the value to the DOM we reset the selection to the
+			// right node, making the caret visible again.
+			if ( value.text.length === 0 && start === 0 ) {
+				this.applyRecord( value );
+			}
+
 			return;
 		}
 


### PR DESCRIPTION
## Description
Follow up to #17439. See https://github.com/WordPress/gutenberg/pull/17439#issuecomment-531553437.

In Chrome, when a rich text instance is set to keep the placeholder on focus, the caret disappears on click. To fix the issue we can reset the selection to the correct one.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
