### PR TITLE
Add missing header options on mobile

### DIFF
--- a/packages/block-library/src/heading/edit.native.js
+++ b/packages/block-library/src/heading/edit.native.js
@@ -28,7 +28,7 @@ const HeadingEdit = ( {
 		<BlockControls>
 			<HeadingToolbar
 				minLevel={ 2 }
-				maxLevel={ 5 }
+				maxLevel={ 7 }
 				selectedLevel={ attributes.level }
 				onChange={ ( newLevel ) => setAttributes( { level: newLevel } ) }
 			/>


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
This PR just adds the missing Header options/sizes to the RN mobile app.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

This can be tested using this PR on GB-mobile: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1377

## Screenshots <!-- if applicable -->

![Simulator Screen Shot - iPhone 11 - 2019-09-23 at 22 08 31](https://user-images.githubusercontent.com/651601/65463069-fcb44a00-de4e-11e9-9702-210be8a5df0e.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
