### PR TITLE
Update E2E tests for WP 5.3 Beta 3

### DIFF
--- a/packages/e2e-tests/specs/font-size-picker.test.js
+++ b/packages/e2e-tests/specs/font-size-picker.test.js
@@ -31,7 +31,7 @@ describe( 'Font Size Picker', () => {
 
 		await page.click( '.blocks-font-size .components-range-control__number' );
 		// This should be the "small" font-size of the current theme.
-		await page.keyboard.type( '16' );
+		await page.keyboard.type( '18' );
 
 		// Ensure content matches snapshot.
 		const content = await getEditedPostContent();


### PR DESCRIPTION
There was a change to the named font sizes in twentytwenty:
https://github.com/WordPress/twentytwenty/pull/764

This updates the tests to use the new value in the theme

## How has this been tested?

Ran:

```
npm run env update
npm run test-e2e:local font-size-picker
```

More importantly, this should pass on travis

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
