### PR TITLE
Navigation: Explore default frontend styles

### DIFF
--- a/packages/block-library/src/navigation-menu/style.scss
+++ b/packages/block-library/src/navigation-menu/style.scss
@@ -1,0 +1,107 @@
+.wp-block-navigation-menu {
+
+	& > ul {
+		display: flex;
+		flex-wrap: wrap;
+		list-style: none;
+		margin: 0;
+		max-width: none;
+		padding-left: 0;
+		position: relative;
+
+		ul {
+			padding-left: 0;
+		}
+
+		li {
+			position: relative;
+			z-index: 1;
+
+			&:hover,
+			&:focus-within {
+				cursor: pointer;
+				z-index: 99999;
+			}
+
+			// Submenu Display
+			&:hover > ul,
+			&:focus-within > ul,
+			& ul:hover,
+			& ul:focus {
+				visibility: visible;
+				opacity: 1;
+				display: block;
+			}
+		}
+
+		& > li {
+			&:first-of-type > a {
+				padding-left: 0;
+			}
+
+			&:last-of-type > a {
+				padding-right: 0;
+			}
+		}
+
+		// Sub-menus Flyout
+		& > li > ul {
+			margin: 0;
+			position: absolute;
+			background: #fff;
+			box-shadow: 0 0 8px 2px rgba(0, 0, 0, 0.2);
+			left: 0;
+			top: 100%;
+			min-width: max-content;
+			opacity: 0;
+			transition: all 0.5s ease;
+			visibility: hidden;
+
+			ul {
+				width: 100%;
+			}
+		}
+	}
+
+	// Menu Link
+	a {
+		display: block;
+		padding: 16px;
+	}
+
+	// Sub-menu depth indicators
+	ul ul {
+
+		list-style: none;
+		margin-left: 0;
+		// Reset the counter for each UL
+		counter-reset: nested-list;
+
+		li a {
+
+			padding-top: 8px;
+			padding-bottom: 8px;
+
+			&::before {
+				// Increment the dashes
+				counter-increment: nested-list;
+				// Insert dashes with spaces in between
+				content: "\2013\00a0" counters(nested-list, "\2013\00a0", none);
+			}
+		}
+	}
+
+	// Top-level sub-menu indicators
+	// TODO: needs to apply to items with children only
+	& > ul > li > a {
+
+		&::after {
+			content: "\00a0\25BC";
+			display: inline-block;
+			font-size: 0.6rem;
+			height: inherit;
+			width: inherit;
+		}
+	}
+
+}

--- a/packages/block-library/src/navigation-menu/style.scss
+++ b/packages/block-library/src/navigation-menu/style.scss
@@ -1,13 +1,17 @@
 .wp-block-navigation-menu {
 
 	& > ul {
-		display: flex;
-		flex-wrap: wrap;
+		display: block;
 		list-style: none;
 		margin: 0;
 		max-width: none;
 		padding-left: 0;
 		position: relative;
+
+		@include break-small {
+			display: flex;
+			flex-wrap: wrap;
+		}
 
 		ul {
 			padding-left: 0;
@@ -35,6 +39,15 @@
 		}
 
 		& > li {
+
+			& > a {
+				padding-left: 0;
+
+				@include break-small {
+					padding-left: 16px;
+				}
+			}
+
 			&:first-of-type > a {
 				padding-left: 0;
 			}

--- a/packages/block-library/src/navigation-menu/style.scss
+++ b/packages/block-library/src/navigation-menu/style.scss
@@ -92,8 +92,7 @@
 	}
 
 	// Top-level sub-menu indicators
-	// TODO: needs to apply to items with children only
-	& > ul > li > a {
+	& .has-sub-menu > a {
 
 		&::after {
 			content: "\00a0\25BC";

--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -11,6 +11,7 @@
 @import "./latest-comments/style.scss";
 @import "./latest-posts/style.scss";
 @import "./media-text/style.scss";
+@import "./navigation-menu/style.scss";
 @import "./paragraph/style.scss";
 @import "./pullquote/style.scss";
 @import "./quote/style.scss";


### PR DESCRIPTION
## Description
This is an exploratory (!) draft PR to see what the default styling for the navigation menu block could look like on the Frontend. As outlined in the related issue https://github.com/WordPress/gutenberg/issues/17542 the styling is supposed to be minimal as the styling should mostly be handled by themes.

~~In https://github.com/WordPress/gutenberg/issues/17542#issuecomment-544584741 it was suggested to try the _s main navigation default styles. The styles in this PR are a copy of the relevant parts of _s's [navigation menu styles](https://github.com/Automattic/_s/blob/master/sass/navigation/_menus.scss). If this is the design route we want to go down we'd probably want to modernize these styles, one can tell they are seven years old.~~

Update: Based on https://github.com/WordPress/gutenberg/pull/18094#issuecomment-546079515 this exploration is inspired by the Varia theme styles.

## How has this been tested?
- Activate "Menu Block" in the experimental Gutenberg settings
- Create a menu via the Menu Block
- Preview on the Frontend

## Screenshots <!-- if applicable -->

Using the Twenty Nineteen theme:

**Before** 

<img width="364" alt="Screen Shot 2019-10-28 at 16 50 56" src="https://user-images.githubusercontent.com/1562646/67702122-75a84380-f9b1-11e9-9483-e0084ca235b7.png">


**After** 

<img width="374" alt="Screen Shot 2019-10-28 at 18 10 48" src="https://user-images.githubusercontent.com/1562646/67702137-7b058e00-f9b1-11e9-81c1-437c47d27855.png">


**After :hover** 

<img width="463" alt="Screen Shot 2019-10-28 at 18 11 04" src="https://user-images.githubusercontent.com/1562646/67702153-81940580-f9b1-11e9-8490-f3a66ce04151.png">





## Types of changes
New feature (non-breaking change which adds functionality)

## TODOs:
Should we want to go down the route of using default styles inspired by the Varia theme, we'd need to make sure to
- [x] ensure the menu indicator is shown only on items with child menus
- [x] make adjustments for small viewport screens i.e. mobile

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
