### PR TITLE
Playground: Only build design system once.

### DIFF
--- a/package.json
+++ b/package.json
@@ -225,7 +225,7 @@
 		"test-unit-php-multisite": "cross-env WP_MULTISITE=1 wp-scripts env test-php",
 		"test-unit:native": "cd test/native/ && cross-env NODE_ENV=test jest --config ./jest.config.js",
 		"test-unit:native:debug": "cd test/native/ && node --inspect ../../node_modules/.bin/jest --runInBand --config ./jest.config.js",
-		"playground:build": "npm run build:packages && parcel build playground/src/index.html -d playground/dist && npm run design-system:build",
+		"playground:build": "npm run build:packages && parcel build playground/src/index.html -d playground/dist",
 		"playground:dev": "concurrently \"npm run dev:packages\" \"parcel playground/src/index.html -d playground/dist\"",
 		"preenv": "npm run check-engines",
 		"env": "wp-scripts env",


### PR DESCRIPTION
## Description

This PR fixes an issue where the design system was being built twice, due to the relevant script being called explicitly in Travis right after another script, the playground build, that included it.

This also caused problems with how the playground is built on Travis, because it uses the argument appending functionality of npm scripts to pass the public URL that should be used. This meant that the parameter was being received by the last script, the design system build, instead of the playground build as intended. 

## How has this been tested?

It was verified that the playground can be built and served.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
