### PR TITLE
Fix: navigation block automatically selects child menu items.

### DIFF
--- a/packages/block-library/src/navigation-menu/edit.js
+++ b/packages/block-library/src/navigation-menu/edit.js
@@ -76,6 +76,7 @@ function NavigationMenu( {
 					<InnerBlocks
 						template={ defaultMenuItems ? defaultMenuItems : null }
 						allowedBlocks={ [ 'core/navigation-menu-item' ] }
+						templateInsertUpdatesSelection={ false }
 					/>
 				}
 			</div>


### PR DESCRIPTION
## Description
When a navigation block is inserted, menu items for top-level pages are automatically inserted.
Then the first child menu item is selected. That is unexpected and is an accessibily problem. We had a similar issue in media & text block and we are applying the same method to fix it.

This problem also cause some intermittent text fails in block transforms as the end 2 end test expected the block navigation to be selected and not his a child.


## How has this been tested?
I added a navigation block, I verified the navigation block got selected after the insert and its children were not selected.
