### PR TITLE
Chore: Align the version of lodash with WordPress core

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -409,6 +409,8 @@ function gutenberg_register_vendor_scripts() {
 	// Vendor Scripts.
 	$react_suffix = ( SCRIPT_DEBUG ? '.development' : '.production' ) . $suffix;
 
+	// TODO: Overrides for react, react-dom and lodash are necessary
+	// until WordPress 5.3 is released.
 	gutenberg_register_vendor_script(
 		'react',
 		'https://unpkg.com/react@16.9.0/umd/react' . $react_suffix . '.js',
@@ -419,12 +421,9 @@ function gutenberg_register_vendor_scripts() {
 		'https://unpkg.com/react-dom@16.9.0/umd/react-dom' . $react_suffix . '.js',
 		array( 'react' )
 	);
-
-	// TODO: This is necessarily only so long as core ships with v4.17.11, and
-	// can be removed at such time a newer version is available.
 	gutenberg_register_vendor_script(
 		'lodash',
-		'https://unpkg.com/lodash@4.17.14/lodash' . $suffix . '.js'
+		'https://unpkg.com/lodash@4.17.15/lodash' . $suffix . '.js'
 	);
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4657,7 +4657,7 @@
 				"@wordpress/hooks": "file:packages/hooks",
 				"@wordpress/i18n": "file:packages/i18n",
 				"@wordpress/rich-text": "file:packages/rich-text",
-				"lodash": "^4.17.14",
+				"lodash": "^4.17.15",
 				"rememo": "^3.0.0",
 				"uuid": "^3.3.2"
 			}
@@ -4686,7 +4686,7 @@
 			"requires": {
 				"@babel/runtime": "^7.4.4",
 				"gettext-parser": "^1.3.1",
-				"lodash": "^4.17.14"
+				"lodash": "^4.17.15"
 			}
 		},
 		"@wordpress/babel-preset-default": {
@@ -4723,7 +4723,7 @@
 				"@wordpress/data": "file:packages/data",
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/i18n": "file:packages/i18n",
-				"lodash": "^4.17.14"
+				"lodash": "^4.17.15"
 			}
 		},
 		"@wordpress/block-editor": {
@@ -4753,7 +4753,7 @@
 				"diff": "^3.5.0",
 				"dom-scroll-into-view": "^1.2.1",
 				"inherits": "^2.0.3",
-				"lodash": "^4.17.10",
+				"lodash": "^4.17.15",
 				"memize": "^1.0.5",
 				"react-autosize-textarea": "^3.0.2",
 				"react-spring": "^8.0.19",
@@ -4791,7 +4791,7 @@
 				"@wordpress/viewport": "file:packages/viewport",
 				"classnames": "^2.2.5",
 				"fast-average-color": "4.3.0",
-				"lodash": "^4.17.14",
+				"lodash": "^4.17.15",
 				"memize": "^1.0.5",
 				"moment": "^2.22.1",
 				"tinycolor2": "^1.4.1",
@@ -4828,7 +4828,7 @@
 				"@wordpress/is-shallow-equal": "file:packages/is-shallow-equal",
 				"@wordpress/shortcode": "file:packages/shortcode",
 				"hpq": "^1.3.0",
-				"lodash": "^4.17.14",
+				"lodash": "^4.17.15",
 				"rememo": "^3.0.0",
 				"showdown": "^1.8.6",
 				"simple-html-tokenizer": "^0.5.7",
@@ -4857,7 +4857,7 @@
 				"classnames": "^2.2.5",
 				"clipboard": "^2.0.1",
 				"dom-scroll-into-view": "^1.2.1",
-				"lodash": "^4.17.14",
+				"lodash": "^4.17.15",
 				"memize": "^1.0.5",
 				"moment": "^2.22.1",
 				"mousetrap": "^1.6.2",
@@ -4875,7 +4875,7 @@
 				"@babel/runtime": "^7.4.4",
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/is-shallow-equal": "file:packages/is-shallow-equal",
-				"lodash": "^4.17.14"
+				"lodash": "^4.17.15"
 			}
 		},
 		"@wordpress/core-data": {
@@ -4889,7 +4889,7 @@
 				"@wordpress/is-shallow-equal": "file:packages/is-shallow-equal",
 				"@wordpress/url": "file:packages/url",
 				"equivalent-key-map": "^0.2.2",
-				"lodash": "^4.17.14",
+				"lodash": "^4.17.15",
 				"rememo": "^3.0.0"
 			}
 		},
