### PR TITLE
Navigation Menu: unify `block.json` for in server and client side

### DIFF
--- a/packages/block-library/src/navigation-menu/block.json
+++ b/packages/block-library/src/navigation-menu/block.json
@@ -1,0 +1,14 @@
+{
+	"name": "core/navigation-menu",
+	"category": "layout",
+	"attributes": {
+		"className": {
+			"type": "string"
+		},
+
+		"automaticallyAdd": {
+			"type": "boolean",
+			"default": false
+		}
+	}
+}

--- a/packages/block-library/src/navigation-menu/index.php
+++ b/packages/block-library/src/navigation-menu/index.php
@@ -69,8 +69,12 @@ function register_block_core_navigation_menu() {
 		);
 	}
 
+	// Pick up block name and remove it from the block-definition object.
 	$block_name = $block_definition['name'];
 	unset( $block_definition['name'] );
+
+	// Add render callback into block-definition object.
+	$block_definition['render_callback'] = 'render_block_navigation_menu';
 
 	register_block_type(
 		$block_name,

--- a/packages/block-library/src/navigation-menu/index.php
+++ b/packages/block-library/src/navigation-menu/index.php
@@ -56,18 +56,25 @@ function build_navigation_menu_html( $block ) {
  * @uses render_block_navigation_menu()
  */
 function register_block_core_navigation_menu() {
+	$block_content = file_get_contents ( dirname( __FILE__ ) . '/../../../packages/block-library/src/navigation-menu/block.json' );
+	if ( ! $block_content ) {
+		throw new Error(
+			'There is not a block.json file defined for the block!'
+		);
+	}
+	$block_definition = json_decode( $block_content, true );
+	if( is_null( $block_definition ) ) {
+		throw new Error(
+			'There is not possible to parse the block.json file!'
+		);
+	}
+
+	$block_name = $block_definition['name'];
+	unset( $block_definition['name'] );
+
 	register_block_type(
-		'core/navigation-menu',
-		array(
-			'category'        => 'layout',
-			'attributes'      => array(
-				'automaticallyAdd' => array(
-					'type'    => 'boolean',
-					'default' => false,
-				),
-			),
-			'render_callback' => 'render_block_navigation_menu',
-		)
+		$block_name,
+		$block_definition
 	);
 }
 


### PR DESCRIPTION
## Description
This PR exports the block definition in its own `block.json file`, making it clearer to read and going a step ahead in the development process. For now, the data of this file is consumed in the server-side by the function which registers the block, but it's quite probable that in the short time we will export this metadata in the core registration process.

## How has this been tested?
1) Apply the patch.
2) Test the navigation menu. Everything should work as expected.
3) Edit the `block.json` file and see how the changes affect the app.
