### PR TITLE
Fix: Widgets screen can not deselect a block

### DIFF
--- a/packages/edit-widgets/src/components/layout/index.js
+++ b/packages/edit-widgets/src/components/layout/index.js
@@ -7,6 +7,7 @@ import {
 	Popover,
 	SlotFillProvider,
 } from '@wordpress/components';
+import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -17,6 +18,7 @@ import WidgetAreas from '../widget-areas';
 import Notices from '../notices';
 
 function Layout( { blockEditorSettings } ) {
+	const [ selectedArea, setSelectedArea ] = useState( null );
 	return (
 		<SlotFillProvider>
 			<Header />
@@ -27,8 +29,13 @@ function Layout( { blockEditorSettings } ) {
 				role="region"
 				aria-label={ __( 'Widgets screen content' ) }
 				tabIndex="-1"
+				onFocus={ () => {
+					setSelectedArea( null );
+				} }
 			>
 				<WidgetAreas
+					selectedArea={ selectedArea }
+					setSelectedArea={ setSelectedArea }
 					blockEditorSettings={ blockEditorSettings }
 				/>
 			</div>

--- a/packages/edit-widgets/src/components/widget-area/index.js
+++ b/packages/edit-widgets/src/components/widget-area/index.js
@@ -105,38 +105,47 @@ function WidgetArea( {
 				title={ widgetAreaName }
 				initialOpen={ initialOpen }
 			>
-				<BlockEditorProvider
-					value={ blocks }
-					onInput={ onInput }
-					onChange={ onChange }
-					settings={ settings }
+				<div
+					onFocus={ ( event ) => {
+						// Stop propagation of the focus event to avoid the parent
+						// widget layout component catching the event and removing the selected area.
+						event.stopPropagation();
+						event.preventDefault();
+					} }
 				>
-					{ isSelectedArea && (
-						<>
-							<Inserter>
-								<BlockInserter />
-							</Inserter>
-							<BlockEditorKeyboardShortcuts />
-						</>
-					) }
-					<SelectionObserver
-						isSelectedArea={ isSelectedArea }
-						onBlockSelected={ onBlockSelected }
-					/>
-					<Sidebar.Inspector>
-						<BlockInspector showNoBlockSelectedMessage={ false } />
-					</Sidebar.Inspector>
-					<div className="editor-styles-wrapper">
-						<WritingFlow>
-							<ObserveTyping>
-								<BlockList
-									className="edit-widgets-main-block-list"
-									renderAppender={ ButtonBlockerAppender }
-								/>
-							</ObserveTyping>
-						</WritingFlow>
-					</div>
-				</BlockEditorProvider>
+					<BlockEditorProvider
+						value={ blocks }
+						onInput={ onInput }
+						onChange={ onChange }
+						settings={ settings }
+					>
+						{ isSelectedArea && (
+							<>
+								<Inserter>
+									<BlockInserter />
+								</Inserter>
+								<BlockEditorKeyboardShortcuts />
+							</>
+						) }
+						<SelectionObserver
+							isSelectedArea={ isSelectedArea }
+							onBlockSelected={ onBlockSelected }
+						/>
+						<Sidebar.Inspector>
+							<BlockInspector showNoBlockSelectedMessage={ false } />
+						</Sidebar.Inspector>
+						<div className="editor-styles-wrapper">
+							<WritingFlow>
+								<ObserveTyping>
+									<BlockList
+										className="edit-widgets-main-block-list"
+										renderAppender={ ButtonBlockerAppender }
+									/>
+								</ObserveTyping>
+							</WritingFlow>
+						</div>
+					</BlockEditorProvider>
+				</div>
 			</PanelBody>
 		</Panel>
 	);

--- a/packages/edit-widgets/src/components/widget-areas/index.js
+++ b/packages/edit-widgets/src/components/widget-areas/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useMemo, useState } from '@wordpress/element';
+import { useMemo } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
 
@@ -12,8 +12,7 @@ import WidgetArea from '../widget-area';
 
 const EMPTY_ARRAY = [];
 
-function WidgetAreas( { areas, blockEditorSettings } ) {
-	const [ selectedArea, setSelectedArea ] = useState( 0 );
+function WidgetAreas( { areas, blockEditorSettings, selectedArea, setSelectedArea } ) {
 	const onBlockSelectedInArea = useMemo(
 		() => areas.map( ( value, index ) => ( () => {
 			setSelectedArea( index );


### PR DESCRIPTION
## Description
Fixes: https://github.com/WordPress/gutenberg/issues/17780

This PR adds behavior to unselect the current widget area (and as a consequence the selected block) when the gray area outside the widget areas is clicked.

## How has this been tested?
I went to the widget screen.
I added some blocks.
I clicked on the gray area outside the widgets screen and verified the currently selected block got unselected.
I did some smoke tests on the widgets screen to check that there are no regressions.
