### PR TITLE
Fix: Cover to video and image transforms

### DIFF
--- a/packages/block-library/src/cover/transforms.js
+++ b/packages/block-library/src/cover/transforms.js
@@ -40,8 +40,13 @@ const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'core/image' ],
-			isMatch: ( { backgroundType, url } ) => {
-				return ! url || backgroundType === IMAGE_BACKGROUND_TYPE;
+			isMatch: ( { backgroundType, url, overlayColor, customOverlayColor, gradient, customGradient } ) => {
+				if ( url ) {
+					// If a url exists the transform could happen if that URL represents an image background.
+					return backgroundType === IMAGE_BACKGROUND_TYPE;
+				}
+				// If a url is not set the transform could happen if the cover has no background color or gradient;
+				return ! overlayColor && ! customOverlayColor && ! gradient && ! customGradient;
 			},
 			transform: ( { title, url, align, id } ) => (
 				createBlock( 'core/image', {
@@ -55,8 +60,13 @@ const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'core/video' ],
-			isMatch: ( { backgroundType, url } ) => {
-				return ! url || backgroundType === VIDEO_BACKGROUND_TYPE;
+			isMatch: ( { backgroundType, url, overlayColor, customOverlayColor, gradient, customGradient } ) => {
+				if ( url ) {
+					// If a url exists the transform could happen if that URL represents a video background.
+					return backgroundType === VIDEO_BACKGROUND_TYPE;
+				}
+				// If a url is not set the transform could happen if the cover has no background color or gradient;
+				return ! overlayColor && ! customOverlayColor && ! gradient && ! customGradient;
 			},
 			transform: ( { title, url, align, id } ) => (
 				createBlock( 'core/video', {

--- a/packages/e2e-tests/fixtures/blocks/core__cover__solid-color.html
+++ b/packages/e2e-tests/fixtures/blocks/core__cover__solid-color.html
@@ -1,0 +1,9 @@
+<!-- wp:cover {"overlayColor":"primary"} -->
+<div class="wp-block-cover has-primary-background-color has-background-dim">
+	<div class="wp-block-cover__inner-container">
+		<!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
+		<p class="has-text-align-center has-large-font-size"></p>
+		<!-- /wp:paragraph -->
+	</div>
+</div>
+<!-- /wp:cover -->

--- a/packages/e2e-tests/fixtures/blocks/core__cover__solid-color.json
+++ b/packages/e2e-tests/fixtures/blocks/core__cover__solid-color.json
@@ -1,0 +1,30 @@
+[
+    {
+        "clientId": "_clientId_0",
+        "name": "core/cover",
+        "isValid": true,
+        "attributes": {
+            "hasParallax": false,
+            "dimRatio": 50,
+            "overlayColor": "primary",
+            "backgroundType": "image"
+        },
+        "innerBlocks": [
+            {
+                "clientId": "_clientId_0",
+                "name": "core/paragraph",
+                "isValid": true,
+                "attributes": {
+                    "align": "center",
+                    "content": "",
+                    "dropCap": false,
+                    "placeholder": "Write title…",
+                    "fontSize": "large"
+                },
+                "innerBlocks": [],
+                "originalContent": "<p class=\"has-text-align-center has-large-font-size\"></p>"
+            }
+        ],
+        "originalContent": "<div class=\"wp-block-cover has-primary-background-color has-background-dim\">\n\t<div class=\"wp-block-cover__inner-container\">\n\t\t\n\t</div>\n</div>"
+    }
+]

--- a/packages/e2e-tests/fixtures/blocks/core__cover__solid-color.parsed.json
+++ b/packages/e2e-tests/fixtures/blocks/core__cover__solid-color.parsed.json
@@ -1,0 +1,38 @@
+[
+    {
+        "blockName": "core/cover",
+        "attrs": {
+            "overlayColor": "primary"
+        },
+        "innerBlocks": [
+            {
+                "blockName": "core/paragraph",
+                "attrs": {
+                    "align": "center",
+                    "placeholder": "Write title…",
+                    "fontSize": "large"
+                },
+                "innerBlocks": [],
+                "innerHTML": "\n\t\t<p class=\"has-text-align-center has-large-font-size\"></p>\n\t\t",
+                "innerContent": [
+                    "\n\t\t<p class=\"has-text-align-center has-large-font-size\"></p>\n\t\t"
+                ]
+            }
+        ],
+        "innerHTML": "\n<div class=\"wp-block-cover has-primary-background-color has-background-dim\">\n\t<div class=\"wp-block-cover__inner-container\">\n\t\t\n\t</div>\n</div>\n",
+        "innerContent": [
+            "\n<div class=\"wp-block-cover has-primary-background-color has-background-dim\">\n\t<div class=\"wp-block-cover__inner-container\">\n\t\t",
+            null,
+            "\n\t</div>\n</div>\n"
+        ]
+    },
+    {
+        "blockName": null,
+        "attrs": {},
+        "innerBlocks": [],
+        "innerHTML": "\n",
+        "innerContent": [
+            "\n"
+        ]
+    }
+]

--- a/packages/e2e-tests/fixtures/blocks/core__cover__solid-color.serialized.html
+++ b/packages/e2e-tests/fixtures/blocks/core__cover__solid-color.serialized.html
@@ -1,0 +1,5 @@
+<!-- wp:cover {"overlayColor":"primary"} -->
+<div class="wp-block-cover has-primary-background-color has-background-dim"><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
+<p class="has-text-align-center has-large-font-size"></p>
+<!-- /wp:paragraph --></div></div>
+<!-- /wp:cover -->


### PR DESCRIPTION
## Description
The transform of cover to video and image was implemented before solid color backgrounds were implemented.
Currently if one selects a solid color as a background, without any image or video it is still possible to transform the cover block into an image or a video.
This PR removes the possibility of transforming cover blocks with a solid color background into a video or image. I think these transforms don't make sense.

## How has this been tested?
I added a cover block.
I selected a solid color background.
I verified it was not possible to transform the block into an image or video.
