### PR TITLE
Env: Add support for custom ports.

### DIFF
--- a/packages/env/.npmrc
+++ b/packages/env/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -15,8 +15,10 @@ wp-env <command>
 
 Commands:
   wp-env start [ref]          Starts WordPress for development on port 8888
-                              (​http://localhost:8888​) and tests on port 8889
-                              (​http://localhost:8889​). If the current working
+                              (​http://localhost:8888​) (override with
+                              WP_ENV_PORT) and tests on port 8889
+                              (​http://localhost:8889​) (override with
+                              WP_ENV_TESTS_PORT). If the current working
                               directory is a plugin and/or has e2e-tests with
                               plugins and/or mu-plugins, they will be mounted
                               appropiately.
@@ -34,10 +36,11 @@ Options:
 ```sh
 wp-env start [ref]
 
-Starts WordPress for development on port 8888 (​http://localhost:8888​) and
-tests on port 8889 (​http://localhost:8889​). If the current working directory
-is a plugin and/or has e2e-tests with plugins and/or mu-plugins, they will be
-mounted appropiately.
+Starts WordPress for development on port 8888 (​http://localhost:8888​)
+(override with WP_ENV_PORT) and tests on port 8889 (​http://localhost:8889​)
+(override with WP_ENV_TESTS_PORT). If the current working directory is a plugin
+and/or has e2e-tests with plugins and/or mu-plugins, they will be mounted
+appropiately.
 
 Positionals:
   ref  A `https://github.com/WordPress/WordPress` git repo branch or commit for
@@ -63,3 +66,5 @@ Positionals:
   environment  Which environments' databases to clean.
             [string] [choices: "all", "development", "tests"] [default: "tests"]
 ```
+
+<br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>

--- a/packages/env/lib/cli.js
+++ b/packages/env/lib/cli.js
@@ -46,10 +46,10 @@ module.exports = function cli() {
 			chalk`Starts WordPress for development on port {bold.underline ${ terminalLink(
 				'8888',
 				'http://localhost:8888'
-			) }} and tests on port {bold.underline ${ terminalLink(
+			) }} (override with WP_ENV_PORT) and tests on port {bold.underline ${ terminalLink(
 				'8889',
 				'http://localhost:8889'
-			) }}. If the current working directory is a plugin and/or has e2e-tests with plugins and/or mu-plugins, they will be mounted appropiately.`
+			) }} (override with WP_ENV_TESTS_PORT). If the current working directory is a plugin and/or has e2e-tests with plugins and/or mu-plugins, they will be mounted appropiately.`
 		),
 		( args ) => {
 			args.positional( 'ref', {

--- a/packages/env/lib/create-docker-compose-config.js
+++ b/packages/env/lib/create-docker-compose-config.js
@@ -11,7 +11,7 @@ module.exports = function createDockerComposeConfig(
       - ${ pluginPath }/../${ pluginName }-wordpress/:/var/www/html/${ commonVolumes }`;
 	const testsVolumes = `
       - tests-wordpress:/var/www/html/${ commonVolumes }`;
-	return `version: '2'
+	return `version: '2.1'
 volumes:
   tests-wordpress:
 services:
@@ -28,7 +28,7 @@ services:
       WORDPRESS_DB_PASSWORD: password
     image: wordpress
     ports:
-      - 8888:80
+      - \${WP_ENV_PORT:-8888}:80
     volumes:${ volumes }
   wordpress-cli:
     depends_on:
@@ -44,7 +44,7 @@ services:
       WORDPRESS_DB_PASSWORD: password
     image: wordpress
     ports:
-      - 8889:80
+      - \${WP_ENV_TESTS_PORT:-8889}:80
     volumes:${ testsVolumes }
   tests-wordpress-cli:
     depends_on:

--- a/packages/env/lib/env.js
+++ b/packages/env/lib/env.js
@@ -30,9 +30,11 @@ const wpCliRun = ( command, isTests = false ) =>
 	);
 const setupSite = ( isTests = false ) =>
 	wpCliRun(
-		`wp core install --url=localhost:888${
-			isTests ? '9' : '8'
-		} --title=Gutenberg --admin_user=admin --admin_password=password --admin_email=admin@wordpress.org`,
+		`wp core install --url=localhost:${
+			isTests ?
+				process.env.WP_ENV_TESTS_PORT || 8889 :
+				process.env.WP_ENV_PORT || 8888
+		} --title=${ pluginName } --admin_user=admin --admin_password=password --admin_email=admin@wordpress.org`,
 		isTests
 	);
 const activatePlugin = ( isTests = false ) =>

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/env",
-	"version": "1.0.0",
+	"version": "0.0.0",
 	"description": "A zero-config, self contained local WordPress environment for development and testing.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
Follows #17724

## Description

This PR adds support for setting custom ports for the development and tests environments of `@wordpress/env`.

It does this through two env variables, `WP_ENV_PORT`, and `WP_ENV_TESTS_PORT` respectively.

## How has this been tested?

It was verified that not setting the environment variables used the defaults `8888` for development and `8889` for tests.

It was also verified that everything works when using custom ports.

## Types of Changes

*New Feature:* Add support for custom ports to `@wordpress/env`.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
