### PR TITLE
Fix: Media & Text Loses upload status if post is closed/reopened during the upload

### DIFF
--- a/packages/block-library/src/media-text/edit.native.js
+++ b/packages/block-library/src/media-text/edit.native.js
@@ -77,13 +77,11 @@ class MediaTextEdit extends Component {
 		setAttributes( {
 			mediaAlt: media.alt,
 			mediaId: media.id,
+			mediaType,
 			mediaUrl: src || media.url,
 			imageFill: undefined,
 			focalPoint: undefined,
 		} );
-		if ( mediaType ) { // We don't want to delete mediaType
-			setAttributes( { mediaType } );
-		}
 	}
 
 	onMediaUpdate( media ) {

--- a/packages/block-library/src/media-text/edit.native.js
+++ b/packages/block-library/src/media-text/edit.native.js
@@ -77,11 +77,13 @@ class MediaTextEdit extends Component {
 		setAttributes( {
 			mediaAlt: media.alt,
 			mediaId: media.id,
-			mediaType,
 			mediaUrl: src || media.url,
 			imageFill: undefined,
 			focalPoint: undefined,
 		} );
+		if ( mediaType ) { // We don't want to delete mediaType
+			setAttributes( { mediaType } );
+		}
 	}
 
 	onMediaUpdate( media ) {

--- a/packages/block-library/src/media-text/media-container.native.js
+++ b/packages/block-library/src/media-text/media-container.native.js
@@ -66,7 +66,7 @@ class MediaContainer extends Component {
 
 		if ( mediaId && mediaUrl && ! isURL( mediaUrl ) ) {
 			if ( mediaUrl.indexOf( 'file:' ) === 0 && mediaType === MEDIA_TYPE_IMAGE ) {
-				// We don't want to call this for video because it is starting a media upload for cover url of the video
+				// We don't want to call this for video because it is starting a media upload for the cover url
 				requestMediaImport( mediaUrl, ( id, url ) => {
 					if ( url ) {
 						onMediaUpdate( { id, url } );

--- a/packages/block-library/src/media-text/media-container.native.js
+++ b/packages/block-library/src/media-text/media-container.native.js
@@ -72,6 +72,7 @@ class MediaContainer extends Component {
 					}
 				} );
 			}
+
 			mediaUploadSync();
 		}
 	}

--- a/packages/block-library/src/media-text/media-container.native.js
+++ b/packages/block-library/src/media-text/media-container.native.js
@@ -62,10 +62,11 @@ class MediaContainer extends Component {
 	}
 
 	componentDidMount() {
-		const { mediaId, mediaUrl, onMediaUpdate } = this.props;
+		const { mediaId, mediaUrl, onMediaUpdate, mediaType } = this.props;
 
 		if ( mediaId && mediaUrl && ! isURL( mediaUrl ) ) {
-			if ( mediaUrl.indexOf( 'file:' ) === 0 ) {
+			if ( mediaUrl.indexOf( 'file:' ) === 0 && mediaType === MEDIA_TYPE_IMAGE ) {
+				// We don't want to call this for video because it is starting a media upload for cover url of the video
 				requestMediaImport( mediaUrl, ( id, url ) => {
 					if ( url ) {
 						onMediaUpdate( { id, url } );

--- a/packages/block-library/src/media-text/media-container.native.js
+++ b/packages/block-library/src/media-text/media-container.native.js
@@ -72,7 +72,6 @@ class MediaContainer extends Component {
 					}
 				} );
 			}
-
 			mediaUploadSync();
 		}
 	}

--- a/packages/block-library/src/media-text/media-container.native.js
+++ b/packages/block-library/src/media-text/media-container.native.js
@@ -62,17 +62,13 @@ class MediaContainer extends Component {
 	}
 
 	componentDidMount() {
-		const { mediaId, mediaUrl, onSelectMedia } = this.props;
+		const { mediaId, mediaUrl, onMediaUpdate } = this.props;
 
 		if ( mediaId && mediaUrl && ! isURL( mediaUrl ) ) {
 			if ( mediaUrl.indexOf( 'file:' ) === 0 ) {
-				requestMediaImport( mediaUrl, ( id, url, type ) => {
+				requestMediaImport( mediaUrl, ( id, url ) => {
 					if ( url ) {
-						onSelectMedia( {
-							media_type: type,
-							id,
-							url,
-						} );
+						onMediaUpdate( { id, url } );
 					}
 				} );
 			}


### PR DESCRIPTION
## Description
Fix: 
https://github.com/wordpress-mobile/gutenberg-mobile/issues/1504
 https://github.com/wordpress-mobile/gutenberg-mobile/issues/1508

Gutenberg PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1506

## How has this been tested?

Tested with WordPressiOS 

- Add media & text block, tap placeholder and choose Choose from device
- Select an image
- Start upload but before it finishes close the post by selecting Update Post
Re-open the post
- Verify that the upload progress is shown properly
- Verify that a dimmed & low resolution copy of the uploaded image is shown
- Tap close(x), select Update Post
- Wait until upload is finished
- Re-open the post and see that uploaded image is shown

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
