### PR TITLE
Fix: Gradient presets to verify some MU kses rules

### DIFF
--- a/packages/block-editor/src/store/defaults.js
+++ b/packages/block-editor/src/store/defaults.js
@@ -155,76 +155,76 @@ export const SETTINGS_DEFAULTS = {
 	gradients: [
 		{
 			name: __( 'Vivid cyan blue to vivid purple' ),
-			gradient: 'linear-gradient(135deg, rgba(6, 147, 227, 1) 0%, rgb(155, 81, 224) 100%)',
+			gradient: 'linear-gradient(135deg,rgba(6,147,227,1) 0%,rgb(155,81,224) 100%)',
 		},
 		{
 			name: __( 'Vivid green cyan to vivid cyan blue' ),
-			gradient: 'linear-gradient(135deg, rgba(0, 208, 132, 1) 0%, rgba(6, 147, 227, 1) 100%)',
+			gradient: 'linear-gradient(135deg,rgba(0,208,132,1) 0%,rgba(6,147,227,1) 100%)',
 		},
 		{
 			name: __( 'Light green cyan to vivid green cyan' ),
-			gradient: 'linear-gradient(135deg, rgb(122, 220, 180) 0%, rgb(0, 208, 130) 100%)',
+			gradient: 'linear-gradient(135deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%)',
 		},
 		{
 			name: __( 'Luminous vivid amber to luminous vivid orange' ),
-			gradient: 'linear-gradient(135deg, rgba(252, 185, 0, 1) 0%, rgba(255, 105, 0, 1) 100%)',
+			gradient: 'linear-gradient(135deg,rgba(252,185,0,1) 0%,rgba(255,105,0,1) 100%)',
 		},
 		{
 			name: __( 'Luminous vivid orange to vivid red' ),
-			gradient: 'linear-gradient(135deg, rgba(255, 105, 0, 1) 0%, rgb(207, 46, 46) 100%)',
+			gradient: 'linear-gradient(135deg,rgba(255,105,0,1) 0%,rgb(207,46,46) 100%)',
 		},
 		{
 			name: __( 'Very light gray to cyan bluish gray' ),
-			gradient: 'linear-gradient(135deg, rgb(238, 238, 238) 0%, rgb(169, 184, 195)',
+			gradient: 'linear-gradient(135deg,rgb(238,238,238) 0%,rgb(169,184,195) 100%)',
 		},
 		// The following use new, customized colors.
 		{
 			name: __( 'Cool to warm spectrum' ),
-			gradient: 'linear-gradient(135deg, rgb(74, 234, 220), rgb(151, 120, 209), rgb(207, 42, 186), rgb(238, 44, 130), rgb(251, 105, 98),rgb(254, 248, 76)',
+			gradient: 'linear-gradient(135deg,rgb(74,234,220) 0%,rgb(151,120,209) 20%,rgb(207,42,186) 40%,rgb(238,44,130) 60%,rgb(251,105,98) 80%,rgb(254,248,76) 100%)',
 		},
 		{
 			name: __( 'Blush light purple' ),
-			gradient: 'linear-gradient(135deg, rgb(255, 206, 236), rgb(152, 150, 240)',
+			gradient: 'linear-gradient(135deg,rgb(255,206,236) 0%,rgb(152,150,240) 100%)',
 		},
 		{
 			name: __( 'Blush bordeaux' ),
-			gradient: 'linear-gradient(135deg, rgb(254, 205, 165), rgb(254, 45, 45), rgb(107, 0, 62)',
+			gradient: 'linear-gradient(135deg,rgb(254,205,165) 0%,rgb(254,45,45) 50%,rgb(107,0,62) 100%)',
 		},
 		{
 			name: __( 'Purple crush' ),
-			gradient: 'linear-gradient(135deg, rgb(52, 226, 228), rgb(71, 33, 251), rgb(171, 29, 254)',
+			gradient: 'linear-gradient(135deg,rgb(52,226,228) 0%,rgb(71,33,251) 50%,rgb(171,29,254) 100%)',
 		},
 		{
 			name: __( 'Luminous dusk' ),
-			gradient: 'linear-gradient(135deg, rgb(255, 203, 112), rgb(199, 81, 192), rgb(65, 88, 208)',
+			gradient: 'linear-gradient(135deg,rgb(255,203,112) 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%)',
 		},
 		{
 			name: __( 'Hazy dawn' ),
-			gradient: 'linear-gradient(135deg, rgb(250, 172, 168), rgb(218, 208, 236)',
+			gradient: 'linear-gradient(135deg,rgb(250,172,168) 0%,rgb(218,208,236) 100%)',
 		},
 		{
 			name: __( 'Pale ocean' ),
-			gradient: 'linear-gradient(135deg, rgb(255, 245, 203), rgb(182, 227, 212), rgb(51, 167, 181)',
+			gradient: 'linear-gradient(135deg,rgb(255,245,203) 0%,rgb(182,227,212) 50%,rgb(51,167,181) 100%)',
 		},
 		{
 			name: __( 'Electric grass' ),
-			gradient: 'linear-gradient(135deg, rgb(202, 248, 128), rgb(113, 206, 126)',
+			gradient: 'linear-gradient(135deg,rgb(202,248,128) 0%,rgb(113,206,126) 100%)',
 		},
 		{
 			name: __( 'Subdued olive' ),
-			gradient: 'linear-gradient(135deg, rgb(250, 250, 225), rgb(103, 166, 113)',
+			gradient: 'linear-gradient(135deg,rgb(250,250,225) 0%,rgb(103,166,113) 100%)',
 		},
 		{
 			name: __( 'Atomic cream' ),
-			gradient: 'linear-gradient(135deg, rgb(253, 215, 154), rgb(0, 74, 89)',
+			gradient: 'linear-gradient(135deg,rgb(253,215,154) 0%,rgb(0,74,89) 100%)',
 		},
 		{
 			name: __( 'Nightshade' ),
-			gradient: 'linear-gradient(135deg, rgb(51, 9, 104), rgb(49, 205, 207)',
+			gradient: 'linear-gradient(135deg,rgb(51,9,104) 0%,rgb(49,205,207) 100%)',
 		},
 		{
 			name: __( 'Midnight' ),
-			gradient: 'linear-gradient(135deg, rgb(2, 3, 129), rgb(40, 116, 252)',
+			gradient: 'linear-gradient(135deg,rgb(2,3,129) 0%,rgb(40,116,252) 100%)',
 		},
 	],
 };


