### PR TITLE
RichText: don't continuously reset selection

### DIFF
--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -448,12 +448,20 @@ class RichText extends Component {
 			// set correctly to zero, but the caret is not visible. By
 			// reapplying the value to the DOM we reset the selection to the
 			// right node, making the caret visible again.
-			if ( value.text.length === 0 && start === 0 ) {
+			if (
+				value.text.length === 0 &&
+				start === 0 &&
+				// Only do this once.
+				! this.onSelectionChange.isCaretVisible
+			) {
 				this.applyRecord( value );
+				this.onSelectionChange.isCaretVisible = true;
 			}
 
 			return;
 		}
+
+		this.onSelectionChange.isCaretVisible = false;
 
 		const {
 			__unstableIsCaretWithinFormattedText: isCaretWithinFormattedText,

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -100,7 +100,7 @@ function fixPlaceholderSelection() {
 		return;
 	}
 
-	window.getSelection().collapseToStart();
+	selection.collapseToStart();
 }
 
 /**

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -79,6 +79,31 @@ function createPrepareEditableTree( props, prefix ) {
 }
 
 /**
+ * If the selection is set on the placeholder element, collapse the selection to
+ * the start (before the placeholder).
+ */
+function fixPlaceholderSelection() {
+	const selection = window.getSelection();
+	const { anchorNode, anchorOffset } = selection;
+
+	if ( anchorNode.nodeType !== anchorNode.ELEMENT_NODE ) {
+		return;
+	}
+
+	const targetNode = anchorNode.childNodes[ anchorOffset ];
+
+	if (
+		! targetNode ||
+		targetNode.nodeType !== targetNode.ELEMENT_NODE ||
+		! targetNode.getAttribute( 'data-rich-text-placeholder' )
+	) {
+		return;
+	}
+
+	window.getSelection().collapseToStart();
+}
+
+/**
  * See export statement below.
  */
 class RichText extends Component {
@@ -442,26 +467,15 @@ class RichText extends Component {
 		}
 
 		if ( start === value.start && end === value.end ) {
-			// If a placeholder is set, some browsers seems to place the
-			// selection after the placeholder instead of the text node that is
-			// padding the empty container element. The internal selection is
-			// set correctly to zero, but the caret is not visible. By
-			// reapplying the value to the DOM we reset the selection to the
-			// right node, making the caret visible again.
-			if (
-				value.text.length === 0 &&
-				start === 0 &&
-				// Only do this once.
-				! this.onSelectionChange.isCaretVisible
-			) {
-				this.applyRecord( value );
-				this.onSelectionChange.isCaretVisible = true;
+			// Sometimes the browser may set the selection on the placeholder
+			// element, in which case the caret is not visible. We need to set
+			// the caret before the placeholder if that's the case.
+			if ( value.text.length === 0 && start === 0 ) {
+				fixPlaceholderSelection();
 			}
 
 			return;
 		}
-
-		this.onSelectionChange.isCaretVisible = false;
 
 		const {
 			__unstableIsCaretWithinFormattedText: isCaretWithinFormattedText,


### PR DESCRIPTION
## Description

Fixes #17729. Sets some conditions so fixing the selection doesn’t cause an infinite selection change event loop.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

See #17729. Also ensure there is a carry visible after clicking on a rich text area that has a placeholder set to stay visible after focus.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
