### PR TITLE
[RNMobile] Fix image native test

### DIFF
--- a/packages/block-library/src/image/test/edit.native.js
+++ b/packages/block-library/src/image/test/edit.native.js
@@ -40,16 +40,16 @@ describe( 'Image Block', () => {
 
 		instance.onSetNewTab( true );
 
-		expect( setAttributes ).toBeCalledWith( { linkTarget: '_blank', rel: NEW_TAB_REL } );
+		expect( setAttributes ).toHaveBeenCalledWith( { linkTarget: '_blank', rel: undefined } );
 	} );
 
 	it( 'unset link target', () => {
-		const component = renderer.create( getImageComponent( { linkTarget: '_blank', rel: NEW_TAB_REL } ) );
+		const component = renderer.create( getImageComponent( { linkTarget: '_blank', rel: NEW_TAB_REL.join( ' ' ) } ) );
 		const instance = component.getInstance();
 
 		instance.onSetNewTab( false );
 
-		expect( setAttributes ).toBeCalledWith( { linkTarget: undefined, rel: undefined } );
+		expect( setAttributes ).toHaveBeenCalledWith( { linkTarget: undefined, rel: undefined } );
 	} );
 } );
 


### PR DESCRIPTION
## Description

Fix a native test of image block after commit https://github.com/WordPress/gutenberg/commit/77c676cf4c1fddc7f81309818840bdf4db0867ba

Test was trying to run `replace` function on the array which doesn't have a replace method.

## How has this been tested?

Run tests locally.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
