### PR TITLE
Add an apiFetch middleware to automatically handle media upload failures

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -249,7 +249,7 @@ function gutenberg_register_scripts_and_styles() {
 			'wp.apiFetch.nonceMiddleware = wp.apiFetch.createNonceMiddleware( "%s" );' .
 			'wp.apiFetch.use( wp.apiFetch.nonceMiddleware );' .
 			'wp.apiFetch.nonceEndpoint = "%s";' .
-			'wp.apiFetch.use( wp.apiFetch.imageUploadMiddleware );',
+			'wp.apiFetch.use( wp.apiFetch.mediaUploadMiddleware );',
 			( wp_installing() && ! is_multisite() ) ? '' : wp_create_nonce( 'wp_rest' ),
 			admin_url( 'admin-ajax.php?action=gutenberg_rest_nonce' )
 		),

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -248,7 +248,8 @@ function gutenberg_register_scripts_and_styles() {
 		sprintf(
 			'wp.apiFetch.nonceMiddleware = wp.apiFetch.createNonceMiddleware( "%s" );' .
 			'wp.apiFetch.use( wp.apiFetch.nonceMiddleware );' .
-			'wp.apiFetch.nonceEndpoint = "%s";',
+			'wp.apiFetch.nonceEndpoint = "%s";' .
+			'wp.apiFetch.use( wp.apiFetch.imageUploadMiddleware );',
 			( wp_installing() && ! is_multisite() ) ? '' : wp_create_nonce( 'wp_rest' ),
 			admin_url( 'admin-ajax.php?action=gutenberg_rest_nonce' )
 		),

--- a/packages/api-fetch/src/index.js
+++ b/packages/api-fetch/src/index.js
@@ -8,7 +8,7 @@ import fetchAllMiddleware from './middlewares/fetch-all-middleware';
 import namespaceEndpointMiddleware from './middlewares/namespace-endpoint';
 import httpV1Middleware from './middlewares/http-v1';
 import userLocaleMiddleware from './middlewares/user-locale';
-import imageUploadMiddleware from './middlewares/image-upload';
+import mediaUploadMiddleware from './middlewares/media-upload';
 import parseResponseAndNormalizeError from './utils/response';
 
 /**
@@ -137,6 +137,6 @@ apiFetch.createNonceMiddleware = createNonceMiddleware;
 apiFetch.createPreloadingMiddleware = createPreloadingMiddleware;
 apiFetch.createRootURLMiddleware = createRootURLMiddleware;
 apiFetch.fetchAllMiddleware = fetchAllMiddleware;
-apiFetch.imageUploadMiddleware = imageUploadMiddleware;
+apiFetch.mediaUploadMiddleware = mediaUploadMiddleware;
 
 export default apiFetch;

--- a/packages/api-fetch/src/index.js
+++ b/packages/api-fetch/src/index.js
@@ -1,9 +1,4 @@
 /**
- * WordPress dependencies
- */
-import { __ } from '@wordpress/i18n';
-
-/**
  * Internal dependencies
  */
 import createNonceMiddleware from './middlewares/nonce';
@@ -13,6 +8,8 @@ import fetchAllMiddleware from './middlewares/fetch-all-middleware';
 import namespaceEndpointMiddleware from './middlewares/namespace-endpoint';
 import httpV1Middleware from './middlewares/http-v1';
 import userLocaleMiddleware from './middlewares/user-locale';
+import imageUploadMiddleware from './middlewares/image-upload';
+import parseResponseAndNormalizeError from './utils/response';
 
 /**
  * Default set of header values which should be sent with every request unless
@@ -80,48 +77,9 @@ const defaultFetchHandler = ( nextOptions ) => {
 		}
 	);
 
-	const parseResponse = ( response ) => {
-		if ( parse ) {
-			if ( response.status === 204 ) {
-				return null;
-			}
-
-			return response.json ? response.json() : Promise.reject( response );
-		}
-
-		return response;
-	};
-
 	return responsePromise
 		.then( checkStatus )
-		.then( parseResponse )
-		.catch( ( response ) => {
-			if ( ! parse ) {
-				throw response;
-			}
-
-			const invalidJsonError = {
-				code: 'invalid_json',
-				message: __( 'The response is not a valid JSON response.' ),
-			};
-
-			if ( ! response || ! response.json ) {
-				throw invalidJsonError;
-			}
-
-			return response.json()
-				.catch( () => {
-					throw invalidJsonError;
-				} )
-				.then( ( error ) => {
-					const unknownError = {
-						code: 'unknown_error',
-						message: __( 'An unknown error occurred.' ),
-					};
-
-					throw error || unknownError;
-				} );
-		} );
+		.then( ( response ) => parseResponseAndNormalizeError( response, parse ) );
 };
 
 let fetchHandler = defaultFetchHandler;
@@ -179,5 +137,6 @@ apiFetch.createNonceMiddleware = createNonceMiddleware;
 apiFetch.createPreloadingMiddleware = createPreloadingMiddleware;
 apiFetch.createRootURLMiddleware = createRootURLMiddleware;
 apiFetch.fetchAllMiddleware = fetchAllMiddleware;
+apiFetch.imageUploadMiddleware = imageUploadMiddleware;
 
 export default apiFetch;

--- a/packages/api-fetch/src/index.js
+++ b/packages/api-fetch/src/index.js
@@ -9,7 +9,7 @@ import namespaceEndpointMiddleware from './middlewares/namespace-endpoint';
 import httpV1Middleware from './middlewares/http-v1';
 import userLocaleMiddleware from './middlewares/user-locale';
 import mediaUploadMiddleware from './middlewares/media-upload';
-import parseResponseAndNormalizeError from './utils/response';
+import { parseResponseAndNormalizeError, parseAndThrowError } from './utils/response';
 
 /**
  * Default set of header values which should be sent with every request unless
@@ -79,6 +79,7 @@ const defaultFetchHandler = ( nextOptions ) => {
 
 	return responsePromise
 		.then( checkStatus )
+		.catch( ( response ) => parseAndThrowError( response, parse ) )
 		.then( ( response ) => parseResponseAndNormalizeError( response, parse ) );
 };
 

--- a/packages/api-fetch/src/middlewares/image-upload.js
+++ b/packages/api-fetch/src/middlewares/image-upload.js
@@ -1,0 +1,49 @@
+/**
+ * Internal dependencies
+ */
+import parseResponseAndNormalizeError from '../utils/response';
+
+/**
+ * Middleware handling media upload failures and retries.
+ *
+ * @param {Object}   options Fetch options.
+ * @param {Function} next    [description]
+ *
+ * @return {*} The evaluated result of the remaining middleware chain.
+ */
+function imageUploadMiddleware( options, next ) {
+	const isMediaUploadRequest =
+		( options.path && options.path.indexOf( '/wp/v2/media' ) !== -1 ) ||
+		( options.url && options.url.indexOf( '/wp/v2/media' ) !== -1 );
+
+	if ( ! isMediaUploadRequest ) {
+		return next( options, next );
+	}
+	let retries = 0;
+	const maxRetries = 5;
+
+	const retry = ( response ) => {
+		const attachmentId = response.headers.get( 'x-wp-upload-attachment-id' );
+		const shouldRetry = !! attachmentId && retries < maxRetries;
+
+		if ( ! shouldRetry ) {
+			return Promise.reject( response );
+		}
+
+		retries++;
+		return next( {
+			path: `/wp/v2/media/${ attachmentId }/post-process`,
+			method: 'POST',
+			data: { action: 'create-image-subsizes' },
+			parse: false,
+		} )
+			.then( ( res ) => parseResponseAndNormalizeError( res, options.parse ) )
+			.catch( retry );
+	};
+
+	return next( { ...options, parse: false } )
+		.then( ( response ) => parseResponseAndNormalizeError( response, options.parse ) )
+		.catch( retry );
+}
+
+export default imageUploadMiddleware;

--- a/packages/api-fetch/src/middlewares/media-upload.js
+++ b/packages/api-fetch/src/middlewares/media-upload.js
@@ -11,7 +11,7 @@ import parseResponseAndNormalizeError from '../utils/response';
  *
  * @return {*} The evaluated result of the remaining middleware chain.
  */
-function imageUploadMiddleware( options, next ) {
+function mediaUploadMiddleware( options, next ) {
 	const isMediaUploadRequest =
 		( options.path && options.path.indexOf( '/wp/v2/media' ) !== -1 ) ||
 		( options.url && options.url.indexOf( '/wp/v2/media' ) !== -1 );
@@ -27,6 +27,12 @@ function imageUploadMiddleware( options, next ) {
 		const shouldRetry = !! attachmentId && retries < maxRetries;
 
 		if ( ! shouldRetry ) {
+			if ( attachmentId ) {
+				next( {
+					path: `/wp/v2/media/${ attachmentId }`,
+					method: 'DELETE',
+				} );
+			}
 			return Promise.reject( response );
 		}
 
@@ -46,4 +52,4 @@ function imageUploadMiddleware( options, next ) {
 		.catch( retry );
 }
 
-export default imageUploadMiddleware;
+export default mediaUploadMiddleware;

--- a/packages/api-fetch/src/middlewares/media-upload.js
+++ b/packages/api-fetch/src/middlewares/media-upload.js
@@ -56,7 +56,7 @@ function mediaUploadMiddleware( options, next ) {
 		.then( ( response ) => parseResponseAndNormalizeError( response, options.parse ) )
 		.catch( ( response ) => {
 			const attachmentId = response.headers.get( 'x-wp-upload-attachment-id' );
-			if ( attachmentId ) {
+			if ( response.status === 500 && attachmentId ) {
 				return postProcess( attachmentId );
 			}
 			return Promise.reject( response );

--- a/packages/api-fetch/src/utils/response.js
+++ b/packages/api-fetch/src/utils/response.js
@@ -1,0 +1,65 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Parses the apiFetch response.
+ *
+ * @param {Response} response
+ * @param {boolean}  shouldParseResponse
+ *
+ * @return {Promise} Parsed response
+ */
+const parseResponse = ( response, shouldParseResponse = true ) => {
+	if ( shouldParseResponse ) {
+		if ( response.status === 204 ) {
+			return null;
+		}
+
+		return response.json ? response.json() : Promise.reject( response );
+	}
+
+	return response;
+};
+
+/**
+ * Parses the apiFetch response properly and normalize response errors.
+ *
+ * @param {Response} response
+ * @param {boolean}  shouldParseResponse
+ *
+ * @return {Promise} Parsed response.
+ */
+const parseResponseAndNormalizeError = ( response, shouldParseResponse = true ) => {
+	return Promise.resolve( parseResponse( response, shouldParseResponse ) )
+		.catch( ( res ) => {
+			if ( ! shouldParseResponse ) {
+				throw res;
+			}
+
+			const invalidJsonError = {
+				code: 'invalid_json',
+				message: __( 'The response is not a valid JSON response.' ),
+			};
+
+			if ( ! res || ! res.json ) {
+				throw invalidJsonError;
+			}
+
+			return res.json()
+				.catch( () => {
+					throw invalidJsonError;
+				} )
+				.then( ( error ) => {
+					const unknownError = {
+						code: 'unknown_error',
+						message: __( 'An unknown error occurred.' ),
+					};
+
+					throw error || unknownError;
+				} );
+		} );
+};
+
+export default parseResponseAndNormalizeError;


### PR DESCRIPTION
closes #17474

Implements the new Media "post-process" endpoint to recover from media upload failures

**Testing instructions**

See here https://github.com/WordPress/gutenberg/issues/17474#issuecomment-539607050

or https://github.com/WordPress/gutenberg/pull/17858#issuecomment-540114688

> Perhaps another (simpler) way to test is to add the following to a WP plugin:
> ```
> add_filter( 'intermediate_image_sizes_advanced', '_test_image_post_processing' );
> add_filter( 'wp_get_missing_image_subsizes', '_test_image_post_processing' );
> function _test_image_post_processing( $sizes ) {
> 	if ( rand( 1, 2 ) === 2 ) {
> 		trigger_error( '', E_USER_ERROR );
> 		exit;
> 	}
> 	
> 	return $sizes;
> }
> ```
> 
> It will fail 50% of the time and should trigger multiple post_process request.

With that in place, you either drag & drop an image from your desktop or use the upload button.