### PR TITLE
[RNMobile] Fix typo on ios check

### DIFF
--- a/packages/rich-text/src/component/index.native.js
+++ b/packages/rich-text/src/component/index.native.js
@@ -760,7 +760,7 @@ export class RichText extends Component {
 			value = '';
 		}
 		// On android if content is empty we need to send no content or else the placeholder with not show.
-		if ( ! this.iOS && value === '' ) {
+		if ( ! this.isIOS && value === '' ) {
 			return value;
 		}
 


### PR DESCRIPTION
While testing https://github.com/wordpress-mobile/WordPress-iOS/pull/12574, I notice that the fix from https://github.com/WordPress/gutenberg/pull/17710 wasn't working.

A fast check showed that a typo was impeding the proper logic.
This PR fixes that typo.

I wonder how did it work when that PR was (personally) reviewed 🤔 

To test:
- Check out this commit on https://github.com/wordpress-mobile/gutenberg-mobile/pull/1392
- Follow the steps on the original issue: https://github.com/wordpress-mobile/gutenberg-mobile/issues/1399