### PR TITLE
Fix: Custom button background color not reflected on reload

### DIFF
--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -142,7 +142,7 @@ function ButtonEdit( {
 				style={ {
 					...( customGradient ?
 						{ background: customGradient } :
-						( { backgroundColor: backgroundColor.color } )
+						{ backgroundColor: backgroundColor.color }
 					),
 					color: textColor.color,
 					borderRadius: borderRadius ? borderRadius + 'px' : undefined,

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -140,8 +140,10 @@ function ButtonEdit( {
 					}
 				) }
 				style={ {
-					backgroundColor: ! customGradient && backgroundColor.color,
-					background: customGradient,
+					...( customGradient ?
+						{ background: customGradient } :
+						( { backgroundColor: backgroundColor.color } )
+					),
 					color: textColor.color,
 					borderRadius: borderRadius ? borderRadius + 'px' : undefined,
 				} }


### PR DESCRIPTION
## Description
Fixes: https://github.com/WordPress/gutenberg/issues/18012

We had a bug where the editor may not reflect the custom button background color after a reload. That happened because the rule background: customGradient, may overwrite the background-color rule even if the custom gradient has not set.
This PR performs a logic update to solve the issue.

cc: @talldan 

## How has this been tested?
- Added a button block to a page or post
- Used custom color for the button, e.g., a red
- Published and reload the browser window
- Verify the color of the button is still red and not the default one.


Props to @jerrysarcastic for reporting this issue.