### PR TITLE
Popover: consistently adjust position on scroll

### DIFF
--- a/packages/block-editor/src/components/rich-text/format-toolbar-container.js
+++ b/packages/block-editor/src/components/rich-text/format-toolbar-container.js
@@ -9,31 +9,7 @@ import { Popover } from '@wordpress/components';
 import BlockFormatControls from '../block-format-controls';
 import FormatToolbar from './format-toolbar';
 
-function getAnchorRect( anchorObj ) {
-	const { current } = anchorObj;
-	const rect = current.getBoundingClientRect();
-
-	// Add some space.
-	const buffer = 6;
-
-	// Subtract padding if any.
-	let { paddingTop } = window.getComputedStyle( current );
-
-	paddingTop = parseInt( paddingTop, 10 );
-
-	return {
-		x: rect.left,
-		y: rect.top + paddingTop - buffer,
-		width: rect.width,
-		height: rect.height - paddingTop + buffer,
-		left: rect.left,
-		right: rect.right,
-		top: rect.top + paddingTop - buffer,
-		bottom: rect.bottom,
-	};
-}
-
-const FormatToolbarContainer = ( { inline, anchorObj } ) => {
+const FormatToolbarContainer = ( { inline, anchorRef } ) => {
 	if ( inline ) {
 		// Render in popover
 		return (
@@ -41,7 +17,8 @@ const FormatToolbarContainer = ( { inline, anchorObj } ) => {
 				noArrow
 				position="top center"
 				focusOnMount={ false }
-				getAnchorRect={ () => getAnchorRect( anchorObj ) }
+				anchorVerticalBuffer={ 6 }
+				anchorRef={ anchorRef }
 				className="block-editor-rich-text__inline-format-toolbar"
 			>
 				<FormatToolbar />

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -404,7 +404,7 @@ class RichTextWrapper extends Component {
 				{ ( { isSelected, value, onChange, Editable } ) =>
 					<>
 						{ children && children( { value, onChange } ) }
-						{ isSelected && hasFormats && ( <FormatToolbarContainer inline={ inlineToolbar } anchorObj={ this.ref } /> ) }
+						{ isSelected && hasFormats && ( <FormatToolbarContainer inline={ inlineToolbar } anchorRef={ this.ref.current } /> ) }
 						{ isSelected && <RemoveBrowserShortcuts /> }
 						<Autocomplete
 							onReplace={ onReplace }

--- a/packages/components/src/autocomplete/index.js
+++ b/packages/components/src/autocomplete/index.js
@@ -18,7 +18,6 @@ import {
 	isCollapsed,
 	getTextContent,
 } from '@wordpress/rich-text';
-import { getRectangleFromRange } from '@wordpress/dom';
 
 /**
  * Internal dependencies
@@ -130,13 +129,9 @@ function filterOptions( search, options = [], maxResults = 10 ) {
 	return filtered;
 }
 
-function getCaretRect() {
+function getRange() {
 	const selection = window.getSelection();
-	const range = selection.rangeCount ? selection.getRangeAt( 0 ) : null;
-
-	if ( range ) {
-		return getRectangleFromRange( range );
-	}
+	return selection.rangeCount ? selection.getRangeAt( 0 ) : null;
 }
 
 export class Autocomplete extends Component {
@@ -426,7 +421,7 @@ export class Autocomplete extends Component {
 						onClose={ this.reset }
 						position="top right"
 						className="components-autocomplete__popover"
-						getAnchorRect={ getCaretRect }
+						anchorRef={ getRange() }
 					>
 						<div
 							id={ listBoxId }

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { useRef, useState, useEffect } from '@wordpress/element';
-import { focus } from '@wordpress/dom';
+import { focus, getRectangleFromRange } from '@wordpress/dom';
 import { ESCAPE } from '@wordpress/keycodes';
 import isShallowEqual from '@wordpress/is-shallow-equal';
 import deprecated from '@wordpress/deprecated';
@@ -62,48 +62,135 @@ function useThrottledWindowScrollOrResize( handler, ignoredScrollableRef ) {
 	}, [] );
 }
 
-/**
- * Hook used to compute and update the anchor position properly.
- *
- * @param {Object} anchorRef       reference to the popover anchor element.
- * @param {Object} contentRef      reference to the popover content element.
- * @param {Object} anchorRect      anchor Rect prop used to override the computed value.
- * @param {Function} getAnchorRect function used to override the anchor value computation algorithm.
- *
- * @return {Object} Anchor position.
- */
-function useAnchor( anchorRef, contentRef, anchorRect, getAnchorRect ) {
-	const [ anchor, setAnchor ] = useState( null );
-	const refreshAnchorRect = () => {
-		if ( ! anchorRef.current ) {
+function computeAnchorRect(
+	anchorRefFallback,
+	anchorRect,
+	getAnchorRect,
+	anchorRef = false,
+	anchorIncludePadding
+) {
+	if ( anchorRect ) {
+		return anchorRect;
+	}
+
+	if ( getAnchorRect ) {
+		if ( ! anchorRefFallback.current ) {
 			return;
 		}
 
-		let newAnchor;
-		if ( anchorRect ) {
-			newAnchor = anchorRect;
-		} else if ( getAnchorRect ) {
-			newAnchor = getAnchorRect( anchorRef.current );
-		} else {
-			const rect = anchorRef.current.parentNode.getBoundingClientRect();
-			// subtract padding
-			const { paddingTop, paddingBottom } = window.getComputedStyle( anchorRef.current.parentNode );
-			const topPad = parseInt( paddingTop, 10 );
-			const bottomPad = parseInt( paddingBottom, 10 );
-			newAnchor = {
-				x: rect.left,
-				y: rect.top + topPad,
-				width: rect.width,
-				height: rect.height - topPad - bottomPad,
-				left: rect.left,
-				right: rect.right,
-				top: rect.top + topPad,
-				bottom: rect.bottom - bottomPad,
-			};
+		return getAnchorRect( anchorRefFallback.current );
+	}
+
+	if ( anchorRef !== false ) {
+		if ( ! anchorRef ) {
+			return;
 		}
 
-		const didAnchorRectChange = ! isShallowEqual( newAnchor, anchor );
-		if ( didAnchorRectChange ) {
+		if ( anchorRef instanceof window.Range ) {
+			return getRectangleFromRange( anchorRef );
+		}
+
+		const rect = anchorRef.getBoundingClientRect();
+
+		if ( anchorIncludePadding ) {
+			return rect;
+		}
+
+		return withoutPadding( rect, anchorRef );
+	}
+
+	if ( ! anchorRefFallback.current ) {
+		return;
+	}
+
+	const { parentNode } = anchorRefFallback.current;
+	const rect = parentNode.getBoundingClientRect();
+
+	if ( anchorIncludePadding ) {
+		return rect;
+	}
+
+	return withoutPadding( rect, parentNode );
+}
+
+function addBuffer( rect, verticalBuffer = 0, horizontalBuffer = 0 ) {
+	return {
+		x: rect.left - horizontalBuffer,
+		y: rect.top - verticalBuffer,
+		width: rect.width + ( 2 * horizontalBuffer ),
+		height: rect.height + ( 2 * verticalBuffer ),
+		left: rect.left - horizontalBuffer,
+		right: rect.right + horizontalBuffer,
+		top: rect.top - verticalBuffer,
+		bottom: rect.bottom + verticalBuffer,
+	};
+}
+
+function withoutPadding( rect, element ) {
+	const {
+		paddingTop,
+		paddingBottom,
+		paddingLeft,
+		paddingRight,
+	} = window.getComputedStyle( element );
+	const top = paddingTop ? parseInt( paddingTop, 10 ) : 0;
+	const bottom = paddingBottom ? parseInt( paddingBottom, 10 ) : 0;
+	const left = paddingLeft ? parseInt( paddingLeft, 10 ) : 0;
+	const right = paddingRight ? parseInt( paddingRight, 10 ) : 0;
+
+	return {
+		x: rect.left + left,
+		y: rect.top + top,
+		width: rect.width - left - right,
+		height: rect.height - top - bottom,
+		left: rect.left + left,
+		right: rect.right - right,
+		top: rect.top + top,
+		bottom: rect.bottom - bottom,
+	};
+}
+
+/**
+ * Hook used to compute and update the anchor position properly.
+ *
+ * @param {Object}   anchorRefFallback      Reference to the popover anchor fallback element.
+ * @param {Object}   contentRef             Reference to the popover content element.
+ * @param {Object}   anchorRect             Anchor Rect prop used to override the computed value.
+ * @param {Function} getAnchorRect          Function used to override the anchor value computation algorithm.
+ * @param {Object}   anchorRef              Reference to the popover anchor fallback element.
+ * @param {Object}   anchorIncludePadding   Whether to include the anchor padding.
+ * @param {Object}   anchorVerticalBuffer   Vertical buffer for the anchor.
+ * @param {Object}   anchorHorizontalBuffer Horizontal buffer for the anchor.
+ *
+ * @return {Object} Anchor position.
+ */
+function useAnchor(
+	anchorRefFallback,
+	contentRef,
+	anchorRect,
+	getAnchorRect,
+	anchorRef,
+	anchorIncludePadding,
+	anchorVerticalBuffer,
+	anchorHorizontalBuffer
+) {
+	const [ anchor, setAnchor ] = useState( null );
+	const refreshAnchorRect = () => {
+		let newAnchor = computeAnchorRect(
+			anchorRefFallback,
+			anchorRect,
+			getAnchorRect,
+			anchorRef,
+			anchorIncludePadding
+		);
+
+		newAnchor = addBuffer(
+			newAnchor,
+			anchorVerticalBuffer,
+			anchorHorizontalBuffer
+		);
+
+		if ( ! isShallowEqual( newAnchor, anchor ) ) {
 			setAnchor( newAnchor );
 		}
 	};
@@ -259,6 +346,10 @@ const Popover = ( {
 	position = 'top',
 	range,
 	focusOnMount = 'firstElement',
+	anchorRef,
+	anchorIncludePadding,
+	anchorVerticalBuffer,
+	anchorHorizontalBuffer,
 	anchorRect,
 	getAnchorRect,
 	expandOnMobile,
@@ -268,14 +359,23 @@ const Popover = ( {
 	/* eslint-enable no-unused-vars */
 	...contentProps
 } ) => {
-	const anchorRef = useRef( null );
+	const anchorRefFallback = useRef( null );
 	const contentRef = useRef( null );
 
 	// Animation
 	const [ isReadyToAnimate, setIsReadyToAnimate ] = useState( false );
 
 	// Anchor position
-	const anchor = useAnchor( anchorRef, contentRef, anchorRect, getAnchorRect );
+	const anchor = useAnchor(
+		anchorRefFallback,
+		contentRef,
+		anchorRect,
+		getAnchorRect,
+		anchorRef,
+		anchorIncludePadding,
+		anchorVerticalBuffer,
+		anchorHorizontalBuffer
+	);
 
 	// Content size
 	const contentSize = useInitialContentSize( contentRef );
@@ -438,7 +538,7 @@ const Popover = ( {
 				}
 
 				return (
-					<span ref={ anchorRef }>
+					<span ref={ anchorRefFallback }>
 						{ content }
 						{ popoverPosition.isMobile && expandOnMobile && <ScrollLock /> }
 					</span>

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -157,7 +157,7 @@ function withoutPadding( rect, element ) {
  * @param {Object}        contentRef                 Reference to the popover content element.
  * @param {Object}        anchorRect                 Anchor Rect prop used to override the computed value.
  * @param {Function}      getAnchorRect              Function used to override the anchor value computation algorithm.
- * @param {Element|Range} anchorRef                  Reference to the popover anchor fallback element.
+ * @param {Element|Range} anchorRef                  A live element or range reference.
  * @param {boolean}       shouldAnchorIncludePadding Whether to include the anchor padding.
  * @param {number}        anchorVerticalBuffer       Vertical buffer for the anchor.
  * @param {number}        anchorHorizontalBuffer     Horizontal buffer for the anchor.

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -67,7 +67,7 @@ function computeAnchorRect(
 	anchorRect,
 	getAnchorRect,
 	anchorRef = false,
-	anchorIncludePadding
+	shouldAnchorIncludePadding
 ) {
 	if ( anchorRect ) {
 		return anchorRect;
@@ -92,7 +92,7 @@ function computeAnchorRect(
 
 		const rect = anchorRef.getBoundingClientRect();
 
-		if ( anchorIncludePadding ) {
+		if ( shouldAnchorIncludePadding ) {
 			return rect;
 		}
 
@@ -106,7 +106,7 @@ function computeAnchorRect(
 	const { parentNode } = anchorRefFallback.current;
 	const rect = parentNode.getBoundingClientRect();
 
-	if ( anchorIncludePadding ) {
+	if ( shouldAnchorIncludePadding ) {
 		return rect;
 	}
 
@@ -153,14 +153,14 @@ function withoutPadding( rect, element ) {
 /**
  * Hook used to compute and update the anchor position properly.
  *
- * @param {Object}   anchorRefFallback      Reference to the popover anchor fallback element.
- * @param {Object}   contentRef             Reference to the popover content element.
- * @param {Object}   anchorRect             Anchor Rect prop used to override the computed value.
- * @param {Function} getAnchorRect          Function used to override the anchor value computation algorithm.
- * @param {Object}   anchorRef              Reference to the popover anchor fallback element.
- * @param {Object}   anchorIncludePadding   Whether to include the anchor padding.
- * @param {Object}   anchorVerticalBuffer   Vertical buffer for the anchor.
- * @param {Object}   anchorHorizontalBuffer Horizontal buffer for the anchor.
+ * @param {Object}        anchorRefFallback          Reference to the popover anchor fallback element.
+ * @param {Object}        contentRef                 Reference to the popover content element.
+ * @param {Object}        anchorRect                 Anchor Rect prop used to override the computed value.
+ * @param {Function}      getAnchorRect              Function used to override the anchor value computation algorithm.
+ * @param {Element|Range} anchorRef                  Reference to the popover anchor fallback element.
+ * @param {boolean}       shouldAnchorIncludePadding Whether to include the anchor padding.
+ * @param {number}        anchorVerticalBuffer       Vertical buffer for the anchor.
+ * @param {number}        anchorHorizontalBuffer     Horizontal buffer for the anchor.
  *
  * @return {Object} Anchor position.
  */
@@ -170,7 +170,7 @@ function useAnchor(
 	anchorRect,
 	getAnchorRect,
 	anchorRef,
-	anchorIncludePadding,
+	shouldAnchorIncludePadding,
 	anchorVerticalBuffer,
 	anchorHorizontalBuffer
 ) {
@@ -181,7 +181,7 @@ function useAnchor(
 			anchorRect,
 			getAnchorRect,
 			anchorRef,
-			anchorIncludePadding
+			shouldAnchorIncludePadding
 		);
 
 		newAnchor = addBuffer(
@@ -241,11 +241,11 @@ function useInitialContentSize( ref ) {
  * Hook used to compute and update the position of the popover
  * based on the anchor position and the content size.
  *
- * @param {Object} anchor          Anchor Position.
- * @param {Object} contentSize     Content Size.
- * @param {string} position        Position prop.
- * @param {boolean} expandOnMobile Whether to show the popover full width on mobile.
- * @param {Object} contentRef      Reference to the popover content element.
+ * @param {Object}  anchor          Anchor Position.
+ * @param {Object}  contentSize     Content Size.
+ * @param {string}  position        Position prop.
+ * @param {boolean} expandOnMobile  Whether to show the popover full width on mobile.
+ * @param {Object}  contentRef      Reference to the popover content element.
  *
  * @return {Object} Popover position.
  */
@@ -293,7 +293,7 @@ function usePopoverPosition( anchor, contentSize, position, expandOnMobile, cont
  * Hook used to focus the first tabbable element on mount.
  *
  * @param {boolean|string} focusOnMount Focus on mount mode.
- * @param {Object} contentRef           Reference to the popover content element.
+ * @param {Object}         contentRef   Reference to the popover content element.
  */
 function useFocusContentOnMount( focusOnMount, contentRef ) {
 	// Focus handling
@@ -347,7 +347,7 @@ const Popover = ( {
 	range,
 	focusOnMount = 'firstElement',
 	anchorRef,
-	anchorIncludePadding,
+	shouldAnchorIncludePadding,
 	anchorVerticalBuffer,
 	anchorHorizontalBuffer,
 	anchorRect,
@@ -372,7 +372,7 @@ const Popover = ( {
 		anchorRect,
 		getAnchorRect,
 		anchorRef,
-		anchorIncludePadding,
+		shouldAnchorIncludePadding,
 		anchorVerticalBuffer,
 		anchorHorizontalBuffer
 	);

--- a/packages/format-library/src/image/index.js
+++ b/packages/format-library/src/image/index.js
@@ -3,11 +3,10 @@
  */
 import { Path, SVG, TextControl, Popover, IconButton } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { Component, useMemo } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import { insertObject } from '@wordpress/rich-text';
 import { MediaUpload, RichTextToolbarButton, MediaUploadCheck } from '@wordpress/block-editor';
 import { LEFT, RIGHT, UP, DOWN, BACKSPACE, ENTER } from '@wordpress/keycodes';
-import { computeCaretRect } from '@wordpress/dom';
 
 const ALLOWED_MEDIA_TYPES = [ 'image' ];
 
@@ -16,16 +15,10 @@ const title = __( 'Inline image' );
 
 const stopKeyPropagation = ( event ) => event.stopPropagation();
 
-const PopoverAtImage = ( { dependencies, ...props } ) => {
-	return (
-		<Popover
-			position="bottom center"
-			focusOnMount={ false }
-			anchorRect={ useMemo( () => computeCaretRect(), dependencies ) }
-			{ ...props }
-		/>
-	);
-};
+function getRange() {
+	const selection = window.getSelection();
+	return selection.rangeCount ? selection.getRangeAt( 0 ) : null;
+}
 
 export const image = {
 	name,
@@ -93,7 +86,6 @@ export const image = {
 
 		render() {
 			const { value, onChange, isObjectActive, activeObjectAttributes } = this.props;
-			const { style } = activeObjectAttributes;
 
 			return (
 				<MediaUploadCheck>
@@ -124,10 +116,10 @@ export const image = {
 						} }
 					/> }
 					{ isObjectActive &&
-						<PopoverAtImage
-							// Reposition Popover when the selection changes or
-							// when the width changes.
-							dependencies={ [ style, value.start ] }
+						<Popover
+							position="bottom center"
+							focusOnMount={ false }
+							anchorRef={ getRange() }
 						>
 							{ // Disable reason: KeyPress must be suppressed so the block doesn't hide the toolbar
 							/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */ }
@@ -165,7 +157,7 @@ export const image = {
 								<IconButton icon="editor-break" label={ __( 'Apply' ) } type="submit" />
 							</form>
 							{ /* eslint-enable jsx-a11y/no-noninteractive-element-interactions */ }
-						</PopoverAtImage>
+						</Popover>
 					}
 				</MediaUploadCheck>
 			);

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -8,7 +8,6 @@ import {
 	withSpokenMessages,
 } from '@wordpress/components';
 import { LEFT, RIGHT, UP, DOWN, BACKSPACE, ENTER } from '@wordpress/keycodes';
-import { getRectangleFromRange } from '@wordpress/dom';
 import { prependHTTP } from '@wordpress/url';
 import {
 	create,
@@ -32,15 +31,17 @@ function isShowingInput( props, state ) {
 }
 
 const URLPopoverAtLink = ( { isActive, addingLink, value, ...props } ) => {
-	const anchorRect = useMemo( () => {
+	const anchorRef = useMemo( () => {
 		const selection = window.getSelection();
-		const range = selection.rangeCount > 0 ? selection.getRangeAt( 0 ) : null;
-		if ( ! range ) {
+
+		if ( ! selection.rangeCount ) {
 			return;
 		}
 
+		const range = selection.getRangeAt( 0 );
+
 		if ( addingLink ) {
-			return getRectangleFromRange( range );
+			return range;
 		}
 
 		let element = range.startContainer;
@@ -52,17 +53,14 @@ const URLPopoverAtLink = ( { isActive, addingLink, value, ...props } ) => {
 			element = element.parentNode;
 		}
 
-		const closest = element.closest( 'a' );
-		if ( closest ) {
-			return closest.getBoundingClientRect();
-		}
+		return element.closest( 'a' );
 	}, [ isActive, addingLink, value.start, value.end ] );
 
-	if ( ! anchorRect ) {
+	if ( ! anchorRef ) {
 		return null;
 	}
 
-	return <URLPopover anchorRect={ anchorRect } { ...props } />;
+	return <URLPopover anchorRef={ anchorRef } { ...props } />;
 };
 
 class InlineLinkUI extends Component {

--- a/packages/nux/src/components/dot-tip/index.js
+++ b/packages/nux/src/components/dot-tip/index.js
@@ -44,7 +44,7 @@ export function DotTip( {
 			position={ position }
 			noArrow
 			focusOnMount="container"
-			anchorIncludePadding
+			shouldAnchorIncludePadding
 			role="dialog"
 			aria-label={ __( 'Editor tips' ) }
 			onClick={ onClick }

--- a/packages/nux/src/components/dot-tip/index.js
+++ b/packages/nux/src/components/dot-tip/index.js
@@ -7,13 +7,6 @@ import { __ } from '@wordpress/i18n';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { useCallback, useRef } from '@wordpress/element';
 
-function getAnchorRect( anchor ) {
-	// The default getAnchorRect() excludes an element's top and bottom padding
-	// from its calculation. We want tips to point to the outer margin of an
-	// element, so we override getAnchorRect() to include all padding.
-	return anchor.parentNode.getBoundingClientRect();
-}
-
 function onClick( event ) {
 	// Tips are often nested within buttons. We stop propagation so that clicking
 	// on a tip doesn't result in the button being clicked.
@@ -29,13 +22,6 @@ export function DotTip( {
 	onDisable,
 } ) {
 	const anchorParent = useRef( null );
-	const getAnchorRectCallback = useCallback(
-		( anchor ) => {
-			anchorParent.current = anchor.parentNode;
-			return getAnchorRect( anchor );
-		},
-		[ anchorParent ]
-	);
 	const onFocusOutsideCallback = useCallback(
 		( event ) => {
 			if ( ! anchorParent.current ) {
@@ -58,7 +44,7 @@ export function DotTip( {
 			position={ position }
 			noArrow
 			focusOnMount="container"
-			getAnchorRect={ getAnchorRectCallback }
+			anchorIncludePadding
 			role="dialog"
 			aria-label={ __( 'Editor tips' ) }
 			onClick={ onClick }

--- a/packages/nux/src/components/dot-tip/test/__snapshots__/index.js.snap
+++ b/packages/nux/src/components/dot-tip/test/__snapshots__/index.js.snap
@@ -2,7 +2,7 @@
 
 exports[`DotTip should render correctly 1`] = `
 <Popover
-  anchorIncludePadding={true}
+  shouldAnchorIncludePadding={true}
   aria-label="Editor tips"
   className="nux-dot-tip"
   focusOnMount="container"

--- a/packages/nux/src/components/dot-tip/test/__snapshots__/index.js.snap
+++ b/packages/nux/src/components/dot-tip/test/__snapshots__/index.js.snap
@@ -2,10 +2,10 @@
 
 exports[`DotTip should render correctly 1`] = `
 <Popover
+  anchorIncludePadding={true}
   aria-label="Editor tips"
   className="nux-dot-tip"
   focusOnMount="container"
-  getAnchorRect={[Function]}
   noArrow={true}
   onClick={[Function]}
   onFocusOutside={[Function]}

--- a/packages/nux/src/components/dot-tip/test/__snapshots__/index.js.snap
+++ b/packages/nux/src/components/dot-tip/test/__snapshots__/index.js.snap
@@ -2,7 +2,6 @@
 
 exports[`DotTip should render correctly 1`] = `
 <Popover
-  shouldAnchorIncludePadding={true}
   aria-label="Editor tips"
   className="nux-dot-tip"
   focusOnMount="container"
@@ -11,6 +10,7 @@ exports[`DotTip should render correctly 1`] = `
   onFocusOutside={[Function]}
   position="middle right"
   role="dialog"
+  shouldAnchorIncludePadding={true}
 >
   <p>
     It looks like you’re writing a letter. Would you like help?


### PR DESCRIPTION
## Description

Currently some popovers won't reposition when the page is scrolled. These include: the link popover, image, and autocomplete.

The problem is that the rectangle is NOT calculated by `Popover`, but by the component implementing it. In other word, the `anchorRect` is no good if you want the popover to reposition on scroll. I'm not sure what the prop would be good for, so perhaps we should look into deprecating it if no core components use it.

`getAnchorRect` would be an option, but I believe we can provide a better API than that. Some implementation might want to adjust the rectangle: add a buffer or include the padding of the target anchor. It seems much cleaner for the implementor to just pass the anchor reference, and let `Popover` compute the anchor rect and adjust it when needed.

So I added a few more props for the `Popover` component. The old ones will still continue to work.

* `anchorRef`: a reference to the anchor, which can be either an `Element` or a `Range` (the browser can give us a `DOMRect` for both of these).
* `anchorIncludePadding`: can be used if you want to include the anchor padding when creating a rectangle.
* `anchorVerticalBuffer` and `anchorHorizontalBuffer` can be used to add a buffer/offset between the anchor and the popover.

## How has this been tested?

Open the link, image, or slash command popover. Scroll the page.

## Screenshots <!-- if applicable -->

![popover-scroll](https://user-images.githubusercontent.com/4710635/66493859-109ab580-eab7-11e9-987d-479879179715.gif)

## Types of changes

Bug fix.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
