### PR TITLE
navigation-menu: apply colors correctly in edition mode

### DIFF
--- a/packages/block-library/src/navigation-menu-item/editor.scss
+++ b/packages/block-library/src/navigation-menu-item/editor.scss
@@ -66,27 +66,12 @@
 .wp-block-navigation-menu-item {
 	&:not(.is-editing) {
 		font-family: inherit;
-		font-size: inherit;
-		background-color: var(--background-color-menu-link);
-		color: var(--color-menu-link);
+		font-size: $text-editor-font-size;
 		font-weight: bold;
-
-		.components-external-link {
-			color: var(--color-menu-link);
-		}
 	}
 
 	&.is-editing .components-text-control__input {
 		width: inherit;
-		background-color: var(--background-color-menu-link);
-		color: var(--color-menu-link);
-
-		.components-external-link {
-			color: var(--color-menu-link);
-			&:focus {
-				color: var(--color-menu-link);
-			}
-		}
 	}
 
 	&.is-editing,
@@ -94,9 +79,6 @@
 		box-shadow: 0 0 1px $light-gray-900 inset;
 		border-radius: 4px;
 		min-width: 30px;
-		&:focus {
-			color: var(--color-menu-link);
-		}
 	}
 }
 

--- a/packages/block-library/src/navigation-menu-item/editor.scss
+++ b/packages/block-library/src/navigation-menu-item/editor.scss
@@ -72,6 +72,12 @@
 
 	&.is-editing .components-text-control__input {
 		width: inherit;
+		background-color: inherit;
+		color: inherit;
+
+		&:focus {
+			color: inherit;
+		}
 	}
 
 	&.is-editing,

--- a/packages/block-library/src/navigation-menu-item/editor.scss
+++ b/packages/block-library/src/navigation-menu-item/editor.scss
@@ -70,6 +70,7 @@
 		background-color: var(--background-color-menu-link);
 		color: var(--color-menu-link);
 		width: inherit;
+		font-weight: bold;
 
 		.components-external-link {
 			color: var(--color-menu-link);
@@ -94,6 +95,9 @@
 		box-shadow: 0 0 1px $light-gray-900 inset;
 		border-radius: 4px;
 		min-width: 30px;
+		&:focus {
+			color: var(--color-menu-link);
+		}
 	}
 }
 

--- a/packages/block-library/src/navigation-menu-item/editor.scss
+++ b/packages/block-library/src/navigation-menu-item/editor.scss
@@ -69,7 +69,6 @@
 		font-size: inherit;
 		background-color: var(--background-color-menu-link);
 		color: var(--color-menu-link);
