### PR TITLE
Scripts: Bump the version of npm-package-json-lint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7850,7 +7850,7 @@
 				"js-yaml": "^3.13.1",
 				"lodash": "^4.17.15",
 				"minimist": "^1.2.0",
-				"npm-package-json-lint": "^4.0.2",
+				"npm-package-json-lint": "^4.0.3",
 				"puppeteer": "^1.20.0",
 				"read-pkg-up": "^1.0.1",
 				"request": "^2.88.0",
@@ -24343,9 +24343,9 @@
 			}
 		},
 		"npm-package-json-lint": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/npm-package-json-lint/-/npm-package-json-lint-4.0.2.tgz",
-			"integrity": "sha512-xlahvfRgZcsawUPzKaJvcQSs4K0EzDgQ9YEe7VODo1XbLMWwS0IEXiywHlKPAvo1fmWBvovIdoAqhe0Gk4InHA==",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/npm-package-json-lint/-/npm-package-json-lint-4.0.3.tgz",
+			"integrity": "sha512-cuvTR2l5dOjjlRR3a1CCp+mh2A2HyQRxydwdcYi0Z77NRlADpf7wF3Jf8XFLGZM7J6afXNRBofBjQ1UWFyOtKA==",
 			"dev": true,
 			"requires": {
 				"ajv": "^6.10.2",

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Breaking Changes
 
-- The bundled `npm-package-json-lint` dependency has been updated from requiring `^3.6.0` to requiring `^4.0.2` ([#18054](https://github.com/WordPress/gutenberg/pull/18054)). Please see the [migration guide](https://npmpackagejsonlint.org/docs/en/v3-to-v4). Note: `npmPackageJsonLintConfig` prop in the `package.json` file needs to be renamed to `npmpackagejsonlint`.
+- The bundled `npm-package-json-lint` dependency has been updated from requiring `^3.6.0` to requiring `^4.0.3` ([#18054](https://github.com/WordPress/gutenberg/pull/18054)). Please see the [migration guide](https://npmpackagejsonlint.org/docs/en/v3-to-v4). Note: `npmPackageJsonLintConfig` prop in the `package.json` file needs to be renamed to `npmpackagejsonlint`.
 
 ### New Features
 

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -50,7 +50,7 @@
 		"js-yaml": "^3.13.1",
 		"lodash": "^4.17.15",
 		"minimist": "^1.2.0",
-		"npm-package-json-lint": "^4.0.2",
+		"npm-package-json-lint": "^4.0.3",
 		"puppeteer": "^1.20.0",
 		"read-pkg-up": "^1.0.1",
 		"request": "^2.88.0",


### PR DESCRIPTION
## Description
As commented by @tclindner in https://github.com/WordPress/gutenberg/pull/18054#discussion_r339320498:

> > This also looks like a breaking change. @tclindner - was it intended?
> Hi @gziolo, no it was not. I've released v4.0.3 that should correct the issue. Please let me know if you have other issues!
https://github.com/tclindner/npm-package-json-lint/releases/tag/v4.0.3

This PR updates the version of `npm-package-json-lint` to the latest to resolve the issue with the unintended pattern matching change inherited by the `wp-scripts lint-pkg-json` command.

## Testing

`npm run test-pkg-json` for the Gutenberg repository. There should be no visible change since we use glob-like pattern now.