### PR TITLE
Remove iframe and img responsiveness rules.

### DIFF
--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -261,13 +261,3 @@
 figcaption {
 	margin-top: 0.5em;
 }
-
-// Apply some base styles to blocks that need them.
-img {
-	max-width: 100%;
-	height: auto;
-}
-
-iframe {
-	width: 100%;
-}


### PR DESCRIPTION
This is an alternative, and/or addition to #18240.

There is discussion around removing these base styles in favor of letting the theme do the work, and the img and iframe rules have been around for a while but might not be needed. This PR removes both those rules, the other only the iframe which seems to be the most offending.