### PR TITLE
Navigation Block: use RichText for navigation menu item instead of TextControl.

### DIFF
--- a/packages/block-library/src/navigation-menu-item/edit.js
+++ b/packages/block-library/src/navigation-menu-item/edit.js
@@ -44,7 +44,6 @@ function NavigationMenuItemEdit( {
 	isParentOfSelectedBlock,
 	setAttributes,
 } ) {
-	const plainTextRef = useRef( null );
 	const [ isLinkOpen, setIsLinkOpen ] = useState( false );
 	const [ isEditingLink, setIsEditingLink ] = useState( false );
 	const [ urlInput, setUrlInput ] = useState( null );
@@ -176,8 +175,7 @@ function NavigationMenuItemEdit( {
 				} ) }
 			>
 				<RichText
-					ref={ plainTextRef }
-					className="wp-block-navigation-menu-item__field"
+					className="wp-block-navigation-menu-item__content"
 					value={ label }
 					onChange={ ( labelValue ) => setAttributes( { label: labelValue } ) }
 					placeholder={ __( 'Add item…' ) }

--- a/packages/block-library/src/navigation-menu-item/edit.js
+++ b/packages/block-library/src/navigation-menu-item/edit.js
@@ -25,6 +25,7 @@ import {
 	ENTER,
 } from '@wordpress/keycodes';
 import { __ } from '@wordpress/i18n';
+import { RichText } from '@wordpress/editor';
 import {
 	BlockControls,
 	InnerBlocks,
@@ -78,23 +79,6 @@ function NavigationMenuItemEdit( {
 	};
 
 	const { label, url } = attributes;
-	let content;
-	if ( isSelected ) {
-		content = (
-			<TextControl
-				ref={ plainTextRef }
-				className="wp-block-navigation-menu-item__field"
-				value={ label }
-				onChange={ ( labelValue ) => setAttributes( { label: labelValue } ) }
-				label={ __( 'Navigation Label' ) }
-				hideLabelFromVision={ true }
-			/>
-		);
-	} else {
-		content = <div className="wp-block-navigation-menu-item__container">
-			{ label }
-		</div>;
-	}
 
 	return (
 		<Fragment>
@@ -191,7 +175,14 @@ function NavigationMenuItemEdit( {
 					'is-selected': isSelected,
 				} ) }
 			>
-				{ content }
+				<RichText
+					ref={ plainTextRef }
+					className="wp-block-navigation-menu-item__field"
+					value={ label }
+					onChange={ ( labelValue ) => setAttributes( { label: labelValue } ) }
+					placeholder={ __( 'Add item…' ) }
+					withoutInteractiveFormatting
+				/>
 				{ ( isSelected || isParentOfSelectedBlock ) &&
 					<InnerBlocks
 						allowedBlocks={ [ 'core/navigation-menu-item' ] }

--- a/packages/block-library/src/navigation-menu-item/edit.js
+++ b/packages/block-library/src/navigation-menu-item/edit.js
@@ -25,12 +25,12 @@ import {
 	ENTER,
 } from '@wordpress/keycodes';
 import { __ } from '@wordpress/i18n';
-import { RichText } from '@wordpress/block-editor';
 import {
 	BlockControls,
 	InnerBlocks,
 	InspectorControls,
 	URLPopover,
+	RichText,
 } from '@wordpress/block-editor';
 import {
 	Fragment,

--- a/packages/block-library/src/navigation-menu-item/edit.js
+++ b/packages/block-library/src/navigation-menu-item/edit.js
@@ -25,7 +25,7 @@ import {
 	ENTER,
 } from '@wordpress/keycodes';
 import { __ } from '@wordpress/i18n';
-import { RichText } from '@wordpress/editor';
+import { RichText } from '@wordpress/block-editor';
 import {
 	BlockControls,
 	InnerBlocks,

--- a/packages/block-library/src/navigation-menu-item/index.js
+++ b/packages/block-library/src/navigation-menu-item/index.js
@@ -14,7 +14,7 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: __( 'Menu Item (Experimental)' ),
+	title: __( 'Menu Item' ),
 
 	parent: [ 'core/navigation-menu' ],
 

--- a/packages/e2e-tests/fixtures/block-transforms.js
+++ b/packages/e2e-tests/fixtures/block-transforms.js
@@ -354,7 +354,7 @@ export const EXPECTED_TRANSFORMS = {
 		],
 	},
 	'core__navigation-menu-item': {
-		originalBlock: 'Menu Item (Experimental)',
+		originalBlock: 'Menu Item',
 		availableTransforms: [
 			'Group',
 		],


### PR DESCRIPTION
Navigation menu items should not be using a plain text control for labels. It should leverage `RichText` which is setup to handle a visually faithful representation and smooth transition between editing and viewing. (You'll notice no visual jump when selecting the item.)

It also allows to add a placeholder property, which is useful to address #18180.

Fixes #18180.

![image](https://user-images.githubusercontent.com/548849/67856380-b2408000-fb14-11e9-95c8-18612de07878.png)

**To Do:**

- [x]  Restore color tools.
- [x] Fix display of inline movers and clean up classes.