### PR TITLE
Fix file permissions in the Docker containers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,8 @@ env:
     - LOCAL_SCRIPT_DEBUG: false
     - INSTALL_COMPOSER: false
     - INSTALL_WORDPRESS: true
+    - PHP_FPM_UID: "`id -u`"
+    - PHP_FPM_GID: "`id -g`"
 
 before_install:
   - nvm install --latest-npm


### PR DESCRIPTION
## Description

WordPress/wpdev-docker-images#16 changed the Docker images to have more reliable file permissions. #17518 is in progress to take full advantage of this, but requires a bunch more work.

This PR helps avoid unnecessarily failing Travis tests in the mean time.

## How has this been tested?

Compare a re-run of Travis on a recent merge to `master` (eg, https://travis-ci.com/WordPress/gutenberg/builds/129202271) to Travis on this PR.
