### PR TITLE
Add nested block / inner block to tutorial

### DIFF
--- a/docs/designers-developers/developers/tutorials/block-tutorial/nested-blocks-inner-blocks.md
+++ b/docs/designers-developers/developers/tutorials/block-tutorial/nested-blocks-inner-blocks.md
@@ -21,7 +21,7 @@ Here is the basic InnerBlocks usage.
 			return el(
 				'div',
 				{ className: props.className },
-				InnerBlocks
+				el( InnerBlocks )
 			);
 		},
 
@@ -29,7 +29,7 @@ Here is the basic InnerBlocks usage.
 			return el(
 				'div',
 				{ className: props.className },
-				InnerBlocks.Content
+				el( InnerBlocks.Content )
 			);
 		},
 	} );
@@ -44,7 +44,7 @@ Here is the basic InnerBlocks usage.
 import { registerBlockType } from '@wordpress/blocks';
 import { InnerBlocks } from '@wordpress/block-editor';
 
-registerBlockType( 'a8c/workshop-ex7', {
+registerBlockType( 'gutenberg-examples/example-06', {
 	// ...
 
 	edit: ( { className } ) => {

--- a/docs/designers-developers/developers/tutorials/block-tutorial/nested-blocks-inner-blocks.md
+++ b/docs/designers-developers/developers/tutorials/block-tutorial/nested-blocks-inner-blocks.md
@@ -13,8 +13,9 @@ Here is the basic InnerBlocks usage.
 	var el = element.createElement;
 	var InnerBlocks = blockEditor.InnerBlocks;
 
-	blocks.registerBlockType( 'a8c/workshop-ex7', {
-		// ...
+	blocks.registerBlockType( 'gutenberg-examples/example-06', {
+		title: 'Example: Inner Blocks',
+		category: 'layout',
 
 		edit: function( props ) {
 			return el(
@@ -26,12 +27,12 @@ Here is the basic InnerBlocks usage.
 
 		save: function( props ) {
 			return el(
-				'div'
+				'div',
 				{ className: props.className },
 				InnerBlocks.Content
 			);
 		},
-	}
+	} );
 } (
 	window.wp.blocks,
 	window.wp.element,

--- a/docs/designers-developers/developers/tutorials/block-tutorial/nested-blocks-inner-blocks.md
+++ b/docs/designers-developers/developers/tutorials/block-tutorial/nested-blocks-inner-blocks.md
@@ -1,0 +1,106 @@
+# Nested Blocks: Using InnerBlocks
+
+You can create a single block that nests other blocks using the [InnerBlocks](/packages/block-editor/src/components/inner-blocks) component. This is used in the Columns block, Social Links block, or any block you want to contain other blocks.
+
+Note: A single block can only contain one `InnerBlock` component.
+
+Here is the basic InnerBlocks usage.
+
+```js
+import { registerBlockType } from '@wordpress/blocks';
+import { InnerBlocks } from '@wordpress/block-editor';
+
+registerBlockType( 'a8c/workshop-ex4', {
+	// ...
+
+	edit: ( { className } ) => {
+		return (
+			<div className={ className }>
+				<InnerBlocks />
+			</div>
+		);
+	},
+
+	save: () => {
+		return (
+			<div>
+				<InnerBlocks.Content />
+			</div>
+		);
+	},
+} );
+```
+
+## Allowed Blocks
+
+Using the `ALLOWED_BLOCKS` property, you can define the set of blocks allowed in your InnerBlock. This restricts the that can be included only to those listed, all other blocks will not show in the inserter. 
+
+```js
+const ALLOWED_BLOCKS = [ 'core/image', 'core/paragraph' ];
+//...
+<InnerBlocks
+    allowedBlocks={ ALLOWED_BLOCKS }
+/>
+```
+
+
+## Template
+
+Use the template property to define a set of blocks that prefill the InnerBlocks component when inserted. You can set attributes on the blocks to define their use. The example below shows a book review template using InnerBlocks component and setting placeholders values to show the block usage.
+
+```js
+const MY_TEMPLATE = [
+	[ 'core/image', {} ],
+	[ 'core/heading', { placeholder: 'Book Title' } ],
+	[ 'core/paragraph', { placeholder: 'Summary' } ],
+];
+
+//...
+
+	edit: () => {
+
+		return (
+			<InnerBlocks
+				template={ MY_TEMPLATE }
+				templateLock="all"
+			/>
+		);
+	},
+```
+
+
+Use the `templateLock` property to lock down the template. Using `all` locks the template complete, no changes can be made. Using `insert` prevents additional blocks to be inserted, but existing blocks can be reorderd. See [templateLock documentation](/packages/block-editor/src/components/inner-blocks#templatelock) for additional information.
+
+### Post Template
+
+Unrelated to `InnerBlocks` but worth mentioning here, you can create a [post template](https://developer.wordpress.org/block-editor/developers/block-api/block-templates/) by post type, that preloads the block editor with a set of blocks. 
+
+The `InnerBlocks` template is for the component in the single block that you created, the rest of the post can include any blocks the user likes. Using a post template, can lock the entire post to just the template you define.
+
+
+```php
+add_action( 'init', function() {
+    $post_type_object = get_post_type_object( 'post' );
+    $post_type_object->template = array(
+		array( 'core/image' ),
+		array( 'core/heading' )
+    );
+} );
+```
+
+
+## Parent-Child InnerBlocks
+
+A common pattern for using InnerBlocks is to create a custom block that will be included only in the InnerBlocks. An example of this is the Columns block, that creates a single parent block called `columns` and then creates an child block called `column`. The parent block is defined to only allow the child blocks. See [Column code for reference](https://github.com/WordPress/gutenberg/tree/master/packages/block-library/src/column).
+
+When defining a child block, use the `parent` block setting to define which block is the parent. This prevents the block showing in the inserter outside of the InnerBlock it is defined for.
+
+```js
+export const settings = {
+	title: __( 'Column' ),
+	parent: [ 'core/columns' ],
+	icon,
+	description: __( 'A single column within a columns block.' ),
+	//...
+}
+```

--- a/docs/designers-developers/developers/tutorials/block-tutorial/nested-blocks-inner-blocks.md
+++ b/docs/designers-developers/developers/tutorials/block-tutorial/nested-blocks-inner-blocks.md
@@ -6,11 +6,44 @@ Note: A single block can only contain one `InnerBlock` component.
 
 Here is the basic InnerBlocks usage.
 
+{% codetabs %}
+{% ES5 %}
+```js
+( function( blocks, element, blockEditor ) {
+	var el = element.createElement;
+	var InnerBlocks = blockEditor.InnerBlocks;
+
+	blocks.registerBlockType( 'a8c/workshop-ex7', {
+		// ...
+
+		edit: function( props ) {
+			return el(
+				'div',
+				{ className: props.className },
+				InnerBlocks
+			);
+		},
+
+		save: function( props ) {
+			return el(
+				'div'
+				{ className: props.className },
+				InnerBlocks.Content
+			);
+		},
+	}
+} (
+	window.wp.blocks,
+	window.wp.element,
+	window.wp.blockEditor,
+) );
+```
+{% ESNext %}
 ```js
 import { registerBlockType } from '@wordpress/blocks';
 import { InnerBlocks } from '@wordpress/block-editor';
 
-registerBlockType( 'a8c/workshop-ex4', {
+registerBlockType( 'a8c/workshop-ex7', {
 	// ...
 
 	edit: ( { className } ) => {
@@ -21,15 +54,16 @@ registerBlockType( 'a8c/workshop-ex4', {
 		);
 	},
 
-	save: () => {
+	save: ( { className } ) => {
 		return (
-			<div>
+			<div className={ className }>
 				<InnerBlocks.Content />
 			</div>
 		);
 	},
 } );
 ```
+{% end %}
 
 ## Allowed Blocks
 
@@ -48,6 +82,29 @@ const ALLOWED_BLOCKS = [ 'core/image', 'core/paragraph' ];
 
 Use the template property to define a set of blocks that prefill the InnerBlocks component when inserted. You can set attributes on the blocks to define their use. The example below shows a book review template using InnerBlocks component and setting placeholders values to show the block usage.
 
+{% codetabs %}
+{% ES5 %}
+```js
+const MY_TEMPLATE = [
+	[ 'core/image', {} ],
+	[ 'core/heading', { placeholder: 'Book Title' } ],
+	[ 'core/paragraph', { placeholder: 'Summary' } ],
+];
+
+//...
+
+	edit: function( props ) {
+
+		return el(
+			InnerBlocks,
+			{
+				template: MY_TEMPLATE,
+				templateLock: "all",
+			}
+		);
+	},
+```
+{% ESNext %}
 ```js
 const MY_TEMPLATE = [
 	[ 'core/image', {} ],
@@ -67,7 +124,7 @@ const MY_TEMPLATE = [
 		);
 	},
 ```
-
+{% end %}
 
 Use the `templateLock` property to lock down the template. Using `all` locks the template complete, no changes can be made. Using `insert` prevents additional blocks to be inserted, but existing blocks can be reorderd. See [templateLock documentation](/packages/block-editor/src/components/inner-blocks#templatelock) for additional information.
 

--- a/docs/designers-developers/developers/tutorials/block-tutorial/nested-blocks-inner-blocks.md
+++ b/docs/designers-developers/developers/tutorials/block-tutorial/nested-blocks-inner-blocks.md
@@ -73,7 +73,7 @@ Using the `ALLOWED_BLOCKS` property, you can define the set of blocks allowed in
 const ALLOWED_BLOCKS = [ 'core/image', 'core/paragraph' ];
 //...
 <InnerBlocks
-    allowedBlocks={ ALLOWED_BLOCKS }
+	allowedBlocks={ ALLOWED_BLOCKS }
 />
 ```
 
@@ -137,11 +137,11 @@ The `InnerBlocks` template is for the component in the single block that you cre
 
 ```php
 add_action( 'init', function() {
-    $post_type_object = get_post_type_object( 'post' );
-    $post_type_object->template = array(
+	$post_type_object = get_post_type_object( 'post' );
+	$post_type_object->template = array(
 		array( 'core/image' ),
 		array( 'core/heading' )
-    );
+	);
 } );
 ```
 

--- a/docs/manifest-devhub.json
+++ b/docs/manifest-devhub.json
@@ -444,12 +444,6 @@
 		"parent": "block-tutorial"
 	},
 	{
-		"title": "Nested Blocks: Using InnerBlock",
-		"slug": "nested-blocks-inner-blocks",
-		"markdown_source": "../docs/designers-developers/developers/tutorials/block-tutorial/nested-blocks-inner-blocks.md",
-		"parent": "block-tutorial"
-	},
-	{
 		"title": "Creating dynamic blocks",
 		"slug": "creating-dynamic-blocks",
 		"markdown_source": "../docs/designers-developers/developers/tutorials/block-tutorial/creating-dynamic-blocks.md",
@@ -459,6 +453,12 @@
 		"title": "Generate Blocks with WP-CLI",
 		"slug": "generate-blocks-with-wp-cli",
 		"markdown_source": "../docs/designers-developers/developers/tutorials/block-tutorial/generate-blocks-with-wp-cli.md",
+		"parent": "block-tutorial"
+	},
+	{
+		"title": "Nested Blocks: Using InnerBlocks",
+		"slug": "nested-blocks-inner-blocks",
+		"markdown_source": "../docs/designers-developers/developers/tutorials/block-tutorial/nested-blocks-inner-blocks.md",
 		"parent": "block-tutorial"
 	},
 	{

--- a/docs/manifest-devhub.json
+++ b/docs/manifest-devhub.json
@@ -444,6 +444,12 @@
 		"parent": "block-tutorial"
 	},
 	{
+		"title": "Nested Blocks: Using InnerBlock",
+		"slug": "nested-blocks-inner-blocks",
+		"markdown_source": "../docs/designers-developers/developers/tutorials/block-tutorial/nested-blocks-inner-blocks.md",
+		"parent": "block-tutorial"
+	},
+	{
 		"title": "Creating dynamic blocks",
 		"slug": "creating-dynamic-blocks",
 		"markdown_source": "../docs/designers-developers/developers/tutorials/block-tutorial/creating-dynamic-blocks.md",

--- a/docs/toc.json
+++ b/docs/toc.json
@@ -86,7 +86,9 @@
 			{ "docs/designers-developers/developers/tutorials/block-tutorial/introducing-attributes-and-editable-fields.md": [] },
 			{ "docs/designers-developers/developers/tutorials/block-tutorial/block-controls-toolbar-and-sidebar.md": [] },
 			{ "docs/designers-developers/developers/tutorials/block-tutorial/creating-dynamic-blocks.md": [] },
-			{ "docs/designers-developers/developers/tutorials/block-tutorial/generate-blocks-with-wp-cli.md": [] }
+			{ "docs/designers-developers/developers/tutorials/block-tutorial/generate-blocks-with-wp-cli.md": [] },
+			{ "docs/designers-developers/developers/tutorials/block-tutorial/nested-blocks-inner-blocks.md": [] }
+			
 		] },
 		{ "docs/designers-developers/developers/tutorials/metabox/readme.md": [
 			{ "docs/designers-developers/developers/tutorials/metabox/meta-block-1-intro.md": [] },


### PR DESCRIPTION
## Description

Adds a new page to the block tutorial for Nested Blocks using InnerBlocks.


## How has this been tested?

Follow documentation and confirm it works. [View live on branch here](https://github.com/WordPress/gutenberg/blob/docs/add-nested-block/docs/designers-developers/developers/tutorials/block-tutorial/nested-blocks-inner-blocks.md).

## Types of changes

Documentation.
