### PR TITLE
Fix issue when providing multiple shortcode aliases for a new block

### DIFF
--- a/packages/blocks/src/api/raw-handling/shortcode-converter.js
+++ b/packages/blocks/src/api/raw-handling/shortcode-converter.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { some, castArray, first, mapValues, pickBy, includes } from 'lodash';
+import { some, castArray, find, mapValues, pickBy, includes } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -29,13 +29,7 @@ function segmentHTMLToShortcodeBlock( HTML, lastIndex = 0 ) {
 	}
 
 	const transformTags = castArray( transformation.tag );
-
-	let transformTag = first( transformTags );
-	for ( let i = 0; i < transformTags.length; i++ ) {
-		if ( regexp( transformTags[ i ] ).test( HTML ) ) {
-			transformTag = transformTags[ i ];
-		}
-	}
+	const transformTag = find( transformTags, ( tag ) => regexp( tag ).test( HTML ) );
 
 	let match;
 

--- a/packages/blocks/src/api/raw-handling/shortcode-converter.js
+++ b/packages/blocks/src/api/raw-handling/shortcode-converter.js
@@ -29,7 +29,13 @@ function segmentHTMLToShortcodeBlock( HTML, lastIndex = 0 ) {
 	}
 
 	const transformTags = castArray( transformation.tag );
-	const transformTag = first( transformTags );
+
+	let transformTag = first( transformTags );
+	for ( let i = 0; i < transformTags.length; i++ ) {
+		if ( regexp( transformTags[ i ] ).test( HTML ) ) {
+			transformTag = transformTags[ i ];
+		}
+	}
 
 	let match;
 

--- a/test/integration/shortcode-converter.test.js
+++ b/test/integration/shortcode-converter.test.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { registerCoreBlocks } from '@wordpress/block-library';
-import { createBlock } from '@wordpress/blocks';
+import { createBlock, registerBlockType } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -12,6 +12,34 @@ import segmentHTMLToShortcodeBlock from '../../packages/blocks/src/api/raw-handl
 describe( 'segmentHTMLToShortcodeBlock', () => {
 	beforeAll( () => {
 		registerCoreBlocks();
+		registerBlockType( 'test/gallery', {
+			title: 'Test Gallery',
+			category: 'common',
+			attributes: {
+				ids: {
+					type: 'array',
+					default: [],
+				},
+			},
+			transforms: {
+				from: [
+					{
+						type: 'shortcode',
+						tag: [ 'my-gallery', 'my-bunch-of-images' ],
+						attributes: {
+							ids: {
+								type: 'array',
+								shortcode: ( { named: { ids } } ) =>
+									ids.split( ',' ).map( ( id ) => (
+										parseInt( id, 10 )
+									) ),
+							},
+						},
+					},
+				],
+			},
+			save: () => null,
+		} );
 	} );
 
 	it( 'should convert a standalone shortcode between two paragraphs', () => {
@@ -100,5 +128,16 @@ describe( 'segmentHTMLToShortcodeBlock', () => {
 		expect( transformed[ 7 ] ).toEqual( fourthExpectedBlock );
 		expect( transformed[ 8 ] ).toEqual( '</p>' );
 		expect( transformed ).toHaveLength( 9 );
+	} );
+
+	it( 'should convert regardless of shortcode alias', () => {
+		const original = `<p>[my-gallery ids="1,2,3"]</p>
+<p>[my-bunch-of-images ids="4,5,6"]</p>`;
+		const transformed = segmentHTMLToShortcodeBlock( original, 0 );
+		expect( transformed[ 0 ] ).toBe( '<p>' );
+		expect( transformed[ 1 ] ).toHaveProperty( 'name', 'test/gallery' );
+		expect( transformed[ 2 ] ).toBe( '</p>\n<p>' );
+		expect( transformed[ 3 ] ).toHaveProperty( 'name', 'test/gallery' );
+		expect( transformed[ 4 ] ).toBe( '</p>' );
 	} );
 } );


### PR DESCRIPTION
## Description
This pull request addresses the bug outlined at #14476. As noted there, when you provide multiple shortcode aliases to transform into a single block only the first shortcode in the array is matched and transformed.

## How has this been tested?
I tested this following these steps:

1. Create a block providing an array of shortcodes that should transform into your block:

```javascript
transforms: {
        from: [
            {
                type: 'shortcode',
                tag: [ 'test_shortcode', 'other_shortcode' ], // the relevant code is here
                attributes: {
                    showOneTime: {
                        type: 'boolean',
                        shortcode: ( attributes, { shortcode } ) => {
                            return false;
                        },
                    }
                },
            },
        ]
    },
```

2. Add a classic editor block to the page and add your first shortcode into the content.
3. Click "Convert to Blocks" for the classic editor.
4. Repeat the steps for each shortcode that should be transformed. The transform should occur for all of them.

## Types of changes
This is a bug fix to address the issue mentioned above.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. (I don't believe this code requires any inline documentation.)
- [x] I've included developer documentation if appropriate. (I don't believe this code requires any developer documentation.)
