### PR TITLE
block-preview: reduce computing delay to zero

### DIFF
--- a/packages/block-editor/src/components/block-preview/index.js
+++ b/packages/block-editor/src/components/block-preview/index.js
@@ -61,7 +61,7 @@ function ScaledBlockPreview( { blocks, viewportWidth } ) {
 			}
 
 			setIsReady( true );
-		}, 100 );
+		}, 0 );
 
 		// Cleanup
 		return () => {


### PR DESCRIPTION
## Description
This PR reduces the delay applied before to start to compute the scale for the preview, from `100ms` to `0`.  This delay is needed to required to account for async render of `BlockEditorProvider`, but it seems to be enough just a `0ms` after the component is mount.

## How has this been tested?
TBD