### PR TITLE
Fix typo: sidabar --> sidebar

### DIFF
--- a/lib/class-experimental-wp-widget-blocks-manager.php
+++ b/lib/class-experimental-wp-widget-blocks-manager.php
@@ -136,14 +136,14 @@ class Experimental_WP_Widget_Blocks_Manager {
 	}
 
 	/**
-	 * Verifies if a sidabar id is valid or not.
+	 * Verifies if a sidebar id is valid or not.
 	 *
 	 * @since 5.7.0
 	 *
 	 * @param string $sidebar_id Identifier of the sidebar.
 	 * @return boolean True if the $sidebar_id value is valid and false otherwise.
 	 */
-	public static function is_valid_sidabar_id( $sidebar_id ) {
+	public static function is_valid_sidebar_id( $sidebar_id ) {
 		$wp_registered_sidebars = self::get_wp_registered_sidebars();
 		return isset( $wp_registered_sidebars[ $sidebar_id ] );
 	}

--- a/lib/class-wp-rest-widget-areas-controller.php
+++ b/lib/class-wp-rest-widget-areas-controller.php
@@ -49,7 +49,7 @@ class WP_REST_Widget_Areas_Controller extends WP_REST_Controller {
 			'description'       => __( 'The sidebar’s ID.', 'gutenberg' ),
 			'type'              => 'string',
 			'required'          => true,
-			'validate_callback' => 'Experimental_WP_Widget_Blocks_Manager::is_valid_sidabar_id',
+			'validate_callback' => 'Experimental_WP_Widget_Blocks_Manager::is_valid_sidebar_id',
 		);
 
 		register_rest_route(


### PR DESCRIPTION
## Description
There is a typo in the function name _is_valid_sid**a**bar_id()_ --> _is_valid_sid**e**bar_id()_. This class is for internal usage and marked as experimental, so this change should be no problem.