### PR TITLE
navigation: Navigation customization

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -171,6 +171,10 @@ _Related_
 
 Undocumented declaration.
 
+<a name="ColorPaletteControl" href="#ColorPaletteControl">#</a> **ColorPaletteControl**
+
+Undocumented declaration.
+
 <a name="ContrastChecker" href="#ContrastChecker">#</a> **ContrastChecker**
 
 Undocumented declaration.

--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -16,6 +16,7 @@ export { default as __experimentalBlockNavigationList } from './block-navigation
 export { default as BlockVerticalAlignmentToolbar } from './block-vertical-alignment-toolbar';
 export { default as ButtonBlockerAppender } from './button-block-appender';
 export { default as ColorPalette } from './color-palette';
+export { default as ColorPaletteControl } from './color-palette/control';
 export { default as ContrastChecker } from './contrast-checker';
 export { default as __experimentalGradientPicker } from './gradient-picker';
 export { default as __experimentalGradientPickerControl } from './gradient-picker/control';

--- a/packages/block-library/src/navigation-menu-item/edit.js
+++ b/packages/block-library/src/navigation-menu-item/edit.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { invoke } from 'lodash';
+import classnames from 'classnames';
 
 /**
  * WordPress dependencies
@@ -84,8 +85,11 @@ function NavigationMenuItemEdit( {
 			</div>
 		);
 	} else {
-		content = attributes.label;
+		content = <div className="wp-block-navigation-menu-item__container">
+			{ attributes.label }
+		</div>;
 	}
+
 	return (
 		<Fragment>
 			<InspectorControls>
@@ -138,7 +142,12 @@ function NavigationMenuItemEdit( {
 					/>
 				</PanelBody>
 			</InspectorControls>
-			<div className="wp-block-navigation-menu-item">
+			<div className={ classnames(
+				'wp-block-navigation-menu-item', {
+					'is-editing': isSelected || isParentOfSelectedBlock,
+					'is-selected': isSelected,
+				} ) }
+			>
 				{ content }
 				{ ( isSelected || isParentOfSelectedBlock ) &&
 					<InnerBlocks

--- a/packages/block-library/src/navigation-menu-item/editor.scss
+++ b/packages/block-library/src/navigation-menu-item/editor.scss
@@ -28,12 +28,16 @@ $menu-label-field-width: 140px;
 	}
 }
 
-
 .wp-block-navigation-menu-item {
 	font-family: $editor-font;
-	color: #0073af;
 	font-weight: bold;
 	font-size: $text-editor-font-size;
+
+	.wp-block-navigation-menu-item__container,
+	&.is-editing .editor-plain-text {
+		background-color: var(--background-color-menu-link);
+		color: var(--color-menu-link);
+	}
 }
 
 .wp-block-navigation-menu-item__nofollow-external-link {
@@ -42,10 +46,7 @@ $menu-label-field-width: 140px;
 
 // Separator
 .wp-block-navigation-menu-item__separator {
-	margin-top: $grid-size;
-	margin-bottom: $grid-size;
-	margin-left: 0;
-	margin-right: 0;
+	margin: $grid-size 0 $grid-size;
 	border-top: $border-width solid $light-gray-500;
 }
 

--- a/packages/block-library/src/navigation-menu/block-colors-selector.js
+++ b/packages/block-library/src/navigation-menu/block-colors-selector.js
@@ -1,0 +1,95 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+import { noop } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { IconButton, Dropdown, Toolbar } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { DOWN } from '@wordpress/keycodes';
+import { ColorPaletteControl, ContrastChecker } from '@wordpress/block-editor';
+
+/**
+ * Color Selector Icon component.
+ *
+ * @return {*} React Icon component.
+ */
+const ColorSelectorIcon = ( { style } ) =>
+	<div className="block-library-colors-selector__icon-container">
+		<div
+			className="block-library-colors-selector__state-selection wp-block-navigation-menu-item"
+			style={ style }
+		>
+			Aa
+		</div>
+	</div>;
+
+/**
+ * Renders the Colors Selector Toolbar with the icon button.
+ *
+ * @param {Object}   style           - Colors style object.
+ * @return {*} React toggle button component.
+ */
+const renderToggleComponent = ( style ) => ( { onToggle, isOpen } ) => {
+	const openOnArrowDown = ( event ) => {
+		if ( ! isOpen && event.keyCode === DOWN ) {
+			event.preventDefault();
+			event.stopPropagation();
+			onToggle();
+		}
+	};
+
+	return (
+		<Toolbar>
+			<IconButton
+				className="components-icon-button components-toolbar__control block-library-colors-selector__toggle"
+				label={ __( 'Open Colors Selector' ) }
+				onClick={ onToggle }
+				onKeyDown={ openOnArrowDown }
+				icon={ <ColorSelectorIcon style={ style } /> }
+			/>
+		</Toolbar>
+	);
+};
+
+const renderContent = ( { backgroundColor, textColor, onColorChange = noop } ) => ( () => {
+	const setColor = ( attr ) => ( value ) => onColorChange( { attr, value } );
+
+	return (
+		<>
+			<div className="color-palette-controller-container">
+				<ColorPaletteControl
+					value={ backgroundColor.color }
+					onChange={ setColor( 'backgroundColor' ) }
+					label={ __( 'Background Color' ) }
+				/>
+			</div>
+
+			<div className="color-palette-controller-container">
+				<ColorPaletteControl
+					value={ textColor.color }
+					onChange={ setColor( 'textColor' ) }
+					label={ __( 'Text Color' ) }
+				/>
+			</div>
+
+			<ContrastChecker
+				textColor={ textColor.color }
+				backgroundColor={ backgroundColor.color }
+				isLargeText={ false }
+			/>
+		</>
+	);
+} );
+
+export default ( { style, className, ...colorControlProps } ) =>
+	<Dropdown
+		position="bottom right"
+		className={ classnames( 'block-library-colors-selector', className ) }
+		contentClassName="block-library-colors-selector__popover"
+		renderToggle={ renderToggleComponent( style ) }
+		renderContent={ renderContent( colorControlProps ) }
+	/>;

