### PR TITLE
Paste: Remove HTML Formatting Space

### DIFF
--- a/packages/blocks/src/api/raw-handling/html-formatting-remover.js
+++ b/packages/blocks/src/api/raw-handling/html-formatting-remover.js
@@ -6,29 +6,23 @@ import { isPhrasingContent } from './phrasing-content';
 function getSibling( node, which ) {
 	const sibling = node[ `${ which }Sibling` ];
 
+	if ( ! sibling || ! isPhrasingContent( sibling ) ) {
+		return;
+	}
+
 	if ( sibling ) {
 		return sibling;
 	}
 
 	const { parentNode } = node;
 
-	if ( ! parentNode ) {
-		return;
-	}
-
-	if ( ! isPhrasingContent( parentNode ) ) {
-		return;
-	}
-
 	return getSibling( parentNode, which );
-}
-
-function isFormattingSpace( character ) {
-	return character === ' ' || character === '\t' || character === '\n';
 }
 
 /**
  * Removes spacing that formats HTML.
+ *
+ * @see https://www.w3.org/TR/css-text-3/#white-space-processing
  *
  * @param {Node} node The node to be processed.
  * @return {void}
@@ -44,7 +38,7 @@ export default function( node ) {
 	}
 
 	// First, replace any sequence of HTML formatting space with a single space.
-	let newData = node.data.replace( /[ \n\t]+/g, ' ' );
+	let newData = node.data.replace( /[ \r\n\t]+/g, ' ' );
 
 	// Remove the leading space if the text element is at the start of a block,
 	// is preceded by a line break element, or has a space in the previous
@@ -62,16 +56,13 @@ export default function( node ) {
 	}
 
 	// Remove the trailing space if the text element is at the end of a block,
-	// is succeded by a line break element, or has a space in the next element.
+	// or is succeded by a line break element.
 	if ( newData[ newData.length - 1 ] === ' ' ) {
 		const nextSibling = getSibling( node, 'next' );
 
 		if (
 			! nextSibling ||
-			nextSibling.nodeName === 'BR' ||
-			// Note that any next node data has not yet been replaced, so we
-			// have to check for any formatting space.
-			isFormattingSpace( nextSibling.textContent[ 0 ] )
+			nextSibling.nodeName === 'BR'
 		) {
 			newData = newData.slice( 0, -1 );
 		}

--- a/packages/blocks/src/api/raw-handling/html-formatting-remover.js
+++ b/packages/blocks/src/api/raw-handling/html-formatting-remover.js
@@ -28,13 +28,18 @@ function isFormattingSpace( character ) {
 }
 
 /**
- * Looks for comments, and removes them.
+ * Removes spacing that formats HTML.
  *
  * @param {Node} node The node to be processed.
  * @return {void}
  */
 export default function( node ) {
 	if ( node.nodeType !== node.TEXT_NODE ) {
+		return;
+	}
+
+	// Ignore pre content.
+	if ( node.parentElement.closest( 'pre' ) ) {
 		return;
 	}
 

--- a/packages/blocks/src/api/raw-handling/html-formatting-remover.js
+++ b/packages/blocks/src/api/raw-handling/html-formatting-remover.js
@@ -1,0 +1,90 @@
+/**
+ * Internal dependencies
+ */
+import { isPhrasingContent } from './phrasing-content';
+
+function getSibling( node, which ) {
+	const sibling = node[ `${ which }Sibling` ];
+
+	if ( sibling ) {
+		return sibling;
+	}
+
+	const { parentNode } = node;
+
+	if ( ! parentNode ) {
+		return;
+	}
+
+	if ( ! isPhrasingContent( parentNode ) ) {
+		return;
+	}
+
+	return getSibling( parentNode, which );
+}
+
+function isFormattingSpace( character ) {
+	return (
+		character === ' ' ||
+		character === '\t' ||
+		character === '\n'
+	);
+}
+
+/**
+ * Looks for comments, and removes them.
+ *
+ * @param {Node} node The node to be processed.
+ * @return {void}
+ */
+export default function( node ) {
+	if ( node.nodeType !== node.TEXT_NODE ) {
+		return;
+	}
+
+	if ( isFormattingSpace( node.data[ 0 ] ) ) {
+		const previousSibling = getSibling( node, 'previous' );
+		const hasPreviousSpace = (
+			! previousSibling ||
+			previousSibling.nodeName === 'BR' ||
+			previousSibling.textContent.slice( -1 ) === ' '
+		);
+		node.data = node.data.replace( /^[ \n\t]+/, hasPreviousSpace ? '' : ' ' );
+	}
+
+	if ( isFormattingSpace( node.data.slice( -1 ) ) ) {
+		const nextSibling = getSibling( node, 'next' );
+		const hasNextSpace = (
+			! nextSibling ||
+			nextSibling.nodeName === 'BR' ||
+			isFormattingSpace( nextSibling.textContent[ 0 ] )
+		);
+		node.data = node.data.replace( /[ \n\t]+$/, hasNextSpace ? '' : ' ' );
+	}
+
+	// Require at least two characters before attempting to replace formatting
+	// spaces in the middle.
+	if ( node.data.length > 2 ) {
+		const middle = node.data.slice( 1, -1 );
+
+		// Require at least two spaces in a row, a line break, or a tab
+		// character before trying to replace anything.
+		if (
+			middle.indexOf( '  ' ) !== -1 ||
+			middle.indexOf( '\n' ) !== -1 ||
+			middle.indexOf( '\t' ) !== -1
+		) {
+			node.data = (
+				node.data[ 0 ] +
+				middle.replace( /[ \n\t]+/g, ' ' ) +
+				node.data[ node.data.length - 1 ]
+			);
+		}
+	}
+
+	// If there's no data left, remove the node, so `previousSibling` stays
+	// accurate.
+	if ( ! node.data ) {
+		node.parentNode.removeChild( node );
+	}
+}

--- a/packages/blocks/src/api/raw-handling/paste-handler.js
+++ b/packages/blocks/src/api/raw-handling/paste-handler.js
@@ -24,6 +24,7 @@ import shortcodeConverter from './shortcode-converter';
 import markdownConverter from './markdown-converter';
 import iframeRemover from './iframe-remover';
 import googleDocsUIDRemover from './google-docs-uid-remover';
+import HTMLFormattingRemover from './html-formatting-remover';
 import { getPhrasingContentSchema } from './phrasing-content';
 import {
 	deepFilterHTML,
@@ -224,6 +225,7 @@ export function pasteHandler( { HTML = '', plainText = '', mode = 'AUTO', tagNam
 
 		piece = deepFilterHTML( piece, filters, blockContentSchema );
 		piece = removeInvalidHTML( piece, schema );
+		piece = deepFilterHTML( piece, [ HTMLFormattingRemover ], blockContentSchema );
 		piece = normaliseBlocks( piece );
 
 		// Allows us to ask for this information when we get a report.

--- a/packages/blocks/src/api/raw-handling/paste-handler.js
+++ b/packages/blocks/src/api/raw-handling/paste-handler.js
@@ -24,7 +24,7 @@ import shortcodeConverter from './shortcode-converter';
 import markdownConverter from './markdown-converter';
 import iframeRemover from './iframe-remover';
 import googleDocsUIDRemover from './google-docs-uid-remover';
-import HTMLFormattingRemover from './html-formatting-remover';
+import htmlFormattingRemover from './html-formatting-remover';
 import { getPhrasingContentSchema } from './phrasing-content';
 import {
 	deepFilterHTML,
@@ -225,7 +225,7 @@ export function pasteHandler( { HTML = '', plainText = '', mode = 'AUTO', tagNam
 
 		piece = deepFilterHTML( piece, filters, blockContentSchema );
 		piece = removeInvalidHTML( piece, schema );
-		piece = deepFilterHTML( piece, [ HTMLFormattingRemover ], blockContentSchema );
+		piece = deepFilterHTML( piece, [ htmlFormattingRemover ], blockContentSchema );
 		piece = normaliseBlocks( piece );
 
 		// Allows us to ask for this information when we get a report.

--- a/packages/blocks/src/api/raw-handling/test/html-formatting-remover.js
+++ b/packages/blocks/src/api/raw-handling/test/html-formatting-remover.js
@@ -96,4 +96,10 @@ describe( 'HTMLFormattingRemover', () => {
 		const input = `<pre> a\n b\n</pre>`;
 		expect( deepFilterHTML( input, [ filter ] ) ).toEqual( input );
 	} );
+
+	it( 'should not remove white space if next elemnt has none', () => {
+		const input = `<div><strong>a </strong>b</div>`;
+		const output = '<div><strong>a </strong>b</div>';
+		expect( deepFilterHTML( input, [ filter ] ) ).toEqual( output );
+	} );
 } );

--- a/packages/blocks/src/api/raw-handling/test/html-formatting-remover.js
+++ b/packages/blocks/src/api/raw-handling/test/html-formatting-remover.js
@@ -91,4 +91,9 @@ describe( 'HTMLFormattingRemover', () => {
 		const output = '<div><strong>a</strong><strong> b</strong></div>';
 		expect( deepFilterHTML( input, [ filter ] ) ).toEqual( output );
 	} );
+
+	it( 'should ignore pre', () => {
+		const input = `<pre> a\n b\n</pre>`;
+		expect( deepFilterHTML( input, [ filter ] ) ).toEqual( input );
+	} );
 } );

--- a/packages/blocks/src/api/raw-handling/test/html-formatting-remover.js
+++ b/packages/blocks/src/api/raw-handling/test/html-formatting-remover.js
@@ -5,6 +5,11 @@ import filter from '../html-formatting-remover';
 import { deepFilterHTML } from '../utils';
 
 describe( 'HTMLFormattingRemover', () => {
+	it( 'should trim text node without parent', () => {
+		const input = 'a';
+		expect( deepFilterHTML( input, [ filter ] ) ).toEqual( input );
+	} );
+
 	it( 'should remove formatting space', () => {
 		const input = `
 			<div>

--- a/packages/blocks/src/api/raw-handling/test/html-formatting-remover.js
+++ b/packages/blocks/src/api/raw-handling/test/html-formatting-remover.js
@@ -1,0 +1,94 @@
+/**
+ * Internal dependencies
+ */
+import filter from '../html-formatting-remover';
+import { deepFilterHTML } from '../utils';
+
+describe( 'HTMLFormattingRemover', () => {
+	it( 'should remove formatting space', () => {
+		const input = `
+			<div>
+				a
+				b
+			</div>
+		`;
+		const output = '<div>a b</div>';
+		expect( deepFilterHTML( input, [ filter ] ) ).toEqual( output );
+	} );
+
+	it( 'should remove nested formatting space', () => {
+		const input = `
+			<div>
+				<strong>
+					a
+					b
+				</strong>
+			</div>
+		`;
+		const output = '<div><strong>a b</strong></div>';
+		expect( deepFilterHTML( input, [ filter ] ) ).toEqual( output );
+	} );
+
+	it( 'should not remove leading or trailing space if previous or next element has no space', () => {
+		const input = `
+			<div>
+				a
+				<strong>b</strong>
+				c
+			</div>
+		`;
+		const output = '<div>a <strong>b</strong> c</div>';
+		expect( deepFilterHTML( input, [ filter ] ) ).toEqual( output );
+	} );
+
+	it( 'should remove formatting space (empty)', () => {
+		const input = `
+			<div>
+			</div>
+		`;
+		const output = '<div></div>';
+		expect( deepFilterHTML( input, [ filter ] ) ).toEqual( output );
+	} );
+
+	it( 'should remove block level formatting space', () => {
+		const input = `
+			<div>
+				<div>
+					a
+				</div>
+				<div>
+					b
+				</div>
+			</div>
+		`;
+		const output = '<div><div>a</div><div>b</div></div>';
+		expect( deepFilterHTML( input, [ filter ] ) ).toEqual( output );
+	} );
+
+	it( 'should remove formatting space around br', () => {
+		const input = `
+			<div>
+				a
+				<br>
+				b
+			</div>
+		`;
+		const output = '<div>a<br>b</div>';
+		expect( deepFilterHTML( input, [ filter ] ) ).toEqual( output );
+	} );
+
+	it( 'should remove formatting space around phasing content elements', () => {
+		const input = `
+			<div>
+				<strong>
+					a
+				</strong>
+				<strong>
+					b
+				</strong>
+			</div>
+		`;
+		const output = '<div><strong>a</strong><strong> b</strong></div>';
+		expect( deepFilterHTML( input, [ filter ] ) ).toEqual( output );
+	} );
+} );

--- a/packages/blocks/src/api/raw-handling/test/html-formatting-remover.js
+++ b/packages/blocks/src/api/raw-handling/test/html-formatting-remover.js
@@ -88,7 +88,7 @@ describe( 'HTMLFormattingRemover', () => {
 				</strong>
 			</div>
 		`;
-		const output = '<div><strong>a</strong><strong> b</strong></div>';
+		const output = '<div><strong>a</strong> <strong>b</strong></div>';
 		expect( deepFilterHTML( input, [ filter ] ) ).toEqual( output );
 	} );
 

--- a/test/integration/fixtures/apple-out.html
+++ b/test/integration/fixtures/apple-out.html
@@ -19,27 +19,9 @@
 <!-- /wp:list -->
 
 <!-- wp:table -->
-<figure class="wp-block-table"><table class=""><tbody><tr><td>
-One
-</td><td>
-Two
-</td><td>
-Three
-</td></tr><tr><td>
-1
-</td><td>
-2
-</td><td>
-3
-</td></tr><tr><td>
-I
-</td><td>
-II
-</td><td>
-III
-</td></tr></tbody></table></figure>
+<figure class="wp-block-table"><table class=""><tbody><tr><td>One</td><td>Two</td><td>Three</td></tr><tr><td>1</td><td>2</td><td>3</td></tr><tr><td>I</td><td>II</td><td>III</td></tr></tbody></table></figure>
 <!-- /wp:table -->
 
 <!-- wp:paragraph -->
-<p>An image: </p>
+<p>An image:</p>
 <!-- /wp:paragraph -->

--- a/test/integration/fixtures/classic-out.html
+++ b/test/integration/fixtures/classic-out.html
@@ -15,7 +15,7 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>Fourth  paragraph</p>
+<p>Fourth paragraph</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:more -->

--- a/test/integration/fixtures/evernote-out.html
+++ b/test/integration/fixtures/evernote-out.html
@@ -1,7 +1,5 @@
 <!-- wp:paragraph -->
-<p>This is a <em>paragraph</em>.
-<br>This is a <a href="https://w.org">link</a>.
-<br></p>
+<p>This is a <em>paragraph</em>.<br>This is a <a href="https://w.org">link</a>.<br></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
@@ -17,13 +15,7 @@
 <!-- /wp:separator -->
 
 <!-- wp:table -->
-<figure class="wp-block-table"><table class=""><tbody><tr><td>One
-</td><td>Two
-</td><td>Three
-</td></tr><tr><td>Four
-</td><td>Five
-</td><td>Six
-</td></tr></tbody></table></figure>
+<figure class="wp-block-table"><table class=""><tbody><tr><td>One</td><td>Two</td><td>Three</td></tr><tr><td>Four</td><td>Five</td><td>Six</td></tr></tbody></table></figure>
 <!-- /wp:table -->
 
 <!-- wp:image -->

--- a/test/integration/fixtures/markdown-out.html
+++ b/test/integration/fixtures/markdown-out.html
@@ -7,8 +7,7 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>Preserve<br>
-line breaks please.</p>
+<p>Preserve<br>line breaks please.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:heading -->

--- a/test/integration/fixtures/ms-word-out.html
+++ b/test/integration/fixtures/ms-word-out.html
@@ -1,11 +1,9 @@
 <!-- wp:paragraph -->
-<p>This is a
-title</p>
+<p>This is a title</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>This is a
-subtitle</p>
+<p>This is a subtitle</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:heading {"level":1} -->
@@ -29,25 +27,7 @@ subtitle</p>
 <!-- /wp:list -->
 
 <!-- wp:table -->
-<figure class="wp-block-table"><table class=""><tbody><tr><td>
-  One
-  </td><td>
-  Two
-  </td><td>
-  Three
-  </td></tr><tr><td>
-  1
-  </td><td>
-  2
-  </td><td>
-  3
-  </td></tr><tr><td>
-  I
-  </td><td>
-  II
-  </td><td>
-  III
-  </td></tr></tbody></table></figure>
+<figure class="wp-block-table"><table class=""><tbody><tr><td>One</td><td>Two</td><td>Three</td></tr><tr><td>1</td><td>2</td><td>3</td></tr><tr><td>I</td><td>II</td><td>III</td></tr></tbody></table></figure>
 <!-- /wp:table -->
 
 <!-- wp:paragraph -->

--- a/test/integration/fixtures/ms-word-styled-out.html
+++ b/test/integration/fixtures/ms-word-styled-out.html
@@ -1,15 +1,7 @@
 <!-- wp:paragraph -->
-<p>
-<strong>Lorem
-ipsum dolor sit amet, consectetur adipiscing elit&nbsp; </strong>
-</p>
+<p><strong>Lorem ipsum dolor sit amet, consectetur adipiscing elit&nbsp;</strong></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>
-Lorem
-ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque
-aliquet hendrerit auctor. Nam lobortis, est vel lacinia tincidunt,
-purus tellus vehicula ex, nec pharetra justo dui sed lorem. Nam
-congue laoreet massa, quis varius est tincidunt ut.</p>
+<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque aliquet hendrerit auctor. Nam lobortis, est vel lacinia tincidunt, purus tellus vehicula ex, nec pharetra justo dui sed lorem. Nam congue laoreet massa, quis varius est tincidunt ut.</p>
 <!-- /wp:paragraph -->


### PR DESCRIPTION
## Description

Fixes #13497. (Alternative to #17459. This is a more general solution to work with any source and any block type, so it also fixes the following issues:)
Fixes #17302.
Fixes #14298.
Fixes #13647.

In HTML, there are a few characters you can use to format the code (indent, make it pretty etc.): `\n`, `\t` and normal spaces. We don't want our paste output to have these characters. Sequences of these characters should be removed, or replaced with a single normal space if it is a meaningful space (in other words, part of the content).

To do: write unit tests.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
