### PR TITLE
Packages: Add information for webpack about no side effects

### DIFF
--- a/packages/autop/package.json
+++ b/packages/autop/package.json
@@ -20,6 +20,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"react-native": "src/index",
+	"sideEffects": false,
 	"dependencies": {
 		"@babel/runtime": "^7.4.4"
 	},

--- a/packages/blob/package.json
+++ b/packages/blob/package.json
@@ -20,6 +20,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"react-native": "src/index",
+	"sideEffects": false,
 	"dependencies": {
 		"@babel/runtime": "^7.4.4"
 	},

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -20,6 +20,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"react-native": "src/index",
+	"sideEffects": false,
 	"dependencies": {
 		"@babel/runtime": "^7.4.4",
 		"@wordpress/a11y": "file:../a11y",

--- a/packages/block-serialization-default-parser/package.json
+++ b/packages/block-serialization-default-parser/package.json
@@ -21,6 +21,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"react-native": "src/index",
+	"sideEffects": false,
 	"dependencies": {
 		"@babel/runtime": "^7.4.4"
 	},

--- a/packages/block-serialization-spec-parser/package.json
+++ b/packages/block-serialization-spec-parser/package.json
@@ -20,6 +20,7 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"main": "parser.js",
+	"sideEffects": false,
 	"dependencies": {
 		"pegjs": "^0.10.0",
 		"phpegjs": "^1.0.0-beta7"

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -330,10 +330,6 @@ _Returns_
 
 -   `Function`: marked registry selector.
 
-<a name="createSelector" href="#createSelector">#</a> **createSelector**
-
-Undocumented declaration.
-
 <a name="dispatch" href="#dispatch">#</a> **dispatch**
 
 Given the name of a registered store, returns an object of the store's action creators.

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -330,6 +330,10 @@ _Returns_
 
 -   `Function`: marked registry selector.
 
+<a name="createSelector" href="#createSelector">#</a> **createSelector**
+
+Undocumented declaration.
+
 <a name="dispatch" href="#dispatch">#</a> **dispatch**
 
 Given the name of a registered store, returns an object of the store's action creators.

--- a/packages/deprecated/package.json
+++ b/packages/deprecated/package.json
@@ -20,6 +20,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"react-native": "src/index",
+	"sideEffects": false,
 	"dependencies": {
 		"@babel/runtime": "^7.4.4",
 		"@wordpress/hooks": "file:../hooks"

--- a/packages/dom-ready/package.json
+++ b/packages/dom-ready/package.json
@@ -20,6 +20,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"react-native": "src/index",
+	"sideEffects": false,
 	"dependencies": {
 		"@babel/runtime": "^7.4.4"
 	},

--- a/packages/dom/package.json
+++ b/packages/dom/package.json
@@ -21,6 +21,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"react-native": "src/index",
+	"sideEffects": false,
 	"dependencies": {
 		"@babel/runtime": "^7.4.4",
 		"lodash": "^4.17.15"

--- a/packages/element/package.json
+++ b/packages/element/package.json
@@ -21,6 +21,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"react-native": "src/index",
+	"sideEffects": false,
 	"dependencies": {
 		"@babel/runtime": "^7.4.4",
 		"@wordpress/escape-html": "file:../escape-html",

--- a/packages/escape-html/package.json
+++ b/packages/escape-html/package.json
@@ -19,6 +19,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"react-native": "src/index",
+	"sideEffects": false,
 	"dependencies": {
 		"@babel/runtime": "^7.4.4"
 	},

--- a/packages/is-shallow-equal/package.json
+++ b/packages/is-shallow-equal/package.json
@@ -25,6 +25,7 @@
 		"objects.js"
 	],
 	"main": "index.js",
+	"sideEffects": false,
 	"dependencies": {
 		"@babel/runtime": "^7.4.4"
 	},

--- a/packages/keycodes/package.json
+++ b/packages/keycodes/package.json
@@ -20,6 +20,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"react-native": "src/index",
+	"sideEffects": false,
 	"dependencies": {
 		"@babel/runtime": "^7.4.4",
 		"@wordpress/i18n": "file:../i18n",

--- a/packages/priority-queue/package.json
+++ b/packages/priority-queue/package.json
@@ -21,6 +21,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"react-native": "src/index",
+	"sideEffects": false,
 	"dependencies": {
 		"@babel/runtime": "^7.4.4"
 	},

--- a/packages/redux-routine/package.json
+++ b/packages/redux-routine/package.json
@@ -22,6 +22,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"react-native": "src/index",
+	"sideEffects": false,
 	"dependencies": {
 		"@babel/runtime": "^7.4.4",
 		"is-promise": "^2.1.0",

--- a/packages/url/package.json
+++ b/packages/url/package.json
@@ -20,6 +20,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"react-native": "src/index",
+	"sideEffects": false,
 	"dependencies": {
 		"@babel/runtime": "^7.4.4",
 		"qs": "^6.5.2"

--- a/packages/wordcount/package.json
+++ b/packages/wordcount/package.json
@@ -20,6 +20,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"react-native": "src/index",
+	"sideEffects": false,
 	"dependencies": {
 		"@babel/runtime": "^7.4.4",
 		"lodash": "^4.17.15"


### PR DESCRIPTION
## Description

Previous work from @talldan: #14135 as explained in #13910:

> The `sideEffects` property indicates whether a package introduces any side effects. It can be specified as either `false` or as an array of files that have side effects.
> 
> By specifying this property, webpack is able to reduce the size of JavaScript bundles by eliminating unused imports:
> https://webpack.js.org/guides/tree-shaking/
> 
> `sideEffects` is particularly relevant when implementing feature flags. Without it, features need to be flagged at every possible point. For further details, see this discussion: https://github.com/WordPress/gutenberg/pull/13829#discussion_r255878995

In our case, this is extremely important for `@wordpress/block-library` package to ensure that dead code behind the `GUTENBERG_PHASE` flag isn't bundled in WordPress 5.3 release.

I also included other packages which @talldan discovered as side-effects free. However, I took a more cautious approach and marked only those packages which only export their APIs which are pure.

## Testing

Set `GUTENBRG_PHASE` flag to **1**:

```diff
diff --git a/package.json b/package.json
index 84f28a49d..abb06b4f1 100644
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
                "url": "https://github.com/WordPress/gutenberg/issues"
        },
        "config": {
-               "GUTENBERG_PHASE": 2
+               "GUTENBERG_PHASE": 1
        },
        "dependencies": {
                "@wordpress/a11y": "file:packages/a11y",
```

Make sure that everything works.

Validate that the block library module is 65kb smaller after running `npm run build`.

### Before

                                                     Asset        Size  Chunks                    Chunk Names
                                     ./build/a11y/index.js    2.18 KiB       0  [emitted]         a11y
                              ./build/annotations/index.js     9.7 KiB       1  [emitted]         annotations
                                ./build/api-fetch/index.js    7.05 KiB       2  [emitted]         apiFetch
                                    ./build/autop/index.js    6.89 KiB       3  [emitted]         autop
                                     ./build/blob/index.js    1.37 KiB       4  [emitted]         blob
                          ./build/block-directory/index.js    15.8 KiB       5  [emitted]         blockDirectory
                             ./build/block-editor/index.js     301 KiB       6  [emitted]  [big]  blockEditor
                            ./build/block-library/index.js     **361 KiB**       7  [emitted]  [big]  blockLibrary
       ./build/block-serialization-default-parser/index.js    3.63 KiB       8  [emitted]         blockSerializationDefaultParser
          ./build/block-serialization-spec-parser/index.js    10.5 KiB       9  [emitted]         blockSerializationSpecParser
                                   ./build/blocks/index.js     170 KiB      10  [emitted]         blocks
                               ./build/components/index.js     559 KiB      11  [emitted]  [big]  components
                                  ./build/compose/index.js    9.23 KiB      12  [emitted]         compose
                                ./build/core-data/index.js    32.9 KiB      13  [emitted]         coreData
                            ./build/data-controls/index.js    2.87 KiB      15  [emitted]         dataControls
                                     ./build/data/index.js    24.4 KiB      14  [emitted]         data
                                     ./build/date/index.js    13.3 KiB      16  [emitted]         date
                               ./build/deprecated/index.js    1.61 KiB      17  [emitted]         deprecated
                                ./build/dom-ready/index.js    1.14 KiB      19  [emitted]         domReady
                                      ./build/dom/index.js    7.51 KiB      18  [emitted]         dom
                                ./build/edit-post/index.js    82.8 KiB      20  [emitted]         editPost
                             ./build/edit-widgets/index.js    13.7 KiB      21  [emitted]         editWidgets
                                   ./build/editor/index.js     163 KiB      22  [emitted]         editor
                                  ./build/element/index.js    9.03 KiB      23  [emitted]         element
                              ./build/escape-html/index.js     1.6 KiB      24  [emitted]         escapeHtml
                           ./build/format-library/index.js    17.7 KiB      25  [emitted]         formatLibrary
                                    ./build/hooks/index.js    5.41 KiB      26  [emitted]         hooks
                            ./build/html-entities/index.js    1.34 KiB      27  [emitted]         htmlEntities
                                     ./build/i18n/index.js    8.52 KiB      28  [emitted]         i18n
                         ./build/is-shallow-equal/index.js    1.63 KiB      29  [emitted]         isShallowEqual
                                 ./build/keycodes/index.js    4.74 KiB      30  [emitted]         keycodes
                     ./build/list-reusable-blocks/index.js    8.41 KiB      31  [emitted]         listReusableBlocks
                              ./build/media-utils/index.js    12.7 KiB      32  [emitted]         mediaUtils
                                  ./build/notices/index.js    4.53 KiB      33  [emitted]         notices
                                      ./build/nux/index.js    7.58 KiB      34  [emitted]         nux
                                  ./build/plugins/index.js    6.75 KiB      35  [emitted]         plugins
                           ./build/priority-queue/index.js    1.46 KiB      36  [emitted]         priorityQueue
                            ./build/redux-routine/index.js    9.49 KiB      37  [emitted]         reduxRoutine
                                ./build/rich-text/index.js    45.5 KiB      38  [emitted]         richText
                       ./build/server-side-render/index.js     7.6 KiB      39  [emitted]         serverSideRender
                                ./build/shortcode/index.js    3.96 KiB      40  [emitted]         shortcode
                               ./build/token-list/index.js    3.16 KiB      41  [emitted]         tokenList
                                      ./build/url/index.js    10.8 KiB      42  [emitted]         url
                                 ./build/viewport/index.js    2.65 KiB      43  [emitted]         viewport
                                ./build/wordcount/index.js    2.93 KiB      44  [emitted]         wordcount

### After
                                                     Asset        Size  Chunks                    Chunk Names
                                     ./build/a11y/index.js    2.18 KiB       0  [emitted]         a11y
                              ./build/annotations/index.js     9.7 KiB       1  [emitted]         annotations
                                ./build/api-fetch/index.js    7.05 KiB       2  [emitted]         apiFetch
                                    ./build/autop/index.js    6.89 KiB       3  [emitted]         autop
                                     ./build/blob/index.js    1.37 KiB       4  [emitted]         blob
                          ./build/block-directory/index.js    15.8 KiB       5  [emitted]         blockDirectory
                             ./build/block-editor/index.js     301 KiB       6  [emitted]  [big]  blockEditor
                            ./build/block-library/index.js     **296 KiB**       7  [emitted]  [big]  blockLibrary
       ./build/block-serialization-default-parser/index.js    3.63 KiB       8  [emitted]         blockSerializationDefaultParser
          ./build/block-serialization-spec-parser/index.js    10.5 KiB       9  [emitted]         blockSerializationSpecParser
                                   ./build/blocks/index.js     170 KiB      10  [emitted]         blocks
                               ./build/components/index.js     559 KiB      11  [emitted]  [big]  components
                                  ./build/compose/index.js    9.23 KiB      12  [emitted]         compose
                                ./build/core-data/index.js    32.9 KiB      13  [emitted]         coreData
                            ./build/data-controls/index.js    2.87 KiB      15  [emitted]         dataControls
                                     ./build/data/index.js    24.4 KiB      14  [emitted]         data
                                     ./build/date/index.js    13.3 KiB      16  [emitted]         date
                               ./build/deprecated/index.js    1.61 KiB      17  [emitted]         deprecated
                                ./build/dom-ready/index.js    1.14 KiB      19  [emitted]         domReady
                                      ./build/dom/index.js    7.51 KiB      18  [emitted]         dom
                                ./build/edit-post/index.js    82.8 KiB      20  [emitted]         editPost
                             ./build/edit-widgets/index.js    13.7 KiB      21  [emitted]         editWidgets
                                   ./build/editor/index.js     163 KiB      22  [emitted]         editor
                                  ./build/element/index.js    9.03 KiB      23  [emitted]         element
                              ./build/escape-html/index.js     1.6 KiB      24  [emitted]         escapeHtml
                           ./build/format-library/index.js    17.7 KiB      25  [emitted]         formatLibrary
                                    ./build/hooks/index.js    5.41 KiB      26  [emitted]         hooks
                            ./build/html-entities/index.js    1.34 KiB      27  [emitted]         htmlEntities
                                     ./build/i18n/index.js    8.52 KiB      28  [emitted]         i18n
                         ./build/is-shallow-equal/index.js    1.63 KiB      29  [emitted]         isShallowEqual
                                 ./build/keycodes/index.js    4.74 KiB      30  [emitted]         keycodes
                     ./build/list-reusable-blocks/index.js    8.41 KiB      31  [emitted]         listReusableBlocks
                              ./build/media-utils/index.js    12.7 KiB      32  [emitted]         mediaUtils
                                  ./build/notices/index.js    4.53 KiB      33  [emitted]         notices
                                      ./build/nux/index.js    7.58 KiB      34  [emitted]         nux
                                  ./build/plugins/index.js    6.75 KiB      35  [emitted]         plugins
                           ./build/priority-queue/index.js    1.46 KiB      36  [emitted]         priorityQueue
                            ./build/redux-routine/index.js    9.49 KiB      37  [emitted]         reduxRoutine
                                ./build/rich-text/index.js    45.5 KiB      38  [emitted]         richText
                       ./build/server-side-render/index.js     7.6 KiB      39  [emitted]         serverSideRender
                                ./build/shortcode/index.js    3.96 KiB      40  [emitted]         shortcode
                               ./build/token-list/index.js    3.16 KiB      41  [emitted]         tokenList
                                      ./build/url/index.js    10.8 KiB      42  [emitted]         url
                                 ./build/viewport/index.js    2.65 KiB      43  [emitted]         viewport
                                ./build/wordcount/index.js    2.93 KiB      44  [emitted]         wordcount
