### PR TITLE
Scripts: Added temporary workaround for the default config used with `lint-js` command

### DIFF
--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Master
+
+### Bug Fixes
+
+- Added a temporary workaround for the default config used with `lint-js` command. It uses linting rules for both e2e and unit tests with all files until override files globbing logic is fixed when using `eslint` with `--config` (related [issue](https://github.com/eslint/eslint/issues/11558)).
+
 ## 5.0.0 (2019-09-16)
 
 ### Breaking Changes

--- a/packages/scripts/config/.eslintrc.js
+++ b/packages/scripts/config/.eslintrc.js
@@ -1,4 +1,12 @@
 module.exports = {
 	root: true,
-	extends: [ 'plugin:@wordpress/eslint-plugin/recommended' ],
+	extends: [
+		'plugin:@wordpress/eslint-plugin/recommended',
+
+		// Temporary workaround to use linting rules for both e2e and unit tests with all files
+		// until override files globbing logic is fixed when using with --config.
+		// @see https://github.com/eslint/eslint/issues/11558
+		'plugin:@wordpress/eslint-plugin/test-e2e',
+		'plugin:@wordpress/eslint-plugin/test-unit',
+	],
 };


### PR DESCRIPTION
## Description
Related issue: #17061.

This PR adds a temporary workaround for the default config used with `lint-js` command. It uses linting rules for both e2e and unit tests with all files until override files globbing logic is fixed when using `eslint` with `--config` (related [issue](https://github.com/eslint/eslint/issues/11558)).

## Testing

I tested it with https://github.com/WordPress/gutenberg-examples. It's not that simple but this is what I did:

1. I removed this line:
https://github.com/WordPress/gutenberg-examples/blob/fe9c5e5bd2657a8d1fff0eedef398c6f5a2dd1d9/test/examples.js#L1
2. I copied the content of https://github.com/WordPress/gutenberg/blob/4847c5a717b2734959a41bed769a1ce4cd795aec/packages/scripts/config/.eslintrc.js to `node_modules/@wordpress/scripts/config/.eslintrc.js`.
3. I executed `npm run lint-js` to confirm it no longer reports errors.