### PR TITLE
link-control: fix spinner position

### DIFF
--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -183,17 +183,13 @@
 	z-index: 100;
 	float: none;
 
-	&.components-spinner { // Specificity overide
+	&.components-spinner { // Specificity override.
 		position: absolute;
-		top: 70px;
-		left: 50%;
-		right: auto;
-		bottom: auto;
-		margin: 0 auto 16px auto;
-		transform: translateX(-50%);
+		top: 27px;
+		left: auto;
+		right: 60px;
+		bottom: 0;
 	}
-
-
 }
 
 .block-editor-link-control__search-item-action {


### PR DESCRIPTION
## Description

This PR fixes the spinner position in the `<LinkControl />` component. It has been tested in the https://github.com/WordPress/gutenberg/pull/18062.

## Screenshots <!-- if applicable -->

![link-control-align-spinner-02](https://user-images.githubusercontent.com/77539/68156241-37b79c00-ff2a-11e9-9ef3-325a518365fc.gif)


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->

