### PR TITLE
Components: Switch screen-reader-text to VisuallyHidden

### DIFF
--- a/packages/components/src/base-control/index.js
+++ b/packages/components/src/base-control/index.js
@@ -3,14 +3,21 @@
  */
 import classnames from 'classnames';
 
+/**
+ * Internal dependencies
+ */
+import VisuallyHidden from '../visually-hidden';
+
 function BaseControl( { id, label, hideLabelFromVision, help, className, children } ) {
 	return (
 		<div className={ classnames( 'components-base-control', className ) }>
 			<div className="components-base-control__field">
-				{ label && id && <label
-					className={ classnames( 'components-base-control__label', { 'screen-reader-text': hideLabelFromVision } ) }
-					htmlFor={ id }>{ label }
-				</label> }
+				{ label && id && hideLabelFromVision && <VisuallyHidden
+					as="label"
+					htmlFor={ id }>{ label }</VisuallyHidden> }
+				{ label && id && ! hideLabelFromVision && <label
+					className="components-base-control__label"
+					htmlFor={ id }>{ label }</label> }
 				{ label && ! id && <BaseControl.VisualLabel>{ label }</BaseControl.VisualLabel> }
 				{ children }
 			</div>

--- a/packages/components/src/form-token-field/token.js
+++ b/packages/components/src/form-token-field/token.js
@@ -61,7 +61,7 @@ function Token( {
 				className="components-form-token-field__token-text"
 				id={ `components-form-token-field__token-text-${ instanceId }` }
 			>
-				<VisuallyHidden>{ termPositionAndCount }</VisuallyHidden>
+				<VisuallyHidden as="span">{ termPositionAndCount }</VisuallyHidden>
 				<span aria-hidden="true">{ transformedValue }</span>
 			</span>
 

--- a/packages/components/src/form-token-field/token.js
+++ b/packages/components/src/form-token-field/token.js
@@ -14,6 +14,7 @@ import { __, sprintf } from '@wordpress/i18n';
  * Internal dependencies
  */
 import IconButton from '../icon-button';
+import VisuallyHidden from '../visually-hidden';
 
 function Token( {
 	value,
@@ -60,7 +61,7 @@ function Token( {
 				className="components-form-token-field__token-text"
 				id={ `components-form-token-field__token-text-${ instanceId }` }
 			>
-				<span className="screen-reader-text">{ termPositionAndCount }</span>
+				<VisuallyHidden>{ termPositionAndCount }</VisuallyHidden>
 				<span aria-hidden="true">{ transformedValue }</span>
 			</span>
 

--- a/packages/e2e-tests/specs/editor/various/taxonomies.test.js
+++ b/packages/e2e-tests/specs/editor/various/taxonomies.test.js
@@ -16,7 +16,7 @@ import {
 /**
  * Module constants
  */
-const TAG_TOKEN_SELECTOR = '.components-form-token-field__token-text span:not(.screen-reader-text)';
+const TAG_TOKEN_SELECTOR = '.components-form-token-field__token-text span:not(.components-visually-hidden)';
 
 describe( 'Taxonomies', () => {
 	const canCreatTermInTaxonomy = ( taxonomy ) => {


### PR DESCRIPTION
## Description

This is the follow up PR from comment in #18127 it addresses changing the other spots in components that use `screen-reader-text`  to using `VisuallyHidden` component.

The two spots changed are: `base-control` and `form-text-token`

## How has this been tested?

I created a story in Storybook to be committed in separate PR and confirmed that using the component shows the label as intended, 


## Types of changes

In essence it changes `<span className="screen-reader-text"> ... </span>` to
`<VisuallyHidden> ... </VisuallyHidden>`

The base-control change uses label, and had a bit more logic wrapped around it. 


## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
