### PR TITLE
Link images in media + text

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -314,6 +314,22 @@ _Related_
 
 -   <https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/inspector-controls/README.md>
 
+<a name="LINK_DESTINATION_ATTACHMENT" href="#LINK_DESTINATION_ATTACHMENT">#</a> **LINK_DESTINATION_ATTACHMENT**
+
+Undocumented declaration.
+
+<a name="LINK_DESTINATION_CUSTOM" href="#LINK_DESTINATION_CUSTOM">#</a> **LINK_DESTINATION_CUSTOM**
+
+Undocumented declaration.
+
+<a name="LINK_DESTINATION_MEDIA" href="#LINK_DESTINATION_MEDIA">#</a> **LINK_DESTINATION_MEDIA**
+
+Undocumented declaration.
+
+<a name="LINK_DESTINATION_NONE" href="#LINK_DESTINATION_NONE">#</a> **LINK_DESTINATION_NONE**
+
+Undocumented declaration.
+
 <a name="MediaPlaceholder" href="#MediaPlaceholder">#</a> **MediaPlaceholder**
 
 _Related_
@@ -346,6 +362,10 @@ Scrolls the multi block selection end into view if not in view already. This
 is important to do after selection by keyboard.
 
 <a name="NavigableToolbar" href="#NavigableToolbar">#</a> **NavigableToolbar**
+
+Undocumented declaration.
+
+<a name="NEW_TAB_REL" href="#NEW_TAB_REL">#</a> **NEW_TAB_REL**
 
 Undocumented declaration.
 
@@ -419,6 +439,14 @@ _Properties_
 -   _\_\_experimentalEnablePageTemplates_ `boolean`: Whether the user has enabled the Page Templates
 
 <a name="SkipToSelectedBlock" href="#SkipToSelectedBlock">#</a> **SkipToSelectedBlock**
+
+Undocumented declaration.
+
+<a name="stopPropagation" href="#stopPropagation">#</a> **stopPropagation**
+
+Undocumented declaration.
+
+<a name="stopPropagationRelevantKeys" href="#stopPropagationRelevantKeys">#</a> **stopPropagationRelevantKeys**
 
 Undocumented declaration.
 

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -442,14 +442,6 @@ _Properties_
 
 Undocumented declaration.
 
-<a name="stopPropagation" href="#stopPropagation">#</a> **stopPropagation**
-
-Undocumented declaration.
-
-<a name="stopPropagationRelevantKeys" href="#stopPropagationRelevantKeys">#</a> **stopPropagationRelevantKeys**
-
-Undocumented declaration.
-
 <a name="storeConfig" href="#storeConfig">#</a> **storeConfig**
 
 Block editor data store configuration.

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -314,22 +314,6 @@ _Related_
 
 -   <https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/inspector-controls/README.md>
 
-<a name="LINK_DESTINATION_ATTACHMENT" href="#LINK_DESTINATION_ATTACHMENT">#</a> **LINK_DESTINATION_ATTACHMENT**
-
-Undocumented declaration.
-
-<a name="LINK_DESTINATION_CUSTOM" href="#LINK_DESTINATION_CUSTOM">#</a> **LINK_DESTINATION_CUSTOM**
-
-Undocumented declaration.
-
-<a name="LINK_DESTINATION_MEDIA" href="#LINK_DESTINATION_MEDIA">#</a> **LINK_DESTINATION_MEDIA**
-
-Undocumented declaration.
-
-<a name="LINK_DESTINATION_NONE" href="#LINK_DESTINATION_NONE">#</a> **LINK_DESTINATION_NONE**
-
-Undocumented declaration.
-
 <a name="MediaPlaceholder" href="#MediaPlaceholder">#</a> **MediaPlaceholder**
 
 _Related_
@@ -362,10 +346,6 @@ Scrolls the multi block selection end into view if not in view already. This
 is important to do after selection by keyboard.
 
 <a name="NavigableToolbar" href="#NavigableToolbar">#</a> **NavigableToolbar**
-
-Undocumented declaration.
-
-<a name="NEW_TAB_REL" href="#NEW_TAB_REL">#</a> **NEW_TAB_REL**
 
 Undocumented declaration.
 

--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -45,6 +45,7 @@ export { default as ToolSelector } from './tool-selector';
 export { default as URLInput } from './url-input';
 export { default as URLInputButton } from './url-input/button';
 export { default as URLPopover } from './url-popover';
