### PR TITLE
Fix: Columns block sample

### DIFF
--- a/packages/block-library/src/columns/index.js
+++ b/packages/block-library/src/columns/index.js
@@ -32,7 +32,7 @@ export const settings = {
 					{
 						name: 'core/paragraph',
 						attributes: {
-							content: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent et eros eu felis pellentesque efficitur. Nam dapibus felis malesuada tincidunt rhoncus. Integer non malesuada tortor.',
+							content: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent et eros eu felis.',
 						},
 					},
 					{
@@ -44,7 +44,7 @@ export const settings = {
 					{
 						name: 'core/paragraph',
 						attributes: {
-							content: 'Suspendisse commodo neque lacus, a dictum orci interdum et. Ut vel mi ut leo fringilla rutrum.',
+							content: 'Suspendisse commodo neque lacus, a dictum orci interdum et.',
 						},
 					},
 				],
@@ -55,13 +55,13 @@ export const settings = {
 					{
 						name: 'core/paragraph',
 						attributes: {
-							content: __( 'Etiam et egestas lorem. Vivamus sagittis sit amet dolor quis lobortis. Integer sed fermentum arcu, id vulputate lacus. Etiam fermentum sem eu quam hendrerit, eget faucibus urna pulvinar.' ),
+							content: __( 'Etiam et egestas lorem. Vivamus sagittis sit amet dolor quis lobortis. Integer sed fermentum arcu, id vulputate lacus. Etiam fermentum sem eu quam hendrerit.' ),
 						},
 					},
 					{
 						name: 'core/paragraph',
 						attributes: {
-							content: __( 'Nam risus massa, ullamcorper consectetur eros fermentum, porta aliquet ligula. Sed vel mauris nec enim ultricies commodo.' ),
+							content: __( 'Nam risus massa, ullamcorper consectetur eros fermentum, porta aliquet ligula. Sed vel mauris nec enim.' ),
 						},
 					},
 				],


### PR DESCRIPTION
## Description
This PR reduces the amount of text in the columns block sample to make sure it fits the available space.

## How has this been tested?
I previewed the columns block sample and verified the sample fitted into the available space.

## Screenshots <!-- if applicable -->
Before:
<img width="252" alt="Screenshot 2019-10-11 at 11 11 42" src="https://user-images.githubusercontent.com/11271197/66644738-9a629400-ec19-11e9-8bdd-3cc7113615fe.png">


After:
<img width="264" alt="Screenshot 2019-10-11 at 11 18 29" src="https://user-images.githubusercontent.com/11271197/66644748-a189a200-ec19-11e9-90ba-be8afc795aec.png">
