### PR TITLE
Components: ExternalLink, add story

### DIFF
--- a/packages/components/src/external-link/stories/index.js
+++ b/packages/components/src/external-link/stories/index.js
@@ -1,0 +1,17 @@
+/**
+ * External dependencies
+ */
+import { text } from '@storybook/addon-knobs';
+/**
+ * Internal dependencies
+ */
+import ExternalLink from '../';
+
+export default { title: 'ExternalLink', component: ExternalLink };
+
+export const _default = () => {
+	const title = text( 'children', 'WordPress' );
+	const href = text( 'href', 'https://wordpress.org' );
+
+	return <ExternalLink href={ href }>{ title }</ExternalLink>;
+};


### PR DESCRIPTION
## Components: ExternalLink, add story

<img width="447" alt="Screen Shot 2019-10-23 at 1 48 11 PM" src="https://user-images.githubusercontent.com/2322354/67420109-f6bf9f00-f59b-11e9-8573-86a39f99b037.png">

This update adds a story for the ExternalLink component.
Storybook knobs were added to better demonstrate the component's
properties.

Style wise, this one is victim to screen reader styles (or rather lack of). I believe @mkaz experienced something similar 😊 