### PR TITLE
[RNMobile] Gallery - GalleryImage component

### DIFF
--- a/packages/block-library/src/gallery/gallery-button.native.js
+++ b/packages/block-library/src/gallery/gallery-button.native.js
@@ -1,0 +1,55 @@
+/**
+ * External dependencies
+ */
+import { StyleSheet, TouchableOpacity, View } from 'react-native';
+
+/**
+ * WordPress dependencies
+ */
+import { Icon } from '@wordpress/components';
+
+const styles = StyleSheet.create( {
+	buttonActive: {
+		flexDirection: 'row',
+		justifyContent: 'center',
+		alignItems: 'center',
+		borderRadius: 6,
+		borderColor: '#2e4453',
+		backgroundColor: '#2e4453',
+		aspectRatio: 1,
+	},
+} );
+
+export function Button( props ) {
+	const {
+		icon,
+		onClick,
+		disabled,
+		'aria-disabled': ariaDisabled,
+		accessibilityLabel = 'button',
+		style,
+	} = props;
+
+	const buttonStyle = StyleSheet.compose( styles.buttonActive, style );
+
+	const isDisabled = disabled || ariaDisabled;
+
+	const fill = isDisabled ? 'gray' : 'white';
+
+	return (
+		<TouchableOpacity
+			activeOpacity={ 0.7 }
+			accessible={ true }
+			accessibilityLabel={ accessibilityLabel }
+			accessibilityRole={ 'button' }
+			onPress={ onClick }
+			disabled={ isDisabled }
+		>
+			<View style={ buttonStyle }>
+				<Icon icon={ icon } fill={ fill } size={ 24 } />
+			</View>
+		</TouchableOpacity>
+	);
+}
+
+export default Button;

--- a/packages/block-library/src/gallery/gallery-button.native.js
+++ b/packages/block-library/src/gallery/gallery-button.native.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { StyleSheet, TouchableOpacity, View } from 'react-native';
+import { StyleSheet, TouchableOpacity } from 'react-native';
 
 /**
  * WordPress dependencies

--- a/packages/block-library/src/gallery/gallery-button.native.js
+++ b/packages/block-library/src/gallery/gallery-button.native.js
@@ -31,16 +31,14 @@ export function Button( props ) {
 
 	return (
 		<TouchableOpacity
+			style={ buttonStyle }
 			activeOpacity={ 0.7 }
-			accessible={ true }
 			accessibilityLabel={ accessibilityLabel }
 			accessibilityRole={ 'button' }
 			onPress={ onClick }
 			disabled={ isDisabled }
 		>
-			<View style={ buttonStyle }>
-				<Icon icon={ icon } fill={ fill } size={ 24 } />
-			</View>
+			<Icon icon={ icon } fill={ fill } size={ 24 } />
 		</TouchableOpacity>
 	);
 }

--- a/packages/block-library/src/gallery/gallery-button.native.js
+++ b/packages/block-library/src/gallery/gallery-button.native.js
@@ -8,17 +8,10 @@ import { StyleSheet, TouchableOpacity, View } from 'react-native';
  */
 import { Icon } from '@wordpress/components';
 