+export * from './url-popover/image-url-input-ui';
 export { default as withColorContext } from './color-palette/with-color-context';
 
 /*

--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -45,7 +45,7 @@ export { default as ToolSelector } from './tool-selector';
 export { default as URLInput } from './url-input';
 export { default as URLInputButton } from './url-input/button';
 export { default as URLPopover } from './url-popover';
-export * from './url-popover/image-url-input-ui';
+export { __experimentalImageURLInputUI } from './url-popover/image-url-input-ui';
 export { default as withColorContext } from './color-palette/with-color-context';
 
 /*

--- a/packages/block-editor/src/components/url-popover/image-url-input-ui.js
+++ b/packages/block-editor/src/components/url-popover/image-url-input-ui.js
@@ -39,21 +39,11 @@ export const NEW_TAB_REL = [ 'noreferrer', 'noopener' ];
 
 const icon = <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path d="M0,0h24v24H0V0z" fill="none" /><Path d="m19 5v14h-14v-14h14m0-2h-14c-1.1 0-2 0.9-2 2v14c0 1.1 0.9 2 2 2h14c1.1 0 2-0.9 2-2v-14c0-1.1-0.9-2-2-2z" /><Path d="m14.14 11.86l-3 3.87-2.14-2.59-3 3.86h12l-3.86-5.14z" /></SVG>;
 
-const stopPropagation = ( event ) => {
-	event.stopPropagation();
-};
-
-const stopPropagationRelevantKeys = ( event ) => {
-	if ( [ LEFT, DOWN, RIGHT, UP, BACKSPACE, ENTER ].indexOf( event.keyCode ) > -1 ) {
-		// Stop the key event from propagating up to ObserveTyping.startTypingInTextField.
-		event.stopPropagation();
-	}
-};
 const ImageURLInputUI = ( {
 	linkDestination,
 	onChangeUrl,
 	url,
-	mediaType,
+	mediaType = 'image',
 	mediaUrl,
 	mediaLink,
 	linkTarget,
@@ -69,6 +59,17 @@ const ImageURLInputUI = ( {
 	const [ urlInput, setUrlInput ] = useState( null );
 
 	const autocompleteRef = useRef( null );
+
+	const stopPropagation = ( event ) => {
+		event.stopPropagation();
+	};
+
+	const stopPropagationRelevantKeys = ( event ) => {
+		if ( [ LEFT, DOWN, RIGHT, UP, BACKSPACE, ENTER ].indexOf( event.keyCode ) > -1 ) {
+			// Stop the key event from propagating up to ObserveTyping.startTypingInTextField.
+			event.stopPropagation();
+		}
+	};
 
 	const startEditLink = useCallback( () => {
 		if ( linkDestination === LINK_DESTINATION_MEDIA ||
@@ -157,8 +158,10 @@ const ImageURLInputUI = ( {
 	} );
 
 	const onLinkRemove = useCallback( () => {
-		closeLinkUI();
-		onChangeUrl( { href: '' } );
+		onChangeUrl( {
+			linkDestination: LINK_DESTINATION_NONE,
+			href: '',
+		} );
 	} );
 
 	const getLinkDestinations = () => {
@@ -166,13 +169,13 @@ const ImageURLInputUI = ( {
 			{
 				linkDestination: LINK_DESTINATION_MEDIA,
 				title: __( 'Media File' ),
-				url: ( mediaType === 'image' && mediaUrl ) || undefined,
+				url: mediaType === 'image' ? mediaUrl : undefined,
 				icon,
 			},
 			{
 				linkDestination: LINK_DESTINATION_ATTACHMENT,
 				title: __( 'Attachment Page' ),
-				url: ( mediaType === 'image' && mediaLink ) || undefined,
+				url: mediaType === 'image' ? mediaLink : undefined,
 				icon: <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path d="M0 0h24v24H0V0z" fill="none" /><Path d="M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zM6 20V4h7v5h5v11H6z" /></SVG>,
 			},
 		];
@@ -191,14 +194,10 @@ const ImageURLInputUI = ( {
 				{ linkDestination: LINK_DESTINATION_CUSTOM }
 			).linkDestination;
 		}
-		if ( linkDestination !== linkDestinationInput ) {
-			onChangeUrl( {
-				linkDestination: linkDestinationInput,
-				href: value,
-			} );
-			return;
-		}
-		onChangeUrl( { href: value } );
+		onChangeUrl( {
+			linkDestination: linkDestinationInput,
+			href: value,
+		} );
 	};
 
 	const onSetNewTab = ( value ) => {

--- a/packages/block-editor/src/components/url-popover/image-url-input-ui.js
+++ b/packages/block-editor/src/components/url-popover/image-url-input-ui.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { find, map } from 'lodash';
+import { find, isEmpty, each, map } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -12,6 +12,10 @@ import {
 	IconButton,
 	NavigableMenu,
 	MenuItem,
+	ToggleControl,
+	TextControl,
+	SVG,
+	Path,
 } from '@wordpress/components';
 import {
 	LEFT,
@@ -33,6 +37,8 @@ export const LINK_DESTINATION_MEDIA = 'media';
 export const LINK_DESTINATION_ATTACHMENT = 'attachment';
 export const NEW_TAB_REL = [ 'noreferrer', 'noopener' ];
 
+const icon = <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path d="M0,0h24v24H0V0z" fill="none" /><Path d="m19 5v14h-14v-14h14m0-2h-14c-1.1 0-2 0.9-2 2v14c0 1.1 0.9 2 2 2h14c1.1 0 2-0.9 2-2v-14c0-1.1-0.9-2-2-2z" /><Path d="m14.14 11.86l-3 3.87-2.14-2.59-3 3.86h12l-3.86-5.14z" /></SVG>;
+
 const stopPropagation = ( event ) => {
 	event.stopPropagation();
 };
@@ -43,13 +49,16 @@ const stopPropagationRelevantKeys = ( event ) => {
 		event.stopPropagation();
 	}
 };
-
 const ImageURLInputUI = ( {
-	advancedOptions,
 	linkDestination,
-	mediaLinks,
 	onChangeUrl,
 	url,
+	mediaType,
+	mediaUrl,
+	mediaLink,
+	linkTarget,
+	linkClass,
+	rel,
 } ) => {
 	const [ isOpen, setIsOpen ] = useState( false );
 	const openLinkUI = useCallback( () => {
@@ -59,6 +68,8 @@ const ImageURLInputUI = ( {
 	const [ isEditingLink, setIsEditingLink ] = useState( false );
 	const [ urlInput, setUrlInput ] = useState( null );
 
+	const autocompleteRef = useRef( null );
+
 	const startEditLink = useCallback( () => {
 		if ( linkDestination === LINK_DESTINATION_MEDIA ||
 			linkDestination === LINK_DESTINATION_ATTACHMENT
@@ -67,6 +78,7 @@ const ImageURLInputUI = ( {
 		}
 		setIsEditingLink( true );
 	} );
+
 	const stopEditLink = useCallback( () => {
 		setIsEditingLink( false );
 	} );
@@ -77,7 +89,45 @@ const ImageURLInputUI = ( {
 		setIsOpen( false );
 	} );
 
-	const autocompleteRef = useRef( null );
+	const removeNewTabRel = ( currentRel ) => {
+		let newRel = currentRel;
+
+		if ( currentRel !== undefined && ! isEmpty( newRel ) ) {
+			if ( ! isEmpty( newRel ) ) {
+				each( NEW_TAB_REL, function( relVal ) {
+					const regExp = new RegExp( '\\b' + relVal + '\\b', 'gi' );
+					newRel = newRel.replace( regExp, '' );
+				} );
+
+				// Only trim if NEW_TAB_REL values was replaced.
+				if ( newRel !== currentRel ) {
+					newRel = newRel.trim();
+				}
+
+				if ( isEmpty( newRel ) ) {
+					newRel = undefined;
+				}
+			}
+		}
+
+		return newRel;
+	};
+
+	const getUpdatedLinkTargetSettings = ( value ) => {
+		const newLinkTarget = value ? '_blank' : undefined;
+
+		let updatedRel;
+		if ( ! newLinkTarget && ! rel ) {
+			updatedRel = undefined;
+		} else {
+			updatedRel = removeNewTabRel( rel );
+		}
+
+		return {
+			linkTarget: newLinkTarget,
+			rel: updatedRel,
+		};
+	};
 
 	const onFocusOutside = useCallback( () => {
 		return ( event ) => {
@@ -98,7 +148,7 @@ const ImageURLInputUI = ( {
 	const onSubmitLinkChange = useCallback( () => {
 		return ( event ) => {
 			if ( urlInput ) {
-				onChangeUrl( urlInput );
+				onChangeUrl( { href: urlInput } );
 			}
 			stopEditLink();
 			setUrlInput( null );
@@ -108,13 +158,89 @@ const ImageURLInputUI = ( {
 
 	const onLinkRemove = useCallback( () => {
 		closeLinkUI();
-		onChangeUrl( '' );
+		onChangeUrl( { href: '' } );
 	} );
+
+	const getLinkDestinations = () => {
+		return [
+			{
+				linkDestination: LINK_DESTINATION_MEDIA,
+				title: __( 'Media File' ),
+				url: ( mediaType === 'image' && mediaUrl ) || undefined,
+				icon,
+			},
+			{
+				linkDestination: LINK_DESTINATION_ATTACHMENT,
+				title: __( 'Attachment Page' ),
+				url: ( mediaType === 'image' && mediaLink ) || undefined,
+				icon: <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path d="M0 0h24v24H0V0z" fill="none" /><Path d="M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zM6 20V4h7v5h5v11H6z" /></SVG>,
+			},
+		];
+	};
+
+	const onSetHref = ( value ) => {
+		const linkDestinations = getLinkDestinations();
+		let linkDestinationInput;
+		if ( ! value ) {
+			linkDestinationInput = LINK_DESTINATION_NONE;
+		} else {
+			linkDestinationInput = (
+				find( linkDestinations, ( destination ) => {
+					return destination.url === value;
+				} ) ||
+				{ linkDestination: LINK_DESTINATION_CUSTOM }
+			).linkDestination;
+		}
+		if ( linkDestination !== linkDestinationInput ) {
+			onChangeUrl( {
+				linkDestination: linkDestinationInput,
+				href: value,
+			} );
+			return;
+		}
+		onChangeUrl( { href: value } );
+	};
+
+	const onSetNewTab = ( value ) => {
+		const updatedLinkTarget = getUpdatedLinkTargetSettings( value );
+		onChangeUrl( updatedLinkTarget );
+	};
+
+	const onSetLinkRel = ( value ) => {
+		onChangeUrl( { rel: value } );
+	};
+
+	const onSetLinkClass = ( value ) => {
+		onChangeUrl( { linkClass: value } );
+	};
+
+	const advancedOptions = (
+		<>
+			<ToggleControl
+				label={ __( 'Open in New Tab' ) }
+				onChange={ onSetNewTab }
+				checked={ linkTarget === '_blank' } />
+			<TextControl
+				label={ __( 'Link Rel' ) }
+				value={ removeNewTabRel( rel ) || '' }
+				onChange={ onSetLinkRel }
+				onKeyPress={ stopPropagation }
+				onKeyDown={ stopPropagationRelevantKeys }
+			/>
+			<TextControl
+				label={ __( 'Link CSS Class' ) }
+				value={ linkClass || '' }
+				onKeyPress={ stopPropagation }
+				onKeyDown={ stopPropagationRelevantKeys }
+				onChange={ onSetLinkClass }
+			/>
+		</>
+	);
+
 	const linkEditorValue = urlInput !== null ? urlInput : url;
 
-	const urlLabel = (
-		find( mediaLinks, [ 'linkDestination', linkDestination ] ) || {}
-	).title;
+	const urlLabel = ( find( getLinkDestinations(), [ 'linkDestination', linkDestination ] ) || {} ).title;
+
 	return (
 		<>
 			<IconButton
@@ -132,13 +258,13 @@ const ImageURLInputUI = ( {
 					additionalControls={ ! linkEditorValue && (
 						<NavigableMenu>
 							{
-								map( mediaLinks, ( link ) => (
+								map( getLinkDestinations(), ( link ) => (
 									<MenuItem
 										key={ link.linkDestination }
 										icon={ link.icon }
 										onClick={ () => {
 											setUrlInput( null );
-											onChangeUrl( link.url );
+											onSetHref( link.url );
 											stopEditLink();
 										} }
 									>
@@ -184,6 +310,4 @@ const ImageURLInputUI = ( {
 
 export {
 	ImageURLInputUI as __experimentalImageURLInputUI,
-	stopPropagation,
-	stopPropagationRelevantKeys,
 };

--- a/packages/block-editor/src/components/url-popover/image-url-input-ui.js
+++ b/packages/block-editor/src/components/url-popover/image-url-input-ui.js
@@ -1,0 +1,189 @@
+/**
+ * External dependencies
+ */
+import { find, map } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useRef, useState, useCallback } from '@wordpress/element';
+import {
+	IconButton,
+	NavigableMenu,
+	MenuItem,
+} from '@wordpress/components';
+import {
+	LEFT,
+	RIGHT,
+	UP,
+	DOWN,
+	BACKSPACE,
+	ENTER,
+} from '@wordpress/keycodes';
+
+/**
+ * Internal dependencies
+ */
+import URLPopover from './index';
+
+export const LINK_DESTINATION_NONE = 'none';
+export const LINK_DESTINATION_CUSTOM = 'custom';
+export const LINK_DESTINATION_MEDIA = 'media';
+export const LINK_DESTINATION_ATTACHMENT = 'attachment';
+export const NEW_TAB_REL = [ 'noreferrer', 'noopener' ];
+
+const stopPropagation = ( event ) => {
+	event.stopPropagation();
+};
+
+const stopPropagationRelevantKeys = ( event ) => {
+	if ( [ LEFT, DOWN, RIGHT, UP, BACKSPACE, ENTER ].indexOf( event.keyCode ) > -1 ) {
+		// Stop the key event from propagating up to ObserveTyping.startTypingInTextField.
+		event.stopPropagation();
+	}
+};
+
+const ImageURLInputUI = ( {
+	advancedOptions,
+	linkDestination,
+	mediaLinks,
+	onChangeUrl,
+	url,
+} ) => {
+	const [ isOpen, setIsOpen ] = useState( false );
+	const openLinkUI = useCallback( () => {
+		setIsOpen( true );
+	} );
+
+	const [ isEditingLink, setIsEditingLink ] = useState( false );
+	const [ urlInput, setUrlInput ] = useState( null );
+
+	const startEditLink = useCallback( () => {
+		if ( linkDestination === LINK_DESTINATION_MEDIA ||
+			linkDestination === LINK_DESTINATION_ATTACHMENT
+		) {
+			setUrlInput( '' );
+		}
+		setIsEditingLink( true );
+	} );
+	const stopEditLink = useCallback( () => {
+		setIsEditingLink( false );
+	} );
+
+	const closeLinkUI = useCallback( () => {
+		setUrlInput( null );
+		stopEditLink();
+		setIsOpen( false );
+	} );
+
+	const autocompleteRef = useRef( null );
+
+	const onFocusOutside = useCallback( () => {
+		return ( event ) => {
+			// The autocomplete suggestions list renders in a separate popover (in a portal),
+			// so onFocusOutside fails to detect that a click on a suggestion occurred in the
+			// LinkContainer. Detect clicks on autocomplete suggestions using a ref here, and
+			// return to avoid the popover being closed.
+			const autocompleteElement = autocompleteRef.current;
+			if ( autocompleteElement && autocompleteElement.contains( event.target ) ) {
+				return;
+			}
+			setIsOpen( false );
+			setUrlInput( null );
+			stopEditLink();
+		};
+	} );
+
+	const onSubmitLinkChange = useCallback( () => {
+		return ( event ) => {
+			if ( urlInput ) {
+				onChangeUrl( urlInput );
+			}
+			stopEditLink();
+			setUrlInput( null );
+			event.preventDefault();
+		};
+	} );
+
+	const onLinkRemove = useCallback( () => {
+		closeLinkUI();
+		onChangeUrl( '' );
+	} );
+	const linkEditorValue = urlInput !== null ? urlInput : url;
+
+	const urlLabel = (
+		find( mediaLinks, [ 'linkDestination', linkDestination ] ) || {}
+	).title;
+	return (
+		<>
+			<IconButton
+				icon="admin-links"
+				className="components-toolbar__control"
+				label={ url ? __( 'Edit link' ) : __( 'Insert link' ) }
+				aria-expanded={ isOpen }
+				onClick={ openLinkUI }
+			/>
+			{ isOpen && (
+				<URLPopover
+					onFocusOutside={ onFocusOutside() }
+					onClose={ closeLinkUI }
+					renderSettings={ () => advancedOptions }
+					additionalControls={ ! linkEditorValue && (
+						<NavigableMenu>
+							{
+								map( mediaLinks, ( link ) => (
+									<MenuItem
+										key={ link.linkDestination }
+										icon={ link.icon }
+										onClick={ () => {
+											setUrlInput( null );
+											onChangeUrl( link.url );
+											stopEditLink();
+										} }
+									>
+										{ link.title }
+									</MenuItem>
+								) )
+							}
+						</NavigableMenu>
+					) }
+				>
+					{ ( ! url || isEditingLink ) && (
+						<URLPopover.LinkEditor
+							className="editor-format-toolbar__link-container-content block-editor-format-toolbar__link-container-content"
+							value={ linkEditorValue }
+							onChangeInputValue={ setUrlInput }
+							onKeyDown={ stopPropagationRelevantKeys }
+							onKeyPress={ stopPropagation }
+							onSubmit={ onSubmitLinkChange() }
+							autocompleteRef={ autocompleteRef }
+						/>
+					) }
+					{ ( url && ! isEditingLink ) && (
+						<>
+							<URLPopover.LinkViewer
+								className="editor-format-toolbar__link-container-content block-editor-format-toolbar__link-container-content"
+								onKeyPress={ stopPropagation }
+								url={ url }
+								onEditLinkClick={ startEditLink }
+								urlLabel={ urlLabel }
+							/>
+							<IconButton
+								icon="no"
+								label={ __( 'Remove link' ) }
+								onClick={ onLinkRemove }
+							/>
+						</>
+					) }
+				</URLPopover>
+			) }
+		</>
+	);
+};
+
+export {
+	ImageURLInputUI as __experimentalImageURLInputUI,
+	stopPropagation,
+	stopPropagationRelevantKeys,
+};

