### PR TITLE
Show appender only when item has submenu

### DIFF
--- a/packages/block-library/src/navigation-menu-item/edit.js
+++ b/packages/block-library/src/navigation-menu-item/edit.js
@@ -95,10 +95,10 @@ function NavigationMenuItemEdit( {
 						title={ __( 'Link' ) }
 						onClick={ () => setIsLinkOpen( ! isLinkOpen ) }
 					/>
-					{ ! hasDescendants && <ToolbarButton
+					{ <ToolbarButton
 						name="submenu"
 						icon={ <SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24"><Path d="M14 5h8v2h-8zm0 5.5h8v2h-8zm0 5.5h8v2h-8zM2 11.5C2 15.08 4.92 18 8.5 18H9v2l3-3-3-3v2h-.5C6.02 16 4 13.98 4 11.5S6.02 7 8.5 7H12V5H8.5C4.92 5 2 7.92 2 11.5z" /><Path fill="none" d="M0 0h24v24H0z" /></SVG> }
-						title={ __( 'Submenu' ) }
+						title={ __( 'Add submenu item' ) }
 						onClick={ insertMenuItemBlock }
 					/> }
 				</Toolbar>

--- a/packages/block-library/src/navigation-menu-item/edit.js
+++ b/packages/block-library/src/navigation-menu-item/edit.js
@@ -6,7 +6,9 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { withSelect } from '@wordpress/data';
+import { compose } from '@wordpress/compose';
+import { createBlock } from '@wordpress/blocks';
+import { withDispatch, withSelect } from '@wordpress/data';
 import {
 	ExternalLink,
 	PanelBody,
@@ -46,13 +48,11 @@ function NavigationMenuItemEdit( {
 	isSelected,
 	isParentOfSelectedBlock,
 	setAttributes,
+	insertMenuItemBlock,
 } ) {
 	const [ isLinkOpen, setIsLinkOpen ] = useState( false );
 	const [ isEditingLink, setIsEditingLink ] = useState( false );
 	const [ urlInput, setUrlInput ] = useState( null );
-	const [ addSubmenu, setaddSubmenu ] = useState( false );
-
-	const showAppender = addSubmenu || hasDescendants;
 
 	const inputValue = urlInput !== null ? urlInput : url;
 
@@ -99,7 +99,7 @@ function NavigationMenuItemEdit( {
 						name="submenu"
 						icon={ <SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24"><Path d="M14 5h8v2h-8zm0 5.5h8v2h-8zm0 5.5h8v2h-8zM2 11.5C2 15.08 4.92 18 8.5 18H9v2l3-3-3-3v2h-.5C6.02 16 4 13.98 4 11.5S6.02 7 8.5 7H12V5H8.5C4.92 5 2 7.92 2 11.5z" /><Path fill="none" d="M0 0h24v24H0z" /></SVG> }
 						title={ __( 'Submenu' ) }
-						onClick={ () => setaddSubmenu( ! addSubmenu ) }
+						onClick={ insertMenuItemBlock }
 					/> }
 				</Toolbar>
 				{ isLinkOpen &&
@@ -196,7 +196,7 @@ function NavigationMenuItemEdit( {
 				{ ( isSelected || isParentOfSelectedBlock ) &&
 					<InnerBlocks
 						allowedBlocks={ [ 'core/navigation-menu-item' ] }
-						renderAppender={ showAppender ? InnerBlocks.ButtonBlockAppender : false }
+						renderAppender={ hasDescendants ? InnerBlocks.ButtonBlockAppender : false }
 					/>
 				}
 			</div>
@@ -204,12 +204,32 @@ function NavigationMenuItemEdit( {
 	);
 }
 
-export default withSelect( ( select, ownProps ) => {
-	const { getClientIdsOfDescendants, hasSelectedInnerBlock } = select( 'core/block-editor' );
-	const { clientId } = ownProps;
+export default compose( [
+	withSelect( ( select, ownProps ) => {
+		const { getClientIdsOfDescendants, hasSelectedInnerBlock } = select( 'core/block-editor' );
+		const { clientId } = ownProps;
 
-	return {
-		isParentOfSelectedBlock: hasSelectedInnerBlock( clientId, true ),
-		hasDescendants: !! getClientIdsOfDescendants( [ clientId ] ).length,
-	};
-} )( NavigationMenuItemEdit );
+		return {
+			isParentOfSelectedBlock: hasSelectedInnerBlock( clientId, true ),
+			hasDescendants: !! getClientIdsOfDescendants( [ clientId ] ).length,
+		};
+	} ),
+	withDispatch( ( dispatch, ownProps ) => {
+		return {
+			insertMenuItemBlock() {
+				const { clientId } = ownProps;
+
+				const {
+					insertBlock,
+				} = dispatch( 'core/block-editor' );
+
+				const blockToInsert = createBlock( 'core/navigation-menu-item' );
+				insertBlock(
+					blockToInsert,
+					0,
+					clientId,
+				);
+			},
+		};
+	} ),
+] )( NavigationMenuItemEdit );

--- a/packages/block-library/src/navigation-menu-item/edit.js
+++ b/packages/block-library/src/navigation-menu-item/edit.js
@@ -193,15 +193,10 @@ function NavigationMenuItemEdit( {
 					placeholder={ __( 'Add item…' ) }
 					withoutInteractiveFormatting
 				/>
-				{ ( isSelected || isParentOfSelectedBlock ) && showAppender &&
+				{ ( isSelected || isParentOfSelectedBlock ) &&
 					<InnerBlocks
 						allowedBlocks={ [ 'core/navigation-menu-item' ] }
-					/>
-				}
-				{ ( isSelected || isParentOfSelectedBlock ) && ! showAppender &&
-					<InnerBlocks
-						allowedBlocks={ [ 'core/navigation-menu-item' ] }
-						renderAppender={ false }
+						renderAppender={ showAppender ? InnerBlocks.ButtonBlockAppender : false }
 					/>
 				}
 			</div>

--- a/packages/block-library/src/navigation-menu-item/edit.js
+++ b/packages/block-library/src/navigation-menu-item/edit.js
@@ -10,6 +10,8 @@ import { withSelect } from '@wordpress/data';
 import {
 	ExternalLink,
 	PanelBody,
+	Path,
+	SVG,
 	TextareaControl,
 	TextControl,
 	Toolbar,
@@ -40,6 +42,7 @@ import {
 
 function NavigationMenuItemEdit( {
 	attributes,
+	hasDescendants,
 	isSelected,
 	isParentOfSelectedBlock,
 	setAttributes,
@@ -47,6 +50,9 @@ function NavigationMenuItemEdit( {
 	const [ isLinkOpen, setIsLinkOpen ] = useState( false );
 	const [ isEditingLink, setIsEditingLink ] = useState( false );
 	const [ urlInput, setUrlInput ] = useState( null );
+	const [ addSubmenu, setaddSubmenu ] = useState( false );
+
+	const showAppender = addSubmenu || hasDescendants;
 
 	const inputValue = urlInput !== null ? urlInput : url;
 
@@ -89,7 +95,14 @@ function NavigationMenuItemEdit( {
 						title={ __( 'Link' ) }
 						onClick={ () => setIsLinkOpen( ! isLinkOpen ) }
 					/>
-					{ isLinkOpen &&
+					{ ! hasDescendants && <ToolbarButton
+						name="submenu"
+						icon={ <SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24"><Path d="M14 5h8v2h-8zm0 5.5h8v2h-8zm0 5.5h8v2h-8zM2 11.5C2 15.08 4.92 18 8.5 18H9v2l3-3-3-3v2h-.5C6.02 16 4 13.98 4 11.5S6.02 7 8.5 7H12V5H8.5C4.92 5 2 7.92 2 11.5z" /><Path fill="none" d="M0 0h24v24H0z" /></SVG> }
+						title={ __( 'Submenu' ) }
+						onClick={ () => setaddSubmenu( ! addSubmenu ) }
+					/> }
+				</Toolbar>
+				{ isLinkOpen &&
 					<>
 						<URLPopover
 							className="wp-block-navigation-menu-item__inline-link-input"
@@ -115,8 +128,7 @@ function NavigationMenuItemEdit( {
 
 						</URLPopover>
 					</>
-					}
-				</Toolbar>
+				}
 			</BlockControls>
 			<InspectorControls>
 				<PanelBody
@@ -181,9 +193,15 @@ function NavigationMenuItemEdit( {
 					placeholder={ __( 'Add item…' ) }
 					withoutInteractiveFormatting
 				/>
-				{ ( isSelected || isParentOfSelectedBlock ) &&
+				{ ( isSelected || isParentOfSelectedBlock ) && showAppender &&
 					<InnerBlocks
 						allowedBlocks={ [ 'core/navigation-menu-item' ] }
+					/>
+				}
+				{ ( isSelected || isParentOfSelectedBlock ) && ! showAppender &&
+					<InnerBlocks
+						allowedBlocks={ [ 'core/navigation-menu-item' ] }
+						renderAppender={ false }
 					/>
 				}
 			</div>
@@ -192,10 +210,11 @@ function NavigationMenuItemEdit( {
 }
 
 export default withSelect( ( select, ownProps ) => {
-	const { hasSelectedInnerBlock } = select( 'core/block-editor' );
+	const { getClientIdsOfDescendants, hasSelectedInnerBlock } = select( 'core/block-editor' );
 	const { clientId } = ownProps;
 
 	return {
 		isParentOfSelectedBlock: hasSelectedInnerBlock( clientId, true ),
+		hasDescendants: !! getClientIdsOfDescendants( [ clientId ] ).length,
 	};
 } )( NavigationMenuItemEdit );

--- a/packages/block-library/src/navigation-menu-item/editor.scss
+++ b/packages/block-library/src/navigation-menu-item/editor.scss
@@ -25,7 +25,7 @@
 	// Compensate for menu item base padding.
 	margin-left: -$grid-size;
 
-	.wp-block-navigation-menu-item__field {
+	.wp-block-navigation-menu-item__content {
 		margin-right: $grid-size;
 
 		// This should match the padding of the menu item.


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

Closes #18104.

Navigation menu items: Block appender should only be visible when the item already has a submenu.
 If the item has no submenu, show a toolbar button that reveals the block appender on click.

Would love some a11y feedback on whether clicking the toolbar button should merely show/hide the appender, or if we should transfer focus to the appender, or announce its presence in any other way.
Currently clicking only shows/hides the appender so screen reader users won't get any feedback on what is happening.


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Tested in browser:
1. Enable navigation block in experiments
2. Add a navigation block with some nav item blocks to a post
3. Check that toolbar button is rendered for nav items that have no children, and appender button is not rendered.
4. Check that toolbar button is not rendered for nav items that do have children, and appender button is rendered.

## Screenshots <!-- if applicable -->

Scenario 1:

<img width="164" alt="Screen Shot 2019-10-29 at 3 41 50 pm" src="https://user-images.githubusercontent.com/8096000/67738441-be6c0500-fa62-11e9-91e5-63ff5aacec3f.png">

Scenario 2:

<img width="311" alt="Screen Shot 2019-10-29 at 3 42 29 pm" src="https://user-images.githubusercontent.com/8096000/67738444-c330b900-fa62-11e9-8d23-8de1a136acbd.png">


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
