### PR TITLE
Fix: Remove "Reusable block" name and descrip. from the inserter

### DIFF
--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -385,7 +385,9 @@ export class InserterMenu extends Component {
 					<div className="block-editor-inserter__menu-help-panel">
 						{ hoveredItem && (
 							<>
-								<BlockCard blockType={ hoveredItemBlockType } />
+								{ ! isReusableBlock( hoveredItem ) && (
+									<BlockCard blockType={ hoveredItemBlockType } />
+								) }
 								{ ( isReusableBlock( hoveredItem ) || hoveredItemBlockType.example ) && (
 									<div className="block-editor-inserter__preview">
 										<div className="block-editor-inserter__preview-content">


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/17527

## Description
This PR removes the reusable block name and description for the help panel. When a reusable block is hovered on the inserter only its preview is shown.

## How has this been tested?
I oppened the inserter.
I put the mouse above a reusable block item and verified only its preview appears on the side help panel.
