### PR TITLE
The snackbar link components hide on focus

### DIFF
--- a/packages/components/src/snackbar/style.scss
+++ b/packages/components/src/snackbar/style.scss
@@ -34,7 +34,7 @@
 	flex-shrink: 0;
 	line-height: $default-line-height;
 
-	&:not(:disabled):not([aria-disabled="true"]):not(.is-default) {
+	&:not(:disabled):not([aria-disabled="true"]):not(.is-default):not(:focus) {
 		text-decoration: underline;
 
 		&:hover {

--- a/packages/components/src/snackbar/style.scss
+++ b/packages/components/src/snackbar/style.scss
@@ -44,7 +44,7 @@
 			box-shadow: none;
 			outline: 1px dotted $white;
 		}
-		
+
 		&:hover {
 			color: $blue-medium-400;
 		}

--- a/packages/components/src/snackbar/style.scss
+++ b/packages/components/src/snackbar/style.scss
@@ -39,14 +39,15 @@
 		text-decoration: underline;
 		background-color: transparent;
 
-		&:hover {
-			color: $blue-medium-400;
-		}
-
 		&:focus {
 			color: $white;
 			box-shadow: none;
 			outline: 1px dotted $white;
+		}
+		
+		&:hover,
+		&:focus:hover {
+			color: $blue-medium-400;
 		}
 	}
 }

--- a/packages/components/src/snackbar/style.scss
+++ b/packages/components/src/snackbar/style.scss
@@ -28,18 +28,25 @@
 }
 
 .components-snackbar__action.components-button {
-	margin-left: 32px;
+	margin-left: $grid-size * 4;
 	color: $white;
 	height: auto;
 	flex-shrink: 0;
 	line-height: $default-line-height;
+	padding: 0;
 
-	&:not(:disabled):not([aria-disabled="true"]):not(.is-default):not(:focus) {
+	&:not(:disabled):not([aria-disabled="true"]):not(.is-default) {
 		text-decoration: underline;
+		background-color: transparent;
 
 		&:hover {
+			color: $blue-medium-400;
+		}
+
+		&:focus {
 			color: $white;
-			text-decoration: none;
+			box-shadow: none;
+			outline: 1px dotted $white;
 		}
 	}
 }

--- a/packages/components/src/snackbar/style.scss
+++ b/packages/components/src/snackbar/style.scss
@@ -45,8 +45,7 @@
 			outline: 1px dotted $white;
 		}
 		
-		&:hover,
-		&:focus:hover {
+		&:hover {
 			color: $blue-medium-400;
 		}
 	}


### PR DESCRIPTION
Default message:
![Default message](https://maheshwaghmare.files.wordpress.com/2019/10/image-2019-10-10-at-7.11.13-pm.png)

Default message + focus:
![Default message + focus](https://maheshwaghmare.files.wordpress.com/2019/10/image-2019-10-10-at-7.12.37-pm.png)

I think the possible fix for this issue is update the below selector:

```
.components-snackbar__action.components-button:not(:disabled):not([aria-disabled="true"]):not(.is-default)
```

with:
```
.components-snackbar__action.components-button:not(:disabled):not([aria-disabled="true"]):not(.is-default):not(:focus)
```

---

I have reported the issue on WordPress core trac. Ticket is https://core.trac.wordpress.org/ticket/48276
