### PR TITLE
Storybook: Add story for FontSizePicker component

### DIFF
--- a/packages/components/src/font-size-picker/stories/index.js
+++ b/packages/components/src/font-size-picker/stories/index.js
@@ -1,0 +1,52 @@
+
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import FontSizePicker from '../';
+
+export default { title: 'FontSizePicker', component: FontSizePicker };
+
+const FontSizePickerWithState = ( { ...props } ) => {
+	const [ fontSize, setFontSize ] = useState( 16 );
+	return (
+		<FontSizePicker
+			{ ...props }
+			value={ fontSize }
+			onChange={ setFontSize }
+		/>
+	);
+};
+
+export const _default = () => {
+	const fontSizes = [
+		{
+			name: 'Small',
+			slug: 'small',
+			size: 12,
+		},
+		{
+			name: 'Normal',
+			slug: 'normal',
+			size: 18,
+		},
+
+		{
+			name: 'Big',
+			slug: 'big',
+			size: 26,
+		},
+	];
+	const fallbackFontSize = 16;
+
+	return (
+		<FontSizePickerWithState
+			fontSizes={ fontSizes }
+			fallbackFontSize={ fallbackFontSize }
+		/>
+	);
+};


### PR DESCRIPTION
## Description

Adds story for FontSizePicker component

This  was created to help test #18165 which updates the base-control and to use the VisuallHidden text. If that PR is not merged first, than you will see the text "choose preset"

## How has this been tested?

Run `npm run design-system:dev` and confirm FontSizePicker shows and works as expected.

## Types of changes

Storybook.
