### PR TITLE
RichText: restore focus after setting selection

### DIFF
--- a/packages/block-editor/src/components/rich-text/toolbar-button.js
+++ b/packages/block-editor/src/components/rich-text/toolbar-button.js
@@ -3,8 +3,17 @@
  */
 import { Fill, ToolbarButton } from '@wordpress/components';
 import { displayShortcut } from '@wordpress/keycodes';
+import { useRef } from '@wordpress/element';
 
-export function RichTextToolbarButton( { name, shortcutType, shortcutCharacter, ...props } ) {
+export function RichTextToolbarButton( {
+	name,
+	shortcutType,
+	shortcutCharacter,
+	onClick,
+	...props
+} ) {
+	const activeElement = useRef( null );
+
 	let shortcut;
 	let fillName = 'RichText.ToolbarControls';
 
@@ -21,6 +30,19 @@ export function RichTextToolbarButton( { name, shortcutType, shortcutCharacter, 
 			<ToolbarButton
 				{ ...props }
 				shortcut={ shortcut }
+				extraProps={ {
+					onMouseDown: () => {
+						activeElement.current = document.activeElement;
+					},
+				} }
+				onClick={ () => {
+					onClick( ...arguments );
+
+					if ( activeElement.current ) {
+						activeElement.current.focus();
+						activeElement.current = null;
+					}
+				} }
 			/>
 		</Fill>
 	);

--- a/packages/e2e-tests/specs/__snapshots__/rich-text.test.js.snap
+++ b/packages/e2e-tests/specs/__snapshots__/rich-text.test.js.snap
@@ -48,6 +48,12 @@ exports[`RichText should not lose selection direction 1`] = `
 <!-- /wp:paragraph -->"
 `;
 
+exports[`RichText should not return focus when tabbing to formatting button 1`] = `
+"<!-- wp:paragraph -->
+<p>Some <strong>bold</strong>.</p>
+<!-- /wp:paragraph -->"
+`;
+
 exports[`RichText should not undo backtick transform with backspace after selection change 1`] = `""`;
 
 exports[`RichText should not undo backtick transform with backspace after typing 1`] = `""`;
@@ -76,14 +82,14 @@ exports[`RichText should transform backtick to code 2`] = `
 <!-- /wp:paragraph -->"
 `;
 
-exports[`RichText should update internal selection after fresh focus 1`] = `
-"<!-- wp:paragraph -->
-<p>1<strong>2</strong></p>
-<!-- /wp:paragraph -->"
-`;
-
 exports[`RichText should undo backtick transform with backspace 1`] = `
 "<!-- wp:paragraph -->
 <p>\`a\`</p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`RichText should update internal selection after fresh focus 1`] = `
+"<!-- wp:paragraph -->
+<p>1<strong>2</strong></p>
 <!-- /wp:paragraph -->"
 `;

--- a/packages/e2e-tests/specs/blocks/list.test.js
+++ b/packages/e2e-tests/specs/blocks/list.test.js
@@ -182,6 +182,7 @@ describe( 'List', () => {
 		await page.keyboard.type( 'one' );
 		await page.keyboard.press( 'Enter' );
 		await clickBlockToolbarButton( 'Indent list item' );
+		await pressKeyTimes( 'Tab', 6 );
 		await page.keyboard.type( 'two' );
 		await transformBlockTo( 'Paragraph' );
 
@@ -264,6 +265,7 @@ describe( 'List', () => {
 		await page.keyboard.type( 'one' );
 		await page.keyboard.press( 'Enter' );
 		await clickBlockToolbarButton( 'Indent list item' );
+		await pressKeyTimes( 'Tab', 6 );
 		await page.keyboard.type( 'two' );
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( 'three' );

--- a/packages/e2e-tests/specs/plugins/annotations.test.js
+++ b/packages/e2e-tests/specs/plugins/annotations.test.js
@@ -49,6 +49,7 @@ describe( 'Using Plugins API', () => {
 		// Click add annotation button.
 		const addAnnotationButton = ( await page.$x( "//button[contains(text(), 'Add annotation')]" ) )[ 0 ];
 		await addAnnotationButton.click();
+		await page.evaluate( () => document.querySelector( '[contenteditable]' ).focus() );
 	}
 
 	/**
@@ -60,6 +61,7 @@ describe( 'Using Plugins API', () => {
 		// Click remove annotations button.
 		const addAnnotationButton = ( await page.$x( "//button[contains(text(), 'Remove annotations')]" ) )[ 0 ];
 		await addAnnotationButton.click();
+		await page.evaluate( () => document.querySelector( '[contenteditable]' ).focus() );
 	}
 
 	/**

--- a/packages/e2e-tests/specs/rich-text.test.js
+++ b/packages/e2e-tests/specs/rich-text.test.js
@@ -84,11 +84,33 @@ describe( 'RichText', () => {
 		await page.mouse.move( 0, 0 );
 		await page.mouse.move( 10, 10 );
 		await page.click( '[aria-label="Bold"]' );
-		await pressKeyTimes( 'Tab', 5 );
 		await page.keyboard.type( 'bold' );
 		await page.mouse.move( 0, 0 );
 		await page.mouse.move( 10, 10 );
 		await page.click( '[aria-label="Bold"]' );
+		await page.keyboard.type( '.' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'should not return focus when tabbing to formatting button', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( 'Some ' );
+		await pressKeyWithModifier( 'alt', 'F10' );
+		// Wait for button to receive focus.
+		await page.waitForFunction( () =>
+			document.activeElement.nodeName === 'BUTTON'
+		);
+		await pressKeyTimes( 'Tab', 2 );
+		await page.keyboard.press( 'Space' );
+		await pressKeyTimes( 'Tab', 5 );
+		await page.keyboard.type( 'bold' );
+		await pressKeyWithModifier( 'alt', 'F10' );
+		await page.waitForFunction( () =>
+			document.activeElement.nodeName === 'BUTTON'
+		);
+		await pressKeyTimes( 'Tab', 2 );
+		await page.keyboard.press( 'Space' );
 		await pressKeyTimes( 'Tab', 5 );
 		await page.keyboard.type( '.' );
 

--- a/packages/e2e-tests/specs/rich-text.test.js
+++ b/packages/e2e-tests/specs/rich-text.test.js
@@ -7,6 +7,7 @@ import {
 	insertBlock,
 	clickBlockAppender,
 	pressKeyWithModifier,
+	pressKeyTimes,
 } from '@wordpress/e2e-test-utils';
 
 describe( 'RichText', () => {
@@ -83,10 +84,12 @@ describe( 'RichText', () => {
 		await page.mouse.move( 0, 0 );
 		await page.mouse.move( 10, 10 );
 		await page.click( '[aria-label="Bold"]' );
+		await pressKeyTimes( 'Tab', 5 );
 		await page.keyboard.type( 'bold' );
 		await page.mouse.move( 0, 0 );
 		await page.mouse.move( 10, 10 );
 		await page.click( '[aria-label="Bold"]' );
+		await pressKeyTimes( 'Tab', 5 );
 		await page.keyboard.type( '.' );
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();

--- a/packages/e2e-tests/specs/rich-text.test.js
+++ b/packages/e2e-tests/specs/rich-text.test.js
@@ -7,6 +7,7 @@ import {
 	insertBlock,
 	clickBlockAppender,
 	pressKeyWithModifier,
+	pressKeyTimes,
 } from '@wordpress/e2e-test-utils';
 
 describe( 'RichText', () => {
@@ -83,10 +84,12 @@ describe( 'RichText', () => {
 		await page.mouse.move( 0, 0 );
 		await page.mouse.move( 10, 10 );
 		await page.click( '[aria-label="Bold"]' );
+		await pressKeyTimes( 'Tab', 5 );
 		await page.keyboard.type( 'bold' );
 		await page.mouse.move( 0, 0 );
 		await page.mouse.move( 10, 10 );
 		await page.click( '[aria-label="Bold"]' );
+		await pressKeyTimes( 'Tab', 5 );
 		await page.keyboard.type( '.' );
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
@@ -238,6 +241,7 @@ describe( 'RichText', () => {
 
 	it( 'should handle Home and End keys', async () => {
 		await page.keyboard.press( 'Enter' );
+		await page.evaluate( () => new Promise( window.requestAnimationFrame ) );
 
 		await pressKeyWithModifier( 'primary', 'b' );
 		await page.keyboard.type( '12' );

--- a/packages/e2e-tests/specs/rich-text.test.js
+++ b/packages/e2e-tests/specs/rich-text.test.js
@@ -7,7 +7,6 @@ import {
 	insertBlock,
 	clickBlockAppender,
 	pressKeyWithModifier,
-	pressKeyTimes,
 } from '@wordpress/e2e-test-utils';
 
 describe( 'RichText', () => {
@@ -84,12 +83,10 @@ describe( 'RichText', () => {
 		await page.mouse.move( 0, 0 );
 		await page.mouse.move( 10, 10 );
 		await page.click( '[aria-label="Bold"]' );
-		await pressKeyTimes( 'Tab', 5 );
 		await page.keyboard.type( 'bold' );
 		await page.mouse.move( 0, 0 );
 		await page.mouse.move( 10, 10 );
 		await page.click( '[aria-label="Bold"]' );
-		await pressKeyTimes( 'Tab', 5 );
 		await page.keyboard.type( '.' );
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
@@ -241,7 +238,6 @@ describe( 'RichText', () => {
 
 	it( 'should handle Home and End keys', async () => {
 		await page.keyboard.press( 'Enter' );
-		await page.evaluate( () => new Promise( window.requestAnimationFrame ) );
 
 		await pressKeyWithModifier( 'primary', 'b' );
 		await page.keyboard.type( '12' );

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -149,9 +149,9 @@ class InlineLinkUI extends Component {
 
 		if ( isCollapsed( value ) && ! isActive ) {
 			const toInsert = applyFormat( create( { text: url } ), format, 0, url.length );
-			onChange( insert( value, toInsert ) );
+			onChange( insert( value, toInsert ), { focus: true } );
 		} else {
-			onChange( applyFormat( value, format ) );
+			onChange( applyFormat( value, format ), { focus: true } );
 		}
 
 		this.resetState();

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -526,6 +526,8 @@ class RichText extends Component {
 	 * @param {Object}  $2                Named options.
 	 * @param {boolean} $2.withoutHistory If true, no undo level will be
 	 *                                    created.
+	 * @param {boolean} $2.focus          If true, the rich text element will
+	 *                                    receive focus.
 	 */
 	onChange( record, { withoutHistory, focus } = {} ) {
 		if ( focus ) {

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -282,19 +282,21 @@ class RichText extends Component {
 
 		this.recalculateBoundaryStyle();
 
-		// We know for certain that on focus, the old selection is invalid. It
-		// will be recalculated on the next mouseup, keyup, or touchend event.
-		const index = undefined;
-		const activeFormats = undefined;
+		if ( ! this.props.__unstableIsSelected ) {
+			// We know for certain that on focus, the old selection is invalid. It
+			// will be recalculated on the next mouseup, keyup, or touchend event.
+			const index = undefined;
+			const activeFormats = undefined;
 
-		this.record = {
-			...this.record,
-			start: index,
-			end: index,
-			activeFormats,
-		};
-		this.props.onSelectionChange( index, index );
-		this.setState( { activeFormats } );
+			this.record = {
+				...this.record,
+				start: index,
+				end: index,
+				activeFormats,
+			};
+			this.props.onSelectionChange( index, index );
+			this.setState( { activeFormats } );
+		}
 
 		// Update selection as soon as possible, which is at the next animation
 		// frame. The event listener for selection changes may be added too late

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -170,6 +170,8 @@ class RichText extends Component {
 	applyRecord( record, { domOnly } = {} ) {
 		const { __unstableMultilineTag: multilineTag } = this.props;
 
+		this.ignoreFocus = true;
+
 		apply( {
 			value: record,
 			current: this.editableRef,
@@ -179,6 +181,8 @@ class RichText extends Component {
 			__unstableDomOnly: domOnly,
 			placeholder: this.props.placeholder,
 		} );
+
+		this.ignoreFocus = false;
 	}
 
 	/**
@@ -275,6 +279,10 @@ class RichText extends Component {
 	 */
 	onFocus() {
 		const { unstableOnFocus } = this.props;
+
+		if ( this.ignoreFocus ) {
+			return;
+		}
 
 		if ( unstableOnFocus ) {
 			unstableOnFocus();

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -282,20 +282,6 @@ class RichText extends Component {
 
 		this.recalculateBoundaryStyle();
 
-		// We know for certain that on focus, the old selection is invalid. It
-		// will be recalculated on the next mouseup, keyup, or touchend event.
-		const index = undefined;
-		const activeFormats = undefined;
-
-		this.record = {
-			...this.record,
-			start: index,
-			end: index,
-			activeFormats,
-		};
-		this.props.onSelectionChange( index, index );
-		this.setState( { activeFormats } );
-
 		// Update selection as soon as possible, which is at the next animation
 		// frame. The event listener for selection changes may be added too late
 		// at this point, but this focus event is still too early to calculate

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -282,6 +282,20 @@ class RichText extends Component {
 
 		this.recalculateBoundaryStyle();
 
+		// We know for certain that on focus, the old selection is invalid. It
+		// will be recalculated on the next mouseup, keyup, or touchend event.
+		const index = undefined;
+		const activeFormats = undefined;
+
+		this.record = {
+			...this.record,
+			start: index,
+			end: index,
+			activeFormats,
+		};
+		this.props.onSelectionChange( index, index );
+		this.setState( { activeFormats } );
+
 		// Update selection as soon as possible, which is at the next animation
 		// frame. The event listener for selection changes may be added too late
 		// at this point, but this focus event is still too early to calculate

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -527,7 +527,11 @@ class RichText extends Component {
 	 * @param {boolean} $2.withoutHistory If true, no undo level will be
 	 *                                    created.
 	 */
-	onChange( record, { withoutHistory } = {} ) {
+	onChange( record, { withoutHistory, focus } = {} ) {
+		if ( focus ) {
+			this.editableRef.focus();
+		}
+
 		this.applyRecord( record );
 
 		const { start, end, activeFormats = [] } = record;

--- a/packages/rich-text/src/to-dom.js
+++ b/packages/rich-text/src/to-dom.js
@@ -278,10 +278,7 @@ export function applySelection( { startPath, endPath }, current ) {
 	range.setStart( startContainer, startOffset );
 	range.setEnd( endContainer, endOffset );
 
-	// Set back focus if focus is lost.
-	if ( ownerDocument.activeElement !== current ) {
-		current.focus();
-	}
+	const { activeElement } = ownerDocument;
 
 	if ( selection.rangeCount > 0 ) {
 		// If the to be added range and the live range are the same, there's no
@@ -294,4 +291,5 @@ export function applySelection( { startPath, endPath }, current ) {
 	}
 
 	selection.addRange( range );
+	activeElement.focus();
 }


### PR DESCRIPTION
## Description

Fixes #17505.

Attempt to NOT return focus to rich text after applying formatting, if focus has been moved elsewhere. This will now be the default for all buttons.

`RichText` will still allow focus to be set if it is desired, through `onChange( value, { focus: true } )`. This can be useful if you know that the currently focussed element will be removed from the DOM. This is the case for the link pop up UI.

## How has this been tested?

See #17505.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
