### PR TITLE
List Block: fix merging with indented list items

### DIFF
--- a/packages/block-editor/src/store/effects.js
+++ b/packages/block-editor/src/store/effects.js
@@ -136,8 +136,15 @@ export default {
 				typeof v === 'string' && v.indexOf( START_OF_SELECTED_AREA ) !== -1
 			);
 			const convertedHtml = updatedAttributes[ newAttributeKey ];
-			const multilineTag = blockAType.attributes[ newAttributeKey ].multiline;
-			const convertedValue = create( { html: convertedHtml, multilineTag } );
+			const {
+				multiline: multilineTag,
+				__unstableMultilineWrapperTags: multilineWrapperTags,
+			} = blockAType.attributes[ newAttributeKey ];
+			const convertedValue = create( {
+				html: convertedHtml,
+				multilineTag,
+				multilineWrapperTags,
+			} );
 			const newOffset = convertedValue.text.indexOf( START_OF_SELECTED_AREA );
 			const newValue = remove( convertedValue, newOffset, newOffset + 1 );
 			const newHtml = toHTMLString( { value: newValue, multilineTag } );

--- a/packages/block-editor/src/store/effects.js
+++ b/packages/block-editor/src/store/effects.js
@@ -102,10 +102,14 @@ export default {
 			const selectedBlock = clientId === clientIdA ? cloneA : cloneB;
 			const html = selectedBlock.attributes[ attributeKey ];
 			const selectedBlockType = clientId === clientIdA ? blockAType : blockBType;
-			const multilineTag = selectedBlockType.attributes[ attributeKey ].multiline;
+			const {
+				multiline: multilineTag,
+				__unstableMultilineWrapperTags: multilineWrapperTags,
+			} = selectedBlockType.attributes[ attributeKey ];
 			const value = insert( create( {
 				html,
 				multilineTag,
+				multilineWrapperTags,
 			} ), START_OF_SELECTED_AREA, offset, offset );
 
 			selectedBlock.attributes[ attributeKey ] = toHTMLString( {

--- a/packages/block-library/src/list/block.json
+++ b/packages/block-library/src/list/block.json
@@ -11,6 +11,7 @@
 			"source": "html",
 			"selector": "ol,ul",
 			"multiline": "li",
+			"__unstableMultilineWrapperTags": [ "ol", "ul" ],
 			"default": ""
 		},
 		"start": {

--- a/packages/e2e-tests/specs/blocks/__snapshots__/list.test.js.snap
+++ b/packages/e2e-tests/specs/blocks/__snapshots__/list.test.js.snap
@@ -234,6 +234,12 @@ exports[`List should place the caret in the right place with nested list 1`] = `
 <!-- /wp:list -->"
 `;
 
+exports[`List should preserve indentation after merge 1`] = `
+"<!-- wp:list -->
+<ul><li>1<ul><li>2</li><li>3</li></ul></li><li></li></ul>
+<!-- /wp:list -->"
+`;
+
 exports[`List should split indented list item 1`] = `
 "<!-- wp:list -->
 <ul><li>one<ul><li>two</li><li>three</li></ul></li></ul>

--- a/packages/e2e-tests/specs/blocks/__snapshots__/list.test.js.snap
+++ b/packages/e2e-tests/specs/blocks/__snapshots__/list.test.js.snap
@@ -234,9 +234,15 @@ exports[`List should place the caret in the right place with nested list 1`] = `
 <!-- /wp:list -->"
 `;
 
-exports[`List should preserve indentation after merge 1`] = `
+exports[`List should preserve indentation after merging backward and forward 1`] = `
 "<!-- wp:list -->
 <ul><li>1<ul><li>2</li><li>3</li></ul></li><li></li></ul>
+<!-- /wp:list -->"
+`;
+
+exports[`List should preserve indentation after merging backward and forward 2`] = `
+"<!-- wp:list -->
+<ul><li>1<ul><li>2</li><li>3</li></ul></li></ul>
 <!-- /wp:list -->"
 `;
 

--- a/packages/e2e-tests/specs/blocks/list.test.js
+++ b/packages/e2e-tests/specs/blocks/list.test.js
@@ -447,7 +447,7 @@ describe( 'List', () => {
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 
-	it( 'should preserve indentation after merge', async () => {
+	it( 'should preserve indentation after merging backward and forward', async () => {
 		await clickBlockAppender();
 
 		// Tests the shortcut with a non breaking space.
@@ -462,8 +462,19 @@ describe( 'List', () => {
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.press( 'Enter' );
 
-		// Merge the pragraph back.
+		// Merge the pragraph back. No list items should be joined.
 		await page.keyboard.press( 'Backspace' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+
+		// Again create a new paragraph.
+		await page.keyboard.press( 'Enter' );
+
+		// Move to the end of the list.
+		await page.keyboard.press( 'ArrowLeft' );
+
+		// Merge forward. No list items should be joined.
+		await page.keyboard.press( 'Delete' );
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );

--- a/packages/e2e-tests/specs/blocks/list.test.js
+++ b/packages/e2e-tests/specs/blocks/list.test.js
@@ -446,4 +446,25 @@ describe( 'List', () => {
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
+
+	it( 'should preserve indentation after merge', async () => {
+		await clickBlockAppender();
+
+		// Tests the shortcut with a non breaking space.
+		await page.keyboard.type( '* 1' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.press( 'Space' );
+		await page.keyboard.type( '2' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '3' );
+
+		// Create a new paragraph.
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.press( 'Enter' );
+
+		// Merge the pragraph back.
+		await page.keyboard.press( 'Backspace' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
 } );


### PR DESCRIPTION
## Description

Fixes #17843. The problem is that `create` is missing the `multilineWrapperTags` argument when using it with an (indented) list. This needs to be provided in the attribute definition. Since lists are kind of a strange case, I've added the key as unstable. Ideally, in the future, we use blocks for each list item.

## How has this been tested?
See #17843 and the e2e test case I've added.

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
