### PR TITLE
Update: Use minimum height instead of height for cover minimum height label

### DIFF
--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -102,7 +102,7 @@ const CoverHeightInput = withInstanceId(
 		);
 		const inputId = `block-cover-height-input-${ instanceId }`;
 		return (
-			<BaseControl label={ __( 'Height in pixels' ) } id={ inputId }>
+			<BaseControl label={ __( 'Minimum height in pixels' ) } id={ inputId }>
 				<input
 					type="number"
 					id={ inputId }


### PR DESCRIPTION
This PR simply changes the cover input minimum height input field label. When changing that value users are setting a minimum heigh property and not a height property we are using the wrong label and this brings confusion as noted on issue https://github.com/WordPress/gutenberg/issues/17582.

