### PR TITLE
Draft: p2p Real Time Collaborative Core Data Entity Editing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4963,6 +4963,47 @@
 				"physical-cpu-count": "^2.0.0"
 			}
 		},
+		"@peculiar/asn1-schema": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-1.0.3.tgz",
+			"integrity": "sha512-Tfgj9eNJ6cTKEtEuidKenLHMx/Q5M8KEE9hnohHqvdpqHJXWYr5RlT3GjAHPjGXy5+mr7sSfuXfzE6aAkEGN7A==",
+			"optional": true,
+			"requires": {
+				"asn1js": "^2.0.22",
+				"tslib": "^1.9.3"
+			}
+		},
+		"@peculiar/json-schema": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.5.tgz",
+			"integrity": "sha512-y5XYA3pf9+c+YKVpWnPtQbNmlNCs2ehNHyMLJvq4K5Fjwc1N64YGy7MNecKW3uYLga+sqbGTQSUdOdlnaRRbpA==",
+			"optional": true,
+			"requires": {
+				"tslib": "^1.9.3"
+			}
+		},
+		"@peculiar/webcrypto": {
+			"version": "1.0.21",
+			"resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.0.21.tgz",
+			"integrity": "sha512-dMQe+vTKSKDpiizQj5q7lFqU56zBgavrjcST4d8RMxEbmgoUOuAUOXlkI5DoqVy3ktcfAhk6CRV4YkaSUEXdAg==",
+			"optional": true,
+			"requires": {
+				"@peculiar/asn1-schema": "^1.0.3",
+				"@peculiar/json-schema": "^1.1.5",
+				"asn1js": "^2.0.26",
+				"pvtsutils": "^1.0.6",
+				"tslib": "^1.10.0",
+				"webcrypto-core": "^1.0.14"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "1.10.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+					"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
+					"optional": true
+				}
+			}
+		},
 		"@reach/router": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/@reach/router/-/router-1.2.1.tgz",
@@ -7150,6 +7191,7 @@
 				"@wordpress/is-shallow-equal": "file:packages/is-shallow-equal",
 				"@wordpress/url": "file:packages/url",
 				"equivalent-key-map": "^0.2.2",
+				"gun": "^0.2019.930",
 				"lodash": "^4.17.15",
 				"rememo": "^3.0.0"
 			}
@@ -7778,6 +7820,12 @@
 			"integrity": "sha512-aT6camzM4xEA54YVJYSqxz1kv4IHnQZRtThJJHhUMRExaU5spC7jX5ugSwTaTgJliIgs4VhZOk7htClvQ/LmRA==",
 			"dev": true
 		},
+		"addressparser": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/addressparser/-/addressparser-0.3.2.tgz",
+			"integrity": "sha1-WYc/Nej89sc2HBAjkmHXbhU0i7I=",
+			"optional": true
+		},
 		"agent-base": {
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
@@ -8375,6 +8423,15 @@
 				"minimalistic-assert": "^1.0.0"
 			}
 		},
+		"asn1js": {
+			"version": "2.0.26",
+			"resolved": "https://registry.npmjs.org/asn1js/-/asn1js-2.0.26.tgz",
+			"integrity": "sha512-yG89F0j9B4B0MKIcFyWWxnpZPLaNTjCj4tkE3fjbAoo0qmpGw0PYYqSbX/4ebnd9Icn8ZgK4K1fvDyEtW1JYtQ==",
+			"optional": true,
+			"requires": {
+				"pvutils": "^1.0.17"
+			}
+		},
 		"assert": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
@@ -8455,8 +8512,7 @@
 		"async-limiter": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-			"integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
-			"dev": true
+			"integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
 		},
 		"asynckit": {
 			"version": "0.4.0",
@@ -14333,6 +14389,41 @@
 				"minimalistic-crypto-utils": "^1.0.0"
 			}
 		},
+		"emailjs": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/emailjs/-/emailjs-2.2.0.tgz",
+			"integrity": "sha1-ulsj5KSwpFEPZS6HOxVOlAe2ygM=",
+			"optional": true,
+			"requires": {
+				"addressparser": "^0.3.2",
+				"emailjs-mime-codec": "^2.0.7"
+			}
+		},
+		"emailjs-base64": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/emailjs-base64/-/emailjs-base64-1.1.4.tgz",
+			"integrity": "sha512-4h0xp1jgVTnIQBHxSJWXWanNnmuc5o+k4aHEpcLXSToN8asjB5qbXAexs7+PEsUKcEyBteNYsSvXUndYT2CGGA==",
+			"optional": true
+		},
+		"emailjs-mime-codec": {
+			"version": "2.0.9",
+			"resolved": "https://registry.npmjs.org/emailjs-mime-codec/-/emailjs-mime-codec-2.0.9.tgz",
+			"integrity": "sha512-7qJo4pFGcKlWh/kCeNjmcgj34YoJWY0ekZXEHYtluWg4MVBnXqGM4CRMtZQkfYwitOhUgaKN5EQktJddi/YIDQ==",
+			"optional": true,
+			"requires": {
+				"emailjs-base64": "^1.1.4",
+				"ramda": "^0.26.1",
+				"text-encoding": "^0.7.0"
+			},
+			"dependencies": {
+				"ramda": {
+					"version": "0.26.1",
+					"resolved": "https://registry.npmjs.org/ramda/-/ramda-0.26.1.tgz",
+					"integrity": "sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==",
+					"optional": true
+				}
+			}
+		},
 		"emoji-regex": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
