### PR TITLE
Editor: Fix custom sources backwards compatibility for the pages post type.

### DIFF
--- a/packages/e2e-tests/specs/plugins/__snapshots__/meta-attribute-block.test.js.snap
+++ b/packages/e2e-tests/specs/plugins/__snapshots__/meta-attribute-block.test.js.snap
@@ -1,3 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Block with a meta attribute Should persist the meta attribute properly 1`] = `"<!-- wp:test/test-meta-attribute-block /-->"`;
+
+exports[`Block with a meta attribute Should persist the meta attribute properly in a different post type 1`] = `"<!-- wp:test/test-meta-attribute-block /-->"`;

--- a/packages/e2e-tests/specs/plugins/meta-attribute-block.test.js
+++ b/packages/e2e-tests/specs/plugins/meta-attribute-block.test.js
@@ -61,4 +61,25 @@ describe( 'Block with a meta attribute', () => {
 			expect( await inputValue.jsonValue() ).toBe( 'Meta Value' );
 		} ) );
 	} );
+
+	it( 'Should persist the meta attribute properly in a different post type', async () => {
+		await createNewPost( { postType: 'page' } );
+		await insertBlock( 'Test Meta Attribute Block' );
+		await page.keyboard.type( 'Value' );
+
+		// Regression Test: Previously the caret would wrongly reset to the end
+		// of any input for meta-sourced attributes, due to syncing behavior of
+		// meta attribute updates.
+		//
+		// See: https://github.com/WordPress/gutenberg/issues/15739
+		await pressKeyTimes( 'ArrowLeft', 5 );
+		await page.keyboard.type( 'Meta ' );
+
+		await saveDraft();
+		await page.reload();
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+		const persistedValue = await page.evaluate( () => document.querySelector( '.my-meta-input' ).value );
+		expect( persistedValue ).toBe( 'Meta Value' );
+	} );
 } );

--- a/packages/editor/src/hooks/custom-sources-backwards-compatibility.js
+++ b/packages/editor/src/hooks/custom-sources-backwards-compatibility.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { getBlockType } from '@wordpress/blocks';
+import { useSelect } from '@wordpress/data';
 import { useEntityProp } from '@wordpress/core-data';
 import { useMemo, useCallback } from '@wordpress/element';
 import { createHigherOrderComponent } from '@wordpress/compose';
@@ -15,7 +16,9 @@ function useMetaAttributeSource( name, _attributes, _setAttributes ) {
 
 	if ( Object.values( attributeTypes ).some( ( type ) => type.source === 'meta' ) ) {
 		// eslint-disable-next-line react-hooks/rules-of-hooks
-		const [ meta, setMeta ] = useEntityProp( 'postType', 'post', 'meta' );
+		const { type } = useSelect( ( select ) => select( 'core/editor' ).getCurrentPost(), [] );
+		// eslint-disable-next-line react-hooks/rules-of-hooks
+		const [ meta, setMeta ] = useEntityProp( 'postType', type, 'meta' );
 
 		// eslint-disable-next-line react-hooks/rules-of-hooks
 		attributes = useMemo(

--- a/packages/editor/src/hooks/custom-sources-backwards-compatibility.js
+++ b/packages/editor/src/hooks/custom-sources-backwards-compatibility.js
@@ -16,7 +16,7 @@ function useMetaAttributeSource( name, _attributes, _setAttributes ) {
 
 	if ( Object.values( attributeTypes ).some( ( type ) => type.source === 'meta' ) ) {
 		// eslint-disable-next-line react-hooks/rules-of-hooks
-		const { type } = useSelect( ( select ) => select( 'core/editor' ).getCurrentPost(), [] );
+		const type = useSelect( ( select ) => select( 'core/editor' ).getCurrentPostType(), [] );
 		// eslint-disable-next-line react-hooks/rules-of-hooks
 		const [ meta, setMeta ] = useEntityProp( 'postType', type, 'meta' );
 


### PR DESCRIPTION
Fixes #17767

## Description

This PR fixes the custom sources backwards compatibility filter's hook to take into account post types other than `post`.

## How has this been tested?

It was verified that adding blocks with meta sources to pages no longer crashes the editor and an e2e test was added to avoid regressions.

## Types of Changes

*Bug Fix:* Meta sources no longer crash the editor if the edited post is not of post type `post`.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
