### PR TITLE
[RNMobile] Add a subtitle for unsupported blocks

### DIFF
--- a/packages/block-library/src/missing/edit.native.js
+++ b/packages/block-library/src/missing/edit.native.js
@@ -27,6 +27,9 @@ export class UnsupportedBlockEdit extends Component {
 		const title = blockType ? blockType.settings.title : __( 'Unsupported' );
 		const titleStyle = getStylesFromColorScheme( styles.unsupportedBlockMessage, styles.unsupportedBlockMessageDark );
 
+		const subTitleStyle = getStylesFromColorScheme( styles.unsupportedBlockSubtitle, styles.unsupportedBlockSubtitleDark );
+		const subtitle = blockType ? <Text style={ subTitleStyle }>{ __( 'Unsupported' ) }</Text> : null;
+
 		const icon = blockType ? normalizeIconObject( blockType.settings.icon ) : 'admin-plugins';
 		const iconStyle = getStylesFromColorScheme( styles.unsupportedBlockIcon, styles.unsupportedBlockIconDark );
 		const iconClassName = 'unsupported-icon' + '-' + preferredColorScheme;
@@ -34,6 +37,7 @@ export class UnsupportedBlockEdit extends Component {
 			<View style={ getStylesFromColorScheme( styles.unsupportedBlock, styles.unsupportedBlockDark ) }>
 				<Icon className={ iconClassName } icon={ icon && icon.src ? icon.src : icon } color={ iconStyle.color } />
 				<Text style={ titleStyle }>{ title }</Text>
+				{ subtitle }
 			</View>
 		);
 	}

--- a/packages/block-library/src/missing/style.native.scss
+++ b/packages/block-library/src/missing/style.native.scss
@@ -36,3 +36,13 @@
 .unsupportedBlockMessageDark {
 	color: $white;
 }
+
+.unsupportedBlockSubtitle {
+	text-align: center;
+	color: $gray-darken-20;
+	font-size: 12;
+}
+
+.unsupportedBlockSubtitleDark {
+	color: $gray-lighten-20;
+}

--- a/packages/block-library/src/missing/style.native.scss
+++ b/packages/block-library/src/missing/style.native.scss
@@ -27,10 +27,11 @@
 }
 
 .unsupportedBlockMessage {
-	margin-top: 2;
+	margin-top: 4;
 	text-align: center;
 	color: $gray-dark;
 	font-size: 14;
+	font-weight: 600;
 }
 
 .unsupportedBlockMessageDark {
@@ -38,11 +39,12 @@
 }
 
 .unsupportedBlockSubtitle {
+	margin-top: 2;
 	text-align: center;
 	color: $gray-darken-20;
 	font-size: 12;
 }
 
 .unsupportedBlockSubtitleDark {
-	color: $gray-lighten-20;
+	color: $gray-20;
 }


### PR DESCRIPTION

## Description

Add a subtitle for unsupported blocks that we know the names of.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

Light mode (Android)
<img width="410" src="https://user-images.githubusercontent.com/40213/67564809-1e417380-f724-11e9-80bc-bcbb5bd6879b.png">

Dark mode (iOS)
<img width="410" alt="Screenshot 2019-10-25 at 15 18 35" src="https://user-images.githubusercontent.com/40213/67574546-eeea3100-f73a-11e9-99a7-028dffe0c7d3.png">



cc @iamthomasbishop - can you double check the font size and font color match your design document?

## Types of changes

This is a new feature (non-breaking change which adds functionality). Only affects mobile apps.

## Checklist:
- [x] My code is tested (manual tests only).
- [x] Styling supports dark mode on iOS.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
