### PR TITLE
REST API: Block directory - Typecast author_block_count as integer.

### DIFF
--- a/lib/class-wp-rest-block-directory-controller.php
+++ b/lib/class-wp-rest-block-directory-controller.php
@@ -286,7 +286,7 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 		$block->rating_count        = $plugin['num_ratings'];
 		$block->active_installs     = $plugin['active_installs'];
 		$block->author_block_rating = $plugin['author_block_rating'] / 20;
-		$block->author_block_count  = $plugin['author_block_count'];
+		$block->author_block_count  = (int) $plugin['author_block_count'];
 
 		// Plugin's author, not author in block.json.
 		$block->author = wp_strip_all_tags( $plugin['author'] );


### PR DESCRIPTION
## Description
`author_block_count` needs to be an integer, otherwise the singular/plural translation functions `_n()` doesn't work.

**Before**: (1 blocks)
<img width="366" alt="Bildschirmfoto 2019-09-26 um 01 25 26" src="https://user-images.githubusercontent.com/695201/65646938-185d5300-dffd-11e9-9559-2688f5a10b06.png">
**After**: (1 block)
<img width="371" alt="Bildschirmfoto 2019-09-26 um 01 24 19" src="https://user-images.githubusercontent.com/695201/65646944-1bf0da00-dffd-11e9-81e7-e1ff2ac881c0.png">
