### PR TITLE
Framework: Add native storybook for components.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1736,6 +1736,24 @@
 			"integrity": "sha512-2Md9mH6mvo+ygq1trTeVp2uzAKwE2P7In0cRpD/M9Q70aH8L+rxMLbb3JCN2JoSWsV2O+DdFjfbbXoMoLBczow==",
 			"dev": true
 		},
+		"@emotion/native": {
+			"version": "10.0.14",
+			"resolved": "https://registry.npmjs.org/@emotion/native/-/native-10.0.14.tgz",
+			"integrity": "sha512-de01O1GvP6Qq8zWbCPOhTZ7GLkaYO6WhDXddVjVIx/16Ax360AotNBs9nBdkTrEExq1cSDa9vj5178Vw3R2x3w==",
+			"dev": true,
+			"requires": {
+				"@emotion/primitives-core": "10.0.14"
+			}
+		},
+		"@emotion/primitives-core": {
+			"version": "10.0.14",
+			"resolved": "https://registry.npmjs.org/@emotion/primitives-core/-/primitives-core-10.0.14.tgz",
+			"integrity": "sha512-ROpEf0ISDUKXiGT73fE55xYa+VCrcZWKrjRNgT/AFTT1v6unHNHaUTKGchGumI3lUv19dvZXs/oSQWBLnMDRWA==",
+			"dev": true,
+			"requires": {
+				"css-to-react-native": "^2.2.1"
+			}
+		},
 		"@emotion/serialize": {
 			"version": "0.11.11",
 			"resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.11.11.tgz",
@@ -5498,6 +5516,29 @@
 				"telejson": "^2.2.2"
 			}
 		},
