### PR TITLE
Core Data: Support server side save filters.

### DIFF
--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -367,7 +367,16 @@ export function* saveEntityRecord(
 		// we need to roll it back here.
 		if ( persistedEntity && currentEdits ) {
 			yield receiveEntityRecords( kind, name, persistedEntity, undefined, true );
-			yield editEntityRecord( kind, name, recordId, currentEdits, { undoIgnore: true } );
+			yield editEntityRecord(
+				kind,
+				name,
+				recordId,
+				{
+					...currentEdits,
+					...( yield select( 'getEntityRecordEdits', kind, name, recordId ) ),
+				},
+				{ undoIgnore: true }
+			);
 		}
 	}
 	yield {

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -253,6 +253,7 @@ export function* saveEntityRecord(
 	let updatedRecord;
 	let error;
 	let persistedEntity;
+	let currentEdits;
 	try {
 		const path = `${ entity.baseURL }${ recordId ? '/' + recordId : '' }`;
 		const persistedRecord = yield select(
@@ -344,6 +345,12 @@ export function* saveEntityRecord(
 				name,
 				recordId
 			);
+			currentEdits = yield select(
+				'getEntityRecordEdits',
+				kind,
+				name,
+				recordId
+			);
 			yield receiveEntityRecords( kind, name, { ...persistedEntity, ...data }, undefined, true );
 
 			updatedRecord = yield apiFetch( {
@@ -358,9 +365,9 @@ export function* saveEntityRecord(
 
 		// If we got to the point in the try block where we made an optimistic update,
 		// we need to roll it back here.
-		if ( persistedEntity ) {
+		if ( persistedEntity && currentEdits ) {
 			yield receiveEntityRecords( kind, name, persistedEntity, undefined, true );
-			yield editEntityRecord( kind, name, recordId, record, { undoIgnore: true } );
+			yield editEntityRecord( kind, name, recordId, currentEdits, { undoIgnore: true } );
 		}
 	}
 	yield {

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -252,6 +252,7 @@ export function* saveEntityRecord(
 	yield { type: 'SAVE_ENTITY_RECORD_START', kind, name, recordId, isAutosave };
 	let updatedRecord;
 	let error;
+	let persistedEntity;
 	try {
 		const path = `${ entity.baseURL }${ recordId ? '/' + recordId : '' }`;
 		const persistedRecord = yield select(
@@ -333,6 +334,18 @@ export function* saveEntityRecord(
 			) {
 				data = { ...data, status: 'draft' };
 			}
+
+			// We perform an optimistic update here to clear all the edits that
+			// will be persisted so that if the server filters them, the new
+			// filtered values are always accepted.
+			persistedEntity = yield select(
+				'getEntityRecord',
+				kind,
+				name,
+				recordId
+			);
+			yield receiveEntityRecords( kind, name, { ...persistedEntity, ...data }, undefined, true );
+
 			updatedRecord = yield apiFetch( {
 				path,
 				method: recordId ? 'PUT' : 'POST',
@@ -342,6 +355,13 @@ export function* saveEntityRecord(
 		}
 	} catch ( _error ) {
 		error = _error;
+
+		// If we got to the point in the try block where we made an optimistic update,
+		// we need to roll it back here.
+		if ( persistedEntity ) {
+			yield receiveEntityRecords( kind, name, persistedEntity, undefined, true );
+			yield editEntityRecord( kind, name, recordId, record, { undoIgnore: true } );
+		}
 	}
 	yield {
 		type: 'SAVE_ENTITY_RECORD_FINISH',

--- a/packages/core-data/src/selectors.js
+++ b/packages/core-data/src/selectors.js
@@ -207,7 +207,11 @@ export const getEntityRecordNonTransientEdits = createSelector(
  * @return {boolean} Whether the entity record has edits or not.
  */
 export function hasEditsForEntityRecord( state, kind, name, recordId ) {
-	return Object.keys( getEntityRecordNonTransientEdits( state, kind, name, recordId ) ).length > 0;
+	return (
+		isSavingEntityRecord( state, kind, name, recordId ) ||
+		Object.keys( getEntityRecordNonTransientEdits( state, kind, name, recordId ) )
+			.length > 0
+	);
 }
 
 /**

--- a/packages/core-data/src/test/actions.js
+++ b/packages/core-data/src/test/actions.js
@@ -15,6 +15,8 @@ describe( 'saveEntityRecord', () => {
 			'SAVE_ENTITY_RECORD_START'
 		);
 		expect( fulfillment.next().value.type ).toBe( 'SELECT' );
+		expect( fulfillment.next().value.type ).toBe( 'SELECT' );
+		expect( fulfillment.next().value.type ).toBe( 'RECEIVE_ITEMS' );
 		const { value: apiFetchAction } = fulfillment.next( {} );
 		expect( apiFetchAction.request ).toEqual( {
 			path: '/wp/v2/posts',
@@ -48,6 +50,8 @@ describe( 'saveEntityRecord', () => {
 			'SAVE_ENTITY_RECORD_START'
 		);
 		expect( fulfillment.next().value.type ).toBe( 'SELECT' );
+		expect( fulfillment.next().value.type ).toBe( 'SELECT' );
+		expect( fulfillment.next().value.type ).toBe( 'RECEIVE_ITEMS' );
 		const { value: apiFetchAction } = fulfillment.next( {} );
 		expect( apiFetchAction.request ).toEqual( {
 			path: '/wp/v2/posts/10',
@@ -71,6 +75,8 @@ describe( 'saveEntityRecord', () => {
 			'SAVE_ENTITY_RECORD_START'
 		);
 		expect( fulfillment.next().value.type ).toBe( 'SELECT' );
+		expect( fulfillment.next().value.type ).toBe( 'SELECT' );
+		expect( fulfillment.next().value.type ).toBe( 'RECEIVE_ITEMS' );
 		const { value: apiFetchAction } = fulfillment.next( {} );
 		expect( apiFetchAction.request ).toEqual( {
 			path: '/wp/v2/types/page',

--- a/packages/core-data/src/test/actions.js
+++ b/packages/core-data/src/test/actions.js
@@ -16,6 +16,7 @@ describe( 'saveEntityRecord', () => {
 		);
 		expect( fulfillment.next().value.type ).toBe( 'SELECT' );
 		expect( fulfillment.next().value.type ).toBe( 'SELECT' );
+		expect( fulfillment.next().value.type ).toBe( 'SELECT' );
 		expect( fulfillment.next().value.type ).toBe( 'RECEIVE_ITEMS' );
 		const { value: apiFetchAction } = fulfillment.next( {} );
 		expect( apiFetchAction.request ).toEqual( {
@@ -51,6 +52,7 @@ describe( 'saveEntityRecord', () => {
 		);
 		expect( fulfillment.next().value.type ).toBe( 'SELECT' );
 		expect( fulfillment.next().value.type ).toBe( 'SELECT' );
+		expect( fulfillment.next().value.type ).toBe( 'SELECT' );
 		expect( fulfillment.next().value.type ).toBe( 'RECEIVE_ITEMS' );
 		const { value: apiFetchAction } = fulfillment.next( {} );
 		expect( apiFetchAction.request ).toEqual( {
@@ -74,6 +76,7 @@ describe( 'saveEntityRecord', () => {
 		expect( fulfillment.next( entities ).value.type ).toBe(
 			'SAVE_ENTITY_RECORD_START'
 		);
+		expect( fulfillment.next().value.type ).toBe( 'SELECT' );
 		expect( fulfillment.next().value.type ).toBe( 'SELECT' );
 		expect( fulfillment.next().value.type ).toBe( 'SELECT' );
 		expect( fulfillment.next().value.type ).toBe( 'RECEIVE_ITEMS' );


### PR DESCRIPTION
## Description

`core-data` saving had an issue where edits (and dirtyness) would be kept after saving when the server had filters that modified the data. This happened because the client did not recognize the edits as persisted if the API responded with different values to what was sent.

This PR fixes this by considering that the API can change values while saving, and it changes `core-data` so it will not keep the corresponding edits unless they were made after the request was sent.

## How has this been tested?

This filter was added to test the behavior with a post title filter:

```php
function test_filter_post_data( $data, $postarr ) {
	if ( 'error' === $data['post_title'] ) {
		throw new Exception();
	}

	$data['post_title'] .= '_filtered!';
	return $data;
}
add_filter( 'wp_insert_post_data', 'test_filter_post_data', 10, 2 );
```

It was then verified that saving `error` keeps everything as is, but saving any other title clears dirty state and sets the current title to whatever you saved with ` '_filtered!'` concatenated at the end.

## Types of Changes

*New Feature:* `core-data` now plays nice with server side save filters.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->

closes #17491 
