### PR TITLE
Fix checkboxes for postmeta.

### DIFF
--- a/packages/edit-post/src/components/meta-boxes/meta-boxes-area/style.scss
+++ b/packages/edit-post/src/components/meta-boxes/meta-boxes-area/style.scss
@@ -81,6 +81,25 @@
 	.is-hidden {
 		display: none;
 	}
+
+
+	// Until checkboxes WordPress-wide are updated to match the new style,
+	// checkboxes used in metaboxes have to be slightly unstyled here.
+	// @todo: remove this entire rule once checkboxes are the same everywhere.
+	// See: https://github.com/WordPress/gutenberg/issues/18053
+	.postbox-container .postbox input[type="checkbox"],
+	.postbox-container .postbox input[type="radio"] {
+		border: $border-width solid $dark-gray-300;
+
+		&:checked {
+			background: $white;
+			border-color: $dark-gray-300;
+		}
+
+		&::before {
+			margin: -3px -4px;
+		}
+	}
 }
 
 .edit-post-meta-boxes-area__clear {

--- a/packages/edit-post/src/style.scss
+++ b/packages/edit-post/src/style.scss
@@ -58,6 +58,24 @@ body.block-editor-page {
 .components-popover,
 .components-modal__frame {
 	@include reset;
+
+	// Until checkboxes WordPress-wide are updated to match the new style,
+	// checkboxes used in metaboxes have to be slightly unstyled here.
+	// @todo: remove this entire rule once checkboxes are the same everywhere.
+	// See: https://github.com/WordPress/gutenberg/issues/18053
+	.postbox-container input[type="checkbox"],
+	.postbox-container input[type="radio"] {
+		border: $border-width solid $dark-gray-300;
+
+		&:checked {
+			background: $white;
+			border-color: $dark-gray-300;
+		}
+
+		&::before {
+			margin: -3px -4px;
+		}
+	}
 }
 
 .block-editor__container {

--- a/packages/edit-post/src/style.scss
+++ b/packages/edit-post/src/style.scss
@@ -58,24 +58,6 @@ body.block-editor-page {
 .components-popover,
 .components-modal__frame {
 	@include reset;
-
-	// Until checkboxes WordPress-wide are updated to match the new style,
-	// checkboxes used in metaboxes have to be slightly unstyled here.
-	// @todo: remove this entire rule once checkboxes are the same everywhere.
-	// See: https://github.com/WordPress/gutenberg/issues/18053
-	.postbox-container input[type="checkbox"],
-	.postbox-container input[type="radio"] {
-		border: $border-width solid $dark-gray-300;
-
-		&:checked {
-			background: $white;
-			border-color: $dark-gray-300;
-		}
-
-		&::before {
-			margin: -3px -4px;
-		}
-	}
 }
 
 .block-editor__container {


### PR DESCRIPTION
This fixes #18053.

It is not a great fix, but it is nonetheless the least disruptive I could think of, and solves the problem now.

The better, longer term, fix is to roll out the singular checkbox and radio button style from the block editor to all of WordPress, in which case the code written for this PR can simply be removed entirely.

For reference, checkboxes in the rest of WordPress look like this:

![Screenshot 2019-10-25 at 12 43 42](https://user-images.githubusercontent.com/1204802/67566748-d6711b00-f728-11e9-9d4e-36af35e47ebb.png)

That explains why the SVG included in the forms.css file has a baked-in blue fill.

Before:

![before](https://user-images.githubusercontent.com/1204802/67566729-ca855900-f728-11e9-90bf-65432e712594.gif)

After:

![after](https://user-images.githubusercontent.com/1204802/67566735-cce7b300-f728-11e9-8891-c42cfced7829.gif)