+		"@storybook/channel-websocket": {
+			"version": "5.2.3",
+			"resolved": "https://registry.npmjs.org/@storybook/channel-websocket/-/channel-websocket-5.2.3.tgz",
+			"integrity": "sha512-YcUKZq0bs3S2q/JFwFvo+TJirTneQSSci1KirKQfC1mXsVJk6hHCY/w8Tv9FOBtpGxY49G+LdBbtpj06IBkkmA==",
+			"dev": true,
+			"requires": {
+				"@storybook/channels": "5.2.3",
+				"core-js": "^3.0.1",
+				"global": "^4.3.2",
+				"json-fn": "^1.1.1"
+			},
+			"dependencies": {
+				"@storybook/channels": {
+					"version": "5.2.3",
+					"resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-5.2.3.tgz",
+					"integrity": "sha512-13Mlb+XbE0mHXiLLHdg0w9byhRy/bE605U7U96PGQp2cwX4lf+4jpViO2mDCsndAFRc0+2hexXPTkwgzvZzq0A==",
+					"dev": true,
+					"requires": {
+						"core-js": "^3.0.1"
+					}
+				}
+			}
+		},
 		"@storybook/channels": {
 			"version": "5.2.1",
 			"resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-5.2.1.tgz",
@@ -6147,6 +6188,1037 @@
 					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
 					"integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==",
 					"dev": true
+				}
+			}
+		},
+		"@storybook/react-native": {
+			"version": "5.2.3",
+			"resolved": "https://registry.npmjs.org/@storybook/react-native/-/react-native-5.2.3.tgz",
+			"integrity": "sha512-aeEBzo2vOau8iLJAYUgVDIaOoKwmWk7HeAe8qbRgVkGtWgzzd/sdRPziLgttSltyS8mNU9KyK1lw41nKDp+/7w==",
+			"dev": true,
+			"requires": {
+				"@emotion/core": "^10.0.14",
+				"@emotion/native": "^10.0.14",
+				"@storybook/addons": "5.2.3",
+				"@storybook/channel-websocket": "5.2.3",
+				"@storybook/channels": "5.2.3",
+				"@storybook/client-api": "5.2.3",
+				"@storybook/core-events": "5.2.3",
+				"core-js": "^3.0.1",
+				"emotion-theming": "^10.0.14",
+				"react-native-swipe-gestures": "^1.0.3",
+				"rn-host-detect": "^1.1.5"
+			},
+			"dependencies": {
+				"@storybook/addons": {
+					"version": "5.2.3",
+					"resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-5.2.3.tgz",
+					"integrity": "sha512-LTkUJB8ZDc4++yt9acNHNjlnGWCyNtP+NVYPDvg7zFOaMip21Pj4T0pg9UwYxdqrFBWz9tVz7DJeXroS3egXxg==",
+					"dev": true,
+					"requires": {
+						"@storybook/api": "5.2.3",
+						"@storybook/channels": "5.2.3",
+						"@storybook/client-logger": "5.2.3",
+						"@storybook/core-events": "5.2.3",
+						"core-js": "^3.0.1",
+						"global": "^4.3.2",
+						"util-deprecate": "^1.0.2"
+					}
+				},
+				"@storybook/api": {
+					"version": "5.2.3",
+					"resolved": "https://registry.npmjs.org/@storybook/api/-/api-5.2.3.tgz",
+					"integrity": "sha512-2csxa/d64rXy4Dwoc7YjbPeNUJRgcI/wJUo30CLujk2stEFzDnKeMPR1mlHMCIFDW+KDxJ28bW59VPxwrqJFjw==",
+					"dev": true,
+					"requires": {
+						"@storybook/channels": "5.2.3",
+						"@storybook/client-logger": "5.2.3",
+						"@storybook/core-events": "5.2.3",
+						"@storybook/router": "5.2.3",
+						"@storybook/theming": "5.2.3",
+						"core-js": "^3.0.1",
+						"fast-deep-equal": "^2.0.1",
+						"global": "^4.3.2",
+						"lodash": "^4.17.11",
+						"memoizerific": "^1.11.3",
+						"prop-types": "^15.6.2",
+						"react": "^16.8.3",
+						"semver": "^6.0.0",
+						"shallow-equal": "^1.1.0",
+						"store2": "^2.7.1",
+						"telejson": "^3.0.2",
+						"util-deprecate": "^1.0.2"
+					}
+				},
+				"@storybook/channel-postmessage": {
+					"version": "5.2.3",
+					"resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-5.2.3.tgz",
+					"integrity": "sha512-ixlpr6aAYoRM72cKwEWU/W0rWzOn3mYqb/eUdIaz3Da5BtFGKm3yEFguII0l1my82uhMm5/d3UNfoh0rO3pUyg==",
+					"dev": true,
+					"requires": {
+						"@storybook/channels": "5.2.3",
+						"@storybook/client-logger": "5.2.3",
+						"core-js": "^3.0.1",
+						"global": "^4.3.2",
+						"telejson": "^3.0.2"
+					}
+				},
+				"@storybook/channels": {
+					"version": "5.2.3",
+					"resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-5.2.3.tgz",
+					"integrity": "sha512-13Mlb+XbE0mHXiLLHdg0w9byhRy/bE605U7U96PGQp2cwX4lf+4jpViO2mDCsndAFRc0+2hexXPTkwgzvZzq0A==",
+					"dev": true,
+					"requires": {
+						"core-js": "^3.0.1"
+					}
+				},
+				"@storybook/client-api": {
+					"version": "5.2.3",
+					"resolved": "https://registry.npmjs.org/@storybook/client-api/-/client-api-5.2.3.tgz",
+					"integrity": "sha512-anXxcf2z+KQAk94xxdbeG1N6nTEWXj087XHQ22L3pOoX9TRzfG71UjL0/S7vj4EFUiXVHj8d6YUFwLb5LwpUIw==",
+					"dev": true,
+					"requires": {
+						"@storybook/addons": "5.2.3",
+						"@storybook/channel-postmessage": "5.2.3",
+						"@storybook/channels": "5.2.3",
+						"@storybook/client-logger": "5.2.3",
+						"@storybook/core-events": "5.2.3",
+						"@storybook/router": "5.2.3",
+						"common-tags": "^1.8.0",
+						"core-js": "^3.0.1",
+						"eventemitter3": "^4.0.0",
+						"global": "^4.3.2",
+						"is-plain-object": "^3.0.0",
+						"lodash": "^4.17.11",
+						"memoizerific": "^1.11.3",
+						"qs": "^6.6.0",
+						"util-deprecate": "^1.0.2"
+					}
+				},
+				"@storybook/client-logger": {
+					"version": "5.2.3",
+					"resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-5.2.3.tgz",
+					"integrity": "sha512-Z1irXW4jiFs7rClgqJqYOgg5op51ynV6dVuoIqxkSC0MrOG5s/VbX7T+ojGPXKyQWD4XYGw66Hnw9jouSfXL9g==",
+					"dev": true,
+					"requires": {
+						"core-js": "^3.0.1"
+					}
+				},
+				"@storybook/core-events": {
+					"version": "5.2.3",
+					"resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-5.2.3.tgz",
+					"integrity": "sha512-sZEv93yE1o+/UJdhtqQ6vo2EauZ90FjN/L8F7CR7iqDEZzqo9g77Idg9LSgcN3TAeXcGAWVSrPb1vkK7H96L2g==",
+					"dev": true,
+					"requires": {
+						"core-js": "^3.0.1"
+					}
+				},
+				"@storybook/router": {
+					"version": "5.2.3",
+					"resolved": "https://registry.npmjs.org/@storybook/router/-/router-5.2.3.tgz",
+					"integrity": "sha512-sOu6y2GySaY82SdXfF3yOn0IJTKMqd2BDOSGEno7PWWtSenHFQWY+z99C9k0dLBTkjRes5tPcgm0OJ7RdQVRDQ==",
+					"dev": true,
+					"requires": {
+						"@reach/router": "^1.2.1",
+						"@types/reach__router": "^1.2.3",
+						"core-js": "^3.0.1",
+						"global": "^4.3.2",
+						"lodash": "^4.17.11",
+						"memoizerific": "^1.11.3",
+						"qs": "^6.6.0"
+					}
+				},
+				"@storybook/theming": {
+					"version": "5.2.3",
+					"resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-5.2.3.tgz",
+					"integrity": "sha512-3/0bo8CaoaHDYZaexydpYcwP6WW8BKRqSQBGXJY9y0TLhwY2Who5nPX9XdOLyu9d7lN//PRZlt8JnZynuncxoQ==",
+					"dev": true,
+					"requires": {
+						"@emotion/core": "^10.0.14",
+						"@emotion/styled": "^10.0.14",
+						"@storybook/client-logger": "5.2.3",
+						"common-tags": "^1.8.0",
+						"core-js": "^3.0.1",
+						"deep-object-diff": "^1.1.0",
+						"emotion-theming": "^10.0.14",
+						"global": "^4.3.2",
+						"memoizerific": "^1.11.3",
+						"polished": "^3.3.1",
+						"prop-types": "^15.7.2",
+						"resolve-from": "^5.0.0"
+					}
+				},
+				"eventemitter3": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.0.tgz",
+					"integrity": "sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg==",
+					"dev": true
+				},
+				"is-plain-object": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
+					"integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
+					"dev": true,
+					"requires": {
+						"isobject": "^4.0.0"
+					}
+				},
+				"is-symbol": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+					"integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+					"dev": true,
+					"requires": {
+						"has-symbols": "^1.0.0"
+					}
+				},
+				"isobject": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
+					"integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
+					"dev": true
+				},
+				"qs": {
+					"version": "6.9.0",
+					"resolved": "https://registry.npmjs.org/qs/-/qs-6.9.0.tgz",
+					"integrity": "sha512-27RP4UotQORTpmNQDX8BHPukOnBP3p1uUJY5UnDhaJB+rMt9iMsok724XL+UHU23bEFOHRMQ2ZhI99qOWUMGFA==",
+					"dev": true
+				},
+				"resolve-from": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+					"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+					"dev": true
+				},
+				"shallow-equal": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-1.2.0.tgz",
+					"integrity": "sha512-Z21pVxR4cXsfwpMKMhCEIO1PCi5sp7KEp+CmOpBQ+E8GpHwKOw2sEzk7sgblM3d/j4z4gakoWEoPcjK0VJQogA==",
+					"dev": true
+				},
+				"telejson": {
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/telejson/-/telejson-3.0.3.tgz",
+					"integrity": "sha512-gUOh6wox1zJjbGMg+e26NquZcp/F18EbIaqVvjiGqikRqVB4fYEAM8Nyin8smgwX30XhaRBOg+kCj4vInmvwAg==",
+					"dev": true,
+					"requires": {
+						"@types/is-function": "^1.0.0",
+						"global": "^4.4.0",
+						"is-function": "^1.0.1",
+						"is-regex": "^1.0.4",
+						"is-symbol": "^1.0.2",
+						"isobject": "^4.0.0",
+						"lodash": "^4.17.15",
+						"memoizerific": "^1.11.3"
+					}
+				}
+			}
+		},
+		"@storybook/react-native-server": {
+			"version": "5.2.3",
+			"resolved": "https://registry.npmjs.org/@storybook/react-native-server/-/react-native-server-5.2.3.tgz",
+			"integrity": "sha512-mnK0Z/RIARvZ5fnU3bC6PGndZQ46Zxj++8WMCpKwl+Mpl78OakjNlKzgvGkbgG9bemrirFkX6pyJRDd/bMKhUQ==",
+			"dev": true,
+			"requires": {
+				"@storybook/addons": "5.2.3",
+				"@storybook/api": "5.2.3",
+				"@storybook/channel-websocket": "5.2.3",
+				"@storybook/core": "5.2.3",
+				"@storybook/core-events": "5.2.3",
+				"@storybook/ui": "5.2.3",
+				"commander": "^2.19.0",
+				"core-js": "^3.0.1",
+				"global": "^4.3.2",
+				"react": "^16.6.0",
+				"react-dom": "^16.8.3",
+				"uuid": "^3.3.2",
+				"webpack": "^4.33.0",
+				"ws": "^6.1.0"
+			},
+			"dependencies": {
+				"@storybook/addons": {
+					"version": "5.2.3",
+					"resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-5.2.3.tgz",
+					"integrity": "sha512-LTkUJB8ZDc4++yt9acNHNjlnGWCyNtP+NVYPDvg7zFOaMip21Pj4T0pg9UwYxdqrFBWz9tVz7DJeXroS3egXxg==",
+					"dev": true,
+					"requires": {
+						"@storybook/api": "5.2.3",
+						"@storybook/channels": "5.2.3",
+						"@storybook/client-logger": "5.2.3",
+						"@storybook/core-events": "5.2.3",
+						"core-js": "^3.0.1",
+						"global": "^4.3.2",
+						"util-deprecate": "^1.0.2"
+					}
+				},
+				"@storybook/api": {
+					"version": "5.2.3",
+					"resolved": "https://registry.npmjs.org/@storybook/api/-/api-5.2.3.tgz",
+					"integrity": "sha512-2csxa/d64rXy4Dwoc7YjbPeNUJRgcI/wJUo30CLujk2stEFzDnKeMPR1mlHMCIFDW+KDxJ28bW59VPxwrqJFjw==",
+					"dev": true,
+					"requires": {
+						"@storybook/channels": "5.2.3",
+						"@storybook/client-logger": "5.2.3",
+						"@storybook/core-events": "5.2.3",
+						"@storybook/router": "5.2.3",
+						"@storybook/theming": "5.2.3",
+						"core-js": "^3.0.1",
+						"fast-deep-equal": "^2.0.1",
+						"global": "^4.3.2",
+						"lodash": "^4.17.11",
+						"memoizerific": "^1.11.3",
+						"prop-types": "^15.6.2",
+						"react": "^16.8.3",
+						"semver": "^6.0.0",
+						"shallow-equal": "^1.1.0",
+						"store2": "^2.7.1",
+						"telejson": "^3.0.2",
+						"util-deprecate": "^1.0.2"
+					}
+				},
+				"@storybook/channel-postmessage": {
+					"version": "5.2.3",
+					"resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-5.2.3.tgz",
+					"integrity": "sha512-ixlpr6aAYoRM72cKwEWU/W0rWzOn3mYqb/eUdIaz3Da5BtFGKm3yEFguII0l1my82uhMm5/d3UNfoh0rO3pUyg==",
+					"dev": true,
+					"requires": {
+						"@storybook/channels": "5.2.3",
+						"@storybook/client-logger": "5.2.3",
+						"core-js": "^3.0.1",
+						"global": "^4.3.2",
+						"telejson": "^3.0.2"
+					}
+				},
+				"@storybook/channels": {
+					"version": "5.2.3",
+					"resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-5.2.3.tgz",
+					"integrity": "sha512-13Mlb+XbE0mHXiLLHdg0w9byhRy/bE605U7U96PGQp2cwX4lf+4jpViO2mDCsndAFRc0+2hexXPTkwgzvZzq0A==",
+					"dev": true,
+					"requires": {
+						"core-js": "^3.0.1"
+					}
+				},
+				"@storybook/client-api": {
+					"version": "5.2.3",
+					"resolved": "https://registry.npmjs.org/@storybook/client-api/-/client-api-5.2.3.tgz",
+					"integrity": "sha512-anXxcf2z+KQAk94xxdbeG1N6nTEWXj087XHQ22L3pOoX9TRzfG71UjL0/S7vj4EFUiXVHj8d6YUFwLb5LwpUIw==",
+					"dev": true,
+					"requires": {
+						"@storybook/addons": "5.2.3",
+						"@storybook/channel-postmessage": "5.2.3",
+						"@storybook/channels": "5.2.3",
+						"@storybook/client-logger": "5.2.3",
+						"@storybook/core-events": "5.2.3",
+						"@storybook/router": "5.2.3",
+						"common-tags": "^1.8.0",
+						"core-js": "^3.0.1",
+						"eventemitter3": "^4.0.0",
+						"global": "^4.3.2",
+						"is-plain-object": "^3.0.0",
+						"lodash": "^4.17.11",
+						"memoizerific": "^1.11.3",
+						"qs": "^6.6.0",
+						"util-deprecate": "^1.0.2"
+					}
+				},
+				"@storybook/client-logger": {
+					"version": "5.2.3",
+					"resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-5.2.3.tgz",
+					"integrity": "sha512-Z1irXW4jiFs7rClgqJqYOgg5op51ynV6dVuoIqxkSC0MrOG5s/VbX7T+ojGPXKyQWD4XYGw66Hnw9jouSfXL9g==",
+					"dev": true,
+					"requires": {
+						"core-js": "^3.0.1"
+					}
+				},
+				"@storybook/components": {
+					"version": "5.2.3",
+					"resolved": "https://registry.npmjs.org/@storybook/components/-/components-5.2.3.tgz",
+					"integrity": "sha512-EiWKa3xONP2BPxrssiRdvKELhF2tO14HVL131CCFY+Zg/ylExzWWWVSBun7vYcKhkI52K5lmvC1vFSsB6Gmlhw==",
+					"dev": true,
+					"requires": {
+						"@storybook/client-logger": "5.2.3",
+						"@storybook/theming": "5.2.3",
+						"@types/react-syntax-highlighter": "10.1.0",
+						"core-js": "^3.0.1",
+						"global": "^4.3.2",
+						"markdown-to-jsx": "^6.9.1",
+						"memoizerific": "^1.11.3",
+						"polished": "^3.3.1",
+						"popper.js": "^1.14.7",
+						"prop-types": "^15.7.2",
+						"react": "^16.8.3",
+						"react-dom": "^16.8.3",
+						"react-focus-lock": "^1.18.3",
+						"react-helmet-async": "^1.0.2",
+						"react-popper-tooltip": "^2.8.3",
+						"react-syntax-highlighter": "^8.0.1",
+						"react-textarea-autosize": "^7.1.0",
+						"simplebar-react": "^1.0.0-alpha.6"
+					}
+				},
+				"@storybook/core": {
+					"version": "5.2.3",
+					"resolved": "https://registry.npmjs.org/@storybook/core/-/core-5.2.3.tgz",
+					"integrity": "sha512-sktjYY8pH4kQGFRKjXwtwwShdG3ajjHkrnw8oh3R383MRPom7i9owx5yHHMuQedLCXIwAg84s2DzO01I2URTcg==",
+					"dev": true,
+					"requires": {
+						"@babel/plugin-proposal-class-properties": "^7.3.3",
+						"@babel/plugin-proposal-object-rest-spread": "^7.3.2",
+						"@babel/plugin-syntax-dynamic-import": "^7.2.0",
+						"@babel/plugin-transform-react-constant-elements": "^7.2.0",
+						"@babel/preset-env": "^7.4.5",
+						"@storybook/addons": "5.2.3",
+						"@storybook/channel-postmessage": "5.2.3",
+						"@storybook/client-api": "5.2.3",
+						"@storybook/client-logger": "5.2.3",
+						"@storybook/core-events": "5.2.3",
+						"@storybook/node-logger": "5.2.3",
+						"@storybook/router": "5.2.3",
+						"@storybook/theming": "5.2.3",
+						"@storybook/ui": "5.2.3",
+						"airbnb-js-shims": "^1 || ^2",
+						"ansi-to-html": "^0.6.11",
+						"autoprefixer": "^9.4.9",
+						"babel-plugin-add-react-displayname": "^0.0.5",
+						"babel-plugin-emotion": "^10.0.14",
+						"babel-plugin-macros": "^2.4.5",
+						"babel-preset-minify": "^0.5.0 || 0.6.0-alpha.5",
+						"boxen": "^3.0.0",
+						"case-sensitive-paths-webpack-plugin": "^2.2.0",
+						"chalk": "^2.4.2",
+						"cli-table3": "0.5.1",
+						"commander": "^2.19.0",
+						"common-tags": "^1.8.0",
+						"core-js": "^3.0.1",
+						"corejs-upgrade-webpack-plugin": "^2.2.0",
+						"css-loader": "^3.0.0",
+						"detect-port": "^1.3.0",
+						"dotenv-webpack": "^1.7.0",
+						"ejs": "^2.6.1",
+						"express": "^4.17.0",
+						"file-loader": "^3.0.1",
+						"file-system-cache": "^1.0.5",
+						"find-cache-dir": "^3.0.0",
+						"fs-extra": "^8.0.1",
+						"global": "^4.3.2",
+						"html-webpack-plugin": "^4.0.0-beta.2",
+						"inquirer": "^6.2.0",
+						"interpret": "^1.2.0",
+						"ip": "^1.1.5",
+						"json5": "^2.1.0",
+						"lazy-universal-dotenv": "^3.0.1",
+						"node-fetch": "^2.6.0",
+						"open": "^6.1.0",
+						"pnp-webpack-plugin": "1.4.3",
+						"postcss-flexbugs-fixes": "^4.1.0",
+						"postcss-loader": "^3.0.0",
+						"pretty-hrtime": "^1.0.3",
+						"qs": "^6.6.0",
+						"raw-loader": "^2.0.0",
+						"react-dev-utils": "^9.0.0",
+						"regenerator-runtime": "^0.12.1",
+						"resolve": "^1.11.0",
+						"resolve-from": "^5.0.0",
+						"semver": "^6.0.0",
+						"serve-favicon": "^2.5.0",
+						"shelljs": "^0.8.3",
+						"style-loader": "^0.23.1",
+						"terser-webpack-plugin": "^1.2.4",
+						"unfetch": "^4.1.0",
+						"url-loader": "^2.0.1",
+						"util-deprecate": "^1.0.2",
+						"webpack": "^4.33.0",
+						"webpack-dev-middleware": "^3.7.0",
+						"webpack-hot-middleware": "^2.25.0"
+					}
+				},
+				"@storybook/core-events": {
+					"version": "5.2.3",
+					"resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-5.2.3.tgz",
+					"integrity": "sha512-sZEv93yE1o+/UJdhtqQ6vo2EauZ90FjN/L8F7CR7iqDEZzqo9g77Idg9LSgcN3TAeXcGAWVSrPb1vkK7H96L2g==",
+					"dev": true,
+					"requires": {
+						"core-js": "^3.0.1"
+					}
+				},
+				"@storybook/node-logger": {
+					"version": "5.2.3",
+					"resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-5.2.3.tgz",
+					"integrity": "sha512-5p+5ltLdr7cZTSCG+vdIMDLHq5AAaL/CQ/bygjl+Rw/RSpvBO5Rg8hryszFyhogToHJbn2JinUbypLA+P6tcuQ==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.4.2",
+						"core-js": "^3.0.1",
+						"npmlog": "^4.1.2",
+						"pretty-hrtime": "^1.0.3",
+						"regenerator-runtime": "^0.12.1"
+					}
+				},
+				"@storybook/router": {
+					"version": "5.2.3",
+					"resolved": "https://registry.npmjs.org/@storybook/router/-/router-5.2.3.tgz",
+					"integrity": "sha512-sOu6y2GySaY82SdXfF3yOn0IJTKMqd2BDOSGEno7PWWtSenHFQWY+z99C9k0dLBTkjRes5tPcgm0OJ7RdQVRDQ==",
+					"dev": true,
+					"requires": {
+						"@reach/router": "^1.2.1",
+						"@types/reach__router": "^1.2.3",
+						"core-js": "^3.0.1",
+						"global": "^4.3.2",
+						"lodash": "^4.17.11",
+						"memoizerific": "^1.11.3",
+						"qs": "^6.6.0"
+					}
+				},
+				"@storybook/theming": {
+					"version": "5.2.3",
+					"resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-5.2.3.tgz",
+					"integrity": "sha512-3/0bo8CaoaHDYZaexydpYcwP6WW8BKRqSQBGXJY9y0TLhwY2Who5nPX9XdOLyu9d7lN//PRZlt8JnZynuncxoQ==",
+					"dev": true,
+					"requires": {
+						"@emotion/core": "^10.0.14",
+						"@emotion/styled": "^10.0.14",
+						"@storybook/client-logger": "5.2.3",
+						"common-tags": "^1.8.0",
+						"core-js": "^3.0.1",
+						"deep-object-diff": "^1.1.0",
+						"emotion-theming": "^10.0.14",
+						"global": "^4.3.2",
+						"memoizerific": "^1.11.3",
+						"polished": "^3.3.1",
+						"prop-types": "^15.7.2",
+						"resolve-from": "^5.0.0"
+					}
+				},
+				"@storybook/ui": {
+					"version": "5.2.3",
+					"resolved": "https://registry.npmjs.org/@storybook/ui/-/ui-5.2.3.tgz",
+					"integrity": "sha512-SNyo5oxupb105N4Rz8O5/iJMs/THrmdvP+vsN7CpOTxebM01rHyvk51cNUwHKG1QwlZmpXL8GbtWlbvqL2d/gQ==",
+					"dev": true,
+					"requires": {
+						"@storybook/addons": "5.2.3",
+						"@storybook/api": "5.2.3",
+						"@storybook/channels": "5.2.3",
+						"@storybook/client-logger": "5.2.3",
+						"@storybook/components": "5.2.3",
+						"@storybook/core-events": "5.2.3",
+						"@storybook/router": "5.2.3",
+						"@storybook/theming": "5.2.3",
+						"copy-to-clipboard": "^3.0.8",
+						"core-js": "^3.0.1",
+						"core-js-pure": "^3.0.1",
+						"emotion-theming": "^10.0.14",
+						"fast-deep-equal": "^2.0.1",
+						"fuse.js": "^3.4.4",
+						"global": "^4.3.2",
+						"lodash": "^4.17.11",
+						"markdown-to-jsx": "^6.9.3",
+						"memoizerific": "^1.11.3",
+						"polished": "^3.3.1",
+						"prop-types": "^15.7.2",
+						"qs": "^6.6.0",
+						"react": "^16.8.3",
+						"react-dom": "^16.8.3",
+						"react-draggable": "^4.0.3",
+						"react-helmet-async": "^1.0.2",
+						"react-hotkeys": "2.0.0-pre4",
+						"react-sizeme": "^2.6.7",
+						"regenerator-runtime": "^0.13.2",
+						"resolve-from": "^5.0.0",
+						"semver": "^6.0.0",
+						"store2": "^2.7.1",
+						"telejson": "^3.0.2",
+						"util-deprecate": "^1.0.2"
+					},
+					"dependencies": {
+						"regenerator-runtime": {
+							"version": "0.13.3",
+							"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+							"integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
+							"dev": true
+						}
+					}
+				},
+				"accepts": {
+					"version": "1.3.7",
+					"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
+					"integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
+					"dev": true,
+					"requires": {
+						"mime-types": "~2.1.24",
+						"negotiator": "0.6.2"
+					}
+				},
+				"ansi-to-html": {
+					"version": "0.6.11",
+					"resolved": "https://registry.npmjs.org/ansi-to-html/-/ansi-to-html-0.6.11.tgz",
+					"integrity": "sha512-88XZtrcwrfkyn6fGstHnkaF1kl7hGtNCYh4vSmItgEV+6JnQHryDBf7udF4f2RhTRQmYvJvPcTtqgaqrxzc9oA==",
+					"dev": true,
+					"requires": {
+						"entities": "^1.1.1"
+					}
+				},
+				"body-parser": {
+					"version": "1.19.0",
+					"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
+					"integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
+					"dev": true,
+					"requires": {
+						"bytes": "3.1.0",
+						"content-type": "~1.0.4",
+						"debug": "2.6.9",
+						"depd": "~1.1.2",
+						"http-errors": "1.7.2",
+						"iconv-lite": "0.4.24",
+						"on-finished": "~2.3.0",
+						"qs": "6.7.0",
+						"raw-body": "2.4.0",
+						"type-is": "~1.6.17"
+					},
+					"dependencies": {
+						"qs": {
+							"version": "6.7.0",
+							"resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+							"integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
+							"dev": true
+						}
+					}
+				},
+				"bytes": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+					"integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
+					"dev": true
+				},
+				"content-disposition": {
+					"version": "0.5.3",
+					"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
+					"integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
+					"dev": true,
+					"requires": {
+						"safe-buffer": "5.1.2"
+					}
+				},
+				"cookie": {
+					"version": "0.4.0",
+					"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
+					"integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==",
+					"dev": true
+				},
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"eventemitter3": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.0.tgz",
+					"integrity": "sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg==",
+					"dev": true
+				},
+				"express": {
+					"version": "4.17.1",
+					"resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
+					"integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
+					"dev": true,
+					"requires": {
+						"accepts": "~1.3.7",
+						"array-flatten": "1.1.1",
+						"body-parser": "1.19.0",
+						"content-disposition": "0.5.3",
+						"content-type": "~1.0.4",
+						"cookie": "0.4.0",
+						"cookie-signature": "1.0.6",
+						"debug": "2.6.9",
+						"depd": "~1.1.2",
+						"encodeurl": "~1.0.2",
+						"escape-html": "~1.0.3",
+						"etag": "~1.8.1",
+						"finalhandler": "~1.1.2",
+						"fresh": "0.5.2",
+						"merge-descriptors": "1.0.1",
+						"methods": "~1.1.2",
+						"on-finished": "~2.3.0",
+						"parseurl": "~1.3.3",
+						"path-to-regexp": "0.1.7",
+						"proxy-addr": "~2.0.5",
+						"qs": "6.7.0",
+						"range-parser": "~1.2.1",
+						"safe-buffer": "5.1.2",
+						"send": "0.17.1",
+						"serve-static": "1.14.1",
+						"setprototypeof": "1.1.1",
+						"statuses": "~1.5.0",
+						"type-is": "~1.6.18",
+						"utils-merge": "1.0.1",
+						"vary": "~1.1.2"
+					},
+					"dependencies": {
+						"qs": {
+							"version": "6.7.0",
+							"resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+							"integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
+							"dev": true
+						}
+					}
+				},
+				"finalhandler": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+					"integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
+					"dev": true,
+					"requires": {
+						"debug": "2.6.9",
+						"encodeurl": "~1.0.2",
+						"escape-html": "~1.0.3",
+						"on-finished": "~2.3.0",
+						"parseurl": "~1.3.3",
+						"statuses": "~1.5.0",
+						"unpipe": "~1.0.0"
+					}
+				},
+				"find-cache-dir": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.0.0.tgz",
+					"integrity": "sha512-t7ulV1fmbxh5G9l/492O1p5+EBbr3uwpt6odhFTMc+nWyhmbloe+ja9BZ8pIBtqFWhOmCWVjx+pTW4zDkFoclw==",
+					"dev": true,
+					"requires": {
+						"commondir": "^1.0.1",
+						"make-dir": "^3.0.0",
+						"pkg-dir": "^4.1.0"
+					}
+				},
+				"find-up": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^5.0.0",
+						"path-exists": "^4.0.0"
+					}
+				},
+				"http-errors": {
+					"version": "1.7.2",
+					"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+					"integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
+					"dev": true,
+					"requires": {
+						"depd": "~1.1.2",
+						"inherits": "2.0.3",
+						"setprototypeof": "1.1.1",
+						"statuses": ">= 1.5.0 < 2",
+						"toidentifier": "1.0.0"
+					}
+				},
+				"iconv-lite": {
+					"version": "0.4.24",
+					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+					"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+					"dev": true,
+					"requires": {
+						"safer-buffer": ">= 2.1.2 < 3"
+					}
+				},
+				"interpret": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
+					"integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
+					"dev": true
+				},
+				"ipaddr.js": {
+					"version": "1.9.0",
+					"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
+					"integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA==",
+					"dev": true
+				},
+				"is-plain-object": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
+					"integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
+					"dev": true,
+					"requires": {
+						"isobject": "^4.0.0"
+					}
+				},
+				"is-symbol": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+					"integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+					"dev": true,
+					"requires": {
+						"has-symbols": "^1.0.0"
+					}
+				},
+				"isobject": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
+					"integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
+					"dev": true
+				},
+				"json5": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.1.tgz",
+					"integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==",
+					"dev": true,
+					"requires": {
+						"minimist": "^1.2.0"
+					}
+				},
+				"locate-path": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^4.1.0"
+					}
+				},
+				"mime": {
+					"version": "1.6.0",
+					"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+					"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+					"dev": true
+				},
+				"mime-db": {
+					"version": "1.40.0",
+					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
+					"integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
+					"dev": true
+				},
+				"mime-types": {
+					"version": "2.1.24",
+					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
+					"integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
+					"dev": true,
+					"requires": {
+						"mime-db": "1.40.0"
+					}
+				},
+				"negotiator": {
+					"version": "0.6.2",
+					"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
+					"integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
+					"dev": true
+				},
+				"node-fetch": {
+					"version": "2.6.0",
+					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+					"integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
+					"dev": true
+				},
+				"p-limit": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+					"integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+					"dev": true,
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.2.0"
+					}
+				},
+				"p-try": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+					"dev": true
+				},
+				"parseurl": {
+					"version": "1.3.3",
+					"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+					"integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+					"dev": true
+				},
+				"path-exists": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+					"dev": true
+				},
+				"path-parse": {
+					"version": "1.0.6",
+					"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+					"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+					"dev": true
+				},
+				"pkg-dir": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+					"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+					"dev": true,
+					"requires": {
+						"find-up": "^4.0.0"
+					}
+				},
+				"proxy-addr": {
+					"version": "2.0.5",
+					"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.5.tgz",
+					"integrity": "sha512-t/7RxHXPH6cJtP0pRG6smSr9QJidhB+3kXu0KgXnbGYMgzEnUxRQ4/LDdfOwZEMyIh3/xHb8PX3t+lfL9z+YVQ==",
+					"dev": true,
+					"requires": {
+						"forwarded": "~0.1.2",
+						"ipaddr.js": "1.9.0"
+					}
+				},
+				"qs": {
+					"version": "6.9.0",
+					"resolved": "https://registry.npmjs.org/qs/-/qs-6.9.0.tgz",
+					"integrity": "sha512-27RP4UotQORTpmNQDX8BHPukOnBP3p1uUJY5UnDhaJB+rMt9iMsok724XL+UHU23bEFOHRMQ2ZhI99qOWUMGFA==",
+					"dev": true
+				},
+				"range-parser": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+					"integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+					"dev": true
+				},
+				"raw-body": {
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
+					"integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
+					"dev": true,
+					"requires": {
+						"bytes": "3.1.0",
+						"http-errors": "1.7.2",
+						"iconv-lite": "0.4.24",
+						"unpipe": "1.0.0"
+					}
+				},
+				"react-draggable": {
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.0.3.tgz",
+					"integrity": "sha512-4vD6zms+9QGeZ2RQXzlUBw8PBYUXy+dzYX5r22idjp9YwQKIIvD/EojL0rbjS1GK4C3P0rAJnmKa8gDQYWUDyA==",
+					"dev": true,
+					"requires": {
+						"classnames": "^2.2.5",
+						"prop-types": "^15.6.0"
+					}
+				},
+				"regenerator-runtime": {
+					"version": "0.12.1",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+					"integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==",
+					"dev": true
+				},
+				"resolve": {
+					"version": "1.12.0",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
+					"integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
+					"dev": true,
+					"requires": {
+						"path-parse": "^1.0.6"
+					}
+				},
+				"resolve-from": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+					"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+					"dev": true
+				},
+				"send": {
+					"version": "0.17.1",
+					"resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
+					"integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
+					"dev": true,
+					"requires": {
+						"debug": "2.6.9",
+						"depd": "~1.1.2",
+						"destroy": "~1.0.4",
+						"encodeurl": "~1.0.2",
+						"escape-html": "~1.0.3",
+						"etag": "~1.8.1",
+						"fresh": "0.5.2",
+						"http-errors": "~1.7.2",
+						"mime": "1.6.0",
+						"ms": "2.1.1",
+						"on-finished": "~2.3.0",
+						"range-parser": "~1.2.1",
+						"statuses": "~1.5.0"
+					},
+					"dependencies": {
+						"ms": {
+							"version": "2.1.1",
+							"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+							"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+							"dev": true
+						}
+					}
+				},
+				"serve-static": {
+					"version": "1.14.1",
+					"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
+					"integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
+					"dev": true,
+					"requires": {
+						"encodeurl": "~1.0.2",
+						"escape-html": "~1.0.3",
+						"parseurl": "~1.3.3",
+						"send": "0.17.1"
+					}
+				},
+				"setprototypeof": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+					"integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
+					"dev": true
+				},
+				"shallow-equal": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-1.2.0.tgz",
+					"integrity": "sha512-Z21pVxR4cXsfwpMKMhCEIO1PCi5sp7KEp+CmOpBQ+E8GpHwKOw2sEzk7sgblM3d/j4z4gakoWEoPcjK0VJQogA==",
+					"dev": true
+				},
+				"statuses": {
+					"version": "1.5.0",
+					"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+					"integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
+					"dev": true
+				},
+				"telejson": {
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/telejson/-/telejson-3.0.3.tgz",
+					"integrity": "sha512-gUOh6wox1zJjbGMg+e26NquZcp/F18EbIaqVvjiGqikRqVB4fYEAM8Nyin8smgwX30XhaRBOg+kCj4vInmvwAg==",
+					"dev": true,
+					"requires": {
+						"@types/is-function": "^1.0.0",
+						"global": "^4.4.0",
+						"is-function": "^1.0.1",
+						"is-regex": "^1.0.4",
+						"is-symbol": "^1.0.2",
+						"isobject": "^4.0.0",
+						"lodash": "^4.17.15",
+						"memoizerific": "^1.11.3"
+					}
+				},
+				"type-is": {
+					"version": "1.6.18",
+					"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+					"integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+					"dev": true,
+					"requires": {
+						"media-typer": "0.3.0",
+						"mime-types": "~2.1.24"
+					}
+				},
+				"ws": {
+					"version": "6.2.1",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
+					"integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
+					"dev": true,
+					"requires": {
+						"async-limiter": "~1.0.0"
+					}
 				}
 			}
 		},
