### PR TITLE
Cover block: change minimum height input step size to 1

### DIFF
--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -110,7 +110,7 @@ const CoverHeightInput = withInstanceId(
 					onBlur={ onBlurEvent }
 					value={ temporaryInput !== null ? temporaryInput : value }
 					min={ COVER_MIN_HEIGHT }
-					step="10"
+					step="1"
 				/>
 			</BaseControl>
 		);


### PR DESCRIPTION
## Description
Closes #17920

This PR changes the step size of the minimum height input in the Cover block from 10 to 1.