### PR TITLE
Autosave: Improve E2E test reliability by consuming synchronous data and bailing on save failure

### DIFF
--- a/packages/e2e-tests/specs/autosave.test.js
+++ b/packages/e2e-tests/specs/autosave.test.js
@@ -98,7 +98,7 @@ describe( 'autosave', () => {
 		// Trigger local autosave
 		await page.evaluate( () => window.wp.data.dispatch( 'core/editor' ).__experimentalLocalAutosave() );
 		// Reload without saving on the server
-		await page.reload();
+		await page.reload( { waitUntil: [ 'domcontentloaded', 'networkidle2' ] } );
 
 		const notice = await page.$eval( '.components-notice__content', ( element ) => element.innerText );
 		expect( notice ).toContain( AUTOSAVE_NOTICE_LOCAL );
@@ -144,7 +144,7 @@ describe( 'autosave', () => {
 		), await getCurrentPostId() );
 		expect( await page.evaluate( () => window.sessionStorage.length ) ).toBe( 1 );
 
-		await page.reload();
+		await page.reload( { waitUntil: [ 'domcontentloaded', 'networkidle2' ] } );
 		const notice = await page.$eval( '.components-notice__content', ( element ) => element.innerText );
 		expect( notice ).toContain( 'The backup of this post in your browser is different from the version below.' );
 
@@ -200,10 +200,10 @@ describe( 'autosave', () => {
 		await page.evaluate( () => window.wp.data.dispatch( 'core/editor' ).__experimentalLocalAutosave() );
 		expect( await page.evaluate( () => window.sessionStorage.length ) ).toBe( 1 );
 
-		await page.reload();
+		await page.reload( { waitUntil: [ 'domcontentloaded', 'networkidle2' ] } );
+		await sleep( 2 );
 
 		// Only one autosave notice should be displayed.
-		await sleep( 2 );
 		const notices = await page.$$( '.components-notice' );
 		expect( notices.length ).toBe( 1 );
 		const notice = await page.$eval( '.components-notice__content', ( element ) => element.innerText );

--- a/packages/e2e-tests/specs/autosave.test.js
+++ b/packages/e2e-tests/specs/autosave.test.js
@@ -98,7 +98,7 @@ describe( 'autosave', () => {
 		// Trigger local autosave
 		await page.evaluate( () => window.wp.data.dispatch( 'core/editor' ).__experimentalLocalAutosave() );
 		// Reload without saving on the server
-		await page.reload( { waitUntil: [ 'domcontentloaded', 'networkidle2' ] } );
+		await page.reload( { waitUntil: [ 'domcontentloaded' ] } );
 
 		const notice = await page.$eval( '.components-notice__content', ( element ) => element.innerText );
 		expect( notice ).toContain( AUTOSAVE_NOTICE_LOCAL );
@@ -144,7 +144,7 @@ describe( 'autosave', () => {
 		), await getCurrentPostId() );
 		expect( await page.evaluate( () => window.sessionStorage.length ) ).toBe( 1 );
 
-		await page.reload( { waitUntil: [ 'domcontentloaded', 'networkidle2' ] } );
+		await page.reload( { waitUntil: [ 'domcontentloaded' ] } );
 		const notice = await page.$eval( '.components-notice__content', ( element ) => element.innerText );
 		expect( notice ).toContain( 'The backup of this post in your browser is different from the version below.' );
 
@@ -200,8 +200,7 @@ describe( 'autosave', () => {
 		await page.evaluate( () => window.wp.data.dispatch( 'core/editor' ).__experimentalLocalAutosave() );
 		expect( await page.evaluate( () => window.sessionStorage.length ) ).toBe( 1 );
 
-		await page.reload( { waitUntil: [ 'domcontentloaded', 'networkidle2' ] } );
-		await sleep( 2 );
+		await page.reload( { waitUntil: [ 'domcontentloaded' ] } );
 
 		// Only one autosave notice should be displayed.
 		const notices = await page.$$( '.components-notice' );

--- a/packages/editor/src/components/local-autosave-monitor/index.js
+++ b/packages/editor/src/components/local-autosave-monitor/index.js
@@ -49,28 +49,17 @@ function useAutosaveNotice() {
 	const {
 		postId,
 		getEditedPostAttribute,
-		remoteAutosave,
-		hasFetchedAutosave,
-	} = useSelect( ( select ) => {
-		const _postId = select( 'core/editor' ).getCurrentPostId();
-		const postType = select( 'core/editor' ).getCurrentPostType();
-		const user = select( 'core' ).getCurrentUser();
-		return {
-			postId: _postId,
-			getEditedPostAttribute: select( 'core/editor' ).getEditedPostAttribute,
-			remoteAutosave: select( 'core' ).getAutosave( postType, _postId, user.id ),
-			hasFetchedAutosave: select( 'core' ).hasFetchedAutosaves( postType, _postId ) && user.id,
-		};
-	} );
+		hasRemoteAutosave,
+	} = useSelect( ( select ) => ( {
+		postId: select( 'core/editor' ).getCurrentPostId(),
+		getEditedPostAttribute: select( 'core/editor' ).getEditedPostAttribute,
+		hasRemoteAutosave: !! select( 'core/editor' ).getEditorSettings().autosave,
+	} ) );
 
 	const { createWarningNotice, removeNotice } = useDispatch( 'core/notices' );
 	const { editPost, resetEditorBlocks } = useDispatch( 'core/editor' );
 
 	useEffect( () => {
-		if ( ! hasFetchedAutosave ) {
-			return;
-		}
-
 		let localAutosave = localAutosaveGet( postId );
 		if ( ! localAutosave ) {
 			return;
@@ -100,7 +89,7 @@ function useAutosaveNotice() {
 			}
 		}
 
-		if ( remoteAutosave ) {
+		if ( hasRemoteAutosave ) {
 			return;
 		}
 
@@ -118,7 +107,7 @@ function useAutosaveNotice() {
 				},
 			],
 		} );
-	}, [ postId, hasFetchedAutosave ] );
+	}, [ postId ] );
 }
 
 /**
@@ -132,7 +121,6 @@ function useAutosavePurge() {
 		didError,
 	} = useSelect( ( select ) => ( {
 		postId: select( 'core/editor' ).getCurrentPostId(),
-		postType: select( 'core/editor' ).getCurrentPostType(),
 		isDirty: select( 'core/editor' ).isEditedPostDirty(),
 		isAutosaving: select( 'core/editor' ).isAutosavingPost(),
 		didError: select( 'core/editor' ).didPostSaveRequestFail(),


### PR DESCRIPTION
## Description

Recently-merged #17501 and #17503 greatly expanded the reach of autosaving and its E2E test coverage. These tests have been remarkably unreliable, especially on Travis, something which this PR sought to fix, and does fix in two main ways.

### Terminology preamble

A **local** autosave is an action — or its resulting object — performed on the client, the object then residing in `window.sessionStorage`. A **remote** autosave is a special kind of WordPress post revision saved on the WordPress site itself. Local autosaves are cheaper but more volatile, and can be performed more frequently, whereas remote autosaves are persisted across clients for a given WordPress user. Currently, per #17500, remote autosaves should take precedence over local ones._

### Fixes

1. How `LocalAutosaveMonitor` waits for remote autosave data.

* Until now, although we were requesting the entire remote autosave entity inside `LocalAutosaveMonitor`'s `useAutosaveNotice`, we only cared about the existence or absence of a remote autosave for the current post. `useAutosaveNotice` was requesting the entire remote entity because there were plans in #17501 to inspect and compare local and remote autosave objects, a requirement which was later dropped. This data needs to be resolved through the `core` data store.

* In contrast, the editor setting `autosave` is immediately available upon editor initialisation. It only contains an `editLink` property that links to a remote autosave's revision page, but most importantly it's an indication of whether there is a remote autosave available for the current post.

* Later on, _if_ we choose to reconcile remote and local autosaves with more sophistication, this could possibly be done based on recency of autosave — in which case we could might still get away with editor settings if the server provides this information (e.g. timestamp) inside the `autosave` object.

* This change should hopefully provide a more reliable page-loading experience for autosave's E2E tests.

2. How the `shouldn't conflict with server-side autosave` test bails under unexpected circumstances.

* Despite the changes described in 1., a particular test would still frequently fail. Debugging led to the conclusion that the test's forced remote autosaves might be failing for unknown reasons.

* This remote autosave failure is independent from the test's scope, which is to make sure that, concurrent remote and local autosaves for the current post, the editor will only show a notice to recover from the remote one.

* Thus, the temporary solution here is to let the test bail if, upon editor reload, it looks like there is no remote autosave available.

## How has this been tested?

E2E tests have been run extensively, and Travis should reliably green-light this branch.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
