### PR TITLE
[Mobile]Remove alignment options from Media & Text until they are fixed

### DIFF
--- a/packages/block-library/src/media-text/edit.native.js
+++ b/packages/block-library/src/media-text/edit.native.js
@@ -10,7 +10,7 @@ import { View } from 'react-native';
 import { __, _x } from '@wordpress/i18n';
 import {
 	BlockControls,
-	BlockVerticalAlignmentToolbar,
+	//	BlockVerticalAlignmentToolbar,
 	InnerBlocks,
 	withColors,
 } from '@wordpress/block-editor';
@@ -131,15 +131,16 @@ class MediaTextEdit extends Component {
 			attributes,
 			backgroundColor,
 			setAttributes,
-			isMobile,
+		//	isMobile,
 		} = this.props;
 		const {
-			isStackedOnMobile,
+		//	isStackedOnMobile,
 			mediaPosition,
 			mediaWidth,
 			verticalAlignment,
 		} = attributes;
-		const shouldStack = isStackedOnMobile && isMobile;
+		const shouldStack = false; //We are temporarily not stacking until we fix alignment buttons
+		// const shouldStack = isStackedOnMobile && isMobile; // <<< Original line
 		const temporaryMediaWidth = shouldStack ? 100 : ( this.state.mediaWidth || mediaWidth );
 		const widthString = `${ temporaryMediaWidth }%`;
 		const containerStyles = {
@@ -165,9 +166,9 @@ class MediaTextEdit extends Component {
 			onClick: () => setAttributes( { mediaPosition: 'right' } ),
 		} ];
 
-		const onVerticalAlignmentChange = ( alignment ) => {
+		/* const onVerticalAlignmentChange = ( alignment ) => {
 			setAttributes( { verticalAlignment: alignment } );
-		};
+		}; */
 
 		return (
 			<>
@@ -175,11 +176,12 @@ class MediaTextEdit extends Component {
 					<Toolbar
 						controls={ toolbarControls }
 					/>
+					{ /* // Temporarily commenting out until alignment functionality is fixed
 					<BlockVerticalAlignmentToolbar
 						onChange={ onVerticalAlignmentChange }
 						value={ verticalAlignment }
 						isCollapsed={ false }
-					/>
+					/> */ }
 				</BlockControls>
 				<View style={ containerStyles }>
 					<View style={ { width: widthString } }>

--- a/packages/block-library/src/media-text/edit.native.js
+++ b/packages/block-library/src/media-text/edit.native.js
@@ -139,7 +139,7 @@ class MediaTextEdit extends Component {
 			mediaWidth,
 			verticalAlignment,
 		} = attributes;
-		const shouldStack = false; //We are temporarily not stacking until we fix alignment buttons
+		const shouldStack = false; // We are temporarily not stacking until we fix alignment buttons
 		// const shouldStack = isStackedOnMobile && isMobile; // <<< Original line
 		const temporaryMediaWidth = shouldStack ? 100 : ( this.state.mediaWidth || mediaWidth );
 		const widthString = `${ temporaryMediaWidth }%`;


### PR DESCRIPTION
## Description

Fix https://github.com/wordpress-mobile/gutenberg-mobile/issues/1501

Gutenberg mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1500

## How has this been tested?

- Open the post on Portrait mode
- Add media & text block
- Verify that it is displayed as horizontally stacked

- Check out toolbar options
- Verify that vertical alignment buttons aren't there

## Screenshots <!-- if applicable -->

<img width="426" alt="Screen Shot 2019-10-25 at 17 55 38" src="https://user-images.githubusercontent.com/5032900/67581572-e997e100-f750-11e9-8a9d-1af866bb71dc.png">

<img width="424" alt="Screen Shot 2019-10-25 at 17 55 54" src="https://user-images.githubusercontent.com/5032900/67581573-ea307780-f750-11e9-9430-55cfbe5b0e91.png">

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
