### PR TITLE
Add 'No Preview Available' text to the inserter preview panel 

### DIFF
--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -392,8 +392,8 @@ export class InserterMenu extends Component {
 								{ ! isReusableBlock( hoveredItem ) && (
 									<BlockCard blockType={ hoveredItemBlockType } />
 								) }
-								{ ( isReusableBlock( hoveredItem ) || hoveredItemBlockType.example ) && (
-									<div className="block-editor-inserter__preview">
+								<div className="block-editor-inserter__preview">
+									{ ( isReusableBlock( hoveredItem ) || hoveredItemBlockType.example ) ? (
 										<div className="block-editor-inserter__preview-content">
 											<BlockPreview
 												padding={ 10 }
@@ -405,8 +405,12 @@ export class InserterMenu extends Component {
 												}
 											/>
 										</div>
-									</div>
-								) }
+									) : (
+										<div className="block-editor-inserter__preview-content-missing">
+											{ __( 'No Preview Available.' ) }
+										</div>
+									) }
+								</div>
 							</>
 						) }
 						{ ! hoveredItem && (

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -227,3 +227,11 @@ $block-inserter-search-height: 38px;
 		padding: 10px;
 	}
 }
+
+.block-editor-inserter__preview-content-missing {
+	flex: 1;
+	display: flex;
+	justify-content: center;
+	padding-top: 90px;
+	color: $dark-gray-400;
+}

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -232,6 +232,8 @@ $block-inserter-search-height: 38px;
 	flex: 1;
 	display: flex;
 	justify-content: center;
-	padding-top: 90px;
 	color: $dark-gray-400;
+	border: $border-width solid $light-gray-500;
+	border-radius: $radius-round-rectangle;
+	align-items: center;
 }


### PR DESCRIPTION
Fixes #17720 based on @mapk's [feedback](https://github.com/WordPress/gutenberg/pull/17740#issuecomment-538452560) to #17740. @youknowriad feel free to use this or not, just saw your PR in the 5.3 project and thought it was something I could take off your plate.

## Description
Adds "No Preview Available." in the space where a preview would display if it existed. 

## How has this been tested?
Open inserter, hover over a block without a preview (video, file, etc) and see that "No Preview Available" now displays

## Screenshots
![Fullscreen_10_8_19__11_45_AM](https://user-images.githubusercontent.com/6653970/66412414-80c80f00-e9c3-11e9-8421-23a8dd1248b2.png)

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->