### PR TITLE
Try: Move figure clearing CSS to editor style.

### DIFF
--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -1,6 +1,10 @@
 .wp-block-image {
 	position: relative;
 
+	// This resets the intrinsic margin on the figure in non-floated, wide, and full-wide alignments.
+	margin-left: 0;
+	margin-right: 0;
+
 	&.is-transient img {
 		opacity: 0.3;
 	}

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -18,10 +18,6 @@
 		width: 100%;
 	}
 
-	// This resets the intrinsic margin on the figure in non-floated, wide, and full-wide alignments.
-	margin-left: 0;
-	margin-right: 0;
-
 	// Floats get an extra wrapping <div> element, so the <figure> becomes a child.
 	.alignleft,
 	.alignright,


### PR DESCRIPTION
Fixes #11234. Alternative to #10228.

This PR fixes an issue where styles meant for the editor bled into the theme.

The editor has styles for alignleft, center, right, wide, fullwide. But it does not output styles for wide and fullwide to the theme itself. The idea is for theme developers to write their own `alignfull` rules in the theme, and that by opting in using `add_theme_support( 'align-wide' );`, they explicitly declare to have written those rules. 

This is mainly because there are a million different ways to add wide alignments — negative margins, unbounded main column, `vw` units. And even then, what full-wide means can be _interpreted differently_ by the theme, just like how TwentyNineteen interprets Align Right to pull it out of the main column.

#10228, although it fixed a problem and is needed, output that fix to the style file, which outputs it on the frontend also. That was a mistake. It should be editor only.