### PR TITLE
allowedBlock attribute implementation at column

### DIFF
--- a/packages/block-library/src/column/block.json
+++ b/packages/block-library/src/column/block.json
@@ -9,6 +9,10 @@
 			"type": "number",
 			"min": 0,
 			"max": 100
+		},
+		"allowedBlocks": {
+			"type": "array"
 		}
+		
 	}
 }

--- a/packages/block-library/src/column/edit.js
+++ b/packages/block-library/src/column/edit.js
@@ -36,7 +36,7 @@ function ColumnEdit( {
 	updateWidth,
 	hasChildBlocks,
 } ) {
-	const { verticalAlignment, width } = attributes;
+	const { verticalAlignment, width, allowedBlocks } = attributes;
 
 	const classes = classnames(
 		className,
@@ -74,6 +74,7 @@ function ColumnEdit( {
 						undefined :
 						() => <InnerBlocks.ButtonBlockAppender />
 				) }
+				allowedBlocks={ allowedBlocks }
 			/>
 		</div>
 	);

--- a/packages/block-library/src/columns/block.json
+++ b/packages/block-library/src/columns/block.json
@@ -5,7 +5,7 @@
 		"verticalAlignment": {
 			"type": "string"
 		},
-		"allowedBlocks": {
+		"childAllowedBlocks": {
 			"type": "array"
 		}
 	}

--- a/packages/block-library/src/columns/block.json
+++ b/packages/block-library/src/columns/block.json
@@ -4,6 +4,9 @@
 	"attributes": {
 		"verticalAlignment": {
 			"type": "string"
+		},
+		"allowedBlocks": {
+			"type": "array"
 		}
 	}
 }

--- a/packages/block-library/src/columns/edit.js
+++ b/packages/block-library/src/columns/edit.js
@@ -217,6 +217,7 @@ export default withDispatch( ( dispatch, ownProps, registry ) => ( {
 	 */
 	updateColumns( previousColumns, newColumns ) {
 		const { clientId } = ownProps;
+		const { allowedBlocks } = ownProps.attributes;
 		const { replaceInnerBlocks } = dispatch( 'core/block-editor' );
 		const { getBlocks } = registry.select( 'core/block-editor' );
 
@@ -240,6 +241,7 @@ export default withDispatch( ( dispatch, ownProps, registry ) => ( {
 				...times( newColumns - previousColumns, () => {
 					return createBlock( 'core/column', {
 						width: newColumnWidth,
+						allowedBlocks,
 					} );
 				} ),
 			];
@@ -247,7 +249,9 @@ export default withDispatch( ( dispatch, ownProps, registry ) => ( {
 			innerBlocks = [
 				...innerBlocks,
 				...times( newColumns - previousColumns, () => {
-					return createBlock( 'core/column' );
+					return createBlock( 'core/column', {
+						allowedBlocks,
+					} );
 				} ),
 			];
 		} else {

--- a/packages/block-library/src/columns/edit.js
+++ b/packages/block-library/src/columns/edit.js
@@ -217,7 +217,7 @@ export default withDispatch( ( dispatch, ownProps, registry ) => ( {
 	 */
 	updateColumns( previousColumns, newColumns ) {
 		const { clientId } = ownProps;
-		const { allowedBlocks } = ownProps.attributes;
+		const { childAllowedBlocks } = ownProps.attributes;
 		const { replaceInnerBlocks } = dispatch( 'core/block-editor' );
 		const { getBlocks } = registry.select( 'core/block-editor' );
 
@@ -241,7 +241,7 @@ export default withDispatch( ( dispatch, ownProps, registry ) => ( {
 				...times( newColumns - previousColumns, () => {
 					return createBlock( 'core/column', {
 						width: newColumnWidth,
-						allowedBlocks,
+						allowedBlocks: childAllowedBlocks,
 					} );
 				} ),
 			];
@@ -250,7 +250,7 @@ export default withDispatch( ( dispatch, ownProps, registry ) => ( {
 				...innerBlocks,
 				...times( newColumns - previousColumns, () => {
 					return createBlock( 'core/column', {
-						allowedBlocks,
+						allowedBlocks: childAllowedBlocks,
 					} );
 				} ),
 			];


### PR DESCRIPTION
Fixes #18161

## Description
I have developed a solution to the issue where a individual **column** could not define any allowed blocks and newly added **column**s in the **columns** block (from the slider at the columns settings) also specify the allowed blocks. 

## How has this been tested?
I have tested this locally.

## Screenshots <!-- if applicable -->
<img width="1054" alt="Screenshot 2019-10-29 at 13 54 43" src="https://user-images.githubusercontent.com/9864796/67768891-c3758800-fa53-11e9-9eb4-694b7d80ad66.png">


## Types of changes
I have added a new attribute called allowedBlocks in both the **column** and **columns** block, which allows for defining the allowed blocks per individual column.
I suggest to add documentation to the InnerBlocks ReadMe on GitHub, where the templates are documented about the use of allowedBlocks.

**EXAMPLE**
You can set this property in for instance a template. Below is an _example_ of how you can provide it to the column and columns block like so:
```js
const allowedBlocks = [
  "cgb/recipe-name-block",
  "cgb/recipe-description-block",
  "cgb/recipe-author-block",
  "cgb/recipe-cuisine-block",
  "cgb/recipe-course-block"
];

//the code below can be used in a template
[ [ 'core/columns', { allowedBlocks }, [
      [ 'core/column', { allowedBlocks }, [
          [ 'cgb/recipe-name-block', { name: attributes.name, allowedBlocks },  ],
      ] ],
      [ 'core/column', { allowedBlocks }, [
        [ 'cgb/recipe-description-block', { recipeDescription: attributes.description, allowedBlocks },  ],          
     ] ],
  ] ] ],
```
## Checklist:
- [ ] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
