### PR TITLE
Full Site Editing: Add experimental SiteDescription block

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -53,6 +53,7 @@ function gutenberg_reregister_core_block_types() {
 		'social-link.php'     => gutenberg_get_registered_social_link_blocks(),
 		'tag-cloud.php'       => 'core/tag-cloud',
 		'site-title.php'      => 'core/site-title',
+		'site-description.php'=> 'core/site-description',
 	);
 
 	$registry = WP_Block_Type_Registry::get_instance();

--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -33,6 +33,7 @@ $z-layers: (
 	".wp-block-cover.has-background-dim::before": 1, // Overlay area inside block cover need to be higher than the video background.
 	".wp-block-cover__video-background": 0, // Video background inside cover block.
 	".wp-block-site-title__save-button": 1,
+	".wp-block-site-description__save-button": 1,
 
 	// Active pill button
 	".components-button.is-button {:focus or .is-primary}": 1,

--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -37,6 +37,7 @@
 @import "./verse/editor.scss";
 @import "./video/editor.scss";
 @import "./site-title/editor.scss";
+@import "./site-description/editor.scss";
 
 /**
  * Import styles from internal editor components used by the blocks.

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -64,6 +64,7 @@ import * as socialLink from './social-link';
 
 // Full Site Editing Blocks
 import * as siteTitle from './site-title';
+import * as siteDescription from './site-description';
 
 /**
  * Function to register an individual block.
@@ -182,7 +183,7 @@ export const __experimentalRegisterExperimentalCoreBlocks =
 				...socialLink.sites,
 
 				// Register Full Site Editing Blocks.
-				...( __experimentalEnableFullSiteEditing ? [ siteTitle ] : [] ),
+				...( __experimentalEnableFullSiteEditing ? [ siteTitle, siteDescription ] : [] ),
 			].forEach( registerBlock );
 		} :
 		undefined;

--- a/packages/block-library/src/site-description/block.json
+++ b/packages/block-library/src/site-description/block.json
@@ -3,37 +3,6 @@
 	"category": "layout",
 	"supports": {
 		"align": [ "wide", "full" ],
-		"html": false,
-		"multiple": false,
-		"reusable": false
-	},
-	"attributes": {
-		"align": {
-			"type": "string",
-			"default": "wide"
-		},
-		"textAlign": {
-			"type": "string",
-			"default": "center"
-		},
-		"textColor": {
-			"type": "string"
-		},
-		"customTextColor": {
-			"type": "string"
-		},
-		"backgroundColor": {
-			"type": "string"
-		},
-		"customBackgroundColor": {
-			"type": "string"
-		},
-		"fontSize": {
-			"type": "string",
-			"default": "small"
-		},
-		"customFontSize": {
-			"type": "number"
-		}
+		"html": false
 	}
 }

--- a/packages/block-library/src/site-description/block.json
+++ b/packages/block-library/src/site-description/block.json
@@ -4,5 +4,34 @@
 	"supports": {
 		"align": [ "wide", "full" ],
 		"html": false
+	},
+	"attributes": {
+		"align": {
+			"type": "string",
+			"default": "wide"
+		},
+		"textAlign": {
+			"type": "string",
+			"default": "center"
+		},
+		"textColor": {
+			"type": "string"
+		},
+		"customTextColor": {
+			"type": "string"
+		},
+		"backgroundColor": {
+			"type": "string"
+		},
+		"customBackgroundColor": {
+			"type": "string"
+		},
+		"fontSize": {
+			"type": "string",
+			"default": "small"
+		},
+		"customFontSize": {
+			"type": "number"
+		}
 	}
 }

--- a/packages/block-library/src/site-description/block.json
+++ b/packages/block-library/src/site-description/block.json
@@ -1,0 +1,39 @@
+{
+	"name": "core/site-description",
+	"category": "layout",
+	"supports": {
+		"align": [ "wide", "full" ],
+		"html": false,
+		"multiple": false,
+		"reusable": false
+	},
+	"attributes": {
+		"align": {
+			"type": "string",
+			"default": "wide"
+		},
+		"textAlign": {
+			"type": "string",
+			"default": "center"
+		},
+		"textColor": {
+			"type": "string"
+		},
+		"customTextColor": {
+			"type": "string"
+		},
+		"backgroundColor": {
+			"type": "string"
+		},
+		"customBackgroundColor": {
+			"type": "string"
+		},
+		"fontSize": {
+			"type": "string",
+			"default": "small"
+		},
+		"customFontSize": {
+			"type": "number"
+		}
+	}
+}

--- a/packages/block-library/src/site-description/edit.js
+++ b/packages/block-library/src/site-description/edit.js
@@ -113,6 +113,7 @@ function SiteDescriptionEdit( {
 					[ fontSize.class ]: ! customFontSize && fontSize.class,
 				} ) }
 				isStylable
+				multiline={ false }
 				onChange={ setDescription }
 				onKeyDown={ preventNewlines }
 				placeholder={ __( 'Site Description' ) }

--- a/packages/block-library/src/site-description/edit.js
+++ b/packages/block-library/src/site-description/edit.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classNames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import {
@@ -25,6 +30,7 @@ import { ENTER } from '@wordpress/keycodes';
 function SiteDescriptionEdit( {
 	attributes,
 	backgroundColor,
+	className,
 	fontSize,
 	insertDefaultBlock,
 	setAttributes,
@@ -98,11 +104,24 @@ function SiteDescriptionEdit( {
 				{ __( 'Update' ) }
 			</Button>
 			<PlainText
-				placeholder={ __( 'Site Description' ) }
-				value={ description }
-				onChange={ setDescription }
+				className={ classNames( 'site-description', className, {
+					'has-text-color': textColor.color,
+					'has-background': backgroundColor.color,
+					[ `has-text-align-${ textAlign }` ]: textAlign,
+					[ backgroundColor.class ]: backgroundColor.class,
+					[ textColor.class ]: textColor.class,
+					[ fontSize.class ]: ! customFontSize && fontSize.class,
+				} ) }
 				isStylable
+				onChange={ setDescription }
 				onKeyDown={ preventNewlines }
+				placeholder={ __( 'Site Description' ) }
+				style={ {
+					backgroundColor: backgroundColor.color,
+					color: textColor.color,
+					fontSize: actualFontSize ? actualFontSize + 'px' : undefined,
+				} }
+				value={ description }
 			/>
 		</>
 	);

--- a/packages/block-library/src/site-description/edit.js
+++ b/packages/block-library/src/site-description/edit.js
@@ -5,20 +5,44 @@ import {
 	useEntityProp,
 	__experimentalUseEntitySaving,
 } from '@wordpress/core-data';
-import { Button } from '@wordpress/components';
+import { Button, PanelBody } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { PlainText } from '@wordpress/block-editor';
+import {
+	AlignmentToolbar,
+	BlockControls,
+	ContrastChecker,
+	FontSizePicker,
+	InspectorControls,
+	PanelColorSettings,
+	PlainText,
+	withColors,
+	withFontSizes,
+} from '@wordpress/block-editor';
 import { compose } from '@wordpress/compose';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { ENTER } from '@wordpress/keycodes';
 
-function SiteDescriptionEdit( { insertDefaultBlock } ) {
+function SiteDescriptionEdit( {
+	attributes,
+	backgroundColor,
+	fontSize,
+	insertDefaultBlock,
+	setAttributes,
+	setBackgroundColor,
+	setFontSize,
+	setTextColor,
+	textColor,
+
+} ) {
 	const [ description, setDescription ] = useEntityProp( 'root', 'site', 'description' );
 	const [ isDirty, isSaving, save ] = __experimentalUseEntitySaving(
 		'root',
 		'site',
 		'description'
 	);
+
+	const { customFontSize, textAlign } = attributes;
+	const actualFontSize = customFontSize || fontSize.size;
 
 	const preventNewlines = ( event ) => {
 		if ( event.keyCode === ENTER ) {
@@ -29,6 +53,41 @@ function SiteDescriptionEdit( { insertDefaultBlock } ) {
 
 	return (
 		<>
+			<BlockControls>
+				<AlignmentToolbar
+					value={ textAlign }
+					onChange={ ( nextAlign ) => setAttributes( { textAlign: nextAlign } ) }
+				/>
+			</BlockControls>
+			<InspectorControls>
+				<PanelBody className="blocks-font-size" title={ __( 'Text Settings' ) }>
+					<FontSizePicker onChange={ setFontSize } value={ actualFontSize } />
+				</PanelBody>
+				<PanelColorSettings
+					title={ __( 'Color Settings' ) }
+					initialOpen={ false }
+					colorSettings={ [
+						{
+							value: backgroundColor.color,
+							onChange: setBackgroundColor,
+							label: __( 'Background Color' ),
+						},
+						{
+							value: textColor.color,
+							onChange: setTextColor,
+							label: __( 'Text Color' ),
+						},
+					] }
+				>
+					<ContrastChecker
+						{ ...{
+							textColor: textColor.color,
+							backgroundColor: backgroundColor.color,
+						} }
+						fontSize={ actualFontSize }
+					/>
+				</PanelColorSettings>
+			</InspectorControls>
 			<Button
 				isPrimary
 				className="wp-block-site-description__save-button"
@@ -50,6 +109,8 @@ function SiteDescriptionEdit( { insertDefaultBlock } ) {
 }
 
 export default compose( [
+	withColors( 'backgroundColor', { textColor: 'color' } ),
+	withFontSizes( 'fontSize' ),
 	withSelect( ( select, { clientId } ) => {
 		const { getBlockIndex, getBlockRootClientId } = select( 'core/block-editor' );
 		const rootClientId = getBlockRootClientId( clientId );

--- a/packages/block-library/src/site-description/edit.js
+++ b/packages/block-library/src/site-description/edit.js
@@ -1,0 +1,65 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	useEntityProp,
+	__experimentalUseEntitySaving,
+} from '@wordpress/core-data';
+import { Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { PlainText } from '@wordpress/block-editor';
+import { compose } from '@wordpress/compose';
+import { withSelect, withDispatch } from '@wordpress/data';
+import { ENTER } from '@wordpress/keycodes';
+
+function SiteDescriptionEdit( { insertDefaultBlock } ) {
+	const [ description, setDescription ] = useEntityProp( 'root', 'site', 'description' );
+	const [ isDirty, isSaving, save ] = __experimentalUseEntitySaving(
+		'root',
+		'site',
+		'description'
+	);
+
+	const preventNewlines = ( event ) => {
+		if ( event.keyCode === ENTER ) {
+			event.preventDefault();
+			insertDefaultBlock();
+		}
+	};
+
+	return (
+		<>
+			<Button
+				isPrimary
+				className="wp-block-site-description__save-button"
+				disabled={ ! isDirty || ! description }
+				isBusy={ isSaving }
+				onClick={ save }
+			>
+				{ __( 'Update' ) }
+			</Button>
+			<PlainText
+				placeholder={ __( 'Site Description' ) }
+				value={ description }
+				onChange={ setDescription }
+				isStylable
+				onKeyDown={ preventNewlines }
+			/>
+		</>
+	);
+}
+
+export default compose( [
+	withSelect( ( select, { clientId } ) => {
+		const { getBlockIndex, getBlockRootClientId } = select( 'core/block-editor' );
+		const rootClientId = getBlockRootClientId( clientId );
+		return {
+			blockIndex: getBlockIndex( clientId, rootClientId ),
+			rootClientId,
+		};
+	} ),
+	withDispatch( ( dispatch, { blockIndex, rootClientId } ) => ( {
+		insertDefaultBlock: () =>
+			dispatch( 'core/block-editor' ).insertDefaultBlock( undefined, rootClientId, blockIndex + 1 ),
+	} ) ),
+] )( SiteDescriptionEdit );

--- a/packages/block-library/src/site-description/editor.scss
+++ b/packages/block-library/src/site-description/editor.scss
@@ -1,0 +1,6 @@
+.wp-block-site-description__save-button {
+	position: absolute;
+	right: 0;
+	top: 0;
+	z-index: z-index(".wp-block-site-description__save-button");
+}

--- a/packages/block-library/src/site-description/icon.js
+++ b/packages/block-library/src/site-description/icon.js
@@ -1,0 +1,11 @@
+/**
+ * WordPress dependencies
+ */
+import { SVG, Path } from '@wordpress/components';
+
+export default (
+	<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24">
+		<Path fill="none" d="M0 0h24v24H0z" />
+		<Path d="M4 9h16v2H4V9zm0 4h10v2H4v-2z" />
+	</SVG>
+);

--- a/packages/block-library/src/site-description/index.js
+++ b/packages/block-library/src/site-description/index.js
@@ -1,0 +1,20 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+import icon from './icon';
+import edit from './edit';
+
+const { name } = metadata;
+export { metadata, name };
+
+export const settings = {
+	title: __( 'Site Description' ),
+	icon,
+	edit,
+};

--- a/packages/block-library/src/site-description/index.php
+++ b/packages/block-library/src/site-description/index.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Server-side rendering of the `core/site-description` block.
+ *
+ * @package WordPress
+ */
+
+/**
+ * Renders the `core/site-description` block on the server.
+ *
+ * @return string The render.
+ */
+function render_block_core_site_description() {
+	return sprintf( '<p>%s</p>', get_bloginfo( 'description' ) );
+}
+
+/**
+ * Registers the `core/site-description` block on the server.
+ */
+function register_block_core_site_description() {
+	register_block_type(
+		'core/site-description',
+		array(
+			'attributes'      => array(
+				'className'             => array(
+					'type'    => 'string',
+					'default' => '',
+				),
+				'align'                 => array(
+					'type'    => 'string',
+				),
+				'textAlign'             => array(
+					'type'    => 'string',
+					'default' => 'center',
+				),
+				'textColor'             => array(
+					'type' => 'string',
+				),
+				'customTextColor'       => array(
+					'type' => 'string',
+				),
+				'backgroundColor'       => array(
+					'type' => 'string',
+				),
+				'customBackgroundColor' => array(
+					'type' => 'string',
+				),
+				'fontSize'              => array(
+					'type'    => 'string',
+				),
+				'customFontSize'        => array(
+					'type' => 'number',
+				),
+			),
+		'render_callback' => 'render_block_core_site_description',
+		)
+	);
+}
+add_action( 'init', 'register_block_core_site_description' );

--- a/packages/block-library/src/site-description/index.php
+++ b/packages/block-library/src/site-description/index.php
@@ -10,8 +10,51 @@
  *
  * @return string The render.
  */
-function render_block_core_site_description() {
-	return sprintf( '<p>%s</p>', get_bloginfo( 'description' ) );
+function render_block_core_site_description( $attributes ) {
+	$styles = '';
+
+	$class = 'wp-block-site-description';
+	if ( isset( $attributes['className'] ) ) {
+		$class .= ' ' . $attributes['className'];
+	}
+
+	if ( isset( $attributes['align'] ) ) {
+		$class .= ' align' . $attributes['align'];
+	}
+
+	if ( isset( $attributes['textAlign'] ) ) {
+		$class .= ' has-text-align-' . $attributes['textAlign'];
+	}
+
+	if ( isset( $attributes['textColor'] ) ) {
+		$class .= ' has-text-color';
+		$class .= ' has-' . $attributes['textColor'] . '-color';
+	} elseif ( isset( $attributes['customTextColor'] ) ) {
+		$class  .= ' has-text-color';
+		$styles .= ' color: ' . $attributes['customTextColor'] . ';';
+	}
+
+	if ( isset( $attributes['backgroundColor'] ) ) {
+		$class .= ' has-background';
+		$class .= ' has-' . $attributes['backgroundColor'] . '-background-color';
+	} elseif ( isset( $attributes['customBackgroundColor'] ) ) {
+		$class  .= ' has-background';
+		$styles .= ' background-color: ' . $attributes['customBackgroundColor'] . ';';
+	}
+
+	if ( isset( $attributes['fontSize'] ) ) {
+		$class .= ' has-' . $attributes['fontSize'] . '-font-size';
+	} elseif ( isset( $attributes['customFontSize'] ) ) {
+		$styles .= ' font-size: ' . $attributes['customFontSize'] . 'px;';
+	}
+
+	ob_start();
+	?>
+	<p class="<?php echo esc_attr( $class ); ?>" style="<?php echo esc_attr( $styles ); ?>">
+		<?php bloginfo( 'description' ); ?>
+	</p>
+	<?php
+	return ob_get_clean();
 }
 
 /**

--- a/packages/block-library/src/site-description/index.php
+++ b/packages/block-library/src/site-description/index.php
@@ -21,38 +21,7 @@ function register_block_core_site_description() {
 	register_block_type(
 		'core/site-description',
 		array(
-			'attributes'      => array(
-				'className'             => array(
-					'type'    => 'string',
-					'default' => '',
-				),
-				'align'                 => array(
-					'type'    => 'string',
-				),
-				'textAlign'             => array(
-					'type'    => 'string',
-					'default' => 'center',
-				),
-				'textColor'             => array(
-					'type' => 'string',
-				),
-				'customTextColor'       => array(
-					'type' => 'string',
-				),
-				'backgroundColor'       => array(
-					'type' => 'string',
-				),
-				'customBackgroundColor' => array(
-					'type' => 'string',
-				),
-				'fontSize'              => array(
-					'type'    => 'string',
-				),
-				'customFontSize'        => array(
-					'type' => 'number',
-				),
-			),
-		'render_callback' => 'render_block_core_site_description',
+			'render_callback' => 'render_block_core_site_description',
 		)
 	);
 }


### PR DESCRIPTION
## Description

Add a `SiteDescription` block similar to [`SiteTitle`](https://github.com/WordPress/gutenberg/tree/51fee9a045298a9c81e81675893c889e8df971cf/packages/block-library/src/site-title) but with styling attributes like text and background colors, text and block alignments, and font size.

Note: this depends on #18238 which enhances the `PlainText` component with a few `RichText`-like features. Should we decide the `PlainText` refactor is not worth it, it's fairly easy to change this to use `RichText` without allowed formats (see the [WordPress.com implementation](https://github.com/Automattic/wp-calypso/blob/51324b8f9735cf7cd58b70e5f90cab718a7be870/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/edit.js)).

## How has this been tested?
Tested on the Docker environment with the Full Site Editing experiment enabled.
Since the FSE experiment replaces the theme, to test this on the front end is necessary to create a template (Appearance > Templates) with `index` as slug, that will render as the theme `index.php` file.

## Screenshots

| Editor | Front End |
| - | - |
| <img width="1151" alt="Screenshot 2019-11-06 at 11 35 00" src="https://user-images.githubusercontent.com/2070010/68295139-a2331e00-0089-11ea-9f8f-03b906bd14a2.png"> | <img width="1313" alt="Screenshot 2019-11-06 at 11 35 46" src="https://user-images.githubusercontent.com/2070010/68295152-a95a2c00-0089-11ea-94a3-7eaf319423ad.png"> |

Note: the font size difference is caused by the theme (Twenty Twenty). For some reasons, the larger font size is 32px in the editor and 42px in the front end.

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
