### PR TITLE
Fix overlapping controls in the Inline Image formatting toolbar

### DIFF
--- a/packages/format-library/src/image/style.scss
+++ b/packages/format-library/src/image/style.scss
@@ -3,9 +3,10 @@
 
 	.components-icon-button {
 		align-self: flex-end;
-		height: $grid-size * 4;
+		height: $grid-size * 4 - ($border-width * 2);
 		margin-bottom: $grid-size;
-		margin-right: $grid-size - $border-width;
+		margin-right: $grid-size;
+		padding: 0 6px;
 	}
 }
 

--- a/packages/format-library/src/image/style.scss
+++ b/packages/format-library/src/image/style.scss
@@ -2,8 +2,10 @@
 	display: flex;
 
 	.components-icon-button {
-		height: $icon-button-size + $grid-size + $grid-size;
 		align-self: flex-end;
+		height: $grid-size * 4;
+		margin-bottom: $grid-size;
+		margin-right: $grid-size - $border-width;
 	}
 }
 

--- a/packages/format-library/src/image/style.scss
+++ b/packages/format-library/src/image/style.scss
@@ -15,7 +15,13 @@
 	min-width: 150px;
 	max-width: 500px;
 
-	&.components-base-control .components-base-control__field {
-		margin-bottom: 0;
+	&.components-base-control {
+		.components-base-control__field {
+			margin-bottom: 0;
+		}
+
+		.components-base-control__label {
+			display: block;
+		}
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/18089.

**Before:**

<img width="311" alt="Screen Shot 2019-10-24 at 15 39 57" src="https://user-images.githubusercontent.com/612155/67454060-8cc6f880-f674-11e9-9ef1-91f877700c76.png">

**After:**

<img width="314" alt="Screen Shot 2019-10-24 at 15 39 41" src="https://user-images.githubusercontent.com/612155/67454063-8e90bc00-f674-11e9-94e0-7ebb34c2356c.png">

**To test:**

1. Place your cursor inside a paragraph block.
2. In the block toolbar, select _More rich text controls_
3. Select _Inline image_ and insert an inline image
4. Click on the inline image