### PR TITLE
Fix the performance tests after e2e tests reorganisation

### DIFF
--- a/packages/e2e-tests/config/performance-reporter.js
+++ b/packages/e2e-tests/config/performance-reporter.js
@@ -6,7 +6,7 @@ function average( array ) {
 
 class PerformanceReporter {
 	onRunComplete() {
-		const path = __dirname + '/../specs/results.json';
+		const path = __dirname + '/../specs/performance/results.json';
 
 		if ( ! existsSync( path ) ) {
 			return;

--- a/packages/e2e-tests/specs/performance/performance.test.js
+++ b/packages/e2e-tests/specs/performance/performance.test.js
@@ -20,7 +20,7 @@ function readFile( filePath ) {
 
 describe( 'Performance', () => {
 	it( '1000 paragraphs', async () => {
-		const html = readFile( join( __dirname, '../assets/large-post.html' ) );
+		const html = readFile( join( __dirname, '../../assets/large-post.html' ) );
 
 		await createNewPost();
 		await page.evaluate( ( _html ) => {


### PR DESCRIPTION
In #17990 we moved tests into different folders causing the performance tests to break.

**Testing instructions**

run `npm run test-performance` locally and ensure you have a resulst :)