### PR TITLE
Fix: Dottips do not disappear when other parts of the editor are engaged

### DIFF
--- a/packages/e2e-test-utils/src/disable-pre-publish-checks.js
+++ b/packages/e2e-test-utils/src/disable-pre-publish-checks.js
@@ -2,10 +2,12 @@
  * Internal dependencies
  */
 import { toggleScreenOption } from './toggle-screen-option';
+import { toggleMoreMenu } from './toggle-more-menu';
 
 /**
  * Disables Pre-publish checks.
  */
 export async function disablePrePublishChecks() {
 	await toggleScreenOption( 'Pre-publish Checks', false );
+	await toggleMoreMenu();
 }

--- a/packages/e2e-test-utils/src/enable-pre-publish-checks.js
+++ b/packages/e2e-test-utils/src/enable-pre-publish-checks.js
@@ -2,10 +2,12 @@
  * Internal dependencies
  */
 import { toggleScreenOption } from './toggle-screen-option';
+import { toggleMoreMenu } from './toggle-more-menu';
 
 /**
  * Enables Pre-publish checks.
  */
 export async function enablePrePublishChecks() {
 	await toggleScreenOption( 'Pre-publish Checks', true );
+	await toggleMoreMenu();
 }

--- a/packages/e2e-test-utils/src/toggle-screen-option.js
+++ b/packages/e2e-test-utils/src/toggle-screen-option.js
@@ -3,7 +3,6 @@
  */
 import { clickOnCloseModalButton } from './click-on-close-modal-button';
 import { clickOnMoreMenuItem } from './click-on-more-menu-item';
-import { toggleMoreMenu } from './toggle-more-menu';
 
 /**
  * Toggles the screen option with the given label.
@@ -25,5 +24,4 @@ export async function toggleScreenOption( label, shouldBeChecked = undefined ) {
 	}
 
 	await clickOnCloseModalButton();
-	await toggleMoreMenu();
 }

--- a/packages/nux/src/components/dot-tip/index.js
+++ b/packages/nux/src/components/dot-tip/index.js
@@ -5,6 +5,7 @@ import { compose } from '@wordpress/compose';
 import { Popover, Button, IconButton } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { withSelect, withDispatch } from '@wordpress/data';
+import { useCallback, useRef } from '@wordpress/element';
 
 function getAnchorRect( anchor ) {
 	// The default getAnchorRect() excludes an element's top and bottom padding
@@ -27,6 +28,26 @@ export function DotTip( {
 	onDismiss,
 	onDisable,
 } ) {
+	const anchorParent = useRef( null );
+	const getAnchorRectCallback = useCallback(
+		( anchor ) => {
+			anchorParent.current = anchor.parentNode;
+			return getAnchorRect( anchor );
+		},
+		[ anchorParent ]
+	);
+	const onFocusOutsideCallback = useCallback(
+		( event ) => {
+			if ( ! anchorParent.current ) {
+				return;
+			}
+			if ( anchorParent.current.contains( event.relatedTarget ) ) {
+				return;
+			}
+			onDisable();
+		},
+		[ onDisable, anchorParent ]
+	);
 	if ( ! isVisible ) {
 		return null;
 	}
@@ -37,10 +58,11 @@ export function DotTip( {
 			position={ position }
 			noArrow
 			focusOnMount="container"
-			getAnchorRect={ getAnchorRect }
+			getAnchorRect={ getAnchorRectCallback }
 			role="dialog"
 			aria-label={ __( 'Editor tips' ) }
 			onClick={ onClick }
+			onFocusOutside={ onFocusOutsideCallback }
 		>
 			<p>{ children }</p>
 			<p>

--- a/packages/nux/src/components/dot-tip/test/__snapshots__/index.js.snap
+++ b/packages/nux/src/components/dot-tip/test/__snapshots__/index.js.snap
@@ -8,6 +8,7 @@ exports[`DotTip should render correctly 1`] = `
   getAnchorRect={[Function]}
   noArrow={true}
   onClick={[Function]}
+  onFocusOutside={[Function]}
   position="middle right"
   role="dialog"
 >


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/8181

This PR makes DotTips disappear when a click outside happens. The logic got a little bit more complex because we want to allow clicks on the target (outside the popover), so if the tip says to click the inserter and the user clicks the inserter the dot tips do not disappear.


## How has this been tested?
I opened block editor.
I cleaned the local storage by executing `window.localStorage.clear();` on the browser console.
I refreshed block editor and verified tips close if I click/focus outside them.
I redid the test and verified tips don't close if their target is clicked e.g: inserter on the first one.


cc: @mapk as the creator of the issue.