### PR TITLE
Avoid PHP warnings when Gutenberg plugin folder isn't writable.

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -494,15 +494,25 @@ function gutenberg_register_vendor_script( $handle, $src, $deps = array() ) {
 		// Determine whether we can write to this file.  If not, don't waste
 		// time doing a network request.
 		// @codingStandardsIgnoreStart
-		$f = @fopen( $full_path, 'a' );
+
+		$is_writable = is_writable( $full_path );
+		if ( $is_writable ) {
+			$f = @fopen( $full_path, 'a' );
+			if ( ! $f ) {
+				$is_writable = false;
+			} else {
+				fclose( $f );
+			}
+		}
+
 		// @codingStandardsIgnoreEnd
-		if ( ! $f ) {
+		if ( ! $is_writable ) {
 			// Failed to open the file for writing, probably due to server
 			// permissions.  Enqueue the script directly from the URL instead.
 			gutenberg_override_script( $handle, $src, $deps, null );
 			return;
 		}
-		fclose( $f );
+
 		$response = wp_remote_get( $src );
 		if ( wp_remote_retrieve_response_code( $response ) === 200 ) {
 			$f = fopen( $full_path, 'w' );


### PR DESCRIPTION
## Description
Running Gutenberg on a systems where the assets are not writable causes a raft of PHP warnings messages that are annoying and irritating. These are silenced through the usage of `@` but debuggers and things like Debug Bar pick it up.

For example, react.js and repeated for react-dom.js and lodash.js
> WARNING: wp-content/plugins/gutenberg/lib/client-assets.php:497 - fopen(/.../wp-content/plugins/gutenberg/vendor/react.eef5f5a3.js): failed to open stream: Permission denied
> require_once('wp-admin/admin-header.php'), do_action('admin_enqueue_scripts'), WP_Hook->do_action, WP_Hook->apply_filters, gutenberg_register_scripts_and_styles, gutenberg_register_vendor_scripts, gutenberg_register_vendor_script, fopen

The attached patch simply prefixes a `is_writable()` check.
I didn't use `wp_is_writable()` as that's primarily to work around ACL on windows hosts and Gutenberg development isn't designed to run on such a platform AFAIK.
The `fopen(.., 'a')` may not even still be needed with this check, but I've left it in there just in case.

## How has this been tested?
1. Loaded WordPress Admin pages, didn't see warnings.

## Types of changes
Bug Fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
