### PR TITLE
Put the core/template block back to support full site editing plugin

### DIFF
--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -54,6 +54,7 @@ import * as shortcode from './shortcode';
 import * as spacer from './spacer';
 import * as subhead from './subhead';
 import * as table from './table';
+import * as template from './template';
 import * as textColumns from './text-columns';
 import * as verse from './verse';
 import * as video from './video';
@@ -136,6 +137,7 @@ export const registerCoreBlocks = () => {
 		subhead,
 		table,
 		tagCloud,
+		template,
 		textColumns,
 		verse,
 		video,

--- a/packages/block-library/src/index.native.js
+++ b/packages/block-library/src/index.native.js
@@ -44,6 +44,7 @@ import * as shortcode from './shortcode';
 import * as spacer from './spacer';
 import * as subhead from './subhead';
 import * as table from './table';
+import * as template from './template';
 import * as textColumns from './text-columns';
 import * as verse from './verse';
 import * as video from './video';
@@ -91,6 +92,7 @@ export const coreBlocks = [
 	subhead,
 	table,
 	tagCloud,
+	template,
 	textColumns,
 	verse,
 	video,

--- a/packages/block-library/src/template/block.json
+++ b/packages/block-library/src/template/block.json
@@ -1,0 +1,4 @@
+{
+	"name": "core/template",
+	"category": "reusable"
+}

--- a/packages/block-library/src/template/edit.js
+++ b/packages/block-library/src/template/edit.js
@@ -1,0 +1,8 @@
+/**
+ * WordPress dependencies
+ */
+import { InnerBlocks } from '@wordpress/block-editor';
+
+export default function TemplateEdit() {
+	return <InnerBlocks />;
+}

--- a/packages/block-library/src/template/icon.js
+++ b/packages/block-library/src/template/icon.js
@@ -1,0 +1,8 @@
+/**
+ * WordPress dependencies
+ */
+import { G, Path, Rect, SVG } from '@wordpress/components';
+
+export default (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><Rect x="0" fill="none" width="24" height="24" /><G><Path d="M19 3H5c-1.105 0-2 .895-2 2v14c0 1.105.895 2 2 2h14c1.105 0 2-.895 2-2V5c0-1.105-.895-2-2-2zM6 6h5v5H6V6zm4.5 13C9.12 19 8 17.88 8 16.5S9.12 14 10.5 14s2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5zm3-6l3-5 3 5h-6z" /></G></SVG>
+);

--- a/packages/block-library/src/template/index.js
+++ b/packages/block-library/src/template/index.js
@@ -1,0 +1,29 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import edit from './edit';
+import icon from './icon';
+import metadata from './block.json';
+import save from './save';
+
+const { name } = metadata;
+
+export { metadata, name };
+
+export const settings = {
+	title: __( 'Reusable Template' ),
+	description: __( 'Template block used as a container.' ),
+	icon,
+	supports: {
+		customClassName: false,
+		html: false,
+		inserter: false,
+	},
+	edit,
+	save,
+};

--- a/packages/block-library/src/template/save.js
+++ b/packages/block-library/src/template/save.js
@@ -1,0 +1,8 @@
+/**
+ * WordPress dependencies
+ */
+import { InnerBlocks } from '@wordpress/block-editor';
+
+export default function save() {
+	return <InnerBlocks.Content />;
+}


### PR DESCRIPTION
## Description
Adds back the core/template block that was removed at https://github.com/WordPress/gutenberg/commit/50fb29bb2181e56a4a2d4c5407ba23c8bba2c4da as this block is currently used by the Full Site Editing plugin at https://github.com/Automattic/wp-calypso/blob/master/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/edit.js#L65.

## How has this been tested?
Install Gutenberg 6.5 on a Full Site Editing dev environment and the plugin fails to load the header and footer template blocks. 
Apply this patch to the environment and the header and footer blocks render in the editor as expected

## Types of changes
Restored template block files removed in previous merge
