### PR TITLE
Suppress browserslist dependency warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7204,35 +7204,35 @@
 			}
 		},
 		"browserslist": {
-			"version": "4.6.2",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.2.tgz",
-			"integrity": "sha512-2neU/V0giQy9h3XMPwLhEY3+Ao0uHSwHvU8Q1Ea6AgLVL1sXbX3dzPrJ8NWe5Hi4PoTkCYXOtVR9rfRLI0J/8Q==",
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.7.0.tgz",
+			"integrity": "sha512-9rGNDtnj+HaahxiVV38Gn8n8Lr8REKsel68v1sPFfIGEK6uSXTY3h9acgiT1dZVtOOUtifo/Dn8daDQ5dUgVsA==",
 			"dev": true,
 			"requires": {
-				"caniuse-lite": "^1.0.30000974",
-				"electron-to-chromium": "^1.3.150",
-				"node-releases": "^1.1.23"
+				"caniuse-lite": "^1.0.30000989",
+				"electron-to-chromium": "^1.3.247",
+				"node-releases": "^1.1.29"
 			},
 			"dependencies": {
 				"caniuse-lite": {
-					"version": "1.0.30000974",
-					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000974.tgz",
-					"integrity": "sha512-xc3rkNS/Zc3CmpMKuczWEdY2sZgx09BkAxfvkxlAEBTqcMHeL8QnPqhKse+5sRTi3nrw2pJwToD2WvKn1Uhvww==",
+					"version": "1.0.30000997",
+					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000997.tgz",
+					"integrity": "sha512-BQLFPIdj2ntgBNWp9Q64LGUIEmvhKkzzHhUHR3CD5A9Lb7ZKF20/+sgadhFap69lk5XmK1fTUleDclaRFvgVUA==",
 					"dev": true
 				},
 				"node-releases": {
-					"version": "1.1.23",
-					"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.23.tgz",
-					"integrity": "sha512-uq1iL79YjfYC0WXoHbC/z28q/9pOl8kSHaXdWmAAc8No+bDwqkZbzIJz55g/MUsPgSGm9LZ7QSUbzTcH5tz47w==",
+					"version": "1.1.32",
+					"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.32.tgz",
+					"integrity": "sha512-VhVknkitq8dqtWoluagsGPn3dxTvN9fwgR59fV3D7sLBHe0JfDramsMI8n8mY//ccq/Kkrf8ZRHRpsyVZ3qw1A==",
 					"dev": true,
 					"requires": {
 						"semver": "^5.3.0"
 					}
 				},
 				"semver": {
-					"version": "5.7.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
 					"dev": true
 				}
 			}
@@ -10632,9 +10632,9 @@
 			"dev": true
 		},
 		"electron-to-chromium": {
-			"version": "1.3.155",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.155.tgz",
-			"integrity": "sha512-/ci/XgZG8jkLYOgOe3mpJY1onxPPTDY17y7scldhnSjjZqV6VvREG/LvwhRuV7BJbnENFfuDWZkSqlTh4x9ZjQ==",
+			"version": "1.3.269",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.269.tgz",
+			"integrity": "sha512-t2ZTfo07HxkxTOUbIwMmqHBSnJsC9heqJUm7LwQu2iSk0wNhG4H5cMREtb8XxeCrQABDZ6IqQKY3yZq+NfAqwg==",
 			"dev": true
 		},
 		"elegant-spinner": {

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
 		"babel-plugin-react-native-classname-to-style": "1.2.2",
 		"babel-plugin-react-native-platform-specific-extensions": "1.1.1",
 		"benchmark": "2.1.4",
-		"browserslist": "4.6.2",
+		"browserslist": "4.7.0",
 		"chalk": "2.4.1",
 		"commander": "2.20.0",
 		"concurrently": "3.5.0",

--- a/packages/babel-preset-default/test/index.js
+++ b/packages/babel-preset-default/test/index.js
@@ -21,5 +21,11 @@ describe( 'Babel preset default', () => {
 		} );
 
 		expect( output.code ).toMatchSnapshot();
+
+		// See https://github.com/WordPress/gutenberg/pull/17643.
+		// Workaround for a problem with browserslist which was warning about outdated
+		// dependencies (even though the dependencies were up-to-date.)
+		/* eslint-disable-next-line no-console */
+		console.warn.mockReset();
 	} );
 } );


### PR DESCRIPTION
## Description
Every so often the unit tests fail because the browserslist dependency needs to be updated. 

Last time https://github.com/WordPress/gutenberg/pull/16066 handled this.

## How has this been tested?
Unit tests should pass

## Types of changes
Non-breaking dependency update

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
