### PR TITLE
Remove iframe from base styles.

### DIFF
--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -267,7 +267,3 @@ img {
 	max-width: 100%;
 	height: auto;
 }
-
-iframe {
-	width: 100%;
-}


### PR DESCRIPTION
I can't recall the exact circumstances for why it was added, I suspect it had to do with embeds for themes that don't opt in to responsive embed styles. So we'll want to test with that. But this PR fixes https://core.trac.wordpress.org/ticket/48482.

This is a rule themes can override, but if it isn't necessary they shouldn't have to. 