### PR TITLE
Scripts: Add a command to tail the Docker environment's error log

### DIFF
--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -165,6 +165,8 @@ In the `wp-env` config block, each entry can be configured like so:
 - `lint-php`: Run PHPCS linting on your plugin. You will need to have `composer.json` configured to install PHPCS, with a `lint` script that runs your linting. You will also need to have an appropriately configured `phpcs.xml.dist` file.
 - `test-php`: Runs your plugin's PHPUnit tests. You will need to have an appropriately configured `phpunit.xml.dist` file.
 - `docker-run`: For more advanced debugging, contributors may sometimes need to run commands in the Docker containers. This is the equivalent of running `docker-compose run` within the WordPress directory.
+- `log`: Displays the last part of the error log and waits for new changes.
+- `log clean`: Empties the error log.
 
 
 ### `lint-js`

--- a/packages/scripts/scripts/env/log.js
+++ b/packages/scripts/scripts/env/log.js
@@ -1,0 +1,19 @@
+/**
+ * Node dependencies.
+ */
+const { execSync } = require( 'child_process' );
+const { env } = require( 'process' );
+const { normalize } = require( 'path' );
+
+/**
+ * Internal dependencies
+ */
+const { hasArgInCLI } = require( '../../utils' );
+
+const logFile = normalize( `${ env.WP_DEVELOP_DIR }/src/wp-content/debug.log` );
+
+if ( hasArgInCLI( 'clean' ) ) {
+	execSync( `> ${ logFile }`, { cwd: env.WP_DEVELOP_DIR, stdio: 'inherit' } );
+} else {
+	execSync( `touch ${ logFile } && tail -F ${ logFile }`, { cwd: env.WP_DEVELOP_DIR, stdio: 'inherit' } );
+}


### PR DESCRIPTION
## Description
Add a new `env` script to display and clean the PHP error log:

- `npm run env log` displays the error log and keeps it open waiting for changes (aka `tail -F`). It also creates the file if it doesn't exist.
- `npm run env log clean` empties the error log file (and again, it also creates it if it doesn't exist).

Note: this is not the same as the Docker's `npm run env:logs` script, which prints the Docker log, not the error log.

## How has this been tested?
Tested on the Gutenberg's Docker environment, freshly cloned from master at 702b11caa6dcb7b3e0fffcd398afe1d3cd451e8a.

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
