### PR TITLE
Ignore translating gutenberg support link

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -58,7 +58,7 @@ function gutenberg_menu() {
 		$submenu['gutenberg'][] = array(
 			__( 'Support', 'gutenberg' ),
 			'edit_posts',
-			__( 'https://wordpress.org/support/plugin/gutenberg', 'gutenberg' ),
+			'https://wordpress.org/support/plugin/gutenberg',
 		);
 
 		$submenu['gutenberg'][] = array(


### PR DESCRIPTION
## Description
Gutenberg support link is registered as a translatable link which is pointless. This PR has a small change that ignore this link being translated.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
