### PR TITLE
[RNMobile] floating toolbar disappear mechanism

### DIFF
--- a/packages/block-editor/src/components/block-list/block-mobile-floating-toolbar.native.js
+++ b/packages/block-editor/src/components/block-list/block-mobile-floating-toolbar.native.js
@@ -8,10 +8,10 @@ import { View } from 'react-native';
  */
 import styles from './block-mobile-floating-toolbar.scss';
 
-function FloatingToolbar( { offsetValue, children } ) {
+function FloatingToolbar( { children } ) {
 	return (
 		<View
-			style={ [ styles.floatingToolbarContainer, { top: offsetValue } ] }
+			style={ styles.floatingToolbarContainer }
 		>
 			<View
 				style={ styles.floatingToolbarFill }

--- a/packages/block-editor/src/components/block-list/block-mobile-floating-toolbar.native.js
+++ b/packages/block-editor/src/components/block-list/block-mobile-floating-toolbar.native.js
@@ -1,0 +1,25 @@
+/**
+ * External dependencies
+ */
+import { View } from 'react-native';
+
+/**
+ * Internal dependencies
+ */
+import styles from './block-mobile-floating-toolbar.scss';
+
+function FloatingToolbar( { offsetValue, children } ) {
+	return (
+		<View
+			style={ [ styles.floatingToolbarContainer, { top: offsetValue } ] }
+		>
+			<View
+				style={ styles.floatingToolbarFill }
+			>{ children }
+			</View>
+		</View>
+	);
+}
+
+export default FloatingToolbar;
+

--- a/packages/block-editor/src/components/block-list/block-mobile-floating-toolbar.native.scss
+++ b/packages/block-editor/src/components/block-list/block-mobile-floating-toolbar.native.scss
@@ -4,6 +4,7 @@
 	z-index: 2;
 	left: 0;
 	right: 0;
+	top: -22;
 }
 
 .floatingToolbarFill {

--- a/packages/block-editor/src/components/block-list/block-mobile-floating-toolbar.native.scss
+++ b/packages/block-editor/src/components/block-list/block-mobile-floating-toolbar.native.scss
@@ -1,0 +1,19 @@
+.floatingToolbarContainer {
+	align-items: center;
+	justify-content: center;
+	z-index: 2;
+	left: 0;
+	right: 0;
+}
+
+.floatingToolbarFill {
+	background-color: $dark-gray-500;
+	margin: auto;
+	min-width: 100;
+	height: 44;
+	max-height: 44;
+	z-index: 2;
+	border-radius: 22px;
+	position: absolute;
+	flex-direction: row;
+}

--- a/packages/block-editor/src/components/block-list/block.native.js
+++ b/packages/block-editor/src/components/block-list/block.native.js
@@ -104,11 +104,6 @@ class BlockListBlock extends Component {
 		return blockName;
 	}
 
-	getOffsetValue() {
-		const { header, isFirstBlock } = this.props;
-		return ! isFirstBlock || header ? -toolbarHeight / 2 : toolbarHeight / 2;
-	}
-
 	render() {
 		const {
 			borderStyle,
@@ -128,7 +123,7 @@ class BlockListBlock extends Component {
 
 		return (
 			<>
-				{ displayToolbar && <FloatingToolbar offsetValue={ this.getOffsetValue() } /> }
+				{ displayToolbar && <FloatingToolbar /> }
 				<TouchableWithoutFeedback
 					onPress={ this.onFocus }
 					accessible={ ! isSelected }

--- a/packages/block-editor/src/components/block-list/block.native.js
+++ b/packages/block-editor/src/components/block-list/block.native.js
@@ -28,6 +28,8 @@ import FloatingToolbar from './block-mobile-floating-toolbar';
 
 const toolbarHeight = 44;
 
+const hideToolbarAfterMs = 3000;
+
 class BlockListBlock extends Component {
 	constructor() {
 		super( ...arguments );
@@ -57,11 +59,11 @@ class BlockListBlock extends Component {
 					this.state.fadeAnim,
 					{
 						toValue: 0,
-						duration: 200,
+						duration: 100,
 						useNativeDriver: true,
 					}
 				).start( () => {
-					this.setState( { showToolbar: false } );
+					this.setState( { showToolbar: false, fadeAnim: new Animated.Value( 1 ) } );
 				} );
 			} );
 	}
@@ -74,12 +76,12 @@ class BlockListBlock extends Component {
 			if ( this.state.showToolbar ) {
 				this.fadeOutToolbar();
 			}
-		}, 3000 );
+		}, hideToolbarAfterMs );
 	}
 
 	onFocus() {
 		if ( ! this.state.showToolbar ) {
-			this.setState( { showToolbar: true } );
+			this.setState( { showToolbar: true, fadeAnim: new Animated.Value( 1 ) } );
 		}
 		if ( ! this.props.isSelected ) {
 			this.props.onSelect();

--- a/packages/block-editor/src/components/block-list/block.native.js
+++ b/packages/block-editor/src/components/block-list/block.native.js
@@ -171,13 +171,9 @@ export default compose( [
 
 		const rootBlockId = getBlockHierarchyRootClientId( clientId );
 		const rootBlock = getBlock( rootBlockId );
-		const parentBlockId = getBlock( clientId ).parent;
-		const parentBlock = getBlock( parentBlockId );
-		const isGroupRoot = rootBlock.name === 'core/group';
 		const hasRootInnerBlocks = rootBlock.innerBlocks.length !== 0;
-		const isMediaTextParent = parentBlock && parentBlock.name === 'core/media-text';
 
-		const displayToolbar = isSelected && isGroupRoot && hasRootInnerBlocks && ! isMediaTextParent;
+		const displayToolbar = isSelected && hasRootInnerBlocks;
 
 		return {
 			icon,

--- a/packages/block-editor/src/components/block-list/block.native.js
+++ b/packages/block-editor/src/components/block-list/block.native.js
@@ -5,6 +5,7 @@ import {
 	View,
 	Text,
 	TouchableWithoutFeedback,
+	Animated,
 } from 'react-native';
 
 /**
@@ -33,13 +34,53 @@ class BlockListBlock extends Component {
 
 		this.insertBlocksAfter = this.insertBlocksAfter.bind( this );
 		this.onFocus = this.onFocus.bind( this );
+		this.hideToolbar = this.hideToolbar.bind( this );
+		this.fadeOutToolbar = this.fadeOutToolbar.bind( this );
 
 		this.state = {
 			isFullyBordered: false,
+			showToolbar: true,
+			fadeAnim: new Animated.Value( 1 ),
 		};
 	}
 
+	componentDidUpdate() {
+		if ( this.props.displayToolbar ) {
+			this.hideToolbar();
+		}
+	}
+
+	fadeOutToolbar() {
+		this.setState( { fadeAnim: new Animated.Value( 1 ) },
+			() => {
+				Animated.timing(
+					this.state.fadeAnim,
+					{
+						toValue: 0,
+						duration: 200,
+						useNativeDriver: true,
+					}
+				).start( () => {
+					this.setState( { showToolbar: false } );
+				} );
+			} );
+	}
+
+	hideToolbar() {
+		if ( this.hideTimeout ) {
+			clearTimeout( this.hideTimeout );
+		}
+		this.hideTimeout = setTimeout( () => {
+			if ( this.state.showToolbar ) {
+				this.fadeOutToolbar();
+			}
+		}, 3000 );
+	}
+
 	onFocus() {
+		if ( ! this.state.showToolbar ) {
+			this.setState( { showToolbar: true } );
+		}
 		if ( ! this.props.isSelected ) {
 			this.props.onSelect();
 		}
@@ -121,9 +162,11 @@ class BlockListBlock extends Component {
 
 		const accessibilityLabel = this.getAccessibilityLabel();
 
+		const { fadeAnim } = this.state;
+
 		return (
 			<>
-				{ displayToolbar && <FloatingToolbar /> }
+				{ this.state.showToolbar && displayToolbar && <Animated.View style={ { opacity: fadeAnim } }><FloatingToolbar /></Animated.View> }
 				<TouchableWithoutFeedback
 					onPress={ this.onFocus }
 					accessible={ ! isSelected }

--- a/packages/block-editor/src/components/block-list/index.native.js
+++ b/packages/block-editor/src/components/block-list/index.native.js
@@ -114,7 +114,7 @@ export class BlockList extends Component {
 
 	renderItem( { item: clientId, index } ) {
 		const blockHolderFocusedStyle = this.props.useStyle( styles.blockHolderFocused, styles.blockHolderFocusedDark );
-		const { shouldShowBlockAtIndex, shouldShowInsertionPoint, header } = this.props;
+		const { shouldShowBlockAtIndex, shouldShowInsertionPoint } = this.props;
 		return (
 			<ReadableContentView>
 				{ shouldShowInsertionPoint( clientId ) && this.renderAddBlockSeparator() }
@@ -127,7 +127,6 @@ export class BlockList extends Component {
 						onCaretVerticalPositionChange={ this.onCaretVerticalPositionChange }
 						borderStyle={ this.blockHolderBorderStyle() }
 						focusedBorderColor={ blockHolderFocusedStyle.borderColor }
-						header={ header }
 					/> ) }
 			</ReadableContentView>
 		);

--- a/packages/block-editor/src/components/block-list/index.native.js
+++ b/packages/block-editor/src/components/block-list/index.native.js
@@ -114,7 +114,7 @@ export class BlockList extends Component {
 
 	renderItem( { item: clientId, index } ) {
 		const blockHolderFocusedStyle = this.props.useStyle( styles.blockHolderFocused, styles.blockHolderFocusedDark );
-		const { shouldShowBlockAtIndex, shouldShowInsertionPoint } = this.props;
+		const { shouldShowBlockAtIndex, shouldShowInsertionPoint, header } = this.props;
 		return (
 			<ReadableContentView>
 				{ shouldShowInsertionPoint( clientId ) && this.renderAddBlockSeparator() }
@@ -127,6 +127,7 @@ export class BlockList extends Component {
 						onCaretVerticalPositionChange={ this.onCaretVerticalPositionChange }
 						borderStyle={ this.blockHolderBorderStyle() }
 						focusedBorderColor={ blockHolderFocusedStyle.borderColor }
+						header={ header }
 					/> ) }
 			</ReadableContentView>
 		);
@@ -166,6 +167,7 @@ export default compose( [
 			getBlockInsertionPoint,
 			isBlockInsertionPointVisible,
 			getSelectedBlock,
+			isBlockSelected,
 		} = select( 'core/block-editor' );
 
 		const selectedBlockClientId = getSelectedBlockClientId();
@@ -201,6 +203,9 @@ export default compose( [
 			shouldShowBlockAtIndex,
 			shouldShowInsertionPoint,
 			selectedBlockClientId,
+			rootClientId,
+			getBlockIndex,
+			isBlockSelected,
 		};
 	} ),
 	withDispatch( ( dispatch ) => {

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -122,6 +122,8 @@ export function getBlockAttributes( state, clientId ) {
 export const getBlock = createSelector(
 	( state, clientId ) => {
 		const block = state.blocks.byClientId[ clientId ];
+		const parent = state.blocks.parents[ clientId ];
+
 		if ( ! block ) {
 			return null;
 		}
@@ -130,6 +132,7 @@ export const getBlock = createSelector(
 			...block,
 			attributes: getBlockAttributes( state, clientId ),
 			innerBlocks: getBlocks( state, clientId ),
+			parent,
 		};
 	},
 	( state, clientId ) => [

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -195,7 +195,7 @@ describe( 'selectors', () => {
 						123: [],
 					},
 					parents: {
-						123: '',
+						123: '23',
 					},
 					cache: {
 						123: {},
@@ -208,6 +208,7 @@ describe( 'selectors', () => {
 				name: 'core/paragraph',
 				attributes: {},
 				innerBlocks: [],
+				parent: '23',
 			} );
 		} );
 
@@ -261,7 +262,9 @@ describe( 'selectors', () => {
 					name: 'core/paragraph',
 					attributes: {},
 					innerBlocks: [],
+					parent: 123,
 				} ],
+				parent: '',
 			} );
 		} );
 	} );
@@ -293,8 +296,8 @@ describe( 'selectors', () => {
 			};
 
 			expect( getBlocks( state ) ).toEqual( [
-				{ clientId: 123, name: 'core/paragraph', attributes: {}, innerBlocks: [] },
-				{ clientId: 23, name: 'core/heading', attributes: {}, innerBlocks: [] },
+				{ clientId: 123, name: 'core/paragraph', attributes: {}, innerBlocks: [], parent: '' },
+				{ clientId: 23, name: 'core/heading', attributes: {}, innerBlocks: [], parent: '' },
 			] );
 		} );
 	} );
@@ -707,7 +710,7 @@ describe( 'selectors', () => {
 					},
 					parents: {
 						123: '',
-						23: '',
+						23: '123',
 					},
 					cache: {
 						23: {},
@@ -721,6 +724,7 @@ describe( 'selectors', () => {
 				name: 'core/heading',
 				attributes: {},
 				innerBlocks: [],
+				parent: '123',
 			} );
 		} );
 	} );
@@ -2247,6 +2251,9 @@ describe( 'selectors', () => {
 					},
 					cache: {
 						block1: {},
+					},
+					parents: {
+						123: '',
 					},
 				},
 				preferences: {

--- a/packages/components/src/mobile/keyboard-aware-flat-list/index.ios.js
+++ b/packages/components/src/mobile/keyboard-aware-flat-list/index.ios.js
@@ -9,7 +9,6 @@ export const KeyboardAwareFlatList = ( {
 	shouldPreventAutomaticScroll,
 	innerRef,
 	autoScroll,
-	style,
 	...listProps
 } ) => (
 	<KeyboardAwareScrollView
@@ -43,7 +42,7 @@ export const KeyboardAwareFlatList = ( {
 		onScroll={ ( event ) => {
 			this.latestContentOffsetY = event.nativeEvent.contentOffset.y;
 		} } >
-		<FlatList { ...listProps } style={ [ style, { overflow: 'visible' } ] } contentContainerStyle={ { overflow: 'visible' } } contentOffset={ { y: 44 } } />
+		<FlatList { ...listProps } />
 	</KeyboardAwareScrollView>
 );
 

--- a/packages/components/src/mobile/keyboard-aware-flat-list/index.ios.js
+++ b/packages/components/src/mobile/keyboard-aware-flat-list/index.ios.js
@@ -9,10 +9,11 @@ export const KeyboardAwareFlatList = ( {
 	shouldPreventAutomaticScroll,
 	innerRef,
 	autoScroll,
+	style,
 	...listProps
 } ) => (
 	<KeyboardAwareScrollView
-		style={ { flex: 1 } }
+		style={ { flex: 1, overflow: 'visible' } }
 		keyboardDismissMode="none"
 		enableResetScrollToCoords={ false }
 		keyboardShouldPersistTaps="handled"
@@ -42,7 +43,7 @@ export const KeyboardAwareFlatList = ( {
 		onScroll={ ( event ) => {
 			this.latestContentOffsetY = event.nativeEvent.contentOffset.y;
 		} } >
-		<FlatList { ...listProps } />
+		<FlatList { ...listProps } style={ [ style, { overflow: 'visible' } ] } contentContainerStyle={ { overflow: 'visible' } } contentOffset={ { y: 44 } } />
 	</KeyboardAwareScrollView>
 );
 


### PR DESCRIPTION
Can be merged after - https://github.com/WordPress/gutenberg/pull/17399
## Description
This PR implements a mechanism for hiding floating toolbar - https://github.com/wordpress-mobile/gutenberg-mobile/issues/1318

## How has this been tested?
Add a group block with some blocks inside.
Navigate between them and check if the toolbar disappears

## Screenshots <!-- if applicable -->
![ezgif com-resize (1)](https://user-images.githubusercontent.com/16336501/65117403-3964e900-d9ea-11e9-96c0-a39a26771b9c.gif)


## Types of changes
New feature

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
