### PR TITLE
Change z-index override logic for popovers.

### DIFF
--- a/assets/stylesheets/_z-index.scss
+++ b/assets/stylesheets/_z-index.scss
@@ -95,6 +95,7 @@ $z-layers: (
 	".components-popover.table-of-contents__popover": 99998,
 	".components-popover.block-editor-block-navigation__popover": 99998,
 	".components-popover.edit-post-more-menu__content": 99998,
+	".components-popover.block-editor-rich-text__inline-format-toolbar": 99998,
 
 	".components-autocomplete__results": 1000000,
 

--- a/assets/stylesheets/_z-index.scss
+++ b/assets/stylesheets/_z-index.scss
@@ -90,14 +90,11 @@ $z-layers: (
 	// #adminmenuwrap { z-index: 9990 }
 	".components-popover": 1000000,
 
-	// Shows adminbar quicklink submenu above bottom popover:
-	// #wpadminbar ul li {z-index: 99999;}
-	".components-popover:not(.is-mobile).is-bottom": 99990,
-
-	// Shows above edit post sidebar; Specificity needs to be higher than 3 classes.
-	".block-editor__container .components-popover.components-color-palette__picker.is-bottom": 100001,
-	".block-editor__container .components-popover.components-font-size-picker__dropdown-content.is-bottom": 100001,
-	".edit-post-post-visibility__dialog.components-popover.is-bottom": 100001,
+	// ...Except for popovers immediately beneath wp-admin menu on large breakpoints
+	".components-popover.block-editor-inserter__popover": 99998,
+	".components-popover.table-of-contents__popover": 99998,
+	".components-popover.block-editor-block-navigation__popover": 99998,
+	".components-popover.edit-post-more-menu__content": 99998,
 
 	".components-autocomplete__results": 1000000,
 

--- a/packages/block-editor/src/components/block-navigation/dropdown.js
+++ b/packages/block-editor/src/components/block-navigation/dropdown.js
@@ -22,6 +22,7 @@ function BlockNavigationDropdown( { hasBlocks, isDisabled } ) {
 
 	return	(
 		<Dropdown
+			contentClassName="editor-block-navigation__popover block-editor-block-navigation__popover"
 			renderToggle={ ( { isOpen, onToggle } ) => (
 				<>
 					{ isEnabled && <KeyboardShortcuts

--- a/packages/block-editor/src/components/block-navigation/style.scss
+++ b/packages/block-editor/src/components/block-navigation/style.scss
@@ -85,3 +85,7 @@ $tree-item-height: 36px;
 		background: $light-gray-300;
 	}
 }
+
+.components-popover.block-editor-block-navigation__popover {
+	z-index: z-index(".components-popover.block-editor-block-navigation__popover");
+}

--- a/packages/block-editor/src/components/font-sizes/style.scss
+++ b/packages/block-editor/src/components/font-sizes/style.scss
@@ -1,3 +1,0 @@
-.block-editor__container .components-popover.components-font-size-picker__dropdown-content.is-bottom {
-	z-index: z-index(".block-editor__container .components-popover.components-font-size-picker__dropdown-content.is-bottom");
-}

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -69,6 +69,10 @@ $block-inserter-search-height: 38px;
 	border-bottom-color: $white;
 }
 
+.components-popover.block-editor-inserter__popover {
+	z-index: z-index(".components-popover.block-editor-inserter__popover");
+}
+
 .components-popover input[type="search"].block-editor-inserter__search {
 	display: block;
 	margin: $grid-size-large;

--- a/packages/block-editor/src/components/rich-text/style.scss
+++ b/packages/block-editor/src/components/rich-text/style.scss
@@ -55,7 +55,7 @@ figcaption.block-editor-rich-text__editable [data-rich-text-placeholder]::before
 .components-popover.block-editor-rich-text__inline-format-toolbar {
 	// Set z-index as if it's displayed on the bottom, otherwise the block
 	// switcher popover might overlap if displayed on the bottom.
-	z-index: z-index(".components-popover:not(.is-mobile).is-bottom");
+	z-index: z-index(".components-popover.block-editor-rich-text__inline-format-toolbar");
 
 	.components-popover__content {
 		min-width: auto;

--- a/packages/block-editor/src/style.scss
+++ b/packages/block-editor/src/style.scss
@@ -17,7 +17,6 @@
 @import "./components/color-palette/control.scss";
 @import "./components/contrast-checker/style.scss";
 @import "./components/default-block-appender/style.scss";
-@import "./components/font-sizes/style.scss";
 @import "./components/inner-blocks/style.scss";
 @import "./components/inserter-with-shortcuts/style.scss";
 @import "./components/inserter/style.scss";

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -119,13 +119,8 @@
 			background-size: 100px 100%;
 			// Disable reason: This function call looks nicer when each argument is on its own line.
 			/* stylelint-disable */
-			background-image: linear-gradient(
-				-45deg,
-				theme(button) 28%,
-				color(theme(button) shade(20%)) 28%,
-				color(theme(button) shade(20%)) 72%,
-				theme(button) 72%
-			);
+			background-image:
+ linear-gradient(-45deg, theme(button) 28%, color(theme(button) shade(20%)) 28%, color(theme(button) shade(20%)) 72%, theme(button) 72%);
 			/* stylelint-enable */
 			border-color: color(theme(button));
 		}

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -119,8 +119,13 @@
 			background-size: 100px 100%;
 			// Disable reason: This function call looks nicer when each argument is on its own line.
 			/* stylelint-disable */
-			background-image:
- linear-gradient(-45deg, theme(button) 28%, color(theme(button) shade(20%)) 28%, color(theme(button) shade(20%)) 72%, theme(button) 72%);
+			background-image: linear-gradient(
+				-45deg,
+				theme(button) 28%,
+				color(theme(button) shade(20%)) 28%,
+				color(theme(button) shade(20%)) 72%,
+				theme(button) 72%
+			);
 			/* stylelint-enable */
 			border-color: color(theme(button));
 		}

--- a/packages/components/src/color-palette/style.scss
+++ b/packages/components/src/color-palette/style.scss
@@ -1,3 +1,0 @@
-.block-editor__container .components-popover.components-color-palette__picker.is-bottom {
-	z-index: z-index(".block-editor__container .components-popover.components-color-palette__picker.is-bottom");
-}

--- a/packages/components/src/popover/style.scss
+++ b/packages/components/src/popover/style.scss
@@ -123,7 +123,6 @@ $arrow-size: 8px;
 
 		&.is-bottom {
 			top: 100%;
-			z-index: z-index(".components-popover:not(.is-mobile).is-bottom");
 		}
 
 		&.is-middle {

--- a/packages/components/src/style.scss
+++ b/packages/components/src/style.scss
@@ -6,7 +6,6 @@
 @import "./checkbox-control/style.scss";
 @import "./circular-option-picker/style.scss";
 @import "./color-indicator/style.scss";
-@import "./color-palette/style.scss";
 @import "./color-picker/style.scss";
 @import "./dashicon/style.scss";
 @import "./date-time/style.scss";

--- a/packages/edit-post/src/components/header/more-menu/style.scss
+++ b/packages/edit-post/src/components/header/more-menu/style.scss
@@ -33,3 +33,7 @@
 		padding: 0;
 	}
 }
+
+.components-popover.edit-post-more-menu__content {
+	z-index: z-index(".components-popover.edit-post-more-menu__content");
+}

--- a/packages/editor/src/components/post-visibility/style.scss
+++ b/packages/editor/src/components/post-visibility/style.scss
@@ -32,7 +32,3 @@
 		margin-left: 28px;
 	}
 }
-
-.edit-post-post-visibility__dialog.components-popover.is-bottom {
-	z-index: z-index(".edit-post-post-visibility__dialog.components-popover.is-bottom");
-}

--- a/packages/editor/src/components/table-of-contents/style.scss
+++ b/packages/editor/src/components/table-of-contents/style.scss
@@ -2,6 +2,10 @@
 	min-width: 380px;
 }
 
+.components-popover.table-of-contents__popover {
+	z-index: z-index(".components-popover.table-of-contents__popover");
+}
+
 .table-of-contents__popover {
 	.components-popover__content {
 		padding: $grid-size-large;


### PR DESCRIPTION
## Description

New popovers in the sidebar won't display on mobile because of their z-index. This fixes that issue.

Found this issue while working on #17418 - turns out that `:not(.is-mobile)` actually targets all mobile instances of Dropdown/Popover _unless_ they are also set to `expandOnMobile`. 

The rule I'm removing was originally added to stop popovers at the top of the page from hiding the wp-admin bar dropdowns, but it is too general so over time a bunch of overrides for it have been added. 

My change removes that rule and the overrides, and instead adds specific rules to keep the z-index of the top-of-the-page popovers under wp-admin dropdowns.

## Steps to test

Open editor on desktop. Click to open block inserter, table of contents, or block navigation in the top toolbar, then hover over "+ New" on wp-admin bar so that the dropdown appears. Verify that the wp-admin dropdown is displaying over the popover from the editor toolbar.

Open editor on mobile. Select a text block and open settings bar for the block. Go to "Color settings"; clicking on "custom color" should bring up a popover.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Checked all the popovers I could find in the editor, on desktop and (emulated) mobile. Triple-checked the ones I added or removed specific rules for.

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
