### PR TITLE
Add a block selection breadcrumb to the bottom of the editor

### DIFF
--- a/docs/designers-developers/developers/data/data-core-block-editor.md
+++ b/docs/designers-developers/developers/data/data-core-block-editor.md
@@ -191,7 +191,7 @@ _Returns_
 
 <a name="getBlockParents" href="#getBlockParents">#</a> **getBlockParents**
 
-Given a block client ID, returns the list of all its parents.
+Given a block client ID, returns the list of all its parents from top to bottom.
 
 _Parameters_
 

--- a/docs/designers-developers/developers/data/data-core-block-editor.md
+++ b/docs/designers-developers/developers/data/data-core-block-editor.md
@@ -191,7 +191,16 @@ _Returns_
 
 <a name="getBlockParents" href="#getBlockParents">#</a> **getBlockParents**
 
-Undocumented declaration.
+Given a block client ID, returns the list of all its parents.
+
+_Parameters_
+
+-   _state_ `Object`: Editor state.
+-   _clientId_ `string`: Block from which to find root client ID.
+
+_Returns_
+
+-   `Array`: ClientIDs of the parent blocks.
 
 <a name="getBlockRootClientId" href="#getBlockRootClientId">#</a> **getBlockRootClientId**
 

--- a/docs/designers-developers/developers/data/data-core-block-editor.md
+++ b/docs/designers-developers/developers/data/data-core-block-editor.md
@@ -189,6 +189,10 @@ _Returns_
 
 -   `Array`: Ordered client IDs of editor blocks.
 
+<a name="getBlockParents" href="#getBlockParents">#</a> **getBlockParents**
+
+Undocumented declaration.
+
 <a name="getBlockRootClientId" href="#getBlockRootClientId">#</a> **getBlockRootClientId**
 
 Given a block client ID, returns the root block from which the block is

--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -24,6 +24,7 @@ $z-layers: (
 	".block-editor-warning": 5,
 	".block-library-gallery-item__inline-menu": 20,
 	".block-editor-url-input__suggestions": 30,
+	".edit-post-layout__footer": 30,
 	".edit-post-header": 30,
 	".edit-widgets-header": 30,
 	".block-library-button__inline-link .block-editor-url-input__suggestions": 6, // URL suggestions for button block above sibling inserter

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -82,6 +82,20 @@ _Related_
 
 Undocumented declaration.
 
+<a name="BlockBreadcrumb" href="#BlockBreadcrumb">#</a> **BlockBreadcrumb**
+
+Block breadcrumb component, displaying the label of the block. If the block
+descends from a root block, a button is displayed enabling the user to select
+the root block.
+
+_Parameters_
+
+-   _props.clientId_ `string`: Client ID of block.
+
+_Returns_
+
+-   `WPElement`: Block Breadcrumb.
+
 <a name="BlockControls" href="#BlockControls">#</a> **BlockControls**
 
 Undocumented declaration.

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -84,13 +84,7 @@ Undocumented declaration.
 
 <a name="BlockBreadcrumb" href="#BlockBreadcrumb">#</a> **BlockBreadcrumb**
 
-Block breadcrumb component, displaying the label of the block. If the block
-descends from a root block, a button is displayed enabling the user to select
-the root block.
-
-_Parameters_
-
--   _props.clientId_ `string`: Client ID of block.
+Block breadcrumb component, displaying the hierarchy of the current block selection as a breadcrumb.
 
 _Returns_
 

--- a/packages/block-editor/src/components/block-breadcrumb/index.js
+++ b/packages/block-editor/src/components/block-breadcrumb/index.js
@@ -31,8 +31,13 @@ const BlockBreadcrumb = function() {
 		};
 	}, [] );
 
+	/*
+	 * Disable reason: The `list` ARIA role is redundant but
+	 * Safari+VoiceOver won't announce the list otherwise.
+	 */
+	/* eslint-disable jsx-a11y/no-redundant-roles */
 	return (
-		<ul className="block-editor-block-breadcrumb">
+		<ul className="block-editor-block-breadcrumb" role="list">
 			<li>
 				<Button
 					className="block-editor-block-breadcrumb__button"
@@ -59,6 +64,7 @@ const BlockBreadcrumb = function() {
 				</li>
 			) }
 		</ul>
+		/* eslint-enable jsx-a11y/no-redundant-roles */
 	);
 };
 

