### PR TITLE
Only show help panel when launched from top bar

### DIFF
--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -72,7 +72,7 @@ class Inserter extends Component {
 	 * @return {WPElement} Dropdown content element.
 	 */
 	renderContent( { onClose } ) {
-		const { rootClientId, clientId, isAppender } = this.props;
+		const { rootClientId, clientId, isAppender, showInserterHelpPanel } = this.props;
 
 		return (
 			<InserterMenu
@@ -80,6 +80,7 @@ class Inserter extends Component {
 				rootClientId={ rootClientId }
 				clientId={ clientId }
 				isAppender={ isAppender }
+				showInserterHelpPanel={ showInserterHelpPanel }
 			/>
 		);
 	}

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -440,7 +440,7 @@ export class InserterMenu extends Component {
 }
 
 export default compose(
-	withSelect( ( select, { clientId, isAppender, rootClientId } ) => {
+	withSelect( ( select, { clientId, isAppender, rootClientId, showInserterHelpPanel } ) => {
 		const {
 			getInserterItems,
 			getBlockName,
@@ -464,7 +464,7 @@ export default compose(
 		return {
 			rootChildBlocks: getChildBlockNames( destinationRootBlockName ),
 			items: getInserterItems( destinationRootClientId ),
-			showInserterHelpPanel: getSettings().showInserterHelpPanel,
+			showInserterHelpPanel: showInserterHelpPanel && getSettings().showInserterHelpPanel,
 			destinationRootClientId,
 		};
 	} ),

--- a/packages/edit-post/src/components/header/header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.js
@@ -31,7 +31,7 @@ function HeaderToolbar( { hasFixedToolbar, isLargeViewport, showInserter, isText
 			aria-label={ toolbarAriaLabel }
 		>
 			<div>
-				<Inserter disabled={ ! showInserter } position="bottom right" />
+				<Inserter disabled={ ! showInserter } position="bottom right" showInserterHelpPanel />
 				<DotTip tipId="core/editor.inserter">
 					{ __( 'Welcome to the wonderful world of blocks! Click the “+” (“Add block”) button to add a new block. There are blocks available for all kinds of content: you can insert text, headings, images, lists, and lots more!' ) }
 				</DotTip>


### PR DESCRIPTION
## Description
Only displays the inserter help panel for the inserter in the top bar.

Closes #17520
Fixes #17177

The change:
The InserterMenu already has a `showInserterHelpPanel` prop passed in from its `withSelect` higher order component. This HOC now requires that the `showInserterHelpPanel` prop is explicity declared as `true` on the component as well for the help to be displayed.

## How has this been tested?
1. Create a new post
2. Open the inserter menu from the top bar
3. Observe it has a help panel
4. Add a group or columns block to the post
5. Click on the + button appender in the group or columns block
6. Observe that the inserter menu has no help panel 
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->
![Screen Shot 2019-09-24 at 4 06 29 pm](https://user-images.githubusercontent.com/677833/65493469-77c83f80-dee5-11e9-87af-2e4d26cd94b4.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
