### PR TITLE
Add appender to Block Navigator

### DIFF
--- a/packages/block-editor/src/components/block-navigation/list.js
+++ b/packages/block-editor/src/components/block-navigation/list.js
@@ -93,7 +93,10 @@ export default function BlockNavigationList( {
 			{ shouldShowAppender && (
 				<li>
 					<div className="editor-block-navigation__item block-editor-block-navigation__item">
-						<ButtonBlockAppender rootClientId={ parentBlockClientId } />
+						<ButtonBlockAppender
+							rootClientId={ parentBlockClientId }
+							__experimentalSelectBlockOnInsert={ false }
+						/>
 					</div>
 				</li>
 			) }

--- a/packages/block-editor/src/components/block-navigation/list.js
+++ b/packages/block-editor/src/components/block-navigation/list.js
@@ -16,7 +16,7 @@ import { create, getTextContent } from '@wordpress/rich-text';
  * Internal dependencies
  */
 import BlockIcon from '../block-icon';
-import BlockListAppender from '../button-block-appender';
+import ButtonBlockAppender from '../button-block-appender';
 
 /**
  * Get the block display name, if it has one, or the block title if it doesn't.
@@ -93,7 +93,7 @@ export default function BlockNavigationList( {
 			{ shouldShowAppender && (
 				<li>
 					<div className="editor-block-navigation__item block-editor-block-navigation__item">
-						<BlockListAppender rootClientId={ parentBlockClientId } />
+						<ButtonBlockAppender rootClientId={ parentBlockClientId } />
 					</div>
 				</li>
 			) }

--- a/packages/block-editor/src/components/block-navigation/list.js
+++ b/packages/block-editor/src/components/block-navigation/list.js
@@ -16,6 +16,7 @@ import { create, getTextContent } from '@wordpress/rich-text';
  * Internal dependencies
  */
 import BlockIcon from '../block-icon';
+import BlockListAppender from '../button-block-appender';
 
 /**
  * Get the block display name, if it has one, or the block title if it doesn't.
@@ -43,8 +44,14 @@ export default function BlockNavigationList( {
 	blocks,
 	selectedBlockClientId,
 	selectBlock,
+	showAppender,
+
+	// Internal use only.
 	showNestedBlocks,
+	parentBlockClientId,
 } ) {
+	const shouldShowAppender = showAppender && !! parentBlockClientId;
+
 	return (
 		/*
 		 * Disable reason: The `list` ARIA role is redundant but
@@ -75,12 +82,21 @@ export default function BlockNavigationList( {
 								blocks={ block.innerBlocks }
 								selectedBlockClientId={ selectedBlockClientId }
 								selectBlock={ selectBlock }
+								parentBlockClientId={ block.clientId }
+								showAppender={ showAppender }
 								showNestedBlocks
 							/>
 						) }
 					</li>
 				);
 			} ) }
+			{ shouldShowAppender && (
+				<li>
+					<div className="editor-block-navigation__item block-editor-block-navigation__item">
+						<BlockListAppender rootClientId={ parentBlockClientId } />
+					</div>
+				</li>
+			) }
 		</ul>
 		/* eslint-enable jsx-a11y/no-redundant-roles */
 	);

--- a/packages/block-editor/src/components/block-navigation/style.scss
+++ b/packages/block-editor/src/components/block-navigation/style.scss
@@ -16,6 +16,24 @@ $tree-item-height: 36px;
 	margin: 0;
 }
 
