### PR TITLE
Pass active state to HeadingLevelIcon in order to native start working

### DIFF
--- a/packages/block-library/src/heading/heading-level-icon.js
+++ b/packages/block-library/src/heading/heading-level-icon.js
@@ -3,7 +3,8 @@
  */
 import { Path, SVG } from '@wordpress/components';
 
-export default function HeadingLevelIcon( { level } ) {
+export default function HeadingLevelIcon( { level, active } ) {
+
 	const levelToPath = {
 		1: 'M9 5h2v10H9v-4H5v4H3V5h2v4h4V5zm6.6 0c-.6.9-1.5 1.7-2.6 2v1h2v7h2V5h-1.4z',
 		2: 'M7 5h2v10H7v-4H3v4H1V5h2v4h4V5zm8 8c.5-.4.6-.6 1.1-1.1.4-.4.8-.8 1.2-1.3.3-.4.6-.8.9-1.3.2-.4.3-.8.3-1.3 0-.4-.1-.9-.3-1.3-.2-.4-.4-.7-.8-1-.3-.3-.7-.5-1.2-.6-.5-.2-1-.2-1.5-.2-.4 0-.7 0-1.1.1-.3.1-.7.2-1 .3-.3.1-.6.3-.9.5-.3.2-.6.4-.8.7l1.2 1.2c.3-.3.6-.5 1-.7.4-.2.7-.3 1.2-.3s.9.1 1.3.4c.3.3.5.7.5 1.1 0 .4-.1.8-.4 1.1-.3.5-.6.9-1 1.2-.4.4-1 .9-1.6 1.4-.6.5-1.4 1.1-2.2 1.6V15h8v-2H15z',
@@ -17,7 +18,7 @@ export default function HeadingLevelIcon( { level } ) {
 	}
 
 	return (
-		<SVG width="20" height="20" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+		<SVG width="20" height="20" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg" active={ active } >
 			<Path d={ levelToPath[ level ] } />
 		</SVG>
 	);

--- a/packages/block-library/src/heading/heading-level-icon.js
+++ b/packages/block-library/src/heading/heading-level-icon.js
@@ -3,7 +3,7 @@
  */
 import { Path, SVG } from '@wordpress/components';
 
-export default function HeadingLevelIcon( { level, active } ) {
+export default function HeadingLevelIcon( { level, __unstableActive } ) {
 
 	const levelToPath = {
 		1: 'M9 5h2v10H9v-4H5v4H3V5h2v4h4V5zm6.6 0c-.6.9-1.5 1.7-2.6 2v1h2v7h2V5h-1.4z',
@@ -18,7 +18,7 @@ export default function HeadingLevelIcon( { level, active } ) {
 	}
 
 	return (
-		<SVG width="20" height="20" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg" active={ active } >
+		<SVG width="20" height="20" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg" __unstableActive={ __unstableActive } >
 			<Path d={ levelToPath[ level ] } />
 		</SVG>
 	);

--- a/packages/block-library/src/heading/heading-toolbar.js
+++ b/packages/block-library/src/heading/heading-toolbar.js
@@ -17,11 +17,12 @@ import HeadingLevelIcon from './heading-level-icon';
 
 class HeadingToolbar extends Component {
 	createLevelControl( targetLevel, selectedLevel, onChange ) {
+		const isActive = targetLevel === selectedLevel;
 		return {
-			icon: <HeadingLevelIcon level={ targetLevel } />,
+			icon: <HeadingLevelIcon level={ targetLevel } active={ isActive }/>,
 			// translators: %s: heading level e.g: "1", "2", "3"
 			title: sprintf( __( 'Heading %d' ), targetLevel ),
-			isActive: targetLevel === selectedLevel,
+			isActive,
 			onClick: () => onChange( targetLevel ),
 		};
 	}

--- a/packages/block-library/src/heading/heading-toolbar.js
+++ b/packages/block-library/src/heading/heading-toolbar.js
@@ -19,7 +19,7 @@ class HeadingToolbar extends Component {
 	createLevelControl( targetLevel, selectedLevel, onChange ) {
 		const isActive = targetLevel === selectedLevel;
 		return {
-			icon: <HeadingLevelIcon level={ targetLevel } active={ isActive }/>,
+			icon: <HeadingLevelIcon level={ targetLevel } __unstableActive={ isActive }/>,
 			// translators: %s: heading level e.g: "1", "2", "3"
 			title: sprintf( __( 'Heading %d' ), targetLevel ),
 			isActive,

--- a/packages/components/src/primitives/svg/index.js
+++ b/packages/components/src/primitives/svg/index.js
@@ -19,5 +19,5 @@ export const SVG = ( props ) => {
 
 	// Disable reason: We need to have a way to render HTML tag for web.
 	// eslint-disable-next-line react/forbid-elements
-	return <svg { ...appliedProps } />;
+	return <svg { ...omit( appliedProps, 'active' ) } />;
 };

--- a/packages/components/src/primitives/svg/index.js
+++ b/packages/components/src/primitives/svg/index.js
@@ -19,5 +19,5 @@ export const SVG = ( props ) => {
 
 	// Disable reason: We need to have a way to render HTML tag for web.
 	// eslint-disable-next-line react/forbid-elements
-	return <svg { ...omit( appliedProps, 'active' ) } />;
+	return <svg { ...omit( appliedProps, '__unstableActive' ) } />;
 };

--- a/packages/components/src/primitives/svg/index.native.js
+++ b/packages/components/src/primitives/svg/index.native.js
@@ -18,7 +18,7 @@ export {
 
 export const SVG = ( props ) => {
 	const stylesFromClasses = ( props.className || '' ).split( ' ' ).map( ( element ) => styles[ element ] ).filter( Boolean );
-	const defaultStyle = props.active ? styles[ 'is-active' ] : styles[ 'components-toolbar__control' ];
+	const defaultStyle = props.__unstableActive ? styles[ 'is-active' ] : styles[ 'components-toolbar__control' ];
 	const styleValues = Object.assign( {}, props.style, defaultStyle, ...stylesFromClasses );
 
 	const safeProps = { ...props, style: styleValues };

--- a/packages/components/src/primitives/svg/index.native.js
+++ b/packages/components/src/primitives/svg/index.native.js
@@ -18,8 +18,8 @@ export {
 
 export const SVG = ( props ) => {
 	const stylesFromClasses = ( props.className || '' ).split( ' ' ).map( ( element ) => styles[ element ] ).filter( Boolean );
-	const stylesFromAriaPressed = props.active ? styles[ 'is-active' ] : styles[ 'components-toolbar__control' ];
-	const styleValues = Object.assign( {}, props.style, stylesFromAriaPressed, ...stylesFromClasses );
+	const defaultStyle = props.active ? styles[ 'is-active' ] : styles[ 'components-toolbar__control' ];
+	const styleValues = Object.assign( {}, props.style, defaultStyle, ...stylesFromClasses );
 
 	const safeProps = { ...props, style: styleValues };
 

--- a/packages/components/src/primitives/svg/index.native.js
+++ b/packages/components/src/primitives/svg/index.native.js
@@ -18,7 +18,7 @@ export {
 
 export const SVG = ( props ) => {
 	const stylesFromClasses = ( props.className || '' ).split( ' ' ).map( ( element ) => styles[ element ] ).filter( Boolean );
-	const stylesFromAriaPressed = props.ariaPressed ? styles[ 'is-active' ] : styles[ 'components-toolbar__control' ];
+	const stylesFromAriaPressed = props.active ? styles[ 'is-active' ] : styles[ 'components-toolbar__control' ];
 	const styleValues = Object.assign( {}, props.style, stylesFromAriaPressed, ...stylesFromClasses );
 
 	const safeProps = { ...props, style: styleValues };


### PR DESCRIPTION
## Description
Fixes: Heading block Hx (level) buttons won't change icon color when active RN mobile issue: https://github.com/wordpress-mobile/gutenberg-mobile/issues/1398

## How has this been tested?

**GB mobile:**
1. Open a new post
2. Add new heading block
3. Active heading buttons in the toolbar should be presented with white text and inactive buttons should be presented with gray text.

**Gutenberg:**

Make sure that there isn't `active` tag in rendered `html`

## Screenshots <!-- if applicable -->

![heading](https://user-images.githubusercontent.com/28219092/66125626-c5c8fb80-e5e7-11e9-890a-4d819f968ea5.png)


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
