### PR TITLE
NavigationMenu: <LinkControl /> integration.

### DIFF
--- a/packages/block-editor/src/components/link-control/README.md
+++ b/packages/block-editor/src/components/link-control/README.md
@@ -58,6 +58,19 @@ through of its function parameter.
 - Type: `Function`
 - Required: No
 
+Use this callback as an opportunity to know if the link has been changed because of user edition.
+The function callback will get selected item, or Null.
+
+```es6
+<LinkControl
+	onLinkChange={ ( item ) => {
+		item
+			? console.log( `The item selected has the ${ item.id } id.` )
+			: console.warn( 'No Item selected.' );
+	}
+/> 
+```  
+
 ### onSettingChange
 
 - Type: `Function`

--- a/packages/block-editor/src/components/link-control/README.md
+++ b/packages/block-editor/src/components/link-control/README.md
@@ -58,8 +58,8 @@ through of its function parameter.
 - Type: `Function`
 - Required: No
 
-Use this callback as an opportunity to know if the link has been changed because of user edition.
-The function callback will get selected item, or Null.
+Use this callback to take an action after a user set or updated a link.
+The function callback will receive the selected item, or Null.
 
 ```es6
 <LinkControl

--- a/packages/block-library/src/navigation-menu-item/block.json
+++ b/packages/block-library/src/navigation-menu-item/block.json
@@ -12,8 +12,14 @@
 		"title": {
 			"type": "string"
 		},
+		"type": {
+			"type": "string"
+		},
 		"description": {
 			"type": "string"
+		},
+		"link_id": {
+			"type": "number"
 		},
 		"opensInNewTab": {
 			"type": "boolean",

--- a/packages/block-library/src/navigation-menu-item/block.json
+++ b/packages/block-library/src/navigation-menu-item/block.json
@@ -18,7 +18,7 @@
 		"description": {
 			"type": "string"
 		},
-		"link_id": {
+		"linkId": {
 			"type": "number"
 		},
 		"opensInNewTab": {

--- a/packages/block-library/src/navigation-menu-item/edit.js
+++ b/packages/block-library/src/navigation-menu-item/edit.js
@@ -47,6 +47,8 @@ function NavigationMenuItemEdit( {
 	insertMenuItemBlock,
 	fetchSearchSuggestions,
 } ) {
+	const { label, link } = attributes;
+	const linkSettings = { 'new-tab': link.newTab };
 	const [ isLinkOpen, setIsLinkOpen ] = useState( false );
 
 	/**
@@ -80,9 +82,6 @@ function NavigationMenuItemEdit( {
 		setAttributes( { link: newlink } );
 	};
 
-	const { label, link } = attributes;
-	const initialLinkSetting = { 'new-tab': !! link ? link.newTab : false };
-
 	/**
 	 * It updates the link attribute when the
 	 * link settings changes.
@@ -112,17 +111,16 @@ function NavigationMenuItemEdit( {
 						onClick={ insertMenuItemBlock }
 					/>
 					{ isLinkOpen &&
-					<LinkControl
-						className="wp-block-navigation-menu-item__inline-link-input"
-						onKeyDown={ handleLinkControlOnKeyDown }
-						onKeyPress={ ( event ) => event.stopPropagation() }
-						onClose={ ( newlink ) => setAttributes( { link: newlink } ) }
-						currentLink={ link }
-						onLinkChange={ updateLink }
-						currentSettings={ initialLinkSetting }
-						onSettingsChange={ updateLinkSetting }
-						fetchSearchSuggestions={ fetchSearchSuggestions }
-					/>
+						<LinkControl
+							className="wp-block-navigation-menu-item__inline-link-input"
+							onKeyDown={ handleLinkControlOnKeyDown }
+							onKeyPress={ ( event ) => event.stopPropagation() }
+							currentLink={ link }
+							onLinkChange={ updateLink }
+							currentSettings={ linkSettings }
+							onSettingsChange={ updateLinkSetting }
+							fetchSearchSuggestions={ fetchSearchSuggestions }
+						/>
 					}
 				</Toolbar>
 			</BlockControls>

--- a/packages/block-library/src/navigation-menu-item/edit.js
+++ b/packages/block-library/src/navigation-menu-item/edit.js
@@ -91,13 +91,11 @@ function NavigationMenuItemEdit( {
 	 *
 	 * @param {Object|null} itemLink Link object if it has been selected. Otherwise, Null.
 	 */
-	const updateLink = ( itemLink ) => {
-		if ( ! itemLink ) {
-			// If not link, then set empty string to link attrs.
-			return setAttributes( { title: '', url: '' } );
-		}
-
-		setAttributes( { title: itemLink.title, url: itemLink.url } );
+	const updateLink = ( { title: newTitle = '', url: newURL = '' } = {} ) => {
+		setAttributes( {
+			title: newTitle,
+			url: newURL,
+		} );
 	};
 
 	/**

--- a/packages/block-library/src/navigation-menu-item/edit.js
+++ b/packages/block-library/src/navigation-menu-item/edit.js
@@ -47,7 +47,8 @@ function NavigationMenuItemEdit( {
 	insertMenuItemBlock,
 	fetchSearchSuggestions,
 } ) {
-	const { label, link } = attributes;
+	const { label, title, url } = attributes;
+	const link = { title, url };
 	const linkSettings = { 'new-tab': link.newTab };
 	const [ isLinkOpen, setIsLinkOpen ] = useState( false );
 
@@ -80,6 +81,8 @@ function NavigationMenuItemEdit( {
 			return;
 		}
 		setAttributes( { link: newlink } );
+		const { newTitle, newUrl } = newlink;
+		setAttributes( { title: newTitle, url: newUrl } );
 	};
 
 	/**
@@ -90,8 +93,9 @@ function NavigationMenuItemEdit( {
 	 * @param {string} value Setting type value.
 	 */
 	const updateLinkSetting = ( setting, value ) => {
-		const newTab = 'new-tab' === setting ? value : link.newTab;
-		setAttributes( { link: { ...link, newTab } } );
+		if ( 'new-tab' ) {
+			setAttributes( { opensInNewTab: value } );
+		}
 	};
 
 	return (
@@ -118,8 +122,8 @@ function NavigationMenuItemEdit( {
 				>
 					<ToggleControl
 						checked={ attributes.opensInNewTab }
-						onChange={ ( opensInNewTab ) => {
-							setAttributes( { opensInNewTab } );
+						onChange={ ( opensInNewTabSetting ) => {
+							setAttributes( { opensInNewTabSetting } );
 						} }
 						label={ __( 'Open in new tab' ) }
 					/>
@@ -136,8 +140,8 @@ function NavigationMenuItemEdit( {
 				>
 					<TextControl
 						value={ attributes.title || '' }
-						onChange={ ( title ) => {
-							setAttributes( { title } );
+						onChange={ ( newtTitle ) => {
+							setAttributes( { newtTitle } );
 						} }
 						label={ __( 'Title Attribute' ) }
 						help={ __( 'Provide more context about where the link goes.' ) }

--- a/packages/block-library/src/navigation-menu-item/edit.js
+++ b/packages/block-library/src/navigation-menu-item/edit.js
@@ -111,47 +111,6 @@ function NavigationMenuItemEdit( {
 		}
 	};
 
-	let content;
-	if ( isSelected ) {
-		content = (
-			<div className="wp-block-navigation-menu-item__field-container">
-				<TextControl
-					ref={ plainTextRef }
-					className="wp-block-navigation-menu-item__field"
-					value={ label }
-					onChange={ ( labelValue ) => setAttributes( { label: labelValue } ) }
-					label={ __( 'Navigation Label' ) }
-					hideLabelFromVision={ true }
-				/>
-				{ isLinkOpen &&
-					<LinkControl
-						className="wp-block-navigation-menu-item__inline-link-input"
-						onKeyDown={ handleLinkControlOnKeyDown }
-						onKeyPress={ ( event ) => event.stopPropagation() }
-						currentLink={ link }
-						onLinkChange={ updateLink }
-						onClose={ () => {
-							setWasCloseByLinkControl( true );
-							setIsLinkOpen( false );
-						} }
-						currentSettings={ { 'new-tab': opensInNewTab } }
-						onSettingsChange={ updateLinkSetting }
-
-					/>
-				}
-			</div>
-		);
-	} else {
-		content = (
-			<div className="wp-block-navigation-menu-item__container">
-				{ ( link && link.url ) && (
-					<span title={ link.url }>{ label }</span>
-				) }
-				{ ( ! link || ! link.url ) && label }
-			</div>
-		);
-	}
-
 	return (
 		<Fragment>
 			<BlockControls>

--- a/packages/block-library/src/navigation-menu-item/edit.js
+++ b/packages/block-library/src/navigation-menu-item/edit.js
@@ -74,7 +74,7 @@ function NavigationMenuItemEdit( {
 	 * For instance, it will block to move between menu items
 	 * when the LinkOver is focused.
 	 *
-	 * @param {Object} event
+	 * @param {Event} event
 	 */
 	const handleLinkControlOnKeyDown = ( event ) => {
 		const { keyCode } = event;
@@ -89,15 +89,14 @@ function NavigationMenuItemEdit( {
 	 * Updates the link attribute when it changes
 	 * through of the `onLinkChange` LinkControl callback.
 	 *
-	 * @param {Object|null} newlink The object link if it has been selected, or null.
+	 * @param {Object|null} itemLink Link object if it has been selected. Otherwise, Null.
 	 */
-	const updateLink = ( newlink ) => {
-		if ( ! newlink ) {
+	const updateLink = ( itemLink ) => {
+		if ( ! itemLink ) {
 			return;
 		}
-		setAttributes( { link: newlink } );
-		const { newTitle, newUrl } = newlink;
-		setAttributes( { title: newTitle, url: newUrl } );
+
+		setAttributes( { title: itemLink.title, url: itemLink.url } );
 	};
 
 	/**
@@ -145,8 +144,8 @@ function NavigationMenuItemEdit( {
 				>
 					<ToggleControl
 						checked={ attributes.opensInNewTab }
-						onChange={ ( opensInNewTabSetting ) => {
-							setAttributes( { opensInNewTabSetting } );
+						onChange={ ( newTab ) => {
+							setAttributes( { opensInNewTab: newTab } );
 						} }
 						label={ __( 'Open in new tab' ) }
 					/>
@@ -163,8 +162,8 @@ function NavigationMenuItemEdit( {
 				>
 					<TextControl
 						value={ attributes.title || '' }
-						onChange={ ( newtTitle ) => {
-							setAttributes( { newtTitle } );
+						onChange={ ( itemTitle ) => {
+							setAttributes( { title: itemTitle } );
 						} }
 						label={ __( 'Title Attribute' ) }
 						help={ __( 'Provide more context about where the link goes.' ) }

--- a/packages/block-library/src/navigation-menu-item/edit.js
+++ b/packages/block-library/src/navigation-menu-item/edit.js
@@ -50,7 +50,7 @@ function NavigationMenuItemEdit( {
 	const { label, opensInNewTab, title, url } = attributes;
 	const link = title ? { title, url } : null;
 	const [ isLinkOpen, setIsLinkOpen ] = useState( false );
-	const [ wasCloseByLinkControl, setWasCloseByLinkControl ] = useState( false );
+	const [ wasClosedByLinkControl, setWasClosedByLinkControl ] = useState( false );
 	const [ showFakePlaceholder, setShowFakePlaceholder ] = useState( false );
 
 	/**
@@ -60,12 +60,12 @@ function NavigationMenuItemEdit( {
 	useEffect( () => {
 		if ( ! isSelected ) {
 			setIsLinkOpen( false );
-			setWasCloseByLinkControl( false );
+			setWasClosedByLinkControl( false );
 			setShowFakePlaceholder( false );
 		}
 		return () => {
 			setIsLinkOpen( false );
-			setWasCloseByLinkControl( false );
+			setWasClosedByLinkControl( false );
 			setShowFakePlaceholder( false );
 		};
 	}, [ isSelected ] );
@@ -144,8 +144,8 @@ function NavigationMenuItemEdit( {
 						onClick={ () => {
 							// If the popover was closed by click outside,
 							// then there is not nothing to do here.
-							if ( wasCloseByLinkControl ) {
-								setWasCloseByLinkControl( false );
+							if ( wasClosedByLinkControl ) {
+								setWasClosedByLinkControl( false );
 								return;
 							}
 							setIsLinkOpen( ! isLinkOpen );
@@ -239,7 +239,7 @@ function NavigationMenuItemEdit( {
 						currentLink={ link }
 						onLinkChange={ updateLink }
 						onClose={ () => {
-							setWasCloseByLinkControl( true );
+							setWasClosedByLinkControl( true );
 							setIsLinkOpen( false );
 						} }
 						currentSettings={ { 'new-tab': opensInNewTab } }

--- a/packages/block-library/src/navigation-menu-item/edit.js
+++ b/packages/block-library/src/navigation-menu-item/edit.js
@@ -51,6 +51,7 @@ function NavigationMenuItemEdit( {
 	const link = title ? { title, url } : null;
 	const [ isLinkOpen, setIsLinkOpen ] = useState( false );
 	const [ wasCloseByLinkControl, setWasCloseByLinkControl ] = useState( false );
+	const [ showFakePlaceholder, setShowFakePlaceholder ] = useState( false );
 
 	/**
 	 * It's a kind of hack to handle closing the LinkControl popover
@@ -60,16 +61,23 @@ function NavigationMenuItemEdit( {
 		if ( ! isSelected ) {
 			setIsLinkOpen( false );
 			setWasCloseByLinkControl( false );
+			setShowFakePlaceholder( false );
 		}
 		return () => {
 			setIsLinkOpen( false );
 			setWasCloseByLinkControl( false );
+			setShowFakePlaceholder( false );
 		};
 	}, [ isSelected ] );
 
-	// Open the LinkControl popover if it's a new item.
+	// Set the menu item when it's new.
+	// - Open LinkControl popover.
+	// - Show a fake placeholder.
 	useEffect( () => {
-		if( ! label && isSelected ) { setIsLinkOpen( true ) }
+		if ( ! label && isSelected ) {
+			setIsLinkOpen( true );
+			setShowFakePlaceholder( true );
+		}
 	}, [] );
 
 
@@ -106,6 +114,7 @@ function NavigationMenuItemEdit( {
 		// Set the item label as well if it isn't already defined.
 		if ( ! label ) {
 			setAttributes( { label: newTitle } );
+			setShowFakePlaceholder( false );
 		}
 	};
 
@@ -121,6 +130,8 @@ function NavigationMenuItemEdit( {
 			setAttributes( { opensInNewTab: value } );
 		}
 	};
+
+	const itemLabelPlaceholder = __( 'Add item…' );
 
 	return (
 		<Fragment>
@@ -204,13 +215,22 @@ function NavigationMenuItemEdit( {
 					'is-selected': isSelected,
 				} ) }
 			>
-				<RichText
-					className="wp-block-navigation-menu-item__content"
-					value={ label }
-					onChange={ ( labelValue ) => setAttributes( { label: labelValue } ) }
-					placeholder={ __( 'Add item…' ) }
-					withoutInteractiveFormatting
-				/>
+				{ ( ! showFakePlaceholder ) && (
+					<RichText
+						className="wp-block-navigation-menu-item__content"
+						value={ label }
+						onChange={ ( labelValue ) => setAttributes( { label: labelValue } ) }
+						placeholder={ itemLabelPlaceholder }
+						withoutInteractiveFormatting
+					/>
+				) }
+
+				{ ( showFakePlaceholder ) && (
+					<div className="wp-block-navigation-menu-item__content">
+						{ itemLabelPlaceholder }
+					</div>
+				) }
+
 				{ isLinkOpen &&
 					<LinkControl
 						className="wp-block-navigation-menu-item__inline-link-input"

--- a/packages/block-library/src/navigation-menu-item/edit.js
+++ b/packages/block-library/src/navigation-menu-item/edit.js
@@ -67,6 +67,12 @@ function NavigationMenuItemEdit( {
 		};
 	}, [ isSelected ] );
 
+	// Open the LinkControl popover if it's a new item.
+	useEffect( () => {
+		if( ! label && isSelected ) { setIsLinkOpen( true ) }
+	}, [] );
+
+
 	/**
 	 * `onKeyDown` LinkControl handler.
 	 * It takes over to stop the event propagation to make the

--- a/packages/block-library/src/navigation-menu-item/edit.js
+++ b/packages/block-library/src/navigation-menu-item/edit.js
@@ -36,7 +36,7 @@ import {
 	RichText,
 	__experimentalLinkControl as LinkControl,
 } from '@wordpress/block-editor';
-import { Fragment, useState } from '@wordpress/element';
+import { Fragment, useState, useEffect } from '@wordpress/element';
 
 function NavigationMenuItemEdit( {
 	attributes,
@@ -47,10 +47,25 @@ function NavigationMenuItemEdit( {
 	insertMenuItemBlock,
 	fetchSearchSuggestions,
 } ) {
-	const { label, title, url } = attributes;
+	const { label, title, url, opensInNewTab } = attributes;
 	const link = { title, url };
-	const linkSettings = { 'new-tab': link.newTab };
 	const [ isLinkOpen, setIsLinkOpen ] = useState( false );
+	const [ wasCloseByLinkControl, setWasCloseByLinkControl ] = useState( false );
+
+	/**
+	 * It's a kind of hack to handle closing the LinkControl popover
+	 * clicking on the ToolbarButton link.
+	 */
+	useEffect( () => {
+		if ( ! isSelected ) {
+			setIsLinkOpen( false );
+			setWasCloseByLinkControl( false );
+		}
+		return () => {
+			setIsLinkOpen( false );
+			setWasCloseByLinkControl( false );
+		};
+	}, [ isSelected ] );
 
 	/**
 	 * `onKeyDown` LinkControl handler.
@@ -106,7 +121,15 @@ function NavigationMenuItemEdit( {
 						name="link"
 						icon="admin-links"
 						title={ __( 'Link' ) }
-						onClick={ () => setIsLinkOpen( ! isLinkOpen ) }
+						onClick={ () => {
+							// If the popover was closed by click outside,
+							// then there is not nothing to do here.
+							if ( wasCloseByLinkControl ) {
+								setWasCloseByLinkControl( false );
+								return;
+							}
+							setIsLinkOpen( ! isLinkOpen );
+						} }
 					/>
 					<ToolbarButton
 						name="submenu"
@@ -186,8 +209,11 @@ function NavigationMenuItemEdit( {
 						onKeyPress={ ( event ) => event.stopPropagation() }
 						currentLink={ link }
 						onLinkChange={ updateLink }
-						onClose={ () => setIsLinkOpen( false ) }
-						currentSettings={ linkSettings }
+						onClose={ () => {
+							setWasCloseByLinkControl( true );
+							setIsLinkOpen( false );
+						} }
+						currentSettings={ { 'new-tab': opensInNewTab } }
 						onSettingsChange={ updateLinkSetting }
 						fetchSearchSuggestions={ fetchSearchSuggestions }
 					/>

--- a/packages/block-library/src/navigation-menu-item/edit.js
+++ b/packages/block-library/src/navigation-menu-item/edit.js
@@ -47,8 +47,8 @@ function NavigationMenuItemEdit( {
 	insertMenuItemBlock,
 	fetchSearchSuggestions,
 } ) {
-	const { label, title, url, opensInNewTab } = attributes;
-	const link = { title, url };
+	const { label, opensInNewTab, title, url } = attributes;
+	const link = title ? { title, url } : null;
 	const [ isLinkOpen, setIsLinkOpen ] = useState( false );
 	const [ wasCloseByLinkControl, setWasCloseByLinkControl ] = useState( false );
 
@@ -93,7 +93,8 @@ function NavigationMenuItemEdit( {
 	 */
 	const updateLink = ( itemLink ) => {
 		if ( ! itemLink ) {
-			return;
+			// If not link, then set empty string to link attrs.
+			return setAttributes( { title: '', url: '' } );
 		}
 
 		setAttributes( { title: itemLink.title, url: itemLink.url } );

--- a/packages/block-library/src/navigation-menu-item/edit.js
+++ b/packages/block-library/src/navigation-menu-item/edit.js
@@ -96,6 +96,11 @@ function NavigationMenuItemEdit( {
 			title: newTitle,
 			url: newURL,
 		} );
+
+		// Set the item label as well if it isn't already defined.
+		if ( ! label ) {
+			setAttributes( { label: newTitle } );
+		}
 	};
 
 	/**

--- a/packages/block-library/src/navigation-menu-item/edit.js
+++ b/packages/block-library/src/navigation-menu-item/edit.js
@@ -117,6 +117,7 @@ function NavigationMenuItemEdit( {
 							onKeyPress={ ( event ) => event.stopPropagation() }
 							currentLink={ link }
 							onLinkChange={ updateLink }
+							onClose={ () => setIsLinkOpen( false ) }
 							currentSettings={ linkSettings }
 							onSettingsChange={ updateLinkSetting }
 							fetchSearchSuggestions={ fetchSearchSuggestions }

--- a/packages/block-library/src/navigation-menu-item/edit.js
+++ b/packages/block-library/src/navigation-menu-item/edit.js
@@ -93,6 +93,7 @@ function NavigationMenuItemEdit( {
 		const newTab = 'new-tab' === setting ? value : link.newTab;
 		setAttributes( { link: { ...link, newTab } } );
 	};
+
 	return (
 		<Fragment>
 			<BlockControls>

--- a/packages/block-library/src/navigation-menu-item/edit.js
+++ b/packages/block-library/src/navigation-menu-item/edit.js
@@ -113,6 +113,47 @@ function NavigationMenuItemEdit( {
 		}
 	};
 
+	let content;
+	if ( isSelected ) {
+		content = (
+			<div className="wp-block-navigation-menu-item__field-container">
+				<TextControl
+					ref={ plainTextRef }
+					className="wp-block-navigation-menu-item__field"
+					value={ label }
+					onChange={ ( labelValue ) => setAttributes( { label: labelValue } ) }
+					label={ __( 'Navigation Label' ) }
+					hideLabelFromVision={ true }
+				/>
+				{ isLinkOpen &&
+					<LinkControl
+						className="wp-block-navigation-menu-item__inline-link-input"
+						onKeyDown={ handleLinkControlOnKeyDown }
+						onKeyPress={ ( event ) => event.stopPropagation() }
+						currentLink={ link }
+						onLinkChange={ updateLink }
+						onClose={ () => {
+							setWasCloseByLinkControl( true );
+							setIsLinkOpen( false );
+						} }
+						currentSettings={ { 'new-tab': opensInNewTab } }
+						onSettingsChange={ updateLinkSetting }
+
+					/>
+				}
+			</div>
+		);
+	} else {
+		content = (
+			<div className="wp-block-navigation-menu-item__container">
+				{ ( link && link.url ) && (
+					<span title={ link.url }>{ label }</span>
+				) }
+				{ ( ! link || ! link.url ) && label }
+			</div>
+		);
+	}
+
 	return (
 		<Fragment>
 			<BlockControls>

--- a/packages/block-library/src/navigation-menu-item/edit.js
+++ b/packages/block-library/src/navigation-menu-item/edit.js
@@ -108,7 +108,7 @@ function NavigationMenuItemEdit( {
 	 * @param {string} value Setting type value.
 	 */
 	const updateLinkSetting = ( setting, value ) => {
-		if ( 'new-tab' ) {
+		if ( setting === 'new-tab' ) {
 			setAttributes( { opensInNewTab: value } );
 		}
 	};

--- a/packages/block-library/src/navigation-menu-item/edit.js
+++ b/packages/block-library/src/navigation-menu-item/edit.js
@@ -49,7 +49,7 @@ function NavigationMenuItemEdit( {
 } ) {
 	const { label, opensInNewTab, title, url } = attributes;
 	const link = title ? { title, url } : null;
-	const [ isLinkOpen, setIsLinkOpen ] = useState( false );
+	const [ isLinkOpen, setIsLinkOpen ] = useState( ! label && isSelected );
 	const [ wasClosedByLinkControl, setWasClosedByLinkControl ] = useState( false );
 
 	/**
@@ -66,12 +66,6 @@ function NavigationMenuItemEdit( {
 			setWasClosedByLinkControl( false );
 		};
 	}, [ isSelected ] );
-
-	// Set the menu item when it's new.
-	// - Open LinkControl popover.
-	useEffect( () => {
-		if ( ! label && isSelected ) setIsLinkOpen( true );
-	}, [] );
 
 	/**
 	 * `onKeyDown` LinkControl handler.

--- a/packages/block-library/src/navigation-menu-item/edit.js
+++ b/packages/block-library/src/navigation-menu-item/edit.js
@@ -51,7 +51,6 @@ function NavigationMenuItemEdit( {
 	const link = title ? { title, url } : null;
 	const [ isLinkOpen, setIsLinkOpen ] = useState( false );
 	const [ wasClosedByLinkControl, setWasClosedByLinkControl ] = useState( false );
-	const [ showFakePlaceholder, setShowFakePlaceholder ] = useState( false );
 
 	/**
 	 * It's a kind of hack to handle closing the LinkControl popover
@@ -61,25 +60,18 @@ function NavigationMenuItemEdit( {
 		if ( ! isSelected ) {
 			setIsLinkOpen( false );
 			setWasClosedByLinkControl( false );
-			setShowFakePlaceholder( false );
 		}
 		return () => {
 			setIsLinkOpen( false );
 			setWasClosedByLinkControl( false );
-			setShowFakePlaceholder( false );
 		};
 	}, [ isSelected ] );
 
 	// Set the menu item when it's new.
 	// - Open LinkControl popover.
-	// - Show a fake placeholder.
 	useEffect( () => {
-		if ( ! label && isSelected ) {
-			setIsLinkOpen( true );
-			setShowFakePlaceholder( true );
-		}
+		if ( ! label && isSelected ) setIsLinkOpen( true );
 	}, [] );
-
 
 	/**
 	 * `onKeyDown` LinkControl handler.
@@ -114,7 +106,6 @@ function NavigationMenuItemEdit( {
 		// Set the item label as well if it isn't already defined.
 		if ( ! label ) {
 			setAttributes( { label: newTitle } );
-			setShowFakePlaceholder( false );
 		}
 	};
 
@@ -215,21 +206,13 @@ function NavigationMenuItemEdit( {
 					'is-selected': isSelected,
 				} ) }
 			>
-				{ ( ! showFakePlaceholder ) && (
-					<RichText
-						className="wp-block-navigation-menu-item__content"
-						value={ label }
-						onChange={ ( labelValue ) => setAttributes( { label: labelValue } ) }
-						placeholder={ itemLabelPlaceholder }
-						withoutInteractiveFormatting
-					/>
-				) }
-
-				{ ( showFakePlaceholder ) && (
-					<div className="wp-block-navigation-menu-item__content">
-						{ itemLabelPlaceholder }
-					</div>
-				) }
+				<RichText
+					className="wp-block-navigation-menu-item__content"
+					value={ label }
+					onChange={ ( labelValue ) => setAttributes( { label: labelValue } ) }
+					placeholder={ itemLabelPlaceholder }
+					withoutInteractiveFormatting
+				/>
 
 				{ isLinkOpen &&
 					<LinkControl

--- a/packages/block-library/src/navigation-menu-item/edit.js
+++ b/packages/block-library/src/navigation-menu-item/edit.js
@@ -97,7 +97,7 @@ function NavigationMenuItemEdit( {
 	 * It takes over to stop the event propagation to make the
 	 * navigation work, avoiding undesired behaviors.
 	 * For instance, it will block to move between menu items
-	 * when the LinkOver is focused.
+	 * when the LinkControl is focused.
 	 *
 	 * @param {Event} event
 	 */

--- a/packages/block-library/src/navigation-menu-item/edit.js
+++ b/packages/block-library/src/navigation-menu-item/edit.js
@@ -81,6 +81,8 @@ function NavigationMenuItemEdit( {
 	const link = title ? { title, url } : null;
 	const [ isLinkOpen, setIsLinkOpen ] = useState( ! label && isSelected );
 
+	let onCloseTimerId = null;
+
 	/**
 	 * It's a kind of hack to handle closing the LinkControl popover
 	 * clicking on the ToolbarButton link.
@@ -89,6 +91,13 @@ function NavigationMenuItemEdit( {
 		if ( ! isSelected ) {
 			setIsLinkOpen( false );
 		}
+
+		return () => {
+			// Clear LinkControl.OnClose timeout.
+			if ( onCloseTimerId ) {
+				clearTimeout( onCloseTimerId );
+			}
+		};
 	}, [ isSelected ] );
 
 	/**
@@ -205,7 +214,9 @@ function NavigationMenuItemEdit( {
 							onKeyPress={ ( event ) => event.stopPropagation() }
 							currentLink={ link }
 							onLinkChange={ updateLink( setAttributes, label ) }
-							onClose={ () => setTimeout( () => setIsLinkOpen( false ), 100 ) }
+							onClose={ () => {
+								onCloseTimerId = setTimeout( () => setIsLinkOpen( false ), 100 );
+							} }
 							currentSettings={ { 'new-tab': opensInNewTab } }
 							onSettingsChange={ updateLinkSetting( setAttributes ) }
 						/>

--- a/packages/block-library/src/navigation-menu-item/edit.js
+++ b/packages/block-library/src/navigation-menu-item/edit.js
@@ -42,8 +42,7 @@ import { Fragment, useState, useEffect } from '@wordpress/element';
  * It updates the link attribute when the
  * link settings changes.
  *
- * @param {string} setting Setting type, for instance, `new-tab`.
- * @param {string} value Setting type value.
+ * @param {Function} setter Setter attribute function.
  */
 const updateLinkSetting = ( setter ) => ( setting, value ) => {
 	if ( setting === 'new-tab' ) {
@@ -55,7 +54,8 @@ const updateLinkSetting = ( setter ) => ( setting, value ) => {
  * Updates the link attribute when it changes
  * through of the `onLinkChange` LinkControl callback.
  *
- * @param {Object|null} itemLink Link object if it has been selected. Otherwise, Null.
+ * @param {Function} setter Setter attribute function.
+ * @param {string} label ItemMenu link label.
  */
 const updateLink = ( setter, label ) => ( { title: newTitle = '', url: newURL = '' } = {} ) => {
 	setter( {

--- a/packages/block-library/src/navigation-menu-item/edit.js
+++ b/packages/block-library/src/navigation-menu-item/edit.js
@@ -121,7 +121,6 @@ function NavigationMenuItemEdit( {
 						icon="admin-links"
 						title={ __( 'Link' ) }
 						onClick={ () => {
-							// It works together with LinkControl onCLose event.
 							if ( isLinkOpen ) {
 								return;
 							}

--- a/packages/block-library/src/navigation-menu-item/edit.js
+++ b/packages/block-library/src/navigation-menu-item/edit.js
@@ -38,6 +38,37 @@ import {
 } from '@wordpress/block-editor';
 import { Fragment, useState, useEffect } from '@wordpress/element';
 
+/**
+ * It updates the link attribute when the
+ * link settings changes.
+ *
+ * @param {string} setting Setting type, for instance, `new-tab`.
+ * @param {string} value Setting type value.
+ */
+const updateLinkSetting = ( setter ) => ( setting, value ) => {
+	if ( setting === 'new-tab' ) {
+		setter( { opensInNewTab: value } );
+	}
+};
+
+/**
+ * Updates the link attribute when it changes
+ * through of the `onLinkChange` LinkControl callback.
+ *
+ * @param {Object|null} itemLink Link object if it has been selected. Otherwise, Null.
+ */
+const updateLink = ( setter, label ) => ( { title: newTitle = '', url: newURL = '' } = {} ) => {
+	setter( {
+		title: newTitle,
+		url: newURL,
+	} );
+
+	// Set the item label as well if it isn't already defined.
+	if ( ! label ) {
+		setter( { label: newTitle } );
+	}
+};
+
 function NavigationMenuItemEdit( {
 	attributes,
 	hasDescendants,
@@ -81,37 +112,6 @@ function NavigationMenuItemEdit( {
 		if ( [ LEFT, DOWN, RIGHT, UP, BACKSPACE, ENTER ].indexOf( keyCode ) > -1 ) {
 			// Stop the key event from propagating up to ObserveTyping.startTypingInTextField.
 			event.stopPropagation();
-		}
-	};
-
-	/**
-	 * Updates the link attribute when it changes
-	 * through of the `onLinkChange` LinkControl callback.
-	 *
-	 * @param {Object|null} itemLink Link object if it has been selected. Otherwise, Null.
-	 */
-	const updateLink = ( { title: newTitle = '', url: newURL = '' } = {} ) => {
-		setAttributes( {
-			title: newTitle,
-			url: newURL,
-		} );
-
-		// Set the item label as well if it isn't already defined.
-		if ( ! label ) {
-			setAttributes( { label: newTitle } );
-		}
-	};
-
-	/**
-	 * It updates the link attribute when the
-	 * link settings changes.
-	 *
-	 * @param {string} setting Setting type, for instance, `new-tab`.
-	 * @param {string} value Setting type value.
-	 */
-	const updateLinkSetting = ( setting, value ) => {
-		if ( setting === 'new-tab' ) {
-			setAttributes( { opensInNewTab: value } );
 		}
 	};
 
@@ -213,13 +213,13 @@ function NavigationMenuItemEdit( {
 						onKeyDown={ handleLinkControlOnKeyDown }
 						onKeyPress={ ( event ) => event.stopPropagation() }
 						currentLink={ link }
-						onLinkChange={ updateLink }
+						onLinkChange={ updateLink( setAttributes, label ) }
 						onClose={ () => {
 							setWasClosedByLinkControl( true );
 							setIsLinkOpen( false );
 						} }
 						currentSettings={ { 'new-tab': opensInNewTab } }
-						onSettingsChange={ updateLinkSetting }
+						onSettingsChange={ updateLinkSetting( setAttributes ) }
 						fetchSearchSuggestions={ fetchSearchSuggestions }
 					/>
 				}

--- a/packages/block-library/src/navigation-menu-item/edit.js
+++ b/packages/block-library/src/navigation-menu-item/edit.js
@@ -191,27 +191,28 @@ function NavigationMenuItemEdit( {
 					'is-selected': isSelected,
 				} ) }
 			>
-				<RichText
-					className="wp-block-navigation-menu-item__content"
-					value={ label }
-					onChange={ ( labelValue ) => setAttributes( { label: labelValue } ) }
-					placeholder={ itemLabelPlaceholder }
-					withoutInteractiveFormatting
-				/>
-
-				{ isLinkOpen &&
-					<LinkControl
-						className="wp-block-navigation-menu-item__inline-link-input"
-						onKeyDown={ handleLinkControlOnKeyDown }
-						onKeyPress={ ( event ) => event.stopPropagation() }
-						currentLink={ link }
-						onLinkChange={ updateLink( setAttributes, label ) }
-						onClose={ () => setTimeout( () => setIsLinkOpen( false ), 100 ) }
-						currentSettings={ { 'new-tab': opensInNewTab } }
-						onSettingsChange={ updateLinkSetting( setAttributes ) }
-						fetchSearchSuggestions={ fetchSearchSuggestions }
+				<div className="wp-block-navigation-menu-item__inner">
+					<RichText
+						className="wp-block-navigation-menu-item__content"
+						value={ label }
+						onChange={ ( labelValue ) => setAttributes( { label: labelValue } ) }
+						placeholder={ itemLabelPlaceholder }
+						withoutInteractiveFormatting
 					/>
-				}
+					{ isLinkOpen && (
+						<LinkControl
+							className="wp-block-navigation-menu-item__inline-link-input"
+							onKeyDown={ handleLinkControlOnKeyDown }
+							onKeyPress={ ( event ) => event.stopPropagation() }
+							currentLink={ link }
+							onLinkChange={ updateLink( setAttributes, label ) }
+							onClose={ () => setTimeout( () => setIsLinkOpen( false ), 100 ) }
+							currentSettings={ { 'new-tab': opensInNewTab } }
+							onSettingsChange={ updateLinkSetting( setAttributes ) }
+							fetchSearchSuggestions={ fetchSearchSuggestions }
+						/>
+					) }
+				</div>
 				<InnerBlocks
 					allowedBlocks={ [ 'core/navigation-menu-item' ] }
 					renderAppender={ hasDescendants ? InnerBlocks.ButtonBlockAppender : false }

--- a/packages/block-library/src/navigation-menu-item/edit.js
+++ b/packages/block-library/src/navigation-menu-item/edit.js
@@ -93,7 +93,6 @@ function NavigationMenuItemEdit( {
 		const newTab = 'new-tab' === setting ? value : link.newTab;
 		setAttributes( { link: { ...link, newTab } } );
 	};
-
 	return (
 		<Fragment>
 			<BlockControls>
@@ -110,19 +109,6 @@ function NavigationMenuItemEdit( {
 						title={ __( 'Add submenu item' ) }
 						onClick={ insertMenuItemBlock }
 					/>
-					{ isLinkOpen &&
-						<LinkControl
-							className="wp-block-navigation-menu-item__inline-link-input"
-							onKeyDown={ handleLinkControlOnKeyDown }
-							onKeyPress={ ( event ) => event.stopPropagation() }
-							currentLink={ link }
-							onLinkChange={ updateLink }
-							onClose={ () => setIsLinkOpen( false ) }
-							currentSettings={ linkSettings }
-							onSettingsChange={ updateLinkSetting }
-							fetchSearchSuggestions={ fetchSearchSuggestions }
-						/>
-					}
 				</Toolbar>
 			</BlockControls>
 			<InspectorControls>
@@ -188,6 +174,19 @@ function NavigationMenuItemEdit( {
 					placeholder={ __( 'Add item…' ) }
 					withoutInteractiveFormatting
 				/>
+				{ isLinkOpen &&
+					<LinkControl
+						className="wp-block-navigation-menu-item__inline-link-input"
+						onKeyDown={ handleLinkControlOnKeyDown }
+						onKeyPress={ ( event ) => event.stopPropagation() }
+						currentLink={ link }
+						onLinkChange={ updateLink }
+						onClose={ () => setIsLinkOpen( false ) }
+						currentSettings={ linkSettings }
+						onSettingsChange={ updateLinkSetting }
+						fetchSearchSuggestions={ fetchSearchSuggestions }
+					/>
+				}
 				<InnerBlocks
 					allowedBlocks={ [ 'core/navigation-menu-item' ] }
 					renderAppender={ hasDescendants ? InnerBlocks.ButtonBlockAppender : false }

--- a/packages/block-library/src/navigation-menu-item/edit.js
+++ b/packages/block-library/src/navigation-menu-item/edit.js
@@ -76,7 +76,6 @@ function NavigationMenuItemEdit( {
 	isParentOfSelectedBlock,
 	setAttributes,
 	insertMenuItemBlock,
-	fetchSearchSuggestions,
 } ) {
 	const { label, opensInNewTab, title, url } = attributes;
 	const link = title ? { title, url } : null;
@@ -209,7 +208,6 @@ function NavigationMenuItemEdit( {
 							onClose={ () => setTimeout( () => setIsLinkOpen( false ), 100 ) }
 							currentSettings={ { 'new-tab': opensInNewTab } }
 							onSettingsChange={ updateLinkSetting( setAttributes ) }
-							fetchSearchSuggestions={ fetchSearchSuggestions }
 						/>
 					) }
 				</div>
@@ -224,13 +222,12 @@ function NavigationMenuItemEdit( {
 
 export default compose( [
 	withSelect( ( select, ownProps ) => {
-		const { getClientIdsOfDescendants, hasSelectedInnerBlock, getSettings } = select( 'core/block-editor' );
+		const { getClientIdsOfDescendants, hasSelectedInnerBlock } = select( 'core/block-editor' );
 		const { clientId } = ownProps;
 
 		return {
 			isParentOfSelectedBlock: hasSelectedInnerBlock( clientId, true ),
 			hasDescendants: !! getClientIdsOfDescendants( [ clientId ] ).length,
-			fetchSearchSuggestions: getSettings().__experimentalFetchLinkSuggestions,
 		};
 	} ),
 	withDispatch( ( dispatch, ownProps ) => {

--- a/packages/block-library/src/navigation-menu-item/edit.js
+++ b/packages/block-library/src/navigation-menu-item/edit.js
@@ -81,7 +81,6 @@ function NavigationMenuItemEdit( {
 	const { label, opensInNewTab, title, url } = attributes;
 	const link = title ? { title, url } : null;
 	const [ isLinkOpen, setIsLinkOpen ] = useState( ! label && isSelected );
-	const [ wasClosedByLinkControl, setWasClosedByLinkControl ] = useState( false );
 
 	/**
 	 * It's a kind of hack to handle closing the LinkControl popover
@@ -90,11 +89,7 @@ function NavigationMenuItemEdit( {
 	useEffect( () => {
 		if ( ! isSelected ) {
 			setIsLinkOpen( false );
-			setWasClosedByLinkControl( false );
 		}
-		return () => {
-			setWasClosedByLinkControl( false );
-		};
 	}, [ isSelected ] );
 
 	/**
@@ -126,10 +121,8 @@ function NavigationMenuItemEdit( {
 						icon="admin-links"
 						title={ __( 'Link' ) }
 						onClick={ () => {
-							// If the popover was closed by click outside,
-							// then there is not nothing to do here.
-							if ( wasClosedByLinkControl ) {
-								setWasClosedByLinkControl( false );
+							// It works together with LinkControl onCLose event.
+							if ( isLinkOpen ) {
 								return;
 							}
 							setIsLinkOpen( ! isLinkOpen );
@@ -214,10 +207,7 @@ function NavigationMenuItemEdit( {
 						onKeyPress={ ( event ) => event.stopPropagation() }
 						currentLink={ link }
 						onLinkChange={ updateLink( setAttributes, label ) }
-						onClose={ () => {
-							setWasClosedByLinkControl( true );
-							setIsLinkOpen( false );
-						} }
+						onClose={ () => setTimeout( () => setIsLinkOpen( false ), 100 ) }
 						currentSettings={ { 'new-tab': opensInNewTab } }
 						onSettingsChange={ updateLinkSetting( setAttributes ) }
 						fetchSearchSuggestions={ fetchSearchSuggestions }

--- a/packages/block-library/src/navigation-menu-item/edit.js
+++ b/packages/block-library/src/navigation-menu-item/edit.js
@@ -62,7 +62,6 @@ function NavigationMenuItemEdit( {
 			setWasClosedByLinkControl( false );
 		}
 		return () => {
-			setIsLinkOpen( false );
 			setWasClosedByLinkControl( false );
 		};
 	}, [ isSelected ] );

--- a/packages/block-library/src/navigation-menu-item/editor.scss
+++ b/packages/block-library/src/navigation-menu-item/editor.scss
@@ -71,6 +71,10 @@
 
 	&:focus {
 		color: var(--color-menu-link);
+
+		.components-external-link {
+			color: var(--color-menu-link);
+		}
 	}
 }
 

--- a/packages/block-library/src/navigation-menu-item/editor.scss
+++ b/packages/block-library/src/navigation-menu-item/editor.scss
@@ -70,6 +70,10 @@
 		background-color: var(--background-color-menu-link);
 		color: var(--color-menu-link);
 		width: inherit;
+
+		.components-external-link {
+			color: var(--color-menu-link);
+		}
 	}
 
 	&.is-editing .components-text-control__input {

--- a/packages/block-library/src/navigation-menu-item/editor.scss
+++ b/packages/block-library/src/navigation-menu-item/editor.scss
@@ -88,6 +88,13 @@
 			}
 		}
 	}
+
+	&.is-editing,
+	&.is-selected {
+		box-shadow: 0 0 1px $light-gray-900 inset;
+		border-radius: 4px;
+		min-width: 30px;
+	}
 }
 
 .wp-block-navigation-menu-item__nofollow-external-link {

--- a/packages/block-library/src/navigation-menu-item/editor.scss
+++ b/packages/block-library/src/navigation-menu-item/editor.scss
@@ -64,16 +64,24 @@
 }
 
 .wp-block-navigation-menu-item {
-	font-family: inherit;
-	font-size: inherit;
-	background-color: var(--background-color-menu-link);
-	color: var(--color-menu-link);
+	&:not(.is-editing) {
+		font-family: inherit;
+		font-size: inherit;
+		background-color: var(--background-color-menu-link);
+		color: var(--color-menu-link);
+		width: inherit;
+	}
 
-	&:focus {
+	&.is-editing .components-text-control__input {
+		width: inherit;
+		background-color: var(--background-color-menu-link);
 		color: var(--color-menu-link);
 
 		.components-external-link {
 			color: var(--color-menu-link);
+			&:focus {
+				color: var(--color-menu-link);
+			}
 		}
 	}
 }

--- a/packages/block-library/src/navigation-menu/edit.js
+++ b/packages/block-library/src/navigation-menu/edit.js
@@ -60,7 +60,7 @@ function NavigationMenu( {
 					type,
 					link_id: id,
 					url: link,
-					newTab: false,
+					opensInNewTab: false,
 				} ]
 			) );
 		},

--- a/packages/block-library/src/navigation-menu/edit.js
+++ b/packages/block-library/src/navigation-menu/edit.js
@@ -52,12 +52,10 @@ function NavigationMenu( {
 				return null;
 			}
 
-			// Disable camelcase because of permalink_template.
-			/* eslint-disable camelcase */
-			return pages.map( ( { title, permalink_template, type, link, id } ) => (
+			return pages.map( ( { title, permalink_template: destination, type, link, id } ) => (
 				[ 'core/navigation-menu-item', {
 					label: title.rendered,
-					destination: permalink_template,
+					destination,
 					title: title.raw,
 					type,
 					link_id: id,
@@ -65,7 +63,6 @@ function NavigationMenu( {
 					newTab: false,
 				} ]
 			) );
-			/* eslint-enable camelcase */
 		},
 		[ pages ]
 	);

--- a/packages/block-library/src/navigation-menu/edit.js
+++ b/packages/block-library/src/navigation-menu/edit.js
@@ -58,7 +58,7 @@ function NavigationMenu( {
 					destination,
 					title: title.raw,
 					type,
-					link_id: id,
+					linkId: id,
 					url: link,
 					opensInNewTab: false,
 				} ]

--- a/packages/block-library/src/navigation-menu/edit.js
+++ b/packages/block-library/src/navigation-menu/edit.js
@@ -52,14 +52,13 @@ function NavigationMenu( {
 				return null;
 			}
 
-			return pages.map( ( { title, permalink_template: destination, type, link, id } ) => (
+			return pages.map( ( { title, type, link: url, id: linkId } ) => (
 				[ 'core/navigation-menu-item', {
 					label: title.rendered,
-					destination,
 					title: title.raw,
 					type,
-					linkId: id,
-					url: link,
+					linkId,
+					url,
 					opensInNewTab: false,
 				} ]
 			) );

--- a/packages/block-library/src/navigation-menu/edit.js
+++ b/packages/block-library/src/navigation-menu/edit.js
@@ -52,7 +52,9 @@ function NavigationMenu( {
 				return null;
 			}
 
-			return pages.map( ( { title, permalink_template, type, link, id  } ) => (
+			// Disable camelcase because of permalink_template.
+			/* eslint-disable camelcase */
+			return pages.map( ( { title, permalink_template, type, link, id } ) => (
 				[ 'core/navigation-menu-item', {
 					label: title.rendered,
 					destination: permalink_template,
@@ -63,6 +65,7 @@ function NavigationMenu( {
 					newTab: false,
 				} ]
 			) );
+			/* eslint-enable camelcase */
 		},
 		[ pages ]
 	);

--- a/packages/block-library/src/navigation-menu/edit.js
+++ b/packages/block-library/src/navigation-menu/edit.js
@@ -51,11 +51,18 @@ function NavigationMenu( {
 			if ( ! pages ) {
 				return null;
 			}
-			return pages.map( ( page ) => {
-				return [ 'core/navigation-menu-item',
-					{ label: page.title.rendered, url: page.permalink_template },
-				];
-			} );
+
+			return pages.map( ( { title, permalink_template, type, link, id  } ) => (
+				[ 'core/navigation-menu-item', {
+					label: title.rendered,
+					destination: permalink_template,
+					title: title.raw,
+					type,
+					link_id: id,
+					url: link,
+					newTab: false,
+				} ]
+			) );
 		},
 		[ pages ]
 	);

--- a/packages/block-library/src/navigation-menu/index.php
+++ b/packages/block-library/src/navigation-menu/index.php
@@ -97,22 +97,33 @@ function build_navigation_menu_html( $block, $colors ) {
 	$html = '';
 	foreach ( (array) $block['innerBlocks'] as $key => $menu_item ) {
 
+		$opens_in_new_tab = isset( $menu_item['attrs']['opensInNewTab'] ) ?? false;
+
 		$html .= '<li class="wp-block-navigation-menu-item ' . $colors['bg_css_classes'] . '"' . $colors['bg_inline_styles'] . '>' .
 			'<a
 				class="wp-block-navigation-menu-item__link ' . $colors['text_css_classes'] . '"
 				' . $colors['text_inline_styles'];
 
+		// Start appending HTML attributes to anchor tag
 		if ( isset( $menu_item['attrs']['url'] ) ) {
 			$html .= ' href="' . $menu_item['attrs']['url'] . '"';
 		}
 		if ( isset( $menu_item['attrs']['title'] ) ) {
 			$html .= ' title="' . $menu_item['attrs']['title'] . '"';
 		}
+
+		if ( isset( $menu_item['attrs']['opensInNewTab'] ) && true == $menu_item['attrs']['opensInNewTab'] ) {
+			$html .= ' target="_blank"  ';
+		}
+		// End appending HTML attributes to anchor tag
+
+		// Start anchor tag content
 		$html .= '>';
 		if ( isset( $menu_item['attrs']['label'] ) ) {
 			$html .= $menu_item['attrs']['label'];
 		}
 		$html .= '</a>';
+		// End anchor tag content
 
 		if ( count( (array) $menu_item['innerBlocks'] ) > 0 ) {
 			$html .= build_navigation_menu_html( $menu_item, $colors );

--- a/packages/block-library/src/navigation-menu/index.php
+++ b/packages/block-library/src/navigation-menu/index.php
@@ -97,14 +97,12 @@ function build_navigation_menu_html( $block, $colors ) {
 	$html = '';
 	foreach ( (array) $block['innerBlocks'] as $key => $menu_item ) {
 
-		$opens_in_new_tab = isset( $menu_item['attrs']['opensInNewTab'] ) ?? false;
-
 		$html .= '<li class="wp-block-navigation-menu-item ' . $colors['bg_css_classes'] . '"' . $colors['bg_inline_styles'] . '>' .
 			'<a
 				class="wp-block-navigation-menu-item__link ' . $colors['text_css_classes'] . '"
 				' . $colors['text_inline_styles'];
 
-		// Start appending HTML attributes to anchor tag
+		// Start appending HTML attributes to anchor tag.
 		if ( isset( $menu_item['attrs']['url'] ) ) {
 			$html .= ' href="' . $menu_item['attrs']['url'] . '"';
 		}
@@ -112,18 +110,18 @@ function build_navigation_menu_html( $block, $colors ) {
 			$html .= ' title="' . $menu_item['attrs']['title'] . '"';
 		}
 
-		if ( isset( $menu_item['attrs']['opensInNewTab'] ) && true == $menu_item['attrs']['opensInNewTab'] ) {
+		if ( isset( $menu_item['attrs']['opensInNewTab'] ) && true === $menu_item['attrs']['opensInNewTab'] ) {
 			$html .= ' target="_blank"  ';
 		}
-		// End appending HTML attributes to anchor tag
+		// End appending HTML attributes to anchor tag.
 
-		// Start anchor tag content
+		// Start anchor tag content.
 		$html .= '>';
 		if ( isset( $menu_item['attrs']['label'] ) ) {
 			$html .= $menu_item['attrs']['label'];
 		}
 		$html .= '</a>';
-		// End anchor tag content
+		// End anchor tag content.
 
 		if ( count( (array) $menu_item['innerBlocks'] ) > 0 ) {
 			$html .= build_navigation_menu_html( $menu_item, $colors );


### PR DESCRIPTION
## Description

`< LinkControl />` and `<NavigationItemMenu />` integration.
This branch contains changes of both respective branches: ~https://github.com/WordPress/gutenberg/pull/17986~ https://github.com/WordPress/gutenberg/pull/17846

![nav-menu-empty-link](https://user-images.githubusercontent.com/77539/67990854-ed76a800-fc15-11e9-8b06-7eef4aa62ccc.gif)



## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## TODOs

- [x] Replace `URLInput` by `LinkControl`
- [x] Fix some of the linting errors
- [x] Store link value and settings in local state
- [x] When inserting a new menu item — or when the link attribute is empty in general — focusing on the text should open the link menu as the primary interaction.
- [x] Clicking "Change" actually removes the link, which is pretty destructive — pressing escape just leaves an empty link. I think "Change" should still have the field populated with the current URL.
- [x] When there is no placeholder you don't know if the RichText has focus.
- [x] After adding a link and clicking the label, the link editor disappears but then you have to click the link toolbar button twice to get the link editor back.

The following issues will be handled in a separated PR:

* First time the link menu opens, the loading indicator is cut off:
* It seems typing in the link field triggers "is typing", which feels a bit odd since the toolbar and movers disappear.
* We should support Command/Ctrl+K to open the link flow.


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->