### PR TITLE
Fix navigation block menu alignment

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -459,7 +459,6 @@ function BlockListBlock( {
 		<BlockEdit
 			name={ name }
 			isSelected={ isSelected }
-			isParentOfSelectedBlock={ isParentOfSelectedBlock }
 			attributes={ attributes }
 			setAttributes={ setAttributes }
 			insertBlocksAfter={ isLocked ? undefined : onInsertBlocksAfter }

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -459,6 +459,7 @@ function BlockListBlock( {
 		<BlockEdit
 			name={ name }
 			isSelected={ isSelected }
+			isParentOfSelectedBlock={ isParentOfSelectedBlock }
 			attributes={ attributes }
 			setAttributes={ setAttributes }
 			insertBlocksAfter={ isLocked ? undefined : onInsertBlocksAfter }

--- a/packages/block-library/src/navigation-menu-item/edit.js
+++ b/packages/block-library/src/navigation-menu-item/edit.js
@@ -140,7 +140,6 @@ function NavigationMenuItemEdit( {
 				{ content }
 				<InnerBlocks
 					allowedBlocks={ [ 'core/navigation-menu-item' ] }
-					renderAppender={ InnerBlocks.ButtonBlockAppender }
 				/>
 			</div>
 		</Fragment>

--- a/packages/block-library/src/navigation-menu-item/edit.js
+++ b/packages/block-library/src/navigation-menu-item/edit.js
@@ -6,6 +6,7 @@ import { invoke } from 'lodash';
 /**
  * WordPress dependencies
  */
+import { withSelect } from '@wordpress/data';
 import {
 	Dropdown,
 	ExternalLink,
@@ -149,4 +150,11 @@ function NavigationMenuItemEdit( {
 	);
 }
 
-export default NavigationMenuItemEdit;
+export default withSelect( ( select, ownProps ) => {
+	const { hasSelectedInnerBlock } = select( 'core/block-editor' );
+	const { clientId } = ownProps;
+
+	return {
+		isParentOfSelectedBlock: hasSelectedInnerBlock( clientId, true ),
+	};
+} )( NavigationMenuItemEdit );

--- a/packages/block-library/src/navigation-menu-item/edit.js
+++ b/packages/block-library/src/navigation-menu-item/edit.js
@@ -138,12 +138,6 @@ function NavigationMenuItemEdit( {
 			</InspectorControls>
 			<div className="wp-block-navigation-menu-item">
 				{ content }
-				{ ! isSelected &&
-					<InnerBlocks
-						allowedBlocks={ [ 'core/navigation-menu-item' ] }
-						renderAppender={ false }
-					/>
-				}
 				{ isSelected &&
 					<InnerBlocks
 						allowedBlocks={ [ 'core/navigation-menu-item' ] }

--- a/packages/block-library/src/navigation-menu-item/edit.js
+++ b/packages/block-library/src/navigation-menu-item/edit.js
@@ -138,9 +138,17 @@ function NavigationMenuItemEdit( {
 			</InspectorControls>
 			<div className="wp-block-navigation-menu-item">
 				{ content }
-				<InnerBlocks
-					allowedBlocks={ [ 'core/navigation-menu-item' ] }
-				/>
+				{ ! isSelected &&
+					<InnerBlocks
+						allowedBlocks={ [ 'core/navigation-menu-item' ] }
+						renderAppender={ false }
+					/>
+				}
+				{ isSelected &&
+					<InnerBlocks
+						allowedBlocks={ [ 'core/navigation-menu-item' ] }
+					/>
+				}
 			</div>
 		</Fragment>
 	);

--- a/packages/block-library/src/navigation-menu-item/edit.js
+++ b/packages/block-library/src/navigation-menu-item/edit.js
@@ -37,6 +37,7 @@ function NavigationMenuItemEdit( {
 	attributes,
 	clientId,
 	isSelected,
+	isParentOfSelectedBlock,
 	setAttributes,
 } ) {
 	const plainTextRef = useRef( null );
@@ -138,7 +139,7 @@ function NavigationMenuItemEdit( {
 			</InspectorControls>
 			<div className="wp-block-navigation-menu-item">
 				{ content }
-				{ isSelected &&
+				{ ( isSelected || isParentOfSelectedBlock ) &&
 					<InnerBlocks
 						allowedBlocks={ [ 'core/navigation-menu-item' ] }
 					/>

--- a/packages/block-library/src/navigation-menu-item/editor.scss
+++ b/packages/block-library/src/navigation-menu-item/editor.scss
@@ -1,13 +1,11 @@
+$menu-label-field-width: 140px;
+
 .wp-block-navigation-menu-item__edit-container {
 	display: grid;
 	grid-auto-columns: min-content;
 	grid-auto-flow: column;
 	align-items: center;
 	white-space: nowrap;
-}
-
-$menu-label-field-width: 140px;
-.wp-block-navigation-menu-item__edit-container {
 	border: 1px solid $light-gray-500;
 	// two pixes comes from two times one pixel border
 	width: $menu-label-field-width + $icon-button-size + 2px;

--- a/packages/block-library/src/navigation-menu/edit.js
+++ b/packages/block-library/src/navigation-menu/edit.js
@@ -53,7 +53,6 @@ function NavigationMenu( {
 			<div className="wp-block-navigation-menu">
 				<InnerBlocks
 					allowedBlocks={ [ 'core/navigation-menu-item' ] }
-					renderAppender={ InnerBlocks.ButtonBlockAppender }
 				/>
 			</div>
 		</Fragment>

--- a/packages/block-library/src/navigation-menu/editor.scss
+++ b/packages/block-library/src/navigation-menu/editor.scss
@@ -1,13 +1,18 @@
 .wp-block-navigation-menu .block-editor-block-list__layout,
 .wp-block-navigation-menu {
-	display: grid;
+	display: flex;
 	grid-auto-columns: min-content;
 	grid-auto-flow: column;
-	align-items: center;
+	align-items: top;
 	white-space: nowrap;
 }
 
 .wp-block-navigation-menu__inserter-content {
-	width: 350px;
 	padding: $grid-size-large;
+}
+
+.wp-block-navigation-menu-item {
+	.wp-block-navigation-menu-item {
+		margin-left: $grid-size-large;
+	}
 }


### PR DESCRIPTION
Closes #17540 

![default-menu-edit-style](https://user-images.githubusercontent.com/107534/65769563-85c3cd80-e13c-11e9-830a-f57d9950e9bb.gif)

- [x] Menu items and nested menu items within a Navigation block should be aligned properly.
- [x] Nested menu items should only be shown when the parent menu item is selected.