@@ -6838,6 +7910,12 @@
 			"version": "4.7.3",
 			"resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.3.tgz",
 			"integrity": "sha512-cS5owqtwzLN5kY+l+KgKdRJ/Cee8tlmQoGQuIE9tWnSmS3JMKzmxo2HIAk2wODMifGwO20d62xZQLYz+RLfXmw==",
+			"dev": true
+		},
+		"@types/is-function": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@types/is-function/-/is-function-1.0.0.tgz",
+			"integrity": "sha512-iTs9HReBu7evG77Q4EC8hZnqRt57irBDkK9nvmHroiOIVwYMQc4IvYvdRgwKfYepunIY7Oh/dBuuld+Gj9uo6w==",
 			"dev": true
 		},
 		"@types/istanbul-lib-coverage": {
@@ -11045,6 +12123,12 @@
 				"quick-lru": "^1.0.0"
 			}
 		},
+		"camelize": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.0.tgz",
+			"integrity": "sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs=",
+			"dev": true
+		},
 		"can-use-dom": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/can-use-dom/-/can-use-dom-0.1.0.tgz",
@@ -13574,6 +14658,12 @@
 				}
 			}
 		},
+		"css-color-keywords": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+			"integrity": "sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU=",
+			"dev": true
+		},
 		"css-color-names": {
 			"version": "0.0.4",
 			"resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
@@ -13896,6 +14986,17 @@
 						"jsesc": "~0.5.0"
 					}
 				}
