### PR TITLE
Add max-width to pinned icon SVGs.

### DIFF
--- a/packages/edit-post/src/components/header/pinned-plugins/style.scss
+++ b/packages/edit-post/src/components/header/pinned-plugins/style.scss
@@ -11,6 +11,11 @@
 		&.is-toggled {
 			margin-left: 5px;
 		}
+
+		svg {
+			max-width: 24px;
+			max-height: 24px;
+		}
 	}
 
 	// Colorize plugin icons to ensure contrast and cohesion, but allow plugin developers to override.


### PR DESCRIPTION
Mitigates https://github.com/WordPress/gutenberg/issues/17719.

![Screenshot 2019-10-02 at 19 41 24](https://user-images.githubusercontent.com/1204802/66067813-a92bb580-e54c-11e9-8972-ab594d0f9680.png)

It's not perfect, because those drop-it icons aren't designed with any clearance. But at least it's a last-defence failsafe. 

In https://github.com/WordPress/gutenberg/issues/17719#issuecomment-537602431 we figured out the cause of the regression. This regression should be fixed separately. But this PR could serve as an addition to that. 