### PR TITLE
Block directory API: Add locale and version param

### DIFF
--- a/lib/class-wp-rest-block-directory-controller.php
+++ b/lib/class-wp-rest-block-directory-controller.php
@@ -219,6 +219,7 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 		}
 
 		include( ABSPATH . WPINC . '/version.php' );
+		global $wp_version;
 
 		$url = 'http://api.wordpress.org/plugins/info/1.2/';
 		$url = add_query_arg(
@@ -236,7 +237,6 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 			$url = set_url_scheme( $url, 'https' );
 		}
 
-		global $wp_version;
 		$http_args = array(
 			'timeout'    => 15,
 			'user-agent' => 'WordPress/' . $wp_version . '; ' . home_url( '/' ),

--- a/lib/class-wp-rest-block-directory-controller.php
+++ b/lib/class-wp-rest-block-directory-controller.php
@@ -227,7 +227,7 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 				'request[block]'      => $search_string,
 				'request[locale]'     => get_user_locale(),
 				'request[per_page]'   => '3',
-				'request[wp_version]' => '5.3',
+				'request[wp_version]' => substr( $wp_version, 0, 3 ),
 			),
 			$url
 		);

--- a/lib/class-wp-rest-block-directory-controller.php
+++ b/lib/class-wp-rest-block-directory-controller.php
@@ -225,8 +225,9 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 			array(
 				'action'              => 'query_plugins',
 				'request[block]'      => $search_string,
-				'request[wp_version]' => '5.3',
+				'request[locale]'     => get_user_locale(),
 				'request[per_page]'   => '3',
+				'request[wp_version]' => '5.3',
 			),
 			$url
 		);


### PR DESCRIPTION
To show the block description in the user language, this PR adds the user locale as parameter to the request. The WP version shouldn't be hard coded, so I changed it to the same format as in [plugins_api()](https://developer.wordpress.org/reference/functions/plugins_api/).

## Test
**Before** (User language is german, description english)
![api-before](https://user-images.githubusercontent.com/695201/65912329-4f9d7c80-e3ce-11e9-9d48-a66f3b79e2d3.png)


**After** (User language is german, description german)
![api-after](https://user-images.githubusercontent.com/695201/65912335-52986d00-e3ce-11e9-9a5f-d35608e2407a.png)
