### PR TITLE
Ensure button border transitions respect reduce motion settings

### DIFF
--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -8,6 +8,7 @@
 	-webkit-appearance: none;
 	background: none;
 	transition: box-shadow 0.1s linear;
+	@include reduce-motion("transition");
 
 	&.is-button {
 		padding: 0 10px;


### PR DESCRIPTION
Quick followup from #17645. This tiny PR just adds our reduce motion mixin to the buttons so that they respect the user's OS-level setting, alongside our other animated elements. 

_Before (with Reduce Motion turned on):_
![old](https://user-images.githubusercontent.com/1202812/65881633-af117300-e361-11e9-800d-062e8a8d55b4.gif)

_After (with Reduce Motion turned on):_
![update](https://user-images.githubusercontent.com/1202812/65881655-b5075400-e361-11e9-85df-aa9bf3da9324.gif)
