### PR TITLE
Refactor the layout component to separate the UI from the content. 

### DIFF
--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -313,21 +313,6 @@
 }
 
 /**
- * Applies editor right position to the selector passed as argument
- */
-
-@mixin editor-right($selector) {
-	#{ $selector } {
-		right: 0;
-	}
-
-	.edit-post-layout.is-sidebar-opened #{ $selector } {
-		right: $sidebar-width;
-	}
-}
-
-
-/**
  * Styles that are reused verbatim in a few places
  */
 

--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -66,7 +66,7 @@ $z-layers: (
 
 	// Show sidebar above wp-admin navigation bar for mobile viewports:
 	// #wpadminbar { z-index: 99999 }
-	".edit-post-sidebar": 100000,
+	".edit-post-editor-regions__sidebar": 100000,
 	".edit-widgets-sidebar": 100000,
 	".edit-post-layout .edit-post-post-publish-panel": 100001,
 	// For larger views, the wp-admin navbar dropdown should be at top of

--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -25,7 +25,7 @@ $z-layers: (
 	".block-library-gallery-item__inline-menu": 20,
 	".block-editor-url-input__suggestions": 30,
 	".edit-post-layout__footer": 30,
-	".edit-post-header": 30,
+	".edit-post-editor-regions__header": 30,
 	".edit-widgets-header": 30,
 	".block-library-button__inline-link .block-editor-url-input__suggestions": 6, // URL suggestions for button block above sibling inserter
 	".block-library-image__resize-handlers": 1, // Resize handlers above sibling inserter
@@ -75,7 +75,8 @@ $z-layers: (
 
 	// Show sidebar in greater than small viewports above editor related elements
 	// but bellow #adminmenuback { z-index: 100 }
-	".edit-post-sidebar {greater than small}": 90,
+	".edit-post-editor-regions__sidebar {greater than small}": 90,
+	".edit-widgets-sidebar {greater than small}": 90,
 
 	// Show notices below expanded editor bar
 	// .edit-post-header { z-index: 30 }

--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -102,7 +102,7 @@ $z-layers: (
 	".components-autocomplete__results": 1000000,
 
 	".skip-to-selected-block": 100000,
-	".edit-post-toggle-publish-panel": 100000,
+	".edit-post-editor-regions__publish": 100000,
 
 	// Show NUX tips above popovers, wp-admin menus, submenus, and sidebar:
 	".nux-dot-tip": 1000001,

--- a/packages/components/src/higher-order/navigate-regions/style.scss
+++ b/packages/components/src/higher-order/navigate-regions/style.scss
@@ -1,4 +1,6 @@
 .components-navigate-regions.is-focusing-regions [role="region"] {
+	position: relative;
+
 	// For browsers that don't support outline-offset (IE11).
 	&:focus::after {
 		content: "";

--- a/packages/e2e-tests/specs/editor/various/block-hierarchy-navigation.test.js
+++ b/packages/e2e-tests/specs/editor/various/block-hierarchy-navigation.test.js
@@ -82,7 +82,6 @@ describe( 'Navigating the block hierarchy', () => {
 		await pressKeyWithModifier( 'ctrl', '`' );
 		await pressKeyWithModifier( 'ctrl', '`' );
 		await pressKeyWithModifier( 'ctrl', '`' );
-		await pressKeyWithModifier( 'ctrl', '`' );
 		await pressKeyTimes( 'Tab', 4 );
 
 		// Tweak the columns count by increasing it by one.

--- a/packages/e2e-tests/specs/editor/various/sidebar.test.js
+++ b/packages/e2e-tests/specs/editor/various/sidebar.test.js
@@ -91,7 +91,6 @@ describe( 'Sidebar', () => {
 		await pressKeyWithModifier( 'ctrl', '`' );
 		await pressKeyWithModifier( 'ctrl', '`' );
 		await pressKeyWithModifier( 'ctrl', '`' );
-		await pressKeyWithModifier( 'ctrl', '`' );
 
 		// Tab lands at first (presumed selected) option "Document".
 		await page.keyboard.press( 'Tab' );

--- a/packages/edit-post/src/components/editor-regions/index.js
+++ b/packages/edit-post/src/components/editor-regions/index.js
@@ -1,0 +1,72 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { navigateRegions } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+function EditorRegions( { footer, header, sidebar, content, publish, className } ) {
+	return (
+		<div className={ classnames( className, 'edit-post-editor-regions' ) }>
+			{ !! header && (
+				<div
+					className="edit-post-editor-regions__header"
+					role="region"
+					/* translators: accessibility text for the top bar landmark region. */
+					aria-label={ __( 'Editor top bar' ) }
+					tabIndex="-1"
+				>
+					{ header }
+				</div>
+			) }
+			<div className="edit-post-editor-regions__body">
+				<div
+					className="edit-post-editor-regions__content"
+					role="region"
+					/* translators: accessibility text for the content landmark region. */
+					aria-label={ __( 'Editor content' ) }
+					tabIndex="-1"
+				>
+					{ content }
+				</div>
+				{ !! publish && (
+					<div
+						className="edit-post-editor-regions__publish"
+						role="region"
+						/* translators: accessibility text for the publish landmark region. */
+						aria-label={ __( 'Editor publish' ) }
+						tabIndex="-1"
+					>
+						{ publish }
+					</div>
+				) }
+				{ !! sidebar && (
+					<div
+						className="edit-post-editor-regions__sidebar"
+						role="region"
+						aria-label={ 'Editor settings' }
+						tabIndex="-1"
+					>
+						{ sidebar }
+					</div>
+				) }
+			</div>
+			{ !! footer && (
+				<div
+					className="edit-post-editor-regions__footer"
+					role="region"
+					aria-label={ 'Editor footer' }
+					tabIndex="-1"
+				>
+					{ footer }
+				</div>
+			) }
+		</div>
+	);
+}
+
+export default navigateRegions( EditorRegions );

--- a/packages/edit-post/src/components/editor-regions/style.scss
+++ b/packages/edit-post/src/components/editor-regions/style.scss
@@ -53,6 +53,7 @@
 	right: 0;
 	bottom: 0;
 	left: 0;
+	background: $white;
 
 	&:empty {
 		display: none;
@@ -63,7 +64,7 @@
 		overflow: auto;
 		border-left: $border-width solid $light-gray-500;
 		position: relative !important;
-		z-index: initial;
+		z-index: z-index(".edit-post-editor-regions__sidebar {greater than small}");
 	}
 }
 
@@ -71,14 +72,19 @@
 	flex-shrink: 0;
 	height: auto;  // Keep the height flexible.
 	border-bottom: $border-width solid $light-gray-500;
+	z-index: z-index(".edit-post-editor-regions__header");
 
 	// On Mobile the header is sticky.
 	position: sticky;
 	top: 0;
+
+	@include break-small() {
+		top: $admin-bar-height-big; // The top bar is fixed on this breakpoint.
+	}
+
 	@include break-medium() {
 		// Cancel the fixed positionning used in mobile.
 		position: initial;
-		overflow: auto;
 	}
 }
 

--- a/packages/edit-post/src/components/editor-regions/style.scss
+++ b/packages/edit-post/src/components/editor-regions/style.scss
@@ -1,0 +1,97 @@
+.edit-post-editor-regions {
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+	max-height: 100%;
+	position: relative;
+
+	// On Mobile keep a margin for the header and admin header
+	// as both of these are fixed
+	top: 0;
+	@include break-small() {
+		margin-top: 0;
+
+		// On Desktop position the container as fixed to avoid scroll bleed.
+		position: fixed;
+		top: $admin-bar-height-big;
+		left: 0;
+		right: 0;
+		bottom: 0;
+		height: auto;
+	}
+
+	@include break-medium() {
+		top: $admin-bar-height;
+	}
+}
+@include editor-left(".edit-post-editor-regions");
+
+.edit-post-editor-regions__body {
+	flex-grow: 1;
+	display: flex;
+
+	// On Mobile the header is fixed to keep HTML as scrollable.
+	@include break-small() {
+		overflow: auto;
+	}
+}
+
+.edit-post-editor-regions__content {
+	flex-grow: 1;
+
+	// On Mobile the header is fixed to keep HTML as scrollable.
+	@include break-small() {
+		overflow: auto;
+	}
+}
+
+.edit-post-editor-regions__sidebar {
+	width: auto; // Keep the sidebar width flexible.
+	flex-shrink: 0;
+
+	// On Mobile the header is fixed to keep HTML as scrollable.
+	@include break-small() {
+		overflow: auto;
+	}
+}
+
+.edit-post-editor-regions__header {
+	flex-shrink: 0;
+	height: auto;  // Keep the height flexible.
+
+	// On Mobile the header is sticky.
+	position: sticky;
+	top: 0;
+	@include break-small() {
+		// Cancel the fixed positionning used in mobile.
+		position: initial;
+		overflow: auto;
+	}
+}
+
+.edit-post-editor-regions__footer {
+	height: auto;  // Keep the height flexible.
+	flex-shrink: 0;
+	overflow: auto;
+
+	// On Mobile the footer is hidden
+	display: none;
+	@include break-small() {
+		display: block;
+	}
+}
+
+.edit-post-editor-regions__publish {
+	z-index: z-index(".edit-post-editor-regions__publish");
+	position: fixed !important; // Need to override the default relative positionning
+	top: -9999em;
+	bottom: auto;
+	left: auto;
+	right: 0;
+	width: $sidebar-width;
+
+	&:focus {
+		top: auto;
+		bottom: 0;
+	}
+}

--- a/packages/edit-post/src/components/editor-regions/style.scss
+++ b/packages/edit-post/src/components/editor-regions/style.scss
@@ -18,10 +18,16 @@
 		right: 0;
 		bottom: 0;
 		height: auto;
+		.is-fullscreen-mode & {
+			top: 0;
+		}
 	}
 
 	@include break-medium() {
 		top: $admin-bar-height;
+		.is-fullscreen-mode & {
+			top: 0;
+		}
 	}
 }
 @include editor-left(".edit-post-editor-regions");

--- a/packages/edit-post/src/components/editor-regions/style.scss
+++ b/packages/edit-post/src/components/editor-regions/style.scss
@@ -8,23 +8,16 @@
 	// On Mobile keep a margin for the header and admin header
 	// as both of these are fixed
 	top: 0;
-	@include break-small() {
+	@include break-medium() {
 		margin-top: 0;
 
 		// On Desktop position the container as fixed to avoid scroll bleed.
 		position: fixed;
-		top: $admin-bar-height-big;
+		top: $admin-bar-height;
 		left: 0;
 		right: 0;
 		bottom: 0;
 		height: auto;
-		.is-fullscreen-mode & {
-			top: 0;
-		}
-	}
-
-	@include break-medium() {
-		top: $admin-bar-height;
 		.is-fullscreen-mode & {
 			top: 0;
 		}
@@ -37,7 +30,7 @@
 	display: flex;
 
 	// On Mobile the header is fixed to keep HTML as scrollable.
-	@include break-small() {
+	@include break-medium() {
 		overflow: auto;
 	}
 }
@@ -46,7 +39,7 @@
 	flex-grow: 1;
 
 	// On Mobile the header is fixed to keep HTML as scrollable.
-	@include break-small() {
+	@include break-medium() {
 		overflow: auto;
 	}
 }
@@ -54,21 +47,35 @@
 .edit-post-editor-regions__sidebar {
 	width: auto; // Keep the sidebar width flexible.
 	flex-shrink: 0;
+	position: fixed !important; // Need to override the default relative positionning
+	z-index: z-index(".edit-post-editor-regions__sidebar");
+	top: 0;
+	right: 0;
+	bottom: 0;
+	left: 0;
+
+	&:empty {
+		display: none;
+	}
 
 	// On Mobile the header is fixed to keep HTML as scrollable.
-	@include break-small() {
+	@include break-medium() {
 		overflow: auto;
+		border-left: $border-width solid $light-gray-500;
+		position: relative !important;
+		z-index: initial;
 	}
 }
 
 .edit-post-editor-regions__header {
 	flex-shrink: 0;
 	height: auto;  // Keep the height flexible.
+	border-bottom: $border-width solid $light-gray-500;
 
 	// On Mobile the header is sticky.
 	position: sticky;
 	top: 0;
-	@include break-small() {
+	@include break-medium() {
 		// Cancel the fixed positionning used in mobile.
 		position: initial;
 		overflow: auto;
@@ -79,10 +86,11 @@
 	height: auto;  // Keep the height flexible.
 	flex-shrink: 0;
 	overflow: auto;
+	border-top: $border-width solid $light-gray-500;
 
 	// On Mobile the footer is hidden
 	display: none;
-	@include break-small() {
+	@include break-medium() {
 		display: block;
 	}
 }

--- a/packages/edit-post/src/components/editor-regions/style.scss
+++ b/packages/edit-post/src/components/editor-regions/style.scss
@@ -85,6 +85,7 @@
 	@include break-medium() {
 		// Cancel the fixed positionning used in mobile.
 		position: initial;
+		top: 0;
 	}
 }
 

--- a/packages/edit-post/src/components/header/header-toolbar/style.scss
+++ b/packages/edit-post/src/components/header/header-toolbar/style.scss
@@ -26,7 +26,7 @@
 .edit-post-header-toolbar__block-toolbar {
 	// Stack toolbar below Editor Bar.
 	position: absolute;
-	top: $header-height;
+	top: $header-height + 1px;
 	left: 0;
 	right: 0;
 	background: $white;

--- a/packages/edit-post/src/components/header/index.js
+++ b/packages/edit-post/src/components/header/index.js
@@ -32,13 +32,7 @@ function Header( {
 	const toggleGeneralSidebar = isEditorSidebarOpened ? closeGeneralSidebar : openGeneralSidebar;
 
 	return (
-		<div
-			role="region"
-			/* translators: accessibility text for the top bar landmark region. */
-			aria-label={ __( 'Editor top bar' ) }
-			className="edit-post-header"
-			tabIndex="-1"
-		>
+		<div className="edit-post-header">
 			<div className="edit-post-header__toolbar">
 				<FullscreenModeClose />
 				<HeaderToolbar />

--- a/packages/edit-post/src/components/header/style.scss
+++ b/packages/edit-post/src/components/header/style.scss
@@ -8,7 +8,6 @@
 	align-items: center;
 	// The header should never be wider than the viewport, or buttons might be hidden. Especially relevant at high zoom levels. Related to https://core.trac.wordpress.org/ticket/47603#ticket.
 	max-width: 100vw;
-	z-index: z-index(".edit-post-header");
 
 	// Make toolbar sticky on larger breakpoints
 	@include break-zoomed-in {

--- a/packages/edit-post/src/components/header/style.scss
+++ b/packages/edit-post/src/components/header/style.scss
@@ -1,6 +1,6 @@
 .edit-post-header {
+	height: $header-height;
 	padding: $grid-size-small 2px;
-	border-bottom: $border-width solid $light-gray-500;
 	background: $white;
 	display: flex;
 	flex-wrap: wrap;

--- a/packages/edit-post/src/components/header/style.scss
+++ b/packages/edit-post/src/components/header/style.scss
@@ -1,5 +1,4 @@
 .edit-post-header {
-	height: $header-height;
 	padding: $grid-size-small 2px;
 	border-bottom: $border-width solid $light-gray-500;
 	background: $white;
@@ -10,30 +9,14 @@
 	// The header should never be wider than the viewport, or buttons might be hidden. Especially relevant at high zoom levels. Related to https://core.trac.wordpress.org/ticket/47603#ticket.
 	max-width: 100vw;
 	z-index: z-index(".edit-post-header");
-	left: 0;
-	right: 0;
 
 	// Make toolbar sticky on larger breakpoints
 	@include break-zoomed-in {
-		height: $header-height;
-		top: 0;
-		position: sticky;
 		flex-wrap: nowrap;
 	}
 
-	// On mobile the main content area has to scroll, otherwise you can invoke the overscroll bounce on the non-scrolling container.
 	@include break-small {
-		position: fixed;
 		padding: $grid-size;
-		top: $admin-bar-height-big;
-	}
-
-	@include break-medium() {
-		top: $admin-bar-height;
-
-		body.is-fullscreen-mode & {
-			top: 0;
-		}
 	}
 
 	// Some browsers, most notably IE11, honor an older version of the flexbox spec
@@ -54,8 +37,6 @@
 		}
 	}
 }
-
-@include editor-left(".edit-post-header");
 
 .edit-post-header__toolbar {
 	display: flex;

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -7,162 +7,141 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import {
-	Button,
-	Popover,
-	ScrollLock,
-	FocusReturnProvider,
-	navigateRegions,
-} from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
-import {
 	AutosaveMonitor,
 	LocalAutosaveMonitor,
 	UnsavedChangesWarning,
 	EditorNotices,
 	PostPublishPanel,
 } from '@wordpress/editor';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { BlockBreadcrumb } from '@wordpress/block-editor';
-import { withDispatch, withSelect } from '@wordpress/data';
-import { PluginArea } from '@wordpress/plugins';
+import {
+	Button,
+	ScrollLock,
+	Popover,
+	FocusReturnProvider,
+} from '@wordpress/components';
 import { withViewportMatch } from '@wordpress/viewport';
-import { compose } from '@wordpress/compose';
+import { PluginArea } from '@wordpress/plugins';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import BrowserURL from '../browser-url';
-import Header from '../header';
 import TextEditor from '../text-editor';
 import VisualEditor from '../visual-editor';
 import EditorModeKeyboardShortcuts from '../keyboard-shortcuts';
 import KeyboardShortcutHelpModal from '../keyboard-shortcut-help-modal';
 import ManageBlocksModal from '../manage-blocks-modal';
 import OptionsModal from '../options-modal';
-import MetaBoxes from '../meta-boxes';
+import EditorRegions from '../editor-regions';
+import FullscreenMode from '../fullscreen-mode';
+import BrowserURL from '../browser-url';
+import Header from '../header';
 import SettingsSidebar from '../sidebar/settings-sidebar';
 import Sidebar from '../sidebar';
+import MetaBoxes from '../meta-boxes';
 import PluginPostPublishPanel from '../sidebar/plugin-post-publish-panel';
 import PluginPrePublishPanel from '../sidebar/plugin-pre-publish-panel';
-import FullscreenMode from '../fullscreen-mode';
 
-function Layout( {
-	mode,
-	editorSidebarOpened,
-	pluginSidebarOpened,
-	publishSidebarOpened,
-	hasFixedToolbar,
-	closePublishSidebar,
-	togglePublishSidebar,
-	hasActiveMetaboxes,
-	isSaving,
-	isMobileViewport,
-	isRichEditingEnabled,
-} ) {
+function Layout( { isMobileViewport } ) {
+	const { closePublishSidebar, togglePublishSidebar } = useDispatch( 'core/edit-post' );
+	const {
+		mode,
+		isRichEditingEnabled,
+		editorSidebarOpened,
+		pluginSidebarOpened,
+		publishSidebarOpened,
+		hasActiveMetaboxes,
+		isSaving,
+		hasFixedToolbar,
+	} = useSelect( ( select ) => {
+		return ( {
+			hasFixedToolbar: select( 'core/edit-post' ).isFeatureActive( 'fixedToolbar' ),
+			editorSidebarOpened: select( 'core/edit-post' ).isEditorSidebarOpened(),
+			pluginSidebarOpened: select( 'core/edit-post' ).isPluginSidebarOpened(),
+			publishSidebarOpened: select( 'core/edit-post' ).isPublishSidebarOpened(),
+			mode: select( 'core/edit-post' ).getEditorMode(),
+			isRichEditingEnabled: select( 'core/editor' ).getEditorSettings().richEditingEnabled,
+			hasActiveMetaboxes: select( 'core/edit-post' ).hasMetaBoxes(),
+			isSaving: select( 'core/edit-post' ).isSavingMetaBoxes(),
+		} );
+	} );
 	const sidebarIsOpened = editorSidebarOpened || pluginSidebarOpened || publishSidebarOpened;
-
 	const className = classnames( 'edit-post-layout', 'is-mode-' + mode, {
 		'is-sidebar-opened': sidebarIsOpened,
 		'has-fixed-toolbar': hasFixedToolbar,
 		'has-metaboxes': hasActiveMetaboxes,
 	} );
 
-	const publishLandmarkProps = {
-		role: 'region',
-		/* translators: accessibility text for the publish landmark region. */
-		'aria-label': __( 'Editor publish' ),
-		tabIndex: -1,
-	};
 	return (
-		<FocusReturnProvider className={ className }>
+		<>
 			<FullscreenMode />
 			<BrowserURL />
 			<UnsavedChangesWarning />
 			<AutosaveMonitor />
 			<LocalAutosaveMonitor />
-			<Header />
-			<div
-				className="edit-post-layout__content edit-post-layout__scrollable-container"
-				role="region"
-				/* translators: accessibility text for the content landmark region. */
-				aria-label={ __( 'Editor content' ) }
-				tabIndex="-1"
-			>
-				<EditorNotices />
-				<EditorModeKeyboardShortcuts />
-				<KeyboardShortcutHelpModal />
-				<ManageBlocksModal />
-				<OptionsModal />
-				{ ( mode === 'text' || ! isRichEditingEnabled ) && <TextEditor /> }
-				{ isRichEditingEnabled && mode === 'visual' && <VisualEditor /> }
-				<div className="edit-post-layout__metaboxes">
-					<MetaBoxes location="normal" />
-				</div>
-				<div className="edit-post-layout__metaboxes">
-					<MetaBoxes location="advanced" />
-				</div>
-				{ isMobileViewport && sidebarIsOpened && <ScrollLock /> }
-			</div>
-			{ isRichEditingEnabled && mode === 'visual' && (
-				<div
-					className="edit-post-layout__footer"
-					role="region"
-					/* translators: accessibility text for the content landmark region. */
-					aria-label={ __( 'Editor footer' ) }
-					tabIndex="-1"
-				>
-					<BlockBreadcrumb />
-				</div>
-			) }
-			{ publishSidebarOpened ? (
-				<PostPublishPanel
-					{ ...publishLandmarkProps }
-					onClose={ closePublishSidebar }
-					forceIsDirty={ hasActiveMetaboxes }
-					forceIsSaving={ isSaving }
-					PrePublishExtension={ PluginPrePublishPanel.Slot }
-					PostPublishExtension={ PluginPostPublishPanel.Slot }
-				/>
-			) : (
-				<>
-					<div className="edit-post-toggle-publish-panel" { ...publishLandmarkProps }>
-						<Button
-							isDefault
-							type="button"
-							className="edit-post-toggle-publish-panel__button"
-							onClick={ togglePublishSidebar }
-							aria-expanded={ false }
-						>
-							{ __( 'Open publish panel' ) }
-						</Button>
-					</div>
-					<SettingsSidebar />
-					<Sidebar.Slot />
-				</>
-			) }
+			<EditorModeKeyboardShortcuts />
+			<ManageBlocksModal />
+			<OptionsModal />
+			<KeyboardShortcutHelpModal />
 			<Popover.Slot />
 			<PluginArea />
-		</FocusReturnProvider>
+			<FocusReturnProvider className={ className }>
+				<EditorRegions
+					className={ className }
+					header={ <Header /> }
+					sidebar={ ! publishSidebarOpened && (
+						<>
+							<SettingsSidebar />
+							<Sidebar.Slot />
+						</>
+					) }
+					content={
+						<>
+							<EditorNotices />
+							{ ( mode === 'text' || ! isRichEditingEnabled ) && <TextEditor /> }
+							{ isRichEditingEnabled && mode === 'visual' && <VisualEditor /> }
+							<div className="edit-post-layout__metaboxes">
+								<MetaBoxes location="normal" />
+							</div>
+							<div className="edit-post-layout__metaboxes">
+								<MetaBoxes location="advanced" />
+							</div>
+							{ isMobileViewport && sidebarIsOpened && <ScrollLock /> }
+						</>
+					}
+					footer={ isRichEditingEnabled && mode === 'visual' && (
+						<div className="edit-post-layout__footer">
+							<BlockBreadcrumb />
+						</div>
+					) }
+					publish={ publishSidebarOpened ? (
+						<PostPublishPanel
+							onClose={ closePublishSidebar }
+							forceIsDirty={ hasActiveMetaboxes }
+							forceIsSaving={ isSaving }
+							PrePublishExtension={ PluginPrePublishPanel.Slot }
+							PostPublishExtension={ PluginPostPublishPanel.Slot }
+						/>
+					) : (
+						<div className="edit-post-toggle-publish-panel">
+							<Button
+								isDefault
+								type="button"
+								className="edit-post-toggle-publish-panel__button"
+								onClick={ togglePublishSidebar }
+								aria-expanded={ false }
+							>
+								{ __( 'Open publish panel' ) }
+							</Button>
+						</div>
+					) }
+				/>
+			</FocusReturnProvider>
+
+		</>
 	);
 }
 
-export default compose(
-	withSelect( ( select ) => ( {
-		mode: select( 'core/edit-post' ).getEditorMode(),
-		editorSidebarOpened: select( 'core/edit-post' ).isEditorSidebarOpened(),
-		pluginSidebarOpened: select( 'core/edit-post' ).isPluginSidebarOpened(),
-		publishSidebarOpened: select( 'core/edit-post' ).isPublishSidebarOpened(),
-		hasFixedToolbar: select( 'core/edit-post' ).isFeatureActive( 'fixedToolbar' ),
-		hasActiveMetaboxes: select( 'core/edit-post' ).hasMetaBoxes(),
-		isSaving: select( 'core/edit-post' ).isSavingMetaBoxes(),
-		isRichEditingEnabled: select( 'core/editor' ).getEditorSettings().richEditingEnabled,
-	} ) ),
-	withDispatch( ( dispatch ) => {
-		const { closePublishSidebar, togglePublishSidebar } = dispatch( 'core/edit-post' );
-		return {
-			closePublishSidebar,
-			togglePublishSidebar,
-		};
-	} ),
-	navigateRegions,
-	withViewportMatch( { isMobileViewport: '< small' } ),
-)( Layout );
+export default withViewportMatch( { isMobileViewport: '< small' } )( Layout );

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -111,7 +111,6 @@
 		height: $footer-height;
 		padding: 0 $grid-size;
 		align-items: center;
-		border-top: $border-width solid $light-gray-500;
 		font-size: $default-font-size;
 	}
 }

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -1,21 +1,6 @@
-.edit-post-layout,
-.edit-post-layout__content {
-	height: 100%;
+.edit-post-layout__metaboxes {
+	flex-shrink: 0;
 }
-
-.edit-post-layout {
-	position: relative;
-	box-sizing: border-box;
-
-	// Beyond the mobile breakpoint, the editor bar is fixed, so make room for it eabove the layout content.
-	@include break-small {
-		padding-top: $header-height;
-	}
-
-	// Beyond the medium breakpoint, the main scrolling area itself becomes fixed so the padding then becomes
-	// unnecessary, but until then it's still needed.
-}
-
 .edit-post-layout__metaboxes:not(:empty) {
 	border-top: $border-width solid $light-gray-500;
 	margin-top: 10px;
@@ -36,95 +21,6 @@
 	padding-right: 16px;
 }
 @include editor-left(".edit-post-layout__content .components-editor-notices__snackbar");
-
-.edit-post-layout__content {
-	display: flex;
-	flex-direction: column;
-
-	// These rules are specific to mobile and small breakpoints.
-	min-height: 100%;
-	position: relative;
-
-	// We scroll the main editing canvas, the sidebar, and the block library separately to prevent scroll bleed.
-	// Because the navigation sidebar menu has "flyout" menus, we can't yet, scroll that independently, but as soon
-	// as we can, we should simplify these rules.
-	// In the mean time, if a user has a small screen and lots of plugin-added menu items in the navigation menu,
-	// they have to be able to scroll. To accommodate the flyout menus, we scroll the `body` element for this.
-	@include break-medium() {
-		// Because the body element scrolls the navigation sidebar, we have to use position fixed here.
-		// Otherwise you would scroll the editing canvas out of view when you scroll the sidebar.
-		position: fixed;
-		bottom: $footer-height;
-		left: 0;
-		right: 0;
-
-		// Because this is scoped to break-medium and larger, the admin-bar is always this height.
-		top: $header-height + $admin-bar-height;
-
-		// Sadly, `position: fixed;` do not inherit boundaries from a relative parent. Due to that we have to compensate using `calc`.
-		min-height: calc(100% - #{ $header-height + $admin-bar-height });
-		height: auto; // This overrides the 100% height the element inherits from line 3.
-
-		// In this matrix, we compensate for any configurations for the presence and width of the navigation sidebar.
-		// This is similar to the code in the @editor-left mixin, but uses margins instead.
-		// Because we are beyond the medium breakpoint, we only have to worry about folded, auto-folded, and default.
-		margin-left: $admin-sidebar-width;
-
-		// Make room for the footer
-		.edit-post-layout.is-mode-visual & {
-			bottom: $footer-height;
-			min-height: calc(100% - #{ $header-height + $admin-bar-height + $footer-height });
-		}
-
-		// Auto fold is when on smaller breakpoints, nav menu auto colllapses.
-		body.auto-fold & {
-			margin-left: $admin-sidebar-width-collapsed;
-
-			@include break-large() {
-				margin-left: $admin-sidebar-width;
-			}
-		}
-
-		// Sidebar manually collapsed.
-		body.folded & {
-			margin-left: $admin-sidebar-width-collapsed;
-		}
-
-		// Provide special rules for fullscreen mode.
-		body.is-fullscreen-mode & {
-			margin-left: 0 !important;
-			top: $header-height;
-		}
-	}
-
-	// For users with the Top Toolbar option enabled, special rules apply to the height of the content area.
-	.has-fixed-toolbar & {
-		// From the medium breakpoint it sits below the editor bar.
-		@include break-medium() {
-			top: $header-height + $admin-bar-height + $block-controls-height;
-		}
-
-		// From the xlarge breakpoint it sits in the editor bar.
-		@include break-xlarge() {
-			top: $header-height + $admin-bar-height;
-		}
-	}
-
-	.edit-post-visual-editor {
-		flex: 1 1 auto;
-
-		// In IE11 flex-basis: 100% cause a bug where the metaboxes area overlap with the content area.
-		// But it works as expected without it.
-		// The flex-basis is needed for the other browsers to make sure the content area is full-height.
-		@supports (position: sticky) {
-			flex-basis: 100%;
-		}
-	}
-
-	.edit-post-layout__metaboxes {
-		flex-shrink: 0;
-	}
-}
 
 .edit-post-layout .editor-post-publish-panel {
 	position: fixed;
@@ -177,20 +73,8 @@
 }
 
 .edit-post-toggle-publish-panel {
-	position: fixed;
-	top: -9999em;
-	bottom: auto;
-	left: auto;
-	right: 0;
-	z-index: z-index(".edit-post-toggle-publish-panel");
-	padding: 10px 10px 10px 0;
-	width: $sidebar-width;
 	background-color: $white;
-
-	&:focus {
-		top: auto;
-		bottom: 0;
-	}
+	padding: 10px 10px 10px 0;
 
 	.edit-post-toggle-publish-panel__button {
 		width: auto;
@@ -223,19 +107,14 @@
 	// Stretch to mimic outline padding on desktop.
 	@include break-medium() {
 		display: flex;
-		position: fixed;
-		bottom: 0;
-		right: 0;
 		background: $white;
 		height: $footer-height;
 		padding: 0 $grid-size;
 		align-items: center;
 		border-top: $border-width solid $light-gray-500;
 		font-size: $default-font-size;
-		box-sizing: border-box;
 	}
 }
-@include editor-left(".edit-post-layout__footer");
 
 .edit-post-layout__scrollable-container {
 	// On mobile the main content (html or body) area has to scroll.

--- a/packages/edit-post/src/components/sidebar/index.js
+++ b/packages/edit-post/src/components/sidebar/index.js
@@ -17,14 +17,9 @@ const { Fill, Slot } = createSlotFill( 'Sidebar' );
  *
  * @return {Object} The rendered sidebar.
  */
-function Sidebar( { children, label, className } ) {
+function Sidebar( { children, className } ) {
 	return (
-		<div
-			className={ classnames( 'edit-post-sidebar', className ) }
-			role="region"
-			aria-label={ label }
-			tabIndex="-1"
-		>
+		<div className={ classnames( 'edit-post-sidebar', className ) }>
 			{ children }
 		</div>
 	);

--- a/packages/edit-post/src/components/sidebar/plugin-sidebar/index.js
+++ b/packages/edit-post/src/components/sidebar/plugin-sidebar/index.js
@@ -41,10 +41,7 @@ function PluginSidebar( props ) {
 					/> }
 				</PinnedPlugins>
 			) }
-			<Sidebar
-				name={ sidebarName }
-				label={ __( 'Editor plugins' ) }
-			>
+			<Sidebar name={ sidebarName }>
 				<SidebarHeader
 					closeLabel={ __( 'Close plugin' ) }
 				>

--- a/packages/edit-post/src/components/sidebar/settings-header/style.scss
+++ b/packages/edit-post/src/components/sidebar/settings-header/style.scss
@@ -4,7 +4,6 @@
 	padding-right: $grid-size-small;
 	border-top: 0;
 	position: sticky;
-	z-index: z-index(".components-panel__header.edit-post-sidebar__panel-tabs");
 	top: 0;
 
 	ul {

--- a/packages/edit-post/src/components/sidebar/settings-sidebar/index.js
+++ b/packages/edit-post/src/components/sidebar/settings-sidebar/index.js
@@ -5,7 +5,7 @@ import { Panel } from '@wordpress/components';
 import { compose, ifCondition } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
 import { BlockInspector } from '@wordpress/block-editor';
-import { __ } from '@wordpress/i18n';
+
 /**
  * Internal dependencies
  */
@@ -23,10 +23,7 @@ import MetaBoxes from '../../meta-boxes';
 import PluginDocumentSettingPanel from '../plugin-document-setting-panel';
 
 const SettingsSidebar = ( { sidebarName } ) => (
-	<Sidebar
-		name={ sidebarName }
-		label={ __( 'Editor settings' ) }
-	>
+	<Sidebar name={ sidebarName }>
 		<SettingsHeader sidebarName={ sidebarName } />
 		<Panel>
 			{ sidebarName === 'edit-post/document' && (

--- a/packages/edit-post/src/components/sidebar/style.scss
+++ b/packages/edit-post/src/components/sidebar/style.scss
@@ -1,7 +1,4 @@
 .edit-post-sidebar {
-	z-index: z-index(".edit-post-sidebar");
-	width: $sidebar-width;
-	border-left: $border-width solid $light-gray-500;
 	background: $white;
 	color: $dark-gray-500;
 
@@ -10,6 +7,10 @@
 		height: 100%;
 		overflow: auto;
 		-webkit-overflow-scrolling: touch;
+	}
+
+	@include break-medium() {
+		width: $sidebar-width;
 	}
 
 	> .components-panel {

--- a/packages/edit-post/src/components/sidebar/style.scss
+++ b/packages/edit-post/src/components/sidebar/style.scss
@@ -1,34 +1,15 @@
 .edit-post-sidebar {
-	position: fixed;
 	z-index: z-index(".edit-post-sidebar");
-	top: 0;
-	right: 0;
-	bottom: 0;
 	width: $sidebar-width;
 	border-left: $border-width solid $light-gray-500;
 	background: $white;
 	color: $dark-gray-500;
-	height: 100vh;
-	overflow: hidden;
 
 	@include break-small() {
-		top: $admin-bar-height-big + $header-height;
-		z-index: z-index(".edit-post-sidebar {greater than small}");
-		height: auto;
+		z-index: auto;
+		height: 100%;
 		overflow: auto;
 		-webkit-overflow-scrolling: touch;
-	}
-
-	@include break-medium() {
-		top: $admin-bar-height + $header-height;
-
-		.edit-post-layout.is-mode-visual & {
-			bottom: $footer-height;
-		}
-
-		body.is-fullscreen-mode & {
-			top: $header-height;
-		}
 	}
 
 	> .components-panel {
@@ -41,7 +22,6 @@
 		margin-top: -1px;
 		margin-bottom: -1px;
 		position: relative;
-		z-index: z-index(".edit-post-sidebar .components-panel");
 
 		@include break-small() {
 			overflow: hidden;
@@ -100,26 +80,6 @@
 		right: 10px;
 		bottom: 10px;
 		left: auto;
-	}
-}
-
-/* Visual and Text editor both */
-.edit-post-layout.is-sidebar-opened .edit-post-layout__content {
-	@include break-medium() {
-		margin-right: $sidebar-width;
-	}
-}
-
-.edit-post-layout.is-sidebar-opened {
-	.edit-post-sidebar,
-	.edit-post-plugin-sidebar__sidebar-layout {
-		/* Sidebar covers screen on mobile */
-		width: 100%;
-
-		/* Sidebar sits on the side on larger breakpoints */
-		@include break-medium() {
-			width: $sidebar-width;
-		}
 	}
 }
 

--- a/packages/edit-post/src/components/text-editor/style.scss
+++ b/packages/edit-post/src/components/text-editor/style.scss
@@ -1,4 +1,5 @@
 .edit-post-text-editor {
+	position: relative;
 	width: 100%;
 
 	// Always show outlines in code editor

--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -5,6 +5,15 @@
 	& .components-button {
 		font-family: $default-font;
 	}
+
+	flex: 1 1 auto;
+
+	// In IE11 flex-basis: 100% cause a bug where the metaboxes area overlap with the content area.
+	// But it works as expected without it.
+	// The flex-basis is needed for the other browsers to make sure the content area is full-height.
+	@supports (position: sticky) {
+		flex-basis: 100%;
+	}
 }
 
 .edit-post-visual-editor .block-editor-writing-flow__click-redirect {

--- a/packages/edit-post/src/style.scss
+++ b/packages/edit-post/src/style.scss
@@ -1,5 +1,6 @@
 $footer-height: $icon-button-size-small;
 
+@import "./components/editor-regions/style.scss";
 @import "./components/fullscreen-mode/style.scss";
 @import "./components/header/style.scss";
 @import "./components/header/fullscreen-mode-close/style.scss";

--- a/packages/edit-widgets/src/components/sidebar/style.scss
+++ b/packages/edit-widgets/src/components/sidebar/style.scss
@@ -13,7 +13,7 @@
 
 	@include break-small() {
 		top: $admin-bar-height-big + $header-height;
-		z-index: z-index(".edit-post-sidebar {greater than small}");
+		z-index: z-index(".edit-widgets-sidebar {greater than small}");
 		height: auto;
 		overflow: auto;
 		-webkit-overflow-scrolling: touch;


### PR DESCRIPTION
While working on #17838 I noticed that it's very hard to work on the Layout of the Editor.

The fact is there are so many things to think about:
  - mobile
  - fullscreen
  - with or without sidebar
  - WP admin header height changing
  ...

These create different constraints that are spread across different components in our code base and also mixed with a lot of unrelated items.

In this PR, I'm basically splitting the `UI` and the editor regions out of the `Layout` component. The idea is that the new `EditorRegions` takes care of how things are displayed on the screen (sidebar, main area, header, footer), gives a name and enable aria region navigation for these different areas and the `Layout` component fills the different regions for content.

A nice side effect here is that all these layouting constraints are now constraint in a single stylesheet making it very easy to maintain and reason about.

This change may have some impacts on classNames, zIndex, browsers so it needs to be tested properly but I'm hoping that it makes our code way more manageable. 

The new `EditorRegions` component can also be easily made more flexible (allowing different names for the  regions) and shared with other screens (Widgets...)

Thoughts?