### PR TITLE
Explore Multi-Entity Saving

### DIFF
--- a/docs/designers-developers/developers/data/data-core-editor.md
+++ b/docs/designers-developers/developers/data/data-core-editor.md
@@ -655,6 +655,19 @@ _Related_
 
 -   hasMultiSelection in core/block-editor store.
 
+<a name="hasNonPostEntityChanges" href="#hasNonPostEntityChanges">#</a> **hasNonPostEntityChanges**
+
+Returns true if there are unsaved edits for entities other than
+the editor's post, and false otherwise.
+
+_Parameters_
+
+-   _state_ `Object`: Global application state.
+
+_Returns_
+
+-   `boolean`: Whether there are edits or not.
+
 <a name="hasSelectedBlock" href="#hasSelectedBlock">#</a> **hasSelectedBlock**
 
 _Related_

--- a/docs/designers-developers/developers/data/data-core.md
+++ b/docs/designers-developers/developers/data/data-core.md
@@ -155,8 +155,10 @@ _Returns_
 
 <a name="getEntityRecordChangesByRecord" href="#getEntityRecordChangesByRecord">#</a> **getEntityRecordChangesByRecord**
 
-Returns a list of objects with each edited entity
+Returns a map of objects with each edited entity
 record and its corresponding edits.
+
+The map is keyed by entity `kind => name => id`.
 
 _Parameters_
 
@@ -164,7 +166,7 @@ _Parameters_
 
 _Returns_
 
--   `Array`: The list of edited records with their edits.
+-   `Object`: The map of edited records with their edits.
 
 <a name="getEntityRecordEdits" href="#getEntityRecordEdits">#</a> **getEntityRecordEdits**
 

--- a/docs/designers-developers/developers/data/data-core.md
+++ b/docs/designers-developers/developers/data/data-core.md
@@ -153,6 +153,19 @@ _Returns_
 
 -   `?Object`: Record.
 
+<a name="getEntityRecordChangesByRecord" href="#getEntityRecordChangesByRecord">#</a> **getEntityRecordChangesByRecord**
+
+Returns a list of objects with each edited entity
+record and its corresponding edits.
+
+_Parameters_
+
+-   _state_ `Object`: State tree.
+
+_Returns_
+
+-   `Array`: The list of edited records with their edits.
+
 <a name="getEntityRecordEdits" href="#getEntityRecordEdits">#</a> **getEntityRecordEdits**
 
 Returns the specified entity record's edits.

--- a/docs/designers-developers/developers/data/data-core.md
+++ b/docs/designers-developers/developers/data/data-core.md
@@ -155,10 +155,10 @@ _Returns_
 
 <a name="getEntityRecordChangesByRecord" href="#getEntityRecordChangesByRecord">#</a> **getEntityRecordChangesByRecord**
 
-Returns a map of objects with each edited entity
-record and its corresponding edits.
+Returns a map of objects with each edited
+raw entity record and its corresponding edits.
 
-The map is keyed by entity `kind => name => id`.
+The map is keyed by entity `kind => name => key => { rawRecord, edits }`.
 
 _Parameters_
 
@@ -166,7 +166,7 @@ _Parameters_
 
 _Returns_
 
--   `Object`: The map of edited records with their edits.
+-   `null`: The map of edited records with their edits.
 
 <a name="getEntityRecordEdits" href="#getEntityRecordEdits">#</a> **getEntityRecordEdits**
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7948,6 +7948,7 @@
 				"@wordpress/viewport": "file:packages/viewport",
 				"@wordpress/wordcount": "file:packages/wordcount",
 				"classnames": "^2.2.5",
+				"equivalent-key-map": "^0.2.2",
 				"lodash": "^4.17.15",
 				"memize": "^1.0.5",
 				"react-autosize-textarea": "^3.0.2",

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -368,10 +368,10 @@ _Returns_
 
 <a name="getEntityRecordChangesByRecord" href="#getEntityRecordChangesByRecord">#</a> **getEntityRecordChangesByRecord**
 
-Returns a map of objects with each edited entity
-record and its corresponding edits.
+Returns a map of objects with each edited
+raw entity record and its corresponding edits.
 
-The map is keyed by entity `kind => name => id`.
+The map is keyed by entity `kind => name => key => { rawRecord, edits }`.
 
 _Parameters_
 
@@ -379,7 +379,7 @@ _Parameters_
 
 _Returns_
 
