### PR TITLE
Update ColorPalette component to accept disableAlpha parameter

### DIFF
--- a/packages/components/src/color-palette/README.md
+++ b/packages/components/src/color-palette/README.md
@@ -50,6 +50,14 @@ Whether the palette should have a clearing button or not.
 - Required: No
 - Default: true
 
+### disableAlpha
+
+Whether to disable alpha channel controls or not.
+
+- Type: `Boolean`
+- Required: No
+- Default: true
+
 
 ## Usage
 ```jsx

--- a/packages/components/src/color-palette/index.js
+++ b/packages/components/src/color-palette/index.js
@@ -19,6 +19,7 @@ export default function ColorPalette( {
 	clearable = true,
 	className,
 	colors,
+	disableAlpha = true,
 	disableCustomColors = false,
 	onChange,
 	value,
@@ -55,7 +56,7 @@ export default function ColorPalette( {
 			<ColorPicker
 				color={ value }
 				onChangeComplete={ ( color ) => onChange( color.hex ) }
-				disableAlpha
+				disableAlpha={ disableAlpha }
 			/>
 		),
 		[ value ]

--- a/packages/components/src/color-palette/stories/index.js
+++ b/packages/components/src/color-palette/stories/index.js
@@ -54,3 +54,17 @@ export const withKnobs = () => {
 	);
 };
 
+export const withAlpha = () => {
+	const colors = [
+		object( 'Red', { name: 'red', color: '#f00' } ),
+		object( 'White', { name: 'white', color: '#fff' } ),
+		object( 'Blue', { name: 'blue', color: '#00f' } ),
+	];
+
+	return (
+		<ColorPaletteWithState
+			colors={ colors }
+			disableAlpha={ false }
+		/>
+	);
+};


### PR DESCRIPTION
## Description

Adds the disableAlpha parameter to ColorPalette component which is passed forward to the ColorPicker to show. Previously it was set to true by default. 

Fixes #4726


## How has this been tested?

Run `npm run design-system:dev` to view component in Storybook.
Click custom color and confirm the Alpha channel shows up.

## Screenshots <!-- if applicable -->

![Screenshot from 2019-10-29 15-24-18](https://user-images.githubusercontent.com/45363/67814015-371d9200-fa60-11e9-8083-e2c7534b5654.png)


## Types of changes

Update ColorPalette component previously hard-coded to false when using the ColorPicker, this allows the parameter to be set by user.

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
