### PR TITLE
Storybook: Add Color Palette Component

### DIFF
--- a/packages/components/src/color-palette/stories/index.js
+++ b/packages/components/src/color-palette/stories/index.js
@@ -15,7 +15,7 @@ import ColorPalette from '../';
 
 export default { title: 'ColorPalette', component: ColorPalette };
 
-const ColorPaletteWithState = ( { ...props } ) => {
+const ColorPaletteWithState = ( props ) => {
 	const [ color, setColor ] = useState( '#F00' );
 	return (
 		<ColorPalette

--- a/packages/components/src/color-palette/stories/index.js
+++ b/packages/components/src/color-palette/stories/index.js
@@ -1,0 +1,53 @@
+/**
+ * External dependencies
+ */
+import { object } from '@storybook/addon-knobs';
+
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import ColorPalette from '../';
+
+export default { title: 'Color Palette', component: ColorPalette };
+
+export const _default = () => {
+	const [ color, setColor ] = useState( '#f00' );
+
+	const colors = [
+		{ name: 'red', color: '#f00' },
+		{ name: 'white', color: '#fff' },
+		{ name: 'blue', color: '#00f' },
+	];
+
+	return (
+		<ColorPalette
+			colors={ colors }
+			value={ color }
+			onChange={ setColor }
+		/>
+	);
+};
+
+export const WithKnobs = () => {
+	const [ color, setColor ] = useState( '#f00' );
+
+	const colors = [
+		object( 'Red', { name: 'red', color: '#f00' } ),
+		object( 'White', { name: 'white', color: '#fff' } ),
+		object( 'Blue', { name: 'blue', color: '#00f' } ),
+	];
+
+	return (
+		<ColorPalette
+			colors={ colors }
+			value={ color }
+			onChange={ setColor }
+		/>
+	);
+};
+

--- a/packages/components/src/color-palette/stories/index.js
+++ b/packages/components/src/color-palette/stories/index.js
@@ -15,9 +15,18 @@ import ColorPalette from '../';
 
 export default { title: 'ColorPalette', component: ColorPalette };
 
-export const _default = () => {
-	const [ color, setColor ] = useState( '#f00' );
+const ColorPaletteWithState = ( { ...props } ) => {
+	const [ color, setColor ] = useState( '#F00' );
+	return (
+		<ColorPalette
+			{ ...props }
+			value={ color }
+			onChange={ setColor }
+		/>
+	);
+};
 
+export const _default = () => {
 	const colors = [
 		{ name: 'red', color: '#f00' },
 		{ name: 'white', color: '#fff' },
@@ -25,17 +34,13 @@ export const _default = () => {
 	];
 
 	return (
-		<ColorPalette
+		<ColorPaletteWithState
 			colors={ colors }
-			value={ color }
-			onChange={ setColor }
 		/>
 	);
 };
 
 export const withKnobs = () => {
-	const [ color, setColor ] = useState( '#f00' );
-
 	const colors = [
 		object( 'Red', { name: 'red', color: '#f00' } ),
 		object( 'White', { name: 'white', color: '#fff' } ),
@@ -43,10 +48,8 @@ export const withKnobs = () => {
 	];
 
 	return (
-		<ColorPalette
+		<ColorPaletteWithState
 			colors={ colors }
-			value={ color }
-			onChange={ setColor }
 		/>
 	);
 };

--- a/packages/components/src/color-palette/stories/index.js
+++ b/packages/components/src/color-palette/stories/index.js
@@ -13,7 +13,7 @@ import { useState } from '@wordpress/element';
  */
 import ColorPalette from '../';
 
-export default { title: 'Color Palette', component: ColorPalette };
+export default { title: 'ColorPalette', component: ColorPalette };
 
 export const _default = () => {
 	const [ color, setColor ] = useState( '#f00' );
@@ -33,7 +33,7 @@ export const _default = () => {
 	);
 };
 
-export const WithKnobs = () => {
+export const withKnobs = () => {
 	const [ color, setColor ] = useState( '#f00' );
 
 	const colors = [


### PR DESCRIPTION
## Description

Adds Color Palette component to storybook.

## How has this been tested?

Run `npm run design-system:dev` and confirm color palette

Question for @ItsJonQ @epiqueras (or anyone else)

When adding a component to Storybook, I've noticed issues around CSS, Button Group was one, see below for ColorPalette issue. Should these be fixed elsewhere, in the component itself, and not in the story? Should Storybook just reflect the state of the raw component?

For the Color Palette there are some problems with the Custom Color control (see screenshot)

![Screenshot from 2019-10-17 06-39-53](https://user-images.githubusercontent.com/45363/67014049-04ab8680-f0a9-11e9-9d61-1350f9ccc3a6.png)
