### PR TITLE
Update design-systems:dev script to build packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -198,7 +198,7 @@
 		"test-unit:native": "cd test/native/ && cross-env NODE_ENV=test jest --config ./jest.config.js",
 		"test-unit:native:debug": "cd test/native/ && node --inspect ../../node_modules/.bin/jest --runInBand --config ./jest.config.js",
 		"design-system:build": "npm run build:packages && build-storybook -c ./packages/components/storybook -o ./playground/dist/design-system/components",
-		"design-system:dev": "concurrently \"npm run dev:packages\" \"start-storybook -c ./packages/components/storybook\"",
+		"design-system:dev": "npm run build:packages && concurrently \"npm run dev:packages\" \"start-storybook -c ./packages/components/storybook\"",
 		"playground:build": "npm run build:packages && parcel build playground/src/index.html -d playground/dist",
 		"playground:dev": "concurrently \"npm run dev:packages\" \"parcel playground/src/index.html -d playground/dist\"",
 		"preenv": "npm run check-engines",


### PR DESCRIPTION
## Description

The build-style/style.css needs to be rebuilt prior to running Storybook in watch mode.

This change adds `npm run build:packages` at the start of the design-systems:dev script to CSS is built prior.

Issue found in #17997

## How has this been tested?

Run `npm run design-systems:dev` confirm the packages are built prior to Storybook started in watch mode. To confirm the bug, you can change CSS in a component prior to the patch and you will not see it reflected in Storybook

## Types of changes

Storybook start script.
