### PR TITLE
Editor: Allow drag and drop in the featured image box.

### DIFF
--- a/packages/editor/src/components/post-featured-image/index.js
+++ b/packages/editor/src/components/post-featured-image/index.js
@@ -40,6 +40,7 @@ function PostFeaturedImage( {
 	onRemoveImage,
 	media,
 	postType,
+	noticeUI,
 } ) {
 	const postLabel = get( postType, [ 'labels' ], {} );
 	const instructions = <p>{ __( 'To edit the featured image, you need permission to upload media.' ) }</p>;
@@ -71,6 +72,7 @@ function PostFeaturedImage( {
 
 	return (
 		<PostFeaturedImageCheck>
+			{ noticeUI }
 			<div className="editor-post-featured-image">
 				<MediaUploadCheck fallback={ instructions }>
 					<MediaUpload

--- a/packages/editor/src/components/post-featured-image/index.js
+++ b/packages/editor/src/components/post-featured-image/index.js
@@ -155,7 +155,7 @@ const applyWithDispatch = withDispatch( ( dispatch, { noticeOperations }, { sele
 		onDropImage( filesList ) {
 			select( 'core/block-editor' )
 				.getSettings()
-				.__experimentalMediaUpload( {
+				.mediaUpload( {
 					allowedTypes: [ 'image' ],
 					filesList,
 					onFileChange( [ image ] ) {

--- a/packages/editor/src/components/post-featured-image/index.js
+++ b/packages/editor/src/components/post-featured-image/index.js
@@ -82,7 +82,7 @@ function PostFeaturedImage( {
 						allowedTypes={ ALLOWED_MEDIA_TYPES }
 						modalClass={ ! featuredImageId ? 'editor-post-featured-image__media-modal' : 'editor-post-featured-image__media-modal' }
 						render={ ( { open } ) => (
-							<>
+							<div className="editor-post-featured-image__container">
 								<Button
 									className={ ! featuredImageId ? 'editor-post-featured-image__toggle' : 'editor-post-featured-image__preview' }
 									onClick={ open }
@@ -99,8 +99,8 @@ function PostFeaturedImage( {
 									{ !! featuredImageId && ! media && <Spinner /> }
 									{ ! featuredImageId && ( postLabel.set_featured_image || DEFAULT_SET_FEATURE_IMAGE_LABEL ) }
 								</Button>
-								<DropZone onFilesDrop={ ! featuredImageId && onDropImage } />
-							</>
+								<DropZone onFilesDrop={ onDropImage } />
+							</div>
 						) }
 						value={ featuredImageId }
 					/>

--- a/packages/editor/src/components/post-featured-image/index.js
+++ b/packages/editor/src/components/post-featured-image/index.js
@@ -81,7 +81,6 @@ function PostFeaturedImage( {
 						modalClass={ ! featuredImageId ? 'editor-post-featured-image__media-modal' : 'editor-post-featured-image__media-modal' }
 						render={ ( { open } ) => (
 							<>
-								<DropZone onFilesDrop={ ! featuredImageId && onDropImage } />
 								<Button
 									className={ ! featuredImageId ? 'editor-post-featured-image__toggle' : 'editor-post-featured-image__preview' }
 									onClick={ open }
@@ -98,6 +97,7 @@ function PostFeaturedImage( {
 									{ !! featuredImageId && ! media && <Spinner /> }
 									{ ! featuredImageId && ( postLabel.set_featured_image || DEFAULT_SET_FEATURE_IMAGE_LABEL ) }
 								</Button>
+								<DropZone onFilesDrop={ ! featuredImageId && onDropImage } />
 							</>
 						) }
 						value={ featuredImageId }

--- a/packages/editor/src/components/post-featured-image/style.scss
+++ b/packages/editor/src/components/post-featured-image/style.scss
@@ -37,6 +37,7 @@
 .editor-post-featured-image__toggle {
 	border: $border-width dashed $light-gray-900;
 	background-color: $light-gray-300;
+	min-height: 90px;
 	line-height: 20px;
 	padding: $grid-size 0;
 	text-align: center;

--- a/packages/editor/src/components/post-featured-image/style.scss
+++ b/packages/editor/src/components/post-featured-image/style.scss
@@ -1,5 +1,6 @@
 .editor-post-featured-image {
 	padding: 0;
+	position: relative;
 
 	.components-spinner {
 		margin: 0;

--- a/packages/editor/src/components/post-featured-image/style.scss
+++ b/packages/editor/src/components/post-featured-image/style.scss
@@ -7,7 +7,11 @@
 	}
 
 	.components-spinner {
-		margin: 0;
+		position: absolute;
+		top: 50%;
+		left: 50%;
+		margin-top: -9px;
+		margin-left: -9px;
 	}
 
 	// Stack consecutive buttons.

--- a/packages/editor/src/components/post-featured-image/style.scss
+++ b/packages/editor/src/components/post-featured-image/style.scss
@@ -1,6 +1,10 @@
 .editor-post-featured-image {
 	padding: 0;
-	position: relative;
+
+	&__container {
+		margin-bottom: 1em;
+		position: relative;
+	}
 
 	.components-spinner {
 		margin: 0;


### PR DESCRIPTION
Closes #10426

## Description

This PR allows users to drop images into the featured image box when it's empty.

## How has this been tested?

Dragging and dropping images was verified to upload and set the featured image correctly.

## Types of Changes

*New Feature:* Allow drag and drop in the featured image box.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
