### PR TITLE
List Block: Do not merge list with previous block if deleting first list item and list is not empty

### DIFF
--- a/packages/e2e-tests/specs/editor/blocks/__snapshots__/list.test.js.snap
+++ b/packages/e2e-tests/specs/editor/blocks/__snapshots__/list.test.js.snap
@@ -80,6 +80,12 @@ exports[`List can undo asterisk transform 1`] = `
 <!-- /wp:paragraph -->"
 `;
 
+exports[`List first empty list item is graciously removed 1`] = `
+"<!-- wp:list -->
+<ul><li>2</li></ul>
+<!-- /wp:list -->"
+`;
+
 exports[`List should be immeadiately saved on indentation 1`] = `
 "<!-- wp:list -->
 <ul><li>one<ul><li></li></ul></li></ul>

--- a/packages/e2e-tests/specs/editor/blocks/list.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/list.test.js
@@ -478,4 +478,16 @@ describe( 'List', () => {
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
+
+	it( 'first empty list item is graciously removed', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( '* 1' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '2' );
+		await page.keyboard.press( 'ArrowUp' );
+		await page.keyboard.press( 'Backspace' );
+		await page.keyboard.press( 'Backspace' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
 } );

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -606,6 +606,15 @@ class RichText extends Component {
 
 		if ( multilineTag ) {
 			const newValue = removeLineSeparator( value, isReverse );
+
+			//check to see if we should remove the first item of a list
+			if ( isReverse && ! newValue && value.start === 0 && value.end === 0 && value.text.length > 0 ) {
+				const simulateDelete = removeLineSeparator( value, ! isReverse );
+				this.onChange( simulateDelete );
+				event.preventDefault();
+				return;
+			}
+
 			if ( newValue ) {
 				this.onChange( newValue );
 				event.preventDefault();

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -35,6 +35,7 @@ import { indentListItems } from '../indent-list-items';
 import { getActiveFormats } from '../get-active-formats';
 import { updateFormats } from '../update-formats';
 import { removeLineSeparator } from '../remove-line-separator';
+import { isEmptyLine } from '../is-empty';
 
 /**
  * Browser dependencies
@@ -605,27 +606,27 @@ class RichText extends Component {
 		const isReverse = keyCode === BACKSPACE;
 
 		if ( multilineTag ) {
-			const newValue = removeLineSeparator( value, isReverse );
-
-			//check to see if we should remove the first item of a list
-			if ( isReverse && ! newValue && value.start === 0 && value.end === 0 && value.text.length > 0 ) {
-				const simulateDelete = removeLineSeparator( value, ! isReverse );
-				this.onChange( simulateDelete );
+			// Always handle full content deletion ourselves.
+			if ( start === 0 && end !== 0 && end === text.length ) {
+				this.onChange( remove( value ) );
 				event.preventDefault();
 				return;
+			}
+
+			let newValue;
+
+			// Check to see if we should remove the first item of a list
+			if ( isReverse && value.start === 0 && value.end === 0 && isEmptyLine( value ) ) {
+				newValue = removeLineSeparator( value, ! isReverse );
+			} else {
+				newValue = removeLineSeparator( value, isReverse );
 			}
 
 			if ( newValue ) {
 				this.onChange( newValue );
 				event.preventDefault();
+				return;
 			}
-		}
-
-		// Always handle full content deletion ourselves.
-		if ( start === 0 && end !== 0 && end === text.length ) {
-			this.onChange( remove( value ) );
-			event.preventDefault();
-			return;
 		}
 
 		// Only process delete if the key press occurs at an uncollapsed edge.

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -605,14 +605,14 @@ class RichText extends Component {
 		const { start, end, text } = value;
 		const isReverse = keyCode === BACKSPACE;
 
-		if ( multilineTag ) {
-			// Always handle full content deletion ourselves.
-			if ( start === 0 && end !== 0 && end === text.length ) {
-				this.onChange( remove( value ) );
-				event.preventDefault();
-				return;
-			}
+		// Always handle full content deletion ourselves.
+		if ( start === 0 && end !== 0 && end === text.length ) {
+			this.onChange( remove( value ) );
+			event.preventDefault();
+			return;
+		}
 
+		if ( multilineTag ) {
 			let newValue;
 
 			// Check to see if we should remove the first item of a list

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -615,7 +615,7 @@ class RichText extends Component {
 		if ( multilineTag ) {
 			let newValue;
 
-			// Check to see if we should remove the first item of a list
+			// Check to see if we should remove the first item if empty.
 			if ( isReverse && value.start === 0 && value.end === 0 && isEmptyLine( value ) ) {
 				newValue = removeLineSeparator( value, ! isReverse );
 			} else {


### PR DESCRIPTION
This enhancement should fix https://github.com/WordPress/gutenberg/issues/8803 and https://github.com/WordPress/gutenberg/issues/8804 by avoiding an unnecessary block merge when we detect this case and simulates a <kbd>del</kbd> to remove the top list item.


| Before  | After |
| ------------- | ------------- |
| ![before collapse](https://user-images.githubusercontent.com/1270189/67134277-4bdb6980-f1c6-11e9-904d-65cc85e1c7c3.gif) | ![first item delete](https://user-images.githubusercontent.com/1270189/67134037-ab387a00-f1c4-11e9-96f9-ada55917b9c7.gif) |


| Before  | After |
| ------------- | ------------- |
| ![stuck](https://user-images.githubusercontent.com/1270189/67134313-804f2580-f1c6-11e9-9a1e-cdf9a246e967.gif) | ![no paragraph](https://user-images.githubusercontent.com/1270189/67134079-fbafd780-f1c4-11e9-813c-b516cdb7de8f.gif) |

### Open Discussion Items
- Does the proposed behavior look okay here? I suspect we may want to update the cursor position to the end of the new list item? Or a new text paragraph in the place of the line item? I'm happy to modify.
- Is there a better place to make this modification? I traced changes down to the rich-text editor, but I'm a little wary of making a list block modification this deep.

### Testing Instructions
- Checkout this branch
- Create a new post
- Add a paragraph
- Then create a list with multiple items
- Delete the first item
- Verify that the list does not collapse into multiple paragraphs
- Create a new post
- Add a list with multiple items
- Delete the first item
- Verify that the first bullet is removed, instead of not being deletable. 