--- a/packages/block-library/src/navigation-menu/editor.scss
+++ b/packages/block-library/src/navigation-menu/editor.scss
@@ -12,7 +12,90 @@
 }
 
 .wp-block-navigation-menu-item {
-	.wp-block-navigation-menu-item {
+	.wp-block-navigation-menu-item__link {
 		margin-left: $grid-size-large;
+	}
+}
+
+/**
+ * Colors Selector component
+ */
+$colors-selector-size: 22px;
+.block-library-colors-selector {
+	width: auto;
+
+	// Toolbar colors-selector button.
+	.block-library-colors-selector__toggle {
+		display: block;
+		margin: 0 auto;
+		padding: 3px;
+		width: auto;
+	}
+
+	// Button container.
+	.block-library-colors-selector__icon-container {
+		width: 42px;
+		height: 30px;
+		position: relative;
+		margin: 0 auto;
+		padding: 3px;
+		display: flex;
+		align-items: center;
+		border-radius: 4px;
+
+		// Add the button arrow.
+		&::after {
+			@include dropdown-arrow();
+		}
+
+		// Styling button states.
+		&:focus,
+		&:hover {
+			color: $dark-gray-500;
+			box-shadow: inset 0 0 0 1px $dark-gray-500, inset 0 0 0 2px #fff;
+		}
+	}
+
+	// colors-selector - selection status.
+	.block-library-colors-selector__state-selection {
+		font-size: 11px;
+		font-style: normal;
+		font-family: inherit;
+		font-weight: 600;
+
+		border-radius: $colors-selector-size / 2;
+		box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.2);
+
+		width: $colors-selector-size;
+		min-width: $colors-selector-size;
+		height: $colors-selector-size;
+		min-height: $colors-selector-size;
+		line-height: ($colors-selector-size - 2);
+
+		background-color: var(--background-color-menu-link);
+		color: var(--color-menu-link);
+	}
+
+	&:not(.has-background-color) .block-library-colors-selector__state-selection {
+		background-image: linear-gradient(135deg, rgba(0, 0, 0, 0.08) 25%, transparent 25%, transparent 50%, rgba(0, 0, 0, 0.08) 50%, rgba(0, 0, 0, 0.08) 75%, transparent 75%, transparent 100%);
+		background-size: 12px 12px;
+	}
+}
+
+// Colors Selector Popover.
+$color-control-label-height: 20px;
+.block-library-colors-selector__popover {
+	.color-palette-controller-container {
+		padding: 16px;
+	}
+
+	.components-base-control__label {
+		height: $color-control-label-height;
+		line-height: $color-control-label-height;
+	}
+
+	.component-color-indicator {
+		float: right;
+		margin-top: 2px;
 	}
 }

