### PR TITLE
Add has-text-color class to heading block.

### DIFF
--- a/packages/block-library/src/heading/deprecated.js
+++ b/packages/block-library/src/heading/deprecated.js
@@ -43,6 +43,38 @@ const blockAttributes = {
 
 const deprecated = [
 	{
+		attributes: blockAttributes,
+		save( { attributes } ) {
+			const {
+				align,
+				content,
+				customTextColor,
+				level,
+				textColor,
+			} = attributes;
+			const tagName = 'h' + level;
+
+			const textClass = getColorClassName( 'color', textColor );
+
+			const className = classnames( {
+				[ textClass ]: textClass,
+				[ `has-text-align-${ align }` ]: align,
+			} );
+
+			return (
+				<RichText.Content
+					className={ className ? className : undefined }
+					tagName={ tagName }
+					style={ {
+						color: textClass ? undefined : customTextColor,
+					} }
+					value={ content }
+				/>
+			);
+		},
+		supports: blockSupports,
+	},
+	{
 		supports: blockSupports,
 		attributes: blockAttributes,
 		save( { attributes } ) {

--- a/packages/block-library/src/heading/save.js
+++ b/packages/block-library/src/heading/save.js
@@ -25,6 +25,7 @@ export default function save( { attributes } ) {
 
 	const className = classnames( {
 		[ textClass ]: textClass,
+		'has-text-color': textColor || customTextColor,
 		[ `has-text-align-${ align }` ]: align,
 	} );
 

--- a/packages/e2e-tests/fixtures/block-transforms.js
+++ b/packages/e2e-tests/fixtures/block-transforms.js
@@ -181,6 +181,14 @@ export const EXPECTED_TRANSFORMS = {
 		originalBlock: 'Group',
 		availableTransforms: [],
 	},
+	'core__heading__h2-color': {
+		originalBlock: 'Heading',
+		availableTransforms: [
+			'Quote',
+			'Group',
+			'Paragraph',
+		],
+	},
 	'core__heading__h4-em': {
 		originalBlock: 'Heading',
 		availableTransforms: [

--- a/packages/e2e-tests/fixtures/blocks/core__heading__deprecated-2.html
+++ b/packages/e2e-tests/fixtures/blocks/core__heading__deprecated-2.html
@@ -1,0 +1,3 @@
+<!-- wp:heading {"textColor":"accent"} -->
+<h2 class="has-accent-color">text</h2>
+<!-- /wp:heading -->

--- a/packages/e2e-tests/fixtures/blocks/core__heading__deprecated-2.json
+++ b/packages/e2e-tests/fixtures/blocks/core__heading__deprecated-2.json
@@ -1,0 +1,14 @@
+[
+    {
+        "clientId": "_clientId_0",
+        "name": "core/heading",
+        "isValid": true,
+        "attributes": {
+            "content": "text",
+            "level": 2,
+            "textColor": "accent"
+        },
+        "innerBlocks": [],
+        "originalContent": "<h2 class=\"has-accent-color\">text</h2>"
+    }
+]

--- a/packages/e2e-tests/fixtures/blocks/core__heading__deprecated-2.parsed.json
+++ b/packages/e2e-tests/fixtures/blocks/core__heading__deprecated-2.parsed.json
@@ -1,0 +1,22 @@
+[
+    {
+        "blockName": "core/heading",
+        "attrs": {
+            "textColor": "accent"
+        },
+        "innerBlocks": [],
+        "innerHTML": "\n<h2 class=\"has-accent-color\">text</h2>\n",
+        "innerContent": [
+            "\n<h2 class=\"has-accent-color\">text</h2>\n"
+        ]
+    },
+    {
+        "blockName": null,
+        "attrs": {},
+        "innerBlocks": [],
+        "innerHTML": "\n",
+        "innerContent": [
+            "\n"
+        ]
+    }
+]

--- a/packages/e2e-tests/fixtures/blocks/core__heading__deprecated-2.serialized.html
+++ b/packages/e2e-tests/fixtures/blocks/core__heading__deprecated-2.serialized.html
@@ -1,0 +1,3 @@
+<!-- wp:heading {"textColor":"accent"} -->
+<h2 class="has-accent-color has-text-color">text</h2>
+<!-- /wp:heading -->

--- a/packages/e2e-tests/fixtures/blocks/core__heading__deprecated-3.html
+++ b/packages/e2e-tests/fixtures/blocks/core__heading__deprecated-3.html
@@ -1,0 +1,3 @@
+<!-- wp:heading {"customTextColor":"#268ebb"} -->
+<h2 style="color:#268ebb">Text</h2>
+<!-- /wp:heading -->

--- a/packages/e2e-tests/fixtures/blocks/core__heading__deprecated-3.json
+++ b/packages/e2e-tests/fixtures/blocks/core__heading__deprecated-3.json
@@ -1,0 +1,14 @@
+[
+    {
+        "clientId": "_clientId_0",
+        "name": "core/heading",
+        "isValid": true,
+        "attributes": {
+            "content": "Text",
+            "level": 2,
+            "customTextColor": "#268ebb"
+        },
+        "innerBlocks": [],
+        "originalContent": "<h2 style=\"color:#268ebb\">Text</h2>"
+    }
+]

--- a/packages/e2e-tests/fixtures/blocks/core__heading__deprecated-3.parsed.json
+++ b/packages/e2e-tests/fixtures/blocks/core__heading__deprecated-3.parsed.json
@@ -1,0 +1,22 @@
+[
+    {
+        "blockName": "core/heading",
+        "attrs": {
+            "customTextColor": "#268ebb"
+        },
+        "innerBlocks": [],
+        "innerHTML": "\n<h2 style=\"color:#268ebb\">Text</h2>\n",
+        "innerContent": [
+            "\n<h2 style=\"color:#268ebb\">Text</h2>\n"
+        ]
+    },
+    {
+        "blockName": null,
+        "attrs": {},
+        "innerBlocks": [],
+        "innerHTML": "\n",
+        "innerContent": [
+            "\n"
+        ]
+    }
+]

--- a/packages/e2e-tests/fixtures/blocks/core__heading__deprecated-3.serialized.html
+++ b/packages/e2e-tests/fixtures/blocks/core__heading__deprecated-3.serialized.html
@@ -1,0 +1,3 @@
+<!-- wp:heading {"customTextColor":"#268ebb"} -->
+<h2 class="has-text-color" style="color:#268ebb">Text</h2>
+<!-- /wp:heading -->

--- a/packages/e2e-tests/fixtures/blocks/core__heading__h2-color.html
+++ b/packages/e2e-tests/fixtures/blocks/core__heading__h2-color.html
@@ -1,0 +1,4 @@
+<!-- wp:heading {"textColor":"accent"} -->
+<h2 class="has-accent-color has-text-color">Text</h2>
+<!-- /wp:heading -->
+

--- a/packages/e2e-tests/fixtures/blocks/core__heading__h2-color.json
+++ b/packages/e2e-tests/fixtures/blocks/core__heading__h2-color.json
@@ -1,0 +1,14 @@
+[
+    {
+        "clientId": "_clientId_0",
+        "name": "core/heading",
+        "isValid": true,
+        "attributes": {
+            "content": "Text",
+            "level": 2,
+            "textColor": "accent"
+        },
+        "innerBlocks": [],
+        "originalContent": "<h2 class=\"has-accent-color has-text-color\">Text</h2>"
+    }
+]

--- a/packages/e2e-tests/fixtures/blocks/core__heading__h2-color.parsed.json
+++ b/packages/e2e-tests/fixtures/blocks/core__heading__h2-color.parsed.json
@@ -1,0 +1,22 @@
+[
+    {
+        "blockName": "core/heading",
+        "attrs": {
+            "textColor": "accent"
+        },
+        "innerBlocks": [],
+        "innerHTML": "\n<h2 class=\"has-accent-color has-text-color\">Text</h2>\n",
+        "innerContent": [
+            "\n<h2 class=\"has-accent-color has-text-color\">Text</h2>\n"
+        ]
+    },
+    {
+        "blockName": null,
+        "attrs": {},
+        "innerBlocks": [],
+        "innerHTML": "\n\n",
+        "innerContent": [
+            "\n\n"
+        ]
+    }
+]

--- a/packages/e2e-tests/fixtures/blocks/core__heading__h2-color.serialized.html
+++ b/packages/e2e-tests/fixtures/blocks/core__heading__h2-color.serialized.html
@@ -1,0 +1,3 @@
+<!-- wp:heading {"textColor":"accent"} -->
+<h2 class="has-accent-color has-text-color">Text</h2>
+<!-- /wp:heading -->

--- a/packages/e2e-tests/specs/__snapshots__/block-transforms.test.js.snap
+++ b/packages/e2e-tests/specs/__snapshots__/block-transforms.test.js.snap
@@ -74,6 +74,18 @@ exports[`Block transforms correctly transform block Heading in fixture core__hea
 <!-- /wp:quote -->"
 `;
 
+exports[`Block transforms correctly transform block Heading in fixture core__heading__h2-color into the Paragraph block 1`] = `
+"<!-- wp:paragraph -->
+<p>Text</p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`Block transforms correctly transform block Heading in fixture core__heading__h2-color into the Quote block 1`] = `
+"<!-- wp:quote -->
+<blockquote class=\\"wp-block-quote\\"><p>Text</p></blockquote>
+<!-- /wp:quote -->"
+`;
+
 exports[`Block transforms correctly transform block Heading in fixture core__heading__h4-em into the Paragraph block 1`] = `
 "<!-- wp:paragraph -->
 <p>The <em>Inserter</em> Tool</p>

--- a/packages/e2e-tests/specs/blocks/__snapshots__/heading.test.js.snap
+++ b/packages/e2e-tests/specs/blocks/__snapshots__/heading.test.js.snap
@@ -14,13 +14,13 @@ exports[`Heading can be created by prefixing number sign and a space 1`] = `
 
 exports[`Heading it should correctly apply custom colors 1`] = `
 "<!-- wp:heading {\\"level\\":3,\\"customTextColor\\":\\"#181717\\"} -->
-<h3 style=\\"color:#181717\\">Heading</h3>
+<h3 class=\\"has-text-color\\" style=\\"color:#181717\\">Heading</h3>
 <!-- /wp:heading -->"
 `;
 
 exports[`Heading it should correctly apply named colors 1`] = `
 "<!-- wp:heading {\\"textColor\\":\\"accent\\"} -->
-<h2 class=\\"has-accent-color\\">Heading</h2>
+<h2 class=\\"has-accent-color has-text-color\\">Heading</h2>
 <!-- /wp:heading -->"
 `;
 


### PR DESCRIPTION
## Description
This PR just adds the has-text-color class to the heading block save method. The edit method already added this class but the save method missed it.

This PR is required for https://github.com/WordPress/gutenberg/pull/17728.
## How has this been tested?
I added a heading, I selected text color. I verified in the code editor that the class has-text-color has correctly added.
I created headings with color in the previous version of Gutenberg. I Oppened Gutenberg in this branch and verified there were no invalid block warnings and the class did not appear as an additional class added in the advanced panel. 
