### PR TITLE
Fix block-mover for images in column block

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -602,6 +602,19 @@
 		}
 	}
 
+	// Full and Wide Image movers inside column blocks
+	.wp-block-columns & {
+		[data-align="full"],
+		[data-align="wide"] {
+			&.is-multi-selected > .block-editor-block-mover,
+			> .block-editor-block-list__block-edit > .block-editor-block-mover {
+				width: 30px;
+				left: -$block-side-ui-width - $block-side-ui-clearance - $block-padding - $border-width - $grid-size;
+				top: -$block-padding - $border-width;
+			}
+		}
+	}
+
 	// Clear floats
 	&[data-clear="true"] {
 		float: none;


### PR DESCRIPTION
## Description
Move block-mover to left side for full or wide images inside column blocks to prevent them overlapping.  Fixes https://github.com/WordPress/gutenberg/issues/18195

## How has this been tested?
- Used the Gutenberg development environment to use WordPress locally
- Tested on Firefox and Chrome at breakpoints 600px and up
- Tested on latest `master` as of 96f7d349
- Made sure that the `full` and `wide` image blocks outside of columns are not impacted

## Screenshots

### Wide Image in a Column block

**Before**
<img width="596" alt="Screen Shot 2019-10-30 at 1 28 20 PM" src="https://user-images.githubusercontent.com/3220162/67896991-b7083280-fb1a-11e9-958b-308307cb0292.png">

**After**
<img width="504" alt="Screen Shot 2019-10-30 at 1 41 25 PM" src="https://user-images.githubusercontent.com/3220162/67897140-03537280-fb1b-11e9-9b13-83c884db16a2.png">

### Full Width Image in a column block:

**Before**
<img width="463" alt="Screen Shot 2019-10-30 at 1 39 53 PM" src="https://user-images.githubusercontent.com/3220162/67897032-d010e380-fb1a-11e9-9b31-1480c3951483.png">

**After**
<img width="499" alt="Screen Shot 2019-10-30 at 1 41 20 PM" src="https://user-images.githubusercontent.com/3220162/67897150-09495380-fb1b-11e9-89fa-5def0688ae2e.png">

## Types of changes
- SCSS changes, introducing new rules for column block wide and full images. 
- Fixes a layout bug

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
