### PR TITLE
Fix fixtures for MS Word, and properly handle newlines

### DIFF
--- a/packages/blocks/src/api/raw-handling/ms-newline-normaliser.js
+++ b/packages/blocks/src/api/raw-handling/ms-newline-normaliser.js
@@ -1,0 +1,11 @@
+export default function( node ) {
+	if ( node.nodeName !== 'P' ) {
+		return;
+	}
+
+	if ( ! [ ...node.classList ].find( ( className ) => className.match( /^Mso[A-Z].*/ ) ) ) {
+		return;
+	}
+
+	node.innerHTML = node.innerHTML.replace( /(?<!<br>)\n/g, ' ' );
+}

--- a/packages/blocks/src/api/raw-handling/paste-handler.js
+++ b/packages/blocks/src/api/raw-handling/paste-handler.js
@@ -16,6 +16,7 @@ import isInlineContent from './is-inline-content';
 import phrasingContentReducer from './phrasing-content-reducer';
 import headRemover from './head-remover';
 import msListConverter from './ms-list-converter';
+import msNewlineNormaliser from './ms-newline-normaliser';
 import listReducer from './list-reducer';
 import imageCorrector from './image-corrector';
 import blockquoteNormaliser from './blockquote-normaliser';
@@ -201,6 +202,7 @@ export function pasteHandler( { HTML = '', plainText = '', mode = 'AUTO', tagNam
 		const filters = [
 			googleDocsUIDRemover,
 			msListConverter,
+			msNewlineNormaliser,
 			headRemover,
 			listReducer,
 			imageCorrector,

--- a/test/integration/fixtures/ms-word-in.html
+++ b/test/integration/fixtures/ms-word-in.html
@@ -1,11 +1,9 @@
 
-<p class=MsoTitle><span lang=EN-US style='mso-ansi-language:EN-US'>This is a
-title<o:p></o:p></span></p>
+<p class=MsoTitle><span lang=EN-US style='mso-ansi-language:EN-US'>This is a title<o:p></o:p></span></p>
 
 <p class=MsoNormal><span lang=EN-US style='mso-ansi-language:EN-US'><o:p>&nbsp;</o:p></span></p>
 
-<p class=MsoSubtitle><span lang=EN-US style='mso-ansi-language:EN-US'>This is a
-subtitle<o:p></o:p></span></p>
+<p class=MsoSubtitle><span lang=EN-US style='mso-ansi-language:EN-US'>This is a subtitle<o:p></o:p></span></p>
 
 <p class=MsoNormal><span lang=EN-US style='mso-ansi-language:EN-US'><o:p>&nbsp;</o:p></span></p>
 
@@ -20,6 +18,16 @@ subtitle<o:p></o:p></span></p>
 <p class=MsoNormal><span lang=EN-US style='mso-ansi-language:EN-US'>This is a <b
 style='mso-bidi-font-weight:normal'>paragraph</b> with a <a
 href="https://w.org/">link</a>.<o:p></o:p></span></p>
+
+<p class=MsoNormal><span lang=EN-US style='mso-ansi-language:EN-US'>This is a <b
+style='mso-bidi-font-weight:normal'>longer paragraph</b> with quite a few lines
+of text to be able to check the correct handling of all the newlines, which are
+automatically injected by Microsoft Word, but which we do not want to land in the
+editor.<o:p></o:p></span></p>
+
+<p class=MsoNormal><span lang=EN-US style='mso-ansi-language:EN-US'>This is a <b
+style='mso-bidi-font-weight:normal'>paragraph</b> with a manual<br>
+newline.<o:p></o:p></span></p>
 
 <p class=MsoNormal><span lang=EN-US style='mso-ansi-language:EN-US'><o:p>&nbsp;</o:p></span></p>
 

--- a/test/integration/fixtures/ms-word-out.html
+++ b/test/integration/fixtures/ms-word-out.html
@@ -1,11 +1,9 @@
 <!-- wp:paragraph -->
-<p>This is a
-title</p>
+<p>This is a title</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>This is a
-subtitle</p>
+<p>This is a subtitle</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:heading {"level":1} -->
@@ -18,6 +16,15 @@ subtitle</p>
 
 <!-- wp:paragraph -->
 <p>This is a <strong>paragraph</strong> with a <a href="https://w.org/">link</a>.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>This is a <strong>longer paragraph</strong> with quite a few lines of text to be able to check the correct handling of all the newlines, which are automatically injected by Microsoft Word, but which we do not want to land in the editor.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>This is a <strong>paragraph</strong> with a manual<br>
+newline.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->


### PR DESCRIPTION
## Description
This is a fix for #13497.

If you copy-paste text from MS Word, this will result in unwanted newlines in the pasted and processed content.

## How has this been tested?
See https://github.com/WordPress/gutenberg/issues/13497#issuecomment-531180850 and https://github.com/WordPress/gutenberg/issues/13497#issuecomment-531668546.

In this PR, I also updated and expanded fixtures.

## Types of changes
Update and fix (!) some fixtures, and include a new RAW paste handler.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
