### PR TITLE
Gallery Block: Don't show gradient overlay unless image is selected or a caption is set.

### DIFF
--- a/packages/block-library/src/gallery/gallery-image.js
+++ b/packages/block-library/src/gallery/gallery-image.js
@@ -160,15 +160,17 @@ class GalleryImage extends Component {
 						disabled={ ! isSelected }
 					/>
 				</div>
-				<RichText
-					tagName="figcaption"
-					placeholder={ isSelected ? __( 'Write caption…' ) : null }
-					value={ caption }
-					isSelected={ this.state.captionSelected }
-					onChange={ ( newCaption ) => setAttributes( { caption: newCaption } ) }
-					unstableOnFocus={ this.onSelectCaption }
-					inlineToolbar
-				/>
+				{ ( isSelected || caption ) && (
+					<RichText
+						tagName="figcaption"
+						placeholder={ isSelected ? __( 'Write caption…' ) : null }
+						value={ caption }
+						isSelected={ this.state.captionSelected }
+						onChange={ ( newCaption ) => setAttributes( { caption: newCaption } ) }
+						unstableOnFocus={ this.onSelectCaption }
+						inlineToolbar
+					/>
+				) }
 			</figure>
 		);
 	}


### PR DESCRIPTION
Fixes #17525

## Description

This PR fixes the Gallery Block so that the dark gradient overlay is only rendered on selected gallery images (in the editor), so that you can add new captions, or on gallery images that already have captions set.

## How has this been tested?

The description of this PR was verified to be correct.

## Screenshots

#### Editor

<img width="605" alt="Screen Shot 2019-09-24 at 2 41 32 PM" src="https://user-images.githubusercontent.com/19157096/65553063-d4722d00-deda-11e9-95c0-35c4c5f78f98.png">

#### Site

<img width="883" alt="Screen Shot 2019-09-24 at 2 41 50 PM" src="https://user-images.githubusercontent.com/19157096/65553067-d6d48700-deda-11e9-8585-33c593274572.png">

## Types of Changes

*Bug Fix:* Gallery Block images will no longer have a dark overlay if they don't have a caption.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
