### PR TITLE
Check for existing of avatar_urls array before trying to return the avatar img part of user autocomplete fragment

### DIFF
--- a/packages/editor/src/components/autocompleters/style.scss
+++ b/packages/editor/src/components/autocompleters/style.scss
@@ -5,6 +5,14 @@
 }
 
 .editor-autocompleters__user {
+	.editor-autocompleters__no-avatar::before {
+		/* stylelint-disable */
+		font: normal 20px/1 dashicons;
+		/* stylelint-enable */
+		content: "\f110";
+		margin-right: 5px;
+		vertical-align: middle;
+	}
 	.editor-autocompleters__user-avatar {
 		margin-right: 8px;
 		flex-grow: 0;

--- a/packages/editor/src/components/autocompleters/test/user.js
+++ b/packages/editor/src/components/autocompleters/test/user.js
@@ -1,0 +1,29 @@
+/**
+ * Internal dependencies
+ */
+import userCompleter from '../user';
+
+describe( 'user', () => {
+	describe( 'getOptionLabel', () => {
+		it( 'should return user details fragment', () => {
+			const user = {
+				name: 'Smithers Jones',
+				slug: 'userSlug',
+				avatar_urls: { 24: 'http://my.avatar' },
+			};
+			const userLabel = userCompleter.getOptionLabel( user );
+			expect( userLabel[ 0 ] ).toEqual( <img key="avatar" className="editor-autocompleters__user-avatar" alt="" src="http://my.avatar" /> );
+			expect( userLabel[ 1 ] ).toEqual( <span key="name" className="editor-autocompleters__user-name">Smithers Jones</span> );
+			expect( userLabel[ 2 ] ).toEqual( <span key="slug" className="editor-autocompleters__user-slug">userSlug</span> );
+		} );
+		it( 'should return user details fragment without img if avatar_urls array not set', () => {
+			const user = {
+				name: 'Smithers Jones',
+				slug: 'userSlug',
+			};
+			const userLabel = userCompleter.getOptionLabel( user );
+			expect( userLabel[ 0 ] ).toEqual( <span key="name" className="editor-autocompleters__user-name">Smithers Jones</span> );
+			expect( userLabel[ 1 ] ).toEqual( <span key="slug" className="editor-autocompleters__user-slug">userSlug</span> );
+		} );
+	} );
+} );

--- a/packages/editor/src/components/autocompleters/test/user.js
+++ b/packages/editor/src/components/autocompleters/test/user.js
@@ -16,14 +16,15 @@ describe( 'user', () => {
 			expect( userLabel[ 1 ] ).toEqual( <span key="name" className="editor-autocompleters__user-name">Smithers Jones</span> );
 			expect( userLabel[ 2 ] ).toEqual( <span key="slug" className="editor-autocompleters__user-slug">userSlug</span> );
 		} );
-		it( 'should return user details fragment without img if avatar_urls array not set', () => {
+		it( 'should return user details fragment without default avatar dashicon if avatar_urls array not set', () => {
 			const user = {
 				name: 'Smithers Jones',
 				slug: 'userSlug',
 			};
 			const userLabel = userCompleter.getOptionLabel( user );
-			expect( userLabel[ 0 ] ).toEqual( <span key="name" className="editor-autocompleters__user-name">Smithers Jones</span> );
-			expect( userLabel[ 1 ] ).toEqual( <span key="slug" className="editor-autocompleters__user-slug">userSlug</span> );
+			expect( userLabel[ 0 ] ).toEqual( <span className="editor-autocompleters__no-avatar"></span> );
+			expect( userLabel[ 1 ] ).toEqual( <span key="name" className="editor-autocompleters__user-name">Smithers Jones</span> );
+			expect( userLabel[ 2 ] ).toEqual( <span key="slug" className="editor-autocompleters__user-slug">userSlug</span> );
 		} );
 	} );
 } );

--- a/packages/editor/src/components/autocompleters/user.js
+++ b/packages/editor/src/components/autocompleters/user.js
@@ -26,11 +26,15 @@ export default {
 		return [ user.slug, user.name ];
 	},
 	getOptionLabel( user ) {
-		return [
-			<img key="avatar" className="editor-autocompleters__user-avatar" alt="" src={ user.avatar_urls[ 24 ] } />,
+		const userDetails = [
 			<span key="name" className="editor-autocompleters__user-name">{ user.name }</span>,
 			<span key="slug" className="editor-autocompleters__user-slug">{ user.slug }</span>,
 		];
+		const avatar = user.avatar_urls && user.avatar_urls[ 24 ] ?
+			<img key="avatar" className="editor-autocompleters__user-avatar" alt="" src={ user.avatar_urls[ 24 ] } /> :
+			null;
+
+		return avatar ? [ avatar, ...userDetails ] : userDetails;
 	},
 	getOptionCompletion( user ) {
 		return `@${ user.slug }`;

--- a/packages/editor/src/components/autocompleters/user.js
+++ b/packages/editor/src/components/autocompleters/user.js
@@ -26,15 +26,15 @@ export default {
 		return [ user.slug, user.name ];
 	},
 	getOptionLabel( user ) {
-		const userDetails = [
+		const avatar = user.avatar_urls && user.avatar_urls[ 24 ] ?
+			<img key="avatar" className="editor-autocompleters__user-avatar" alt="" src={ user.avatar_urls[ 24 ] } /> :
+			<span className="editor-autocompleters__no-avatar"></span>;
+
+		return [
+			avatar,
 			<span key="name" className="editor-autocompleters__user-name">{ user.name }</span>,
 			<span key="slug" className="editor-autocompleters__user-slug">{ user.slug }</span>,
 		];
-		const avatar = user.avatar_urls && user.avatar_urls[ 24 ] ?
-			<img key="avatar" className="editor-autocompleters__user-avatar" alt="" src={ user.avatar_urls[ 24 ] } /> :
-			null;
-
-		return avatar ? [ avatar, ...userDetails ] : userDetails;
 	},
 	getOptionCompletion( user ) {
 		return `@${ user.slug }`;


### PR DESCRIPTION
## Description
Currently the user mention autocomplete fails if the site is returning false for `get_option( 'show_avatars' )`.

Fixes #18258
## How has this been tested?
Tested manually by toggling `show_avatars`
Added simple unit test to ensure return of user details fragment doesn't fail if avatars array not set

## Screenshots

Before:
![user-auto-complete](https://user-images.githubusercontent.com/3629020/68094336-468b5800-ff04-11e9-998b-89326d0d55ea.gif)

After:

![after-mention-fix](https://user-images.githubusercontent.com/3629020/68094338-4b500c00-ff04-11e9-82d4-2a9990ae0e8c.gif)

## Types of changes
Made the packages/editor/src/components/autocompleters/user.js getOptionLabel method defensive to check for existence of the avatar url before trying to set img tag

## Checklist:
- [ X ] My code is tested.
- [ X ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->

