### PR TITLE
Optimize exports of the wp/compose package

### DIFF
--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -21,6 +21,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"react-native": "src/index",
+	"sideEffects": false,
 	"dependencies": {
 		"@babel/runtime": "^7.4.4",
 		"@wordpress/element": "file:../element",

--- a/packages/compose/src/higher-order/compose.js
+++ b/packages/compose/src/higher-order/compose.js
@@ -1,0 +1,14 @@
+/**
+ * External dependencies
+ */
+import { flowRight as compose } from 'lodash';
+
+/**
+ * Composes multiple higher-order components into a single higher-order component. Performs right-to-left function
+ * composition, where each successive invocation is supplied the return value of the previous.
+ *
+ * @param {...Function} hocs The HOC functions to invoke.
+ *
+ * @return {Function} Returns the new composite function.
+ */
+export default compose;

--- a/packages/compose/src/index.js
+++ b/packages/compose/src/index.js
@@ -1,20 +1,8 @@
-/**
- * External dependencies
- */
-import { flowRight } from 'lodash';
-
 // Utils
 export { default as createHigherOrderComponent } from './utils/create-higher-order-component';
 
-/**
- * Composes multiple higher-order components into a single higher-order component. Performs right-to-left function
- * composition, where each successive invocation is supplied the return value of the previous.
- *
- * @param {...Function} hocs The HOC functions to invoke.
- *
- * @return {Function} Returns the new composite function.
- */
-export { flowRight as compose };
+// Compose helper (aliased flowRight from Lodash)
+export { default as compose } from './higher-order/compose';
 
 // Higher-order components
 export { default as ifCondition } from './higher-order/if-condition';


### PR DESCRIPTION
Adds `sideEffects:false` to `package.json` so that unused exports can be optimized away by the bundler.

Moves the `compose` definition (i.e., reexport from Lodash) to its own module, so that we don't pull in Lodash just by importing something from `@wordpress/compose`. After this patch, one needs to import `compose` explicitly to trigger the Lodash import.
