### PR TITLE
Introduce CustomElement interoperability for block types

### DIFF
--- a/packages/block-editor/src/components/block-edit/edit.js
+++ b/packages/block-editor/src/components/block-edit/edit.js
@@ -9,6 +9,12 @@ import classnames from 'classnames';
 import { withFilters } from '@wordpress/components';
 import { getBlockDefaultClassName, hasBlockSupport, getBlockType } from '@wordpress/blocks';
 
+/**
+ * Internal dependencies
+ */
+import CustomElement from '../custom-element';
+import { isCustomElement } from '../../utils/dom';
+
 export const Edit = ( props ) => {
 	const { attributes = {}, name } = props;
 	const blockType = getBlockType( name );
@@ -27,6 +33,10 @@ export const Edit = ( props ) => {
 	// with which a block is displayed. If `blockType` is valid, assign
 	// them preferentially as the render value for the block.
 	const Component = blockType.edit || blockType.save;
+
+	if ( isCustomElement( Component ) ) {
+		return <CustomElement { ...props } tagName={ Component } className={ className } />;
+	}
 
 	return <Component { ...props } className={ className } />;
 };

--- a/packages/block-editor/src/components/block-edit/edit.native.js
+++ b/packages/block-editor/src/components/block-edit/edit.native.js
@@ -4,6 +4,12 @@
 import { withFilters } from '@wordpress/components';
 import { getBlockType } from '@wordpress/blocks';
 
+/**
+ * Internal dependencies
+ */
+import CustomElement from '../custom-element';
+import { isCustomElement } from '../../utils/dom';
+
 export const Edit = ( props ) => {
 	const { name } = props;
 	const blockType = getBlockType( name );
@@ -13,6 +19,10 @@ export const Edit = ( props ) => {
 	}
 
 	const Component = blockType.edit;
+
+	if ( isCustomElement( Component ) ) {
+		return <CustomElement { ...props } tagName={ Component } />;
+	}
 
 	return (
 		<Component { ...props } />

--- a/packages/block-editor/src/components/custom-element/index.js
+++ b/packages/block-editor/src/components/custom-element/index.js
@@ -1,0 +1,66 @@
+/**
+ * External dependencies
+ */
+import { forOwn, kebabCase, uniq } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { Component, createRef } from '@wordpress/element';
+
+const mapAttributeName = ( name ) => {
+	if ( 'className' === name ) {
+		return 'class';
+	}
+	return kebabCase( name );
+};
+
+class CustomElement extends Component {
+	constructor() {
+		super( ...arguments );
+
+		this.ref = createRef();
+	}
+
+	componentDidMount() {
+		this.setCustomElementProps( this.props );
+	}
+
+	componentDidUpdate() {
+		this.setCustomElementProps( this.props );
+	}
+
+	setCustomElementProps( props ) {
+		const { tagName, attributes, ...properties } = props;
+
+		let child = this.ref.current.firstChild;
+		if ( ! child ) {
+			child = document.createElement( tagName );
+			this.ref.current.appendChild( child );
+		}
+
+		// Ensure class names are passed as attribute.
+		if ( properties.className ) {
+			attributes.className = uniq( [
+				...properties.className.split( ' ' ),
+				...( attributes.className || '' ).split( ' ' ),
+			] ).join( ' ' );
+			delete properties.className;
+		}
+
+		forOwn( properties, ( value, key ) => {
+			child[ key ] = value;
+		} );
+
+		forOwn( attributes, ( value, key ) => {
+			key = mapAttributeName( key );
+			child.setAttribute( key, value );
+		} );
+	}
+
+	render() {
+		return <div ref={ this.ref } />;
+	}
+}
+
+export default CustomElement;

--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -17,6 +17,7 @@ export { default as BlockVerticalAlignmentToolbar } from './block-vertical-align
 export { default as ButtonBlockerAppender } from './button-block-appender';
 export { default as ColorPalette } from './color-palette';
 export { default as ContrastChecker } from './contrast-checker';
+export { default as CustomElement } from './custom-element';
 export { default as InnerBlocks } from './inner-blocks';
 export { default as InspectorAdvancedControls } from './inspector-advanced-controls';
 export { default as InspectorControls } from './inspector-controls';

--- a/packages/block-editor/src/utils/dom.js
+++ b/packages/block-editor/src/utils/dom.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { isString, includes } from 'lodash';
+
+/**
  * Given a block client ID, returns the corresponding DOM node for the block,
  * if exists. As much as possible, this helper should be avoided, and used only
  * in cases where isolated behaviors need remote access to a block node.
@@ -85,4 +90,15 @@ export function isInsideRootBlock( blockElement, element ) {
  */
 export function hasInnerBlocksContext( element ) {
 	return !! element.querySelector( '.block-editor-block-list__layout' );
+}
+
+/**
+ * Determines whether the parameter is a custom element tag name.
+ *
+ * @param {*} tagName Parameter to be checked.
+ *
+ * @return {boolean} True if the parameter is a custom element, or false otherwise.
+ */
+export function isCustomElement( tagName ) {
+	return isString( tagName ) && includes( tagName, '-' );
 }

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -21,7 +21,7 @@ import { select, dispatch } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { isValidIcon, normalizeIconObject } from './utils';
+import { isValidIcon, normalizeIconObject, isCustomElement } from './utils';
 import { DEPRECATED_ENTRY_KEYS } from './constants';
 
 /**
@@ -180,9 +180,9 @@ export function registerBlockType( name, settings ) {
 		);
 		return;
 	}
-	if ( 'edit' in settings && ! isFunction( settings.edit ) ) {
+	if ( 'edit' in settings && ! isFunction( settings.edit ) && ! isCustomElement( settings.edit ) ) {
 		console.error(
-			'The "edit" property must be a valid function.'
+			'The "edit" property must be a valid component or custom element tag name.'
 		);
 		return;
 	}

--- a/packages/blocks/src/api/utils.js
+++ b/packages/blocks/src/api/utils.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { every, has, isFunction, isString } from 'lodash';
+import { every, has, isFunction, isString, includes } from 'lodash';
 import { default as tinycolor, mostReadable } from 'tinycolor2';
 
 /**
@@ -120,4 +120,15 @@ export function normalizeBlockType( blockTypeOrName ) {
 	}
 
 	return blockTypeOrName;
+}
+
+/**
+ * Determines whether the parameter is a custom element tag name.
+ *
+ * @param {*} tagName Parameter to be checked.
+ *
+ * @return {boolean} True if the parameter is a custom element, or false otherwise.
+ */
+export function isCustomElement( tagName ) {
+	return isString( tagName ) && includes( tagName, '-' );
 }


### PR DESCRIPTION
## Description
Addressing #17360, this is a port from #2791, migrating that PR to work within the current APIs and making a few adjustments.

## Types of changes
* Introduce a `CustomElement` component, which accepts a `tagName`, `attributes` and variable other props. Internally it creates a custom element of `tagName`, and adds the `attributes` as HTML attributes, and all other props as HTML properties.
    * Contrary to the original PR, this component is intended for custom elements only, to keep it single-purpose. Whether or not to use that component should be decided by the consuming code.
* Check if a block type's `edit` property is a custom element tag name, and if so use the above component to render it instead of directly interpreting `edit` as a component.
* Support passing a custom element tag name for `edit` when registering a block type.

### Considerations

* Note that the `CustomElement` component itself is very generic and technically not limited to the block editor. I'd like for us to consider whether we want to add it to the `@wordpress/element` package. I didn't want to do that without discussing first, but I think this being a workaround for something essential that React does not allow out of the box gives us food for thought whether we should include it in that package.
* The same applies to the `isCustomElement()` function, which goes together with the `CustomElement` component. Right now the function is even redeclared (we should _definitely_ address that one way or another) because I wasn't sure where to put it (`@wordpress/element` would work) so that all areas where it's needed could access it.
* Alternatively, we could make these two its own package `@wordpress/custom-element`.
* We might want to also allow passing a custom element tag name as a block type's `save`. That would clarify the intent that you can easily use a custom element even for both variants `edit` and `save` (without having to do that of course). Today, an easy way the custom element could check whether it is in edit mode or not would be checking if a `setAttributes` property is present or not.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
