### PR TITLE
I18n: Change time difference string.

### DIFF
--- a/lib/class-wp-rest-block-directory-controller.php
+++ b/lib/class-wp-rest-block-directory-controller.php
@@ -300,7 +300,11 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 			$block->assets[] = 'https://plugins.svn.wordpress.org/' . $plugin['slug'] . $asset;
 		}
 
-		$block->humanized_updated = human_time_diff( strtotime( $plugin['last_updated'] ), current_time( 'timestamp' ) ) . __( ' ago', 'gutenberg' );
+		$block->humanized_updated = sprintf(
+			/* translators: %s: Human-readable time difference. */
+			__( '%s ago', 'gutenberg' ),
+			human_time_diff( strtotime( $plugin['last_updated'] ), current_time( 'timestamp' ) )
+		);
 
 		return $block;
 	}


### PR DESCRIPTION
## Description
To improve the internationalization,  the time difference `xxx` `ago` should be translatable as one string.

For german, we need to change the sequence and translate the string `%s ago` into `vor %s`.