### PR TITLE
[RNMobile] Gallery - Button

### DIFF
--- a/packages/block-library/src/gallery/gallery-button.native.js
+++ b/packages/block-library/src/gallery/gallery-button.native.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { StyleSheet, TouchableOpacity, View } from 'react-native';
-import { isString } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -47,9 +46,7 @@ export function Button( props ) {
 			disabled={ isDisabled }
 		>
 			<View style={ buttonStyle }>
-				{ isString( icon ) ?
-					<Icon icon={ icon } fill={ fill } size={ 24 } /> :
-					icon }
+				<Icon icon={ icon } fill={ fill } size={ 24 } />
 			</View>
 		</TouchableOpacity>
 	);

--- a/packages/block-library/src/gallery/gallery-button.native.js
+++ b/packages/block-library/src/gallery/gallery-button.native.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { StyleSheet, TouchableOpacity, Text, View, Platform } from 'react-native';
+import { StyleSheet, TouchableOpacity, View } from 'react-native';
 import { isString } from 'lodash';
 
 /**
@@ -16,26 +16,26 @@ const styles = StyleSheet.create( {
 		alignItems: 'center',
 		borderRadius: 6,
 		borderColor: '#2e4453',
-    backgroundColor: '#2e4453',
-    aspectRatio: 1,
+		backgroundColor: '#2e4453',
+		aspectRatio: 1,
 	},
 } );
 
 export function Button( props ) {
 	const {
-    icon,
+		icon,
 		onClick,
-    disabled,
-    'aria-disabled': ariaDisabled,
-    accessibilityLabel = 'button',
-    style,
-  } = props;
+		disabled,
+		'aria-disabled': ariaDisabled,
+		accessibilityLabel = 'button',
+		style,
+	} = props;
 
-  const buttonStyle = StyleSheet.compose( styles.buttonActive, style );
+	const buttonStyle = StyleSheet.compose( styles.buttonActive, style );
 
-  const isDisabled = disabled || ariaDisabled;
+	const isDisabled = disabled || ariaDisabled;
 
-  const fill = isDisabled ? "gray" : "white";
+	const fill = isDisabled ? 'gray' : 'white';
 
 	return (
 		<TouchableOpacity
@@ -47,9 +47,9 @@ export function Button( props ) {
 			disabled={ isDisabled }
 		>
 			<View style={ buttonStyle }>
-        { isString( icon )
-          ? <Icon icon={ icon } fill={ fill } size={ 24 } /> 
-          : icon }
+				{ isString( icon ) ?
+					<Icon icon={ icon } fill={ fill } size={ 24 } /> :
+					icon }
 			</View>
 		</TouchableOpacity>
 	);

--- a/packages/block-library/src/gallery/gallery-button.native.js
+++ b/packages/block-library/src/gallery/gallery-button.native.js
@@ -1,0 +1,58 @@
+/**
+ * External dependencies
+ */
+import { StyleSheet, TouchableOpacity, Text, View, Platform } from 'react-native';
+import { isString } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { Icon } from '@wordpress/components';
+
+const styles = StyleSheet.create( {
+	buttonActive: {
+		flexDirection: 'row',
+		justifyContent: 'center',
+		alignItems: 'center',
+		borderRadius: 6,
+		borderColor: '#2e4453',
+    backgroundColor: '#2e4453',
+    aspectRatio: 1,
+	},
+} );
+
+export function Button( props ) {
+	const {
+    icon,
+		onClick,
+    disabled,
+    'aria-disabled': ariaDisabled,
+    accessibilityLabel = 'button',
+    style,
+  } = props;
+
+  const buttonStyle = StyleSheet.compose( styles.buttonActive, style );
+
+  const isDisabled = disabled || ariaDisabled;
+
+  const fill = isDisabled ? "gray" : "white";
+
+	return (
+		<TouchableOpacity
+			activeOpacity={ 0.7 }
+			accessible={ true }
+			accessibilityLabel={ accessibilityLabel }
+			accessibilityRole={ 'button' }
+			onPress={ onClick }
+			disabled={ isDisabled }
+		>
+			<View style={ buttonStyle }>
+        { isString( icon )
+          ? <Icon icon={ icon } fill={ fill } size={ 24 } /> 
+          : icon }
+			</View>
+		</TouchableOpacity>
+	);
+}
+
+export default Button;


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
This PR introduces a `Button` component for the semi-cross-platform Gallery block. The purpose of this component is to provide UI buttons that can be styled for the native implementation of the Gallery block.

This `Button` component is used by the `GalleryImage` component introduced here: https://github.com/WordPress/gutenberg/pull/18155. The web implementation of the Gallery block uses `IconButton`, which, in turn, uses `Button` from `@wordpress/components`. Initially, I attempted to use the mobile implementation of `IconButton`, and then `Button`, but I struggled to find a way to make this work. Our mobile implementation of the `Button` component seemingly lacks a way to style the button for the purpose of the gallery image.

Ideally, `Button` (or `IconButton`) from `@wordpress/components` can be general enough to allow re-use from the `GalleryImage` component, supporting the respective designs, but perhaps it's best to constrain the scope here for the first iteration of mobile Gallery block, as the potential for reuse of `Button` may require a wider set of changes.

The changeset here is used in the related "parent" PR: https://github.com/WordPress/gutenberg/pull/18111, which includes these changes integrated with related changes in other components necessary for the gallery block.


## To test
Test this component via the main draft PR.


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
