### PR TITLE
Fix invalid block warning

### DIFF
--- a/packages/block-editor/src/components/block-list/block-invalid-warning.js
+++ b/packages/block-editor/src/components/block-list/block-invalid-warning.js
@@ -44,46 +44,45 @@ export class BlockInvalidWarning extends Component {
 			{ title: __( 'Attempt Block Recovery' ), onClick: attemptBlockRecovery },
 		];
 
-		if ( compare ) {
-			return (
-				<Modal
-					title={
-						// translators: Dialog title to fix block content
-						__( 'Resolve Block' )
-					}
-					onRequestClose={ this.onCompareClose }
-					className="editor-block-compare block-editor-block-compare"
-				>
-					<BlockCompare
-						block={ block }
-						onKeep={ convertToHTML }
-						onConvert={ convertToBlocks }
-						convertor={ blockToBlocks }
-						convertButtonText={ __( 'Convert to Blocks' ) }
-					/>
-				</Modal>
-			);
-		}
-
 		return (
-			<Warning
-				actions={ [
-					<Button key="convert" onClick={ this.onCompare } isLarge isPrimary={ ! hasHTMLBlock }>
-						{
-							// translators: Button to fix block content
-							_x( 'Resolve', 'imperative verb' )
+			<>
+				<Warning
+					actions={ [
+						<Button key="convert" onClick={ this.onCompare } isLarge isPrimary={ ! hasHTMLBlock }>
+							{
+								// translators: Button to fix block content
+								_x( 'Resolve', 'imperative verb' )
+							}
+						</Button>,
+						hasHTMLBlock && (
+							<Button key="edit" onClick={ convertToHTML } isLarge isPrimary>
+								{ __( 'Convert to HTML' ) }
+							</Button>
+						),
+					] }
+					secondaryActions={ hiddenActions }
+				>
+					{ __( 'This block contains unexpected or invalid content.' ) }
+				</Warning>
+				{ compare && (
+					<Modal
+						title={
+							// translators: Dialog title to fix block content
+							__( 'Resolve Block' )
 						}
-					</Button>,
-					hasHTMLBlock && (
-						<Button key="edit" onClick={ convertToHTML } isLarge isPrimary>
-							{ __( 'Convert to HTML' ) }
-						</Button>
-					),
-				] }
-				secondaryActions={ hiddenActions }
-			>
-				{ __( 'This block contains unexpected or invalid content.' ) }
-			</Warning>
+						onRequestClose={ this.onCompareClose }
+						className="editor-block-compare block-editor-block-compare"
+					>
+						<BlockCompare
+							block={ block }
+							onKeep={ convertToHTML }
+							onConvert={ convertToBlocks }
+							convertor={ blockToBlocks }
+							convertButtonText={ __( 'Convert to Blocks' ) }
+						/>
+					</Modal>
+				) }
+			</>
 		);
 	}
 }

--- a/packages/block-editor/src/components/warning/style.scss
+++ b/packages/block-editor/src/components/warning/style.scss
@@ -27,6 +27,7 @@
 		line-height: $default-line-height;
 		font-family: $default-font;
 		font-size: $default-font-size;
+		margin: 1em 0;
 	}
 
 	.block-editor-warning__contents {
@@ -44,11 +45,16 @@
 
 	.block-editor-warning__action {
 		margin: 0 6px 0 0;
+
+		.components-button {
+			vertical-align: top;
+		}
 	}
 }
 
 .block-editor-warning__secondary {
 	margin: 3px 0 0 -4px;
+	height: $block-controls-height;
 
 	// the padding and margin of the more menu is intentionally non-standard
 	.components-icon-button {


### PR DESCRIPTION
## Description
The invalid block warning had all kinds of problems:

1. The message has too much padding around it
2. The more menu dropdown doesn't open in the right location
3. The buttons are poorly aligned because `components-button.is-default` has `vertical-align: top` while `components-button.is-primary` doesn't
4. When clicking the resolve button and closing the modal with keyboard, focus isn't returned to the right place because the button that launched the modal is unmounted.

This PR fixes those issues by:
1. Removing the additional padding around the message
2. Ensure the containing element around the more menu button is the correct height
3. Overriding vertical-align for the buttons
4. Ensuring the button that launches the modal remains rendered in the background.

## How has this been tested?
1. Add a paragraph block
2. Switch to the code editor and add a span before the paragraph
3. Revert back to the visual editor
4. Observe the invalid block warning
5. Click the resolve button
6. Press escape
7. Observe the location of focus.
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->
### Before
![Screen Shot 2019-09-25 at 5 09 52 pm](https://user-images.githubusercontent.com/677833/65587249-250b8800-dfb8-11e9-9b10-811e434c9dd5.png)

### After
![Screen Shot 2019-09-25 at 5 16 30 pm](https://user-images.githubusercontent.com/677833/65587322-42405680-dfb8-11e9-92bf-cbbd658f9474.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