@@ -4912,7 +4912,7 @@
 				"@wordpress/redux-routine": "file:packages/redux-routine",
 				"equivalent-key-map": "^0.2.2",
 				"is-promise": "^2.1.0",
-				"lodash": "^4.17.14",
+				"lodash": "^4.17.15",
 				"redux": "^4.0.0",
 				"turbo-combine-reducers": "^1.0.2"
 			}
@@ -4954,7 +4954,7 @@
 			"requires": {
 				"doctrine": "^2.1.0",
 				"espree": "^4.0.0",
-				"lodash": "^4.17.14",
+				"lodash": "^4.17.15",
 				"mdast-util-inject": "1.1.0",
 				"optionator": "0.8.2",
 				"remark": "10.0.1",
@@ -4966,7 +4966,7 @@
 			"version": "file:packages/dom",
 			"requires": {
 				"@babel/runtime": "^7.4.4",
-				"lodash": "^4.17.14"
+				"lodash": "^4.17.15"
 			}
 		},
 		"@wordpress/dom-ready": {
@@ -4982,7 +4982,7 @@
 				"@babel/runtime": "^7.4.4",
 				"@wordpress/keycodes": "file:packages/keycodes",
 				"@wordpress/url": "file:packages/url",
-				"lodash": "^4.17.14",
+				"lodash": "^4.17.15",
 				"node-fetch": "^1.7.3"
 			}
 		},
@@ -4995,7 +4995,7 @@
 				"@wordpress/jest-puppeteer-axe": "file:packages/jest-puppeteer-axe",
 				"@wordpress/scripts": "file:packages/scripts",
 				"expect-puppeteer": "^4.3.0",
-				"lodash": "^4.17.14",
+				"lodash": "^4.17.15",
 				"uuid": "^3.3.2"
 			}
 		},
@@ -5024,7 +5024,7 @@
 				"@wordpress/url": "file:packages/url",
 				"@wordpress/viewport": "file:packages/viewport",
 				"classnames": "^2.2.5",
-				"lodash": "^4.17.14",
+				"lodash": "^4.17.15",
 				"memize": "^1.0.5",
 				"refx": "^3.0.0",
 				"rememo": "^3.0.0"
@@ -5046,7 +5046,7 @@
 				"@wordpress/i18n": "file:packages/i18n",
 				"@wordpress/media-utils": "file:packages/media-utils",
 				"@wordpress/notices": "file:packages/notices",
-				"lodash": "^4.17.14",
+				"lodash": "^4.17.15",
 				"rememo": "^3.0.0"
 			}
 		},
@@ -5082,7 +5082,7 @@
 				"@wordpress/viewport": "file:packages/viewport",
 				"@wordpress/wordcount": "file:packages/wordcount",
 				"classnames": "^2.2.5",
-				"lodash": "^4.17.14",
+				"lodash": "^4.17.15",
 				"memize": "^1.0.5",
 				"react-autosize-textarea": "^3.0.2",
 				"redux-optimist": "^1.0.0",
@@ -5095,7 +5095,7 @@
 			"requires": {
 				"@babel/runtime": "^7.4.4",
 				"@wordpress/escape-html": "file:packages/escape-html",
-				"lodash": "^4.17.14",
+				"lodash": "^4.17.15",
 				"react": "^16.9.0",
 				"react-dom": "^16.9.0"
 			}
@@ -5133,7 +5133,7 @@
 				"@wordpress/keycodes": "file:packages/keycodes",
 				"@wordpress/rich-text": "file:packages/rich-text",
 				"@wordpress/url": "file:packages/url",