--   `Object`: The map of edited records with their edits.
+-   `null`: The map of edited records with their edits.
 
 <a name="getEntityRecordEdits" href="#getEntityRecordEdits">#</a> **getEntityRecordEdits**
 

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -368,8 +368,10 @@ _Returns_
 
 <a name="getEntityRecordChangesByRecord" href="#getEntityRecordChangesByRecord">#</a> **getEntityRecordChangesByRecord**
 
-Returns a list of objects with each edited entity
+Returns a map of objects with each edited entity
 record and its corresponding edits.
+
+The map is keyed by entity `kind => name => id`.
 
 _Parameters_
 
@@ -377,7 +379,7 @@ _Parameters_
 
 _Returns_
 
--   `Array`: The list of edited records with their edits.
+-   `Object`: The map of edited records with their edits.
 
 <a name="getEntityRecordEdits" href="#getEntityRecordEdits">#</a> **getEntityRecordEdits**
 

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -366,6 +366,19 @@ _Returns_
 
 -   `?Object`: Record.
 
+<a name="getEntityRecordChangesByRecord" href="#getEntityRecordChangesByRecord">#</a> **getEntityRecordChangesByRecord**
+
+Returns a list of objects with each edited entity
+record and its corresponding edits.
+
+_Parameters_
+
+-   _state_ `Object`: State tree.
+
+_Returns_
+
+-   `Array`: The list of edited records with their edits.
+
 <a name="getEntityRecordEdits" href="#getEntityRecordEdits">#</a> **getEntityRecordEdits**
 
 Returns the specified entity record's edits.

