### PR TITLE
Image Block: Improve performance by only requesting image metadata if selected.

### DIFF
--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -939,7 +939,7 @@ export default compose( [
 	withSelect( ( select, props ) => {
 		const { getMedia } = select( 'core' );
 		const { getSettings } = select( 'core/block-editor' );
-		const { id } = props.attributes;
+		const { attributes: { id }, isSelected } = props;
 		const {
 			__experimentalMediaUpload,
 			imageSizes,
@@ -948,7 +948,7 @@ export default compose( [
 		} = getSettings();
 
 		return {
-			image: id ? getMedia( id ) : null,
+			image: id && isSelected ? getMedia( id ) : null,
 			maxWidth,
 			isRTL,
 			imageSizes,


### PR DESCRIPTION
Fixes #17465

## Description

This PR stops image blocks from preemptively requesting image metadata and delays it until the block is selected.

This fixes performance issues with posts that contain many images.

## How to test?

Verify that the image block still works as expected and that the issue described in #17465 is no longer happening.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
