### PR TITLE
Reverts ColorPalette disableAlpha #18175

### DIFF
--- a/packages/components/src/color-palette/README.md
+++ b/packages/components/src/color-palette/README.md
@@ -50,14 +50,6 @@ Whether the palette should have a clearing button or not.
 - Required: No
 - Default: true
 
-### disableAlpha
-
-Whether to disable alpha channel controls or not.
-
-- Type: `Boolean`
-- Required: No
-- Default: true
-
 
 ## Usage
 ```jsx

--- a/packages/components/src/color-palette/index.js
+++ b/packages/components/src/color-palette/index.js
@@ -19,7 +19,6 @@ export default function ColorPalette( {
 	clearable = true,
 	className,
 	colors,
-	disableAlpha = true,
 	disableCustomColors = false,
 	onChange,
 	value,
@@ -56,7 +55,7 @@ export default function ColorPalette( {
 			<ColorPicker
 				color={ value }
 				onChangeComplete={ ( color ) => onChange( color.hex ) }
-				disableAlpha={ disableAlpha }
+				disableAlpha
 			/>
 		),
 		[ value ]

--- a/packages/components/src/color-palette/stories/index.js
+++ b/packages/components/src/color-palette/stories/index.js
@@ -53,18 +53,3 @@ export const withKnobs = () => {
 		/>
 	);
 };
-
-export const withAlpha = () => {
-	const colors = [
-		object( 'Red', { name: 'red', color: '#f00' } ),
-		object( 'White', { name: 'white', color: '#fff' } ),
-		object( 'Blue', { name: 'blue', color: '#00f' } ),
-	];
-
-	return (
-		<ColorPaletteWithState
-			colors={ colors }
-			disableAlpha={ false }
-		/>
-	);
-};


### PR DESCRIPTION
## Description

Reverts the change made in #18175 introducing the disableAlpha property to pass forward.

@youknowriad raised some good issues since the ColorPalette returns an hex code, that does not accept the alpha parameter it makes the additional feature unusable, or at least setting the channel does not get returned with the parameters. 

The solution is likely to switch to returning rgba syntax if disableAlpha is false, reverting that change so we can address.

## How has this been tested?

Previous state prior to #18175 being enabled.
