### PR TITLE
Testing: Upgrade puppeteer to v2.0 to fix the broken interactive mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7851,7 +7851,7 @@
 				"lodash": "^4.17.15",
 				"minimist": "^1.2.0",
 				"npm-package-json-lint": "^4.0.3",
-				"puppeteer": "^1.20.0",
+				"puppeteer": "^2.0.0",
 				"read-pkg-up": "^1.0.1",
 				"request": "^2.88.0",
 				"resolve-bin": "^0.4.0",
@@ -8854,9 +8854,9 @@
 			"dev": true
 		},
 		"axe-core": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.1.2.tgz",
-			"integrity": "sha512-e1WVs0SQu3tM29J9a/mISGvlo2kdCStE+yffIAJF6eb42FS+eUFEVz9j4rgDeV2TAfPJmuOZdRetWYycIbK7Vg==",
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.4.0.tgz",
+			"integrity": "sha512-5C0OdgxPv/DrQguO6Taj5F1dY5OlkWg4SVmZIVABFYKWlnAc5WTLPzG+xJSgIwf2fmY+NiNGiZXhXx2qT0u/9Q==",
 			"dev": true
 		},
 		"axe-puppeteer": {
@@ -15276,6 +15276,15 @@
 				}
 			}
 		},
+		"expand-tilde": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
+			"integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
+			"dev": true,
+			"requires": {
+				"os-homedir": "^1.0.1"
+			}
+		},
 		"expect": {
 			"version": "24.7.1",
 			"resolved": "https://registry.npmjs.org/expect/-/expect-24.7.1.tgz",
@@ -15860,55 +15869,6 @@
 			"requires": {
 				"fs-exists-sync": "^0.1.0",
 				"resolve-dir": "^0.1.0"
-			},
-			"dependencies": {
-				"expand-tilde": {
-					"version": "1.2.2",
-					"resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
-					"integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
-					"dev": true,
-					"requires": {
-						"os-homedir": "^1.0.1"
-					}
-				},
-				"global-modules": {
-					"version": "0.2.3",
-					"resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
-					"integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
-					"dev": true,
-					"requires": {
-						"global-prefix": "^0.1.4",
-						"is-windows": "^0.2.0"
-					}
-				},
-				"global-prefix": {
-					"version": "0.1.5",
-					"resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
-					"integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
-					"dev": true,
-					"requires": {
-						"homedir-polyfill": "^1.0.0",
-						"ini": "^1.3.4",
-						"is-windows": "^0.2.0",
-						"which": "^1.2.12"
-					}
-				},
-				"is-windows": {
-					"version": "0.2.0",
-					"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
-					"integrity": "sha1-3hqm1j6indJIc3tp8f+LgALSEIw=",
-					"dev": true
-				},
-				"resolve-dir": {
-					"version": "0.1.1",
-					"resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
-					"integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
-					"dev": true,
-					"requires": {
-						"expand-tilde": "^1.2.2",
-						"global-modules": "^0.2.3"
-					}
-				}
 			}
 		},
 		"find-parent-dir": {
@@ -17731,9 +17691,9 @@
 			"integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
 		},
 		"homedir-polyfill": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
