### PR TITLE
[RNMobile] Gallery - Add append logic to MediaPlaceholder

### DIFF
--- a/packages/block-editor/src/components/media-placeholder/index.native.js
+++ b/packages/block-editor/src/components/media-placeholder/index.native.js
@@ -35,9 +35,9 @@ function MediaPlaceholder( props ) {
 		value = [],
 	} = props;
 
-	const setMedia =  multiple && addToGallery
-		? ( selected ) => onSelect( uniqBy( [ ...value, ...selected ], 'id' ) )
-		: onSelect;
+	const setMedia = multiple && addToGallery ?
+		( selected ) => onSelect( uniqBy( [ ...value, ...selected ], 'id' ) ) :
+		onSelect;
 
 	const isOneType = allowedTypes.length === 1;
 	const isImage = isOneType && allowedTypes.includes( MEDIA_TYPE_IMAGE );


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
This PR modifies the `MediaPlaceholder` component to append media for the native `Gallery` implementation.

On web, when new media is added to a gallery, the current selection of items in the gallery is available to the media selection interface, and can be presented as such to the user. The selector behaves more like a "gallery editor", in the sense that the selection is modified (users can add and / or remove items). On mobile, the interface for selecting media items is handled by the "parent apps", and does not "know" about what is currently selected as part of the gallery.

This PR adds the `addToGallery` prop to the `MediaPlaceholder` component, and conditionally appends media items to the current selection, passing the resulting collection back through `onSelect` when the `addToGallery` flag is set. When the `addToGallery` flag is not set, `onSelect` behavior is not modified.

**Note:** In this implementation, duplicates are removed from the collection via the `id` property, since this is used as a `key` in the list of elements that renders these items.

The changeset here is used in the related "parent" PR: https://github.com/WordPress/gutenberg/pull/18111, which includes these changes integrated with related changes in other components necessary for the gallery block.


## To test
Test this component via the main draft PR.


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
