### PR TITLE
[Tiny PR] Popover: smooth repositioning on scroll

### DIFF
--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -53,11 +53,11 @@ function useThrottledWindowScrollOrResize( handler, ignoredScrollableRef ) {
 		};
 
 		window.addEventListener( 'resize', throttledRefresh );
-		window.addEventListener( 'scroll', throttledRefresh );
+		window.addEventListener( 'scroll', throttledRefresh, true );
 
 		return () => {
 			window.removeEventListener( 'resize', throttledRefresh );
-			window.removeEventListener( 'scroll', throttledRefresh );
+			window.removeEventListener( 'scroll', throttledRefresh, true );
 		};
 	}, [] );
 }


### PR DESCRIPTION
## Description

Currently, popovers for blocks don't reposition smoothly because the anchor rect/element is in a nested scroll container:

* Block switcher
* Alignment
* Rich text collapsed buttons
* "More options" for the block
* Slash command
* Autocomplete in general (users)
* Potentially #17607

It looks like the event listener is only added for window scrolling, not nested container scrolling. The solution is to use the `useCapture` flag to listen for all scroll events, not just top-level scrolling.

## How has this been tested?

Open the block switcher popover and scroll the page. The popover should reposition instantly.

## Screenshots <!-- if applicable -->

| Before | After |
| --- | --- |
| ![popover](https://user-images.githubusercontent.com/4710635/66027822-634aff00-e504-11e9-8213-557793f5ecd1.gif) | ![popover-smooth](https://user-images.githubusercontent.com/4710635/66027824-634aff00-e504-11e9-9773-7c72fc141b58.gif) |

## Types of changes

Bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
