### PR TITLE
Block Directory: Convert it to UI Plugin to avoid bundling into Core

### DIFF
--- a/bin/get-vendor-scripts.php
+++ b/bin/get-vendor-scripts.php
@@ -32,4 +32,13 @@ define( 'GUTENBERG_LIST_VENDOR_ASSETS', true );
 
 require_once dirname( dirname( __FILE__ ) ) . '/lib/client-assets.php';
 
-gutenberg_register_vendor_scripts();
+/**
+ * Hi, phpcs
+ */
+function run_gutenberg_register_vendor_scripts() {
+	global $wp_scripts;
+
+	gutenberg_register_vendor_scripts( $wp_scripts );
+}
+
+run_gutenberg_register_vendor_scripts();

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -17,6 +17,20 @@ defined( 'GUTENBERG_DEVELOPMENT_MODE' ) or define( 'GUTENBERG_DEVELOPMENT_MODE',
 gutenberg_pre_init();
 
 /**
+ * Checks whether the Gutenberg experiment is enabled.
+ *
+ * @since 6.7.0
+ *
+ * @param string $name The name of the experiment.
+ *
+ * @return bool True when the experiment is enabled.
+ */
+function gutenberg_is_experiment_enabled( $name ) {
+	$experiments = get_option( 'gutenberg-experiments' );
+	return ! empty( $experiments[ $name ] );
+}
+
+/**
  * Gutenberg's Menu.
  *
  * Adds a new wp-admin menu page for the Gutenberg editor.

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -17,20 +17,6 @@ defined( 'GUTENBERG_DEVELOPMENT_MODE' ) or define( 'GUTENBERG_DEVELOPMENT_MODE',
 gutenberg_pre_init();
 
 /**
- * Checks whether the Gutenberg experiment is enabled.
- *
- * @since 6.7.0
- *
- * @param string $name The name of the experiment.
- *
- * @return bool True when the experiment is enabled.
- */
-function gutenberg_is_experiment_enabled( $name ) {
-	$experiments = get_option( 'gutenberg-experiments' );
-	return ! empty( $experiments[ $name ] );
-}
-
-/**
  * Gutenberg's Menu.
  *
  * Adds a new wp-admin menu page for the Gutenberg editor.

--- a/lib/block-directory.php
+++ b/lib/block-directory.php
@@ -1,0 +1,17 @@
+<?php
+
+if ( ! has_action( 'admin_enqueue_scripts', 'gutenberg_admin_enqueue_scripts_block_directory' ) ) {
+	/**
+	 * Function responsible for enqueuing the assets required
+	 * for the block directory functionality on the editor.
+	 */
+	function gutenberg_admin_enqueue_scripts_block_directory() {
+		if ( ! gutenberg_is_experiment_enabled( 'gutenberg-block-directory' ) ) {
+			return;
+		}
+
+		wp_enqueue_script( 'wp-block-directory' );
+		wp_enqueue_style( 'wp-block-directory' );
+	}
+	add_action( 'admin_enqueue_scripts', 'gutenberg_admin_enqueue_scripts_block_directory', 5 );
+}

