### PR TITLE
Data: Support generator resolvers for stores without controls defined

### DIFF
--- a/packages/data/CHANGELOG.md
+++ b/packages/data/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Master
+
+### Bug Fixes
+
+- Support generator resolvers for stores without controls defined.
+
 ## 4.6.0 (2019-06-12)
 
 ### New Feature

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -127,7 +127,7 @@ The **`selectors`** object includes a set of functions for accessing and derivin
 
 A **resolver** is a side-effect for a selector. If your selector result may need to be fulfilled from an external source, you can define a resolver such that the first time the selector is called, the fulfillment behavior is effected.
 
-The `resolvers` option should be passed as an object where each key is the name of the selector to act upon, the value a function which receives the same arguments passed to the selector, excluding the state argument. It can then dispatch as necessary to fulfill the requirements of the selector, taking advantage of the fact that most data consumers will subscribe to subsequent state changes (by `subscribe` or `withSelect`).
+The `resolvers` option should be passed as an object where each key is the name of the selector to act upon, the value a function or generator which receives the same arguments passed to the selector, excluding the state argument. It can then return or yield actions to fulfill the requirements of the selector, taking advantage of the fact that most data consumers will subscribe to subsequent state changes (by `subscribe` or `withSelect`).
 
 #### `controls`
 

--- a/packages/data/src/namespace-store/index.js
+++ b/packages/data/src/namespace-store/index.js
@@ -118,7 +118,7 @@ function createReduxStore( key, options, registry ) {
 		promise,
 	];
 
-	if ( options.controls ) {
+	if ( options.controls || options.resolvers ) {
 		const normalizedControls = mapValues( options.controls, ( control ) => {
 			return control.isRegistryControl ? control( registry ) : control;
 		} );


### PR DESCRIPTION
This pull request seeks to resolve an error which occurs when attempting to use generator resolvers for a store which has no `controls` otherwise assigned.

>Actions must be plain objects. Use custom middleware for async actions.

Prior to these changes, the middleware responsible for handling generator actions was only added if the store assigns `controls` in its store configuration. As such, a workaround can be to assign an empty object (`controls: {}`).

Two notes:

- `resolvers` aren't technically documented to be supported as generators, but there are many instances within Gutenberg's own code base of this usage ([example](https://github.com/WordPress/gutenberg/blob/3d7e81324563461232b3954fb6e11274515ff5c2/packages/core-data/src/resolvers.js#L30-L33)). With these changes, I've revised the `README.md` to clarify support for generators.
- Resolvers are often used in combination with controls, but it doesn't seem necessarily linked. Or otherwise, the documentation should be made further clear about when and how generators can be used in a store's resolvers / controls.

**Testing Instructions:**

Ensure unit tests pass:

```
npm run test-unit packages/data/src/test/registry.js
```

In testing this behavior, I observed a silent test failure unrelated to these changes. I've opened #17771 for tracking.