### PR TITLE
makes the submenu items stacked vertically

### DIFF
--- a/packages/block-library/src/navigation-menu-item/editor.scss
+++ b/packages/block-library/src/navigation-menu-item/editor.scss
@@ -11,6 +11,11 @@
 .wp-block-navigation-menu-item {
 	margin-right: $grid-size;
 
+	.block-editor-block-list__layout {
+		display: block;
+		margin: $grid-size;
+	}
+
 	// Provide a base menu item margin.
 	// This should be the same inside the field,
 	// and the edit container should compensate.


### PR DESCRIPTION
## Description
Closes #18207 

## How has this been tested?
Tested locally.

## Screenshots <!-- if applicable -->

## Types of changes
A rule that makes the layout container of submenu items display block instead of flex.
