### PR TITLE
Override the new core line-height value for input fields.

### DIFF
--- a/assets/stylesheets/_mixins.scss
+++ b/assets/stylesheets/_mixins.scss
@@ -419,8 +419,12 @@
 
 		/* Fonts smaller than 16px causes mobile safari to zoom. */
 		font-size: $mobile-text-min-font-size;
+		/* Override core line-height. To be reviewed. */
+		line-height: normal;
 		@include break-small {
 			font-size: $default-font-size;
+			/* Override core line-height. To be reviewed. */
+			line-height: normal;
 		}
 
 		&:focus {


### PR DESCRIPTION
## Description

This PR seeks to introduce compatibility with the core admin changes in the last patch on https://core.trac.wordpress.org/ticket/47477.

TL;DR
To make input fields scale with text soom we removed fixed heights. Input fields now use `min-height`. For Firefox, there's the need to use also a `line-height` value for the input fields. These new `line-height` values would conflict with the Gutenberg input fields.

Luckily, Gutenberg uses a sass mixin to normalize the input fields. 

By adding `line-height: normal;` to the mixin, the core values are overridden. This appears to be safe as `line-height: normal;` is what Gutenberg is already implicitly using (by the lack of it).

- yes CSS purists: `line-height: normal;` [shouldn't be used](https://meyerweb.com/eric/thoughts/2008/05/06/line-height-abnormal/)
- it is what we need though
- for the future, all the input fields should have an explicitly set `line-height` value.

To test:
- please test if this changes anything in the Gutenberg UI
