### PR TITLE
Change BaseControl sibling selector to use margin-top

### DIFF
--- a/packages/components/src/base-control/style.scss
+++ b/packages/components/src/base-control/style.scss
@@ -22,5 +22,5 @@
 }
 
 .components-base-control + .components-base-control {
-	margin-bottom: $grid-size-large;
+	margin-top: $grid-size-large;
 }


### PR DESCRIPTION
## Description
Changes the BaseControl sibling selector to use margin-top instead of margin-bottom for consistent spacing. Fixes #17984.

## How has this been tested?
Confirmed in CSS via web inspector and in local development environment.

## Screenshots

**Before:**

**<img width="285" alt="Screen Shot 2019-10-16 at 9 30 05 PM" src="https://user-images.githubusercontent.com/1231306/66970644-2fbbb900-f05c-11e9-920c-285accb2d90f.png">**|**<img width="285" alt="Screen Shot 2019-10-16 at 9 30 56 PM" src="https://user-images.githubusercontent.com/1231306/66970691-537eff00-f05c-11e9-9734-050bba9b201f.png">**
:-----:|:-----:

**After:**

**<img width="287" alt="Screen Shot 2019-10-16 at 9 32 33 PM" src="https://user-images.githubusercontent.com/1231306/66970757-89bc7e80-f05c-11e9-9e86-f9fdafece1b4.png">**|**<img width="286" alt="Screen Shot 2019-10-16 at 9 32 39 PM" src="https://user-images.githubusercontent.com/1231306/66970767-8fb25f80-f05c-11e9-8749-c69d78da4eb2.png">**
:-----:|:-----:

## Types of changes
Small CSS bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->