### PR TITLE
Add gradients in cover block

### DIFF
--- a/packages/block-editor/src/components/gradient-picker/control.js
+++ b/packages/block-editor/src/components/gradient-picker/control.js
@@ -3,19 +3,27 @@
  * External dependencies
  */
 import classnames from 'classnames';
+import { isEmpty } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { BaseControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import GradientPicker from './';
 
-export default function( { className, ...props } ) {
+export default function( { className, label = __( 'Gradient Presets' ), ...props } ) {
+	const gradients = useSelect( ( select ) => (
+		select( 'core/block-editor' ).getSettings().gradients
+	) );
+	if ( isEmpty( gradients ) ) {
+		return null;
+	}
 	return (
 		<BaseControl
 			className={ classnames(
@@ -24,10 +32,11 @@ export default function( { className, ...props } ) {
 			) }
 		>
 			<BaseControl.VisualLabel>
-				{ __( 'Gradient Presets' ) }
+				{ label }
 			</BaseControl.VisualLabel>
 			<GradientPicker
 				className="block-editor-gradient-picker-control__gradient-picker-presets"
+				gradients={ gradients }
 				{ ...props }
 			/>
 		</BaseControl>

--- a/packages/block-library/src/cover/block.json
+++ b/packages/block-library/src/cover/block.json
@@ -31,6 +31,9 @@
 		},
 		"minHeight": {
 			"type": "number"
+		},
+		"customGradient": {
+			"type": "string"
 		}
 	}
 }

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -39,6 +39,8 @@ import {
 	PanelColorSettings,
 	withColors,
 	ColorPalette,
+	__experimentalGradientPickerControl,
+	__experimentalGradientPicker,
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import { withDispatch } from '@wordpress/data';
@@ -219,12 +221,13 @@ class CoverEdit extends Component {
 		} = this.props;
 		const {
 			backgroundType,
+			customGradient,
 			dimRatio,
 			focalPoint,
 			hasParallax,
 			id,
-			url,
 			minHeight,
+			url,
 		} = attributes;
 		const onSelectMedia = ( media ) => {
 			if ( ! media || ! media.url ) {
@@ -282,14 +285,20 @@ class CoverEdit extends Component {
 			minHeight: ( temporaryMinHeight || minHeight ),
 		};
 
+		if ( customGradient && ! url ) {
+			style.background = customGradient;
+		}
+
 		if ( focalPoint ) {
 			style.backgroundPosition = `${ focalPoint.x * 100 }% ${ focalPoint.y * 100 }%`;
 		}
 
+		const hasBackground = !! ( url || overlayColor.color || customGradient );
+
 		const controls = (
 			<>
 				<BlockControls>
-					{ !! ( url || overlayColor.color ) && (
+					{ hasBackground && (
 						<>
 							<MediaUploadCheck>
 								<Toolbar>
@@ -348,7 +357,7 @@ class CoverEdit extends Component {
 							</PanelRow>
 						</PanelBody>
 					) }
-					{ ( url || overlayColor.color ) && (
+					{ hasBackground && (
 						<>
 							<PanelBody title={ __( 'Dimensions' ) }>
 								<CoverHeightInput
@@ -367,10 +376,28 @@ class CoverEdit extends Component {
 								initialOpen={ true }
 								colorSettings={ [ {
 									value: overlayColor.color,
-									onChange: setOverlayColor,
+									onChange: ( ...args ) => {
+										setAttributes( {
+											customGradient: undefined,
+										} );
+										setOverlayColor( ...args );
+									},
 									label: __( 'Overlay Color' ),
 								} ] }
 							>
+								<__experimentalGradientPickerControl
+									label={ __( 'Overlay Gradient' ) }
+									onChange={
+										( newGradient ) => {
+											setAttributes( {
+												customGradient: newGradient,
+												customOverlayColor: undefined,
+												overlayColor: undefined,
+											} );
+										}
+									}
+									value={ customGradient }
+								/>
 								{ !! url && (
 									<RangeControl
 										label={ __( 'Background Opacity' ) }
@@ -389,7 +416,7 @@ class CoverEdit extends Component {
 			</>
 		);
 
-		if ( ! ( url || overlayColor.color ) ) {
+		if ( ! hasBackground ) {
 			const placeholderIcon = <BlockIcon icon={ icon } />;
 			const label = __( 'Cover' );
 
@@ -409,13 +436,29 @@ class CoverEdit extends Component {
 						notices={ noticeUI }
 						onError={ this.onUploadError }
 					>
-						<ColorPalette
-							disableCustomColors={ true }
-							value={ overlayColor.color }
-							onChange={ setOverlayColor }
-							clearable={ false }
-							className="wp-block-cover__placeholder-color-palette"
-						/>
+						<div
+							className="wp-block-cover__placeholder-background-options"
+						>
+							<ColorPalette
+								disableCustomColors={ true }
+								value={ overlayColor.color }
+								onChange={ setOverlayColor }
+								clearable={ false }
+							/>
+							<__experimentalGradientPicker
+								onChange={
+									( newGradient ) => {
+										setAttributes( {
+											customGradient: newGradient,
+											customOverlayColor: undefined,
+											overlayColor: undefined,
+										} );
+									}
+								}
+								value={ customGradient }
+								clearable={ false }
+							/>
+						</div>
 					</MediaPlaceholder>
 				</>
 			);
@@ -429,6 +472,7 @@ class CoverEdit extends Component {
 				'has-background-dim': dimRatio !== 0,
 				'has-parallax': hasParallax,
 				[ overlayColor.class ]: overlayColor.class,
+				'has-background-gradient': customGradient,
 			}
 		);
 
@@ -474,6 +518,13 @@ class CoverEdit extends Component {
 									display: 'none',
 								} }
 								src={ url }
+							/>
+						) }
+						{ url && customGradient && dimRatio !== 0 && (
+							<span
+								aria-hidden="true"
+								className="wp-block-cover__gradient-background"
+								style={ { background: customGradient } }
 							/>
 						) }
 						{ VIDEO_BACKGROUND_TYPE === backgroundType && (

--- a/packages/block-library/src/cover/editor.scss
+++ b/packages/block-library/src/cover/editor.scss
@@ -34,10 +34,11 @@
 		}
 	}
 
-	.wp-block-cover__placeholder-color-palette {
+	.wp-block-cover__placeholder-background-options {
 		// wraps about 6 color swatches
 		max-width: 290px;
 		margin-top: 1em;
+		width: 100%;
 	}
 
 	// Apply max-width to floated items that have no intrinsic width

--- a/packages/block-library/src/cover/save.js
+++ b/packages/block-library/src/cover/save.js
@@ -24,6 +24,7 @@ import {
 export default function save( { attributes } ) {
 	const {
 		backgroundType,
+		customGradient,
 		customOverlayColor,
 		dimRatio,
 		focalPoint,
@@ -42,6 +43,9 @@ export default function save( { attributes } ) {
 	if ( focalPoint && ! hasParallax ) {
 		style.backgroundPosition = `${ focalPoint.x * 100 }% ${ focalPoint.y * 100 }%`;
 	}
+	if ( customGradient && ! url ) {
+		style.background = customGradient;
+	}
 	style.minHeight = minHeight || undefined;
 
 	const classes = classnames(
@@ -50,11 +54,19 @@ export default function save( { attributes } ) {
 		{
 			'has-background-dim': dimRatio !== 0,
 			'has-parallax': hasParallax,
+			'has-background-gradient': customGradient,
 		},
 	);
 
 	return (
 		<div className={ classes } style={ style }>
+			{ url && customGradient && dimRatio !== 0 && (
+				<span
+					aria-hidden="true"
+					className="wp-block-cover__gradient-background"
+					style={ { background: customGradient } }
+				/>
+			) }
 			{ VIDEO_BACKGROUND_TYPE === backgroundType && url && ( <video
 				className="wp-block-cover__video-background"
 				autoPlay

--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -30,19 +30,33 @@
 
 	&.has-background-dim::before {
 		content: "";
+		background-color: inherit;
+	}
+
+	&.has-background-dim:not(.has-background-gradient)::before,
+	.wp-block-cover__gradient-background {
 		position: absolute;
 		top: 0;
 		left: 0;
 		bottom: 0;
 		right: 0;
-		background-color: inherit;
-		opacity: 0.5;
 		z-index: z-index(".wp-block-cover.has-background-dim::before");
 	}
 
+	&.has-background-dim:not(.has-background-gradient)::before,
+	& .wp-block-cover__gradient-background {
+		opacity: 0.5;
+	}
+
+
 	@for $i from 1 through 10 {
-		&.has-background-dim.has-background-dim-#{ $i * 10 }::before {
-			opacity: $i * 0.1;
+		&.has-background-dim.has-background-dim-#{ $i * 10 } {
+			&:not(.has-background-gradient)::before {
+				opacity: $i * 0.1;
+			}
+			.wp-block-cover__gradient-background {
+				opacity: $i * 0.1;
+			}
 		}
 	}
 

--- a/packages/components/src/gradient-picker/index.js
+++ b/packages/components/src/gradient-picker/index.js
@@ -19,6 +19,7 @@ export default function GradientPicker( {
 	gradients,
 	onChange,
 	value,
+	clearable = true,
 } ) {
 	const clearGradient = useCallback(
 		() => onChange( undefined ),
@@ -56,7 +57,7 @@ export default function GradientPicker( {
 		<CircularOptionPicker
 			className={ className }
 			options={ gradientOptions }
-			actions={ (
+			actions={ clearable && (
 				<CircularOptionPicker.ButtonAction onClick={ clearGradient }>
 					{ __( 'Clear' ) }
 				</CircularOptionPicker.ButtonAction>


### PR DESCRIPTION
## Description
This PR adds the gradient functionality to the cover block.


## How has this been tested?
- I added a cover block, selected a gradient and verified the gradient works well as a background.
- I added a cover block, selected an image as a background, selected a gradient overlay, verified it is possible to change the opacity, I left the opacity at 80%.
- I added a cover block, selected a video as a background, selected a gradient overlay, verified it is possible to change the opacity, I left the opacity at 20%.
- I saved the post and verified, all the three cover blocks.


I added fixtures in this branch but it made the PR too big and would make things hard to review. I will submit a PR that adds the fixtures.


## Screenshots <!-- if applicable -->

<img width="990" alt="Screenshot 2019-10-17 at 14 59 27" src="https://user-images.githubusercontent.com/11271197/67016023-6bec2980-f0ef-11e9-9960-08df53c7b81a.png">

https://make.wordpress.org/core/files/2019/10/Oct-17-2019-10-39-06.mp4

https://make.wordpress.org/core/files/2019/10/Oct-17-2019-14-58-31.mp4