### PR TITLE
Add simulate media queries

### DIFF
--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -87,3 +87,4 @@ export { default as WritingFlow } from './writing-flow';
  */
 
 export { default as BlockEditorProvider } from './provider';
+export { default as __experimentalSimulateMediaQuery } from './simulate-media-query';

--- a/packages/block-editor/src/components/simulate-media-query/index.js
+++ b/packages/block-editor/src/components/simulate-media-query/index.js
@@ -1,0 +1,103 @@
+/**
+ * External dependencies
+ */
+import {
+	filter,
+	get,
+	some,
+} from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { useEffect } from '@wordpress/element';
+
+const ENABLED_MEDIA_QUERY = '(min-width:0px)';
+const DISABLED_MEDIA_QUERY = '(min-width:999999px)';
+
+const VALID_MEDIA_QUERY_REGEX = /\((min|max)-width:([^\(]*?)px\)/g;
+
+function getStyleSheetsThatMatchPaths( partialPaths ) {
+	return filter(
+		get( window, [ 'document', 'styleSheets' ], [] ),
+		( styleSheet ) => {
+			return (
+				styleSheet.href &&
+				some(
+					partialPaths,
+					( partialPath ) => {
+						return styleSheet.href.includes( partialPath );
+					}
+				)
+			);
+		}
+	);
+}
+
+function isReplaceableMediaRule( rule ) {
+	if ( ! rule.media ) {
+		return false;
+	}
+	return !! rule.conditionText.match( VALID_MEDIA_QUERY_REGEX );
+}
+
+function replaceRule( styleSheet, newRuleText, index ) {
+	styleSheet.removeRule( index );
+	styleSheet.insertRule( newRuleText, index );
+}
+
+function replaceMediaQueryWithWidthEvaluation( ruleText, widthValue ) {
+	return ruleText.replace( VALID_MEDIA_QUERY_REGEX, ( match, minOrMax, value ) => {
+		const integerValue = parseInt( value );
+		if (
+			( minOrMax === 'min' && widthValue >= integerValue ) ||
+			( minOrMax === 'max' && widthValue <= integerValue )
+		) {
+			return ENABLED_MEDIA_QUERY;
+		}
+		return DISABLED_MEDIA_QUERY;
+	} );
+}
+
+export default function SimulateMediaQuery( { partialPaths, value } ) {
+	useEffect(
+		() => {
+			const styleSheets = getStyleSheetsThatMatchPaths( partialPaths );
+			const originalStyles = [];
+			styleSheets.forEach( ( styleSheet, styleSheetIndex ) => {
+				for ( let ruleIndex = 0; ruleIndex < styleSheet.rules.length; ++ruleIndex ) {
+					const rule = styleSheet.rules[ ruleIndex ];
+					if ( ! isReplaceableMediaRule( rule ) ) {
+						continue;
+					}
+					const ruleText = rule.cssText;
+					if ( ! originalStyles[ styleSheetIndex ] ) {
+						originalStyles[ styleSheetIndex ] = [];
+					}
+					originalStyles[ styleSheetIndex ][ ruleIndex ] = ruleText;
+					replaceRule(
+						styleSheet,
+						replaceMediaQueryWithWidthEvaluation( ruleText, value ),
+						ruleIndex
+					);
+				}
+			} );
+			return () => {
+				originalStyles.forEach( ( rulesCollection, styleSheetIndex ) => {
+					if ( ! rulesCollection ) {
+						return;
+					}
+					for ( let ruleIndex = 0; ruleIndex < rulesCollection.length; ++ruleIndex ) {
+						const originalRuleText = rulesCollection[ ruleIndex ];
+						if ( originalRuleText ) {
+							replaceRule( styleSheets[ styleSheetIndex ], originalRuleText, ruleIndex );
+						}
+					}
+				} );
+			};
+		},
+		[ partialPaths, value ]
+	);
+	return null;
+}
+

--- a/packages/block-editor/src/components/simulate-media-query/index.js
+++ b/packages/block-editor/src/components/simulate-media-query/index.js
@@ -59,14 +59,14 @@ function replaceMediaQueryWithWidthEvaluation( ruleText, widthValue ) {
 	} );
 }
 
