### PR TITLE
Fix block crash boundary

### DIFF
--- a/packages/block-editor/src/components/block-list/block-crash-warning.js
+++ b/packages/block-editor/src/components/block-list/block-crash-warning.js
@@ -9,7 +9,7 @@ import { __ } from '@wordpress/i18n';
 import Warning from '../warning';
 
 const warning = (
-	<Warning className="block-editor-block-crash-warning">
+	<Warning className="block-editor-block-list__block-crash-warning">
 		{ __( 'This block has encountered an error and cannot be previewed.' ) }
 	</Warning>
 );

--- a/packages/block-editor/src/components/block-list/block-crash-warning.js
+++ b/packages/block-editor/src/components/block-list/block-crash-warning.js
@@ -9,7 +9,7 @@ import { __ } from '@wordpress/i18n';
 import Warning from '../warning';
 
 const warning = (
-	<Warning>
+	<Warning className="block-editor-block-crash-warning">
 		{ __( 'This block has encountered an error and cannot be previewed.' ) }
 	</Warning>
 );

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -181,7 +181,7 @@ function BlockListBlock( {
 
 	// Handling the error state
 	const [ hasError, setErrorState ] = useState( false );
-	const onBlockError = () => setErrorState( false );
+	const onBlockError = () => setErrorState( true );
 
 	// Handling of forceContextualToolbarFocus
 	const isForcingContextualToolbar = useRef( false );

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -576,10 +576,10 @@ function BlockListBlock( {
 							</div>,
 						] }
 					</BlockCrashBoundary>
+					{ !! hasError && <BlockCrashWarning /> }
 					{ shouldShowMobileToolbar && (
 						<BlockMobileToolbar clientId={ clientId } />
 					) }
-					{ !! hasError && <BlockCrashWarning /> }
 				</IgnoreNestedEvents>
 			</div>
 			{ showInserterShortcuts && (

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -1235,7 +1235,7 @@
 	margin-bottom: -$block-padding;
 	transform: translateY(-$block-padding);
 
-	&.block-editor-block-crash-warning {
+	&.block-editor-block-list__block-crash-warning {
 		// Reset margin-bottom. Without this, the block has negative margin.
 		// Because of the crash the block also has no content, so this avoids
 		// overlapping of the next block.

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -1236,9 +1236,11 @@
 	transform: translateY(-$block-padding);
 
 	&.block-editor-block-list__block-crash-warning {
-		// Reset margin-bottom. Without this, the block has negative margin.
-		// Because of the crash the block also has no content, so this avoids
-		// overlapping of the next block.
+		// The block crash warning has no block preview underneath it.
+		// The lack of a preview combined with the negative margin that
+		// the warning normally has results in crashed blocks overlapping
+		// any blocks that come after them. Resetting the margin to `auto`
+		// solves this.
 		margin-bottom: auto;
 	}
 }

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -1234,4 +1234,11 @@
 	// Pull the warning upwards to the edge, and add a negative bottom margin to compensate.
 	margin-bottom: -$block-padding;
 	transform: translateY(-$block-padding);
+
+	&.block-editor-block-crash-warning {
+		// Reset margin-bottom. Without this, the block has negative margin.
+		// Because of the crash the block also has no content, so this avoids
+		// overlapping of the next block.
+		margin-bottom: auto;
+	}
 }

--- a/packages/block-editor/src/components/warning/style.scss
+++ b/packages/block-editor/src/components/warning/style.scss
@@ -16,7 +16,10 @@
 	.is-selected & {
 		// Use opacity to work in various editor styles.
 		border-color: $dark-opacity-light-800;
-		border-left-color: transparent;
+
+		@include break-small {
+			border-left-color: transparent;
+		}
 
 		.is-dark-theme & {
 			border-color: $light-opacity-light-800;


### PR DESCRIPTION
## Description
Block crash boundaries seem to have become broken after a recent change.

The fix was just changing `false` to `true`. Some of the styling also needed fixing.

## How has this been tested?
1. Add a block to a post. 
2. Add a `throw 'error'` into the block's edit function
3. Reload the post
4. Observe that the block should show an error

## Screenshots <!-- if applicable -->
### Desktop
![Screen Shot 2019-09-27 at 10 36 19 am](https://user-images.githubusercontent.com/677833/65738020-ffdf5c80-e112-11e9-9253-a4b346c975de.png)

### Mobile
![Screen Shot 2019-09-27 at 10 44 52 am](https://user-images.githubusercontent.com/677833/65738299-e1c62c00-e113-11e9-9c13-2b78b6ddea89.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
