### PR TITLE
i18n: `All content copied.`

### DIFF
--- a/packages/edit-post/src/plugins/copy-content-menu-item/index.js
+++ b/packages/edit-post/src/plugins/copy-content-menu-item/index.js
@@ -17,7 +17,7 @@ function CopyContentMenuItem( { createNotice, editedPostContent, hasCopied, setS
 					setState( { hasCopied: true } );
 					createNotice(
 						'info',
-						'All content copied.',
+						__( 'All content copied.' ),
 						{
 							isDismissible: true,
 							type: 'snackbar',


### PR DESCRIPTION
## Description
Makes the string `All content copied.` translatable.