### PR TITLE
I18N: Always return the translation file prefixed with `gutenberg-`.

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -145,10 +145,6 @@ function gutenberg_override_translation_file( $file, $handle ) {
 		$path_parts['basename']
 	);
 
-	if ( ! is_readable( $plugin_translation_file ) ) {
-		return $file;
-	}
-
 	return $plugin_translation_file;
 }
 add_filter( 'load_script_translation_file', 'gutenberg_override_translation_file', 10, 2 );


### PR DESCRIPTION
## Description
`gutenberg_override_translation_file()` ensures that the missing text domain is added to the translation file path. But it also checks if the file exists.
In this case it's not necessary because `load_script_translations()` already checks if the file is readable. It also prevents other plugins like [Preferred Languages](https://wordpress.org/plugins/preferred-languages/) to process the correct path. Correct, because there will never be a file in `/languages/plugins` without a text domain/slug of the plugin. Therefore the replaced path should always be returned.

## How has this been tested?
With Preferred Languages installed and using de_CH with de_DE as fallback. Currently no translations are loaded because [Preferred Languages checks the file without the `gutenberg-` prefix](https://github.com/swissspidy/preferred-languages/blob/538037f5dff346f8e5177b422d39375c69cd638f/inc/functions.php#L360-L396).