### PR TITLE
[RNMobile] fix button component

### DIFF
--- a/packages/components/src/button/index.native.js
+++ b/packages/components/src/button/index.native.js
@@ -93,7 +93,7 @@ export function Button( props ) {
 	const subscriptInactive = getStylesFromColorScheme( styles.subscriptInactive, styles.subscriptInactiveDark );
 
 	const newChildren = Children.map( children, ( child ) => {
-		return child ? cloneElement( child, { colorScheme: props.preferredColorScheme, active: ariaPressed } ) : null;
+		return child ? cloneElement( child, { colorScheme: props.preferredColorScheme, active: ariaPressed } ) : child;
 	} );
 
 	return (

--- a/packages/components/src/button/index.native.js
+++ b/packages/components/src/button/index.native.js
@@ -93,9 +93,9 @@ export function Button( props ) {
 
 	const subscriptInactive = getStylesFromColorScheme( styles.subscriptInactive, styles.subscriptInactiveDark );
 
-	const newChildren = Children.map( compact( children ), ( child ) => {
+	const newChildren = Array.isArray( children ) ? Children.map( compact( children ), ( child ) => {
 		return cloneElement( child, { colorScheme: props.preferredColorScheme, active: ariaPressed } );
-	} );
+	} ) : cloneElement( children, { colorScheme: props.preferredColorScheme, active: ariaPressed } );
 
 	return (
 		<TouchableOpacity

--- a/packages/components/src/button/index.native.js
+++ b/packages/components/src/button/index.native.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { StyleSheet, TouchableOpacity, Text, View, Platform } from 'react-native';
-import { compact } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -93,9 +92,9 @@ export function Button( props ) {
 
 	const subscriptInactive = getStylesFromColorScheme( styles.subscriptInactive, styles.subscriptInactiveDark );
 
-	const newChildren = Array.isArray( children ) ? Children.map( compact( children ), ( child ) => {
-		return cloneElement( child, { colorScheme: props.preferredColorScheme, active: ariaPressed } );
-	} ) : cloneElement( children, { colorScheme: props.preferredColorScheme, active: ariaPressed } );
+	const newChildren = Children.map( children, ( child ) => {
+		return child ? cloneElement( child, { colorScheme: props.preferredColorScheme, active: ariaPressed } ) : null;
+	} );
 
 	return (
 		<TouchableOpacity


### PR DESCRIPTION
## Description
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/1406
Gutenberg-mobile PR - https://github.com/wordpress-mobile/gutenberg-mobile/pull/1405
There is the wrong assumption that the child is always an array. https://github.com/WordPress/gutenberg/blob/master/packages/components/src/button/index.native.js#L96
When we pass only one component like View to the button it will be not rendered

## How has this been tested?
Pass only one component as a child to Button and check if it is rendered correctly

## Screenshots <!-- if applicable -->

## Types of changes
bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
