### PR TITLE
Re-add & deprecate core/editor's getReferenceByDistinctEdits

### DIFF
--- a/docs/designers-developers/developers/data/data-core-editor.md
+++ b/docs/designers-developers/developers/data/data-core-editor.md
@@ -481,6 +481,29 @@ _Related_
 
 -   getPreviousBlockClientId in core/block-editor store.
 
+<a name="getReferenceByDistinctEdits" href="#getReferenceByDistinctEdits">#</a> **getReferenceByDistinctEdits**
+
+> **Deprecated** since Gutenberg 6.5.0.
+
+Returns a new reference when edited values have changed. This is useful in
+inferring where an edit has been made between states by comparison of the
+return values using strict equality.
+
+_Usage_
+
+    const hasEditOccurred = (
+       getReferenceByDistinctEdits( beforeState ) !==
+       getReferenceByDistinctEdits( afterState )
+    );
+
+_Parameters_
+
+-   _state_ `Object`: Editor state.
+
+_Returns_
+
+-   `*`: A value whose reference will change only when an edit occurs.
+
 <a name="getSelectedBlock" href="#getSelectedBlock">#</a> **getSelectedBlock**
 
 _Related_

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -231,6 +231,36 @@ export const getPostEdits = createRegistrySelector( ( select ) => ( state ) => {
 } );
 
 /**
+ * Returns a new reference when edited values have changed. This is useful in
+ * inferring where an edit has been made between states by comparison of the
+ * return values using strict equality.
+ *
+ * @deprecated since Gutenberg 6.5.0.
+ *
+ * @example
+ *
+ * ```
+ * const hasEditOccurred = (
+ *    getReferenceByDistinctEdits( beforeState ) !==
+ *    getReferenceByDistinctEdits( afterState )
+ * );
+ * ```
+ *
+ * @param {Object} state Editor state.
+ *
+ * @return {*} A value whose reference will change only when an edit occurs.
+ */
+export const getReferenceByDistinctEdits = createRegistrySelector(
+	( select ) => ( /* state */ ) => {
+		deprecated( '`wp.data.select( \'core/editor\' ).getReferenceByDistinctEdits`', {
+			alternative: '`wp.data.select( \'core\' ).getReferenceByDistinctEdits`',
+		} );
+
+		return select( 'core' ).getReferenceByDistinctEdits();
+	}
+);
+
+/**
  * Returns an attribute value of the saved post.
  *
  * @param {Object} state         Global application state.


### PR DESCRIPTION
Follow-up of #16490

## Description
<!-- Please describe what you have changed or added -->

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
