### PR TITLE
Fix: Heading and paragraph colors not applied inside the cover block

### DIFF
--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -37,7 +37,6 @@
 	h2,
 	.wp-block-cover-image-text,
 	.wp-block-cover-text {
-		color: $white;
 		font-size: 2em;
 		line-height: 1.25;
 		z-index: 1;
@@ -45,7 +44,12 @@
 		max-width: $content-width;
 		padding: $block-padding;
 		text-align: center;
+	}
 
+	h2:not(.has-text-color),
+	.wp-block-cover-image-text,
+	.wp-block-cover-text {
+		color: $white;
 		a,
 		a:hover,
 		a:focus,
@@ -130,7 +134,9 @@
 	h5,
 	h6,
 	.wp-block-subhead {
-		color: inherit;
+		&:not(.has-text-color) {
+			color: inherit;
+		}
 	}
 }
 


### PR DESCRIPTION
## Description
Fixes: https://github.com/WordPress/gutenberg/issues/17706

The cover block had a rule to make paragraphs and headings inherit the color. This rule had higher specificity then what most themes use in their color classes so it made the colors selected by users not applicable inside the cover block.

This PR fixes the problem by not applying color rules if the class has-text-color is present.
Meanwhile, I discovered that the heading block is not adding this class when it should. I'm creating a parallel PR to address this issue.

## How has this been tested?
I used the 2020 theme.
I added a cover block.
I added a paragraph inside it.
I selected the color "accent" in the color palette (first one).
I checked the post on the front end and verified the color was applied as expected (in master the color was white).
