### PR TITLE
Small changes to Git Workflow docs

### DIFF
--- a/docs/contributors/git-workflow.md
+++ b/docs/contributors/git-workflow.md
@@ -41,7 +41,18 @@ git push --force-with-lease your-branch-name
 
 ## Keeping Your Fork Up To Date
 
-Working on pull request starts with forking the Gutenberg repository, your separate working copy. Which can easily go out of sync as new pull requests are merged into the main repository. Here your working repository is a `fork` and the main Gutenberg repository is `upstream`. When working on new pull request you should always update your fork before you do `git checkout -b my-new-branch` to work on a feature or fix. 
+Working on pull request starts with forking the Gutenberg repository, your separate working copy. Which can easily go out of sync as new pull requests are merged into the main repository. Here your working repository is a `fork` and the main Gutenberg repository is `upstream`. When working on new pull request you should always update your fork before you do `git checkout -b my-new-branch` to work on a feature or fix.
+
+You will need to add an `upstream` origin in order to keep your fork updated.
+
+```sh
+git remote add origin upstream https://github.com/WordPress/gutenberg.git
+git remote -v
+origin	git@github.com:your-account/gutenberg.git (fetch)
+origin	git@github.com:your-account/gutenberg.git (push)
+upstream	https://github.com/WordPress/gutenberg.git (fetch)
+upstream	https://github.com/WordPress/gutenberg.git (push)
+```
 
 To sync your fork you need to fetch the upstream changes and merge them into your fork. These are the corresponding commands:
 
@@ -57,7 +68,7 @@ This will update you local copy to update your fork on github push your changes
 git push
 ```
 
-The above commands will update your `master` branch from _upstream_. To update any other branch replace `master` with the respective branch name. 
+The above commands will update your `master` branch from _upstream_. To update any other branch replace `master` with the respective branch name.
 
 
 ## References

--- a/docs/contributors/git-workflow.md
+++ b/docs/contributors/git-workflow.md
@@ -36,14 +36,14 @@ To sum it up, you need to fetch any new changes in the repository, rebase your b
 ```sh
 git fetch
 git rebase master
-git push --force-with-lease your-branch-name
+git push --force-with-lease origin your-branch-name
 ```
 
 ## Keeping Your Fork Up To Date
 
 Working on pull request starts with forking the Gutenberg repository, your separate working copy. Which can easily go out of sync as new pull requests are merged into the main repository. Here your working repository is a `fork` and the main Gutenberg repository is `upstream`. When working on new pull request you should always update your fork before you do `git checkout -b my-new-branch` to work on a feature or fix.
 
-You will need to add an `upstream` origin in order to keep your fork updated.
+You will need to add an `upstream` remote in order to keep your fork updated.
 
 ```sh
 git remote add origin upstream https://github.com/WordPress/gutenberg.git


### PR DESCRIPTION
## Description
Added instructions to the "git workflow" docs about how to create an `upstream` remote, also added a missing word `origin` to another workflow step.

## How has this been tested?
Through reading and trying out the workflow steps.

## Types of changes
* enhancement: how to create an `upstream` remote
* bugfix: added missing remote to `git push --force-with-lease origin branch-name` step

## Checklist:
- [x] My docs are tested.
- [x] My docs follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My docs follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My docs have proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
