### PR TITLE
Fix icons for Media & Text in dark mode

### DIFF
--- a/packages/block-library/src/media-text/media-container.native.js
+++ b/packages/block-library/src/media-text/media-container.native.js
@@ -20,7 +20,6 @@ import {
 } from '@wordpress/components';
 import {
 	BlockControls,
-	BlockIcon,
 	MEDIA_TYPE_IMAGE,
 	MEDIA_TYPE_VIDEO,
 	MediaPlaceholder,

--- a/packages/block-library/src/media-text/media-container.native.js
+++ b/packages/block-library/src/media-text/media-container.native.js
@@ -32,6 +32,7 @@ import {
 import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { isURL } from '@wordpress/url';
+import { compose, withPreferredColorScheme } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -112,7 +113,8 @@ class MediaContainer extends Component {
 			return <Icon icon={ SvgIconRetry } { ...( styles.iconRetry, isVideo ? styles.iconRetryVideo : {} ) } />;
 		}
 
-		return <Icon icon={ icon } { ...styles.icon } />;
+		const iconStyle = this.props.getStylesFromColorScheme( styles.icon, styles.iconDark );
+		return <Icon icon={ icon } { ...iconStyle } />;
 	}
 
 	renderToolbarEditButton( open ) {
@@ -254,7 +256,7 @@ class MediaContainer extends Component {
 	renderPlaceholder() {
 		return (
 			<MediaPlaceholder
-				icon={ <BlockIcon icon={ icon } /> }
+				icon={ this.getIcon( false ) }
 				labels={ {
 					title: __( 'Media area' ),
 				} }
@@ -307,4 +309,7 @@ class MediaContainer extends Component {
 	}
 }
 
-export default withNotices( MediaContainer );
+export default compose(
+	withNotices,
+	withPreferredColorScheme,
+)( MediaContainer );

--- a/packages/block-library/src/media-text/style.native.scss
+++ b/packages/block-library/src/media-text/style.native.scss
@@ -52,6 +52,10 @@
 	height: 24px;
 }
 
+.iconDark {
+	fill: $white;
+}
+
 .iconRetry {
 	fill: #fff;
 	width: 100%;


### PR DESCRIPTION
## Description

The media & text placeholder icon was showing the wrong color in dark mode. This PR makes it white like the other blocks.

## How has this been tested?

Tested on gutenberg-mobile (https://github.com/wordpress-mobile/gutenberg-mobile/pull/1443):

1. Launch the app with the sample content
2. Notice the media-text placeholder icon has the same color as the image block


## Screenshots <!-- if applicable -->

![mt-icon-dark](https://user-images.githubusercontent.com/8739/66756036-77461780-ee99-11e9-8fc1-875453eb381a.png)


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
