### PR TITLE
Fix lint on rnmobile/master

### DIFF
--- a/packages/block-editor/src/components/media-placeholder/index.native.js
+++ b/packages/block-editor/src/components/media-placeholder/index.native.js
@@ -61,7 +61,6 @@ function MediaPlaceholder( props ) {
 		accessibilityHint = __( 'Double tap to select a video' );
 	}
 
-	const emptyStateContainerStyle = getStylesFromColorScheme( styles.emptyStateContainer, styles.emptyStateContainerDark );
 	const emptyStateTitleStyle = getStylesFromColorScheme( styles.emptyStateTitle, styles.emptyStateTitleDark );
 
 	const renderContent = () => {
@@ -94,6 +93,8 @@ function MediaPlaceholder( props ) {
 	if ( isAppender && disableMediaButtons ) {
 		return null;
 	}
+
+	const emptyStateContainerStyle = getStylesFromColorScheme( styles.emptyStateContainer, styles.emptyStateContainerDark );
 
 	return (
 		<View style={ { flex: 1 } }>


### PR DESCRIPTION
## Description

Ref to gutenberg mobile https://github.com/wordpress-mobile/gutenberg-mobile/pull/1388

Lint is failing on TravisCI, because variable called `emptyStateContainerStyle` is located before return statement:

```
	if ( isAppender && disableMediaButtons ) {
		return null;
	}
```

which means that the variable can be unused.

Error message:

```
[0] /home/travis/build/WordPress/gutenberg/packages/block-editor/src/components/media-placeholder/index.native.js
[0]   66:8  error  Variables should not be assigned until just prior its first reference. An early return statement may leave this variable unused  @wordpress/no-unused-vars-before-return
```

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
