### PR TITLE
Fix columns full-wide regression.

### DIFF
--- a/packages/block-library/src/columns/editor.scss
+++ b/packages/block-library/src/columns/editor.scss
@@ -12,18 +12,6 @@
 	}
 }
 
-// Fullwide: show margin left/right to ensure there's room for the side UI.
-// This is not a 1:1 preview with the front-end where these margins would presumably be zero.
-[data-type="core/columns"][data-align="full"] .wp-block-columns > .editor-inner-blocks {
-	padding-left: $block-padding;
-	padding-right: $block-padding;
-
-	@include break-small() {
-		padding-left: $block-container-side-padding;
-		padding-right: $block-container-side-padding;
-	}
-}
-
 .wp-block-columns {
 	display: block;
 
@@ -188,15 +176,28 @@ div.block-core-columns.is-vertically-aligned-bottom {
 /**
  * Add extra padding when the parent block is selected, for easier interaction.
  */
-.block-editor-block-list__layout .block-editor-block-list__block[data-type="core/columns"].is-selected > .block-editor-block-list__block-edit > [data-block] > div > .block-editor-inner-blocks,
-.block-editor-block-list__layout .block-editor-block-list__block[data-type="core/columns"].has-child-selected > .block-editor-block-list__block-edit > [data-block] > div > .block-editor-inner-blocks,
-.block-editor-block-list__layout .block-editor-block-list__block[data-type="core/column"].is-selected > .block-editor-block-list__block-edit > [data-block] > div > .block-editor-inner-blocks,
-.block-editor-block-list__layout .block-editor-block-list__block[data-type="core/column"].has-child-selected > .block-editor-block-list__block-edit > [data-block] > div > .block-editor-inner-blocks {
+[data-type="core/columns"].is-selected > .block-editor-block-list__block-edit > [data-block] > div > .block-editor-inner-blocks,
+[data-type="core/columns"].has-child-selected > .block-editor-block-list__block-edit > [data-block] > div > .block-editor-inner-blocks,
+[data-type="core/column"].is-selected > .block-editor-block-list__block-edit > [data-block] > div > .block-editor-inner-blocks,
+[data-type="core/column"].has-child-selected > .block-editor-block-list__block-edit > [data-block] > div > .block-editor-inner-blocks {
 	padding: $block-padding;
 
 	// Negate this padding for the placeholder.
 	> .components-placeholder {
 		margin: -$block-padding;
 		width: calc(100% + #{$block-padding * 2});
+	}
+}
+
+
+// Fullwide: show margin left/right to ensure there's room for the side UI.
+// This is not a 1:1 preview with the front-end where these margins would presumably be zero.
+[data-type="core/columns"][data-align="full"] .wp-block-columns {
+	padding-left: $block-padding;
+	padding-right: $block-padding;
+
+	@include break-small() {
+		padding-left: $block-container-side-padding;
+		padding-right: $block-container-side-padding;
 	}
 }


### PR DESCRIPTION
The Columns block, when full-wide, has intentional left and right padding to ensure the mover controls of child blocks are accessible. This is editor-only, and only when the block is selected.

This regressed at some point, a while ago, probably around the introduction of extra on-click padding to show the dashed outlines of child elements.

This PR shuffles the rules a bit, reduces some of their specificity, and applies the left and right padding elsewhere to make it work.

Before:

![Screenshot 2019-10-18 at 10 13 22](https://user-images.githubusercontent.com/1204802/67080418-81b42a00-f195-11e9-847c-7d18f1b76223.png)

![before](https://user-images.githubusercontent.com/1204802/67080422-837ded80-f195-11e9-8476-0d2054936809.gif)

After:

![after](https://user-images.githubusercontent.com/1204802/67080431-8547b100-f195-11e9-8830-19229b2ae5fe.gif)
