### PR TITLE
Remove margin-top from block placeholder input field

### DIFF
--- a/packages/components/src/placeholder/style.scss
+++ b/packages/components/src/placeholder/style.scss
@@ -60,6 +60,7 @@
 }
 
 .components-placeholder__input {
+	margin-top: 0;
 	margin-right: 8px;
 	flex: 1 1 auto;
 }


### PR DESCRIPTION
Fixes #17592

There's an `margin-top: 1px` being inherited from a generic `forms.css` stylesheet. I added a `margin-top: 0;` to `placeholder/style.scss` to override this.

**Before fix:**

<img width="449" alt="Screen Shot 2019-09-26 at 12 26 26 PM" src="https://user-images.githubusercontent.com/3276087/65711605-db27ae00-e05a-11e9-9a28-a7f3cf581f81.png">

**After fix:** (lines are superimposed for reference, not actually there).

<img width="436" alt="Screen Shot 2019-09-26 at 12 34 22 PM" src="https://user-images.githubusercontent.com/3276087/65711617-e1b62580-e05a-11e9-989a-a36857fc7509.png">

