### PR TITLE
Changing Unsupported title and adding help info block (Issue #479)

### DIFF
--- a/packages/block-library/src/missing/edit.native.js
+++ b/packages/block-library/src/missing/edit.native.js
@@ -33,28 +33,32 @@ export class UnsupportedBlockEdit extends Component {
 	}
 
 	renderHelpIcon() {
-		return <View style={ styles.helpIconContainer } >
-			<Icon
-				className="unsupported-icon-help"
-				label={ __( 'Help icon' ) }
-				icon="editor-help"
-			/>
-		</View>;
+		return <TouchableWithoutFeedback
+			accessibilityLabel={ __( 'Help icon' ) }
+			accessibilityRole={ 'button' }
+			accessibilityHint={ __( 'Tap here to show help' ) }
+			onPress={ this.toggleSheet.bind( this ) }
+		>
+			<View style={ styles.helpIconContainer } >
+				<Icon
+					className="unsupported-icon-help"
+					label={ __( 'Help icon' ) }
+					icon="editor-help"
+				/>
+			</View>
+		</TouchableWithoutFeedback>;
 	}
 
 	renderSheetButton( text, action ) {
-		// This margin is necessary for Android because of the way the modals on each platform are
-		// being rendered. This extra margin makes the modals look the same on each platform.
-		const marginBottom = isAndroid ? 16 : 0;
 		return <TouchableOpacity
 			onPress={ action() }
-			style={ [ styles.infoButton, { marginBottom } ] }
+			style={ styles.sheetButton }
 		>
-			<Text style={ styles.infoButtonText } >{ text }</Text>
+			<Text style={ styles.sheetButtonText } >{ text }</Text>
 		</TouchableOpacity>;
 	}
 
-	renderSheet() {
+	renderSheet( title ) {
 		return <BottomSheet
 			isVisible={ this.state.showHelp }
 			hideHeader
@@ -63,12 +67,11 @@ export class UnsupportedBlockEdit extends Component {
 			<View style={ styles.infoContainer } >
 				<Icon icon="editor-help" style={ styles.infoIcon } size={ styles.infoIcon.size } />
 				<Text style={ [ styles.infoText, styles.infoTitle ] }>
-					{ __( 'This block isn\'t yet supported on WordPress for ' + platformText ) }
+					{ __( title + ' isn\'t yet supported on WordPress for ' + platformText ) }
 				</Text>
 				<Text style={ [ styles.infoText, styles.infoDescription ] }>
 					{ __( 'We are working hard to add more blocks with each release. In the meantime, you can also edit this post on the web.' ) }
 				</Text>
-				{ this.renderSheetButton( __( 'Edit in Safari' ), () => this.toggleSheet.bind( this ) ) }
 				{ this.renderSheetButton( __( 'Close' ), () => this.toggleSheet.bind( this ) ) }
 			</View>
 		</BottomSheet>;
@@ -86,19 +89,12 @@ export class UnsupportedBlockEdit extends Component {
 		const iconStyle = getStylesFromColorScheme( styles.unsupportedBlockIcon, styles.unsupportedBlockIconDark );
 		const iconClassName = 'unsupported-icon' + '-' + preferredColorScheme;
 		return (
-			<TouchableWithoutFeedback
-				accessibilityLabel={ __( originalName + ' block' ) }
-				accessibilityRole={ 'button' }
-				accessibilityHint={ __( 'Tap the top right corner to show help' ) }
-				onPress={ this.toggleSheet.bind( this ) }
-			>
-				<View style={ getStylesFromColorScheme( styles.unsupportedBlock, styles.unsupportedBlockDark ) }>
-					{ this.renderHelpIcon() }
-					<Icon className={ iconClassName } icon={ icon && icon.src ? icon.src : icon } color={ iconStyle.color } />
-					<Text style={ titleStyle }>{ title }</Text>
-					{ this.renderSheet() }
-				</View>
-			</TouchableWithoutFeedback>
+			<View style={ getStylesFromColorScheme( styles.unsupportedBlock, styles.unsupportedBlockDark ) }>
+				{ this.renderHelpIcon() }
+				<Icon className={ iconClassName } icon={ icon && icon.src ? icon.src : icon } color={ iconStyle.color } />
+				<Text style={ titleStyle }>{ title }</Text>
+				{ this.renderSheet( title ) }
+			</View>
 		);
 	}
 }

--- a/packages/block-library/src/missing/edit.native.js
+++ b/packages/block-library/src/missing/edit.native.js
@@ -1,12 +1,12 @@
 /**
  * External dependencies
  */
-import { View, Text } from 'react-native';
+import { Platform, View, Text } from 'react-native';
 
 /**
  * WordPress dependencies
  */
-import { Icon } from '@wordpress/components';
+import { BottomSheet, Button, Icon, IconButton } from '@wordpress/components';
 import { withPreferredColorScheme } from '@wordpress/compose';
 import { coreBlocks } from '@wordpress/block-library';
 import { normalizeIconObject } from '@wordpress/blocks';
@@ -18,13 +18,61 @@ import { __ } from '@wordpress/i18n';
  */
 import styles from './style.scss';
 
+const isAndroid = Platform.OS === 'android';
+const platformText = isAndroid ? 'Android' : 'iOS';
 export class UnsupportedBlockEdit extends Component {
+	constructor( props ) {
+		super( props );
+		this.state = { showHelp: false };
+	}
+
+	toggleSheet() {
+		this.setState( {
+			showHelp: ! this.state.showHelp,
+		} );
+	}
+
+	renderHelpIcon() {
+		return <View style={ styles.helpIconContainer } >
+			<IconButton
+				className="unsupported-icon-help"
+				label={ __( 'Help icon' ) }
+				onClick={ this.toggleSheet.bind( this ) }
+				icon="editor-help"
+			/>
+		</View>;
+	}
+
+	renderSheet() {
+		return <BottomSheet
+			isVisible={ this.state.showHelp }
+			hideHeader={ true }
+			onClose={ this.toggleSheet.bind( this ) }
+			contentStyle={ styles.content }
+		>
+			<Icon icon="info-outline" style={ styles.infoIcon } size={ styles.infoIcon.size } />
+			<Text style={ styles.infoTitle }>
+				{ __( 'This block isn\'t yet supported on WordPress for ' + platformText ) }
+			</Text>
+			<Button
+				onClick={ this.toggleSheet.bind( this ) }
+				fixedRatio={ false }
+			>
+				<View style={ styles.infoCloseButton } >
+					<Text style={ styles.infoCloseButtonText } >
+						{ __( 'Close' ) }
+					</Text>
+				</View>
+			</Button>
+		</BottomSheet>;
+	}
+
 	render() {
 		const { originalName } = this.props.attributes;
 		const { getStylesFromColorScheme, preferredColorScheme } = this.props;
 		const blockType = coreBlocks[ originalName ];
 
-		const title = blockType ? blockType.settings.title : __( 'Unsupported' );
+		const title = blockType ? blockType.settings.title : originalName;
 		const titleStyle = getStylesFromColorScheme( styles.unsupportedBlockMessage, styles.unsupportedBlockMessageDark );
 
 		const icon = blockType ? normalizeIconObject( blockType.settings.icon ) : 'admin-plugins';
@@ -32,8 +80,10 @@ export class UnsupportedBlockEdit extends Component {
 		const iconClassName = 'unsupported-icon' + '-' + preferredColorScheme;
 		return (
 			<View style={ getStylesFromColorScheme( styles.unsupportedBlock, styles.unsupportedBlockDark ) }>
+				{ this.renderHelpIcon() }
 				<Icon className={ iconClassName } icon={ icon && icon.src ? icon.src : icon } color={ iconStyle.color } />
 				<Text style={ titleStyle }>{ title }</Text>
+				{ this.renderSheet() }
 			</View>
 		);
 	}

--- a/packages/block-library/src/missing/edit.native.js
+++ b/packages/block-library/src/missing/edit.native.js
@@ -42,28 +42,34 @@ export class UnsupportedBlockEdit extends Component {
 		</View>;
 	}
 
-	renderSheet() {
+	renderSheetButton( text, action ) {
 		// This margin is necessary for Android because of the way the modals on each platform are
 		// being rendered. This extra margin makes the modals look the same on each platform.
 		const marginBottom = isAndroid ? 16 : 0;
+		return <TouchableOpacity
+			onPress={ action() }
+			style={ [ styles.infoButton, { marginBottom } ] }
+		>
+			<Text style={ styles.infoButtonText } >{ text }</Text>
+		</TouchableOpacity>;
+	}
+
+	renderSheet() {
 		return <BottomSheet
 			isVisible={ this.state.showHelp }
 			hideHeader
 			onClose={ this.toggleSheet.bind( this ) }
 		>
 			<View style={ styles.infoContainer } >
-				<Icon icon="info-outline" style={ styles.infoIcon } size={ styles.infoIcon.size } />
-				<Text style={ styles.infoTitle }>
+				<Icon icon="editor-help" style={ styles.infoIcon } size={ styles.infoIcon.size } />
+				<Text style={ [ styles.infoText, styles.infoTitle ] }>
 					{ __( 'This block isn\'t yet supported on WordPress for ' + platformText ) }
 				</Text>
-				<TouchableOpacity
-					onPress={ this.toggleSheet.bind( this ) }
-					style={ [ styles.infoCloseButton, { marginBottom } ] }
-				>
-					<Text style={ styles.infoCloseButtonText } >
-						{ __( 'Close' ) }
-					</Text>
-				</TouchableOpacity>
+				<Text style={ [ styles.infoText, styles.infoDescription ] }>
+					{ __( 'We are working hard to add more blocks with each release. In the meantime, you can also edit this post on the web.' ) }
+				</Text>
+				{ this.renderSheetButton( __( 'Edit in Safari' ), () => this.toggleSheet.bind( this ) ) }
+				{ this.renderSheetButton( __( 'Close' ), () => this.toggleSheet.bind( this ) ) }
 			</View>
 		</BottomSheet>;
 	}

--- a/packages/block-library/src/missing/edit.native.js
+++ b/packages/block-library/src/missing/edit.native.js
@@ -43,6 +43,8 @@ export class UnsupportedBlockEdit extends Component {
 	}
 
 	renderSheet() {
+		// This margin is necessary for Android because of the way the modals on each platform are
+		// being rendered. This extra margin makes the modals look the same on each platform.
 		const marginBottom = isAndroid ? 16 : 0;
 		return <BottomSheet
 			isVisible={ this.state.showHelp }
@@ -81,7 +83,7 @@ export class UnsupportedBlockEdit extends Component {
 			<TouchableWithoutFeedback
 				accessibilityLabel={ __( originalName + ' block' ) }
 				accessibilityRole={ 'button' }
-				accessibilityHint={ __( 'Double click to show help' ) }
+				accessibilityHint={ __( 'Tap the top right corner to show help' ) }
 				onPress={ this.toggleSheet.bind( this ) }
 			>
 				<View style={ getStylesFromColorScheme( styles.unsupportedBlock, styles.unsupportedBlockDark ) }>

--- a/packages/block-library/src/missing/edit.native.js
+++ b/packages/block-library/src/missing/edit.native.js
@@ -1,12 +1,12 @@
 /**
  * External dependencies
  */
-import { Platform, View, Text } from 'react-native';
+import { Platform, View, Text, TouchableOpacity, TouchableWithoutFeedback } from 'react-native';
 
 /**
  * WordPress dependencies
  */
-import { BottomSheet, Button, Icon, IconButton } from '@wordpress/components';
+import { BottomSheet, Icon } from '@wordpress/components';
 import { withPreferredColorScheme } from '@wordpress/compose';
 import { coreBlocks } from '@wordpress/block-library';
 import { normalizeIconObject } from '@wordpress/blocks';
@@ -34,36 +34,35 @@ export class UnsupportedBlockEdit extends Component {
 
 	renderHelpIcon() {
 		return <View style={ styles.helpIconContainer } >
-			<IconButton
+			<Icon
 				className="unsupported-icon-help"
 				label={ __( 'Help icon' ) }
-				onClick={ this.toggleSheet.bind( this ) }
 				icon="editor-help"
 			/>
 		</View>;
 	}
 
 	renderSheet() {
+		const marginBottom = isAndroid ? 16 : 0;
 		return <BottomSheet
 			isVisible={ this.state.showHelp }
-			hideHeader={ true }
+			hideHeader
 			onClose={ this.toggleSheet.bind( this ) }
-			contentStyle={ styles.content }
 		>
-			<Icon icon="info-outline" style={ styles.infoIcon } size={ styles.infoIcon.size } />
-			<Text style={ styles.infoTitle }>
-				{ __( 'This block isn\'t yet supported on WordPress for ' + platformText ) }
-			</Text>
-			<Button
-				onClick={ this.toggleSheet.bind( this ) }
-				fixedRatio={ false }
-			>
-				<View style={ styles.infoCloseButton } >
+			<View style={ styles.infoContainer } >
+				<Icon icon="info-outline" style={ styles.infoIcon } size={ styles.infoIcon.size } />
+				<Text style={ styles.infoTitle }>
+					{ __( 'This block isn\'t yet supported on WordPress for ' + platformText ) }
+				</Text>
+				<TouchableOpacity
+					onPress={ this.toggleSheet.bind( this ) }
+					style={ [ styles.infoCloseButton, { marginBottom } ] }
+				>
 					<Text style={ styles.infoCloseButtonText } >
 						{ __( 'Close' ) }
 					</Text>
-				</View>
-			</Button>
+				</TouchableOpacity>
+			</View>
 		</BottomSheet>;
 	}
 
@@ -79,12 +78,19 @@ export class UnsupportedBlockEdit extends Component {
 		const iconStyle = getStylesFromColorScheme( styles.unsupportedBlockIcon, styles.unsupportedBlockIconDark );
 		const iconClassName = 'unsupported-icon' + '-' + preferredColorScheme;
 		return (
-			<View style={ getStylesFromColorScheme( styles.unsupportedBlock, styles.unsupportedBlockDark ) }>
-				{ this.renderHelpIcon() }
-				<Icon className={ iconClassName } icon={ icon && icon.src ? icon.src : icon } color={ iconStyle.color } />
-				<Text style={ titleStyle }>{ title }</Text>
-				{ this.renderSheet() }
-			</View>
+			<TouchableWithoutFeedback
+				accessibilityLabel={ __( originalName + ' block' ) }
+				accessibilityRole={ 'button' }
+				accessibilityHint={ __( 'Double click to show help' ) }
+				onPress={ this.toggleSheet.bind( this ) }
+			>
+				<View style={ getStylesFromColorScheme( styles.unsupportedBlock, styles.unsupportedBlockDark ) }>
+					{ this.renderHelpIcon() }
+					<Icon className={ iconClassName } icon={ icon && icon.src ? icon.src : icon } color={ iconStyle.color } />
+					<Text style={ titleStyle }>{ title }</Text>
+					{ this.renderSheet() }
+				</View>
+			</TouchableWithoutFeedback>
 		);
 	}
 }

--- a/packages/block-library/src/missing/style.native.scss
+++ b/packages/block-library/src/missing/style.native.scss
@@ -9,10 +9,14 @@
 }
 
 .helpIconContainer {
-	padding-top: 8;
-	padding-right: 0;
-	height: 24;
-	width: 100%;
+	position: absolute;
+	top: 0;
+	right: 0;
+	height: 48;
+	width: 48;
+	padding-top: 12;
+	padding-right: 12;
+	justify-content: flex-start;
 	align-items: flex-end;
 }
 
@@ -23,43 +27,47 @@
 }
 
 .infoIcon {
-	size: 32;
-	height: 32;
+	size: 36;
+	height: 36;
 	padding-top: 8;
 	padding-bottom: 8;
-	color: $gray-darken-30;
 }
 
 .infoText {
 	text-align: center;
-	font-size: 18;
 }
 
 .infoTitle {
 	padding-top: 8;
 	padding-bottom: 12;
+	font-size: 20;
 	font-weight: bold;
+	color: $gray-dark;
 }
 
 .infoDescription {
 	padding-bottom: 24;
+	font-size: 16;
+	color: $gray-darken-20;
 }
 
-.infoButton {
+.sheetButton {
+	border-top-width: 1px;
+	border-color: #f0f0f0;
 	height: 48;
 	width: 100%;
 	justify-content: center;
 }
 
-.infoButtonText {
+.sheetButtonText {
 	font-size: 16;
 	text-align: center;
-	color: $gray-darken-30;
+	color: #2271b1;
 }
 
 .unsupportedBlock {
-	background-color: #e9eff3; // grey lighten 30
-	padding-top: 0;
+	background-color: $gray-lighten-30;
+	padding-top: 24;
 	padding-bottom: 24;
 	padding-left: 8;
 	padding-right: 8;

--- a/packages/block-library/src/missing/style.native.scss
+++ b/packages/block-library/src/missing/style.native.scss
@@ -1,9 +1,9 @@
 /** @format */
 .content {
 	padding-top: 8;
-	padding-bottom: 16;
-	padding-left: 16;
-	padding-right: 16;
+	padding-bottom: 0;
+	padding-left: 24;
+	padding-right: 24;
 	align-items: center;
 	justify-content: space-evenly;
 }
@@ -25,26 +25,33 @@
 .infoIcon {
 	size: 32;
 	height: 32;
+	padding-top: 8;
+	padding-bottom: 8;
 	color: $gray-darken-30;
 }
 
-.infoTitle {
-	padding-top: 16;
-	padding-bottom: 8;
-	padding-left: 16;
-	padding-right: 16;
+.infoText {
 	text-align: center;
 	font-size: 18;
+}
+
+.infoTitle {
+	padding-top: 8;
+	padding-bottom: 12;
 	font-weight: bold;
 }
 
-.infoCloseButton {
+.infoDescription {
+	padding-bottom: 24;
+}
+
+.infoButton {
 	height: 48;
 	width: 100%;
 	justify-content: center;
 }
 
-.infoCloseButtonText {
+.infoButtonText {
 	font-size: 16;
 	text-align: center;
 	color: $gray-darken-30;

--- a/packages/block-library/src/missing/style.native.scss
+++ b/packages/block-library/src/missing/style.native.scss
@@ -9,21 +9,28 @@
 }
 
 .helpIconContainer {
-	padding-top: 16;
-	padding-right: 8;
+	padding-top: 8;
+	padding-right: 0;
 	height: 24;
 	width: 100%;
 	align-items: flex-end;
 }
 
+.infoContainer {
+	flex-direction: column;
+	align-items: center;
+	justify-content: flex-end;
+}
+
 .infoIcon {
 	size: 32;
+	height: 32;
 	color: $gray-darken-30;
 }
 
 .infoTitle {
 	padding-top: 16;
-	padding-bottom: 24;
+	padding-bottom: 8;
 	padding-left: 16;
 	padding-right: 16;
 	text-align: center;
@@ -32,8 +39,9 @@
 }
 
 .infoCloseButton {
-	height: 24;
-	flex: 1;
+	height: 48;
+	width: 100%;
+	justify-content: center;
 }
 
 .infoCloseButtonText {

--- a/packages/block-library/src/missing/style.native.scss
+++ b/packages/block-library/src/missing/style.native.scss
@@ -1,8 +1,50 @@
 /** @format */
+.content {
+	padding-top: 8;
+	padding-bottom: 16;
+	padding-left: 16;
+	padding-right: 16;
+	align-items: center;
+	justify-content: space-evenly;
+}
+
+.helpIconContainer {
+	padding-top: 16;
+	padding-right: 8;
+	height: 24;
+	width: 100%;
+	align-items: flex-end;
+}
+
+.infoIcon {
+	size: 32;
+	color: $gray-darken-30;
+}
+
+.infoTitle {
+	padding-top: 16;
+	padding-bottom: 24;
+	padding-left: 16;
+	padding-right: 16;
+	text-align: center;
+	font-size: 18;
+	font-weight: bold;
+}
+
+.infoCloseButton {
+	height: 24;
+	flex: 1;
+}
+
+.infoCloseButtonText {
+	font-size: 16;
+	text-align: center;
+	color: $gray-darken-30;
+}
 
 .unsupportedBlock {
 	background-color: #e9eff3; // grey lighten 30
-	padding-top: 24;
+	padding-top: 0;
 	padding-bottom: 24;
 	padding-left: 8;
 	padding-right: 8;

--- a/packages/block-library/src/missing/test/__snapshots__/edit.native.js.snap
+++ b/packages/block-library/src/missing/test/__snapshots__/edit.native.js.snap
@@ -1,0 +1,60 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Missing block renders without crashing 1`] = `
+<View>
+  <View>
+    <View
+      accessibilityLabel="Help icon"
+      accessibilityRole="button"
+      accessibilityStates={Array []}
+      accessible={true}
+      clickable={true}
+      isTVSelectable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "alignItems": "center",
+          "flex": 1,
+          "justifyContent": "center",
+          "opacity": 1,
+          "padding": 3,
+        }
+      }
+    >
+      <View
+        style={
+          Object {
+            "alignItems": "center",
+            "aspectRatio": 1,
+            "flex": 1,
+            "flexDirection": "row",
+            "justifyContent": "center",
+            "opacity": 1,
+          }
+        }
+      >
+        <View
+          style={
+            Object {
+              "flexDirection": "row",
+            }
+          }
+        >
+          Svg
+        </View>
+      </View>
+    </View>
+  </View>
+  Svg
+  <Text>
+    missing/block/title
+  </Text>
+  Modal
+</View>
+`;

--- a/packages/block-library/src/missing/test/__snapshots__/edit.native.js.snap
+++ b/packages/block-library/src/missing/test/__snapshots__/edit.native.js.snap
@@ -1,55 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Missing block renders without crashing 1`] = `
-<View>
+<View
+  accessibilityHint="Double click to show help"
+  accessibilityLabel="missing/block/title block"
+  accessibilityRole="button"
+  accessible={true}
+  clickable={true}
+  onClick={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+>
   <View>
-    <View
-      accessibilityLabel="Help icon"
-      accessibilityRole="button"
-      accessibilityStates={Array []}
-      accessible={true}
-      clickable={true}
-      isTVSelectable={true}
-      onClick={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
-      style={
-        Object {
-          "alignItems": "center",
-          "flex": 1,
-          "justifyContent": "center",
-          "opacity": 1,
-          "padding": 3,
-        }
-      }
-    >
-      <View
-        style={
-          Object {
-            "alignItems": "center",
-            "aspectRatio": 1,
-            "flex": 1,
-            "flexDirection": "row",
-            "justifyContent": "center",
-            "opacity": 1,
-          }
-        }
-      >
-        <View
-          style={
-            Object {
-              "flexDirection": "row",
-            }
-          }
-        >
-          Svg
-        </View>
-      </View>
-    </View>
+    Svg
   </View>
   Svg
   <Text>

--- a/packages/block-library/src/missing/test/edit.native.js
+++ b/packages/block-library/src/missing/test/edit.native.js
@@ -1,0 +1,94 @@
+/**
+ * External dependencies
+ */
+import renderer from 'react-test-renderer';
+import { Text } from 'react-native';
+jest.mock( 'Platform', () => {
+	const Platform = require.requireActual( 'Platform' );
+	Platform.OS = 'ios';
+	return Platform;
+} );
+
+/**
+ * WordPress dependencies
+ */
+import { BottomSheet, Icon } from '@wordpress/components';
+jest.mock( '@wordpress/blocks' );
+jest.mock( '../styles.scss', () => {
+	return {
+		infoIcon: { size: 32 },
+		unsupportedBlockIcon: { color: 'white' },
+	};
+} );
+
+/**
+ * Internal dependencies
+ */
+import UnsupportedBlockEdit from '../edit.native.js';
+
+const defaultAttributes = {
+	originalName: 'missing/block/title',
+};
+
+const getTestComponentWithContent = ( attributes = defaultAttributes ) => {
+	return renderer.create( <UnsupportedBlockEdit attributes={ attributes } /> );
+};
+
+describe( 'Missing block', () => {
+	it( 'renders without crashing', () => {
+		const component = getTestComponentWithContent();
+		const rendered = component.toJSON();
+		expect( rendered ).toMatchSnapshot();
+	} );
+
+	describe( 'help modal', () => {
+		it( 'renders help icon', () => {
+			const component = getTestComponentWithContent();
+			const testInstance = component.root;
+			const icons = testInstance.findAllByType( Icon );
+			expect( icons.length ).toBe( 2 );
+			expect( icons[ 0 ].props.icon ).toBe( 'editor-help' );
+		} );
+
+		it( 'renders info icon on modal', () => {
+			const component = getTestComponentWithContent();
+			const testInstance = component.root;
+			const bottomSheet = testInstance.findByType( BottomSheet );
+			const children = bottomSheet.props.children;
+			expect( children.length ).toBe( 3 );
+			expect( children[ 0 ].props.icon ).toBe( 'info-outline' );
+		} );
+
+		it( 'renders unsupported text on modal', () => {
+			const component = getTestComponentWithContent();
+			const testInstance = component.root;
+			const bottomSheet = testInstance.findByType( BottomSheet );
+			const children = bottomSheet.props.children;
+			expect( children[ 1 ].props.children ).toBe( 'This block isn\'t yet supported on WordPress for iOS' );
+		} );
+
+		it( 'renders close button on modal', () => {
+			const component = getTestComponentWithContent();
+			const testInstance = component.root;
+			const bottomSheet = testInstance.findByType( BottomSheet );
+			const children = bottomSheet.props.children;
+			expect( children[ 2 ].props.children.props.children.props.children ).toBe( 'Close' );
+		} );
+	} );
+
+	it( 'renders admin plugins icon', () => {
+		const component = getTestComponentWithContent();
+		const testInstance = component.root;
+		const icons = testInstance.findAllByType( Icon );
+		expect( icons.length ).toBe( 2 );
+		expect( icons[ 1 ].props.icon ).toBe( 'admin-plugins' );
+	} );
+
+	it( 'renders title text without crashing', () => {
+		const component = getTestComponentWithContent();
+		const testInstance = component.root;
+		const text = testInstance.findByType( Text );
+		expect( text ).toBeTruthy();
+		expect( text.props.children ).toBe( 'missing/block/title' );
+	} );
+} );

--- a/packages/block-library/src/missing/test/edit.native.js
+++ b/packages/block-library/src/missing/test/edit.native.js
@@ -54,7 +54,7 @@ describe( 'Missing block', () => {
 			const component = getTestComponentWithContent();
 			const testInstance = component.root;
 			const bottomSheet = testInstance.findByType( BottomSheet );
-			const children = bottomSheet.props.children;
+			const children = bottomSheet.props.children.props.children;
 			expect( children.length ).toBe( 3 );
 			expect( children[ 0 ].props.icon ).toBe( 'info-outline' );
 		} );
@@ -63,7 +63,7 @@ describe( 'Missing block', () => {
 			const component = getTestComponentWithContent();
 			const testInstance = component.root;
 			const bottomSheet = testInstance.findByType( BottomSheet );
-			const children = bottomSheet.props.children;
+			const children = bottomSheet.props.children.props.children;
 			expect( children[ 1 ].props.children ).toBe( 'This block isn\'t yet supported on WordPress for iOS' );
 		} );
 
@@ -71,8 +71,8 @@ describe( 'Missing block', () => {
 			const component = getTestComponentWithContent();
 			const testInstance = component.root;
 			const bottomSheet = testInstance.findByType( BottomSheet );
-			const children = bottomSheet.props.children;
-			expect( children[ 2 ].props.children.props.children.props.children ).toBe( 'Close' );
+			const children = bottomSheet.props.children.props.children;
+			expect( children[ 2 ].props.children.props.children ).toBe( 'Close' );
 		} );
 	} );
 


### PR DESCRIPTION
## Description
* Changed text on `Unsupported` block to show original block name.
* Added a help icon that shows additional information when the block is clicked.

## How has this been tested?
* Tested on simulator and on Android device.
* Wrote unit tests for component change.
* Component change affects all types of blocks that were defaulting to the 'Missing' block (aka `UnsupportedBlockEdit`)

## Screenshots
![unsupported](https://user-images.githubusercontent.com/13263478/66786237-b4b4a000-eead-11e9-9043-3ac47279c4e4.gif)

## Types of changes
* New feature: [Issue #479](https://github.com/wordpress-mobile/gutenberg-mobile/issues/479)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
