### PR TITLE
Disable the navigation mode when clicking the redirect element

### DIFF
--- a/packages/block-editor/src/components/writing-flow/index.js
+++ b/packages/block-editor/src/components/writing-flow/index.js
@@ -377,6 +377,7 @@ class WritingFlow extends Component {
 	 * Sets focus to the end of the last tabbable text field, if one exists.
 	 */
 	focusLastTextField() {
+		this.disableNavigationMode();
 		const focusableNodes = focus.focusable.find( this.container );
 		const target = findLast( focusableNodes, isTabbableTextField );
 		if ( target ) {

--- a/packages/e2e-tests/specs/adding-blocks.test.js
+++ b/packages/e2e-tests/specs/adding-blocks.test.js
@@ -29,6 +29,9 @@ describe( 'adding blocks', () => {
 	}
 
 	it( 'Should insert content using the placeholder and the regular inserter', async () => {
+		// This ensures the editor is loaded in navigation mode.
+		await page.reload();
+
 		// Click below editor to focus last field (block appender)
 		await clickBelow( await page.$( '.block-editor-default-block-appender' ) );
 		expect( await page.$( '[data-type="core/paragraph"]' ) ).not.toBeNull();


### PR DESCRIPTION
closes #17776

Clicking the empty area below the writing prompt should disable navigation mode and create a new block to start typing.

In my testing, the first click puts the caret in the title and the second creates a block, but this might be the expected behavior.

**Testing instructions**

- Navigate to Posts > Add New
- Click below the writing prompt
- Start typing
- Note that while the paragraph was created and is focused, your typed characters are not reflected - - - because the caret was not placed within the paragraph