### PR TITLE
Fix MediaUpload README value prop description

### DIFF
--- a/packages/block-editor/src/components/media-upload/README.md
+++ b/packages/block-editor/src/components/media-upload/README.md
@@ -38,7 +38,7 @@ function MyMediaUploader() {
 			<MediaUpload
 				onSelect={ ( media ) => console.log( 'selected ' + media.length ) }
 				allowedTypes={ ALLOWED_MEDIA_TYPES }
-				value={ media }
+				value={ mediaId }
 				render={ ( { open } ) => (
 					<Button onClick={ open }>
 						Open Media Library
@@ -76,9 +76,9 @@ Whether to allow multiple selections or not.
 
 ### value
 
-An object or an array of objects that contain media ID (`id` property) to be selected by default when opening the media library.
+Media ID (or media IDs if multiple is true) to be selected by default when opening the media library.
 
-- Type: `Object|Array`
+- Type: `Number|Array`
 - Required: No
 - Platform: Web
 


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
I've updated the MediaUpload README to revert the description of the value prop. This fixes an issue [described here](https://github.com/WordPress/gutenberg/pull/17980#issuecomment-544307492).
## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
[Viewed the document](https://github.com/WordPress/gutenberg/tree/fix/media-upload-readme-value-prop/packages/block-editor/src/components/media-upload).
