### PR TITLE
Add SVGR support to wp-scripts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8985,10 +8985,60 @@
 				"stylelint": "^9.10.1",
 				"stylelint-config-wordpress": "^13.1.0",
 				"thread-loader": "^2.1.2",
+				"url-loader": "^3.0.0",
 				"webpack": "^4.41.0",
 				"webpack-bundle-analyzer": "^3.3.2",
 				"webpack-cli": "^3.1.2",
 				"webpack-livereload-plugin": "^2.2.0"
+			},
+			"dependencies": {
+				"big.js": {
+					"version": "5.2.2",
+					"resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+					"integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+					"dev": true
+				},
+				"json5": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+					"dev": true,
+					"requires": {
+						"minimist": "^1.2.0"
+					}
+				},
+				"loader-utils": {
+					"version": "1.2.3",
+					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
+					"integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
+					"dev": true,
+					"requires": {
+						"big.js": "^5.2.2",
+						"emojis-list": "^2.0.0",
+						"json5": "^1.0.1"
+					}
+				},
+				"schema-utils": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.6.1.tgz",
+					"integrity": "sha512-0WXHDs1VDJyo+Zqs9TKLKyD/h7yDpHUhEFsM2CzkICFdoX1av+GBq/J2xRTFfsQO5kBfhZzANf2VcIm84jqDbg==",
+					"dev": true,
+					"requires": {
+						"ajv": "^6.10.2",
+						"ajv-keywords": "^3.4.1"
+					}
+				},
+				"url-loader": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/url-loader/-/url-loader-3.0.0.tgz",
+					"integrity": "sha512-a84JJbIA5xTFTWyjjcPdnsu+41o/SNE8SpXMdUvXs6Q+LuhCD9E2+0VCiuDWqgo3GGXVlFHzArDmBpj9PgWn4A==",
+					"dev": true,
+					"requires": {
+						"loader-utils": "^1.2.3",
+						"mime": "^2.4.4",
+						"schema-utils": "^2.5.0"
+					}
+				}
 			}
 		},
 		"@wordpress/server-side-render": {
@@ -22766,7 +22816,7 @@
 			"dependencies": {
 				"clone-deep": {
 					"version": "0.2.4",
-					"resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
+					"resolved": "http://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
 					"integrity": "sha1-TnPdCen7lxzDhnDF3O2cGJZIHMY=",
 					"dev": true,
 					"requires": {
@@ -22800,7 +22850,7 @@
 					"dependencies": {
 						"kind-of": {
 							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+							"resolved": "http://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
 							"integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
 							"dev": true,
 							"requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8956,6 +8956,7 @@
 			"version": "file:packages/scripts",
 			"dev": true,
 			"requires": {
+				"@svgr/webpack": "^4.3.3",
 				"@wordpress/babel-preset-default": "file:packages/babel-preset-default",
 				"@wordpress/dependency-extraction-webpack-plugin": "file:packages/dependency-extraction-webpack-plugin",
 				"@wordpress/eslint-plugin": "file:packages/eslint-plugin",

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Master
+
+### New Features
+
+- Add SVGR support to compile SVG files to React components using the `@svgr/webpack` plugin.  [#18243](https://github.com/WordPress/gutenberg/pull/18243)
+
 ## 6.1.1 (2020-01-01)
 
 ### Bug Fixes

--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -380,7 +380,7 @@ Should there be any situation where you want to provide your own webpack config,
 
 To extend the provided webpack config, or replace subsections within the provided webpack config, you can provide your own `webpack.config.js` file, `require` the provided `webpack.config.js` file, and use the [`spread` operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax) to import all of or part of the provided configuration.
 
-In the example below, a `webpack.config.js` file is added to the root folder extending the provided webpack config to include [`@svgr/webpack`](https://www.npmjs.com/package/@svgr/webpack) and [`url-loader`](https://github.com/webpack-contrib/url-loader):
+In the example below, a `webpack.config.js` file is added to the root folder extending the provided webpack config to include [`css-loader`](https://github.com/webpack-contrib/css-loader) and [`style-loader`](https://github.com/webpack-contrib/style-loader):
 
 ```javascript
 const defaultConfig = require("@wordpress/scripts/config/webpack.config");
@@ -392,12 +392,13 @@ module.exports = {
     rules: [
       ...defaultConfig.module.rules,
       {
-        test: /\.svg$/,
-        use: ["@svgr/webpack", "url-loader"]
+        test: /\.css$/,
+        use: ["css-loader", "style-loader"],
       }
     ]
   }
 };
 ```
+
 If you follow this approach, please, be aware that future versions of this package may change what webpack and Babel plugins we bundle, default configs, etc. Should those changes be necessary, they will be registered in the [package’s CHANGELOG](https://github.com/WordPress/gutenberg/blob/master/packages/scripts/CHANGELOG.md), so make sure to read it before upgrading.
 <br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>

--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -58,6 +58,10 @@ const config = {
 					},
 				],
 			},
+			{
+				test: /\.svg$/,
+				use: '@svgr/webpack',
+			},
 		],
 	},
 	plugins: [

--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -60,7 +60,7 @@ const config = {
 			},
 			{
 				test: /\.svg$/,
-				use: '@svgr/webpack',
+				use: [ '@svgr/webpack', 'url-loader' ],
 			},
 		],
 	},

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -61,6 +61,7 @@
 		"stylelint": "^9.10.1",
 		"stylelint-config-wordpress": "^13.1.0",
 		"thread-loader": "^2.1.2",
+		"url-loader": "^3.0.0",
 		"webpack": "^4.41.0",
 		"webpack-bundle-analyzer": "^3.3.2",
 		"webpack-cli": "^3.1.2",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -32,6 +32,7 @@
 		"wp-scripts": "./bin/wp-scripts.js"
 	},
 	"dependencies": {
+		"@svgr/webpack": "^4.3.3",
 		"@wordpress/babel-preset-default": "file:../babel-preset-default",
 		"@wordpress/dependency-extraction-webpack-plugin": "file:../dependency-extraction-webpack-plugin",
 		"@wordpress/eslint-plugin": "file:../eslint-plugin",


### PR DESCRIPTION
## Description

This PR adds `@svgr/webpack` plugin to compile SVG icons to React Components during the build step. This allows for loading an svg direct from a file and using as an component, for example:

```
import MyIcon from './icon.svg'
...
edit: () => {
    <>
        <MyIcon />
    </>
}
```

Related to #14628 

## How has this been tested?

In a separate project using `wp-scripts build` added a svg file and loaded and displayed.


## Types of changes

Enhancement to wp-scripts


## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