-export default function SimulateMediaQuery( { partialPaths, value } ) {
+export default function SimulateMediaQuery( { partialPaths, width } ) {
 	useEffect(
 		() => {
 			const styleSheets = getStyleSheetsThatMatchPaths( partialPaths );
 			const originalStyles = [];
 			styleSheets.forEach( ( styleSheet, styleSheetIndex ) => {
-				for ( let ruleIndex = 0; ruleIndex < styleSheet.rules.length; ++ruleIndex ) {
-					const rule = styleSheet.rules[ ruleIndex ];
+				for ( let ruleIndex = 0; ruleIndex < styleSheet.cssRules.length; ++ruleIndex ) {
+					const rule = styleSheet.cssRules[ ruleIndex ];
 					if ( ! isReplaceableMediaRule( rule ) ) {
 						continue;
 					}
@@ -77,7 +77,7 @@ export default function SimulateMediaQuery( { partialPaths, value } ) {
 					originalStyles[ styleSheetIndex ][ ruleIndex ] = ruleText;
 					replaceRule(
 						styleSheet,
-						replaceMediaQueryWithWidthEvaluation( ruleText, value ),
+						replaceMediaQueryWithWidthEvaluation( ruleText, width ),
 						ruleIndex
 					);
 				}
@@ -96,7 +96,7 @@ export default function SimulateMediaQuery( { partialPaths, value } ) {
 				} );
 			};
 		},
-		[ partialPaths, value ]
+		[ partialPaths, width ]
 	);
 	return null;
 }

--- a/packages/edit-post/src/components/sidebar/settings-sidebar/index.js
+++ b/packages/edit-post/src/components/sidebar/settings-sidebar/index.js
@@ -37,7 +37,7 @@ function TestSimulateMediaQuery() {
 	const toggleUI = (
 		<ToggleControl
 			label={ __( 'Enabled width simulation' ) }
-			checked={ isSimulationEnable }
+			checked={ isSimulationEnabled }
 			onChange={ ( newValue ) => setIsSimulationEnabled( newValue ) }
 		/>
 	);

--- a/packages/edit-post/src/components/sidebar/settings-sidebar/index.js
+++ b/packages/edit-post/src/components/sidebar/settings-sidebar/index.js
@@ -48,7 +48,7 @@ function TestSimulateMediaQuery() {
 		<>
 			{ toggleUI }
 			<RangeControl
-				value={ simulateValue }
+				value={ simulationWidth }
 				label={ __( 'Simulated width value' ) }
 				min={ 0 }
 				max={ 2000 }

--- a/packages/edit-post/src/components/sidebar/settings-sidebar/index.js
+++ b/packages/edit-post/src/components/sidebar/settings-sidebar/index.js
@@ -32,7 +32,7 @@ const PARTIAL_PATHS = [
 	//'format-library/style.css',
 ];
 function TestSimulateMediaQuery() {
-	const [ simulateValue, setSimulateValue ] = useState( 400 );
+	const [ simulationWidth, setSimulationWidth ] = useState( 400 );
 	const [ isSimulationEnable, setIsSimulationEnabled ] = useState( true );
 	const toggleUI = (
 		<ToggleControl

--- a/packages/edit-post/src/components/sidebar/settings-sidebar/index.js
+++ b/packages/edit-post/src/components/sidebar/settings-sidebar/index.js
@@ -33,7 +33,7 @@ const PARTIAL_PATHS = [
 ];
 function TestSimulateMediaQuery() {
 	const [ simulationWidth, setSimulationWidth ] = useState( 400 );
-	const [ isSimulationEnable, setIsSimulationEnabled ] = useState( true );
+	const [ isSimulationEnabled, setIsSimulationEnabled ] = useState( true );
 	const toggleUI = (
 		<ToggleControl
 			label={ __( 'Enabled width simulation' ) }

--- a/packages/edit-post/src/components/sidebar/settings-sidebar/index.js
+++ b/packages/edit-post/src/components/sidebar/settings-sidebar/index.js
@@ -41,7 +41,7 @@ function TestSimulateMediaQuery() {
 			onChange={ ( newValue ) => setIsSimulationEnabled( newValue ) }
 		/>
 	);
-	if ( ! isSimulationEnable ) {
+	if ( ! isSimulationEnabled ) {
 		return toggleUI;
 	}
 	return (
@@ -56,7 +56,7 @@ function TestSimulateMediaQuery() {
 				onChange={ ( newValue ) => ( setSimulationWidth( newValue ) ) }
 			/>
 			<__experimentalSimulateMediaQuery
-				value={ simulationWidth }
+				width={ simulationWidth }
 				partialPaths={ PARTIAL_PATHS }
 			/>
 		</>

--- a/packages/edit-post/src/components/sidebar/settings-sidebar/index.js
+++ b/packages/edit-post/src/components/sidebar/settings-sidebar/index.js
@@ -56,7 +56,7 @@ function TestSimulateMediaQuery() {
 				onChange={ ( newValue ) => ( setSimulationWidth( newValue ) ) }
 			/>
 			<__experimentalSimulateMediaQuery
-				value={ simulateValue }
+				value={ simulationWidth }
 				partialPaths={ PARTIAL_PATHS }
 			/>
 		</>

--- a/packages/edit-post/src/components/sidebar/settings-sidebar/index.js
+++ b/packages/edit-post/src/components/sidebar/settings-sidebar/index.js
@@ -53,7 +53,7 @@ function TestSimulateMediaQuery() {
 				min={ 0 }
 				max={ 2000 }
 				allowReset
-				onChange={ ( newValue ) => ( setSimulateValue( newValue ) ) }
+				onChange={ ( newValue ) => ( setSimulationWidth( newValue ) ) }
 			/>
 			<__experimentalSimulateMediaQuery
 				value={ simulateValue }

--- a/packages/edit-post/src/components/sidebar/settings-sidebar/index.js
+++ b/packages/edit-post/src/components/sidebar/settings-sidebar/index.js
@@ -25,11 +25,9 @@ import MetaBoxes from '../../meta-boxes';
 import PluginDocumentSettingPanel from '../plugin-document-setting-panel';
 
 const PARTIAL_PATHS = [
-	//'block-editor/style.css',
 	'block-library/style.css',
 	'block-library/theme.css',
 	'block-library/editor.css',
-	//'format-library/style.css',
 ];
 function TestSimulateMediaQuery() {
 	const [ simulationWidth, setSimulationWidth ] = useState( 400 );

--- a/packages/edit-post/src/components/sidebar/settings-sidebar/index.js
+++ b/packages/edit-post/src/components/sidebar/settings-sidebar/index.js
@@ -1,10 +1,12 @@
 /**
  * WordPress dependencies
  */
-import { Panel } from '@wordpress/components';
+import { Panel, ToggleControl, RangeControl } from '@wordpress/components';
 import { compose, ifCondition } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
-import { BlockInspector } from '@wordpress/block-editor';
+import { BlockInspector, __experimentalSimulateMediaQuery } from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
+import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -21,6 +23,45 @@ import DiscussionPanel from '../discussion-panel';
 import PageAttributes from '../page-attributes';
 import MetaBoxes from '../../meta-boxes';
 import PluginDocumentSettingPanel from '../plugin-document-setting-panel';
+
+const PARTIAL_PATHS = [
+	//'block-editor/style.css',
+	'block-library/style.css',
+	'block-library/theme.css',
+	'block-library/editor.css',
+	//'format-library/style.css',
+];
+function TestSimulateMediaQuery() {
+	const [ simulateValue, setSimulateValue ] = useState( 400 );
+	const [ isSimulationEnable, setIsSimulationEnabled ] = useState( true );
+	const toggleUI = (
+		<ToggleControl
+			label={ __( 'Enabled width simulation' ) }
+			checked={ isSimulationEnable }
+			onChange={ ( newValue ) => setIsSimulationEnabled( newValue ) }
+		/>
+	);
+	if ( ! isSimulationEnable ) {
+		return toggleUI;
+	}
+	return (
+		<>
+			{ toggleUI }
+			<RangeControl
+				value={ simulateValue }
+				label={ __( 'Simulated width value' ) }
+				min={ 0 }
+				max={ 2000 }
+				allowReset
+				onChange={ ( newValue ) => ( setSimulateValue( newValue ) ) }
+			/>
+			<__experimentalSimulateMediaQuery
+				value={ simulateValue }
+				partialPaths={ PARTIAL_PATHS }
+			/>
+		</>
+	);
+}
 
 const SettingsSidebar = ( { sidebarName } ) => (
 	<Sidebar name={ sidebarName }>
@@ -43,6 +84,7 @@ const SettingsSidebar = ( { sidebarName } ) => (
 			{ sidebarName === 'edit-post/block' && (
 				<BlockInspector />
 			) }
+			<TestSimulateMediaQuery />
 		</Panel>
 	</Sidebar>
 );


### PR DESCRIPTION
## Description
This PR adds an experimental block-editor component that allows one to simulate a width value in media queries part of a specific set.

This together with PR https://github.com/WordPress/gutenberg/pull/17085 that adds the same simulation mechanism for withViewPortMatch will allow us to show a mobile UI in the block editor present in the customizer even though the window size may be big.

It will also allow us to provide components that allow one to switch between mobile desktop and target views.

To force media queries to react as if the width as different from the true window size we iterate on the stylesheets and each time if find a media query with a min or max-width rule evaluate that value against our simulated value if the rule matches we replace the media query with another media query that evaluates to true, if the rule does not match we replace the media-query with a rule that evaluates to false.

This PR is an alternative to https://github.com/WordPress/gutenberg/pull/17057.
It fixes the biggest problems:
- The low performance of the current element queries polyfills (the editor has lots of styles and each block can add more styles the current polyfills don't scale in this scenario).
- The current polyfills rely on added wrapping class/attribute selectors which change the specificity and make the editor behaver differently.


In this case, the performance is very hight we just change the media queries when the simulated value change and then we totally rely on the browser and the specificity is not changed.

## How has this been tested?
I added media & text block which has a stack on mobile option.
I used the test UI added on this PR (to be removed before the merge) that allows us to change the simulated value or to disable the simulation and I verified I was able to trigger to stack on mobile behavior even though the window was big.
