### PR TITLE
Prevent prependHttp from failing if url is not defined

### DIFF
--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -227,7 +227,7 @@ class InlineLinkUI extends Component {
 						onKeyPress={ stopKeyPropagation }
 						url={ url }
 						onEditLinkClick={ this.editLink }
-						linkClassName={ isValidHref( prependHTTP( url ) ) ? undefined : 'has-invalid-link' }
+						linkClassName={ url && isValidHref( prependHTTP( url ) ) ? undefined : 'has-invalid-link' }
 					/>
 				) }
 			</URLPopoverAtLink>

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -227,7 +227,7 @@ class InlineLinkUI extends Component {
 						onKeyPress={ stopKeyPropagation }
 						url={ url }
 						onEditLinkClick={ this.editLink }
-						linkClassName={ url && isValidHref( prependHTTP( url ) ) ? undefined : 'has-invalid-link' }
+						linkClassName={ isValidHref( prependHTTP( url ) ) ? undefined : 'has-invalid-link' }
 					/>
 				) }
 			</URLPopoverAtLink>

--- a/packages/url/src/index.js
+++ b/packages/url/src/index.js
@@ -360,6 +360,10 @@ export function removeQueryArgs( url, ...args ) {
  * @return {string} The updated URL.
  */
 export function prependHTTP( url ) {
+	if ( ! url ) {
+		return url;
+	}
+
 	url = url.trim();
 	if ( ! USABLE_HREF_REGEXP.test( url ) && ! EMAIL_REGEXP.test( url ) ) {
 		return 'http://' + url;


### PR DESCRIPTION
## Description

The url package methods don't defend against undefined values being passed in, so this PR adds a check at the caller end in the inline link component which fixes #17657.

It might be better to defend against this at the prependHttp end, but maybe it is a deliberate decision that all the methods in this package leave checking to the caller. Also, changing the prependHttp method would require updating the related index.d.ts to allow undefined or false as an optional return type - but happy to look at doing that if it is a preferred approach

## How has this been tested?

- Copy text from a source where there is a tag with no href or create a link with no href when editing a block in HTML mode
- In visual mode, click on the link or drag over it (like when you want to select text containing a anchor with no href).
- You should see a broken block error
- Apply this patch and repeat the above steps
 - Block should not break this time

## Screenshots 

Before:

<img width="515" alt="before" src="https://user-images.githubusercontent.com/3629020/66729681-75845000-eea9-11e9-88fb-3a0f344b0c99.png">

After: 

<img width="456" alt="after" src="https://user-images.githubusercontent.com/3629020/66729678-70bf9c00-eea9-11e9-9803-d632015d1cf6.png">

## Types of changes
Adds a simple check to see if value defined before passing in to  prependHttp

## Checklist:
- [ X ] My code is tested - juts manually, couldn't see an easy/obvious way to unit test this.
- [ X ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [  NA ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [  NA ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ NA ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
