### PR TITLE
Fix Publish Button!!!

### DIFF
--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -37,7 +37,7 @@
 			background: #f3f5f6;
 			color: color(theme(button) shade(25%));
 			border-color: color(theme(button) shade(5%));
-			box-shadow: 0 0 0 1px color(theme(button) shade(5%));
+			box-shadow: 0 0 0 $border-width color(theme(button) shade(5%));
 			text-decoration: none;
 
 		}
@@ -54,7 +54,7 @@
 			color: #a0a5aa;
 			border-color: #ddd;
 			background: #f7f7f7;
-			text-shadow: 0 1px 0 #fff;
+			text-shadow: 0 $border-width 0 #fff;
 			transform: none;
 			opacity: 1;
 		}
@@ -76,7 +76,7 @@
 
 		&:focus:enabled {
 			box-shadow:
-				0 0 0 1px $white,
+				0 0 0 $border-width $white,
 				0 0 0 3px color(theme(button));
 		}
 
@@ -107,7 +107,7 @@
 
 			&:focus:enabled {
 				box-shadow:
-					0 0 0 1px $white,
+					0 0 0 $border-width $white,
 					0 0 0 3px color(theme(button));
 			}
 		}
@@ -157,8 +157,8 @@
 		&:focus {
 			color: #124964;
 			box-shadow:
-				0 0 0 1px #5b9dd9,
-				0 0 2px 1px rgba(30, 140, 190, 0.8);
+				0 0 0 $border-width #5b9dd9,
+				0 0 2px $border-width rgba(30, 140, 190, 0.8);
 		}
 	}
 

--- a/packages/edit-post/src/components/header/style.scss
+++ b/packages/edit-post/src/components/header/style.scss
@@ -91,7 +91,7 @@
 	&.editor-post-publish-button,
 	&.editor-post-publish-panel__toggle {
 		margin: 2px;
-		height: 33px;
+		height: 34px;
 		line-height: 32px;
 		font-size: $default-font-size;
 	}
@@ -105,13 +105,17 @@
 		}
 	}
 
+	// These paddings actually duplicate existing rules from button component.
+	// But they are duplicated so as to provide smaller paddings to fit the buttons on mobile.
 	&.editor-post-preview,
 	&.editor-post-publish-button,
 	&.editor-post-publish-panel__toggle {
-		padding: 0 5px 2px;
+		padding-left: 5px;
+		padding-right: 5px;
 
 		@include break-small() {
-			padding: 0 12px 2px;
+			padding-left: 12px;
+			padding-right: 12px;
 		}
 	}
 

--- a/packages/editor/src/components/post-publish-button/index.js
+++ b/packages/editor/src/components/post-publish-button/index.js
@@ -113,6 +113,7 @@ export class PostPublishButton extends Component {
 		return (
 			<div>
 				<Button
+					isLarge
 					ref={ this.buttonNode }
 					{ ...componentProps }
 				>


### PR DESCRIPTION
Fixes #18004 and thank science, that was driving me insane ever since you pointed it out.

This PR does a couple of things:

1. It adds `isLarge` to the Publish button. It was there for Preview, but not Publish.
2. It simplifies a little CSS as a result of that.
3. It also tweaks the button height as defined for the two preview publish buttons.

First I commented out the special case CSS we had for publish preview:

![Screenshot 2019-10-18 at 08 44 54](https://user-images.githubusercontent.com/1204802/67073223-e4ea9000-f186-11e9-85e6-6428c8545fe2.png)

Whaaa? Yep, Preview `isLarge`, Publish `wasNot`.

![Screenshot 2019-10-18 at 08 55 43](https://user-images.githubusercontent.com/1204802/67073237-efa52500-f186-11e9-8c72-d345c4e6cde6.png)

There, better.

![Screenshot 2019-10-18 at 08 58 14](https://user-images.githubusercontent.com/1204802/67073248-f6339c80-f186-11e9-97c2-11047a5a710a.png)

There, even better.

![Screenshot 2019-10-18 at 09 00 33](https://user-images.githubusercontent.com/1204802/67073258-fcc21400-f186-11e9-9f4d-d53ac86386ab.png)

There, now the mobile rules are nice too.