### PR TITLE
Update mixin that sets hover style on some buttons

### DIFF
--- a/assets/stylesheets/_mixins.scss
+++ b/assets/stylesheets/_mixins.scss
@@ -126,7 +126,7 @@
 @mixin button-style__hover {
 	background-color: $white;
 	color: $dark-gray-900;
-	box-shadow: inset 0 0 0 1px $light-gray-500, inset 0 0 0 2px $white, 0 1px 1px rgba($dark-gray-900, 0.2);
+	box-shadow: inset 0 0 0 1px $dark-gray-500, inset 0 0 0 2px $white;
 }
 
 @mixin button-style__active() {

--- a/packages/components/src/dropdown-menu/style.scss
+++ b/packages/components/src/dropdown-menu/style.scss
@@ -79,6 +79,11 @@
 			@include menu-style__focus();
 		}
 
+		&:hover,
+		&:not(:disabled):not([aria-disabled="true"]):not(.is-default):hover {
+			@include menu-style__hover();
+		}
+
 		// Formatting buttons
 		> svg {
 			border-radius: $radius-round-rectangle;


### PR DESCRIPTION
Fixes #17337

This is a small update to the `button-style__hover` mixin in `_mixins.scss`. The change makes the hover style match the "hard line" style used on the block toolbar and the "Settings" and "More tools & options".

![hovers](https://user-images.githubusercontent.com/3276087/65629895-ef57a680-df99-11e9-853c-ce0e576dfa01.gif)

## Some nitpicks

This change makes more noticeable the size/padding difference between the top toolbar and block toolbar buttons that was already present. Not sure if it's worth looking at this, thoughts?

![toolbar-hovers](https://user-images.githubusercontent.com/3276087/65630202-8d4b7100-df9a-11e9-9766-607c56e9b814.gif)

We also have another hover style in the block inserter, should we also look at updating this one?

<img width="713" alt="Screen Shot 2019-09-25 at 1 27 47 PM" src="https://user-images.githubusercontent.com/3276087/65630284-bc61e280-df9a-11e9-863e-ce88a470aff8.png">

