### PR TITLE
Add isInvalidDate prop to DatePicker

### DIFF
--- a/packages/components/src/date-time/index.js
+++ b/packages/components/src/date-time/index.js
@@ -34,7 +34,7 @@ export class DateTimePicker extends Component {
 	}
 
 	render() {
-		const { currentDate, is12Hour, onChange } = this.props;
+		const { currentDate, is12Hour, isInvalidDate, onChange } = this.props;
 
 		return (
 			<div className="components-datetime">
@@ -48,6 +48,7 @@ export class DateTimePicker extends Component {
 						<DatePicker
 							currentDate={ currentDate }
 							onChange={ onChange }
+							isInvalidDate={ isInvalidDate }
 						/>
 					</>
 				) }


### PR DESCRIPTION
## Description
The PR adds the missing `isInvalidDate` prop to `DatePicker`. Fixes #17497 

## How has this been tested?
Yes

## Screenshots <!-- if applicable -->

## Types of changes
Passes an additional prop to an existing component

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
