### PR TITLE
[RNMobile] Gallery  - Native gallery component draft

### DIFF
--- a/packages/block-editor/src/components/media-placeholder/index.native.js
+++ b/packages/block-editor/src/components/media-placeholder/index.native.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { View, Text, TouchableWithoutFeedback } from 'react-native';
+import { uniqBy } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -22,6 +23,7 @@ import styles from './styles.scss';
 
 function MediaPlaceholder( props ) {
 	const {
+		addToGallery,
 		allowedTypes = [],
 		labels = {},
 		icon,
@@ -30,7 +32,12 @@ function MediaPlaceholder( props ) {
 		disableMediaButtons,
 		getStylesFromColorScheme,
 		multiple,
+		value = [],
 	} = props;
+
+	const setMedia = multiple && addToGallery ?
+		( selected ) => onSelect( uniqBy( [ ...value, ...selected ], 'id' ) ) :
+		onSelect;
 
 	const isOneType = allowedTypes.length === 1;
 	const isImage = isOneType && allowedTypes.includes( MEDIA_TYPE_IMAGE );
@@ -103,7 +110,7 @@ function MediaPlaceholder( props ) {
 		<View style={ { flex: 1 } }>
 			<MediaUpload
 				allowedTypes={ allowedTypes }
-				onSelect={ onSelect }
+				onSelect={ setMedia }
 				multiple={ multiple }
 				render={ ( { open, getMediaOptions } ) => {
 					return (

--- a/packages/block-editor/src/components/media-placeholder/index.native.js
+++ b/packages/block-editor/src/components/media-placeholder/index.native.js
@@ -72,6 +72,7 @@ function MediaPlaceholder( props ) {
 	}
 
 	const emptyStateTitleStyle = getStylesFromColorScheme( styles.emptyStateTitle, styles.emptyStateTitleDark );
+	const addMediaButtonStyle = getStylesFromColorScheme( styles.addMediaButton, styles.addMediaButtonDark );
 
 	const renderContent = () => {
 		if ( isAppender === undefined || ! isAppender ) {
@@ -92,9 +93,9 @@ function MediaPlaceholder( props ) {
 			return (
 				<Dashicon
 					icon="plus-alt"
-					style={ styles.addBlockButton }
-					color={ styles.addBlockButton.color }
-					size={ styles.addBlockButton.size }
+					style={ addMediaButtonStyle }
+					color={ addMediaButtonStyle.color }
+					size={ addMediaButtonStyle.size }
 				/>
 			);
 		}
@@ -104,6 +105,7 @@ function MediaPlaceholder( props ) {
 		return null;
 	}
 
+	const appenderStyle = getStylesFromColorScheme( styles.appender, styles.appenderDark );
 	const emptyStateContainerStyle = getStylesFromColorScheme( styles.emptyStateContainer, styles.emptyStateContainerDark );
 
 	return (
@@ -129,7 +131,7 @@ function MediaPlaceholder( props ) {
 							<View
 								style={ [
 									emptyStateContainerStyle,
-									isAppender && styles.isAppender,
+									isAppender && appenderStyle,
 								] }>
 								{ getMediaOptions() }
 								{ renderContent() }

--- a/packages/block-editor/src/components/media-placeholder/styles.native.scss
+++ b/packages/block-editor/src/components/media-placeholder/styles.native.scss
@@ -46,17 +46,27 @@
 	fill: $gray-dark;
 }
 
-.isAppender {
+.appender {
 	height: auto;
 	background-color: $white;
 	border: $border-width solid $light-gray-500;
 	border-radius: 4px;
 }
 
-.addBlockButton {
+.appenderDark {
+	background-color: $background-dark-secondary;
+	border: $border-width solid $gray-70;
+}
+
+.addMediaButton {
 	color: $white;
 	background-color: $dark-gray-500;
 	border-radius: $icon-button-size-small / 2;
 	overflow: hidden;
 	size: $icon-button-size-small;
+}
+
+.addMediaButtonDark {
+	color: $background-dark-secondary;
+	background-color: $gray-40;
 }

--- a/packages/block-library/src/gallery/gallery-styles.native.scss
+++ b/packages/block-library/src/gallery/gallery-styles.native.scss
@@ -1,3 +1,3 @@
 .galleryTilesContainerSelected {
-  margin-bottom: 16px;
+	margin-bottom: 16px;
 }

--- a/packages/block-library/src/gallery/gallery-styles.native.scss
+++ b/packages/block-library/src/gallery/gallery-styles.native.scss
@@ -1,0 +1,3 @@
+.galleryTilesContainerSelected {
+  margin-bottom: 16px;
+}

--- a/packages/block-library/src/gallery/gallery.native.js
+++ b/packages/block-library/src/gallery/gallery.native.js
@@ -8,12 +8,15 @@ import { View } from 'react-native';
  */
 import GalleryImage from './gallery-image';
 import { defaultColumnsNumber } from './shared';
+import styles from './gallery-styles';
 import Tiles from './tiles';
 
 /**
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
+
+const TILE_SPACING = 15;
 
 export const Gallery = ( props ) => {
 	const {
@@ -32,7 +35,6 @@ export const Gallery = ( props ) => {
 	} = props;
 
 	const {
-		align,
 		columns = defaultColumnsNumber( attributes ),
 		imageCrop,
 		images,
@@ -44,8 +46,8 @@ export const Gallery = ( props ) => {
 		<View>
 			<Tiles
 				columns={ displayedColumns }
-				spacing={ 15 }
-				align={ align }
+				spacing={ TILE_SPACING }
+				style={ isSelected ? styles.galleryTilesContainerSelected : undefined }
 			>
 				{ images.map( ( img, index ) => {
 					/* translators: %1$d is the order number of the image, %2$d is the total number of images. */

--- a/packages/block-library/src/gallery/gallery.native.js
+++ b/packages/block-library/src/gallery/gallery.native.js
@@ -53,6 +53,7 @@ export const Gallery = ( props ) => {
 							url={ img.url }
 							alt={ img.alt }
 							id={ img.id }
+							isCropped={ imageCrop }
 							isFirstItem={ index === 0 }
 							isLastItem={ ( index + 1 ) === images.length }
 							isSelected={ isSelected && selectedImage === index }

--- a/packages/block-library/src/gallery/gallery.native.js
+++ b/packages/block-library/src/gallery/gallery.native.js
@@ -41,8 +41,16 @@ export const Gallery = ( props ) => {
 		images,
 	} = attributes;
 
-	const displayedColumns = isMobile ? Math.min( columns, 2 ) :
-		isNarrow ? Math.min( columns, 4 ) : columns;
+	let displayedColumns;
+
+	// limit displayed columns based on viewport width
+	if ( isMobile ) {
+		displayedColumns = Math.min( columns, 2 );
+	} else if ( isNarrow ) {
+		displayedColumns = Math.min( columns, 4 );
+	} else {
+		displayedColumns = columns;
+	}
 
 	return (
 		<View>

--- a/packages/block-library/src/gallery/gallery.native.js
+++ b/packages/block-library/src/gallery/gallery.native.js
@@ -17,7 +17,6 @@ import { __, sprintf } from '@wordpress/i18n';
 
 export const Gallery = ( props ) => {
 	const {
-		galleryProps,
 		selectedImage,
 		mediaPlaceholder,
 		onMoveBackward,
@@ -26,13 +25,10 @@ export const Gallery = ( props ) => {
 		onSelectImage,
 		onSetImageAttributes,
 	//	onFocusGalleryCaption,
-	} = props;
-
-	const {
 		attributes,
 		isSelected,
 	//	setAttributes,
-	} = galleryProps;
+	} = props;
 
 	const {
 		align,
@@ -46,7 +42,7 @@ export const Gallery = ( props ) => {
 
 	return (
 		<View>
-			<Tiles tilesProps={ tilesProps }>
+			<Tiles { ...tilesProps }>
 				{ images.map( ( img, index ) => {
 					/* translators: %1$d is the order number of the image, %2$d is the total number of images. */
 					const ariaLabel = sprintf( __( 'image %1$d of %2$d in gallery' ), ( index + 1 ), images.length );

--- a/packages/block-library/src/gallery/gallery.native.js
+++ b/packages/block-library/src/gallery/gallery.native.js
@@ -33,6 +33,7 @@ export const Gallery = ( props ) => {
 		//	setAttributes,
 		isMobile,
 		isNarrow,
+		onFocus,
 	} = props;
 
 	const {
@@ -78,6 +79,7 @@ export const Gallery = ( props ) => {
 							onMoveForward={ onMoveForward( index ) }
 							onRemove={ onRemoveImage( index ) }
 							onSelect={ onSelectImage( index ) }
+							onSelectBlock={ onFocus }
 							setAttributes={ ( attrs ) => onSetImageAttributes( index, attrs ) }
 							caption={ img.caption }
 							aria-label={ ariaLabel }

--- a/packages/block-library/src/gallery/gallery.native.js
+++ b/packages/block-library/src/gallery/gallery.native.js
@@ -56,6 +56,7 @@ export const Gallery = ( props ) => {
 							isFirstItem={ index === 0 }
 							isLastItem={ ( index + 1 ) === images.length }
 							isSelected={ isSelected && selectedImage === index }
+							isBlockSelected={ isSelected }
 							onMoveBackward={ onMoveBackward( index ) }
 							onMoveForward={ onMoveForward( index ) }
 							onRemove={ onRemoveImage( index ) }

--- a/packages/block-library/src/gallery/gallery.native.js
+++ b/packages/block-library/src/gallery/gallery.native.js
@@ -1,0 +1,79 @@
+/**
+ * External dependencies
+ */
+import { View } from 'react-native';
+
+/**
+ * Internal dependencies
+ */
+import GalleryImage from './gallery-image';
+import { defaultColumnsNumber } from './shared';
+import Tiles from './tiles';
+
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+
+export const Gallery = ( props ) => {
+	const {
+		galleryProps,
+		selectedImage,
+		mediaPlaceholder,
+		onMoveBackward,
+		onMoveForward,
+		onRemoveImage,
+		onSelectImage,
+		onSetImageAttributes,
+	//	onFocusGalleryCaption,
+	} = props;
+
+	const {
+		attributes,
+		isSelected,
+	//	setAttributes,
+	} = galleryProps;
+
+	const {
+		align,
+		columns = defaultColumnsNumber( attributes ),
+		//	caption,
+		imageCrop,
+		images,
+	} = attributes;
+
+	const tilesProps = { images, columns, align, imageCrop };
+
+	return (
+		<View>
+			<Tiles tilesProps={ tilesProps }>
+				{ images.map( ( img, index ) => {
+					/* translators: %1$d is the order number of the image, %2$d is the total number of images. */
+					const ariaLabel = sprintf( __( 'image %1$d of %2$d in gallery' ), ( index + 1 ), images.length );
+
+					return (
+						<GalleryImage
+							key={ img.id || img.url }
+							url={ img.url }
+							alt={ img.alt }
+							id={ img.id }
+							isFirstItem={ index === 0 }
+							isLastItem={ ( index + 1 ) === images.length }
+							isSelected={ isSelected && selectedImage === index }
+							onMoveBackward={ onMoveBackward( index ) }
+							onMoveForward={ onMoveForward( index ) }
+							onRemove={ onRemoveImage( index ) }
+							onSelect={ onSelectImage( index ) }
+							setAttributes={ ( attrs ) => onSetImageAttributes( index, attrs ) }
+							caption={ img.caption }
+							aria-label={ ariaLabel }
+						/>
+					);
+				} ) }
+			</Tiles>
+			{ mediaPlaceholder }
+		</View>
+	);
+};
+
+export default Gallery;

--- a/packages/block-library/src/gallery/gallery.native.js
+++ b/packages/block-library/src/gallery/gallery.native.js
@@ -24,10 +24,10 @@ export const Gallery = ( props ) => {
 		onRemoveImage,
 		onSelectImage,
 		onSetImageAttributes,
-	//	onFocusGalleryCaption,
+		//	onFocusGalleryCaption,
 		attributes,
 		isSelected,
-	//	setAttributes,
+		//	setAttributes,
 		isMobile,
 	} = props;
 

--- a/packages/block-library/src/gallery/gallery.native.js
+++ b/packages/block-library/src/gallery/gallery.native.js
@@ -32,6 +32,7 @@ export const Gallery = ( props ) => {
 		isSelected,
 		//	setAttributes,
 		isMobile,
+		isNarrow,
 	} = props;
 
 	const {
@@ -40,7 +41,8 @@ export const Gallery = ( props ) => {
 		images,
 	} = attributes;
 
-	const displayedColumns = isMobile ? Math.min( columns, 2 ) : columns;
+	const displayedColumns = isMobile ? Math.min( columns, 2 ) :
+		isNarrow ? Math.min( columns, 4 ) : columns;
 
 	return (
 		<View>

--- a/packages/block-library/src/gallery/gallery.native.js
+++ b/packages/block-library/src/gallery/gallery.native.js
@@ -44,7 +44,7 @@ export const Gallery = ( props ) => {
 		<View>
 			<Tiles
 				columns={ displayedColumns }
-				groutSpacing={ 15 }
+				spacing={ 15 }
 				align={ align }
 			>
 				{ images.map( ( img, index ) => {

--- a/packages/block-library/src/gallery/gallery.native.js
+++ b/packages/block-library/src/gallery/gallery.native.js
@@ -28,21 +28,25 @@ export const Gallery = ( props ) => {
 		attributes,
 		isSelected,
 	//	setAttributes,
+		isMobile,
 	} = props;
 
 	const {
 		align,
 		columns = defaultColumnsNumber( attributes ),
-		//	caption,
 		imageCrop,
 		images,
 	} = attributes;
 
-	const tilesProps = { images, columns, align, imageCrop };
+	const displayedColumns = isMobile ? Math.min( columns, 2 ) : columns;
 
 	return (
 		<View>
-			<Tiles { ...tilesProps }>
+			<Tiles
+				columns={ displayedColumns }
+				groutSpacing={ 15 }
+				align={ align }
+			>
 				{ images.map( ( img, index ) => {
 					/* translators: %1$d is the order number of the image, %2$d is the total number of images. */
 					const ariaLabel = sprintf( __( 'image %1$d of %2$d in gallery' ), ( index + 1 ), images.length );

--- a/packages/block-library/src/gallery/gallery.native.js
+++ b/packages/block-library/src/gallery/gallery.native.js
@@ -18,6 +18,10 @@ import { __, sprintf } from '@wordpress/i18n';
 
 const TILE_SPACING = 15;
 
+// we must limit displayed columns since readable content max-width is 580px
+const MAX_DISPLAYED_COLUMNS = 4;
+const MAX_DISPLAYED_COLUMNS_MOBILE = 2;
+
 export const Gallery = ( props ) => {
 	const {
 		selectedImage,
@@ -32,7 +36,6 @@ export const Gallery = ( props ) => {
 		isSelected,
 		//	setAttributes,
 		isMobile,
-		isNarrow,
 		onFocus,
 	} = props;
 
@@ -42,16 +45,10 @@ export const Gallery = ( props ) => {
 		images,
 	} = attributes;
 
-	let displayedColumns;
-
 	// limit displayed columns based on viewport width
-	if ( isMobile ) {
-		displayedColumns = Math.min( columns, 2 );
-	} else if ( isNarrow ) {
-		displayedColumns = Math.min( columns, 4 );
-	} else {
-		displayedColumns = columns;
-	}
+	const displayedColumns = isMobile ?
+		Math.min( columns, MAX_DISPLAYED_COLUMNS_MOBILE ) :
+		Math.min( columns, MAX_DISPLAYED_COLUMNS );
 
 	return (
 		<View>

--- a/packages/block-library/src/gallery/gallery.native.js
+++ b/packages/block-library/src/gallery/gallery.native.js
@@ -62,7 +62,7 @@ export const Gallery = ( props ) => {
 				setIsCaptionSelected( false );
 			}
 			// we need to fully invoke the curried function here
-			onSelectImage( index )(); 
+			onSelectImage( index )();
 		};
 	};
 

--- a/packages/block-library/src/gallery/gallery.native.js
+++ b/packages/block-library/src/gallery/gallery.native.js
@@ -23,7 +23,7 @@ const TILE_SPACING = 15;
 
 // we must limit displayed columns since readable content max-width is 580px
 const MAX_DISPLAYED_COLUMNS = 4;
-const MAX_DISPLAYED_COLUMNS_MOBILE = 2;
+const MAX_DISPLAYED_COLUMNS_NARROW = 2;
 
 export const Gallery = ( props ) => {
 	const [ isCaptionSelected, setIsCaptionSelected ] = useState( false );
@@ -41,7 +41,7 @@ export const Gallery = ( props ) => {
 		onFocusGalleryCaption,
 		attributes,
 		isSelected,
-		isMobile,
+		isNarrow,
 		onFocus,
 	} = props;
 
@@ -51,9 +51,10 @@ export const Gallery = ( props ) => {
 		images,
 	} = attributes;
 
-	// limit displayed columns based on viewport width
-	const displayedColumns = isMobile ?
-		Math.min( columns, MAX_DISPLAYED_COLUMNS_MOBILE ) :
+	// limit displayed columns when isNarrow is true (i.e. when viewport width is
+	// less than "small", where small = 600)
+	const displayedColumns = isNarrow ?
+		Math.min( columns, MAX_DISPLAYED_COLUMNS_NARROW ) :
 		Math.min( columns, MAX_DISPLAYED_COLUMNS );
 
 	const selectImage = ( index ) => {

--- a/packages/block-library/src/gallery/gallery.native.js
+++ b/packages/block-library/src/gallery/gallery.native.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { View } from 'react-native';
+import { isEmpty } from 'lodash';
 
 /**
  * Internal dependencies
@@ -15,6 +16,8 @@ import Tiles from './tiles';
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
+import { Caption } from '@wordpress/block-editor';
+import { useState } from '@wordpress/element';
 
 const TILE_SPACING = 15;
 
@@ -23,18 +26,21 @@ const MAX_DISPLAYED_COLUMNS = 4;
 const MAX_DISPLAYED_COLUMNS_MOBILE = 2;
 
 export const Gallery = ( props ) => {
+	const [ isCaptionSelected, setIsCaptionSelected ] = useState( false );
+
 	const {
+		clientId,
 		selectedImage,
 		mediaPlaceholder,
+		onBlur,
 		onMoveBackward,
 		onMoveForward,
 		onRemoveImage,
 		onSelectImage,
 		onSetImageAttributes,
-		//	onFocusGalleryCaption,
+		onFocusGalleryCaption,
 		attributes,
 		isSelected,
-		//	setAttributes,
 		isMobile,
 		onFocus,
 	} = props;
@@ -49,6 +55,23 @@ export const Gallery = ( props ) => {
 	const displayedColumns = isMobile ?
 		Math.min( columns, MAX_DISPLAYED_COLUMNS_MOBILE ) :
 		Math.min( columns, MAX_DISPLAYED_COLUMNS );
+
+	const selectImage = ( index ) => {
+		return () => {
+			if ( isCaptionSelected ) {
+				setIsCaptionSelected( false );
+			}
+			// we need to fully invoke the curried function here
+			onSelectImage( index )(); 
+		};
+	};
+
+	const focusGalleryCaption = () => {
+		if ( ! isCaptionSelected ) {
+			setIsCaptionSelected( true );
+		}
+		onFocusGalleryCaption();
+	};
 
 	return (
 		<View>
@@ -75,7 +98,7 @@ export const Gallery = ( props ) => {
 							onMoveBackward={ onMoveBackward( index ) }
 							onMoveForward={ onMoveForward( index ) }
 							onRemove={ onRemoveImage( index ) }
-							onSelect={ onSelectImage( index ) }
+							onSelect={ selectImage( index ) }
 							onSelectBlock={ onFocus }
 							setAttributes={ ( attrs ) => onSetImageAttributes( index, attrs ) }
 							caption={ img.caption }
@@ -85,6 +108,22 @@ export const Gallery = ( props ) => {
 				} ) }
 			</Tiles>
 			{ mediaPlaceholder }
+			<Caption
+				clientId={ clientId }
+				isSelected={ isCaptionSelected }
+				accessible={ true }
+				accessibilityLabelCreator={ ( caption ) =>
+					isEmpty( caption ) ?
+					/* translators: accessibility text. Empty gallery caption. */
+						( 'Gallery caption. Empty' ) :
+						sprintf(
+						/* translators: accessibility text. %s: gallery caption. */
+							__( 'Gallery caption. %s' ),
+							caption )
+				}
+				onFocus={ focusGalleryCaption }
+				onBlur={ onBlur } // always assign onBlur as props
+			/>
 		</View>
 	);
 };

--- a/packages/block-library/src/gallery/gallery.native.js
+++ b/packages/block-library/src/gallery/gallery.native.js
@@ -9,7 +9,7 @@ import { isEmpty } from 'lodash';
  */
 import GalleryImage from './gallery-image';
 import { defaultColumnsNumber } from './shared';
-import styles from './gallery-styles';
+import styles from './gallery-styles.scss';
 import Tiles from './tiles';
 
 /**

--- a/packages/block-library/src/index.native.js
+++ b/packages/block-library/src/index.native.js
@@ -151,6 +151,8 @@ export const registerCoreBlocks = () => {
 		// eslint-disable-next-line no-undef
 		!! __DEV__ ? group : null,
 		spacer,
+		// eslint-disable-next-line no-undef
+		!! __DEV__ ? gallery : null,
 	].forEach( registerBlock );
 
 	setDefaultBlockName( paragraph.name );


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
This PR introduces a native `Gallery` component for the semi-cross-platform Gallery block. The purpose of this component is to render a list of images passed via the `images` prop.


### PR Hierarchy
This PR is part of the [PR hierarchy described here](https://github.com/wordpress-mobile/gutenberg-mobile/issues/1416#issuecomment-551057738). This PR can be tested with the aggregate changeset and integration of components within the related PRs by checking out the branch of the "top level" PR: https://github.com/WordPress/gutenberg/pull/18265 via the `gutenberg-mobile` PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1498.


### MediaPlaceholder

Changes to `MediaPlaceholder` from this PR: https://github.com/WordPress/gutenberg/pull/18262 have been merged for review here. The `MediaPlaceholder` component has been modified to append media for the native `Gallery` implementation.

On web, when new media is added to a gallery, the current selection of items in the gallery is available to the media selection interface, and can be presented as such to the user. The selector behaves more like a "gallery editor", in the sense that the selection is modified (users can add and / or remove items). On mobile, the interface for selecting media items is handled by the "parent apps", and does not "know" about what is currently selected as part of the gallery.

This PR adds the `addToGallery` prop to the `MediaPlaceholder` component, and conditionally appends media items to the current selection, passing the resulting collection back through `onSelect` when the `addToGallery` flag is set. When the `addToGallery` flag is not set, `onSelect` behavior is not modified.

**Note:** In this implementation, duplicates are removed from the collection via the `id` property, since this is used as a `key` in the list of elements that renders these items.
The MediaPlaceholder

The changeset here is used in the related "parent" PR: https://github.com/WordPress/gutenberg/pull/18111, which includes these changes integrated with related changes in other components necessary for the gallery block.

### Block-level caption

This component uses the mobile `Caption` component to add a block-level caption for gallery.

## To test
Test this component by checking out the branch of the "top level" PR: https://github.com/WordPress/gutenberg/pull/18265 via the `gutenberg-mobile` PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1498.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
