### PR TITLE
RichText: allow emoji panel at list item start

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -260,6 +260,7 @@ class RichTextWrapper extends Component {
 		const { start, text } = value;
 		const characterBefore = text.slice( start - 1, start );
 
+		// The character right before the caret must be a plain space.
 		if ( characterBefore !== ' ' ) {
 			return;
 		}

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -260,7 +260,7 @@ class RichTextWrapper extends Component {
 		const { start, text } = value;
 		const characterBefore = text.slice( start - 1, start );
 
-		if ( ! /\s/.test( characterBefore ) ) {
+		if ( characterBefore !== ' ' ) {
 			return;
 		}
 

--- a/packages/e2e-tests/specs/blocks/__snapshots__/list.test.js.snap
+++ b/packages/e2e-tests/specs/blocks/__snapshots__/list.test.js.snap
@@ -210,6 +210,12 @@ exports[`List should not undo asterisk transform with backspace after selection 
 
 exports[`List should not undo asterisk transform with backspace after typing 1`] = `""`;
 
+exports[`List should only convert to list when shortcut ends with space 1`] = `
+"<!-- wp:paragraph -->
+<p>* </p>
+<!-- /wp:paragraph -->"
+`;
+
 exports[`List should outdent with children 1`] = `
 "<!-- wp:list -->
 <ul><li>a<ul><li>b<ul><li>c</li></ul></li></ul></li></ul>

--- a/packages/e2e-tests/specs/blocks/__snapshots__/list.test.js.snap
+++ b/packages/e2e-tests/specs/blocks/__snapshots__/list.test.js.snap
@@ -194,6 +194,12 @@ exports[`List should insert a line break on shift+enter in a non trailing list i
 <!-- /wp:list -->"
 `;
 
+exports[`List should not indent list on space with modifier 1`] = `
+"<!-- wp:list -->
+<ul><li>1</li><li> </li></ul>
+<!-- /wp:list -->"
+`;
+
 exports[`List should not transform lines in block when transforming multiple blocks 1`] = `
 "<!-- wp:list -->
 <ul><li>one<br>...</li><li>two</li></ul>

--- a/packages/e2e-tests/specs/blocks/list.test.js
+++ b/packages/e2e-tests/specs/blocks/list.test.js
@@ -427,4 +427,14 @@ describe( 'List', () => {
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
+
+	it( 'should not indent list on space with modifier', async () => {
+		await clickBlockAppender();
+
+		await page.keyboard.type( '* 1' );
+		await page.keyboard.press( 'Enter' );
+		await pressKeyWithModifier( 'shift', 'Space' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
 } );

--- a/packages/e2e-tests/specs/blocks/list.test.js
+++ b/packages/e2e-tests/specs/blocks/list.test.js
@@ -437,4 +437,13 @@ describe( 'List', () => {
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
+
+	it( 'should only convert to list when shortcut ends with space', async () => {
+		await clickBlockAppender();
+
+		// Tests the shortcut with a non breaking space.
+		await page.keyboard.type( '* ' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
 } );

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -642,9 +642,14 @@ class RichText extends Component {
 	 * @param {SyntheticEvent} event A synthetic keyboard event.
 	 */
 	handleSpace( event ) {
+		const { keyCode, shiftKey, altKey, metaKey, ctrlKey } = event;
 		const { tagName, __unstableMultilineTag: multilineTag } = this.props;
 
-		if ( event.keyCode !== SPACE || multilineTag !== 'li' ) {
+		if (
+			// Only override when no modifiers are pressed.
+			shiftKey || altKey || metaKey || ctrlKey ||
+			keyCode !== SPACE || multilineTag !== 'li'
+		) {
 			return;
 		}
 


### PR DESCRIPTION
## Description

Fixes #17538.

Currently it is not possible to use `Space` together with any modifier keys at the start of a list item:

* The emoji pop up can't be opened on `MacOS` (`Ctrl+Cmd+Space`).
* You can't insert a non breaking space (`Alt+Space`).
* You can't insert a normal space character (`Shift+Space`).

This PR fixes the issues. I also added an e2e test.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
