### PR TITLE
Gallery Block: Stop reflows from breaking custom alignment layouts.

### DIFF
--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -135,14 +135,6 @@
 		width: 100%;
 	}
 
-	// Keep the display property consistent when alignments are applied
-	// to preserve columns
-	&.alignleft,
-	&.aligncenter,
-	&.alignright {
-		display: flex;
-	}
-
 	// If the gallery is centered, center the content inside as well.
 	&.aligncenter {
 		.blocks-gallery-item figure {


### PR DESCRIPTION
Fixes #17584

## Description

A seemingly unnecessary flex property on the gallery block's figure element when it had left, right, or center alignment set, was causing issues when the alignment was changed between the 3 modes.

Something with how the flex space allocation calculations work was causing the breakage in #17584.

This PR fixes that by removing the property.

## How has this been tested?

It was verified that the issue described is no longer happening and that the gallery block's alignment works as expected both in the editor and published site.

## Types of Changes

*Bug Fix:* Switching between different alignment modes for the gallery block no longer breaks its layout.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