--- a/packages/block-library/src/navigation-menu/index.php
+++ b/packages/block-library/src/navigation-menu/index.php
@@ -6,6 +6,56 @@
  */
 
 /**
+ * Build an array with CSS classes and inline styles defining the colors
+ * which will be applied to the navigation menu markup in the front-end.
+ *
+ * @param  array $attributes NavigationMenu block attributes.
+ * @return array Colors CSS classes and inline styles.
+ */
+function build_css_colors( $attributes ) {
+	// CSS classes.
+	$colors = array(
+		'bg_css_classes'     => '',
+		'bg_inline_styles'   => '',
+		'text_css_classes'   => '',
+		'text_inline_styles' => '',
+	);
+
+	// Background color.
+	// Background color - has text color.
+	if ( array_key_exists( 'backgroundColor', $attributes ) ) {
+		$colors['bg_css_classes'] .= ' has-background-color';
+	}
+
+	// Background color - add custom CSS class.
+	if ( array_key_exists( 'backgroundColorCSSClass', $attributes ) ) {
+		$colors['bg_css_classes'] .= " {$attributes['backgroundColorCSSClass']}";
+
+	} elseif ( array_key_exists( 'customBackgroundColor', $attributes ) ) {
+		// Background color - or add inline `background-color` style.
+		$colors['bg_inline_styles'] = ' style="background-color: ' . esc_attr( $attributes['customBackgroundColor'] ) . ';"';
+	}
+
+	// Text color.
+	// Text color - has text color.
+	if ( array_key_exists( 'textColor', $attributes ) ) {
+		$colors['text_css_classes'] .= ' has-text-color';
+	}
+	// Text color - add custom CSS class.
+	if ( array_key_exists( 'textColorCSSClass', $attributes ) ) {
+		$colors['text_css_classes'] .= " {$attributes['textColorCSSClass']}";
+
+	} elseif ( array_key_exists( 'customTextColor', $attributes ) ) {
+		// Text color - or add inline `color` style.
+		$colors['text_inline_styles'] = ' style="color: ' . esc_attr( $attributes['customTextColor'] ) . ';"';
+	}
+
+	$colors['bg_css_classes']   = esc_attr( trim( $colors['bg_css_classes'] ) );
+	$colors['text_css_classes'] = esc_attr( trim( $colors['text_css_classes'] ) );
+
+	return $colors;
+}
+/**
  * Renders the `core/navigation-menu` block on server.
  *
  * @param array $attributes The block attributes.
@@ -15,20 +65,43 @@
  * @return string Returns the post content with the legacy widget added.
  */
 function render_block_navigation_menu( $attributes, $content, $block ) {
-	return '<nav class="wp-block-navigation-menu">' . build_navigation_menu_html( $block ) . '</nav>';
+	// Inline computed colors.
+	$comp_inline_styles = '';
+	if ( array_key_exists( 'backgroundColorValue', $attributes ) ) {
+		$comp_inline_styles .= ' background-color: ' . esc_attr( $attributes['backgroundColorValue'] ) . ';';
+	}
+
+	if ( array_key_exists( 'textColorValue', $attributes ) ) {
+		$comp_inline_styles .= ' color: ' . esc_attr( $attributes['textColorValue'] ) . ';';
+	}
+	$comp_inline_styles = ! empty( $comp_inline_styles )
+		? ' style="' . esc_attr( trim( $comp_inline_styles ) ) . '"'
+		: '';
+
+	$colors = build_css_colors( $attributes );
+
+	return "<nav class='wp-block-navigation-menu' {$comp_inline_styles}>" .
+		build_navigation_menu_html( $block, $colors ) .
+	'</nav>';
 }
 
 /**
  * Walks the inner block structure and returns an HTML list for it.
  *
- * @param array $block The block.
+ * @param array $block  The block.
+ * @param array $colors Contains inline styles and CSS classes to apply to menu item.
  *
  * @return string Returns  an HTML list from innerBlocks.
  */