+			}
+		},
+		"css-to-react-native": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-2.3.2.tgz",
+			"integrity": "sha512-VOFaeZA053BqvvvqIA8c9n0+9vFppVBAHCp6JgFTtTMU3Mzi+XnelJ9XC9ul3BqFzZyQ5N+H0SnwsWT2Ebchxw==",
+			"dev": true,
+			"requires": {
+				"camelize": "^1.0.0",
+				"css-color-keywords": "^1.0.0",
+				"postcss-value-parser": "^3.3.0"
 			}
 		},
 		"css-tree": {
@@ -21523,6 +22624,12 @@
 			"version": "2.5.1",
 			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
 			"integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
+			"dev": true
+		},
+		"json-fn": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/json-fn/-/json-fn-1.1.1.tgz",
+			"integrity": "sha1-QpPJGYpILWaX0zSm4yzQ0iESHoA=",
 			"dev": true
 		},
 		"json-parse-better-errors": {
@@ -29160,6 +30267,12 @@
 				}
 			}
 		},
+		"react-native-swipe-gestures": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/react-native-swipe-gestures/-/react-native-swipe-gestures-1.0.4.tgz",
+			"integrity": "sha512-C/vz0KPHNyqHk3uF4Cz/jzd/0N8z34ZgsjAZUh/RsXPH2FtJJf3Fw73pQDWJSoCMtvVadlztb8xQ+/aEQrll7w==",
+			"dev": true
+		},
 		"react-outside-click-handler": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/react-outside-click-handler/-/react-outside-click-handler-1.2.2.tgz",
