### PR TITLE
Fix for: "Pinned plugins menu icons are not scaled properly"

### DIFF
--- a/packages/components/src/icon-button/index.js
+++ b/packages/components/src/icon-button/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { isArray } from 'lodash';
+import { isArray, isString } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -55,7 +55,7 @@ function IconButton( props, ref ) {
 			className={ classes }
 			ref={ ref }
 		>
-			<Icon icon={ icon } />
+			{ isString( icon ) ? <Icon icon={ icon } /> : icon }
 			{ children }
 		</Button>
 	);


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
This PR fixes https://github.com/WordPress/gutenberg/issues/17719

Alternative to: #17722.

## How has this been tested?
**Web:**
- Install the dropit plugin on a local instance.
- Check that the drop icons are sized correctly.
- Check that the span has the correct `is-small` class.

**Mobile**
- Check out this mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1402
- Check that all icons look properly on the app.
- Be sure to test `Media & Text` block and toolbar icons.

## Screenshots <!-- if applicable -->

![Screen Shot 2019-10-03 at 2 56 07 PM](https://user-images.githubusercontent.com/9772967/66128515-3e32bb00-e5ee-11e9-9020-1e64dbea30a6.png)

