### PR TITLE
Add FontSizePicker component to Storybook

### DIFF
--- a/packages/components/src/font-size-picker/stories/index.js
+++ b/packages/components/src/font-size-picker/stories/index.js
@@ -1,0 +1,65 @@
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import FontSizePicker from '../';
+
+export default { title: 'FontSizePicker', component: FontSizePicker };
+
+const FontSizePickerWithState = ( { ...props } ) => {
+	const [ fontSize, setFontSize ] = useState( 16 );
+	const fontSizes = [
+		{
+			name: 'Small',
+			slug: 'small',
+			size: 12,
+		},
+		{
+			name: 'Normal',
+			slug: 'normal',
+			size: 16,
+		},
+		{
+			name: 'Big',
+			slug: 'big',
+			size: 26,
+		},
+	];
+	const fallbackFontSize = 16;
+
+	return (
+		<FontSizePicker
+			{ ...props }
+			fontSizes={ fontSizes }
+			fallbackFontSize={ fallbackFontSize }
+			value={ fontSize }
+			onChange={ setFontSize }
+		/>
+	);
+};
+
+export const _default = () => {
+	return (
+		<FontSizePickerWithState />
+	);
+};
+
+export const withSlider = () => {
+	return (
+		<FontSizePickerWithState
+			withSlider={ true }
+		/>
+	);
+};
+
+export const withoutCustomSizes = () => {
+	return (
+		<FontSizePickerWithState
+			disableCustomFontSizes={ true }
+		/>
+	);
+};

--- a/packages/components/src/font-size-picker/stories/index.js
+++ b/packages/components/src/font-size-picker/stories/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { number, object } from '@storybook/addon-knobs';
+
+/**
  * WordPress dependencies
  */
 import { useState } from '@wordpress/element';
@@ -12,7 +17,18 @@ export default { title: 'FontSizePicker', component: FontSizePicker };
 
 const FontSizePickerWithState = ( { ...props } ) => {
 	const [ fontSize, setFontSize ] = useState( 16 );
-	const fontSizes = [
+
+	return (
+		<FontSizePicker
+			{ ...props }
+			value={ fontSize }
+			onChange={ setFontSize }
+		/>
+	);
+};
+
+export const _default = () => {
+	const fontSizes = object( 'Font Sizes', [
 		{
 			name: 'Small',
 			slug: 'small',
@@ -28,38 +44,64 @@ const FontSizePickerWithState = ( { ...props } ) => {
 			slug: 'big',
 			size: 26,
 		},
-	];
-	const fallbackFontSize = 16;
-
+	] );
 	return (
-		<FontSizePicker
-			{ ...props }
+		<FontSizePickerWithState
 			fontSizes={ fontSizes }
-			fallbackFontSize={ fallbackFontSize }
-			value={ fontSize }
-			onChange={ setFontSize }
 		/>
 	);
 };
 
-export const _default = () => {
-	return (
-		<FontSizePickerWithState />
-	);
-};
-
 export const withSlider = () => {
+	const fontSizes = object( 'Font Sizes', [
+		{
+			name: 'Small',
+			slug: 'small',
+			size: 12,
+		},
+		{
+			name: 'Normal',
+			slug: 'normal',
+			size: 16,
+		},
+		{
+			name: 'Big',
+			slug: 'big',
+			size: 26,
+		},
+	] );
+	const fallbackFontSize = number( 'Fallback Font Size - Slider Only', 16 );
 	return (
 		<FontSizePickerWithState
-			withSlider={ true }
+			fontSizes={ fontSizes }
+			fallbackFontSize={ fallbackFontSize }
+			withSlider
 		/>
 	);
 };
 
 export const withoutCustomSizes = () => {
+	const fontSizes = object( 'Font Sizes', [
+		{
+			name: 'Small',
+			slug: 'small',
+			size: 12,
+		},
+		{
+			name: 'Normal',
+			slug: 'normal',
+			size: 16,
+		},
+		{
+			name: 'Big',
+			slug: 'big',
+			size: 26,
+		},
+	] );
 	return (
 		<FontSizePickerWithState
-			disableCustomFontSizes={ true }
+			fontSizes={ fontSizes }
+			disableCustomFontSizes
 		/>
 	);
 };


### PR DESCRIPTION
## Description
Add the FontSizePicker component to Storybook as part of #17973.
Added with the following "stories":
- Default
- With Slider Control
- With Disabled Custom Sizes

Note: The last story brought to my attention a bug, which is in the process of being resolved in #18049. Once that is merged the story should look correct. 

## How has this been tested?
run `npm run design-system:dev`
Browse to the local Storybook instance
See FontSizePicker component is rendered with various options when selected in left-hand navigation

## Types of changes
New feature (non-breaking change which adds functionality)