### PR TITLE
Storybook: Add knobs to ColorIndicator

### DIFF
--- a/packages/components/src/color-indicator/stories/index.js
+++ b/packages/components/src/color-indicator/stories/index.js
@@ -1,13 +1,20 @@
 /**
+ * External dependencies
+ */
+import { text } from '@storybook/addon-knobs';
+/**
  * Internal dependencies
  */
 import ColorIndicator from '../';
 
 export default {
-	title: 'Color Indicator',
+	title: 'ColorIndicator',
 	component: ColorIndicator,
 };
 
-export const _default = () => (
-	<ColorIndicator colorValue="#0073aa" />
-);
+export const _default = () => {
+	const color = text( 'Color', '#0073aa' );
+	return (
+		<ColorIndicator colorValue={ color } />
+	);
+};

--- a/packages/components/src/color-indicator/stories/index.js
+++ b/packages/components/src/color-indicator/stories/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { text } from '@storybook/addon-knobs';
+
 /**
  * Internal dependencies
  */


### PR DESCRIPTION
## Description

- Add knobs to give user ability to change color in Storybook
- Additionally changed the display name removing space to match other components in Storybook, as well as match exactly the component name as used

## How has this been tested?

Run `npm run design-system:dev` confirm component shows with default color.
Click knobs tab and confirm you can change color

## Types of changes

Storybook.
