### PR TITLE
Polish font size picker.

### DIFF
--- a/packages/components/src/font-size-picker/style.scss
+++ b/packages/components/src/font-size-picker/style.scss
@@ -1,7 +1,6 @@
 .components-font-size-picker__controls {
 	max-width: $sidebar-width - ( 2 * $panel-padding );
 	display: flex;
-	justify-content: space-between;
 	align-items: center;
 	margin-bottom: $grid-size * 3;
 
@@ -9,6 +8,7 @@
 	.components-range-control__number {
 		height: 30px;
 		margin-left: 0;
+		margin-right: $grid-size;
 
 		// Show the reset button as disabled until a value is entered.
 		&[value=""] + .components-button {
@@ -17,9 +17,15 @@
 			pointer-events: none;
 		}
 	}
+
+	// Allow the font-size picker dropdown to grow in width.
+	.components-font-size-picker__select {
+		margin-right: $grid-size;
+		flex-grow: 1;
+	}
 }
 
-// needed to override CSS set in https://github.com/WordPress/gutenberg/blob/9c438f93a7215d50d1efc0492c308e4cbaa59c52/packages/edit-post/src/components/sidebar/settings-sidebar/style.scss#L6
+// Needed to override CSS set in https://github.com/WordPress/gutenberg/blob/9c438f93a7215d50d1efc0492c308e4cbaa59c52/packages/edit-post/src/components/sidebar/settings-sidebar/style.scss#L6.
 .components-font-size-picker__select.components-font-size-picker__select.components-font-size-picker__select.components-font-size-picker__select,
 .components-font-size-picker__select .components-base-control__field {
 	margin-bottom: 0;


### PR DESCRIPTION
Fixes #17593.

This changes the font size picker to let things be spaced by the grid, and let the font size dropdown grow in width.

Note that the weird dropdown in the screenshot is fixed separately in https://core.trac.wordpress.org/ticket/47477.

Before:

<img width="279" alt="before" src="https://user-images.githubusercontent.com/1204802/65870179-e0973800-e37b-11e9-8dc6-1b56f72e1920.png">

After:

<img width="313" alt="after" src="https://user-images.githubusercontent.com/1204802/65870185-e260fb80-e37b-11e9-9743-834ca4f7aad6.png">
