### PR TITLE
Fix margin styles for gallery and social.

### DIFF
--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -12,6 +12,11 @@
 	}
 }
 
+figure.wp-block-gallery {
+	display: block;
+	margin: 0;
+}
+
 // need to override default editor ul styles
 .blocks-gallery-grid.blocks-gallery-grid {
 	margin-bottom: 0;

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -4,7 +4,8 @@
 	flex-wrap: wrap;
 	list-style-type: none;
 	padding: 0;
-	margin-bottom: 0;
+	// Some themes give all <ul> default margin instead of padding.
+	margin: 0;
 
 	.blocks-gallery-image,
 	.blocks-gallery-item {
@@ -143,7 +144,3 @@
 	}
 }
 
-figure.wp-block-gallery {
-	display: block;
-	margin: 0;
-}

--- a/packages/block-library/src/social-links/style.scss
+++ b/packages/block-library/src/social-links/style.scss
@@ -3,6 +3,8 @@
 	justify-content: flex-start;
 	padding-left: 0;
 	padding-right: 0;
+	// Some themes give all <ul> default margin instead of padding.
+	margin-left: 0;
 }
 
 .wp-social-link {


### PR DESCRIPTION
## Description

Fixes #17693.
Incidentally should also fix #17690.

Added margin overrides for the `<ul>`s in Gallery and Social blocks. (In the case of Gallery, for the current and deprecated markup versions both.)

## How has this been tested?

Checked with several themes, on desktop and mobile.

## Screenshots <!-- if applicable -->

<img width="803" alt="Screen Shot 2019-10-02 at 10 52 26 am" src="https://user-images.githubusercontent.com/8096000/66010554-bf148880-e502-11e9-8594-a6e500e6fc24.png">

<img width="305" alt="Screen Shot 2019-10-02 at 10 52 10 am" src="https://user-images.githubusercontent.com/8096000/66010556-c20f7900-e502-11e9-8d34-d4e96d4348ba.png">


## Types of changes
<!-- What types of changes does your code introduce?  -->
 Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
