### PR TITLE
Remove overflow to have SafeArea over the BlockList

### DIFF
--- a/packages/components/src/mobile/keyboard-aware-flat-list/index.ios.js
+++ b/packages/components/src/mobile/keyboard-aware-flat-list/index.ios.js
@@ -12,7 +12,7 @@ export const KeyboardAwareFlatList = ( {
 	...listProps
 } ) => (
 	<KeyboardAwareScrollView
-		style={ { flex: 1, overflow: 'visible' } }
+		style={ { flex: 1 } }
 		keyboardDismissMode="none"
 		enableResetScrollToCoords={ false }
 		keyboardShouldPersistTaps="handled"


### PR DESCRIPTION
## Description
Fix SafeArea to be hierarchically over the Block List.

Ref to gb-mobile: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1425
Fixes: https://github.com/wordpress-mobile/gutenberg-mobile/issues/1424
## How has this been tested?

Tested on iOS:

1. Check if the SafeArea is not transparent and the block content isn't drown on top of it.

## Screenshots <!-- if applicable -->
<img width="300" alt="Screenshot 2019-10-09 at 09 51 33" src="https://user-images.githubusercontent.com/22746080/66462060-977d6d00-ea7a-11e9-87e7-87fba14ad7f8.png">

## Types of changes
Remove `overflow: 'visible'` from `KeyboardAwareFlatList` on iOS.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
