### PR TITLE
Fix: Invalid import statement for deprecated in the modal component

### DIFF
--- a/packages/components/src/modal/index.js
+++ b/packages/components/src/modal/index.js
@@ -3,7 +3,7 @@
  */
 import { Component, createPortal } from '@wordpress/element';
 import { withInstanceId } from '@wordpress/compose';
-import { deprecated } from '@wordpress/deprecated';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies

--- a/packages/e2e-tests/specs/font-size-picker.test.js
+++ b/packages/e2e-tests/specs/font-size-picker.test.js
@@ -75,8 +75,8 @@ describe( 'Font Size Picker', () => {
 
 		// Clear the custom font size input.
 		await page.click( '.blocks-font-size .components-range-control__number' );
-		await pressKeyTimes( 'ArrowRight', 4 );
-		await pressKeyTimes( 'Backspace', 4 );
+		await pressKeyTimes( 'ArrowRight', 5 );
+		await pressKeyTimes( 'Backspace', 5 );
 
 		// Ensure content matches snapshot.
 		const content = await getEditedPostContent();


### PR DESCRIPTION
## Description

I noticed the incorrect import statement while running Storybook.

@youknowriad – the package published to npm is not affected by this bug:
https://unpkg.com/browse/@wordpress/components@8.3.2/build/modal/index.js