### PR TITLE
Navigation: Use class attribute

### DIFF
--- a/packages/block-library/src/navigation-menu/index.php
+++ b/packages/block-library/src/navigation-menu/index.php
@@ -15,7 +15,7 @@
  * @return string Returns the post content with the legacy widget added.
  */
 function render_block_navigation_menu( $attributes, $content, $block ) {
-	return '<nav className="wp-block-navigation-menu">' . build_navigation_menu_html( $block ) . '</nav>';
+	return '<nav class="wp-block-navigation-menu">' . build_navigation_menu_html( $block ) . '</nav>';
 }
 
 /**
@@ -52,6 +52,8 @@ function build_navigation_menu_html( $block ) {
 
 /**
  * Register the navigation menu block.
+ *
+ * @uses render_block_navigation_menu()
  */
 function register_block_core_navigation_menu() {
 	register_block_type(


### PR DESCRIPTION
## Description
Fixes a bug where the class attribute wasn't set.
Also fixes a missing link to the function for IDEs.

## How has this been tested?
Preview a navigation block, inspect the element, and make sure it recognizes it as a class attribute.

## Types of changes
Bug fix (non-breaking change which fixes an issue)
Introduced in #16796.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
