### PR TITLE
Tweak margin and padding of toolbar icon buttons

### DIFF
--- a/packages/edit-post/src/components/edit-post-settings/style.scss
+++ b/packages/edit-post/src/components/edit-post-settings/style.scss
@@ -1,0 +1,13 @@
+.edit-post-header__settings {
+	.components-button.is-toggled {
+		padding: 5px;
+	}
+
+	.components-icon-button {
+		padding: 5px;
+
+		svg {
+			margin: 3px;
+		}
+	}
+}

--- a/packages/edit-post/src/components/header/header-toolbar/style.scss
+++ b/packages/edit-post/src/components/header/header-toolbar/style.scss
@@ -11,6 +11,14 @@
 		}
 	}
 
+	.components-icon-button {
+		padding: 5px;
+
+		svg {
+			margin: 3px;
+		}
+	}
+
 	// Hide table of contents and block navigation on mobile.
 	.block-editor-block-navigation,
 	.table-of-contents {

--- a/packages/edit-post/src/style.scss
+++ b/packages/edit-post/src/style.scss
@@ -23,6 +23,7 @@ $footer-height: $icon-button-size-small;
 @import "./components/text-editor/style.scss";
 @import "./components/visual-editor/style.scss";
 @import "./components/options-modal/style.scss";
+@import "./components/edit-post-settings/style.scss";
 
 
 /**


### PR DESCRIPTION
Fixes 1/3 of #12260

## Description
This PR tweaks the margin and padding of the toolbar icon buttons in order to give their corresponding tooltips more breathing room when hovering.

## How has this been tested?
Tested on Firefox, Safari and Chrome (Mac), on large and narrow viewports.

## Screenshots <!-- if applicable -->
### Before:
<img width="240" alt="Screen Shot 2019-10-28 at 1 18 46 PM" src="https://user-images.githubusercontent.com/3276087/67710417-86db5b00-f985-11e9-9a1d-11f017da6534.png">
<img width="343" alt="Screen Shot 2019-10-28 at 1 18 53 PM" src="https://user-images.githubusercontent.com/3276087/67710423-8b077880-f985-11e9-94aa-ad515020a588.png">

### After:
<img width="218" alt="Screen Shot 2019-10-25 at 4 36 13 PM" src="https://user-images.githubusercontent.com/3276087/67710438-935fb380-f985-11e9-92ec-a00633c7b795.png">
<img width="282" alt="Screen Shot 2019-10-28 at 12 49 40 PM" src="https://user-images.githubusercontent.com/3276087/67710454-99559480-f985-11e9-96a7-d00162acb2b3.png">
<img width="672" alt="Screen Shot 2019-10-28 at 1 17 06 PM" src="https://user-images.githubusercontent.com/3276087/67710464-9eb2df00-f985-11e9-9acc-55dae7f74d6b.png">
<img width="498" alt="Screen Shot 2019-10-28 at 1 17 25 PM" src="https://user-images.githubusercontent.com/3276087/67710486-a6728380-f985-11e9-8435-bdeb085bf1d8.png">
<img width="499" alt="Screen Shot 2019-10-28 at 1 17 16 PM" src="https://user-images.githubusercontent.com/3276087/67710487-a6728380-f985-11e9-9e68-77188edf6d2e.png">
<img width="671" alt="Screen Shot 2019-10-28 at 1 16 58 PM" src="https://user-images.githubusercontent.com/3276087/67710488-a6728380-f985-11e9-9d04-40e6667e5cb0.png">

## Types of changes
CSS and visual.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
