### PR TITLE
Polish search widget.

### DIFF
--- a/packages/block-library/src/search/style.scss
+++ b/packages/block-library/src/search/style.scss
@@ -8,6 +8,7 @@
 
 	.wp-block-search__input {
 		flex-grow: 1;
+		max-width: 360px;
 	}
 
 	.wp-block-search__button {


### PR DESCRIPTION
This applies a max-width.

Fixes #17593 — the other half of it.

Basically the search widget can grow as wide as your main body content column will let it. This PR applies a max-width.

Do we want this? If you insert the search widget in a really wide space, then it will grow to fill it. Not sure if good or bad, but it can definitely look a little overwhelming.

Before:

<img width="1158" alt="Screenshot 2019-09-30 at 12 16 21" src="https://user-images.githubusercontent.com/1204802/65870549-c01bad80-e37c-11e9-94c8-dd354998cb0e.png">

After:

<img width="522" alt="Screenshot 2019-09-30 at 12 17 43" src="https://user-images.githubusercontent.com/1204802/65870553-c27e0780-e37c-11e9-90cc-af83d8b8ff6c.png">
