### PR TITLE
Navigation Block: Add text indicating that a menu is loading.

### DIFF
--- a/packages/block-library/src/navigation-menu/edit.js
+++ b/packages/block-library/src/navigation-menu/edit.js
@@ -7,7 +7,6 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import {
-	Fragment,
 	useMemo,
 	useEffect,
 } from '@wordpress/element';
@@ -109,7 +108,7 @@ function NavigationMenu( {
 	}, [ backgroundColor.class, textColor.class ] );
 
 	return (
-		<Fragment>
+		<>
 			<BlockControls>
 				<Toolbar>
 					{ navigatorToolbarButton }
@@ -137,7 +136,7 @@ function NavigationMenu( {
 			</InspectorControls>
 
 			<div className={ navigationMenuClasses } style={ navigationMenuStyles }>
-				{ isRequesting && <Spinner /> }
+				{ isRequesting && <><Spinner /> { __( 'Loading Navigation…' ) } </> }
 				{ pages &&
 					<InnerBlocks
 						template={ defaultMenuItems ? defaultMenuItems : null }
@@ -147,7 +146,7 @@ function NavigationMenu( {
 					/>
 				}
 			</div>
-		</Fragment>
+		</>
 	);
 }
 


### PR DESCRIPTION
Display text to indicate a menu is loading.

![image](https://user-images.githubusercontent.com/548849/67869458-c04eca80-fb2d-11e9-88cf-b1a44aabb20c.png)

Closes #18179.