### PR TITLE
fix(modal): refactors all occurances of isDismissable to isDismissible

### DIFF
--- a/packages/components/src/modal/README.md
+++ b/packages/components/src/modal/README.md
@@ -207,7 +207,7 @@ If this property is added, it will determine whether the modal requests to close
 - Required: No
 - Default: true
 
-#### isDismissable
+#### isDismissible
 
 If this property is set to false, the modal will not display a close icon and cannot be dismissed.
 

--- a/packages/components/src/modal/header.js
+++ b/packages/components/src/modal/header.js
@@ -8,7 +8,7 @@ import { __ } from '@wordpress/i18n';
  */
 import IconButton from '../icon-button';
 
-const ModalHeader = ( { icon, title, onClose, closeLabel, headingId, isDismissable } ) => {
+const ModalHeader = ( { icon, title, onClose, closeLabel, headingId, isDismissible } ) => {
 	const label = closeLabel ? closeLabel : __( 'Close dialog' );
 
 	return (
@@ -28,7 +28,7 @@ const ModalHeader = ( { icon, title, onClose, closeLabel, headingId, isDismissab
 					</h1>
 				}
 			</div>
-			{ isDismissable &&
+			{ isDismissible &&
 				<IconButton
 					onClick={ onClose }
 					icon="no-alt"

--- a/packages/components/src/modal/index.js
+++ b/packages/components/src/modal/index.js
@@ -119,8 +119,8 @@ class Modal extends Component {
 		const headingId = aria.labelledby || `components-modal-header-${ instanceId }`;
 
 		if ( isDismissable ) {
-			deprecated( 'isDismissable property', {
-				alternative: 'isDismissible',
+			deprecated( 'isDismissable prop of the Modal component', {
+				alternative: 'isDismissible prop (renamed) of the Modal component',
 			} );
 		}
 		// Disable reason: this stops mouse events from triggering tooltips and

--- a/packages/components/src/modal/index.js
+++ b/packages/components/src/modal/index.js
@@ -3,6 +3,7 @@
  */
 import { Component, createPortal } from '@wordpress/element';
 import { withInstanceId } from '@wordpress/compose';
+import { deprecated } from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -109,6 +110,7 @@ class Modal extends Component {
 			aria,
 			instanceId,
 			isDismissible,
+			isDismissable, //Deprecated
 			// Many of the documented props for Modal are passed straight through
 			// to the ModalFrame component and handled there.
 			...otherProps
@@ -116,6 +118,11 @@ class Modal extends Component {
 
 		const headingId = aria.labelledby || `components-modal-header-${ instanceId }`;
 
+		if ( isDismissable ) {
+			deprecated( 'isDismissable property', {
+				alternative: 'isDismissible',
+			} );
+		}
 		// Disable reason: this stops mouse events from triggering tooltips and
 		// other elements underneath the modal overlay.
 		return createPortal(
@@ -132,7 +139,7 @@ class Modal extends Component {
 						closeLabel={ closeButtonLabel }
 						headingId={ headingId }
 						icon={ icon }
-						isDismissible={ isDismissible }
+						isDismissible={ isDismissible || isDismissable }
 						onClose={ onRequestClose }
 						title={ title }
 					/>

--- a/packages/components/src/modal/index.js
+++ b/packages/components/src/modal/index.js
@@ -108,7 +108,7 @@ class Modal extends Component {
 			children,
 			aria,
 			instanceId,
-			isDismissable,
+			isDismissible,
 			// Many of the documented props for Modal are passed straight through
 			// to the ModalFrame component and handled there.
 			...otherProps
@@ -132,7 +132,7 @@ class Modal extends Component {
 						closeLabel={ closeButtonLabel }
 						headingId={ headingId }
 						icon={ icon }
-						isDismissable={ isDismissable }
+						isDismissible={ isDismissible }
 						onClose={ onRequestClose }
 						title={ title }
 					/>
@@ -151,7 +151,7 @@ Modal.defaultProps = {
 	focusOnMount: true,
 	shouldCloseOnEsc: true,
 	shouldCloseOnClickOutside: true,
-	isDismissable: true,
+	isDismissible: true,
 	/* accessibility */
 	aria: {
 		labelledby: null,

--- a/packages/editor/src/components/post-locked-modal/index.js
+++ b/packages/editor/src/components/post-locked-modal/index.js
@@ -156,7 +156,7 @@ class PostLockedModal extends Component {
 				focusOnMount={ true }
 				shouldCloseOnClickOutside={ false }
 				shouldCloseOnEsc={ false }
-				isDismissable={ false }
+				isDismissible={ false }
 				className="editor-post-locked-modal"
 			>
 				{ !! userAvatar && (


### PR DESCRIPTION
## Description
Refactors all occurences of `isDismissable` to `isDismissible` within `packages/components/src/modal` and `editor/src/components/post-locked-modal`

## How has this been tested?
- Reran all unit tests `npm test`
- Reran the wordpress locally after the changes (docker version 19.03.2, wordpress development version (5.3-beta2-46366))

## Types of changes
- Simple refactoring potentially 🤞 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->

## Picture of a cute animal:
![chicks-4003579_640](https://user-images.githubusercontent.com/87614/65992829-eb3ef380-e487-11e9-8dd7-ccaea52f649a.jpg)

Fixes #17687