### PR TITLE
link-control: implement onEdit mode

### DIFF
--- a/packages/block-editor/src/components/link-control/README.md
+++ b/packages/block-editor/src/components/link-control/README.md
@@ -24,6 +24,20 @@
 
 ## Event handlers
 
+### onChangeMode
+
+- Type: `Function`
+- Required: No
+
+Use this callback to know when the LinkControl component changes its mode to `edit` or `show`
+through of its function parameter.
+
+```es6
+<LinkControl
+	onChangeMode={ ( mode ) => { console.log( `Mode change to ${ mode } mode.` ) }
+/> 
+```  
+
 ### onClose
 
 - Type: `Function`

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -46,6 +46,7 @@ function LinkControl( {
 	fetchSearchSuggestions,
 	instanceId,
 	onClose = noop,
+	onEdit = noop,
 	onKeyDown = noop,
 	onKeyPress = noop,
 	onLinkChange = noop,
@@ -77,9 +78,22 @@ function LinkControl( {
 	};
 
 	// Utils
-	const startEditMode = () => {
-		if ( isFunction( onLinkChange ) ) {
-			onLinkChange();
+
+	/**
+	 * Handler function which turns edit mode ON.
+	 * Also, it calls `onEdit` prop.
+	 */
+	const onEditHandler = () => {
+		setIsEditingLink( true );
+
+		// Populate input searcher whether
+		// the current link has a title.
+		if ( currentLink && currentLink.title ) {
+			setInputValue( currentLink.title );
+		}
+
+		if ( isFunction( onEdit ) ) {
+			onEdit();
 		}
 	};
 
@@ -205,7 +219,7 @@ function LinkControl( {
 									<span className="block-editor-link-control__search-item-info">{ filterURLForDisplay( safeDecodeURI( currentLink.url ) ) || '' }</span>
 								</span>
 
-								<Button isDefault onClick={ startEditMode } className="block-editor-link-control__search-item-action block-editor-link-control__search-item-action--edit">
+								<Button isDefault onClick={ onEditHandler } className="block-editor-link-control__search-item-action block-editor-link-control__search-item-action--edit">
 									{ __( 'Change' ) }
 								</Button>
 							</div>

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -40,7 +40,7 @@ import LinkControlSearchItem from './search-item';
 import LinkControlSearchInput from './search-input';
 
 const MODE_EDIT = 'edit';
-const MODE_SHOW = 'show';
+// const MODE_SHOW = 'show';
 
 function LinkControl( {
 	className,
@@ -85,11 +85,12 @@ function LinkControl( {
 	/**
 	 * Handler function which switches the mode of the component,
 	 * between `edit` and `show` mode.
-	 *
 	 * Also, it calls `onChangeMode` callback function.
+	 *
+	 * @param {string} mode Component mode: `show` or `edit`.
 	 */
 	const setMode = ( mode = 'show' ) => () => {
-		setIsEditingLink( MODE_EDIT === mode  );
+		setIsEditingLink( MODE_EDIT === mode );
 
 		// Populate input searcher whether
 		// the current link has a title.

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -39,6 +39,9 @@ import LinkControlSettingsDrawer from './settings-drawer';
 import LinkControlSearchItem from './search-item';
 import LinkControlSearchInput from './search-input';
 
+const MODE_EDIT = 'edit';
+const MODE_SHOW = 'show';
+
 function LinkControl( {
 	className,
 	currentLink,
@@ -46,7 +49,7 @@ function LinkControl( {
 	fetchSearchSuggestions,
 	instanceId,
 	onClose = noop,
-	onEdit = noop,
+	onChangeMode = noop,
 	onKeyDown = noop,
 	onKeyPress = noop,
 	onLinkChange = noop,
@@ -80,11 +83,13 @@ function LinkControl( {
 	// Utils
 
 	/**
-	 * Handler function which turns edit mode ON.
-	 * Also, it calls `onEdit` prop.
+	 * Handler function which switches the mode of the component,
+	 * between `edit` and `show` mode.
+	 *
+	 * Also, it calls `onChangeMode` callback function.
 	 */
-	const onEditHandler = () => {
-		setIsEditingLink( true );
+	const setMode = ( mode = 'show' ) => () => {
+		setIsEditingLink( MODE_EDIT === mode  );
 
 		// Populate input searcher whether
 		// the current link has a title.
@@ -92,8 +97,8 @@ function LinkControl( {
 			setInputValue( currentLink.title );
 		}
 
-		if ( isFunction( onEdit ) ) {
-			onEdit();
+		if ( isFunction( onChangeMode ) ) {
+			onChangeMode( mode );
 		}
 	};
 
@@ -219,7 +224,7 @@ function LinkControl( {
 									<span className="block-editor-link-control__search-item-info">{ filterURLForDisplay( safeDecodeURI( currentLink.url ) ) || '' }</span>
 								</span>
 
-								<Button isDefault onClick={ onEditHandler } className="block-editor-link-control__search-item-action block-editor-link-control__search-item-action--edit">
+								<Button isDefault onClick={ setMode( MODE_EDIT ) } className="block-editor-link-control__search-item-action block-editor-link-control__search-item-action--edit">
 									{ __( 'Change' ) }
 								</Button>
 							</div>

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -353,7 +353,7 @@ describe( 'Selecting links', () => {
 					currentLink={ link }
 					onLinkChange={ ( suggestion ) => setLink( suggestion ) }
 					fetchSearchSuggestions={ fetchFauxEntitySuggestions }
-					onEdit={ spyOnEditMode }
+					onChangeMode={ spyOnEditMode( 'edit' ) }
 				/>
 			);
 		};

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -15,6 +15,14 @@ import { UP, DOWN, ENTER } from '@wordpress/keycodes';
 import LinkControl from '../index';
 import { fauxEntitySuggestions, fetchFauxEntitySuggestions } from './fixtures';
 
+/**
+ * Wait for next tick of event loop. This is required
+ * because the `fetchSearchSuggestions` Promise will
+ * resolve on the next tick of the event loop (this is
+ * inline with the Promise spec). As a result we need to
+ * wait on this loop to "tick" before we can expect the UI
+ * to have updated.
+ */
 function eventLoopTick() {
 	return new Promise( ( resolve ) => setImmediate( resolve ) );
 }
@@ -333,8 +341,9 @@ describe( 'Selecting links', () => {
 		expect( currentLinkAnchor ).not.toBeNull();
 	} );
 
-	it( 'should remove currently selected link and (re)display search UI when "Change" button is clicked', () => {
+	it( 'should hide "selected" link UI and display search UI prepopulated with previously selected link title when "Change" button is clicked', () => {
 		const selectedLink = first( fauxEntitySuggestions );
+		const spyOnEditMode = jest.fn();
 
 		const LinkControlConsumer = () => {
 			const [ link, setLink ] = useState( selectedLink );
@@ -344,6 +353,7 @@ describe( 'Selecting links', () => {
 					currentLink={ link }
 					onLinkChange={ ( suggestion ) => setLink( suggestion ) }
 					fetchSearchSuggestions={ fetchFauxEntitySuggestions }
+					onEdit={ spyOnEditMode }
 				/>
 			);
 		};
@@ -354,10 +364,9 @@ describe( 'Selecting links', () => {
 			);
 		} );
 
-		// TODO: select by aria role or visible text
-		let currentLink = container.querySelector( '.block-editor-link-control__search-item.is-current' );
-
-		const currentLinkBtn = currentLink.querySelector( 'button' );
+		// Required in order to select the button below
+		let currentLinkUI = container.querySelector( '.block-editor-link-control__search-item.is-current' );
+		const currentLinkBtn = currentLinkUI.querySelector( 'button' );
 
 		// Simulate searching for a term
 		act( () => {
@@ -365,11 +374,13 @@ describe( 'Selecting links', () => {
 		} );
 
 		const searchInput = container.querySelector( 'input[aria-label="URL"]' );
-		currentLink = container.querySelector( '.block-editor-link-control__search-item.is-current' );
+		currentLinkUI = container.querySelector( '.block-editor-link-control__search-item.is-current' );
 
 		// We should be back to showing the search input
 		expect( searchInput ).not.toBeNull();
-		expect( currentLink ).toBeNull();
+		expect( searchInput.value ).toBe( selectedLink.title ); // prepopulated with previous link's title
+		expect( currentLinkUI ).toBeNull();
+		expect( spyOnEditMode ).toHaveBeenCalled();
 	} );
 
 	describe( 'Selection using mouse click', () => {


### PR DESCRIPTION
## Description
It adds the idea of `edit` mode explicitly for the `<LinkControl />` component.

Currently, this component changes its edit mode looking at the changes of `currentLink` property. This approach is used when it selects a new link from the link suggestions, and also when it clicks in the Change button.

The tricky part comes when:

1) want to switch to edit mode
2) populate the searcher input with the `currentLink.title` value

We need to change the `currentLink` to trigger the edit mode, but at the same time, we want to keep the `currentLink` value in order to populate the searcher input with its title.

This PR set the edit mode explicitly and internally, populating the title if it's defined.

## How has this been tested?

It has been tested in this PR: https://github.com/WordPress/gutenberg/pull/18062.

1) Edit a Menu Item
2) Start to edit the link
3) Click on the `Change` button

The searcher input should be populated with the current link title.

## Screenshots <!-- if applicable -->

![link-control-02](https://user-images.githubusercontent.com/77539/67980184-9fa17600-fbfc-11e9-9978-cde490d01bae.gif)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
