### PR TITLE
Colors Selector: replace `Aa` text by SVG icon

### DIFF
--- a/packages/block-library/src/navigation-menu/block-colors-selector.js
+++ b/packages/block-library/src/navigation-menu/block-colors-selector.js
@@ -7,27 +7,14 @@ import { noop } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { IconButton, Dropdown, Toolbar, SVG } from '@wordpress/components';
+import { IconButton, Dropdown, Toolbar, SVG, Path } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { DOWN } from '@wordpress/keycodes';
 import { ColorPaletteControl, ContrastChecker } from '@wordpress/block-editor';
 
 const ColorSelectorSVGIcon = () => (
-	<SVG
-		xmlns="http://www.w3.org/2000/svg"
-		viewBox="0 0 20 20"
-	>
-		<text
-			transform="translate(-63 -14)"
-			fillRule="evenodd"
-			fontFamily="SFUIText-Bold, SF UI Text"
-			fontSize="12"
-			fontWeight="bold"
-			letterSpacing="-.5"
-			alignmentBaseline="middle"
-		>
-			<tspan x="63.453" y="23">Aa</tspan>
-		</text>
+	<SVG xmlns="https://www.w3.org/2000/svg" viewBox="0 0 20 20">
+		<Path d="M7.434 5l3.18 9.16H8.538l-.692-2.184H4.628l-.705 2.184H2L5.18 5h2.254zm-1.13 1.904h-.115l-1.148 3.593H7.44L6.304 6.904zM14.348 7.006c1.853 0 2.9.876 2.9 2.374v4.78h-1.79v-.914h-.114c-.362.64-1.123 1.022-2.031 1.022-1.346 0-2.292-.826-2.292-2.108 0-1.27.972-2.006 2.71-2.107l1.696-.102V9.38c0-.584-.42-.914-1.18-.914-.667 0-1.112.228-1.264.647h-1.701c.12-1.295 1.307-2.107 3.066-2.107zm1.079 4.1l-1.416.09c-.793.056-1.18.342-1.18.844 0 .52.45.837 1.091.837.857 0 1.505-.545 1.505-1.256v-.515z" />
 	</SVG>
 );
 

--- a/packages/block-library/src/navigation-menu/block-colors-selector.js
+++ b/packages/block-library/src/navigation-menu/block-colors-selector.js
@@ -7,12 +7,10 @@ import { noop } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { IconButton, Dropdown, Toolbar } from '@wordpress/components';
+import { IconButton, Dropdown, Toolbar, SVG } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { DOWN } from '@wordpress/keycodes';
 import { ColorPaletteControl, ContrastChecker } from '@wordpress/block-editor';
-import { SVG } from '@wordpress/components';
-
 
 const ColorSelectorSVGIcon = () => (
 	<SVG
@@ -32,7 +30,6 @@ const ColorSelectorSVGIcon = () => (
 		</text>
 	</SVG>
 );
-
 
 /**
  * Color Selector Icon component.

--- a/packages/block-library/src/navigation-menu/block-colors-selector.js
+++ b/packages/block-library/src/navigation-menu/block-colors-selector.js
@@ -11,6 +11,28 @@ import { IconButton, Dropdown, Toolbar } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { DOWN } from '@wordpress/keycodes';
 import { ColorPaletteControl, ContrastChecker } from '@wordpress/block-editor';
+import { SVG } from '@wordpress/components';
+
+
+const ColorSelectorSVGIcon = () => (
+	<SVG
+		xmlns="http://www.w3.org/2000/svg"
+		viewBox="0 0 20 20"
+	>
+		<text
+			transform="translate(-63 -14)"
+			fillRule="evenodd"
+			fontFamily="SFUIText-Bold, SF UI Text"
+			fontSize="12"
+			fontWeight="bold"
+			letterSpacing="-.5"
+			alignmentBaseline="middle"
+		>
+			<tspan x="63.453" y="23">Aa</tspan>
+		</text>
+	</SVG>
+);
+
 
 /**
  * Color Selector Icon component.
@@ -20,10 +42,10 @@ import { ColorPaletteControl, ContrastChecker } from '@wordpress/block-editor';
 const ColorSelectorIcon = ( { style } ) =>
 	<div className="block-library-colors-selector__icon-container">
 		<div
-			className="block-library-colors-selector__state-selection wp-block-navigation-menu-item"
+			className="block-library-colors-selector__state-selection"
 			style={ style }
 		>
-			Aa
+			<ColorSelectorSVGIcon />
 		</div>
 	</div>;
 

--- a/packages/block-library/src/navigation-menu/editor.scss
+++ b/packages/block-library/src/navigation-menu/editor.scss
@@ -122,13 +122,6 @@ $colors-selector-size: 22px;
 		min-height: $colors-selector-size;
 		line-height: ($colors-selector-size - 2);
 
-		// Adjust `Aa` icon position.
-		> svg {
-			position: relative;
-			top: 4px;
-			left: 2px;
-		}
-
 		background-color: var(--background-color-menu-link);
 		color: var(--color-menu-link);
 	}

--- a/packages/block-library/src/navigation-menu/editor.scss
+++ b/packages/block-library/src/navigation-menu/editor.scss
@@ -113,11 +113,6 @@ $colors-selector-size: 22px;
 
 	// colors-selector - selection status.
 	.block-library-colors-selector__state-selection {
-		font-size: 11px;
-		font-style: normal;
-		font-family: inherit;
-		font-weight: 600;
-
 		border-radius: $colors-selector-size / 2;
 		box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.2);
 
@@ -126,6 +121,13 @@ $colors-selector-size: 22px;
 		height: $colors-selector-size;
 		min-height: $colors-selector-size;
 		line-height: ($colors-selector-size - 2);
+
+		// Adjust `Aa` icon position.
+		> svg {
+			position: relative;
+			top: 4px;
+			left: 2px;
+		}
 
 		background-color: var(--background-color-menu-link);
 		color: var(--color-menu-link);

--- a/packages/block-library/src/navigation-menu/editor.scss
+++ b/packages/block-library/src/navigation-menu/editor.scss
@@ -121,6 +121,7 @@ $colors-selector-size: 22px;
 		height: $colors-selector-size;
 		min-height: $colors-selector-size;
 		line-height: ($colors-selector-size - 2);
+		padding: 2px;
 
 		background-color: var(--background-color-menu-link);
 		color: var(--color-menu-link);


### PR DESCRIPTION
## Description
It changes the text used to implement the `Aa` icon of the ColorsSelector component by an SVG icon.

## How has this been tested?
1) Apply this patch
2) Check the toolbar button of the ColorsSelector

## Screenshots <!-- if applicable -->

![image](https://user-images.githubusercontent.com/77539/67989197-c8336b00-fc10-11e9-8463-325ec6e0fa78.png)


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
