### PR TITLE
Fix: Featured image block contains invalid HTML

### DIFF
--- a/packages/components/src/responsive-wrapper/index.js
+++ b/packages/components/src/responsive-wrapper/index.js
@@ -8,20 +8,26 @@ import classnames from 'classnames';
  */
 import { cloneElement, Children } from '@wordpress/element';
 
-function ResponsiveWrapper( { naturalWidth, naturalHeight, children } ) {
+function ResponsiveWrapper( {
+	naturalWidth,
+	naturalHeight,
+	children,
+	isInline = false,
+} ) {
 	if ( Children.count( children ) !== 1 ) {
 		return null;
 	}
 	const imageStyle = {
 		paddingBottom: ( naturalHeight / naturalWidth * 100 ) + '%',
 	};
+	const TagName = isInline ? 'span' : 'div';
 	return (
-		<div className="components-responsive-wrapper">
-			<div style={ imageStyle } />
+		<TagName className="components-responsive-wrapper">
+			<TagName style={ imageStyle } />
 			{ cloneElement( children, {
 				className: classnames( 'components-responsive-wrapper__content', children.props.className ),
 			} ) }
-		</div>
+		</TagName>
 	);
 }
 

--- a/packages/components/src/responsive-wrapper/style.scss
+++ b/packages/components/src/responsive-wrapper/style.scss
@@ -1,6 +1,10 @@
 .components-responsive-wrapper {
 	position: relative;
 	max-width: 100%;
+	&,
+	& > span {
+		display: block;
+	}
 }
 
 .components-responsive-wrapper__content {

--- a/packages/editor/src/components/post-featured-image/index.js
+++ b/packages/editor/src/components/post-featured-image/index.js
@@ -62,6 +62,7 @@ function PostFeaturedImage( { currentPostId, featuredImageId, onUpdateImage, onR
 									<ResponsiveWrapper
 										naturalWidth={ mediaWidth }
 										naturalHeight={ mediaHeight }
+										isInline
 									>
 										<img src={ mediaSourceUrl } alt="" />
 									</ResponsiveWrapper>


### PR DESCRIPTION
## Description
Fixes: https://github.com/WordPress/gutenberg/issues/17739

This PR changes the responsive wrapper component to use a span instead of a div. The reason is that the component is used inside a button and having a div inside a button is not valid HTML.

## How has this been tested?
I added a featured image and I checked it showed correctly on the panel.
I clecked the image and verified the media library opened.
I was able to select a new image with success.