### PR TITLE
Remove any existing subscriptions before adding a new save metaboxes sub to prevent multiple saves

### DIFF
--- a/packages/edit-post/src/store/effects.js
+++ b/packages/edit-post/src/store/effects.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { reduce, isFunction } from 'lodash';
+import { reduce } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -44,7 +44,7 @@ const effects = {
 		const hasActiveMetaBoxes = select( 'core/edit-post' ).hasMetaBoxes();
 
 		// First remove any existing subscription in order to prevent multiple saves
-		if ( isFunction( saveMetaboxUnsubscribe ) ) {
+		if ( !! saveMetaboxUnsubscribe ) {
 			saveMetaboxUnsubscribe();
 		}
 

--- a/packages/edit-post/src/store/effects.js
+++ b/packages/edit-post/src/store/effects.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { reduce } from 'lodash';
+import { reduce, isFunction } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -17,6 +17,8 @@ import apiFetch from '@wordpress/api-fetch';
 import { metaBoxUpdatesSuccess, requestMetaBoxUpdates } from './actions';
 import { getActiveMetaBoxLocations } from './selectors';
 import { getMetaBoxContainer } from '../utils/meta-boxes';
+
+let saveMetaboxUnsubscribe;
 
 const effects = {
 	SET_META_BOXES_PER_LOCATIONS( action, store ) {
@@ -40,8 +42,14 @@ const effects = {
 		//
 		// See: https://github.com/WordPress/WordPress/blob/5.1.1/wp-admin/includes/post.php#L2307-L2309
 		const hasActiveMetaBoxes = select( 'core/edit-post' ).hasMetaBoxes();
+
+		// First remove any existing subscription in order to prevent multiple saves
+		if ( isFunction( saveMetaboxUnsubscribe ) ) {
+			saveMetaboxUnsubscribe();
+		}
+
 		// Save metaboxes when performing a full save on the post.
-		subscribe( () => {
+		saveMetaboxUnsubscribe = subscribe( () => {
 			const isSavingPost = select( 'core/editor' ).isSavingPost();
 			const isAutosavingPost = select( 'core/editor' ).isAutosavingPost();
 


### PR DESCRIPTION
## Description
Currently multiple calls to setAvailableMetaBoxesPerLocation() action causes multiple AJAX requests to post.php to be made as each call initiates a new store subscription. This change removes any existing subscription before adding a new one to ensure only one sub is in play at a time.

## How has this been tested?
1. Create a new post
2. Open Options and enable the Custom Fields advanced panel
3. Type some content in the post
4. Open DevTools and run this code in the Console tab:
`wp.data.dispatch( 'core/edit-post' ).setAvailableMetaBoxesPerLocation( {"side":[],"normal":[{"id":"postcustom","title":"Custom Fields"}],"advanced":[]} );`
5. Press Publish
6. Open DevTools and look in the Network tab and make sure there is only one requests to post.php with each publish/update

## Types of changes
Fixes #14759

## Checklist:
- [ X ] Only manually tested - there are no existing unit tests for the effects, and it would require a considerable amount of mocking to add any useful tests
- [ X ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ NA ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [  X ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ NA ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
