### PR TITLE
Fix the block preview padding in themes with custom backgrounds

### DIFF
--- a/packages/block-editor/src/components/block-preview/index.js
+++ b/packages/block-editor/src/components/block-preview/index.js
@@ -18,7 +18,7 @@ import BlockEditorProvider from '../provider';
 import BlockList from '../block-list';
 import { getBlockPreviewContainerDOMNode } from '../../utils/dom';
 
-function ScaledBlockPreview( { blocks, viewportWidth } ) {
+function ScaledBlockPreview( { blocks, viewportWidth, padding = 0 } ) {
 	const previewRef = useRef( null );
 
 	const [ isReady, setIsReady ] = useState( false );
@@ -42,16 +42,22 @@ function ScaledBlockPreview( { blocks, viewportWidth } ) {
 					return;
 				}
 
-				const containerElementRect = containerElement.getBoundingClientRect();
+				let containerElementRect = containerElement.getBoundingClientRect();
+				containerElementRect = {
+					width: containerElementRect.width - ( padding * 2 ),
+					height: containerElementRect.height - ( padding * 2 ),
+					left: containerElementRect.left,
+					top: containerElementRect.top,
+				};
 				const scaledElementRect = previewElement.getBoundingClientRect();
 
 				const scale = containerElementRect.width / scaledElementRect.width || 1;
-				const offsetX = scaledElementRect.left - containerElementRect.left;
+				const offsetX = ( -( scaledElementRect.left - containerElementRect.left ) * scale ) + padding;
 				const offsetY = ( containerElementRect.height > scaledElementRect.height * scale ) ?
-					( containerElementRect.height - ( scaledElementRect.height * scale ) ) / 2 : 0;
+					( ( containerElementRect.height - ( scaledElementRect.height * scale ) ) / 2 ) + padding : 0;
 
 				setPreviewScale( scale );
-				setPosition( { x: offsetX * scale, y: offsetY } );
+				setPosition( { x: offsetX, y: offsetY } );
 
 				// Hack: we need  to reset the scaled elements margins
 				previewElement.style.marginTop = '0';
@@ -78,7 +84,7 @@ function ScaledBlockPreview( { blocks, viewportWidth } ) {
 	const previewStyles = {
 		transform: `scale(${ previewScale })`,
 		visibility: isReady ? 'visible' : 'hidden',
-		left: -x,
+		left: x,
 		top: y,
 		width: viewportWidth,
 	};
@@ -98,7 +104,7 @@ function ScaledBlockPreview( { blocks, viewportWidth } ) {
 	);
 }
 
-export function BlockPreview( { blocks, viewportWidth = 700, settings } ) {
+export function BlockPreview( { blocks, viewportWidth = 700, padding, settings } ) {
 	const renderedBlocks = useMemo( () => castArray( blocks ), [ blocks ] );
 	const [ recompute, triggerRecompute ] = useReducer( ( state ) => state + 1, 0 );
 	useLayoutEffect( triggerRecompute, [ blocks ] );
@@ -118,6 +124,7 @@ export function BlockPreview( { blocks, viewportWidth = 700, settings } ) {
 				key={ recompute }
 				blocks={ renderedBlocks }
 				viewportWidth={ viewportWidth }
+				padding={ padding }
 			/>
 		</BlockEditorProvider>
 	);

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -396,6 +396,7 @@ export class InserterMenu extends Component {
 									<div className="block-editor-inserter__preview">
 										<div className="block-editor-inserter__preview-content">
 											<BlockPreview
+												padding={ 10 }
 												viewportWidth={ 500 }
 												blocks={
 													hoveredItemBlockType.example ?

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -218,12 +218,12 @@ $block-inserter-search-height: 38px;
 	border: $border-width solid $light-gray-500;
 	border-radius: $radius-round-rectangle;
 	min-height: 150px;
-	padding: 10px;
 	display: grid;
 	flex-grow: 2;
 
 	.block-editor-block-preview__container {
 		margin-right: 0;
 		margin-left: 0;
+		padding: 10px;
 	}
 }


### PR DESCRIPTION
closes #17777

This PR removes the padding around the block preview from the help panel in the inserter and instead adds a `padding` prop to the ` BlockPreview` component in order to apply that padding inside the div affected by the editor styles.

**Testing instructions**

 - Use the TwentyTwenty theme
 - Hover the Image block in the inserter
 - Notice that the theme's background color is applied to the padding around the images 
