### PR TITLE
Mobile Web: Ensure that sidebar is closed on the first visit

### DIFF
--- a/packages/e2e-tests/specs/sidebar.test.js
+++ b/packages/e2e-tests/specs/sidebar.test.js
@@ -2,8 +2,9 @@
  * WordPress dependencies
  */
 import {
-	findSidebarPanelWithTitle,
+	clearLocalStorage,
 	createNewPost,
+	findSidebarPanelWithTitle,
 	observeFocusLoss,
 	openDocumentSettingsSidebar,
 	pressKeyWithModifier,
@@ -21,6 +22,7 @@ describe( 'Sidebar', () => {
 
 	it( 'should have sidebar visible at the start with document sidebar active on desktop', async () => {
 		await setBrowserViewport( 'large' );
+		await clearLocalStorage();
 		await createNewPost();
 		const { nodesCount, content, height, width } = await page.$$eval( ACTIVE_SIDEBAR_TAB_SELECTOR, ( nodes ) => {
 			const firstNode = nodes[ 0 ];
@@ -45,6 +47,7 @@ describe( 'Sidebar', () => {
 
 	it( 'should have the sidebar closed by default on mobile', async () => {
 		await setBrowserViewport( 'small' );
+		await clearLocalStorage();
 		await createNewPost();
 		const sidebar = await page.$( SIDEBAR_SELECTOR );
 		expect( sidebar ).toBeNull();
@@ -52,6 +55,7 @@ describe( 'Sidebar', () => {
 
 	it( 'should close the sidebar when resizing from desktop to mobile', async () => {
 		await setBrowserViewport( 'large' );
+		await clearLocalStorage();
 		await createNewPost();
 
 		const sidebars = await page.$$( SIDEBAR_SELECTOR );
@@ -66,6 +70,7 @@ describe( 'Sidebar', () => {
 
 	it( 'should reopen sidebar the sidebar when resizing from mobile to desktop if the sidebar was closed automatically', async () => {
 		await setBrowserViewport( 'large' );
+		await clearLocalStorage();
 		await createNewPost();
 		await setBrowserViewport( 'small' );
 

--- a/packages/edit-post/src/components/editor-initialization/index.js
+++ b/packages/edit-post/src/components/editor-initialization/index.js
@@ -21,8 +21,8 @@ import {
  * @return {null} This is a data component so does not render any ui.
  */
 export default function( { postId } ) {
-	useAdjustSidebarListener( postId );
 	useBlockSelectionListener( postId );
+	useAdjustSidebarListener( postId );
 	useUpdatePostLinkListener( postId );
 	const { triggerGuide } = useDispatch( 'core/nux' );
 	useEffect( () => {

--- a/packages/edit-post/src/components/editor-initialization/listener-hooks.js
+++ b/packages/edit-post/src/components/editor-initialization/listener-hooks.js
@@ -64,7 +64,7 @@ export const useAdjustSidebarListener = ( postId ) => {
 
 	const { openGeneralSidebar, closeGeneralSidebar } = useDispatch( STORE_KEY );
 
-	const previousIsSmall = useRef( isSmall );
+	const previousIsSmall = useRef( null );
 	const sidebarToReOpenOnExpand = useRef( null );
 
 	useEffect( () => {

--- a/packages/edit-post/src/components/editor-initialization/test/listener-hooks.js
+++ b/packages/edit-post/src/components/editor-initialization/test/listener-hooks.js
@@ -137,11 +137,10 @@ describe( 'listener hook tests', () => {
 				getSpyedFunction( STORE_KEY, 'closeGeneralSidebar' )
 			).not.toHaveBeenCalled();
 		} );
-		it( 'does not close sidebar if viewport is small and there is an active ' +
+		it( 'closes sidebar if viewport is small and there is an active ' +
 			'sidebar name available on initial render', () => {
 			setMockReturnValue( 'core/viewport', 'isViewportMatch', true );
 			setMockReturnValue( STORE_KEY, 'getActiveGeneralSidebarName', 'foo' );
-			// initial render does nothing (and sidebar will be closed already)
 			act( () => {
 				renderComponent( useAdjustSidebarListener, 10 );
 			} );
@@ -150,7 +149,7 @@ describe( 'listener hook tests', () => {
 			).not.toHaveBeenCalled();
 			expect(
 				getSpyedFunction( STORE_KEY, 'closeGeneralSidebar' )
-			).not.toHaveBeenCalled();
+			).toHaveBeenCalled();
 		} );
 		it( 'closes sidebar if viewport is small and there is an active ' +
 			'sidebar name available when viewport size changes', () => {


### PR DESCRIPTION
## Description
Related to #17712.

Fixes #17341.
Fixes #17708.

> **Describe the bug**
> 
> I was going to test gutenberg on a new install (via `npm run env install`) with the iOS simulator, and noticed this is what you see the first time you open gutenberg:
> 
> ![gutenberg-ios-nux](https://user-images.githubusercontent.com/8739/66040920-e8d8aa00-e518-11e9-8d9f-0f6ec52bb71e.gif)
> 
> First, instead of showing the editor, the settings sidebar is initially visible, completely covering the editor.

I still need to add a proper fix, for the time being, I updated the test to catch this bug.

## Steps to reproduce

1. Clear the local storage
2. Set a mobile viewport in your browser when using Desktop or use any mobile device with a smaller screen.
3. Open `Add New Post` page.

With the fix applied Sidebar shouldn't cover the screen, it should be closed by default.

## How has this been tested?
I updated e2e tests to ensure they catch this issue in the future in 4c68cb2. 
They should all pas with:
`npm run test-e2e`

