### PR TITLE
RNMobile: Add image alignment controls

### DIFF
--- a/packages/block-editor/src/components/index.native.js
+++ b/packages/block-editor/src/components/index.native.js
@@ -1,4 +1,5 @@
 // Block Creation Components
+export { default as BlockAlignmentToolbar } from './block-alignment-toolbar';
 export { default as BlockControls } from './block-controls';
 export { default as BlockEdit } from './block-edit';
 export { default as BlockFormatControls } from './block-format-controls';

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -25,7 +25,6 @@ import {
 	NavigableMenu,
 	PanelBody,
 	Path,
-	Rect,
 	ResizableBox,
 	SelectControl,
 	Spinner,
@@ -70,7 +69,7 @@ import { speak } from '@wordpress/a11y';
  * Internal dependencies
  */
 import { createUpgradedEmbedBlock } from '../embed/util';
-import icon from './icon';
+import icon, { editImageIcon } from './icon';
 import ImageSize from './image-size';
 import { getUpdatedLinkTargetSettings, removeNewTabRel } from './utils';
 
@@ -587,7 +586,6 @@ export class ImageEdit extends Component {
 
 		const cleanRel = removeNewTabRel( rel );
 		const isExternal = isExternalImage( id, url );
-		const editImageIcon = ( <SVG width={ 20 } height={ 20 } viewBox="0 0 20 20"><Rect x={ 11 } y={ 3 } width={ 7 } height={ 5 } rx={ 1 } /><Rect x={ 2 } y={ 12 } width={ 7 } height={ 5 } rx={ 1 } /><Path d="M13,12h1a3,3,0,0,1-3,3v2a5,5,0,0,0,5-5h1L15,9Z" /><Path d="M4,8H3l2,3L7,8H6A3,3,0,0,1,9,5V3A5,5,0,0,0,4,8Z" /></SVG> );
 		const controls = (
 			<BlockControls>
 				<BlockAlignmentToolbar

--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -89,7 +89,7 @@ export class ImageEdit extends React.Component {
 		this.onImagePressed = this.onImagePressed.bind( this );
 		this.onClearSettings = this.onClearSettings.bind( this );
 		this.onFocusCaption = this.onFocusCaption.bind( this );
-		this.updateAlignment = this.updateAlignment.bind(this)
+		this.updateAlignment = this.updateAlignment.bind( this );
 	}
 
 	componentDidMount() {
@@ -185,7 +185,7 @@ export class ImageEdit extends React.Component {
 	}
 
 	updateAlignment( nextAlign ) {
-		this.props.setAttributes( { align: nextAlign } )
+		this.props.setAttributes( { align: nextAlign } );
 	}
 
 	onSetLinkDestination( href ) {
@@ -365,7 +365,7 @@ export class ImageEdit extends React.Component {
 							);
 
 							return (
-								<View style={ { flex: 1, alignSelf: alignToFlex[align] } } >
+								<View style={ { flex: 1, alignSelf: alignToFlex[ align ] } } >
 									{ ! imageWidthWithinContainer &&
 										<View style={ [ styles.imageContainer, { height: imageContainerHeight } ] } >
 											{ this.getIcon( false ) }

--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -32,6 +32,7 @@ import {
 	MEDIA_TYPE_IMAGE,
 	BlockControls,
 	InspectorControls,
+	BlockAlignmentToolbar,
 } from '@wordpress/block-editor';
 import { __, sprintf } from '@wordpress/i18n';
 import { isURL } from '@wordpress/url';
@@ -42,7 +43,7 @@ import { withPreferredColorScheme } from '@wordpress/compose';
  * Internal dependencies
  */
 import styles from './styles.scss';
-import SvgIcon from './icon';
+import SvgIcon, { editImageIcon } from './icon';
 import SvgIconRetry from './icon-retry';
 import { getUpdatedLinkTargetSettings } from './utils';
 
@@ -88,6 +89,7 @@ export class ImageEdit extends React.Component {
 		this.onImagePressed = this.onImagePressed.bind( this );
 		this.onClearSettings = this.onClearSettings.bind( this );
 		this.onFocusCaption = this.onFocusCaption.bind( this );
+		this.updateAlignment = this.updateAlignment.bind(this)
 	}
 
 	componentDidMount() {
@@ -182,6 +184,10 @@ export class ImageEdit extends React.Component {
 		this.props.setAttributes( { url, width: undefined, height: undefined } );
 	}
 
+	updateAlignment( nextAlign ) {
+		this.props.setAttributes( { align: nextAlign } )
+	}
+
 	onSetLinkDestination( href ) {
 		this.props.setAttributes( {
 			linkDestination: LINK_DESTINATION_CUSTOM,
@@ -238,17 +244,22 @@ export class ImageEdit extends React.Component {
 
 	render() {
 		const { attributes, isSelected } = this.props;
-		const { url, height, width, alt, href, id, linkTarget, sizeSlug } = attributes;
+		const { align, url, height, width, alt, href, id, linkTarget, sizeSlug } = attributes;
 
 		const getToolbarEditButton = ( open ) => (
 			<BlockControls>
 				<Toolbar>
 					<ToolbarButton
 						title={ __( 'Edit image' ) }
-						icon="edit"
+						icon={ editImageIcon }
 						onClick={ open }
 					/>
 				</Toolbar>
+				<BlockAlignmentToolbar
+					value={ align }
+					onChange={ this.updateAlignment }
+					isCollapsed={ false }
+				/>
 			</BlockControls>
 		);
 
@@ -312,6 +323,14 @@ export class ImageEdit extends React.Component {
 			);
 		}
 
+		const alignToFlex = {
+			left: 'flex-start',
+			center: 'center',
+			right: 'flex-end',
+			full: 'center',
+			wide: 'center',
+		};
+
 		const imageContainerHeight = Dimensions.get( 'window' ).width / IMAGE_ASPECT_RATIO;
 		const getImageComponent = ( openMediaOptions, getMediaOptions ) => (
 			<TouchableWithoutFeedback
@@ -346,7 +365,7 @@ export class ImageEdit extends React.Component {
 							);
 
 							return (
-								<View style={ { flex: 1 } } >
+								<View style={ { flex: 1, alignSelf: alignToFlex[align] } } >
 									{ ! imageWidthWithinContainer &&
 										<View style={ [ styles.imageContainer, { height: imageContainerHeight } ] } >
 											{ this.getIcon( false ) }

--- a/packages/block-library/src/image/icon.js
+++ b/packages/block-library/src/image/icon.js
@@ -1,6 +1,8 @@
 /**
  * WordPress dependencies
  */
-import { Path, SVG } from '@wordpress/components';
+import { Path, Rect, SVG } from '@wordpress/components';
 
 export default <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path d="M0,0h24v24H0V0z" fill="none" /><Path d="m19 5v14h-14v-14h14m0-2h-14c-1.1 0-2 0.9-2 2v14c0 1.1 0.9 2 2 2h14c1.1 0 2-0.9 2-2v-14c0-1.1-0.9-2-2-2z" /><Path d="m14.14 11.86l-3 3.87-2.14-2.59-3 3.86h12l-3.86-5.14z" /></SVG>;
+
+export const editImageIcon = ( <SVG width={ 20 } height={ 20 } viewBox="0 0 20 20"><Rect x={ 11 } y={ 3 } width={ 7 } height={ 5 } rx={ 1 } /><Rect x={ 2 } y={ 12 } width={ 7 } height={ 5 } rx={ 1 } /><Path d="M13,12h1a3,3,0,0,1-3,3v2a5,5,0,0,0,5-5h1L15,9Z" /><Path d="M4,8H3l2,3L7,8H6A3,3,0,0,1,9,5V3A5,5,0,0,0,4,8Z" /></SVG> );


### PR DESCRIPTION
[related mobile-gutenberg PR](https://github.com/wordpress-mobile/gutenberg-mobile/pull/1460)

## Description
This PR adds left, center, and right alignment controls for image blocks on mobile. In addition, it updates the edit image icon to be consistent with web [as requested by design](https://github.com/wordpress-mobile/gutenberg-mobile/issues/198#issuecomment-537269524).

Note that this PR does *not* add alignment controls for wide or full alignments. Images with wide or full alignments are displayed with center alignment.

Most images will take up the full-width, but small images that do not naturally take up the full width of the screen should be displayed with the applied alignment.

![Screen Shot 2019-10-15 at 5 00 59 PM](https://user-images.githubusercontent.com/4656348/66869603-be054180-ef6d-11e9-851c-0e554b624484.png)

In addition, this PR also updates the edit image icon to be consistent with web [as requested](https://github.com/wordpress-mobile/gutenberg-mobile/issues/198#issuecomment-537269524).

## How has this been tested?
* Applying alignment to images that do not take up the full width of the screen should reflect the applied alignment.
* Posts containing image blocks with alignment **on mobile** should display with the relevant alignment **on the web**. This PR does *not* include the ability to set full or wide alignment.
* Posts containing image blocks with left, right, center, or no alignment applied **on the web** should display with the relevant alignment **on mobile**. Image blocks with wide or full alignment set on the web will display on mobile visually as if they had center alignment applied and it will appear that there is no alignment set. There is obviously more work to do here, but this seemed like a reasonable first step for image alignment and brings us parity with Aztec.

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
