### PR TITLE
Add block inspector to the Gutenberg playground.

### DIFF
--- a/playground/src/index.js
+++ b/playground/src/index.js
@@ -8,6 +8,7 @@ import {
 	BlockEditorKeyboardShortcuts,
 	BlockEditorProvider,
 	BlockList,
+	BlockInspector,
 	WritingFlow,
 	ObserveTyping,
 } from '@wordpress/block-editor';
@@ -53,6 +54,9 @@ function App() {
 							onInput={ updateBlocks }
 							onChange={ updateBlocks }
 						>
+							<div className="playground__sidebar">
+								<BlockInspector />
+							</div>
 							<div className="editor-styles-wrapper">
 								<BlockEditorKeyboardShortcuts />
 								<WritingFlow>

--- a/playground/src/style.scss
+++ b/playground/src/style.scss
@@ -8,6 +8,7 @@
 @import "./reset";
 @import "./editor-styles";
 
+$playground-header-height: 95px;
 
 .playground__header {
 	align-items: center;
@@ -15,6 +16,25 @@
 	display: flex;
 	justify-content: space-between;
 	padding: 20px;
+	height: $playground-header-height;
+}
+
+.playground__sidebar {
+	position: fixed;
+	top: $playground-header-height;
+	right: 0;
+	bottom: 0;
+	width: $sidebar-width;
+	border-left: $border-width solid $light-gray-500;
+	height: auto;
+	overflow: auto;
+	-webkit-overflow-scrolling: touch;
+
+	// Temporarily disable the sidebar on mobile
+	display: none;
+	@include break-small() {
+		display: block;
+	}
 }
 
 .playground__logo {
@@ -23,6 +43,9 @@
 }
 
 .playground__body {
+	@include break-small() {
+		width: calc(100% - #{$sidebar-width});
+	}
 	padding-top: 20px;
 
 	img {


### PR DESCRIPTION
## Description
This PR adds the block inspector in the playground.
Now we deploy a test site with the playground on each PR so the playground is even more useful as it allows to test things without any local environment.
With this addition, blocks can now be almost totally tested on the playground.
It is also useful to catch problems where our components rely on styles provided by WordPress, e.g: it is possible to see that the font size picker contains a style problem(will be addressed in other PR).


## How has this been tested?
I executed `npm run playground:dev` and verified the block inspector was available on the playground.

I opened https://deploy-preview-18077--gutenberg-playground.netlify.com/ and verified the playground contained the inspector.
