### PR TITLE
Update dropdown menu items to match hover style in other places

### DIFF
--- a/packages/components/src/dropdown-menu/style.scss
+++ b/packages/components/src/dropdown-menu/style.scss
@@ -79,6 +79,12 @@
 			@include menu-style__focus();
 		}
 
+		&:hover,
+		&:focus,
+		&:not(:disabled):not([aria-disabled="true"]):not(.is-default):hover {
+			@include menu-style__hover();
+		}
+
 		// Formatting buttons
 		> svg {
 			border-radius: $radius-round-rectangle;

--- a/packages/components/src/dropdown-menu/style.scss
+++ b/packages/components/src/dropdown-menu/style.scss
@@ -80,7 +80,6 @@
 		}
 
 		&:hover,
-		&:focus,
 		&:not(:disabled):not([aria-disabled="true"]):not(.is-default):hover {
 			@include menu-style__hover();
 		}


### PR DESCRIPTION
## Description
Fixes second part of #17337 (see #17581). It normalizes the hover style of the dropdown menu items.

## How has this been tested?
Tested by reviewing the styles of different dropdown menus.

## Screenshots <!-- if applicable -->
**Before the fix** (different hover styles):

<img width="1042" alt="Screen Shot 2019-09-26 at 4 39 31 PM" src="https://user-images.githubusercontent.com/3276087/65727056-4635ac80-e07c-11e9-8ed1-463227192c7c.png">

**After the fix** (styles are normalized to the solid grey background):

<img width="1546" alt="Screen Shot 2019-09-26 at 4 43 57 PM" src="https://user-images.githubusercontent.com/3276087/65727280-dd9aff80-e07c-11e9-97fb-91bd8ebef0c0.png">

## Types of changes
Visual (CSS).

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
