### PR TITLE
Try: apply the new type scale

### DIFF
--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -1,4 +1,84 @@
 /**
+ * Type scale mixins
+ */
+
+@mixin text-title-large {
+	$font-size: 32px;
+	font-weight: 400;
+	font-size: $font-size;
+	line-height: (40px / $font-size); // line-height in px divided by font-size
+}
+
+@mixin text-title-medium {
+	$font-size: 24px;
+	font-weight: 400;
+	font-size: $font-size;
+	line-height: (32px / $font-size); // line-height in px divided by font-size
+}
+
+@mixin text-title-small {
+	$font-size: 20px;
+	font-weight: 400;
+	font-size: $font-size;
+	line-height: (28px / $font-size); // line-height in px divided by font-size
+}
+
+@mixin text-subtitle {
+	$font-size: 16px;
+	font-weight: 600;
+	font-size: $font-size;
+	line-height: (24px / $font-size); // line-height in px divided by font-size
+}
+
+@mixin text-subtitle-small {
+	$font-size: 14px;
+	font-weight: 600;
+	font-size: $font-size;
+	line-height: (20px / $font-size); // line-height in px divided by font-size
+}
+
+@mixin text-body {
+	$font-size: 16px;
+	font-weight: 400;
+	font-size: $font-size;
+	line-height: (24px / $font-size); // line-height in px divided by font-size
+}
+
+@mixin text-body-small {
+	$font-size: 14px;
+	font-weight: 400;
+	font-size: $font-size;
+	line-height: (20px / $font-size); // line-height in px divided by font-size
+}
+
+@mixin text-button {
+	$font-size: 14px;
+	font-weight: 600;
+	font-size: $font-size;
+	line-height: (20px / $font-size); // line-height in px divided by font-size
+}
+
+@mixin text-caption {
+	$font-size: 12px;
+	font-weight: 400;
+	font-size: $font-size;
+	line-height: (16px / $font-size); // line-height in px divided by font-size
+}
+
+@mixin text-label {
+	$font-size: 12px;
+	font-weight: 600;
+	font-size: $font-size;
+	line-height: (16px / $font-size); // line-height in px divided by font-size
+}
+
+// Utility classes
+
+.block-editor-page .text-caption {
+	@include text-caption;
+}
+
+/**
  * Breakpoint mixins
  */
 

--- a/packages/base-styles/_variables.scss
+++ b/packages/base-styles/_variables.scss
@@ -4,15 +4,15 @@
 
 // Fonts & basics
 $default-font: -apple-system, BlinkMacSystemFont,"Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell,"Helvetica Neue", sans-serif;
-$default-font-size: 13px;
-$default-line-height: 1.4;
+$default-font-size: 14px;
+$default-line-height: (20px / $default-font-size); // line-height in px divided by font-size
 $editor-font: "Noto Serif", serif;
 $editor-html-font: Menlo, Consolas, monaco, monospace;
 $editor-font-size: 16px;
 $default-block-margin: 28px; // This value provides a consistent, contiguous spacing between blocks (it's 2x $block-padding).
 $text-editor-font-size: 14px;
 $editor-line-height: 1.8;
-$big-font-size: 18px;
+$big-font-size: 16px;
 $mobile-text-min-font-size: 16px; // Any font size below 16px will cause Mobile Safari to "zoom in"
 
 // Grid size

--- a/packages/block-directory/src/components/downloadable-block-author-info/style.scss
+++ b/packages/block-directory/src/components/downloadable-block-author-info/style.scss
@@ -5,5 +5,5 @@
 
 .block-directory-downloadable-block-author-info__content-author {
 	margin-bottom: 4px;
-	font-size: 14px;
+	@include text-body-small;
 }

--- a/packages/block-editor/src/components/block-breadcrumb/style.scss
+++ b/packages/block-editor/src/components/block-breadcrumb/style.scss
@@ -37,5 +37,5 @@
 .block-editor-block-breadcrumb__current {
 	color: $dark-gray-500;
 	padding: 0 $grid-size;
-	font-size: inherit;
+	@include text-label;
 }

