### PR TITLE
Remove state from FontSizePicker

### DIFF
--- a/packages/components/src/font-size-picker/index.js
+++ b/packages/components/src/font-size-picker/index.js
@@ -2,7 +2,6 @@
 /**
  * WordPress dependencies
  */
-import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -35,15 +34,12 @@ function FontSizePicker( {
 	value,
 	withSlider = false,
 } ) {
-	const [ currentSelectValue, setCurrentSelectValue ] = useState( getSelectValueFromFontSize( fontSizes, value ) );
-
 	if ( disableCustomFontSizes && ! fontSizes.length ) {
 		return null;
 	}
 
 	const onChangeValue = ( event ) => {
 		const newValue = event.target.value;
-		setCurrentSelectValue( getSelectValueFromFontSize( fontSizes, Number( newValue ) ) );
 		if ( newValue === '' ) {
 			onChange( undefined );
 			return;
@@ -52,7 +48,6 @@ function FontSizePicker( {
 	};
 
 	const onSelectChangeValue = ( eventValue ) => {
-		setCurrentSelectValue( eventValue );
 		const selectedFont = fontSizes.find( ( font ) => font.slug === eventValue );
 		if ( selectedFont ) {
 			onChange( selectedFont.size );
@@ -70,7 +65,7 @@ function FontSizePicker( {
 						className={ 'components-font-size-picker__select' }
 						label={ 'Choose preset' }
 						hideLabelFromVision={ true }
-						value={ currentSelectValue }
+						value={ getSelectValueFromFontSize( fontSizes, value ) }
 						onChange={ onSelectChangeValue }
 						options={ getSelectOptions( fontSizes ) }
 					/>
@@ -88,10 +83,7 @@ function FontSizePicker( {
 					className="components-color-palette__clear"
 					type="button"
 					disabled={ value === undefined }
-					onClick={ () => {
-						onChange( undefined );
-						setCurrentSelectValue( getSelectValueFromFontSize( fontSizes, undefined ) );
-					} }
+					onClick={ () => onChange( undefined ) }
 					isSmall
 					isDefault
 				>


### PR DESCRIPTION
# Description
Fixes #18211 
In `FontSizePicker` changes made via slider or text input weren't reflected in the font size dropdown. 
This was happening because `FontSizePicker`'s font size dropdown was copying selected `value` from props onto state, therefore it was not properly updated when the props changed. By removing the state
and deriving it directly from props in render ensures the Dropdown has up to date `value`.

## How has this been tested?
1. Run Storybook: `npm run design-system:dev` 
2. Go to the `FontSizePicker` section.
3. Select `withSlider`
4. Drag the slider or select font size from input to change font size value.
5. Observe that both select dropdown and input values are updating to reflect slider's value

## Screenshots <!-- if applicable -->
![slide1](https://user-images.githubusercontent.com/8878045/67979805-ba3c1500-fc25-11e9-9180-86ddc934850f.png)
![slide2](https://user-images.githubusercontent.com/8878045/67979815-bc9e6f00-fc25-11e9-9c54-5c2d4bbcf6fd.png)
![slide3](https://user-images.githubusercontent.com/8878045/67979818-be683280-fc25-11e9-8150-c4138da945e1.png)

## Types of changes
Bug fix (non-breaking change which fixes an issue) 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