--- a/packages/core-data/src/selectors.js
+++ b/packages/core-data/src/selectors.js
@@ -154,12 +154,14 @@ export function getEntityRecords( state, kind, name, query ) {
 }
 
 /**
- * Returns a list of objects with each edited entity
+ * Returns a map of objects with each edited entity
  * record and its corresponding edits.
+ *
+ * The map is keyed by entity `kind => name => id`.
  *
  * @param {Object} state State tree.
  *
- * @return {Array} The list of edited records with their edits.
+ * @return {Object} The map of edited records with their edits.
  */
 export const getEntityRecordChangesByRecord = createSelector(
 	( state ) => {

--- a/packages/core-data/src/selectors.js
+++ b/packages/core-data/src/selectors.js
@@ -154,6 +154,52 @@ export function getEntityRecords( state, kind, name, query ) {
 }
 
 /**
+ * Returns a list of objects with each edited entity
+ * record and its corresponding edits.
+ *
+ * @param {Object} state State tree.
+ *
+ * @return {Array} The list of edited records with their edits.
+ */
+export const getEntityRecordChangesByRecord = createSelector(
+	( state ) => {
+		const {
+			entities: { data },
+		} = state;
+		return Object.keys( data ).reduce( ( acc, kind ) => {
+			Object.keys( data[ kind ] ).forEach( ( name ) => {
+				const editsKeys = Object.keys( data[ kind ][ name ].edits ).filter( ( editsKey ) =>
+					hasEditsForEntityRecord( state, kind, name, editsKey )
+				);
+				if ( editsKeys.length ) {
+					if ( ! acc[ kind ] ) {
+						acc[ kind ] = {};
+					}
+					if ( ! acc[ kind ][ name ] ) {
+						acc[ kind ][ name ] = {};
+					}
+					editsKeys.forEach(
+						( editsKey ) =>
+							( acc[ kind ][ name ][ editsKey ] = {
+								rawRecord: getRawEntityRecord( state, kind, name, editsKey ),
+								edits: getEntityRecordNonTransientEdits(
+									state,
+									kind,
+									name,
+									editsKey
+								),
+							} )
+					);
+				}
+			} );
+
+			return acc;
+		}, {} );
+	},
+	( state ) => [ state.entities.data ]
+);
+
+/**
  * Returns the specified entity record's edits.
  *
  * @param {Object} state    State tree.

--- a/packages/core-data/src/selectors.js
+++ b/packages/core-data/src/selectors.js
@@ -154,14 +154,14 @@ export function getEntityRecords( state, kind, name, query ) {
 }
 
 /**
- * Returns a map of objects with each edited entity
- * record and its corresponding edits.
+ * Returns a map of objects with each edited
+ * raw entity record and its corresponding edits.
  *
- * The map is keyed by entity `kind => name => id`.
+ * The map is keyed by entity `kind => name => key => { rawRecord, edits }`.
  *
  * @param {Object} state State tree.
  *
- * @return {Object} The map of edited records with their edits.
+ * @return {{ [kind: string]: { [name: string]: { [key: string]: { rawRecord: Object<string,*>, edits: Object<string,*> } } } }} The map of edited records with their edits.
  */
 export const getEntityRecordChangesByRecord = createSelector(
 	( state ) => {

--- a/packages/core-data/src/test/selectors.js
+++ b/packages/core-data/src/test/selectors.js
@@ -9,6 +9,7 @@ import deepFreeze from 'deep-freeze';
 import {
 	getEntityRecord,
 	getEntityRecords,
+	getEntityRecordChangesByRecord,
 	getEntityRecordNonTransientEdits,
 	getEmbedPreview,
 	isPreviewEmbedFallback,
@@ -105,10 +106,63 @@ describe( 'getEntityRecords', () => {
 	} );
 } );
 
+describe( 'getEntityRecordChangesByRecord', () => {
+	it( 'should return a map of objects with each raw edited entity record and its corresponding edits', () => {
+		const state = deepFreeze( {
+			entities: {
+				config: [
+					{
+						kind: 'someKind',
+						name: 'someName',
+						transientEdits: { someTransientEditProperty: true },
+					},
+				],
+				data: {
+					someKind: {
+						someName: {
+							queriedData: {
+								items: {
+									someKey: {
+										someProperty: 'somePersistedValue',
+										someRawProperty: { raw: 'somePersistedRawValue' },
+									},
+								},
+							},
+							edits: {
+								someKey: {
+									someProperty: 'someEditedValue',
+									someRawProperty: 'someEditedRawValue',
+									someTransientEditProperty: 'someEditedTransientEditValue',
+								},
+							},
+						},
+					},
+				},
+			},
+		} );
+		expect( getEntityRecordChangesByRecord( state ) ).toEqual( {
+			someKind: {
+				someName: {
+					someKey: {
+						rawRecord: {
+							someProperty: 'somePersistedValue',
+							someRawProperty: 'somePersistedRawValue',
+						},
+						edits: {
+							someProperty: 'someEditedValue',
+							someRawProperty: 'someEditedRawValue',
+						},
+					},
+				},
+			},
+		} );
+	} );
+} );
+
 describe( 'getEntityRecordNonTransientEdits', () => {
 	it( 'should return an empty object when the entity does not have a loaded config.', () => {
 		const state = deepFreeze( {
-			entities: { config: {}, data: {} },
+			entities: { config: [], data: {} },
 		} );
 		expect(
 			getEntityRecordNonTransientEdits( state, 'someKind', 'someName', 'someId' )

--- a/packages/edit-post/src/components/header/index.js
+++ b/packages/edit-post/src/components/header/index.js
@@ -4,6 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { IconButton } from '@wordpress/components';
 import {
+	EntitiesSavedStates,
 	PostPreviewButton,
 	PostSavedState,
 } from '@wordpress/editor';
@@ -26,6 +27,7 @@ function Header( {
 	isEditorSidebarOpened,
 	isPublishSidebarOpened,
 	isSaving,
+	enableFullSiteEditing,
 	openGeneralSidebar,
 } ) {
 	const toggleGeneralSidebar = isEditorSidebarOpened ? closeGeneralSidebar : openGeneralSidebar;
@@ -37,6 +39,7 @@ function Header( {
 				<HeaderToolbar />
 			</div>
 			<div className="edit-post-header__settings">
+				{ enableFullSiteEditing && <EntitiesSavedStates /> }
 				{ ! isPublishSidebarOpened && (
 					// This button isn't completely hidden by the publish sidebar.
 					// We can't hide the whole toolbar when the publish sidebar is open because
@@ -77,6 +80,7 @@ export default compose(
 		isEditorSidebarOpened: select( 'core/edit-post' ).isEditorSidebarOpened(),
 		isPublishSidebarOpened: select( 'core/edit-post' ).isPublishSidebarOpened(),
 		isSaving: select( 'core/edit-post' ).isSavingMetaBoxes(),
+		enableFullSiteEditing: select( 'core/editor' ).getEditorSettings( '__experimentalEnableFullSiteEditing' ),
 	} ) ),
 	withDispatch( ( dispatch, ownProps, { select } ) => {
 		const { getBlockSelectionStart } = select( 'core/block-editor' );

--- a/packages/edit-post/src/components/header/index.js
+++ b/packages/edit-post/src/components/header/index.js
@@ -4,7 +4,6 @@
 import { __ } from '@wordpress/i18n';
 import { IconButton } from '@wordpress/components';
 import {
-	EntitiesSavedStates,
 	PostPreviewButton,
 	PostSavedState,
 } from '@wordpress/editor';
@@ -27,7 +26,6 @@ function Header( {
 	isEditorSidebarOpened,
 	isPublishSidebarOpened,
 	isSaving,
-	enableFullSiteEditing,
 	openGeneralSidebar,
 } ) {
 	const toggleGeneralSidebar = isEditorSidebarOpened ? closeGeneralSidebar : openGeneralSidebar;
@@ -39,7 +37,6 @@ function Header( {
 				<HeaderToolbar />
 			</div>
 			<div className="edit-post-header__settings">
-				{ enableFullSiteEditing && <EntitiesSavedStates /> }
 				{ ! isPublishSidebarOpened && (
 					// This button isn't completely hidden by the publish sidebar.
 					// We can't hide the whole toolbar when the publish sidebar is open because
@@ -80,7 +77,6 @@ export default compose(
 		isEditorSidebarOpened: select( 'core/edit-post' ).isEditorSidebarOpened(),
 		isPublishSidebarOpened: select( 'core/edit-post' ).isPublishSidebarOpened(),
 		isSaving: select( 'core/edit-post' ).isSavingMetaBoxes(),
-		enableFullSiteEditing: select( 'core/editor' ).getEditorSettings( '__experimentalEnableFullSiteEditing' ),
 	} ) ),
 	withDispatch( ( dispatch, ownProps, { select } ) => {
 		const { getBlockSelectionStart } = select( 'core/block-editor' );

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -50,6 +50,7 @@
 		"@wordpress/viewport": "file:../viewport",
 		"@wordpress/wordcount": "file:../wordcount",
 		"classnames": "^2.2.5",
+		"equivalent-key-map": "^0.2.2",
 		"lodash": "^4.17.15",
 		"memize": "^1.0.5",
 		"react-autosize-textarea": "^3.0.2",

--- a/packages/editor/src/components/entities-saved-states/index.js
+++ b/packages/editor/src/components/entities-saved-states/index.js
@@ -63,7 +63,7 @@ export default function EntitiesSavedStates( {
 		isOpen && (
 			<Modal
 				title={ __( 'What do you want to save?' ) }
-				onRequestClose={ onRequestClose }
+				onRequestClose={ () => onRequestClose() }
 				contentLabel={ __( 'Select items to save.' ) }
 			>
 				{ Object.keys( entityRecordChangesByRecord ).map( ( changedKind ) =>

--- a/packages/editor/src/components/entities-saved-states/index.js
+++ b/packages/editor/src/components/entities-saved-states/index.js
@@ -13,13 +13,12 @@ import { useState, useCallback } from '@wordpress/element';
 const EntitiesSavedStatesCheckbox = ( {
 	id,
 	name,
-	changes: { rawRecord, edits },
+	changes: { rawRecord },
 	checked,
 	setCheckedById,
 } ) => (
 	<CheckboxControl
 		label={ `${ startCase( name ) }: "${ rawRecord.title || rawRecord.name }"` }
-		help={ `Changed Properties: ${ Object.keys( edits ).join( ', ' ) }.` }
 		checked={ checked }
 		onChange={ useCallback( ( nextChecked ) => setCheckedById( id, nextChecked ), [ id ] ) }
 	/>

--- a/packages/editor/src/components/entities-saved-states/index.js
+++ b/packages/editor/src/components/entities-saved-states/index.js
@@ -1,0 +1,111 @@
+/**
+ * External dependencies
+ */
+import { startCase } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { useSelect, useDispatch } from '@wordpress/data';
+import { useState, useCallback } from '@wordpress/element';
+import { Button, Modal, CheckboxControl } from '@wordpress/components';
+
+const EntitiesSavedStatesCheckbox = ( {
+	id,
+	name,
+	changes: { rawRecord, edits },
+	checked,
+	setCheckedById,
+} ) => (
+	<CheckboxControl
+		label={ `${ startCase( name ) }: "${ rawRecord.title || rawRecord.name }"` }
+		help={ `Changed Properties: ${ Object.keys( edits ).join( ', ' ) }.` }
+		checked={ checked }
+		onChange={ useCallback( ( nextChecked ) => setCheckedById( id, nextChecked ), [ id ] ) }
+	/>
+);
+
+export default function EntitiesSavedStates() {
+	const entityRecordChangesByRecord = useSelect( ( select ) =>
+		select( 'core' ).getEntityRecordChangesByRecord()
+	);
+	const { saveEditedEntityRecord } = useDispatch( 'core' );
+
+	const [ isOpen, setIsOpen ] = useState( false );
+	const [ checkedById, _setCheckedById ] = useState( {} );
+
+	const openModal = useCallback( setIsOpen.bind( null, true ), [] );
+	const closeModal = useCallback( setIsOpen.bind( null, false ), [] );
+	const setCheckedById = useCallback(
+		( id, checked ) =>
+			_setCheckedById( ( prevCheckedById ) => {
+				const nextCheckedById = {
+					...prevCheckedById,
+				};
+				if ( checked ) {
+					nextCheckedById[ id ] = true;
+				} else {
+					delete nextCheckedById[ id ];
+				}
+				return nextCheckedById;
+			} ),
+		[]
+	);
+	const saveCheckedEntities = useCallback( () => {
+		closeModal();
+		Object.keys( checkedById ).forEach( ( id ) =>
+			saveEditedEntityRecord( ...id.split( ' | ' ) )
+		);
+	}, [ checkedById ] );
+
+	const changedKinds = Object.keys( entityRecordChangesByRecord );
+	return (
+		changedKinds.length > 0 && (
+			<>
+				<Button isSmall onClick={ openModal }>
+					Save Global Changes
+				</Button>
+				{ isOpen && (
+					<Modal
+						title="What do you want to save?"
+						onRequestClose={ closeModal }
+						contentLabel="Select items to save."
+					>
+						{ changedKinds.map( ( changedKind ) =>
+							Object.keys( entityRecordChangesByRecord[ changedKind ] ).map(
+								( changedName ) =>
+									Object.keys(
+										entityRecordChangesByRecord[ changedKind ][ changedName ]
+									).map( ( changedKey ) => {
+										const id = `${ changedKind } | ${ changedName } | ${ changedKey }`;
+										return (
+											<EntitiesSavedStatesCheckbox
+												key={ id }
+												id={ id }
+												name={ changedName }
+												changes={
+													entityRecordChangesByRecord[ changedKind ][ changedName ][
+														changedKey
+													]
+												}
+												checked={ checkedById[ id ] }
+												setCheckedById={ setCheckedById }
+											/>
+										);
+									} )
+							)
+						) }
+						<Button
+							isPrimary
+							disabled={ Object.keys( checkedById ).length === 0 }
+							onClick={ saveCheckedEntities }
+							className="editor-entities-saved-states__save-button"
+						>
+							Save
+						</Button>
+					</Modal>
+				) }
+			</>
+		)
+	);
+}

--- a/packages/editor/src/components/entities-saved-states/style.scss
+++ b/packages/editor/src/components/entities-saved-states/style.scss
@@ -1,0 +1,5 @@
+.editor-entities-saved-states__save-button {
+	display: block;
+	margin-left: auto;
+	margin-right: 0;
+}

--- a/packages/editor/src/components/index.js
+++ b/packages/editor/src/components/index.js
@@ -13,6 +13,7 @@ export { default as TextEditorGlobalKeyboardShortcuts } from './global-keyboard-
 export { default as EditorHistoryRedo } from './editor-history/redo';
 export { default as EditorHistoryUndo } from './editor-history/undo';
 export { default as EditorNotices } from './editor-notices';
+export { default as EntitiesSavedStates } from './entities-saved-states';
 export { default as ErrorBoundary } from './error-boundary';
 export { default as LocalAutosaveMonitor } from './local-autosave-monitor';
 export { default as PageAttributesCheck } from './page-attributes/check';

--- a/packages/editor/src/components/post-publish-button/index.js
+++ b/packages/editor/src/components/post-publish-button/index.js
@@ -65,7 +65,7 @@ export class PostPublishButton extends Component {
 		const { postType, postId } = this.props;
 		const { entitiesSavedStatesCallback } = this.state;
 		this.setState( { entitiesSavedStatesCallback: false }, () => {
-			if ( savedById.has( [ 'postType', postType, String( postId ) ] ) ) {
+			if ( savedById && savedById.has( [ 'postType', postType, String( postId ) ] ) ) {
 				// The post entity was checked, call the held callback from `createOnClick`.
 				entitiesSavedStatesCallback();
 			}

--- a/packages/editor/src/components/post-publish-button/index.js
+++ b/packages/editor/src/components/post-publish-button/index.js
@@ -6,7 +6,7 @@ import { noop, get } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { Button } from '@wordpress/components';
+import { Button, Dashicon } from '@wordpress/components';
 import { Component, createRef } from '@wordpress/element';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
@@ -15,16 +15,48 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import EntitiesSavedStates from '../entities-saved-states';
 import PublishButtonLabel from './label';
+
 export class PostPublishButton extends Component {
 	constructor( props ) {
 		super( props );
 		this.buttonNode = createRef();
+
+		this.createOnClick = this.createOnClick.bind( this );
+		this.closeEntitiesSavedStates = this.closeEntitiesSavedStates.bind( this );
+
+		this.state = {
+			entitiesSavedStatesCallback: false,
+		};
 	}
 	componentDidMount() {
 		if ( this.props.focusOnMount ) {
 			this.buttonNode.current.focus();
 		}
+	}
+
+	createOnClick( callback ) {
+		return ( ...args ) => {
+			const { hasNonPostEntityChanges } = this.props;
+			if ( hasNonPostEntityChanges ) {
+				return this.setState( {
+					entitiesSavedStatesCallback: () => callback( ...args ),
+				} );
+			}
+
+			return callback( ...args );
+		};
+	}
+
+	closeEntitiesSavedStates( savedById ) {
+		const { postType, postId } = this.props;
+		const { entitiesSavedStatesCallback } = this.state;
+		this.setState( { entitiesSavedStatesCallback: false }, () => {
+			if ( savedById[ `postType | ${ postType } | ${ postId }` ] ) {
+				entitiesSavedStatesCallback();
+			}
+		} );
 	}
 
 	render() {
@@ -45,7 +77,12 @@ export class PostPublishButton extends Component {
 			onSubmit = noop,
 			onToggle,
 			visibility,
+			hasNonPostEntityChanges,
 		} = this.props;
+		const {
+			entitiesSavedStatesCallback,
+		} = this.state;
+
 		const isButtonDisabled =
 			isSaving ||
 			forceIsSaving ||
@@ -92,7 +129,7 @@ export class PostPublishButton extends Component {
 			className: 'editor-post-publish-button',
 			isBusy: isSaving && isPublished,
 			isPrimary: true,
-			onClick: onClickButton,
+			onClick: this.createOnClick( onClickButton ),
 		};
 
 		const toggleProps = {
@@ -101,7 +138,7 @@ export class PostPublishButton extends Component {
 			className: 'editor-post-publish-panel__toggle',
 			isBusy: isSaving && isPublished,
 			isPrimary: true,
-			onClick: onClickToggle,
+			onClick: this.createOnClick( onClickToggle ),
 		};
 
 		const toggleChildren = isBeingScheduled ? __( 'Schedule…' ) : __( 'Publish…' );
@@ -110,12 +147,21 @@ export class PostPublishButton extends Component {
 		const componentProps = isToggle ? toggleProps : buttonProps;
 		const componentChildren = isToggle ? toggleChildren : buttonChildren;
 		return (
-			<Button
-				ref={ this.buttonNode }
-				{ ...componentProps }
-			>
-				{ componentChildren }
-			</Button>
+			<>
+				<EntitiesSavedStates
+					isOpen={ Boolean( entitiesSavedStatesCallback ) }
+					onRequestClose={ this.closeEntitiesSavedStates }
+				/>
+				<Button ref={ this.buttonNode } { ...componentProps }>
+					{ hasNonPostEntityChanges && (
+						<Dashicon
+							icon="layout"
+							style={ { marginRight: '3px', marginLeft: '-5px' } }
+						/>
+					) }
+					{ componentChildren }
+				</Button>
+			</>
 		);
 	}
 }
@@ -132,6 +178,8 @@ export default compose( [
 			isPostSavingLocked,
 			getCurrentPost,
 			getCurrentPostType,
+			getCurrentPostId,
+			hasNonPostEntityChanges,
 		} = select( 'core/editor' );
 		return {
 			isSaving: isSavingPost(),
@@ -143,6 +191,8 @@ export default compose( [
 			isPublished: isCurrentPostPublished(),
 			hasPublishAction: get( getCurrentPost(), [ '_links', 'wp:action-publish' ], false ),
 			postType: getCurrentPostType(),
+			postId: getCurrentPostId(),
+			hasNonPostEntityChanges: hasNonPostEntityChanges(),
 		};
 	} ),
 	withDispatch( ( dispatch ) => {

--- a/packages/editor/src/components/post-publish-button/index.js
+++ b/packages/editor/src/components/post-publish-button/index.js
@@ -2,11 +2,12 @@
  * External dependencies
  */
 import { noop, get } from 'lodash';
+import classnames from 'classnames';
 
 /**
  * WordPress dependencies
  */
-import { Button, Dashicon } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { Component, createRef } from '@wordpress/element';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
@@ -152,13 +153,13 @@ export class PostPublishButton extends Component {
 					isOpen={ Boolean( entitiesSavedStatesCallback ) }
 					onRequestClose={ this.closeEntitiesSavedStates }
 				/>
-				<Button ref={ this.buttonNode } { ...componentProps }>
-					{ hasNonPostEntityChanges && (
-						<Dashicon
-							icon="layout"
-							style={ { marginRight: '3px', marginLeft: '-5px' } }
-						/>
-					) }
+				<Button
+					ref={ this.buttonNode }
+					{ ...componentProps }
+					className={ classnames( componentProps.className, {
+						'editor-post-publish-button__has-changes-dot': hasNonPostEntityChanges,
+					} ) }
+				>
 					{ componentChildren }
 				</Button>
 			</>

--- a/packages/editor/src/components/post-publish-button/index.js
+++ b/packages/editor/src/components/post-publish-button/index.js
@@ -146,7 +146,8 @@ export class PostPublishButton extends Component {
 		const buttonChildren = <PublishButtonLabel forceIsSaving={ forceIsSaving } />;
 
 		const componentProps = isToggle ? toggleProps : buttonProps;
-		const componentChildren = isToggle ? toggleChildren : buttonChildren;
+		const componentChildren =
+			isToggle || hasNonPostEntityChanges ? toggleChildren : buttonChildren;
 		return (
 			<>
 				<EntitiesSavedStates

--- a/packages/editor/src/components/post-publish-button/index.js
+++ b/packages/editor/src/components/post-publish-button/index.js
@@ -54,7 +54,7 @@ export class PostPublishButton extends Component {
 		const { postType, postId } = this.props;
 		const { entitiesSavedStatesCallback } = this.state;
 		this.setState( { entitiesSavedStatesCallback: false }, () => {
-			if ( savedById[ `postType | ${ postType } | ${ postId }` ] ) {
+			if ( savedById.has( [ 'postType', postType, String( postId ) ] ) ) {
 				entitiesSavedStatesCallback();
 			}
 		} );
@@ -161,9 +161,13 @@ export class PostPublishButton extends Component {
 				<Button
 					ref={ this.buttonNode }
 					{ ...componentProps }
-					className={ classnames( componentProps.className, {
-						'editor-post-publish-button__has-changes-dot': hasNonPostEntityChanges,
-					} ) }
+					className={ classnames(
+						componentProps.className,
+						'editor-post-publish-button__button',
+						{
+							'has-changes-dot': hasNonPostEntityChanges,
+						}
+					) }
 				>
 					{ componentChildren }
 				</Button>

--- a/packages/editor/src/components/post-publish-button/index.js
+++ b/packages/editor/src/components/post-publish-button/index.js
@@ -143,11 +143,15 @@ export class PostPublishButton extends Component {
 		};
 
 		const toggleChildren = isBeingScheduled ? __( 'Schedule…' ) : __( 'Publish…' );
-		const buttonChildren = <PublishButtonLabel forceIsSaving={ forceIsSaving } />;
+		const buttonChildren = (
+			<PublishButtonLabel
+				forceIsSaving={ forceIsSaving }
+				hasNonPostEntityChanges={ hasNonPostEntityChanges }
+			/>
+		);
 
 		const componentProps = isToggle ? toggleProps : buttonProps;
-		const componentChildren =
-			isToggle || hasNonPostEntityChanges ? toggleChildren : buttonChildren;
+		const componentChildren = isToggle ? toggleChildren : buttonChildren;
 		return (
 			<>
 				<EntitiesSavedStates

--- a/packages/editor/src/components/post-publish-button/index.js
+++ b/packages/editor/src/components/post-publish-button/index.js
@@ -140,7 +140,7 @@ export class PostPublishButton extends Component {
 		};
 
 		const buttonProps = {
-			'aria-disabled': isButtonDisabled,
+			'aria-disabled': isButtonDisabled && ! hasNonPostEntityChanges,
 			className: 'editor-post-publish-button',
 			isBusy: isSaving && isPublished,
 			isPrimary: true,
@@ -148,7 +148,7 @@ export class PostPublishButton extends Component {
 		};
 
 		const toggleProps = {
-			'aria-disabled': isToggleDisabled,
+			'aria-disabled': isToggleDisabled && ! hasNonPostEntityChanges,
 			'aria-expanded': isOpen,
 			className: 'editor-post-publish-panel__toggle',
 			isBusy: isSaving && isPublished,

--- a/packages/editor/src/components/post-publish-button/label.js
+++ b/packages/editor/src/components/post-publish-button/label.js
@@ -17,6 +17,7 @@ export function PublishButtonLabel( {
 	isPublishing,
 	hasPublishAction,
 	isAutosaving,
+	hasNonPostEntityChanges,
 } ) {
 	if ( isPublishing ) {
 		return __( 'Publishing…' );
@@ -27,14 +28,16 @@ export function PublishButtonLabel( {
 	}
 
 	if ( ! hasPublishAction ) {
-		return __( 'Submit for Review' );
+		return hasNonPostEntityChanges ?
+			__( 'Submit for Review…' ) :
+			__( 'Submit for Review' );
 	} else if ( isPublished ) {
-		return __( 'Update' );
+		return hasNonPostEntityChanges ? __( 'Update…' ) : __( 'Update' );
 	} else if ( isBeingScheduled ) {
-		return __( 'Schedule' );
+		return hasNonPostEntityChanges ? __( 'Schedule…' ) : __( 'Schedule' );
 	}
 
-	return __( 'Publish' );
+	return hasNonPostEntityChanges ? __( 'Publish…' ) : __( 'Publish' );
 }
 
 export default compose( [

--- a/packages/editor/src/components/post-publish-button/style.scss
+++ b/packages/editor/src/components/post-publish-button/style.scss
@@ -1,0 +1,8 @@
+.editor-post-publish-button__has-changes-dot::before {
+	background: $white;
+	border-radius: 4px;
+	content: "";
+	height: 8px;
+	margin: auto 5px auto -3px;
+	width: 8px;
+}

--- a/packages/editor/src/components/post-publish-button/style.scss
+++ b/packages/editor/src/components/post-publish-button/style.scss
@@ -1,5 +1,5 @@
-.editor-post-publish-button__has-changes-dot::before {
-	background: $white;
+.editor-post-publish-button__button.has-changes-dot::before {
+	background: currentcolor;
 	border-radius: 4px;
 	content: "";
 	height: 8px;

--- a/packages/editor/src/style.scss
+++ b/packages/editor/src/style.scss
@@ -10,6 +10,7 @@
 @import "./components/post-last-revision/style.scss";
 @import "./components/post-locked-modal/style.scss";
 @import "./components/post-permalink/style.scss";
+@import "./components/post-publish-button/style.scss";
 @import "./components/post-publish-panel/style.scss";
 @import "./components/post-saved-state/style.scss";
 @import "./components/post-taxonomies/style.scss";

--- a/packages/editor/src/style.scss
+++ b/packages/editor/src/style.scss
@@ -1,6 +1,7 @@
 @import "./components/autocompleters/style.scss";
 @import "./components/document-outline/style.scss";
 @import "./components/editor-notices/style.scss";
+@import "./components/entities-saved-states/style.scss";
 @import "./components/error-boundary/style.scss";
 @import "./components/page-attributes/style.scss";
 @import "./components/post-excerpt/style.scss";


### PR DESCRIPTION
Follows #17368

## Description

This PR explores what it could look like to save multiple entities at the same time using a modal with a list of checkboxes that let you select a set of entity changes to save.

## How has this been tested?

It was verified that:

- The new button appears only when there are pending changes to an entity and the full site editing experiment is enabled.
- Clicking the button opens a modal with a checkbox list of entities with pending changes and their changed properties.
- Selecting a set of entities and clicking the save button works as expected, only saving the selected entities.
- If there are no selected entities, the save button is disabled.

## Screenshots

<img width="846" alt="Screen Shot 2019-10-18 at 1 23 01 PM" src="https://user-images.githubusercontent.com/19157096/67125869-94852980-f1aa-11e9-97aa-880fc94039f9.png">

## Types of Changes

*New Feature:* The full site editing experiment now has a button for selecting and saving multiple entities at once.

## Checklist:

- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
