### PR TITLE
Fix left aligned nested blocks

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -448,7 +448,7 @@
 	// Left
 	&[data-align="left"] {
 		// This is in the editor only; the image should be floated on the frontend.
-		.block-editor-block-list__block-edit {
+		> .block-editor-block-list__block-edit {
 			/*!rtl:begin:ignore*/
 			float: left;
 			margin-right: 2em;


### PR DESCRIPTION
Left aligned blocks should not inherited "float:left" to nested blocks.

In reference to #17793