-				"lodash": "^4.17.14"
+				"lodash": "^4.17.15"
 			}
 		},
 		"@wordpress/hooks": {
@@ -5153,7 +5153,7 @@
 			"requires": {
 				"@babel/runtime": "^7.4.4",
 				"gettext-parser": "^1.3.1",
-				"lodash": "^4.17.14",
+				"lodash": "^4.17.15",
 				"memize": "^1.0.5",
 				"sprintf-js": "^1.1.1",
 				"tannin": "^1.1.0"
@@ -5171,7 +5171,7 @@
 			"requires": {
 				"@babel/runtime": "^7.4.4",
 				"jest-matcher-utils": "^24.7.0",
-				"lodash": "^4.17.14"
+				"lodash": "^4.17.15"
 			}
 		},
 		"@wordpress/jest-preset-default": {
@@ -5197,14 +5197,14 @@
 			"requires": {
 				"@babel/runtime": "^7.4.4",
 				"@wordpress/i18n": "file:packages/i18n",
-				"lodash": "^4.17.14"
+				"lodash": "^4.17.15"
 			}
 		},
 		"@wordpress/library-export-default-webpack-plugin": {
 			"version": "file:packages/library-export-default-webpack-plugin",
 			"dev": true,
 			"requires": {
-				"lodash": "^4.17.14",
+				"lodash": "^4.17.15",
 				"webpack-sources": "^1.1.0"
 			}
 		},
@@ -5217,7 +5217,7 @@
 				"@wordpress/compose": "file:packages/compose",
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/i18n": "file:packages/i18n",
-				"lodash": "^4.17.14"
+				"lodash": "^4.17.15"
 			}
 		},
 		"@wordpress/media-utils": {
@@ -5228,7 +5228,7 @@
 				"@wordpress/blob": "file:packages/blob",
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/i18n": "file:packages/i18n",
-				"lodash": "^4.17.14"
+				"lodash": "^4.17.15"
 			}
 		},
 		"@wordpress/notices": {
@@ -5237,7 +5237,7 @@
 				"@babel/runtime": "^7.4.4",
 				"@wordpress/a11y": "file:packages/a11y",
 				"@wordpress/data": "file:packages/data",
-				"lodash": "^4.17.14"
+				"lodash": "^4.17.15"
 			}
 		},
 		"@wordpress/npm-package-json-lint-config": {
@@ -5253,7 +5253,7 @@
 				"@wordpress/data": "file:packages/data",
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/i18n": "file:packages/i18n",
-				"lodash": "^4.17.14",
+				"lodash": "^4.17.15",
 				"rememo": "^3.0.0"
 			}
 		},
@@ -5264,7 +5264,7 @@
 				"@wordpress/compose": "file:packages/compose",
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/hooks": "file:packages/hooks",
-				"lodash": "^4.17.14"
+				"lodash": "^4.17.15"
 			}
 		},
 		"@wordpress/postcss-themes": {
@@ -5287,7 +5287,7 @@
 			"requires": {
 				"@babel/runtime": "^7.4.4",
 				"is-promise": "^2.1.0",
-				"lodash": "^4.17.14",
+				"lodash": "^4.17.15",
 				"rungen": "^0.3.2"
 			}
 		},
@@ -5304,7 +5304,7 @@
 				"@wordpress/is-shallow-equal": "file:packages/is-shallow-equal",
 				"@wordpress/keycodes": "file:packages/keycodes",
 				"classnames": "^2.2.5",
-				"lodash": "^4.17.14",
+				"lodash": "^4.17.15",
 				"memize": "^1.0.5",
 				"rememo": "^3.0.0"
 			}
@@ -5329,7 +5329,7 @@
 				"jest": "^24.7.1",
 				"jest-puppeteer": "^4.3.0",
 				"js-yaml": "3.13.1",
-				"lodash": "^4.17.14",
+				"lodash": "^4.17.15",
 				"minimist": "^1.2.0",
 				"npm-package-json-lint": "^3.6.0",
 				"puppeteer": "^1.19.0",
@@ -5449,14 +5449,14 @@
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/i18n": "file:packages/i18n",
 				"@wordpress/url": "file:packages/url",
-				"lodash": "^4.17.14"
+				"lodash": "^4.17.15"
 			}
 		},
 		"@wordpress/shortcode": {
 			"version": "file:packages/shortcode",
 			"requires": {
 				"@babel/runtime": "^7.4.4",
-				"lodash": "^4.17.14",
+				"lodash": "^4.17.15",
 				"memize": "^1.0.5"
 			}
 		},
