### PR TITLE
Fix Block Controls behavior for List Block.

### DIFF
--- a/packages/block-library/src/list/edit.js
+++ b/packages/block-library/src/list/edit.js
@@ -35,12 +35,8 @@ export default function ListEdit( {
 	const { ordered, values, reversed, start } = attributes;
 	const tagName = ordered ? 'ol' : 'ul';
 
-	const controls = ( { value, onChange } ) => {
-		if ( value.start === undefined ) {
-			return;
-		}
-
-		return <>
+	const controls = ( { value, onChange } ) => (
+		<>
 			<RichTextShortcut
 				type="primary"
 				character="["
@@ -115,8 +111,8 @@ export default function ListEdit( {
 					] }
 				/>
 			</BlockControls>
-		</>;
-	};
+		</>
+	);
 
 	return <>
 		<RichText


### PR DESCRIPTION
## Description
When toggling between Bulleted List and Numbered List, the Block Controls for List block disappears. You have to click inside the block to get them back. Ideally, the Block Controls should always be present, if the block is selected.

This seems to be introduced with #16962. Not sure if this behaviour is intentional or it's a legit bug. Happy to decline this PR if there's a reasoning behind current behaviour. @ellatrix would know better here.

## How has this been tested?
After the fix is applied, the Block Controls always stays in the toolbar. So that I can easily toggle between Bulleted/Numbered List.

## Screenshots
**Before**
![2019-10-10 17 58 43](https://user-images.githubusercontent.com/2236554/66546624-1cef4300-eb89-11e9-89fd-a7966c7c0235.gif)
**After**
![2019-10-10 18 10 23](https://user-images.githubusercontent.com/2236554/66546691-47410080-eb89-11e9-8cc8-6016bc70a076.gif)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->