### PR TITLE
Make the mediaUpload block editor setting a stable API

### DIFF
--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -429,7 +429,7 @@ const applyWithSelect = withSelect( ( select ) => {
 	const { getSettings } = select( 'core/block-editor' );
 
 	return {
-		mediaUpload: getSettings().__experimentalMediaUpload,
+		mediaUpload: getSettings().mediaUpload,
 	};
 } );
 

--- a/packages/block-editor/src/components/media-upload/check.js
+++ b/packages/block-editor/src/components/media-upload/check.js
@@ -14,6 +14,6 @@ export default withSelect( ( select ) => {
 	const { getSettings } = select( 'core/block-editor' );
 
 	return {
-		hasUploadPermissions: !! getSettings().__experimentalMediaUpload,
+		hasUploadPermissions: !! getSettings().mediaUpload,
 	};
 } )( MediaUploadCheck );

--- a/packages/block-library/src/audio/edit.js
+++ b/packages/block-library/src/audio/edit.js
@@ -214,10 +214,8 @@ class AudioEdit extends Component {
 export default compose( [
 	withSelect( ( select ) => {
 		const { getSettings } = select( 'core/block-editor' );
-		const { __experimentalMediaUpload } = getSettings();
-		return {
-			mediaUpload: __experimentalMediaUpload,
-		};
+		const { mediaUpload } = getSettings();
+		return { mediaUpload };
 	} ),
 	withNotices,
 ] )( AudioEdit );

--- a/packages/block-library/src/file/edit.js
+++ b/packages/block-library/src/file/edit.js
@@ -257,11 +257,11 @@ export default compose( [
 	withSelect( ( select, props ) => {
 		const { getMedia } = select( 'core' );
 		const { getSettings } = select( 'core/block-editor' );
-		const { __experimentalMediaUpload } = getSettings();
+		const { mediaUpload } = getSettings();
 		const { id } = props.attributes;
 		return {
 			media: id === undefined ? undefined : getMedia( id ),
-			mediaUpload: __experimentalMediaUpload,
+			mediaUpload,
 		};
 	} ),
 	withNotices,

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -379,13 +379,8 @@ class GalleryEdit extends Component {
 export default compose( [
 	withSelect( ( select ) => {
 		const { getSettings } = select( 'core/block-editor' );
-		const {
-			__experimentalMediaUpload,
-		} = getSettings();
-
-		return {
-			mediaUpload: __experimentalMediaUpload,
-		};
+		const { mediaUpload } = getSettings();
+		return { mediaUpload };
 	} ),
 	withNotices,
 ] )( GalleryEdit );

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -930,7 +930,7 @@ export default compose( [
 		const { getSettings } = select( 'core/block-editor' );
 		const { attributes: { id }, isSelected } = props;
 		const {
-			__experimentalMediaUpload,
+			mediaUpload,
 			imageSizes,
 			isRTL,
 			maxWidth,
@@ -941,7 +941,7 @@ export default compose( [
 			maxWidth,
 			isRTL,
 			imageSizes,
-			mediaUpload: __experimentalMediaUpload,
+			mediaUpload,
 		};
 	} ),
 	withViewportMatch( { isLargeViewport: 'medium' } ),

--- a/packages/block-library/src/video/edit.js
+++ b/packages/block-library/src/video/edit.js
@@ -319,10 +319,8 @@ class VideoEdit extends Component {
 export default compose( [
 	withSelect( ( select ) => {
 		const { getSettings } = select( 'core/block-editor' );
-		const { __experimentalMediaUpload } = getSettings();
-		return {
-			mediaUpload: __experimentalMediaUpload,
-		};
+		const { mediaUpload } = getSettings();
+		return { mediaUpload };
 	} ),
 	withNotices,
 	withInstanceId,

--- a/packages/edit-widgets/src/components/widget-area/index.js
+++ b/packages/edit-widgets/src/components/widget-area/index.js
@@ -42,7 +42,7 @@ function getBlockEditorSettings( blockEditorSettings, hasUploadPermissions ) {
 	};
 	return {
 		...blockEditorSettings,
-		__experimentalMediaUpload: mediaUploadBlockEditor,
+		mediaUpload: mediaUploadBlockEditor,
 	};
 }
 

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -108,8 +108,8 @@ class EditorProvider extends Component {
 				'__experimentalEnableFullSiteEditing',
 				'showInserterHelpPanel',
 			] ),
+			mediaUpload: hasUploadPermissions ? mediaUpload : undefined,
 			__experimentalReusableBlocks: reusableBlocks,
-			__experimentalMediaUpload: hasUploadPermissions ? mediaUpload : undefined,
 			__experimentalFetchLinkSuggestions: fetchLinkSuggestions,
 			__experimentalCanUserUseUnfilteredHTML: canUserUseUnfilteredHTML,
 		};


### PR DESCRIPTION
refs #17743 

Part of our journey to audit the existing experimental APIs. 

In this PR, I'm making the `mediaUpload` block-editor setting a stable API. I think a block editor need a setting to define how media gets uploaded and a generic mediaUpload handler has proven to be a solid one.