### PR TITLE
Fix the browser warning for IconButton component.

### DIFF
--- a/packages/components/src/icon-button/index.js
+++ b/packages/components/src/icon-button/index.js
@@ -56,7 +56,7 @@ function IconButton( props, ref ) {
 			className={ classes }
 			ref={ ref }
 		>
-			<Icon icon={ icon } ariaPressed={ ariaPressed } />
+			<Icon icon={ icon } aria-pressed={ ariaPressed } />
 			{ children }
 		</Button>
 	);


### PR DESCRIPTION
## Description
I'm seeing this warning in the browser console on the latest master branch. This PR fixes it. It's a small one.

```
react-dom.8b3dda97.js:539 Warning: Invalid ARIA attribute `ariaPressed`. Did you mean `aria-pressed`?
    in svg (created by SVG)
    in SVG (created by Icon)
    in Icon (created by ForwardRef(IconButton))
    in button (created by ForwardRef(Button))
    in ForwardRef(Button) (created by ForwardRef(IconButton))
    in Tooltip (created by ForwardRef(IconButton))
    in ForwardRef(IconButton) (created by Dropdown)
    in div (created by Dropdown)
    in Dropdown (created by BlockNavigationDropdown)
    in BlockNavigationDropdown
    in Unknown (created by WithSelect(BlockNavigationDropdown))
    in WithSelect(BlockNavigationDropdown) (created by HeaderToolbar)
    in div (created by NavigableContainer)
    in NavigableContainer (created by ForwardRef(NavigableContainer))
    in ForwardRef(NavigableContainer) (created by ForwardRef(NavigableMenu))
    in ForwardRef(NavigableMenu) (created by NavigableToolbar)
    in NavigableToolbar (created by HeaderToolbar)
    in HeaderToolbar
    in Unknown (created by WithViewportMatch(HeaderToolbar))
    in WithViewportMatch(HeaderToolbar)
    in Unknown (created by WithSelect(WithViewportMatch(HeaderToolbar)))
    in WithSelect(WithViewportMatch(HeaderToolbar)) (created by Header)
    in div (created by Header)
    in div (created by Header)
    in Header (created by WithDispatch(Header))
    in WithDispatch(Header)
    in Unknown (created by WithSelect(WithDispatch(Header)))
    in WithSelect(WithDispatch(Header)) (created by Layout)
    in div (created by FocusReturnProvider)
    in FocusReturnProvider (created by Layout)
    in Layout
    in Unknown (created by WithViewportMatch(Layout))
    in WithViewportMatch(Layout) (created by NavigateRegions(WithViewportMatch(Layout)))
    in div (created by NavigateRegions(WithViewportMatch(Layout)))
    in NavigateRegions(WithViewportMatch(Layout)) (created by WithDispatch(NavigateRegions(WithViewportMatch(Layout))))
    in WithDispatch(NavigateRegions(WithViewportMatch(Layout)))
    in Unknown (created by WithSelect(WithDispatch(NavigateRegions(WithViewportMatch(Layout)))))
    in WithSelect(WithDispatch(NavigateRegions(WithViewportMatch(Layout)))) (created by Editor)
    in ErrorBoundary (created by Editor)
    in BlockEditorProvider (created by WithDispatch(BlockEditorProvider))
    in WithDispatch(BlockEditorProvider)
    in Unknown (created by Context.Consumer)
    in WithRegistryProvider(WithDispatch(BlockEditorProvider)) (created by EditorProvider)
    in EntityProvider (created by EditorProvider)
    in EditorProvider (created by WithDispatch(EditorProvider))
    in WithDispatch(EditorProvider)
    in Unknown (created by WithSelect(WithDispatch(EditorProvider)))
    in WithSelect(WithDispatch(EditorProvider))
    in Unknown (created by Context.Consumer)
    in WithRegistryProvider(WithSelect(WithDispatch(EditorProvider))) (created by Editor)
    in div (created by DropZoneProvider)
    in DropZoneProvider (created by Editor)
    in SlotFillProvider (created by Editor)
    in StrictMode (created by Editor)
    in Editor (created by WithDispatch(Editor))
    in WithDispatch(Editor)
    in Unknown (created by WithSelect(WithDispatch(Editor)))
    in WithSelect(WithDispatch(Editor))
```

## How has this been tested?
After the fix is applied, the warning no longer appears in the browser console.

**Operating System** Mac OSX 10
**Web Browser** Chrome 77.0.3865.9
**Screen Resolution** 2560 x 1440
**Browser Size** 2560 x 1306
**Javascript** Yes
**Cookies** Yes
**Color Depth** 24
**Flash Version** Not Installed
**User Agent** Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36

## Types of changes
I have renamed the prop being passed to `Icon` component. `ariaPressed => aria-pressed` (Nin-breaking)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
