### PR TITLE
Add eslint rule for object shorthand

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -32,6 +32,7 @@ module.exports = {
 		'@wordpress/dependency-group': 'error',
 		'@wordpress/gutenberg-phase': 'error',
 		'@wordpress/react-no-unsafe-timeout': 'error',
+		'object-shorthand': [ 'error', 'always' ],
 		'no-restricted-syntax': [
 			'error',
 			// NOTE: We can't include the forward slash in our regex or


### PR DESCRIPTION
## Description
Added a rule to the .eslintrc.js file to always use the object shorthand - as requested in https://github.com/WordPress/gutenberg/issues/8009. The wordpress eslint-plugin does not use "always" for this rule so I have added it for Gutenberg.

## How has this been tested?
Tested that failure examples from the eslint docs caused an error message from the linter.
Ran the lint script and did not see any related errors in existing files from this update.

## Types of changes
Linter update (non-breaking change) based on https://eslint.org/docs/rules/object-shorthand

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
