### PR TITLE
Editor: Fix and align collapsing logic for "Save Draft" and "Saved" button states.

### DIFF
--- a/packages/editor/src/components/post-saved-state/index.js
+++ b/packages/editor/src/components/post-saved-state/index.js
@@ -156,5 +156,5 @@ export default compose( [
 		onSave: dispatch( 'core/editor' ).savePost,
 	} ) ),
 	withSafeTimeout,
-	withViewportMatch( { isLargeViewport: 'medium' } ),
+	withViewportMatch( { isLargeViewport: 'small' } ),
 ] )( PostSavedState );

--- a/packages/editor/src/components/post-saved-state/style.scss
+++ b/packages/editor/src/components/post-saved-state/style.scss
@@ -27,10 +27,4 @@
 // This needs specificity to override inherited styles.
 .edit-post-header .edit-post-header__settings .components-button.editor-post-save-draft {
 	margin: 0;
-
-	@include break-small() {
-		.dashicon {
-			display: none;
-		}
-	}
 }


### PR DESCRIPTION
Fixes #17461

## Description

#10552 introduced an issue where the breakpoints used for switching between the icon and text forms of the save, saving, and saved state buttons were not aligned.

There was a CSS breakpoint that hid the save button when the screen was wider than 600 pixels, but JS code would switch to rendering the text form only when the screen was wider than 800 pixels. This resulted in no save button being shown between those two breakpoints.

This PR fixes that by removing the 600 pixels CSS breakpoint, because JS now handles toggling between icon and text modes, so it's no longer needed. It also switches that JS breakpoint to 600 pixels so that it is aligned with the saving and saved state button breakpoints.

This makes me think that we really should have e2e tests also running in smaller screen sizes.

## How has this been tested?

It was verified that when the screen is wider than 600 pixels, the long form text version of the buttons is rendered, and when the screen is narrower than 600 pixels, the icon version is rendered.

## Screenshots

#### Long Form Save

<img width="378" alt="Screen Shot 2019-09-20 at 11 18 04 AM" src="https://user-images.githubusercontent.com/19157096/65349503-6525d180-db98-11e9-9af0-be9aedc21b7b.png">

#### Long Form Saved

<img width="396" alt="Screen Shot 2019-09-20 at 11 17 59 AM" src="https://user-images.githubusercontent.com/19157096/65349508-68b95880-db98-11e9-8fb9-216d1e1c8395.png">

#### Short Form Save

<img width="271" alt="Screen Shot 2019-09-20 at 11 18 19 AM" src="https://user-images.githubusercontent.com/19157096/65349517-6d7e0c80-db98-11e9-82e5-402e30b0daca.png">

#### Short Form Saved

<img width="272" alt="Screen Shot 2019-09-20 at 11 18 23 AM" src="https://user-images.githubusercontent.com/19157096/65349521-6f47d000-db98-11e9-8bd6-76e69874e337.png">


## Types of Changes

*Bug Fix:* Show missing save button in small screen sizes.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