--- a/packages/block-editor/src/components/block-breadcrumb/index.js
+++ b/packages/block-editor/src/components/block-breadcrumb/index.js
@@ -3,6 +3,7 @@
  */
 import { Button } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -18,17 +19,32 @@ import BlockTitle from '../block-title';
  * @return {WPElement} Block Breadcrumb.
  */
 const BlockBreadcrumb = function() {
-	const { selectBlock } = useDispatch( 'core/block-editor' );
-	const { clientId, parents } = useSelect( ( select ) => {
-		const selectedBlockClientId = select( 'core/block-editor' ).getSelectedBlockClientId();
+	const { selectBlock, clearSelectedBlock } = useDispatch( 'core/block-editor' );
+	const { clientId, parents, hasSelection } = useSelect( ( select ) => {
+		const {
+			getSelectionStart,
+			getSelectedBlockClientId,
+			getBlockParents,
+		} = select( 'core/block-editor' );
+		const selectedBlockClientId = getSelectedBlockClientId();
 		return {
-			parents: select( 'core/block-editor' ).getBlockParents( selectedBlockClientId ),
+			parents: getBlockParents( selectedBlockClientId ),
 			clientId: selectedBlockClientId,
+			hasSelection: getSelectionStart(),
 		};
 	}, [] );
 
 	return (
 		<ul className="block-editor-block-breadcrumb">
+			<li>
+				<Button
+					className="block-editor-block-breadcrumb__button"
+					isTertiary
+					onClick={ hasSelection ? clearSelectedBlock : null }
+				>
+					{ __( 'Document' ) }
+				</Button>
+			</li>
 			{ parents.map( ( parent ) => (
 				<li key={ parent }>
 					<Button

--- a/packages/block-editor/src/components/block-breadcrumb/index.js
+++ b/packages/block-editor/src/components/block-breadcrumb/index.js
@@ -27,7 +27,7 @@ const BlockBreadcrumb = function() {
 		return {
 			parents: getBlockParents( selectedBlockClientId ),
 			clientId: selectedBlockClientId,
-			hasSelection: getSelectionStart().clientId,
+			hasSelection: !! getSelectionStart().clientId,
 		};
 	}, [] );
 

--- a/packages/block-editor/src/components/block-breadcrumb/index.js
+++ b/packages/block-editor/src/components/block-breadcrumb/index.js
@@ -27,7 +27,7 @@ const BlockBreadcrumb = function() {
 		return {
 			parents: getBlockParents( selectedBlockClientId ),
 			clientId: selectedBlockClientId,
-			hasSelection: getSelectionStart(),
+			hasSelection: getSelectionStart().clientId,
 		};
 	}, [] );
 
@@ -37,17 +37,22 @@ const BlockBreadcrumb = function() {
 	 */
 	/* eslint-disable jsx-a11y/no-redundant-roles */
 	return (
-		<nav aria-label={ __( 'Blocks breadcrumb' ) }>
+		<nav aria-label={ __( 'Block breadcrumb' ) }>
 			<ul className="block-editor-block-breadcrumb" role="list">
-				<li>
-					<Button
-						className="block-editor-block-breadcrumb__button"
-						isTertiary
-						onClick={ hasSelection ? clearSelectedBlock : null }
-						aria-current={ hasSelection ? false : 'true' }
-					>
-						{ __( 'Document' ) }
-					</Button>
+				<li
+					className={ ! hasSelection ? 'block-editor-block-breadcrumb__current' : undefined }
+					aria-current={ ! hasSelection ? 'true' : undefined }
+				>
+					{ hasSelection && (
+						<Button
+							className="block-editor-block-breadcrumb__button"
+							isTertiary
+							onClick={ clearSelectedBlock }
+						>
+							{ __( 'Document' ) }
+						</Button>
+					) }
+					{ ! hasSelection && __( 'Document' ) }
 				</li>
 				{ parents.map( ( parentClientId ) => (
 					<li key={ parentClientId }>

--- a/packages/block-editor/src/components/block-breadcrumb/index.js
+++ b/packages/block-editor/src/components/block-breadcrumb/index.js
@@ -37,33 +37,36 @@ const BlockBreadcrumb = function() {
 	 */
 	/* eslint-disable jsx-a11y/no-redundant-roles */
 	return (
-		<ul className="block-editor-block-breadcrumb" role="list">
-			<li>
-				<Button
-					className="block-editor-block-breadcrumb__button"
-					isTertiary
-					onClick={ hasSelection ? clearSelectedBlock : null }
-				>
-					{ __( 'Document' ) }
-				</Button>
-			</li>
-			{ parents.map( ( parentClientId ) => (
-				<li key={ parentClientId }>
+		<nav aria-label={ __( 'Blocks breadcrumb' ) }>
+			<ul className="block-editor-block-breadcrumb" role="list">
+				<li>
 					<Button
 						className="block-editor-block-breadcrumb__button"
 						isTertiary
-						onClick={ () => selectBlock( parentClientId ) }
+						onClick={ hasSelection ? clearSelectedBlock : null }
+						aria-current={ hasSelection ? false : 'true' }
 					>
-						<BlockTitle clientId={ parentClientId } />
+						{ __( 'Document' ) }
 					</Button>
 				</li>
-			) ) }
-			{ !! clientId && (
-				<li className="block-editor-block-breadcrumb__current">
-					<BlockTitle clientId={ clientId } />
-				</li>
-			) }
-		</ul>
+				{ parents.map( ( parentClientId ) => (
+					<li key={ parentClientId }>
+						<Button
+							className="block-editor-block-breadcrumb__button"
+							isTertiary
+							onClick={ () => selectBlock( parentClientId ) }
+						>
+							<BlockTitle clientId={ parentClientId } />
+						</Button>
+					</li>
+				) ) }
+				{ !! clientId && (
+					<li className="block-editor-block-breadcrumb__current" aria-current="true">
+						<BlockTitle clientId={ clientId } />
+					</li>
+				) }
+			</ul>
+		</nav>
 		/* eslint-enable jsx-a11y/no-redundant-roles */
 	);
 };

--- a/packages/block-editor/src/components/block-breadcrumb/index.js
+++ b/packages/block-editor/src/components/block-breadcrumb/index.js
@@ -11,11 +11,8 @@ import { __ } from '@wordpress/i18n';
 import BlockTitle from '../block-title';
 
 /**
- * Block breadcrumb component, displaying the label of the block. If the block
- * descends from a root block, a button is displayed enabling the user to select
- * the root block.
+ * Block breadcrumb component, displaying the hierarchy of the current block selection as a breadcrumb.
  *
- * @param {string}   props.clientId        Client ID of block.
  * @return {WPElement} Block Breadcrumb.
  */
 const BlockBreadcrumb = function() {

--- a/packages/block-editor/src/components/block-breadcrumb/index.js
+++ b/packages/block-editor/src/components/block-breadcrumb/index.js
@@ -37,41 +37,39 @@ const BlockBreadcrumb = function() {
 	 */
 	/* eslint-disable jsx-a11y/no-redundant-roles */
 	return (
-		<nav aria-label={ __( 'Block breadcrumb' ) }>
-			<ul className="block-editor-block-breadcrumb" role="list">
-				<li
-					className={ ! hasSelection ? 'block-editor-block-breadcrumb__current' : undefined }
-					aria-current={ ! hasSelection ? 'true' : undefined }
-				>
-					{ hasSelection && (
-						<Button
-							className="block-editor-block-breadcrumb__button"
-							isTertiary
-							onClick={ clearSelectedBlock }
-						>
-							{ __( 'Document' ) }
-						</Button>
-					) }
-					{ ! hasSelection && __( 'Document' ) }
-				</li>
-				{ parents.map( ( parentClientId ) => (
-					<li key={ parentClientId }>
-						<Button
-							className="block-editor-block-breadcrumb__button"
-							isTertiary
-							onClick={ () => selectBlock( parentClientId ) }
-						>
-							<BlockTitle clientId={ parentClientId } />
-						</Button>
-					</li>
-				) ) }
-				{ !! clientId && (
-					<li className="block-editor-block-breadcrumb__current" aria-current="true">
-						<BlockTitle clientId={ clientId } />
-					</li>
+		<ul className="block-editor-block-breadcrumb" role="list" aria-label={ __( 'Block breadcrumb' ) }>
+			<li
+				className={ ! hasSelection ? 'block-editor-block-breadcrumb__current' : undefined }
+				aria-current={ ! hasSelection ? 'true' : undefined }
+			>
+				{ hasSelection && (
+					<Button
+						className="block-editor-block-breadcrumb__button"
+						isTertiary
+						onClick={ clearSelectedBlock }
+					>
+						{ __( 'Document' ) }
+					</Button>
 				) }
-			</ul>
-		</nav>
+				{ ! hasSelection && __( 'Document' ) }
+			</li>
+			{ parents.map( ( parentClientId ) => (
+				<li key={ parentClientId }>
+					<Button
+						className="block-editor-block-breadcrumb__button"
+						isTertiary
+						onClick={ () => selectBlock( parentClientId ) }
+					>
+						<BlockTitle clientId={ parentClientId } />
+					</Button>
+				</li>
+			) ) }
+			{ !! clientId && (
+				<li className="block-editor-block-breadcrumb__current" aria-current="true">
+					<BlockTitle clientId={ clientId } />
+				</li>
+			) }
+		</ul>
 		/* eslint-enable jsx-a11y/no-redundant-roles */
 	);
 };

--- a/packages/block-editor/src/components/block-breadcrumb/index.js
+++ b/packages/block-editor/src/components/block-breadcrumb/index.js
@@ -1,0 +1,52 @@
+/**
+ * WordPress dependencies
+ */
+import { Button } from '@wordpress/components';
+import { useSelect, useDispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import BlockTitle from '../block-title';
+
+/**
+ * Block breadcrumb component, displaying the label of the block. If the block
+ * descends from a root block, a button is displayed enabling the user to select
+ * the root block.
+ *
+ * @param {string}   props.clientId        Client ID of block.
+ * @return {WPElement} Block Breadcrumb.
+ */
+const BlockBreadcrumb = function() {
+	const { selectBlock } = useDispatch( 'core/block-editor' );
+	const { clientId, parents } = useSelect( ( select ) => {
+		const selectedBlockClientId = select( 'core/block-editor' ).getSelectedBlockClientId();
+		return {
+			parents: select( 'core/block-editor' ).getBlockParents( selectedBlockClientId ),
+			clientId: selectedBlockClientId,
+		};
+	}, [] );
+
+	return (
+		<ul className="block-editor-block-breadcrumb">
+			{ parents.map( ( parent ) => (
+				<li key={ parent }>
+					<Button
+						className="block-editor-block-breadcrumb__button"
+						isTertiary
+						onClick={ () => selectBlock( parent ) }
+					>
+						<BlockTitle clientId={ parent } />
+					</Button>
+				</li>
+			) ) }
+			{ !! clientId && (
+				<li className="block-editor-block-breadcrumb__current">
+					<BlockTitle clientId={ clientId } />
+				</li>
+			) }
+		</ul>
+	);
+};
+
+export default BlockBreadcrumb;

--- a/packages/block-editor/src/components/block-breadcrumb/index.js
+++ b/packages/block-editor/src/components/block-breadcrumb/index.js
@@ -47,14 +47,14 @@ const BlockBreadcrumb = function() {
 					{ __( 'Document' ) }
 				</Button>
 			</li>
-			{ parents.map( ( parent ) => (
-				<li key={ parent }>
+			{ parents.map( ( parentClientId ) => (
+				<li key={ parentClientId }>
 					<Button
 						className="block-editor-block-breadcrumb__button"
 						isTertiary
-						onClick={ () => selectBlock( parent ) }
+						onClick={ () => selectBlock( parentClientId ) }
 					>
-						<BlockTitle clientId={ parent } />
+						<BlockTitle clientId={ parentClientId } />
 					</Button>
 				</li>
 			) ) }

--- a/packages/block-editor/src/components/block-breadcrumb/style.scss
+++ b/packages/block-editor/src/components/block-breadcrumb/style.scss
@@ -14,8 +14,6 @@
 }
 
 .block-editor-block-breadcrumb__button.components-button {
-	color: $dark-gray-500;
-	font-size: inherit;
 	height: $icon-button-size-small;
 	line-height: 100%;
 
@@ -31,8 +29,12 @@
 }
 
 .block-editor-block-breadcrumb__current {
+	cursor: default;
+}
+
+.block-editor-block-breadcrumb__button.components-button,
+.block-editor-block-breadcrumb__current {
 	color: $dark-gray-500;
 	padding: 0 $grid-size;
 	font-size: inherit;
-	cursor: default;
 }

--- a/packages/block-editor/src/components/block-breadcrumb/style.scss
+++ b/packages/block-editor/src/components/block-breadcrumb/style.scss
@@ -15,7 +15,8 @@
 
 .block-editor-block-breadcrumb__button.components-button {
 	height: $icon-button-size-small;
-	line-height: 100%;
+	line-height: $icon-button-size-small;
+	padding: 0;
 
 	&:hover {
 		text-decoration: underline;

--- a/packages/block-editor/src/components/block-breadcrumb/style.scss
+++ b/packages/block-editor/src/components/block-breadcrumb/style.scss
@@ -7,7 +7,7 @@
 		display: inline-block;
 		margin: 0;
 
-		&:not(.block-editor-block-breadcrumb__current)::after {
+		&:not(:last-child)::after {
 			content: "▸";
 		}
 	}

--- a/packages/block-editor/src/components/block-breadcrumb/style.scss
+++ b/packages/block-editor/src/components/block-breadcrumb/style.scss
@@ -1,0 +1,24 @@
+.block-editor-block-breadcrumb {
+	list-style: none;
+	padding: 0;
+	margin: 0;
+
+	li {
+		display: inline-block;
+		margin: 0;
+
+		&:not(.block-editor-block-breadcrumb__current)::after {
+			content: "▸";
+		}
+	}
+}
+
+.block-editor-block-breadcrumb__button.components-button {
+	color: inherit;
+	font-size: inherit;
+}
+
+.block-editor-block-breadcrumb__current {
+	padding: 0 10px;
+	font-size: inherit;
+}

--- a/packages/block-editor/src/components/block-breadcrumb/style.scss
+++ b/packages/block-editor/src/components/block-breadcrumb/style.scss
@@ -8,17 +8,31 @@
 		margin: 0;
 
 		&:not(:last-child)::after {
-			content: "▸";
+			content: "\2192"; // This becomes →.
 		}
 	}
 }
 
 .block-editor-block-breadcrumb__button.components-button {
-	color: inherit;
+	color: $dark-gray-500;
 	font-size: inherit;
+	height: $icon-button-size-small;
+	line-height: 100%;
+
+	&:hover {
+		text-decoration: underline;
+	}
+
+	&:focus {
+		@include square-style__focus();
+		outline-offset: -2px;
+		box-shadow: none;
+	}
 }
 
 .block-editor-block-breadcrumb__current {
-	padding: 0 10px;
+	color: $dark-gray-500;
+	padding: 0 $grid-size;
 	font-size: inherit;
+	cursor: default;
 }

--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -7,6 +7,7 @@ export * from './font-sizes';
 export { default as AlignmentToolbar } from './alignment-toolbar';
 export { default as Autocomplete } from './autocomplete';
 export { default as BlockAlignmentToolbar } from './block-alignment-toolbar';
+export { default as BlockBreadcrumb } from './block-breadcrumb';
 export { default as BlockControls } from './block-controls';
 export { default as BlockEdit } from './block-edit';
 export { default as BlockFormatControls } from './block-format-controls';

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -421,7 +421,7 @@ export function getBlockRootClientId( state, clientId ) {
 }
 
 /**
- * Given a block client ID, returns the list of all its parents.
+ * Given a block client ID, returns the list of all its parents from top to bottom.
  *
  * @param {Object} state    Editor state.
  * @param {string} clientId Block from which to find root client ID.

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -420,6 +420,22 @@ export function getBlockRootClientId( state, clientId ) {
 		null;
 }
 
+export const getBlockParents = createSelector(
+	( state, clientId ) => {
+		const parents = [];
+		let current = clientId;
+		while ( !! state.blocks.parents[ current ] ) {
+			current = state.blocks.parents[ current ];
+			parents.push( current );
+		}
+
+		return parents.reverse();
+	},
+	( state ) => [
+		state.blocks.parents,
+	]
+);
+
 /**
  * Given a block client ID, returns the root of the hierarchy from which the block is nested, return the block itself for root level blocks.
  *

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -420,6 +420,14 @@ export function getBlockRootClientId( state, clientId ) {
 		null;
 }
 
+/**
+ * Given a block client ID, returns the list of all its parents.
+ *
+ * @param {Object} state    Editor state.
+ * @param {string} clientId Block from which to find root client ID.
+ *
+ * @return {Array} ClientIDs of the parent blocks.
+ */
 export const getBlockParents = createSelector(
 	( state, clientId ) => {
 		const parents = [];

--- a/packages/block-editor/src/style.scss
+++ b/packages/block-editor/src/style.scss
@@ -3,6 +3,7 @@
 @import "./components/block-inspector/style.scss";
 @import "./components/block-list/style.scss";
 @import "./components/block-list-appender/style.scss";
+@import "./components/block-breadcrumb/style.scss";
 @import "./components/block-card/style.scss";
 @import "./components/block-compare/style.scss";
 @import "./components/block-mover/style.scss";

--- a/packages/e2e-tests/specs/editor/various/block-hierarchy-navigation.test.js
+++ b/packages/e2e-tests/specs/editor/various/block-hierarchy-navigation.test.js
@@ -82,6 +82,7 @@ describe( 'Navigating the block hierarchy', () => {
 		await pressKeyWithModifier( 'ctrl', '`' );
 		await pressKeyWithModifier( 'ctrl', '`' );
 		await pressKeyWithModifier( 'ctrl', '`' );
+		await pressKeyWithModifier( 'ctrl', '`' );
 		await pressKeyTimes( 'Tab', 4 );
 
 		// Tweak the columns count by increasing it by one.

--- a/packages/e2e-tests/specs/editor/various/sidebar.test.js
+++ b/packages/e2e-tests/specs/editor/various/sidebar.test.js
@@ -91,6 +91,7 @@ describe( 'Sidebar', () => {
 		await pressKeyWithModifier( 'ctrl', '`' );
 		await pressKeyWithModifier( 'ctrl', '`' );
 		await pressKeyWithModifier( 'ctrl', '`' );
+		await pressKeyWithModifier( 'ctrl', '`' );
 
 		// Tab lands at first (presumed selected) option "Document".
 		await page.keyboard.press( 'Tab' );

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -60,7 +60,7 @@ function Layout( {
 } ) {
 	const sidebarIsOpened = editorSidebarOpened || pluginSidebarOpened || publishSidebarOpened;
 
-	const className = classnames( 'edit-post-layout', {
+	const className = classnames( 'edit-post-layout', 'is-mode-' + mode, {
 		'is-sidebar-opened': sidebarIsOpened,
 		'has-fixed-toolbar': hasFixedToolbar,
 		'has-metaboxes': hasActiveMetaboxes,
@@ -81,7 +81,7 @@ function Layout( {
 			<LocalAutosaveMonitor />
 			<Header />
 			<div
-				className="edit-post-layout__content"
+				className="edit-post-layout__content edit-post-layout__scrollable-container"
 				role="region"
 				/* translators: accessibility text for the content landmark region. */
 				aria-label={ __( 'Editor content' ) }
@@ -92,23 +92,21 @@ function Layout( {
 				<KeyboardShortcutHelpModal />
 				<ManageBlocksModal />
 				<OptionsModal />
-				<div className="edit-post-layout__scrollable-container">
-					{ ( mode === 'text' || ! isRichEditingEnabled ) && <TextEditor /> }
-					{ isRichEditingEnabled && mode === 'visual' && <VisualEditor /> }
-					<div className="edit-post-layout__metaboxes">
-						<MetaBoxes location="normal" />
-					</div>
-					<div className="edit-post-layout__metaboxes">
-						<MetaBoxes location="advanced" />
-					</div>
-					{ isMobileViewport && sidebarIsOpened && <ScrollLock /> }
+				{ ( mode === 'text' || ! isRichEditingEnabled ) && <TextEditor /> }
+				{ isRichEditingEnabled && mode === 'visual' && <VisualEditor /> }
+				<div className="edit-post-layout__metaboxes">
+					<MetaBoxes location="normal" />
 				</div>
-				{ isRichEditingEnabled && mode === 'visual' && (
-					<div className="edit-post-layout__footer">
-						<BlockBreadcrumb />
-					</div>
-				) }
+				<div className="edit-post-layout__metaboxes">
+					<MetaBoxes location="advanced" />
+				</div>
+				{ isMobileViewport && sidebarIsOpened && <ScrollLock /> }
 			</div>
+			{ isRichEditingEnabled && mode === 'visual' && (
+				<div className="edit-post-layout__footer">
+					<BlockBreadcrumb />
+				</div>
+			) }
 			{ publishSidebarOpened ? (
 				<PostPublishPanel
 					{ ...publishLandmarkProps }

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -92,21 +92,22 @@ function Layout( {
 				<KeyboardShortcutHelpModal />
 				<ManageBlocksModal />
 				<OptionsModal />
-				{ ( mode === 'text' || ! isRichEditingEnabled ) && <TextEditor /> }
+				<div className="edit-post-layout__scrollable-container">
+					{ ( mode === 'text' || ! isRichEditingEnabled ) && <TextEditor /> }
+					{ isRichEditingEnabled && mode === 'visual' && <VisualEditor /> }
+					<div className="edit-post-layout__metaboxes">
+						<MetaBoxes location="normal" />
+					</div>
+					<div className="edit-post-layout__metaboxes">
+						<MetaBoxes location="advanced" />
+					</div>
+					{ isMobileViewport && sidebarIsOpened && <ScrollLock /> }
+				</div>
 				{ isRichEditingEnabled && mode === 'visual' && (
-					<>
-						<VisualEditor />
-						<div className="edit-post-layout__footer">
-							<BlockBreadcrumb />
-						</div>
-					</>
+					<div className="edit-post-layout__footer">
+						<BlockBreadcrumb />
+					</div>
 				) }
-				<div className="edit-post-layout__metaboxes">
-					<MetaBoxes location="normal" />
-				</div>
-				<div className="edit-post-layout__metaboxes">
-					<MetaBoxes location="advanced" />
-				</div>
 			</div>
 			{ publishSidebarOpened ? (
 				<PostPublishPanel
@@ -132,9 +133,6 @@ function Layout( {
 					</div>
 					<SettingsSidebar />
 					<Sidebar.Slot />
-					{
-						isMobileViewport && sidebarIsOpened && <ScrollLock />
-					}
 				</>
 			) }
 			<Popover.Slot />

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -103,7 +103,13 @@ function Layout( {
 				{ isMobileViewport && sidebarIsOpened && <ScrollLock /> }
 			</div>
 			{ isRichEditingEnabled && mode === 'visual' && (
-				<div className="edit-post-layout__footer">
+				<div
+					className="edit-post-layout__footer"
+					role="region"
+					/* translators: accessibility text for the content landmark region. */
+					aria-label={ __( 'Editor footer' ) }
+					tabIndex="-1"
+				>
 					<BlockBreadcrumb />
 				</div>
 			) }

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -57,7 +57,6 @@ function Layout( {
 	isSaving,
 	isMobileViewport,
 	isRichEditingEnabled,
-	showFooter,
 } ) {
 	const sidebarIsOpened = editorSidebarOpened || pluginSidebarOpened || publishSidebarOpened;
 
@@ -97,11 +96,9 @@ function Layout( {
 				{ isRichEditingEnabled && mode === 'visual' && (
 					<>
 						<VisualEditor />
-						{ showFooter && (
-							<div className="edit-post-layout__footer">
-								<BlockBreadcrumb />
-							</div>
-						) }
+						<div className="edit-post-layout__footer">
+							<BlockBreadcrumb />
+						</div>
 					</>
 				) }
 				<div className="edit-post-layout__metaboxes">
@@ -156,7 +153,6 @@ export default compose(
 		hasActiveMetaboxes: select( 'core/edit-post' ).hasMetaBoxes(),
 		isSaving: select( 'core/edit-post' ).isSavingMetaBoxes(),
 		isRichEditingEnabled: select( 'core/editor' ).getEditorSettings().richEditingEnabled,
-		showFooter: !! select( 'core/block-editor' ).getSelectedBlockClientId(),
 	} ) ),
 	withDispatch( ( dispatch ) => {
 		const { closePublishSidebar, togglePublishSidebar } = dispatch( 'core/edit-post' );

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -21,6 +21,7 @@ import {
 	EditorNotices,
 	PostPublishPanel,
 } from '@wordpress/editor';
+import { BlockBreadcrumb } from '@wordpress/block-editor';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { PluginArea } from '@wordpress/plugins';
 import { withViewportMatch } from '@wordpress/viewport';
@@ -56,6 +57,7 @@ function Layout( {
 	isSaving,
 	isMobileViewport,
 	isRichEditingEnabled,
+	showFooter,
 } ) {
 	const sidebarIsOpened = editorSidebarOpened || pluginSidebarOpened || publishSidebarOpened;
 
@@ -92,7 +94,16 @@ function Layout( {
 				<ManageBlocksModal />
 				<OptionsModal />
 				{ ( mode === 'text' || ! isRichEditingEnabled ) && <TextEditor /> }
-				{ isRichEditingEnabled && mode === 'visual' && <VisualEditor /> }
+				{ isRichEditingEnabled && mode === 'visual' && (
+					<>
+						<VisualEditor />
+						{ showFooter && (
+							<div className="edit-post-layout__footer">
+								<BlockBreadcrumb />
+							</div>
+						) }
+					</>
+				) }
 				<div className="edit-post-layout__metaboxes">
 					<MetaBoxes location="normal" />
 				</div>
@@ -145,6 +156,7 @@ export default compose(
 		hasActiveMetaboxes: select( 'core/edit-post' ).hasMetaBoxes(),
 		isSaving: select( 'core/edit-post' ).isSavingMetaBoxes(),
 		isRichEditingEnabled: select( 'core/editor' ).getEditorSettings().richEditingEnabled,
+		showFooter: !! select( 'core/block-editor' ).getSelectedBlockClientId(),
 	} ) ),
 	withDispatch( ( dispatch ) => {
 		const { closePublishSidebar, togglePublishSidebar } = dispatch( 'core/edit-post' );

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -54,7 +54,7 @@
 		// Because the body element scrolls the navigation sidebar, we have to use position fixed here.
 		// Otherwise you would scroll the editing canvas out of view when you scroll the sidebar.
 		position: fixed;
-		bottom: 0;
+		bottom: $footer-height;
 		left: 0;
 		right: 0;
 
@@ -69,6 +69,12 @@
 		// This is similar to the code in the @editor-left mixin, but uses margins instead.
 		// Because we are beyond the medium breakpoint, we only have to worry about folded, auto-folded, and default.
 		margin-left: $admin-sidebar-width;
+
+		// Make room for the footer
+		.edit-post-layout.is-mode-visual & {
+			bottom: $footer-height;
+			min-height: calc(100% - #{ $header-height + $admin-bar-height + $footer-height });
+		}
 
 		// Auto fold is when on smaller breakpoints, nav menu auto colllapses.
 		body.auto-fold & {
@@ -217,18 +223,19 @@
 	// Stretch to mimic outline padding on desktop.
 	@include break-medium() {
 		display: flex;
+		position: fixed;
+		bottom: 0;
+		right: 0;
 		background: $white;
-		height: $icon-button-size-small;
+		height: $footer-height;
 		padding: 0 $grid-size;
 		align-items: center;
 		border-top: $border-width solid $light-gray-500;
 		font-size: $default-font-size;
-
-		.edit-post-layout.is-sidebar-opened & {
-			right: $sidebar-width;
-		}
+		box-sizing: border-box;
 	}
 }
+@include editor-left(".edit-post-layout__footer");
 
 .edit-post-layout__scrollable-container {
 	// On mobile the main content (html or body) area has to scroll.

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -104,31 +104,6 @@
 		}
 	}
 
-	// Pad the scroll box so content on the bottom can be scrolled up.
-	padding-bottom: 50vh;
-	@include break-small {
-		padding-bottom: 0;
-	}
-
-	// On mobile the main content (html or body) area has to scroll.
-	// If, like we do on the desktop, scroll an element (.edit-post-layout__content) you can invoke
-	// the overscroll bounce on the non-scrolling container, causing for a frustrating scrolling experience.
-	// The following rule enables this scrolling beyond the mobile breakpoint, because on the desktop
-	// breakpoints scrolling an isolated element helps avoid scroll bleed.
-	@include break-small() {
-		overflow-y: auto;
-	}
-	-webkit-overflow-scrolling: touch;
-
-	// This rule ensures that if you've scrolled to the end of a container,
-	// then pause, then keep scrolling downwards, the browser doesn't try to scroll
-	// the parent element, usually invoking a "bounce" effect and then preventing you
-	// from scrolling upwards until you pause again.
-	// This is only necessary beyond the small breakpoint because that's when the scroll container changes.
-	@include break-small() {
-		overscroll-behavior-y: none;
-	}
-
 	.edit-post-visual-editor {
 		flex: 1 1 auto;
 
@@ -241,10 +216,7 @@
 
 	// Stretch to mimic outline padding on desktop.
 	@include break-medium() {
-		display: inline-flex;
-		position: fixed;
-		bottom: 0;
-		right: 0;
+		display: flex;
 		background: $white;
 		height: $icon-button-size-small;
 		padding: 0 $grid-size;
@@ -258,4 +230,29 @@
 	}
 }
 
-@include editor-left(".edit-post-layout__footer");
+.edit-post-layout__scrollable-container {
+	// On mobile the main content (html or body) area has to scroll.
+	// If, like we do on the desktop, scroll an element (.edit-post-layout__content) you can invoke
+	// the overscroll bounce on the non-scrolling container, causing for a frustrating scrolling experience.
+	// The following rule enables this scrolling beyond the mobile breakpoint, because on the desktop
+	// breakpoints scrolling an isolated element helps avoid scroll bleed.
+	@include break-small() {
+		overflow-y: auto;
+	}
+	-webkit-overflow-scrolling: touch;
+
+	// This rule ensures that if you've scrolled to the end of a container,
+	// then pause, then keep scrolling downwards, the browser doesn't try to scroll
+	// the parent element, usually invoking a "bounce" effect and then preventing you
+	// from scrolling upwards until you pause again.
+	// This is only necessary beyond the small breakpoint because that's when the scroll container changes.
+	@include break-small() {
+		overscroll-behavior-y: none;
+	}
+
+	// Pad the scroll box so content on the bottom can be scrolled up.
+	padding-bottom: 50vh;
+	@include break-small {
+		padding-bottom: 0;
+	}
+}

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -246,16 +246,16 @@
 		bottom: 0;
 		right: 0;
 		background: $white;
-		height: 30px;
-		padding: 0 10px;
+		height: $icon-button-size-small;
+		padding: 0 $grid-size;
 		align-items: center;
 		border-top: $border-width solid $light-gray-500;
-		font-size: 12px;
+		font-size: $default-font-size;
 
 		.edit-post-layout.is-sidebar-opened & {
 			right: $sidebar-width;
 		}
 	}
 }
-@include editor-left(".edit-post-layout__footer");
 
+@include editor-left(".edit-post-layout__footer");

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -234,3 +234,28 @@
 		}
 	}
 }
+
+.edit-post-layout__footer {
+	display: none;
+	z-index: z-index(".edit-post-layout__footer");
+
+	// Stretch to mimic outline padding on desktop.
+	@include break-medium() {
+		display: inline-flex;
+		position: fixed;
+		bottom: 0;
+		right: 0;
+		background: $white;
+		height: 30px;
+		padding: 0 10px;
+		align-items: center;
+		border-top: $border-width solid $light-gray-500;
+		font-size: 12px;
+
+		.edit-post-layout.is-sidebar-opened & {
+			right: $sidebar-width;
+		}
+	}
+}
+@include editor-left(".edit-post-layout__footer");
+

--- a/packages/edit-post/src/components/sidebar/style.scss
+++ b/packages/edit-post/src/components/sidebar/style.scss
@@ -22,6 +22,10 @@
 	@include break-medium() {
 		top: $admin-bar-height + $header-height;
 
+		.edit-post-layout.is-mode-visual & {
+			bottom: $footer-height;
+		}
+
 		body.is-fullscreen-mode & {
 			top: $header-height;
 		}

--- a/packages/edit-post/src/components/text-editor/style.scss
+++ b/packages/edit-post/src/components/text-editor/style.scss
@@ -1,30 +1,5 @@
-.edit-post-text-editor__body {
-	padding-top: $grid-size * 5;
-
-	@include break-small() {
-		padding-top: ($grid-size * 5) + $admin-bar-height-big;
-	}
-
-	@include break-medium() {
-		padding-top: $grid-size * 5;
-
-		body.is-fullscreen-mode & {
-			padding-top: $grid-size * 5;
-		}
-	}
-}
-
 .edit-post-text-editor {
 	width: 100%;
-	max-width: calc(100% - #{$grid-size-large * 2});
-	margin-left: $grid-size-large;
-	margin-right: $grid-size-large;
-
-	@include break-small() {
-		max-width: $content-width;
-		margin-left: auto;
-		margin-right: auto;
-	}
 
 	// Always show outlines in code editor
 	.editor-post-title__block {
@@ -67,34 +42,41 @@
 		}
 	}
 
-	.editor-post-text-editor {
-		padding: $block-padding;
-		min-height: 200px;
-		line-height: 1.8;
-	}
-
 	// Make room for toolbar.
 	padding-top: $block-controls-height + $grid-size;
+}
 
-	// Exit Code Editor toolbar.
-	.edit-post-text-editor__toolbar {
-		position: absolute;
-		top: $grid-size;
-		left: 0;
-		right: 0;
-		height: $block-controls-height;
-		line-height: $block-controls-height;
-		padding: 0 $grid-size 0 $grid-size-large;
-		display: flex;
+// Exit Code Editor toolbar.
+.edit-post-text-editor__toolbar {
+	position: absolute;
+	top: $grid-size;
+	left: 0;
+	right: 0;
+	height: $block-controls-height;
+	line-height: $block-controls-height;
+	padding: 0 $grid-size 0 $grid-size-large;
+	display: flex;
 
-		h2 {
-			margin: 0 auto 0 0;
-			font-size: $default-font-size;
-			color: $dark-gray-500;
-		}
+	h2 {
+		margin: 0 auto 0 0;
+		font-size: $default-font-size;
+		color: $dark-gray-500;
+	}
 
-		.components-icon-button svg {
-			order: 1;
-		}
+	.components-icon-button svg {
+		order: 1;
+	}
+}
+
+.edit-post-text-editor__body {
+	max-width: calc(100% - #{$grid-size-large * 2});
+	margin-left: $grid-size-large;
+	margin-right: $grid-size-large;
+	padding-top: $grid-size * 5;
+
+	@include break-small() {
+		max-width: $content-width;
+		margin-left: auto;
+		margin-right: auto;
 	}
 }

--- a/packages/edit-post/src/style.scss
+++ b/packages/edit-post/src/style.scss
@@ -1,3 +1,5 @@
+$footer-height: $icon-button-size-small;
+
 @import "./components/fullscreen-mode/style.scss";
 @import "./components/header/style.scss";
 @import "./components/header/fullscreen-mode-close/style.scss";


### PR DESCRIPTION
closes #17089

This PR implements the block selection breadcrumb at the bottom of the editor screen like proposed in #17089 
The idea is to simplify nested block navigation.

<img width="990" alt="Capture d’écran 2019-10-16 à 11 34 50 AM" src="https://user-images.githubusercontent.com/272444/66911789-1dfcf600-f009-11e9-922c-fc2153fd1035.png">
