### PR TITLE
Update class specificity of publish radio buttons

### DIFF
--- a/packages/editor/src/components/post-visibility/style.scss
+++ b/packages/editor/src/components/post-visibility/style.scss
@@ -1,8 +1,7 @@
-.edit-post-post-visibility__dialog {
-	.editor-post-visibility__dialog-fieldset {
-		padding: $grid-size-small;
-		padding-top: 0;
-	}
+.edit-post-post-visibility__dialog,
+.editor-post-visibility__dialog-fieldset {
+	padding: $grid-size-small;
+	padding-top: 0;
 
 	.editor-post-visibility__dialog-legend {
 		font-weight: 600;


### PR DESCRIPTION
Fixes #17589

This PR updates the specificity that targets the class on the radio buttons of the publish panel.

**Before the fix:**
![65645972-69ffe080-dff1-11e9-97bd-5ab39606c84d](https://user-images.githubusercontent.com/3276087/65706858-f988ac00-e050-11e9-8ff1-2dea95fdf785.png)

**After the fix:**
<img width="280" alt="Screen Shot 2019-09-26 at 11 22 14 AM" src="https://user-images.githubusercontent.com/3276087/65706889-06a59b00-e051-11e9-9c18-e73f397d97e8.png">

 