### PR TITLE
[RNMobile] Improve autosave on mobile and ping the native at each keystroke

### DIFF
--- a/packages/editor/src/store/reducer.native.js
+++ b/packages/editor/src/store/reducer.native.js
@@ -28,7 +28,7 @@ import {
 
 import { EDITOR_SETTINGS_DEFAULTS } from './defaults.js';
 
-EDITOR_SETTINGS_DEFAULTS.autosaveInterval = 2; // This is a way to override default on mobile
+EDITOR_SETTINGS_DEFAULTS.autosaveInterval = 0; // This is a way to override default behavior on mobile, and make it ping the native save at each keystroke
 
 export * from './reducer.js';
 


### PR DESCRIPTION
This is a quick patch that improves the autosave for mobile, and introduces pings to the native side at each keystroke. The debouncing logic that handles the actual saving of the content on the local DB is already available in apps, and already used in the other editors included in the apps.

Note: This is just a way to override default behavior for mobile, and make it pings the native side at each keystroke. 

_We're still working on an old version of `master`, and the local autosave added [here](https://github.com/WordPress/gutenberg/pull/16490) is still not available. We should  probably revisit the autosave when we switch back to use `master`_.

