### PR TITLE
Typewriter: use DOMRect.top to fix for Edge

### DIFF
--- a/packages/block-editor/src/components/typewriter/index.js
+++ b/packages/block-editor/src/components/typewriter/index.js
@@ -129,7 +129,7 @@ class Typewriter extends Component {
 			return;
 		}
 
-		const diff = currentCaretRect.y - this.caretRect.y;
+		const diff = currentCaretRect.top - this.caretRect.top;
 
 		if ( diff === 0 ) {
 			return;
@@ -148,10 +148,10 @@ class Typewriter extends Component {
 			scrollContainer.scrollTop;
 		const scrollContainerY = windowScroll ?
 			0 :
-			scrollContainer.getBoundingClientRect().y;
+			scrollContainer.getBoundingClientRect().top;
 		const relativeScrollPosition = windowScroll ?
-			this.caretRect.y / window.innerHeight :
-			( this.caretRect.y - scrollContainerY ) /
+			this.caretRect.top / window.innerHeight :
+			( this.caretRect.top - scrollContainerY ) /
 			( window.innerHeight - scrollContainerY );
 
 		// If the scroll position is at the start, the active editable element
@@ -178,10 +178,10 @@ class Typewriter extends Component {
 		// view.
 		if (
 			// The caret is under the lower fold.
-			this.caretRect.y + this.caretRect.height >
+			this.caretRect.top + this.caretRect.height >
 				scrollContainerY + scrollContainerHeight ||
 			// The caret is above the upper fold.
-			this.caretRect.y < scrollContainerY
+			this.caretRect.top < scrollContainerY
 		) {
 			// Reset the caret position to maintain.
 			this.caretRect = currentCaretRect;


### PR DESCRIPTION
## Description

Fixes #17255. The problem is that Edge does not support the `y` property on `DOMRect`. Instead, we can use `top`.

## How has this been tested?
See #17255.
## Screenshots <!-- if applicable -->

## Types of changes
Bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
