### PR TITLE
[Tiny PR] Editor: Friendlier Offline Message

### DIFF
--- a/packages/api-fetch/src/index.js
+++ b/packages/api-fetch/src/index.js
@@ -87,8 +87,8 @@ const defaultFetchHandler = ( nextOptions ) => {
 		// network connection. Unfortunately fetch just throws a TypeError and
 		// the message might depend on the browser.
 		.then(
-			( response ) =>
-				Promise.resolve( response )
+			( value ) =>
+				Promise.resolve( value )
 					.then( checkStatus )
 					.catch( ( response ) => parseAndThrowError( response, parse ) )
 					.then( ( response ) => parseResponseAndNormalizeError( response, parse ) ),

--- a/packages/api-fetch/src/test/index.js
+++ b/packages/api-fetch/src/test/index.js
@@ -150,6 +150,17 @@ describe( 'apiFetch', () => {
 		} );
 	} );
 
+	it( 'should return offline error when fetch errors', () => {
+		window.fetch.mockReturnValue( Promise.reject() );
+
+		return apiFetch( { path: '/random' } ).catch( ( body ) => {
+			expect( body ).toEqual( {
+				code: 'fetch_error',
+				message: 'You are probably offline.',
+			} );
+		} );
+	} );
+
 	it( 'should return null if response has no content status code', () => {
 		window.fetch.mockReturnValue( Promise.resolve( {
 			status: 204,

--- a/packages/e2e-tests/specs/editor/various/change-detection.test.js
+++ b/packages/e2e-tests/specs/editor/various/change-detection.test.js
@@ -200,7 +200,7 @@ describe( 'Change detection', () => {
 
 			// Ensure save update fails and presents button.
 			page.waitForXPath(
-				'//*[contains(@class, "components-notice") and contains(@class, "is-error")]/*[text()="Updating failed. Error message: The response is not a valid JSON response."]'
+				'//*[contains(@class, "components-notice") and contains(@class, "is-error")]/*[text()="Updating failed. You are probably offline."]'
 			),
 			page.waitForSelector( '.editor-post-save-draft' ),
 		] );

--- a/packages/editor/src/store/utils/notice-builder.js
+++ b/packages/editor/src/store/utils/notice-builder.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -108,10 +108,11 @@ export function getNotificationArgumentsForSaveFail( data ) {
 	// Check if message string contains HTML. Notice text is currently only
 	// supported as plaintext, and stripping the tags may muddle the meaning.
 	if ( error.message && ! ( /<\/?[^>]*>/.test( error.message ) ) ) {
-		noticeMessage = sprintf( __( '%1$s Error message: %2$s' ), noticeMessage, error.message );
+		noticeMessage = [ noticeMessage, error.message ].join( ' ' );
 	}
 	return [ noticeMessage, {
 		id: SAVE_POST_NOTICE_ID,
+		type: 'snackbar',
 	} ];
 }
 

--- a/packages/editor/src/store/utils/notice-builder.js
+++ b/packages/editor/src/store/utils/notice-builder.js
@@ -112,7 +112,6 @@ export function getNotificationArgumentsForSaveFail( data ) {
 	}
 	return [ noticeMessage, {
 		id: SAVE_POST_NOTICE_ID,
-		type: 'snackbar',
 	} ];
 }
 

--- a/packages/editor/src/store/utils/test/notice-builder.js
+++ b/packages/editor/src/store/utils/test/notice-builder.js
@@ -28,7 +28,7 @@ describe( 'getNotificationArgumentsForSaveSuccess()', () => {
 		link: 'some_link',
 	};
 	const post = { ...previousPost };
-	const defaultExpectedAction = { id: SAVE_POST_NOTICE_ID, actions: [] };
+	const defaultExpectedAction = { id: SAVE_POST_NOTICE_ID, actions: [], type: 'snackbar' };
 	[
 		[
 			'when previous post is not published and post will not be published',

--- a/packages/editor/src/store/utils/test/notice-builder.js
+++ b/packages/editor/src/store/utils/test/notice-builder.js
@@ -28,7 +28,7 @@ describe( 'getNotificationArgumentsForSaveSuccess()', () => {
 		link: 'some_link',
 	};
 	const post = { ...previousPost };
-	const defaultExpectedAction = { id: SAVE_POST_NOTICE_ID, actions: [], type: 'snackbar' };
+	const defaultExpectedAction = { id: SAVE_POST_NOTICE_ID, actions: [] };
 	[
 		[
 			'when previous post is not published and post will not be published',

--- a/packages/editor/src/store/utils/test/notice-builder.js
+++ b/packages/editor/src/store/utils/test/notice-builder.js
@@ -96,7 +96,7 @@ describe( 'getNotificationArgumentsForSaveFail()', () => {
 	const error = { code: '42', message: 'Something went wrong.' };
 	const post = { status: 'publish' };
 	const edits = { status: 'publish' };
-	const defaultExpectedAction = { id: SAVE_POST_NOTICE_ID, type: 'snackbar' };
+	const defaultExpectedAction = { id: SAVE_POST_NOTICE_ID };
 	[
 		[
 			'when error code is `rest_autosave_no_changes`',

--- a/packages/editor/src/store/utils/test/notice-builder.js
+++ b/packages/editor/src/store/utils/test/notice-builder.js
@@ -96,7 +96,7 @@ describe( 'getNotificationArgumentsForSaveFail()', () => {
 	const error = { code: '42', message: 'Something went wrong.' };
 	const post = { status: 'publish' };
 	const edits = { status: 'publish' };
-	const defaultExpectedAction = { id: SAVE_POST_NOTICE_ID };
+	const defaultExpectedAction = { id: SAVE_POST_NOTICE_ID, type: 'snackbar' };
 	[
 		[
 			'when error code is `rest_autosave_no_changes`',
@@ -108,25 +108,25 @@ describe( 'getNotificationArgumentsForSaveFail()', () => {
 			'when post is not published and edits is published',
 			'',
 			[ 'draft', 'publish' ],
-			[ 'Publishing failed. Error message: Something went wrong.', defaultExpectedAction ],
+			[ 'Publishing failed. Something went wrong.', defaultExpectedAction ],
 		],
 		[
 			'when post is published and edits is privately published',
 			'',
 			[ 'draft', 'private' ],
-			[ 'Publishing failed. Error message: Something went wrong.', defaultExpectedAction ],
+			[ 'Publishing failed. Something went wrong.', defaultExpectedAction ],
 		],
 		[
 			'when post is published and edits is scheduled to be published',
 			'',
 			[ 'draft', 'future' ],
-			[ 'Scheduling failed. Error message: Something went wrong.', defaultExpectedAction ],
+			[ 'Scheduling failed. Something went wrong.', defaultExpectedAction ],
 		],
 		[
 			'when post is published and edits is published',
 			'',
 			[ 'publish', 'publish' ],
-			[ 'Updating failed. Error message: Something went wrong.', defaultExpectedAction ],
+			[ 'Updating failed. Something went wrong.', defaultExpectedAction ],
 		],
 	].forEach( ( [
 		description,


### PR DESCRIPTION
## Description

Currently the message displayed when saving fails if there is not network connection is inappropriate. We should catch fetch errors early and display a friendlier message.

I also removed the "Error Message" string, because it seems obvious that an error occurred if saving failed.

## How has this been tested?

You can test in Chrome by using the Network tab and switching to offline.

## Screenshots <!-- if applicable -->

<img width="788" alt="Screenshot 2019-11-27 at 08 42 58" src="https://user-images.githubusercontent.com/4710635/69703568-f615ad80-10f1-11ea-9c8f-929381ba84f6.png">


Before:

<img width="842" alt="Screenshot 2019-10-15 at 21 59 27" src="https://user-images.githubusercontent.com/4710635/66865253-287ea780-ef97-11e9-9898-fd1ac86deaa2.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