-const styles = StyleSheet.create( {
-	buttonActive: {
-		flexDirection: 'row',
-		justifyContent: 'center',
-		alignItems: 'center',
-		borderRadius: 6,
-		borderColor: '#2e4453',
-		backgroundColor: '#2e4453',
-		aspectRatio: 1,
-	},
-} );
+/**
+ * Internal dependencies
+ */
+import styles from './gallery-image-styles';
 
 export function Button( props ) {
 	const {

--- a/packages/block-library/src/gallery/gallery-button.native.js
+++ b/packages/block-library/src/gallery/gallery-button.native.js
@@ -11,7 +11,7 @@ import { Icon } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-import styles from './gallery-image-styles';
+import style from './gallery-image-style';
 
 export function Button( props ) {
 	const {
@@ -20,14 +20,14 @@ export function Button( props ) {
 		disabled,
 		'aria-disabled': ariaDisabled,
 		accessibilityLabel = 'button',
-		style,
+		style: customStyle,
 	} = props;
 
-	const buttonStyle = StyleSheet.compose( styles.buttonActive, style );
+	const buttonStyle = StyleSheet.compose( style.buttonActive, customStyle );
 
 	const isDisabled = disabled || ariaDisabled;
 
-	const { fill } = isDisabled ? styles.buttonDisabled : styles.button;
+	const { fill } = isDisabled ? style.buttonDisabled : style.button;
 
 	return (
 		<TouchableOpacity

--- a/packages/block-library/src/gallery/gallery-button.native.js
+++ b/packages/block-library/src/gallery/gallery-button.native.js
@@ -27,7 +27,7 @@ export function Button( props ) {
 
 	const isDisabled = disabled || ariaDisabled;
 
-	const fill = isDisabled ? 'gray' : 'white';
+	const { fill } = isDisabled ? styles.buttonDisabled : styles.button;
 
 	return (
 		<TouchableOpacity

--- a/packages/block-library/src/gallery/gallery-button.native.js
+++ b/packages/block-library/src/gallery/gallery-button.native.js
@@ -16,6 +16,7 @@ import style from './gallery-image-style';
 export function Button( props ) {
 	const {
 		icon,
+		iconSize = 24,
 		onClick,
 		disabled,
 		'aria-disabled': ariaDisabled,
@@ -38,7 +39,7 @@ export function Button( props ) {
 			onPress={ onClick }
 			disabled={ isDisabled }
 		>
-			<Icon icon={ icon } fill={ fill } size={ 24 } />
+			<Icon icon={ icon } fill={ fill } size={ iconSize } />
 		</TouchableOpacity>
 	);
 }

--- a/packages/block-library/src/gallery/gallery-button.native.js
+++ b/packages/block-library/src/gallery/gallery-button.native.js
@@ -11,7 +11,7 @@ import { Icon } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-import style from './gallery-image-style';
+import style from './gallery-image-style.scss';
 
 export function Button( props ) {
 	const {

--- a/packages/block-library/src/gallery/gallery-image-style.native.scss
+++ b/packages/block-library/src/gallery/gallery-image-style.native.scss
@@ -121,7 +121,7 @@
 }
 
 @mixin caption-shared {
-	font-size: 15;
+	font-size: 12px;
 	color: #fff;
 	font-family: $default-regular-font;
 	min-height: $min-height-paragraph;

--- a/packages/block-library/src/gallery/gallery-image-style.native.scss
+++ b/packages/block-library/src/gallery/gallery-image-style.native.scss
@@ -21,7 +21,7 @@
 	opacity: 0.3;
 }
 
-@function getOverlayBorderWidth() {
+@function get-overlay-border-width() {
 	@return 3px;
 }
 
@@ -31,7 +31,7 @@
 	bottom: 0;
 	left: 0;
 	right: 0;
-	border-width: getOverlayBorderWidth();
+	border-width: get-overlay-border-width();
 	border-color: #0000;
 }
 
@@ -110,7 +110,7 @@
 	margin-top: 5px;
 }
 
-@function getCaptionBackgroundColor() {
+@function get-caption-background-color() {
 	@return rgba(0, 0, 0, 0.4);
 }
 
@@ -120,7 +120,7 @@
 	align-items: flex-end;
 }
 
-@mixin captionShared {
+@mixin caption-shared {
 	font-size: 15;
 	color: #fff;
 	font-family: $default-regular-font;
@@ -128,8 +128,8 @@
 }
 
 .caption {
-	@include captionShared;
-	background-color: getCaptionBackgroundColor();
+	@include caption-shared;
+	background-color: get-caption-background-color();
 }
 
 .captionPlaceholder {
@@ -144,7 +144,7 @@
 
 // expand caption in ellipsis mode to compensate for overlay border
 .captionEllipsisContainer {
-	$width: getOverlayBorderWidth();
+	$width: get-overlay-border-width();
 	position: absolute;
 	bottom: - $width;
 	left: - $width;
@@ -153,10 +153,10 @@
 	padding-left: $width;
 	padding-right: $width;
 	// use caption background color on container in ellipsis mode
-	background-color: getCaptionBackgroundColor();
+	background-color: get-caption-background-color();
 }
 
 .captionEllipsis {
-	@include captionShared;
+	@include caption-shared;
 	padding-top: 15px;
 }

--- a/packages/block-library/src/gallery/gallery-image-style.native.scss
+++ b/packages/block-library/src/gallery/gallery-image-style.native.scss
@@ -21,14 +21,17 @@
 	opacity: 0.3;
 }
 
+@function getOverlayBorderWidth() {
+	@return 3px;
+}
+
 .overlay {
 	position: absolute;
 	top: 0;
 	bottom: 0;
 	left: 0;
 	right: 0;
-	padding: 5px;
-	border-width: 3px;
+	border-width: getOverlayBorderWidth();
 	border-color: #0000;
 }
 
@@ -74,15 +77,9 @@
 }
 
 .toolbar {
+	padding: 5px;
 	flex-direction: row;
 	justify-content: space-between;
-}
-
-.captionContainer {
-	position: absolute;
-	bottom: 0;
-	left: 0;
-	right: 0;
 }
 
 .uploadFailedContainer {
@@ -113,16 +110,53 @@
 	margin-top: 5px;
 }
 
-.caption {
-	// background-color: #fff7;
-	background-color: #0007;
+@function getCaptionBackgroundColor() {
+	@return rgba(0, 0, 0, 0.4);
+}
+
+.captionContainer {
+	flex: 1;
+	flex-direction: row;
+	align-items: flex-end;
+}
+
+@mixin captionShared {
+	font-size: 15;
 	color: #fff;
+	font-family: $default-regular-font;
+	min-height: $min-height-paragraph;
+}
+
+.caption {
+	@include captionShared;
+	background-color: getCaptionBackgroundColor();
 }
 
 .captionPlaceholder {
 	color: #ccc;
 }
 
+/*
 .captionDark {
-	// background-color: #0007;
+	background-color: #0007;
+}
+*/
+
+// expand caption in ellipsis mode to compensate for overlay border
+.captionEllipsisContainer {
+	$width: getOverlayBorderWidth();
+	position: absolute;
+	bottom: - $width;
+	left: - $width;
+	right: - $width;
+	padding-bottom: $width;
+	padding-left: $width;
+	padding-right: $width;
+	// use caption background color on container in ellipsis mode
+	background-color: getCaptionBackgroundColor();
+}
+
+.captionEllipsis {
+	@include captionShared;
+	padding-top: 15px;
 }

--- a/packages/block-library/src/gallery/gallery-image-style.native.scss
+++ b/packages/block-library/src/gallery/gallery-image-style.native.scss
@@ -143,9 +143,10 @@
 }
 */
 
-// expand caption in ellipsis mode to compensate for overlay border
-.captionEllipsisContainer {
+// expand caption container to compensate for overlay border
+.captionExpandedContainer {
 	$width: get-overlay-border-width();
+	max-height: $min-height-paragraph + $width;
 	position: absolute;
 	bottom: - $width;
 	left: - $width;
@@ -153,11 +154,10 @@
 	padding-bottom: $width;
 	padding-left: $width;
 	padding-right: $width;
-	// use caption background color on container in ellipsis mode
+	// use caption background color on container when expanded
 	background-color: get-caption-background-color();
 }
 
-.captionEllipsis {
+.captionExpanded {
 	@include caption-shared;
-	padding-top: 15px;
 }

--- a/packages/block-library/src/gallery/gallery-image-style.native.scss
+++ b/packages/block-library/src/gallery/gallery-image-style.native.scss
@@ -125,6 +125,7 @@
 	color: #fff;
 	font-family: $default-regular-font;
 	min-height: $min-height-paragraph;
+	text-align: center;
 }
 
 .caption {

--- a/packages/block-library/src/gallery/gallery-image-style.native.scss
+++ b/packages/block-library/src/gallery/gallery-image-style.native.scss
@@ -1,10 +1,10 @@
-@function get-gallery-image-container-height() {
-	@return 150px;
-}
+$get-gallery-image-container-height: 150px;
+$get-overlay-border-width: 3px;
+$get-caption-background-color: rgba(0, 0, 0, 0.4);
 
 .galleryImageContainer {
 	flex: 1;
-	height: get-gallery-image-container-height();
+	height: $get-gallery-image-container-height;
 	background-color: $gray-lighten-30;
 }
 
@@ -25,17 +25,13 @@
 	opacity: 0.3;
 }
 
-@function get-overlay-border-width() {
-	@return 3px;
-}
-
 .overlay {
 	position: absolute;
 	top: 0;
 	bottom: 0;
 	left: 0;
 	right: 0;
-	border-width: get-overlay-border-width();
+	border-width: $get-overlay-border-width;
 	border-color: #0000;
 }
 
@@ -114,10 +110,6 @@
 	margin-top: 5px;
 }
 
-@function get-caption-background-color() {
-	@return rgba(0, 0, 0, 0.4);
-}
-
 .captionContainer {
 	flex: 1;
 	flex-direction: row;
@@ -135,7 +127,7 @@
 
 .caption {
 	@include caption-shared;
-	background-color: get-caption-background-color();
+	background-color: $get-caption-background-color;
 }
 
 .captionPlaceholder {
@@ -150,9 +142,9 @@
 
 // expand caption container to compensate for overlay border
 .captionExpandedContainer {
-	$width: get-overlay-border-width();
+	$width: $get-overlay-border-width;
 	// constrain height to gallery image height for caption scroll
-	max-height: get-gallery-image-container-height();
+	max-height: $get-gallery-image-container-height;
 	position: absolute;
 	bottom: - $width;
 	left: - $width;
@@ -161,7 +153,7 @@
 	padding-left: $width;
 	padding-right: $width;
 	// use caption background color on container when expanded
-	background-color: get-caption-background-color();
+	background-color: $get-caption-background-color;
 }
 
 .captionExpanded {

--- a/packages/block-library/src/gallery/gallery-image-style.native.scss
+++ b/packages/block-library/src/gallery/gallery-image-style.native.scss
@@ -126,6 +126,7 @@
 
 @mixin caption-shared {
 	font-size: 12px;
+	background-color: #0000;
 	color: #fff;
 	font-family: $default-regular-font;
 	min-height: $min-height-paragraph;

--- a/packages/block-library/src/gallery/gallery-image-style.native.scss
+++ b/packages/block-library/src/gallery/gallery-image-style.native.scss
@@ -1,6 +1,10 @@
+@function get-gallery-image-container-height() {
+	@return 150px;
+}
+
 .galleryImageContainer {
 	flex: 1;
-	height: 150px;
+	height: get-gallery-image-container-height();
 	background-color: $gray-lighten-30;
 }
 
@@ -146,7 +150,8 @@
 // expand caption container to compensate for overlay border
 .captionExpandedContainer {
 	$width: get-overlay-border-width();
-	max-height: $min-height-paragraph + $width;
+	// constrain height to gallery image height for caption scroll
+	max-height: get-gallery-image-container-height();
 	position: absolute;
 	bottom: - $width;
 	left: - $width;

--- a/packages/block-library/src/gallery/gallery-image-styles.native.scss
+++ b/packages/block-library/src/gallery/gallery-image-styles.native.scss
@@ -79,10 +79,10 @@
 }
 
 .captionContainer {
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  right: 0;
+	position: absolute;
+	bottom: 0;
+	left: 0;
+	right: 0;
 }
 
 .uploadFailedContainer {
@@ -114,15 +114,15 @@
 }
 
 .caption {
-  // background-color: #fff7;
-  background-color: #0007;
-  color: #fff;
+	// background-color: #fff7;
+	background-color: #0007;
+	color: #fff;
 }
 
 .captionPlaceholder {
-  color: #ccc;
+	color: #ccc;
 }
 
 .captionDark {
-  // background-color: #0007;
+	// background-color: #0007;
 }

--- a/packages/block-library/src/gallery/gallery-image-styles.native.scss
+++ b/packages/block-library/src/gallery/gallery-image-styles.native.scss
@@ -1,6 +1,11 @@
-.container {
+.galleryImageContainer {
   flex: 1;
   height: 150px;
+  background-color: $gray-lighten-30;
+}
+
+.galleryImageContainerDark {
+  background-color: $gray-90;
 }
 
 .image {
@@ -24,11 +29,11 @@
   right: 0;
   padding: 5px;
   border-width: 3px;
-  border-color: #00000000;
+  border-color: #0000;
 }
 
 .overlaySelected {
-  border-color: #0070ff;
+  border-color: $blue-wordpress;
 }
 
 .button {

--- a/packages/block-library/src/gallery/gallery-image-styles.native.scss
+++ b/packages/block-library/src/gallery/gallery-image-styles.native.scss
@@ -37,7 +37,18 @@
 }
 
 .button {
+  fill: $gray-0;
 	width: 30px;
+}
+
+.buttonActive {
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  border-radius: 6px;
+  border-color: #2e4453;
+  background-color: #2e4453;
+  aspect-ratio: 1;
 }
 
 .moverButtons {

--- a/packages/block-library/src/gallery/gallery-image-styles.native.scss
+++ b/packages/block-library/src/gallery/gallery-image-styles.native.scss
@@ -1,0 +1,57 @@
+.container {
+  flex: 1;
+  height: 150px;
+}
+
+.image {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+}
+
+.overlay {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding: 5px;
+  border-width: 3px;
+}
+
+.button {
+  width: 30px;
+}
+
+.moverButtons {
+  flex-direction: row;
+  align-items: center;
+  border-radius: 3px;
+  background-color: #2e4453;
+}
+
+.separator {
+  border-right-color: gray;
+  // border-right-width: StyleSheet.hairlineWidth;
+  border-right-width: 1px;
+  height: 20px;
+}
+
+.removeButton {
+  width: 30px;
+  border-radius: 30px;
+}
+
+.toolbar {
+  flex-direction: row;
+  justify-content: space-between;
+}
+
+.caption {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+}

--- a/packages/block-library/src/gallery/gallery-image-styles.native.scss
+++ b/packages/block-library/src/gallery/gallery-image-styles.native.scss
@@ -55,3 +55,31 @@
   left: 0;
   right: 0;
 }
+
+.uploadFailedContainer {
+  position: absolute;
+  background-color: rgba(0, 0, 0, 0.5);
+  width: 100%;
+  height: 100%;
+  justify-content: center;
+  align-items: center;
+}
+
+.uploadFailed {
+  width: 24px;
+  height: 24px;
+  justify-content: center;
+  align-items: center;
+}
+
+.uploadFailedIcon {
+  fill: #fff;
+  width: 100%;
+  height: 100%;
+}
+
+.uploadFailedText {
+  color: #fff;
+  font-size: 14px;
+  margin-top: 5px;
+}

--- a/packages/block-library/src/gallery/gallery-image-styles.native.scss
+++ b/packages/block-library/src/gallery/gallery-image-styles.native.scss
@@ -37,21 +37,21 @@
 }
 
 .button {
-  fill: $gray-0;
+	fill: $gray-0;
 	width: 30px;
 }
 
 .buttonDisabled {
-  fill: $gray-30;
+	fill: $gray-30;
 }
 
 .buttonActive {
-  flex-direction: row;
-  justify-content: center;
-  align-items: center;
-  border-radius: 6px;
-  border-color: $gray-70;
-  background-color: $gray-70;
+	flex-direction: row;
+	justify-content: center;
+	align-items: center;
+	border-radius: 6px;
+	border-color: $gray-70;
+	background-color: $gray-70;
 }
 
 .moverButtonContainer {

--- a/packages/block-library/src/gallery/gallery-image-styles.native.scss
+++ b/packages/block-library/src/gallery/gallery-image-styles.native.scss
@@ -9,6 +9,11 @@
   bottom: 0;
   left: 0;
   right: 0;
+  opacity: 1;
+}
+
+.imageUploading {
+  opacity: 0.3;
 }
 
 .overlay {
@@ -19,6 +24,11 @@
   right: 0;
   padding: 5px;
   border-width: 3px;
+  border-color: #00000000;
+}
+
+.overlaySelected {
+  border-color: #0070ff;
 }
 
 .button {

--- a/packages/block-library/src/gallery/gallery-image-styles.native.scss
+++ b/packages/block-library/src/gallery/gallery-image-styles.native.scss
@@ -1,67 +1,67 @@
 .galleryImageContainer {
-  flex: 1;
-  height: 150px;
-  background-color: $gray-lighten-30;
+	flex: 1;
+	height: 150px;
+	background-color: $gray-lighten-30;
 }
 
 .galleryImageContainerDark {
-  background-color: $gray-90;
+	background-color: $gray-90;
 }
 
 .image {
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  opacity: 1;
+	position: absolute;
+	top: 0;
+	bottom: 0;
+	left: 0;
+	right: 0;
+	opacity: 1;
 }
 
 .imageUploading {
-  opacity: 0.3;
+	opacity: 0.3;
 }
 
 .overlay {
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  padding: 5px;
-  border-width: 3px;
-  border-color: #0000;
+	position: absolute;
+	top: 0;
+	bottom: 0;
+	left: 0;
+	right: 0;
+	padding: 5px;
+	border-width: 3px;
+	border-color: #0000;
 }
 
 .overlaySelected {
-  border-color: $blue-wordpress;
+	border-color: $blue-wordpress;
 }
 
 .button {
-  width: 30px;
+	width: 30px;
 }
 
 .moverButtons {
-  flex-direction: row;
-  align-items: center;
-  border-radius: 3px;
-  background-color: #2e4453;
+	flex-direction: row;
+	align-items: center;
+	border-radius: 3px;
+	background-color: #2e4453;
 }
 
 .separator {
-  border-right-color: gray;
-  // border-right-width: StyleSheet.hairlineWidth;
-  border-right-width: 1px;
-  height: 20px;
+	border-right-color: $gray-30;
+	// border-right-width: StyleSheet.hairlineWidth;
+	border-right-width: 1px;
+	height: 20px;
 }
 
 .removeButton {
-  width: 30px;
-  border-radius: 30px;
+	width: 30px;
+	border-radius: 30px;
 }
 
 .toolbar {
-  flex-direction: row;
-  justify-content: space-between;
+	flex-direction: row;
+	justify-content: space-between;
 }
 
 .caption {
@@ -72,29 +72,29 @@
 }
 
 .uploadFailedContainer {
-  position: absolute;
-  background-color: rgba(0, 0, 0, 0.5);
-  width: 100%;
-  height: 100%;
-  justify-content: center;
-  align-items: center;
+	position: absolute;
+	background-color: rgba(0, 0, 0, 0.5);
+	width: 100%;
+	height: 100%;
+	justify-content: center;
+	align-items: center;
 }
 
 .uploadFailed {
-  width: 24px;
-  height: 24px;
-  justify-content: center;
-  align-items: center;
+	width: 24px;
+	height: 24px;
+	justify-content: center;
+	align-items: center;
 }
 
 .uploadFailedIcon {
-  fill: #fff;
-  width: 100%;
-  height: 100%;
+	fill: #fff;
+	width: 100%;
+	height: 100%;
 }
 
 .uploadFailedText {
-  color: #fff;
-  font-size: 14px;
-  margin-top: 5px;
+	color: #fff;
+	font-size: 14px;
+	margin-top: 5px;
 }

--- a/packages/block-library/src/gallery/gallery-image-styles.native.scss
+++ b/packages/block-library/src/gallery/gallery-image-styles.native.scss
@@ -78,7 +78,7 @@
 	justify-content: space-between;
 }
 
-.caption {
+.captionContainer {
   position: absolute;
   bottom: 0;
   left: 0;
@@ -111,4 +111,18 @@
 	color: #fff;
 	font-size: 14px;
 	margin-top: 5px;
+}
+
+.caption {
+  // background-color: #fff7;
+  background-color: #0007;
+  color: #fff;
+}
+
+.captionPlaceholder {
+  color: #ccc;
+}
+
+.captionDark {
+  // background-color: #0007;
 }

--- a/packages/block-library/src/gallery/gallery-image-styles.native.scss
+++ b/packages/block-library/src/gallery/gallery-image-styles.native.scss
@@ -41,21 +41,24 @@
 	width: 30px;
 }
 
+.buttonDisabled {
+  fill: $gray-30;
+}
+
 .buttonActive {
   flex-direction: row;
   justify-content: center;
   align-items: center;
   border-radius: 6px;
-  border-color: #2e4453;
-  background-color: #2e4453;
-  aspect-ratio: 1;
+  border-color: $gray-70;
+  background-color: $gray-70;
 }
 
-.moverButtons {
+.moverButtonContainer {
 	flex-direction: row;
 	align-items: center;
 	border-radius: 3px;
-	background-color: #2e4453;
+	background-color: $gray-70;
 }
 
 .separator {

--- a/packages/block-library/src/gallery/gallery-image.native.js
+++ b/packages/block-library/src/gallery/gallery-image.native.js
@@ -131,7 +131,7 @@ class GalleryImage extends Component {
 		const {
 			url, isFirstItem, isLastItem, isSelected, caption, onRemove,
 			onMoveForward, onMoveBackward, setAttributes, 'aria-label': ariaLabel,
-			isCropped } = this.props;
+			isCropped, getStylesFromColorScheme } = this.props;
 
 		const { compose } = StyleSheet;
 

--- a/packages/block-library/src/gallery/gallery-image.native.js
+++ b/packages/block-library/src/gallery/gallery-image.native.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { Image, StyleSheet, View, Text, TouchableWithoutFeedback } from 'react-native';
+import { Image, StyleSheet, View, ScrollView, Text, TouchableWithoutFeedback } from 'react-native';
 import {
 	requestImageFailedRetryDialog,
 	requestImageUploadCancelDialog,
@@ -21,7 +21,21 @@ import { withPreferredColorScheme } from '@wordpress/compose';
  * Internal dependencies
  */
 import Button from './gallery-button';
-import styles from './gallery-image-styles';
+import style from './gallery-image-style';
+
+const { compose } = StyleSheet;
+
+const separatorStyle = compose( style.separator,
+	{ borderRightWidth: StyleSheet.hairlineWidth }
+);
+
+const buttonStyle = compose( style.button,
+	{ aspectRatio: 1 }
+);
+
+const removeButtonStyle = compose( style.removeButton,
+	{ aspectRatio: 1 }
+);
 
 class GalleryImage extends Component {
 	constructor() {
@@ -133,34 +147,21 @@ class GalleryImage extends Component {
 			onMoveForward, onMoveBackward, setAttributes, 'aria-label': ariaLabel,
 			isCropped, getStylesFromColorScheme } = this.props;
 
-		const { compose } = StyleSheet;
 
 		const { isUploadInProgress } = this.state;
 		const { isUploadFailed, retryMessage } = params;
 		const resizeMode = isCropped ? 'cover' : 'contain';
 
-		const imageStyle = [ styles.image, { resizeMode },
-			isUploadInProgress ? styles.imageUploading : undefined,
+		const imageStyle = [ style.image, { resizeMode },
+			isUploadInProgress ? style.imageUploading : undefined,
 		];
 
-		const overlayStyle = compose( styles.overlay,
-			isSelected ? styles.overlaySelected : undefined,
+		const overlayStyle = compose( style.overlay,
+			isSelected ? style.overlaySelected : undefined,
 		);
 
-		const separatorStyle = compose( styles.separator,
-			{ borderRightWidth: StyleSheet.hairlineWidth }
-		);
-
-		const buttonStyle = compose( styles.button,
-			{ aspectRatio: 1 }
-		);
-
-		const removeButtonStyle = compose( styles.removeButton,
-			{ aspectRatio: 1 }
-		);
-
-		const captionStyle = getStylesFromColorScheme( styles.caption, styles.captionDark );
-		const captionPlaceholderStyle = getStylesFromColorScheme( styles.captionPlaceholder, styles.captionPlaceholderDark );
+		const captionStyle = getStylesFromColorScheme( style.caption, style.captionDark );
+		const captionPlaceholderStyle = getStylesFromColorScheme( style.captionPlaceholder, style.captionPlaceholderDark );
 
 		return (
 			<>
@@ -172,19 +173,19 @@ class GalleryImage extends Component {
 					ref={ this.bindContainer }
 				/>
 				{ isUploadFailed && (
-					<View style={ styles.uploadFailedContainer }>
-						<View style={ styles.uploadFailed }>
-							<Icon icon={ 'warning' } { ...styles.uploadFailedIcon } />
+					<View style={ style.uploadFailedContainer }>
+						<View style={ style.uploadFailed }>
+							<Icon icon={ 'warning' } { ...style.uploadFailedIcon } />
 						</View>
-						<Text style={ styles.uploadFailedText }>{ retryMessage }</Text>
+						<Text style={ style.uploadFailedText }>{ retryMessage }</Text>
 					</View>
 				) }
 				<View style={ overlayStyle }>
 					{ ! isUploadInProgress && (
 					<>
 						{ isSelected && (
-							<View style={ styles.toolbar }>
-								<View style={ styles.moverButtonContainer } >
+							<View style={ style.toolbar }>
+								<View style={ style.moverButtonContainer } >
 									<Button
 										style={ buttonStyle }
 										icon="arrow-left"
@@ -238,8 +239,8 @@ class GalleryImage extends Component {
 	render() {
 		const { id, isBlockSelected, onRemove, getStylesFromColorScheme } = this.props;
 
-		const containerStyle = getStylesFromColorScheme( styles.galleryImageContainer,
-			styles.galleryImageContainerDark );
+		const containerStyle = getStylesFromColorScheme( style.galleryImageContainer,
+			style.galleryImageContainerDark );
 
 		return (
 			<TouchableWithoutFeedback
@@ -248,7 +249,6 @@ class GalleryImage extends Component {
 			>
 				<View style={ containerStyle }>
 					<MediaUploadProgress
-						// coverUrl={ url }
 						mediaId={ id }
 						onUpdateMediaProgress={ this.updateMediaProgress }
 						onFinishMediaUploadWithSuccess={ this.finishMediaUploadWithSuccess }

--- a/packages/block-library/src/gallery/gallery-image.native.js
+++ b/packages/block-library/src/gallery/gallery-image.native.js
@@ -16,7 +16,6 @@ import { Component } from '@wordpress/element';
 import { Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { BACKSPACE, DELETE } from '@wordpress/keycodes';
-import { withSelect } from '@wordpress/data';
 import { RichText, MediaUploadProgress } from '@wordpress/block-editor';
 import { isURL } from '@wordpress/url';
 
@@ -293,11 +292,4 @@ class GalleryImage extends Component {
 	}
 }
 
-export default withSelect( ( select, ownProps ) => {
-	const { getMedia } = select( 'core' );
-	const { id } = ownProps;
-
-	return {
-		image: id ? getMedia( id ) : null,
-	};
-} )( GalleryImage );
+export default GalleryImage;

--- a/packages/block-library/src/gallery/gallery-image.native.js
+++ b/packages/block-library/src/gallery/gallery-image.native.js
@@ -162,6 +162,9 @@ class GalleryImage extends Component {
 
 		const captionStyle = getStylesFromColorScheme( style.caption, style.captionDark );
 		const captionPlaceholderStyle = getStylesFromColorScheme( style.captionPlaceholder, style.captionPlaceholderDark );
+		
+		const shouldShowCaptionEditable = ! isUploadFailed && isSelected;
+		const shouldShowCaptionEllipsis = ! isUploadFailed && ( ! isSelected && !! caption );
 
 		return (
 			<>
@@ -213,7 +216,7 @@ class GalleryImage extends Component {
 								/>
 							</View>
 						) }
-						{ ! isUploadFailed && isSelected && (
+						{ shouldShowCaptionEditable && (
 							<View style={ style.captionContainer }>
 								<ScrollView nestedScrollEnabled>
 									<RichText
@@ -233,7 +236,7 @@ class GalleryImage extends Component {
 						) }
 					</>
 					) }
-					{ ! isUploadFailed && ( ! isSelected && !! caption ) && (
+					{ shouldShowCaptionEllipsis && (
 						<View  style={ style.captionEllipsisContainer }>
 							<Text style={ style.captionEllipsis } numberOfLines={ 1 }>
 								{ caption }

--- a/packages/block-library/src/gallery/gallery-image.native.js
+++ b/packages/block-library/src/gallery/gallery-image.native.js
@@ -32,14 +32,12 @@ class GalleryImage extends Component {
 		this.onSelectImage = this.onSelectImage.bind( this );
 		this.onSelectCaption = this.onSelectCaption.bind( this );
 		this.onMediaPressed = this.onMediaPressed.bind( this );
-		this.onRemoveImage = this.onRemoveImage.bind( this );
 		this.bindContainer = this.bindContainer.bind( this );
 
 		this.updateMediaProgress = this.updateMediaProgress.bind( this );
 		this.finishMediaUploadWithSuccess = this.finishMediaUploadWithSuccess.bind( this );
 		this.finishMediaUploadWithFailure = this.finishMediaUploadWithFailure.bind( this );
 		this.mediaUploadStateReset = this.mediaUploadStateReset.bind( this );
-		this.onMediaUpdate = this.onMediaUpdate.bind( this );
 		this.renderContent = this.renderContent.bind( this );
 
 		this.state = {
@@ -66,14 +64,14 @@ class GalleryImage extends Component {
 	}
 
 	onMediaPressed() {
-		const { id: mediaId, url: mediaUrl } = this.props;
+		const { id, url } = this.props;
 
 		this.onSelectImage();
 
 		if ( this.state.isUploadInProgress ) {
-			requestImageUploadCancelDialog( mediaId );
-		} else if ( ( this.state.didUploadFail ) || mediaId && ! isURL( mediaUrl ) ) {
-			requestImageFailedRetryDialog( mediaId );
+			requestImageUploadCancelDialog( id );
+		} else if ( ( this.state.didUploadFail ) || id && ! isURL( url ) ) {
+			requestImageFailedRetryDialog( id );
 		}
 	}
 
@@ -86,17 +84,6 @@ class GalleryImage extends Component {
 			this.setState( {
 				captionSelected: false,
 			} );
-		}
-	}
-
-	onRemoveImage( event ) {
-		if (
-			this.container === document.activeElement &&
-			this.props.isSelected && [ BACKSPACE, DELETE ].indexOf( event.keyCode ) !== -1
-		) {
-			event.stopPropagation();
-			event.preventDefault();
-			this.props.onRemove();
 		}
 	}
 
@@ -125,12 +112,11 @@ class GalleryImage extends Component {
 	}
 
 	finishMediaUploadWithSuccess( payload ) {
-		const { onMediaUpdate } = this;
-
-		onMediaUpdate( {
+		this.props.setAttributes( {
 			id: payload.mediaServerId,
 			url: payload.mediaUrl,
 		} );
+
 		this.setState( {
 			isUploadInProgress: false,
 			didUploadFail: false,
@@ -145,24 +131,13 @@ class GalleryImage extends Component {
 	}
 
 	mediaUploadStateReset() {
-		const { onMediaUpdate } = this;
+		this.props.setAttributes( { id: null, url: null } );
 
-		onMediaUpdate( { id: null, url: null } );
 		this.setState( {
 			isUploadInProgress: false,
 			didUploadFail: false,
 		} );
 	}
-
-	onMediaUpdate( media ) {
-		const { setAttributes } = this.props;
-
-		setAttributes( {
-			mediaId: media.id,
-			mediaUrl: media.url,
-		} );
-	}
-
 
 	renderContent( params ) {
 		const {
@@ -195,12 +170,8 @@ class GalleryImage extends Component {
 						opacity,
 					} ] }
 					source={ { uri: url } }
-					alt={ alt }
-					data-id={ id }
-					onFocus={ this.onSelectImage }
-					onKeyDown={ this.onRemoveImage }
-					tabIndex="0"
-					aria-label={ ariaLabel }
+					// alt={ alt }
+					accessibilityLabel={ ariaLabel }
 					ref={ this.bindContainer }
 				/>
 				{ isUploadFailed && (

--- a/packages/block-library/src/gallery/gallery-image.native.js
+++ b/packages/block-library/src/gallery/gallery-image.native.js
@@ -3,8 +3,6 @@
  */
 import { Image, StyleSheet, View, Text, TouchableWithoutFeedback } from 'react-native';
 import {
-	requestMediaImport,
-	mediaUploadSync,
 	requestImageFailedRetryDialog,
 	requestImageUploadCancelDialog,
 } from 'react-native-gutenberg-bridge';
@@ -15,7 +13,6 @@ import {
 import { Component } from '@wordpress/element';
 import { Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { BACKSPACE, DELETE } from '@wordpress/keycodes';
 import { RichText, MediaUploadProgress } from '@wordpress/block-editor';
 import { isURL } from '@wordpress/url';
 
@@ -131,8 +128,8 @@ class GalleryImage extends Component {
 
 	renderContent( params ) {
 		const {
-			url, alt, id, linkTo, link, isFirstItem, isLastItem, isSelected, caption,
-			isBlockSelected, onRemove, onMoveForward, onMoveBackward, setAttributes,
+			url, alt, linkTo, link, isFirstItem, isLastItem, isSelected, caption,
+			onRemove, onMoveForward, onMoveBackward, setAttributes,
 			'aria-label': ariaLabel, isCropped } = this.props;
 
 		// I'm not sure if or how we can use this on mobile

--- a/packages/block-library/src/gallery/gallery-image.native.js
+++ b/packages/block-library/src/gallery/gallery-image.native.js
@@ -132,17 +132,28 @@ class GalleryImage extends Component {
 			onMoveForward, onMoveBackward, setAttributes, 'aria-label': ariaLabel,
 			isCropped } = this.props;
 
+		const { compose } = StyleSheet;
+
 		const { isUploadInProgress } = this.state;
 		const { isUploadFailed, retryMessage } = params;
-		const opacity = isUploadInProgress ? 0.3 : 1;
+		const resizeMode = isCropped ? 'cover' : 'contain';
+
+		const imageStyle = [ styles.image, resizeMode,
+			isUploadInProgress ? styles.imageUploading : undefined,
+		];
+
+		const overlayStyle = compose( styles.overlay,
+			isSelected ? styles.overlaySelected : undefined,
+		);
+
+		const separatorStyle = compose( styles.separator,
+			{ borderRightWidth: StyleSheet.hairlineWidth }
+		);
 
 		return (
 			<>
 				<Image
-					style={ [ styles.image, {
-						resizeMode: isCropped ? 'cover' : 'contain',
-						opacity,
-					} ] }
+					style={ imageStyle }
 					source={ { uri: url } }
 					// alt={ alt }
 					accessibilityLabel={ ariaLabel }
@@ -156,9 +167,7 @@ class GalleryImage extends Component {
 						<Text style={ styles.uploadFailedText }>{ retryMessage }</Text>
 					</View>
 				) }
-				<View style={ [ styles.overlay, {
-					borderColor: isSelected ? '#0070ff' : '#00000000',
-				} ] }>
+				<View style={ overlayStyle }>
 				{ ! isUploadInProgress && (
 					<>
 						{ isSelected && (
@@ -172,9 +181,7 @@ class GalleryImage extends Component {
 										aria-disabled={ isFirstItem }
 										disabled={ ! isSelected }
 									/>
-									<View style={ [ styles.separator, {
-										borderRightWidth: StyleSheet.hairlineWidth,
-									} ] }></View>
+									<View style={ separatorStyle }></View>
 									<Button
 										style={ styles.button }
 										icon="arrow-right"

--- a/packages/block-library/src/gallery/gallery-image.native.js
+++ b/packages/block-library/src/gallery/gallery-image.native.js
@@ -128,22 +128,9 @@ class GalleryImage extends Component {
 
 	renderContent( params ) {
 		const {
-			url, alt, linkTo, link, isFirstItem, isLastItem, isSelected, caption,
-			onRemove, onMoveForward, onMoveBackward, setAttributes,
-			'aria-label': ariaLabel, isCropped } = this.props;
-
-		// I'm not sure if or how we can use this on mobile
-		// eslint-disable-next-line no-unused-vars
-		let href;
-
-		switch ( linkTo ) {
-			case 'media':
-				href = url;
-				break;
-			case 'attachment':
-				href = link;
-				break;
-		}
+			url, alt, isFirstItem, isLastItem, isSelected, caption, onRemove,
+			onMoveForward, onMoveBackward, setAttributes, 'aria-label': ariaLabel,
+			isCropped } = this.props;
 
 		const { isUploadInProgress } = this.state;
 		const { isUploadFailed, retryMessage } = params;

--- a/packages/block-library/src/gallery/gallery-image.native.js
+++ b/packages/block-library/src/gallery/gallery-image.native.js
@@ -66,7 +66,7 @@ class GalleryImage extends Component {
 
 		if ( this.state.isUploadInProgress ) {
 			requestImageUploadCancelDialog( id );
-		} else if ( ( this.state.didUploadFail ) || id && ! isURL( url ) ) {
+		} else if ( ( this.state.didUploadFail ) || ( id && ! isURL( url ) ) ) {
 			requestImageFailedRetryDialog( id );
 		}
 	}
@@ -128,7 +128,7 @@ class GalleryImage extends Component {
 
 	renderContent( params ) {
 		const {
-			url, alt, isFirstItem, isLastItem, isSelected, caption, onRemove,
+			url, isFirstItem, isLastItem, isSelected, caption, onRemove,
 			onMoveForward, onMoveBackward, setAttributes, 'aria-label': ariaLabel,
 			isCropped } = this.props;
 
@@ -162,13 +162,13 @@ class GalleryImage extends Component {
 				{ isUploadFailed && (
 					<View style={ styles.uploadFailedContainer }>
 						<View style={ styles.uploadFailed }>
-							<Icon icon={ "warning" } { ...styles.uploadFailedIcon } />
+							<Icon icon={ 'warning' } { ...styles.uploadFailedIcon } />
 						</View>
 						<Text style={ styles.uploadFailedText }>{ retryMessage }</Text>
 					</View>
 				) }
 				<View style={ overlayStyle }>
-				{ ! isUploadInProgress && (
+					{ ! isUploadInProgress && (
 					<>
 						{ isSelected && (
 							<View style={ styles.toolbar }>
@@ -214,14 +214,14 @@ class GalleryImage extends Component {
 							</View>
 						) }
 					</>
-				) }
+					) }
 				</View>
 			</>
 		);
 	}
 
 	render() {
-		const { url, id, isBlockSelected, onRemove } = this.props;
+		const { id, isBlockSelected, onRemove } = this.props;
 
 		return (
 			<TouchableWithoutFeedback

--- a/packages/block-library/src/gallery/gallery-image.native.js
+++ b/packages/block-library/src/gallery/gallery-image.native.js
@@ -15,6 +15,7 @@ import { Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { RichText, MediaUploadProgress } from '@wordpress/block-editor';
 import { isURL } from '@wordpress/url';
+import { withPreferredColorScheme } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -244,4 +245,4 @@ class GalleryImage extends Component {
 	}
 }
 
-export default GalleryImage;
+export default withPreferredColorScheme( GalleryImage );

--- a/packages/block-library/src/gallery/gallery-image.native.js
+++ b/packages/block-library/src/gallery/gallery-image.native.js
@@ -257,7 +257,7 @@ class GalleryImage extends Component {
 	}
 
 	render() {
-		const { id, isBlockSelected, onRemove, getStylesFromColorScheme } = this.props;
+		const { id, onRemove, getStylesFromColorScheme } = this.props;
 
 		const containerStyle = getStylesFromColorScheme( style.galleryImageContainer,
 			style.galleryImageContainerDark );

--- a/packages/block-library/src/gallery/gallery-image.native.js
+++ b/packages/block-library/src/gallery/gallery-image.native.js
@@ -18,58 +18,7 @@ import { isBlobURL } from '@wordpress/blob';
  * Internal dependencies
  */
 import Button from './gallery-button';
-
-// TODO: extract this to scss
-const styles = StyleSheet.create( {
-	container: {
-		flex: 1,
-		height: 150,
-	},
-	image: {
-		position: 'absolute',
-		top: 0,
-		bottom: 0,
-		left: 0,
-		right: 0,
-	},
-	overlay: {
-		position: 'absolute',
-		top: 0,
-		bottom: 0,
-		left: 0,
-		right: 0,
-		padding: 5,
-		borderWidth: 3,
-	},
-	button: {
-		width: 30,
-	},
-	moverButtons: {
-		flexDirection: 'row',
-		alignItems: 'center',
-		borderRadius: 3,
-		backgroundColor: '#2e4453',
-	},
-	separator: {
-		borderRightColor: 'gray',
-		borderRightWidth: StyleSheet.hairlineWidth,
-		height: 20,
-	},
-	removeButton: {
-		width: 30,
-		borderRadius: 30,
-	},
-	toolbar: {
-		flexDirection: 'row',
-		justifyContent: 'space-between',
-	},
-	caption: {
-		position: 'absolute',
-		bottom: 0,
-		left: 0,
-		right: 0,
-	},
-} );
+import styles from './gallery-image-styles';
 
 class GalleryImage extends Component {
 	constructor() {
@@ -246,7 +195,9 @@ class GalleryImage extends Component {
 										aria-disabled={ isFirstItem }
 										disabled={ ! isSelected }
 									/>
-									<View style={ styles.separator }></View>
+									<View style={ [ styles.separator, {
+										borderRightWidth: StyleSheet.hairlineWidth,
+									} ] }></View>
 									<Button
 										style={ styles.button }
 										icon="arrow-right"

--- a/packages/block-library/src/gallery/gallery-image.native.js
+++ b/packages/block-library/src/gallery/gallery-image.native.js
@@ -213,23 +213,32 @@ class GalleryImage extends Component {
 								/>
 							</View>
 						) }
-						{ ! isUploadFailed && ( isSelected || !! caption ) && (
-							<View style={ styles.captionContainer } >
-								<RichText
-									tagName="figcaption"
-									placeholder={ isSelected ? __( 'Write caption…' ) : null }
-									value={ caption }
-									isSelected={ this.state.captionSelected }
-									onChange={ ( newCaption ) => setAttributes( { caption: newCaption } ) }
-									unstableOnFocus={ this.onSelectCaption }
-									// fontSize={ 36 }
-									style={ captionStyle }
-									placeholderStyle={ captionPlaceholderStyle }
-									inlineToolbar
-								/>
+						{ ! isUploadFailed && isSelected && (
+							<View style={ style.captionContainer }>
+								<ScrollView nestedScrollEnabled>
+									<RichText
+										tagName="figcaption"
+										placeholder={ isSelected ? __( 'Write caption…' ) : null }
+										value={ caption }
+										isSelected={ this.state.captionSelected }
+										onChange={ ( newCaption ) => setAttributes( { caption: newCaption } ) }
+										unstableOnFocus={ this.onSelectCaption }
+										fontSize={ captionStyle.fontSize }
+										style={ captionStyle }
+										placeholderTextColor={ captionPlaceholderStyle.color }
+										inlineToolbar
+									/>
+								</ScrollView>
 							</View>
 						) }
 					</>
+					) }
+					{ ! isUploadFailed && ( ! isSelected && !! caption ) && (
+						<View  style={ style.captionEllipsisContainer }>
+							<Text style={ style.captionEllipsis } numberOfLines={ 1 }>
+								{ caption }
+							</Text>
+						</View>
 					) }
 				</View>
 			</>

--- a/packages/block-library/src/gallery/gallery-image.native.js
+++ b/packages/block-library/src/gallery/gallery-image.native.js
@@ -87,6 +87,10 @@ class GalleryImage extends Component {
 	}
 
 	onSelectImage() {
+		if ( ! this.props.isBlockSelected ) {
+			this.props.onSelectBlock();
+		}
+
 		if ( ! this.props.isSelected ) {
 			this.props.onSelect();
 		}
@@ -261,7 +265,6 @@ class GalleryImage extends Component {
 		return (
 			<TouchableWithoutFeedback
 				onPress={ this.onMediaPressed }
-				disabled={ ! isBlockSelected }
 			>
 				<View style={ containerStyle }>
 					<MediaUploadProgress

--- a/packages/block-library/src/gallery/gallery-image.native.js
+++ b/packages/block-library/src/gallery/gallery-image.native.js
@@ -138,7 +138,7 @@ class GalleryImage extends Component {
 		const { isUploadFailed, retryMessage } = params;
 		const resizeMode = isCropped ? 'cover' : 'contain';
 
-		const imageStyle = [ styles.image, resizeMode,
+		const imageStyle = [ styles.image, { resizeMode },
 			isUploadInProgress ? styles.imageUploading : undefined,
 		];
 

--- a/packages/block-library/src/gallery/gallery-image.native.js
+++ b/packages/block-library/src/gallery/gallery-image.native.js
@@ -181,7 +181,7 @@ class GalleryImage extends Component {
 										style={ styles.button }
 										icon="arrow-left"
 										onClick={ isFirstItem ? undefined : onMoveBackward }
-										label={ __( 'Move Image Backward' ) }
+										accessibilityLabel={ __( 'Move Image Backward' ) }
 										aria-disabled={ isFirstItem }
 										disabled={ ! isSelected }
 									/>
@@ -192,7 +192,7 @@ class GalleryImage extends Component {
 										style={ styles.button }
 										icon="arrow-right"
 										onClick={ isLastItem ? undefined : onMoveForward }
-										label={ __( 'Move Image Forward' ) }
+										accessibilityLabel={ __( 'Move Image Forward' ) }
 										aria-disabled={ isLastItem }
 										disabled={ ! isSelected }
 									/>
@@ -201,7 +201,7 @@ class GalleryImage extends Component {
 									style={ styles.removeButton }
 									icon="trash"
 									onClick={ onRemove }
-									label={ __( 'Remove Image' ) }
+									accessibilityLabel={ __( 'Remove Image' ) }
 									disabled={ ! isSelected }
 								/>
 							</View>

--- a/packages/block-library/src/gallery/gallery-image.native.js
+++ b/packages/block-library/src/gallery/gallery-image.native.js
@@ -159,6 +159,9 @@ class GalleryImage extends Component {
 			{ aspectRatio: 1 }
 		);
 
+		const captionStyle = getStylesFromColorScheme( styles.caption, styles.captionDark );
+		const captionPlaceholderStyle = getStylesFromColorScheme( styles.captionPlaceholder, styles.captionPlaceholderDark );
+
 		return (
 			<>
 				<Image
@@ -210,7 +213,7 @@ class GalleryImage extends Component {
 							</View>
 						) }
 						{ ! isUploadFailed && ( isSelected || !! caption ) && (
-							<View style={ styles.caption } >
+							<View style={ styles.captionContainer } >
 								<RichText
 									tagName="figcaption"
 									placeholder={ isSelected ? __( 'Write caption…' ) : null }
@@ -218,6 +221,9 @@ class GalleryImage extends Component {
 									isSelected={ this.state.captionSelected }
 									onChange={ ( newCaption ) => setAttributes( { caption: newCaption } ) }
 									unstableOnFocus={ this.onSelectCaption }
+									// fontSize={ 36 }
+									style={ captionStyle }
+									placeholderStyle={ captionPlaceholderStyle }
 									inlineToolbar
 								/>
 							</View>

--- a/packages/block-library/src/gallery/gallery-image.native.js
+++ b/packages/block-library/src/gallery/gallery-image.native.js
@@ -159,11 +159,18 @@ class GalleryImage extends Component {
 			isSelected ? style.overlaySelected : undefined,
 		);
 
-		const captionStyle = getStylesFromColorScheme( style.caption, style.captionDark );
 		const captionPlaceholderStyle = getStylesFromColorScheme( style.captionPlaceholder, style.captionPlaceholderDark );
 
 		const shouldShowCaptionEditable = ! isUploadFailed && isSelected;
-		const shouldShowCaptionEllipsis = ! isUploadFailed && ( ! isSelected && !! caption );
+		const shouldShowCaptionExpanded = ! isUploadFailed && ( ! isSelected && !! caption );
+
+		const captionContainerStyle = shouldShowCaptionExpanded ?
+			style.captionExpandedContainer :
+			style.captionContainer;
+
+		const captionStyle = shouldShowCaptionExpanded ?
+			style.captionExpanded :
+			getStylesFromColorScheme( style.caption, style.captionDark );
 
 		return (
 			<>
@@ -218,9 +225,9 @@ class GalleryImage extends Component {
 								/>
 							</View>
 						) }
-						{ shouldShowCaptionEditable && (
-							<View style={ style.captionContainer }>
-								<ScrollView nestedScrollEnabled>
+						{ ( shouldShowCaptionEditable || shouldShowCaptionExpanded ) && (
+							<View style={ captionContainerStyle }>
+								<ScrollView nestedScrollEnabled keyboardShouldPersistTaps="handled">
 									<RichText
 										// tagName="figcaption"
 										tagName="" // needed to keep center alignment ?
@@ -233,20 +240,12 @@ class GalleryImage extends Component {
 										style={ captionStyle }
 										textAlign={ captionStyle.textAlign }
 										placeholderTextColor={ captionPlaceholderStyle.color }
-										__experimentalForceBlurOnUnmount
 										inlineToolbar
 									/>
 								</ScrollView>
 							</View>
 						) }
 					</>
-					) }
-					{ shouldShowCaptionEllipsis && (
-						<View style={ style.captionEllipsisContainer }>
-							<Text style={ style.captionEllipsis } numberOfLines={ 1 }>
-								{ caption }
-							</Text>
-						</View>
 					) }
 				</View>
 			</>

--- a/packages/block-library/src/gallery/gallery-image.native.js
+++ b/packages/block-library/src/gallery/gallery-image.native.js
@@ -222,7 +222,8 @@ class GalleryImage extends Component {
 							<View style={ style.captionContainer }>
 								<ScrollView nestedScrollEnabled>
 									<RichText
-										tagName="figcaption"
+										// tagName="figcaption"
+										tagName="" // needed to keep center alignment ?
 										placeholder={ isSelected ? __( 'Write caption…' ) : null }
 										value={ caption }
 										isSelected={ this.state.captionSelected }
@@ -230,6 +231,7 @@ class GalleryImage extends Component {
 										unstableOnFocus={ this.onSelectCaption }
 										fontSize={ captionStyle.fontSize }
 										style={ captionStyle }
+										textAlign={ captionStyle.textAlign }
 										placeholderTextColor={ captionPlaceholderStyle.color }
 										__experimentalForceBlurOnUnmount
 										inlineToolbar

--- a/packages/block-library/src/gallery/gallery-image.native.js
+++ b/packages/block-library/src/gallery/gallery-image.native.js
@@ -151,6 +151,14 @@ class GalleryImage extends Component {
 			{ borderRightWidth: StyleSheet.hairlineWidth }
 		);
 
+		const buttonStyle = compose( styles.button,
+			{ aspectRatio: 1 }
+		);
+
+		const removeButtonStyle = compose( styles.removeButton,
+			{ aspectRatio: 1 }
+		);
+
 		return (
 			<>
 				<Image
@@ -173,9 +181,9 @@ class GalleryImage extends Component {
 					<>
 						{ isSelected && (
 							<View style={ styles.toolbar }>
-								<View style={ styles.moverButtons } >
+								<View style={ styles.moverButtonContainer } >
 									<Button
-										style={ styles.button }
+										style={ buttonStyle }
 										icon="arrow-left"
 										onClick={ isFirstItem ? undefined : onMoveBackward }
 										accessibilityLabel={ __( 'Move Image Backward' ) }
@@ -184,7 +192,7 @@ class GalleryImage extends Component {
 									/>
 									<View style={ separatorStyle }></View>
 									<Button
-										style={ styles.button }
+										style={ buttonStyle }
 										icon="arrow-right"
 										onClick={ isLastItem ? undefined : onMoveForward }
 										accessibilityLabel={ __( 'Move Image Forward' ) }
@@ -193,7 +201,7 @@ class GalleryImage extends Component {
 									/>
 								</View>
 								<Button
-									style={ styles.removeButton }
+									style={ removeButtonStyle }
 									icon="trash"
 									onClick={ onRemove }
 									accessibilityLabel={ __( 'Remove Image' ) }

--- a/packages/block-library/src/gallery/gallery-image.native.js
+++ b/packages/block-library/src/gallery/gallery-image.native.js
@@ -222,14 +222,17 @@ class GalleryImage extends Component {
 	}
 
 	render() {
-		const { id, isBlockSelected, onRemove } = this.props;
+		const { id, isBlockSelected, onRemove, getStylesFromColorScheme } = this.props;
+
+		const containerStyle = getStylesFromColorScheme( styles.galleryImageContainer,
+			styles.galleryImageContainerDark );
 
 		return (
 			<TouchableWithoutFeedback
 				onPress={ this.onMediaPressed }
 				disabled={ ! isBlockSelected }
 			>
-				<View style={ styles.container }>
+				<View style={ containerStyle }>
 					<MediaUploadProgress
 						// coverUrl={ url }
 						mediaId={ id }

--- a/packages/block-library/src/gallery/gallery-image.native.js
+++ b/packages/block-library/src/gallery/gallery-image.native.js
@@ -163,7 +163,7 @@ class GalleryImage extends Component {
 
 		return (
 			<TouchableWithoutFeedback
-				onPress={ this.props.onSelect }
+				onPress={ this.onSelectImage }
 				disabled={ ! isBlockSelected }
 			>
 				<View style={ styles.container }>

--- a/packages/block-library/src/gallery/gallery-image.native.js
+++ b/packages/block-library/src/gallery/gallery-image.native.js
@@ -1,0 +1,198 @@
+/**
+ * External dependencies
+ */
+import { Image, View } from 'react-native';
+
+/**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
+import { IconButton, Spinner } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { BACKSPACE, DELETE } from '@wordpress/keycodes';
+import { withSelect } from '@wordpress/data';
+import { RichText } from '@wordpress/block-editor';
+import { isBlobURL } from '@wordpress/blob';
+
+class GalleryImage extends Component {
+	constructor() {
+		super( ...arguments );
+
+		this.onSelectImage = this.onSelectImage.bind( this );
+		this.onSelectCaption = this.onSelectCaption.bind( this );
+		this.onRemoveImage = this.onRemoveImage.bind( this );
+		this.bindContainer = this.bindContainer.bind( this );
+
+		this.state = {
+			captionSelected: false,
+		};
+	}
+
+	bindContainer( ref ) {
+		this.container = ref;
+	}
+
+	onSelectCaption() {
+		if ( ! this.state.captionSelected ) {
+			this.setState( {
+				captionSelected: true,
+			} );
+		}
+
+		if ( ! this.props.isSelected ) {
+			this.props.onSelect();
+		}
+	}
+
+	onSelectImage() {
+		if ( ! this.props.isSelected ) {
+			this.props.onSelect();
+		}
+
+		if ( this.state.captionSelected ) {
+			this.setState( {
+				captionSelected: false,
+			} );
+		}
+	}
+
+	onRemoveImage( event ) {
+		if (
+			this.container === document.activeElement &&
+			this.props.isSelected && [ BACKSPACE, DELETE ].indexOf( event.keyCode ) !== -1
+		) {
+			event.stopPropagation();
+			event.preventDefault();
+			this.props.onRemove();
+		}
+	}
+
+	componentDidUpdate( prevProps ) {
+		const { isSelected, image, url } = this.props;
+		if ( image && ! url ) {
+			this.props.setAttributes( {
+				url: image.source_url,
+				alt: image.alt_text,
+			} );
+		}
+
+		// unselect the caption so when the user selects other image and comeback
+		// the caption is not immediately selected
+		if ( this.state.captionSelected && ! isSelected && prevProps.isSelected ) {
+			this.setState( {
+				captionSelected: false,
+			} );
+		}
+	}
+
+	render() {
+		const { url, alt, id, linkTo, link, isFirstItem, isLastItem, isSelected, caption, onRemove, onMoveForward, onMoveBackward, setAttributes, 'aria-label': ariaLabel } = this.props;
+
+		let href;
+
+		switch ( linkTo ) {
+			case 'media':
+				href = url;
+				break;
+			case 'attachment':
+				href = link;
+				break;
+		}
+
+		const img = (
+			// Disable reason: Image itself is not meant to be interactive, but should
+			// direct image selection and unfocus caption fields.
+			/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
+			<>
+				<Image
+					style={ {
+						width: '100%',
+						height: '100%',
+						resizeMode: 'cover',
+					} }
+					source={ { uri: url } }
+					alt={ alt }
+					data-id={ id }
+					onClick={ this.onSelectImage }
+					onFocus={ this.onSelectImage }
+					onKeyDown={ this.onRemoveImage }
+					tabIndex="0"
+					aria-label={ ariaLabel }
+					ref={ this.bindContainer }
+				/>
+				{ isBlobURL( url ) && <Spinner /> }
+			</>
+			/* eslint-enable jsx-a11y/no-noninteractive-element-interactions */
+		);
+
+		return (
+			<View
+				style={ {
+					flex: 1,
+					height: 150,
+				} }>
+				{ href ? <a href={ href }>{ img }</a> : img }
+				<View
+					style={ {
+						position: 'absolute',
+					} }>
+					<IconButton
+						icon="arrow-left"
+						onClick={ isFirstItem ? undefined : onMoveBackward }
+						label={ __( 'Move Image Backward' ) }
+						aria-disabled={ isFirstItem }
+						disabled={ ! isSelected }
+					/>
+					<IconButton
+						icon="arrow-right"
+						onClick={ isLastItem ? undefined : onMoveForward }
+						label={ __( 'Move Image Forward' ) }
+						aria-disabled={ isLastItem }
+						disabled={ ! isSelected }
+					/>
+				</View>
+				<View
+					style={ {
+						position: 'absolute',
+						right: 0,
+					} }>
+					<IconButton
+						icon="no-alt"
+						onClick={ onRemove }
+						label={ __( 'Remove Image' ) }
+						disabled={ ! isSelected }
+					/>
+				</View>
+				<View
+					style={ {
+						flex: 1,
+						position: 'absolute',
+						bottom: 0,
+						left: 0,
+						right: 0,
+					} }
+				>
+
+					<RichText
+						tagName="figcaption"
+						placeholder={ isSelected ? __( 'Write caption…' ) : null }
+						value={ caption }
+						isSelected={ this.state.captionSelected }
+						onChange={ ( newCaption ) => setAttributes( { caption: newCaption } ) }
+						unstableOnFocus={ this.onSelectCaption }
+						inlineToolbar
+					/>
+				</View>
+			</View>
+		);
+	}
+}
+
+export default withSelect( ( select, ownProps ) => {
+	const { getMedia } = select( 'core' );
+	const { id } = ownProps;
+
+	return {
+		image: id ? getMedia( id ) : null,
+	};
+} )( GalleryImage );

--- a/packages/block-library/src/gallery/gallery-image.native.js
+++ b/packages/block-library/src/gallery/gallery-image.native.js
@@ -147,7 +147,6 @@ class GalleryImage extends Component {
 			onMoveForward, onMoveBackward, setAttributes, 'aria-label': ariaLabel,
 			isCropped, getStylesFromColorScheme } = this.props;
 
-
 		const { isUploadInProgress } = this.state;
 		const { isUploadFailed, retryMessage } = params;
 		const resizeMode = isCropped ? 'cover' : 'contain';
@@ -162,7 +161,7 @@ class GalleryImage extends Component {
 
 		const captionStyle = getStylesFromColorScheme( style.caption, style.captionDark );
 		const captionPlaceholderStyle = getStylesFromColorScheme( style.captionPlaceholder, style.captionPlaceholderDark );
-		
+
 		const shouldShowCaptionEditable = ! isUploadFailed && isSelected;
 		const shouldShowCaptionEllipsis = ! isUploadFailed && ( ! isSelected && !! caption );
 
@@ -238,7 +237,7 @@ class GalleryImage extends Component {
 					</>
 					) }
 					{ shouldShowCaptionEllipsis && (
-						<View  style={ style.captionEllipsisContainer }>
+						<View style={ style.captionEllipsisContainer }>
 							<Text style={ style.captionEllipsis } numberOfLines={ 1 }>
 								{ caption }
 							</Text>

--- a/packages/block-library/src/gallery/gallery-image.native.js
+++ b/packages/block-library/src/gallery/gallery-image.native.js
@@ -190,7 +190,8 @@ class GalleryImage extends Component {
 								<View style={ style.moverButtonContainer } >
 									<Button
 										style={ buttonStyle }
-										icon="arrow-left"
+										icon="arrow-left-alt"
+										iconSize={ 15 }
 										onClick={ isFirstItem ? undefined : onMoveBackward }
 										accessibilityLabel={ __( 'Move Image Backward' ) }
 										aria-disabled={ isFirstItem }
@@ -199,7 +200,8 @@ class GalleryImage extends Component {
 									<View style={ separatorStyle }></View>
 									<Button
 										style={ buttonStyle }
-										icon="arrow-right"
+										icon="arrow-right-alt"
+										iconSize={ 15 }
 										onClick={ isLastItem ? undefined : onMoveForward }
 										accessibilityLabel={ __( 'Move Image Forward' ) }
 										aria-disabled={ isLastItem }
@@ -208,7 +210,8 @@ class GalleryImage extends Component {
 								</View>
 								<Button
 									style={ removeButtonStyle }
-									icon="trash"
+									icon="no-alt"
+									iconSize={ 20 }
 									onClick={ onRemove }
 									accessibilityLabel={ __( 'Remove Image' ) }
 									disabled={ ! isSelected }

--- a/packages/block-library/src/gallery/gallery-image.native.js
+++ b/packages/block-library/src/gallery/gallery-image.native.js
@@ -229,6 +229,7 @@ class GalleryImage extends Component {
 										fontSize={ captionStyle.fontSize }
 										style={ captionStyle }
 										placeholderTextColor={ captionPlaceholderStyle.color }
+										__experimentalForceBlurOnUnmount
 										inlineToolbar
 									/>
 								</ScrollView>

--- a/packages/block-library/src/gallery/gallery-image.native.js
+++ b/packages/block-library/src/gallery/gallery-image.native.js
@@ -37,7 +37,6 @@ class GalleryImage extends Component {
 		this.updateMediaProgress = this.updateMediaProgress.bind( this );
 		this.finishMediaUploadWithSuccess = this.finishMediaUploadWithSuccess.bind( this );
 		this.finishMediaUploadWithFailure = this.finishMediaUploadWithFailure.bind( this );
-		this.mediaUploadStateReset = this.mediaUploadStateReset.bind( this );
 		this.renderContent = this.renderContent.bind( this );
 
 		this.state = {
@@ -127,15 +126,6 @@ class GalleryImage extends Component {
 		this.setState( {
 			isUploadInProgress: false,
 			didUploadFail: true,
-		} );
-	}
-
-	mediaUploadStateReset() {
-		this.props.setAttributes( { id: null, url: null } );
-
-		this.setState( {
-			isUploadInProgress: false,
-			didUploadFail: false,
 		} );
 	}
 
@@ -240,7 +230,7 @@ class GalleryImage extends Component {
 	}
 
 	render() {
-		const { url, id, isBlockSelected } = this.props;
+		const { url, id, isBlockSelected, onRemove } = this.props;
 
 		return (
 			<TouchableWithoutFeedback
@@ -254,7 +244,7 @@ class GalleryImage extends Component {
 						onUpdateMediaProgress={ this.updateMediaProgress }
 						onFinishMediaUploadWithSuccess={ this.finishMediaUploadWithSuccess }
 						onFinishMediaUploadWithFailure={ this.finishMediaUploadWithFailure }
-						onMediaUploadStateReset={ this.mediaUploadStateReset }
+						onMediaUploadStateReset={ onRemove }
 						renderContent={ this.renderContent }
 					/>
 				</View>

--- a/packages/block-library/src/gallery/gallery-image.native.js
+++ b/packages/block-library/src/gallery/gallery-image.native.js
@@ -21,7 +21,7 @@ import { withPreferredColorScheme } from '@wordpress/compose';
  * Internal dependencies
  */
 import Button from './gallery-button';
-import style from './gallery-image-style';
+import style from './gallery-image-style.scss';
 
 const { compose } = StyleSheet;
 

--- a/packages/block-library/src/gallery/gallery-image.native.js
+++ b/packages/block-library/src/gallery/gallery-image.native.js
@@ -36,6 +36,8 @@ const buttonStyle = compose( style.button,
 const removeButtonStyle = compose( style.removeButton,
 	{ aspectRatio: 1 }
 );
+const ICON_SIZE_ARROW = 15;
+const ICON_SIZE_REMOVE = 20;
 
 class GalleryImage extends Component {
 	constructor() {
@@ -202,7 +204,7 @@ class GalleryImage extends Component {
 									<Button
 										style={ buttonStyle }
 										icon="arrow-left-alt"
-										iconSize={ 15 }
+										iconSize={ ICON_SIZE_ARROW }
 										onClick={ isFirstItem ? undefined : onMoveBackward }
 										accessibilityLabel={ __( 'Move Image Backward' ) }
 										aria-disabled={ isFirstItem }
@@ -212,7 +214,7 @@ class GalleryImage extends Component {
 									<Button
 										style={ buttonStyle }
 										icon="arrow-right-alt"
-										iconSize={ 15 }
+										iconSize={ ICON_SIZE_ARROW }
 										onClick={ isLastItem ? undefined : onMoveForward }
 										accessibilityLabel={ __( 'Move Image Forward' ) }
 										aria-disabled={ isLastItem }
@@ -222,7 +224,7 @@ class GalleryImage extends Component {
 								<Button
 									style={ removeButtonStyle }
 									icon="no-alt"
-									iconSize={ 20 }
+									iconSize={ ICON_SIZE_REMOVE }
 									onClick={ onRemove }
 									accessibilityLabel={ __( 'Remove Image' ) }
 									disabled={ ! isSelected }

--- a/packages/block-library/src/gallery/gallery-image.native.js
+++ b/packages/block-library/src/gallery/gallery-image.native.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { Image, StyleSheet, View, ScrollView, Text, TouchableWithoutFeedback } from 'react-native';
+import { Image, StyleSheet, View, ScrollView, Text, TouchableWithoutFeedback, Platform } from 'react-native';
 import {
 	requestImageFailedRetryDialog,
 	requestImageUploadCancelDialog,
@@ -30,6 +30,13 @@ const buttonStyle = compose( style.button, { aspectRatio: 1 } );
 const removeButtonStyle = compose( style.removeButton, { aspectRatio: 1 } );
 const ICON_SIZE_ARROW = 15;
 const ICON_SIZE_REMOVE = 20;
+
+// this platform difference is needed to avoid a regression described here:
+// https://github.com/WordPress/gutenberg/pull/18818#issuecomment-559818548
+const CAPTION_TAG_NAME = Platform.select( {
+	ios: 'p',
+	android: '',
+} );
 
 class GalleryImage extends Component {
 	constructor() {
@@ -227,7 +234,7 @@ class GalleryImage extends Component {
 							<View style={ captionContainerStyle }>
 								<ScrollView nestedScrollEnabled keyboardShouldPersistTaps="handled">
 									<RichText
-										tagName=""
+										tagName={ CAPTION_TAG_NAME }
 										rootTagsToEliminate={ [ 'p' ] }
 										placeholder={ isSelected ? __( 'Write caption…' ) : null }
 										value={ caption }

--- a/packages/block-library/src/gallery/gallery-image.native.js
+++ b/packages/block-library/src/gallery/gallery-image.native.js
@@ -233,8 +233,8 @@ class GalleryImage extends Component {
 							<View style={ captionContainerStyle }>
 								<ScrollView nestedScrollEnabled keyboardShouldPersistTaps="handled">
 									<RichText
-										// tagName="figcaption"
-										tagName="" // needed to keep center alignment ?
+										tagName=""
+										rootTagsToEliminate={ [ 'p' ] }
 										placeholder={ isSelected ? __( 'Write caption…' ) : null }
 										value={ caption }
 										isSelected={ this.state.captionSelected }

--- a/packages/block-library/src/gallery/gallery-image.native.js
+++ b/packages/block-library/src/gallery/gallery-image.native.js
@@ -25,17 +25,9 @@ import style from './gallery-image-style';
 
 const { compose } = StyleSheet;
 
-const separatorStyle = compose( style.separator,
-	{ borderRightWidth: StyleSheet.hairlineWidth }
-);
-
-const buttonStyle = compose( style.button,
-	{ aspectRatio: 1 }
-);
-
-const removeButtonStyle = compose( style.removeButton,
-	{ aspectRatio: 1 }
-);
+const separatorStyle = compose( style.separator, { borderRightWidth: StyleSheet.hairlineWidth } );
+const buttonStyle = compose( style.button, { aspectRatio: 1 } );
+const removeButtonStyle = compose( style.removeButton, { aspectRatio: 1 } );
 const ICON_SIZE_ARROW = 15;
 const ICON_SIZE_REMOVE = 20;
 

--- a/packages/rich-text/src/component/index.native.js
+++ b/packages/rich-text/src/component/index.native.js
@@ -618,7 +618,6 @@ export class RichText extends Component {
 		const {
 			tagName,
 			style,
-			placeholderStyle: placeholderStyleOverride,
 			__unstableIsSelected: isSelected,
 			children,
 			getStylesFromColorScheme,
@@ -632,13 +631,11 @@ export class RichText extends Component {
 			minHeight = style.minHeight;
 		}
 
-		const { color: colorOverride } = style || {};
-
 		const placeholderStyle = getStylesFromColorScheme( styles.richTextPlaceholder, styles.richTextPlaceholderDark );
 
 		const {
 			color: defaultPlaceholderTextColor,
-		} = placeholderStyleOverride || placeholderStyle;
+		} = placeholderStyle;
 
 		const {
 			color: defaultColor,
@@ -726,7 +723,7 @@ export class RichText extends Component {
 					onCaretVerticalPositionChange={ this.props.onCaretVerticalPositionChange }
 					onSelectionChange={ this.onSelectionChangeFromAztec }
 					blockType={ { tag: tagName } }
-					color={ colorOverride || defaultColor }
+					color={ ( style && style.color ) || defaultColor }
 					linkTextColor={ defaultTextDecorationColor }
 					maxImagesWidth={ 200 }
 					fontFamily={ this.props.fontFamily || defaultFontFamily }

--- a/packages/rich-text/src/component/index.native.js
+++ b/packages/rich-text/src/component/index.native.js
@@ -618,6 +618,7 @@ export class RichText extends Component {
 		const {
 			tagName,
 			style,
+			placeholderStyle: placeholderStyleOverride,
 			__unstableIsSelected: isSelected,
 			children,
 			getStylesFromColorScheme,
@@ -631,11 +632,13 @@ export class RichText extends Component {
 			minHeight = style.minHeight;
 		}
 
+		const { color: colorOverride } = style || {};
+
 		const placeholderStyle = getStylesFromColorScheme( styles.richTextPlaceholder, styles.richTextPlaceholderDark );
 
 		const {
 			color: defaultPlaceholderTextColor,
-		} = placeholderStyle;
+		} = placeholderStyleOverride || placeholderStyle;
 
 		const {
 			color: defaultColor,
@@ -723,7 +726,7 @@ export class RichText extends Component {
 					onCaretVerticalPositionChange={ this.props.onCaretVerticalPositionChange }
 					onSelectionChange={ this.onSelectionChangeFromAztec }
 					blockType={ { tag: tagName } }
-					color={ defaultColor }
+					color={ colorOverride || defaultColor }
 					linkTextColor={ defaultTextDecorationColor }
 					maxImagesWidth={ 200 }
 					fontFamily={ this.props.fontFamily || defaultFontFamily }


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
This PR introduces a native `GalleryImage` component for the semi-cross-platform Gallery block. The purpose of this component is to render a gallery image on mobile, providing UI controls for the image if the image is selected. It incorporates the designs described here: https://github.com/wordpress-mobile/gutenberg-mobile/issues/1301#issuecomment-523124782.

### PR Hierarchy
This PR is part of the [PR hierarchy described here](https://github.com/wordpress-mobile/gutenberg-mobile/issues/1416#issuecomment-551057738). This PR can be tested with the aggregate changeset and integration of components within the related PRs by checking out the branch of the "top level" PR: https://github.com/WordPress/gutenberg/pull/18265 via the `gutenberg-mobile` PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1498.

### Native vs. Web

Much of the code in this component is adapted from the web component counterpart. HTML elements have been replaced with components that work on mobile (i.e. `<div> => <View>`, `<img> => <Image>`, but much of the logic is the same.

Since media uploading is handled differently on mobile, this component also incorporates logic to handle events associated with the `MediaUploadProgress` component used in its composition.

### Buttons

<details>
<summary>Buttons just for GalleryImage (for now)</summary>

The web implementation of this component uses `IconButton`, which, in turn, uses `Button`. Our mobile implementation of the `Button` component seemingly lacks a way to style the button for the purpose of the gallery image. I have created an implementation of `Button` for `GalleryImage` here: https://github.com/WordPress/gutenberg/pull/18264. Ideally, `Button` (or `IconButton`) from `@wordpress/components` can be general enough to allow re-use from this component. I have opened a separate draft PR for gallery `Button` for the purpose of that discussion.
</details>

**Note:** The [buttons PR](https://github.com/WordPress/gutenberg/pull/18264) has been merged with this one for review here.

### TouchableWithoutFeedback

To make gallery images "touchable", they are wrapped in a `TouchableWithoutFeedback`. This state is disabled unless the block is selected. This is similar to "navigating down the hierarchy" with inner blocks.

## To test
Test this component by checking out the branch of the "top level" PR: https://github.com/WordPress/gutenberg/pull/18265 via the `gutenberg-mobile` PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1498.

### Image Selection
---
Tap a gallery image

#### Expected behavior

* That image should immediately become selected
* The gallery block should become selected if it was not already
* The selected image should have a border identifying it as selected
* The selected image should display buttons to move the image and remove the image
* For empty captions, placeholder text should become visible for the selected image

### Captions
---
Tap the caption of a selected image. Then tap the image.

#### Expected behavior

* The caption should get focus (the caret should appear)
* After tapping the image, the caption should lose focus (the caret should disappear)

Type rich text into the caption

#### Expected behavior

* Rich text styles should be displayed / preserved (i.e. bold, italic..)

Type a very long caption (use newlines / [enter] if you want)

#### Expected behavior

* Caption should grow vertically, but be bound by the mover / remove buttons
* Long captions should be scrollable
* Really long captions should take up the entire image when not selected

#### Known issues:

* Caption font size shrinks when captions become multiline

### Movement
---
* The "move left" button (left-arrow) for the first image should be disabled
* The "move right" button (right-arrow) for the last image should be disabled

Tap the image mover buttons for any selected image

#### Expected behavior

* The images should change order / position based on movement

### Removal
---
Tap the 'X' button on the selected image

#### Expected behavior

* The image should be removed from the gallery

### Appender
---
* The gallery image appender should only be visible while the gallery block is selected

Tap the appender

#### Expected behavior

* The bottomsheet should present only the Media Library option (no options that require uploading)

Tap the Media Library option. Select multiple images (multiple selection should be possible).

#### Expected behavior

* All selected images should be added to the gallery

## Questions

### Accessibility

I have not yet tested this implementation via TalkBack nor VoiceOver, and it'd be good to get feedback on the structure introduced here, to provide the best experience possible for users who utilize those tools. Two questions that come to mind:

* Can anything be done with the `alt` text that is associated with images to enhance / improve the experience?
* More generally, does the current UI work well with the described tools, and if not, what adjustments can be made to improve the experience?

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
