### PR TITLE
[RNMobile] BottomSheet controls

### DIFF
--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -15,7 +15,7 @@ import { isEmpty } from 'lodash';
  * WordPress dependencies
  */
 import {
-	BottomSheet,
+	TextControl,
 	Icon,
 	Toolbar,
 	ToolbarButton,
@@ -221,25 +221,25 @@ class ImageEdit extends React.Component {
 		const getInspectorControls = () => (
 			<InspectorControls>
 				<PanelBody title={ __( 'Image Settings' ) } >
-					<BottomSheet.Cell
+					<TextControl
 						icon={ 'admin-links' }
 						label={ __( 'Link To' ) }
 						value={ href || '' }
 						valuePlaceholder={ __( 'Add URL' ) }
-						onChangeValue={ this.onSetLinkDestination }
+						onChange={ this.onSetLinkDestination }
 						autoCapitalize="none"
 						autoCorrect={ false }
 						keyboardType="url"
 					/>
-					<BottomSheet.Cell
+					<TextControl
 						icon={ 'editor-textcolor' }
 						label={ __( 'Alt Text' ) }
 						value={ alt || '' }
 						valuePlaceholder={ __( 'None' ) }
 						separatorType={ 'fullWidth' }
-						onChangeValue={ this.updateAlt }
+						onChange={ this.updateAlt }
 					/>
-					<BottomSheet.Cell
+					<TextControl
 						label={ __( 'Clear All Settings' ) }
 						labelStyle={ styles.clearSettingsButton }
 						separatorType={ 'none' }

--- a/packages/components/src/index.native.js
+++ b/packages/components/src/index.native.js
@@ -12,6 +12,9 @@ export { default as BaseControl } from './base-control';
 export { default as TextareaControl } from './textarea-control';
 export { default as PanelBody } from './panel/body';
 export { default as Button } from './button';
+export { default as TextControl } from './text-control';
+export { default as ToggleControl } from './toggle-control';
+export { default as SelectControl } from './select-control';
 
 // Higher-Order Components
 export { default as withConstrainedTabbing } from './higher-order/with-constrained-tabbing';

--- a/packages/components/src/select-control/index.native.js
+++ b/packages/components/src/select-control/index.native.js
@@ -1,9 +1,4 @@
 /**
- * WordPress dependencies
- */
-// import { withInstanceId } from '@wordpress/compose';
-
-/**
  * Internal dependencies
  */
 import PickerCell from '../mobile/bottom-sheet/picker-cell';

--- a/packages/components/src/select-control/index.native.js
+++ b/packages/components/src/select-control/index.native.js
@@ -1,0 +1,40 @@
+/**
+ * WordPress dependencies
+ */
+// import { withInstanceId } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import PickerCell from '../mobile/bottom-sheet/picker-cell';
+
+function SelectControl( {
+	help,
+	instanceId,
+	label,
+	multiple = false,
+	onChange,
+	options = [],
+	className,
+	hideLabelFromVision,
+	...props
+} ) {
+	const id = `inspector-select-control-${ instanceId }`;
+
+	return (
+		<PickerCell
+			label={ label }
+			hideLabelFromVision={ hideLabelFromVision }
+			id={ id }
+			help={ help }
+			className={ className }
+			onChangeValue={ onChange }
+			aria-describedby={ !! help ? `${ id }__help` : undefined }
+			multiple={ multiple }
+			options={ options }
+			{ ...props }
+		/>
+	);
+}
+
+export default SelectControl;

--- a/packages/components/src/text-control/index.native.js
+++ b/packages/components/src/text-control/index.native.js
@@ -1,9 +1,4 @@
 /**
- * WordPress dependencies
- */
-// import { withInstanceId } from '@wordpress/compose';
-
-/**
  * Internal dependencies
  */
 import Cell from '../mobile/bottom-sheet/cell';

--- a/packages/components/src/text-control/index.native.js
+++ b/packages/components/src/text-control/index.native.js
@@ -1,0 +1,40 @@
+/**
+ * WordPress dependencies
+ */
+// import { withInstanceId } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import Cell from '../mobile/bottom-sheet/cell';
+
+function TextControl( {
+	label,
+	hideLabelFromVision,
+	value,
+	help,
+	className,
+	instanceId,
+	onChange,
+	type = 'text',
+	...props
+} ) {
+	const id = `inspector-text-control-${ instanceId }`;
+
+	return (
+		<Cell
+			label={ label }
+			hideLabelFromVision={ hideLabelFromVision }
+			id={ id }
+			help={ help }
+			className={ className }
+			type={ type }
+			value={ value }
+			onChangeValue={ onChange }
+			aria-describedby={ !! help ? id + '__help' : undefined }
+			{ ...props }
+		/>
+	);
+}
+
+export default TextControl;

--- a/packages/components/src/toggle-control/index.native.js
+++ b/packages/components/src/toggle-control/index.native.js
@@ -1,9 +1,4 @@
 /**
- * WordPress dependencies
- */
-// import { withInstanceId } from '@wordpress/compose';
-
-/**
  * Internal dependencies
  */
 import SwitchCell from '../mobile/bottom-sheet/switch-cell';

--- a/packages/components/src/toggle-control/index.native.js
+++ b/packages/components/src/toggle-control/index.native.js
@@ -1,0 +1,36 @@
+/**
+ * WordPress dependencies
+ */
+// import { withInstanceId } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import SwitchCell from '../mobile/bottom-sheet/switch-cell';
+
+function ToggleControl( {
+	label,
+	checked,
+	help,
+	instanceId,
+	className,
+	onChange,
+	...props
+} ) {
+	const id = `inspector-toggle-control-${ instanceId }`;
+
+	return (
+		<SwitchCell
+			label={ label }
+			id={ id }
+			help={ help }
+			className={ className }
+			value={ checked }
+			onValueChange={ onChange }
+			aria-describedby={ !! help ? id + '__help' : undefined }
+			{ ...props }
+		/>
+	);
+}
+
+export default ToggleControl;


### PR DESCRIPTION
## Description
PR is connected with [#1365](https://github.com/wordpress-mobile/gutenberg-mobile/issues/1365) in gutenberg-mobile.

Please also refer to:

[Related gutenberg-mobile PR](https://github.com/wordpress-mobile/gutenberg-mobile/pull/1380)
merge this PR first [[RNMobile] add RangeControl mobile implementation](https://github.com/WordPress/gutenberg/pull/17282) and [[RNMobile] refactor InspectorControls](https://github.com/WordPress/gutenberg/pull/17279)

It presents ability to select all parents in cascade way (according to the way how selecting in groups works on web version)

## How has this been tested?
Manual test on Android and iOS plus CI tests

## Types of changes
Adds new layer on top of `BottomSheet.Cells` to use controls placed in `BottomSheet` in the same way as `Sidebar` controls in web version.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
