### PR TITLE
Data Controls: Docs: Fix syntax errors and inaccurate usage example for dispatch data control

### DIFF
--- a/packages/data-controls/CHANGELOG.md
+++ b/packages/data-controls/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Master
+
+### Documentation
+
+- Resolve inaccurate usage examples associated with `dispatch` function.
+
 ## 1.0.0 (2019-06-12)
 
 Initial release of the @wordpress/data-controls package.

--- a/packages/data-controls/CHANGELOG.md
+++ b/packages/data-controls/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Documentation
 
-- Resolve inaccurate usage examples associated with `dispatch` function.
+- Resolved syntax errors and inaccurate usage examples associated with `dispatch` function.
 
 ## 1.0.0 (2019-06-12)
 

--- a/packages/data-controls/README.md
+++ b/packages/data-controls/README.md
@@ -87,7 +87,7 @@ import { dispatch } from '@wordpress/data-controls';
 
 // Action generator using dispatch
 export function* myAction {
-  yield dispatch( 'core/edit-post' ).togglePublishSidebar();
+  yield dispatch( 'core/edit-post', 'togglePublishSidebar' );
   // do some other things.
 }
 ```

--- a/packages/data-controls/README.md
+++ b/packages/data-controls/README.md
@@ -30,7 +30,7 @@ _Usage_
 import { apiFetch } from '@wordpress/data-controls';
 
 // Action generator using apiFetch
-export function* myAction {
+export function* myAction() {
 	const path = '/v2/my-api/items';
 	const items = yield apiFetch( { path } );
 	// do something with the items.
@@ -63,7 +63,7 @@ import * as selectors from './selectors';
 import * as actions from './actions';
 import * as resolvers from './resolvers';
 
-registerStore ( 'my-custom-store', {
+registerStore( 'my-custom-store', {
 	reducer,
 	controls,
 	actions,
@@ -86,9 +86,9 @@ _Usage_
 import { dispatch } from '@wordpress/data-controls';
 
 // Action generator using dispatch
-export function* myAction {
-  yield dispatch( 'core/edit-post', 'togglePublishSidebar' );
-  // do some other things.
+export function* myAction() {
+	yield dispatch( 'core/edit-post', 'togglePublishSidebar' );
+	// do some other things.
 }
 ```
 
@@ -116,7 +116,7 @@ _Usage_
 import { select } from '@wordpress/data-controls';
 
 // Action generator using select
-export function* myAction {
+export function* myAction() {
 	const isSidebarOpened = yield select( 'core/edit-post', 'isEditorSideBarOpened' );
 	// do stuff with the result from the select.
 }

--- a/packages/data-controls/src/index.js
+++ b/packages/data-controls/src/index.js
@@ -14,10 +14,10 @@ import { createRegistryControl } from '@wordpress/data';
  * import { apiFetch } from '@wordpress/data-controls';
  *
  * // Action generator using apiFetch
- * export function* myAction {
- *		const path = '/v2/my-api/items';
- *		const items = yield apiFetch( { path } );
- *		// do something with the items.
+ * export function* myAction() {
+ * 	const path = '/v2/my-api/items';
+ * 	const items = yield apiFetch( { path } );
+ * 	// do something with the items.
  * }
  * ```
  *
@@ -46,9 +46,9 @@ export const apiFetch = ( request ) => {
  * import { select } from '@wordpress/data-controls';
  *
  * // Action generator using select
- * export function* myAction {
- *		const isSidebarOpened = yield select( 'core/edit-post', 'isEditorSideBarOpened' );
- *		// do stuff with the result from the select.
+ * export function* myAction() {
+ * 	const isSidebarOpened = yield select( 'core/edit-post', 'isEditorSideBarOpened' );
+ * 	// do stuff with the result from the select.
  * }
  * ```
  *
@@ -75,9 +75,9 @@ export function select( storeKey, selectorName, ...args ) {
  * import { dispatch } from '@wordpress/data-controls';
  *
  * // Action generator using dispatch
- * export function* myAction {
- *   yield dispatch( 'core/edit-post', 'togglePublishSidebar' );
- *   // do some other things.
+ * export function* myAction() {
+ * 	yield dispatch( 'core/edit-post', 'togglePublishSidebar' );
+ * 	// do some other things.
  * }
  * ```
  *
@@ -141,7 +141,7 @@ const resolveSelect = ( registry, { storeKey, selectorName, args } ) => {
  * import * as actions from './actions';
  * import * as resolvers from './resolvers';
  *
- * registerStore ( 'my-custom-store', {
+ * registerStore( 'my-custom-store', {
  * 	reducer,
  * 	controls,
  * 	actions,

--- a/packages/data-controls/src/index.js
+++ b/packages/data-controls/src/index.js
@@ -76,7 +76,7 @@ export function select( storeKey, selectorName, ...args ) {
  *
  * // Action generator using dispatch
  * export function* myAction {
- *   yield dispatch( 'core/edit-post' ).togglePublishSidebar();
+ *   yield dispatch( 'core/edit-post', 'togglePublishSidebar' );
  *   // do some other things.
  * }
  * ```


### PR DESCRIPTION
This pull request seeks to improve the documentation for the `@wordpress/data-controls` package in two ways:

- Fix an inaccuracy with the usage of `dispatch` as receiving multiple arguments (vs. the store key and returning an object of action dispatchers)
- Resolve syntax errors, notably with the generator function declaration

**Testing Instructions:**

As these changes purely impact documentation, there should be no runtime impact.