### PR TITLE
Show video preview on cover media settings panel

### DIFF
--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -344,6 +344,14 @@ function CoverEdit( {
 								onChange={ ( newFocalPoint ) => setAttributes( { focalPoint: newFocalPoint } ) }
 							/>
 						) }
+						{ VIDEO_BACKGROUND_TYPE === backgroundType && (
+							<video
+								autoPlay
+								muted
+								loop
+								src={ url }
+							/>
+						) }
 						<PanelRow>
 							<Button
 								isDefault


### PR DESCRIPTION
## Description
This PR adds a video preview on the media settings panel. Before I just rendered the clear media button for video backgrounds. I think we should show a preview of the media we are cleaning, also I think the UI looks better if we show a preview.
For image backgrounds, we show the focal point picker which is also a preview of the image.

## How has this been tested?
I added a cover block.
I selected a video as a background.
I verified a video preview appeared on the media settings panel on the block inspector.

## Before
<img width="271" alt="Screenshot 2019-11-14 at 16 15 46" src="https://user-images.githubusercontent.com/11271197/68875033-114bea80-06fa-11ea-9410-cd2dc2b6623c.png">

## After
<img width="277" alt="Screenshot 2019-11-14 at 16 14 21" src="https://user-images.githubusercontent.com/11271197/68875052-16a93500-06fa-11ea-8705-86de63febd54.png">

