### PR TITLE
Editor: Don't dirty the post when forcing an undo level creation.

### DIFF
--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -219,6 +219,15 @@ export function* redo() {
 }
 
 /**
+ * Forces the creation of a new undo level.
+ *
+ * @return {Object} Action object.
+ */
+export function __unstableCreateUndoLevel() {
+	return { type: 'CREATE_UNDO_LEVEL' };
+}
+
+/**
  * Action triggered to save an entity record.
  *
  * @param {string} kind    Kind of the received entity.

--- a/packages/core-data/src/reducer.js
+++ b/packages/core-data/src/reducer.js
@@ -304,9 +304,17 @@ export const entities = ( state = {}, action ) => {
  */
 const UNDO_INITIAL_STATE = [];
 UNDO_INITIAL_STATE.offset = 0;
+let lastEditAction;
 export function undo( state = UNDO_INITIAL_STATE, action ) {
 	switch ( action.type ) {
 		case 'EDIT_ENTITY_RECORD':
+		case 'CREATE_UNDO_LEVEL':
+			if ( action.type === 'CREATE_UNDO_LEVEL' ) {
+				action = lastEditAction;
+			} else {
+				lastEditAction = action;
+			}
+
 			if ( action.meta.isUndo || action.meta.isRedo ) {
 				const nextState = [ ...state ];
 				nextState.offset = state.offset + ( action.meta.isUndo ? -1 : 1 );

--- a/packages/e2e-tests/specs/change-detection.test.js
+++ b/packages/e2e-tests/specs/change-detection.test.js
@@ -170,6 +170,21 @@ describe( 'Change detection', () => {
 		await assertIsDirty( false );
 	} );
 
+	it( 'Should not prompt if changes saved right after typing', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( 'Hello World' );
+
+		await Promise.all( [
+			// Wait for "Saved" to confirm save complete.
+			page.waitForSelector( '.editor-post-saved-state.is-saved' ),
+
+			// Keyboard shortcut Ctrl+S save.
+			pressKeyWithModifier( 'primary', 'S' ),
+		] );
+
+		await assertIsDirty( false );
+	} );
+
 	it( 'Should not save if all changes saved', async () => {
 		await page.type( '.editor-post-title__input', 'Hello World' );
 

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -832,6 +832,20 @@ export function* resetEditorBlocks( blocks, options = {} ) {
 	const edits = { blocks: yield* getBlocksWithSourcedAttributes( blocks ) };
 
 	if ( options.__unstableShouldCreateUndoLevel !== false ) {
+		const { id, type } = yield select( STORE_KEY, 'getCurrentPost' );
+		const noChange =
+			( yield select( 'core', 'getEditedEntityRecord', 'postType', type, id ) )
+				.blocks === edits.blocks;
+		if ( noChange ) {
+			return yield dispatch(
+				'core',
+				'__unstableCreateUndoLevel',
+				'postType',
+				type,
+				id
+			);
+		}
+
 		// We create a new function here on every persistent edit
 		// to make sure the edit makes the post dirty and creates
 		// a new undo level.


### PR DESCRIPTION
Fixes #17484

## Description

From #17484:

>If you edit a RichText input and save quickly, you'll see that the post is still marked as dirty (leaving the page shows a warning).
>
>This happens because RichText triggers an edit after 5 seconds of inactivity to mark the last undo as "persistent" to avoid creating undo levels for each character typed.

This PR fixes that by leveraging selectors in the `editor` store's blocks reset function. If the blocks have not changed, it will bail out of editing the post and instead opt for explicitly creating an undo level in `core-data` through a new unstable action.

This new action, `__unstableCreateUndoLevel`, is unstable instead of experimental because it is not certain that it will be needed after refactoring the undo history into a data structure that supports diff based edits for real-time collaborative workflows.

## How has this been tested?

It was verified that the issue described was fixed and all test suites still pass.

## Types of Changes

*Bug Fix:* There was an issue where explicit undo history entry levels being created right after typing and saving would make the post dirty again after saving completed. This is now fixed.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
