### PR TITLE
Full-height columns fix in IE11.

### DIFF
--- a/packages/block-library/src/columns/editor.scss
+++ b/packages/block-library/src/columns/editor.scss
@@ -41,12 +41,9 @@
 		> [data-type="core/column"] > .editor-block-list__block-edit,
 		> [data-type="core/column"] > .editor-block-list__block-edit > div[data-block],
 		> [data-type="core/column"] > .editor-block-list__block-edit .block-core-columns {
-			// IE11 doesn't read rules inside this query. They are applied only to modern browsers.
-			@supports (position: sticky) {
-				display: flex;
-				flex-direction: column;
-				flex: 1;
-			}
+			display: flex;
+			flex-direction: column;
+			flex: 1 0 auto;
 		}
 
 		// Adjust the individual column block.

--- a/packages/block-library/src/columns/editor.scss
+++ b/packages/block-library/src/columns/editor.scss
@@ -41,9 +41,12 @@
 		> [data-type="core/column"] > .editor-block-list__block-edit,
 		> [data-type="core/column"] > .editor-block-list__block-edit > div[data-block],
 		> [data-type="core/column"] > .editor-block-list__block-edit .block-core-columns {
-			display: flex;
-			flex-direction: column;
-			flex: 1 0 auto;
+			// IE11 doesn't read rules inside this query. They are applied only to modern browsers.
+			@supports (position: sticky) {
+				display: flex;
+				flex-direction: column;
+				flex: 1;
+			}
 		}
 
 		// Adjust the individual column block.

--- a/packages/block-library/src/columns/editor.scss
+++ b/packages/block-library/src/columns/editor.scss
@@ -1,10 +1,3 @@
-@mixin flex-full-height() {
-	display: flex;
-	flex-direction: column;
-	flex: 1;
-}
-
-
 // These margins make sure that nested blocks stack/overlay with the parent block chrome
 // This is sort of an experiment at making sure the editor looks as much like the end result as possible
 // Potentially the rules here can apply to all nested blocks and enable stacking, in which case it should be moved elsewhere
@@ -48,8 +41,14 @@
 		> [data-type="core/column"] > .editor-block-list__block-edit,
 		> [data-type="core/column"] > .editor-block-list__block-edit > div[data-block],
 		> [data-type="core/column"] > .editor-block-list__block-edit .block-core-columns {
-			@include flex-full-height();
+			// IE11 doesn't read rules inside this query. They are applied only to modern browsers.
+			@supports (position: sticky) {
+				display: flex;
+				flex-direction: column;
+				flex: 1;
+			}
 		}
+
 		// Adjust the individual column block.
 		> [data-type="core/column"] {
 

--- a/packages/components/src/placeholder/style.scss
+++ b/packages/components/src/placeholder/style.scss
@@ -1,13 +1,17 @@
 .components-placeholder {
 	margin-bottom: $default-block-margin;
-	display: flex;
-	flex-direction: column;
-	align-items: center;
-	justify-content: center;
 	padding: 1em;
 	min-height: 200px;
 	width: 100%;
 	text-align: center;
+
+	// IE11 doesn't read rules inside this query. They are applied only to modern browsers.
+	@supports (position: sticky) {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+	}
 
 	// Use opacity to work in various editor styles.
 	background: $dark-opacity-light-200;


### PR DESCRIPTION
closes #17882

This PR first of all makes the columns block usable in IE11. It was barely functional before.

Secondly, but I'm not entirely sure how to test this, it appears to disable full-height columns previews, but I'm not entirely sure exactly what that means. It does so because the rules to enable what that is, break the entire block for IE11, so they have been wrapped in a "supports".

Depending on what it is, this is probably fine, and we can see that preview as a progressive enhancement.

Before:

![Screenshot 2019-10-11 at 11 43 21](https://user-images.githubusercontent.com/1204802/66642166-73599180-ec1c-11e9-9df9-490b6498b6cd.png)

After:

![after](https://user-images.githubusercontent.com/1204802/66642183-794f7280-ec1c-11e9-9efa-4581d7c67784.png)
