### PR TITLE
Fix: Font size picker component relies on WordPress styles.

### DIFF
--- a/packages/components/src/font-size-picker/index.js
+++ b/packages/components/src/font-size-picker/index.js
@@ -60,7 +60,7 @@ function FontSizePicker( {
 	};
 
 	return (
-		<fieldset>
+		<fieldset className="components-font-size-picker">
 			<legend>
 				{ __( 'Font Size' ) }
 			</legend>

--- a/packages/components/src/font-size-picker/style.scss
+++ b/packages/components/src/font-size-picker/style.scss
@@ -38,3 +38,9 @@
 	}
 }
 
+.components-font-size-picker {
+	border: 0;
+	padding: 0;
+	margin: 0;
+}
+


### PR DESCRIPTION
## Description
The font size picker component relies on some WordPress styles and does not looks as expected, outside a WordPress context.
This PR adds the required styles to make the component work as expected.

## How has this been tested?
I cherry-picked this commit into the branch of PR https://github.com/WordPress/gutenberg/pull/18077. So the inspector is available on the playground.
I verified the font size picker design is the same we have in WordPress contexts.

## Screenshots <!-- if applicable -->
Before:
<img width="254" alt="Screenshot 2019-10-23 at 13 06 44" src="https://user-images.githubusercontent.com/11271197/67391213-22d82180-f596-11e9-9f3a-ba138d364c42.png">


After:
<img width="252" alt="Screenshot 2019-10-23 at 13 02 21" src="https://user-images.githubusercontent.com/11271197/67391233-29ff2f80-f596-11e9-9d8c-749694b71447.png">


