### PR TITLE
Fix inserter / block directory issues

### DIFF
--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -264,9 +264,11 @@ export class InserterMenu extends Component {
 			suggestedItems,
 			filterValue,
 		} = this.state;
+
 		const isPanelOpen = ( panel ) => openPanels.indexOf( panel ) !== -1;
 		const hasItems = ! ( isEmpty( suggestedItems ) && isEmpty( reusableItems ) && isEmpty( itemsPerCategory ) );
 		const hoveredItemBlockType = hoveredItem ? getBlockType( hoveredItem.name ) : null;
+		const hasHelpPanel = hasItems && showInserterHelpPanel;
 
 		// Disable reason (no-autofocus): The inserter menu is a modal display, not one which
 		// is always visible, and one which already incurs this behavior of autoFocus via
@@ -277,7 +279,7 @@ export class InserterMenu extends Component {
 		return (
 			<div
 				className={ classnames( 'editor-inserter__menu block-editor-inserter__menu', {
-					'has-help-panel': showInserterHelpPanel,
+					'has-help-panel': hasHelpPanel,
 				} ) }
 				onKeyPress={ stopKeyPropagation }
 				onKeyDown={ this.onKeyDown }
@@ -382,7 +384,7 @@ export class InserterMenu extends Component {
 					</div>
 				</div>
 
-				{ hasItems && showInserterHelpPanel && (
+				{ hasHelpPanel && (
 					<div className="block-editor-inserter__menu-help-panel">
 						{ hoveredItem && (
 							<>

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -262,9 +262,10 @@ export class InserterMenu extends Component {
 			openPanels,
 			reusableItems,
 			suggestedItems,
+			filterValue,
 		} = this.state;
 		const isPanelOpen = ( panel ) => openPanels.indexOf( panel ) !== -1;
-		const hasItems = isEmpty( suggestedItems ) && isEmpty( reusableItems ) && isEmpty( itemsPerCategory );
+		const hasItems = ! ( isEmpty( suggestedItems ) && isEmpty( reusableItems ) && isEmpty( itemsPerCategory ) );
 		const hoveredItemBlockType = hoveredItem ? getBlockType( hoveredItem.name ) : null;
 
 		// Disable reason (no-autofocus): The inserter menu is a modal display, not one which
@@ -362,7 +363,7 @@ export class InserterMenu extends Component {
 							fillProps={ {
 								onSelect,
 								onHover: this.onHover,
-								filterValue: this.state.filterValue,
+								filterValue,
 								hasItems,
 							} }
 						>
@@ -370,7 +371,7 @@ export class InserterMenu extends Component {
 								if ( fills.length ) {
 									return fills;
 								}
-								if ( hasItems ) {
+								if ( ! hasItems ) {
 									return (
 										<p className="editor-inserter__no-results block-editor-inserter__no-results">{ __( 'No blocks found.' ) }</p>
 									);
@@ -381,7 +382,7 @@ export class InserterMenu extends Component {
 					</div>
 				</div>
 
-				{ showInserterHelpPanel && (
+				{ hasItems && showInserterHelpPanel && (
 					<div className="block-editor-inserter__menu-help-panel">
 						{ hoveredItem && (
 							<>

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -266,7 +266,7 @@ export class InserterMenu extends Component {
 		} = this.state;
 
 		const isPanelOpen = ( panel ) => openPanels.indexOf( panel ) !== -1;
-		const hasItems = ! ( isEmpty( suggestedItems ) && isEmpty( reusableItems ) && isEmpty( itemsPerCategory ) );
+		const hasItems = ! isEmpty( suggestedItems ) || ! isEmpty( reusableItems ) || ! isEmpty( itemsPerCategory );
 		const hoveredItemBlockType = hoveredItem ? getBlockType( hoveredItem.name ) : null;
 		const hasHelpPanel = hasItems && showInserterHelpPanel;
 

--- a/packages/editor/src/components/inserter-menu-downloadable-blocks-panel/index.js
+++ b/packages/editor/src/components/inserter-menu-downloadable-blocks-panel/index.js
@@ -19,7 +19,7 @@ function InserterMenuDownloadableBlocksPanel() {
 		<__experimentalInserterMenuExtension>
 			{
 				( { onSelect, onHover, filterValue, hasItems } ) => {
-					if ( hasItems ) {
+					if ( hasItems || ! filterValue ) {
 						return null;
 					}
 

--- a/packages/editor/src/components/inserter-menu-downloadable-blocks-panel/index.js
+++ b/packages/editor/src/components/inserter-menu-downloadable-blocks-panel/index.js
@@ -19,7 +19,7 @@ function InserterMenuDownloadableBlocksPanel() {
 		<__experimentalInserterMenuExtension>
 			{
 				( { onSelect, onHover, filterValue, hasItems } ) => {
-					if ( ! hasItems ) {
+					if ( hasItems ) {
 						return null;
 					}
 


### PR DESCRIPTION
## Description
I started this PR to fix one issue, but noticed a few related to the same piece of code, so it now fixes three 😄 

The fixes are as follows:

#### Code quality - fix incorrect value for `hasItems` variable

A late change in #17431 was to rename `isMenuEmpty` to `hasItems`, but we forgot to also flip the value of the variable to match the new meaning. 

fcb5f74 fixes this by flipping the logic and updating usage of the variable.

#### Inserter help panel was being displayed when no available blocks in the inserter menu

To reproduce this:
1. Make sure the Block Directory feature is disabled
2. Insert a columns block
3. Select the column
4. Click the '+' inserter button on the top bar.
5. Observe that help is displayed, but it's not applicable in this situation.

ef0ea34 fixes this by not rendering the help panel when no blocks are available for insert.

#### Block directory showing a loading spinner when no block available and no search term entered

To reproduce this:
1. Make sure the Block Directory feature is enabled
2. Insert a columns block
3. Select the column
4. Click the '+' inserter button on the top bar.
5. Observe that the forever loading spinner is displayed.

ae562e1 fixes this by not rendering the block directory unless there is a search term. There still seems to be a separate issue that the block directory doesn't respect template locking, and I've added this to the list on #17440.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
