### PR TITLE
Allow block creators to disable block deletion via block support.

### DIFF
--- a/docs/designers-developers/developers/block-api/block-registration.md
+++ b/docs/designers-developers/developers/block-api/block-registration.md
@@ -632,6 +632,14 @@ multiple: false,
 By default all blocks can be converted to a reusable block. If supports reusable is set to false, the option to convert the block into a reusable block will not appear.
 
 ```js
+// Use the block just once per post
+removal: false,
+```
+
+- `removal` (default `true`): You may want to disable the user's ability to remove a block.
+By default, all blocks can be removed. If supports removal is set to false, UI for removing the block will not appear.
+
+```js
 // Don't allow the block to be converted into a reusable block.
 reusable: false,
 ```

--- a/packages/block-editor/src/components/block-actions/index.js
+++ b/packages/block-editor/src/components/block-actions/index.js
@@ -55,6 +55,13 @@ export default compose( [
 			);
 		} );
 
+		const canRemove = every( blocks, ( block ) => {
+			return (
+				!! block &&
+				hasBlockSupport( block.name, 'removal', true )
+			);
+		} );
+
 		const canInsertDefaultBlock = canInsertBlockType(
 			getDefaultBlockName(),
 			rootClientId
@@ -63,6 +70,7 @@ export default compose( [
 		return {
 			blocks,
 			canDuplicate,
+			canRemove,
 			canInsertDefaultBlock,
 			extraProps: props,
 			isLocked: !! getTemplateLock( rootClientId ),
@@ -76,6 +84,7 @@ export default compose( [
 			blocks,
 			isLocked,
 			canDuplicate,
+			canRemove,
 		} = props;
 
 		const {
@@ -108,7 +117,7 @@ export default compose( [
 				}
 			},
 			onRemove() {
-				if ( ! isLocked ) {
+				if ( ! isLocked && canRemove ) {
 					removeBlocks( clientIds );
 				}
 			},

--- a/packages/block-editor/src/components/block-actions/index.js
+++ b/packages/block-editor/src/components/block-actions/index.js
@@ -13,6 +13,7 @@ import { cloneBlock, hasBlockSupport, switchToBlockType } from '@wordpress/block
 function BlockActions( {
 	canDuplicate,
 	canInsertDefaultBlock,
+	canRemove,
 	children,
 	isLocked,
 	onDuplicate,
@@ -25,6 +26,7 @@ function BlockActions( {
 	return children( {
 		canDuplicate,
 		canInsertDefaultBlock,
+		canRemove,
 		isLocked,
 		onDuplicate,
 		onGroup,

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -18,6 +18,7 @@ import { BACKSPACE, DELETE, ENTER, ESCAPE } from '@wordpress/keycodes';
 import {
 	getBlockType,
 	getSaveElement,
+	hasBlockSupport,
 	isReusableBlock,
 	isUnmodifiedDefaultBlock,
 	getUnregisteredTypeHandlerName,
@@ -718,7 +719,9 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps, { select } ) => {
 			insertBlocks( blocks, index + 1, rootClientId );
 		},
 		onRemove( clientId ) {
-			removeBlock( clientId );
+			if ( hasBlockSupport( clientId, 'removal', true ) ) {
+				removeBlock( clientId );
+			}
 		},
 		onMerge( forward ) {
 			const { clientId } = ownProps;

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -676,6 +676,7 @@ const applyWithSelect = withSelect(
 );
 
 const applyWithDispatch = withDispatch( ( dispatch, ownProps, { select } ) => {
+	const { name: blockName } = ownProps;
 	const {
 		updateBlockAttributes,
 		selectBlock,
@@ -719,7 +720,7 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps, { select } ) => {
 			insertBlocks( blocks, index + 1, rootClientId );
 		},
 		onRemove( clientId ) {
-			if ( hasBlockSupport( clientId, 'removal', true ) ) {
+			if ( hasBlockSupport( blockName, 'removal', true ) ) {
 				removeBlock( clientId );
 			}
 		},

--- a/packages/block-editor/src/components/block-settings-menu/index.js
+++ b/packages/block-editor/src/components/block-settings-menu/index.js
@@ -45,6 +45,7 @@ export function BlockSettingsMenu( { clientIds } ) {
 				onInsertAfter,
 				onInsertBefore,
 				onRemove,
+				canRemove,
 			} ) => (
 				<Toolbar>
 					<DropdownMenu
@@ -112,6 +113,7 @@ export function BlockSettingsMenu( { clientIds } ) {
 								<MenuGroup>
 									{ ! isLocked && (
 										<MenuItem
+											disabled={ ! canRemove }
 											className="editor-block-settings-menu__control block-editor-block-settings-menu__control"
 											onClick={ flow( onClose, onRemove ) }
 											icon="trash"


### PR DESCRIPTION
## Description
Allow block developers to disable the ability to delete a specific block via block supports.

**Some issues with this approach:**
1. Existing code like this appears to remove the button entirely instead of disabling it. For our use case, we would like to disable the button instead of removing it. Should that be done differently?
2. The user can still delete the block using the code editor. I think the solution to this would be improving the block template API to support block removal.
3. I need to figure out how to dynamically disable these buttons. For example, I'll need to turn on block removal if a condition is met.

## How has this been tested?
1. Tested in my local environment.
2. Existing tests should pass.

To test this yourself, create a new block with `supports: { removal: false }`. Insert the block into the editor and make sure you cannot delete it with backspace or through the UI.

## Screenshots <!-- if applicable -->
<img width="919" alt="Screen Shot 2019-10-25 at 2 34 31 PM" src="https://user-images.githubusercontent.com/6265975/67606304-c01d8c00-f735-11e9-8638-11467ee1b5d5.png">

## Types of changes
New feature.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->

Resolves #16364