@@ -17723,6 +17814,27 @@
 			"resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
 			"integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw==",
 			"dev": true
+		},
+		"gun": {
+			"version": "0.2019.930",
+			"resolved": "https://registry.npmjs.org/gun/-/gun-0.2019.930.tgz",
+			"integrity": "sha512-JZunmIcZqwq9MgrMHBRVAB7HbgNWUnwnHSJZPq0QCCbJwJ4rRctBcBWZF3BgS3AGpOUM9S+ecSQDacQHYJkujg==",
+			"requires": {
+				"@peculiar/webcrypto": "^1.0.19",
+				"emailjs": "^2.2.0",
+				"text-encoding": "^0.7.0",
+				"ws": "~>7.1.0"
+			},
+			"dependencies": {
+				"ws": {
+					"version": "7.1.2",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-7.1.2.tgz",
+					"integrity": "sha512-gftXq3XI81cJCgkUiAVixA0raD9IVmXqsylCrjRygw4+UOOGzPoxnQ6r/CnVL9i+mDncJo94tSkyrtuuQVBmrg==",
+					"requires": {
+						"async-limiter": "^1.0.0"
+					}
+				}
+			}
 		},
 		"gzip-size": {
 			"version": "5.0.0",
@@ -27317,6 +27429,36 @@
 				}
 			}
 		},
+		"pvtsutils": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.0.6.tgz",
+			"integrity": "sha512-0yNrOdJyLE7FZzmeEHTKanwBr5XbmDAd020cKa4ZiTYuGMBYBZmq7vHOhcOqhVllh6gghDBbaz1lnVdOqiB7cw==",
+			"optional": true,
+			"requires": {
+				"@types/node": "^10.14.17",
+				"tslib": "^1.10.0"
+			},
+			"dependencies": {
+				"@types/node": {
+					"version": "10.14.21",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.21.tgz",
+					"integrity": "sha512-nuFlRdBiqbF+PJIEVxm2jLFcQWN7q7iWEJGsBV4n7v1dbI9qXB8im2pMMKMCUZe092sQb5SQft2DHfuQGK5hqQ==",
+					"optional": true
+				},
+				"tslib": {
+					"version": "1.10.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+					"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
+					"optional": true
+				}
+			}
+		},
+		"pvutils": {
+			"version": "1.0.17",
+			"resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.0.17.tgz",
+			"integrity": "sha512-wLHYUQxWaXVQvKnwIDWFVKDJku9XDCvyhhxoq8dc5MFdIlRenyPI9eSfEtcvgHgD7FlvCyGAlWgOzRnZD99GZQ==",
+			"optional": true
+		},
 		"q": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
@@ -32727,6 +32869,12 @@
 				}
 			}
 		},
+		"text-encoding": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.7.0.tgz",
+			"integrity": "sha512-oJQ3f1hrOnbRLOcwKz0Liq2IcrvDeZRHXhd9RgLrsT+DjWY/nty1Hi7v3dtkaEYbPYe0mUoOfzRrMwfXXwgPUA==",
+			"optional": true
+		},
 		"text-extensions": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-2.0.0.tgz",