-			"integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
+			"integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
 			"dev": true,
 			"requires": {
 				"parse-passwd": "^1.0.0"
@@ -19789,26 +19749,27 @@
 				"wait-on": "^3.3.0"
 			},
 			"dependencies": {
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
+				"kleur": {
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+					"integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+					"dev": true
 				},
 				"prompts": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.1.0.tgz",
-					"integrity": "sha512-+x5TozgqYdOwWsQFZizE/Tra3fKvAoy037kOyU6cgz84n8f6zxngLOV4O32kTwt9FcLCxAqw0P/c8rOr9y+Gfg==",
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.2.1.tgz",
+					"integrity": "sha512-VObPvJiWPhpZI6C5m60XOzTfnYg/xc/an+r9VYymj9WJW3B/DIH+REzjpAACPf8brwPeP+7vz3bIim3S+AaMjw==",
 					"dev": true,
 					"requires": {
-						"kleur": "^3.0.2",
-						"sisteransi": "^1.0.0"
+						"kleur": "^3.0.3",
+						"sisteransi": "^1.0.3"
 					}
+				},
+				"sisteransi": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.3.tgz",
+					"integrity": "sha512-SbEG75TzH8G7eVXFSN5f9EExILKfly7SUvVY5DhhYLvfhKqhDFY0OzevWa/zwak0RLRfWS5AvfMWpd9gJvr5Yg==",
+					"dev": true
 				},
 				"tree-kill": {
 					"version": "1.2.1",
@@ -19897,19 +19858,6 @@
 				"cwd": "^0.10.0",
 				"jest-dev-server": "^4.3.0",
 				"merge-deep": "^3.0.2"
-			},
-			"dependencies": {
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				}
 			}
 		},
 		"jest-get-type": {
@@ -27057,14 +27005,14 @@
 			"dev": true
 		},
 		"puppeteer": {
-			"version": "1.20.0",
-			"resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.20.0.tgz",
-			"integrity": "sha512-bt48RDBy2eIwZPrkgbcwHtb51mj2nKvHOPMaSH2IsWiv7lOG9k9zhaRzpDZafrk05ajMc3cu+lSQYYOfH2DkVQ==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-2.0.0.tgz",
+			"integrity": "sha512-t3MmTWzQxPRP71teU6l0jX47PHXlc4Z52sQv4LJQSZLq1ttkKS2yGM3gaI57uQwZkNaoGd0+HPPMELZkcyhlqA==",
 			"dev": true,
 			"requires": {
 				"debug": "^4.1.0",
 				"extract-zip": "^1.6.6",
-				"https-proxy-agent": "^2.2.1",
+				"https-proxy-agent": "^3.0.0",
 				"mime": "^2.0.3",
 				"progress": "^2.0.1",
 				"proxy-from-env": "^1.0.0",
@@ -27079,6 +27027,27 @@
 					"dev": true,
 					"requires": {
 						"ms": "^2.1.1"
+					}
+				},
+				"https-proxy-agent": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-3.0.1.tgz",
+					"integrity": "sha512-+ML2Rbh6DAuee7d07tYGEKOEi2voWPUGan+ExdPbPW6Z3svq+JCqr0v8WmKPOkz1vOVykPCBSuobe7G8GJUtVg==",
+					"dev": true,
+					"requires": {
+						"agent-base": "^4.3.0",
+						"debug": "^3.1.0"
+					},
+					"dependencies": {
+						"debug": {
+							"version": "3.2.6",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+							"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+							"dev": true,
+							"requires": {
+								"ms": "^2.1.1"
+							}
+						}
 					}
 				},
 				"ms": {
@@ -29363,6 +29332,46 @@
 			"dev": true,
 			"requires": {
 				"resolve-from": "^3.0.0"
+			}
+		},
+		"resolve-dir": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
+			"integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
+			"dev": true,
+			"requires": {
+				"expand-tilde": "^1.2.2",
+				"global-modules": "^0.2.3"
+			},
+			"dependencies": {
+				"global-modules": {
+					"version": "0.2.3",
+					"resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
+					"integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
+					"dev": true,
+					"requires": {
+						"global-prefix": "^0.1.4",
+						"is-windows": "^0.2.0"
+					}
+				},
+				"global-prefix": {
+					"version": "0.1.5",
+					"resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
+					"integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
+					"dev": true,
+					"requires": {
+						"homedir-polyfill": "^1.0.0",
+						"ini": "^1.3.4",
+						"is-windows": "^0.2.0",
+						"which": "^1.2.12"
+					}
+				},
+				"is-windows": {
+					"version": "0.2.0",
+					"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
+					"integrity": "sha1-3hqm1j6indJIc3tp8f+LgALSEIw=",
+					"dev": true
+				}
 			}
 		},
 		"resolve-from": {
@@ -33560,106 +33569,11 @@
 				"rx": "^4.1.0"
 			},
 			"dependencies": {
-				"ajv": {
-					"version": "6.10.2",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
-					"integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
-					"dev": true,
-					"requires": {
-						"fast-deep-equal": "^2.0.1",
-						"fast-json-stable-stringify": "^2.0.0",
-						"json-schema-traverse": "^0.4.1",
-						"uri-js": "^4.2.2"
-					}
-				},
-				"aws4": {
-					"version": "1.8.0",
-					"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-					"integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
-					"dev": true
-				},
 				"core-js": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
-					"integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==",
+					"version": "2.6.10",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
+					"integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA==",
 					"dev": true
-				},
-				"extend": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-					"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-					"dev": true
-				},
-				"fast-deep-equal": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-					"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-					"dev": true
-				},
-				"har-validator": {
-					"version": "5.1.3",
-					"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-					"integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
-					"dev": true,
-					"requires": {
-						"ajv": "^6.5.5",
-						"har-schema": "^2.0.0"
-					}
-				},
-				"json-schema-traverse": {
-					"version": "0.4.1",
-					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-					"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-					"dev": true
-				},
-				"mime-db": {
-					"version": "1.40.0",
-					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
-					"integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
-					"dev": true
-				},
-				"mime-types": {
-					"version": "2.1.24",
-					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
-					"integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
-					"dev": true,
-					"requires": {
-						"mime-db": "1.40.0"
-					}
-				},
-				"oauth-sign": {
-					"version": "0.9.0",
-					"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-					"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-					"dev": true
-				},
-				"request": {
-					"version": "2.88.0",
-					"resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-					"integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
-					"dev": true,
-					"requires": {
-						"aws-sign2": "~0.7.0",
-						"aws4": "^1.8.0",
-						"caseless": "~0.12.0",
-						"combined-stream": "~1.0.6",
-						"extend": "~3.0.2",
-						"forever-agent": "~0.6.1",
-						"form-data": "~2.3.2",
-						"har-validator": "~5.1.0",
-						"http-signature": "~1.2.0",
-						"is-typedarray": "~1.0.0",
-						"isstream": "~0.1.2",
-						"json-stringify-safe": "~5.0.1",
-						"mime-types": "~2.1.19",
-						"oauth-sign": "~0.9.0",
-						"performance-now": "^2.1.0",
-						"qs": "~6.5.2",
-						"safe-buffer": "^5.1.2",
-						"tough-cookie": "~2.4.3",
-						"tunnel-agent": "^0.6.0",
-						"uuid": "^3.3.2"
-					}
 				},
 				"rx": {
 					"version": "4.1.0",
@@ -33670,63 +33584,35 @@
 			}
 		},
 		"wait-port": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/wait-port/-/wait-port-0.2.2.tgz",
