### PR TITLE
[Mobile] Add Gallery block - semi x-platform

### DIFF
--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -281,6 +281,7 @@ class GalleryEdit extends Component {
 				value={ hasImagesWithId ? images : undefined }
 				onError={ this.onUploadError }
 				notices={ hasImages ? undefined : noticeUI }
+				onFocus={ this.props.onFocus }
 			/>
 		);
 

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import classnames from 'classnames';
 import {
 	every,
 	filter,
@@ -26,19 +25,18 @@ import {
 	BlockIcon,
 	MediaPlaceholder,
 	InspectorControls,
-	RichText,
 } from '@wordpress/block-editor';
 import { Component } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { getBlobByURL, isBlobURL, revokeBlobURL } from '@wordpress/blob';
 import { withSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
-import GalleryImage from './gallery-image';
 import { icon } from './icons';
 import { defaultColumnsNumber, pickRelevantMediaFiles } from './shared';
+import Gallery from './gallery';
 
 const MAX_COLUMNS = 8;
 const linkOptions = [
@@ -254,12 +252,9 @@ class GalleryEdit extends Component {
 			className,
 			isSelected,
 			noticeUI,
-			setAttributes,
 		} = this.props;
 		const {
-			align,
 			columns = defaultColumnsNumber( attributes ),
-			caption,
 			imageCrop,
 			images,
 			linkTo,
@@ -292,13 +287,6 @@ class GalleryEdit extends Component {
 		if ( ! hasImages ) {
 			return mediaPlaceholder;
 		}
-
-		const captionClassNames = classnames(
-			'blocks-gallery-caption',
-			{
-				'screen-reader-text': ! isSelected && RichText.isEmpty( caption ),
-			}
-		);
 		return (
 			<>
 				<InspectorControls>
@@ -326,52 +314,17 @@ class GalleryEdit extends Component {
 					</PanelBody>
 				</InspectorControls>
 				{ noticeUI }
-				<figure className={ classnames(
-					className,
-					{
-						[ `align${ align }` ]: align,
-						[ `columns-${ columns }` ]: columns,
-						'is-cropped': imageCrop,
-					}
-				) }
-				>
-					<ul className="blocks-gallery-grid">
-						{ images.map( ( img, index ) => {
-						/* translators: %1$d is the order number of the image, %2$d is the total number of images. */
-							const ariaLabel = sprintf( __( 'image %1$d of %2$d in gallery' ), ( index + 1 ), images.length );
-
-							return (
-								<li className="blocks-gallery-item" key={ img.id || img.url }>
-									<GalleryImage
-										url={ img.url }
-										alt={ img.alt }
-										id={ img.id }
-										isFirstItem={ index === 0 }
-										isLastItem={ ( index + 1 ) === images.length }
-										isSelected={ isSelected && this.state.selectedImage === index }
-										onMoveBackward={ this.onMoveBackward( index ) }
-										onMoveForward={ this.onMoveForward( index ) }
-										onRemove={ this.onRemoveImage( index ) }
-										onSelect={ this.onSelectImage( index ) }
-										setAttributes={ ( attrs ) => this.setImageAttributes( index, attrs ) }
-										caption={ img.caption }
-										aria-label={ ariaLabel }
-									/>
-								</li>
-							);
-						} ) }
-					</ul>
-					{ mediaPlaceholder }
-					<RichText
-						tagName="figcaption"
-						className={ captionClassNames }
-						placeholder={ __( 'Write gallery caption…' ) }
-						value={ caption }
-						unstableOnFocus={ this.onFocusGalleryCaption }
-						onChange={ ( value ) => setAttributes( { caption: value } ) }
-						inlineToolbar
-					/>
-				</figure>
+				<Gallery
+					galleryProps={ this.props }
+					selectedImage={ this.state.selectedImage }
+					mediaPlaceholder={ mediaPlaceholder }
+					onMoveBackward={ this.onMoveBackward }
+					onMoveForward={ this.onMoveForward }
+					onRemoveImage={ this.onRemoveImage }
+					onSelectImage={ this.onSelectImage }
+					onSetImageAttributes={ this.setImageAttributes }
+					onFocusGalleryCaption={ this.onFocusGalleryCaption }
+				/>
 			</>
 		);
 	}

--- a/packages/block-library/src/gallery/gallery-image.native.js
+++ b/packages/block-library/src/gallery/gallery-image.native.js
@@ -1,0 +1,198 @@
+/**
+ * External dependencies
+ */
+import { Image, View } from 'react-native';
+
+/**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
+import { IconButton, Spinner } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { BACKSPACE, DELETE } from '@wordpress/keycodes';
+import { withSelect } from '@wordpress/data';
+import { RichText } from '@wordpress/block-editor';
+import { isBlobURL } from '@wordpress/blob';
+
+class GalleryImage extends Component {
+	constructor() {
+		super( ...arguments );
+
+		this.onSelectImage = this.onSelectImage.bind( this );
+		this.onSelectCaption = this.onSelectCaption.bind( this );
+		this.onRemoveImage = this.onRemoveImage.bind( this );
+		this.bindContainer = this.bindContainer.bind( this );
+
+		this.state = {
+			captionSelected: false,
+		};
+	}
+
+	bindContainer( ref ) {
+		this.container = ref;
+	}
+
+	onSelectCaption() {
+		if ( ! this.state.captionSelected ) {
+			this.setState( {
+				captionSelected: true,
+			} );
+		}
+
+		if ( ! this.props.isSelected ) {
+			this.props.onSelect();
+		}
+	}
+
+	onSelectImage() {
+		if ( ! this.props.isSelected ) {
+			this.props.onSelect();
+		}
+
+		if ( this.state.captionSelected ) {
+			this.setState( {
+				captionSelected: false,
+			} );
+		}
+	}
+
+	onRemoveImage( event ) {
+		if (
+			this.container === document.activeElement &&
+			this.props.isSelected && [ BACKSPACE, DELETE ].indexOf( event.keyCode ) !== -1
+		) {
+			event.stopPropagation();
+			event.preventDefault();
+			this.props.onRemove();
+		}
+	}
+
+	componentDidUpdate( prevProps ) {
+		const { isSelected, image, url } = this.props;
+		if ( image && ! url ) {
+			this.props.setAttributes( {
+				url: image.source_url,
+				alt: image.alt_text,
+			} );
+		}
+
+		// unselect the caption so when the user selects other image and comeback
+		// the caption is not immediately selected
+		if ( this.state.captionSelected && ! isSelected && prevProps.isSelected ) {
+			this.setState( {
+				captionSelected: false,
+			} );
+		}
+	}
+
+	render() {
+		const { url, alt, id, linkTo, link, isFirstItem, isLastItem, isSelected, caption, onRemove, onMoveForward, onMoveBackward, setAttributes, 'aria-label': ariaLabel } = this.props;
+
+		let href;
+
+		switch ( linkTo ) {
+			case 'media':
+				href = url;
+				break;
+			case 'attachment':
+				href = link;
+				break;
+		}
+
+		const img = (
+			// Disable reason: Image itself is not meant to be interactive, but should
+			// direct image selection and unfocus caption fields.
+			/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
+			<>
+				<Image
+					style={ {
+						width: '100%',
+						height: '100%',
+						resizeMode: 'cover',
+					} }
+					source={ { uri: url } }
+					alt={ alt }
+					data-id={ id }
+					onClick={ this.onSelectImage }
+					onFocus={ this.onSelectImage }
+					onKeyDown={ this.onRemoveImage }
+					tabIndex="0"
+					aria-label={ ariaLabel }
+					ref={ this.bindContainer }
+				/>
+				{ isBlobURL( url ) && <Spinner /> }
+			</>
+			/* eslint-enable jsx-a11y/no-noninteractive-element-interactions */
+		);
+
+		return (
+			<View
+				style={ {
+					flex: 1,
+					height: 150,
+				} }>
+				{ href ? <a href={ href }>{ img }</a> : img }
+				<View
+					style={ {
+						position: 'absolute',
+					} }>
+					<IconButton
+						icon="arrow-left"
+						onClick={ isFirstItem ? undefined : onMoveBackward }
+						label={ __( 'Move Image Backward' ) }
+						aria-disabled={ isFirstItem }
+						disabled={ ! isSelected }
+					/>
+					<IconButton
+						icon="arrow-right"
+						onClick={ isLastItem ? undefined : onMoveForward }
+						label={ __( 'Move Image Forward' ) }
+						aria-disabled={ isLastItem }
+						disabled={ ! isSelected }
+					/>
+				</View>
+				<View
+					style={ {
+						position: 'absolute',
+						right: 0,
+					} }>
+					<IconButton
+						icon="no-alt"
+						onClick={ onRemove }
+						label={ __( 'Remove Image' ) }
+						disabled={ ! isSelected }
+					/>
+				</View>
+				<View
+					style={ {
+						flex: 1,
+						position: 'absolute',
+						bottom: 0,
+						left: 0,
+						right: 0,
+					} }
+				>
+
+					<RichText
+						tagName="figcaption"
+						placeholder={ isSelected ? __( 'Write caption…' ) : null }
+						value={ caption }
+						isSelected={ this.state.captionSelected }
+						onChange={ ( newCaption ) => setAttributes( { caption: newCaption } ) }
+						unstableOnFocus={ this.onSelectCaption }
+						inlineToolbar
+					/>
+				</View>
+			</View>
+		);
+	}
+}
+
+export default withSelect( ( select, ownProps ) => {
+	const { getMedia } = select( 'core' );
+	const { id } = ownProps;
+
+	return {
+		image: id ? getMedia( id ) : null,
+	};
+} )( GalleryImage );

--- a/packages/block-library/src/gallery/gallery.js
+++ b/packages/block-library/src/gallery/gallery.js
@@ -1,0 +1,105 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import {
+	RichText,
+} from '@wordpress/block-editor';
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import GalleryImage from './gallery-image';
+import { defaultColumnsNumber } from './shared';
+
+export const Gallery = ( props ) => {
+	const {
+		galleryProps,
+		selectedImage,
+		mediaPlaceholder,
+		onMoveBackward,
+		onMoveForward,
+		onRemoveImage,
+		onSelectImage,
+		onSetImageAttributes,
+		onFocusGalleryCaption,
+	} = props;
+
+	const {
+		attributes,
+		className,
+		isSelected,
+		setAttributes,
+	} = galleryProps;
+
+	const {
+		align,
+		columns = defaultColumnsNumber( attributes ),
+		caption,
+		imageCrop,
+		images,
+	} = attributes;
+
+	const captionClassNames = classnames(
+		'blocks-gallery-caption',
+		{
+			'screen-reader-text': ! isSelected && RichText.isEmpty( caption ),
+		}
+	);
+
+	return (
+		<figure className={ classnames(
+			className,
+			{
+				[ `align${ align }` ]: align,
+				[ `columns-${ columns }` ]: columns,
+				'is-cropped': imageCrop,
+			}
+		) }
+		>
+			<ul className="blocks-gallery-grid">
+				{ images.map( ( img, index ) => {
+					/* translators: %1$d is the order number of the image, %2$d is the total number of images. */
+					const ariaLabel = sprintf( __( 'image %1$d of %2$d in gallery' ), ( index + 1 ), images.length );
+
+					return (
+						<li className="blocks-gallery-item" key={ img.id || img.url }>
+							<GalleryImage
+								url={ img.url }
+								alt={ img.alt }
+								id={ img.id }
+								isFirstItem={ index === 0 }
+								isLastItem={ ( index + 1 ) === images.length }
+								isSelected={ isSelected && selectedImage === index }
+								onMoveBackward={ onMoveBackward( index ) }
+								onMoveForward={ onMoveForward( index ) }
+								onRemove={ onRemoveImage( index ) }
+								onSelect={ onSelectImage( index ) }
+								setAttributes={ ( attrs ) => onSetImageAttributes( index, attrs ) }
+								caption={ img.caption }
+								aria-label={ ariaLabel }
+							/>
+						</li>
+					);
+				} ) }
+			</ul>
+			{ mediaPlaceholder }
+			<RichText
+				tagName="figcaption"
+				className={ captionClassNames }
+				placeholder={ __( 'Write gallery caption…' ) }
+				value={ caption }
+				unstableOnFocus={ onFocusGalleryCaption }
+				onChange={ ( value ) => setAttributes( { caption: value } ) }
+				inlineToolbar
+			/>
+		</figure>
+	);
+};
+
+export default Gallery;

--- a/packages/block-library/src/gallery/gallery.native.js
+++ b/packages/block-library/src/gallery/gallery.native.js
@@ -1,0 +1,79 @@
+/**
+ * External dependencies
+ */
+import { View } from 'react-native';
+
+/**
+ * Internal dependencies
+ */
+import GalleryImage from './gallery-image';
+import { defaultColumnsNumber } from './shared';
+import Tiles from './tiles';
+
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+
+export const Gallery = ( props ) => {
+	const {
+		galleryProps,
+		selectedImage,
+		mediaPlaceholder,
+		onMoveBackward,
+		onMoveForward,
+		onRemoveImage,
+		onSelectImage,
+		onSetImageAttributes,
+	//	onFocusGalleryCaption,
+	} = props;
+
+	const {
+		attributes,
+		isSelected,
+	//	setAttributes,
+	} = galleryProps;
+
+	const {
+		align,
+		columns = defaultColumnsNumber( attributes ),
+		//	caption,
+		imageCrop,
+		images,
+	} = attributes;
+
+	const tilesProps = { images, columns, align, imageCrop };
+
+	return (
+		<View>
+			<Tiles tilesProps={ tilesProps }>
+				{ images.map( ( img, index ) => {
+					/* translators: %1$d is the order number of the image, %2$d is the total number of images. */
+					const ariaLabel = sprintf( __( 'image %1$d of %2$d in gallery' ), ( index + 1 ), images.length );
+
+					return (
+						<GalleryImage
+							key={ img.id || img.url }
+							url={ img.url }
+							alt={ img.alt }
+							id={ img.id }
+							isFirstItem={ index === 0 }
+							isLastItem={ ( index + 1 ) === images.length }
+							isSelected={ isSelected && selectedImage === index }
+							onMoveBackward={ onMoveBackward( index ) }
+							onMoveForward={ onMoveForward( index ) }
+							onRemove={ onRemoveImage( index ) }
+							onSelect={ onSelectImage( index ) }
+							setAttributes={ ( attrs ) => onSetImageAttributes( index, attrs ) }
+							caption={ img.caption }
+							aria-label={ ariaLabel }
+						/>
+					);
+				} ) }
+			</Tiles>
+			{ mediaPlaceholder }
+		</View>
+	);
+};
+
+export default Gallery;

--- a/packages/block-library/src/gallery/tiles.native.js
+++ b/packages/block-library/src/gallery/tiles.native.js
@@ -1,0 +1,43 @@
+/**
+ * External dependencies
+ */
+import { View } from 'react-native';
+
+/**
+ * WordPress dependencies
+ */
+import { Children } from '@wordpress/element';
+
+function Tiles( props ) {
+	const {
+		tilesProps: {
+		//	align,
+			columns,
+		//	imageCrop,
+		},
+		children,
+	} = props;
+
+	return (
+		<View
+			style={ {
+				flexDirection: 'row',
+				flexWrap: 'wrap',
+			} }
+		>
+			{ Children.map( children, ( child ) => {
+				return (
+					<View
+						style={ {
+							flex: 1,
+							flexBasis: ( ( 1 / columns ) * 100 ) + '%',
+						} }>
+						{ child }
+					</View>
+				);
+			}	) }
+		</View>
+	);
+}
+
+export default Tiles;

--- a/packages/block-library/src/image/test/edit.native.js
+++ b/packages/block-library/src/image/test/edit.native.js
@@ -40,7 +40,7 @@ describe( 'Image Block', () => {
 
 		instance.onSetNewTab( true );
 
-		expect( setAttributes ).toBeCalledWith( { linkTarget: '_blank', rel: NEW_TAB_REL } );
+		expect( setAttributes ).toHaveBeenCalledWith( { linkTarget: '_blank', rel: NEW_TAB_REL } );
 	} );
 
 	it( 'unset link target', () => {
@@ -49,7 +49,7 @@ describe( 'Image Block', () => {
 
 		instance.onSetNewTab( false );
 
-		expect( setAttributes ).toBeCalledWith( { linkTarget: undefined, rel: undefined } );
+		expect( setAttributes ).toHaveBeenCalledWith( { linkTarget: undefined, rel: undefined } );
 	} );
 } );
 

--- a/packages/block-library/src/index.native.js
+++ b/packages/block-library/src/index.native.js
@@ -144,6 +144,8 @@ export const registerCoreBlocks = () => {
 		!! __DEV__ ? mediaText : null,
 		// eslint-disable-next-line no-undef
 		!! __DEV__ ? group : null,
+		// eslint-disable-next-line no-undef
+		!! __DEV__ ? gallery : null,
 	].forEach( registerBlock );
 
 	setDefaultBlockName( paragraph.name );

--- a/packages/components/src/mobile/bottom-sheet/index.native.js
+++ b/packages/components/src/mobile/bottom-sheet/index.native.js
@@ -19,6 +19,7 @@ import Button from './button';
 import Cell from './cell';
 import PickerCell from './picker-cell';
 import SwitchCell from './switch-cell';
+import RangeCell from './range-cell';
 import KeyboardAvoidingView from './keyboard-avoiding-view';
 
 class BottomSheet extends Component {
@@ -171,5 +172,6 @@ ThemedBottomSheet.Button = Button;
 ThemedBottomSheet.Cell = Cell;
 ThemedBottomSheet.PickerCell = PickerCell;
 ThemedBottomSheet.SwitchCell = SwitchCell;
+ThemedBottomSheet.RangeCell = RangeCell;
 
 export default ThemedBottomSheet;

--- a/packages/components/src/mobile/bottom-sheet/range-cell.native.js
+++ b/packages/components/src/mobile/bottom-sheet/range-cell.native.js
@@ -1,0 +1,39 @@
+/**
+ * Internal dependencies
+ */
+import Cell from './cell';
+import Slider from '../slider';
+
+export default function BottomSheetRangeCell( props ) {
+	const {
+		value,
+		onChangeValue,
+		minimumValue = 0,
+		maximumValue = 10,
+		disabled,
+		step = 1,
+		minimumTrackTintColor = '#909090',
+		maximumTrackTintColor = '#909090',
+		thumbTintColor = '#000',
+		...cellProps
+	} = props;
+
+	return (
+		<Cell
+			editable={ false }
+			{ ...cellProps }
+		>
+			<Slider
+				value={ value }
+				disabled={ disabled }
+				step={ step }
+				minimumValue={ minimumValue }
+				maximumValue={ maximumValue }
+				minimumTrackTintColor={ minimumTrackTintColor }
+				maximumTrackTintColor={ maximumTrackTintColor }
+				thumbTintColor={ thumbTintColor }
+				onChangeValue={ onChangeValue }
+			/>
+		</Cell>
+	);
+}

--- a/packages/components/src/mobile/slider/index.native.js
+++ b/packages/components/src/mobile/slider/index.native.js
@@ -1,0 +1,96 @@
+/**
+ * External dependencies
+ */
+import { Slider as RNSlider, TextInput, View } from 'react-native';
+
+/**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import styles from './styles.scss';
+
+class Slider extends Component {
+	constructor( props ) {
+		super( props );
+		this.handleToggleFocus = this.handleToggleFocus.bind( this );
+		this.handleChange = this.handleChange.bind( this );
+
+		this.state = { hasFocus: false, sliderValue: props.value || props.minimumValue };
+	}
+
+	componentDidUpdate( ) {
+		const reset = this.props.value === null;
+		if ( reset ) {
+			this.handleChange( this.props.minimumValue );
+		}
+	}
+
+	handleToggleFocus() {
+		this.setState( { hasFocus: ! this.state.hasFocus } );
+	}
+
+	validateInput( text ) {
+		const { minimumValue, maximumValue } = this.props;
+		if ( ! text ) {
+			return minimumValue;
+		}
+		if ( typeof text === 'number' ) {
+			return text;
+		}
+		return Math.min( Math.max( text.replace( /[^0-9]/g, '' ).replace( /^0+(?=\d)/, '' ), minimumValue ), maximumValue );
+	}
+
+	handleChange( text ) {
+		if ( ! isNaN( Number( text ) ) ) {
+			const newValue = this.validateInput( text );
+			this.props.onChangeValue( newValue );
+			this.setState( { sliderValue: newValue } );
+		}
+	}
+
+	render() {
+		const {
+			value,
+			minimumValue,
+			maximumValue,
+			disabled,
+			step,
+			minimumTrackTintColor,
+			maximumTrackTintColor,
+			thumbTintColor,
+		} = this.props;
+
+		const { hasFocus, sliderValue } = this.state;
+
+		return (
+			<View style={ styles.sliderContainer }>
+				<RNSlider
+					value={ value }
+					disabled={ disabled }
+					style={ styles.slider }
+					step={ step }
+					minimumValue={ minimumValue }
+					maximumValue={ maximumValue }
+					minimumTrackTintColor={ minimumTrackTintColor }
+					maximumTrackTintColor={ maximumTrackTintColor }
+					thumbTintColor={ thumbTintColor }
+					onValueChange={ this.handleChange }
+				/>
+				<TextInput
+					style={ [ styles.sliderTextInput, hasFocus ? styles.isSelected : {} ] }
+					onChangeText={ this.handleChange }
+					onFocus={ this.handleToggleFocus }
+					onBlur={ this.handleToggleFocus }
+					keyboardType="numeric"
+					value={ `${ sliderValue }` }
+				/>
+			</View>
+		);
+	}
+}
+
+export default Slider;

--- a/packages/components/src/mobile/slider/styles.scss
+++ b/packages/components/src/mobile/slider/styles.scss
@@ -1,0 +1,25 @@
+.sliderContainer {
+	flex: 1;
+	flex-direction: row;
+	align-content: center;
+	justify-content: space-evenly;
+}
+
+.slider {
+	flex-grow: 1;
+}
+
+.sliderTextInput {
+	width: 40px;
+	height: 25px;
+	align-self: center;
+	margin-left: 10px;
+	border-width: 1px;
+	border-radius: 4px;
+	border-color: $dark-gray-150;
+}
+
+.isSelected {
+	border-width: 2px;
+	border-color: $blue-wordpress;
+}

--- a/packages/editor/src/utils/index.native.js
+++ b/packages/editor/src/utils/index.native.js
@@ -1,0 +1,6 @@
+/**
+ * Internal dependencies
+ */
+import mediaUpload from './media-upload';
+
+export { mediaUpload };

--- a/packages/editor/src/utils/media-upload/index.native.js
+++ b/packages/editor/src/utils/media-upload/index.native.js
@@ -1,0 +1,1 @@
+export default function() { }


### PR DESCRIPTION
## Description

Draft PR that allows picking multiple image from WP media library:

<img width="381" alt="Screen Shot 2019-10-10 at 19 12 09" src="https://user-images.githubusercontent.com/5032900/66587375-f33b1980-eb92-11e9-99c3-6d43d8f62719.png">

tiles, gallery-image components are used from [this PR](https://github.com/WordPress/gutenberg/pull/17327)

Gutenberg mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1432

I cherry-picked [range control changes](https://github.com/WordPress/gutenberg/pull/17282) to onto this PR

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
