### PR TITLE
Editor: Test that consecutive edits to the same attribute after saving are considered "persistent".

### DIFF
--- a/packages/e2e-tests/specs/editor/various/change-detection.test.js
+++ b/packages/e2e-tests/specs/editor/various/change-detection.test.js
@@ -362,34 +362,32 @@ describe( 'Change detection', () => {
 		await clickBlockAppender();
 		await page.keyboard.type( 'Hello, World!' );
 
-		// Save
+		// Save and wait till the post is clean.
 		await Promise.all( [
 			page.waitForSelector( '.editor-post-saved-state.is-saved' ),
 			pressKeyWithModifier( 'primary', 'S' ),
 		] );
-
-		await assertIsDirty( false );
 
 		// Increase the paragraph's font size.
 		await page.click( '[data-type="core/paragraph"]' );
 		await page.select( '.components-select-control__input', 'large' );
 		await page.click( '[data-type="core/paragraph"]' );
 
-		await assertIsDirty( true );
+		// Check that the post is dirty.
+		await page.waitForSelector( '.editor-post-save-draft' );
 
-		// Save
+		// Save and wait till the post is clean.
 		await Promise.all( [
 			page.waitForSelector( '.editor-post-saved-state.is-saved' ),
 			pressKeyWithModifier( 'primary', 'S' ),
 		] );
-
-		await assertIsDirty( false );
 
 		// Increase the paragraph's font size again.
 		await page.click( '[data-type="core/paragraph"]' );
 		await page.select( '.components-select-control__input', 'huge' );
 		await page.click( '[data-type="core/paragraph"]' );
 
-		await assertIsDirty( true );
+		// Check that the post is dirty.
+		await page.waitForSelector( '.editor-post-save-draft' );
 	} );
 } );

--- a/packages/e2e-tests/specs/editor/various/change-detection.test.js
+++ b/packages/e2e-tests/specs/editor/various/change-detection.test.js
@@ -352,4 +352,44 @@ describe( 'Change detection', () => {
 
 		expect( isCurrentURL( '/wp-admin/edit.php', `post_type=post&ids=${ postId }` ) ).toBe( true );
 	} );
+
+	it( 'consecutive edits to the same attribute should mark the post as dirty after a save', async () => {
+		// Open the sidebar block settings.
+		await openDocumentSettingsSidebar();
+		await page.click( '.edit-post-sidebar__panel-tab[data-label="Block"]' );
+
+		// Insert a paragraph.
+		await clickBlockAppender();
+		await page.keyboard.type( 'Hello, World!' );
+
+		// Save
+		await Promise.all( [
+			page.waitForSelector( '.editor-post-saved-state.is-saved' ),
+			pressKeyWithModifier( 'primary', 'S' ),
+		] );
+
+		await assertIsDirty( false );
+
+		// Increase the paragraph's font size.
+		await page.click( '[data-type="core/paragraph"]' );
+		await page.select( '.components-select-control__input', 'large' );
+		await page.click( '[data-type="core/paragraph"]' );
+
+		await assertIsDirty( true );
+
+		// Save
+		await Promise.all( [
+			page.waitForSelector( '.editor-post-saved-state.is-saved' ),
+			pressKeyWithModifier( 'primary', 'S' ),
+		] );
+
+		await assertIsDirty( false );
+
+		// Increase the paragraph's font size again.
+		await page.click( '[data-type="core/paragraph"]' );
+		await page.select( '.components-select-control__input', 'huge' );
+		await page.click( '[data-type="core/paragraph"]' );
+
+		await assertIsDirty( true );
+	} );
 } );

--- a/packages/e2e-tests/specs/editor/various/change-detection.test.js
+++ b/packages/e2e-tests/specs/editor/various/change-detection.test.js
@@ -384,7 +384,7 @@ describe( 'Change detection', () => {
 
 		// Increase the paragraph's font size again.
 		await page.click( '[data-type="core/paragraph"]' );
-		await page.select( '.components-select-control__input', 'huge' );
+		await page.select( '.components-select-control__input', 'larger' );
 		await page.click( '[data-type="core/paragraph"]' );
 
 		// Check that the post is dirty.


### PR DESCRIPTION
Closes #17914

## Description

This PR adds an E2E test to guard against the regression fixed by #17888.

## How has this been tested?

It was verified that the test tests the desired behavior and passes.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
