### PR TITLE
Add block navigator to sidebar panel for nav block

### DIFF
--- a/packages/block-library/src/navigation-menu/block-navigation-list.js
+++ b/packages/block-library/src/navigation-menu/block-navigation-list.js
@@ -1,0 +1,40 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	__experimentalBlockNavigationList,
+} from '@wordpress/block-editor';
+import {
+	useSelect,
+	useDispatch,
+} from '@wordpress/data';
+
+export default function BlockNavigationList( { clientId } ) {
+	const {
+		block,
+		selectedBlockClientId,
+	} = useSelect( ( select ) => {
+		const {
+			getSelectedBlockClientId,
+			getBlock,
+		} = select( 'core/block-editor' );
+
+		return {
+			block: getBlock( clientId ),
+			selectedBlockClientId: getSelectedBlockClientId(),
+		};
+	}, [ clientId ] );
+
+	const {
+		selectBlock,
+	} = useDispatch( 'core/block-editor' );
+
+	return (
+		<__experimentalBlockNavigationList
+			blocks={ [ block ] }
+			selectedBlockClientId={ selectedBlockClientId }
+			selectBlock={ selectBlock }
+			showNestedBlocks
+		/>
+	);
+}

--- a/packages/block-library/src/navigation-menu/edit.js
+++ b/packages/block-library/src/navigation-menu/edit.js
@@ -135,7 +135,7 @@ function NavigationMenu( {
 					/>
 				</PanelBody>
 				<PanelBody
-					title={ __( 'Nested Blocks' ) }
+					title={ __( 'Navigation Structure' ) }
 				>
 					<BlockNavigationList clientId={ clientId } />
 				</PanelBody>

--- a/packages/block-library/src/navigation-menu/edit.js
+++ b/packages/block-library/src/navigation-menu/edit.js
@@ -31,6 +31,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import useBlockNavigator from './use-block-navigator';
+import BlockNavigationList from './block-navigation-list';
 import BlockColorsStyleSelector from './block-colors-selector';
 
 function NavigationMenu( {
@@ -132,6 +133,11 @@ function NavigationMenu( {
 						label={ __( 'Automatically add new pages' ) }
 						help={ __( 'Automatically add new top level pages to this menu.' ) }
 					/>
+				</PanelBody>
+				<PanelBody
+					title={ __( 'Nested Blocks' ) }
+				>
+					<BlockNavigationList clientId={ clientId } />
 				</PanelBody>
 			</InspectorControls>
 

--- a/packages/block-library/src/navigation-menu/use-block-navigator.js
+++ b/packages/block-library/src/navigation-menu/use-block-navigator.js
@@ -5,19 +5,17 @@ import {
 	useState,
 } from '@wordpress/element';
 import {
-	useSelect,
-	useDispatch,
-} from '@wordpress/data';
-import {
-	__experimentalBlockNavigationList,
-} from '@wordpress/block-editor';
-import {
 	IconButton,
 	SVG,
 	Path,
 	Modal,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import BlockNavigationList from './block-navigation-list';
 
 const NavigatorIcon = (
 	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20">
@@ -27,25 +25,6 @@ const NavigatorIcon = (
 
 export default function useBlockNavigator( clientId ) {
 	const [ isNavigationListOpen, setIsNavigationListOpen ] = useState( false );
-
-	const {
-		block,
-		selectedBlockClientId,
-	} = useSelect( ( select ) => {
-		const {
-			getSelectedBlockClientId,
-			getBlock,
-		} = select( 'core/block-editor' );
-
-		return {
-			block: getBlock( clientId ),
-			selectedBlockClientId: getSelectedBlockClientId(),
-		};
-	}, [ clientId ] );
-
-	const {
-		selectBlock,
-	} = useDispatch( 'core/block-editor' );
 
 	const navigatorToolbarButton = (
 		<IconButton
@@ -64,12 +43,7 @@ export default function useBlockNavigator( clientId ) {
 				setIsNavigationListOpen( false );
 			} }
 		>
-			<__experimentalBlockNavigationList
-				blocks={ [ block ] }
-				selectedBlockClientId={ selectedBlockClientId }
-				selectBlock={ selectBlock }
-				showNestedBlocks
-			/>
+			<BlockNavigationList clientId={ clientId } />
 		</Modal>
 	);
 


### PR DESCRIPTION
## Description
Closes #18190

Adds the navigator to the block sidebar panel

## How has this been tested?
1. Add a Navigation Block
2. Add some menu items
3. Check the sidebar of the Navigation Block
4. Expect to see the Block Navigator
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->
![Screen Shot 2019-10-31 at 3 21 21 pm](https://user-images.githubusercontent.com/677833/67926924-45031c80-fbf2-11e9-8ce6-df1eb9995d07.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
