### PR TITLE
[WIP] Data: Inline rememo inside data package to decrease code duplication

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"config": {
-		"GUTENBERG_PHASE": 2
+		"GUTENBERG_PHASE": 1
 	},
 	"dependencies": {
 		"@wordpress/a11y": "file:packages/a11y",

--- a/packages/annotations/src/store/selectors.js
+++ b/packages/annotations/src/store/selectors.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import createSelector from 'rememo';
+import { createSelector } from '@wordpress/data';
 import { get, flatMap } from 'lodash';
 
 /**

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -16,7 +16,7 @@ import {
 	some,
 	find,
 } from 'lodash';
-import createSelector from 'rememo';
+import { createSelector } from '@wordpress/data';
 
 /**
  * WordPress dependencies

--- a/packages/blocks/src/store/selectors.js
+++ b/packages/blocks/src/store/selectors.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import createSelector from 'rememo';
+import { createSelector } from '@wordpress/data';
 import { filter, get, includes, map, some, flow, deburr } from 'lodash';
 
 /**

--- a/packages/core-data/src/queried-data/selectors.js
+++ b/packages/core-data/src/queried-data/selectors.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import createSelector from 'rememo';
+import { createSelector } from '@wordpress/data';
 import EquivalentKeyMap from 'equivalent-key-map';
 
 /**

--- a/packages/core-data/src/selectors.js
+++ b/packages/core-data/src/selectors.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import createSelector from 'rememo';
+import { createSelector } from '@wordpress/data';
 import { map, find, get, filter, compact, defaultTo } from 'lodash';
 
 /**

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -33,6 +33,7 @@
 		"is-promise": "^2.1.0",
 		"lodash": "^4.17.15",
 		"redux": "^4.0.0",
+		"rememo": "^3.0.0",
 		"turbo-combine-reducers": "^1.0.2"
 	},
 	"publishConfig": {

--- a/packages/data/src/index.js
+++ b/packages/data/src/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import combineReducers from 'turbo-combine-reducers';
+import { createSelector } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -72,6 +73,8 @@ export { plugins };
  *                          object, and constructs a state object with the same shape.
  */
 export { combineReducers };
+
+export { createSelector };
 
 /**
  * Given the name of a registered store, returns an object of the store's selectors.

--- a/packages/edit-post/src/store/selectors.js
+++ b/packages/edit-post/src/store/selectors.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import createSelector from 'rememo';
+import { createSelector } from '@wordpress/data';
 import { get, includes, some, flatten, values } from 'lodash';
 
 /**

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -10,7 +10,7 @@ import {
 	mapValues,
 	includes,
 } from 'lodash';
-import createSelector from 'rememo';
+import { createSelector } from '@wordpress/data';
 
 /**
  * WordPress dependencies

--- a/packages/nux/src/store/selectors.js
+++ b/packages/nux/src/store/selectors.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import createSelector from 'rememo';
+import { createSelector } from '@wordpress/data';
 import { includes, difference, keys, has } from 'lodash';
 
 /**

--- a/packages/rich-text/src/store/selectors.js
+++ b/packages/rich-text/src/store/selectors.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import createSelector from 'rememo';
+import { createSelector } from '@wordpress/data';
 import { find } from 'lodash';
 
 /**


### PR DESCRIPTION
## Description

Related: #8078.

This way `rememo` is no longer bundled into **8** packages but gets bundled to `@wordpress/data` instead.

## Testing

Set `GUTENBRG_PHASE` flag to **1** (optimized agains WordPress 5.3 release):

```diff
diff --git a/package.json b/package.json
index 84f28a49d..abb06b4f1 100644
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
                "url": "https://github.com/WordPress/gutenberg/issues"
        },
        "config": {
-               "GUTENBERG_PHASE": 2
+               "GUTENBERG_PHASE": 1
        },
        "dependencies": {
                "@wordpress/a11y": "file:packages/a11y",
```

Make sure that everything works.

### Before

                                                     Asset        Size  Chunks                    Chunk Names
                                     ./build/a11y/index.js    2.18 KiB       0  [emitted]         a11y
                              ./build/annotations/index.js     *9.7 KiB*       1  [emitted]         annotations
                                ./build/api-fetch/index.js    7.05 KiB       2  [emitted]         apiFetch
                                    ./build/autop/index.js    6.89 KiB       3  [emitted]         autop
                                     ./build/blob/index.js    1.37 KiB       4  [emitted]         blob
                          ./build/block-directory/index.js    15.8 KiB       5  [emitted]         blockDirectory
                             ./build/block-editor/index.js     *301 KiB*       6  [emitted]  [big]  blockEditor
                            ./build/block-library/index.js     361 KiB       7  [emitted]  [big]  blockLibrary
       ./build/block-serialization-default-parser/index.js    3.63 KiB       8  [emitted]         blockSerializationDefaultParser
          ./build/block-serialization-spec-parser/index.js    10.5 KiB       9  [emitted]         blockSerializationSpecParser
                                   ./build/blocks/index.js     *170 KiB*      10  [emitted]         blocks
                               ./build/components/index.js     559 KiB      11  [emitted]  [big]  components
                                  ./build/compose/index.js    9.23 KiB      12  [emitted]         compose
                                ./build/core-data/index.js    *32.9 KiB*      13  [emitted]         coreData
                            ./build/data-controls/index.js    2.87 KiB      15  [emitted]         dataControls
                                     ./build/data/index.js    *24.4 KiB*      14  [emitted]         data
                                     ./build/date/index.js    13.3 KiB      16  [emitted]         date
                               ./build/deprecated/index.js    1.61 KiB      17  [emitted]         deprecated
                                ./build/dom-ready/index.js    1.14 KiB      19  [emitted]         domReady
                                      ./build/dom/index.js    7.51 KiB      18  [emitted]         dom
                                ./build/edit-post/index.js    82.8 KiB      20  [emitted]         editPost
                             ./build/edit-widgets/index.js    13.7 KiB      21  [emitted]         editWidgets
                                   ./build/editor/index.js     163 KiB      22  [emitted]         editor
                                  ./build/element/index.js    9.03 KiB      23  [emitted]         element
                              ./build/escape-html/index.js     1.6 KiB      24  [emitted]         escapeHtml
                           ./build/format-library/index.js    17.7 KiB      25  [emitted]         formatLibrary
                                    ./build/hooks/index.js    5.41 KiB      26  [emitted]         hooks
                            ./build/html-entities/index.js    1.34 KiB      27  [emitted]         htmlEntities
                                     ./build/i18n/index.js    8.52 KiB      28  [emitted]         i18n
                         ./build/is-shallow-equal/index.js    1.63 KiB      29  [emitted]         isShallowEqual
                                 ./build/keycodes/index.js    4.74 KiB      30  [emitted]         keycodes
                     ./build/list-reusable-blocks/index.js    8.41 KiB      31  [emitted]         listReusableBlocks
                              ./build/media-utils/index.js    12.7 KiB      32  [emitted]         mediaUtils
                                  ./build/notices/index.js    4.53 KiB      33  [emitted]         notices
                                      ./build/nux/index.js    7.58 KiB      34  [emitted]         nux
                                  ./build/plugins/index.js    6.75 KiB      35  [emitted]         plugins
                           ./build/priority-queue/index.js    1.46 KiB      36  [emitted]         priorityQueue
                            ./build/redux-routine/index.js    9.49 KiB      37  [emitted]         reduxRoutine
                                ./build/rich-text/index.js    45.5 KiB      38  [emitted]         richText
                       ./build/server-side-render/index.js     7.6 KiB      39  [emitted]         serverSideRender
                                ./build/shortcode/index.js    3.96 KiB      40  [emitted]         shortcode
                               ./build/token-list/index.js    3.16 KiB      41  [emitted]         tokenList
                                      ./build/url/index.js    10.8 KiB      42  [emitted]         url
                                 ./build/viewport/index.js    2.65 KiB      43  [emitted]         viewport
                                ./build/wordcount/index.js    2.93 KiB      44  [emitted]         wordcount


### After

                                                     Asset        Size  Chunks                    Chunk Names
                                     ./build/a11y/index.js    2.18 KiB       0  [emitted]         a11y
                              ./build/annotations/index.js    *8.62 KiB*       1  [emitted]         annotations
                                ./build/api-fetch/index.js    7.05 KiB       2  [emitted]         apiFetch
                                    ./build/autop/index.js    6.89 KiB       3  [emitted]         autop
                                     ./build/blob/index.js    1.37 KiB       4  [emitted]         blob
                          ./build/block-directory/index.js    15.8 KiB       5  [emitted]         blockDirectory
                             ./build/block-editor/index.js     *300 KiB*       6  [emitted]  [big]  blockEditor
                            ./build/block-library/index.js     361 KiB       7  [emitted]  [big]  blockLibrary
       ./build/block-serialization-default-parser/index.js    3.63 KiB       8  [emitted]         blockSerializationDefaultParser
          ./build/block-serialization-spec-parser/index.js    10.5 KiB       9  [emitted]         blockSerializationSpecParser
                                   ./build/blocks/index.js     *169 KiB*      10  [emitted]         blocks
                               ./build/components/index.js     559 KiB      11  [emitted]  [big]  components
                                  ./build/compose/index.js    9.23 KiB      12  [emitted]         compose
                                ./build/core-data/index.js    *31.9 KiB*      13  [emitted]         coreData
                            ./build/data-controls/index.js    2.87 KiB      15  [emitted]         dataControls
                                     ./build/data/index.js    *24.6 KiB*      14  [emitted]         data
                                     ./build/date/index.js    13.3 KiB      16  [emitted]         date
                               ./build/deprecated/index.js    1.61 KiB      17  [emitted]         deprecated
                                ./build/dom-ready/index.js    1.14 KiB      19  [emitted]         domReady
                                      ./build/dom/index.js    7.51 KiB      18  [emitted]         dom
                                ./build/edit-post/index.js    81.8 KiB      20  [emitted]         editPost
                             ./build/edit-widgets/index.js    13.7 KiB      21  [emitted]         editWidgets
                                   ./build/editor/index.js     162 KiB      22  [emitted]         editor
                                  ./build/element/index.js    9.03 KiB      23  [emitted]         element
                              ./build/escape-html/index.js     1.6 KiB      24  [emitted]         escapeHtml
                           ./build/format-library/index.js    17.7 KiB      25  [emitted]         formatLibrary
                                    ./build/hooks/index.js    5.41 KiB      26  [emitted]         hooks
                            ./build/html-entities/index.js    1.34 KiB      27  [emitted]         htmlEntities
                                     ./build/i18n/index.js    8.52 KiB      28  [emitted]         i18n
                         ./build/is-shallow-equal/index.js    1.63 KiB      29  [emitted]         isShallowEqual
                                 ./build/keycodes/index.js    4.74 KiB      30  [emitted]         keycodes
                     ./build/list-reusable-blocks/index.js    8.41 KiB      31  [emitted]         listReusableBlocks
                              ./build/media-utils/index.js    12.7 KiB      32  [emitted]         mediaUtils
                                  ./build/notices/index.js    4.53 KiB      33  [emitted]         notices
                                      ./build/nux/index.js    6.49 KiB      34  [emitted]         nux
                                  ./build/plugins/index.js    6.75 KiB      35  [emitted]         plugins
                           ./build/priority-queue/index.js    1.46 KiB      36  [emitted]         priorityQueue
                            ./build/redux-routine/index.js    9.49 KiB      37  [emitted]         reduxRoutine
                                ./build/rich-text/index.js    44.4 KiB      38  [emitted]         richText
                       ./build/server-side-render/index.js     7.6 KiB      39  [emitted]         serverSideRender
                                ./build/shortcode/index.js    3.96 KiB      40  [emitted]         shortcode
                               ./build/token-list/index.js    3.16 KiB      41  [emitted]         tokenList
                                      ./build/url/index.js    10.8 KiB      42  [emitted]         url
                                 ./build/viewport/index.js    2.65 KiB      43  [emitted]         viewport
                                ./build/wordcount/index.js    2.93 KiB      44  [emitted]         wordcount

## Result

It looks like the total gain is around 8 Kib less before gzip which is rather something which users won't notice at all.