### PR TITLE
Fix: setting a preset color on pullquote default style makes the block invalid

### DIFF
--- a/packages/block-library/src/pullquote/deprecated.js
+++ b/packages/block-library/src/pullquote/deprecated.js
@@ -52,6 +52,67 @@ const deprecated = [
 	{
 		attributes: blockAttributes,
 		save( { attributes } ) {
+			const {
+				mainColor,
+				customMainColor,
+				textColor,
+				customTextColor,
+				value,
+				citation,
+				className,
+			} = attributes;
+
+			const isSolidColorStyle = includes( className, SOLID_COLOR_CLASS );
+
+			let figureClasses, figureStyles;
+
+			// Is solid color style
+			if ( isSolidColorStyle ) {
+				const backgroundClass = getColorClassName( 'background-color', mainColor );
+
+				figureClasses = classnames( {
+					'has-background': ( backgroundClass || customMainColor ),
+					[ backgroundClass ]: backgroundClass,
+				} );
+
+				figureStyles = {
+					backgroundColor: backgroundClass ? undefined : customMainColor,
+				};
+			// Is normal style and a custom color is being used ( we can set a style directly with its value)
+			} else if ( customMainColor ) {
+				figureStyles = {
+					borderColor: customMainColor,
+				};
+			// If normal style and a named color are being used, we need to retrieve the color value to set the style,
+			// as there is no expectation that themes create classes that set border colors.
+			} else if ( mainColor ) {
+				const colors = get( select( 'core/block-editor' ).getSettings(), [ 'colors' ], [] );
+				const colorObject = getColorObjectByAttributeValues( colors, mainColor );
+				figureStyles = {
+					borderColor: colorObject.color,
+				};
+			}
+
+			const blockquoteTextColorClass = getColorClassName( 'color', textColor );
+			const blockquoteClasses = ( textColor || customTextColor ) && classnames( 'has-text-color', {
+				[ blockquoteTextColorClass ]: blockquoteTextColorClass,
+			} );
+
+			const blockquoteStyles = blockquoteTextColorClass ? undefined : { color: customTextColor };
+
+			return (
+				<figure className={ figureClasses } style={ figureStyles }>
+					<blockquote className={ blockquoteClasses } style={ blockquoteStyles } >
+						<RichText.Content value={ value } multiline />
+						{ ! RichText.isEmpty( citation ) && <RichText.Content tagName="cite" value={ citation } /> }
+					</blockquote>
+				</figure>
+			);
+		},
+	},
+	{
+		attributes: blockAttributes,
+		save( { attributes } ) {
 			const { mainColor, customMainColor, textColor, customTextColor, value, citation, className } = attributes;
 			const isSolidColorStyle = includes( className, SOLID_COLOR_CLASS );
 

--- a/packages/block-library/src/pullquote/save.js
+++ b/packages/block-library/src/pullquote/save.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { get, includes } from 'lodash';
+import { includes } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -10,11 +10,7 @@ import { get, includes } from 'lodash';
 import {
 	getColorClassName,
 	RichText,
-	getColorObjectByAttributeValues,
 } from '@wordpress/block-editor';
-import {
-	select,
-} from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -52,14 +48,6 @@ export default function save( { attributes } ) {
 	} else if ( customMainColor ) {
 		figureStyles = {
 			borderColor: customMainColor,
-		};
-	// If normal style and a named color are being used, we need to retrieve the color value to set the style,
-	// as there is no expectation that themes create classes that set border colors.
-	} else if ( mainColor ) {
-		const colors = get( select( 'core/block-editor' ).getSettings(), [ 'colors' ], [] );
-		const colorObject = getColorObjectByAttributeValues( colors, mainColor );
-		figureStyles = {
-			borderColor: colorObject.color,
 		};
 	}
 

--- a/packages/e2e-tests/fixtures/block-transforms.js
+++ b/packages/e2e-tests/fixtures/block-transforms.js
@@ -390,6 +390,13 @@ export const EXPECTED_TRANSFORMS = {
 			'Group',
 		],
 	},
+	'core__pullquote__main-color': {
+		originalBlock: 'Pullquote',
+		availableTransforms: [
+			'Quote',
+			'Group',
+		],
+	},
 	'core__pullquote__multi-paragraph': {
 		originalBlock: 'Pullquote',
 		availableTransforms: [

--- a/packages/e2e-tests/fixtures/blocks/core__pullquote__deprecated-3.html
+++ b/packages/e2e-tests/fixtures/blocks/core__pullquote__deprecated-3.html
@@ -1,0 +1,3 @@
+<!-- wp:pullquote {"mainColor":"accent","textColor":"secondary"} -->
+<figure class="wp-block-pullquote" style="border-color:#cd2653"><blockquote class="has-text-color has-secondary-color"><p>pullquote</p></blockquote></figure>
+<!-- /wp:pullquote -->

--- a/packages/e2e-tests/fixtures/blocks/core__pullquote__deprecated-3.json
+++ b/packages/e2e-tests/fixtures/blocks/core__pullquote__deprecated-3.json
@@ -1,0 +1,15 @@
+[
+    {
+        "clientId": "_clientId_0",
+        "name": "core/pullquote",
+        "isValid": false,
+        "attributes": {
+            "value": "<p>pullquote</p>",
+            "citation": "",
+            "mainColor": "accent",
+            "textColor": "secondary"
+        },
+        "innerBlocks": [],
+        "originalContent": "<figure class=\"wp-block-pullquote\" style=\"border-color:#cd2653\"><blockquote class=\"has-text-color has-secondary-color\"><p>pullquote</p></blockquote></figure>"
+    }
+]

--- a/packages/e2e-tests/fixtures/blocks/core__pullquote__deprecated-3.json
+++ b/packages/e2e-tests/fixtures/blocks/core__pullquote__deprecated-3.json
@@ -2,11 +2,11 @@
     {
         "clientId": "_clientId_0",
         "name": "core/pullquote",
-        "isValid": false,
+        "isValid": true,
         "attributes": {
             "value": "<p>pullquote</p>",
             "citation": "",
-            "mainColor": "accent",
+            "customMainColor": "#cd2653",
             "textColor": "secondary"
         },
         "innerBlocks": [],

--- a/packages/e2e-tests/fixtures/blocks/core__pullquote__deprecated-3.parsed.json
+++ b/packages/e2e-tests/fixtures/blocks/core__pullquote__deprecated-3.parsed.json
@@ -1,0 +1,23 @@
+[
+    {
+        "blockName": "core/pullquote",
+        "attrs": {
+            "mainColor": "accent",
+            "textColor": "secondary"
+        },
+        "innerBlocks": [],
+        "innerHTML": "\n<figure class=\"wp-block-pullquote\" style=\"border-color:#cd2653\"><blockquote class=\"has-text-color has-secondary-color\"><p>pullquote</p></blockquote></figure>\n",
+        "innerContent": [
+            "\n<figure class=\"wp-block-pullquote\" style=\"border-color:#cd2653\"><blockquote class=\"has-text-color has-secondary-color\"><p>pullquote</p></blockquote></figure>\n"
+        ]
+    },
+    {
+        "blockName": null,
+        "attrs": {},
+        "innerBlocks": [],
+        "innerHTML": "\n",
+        "innerContent": [
+            "\n"
+        ]
+    }
+]

--- a/packages/e2e-tests/fixtures/blocks/core__pullquote__deprecated-3.serialized.html
+++ b/packages/e2e-tests/fixtures/blocks/core__pullquote__deprecated-3.serialized.html
@@ -1,0 +1,3 @@
+<!-- wp:pullquote {"mainColor":"accent","textColor":"secondary"} -->
+<figure class="wp-block-pullquote" style="border-color:#cd2653"><blockquote class="has-text-color has-secondary-color"><p>pullquote</p></blockquote></figure>
+<!-- /wp:pullquote -->

--- a/packages/e2e-tests/fixtures/blocks/core__pullquote__deprecated-3.serialized.html
+++ b/packages/e2e-tests/fixtures/blocks/core__pullquote__deprecated-3.serialized.html
@@ -1,3 +1,3 @@
-<!-- wp:pullquote {"mainColor":"accent","textColor":"secondary"} -->
+<!-- wp:pullquote {"customMainColor":"#cd2653","textColor":"secondary"} -->
 <figure class="wp-block-pullquote" style="border-color:#cd2653"><blockquote class="has-text-color has-secondary-color"><p>pullquote</p></blockquote></figure>
 <!-- /wp:pullquote -->

--- a/packages/e2e-tests/fixtures/blocks/core__pullquote__main-color.html
+++ b/packages/e2e-tests/fixtures/blocks/core__pullquote__main-color.html
@@ -1,0 +1,3 @@
+<!-- wp:pullquote {"customMainColor":"#2207d0","textColor":"subtle-background","className":"has-background is-style-default"} -->
+<figure class="wp-block-pullquote has-background is-style-default" style="border-color:#2207d0"><blockquote class="has-text-color has-subtle-background-color"><p>Pullquote custom color</p><cite>my citation</cite></blockquote></figure>
+<!-- /wp:pullquote -->

--- a/packages/e2e-tests/fixtures/blocks/core__pullquote__main-color.json
+++ b/packages/e2e-tests/fixtures/blocks/core__pullquote__main-color.json
@@ -1,0 +1,16 @@
+[
+    {
+        "clientId": "_clientId_0",
+        "name": "core/pullquote",
+        "isValid": true,
+        "attributes": {
+            "value": "<p>Pullquote custom color</p>",
+            "citation": "my citation",
+            "customMainColor": "#2207d0",
+            "textColor": "subtle-background",
+            "className": "has-background is-style-default"
+        },
+        "innerBlocks": [],
+        "originalContent": "<figure class=\"wp-block-pullquote has-background is-style-default\" style=\"border-color:#2207d0\"><blockquote class=\"has-text-color has-subtle-background-color\"><p>Pullquote custom color</p><cite>my citation</cite></blockquote></figure>"
+    }
+]

--- a/packages/e2e-tests/fixtures/blocks/core__pullquote__main-color.parsed.json
+++ b/packages/e2e-tests/fixtures/blocks/core__pullquote__main-color.parsed.json
@@ -1,0 +1,24 @@
+[
+    {
+        "blockName": "core/pullquote",
+        "attrs": {
+            "customMainColor": "#2207d0",
+            "textColor": "subtle-background",
+            "className": "has-background is-style-default"
+        },
+        "innerBlocks": [],
+        "innerHTML": "\n<figure class=\"wp-block-pullquote has-background is-style-default\" style=\"border-color:#2207d0\"><blockquote class=\"has-text-color has-subtle-background-color\"><p>Pullquote custom color</p><cite>my citation</cite></blockquote></figure>\n",
+        "innerContent": [
+            "\n<figure class=\"wp-block-pullquote has-background is-style-default\" style=\"border-color:#2207d0\"><blockquote class=\"has-text-color has-subtle-background-color\"><p>Pullquote custom color</p><cite>my citation</cite></blockquote></figure>\n"
+        ]
+    },
+    {
+        "blockName": null,
+        "attrs": {},
+        "innerBlocks": [],
+        "innerHTML": "\n",
+        "innerContent": [
+            "\n"
+        ]
+    }
+]

--- a/packages/e2e-tests/fixtures/blocks/core__pullquote__main-color.serialized.html
+++ b/packages/e2e-tests/fixtures/blocks/core__pullquote__main-color.serialized.html
@@ -1,0 +1,3 @@
+<!-- wp:pullquote {"customMainColor":"#2207d0","textColor":"subtle-background","className":"has-background is-style-default"} -->
+<figure class="wp-block-pullquote has-background is-style-default" style="border-color:#2207d0"><blockquote class="has-text-color has-subtle-background-color"><p>Pullquote custom color</p><cite>my citation</cite></blockquote></figure>
+<!-- /wp:pullquote -->

--- a/packages/e2e-tests/specs/experimental/__snapshots__/block-transforms.test.js.snap
+++ b/packages/e2e-tests/specs/experimental/__snapshots__/block-transforms.test.js.snap
@@ -456,6 +456,12 @@ exports[`Block transforms correctly transform block Pullquote in fixture core__p
 <!-- /wp:quote -->"
 `;
 
+exports[`Block transforms correctly transform block Pullquote in fixture core__pullquote__main-color into the Quote block 1`] = `
+"<!-- wp:quote -->
+<blockquote class=\\"wp-block-quote\\"><p>Pullquote custom color</p><cite>my citation</cite></blockquote>
+<!-- /wp:quote -->"
+`;
+
 exports[`Block transforms correctly transform block Pullquote in fixture core__pullquote__multi-paragraph into the Quote block 1`] = `
 "<!-- wp:quote -->
 <blockquote class=\\"wp-block-quote\\"><p>Paragraph <strong>one</strong></p><p>Paragraph two</p><cite>by whomever</cite></blockquote>


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/16429

The color mechanism on pull quotes is complex.
On the default style, the main color sets a border while on the solid color style, it sets a background.
The color mechanism uses a class for preset colors and does not set the color values on the attribute, but for borders, we don't have classes.
Previously we used the color mechanism normally for both styles and on the save function given that for presets colors, we don't have the color value as an attribute we queried the block-editor store settings to retrieve the color value and used the value in a border style.
The implementation is not correct, and it was a wrong decision because the save function becomes impure. Although not correct, It was working without block validation issues in the current WordPress version.
Meanwhile, other changes made this existing problem noticeable, and each time we set a preset color on the pullquote default style, the block becomes invalid.

This PR addresses the problem by on the default style even for preset colors setting the customMainColor attribute, instead of using the default color setting mechanism. This allows the color value to be directly available on the save function, so the function can be pure and depends on its attributes only.

## How has this been tested?
I added a pull-quote block; I wrote some text, and I choose a preset color.
I added another pull-quote block; I wrote some text; I changed the block style to the solid color; I chose a preset color and verified it the editor applied it as a background; I changed the block style back to the default.
I saved the post with the two blocks and reloaded the editor and verified the blocks continue to be valid (on master they are not).
