### PR TITLE
Display ESnext examples first

### DIFF
--- a/docs/designers-developers/developers/block-api/block-edit-save.md
+++ b/docs/designers-developers/developers/block-api/block-edit-save.md
@@ -7,6 +7,12 @@ When registering a block, the `edit` and `save` functions provide the interface 
 The `edit` function describes the structure of your block in the context of the editor. This represents what the editor will render when the block is used.
 
 {% codetabs %}
+{% ESNext %}
+```jsx
+edit: () => {
+	return <div>Your block.</div>;
+}
+```
 {% ES5 %}
 ```js
 // A static div
@@ -16,12 +22,6 @@ edit: function() {
 		null,
 		'Your block.'
 	);
-}
-```
-{% ESNext %}
-```jsx
-edit: () => {
-	return <div>Your block.</div>;
 }
 ```
 {% end %}
@@ -35,6 +35,12 @@ This property surfaces all the available attributes and their corresponding valu
 In this case, assuming we had defined an attribute of `content` during block registration, we would receive and use that value in our edit function:
 
 {% codetabs %}
+{% ESNext %}
+```js
+edit: ( { attributes } ) => {
+	return <div>{ attributes.content }</div>;
+}
+```
 {% ES5 %}
 ```js
 edit: function( props ) {
@@ -43,12 +49,6 @@ edit: function( props ) {
 		null,
 		props.attributes.content
 	);
-}
-```
-{% ESNext %}
-```js
-edit: ( { attributes } ) => {
-	return <div>{ attributes.content }</div>;
 }
 ```
 {% end %}
@@ -60,6 +60,12 @@ The value of `attributes.content` will be displayed inside the `div` when insert
 This property returns the class name for the wrapper element. This is automatically added in the `save` method, but not on `edit`, as the root element may not correspond to what is _visually_ the main element of the block. You can request it to add it to the correct element in your function.
 
 {% codetabs %}
+{% ESNext %}
+```js
+edit: ( { attributes, className } ) => {
+	return <div className={ className }>{ attributes.content }</div>;
+}
+```
 {% ES5 %}
 ```js
 edit: function( props ) {
@@ -70,12 +76,6 @@ edit: function( props ) {
 	);
 }
 ```
-{% ESNext %}
-```js
-edit: ( { attributes, className } ) => {
-	return <div className={ className }>{ attributes.content }</div>;
-}
-```
 {% end %}
 
 ### isSelected
