### PR TITLE
Components: Cleanup Dashicons component

### DIFF
--- a/packages/components/src/dashicon/icon-class.js
+++ b/packages/components/src/dashicon/icon-class.js
@@ -1,3 +1,0 @@
-export const getIconClassName = ( icon, className ) => {
-	return [ 'dashicon', 'dashicons-' + icon, className ].filter( Boolean ).join( ' ' );
-};

--- a/packages/components/src/dashicon/icon-class.native.js
+++ b/packages/components/src/dashicon/icon-class.native.js
@@ -1,3 +1,0 @@
-export const getIconClassName = ( icon, className, ariaPressed ) => {
-	return [ ariaPressed ? 'dashicon-active' : 'dashicon', 'dashicons-' + icon, className ].filter( Boolean ).join( ' ' );
-};

--- a/packages/components/src/dashicon/index.js
+++ b/packages/components/src/dashicon/index.js
@@ -14,11 +14,10 @@ import { Component } from '@wordpress/element';
  * Internal dependencies
  */
 import { Path, SVG } from '../primitives';
-import { getIconClassName } from './icon-class';
 
 export default class Dashicon extends Component {
 	render() {
-		const { icon, size = 20, className, ariaPressed, ...extraProps } = this.props;
+		const { icon, size = 20, className, ...extraProps } = this.props;
 		let path;
 
 		switch ( icon ) {
@@ -892,7 +891,7 @@ export default class Dashicon extends Component {
 			return null;
 		}
 
-		const iconClass = getIconClassName( icon, className, ariaPressed );
+		const iconClass = [ 'dashicon', 'dashicons-' + icon, className ].filter( Boolean ).join( ' ' );
 
 		return (
 			<SVG


### PR DESCRIPTION
## Description
This is a follow-up for #17356 where we refactored `IconButton` component to no longer pass down `ariaPressed` prop. This means that it's no longer used in the code and it should be removed from the child components which were reading its value.

> I checked the history and it looks like `ariaPressed` was introduced in https://github.com/WordPress/gutenberg/pull/11827. It was never really used in the web code. Should it be also removed in other places?
> 
> In particular, I think about `Dashicon` implementation which used to pass this prop down but it seems to longer be necessary. See: https://github.com/WordPress/gutenberg/blob/eb3a82f4354ea18c349b92279d798fdbfa00f8e2/packages/components/src/dashicon/index.js#L895

I updated `Dashicon` to look closer to:
https://github.com/WordPress/dashicons/blob/master/react/index.jsx


## Testing

Steps from #17356 are the best way to validate it:

- Run the example app with Xcode 11 beta
- Check that the toolbar colors are correct on the toolbar (following the screenshots)
- Check that the rest of the icons in the app shows properly
- In particular the BottomSheet icons (Add link / Image settings)
- Check that the icon Subscript is colored properly (Numbers on H1, H2, etc...)