### PR TITLE
Add URL Details endpoint to REST API to allow retrieval of info about a remote URL

### DIFF
--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -270,15 +270,17 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 			return;
 		}
 
+		$ttl = HOUR_IN_SECONDS;
+
 		/**
 		 * Filters the cache expiration.
 		 *
 		 * Can be used to adjust the time until expiration in seconds for the cache
 		 * of the data retrieved for the given URL.
 		 *
-		 * @param int HOUR_IN_SECONDS the time until cache expiration in seconds.
+		 * @param int $ttl the time until cache expiration in seconds.
 		 */
-		$cache_expiration = apply_filters( 'rest_url_details_cache_expiration', HOUR_IN_SECONDS );
+		$cache_expiration = apply_filters( 'rest_url_details_cache_expiration', $ttl );
 
 		return set_transient( $key, wp_json_encode( $data ), $cache_expiration );
 	}

--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -103,7 +103,7 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 		$cached_response = $this->get_cache( $cache_key );
 
 		if ( ! empty( $cached_response ) ) {
-			$remote_url_response = json_decode( $cached_response, true );
+			$remote_url_response = $cached_response;
 		} else {
 			$remote_url_response = $this->get_remote_url( $url );
 
@@ -239,10 +239,10 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 	 * Utility function to cache a given data set at a given cache key.
 	 *
 	 * @param string $key the cache key under which to store the value.
-	 * @param array  $data the data to be stored at the given cache key.
+	 * @param string $data the data to be stored at the given cache key.
 	 * @return void
 	 */
-	private function set_cache( $key, $data = array() ) {
+	private function set_cache( $key, $data = '' ) {
 		if ( ! is_array( $data ) ) {
 			return;
 		}
@@ -259,6 +259,6 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 		 */
 		$cache_expiration = apply_filters( 'rest_url_details_cache_expiration', $ttl );
 
-		return set_transient( $key, wp_json_encode( $data ), $cache_expiration );
+		return set_transient( $key, $data, $cache_expiration );
 	}
 }

--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -56,8 +56,8 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 	 * response.
 	 *
 	 * @access public
-	 * @param  WP_REST_REQUEST $request Full details about the request.
-	 * @return String|WP_Error          the title text or an error.
+	 * @param WP_REST_REQUEST $request Full details about the request.
+	 * @return String|WP_Error The title text or an error.
 	 */
 	public function get_title( $request ) {
 		$url   = $request->get_param( 'url' );
@@ -87,9 +87,9 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Retrieves the document title from a remote URL
+	 * Retrieves the document title from a remote URL.
 	 *
-	 * @param  String $url the website url whose HTML we want to access.
+	 * @param string $url The website url whose HTML we want to access.
 	 * @return string|WP_Error The URL's document title on success, WP_Error on failure.
 	 */
 	private function get_remote_url_title( $url ) {
@@ -97,12 +97,11 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 		$cache_key = 'g_url_details_response_' . hash( 'crc32b', $url );
 
 		// Attempt to retrieve cached response.
-		$title = null;//get_transient( $cache_key );
+		$title = get_transient( $cache_key );
 
 		if ( empty( $title ) ) {
 			$request                = wp_safe_remote_get( $url, array(
 				'timeout'             => 10,
-			//	'redirection'         => 0,
 				'limit_response_size' => 153600, // 150 KB
 			) );
 			$remote_source = wp_remote_retrieve_body( $request );

--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -17,8 +17,6 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 
 	/**
 	 * Constructs the controller.
-	 *
-	 * @access public
 	 */
 	public function __construct() {
 		$this->namespace = '__experimental';
@@ -27,8 +25,6 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 
 	/**
 	 * Registers the necessary REST API routes.
-	 *
-	 * @access public
 	 */
 	public function register_routes() {
 		register_rest_route(
@@ -80,7 +76,6 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 	 * Retrieves the contents of the <title> tag from the HTML
 	 * response.
 	 *
-	 * @access public
 	 * @param WP_REST_REQUEST $request Full details about the request.
 	 * @return String|WP_Error The title text or an error.
 	 */

--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -105,13 +105,7 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 		if ( ! empty( $cached_response ) ) {
 			$response = rest_ensure_response( json_decode( $cached_response, true ) );
 
-			/**
-			 * Filters the URL data for the response.
-			 *
-			 * @param WP_REST_Response $response The response object.
-			 * @param string           $url      The requested URL.
-			 * @param WP_REST_Request  $request  Request object.
-			 */
+			/** This filter is documented in lib/class-wp-rest-url-details-controller.php#147 */
 			return apply_filters( 'rest_prepare_url_details', $response, $url, $request );
 		}
 

--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -77,7 +77,7 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 		$data = $this->get_cache( $cache_key );
 
 		// Return cache if valid data.
-		if ( ! is_wp_error( $data ) && ! empty( $data ) ) {
+		if ( false && ! is_wp_error( $data ) && ! empty( $data ) ) {
 			return json_decode( $data, true );
 		}
 

--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -72,7 +72,7 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 		}
 
 		// Transient per URL.
-		$cache_key = 'g_url_details_response_' . hash( 'crc32b', $url );
+		$cache_key = 'g_url_details_response_' . md5( $url );
 
 		// Attempt to retrieve cached response.
 		$data = get_transient( $cache_key );

--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ *
+ *
+ * @package gutenberg
+ * @since 5.?.0
+ */
+
+/**
+ * Controller which provides REST endpoint for the widget areas.
+ *
+ * @since 5.?.0
+ *
+ * @see WP_REST_Controller
+ */
+class WP_REST_URL_Details_Controller extends WP_REST_Controller {
+
+	/**
+	 * Constructs the controller.
+	 *
+	 * @access public
+	 */
+	public function __construct() {
+		$this->namespace = '__experimental';
+		$this->rest_base = 'url-details';
+	}
+
+	/**
+	 * Registers the necessary REST API routes.
+	 *
+	 * @access public
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_remote_url' ),
+					// 'permission_callback' => array( $this, 'get_remote_url_permissions_check' ),
+				),
+				// 'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+
+	}
+
+	/**
+	 * Retrieves the comment's schema, conforming to JSON Schema.
+	 *
+	 * @since 6.1.0
+	 *
+	 * @return array
+	 */
+	public function get_item_schema() {
+		$schema = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'widget-area',
+			'type'       => 'object',
+			'properties' => array(
+				'id'      => array(
+					'description' => __( 'Unique identifier for the object.', 'gutenberg' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit', 'embed' ),
+					'readonly'    => true,
+				),
+				'content' => array(
+					'description' => __( 'The content for the object.', 'gutenberg' ),
+					'type'        => 'object',
+					'context'     => array( 'view', 'edit', 'embed' ),
+					'arg_options' => array(
+						'sanitize_callback' => null,
+						'validate_callback' => null,
+					),
+					'properties'  => array(
+						'raw'           => array(
+							'description' => __( 'Content for the object, as it exists in the database.', 'gutenberg' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit', 'embed' ),
+						),
+						'rendered'      => array(
+							'description' => __( 'HTML content for the object, transformed for display.', 'gutenberg' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit', 'embed' ),
+							'readonly'    => true,
+						),
+						'block_version' => array(
+							'description' => __( 'Version of the content block format used by the object.', 'gutenberg' ),
+							'type'        => 'integer',
+							'context'     => array( 'view', 'edit', 'embed' ),
+							'readonly'    => true,
+						),
+					),
+				),
+			),
+		);
+
+		return $schema;
+	}
+
+	/**
+	 * Checks whether a given request has permission to read widget areas.
+	 *
+	 * @since 5.7.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|bool True if the request has read access, WP_Error object otherwise.
+	 *
+	 * This function is overloading a function defined in WP_REST_Controller so it should have the same parameters.
+	 * phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+	 */
+	public function get_items_permissions_check( $request ) {
+		if ( ! current_user_can( 'edit_theme_options' ) ) {
+			return new WP_Error(
+				'rest_user_cannot_view',
+				__( 'Sorry, you are not allowed to read sidebars.', 'gutenberg' )
+			);
+		}
+
+		return true;
+	}
+	/* phpcs:enable */
+
+	/**
+	 * Retrieves all widget areas.
+	 *
+	 * @since 5.7.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|WP_REST_Response Response object on success, or WP_Error object on failure.
+	 */
+	public function get_remote_url( $request ) {
+
+		$data = [ 'hello-world' ];
+
+		return rest_ensure_response( $data );
+	}
+}

--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -103,22 +103,17 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 		$cached_response = $this->get_cache( $cache_key );
 
 		if ( ! empty( $cached_response ) ) {
-			$from_cache = true;
-			$response   = rest_ensure_response( json_decode( $cached_response, true ) );
+			$response = rest_ensure_response( json_decode( $cached_response, true ) );
 
 			/**
 			 * Filters the URL data for the response.
 			 *
 			 * @param WP_REST_Response $response The response object.
 			 * @param string           $url      The requested URL.
-			 * @param bool             $from_cache Whether the response is from the cache.
 			 * @param WP_REST_Request  $request  Request object.
 			 */
-			return apply_filters( 'rest_url_details_prepare_response', $response, $url, $from_cache, $request );
+			return apply_filters( 'rest_url_details_prepare_response', $response, $url, $request );
 		}
-
-		// If we're this far the response is not from the cache.
-		$from_cache = false;
 
 		$response_body = $this->get_remote_url( $url );
 
@@ -160,10 +155,9 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 		 *
 		 * @param WP_REST_Response $response The response object.
 		 * @param string           $url      The requested URL.
-		 * @param bool             $from_cache Whether the response is from the cache.
 		 * @param WP_REST_Request  $request  Request object.
 		 */
-		return apply_filters( 'rest_url_details_prepare_response', $response, $url, $from_cache, $request );
+		return apply_filters( 'rest_url_details_prepare_response', $response, $url, $request );
 	}
 
 	/**

--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -182,7 +182,7 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 
 		if ( WP_Http::OK !== wp_remote_retrieve_response_code( $response ) ) {
 			// Not saving the error response to cache since the error might be temporary.
-			return new WP_Error( 'no_response', get_status_header_desc( 404 ), array( 'status' => WP_Http::NOT_FOUND ) );
+			return new WP_Error( 'no_response', __( 'URL not found. Response returned a non-200 status code for this URL.', 'gutenberg' ), array( 'status' => WP_Http::NOT_FOUND ) );
 		}
 
 		$remote_body = wp_remote_retrieve_body( $response );

--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -49,15 +49,20 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 						),
 					),
 					'permission_callback' => array( $this, 'permissions_check' ),
-					'schema'              => array( $this, 'get_schema' ),
+					'schema'              => array( $this, 'get_public_item_schema' ),
 				),
 			)
 		);
 	}
 
-	public function get_schema() {
+	/**
+	 * Get the schema for the endpoint.
+	 *
+	 * @return array the schema.
+	 */
+	public function get_item_schema() {
 		return array(
-			'$schema'    => 'http://json-schema.org/draft-07/schema#',
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
 			'title'      => 'url-details',
 			'type'       => 'object',
 			'properties' => array(
@@ -93,7 +98,7 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 		// Attempt to retrieve cached response.
 		$data = $this->get_cache( $cache_key );
 
-		// Return cache if valid data.
+		$use_cache = true;
 
 		/**
 		 * Filters whether to check for previously cached
@@ -104,7 +109,7 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 		 * @param string $url the attempted URL.
 		 * @param string $cache_key the generated cache key for the given URL.
 		 */
-		if ( apply_filters( 'rest_url_details_use_cache', $use_cache = true, $url, $cache_key ) && ! is_wp_error( $data ) && ! empty( $data ) ) {
+		if ( apply_filters( 'rest_url_details_use_cache', $use_cache, $url, $cache_key ) && ! is_wp_error( $data ) && ! empty( $data ) ) {
 			return json_decode( $data, true );
 		}
 

--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -228,6 +228,17 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 		if ( ! is_array( $data ) ) {
 			return;
 		}
-		return set_transient( $key, wp_json_encode( $data ), HOUR_IN_SECONDS );
+
+		/**
+		 * Filters the cache expiration.
+		 *
+		 * Can be used to adjust the time until expiration in seconds for the cache
+		 * of the data retrieved for the given URL.
+		 *
+		 * @param int HOUR_IN_SECONDS the time until cache expiration in seconds.
+		 */
+		$cache_expiration = apply_filters( 'rest_url_details_cache_expiration', HOUR_IN_SECONDS );
+
+		return set_transient( $key, wp_json_encode( $data ), $cache_expiration );
 	}
 }

--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -77,7 +77,17 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 		$data = $this->get_cache( $cache_key );
 
 		// Return cache if valid data.
-		if ( apply_filters( 'rest_url_details_use_cache', true ) && ! is_wp_error( $data ) && ! empty( $data ) ) {
+
+		/**
+		 * Filters whether to check for previously cached
+		 * data for a given URL. Filtering for `false` will
+		 * mean that the cache is bypassed.
+		 *
+		 * @param bool $use_cache whether or not to use the cache
+		 * @param string $url the attempted URL.
+		 * @param string $cache_key the generated cache key for the given URL.
+		 */
+		if ( apply_filters( 'rest_url_details_use_cache', $use_cache = true, $url, $cache_key ) && ! is_wp_error( $data ) && ! empty( $data ) ) {
 			return json_decode( $data, true );
 		}
 

--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -109,8 +109,24 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 			return $response_body;
 		}
 
-		$data = array(
-			'title' => $this->get_title( $response_body ),
+		/**
+		 * Filters the data returned for a given URL.
+		 *
+		 * Can be used to modify the data retrieved for a given URL.
+		 * For example, you may wish to retrieve additional information
+		 * from the response body at a given URL over and above the `<title>`.
+		 *
+		 * @param array $data The default data retrieved for the given URL.
+		 * @param array $response_body The response body (HTML) for the given URL.
+		 * @param string $url The attempted URL.
+		 */
+		$data = apply_filters(
+			'rest_url_details_url_data',
+			array(
+				'title' => $this->get_title( $response_body ),
+			),
+			$response_body,
+			$url
 		);
 
 		// Cache the valid response.

--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -129,12 +129,24 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 	 */
 	private function get_remote_url( $url ) {
 
+		$args = array(
+			'timeout'             => 10,
+			'limit_response_size' => 153600, // 150 KB.
+		);
+
+		/**
+		 * Filters the HTTP request args for URL data retrieval.
+		 *
+		 * Can be used to adjust timeout and response size limit.
+		 *
+		 * @param array $args Arguments used for the HTTP request
+		 * @param string $url The attempted URL.
+		 */
+		$args = apply_filters( 'rest_url_details_http_request_args', $args, $url );
+
 		$response = wp_safe_remote_get(
 			$url,
-			array(
-				'timeout'             => 10,
-				'limit_response_size' => 153600, // 150 KB.
-			)
+			$args
 		);
 
 		if ( WP_Http::OK !== wp_remote_retrieve_response_code( $response ) ) {

--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -177,7 +177,7 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 		}
 
 		return new WP_Error(
-			'rest_user_cannot_view',
+			'rest_cannot_view_url_details',
 			__( 'Sorry, you are not allowed to process remote urls.', 'gutenberg' ),
 			array( 'status' => rest_authorization_required_code() )
 		);

--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -67,8 +67,9 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 			'type'       => 'object',
 			'properties' => array(
 				'title' => array(
-					'description' => esc_html__( 'The contents of the <title> tag from the URL.', 'gutenberg' ),
+					'description' => __( 'The contents of the <title> tag from the URL.', 'gutenberg' ),
 					'type'        => 'string',
+					'default'     => '',
 					'context'     => array( 'view', 'edit', 'embed' ),
 					'readonly'    => true,
 				),

--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -57,7 +57,12 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 	 * @return array the schema.
 	 */
 	public function get_item_schema() {
-		return array(
+
+		if ( $this->schema ) {
+			return $this->add_additional_fields_schema( $this->schema );
+		}
+
+		$schema = array(
 			'$schema'    => 'http://json-schema.org/draft-04/schema#',
 			'title'      => 'url-details',
 			'type'       => 'object',
@@ -70,6 +75,10 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 				),
 			),
 		);
+
+		$this->schema = $schema;
+
+		return $this->add_additional_fields_schema( $this->schema );
 	}
 
 	/**

--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -152,7 +152,6 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 	private function get_remote_url( $url ) {
 
 		$args = array(
-			'timeout'             => 10,
 			'limit_response_size' => 153600, // 150 KB.
 		);
 

--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -112,7 +112,7 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 			 * @param string           $url      The requested URL.
 			 * @param WP_REST_Request  $request  Request object.
 			 */
-			return apply_filters( 'rest_url_details_prepare_response', $response, $url, $request );
+			return apply_filters( 'rest_prepare_url_details', $response, $url, $request );
 		}
 
 		$response_body = $this->get_remote_url( $url );
@@ -157,7 +157,7 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 		 * @param string           $url      The requested URL.
 		 * @param WP_REST_Request  $request  Request object.
 		 */
-		return apply_filters( 'rest_url_details_prepare_response', $response, $url, $request );
+		return apply_filters( 'rest_prepare_url_details', $response, $url, $request );
 	}
 
 	/**

--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -1,9 +1,8 @@
 <?php
 /**
+ * REST API: WP_REST_URL_Details_Controller class
  *
- *
- * @package gutenberg
- * @since 5.?.0
+ * @package Gutenberg
  */
 
 /**
@@ -189,7 +188,7 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 	/**
 	 * Utility function to cache a given data set at a given cache key.
 	 *
-	 * @param string $key the cache key under which to store the value
+	 * @param string $key the cache key under which to store the value.
 	 * @param array  $data the data to be stored at the given cache key.
 	 * @return void
 	 */

--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -139,7 +139,7 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 
 		if ( WP_Http::OK !== wp_remote_retrieve_response_code( $response ) ) {
 			// Not saving the error response to cache since the error might be temporary.
-			return new WP_Error( 'rest_invalid_url', get_status_header_desc( 404 ), array( 'status' => 404 ) );
+			return new WP_Error( 'no_response', get_status_header_desc( 404 ), array( 'status' => 404 ) );
 		}
 
 		$remote_body = wp_remote_retrieve_body( $response );

--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -72,10 +72,10 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 		}
 
 		// Transient per URL.
-		$cache_key = 'g_url_details_response_' . md5( $url );
+		$cache_key = $this->build_cache_key_for_url( $url );
 
 		// Attempt to retrieve cached response.
-		$data = get_transient( $cache_key );
+		$data = $this->get_cache( $cache_key );
 
 		// Return cache if valid data.
 		if ( ! is_wp_error( $data ) && ! empty( $data ) ) {
@@ -93,8 +93,8 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 			'title' => $this->get_title( $response_body ),
 		);
 
-		// Only cache valid responses.
-		set_transient( $cache_key, wp_json_encode( $data ), HOUR_IN_SECONDS );
+		// Cache the valid response.
+		$this->set_cache( $cache_key, $data );
 
 		return rest_ensure_response( $data );
 	}
@@ -164,5 +164,39 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 		$title = isset( $match_title[1] ) ? trim( $match_title[1] ) : '';
 
 		return $title;
+	}
+
+	/**
+	 * Utility function to build cache key for a given URL.
+	 *
+	 * @param string $url the URL for which to build a cache key.
+	 * @return string the cache key.
+	 */
+	private function build_cache_key_for_url( $url ) {
+		return 'g_url_details_response_' . md5( $url );
+	}
+
+	/**
+	 * Utility function to retrieve a value from the cache at a given key.
+	 *
+	 * @param string $key the cache key.
+	 * @return string the value from the cache.
+	 */
+	private function get_cache( $key ) {
+		return get_transient( $key );
+	}
+
+	/**
+	 * Utility function to cache a given data set at a given cache key.
+	 *
+	 * @param string $key the cache key under which to store the value
+	 * @param array  $data the data to be stored at the given cache key.
+	 * @return void
+	 */
+	private function set_cache( $key, $data = array() ) {
+		if ( ! is_array( $data ) ) {
+			return;
+		}
+		return set_transient( $key, wp_json_encode( $data ), HOUR_IN_SECONDS );
 	}
 }

--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -49,8 +49,25 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 						),
 					),
 					'permission_callback' => array( $this, 'permissions_check' ),
+					'schema'              => array( $this, 'get_schema' ),
 				),
 			)
+		);
+	}
+
+	public function get_schema() {
+		return array(
+			'$schema'    => 'http://json-schema.org/draft-07/schema#',
+			'title'      => 'url-details',
+			'type'       => 'object',
+			'properties' => array(
+				'title' => array(
+					'description' => esc_html__( 'The contents of the <title> tag from the URL.', 'gutenberg' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit', 'embed' ),
+					'readonly'    => true,
+				),
+			),
 		);
 	}
 

--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -103,8 +103,22 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 		$cached_response = $this->get_cache( $cache_key );
 
 		if ( ! empty( $cached_response ) ) {
-			return rest_ensure_response( json_decode( $cached_response, true ) );
+			$from_cache = true;
+			$response = rest_ensure_response( json_decode( $cached_response, true ) );
+
+			/**
+			 * Filters the URL data for the response.
+			 *
+			 * @param WP_REST_Response $response The response object.
+			 * @param string           $url      The requested URL.
+			 * @param WP_REST_Request  $request  Request object.
+			 * @param bool             $from_cache Whether the response is from the cache.
+			 */
+			return apply_filters( 'rest_url_details_prepare_response', $response, $url, $request, $from_cache );
 		}
+
+		// If we're this far the response is not from the cache.
+		$from_cache = false;
 
 		$response_body = $this->get_remote_url( $url );
 
@@ -141,7 +155,15 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 		// Wrap the data in a response object.
 		$response = rest_ensure_response( $data );
 
-		return $response;
+		/**
+		 * Filters the URL data for the response.
+		 *
+		 * @param WP_REST_Response $response The response object.
+		 * @param string           $url      The requested URL.
+		 * @param WP_REST_Request  $request  Request object.
+		 * @param bool             $from_cache Whether the response is from the cache.
+		 */
+		return apply_filters( 'rest_url_details_prepare_response', $response, $url, $request, $from_cache );
 	}
 
 	/**

--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -99,18 +99,7 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 		// Attempt to retrieve cached response.
 		$data = $this->get_cache( $cache_key );
 
-		$use_cache = true;
-
-		/**
-		 * Filters whether to check for previously cached
-		 * data for a given URL. Filtering for `false` will
-		 * mean that the cache is bypassed.
-		 *
-		 * @param bool $use_cache whether or not to use the cache
-		 * @param string $url the attempted URL.
-		 * @param string $cache_key the generated cache key for the given URL.
-		 */
-		if ( apply_filters( 'rest_url_details_use_cache', $use_cache, $url, $cache_key ) && ! is_wp_error( $data ) && ! empty( $data ) ) {
+		if ( ! empty( $data ) ) {
 			return json_decode( $data, true );
 		}
 

--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -69,13 +69,9 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 	/**
 	 * Checks whether a given request has permission to read remote urls.
 	 *
-	 * phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-	 *
-	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_Error|bool True if the request has access, WP_Error object otherwise.
 	 */
-	public function get_remote_url_permissions_check( $request ) {
-		/* phpcs:enable */
+	public function get_remote_url_permissions_check() {
 		if ( ! current_user_can( 'edit_posts' ) ) {
 			return new WP_Error(
 				'rest_user_cannot_view',
@@ -102,7 +98,7 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 		if ( empty( $title ) ) {
 			$request                = wp_safe_remote_get( $url, array(
 				'timeout'             => 10,
-				'limit_response_size' => 153600, // 150 KB
+				'limit_response_size' => 153600, // 150 KB.
 			) );
 			$remote_source = wp_remote_retrieve_body( $request );
 
@@ -110,13 +106,9 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 				return new WP_Error( 'no_response', __( 'The source URL does not exist.', 'gutenberg' ), array( 'status' => 404 ) );
 			}
 
-			// Work around bug in strip_tags():
-			$remote_source = str_replace( '<!DOC', '<DOC', $remote_source );
-			$remote_source = preg_replace( '/[\r\n\t ]+/', ' ', $remote_source ); // Normalize spaces.
-			$remote_source = preg_replace( '/<\/*(h1|h2|h3|h4|h5|h6|p|th|td|li|dt|dd|pre|caption|input|textarea|button|body)[^>]*>/', "\n\n", $remote_source );
-
 			preg_match( '|<title>([^<]*?)</title>|is', $remote_source, $match_title );
-			$title = isset( $match_title[1] ) ? $match_title[1] : '';
+			$title = isset( $match_title[1] ) ? trim( $match_title[1] ) : '';
+
 			if ( empty( $title ) ) {
 				return new WP_Error( 'no_title', __( 'No document title at remote url.', 'gutenberg' ), array( 'status' => 404 ) );
 			}

--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -151,13 +151,13 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 	private function get_remote_url( $url ) {
 
 		$args = array(
-			'limit_response_size' => 153600, // 150 KB.
+			'limit_response_size' => 150 * KB_IN_BYTES,
 		);
 
 		/**
 		 * Filters the HTTP request args for URL data retrieval.
 		 *
-		 * Can be used to adjust timeout and response size limit.
+		 * Can be used to adjust response size limit and other WP_Http::request args.
 		 *
 		 * @param array $args Arguments used for the HTTP request
 		 * @param string $url The attempted URL.

--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -111,10 +111,10 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 			 *
 			 * @param WP_REST_Response $response The response object.
 			 * @param string           $url      The requested URL.
-			 * @param WP_REST_Request  $request  Request object.
 			 * @param bool             $from_cache Whether the response is from the cache.
+			 * @param WP_REST_Request  $request  Request object.
 			 */
-			return apply_filters( 'rest_url_details_prepare_response', $response, $url, $request, $from_cache );
+			return apply_filters( 'rest_url_details_prepare_response', $response, $url, $from_cache, $request );
 		}
 
 		// If we're this far the response is not from the cache.
@@ -160,10 +160,10 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 		 *
 		 * @param WP_REST_Response $response The response object.
 		 * @param string           $url      The requested URL.
-		 * @param WP_REST_Request  $request  Request object.
 		 * @param bool             $from_cache Whether the response is from the cache.
+		 * @param WP_REST_Request  $request  Request object.
 		 */
-		return apply_filters( 'rest_url_details_prepare_response', $response, $url, $request, $from_cache );
+		return apply_filters( 'rest_url_details_prepare_response', $response, $url, $from_cache, $request );
 	}
 
 	/**

--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -139,13 +139,13 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 
 		if ( WP_Http::OK !== wp_remote_retrieve_response_code( $response ) ) {
 			// Not saving the error response to cache since the error might be temporary.
-			return new WP_Error( 'no_response', get_status_header_desc( 404 ), array( 'status' => 404 ) );
+			return new WP_Error( 'no_response', get_status_header_desc( 404 ), array( 'status' => WP_Http::NOT_FOUND ) );
 		}
 
 		$remote_body = wp_remote_retrieve_body( $response );
 
-		if ( ! $remote_body ) {
-			return new WP_Error( 'no_response', __( 'Unable to retrieve body from response at this URL.', 'gutenberg' ), array( 'status' => 404 ) );
+		if ( empty( $remote_body ) ) {
+			return new WP_Error( 'no_content', __( 'Unable to retrieve body from response at this URL.', 'gutenberg' ), array( 'status' => WP_Http::NOT_FOUND ) );
 		}
 
 		return $remote_body;

--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -7,7 +7,8 @@
  */
 
 /**
- * Controller which provides REST endpoint for the widget areas.
+ * Controller which provides REST endpoint for retrieving information
+ * from a remote site's HTML response.
  *
  * @since 5.?.0
  *
@@ -57,16 +58,22 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 
 
 
-
+	/**
+	 * Retrieves the contents of the <title> tag from the HTML
+	 * response.
+	 *
+	 * @access public
+	 * @param  WP_REST_REQUEST $request Full details about the request.
+	 * @return String|WP_Error          the title text or an error.
+	 */
 	public function get_title( $request ) {
 
-		// TODO: Sanitize and validate
 		$url = $request->get_param( 'url' );
 
 		$html_response = $this->get_remote_url_html( $url );
 
 		if ( is_wp_error( $html_response ) ) {
-			return new WP_Error( 'no_title', 'Unable to retrieve title tag. ' . $html_response->get_error_message(), array( 'status' => 404 ) );
+			return new WP_Error( 'no_title', __( 'Unable to retrieve title tag.', 'gutenberg' ) . $html_response->get_error_message(), array( 'status' => 404 ) );
 		}
 
 		$title_list = $html_response->getElementsByTagName( 'title' );
@@ -74,7 +81,7 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 		$title = $title_list->item( 0 );
 
 		if ( empty( $title ) ) {
-			return new WP_Error( 'no_title', 'No title tag at remote url.', array( 'status' => 404 ) );
+			return new WP_Error( 'no_title', __( 'No title tag at remote url.', 'gutenberg' ), array( 'status' => 404 ) );
 		}
 
 		$title_text = $title->nodeValue;
@@ -82,18 +89,28 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 		return rest_ensure_response( $title_text );
 	}
 
+	/**
+	 * Validates a given URL
+	 *
+	 * @param  String $url the url to validate
+	 * @return Boolean      whether or not the URL is considered valid.
+	 */
 	public function validate_url( $url ) {
 		return wp_http_validate_url( $url );
 	}
 
+	/**
+	 * Sanitizes a given URL.
+	 *
+	 * @param  String $url the URL to sanitize.
+	 * @return String      the sanitized version of the URL.
+	 */
 	public function sanitize_url( $url ) {
 		return esc_url_raw( $url );
 	}
 
 	/**
 	 * Checks whether a given request has permission to read remote urls.
-	 *
-	 * @since 5.7.0
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_Error|bool True if the request has access, WP_Error object otherwise.
@@ -117,17 +134,24 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 	/* phpcs:enable */
 
 
+	/**
+	 * Retrives a DOMDocument representation of the
+	 * HTML from a remote URL
+	 *
+	 * @param  String $url the website url whose HTML we want to access.
+	 * @return DOMDocument      the loaded HTML response.
+	 */
 	private function get_remote_url_html( $url ) {
 
 		$response = wp_remote_get( $url );
 
 		if ( is_wp_error( $response ) || ! is_array( $response ) ) {
-			return new WP_Error( 'no_response', 'Unable to contact remote url . ' . $response->get_error_message(), array( 'status' => 404 ) );
+			return new WP_Error( 'no_response', __( 'Unable to contact remote url.', 'gutenberg' ) . $response->get_error_message(), array( 'status' => 404 ) );
 		}
 
 		$body = wp_remote_retrieve_body( $response );
 
-		$dom = new DOMDocument( '1.0', 'UTF - 8' );
+		$dom = new DOMDocument( '1.0', 'UTF-8' );
 
 		// set error level
 		$internalErrors = libxml_use_internal_errors( true );

--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -77,7 +77,7 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 		$data = $this->get_cache( $cache_key );
 
 		// Return cache if valid data.
-		if ( false && ! is_wp_error( $data ) && ! empty( $data ) ) {
+		if ( apply_filters( 'rest_url_details_use_cache', true ) && ! is_wp_error( $data ) && ! empty( $data ) ) {
 			return json_decode( $data, true );
 		}
 

--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -100,10 +100,10 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 		$cache_key = $this->build_cache_key_for_url( $url );
 
 		// Attempt to retrieve cached response.
-		$data = $this->get_cache( $cache_key );
+		$cached_response = $this->get_cache( $cache_key );
 
-		if ( ! empty( $data ) ) {
-			return json_decode( $data, true );
+		if ( ! empty( $cached_response ) ) {
+			return rest_ensure_response( json_decode( $cached_response, true ) );
 		}
 
 		$response_body = $this->get_remote_url( $url );
@@ -133,10 +133,15 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 			$url
 		);
 
+		$data = $this->add_additional_fields_to_object( $data, $request );
+
 		// Cache the valid response.
 		$this->set_cache( $cache_key, $data );
 
-		return rest_ensure_response( $data );
+		// Wrap the data in a response object.
+		$response = rest_ensure_response( $data );
+
+		return $response;
 	}
 
 	/**

--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -41,8 +41,12 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 					'callback'            => array( $this, 'get_title' ),
 					'args'                => array(
 						'url' => array(
+							'required'          => true,
+							'description'       => __( 'The URL to process.', 'gutenberg' ),
 							'validate_callback' => 'wp_http_validate_url',
 							'sanitize_callback' => 'esc_url_raw',
+							'type'              => 'string',
+							'format'            => 'uri',
 						),
 					),
 					'permission_callback' => array( $this, 'get_remote_url_permissions_check' ),
@@ -84,7 +88,7 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 
 		return new WP_Error(
 			'rest_user_cannot_view',
-			__( 'Sorry, you are not allowed to access remote urls.', 'gutenberg' ),
+			__( 'Sorry, you are not allowed to process remote urls.', 'gutenberg' ),
 			array( 'status' => rest_authorization_required_code() )
 		);
 	}
@@ -100,7 +104,7 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 		$url = untrailingslashit( $url );
 
 		if ( empty( $url ) ) {
-			return new WP_Error( 'rest_invalid_url', __( 'Invalid URL', 'gutenberg' ), [ 'status' => 404 ] );
+			return new WP_Error( 'rest_invalid_url', __( 'Invalid URL', 'gutenberg' ), array( 'status' => 404 ) );
 		}
 
 		// Transient per URL.
@@ -123,7 +127,7 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 
 		if ( WP_Http::OK !== wp_remote_retrieve_response_code( $response ) ) {
 			// Not saving the error response to cache since the error might be temporary.
-			return new WP_Error( 'rest_invalid_url', get_status_header_desc( 404 ), [ 'status' => 404 ] );
+			return new WP_Error( 'rest_invalid_url', get_status_header_desc( 404 ), array( 'status' => 404 ) );
 		}
 
 		$remote_body = wp_remote_retrieve_body( $response );

--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -69,7 +69,6 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 				'title' => array(
 					'description' => __( 'The contents of the <title> tag from the URL.', 'gutenberg' ),
 					'type'        => 'string',
-					'default'     => '',
 					'context'     => array( 'view', 'edit', 'embed' ),
 					'readonly'    => true,
 				),

--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -90,7 +90,7 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 	 */
 	public function parse_url_details( $request ) {
 
-		$url = untrailingslashit( $request->get_param( 'url' ) );
+		$url = untrailingslashit( $request['url'] );
 
 		if ( empty( $url ) ) {
 			return new WP_Error( 'rest_invalid_url', __( 'Invalid URL', 'gutenberg' ), array( 'status' => 404 ) );
@@ -104,7 +104,7 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 
 		if ( ! empty( $cached_response ) ) {
 			$from_cache = true;
-			$response = rest_ensure_response( json_decode( $cached_response, true ) );
+			$response   = rest_ensure_response( json_decode( $cached_response, true ) );
 
 			/**
 			 * Filters the URL data for the response.

--- a/lib/load.php
+++ b/lib/load.php
@@ -72,7 +72,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	*/
 
 	if ( ! class_exists( 'WP_REST_URL_Details_Controller' ) ) {
-		require dirname( __FILE__ ) . '/class-wp-rest-url-details-controller.php';
+		require_once __DIR__ . '/class-wp-rest-url-details-controller.php';
 	}
 
 	require __DIR__ . '/rest-api.php';

--- a/lib/load.php
+++ b/lib/load.php
@@ -71,6 +71,10 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	* End: Include for phase 2
 	*/
 
+	if ( ! class_exists( 'WP_REST_URL_Details_Controller' ) ) {
+		require dirname( __FILE__ ) . '/class-wp-rest-url-details-controller.php';
+	}
+
 	require __DIR__ . '/rest-api.php';
 }
 

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -10,6 +10,18 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die( 'Silence is golden.' );
 }
 
+
+/**
+ * Registers the REST API routes for URL Details.
+ *
+ * @since 5.0.0
+ */
+function gutenberg_register_url_details_routes() {
+	$url_details_controller = new WP_REST_URL_Details_Controller();
+	$url_details_controller->register_routes();
+}
+add_action( 'rest_api_init', 'gutenberg_register_url_details_routes' );
+
 /**
  * Registers the block pattern directory.
  */

--- a/phpunit/class-wp-rest-url-details-controller-test.php
+++ b/phpunit/class-wp-rest-url-details-controller-test.php
@@ -401,12 +401,12 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 		// Filter the response to known set of values changing only
 		// based on whether the response came from the cache or not.
 		add_filter(
-			'rest_url_details_prepare_response',
+			'rest_prepare_url_details',
 			function( $response, $url ) {
 				return new WP_REST_Response(
 					array(
 						'status'        => 418,
-						'response'      => "Response for URL $url altered via rest_url_details_prepare_response filter",
+						'response'      => "Response for URL $url altered via rest_prepare_url_details filter",
 						'body_response' => array(),
 					)
 				);
@@ -433,12 +433,12 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 		);
 
 		$this->assertEquals(
-			'Response for URL https://placeholder-site.com altered via rest_url_details_prepare_response filter',
+			'Response for URL https://placeholder-site.com altered via rest_prepare_url_details filter',
 			$data['response']
 		);
 
 		remove_all_filters(
-			'rest_url_details_prepare_response'
+			'rest_prepare_url_details'
 		);
 	}
 

--- a/phpunit/class-wp-rest-url-details-controller-test.php
+++ b/phpunit/class-wp-rest-url-details-controller-test.php
@@ -402,7 +402,7 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 				return new WP_REST_Response(
 					array(
 						'status'        => 418,
-						'response'      => "Uncached response for URL $url altered via rest_url_details_prepare_response filter",
+						'response'      => ( $from_cache ? 'Cached' : 'Uncached' ) . " response for URL $url altered via rest_url_details_prepare_response filter",
 						'body_response' => array(),
 					)
 				);

--- a/phpunit/class-wp-rest-url-details-controller-test.php
+++ b/phpunit/class-wp-rest-url-details-controller-test.php
@@ -13,7 +13,7 @@
  * @since x.x.0
  *
  * @covers WP_REST_URL_Details_Controller
- *
+ * @group url-details
  * @group restapi
  */
 class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testcase {
@@ -35,6 +35,9 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 	 * @var int $subscriber_id
 	 */
 	protected static $subscriber_id;
+
+
+	protected static $route = '/__experimental/url-details';
 
 	/**
 	 * Create fake data before our tests run.
@@ -61,22 +64,163 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 		self::delete_user( self::$subscriber_id );
 	}
 
-	public function test_register_routes() {
-		$routes = rest_get_server()->get_routes();
-		$this->assertArrayHasKey( '/__experimental/url-details', $routes );
+	/**
+	 * Setup.
+	 */
+	public function setUp() {
+		parent::setUp();
+		add_filter( 'pre_http_request', array( $this, 'mock_success_request_to_remote_url' ), 10, 3 );
 	}
 
+	/**
+	 * Tear down.
+	 */
+	public function tearDown() {
+		remove_filter( 'pre_http_request', array( $this, 'mock_success_request_to_remote_url' ), 10 );
+		parent::tearDown();
+	}
+
+	public function mock_success_request_to_remote_url() {
+		return array(
+			'response'    => array( 'code' => 200 ),
+			'headers'     => array(),
+			'cookies'     => array(),
+			'filename'    => null,
+			'status_code' => 200,
+			'success'     => 1,
+			'body'        => file_get_contents( __DIR__ . '/fixtures/example-website.html' ),
+		);
+	}
+
+	public function test_register_routes() {
+		$routes = rest_get_server()->get_routes();
+		$this->assertArrayHasKey( static::$route, $routes );
+	}
 
 	public function test_context_param() {
-
 	}
 
 	public function test_get_items() {
+		wp_set_current_user( self::$admin_id );
 
+		$request = new WP_REST_Request( 'GET', static::$route );
+		$request->set_query_params(
+			array(
+				'url' => 'https://examplewebsitedoesnotexist.org',
+			)
+		);
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals(
+			array(
+				'title' => 'Example Website &mdash; - with encoded content.',
+			),
+			$data
+		);
 	}
 
-	public function test_get_item() {
+	public function test_get_items_fails_for_user_with_insufficient_permissions() {
+		wp_set_current_user( self::$subscriber_id );
 
+		$request = new WP_REST_Request( 'GET', static::$route );
+		$request->set_query_params(
+			array(
+				'url' => 'https://wordpress.org',
+			)
+		);
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 403, $response->get_status() );
+
+		$this->assertEquals(
+			'rest_user_cannot_view',
+			$data['code']
+		);
+
+		$this->assertContains(
+			'you are not allowed to process remote urls',
+			$data['message']
+		);
+	}
+
+
+	public function provide_invalid_url_data() {
+		return array(
+			'empty_url'          => array(
+				null,
+				'',
+			), // empty!
+			'not_a_string'       => array(
+				null,
+				1234456,
+			),
+			'string_but_invalid' => array(
+				null,
+				'invalid.proto://wordpress.org',
+			),
+		);
+	}
+
+
+	public function test_get_items_fails_for_invalid_url() {
+		$this->markTestSkipped( 'must be revisited.' );
+		wp_set_current_user( self::$admin_id );
+
+		$request = new WP_REST_Request( 'GET', static::$route );
+		$request->set_query_params(
+			array(
+				'url' => $invalid_url,
+			)
+		);
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 400, $response->get_status() );
+
+		$this->assertEquals(
+			'rest_invalid_param',
+			$data['code']
+		);
+
+		$this->assertContains(
+			'Invalid parameter(s): url',
+			$data['message']
+		);
+	}
+
+	/**
+	 * @dataProvider provide_invalid_url_data
+	 */
+	public function test_get_items_fails_for_url_which_returns_non_200_status_code() {
+		wp_set_current_user( self::$admin_id );
+
+		$request = new WP_REST_Request( 'GET', static::$route );
+		$request->set_query_params(
+			array(
+				'url' => $invalid_url,
+			)
+		);
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 400, $response->get_status() );
+
+		$this->assertEquals(
+			'rest_invalid_param',
+			$data['code']
+		);
+
+		$this->assertContains(
+			'Invalid parameter(s): url',
+			$data['message']
+		);
+	}
+
+
+
+	public function test_get_item() {
 	}
 
 	public function test_create_item() {

--- a/phpunit/class-wp-rest-url-details-controller-test.php
+++ b/phpunit/class-wp-rest-url-details-controller-test.php
@@ -324,9 +324,7 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 		add_filter(
 			"pre_transient_$transient_name",
 			function() {
-				return wp_json_encode(
-					'<html><head><title>This value from cache.</title></head></html>'
-				);
+				return '<html><head><title>This value from cache.</title></head></html>';
 			}
 		);
 

--- a/phpunit/class-wp-rest-url-details-controller-test.php
+++ b/phpunit/class-wp-rest-url-details-controller-test.php
@@ -395,43 +395,18 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 
 
 
-	/**
-	 * @dataProvider provide_response_is_from_cache
-	 */
-	public function test_allows_filtering_response( $expected, $expected_is_from_cache ) {
 
-		// If we're testing ability to filter response from cache then
-		// force the response to come from the cache code path.
-		if ( $expected_is_from_cache ) {
-			$transient_name = 'g_url_details_response_' . md5( static::$url_placeholder );
-
-			remove_filter(
-				"pre_transient_$transient_name",
-				'__return_null'
-			);
-
-			// Force cache to return a known value.
-			add_filter(
-				"pre_transient_$transient_name",
-				function() {
-					return wp_json_encode(
-						array(
-							'title' => 'This value from cache',
-						)
-					);
-				}
-			);
-		}
+	public function test_allows_filtering_response() {
 
 		// Filter the response to known set of values changing only
 		// based on whether the response came from the cache or not.
 		add_filter(
 			'rest_url_details_prepare_response',
-			function( $response, $url, $from_cache ) {
+			function( $response, $url ) {
 				return new WP_REST_Response(
 					array(
 						'status'        => 418,
-						'response'      => ( $from_cache ? 'Cached' : 'Uncached' ) . " response for URL $url altered via rest_url_details_prepare_response filter",
+						'response'      => "Response for URL $url altered via rest_url_details_prepare_response filter",
 						'body_response' => array(),
 					)
 				);
@@ -458,16 +433,12 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 		);
 
 		$this->assertEquals(
-			( $expected_is_from_cache ? 'Cached' : 'Uncached' ) . ' response for URL https://placeholder-site.com altered via rest_url_details_prepare_response filter',
+			'Response for URL https://placeholder-site.com altered via rest_url_details_prepare_response filter',
 			$data['response']
 		);
 
 		remove_all_filters(
 			'rest_url_details_prepare_response'
-		);
-
-		remove_all_filters(
-			"pre_transient_$transient_name"
 		);
 	}
 

--- a/phpunit/class-wp-rest-url-details-controller-test.php
+++ b/phpunit/class-wp-rest-url-details-controller-test.php
@@ -325,9 +325,7 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 			"pre_transient_$transient_name",
 			function() {
 				return wp_json_encode(
-					array(
-						'title' => 'This value from cache',
-					)
+					'<html><head><title>This value from cache.</title></head></html>'
 				);
 			}
 		);
@@ -357,12 +355,21 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 	public function test_allows_filtering_data_retrieved_for_a_given_url() {
 
 		add_filter(
-			'rest_url_details_url_data',
-			function() {
-				return array(
-					'title'    => 'Updated response title via filter',
-					'og_title' => 'This was manually added to the data via filter',
+			'rest_prepare_url_details',
+			function( $response ) {
+
+				$data = $response->get_data();
+
+				$response->set_data(
+					array_merge(
+						$data,
+						array(
+							'og_title' => 'This was manually added to the data via filter',
+						)
+					)
 				);
+
+				return $response;
 
 			}
 		);
@@ -382,14 +389,14 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 		// data we provided via the filter.
 		$this->assertEquals(
 			array(
-				'title'    => 'Updated response title via filter',
+				'title'    => 'Example Website &mdash; - with encoded content.',
 				'og_title' => 'This was manually added to the data via filter',
 			),
 			$data
 		);
 
 		remove_all_filters(
-			'rest_url_details_url_data'
+			'rest_prepare_url_details'
 		);
 	}
 

--- a/phpunit/class-wp-rest-url-details-controller-test.php
+++ b/phpunit/class-wp-rest-url-details-controller-test.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * WP_REST_URL_Details_Controller tests.
+ *
+ * @package WordPress
+ * @subpackage REST_API
+ * @since x.x.0
+ */
+
+/**
+ * Tests for WP_REST_URL_Details_Controller.
+ *
+ * @since x.x.0
+ *
+ * @covers WP_REST_URL_Details_Controller
+ *
+ * @group restapi
+ */
+class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testcase {
+
+	/**
+	 * Admin user ID.
+	 *
+	 * @since x.x.0
+	 *
+	 * @var int $subscriber_id
+	 */
+	protected static $admin_id;
+
+	/**
+	 * Subscriber user ID.
+	 *
+	 * @since x.x.0
+	 *
+	 * @var int $subscriber_id
+	 */
+	protected static $subscriber_id;
+
+	/**
+	 * Create fake data before our tests run.
+	 *
+	 * @since x.x.0
+	 *
+	 * @param WP_UnitTest_Factory $factory Helper that lets us create fake data.
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$admin_id      = $factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+		self::$subscriber_id = $factory->user->create(
+			array(
+				'role' => 'subscriber',
+			)
+		);
+	}
+
+	public static function wpTearDownAfterClass() {
+		self::delete_user( self::$admin_id );
+		self::delete_user( self::$subscriber_id );
+	}
+
+	public function test_register_routes() {
+		$routes = rest_get_server()->get_routes();
+		$this->assertArrayHasKey( '/__experimental/url-details', $routes );
+	}
+
+
+	public function test_context_param() {
+
+	}
+
+	public function test_get_items() {
+
+	}
+
+	public function test_get_item() {
+
+	}
+
+	public function test_create_item() {
+
+	}
+
+	public function test_update_item() {
+
+	}
+
+	public function test_delete_item() {
+
+	}
+
+	public function test_prepare_item() {
+
+	}
+
+	public function test_get_item_schema() {
+
+	}
+}

--- a/phpunit/class-wp-rest-url-details-controller-test.php
+++ b/phpunit/class-wp-rest-url-details-controller-test.php
@@ -40,7 +40,7 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 	protected static $route = '/__experimental/url-details';
 
 
-	protected static $url_placeholder = 'https://dummysite.com';
+	protected static $url_placeholder = 'https://placeholder-site.com';
 
 	protected static $request_args = array();
 
@@ -429,7 +429,7 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 		);
 
 		$this->assertEquals(
-			'Uncached response for URL https://dummysite.com altered via rest_url_details_prepare_response filter',
+			'Uncached response for URL https://placeholder-site.com altered via rest_url_details_prepare_response filter',
 			$data['response']
 		);
 

--- a/phpunit/class-wp-rest-url-details-controller-test.php
+++ b/phpunit/class-wp-rest-url-details-controller-test.php
@@ -400,7 +400,6 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 	 */
 	public function test_allows_filtering_response( $expected, $expected_is_from_cache ) {
 
-
 		// If we're testing ability to filter response from cache then
 		// force the response to come from the cache code path.
 		if ( $expected_is_from_cache ) {

--- a/phpunit/class-wp-rest-url-details-controller-test.php
+++ b/phpunit/class-wp-rest-url-details-controller-test.php
@@ -150,7 +150,7 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 		$this->assertEquals( WP_Http::UNAUTHORIZED, $response->get_status() );
 
 		$this->assertEquals(
-			'rest_user_cannot_view',
+			'rest_cannot_view_url_details',
 			$data['code']
 		);
 
@@ -175,7 +175,7 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 		$this->assertEquals( WP_Http::FORBIDDEN, $response->get_status() );
 
 		$this->assertEquals(
-			'rest_user_cannot_view',
+			'rest_cannot_view_url_details',
 			$data['code']
 		);
 

--- a/phpunit/class-wp-rest-url-details-controller-test.php
+++ b/phpunit/class-wp-rest-url-details-controller-test.php
@@ -102,47 +102,7 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 		parent::tearDown();
 	}
 
-	public function test_will_return_from_cache_if_populated() {
-		$transient_name = 'g_url_details_response_' . md5( static::$url_placeholder );
 
-		remove_filter(
-			"pre_transient_$transient_name",
-			'__return_null'
-		);
-
-		// Force cache to return a known value.
-		add_filter(
-			"pre_transient_$transient_name",
-			function() {
-				return wp_json_encode(
-					array(
-						'title' => 'This value from cache',
-					)
-				);
-			}
-		);
-
-		wp_set_current_user( self::$admin_id );
-
-		$request = new WP_REST_Request( 'GET', static::$route );
-		$request->set_query_params(
-			array(
-				'url' => static::$url_placeholder,
-			)
-		);
-		$response = rest_get_server()->dispatch( $request );
-		$data     = $response->get_data();
-
-		// Data should be that from cache not from mocked network response.
-		$this->assertContains(
-			'This value from cache',
-			$data['title']
-		);
-
-		remove_all_filters(
-			"pre_transient_$transient_name"
-		);
-	}
 
 	public function test_register_routes() {
 		$routes = rest_get_server()->get_routes();
@@ -350,6 +310,48 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 		);
 
 		remove_all_filters( 'rest_url_details_http_request_args' );
+	}
+
+	public function test_will_return_from_cache_if_populated() {
+		$transient_name = 'g_url_details_response_' . md5( static::$url_placeholder );
+
+		remove_filter(
+			"pre_transient_$transient_name",
+			'__return_null'
+		);
+
+		// Force cache to return a known value.
+		add_filter(
+			"pre_transient_$transient_name",
+			function() {
+				return wp_json_encode(
+					array(
+						'title' => 'This value from cache',
+					)
+				);
+			}
+		);
+
+		wp_set_current_user( self::$admin_id );
+
+		$request = new WP_REST_Request( 'GET', static::$route );
+		$request->set_query_params(
+			array(
+				'url' => static::$url_placeholder,
+			)
+		);
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		// Data should be that from cache not from mocked network response.
+		$this->assertContains(
+			'This value from cache',
+			$data['title']
+		);
+
+		remove_all_filters(
+			"pre_transient_$transient_name"
+		);
 	}
 
 

--- a/phpunit/class-wp-rest-url-details-controller-test.php
+++ b/phpunit/class-wp-rest-url-details-controller-test.php
@@ -318,7 +318,23 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 	}
 
 	public function test_get_item_schema() {
+		wp_set_current_user( self::$admin_id );
 
+		$request  = new WP_REST_Request( 'OPTIONS', static::$route );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$endpoint = $data['endpoints'][0];
+
+		$this->assertArrayHasKey( 'url', $endpoint['args'] );
+		$this->assertArraySubset(
+			array(
+				'type'     => 'string',
+				'required' => true,
+				'format'   => 'uri',
+			),
+			$endpoint['args']['url']
+		);
 	}
 
 	public function provide_invalid_url_data() {

--- a/phpunit/class-wp-rest-url-details-controller-test.php
+++ b/phpunit/class-wp-rest-url-details-controller-test.php
@@ -320,7 +320,7 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 			'__return_null'
 		);
 
-		// Force cache to return a known value.
+		// Force cache to return a known value as the remote URL http response body.
 		add_filter(
 			"pre_transient_$transient_name",
 			function() {

--- a/phpunit/class-wp-rest-url-details-controller-test.php
+++ b/phpunit/class-wp-rest-url-details-controller-test.php
@@ -354,6 +354,45 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 		);
 	}
 
+	public function test_allows_filtering_data_retrieved_for_a_given_url() {
+
+		add_filter(
+			'rest_url_details_url_data',
+			function() {
+				return array(
+					'title'    => 'Updated response title via filter',
+					'og_title' => 'This was manually added to the data via filter',
+				);
+
+			}
+		);
+
+		wp_set_current_user( self::$admin_id );
+
+		$request = new WP_REST_Request( 'GET', static::$route );
+		$request->set_query_params(
+			array(
+				'url' => static::$url_placeholder,
+			)
+		);
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		// Instead of the default data retrieved we expect to see the modified
+		// data we provided via the filter.
+		$this->assertEquals(
+			array(
+				'title'    => 'Updated response title via filter',
+				'og_title' => 'This was manually added to the data via filter',
+			),
+			$data
+		);
+
+		remove_all_filters(
+			'rest_url_details_url_data'
+		);
+	}
+
 
 
 	public function test_get_item() {

--- a/phpunit/fixtures/example-website.html
+++ b/phpunit/fixtures/example-website.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" dir="ltr" lang="en-US">
+<head>
+<meta charset="utf-8" />
+<title>Example Website &mdash; - with encoded content.</title>
+
+<link rel="shortcut icon" href="//s.w.org/favicon.ico?2" type="image/x-icon" />
+
+<link rel="canonical" href="https://example.com">
+
+
+<!-- Open Graph Tags -->
+<meta property="og:type" content="website" />
+<meta property="og:title" content="Example Website" />
+<meta property="og:url" content="https://example.com" />
+<meta property="og:site_name" content="Example Website" />
+
+</head>
+<body>
+	<h1>Example Website</h1>
+    <p>loreLorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+</body>
+</html>


### PR DESCRIPTION
Closes https://github.com/WordPress/gutenberg/issues/18047.

Adds a new REST API endpoint to grab details from a external URL. So now if I want to get the contents of the `title` tag on `https://wordpress.org` I can send a request to this API endpoint and it will return the value in the response for use in the Gutenberg UI.

Why might this be useful? See https://github.com/WordPress/gutenberg/pull/19387.

-----

~As part of https://github.com/WordPress/gutenberg/pull/17846 we need to display the contents of the `<title>` tag from the url the user has typed into the input field.~ This has now long since shipped. Nonetheless, it might be a nice enhancement to be able to show details about the remote URL that has been selected.

This PR addresses this by adding a new **experimental** custom Gutenberg REST API endpoint. This endpoint:

* makes a request for a remote URL.
* ~parses the response in a `DOMDocument`~ we should investigate this in future (see [here](https://github.com/google/web-stories-wp/blob/a190acea43fc8dcac937d95b114d61ef4cad6aad/includes/REST_API/Link_Controller.php))
* retrieves the `title` tag contents.

To prevent abuse, the endpoint is authenticated and requires the user to have the `edit_posts` capability to be able to make a request.

## How has this been tested?

- [x] Manual testing (see below)
- [x] Automated tests

## Automated Testing Instructions

`npm run test-php` should run the unit tests which reside in `phpunit/class-wp-rest-url-details-controller-test.php`.

## Manual Testing Instructions

* Check out this PR.
* Open the Gutenberg local testing env at `http://localhost:8889/wp-admin/` and login.
* Create a new Post.
* Choose one of the following options:

### Option 1

* Open devtools and in the `console` enter:

```
wp.apiFetch( { path: '/__experimental/url-details/?url=https://wordpress.org' } ).then( data => {
    console.log( data );
} );
```

You'll see the response returned there.

### Option 2
* Open devtools and in the `console` enter `wpApiSettings.nonce`. You should see a valid nonce returned as a string.
* Copy the nonce.
* In your browser goto: `http://localhost:8889/wp-json/__experimental/url-details/?url=https://wordpress.org&_wpnonce=%YOUR_NONCE_HERE%` - be sure to replace the nonce value with that copied from the previous step.
* You should see a valid REST API response containing the contents of the title tag from `wordpress.org` (ie: `"Blog Tool, Publishing Platform, and CMS \u2014 WordPress.org"`).



## Types of changes
New feature (non-breaking change which adds functionality).

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->

