### PR TITLE
Update: Refactor paragraph block to be a functional component

### DIFF
--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { __, _x } from '@wordpress/i18n';
-import { Component } from '@wordpress/element';
+import { useCallback, useMemo } from '@wordpress/element';
 import {
 	PanelBody,
 	ToggleControl,
@@ -27,7 +27,7 @@ import {
 } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
 import { compose } from '@wordpress/compose';
-import { withSelect } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 
 const { getComputedStyle } = window;
 
@@ -45,174 +45,215 @@ const applyFallbackStyles = withFallbackStyles( ( node, ownProps ) => {
 	};
 } );
 
-class ParagraphBlock extends Component {
-	constructor() {
-		super( ...arguments );
+function useAttributeSetter( attribute, setAttributes ) {
+	return useCallback(
+		( newValue ) => {
+			setAttributes( { [ attribute ]: newValue } );
+		},
+		[ attribute, setAttributes ]
+	);
+}
 
-		this.toggleDropCap = this.toggleDropCap.bind( this );
-	}
+function ParagraphToolbar( { direction, setDirection } ) {
+	const isRTL = useSelect( ( select ) => {
+		return select( 'core/block-editor' ).getSettings().isRTL;
+	} );
+	const toolbarControls = useMemo(
+		() => ( [
+			{
+				icon: 'editor-ltr',
+				title: _x( 'Left to right', 'editor button' ),
+				isActive: direction === 'ltr',
+				onClick() {
+					setDirection( direction === 'ltr' ? undefined : 'ltr' );
+				},
+			},
+		] ),
+		[ direction, setDirection ]
+	);
+	return ( isRTL && (
+		<Toolbar
+			controls={ toolbarControls }
+		/>
+	) );
+}
 
-	toggleDropCap() {
-		const { attributes, setAttributes } = this.props;
-		setAttributes( { dropCap: ! attributes.dropCap } );
-	}
+function ParagraphPanelColor( {
+	backgroundColor,
+	fallbackBackgroundColor,
+	fallbackTextColor,
+	fontSize,
+	setBackgroundColor,
+	setTextColor,
+	textColor,
+} ) {
+	const colorSettings = useMemo(
+		() => ( [
+			{
+				value: backgroundColor,
+				onChange: setBackgroundColor,
+				label: __( 'Background Color' ),
+			},
+			{
+				value: textColor,
+				onChange: setTextColor,
+				label: __( 'Text Color' ),
+			},
+		] ),
+		[ backgroundColor, textColor, setBackgroundColor, setTextColor ]
+	);
+	return (
+		<PanelColorSettings
+			title={ __( 'Color Settings' ) }
+			initialOpen={ false }
+			colorSettings={ colorSettings }
+		>
+			<ContrastChecker
+				{ ...{
+					textColor,
+					backgroundColor,
+					fallbackTextColor,
+					fallbackBackgroundColor,
+					fontSize,
+				} }
+			/>
+		</PanelColorSettings>
+	);
+}
 
-	getDropCapHelp( checked ) {
-		return checked ? __( 'Showing large initial letter.' ) : __( 'Toggle to show a large initial letter.' );
-	}
+function ParagraphBlock( {
+	attributes,
+	backgroundColor,
+	className,
+	fallbackBackgroundColor,
+	fallbackFontSize,
+	fallbackTextColor,
+	fontSize,
+	mergeBlocks,
+	onReplace,
+	setAttributes,
+	setBackgroundColor,
+	setFontSize,
+	setTextColor,
+	textColor,
+} ) {
+	const {
+		align,
+		content,
+		dropCap,
+		placeholder,
+		direction,
+	} = attributes;
 
-	render() {
-		const {
-			attributes,
-			setAttributes,
-			mergeBlocks,
-			onReplace,
-			className,
-			backgroundColor,
-			textColor,
-			setBackgroundColor,
-			setTextColor,
-			fallbackBackgroundColor,
-			fallbackTextColor,
-			fallbackFontSize,
-			fontSize,
-			setFontSize,
-			isRTL,
-		} = this.props;
+	const setAlign = useAttributeSetter( 'align', setAttributes );
+	const setContent = useAttributeSetter( 'content', setAttributes );
+	const setDirection = useAttributeSetter( 'direction', setAttributes );
+	const setDropCap = useAttributeSetter( 'dropCap', setAttributes );
 
-		const {
-			align,
-			content,
-			dropCap,
-			placeholder,
+	const toggleDropCap = useCallback(
+		() => (	setDropCap( ! dropCap ) ),
+		[ dropCap, setDropCap ]
+	);
+
+	const onSplit = useCallback(
+		( value ) => {
+			if ( ! value ) {
+				return createBlock( name );
+			}
+
+			return createBlock( name, {
+				...attributes,
+				content: value,
+			} );
+		},
+		[ attributes ]
+	);
+
+	const onRemove = useMemo(
+		() => ( onReplace ? () => onReplace( [] ) : undefined ),
+		[ onReplace ]
+	);
+
+	const richTextStyles = useMemo(
+		() => ( {
+			backgroundColor: backgroundColor.color,
+			color: textColor.color,
+			fontSize: fontSize.size ? fontSize.size + 'px' : undefined,
 			direction,
-		} = attributes;
+		} ),
+		[ backgroundColor.color, textColor.color, fontSize.size, direction ]
+	);
 
-		return (
-			<>
-				<BlockControls>
-					<AlignmentToolbar
-						value={ align }
-						onChange={ ( nextAlign ) => {
-							setAttributes( { align: nextAlign } );
-						} }
-					/>
-					{ isRTL && (
-						<Toolbar
-							controls={ [
-								{
-									icon: 'editor-ltr',
-									title: _x( 'Left to right', 'editor button' ),
-									isActive: direction === 'ltr',
-									onClick() {
-										const nextDirection = direction === 'ltr' ? undefined : 'ltr';
-										setAttributes( {
-											direction: nextDirection,
-										} );
-									},
-								},
-							] }
-						/>
-					) }
-				</BlockControls>
-				<InspectorControls>
-					<PanelBody title={ __( 'Text Settings' ) } className="blocks-font-size">
-						<FontSizePicker
-							fallbackFontSize={ fallbackFontSize }
-							value={ fontSize.size }
-							onChange={ setFontSize }
-						/>
-						<ToggleControl
-							label={ __( 'Drop Cap' ) }
-							checked={ !! dropCap }
-							onChange={ this.toggleDropCap }
-							help={ this.getDropCapHelp }
-						/>
-					</PanelBody>
-					<PanelColorSettings
-						title={ __( 'Color Settings' ) }
-						initialOpen={ false }
-						colorSettings={ [
-							{
-								value: backgroundColor.color,
-								onChange: setBackgroundColor,
-								label: __( 'Background Color' ),
-							},
-							{
-								value: textColor.color,
-								onChange: setTextColor,
-								label: __( 'Text Color' ),
-							},
-						] }
-					>
-						<ContrastChecker
-							{ ...{
-								textColor: textColor.color,
-								backgroundColor: backgroundColor.color,
-								fallbackTextColor,
-								fallbackBackgroundColor,
-							} }
-							fontSize={ fontSize.size }
-						/>
-					</PanelColorSettings>
-				</InspectorControls>
-				<RichText
-					identifier="content"
-					tagName="p"
-					className={ classnames( 'wp-block-paragraph', className, {
-						'has-text-color': textColor.color,
-						'has-background': backgroundColor.color,
-						'has-drop-cap': dropCap,
-						[ `has-text-align-${ align }` ]: align,
-						[ backgroundColor.class ]: backgroundColor.class,
-						[ textColor.class ]: textColor.class,
-						[ fontSize.class ]: fontSize.class,
-					} ) }
-					style={ {
-						backgroundColor: backgroundColor.color,
-						color: textColor.color,
-						fontSize: fontSize.size ? fontSize.size + 'px' : undefined,
-						direction,
-					} }
-					value={ content }
-					onChange={ ( nextContent ) => {
-						setAttributes( {
-							content: nextContent,
-						} );
-					} }
-					onSplit={ ( value ) => {
-						if ( ! value ) {
-							return createBlock( name );
-						}
-
-						return createBlock( name, {
-							...attributes,
-							content: value,
-						} );
-					} }
-					onMerge={ mergeBlocks }
-					onReplace={ onReplace }
-					onRemove={ onReplace ? () => onReplace( [] ) : undefined }
-					aria-label={ content ? __( 'Paragraph block' ) : __( 'Empty block; start writing or type forward slash to choose a block' ) }
-					placeholder={ placeholder || __( 'Start writing or type / to choose a block' ) }
-					__unstableEmbedURLOnPaste
+	return (
+		<>
+			<BlockControls>
+				<AlignmentToolbar
+					value={ align }
+					onChange={ setAlign }
 				/>
-			</>
-		);
-	}
+				<ParagraphToolbar
+					direction={ direction }
+					setDirection={ setDirection }
+				/>
+			</BlockControls>
+			<InspectorControls>
+				<PanelBody title={ __( 'Text Settings' ) } className="blocks-font-size">
+					<FontSizePicker
+						fallbackFontSize={ fallbackFontSize }
+						value={ fontSize.size }
+						onChange={ setFontSize }
+					/>
+					<ToggleControl
+						label={ __( 'Drop Cap' ) }
+						checked={ !! dropCap }
+						onChange={ toggleDropCap }
+						help={ dropCap ?
+							__( 'Showing large initial letter.' ) :
+							__( 'Toggle to show a large initial letter.' )
+						}
+					/>
+				</PanelBody>
+				<ParagraphPanelColor
+					backgroundColor={ backgroundColor.color }
+					fallbackBackgroundColor={ fallbackBackgroundColor }
+					fallbackTextColor={ fallbackTextColor }
+					fontSize={ fontSize.size }
+					setBackgroundColor={ setBackgroundColor }
+					setTextColor={ setTextColor }
+					textColor={ textColor.color }
+				/>
+			</InspectorControls>
+			<RichText
+				identifier="content"
+				tagName="p"
+				className={ classnames( 'wp-block-paragraph', className, {
+					'has-text-color': textColor.color,
+					'has-background': backgroundColor.color,
+					'has-drop-cap': dropCap,
+					[ `has-text-align-${ align }` ]: align,
+					[ backgroundColor.class ]: backgroundColor.class,
+					[ textColor.class ]: textColor.class,
+					[ fontSize.class ]: fontSize.class,
+				} ) }
+				style={ richTextStyles }
+				value={ content }
+				onChange={ setContent }
+				onSplit={ onSplit }
+				onMerge={ mergeBlocks }
+				onReplace={ onReplace }
+				onRemove={ onRemove }
+				aria-label={ content ? __( 'Paragraph block' ) : __( 'Empty block; start writing or type forward slash to choose a block' ) }
+				placeholder={ placeholder || __( 'Start writing or type / to choose a block' ) }
+				__unstableEmbedURLOnPaste
+			/>
+		</>
+	);
 }
 
 const ParagraphEdit = compose( [
 	withColors( 'backgroundColor', { textColor: 'color' } ),
 	withFontSizes( 'fontSize' ),
 	applyFallbackStyles,
-	withSelect( ( select ) => {
-		const { getSettings } = select( 'core/block-editor' );
-
-		return {
-			isRTL: getSettings().isRTL,
-		};
-	} ),
 ] )( ParagraphBlock );
 
 export default ParagraphEdit;


### PR DESCRIPTION
## Description
This PR updates the paragraph block to be a functional component.
We are introducing new hook based API's (e.g: the colors hook) and these API's can only be used if the component is functional.

## How has this been tested?
I verified the paragraph still works as before.
