### PR TITLE
Navigation: Explore using Walker_Nav_Menu

### DIFF
--- a/packages/block-library/src/navigation-menu/index.php
+++ b/packages/block-library/src/navigation-menu/index.php
@@ -16,11 +16,11 @@ function block_navigation_colors( $attributes ) {
 	// CSS classes.
 	$colors = array(
 		'classes' => array(),
-		'style' => '',
+		'style'   => '',
 	);
 
 	// Background color.
-	// Background color - has text color.
+	// Background color - has background color.
 	if ( array_key_exists( 'backgroundColor', $attributes ) ) {
 		$colors['classes'][] = 'has-background-color';
 	}
@@ -74,7 +74,12 @@ function render_block_navigation_menu( $attributes, $content, $block ) {
 	);
 
 	add_filter( 'nav_menu_link_attributes', 'block_navigation_link_attributes', 10, 2 );
-	return '<nav class="wp-block-navigation-menu" style="' . esc_attr( $colors['style'] ) . '"><ul class="menu">' . walk_nav_menu_tree( $items, 0, $args ) . '</ul></nav>';
+
+	return sprintf(
+		'<nav class="wp-block-navigation-menu" style="%1$s"><ul class="menu">%2$s</ul></nav>',
+		esc_attr( $colors['style'] ),
+		walk_nav_menu_tree( $items, 0, $args )
+	);
 }
 
 /**
@@ -125,7 +130,7 @@ function setup_block_nav_items( $block, $colors ) {
 
 		$nav_menu_item['ID']         = $menu_item_id;
 		$nav_menu_item['post_title'] = $inner_block['attrs']['label'];
-		$nav_menu_item['url']        = $inner_block['attrs']['destination'] ?? '#';
+		$nav_menu_item['url']        = $inner_block['attrs']['url'] ?? '#';
 
 		++$menu_item_id;
 		$nav_menu_items[] = (object) $nav_menu_item;

--- a/packages/block-library/src/navigation-menu/index.php
+++ b/packages/block-library/src/navigation-menu/index.php
@@ -128,6 +128,10 @@ function setup_block_nav_items( $block, $colors ) {
 			continue;
 		}
 
+		if ( ! empty( $sub_menu_items ) ) {
+			$nav_menu_item['classes'][] = 'menu-item-has-children';
+		}
+
 		$nav_menu_item['ID']         = $menu_item_id;
 		$nav_menu_item['post_title'] = $inner_block['attrs']['label'];
 		$nav_menu_item['url']        = $inner_block['attrs']['url'] ?? '#';

--- a/packages/block-library/src/navigation-menu/index.php
+++ b/packages/block-library/src/navigation-menu/index.php
@@ -104,8 +104,8 @@ function block_navigation_link_attributes( $attributes, $item ) {
  * @param array $colors Custom colors classes and styles.
  * @return array Menu items
  */
-function setup_block_nav_items( $block, $colors ) {
-	static $menu_item_id = 1;
+function setup_block_nav_items( $block, $colors, $parent_id = 0 ) {
+	static $menu_item_id = 0;
 	$nav_menu_items = array();
 	$nav_menu_item  = array(
 		'classes'       => $colors['classes'],
@@ -118,26 +118,26 @@ function setup_block_nav_items( $block, $colors ) {
 	);
 
 	foreach ( $block['innerBlocks'] as $inner_block ) {
-		$sub_menu_items = setup_block_nav_items( $inner_block, $colors );
-		foreach ( $sub_menu_items as $sub_menu_item ) {
-			$sub_menu_item->menu_item_parent = $menu_item_id;
-			$nav_menu_items[]                = $sub_menu_item;
-		}
-
 		if ( empty( $inner_block['attrs']['label'] ) ) {
 			continue;
 		}
+
+		$nav_menu_item['ID']         = ++$menu_item_id;
+		$nav_menu_item['post_title'] = $inner_block['attrs']['label'];
+		$nav_menu_item['url']        = $inner_block['attrs']['url'] ?? '#';
 
 		if ( ! empty( $sub_menu_items ) ) {
 			$nav_menu_item['classes'][] = 'menu-item-has-children';
 		}
 
-		$nav_menu_item['ID']         = $menu_item_id;
-		$nav_menu_item['post_title'] = $inner_block['attrs']['label'];
-		$nav_menu_item['url']        = $inner_block['attrs']['url'] ?? '#';
+		if ( $parent_id ) {
+			$nav_menu_item['menu_item_parent'] = $parent_id;
+		}
 
-		++$menu_item_id;
 		$nav_menu_items[] = (object) $nav_menu_item;
+
+		$sub_menu_items = setup_block_nav_items( $inner_block, $colors, $nav_menu_item['ID'] );
+		$nav_menu_items = array_merge( $nav_menu_items, $sub_menu_items );
 	}
 
 	return array_map( 'wp_setup_nav_menu_item', $nav_menu_items );


### PR DESCRIPTION
## Description

Exploratory PR to see what's needed in order to be able to use `Walker_Nav_Menu` to render site navigation menu blocks.

See #17194.

## How has this been tested?
So far only locally, by setting up a menu block and loading it in the front-end.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