### PR DESCRIPTION
## Description
Fixes part of: https://github.com/WordPress/gutenberg/issues/17938
It seems like some kses rules on WP multi sites don't accept the spacing in the gradients our presets were using.

> Those whitespaces are removed by the [`wp_kses_hair` function](https://core.trac.wordpress.org/browser/tags/5.2.3/src/wp-includes/kses.php?marks=1223#L1223) which is executed by the [KSES filters triggered when saving the post](https://core.trac.wordpress.org/browser/tags/5.2.3/src/wp-includes/kses.php?marks=1989#L1977). These filters are only registered [when a user doesn't have the `unfiltered_html` capability](https://core.trac.wordpress.org/browser/tags/5.2.3/src/wp-includes/kses.php?marks=2033#L2029) (which is the case for [multisite regular admins](https://core.trac.wordpress.org/browser/tags/5.2.3/src/wp-includes/capabilities.php?marks=401,402#L397)).

We were getting the following validation error:
```
Content generated by `save` function:

<div class="wp-block-button"><a class="wp-block-button__link has-background" style="background:linear-gradient(135deg, rgba(6, 147, 227, 1) 0%, rgb(155, 81, 224) 100%)">test21</a></div>

Content retrieved from post body:

<div class="wp-block-button"><a class="wp-block-button__link has-background" style="background:linear-gradient(135deg,rgba(6,147,227,1) 0%,rgb(155,81,224) 100%);">test21</a></div>
```
Provided by @mmtr 

This PR's fixes the spacing, and given that for the custom gradient works we don't accept implicit gradient position values (at least initially), this PR also adds explicit control point values (%'s) for the presets that did not explicitly set the value before ( to avoid changing presets again soon).

## How has this been tested?
I verified the gradients look as before.
I tested on an admin user on a multi-site network that the new gradient attribute values are accepted.
