### PR TITLE
NavigationMenu: set attributes rightly

### DIFF
--- a/packages/block-library/src/navigation-menu/edit.js
+++ b/packages/block-library/src/navigation-menu/edit.js
@@ -9,6 +9,7 @@ import classnames from 'classnames';
 import {
 	Fragment,
 	useMemo,
+	useEffect,
 } from '@wordpress/element';
 import {
 	InnerBlocks,
@@ -99,11 +100,13 @@ function NavigationMenu( {
 		}
 	};
 
-	// Set/Unset colors CSS classes.
-	setAttributes( {
-		backgroundColorCSSClass: backgroundColor.class ? backgroundColor.class : null,
-		textColorCSSClass: textColor.class ? textColor.class : null,
-	} );
+	useEffect( () => {
+		// Set/Unset colors CSS classes.
+		setAttributes( {
+			backgroundColorCSSClass: backgroundColor.class ? backgroundColor.class : null,
+			textColorCSSClass: textColor.class ? textColor.class : null,
+		} );
+	}, [] );
 
 	return (
 		<Fragment>

--- a/packages/block-library/src/navigation-menu/edit.js
+++ b/packages/block-library/src/navigation-menu/edit.js
@@ -106,7 +106,7 @@ function NavigationMenu( {
 			backgroundColorCSSClass: backgroundColor.class ? backgroundColor.class : null,
 			textColorCSSClass: textColor.class ? textColor.class : null,
 		} );
-	}, [ backgroundColor, textColor ] );
+	}, [ backgroundColor.class, textColor.class ] );
 
 	return (
 		<Fragment>

--- a/packages/block-library/src/navigation-menu/edit.js
+++ b/packages/block-library/src/navigation-menu/edit.js
@@ -80,7 +80,7 @@ function NavigationMenu( {
 	 * Set the color type according to the given values.
 	 * It propagate the color values into the attributes object.
 	 * Both `backgroundColorValue` and `textColorValue` are
-	 * using the apply inline styles.
+	 * using the inline styles.
 	 *
 	 * @param {Object}  colorsData       Arguments passed by BlockColorsStyleSelector onColorChange.
 	 * @param {string}  colorsData.attr  Color attribute.
@@ -106,7 +106,7 @@ function NavigationMenu( {
 			backgroundColorCSSClass: backgroundColor.class ? backgroundColor.class : null,
 			textColorCSSClass: textColor.class ? textColor.class : null,
 		} );
-	}, [] );
+	}, [ backgroundColor, textColor ] );
 
 	return (
 		<Fragment>


### PR DESCRIPTION
## Description
This PR is a performance enhancement when it sets some attributes when the block is mounted.
Right now, it set the attributes multiple times when the component renders which is not ok.

~Since it needs to be done once when the component is mounted, I've wrapped this code in a useEffect() call, ensuring its execution just one time passing an empty array as the second parameter of the hook.~

In this PR, these attributes are set only when `backgroundColor` and `textColor` change.

Props to @epiqueras

## How has this been tested?

1) Apply the patch.
2) Set text and background color in the menu using the colors selector button
3) Save the post
4) Confirm that the styles are still there, and they are persistent.

## Screenshots <!-- if applicable -->

![image](https://user-images.githubusercontent.com/77539/67724883-3b45a300-f9bf-11e9-83e2-c821a3c14706.png)


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->