### PR TITLE
Template Loader: Add theme block template resolution.

### DIFF
--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -120,6 +120,7 @@ function gutenberg_find_template( $template_file ) {
 		foreach ( array_unique( array_merge( glob( get_stylesheet_directory() . '/block-templates/*.html', 1 ), glob( get_template_directory() . '/block-templates/*.html', 1 ) ) ) as $path ) {
 			$theme_block_template_priority = $slug_priorities[ basename( $path, '.html' ) ];
 			if (
+				isset( $theme_block_template_priority ) &&
 				$theme_block_template_priority < $higher_priority_block_template_priority &&
 				$theme_block_template_priority < $slug_priorities[ $_wp_current_template_post->post_name ]
 			) {

--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -109,15 +109,16 @@ function gutenberg_find_template( $template_file ) {
 		$current_template_post = array_shift( $template_posts );
 
 		// Build map of template slugs to their priority in the current hierarchy.
-		$slug_priorities = array();
-		foreach ( $slugs as $index => $slug ) {
-			$slug_priorities[ $slug ] = $index;
-		}
+		$slug_priorities = array_flip( $slugs );
 
 		// See if there is a theme block template with higher priority than the resolved template post.
 		$higher_priority_block_template_path     = null;
 		$higher_priority_block_template_priority = PHP_INT_MAX;
-		foreach ( array_unique( array_merge( glob( get_stylesheet_directory() . '/block-templates/*.html', 1 ), glob( get_template_directory() . '/block-templates/*.html', 1 ) ) ) as $path ) {
+		$block_template_files                    = glob( get_stylesheet_directory() . '/block-templates/*.html', 1 );
+		if ( is_child_theme() ) {
+				$block_template_files = array_merge( $block_template_files, glob( get_template_directory() . '/block-templates/*.html', 1 ) );
+		}
+		foreach ( $block_template_files as $path ) {
 			$theme_block_template_priority = $slug_priorities[ basename( $path, '.html' ) ];
 			if (
 				isset( $theme_block_template_priority ) &&
@@ -131,7 +132,7 @@ function gutenberg_find_template( $template_file ) {
 
 		// If there is, use it instead.
 		if ( isset( $higher_priority_block_template_path ) ) {
-			$post_name                 = basename( $path, '.html' );
+			$post_name             = basename( $path, '.html' );
 			$current_template_post = array(
 				'post_content' => file_get_contents( $higher_priority_block_template_path ),
 				'post_title'   => ucfirst( $post_name ),

--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -109,19 +109,19 @@ function gutenberg_find_template( $template_file ) {
 		$_wp_current_template_post = array_shift( $template_posts );
 
 		// Build map of template slugs to their priority in the current hierarchy.
-		$slug_priorities = new stdClass();
+		$slug_priorities = array();
 		foreach ( $slugs as $index => $slug ) {
-			$slug_priorities->{$slug} = $index;
+			$slug_priorities[ $slug ] = $index;
 		}
 
 		// See if there is a theme block template with higher priority than the resolved template post.
 		$higher_priority_block_template_path     = null;
 		$higher_priority_block_template_priority = PHP_INT_MAX;
-		foreach ( glob( get_template_directory() . '/block-templates/*.html', 1 ) as $path ) {
-			$theme_block_template_priority = $slug_priorities->{basename( $path, '.html' )};
+		foreach ( array_unique( array_merge( glob( get_stylesheet_directory() . '/block-templates/*.html', 1 ), glob( get_template_directory() . '/block-templates/*.html', 1 ) ) ) as $path ) {
+			$theme_block_template_priority = $slug_priorities[ basename( $path, '.html' ) ];
 			if (
 				$theme_block_template_priority < $higher_priority_block_template_priority &&
-				$theme_block_template_priority < $slug_priorities->{$_wp_current_template_post->post_name}
+				$theme_block_template_priority < $slug_priorities[ $_wp_current_template_post->post_name ]
 			) {
 				$higher_priority_block_template_path     = $path;
 				$higher_priority_block_template_priority = $theme_block_template_priority;
@@ -136,7 +136,7 @@ function gutenberg_find_template( $template_file ) {
 					array(
 						'post_content' => file_get_contents( $higher_priority_block_template_path ),
 						'post_title'   => ucfirst( $post_name ),
-						'post_status'  => 'auto_draft',
+						'post_status'  => 'auto-draft',
 						'post_type'    => 'wp_template',
 						'post_name'    => $post_name,
 					)


### PR DESCRIPTION
Follows #17512

cc @youknowriad @felixarntz @westonruter 

## Description

This PR follows the template loader work to support resolving theme block templates from a new `/block-templates` directory in themes.

A theme block template is an HTML file named after the relevant template from the template hierarchy and it contains the serialized block content for the template.

The logic for resolving them is as follows:

After finding a suitable `wp_template` post for the current hierarchy, search for a higher priority match in the active theme's block templates and use it if found. If there is more than one, use the one with the highest priority.

Note that it's "higher priority" and not "higher or equal priority". Between a `wp_template` post and a theme block template with the same priority, the `wp_template` post  should be preferred as it contains changes that the user explicitly persisted and that should live on across theme changes.

"Using it" means creating a temporary auto-draft so that the rest of the template loading logic works as expected and so that the user can eventually make changes and persist them in a `wp_template` post if they so desire.

## How has this been tested?

It was verified that `/block-templates` theme block templates are resolved as expected in the full site editing experiment.

## Types of Changes

*New Feature:* Themes can now register block templates for the dynamic template hierarchy.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
