### PR TITLE
Mark Link Creation Interface as Experimental

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -302,10 +302,6 @@ _Related_
 
 -   <https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/inspector-controls/README.md>
 
-<a name="LinkControl" href="#LinkControl">#</a> **LinkControl**
-
-Undocumented declaration.
-
 <a name="MediaPlaceholder" href="#MediaPlaceholder">#</a> **MediaPlaceholder**
 
 _Related_

--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -22,7 +22,7 @@ export { default as __experimentalGradientPickerControl } from './gradient-picke
 export { default as InnerBlocks } from './inner-blocks';
 export { default as InspectorAdvancedControls } from './inspector-advanced-controls';
 export { default as InspectorControls } from './inspector-controls';
-export { default as LinkControl } from './link-control';
+export { default as __experimentalLinkControl } from './link-control';
 export { default as MediaPlaceholder } from './media-placeholder';
 export { default as MediaUpload } from './media-upload';
 export { default as MediaUploadCheck } from './media-upload/check';

--- a/packages/block-editor/src/components/link-control/input-search.js
+++ b/packages/block-editor/src/components/link-control/input-search.js
@@ -50,9 +50,9 @@ const LinkControlInputSearch = ( {
 				value={ value }
 				onChange={ selectItemHandler }
 				placeholder={ __( 'Search or type url' ) }
-				renderSuggestions={ renderSuggestions }
-				fetchLinkSuggestions={ fetchSuggestions }
-				handleURLSuggestions={ true }
+				__experimentalRenderSuggestions={ renderSuggestions }
+				__experimentalFetchLinkSuggestions={ fetchSuggestions }
+				__experimentalHandleURLSuggestions={ true }
 			/>
 
 			<IconButton

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { throttle, isFunction, noop } from 'lodash';
+import { throttle, isFunction } from 'lodash';
 import classnames from 'classnames';
 import scrollIntoView from 'dom-scroll-into-view';
 
@@ -256,6 +256,7 @@ class URLInput extends Component {
 			isFullWidth,
 			hasBorder,
 			__experimentalRenderSuggestions,
+			__experimentalOnKeyPress,
 			placeholder = __( 'Paste URL or type to search' ),
 			value = '',
 			autoFocus = true,

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -256,7 +256,6 @@ class URLInput extends Component {
 			isFullWidth,
 			hasBorder,
 			__experimentalRenderSuggestions,
-			__experimentalOnKeyPress,
 			placeholder = __( 'Paste URL or type to search' ),
 			value = '',
 			autoFocus = true,

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -71,14 +71,17 @@ class URLInput extends Component {
 	}
 
 	updateSuggestions( value ) {
-		const { __experimentalFetchLinkSuggestions, __experimentalHandleURLSuggestions } = this.props;
-		if ( ! __experimentalFetchLinkSuggestions ) {
+		const {
+			__experimentalFetchLinkSuggestions: fetchLinkSuggestions,
+			__experimentalHandleURLSuggestions: handleURLSuggestions,
+		} = this.props;
+		if ( ! fetchLinkSuggestions ) {
 			return;
 		}
 
 		// Show the suggestions after typing at least 2 characters
 		// and also for URLs
-		if ( value.length < 2 || ( ! __experimentalHandleURLSuggestions && isURL( value ) ) ) {
+		if ( value.length < 2 || ( ! handleURLSuggestions && isURL( value ) ) ) {
 			this.setState( {
 				showSuggestions: false,
 				selectedSuggestion: null,
@@ -94,7 +97,7 @@ class URLInput extends Component {
 			loading: true,
 		} );
 
-		const request = __experimentalFetchLinkSuggestions( value );
+		const request = fetchLinkSuggestions( value );
 
 		request.then( ( suggestions ) => {
 			// A fetch Promise doesn't have an abort option. It's mimicked by
@@ -255,7 +258,7 @@ class URLInput extends Component {
 			id,
 			isFullWidth,
 			hasBorder,
-			__experimentalRenderSuggestions,
+			__experimentalRenderSuggestions: renderSuggestions,
 			placeholder = __( 'Paste URL or type to search' ),
 			value = '',
 			autoFocus = true,
@@ -314,7 +317,7 @@ class URLInput extends Component {
 
 				{ ( loading ) && <Spinner /> }
 
-				{ isFunction( __experimentalRenderSuggestions ) && showSuggestions && !! suggestions.length && __experimentalRenderSuggestions( {
+				{ isFunction( renderSuggestions ) && showSuggestions && !! suggestions.length && renderSuggestions( {
 					suggestions,
 					selectedSuggestion,
 					suggestionsListProps,
@@ -323,7 +326,7 @@ class URLInput extends Component {
 					handleSuggestionClick: this.handleOnClick,
 				} ) }
 
-				{ ! isFunction( __experimentalRenderSuggestions ) && showSuggestions && !! suggestions.length &&
+				{ ! isFunction( renderSuggestions ) && showSuggestions && !! suggestions.length &&
 					<Popover
 						position="bottom"
 						noArrow

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -71,14 +71,14 @@ class URLInput extends Component {
 	}
 
 	updateSuggestions( value ) {
-		const { fetchLinkSuggestions, handleURLSuggestions } = this.props;
-		if ( ! fetchLinkSuggestions ) {
+		const { __experimentalFetchLinkSuggestions, __experimentalHandleURLSuggestions } = this.props;
+		if ( ! __experimentalFetchLinkSuggestions ) {
 			return;
 		}
 
 		// Show the suggestions after typing at least 2 characters
 		// and also for URLs
-		if ( value.length < 2 || ( ! handleURLSuggestions && isURL( value ) ) ) {
+		if ( value.length < 2 || ( ! __experimentalHandleURLSuggestions && isURL( value ) ) ) {
 			this.setState( {
 				showSuggestions: false,
 				selectedSuggestion: null,
@@ -94,7 +94,7 @@ class URLInput extends Component {
 			loading: true,
 		} );
 
-		const request = fetchLinkSuggestions( value );
+		const request = __experimentalFetchLinkSuggestions( value );
 
 		request.then( ( suggestions ) => {
 			// A fetch Promise doesn't have an abort option. It's mimicked by
@@ -255,7 +255,7 @@ class URLInput extends Component {
 			id,
 			isFullWidth,
 			hasBorder,
-			renderSuggestions,
+			__experimentalRenderSuggestions,
 			placeholder = __( 'Paste URL or type to search' ),
 			value = '',
 			autoFocus = true,
@@ -314,7 +314,7 @@ class URLInput extends Component {
 
 				{ ( loading ) && <Spinner /> }
 
-				{ isFunction( renderSuggestions ) && showSuggestions && !! suggestions.length && renderSuggestions( {
+				{ isFunction( __experimentalRenderSuggestions ) && showSuggestions && !! suggestions.length && __experimentalRenderSuggestions( {
 					suggestions,
 					selectedSuggestion,
 					suggestionsListProps,
@@ -323,7 +323,7 @@ class URLInput extends Component {
 					handleSuggestionClick: this.handleOnClick,
 				} ) }
 
-				{ ! isFunction( renderSuggestions ) && showSuggestions && !! suggestions.length &&
+				{ ! isFunction( __experimentalRenderSuggestions ) && showSuggestions && !! suggestions.length &&
 					<Popover
 						position="bottom"
 						noArrow
@@ -368,12 +368,12 @@ export default compose(
 	withSelect( ( select, props ) => {
 		// If a link suggestions handler is already provided then
 		// bail
-		if ( isFunction( props.fetchLinkSuggestions ) ) {
+		if ( isFunction( props.__experimentalFetchLinkSuggestions ) ) {
 			return;
 		}
 		const { getSettings } = select( 'core/block-editor' );
 		return {
-			fetchLinkSuggestions: getSettings().__experimentalFetchLinkSuggestions,
+			__experimentalFetchLinkSuggestions: getSettings().__experimentalFetchLinkSuggestions,
 		};
 	} )
 )( URLInput );

--- a/playground/src/index.js
+++ b/playground/src/index.js
@@ -16,7 +16,7 @@ import {
 	BlockList,
 	WritingFlow,
 	ObserveTyping,
-	LinkControl,
+	__experimentalLinkControl,
 } from '@wordpress/block-editor';
 import {
 	Popover,
@@ -123,7 +123,7 @@ function App() {
 								<WritingFlow>
 									<ObserveTyping>
 										{ isVisible &&
-											<LinkControl
+											<__experimentalLinkControl
 												currentLink={ link }
 												currentSettings={ linkSettings }
 												onLinkChange={ ( theLink ) => {


### PR DESCRIPTION
Sub-PR of #17846, meant to be merged into it, not master. 

It adds experimental flags for the main component and all additions (in form of props) that were added to (already public) `URLInput`.