### PR TITLE
Local autosave: Clear after successful save

### DIFF
--- a/packages/e2e-tests/specs/editor/various/autosave.test.js
+++ b/packages/e2e-tests/specs/editor/various/autosave.test.js
@@ -17,13 +17,22 @@ const AUTOSAVE_INTERVAL_SECONDS = 5;
 const AUTOSAVE_NOTICE_REMOTE = 'There is an autosave of this post that is more recent than the version below.';
 const AUTOSAVE_NOTICE_LOCAL = 'The backup of this post in your browser is different from the version below.';
 
+// Save and wait for "Saved" to confirm save complete. Preserves focus in the
+// editing area.
 async function saveDraftWithKeyboard() {
-	return pressKeyWithModifier( 'primary', 's' );
+	await page.waitForSelector( '.editor-post-save-draft' );
+	await Promise.all( [
+		page.waitForSelector( '.editor-post-saved-state.is-saved' ),
+		pressKeyWithModifier( 'primary', 'S' ),
+	] );
 }
 
 async function sleep( durationInSeconds ) {
-	return new Promise( ( resolve ) =>
-		setTimeout( resolve, durationInSeconds * 1000 ) );
+	// Rule `no-restricted-syntax` recommends `waitForSelector` against
+	// `waitFor`, which isn't apt for the use case, when provided an integer,
+	// of waiting for a given amount of time.
+	// eslint-disable-next-line no-restricted-syntax
+	await page.waitFor( durationInSeconds * 1000 );
 }
 
 async function clearSessionStorage() {
@@ -153,11 +162,11 @@ describe( 'autosave', () => {
 	} );
 
 	it( 'should clear local autosave after successful remote autosave', async () => {
+		// Edit, save draft, edit again
 		await clickBlockAppender();
 		await page.keyboard.type( 'before save' );
-		await saveDraft();
-
-		await page.keyboard.type( 'after save' );
+		await saveDraftWithKeyboard();
+		await page.keyboard.type( ' after save' );
 
 		// Trigger local autosave
 		await page.evaluate( () => window.wp.data.dispatch( 'core/editor' ).__experimentalLocalAutosave() );
@@ -169,64 +178,52 @@ describe( 'autosave', () => {
 	} );
 
 	it( 'shouldn\'t clear local autosave if remote autosave fails', async () => {
+		// Edit, save draft, edit again
 		await clickBlockAppender();
 		await page.keyboard.type( 'before save' );
-		await saveDraft();
+		await saveDraftWithKeyboard();
+		await page.keyboard.type( ' after save' );
 
-		await page.keyboard.type( 'after save' );
+		// Trigger local autosave
 		await page.evaluate( () => window.wp.data.dispatch( 'core/editor' ).__experimentalLocalAutosave() );
 		expect( await page.evaluate( () => window.sessionStorage.length ) ).toBe( 1 );
 
+		// Bring network down and attempt to autosave remotely
 		toggleOfflineMode( true );
-
-		// Trigger remote autosave
 		await page.evaluate( () => window.wp.data.dispatch( 'core/editor' ).autosave() );
 		expect( await page.evaluate( () => window.sessionStorage.length ) ).toBe( 1 );
-
-		toggleOfflineMode( false );
 	} );
 
 	it( 'should clear local autosave after successful save', async () => {
+		// Edit, save draft, edit again
 		await clickBlockAppender();
 		await page.keyboard.type( 'before save' );
-		await saveDraft();
-
-		await page.keyboard.type( 'after save' );
+		await saveDraftWithKeyboard();
+		await page.keyboard.type( ' after save' );
 
 		// Trigger local autosave
-		expect( await page.evaluate( () => window.sessionStorage.length ) ).toBe( 0 );
 		await page.evaluate( () => window.wp.data.dispatch( 'core/editor' ).__experimentalLocalAutosave() );
 		expect( await page.evaluate( () => window.sessionStorage.length ) ).toBe( 1 );
 
-		// Save and wait for "Saved" to confirm save complete.
-		await Promise.all( [
-			page.waitForSelector( '.editor-post-saved-state.is-saved' ),
-			pressKeyWithModifier( 'primary', 'S' ),
-		] );
-
-		expect( await page.evaluate( () => window.sessionStorage.length ) ).toBe( 1 );
+		await saveDraftWithKeyboard();
+		expect( await page.evaluate( () => window.sessionStorage.length ) ).toBe( 0 );
 	} );
 
 	it( 'shouldn\'t clear local autosave if save fails', async () => {
+		// Edit, save draft, edit again
 		await clickBlockAppender();
 		await page.keyboard.type( 'before save' );
-		await saveDraft();
+		await saveDraftWithKeyboard();
+		await page.keyboard.type( ' after save' );
 
-		await page.keyboard.type( 'after save' );
+		// Trigger local autosave
 		await page.evaluate( () => window.wp.data.dispatch( 'core/editor' ).__experimentalLocalAutosave() );
 		expect( await page.evaluate( () => window.sessionStorage.length ) ).toBe( 1 );
 
+		// Bring network down and attempt to save
 		toggleOfflineMode( true );
-
-		// Save and wait for "Saved" to confirm save complete.
-		await Promise.all( [
-			page.waitForSelector( '.editor-post-saved-state.is-saved' ),
-			pressKeyWithModifier( 'primary', 'S' ),
-		] );
-
+		saveDraftWithKeyboard();
 		expect( await page.evaluate( () => window.sessionStorage.length ) ).toBe( 1 );
-
-		toggleOfflineMode( false );
 	} );
 
 	it( 'shouldn\'t conflict with server-side autosave', async () => {
@@ -264,7 +261,8 @@ describe( 'autosave', () => {
 		expect( notice ).toContain( AUTOSAVE_NOTICE_REMOTE );
 	} );
 
-	afterAll( async () => {
+	afterEach( async () => {
+		toggleOfflineMode( false );
 		await clearSessionStorage();
 	} );
 } );

--- a/packages/editor/src/components/local-autosave-monitor/index.js
+++ b/packages/editor/src/components/local-autosave-monitor/index.js
@@ -130,7 +130,12 @@ function useAutosavePurge() {
 	const lastIsAutosaving = useRef( isAutosaving );
 
 	useEffect( () => {
-		if ( lastIsAutosaving.current && ! isAutosaving && ! didError ) {
+		if (
+			! didError && (
+				( lastIsAutosaving.current && ! isAutosaving ) ||
+				( lastIsDirty.current && ! isDirty )
+			)
+		) {
 			localAutosaveClear( postId );
 		}
 


### PR DESCRIPTION
## Description

Presumably, somewhere in the fixing of conflicts between remote and local autosaves (purging local upon successful remote autosave, see #17501),`LocalAutosaveMonitor` stopped purging the local autosave upon successful *saves*.

## How has this been tested?
- Run expanded E2E test suite
- Try for yourself:
  - Open developer tools to monitor Session Storage under _Storage_
  - Edit a post, save (draft or published), make unsaved changes
  - Wait for local autosave to act and an item to appear in Session Storage
  - Save the changes, ensure Session Storage is cleared

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
