### PR TITLE
Add a README file for storybook directory

### DIFF
--- a/packages/components/storybook/README.md
+++ b/packages/components/storybook/README.md
@@ -1,0 +1,11 @@
+
+# Storybook 
+
+Storybook is an open-source tool that provides a sandbox to develop and visualize components in isolation. See the [Storybookjs site](https://storybook.js.org/) for more information about the tool. 
+
+The Gutenberg project uses Storybook to view and work the the `@wordpress/components` package.
+
+View online at: https://wordpress.github.io/gutenberg/design-system/components
+
+Run locally in your development environment running: `npm run design-system:dev` from the top-level Gutenberg directory.
+

--- a/packages/components/storybook/README.md
+++ b/packages/components/storybook/README.md
@@ -3,7 +3,7 @@
 
 Storybook is an open-source tool that provides a sandbox to develop and visualize components in isolation. See the [Storybookjs site](https://storybook.js.org/) for more information about the tool. 
 
-The Gutenberg project uses Storybook to view and work the the `@wordpress/components` package.
+The Gutenberg project uses Storybook to view and work with the `@wordpress/components` package.
 
 View online at: https://wordpress.github.io/gutenberg/design-system/components
 


### PR DESCRIPTION
## Description

Adds a README file explaining Storybook and providing a link to the live site and instructions on how to run locally.

## How has this been tested?

No code, just readme documentation file.

You can [view live on the branch here](https://github.com/WordPress/gutenberg/tree/add/storybook-readme/packages/components/storybook)


## Types of changes

Meta documentation

