### PR TITLE
Fix handling of pasted images and prevent thumbnail uploads

### DIFF
--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -104,14 +104,18 @@ export class ImageEdit extends React.Component {
 			console.warn( 'Attributes has id with no url.' );
 		}
 
+		// Detect any pasted image and start an upload
+		if ( ! attributes.id && attributes.url && attributes.url.indexOf( 'file:' ) === 0 ) {
+			requestMediaImport( attributes.url, ( id, url ) => {
+				if ( url ) {
+					setAttributes( { id, url } );
+				}
+			} );
+		}
+
+		// Make sure we mark any temporary images as failed if they failed while
+		// the editor wasn't open
 		if ( attributes.id && attributes.url && ! isURL( attributes.url ) ) {
-			if ( attributes.url.indexOf( 'file:' ) === 0 ) {
-				requestMediaImport( attributes.url, ( id, url ) => {
-					if ( url ) {
-						setAttributes( { id, url } );
-					}
-				} );
-			}
 			mediaUploadSync();
 		}
 	}

--- a/packages/block-library/src/media-text/media-container.native.js
+++ b/packages/block-library/src/media-text/media-container.native.js
@@ -64,15 +64,9 @@ class MediaContainer extends Component {
 	componentDidMount() {
 		const { mediaId, mediaUrl, onMediaUpdate, mediaType } = this.props;
 
-		if ( mediaId && mediaUrl && ! isURL( mediaUrl ) ) {
-			if ( mediaUrl.indexOf( 'file:' ) === 0 && mediaType === MEDIA_TYPE_IMAGE ) {
-				// We don't want to call this for video because it is starting a media upload for the cover url
-				requestMediaImport( mediaUrl, ( id, url ) => {
-					if ( url ) {
-						onMediaUpdate( { id, url } );
-					}
-				} );
-			}
+		// Make sure we mark any temporary images as failed if they failed while
+		// the editor wasn't open
+		if ( mediaId && mediaUrl && mediaUrl.indexOf( 'file:' ) === 0 && mediaType === MEDIA_TYPE_IMAGE ) {
 			mediaUploadSync();
 		}
 	}

--- a/packages/block-library/src/media-text/media-container.native.js
+++ b/packages/block-library/src/media-text/media-container.native.js
@@ -3,7 +3,6 @@
  */
 import { View, ImageBackground, Text, TouchableWithoutFeedback } from 'react-native';
 import {
-	requestMediaImport,
 	mediaUploadSync,
 	requestImageFailedRetryDialog,
 	requestImageUploadCancelDialog,
@@ -62,7 +61,7 @@ class MediaContainer extends Component {
 	}
 
 	componentDidMount() {
-		const { mediaId, mediaUrl, onMediaUpdate, mediaType } = this.props;
+		const { mediaId, mediaUrl, mediaType } = this.props;
 
 		// Make sure we mark any temporary images as failed if they failed while
 		// the editor wasn't open

--- a/packages/block-library/src/media-text/media-container.native.js
+++ b/packages/block-library/src/media-text/media-container.native.js
@@ -61,11 +61,11 @@ class MediaContainer extends Component {
 	}
 
 	componentDidMount() {
-		const { mediaId, mediaUrl, mediaType } = this.props;
+		const { mediaId, mediaUrl } = this.props;
 
 		// Make sure we mark any temporary images as failed if they failed while
 		// the editor wasn't open
-		if ( mediaId && mediaUrl && mediaUrl.indexOf( 'file:' ) === 0 && mediaType === MEDIA_TYPE_IMAGE ) {
+		if ( mediaId && mediaUrl && mediaUrl.indexOf( 'file:' ) === 0 ) {
 			mediaUploadSync();
 		}
 	}


### PR DESCRIPTION
## Description

The original implementation of image pasting was adding a fake media upload id, then detecting that and a `file:` url on component mount and initiating the upload.

After the consolidation with the web in #17897, it seems we're not setting the id anymore, so the import didn't happen.

On the other hand, this was causing some issues where a thumbnail might end up being uploaded if you closed and opened the editor before the upload was finished.

Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/1510

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
