### PR TITLE
Fix mover for floats.

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -711,37 +711,6 @@
 	&.is-multi-selected > .block-editor-block-mover {
 		left: -$block-side-ui-width - $block-side-ui-clearance;
 	}
-
-	// For floats, show block mover when block is selected, and never on hover.
-	&[data-align="left"],
-	&[data-align="right"] {
-		// Show always when the block is selected.
-		&.is-selected > .block-editor-block-list__block-edit > .block-editor-block-mover {
-			// Don't show on mobile, allow the special mobile toolbar to work there.
-			display: none;
-			@include break-small() {
-				display: block;
-				opacity: 1;
-				animation: none;
-
-				// Make wider and taller to make "safe" hover area bigger.
-				// The intent is to make it less likely that you hover float-adjacent
-				// blocks that visually appear below the block.
-				width: $block-side-ui-width + $block-side-ui-clearance + $block-padding + $border-width;
-				height: auto;
-				padding-bottom: $block-padding;
-
-				// Unset the negative top margin, or it might overlap the block toolbar.
-				margin-top: 0;
-			}
-		}
-
-		// Don't show on hover, or on the "ghost" when dragging.
-		&.is-hovered > .block-editor-block-list__block-edit > .block-editor-block-mover,
-		&.is-dragging > .block-editor-block-list__block-edit > .block-editor-block-mover {
-			display: none;
-		}
-	}
 }
 
 


### PR DESCRIPTION
Floated images had special rules for the mover control. These are no longer necessary, and indeed created a buggy looking control.

Before:

![Screenshot 2019-11-01 at 10 04 32](https://user-images.githubusercontent.com/1204802/68015881-80095c80-fc93-11e9-8de5-24c0499c293b.png)

After:

![Screenshot 2019-11-01 at 10 34 59](https://user-images.githubusercontent.com/1204802/68015886-81d32000-fc93-11e9-8f77-f7b01fbc1347.png)

There is a little extra margin around the floats, that is not really necessary as you can see — this is due to the lack of block borders around floated images. This can be improved in a separate exploration if need be, but isn't strictly necessary as we are likely to revisit the mover control in the not too distant future. 