### PR TITLE
RichText: run input rule on composition end

### DIFF
--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -326,7 +326,11 @@ class RichText extends Component {
 		// (CJK), do not trigger a change if characters are being composed.
 		// Browsers setting `isComposing` to `true` will usually emit a final
 		// `input` event when the characters are composed.
-		if ( event && event.nativeEvent.isComposing ) {
+		if (
+			event &&
+			event.nativeEvent &&
+			event.nativeEvent.isComposing
+		) {
 			// Also don't update any selection.
 			document.removeEventListener( 'selectionchange', this.onSelectionChange );
 			return;
@@ -335,6 +339,10 @@ class RichText extends Component {
 		let inputType;
 
 		if ( event ) {
+			inputType = event.inputType;
+		}
+
+		if ( ! inputType ) {
 			inputType = event.nativeEvent.inputType;
 		}
 
@@ -401,7 +409,7 @@ class RichText extends Component {
 	onCompositionEnd() {
 		// Ensure the value is up-to-date for browsers that don't emit a final
 		// input event after composition.
-		this.onInput();
+		this.onInput( { inputType: 'insertText' } );
 		// Tracking selection changes can be resumed.
 		document.addEventListener( 'selectionchange', this.onSelectionChange );
 	}


### PR DESCRIPTION
## Description

Fixes input rules on composition end, after #14776.

## How has this been tested?

On an American keyboard, press `` Alt+` ``, type "test", press `` Alt+` ``, and finally `Space`. The result should be `<code>test</code>`.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
