### PR TITLE
Columns Block: Account for the margin between columns when setting custom widths inline

### DIFF
--- a/packages/block-library/src/column/index.js
+++ b/packages/block-library/src/column/index.js
@@ -30,7 +30,7 @@ export const settings = {
 		if ( Number.isFinite( width ) ) {
 			return {
 				style: {
-					flexBasis: width + '%',
+					flexBasis: 'calc(' + width + '% - 16px)',
 				},
 			};
 		}

--- a/packages/block-library/src/column/save.js
+++ b/packages/block-library/src/column/save.js
@@ -17,7 +17,7 @@ export default function save( { attributes } ) {
 
 	let style;
 	if ( Number.isFinite( width ) ) {
-		style = { flexBasis: width + '%' };
+		style = { flexBasis: 'calc(' + width + '% - 16px)' };
 	}
 
 	return (


### PR DESCRIPTION
## Description

This PR updates the inline column widths to subtract the 16px used for margins from the flex basis (changing them from `flex-basis: ##%` to `flex-basis: calc( ##% - 16px. )`. This makes sure the columns don't wrap prematurely on tablet-sized screens. 

## How has this been tested?

I've tested in Firefox (69.0.1), Chrome (77.0.3865.90), Safari (13.0.1) and IE Edge (18), moving between different screen sizes -- confirming that the display of the block outside of the affected breakpoint doesn't change.

## Screenshots

The below screenshots use a two column block, with widths set to 66.66% and 33.33%, and the testing site uses Twenty Nineteen, but I've been able to recreate the issue with other themes:

**Before:** 

Tablet width: (less than 767px wide but more than 600px wide):

![image](https://user-images.githubusercontent.com/177561/65633449-0219ad80-df91-11e9-8164-add69f9f64a1.png)

**After:**

Tablet width: (less than 767px wide but more than 600px wide):

![image](https://user-images.githubusercontent.com/177561/65633959-10b49480-df92-11e9-8171-c20a05a054a5.png)

## Types of changes
Breaking fix -- as is right now, this PR will cause existing columns block to throw an error in the editor ("This block contains unexpected or invalid content."). The blocks need to be recreated from scratch after the PR is applied. 

Fixes: #17340 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