@@ -30547,6 +31660,12 @@
 				"hash-base": "^3.0.0",
 				"inherits": "^2.0.1"
 			}
+		},
+		"rn-host-detect": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/rn-host-detect/-/rn-host-detect-1.1.5.tgz",
+			"integrity": "sha512-ufk2dFT3QeP9HyZ/xTuMtW27KnFy815CYitJMqQm+pgG3ZAtHBsrU8nXizNKkqXGy3bQmhEoloVbrfbvMJMqkg==",
+			"dev": true
 		},
 		"rst-selector-parser": {
 			"version": "2.2.3",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,8 @@
 		"@storybook/addon-docs": "5.3.0-alpha.2",
 		"@storybook/addon-viewport": "5.2.1",
 		"@storybook/react": "5.2.1",
+		"@storybook/react-native": "5.2.3",
+		"@storybook/react-native-server": "5.2.3",
 		"@wordpress/babel-plugin-import-jsx-pragma": "file:packages/babel-plugin-import-jsx-pragma",
 		"@wordpress/babel-plugin-makepot": "file:packages/babel-plugin-makepot",
 		"@wordpress/babel-preset-default": "file:packages/babel-preset-default",
@@ -85,8 +87,8 @@
 		"@wordpress/docgen": "file:packages/docgen",
 		"@wordpress/e2e-test-utils": "file:packages/e2e-test-utils",
 		"@wordpress/e2e-tests": "file:packages/e2e-tests",
-		"@wordpress/eslint-plugin": "file:packages/eslint-plugin",
 		"@wordpress/env": "file:packages/env",
+		"@wordpress/eslint-plugin": "file:packages/eslint-plugin",
 		"@wordpress/jest-console": "file:packages/jest-console",
 		"@wordpress/jest-preset-default": "file:packages/jest-preset-default",
 		"@wordpress/jest-puppeteer-axe": "file:packages/jest-puppeteer-axe",
@@ -229,7 +231,8 @@
 		"playground:dev": "concurrently \"npm run dev:packages\" \"parcel playground/src/index.html -d playground/dist\"",
 		"preenv": "npm run check-engines",
 		"env": "wp-scripts env",
-		"design-system:dev": "concurrently \"npm run dev:packages\" \"start-storybook -c ./packages/components/storybook\"",
+		"design-system:dev": "concurrently \"npm run dev:packages\" \"./node_modules/@storybook/react/bin/index.js -c ./packages/components/storybook\"",
+		"design-system:dev:native": "concurrently \"npm run dev:packages\" \"(adb reverse tcp:7007 tcp:7007 || true) && ./node_modules/@storybook/react-native-server/bin/index.js -c ./packages/components/storybook\"",
 		"design-system:build": "build-storybook -c ./packages/components/storybook -o ./playground/dist/design-system/components"
 	},
 	"husky": {

--- a/packages/components/storybook/index.js
+++ b/packages/components/storybook/index.js
@@ -1,0 +1,18 @@
+/**
+ * External dependencies
+ */
+import { configure, getStorybookUI } from '@storybook/react-native';
+import { AppRegistry } from 'react-native';
+
+configure(
+	[
+		require.context( '../docs', true, /\/.+\.mdx$/ ),
+		require.context( '../src', true, /\/stories\/.+\.js$/ ),
+	],
+	module
+);
+
+const StorybookUI = getStorybookUI();
+AppRegistry.registerComponent( 'Gutenberg Design System', () => StorybookUI );
+
+export default StorybookUI;


### PR DESCRIPTION
## Description

This PR adds Storybook for React Native and uses it to create a native version of the `@wordpress/components` storybook.

This will be super useful for testing cross platform compatibility of components.

The new storybook can be started with `npm run design-system:dev:native`.

## How has this been tested?

It was verified that the web storybook still works as expected and that so does `npm run design-system:dev:native`.

## Screenshots

<img width="1467" alt="Screen Shot 2019-10-07 at 2 12 34 PM" src="https://user-images.githubusercontent.com/19157096/66349996-ffaf4000-e90e-11e9-8ffd-7e1924adc5e1.png">

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
