### PR TITLE
Fix navigation menu insertion issues

### DIFF
--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -12,7 +12,6 @@ import { withDispatch, withSelect } from '@wordpress/data';
 import { compose, ifCondition } from '@wordpress/compose';
 import {
 	createBlock,
-	getBlockType,
 } from '@wordpress/blocks';
 
 /**
@@ -136,7 +135,7 @@ export default compose( [
 		const hasSingleBlockType = allowedBlocks && ( get( allowedBlocks, [ 'length' ], 0 ) === 1 );
 		let allowedBlockType = false;
 		if ( hasSingleBlockType ) {
-			allowedBlockType = getBlockType( allowedBlocks );
+			allowedBlockType = allowedBlocks[ 0 ];
 		}
 		return {
 			hasItems: hasInserterItems( rootClientId ),

--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -148,7 +148,7 @@ export default compose( [
 	withDispatch( ( dispatch, ownProps, { select } ) => {
 		return {
 			insertOnlyAllowedBlock() {
-				const { rootClientId, clientId, isAppender, destinationRootClientId } = ownProps;
+				const { rootClientId, clientId, isAppender } = ownProps;
 				const {
 					hasSingleBlockType,
 					allowedBlockType,
@@ -167,17 +167,17 @@ export default compose( [
 
 					// If the clientId is defined, we insert at the position of the block.
 					if ( clientId ) {
-						return getBlockIndex( clientId, destinationRootClientId );
+						return getBlockIndex( clientId, rootClientId );
 					}
 
 					// If there a selected block, we insert after the selected block.
 					const end = getBlockSelectionEnd();
 					if ( ! isAppender && end ) {
-						return getBlockIndex( end, destinationRootClientId ) + 1;
+						return getBlockIndex( end, rootClientId ) + 1;
 					}
 
 					// Otherwise, we insert at the end of the current rootClientId
-					return getBlockOrder( destinationRootClientId ).length;
+					return getBlockOrder( rootClientId ).length;
 				}
 
 				const {

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -15,6 +15,7 @@ import {
 	reduce,
 	some,
 	find,
+	filter,
 } from 'lodash';
 import createSelector from 'rememo';
 
@@ -1316,15 +1317,27 @@ export const hasInserterItems = createSelector(
  * @param {Object}  state        Editor state.
  * @param {?string} rootClientId Optional root client ID of block list.
  *
- * @return {Array?} The list of allowed block types or false.
+ * @return {Array?} The list of allowed block types.
  */
-export const __experimentalGetAllowedBlocks = ( state, rootClientId = null ) => {
-	if ( ! rootClientId ) {
-		return false;
-	}
-	const { allowedBlocks } = getBlockListSettings( state, rootClientId );
-	return allowedBlocks;
-};
+export const __experimentalGetAllowedBlocks = createSelector(
+	( state, rootClientId = null ) => {
+		if ( ! rootClientId ) {
+			return;
+		}
+
+		return filter(
+			getBlockTypes(),
+			( blockType ) => canIncludeBlockTypeInInserter( state, blockType, rootClientId )
+		);
+	},
+	( state, rootClientId ) => [
+		state.blockListSettings[ rootClientId ],
+		state.blocks.byClientId,
+		state.settings.allowedBlockTypes,
+		state.settings.templateLock,
+		getBlockTypes(),
+	]
+);
 
 /**
  * Returns the Block List settings of a block, if any exist.


### PR DESCRIPTION
## Description
On #18100 I was having some issues with insertion in the nav block:
- the new `__experimentalGetAllowedBlockTypes` selector was throwing an error when `blockListSettings` didn't contain a setting for a particular block. Not entirely sure why this happens.
- An undefined `destinationRootClientId` prop was being used to get the insertion index. This would mean the block would often be insterted in the wrong place.

The fixes:
- Update the selector to be more like the `hasInserterItems` selector.
- Use the already defined `rootClientId` prop.

## How has this been tested?
1. Add a navigation block
2. Add menu items to the nav block
3. Expect that the menu items are added correctly
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
