### PR TITLE
Storybook: Add margin to ButtonGroup example

### DIFF
--- a/packages/components/src/button-group/stories/index.js
+++ b/packages/components/src/button-group/stories/index.js
@@ -6,9 +6,12 @@ import ButtonGroup from '../';
 
 export default { title: 'Button Group', component: ButtonGroup };
 
-export const _default = () => (
-	<ButtonGroup>
-		<Button isPrimary>Button 1</Button>
-		<Button isPrimary>Button 2</Button>
-	</ButtonGroup>
-);
+export const _default = () => {
+	const style = { margin: '0 4px' };
+	return (
+		<ButtonGroup>
+			<Button isPrimary style={ style }>Button 1</Button>
+			<Button isPrimary style={ style }>Button 2</Button>
+		</ButtonGroup>
+	);
+};


### PR DESCRIPTION
## Description

Fixes margin issue @gziolo noticed in #17884 

## How has this been tested?

Confirm in Storybook (`npm run design-system:dev`) that space exists between two buttons

## Screenshots

![button-group-margin](https://user-images.githubusercontent.com/45363/66673436-6b4a2380-ec15-11e9-9859-afb86354265d.png)


## Types of changes

Storybook.