@@ -5464,7 +5464,7 @@
 			"version": "file:packages/token-list",
 			"requires": {
 				"@babel/runtime": "^7.4.4",
-				"lodash": "^4.17.14"
+				"lodash": "^4.17.15"
 			}
 		},
 		"@wordpress/url": {
@@ -5480,14 +5480,14 @@
 				"@babel/runtime": "^7.4.4",
 				"@wordpress/compose": "file:packages/compose",
 				"@wordpress/data": "file:packages/data",
-				"lodash": "^4.17.14"
+				"lodash": "^4.17.15"
 			}
 		},
 		"@wordpress/wordcount": {
 			"version": "file:packages/wordcount",
 			"requires": {
 				"@babel/runtime": "^7.4.4",
-				"lodash": "^4.17.14"
+				"lodash": "^4.17.15"
 			}
 		},
 		"@zkochan/cmd-shim": {
@@ -11546,12 +11546,6 @@
 						"ms": "^2.1.1"
 					}
 				},
-				"lodash": {
-					"version": "4.17.15",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-					"dev": true
-				},
 				"ms": {
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -17352,9 +17346,9 @@
 			}
 		},
 		"lodash": {
-			"version": "4.17.14",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-			"integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw=="
+			"version": "4.17.15",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
 		},
 		"lodash._reinterpolate": {
 			"version": "3.0.0",
@@ -22080,14 +22074,6 @@
 				"lodash": "^4.17.11",
 				"log-symbols": "^2.2.0",
 				"postcss": "^7.0.7"
-			},
-			"dependencies": {
-				"lodash": {
-					"version": "4.17.15",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-					"dev": true
-				}
 			}
 		},
 		"postcss-resolve-nested-selector": {
@@ -25910,9 +25896,9 @@
 			},
 			"dependencies": {
 				"ajv": {
-					"version": "6.7.0",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.7.0.tgz",
-					"integrity": "sha512-RZXPviBTtfmtka9n9sy1N5M5b82CbxWIR6HIis4s3WQTXDJamc/0gpCWNGz6EWdWp4DOfjzJfhz/AS9zVPjjWg==",
+					"version": "6.10.2",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+					"integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
 					"dev": true,
 					"requires": {
 						"fast-deep-equal": "^2.0.1",
@@ -25931,12 +25917,6 @@
 					"version": "0.4.1",
 					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
 					"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-					"dev": true
-				},
-				"lodash": {
-					"version": "4.17.15",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
 					"dev": true
 				},
 				"slice-ansi": {

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
 		"jsdom": "11.12.0",
 		"lerna": "3.16.4",
 		"lint-staged": "9.2.5",
-		"lodash": "4.17.14",
+		"lodash": "4.17.15",
 		"make-dir": "3.0.0",
 		"metro-react-native-babel-preset": "0.55.0",
 		"metro-react-native-babel-transformer": "0.55.0",

--- a/packages/annotations/package.json
+++ b/packages/annotations/package.json
@@ -26,7 +26,7 @@
 		"@wordpress/hooks": "file:../hooks",
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/rich-text": "file:../rich-text",
-		"lodash": "^4.17.14",
+		"lodash": "^4.17.15",
 		"rememo": "^3.0.0",
 		"uuid": "^3.3.2"
 	},

--- a/packages/babel-plugin-makepot/package.json
+++ b/packages/babel-plugin-makepot/package.json
@@ -31,7 +31,7 @@
 	"dependencies": {
 		"@babel/runtime": "^7.4.4",
 		"gettext-parser": "^1.3.1",
-		"lodash": "^4.17.14"
+		"lodash": "^4.17.15"
 	},
 	"peerDependencies": {
 		"@babel/core": "^7.0.0"

--- a/packages/block-directory/package.json
+++ b/packages/block-directory/package.json
@@ -28,7 +28,7 @@
 		"@wordpress/data": "file:../data",
 		"@wordpress/element": "file:../element",
 		"@wordpress/i18n": "file:../i18n",
-		"lodash": "^4.17.14"
+		"lodash": "^4.17.15"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -46,7 +46,7 @@
 		"diff": "^3.5.0",
 		"dom-scroll-into-view": "^1.2.1",
 		"inherits": "^2.0.3",
-		"lodash": "^4.17.10",
+		"lodash": "^4.17.15",
 		"memize": "^1.0.5",
 		"react-autosize-textarea": "^3.0.2",
 		"react-spring": "^8.0.19",

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -45,7 +45,7 @@
 		"@wordpress/viewport": "file:../viewport",
 		"classnames": "^2.2.5",
 		"fast-average-color": "4.3.0",
-		"lodash": "^4.17.14",
+		"lodash": "^4.17.15",
 		"memize": "^1.0.5",
 		"moment": "^2.22.1",
 		"tinycolor2": "^1.4.1",

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -35,7 +35,7 @@
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
 		"@wordpress/shortcode": "file:../shortcode",
 		"hpq": "^1.3.0",
-		"lodash": "^4.17.14",
+		"lodash": "^4.17.15",
 		"rememo": "^3.0.0",
 		"showdown": "^1.8.6",
 		"simple-html-tokenizer": "^0.5.7",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -35,7 +35,7 @@
 		"classnames": "^2.2.5",
 		"clipboard": "^2.0.1",
 		"dom-scroll-into-view": "^1.2.1",
-		"lodash": "^4.17.14",
+		"lodash": "^4.17.15",
 		"memize": "^1.0.5",
 		"moment": "^2.22.1",
 		"mousetrap": "^1.6.2",

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -25,7 +25,7 @@
 		"@babel/runtime": "^7.4.4",
 		"@wordpress/element": "file:../element",
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
-		"lodash": "^4.17.14"
+		"lodash": "^4.17.15"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/core-data/package.json
+++ b/packages/core-data/package.json
@@ -30,7 +30,7 @@
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
 		"@wordpress/url": "file:../url",
 		"equivalent-key-map": "^0.2.2",
-		"lodash": "^4.17.14",
+		"lodash": "^4.17.15",
 		"rememo": "^3.0.0"
 	},
 	"publishConfig": {

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -31,7 +31,7 @@
 		"@wordpress/redux-routine": "file:../redux-routine",
 		"equivalent-key-map": "^0.2.2",
 		"is-promise": "^2.1.0",
-		"lodash": "^4.17.14",
+		"lodash": "^4.17.15",
 		"redux": "^4.0.0",
 		"turbo-combine-reducers": "^1.0.2"
 	},

--- a/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
+++ b/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
@@ -48,7 +48,7 @@ Array [
 ]
 `;
 
-exports[`Webpack \`no-default\` should produce expected output: Asset file should match snapshot 1`] = `"<?php return array('dependencies' => array(), 'version' => '4def21ff1ab3d47e29e1aacf8bd2a1f4');"`;
+exports[`Webpack \`no-default\` should produce expected output: Asset file should match snapshot 1`] = `"<?php return array('dependencies' => array(), 'version' => 'd94a1f5b1a8be61b8e648a178488bb87');"`;
 
 exports[`Webpack \`no-default\` should produce expected output: External modules should match snapshot 1`] = `Array []`;
 

--- a/packages/docgen/package.json
+++ b/packages/docgen/package.json
@@ -24,7 +24,7 @@
 	"dependencies": {
 		"doctrine": "^2.1.0",
 		"espree": "^4.0.0",
-		"lodash": "^4.17.14",
+		"lodash": "^4.17.15",
 		"mdast-util-inject": "1.1.0",
 		"optionator": "0.8.2",
 		"remark": "10.0.1",

--- a/packages/dom/package.json
+++ b/packages/dom/package.json
@@ -23,7 +23,7 @@
 	"react-native": "src/index",
 	"dependencies": {
 		"@babel/runtime": "^7.4.4",
-		"lodash": "^4.17.14"
+		"lodash": "^4.17.15"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/e2e-test-utils/package.json
+++ b/packages/e2e-test-utils/package.json
@@ -31,7 +31,7 @@
 		"@babel/runtime": "^7.4.4",
 		"@wordpress/keycodes": "file:../keycodes",
 		"@wordpress/url": "file:../url",
-		"lodash": "^4.17.14",
+		"lodash": "^4.17.15",
 		"node-fetch": "^1.7.3"
 	},
 	"peerDependencies": {

--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -27,7 +27,7 @@
 		"@wordpress/jest-puppeteer-axe": "file:../jest-puppeteer-axe",
 		"@wordpress/scripts": "file:../scripts",
 		"expect-puppeteer": "^4.3.0",
-		"lodash": "^4.17.14",
+		"lodash": "^4.17.15",
 		"uuid": "^3.3.2"
 	},
 	"peerDependencies": {

--- a/packages/edit-post/package.json
+++ b/packages/edit-post/package.json
@@ -43,7 +43,7 @@
 		"@wordpress/url": "file:../url",
 		"@wordpress/viewport": "file:../viewport",
 		"classnames": "^2.2.5",
-		"lodash": "^4.17.14",
+		"lodash": "^4.17.15",
 		"memize": "^1.0.5",
 		"refx": "^3.0.0",
 		"rememo": "^3.0.0"

--- a/packages/edit-widgets/package.json
+++ b/packages/edit-widgets/package.json
@@ -34,7 +34,7 @@
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/media-utils": "file:../media-utils",
 		"@wordpress/notices": "file:../notices",
-		"lodash": "^4.17.14",
+		"lodash": "^4.17.15",
 		"rememo": "^3.0.0"
 	},
 	"publishConfig": {

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -50,7 +50,7 @@
 		"@wordpress/viewport": "file:../viewport",
 		"@wordpress/wordcount": "file:../wordcount",
 		"classnames": "^2.2.5",
-		"lodash": "^4.17.14",
+		"lodash": "^4.17.15",
 		"memize": "^1.0.5",
 		"react-autosize-textarea": "^3.0.2",
 		"redux-optimist": "^1.0.0",

--- a/packages/element/package.json
+++ b/packages/element/package.json
@@ -24,7 +24,7 @@
 	"dependencies": {
 		"@babel/runtime": "^7.4.4",
 		"@wordpress/escape-html": "file:../escape-html",
-		"lodash": "^4.17.14",
+		"lodash": "^4.17.15",
 		"react": "^16.9.0",
 		"react-dom": "^16.9.0"
 	},

--- a/packages/format-library/package.json
+++ b/packages/format-library/package.json
@@ -31,7 +31,7 @@
 		"@wordpress/keycodes": "file:../keycodes",
 		"@wordpress/rich-text": "file:../rich-text",
 		"@wordpress/url": "file:../url",
-		"lodash": "^4.17.14"
+		"lodash": "^4.17.15"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -26,7 +26,7 @@
 	"dependencies": {
 		"@babel/runtime": "^7.4.4",
 		"gettext-parser": "^1.3.1",
-		"lodash": "^4.17.14",
+		"lodash": "^4.17.15",
 		"memize": "^1.0.5",
 		"sprintf-js": "^1.1.1",
 		"tannin": "^1.1.0"

--- a/packages/jest-console/package.json
+++ b/packages/jest-console/package.json
@@ -31,7 +31,7 @@
 	"dependencies": {
 		"@babel/runtime": "^7.4.4",
 		"jest-matcher-utils": "^24.7.0",
-		"lodash": "^4.17.14"
+		"lodash": "^4.17.15"
 	},
 	"peerDependencies": {
 		"jest": ">=24"

--- a/packages/keycodes/package.json
+++ b/packages/keycodes/package.json
@@ -23,7 +23,7 @@
 	"dependencies": {
 		"@babel/runtime": "^7.4.4",
 		"@wordpress/i18n": "file:../i18n",
-		"lodash": "^4.17.14"
+		"lodash": "^4.17.15"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/library-export-default-webpack-plugin/package.json
+++ b/packages/library-export-default-webpack-plugin/package.json
@@ -26,7 +26,7 @@
 	],
 	"main": "index.js",
 	"dependencies": {
-		"lodash": "^4.17.14",
+		"lodash": "^4.17.15",
 		"webpack-sources": "^1.1.0"
 	},
 	"peerDependencies": {

--- a/packages/list-reusable-blocks/package.json
+++ b/packages/list-reusable-blocks/package.json
@@ -26,7 +26,7 @@
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/element": "file:../element",
 		"@wordpress/i18n": "file:../i18n",
-		"lodash": "^4.17.14"
+		"lodash": "^4.17.15"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/media-utils/package.json
+++ b/packages/media-utils/package.json
@@ -27,7 +27,7 @@
 		"@wordpress/blob": "file:../blob",
 		"@wordpress/element": "file:../element",
 		"@wordpress/i18n": "file:../i18n",
-		"lodash": "^4.17.14"
+		"lodash": "^4.17.15"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/notices/package.json
+++ b/packages/notices/package.json
@@ -24,7 +24,7 @@
 		"@babel/runtime": "^7.4.4",
 		"@wordpress/a11y": "file:../a11y",
 		"@wordpress/data": "file:../data",
-		"lodash": "^4.17.14"
+		"lodash": "^4.17.15"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/nux/package.json
+++ b/packages/nux/package.json
@@ -27,7 +27,7 @@
 		"@wordpress/data": "file:../data",
 		"@wordpress/element": "file:../element",
 		"@wordpress/i18n": "file:../i18n",
-		"lodash": "^4.17.14",
+		"lodash": "^4.17.15",
 		"rememo": "^3.0.0"
 	},
 	"publishConfig": {

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -25,7 +25,7 @@
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/element": "file:../element",
 		"@wordpress/hooks": "file:../hooks",
-		"lodash": "^4.17.14"
+		"lodash": "^4.17.15"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/redux-routine/package.json
+++ b/packages/redux-routine/package.json
@@ -25,7 +25,7 @@
 	"dependencies": {
 		"@babel/runtime": "^7.4.4",
 		"is-promise": "^2.1.0",
-		"lodash": "^4.17.14",
+		"lodash": "^4.17.15",
 		"rungen": "^0.3.2"
 	},
 	"publishConfig": {

--- a/packages/rich-text/package.json
+++ b/packages/rich-text/package.json
@@ -31,7 +31,7 @@
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
 		"@wordpress/keycodes": "file:../keycodes",
 		"classnames": "^2.2.5",
-		"lodash": "^4.17.14",
+		"lodash": "^4.17.15",
 		"memize": "^1.0.5",
 		"rememo": "^3.0.0"
 	},

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -48,7 +48,7 @@
 		"jest": "^24.7.1",
 		"jest-puppeteer": "^4.3.0",
 		"js-yaml": "3.13.1",
-		"lodash": "^4.17.14",
+		"lodash": "^4.17.15",
 		"minimist": "^1.2.0",
 		"npm-package-json-lint": "^3.6.0",
 		"puppeteer": "^1.19.0",

--- a/packages/server-side-render/package.json
+++ b/packages/server-side-render/package.json
@@ -30,7 +30,7 @@
 		"@wordpress/element": "file:../element",
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/url": "file:../url",
-		"lodash": "^4.17.14"
+		"lodash": "^4.17.15"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/shortcode/package.json
+++ b/packages/shortcode/package.json
@@ -22,7 +22,7 @@
 	"react-native": "src/index",
 	"dependencies": {
 		"@babel/runtime": "^7.4.4",
-		"lodash": "^4.17.14",
+		"lodash": "^4.17.15",
 		"memize": "^1.0.5"
 	},
 	"publishConfig": {

--- a/packages/token-list/package.json
+++ b/packages/token-list/package.json
@@ -21,7 +21,7 @@
 	"react-native": "src/index",
 	"dependencies": {
 		"@babel/runtime": "^7.4.4",
-		"lodash": "^4.17.14"
+		"lodash": "^4.17.15"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/viewport/package.json
+++ b/packages/viewport/package.json
@@ -24,7 +24,7 @@
 		"@babel/runtime": "^7.4.4",
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/data": "file:../data",
-		"lodash": "^4.17.14"
+		"lodash": "^4.17.15"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/wordcount/package.json
+++ b/packages/wordcount/package.json
@@ -22,7 +22,7 @@
 	"react-native": "src/index",
 	"dependencies": {
 		"@babel/runtime": "^7.4.4",
-		"lodash": "^4.17.14"
+		"lodash": "^4.17.15"
 	},
 	"publishConfig": {
 		"access": "public"


### PR DESCRIPTION
## Description
WordPress core is going to use `lodash` v4.17.15 in the upcoming 5.3 release:
https://github.com/WordPress/wordpress-develop/blob/42b5133a2557c0fd58dae731d8694408133ea339/src/wp-includes/script-loader.php#L93-L103

This PR tries to align Gutenberg and core in that regard.