-			"integrity": "sha1-1RpJHkhKF791qUfnEaLwErTm8uM=",
+			"version": "0.2.6",
+			"resolved": "https://registry.npmjs.org/wait-port/-/wait-port-0.2.6.tgz",
+			"integrity": "sha512-nXE5Yp0Zs1obhFVc0Da7WVJc3y0LxoCq3j4mtV0NdI5P/ZvRdKp5yhuojvMOcOxSwpQL1hGbOgMNQ+4wpRpwCA==",
 			"dev": true,
 			"requires": {
-				"chalk": "^1.1.3",
-				"commander": "^2.9.0",
-				"debug": "^2.6.6"
+				"chalk": "^2.4.2",
+				"commander": "^3.0.2",
+				"debug": "^4.1.1"
 			},
 			"dependencies": {
-				"ansi-regex": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+				"commander": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
+					"integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow==",
 					"dev": true
-				},
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-					"dev": true
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
-					}
 				},
 				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
 					"dev": true,
 					"requires": {
-						"ms": "2.0.0"
+						"ms": "^2.1.1"
 					}
 				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
-				},
-				"supports-color": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 					"dev": true
 				}
 			}

--- a/packages/e2e-tests/config/setup-test-framework.js
+++ b/packages/e2e-tests/config/setup-test-framework.js
@@ -182,6 +182,8 @@ async function runAxeTestsForBlockEditor() {
 		// See: https://github.com/WordPress/gutenberg/pull/15018.
 		disabledRules: [
 			'aria-allowed-role',
+			'aria-hidden-focus',
+			'aria-input-field-name',
 			'aria-valid-attr-value',
 			'button-name',
 			'color-contrast',

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -3,10 +3,7 @@
 ### Breaking Changes
 
 - The bundled `npm-package-json-lint` dependency has been updated from requiring `^3.6.0` to requiring `^4.0.3` ([#18054](https://github.com/WordPress/gutenberg/pull/18054)). Please see the [migration guide](https://npmpackagejsonlint.org/docs/en/v3-to-v4). Note: `npmPackageJsonLintConfig` prop in the `package.json` file needs to be renamed to `npmpackagejsonlint`.
-
-### New Features
-
-- The bundled `puppeteer` dependency has been updated from requiring `^1.19.0` to requiring `^1.20.0` ([#18054](https://github.com/WordPress/gutenberg/pull/18054)). It uses Chromium v78 instead of Chromium v77.
+- The bundled `puppeteer` dependency has been updated from requiring `^1.19.0` to requiring `^2.0.0` ([#18205](https://github.com/WordPress/gutenberg/pull/18205)). It uses Chromium v79 instead of Chromium v77. See the [full list of changes](https://github.com/GoogleChrome/puppeteer/releases/tag/v2.0.0).
 
 ## 5.1.0
 

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -51,7 +51,7 @@
 		"lodash": "^4.17.15",
 		"minimist": "^1.2.0",
 		"npm-package-json-lint": "^4.0.3",
-		"puppeteer": "^1.20.0",
+		"puppeteer": "^2.0.0",
 		"read-pkg-up": "^1.0.1",
 		"request": "^2.88.0",
 		"resolve-bin": "^0.4.0",


### PR DESCRIPTION
## Description
Reported by @diegohaz:

> Does anyone know why I can’t run `npm run test-e2e -- --puppeteer-interactive` to see the browser? I always get a `connect ECONNREFUSED 127.0.0.1:<PORT>` error. The Chrome browser opens and closes really fast.

This PR resolves the issues by upgrading the `puppeteer` to the new major version. As usual, new major version produces some warnings during `npm install` but we can't do anything about it since external packages need to update their `package.json` entries.

## How has this been tested?
`npm run test-e2e -- --puppeteer-interactive`

I confirmed it works with the latest version of `puppeteer`.

