### PR TITLE
Core Data: Shallow merge, not deep merge meta.

### DIFF
--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { castArray, get, merge, isEqual, find } from 'lodash';
+import { castArray, get, isEqual, find } from 'lodash';
 
 /**
  * Internal dependencies
@@ -159,7 +159,7 @@ export function* editEntityRecord( kind, name, recordId, edits, options = {} ) {
 			const recordValue = record[ key ];
 			const editedRecordValue = editedRecord[ key ];
 			const value = mergedEdits[ key ] ?
-				merge( {}, editedRecordValue, edits[ key ] ) :
+				{ ...editedRecordValue, ...edits[ key ] } :
 				edits[ key ];
 			acc[ key ] = isEqual( recordValue, value ) ? undefined : value;
 			return acc;


### PR DESCRIPTION
Fixes #17692

cc @youknowriad 

## Description

This PR changes Core Data so that it merges `mergedEdits` like `meta` shallowly instead of deeply.

Meta is set through a setter dispatching function and all of these take a new value and set the target to it. If we merged deeply, it would not line up with this behavior and cause issues like #17692 for non-primitive meta values.

## How has this been tested?

It was verified that non-primitive meta value edits work as expected and are not merged into the previous value.

## Types of Changes

*Bug Fix:* Fix an issue where non-primitive meta edits would get deeply merged into their previous value.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
