### PR TITLE
Enables horizontal movers in social blocks

### DIFF
--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -32,6 +32,7 @@ export const SocialLinksEdit = function( { className } ) {
 				allowedBlocks={ ALLOWED_BLOCKS }
 				templateLock={ false }
 				template={ TEMPLATE }
+				__experimentalMoverDirection={ 'horizontal' }
 			/>
 		</div>
 	);

--- a/packages/block-library/src/social-links/editor.scss
+++ b/packages/block-library/src/social-links/editor.scss
@@ -62,8 +62,7 @@
 	// Hide the mover.
 	// Hide the sibling inserter.
 	.wp-block-social-links .block-editor-block-list__insertion-point,
-	.wp-block-social-links .block-editor-block-list__breadcrumb,
-	.wp-block-social-links .block-editor-block-mover.block-editor-block-mover { // Needs specificity.
+	.wp-block-social-links .block-editor-block-list__breadcrumb { // Needs specificity.
 		display: none;
 	}
 }


### PR DESCRIPTION
## Description
Adds horizontal movers to the Social Icons block.
Because we now have horizontal movers in master.

## Screenshots <!-- if applicable -->
![horizontal-movers-social-icons](https://user-images.githubusercontent.com/107534/68021626-aa1a4900-fcaa-11e9-8074-6bb6bd6b9b9d.gif)

@jasmussen I have updated the GIF above with the current state.
