### PR TITLE
Tutorial: Specify block naming restrictions

### DIFF
--- a/docs/designers-developers/developers/tutorials/block-tutorial/writing-your-first-block-type.md
+++ b/docs/designers-developers/developers/tutorials/block-tutorial/writing-your-first-block-type.md
@@ -107,4 +107,6 @@ Once a block is registered, you should immediately see that it becomes available
 
 A block name must be prefixed with a namespace specific to your plugin. This helps prevent conflicts when more than one plugin registers a block with the same name. In this example, the namespace is `gutenberg-examples`.
 
+Block names _must_ include only lowercase alphanumeric characters or dashes, and start with a letter. Example: `my-plugin/my-custom-block`.
+
 The `edit` and `save` functions describe the structure of your block in the context of the editor and the saved content respectively. While the difference is not obvious in this simple example, in the following sections we'll explore how these are used to enable customization of the block in the editor preview.

--- a/docs/designers-developers/developers/tutorials/block-tutorial/writing-your-first-block-type.md
+++ b/docs/designers-developers/developers/tutorials/block-tutorial/writing-your-first-block-type.md
@@ -107,6 +107,6 @@ Once a block is registered, you should immediately see that it becomes available
 
 A block name must be prefixed with a namespace specific to your plugin. This helps prevent conflicts when more than one plugin registers a block with the same name. In this example, the namespace is `gutenberg-examples`.
 
-Block names _must_ include only lowercase alphanumeric characters or dashes, and start with a letter. Example: `my-plugin/my-custom-block`.
+Block names _must_ include only lowercase alphanumeric characters or dashes and start with a letter. Example: `my-plugin/my-custom-block`.
 
 The `edit` and `save` functions describe the structure of your block in the context of the editor and the saved content respectively. While the difference is not obvious in this simple example, in the following sections we'll explore how these are used to enable customization of the block in the editor preview.


### PR DESCRIPTION
## Description

As per [this error](https://github.com/WordPress/gutenberg/blob/7515397fef469e8cbdaf68162d6d6e1f2a5f9aa1/packages/blocks/src/api/registration.js#L133-L138) in the JS block registration API...

> Block names must contain a namespace prefix, include only lowercase alphanumeric characters or dashes, and start with a letter. Example: my-plugin/my-custom-block

However, if someone attempts to register a block in PHP with, say, an underscore in the block name, the scripts are not enqueued and no obvious warning is provided in the browser console or otherwise. Adding this line to the tutorial document could help folks to avoid this situation by indicating the permissible characters.

Further, it might be nice if a PHP warning was issued (if it's not already).

## Checklist:
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
