### PR TITLE
Record selection changes in history (undo)

### DIFF
--- a/docs/designers-developers/developers/data/data-core-block-editor.md
+++ b/docs/designers-developers/developers/data/data-core-block-editor.md
@@ -1075,6 +1075,20 @@ _Returns_
 
 -   `Object`: Action object.
 
+<a name="resetSelection" href="#resetSelection">#</a> **resetSelection**
+
+Returns an action object used in signalling that selection state should be
+reset to the specified selection.
+
+_Parameters_
+
+-   _selectionStart_ `WPBlockSelection`: The selection start.
+-   _selectionEnd_ `WPBlockSelection`: The selection end.
+
+_Returns_
+
+-   `Object`: Action object.
+
 <a name="selectBlock" href="#selectBlock">#</a> **selectBlock**
 
 Returns an action object used in signalling that the block with the

--- a/docs/designers-developers/developers/data/data-core-editor.md
+++ b/docs/designers-developers/developers/data/data-core-editor.md
@@ -359,6 +359,30 @@ _Returns_
 
 -   `Array`: Block list.
 
+<a name="getEditorSelectionEnd" href="#getEditorSelectionEnd">#</a> **getEditorSelectionEnd**
+
+Returns the current selection end.
+
+_Parameters_
+
+-   _state_ `Object`: 
+
+_Returns_
+
+-   `WPBlockSelection`: The selection end.
+
+<a name="getEditorSelectionStart" href="#getEditorSelectionStart">#</a> **getEditorSelectionStart**
+
+Returns the current selection start.
+
+_Parameters_
+
+-   _state_ `Object`: 
+
+_Returns_
+
+-   `WPBlockSelection`: The selection start.
+
 <a name="getEditorSettings" href="#getEditorSettings">#</a> **getEditorSettings**
 
 Returns the post editor settings.

--- a/packages/block-editor/src/components/provider/index.js
+++ b/packages/block-editor/src/components/provider/index.js
@@ -29,6 +29,9 @@ class BlockEditorProvider extends Component {
 			updateSettings,
 			value,
 			resetBlocks,
+			selectionStart,
+			selectionEnd,
+			resetSelection,
 			registry,
 		} = this.props;
 
@@ -58,6 +61,10 @@ class BlockEditorProvider extends Component {
 			this.isSyncingOutcomingValue = [];
 			this.isSyncingIncomingValue = value;
 			resetBlocks( value );
+
+			if ( selectionStart && selectionEnd ) {
+				resetSelection( selectionStart, selectionEnd );
+			}
 		}
 	}
 
@@ -86,6 +93,8 @@ class BlockEditorProvider extends Component {
 
 		const {
 			getBlocks,
+			getSelectionStart,
+			getSelectionEnd,
 			isLastBlockChangePersistent,
 			__unstableIsLastBlockChangeIgnored,
 		} = registry.select( 'core/block-editor' );
@@ -128,10 +137,13 @@ class BlockEditorProvider extends Component {
 				blocks = newBlocks;
 				isPersistent = newIsPersistent;
 
+				const selectionStart = getSelectionStart();
+				const selectionEnd = getSelectionEnd();
+
 				if ( isPersistent ) {
-					onChange( blocks );
+					onChange( blocks, { selectionStart, selectionEnd } );
 				} else {
-					onInput( blocks );
+					onInput( blocks, { selectionStart, selectionEnd } );
 				}
 			}
 		} );
