### PR TITLE
Make sure that HTML that is sent is correctly updated.

### DIFF
--- a/packages/rich-text/src/component/index.native.js
+++ b/packages/rich-text/src/component/index.native.js
@@ -758,8 +758,12 @@ export class RichText extends Component {
 		if ( value === undefined ) {
 			this.lastEventCount = undefined; // force a refresh on the native side
 			value = '';
-		} 
-		
+		}
+		// On android if content is empty we need to send no content or else the placeholder with not show 
+		if ( ! this.iOS  && value === '') {
+			return value;
+		}
+
 		if ( tagName ) {
 			value = `<${ tagName }>${ value }</${ tagName }>`;
 		}

--- a/packages/rich-text/src/component/index.native.js
+++ b/packages/rich-text/src/component/index.native.js
@@ -753,13 +753,15 @@ export class RichText extends Component {
 
 	getHtmlToRender( record, tagName ) {
 		// Save back to HTML from React tree
-		const value = this.valueToFormat( record );
+		let value = this.valueToFormat( record );
 
-		if ( value === undefined || value === '' ) {
+		if ( value === undefined ) {
 			this.lastEventCount = undefined; // force a refresh on the native side
-			return '';
-		} else if ( tagName ) {
-			return `<${ tagName }>${ value }</${ tagName }>`;
+			value = '';
+		} 
+		
+		if ( tagName ) {
+			value = `<${ tagName }>${ value }</${ tagName }>`;
 		}
 		return value;
 	}

--- a/packages/rich-text/src/component/index.native.js
+++ b/packages/rich-text/src/component/index.native.js
@@ -440,7 +440,7 @@ export class RichText extends Component {
 	/**
 	 * Handles a paste event from the native Aztec Wrapper.
 	 *
-	 * @param {PasteEvent} event The paste event which wraps `nativeEvent`.
+	 * @param {Object} event The paste event which wraps `nativeEvent`.
 	 */
 	onPaste( event ) {
 		const {
@@ -759,8 +759,8 @@ export class RichText extends Component {
 			this.lastEventCount = undefined; // force a refresh on the native side
 			value = '';
 		}
-		// On android if content is empty we need to send no content or else the placeholder with not show 
-		if ( ! this.iOS  && value === '') {
+		// On android if content is empty we need to send no content or else the placeholder with not show.
+		if ( ! this.iOS && value === '' ) {
 			return value;
 		}
 


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
This PR updates the way the HTML is sent from RichText JS to the native side and make sure that even if the content is empty the **tagName** is always sent to the native component.

This will fix this [issue](https://github.com/wordpress-mobile/gutenberg-mobile/issues/1399).
## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Use the Gutenberg-mobile release 1.14.0 branch to test this PR, by pointing it to this branch.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
