### PR TITLE
Update button styling to match WP 5.3

### DIFF
--- a/bin/packages/post-css-config.js
+++ b/bin/packages/post-css-config.js
@@ -4,7 +4,7 @@ module.exports = [
 			primary: '#0085ba',
 			secondary: '#11a0d2',
 			toggle: '#11a0d2',
-			button: '#0085ba',
+			button: '#007cba',
 			outlines: '#007cba',
 		},
 		themes: {

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -85,13 +85,10 @@
 			color: $white;
 		}
 
-		// [aria-disabled="true"] is not specific enough to override default styling,
-		// so double-up selector to increase specificity.
-		// This is primarily an issue on Button components that are aria-disabled,
-		// but not disabled.
 		&:disabled,
 		&:disabled:active:enabled,
-		&[aria-disabled="true"][aria-disabled="true"],
+		&[aria-disabled="true"],
+		&[aria-disabled="true"]:enabled, // This catches a situation where a Button is aria-disabled, but not disabled.
 		&[aria-disabled="true"]:active:enabled {
 			color: color(theme(button) tint(40%));
 			background: color(theme(button) tint(10%));

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -20,8 +20,8 @@
 
 	// Default button style
 	&.is-default {
-		color: color(theme(button) shade(5%));
-		border-color: color(theme(button) shade(5%));
+		color: color(theme(button) shade(6%));
+		border-color: color(theme(button) shade(6%));
 		background: #f3f5f6;
 
 		&:hover {
@@ -41,7 +41,6 @@
 		}
 
 		&:active:enabled {
-			transform: translateY(1px);
 			background: #f3f5f6;
 			color: color(theme(button) shade(5%));
 			border-color: #7e8993;
@@ -80,7 +79,6 @@
 		}
 
 		&:active:enabled {
-			transform: translateY(1px);
 			background: color(theme(button) shade(20%));
 			border-color: color(theme(button) shade(20%));
 			color: $white;

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -7,6 +7,7 @@
 	cursor: pointer;
 	-webkit-appearance: none;
 	background: none;
+	transition: box-shadow 0.1s linear;
 
 	&.is-button {
 		padding: 0 10px;

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -87,6 +87,8 @@
 
 		// [aria-disabled="true"] is not specific enough to override default styling,
 		// so double-up selector to increase specificity.
+		// This is primarily an issue on Button components that are aria-disabled,
+		// but not disabled.
 		&:disabled,
 		&:disabled:active:enabled,
 		&[aria-disabled="true"][aria-disabled="true"],
@@ -97,6 +99,7 @@
 			opacity: 1;
 
 			// This specificity is needed to override alternate color schemes in WP-Admin.
+			// This can presumably be removed when https://core.trac.wordpress.org/ticket/34904 lands.
 			&.is-button,
 			&.is-button:hover,
 			&:active:enabled {

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -20,35 +20,32 @@
 
 	// Default button style
 	&.is-default {
-		color: #555;
-		border-color: #ccc;
-		background: #f7f7f7;
-		box-shadow: inset 0 -1px 0 #ccc;
+		color: color(theme(button) shade(5%));
+		border-color: color(theme(button) shade(5%));
+		background: #f3f5f6;
 
 		&:hover {
-			background: #fafafa;
-			border-color: #999;
-			box-shadow: inset 0 -1px 0 #999;
-			color: #23282d;
+			background: #f1f1f1;
+			border-color: color(theme(button) shade(25%));
+			color: color(theme(button) shade(25%));
 			text-decoration: none;
 		}
 
 		&:focus:enabled {
-			background: #fafafa;
-			color: #23282d;
-			border-color: #999;
-			box-shadow:
-				inset 0 -1px 0 #999,
-				0 0 0 1px $white,
-				0 0 0 3px $blue-medium-focus;
+			background: #f3f5f6;
+			color: color(theme(button) shade(25%));
+			border-color: color(theme(button) shade(5%));
+			box-shadow: 0 0 0 1px color(theme(button) shade(5%));
 			text-decoration: none;
 
 		}
 
 		&:active:enabled {
-			background: #eee;
-			border-color: #999;
-			box-shadow: inset 0 1px 0 #999,;
+			transform: translateY(1px);
+			background: #f3f5f6;
+			color: color(theme(button) shade(5%));
+			border-color: #7e8993;
+			box-shadow: none;
 		}
 
 		&:disabled,
@@ -56,7 +53,6 @@
 			color: #a0a5aa;
 			border-color: #ddd;
 			background: #f7f7f7;
-			box-shadow: none;
 			text-shadow: 0 1px 0 #fff;
 			transform: none;
 			opacity: 1;

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -65,49 +65,40 @@
 
 	&.is-primary {
 		background: color(theme(button));
-		border-color: color(theme(button) shade(20%)) color(theme(button) shade(25%)) color(theme(button) shade(25%));
-		box-shadow: inset 0 -1px 0 color(theme(button) shade(25%));
+		border-color: color(theme(button));
 		color: $white;
 		text-decoration: none;
-		text-shadow:
-			0 -1px 1px color(theme(button) shade(30%)),
-			1px 0 1px color(theme(button) shade(30%)),
-			0 1px 1px color(theme(button) shade(30%)),
-			-1px 0 1px color(theme(button) shade(30%));
+		text-shadow: none;
 
 		&:hover,
 		&:focus:enabled {
-			background: color(theme(button) shade(5%));
-			border-color: color(theme(button) shade(50%));
+			background: color(theme(button) shade(10%));
+			border-color: color(theme(button) shade(10%));
 			color: $white;
-		}
-
-		&:hover {
-			box-shadow: inset 0 -1px 0 color(theme(button) shade(50%));
 		}
 
 		&:focus:enabled {
 			box-shadow:
-				inset 0 -1px 0 color(theme(button) shade(50%)),
 				0 0 0 1px $white,
-				0 0 0 3px color(theme(button) shade(5%));
+				0 0 0 3px color(theme(button));
 		}
 
 		&:active:enabled {
+			transform: translateY(1px);
 			background: color(theme(button) shade(20%));
-			border-color: color(theme(button) shade(50%));
-			box-shadow: inset 0 1px 0 color(theme(button) shade(50%));
+			border-color: color(theme(button) shade(20%));
+			color: $white;
 		}
 
+		// [aria-disabled="true"] is not specific enough to override default styling,
+		// so double-up selector to increase specificity.
 		&:disabled,
 		&:disabled:active:enabled,
-		&[aria-disabled="true"],
+		&[aria-disabled="true"][aria-disabled="true"],
 		&[aria-disabled="true"]:active:enabled {
 			color: color(theme(button) tint(40%));
-			background: color(theme(button));
-			border-color: color(theme(button) shade(7%));
-			box-shadow: none;
-			text-shadow: none;
+			background: color(theme(button) tint(10%));
+			border-color: color(theme(button) tint(10%));
 			opacity: 1;
 
 			// This specificity is needed to override alternate color schemes in WP-Admin.
@@ -119,11 +110,9 @@
 			}
 
 			&:focus:enabled {
-				color: color(theme(button) tint(40%));
-				border-color: color(theme(button) shade(7%));
 				box-shadow:
 					0 0 0 1px $white,
-					0 0 0 3px $blue-medium-focus;
+					0 0 0 3px color(theme(button));
 			}
 		}
 
@@ -136,13 +125,13 @@
 			/* stylelint-disable */
 			background-image: linear-gradient(
 				-45deg,
-				theme(primary) 28%,
-				color(theme(primary) shade(30%)) 28%,
-				color(theme(primary) shade(30%)) 72%,
-				theme(primary) 72%
+				theme(button) 28%,
+				color(theme(button) shade(20%)) 28%,
+				color(theme(button) shade(20%)) 72%,
+				theme(button) 72%
 			);
 			/* stylelint-enable */
-			border-color: color(theme(primary) shade(50%));
+			border-color: color(theme(button));
 		}
 	}
 

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -9,8 +9,8 @@
 	background: none;
 
 	&.is-button {
-		padding: 0 10px 1px;
-		line-height: 26px;
+		padding: 0 10px;
+		line-height: 2;
 		height: 28px;
 		border-radius: 3px;
 		white-space: nowrap;

--- a/packages/edit-post/src/components/fullscreen-mode/style.scss
+++ b/packages/edit-post/src/components/fullscreen-mode/style.scss
@@ -21,8 +21,6 @@ body.js.is-fullscreen-mode {
 		}
 
 		// Animations.
-		@include edit-post__fade-in-animation(0.3s);
-
 		.edit-post-header {
 			transform: translateY(-100%);
 			animation: edit-post-fullscreen-mode__slide-in-animation 0.1s forwards;

--- a/packages/editor/src/components/post-trash/style.scss
+++ b/packages/editor/src/components/post-trash/style.scss
@@ -1,10 +1,12 @@
 .editor-post-trash.components-button {
 	width: 100%;
-	color: darken($alert-red, 10%);
+	color: darken($alert-red, 15%);
+	border-color: darken($alert-red, 15%);
 	justify-content: center;
 
 	&:hover,
 	&:focus {
-		color: darken($alert-red, 15%);
+		color: darken($alert-red, 20%);
+		border-color: darken($alert-red, 20%);
 	}
 }


### PR DESCRIPTION
## Description
Update button styles to 'match' those in core.

See https://core.trac.wordpress.org/ticket/34904 for the change in core.

Closes #17585

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->
Default button on the left, Primary on the right.

### Normal
![Screen Shot 2019-09-30 at 2 44 28 pm](https://user-images.githubusercontent.com/677833/65855460-a173e180-e391-11e9-913f-bcc357b521b2.png)

### Hovered
![Screen Shot 2019-09-30 at 2 44 55 pm](https://user-images.githubusercontent.com/677833/65855491-a769c280-e391-11e9-9d56-fe858df14513.png)

### Focused
![Screen Shot 2019-09-30 at 2 45 17 pm](https://user-images.githubusercontent.com/677833/65855532-b18bc100-e391-11e9-9266-ae8e18c2b202.png)

### Active
![Screen Shot 2019-09-30 at 2 45 39 pm](https://user-images.githubusercontent.com/677833/65855536-b6e90b80-e391-11e9-9f1f-ef21a308ff8d.png)

### Disabled
![Screen Shot 2019-09-30 at 2 51 38 pm](https://user-images.githubusercontent.com/677833/65855575-daac5180-e391-11e9-9938-03b06aee582a.png)

### Busy (primary button only)
![Screen Shot 2019-09-30 at 2 59 23 pm](https://user-images.githubusercontent.com/677833/65855973-f9f7ae80-e392-11e9-9899-ec91a56aecbd.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
