### PR TITLE
Fix postmeta radio regression.

### DIFF
--- a/packages/edit-post/src/components/meta-boxes/meta-boxes-area/style.scss
+++ b/packages/edit-post/src/components/meta-boxes/meta-boxes-area/style.scss
@@ -87,7 +87,7 @@
 	// checkboxes used in metaboxes have to be slightly unstyled here.
 	// @todo: remove this entire rule once checkboxes are the same everywhere.
 	// See: https://github.com/WordPress/gutenberg/issues/18053
-	.postbox-container .postbox input[type="checkbox"] {
+	.metabox-location-side .postbox input[type="checkbox"] {
 		border: $border-width solid $dark-gray-300;
 
 		&:checked {

--- a/packages/edit-post/src/components/meta-boxes/meta-boxes-area/style.scss
+++ b/packages/edit-post/src/components/meta-boxes/meta-boxes-area/style.scss
@@ -87,8 +87,7 @@
 	// checkboxes used in metaboxes have to be slightly unstyled here.
 	// @todo: remove this entire rule once checkboxes are the same everywhere.
 	// See: https://github.com/WordPress/gutenberg/issues/18053
-	.postbox-container .postbox input[type="checkbox"],
-	.postbox-container .postbox input[type="radio"] {
+	.postbox-container .postbox input[type="checkbox"] {
 		border: $border-width solid $dark-gray-300;
 
 		&:checked {


### PR DESCRIPTION
This PR fixes #18181.

The regression was caused due to a margin added to the pseudo element which was not necessary for the radio buttons.

![Screenshot 2019-10-30 at 13 14 50](https://user-images.githubusercontent.com/1204802/67857596-7b1f9e00-fb17-11e9-8133-91a79772b409.png)
