### PR TITLE
[Mobile]Add left right borders to inner blocks

### DIFF
--- a/packages/block-editor/src/components/inner-blocks/index.native.js
+++ b/packages/block-editor/src/components/inner-blocks/index.native.js
@@ -122,6 +122,7 @@ class InnerBlocks extends Component {
 							rootClientId={ clientId }
 							renderAppender={ renderAppender }
 							withFooter={ false }
+							isFullyBordered={ true }
 						/>
 				) }
 			</>


### PR DESCRIPTION
## Description

gutenberg-mobile PR https://github.com/wordpress-mobile/gutenberg-mobile/pull/1496

Fix: https://github.com/wordpress-mobile/gutenberg-mobile/issues/1497

I am adding left/right borders to blocks inside InnerBlocks to help with this:

![mediaText](https://user-images.githubusercontent.com/5032900/67570729-c82bfa80-f73a-11e9-9c93-5b64d54c0922.gif)

## How has this been tested?

- Add Media & Text
- Add paragraph block inside Media & Text
- Verify the paragraph block has left right borders

- Check blocks outside of Media & Text and verify they don't have left-right borders on Portrait mode

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
