### PR TITLE
Update docs with example attributes for Inspector previews

### DIFF
--- a/docs/designers-developers/developers/block-api/README.md
+++ b/docs/designers-developers/developers/block-api/README.md
@@ -8,4 +8,4 @@ All blocks must be registered before they can be used in the editor. You can lea
 
 ## Block `edit` and `save`
 
-The `edit` and `save` functions define the editor interface with which a user would interact, and the markup to be serialized back when a post is saved. They are the heart of how a block operates, so they are [covered separately](/docs/designers-developers/developers/block-api/block-edit-save.md).
+The `edit` function defines the components for the block in the editor interface the user interacts with. The `save` function defines the markup to be serialized back when a post is saved. They are the heart of how a block operates, so they are [covered separately](/docs/designers-developers/developers/block-api/block-edit-save.md).

--- a/docs/designers-developers/developers/block-api/block-registration.md
+++ b/docs/designers-developers/developers/block-api/block-registration.md
@@ -168,6 +168,26 @@ attributes: {
 
 * **See: [Attributes](/docs/designers-developers/developers/block-api/block-attributes.md).**
 
+#### Example (optional)
+
+* **Type:** `Object`
+
+Example provides structured example data for the block. This data is used to construct a preview for the block to be shown in the Inspector Help Panel when the user mouses over the block.
+
+The data provided in the example object should match the attributes defined. For example:
+
+```js
+example: {
+    attributes: {
+        cover: 'https://example.com/image.jpg',
+        author: 'William Shakespeare',
+        pages: 500
+    },
+},
+```
+
+If `example` is not defined, the preview will not be shown. So even if no-attributes are defined, setting a empty example object `example: {}` will trigger the preview to show.
+
 #### Transforms (optional)
 
 * **Type:** `Array`

--- a/docs/designers-developers/developers/tutorials/block-tutorial/applying-styles-with-stylesheets.md
+++ b/docs/designers-developers/developers/tutorials/block-tutorial/applying-styles-with-stylesheets.md
@@ -14,6 +14,7 @@ The editor will automatically generate a class name for each block type to simpl
 		title: 'Example: Stylesheets',
 		icon: 'universal-access-alt',
 		category: 'layout',
+		example: {},
 		edit: function( props ) {
 			return el(
 				'p',
@@ -44,6 +45,8 @@ registerBlockType( 'gutenberg-examples/example-02-stylesheets', {
 	icon: 'universal-access-alt',
 
 	category: 'layout',
+
+	example: {},
 
 	edit( { className } ) {
 		return <p className={ className }>Hello World, step 2 (from the editor, in green).</p>;

--- a/docs/designers-developers/developers/tutorials/block-tutorial/block-controls-toolbar-and-sidebar.md
+++ b/docs/designers-developers/developers/tutorials/block-tutorial/block-controls-toolbar-and-sidebar.md
@@ -35,7 +35,12 @@ You can also customize the toolbar to include controls specific to your block ty
 				default: 'none',
 			},
 		},
-
+		example: {
+			attributes: {
+				content: 'Hello World',
+				alignment: 'right',
+			},
+		},
 		edit: function( props ) {
 			var content = props.attributes.content;
 			var alignment = props.attributes.alignment;
@@ -111,6 +116,12 @@ registerBlockType( 'gutenberg-examples/example-04-controls-esnext', {
 		alignment: {
 			type: 'string',
 			default: 'none',
+		},
+	},
+	example: {
+		attributes: {
+			content: 'Hello World',
+			alignment: 'right',
 		},
 	},
 	edit: ( props ) => {

--- a/docs/designers-developers/developers/tutorials/block-tutorial/introducing-attributes-and-editable-fields.md
+++ b/docs/designers-developers/developers/tutorials/block-tutorial/introducing-attributes-and-editable-fields.md
@@ -72,7 +72,11 @@ Here is the complete block definition for Example 03.
 				selector: 'p',
 			},
 		},
-
+		example: {
+			attributes: {
+				content: 'Hello World',
+			},
+		},
 		edit: function( props ) {
 			var content = props.attributes.content;
 			function onChangeContent( newContent ) {
@@ -116,6 +120,11 @@ registerBlockType( 'gutenberg-examples/example-03-editable-esnext', {
 			type: 'array',
 			source: 'children',
 			selector: 'p',
+		},
+	},
+	example: {
+		attributes: {
+			content: 'Hello World',
 		},
 	},
 	edit: ( props ) => {

--- a/docs/designers-developers/developers/tutorials/block-tutorial/writing-your-first-block-type.md
+++ b/docs/designers-developers/developers/tutorials/block-tutorial/writing-your-first-block-type.md
@@ -55,6 +55,7 @@ With the script enqueued, let's look at the implementation of the block itself:
 		title: 'Example: Basic',
 		icon: 'universal-access-alt',
 		category: 'layout',
+		example: {},
 		edit: function() {
 			return el(
 				'p',
@@ -89,6 +90,7 @@ registerBlockType( 'gutenberg-examples/example-01-basic-esnext', {
 	title: 'Example: Basic (esnext)',
 	icon: 'universal-access-alt',
 	category: 'layout',
+	example: {},
 	edit() {
 		return <div style={ blockStyle }>Hello World, step 1 (from the editor).</div>;
 	},


### PR DESCRIPTION
## Description

Follow-up for #17124.

Adds example as block registration attribute
Updates tutorials with example defined in examples

Sister PR for Gutenberg Examples with same updates
https://github.com/WordPress/gutenberg-examples/pull/93

## How has this been tested?

Follow the directions and confirm the previews show as expected in Inspector


## Types of changes

Documentation.
