### PR TITLE
Update image URLs for preview content.

### DIFF
--- a/packages/block-library/src/columns/index.js
+++ b/packages/block-library/src/columns/index.js
@@ -38,7 +38,7 @@ export const settings = {
 					{
 						name: 'core/image',
 						attributes: {
-							url: 'https://upload.wikimedia.org/wikipedia/commons/9/95/Windbuchencom.jpg',
+							url: 'https://s.w.org/images/core/5.3/Windbuchencom.jpg',
 						},
 					},
 					{

--- a/packages/block-library/src/cover/index.js
+++ b/packages/block-library/src/cover/index.js
@@ -28,7 +28,7 @@ export const settings = {
 		attributes: {
 			customOverlayColor: '#065174',
 			dimRatio: 40,
-			url: 'https://upload.wikimedia.org/wikipedia/commons/9/95/Windbuchencom.jpg',
+			url: 'https://s.w.org/images/core/5.3/Windbuchencom.jpg',
 		},
 		innerBlocks: [
 			{

--- a/packages/block-library/src/gallery/index.js
+++ b/packages/block-library/src/gallery/index.js
@@ -26,7 +26,7 @@ export const settings = {
 		attributes: {
 			columns: 2,
 			images: [
-				{ url: 'https://s.w.org/images/core/5.3/Glacial_lakes,_Bhutan.jpg' },
+				{ url: 'https://s.w.org/images/core/5.3/Glacial_lakes%2C_Bhutan.jpg' },
 				{ url: 'https://s.w.org/images/core/5.3/Sediment_off_the_Yucatan_Peninsula.jpg' },
 			],
 		},

--- a/packages/block-library/src/gallery/index.js
+++ b/packages/block-library/src/gallery/index.js
@@ -26,8 +26,8 @@ export const settings = {
 		attributes: {
 			columns: 2,
 			images: [
-				{ url: 'https://upload.wikimedia.org/wikipedia/commons/c/c3/Glacial_lakes%2C_Bhutan.jpg' },
-				{ url: 'https://upload.wikimedia.org/wikipedia/commons/0/01/Sediment_off_the_Yucatan_Peninsula.jpg' },
+				{ url: 'https://s.w.org/images/core/5.3/Glacial_lakes,_Bhutan.jpg' },
+				{ url: 'https://s.w.org/images/core/5.3/Sediment_off_the_Yucatan_Peninsula.jpg' },
 			],
 		},
 	},

--- a/packages/block-library/src/image/index.js
+++ b/packages/block-library/src/image/index.js
@@ -28,7 +28,7 @@ export const settings = {
 	example: {
 		attributes: {
 			sizeSlug: 'large',
-			url: 'https://upload.wikimedia.org/wikipedia/commons/1/15/MtBlanc1.JPG',
+			url: 'https://s.w.org/images/core/5.3/MtBlanc1.jpg',
 			caption: __( 'Mont Blanc appears—still, snowy, and serene.' ),
 		},
 	},

--- a/packages/block-library/src/media-text/index.js
+++ b/packages/block-library/src/media-text/index.js
@@ -29,7 +29,7 @@ export const settings = {
 	example: {
 		attributes: {
 			mediaType: 'image',
-			mediaUrl: 'https://upload.wikimedia.org/wikipedia/commons/d/d4/Biologia_Centrali-Americana_-_Cantorchilus_semibadius_1902.jpg',
+			mediaUrl: 'https://s.w.org/images/core/5.3/Biologia_Centrali-Americana_-_Cantorchilus_semibadius_1902.jpg',
 		},
 		innerBlocks: [
 			{


### PR DESCRIPTION
This PR updates the URLs for preview content to ones referencing s.w.org:

https://core.trac.wordpress.org/ticket/48292

Please test Image, Cover, Columns, Media & Text, and Gallery blocks in the Block Library, and verify they have image preview content. 