### PR TITLE
Editor: Fix move to trash redirect save race conditions.

### DIFF
--- a/packages/e2e-tests/specs/editor/various/change-detection.test.js
+++ b/packages/e2e-tests/specs/editor/various/change-detection.test.js
@@ -7,7 +7,6 @@ import {
 	pressKeyWithModifier,
 	ensureSidebarOpened,
 	publishPost,
-	openDocumentSettingsSidebar,
 } from '@wordpress/e2e-test-utils';
 
 describe( 'Change detection', () => {
@@ -347,27 +346,6 @@ describe( 'Change detection', () => {
 		expect( title ).toBe( '' );
 
 		// Verify that the post is not dirty.
-		await assertIsDirty( false );
-	} );
-
-	it( 'should not prompt to confirm unsaved changes when trashing an existing post', async () => {
-		// Enter title.
-		await page.type( '.editor-post-title__input', 'Hello World' );
-
-		// Save
-		await Promise.all( [
-			// Wait for "Saved" to confirm save complete.
-			page.waitForSelector( '.editor-post-saved-state.is-saved' ),
-
-			// Keyboard shortcut Ctrl+S save.
-			pressKeyWithModifier( 'primary', 'S' ),
-		] );
-
-		// Trash post.
-		await openDocumentSettingsSidebar();
-		await page.click( '.editor-post-trash.components-button' );
-
-		// Check that the dialog didn't show.
 		await assertIsDirty( false );
 	} );
 } );

--- a/packages/e2e-tests/specs/editor/various/change-detection.test.js
+++ b/packages/e2e-tests/specs/editor/various/change-detection.test.js
@@ -7,6 +7,7 @@ import {
 	pressKeyWithModifier,
 	ensureSidebarOpened,
 	publishPost,
+	openDocumentSettingsSidebar,
 } from '@wordpress/e2e-test-utils';
 
 describe( 'Change detection', () => {
@@ -346,6 +347,27 @@ describe( 'Change detection', () => {
 		expect( title ).toBe( '' );
 
 		// Verify that the post is not dirty.
+		await assertIsDirty( false );
+	} );
+
+	it( 'should not prompt to confirm unsaved changes when trashing an existing post', async () => {
+		// Enter title.
+		await page.type( '.editor-post-title__input', 'Hello World' );
+
+		// Save
+		await Promise.all( [
+			// Wait for "Saved" to confirm save complete.
+			page.waitForSelector( '.editor-post-saved-state.is-saved' ),
+
+			// Keyboard shortcut Ctrl+S save.
+			pressKeyWithModifier( 'primary', 'S' ),
+		] );
+
+		// Trash post.
+		await openDocumentSettingsSidebar();
+		await page.click( '.editor-post-trash.components-button' );
+
+		// Check that the dialog didn't show.
 		await assertIsDirty( false );
 	} );
 } );

--- a/packages/edit-post/src/components/browser-url/index.js
+++ b/packages/edit-post/src/components/browser-url/index.js
@@ -42,10 +42,12 @@ export class BrowserURL extends Component {
 	}
 
 	componentDidUpdate( prevProps ) {
-		const { postId, postStatus, postType } = this.props;
+		const { postId, postStatus, postType, isSavingPost } = this.props;
 		const { historyId } = this.state;
 
-		if ( postStatus === 'trash' ) {
+		// Posts are still dirty while saving so wait for saving to finish
+		// to avoid the unsaved changes warning when trashing posts.
+		if ( postStatus === 'trash' && ! isSavingPost ) {
 			this.setTrashURL( postId, postType );
 			return;
 		}
@@ -92,12 +94,13 @@ export class BrowserURL extends Component {
 }
 
 export default withSelect( ( select ) => {
-	const { getCurrentPost } = select( 'core/editor' );
+	const { getCurrentPost, isSavingPost } = select( 'core/editor' );
 	const { id, status, type } = getCurrentPost();
 
 	return {
 		postId: id,
 		postStatus: status,
 		postType: type,
+		isSavingPost: isSavingPost(),
 	};
 } )( BrowserURL );

--- a/packages/editor/src/components/unsaved-changes-warning/index.js
+++ b/packages/editor/src/components/unsaved-changes-warning/index.js
@@ -41,6 +41,9 @@ class UnsavedChangesWarning extends Component {
 }
 
 export default withSelect( ( select ) => ( {
-	// We need the function to avoid race conditions.
+	// We need to call the selector directly in the listener to avoid race
+	// conditions with `BrowserUrl` where `componentDidUpdate` gets the
+	// new value of `isEditedPostDirty` before this component does,
+	// causing this component to incorrectly think a trashed post is still dirty.
 	isEditedPostDirty: select( 'core/editor' ).isEditedPostDirty,
 } ) )( UnsavedChangesWarning );

--- a/packages/editor/src/components/unsaved-changes-warning/index.js
+++ b/packages/editor/src/components/unsaved-changes-warning/index.js
@@ -42,7 +42,7 @@ class UnsavedChangesWarning extends Component {
 
 export default withSelect( ( select ) => ( {
 	// We need to call the selector directly in the listener to avoid race
-	// conditions with `BrowserUrl` where `componentDidUpdate` gets the
+	// conditions with `BrowserURL` where `componentDidUpdate` gets the
 	// new value of `isEditedPostDirty` before this component does,
 	// causing this component to incorrectly think a trashed post is still dirty.
 	isEditedPostDirty: select( 'core/editor' ).isEditedPostDirty,

--- a/packages/editor/src/components/unsaved-changes-warning/index.js
+++ b/packages/editor/src/components/unsaved-changes-warning/index.js
@@ -27,9 +27,9 @@ class UnsavedChangesWarning extends Component {
 	 * @return {?string} Warning prompt message, if unsaved changes exist.
 	 */
 	warnIfUnsavedChanges( event ) {
-		const { isDirty } = this.props;
+		const { isEditedPostDirty } = this.props;
 
-		if ( isDirty ) {
+		if ( isEditedPostDirty() ) {
 			event.returnValue = __( 'You have unsaved changes. If you proceed, they will be lost.' );
 			return event.returnValue;
 		}
@@ -41,5 +41,6 @@ class UnsavedChangesWarning extends Component {
 }
 
 export default withSelect( ( select ) => ( {
-	isDirty: select( 'core/editor' ).isEditedPostDirty(),
+	// We need the function to avoid race conditions.
+	isEditedPostDirty: select( 'core/editor' ).isEditedPostDirty,
 } ) )( UnsavedChangesWarning );


### PR DESCRIPTION
## Description

Two things were causing the unsaved changes warning to trigger when trashing a post:

1. Posts are still dirty while saving and `BrowserUrl` was navigating away as soon as the new post status was received, causing the redirection to happen while the post was still technically dirty.

https://github.com/WordPress/gutenberg/blob/61753df6a89c7be467c09a91c7ff18410e5685cf/packages/edit-post/src/components/browser-url/index.js#L44-L51

2. Even after that was fixed by waiting for saving to finish completely before navigating away, the `UnsavedChangesWarning` listener fired immediately with stale values.

https://github.com/WordPress/gutenberg/blob/61753df6a89c7be467c09a91c7ff18410e5685cf/packages/editor/src/components/unsaved-changes-warning/index.js#L29-L36

That was fixed by calling the selector from within the listener.

## How has this been tested?

It was verified that trashing a post no longer triggers an unsaved changes warning.

## Types of Changes

*Bug Fix:* Trashing a post no longer triggers an unsaved changes warning.

## Checklist:

- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
