### PR TITLE
Block Directory REST API cleanup

### DIFF
--- a/lib/class-wp-rest-block-directory-controller.php
+++ b/lib/class-wp-rest-block-directory-controller.php
@@ -84,7 +84,7 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 	 *
 	 * @return WP_Error|bool True if the request has permission, WP_Error object otherwise.
 	 */
-	public function get_items_permissions_check() {
+	public function get_items_permissions_check( $request ) {
 		if ( ! current_user_can( 'install_plugins' ) || ! current_user_can( 'activate_plugins' ) ) {
 			return new WP_Error(
 				'rest_user_cannot_view',

--- a/lib/class-wp-rest-block-directory-controller.php
+++ b/lib/class-wp-rest-block-directory-controller.php
@@ -204,9 +204,9 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 			global $wp_filesystem;
 			// Pass through the error from WP_Filesystem if one was raised.
 			if ( $wp_filesystem instanceof WP_Filesystem_Base && is_wp_error( $wp_filesystem->errors ) && $wp_filesystem->errors->has_errors() ) {
-				return WP_Error( 'unable_to_connect_to_filesystem', esc_html( $wp_filesystem->errors->get_error_message() ) );
+				return new WP_Error( 'unable_to_connect_to_filesystem', esc_html( $wp_filesystem->errors->get_error_message() ) );
 			}
-			return WP_Error( 'unable_to_connect_to_filesystem', __( 'Unable to connect to the filesystem. Please confirm your credentials.', 'gutenberg' ) );
+			return new WP_Error( 'unable_to_connect_to_filesystem', __( 'Unable to connect to the filesystem. Please confirm your credentials.', 'gutenberg' ) );
 		}
 
 		// Find the plugin to activate it.

--- a/lib/class-wp-rest-block-directory-controller.php
+++ b/lib/class-wp-rest-block-directory-controller.php
@@ -82,6 +82,7 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 	 *
 	 * @since 6.5.0
 	 *
+	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_Error|bool True if the request has permission, WP_Error object otherwise.
 	 */
 	public function get_items_permissions_check( $request ) {

--- a/lib/class-wp-rest-block-directory-controller.php
+++ b/lib/class-wp-rest-block-directory-controller.php
@@ -99,6 +99,8 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 		include_once( ABSPATH . 'wp-admin/includes/class-wp-upgrader.php' );
 		include_once( ABSPATH . 'wp-admin/includes/plugin-install.php' );
 
+		$slug = $request->get_param( 'slug' );
+
 		// Verify filesystem is accessible first.
 		$filesystem_available = self::is_filesystem_available();
 		if ( is_wp_error( $filesystem_available ) ) {
@@ -108,7 +110,7 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 		$api = plugins_api(
 			'plugin_information',
 			array(
-				'slug'   => $request->get_param( 'slug' ),
+				'slug'   => $slug,
 				'fields' => array(
 					'sections' => false,
 				),
@@ -146,13 +148,13 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 			return WP_Error( 'unable_to_connect_to_filesystem', __( 'Unable to connect to the filesystem. Please confirm your credentials.', 'gutenberg' ) );
 		}
 
-		$install_status = install_plugin_install_status( $api );
+		// Find the plugin to activate it.
+		$plugin_files = get_plugins( '/' . $slug );
+		$plugin_files = array_keys( $plugin_files );
 
-		$activate_result = activate_plugin( $install_status['file'] );
+		$plugin_file = $slug . '/' . reset( $plugin_files );
 
-		if ( is_wp_error( $activate_result ) ) {
-			return WP_Error( $activate_result->get_error_code(), $activate_result->get_error_message() );
-		}
+		activate_plugin( $plugin_file );
 
 		return rest_ensure_response( true );
 	}

--- a/lib/class-wp-rest-block-directory-controller.php
+++ b/lib/class-wp-rest-block-directory-controller.php
@@ -295,12 +295,15 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 		$block->icon = isset( $plugin['icons']['1x'] ) ? $plugin['icons']['1x'] : 'block-default';
 
 		$block->assets = array();
-
 		foreach ( $plugin['block_assets'] as $asset ) {
 			$block->assets[] = 'https://plugins.svn.wordpress.org/' . $plugin['slug'] . $asset;
 		}
 
-		$block->humanized_updated = human_time_diff( strtotime( $plugin['last_updated'] ), current_time( 'timestamp' ) ) . __( ' ago', 'gutenberg' );
+		$block->humanized_updated = sprintf(
+			/* translators: %s: Human-readable time difference. */
+			__( '%s ago', 'gutenberg' ),
+			human_time_diff( strtotime( $plugin['last_updated'] ), current_time( 'timestamp' ) )
+		);
 
 		return $block;
 	}

--- a/lib/class-wp-rest-block-directory-controller.php
+++ b/lib/class-wp-rest-block-directory-controller.php
@@ -32,14 +32,12 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 			$this->namespace,
 			'/' . $this->rest_base . '/search',
 			array(
-				array(
-					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => array( $this, 'get_items' ),
-					'permission_callback' => array( $this, 'get_items_permissions_check' ),
-					'args' => array(
-						'term' => array(
-							'required' => true,
-						),
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_items' ),
+				'permission_callback' => array( $this, 'get_items_permissions_check' ),
+				'args' => array(
+					'term' => array(
+						'required' => true,
 					),
 				),
 				'schema' => array( $this, 'get_item_schema' ),
@@ -50,14 +48,12 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 			$this->namespace,
 			'/' . $this->rest_base . '/install',
 			array(
-				array(
-					'methods'             => WP_REST_Server::CREATABLE,
-					'callback'            => array( $this, 'install_block' ),
-					'permission_callback' => array( $this, 'install_items_permissions_check' ),
-					'args' => array(
-						'slug' => array(
-							'required' => true,
-						),
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'install_block' ),
+				'permission_callback' => array( $this, 'install_items_permissions_check' ),
+				'args' => array(
+					'slug' => array(
+						'required' => true,
 					),
 				),
 				'schema' => array( $this, 'get_item_schema' ),
@@ -68,14 +64,12 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 			$this->namespace,
 			'/' . $this->rest_base . '/uninstall',
 			array(
-				array(
-					'methods'             => WP_REST_Server::DELETABLE,
-					'callback'            => array( $this, 'uninstall_block' ),
-					'permission_callback' => array( $this, 'delete_items_permissions_check' ),
-					'args' => array(
-						'slug' => array(
-							'required' => true,
-						),
+				'methods'             => WP_REST_Server::DELETABLE,
+				'callback'            => array( $this, 'uninstall_block' ),
+				'permission_callback' => array( $this, 'delete_items_permissions_check' ),
+				'args' => array(
+					'slug' => array(
+						'required' => true,
 					),
 				),
 				'schema' => array( $this, 'get_item_schema' ),

--- a/lib/class-wp-rest-block-directory-controller.php
+++ b/lib/class-wp-rest-block-directory-controller.php
@@ -315,7 +315,7 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 	/**
 	 * Determine if the endpoints are available.
 	 *
-	 * Only the 'Direct' filesystem transport is supported at present.
+	 * Only the 'Direct' filesystem transport, and SSH/FTP when credentials are stored are supported at present.
 	 *
 	 * @since 6.5.0
 	 *
@@ -323,11 +323,16 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 	 */
 	private static function is_filesystem_available() {
 		$filesystem_method = get_filesystem_method();
-		if ( 'direct' !== $filesystem_method ) {
-			return new WP_Error( 'fs_unavailable', 'The filesystem is currently unavailable for installing blocks.' );
+
+		ob_start();
+		$filesystem_credentials_are_stored = request_filesystem_credentials( self_admin_url() );
+		ob_end_clean();
+
+		if ( 'direct' === $filesystem_method || $filesystem_credentials_are_stored ) {
+			return true;
 		}
 
-		return true;
+		return new WP_Error( 'fs_unavailable', __( 'The filesystem is currently unavailable for installing blocks.', 'gutenberg' ) );
 	}
 
 	/**

--- a/lib/class-wp-rest-block-directory-controller.php
+++ b/lib/class-wp-rest-block-directory-controller.php
@@ -276,7 +276,7 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 		// There might be multiple blocks in a plugin. Only the first block is mapped.
 		$block_data   = reset( $plugin['blocks'] );
 		$block->name  = $block_data['name'];
-		$block->title = $block_data['title'];
+		$block->title = $block_data['title'] ?: $plugin['name'];
 
 		// Plugin's description, not description in block.json.
 		$block->description = wp_trim_words( wp_strip_all_tags( $plugin['description'] ), 30, '...' );

--- a/lib/class-wp-rest-block-directory-controller.php
+++ b/lib/class-wp-rest-block-directory-controller.php
@@ -218,39 +218,17 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 			return rest_ensure_response( array() );
 		}
 
-		include( ABSPATH . WPINC . '/version.php' );
+		require_once ABSPATH . 'wp-admin/includes/plugin-install.php';
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
 
-		$url = 'http://api.wordpress.org/plugins/info/1.2/';
-		$url = add_query_arg(
-			array(
-				'action'              => 'query_plugins',
-				'request[block]'      => $search_string,
-				'request[wp_version]' => '5.3',
-				'request[per_page]'   => '3',
-			),
-			$url
-		);
-		$ssl = wp_http_supports( array( 'ssl' ) );
-		if ( $ssl ) {
-			$url = set_url_scheme( $url, 'https' );
-		}
-
-		global $wp_version;
-		$http_args = array(
-			'timeout'    => 15,
-			'user-agent' => 'WordPress/' . $wp_version . '; ' . home_url( '/' ),
-		);
-
-		$request  = wp_remote_get( $url, $http_args );
-		$response = json_decode( wp_remote_retrieve_body( $request ), true );
-
-		if ( ! function_exists( 'get_plugins' ) ) {
-			require_once ABSPATH . 'wp-admin/includes/plugin.php';
-		}
+		$response = plugins_api( 'query_plugins', array(
+			'block' => $search_string,
+			'per_page' => 3
+		) );
 
 		$result = array();
 
-		foreach ( $response['plugins'] as $plugin ) {
+		foreach ( $response->plugins as $plugin ) {
 			$installed_plugins = get_plugins( '/' . $plugin['slug'] );
 
 			// Only show uninstalled blocks.

--- a/lib/class-wp-rest-block-directory-controller.php
+++ b/lib/class-wp-rest-block-directory-controller.php
@@ -212,7 +212,7 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 	 */
 	public function get_items( $request ) {
 
-		$search_string = $request->get_param( 'term' );
+		$search_string = trim( $request->get_param( 'term' ) );
 
 		if ( empty( $search_string ) ) {
 			return rest_ensure_response( array() );
@@ -274,6 +274,7 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 
 		$block->assets = array();
 		foreach ( $plugin['block_assets'] as $asset ) {
+			// TODO: Return from API, not client-set
 			$block->assets[] = 'https://plugins.svn.wordpress.org/' . $plugin['slug'] . $asset;
 		}
 

--- a/lib/class-wp-rest-block-directory-controller.php
+++ b/lib/class-wp-rest-block-directory-controller.php
@@ -35,12 +35,12 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_items' ),
 				'permission_callback' => array( $this, 'get_items_permissions_check' ),
-				'args' => array(
+				'args'                => array(
 					'term' => array(
 						'required' => true,
 					),
 				),
-				'schema' => array( $this, 'get_item_schema' ),
+				'schema'              => array( $this, 'get_item_schema' ),
 			)
 		);
 
@@ -51,12 +51,12 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 				'methods'             => WP_REST_Server::CREATABLE,
 				'callback'            => array( $this, 'install_block' ),
 				'permission_callback' => array( $this, 'install_items_permissions_check' ),
-				'args' => array(
+				'args'                => array(
 					'slug' => array(
 						'required' => true,
 					),
 				),
-				'schema' => array( $this, 'get_item_schema' ),
+				'schema'              => array( $this, 'get_item_schema' ),
 			)
 		);
 
@@ -67,12 +67,12 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 				'methods'             => WP_REST_Server::DELETABLE,
 				'callback'            => array( $this, 'uninstall_block' ),
 				'permission_callback' => array( $this, 'delete_items_permissions_check' ),
-				'args' => array(
+				'args'                => array(
 					'slug' => array(
 						'required' => true,
 					),
 				),
-				'schema' => array( $this, 'get_item_schema' ),
+				'schema'              => array( $this, 'get_item_schema' ),
 			)
 		);
 	}
@@ -82,10 +82,9 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 	 *
 	 * @since 6.5.0
 	 *
-	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_Error|bool True if the request has permission, WP_Error object otherwise.
 	 */
-	public function get_items_permissions_check( $request ) {
+	public function get_items_permissions_check() {
 		if ( ! current_user_can( 'install_plugins' ) || ! current_user_can( 'activate_plugins' ) ) {
 			return new WP_Error(
 				'rest_user_cannot_view',
@@ -255,7 +254,7 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 		}
 
 		$plugin_files = array_keys( $plugin_files );
-		$plugin_file = $slug . '/' . reset( $plugin_files );
+		$plugin_file  = $slug . '/' . reset( $plugin_files );
 
 		deactivate_plugins( $plugin_file );
 
@@ -287,10 +286,13 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 		require_once ABSPATH . 'wp-admin/includes/plugin-install.php';
 		require_once ABSPATH . 'wp-admin/includes/plugin.php';
 
-		$response = plugins_api( 'query_plugins', array(
-			'block' => $search_string,
-			'per_page' => 3
-		) );
+		$response = plugins_api(
+			'query_plugins',
+			array(
+				'block'    => $search_string,
+				'per_page' => 3,
+			)
+		);
 
 		$result = array();
 
@@ -343,7 +345,10 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 		// There might be multiple blocks in a plugin. Only the first block is mapped.
 		$block_data   = reset( $plugin['blocks'] );
 		$block->name  = $block_data['name'];
-		$block->title = $block_data['title'] ?: $plugin['name'];
+		$block->title = $block_data['title'];
+		if ( ! $block->title ) {
+			$block->title = $plugin['name'];
+		}
 
 		// Plugin's description, not description in block.json.
 		$block->description = wp_trim_words( wp_strip_all_tags( $plugin['description'] ), 30, '...' );
@@ -363,7 +368,7 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 
 		$block->assets = array();
 		foreach ( $plugin['block_assets'] as $asset ) {
-			// TODO: Return from API, not client-set
+			// TODO: Return from API, not client-set.
 			$block->assets[] = 'https://plugins.svn.wordpress.org/' . $plugin['slug'] . $asset;
 		}
 

--- a/lib/class-wp-rest-block-directory-controller.php
+++ b/lib/class-wp-rest-block-directory-controller.php
@@ -110,7 +110,7 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 		);
 
 		if ( is_wp_error( $api ) ) {
-			return new WP_Error( $api->get_error_code(), $api->get_error_message() );
+			return $api;
 		}
 
 		$skin     = new WP_Ajax_Upgrader_Skin();
@@ -125,15 +125,16 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 		$result = $upgrader->install( $api->download_link );
 
 		if ( is_wp_error( $result ) ) {
-			return WP_Error( $result->get_error_code(), $result->get_error_message() );
+			return $result;
 		}
 
+		// This should be the same as $result above.
 		if ( is_wp_error( $skin->result ) ) {
-			return WP_Error( $skin->$result->get_error_code(), $skin->$result->get_error_message() );
+			return $skin->result;
 		}
 
 		if ( $skin->get_errors()->has_errors() ) {
-			return WP_Error( $skin->$result->get_error_code(), $skin->$result->get_error_messages() );
+			return $skin->get_errors();
 		}
 
 		if ( is_null( $result ) ) {
@@ -196,7 +197,7 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 		$delete_result = delete_plugins( array( $install_status['file'] ) );
 
 		if ( is_wp_error( $delete_result ) ) {
-			return WP_Error( $delete_result->get_error_code(), $delete_result->get_error_message() );
+			return $delete_result;
 		}
 
 		return rest_ensure_response( true );

--- a/lib/class-wp-rest-block-directory-controller.php
+++ b/lib/class-wp-rest-block-directory-controller.php
@@ -110,7 +110,7 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 		);
 
 		if ( is_wp_error( $api ) ) {
-			return WP_Error( $api->get_error_code(), $api->get_error_message() );
+			return new WP_Error( $api->get_error_code(), $api->get_error_message() );
 		}
 
 		$skin     = new WP_Ajax_Upgrader_Skin();

--- a/lib/class-wp-rest-block-directory-controller.php
+++ b/lib/class-wp-rest-block-directory-controller.php
@@ -36,10 +36,16 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => array( $this, 'get_items' ),
 					'permission_callback' => array( $this, 'permissions_check' ),
+					'args' => array(
+						'term' => array(
+							'required' => true,
+						),
+					),
 				),
 				'schema' => array( $this, 'get_item_schema' ),
 			)
 		);
+
 		register_rest_route(
 			$this->namespace,
 			'/' . $this->rest_base . '/install',
@@ -48,10 +54,16 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 					'methods'             => WP_REST_Server::CREATABLE,
 					'callback'            => array( $this, 'install_block' ),
 					'permission_callback' => array( $this, 'permissions_check' ),
+					'args' => array(
+						'slug' => array(
+							'required' => true,
+						),
+					),
 				),
 				'schema' => array( $this, 'get_item_schema' ),
 			)
 		);
+
 		register_rest_route(
 			$this->namespace,
 			'/' . $this->rest_base . '/uninstall',
@@ -60,6 +72,11 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 					'methods'             => WP_REST_Server::DELETABLE,
 					'callback'            => array( $this, 'uninstall_block' ),
 					'permission_callback' => array( $this, 'permissions_check' ),
+					'args' => array(
+						'slug' => array(
+							'required' => true,
+						),
+					),
 				),
 				'schema' => array( $this, 'get_item_schema' ),
 			)

--- a/lib/class-wp-rest-block-directory-controller.php
+++ b/lib/class-wp-rest-block-directory-controller.php
@@ -35,7 +35,7 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 				array(
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => array( $this, 'get_items' ),
-					'permission_callback' => array( $this, 'permissions_check' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
 					'args' => array(
 						'term' => array(
 							'required' => true,
@@ -53,7 +53,7 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 				array(
 					'methods'             => WP_REST_Server::CREATABLE,
 					'callback'            => array( $this, 'install_block' ),
-					'permission_callback' => array( $this, 'permissions_check' ),
+					'permission_callback' => array( $this, 'install_items_permissions_check' ),
 					'args' => array(
 						'slug' => array(
 							'required' => true,
@@ -71,7 +71,7 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 				array(
 					'methods'             => WP_REST_Server::DELETABLE,
 					'callback'            => array( $this, 'uninstall_block' ),
-					'permission_callback' => array( $this, 'permissions_check' ),
+					'permission_callback' => array( $this, 'delete_items_permissions_check' ),
 					'args' => array(
 						'slug' => array(
 							'required' => true,
@@ -88,13 +88,64 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 	 *
 	 * @since 6.5.0
 	 *
+	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_Error|bool True if the request has permission, WP_Error object otherwise.
 	 */
-	public function permissions_check() {
+	public function get_items_permissions_check( $request ) {
 		if ( ! current_user_can( 'install_plugins' ) || ! current_user_can( 'activate_plugins' ) ) {
 			return new WP_Error(
 				'rest_user_cannot_view',
 				__( 'Sorry, you are not allowed to install blocks.', 'gutenberg' )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Checks whether a given request has permission to install and activate plugins.
+	 *
+	 * @since 6.5.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|bool True if the request has permission, WP_Error object otherwise.
+	 */
+	public function install_items_permissions_check( $request ) {
+		$plugin = $request->get_param( 'slug' );
+
+		if (
+			! current_user_can( 'install_plugins' ) ||
+			! current_user_can( 'activate_plugins' ) ||
+			! current_user_can( 'activate_plugin', $plugin )
+		) {
+			return new WP_Error(
+				'rest_user_cannot_view',
+				__( 'Sorry, you are not allowed to install blocks.', 'gutenberg' )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Checks whether a given request has permission to remove/deactivate plugins.
+	 *
+	 * @since 6.5.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|bool True if the request has permission, WP_Error object otherwise.
+	 */
+	public function delete_items_permissions_check( $request ) {
+		$plugin = $request->get_param( 'slug' );
+
+		if (
+			! current_user_can( 'delete_plugins' ) ||
+			! current_user_can( 'deactivate_plugins' ) ||
+			! current_user_can( 'deactivate_plugin', $plugin )
+		) {
+			return new WP_Error(
+				'rest_user_cannot_edit',
+				__( 'Sorry, you are not allowed to uninstall blocks.', 'gutenberg' )
 			);
 		}
 

--- a/lib/class-wp-rest-block-directory-controller.php
+++ b/lib/class-wp-rest-block-directory-controller.php
@@ -295,7 +295,6 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 		$block->icon = isset( $plugin['icons']['1x'] ) ? $plugin['icons']['1x'] : 'block-default';
 
 		$block->assets = array();
-
 		foreach ( $plugin['block_assets'] as $asset ) {
 			$block->assets[] = 'https://plugins.svn.wordpress.org/' . $plugin['slug'] . $asset;
 		}

--- a/lib/class-wp-rest-block-directory-controller.php
+++ b/lib/class-wp-rest-block-directory-controller.php
@@ -84,6 +84,7 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_Error|bool True if the request has permission, WP_Error object otherwise.
+	 * phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 	 */
 	public function get_items_permissions_check( $request ) {
 		if ( ! current_user_can( 'install_plugins' ) || ! current_user_can( 'activate_plugins' ) ) {
@@ -95,6 +96,7 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 
 		return true;
 	}
+	/* phpcs:enable */
 
 	/**
 	 * Checks whether a given request has permission to install and activate plugins.

--- a/lib/class-wp-rest-block-directory-controller.php
+++ b/lib/class-wp-rest-block-directory-controller.php
@@ -323,11 +323,15 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 	private static function is_filesystem_available() {
 		$filesystem_method = get_filesystem_method();
 
+		if ( 'direct' === $filesystem_method ) {
+			return true;
+		}
+
 		ob_start();
 		$filesystem_credentials_are_stored = request_filesystem_credentials( self_admin_url() );
 		ob_end_clean();
 
-		if ( 'direct' === $filesystem_method || $filesystem_credentials_are_stored ) {
+		if ( $filesystem_credentials_are_stored ) {
 			return true;
 		}
 


### PR DESCRIPTION
## Description

Fixes #17664, fixes #17535.

This PR contains a lot of changes, which is my first pass at the Block Directory rest api endpoints.

In short, the major components of this include:
 - A better `permission_callback` for each endpoint that calls the more fine-grained capabilities
 - Doesn't re-create WP_Error objects when returning from called functions (which also fixes some fatal errors in the error-handling branches)
 - Handles the installation process better using the `$plugin_slug` as the unique identifier internally, removing the need for multiple WordPress.org API calls
 - Uses `plugins_api()` where possible
 - Updates it to also allow block installation where FTP is in use, and the credentials are hard-coded (Still doesn't support the user entering FTP credentials, which I believe we don't really want to support).

There's a TODO remaining in the content where a change needs to be made on api.wordpress.org before the code can be altered.

## How has this been tested?
 1. Inserting Blocks that aren't installed into a post, and verifying that the REST API endpoints behave as expected
 2. That the Uninstall hook is triggered and cleans up the plugins as expected.

## Types of changes
This change is only code cleanup and bug fixes.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
