### PR TITLE
Add RangeControl component to Storybook

### DIFF
--- a/packages/components/src/range-control/stories/index.js
+++ b/packages/components/src/range-control/stories/index.js
@@ -1,0 +1,99 @@
+/**
+ * External dependencies
+ */
+import { number, text } from '@storybook/addon-knobs';
+
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import RangeControl from '../';
+
+export default { title: 'RangeControl', component: RangeControl };
+
+const RangeControlWithState = ( { ...props } ) => {
+	const [ value, setValue ] = useState( 5 );
+
+	return (
+		<RangeControl
+			{ ...props }
+			value={ value }
+			onChange={ setValue }
+		/>
+	);
+};
+
+export const _default = () => {
+	const label = text( 'Label', 'How many columns should this use?' );
+
+	return (
+		<RangeControlWithState
+			label={ label }
+		/>
+	);
+};
+
+export const withHelp = () => {
+	const label = text( 'Label', 'How many columns should this use?' );
+	const help = text( 'Help Text', 'Please select the number of columns you would like this to contain.' );
+
+	return (
+		<RangeControlWithState
+			label={ label }
+			help={ help }
+		/>
+	);
+};
+
+export const withMinimumAndMaximumLimits = () => {
+	const label = text( 'Label', 'How many columns should this use?' );
+	const min = number( 'Min Value', 2 );
+	const max = number( 'Max Value', 10 );
+
+	return (
+		<RangeControlWithState
+			label={ label }
+			min={ min }
+			max={ max }
+		/>
+	);
+};
+
+export const withIconBefore = () => {
+	const label = text( 'Label', 'How many columns should this use?' );
+	const icon = text( 'Icon', 'wordpress' );
+
+	return (
+		<RangeControlWithState
+			label={ label }
+			beforeIcon={ icon }
+		/>
+	);
+};
+
+export const withIconAfter = () => {
+	const label = text( 'Label', 'How many columns should this use?' );
+	const icon = text( 'Icon', 'wordpress' );
+
+	return (
+		<RangeControlWithState
+			label={ label }
+			afterIcon={ icon }
+		/>
+	);
+};
+
+export const withReset = () => {
+	const label = text( 'Label', 'How many columns should this use?' );
+
+	return (
+		<RangeControlWithState
+			label={ label }
+			allowReset={ true }
+		/>
+	);
+};


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
Add RangeControl component to Storybook as part of #17973. 
Added with the following "stories":
- Default
- With Help Text
- With Min/Max Limits
- With Icon Before
- With Icon After
- With Reset Button

## How has this been tested?
run npm run design-system:dev
Browse to the local Storybook instance
See Range Control component is rendered with various options when selected in left-hand navigation

## Types of changes
New feature (non-breaking change which adds functionality)