### PR TITLE
Docs: update data package README

### DIFF
--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -238,6 +238,8 @@ The data module shares many of the same [core principles](https://redux.js.org/i
 
 The [higher-order components](#higher-order-components) were created to complement this distinction. The intention with splitting `withSelect` and `withDispatch` — where in React Redux they are combined under `connect` as `mapStateToProps` and `mapDispatchToProps` arguments — is to more accurately reflect that dispatch is not dependent upon a subscription to state changes, and to allow for state-derived values to be used in `withDispatch` (via [higher-order component composition](/packages/compose/README.md)).
 
+The data module also has built-in solutions for handling asynchronous side-effects, through [resolvers](#resolvers) and [controls](#controls). These differ slightly from [standard redux async solutions](https://redux.js.org/advanced/async-actions) like [`redux-thunk`](https://github.com/gaearon/redux-thunk) or [`redux-saga`](https://redux-saga.js.org/).
+
 Specific implementation differences from Redux and React Redux:
 
 -   In Redux, a `subscribe` listener is called on every dispatch, regardless of whether the value of state has changed.


### PR DESCRIPTION
When starting development with `@wordpress/data` and reading the "Comparison with Redux" section I was surprised that a package would be created just to "establish a modularization pattern" and "codify conventions". 
For me the selling point was the built-in async data flow handling, which is visible in the examples, but missing in the section that people coming from from redux might read first.