### PR TITLE
WIP: Try/navigator in sidebar for nav and menu items

### DIFF
--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -16,6 +16,7 @@ import { withSelect } from '@wordpress/data';
  */
 import SkipToSelectedBlock from '../skip-to-selected-block';
 import BlockCard from '../block-card';
+import ParentInspectorControls from '../parent-inspector-controls';
 import InspectorControls from '../inspector-controls';
 import InspectorAdvancedControls from '../inspector-advanced-controls';
 import BlockStyles from '../block-styles';
@@ -66,7 +67,10 @@ const BlockInspector = ( {
 					</PanelBody>
 				</div>
 			) }
-			<div><InspectorControls.Slot /></div>
+			<div>
+				<ParentInspectorControls.Slot />
+				<InspectorControls.Slot />
+			</div>
 			<div>
 				<InspectorAdvancedControls.Slot>
 					{ ( fills ) => ! isEmpty( fills ) && (

--- a/packages/block-editor/src/components/block-navigation/navigator.js
+++ b/packages/block-editor/src/components/block-navigation/navigator.js
@@ -1,0 +1,3 @@
+export default function BlockNavigator() {
+	return "I'm the navigator.";
+}

--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -26,6 +26,7 @@ export { default as __experimentalGradientPickerPanel } from './gradient-picker/
 export { default as InnerBlocks } from './inner-blocks';
 export { default as InspectorAdvancedControls } from './inspector-advanced-controls';
 export { default as InspectorControls } from './inspector-controls';
+export { default as __experimentalParentInspectorControls } from './parent-inspector-controls';
 export { default as __experimentalLinkControl } from './link-control';
 export { default as MediaPlaceholder } from './media-placeholder';
 export { default as MediaUpload } from './media-upload';

--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -15,6 +15,7 @@ export { default as BlockFormatControls } from './block-format-controls';
 export { default as BlockIcon } from './block-icon';
 export { default as BlockNavigationDropdown } from './block-navigation/dropdown';
 export { default as __experimentalBlockNavigationList } from './block-navigation/list';
+export { default as __experimentalBlockNavigator } from './block-navigation/navigator';
 export { default as BlockVerticalAlignmentToolbar } from './block-vertical-alignment-toolbar';
 export { default as ButtonBlockerAppender } from './button-block-appender';
 export { default as ColorPalette } from './color-palette';

--- a/packages/block-editor/src/components/parent-inspector-controls/index.js
+++ b/packages/block-editor/src/components/parent-inspector-controls/index.js
@@ -1,0 +1,39 @@
+/**
+ * WordPress dependencies
+ */
+import { createSlotFill } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { withBlockEditContext } from '../block-edit/context';
+
+const { Fill, Slot } = createSlotFill( 'ParentInspectorControls' );
+
+function mapBlockEditContext( { clientId, isSelected } ) {
+	return { clientId, isSelected };
+}
+
+function EnhancedFill( props ) {
+	const { clientId, isSelected } = props;
+
+	const hasSelectedInnerBlock = useSelect( ( select ) => {
+		const searchDeep = true;
+		return select( 'core/block-editor' ).hasSelectedInnerBlock( clientId, searchDeep );
+	}, [ clientId ] );
+
+	if ( ! hasSelectedInnerBlock && ! isSelected ) {
+		return null;
+	}
+
+	return (
+		<Fill { ...props } />
+	);
+}
+
+const ParentInspectorControls = withBlockEditContext( mapBlockEditContext )( EnhancedFill );
+
+ParentInspectorControls.Slot = Slot;
+
+export default ParentInspectorControls;

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -446,6 +446,26 @@ export const getBlockParents = createSelector(
 );
 
 /**
+ * Given a block client ID, find the closest parent with the given name.
+ *
+ * @param {Object} state    Editor state.
+ * @param {string} clientId Block from which to find root client ID.
+ * @param {string} name     The name of the block to find.
+ *
+ * @return {?Object} Block type of the parent if one exists
+ */
+export function __experimentalGetClosestParentWithName( state, clientId, name ) {
+	let current = clientId;
+	do {
+		current = state.blocks.parents[ current ];
+	} while ( current && state.blocks.byClientId[ current ].name !== name );
+
+	if ( current !== clientId ) {
+		return current;
+	}
+}
+
+/**
  * Given a block client ID, returns the root of the hierarchy from which the block is nested, return the block itself for root level blocks.
  *
  * @param {Object} state    Editor state.

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -446,26 +446,6 @@ export const getBlockParents = createSelector(
 );
 
 /**
- * Given a block client ID, find the closest parent with the given name.
- *
- * @param {Object} state    Editor state.
- * @param {string} clientId Block from which to find root client ID.
- * @param {string} name     The name of the block to find.
- *
- * @return {?Object} Block type of the parent if one exists
- */
-export function __experimentalGetClosestParentWithName( state, clientId, name ) {
-	let current = clientId;
-	do {
-		current = state.blocks.parents[ current ];
-	} while ( current && state.blocks.byClientId[ current ].name !== name );
-
-	if ( current !== clientId ) {
-		return current;
-	}
-}
-
-/**
  * Given a block client ID, returns the root of the hierarchy from which the block is nested, return the block itself for root level blocks.
  *
  * @param {Object} state    Editor state.

--- a/packages/block-library/src/navigation-menu-item/edit.js
+++ b/packages/block-library/src/navigation-menu-item/edit.js
@@ -42,6 +42,11 @@ import {
 	useState,
 } from '@wordpress/element';
 
+/**
+ * Internal dependencies
+ */
+import BlockNavigationList from '../navigation-menu/block-navigation-list';
+
 function NavigationMenuItemEdit( {
 	attributes,
 	hasDescendants,
@@ -49,6 +54,7 @@ function NavigationMenuItemEdit( {
 	isParentOfSelectedBlock,
 	setAttributes,
 	insertMenuItemBlock,
+	parentNavigationClientId,
 } ) {
 	const [ isLinkOpen, setIsLinkOpen ] = useState( false );
 	const [ isEditingLink, setIsEditingLink ] = useState( false );
@@ -132,6 +138,11 @@ function NavigationMenuItemEdit( {
 			</BlockControls>
 			<InspectorControls>
 				<PanelBody
+					title={ __( 'Navigation Structure' ) }
+				>
+					<BlockNavigationList clientId={ parentNavigationClientId } />
+				</PanelBody>
+				<PanelBody
 					title={ __( 'Menu Settings' ) }
 				>
 					<ToggleControl
@@ -206,12 +217,17 @@ function NavigationMenuItemEdit( {
 
 export default compose( [
 	withSelect( ( select, ownProps ) => {
-		const { getClientIdsOfDescendants, hasSelectedInnerBlock } = select( 'core/block-editor' );
+		const {
+			getClientIdsOfDescendants,
+			hasSelectedInnerBlock,
+			__experimentalGetClosestParentWithName: getClosestParentWithName,
+		} = select( 'core/block-editor' );
 		const { clientId } = ownProps;
 
 		return {
 			isParentOfSelectedBlock: hasSelectedInnerBlock( clientId, true ),
 			hasDescendants: !! getClientIdsOfDescendants( [ clientId ] ).length,
+			parentNavigationClientId: getClosestParentWithName( clientId, 'core/navigation-menu' ),
 		};
 	} ),
 	withDispatch( ( dispatch, ownProps ) => {

--- a/packages/block-library/src/navigation-menu-item/edit.js
+++ b/packages/block-library/src/navigation-menu-item/edit.js
@@ -42,11 +42,6 @@ import {
 	useState,
 } from '@wordpress/element';
 
-/**
- * Internal dependencies
- */
-import BlockNavigationList from '../navigation-menu/block-navigation-list';
-
 function NavigationMenuItemEdit( {
 	attributes,
 	hasDescendants,
@@ -54,7 +49,6 @@ function NavigationMenuItemEdit( {
 	isParentOfSelectedBlock,
 	setAttributes,
 	insertMenuItemBlock,
-	parentNavigationClientId,
 } ) {
 	const [ isLinkOpen, setIsLinkOpen ] = useState( false );
 	const [ isEditingLink, setIsEditingLink ] = useState( false );
@@ -138,11 +132,6 @@ function NavigationMenuItemEdit( {
 			</BlockControls>
 			<InspectorControls>
 				<PanelBody
-					title={ __( 'Navigation Structure' ) }
-				>
-					<BlockNavigationList clientId={ parentNavigationClientId } />
-				</PanelBody>
-				<PanelBody
 					title={ __( 'Menu Settings' ) }
 				>
 					<ToggleControl
@@ -220,14 +209,12 @@ export default compose( [
 		const {
 			getClientIdsOfDescendants,
 			hasSelectedInnerBlock,
-			__experimentalGetClosestParentWithName: getClosestParentWithName,
 		} = select( 'core/block-editor' );
 		const { clientId } = ownProps;
 
 		return {
 			isParentOfSelectedBlock: hasSelectedInnerBlock( clientId, true ),
 			hasDescendants: !! getClientIdsOfDescendants( [ clientId ] ).length,
-			parentNavigationClientId: getClosestParentWithName( clientId, 'core/navigation-menu' ),
 		};
 	} ),
 	withDispatch( ( dispatch, ownProps ) => {

--- a/packages/block-library/src/navigation-menu/edit.js
+++ b/packages/block-library/src/navigation-menu/edit.js
@@ -15,6 +15,7 @@ import {
 	InspectorControls,
 	BlockControls,
 	withColors,
+	__experimentalParentInspectorControls as ParentInspectorControls,
 } from '@wordpress/block-editor';
 import { withSelect } from '@wordpress/data';
 import {
@@ -123,12 +124,14 @@ function NavigationMenu( {
 				/>
 			</BlockControls>
 			{ navigatorModal }
-			<InspectorControls>
+			<ParentInspectorControls>
 				<PanelBody
 					title={ __( 'Navigation Structure' ) }
 				>
 					<BlockNavigationList clientId={ clientId } />
 				</PanelBody>
+			</ParentInspectorControls>
+			<InspectorControls>
 				<PanelBody
 					title={ __( 'Menu Settings' ) }
 				>

--- a/packages/block-library/src/navigation-menu/edit.js
+++ b/packages/block-library/src/navigation-menu/edit.js
@@ -125,6 +125,11 @@ function NavigationMenu( {
 			{ navigatorModal }
 			<InspectorControls>
 				<PanelBody
+					title={ __( 'Navigation Structure' ) }
+				>
+					<BlockNavigationList clientId={ clientId } />
+				</PanelBody>
+				<PanelBody
 					title={ __( 'Menu Settings' ) }
 				>
 					<CheckboxControl
@@ -133,11 +138,6 @@ function NavigationMenu( {
 						label={ __( 'Automatically add new pages' ) }
 						help={ __( 'Automatically add new top level pages to this menu.' ) }
 					/>
-				</PanelBody>
-				<PanelBody
-					title={ __( 'Navigation Structure' ) }
-				>
-					<BlockNavigationList clientId={ clientId } />
 				</PanelBody>
 			</InspectorControls>
 

--- a/packages/edit-post/src/components/sidebar/settings-header/index.js
+++ b/packages/edit-post/src/components/sidebar/settings-header/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -9,19 +14,33 @@ import { withDispatch } from '@wordpress/data';
  */
 import SidebarHeader from '../sidebar-header';
 
-const SettingsHeader = ( { openDocumentSettings, openBlockSettings, sidebarName } ) => {
-	const blockLabel = __( 'Block' );
-	const [ documentAriaLabel, documentActiveClass ] = sidebarName === 'edit-post/document' ?
-		// translators: ARIA label for the Document sidebar tab, selected.
-		[ __( 'Document (selected)' ), 'is-active' ] :
-		// translators: ARIA label for the Document sidebar tab, not selected.
-		[ __( 'Document' ), '' ];
-
-	const [ blockAriaLabel, blockActiveClass ] = sidebarName === 'edit-post/block' ?
-		// translators: ARIA label for the Settings Sidebar tab, selected.
-		[ __( 'Block (selected)' ), 'is-active' ] :
-		// translators: ARIA label for the Settings Sidebar tab, not selected.
-		[ __( 'Block' ), '' ];
+const SettingsHeader = ( { openDocumentSettings, openBlockSettings, openNavigator, sidebarName } ) => {
+	const headerButtons = [
+		{
+			name: 'edit-post/document',
+			// translators: ARIA label for the Document sidebar tab, not selected.
+			label: __( 'Document' ),
+			// translators: ARIA label for the Document sidebar tab, selected.
+			activeLabel: __( 'Document (selected)' ),
+			onClick: openDocumentSettings,
+		},
+		{
+			name: 'edit-post/block',
+			// translators: ARIA label for the Settings Sidebar tab, not selected.
+			label: __( 'Block' ),
+			// translators: ARIA label for the Settings Sidebar tab, selected.
+			activeLabel: __( 'Block (selected)' ),
+			onClick: openBlockSettings,
+		},
+		{
+			name: 'edit-post/navigator',
+			// translators: ARIA label for the Settings Sidebar tab, not selected.
+			label: __( 'Navigator' ),
+			// translators: ARIA label for the Settings Sidebar tab, selected.
+			activeLabel: __( 'Navigator (selected)' ),
+			onClick: openNavigator,
+		},
+	];
 
 	return (
 		<SidebarHeader
@@ -30,26 +49,24 @@ const SettingsHeader = ( { openDocumentSettings, openBlockSettings, sidebarName 
 		>
 			{ /* Use a list so screen readers will announce how many tabs there are. */ }
 			<ul>
-				<li>
-					<button
-						onClick={ openDocumentSettings }
-						className={ `edit-post-sidebar__panel-tab ${ documentActiveClass }` }
-						aria-label={ documentAriaLabel }
-						data-label={ __( 'Document' ) }
-					>
-						{ __( 'Document' ) }
-					</button>
-				</li>
-				<li>
-					<button
-						onClick={ openBlockSettings }
-						className={ `edit-post-sidebar__panel-tab ${ blockActiveClass }` }
-						aria-label={ blockAriaLabel }
-						data-label={ blockLabel }
-					>
-						{ blockLabel }
-					</button>
-				</li>
+				{ headerButtons.map( ( { name, label, activeLabel, onClick } ) => {
+					const isActive = name === sidebarName;
+
+					return (
+						<li key={ name }>
+							<button
+								onClick={ onClick }
+								className={ classnames( 'edit-post-sidebar__panel-tab', {
+									'is-active': isActive,
+								} ) }
+								aria-label={ isActive ? activeLabel : label }
+								data-label={ label }
+							>
+								{ label }
+							</button>
+						</li>
+					);
+				} ) }
 			</ul>
 		</SidebarHeader>
 	);
@@ -65,6 +82,9 @@ export default withDispatch( ( dispatch ) => {
 		},
 		openBlockSettings() {
 			openGeneralSidebar( 'edit-post/block' );
+		},
+		openNavigator() {
+			openGeneralSidebar( 'edit-post/block-navigator' );
 		},
 	};
 } )( SettingsHeader );

--- a/packages/edit-post/src/components/sidebar/settings-sidebar/index.js
+++ b/packages/edit-post/src/components/sidebar/settings-sidebar/index.js
@@ -4,7 +4,10 @@
 import { Panel } from '@wordpress/components';
 import { compose, ifCondition } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
-import { BlockInspector } from '@wordpress/block-editor';
+import {
+	BlockInspector,
+	__experimentalBlockNavigator as BlockNavigator,
+} from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
@@ -45,6 +48,9 @@ const SettingsSidebar = ( { sidebarName } ) => (
 			) }
 			{ sidebarName === 'edit-post/block' && (
 				<BlockInspector />
+			) }
+			{ sidebarName === 'edit-post/block-navigator' && (
+				<BlockNavigator />
 			) }
 		</Panel>
 	</Sidebar>

--- a/packages/edit-post/src/store/selectors.js
+++ b/packages/edit-post/src/store/selectors.js
@@ -25,7 +25,11 @@ export function getEditorMode( state ) {
 export function isEditorSidebarOpened( state ) {
 	const activeGeneralSidebar = getActiveGeneralSidebarName( state );
 
-	return includes( [ 'edit-post/document', 'edit-post/block' ], activeGeneralSidebar );
+	return includes( [
+		'edit-post/document',
+		'edit-post/block',
+		'edit-post/block-navigator',
+	], activeGeneralSidebar );
 }
 
 /**


### PR DESCRIPTION
## Description
Experiment to test the Block Navigator in the sidebars of both the Navigation Menu and Menu Item blocks.

This has been done in a very hacky way, it's just a proof of concept right now, not meant to be code reviewed.

This is an iteration from https://github.com/WordPress/gutenberg/pull/18202

## Screenshots <!-- if applicable -->
![navigator-sidebar](https://user-images.githubusercontent.com/677833/67936462-cd8bb800-fc06-11e9-8f18-9b3f461f523f.gif)

