### PR TITLE
Playground: Add link to components storybook.

### DIFF
--- a/playground/src/index.js
+++ b/playground/src/index.js
@@ -12,6 +12,7 @@ import {
 	ObserveTyping,
 } from '@wordpress/block-editor';
 import {
+	Button,
 	Popover,
 	SlotFillProvider,
 	DropZoneProvider,
@@ -40,6 +41,9 @@ function App() {
 		<Fragment>
 			<div className="playground__header">
 				<h1 className="playground__logo">Gutenberg Playground</h1>
+				<Button isLarge href="design-system/components" target="_blank">
+					Design System Components
+				</Button>
 			</div>
 			<div className="playground__body">
 				<SlotFillProvider>
@@ -67,7 +71,4 @@ function App() {
 }
 
 registerCoreBlocks();
-render(
-	<App />,
-	document.querySelector( '#app' )
-);
+render( <App />, document.querySelector( '#app' ) );

--- a/playground/src/style.scss
+++ b/playground/src/style.scss
@@ -10,8 +10,11 @@
 
 
 .playground__header {
-	padding: 20px;
+	align-items: center;
 	border-bottom: 1px solid #ddd;
+	display: flex;
+	justify-content: space-between;
+	padding: 20px;
 }
 
 .playground__logo {


### PR DESCRIPTION
## Description

This PR adds a `_blank` target link in the playground's header to `design-system/components` so that we can navigate to it without having to type out the full URL.

## How has this been tested?

It was verified that the new link in the playground header opens `design-system/components` in a new tab.

## Screenshots

<img width="978" alt="Screen Shot 2019-10-16 at 3 07 18 PM" src="https://user-images.githubusercontent.com/19157096/66962853-ee5ce680-f026-11e9-8c75-9a0e1f955139.png">

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