-function build_navigation_menu_html( $block ) {
+function build_navigation_menu_html( $block, $colors ) {
 	$html = '';
 	foreach ( (array) $block['innerBlocks'] as $key => $menu_item ) {
-		$html .= '<li class="wp-block-navigation-menu-item"><a class="wp-block-navigation-menu-item"';
+
+		$html .= '<li class="wp-block-navigation-menu-item ' . $colors['bg_css_classes'] . '"' . $colors['bg_inline_styles'] . '>' .
+			'<a
+				class="wp-block-navigation-menu-item__link ' . $colors['text_css_classes'] . '"
+				' . $colors['text_inline_styles'];
+
 		if ( isset( $menu_item['attrs']['destination'] ) ) {
 			$html .= ' href="' . $menu_item['attrs']['destination'] . '"';
 		}
@@ -42,7 +115,7 @@ function build_navigation_menu_html( $block ) {
 		$html .= '</a>';
 
 		if ( count( (array) $menu_item['innerBlocks'] ) > 0 ) {
-			$html .= build_navigation_menu_html( $menu_item );
+			$html .= build_navigation_menu_html( $menu_item, $colors );
 		}
 
 		$html .= '</li>';
@@ -54,18 +127,57 @@ function build_navigation_menu_html( $block ) {
  * Register the navigation menu block.
  *
  * @uses render_block_navigation_menu()
+ * @throws WP_Error An WP_Error exception parsing the block definition.
  */
 function register_block_core_navigation_menu() {
+
 	register_block_type(
 		'core/navigation-menu',
 		array(
 			'category'        => 'layout',
 			'attributes'      => array(
-				'automaticallyAdd' => array(
+				'className'               => array(
+					'type' => 'string',
+				),
+
+				'automaticallyAdd'        => array(
 					'type'    => 'boolean',
 					'default' => false,
 				),
+
+				'backgroundColor'         => array(
+					'type' => 'string',
+				),
+
+				'textColor'               => array(
+					'type' => 'string',
+				),
+
+				'backgroundColorValue'    => array(
+					'type' => 'string',
+				),
+
+				'textColorValue'          => array(
+					'type' => 'string',
+				),
+
+				'customBackgroundColor'   => array(
+					'type' => 'string',
+				),
+
+				'customTextColor'         => array(
+					'type' => 'string',
+				),
+
+				'backgroundColorCSSClass' => array(
+					'type' => 'string',
+				),
+
+				'textColorCSSClass'       => array(
+					'type' => 'string',
+				),
 			),
+
 			'render_callback' => 'render_block_navigation_menu',
 		)
 	);


### PR DESCRIPTION
## Description

This PR adds a color selector to the navigation menu through a new `Aa` button in the editor toolbar.

![image](https://user-images.githubusercontent.com/77539/66758618-042aaa00-ee75-11e9-9b6d-d9be3516b48f.png)

## How does it apply the colors?

Thr following shows an idea arond the built markup in the front-end for the NavigationMenu:

```html
	 <div
	     class="wp-block-navigation-menu"
	     style="background-color: <computed>; color: <computed>"
	>
		<ul>
			<li
			    class="wp-block-navigation-menu-item <background-color-classes>"
			    style="background-color: <custom>"
			>
				<a
				    class="wp-block-navigation-menu-item__link <text-color-classes>"
				    style="color: <custom>"
				>
					Item text
				</a>
			</li>
		</ul>
	 </div>
```

Let's walk through of all elements, from the menu item to the main contaner:

#### Text color

The `Item text` is wrapped by an anchor element which contains the `wp-block-navigation-menu-item__link` as default, and depending on whether the color was defined by the color pelette will contain the color CSS class and the generic `has-text-color` class, for instance:

```html
<a
    href="#link"
    class="wp-block-navigation-menu-item__link has-text-color has-very-dark-gray-color"
>
    Item Text
</a>
```

Now, if the text color is defined using a custom color, these both classes won't be added and the color will be applied by inline styles:

```html
<a
    href="#link"
    class="wp-block-navigation-menu-item__link"
    style="color: #ff9c9c;"
>
    Item Text
</a>
```

#### Background color

Something similar happends with the background color but it's handled by the `<li>` element. It contains the `wp-block-navigation-menu-item` class as default, and if the color comes from the palette, it will add the color CSS classes.

```html
<il
    class="wp-block-navigation-menu-item has-background-color has-vivid-red-background-color"
>
    <a ...>Item Text</a>
</li>
```


If not, inline styles:

```html
<il
    class="wp-block-navigation-menu-item"
    style="background-color: #544d4d;"
>
    <a ...>Item Text</a>
</li>
```

This behaviour of applying colors by CSS classes or inline styles tries to be coherent with the styles defined by the theme.

For instance, some themes define a set of colors classes making this implementation works was expected.

```css

// ...

:root .has-light-green-cyan-background-color { background-color: #7bdcb5; }

:root .has-vivid-green-cyan-background-color { background-color: #00d084; }

:root .has-pale-cyan-blue-background-color { background-color: #8ed1fc; }

:root .has-vivid-cyan-blue-background-color { background-color: #0693e3; }

:root .has-vivid-purple-background-color { background-color: #9b51e0; }

// ...
```

But, what happens if the theme doesn't have defined the color CSS class? For this reason, I've added the inlines styles either for background as well as color, in the main menu-item container:

```html
<nav
  class="wp-block-navigation-menu"
  style="background-color: #0693e3; color: #ff9c9c;"
>
    <ul>
        <li>
            <a>
                Item Text
            </a>
        </li>
    </ul>
</nav>
```

Since the classes are added to deeper elements are stronger than the computed-inline-styles applied to the main container. Notice that these styles will be always added without caring if colors come from the palette or are custom ones.

## How has this been tested?

1) Enable Navigation Menu. It's doable through the Gutenberg menu.
2) Play setting the background and text color of the navigation menu.
3) Confirm that colors are rightly applied in the front-end


![navigation-menu-06](https://user-images.githubusercontent.com/77539/67100550-3fd7b380-f196-11e9-9e89-c49d833c16e9.gif)

Fixes #17683

## Types of changes
✔️ Add colors selector block


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
