### PR TITLE
create a screen-reader-text label for search block (fix #17351) 

### DIFF
--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -25,6 +25,12 @@ function render_block_core_search( $attributes ) {
 			$input_id,
 			$attributes['label']
 		);
+	} else {
+		$label_markup = sprintf(
+			'<label for="%s" class="wp-block-search__label screen-reader-text">%s</label>',
+			$input_id,
+			__( 'Search' )
+		);
 	}
 
 	$input_markup = sprintf(
@@ -45,7 +51,6 @@ function render_block_core_search( $attributes ) {
 	if ( isset( $attributes['className'] ) ) {
 		$class .= ' ' . $attributes['className'];
 	}
-
 	if ( isset( $attributes['align'] ) ) {
 		$class .= ' align' . $attributes['align'];
 	}


### PR DESCRIPTION
## Description

The search block should always have a label in it even if it's not visible.

When a user removes the label from the search block when the user is editing content; there should be still be a label present for the corresponding input field, so a user who is consuming the site with a screen reader or other assistive technology has a contextual clue of what the empty input field is :) 

What this addition does is, when the label is deleted, a label named "search" is created but is not visually displayed on the screen because the screen-reader-text class is applied to the label element. 

I've also manually tested this when you insert multiple search blocks into the same post; a unique label property is created for each one. 

[WordPress' Accessibility Labeling guidelines also state](https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/#labeling) that all future code should have a label as well. 

## How has this been tested?
As mentioned at https://github.com/WordPress/gutenberg/issues/17351 ; I've tested this in JAWS 2018 with default settings and chrome; and it functioned as I expected. 

If you'd like to personally test yourself:
( pull in my changes ) 
1. Create or edit new post
2. Add a search block 
3. delete the label text above the search input field; 
4.  publish post.

(Note: I haven't ran automatic tests on this yet, note to self, I'll do that https://github.com/WordPress/gutenberg/blob/master/docs/contributors/testing-overview.md#php-testing ) 

It's also my first feature/bug PR on Gutenberg. :)

## Checklist:
- [ ] My code is tested. 
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
