### PR TITLE
Font Size Picker: Add default size

### DIFF
--- a/docs/designers-developers/developers/themes/theme-support.md
+++ b/docs/designers-developers/developers/themes/theme-support.md
@@ -176,7 +176,7 @@ add_theme_support(
 
 ### Block Font Sizes:
 
-Blocks may allow the user to configure the font sizes they use, e.g., the paragraph block. The block  provides a default set of font sizes, but a theme can overwrite it and provide its own:
+Blocks may allow the user to configure the font sizes they use, e.g., the paragraph block. The block provides a default set of font sizes, but a theme can overwrite it and provide its own:
 
 ```php
 add_theme_support( 'editor-font-sizes', array(
@@ -186,9 +186,9 @@ add_theme_support( 'editor-font-sizes', array(
 		'slug' => 'small'
 	),
 	array(
-		'name' => __( 'Normal', 'themeLangDomain' ),
+		'name' => __( 'Regular', 'themeLangDomain' ),
 		'size' => 16,
-		'slug' => 'normal'
+		'slug' => 'regular'
 	),
 	array(
 		'name' => __( 'Large', 'themeLangDomain' ),
@@ -215,6 +215,8 @@ As an example for the regular font size, a theme may provide the following class
 	font-size: 16px;
 }
 ```
+
+**Note:** The slugs `default` and `custom` are reserved and cannot be used by themes.
 
 ### Disabling custom font sizes
 

--- a/packages/components/src/font-size-picker/README.md
+++ b/packages/components/src/font-size-picker/README.md
@@ -72,6 +72,8 @@ The property `size` contains a number with the font size value, in `px`.
 The `name` property includes a label for that font size e.g.: `Small`.
 The `slug` property is a string with a unique identifier for the font size. Used for the class generation process.
 
+**Note:** The slugs `default` and `custom` are reserved and cannot be used.
+
 - Type: `Array`
 - Required: No
 

--- a/packages/components/src/font-size-picker/index.js
+++ b/packages/components/src/font-size-picker/index.js
@@ -18,7 +18,7 @@ const CUSTOM_FONT_SIZE = 'custom';
 
 function getSelectValueFromFontSize( fontSizes, value ) {
 	if ( value ) {
-		const fontSizeValue = fontSizes.find( ( font ) => font.size === value );
+		const fontSizeValue = fontSizes.find( ( font ) => font.size === Number( value ) );
 		return fontSizeValue ? fontSizeValue.slug : CUSTOM_FONT_SIZE;
 	}
 	return DEFAULT_FONT_SIZE;
@@ -55,31 +55,28 @@ export default function FontSizePicker( {
 
 	const onChangeValue = ( event ) => {
 		const newValue = event.target.value;
-		if ( newValue === '' ) {
-			setDefault();
-			return;
-		}
-		setCurrentSelectValue( getSelectValueFromFontSize( fontSizes, Number( newValue ) ) );
-		onChange( Number( newValue ) );
+		setCurrentSelectValue( getSelectValueFromFontSize( fontSizes, newValue ) );
+		onChange( newValue ? Number( newValue ) : undefined );
 	};
 
 	const onSelectChangeValue = ( { selectedItem } ) => {
+		setCurrentSelectValue( selectedItem.key );
+
 		if ( selectedItem.key === DEFAULT_FONT_SIZE ) {
-			setDefault();
+			onChange( undefined );
 			return;
 		}
-		setCurrentSelectValue( selectedItem.key );
+
+		if ( selectedItem.key === CUSTOM_FONT_SIZE ) {
+			return;
+		}
+
 		onChange( selectedItem.style && selectedItem.style.fontSize );
 	};
 
 	const onSliderChangeValue = ( sliderValue ) => {
 		onChange( sliderValue );
 		setCurrentSelectValue( getSelectValueFromFontSize( fontSizes, sliderValue ) );
-	};
-
-	const setDefault = () => {
-		onChange( undefined );
-		setCurrentSelectValue( getSelectValueFromFontSize( fontSizes, undefined ) );
 	};
 
 	const options = getSelectOptions( fontSizes, disableCustomFontSizes );
@@ -118,7 +115,7 @@ export default function FontSizePicker( {
 				<Button
 					className="components-color-palette__clear"
 					disabled={ value === undefined }
-					onClick={ setDefault }
+					onClick={ () => onSelectChangeValue( DEFAULT_FONT_SIZE ) }
 					isSmall
 					isSecondary
 				>

--- a/packages/components/src/font-size-picker/index.js
+++ b/packages/components/src/font-size-picker/index.js
@@ -13,26 +13,29 @@ import Button from '../button';
 import RangeControl from '../range-control';
 import CustomSelectControl from '../custom-select-control';
 
+const DEFAULT_FONT_SIZE = 'default';
+const CUSTOM_FONT_SIZE = 'custom';
+
 function getSelectValueFromFontSize( fontSizes, value ) {
 	if ( value ) {
 		const fontSizeValue = fontSizes.find( ( font ) => font.size === value );
-		return fontSizeValue ? fontSizeValue.slug : 'custom';
+		return fontSizeValue ? fontSizeValue.slug : CUSTOM_FONT_SIZE;
 	}
-	return 'normal';
+	return DEFAULT_FONT_SIZE;
 }
 
 function getSelectOptions( optionsArray, disableCustomFontSizes ) {
-	if ( ! disableCustomFontSizes ) {
-		optionsArray = [
-			...optionsArray,
-			{ slug: 'custom', name: __( 'Custom' ) },
-		];
-	}
+	optionsArray = [
+		{ slug: DEFAULT_FONT_SIZE, name: __( 'Default' ) },
+		...optionsArray,
+		...disableCustomFontSizes ? [] : [ { slug: CUSTOM_FONT_SIZE, name: __( 'Custom' ) } ],
+	];
 	return optionsArray.map( ( option ) => ( {
 		key: option.slug,
 		name: option.name,
 		style: { fontSize: option.size },
 	} ) );
+
 }
 
 export default function FontSizePicker( {
@@ -52,15 +55,19 @@ export default function FontSizePicker( {
 
 	const onChangeValue = ( event ) => {
 		const newValue = event.target.value;
-		setCurrentSelectValue( getSelectValueFromFontSize( fontSizes, Number( newValue ) ) );
 		if ( newValue === '' ) {
-			onChange( undefined );
+			setDefault();
 			return;
 		}
+		setCurrentSelectValue( getSelectValueFromFontSize( fontSizes, Number( newValue ) ) );
 		onChange( Number( newValue ) );
 	};
 
 	const onSelectChangeValue = ( { selectedItem } ) => {
+		if ( selectedItem.key === DEFAULT_FONT_SIZE ) {
+			setDefault();
+			return;
+		}
 		setCurrentSelectValue( selectedItem.key );
 		onChange( selectedItem.style && selectedItem.style.fontSize );
 	};
@@ -68,6 +75,11 @@ export default function FontSizePicker( {
 	const onSliderChangeValue = ( sliderValue ) => {
 		onChange( sliderValue );
 		setCurrentSelectValue( getSelectValueFromFontSize( fontSizes, sliderValue ) );
+	};
+
+	const setDefault = () => {
+		onChange( undefined );
+		setCurrentSelectValue( getSelectValueFromFontSize( fontSizes, undefined ) );
 	};
 
 	const options = getSelectOptions( fontSizes, disableCustomFontSizes );
@@ -106,10 +118,7 @@ export default function FontSizePicker( {
 				<Button
 					className="components-color-palette__clear"
 					disabled={ value === undefined }
-					onClick={ () => {
-						onChange( undefined );
-						setCurrentSelectValue( getSelectValueFromFontSize( fontSizes, undefined ) );
-					} }
+					onClick={ setDefault }
 					isSmall
 					isSecondary
 				>

--- a/packages/components/src/font-size-picker/index.js
+++ b/packages/components/src/font-size-picker/index.js
@@ -66,7 +66,7 @@ export default function FontSizePicker( {
 			return;
 		}
 
-		onChange( fontSizeValue );
+		onChange( Number( fontSizeValue ) );
 	};
 
 	const onChangeValue = ( event ) => {

--- a/packages/components/src/font-size-picker/index.js
+++ b/packages/components/src/font-size-picker/index.js
@@ -79,6 +79,13 @@ export default function FontSizePicker( {
 		setCurrentSelectValue( getSelectValueFromFontSize( fontSizes, sliderValue ) );
 	};
 
+	const reset = () => {
+		const defaultFontSize = items.find( ( item ) => item.key === DEFAULT_FONT_SIZE );
+		onSelectChangeValue( {
+			selectedItem: defaultFontSize,
+		} );
+	};
+
 	const options = getSelectOptions( fontSizes, disableCustomFontSizes );
 	const rangeControlNumberId = `components-range-control__number#${ instanceId }`;
 	return (
@@ -115,7 +122,7 @@ export default function FontSizePicker( {
 				<Button
 					className="components-color-palette__clear"
 					disabled={ value === undefined }
-					onClick={ () => onSelectChangeValue( DEFAULT_FONT_SIZE ) }
+					onClick={ reset }
 					isSmall
 					isSecondary
 				>

--- a/packages/components/src/font-size-picker/index.js
+++ b/packages/components/src/font-size-picker/index.js
@@ -30,12 +30,13 @@ function getSelectOptions( optionsArray, disableCustomFontSizes ) {
 		...optionsArray,
 		...disableCustomFontSizes ? [] : [ { slug: CUSTOM_FONT_SIZE, name: __( 'Custom' ) } ],
 	];
-	return optionsArray.map( ( option ) => ( {
-		key: option.slug,
-		name: option.name,
-		style: { fontSize: option.size },
-	} ) );
-
+	return optionsArray.map( ( option ) => (
+		{
+			key: option.slug,
+			name: option.name,
+			style: { fontSize: option.size },
+		}
+	) );
 }
 
 export default function FontSizePicker( {
@@ -53,40 +54,44 @@ export default function FontSizePicker( {
 		return null;
 	}
 
-	const onChangeValue = ( event ) => {
-		const newValue = event.target.value;
-		setCurrentSelectValue( getSelectValueFromFontSize( fontSizes, newValue ) );
-		onChange( newValue ? Number( newValue ) : undefined );
-	};
+	const setFontSize = ( fontSizeKey, fontSizeValue ) => {
+		setCurrentSelectValue( fontSizeKey );
 
-	const onSelectChangeValue = ( { selectedItem } ) => {
-		setCurrentSelectValue( selectedItem.key );
-
-		if ( selectedItem.key === DEFAULT_FONT_SIZE ) {
+		if ( fontSizeKey === DEFAULT_FONT_SIZE ) {
 			onChange( undefined );
 			return;
 		}
 
-		if ( selectedItem.key === CUSTOM_FONT_SIZE ) {
+		if ( ! fontSizeValue ) {
 			return;
 		}
 
-		onChange( selectedItem.style && selectedItem.style.fontSize );
+		onChange( fontSizeValue );
+	};
+
+	const onChangeValue = ( event ) => {
+		const newValue = event.target.value;
+		const key = getSelectValueFromFontSize( fontSizes, newValue );
+		setFontSize( key, newValue );
+	};
+
+	const onSelectChangeValue = ( { selectedItem } ) => {
+		const selectedKey = selectedItem.key;
+		const selectedValue = selectedItem.style && selectedItem.style.fontSize;
+		setFontSize( selectedKey, selectedValue );
 	};
 
 	const onSliderChangeValue = ( sliderValue ) => {
-		onChange( sliderValue );
-		setCurrentSelectValue( getSelectValueFromFontSize( fontSizes, sliderValue ) );
+		const sliderKey = getSelectValueFromFontSize( fontSizes, sliderValue );
+		setFontSize( sliderKey, sliderValue );
 	};
 
 	const reset = () => {
-		const defaultFontSize = items.find( ( item ) => item.key === DEFAULT_FONT_SIZE );
-		onSelectChangeValue( {
-			selectedItem: defaultFontSize,
-		} );
+		setFontSize( DEFAULT_FONT_SIZE );
 	};
 
 	const options = getSelectOptions( fontSizes, disableCustomFontSizes );
+
 	const rangeControlNumberId = `components-range-control__number#${ instanceId }`;
 	return (
 		<fieldset className="components-font-size-picker">

--- a/packages/e2e-tests/specs/editor/various/editor-modes.test.js
+++ b/packages/e2e-tests/specs/editor/various/editor-modes.test.js
@@ -79,7 +79,7 @@ describe( 'Editing modes (visual/HTML)', () => {
 
 		// Change the font size using the sidebar.
 		await page.click( '.components-font-size-picker__select' );
-		await page.click( '.components-custom-select-control__item:nth-child(4)' );
+		await page.click( '.components-custom-select-control__item:nth-child(5)' );
 
 		// Make sure the HTML content updated.
 		htmlBlockContent = await page.$eval( '.block-editor-block-list__layout .block-editor-block-list__block .block-editor-block-list__block-html-textarea', ( node ) => node.textContent );

--- a/packages/e2e-tests/specs/editor/various/font-size-picker.test.js
+++ b/packages/e2e-tests/specs/editor/various/font-size-picker.test.js
@@ -18,7 +18,7 @@ describe( 'Font Size Picker', () => {
 		await clickBlockAppender();
 		await page.keyboard.type( 'Paragraph to be made "large"' );
 		await page.click( '.components-font-size-picker__select' );
-		await page.click( '.components-custom-select-control__item:nth-child(4)' );
+		await page.click( '.components-custom-select-control__item:nth-child(5)' );
 
 		// Ensure content matches snapshot.
 		const content = await getEditedPostContent();


### PR DESCRIPTION
## Description

Adds a default option to the font size picker component that unsets any font size.

Previously, the font size selector was falling back to the `normal` size, but this size might have not been defined by theme.

Fixes #17908

## How has this been tested?
- Activated the ~Twenty Twenty theme~ or any other theme providing font sizes not including a `normal` size (Twenty Twenty recently added a `normal` font size: https://github.com/WordPress/twentytwenty/pull/989).
- Created a new post and added some paragraph blocks.
- Made sure the Text Settings on the right sidebar has the "Default" font size, with no font size applied to the block.
- Tried setting any other font size and made sure it worked as expected.
- Clicked on "Reset" and verified the selector changed to "Default", with no font size applied to the block.
- Removed the font size number (after toggling any font size) and verified the selector changed to "Default", with no font size applied to the block.

## Types of changes

Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
