### PR TITLE
Fix: include plural version in remove block(s) label

### DIFF
--- a/packages/block-editor/src/components/block-settings-menu/index.js
+++ b/packages/block-editor/src/components/block-settings-menu/index.js
@@ -6,7 +6,7 @@ import { castArray, flow } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _n } from '@wordpress/i18n';
 import {
 	Toolbar,
 	DropdownMenu,
@@ -117,7 +117,7 @@ export function BlockSettingsMenu( { clientIds } ) {
 											icon="trash"
 											shortcut={ shortcuts.removeBlock.display }
 										>
-											{ __( 'Remove Block' ) }
+											{ _n( 'Remove Block', 'Remove Blocks', count ) }
 										</MenuItem>
 									) }
 								</MenuGroup>


### PR DESCRIPTION
## Description
Even if multiple blocks are selected the elipsis/block menu says "Remove Block". This PR fixes this problem and when multiple blocks are selected the label now says "Remove Blocks".

## How has this been tested?
I selected a bloc, opened the block menu and verified the label was "Remove Block".
I selected multiple blocks, opened the block menu and verified the label was "Remove Blocks".