### PR TITLE
Add `has-background` classes to pullquote and Media & Text blocks

### DIFF
--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -141,6 +141,7 @@ class MediaTextEdit extends Component {
 		const classNames = classnames( className, {
 			'has-media-on-the-right': 'right' === mediaPosition,
 			'is-selected': isSelected,
+			'has-background': ( backgroundColor.class || backgroundColor.color ),
 			[ backgroundColor.class ]: backgroundColor.class,
 			'is-stacked-on-mobile': isStackedOnMobile,
 			[ `is-vertically-aligned-${ verticalAlignment }` ]: verticalAlignment,

--- a/packages/block-library/src/media-text/save.js
+++ b/packages/block-library/src/media-text/save.js
@@ -41,6 +41,7 @@ export default function save( { attributes } ) {
 	const backgroundClass = getColorClassName( 'background-color', backgroundColor );
 	const className = classnames( {
 		'has-media-on-the-right': 'right' === mediaPosition,
+		'has-background': ( backgroundClass || customBackgroundColor ),
 		[ backgroundClass ]: backgroundClass,
 		'is-stacked-on-mobile': isStackedOnMobile,
 		[ `is-vertically-aligned-${ verticalAlignment }` ]: verticalAlignment,

--- a/packages/block-library/src/pullquote/deprecated.js
+++ b/packages/block-library/src/pullquote/deprecated.js
@@ -1,7 +1,25 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+import { get, includes } from 'lodash';
+
+/**
  * WordPress dependencies
  */
-import { RichText } from '@wordpress/block-editor';
+import {
+	getColorClassName,
+	getColorObjectByAttributeValues,
+	RichText,
+} from '@wordpress/block-editor';
+import {
+	select,
+} from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { SOLID_COLOR_CLASS } from './shared';
 
 const blockAttributes = {
 	value: {
@@ -31,6 +49,51 @@ const blockAttributes = {
 };
 
 const deprecated = [
+	{
+		attributes: blockAttributes,
+		save( { attributes } ) {
+			const { mainColor, customMainColor, textColor, customTextColor, value, citation, className } = attributes;
+			const isSolidColorStyle = includes( className, SOLID_COLOR_CLASS );
+
+			let figureClass, figureStyles;
+			// Is solid color style
+			if ( isSolidColorStyle ) {
+				figureClass = getColorClassName( 'background-color', mainColor );
+				if ( ! figureClass ) {
+					figureStyles = {
+						backgroundColor: customMainColor,
+					};
+				}
+				// Is normal style and a custom color is being used ( we can set a style directly with its value)
+			} else if ( customMainColor ) {
+				figureStyles = {
+					borderColor: customMainColor,
+				};
+				// Is normal style and a named color is being used, we need to retrieve the color value to set the style,
+				// as there is no expectation that themes create classes that set border colors.
+			} else if ( mainColor ) {
+				const colors = get( select( 'core/block-editor' ).getSettings(), [ 'colors' ], [] );
+				const colorObject = getColorObjectByAttributeValues( colors, mainColor );
+				figureStyles = {
+					borderColor: colorObject.color,
+				};
+			}
+
+			const blockquoteTextColorClass = getColorClassName( 'color', textColor );
+			const blockquoteClasses = textColor || customTextColor ? classnames( 'has-text-color', {
+				[ blockquoteTextColorClass ]: blockquoteTextColorClass,
+			} ) : undefined;
+			const blockquoteStyle = blockquoteTextColorClass ? undefined : { color: customTextColor };
+			return (
+				<figure className={ figureClass } style={ figureStyles }>
+					<blockquote className={ blockquoteClasses } style={ blockquoteStyle } >
+						<RichText.Content value={ value } multiline />
+						{ ! RichText.isEmpty( citation ) && <RichText.Content tagName="cite" value={ citation } /> }
+					</blockquote>
+				</figure>
+			);
+		},
+	},
 	{
 		attributes: {
 			...blockAttributes,

--- a/packages/block-library/src/pullquote/edit.js
+++ b/packages/block-library/src/pullquote/edit.js
@@ -63,22 +63,28 @@ class PullQuoteEdit extends Component {
 		const { value, citation } = attributes;
 
 		const isSolidColorStyle = includes( className, SOLID_COLOR_CLASS );
-		const figureStyle = isSolidColorStyle ?
+		const figureStyles = isSolidColorStyle ?
 			{ backgroundColor: mainColor.color } :
 			{ borderColor: mainColor.color };
-		const blockquoteStyle = {
+
+		const figureClasses = classnames( className, {
+			'has-background': isSolidColorStyle && mainColor.color,
+			[ mainColor.class ]: isSolidColorStyle && mainColor.class,
+		} );
+
+		const blockquoteStyles = {
 			color: textColor.color,
 		};
-		const blockquoteClasses = textColor.color ? classnames( 'has-text-color', {
-			[ textColor.class ]: textColor.class,
-		} ) : undefined;
+
+		const blockquoteClasses = textColor.color && classnames(
+			'has-text-color',
+			{ [ textColor.class ]: textColor.class }
+		);
+
 		return (
 			<>
-				<figure style={ figureStyle } className={ classnames(
-					className, {
-						[ mainColor.class ]: isSolidColorStyle && mainColor.class,
-					} ) }>
-					<blockquote style={ blockquoteStyle } className={ blockquoteClasses }>
+				<figure style={ figureStyles } className={ figureClasses }>
+					<blockquote style={ blockquoteStyles } className={ blockquoteClasses }>
 						<RichText
 							multiline
 							value={ value }

--- a/packages/block-library/src/pullquote/save.js
+++ b/packages/block-library/src/pullquote/save.js
@@ -22,25 +22,39 @@ import {
 import { SOLID_COLOR_CLASS } from './shared';
 
 export default function save( { attributes } ) {
-	const { mainColor, customMainColor, textColor, customTextColor, value, citation, className } = attributes;
+	const {
+		mainColor,
+		customMainColor,
+		textColor,
+		customTextColor,
+		value,
+		citation,
+		className,
+	} = attributes;
+
 	const isSolidColorStyle = includes( className, SOLID_COLOR_CLASS );
 
-	let figureClass, figureStyles;
+	let figureClasses, figureStyles;
+
 	// Is solid color style
 	if ( isSolidColorStyle ) {
-		figureClass = getColorClassName( 'background-color', mainColor );
-		if ( ! figureClass ) {
-			figureStyles = {
-				backgroundColor: customMainColor,
-			};
-		}
-		// Is normal style and a custom color is being used ( we can set a style directly with its value)
+		const backgroundClass = getColorClassName( 'background-color', mainColor );
+
+		figureClasses = classnames( {
+			'has-background': ( backgroundClass || customMainColor ),
+			[ backgroundClass ]: backgroundClass,
+		} );
+
+		figureStyles = {
+			backgroundColor: backgroundClass ? undefined : customMainColor,
+		};
+	// Is normal style and a custom color is being used ( we can set a style directly with its value)
 	} else if ( customMainColor ) {
 		figureStyles = {
 			borderColor: customMainColor,
 		};
-		// Is normal style and a named color is being used, we need to retrieve the color value to set the style,
-		// as there is no expectation that themes create classes that set border colors.
+	// If normal style and a named color are being used, we need to retrieve the color value to set the style,
+	// as there is no expectation that themes create classes that set border colors.
 	} else if ( mainColor ) {
 		const colors = get( select( 'core/block-editor' ).getSettings(), [ 'colors' ], [] );
 		const colorObject = getColorObjectByAttributeValues( colors, mainColor );
@@ -50,13 +64,15 @@ export default function save( { attributes } ) {
 	}
 
 	const blockquoteTextColorClass = getColorClassName( 'color', textColor );
-	const blockquoteClasses = textColor || customTextColor ? classnames( 'has-text-color', {
+	const blockquoteClasses = ( textColor || customTextColor ) && classnames( 'has-text-color', {
 		[ blockquoteTextColorClass ]: blockquoteTextColorClass,
-	} ) : undefined;
-	const blockquoteStyle = blockquoteTextColorClass ? undefined : { color: customTextColor };
+	} );
+
+	const blockquoteStyles = blockquoteTextColorClass ? undefined : { color: customTextColor };
+
 	return (
-		<figure className={ figureClass } style={ figureStyles }>
-			<blockquote className={ blockquoteClasses } style={ blockquoteStyle } >
+		<figure className={ figureClasses } style={ figureStyles }>
+			<blockquote className={ blockquoteClasses } style={ blockquoteStyles } >
 				<RichText.Content value={ value } multiline />
 				{ ! RichText.isEmpty( citation ) && <RichText.Content tagName="cite" value={ citation } /> }
 			</blockquote>


### PR DESCRIPTION
Supersedes: https://github.com/WordPress/gutenberg/pull/11228

This PR continues the work started on https://github.com/WordPress/gutenberg/pull/11228. It adds the has-background class to media & text and pullquote blocks with the correct deprecation logic in place.
For the media-text, we are not adding new deprecation logic because a PR (https://github.com/WordPress/gutenberg/pull/14364) that adds a new deprecation was just merged and provided both PR's are released on the same version we can use the same deprecation.

Props to @chrisvanpatten for creating the original PR.


## Description
<!-- Please describe what you have changed or added -->

## How has this been tested?
I pasted the following post content in the code editor created using Gutenberg 6.5:
```
<!-- wp:media-text {"backgroundColor":"primary","mediaType":"image","isStackedOnMobile":false,"className":"alignwide"} -->
<div class="wp-block-media-text alignwide has-background has-primary-background-color"><figure class="wp-block-media-text__media"><img src="https://s.w.org/images/home/screen-themes.png?3" alt=""/></figure><div class="wp-block-media-text__content"><!-- wp:paragraph {"placeholder":"Content…","fontSize":"large"} -->
<p class="has-large-font-size">dfdfd</p>
<!-- /wp:paragraph --></div></div>
<!-- /wp:media-text -->

<!-- wp:pullquote {"customMainColor":"#d52b8b","textColor":"primary"} -->
<figure class="wp-block-pullquote" style="border-color:#d52b8b"><blockquote class="has-text-color has-primary-color"><p>fghgfhfg</p><cite>hghghg</cite></blockquote></figure>
<!-- /wp:pullquote -->

<!-- wp:pullquote {"customMainColor":"#d52b8b","customTextColor":"#bb1212","className":"has-background is-style-solid-color"} -->
<figure class="wp-block-pullquote has-background is-style-solid-color" style="background-color:#d52b8b"><blockquote class="has-text-color" style="color:#bb1212"><p>fghgfhfg</p><cite>hghghg</cite></blockquote></figure>
<!-- /wp:pullquote -->

<!-- wp:pullquote {"mainColor":"primary","customTextColor":"#bb1212","className":"has-background has-primary-background-color is-style-solid-color"} -->
<figure class="wp-block-pullquote has-background has-primary-background-color is-style-solid-color"><blockquote class="has-text-color" style="color:#bb1212"><p>fghgfhfg</p><cite>hghghg</cite></blockquote></figure>
<!-- /wp:pullquote -->
```

I verified there are no invalid block warnings.