### PR TITLE
Limit of Next Page (Page Break) block to root level only

### DIFF
--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1038,9 +1038,7 @@ const canInsertBlockTypeUnmemoized = ( state, blockName, rootClientId = null ) =
 		if ( isArray( list ) ) {
 			// TODO: when there is a canonical way to detect that we are editing a post
 			// the following check should be changed to something like:
-			// if ( includes( list, 'core/post-content' ) &&
-			//		( item === 'core/post-content' || (getEditorMode() === 'post-content' && item === null)
-			// )
+			// if (includes( list, 'core/post-content' ) && getEditorMode() === 'post-content' && item === null )
 			if ( includes( list, 'core/post-content' ) && item === null ) {
 				return true;
 			}

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1036,7 +1036,12 @@ const canInsertBlockTypeUnmemoized = ( state, blockName, rootClientId = null ) =
 			return list;
 		}
 		if ( isArray( list ) ) {
-			if ( includes( list, 'root' ) && item === null ) {
+			// TODO: when there is a canonical way to detect that we are editing a post
+			// the following check should be changed to something like:
+			// if ( includes( list, 'core/post-content' ) &&
+			//		( item === 'core/post-content' || (getEditorMode() === 'post-content' && item === null)
+			// )
+			if ( includes( list, 'core/post-content' ) && item === null ) {
 				return true;
 			}
 			return includes( list, item );

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1038,7 +1038,7 @@ const canInsertBlockTypeUnmemoized = ( state, blockName, rootClientId = null ) =
 		if ( isArray( list ) ) {
 			// TODO: when there is a canonical way to detect that we are editing a post
 			// the following check should be changed to something like:
-			// if (includes( list, 'core/post-content' ) && getEditorMode() === 'post-content' && item === null )
+			// if ( includes( list, 'core/post-content' ) && getEditorMode() === 'post-content' && item === null )
 			if ( includes( list, 'core/post-content' ) && item === null ) {
 				return true;
 			}

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1036,6 +1036,9 @@ const canInsertBlockTypeUnmemoized = ( state, blockName, rootClientId = null ) =
 			return list;
 		}
 		if ( isArray( list ) ) {
+			if ( includes( list, 'root' ) && item === null ) {
+				return true;
+			}
 			return includes( list, item );
 		}
 		return defaultResult;

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -142,6 +142,7 @@ describe( 'selectors', () => {
 		unregisterBlockType( 'core/test-block-c' );
 		unregisterBlockType( 'core/test-freeform' );
 		unregisterBlockType( 'core/post-content-child' );
+
 		setFreeformContentHandlerName( undefined );
 	} );
 

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -122,7 +122,7 @@ describe( 'selectors', () => {
 		} );
 
 		registerBlockType( 'core/post-content-child', {
-			save: ( props ) => props.attributes.text,
+			save: () => null,
 			category: 'common',
 			title: 'Test Block Post Content Child',
 			icon: 'test',
@@ -1964,9 +1964,7 @@ describe( 'selectors', () => {
 			const state = {
 				blocks: {
 					byClientId: {},
-					attributes: {
-						block1: {},
-					},
+					attributes: {},
 				},
 				blockListSettings: {},
 				settings: {},

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -121,6 +121,15 @@ describe( 'selectors', () => {
 			},
 		} );
 
+		registerBlockType( 'core/post-content-child', {
+			save: ( props ) => props.attributes.text,
+			category: 'common',
+			title: 'Test Block Post Content Child',
+			icon: 'test',
+			keywords: [ 'testing' ],
+			parent: [ 'core/post-content' ],
+		} );
+
 		setFreeformContentHandlerName( 'core/test-freeform' );
 
 		cachedSelectors.forEach( ( { clear } ) => clear() );
@@ -132,7 +141,7 @@ describe( 'selectors', () => {
 		unregisterBlockType( 'core/test-block-b' );
 		unregisterBlockType( 'core/test-block-c' );
 		unregisterBlockType( 'core/test-freeform' );
-
+		unregisterBlockType( 'core/post-content-child' );
 		setFreeformContentHandlerName( undefined );
 	} );
 
@@ -1933,6 +1942,36 @@ describe( 'selectors', () => {
 			};
 			expect( canInsertBlockType( state, 'core/test-block-c', 'block1' ) ).toBe( true );
 		} );
+
+		it( 'should deny blocks that restrict parent to core/post-content when not in editor root ', () => {
+			const state = {
+				blocks: {
+					byClientId: {
+						block1: { name: 'core/test-block-c' },
+					},
+					attributes: {
+						block1: {},
+					},
+				},
+				blockListSettings: {},
+				settings: {},
+			};
+			expect( canInsertBlockType( state, 'core/post-content-child', 'block1' ) ).toBe( false );
+		} );
+
+		it( 'should allow blocks that restrict parent to core/post-content when in editor root ', () => {
+			const state = {
+				blocks: {
+					byClientId: {},
+					attributes: {
+						block1: {},
+					},
+				},
+				blockListSettings: {},
+				settings: {},
+			};
+			expect( canInsertBlockType( state, 'core/post-content-child' ) ).toBe( true );
+		} );
 	} );
 
 	describe( 'getInserterItems', () => {
@@ -2033,6 +2072,7 @@ describe( 'selectors', () => {
 			};
 			const itemIDs = getInserterItems( state ).map( ( item ) => item.id );
 			expect( itemIDs ).toEqual( [
+				'core/post-content-child',
 				'core/block/2',
 				'core/block/1',
 				'core/test-block-b',

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -1944,7 +1944,7 @@ describe( 'selectors', () => {
 			expect( canInsertBlockType( state, 'core/test-block-c', 'block1' ) ).toBe( true );
 		} );
 
-		it( 'should deny blocks that restrict parent to core/post-content when not in editor root ', () => {
+		it( 'should deny blocks that restrict parent to core/post-content when not in editor root', () => {
 			const state = {
 				blocks: {
 					byClientId: {

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -1960,7 +1960,7 @@ describe( 'selectors', () => {
 			expect( canInsertBlockType( state, 'core/post-content-child', 'block1' ) ).toBe( false );
 		} );
 
-		it( 'should allow blocks that restrict parent to core/post-content when in editor root ', () => {
+		it( 'should allow blocks that restrict parent to core/post-content when in editor root', () => {
 			const state = {
 				blocks: {
 					byClientId: {},

--- a/packages/block-library/src/nextpage/index.js
+++ b/packages/block-library/src/nextpage/index.js
@@ -18,6 +18,7 @@ export { metadata, name };
 
 export const settings = {
 	title: __( 'Page Break' ),
+	parent: [ 'root' ],
 	description: __( 'Separate your content into a multi-page experience.' ),
 	icon,
 	keywords: [ __( 'next page' ), __( 'pagination' ) ],

--- a/packages/block-library/src/nextpage/index.js
+++ b/packages/block-library/src/nextpage/index.js
@@ -18,7 +18,7 @@ export { metadata, name };
 
 export const settings = {
 	title: __( 'Page Break' ),
-	parent: [ 'root' ],
+	parent: [ 'core/post-content' ],
 	description: __( 'Separate your content into a multi-page experience.' ),
 	icon,
 	keywords: [ __( 'next page' ), __( 'pagination' ) ],


### PR DESCRIPTION
## Description

Adds a new 'root' parent block type which allows a block to be limited to only insertion in the root context. This is  initially as a suggested fix for a bug with the Page Break block ( #16411 ) but could be documented as a way to limit any block to the root context.

## How has this been tested

Just tested manually at this stage. If it is agreed that this is a possible way forward I will look at adding some unit or e2e tests.
## To test

- Check out this branch
- Add a Page Break block to the editor root - should work as normal
- Try adding a Page Break block to a block that allows nesting like Columns - it should not appear as an available block to add

## Screenshots

![pagebreak](https://user-images.githubusercontent.com/3629020/68574242-4f64c680-04ce-11ea-90f7-2a36c00b23c4.gif)

