### PR TITLE
Use Colors: Enhance contrast checking API.

### DIFF
--- a/packages/block-editor/src/components/colors/use-colors.js
+++ b/packages/block-editor/src/components/colors/use-colors.js
@@ -203,7 +203,7 @@ export default function __experimentalUseColors(
 				detectedBackgroundColorRef.current = backgroundColor;
 				return { backgroundColor };
 			} )( () => <></> ),
-		[]
+		[ attributes ]
 	);
 
 	return useMemo( () => {

--- a/packages/block-editor/src/components/colors/use-colors.js
+++ b/packages/block-editor/src/components/colors/use-colors.js
@@ -194,7 +194,10 @@ export default function __experimentalUseColors(
 	const detectedBackgroundColorRef = useRef();
 	const BackgroundColorDetector = useMemo(
 		() =>
-			withFallbackStyles( ( node ) => {
+			withFallbackStyles( ( node, { querySelector } ) => {
+				if ( querySelector ) {
+					node = node.parentNode.querySelector( querySelector );
+				}
 				let backgroundColor = getComputedStyle( node ).backgroundColor;
 				while ( backgroundColor === 'rgba(0, 0, 0, 0)' && node.parentNode ) {
 					node = node.parentNode;

--- a/packages/block-editor/src/components/colors/use-colors.js
+++ b/packages/block-editor/src/components/colors/use-colors.js
@@ -3,12 +3,7 @@
  */
 import memoize from 'memize';
 import classnames from 'classnames';
-import {
-	camelCase,
-	kebabCase,
-	map,
-	startCase,
-} from 'lodash';
+import { map, kebabCase, camelCase, startCase } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -20,7 +15,9 @@ import {
 	useMemo,
 	Children,
 	cloneElement,
+	useRef,
 } from '@wordpress/element';
+import { withFallbackStyles } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -30,13 +27,28 @@ import ContrastChecker from '../contrast-checker';
 import InspectorControls from '../inspector-controls';
 import { useBlockEditContext } from '../block-edit';
 
+/**
+ * Browser dependencies
+ */
+const { getComputedStyle } = window;
+
 const DEFAULT_COLORS = [];
+
+const resolveContrastCheckerColor = ( color, colorSettings, detectedColor ) => {
+	if ( typeof color === 'function' ) {
+		return color( colorSettings );
+	} else if ( color === true ) {
+		return detectedColor;
+	}
+	return color;
+};
+
 const ColorPanel = ( {
 	title,
 	colorSettings,
 	colorPanelProps,
-	contrastCheckerProps,
-	components,
+	contrastCheckers,
+	detectedBackgroundColor,
 	panelChildren,
 } ) => (
 	<PanelColorSettings
@@ -45,16 +57,46 @@ const ColorPanel = ( {
 		colorSettings={ Object.values( colorSettings ) }
 		{ ...colorPanelProps }
 	>
-		{ contrastCheckerProps &&
-			map( components, ( ( Component, key ) => (
-				<ContrastChecker
-					key={ key }
-					textColor={ colorSettings[ key ].value }
-					{ ...contrastCheckerProps }
-				/>
-			) ) ) }
+		{ contrastCheckers &&
+			( Array.isArray( contrastCheckers ) ?
+				contrastCheckers.map( ( { backgroundColor, textColor, ...rest } ) => {
+					backgroundColor = resolveContrastCheckerColor(
+						backgroundColor,
+						colorSettings,
+						detectedBackgroundColor
+					);
+					textColor = resolveContrastCheckerColor( textColor, colorSettings );
+					return (
+						<ContrastChecker
+							key={ `${ backgroundColor }-${ textColor }` }
+							backgroundColor={ backgroundColor }
+							textColor={ textColor }
+							{ ...rest }
+						/>
+					);
+				} ) :
+				map( colorSettings, ( { value } ) => {
+					let { backgroundColor, textColor } = contrastCheckers;
+					backgroundColor = resolveContrastCheckerColor(
+						backgroundColor || value,
+						colorSettings,
+						detectedBackgroundColor
+					);
+					textColor = resolveContrastCheckerColor(
+						textColor || value,
+						colorSettings
+					);
+					return (
+						<ContrastChecker
+							{ ...contrastCheckers }
+							key={ `${ backgroundColor }-${ textColor }` }
+							backgroundColor={ backgroundColor }
+							textColor={ textColor }
+						/>
+					);
+				} ) ) }
 		{ typeof panelChildren === 'function' ?
-			panelChildren( components ) :
+			panelChildren( colorSettings ) :
 			panelChildren }
 	</PanelColorSettings>
 );
@@ -69,7 +111,7 @@ export default function __experimentalUseColors(
 	{
 		panelTitle = __( 'Color Settings' ),
 		colorPanelProps,
-		contrastCheckerProps,
+		contrastCheckers,
 		panelChildren,
 	} = {
 		panelTitle: __( 'Color Settings' ),
@@ -113,14 +155,10 @@ export default function __experimentalUseColors(
 						}
 
 						return cloneElement( child, {
-							className: classnames(
-								componentClassName,
-								child.props.className,
-								{
-									[ `has-${ kebabCase( color ) }-${ kebabCase( property ) }` ]: color,
-									[ className || `has-${ kebabCase( name ) }` ]: color || customColor,
-								}
-							),
+							className: classnames( componentClassName, child.props.className, {
+								[ `has-${ kebabCase( color ) }-${ kebabCase( property ) }` ]: color,
+								[ className || `has-${ kebabCase( name ) }` ]: color || customColor,
+							} ),
 							style: {
 								...colorStyle,
 								...componentStyle,
@@ -151,6 +189,21 @@ export default function __experimentalUseColors(
 				}
 			),
 		[ setAttributes, colorConfigs.length ]
+	);
+
+	const detectedBackgroundColorRef = useRef();
+	const BackgroundColorDetector = useMemo(
+		() =>
+			withFallbackStyles( ( node ) => {
+				let backgroundColor = getComputedStyle( node ).backgroundColor;
+				while ( backgroundColor === 'rgba(0, 0, 0, 0)' && node.parentNode ) {
+					node = node.parentNode;
+					backgroundColor = getComputedStyle( node ).backgroundColor;
+				}
+				detectedBackgroundColorRef.current = backgroundColor;
+				return { backgroundColor };
+			} )( () => <></> ),
+		[]
 	);
 
 	return useMemo( () => {
@@ -191,9 +244,7 @@ export default function __experimentalUseColors(
 			acc[ componentName ].setColor = createSetColor( name, colors );
 
 			colorSettings[ componentName ] = {
-				value: _color ?
-					_color.color :
-					attributes[ camelCase( `custom ${ name }` ) ],
+				value: _color ? _color.color : attributes[ camelCase( `custom ${ name }` ) ],
 				onChange: acc[ componentName ].setColor,
 				label: panelLabel,
 				colors,
@@ -213,8 +264,8 @@ export default function __experimentalUseColors(
 			title: panelTitle,
 			colorSettings,
 			colorPanelProps,
-			contrastCheckerProps,
-			components,
+			contrastCheckers,
+			detectedBackgroundColor: detectedBackgroundColorRef.current,
 			panelChildren,
 		};
 		return {
@@ -223,6 +274,7 @@ export default function __experimentalUseColors(
 			InspectorControlsColorPanel: (
 				<InspectorControlsColorPanel { ...wrappedColorPanelProps } />
 			),
+			BackgroundColorDetector,
 		};
 	}, [ attributes, setAttributes, ...deps ] );
 }

--- a/packages/block-editor/src/components/colors/use-colors.js
+++ b/packages/block-editor/src/components/colors/use-colors.js
@@ -203,7 +203,15 @@ export default function __experimentalUseColors(
 				detectedBackgroundColorRef.current = backgroundColor;
 				return { backgroundColor };
 			} )( () => <></> ),
-		[ attributes ]
+		[
+			colorConfigs.reduce(
+				( acc, colorConfig ) =>
+					`${ acc } | ${ attributes[ colorConfig.name ] } | ${
+						attributes[ camelCase( `custom ${ colorConfig.name }` ) ]
+					}`,
+				''
+			),
+		]
 	);
 
 	return useMemo( () => {
@@ -276,5 +284,5 @@ export default function __experimentalUseColors(
 			),
 			BackgroundColorDetector,
 		};
-	}, [ attributes, setAttributes, ...deps ] );
+	}, [ attributes, setAttributes, detectedBackgroundColorRef.current, ...deps ] );
 }

--- a/packages/block-editor/src/components/colors/use-colors.js
+++ b/packages/block-editor/src/components/colors/use-colors.js
@@ -194,6 +194,12 @@ export default function __experimentalUseColors(
 	const detectedBackgroundColorRef = useRef();
 	const BackgroundColorDetector = useMemo(
 		() =>
+			contrastCheckers &&
+			( Array.isArray( contrastCheckers ) ?
+				contrastCheckers.some(
+					( { backgroundColor } ) => backgroundColor === true
+				) :
+				contrastCheckers.backgroundColor === true ) &&
 			withFallbackStyles( ( node, { querySelector } ) => {
 				if ( querySelector ) {
 					node = node.parentNode.querySelector( querySelector );
@@ -214,6 +220,7 @@ export default function __experimentalUseColors(
 					}`,
 				''
 			),
+			...deps,
 		]
 	);
 

--- a/packages/block-library/src/heading/edit.js
+++ b/packages/block-library/src/heading/edit.js
@@ -55,8 +55,8 @@ function HeadingEdit( {
 				</PanelBody>
 			</InspectorControls>
 			{ InspectorControlsColorPanel }
-			<BackgroundColorDetector />
 			<TextColor>
+				<BackgroundColorDetector querySelector='[contenteditable="true"]' />
 				<RichText
 					identifier="content"
 					tagName={ tagName }

--- a/packages/block-library/src/heading/edit.js
+++ b/packages/block-library/src/heading/edit.js
@@ -12,7 +12,7 @@ import HeadingToolbar from './heading-toolbar';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { PanelBody, withFallbackStyles } from '@wordpress/components';
+import { PanelBody } from '@wordpress/components';
 import { createBlock } from '@wordpress/blocks';
 import {
 	AlignmentToolbar,
@@ -22,23 +22,17 @@ import {
 	__experimentalUseColors,
 } from '@wordpress/block-editor';
 
-/**
- * Browser dependencies
- */
-const { getComputedStyle } = window;
-
 function HeadingEdit( {
-	backgroundColor,
 	attributes,
 	setAttributes,
 	mergeBlocks,
 	onReplace,
 	className,
 } ) {
-	const { TextColor, InspectorControlsColorPanel } = __experimentalUseColors(
+	const { TextColor, InspectorControlsColorPanel, BackgroundColorDetector } = __experimentalUseColors(
 		[ { name: 'textColor', property: 'color' } ],
 		{
-			contrastCheckerProps: { backgroundColor, isLargeText: true },
+			contrastCheckers: { backgroundColor: true },
 		},
 		[]
 	);
@@ -61,6 +55,7 @@ function HeadingEdit( {
 				</PanelBody>
 			</InspectorControls>
 			{ InspectorControlsColorPanel }
+			<BackgroundColorDetector />
 			<TextColor>
 				<RichText
 					identifier="content"
@@ -90,11 +85,4 @@ function HeadingEdit( {
 	);
 }
 
-export default withFallbackStyles( ( node ) => {
-	let backgroundColor = getComputedStyle( node ).backgroundColor;
-	while ( backgroundColor === 'rgba(0, 0, 0, 0)' && node.parentNode ) {
-		node = node.parentNode;
-		backgroundColor = getComputedStyle( node ).backgroundColor;
-	}
-	return { backgroundColor };
-} )( HeadingEdit );
+export default HeadingEdit;


### PR DESCRIPTION
Follows #16781
Helps #18148

cc @youknowriad @jorgefilipecosta 

## Description

This PR enhances the contrast checker API in the `__experimentalUseColors` hook to fit all possible use cases pertaining a hook call's colors and refactors the heading block to take advantage of it.

See https://github.com/WordPress/gutenberg/pull/18148#discussion_r340244857 and https://github.com/WordPress/gutenberg/pull/16781#discussion_r339418615 for the discussions that led to this PR.

To summarize, the current API supports a `contrastCheckerProps` option that takes a set of props to render multiple identical contrast checkers for each color managed by the hook, where the text color is set to the edited color attribute and the background color is expected to be part of the passed in props. This is insufficient for a lot of use cases. What if you need the edited color attribute to be the background color instead? What if you need the background and text colors to both be edited color attributes? What if you don't want a contrast checker for every edited color attribute? All of this are common use cases, and furthermore, it will be pretty common, as was required by the heading block, to have the background color in a contrast checker be the actual DOM background color of the nearest parent element with a set background. This was also catered to.

This is the new API:

```js
const { TextColor, InspectorControlsColorPanel, BackgroundColorDetector } = __experimentalUseColors(
	[ { name: 'textColor', property: 'color' } ],
	{
		contrastCheckers: contrastCheckersOptions,
	},
	[]
);
```

`contrastCheckersOptions` can be a single object or an array of objects. If it's an object, its values will be used to generate a contrast checker per edited color attribute as before, if it's an array of objects, a contrast checker will be created per item in the array.

The properties of the objects are the props for the contrast checker with `backgroundColor` and `textColor` handled a bit differently than any other props that will just get passed through as is.

### Single Object Form

```js
// You can pass in literals.
// `textColor` would default here to the edited color attribute for each color.
const contrastCheckersOptions = { backgroundColor: 'white', ...maybeOtherProps };

// You can pass in functions that take the color panel settings
// to get the color value of another edited color attribute.
const contrastCheckersOptions = {
	backgroundColor: ( { BackgroundColor } ) => BackgroundColor.value
};

// `true` means resolve to nearest parent background color.
const contrastCheckersOptions = { backgroundColor: true };

// You can also pass in literals or functions for `textColor` and
// have `backgroundColor` default to the edited color attribute for each color.
const contrastCheckersOptions = { textColor: 'white' };
const contrastCheckersOptions = {
	textColor: ( { TextColor } ) => TextColor.value,
};
```

### Array of Objects Form

```js
// You can pass in literals, functions, or `true`, but you need to specify both
// `backgroundColor` and `textColor` for each contrast checker as they
// are not mapped from edited color attributes here.
const contrastCheckersOptions = [
	{ backgroundColor: 'white', textColor: ( { TextColor } ) => TextColor.value },
	{ backgroundColor: true, textColor: ( { TextColor } ) => TextColor.value },
	// ...etc, etc.
];
```

### Detecting Parent Background Color

To detect the background color for the `true` options, the hook now returns a `BackgroundColorDetector` component that you will need to render somewhere in the consuming component to get a handle to the right area of the DOM tree. See the heading block for an example of this.

## How has this been tested?

The heading block was refactored to use the new API and it was verified that it works as expected.

## Types of Changes

*New Feature:* The `__experimentalUseColors` contrast checking API now supports more use cases.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
