### PR TITLE
 Hide custom font size label and option from font size picker select

### DIFF
--- a/packages/components/src/font-size-picker/index.js
+++ b/packages/components/src/font-size-picker/index.js
@@ -20,7 +20,12 @@ function getSelectValueFromFontSize( fontSizes, value ) {
 	return 'normal';
 }
 
-function getSelectOptions( optionsArray ) {
+function getSelectOptions( optionsArray, disableCustomFontSizes ) {
+	if(disableCustomFontSizes){
+		return [
+			...optionsArray.map( ( option ) => ( { value: option.slug, label: option.name } ) )
+		];
+	}
 	return [
 		...optionsArray.map( ( option ) => ( { value: option.slug, label: option.name } ) ),
 		{ value: 'custom', label: __( 'Custom' ) },
@@ -72,7 +77,7 @@ function FontSizePicker( {
 						hideLabelFromVision={ true }
 						value={ currentSelectValue }
 						onChange={ onSelectChangeValue }
-						options={ getSelectOptions( fontSizes ) }
+						options={ getSelectOptions( fontSizes, disableCustomFontSizes ) }
 					/>
 				}
 				{ ( ! withSlider && ! disableCustomFontSizes ) &&


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
Fixes #17941 

This PR solves removes Custom as an option from font-size-picker, a fully accessible and customizable select component with font sizes, in the @wordpress/components package.

It works well, if you call function `add_theme_support('disable-custom-font-sizes')` inside functions.php of the active theme, it hides custom size option inside font size picker select component on gutenberg paragraph block on post or page add or edit screens.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Blank installation of WP 5.2.3 and TwentyNineteen theme.
Install and enable Gutenberg forked from WordPress/gutenberg 
Added patch
Run `npm install`, `npm run-script build` on command line inside gutenberg plugin folder
Goto post add screen and add a paragraph block
Add or remove `add_theme_support('disable-custom-font-sizes')` in functions.php of active theme
Custom font size option will be removed or shown respectively
Tested on post, page add new and edit menus, updated successfully


## Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/11679050/67213256-21441780-f437-11e9-9a41-818066365363.png)
![image](https://user-images.githubusercontent.com/11679050/67213265-299c5280-f437-11e9-850b-7a75b64243b0.png)
![image](https://user-images.githubusercontent.com/11679050/67213274-2e610680-f437-11e9-927f-97dd958c70fd.png)



## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix ( Disabling custom font sizes does not remove 'custom' option from Paragraph block font size dropdown )

## Checklist:
- [x] My code is tested.
- [] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
