### PR TITLE
Fix toolbars positionning in IE11

### DIFF
--- a/packages/components/src/toolbar/style.scss
+++ b/packages/components/src/toolbar/style.scss
@@ -2,7 +2,15 @@
 	margin: 0;
 	border: $border-width solid $light-gray-500;
 	background-color: $white;
-	display: flex;
+
+	// Required for IE11.
+	display: inline-flex;
+
+	// IE11 doesn't read rules inside this query. They are applied only to modern browsers.
+	@supports (position: sticky) {
+		display: flex;
+	}
+
 	flex-shrink: 0;
 }
 


### PR DESCRIPTION
This PR fixes a visual glitch in ie11 where toolbar segments in block toolbars appear one per line instead of part of the same "line". 

I'm interested in testing this PR in other browsers to ensure there's no unwanted side-effect.

**Testing instructions**

Test block toolbars in Chrome/Firefox in several situations/alignments... and ensure it displays properly.