--- a/packages/block-editor/src/components/block-card/style.scss
+++ b/packages/block-editor/src/components/block-card/style.scss
@@ -17,8 +17,8 @@
 }
 
 .block-editor-block-card__title {
-	font-weight: 500;
-	margin-bottom: 5px;
+	@include text-body;
+	color: $dark-gray-900;
 }
 
 .block-editor-block-card__description {

--- a/packages/block-editor/src/components/block-compare/style.scss
+++ b/packages/block-editor/src/components/block-compare/style.scss
@@ -37,11 +37,10 @@
 
 	.block-editor-block-compare__html {
 		font-family: $editor-html-font;
-		font-size: 12px;
+		@include text-caption;
 		color: $dark-gray-800;
 		border-bottom: 1px solid #ddd;
 		padding-bottom: 15px;
-		line-height: 1.7;
 
 		span {
 			background-color: #e6ffed;

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -1090,9 +1090,8 @@
 
 	.components-toolbar {
 		border: none;
-		line-height: 1;
 		font-family: $default-font;
-		font-size: 11px;
+		@include text-caption;
 		padding: 4px 4px;
 		background: $light-gray-500;
 		color: $dark-gray-900;
@@ -1100,8 +1099,7 @@
 		@include reduce-motion("transition");
 
 		.components-button {
-			font-size: inherit;
-			line-height: inherit;
+			@include text-label;
 			padding: 0;
 		}
 

--- a/packages/block-editor/src/components/inserter-list-item/style.scss
+++ b/packages/block-editor/src/components/inserter-list-item/style.scss
@@ -9,7 +9,7 @@
 	display: flex;
 	flex-direction: column;
 	width: 100%;
-	font-size: $default-font-size;
+	@include text-caption;
 	color: $dark-gray-700;
 	padding: 0 4px;
 	align-items: stretch;
@@ -72,7 +72,7 @@
 }
 
 .block-editor-block-types-list__item-icon {
-	padding: 12px 20px;
+	padding: 8px 20px;
 	border-radius: $radius-round-rectangle;
 	color: $dark-gray-500;
 	transition: all 0.05s ease-in-out;

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -141,7 +141,7 @@ $block-inserter-search-height: 38px;
 	align-items: center;
 
 	h2 {
-		font-size: 13px;
+		@include text-body-small;
 	}
 
 	.block-editor-block-icon {

--- a/packages/block-editor/src/style.scss
+++ b/packages/block-editor/src/style.scss
@@ -37,3 +37,11 @@
 @import "./components/warning/style.scss";
 @import "./components/writing-flow/style.scss";
 @import "./hooks/anchor.scss";
+
+body {
+	@include text-body-small;
+}
+
+body p {
+	@include text-body-small;
+}

--- a/packages/block-library/src/block/edit-panel/editor.scss
+++ b/packages/block-library/src/block/edit-panel/editor.scss
@@ -40,7 +40,7 @@
 
 	.reusable-block-edit-panel__title {
 		flex: 1 1 100%;
-		font-size: 14px;
+		@include text-body-small;
 		height: 30px;
 		margin: $grid-size-small 0 $grid-size;
 	}

--- a/packages/components/src/base-control/style.scss
+++ b/packages/components/src/base-control/style.scss
@@ -3,7 +3,7 @@
 	font-size: $default-font-size;
 
 	.components-base-control__field {
-		margin-bottom: $grid-size;
+		margin-bottom: $grid-size-small;
 
 		.components-panel__row & {
 			margin-bottom: inherit;
@@ -16,8 +16,7 @@
 	}
 
 	.components-base-control__help {
-		margin-top: -$grid-size;
-		font-style: italic;
+		@include text-caption;
 	}
 }
 

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -1,18 +1,18 @@
 .components-button {
 	display: inline-flex;
+	align-items: center;
 	text-decoration: none;
-	font-size: $default-font-size;
 	margin: 0;
 	border: 0;
 	cursor: pointer;
 	-webkit-appearance: none;
 	background: none;
 	transition: box-shadow 0.1s linear;
+	@include text-button;
 	@include reduce-motion("transition");
 
 	&.is-button {
 		padding: 0 10px;
-		line-height: 2;
 		height: 28px;
 		border-radius: 3px;
 		white-space: nowrap;
@@ -193,15 +193,13 @@
 
 	&.is-large {
 		height: 30px;
-		line-height: 28px;
-		padding: 0 12px 2px;
+		padding: 0 12px 0;
 	}
 
 	&.is-small {
 		height: 24px;
-		line-height: 22px;
-		padding: 0 8px 1px;
-		font-size: 11px;
+		padding: 0 8px 0;
+		font-size: 12px;
 	}
 
 	// Buttons that are text-based.
@@ -210,7 +208,6 @@
 
 		// Matches default button in hit area. See line 11.
 		padding: 0 10px;
-		line-height: 26px;
 		height: 28px;
 
 		.dashicon {

--- a/packages/components/src/date-time/style.scss
+++ b/packages/components/src/date-time/style.scss
@@ -141,7 +141,7 @@
 
 
 			&.am-pm button {
-				font-size: 11px;
+				font-size: 12px;
 				font-weight: 600;
 			}
 

--- a/packages/components/src/form-token-field/style.scss
+++ b/packages/components/src/form-token-field/style.scss
@@ -3,7 +3,7 @@
 	flex-wrap: wrap;
 	align-items: flex-start;
 	width: 100%;
-	margin: 0 0 $grid-size 0;
+	margin: 0 0 $grid-size-small 0;
 	padding: $grid-size-small;
 	background-color: $white;
 	border: $border-width solid $light-gray-700;
@@ -51,7 +51,7 @@
 }
 
 .components-form-token-field__help {
-	font-style: italic;
+	@include text-caption;
 }
 
 // Tokens

--- a/packages/components/src/menu-item/style.scss
+++ b/packages/components/src/menu-item/style.scss
@@ -5,6 +5,7 @@
 	text-align: left;
 	color: $dark-gray-600;
 	@include menu-style__neutral;
+	@include text-body-small;
 
 	// Target plugin icons that can have arbitrary classes by using an aggressive selector.
 	.dashicon,
@@ -37,8 +38,6 @@
 }
 
 .components-menu-item__info {
-	margin-top: $grid-size-small;
-	font-size: $default-font-size - 1px;
 	color: $dark-gray-300;
 }
 

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -82,8 +82,7 @@
 	}
 
 	.components-modal__header-heading {
-		font-size: 1rem;
-		font-weight: 600;
+		@include text-subtitle;
 	}
 
 	h1 {

--- a/packages/edit-post/src/components/keyboard-shortcut-help-modal/style.scss
+++ b/packages/edit-post/src/components/keyboard-shortcut-help-modal/style.scss
@@ -1,3 +1,7 @@
+kbd.edit-post-keyboard-shortcut-help__shortcut-term {
+	@include text-body-small;
+}
+
 .edit-post-keyboard-shortcut-help {
 	&__section {
 		margin: 0 0 2rem 0;
@@ -9,8 +13,7 @@
 	}
 
 	&__section-title {
-		font-size: 0.9rem;
-		font-weight: 600;
+		@include text-subtitle-small;
 	}
 
 	&__shortcut {
@@ -26,7 +29,7 @@
 	}
 
 	&__shortcut-term {
-		font-weight: 600;
+		// @include text-body-small;
 		margin: 0 0 0 1rem;
 	}
 

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -166,7 +166,6 @@
 	// Match the size of the Publish... button.
 	.components-button.is-large {
 		height: 33px;
-		line-height: 32px;
 	}
 
 	// Size the spacer flexibly to allow for different button lengths.
@@ -196,8 +195,7 @@
 		width: auto;
 		height: auto;
 		display: block;
-		font-size: 14px;
-		font-weight: 600;
+		@include text-button;
 		margin: 0 0 0 auto;
 		padding: 15px 23px 14px;
 		line-height: normal;

--- a/packages/edit-post/src/components/manage-blocks-modal/style.scss
+++ b/packages/edit-post/src/components/manage-blocks-modal/style.scss
@@ -72,8 +72,7 @@
 	}
 
 	.components-checkbox-control__label {
-		font-size: 0.9rem;
-		font-weight: 600;
+		@include text-subtitle-small;
 	}
 }
 

--- a/packages/edit-post/src/components/options-modal/style.scss
+++ b/packages/edit-post/src/components/options-modal/style.scss
@@ -4,8 +4,7 @@
 	}
 
 	&__section-title {
-		font-size: 0.9rem;
-		font-weight: 600;
+		@include text-subtitle-small;
 	}
 
 	&__option {

--- a/packages/edit-post/src/components/sidebar/post-link/index.js
+++ b/packages/edit-post/src/components/sidebar/post-link/index.js
@@ -87,7 +87,7 @@ function PostLink( {
 							}
 						} }
 					/>
-					<p>
+					<p className="text-caption">
 						{ __( 'The last part of the URL.' ) }
 						{ ' ' }
 						<ExternalLink href="https://wordpress.org/support/article/writing-posts/#post-field-descriptions">

--- a/packages/edit-post/src/components/sidebar/post-link/style.scss
+++ b/packages/edit-post/src/components/sidebar/post-link/style.scss
@@ -10,6 +10,7 @@
 	text-align: left;
 	word-wrap: break-word;
 	display: block;
+	@include text-caption;
 }
 
 /* rtl:begin:ignore */

--- a/packages/edit-post/src/components/sidebar/settings-header/style.scss
+++ b/packages/edit-post/src/components/sidebar/settings-header/style.scss
@@ -22,7 +22,6 @@
 	cursor: pointer;
 	padding: 3px 15px; // Use padding to offset the is-active border, this benefits Windows High Contrast mode
 	margin-left: 0;
-	font-weight: 400;
 	color: $dark-gray-900;
 	@include square-style__neutral;
 	transition: box-shadow 0.1s linear;

--- a/packages/edit-post/src/components/sidebar/style.scss
+++ b/packages/edit-post/src/components/sidebar/style.scss
@@ -158,6 +158,7 @@
 }
 
 .edit-post-sidebar__panel-tab {
+	@include text-button;
 	background: transparent;
 	border: none;
 	box-shadow: none;
@@ -165,14 +166,12 @@
 	height: 50px;
 	padding: 3px 15px; // Use padding to offset the is-active border, this benefits Windows High Contrast mode
 	margin-left: 0;
-	font-weight: 400;
 	@include square-style__neutral;
 	transition: box-shadow 0.1s linear;
 	@include reduce-motion("transition");
 
 	&.is-active {
 		box-shadow: inset 0 -3px theme(outlines);
-		font-weight: 600;
 		position: relative;
 
 		// This border appears in Windows High Contrast mode instead of the box-shadow.

--- a/packages/editor/src/components/table-of-contents/style.scss
+++ b/packages/editor/src/components/table-of-contents/style.scss
@@ -48,15 +48,12 @@
 
 .table-of-contents__number,
 .table-of-contents__popover .word-count {
-	font-size: 21px;
-	font-weight: 400;
-	line-height: 30px;
+	@include text-title-small;
 	color: $dark-gray-500;
 }
 
 .table-of-contents__title {
 	display: block;
 	margin-top: 20px;
-	font-size: 15px;
-	font-weight: 600;
+	@include text-subtitle;
 }


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
This PR is an **experiment** to try and apply the new [type scale](https://make.wordpress.org/design/2019/10/11/proposal-a-consistent-type-scale-for-wordpress/), which is still a proposal at the moment.

Please note, I know there may be bugs, and there may be better ways to implement the type scale in code. This PR serves as a way to see the type scale in context. I did a few somewhat hacky things to override some styles.

Please give it a try and let me know what you think.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

I have only visually tested the block editor.

## Screenshots <!-- if applicable -->

Before/After gif https://make.wordpress.org/design/files/2019/10/comparison-editor.gif

Codepen of type scale https://codepen.io/drw158/pen/zbgEqO

After:

![download-6](https://user-images.githubusercontent.com/618551/68144209-c27fa300-fef8-11e9-9f49-4db771bef7bb.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

- Created mixins for every type style
- Updated various parts of Gutenberg to use the mixins
- Minimal adjustments to spacing of some elements to solve visual defects

Visual changes:

- This PR uses the new type scale, so the only visual changes are to type.
- The default font size was increased to 14px, which is the biggest change.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