@@ -33065,8 +33213,7 @@
 		"tslib": {
 			"version": "1.9.3",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-			"integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
-			"dev": true
+			"integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
 		},
 		"tty-browserify": {
 			"version": "0.0.0",
@@ -34030,6 +34177,24 @@
 			"resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-1.1.3.tgz",
 			"integrity": "sha512-r8sAtNmgR0WKOKOxzuSgk09JsHlpKlB+uHi937qypOu3PZ17UxPrierFKDye/uNHjNTTEshu5PId8rojIPj/tA==",
 			"dev": true
+		},
+		"webcrypto-core": {
+			"version": "1.0.14",
+			"resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.0.14.tgz",
+			"integrity": "sha512-iGZQcH/o3Jv6mpvCbzan6uAcUcLTTnUCil6RVYakcNh5/QXIKRRC06EFxHru9lHgVKucZy3gG4OBiup0IsOr0g==",
+			"optional": true,
+			"requires": {
+				"pvtsutils": "^1.0.4",
+				"tslib": "^1.10.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "1.10.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+					"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
+					"optional": true
+				}
+			}
 		},
 		"webidl-conversions": {
 			"version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -193,6 +193,7 @@
 		"check-local-changes": "( git diff -U0 | xargs -0 node bin/process-git-diff ) || ( echo \"There are local uncommitted changes after one or both of 'npm install' or 'npm run docs:build'!\" && exit 1 );",
 		"predev": "npm run check-engines",
 		"dev": "npm run build:packages && concurrently \"wp-scripts start\" \"npm run dev:packages\"",
+		"dev:gun": "npm run build:packages && concurrently \"cd ./node_modules/gun && npm start\" \"npm run dev\"",
 		"dev:packages": "node ./bin/packages/watch.js",
 		"docs:build": "node ./docs/tool/index.js && node ./bin/update-readmes.js",
 		"fixtures:clean": "rimraf \"packages/e2e-tests/fixtures/blocks/*.+(json|serialized.html)\"",

--- a/packages/core-data/package.json
+++ b/packages/core-data/package.json
@@ -30,6 +30,7 @@
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
 		"@wordpress/url": "file:../url",
 		"equivalent-key-map": "^0.2.2",
+		"gun": "^0.2019.930",
 		"lodash": "^4.17.15",
 		"rememo": "^3.0.0"
 	},

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -37,6 +37,7 @@ function* loadPostTypeEntities() {
 			name,
 			transientEdits: { blocks: true },
 			mergedEdits: { meta: true },
+			syncedEdits: { blocks: true },
 		};
 	} );
 }

--- a/packages/core-data/src/gun.js
+++ b/packages/core-data/src/gun.js
@@ -1,0 +1,133 @@
+/**
+ * External dependencies
+ */
+import Gun from 'gun/gun';
+import 'gun/lib/then';
+import 'gun/lib/open';
+
+/**
+ * Gun is a Conflict-free Replicated Data Type (CRDT) based p2p synchronized
+ * storage engine.
+ *
+ * It will automatically convert JSON objects without arrays into
+ * CRDTs in a generalized way, but since lots of our entity edits
+ * are made up of arrays, we extend Gun here to support them.
+ *
+ * The extensions provide a way to `open` and `put` items with arrays.
+ * They do this by recursively converting arrays into "array objects" with an
+ * `_isArray` property when `put`ting them and then recursively converting
+ * those objects back into arrays when `open`ing them.
+ *
+ * When an "array object" in the storage graph is updated, we remove all the
+ * indexes from the graph that are not part of the new array. We need to do
+ * this, because Gun works by deeply patching/merging the graph.
+ *
+ * @see https://gun.eco
+ */
+const gun = Gun( 'http://localhost:8765/gun' ); // URL to lightweight relay server.
+
+Gun.chain.openWithArrays = function( callback ) {
+	// Recursively converts "array objects" in items
+	// into arrays.
+	const parseItem = ( currentItem ) => {
+		if ( typeof currentItem === 'object' && currentItem !== null ) {
+			let keys = Object.keys( currentItem );
+			if ( currentItem._isArray === true ) {
+				// Only consider (filled) array indexes.
+				keys = keys.filter( ( key ) => ! isNaN( key ) && currentItem[ key ] !== null );
+			}
+
+			let parsedItem = keys.reduce( ( acc, key ) => {
+				acc[ key ] = parseItem( currentItem[ key ] );
+				return acc;
+			}, {} );
+
+			if ( currentItem._isArray === true ) {
+				// Parse into array.
+				parsedItem = keys.map( ( key ) => parsedItem[ key ] );
+			}
+
+			return parsedItem;
+		}
+
+		return currentItem;
+	};
+
+	return this.open( ( item, ...args ) => callback( parseItem( item ), ...args ), {
+		wait: 99, // Wait a bit more than the default to avoid partial graphs.
+	} );
+};
+
+Gun.chain.putWithArrays = async function( item ) {
+	const arrayLengths = {};
+
+	// Recursively converts arrays in items
+	// into "array objects".
+	const normalizeItem = ( currentItem, currentPath = '' ) => {
+		if ( typeof currentItem === 'object' && currentItem !== null ) {
+			const keys = Object.keys( currentItem );
+
+			const normalizedItem = keys.reduce( ( acc, key ) => {
+				acc[ key ] = normalizeItem(
+					currentItem[ key ],
+					`${ currentPath }${ currentPath ? '.' : '' }${ key }`
+				);
+				return acc;
+			}, {} );
+
+			if ( Array.isArray( currentItem ) ) {
+				// Mark converted arrays and cache their length.
+				normalizedItem._isArray = true;
+				arrayLengths[ currentPath ] = keys.length;
+			}
+
+			return normalizedItem;
+		}
+
+		// Gun does not support `undefined`.
+		return currentItem === undefined ? null : currentItem;
+	};
+	const normalizedItem = normalizeItem( item );
+
+	// Delete all indexes in updated "array objects" that won't
+	// be updated due to being out of range, i.e. not existing
+	// anymore.
+	await Promise.all(
+		Object.keys( arrayLengths ).map( async ( path ) => {
+			// Get the "array object" at the cached path.
+			let chain = this;
+			if ( path ) {
+				path.split( '.' ).forEach( ( key ) => ( chain = chain.get( key ) ) );
+			}
+			const arrayObject = await chain.once( () => {}, { wait: 2000 } ).then();
+
+			// Make sure the "array object" exists already.
+			if ( arrayObject ) {
+				return Promise.all(
+					Object.keys( arrayObject ).map( ( key ) => {
+						// Delete any non-metadata key that is not an
+						// array index in the new array.
+						if (
+							isNaN( key ) ?
+								key !== '_' && key !== '_isArray' :
+								Number( key ) >= arrayLengths[ path ]
+						) {
+							return chain
+								.get( key )
+								.put( null )
+								.then();
+						}
+
+						return Promise.resolve();
+					} )
+				);
+			}
+
+			return Promise.resolve();
+		} )
+	);
+
+	return this.put( normalizedItem );
+};
+
+export default gun;


