### PR TITLE
[RNMobile] Add content alignment options to paragraph block

### DIFF
--- a/packages/block-editor/src/components/alignment-toolbar/index.native.js
+++ b/packages/block-editor/src/components/alignment-toolbar/index.native.js
@@ -1,5 +1,0 @@
-const AlignmentToolbar = () => {
-	return null;
-};
-
-export default AlignmentToolbar;

--- a/packages/block-library/src/paragraph/edit.native.js
+++ b/packages/block-library/src/paragraph/edit.native.js
@@ -9,7 +9,7 @@ import { View } from 'react-native';
 import { __ } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
 import { createBlock } from '@wordpress/blocks';
-import { RichText } from '@wordpress/block-editor';
+import { AlignmentToolbar, BlockControls, RichText } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -47,12 +47,22 @@ class ParagraphEdit extends Component {
 		} = this.props;
 
 		const {
-			placeholder,
+			align,
 			content,
+			placeholder,
 		} = attributes;
 
 		return (
 			<View>
+				<BlockControls>
+					<AlignmentToolbar
+						isCollapsed={ false }
+						value={ align }
+						onChange={ ( nextAlign ) => {
+							setAttributes( { align: nextAlign } );
+						} }
+					/>
+				</BlockControls>
 				<RichText
 					identifier="content"
 					tagName="p"
@@ -78,6 +88,7 @@ class ParagraphEdit extends Component {
 					onReplace={ onReplace }
 					onRemove={ onReplace ? () => onReplace( [] ) : undefined }
 					placeholder={ placeholder || __( 'Start writing…' ) }
+					textAlign={ align }
 				/>
 			</View>
 		);


### PR DESCRIPTION
[related gutenberg-mobile PR](https://github.com/wordpress-mobile/gutenberg-mobile/pull/1489)

## Description
This PR adds alignment controls for paragraph blocks on mobile, addressing [gutenberg-mobile#1266](https://github.com/wordpress-mobile/gutenberg-mobile/issues/1266).

iOS | Android
--- | ---
![p_alignment_ios mov](https://user-images.githubusercontent.com/4656348/67418961-c840c480-f599-11e9-950c-6db8c92524ae.gif) | ![p_alignment_android mp4](https://user-images.githubusercontent.com/4656348/67418971-cd9e0f00-f599-11e9-8ab4-d5e871afd680.gif)





## How has this been tested?

1. Open a paragraph block
2. Adjust its alignment a few times
3. Verify that both the display of the text and the html is updated appropriately after each change
4. Verify that a block with alignment can be saved and loaded on web with the alignment reflected
5. Adjust the block's alignment on the web
6. Verify that the block can be saved on web and loaded on mobile with the alignment reflected

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
