### PR TITLE
Fix function name (camel case)

### DIFF
--- a/docs/designers-developers/developers/block-api/block-registration.md
+++ b/docs/designers-developers/developers/block-api/block-registration.md
@@ -1,6 +1,6 @@
 # Block Registration
 
-## `register_block_type`
+## `registerBlockType`
 
 * **Type:** `Function`
 


### PR DESCRIPTION
## Description
Fix function name: was `register_block_type`, is now `registerBlockType`.