### PR TITLE
PanelColorSettings: add README.md file

### DIFF
--- a/packages/block-editor/src/components/panel-color-settings/README.md
+++ b/packages/block-editor/src/components/panel-color-settings/README.md
@@ -1,0 +1,42 @@
+# `PanelColorSettings`
+
+Render a panel with color choices shown in circles, allowing a user to pick them.
+
+## Properties
+
+### `children`
+
+* **Type:** `Element`
+* *Required:*  No
+* *Default:* Null
+
+The content to be displayed within the panel.
+
+### `colors`
+
+Array with the colors to be shown.
+
+* *Type:* `Array`
+* *Required:* Yes
+
+### `colorSettings`
+
+* **Type:** `Array`
+* *Required:* Yes
+
+An array of props used for mapping both ColorIndicator and ColorPaletteControl components.
+
+### `title`
+
+* **Type:** `String`
+* *Required:* Yes
+
+Panel title.
+
+### `disableCustomColors`
+
+Whether to allow custom color or not.
+
+* *Type:* `Boolean`
+* *Required:* No
+* *Default:* False


### PR DESCRIPTION
## Description
It adds the README.md file to the `PanelColorSettings` compoment.

## How has this been tested?
Just read the doc.