### PR TITLE
Lint: Fix warning for Component invalid in VisuallyHidden docstring

### DIFF
--- a/packages/components/src/visually-hidden/utils.js
+++ b/packages/components/src/visually-hidden/utils.js
@@ -9,8 +9,8 @@
  *
  * See VisuallyHidden hidden for example.
  *
- * @param {string|Component} as A tag or component to render.
- * @return {Component} The rendered component.
+ * @param {string|WPComponent} as A tag or component to render.
+ * @return {WPComponent} The rendered component.
  */
 function renderAsRenderProps( { as: Component = 'div', ...props } ) {
 	if ( typeof props.children === 'function' ) {


### PR DESCRIPTION
## Description
The docstring in the utils.js function fo the VisuallyHidden component used `Component` as the parameter and return value, and this giving a lint warning.

This PR rename the docstring from Component to WPComponent.

## How has this been tested?

`npm run lint` confirm Warning is no more.


## Types of changes

No code change, just function docstring.