--- a/lib/block-directory.php
+++ b/lib/block-directory.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * Block directory functions.
+ *
+ * @package gutenberg
+ */
 
 if ( ! has_action( 'admin_enqueue_scripts', 'gutenberg_aenqueue_block_editor_assets_block_directory' ) ) {
 	/**

--- a/lib/block-directory.php
+++ b/lib/block-directory.php
@@ -5,16 +5,15 @@
  * @package gutenberg
  */
 
-if ( ! has_action( 'admin_enqueue_scripts', 'enqueue_block_editor_assets_block_directory' ) ) {
+if (
+	gutenberg_is_experiment_enabled( 'gutenberg-block-directory' ) &&
+	! has_action( 'admin_enqueue_scripts', 'enqueue_block_editor_assets_block_directory' )
+) {
 	/**
 	 * Function responsible for enqueuing the assets required
 	 * for the block directory functionality in the editor.
 	 */
 	function gutenberg_enqueue_block_editor_assets_block_directory() {
-		if ( ! gutenberg_is_experiment_enabled( 'gutenberg-block-directory' ) ) {
-			return;
-		}
-
 		wp_enqueue_script( 'wp-block-directory' );
 		wp_enqueue_style( 'wp-block-directory' );
 	}

--- a/lib/block-directory.php
+++ b/lib/block-directory.php
@@ -1,11 +1,11 @@
 <?php
 
-if ( ! has_action( 'admin_enqueue_scripts', 'gutenberg_admin_enqueue_scripts_block_directory' ) ) {
+if ( ! has_action( 'admin_enqueue_scripts', 'gutenberg_aenqueue_block_editor_assets_block_directory' ) ) {
 	/**
 	 * Function responsible for enqueuing the assets required
-	 * for the block directory functionality on the editor.
+	 * for the block directory functionality in the editor.
 	 */
-	function gutenberg_admin_enqueue_scripts_block_directory() {
+	function gutenberg_enqueue_block_editor_assets_block_directory() {
 		if ( ! gutenberg_is_experiment_enabled( 'gutenberg-block-directory' ) ) {
 			return;
 		}
@@ -13,5 +13,5 @@ if ( ! has_action( 'admin_enqueue_scripts', 'gutenberg_admin_enqueue_scripts_blo
 		wp_enqueue_script( 'wp-block-directory' );
 		wp_enqueue_style( 'wp-block-directory' );
 	}
-	add_action( 'admin_enqueue_scripts', 'gutenberg_admin_enqueue_scripts_block_directory', 5 );
+	add_action( 'enqueue_block_editor_assets', 'gutenberg_enqueue_block_editor_assets_block_directory' );
 }

--- a/lib/block-directory.php
+++ b/lib/block-directory.php
@@ -5,7 +5,7 @@
  * @package gutenberg
  */
 
-if ( ! has_action( 'admin_enqueue_scripts', 'gutenberg_aenqueue_block_editor_assets_block_directory' ) ) {
+if ( ! has_action( 'admin_enqueue_scripts', 'enqueue_block_editor_assets_block_directory' ) ) {
 	/**
 	 * Function responsible for enqueuing the assets required
 	 * for the block directory functionality in the editor.

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -272,6 +272,8 @@ function gutenberg_register_scripts_and_styles() {
 		)
 	);
 
+	wp_enqueue_script( 'wp-block-directory' );
+
 	// Editor Styles.
 	// This empty stylesheet is defined to ensure backward compatibility.
 	gutenberg_override_style( 'wp-blocks', false );

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -409,7 +409,7 @@ function gutenberg_enqueue_block_editor_assets() {
 		sprintf(
 			'wp.apiFetch.nonceMiddleware = wp.apiFetch.createNonceMiddleware( "%s" );' .
 			'wp.apiFetch.use( wp.apiFetch.nonceMiddleware );' .
-			'wp.apiFetch.nonceEndpoint = "%s";',
+			'wp.apiFetch.nonceEndpoint = "%s";' .
 			'wp.apiFetch.use( wp.apiFetch.mediaUploadMiddleware );',
 			( wp_installing() && ! is_multisite() ) ? '' : wp_create_nonce( 'wp_rest' ),
 			admin_url( 'admin-ajax.php?action=gutenberg_rest_nonce' )

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -272,8 +272,6 @@ function gutenberg_register_scripts_and_styles() {
 		)
 	);
 
-	wp_enqueue_script( 'wp-block-directory' );
-
 	// Editor Styles.
 	// This empty stylesheet is defined to ensure backward compatibility.
 	gutenberg_override_style( 'wp-blocks', false );
@@ -289,7 +287,7 @@ function gutenberg_register_scripts_and_styles() {
 	gutenberg_override_style(
 		'wp-editor',
 		gutenberg_url( 'build/editor/style.css' ),
-		array( 'wp-components', 'wp-block-editor', 'wp-nux', 'wp-block-directory' ),
+		array( 'wp-components', 'wp-block-editor', 'wp-nux' ),
 		filemtime( gutenberg_dir_path() . 'build/editor/style.css' )
 	);
 	wp_style_add_data( 'wp-editor', 'rtl', 'replace' );

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -42,6 +42,7 @@ function gutenberg_url( $path ) {
  *
  * @since 4.1.0
  *
+ * @param WP_Scripts       $scripts   WP_Scripts instance (passed by reference).
  * @param string           $handle    Name of the script. Should be unique.
  * @param string           $src       Full URL of the script, or path of the script relative to the WordPress root directory.
  * @param array            $deps      Optional. An array of registered script handles this script depends on. Default empty array.
@@ -52,10 +53,8 @@ function gutenberg_url( $path ) {
  * @param bool             $in_footer Optional. Whether to enqueue the script before </body> instead of in the <head>.
  *                                    Default 'false'.
  */
-function gutenberg_override_script( $handle, $src, $deps = array(), $ver = false, $in_footer = false ) {
-	global $wp_scripts;
-
-	$script = $wp_scripts->query( $handle, 'registered' );
+function gutenberg_override_script( &$scripts, $handle, $src, $deps = array(), $ver = false, $in_footer = false ) {
+	$script = $scripts->query( $handle, 'registered' );
 	if ( $script ) {
 		/*
 		 * In many ways, this is a reimplementation of `wp_register_script` but
@@ -81,7 +80,7 @@ function gutenberg_override_script( $handle, $src, $deps = array(), $ver = false
 			$script->add_data( 'group', 1 );
 		}
 	} else {
-		wp_register_script( $handle, $src, $deps, $ver, $in_footer );
+		$scripts->add( $handle, $src, $deps, $ver, $in_footer );
 	}
 
 	/*
@@ -93,7 +92,7 @@ function gutenberg_override_script( $handle, $src, $deps = array(), $ver = false
 	 * See: https://core.trac.wordpress.org/ticket/46089
 	 */
 	if ( 'wp-i18n' !== $handle && 'wp-polyfill' !== $handle ) {
-		wp_set_script_translations( $handle, 'default' );
+		$scripts->set_translations( $handle, 'default' );
 	}
 }
 
@@ -166,18 +165,62 @@ add_filter( 'load_script_translation_file', 'gutenberg_override_translation_file
  *                                 Default 'all'. Accepts media types like 'all', 'print' and 'screen', or media queries like
  *                                 '(orientation: portrait)' and '(max-width: 640px)'.
  */
-function gutenberg_override_style( $handle, $src, $deps = array(), $ver = false, $media = 'all' ) {
-	wp_deregister_style( $handle );
-	wp_register_style( $handle, $src, $deps, $ver, $media );
+function gutenberg_override_style( &$styles, $handle, $src, $deps = array(), $ver = false, $media = 'all' ) {
+	$style = $styles->query( $handle, 'registered' );
+	if ( $style ) {
+		$styles->remove( $handle );
+	}
+	$styles->add( $handle, $src, $deps, $ver, $media );
 }
+
+/**
+ * Registers vendor JavaScript files to be used as dependencies of the editor
+ * and plugins.
+ *
+ * This function is called from a script during the plugin build process, so it
+ * should not call any WordPress PHP functions.
+ *
+ * @since 0.1.0
+ *
+ * @param WP_Scripts $scripts WP_Scripts instance (passed by reference).
+ */
+function gutenberg_register_vendor_scripts( &$scripts ) {
+	$suffix = SCRIPT_DEBUG ? '' : '.min';
+
+	// Vendor Scripts.
+	$react_suffix = ( SCRIPT_DEBUG ? '.development' : '.production' ) . $suffix;
+
+	// TODO: Overrides for react, react-dom and lodash are necessary
+	// until WordPress 5.3 is released.
+	gutenberg_register_vendor_script(
+		$scripts,
+		'react',
+		'https://unpkg.com/react@16.9.0/umd/react' . $react_suffix . '.js',
+		array( 'wp-polyfill' )
+	);
+	gutenberg_register_vendor_script(
+		$scripts,
+		'react-dom',
+		'https://unpkg.com/react-dom@16.9.0/umd/react-dom' . $react_suffix . '.js',
+		array( 'react' )
+	);
+	gutenberg_register_vendor_script(
+		$scripts,
+		'lodash',
+		'https://unpkg.com/lodash@4.17.15/lodash' . $suffix . '.js'
+	);
+}
+add_action( 'wp_default_scripts', 'gutenberg_register_vendor_scripts' );
 
 /**
  * Registers all the WordPress packages scripts that are in the standardized
  * `build/` location.
  *
  * @since 4.5.0
+ *
+ * @param WP_Scripts $scripts WP_Scripts instance (passed by reference).
  */
-function gutenberg_register_packages_scripts() {
+function gutenberg_register_packages_scripts( &$scripts ) {
 	foreach ( glob( gutenberg_dir_path() . 'build/*/index.js' ) as $path ) {
 		// Prefix `wp-` to package directory to get script handle.
 		// For example, `…/build/a11y/index.js` becomes `wp-a11y`.
@@ -206,6 +249,7 @@ function gutenberg_register_packages_scripts() {
 		$gutenberg_path = substr( $path, strlen( gutenberg_dir_path() ) );
 
 		gutenberg_override_script(
+			$scripts,
 			$handle,
 			gutenberg_url( $gutenberg_path ),
 			$dependencies,
@@ -214,6 +258,133 @@ function gutenberg_register_packages_scripts() {
 		);
 	}
 }
+add_action( 'wp_default_scripts', 'gutenberg_register_packages_scripts' );
+
+/**
+ * Registers all the WordPress packages styles that are in the standardized
+ * `build/` location.
+ *
+ * @since 6.7.0
+
+ * @param WP_Styles $styles WP_Styles instance (passed by reference).
+ */
+function gutenberg_register_packages_styles( &$styles ) {
+	// Editor Styles.
+	gutenberg_override_style(
+		$styles,
+		'wp-block-editor',
+		gutenberg_url( 'build/block-editor/style.css' ),
+		array( 'wp-components', 'wp-editor-font' ),
+		filemtime( gutenberg_dir_path() . 'build/editor/style.css' )
+	);
+	$styles->add_data( 'wp-block-editor', 'rtl', 'replace' );
+
+	gutenberg_override_style(
+		$styles,
+		'wp-editor',
+		gutenberg_url( 'build/editor/style.css' ),
+		array( 'wp-components', 'wp-block-editor', 'wp-nux' ),
+		filemtime( gutenberg_dir_path() . 'build/editor/style.css' )
+	);
+	$styles->add_data( 'wp-editor', 'rtl', 'replace' );
+
+	gutenberg_override_style(
+		$styles,
+		'wp-edit-post',
+		gutenberg_url( 'build/edit-post/style.css' ),
+		array( 'wp-components', 'wp-block-editor', 'wp-editor', 'wp-edit-blocks', 'wp-block-library', 'wp-nux' ),
+		filemtime( gutenberg_dir_path() . 'build/edit-post/style.css' )
+	);
+	$styles->add_data( 'wp-edit-post', 'rtl', 'replace' );
+
+	gutenberg_override_style(
+		$styles,
+		'wp-components',
+		gutenberg_url( 'build/components/style.css' ),
+		array(),
+		filemtime( gutenberg_dir_path() . 'build/components/style.css' )
+	);
+	$styles->add_data( 'wp-components', 'rtl', 'replace' );
+
+	gutenberg_override_style(
+		$styles,
+		'wp-block-library',
+		gutenberg_url( 'build/block-library/style.css' ),
+		array(),
+		filemtime( gutenberg_dir_path() . 'build/block-library/style.css' )
+	);
+	$styles->add_data( 'wp-block-library', 'rtl', 'replace' );
+
+	gutenberg_override_style(
+		$styles,
+		'wp-format-library',
+		gutenberg_url( 'build/format-library/style.css' ),
+		array( 'wp-block-editor', 'wp-components' ),
+		filemtime( gutenberg_dir_path() . 'build/format-library/style.css' )
+	);
+	$styles->add_data( 'wp-format-library', 'rtl', 'replace' );
+
+	gutenberg_override_style(
+		$styles,
+		'wp-edit-blocks',
+		gutenberg_url( 'build/block-library/editor.css' ),
+		array(
+			'wp-components',
+			'wp-editor',
+			'wp-block-library',
+			// Always include visual styles so the editor never appears broken.
+			'wp-block-library-theme',
+		),
+		filemtime( gutenberg_dir_path() . 'build/block-library/editor.css' )
+	);
+	$styles->add_data( 'wp-edit-blocks', 'rtl', 'replace' );
+
+	gutenberg_override_style(
+		$styles,
+		'wp-nux',
+		gutenberg_url( 'build/nux/style.css' ),
+		array( 'wp-components' ),
+		filemtime( gutenberg_dir_path() . 'build/nux/style.css' )
+	);
+	$styles->add_data( 'wp-nux', 'rtl', 'replace' );
+
+	gutenberg_override_style(
+		$styles,
+		'wp-block-library-theme',
+		gutenberg_url( 'build/block-library/theme.css' ),
+		array(),
+		filemtime( gutenberg_dir_path() . 'build/block-library/theme.css' )
+	);
+	$styles->add_data( 'wp-block-library-theme', 'rtl', 'replace' );
+
+	gutenberg_override_style(
+		$styles,
+		'wp-list-reusable-blocks',
+		gutenberg_url( 'build/list-reusable-blocks/style.css' ),
+		array( 'wp-components' ),
+		filemtime( gutenberg_dir_path() . 'build/list-reusable-blocks/style.css' )
+	);
+	$styles->add_data( 'wp-list-reusable-block', 'rtl', 'replace' );
+
+	gutenberg_override_style(
+		$styles,
+		'wp-edit-widgets',
+		gutenberg_url( 'build/edit-widgets/style.css' ),
+		array( 'wp-components', 'wp-block-editor', 'wp-edit-blocks' ),
+		filemtime( gutenberg_dir_path() . 'build/edit-widgets/style.css' )
+	);
+	$styles->add_data( 'wp-edit-widgets', 'rtl', 'replace' );
+
+	gutenberg_override_style(
+		$styles,
+		'wp-block-directory',
+		gutenberg_url( 'build/block-directory/style.css' ),
+		array( 'wp-block-editor', 'wp-components' ),
+		filemtime( gutenberg_dir_path() . 'build/block-directory/style.css' )
+	);
+	$styles->add_data( 'wp-block-directory', 'rtl', 'replace' );
+}
+add_action( 'wp_default_styles', 'gutenberg_register_packages_styles' );
 
 /**
  * Registers common scripts and styles to be used as dependencies of the editor
@@ -223,9 +394,7 @@ function gutenberg_register_packages_scripts() {
  */
 function gutenberg_register_scripts_and_styles() {
 	global $wp_scripts;
-
-	gutenberg_register_vendor_scripts();
-	gutenberg_register_packages_scripts();
+	global $wp_styles;
 
 	// Add nonce middleware which accounts for the absence of the heartbeat
 	// listener. This relies on API Fetch implementation running middlewares in
@@ -244,7 +413,7 @@ function gutenberg_register_scripts_and_styles() {
 		sprintf(
 			'wp.apiFetch.nonceMiddleware = wp.apiFetch.createNonceMiddleware( "%s" );' .
 			'wp.apiFetch.use( wp.apiFetch.nonceMiddleware );' .
-			'wp.apiFetch.nonceEndpoint = "%s";' .
+			'wp.apiFetch.nonceEndpoint = "%s";',
 			'wp.apiFetch.use( wp.apiFetch.mediaUploadMiddleware );',
 			( wp_installing() && ! is_multisite() ) ? '' : wp_create_nonce( 'wp_rest' ),
 			admin_url( 'admin-ajax.php?action=gutenberg_rest_nonce' )
@@ -272,111 +441,8 @@ function gutenberg_register_scripts_and_styles() {
 		)
 	);
 
-	// Editor Styles.
 	// This empty stylesheet is defined to ensure backward compatibility.
-	gutenberg_override_style( 'wp-blocks', false );
-
-	gutenberg_override_style(
-		'wp-block-editor',
-		gutenberg_url( 'build/block-editor/style.css' ),
-		array( 'wp-components', 'wp-editor-font' ),
-		filemtime( gutenberg_dir_path() . 'build/editor/style.css' )
-	);
-	wp_style_add_data( 'wp-block-editor', 'rtl', 'replace' );
-
-	gutenberg_override_style(
-		'wp-editor',
-		gutenberg_url( 'build/editor/style.css' ),
-		array( 'wp-components', 'wp-block-editor', 'wp-nux' ),
-		filemtime( gutenberg_dir_path() . 'build/editor/style.css' )
-	);
-	wp_style_add_data( 'wp-editor', 'rtl', 'replace' );
-
-	gutenberg_override_style(
-		'wp-edit-post',
-		gutenberg_url( 'build/edit-post/style.css' ),
-		array( 'wp-components', 'wp-block-editor', 'wp-editor', 'wp-edit-blocks', 'wp-block-library', 'wp-nux' ),
-		filemtime( gutenberg_dir_path() . 'build/edit-post/style.css' )
-	);
-	wp_style_add_data( 'wp-edit-post', 'rtl', 'replace' );
-
-	gutenberg_override_style(
-		'wp-components',
-		gutenberg_url( 'build/components/style.css' ),
-		array(),
-		filemtime( gutenberg_dir_path() . 'build/components/style.css' )
-	);
-	wp_style_add_data( 'wp-components', 'rtl', 'replace' );
-
-	gutenberg_override_style(
-		'wp-block-library',
-		gutenberg_url( 'build/block-library/style.css' ),
-		array(),
-		filemtime( gutenberg_dir_path() . 'build/block-library/style.css' )
-	);
-	wp_style_add_data( 'wp-block-library', 'rtl', 'replace' );
-
-	gutenberg_override_style(
-		'wp-format-library',
-		gutenberg_url( 'build/format-library/style.css' ),
-		array( 'wp-block-editor', 'wp-components' ),
-		filemtime( gutenberg_dir_path() . 'build/format-library/style.css' )
-	);
-	wp_style_add_data( 'wp-format-library', 'rtl', 'replace' );
-
-	gutenberg_override_style(
-		'wp-edit-blocks',
-		gutenberg_url( 'build/block-library/editor.css' ),
-		array(
-			'wp-components',
-			'wp-editor',
-			'wp-block-library',
-			// Always include visual styles so the editor never appears broken.
-			'wp-block-library-theme',
-		),
-		filemtime( gutenberg_dir_path() . 'build/block-library/editor.css' )
-	);
-	wp_style_add_data( 'wp-edit-blocks', 'rtl', 'replace' );
-
-	gutenberg_override_style(
-		'wp-nux',
-		gutenberg_url( 'build/nux/style.css' ),
-		array( 'wp-components' ),
-		filemtime( gutenberg_dir_path() . 'build/nux/style.css' )
-	);
-	wp_style_add_data( 'wp-nux', 'rtl', 'replace' );
-
-	gutenberg_override_style(
-		'wp-block-library-theme',
-		gutenberg_url( 'build/block-library/theme.css' ),
-		array(),
-		filemtime( gutenberg_dir_path() . 'build/block-library/theme.css' )
-	);
-	wp_style_add_data( 'wp-block-library-theme', 'rtl', 'replace' );
-
-	gutenberg_override_style(
-		'wp-list-reusable-blocks',
-		gutenberg_url( 'build/list-reusable-blocks/style.css' ),
-		array( 'wp-components' ),
-		filemtime( gutenberg_dir_path() . 'build/list-reusable-blocks/style.css' )
-	);
-	wp_style_add_data( 'wp-list-reusable-block', 'rtl', 'replace' );
-
-	gutenberg_override_style(
-		'wp-edit-widgets',
-		gutenberg_url( 'build/edit-widgets/style.css' ),
-		array( 'wp-components', 'wp-block-editor', 'wp-edit-blocks' ),
-		filemtime( gutenberg_dir_path() . 'build/edit-widgets/style.css' )
-	);
-	wp_style_add_data( 'wp-edit-widgets', 'rtl', 'replace' );
-
-	gutenberg_override_style(
-		'wp-block-directory',
-		gutenberg_url( 'build/block-directory/style.css' ),
-		array( 'wp-components' ),
-		filemtime( gutenberg_dir_path() . 'build/block-directory/style.css' )
-	);
-	wp_style_add_data( 'wp-block-directory', 'rtl', 'replace' );
+	// gutenberg_override_style( $wp_styles, 'wp-blocks', false );
 
 	if ( defined( 'GUTENBERG_LIVE_RELOAD' ) && GUTENBERG_LIVE_RELOAD ) {
 		$live_reload_url = ( GUTENBERG_LIVE_RELOAD === true ) ? 'http://localhost:35729/livereload.js' : GUTENBERG_LIVE_RELOAD;
@@ -389,39 +455,6 @@ function gutenberg_register_scripts_and_styles() {
 }
 add_action( 'wp_enqueue_scripts', 'gutenberg_register_scripts_and_styles', 5 );
 add_action( 'admin_enqueue_scripts', 'gutenberg_register_scripts_and_styles', 5 );
-
-/**
- * Registers vendor JavaScript files to be used as dependencies of the editor
- * and plugins.
- *
- * This function is called from a script during the plugin build process, so it
- * should not call any WordPress PHP functions.
- *
- * @since 0.1.0
- */
-function gutenberg_register_vendor_scripts() {
-	$suffix = SCRIPT_DEBUG ? '' : '.min';
-
-	// Vendor Scripts.
-	$react_suffix = ( SCRIPT_DEBUG ? '.development' : '.production' ) . $suffix;
-
-	// TODO: Overrides for react, react-dom and lodash are necessary
-	// until WordPress 5.3 is released.
-	gutenberg_register_vendor_script(
-		'react',
-		'https://unpkg.com/react@16.9.0/umd/react' . $react_suffix . '.js',
-		array( 'wp-polyfill' )
-	);
-	gutenberg_register_vendor_script(
-		'react-dom',
-		'https://unpkg.com/react-dom@16.9.0/umd/react-dom' . $react_suffix . '.js',
-		array( 'react' )
-	);
-	gutenberg_register_vendor_script(
-		'lodash',
-		'https://unpkg.com/lodash@4.17.15/lodash' . $suffix . '.js'
-	);
-}
 
 /**
  * Retrieves a unique and reasonably short and human-friendly filename for a
@@ -459,14 +492,15 @@ function gutenberg_vendor_script_filename( $handle, $src ) {
  * possible, or downloading it if the cached version is unavailable or
  * outdated.
  *
- * @param  string $handle Name of the script.
- * @param  string $src    Full URL of the external script.
- * @param  array  $deps   Optional. An array of registered script handles this
- *                        script depends on.
+ * @param WP_Scripts $scripts WP_Scripts instance (passed by reference).
+ * @param string     $handle  Name of the script.
+ * @param string     $src     Full URL of the external script.
+ * @param array      $deps    Optional. An array of registered script handles this
+ *                            script depends on.
  *
  * @since 0.1.0
  */
-function gutenberg_register_vendor_script( $handle, $src, $deps = array() ) {
+function gutenberg_register_vendor_script( &$scripts, $handle, $src, $deps = array() ) {
 	if ( defined( 'GUTENBERG_LOAD_VENDOR_SCRIPTS' ) && ! GUTENBERG_LOAD_VENDOR_SCRIPTS ) {
 		return;
 	}
@@ -496,7 +530,7 @@ function gutenberg_register_vendor_script( $handle, $src, $deps = array() ) {
 		if ( ! $f ) {
 			// Failed to open the file for writing, probably due to server
 			// permissions.  Enqueue the script directly from the URL instead.
-			gutenberg_override_script( $handle, $src, $deps, null );
+			gutenberg_override_script( $scripts, $handle, $src, $deps, null );
 			return;
 		}
 		fclose( $f );
@@ -509,12 +543,13 @@ function gutenberg_register_vendor_script( $handle, $src, $deps = array() ) {
 			// The request failed. If the file is already cached, continue to
 			// use this file. If not, then unlink the 0 byte file, and enqueue
 			// the script directly from the URL.
-			gutenberg_override_script( $handle, $src, $deps, null );
+			gutenberg_override_script( $scripts, $handle, $src, $deps, null );
 			unlink( $full_path );
 			return;
 		}
 	}
 	gutenberg_override_script(
+		$scripts,
 		$handle,
 		gutenberg_url( 'vendor/' . $filename ),
 		$deps,

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -66,19 +66,7 @@ function gutenberg_override_script( &$scripts, $handle, $src, $deps = array(), $
 		$script->src  = $src;
 		$script->deps = $deps;
 		$script->ver  = $ver;
-
-		/*
-		 * The script's `group` designation is an indication of whether it is
-		 * to be printed in the header or footer. The behavior here defers to
-		 * the arguments as passed. Specifically, group data is not assigned
-		 * for a script unless it is designated to be printed in the footer.
-		 */
-
-		// See: `wp_register_script` .
-		unset( $script->extra['group'] );
-		if ( $in_footer ) {
-			$script->add_data( 'group', 1 );
-		}
+		$script->args = $in_footer;
 	} else {
 		$scripts->add( $handle, $src, $deps, $ver, $in_footer );
 	}

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -154,6 +154,7 @@ add_filter( 'load_script_translation_file', 'gutenberg_override_translation_file
  *
  * @since 4.1.0
  *
+ * @param WP_Styles        $styles WP_Styles instance (passed by reference).
  * @param string           $handle Name of the stylesheet. Should be unique.
  * @param string           $src    Full URL of the stylesheet, or path of the stylesheet relative to the WordPress root directory.
  * @param array            $deps   Optional. An array of registered stylesheet handles this stylesheet depends on. Default empty array.
@@ -392,22 +393,9 @@ add_action( 'wp_default_styles', 'gutenberg_register_packages_styles' );
  *
  * @since 0.1.0
  */
-function gutenberg_register_scripts_and_styles() {
+function gutenberg_enqueue_block_editor_assets() {
 	global $wp_scripts;
-	global $wp_styles;
 
-	// Add nonce middleware which accounts for the absence of the heartbeat
-	// listener. This relies on API Fetch implementation running middlewares in
-	// order of last added, and that the original nonce middleware would defer
-	// to an X-WP-Nonce header already being present. This inline script should
-	// be removed once the following Core ticket is resolved in assigning the
-	// nonce received from heartbeat to the created middleware.
-	//
-	// See: https://core.trac.wordpress.org/ticket/46107 .
-	// See: https://github.com/WordPress/gutenberg/pull/13451 .
-	if ( isset( $wp_scripts->registered['wp-api-fetch'] ) ) {
-		$wp_scripts->registered['wp-api-fetch']->deps[] = 'wp-hooks';
-	}
 	wp_add_inline_script(
 		'wp-api-fetch',
 		sprintf(
@@ -441,9 +429,6 @@ function gutenberg_register_scripts_and_styles() {
 		)
 	);
 
-	// This empty stylesheet is defined to ensure backward compatibility.
-	// gutenberg_override_style( $wp_styles, 'wp-blocks', false );
-
 	if ( defined( 'GUTENBERG_LIVE_RELOAD' ) && GUTENBERG_LIVE_RELOAD ) {
 		$live_reload_url = ( GUTENBERG_LIVE_RELOAD === true ) ? 'http://localhost:35729/livereload.js' : GUTENBERG_LIVE_RELOAD;
 
@@ -453,8 +438,7 @@ function gutenberg_register_scripts_and_styles() {
 		);
 	}
 }
-add_action( 'wp_enqueue_scripts', 'gutenberg_register_scripts_and_styles', 5 );
-add_action( 'admin_enqueue_scripts', 'gutenberg_register_scripts_and_styles', 5 );
+add_action( 'enqueue_block_editor_assets', 'gutenberg_enqueue_block_editor_assets', 5 );
 
 /**
  * Retrieves a unique and reasonably short and human-friendly filename for a

--- a/lib/customizer.php
+++ b/lib/customizer.php
@@ -55,7 +55,7 @@ function gutenberg_customize_register( $wp_customize ) {
 			'sanitize_callback' => 'gutenberg_customize_sanitize',
 		)
 	);
-	if ( get_option( 'gutenberg-experiments' ) && array_key_exists( 'gutenberg-widget-experiments', get_option( 'gutenberg-experiments' ) ) ) {
+	if ( gutenberg_is_experiment_enabled( 'gutenberg-widget-experiments' ) ) {
 		$wp_customize->add_section(
 			'gutenberg_widget_blocks',
 			array( 'title' => __( 'Widget Blocks (Experimental)', 'gutenberg' ) )

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -130,12 +130,11 @@ function gutenberg_display_experiment_section() {
  * @return array Filtered editor settings.
  */
 function gutenberg_experiments_editor_settings( $settings ) {
-	$experiments_exist    = get_option( 'gutenberg-experiments' );
 	$experiments_settings = array(
-		'__experimentalEnableLegacyWidgetBlock' => $experiments_exist ? array_key_exists( 'gutenberg-widget-experiments', get_option( 'gutenberg-experiments' ) ) : false,
-		'__experimentalEnableMenuBlock'         => $experiments_exist ? array_key_exists( 'gutenberg-menu-block', get_option( 'gutenberg-experiments' ) ) : false,
-		'__experimentalBlockDirectory'          => $experiments_exist ? array_key_exists( 'gutenberg-block-directory', get_option( 'gutenberg-experiments' ) ) : false,
-		'__experimentalEnableFullSiteEditing'   => $experiments_exist ? array_key_exists( 'gutenberg-full-site-editing', get_option( 'gutenberg-experiments' ) ) : false,
+		'__experimentalEnableLegacyWidgetBlock' => gutenberg_is_experiment_enabled( 'gutenberg-widget-experiments' ),
+		'__experimentalEnableMenuBlock'         => gutenberg_is_experiment_enabled( 'gutenberg-menu-block' ),
+		'__experimentalBlockDirectory'          => gutenberg_is_experiment_enabled( 'gutenberg-block-directory' ),
+		'__experimentalEnableFullSiteEditing'   => gutenberg_is_experiment_enabled( 'gutenberg-full-site-editing' ),
 
 	);
 	return array_merge( $settings, $experiments_settings );

--- a/lib/load.php
+++ b/lib/load.php
@@ -9,6 +9,20 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die( 'Silence is golden.' );
 }
 
+/**
+ * Checks whether the Gutenberg experiment is enabled.
+ *
+ * @since 6.7.0
+ *
+ * @param string $name The name of the experiment.
+ *
+ * @return bool True when the experiment is enabled.
+ */
+function gutenberg_is_experiment_enabled( $name ) {
+	$experiments = get_option( 'gutenberg-experiments' );
+	return ! empty( $experiments[ $name ] );
+}
+
 // These files only need to be loaded if within a rest server instance
 // which this class will exist if that is the case.
 if ( class_exists( 'WP_REST_Controller' ) ) {

--- a/lib/load.php
+++ b/lib/load.php
@@ -22,13 +22,12 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 		require dirname( __FILE__ ) . '/class-experimental-wp-widget-blocks-manager.php';
 		require dirname( __FILE__ ) . '/class-wp-rest-widget-areas-controller.php';
 	}
-	/**
-	* End: Include for phase 2
-	*/
-
 	if ( ! class_exists( 'WP_REST_Block_Directory_Controller' ) ) {
 		require dirname( __FILE__ ) . '/class-wp-rest-block-directory-controller.php';
 	}
+	/**
+	* End: Include for phase 2
+	*/
 
 	require dirname( __FILE__ ) . '/rest-api.php';
 }
@@ -43,6 +42,7 @@ require dirname( __FILE__ ) . '/blocks.php';
 require dirname( __FILE__ ) . '/templates.php';
 require dirname( __FILE__ ) . '/template-loader.php';
 require dirname( __FILE__ ) . '/client-assets.php';
+require dirname( __FILE__ ) . '/block-directory.php';
 require dirname( __FILE__ ) . '/demo.php';
 require dirname( __FILE__ ) . '/widgets.php';
 require dirname( __FILE__ ) . '/widgets-page.php';

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -85,6 +85,10 @@ add_action( 'rest_api_init', 'gutenberg_register_rest_widget_areas' );
  * @since 6.5.0
  */
 function gutenberg_register_rest_block_directory() {
+	if ( ! gutenberg_is_experiment_enabled( 'gutenberg-block-directory' ) ) {
+		return;
+	}
+
 	$block_directory_controller = new WP_REST_Block_Directory_Controller();
 	$block_directory_controller->register_routes();
 }

--- a/lib/templates.php
+++ b/lib/templates.php
@@ -9,10 +9,7 @@
  * Registers block editor 'wp_template' post type.
  */
 function gutenberg_register_template_post_type() {
-	if (
-		! get_option( 'gutenberg-experiments' ) ||
-		! array_key_exists( 'gutenberg-full-site-editing', get_option( 'gutenberg-experiments' ) )
-	) {
+	if ( ! gutenberg_is_experiment_enabled( 'gutenberg-full-site-editing' ) ) {
 		return;
 	}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7228,6 +7228,7 @@
 				"@wordpress/data": "file:packages/data",
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/i18n": "file:packages/i18n",
+				"@wordpress/plugins": "file:packages/plugins",
 				"lodash": "^4.17.15"
 			}
 		},

--- a/packages/block-directory/package.json
+++ b/packages/block-directory/package.json
@@ -29,6 +29,7 @@
 		"@wordpress/data": "file:../data",
 		"@wordpress/element": "file:../element",
 		"@wordpress/i18n": "file:../i18n",
+		"@wordpress/plugins": "file:../plugins",
 		"lodash": "^4.17.15"
 	},
 	"publishConfig": {

--- a/packages/block-directory/src/index.js
+++ b/packages/block-directory/src/index.js
@@ -2,5 +2,4 @@
  * Internal dependencies
  */
 import './store';
-
-export { default as DownloadableBlocksPanel } from './components/downloadable-blocks-panel';
+import './plugins';

--- a/packages/block-directory/src/plugins/index.js
+++ b/packages/block-directory/src/plugins/index.js
@@ -1,0 +1,15 @@
+/**
+ * WordPress dependencies
+ */
+import { registerPlugin } from '@wordpress/plugins';
+
+/**
+ * Internal dependencies
+ */
+import InserterMenuDownloadableBlocksPanel from './inserter-menu-downloadable-blocks-panel';
+
+registerPlugin( 'block-directory', {
+	render() {
+		return <InserterMenuDownloadableBlocksPanel />;
+	},
+} );

--- a/packages/block-directory/src/plugins/inserter-menu-downloadable-blocks-panel/index.js
+++ b/packages/block-directory/src/plugins/inserter-menu-downloadable-blocks-panel/index.js
@@ -7,8 +7,12 @@ import { debounce } from 'lodash';
  * WordPress dependencies
  */
 import { __experimentalInserterMenuExtension } from '@wordpress/block-editor';
-import { DownloadableBlocksPanel } from '@wordpress/block-directory';
 import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import DownloadableBlocksPanel from '../../components/downloadable-blocks-panel';
 
 function InserterMenuDownloadableBlocksPanel() {
 	const [ debouncedFilterValue, setFilterValue ] = useState( '' );

--- a/phpunit/class-override-script-test.php
+++ b/phpunit/class-override-script-test.php
@@ -62,7 +62,7 @@ class Override_Script_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'https://example.com/updated', $script->src );
 		$this->assertEquals( array( 'updated-dependency', 'wp-i18n' ), $script->deps );
 		$this->assertEquals( 'updated-version', $script->ver );
-		$this->assertEquals( 1, $script->extra['group'] );
+		$this->assertTrue( $script->args );
 	}
 
 	/**
@@ -84,6 +84,6 @@ class Override_Script_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'https://example.com/', $script->src );
 		$this->assertEquals( array( 'dependency', 'wp-i18n' ), $script->deps );
 		$this->assertEquals( 'version', $script->ver );
-		$this->assertEquals( 1, $script->extra['group'] );
+		$this->assertTrue( $script->args );
 	}
 }

--- a/phpunit/class-override-script-test.php
+++ b/phpunit/class-override-script-test.php
@@ -28,7 +28,10 @@ class Override_Script_Test extends WP_UnitTestCase {
 	 * Tests that script is localized.
 	 */
 	function test_localizes_script() {
+		global $wp_scripts;
+
 		gutenberg_override_script(
+			$wp_scripts,
 			'gutenberg-dummy-script',
 			'https://example.com/',
 			array( 'dependency' ),
@@ -36,7 +39,6 @@ class Override_Script_Test extends WP_UnitTestCase {
 			false
 		);
 
-		global $wp_scripts;
 		$script = $wp_scripts->query( 'gutenberg-dummy-script', 'registered' );
 		$this->assertEquals( array( 'dependency', 'wp-i18n' ), $script->deps );
 	}
@@ -45,7 +47,10 @@ class Override_Script_Test extends WP_UnitTestCase {
 	 * Tests that script properties are overridden.
 	 */
 	function test_replaces_registered_properties() {
+		global $wp_scripts;
+
 		gutenberg_override_script(
+			$wp_scripts,
 			'gutenberg-dummy-script',
 			'https://example.com/updated',
 			array( 'updated-dependency' ),
@@ -53,7 +58,6 @@ class Override_Script_Test extends WP_UnitTestCase {
 			true
 		);
 
-		global $wp_scripts;
 		$script = $wp_scripts->query( 'gutenberg-dummy-script', 'registered' );
 		$this->assertEquals( 'https://example.com/updated', $script->src );
 		$this->assertEquals( array( 'updated-dependency', 'wp-i18n' ), $script->deps );
@@ -65,7 +69,10 @@ class Override_Script_Test extends WP_UnitTestCase {
 	 * Tests that new script registers normally if no handle by the name.
 	 */
 	function test_registers_new_script() {
+		global $wp_scripts;
+
 		gutenberg_override_script(
+			$wp_scripts,
 			'gutenberg-second-dummy-script',
 			'https://example.com/',
 			array( 'dependency' ),
@@ -73,7 +80,6 @@ class Override_Script_Test extends WP_UnitTestCase {
 			true
 		);
 
-		global $wp_scripts;
 		$script = $wp_scripts->query( 'gutenberg-second-dummy-script', 'registered' );
 		$this->assertEquals( 'https://example.com/', $script->src );
 		$this->assertEquals( array( 'dependency', 'wp-i18n' ), $script->deps );


### PR DESCRIPTION
## Description
This PR optimizes the way modules are configured to ensure that `wp-block-directory` isn't bundled into the WordPress core. It turns out that `@wordpress/block-directory` has side effects coming from the store registration so we can't tree-shake it using `GUTENBERG_PHASE` flag. That's why I started the process of converting it into a UI Plugin which is enqueued separately. It also means that we don't need to enqueue 

I removed the logic which uninstalls the block/plugin if it isn't used in the post. We should bring it back in a separate PR once we agree on the best approach. It's already listed as an action item on https://github.com/WordPress/gutenberg/issues/17440.

This PR also introduces `gutenberg_is_experiment_enabled` helper method to make it easier to validate whether a given experiment is enabled.

## How it works

The block directory is behind the experimental flag. That's why we don't need to enqueue CSS and JS files where this feature is disabled. The fact that this module/package works now as a UI Plugin makes it completely independent from the rest of Gutenberg. It works like an **internal plugin**.

To get us there and use `enqueue_block_editor_assets` to enqueue CSS and JS files only when the block editor is loaded on the page I had to apply quite aggressive refactor. The biggest change is that we no longer use `wp_enqueue_scripts` and `admin_enqueue_scripts` to override CSS and JS assets. This drastic change was motivated by the fact that `enqueue_block_editor_assets` is triggered before those 2 hooks. Fortunately, it was possible to refactor plugin's code to use `wp_default_styles` and `wp_default_scripts` instead. It required some moving code around which makes this PR harder to review. On the bright side, it seems like this is something which makes the whole override dance more reliable as it happens just after all those scripts and styles get registered in the WordPress core before any other hooks get applied.