### PR TITLE
18005  Removes declaration of Select button text in frameConfig

### DIFF
--- a/packages/media-utils/src/components/media-upload/index.js
+++ b/packages/media-utils/src/components/media-upload/index.js
@@ -125,9 +125,6 @@ class MediaUpload extends Component {
 		} else {
 			const frameConfig = {
 				title,
-				button: {
-					text: __( 'Select' ),
-				},
 				multiple,
 			};
 			if ( !! allowedTypes ) {


### PR DESCRIPTION
## Description
The declaration of "Select" in the button object of frameConfig was causing conflict with the Core frames default behavior. A synopsis of this issue can be found here: https://github.com/WordPress/gutenberg/issues/18005

"The default state set by the select fame is using the exact same string that we are attempting to define. Removing this allows the edit image state to return back to the Library frame when a user clicks "back""


## How has this been tested?

1 add image block
2 select image
3 click "edit image"
4 click "back"
5 notice select button says "Select". :) 

## Screenshots <!-- if applicable -->
<img width="498" alt="Screen Shot 2019-10-17 at 2 23 01 PM" src="https://user-images.githubusercontent.com/11888980/67040733-b2d72080-f0e9-11e9-8611-19ffb9239aea.png">

Fixes: #18005