### PR TITLE
Block Merge: guard for undefined attribute definition

### DIFF
--- a/packages/block-editor/src/store/effects.js
+++ b/packages/block-editor/src/store/effects.js
@@ -94,7 +94,7 @@ export default {
 			// is not a defined block attribute key. This can be the case if the
 			// fallback intance ID is used to store selection (and no RichText
 			// identifier is set), or when the identifier is wrong.
-			attributeDefinition
+			!! attributeDefinition
 		);
 
 		if ( ! attributeDefinition ) {

--- a/packages/block-editor/src/store/effects.js
+++ b/packages/block-editor/src/store/effects.js
@@ -100,7 +100,7 @@ export default {
 		if ( ! attributeDefinition ) {
 			if ( typeof attributeKey === 'number' ) {
 				window.console.error(
-					'RichText needs an identifier prop that is the block attribute key of the attribute it controls.'
+					`RichText needs an identifier prop that is the block attribute key of the attribute it controls. Its type is expected to be a string, but was ${ typeof attributeKey }`
 				);
 			} else {
 				window.console.error(

--- a/packages/block-editor/src/store/effects.js
+++ b/packages/block-editor/src/store/effects.js
@@ -84,11 +84,30 @@ export default {
 		const blockB = getBlock( state, clientIdB );
 		const blockBType = getBlockType( blockB.name );
 		const { clientId, attributeKey, offset } = getSelectionStart( state );
-		const hasTextSelection = (
+		const selectedBlockType = clientId === clientIdA ? blockAType : blockBType;
+		const attributeDefinition = selectedBlockType.attributes[ attributeKey ];
+		const canRestoreTextSelection = (
 			( clientId === clientIdA || clientId === clientIdB ) &&
 			attributeKey !== undefined &&
-			offset !== undefined
+			offset !== undefined &&
+			// We cannot restore text selection if the RichText identifier
+			// is not a defined block attribute key. This can be the case if the
+			// fallback intance ID is used to store selection (and no RichText
+			// identifier is set), or when the identifier is wrong.
+			attributeDefinition
 		);
+
+		if ( ! attributeDefinition ) {
+			if ( typeof attributeKey === 'number' ) {
+				window.console.error(
+					'RichText needs an identifier prop that is the block attribute key of the attribute it controls.'
+				);
+			} else {
+				window.console.error(
+					'The RichText identifier prop does not match any attributes defined by the block.'
+				);
+			}
+		}
 
 		// A robust way to retain selection position through various transforms
 		// is to insert a special character at the position and then recover it.
@@ -98,14 +117,13 @@ export default {
 		const cloneA = cloneBlock( blockA );
 		const cloneB = cloneBlock( blockB );
 
-		if ( hasTextSelection ) {
+		if ( canRestoreTextSelection ) {
 			const selectedBlock = clientId === clientIdA ? cloneA : cloneB;
 			const html = selectedBlock.attributes[ attributeKey ];
-			const selectedBlockType = clientId === clientIdA ? blockAType : blockBType;
 			const {
 				multiline: multilineTag,
 				__unstableMultilineWrapperTags: multilineWrapperTags,
-			} = selectedBlockType.attributes[ attributeKey ];
+			} = attributeDefinition;
 			const value = insert( create( {
 				html,
 				multilineTag,
@@ -135,7 +153,7 @@ export default {
 			blocksWithTheSameType[ 0 ].attributes
 		);
 
-		if ( hasTextSelection ) {
+		if ( canRestoreTextSelection ) {
 			const newAttributeKey = findKey( updatedAttributes, ( v ) =>
 				typeof v === 'string' && v.indexOf( START_OF_SELECTED_AREA ) !== -1
 			);


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
Related: https://github.com/wordpress-mobile/WordPress-iOS/issues/11950. Cc @SergioEstevao.

Currently, when a block implements a merge function, but doesn't set the `identifier` prop for `RichText`, merging will error because selection cannot be restored. Instead, we should log an error and let the merge continue without restoring selection.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
