### PR TITLE
Enable media-text in all builds

### DIFF
--- a/packages/block-library/src/index.native.js
+++ b/packages/block-library/src/index.native.js
@@ -140,8 +140,7 @@ export const registerCoreBlocks = () => {
 		separator,
 		list,
 		quote,
-		// eslint-disable-next-line no-undef
-		!! __DEV__ ? mediaText : null,
+		mediaText,
 		// eslint-disable-next-line no-undef
 		!! __DEV__ ? group : null,
 	].forEach( registerBlock );


### PR DESCRIPTION
This enables the media&text block on production builds for the mobile apps.

gutenberg-mobile: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1439
WPiOS: https://github.com/wordpress-mobile/WordPress-iOS/pull/12682
WPAndroid: https://github.com/wordpress-mobile/WordPress-Android/pull/10599
