### PR TITLE
Fix select element sizing in publish date picker

### DIFF
--- a/assets/stylesheets/_mixins.scss
+++ b/assets/stylesheets/_mixins.scss
@@ -511,10 +511,14 @@
 		}
 	}
 
+	// We provide explicit pixel dimensions to ensure a crisp appearance.
+	// This radio button style should be ported upstream.
 	input[type="radio"] {
 		border-radius: $radius-round;
 
 		&:checked::before {
+			width: 6px;
+			height: 6px;
 			margin: 6px 0 0 6px;
 			background-color: $white;
 

--- a/packages/components/src/date-time/style.scss
+++ b/packages/components/src/date-time/style.scss
@@ -146,7 +146,6 @@
 			}
 
 			select {
-				padding: 2px;
 				margin-right: 4px;
 
 				&:focus {
@@ -158,7 +157,6 @@
 			input[type="number"] {
 				padding: 2px;
 				margin-right: 4px;
-				width: 40px;
 				text-align: center;
 				-moz-appearance: textfield;
 
@@ -210,7 +208,7 @@
 }
 
 .components-datetime__time-field-month-select {
-	width: 90px;
+	max-width: 145px;
 }
 
 // Hack to center the datepicker component within the popover.


### PR DESCRIPTION
## Description
Fixes #17590

New styles for select elements in core were clashing slightly with some styling in the publish date picker.

The issue was that the padding and width of the popover of the core select element was being overridden. I've removed the padding and opted to use a max width for the select, which should cover cases where a translated month name is significantly longer.

## How has this been tested?
1. Create a new post
2. Click on the publish date from the sidebar
3. Notice the elements in the popover should be sized and spaced consistently and correctly..
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->
### Before
![Screen Shot 2019-09-30 at 5 29 55 pm](https://user-images.githubusercontent.com/677833/65867196-90829a80-e3a8-11e9-9db9-98c0c517fee4.png)

### After
![Screen Shot 2019-09-30 at 5 28 39 pm](https://user-images.githubusercontent.com/677833/65867208-96787b80-e3a8-11e9-8988-2e425f435f09.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
