### PR TITLE
Editor: Make sure that all edits after saving are considered "persistent".

### DIFF
--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -281,6 +281,11 @@ export function* savePost( options = {} ) {
 		if ( args.length ) {
 			yield dispatch( 'core/notices', 'createSuccessNotice', ...args );
 		}
+		// Make sure that any edits after saving create an undo level and are
+		// considered for change detection.
+		if ( ! options.isAutosave ) {
+			yield dispatch( 'core/block-editor', '__unstableMarkLastChangeAsPersistent' );
+		}
 	}
 }
 

--- a/packages/editor/src/store/test/actions.js
+++ b/packages/editor/src/store/test/actions.js
@@ -226,6 +226,21 @@ describe( 'Post generator actions', () => {
 				},
 			],
 			[
+				'yields an action for marking the last change as persistent',
+				() => true,
+				() => {
+					if ( ! isAutosave ) {
+						const { value } = fulfillment.next();
+						expect( value ).toEqual(
+							dispatch(
+								'core/block-editor',
+								'__unstableMarkLastChangeAsPersistent'
+							)
+						);
+					}
+				},
+			],
+			[
 				'implicitly returns undefined',
 				() => true,
 				() => {


### PR DESCRIPTION
Fixes #17852

## Description

This PR fixes the issue discussed in #17852, by making sure that any change after a save is considered as persistent for undo level creation and change detection.

## How has this been tested?

It was verified that #17852 was fixed and all the tests pass.

## Types of Changes

*Bug Fix:* Fix an issue where editing the same block attribute after saving would not dirty the post again.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
