### PR TITLE
default state for the menu

### DIFF
--- a/packages/block-library/src/navigation-menu/edit.js
+++ b/packages/block-library/src/navigation-menu/edit.js
@@ -74,6 +74,8 @@ export default withSelect( ( select ) => {
 	const { getEntityRecords } = select( 'core' );
 	const filterDefaultPages = {
 		parent: 0,
+		order: 'asc',
+		orderby: 'id',
 	};
 	return {
 		pages: getEntityRecords( 'postType', 'page', filterDefaultPages ),

--- a/packages/block-library/src/navigation-menu/edit.js
+++ b/packages/block-library/src/navigation-menu/edit.js
@@ -9,6 +9,7 @@ import {
 	InspectorControls,
 	BlockControls,
 } from '@wordpress/block-editor';
+import { withSelect } from '@wordpress/data';
 import {
 	CheckboxControl,
 	PanelBody,
@@ -25,8 +26,17 @@ function NavigationMenu( {
 	attributes,
 	setAttributes,
 	clientId,
+	pages,
 } ) {
 	const { navigatorToolbarButton, navigatorModal } = useBlockNavigator( clientId );
+	let defaultMenuItems = false;
+	if ( pages ) {
+		defaultMenuItems = pages.map( ( page ) => {
+			return [ 'core/navigation-menu-item',
+				{ label: page.title.rendered, destination: page.permalink_template },
+			];
+		} );
+	}
 
 	return (
 		<Fragment>
@@ -52,6 +62,7 @@ function NavigationMenu( {
 			</InspectorControls>
 			<div className="wp-block-navigation-menu">
 				<InnerBlocks
+					template={ defaultMenuItems ? defaultMenuItems : null }
 					allowedBlocks={ [ 'core/navigation-menu-item' ] }
 				/>
 			</div>
@@ -59,4 +70,13 @@ function NavigationMenu( {
 	);
 }
 
-export default NavigationMenu;
+export default withSelect( ( select ) => {
+	const { getEntityRecords } = select( 'core' );
+	const filterDefaultPages = {
+		parent: 0,
+	};
+	return {
+		pages: getEntityRecords( 'postType', 'page', filterDefaultPages ),
+	};
+} )( NavigationMenu );
+

--- a/packages/block-library/src/navigation-menu/edit.js
+++ b/packages/block-library/src/navigation-menu/edit.js
@@ -13,6 +13,7 @@ import { withSelect } from '@wordpress/data';
 import {
 	CheckboxControl,
 	PanelBody,
+	Spinner,
 	Toolbar,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -27,6 +28,7 @@ function NavigationMenu( {
 	setAttributes,
 	clientId,
 	pages,
+	isRequesting,
 } ) {
 	const { navigatorToolbarButton, navigatorModal } = useBlockNavigator( clientId );
 	let defaultMenuItems = false;
@@ -61,10 +63,15 @@ function NavigationMenu( {
 				</PanelBody>
 			</InspectorControls>
 			<div className="wp-block-navigation-menu">
-				<InnerBlocks
-					template={ defaultMenuItems ? defaultMenuItems : null }
-					allowedBlocks={ [ 'core/navigation-menu-item' ] }
-				/>
+				{ isRequesting &&
+					<Spinner />
+				}
+				{ pages &&
+					<InnerBlocks
+						template={ defaultMenuItems ? defaultMenuItems : null }
+						allowedBlocks={ [ 'core/navigation-menu-item' ] }
+					/>
+				}
 			</div>
 		</Fragment>
 	);
@@ -72,6 +79,7 @@ function NavigationMenu( {
 
 export default withSelect( ( select ) => {
 	const { getEntityRecords } = select( 'core' );
+	const { isResolving } = select( 'core/data' );
 	const filterDefaultPages = {
 		parent: 0,
 		order: 'asc',
@@ -79,6 +87,7 @@ export default withSelect( ( select ) => {
 	};
 	return {
 		pages: getEntityRecords( 'postType', 'page', filterDefaultPages ),
+		isRequesting: isResolving( 'core', 'getEntityRecords', [ 'postType', 'page', filterDefaultPages ] ),
 	};
 } )( NavigationMenu );
 

--- a/packages/block-library/src/navigation-menu/edit.js
+++ b/packages/block-library/src/navigation-menu/edit.js
@@ -3,6 +3,7 @@
  */
 import {
 	Fragment,
+	useMemo,
 } from '@wordpress/element';
 import {
 	InnerBlocks,
@@ -31,14 +32,19 @@ function NavigationMenu( {
 	isRequesting,
 } ) {
 	const { navigatorToolbarButton, navigatorModal } = useBlockNavigator( clientId );
-	let defaultMenuItems = false;
-	if ( pages ) {
-		defaultMenuItems = pages.map( ( page ) => {
-			return [ 'core/navigation-menu-item',
-				{ label: page.title.rendered, destination: page.permalink_template },
-			];
-		} );
-	}
+	const defaultMenuItems = useMemo(
+		() => {
+			if ( ! pages ) {
+				return null;
+			}
+			return pages.map( ( page ) => {
+				return [ 'core/navigation-menu-item',
+					{ label: page.title.rendered, destination: page.permalink_template },
+				];
+			} );
+		},
+		[ pages ]
+	);
 
 	return (
 		<Fragment>


### PR DESCRIPTION
## Description
Closes #17541

## How has this been tested?
Tested locally.

![default-menu-items](https://user-images.githubusercontent.com/107534/65819219-86369400-e222-11e9-92a4-2bed96005ebd.gif)

## Types of changes
Wrapped the menu in a select looking for top level pages.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
