### PR TITLE
Fix: Remove unnecessary space on columns

### DIFF
--- a/packages/block-library/src/columns/style.scss
+++ b/packages/block-library/src/columns/style.scss
@@ -11,7 +11,6 @@
 }
 
 .wp-block-column {
-	margin-bottom: 1em;
 	flex-grow: 1;
 
 	@media (max-width: #{ ($break-small - 1) }) {


### PR DESCRIPTION
## Description
This PR removes an unnecessary space from the columns block.

## How has this been tested?
I checked the columns block works as before without an unnecessary space at the button.

## Screenshots <!-- if applicable -->
Before:
<img width="654" alt="Screenshot 2019-10-11 at 14 29 42" src="https://user-images.githubusercontent.com/11271197/66665901-61d9af00-ec47-11e9-9689-7c107a6c762d.png">


After:
<img width="627" alt="Screenshot 2019-10-11 at 16 21 43" src="https://user-images.githubusercontent.com/11271197/66665918-6bfbad80-ec47-11e9-917b-b04cf556a433.png">

