### PR TITLE
Improve columns flex rule, round 2.

### DIFF
--- a/packages/block-library/src/columns/editor.scss
+++ b/packages/block-library/src/columns/editor.scss
@@ -45,7 +45,7 @@
 			flex-direction: column;
 
 			// This flex rule fixes an issue in IE11.
-			flex: 1 0 auto;
+			flex: 1 1 auto;
 
 			// IE11 does not support `position: sticky`, so we use it here to serve correct Flex rules to modern browsers.
 			@supports (position: sticky) {

--- a/packages/block-library/src/columns/editor.scss
+++ b/packages/block-library/src/columns/editor.scss
@@ -43,7 +43,14 @@
 		> [data-type="core/column"] > .editor-block-list__block-edit .block-core-columns {
 			display: flex;
 			flex-direction: column;
+
+			// This flex rule fixes an issue in IE11.
 			flex: 1 0 auto;
+
+			// IE11 does not support `position: sticky`, so we use it here to serve correct Flex rules to modern browsers.
+			@supports (position: sticky) {
+				flex: 1;
+			}
 		}
 
 		// Adjust the individual column block.


### PR DESCRIPTION
This is a followup to https://github.com/WordPress/gutenberg/pull/17901#issuecomment-542550843, where we improved the display of columns in IE11, but introduced a regression for modern browsers.

This PR wraps the rule for modern browsers in a @supports, so that we fix it for both.

It has not yet been tested thoroughly, so we need to test this in all the browsers as we review it. 