### PR TITLE
Polish datetime popover.

### DIFF
--- a/packages/components/src/date-time/style.scss
+++ b/packages/components/src/date-time/style.scss
@@ -5,10 +5,10 @@
 /*rtl:end:ignore*/
 
 .components-datetime {
-	padding: $grid-size;
+	padding: $grid-size-large;
 
 	.components-datetime__calendar-help {
-		padding: $grid-size;
+		padding: $grid-size-large;
 
 		h4 {
 			margin: 0;
@@ -18,8 +18,6 @@
 	.components-datetime__date-help-button {
 		display: block;
 		margin-left: auto;
-		margin-right: $grid-size;
-		margin-top: 0.5em;
 	}
 
 	fieldset {
@@ -30,21 +28,33 @@
 
 	select,
 	input {
-		box-sizing: border-box;
-		height: 28px;
-		vertical-align: middle;
-		padding: 0;
 		@include input-style__neutral();
+	}
+
+	// Override inherited conflicting styles to be consistent.
+	select,
+	input[type="number"],
+	.components-button {
+		height: 30px;
+		margin-top: 0;
+		margin-bottom: 0;
 	}
 }
 
 .components-datetime__date {
 	min-height: 236px;
 	border-top: 1px solid $light-gray-500;
-	margin-left: -$grid-size;
-	margin-right: -$grid-size;
 
 	// Override external DatePicker styles.
+	.CalendarMonthGrid {
+		// The included component contains an arbitrary 13px padding that misaligns things.
+		margin-left: -13px;
+	}
+
+	.DayPickerNavigation_leftButton__horizontalDefault {
+		left: 0;
+	}
+
 	.CalendarMonth_caption {
 		font-size: $default-font-size;
 	}
@@ -84,11 +94,15 @@
 }
 
 .components-datetime__time {
-	margin-bottom: 1em;
+	padding-bottom: $grid-size-large;
 
 	fieldset {
-		margin-top: 0.5em;
 		position: relative;
+		margin-bottom: 0.5em;
+	}
+
+	fieldset + fieldset {
+		margin-bottom: 0;
 	}
 
 	.components-datetime__time-field-am-pm fieldset {

--- a/packages/components/src/date-time/style.scss
+++ b/packages/components/src/date-time/style.scss
@@ -5,6 +5,8 @@
 /*rtl:end:ignore*/
 
 .components-datetime {
+	padding: $grid-size;
+
 	.components-datetime__calendar-help {
 		padding: $grid-size;
 

--- a/packages/edit-post/src/components/sidebar/post-schedule/style.scss
+++ b/packages/edit-post/src/components/sidebar/post-schedule/style.scss
@@ -6,11 +6,3 @@
 .components-button.edit-post-post-schedule__toggle {
 	text-align: right;
 }
-
-.edit-post-post-schedule__dialog .components-popover__content {
-	padding: 10px;
-
-	@include break-medium {
-		width: 270px;
-	}
-}

--- a/packages/editor/src/components/post-publish-panel/style.scss
+++ b/packages/editor/src/components/post-publish-panel/style.scss
@@ -79,6 +79,10 @@
 	.editor-post-visibility__dialog-legend {
 		display: none;
 	}
+
+	.components-datetime {
+		padding: 0;
+	}
 }
 
 .post-publish-panel__postpublish .components-panel__body {

--- a/packages/editor/src/components/post-publish-panel/style.scss
+++ b/packages/editor/src/components/post-publish-panel/style.scss
@@ -80,6 +80,8 @@
 		display: none;
 	}
 
+	// The DateTime component has an intrinsic padding in order for the horizontal scrolling to function inside a popover.
+	// We unset that here when used inline.
 	.components-datetime {
 		padding: 0;
 	}


### PR DESCRIPTION
The popover inherited a min-width of 260, which is insufficient, then overrode it just for the edit-post-schedule flow. This means the datetime component looks fine in the sidebar, but no-where else.

This PR changes to use a padding in the component itself, making it work everywhere.

Example of component used outside of sidebar, before:

![Screenshot 2019-11-01 at 12 23 11](https://user-images.githubusercontent.com/1204802/68021673-67ed0980-fca2-11e9-98ed-e219dedf7821.png)


After:

![Screenshot 2019-11-01 at 12 28 45](https://user-images.githubusercontent.com/1204802/68021955-2872ed00-fca3-11e9-98ea-9887c32e0d87.png)
