### PR TITLE
Core Data: Clear auto-draft titles on save if not changed explicitly.

### DIFF
--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -325,15 +325,16 @@ export function* saveEntityRecord(
 				yield receiveAutosaves( persistedRecord.id, updatedRecord );
 			}
 		} else {
-			// Auto drafts should be converted to drafts on explicit saves,
+			// Auto drafts should be converted to drafts on explicit saves and we should not respect their default title,
 			// but some plugins break with this behavior so we can't filter it on the server.
 			let data = record;
-			if (
-				kind === 'postType' &&
-				persistedRecord && persistedRecord.status === 'auto-draft' &&
-				! data.status
-			) {
-				data = { ...data, status: 'draft' };
+			if ( kind === 'postType' && persistedRecord && persistedRecord.status === 'auto-draft' ) {
+				if ( ! data.status ) {
+					data = { ...data, status: 'draft' };
+				}
+				if ( ! data.title || data.title === 'Auto Draft' ) {
+					data = { ...data, title: '' };
+				}
 			}
 
 			// We perform an optimistic update here to clear all the edits that

--- a/packages/e2e-tests/specs/change-detection.test.js
+++ b/packages/e2e-tests/specs/change-detection.test.js
@@ -323,4 +323,23 @@ describe( 'Change detection', () => {
 
 		await assertIsDirty( false );
 	} );
+
+	it( 'should save posts without titles and persist and overwrite the auto draft title', async () => {
+		// Enter content.
+		await clickBlockAppender();
+		await page.keyboard.type( 'Paragraph' );
+
+		// Save
+		await pressKeyWithModifier( 'primary', 'S' );
+
+		// Verify that the title is empty.
+		const title = await page.$eval(
+			'.editor-post-title__input',
+			( element ) => element.innerHTML
+		);
+		expect( title ).toBe( '' );
+
+		// Verify that the post is not dirty.
+		await assertIsDirty( false );
+	} );
 } );

--- a/packages/e2e-tests/specs/change-detection.test.js
+++ b/packages/e2e-tests/specs/change-detection.test.js
@@ -330,7 +330,13 @@ describe( 'Change detection', () => {
 		await page.keyboard.type( 'Paragraph' );
 
 		// Save
-		await pressKeyWithModifier( 'primary', 'S' );
+		await Promise.all( [
+			// Wait for "Saved" to confirm save complete.
+			page.waitForSelector( '.editor-post-saved-state.is-saved' ),
+
+			// Keyboard shortcut Ctrl+S save.
+			pressKeyWithModifier( 'primary', 'S' ),
+		] );
 
 		// Verify that the title is empty.
 		const title = await page.$eval(


### PR DESCRIPTION
Fixes #17628

## Description

This PR fixes an issue where saving an `auto-draft` without a title would persist its default title, "Auto Draft", in the new `draft` or `published` post. The latter two statuses don't have an incoming filter to clear the "Auto Draft" title so it would show in the editor and confuse users.

## How has this been tested?

It was verified that saving or publishing new posts without titles no longer sets the title to "Auto Draft", but keeps it empty instead.

## Types of Changes

*Bug Fix:* New posts saved or published without a title will no longer have their title set to "Auto Draft".

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
