### PR TITLE
i18n: Remove incorrect text domain

### DIFF
--- a/packages/block-directory/src/components/downloadable-block-author-info/index.js
+++ b/packages/block-directory/src/components/downloadable-block-author-info/index.js
@@ -11,7 +11,15 @@ function DownloadableBlockAuthorInfo( { author, authorBlockCount, authorBlockRat
 				{ sprintf( __( 'Authored by %s' ), author ) }
 			</span>
 			<span className="block-directory-downloadable-block-author-info__content">
-				{ sprintf( _n( 'This author has %d block, with an average rating of %d.', 'This author has %d blocks, with an average rating of %d.', authorBlockCount, authorBlockRating ), authorBlockCount, authorBlockRating ) }
+				{ sprintf(
+					_n(
+						'This author has %d block, with an average rating of %d.',
+						'This author has %d blocks, with an average rating of %d.',
+						authorBlockCount
+					),
+					authorBlockCount,
+					authorBlockRating
+				) }
 			</span>
 		</Fragment>
 	);


### PR DESCRIPTION
## Description
To make the string `This author has %d block, with an average rating of %d.` translatable, this PR removes the the 4th parameter `authorBlockRating` from the function `_n()`. The [4th parameter](https://github.com/WordPress/gutenberg/tree/master/packages/i18n#_n) in `_n()` is for the text domain. This usage is not correct in this context.