### PR TITLE
[enqueue script] - required param missing

### DIFF
--- a/docs/designers-developers/developers/filters/block-filters.md
+++ b/docs/designers-developers/developers/filters/block-filters.md
@@ -39,7 +39,8 @@ function myguten_enqueue() {
 		'myguten-script',
 		plugins_url( 'myguten.js', __FILE__ ),
 		array( 'wp-blocks', 'wp-dom-ready', 'wp-edit-post' ),
-		filemtime( plugin_dir_path( __FILE__ ) . '/myguten.js' )
+		filemtime( plugin_dir_path( __FILE__ ) . '/myguten.js' ),
+		true
 	);
 }
 add_action( 'enqueue_block_editor_assets', 'myguten_enqueue' );


### PR DESCRIPTION
This code doesn't work unless the `$in_footer` param is set to `true`. I'm not sure why this matters considering the `$deps` set correctly.

But anyway, adding `true`, fixes this code block.