### PR TITLE
Lists: Move Default Styles

### DIFF
--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -17,7 +17,6 @@
 @import "./latest-posts/editor.scss";
 @import "./legacy-widget/editor.scss";
 @import "./media-text/editor.scss";
-@import "./list/editor.scss";
 @import "./more/editor.scss";
 @import "./navigation-menu/editor.scss";
 @import "./navigation-menu-item/editor.scss";

--- a/packages/block-library/src/list/editor.scss
+++ b/packages/block-library/src/list/editor.scss
@@ -1,5 +1,0 @@
-.editor-styles-wrapper div[data-type="core/list"] ul,
-.editor-styles-wrapper div[data-type="core/list"] ol {
-	padding-left: 1.3em;
-	margin-left: 1.3em;
-}

--- a/packages/editor/src/editor-styles.scss
+++ b/packages/editor/src/editor-styles.scss
@@ -104,6 +104,8 @@ ul,
 ol {
 	margin-bottom: $default-block-margin;
 	padding: inherit;
+	padding-left: 1.3em;
+	margin-left: 1.3em;
 
 	// Remove bottom margin from nested lists.
 	ul,


### PR DESCRIPTION
## Description

Currently the list block contains some default editor styles to override the admin styles. This seems like the wrong place to override them as we have a dedicated stylesheet for it. In this way, it also becomes easier for themes to override the default styles, since the selector specificity has been reduced.

## How has this been tested?

Test the list block in some themes, and ideally a theme without an editor stylesheet.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
