### PR TITLE
List Block: disable indent/outdent buttons

### DIFF
--- a/packages/block-library/src/list/edit.js
+++ b/packages/block-library/src/list/edit.js
@@ -12,6 +12,8 @@ import {
 	Toolbar,
 } from '@wordpress/components';
 import {
+	__unstableCanIndentListItems as canIndentListItems,
+	__unstableCanOutdentListItems as canOutdentListItems,
 	__unstableIndentListItems as indentListItems,
 	__unstableOutdentListItems as outdentListItems,
 	__unstableChangeListType as changeListType,
@@ -100,6 +102,7 @@ export default function ListEdit( {
 							icon: 'editor-outdent',
 							title: __( 'Outdent list item' ),
 							shortcut: _x( 'Backspace', 'keyboard key' ),
+							isDisabled: ! canOutdentListItems( value ),
 							onClick() {
 								onChange( outdentListItems( value ) );
 							},
@@ -108,6 +111,7 @@ export default function ListEdit( {
 							icon: 'editor-indent',
 							title: __( 'Indent list item' ),
 							shortcut: _x( 'Space', 'keyboard key' ),
+							isDisabled: ! canIndentListItems( value ),
 							onClick() {
 								onChange( indentListItems( value, { type: tagName } ) );
 							},

--- a/packages/rich-text/src/can-indent-list-items.js
+++ b/packages/rich-text/src/can-indent-list-items.js
@@ -1,0 +1,29 @@
+/**
+ * Internal dependencies
+ */
+import { getLineIndex } from './get-line-index';
+
+/**
+ * Indents any selected list items if possible.
+ *
+ * @param {Object} value Value to check.
+ *
+ * @return {boolean} Whether or not the
+ */
+export function canIndentListItems( value ) {
+	const lineIndex = getLineIndex( value );
+
+	// There is only one line, so the line cannot be indented.
+	if ( lineIndex === undefined ) {
+		return false;
+	}
+
+	const { replacements } = value;
+	const previousLineIndex = getLineIndex( value, lineIndex );
+	const formatsAtLineIndex = replacements[ lineIndex ] || [];
+	const formatsAtPreviousLineIndex = replacements[ previousLineIndex ] || [];
+
+	// If the indentation of the current line is greater than previous line,
+	// then the line cannot be furter indented.
+	return formatsAtLineIndex.length <= formatsAtPreviousLineIndex.length;
+}

--- a/packages/rich-text/src/can-indent-list-items.js
+++ b/packages/rich-text/src/can-indent-list-items.js
@@ -4,11 +4,11 @@
 import { getLineIndex } from './get-line-index';
 
 /**
- * Indents any selected list items if possible.
+ * Checks if the selected list item can be indented.
  *
  * @param {Object} value Value to check.
  *
- * @return {boolean} Whether or not the
+ * @return {boolean} Whether or not the selected list item can be indented.
  */
 export function canIndentListItems( value ) {
 	const lineIndex = getLineIndex( value );

--- a/packages/rich-text/src/can-outdent-list-items.js
+++ b/packages/rich-text/src/can-outdent-list-items.js
@@ -1,0 +1,18 @@
+/**
+ * Internal dependencies
+ */
+
+import { getLineIndex } from './get-line-index';
+
+/**
+ * Outdents any selected list items if possible.
+ *
+ * @param {Object} value Value to change.
+ *
+ * @return {Object} The changed value.
+ */
+export function canOutdentListItems( value ) {
+	const { replacements, start } = value;
+	const startingLineIndex = getLineIndex( value, start );
+	return replacements[ startingLineIndex ] !== undefined;
+}

--- a/packages/rich-text/src/can-outdent-list-items.js
+++ b/packages/rich-text/src/can-outdent-list-items.js
@@ -5,11 +5,11 @@
 import { getLineIndex } from './get-line-index';
 
 /**
- * Outdents any selected list items if possible.
+ * Checks if the selected list item can be outdented.
  *
- * @param {Object} value Value to change.
+ * @param {Object} value Value to check.
  *
- * @return {Object} The changed value.
+ * @return {boolean} Whether or not the selected list item can be outdented.
  */
 export function canOutdentListItems( value ) {
 	const { replacements, start } = value;

--- a/packages/rich-text/src/indent-list-items.js
+++ b/packages/rich-text/src/indent-list-items.js
@@ -4,6 +4,7 @@
 
 import { LINE_SEPARATOR } from './special-characters';
 import { getLineIndex } from './get-line-index';
+import { canIndentListItems } from './can-indent-list-items';
 
 /**
  * Gets the line index of the first previous list item with higher indentation.
@@ -44,24 +45,13 @@ function getTargetLevelLineIndex( { text, replacements }, lineIndex ) {
  * @return {Object} The changed value.
  */
 export function indentListItems( value, rootFormat ) {
+	if ( ! canIndentListItems( value ) ) {
+		return value;
+	}
+
 	const lineIndex = getLineIndex( value );
-
-	// There is only one line, so the line cannot be indented.
-	if ( lineIndex === undefined ) {
-		return value;
-	}
-
-	const { text, replacements, end } = value;
 	const previousLineIndex = getLineIndex( value, lineIndex );
-	const formatsAtLineIndex = replacements[ lineIndex ] || [];
-	const formatsAtPreviousLineIndex = replacements[ previousLineIndex ] || [];
-
-	// The the indentation of the current line is greater than previous line,
-	// then the line cannot be furter indented.
-	if ( formatsAtLineIndex.length > formatsAtPreviousLineIndex.length ) {
-		return value;
-	}
-
+	const { text, replacements, end } = value;
 	const newFormats = replacements.slice();
 	const targetLevelLineIndex = getTargetLevelLineIndex( value, lineIndex );
 

--- a/packages/rich-text/src/index.js
+++ b/packages/rich-text/src/index.js
@@ -29,6 +29,8 @@ export { toHTMLString } from './to-html-string';
 export { toggleFormat } from './toggle-format';
 export { LINE_SEPARATOR as __UNSTABLE_LINE_SEPARATOR } from './special-characters';
 export { unregisterFormatType } from './unregister-format-type';
+export { canIndentListItems as __unstableCanIndentListItems } from './can-indent-list-items';
+export { canOutdentListItems as __unstableCanOutdentListItems } from './can-outdent-list-items';
 export { indentListItems as __unstableIndentListItems } from './indent-list-items';
 export { outdentListItems as __unstableOutdentListItems } from './outdent-list-items';
 export { changeListType as __unstableChangeListType } from './change-list-type';

--- a/packages/rich-text/src/outdent-list-items.js
+++ b/packages/rich-text/src/outdent-list-items.js
@@ -6,6 +6,7 @@ import { LINE_SEPARATOR } from './special-characters';
 import { getLineIndex } from './get-line-index';
 import { getParentLineIndex } from './get-parent-line-index';
 import { getLastChildIndex } from './get-last-child-index';
+import { canOutdentListItems } from './can-outdent-list-items';
 
 /**
  * Outdents any selected list items if possible.
@@ -15,14 +16,12 @@ import { getLastChildIndex } from './get-last-child-index';
  * @return {Object} The changed value.
  */
 export function outdentListItems( value ) {
-	const { text, replacements, start, end } = value;
-	const startingLineIndex = getLineIndex( value, start );
-
-	// Return early if the starting line index cannot be further outdented.
-	if ( replacements[ startingLineIndex ] === undefined ) {
+	if ( ! canOutdentListItems( value ) ) {
 		return value;
 	}
 
+	const { text, replacements, start, end } = value;
+	const startingLineIndex = getLineIndex( value, start );
 	const newFormats = replacements.slice( 0 );
 	const parentFormats = replacements[ getParentLineIndex( value, startingLineIndex ) ] || [];
 	const endingLineIndex = getLineIndex( value, end );

--- a/packages/rich-text/src/test/can-indent-list-items.js
+++ b/packages/rich-text/src/test/can-indent-list-items.js
@@ -1,0 +1,51 @@
+/**
+ * External dependencies
+ */
+import deepFreeze from 'deep-freeze';
+
+/**
+ * Internal dependencies
+ */
+
+import { canIndentListItems } from '../can-indent-list-items';
+import { LINE_SEPARATOR } from '../special-characters';
+
+describe( 'indentListItems', () => {
+	const ul = { type: 'ul' };
+
+	it( 'should not be able to indent if no previous item', () => {
+		const record = {
+			replacements: [ , ],
+			text: '1',
+			start: 1,
+			end: 1,
+		};
+		const result = canIndentListItems( deepFreeze( record ) );
+
+		expect( result ).toBe( false );
+	} );
+
+	it( 'should be able to indent if previous item', () => {
+		const record = {
+			replacements: [ , , ],
+			text: `1${ LINE_SEPARATOR }`,
+			start: 2,
+			end: 2,
+		};
+		const result = canIndentListItems( deepFreeze( record ) );
+
+		expect( result ).toBe( true );
+	} );
+
+	it( 'should not be able to indent already far indented item', () => {
+		const record = {
+			replacements: [ , [ ul ] ],
+			text: `1${ LINE_SEPARATOR }`,
+			start: 2,
+			end: 2,
+		};
+		const result = canIndentListItems( deepFreeze( record ) );
+
+		expect( result ).toBe( false );
+	} );
+} );

--- a/packages/rich-text/src/test/can-outdent-list-items.js
+++ b/packages/rich-text/src/test/can-outdent-list-items.js
@@ -1,0 +1,39 @@
+/**
+ * External dependencies
+ */
+import deepFreeze from 'deep-freeze';
+
+/**
+ * Internal dependencies
+ */
+
+import { canOutdentListItems } from '../can-outdent-list-items';
+import { LINE_SEPARATOR } from '../special-characters';
+
+describe( 'outdentListItems', () => {
+	const ul = { type: 'ul' };
+
+	it( 'should not be able to outdent if not indented', () => {
+		const record = {
+			replacements: [ , ],
+			text: '1',
+			start: 1,
+			end: 1,
+		};
+		const result = canOutdentListItems( deepFreeze( record ) );
+
+		expect( result ).toBe( false );
+	} );
+
+	it( 'should be able to outdent if indented', () => {
+		const record = {
+			replacements: [ , [ ul ] ],
+			text: `1${ LINE_SEPARATOR }`,
+			start: 2,
+			end: 2,
+		};
+		const result = canOutdentListItems( deepFreeze( record ) );
+
+		expect( result ).toBe( true );
+	} );
+} );


### PR DESCRIPTION
## Description

Fixes #13402.

## How has this been tested?

Create a list and ensure indent/outdent buttons are disable appropriately.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
