### PR TITLE
[RNMobile] Display UngroupingButton only for selected Group

### DIFF
--- a/packages/block-editor/src/components/block-toolbar/index.native.js
+++ b/packages/block-editor/src/components/block-toolbar/index.native.js
@@ -14,7 +14,7 @@ import BlockFormatControls from '../block-format-controls';
  */
 import UngroupButton from '../ungroup-button';
 
-export const BlockToolbar = ( { blockClientIds, isValid, mode, isSelectedGroup } ) => {
+export const BlockToolbar = ( { blockClientIds, isValid, mode } ) => {
 	if ( blockClientIds.length === 0 ) {
 		return null;
 	}
@@ -23,7 +23,7 @@ export const BlockToolbar = ( { blockClientIds, isValid, mode, isSelectedGroup }
 		<>
 			{ mode === 'visual' && isValid && (
 				<>
-					{ isSelectedGroup && <UngroupButton /> }
+					<UngroupButton />
 					<BlockControls.Slot />
 					<BlockFormatControls.Slot />
 				</>
@@ -37,16 +37,12 @@ export default withSelect( ( select ) => {
 		getBlockMode,
 		getSelectedBlockClientIds,
 		isBlockValid,
-		getSelectedBlock,
 	} = select( 'core/block-editor' );
 	const blockClientIds = getSelectedBlockClientIds();
-	const selectedBlock = getSelectedBlock();
-	const isSelectedGroup = selectedBlock && selectedBlock.name === 'core/group';
 
 	return {
 		blockClientIds,
 		isValid: blockClientIds.length === 1 ? isBlockValid( blockClientIds[ 0 ] ) : null,
 		mode: blockClientIds.length === 1 ? getBlockMode( blockClientIds[ 0 ] ) : null,
-		isSelectedGroup,
 	};
 } )( BlockToolbar );

--- a/packages/block-editor/src/components/block-toolbar/index.native.js
+++ b/packages/block-editor/src/components/block-toolbar/index.native.js
@@ -14,7 +14,7 @@ import BlockFormatControls from '../block-format-controls';
  */
 import UngroupButton from '../ungroup-button';
 
-export const BlockToolbar = ( { blockClientIds, isValid, mode } ) => {
+export const BlockToolbar = ( { blockClientIds, isValid, mode, isSelectedGroup } ) => {
 	if ( blockClientIds.length === 0 ) {
 		return null;
 	}
@@ -23,7 +23,7 @@ export const BlockToolbar = ( { blockClientIds, isValid, mode } ) => {
 		<>
 			{ mode === 'visual' && isValid && (
 				<>
-					<UngroupButton />
+					{ isSelectedGroup && <UngroupButton /> }
 					<BlockControls.Slot />
 					<BlockFormatControls.Slot />
 				</>
@@ -37,12 +37,16 @@ export default withSelect( ( select ) => {
 		getBlockMode,
 		getSelectedBlockClientIds,
 		isBlockValid,
+		getSelectedBlock,
 	} = select( 'core/block-editor' );
 	const blockClientIds = getSelectedBlockClientIds();
+	const selectedBlock = getSelectedBlock();
+	const isSelectedGroup = selectedBlock && selectedBlock.name === 'core/group';
 
 	return {
 		blockClientIds,
 		isValid: blockClientIds.length === 1 ? isBlockValid( blockClientIds[ 0 ] ) : null,
 		mode: blockClientIds.length === 1 ? getBlockMode( blockClientIds[ 0 ] ) : null,
+		isSelectedGroup,
 	};
 } )( BlockToolbar );

--- a/packages/block-editor/src/components/ungroup-button/icon.js
+++ b/packages/block-editor/src/components/ungroup-button/icon.js
@@ -1,8 +1,8 @@
 /**
  * WordPress dependencies
  */
-import { Icon, SVG, Path } from '@wordpress/components';
+import { SVG, Path } from '@wordpress/components';
 
 const UngroupSVG = <SVG width="20" height="20" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><Path fillRule="evenodd" clipRule="evenodd" d="M9 2H15C16.1 2 17 2.9 17 4V7C17 8.1 16.1 9 15 9H9C7.9 9 7 8.1 7 7V4C7 2.9 7.9 2 9 2ZM9 7H15V4H9V7Z" /><Path fillRule="evenodd" clipRule="evenodd" d="M5 11H11C12.1 11 13 11.9 13 13V16C13 17.1 12.1 18 11 18H5C3.9 18 3 17.1 3 16V13C3 11.9 3.9 11 5 11ZM5 16H11V13H5V16Z" /></SVG>;
 
-export const Ungroup = <Icon icon={ UngroupSVG } />;
+export default UngroupSVG;

--- a/packages/block-editor/src/components/ungroup-button/index.native.js
+++ b/packages/block-editor/src/components/ungroup-button/index.native.js
@@ -44,10 +44,16 @@ export default compose( [
 			getBlock,
 		} = select( 'core/block-editor' );
 
+		const {
+			getGroupingBlockName,
+		} = select( 'core/blocks' );
+
 		const selectedId = getSelectedBlockClientId();
 		const selectedBlock = getBlock( selectedId );
 
-		const isUngroupable = selectedBlock && selectedBlock.innerBlocks && !! selectedBlock.innerBlocks.length;
+		const groupingBlockName = getGroupingBlockName();
+
+		const isUngroupable = selectedBlock && selectedBlock.innerBlocks && !! selectedBlock.innerBlocks.length && selectedBlock.name === groupingBlockName;
 		const innerBlocks = isUngroupable ? selectedBlock.innerBlocks : [];
 
 		return {

--- a/packages/block-editor/src/components/ungroup-button/index.native.js
+++ b/packages/block-editor/src/components/ungroup-button/index.native.js
@@ -17,7 +17,7 @@ import { compose } from '@wordpress/compose';
 /**
  * Internal dependencies
  */
-import { UngroupIcon } from './icon';
+import UngroupIcon from './icon';
 
 export function UngroupButton( {
 	onConvertFromGroup,

--- a/packages/block-library/src/index.native.js
+++ b/packages/block-library/src/index.native.js
@@ -5,6 +5,7 @@ import {
 	registerBlockType,
 	setDefaultBlockName,
 	setUnregisteredTypeHandlerName,
+	setGroupingBlockName,
 } from '@wordpress/blocks';
 
 /**
@@ -148,4 +149,7 @@ export const registerCoreBlocks = () => {
 
 	setDefaultBlockName( paragraph.name );
 	setUnregisteredTypeHandlerName( missing.name );
+	if ( group ) {
+		setGroupingBlockName( group.name );
+	}
 };

--- a/packages/blocks/src/api/index.native.js
+++ b/packages/blocks/src/api/index.native.js
@@ -30,6 +30,7 @@ export {
 	hasChildBlocksWithInserterSupport,
 	setDefaultBlockName,
 	getDefaultBlockName,
+	setGroupingBlockName,
 } from './registration';
 export {
 	isUnmodifiedDefaultBlock,


### PR DESCRIPTION
## Description
Make `UngroupingButton` conditional to check if selected block is a group

Ref to gb-mobile: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1420
Fixes: https://github.com/wordpress-mobile/gutenberg-mobile/issues/1418

## How has this been tested?
Tested on both platforms.

1. Add a `Group` component 
2. Add an item into `Group`
3. Check if ungrouping icons exists.

---

1. Add a `Media&Text` component.
2. Check if `ungrouping` is not displayed.

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