+.block-editor-block-navigation__list .block-editor-button-block-appender {
+	outline: none;
+	background: none;
+	padding: $grid-size;
+	margin-left: 0.8em;
+	width: $icon-button-size;
+	border-radius: 4px;
+
+	&:hover:not(:disabled):not([aria-disabled="true"]) {
+		@include menu-style__hover;
+		outline: none;
+	}
+
+	&:focus:not(:disabled):not([aria-disabled="true"]) {
+		@include menu-style__focus;
+	}
+}
+
 .block-editor-block-navigation__list .block-editor-block-navigation__list {
 	margin-top: 2px;
 	border-left: $tree-border-width solid $light-gray-900;

--- a/packages/block-editor/src/components/button-block-appender/index.js
+++ b/packages/block-editor/src/components/button-block-appender/index.js
@@ -15,12 +15,13 @@ import { _x, sprintf } from '@wordpress/i18n';
 import BlockDropZone from '../block-drop-zone';
 import Inserter from '../inserter';
 
-function ButtonBlockAppender( { rootClientId, className } ) {
+function ButtonBlockAppender( { rootClientId, className, __experimentalSelectBlockOnInsert: selectBlockOnInsert } ) {
 	return (
 		<>
 			<BlockDropZone rootClientId={ rootClientId } />
 			<Inserter
 				rootClientId={ rootClientId }
+				__experimentalSelectBlockOnInsert={ selectBlockOnInsert }
 				renderToggle={ ( { onToggle, disabled, isOpen, blockTitle, hasSingleBlockType } ) => {
 					let label;
 					if ( hasSingleBlockType ) {

--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -5,6 +5,7 @@ import { get } from 'lodash';
 /**
  * WordPress dependencies
  */
+import { speak } from '@wordpress/a11y';
 import { __, _x, sprintf } from '@wordpress/i18n';
 import { Dropdown, IconButton } from '@wordpress/components';
 import { Component } from '@wordpress/element';
@@ -112,9 +113,11 @@ class Inserter extends Component {
 
 	render() {
 		const { position, hasSingleBlockType, insertOnlyAllowedBlock } = this.props;
+
 		if ( hasSingleBlockType ) {
 			return this.renderToggle( { onToggle: insertOnlyAllowedBlock } );
 		}
+
 		return (
 			<Dropdown
 				className="editor-inserter block-editor-inserter"
@@ -194,12 +197,19 @@ export default compose( [
 				} = dispatch( 'core/block-editor' );
 
 				const blockToInsert = createBlock( allowedBlockType.name );
+
 				insertBlock(
 					blockToInsert,
 					getInsertionIndex(),
 					rootClientId,
 					selectBlockOnInsert
 				);
+
+				if ( ! selectBlockOnInsert ) {
+					// translators: %s: the name of the block that has been added
+					const message = sprintf( __( '%s block added' ), allowedBlockType.title );
+					speak( message );
+				}
 			},
 		};
 	} ),

--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -90,7 +90,13 @@ class Inserter extends Component {
 	 * @return {WPElement} Dropdown content element.
 	 */
 	renderContent( { onClose } ) {
-		const { rootClientId, clientId, isAppender, showInserterHelpPanel } = this.props;
+		const {
+			rootClientId,
+			clientId,
+			isAppender,
+			showInserterHelpPanel,
+			__experimentalSelectBlockOnInsert: selectBlockOnInsert,
+		} = this.props;
 
 		return (
 			<InserterMenu
@@ -99,6 +105,7 @@ class Inserter extends Component {
 				clientId={ clientId }
 				isAppender={ isAppender }
 				showInserterHelpPanel={ showInserterHelpPanel }
+				__experimentalSelectBlockOnInsert={ selectBlockOnInsert }
 			/>
 		);
 	}
@@ -133,10 +140,12 @@ export default compose( [
 		const allowedBlocks = __experimentalGetAllowedBlocks( rootClientId );
 
 		const hasSingleBlockType = allowedBlocks && ( get( allowedBlocks, [ 'length' ], 0 ) === 1 );
+
 		let allowedBlockType = false;
 		if ( hasSingleBlockType ) {
 			allowedBlockType = allowedBlocks[ 0 ];
 		}
+
 		return {
 			hasItems: hasInserterItems( rootClientId ),
 			hasSingleBlockType,
@@ -151,6 +160,7 @@ export default compose( [
 				const {
 					hasSingleBlockType,
 					allowedBlockType,
+					__experimentalSelectBlockOnInsert: selectBlockOnInsert,
 				} = ownProps;
 
 				if ( ! hasSingleBlockType ) {
@@ -187,7 +197,8 @@ export default compose( [
 				insertBlock(
 					blockToInsert,
 					getInsertionIndex(),
-					rootClientId
+					rootClientId,
+					selectBlockOnInsert
 				);
 			},
 		};

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -531,21 +531,27 @@ export default compose(
 				const {
 					getSelectedBlock,
 				} = select( 'core/block-editor' );
-				const { isAppender } = ownProps;
+				const {
+					isAppender,
+					onSelect,
+					__experimentalSelectBlockOnInsert: selectBlockOnInsert,
+				} = ownProps;
 				const { name, initialAttributes } = item;
 				const selectedBlock = getSelectedBlock();
 				const insertedBlock = createBlock( name, initialAttributes );
+
 				if ( ! isAppender && selectedBlock && isUnmodifiedDefaultBlock( selectedBlock ) ) {
 					replaceBlocks( selectedBlock.clientId, insertedBlock );
 				} else {
 					insertBlock(
 						insertedBlock,
 						getInsertionIndex(),
-						ownProps.destinationRootClientId
+						ownProps.destinationRootClientId,
+						selectBlockOnInsert
 					);
 				}
 
-				ownProps.onSelect();
+				onSelect();
 				return insertedBlock;
 			},
 		};

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -21,6 +21,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
+import { speak } from '@wordpress/a11y';
 import { __, _n, _x, sprintf } from '@wordpress/i18n';
 import { Component, createRef } from '@wordpress/element';
 import {
@@ -536,7 +537,7 @@ export default compose(
 					onSelect,
 					__experimentalSelectBlockOnInsert: selectBlockOnInsert,
 				} = ownProps;
-				const { name, initialAttributes } = item;
+				const { name, title, initialAttributes } = item;
 				const selectedBlock = getSelectedBlock();
 				const insertedBlock = createBlock( name, initialAttributes );
 
@@ -549,6 +550,12 @@ export default compose(
 						ownProps.destinationRootClientId,
 						selectBlockOnInsert
 					);
+
+					if ( ! selectBlockOnInsert ) {
+						// translators: %s: the name of the block that has been added
+						const message = sprintf( __( '%s block added' ), title );
+						speak( message );
+					}
 				}
 
 				onSelect();

--- a/packages/block-library/src/navigation-menu-item/edit.js
+++ b/packages/block-library/src/navigation-menu-item/edit.js
@@ -193,12 +193,10 @@ function NavigationMenuItemEdit( {
 					placeholder={ __( 'Add item…' ) }
 					withoutInteractiveFormatting
 				/>
-				{ ( isSelected || isParentOfSelectedBlock ) &&
-					<InnerBlocks
-						allowedBlocks={ [ 'core/navigation-menu-item' ] }
-						renderAppender={ hasDescendants ? InnerBlocks.ButtonBlockAppender : false }
-					/>
-				}
+				<InnerBlocks
+					allowedBlocks={ [ 'core/navigation-menu-item' ] }
+					renderAppender={ hasDescendants ? InnerBlocks.ButtonBlockAppender : false }
+				/>
 			</div>
 		</Fragment>
 	);

--- a/packages/block-library/src/navigation-menu-item/editor.scss
+++ b/packages/block-library/src/navigation-menu-item/editor.scss
@@ -21,6 +21,15 @@
 	// and the edit container should compensate.
 	// This is to make sure the edit and view are the same.
 	padding: 0 $grid-size;
+
+	// Only display inner blocks when the block is being edited.
+	.block-editor-inner-blocks {
+		display: none;
+	}
+
+	&.is-editing .block-editor-inner-blocks {
+		display: block;
+	}
 }
 
 .wp-block-navigation-menu-item__edit-container {

--- a/packages/block-library/src/navigation-menu/block-navigation-list.js
+++ b/packages/block-library/src/navigation-menu/block-navigation-list.js
@@ -35,6 +35,7 @@ export default function BlockNavigationList( { clientId } ) {
 			selectedBlockClientId={ selectedBlockClientId }
 			selectBlock={ selectBlock }
 			showNestedBlocks
+			showAppender
 		/>
 	);
 }


### PR DESCRIPTION
## Description
Closes #17543.

Adds an appender to blocks that have inner blocks in the block navigator.

## How has this been tested?
1. Enable the experimental navigation block
2. Add a navigation block to a post
3. Make sure the block has some menu items
4. Open the block navigator from the block toolbar
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->
![Screen Shot 2019-10-25 at 3 03 34 pm](https://user-images.githubusercontent.com/677833/67550454-1cce7600-f739-11e9-8640-b4055948b2d4.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
