### PR TITLE
URLInput: ensuring value is defined on key down

### DIFF
--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -134,7 +134,10 @@ class URLInput extends Component {
 		const { showSuggestions, selectedSuggestion, suggestions, loading } = this.state;
 		// If the suggestions are not shown or loading, we shouldn't handle the arrow keys
 		// We shouldn't preventDefault to allow block arrow keys navigation
-		if ( ! showSuggestions || ! suggestions.length || loading ) {
+		if (
+			( ! showSuggestions || ! suggestions.length || loading ) &&
+			this.props.value
+		) {
 			// In the Windows version of Firefox the up and down arrows don't move the caret
 			// within an input field like they do for Mac Firefox/Chrome/Safari. This causes
 			// a form of focus trapping that is disruptive to the user experience. This disruption


### PR DESCRIPTION
## Description
This patch takes over ensuring that the value defined in the component prop is defined before to start to handle the caret position when `UP` or `DOWN` keypress happens.

## How has this been tested?
1) Apply the patch
2) Create a new post/page/whatever
3) Type some text
4) Start to add a link to the text
5) Press the `DOWN` key. It should not trigger an error in the console log.

Fixes https://github.com/WordPress/gutenberg/issues/18086

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->