### PR TITLE
Autosave: fix conflict between remote and local autosaves

### DIFF
--- a/packages/e2e-test-utils/README.md
+++ b/packages/e2e-test-utils/README.md
@@ -299,6 +299,10 @@ _Returns_
 
 -   `Promise`: Promise resolving with a boolean indicating if the focused block is the default block.
 
+<a name="isOfflineMode" href="#isOfflineMode">#</a> **isOfflineMode**
+
+Undocumented declaration.
+
 <a name="loginUser" href="#loginUser">#</a> **loginUser**
 
 Performs log in with specified username and password.
@@ -476,6 +480,10 @@ running the tests as (if we're not already that user).
 <a name="toggleMoreMenu" href="#toggleMoreMenu">#</a> **toggleMoreMenu**
 
 Toggles the More Menu.
+
+<a name="toggleOfflineMode" href="#toggleOfflineMode">#</a> **toggleOfflineMode**
+
+Undocumented declaration.
 
 <a name="toggleScreenOption" href="#toggleScreenOption">#</a> **toggleScreenOption**
 

--- a/packages/e2e-test-utils/src/index.js
+++ b/packages/e2e-test-utils/src/index.js
@@ -47,6 +47,7 @@ export { disableNavigationMode } from './keyboard-mode';
 export { switchUserToAdmin } from './switch-user-to-admin';
 export { switchUserToTest } from './switch-user-to-test';
 export { toggleMoreMenu } from './toggle-more-menu';
+export { toggleOfflineMode, isOfflineMode } from './offline-mode';
 export { toggleScreenOption } from './toggle-screen-option';
 export { transformBlockTo } from './transform-block-to';
 export { uninstallPlugin } from './uninstall-plugin';

--- a/packages/e2e-test-utils/src/offline-mode.js
+++ b/packages/e2e-test-utils/src/offline-mode.js
@@ -1,0 +1,10 @@
+let _isOfflineMode = false;
+
+export async function toggleOfflineMode( isOffline ) {
+	_isOfflineMode = isOffline;
+	page.setOfflineMode( isOffline );
+}
+
+export function isOfflineMode() {
+	return _isOfflineMode;
+}

--- a/packages/e2e-tests/config/setup-test-framework.js
+++ b/packages/e2e-tests/config/setup-test-framework.js
@@ -10,6 +10,7 @@ import {
 	activatePlugin,
 	clearLocalStorage,
 	enablePageDialogAccept,
+	isOfflineMode,
 	setBrowserViewport,
 	switchUserToAdmin,
 	switchUserToTest,
@@ -119,6 +120,12 @@ function observeConsoleLogging() {
 		// Viewing posts on the front end can result in this error, which
 		// has nothing to do with Gutenberg.
 		if ( text.includes( 'net::ERR_UNKNOWN_URL_SCHEME' ) ) {
+			return;
+		}
+
+		// Network errors are ignored only if we are intentionally testing
+		// offline mode.
+		if ( text.includes( 'net::ERR_INTERNET_DISCONNECTED' ) && isOfflineMode() ) {
 			return;
 		}
 

--- a/packages/e2e-tests/specs/autosave.test.js
+++ b/packages/e2e-tests/specs/autosave.test.js
@@ -91,8 +91,9 @@ describe( 'autosave', () => {
 		await saveDraftWithKeyboard();
 		await page.keyboard.type( ' after save' );
 
+		// Trigger local autosave
+		await page.evaluate( () => window.wp.data.dispatch( 'core/editor' ).localAutosave() );
 		// Reload without saving on the server
-		await sleep( AUTOSAVE_INTERVAL_SECONDS + 1 );
 		await page.reload();
 
 		const notice = await page.$eval( '.components-notice__content', ( element ) => element.innerText );
@@ -152,11 +153,10 @@ describe( 'autosave', () => {
 		await page.keyboard.type( 'before save' );
 		await saveDraft();
 
-		// Fake local autosave
-		await page.evaluate( ( postId ) => window.sessionStorage.setItem(
-			`wp-autosave-block-editor-post-${ postId }`,
-			JSON.stringify( { post_title: 'A', content: 'B', excerpt: 'C' } )
-		), await getCurrentPostId() );
+		await page.keyboard.type( 'after save' );
+
+		// Trigger local autosave
+		await page.evaluate( () => window.wp.data.dispatch( 'core/editor' ).localAutosave() );
 		expect( await page.evaluate( () => window.sessionStorage.length ) ).toBe( 1 );
 
 		// Trigger remote autosave

--- a/packages/e2e-tests/specs/autosave.test.js
+++ b/packages/e2e-tests/specs/autosave.test.js
@@ -156,9 +156,9 @@ describe( 'autosave', () => {
 
 		await Promise.all( [
 			// Force remote autosave to occur immediately
-			await page.evaluate( () => window.wp.data.dispatch( 'core/editor' ).autosave() ),
+			page.evaluate( () => window.wp.data.dispatch( 'core/editor' ).autosave() ),
 			// Meanwhile, wait for local autosave
-			await sleep( AUTOSAVE_INTERVAL_SECONDS + 1 ),
+			sleep( AUTOSAVE_INTERVAL_SECONDS + 2 ),
 		] );
 
 		await page.reload();

--- a/packages/e2e-tests/specs/autosave.test.js
+++ b/packages/e2e-tests/specs/autosave.test.js
@@ -147,6 +147,24 @@ describe( 'autosave', () => {
 		expect( await page.$( '.components-notice__content' ) ).toBe( null );
 	} );
 
+	it( 'should clear local autosave after successful remote autosave', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( 'before save' );
+		await saveDraft();
+
+		// Fake local autosave
+		await page.evaluate( ( postId ) => window.sessionStorage.setItem(
+			`wp-autosave-block-editor-post-${ postId }`,
+			JSON.stringify( { post_title: 'A', content: 'B', excerpt: 'C' } )
+		), await getCurrentPostId() );
+		expect( await page.evaluate( () => window.sessionStorage.length ) ).toBe( 1 );
+
+		// Trigger remote autosave
+		await page.evaluate( () => window.wp.data.dispatch( 'core/editor' ).autosave() );
+
+		expect( await page.evaluate( () => window.sessionStorage.length ) ).toBe( 0 );
+	} );
+
 	it( 'shouldn\'t conflict with server-side autosave', async () => {
 		await clickBlockAppender();
 		await page.keyboard.type( 'before publish' );

--- a/packages/e2e-tests/specs/autosave.test.js
+++ b/packages/e2e-tests/specs/autosave.test.js
@@ -154,12 +154,8 @@ describe( 'autosave', () => {
 
 		await page.type( '.wp-block-paragraph', ' after publish' );
 
-		await Promise.all( [
-			// Force remote autosave to occur immediately
-			page.evaluate( () => window.wp.data.dispatch( 'core/editor' ).autosave() ),
-			// Meanwhile, wait for local autosave
-			sleep( AUTOSAVE_INTERVAL_SECONDS + 2 ),
-		] );
+		await sleep( AUTOSAVE_INTERVAL_SECONDS + 2 );
+		await page.evaluate( () => window.wp.data.dispatch( 'core/editor' ).autosave() );
 
 		await page.reload();
 

--- a/packages/e2e-tests/specs/autosave.test.js
+++ b/packages/e2e-tests/specs/autosave.test.js
@@ -96,7 +96,7 @@ describe( 'autosave', () => {
 		await page.keyboard.type( ' after save' );
 
 		// Trigger local autosave
-		await page.evaluate( () => window.wp.data.dispatch( 'core/editor' ).localAutosave() );
+		await page.evaluate( () => window.wp.data.dispatch( 'core/editor' ).__experimentalLocalAutosave() );
 		// Reload without saving on the server
 		await page.reload();
 
@@ -160,7 +160,7 @@ describe( 'autosave', () => {
 		await page.keyboard.type( 'after save' );
 
 		// Trigger local autosave
-		await page.evaluate( () => window.wp.data.dispatch( 'core/editor' ).localAutosave() );
+		await page.evaluate( () => window.wp.data.dispatch( 'core/editor' ).__experimentalLocalAutosave() );
 		expect( await page.evaluate( () => window.sessionStorage.length ) ).toBe( 1 );
 
 		// Trigger remote autosave
@@ -174,7 +174,7 @@ describe( 'autosave', () => {
 		await saveDraft();
 
 		await page.keyboard.type( 'after save' );
-		await page.evaluate( () => window.wp.data.dispatch( 'core/editor' ).localAutosave() );
+		await page.evaluate( () => window.wp.data.dispatch( 'core/editor' ).__experimentalLocalAutosave() );
 		expect( await page.evaluate( () => window.sessionStorage.length ) ).toBe( 1 );
 
 		toggleOfflineMode( true );
@@ -197,7 +197,7 @@ describe( 'autosave', () => {
 		// Trigger remote autosave
 		await page.evaluate( () => window.wp.data.dispatch( 'core/editor' ).autosave() );
 		// Force conflicting local autosave
-		await page.evaluate( () => window.wp.data.dispatch( 'core/editor' ).localAutosave() );
+		await page.evaluate( () => window.wp.data.dispatch( 'core/editor' ).__experimentalLocalAutosave() );
 		expect( await page.evaluate( () => window.sessionStorage.length ) ).toBe( 1 );
 
 		await page.reload();

--- a/packages/e2e-tests/specs/autosave.test.js
+++ b/packages/e2e-tests/specs/autosave.test.js
@@ -6,8 +6,9 @@ import {
 	createNewPost,
 	getEditedPostContent,
 	pressKeyWithModifier,
-	saveDraft,
 	publishPost,
+	saveDraft,
+	toggleOfflineMode,
 } from '@wordpress/e2e-test-utils';
 
 // Constant to override editor preference
@@ -161,8 +162,25 @@ describe( 'autosave', () => {
 
 		// Trigger remote autosave
 		await page.evaluate( () => window.wp.data.dispatch( 'core/editor' ).autosave() );
-
 		expect( await page.evaluate( () => window.sessionStorage.length ) ).toBe( 0 );
+	} );
+
+	it( 'shouldn\'t clear local autosave if remote autosave fails', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( 'before save' );
+		await saveDraft();
+
+		await page.keyboard.type( 'after save' );
+		await page.evaluate( () => window.wp.data.dispatch( 'core/editor' ).localAutosave() );
+		expect( await page.evaluate( () => window.sessionStorage.length ) ).toBe( 1 );
+
+		toggleOfflineMode( true );
+
+		// Trigger remote autosave
+		await page.evaluate( () => window.wp.data.dispatch( 'core/editor' ).autosave() );
+		expect( await page.evaluate( () => window.sessionStorage.length ) ).toBe( 1 );
+
+		toggleOfflineMode( false );
 	} );
 
 	it( 'shouldn\'t conflict with server-side autosave', async () => {

--- a/packages/e2e-tests/specs/autosave.test.js
+++ b/packages/e2e-tests/specs/autosave.test.js
@@ -195,7 +195,7 @@ describe( 'autosave', () => {
 		await page.keyboard.type( ' after publish' );
 
 		// Trigger remote autosave
-		// await page.evaluate( () => window.wp.data.dispatch( 'core/editor' ).autosave() );
+		await page.evaluate( () => window.wp.data.dispatch( 'core/editor' ).autosave() );
 		// Force conflicting local autosave
 		await page.evaluate( () => window.wp.data.dispatch( 'core/editor' ).localAutosave() );
 		expect( await page.evaluate( () => window.sessionStorage.length ) ).toBe( 1 );

--- a/packages/editor/src/components/local-autosave-monitor/index.js
+++ b/packages/editor/src/components/local-autosave-monitor/index.js
@@ -152,9 +152,9 @@ function useAutosavePurge() {
 }
 
 function LocalAutosaveMonitor() {
-	const { localAutosave } = useDispatch( 'core/editor' );
+	const { __experimentalLocalAutosave } = useDispatch( 'core/editor' );
 	const autosave = useCallback( () => {
-		requestIdleCallback( localAutosave );
+		requestIdleCallback( __experimentalLocalAutosave );
 	}, [] );
 	useAutosaveNotice();
 	useAutosavePurge();

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -372,7 +372,7 @@ export function* autosave( options ) {
 	);
 }
 
-export function* localAutosave() {
+export function* __experimentalLocalAutosave() {
 	const post = yield select( STORE_KEY, 'getCurrentPost' );
 	const title = yield select( STORE_KEY, 'getEditedPostAttribute', 'title' );
 	const content = yield select( STORE_KEY, 'getEditedPostAttribute', 'content' );

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -372,6 +372,20 @@ export function* autosave( options ) {
 	);
 }
 
+export function* localAutosave() {
+	const post = yield select( STORE_KEY, 'getCurrentPost' );
+	const title = yield select( STORE_KEY, 'getEditedPostAttribute', 'title' );
+	const content = yield select( STORE_KEY, 'getEditedPostAttribute', 'content' );
+	const excerpt = yield select( STORE_KEY, 'getEditedPostAttribute', 'excerpt' );
+	yield {
+		type: 'LOCAL_AUTOSAVE_SET',
+		postId: post.id,
+		title,
+		content,
+		excerpt,
+	};
+}
+
 /**
  * Returns an action object used in signalling that undo history should
  * restore last popped state.

--- a/packages/editor/src/store/controls.js
+++ b/packages/editor/src/store/controls.js
@@ -23,6 +23,38 @@ export function getRegistry() {
 	return { type: 'GET_REGISTRY' };
 }
 
+/**
+ * Function returning a sessionStorage key to set or retrieve a given post's
+ * automatic session backup.
+ *
+ * Keys are crucially prefixed with 'wp-autosave-' so that wp-login.php's
+ * `loggedout` handler can clear sessionStorage of any user-private content.
+ *
+ * @see https://github.com/WordPress/wordpress-develop/blob/6dad32d2aed47e6c0cf2aee8410645f6d7aba6bd/src/wp-login.php#L103
+ *
+ * @param {string} postId  Post ID.
+ * @return {string}        sessionStorage key
+ */
+function postKey( postId ) {
+	return `wp-autosave-block-editor-post-${ postId }`;
+}
+
+export function localAutosaveGet( postId ) {
+	return window.sessionStorage.getItem( postKey( postId ) );
+}
+
+export function localAutosaveSet( postId, title, content, excerpt ) {
+	window.sessionStorage.setItem( postKey( postId ), JSON.stringify( {
+		post_title: title,
+		content,
+		excerpt,
+	} ) );
+}
+
+export function localAutosaveClear( postId ) {
+	window.sessionStorage.removeItem( postKey( postId ) );
+}
+
 const controls = {
 	AWAIT_NEXT_STATE_CHANGE: createRegistryControl(
 		( registry ) => () => new Promise( ( resolve ) => {
@@ -33,6 +65,9 @@ const controls = {
 		} )
 	),
 	GET_REGISTRY: createRegistryControl( ( registry ) => () => registry ),
+	LOCAL_AUTOSAVE_SET( { postId, title, content, excerpt } ) {
+		localAutosaveSet( postId, title, content, excerpt );
+	},
 };
 
 export default controls;


### PR DESCRIPTION
Fixes #17500

## Description
_For now, this only includes failing E2E tests_

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
