### PR TITLE
Fallback to the default block content if there's no preview for the currently hovered block

### DIFF
--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -270,6 +270,7 @@ export class InserterMenu extends Component {
 		const hasItems = ! isEmpty( suggestedItems ) || ! isEmpty( reusableItems ) || ! isEmpty( itemsPerCategory );
 		const hoveredItemBlockType = hoveredItem ? getBlockType( hoveredItem.name ) : null;
 		const hasHelpPanel = hasItems && showInserterHelpPanel;
+		const shouldShowBlockHelpPanel = hasHelpPanel && hoveredItem && ( isReusableBlock( hoveredItem ) || hoveredItemBlockType.example );
 
 		// Disable reason (no-autofocus): The inserter menu is a modal display, not one which
 		// is always visible, and one which already incurs this behavior of autoFocus via
@@ -387,28 +388,26 @@ export class InserterMenu extends Component {
 
 				{ hasHelpPanel && (
 					<div className="block-editor-inserter__menu-help-panel">
-						{ hoveredItem && (
+						{ shouldShowBlockHelpPanel && (
 							<>
 								{ ! isReusableBlock( hoveredItem ) && (
 									<BlockCard blockType={ hoveredItemBlockType } />
 								) }
-								{ ( isReusableBlock( hoveredItem ) || hoveredItemBlockType.example ) && (
-									<div className="block-editor-inserter__preview">
-										<div className="block-editor-inserter__preview-content">
-											<BlockPreview
-												viewportWidth={ 500 }
-												blocks={
-													hoveredItemBlockType.example ?
-														getBlockFromExample( hoveredItem.name, hoveredItemBlockType.example ) :
-														createBlock( hoveredItem.name, hoveredItem.initialAttributes )
-												}
-											/>
-										</div>
+								<div className="block-editor-inserter__preview">
+									<div className="block-editor-inserter__preview-content">
+										<BlockPreview
+											viewportWidth={ 500 }
+											blocks={
+												hoveredItemBlockType.example ?
+													getBlockFromExample( hoveredItem.name, hoveredItemBlockType.example ) :
+													createBlock( hoveredItem.name, hoveredItem.initialAttributes )
+											}
+										/>
 									</div>
-								) }
+								</div>
 							</>
 						) }
-						{ ! hoveredItem && (
+						{ ! shouldShowBlockHelpPanel && (
 							<div className="block-editor-inserter__menu-help-panel-no-block">
 								<div className="block-editor-inserter__menu-help-panel-no-block-text">
 									<div className="block-editor-inserter__menu-help-panel-title">{ __( 'Content Blocks' ) }</div>


### PR DESCRIPTION
closes #17720

The idea is that if a block doesn't have an "example", avoid showing the specific block help panel for that block and fallback to the default content there to avoid the feeling of a "broken panel".