### PR TITLE
Add custom gradient component

### DIFF
--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -154,6 +154,8 @@ function gutenberg_experiments_editor_settings( $settings ) {
 		$experiments_settings['gradients'] = $gradient_presets;
 	}
 
+	$experiments_settings['disableCustomGradients'] = get_theme_support( '__experimental-disable-custom-gradients' );
+
 	return array_merge( $settings, $experiments_settings );
 }
 add_filter( 'block_editor_settings', 'gutenberg_experiments_editor_settings' );

--- a/package-lock.json
+++ b/package-lock.json
@@ -7713,6 +7713,7 @@
 				"clipboard": "^2.0.1",
 				"dom-scroll-into-view": "^1.2.1",
 				"downshift": "^3.3.4",
+				"gradient-parser": "^0.1.5",
 				"lodash": "^4.17.15",
 				"memize": "^1.0.5",
 				"moment": "^2.22.1",
@@ -18197,6 +18198,11 @@
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
 			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
 			"dev": true
+		},
+		"gradient-parser": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/gradient-parser/-/gradient-parser-0.1.5.tgz",
+			"integrity": "sha1-DH4heVWeXOfY1x9EI6+TcQCyJIw="
 		},
 		"growly": {
 			"version": "1.3.0",

--- a/packages/block-editor/src/components/color-palette/control.scss
+++ b/packages/block-editor/src/components/color-palette/control.scss
@@ -1,4 +1,0 @@
-.block-editor-color-palette-control__color-palette {
-	display: inline-block;
-	margin-top: 0.6rem;
-}

--- a/packages/block-editor/src/components/gradient-picker/control.js
+++ b/packages/block-editor/src/components/gradient-picker/control.js
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { isEmpty } from 'lodash';
+import { isEmpty, pick } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -17,11 +17,14 @@ import { useSelect } from '@wordpress/data';
  */
 import GradientPicker from './';
 
-export default function( { className, label = __( 'Gradient Presets' ), ...props } ) {
-	const gradients = useSelect( ( select ) => (
-		select( 'core/block-editor' ).getSettings().gradients
+export default function( { className, value, onChange, label = __( 'Gradient Presets' ), ...props } ) {
+	const { gradients = [], disableCustomGradients } = useSelect( ( select ) => (
+		pick(
+			select( 'core/block-editor' ).getSettings(),
+			[ 'gradients', 'disableCustomGradients' ]
+		)
 	) );
-	if ( isEmpty( gradients ) ) {
+	if ( isEmpty( gradients ) && disableCustomGradients ) {
 		return null;
 	}
 	return (
@@ -35,8 +38,11 @@ export default function( { className, label = __( 'Gradient Presets' ), ...props
 				{ label }
 			</BaseControl.VisualLabel>
 			<GradientPicker
+				value={ value }
+				onChange={ onChange }
 				className="block-editor-gradient-picker-control__gradient-picker-presets"
 				gradients={ gradients }
+				disableCustomGradients={ disableCustomGradients }
 				{ ...props }
 			/>
 		</BaseControl>

--- a/packages/block-editor/src/components/gradient-picker/control.scss
+++ b/packages/block-editor/src/components/gradient-picker/control.scss
@@ -1,4 +1,0 @@
-.block-editor-gradient-picker-control__gradient-picker-presets {
-	display: inline-block;
-	margin-top: 0.6rem;
-}

--- a/packages/block-editor/src/components/gradient-picker/index.js
+++ b/packages/block-editor/src/components/gradient-picker/index.js
@@ -1,3 +1,9 @@
+
+/**
+ * External dependencies
+ */
+import { pick } from 'lodash';
+
 /**
  * WordPress dependencies
  */
@@ -5,19 +11,23 @@ import { __experimentalGradientPicker } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 
 function GradientPickerWithGradients( props ) {
-	const gradients = useSelect( ( select ) => (
-		select( 'core/block-editor' ).getSettings().gradients
+	const { gradients, disableCustomGradients } = useSelect( ( select ) => (
+		pick(
+			select( 'core/block-editor' ).getSettings(),
+			[ 'gradients', 'disableCustomGradients' ]
+		)
 	) );
 	return (
 		<__experimentalGradientPicker
+			gradients={ props.gradients !== undefined ? props.gradient : gradients }
+			disableCustomGradients={ props.disableCustomGradients !== undefined ? props.disableCustomGradients : disableCustomGradients }
 			{ ...props }
-			gradients={ gradients }
 		/>
 	);
 }
 
 export default function( props ) {
-	const ComponentToUse = props.gradients ?
+	const ComponentToUse = props.gradients !== undefined && props.disableCustomGradients !== undefined ?
 		__experimentalGradientPicker :
 		GradientPickerWithGradients;
 	return ( <ComponentToUse { ...props } /> );

--- a/packages/block-editor/src/style.scss
+++ b/packages/block-editor/src/style.scss
@@ -17,10 +17,8 @@
 @import "./components/block-toolbar/style.scss";
 @import "./components/block-types-list/style.scss";
 @import "./components/button-block-appender/style.scss";
-@import "./components/color-palette/control.scss";
 @import "./components/contrast-checker/style.scss";
 @import "./components/default-block-appender/style.scss";
-@import "./components/gradient-picker/control.scss";
 @import "./components/link-control/style.scss";
 @import "./components/inner-blocks/style.scss";
 @import "./components/inserter-with-shortcuts/style.scss";

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -461,6 +461,7 @@ function CoverEdit( {
 							clearable={ false }
 						/>
 						<__experimentalGradientPicker
+							disableCustomGradients
 							onChange={
 								( newGradient ) => {
 									setGradient( newGradient );

--- a/packages/block-library/src/cover/editor.scss
+++ b/packages/block-library/src/cover/editor.scss
@@ -36,7 +36,7 @@
 
 	.wp-block-cover__placeholder-background-options {
 		// wraps about 6 color swatches
-		max-width: 290px;
+		max-width: 260px;
 		margin-top: 1em;
 		width: 100%;
 	}

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -39,6 +39,7 @@
 		"clipboard": "^2.0.1",
 		"dom-scroll-into-view": "^1.2.1",
 		"downshift": "^3.3.4",
+		"gradient-parser": "^0.1.5",
 		"lodash": "^4.17.15",
 		"memize": "^1.0.5",
 		"moment": "^2.22.1",

--- a/packages/components/src/circular-option-picker/index.js
+++ b/packages/components/src/circular-option-picker/index.js
@@ -90,10 +90,12 @@ export default function CircularOptionPicker( {
 	actions,
 	className,
 	options,
+	children,
 } ) {
 	return (
 		<div className={ classnames( 'components-circular-option-picker', className ) }>
 			{ options }
+			{ children }
 			{ actions && (
 				<div className="components-circular-option-picker__custom-clear-wrapper">
 					{ actions }

--- a/packages/components/src/circular-option-picker/style.scss
+++ b/packages/components/src/circular-option-picker/style.scss
@@ -1,12 +1,12 @@
 $color-palette-circle-size: 28px;
-$color-palette-circle-spacing: 14px;
+$color-palette-circle-spacing: 12px;
 
 .components-circular-option-picker {
-	margin-right: -14px;
-	width: calc(100% + 14px);
+	display: inline-block;
+	margin-top: 0.6rem;
+	width: 100%;
 
 	.components-circular-option-picker__custom-clear-wrapper {
-		width: calc(100% - 14px);
 		display: flex;
 		justify-content: flex-end;
 	}
@@ -22,6 +22,7 @@ $color-palette-circle-spacing: 14px;
 	transform: scale(1);
 	transition: 100ms transform ease;
 	@include reduce-motion("transition");
+
 	&:hover {
 		transform: scale(1.2);
 	}
@@ -30,6 +31,10 @@ $color-palette-circle-spacing: 14px;
 	& > div {
 		height: 100%;
 		width: 100%;
+	}
+
+	&:nth-child(6n+6) {
+		margin-right: 0;
 	}
 }
 

--- a/packages/components/src/custom-gradient-picker/constants.js
+++ b/packages/components/src/custom-gradient-picker/constants.js
@@ -1,0 +1,11 @@
+export const INSERT_POINT_WIDTH = 23;
+export const GRADIENT_MARKERS_WIDTH = 18;
+export const MINIMUM_DISTANCE_BETWEEN_INSERTER_AND_MARKER = ( INSERT_POINT_WIDTH + GRADIENT_MARKERS_WIDTH ) / 2;
+export const MINIMUM_ABSOLUTE_LEFT_POSITION = 5;
+export const MINIMUM_DISTANCE_BETWEEN_POINTS = 9;
+export const MINIMUM_SIGNIFICANT_MOVE = 5;
+export const DEFAULT_GRADIENT = 'linear-gradient(135deg, rgba(6, 147, 227, 1) 0%, rgb(155, 81, 224) 100%)';
+export const COLOR_POPOVER_PROPS = {
+	className: 'components-custom-gradient-picker__color-picker-popover',
+	position: 'top',
+};

--- a/packages/components/src/custom-gradient-picker/control-points.js
+++ b/packages/components/src/custom-gradient-picker/control-points.js
@@ -1,0 +1,278 @@
+
+/**
+ * External dependencies
+ */
+import { map } from 'lodash';
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { Component, useCallback, useRef, useMemo } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { withInstanceId } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import Button from '../button';
+import ColorPicker from '../color-picker';
+import Dropdown from '../dropdown';
+import { serializeGradientColor, serializeGradientPosition } from './serializer';
+import {
+	getGradientWithColorAtIndexChanged,
+	getGradientWithControlPointRemoved,
+	getGradientWithPositionAtIndexChanged,
+	getGradientWithPositionAtIndexDecreased,
+	getGradientWithPositionAtIndexIncreased,
+	getHorizontalRelativeGradientPosition,
+	isControlPointOverlapping,
+} from './utils';
+import {
+	COLOR_POPOVER_PROPS,
+	GRADIENT_MARKERS_WIDTH,
+	MINIMUM_SIGNIFICANT_MOVE,
+} from './constants';
+import KeyboardShortcuts from '../keyboard-shortcuts';
+
+export function useMarkerPoints( parsedGradient, maximumAbsolutePositionValue ) {
+	return useMemo(
+		() => {
+			if ( ! parsedGradient ) {
+				return [];
+			}
+			return map( parsedGradient.colorStops, ( colorStop ) => {
+				if ( ! colorStop || ! colorStop.length || colorStop.length.type !== '%' ) {
+					return null;
+				}
+				return {
+					color: serializeGradientColor( colorStop ),
+					position: serializeGradientPosition( colorStop.length ),
+					positionValue: parseInt( colorStop.length.value ),
+				};
+			} );
+		},
+		[ parsedGradient, maximumAbsolutePositionValue ]
+	);
+}
+
+class ControlPointKeyboardMove extends Component {
+	constructor() {
+		super( ...arguments );
+		this.increase = this.increase.bind( this );
+		this.decrease = this.decrease.bind( this );
+		this.shortcuts = {
+			right: () => this.increase(),
+			left: () => this.decrease(),
+		};
+	}
+	increase() {
+		const { gradientIndex, onChange, parsedGradient } = this.props;
+		onChange( getGradientWithPositionAtIndexIncreased( parsedGradient, gradientIndex ) );
+	}
+
+	decrease() {
+		const { gradientIndex, onChange, parsedGradient } = this.props;
+		onChange( getGradientWithPositionAtIndexDecreased( parsedGradient, gradientIndex ) );
+	}
+	render() {
+		const { children } = this.props;
+		return (
+			<KeyboardShortcuts shortcuts={ this.shortcuts }>
+				{ children }
+			</KeyboardShortcuts>
+		);
+	}
+}
+
+const ControlPointButton = withInstanceId(
+	function( {
+		instanceId,
+		isOpen,
+		position,
+		color,
+		onChange,
+		gradientIndex,
+		parsedGradient,
+		...additionalProps
+	} ) {
+		const descriptionId = `components-custom-gradient-picker__control-point-button-description-${ instanceId }`;
+		return (
+			<ControlPointKeyboardMove
+				onChange={ onChange }
+				gradientIndex={ gradientIndex }
+				parsedGradient={ parsedGradient }
+			>
+				<Button
+					aria-label={
+						sprintf(
+							// translators: %1$s: gradient position e.g: 70%, %2$s: gradient color code e.g: rgb( 52,121,151).
+							__( 'Gradient control point at position %1$s with color code %2$s.' ),
+							position,
+							color
+						)
+					}
+					aria-describedby={ descriptionId }
+					aria-expanded={ isOpen }
+					className={
+						classnames(
+							'components-custom-gradient-picker__control-point-button',
+							{ 'is-active': isOpen }
+						)
+					}
+					style={ {
+						left: position,
+					} }
+					{ ...additionalProps }
+				/>
+				<div
+					className="screen-reader-text"
+					id={ descriptionId }>
+					{ __(
+						'Use your left or right arrow keys or drag&drop with the mouse to change the gradient position. Press the button to change the color or remove the control point.'
+					) }
+				</div>
+			</ControlPointKeyboardMove>
+		);
+	}
+);
+
+export function ControlPoints( {
+	gradientPickerDomRef,
+	ignoreMarkerPosition,
+	markerPoints,
+	onChange,
+	parsedGradient,
+	setIsInsertPointMoveEnabled,
+} ) {
+	const controlPointMoveState = useRef();
+	const controlPointMove = useCallback(
+		( event ) => {
+			const relativePosition = getHorizontalRelativeGradientPosition(
+				event.clientX,
+				gradientPickerDomRef.current,
+				GRADIENT_MARKERS_WIDTH,
+			);
+			const { parsedGradient: referenceParsedGradient, position, significantMoveHappened } = controlPointMoveState.current;
+			if ( ! significantMoveHappened ) {
+				const initialPosition = referenceParsedGradient.colorStops[ position ].length.value;
+				if ( Math.abs( initialPosition - relativePosition ) >= MINIMUM_SIGNIFICANT_MOVE ) {
+					controlPointMoveState.current.significantMoveHappened = true;
+				}
+			}
+
+			if ( ! isControlPointOverlapping( parsedGradient, relativePosition, position ) ) {
+				onChange(
+					getGradientWithPositionAtIndexChanged( referenceParsedGradient, position, relativePosition )
+				);
+			}
+		},
+		[ controlPointMoveState, onChange, gradientPickerDomRef ]
+	);
+
+	const onMouseUp = useCallback(
+		() => {
+			if ( window && window.removeEventListener ) {
+				window.removeEventListener( 'mousemove', controlPointMove );
+				window.removeEventListener( 'mouseup', onMouseUp );
+			}
+		},
+		[ controlPointMove ]
+	);
+
+	const controlPointMouseDown = useMemo(
+		() => {
+			return parsedGradient.colorStops.map(
+				( colorStop, index ) => () => {
+					if ( window && window.addEventListener ) {
+						controlPointMoveState.current = {
+							parsedGradient,
+							position: index,
+							significantMoveHappened: false,
+						};
+						window.addEventListener( 'mousemove', controlPointMove );
+						window.addEventListener( 'mouseup', onMouseUp );
+					}
+				}
+			);
+		},
+		[ parsedGradient, controlPointMove, onMouseUp, controlPointMoveState ]
+	);
+
+	const enableInsertPointMove = useCallback(
+		() => {
+			setIsInsertPointMoveEnabled( true );
+		},
+		[ setIsInsertPointMoveEnabled ]
+	);
+
+	const keyboardShortcuts = useMemo(
+		() => {
+			return parsedGradient.colorStops.map(
+				( colorStop, index ) => {
+					return {
+						left: () => onChange( getGradientWithPositionAtIndexDecreased( parsedGradient, index ) ),
+						right: () => onChange( getGradientWithPositionAtIndexIncreased( parsedGradient, index ) ),
+					};
+				}
+			);
+		},
+		[ parsedGradient, onChange ]
+	);
+
+	return markerPoints.map(
+		( point, index ) => (
+			point && ignoreMarkerPosition !== point.positionValue && (
+				<Dropdown
+					key={ index }
+					onClose={ enableInsertPointMove }
+					renderToggle={ ( { isOpen, onToggle } ) => (
+						<ControlPointButton
+							keyboardShortcuts={ keyboardShortcuts[ index ] }
+							onClick={ () => {
+								if ( controlPointMoveState.current.significantMoveHappened ) {
+									return;
+								}
+								onToggle();
+								setIsInsertPointMoveEnabled( false );
+							} }
+							onMouseDown={ controlPointMouseDown[ index ] }
+							isOpen={ isOpen }
+							position={ point.position }
+							color={ point.color }
+							onChange={ onChange }
+							parsedGradient={ parsedGradient }
+							gradientIndex={ index }
+						/>
+					) }
+					renderContent={ ( { onClose } ) => (
+						<>
+							<ColorPicker
+								color={ point.color }
+								onChangeComplete={ ( { rgb } ) => {
+									onChange(
+										getGradientWithColorAtIndexChanged( parsedGradient, index, rgb )
+									);
+								} }
+							/>
+							<Button
+								className="components-custom-gradient-picker__remove-control-point"
+								onClick={ () => {
+									onChange(
+										getGradientWithControlPointRemoved( parsedGradient, index )
+									);
+									setIsInsertPointMoveEnabled( true );
+									onClose();
+								} }
+								isLink
+							>
+								{ __( 'Remove Control Point' ) }
+							</Button>
+						</>
+					) }
+					popoverProps={ COLOR_POPOVER_PROPS }
+				/>
+			)
+		)
+	);
+}

--- a/packages/components/src/custom-gradient-picker/control-points.js
+++ b/packages/components/src/custom-gradient-picker/control-points.js
@@ -112,7 +112,7 @@ const ControlPointButton = withInstanceId(
 					className="screen-reader-text"
 					id={ descriptionId }>
 					{ __(
-						'Use your left or right arrow keys or drag&drop with the mouse to change the gradient position. Press the button to change the color or remove the control point.'
+						'Use your left or right arrow keys or drag and drop with the mouse to change the gradient position. Press the button to change the color or remove the control point.'
 					) }
 				</div>
 			</ControlPointKeyboardMove>

--- a/packages/components/src/custom-gradient-picker/control-points.js
+++ b/packages/components/src/custom-gradient-picker/control-points.js
@@ -89,7 +89,7 @@ const ControlPointButton = withInstanceId(
 				<Button
 					aria-label={
 						sprintf(
-							// translators: %1$s: gradient position e.g: 70%, %2$s: gradient color code e.g: rgb( 52,121,151).
+							// translators: %1$s: gradient position e.g: 70%, %2$s: gradient color code e.g: rgb(52,121,151).
 							__( 'Gradient control point at position %1$s with color code %2$s.' ),
 							position,
 							color

--- a/packages/components/src/custom-gradient-picker/index.js
+++ b/packages/components/src/custom-gradient-picker/index.js
@@ -1,0 +1,204 @@
+
+/**
+ * External dependencies
+ */
+import gradientParser from 'gradient-parser';
+import { some } from 'lodash';
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { useCallback, useState, useRef, useMemo } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import IconButton from '../icon-button';
+import ColorPicker from '../color-picker';
+import Dropdown from '../dropdown';
+import { useMarkerPoints, ControlPoints } from './control-points';
+import {
+	DEFAULT_GRADIENT,
+	INSERT_POINT_WIDTH,
+	COLOR_POPOVER_PROPS,
+	MINIMUM_DISTANCE_BETWEEN_POINTS,
+} from './constants';
+import { serializeGradient } from './serializer';
+import { getHorizontalRelativeGradientPosition, getGradientWithColorStopAdded, getGradientWithColorAtPositionChanged } from './utils';
+
+function InsertPoint( {
+	onChange,
+	parsedGradient,
+	insertPointPosition,
+	setIsInsertPointMoveEnabled,
+	isInsertingColorAtPosition,
+	setIsInsertingColorAtPosition,
+	setInsertPointPosition,
+} ) {
+	const onColorPopoverClose = useCallback(
+		() => {
+			setIsInsertPointMoveEnabled( true );
+			setIsInsertingColorAtPosition( null );
+			setInsertPointPosition( null );
+		},
+		[ setIsInsertPointMoveEnabled, setIsInsertingColorAtPosition, setInsertPointPosition ]
+	);
+	const renderToggle = useCallback(
+		( { isOpen, onToggle } ) => (
+			<IconButton
+				aria-expanded={ isOpen }
+				onClick={ () => {
+					setIsInsertPointMoveEnabled( false );
+					onToggle();
+				} }
+				className="components-custom-gradient-picker__insert-point"
+				icon="insert"
+				style={ {
+					left: insertPointPosition !== null ? `${ insertPointPosition }%` : undefined,
+				} }
+			/>
+		),
+		[ insertPointPosition, setIsInsertPointMoveEnabled ]
+	);
+	const onColorChange = useCallback(
+		( { rgb } ) => {
+			let newGradient;
+			if ( isInsertingColorAtPosition === null ) {
+				newGradient = getGradientWithColorStopAdded( parsedGradient, insertPointPosition, rgb );
+				setIsInsertingColorAtPosition( insertPointPosition );
+			} else {
+				newGradient = getGradientWithColorAtPositionChanged( parsedGradient, isInsertingColorAtPosition, rgb );
+			}
+			onChange( newGradient );
+		},
+		[ insertPointPosition, isInsertingColorAtPosition, onChange, setIsInsertingColorAtPosition ]
+	);
+	const renderContent = useCallback(
+		() => (
+			<ColorPicker
+				onChangeComplete={ onColorChange }
+			/>
+		),
+		[ onColorChange ]
+	);
+	return (
+		<Dropdown
+			className="components-custom-gradient-picker__inserter"
+			onClose={ onColorPopoverClose }
+			renderToggle={ renderToggle }
+			renderContent={ renderContent }
+			popoverProps={ COLOR_POPOVER_PROPS }
+		/>
+	);
+}
+
+export default function CustomGradientPicker( { value, onChange } ) {
+	let hasGradient = true;
+	if ( ! value ) {
+		hasGradient = false;
+		value = DEFAULT_GRADIENT;
+	}
+	const parsedGradient = useMemo(
+		() => {
+			try {
+				return gradientParser.parse( value )[ 0 ];
+			} catch ( error ) {
+				hasGradient = false;
+				return gradientParser.parse( DEFAULT_GRADIENT )[ 0 ];
+			}
+		},
+		[ value ]
+	);
+	const onGradientStructureChange = useCallback(
+		( newGradientStructure ) => {
+			onChange( serializeGradient( newGradientStructure ) );
+		},
+		[ onChange ]
+	);
+	const [ insertPointPosition, setInsertPointPosition ] = useState( null );
+	const isInsertPointMoveEnabled = useRef( true );
+	const setIsInsertPointMoveEnabled = useCallback(
+		( isEnabled ) => {
+			isInsertPointMoveEnabled.current = isEnabled;
+		},
+		[ isInsertPointMoveEnabled ]
+	);
+	const [ isInsertingColorAtPosition, setIsInsertingColorAtPosition ] = useState( null );
+	const gradientPickerDomRef = useRef();
+	const markerPoints = useMarkerPoints( parsedGradient, gradientPickerDomRef );
+	const updateInsertPointPosition = useCallback(
+		( event ) => {
+			if ( ! gradientPickerDomRef.current || ! isInsertPointMoveEnabled.current ) {
+				return;
+			}
+			const insertPosition = getHorizontalRelativeGradientPosition(
+				event.clientX,
+				gradientPickerDomRef.current,
+				INSERT_POINT_WIDTH,
+			);
+
+			// If the insert point is close to an existing control point don't show it.
+			if ( some(
+				markerPoints,
+				( { positionValue } ) => {
+					return Math.abs( insertPosition - positionValue ) < MINIMUM_DISTANCE_BETWEEN_POINTS;
+				}
+			) ) {
+				setInsertPointPosition( null );
+				return;
+			}
+
+			setInsertPointPosition( insertPosition );
+		},
+		[ markerPoints, gradientPickerDomRef, setInsertPointPosition ]
+	);
+
+	const onMouseLeave = useCallback(
+		() => {
+			if ( ! isInsertPointMoveEnabled.current ) {
+				return;
+			}
+			setInsertPointPosition( null );
+		},
+		[ isInsertPointMoveEnabled, setInsertPointPosition ]
+	);
+
+	return (
+		<div
+			ref={ gradientPickerDomRef }
+			className={ classnames(
+				'components-custom-gradient-picker',
+				{ 'has-gradient': hasGradient }
+			) }
+			onMouseEnter={ updateInsertPointPosition }
+			onMouseMove={ updateInsertPointPosition }
+			style={ {
+				background: value,
+			} }
+			onMouseLeave={ onMouseLeave }
+		>
+			<div className="components-custom-gradient-picker__markers-container">
+				{ insertPointPosition !== null && (
+					<InsertPoint
+						setIsInsertPointMoveEnabled={ setIsInsertPointMoveEnabled }
+						insertPointPosition={ insertPointPosition }
+						isInsertingColorAtPosition={ isInsertingColorAtPosition }
+						setIsInsertingColorAtPosition={ setIsInsertingColorAtPosition }
+						onChange={ onGradientStructureChange }
+						parsedGradient={ parsedGradient }
+						setInsertPointPosition={ setInsertPointPosition }
+					/>
+				) }
+				<ControlPoints
+					gradientPickerDomRef={ gradientPickerDomRef }
+					ignoreMarkerPosition={ isInsertingColorAtPosition }
+					markerPoints={ markerPoints }
+					onChange={ onGradientStructureChange }
+					parsedGradient={ parsedGradient }
+					setIsInsertPointMoveEnabled={ setIsInsertPointMoveEnabled }
+				/>
+			</div>
+		</div>
+	);
+}

--- a/packages/components/src/custom-gradient-picker/index.js
+++ b/packages/components/src/custom-gradient-picker/index.js
@@ -9,7 +9,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { useCallback, useState, useRef, useMemo } from '@wordpress/element';
+import { useRef, useReducer, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -17,7 +17,7 @@ import { useCallback, useState, useRef, useMemo } from '@wordpress/element';
 import IconButton from '../icon-button';
 import ColorPicker from '../color-picker';
 import Dropdown from '../dropdown';
-import { useMarkerPoints, ControlPoints } from './control-points';
+import ControlPoints from './control-points';
 import {
 	DEFAULT_GRADIENT,
 	INSERT_POINT_WIDTH,
@@ -25,144 +25,167 @@ import {
 	MINIMUM_DISTANCE_BETWEEN_POINTS,
 } from './constants';
 import { serializeGradient } from './serializer';
-import { getHorizontalRelativeGradientPosition, getGradientWithColorStopAdded, getGradientWithColorAtPositionChanged } from './utils';
+import {
+	getGradientWithColorAtPositionChanged,
+	getGradientWithColorStopAdded,
+	getHorizontalRelativeGradientPosition,
+	getMarkerPoints,
+} from './utils';
 
 function InsertPoint( {
 	onChange,
-	parsedGradient,
-	insertPointPosition,
-	setIsInsertPointMoveEnabled,
-	isInsertingColorAtPosition,
-	setIsInsertingColorAtPosition,
-	setInsertPointPosition,
+	gradientAST,
+	onOpenInserter,
+	onCloseInserter,
+	insertPosition,
 } ) {
-	const onColorPopoverClose = useCallback(
-		() => {
-			setIsInsertPointMoveEnabled( true );
-			setIsInsertingColorAtPosition( null );
-			setInsertPointPosition( null );
-		},
-		[ setIsInsertPointMoveEnabled, setIsInsertingColorAtPosition, setInsertPointPosition ]
-	);
-	const renderToggle = useCallback(
-		( { isOpen, onToggle } ) => (
-			<IconButton
-				aria-expanded={ isOpen }
-				onClick={ () => {
-					setIsInsertPointMoveEnabled( false );
-					onToggle();
-				} }
-				className="components-custom-gradient-picker__insert-point"
-				icon="insert"
-				style={ {
-					left: insertPointPosition !== null ? `${ insertPointPosition }%` : undefined,
-				} }
-			/>
-		),
-		[ insertPointPosition, setIsInsertPointMoveEnabled ]
-	);
-	const onColorChange = useCallback(
-		( { rgb } ) => {
-			let newGradient;
-			if ( isInsertingColorAtPosition === null ) {
-				newGradient = getGradientWithColorStopAdded( parsedGradient, insertPointPosition, rgb );
-				setIsInsertingColorAtPosition( insertPointPosition );
-			} else {
-				newGradient = getGradientWithColorAtPositionChanged( parsedGradient, isInsertingColorAtPosition, rgb );
-			}
-			onChange( newGradient );
-		},
-		[ insertPointPosition, isInsertingColorAtPosition, onChange, setIsInsertingColorAtPosition ]
-	);
-	const renderContent = useCallback(
-		() => (
-			<ColorPicker
-				onChangeComplete={ onColorChange }
-			/>
-		),
-		[ onColorChange ]
-	);
+	const [ alreadyInsertedPoint, setAlreadyInsertedPoint ] = useState( false );
 	return (
 		<Dropdown
 			className="components-custom-gradient-picker__inserter"
-			onClose={ onColorPopoverClose }
-			renderToggle={ renderToggle }
-			renderContent={ renderContent }
+			onClose={ () => {
+				onCloseInserter();
+			} }
+			renderToggle={ ( { isOpen, onToggle } ) => (
+				<IconButton
+					aria-expanded={ isOpen }
+					onClick={ () => {
+						setAlreadyInsertedPoint( false );
+						onOpenInserter();
+						onToggle();
+					} }
+					className="components-custom-gradient-picker__insert-point"
+					icon="insert"
+					style={ {
+						left: insertPosition !== null ? `${ insertPosition }%` : undefined,
+					} }
+				/>
+			) }
+			renderContent={ () => (
+				<ColorPicker
+					onChangeComplete={ ( { rgb } ) => {
+						let newGradient;
+						if ( alreadyInsertedPoint ) {
+							newGradient = getGradientWithColorAtPositionChanged( gradientAST, insertPosition, rgb );
+						} else {
+							newGradient = getGradientWithColorStopAdded( gradientAST, insertPosition, rgb );
+							setAlreadyInsertedPoint( true );
+						}
+						onChange( newGradient );
+					} }
+				/>
+			) }
 			popoverProps={ COLOR_POPOVER_PROPS }
 		/>
 	);
 }
 
-export default function CustomGradientPicker( { value, onChange } ) {
-	let hasGradient = true;
-	if ( ! value ) {
-		hasGradient = false;
-		value = DEFAULT_GRADIENT;
+function customGradientBarReducer( state, action ) {
+	switch ( action.type ) {
+		case 'MOVE_INSERTER':
+			if ( state.id === 'IDLE' || state.id === 'MOVING_INSERTER' ) {
+				return {
+					id: 'MOVING_INSERTER',
+					insertPosition: action.insertPosition,
+				};
+			}
+			break;
+		case 'STOP_INSERTER_MOVE':
+			if ( state.id === 'MOVING_INSERTER' ) {
+				return {
+					id: 'IDLE',
+				};
+			}
+			break;
+		case 'OPEN_INSERTER':
+			if ( state.id === 'MOVING_INSERTER' ) {
+				return {
+					id: 'INSERTING_CONTROL_POINT',
+					insertPosition: state.insertPosition,
+				};
+			}
+			break;
+		case 'CLOSE_INSERTER':
+			if ( state.id === 'INSERTING_CONTROL_POINT' ) {
+				return {
+					id: 'IDLE',
+				};
+			}
+			break;
+		case 'START_CONTROL_CHANGE':
+			if ( state.id === 'IDLE' ) {
+				return {
+					id: 'MOVING_CONTROL_POINT',
+				};
+			}
+			break;
+		case 'STOP_CONTROL_CHANGE':
+			if ( state.id === 'MOVING_CONTROL_POINT' ) {
+				return {
+					id: 'IDLE',
+				};
+			}
+			break;
 	}
-	const parsedGradient = useMemo(
-		() => {
-			try {
-				return gradientParser.parse( value )[ 0 ];
-			} catch ( error ) {
-				hasGradient = false;
-				return gradientParser.parse( DEFAULT_GRADIENT )[ 0 ];
-			}
-		},
-		[ value ]
-	);
-	const onGradientStructureChange = useCallback(
-		( newGradientStructure ) => {
-			onChange( serializeGradient( newGradientStructure ) );
-		},
-		[ onChange ]
-	);
-	const [ insertPointPosition, setInsertPointPosition ] = useState( null );
-	const isInsertPointMoveEnabled = useRef( true );
-	const setIsInsertPointMoveEnabled = useCallback(
-		( isEnabled ) => {
-			isInsertPointMoveEnabled.current = isEnabled;
-		},
-		[ isInsertPointMoveEnabled ]
-	);
-	const [ isInsertingColorAtPosition, setIsInsertingColorAtPosition ] = useState( null );
+	return state;
+}
+const customGradientBarReducerInitialState = { id: 'IDLE' };
+
+export default function CustomGradientPicker( { value, onChange } ) {
+	let hasGradient = !! value;
+	// gradientAST will contain the gradient AST as parsed by gradient-parser npm module.
+	// More information of its structure available at.
+	let gradientAST;
+	let gradientValueUsed;
+	try {
+		gradientAST = gradientParser.parse( value || DEFAULT_GRADIENT )[ 0 ];
+		gradientValueUsed = value || DEFAULT_GRADIENT;
+	} catch ( error ) {
+		hasGradient = false;
+		gradientAST = gradientParser.parse( DEFAULT_GRADIENT )[ 0 ];
+		gradientValueUsed = DEFAULT_GRADIENT;
+	}
+
+	const onGradientStructureChange = ( newGradientStructure ) => {
+		onChange( serializeGradient( newGradientStructure ) );
+	};
+
 	const gradientPickerDomRef = useRef();
-	const markerPoints = useMarkerPoints( parsedGradient, gradientPickerDomRef );
-	const updateInsertPointPosition = useCallback(
-		( event ) => {
-			if ( ! gradientPickerDomRef.current || ! isInsertPointMoveEnabled.current ) {
-				return;
-			}
-			const insertPosition = getHorizontalRelativeGradientPosition(
-				event.clientX,
-				gradientPickerDomRef.current,
-				INSERT_POINT_WIDTH,
-			);
+	const markerPoints = getMarkerPoints( gradientAST );
 
-			// If the insert point is close to an existing control point don't show it.
-			if ( some(
-				markerPoints,
-				( { positionValue } ) => {
-					return Math.abs( insertPosition - positionValue ) < MINIMUM_DISTANCE_BETWEEN_POINTS;
-				}
-			) ) {
-				setInsertPointPosition( null );
-				return;
-			}
-
-			setInsertPointPosition( insertPosition );
-		},
-		[ markerPoints, gradientPickerDomRef, setInsertPointPosition ]
+	const [ gradientBarState, gradientBarStateDispatch ] = useReducer(
+		customGradientBarReducer,
+		customGradientBarReducerInitialState
 	);
+	const onMouseEnterAndMove = ( event ) => {
+		const insertPosition = getHorizontalRelativeGradientPosition(
+			event.clientX,
+			gradientPickerDomRef.current,
+			INSERT_POINT_WIDTH,
+		);
 
-	const onMouseLeave = useCallback(
-		() => {
-			if ( ! isInsertPointMoveEnabled.current ) {
-				return;
+		// If the insert point is close to an existing control point don't show it.
+		if ( some(
+			markerPoints,
+			( { positionValue } ) => {
+				return Math.abs( insertPosition - positionValue ) < MINIMUM_DISTANCE_BETWEEN_POINTS;
 			}
-			setInsertPointPosition( null );
-		},
-		[ isInsertPointMoveEnabled, setInsertPointPosition ]
-	);
+		) ) {
+			if ( gradientBarState.id === 'MOVING_INSERTER' ) {
+				gradientBarStateDispatch( { type: 'STOP_INSERTER_MOVE' } );
+			}
+			return;
+		}
+
+		gradientBarStateDispatch( { type: 'MOVE_INSERTER', insertPosition } );
+	};
+
+	const onMouseLeave = () => {
+		gradientBarStateDispatch( { type: 'STOP_INSERTER_MOVE' } );
+	};
+
+	const isMovingInserter = gradientBarState.id === 'MOVING_INSERTER';
+	const isInsertingControlPoint = gradientBarState.id === 'INSERTING_CONTROL_POINT';
 
 	return (
 		<div
@@ -171,32 +194,39 @@ export default function CustomGradientPicker( { value, onChange } ) {
 				'components-custom-gradient-picker',
 				{ 'has-gradient': hasGradient }
 			) }
-			onMouseEnter={ updateInsertPointPosition }
-			onMouseMove={ updateInsertPointPosition }
+			onMouseEnter={ onMouseEnterAndMove }
+			onMouseMove={ onMouseEnterAndMove }
 			style={ {
-				background: value,
+				background: gradientValueUsed,
 			} }
 			onMouseLeave={ onMouseLeave }
 		>
 			<div className="components-custom-gradient-picker__markers-container">
-				{ insertPointPosition !== null && (
+				{ ( isMovingInserter || isInsertingControlPoint ) && (
 					<InsertPoint
-						setIsInsertPointMoveEnabled={ setIsInsertPointMoveEnabled }
-						insertPointPosition={ insertPointPosition }
-						isInsertingColorAtPosition={ isInsertingColorAtPosition }
-						setIsInsertingColorAtPosition={ setIsInsertingColorAtPosition }
+						insertPosition={ gradientBarState.insertPosition }
 						onChange={ onGradientStructureChange }
-						parsedGradient={ parsedGradient }
-						setInsertPointPosition={ setInsertPointPosition }
+						gradientAST={ gradientAST }
+						onOpenInserter={ () => {
+							gradientBarStateDispatch( { type: 'OPEN_INSERTER' } );
+						} }
+						onCloseInserter={ () => {
+							gradientBarStateDispatch( { type: 'CLOSE_INSERTER' } );
+						} }
 					/>
 				) }
 				<ControlPoints
 					gradientPickerDomRef={ gradientPickerDomRef }
-					ignoreMarkerPosition={ isInsertingColorAtPosition }
+					ignoreMarkerPosition={ isInsertingControlPoint ? gradientBarState.insertPosition : undefined }
 					markerPoints={ markerPoints }
 					onChange={ onGradientStructureChange }
-					parsedGradient={ parsedGradient }
-					setIsInsertPointMoveEnabled={ setIsInsertPointMoveEnabled }
+					gradientAST={ gradientAST }
+					onStartControlPointChange={ () => {
+						gradientBarStateDispatch( { type: 'START_CONTROL_CHANGE' } );
+					} }
+					onStopControlPointChange={ () => {
+						gradientBarStateDispatch( { type: 'STOP_CONTROL_CHANGE' } );
+					} }
 				/>
 			</div>
 		</div>

--- a/packages/components/src/custom-gradient-picker/serializer.js
+++ b/packages/components/src/custom-gradient-picker/serializer.js
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import { compact, get } from 'lodash';
+
+export function serializeGradientColor( { type, value } ) {
+	return `${ type }( ${ value.join( ',' ) })`;
+}
+
+export function serializeGradientPosition( { type, value } ) {
+	return `${ value }${ type }`;
+}
+
+export function serializeGradientColorStop( { type, value, length } ) {
+	return `${ serializeGradientColor( { type, value } ) } ${ serializeGradientPosition( length ) }`;
+}
+
+export function serializeGradientOrientation( orientation ) {
+	if ( ! orientation || orientation.type !== 'angular' ) {
+		return;
+	}
+	return `${ orientation.value }deg`;
+}
+
+export function serializeGradient( { type, orientation, colorStops } ) {
+	const serializedOrientation = serializeGradientOrientation( orientation );
+	const serializedColorStops = colorStops.sort( ( colorStop1, colorStop2 ) => {
+		return get( colorStop1, [ 'length', 'value' ], 0 ) - get( colorStop2, [ 'length', 'value' ], 0 );
+	} ).map( serializeGradientColorStop );
+	return `${ type }( ${ compact( [ serializedOrientation, ...serializedColorStops ] ).join( ', ' ) } )`;
+}

--- a/packages/components/src/custom-gradient-picker/serializer.js
+++ b/packages/components/src/custom-gradient-picker/serializer.js
@@ -4,7 +4,7 @@
 import { compact, get } from 'lodash';
 
 export function serializeGradientColor( { type, value } ) {
-	return `${ type }( ${ value.join( ',' ) })`;
+	return `${ type }(${ value.join( ',' ) })`;
 }
 
 export function serializeGradientPosition( { type, value } ) {
@@ -27,5 +27,5 @@ export function serializeGradient( { type, orientation, colorStops } ) {
 	const serializedColorStops = colorStops.sort( ( colorStop1, colorStop2 ) => {
 		return get( colorStop1, [ 'length', 'value' ], 0 ) - get( colorStop2, [ 'length', 'value' ], 0 );
 	} ).map( serializeGradientColorStop );
-	return `${ type }( ${ compact( [ serializedOrientation, ...serializedColorStops ] ).join( ', ' ) } )`;
+	return `${ type }(${ compact( [ serializedOrientation, ...serializedColorStops ] ).join( ',' ) })`;
 }

--- a/packages/components/src/custom-gradient-picker/style.scss
+++ b/packages/components/src/custom-gradient-picker/style.scss
@@ -1,0 +1,57 @@
+$components-custom-gradient-picker__padding: 3px; // 24px container, 18px handles inside, that leaves 6px padding, half of which is 3.
+
+.components-custom-gradient-picker:not(.has-gradient) {
+	opacity: 0.4;
+}
+
+.components-custom-gradient-picker {
+	width: 100%;
+	height: $icon-button-size-small;
+	border-radius: $icon-button-size-small;
+	margin-bottom: $grid-size;
+	padding-left: $components-custom-gradient-picker__padding;
+	padding-right: $icon-button-size-small - $components-custom-gradient-picker__padding;
+
+	.components-custom-gradient-picker__markers-container {
+		position: relative;
+	}
+
+	.components-custom-gradient-picker__insert-point {
+		border-radius: 50%;
+		background: $white;
+		padding: 2px;
+		width: $icon-button-size-small;
+		height: $icon-button-size-small;
+		position: relative;
+	}
+
+	.components-custom-gradient-picker__control-point-button {
+		border: 2px solid $white;
+		border-radius: 50%;
+		height: 18px;
+		position: absolute;
+		width: 18px;
+		top: $components-custom-gradient-picker__padding;
+
+		&.is-active {
+			background: #fafafa;
+			color: #23282d;
+			border-color: #999;
+			box-shadow:
+				inset 0 -1px 0 #999,
+				0 0 0 1px $white,
+				0 0 0 3px $blue-medium-focus;
+		}
+	}
+}
+
+.components-custom-gradient-picker__color-picker-popover .components-custom-gradient-picker__remove-control-point {
+	margin-left: auto;
+	margin-right: auto;
+	display: block;
+	margin-bottom: 8px;
+}
+
+.components-custom-gradient-picker__inserter {
+	width: 100%;
+}

--- a/packages/components/src/custom-gradient-picker/test/serializer.js
+++ b/packages/components/src/custom-gradient-picker/test/serializer.js
@@ -1,0 +1,96 @@
+/**
+ * Internal dependencies
+ */
+import {
+	serializeGradientColor,
+	serializeGradientPosition,
+	serializeGradientColorStop,
+	serializeGradientOrientation,
+	serializeGradient,
+} from '../serializer';
+
+describe( 'It should serialize a gradient', () => {
+	test( 'serializeGradientColor', () => {
+		expect( serializeGradientColor(
+			{ type: 'rgba', value: [ 1, 2, 3, 0.5 ] }
+		) ).toBe( 'rgba(1,2,3,0.5)' );
+
+		expect( serializeGradientColor(
+			{ type: 'rgb', value: [ 255, 0, 0 ] }
+		) ).toBe( 'rgb(255,0,0)' );
+	} );
+
+	test( 'serializeGradientPosition', () => {
+		expect( serializeGradientPosition(
+			{ type: '%', value: 70 }
+		) ).toBe( '70%' );
+
+		expect( serializeGradientPosition(
+			{ type: '%', value: 0 }
+		) ).toBe( '0%' );
+
+		expect( serializeGradientPosition(
+			{ type: 'px', value: 4 }
+		) ).toBe( '4px' );
+	} );
+
+	test( 'serializeGradientColorStop', () => {
+		expect( serializeGradientColorStop(
+			{ type: 'rgba', value: [ 1, 2, 3, 0.5 ], length: { type: '%', value: 70 } }
+		) ).toBe( 'rgba(1,2,3,0.5) 70%' );
+
+		expect( serializeGradientColorStop(
+			{ type: 'rgb', value: [ 255, 0, 0 ], length: { type: '%', value: 0 } }
+		) ).toBe( 'rgb(255,0,0) 0%' );
+
+		expect( serializeGradientColorStop(
+			{ type: 'rgba', value: [ 1, 2, 3, 0.5 ], length: { type: 'px', value: 100 } }
+		) ).toBe( 'rgba(1,2,3,0.5) 100px' );
+	} );
+
+	test( 'serializeGradientOrientation', () => {
+		expect( serializeGradientOrientation(
+			{ type: 'angular', value: 40 }
+		) ).toBe( '40deg' );
+
+		expect( serializeGradientOrientation(
+			{ type: 'angular', value: 0 }
+		) ).toBe( '0deg' );
+	} );
+
+	test( 'serializeGradient', () => {
+		expect( serializeGradient(
+			{
+				type: 'linear-gradient',
+				orientation: { type: 'angular', value: 40 },
+				colorStops: [
+					{ type: 'rgba', value: [ 1, 2, 3, 0.5 ], length: { type: '%', value: 70 } },
+					{ type: 'rgba', value: [ 255, 1, 1, 0.9 ], length: { type: '%', value: 40 } },
+				],
+			}
+		) ).toBe( 'linear-gradient(40deg,rgba(255,1,1,0.9) 40%,rgba(1,2,3,0.5) 70%)' );
+
+		expect( serializeGradient(
+			{
+				type: 'linear-gradient',
+				colorStops: [
+					{ type: 'rgba', value: [ 1, 2, 3, 0.5 ], length: { type: '%', value: 70 } },
+					{ type: 'rgba', value: [ 255, 1, 1, 0.9 ], length: { type: '%', value: 40 } },
+				],
+			}
+		) ).toBe( 'linear-gradient(rgba(255,1,1,0.9) 40%,rgba(1,2,3,0.5) 70%)' );
+
+		expect( serializeGradient(
+			{
+				type: 'linear-gradient',
+				orientation: { type: 'angular', value: 0 },
+				colorStops: [
+					{ type: 'rgba', value: [ 1, 2, 3, 0.5 ], length: { type: '%', value: 0 } },
+					{ type: 'rgba', value: [ 255, 1, 1, 0.9 ], length: { type: '%', value: 40 } },
+					{ type: 'rgba', value: [ 1, 2, 3, 0.5 ], length: { type: '%', value: 100 } },
+					{ type: 'rgba', value: [ 10, 20, 30, 0.5 ], length: { type: '%', value: 20 } },
+				],
+			}
+		) ).toBe( 'linear-gradient(0deg,rgba(1,2,3,0.5) 0%,rgba(10,20,30,0.5) 20%,rgba(255,1,1,0.9) 40%,rgba(1,2,3,0.5) 100%)' );
+	} );
+} );

--- a/packages/components/src/custom-gradient-picker/utils.js
+++ b/packages/components/src/custom-gradient-picker/utils.js
@@ -149,7 +149,7 @@ export function getHorizontalRelativeGradientPosition( mouseXCoordinate, contain
 }
 
 /**
- * Get the connection state.
+ * Returns the marker points from a gradient AST.
  *
  * @param {Object} gradientAST An object representing the gradient AST.
  *

--- a/packages/components/src/custom-gradient-picker/utils.js
+++ b/packages/components/src/custom-gradient-picker/utils.js
@@ -1,0 +1,145 @@
+/**
+ * External dependencies
+ */
+import { findIndex, some } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import {
+	INSERT_POINT_WIDTH,
+	MINIMUM_ABSOLUTE_LEFT_POSITION,
+	MINIMUM_DISTANCE_BETWEEN_POINTS,
+} from './constants';
+
+function tinyColorRgbToGradientColorStop( { r, g, b, a } ) {
+	if ( a === 1 ) {
+		return {
+			type: 'rgb',
+			value: [ r, g, b ],
+		};
+	}
+	return {
+		type: 'rgba',
+		value: [ r, g, b, a ],
+	};
+}
+
+export function getGradientWithColorStopAdded( parsedGradient, relativePosition, rgbaColor ) {
+	const colorStop = tinyColorRgbToGradientColorStop( rgbaColor );
+	colorStop.length = {
+		type: '%',
+		value: relativePosition,
+	};
+	return {
+		...parsedGradient,
+		colorStops: [
+			...parsedGradient.colorStops,
+			colorStop,
+		],
+	};
+}
+
+export function getGradientWithPositionAtIndexChanged( parsedGradient, index, relativePosition ) {
+	return {
+		...parsedGradient,
+		colorStops: parsedGradient.colorStops.map(
+			( colorStop, colorStopIndex ) => {
+				if ( colorStopIndex !== index ) {
+					return colorStop;
+				}
+				return {
+					...colorStop,
+					length: {
+						...colorStop.length,
+						value: relativePosition,
+					},
+				};
+			}
+		),
+	};
+}
+
+export function isControlPointOverlapping( parsedGradient, position, initialIndex ) {
+	const initialPosition = parseInt( parsedGradient.colorStops[ initialIndex ].length.value );
+	const minPosition = Math.min( initialPosition, position );
+	const maxPosition = Math.max( initialPosition, position );
+
+	return some(
+		parsedGradient.colorStops,
+		( { length }, index ) => {
+			const itemPosition = parseInt( length.value );
+			return index !== initialIndex && (
+				Math.abs( itemPosition - position ) < MINIMUM_DISTANCE_BETWEEN_POINTS ||
+				( minPosition < itemPosition && itemPosition < maxPosition )
+			);
+		}
+	);
+}
+
+function getGradientWithPositionAtIndexSummed( parsedGradient, index, valueToSum ) {
+	const currentPosition = parsedGradient.colorStops[ index ].length.value;
+	const newPosition = Math.max( 0, Math.min( 100, parseInt( currentPosition ) + valueToSum ) );
+	if ( isControlPointOverlapping( parsedGradient, newPosition, index ) ) {
+		return parsedGradient;
+	}
+	return getGradientWithPositionAtIndexChanged( parsedGradient, index, newPosition );
+}
+
+export function getGradientWithPositionAtIndexIncreased( parsedGradient, index ) {
+	return getGradientWithPositionAtIndexSummed( parsedGradient, index, MINIMUM_DISTANCE_BETWEEN_POINTS );
+}
+
+export function getGradientWithPositionAtIndexDecreased( parsedGradient, index ) {
+	return getGradientWithPositionAtIndexSummed( parsedGradient, index, -MINIMUM_DISTANCE_BETWEEN_POINTS );
+}
+
+export function getGradientWithColorAtIndexChanged( parsedGradient, index, rgbaColor ) {
+	return {
+		...parsedGradient,
+		colorStops: parsedGradient.colorStops.map(
+			( colorStop, colorStopIndex ) => {
+				if ( colorStopIndex !== index ) {
+					return colorStop;
+				}
+				return {
+					...colorStop,
+					...tinyColorRgbToGradientColorStop( rgbaColor ),
+				};
+			}
+		),
+	};
+}
+
+export function getGradientWithColorAtPositionChanged( parsedGradient, relativePositionValue, rgbaColor ) {
+	const index = findIndex( parsedGradient.colorStops, ( colorStop ) => {
+		return (
+			colorStop &&
+			colorStop.length &&
+			colorStop.length.type === '%' &&
+			colorStop.length.value === relativePositionValue.toString()
+		);
+	} );
+	return getGradientWithColorAtIndexChanged( parsedGradient, index, rgbaColor );
+}
+
+export function getGradientWithControlPointRemoved( parsedGradient, index ) {
+	return {
+		...parsedGradient,
+		colorStops: parsedGradient.colorStops.filter( ( elem, elemIndex ) => {
+			return elemIndex !== index;
+		} ),
+	};
+}
+
+export function getHorizontalRelativeGradientPosition( mouseXCoordinate, containerElement, positionedElementWidth ) {
+	if ( ! containerElement ) {
+		return;
+	}
+	const { x, width } = containerElement.getBoundingClientRect();
+	const absolutePositionValue = mouseXCoordinate - x - MINIMUM_ABSOLUTE_LEFT_POSITION - ( positionedElementWidth / 2 );
+	const availableWidth = width - MINIMUM_ABSOLUTE_LEFT_POSITION - INSERT_POINT_WIDTH;
+	return Math.round(
+		Math.min( Math.max( ( absolutePositionValue * 100 ) / availableWidth, 0 ), 100 )
+	);
+}

--- a/packages/components/src/dropdown/index.js
+++ b/packages/components/src/dropdown/index.js
@@ -67,6 +67,9 @@ class Dropdown extends Component {
 	}
 
 	close() {
+		if ( this.props.onClose ) {
+			this.props.onClose();
+		}
 		this.setState( { isOpen: false } );
 	}
 

--- a/packages/components/src/gradient-picker/index.js
+++ b/packages/components/src/gradient-picker/index.js
@@ -13,6 +13,7 @@ import { useCallback, useMemo } from '@wordpress/element';
  * Internal dependencies
  */
 import CircularOptionPicker from '../circular-option-picker';
+import CustomGradientPicker from '../custom-gradient-picker';
 
 export default function GradientPicker( {
 	className,
@@ -20,6 +21,7 @@ export default function GradientPicker( {
 	onChange,
 	value,
 	clearable = true,
+	disableCustomGradients = false,
 } ) {
 	const clearGradient = useCallback(
 		() => onChange( undefined ),
@@ -62,6 +64,11 @@ export default function GradientPicker( {
 					{ __( 'Clear' ) }
 				</CircularOptionPicker.ButtonAction>
 			) }
-		/>
+		>
+			{ ! disableCustomGradients && ( <CustomGradientPicker
+				value={ value }
+				onChange={ onChange }
+			/> ) }
+		</CircularOptionPicker>
 	);
 }

--- a/packages/components/src/gradient-picker/index.js
+++ b/packages/components/src/gradient-picker/index.js
@@ -13,7 +13,6 @@ import { useCallback, useMemo } from '@wordpress/element';
  * Internal dependencies
  */
 import CircularOptionPicker from '../circular-option-picker';
-import CustomGradientPicker from '../custom-gradient-picker';
 
 export default function GradientPicker( {
 	className,
@@ -21,7 +20,6 @@ export default function GradientPicker( {
 	onChange,
 	value,
 	clearable = true,
-	disableCustomGradients = false,
 } ) {
 	const clearGradient = useCallback(
 		() => onChange( undefined ),
@@ -64,11 +62,6 @@ export default function GradientPicker( {
 					{ __( 'Clear' ) }
 				</CircularOptionPicker.ButtonAction>
 			) }
-		>
-			{ ! disableCustomGradients && ( <CustomGradientPicker
-				value={ value }
-				onChange={ onChange }
-			/> ) }
-		</CircularOptionPicker>
+		/>
 	);
 }

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -34,6 +34,7 @@ export { default as FormFileUpload } from './form-file-upload';
 export { default as FormToggle } from './form-toggle';
 export { default as FormTokenField } from './form-token-field';
 export { default as __experimentalGradientPicker } from './gradient-picker';
+export { default as __experimentalCustomGradientPicker } from './custom-gradient-picker';
 export { default as Guide } from './guide';
 export { default as GuidePage } from './guide/page';
 export { default as Icon } from './icon';

--- a/packages/components/src/style.scss
+++ b/packages/components/src/style.scss
@@ -7,6 +7,7 @@
 @import "./circular-option-picker/style.scss";
 @import "./color-indicator/style.scss";
 @import "./color-picker/style.scss";
+@import "./custom-gradient-picker/style.scss";
 @import "./custom-select-control/style.scss";
 @import "./dashicon/style.scss";
 @import "./date-time/style.scss";

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -92,6 +92,7 @@ class EditorProvider extends Component {
 				'colors',
 				'disableCustomColors',
 				'disableCustomFontSizes',
+				'disableCustomGradients',
 				'focusMode',
 				'fontSizes',
 				'hasFixedToolbar',


### PR DESCRIPTION
## Description
Issued discussing the design: https://github.com/WordPress/gutenberg/issues/16662


This PR is a WIP with the objective of implementing a custom gradient component.

The objective is to get something similar to:
![image](https://user-images.githubusercontent.com/11271197/65678517-5b461780-e04b-11e9-8989-0d8de7a236d3.png)

But for now, we are not yet trying to get that design pixel perfect it is more important to test the interactions.

The small gradient component should be able to:
- Add new control points in a given position with a given color.
- Change the color of the control point in a gradient.
- Remove a gradient control point.
- Move a control point position e.g: from 0% to 20%.

This version misses the ability to move a control point. The implementation is getting complex and I would like some intermediary feedback about this path before implementing it. The idea I have is simply being able to drag the control points.

Besides this small visual component we also need inputs to select between radial and linear gradients and the angle. My idea is to use our existing input components for that. We will also probably need to allow to edit the control points in a normal input for a11y reasons, using drag & drop is not accessible to everyone.

For now, I would like some feedback on what we have and thoughts if we need to change direction.


The code is not polished yet.

## How has this been tested?
I added a button.
I tried to create some gradients using the custom gradients bar.

## Screenshots <!-- if applicable -->
![Sep-26-2019 10-43-56](https://user-images.githubusercontent.com/11271197/65679219-8f6e0800-e04c-11e9-8224-fce935e28223.gif)