@@ -83,6 +83,19 @@ edit: ( { attributes, className } ) => {
 The isSelected property is an object that communicates whether the block is currently selected.
 
 {% codetabs %}
+{% ESNext %}
+```jsx
+edit: ( { attributes, className, isSelected } ) => {
+	return (
+		<div className={ className }>
+			Your block.
+			{ isSelected &&
+				<span>Shows only when the block is selected.</span>
+			}
+		</div>
+	);
+}
+```
 {% ES5 %}
 ```js
 edit: function( props ) {
@@ -100,19 +113,6 @@ edit: function( props ) {
 	);
 }
 ```
-{% ESNext %}
-```jsx
-edit: ( { attributes, className, isSelected } ) => {
-	return (
-		<div className={ className }>
-			Your block.
-			{ isSelected &&
-				<span>Shows only when the block is selected.</span>
-			}
-		</div>
-	);
-}
-```
 {% end %}
 
 ### setAttributes
@@ -120,6 +120,24 @@ edit: ( { attributes, className, isSelected } ) => {
 This function allows the block to update individual attributes based on user interactions.
 
 {% codetabs %}
+{% ESNext %}
+```jsx
+edit: ( { attributes, setAttributes, className, isSelected } ) => {
+	// Simplify access to attributes
+	const { content, mySetting } = attributes;
+
+	// Toggle a setting when the user clicks the button
+	const toggleSetting = () => setAttributes( { mySetting: ! mySetting } );
+	return (
+		<div className={ className }>
+			{ content }
+			{ isSelected &&
+				<button onClick={ toggleSetting }>Toggle setting</button>
+			}
+		</div>
+	);
+}
+```
 {% ES5 %}
 ```js
 edit: function( props ) {
@@ -143,29 +161,24 @@ edit: function( props ) {
 	);
 },
 ```
-{% ESNext %}
-```jsx
-edit: ( { attributes, setAttributes, className, isSelected } ) => {
-	// Simplify access to attributes
-	const { content, mySetting } = attributes;
-
-	// Toggle a setting when the user clicks the button
-	const toggleSetting = () => setAttributes( { mySetting: ! mySetting } );
-	return (
-		<div className={ className }>
-			{ content }
-			{ isSelected &&
-				<button onClick={ toggleSetting }>Toggle setting</button>
-			}
-		</div>
-	);
-}
-```
 {% end %}
 
 When using attributes that are objects or arrays it's a good idea to copy or clone the attribute prior to updating it:
 
 {% codetabs %}
+{% ESNext %}
+```js
+// Good - a new array is created from the old list attribute and a new list item:
+const { list } = attributes;
+const addListItem = ( newListItem ) => setAttributes( { list: [ ...list, newListItem ] } );
+
+// Bad - the list from the existing attribute is modified directly to add the new list item:
+const { list } = attributes;
+const addListItem = ( newListItem ) => {
+	list.push( newListItem );
+	setAttributes( { list } );
+};
+```
 {% ES5 %}
 ```js
 // Good - cloning the old list
@@ -182,19 +195,6 @@ var addListItem = function( newListItem ) {
 	setAttributes( { list: list } );
 };
 ```
-{% ESNext %}
-```js
-// Good - a new array is created from the old list attribute and a new list item:
-const { list } = attributes;
-const addListItem = ( newListItem ) => setAttributes( { list: [ ...list, newListItem ] } );
-
-// Bad - the list from the existing attribute is modified directly to add the new list item:
-const { list } = attributes;
-const addListItem = ( newListItem ) => {
-	list.push( newListItem );
-	setAttributes( { list } );
-};
-```
 {% end %}
 
 Why do this? In JavaScript, arrays and objects are passed by reference, so this practice ensures changes won't affect other code that might hold references to the same data. Furthermore, the Gutenberg project follows the philosophy of the Redux library that [state should be immutable](https://redux.js.org/faq/immutable-data#what-are-the-benefits-of-immutability)—data should not be changed directly, but instead a new version of the data created containing the changes.
@@ -204,6 +204,12 @@ Why do this? In JavaScript, arrays and objects are passed by reference, so this 
 The `save` function defines the way in which the different attributes should be combined into the final markup, which is then serialized into `post_content`.
 
 {% codetabs %}
+{% ESNext %}
+```jsx
+save: () => {
+	return <div> Your block. </div>;
+}
+```
 {% ES5 %}
 ```js
 save: function() {
@@ -212,12 +218,6 @@ save: function() {
 		null,
 		'Your block.'
 	);
-}
-```
-{% ESNext %}
-```jsx
-save: () => {
-	return <div> Your block. </div>;
 }
 ```
 {% end %}
@@ -242,6 +242,12 @@ If left unspecified, the default implementation will save no markup in post cont
 As with `edit`, the `save` function also receives an object argument including attributes which can be inserted into the markup.
 
 {% codetabs %}
+{% ESNext %}
+```jsx
+save: ( { attributes } ) => {
+	return <div>{ attributes.content }</div>;
+}
+```
 {% ES5 %}
 ```js
 save: function( props ) {
@@ -250,12 +256,6 @@ save: function( props ) {
 		null,
 		props.attributes.content
 	);
-}
-```
-{% ESNext %}
-```jsx
-save: ( { attributes } ) => {
-	return <div>{ attributes.content }</div>;
 }
 ```
 {% end %}
@@ -333,6 +333,29 @@ Ideally, the attributes saved should be included in the markup. However, there a
 This example could be for a dynamic block, such as the [Latest Posts block](https://github.com/WordPress/gutenberg/blob/master/packages/block-library/src/latest-posts/index.js), which renders the markup server-side. The save function is still required, however in this case it simply returns null since the block is not saving content from the editor.
 
 {% codetabs %}
+{% ESNext %}
+```jsx
+attributes: {
+	postsToShow: {
+		type: 'number',
+	}
+},
+
+edit: ( { attributes, setAttributes } ) => {
+	return <TextControl
+			label='Number Posts to Show'
+			value={ attributes.postsToShow }
+			onChange={ ( val ) => {
+				setAttributes( { postsToShow: parseInt( val ) } );
+			}},
+		}
+	);
+},
+
+save: () => {
+	return null;
+}
+```
 {% ES5 %}
 ```js
 attributes: {
@@ -355,29 +378,6 @@ edit: function( props ) {
 },
 
 save: function() {
-	return null;
-}
-```
-{% ESNext %}
-```jsx
-attributes: {
-	postsToShow: {
-		type: 'number',
-	}
-},
-
-edit: ( { attributes, setAttributes } ) => {
-	return <TextControl
-			label='Number Posts to Show'
-			value={ attributes.postsToShow }
-			onChange={ ( val ) => {
-				setAttributes( { postsToShow: parseInt( val ) } );
-			}},
-		}
-	);
-},
-
-save: () => {
 	return null;
 }
 ```

--- a/docs/designers-developers/developers/block-api/block-registration.md
+++ b/docs/designers-developers/developers/block-api/block-registration.md
@@ -197,22 +197,6 @@ Transforms provide rules for what a block can be transformed from and what it ca
 For example, a Paragraph block can be transformed into a Heading block. This uses the `createBlock` function from the [`wp-blocks` package](/packages/blocks/README.md#createBlock).
 
 {% codetabs %}
-{% ES5 %}
-```js
-transforms: {
-    from: [
-        {
-            type: 'block',
-            blocks: [ 'core/paragraph' ],
-            transform: function ( attributes ) {
-                return createBlock( 'core/heading', {
-                    content: attributes.content,
-                } );
-            },
-        },
-    ]
-},
-```
 {% ESNext %}
 ```js
 transforms: {
@@ -229,40 +213,27 @@ transforms: {
     ]
 },
 ```
-{% end %}
-
-An existing shortcode can be transformed into its block counterpart.
-
-{% codetabs %}
 {% ES5 %}
 ```js
 transforms: {
     from: [
         {
-            type: 'shortcode',
-            // Shortcode tag can also be an array of shortcode aliases
-            tag: 'caption',
-            attributes: {
-                // An attribute can be source from a tag attribute in the shortcode content
-                url: {
-                    type: 'string',
-                    source: 'attribute',
-                    attribute: 'src',
-                    selector: 'img',
-                },
-                // An attribute can be source from the shortcode attributes
-                align: {
-                    type: 'string',
-                    shortcode: function( attributes ) {
-                        var align = attributes.named.align ? attributes.named.align : 'alignnone';
-                        return align.replace( 'align', '' );
-                    },
-                },
+            type: 'block',
+            blocks: [ 'core/paragraph' ],
+            transform: function ( attributes ) {
+                return createBlock( 'core/heading', {
+                    content: attributes.content,
+                } );
             },
         },
     ]
 },
 ```
+{% end %}
+
+An existing shortcode can be transformed into its block counterpart.
+
+{% codetabs %}
 {% ESNext %}
 ```js
 transforms: {
@@ -292,27 +263,40 @@ transforms: {
 },
 
 ```
+{% ES5 %}
+```js
+transforms: {
+    from: [
+        {
+            type: 'shortcode',
+            // Shortcode tag can also be an array of shortcode aliases
+            tag: 'caption',
+            attributes: {
+                // An attribute can be source from a tag attribute in the shortcode content
+                url: {
+                    type: 'string',
+                    source: 'attribute',
+                    attribute: 'src',
+                    selector: 'img',
+                },
+                // An attribute can be source from the shortcode attributes
+                align: {
+                    type: 'string',
+                    shortcode: function( attributes ) {
+                        var align = attributes.named.align ? attributes.named.align : 'alignnone';
+                        return align.replace( 'align', '' );
+                    },
+                },
+            },
+        },
+    ]
+},
+```
 {% end %}
 
 A block can also be transformed into another block type. For example, a Heading block can be transformed into a Paragraph block.
 
 {% codetabs %}
-{% ES5 %}
-```js
-transforms: {
-    to: [
-        {
-            type: 'block',
-            blocks: [ 'core/paragraph' ],
-            transform: function( attributes ) {
-                return createBlock( 'core/paragraph', {
-                    content: attributes.content,
-                } );
-            },
-        },
-    ],
-},
-```
 {% ESNext %}
 ```js
 transforms: {
@@ -329,25 +313,27 @@ transforms: {
     ],
 },
 ```
-{% end %}
-
-In addition to accepting an array of known block types, the `blocks` option also accepts a "wildcard" (`"*"`). This allows for transformations which apply to _all_ block types (eg: all blocks can transform into `core/group`):
-
-{% codetabs %}
 {% ES5 %}
 ```js
 transforms: {
-    from: [
+    to: [
         {
             type: 'block',
-            blocks: [ '*' ], // wildcard - match any block
-            transform: function( attributes, innerBlocks ) {
-                // transform logic here
+            blocks: [ 'core/paragraph' ],
+            transform: function( attributes ) {
+                return createBlock( 'core/paragraph', {
+                    content: attributes.content,
+                } );
             },
         },
     ],
 },
 ```
+{% end %}
+
+In addition to accepting an array of known block types, the `blocks` option also accepts a "wildcard" (`"*"`). This allows for transformations which apply to _all_ block types (eg: all blocks can transform into `core/group`):
+
+{% codetabs %}
 {% ESNext %}
 ```js
 transforms: {
@@ -362,26 +348,26 @@ transforms: {
     ],
 },
 ```
+{% ES5 %}
+```js
+transforms: {
+    from: [
+        {
+            type: 'block',
+            blocks: [ '*' ], // wildcard - match any block
+            transform: function( attributes, innerBlocks ) {
+                // transform logic here
+            },
+        },
+    ],
+},
+```
 {% end %}
 
 
 A block with InnerBlocks can also be transformed from and to another block with InnerBlocks.
 
 {% codetabs %}
-{% ES5 %}
-```js
-transforms: {
-    to: [
-        {
-            type: 'block',
-            blocks: [ 'some/block-with-innerblocks' ],
-            transform: function( attributes, innerBlocks ) {
-                return createBlock( 'some/other-block-with-innerblocks', attributes, innerBlocks );
-            },
-        },
-    ],
-},
-```
 {% ESNext %}
 ```js
 transforms: {
@@ -396,30 +382,25 @@ transforms: {
     ],
 },
 ```
-{% end %}
-
-An optional `isMatch` function can be specified on a transform object. This provides an opportunity to perform additional checks on whether a transform should be possible. Returning `false` from this function will prevent the transform from being displayed as an option to the user.
-
-{% codetabs %}
 {% ES5 %}
 ```js
 transforms: {
     to: [
         {
             type: 'block',
-			blocks: [ 'core/paragraph' ],
-			isMatch: function( attributes ) {
-				return attributes.isText;
-			},
-            transform: function( attributes ) {
-                return createBlock( 'core/paragraph', {
-                    content: attributes.content,
-                } );
+            blocks: [ 'some/block-with-innerblocks' ],
+            transform: function( attributes, innerBlocks ) {
+                return createBlock( 'some/other-block-with-innerblocks', attributes, innerBlocks );
             },
         },
     ],
 },
 ```
+{% end %}
+
+An optional `isMatch` function can be specified on a transform object. This provides an opportunity to perform additional checks on whether a transform should be possible. Returning `false` from this function will prevent the transform from being displayed as an option to the user.
+
+{% codetabs %}
 {% ESNext %}
 ```js
 transforms: {
@@ -437,6 +418,25 @@ transforms: {
     ],
 },
 ```
+{% ES5 %}
+```js
+transforms: {
+    to: [
+        {
+            type: 'block',
+            blocks: [ 'core/paragraph' ],
+            isMatch: function( attributes ) {
+                return attributes.isText;
+            },
+            transform: function( attributes ) {
+                return createBlock( 'core/paragraph', {
+                    content: attributes.content,
+                } );
+            },
+        },
+    ],
+},
+```
 {% end %}
 
 To control the priority with which a transform is applied, define a `priority` numeric property on your transform object, where a lower value will take precedence over higher values. This behaves much like a [WordPress hook](https://codex.wordpress.org/Plugin_API#Hook_to_WordPress). Like hooks, the default priority is `10` when not otherwise set.
@@ -444,33 +444,6 @@ To control the priority with which a transform is applied, define a `priority` n
 A file can be dropped into the editor and converted into a block with a matching transform.
 
 {% codetabs %}
-{% ES5 %}
-```js
-transforms: {
-	from: [
-		{
-			type: 'files',
-			isMatch: function ( files ) {
-				return files.length === 1;
-			},
-			// We define a lower priority (higher number) than the default of 10. This
-			// ensures that the File block is only created as a fallback.
-			priority: 15,
-			transform: function( files ) {
-				var file = files[ 0 ];
-				var blobURL = createBlobURL( file );
-
-				// File will be uploaded in componentDidMount()
-				return createBlock( 'core/file', {
-					href: blobURL,
-					fileName: file.name,
-					textLinkHref: blobURL,
-				} );
-			},
-		},
-	]
-}
-```
 {% ESNext %}
 ```js
 transforms: {
@@ -496,27 +469,38 @@ transforms: {
 	]
 }
 ```
-{% end %}
-
-A prefix transform is a transform that will be applied if the user prefixes some text in e.g. the Paragraph block with a given pattern and a trailing space.
-
-{% codetabs %}
 {% ES5 %}
 ```js
 transforms: {
     from: [
         {
-            type: 'prefix',
-            prefix: '?',
-            transform: function( content ) {
-                return createBlock( 'my-plugin/question', {
-                    content,
+            type: 'files',
+            isMatch: function ( files ) {
+                return files.length === 1;
+            },
+            // We define a lower priority (higher number) than the default of 10. This
+            // ensures that the File block is only created as a fallback.
+            priority: 15,
+            transform: function( files ) {
+                var file = files[ 0 ];
+                var blobURL = createBlobURL( file );
+
+                // File will be uploaded in componentDidMount()
+                return createBlock( 'core/file', {
+                    href: blobURL,
+                    fileName: file.name,
+                    textLinkHref: blobURL,
                 } );
             },
         },
     ]
 }
 ```
+{% end %}
+
+A prefix transform is a transform that will be applied if the user prefixes some text in e.g. the Paragraph block with a given pattern and a trailing space.
+
+{% codetabs %}
 {% ESNext %}
 ```js
 transforms: {
@@ -525,6 +509,22 @@ transforms: {
             type: 'prefix',
             prefix: '?',
             transform( content ) {
+                return createBlock( 'my-plugin/question', {
+                    content,
+                } );
+            },
+        },
+    ]
+}
+```
+{% ES5 %}
+```js
+transforms: {
+    from: [
+        {
+            type: 'prefix',
+            prefix: '?',
+            transform: function( content ) {
                 return createBlock( 'my-plugin/question', {
                     content,
                 } );


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

Following up from the meeting, I switch the placement of the Code tabs for JS type in the `block-registration` page.

```
{% codetabs %}
{% ESNext %}
```js
transforms: {
    from: [
        {
            type: 'prefix',
            prefix: '?',
            transform( content ) {
                return createBlock( 'my-plugin/question', {
                    content,
                } );
            },
        },
    ]
}
```
{% ES5 %}
```js
transforms: {
    from: [
        {
            type: 'prefix',
            prefix: '?',
            transform: function( content ) {
                return createBlock( 'my-plugin/question', {
                    content,
                } );
            },
        },
    ]
}
```
{% end %}```

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

Not sure how to test, but I'd like to

<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
