### PR TITLE
RichText: mark component in rich-text package experimental

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -12,7 +12,7 @@ import { withDispatch, withSelect } from '@wordpress/data';
 import { pasteHandler, children as childrenSource, getBlockTransforms, findTransform } from '@wordpress/blocks';
 import { withInstanceId, compose } from '@wordpress/compose';
 import {
-	RichText,
+	__experimentalRichText as RichText,
 	__unstableCreateElement,
 	isEmpty,
 	__unstableIsEmptyLine as isEmptyLine,

--- a/packages/rich-text/README.md
+++ b/packages/rich-text/README.md
@@ -273,11 +273,6 @@ _Returns_
 
 -   `Object`: A new value with replacements applied.
 
-<a name="RichText" href="#RichText">#</a> **RichText**
-
-Renders a rich content input, providing users with the option to format the
-content.
-
 <a name="slice" href="#slice">#</a> **slice**
 
 Slice a Rich Text value from `startIndex` to `endIndex`. Indices are

--- a/packages/rich-text/src/index.js
+++ b/packages/rich-text/src/index.js
@@ -34,5 +34,5 @@ export { outdentListItems as __unstableOutdentListItems } from './outdent-list-i
 export { changeListType as __unstableChangeListType } from './change-list-type';
 export { createElement as __unstableCreateElement } from './create-element';
 
-export { default as RichText } from './component';
+export { default as __experimentalRichText } from './component';
 export { default as __unstableFormatEdit } from './component/format-edit';


### PR DESCRIPTION
## Description

I’m thinking we should mark `wp.richText.RichText` experimental for now, to avoid confusion with other components. For now the component is anyway not meant to be used anywhere, it was not available in WP 5.2, and it’s remained undocumented.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
