### PR TITLE
RichText: don't focus when updating store

### DIFF
--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -860,7 +860,7 @@ class RichText extends Component {
 				formats: activeFormats,
 			} );
 
-			this.applyRecord( this.record );
+			this.applyRecord( this.record, { domOnly: true } );
 		} else if (
 			this.record.start !== selectionStart ||
 			this.record.end !== selectionEnd


### PR DESCRIPTION
## Description

Fixes #17505. When updating the store, RichText shouldn't set any selection. This does NOT fix the popover issue. :) Only fixes the issue when updating the store directly.

Let's see if e2e tests pass.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

See steps to reproduce in #17505.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