@@ -150,11 +162,13 @@ export default compose( [
 		const {
 			updateSettings,
 			resetBlocks,
+			resetSelection,
 		} = dispatch( 'core/block-editor' );
 
 		return {
 			updateSettings,
 			resetBlocks,
+			resetSelection,
 		};
 	} ),
 ] )( BlockEditorProvider );

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -49,6 +49,31 @@ export function resetBlocks( blocks ) {
 }
 
 /**
+ * @typedef {WPBlockSelection} A block selection object.
+ *
+ * @property {string} clientId     A block client ID.
+ * @property {string} attributeKey A block attribute key.
+ * @property {number} offset       A block attribute offset.
+ */
+
+/**
+ * Returns an action object used in signalling that selection state should be
+ * reset to the specified selection.
+ *
+ * @param {WPBlockSelection} selectionStart The selection start.
+ * @param {WPBlockSelection} selectionEnd   The selection end.
+ *
+ * @return {Object} Action object.
+ */
+export function resetSelection( selectionStart, selectionEnd ) {
+	return {
+		type: 'RESET_SELECTION',
+		selectionStart,
+		selectionEnd,
+	};
+}
+
+/**
  * Returns an action object used in signalling that blocks have been received.
  * Unlike resetBlocks, these should be appended to the existing known set, not
  * replacing.

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -36,7 +36,11 @@ function* loadPostTypeEntities() {
 			kind: 'postType',
 			baseURL: '/wp/v2/' + postType.rest_base,
 			name,
-			transientEdits: { blocks: true },
+			transientEdits: {
+				blocks: true,
+				selectionStart: true,
+				selectionEnd: true,
+			},
 			mergedEdits: { meta: true },
 		};
 	} );

--- a/packages/e2e-tests/specs/editor/various/undo.test.js
+++ b/packages/e2e-tests/specs/editor/various/undo.test.js
@@ -31,13 +31,18 @@ const getSelection = async () => {
 			return { blockIndex };
 		}
 
-		const { startOffset, endOffset } = selection.getRangeAt( 0 );
+		const range = selection.getRangeAt( 0 );
+		const cloneStart = range.cloneRange();
+		const cloneEnd = range.cloneRange();
+
+		cloneStart.setStart( document.activeElement, 0 );
+		cloneEnd.setStart( document.activeElement, 0 );
 
 		return {
 			blockIndex,
 			editableIndex,
-			startOffset,
-			endOffset,
+			startOffset: cloneStart.toString().length,
+			endOffset: cloneEnd.toString().length,
 		};
 	} );
 };

--- a/packages/e2e-tests/specs/editor/various/undo.test.js
+++ b/packages/e2e-tests/specs/editor/various/undo.test.js
@@ -13,6 +13,35 @@ import {
 	disableNavigationMode,
 } from '@wordpress/e2e-test-utils';
 
+const getSelection = async () => {
+	return await page.evaluate( () => {
+		const selectedBlock = document.activeElement.closest( '.wp-block' );
+		const blocks = Array.from( document.querySelectorAll( '.wp-block' ) );
+		const blockIndex = blocks.indexOf( selectedBlock );
+
+		if ( blockIndex === -1 ) {
+			return {};
+		}
+
+		const editables = Array.from( selectedBlock.querySelectorAll( '[contenteditable]' ) );
+		const editableIndex = editables.indexOf( document.activeElement );
+		const selection = window.getSelection();
+
+		if ( editableIndex === -1 || ! selection.rangeCount ) {
+			return { blockIndex };
+		}
+
+		const { startOffset, endOffset } = selection.getRangeAt( 0 );
+
+		return {
+			blockIndex,
+			editableIndex,
+			startOffset,
+			endOffset,
+		};
+	} );
+};
+
 describe( 'undo', () => {
 	beforeEach( async () => {
 		await createNewPost();
@@ -34,18 +63,42 @@ describe( 'undo', () => {
 		const before = await getEditedPostContent();
 
 		expect( before ).toMatchSnapshot();
+		expect( await getSelection() ).toEqual( {
+			blockIndex: 1,
+			editableIndex: 0,
+			startOffset: 'before pause'.length,
+			endOffset: 'before pause'.length,
+		} );
 
 		await pressKeyWithModifier( 'primary', 'z' );
 
 		expect( await getEditedPostContent() ).toBe( '' );
+		expect( await getSelection() ).toEqual( {
+			blockIndex: 1,
+			editableIndex: 0,
+			startOffset: 0,
+			endOffset: 0,
+		} );
 
 		await pressKeyWithModifier( 'primaryShift', 'z' );
 
 		expect( await getEditedPostContent() ).toBe( before );
+		expect( await getSelection() ).toEqual( {
+			blockIndex: 1,
+			editableIndex: 0,
+			startOffset: 'before pause'.length,
+			endOffset: 'before pause'.length,
+		} );
 
 		await pressKeyWithModifier( 'primaryShift', 'z' );
 
 		expect( await getEditedPostContent() ).toBe( after );
+		expect( await getSelection() ).toEqual( {
+			blockIndex: 1,
+			editableIndex: 0,
+			startOffset: 'before pause after pause'.length,
+			endOffset: 'before pause after pause'.length,
+		} );
 	} );
 
 	it( 'should undo typing after non input change', async () => {
@@ -64,18 +117,42 @@ describe( 'undo', () => {
 		const before = await getEditedPostContent();
 
 		expect( before ).toMatchSnapshot();
+		expect( await getSelection() ).toEqual( {
+			blockIndex: 1,
+			editableIndex: 0,
+			startOffset: 'before keyboard '.length,
+			endOffset: 'before keyboard '.length,
+		} );
 
 		await pressKeyWithModifier( 'primary', 'z' );
 
 		expect( await getEditedPostContent() ).toBe( '' );
+		expect( await getSelection() ).toEqual( {
+			blockIndex: 1,
+			editableIndex: 0,
+			startOffset: 0,
+			endOffset: 0,
+		} );
 
 		await pressKeyWithModifier( 'primaryShift', 'z' );
 
 		expect( await getEditedPostContent() ).toBe( before );
+		expect( await getSelection() ).toEqual( {
+			blockIndex: 1,
+			editableIndex: 0,
+			startOffset: 'before keyboard '.length,
+			endOffset: 'before keyboard '.length,
+		} );
 
 		await pressKeyWithModifier( 'primaryShift', 'z' );
 
 		expect( await getEditedPostContent() ).toBe( after );
+		expect( await getSelection() ).toEqual( {
+			blockIndex: 1,
+			editableIndex: 0,
+			startOffset: 'before keyboard after keyboard'.length,
+			endOffset: 'before keyboard after keyboard'.length,
+		} );
 	} );
 
 	it( 'should undo bold', async () => {
@@ -120,54 +197,121 @@ describe( 'undo', () => {
 		await pressKeyWithModifier( 'primary', 'z' ); // Undo 3rd paragraph text.
 
 		expect( await getEditedPostContent() ).toBe( thirdBlock );
+		expect( await getSelection() ).toEqual( {
+			blockIndex: 3,
+			editableIndex: 0,
+			startOffset: 0,
+			endOffset: 0,
+		} );
 
 		await pressKeyWithModifier( 'primary', 'z' ); // Undo 3rd block.
 
 		expect( await getEditedPostContent() ).toBe( secondText );
+		expect( await getSelection() ).toEqual( {
+			blockIndex: 2,
+			editableIndex: 0,
+			startOffset: 0,
+			endOffset: 0,
+		} );
 
 		await pressKeyWithModifier( 'primary', 'z' ); // Undo 2nd paragraph text.
 
 		expect( await getEditedPostContent() ).toBe( secondBlock );
+		expect( await getSelection() ).toEqual( {
+			blockIndex: 2,
+			editableIndex: 0,
+			startOffset: 0,
+			endOffset: 0,
+		} );
 
 		await pressKeyWithModifier( 'primary', 'z' ); // Undo 2nd block.
 
 		expect( await getEditedPostContent() ).toBe( firstText );
+		expect( await getSelection() ).toEqual( {
+			blockIndex: 1,
+			editableIndex: 0,
+			startOffset: 0,
+			endOffset: 0,
+		} );
 
 		await pressKeyWithModifier( 'primary', 'z' ); // Undo 1st paragraph text.
 
 		expect( await getEditedPostContent() ).toBe( firstBlock );
+		expect( await getSelection() ).toEqual( {
+			blockIndex: 1,
+			editableIndex: 0,
+			startOffset: 0,
+			endOffset: 0,
+		} );
 
 		await pressKeyWithModifier( 'primary', 'z' ); // Undo 1st block.
 
 		expect( await getEditedPostContent() ).toBe( '' );
+		expect( await getSelection() ).toEqual( {} );
 		// After undoing every action, there should be no more undo history.
 		expect( await page.$( '.editor-history__undo[aria-disabled="true"]' ) ).not.toBeNull();
 
 		await pressKeyWithModifier( 'primaryShift', 'z' ); // Redo 1st block.
 
 		expect( await getEditedPostContent() ).toBe( firstBlock );
+		expect( await getSelection() ).toEqual( {
+			blockIndex: 1,
+			editableIndex: 0,
+			startOffset: 0,
+			endOffset: 0,
+		} );
 		// After redoing one change, the undo button should be enabled again.
 		expect( await page.$( '.editor-history__undo[aria-disabled="true"]' ) ).toBeNull();
 
 		await pressKeyWithModifier( 'primaryShift', 'z' ); // Redo 1st paragraph text.
 
 		expect( await getEditedPostContent() ).toBe( firstText );
+		expect( await getSelection() ).toEqual( {
+			blockIndex: 1,
+			editableIndex: 0,
+			startOffset: 'This'.length,
+			endOffset: 'This'.length,
+		} );
 
 		await pressKeyWithModifier( 'primaryShift', 'z' ); // Redo 2nd block.
 
 		expect( await getEditedPostContent() ).toBe( secondBlock );
+		expect( await getSelection() ).toEqual( {
+			blockIndex: 2,
+			editableIndex: 0,
+			startOffset: 0,
+			endOffset: 0,
+		} );
 
 		await pressKeyWithModifier( 'primaryShift', 'z' ); // Redo 2nd paragraph text.
 
 		expect( await getEditedPostContent() ).toBe( secondText );
+		expect( await getSelection() ).toEqual( {
+			blockIndex: 2,
+			editableIndex: 0,
+			startOffset: 'is'.length,
+			endOffset: 'is'.length,
+		} );
 
 		await pressKeyWithModifier( 'primaryShift', 'z' ); // Redo 3rd block.
 
 		expect( await getEditedPostContent() ).toBe( thirdBlock );
+		expect( await getSelection() ).toEqual( {
+			blockIndex: 3,
+			editableIndex: 0,
+			startOffset: 0,
+			endOffset: 0,
+		} );
 
 		await pressKeyWithModifier( 'primaryShift', 'z' ); // Redo 3rd paragraph text.
 
 		expect( await getEditedPostContent() ).toBe( thirdText );
+		expect( await getSelection() ).toEqual( {
+			blockIndex: 3,
+			editableIndex: 0,
+			startOffset: 'test'.length,
+			endOffset: 'test'.length,
+		} );
 	} );
 
 	it( 'should undo for explicit persistence editing post', async () => {

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -152,6 +152,8 @@ class EditorProvider extends Component {
 			post,
 			blocks,
 			resetEditorBlocks,
+			selectionStart,
+			selectionEnd,
 			isReady,
 			settings,
 			reusableBlocks,
@@ -177,6 +179,8 @@ class EditorProvider extends Component {
 						value={ blocks }
 						onInput={ resetEditorBlocksWithoutUndoLevel }
 						onChange={ resetEditorBlocks }
+						selectionStart={ selectionStart }
+						selectionEnd={ selectionEnd }
 						settings={ editorSettings }
 						useSubRegistry={ false }
 					>
@@ -197,6 +201,8 @@ export default compose( [
 			canUserUseUnfilteredHTML,
 			__unstableIsEditorReady: isEditorReady,
 			getEditorBlocks,
+			getEditorSelectionStart,
+			getEditorSelectionEnd,
 			__experimentalGetReusableBlocks,
 		} = select( 'core/editor' );
 		const { canUser } = select( 'core' );
@@ -205,6 +211,8 @@ export default compose( [
 			canUserUseUnfilteredHTML: canUserUseUnfilteredHTML(),
 			isReady: isEditorReady(),
 			blocks: getEditorBlocks(),
+			selectionStart: getEditorSelectionStart(),
+			selectionEnd: getEditorSelectionEnd(),
 			reusableBlocks: __experimentalGetReusableBlocks(),
 			hasUploadPermissions: defaultTo( canUser( 'create', 'media' ), true ),
 		};
@@ -225,8 +233,9 @@ export default compose( [
 			createWarningNotice,
 			resetEditorBlocks,
 			updateEditorSettings,
-			resetEditorBlocksWithoutUndoLevel( blocks ) {
+			resetEditorBlocksWithoutUndoLevel( blocks, options ) {
 				resetEditorBlocks( blocks, {
+					...options,
 					__unstableShouldCreateUndoLevel: false,
 				} );
 			},

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -646,8 +646,14 @@ export function unlockPostSaving( lockName ) {
  * @yield {Object} Action object
  */
 export function* resetEditorBlocks( blocks, options = {} ) {
-	const edits = { blocks };
-	if ( options.__unstableShouldCreateUndoLevel !== false ) {
+	const {
+		__unstableShouldCreateUndoLevel,
+		selectionStart,
+		selectionEnd,
+	} = options;
+	const edits = { blocks, selectionStart, selectionEnd };
+
+	if ( __unstableShouldCreateUndoLevel !== false ) {
 		const { id, type } = yield select( STORE_KEY, 'getCurrentPost' );
 		const noChange =
 			( yield select( 'core', 'getEditedEntityRecord', 'postType', type, id ) )

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -1192,10 +1192,30 @@ export function getEditorBlocks( state ) {
 	return getEditedPostAttribute( state, 'blocks' ) || EMPTY_ARRAY;
 }
 
+/**
+ * @typedef {WPBlockSelection} A block selection object.
+ *
+ * @property {string} clientId     A block client ID.
+ * @property {string} attributeKey A block attribute key.
+ * @property {number} offset       A block attribute offset.
+ */
+
+/**
+ * Returns the current selection start.
+ *
+ * @param {Object} state
+ * @return {WPBlockSelection} The selection start.
+ */
 export function getEditorSelectionStart( state ) {
 	return getEditedPostAttribute( state, 'selectionStart' );
 }
 
+/**
+ * Returns the current selection end.
+ *
+ * @param {Object} state
+ * @return {WPBlockSelection} The selection end.
+ */
 export function getEditorSelectionEnd( state ) {
 	return getEditedPostAttribute( state, 'selectionEnd' );
 }

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -1192,6 +1192,14 @@ export function getEditorBlocks( state ) {
 	return getEditedPostAttribute( state, 'blocks' ) || EMPTY_ARRAY;
 }
 
+export function getEditorSelectionStart( state ) {
+	return getEditedPostAttribute( state, 'selectionStart' );
+}
+
+export function getEditorSelectionEnd( state ) {
+	return getEditedPostAttribute( state, 'selectionEnd' );
+}
+
 /**
  * Is the editor ready
  *

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -598,8 +598,10 @@ class RichText extends Component {
 
 		this.value = this.valueToFormat( record );
 		this.record = record;
-		this.props.onChange( this.value );
+		// Selection must be updated first, so it is recorded in history when
+		// the content change happens.
 		this.props.onSelectionChange( start, end );
+		this.props.onChange( this.value );
 		this.setState( { activeFormats } );
 
 		if ( ! withoutHistory ) {


### PR DESCRIPTION
## Description

Same as  #16428, but adjusted after #16932.

Stores selection in the undo reducer. The following gif shows the result after two times undo:

![undo-selection](https://user-images.githubusercontent.com/4710635/60721595-c2fa3400-9f2e-11e9-9925-9e6575f53dac.gif)

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
