### PR TITLE
Update: Default gradients

### DIFF
--- a/packages/block-editor/src/store/defaults.js
+++ b/packages/block-editor/src/store/defaults.js
@@ -161,11 +161,6 @@ export const SETTINGS_DEFAULTS = {
 			slug: 'vivid-cyan-blue-to-vivid-purple',
 		},
 		{
-			name: __( 'Vivid green cyan to vivid cyan blue' ),
-			gradient: 'linear-gradient(135deg,rgba(0,208,132,1) 0%,rgba(6,147,227,1) 100%)',
-			slug: 'vivid-green-cyan-to-vivid-cyan-blue',
-		},
-		{
 			name: __( 'Light green cyan to vivid green cyan' ),
 			gradient: 'linear-gradient(135deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%)',
 			slug: 'light-green-cyan-to-vivid-green-cyan',
@@ -185,7 +180,6 @@ export const SETTINGS_DEFAULTS = {
 			gradient: 'linear-gradient(135deg,rgb(238,238,238) 0%,rgb(169,184,195) 100%)',
 			slug: 'very-light-gray-to-cyan-bluish-gray',
 		},
-		// The following use new, customized colors.
 		{
 			name: __( 'Cool to warm spectrum' ),
 			gradient: 'linear-gradient(135deg,rgb(74,234,220) 0%,rgb(151,120,209) 20%,rgb(207,42,186) 40%,rgb(238,44,130) 60%,rgb(251,105,98) 80%,rgb(254,248,76) 100%)',
@@ -202,19 +196,9 @@ export const SETTINGS_DEFAULTS = {
 			slug: 'blush-bordeaux',
 		},
 		{
-			name: __( 'Purple crush' ),
-			gradient: 'linear-gradient(135deg,rgb(52,226,228) 0%,rgb(71,33,251) 50%,rgb(171,29,254) 100%)',
-			slug: 'purple-crush',
-		},
-		{
 			name: __( 'Luminous dusk' ),
 			gradient: 'linear-gradient(135deg,rgb(255,203,112) 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%)',
 			slug: 'luminous-dusk',
-		},
-		{
-			name: __( 'Hazy dawn' ),
-			gradient: 'linear-gradient(135deg,rgb(250,172,168) 0%,rgb(218,208,236) 100%)',
-			slug: 'hazy-dawn',
 		},
 		{
 			name: __( 'Pale ocean' ),
@@ -225,21 +209,6 @@ export const SETTINGS_DEFAULTS = {
 			name: __( 'Electric grass' ),
 			gradient: 'linear-gradient(135deg,rgb(202,248,128) 0%,rgb(113,206,126) 100%)',
 			slug: 'electric-grass',
-		},
-		{
-			name: __( 'Subdued olive' ),
-			gradient: 'linear-gradient(135deg,rgb(250,250,225) 0%,rgb(103,166,113) 100%)',
-			slug: 'subdued-olive',
-		},
-		{
-			name: __( 'Atomic cream' ),
-			gradient: 'linear-gradient(135deg,rgb(253,215,154) 0%,rgb(0,74,89) 100%)',
-			slug: 'atomic-cream',
-		},
-		{
-			name: __( 'Nightshade' ),
-			gradient: 'linear-gradient(135deg,rgb(51,9,104) 0%,rgb(49,205,207) 100%)',
-			slug: 'nightshade',
 		},
 		{
 			name: __( 'Midnight' ),


### PR DESCRIPTION
## Description
@jasmussen updated the default gradients in https://github.com/WordPress/gutenberg/pull/17603. This change is not directly related to the custom gradients and makes rebasing hard.
I'm extracting this change to a separate PR, so both PR's are easier to review.

## How has this been tested?
I verified the new gradients work as expected on the button and cover block.