### PR TITLE
Docs: Fix typos - PHP code

### DIFF
--- a/lib/class-experimental-wp-widget-blocks-manager.php
+++ b/lib/class-experimental-wp-widget-blocks-manager.php
@@ -8,7 +8,7 @@
 
 /**
  * Class that provides a set of static abstractions to deal with widgets.
- * Itended to be used by WP_REST_Widget_Areas_Controller.
+ * Intended to be used by WP_REST_Widget_Areas_Controller.
  *
  * @since 5.7.0
  */
@@ -72,7 +72,7 @@ class Experimental_WP_Widget_Blocks_Manager {
 	 *
 	 * @since 5.7.0
 	 *
-	 * @param string $sidebar_id Indentifier of the sidebar.
+	 * @param string $sidebar_id Identifier of the sidebar.
 	 * @return integer Post id.
 	 */
 	public static function get_post_id_referenced_in_sidebar( $sidebar_id ) {
@@ -86,7 +86,7 @@ class Experimental_WP_Widget_Blocks_Manager {
 	 *
 	 * @since 5.7.0
 	 *
-	 * @param string  $sidebar_id Indentifier of the sidebar.
+	 * @param string  $sidebar_id Identifier of the sidebar.
 	 * @param integer $post_id    Post id.
 	 */
 	public static function reference_post_id_in_sidebar( $sidebar_id, $post_id ) {
@@ -111,7 +111,7 @@ class Experimental_WP_Widget_Blocks_Manager {
 	 *
 	 * @since 5.7.0
 	 *
-	 * @param string $sidebar_id Indentifier of the sidebar.
+	 * @param string $sidebar_id Identifier of the sidebar.
 	 * @return array $post_id    Post id.
 	 */
 	public static function get_sidebar_as_blocks( $sidebar_id ) {
@@ -140,7 +140,7 @@ class Experimental_WP_Widget_Blocks_Manager {
 	 *
 	 * @since 5.7.0
 	 *
-	 * @param string $sidebar_id Indentifier of the sidebar.
+	 * @param string $sidebar_id Identifier of the sidebar.
 	 * @return boolean True if the $sidebar_id value is valid and false otherwise.
 	 */
 	public static function is_valid_sidabar_id( $sidebar_id ) {
@@ -154,7 +154,7 @@ class Experimental_WP_Widget_Blocks_Manager {
 	 *
 	 * @since 5.7.0
 	 *
-	 * @param string $widget_id Indentifier of the widget.
+	 * @param string $widget_id Identifier of the widget.
 	 * @return string|null Name of the class that represents the widget or null if the widget is not represented by a class.
 	 */
 	private static function get_widget_class( $widget_id ) {
@@ -174,7 +174,7 @@ class Experimental_WP_Widget_Blocks_Manager {
 	 * @since 5.7.0
 	 *
 	 * @param array  $sidebar sidebar data available at $wp_registered_sidebars.
-	 * @param string $id Idenfitier of the widget instance.
+	 * @param string $id Identifier of the widget instance.
 	 * @return array Array containing the widget instance.
 	 */
 	private static function get_sidebar_widget_instance( $sidebar, $id ) {
@@ -221,8 +221,8 @@ class Experimental_WP_Widget_Blocks_Manager {
 	 *
 	 * @since 5.7.0
 	 *
-	 * @param string $widget_id Indentifier of the widget.
-	 * @return array Array containing the the wiget object, the number, and the name.
+	 * @param string $widget_id Identifier of the widget.
+	 * @return array Array containing the the widget object, the number, and the name.
 	 */
 	private static function get_widget_info( $widget_id ) {
 		$wp_registered_widgets = self::get_wp_registered_widgets();

--- a/lib/class-wp-rest-widget-areas-controller.php
+++ b/lib/class-wp-rest-widget-areas-controller.php
@@ -245,7 +245,7 @@ class WP_REST_Widget_Areas_Controller extends WP_REST_Controller {
 	 *
 	 * @since 5.7.0
 	 *
-	 * @param string $sidebar_id Indentifier of the sidebar.
+	 * @param string $sidebar_id Identifier of the sidebar.
 	 * @return object Sidebar data with a content array.
 	 */
 	protected function get_sidebar_data( $sidebar_id ) {


### PR DESCRIPTION
## Description
Fixes some typos in the docs of the class `Experimental_WP_Widget_Blocks_Manager` and `WP_REST_Widget_Areas_Controller`.