### PR TITLE
[RNMobile][FIX] Remove getItemLayout which causes scroll position issue

### DIFF
--- a/packages/block-editor/src/components/block-list/index.native.js
+++ b/packages/block-editor/src/components/block-list/index.native.js
@@ -96,9 +96,6 @@ export class BlockList extends Component {
 					ListHeaderComponent={ header }
 					ListEmptyComponent={ this.renderDefaultBlockAppender }
 					ListFooterComponent={ withFooter && this.renderBlockListFooter }
-					getItemLayout={ ( data, index ) => {
-						return { length: 0, offset: 0, index };
-					} }
 				/>
 
 				{ renderAppender && blockClientIds.length > 0 &&


### PR DESCRIPTION
## Description
During the `floatingToolbar` implementation we added a `getItemLayout` to the block-list component to make the floating toolbar clickable on Android (It's a hacky solution). However, it causes an issue with the scroll position after scrolling to the very bottom.
Please check this issue - https://github.com/wordpress-mobile/gutenberg-mobile/issues/1474
gutenberg-mobile PR - https://github.com/wordpress-mobile/gutenberg-mobile/pull/1478
Note: This fixes the scrolling issue but makes floating toolbar not clickable on Android, however, we are reimplementing the floating toolbar and we will not need this hack anymore.

## How has this been tested?
- In the android app, focus the first editable field you can find (example: the "What is Gutenberg?" heading block
- Scroll down, trying to reach the end of the content
- Wait and check if you still see the end of content (scroll position should not move up)


## Types of changes
In this PR I removed the `getItemLayout` to fix that scrolling issue.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
