### PR TITLE
Add config file support to @wordpress/env

### DIFF
--- a/packages/env/lib/create-docker-compose-config.js
+++ b/packages/env/lib/create-docker-compose-config.js
@@ -1,11 +1,17 @@
+// Gets the dependency volume mapping (including the current context)
+function getDependencyConfig( deps, currentContext ) {
+	const dependencies = [ ...deps, currentContext ];
+	return dependencies.map( ( { path, pathName, type } ) => `      - ${ path }/:/var/www/html/wp-content/${ type }s/${ pathName }/\n` ).join( '' );
+}
+
 module.exports = function createDockerComposeConfig(
-	cwd,
-	cwdName,
 	cwdTestsPath,
-	context
+	context,
+	dependencies,
 ) {
+	const { path: cwd, pathName: cwdName } = context;
 	const commonVolumes = `
-      - ${ cwd }/:/var/www/html/wp-content/${ context.type }s/${ cwdName }/
+${ getDependencyConfig( dependencies, context ) }
       - ${ cwd }${ cwdTestsPath }/e2e-tests/mu-plugins/:/var/www/html/wp-content/mu-plugins/
       - ${ cwd }${ cwdTestsPath }/e2e-tests/plugins/:/var/www/html/wp-content/plugins/${ cwdName }-test-plugins/`;
 	const volumes = `

--- a/packages/env/lib/create-docker-compose-config.js
+++ b/packages/env/lib/create-docker-compose-config.js
@@ -1,17 +1,15 @@
-// Gets the dependency volume mapping (including the current context)
-function getDependencyConfig( deps, currentContext ) {
-	const dependencies = [ ...deps, currentContext ];
-	return dependencies.map( ( { path, pathName, type } ) => `      - ${ path }/:/var/www/html/wp-content/${ type }s/${ pathName }/\n` ).join( '' );
-}
-
 module.exports = function createDockerComposeConfig(
 	cwdTestsPath,
 	context,
 	dependencies,
 ) {
-	const { path: cwd, pathName: cwdName } = context;
+	const { path: cwd, pathBasename: cwdName } = context;
+
+	const dependencyMappings = [ ...dependencies, context ].map(
+		( { path, pathBasename, type } ) => `      - ${ path }/:/var/www/html/wp-content/${ type }s/${ pathBasename }/\n`
+	).join( '' );
 	const commonVolumes = `
-${ getDependencyConfig( dependencies, context ) }
+${ dependencyMappings }
       - ${ cwd }${ cwdTestsPath }/e2e-tests/mu-plugins/:/var/www/html/wp-content/mu-plugins/
       - ${ cwd }${ cwdTestsPath }/e2e-tests/plugins/:/var/www/html/wp-content/plugins/${ cwdName }-test-plugins/`;
 	const volumes = `

--- a/packages/env/lib/detect-context.js
+++ b/packages/env/lib/detect-context.js
@@ -52,6 +52,7 @@ module.exports = async function detectContext( directoryPath = cwd ) {
 				context.type = type.toLowerCase();
 				context.path = absPath;
 				context.pathName = path.basename( absPath );
+
 				// Stop the creation of new streams by mutating the iterated array. We can't `break`, because we are inside a function.
 				files.splice( 0 );
 				fileStream.destroy();

--- a/packages/env/lib/detect-context.js
+++ b/packages/env/lib/detect-context.js
@@ -13,24 +13,22 @@ const path = require( 'path' );
 const readDir = util.promisify( fs.readdir );
 const finished = util.promisify( stream.finished );
 
-const cwd = process.cwd();
-
 /**
  * @typedef Context
  * @type {Object}
  * @property {string} type
  * @property {string} path
- * @property {string} pathName
+ * @property {string} pathBasename
  */
 
 /**
  * Detects the context of a given path.
  *
- * @param {string} directoryPath The directory to detect. Should point to a directory, defaulting to the current directory.
+ * @param {string} [directoryPath=process.cwd()] The directory to detect. Should point to a directory, defaulting to the current working directory.
  *
  * @return {Context} The context of the directory. If a theme or plugin, the type property will contain 'theme' or 'plugin'.
  */
-module.exports = async function detectContext( directoryPath = cwd ) {
+module.exports = async function detectContext( directoryPath = process.cwd() ) {
 	const context = {};
 
 	// Use absolute paths to files so that we can properly read
@@ -51,7 +49,7 @@ module.exports = async function detectContext( directoryPath = cwd ) {
 			if ( type ) {
 				context.type = type.toLowerCase();
 				context.path = absPath;
-				context.pathName = path.basename( absPath );
+				context.pathBasename = path.basename( absPath );
 
 				// Stop the creation of new streams by mutating the iterated array. We can't `break`, because we are inside a function.
 				files.splice( 0 );

--- a/packages/env/lib/detect-context.js
+++ b/packages/env/lib/detect-context.js
@@ -13,14 +13,36 @@ const path = require( 'path' );
 const readDir = util.promisify( fs.readdir );
 const finished = util.promisify( stream.finished );
 
-module.exports = async function detectContext() {
+const cwd = process.cwd();
+
+/**
+ * @typedef Context
+ * @type {Object}
+ * @property {string} type
+ * @property {string} path
+ * @property {string} pathName
+ */
+
+/**
+ * Detects the context of a given path.
+ *
+ * @param {string} directoryPath The directory to detect. Should point to a directory, defaulting to the current directory.
+ *
+ * @return {Context} The context of the directory. If a theme or plugin, the type property will contain 'theme' or 'plugin'.
+ */
+module.exports = async function detectContext( directoryPath = cwd ) {
 	const context = {};
+
+	// Use absolute paths to files so that we can properly read
+	// dependencies not in the current working directory.
+	const absPath = path.resolve( directoryPath );
 
 	// Race multiple file read streams against each other until
 	// a plugin or theme header is found.
-	const files = ( await readDir( './' ) ).filter(
+	const files = ( await readDir( absPath ) ).filter(
 		( file ) => path.extname( file ) === '.php' || path.basename( file ) === 'style.css'
-	);
+	).map( ( fileName ) => path.join( absPath, fileName ) );
+
 	const streams = [];
 	for ( const file of files ) {
 		const fileStream = fs.createReadStream( file, 'utf8' );
@@ -28,7 +50,8 @@ module.exports = async function detectContext() {
 			const [ , type ] = text.match( /(Plugin|Theme) Name: .*[\r\n]/ ) || [];
 			if ( type ) {
 				context.type = type.toLowerCase();
-
+				context.path = absPath;
+				context.pathName = path.basename( absPath );
 				// Stop the creation of new streams by mutating the iterated array. We can't `break`, because we are inside a function.
 				files.splice( 0 );
 				fileStream.destroy();

--- a/packages/env/lib/env.js
+++ b/packages/env/lib/env.js
@@ -11,8 +11,9 @@ const wait = require( 'util' ).promisify( setTimeout );
 /**
  * Internal dependencies
  */
-const detectContext = require( './detect-context' );
 const createDockerComposeConfig = require( './create-docker-compose-config' );
+const detectContext = require( './detect-context' );
+const resolveDependencies = require( './resolve-dependencies' );
 
 // Config Variables
 const cwd = process.cwd();
@@ -38,14 +39,15 @@ const setupSite = ( isTests = false ) =>
 		} --title=${ cwdName } --admin_user=admin --admin_password=password --admin_email=admin@wordpress.org`,
 		isTests
 	);
-const activateContext = ( context, isTests = false ) =>
-	wpCliRun( `wp ${ context.type } activate ${ cwdName }`, isTests );
+const activateContext = ( { type, pathName }, isTests = false ) =>
+	wpCliRun( `wp ${ type } activate ${ pathName }`, isTests );
 const resetDatabase = ( isTests = false ) =>
 	wpCliRun( 'wp db reset --yes', isTests );
 
 module.exports = {
 	async start( { ref, spinner = {} } ) {
 		const context = await detectContext();
+		const dependencies = await resolveDependencies();
 
 		spinner.text = `Downloading WordPress@${ ref } 0/100%.`;
 		const gitFetchOptions = {
@@ -100,7 +102,7 @@ module.exports = {
 		spinner.text = `Starting WordPress@${ ref }.`;
 		fs.writeFileSync(
 			dockerComposeOptions.config,
-			createDockerComposeConfig( cwd, cwdName, cwdTestsPath, context )
+			createDockerComposeConfig( cwdTestsPath, context, dependencies )
 		);
 
 		// These will bring up the database container,
@@ -127,6 +129,7 @@ module.exports = {
 		await Promise.all( [
 			activateContext( context ),
 			activateContext( context, true ),
+			...dependencies.map( activateContext ),
 		] );
 
 		// Remove dangling containers and finish.

--- a/packages/env/lib/env.js
+++ b/packages/env/lib/env.js
@@ -145,6 +145,8 @@ module.exports = {
 
 	async clean( { environment, spinner } ) {
 		const context = await detectContext();
+		const dependencies = await resolveDependencies();
+		const activateDependencies = () => Promise.all( dependencies.map( activateContext ) );
 
 		const description = `${ environment } environment${
 			environment === 'all' ? 's' : ''
@@ -158,6 +160,7 @@ module.exports = {
 				resetDatabase()
 					.then( setupSite )
 					.then( activateContext.bind( null, context ) )
+					.then( activateDependencies )
 					.catch( () => {} )
 			);
 		}
@@ -166,6 +169,7 @@ module.exports = {
 				resetDatabase( true )
 					.then( setupSite.bind( null, true ) )
 					.then( activateContext.bind( null, context, true ) )
+					.then( activateDependencies )
 					.catch( () => {} )
 			);
 		}

--- a/packages/env/lib/env.js
+++ b/packages/env/lib/env.js
@@ -39,8 +39,8 @@ const setupSite = ( isTests = false ) =>
 		} --title=${ cwdName } --admin_user=admin --admin_password=password --admin_email=admin@wordpress.org`,
 		isTests
 	);
-const activateContext = ( { type, pathName }, isTests = false ) =>
-	wpCliRun( `wp ${ type } activate ${ pathName }`, isTests );
+const activateContext = ( { type, pathBasename }, isTests = false ) =>
+	wpCliRun( `wp ${ type } activate ${ pathBasename }`, isTests );
 const resetDatabase = ( isTests = false ) =>
 	wpCliRun( 'wp db reset --yes', isTests );
 

--- a/packages/env/lib/env.js
+++ b/packages/env/lib/env.js
@@ -169,7 +169,6 @@ module.exports = {
 				resetDatabase( true )
 					.then( setupSite.bind( null, true ) )
 					.then( activateContext.bind( null, context, true ) )
-					.then( activateDependencies )
 					.catch( () => {} )
 			);
 		}

--- a/packages/env/lib/resolve-dependencies.js
+++ b/packages/env/lib/resolve-dependencies.js
@@ -1,0 +1,44 @@
+'use strict';
+
+/**
+ * External dependencies
+ */
+const util = require( 'util' );
+const fs = require( 'fs' );
+
+/**
+ * Internal dependencies
+ */
+const detectContext = require( './detect-context' );
+
+/**
+ * Promisified dependencies
+ */
+const readFile = util.promisify( fs.readFile );
+
+/**
+ * Returns an array of dependencies to be mounted in the Docker image.
+ *
+ * Reads from the .wpenv file in the current directory and uses detect
+ * context to make sure the specified dependencies exist and are plugins
+ * and/or themes.
+ *
+ * @return {Array<detectContext.Context>} An array of dependencies in the context format.
+ */
+module.exports = async function resolveDependencies() {
+	const envFile = await readFile( './.wpenv' );
+	const { themes, plugins } = JSON.parse( envFile );
+
+	const dependencyResolvers = [];
+	if ( Array.isArray( themes ) ) {
+		dependencyResolvers.push( ...themes.map( detectContext ) );
+	}
+
+	if ( Array.isArray( plugins ) ) {
+		dependencyResolvers.push( ...plugins.map( detectContext ) );
+	}
+
+	// Return all dependencies which have been detected to be a plugin or a theme.
+	const dependencies = await Promise.all( dependencyResolvers );
+	return dependencies.filter( ( { type } ) => !! type );
+};

--- a/packages/env/lib/resolve-dependencies.js
+++ b/packages/env/lib/resolve-dependencies.js
@@ -26,7 +26,7 @@ const readFile = util.promisify( fs.readFile );
  * @return {Array<detectContext.Context>} An array of dependencies in the context format.
  */
 module.exports = async function resolveDependencies() {
-	const envFile = await readFile( './.wpenv' );
+	const envFile = await readFile( './.wp-env' );
 	const { themes, plugins } = JSON.parse( envFile );
 
 	const dependencyResolvers = [];

--- a/packages/env/lib/resolve-dependencies.js
+++ b/packages/env/lib/resolve-dependencies.js
@@ -26,7 +26,7 @@ const readFile = util.promisify( fs.readFile );
  * @return {Array<detectContext.Context>} An array of dependencies in the context format.
  */
 module.exports = async function resolveDependencies() {
-	const envFile = await readFile( './.wp-env' );
+	const envFile = await readFile( './wp-env.json' );
 	const { themes, plugins } = JSON.parse( envFile );
 
 	const dependencyResolvers = [];

--- a/packages/env/lib/resolve-dependencies.js
+++ b/packages/env/lib/resolve-dependencies.js
@@ -19,7 +19,7 @@ const readFile = util.promisify( fs.readFile );
 /**
  * Returns an array of dependencies to be mounted in the Docker image.
  *
- * Reads from the .wpenv file in the current directory and uses detect
+ * Reads from the wp-env.json file in the current directory and uses detect
  * context to make sure the specified dependencies exist and are plugins
  * and/or themes.
  *


### PR DESCRIPTION
> _Note: This PR has been superseded by https://github.com/WordPress/gutenberg/pull/20002, so follow the information there instead._

## Description
With this PR, a user can specify a `wp-env.json` file with local dependencies for the tool to load. The goal is to make life easier for plugin devs who need to be working on multiple plugins and/or themes at the same time.

1. During the `wp-env start` command, look in the local directory for a `wp-env.json` file.
2. Parse the JSON out of this file into a `plugins` and `themes` array.
3. Use `detect-context` to create context objects for each dependency path. This is the same format used for the local context, which makes things easy. I also added the absolute path to the dependency and basname of the path to the context object so that they can be reused easily.
4. Map each dependency to the Docker config file as a volume.

Here is a JSON file I used to test this:

`wp-calypso/apps/full-site-editing/full-site-editing-plugin/wp-env.json`
```json
{
    "themes": [
        "../../../../themes/varia",
        "../../../../themes/maywood"
    ],
    "plugins": [
        "../../../../gutenberg"
    ]
}
```

That's pretty nasty with the relative paths, but I wanted all developers of the plugin to use it if the repos are in the same top-level directory. For me this is source/gutenberg, source/wp-calypso, etc. Home paths (i.e. `~/source`) don't work since the tilde is not supported in `fs`, and absolute paths wouldn't be flexible for other devs. I'm open to a better approach here if folks have ideas. :)

## How has this been tested?
I verified locally that the specified plugins and themes in the wp-env.json file were loaded into the local WordPress install created by `wp-env start`.

## Types of changes
New Feature.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->

cc @epiqueras 

See here: https://github.com/WordPress/gutenberg/issues/17724#issuecomment-539717371