### PR TITLE
Tidy up button vertical align styles

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -1234,5 +1234,4 @@
 	// Pull the warning upwards to the edge, and add a negative bottom margin to compensate.
 	margin-bottom: -$block-padding;
 	transform: translateY(-$block-padding);
-	padding: 10px $block-padding $block-padding;
 }

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -1234,10 +1234,5 @@
 	// Pull the warning upwards to the edge, and add a negative bottom margin to compensate.
 	margin-bottom: -$block-padding;
 	transform: translateY(-$block-padding);
-
-	// Bigger padding on mobile where blocks are edge to edge.
-	padding: 10px $block-padding;
-	@include break-small() {
-		padding: 10px $block-padding;
-	}
+	padding: 10px $block-padding $block-padding;
 }

--- a/packages/block-editor/src/components/warning/style.scss
+++ b/packages/block-editor/src/components/warning/style.scss
@@ -6,7 +6,7 @@
 	background-color: $white;
 	border: $border-width solid $light-gray-500;
 	text-align: left;
-	padding: 20px;
+	padding: 10px $block-padding $block-padding;
 
 	// Avoid conflict with the multi-selection highlight color.
 	.has-warning.is-multi-selected & {
@@ -28,6 +28,11 @@
 		font-family: $default-font;
 		font-size: $default-font-size;
 		margin: 1em 0;
+
+	}
+	// Required extra-specifity to override paragraph block styles.
+	p.block-editor-warning__message.block-editor-warning__message {
+		min-height: auto;
 	}
 
 	.block-editor-warning__contents {
@@ -35,7 +40,7 @@
 		flex-direction: row;
 		justify-content: space-between;
 		flex-wrap: wrap;
-		align-items: center;
+		align-items: baseline;
 		width: 100%;
 	}
 
@@ -49,7 +54,7 @@
 }
 
 .block-editor-warning__secondary {
-	margin: 3px 0 0 -4px;
+	margin: 5px 0 0 -4px;
 	height: $block-controls-height;
 
 	// the padding and margin of the more menu is intentionally non-standard

--- a/packages/block-editor/src/components/warning/style.scss
+++ b/packages/block-editor/src/components/warning/style.scss
@@ -45,10 +45,6 @@
 
 	.block-editor-warning__action {
 		margin: 0 6px 0 0;
-
-		.components-button {
-			vertical-align: top;
-		}
 	}
 }
 

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -24,7 +24,6 @@
 		border-color: #ccc;
 		background: #f7f7f7;
 		box-shadow: inset 0 -1px 0 #ccc;
-		vertical-align: top;
 
 		&:hover {
 			background: #fafafa;
@@ -98,7 +97,6 @@
 			background: color(theme(button) shade(20%));
 			border-color: color(theme(button) shade(50%));
 			box-shadow: inset 0 1px 0 color(theme(button) shade(50%));
-			vertical-align: top;
 		}
 
 		&:disabled,


### PR DESCRIPTION
NOTE - I don't think should be merged for WP5.3 as it affects every `Button`. Having said that, it looks like buttons maybe updated anyway - https://github.com/WordPress/gutenberg/issues/17585.

## Description
This is a follow-up to https://github.com/WordPress/gutenberg/pull/17572#discussion_r328341452

Primary buttons had `vertical-align: top`, but other types of buttons didn't, which made laying them out alongside one another difficult. This PR removes that `vertical-align: top` from all buttons to make them consistent. It affects all buttons so it might have some far-reaching consequences (but I couldn't see any particular issues).

I've removed the slightly hacky fixes from #17572 and switched to flexbox's `align-items: baseline` to properly align the buttons in the block warnings.

There were also some other minor tweaks required
- The block warning message for paragraph blocks was inheriting paragraph styling from that block, so I've had to reset the min-height rule.
- Added some additional padding to the more icon in block warnings to line it up with new the baseline alignment
- Remove a breakpoint that didn't do anything
- Move a padding style from the block-list stylesheet to the warning stylesheet. The existing `20px` definition was only used for the editor warning message, and its defined in the error boundary anyway: https://github.com/WordPress/gutenberg/blob/master/packages/editor/src/components/error-boundary/style.scss#L4

## How has this been tested?
Manual testing
- Test invalidating a block and viewing the warning message (the easiest way is to switch to the code editor and add a self closing `div` in a block)
- Testing missing blocks and viewing the warning message (install a block, add it to a post, then deactivate it)
- Test the editor error boundary message (throw an exception somewhere (like BlockList))
- Test the block error boundary message (throw an error in a block `edit`) (oh, turns out block error boundaries are not working!).
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->
![Screen Shot 2019-09-26 at 4 46 59 pm](https://user-images.githubusercontent.com/677833/65673369-4bdfc200-e07d-11e9-96f5-8de868d5a0c3.png)
![Screen Shot 2019-09-26 at 4 41 17 pm](https://user-images.githubusercontent.com/677833/65673380-500bdf80-e07d-11e9-89af-2b6812959033.png)


## Types of changes
Task
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
