### PR TITLE
Stabilise List E2E tests

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -39,11 +39,6 @@ import FormatToolbar from './format-toolbar';
 import { withBlockEditContext } from '../block-edit/context';
 import { RemoveBrowserShortcuts } from './remove-browser-shortcuts';
 
-const requestIdleCallback = window.requestIdleCallback ||
-	function fallbackRequestIdleCallback( fn ) {
-		window.setTimeout( fn, 100 );
-	};
-
 const wrapperClasses = 'editor-rich-text block-editor-rich-text';
 const classes = 'editor-rich-text__editable block-editor-rich-text__editable';
 
@@ -70,11 +65,15 @@ class RichTextWrapper extends Component {
 		this.onPaste = this.onPaste.bind( this );
 		this.onDelete = this.onDelete.bind( this );
 		this.inputRule = this.inputRule.bind( this );
-		this.markAutomaticChange = this.markAutomaticChange.bind( this );
 	}
 
 	onEnter( { value, onChange, shiftKey } ) {
-		const { onReplace, onSplit, multiline } = this.props;
+		const {
+			onReplace,
+			onSplit,
+			multiline,
+			markAutomaticChange,
+		} = this.props;
 		const canSplit = onReplace && onSplit;
 
 		if ( onReplace ) {
@@ -88,7 +87,7 @@ class RichTextWrapper extends Component {
 				onReplace( [
 					transformation.transform( { content: value.text } ),
 				] );
-				this.markAutomaticChange();
+				markAutomaticChange();
 			}
 		}
 
@@ -252,7 +251,7 @@ class RichTextWrapper extends Component {
 	}
 
 	inputRule( value, valueToFormat ) {
-		const { onReplace } = this.props;
+		const { onReplace, markAutomaticChange } = this.props;
 
 		if ( ! onReplace ) {
 			return;
@@ -280,7 +279,7 @@ class RichTextWrapper extends Component {
 		const block = transformation.transform( content );
 
 		onReplace( [ block ] );
-		this.markAutomaticChange();
+		markAutomaticChange();
 	}
 
 	getAllowedFormats() {
@@ -299,16 +298,6 @@ class RichTextWrapper extends Component {
 		} );
 
 		return formattingControls.map( ( name ) => `core/${ name }` );
-	}
-
-	/**
-	 * Marks the last change as an automatic change at the next idle period to
-	 * ensure all selection changes have been recorded.
-	 */
-	markAutomaticChange() {
-		requestIdleCallback( () => {
-			this.props.markAutomaticChange();
-		} );
 	}
 
 	render() {
@@ -331,7 +320,6 @@ class RichTextWrapper extends Component {
 			onExitFormattedText,
 			isSelected: originalIsSelected,
 			onCreateUndoLevel,
-			// eslint-disable-next-line no-unused-vars
 			markAutomaticChange,
 			didAutomaticChange,
 			undo,
@@ -401,7 +389,7 @@ class RichTextWrapper extends Component {
 				__unstableOnEnterFormattedText={ onEnterFormattedText }
 				__unstableOnExitFormattedText={ onExitFormattedText }
 				__unstableOnCreateUndoLevel={ onCreateUndoLevel }
-				__unstableMarkAutomaticChange={ this.markAutomaticChange }
+				__unstableMarkAutomaticChange={ markAutomaticChange }
 				__unstableDidAutomaticChange={ didAutomaticChange }
 				__unstableUndo={ undo }
 			>

--- a/packages/block-editor/src/store/effects.js
+++ b/packages/block-editor/src/store/effects.js
@@ -183,4 +183,14 @@ export default {
 
 		return resetBlocks( updatedBlockList );
 	},
+	MARK_AUTOMATIC_CHANGE( action, store ) {
+		const {
+			setTimeout,
+			requestIdleCallback = ( callback ) => setTimeout( callback, 100 ),
+		} = window;
+
+		requestIdleCallback( () => {
+			store.dispatch( { type: 'MARK_AUTOMATIC_CHANGE_FINAL' } );
+		} );
+	},
 };

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1282,7 +1282,21 @@ export function lastBlockAttributesChange( state, action ) {
  * @return {boolean} Updated state.
  */
 export function didAutomaticChange( state, action ) {
-	return action.type === 'MARK_AUTOMATIC_CHANGE';
+	switch ( action.type ) {
+		case 'MARK_AUTOMATIC_CHANGE':
+			return 'pending';
+		case 'MARK_AUTOMATIC_CHANGE_FINAL':
+			if ( state === 'pending' ) {
+				return 'final';
+			}
+
+			return;
+		case 'SELECTION_CHANGE':
+			// As long as the state is not final, ignore any selection changes.
+			if ( state !== 'final' ) {
+				return state;
+			}
+	}
 }
 
 export default combineReducers( {

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1398,5 +1398,5 @@ export function isNavigationMode( state ) {
  * @return {boolean} Whether the last change was automatic.
  */
 export function didAutomaticChange( state ) {
-	return state.didAutomaticChange;
+	return !! state.didAutomaticChange;
 }

--- a/packages/e2e-tests/specs/blocks/__snapshots__/list.test.js.snap
+++ b/packages/e2e-tests/specs/blocks/__snapshots__/list.test.js.snap
@@ -278,6 +278,18 @@ exports[`List should undo asterisk transform with backspace 1`] = `
 <!-- /wp:paragraph -->"
 `;
 
+exports[`List should undo asterisk transform with backspace after selection changes 1`] = `
+"<!-- wp:paragraph -->
+<p>* </p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`List should undo asterisk transform with backspace after selection changes without requestIdleCallback 1`] = `
+"<!-- wp:paragraph -->
+<p>* </p>
+<!-- /wp:paragraph -->"
+`;
+
 exports[`List should undo asterisk transform with escape 1`] = `
 "<!-- wp:paragraph -->
 <p>* </p>

--- a/packages/e2e-tests/specs/blocks/list.test.js
+++ b/packages/e2e-tests/specs/blocks/list.test.js
@@ -58,7 +58,25 @@ describe( 'List', () => {
 	it( 'should undo asterisk transform with backspace', async () => {
 		await clickBlockAppender();
 		await page.keyboard.type( '* ' );
+		await page.keyboard.press( 'Backspace' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'should undo asterisk transform with backspace after selection changes', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( '* ' );
 		await page.evaluate( () => new Promise( window.requestIdleCallback ) );
+		await page.keyboard.press( 'Backspace' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'should undo asterisk transform with backspace after selection changes without requestIdleCallback', async () => {
+		await clickBlockAppender();
+		await page.evaluate( () => delete window.requestIdleCallback );
+		await page.keyboard.type( '* ' );
+		await new Promise( ( resolve ) => setTimeout( resolve, 100 ) );
 		await page.keyboard.press( 'Backspace' );
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
@@ -67,7 +85,6 @@ describe( 'List', () => {
 	it( 'should undo asterisk transform with escape', async () => {
 		await clickBlockAppender();
 		await page.keyboard.type( '* ' );
-		await page.evaluate( () => new Promise( window.requestIdleCallback ) );
 		await page.keyboard.press( 'Escape' );
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
@@ -76,7 +93,6 @@ describe( 'List', () => {
 	it( 'should not undo asterisk transform with backspace after typing', async () => {
 		await clickBlockAppender();
 		await page.keyboard.type( '* a' );
-		await page.evaluate( () => new Promise( window.requestIdleCallback ) );
 		await page.keyboard.press( 'Backspace' );
 		await page.keyboard.press( 'Backspace' );
 
@@ -87,7 +103,6 @@ describe( 'List', () => {
 		await clickBlockAppender();
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( '* ' );
-		await page.evaluate( () => new Promise( window.requestIdleCallback ) );
 		await page.keyboard.press( 'ArrowUp' );
 		await page.keyboard.press( 'ArrowDown' );
 		await page.keyboard.press( 'Backspace' );

--- a/packages/e2e-tests/specs/rich-text.test.js
+++ b/packages/e2e-tests/specs/rich-text.test.js
@@ -106,7 +106,6 @@ describe( 'RichText', () => {
 	it( 'should undo backtick transform with backspace', async () => {
 		await clickBlockAppender();
 		await page.keyboard.type( '`a`' );
-		await page.evaluate( () => new Promise( window.requestIdleCallback ) );
 		await page.keyboard.press( 'Backspace' );
 
 		// Expect "`a`" to be restored.
@@ -116,7 +115,6 @@ describe( 'RichText', () => {
 	it( 'should not undo backtick transform with backspace after typing', async () => {
 		await clickBlockAppender();
 		await page.keyboard.type( '`a`' );
-		await page.evaluate( () => new Promise( window.requestIdleCallback ) );
 		await page.keyboard.type( 'b' );
 		await page.keyboard.press( 'Backspace' );
 		await page.keyboard.press( 'Backspace' );
@@ -128,7 +126,6 @@ describe( 'RichText', () => {
 	it( 'should not undo backtick transform with backspace after selection change', async () => {
 		await clickBlockAppender();
 		await page.keyboard.type( '`a`' );
-		await page.evaluate( () => new Promise( window.requestIdleCallback ) );
 		// Move inside format boundary.
 		await page.keyboard.press( 'ArrowLeft' );
 		await page.keyboard.press( 'ArrowLeft' );

--- a/packages/e2e-tests/specs/rich-text.test.js
+++ b/packages/e2e-tests/specs/rich-text.test.js
@@ -126,6 +126,7 @@ describe( 'RichText', () => {
 	it( 'should not undo backtick transform with backspace after selection change', async () => {
 		await clickBlockAppender();
 		await page.keyboard.type( '`a`' );
+		await page.evaluate( () => new Promise( window.requestIdleCallback ) );
 		// Move inside format boundary.
 		await page.keyboard.press( 'ArrowLeft' );
 		await page.keyboard.press( 'ArrowLeft' );


### PR DESCRIPTION
## Description

This is an attempt to stabilise list E2E tests and improves marking automatic changes, which enables undo through `Backspace` and `Escape`.

Looking back, it doesn't seem like a good idea to request an idle callback through `RichText`, as the component will be unmounted after an automatic change. Instead, it's now an effect of `MARK_AUTOMATIC_CHANGE` to make the marking "final". A problem with marking automatic changes is that there will be async selection changes from other effects, which should be ignored. They were ignored by using `requestIdleCallback`, so a change was only marked after everything had been completed. Instead of this, an automatic change will immediately be marked, but marked as "pending", during which time selection changes will not unmark it. During the first idle period, the change will be marked as "final", after which any selection changes _will_ unmark the automatic change.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
