### PR TITLE
[Tiny PR] RichText: correctly update value after undo

### DIFF
--- a/packages/e2e-tests/specs/undo.test.js
+++ b/packages/e2e-tests/specs/undo.test.js
@@ -54,6 +54,20 @@ describe( 'undo', () => {
 		expect( await getEditedPostContent() ).toBe( '' );
 	} );
 
+	it( 'should undo bold', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( 'test' );
+		await saveDraft();
+		await page.reload();
+		await page.click( '.wp-block-paragraph' );
+		await pressKeyWithModifier( 'primary', 'a' );
+		await pressKeyWithModifier( 'primary', 'b' );
+		await pressKeyWithModifier( 'primary', 'z' );
+
+		const visibleResult = await page.evaluate( () => document.activeElement.innerHTML );
+		expect( visibleResult ).toBe( 'test' );
+	} );
+
 	it( 'Should undo/redo to expected level intervals', async () => {
 		await clickBlockAppender();
 

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -843,21 +843,11 @@ class RichText extends Component {
 		shouldReapply = shouldReapply ||
 			placeholder !== prevProps.placeholder;
 
-		const { activeFormats = [] } = this.record;
-
 		if ( shouldReapply ) {
 			this.value = value;
 			this.record = this.formatToValue( value );
 			this.record.start = selectionStart;
 			this.record.end = selectionEnd;
-
-			updateFormats( {
-				value: this.record,
-				start: this.record.start,
-				end: this.record.end,
-				formats: activeFormats,
-			} );
-
 			this.applyRecord( this.record );
 		} else if (
 			this.record.start !== selectionStart ||


### PR DESCRIPTION
## Description

See #17839. RichText is not removing formatting after undo. This is caused by `updateFormats`, which seems to be called in that place for no reason. Looks like I made a mistake calling it there.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
