### PR TITLE
i18n: Remove text domain

### DIFF
--- a/packages/block-directory/src/components/block-ratings/stars.js
+++ b/packages/block-directory/src/components/block-ratings/stars.js
@@ -19,7 +19,7 @@ function Stars( {
 	const emptyStarCount = 5 - ( fullStarCount + halfStarCount );
 
 	return (
-		<div aria-label={ sprintf( __( '%s out of 5 stars', stars ), stars ) }>
+		<div aria-label={ sprintf( __( '%s out of 5 stars' ), stars ) }>
 			{ times( fullStarCount, ( i ) => <Icon key={ `full_stars_${ i }` } icon="star-filled" size={ 16 } /> ) }
 			{ times( halfStarCount, ( i ) => <Icon key={ `half_stars_${ i }` } icon="star-half" size={ 16 } /> ) }
 			{ times( emptyStarCount, ( i ) => <Icon key={ `empty_stars_${ i }` } icon="star-empty" size={ 16 } /> ) }


### PR DESCRIPTION
## Description
At the moment the string `%s out of 5 stars` is not translatable, because there is a second parameter in the translation function for the text domain which shouldn't be there.