### PR TITLE
Fix regression with Gallery margin.

### DIFF
--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -17,8 +17,10 @@ figure.wp-block-gallery {
 	margin: 0;
 }
 
-// need to override default editor ul styles
+// Necessary to to override default editor ul styles.
 .blocks-gallery-grid.blocks-gallery-grid {
+	padding-left: 0;
+	margin-left: 0;
 	margin-bottom: 0;
 }
 


### PR DESCRIPTION
I failed to verify the Gallery block when I approved https://github.com/WordPress/gutenberg/pull/17958#issuecomment-543597183 and therefore caused a regression.

This PR adds explicity left margins and paddings to the gallery ul to ensure there isn't any added padding and margin.

Before:

![Screenshot 2019-10-18 at 10 22 51](https://user-images.githubusercontent.com/1204802/67078986-ac50b380-f192-11e9-83b2-7b5d9d442c01.png)

After:

![Screenshot 2019-10-18 at 10 31 04](https://user-images.githubusercontent.com/1204802/67078997-b07cd100-f192-11e9-8448-0fd0671b5498.png)
