### PR TITLE
Fix: Cover Block: Unnecessary default styles for H2 heading

### DIFF
--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -12,52 +12,6 @@
 	align-items: center;
 	overflow: hidden;
 
-	&.has-left-content {
-		justify-content: flex-start;
-
-		h2,
-		.wp-block-cover-image-text,
-		.wp-block-cover-text {
-			margin-left: 0;
-			text-align: left;
-		}
-	}
-
-	&.has-right-content {
-		justify-content: flex-end;
-
-		h2,
-		.wp-block-cover-image-text,
-		.wp-block-cover-text {
-			margin-right: 0;
-			text-align: right;
-		}
-	}
-
-	h2,
-	.wp-block-cover-image-text,
-	.wp-block-cover-text {
-		font-size: 2em;
-		line-height: 1.25;
-		z-index: 1;
-		margin-bottom: 0;
-		max-width: $content-width;
-		padding: $block-padding;
-		text-align: center;
-	}
-
-	h2:not(.has-text-color),
-	.wp-block-cover-image-text,
-	.wp-block-cover-text {
-		color: $white;
-		a,
-		a:hover,
-		a:focus,
-		a:active {
-			color: $white;
-		}
-	}
-
 	&.has-parallax {
 		background-attachment: fixed;
 
@@ -149,4 +103,57 @@
 	height: 100%;
 	z-index: z-index(".wp-block-cover__video-background");
 	object-fit: cover;
+}
+
+// Styles bellow only exist to support older versions of the block.
+// Versions that not had inner blocks and used an h2 heading had a section (and not a div) with a class wp-block-cover-image (and not a wp-block-cover).
+// We are using the previous referred differences to target old versions.
+
+section.wp-block-cover-image h2,
+.wp-block-cover-image-text,
+.wp-block-cover-text {
+	color: $white;
+	a,
+	a:hover,
+	a:focus,
+	a:active {
+		color: $white;
+	}
+}
+
+.wp-block-cover-image
+.wp-block-cover {
+	&.has-left-content {
+		justify-content: flex-start;
+	}
+
+	&.has-right-content {
+		justify-content: flex-end;
+	}
+}
+
+section.wp-block-cover-image.has-left-content > h2,
+.wp-block-cover-image.has-left-content .wp-block-cover-image-text,
+.wp-block-cover.has-left-content .wp-block-cover-text {
+	margin-left: 0;
+	text-align: left;
+}
+
+section.wp-block-cover-image.has-right-content > h2,
+.wp-block-cover-image.has-right-content .wp-block-cover-image-text,
+.wp-block-cover.has-right-content .wp-block-cover-text {
+	margin-right: 0;
+	text-align: right;
+}
+
+section.wp-block-cover-image > h2,
+.wp-block-cover-image .wp-block-cover-image-text,
+.wp-block-cover .wp-block-cover-text {
+	font-size: 2em;
+	line-height: 1.25;
+	z-index: 1;
+	margin-bottom: 0;
+	max-width: $content-width;
+	padding: $block-padding;
+	text-align: center;
 }


### PR DESCRIPTION
## Description
Fixes: https://github.com/WordPress/gutenberg/issues/17704

The cover block needs h2 styles to support older versions of the block, but these styles were styling current heading blocks and make the ability of themes styling the block hard.

This PR fixes this problem by changing the heading selector to rely on section.wp-block-cover-image as a parent. Versions that not had inner blocks and used an h2 heading had a section (and not a div as the current) with a class wp-block-cover-image (and not a wp-block-cover as the current). So relying on this we can apply the styles to older versions and not affect new versions.

Styles that only exist to support deprecated versions were moved and grouped together.

## How has this been tested?
I used the classic editor and created a post with the following content (pasting it on Gutenberg automatically migrates to the new version of the blocks):
```
<!-- wp:cover-image {"url":"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==","id":34} -->
<section class="wp-block-cover-image has-background-dim" style="background-image:url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==)"><h2><strong>Cover Image</strong></h2></section>
<!-- /wp:cover-image -->

<!-- wp:cover-image {"url":"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==","id":34} -->
<div class="wp-block-cover-image has-background-dim" style="background-image:url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==)"><p class="wp-block-cover-image-text"><strong>Cover Block</strong></p></div>
<!-- /wp:cover-image -->

<!-- wp:cover {"url":"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==","id":35} -->
<div class="wp-block-cover has-background-dim" style="background-image:url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==)"><p class="wp-block-cover-text"><strong>Cover Block</strong></p></div>
<!-- /wp:cover -->
```

I disabled classic editor, opened the post verified it was automatically migrated. Did not save the migration.
I opened the post with Gutenberg master and in this branch and verified it displays equal in both places.
I created a new cover block, I added a new heading inside the cover and verified it was not centered aligned.

