### PR TITLE
Check for persistedRecord before evaluating status property to prevent uncaught type error

### DIFF
--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -319,7 +319,7 @@ export function* saveEntityRecord(
 			let data = record;
 			if (
 				kind === 'postType' &&
-				persistedRecord.status === 'auto-draft' &&
+				persistedRecord && persistedRecord.status === 'auto-draft' &&
 				! data.status
 			) {
 				data = { ...data, status: 'draft' };


### PR DESCRIPTION
## Description

A recent change related to the setting of autodraft titles (https://github.com/WordPress/gutenberg/commit/53857f67563eb97025d75c196afa643994f0bbcc) fails with an unhandled error at https://github.com/WordPress/gutenberg/commit/53857f67563eb97025d75c196afa643994f0bbcc#diff-83cecb38834613f359225842d097fc6eR319 in cases when persisted record is undefined, which causes the entity to be unsaved and undefined returned.

This issue was discovered in https://github.com/Automattic/wp-calypso/issues/36194.  When a Simple Payments block is first added it uses saveEntityRecord to save the product details - this was failing for the above reason and consequently the block did not display on the front end.

## How has this been tested?

1. On a site with Jetpack premium enabled and Gutenberg 6.5, add a Simple Payment Button block then save and preview the page. The Simple Payment Button does not display on the front end.
2. Apply this patch and rebuild Gutenberg and install on test site
3. Try adding another Simple Payment button, saving, and previewing. The block should now appear on the front end.


## Types of changes

Add a check for persistedRecord object before checking its status property

## Checklist:
- [ x ] My code is tested.
- [  x ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [  NA ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ NA ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ NA] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
