### PR TITLE
Add end to end test to the date picker UI next&previous month butons

### DIFF
--- a/packages/e2e-tests/specs/scheduling.test.js
+++ b/packages/e2e-tests/specs/scheduling.test.js
@@ -1,0 +1,28 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	createNewPost,
+} from '@wordpress/e2e-test-utils';
+
+describe( 'Scheduling', () => {
+	beforeEach( createNewPost );
+
+	const isDateTimeComponentFocused = () => {
+		return page.evaluate( () => {
+			const dateTimeElement = document.querySelector( '.components-datetime__date' );
+			if ( ! dateTimeElement || ! document.activeElement ) {
+				return false;
+			}
+			return dateTimeElement.contains( document.activeElement );
+		} );
+	};
+
+	it( 'Should keep date time UI focused when the previous and next month buttons are clicked', async () => {
+		await page.click( '.edit-post-post-schedule__toggle' );
+		await page.click( 'div[aria-label="Move backward to switch to the previous month."]' );
+		expect( await isDateTimeComponentFocused() ).toBe( true );
+		await page.click( 'div[aria-label="Move forward to switch to the next month."]' );
+		expect( await isDateTimeComponentFocused() ).toBe( true );
+	} );
+} );


### PR DESCRIPTION
This PR adds an end 2 end test that makes sure when next&previous month buttons are clicked the focus stays on the date picker interface and consequently the popover stays open.

This makes sure that the fix added in PR https://github.com/WordPress/gutenberg/pull/17201 does not regress.

The post scheduler mechanism is not covered with end 2 end tests I plan to follow up with more tests on this file.


## How has this been tested?
I verified the end to end test passes:
```
LOCAL_SCRIPT_DEBUG=false npm run test-e2e packages/e2e-tests/specs/scheduling.test.js
```
I reverted PR https://github.com/WordPress/gutenberg/pull/17201 and verified the end 2 end test fails:
```
git revert 59736039bd28b44b69c8d8fdc4ab9cb6db647466
```