### PR TITLE
Escape spaces in file paths

### DIFF
--- a/bin/update-readmes.js
+++ b/bin/update-readmes.js
@@ -51,7 +51,7 @@ packages.forEach( ( entry ) => {
 		// Each target operates over the same file, so it needs to be processed synchronously,
 		// as to make sure the processes don't overwrite each other.
 		const { status, stderr } = spawnSync(
-			join( __dirname, '..', 'node_modules', '.bin', 'docgen' ),
+			join( __dirname, '..', 'node_modules', '.bin', 'docgen' ).replace( / /g, '\\ ' ),
 			[
 				join( 'packages', packageName, path ),
 				`--output packages/${ packageName }/README.md`,

--- a/docs/tool/update-data.js
+++ b/docs/tool/update-data.js
@@ -33,7 +33,7 @@ modules.forEach( ( entry ) => {
 		// until docgen provides a way to update many tokens at once, we need to make sure
 		// the output file is updated before starting the second pass for the next token.
 		const { status, stderr } = spawnSync(
-			join( __dirname, '..', '..', 'node_modules', '.bin', 'docgen' ),
+			join( __dirname, '..', '..', 'node_modules', '.bin', 'docgen' ).replace( / /g, '\\ ' ),
 			[
 				target,
 				`--output docs/designers-developers/developers/data/data-${ namespace.replace( '/', '-' ) }.md`,


### PR DESCRIPTION
## Description
I came across an issue trying to commit for the first time at contributor day. Further up in my file tree I have a folder name with a space in it. `npm install` seemed to run fine, but when I tried to commit, the `docs:build` process was not able to run as it could not find the proper file path. Where the file path is created, this PR replaces the space with an escaped space.

CC: @aduth - thanks for your help with this! 

## How has this been tested?
Gutenberg plugin cloned and installed with a space in the path prior to the WordPress instance. My file path was `/Users/mmarzeotti/Local Sites/contribute/app/public/wp-content/plugins/gutenberg/docs/tool/update-data.js` for reference. Run `npm run docs:build` and it will be unable to find the files necessary to run. When spaces are escaped, the command runs as it should.

## Types of changes
The same change (replace space with escaped space) is made in two places referencing `docgen`.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
