### PR TITLE
Use URL in clipboard, if available, to create a new link

### DIFF
--- a/packages/format-library/src/link/index.native.js
+++ b/packages/format-library/src/link/index.native.js
@@ -44,6 +44,7 @@ export const link = {
 			this.addLink = this.addLink.bind( this );
 			this.stopAddingLink = this.stopAddingLink.bind( this );
 			this.onRemoveFormat = this.onRemoveFormat.bind( this );
+			this.getURLFromClipboard = this.getURLFromClipboard.bind( this );
 			this.state = {
 				addingLink: false,
 			};
@@ -110,7 +111,7 @@ export const link = {
 			speak( __( 'Link removed.' ), 'assertive' );
 		}
 
-		getURLFromClipboard = async () => {
+		async getURLFromClipboard() {
 			const clipboardText = await Clipboard.getString();
 			if ( ! clipboardText ) {
 				return '';

--- a/packages/format-library/src/link/index.native.js
+++ b/packages/format-library/src/link/index.native.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { find } from 'lodash';
+import { Clipboard } from 'react-native';
 
 /**
  * WordPress dependencies
@@ -56,6 +57,7 @@ export const link = {
 				onChange( applyFormat( value, { type: name, attributes: { url: text } } ) );
 			} else {
 				this.setState( { addingLink: true } );
+				this.getURLFromClipboard();
 			}
 		}
 
@@ -108,10 +110,25 @@ export const link = {
 			speak( __( 'Link removed.' ), 'assertive' );
 		}
 
+		getURLFromClipboard = async () => {
+			const clipboardText = await Clipboard.getString();
+			if ( ! clipboardText ) {
+				return '';
+			}
+			// Check if pasted text is URL
+			if ( ! isURL( clipboardText ) ) {
+				return '';
+			}
+			this.setState( { clipboardURL: clipboardText } );
+		}
+
 		render() {
 			const { isActive, activeAttributes, onChange } = this.props;
 			const linkSelection = this.getLinkSelection();
-
+			// If no URL is set and we have a clipboard URL let's use it
+			if ( ! activeAttributes.url && this.state.clipboardURL ) {
+				activeAttributes.url = this.state.clipboardURL;
+			}
 			return (
 				<>
 					<ModalLinkUI

--- a/packages/format-library/src/link/index.native.js
+++ b/packages/format-library/src/link/index.native.js
@@ -114,11 +114,11 @@ export const link = {
 		async getURLFromClipboard() {
 			const clipboardText = await Clipboard.getString();
 			if ( ! clipboardText ) {
-				return '';
+				return;
 			}
 			// Check if pasted text is URL
 			if ( ! isURL( clipboardText ) ) {
-				return '';
+				return;
 			}
 			this.setState( { clipboardURL: clipboardText } );
 		}


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
Related to: https://github.com/wordpress-mobile/gutenberg-mobile/issues/680

This PR changes the link code in React Native to check if the clipboard has an URL and use it if editing a new link on the content.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

This can be tested using this GB-mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1537

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
