### PR TITLE
Navigation Block: remove font-family styles and let the block inherit.

### DIFF
--- a/packages/block-library/src/navigation-menu-item/editor.scss
+++ b/packages/block-library/src/navigation-menu-item/editor.scss
@@ -50,9 +50,8 @@
 }
 
 .wp-block-navigation-menu-item {
-	font-family: $editor-font;
-	font-weight: bold;
-	font-size: $text-editor-font-size;
+	font-family: inherit;
+	font-size: inherit;
 	background-color: var(--background-color-menu-link);
 	color: var(--color-menu-link);
 


### PR DESCRIPTION
The block should not be forcing a specific font-family here. If we are handling font-sizes we should add support for the regular font size selector with predefined classes.