### PR TITLE
Fix: Cover block may contain has-background-dim-NaN class

### DIFF
--- a/packages/block-library/src/cover/shared.js
+++ b/packages/block-library/src/cover/shared.js
@@ -8,7 +8,7 @@ export function backgroundImageStyles( url ) {
 }
 
 export function dimRatioToClass( ratio ) {
-	return ( ratio === 0 || ratio === 50 ) ?
+	return ( ratio === 0 || ratio === 50 || ! ratio ) ?
 		null :
 		'has-background-dim-' + ( 10 * Math.round( ratio / 10 ) );
 }


### PR DESCRIPTION
## Description
The cover block contained a bug and in some cases added a has-background-dim-NaN class.

## How has this been tested?
I added a cover block.
I selected an image for the block.
I added an overlay color.
I set the opacity value to 80%.
I pressed the "Clear Media" button, I went to the code editor and verified the button block does not contain the has-background-dim-NaN class (on master there is a bug and the class is added).
