### PR TITLE
Checkbox component: Hide conflicting checked styles in IE

### DIFF
--- a/packages/components/src/checkbox-control/style.scss
+++ b/packages/components/src/checkbox-control/style.scss
@@ -34,6 +34,11 @@ $checkbox-input-size-sm: 25px; // width + height for small viewports
 	&:checked {
 		background: #11a0d2;
 		border-color: #11a0d2;
+
+		// Hide default checkbox styles in IE.
+		&::-ms-check {
+			opacity: 0;
+		}
 	}
 
 	&:focus:checked {


### PR DESCRIPTION
Fixes #17680.

This PR hides the default `checked` checkbox styles in IE, to prevent them from interfering with the custom styles and SVG overlay that are baked into the `checkbox-control` component. I'm not sure if `opacity` is the best rule here, but it seemed fairly non-destructive. 

**Before**

<img width="262" alt="Screen Shot 2019-10-02 at 9 20 38 AM" src="https://user-images.githubusercontent.com/1202812/66047700-38f24500-e4f6-11e9-9da1-147e81679608.png">

**After**

<img width="262" alt="Screen Shot 2019-10-02 at 9 16 56 AM" src="https://user-images.githubusercontent.com/1202812/66047421-bbc6d000-e4f5-11e9-986e-5976e4c3228b.png">

---

Tested in IE11 on Windows 7.