--- a/packages/block-editor/src/components/url-popover/image-url-input-ui.js
+++ b/packages/block-editor/src/components/url-popover/image-url-input-ui.js
@@ -31,11 +31,11 @@ import {
  */
 import URLPopover from './index';
 
-export const LINK_DESTINATION_NONE = 'none';
-export const LINK_DESTINATION_CUSTOM = 'custom';
-export const LINK_DESTINATION_MEDIA = 'media';
-export const LINK_DESTINATION_ATTACHMENT = 'attachment';
-export const NEW_TAB_REL = [ 'noreferrer', 'noopener' ];
+const LINK_DESTINATION_NONE = 'none';
+const LINK_DESTINATION_CUSTOM = 'custom';
+const LINK_DESTINATION_MEDIA = 'media';
+const LINK_DESTINATION_ATTACHMENT = 'attachment';
+const NEW_TAB_REL = [ 'noreferrer', 'noopener' ];
 
 const icon = <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path d="M0,0h24v24H0V0z" fill="none" /><Path d="m19 5v14h-14v-14h14m0-2h-14c-1.1 0-2 0.9-2 2v14c0 1.1 0.9 2 2 2h14c1.1 0 2-0.9 2-2v-14c0-1.1-0.9-2-2-2z" /><Path d="m14.14 11.86l-3 3.87-2.14-2.59-3 3.86h12l-3.86-5.14z" /></SVG>;
 

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -54,7 +54,6 @@ import { withViewportMatch } from '@wordpress/viewport';
 import { createUpgradedEmbedBlock } from '../embed/util';
 import icon from './icon';
 import ImageSize from './image-size';
-import { getUpdatedLinkTargetSettings } from './utils';
 /**
  * Module constants
  */
@@ -252,11 +251,6 @@ export class ImageEdit extends Component {
 	onSetTitle( value ) {
 		// This is the HTML title attribute, separate from the media object title
 		this.props.setAttributes( { title: value } );
-	}
-
-	onSetNewTab( value ) {
-		const updatedLinkTarget = getUpdatedLinkTargetSettings( value, this.props.attributes );
-		this.props.setAttributes( updatedLinkTarget );
 	}
 
 	onFocusCaption() {

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -20,9 +20,6 @@ import {
 	Button,
 	ButtonGroup,
 	ExternalLink,
-	IconButton,
-	MenuItem,
-	NavigableMenu,
 	PanelBody,
 	Path,
 	ResizableBox,
@@ -36,14 +33,6 @@ import {
 	withNotices,
 } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
-import {
-	LEFT,
-	RIGHT,
-	UP,
-	DOWN,
-	BACKSPACE,
-	ENTER,
-} from '@wordpress/keycodes';
 import { withSelect, withDispatch } from '@wordpress/data';
 import {
 	BlockAlignmentToolbar,
@@ -53,14 +42,13 @@ import {
 	InspectorAdvancedControls,
 	MediaPlaceholder,
 	MediaReplaceFlow,
-	URLPopover,
 	RichText,
+	__experimentalImageURLInputUI as ImageURLInputUI,
+	stopPropagation,
+	stopPropagationRelevantKeys,
 } from '@wordpress/block-editor';
 import {
 	Component,
-	useCallback,
-	useState,
-	useRef,
 } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { getPath } from '@wordpress/url';
@@ -73,7 +61,6 @@ import { createUpgradedEmbedBlock } from '../embed/util';
 import icon from './icon';
 import ImageSize from './image-size';
 import { getUpdatedLinkTargetSettings, removeNewTabRel } from './utils';
-
 /**
  * Module constants
  */
@@ -114,155 +101,6 @@ const isTemporaryImage = ( id, url ) => ! id && isBlobURL( url );
  * @return {boolean} Is the url an externally hosted url?
  */
 const isExternalImage = ( id, url ) => url && ! id && ! isBlobURL( url );
-
-const stopPropagation = ( event ) => {
-	event.stopPropagation();
-};
-
-const stopPropagationRelevantKeys = ( event ) => {
-	if ( [ LEFT, DOWN, RIGHT, UP, BACKSPACE, ENTER ].indexOf( event.keyCode ) > -1 ) {
-		// Stop the key event from propagating up to ObserveTyping.startTypingInTextField.
-		event.stopPropagation();
-	}
-};
-
-const ImageURLInputUI = ( {
-	advancedOptions,
-	linkDestination,
-	mediaLinks,
-	onChangeUrl,
-	url,
-} ) => {
-	const [ isOpen, setIsOpen ] = useState( false );
-	const openLinkUI = useCallback( () => {
-		setIsOpen( true );
-	} );
-
-	const [ isEditingLink, setIsEditingLink ] = useState( false );
-	const [ urlInput, setUrlInput ] = useState( null );
-
-	const startEditLink = useCallback( () => {
-		if ( linkDestination === LINK_DESTINATION_MEDIA ||
-			linkDestination === LINK_DESTINATION_ATTACHMENT
-		) {
-			setUrlInput( '' );
-		}
-		setIsEditingLink( true );
-	} );
-	const stopEditLink = useCallback( () => {
-		setIsEditingLink( false );
-	} );
-
-	const closeLinkUI = useCallback( () => {
-		setUrlInput( null );
-		stopEditLink();
-		setIsOpen( false );
-	} );
-
-	const autocompleteRef = useRef( null );
-
-	const onClickOutside = useCallback( () => {
-		return ( event ) => {
-			// The autocomplete suggestions list renders in a separate popover (in a portal),
-			// so onClickOutside fails to detect that a click on a suggestion occurred in the
-			// LinkContainer. Detect clicks on autocomplete suggestions using a ref here, and
-			// return to avoid the popover being closed.
-			const autocompleteElement = autocompleteRef.current;
-			if ( autocompleteElement && autocompleteElement.contains( event.target ) ) {
-				return;
-			}
-			setIsOpen( false );
-			setUrlInput( null );
-			stopEditLink();
-		};
-	} );
-
-	const onSubmitLinkChange = useCallback( () => {
-		return ( event ) => {
-			if ( urlInput ) {
-				onChangeUrl( urlInput );
-			}
-			stopEditLink();
-			setUrlInput( null );
-			event.preventDefault();
-		};
-	} );
-
-	const onLinkRemove = useCallback( () => {
-		closeLinkUI();
-		onChangeUrl( '' );
-	} );
-	const linkEditorValue = urlInput !== null ? urlInput : url;
-
-	const urlLabel = (
-		find( mediaLinks, [ 'linkDestination', linkDestination ] ) || {}
-	).title;
-	return (
-		<>
-			<IconButton
-				icon="admin-links"
-				className="components-toolbar__control"
-				label={ url ? __( 'Edit link' ) : __( 'Insert link' ) }
-				aria-expanded={ isOpen }
-				onClick={ openLinkUI }
-			/>
-			{ isOpen && (
-				<URLPopover
-					onClickOutside={ onClickOutside() }
-					onClose={ closeLinkUI }
-					renderSettings={ () => advancedOptions }
-					additionalControls={ ! linkEditorValue && (
-						<NavigableMenu>
-							{
-								map( mediaLinks, ( link ) => (
-									<MenuItem
-										key={ link.linkDestination }
-										icon={ link.icon }
-										onClick={ () => {
-											setUrlInput( null );
-											onChangeUrl( link.url );
-											stopEditLink();
-										} }
-									>
-										{ link.title }
-									</MenuItem>
-								) )
-							}
-						</NavigableMenu>
-					) }
-				>
-					{ ( ! url || isEditingLink ) && (
-						<URLPopover.LinkEditor
-							className="editor-format-toolbar__link-container-content block-editor-format-toolbar__link-container-content"
-							value={ linkEditorValue }
-							onChangeInputValue={ setUrlInput }
-							onKeyDown={ stopPropagationRelevantKeys }
-							onKeyPress={ stopPropagation }
-							onSubmit={ onSubmitLinkChange() }
-							autocompleteRef={ autocompleteRef }
-						/>
-					) }
-					{ ( url && ! isEditingLink ) && (
-						<>
-							<URLPopover.LinkViewer
-								className="editor-format-toolbar__link-container-content block-editor-format-toolbar__link-container-content"
-								onKeyPress={ stopPropagation }
-								url={ url }
-								onEditLinkClick={ startEditLink }
-								urlLabel={ urlLabel }
-							/>
-							<IconButton
-								icon="no"
-								label={ __( 'Remove link' ) }
-								onClick={ onLinkRemove }
-							/>
-						</>
-					) }
-				</URLPopover>
-			) }
-		</>
-	);
-};
 
 export class ImageEdit extends Component {
 	constructor() {

--- a/packages/block-library/src/media-text/block.json
+++ b/packages/block-library/src/media-text/block.json
@@ -32,6 +32,27 @@
 			"selector": "figure video,figure img",
 			"attribute": "src"
 		},
+		"mediaLink": {
+			"type": "string"
+		},
+		"href": {
+			"type": "string",
+			"source": "attribute",
+			"selector": "figure a",
+			"attribute": "href"
+		},
+		"rel": {
+			"type": "string",
+			"source": "attribute",
+			"selector": "figure a",
+			"attribute": "rel"
+		},
+		"linkClass": {
+			"type": "string",
+			"source": "attribute",
+			"selector": "figure a",
+			"attribute": "class"
+		},
 		"mediaType": {
 			"type": "string"
 		},

--- a/packages/block-library/src/media-text/block.json
+++ b/packages/block-library/src/media-text/block.json
@@ -36,8 +36,7 @@
 			"type": "string"
 		},
 		"linkDestination": {
-			"type": "string",
-			"default": "none"
+			"type": "string"
 		},
 		"linkTarget": {
 			"type": "string",

--- a/packages/block-library/src/media-text/block.json
+++ b/packages/block-library/src/media-text/block.json
@@ -35,6 +35,12 @@
 		"mediaLink": {
 			"type": "string"
 		},
+		"linkTarget": {
+			"type": "string",
+			"source": "attribute",
+			"selector": "figure a",
+			"attribute": "target"
+		},
 		"href": {
 			"type": "string",
 			"source": "attribute",

--- a/packages/block-library/src/media-text/block.json
+++ b/packages/block-library/src/media-text/block.json
@@ -35,6 +35,10 @@
 		"mediaLink": {
 			"type": "string"
 		},
+		"linkDestination": {
+			"type": "string",
+			"default": "none"
+		},
 		"linkTarget": {
 			"type": "string",
 			"source": "attribute",

--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -8,6 +8,8 @@ import { get } from 'lodash';
  * WordPress dependencies
  */
 import { __, _x } from '@wordpress/i18n';
+import { compose } from '@wordpress/compose';
+import { withSelect } from '@wordpress/data';
 import {
 	BlockControls,
 	BlockVerticalAlignmentToolbar,
@@ -118,7 +120,6 @@ class MediaTextEdit extends Component {
 	renderMediaArea() {
 		const { attributes } = this.props;
 		const { mediaAlt, mediaId, mediaPosition, mediaType, mediaUrl, mediaWidth, imageFill, focalPoint } = attributes;
-
 		return (
 			<MediaContainer
 				className="block-library-media-text__media-container"
@@ -147,7 +148,6 @@ class MediaTextEdit extends Component {
 			mediaWidth,
 			verticalAlignment,
 			mediaUrl,
-			mediaLink,
 			imageFill,
 			focalPoint,
 			rel,
@@ -258,8 +258,8 @@ class MediaTextEdit extends Component {
 							onChangeUrl={ this.onSetHref }
 							linkDestination={ linkDestination }
 							mediaType={ mediaType }
-							mediaUrl={ mediaUrl }
-							mediaLink={ mediaLink }
+							mediaUrl={ this.props.image && this.props.image.source_url }
+							mediaLink={ this.props.image && this.props.image.link }
 							linkTarget={ linkTarget }
 							linkClass={ linkClass }
 							rel={ rel }
@@ -278,4 +278,13 @@ class MediaTextEdit extends Component {
 	}
 }
 
-export default withColors( 'backgroundColor' )( MediaTextEdit );
+export default compose( [
+	withColors( 'backgroundColor' ),
+	withSelect( ( select, props ) => {
+		const { getMedia } = select( 'core' );
+		const { attributes: { mediaId }, isSelected } = props;
+		return {
+			image: mediaId && isSelected ? getMedia( mediaId ) : null,
+		};
+	} ),
+] )( MediaTextEdit );

--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -236,6 +236,22 @@ const ImageURLInputUI = ( {
 	);
 };
 
+const getUpdatedLinkTargetSettings = ( value, { rel } ) => {
+	const linkTarget = value ? '_blank' : undefined;
+
+	let updatedRel;
+	if ( ! linkTarget && ! rel ) {
+		updatedRel = undefined;
+	} else {
+		updatedRel = removeNewTabRel( rel );
+	}
+
+	return {
+		linkTarget,
+		rel: updatedRel,
+	};
+};
+
 class MediaTextEdit extends Component {
 	constructor() {
 		super( ...arguments );
@@ -248,6 +264,7 @@ class MediaTextEdit extends Component {
 		};
 		this.getLinkDestinations = this.getLinkDestinations.bind( this );
 		this.onSetHref = this.onSetHref.bind( this );
+		this.onSetNewTab = this.onSetNewTab.bind( this );
 		this.onSetLinkRel = this.onSetLinkRel.bind( this );
 		this.onSetLinkClass = this.onSetLinkClass.bind( this );
 	}
@@ -293,6 +310,11 @@ class MediaTextEdit extends Component {
 			return;
 		}
 		this.props.setAttributes( { href: value } );
+	}
+
+	onSetNewTab( value ) {
+		const updatedLinkTarget = getUpdatedLinkTargetSettings( value, this.props.attributes );
+		this.props.setAttributes( updatedLinkTarget );
 	}
 
 	onSetLinkRel( value ) {

--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -44,12 +44,6 @@ const TEMPLATE = [
 const WIDTH_CONSTRAINT_PERCENTAGE = 15;
 const applyWidthConstraints = ( width ) => Math.max( WIDTH_CONSTRAINT_PERCENTAGE, Math.min( width, 100 - WIDTH_CONSTRAINT_PERCENTAGE ) );
 
-export const LINK_DESTINATION_NONE = 'none';
-export const LINK_DESTINATION_CUSTOM = 'custom';
-export const LINK_DESTINATION_MEDIA = 'media';
-export const LINK_DESTINATION_ATTACHMENT = 'attachment';
-export const NEW_TAB_REL = [ 'noreferrer', 'noopener' ];
-
 class MediaTextEdit extends Component {
 	constructor() {
 		super( ...arguments );

--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -246,7 +246,7 @@ class MediaTextEdit extends Component {
 						onChange={ onVerticalAlignmentChange }
 						value={ verticalAlignment }
 					/>
-					{ mediaType === 'image' && ( <Toolbar>
+					{ mediaType === 'image' && ( <ToolbarGroup>
 						<ImageURLInputUI
 							url={ href || '' }
 							onChangeUrl={ this.onSetHref }
@@ -258,7 +258,7 @@ class MediaTextEdit extends Component {
 							linkClass={ linkClass }
 							rel={ rel }
 						/>
-					</Toolbar> ) }
+					</ToolbarGroup> ) }
 				</BlockControls>
 				<div className={ classNames } style={ style } >
 					{ this.renderMediaArea() }

--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -43,6 +43,9 @@ const TEMPLATE = [
 const WIDTH_CONSTRAINT_PERCENTAGE = 15;
 const applyWidthConstraints = ( width ) => Math.max( WIDTH_CONSTRAINT_PERCENTAGE, Math.min( width, 100 - WIDTH_CONSTRAINT_PERCENTAGE ) );
 
+export const LINK_DESTINATION_MEDIA = 'media';
+export const LINK_DESTINATION_ATTACHMENT = 'attachment';
+
 class MediaTextEdit extends Component {
 	constructor() {
 		super( ...arguments );
@@ -58,6 +61,7 @@ class MediaTextEdit extends Component {
 
 	onSelectMedia( media ) {
 		const { setAttributes } = this.props;
+		const { linkDestination, href } = this.props.attributes;
 
 		let mediaType;
 		let src;
@@ -78,12 +82,26 @@ class MediaTextEdit extends Component {
 			// Try the "large" size URL, falling back to the "full" size URL below.
 			src = get( media, [ 'sizes', 'large', 'url' ] ) || get( media, [ 'media_details', 'sizes', 'large', 'source_url' ] );
 		}
+
+		let newHref = href;
+		if ( linkDestination === LINK_DESTINATION_MEDIA ) {
+			// Update the media link.
+			newHref = media.url;
+		}
+
+		// Check if the image is linked to the attachment page.
+		if ( linkDestination === LINK_DESTINATION_ATTACHMENT ) {
+			// Update the media link.
+			newHref = media.link;
+		}
+
 		setAttributes( {
 			mediaAlt: media.alt,
 			mediaId: media.id,
 			mediaType,
 			mediaUrl: src || media.url,
 			mediaLink: media.link || undefined,
+			href: newHref,
 			imageFill: undefined,
 			focalPoint: undefined,
 		} );

--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -25,7 +25,6 @@ import {
 	TextareaControl,
 	ToggleControl,
 	ToolbarGroup,
-	Toolbar,
 	ExternalLink,
 	FocalPointPicker,
 } from '@wordpress/components';
@@ -133,6 +132,7 @@ class MediaTextEdit extends Component {
 			isSelected,
 			setAttributes,
 			setBackgroundColor,
+			image,
 		} = this.props;
 		const {
 			isStackedOnMobile,
@@ -252,8 +252,8 @@ class MediaTextEdit extends Component {
 							onChangeUrl={ this.onSetHref }
 							linkDestination={ linkDestination }
 							mediaType={ mediaType }
-							mediaUrl={ this.props.image && this.props.image.source_url }
-							mediaLink={ this.props.image && this.props.image.link }
+							mediaUrl={ image && image.source_url }
+							mediaLink={ image && image.link }
 							linkTarget={ linkTarget }
 							linkClass={ linkClass }
 							rel={ rel }

--- a/packages/block-library/src/media-text/save.js
+++ b/packages/block-library/src/media-text/save.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { noop } from 'lodash';
+import { noop, isEmpty } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -33,9 +33,29 @@ export default function save( { attributes } ) {
 		verticalAlignment,
 		imageFill,
 		focalPoint,
+		linkClass,
+		href,
+		linkTarget,
+		rel,
 	} = attributes;
+	const newRel = isEmpty( rel ) ? undefined : rel;
+	const image = <img src={ mediaUrl } alt={ mediaAlt } className={ ( mediaId && mediaType === 'image' ) ? `wp-image-${ mediaId }` : null } />;
+	const imageMedia = (
+		<>
+			{ href ? (
+				<a
+					className={ linkClass }
+					href={ href }
+					target={ linkTarget }
+					rel={ newRel }
+				>
+					{ image }
+				</a>
+			) : image }
+		</>
+	);
 	const mediaTypeRenders = {
-		image: () => <img src={ mediaUrl } alt={ mediaAlt } className={ ( mediaId && mediaType === 'image' ) ? `wp-image-${ mediaId }` : null } />,
+		image: () => imageMedia,
 		video: () => <video controls src={ mediaUrl } />,
 	};
 	const backgroundClass = getColorClassName( 'background-color', backgroundColor );

--- a/packages/block-library/src/media-text/save.js
+++ b/packages/block-library/src/media-text/save.js
@@ -39,23 +39,28 @@ export default function save( { attributes } ) {
 		rel,
 	} = attributes;
 	const newRel = isEmpty( rel ) ? undefined : rel;
-	const image = <img src={ mediaUrl } alt={ mediaAlt } className={ ( mediaId && mediaType === 'image' ) ? `wp-image-${ mediaId }` : null } />;
-	const imageMedia = (
-		<>
-			{ href ? (
-				<a
-					className={ linkClass }
-					href={ href }
-					target={ linkTarget }
-					rel={ newRel }
-				>
-					{ image }
-				</a>
-			) : image }
-		</>
-	);
+
+	let image = <img
+		src={ mediaUrl }
+		alt={ mediaAlt }
+		className={ ( mediaId && mediaType === 'image' ) ? `wp-image-${ mediaId }` : null }
+	/>;
+
+	if ( href ) {
+		image = (
+			<a
+				className={ linkClass }
+				href={ href }
+				target={ linkTarget }
+				rel={ newRel }
+			>
+				{ image }
+			</a>
+		);
+	}
+
 	const mediaTypeRenders = {
-		image: () => imageMedia,
+		image: () => image,
 		video: () => <video controls src={ mediaUrl } />,
 	};
 	const backgroundClass = getColorClassName( 'background-color', backgroundColor );

--- a/packages/block-library/src/media-text/save.js
+++ b/packages/block-library/src/media-text/save.js
@@ -40,27 +40,7 @@ export default function save( { attributes } ) {
 	} = attributes;
 	const newRel = isEmpty( rel ) ? undefined : rel;
 
-	let image;
-	if ( href ) {
-		image = () => (
-			<a
-				className={ linkClass }
-				href={ href }
-				target={ linkTarget }
-				rel={ newRel }
-			>
-				{ image }
-			</a>
-		);
-	} else {
-		image = () => (
-			<img
-				src={ mediaUrl }
-				alt={ mediaAlt }
-				className={ ( mediaId && mediaType === 'image' ) ? `wp-image-${ mediaId }` : null }
-			/>
-		);
-	}
+	let image = <img
 		src={ mediaUrl }
 		alt={ mediaAlt }
 		className={ ( mediaId && mediaType === 'image' ) ? `wp-image-${ mediaId }` : null }

--- a/packages/block-library/src/media-text/save.js
+++ b/packages/block-library/src/media-text/save.js
@@ -40,7 +40,27 @@ export default function save( { attributes } ) {
 	} = attributes;
 	const newRel = isEmpty( rel ) ? undefined : rel;
 
-	let image = <img
+	let image;
+	if ( href ) {
+		image = () => (
+			<a
+				className={ linkClass }
+				href={ href }
+				target={ linkTarget }
+				rel={ newRel }
+			>
+				{ image }
+			</a>
+		);
+	} else {
+		image = () => (
+			<img
+				src={ mediaUrl }
+				alt={ mediaAlt }
+				className={ ( mediaId && mediaType === 'image' ) ? `wp-image-${ mediaId }` : null }
+			/>
+		);
+	}
 		src={ mediaUrl }
 		alt={ mediaAlt }
 		className={ ( mediaId && mediaType === 'image' ) ? `wp-image-${ mediaId }` : null }


### PR DESCRIPTION
## Description
Adds a link functionality to images in the media + text block.
Closes:  #15422

# Screenshots
<img width="913" alt="Screenshot 2019-11-01 at 15 59 41" src="https://user-images.githubusercontent.com/107534/68029796-b3161500-fcc0-11e9-82c2-69cb30da632e.png">


## How has this been tested?
Tested locally.

## Types of changes
Copied the same functionality available in the image block.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