-		width: inherit;
 		font-weight: bold;
 
 		.components-external-link {

--- a/packages/block-library/src/navigation-menu/block-colors-selector.js
+++ b/packages/block-library/src/navigation-menu/block-colors-selector.js
@@ -27,11 +27,11 @@ const ColorSelectorSVGIcon = () => (
 const ColorSelectorIcon = ( { backgroundColor, textColor } ) => {
 	const iconStyle = {};
 	if ( textColor && ! textColor.class ) {
-		iconStyle[ 'color' ] = textColor.color;
+		iconStyle.color = textColor.color;
 	}
 
 	if ( backgroundColor && ! backgroundColor.class ) {
-		iconStyle[ 'backgroundColor' ] = backgroundColor.color;
+		iconStyle.backgroundColor = backgroundColor.color;
 	}
 
 	const iconClasses = classnames( 'block-library-colors-selector__state-selection', {

--- a/packages/block-library/src/navigation-menu/block-colors-selector.js
+++ b/packages/block-library/src/navigation-menu/block-colors-selector.js
@@ -35,6 +35,8 @@ const ColorSelectorIcon = ( { backgroundColor, textColor } ) => {
 	}
 
 	const iconClasses = classnames( 'block-library-colors-selector__state-selection', {
+		'has-background-color': backgroundColor && backgroundColor.color,
+		'has-text-color': backgroundColor && backgroundColor.color,
 		[ backgroundColor.class ]: backgroundColor && backgroundColor.class,
 		[ textColor.class ]: textColor && textColor.class,
 	} );

--- a/packages/block-library/src/navigation-menu/block-colors-selector.js
+++ b/packages/block-library/src/navigation-menu/block-colors-selector.js
@@ -21,25 +21,40 @@ const ColorSelectorSVGIcon = () => (
 /**
  * Color Selector Icon component.
  *
+ * @param {Object} colorControlProps colorControl properties.
  * @return {*} React Icon component.
  */
-const ColorSelectorIcon = ( { style } ) =>
-	<div className="block-library-colors-selector__icon-container">
-		<div
-			className="block-library-colors-selector__state-selection"
-			style={ style }
-		>
-			<ColorSelectorSVGIcon />
+const ColorSelectorIcon = ( { backgroundColor, textColor } ) => {
+	const iconStyle = {};
+	if ( textColor && ! textColor.class ) {
+		iconStyle[ 'color' ] = textColor.color;
+	}
+
+	if ( backgroundColor && ! backgroundColor.class ) {
+		iconStyle[ 'backgroundColor' ] = backgroundColor.color;
+	}
+
+	const iconClasses = classnames( 'block-library-colors-selector__state-selection', {
+		[ backgroundColor.class ]: backgroundColor && backgroundColor.class,
+		[ textColor.class ]: textColor && textColor.class,
+	} );
+
+	return (
+		<div className="block-library-colors-selector__icon-container">
+			<div className={ iconClasses } style={ iconStyle }>
+				<ColorSelectorSVGIcon />
+			</div>
 		</div>
-	</div>;
+	);
+};
 
 /**
  * Renders the Colors Selector Toolbar with the icon button.
  *
- * @param {Object}   style           - Colors style object.
+ * @param {Object} colorControlProps colorControl properties.
  * @return {*} React toggle button component.
  */
-const renderToggleComponent = ( style ) => ( { onToggle, isOpen } ) => {
+const renderToggleComponent = ( { backgroundColor, textColor } ) => ( { onToggle, isOpen } ) => {
 	const openOnArrowDown = ( event ) => {
 		if ( ! isOpen && event.keyCode === DOWN ) {
 			event.preventDefault();
@@ -55,7 +70,7 @@ const renderToggleComponent = ( style ) => ( { onToggle, isOpen } ) => {
 				label={ __( 'Open Colors Selector' ) }
 				onClick={ onToggle }
 				onKeyDown={ openOnArrowDown }
-				icon={ <ColorSelectorIcon style={ style } /> }
+				icon={ <ColorSelectorIcon backgroundColor={ backgroundColor } textColor={ textColor } /> }
 			/>
 		</Toolbar>
 	);
@@ -91,11 +106,12 @@ const renderContent = ( { backgroundColor, textColor, onColorChange = noop } ) =
 	);
 } );
 
-export default ( { style, className, ...colorControlProps } ) =>
+export default ( colorControlProps ) => (
 	<Dropdown
 		position="bottom right"
-		className={ classnames( 'block-library-colors-selector', className ) }
+		className="block-library-colors-selector"
 		contentClassName="block-library-colors-selector__popover"
-		renderToggle={ renderToggleComponent( style ) }
+		renderToggle={ renderToggleComponent( colorControlProps ) }
 		renderContent={ renderContent( colorControlProps ) }
-	/>;
+	/>
+);

--- a/packages/block-library/src/navigation-menu/edit.js
+++ b/packages/block-library/src/navigation-menu/edit.js
@@ -66,13 +66,13 @@ function NavigationMenu( {
 		[ pages ]
 	);
 
-	const navigationMenuStyles = {};
-	if ( textColor.color ) {
-		navigationMenuStyles[ '--color-menu-link' ] = textColor.color;
+	const navigationMenuInlineStyles = {};
+	if ( attributes.customTextColor) {
+		navigationMenuInlineStyles[ 'color' ] = attributes.customTextColor;
 	}
 
-	if ( backgroundColor.color ) {
-		navigationMenuStyles[ '--background-color-menu-link' ] = backgroundColor.color;
+	if ( attributes.customBackgroundColor ) {
+		navigationMenuInlineStyles[ 'backgroundColor' ] = attributes.customBackgroundColor;
 	}
 
 	const navigationMenuClasses = classnames(
@@ -121,7 +121,7 @@ function NavigationMenu( {
 					{ navigatorToolbarButton }
 				</Toolbar>
 				<BlockColorsStyleSelector
-					style={ navigationMenuStyles }
+					style={ navigationMenuInlineStyles }
 					className={ navigationMenuClasses }
 					backgroundColor={ backgroundColor }
 					textColor={ textColor }
@@ -147,7 +147,7 @@ function NavigationMenu( {
 				</PanelBody>
 			</InspectorControls>
 
-			<div className={ navigationMenuClasses } style={ navigationMenuStyles }>
+			<div className={ navigationMenuClasses } style={ navigationMenuInlineStyles }>
 				{ isRequesting && <><Spinner /> { __( 'Loading Navigation…' ) } </> }
 				{ pages &&
 					<InnerBlocks

--- a/packages/block-library/src/navigation-menu/edit.js
+++ b/packages/block-library/src/navigation-menu/edit.js
@@ -123,8 +123,6 @@ function NavigationMenu( {
 					{ navigatorToolbarButton }
 				</Toolbar>
 				<BlockColorsStyleSelector
-					style={ navigationMenuInlineStyles }
-					className={ navigationMenuClasses }
 					backgroundColor={ backgroundColor }
 					textColor={ textColor }
 					onColorChange={ setColorType }

--- a/packages/block-library/src/navigation-menu/edit.js
+++ b/packages/block-library/src/navigation-menu/edit.js
@@ -68,11 +68,11 @@ function NavigationMenu( {
 
 	const navigationMenuInlineStyles = {};
 	if ( textColor ) {
-		navigationMenuInlineStyles[ 'color' ] = textColor.color;
+		navigationMenuInlineStyles.color = textColor.color;
 	}
 
 	if ( backgroundColor ) {
-		navigationMenuInlineStyles[ 'backgroundColor' ] = backgroundColor.color;
+		navigationMenuInlineStyles.backgroundColor = backgroundColor.color;
 	}
 
 	const navigationMenuClasses = classnames(

--- a/packages/block-library/src/navigation-menu/edit.js
+++ b/packages/block-library/src/navigation-menu/edit.js
@@ -79,6 +79,8 @@ function NavigationMenu( {
 		'wp-block-navigation-menu', {
 			'has-text-color': textColor.color,
 			'has-background-color': backgroundColor.color,
+			[ attributes.backgroundColorCSSClass ]: attributes && attributes.backgroundColorCSSClass,
+			[ attributes.textColorCSSClass ]: attributes && attributes.textColorCSSClass,
 		}
 	);
 

--- a/packages/block-library/src/navigation-menu/edit.js
+++ b/packages/block-library/src/navigation-menu/edit.js
@@ -67,12 +67,12 @@ function NavigationMenu( {
 	);
 
 	const navigationMenuInlineStyles = {};
-	if ( attributes.customTextColor) {
-		navigationMenuInlineStyles[ 'color' ] = attributes.customTextColor;
+	if ( textColor ) {
+		navigationMenuInlineStyles[ 'color' ] = textColor.color;
 	}
 
-	if ( attributes.customBackgroundColor ) {
-		navigationMenuInlineStyles[ 'backgroundColor' ] = attributes.customBackgroundColor;
+	if ( backgroundColor ) {
+		navigationMenuInlineStyles[ 'backgroundColor' ] = backgroundColor.color;
 	}
 
 	const navigationMenuClasses = classnames(

--- a/packages/block-library/src/navigation-menu/editor.scss
+++ b/packages/block-library/src/navigation-menu/editor.scss
@@ -122,9 +122,6 @@ $colors-selector-size: 22px;
 		min-height: $colors-selector-size;
 		line-height: ($colors-selector-size - 2);
 		padding: 2px;
-
-		background-color: var(--background-color-menu-link);
-		color: var(--color-menu-link);
 	}
 
 	&:not(.has-background-color) .block-library-colors-selector__state-selection {

--- a/packages/block-library/src/navigation-menu/editor.scss
+++ b/packages/block-library/src/navigation-menu/editor.scss
@@ -122,11 +122,11 @@ $colors-selector-size: 22px;
 		min-height: $colors-selector-size;
 		line-height: ($colors-selector-size - 2);
 		padding: 2px;
-	}
 
-	&:not(.has-background-color) .block-library-colors-selector__state-selection {
-		background-image: linear-gradient(135deg, rgba(0, 0, 0, 0.08) 25%, transparent 25%, transparent 50%, rgba(0, 0, 0, 0.08) 50%, rgba(0, 0, 0, 0.08) 75%, transparent 75%, transparent 100%);
-		background-size: 12px 12px;
+		&:not(.has-background-color) {
+			background-image: linear-gradient(135deg, rgba(0, 0, 0, 0.08) 25%, transparent 25%, transparent 50%, rgba(0, 0, 0, 0.08) 50%, rgba(0, 0, 0, 0.08) 75%, transparent 75%, transparent 100%);
+			background-size: 12px 12px;
+		}
 	}
 }
 

--- a/packages/block-library/src/navigation-menu/editor.scss
+++ b/packages/block-library/src/navigation-menu/editor.scss
@@ -54,7 +54,6 @@
 	}
 }
 
-
 .wp-block-navigation-menu .block-editor-block-list__layout,
 .wp-block-navigation-menu {
 	display: flex;


### PR DESCRIPTION
## Description
This PR ~fixes~ implements the following changes:

* Align the `Aa` text of the toolbar colors-selector button.
* Apply the styles via CSS classes when the colores comes from the color palette.
* Apply the styles via inline styles when the colors are custom one.

These changes are implemented in the Editor Canvas. Let's handle the front-end in another PR.

## Screenshots 

**before**
![image](https://user-images.githubusercontent.com/77539/67900555-838dce00-fb43-11e9-96cf-84ee83cd7781.png)

![image](https://user-images.githubusercontent.com/77539/67900996-6d344200-fb44-11e9-9721-01e340f4e1a0.png)


**after**
![image](https://user-images.githubusercontent.com/77539/67900611-a3bd8d00-fb43-11e9-90d9-fc39567508fa.png)

![image](https://user-images.githubusercontent.com/77539/67901063-9523a580-fb44-11e9-9472-2d521e95da64.png)



## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->