### PR TITLE
Check that scrollViewRef is still available before trying to scroll

### DIFF
--- a/packages/components/src/mobile/keyboard-aware-flat-list/index.ios.js
+++ b/packages/components/src/mobile/keyboard-aware-flat-list/index.ios.js
@@ -32,7 +32,7 @@ export const KeyboardAwareFlatList = ( {
 					this.latestContentOffsetY !== undefined &&
 					! shouldPreventAutomaticScroll() ) {
 					// Reset the content position if keyboard is still closed
-					this.scrollViewRef.props.scrollToPosition( 0, this.latestContentOffsetY, true );
+					this.scrollViewRef && this.scrollViewRef.props.scrollToPosition( 0, this.latestContentOffsetY, true );
 				}
 			}, 50 );
 		} }

--- a/packages/components/src/mobile/keyboard-aware-flat-list/index.ios.js
+++ b/packages/components/src/mobile/keyboard-aware-flat-list/index.ios.js
@@ -32,7 +32,9 @@ export const KeyboardAwareFlatList = ( {
 					this.latestContentOffsetY !== undefined &&
 					! shouldPreventAutomaticScroll() ) {
 					// Reset the content position if keyboard is still closed
-					this.scrollViewRef && this.scrollViewRef.props.scrollToPosition( 0, this.latestContentOffsetY, true );
+					if ( this.scrollViewRef ) {
+						this.scrollViewRef.props.scrollToPosition( 0, this.latestContentOffsetY, true );
+					}
 				}
 			}, 50 );
 		} }


### PR DESCRIPTION
This was meant to fix https://github.com/wordpress-mobile/gutenberg-mobile/issues/1390 although I can't reproduce the issue anymore.

In any case, it's a good safety check. Since this happens in a delayed fashion, there scrollView might not exist anymore by the time this runs, so it's better to check that it's still there before trying to scroll.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
