### PR TITLE
Use body color for post publish panel

### DIFF
--- a/packages/editor/src/components/post-publish-panel/style.scss
+++ b/packages/editor/src/components/post-publish-panel/style.scss
@@ -1,6 +1,5 @@
 .editor-post-publish-panel {
 	background: $white;
-	color: $dark-gray-500;
 }
 
 .editor-post-publish-panel__content {


### PR DESCRIPTION
## Description
Attempts to fix #17686

There's currently a slight variation of text color on the post publish panel and the post visibility settings popover on the sidebar:

<img width="665" alt="66005169-4bc23680-e470-11e9-9244-a252a87a608f" src="https://user-images.githubusercontent.com/3276087/66085790-d5890700-e537-11e9-9582-73fc22ddc97f.png">

This PR fixes this by removing what I think is an unnecessary color declaration on `.editor-post-publish-panel`. This change makes the panel to use the default body color, which is also used on the visibility settings popover.

## Screenshots <!-- if applicable -->

<img width="294" alt="Screen Shot 2019-10-02 at 5 07 22 PM" src="https://user-images.githubusercontent.com/3276087/66085864-08cb9600-e538-11e9-8268-45dcb77a9ab7.png">


## Types of changes
- CSS
- Visual changes

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
