### PR TITLE
[RNMobile] Gallery - Tiles component

### DIFF
--- a/packages/block-library/src/gallery/tiles-styles.native.scss
+++ b/packages/block-library/src/gallery/tiles-styles.native.scss
@@ -1,0 +1,11 @@
+.containerStyle {
+	flex-direction: row;
+	flex-wrap: wrap;
+}
+
+.tileStyle {
+	overflow: hidden;
+	flex-direction: row;
+	align-items: center;
+	border-color: transparent;
+}

--- a/packages/block-library/src/gallery/tiles.native.js
+++ b/packages/block-library/src/gallery/tiles.native.js
@@ -25,6 +25,30 @@ function Tiles( props ) {
 	const lastRow = Math.floor( lastTile / columns );
 
 	const wrappedChildren = Children.map( children, ( child, index ) => {
+		/** Since we don't have `calc()`, we must calculate our spacings here in
+		 * order to preserve even spacing between tiles and equal width for tiles
+		 * in a given row.
+		 *
+		 * In order to ensure equal sizing of tile contents, we distribute the
+		 * spacing such that each tile has an equal "share" of the fixed spacing.
+		 * To keep the tiles properly aligned within their rows, we calculate the
+		 * left and right border widths based on the tile's relative position within
+		 * the row.
+		 *
+		 * Note: we use transparent borders instead of margins so that the fixed
+		 * spacing is included within the relative spacing (i.e. width percentage),
+		 * and wrapping behavior is preserved.
+		 *
+		 *  - The left most tile in a row must have left border width of zero.
+		 *  - The right most tile in a row must have a right border width of zero.
+		 *
+		 * The values of these widths are interpolated for tiles in between. The
+		 * right border width is complementary with the left border width of the
+		 * next tile (i.e. the right border of [tile n] + the left border of
+		 * [tile n + 1] will be equal for all tiles except the last one in a given
+		 * row).
+		 */
+
 		const row = Math.floor( index / columns );
 		const rowLength = row === lastRow ? ( lastTile % columns ) + 1 : columns;
 		const indexInRow = index % columns;

--- a/packages/block-library/src/gallery/tiles.native.js
+++ b/packages/block-library/src/gallery/tiles.native.js
@@ -1,0 +1,43 @@
+/**
+ * External dependencies
+ */
+import { View } from 'react-native';
+
+/**
+ * WordPress dependencies
+ */
+import { Children } from '@wordpress/element';
+
+function Tiles( props ) {
+	const {
+		tilesProps: {
+		//	align,
+			columns,
+		//	imageCrop,
+		},
+		children,
+	} = props;
+
+	return (
+		<View
+			style={ {
+				flexDirection: 'row',
+				flexWrap: 'wrap',
+			} }
+		>
+			{ Children.map( children, ( child ) => {
+				return (
+					<View
+						style={ {
+							flex: 1,
+							flexBasis: ( ( 1 / columns ) * 100 ) + '%',
+						} }>
+						{ child }
+					</View>
+				);
+			}	) }
+		</View>
+	);
+}
+
+export default Tiles;

--- a/packages/block-library/src/gallery/tiles.native.js
+++ b/packages/block-library/src/gallery/tiles.native.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { View } from 'react-native';
+import { View, StyleSheet } from 'react-native';
 
 /**
  * WordPress dependencies
@@ -18,7 +18,10 @@ function Tiles( props ) {
 		columns,
 		children,
 		spacing = 10,
+		style,
 	} = props;
+
+	const { compose } = StyleSheet;
 
 	const tileCount = Children.count( children );
 	const lastTile = tileCount - 1;
@@ -66,8 +69,10 @@ function Tiles( props ) {
 		);
 	} );
 
+	const containerStyle = compose( styles.containerStyle, style );
+
 	return (
-		<View style={ styles.containerStyle }>
+		<View style={ containerStyle }>
 			{ wrappedChildren }
 		</View>
 	);

--- a/packages/block-library/src/gallery/tiles.native.js
+++ b/packages/block-library/src/gallery/tiles.native.js
@@ -8,32 +8,56 @@ import { View } from 'react-native';
  */
 import { Children } from '@wordpress/element';
 
+const containerStyle = {
+	flex: 1,
+	flexDirection: 'row',
+	flexWrap: 'wrap',
+};
+
 function Tiles( props ) {
 	const {
-		//	align,
 		columns,
-		//	imageCrop,
 		children,
+		groutSpacing = 10,
 	} = props;
 
+	const tileBorderWidth = groutSpacing / 2;
+	const tileCount = Children.count( children );
+	const lastRow = Math.floor( ( tileCount - 1 ) / columns );
+
+	const wrappedChilren = Children.map( children, ( child, index ) => {
+		const row = Math.floor( index / columns );
+		const isLastItem = ( index + 1 ) === tileCount;
+
+		const isInFirstRow = row === 0;
+		const isInLastRow = row === lastRow;
+
+		const isFirstInRow = index % columns === 0;
+		const isLastInRow = ( index + 1 ) % columns === 0 || isLastItem;
+
+		const tileStyle = {
+			flex: 1,
+			flexBasis: ( ( 1 / columns ) * 100 ) + '%',
+			overflow: 'hidden',
+			flexDirection: 'row',
+			alignItems: 'center',
+			borderColor: 'transparent',
+			borderLeftWidth: isFirstInRow ? 0 : tileBorderWidth,
+			borderRightWidth: isLastInRow ? 0 : tileBorderWidth,
+			borderTopWidth: isInFirstRow ? 0 : tileBorderWidth,
+			borderBottomWidth: isInLastRow ? 0 : tileBorderWidth,
+		};
+
+		return (
+			<View style={ tileStyle }>
+				{ child }
+			</View>
+		);
+	}	)
+
 	return (
-		<View
-			style={ {
-				flexDirection: 'row',
-				flexWrap: 'wrap',
-			} }
-		>
-			{ Children.map( children, ( child ) => {
-				return (
-					<View
-						style={ {
-							flex: 1,
-							flexBasis: ( ( 1 / columns ) * 100 ) + '%',
-						} }>
-						{ child }
-					</View>
-				);
-			}	) }
+		<View style={ containerStyle }>
+			{ wrappedChilren }
 		</View>
 	);
 }

--- a/packages/block-library/src/gallery/tiles.native.js
+++ b/packages/block-library/src/gallery/tiles.native.js
@@ -24,7 +24,7 @@ function Tiles( props ) {
 	const {
 		columns,
 		children,
-		groutSpacing = 10,
+		spacing = 10,
 	} = props;
 
 	const tileCount = Children.count( children );
@@ -39,10 +39,10 @@ function Tiles( props ) {
 		return (
 			<View style={ [ tileStyle, {
 				width: ( ( 1 / rowLength ) * 100 ) + '%',
-				borderLeftWidth: groutSpacing * ( indexInRow / rowLength ),
-				borderRightWidth: groutSpacing * ( 1 - ( ( indexInRow + 1 ) / rowLength ) ),
-				borderTopWidth: row === 0 ? 0 : groutSpacing / 2,
-				borderBottomWidth: row === lastRow ? 0 : groutSpacing / 2,
+				borderLeftWidth: spacing * ( indexInRow / rowLength ),
+				borderRightWidth: spacing * ( 1 - ( ( indexInRow + 1 ) / rowLength ) ),
+				borderTopWidth: row === 0 ? 0 : spacing / 2,
+				borderBottomWidth: row === lastRow ? 0 : spacing / 2,
 			} ] }>
 				{ child }
 			</View>

--- a/packages/block-library/src/gallery/tiles.native.js
+++ b/packages/block-library/src/gallery/tiles.native.js
@@ -10,11 +10,9 @@ import { Children } from '@wordpress/element';
 
 function Tiles( props ) {
 	const {
-		tilesProps: {
 		//	align,
-			columns,
+		columns,
 		//	imageCrop,
-		},
 		children,
 	} = props;
 

--- a/packages/block-library/src/gallery/tiles.native.js
+++ b/packages/block-library/src/gallery/tiles.native.js
@@ -6,83 +6,52 @@ import { View } from 'react-native';
 /**
  * WordPress dependencies
  */
-import { Children, useEffect, useLayoutEffect, useState } from '@wordpress/element';
+import { Children } from '@wordpress/element';
 
 const containerStyle = {
-	// flex: 1,
 	flexDirection: 'row',
 	flexWrap: 'wrap',
 };
 
-function Tiles( props ) {
-	// const [ columns, setColumns ] = useState();
+const tileStyle = {
+	overflow: 'hidden',
+	flexDirection: 'row',
+	alignItems: 'center',
+	borderColor: 'transparent',
+};
 
+function Tiles( props ) {
 	const {
-		// columns: newColumns,
 		columns,
 		children,
 		groutSpacing = 10,
 	} = props;
 
-	// useEffect(() => {
-	// 	// if ( columns !== newColumns ) {
-	// 		setTimeout(() => {
-	// 			setColumns(newColumns);
-	// 		}, 1);
-	// 	// }
-	// });
-
-	// useLayoutEffect(() => {
-	// 	// setTimeout(() => {
-	// 		setColumns(newColumns);
-	// 	// }, 1);
-	// });
-
-	const tileBorderWidth = groutSpacing / 2;
 	const tileCount = Children.count( children );
-	const lastRow = Math.floor( ( tileCount - 1 ) / columns );
+	const lastTile = tileCount - 1;
+	const lastRow = Math.floor( lastTile / columns );
 
-	const wrappedChilren = Children.map( children, ( child, index ) => {
+	const wrappedChildren = Children.map( children, ( child, index ) => {
 		const row = Math.floor( index / columns );
-		const isLastItem = ( index + 1 ) === tileCount;
-
-		const isInFirstRow = row === 0;
-		const isInLastRow = row === lastRow;
-
-		const isFirstInRow = index % columns === 0;
-		const isLastInRow = ( index + 1 ) % columns === 0 || isLastItem;
-
-		const tileStyle = {
-			flex: 1,
-			flexBasis: ( ( 1 / columns ) * 100 ) + '%',
-			overflow: 'hidden',
-			flexDirection: 'row',
-			alignItems: 'center',
-			borderColor: 'transparent',
-			borderLeftWidth: isFirstInRow ? 0 : tileBorderWidth,
-			borderRightWidth: isLastInRow ? 0 : tileBorderWidth,
-			borderTopWidth: isInFirstRow ? 0 : tileBorderWidth,
-			borderBottomWidth: isInLastRow ? 0 : tileBorderWidth,
-		};
+		const rowLength = row === lastRow ? lastTile % columns + 1: columns;
+		const indexInRow = index % columns;
 
 		return (
-			<View style={ tileStyle }
-				onLayout={ (e) => {
-					console.log(`Tile ${index} width: ${e.nativeEvent.layout.width}`)
-				} }
-			>
+			<View style={ [ tileStyle, {
+				flexBasis: ( ( 1 / rowLength ) * 100 ) + '%',
+				borderLeftWidth: groutSpacing * ( indexInRow / rowLength ),
+				borderRightWidth: groutSpacing * ( 1 - ( indexInRow + 1 ) / rowLength ),
+				borderTopWidth: row === 0 ? 0 : groutSpacing / 2,
+				borderBottomWidth: row === lastRow ? 0 : groutSpacing / 2,
+			} ]}>
 				{ child }
 			</View>
 		);
-	}	)
+	} );
 
 	return (
-		<View style={ containerStyle }
-		 onLayout={ (e) => {
-			 console.log(`Tiles width: ${e.nativeEvent.layout.width}`)
-			} }
-		 >
-			{ wrappedChilren }
+		<View style={ containerStyle }>
+			{ wrappedChildren }
 		</View>
 	);
 }

--- a/packages/block-library/src/gallery/tiles.native.js
+++ b/packages/block-library/src/gallery/tiles.native.js
@@ -38,7 +38,7 @@ function Tiles( props ) {
 
 		return (
 			<View style={ [ tileStyle, {
-				flexBasis: ( ( 1 / rowLength ) * 100 ) + '%',
+				width: ( ( 1 / rowLength ) * 100 ) + '%',
 				borderLeftWidth: groutSpacing * ( indexInRow / rowLength ),
 				borderRightWidth: groutSpacing * ( 1 - ( indexInRow + 1 ) / rowLength ),
 				borderTopWidth: row === 0 ? 0 : groutSpacing / 2,

--- a/packages/block-library/src/gallery/tiles.native.js
+++ b/packages/block-library/src/gallery/tiles.native.js
@@ -6,20 +6,37 @@ import { View } from 'react-native';
 /**
  * WordPress dependencies
  */
-import { Children } from '@wordpress/element';
+import { Children, useEffect, useLayoutEffect, useState } from '@wordpress/element';
 
 const containerStyle = {
-	flex: 1,
+	// flex: 1,
 	flexDirection: 'row',
 	flexWrap: 'wrap',
 };
 
 function Tiles( props ) {
+	// const [ columns, setColumns ] = useState();
+
 	const {
+		// columns: newColumns,
 		columns,
 		children,
 		groutSpacing = 10,
 	} = props;
+
+	// useEffect(() => {
+	// 	// if ( columns !== newColumns ) {
+	// 		setTimeout(() => {
+	// 			setColumns(newColumns);
+	// 		}, 1);
+	// 	// }
+	// });
+
+	// useLayoutEffect(() => {
+	// 	// setTimeout(() => {
+	// 		setColumns(newColumns);
+	// 	// }, 1);
+	// });
 
 	const tileBorderWidth = groutSpacing / 2;
 	const tileCount = Children.count( children );
@@ -49,14 +66,22 @@ function Tiles( props ) {
 		};
 
 		return (
-			<View style={ tileStyle }>
+			<View style={ tileStyle }
+				onLayout={ (e) => {
+					console.log(`Tile ${index} width: ${e.nativeEvent.layout.width}`)
+				} }
+			>
 				{ child }
 			</View>
 		);
 	}	)
 
 	return (
-		<View style={ containerStyle }>
+		<View style={ containerStyle }
+		 onLayout={ (e) => {
+			 console.log(`Tiles width: ${e.nativeEvent.layout.width}`)
+			} }
+		 >
 			{ wrappedChilren }
 		</View>
 	);

--- a/packages/block-library/src/gallery/tiles.native.js
+++ b/packages/block-library/src/gallery/tiles.native.js
@@ -33,17 +33,17 @@ function Tiles( props ) {
 
 	const wrappedChildren = Children.map( children, ( child, index ) => {
 		const row = Math.floor( index / columns );
-		const rowLength = row === lastRow ? lastTile % columns + 1: columns;
+		const rowLength = row === lastRow ? ( lastTile % columns ) + 1 : columns;
 		const indexInRow = index % columns;
 
 		return (
 			<View style={ [ tileStyle, {
 				width: ( ( 1 / rowLength ) * 100 ) + '%',
 				borderLeftWidth: groutSpacing * ( indexInRow / rowLength ),
-				borderRightWidth: groutSpacing * ( 1 - ( indexInRow + 1 ) / rowLength ),
+				borderRightWidth: groutSpacing * ( 1 - ( ( indexInRow + 1 ) / rowLength ) ),
 				borderTopWidth: row === 0 ? 0 : groutSpacing / 2,
 				borderBottomWidth: row === lastRow ? 0 : groutSpacing / 2,
-			} ]}>
+			} ] }>
 				{ child }
 			</View>
 		);

--- a/packages/block-library/src/gallery/tiles.native.js
+++ b/packages/block-library/src/gallery/tiles.native.js
@@ -55,7 +55,7 @@ function Tiles( props ) {
 
 		return (
 			<View style={ [ styles.tileStyle, {
-				width: ( ( 1 / rowLength ) * 100 ) + '%',
+				width: `${ 100 / rowLength }%`,
 				borderLeftWidth: spacing * ( indexInRow / rowLength ),
 				borderRightWidth: spacing * ( 1 - ( ( indexInRow + 1 ) / rowLength ) ),
 				borderTopWidth: row === 0 ? 0 : spacing / 2,

--- a/packages/block-library/src/gallery/tiles.native.js
+++ b/packages/block-library/src/gallery/tiles.native.js
@@ -8,17 +8,10 @@ import { View } from 'react-native';
  */
 import { Children } from '@wordpress/element';
 
-const containerStyle = {
-	flexDirection: 'row',
-	flexWrap: 'wrap',
-};
-
-const tileStyle = {
-	overflow: 'hidden',
-	flexDirection: 'row',
-	alignItems: 'center',
-	borderColor: 'transparent',
-};
+/**
+ * Internal dependencies
+ */
+import styles from './tiles-styles';
 
 function Tiles( props ) {
 	const {
@@ -37,7 +30,7 @@ function Tiles( props ) {
 		const indexInRow = index % columns;
 
 		return (
-			<View style={ [ tileStyle, {
+			<View style={ [ styles.tileStyle, {
 				width: ( ( 1 / rowLength ) * 100 ) + '%',
 				borderLeftWidth: spacing * ( indexInRow / rowLength ),
 				borderRightWidth: spacing * ( 1 - ( ( indexInRow + 1 ) / rowLength ) ),
@@ -50,7 +43,7 @@ function Tiles( props ) {
 	} );
 
 	return (
-		<View style={ containerStyle }>
+		<View style={ styles.containerStyle }>
 			{ wrappedChildren }
 		</View>
 	);

--- a/packages/block-library/src/gallery/tiles.native.js
+++ b/packages/block-library/src/gallery/tiles.native.js
@@ -11,7 +11,7 @@ import { Children } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import styles from './tiles-styles';
+import styles from './tiles-styles.scss';
 
 function Tiles( props ) {
 	const {

--- a/packages/block-library/src/gallery/tiles.native.js
+++ b/packages/block-library/src/gallery/tiles.native.js
@@ -33,21 +33,20 @@ function Tiles( props ) {
 		 * in a given row.
 		 *
 		 * In order to ensure equal sizing of tile contents, we distribute the
-		 * spacing such that each tile has an equal "share" of the fixed spacing.
-		 * To keep the tiles properly aligned within their rows, we calculate the
-		 * left and right border widths based on the tile's relative position within
-		 * the row.
+		 * spacing such that each tile has an equal "share" of the fixed spacing. To
+		 * keep the tiles properly aligned within their rows, we calculate the left
+		 * and right paddings based on the tile's relative position within the row.
 		 *
-		 * Note: we use transparent borders instead of margins so that the fixed
-		 * spacing is included within the relative spacing (i.e. width percentage),
-		 * and wrapping behavior is preserved.
+		 * Note: we use padding instead of margins so that the fixed spacing is
+		 * included within the relative spacing (i.e. width percentage), and
+		 * wrapping behavior is preserved.
 		 *
-		 *  - The left most tile in a row must have left border width of zero.
-		 *  - The right most tile in a row must have a right border width of zero.
+		 *  - The left most tile in a row must have left padding of zero.
+		 *  - The right most tile in a row must have a right padding of zero.
 		 *
-		 * The values of these widths are interpolated for tiles in between. The
-		 * right border width is complementary with the left border width of the
-		 * next tile (i.e. the right border of [tile n] + the left border of
+		 * The values of these left and right paddings are interpolated for tiles in
+		 * between. The right padding is complementary with the left padding of the
+		 * next tile (i.e. the right padding of [tile n] + the left padding of
 		 * [tile n + 1] will be equal for all tiles except the last one in a given
 		 * row).
 		 */
@@ -59,10 +58,10 @@ function Tiles( props ) {
 		return (
 			<View style={ [ styles.tileStyle, {
 				width: `${ 100 / rowLength }%`,
-				borderLeftWidth: spacing * ( indexInRow / rowLength ),
-				borderRightWidth: spacing * ( 1 - ( ( indexInRow + 1 ) / rowLength ) ),
-				borderTopWidth: row === 0 ? 0 : spacing / 2,
-				borderBottomWidth: row === lastRow ? 0 : spacing / 2,
+				paddingLeft: spacing * ( indexInRow / rowLength ),
+				paddingRight: spacing * ( 1 - ( ( indexInRow + 1 ) / rowLength ) ),
+				paddingTop: row === 0 ? 0 : spacing / 2,
+				paddingBottom: row === lastRow ? 0 : spacing / 2,
 			} ] }>
 				{ child }
 			</View>


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
This PR introduces a Tiles component for the semi-cross-platform Gallery block. The purpose of this component is to introduce a responsive layout abstraction for mobile views.

### PR Hierarchy
This PR is part of the [PR hierarchy described here](https://github.com/wordpress-mobile/gutenberg-mobile/issues/1416#issuecomment-551057738). This PR can be tested with the aggregate changeset and integration of components within the related PRs by checking out the branch of the "top level" PR: https://github.com/WordPress/gutenberg/pull/18265.

## To test
Test this component by checking out the branch of the "top level" PR: https://github.com/WordPress/gutenberg/pull/18265.

Open the gallery settings from the demo app and change the "Columns" value (in the BottomSheet) to different values.

#### Expected behavior in portrait

* Tiles layout should update to reflect the columns setting (visible columns should not exceed 2, but will go down to 1)
* Tiles should be evenly spaced
* Tiles in last row should expand to fill available width

#### Expected behavior in landscape

* Tiles layout should update to reflect the columns setting
* Tiles should be evenly spaced
* Tiles in last row should expand to fill available width

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
