### PR TITLE
Remove "experimental" name from navigation block.

### DIFF
--- a/packages/block-library/src/navigation-menu/index.js
+++ b/packages/block-library/src/navigation-menu/index.js
@@ -12,7 +12,7 @@ import save from './save';
 export const name = 'core/navigation-menu';
 
 export const settings = {
-	title: __( 'Navigation Menu (Experimental)' ),
+	title: __( 'Navigation' ),
 
 	icon: 'menu',
 

--- a/packages/e2e-tests/fixtures/block-transforms.js
+++ b/packages/e2e-tests/fixtures/block-transforms.js
@@ -348,7 +348,7 @@ export const EXPECTED_TRANSFORMS = {
 		],
 	},
 	'core__navigation-menu': {
-		originalBlock: 'Navigation Menu (Experimental)',
+		originalBlock: 'Navigation',
 		availableTransforms: [
 			'Group',
 		],


### PR DESCRIPTION
This shouldn't be needed anymore.