### PR TITLE
Force block inserter to re-render on device rotation

### DIFF
--- a/packages/block-editor/src/components/inserter/menu.native.js
+++ b/packages/block-editor/src/components/inserter/menu.native.js
@@ -21,6 +21,15 @@ import { BottomSheet, Icon } from '@wordpress/components';
 import styles from './style.scss';
 
 export class InserterMenu extends Component {
+	constructor() {
+		super( ...arguments );
+
+		this.onLayout = this.onLayout.bind( this );
+		this.state = {
+			numberOfColumns: this.calculateNumberOfColumns(),
+		};
+	}
+
 	componentDidMount() {
 		this.onOpen();
 	}
@@ -47,9 +56,13 @@ export class InserterMenu extends Component {
 		this.props.hideInsertionPoint();
 	}
 
+	onLayout() {
+		const numberOfColumns = this.calculateNumberOfColumns();
+		this.setState( { numberOfColumns } );
+	}
+
 	render() {
 		const { getStylesFromColorScheme } = this.props;
-		const numberOfColumns = this.calculateNumberOfColumns();
 		const bottomPadding = styles.contentBottomPadding;
 		const modalIconWrapperStyle = getStylesFromColorScheme( styles.modalIconWrapper, styles.modalIconWrapperDark );
 		const modalIconStyle = getStylesFromColorScheme( styles.modalIcon, styles.modalIconDark );
@@ -63,10 +76,11 @@ export class InserterMenu extends Component {
 				hideHeader
 			>
 				<FlatList
+					onLayout={ this.onLayout }
 					scrollEnabled={ false }
-					key={ `InserterUI-${ numberOfColumns }` } //re-render when numberOfColumns changes
+					key={ `InserterUI-${ this.state.numberOfColumns }` } //re-render when numberOfColumns changes
 					keyboardShouldPersistTaps="always"
-					numColumns={ numberOfColumns }
+					numColumns={ this.state.numberOfColumns }
 					data={ this.props.items }
 					ItemSeparatorComponent={ () =>
 						<View style={ styles.rowSeparator } />


### PR DESCRIPTION
## Description
This PR uses onLayout and the internal State of inserter menu to force a re-render of the component on device rotation.

Fixes: https://github.com/wordpress-mobile/gutenberg-mobile/issues/1491
gutenberg-mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1495

## How has this been tested?
- Run the example app (iOS and Android).
- Press (+) to show the block inserter.
- Check that the layout looks fine.
- Rotate the device.
- Check that the layout rearranges.

**Note:** There's a small jump after the rotation while the layout changes. As a hotfix is probably good enough, but I'd like to check this out later on.