### PR DESCRIPTION
Related to #1930

## Background

I’ve been thinking a lot about full collaborative editing for Gutenberg, Google Docs style.

I know this was explored in a few PRs (#1930) with per-block locking, because “full collaborative” seemed too hard without relying on the WordPress host being able to run and keep up long running syncing processes and what not. However, I think that if we reframe a few things we could achieve it relatively easily, fully client side, and avoid going with a solution that might make it harder to refactor into supporting “full collaborative” later on.

Here is the minimum code/effort approach that I think would work:

Convert block edits into conflict-free replicated data types (CRDT). This should be pretty straight forward because they are mostly Redux action POJOs. We would need to add a version vector for them and a new relative index based abstraction for storing block position, i.e. inserting a block between block 1 and block 2 should yield a new block at position 1.5 and not change the others’ indexes.
This would essentially mean that all block edits would become idempotent and commutative. We would also need to implement undo in `block-editor`, instead of relying on `core-data`, so that we can keep the undo stack specific to the client.

For `RichText`, things will be a bit more complex and a CRDT refactor might be too costly, but we could easily implement diff-sync for it or use a compatible library.
Diff-sync, in short, is when the client keeps a copy of what the server has and the server keeps a copy of what each client has. When the client wants to sync, it can easily send a diff, the server then applies that diff both to its copy of the client’s contents and to itself. Now the diff between the server’s copy of the client’s contents and what the server has, is a representation of what couldn’t be applied due to changes made to the server by other clients and this is sent back to the client to be patched on top. There’s a bit more nuance to it for handling failures, but there are a lot of open source implementations for it that work with formatted text.

The only issue with diff-sync is that you need a host, now although not ideal, if the WordPress instance does not support being a host for this, we could fallback to a client acting as the host. Otherwise, we could embark on the `RichText` refactor or just lock `RichText` fields and send CRDT edits for their whole value.

## Description

This PR explores a Conflict-free Replicated Data Type (CRDT) based p2p approach to collaborative `core-data` entity (#17368) editing.

It adds a new property to entity configs that allows you to specify edits that should be synced across peers and uses it for post blocks. The demo video below also shows how easily you can include other properties like post titles.

The p2p layer uses the [Gun](https://gun.eco) engine which automatically converts JSON objects without arrays into CRDTs with some compromises, with some extensions to support array edits as CRDTs. The reasoning for the extensions is provided in the header comment on `packages/core-data/src/gun.js`.

The server-side requirements of [Gun](https://gun.eco) are very low. All that is needed is a lightweight stateless relay server, similar to WebRTCs public signaling servers, to bootstrap peer connections with peers without public IP addresses. The relay servers could be provided by a plugin provider or even be community-ran and shared between all WordPress instances. They even support a Daisy-chain Ad-hoc Mesh-network mode to relay messages between peers without WebRTC, but of course, enabling that would make it more prohibitive to host publicly.

Authentication doesn't even have to happen at the relay server, because [Gun](https://gun.eco) supports only subscribing to subgraphs of the network and subgraphs can be encrypted by say, the hash of a token or password shared by a WordPress site's users with access to that data.

## How has this been tested?

It was verified that running `npm run dev:gun` starts a local relay server and lets you edit collaboratively on `localhost`.

# Video

https://youtu.be/8SejOZSTJ5I

## Types of Changes

*New Feature:* Core Data entities now support p2p synced edits.

## Checklist:

- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
