### PR TITLE
Update `LinkControl` component to utilitse dynamic settings for additional settings "drawer"

### DIFF
--- a/packages/block-editor/src/components/link-control/README.md
+++ b/packages/block-editor/src/components/link-control/README.md
@@ -14,8 +14,20 @@
 
 ### currentSettings
 
-- Type: `Object`
-- Required: Yes
+- Type: `Array`
+- Required: No
+- Default: 
+```
+[
+	{
+		id: 'newTab',
+		title: 'Open in New Tab',
+		checked: false,
+	},
+];
+```
+
+An array of settings objects. Each object will used to render a `ToggleControl` for that setting.
 
 ### fetchSearchSuggestions
 
@@ -75,3 +87,5 @@ The function callback will receive the selected item, or Null.
 
 - Type: `Function`
 - Required: No
+
+Call when any of the settings supplied as `currentSettings` are changed/toggled.

--- a/packages/block-editor/src/components/link-control/README.md
+++ b/packages/block-editor/src/components/link-control/README.md
@@ -27,7 +27,7 @@
 ];
 ```
 
-An array of settings objects. Each object will used to render a `ToggleControl` for that setting.
+An array of settings objects. Each object will used to render a `ToggleControl` for that setting. See also `onSettingsChange`.
 
 ### fetchSearchSuggestions
 
@@ -83,9 +83,27 @@ The function callback will receive the selected item, or Null.
 /> 
 ```  
 
-### onSettingChange
+### onSettingsChange
 
 - Type: `Function`
 - Required: No
+- Args:
+  - `id` - the `id` property of the setting that changed (eg: `newTab`).
+  - `value` - the `checked` value of the control.
+  - `settings` - the current settings object.
 
-Call when any of the settings supplied as `currentSettings` are changed/toggled.
+Called when any of the settings supplied as `currentSettings` are changed/toggled. May be used to attribute a Block's `attributes` with the current state of the control.
+
+```
+<LinkControl
+	currentSettings={ [
+		{
+			id: 'opensInNewTab',
+			title: __( 'Open in New Tab' ),
+			checked: attributes.opensInNewTab, // Block attributes persist control state
+		},
+	] }
+	onSettingsChange={ ( setting, value ) => setAttributes( { [ setting ]: value } ) }
+/>
+```
+

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -53,7 +53,7 @@ function LinkControl( {
 	onKeyDown = noop,
 	onKeyPress = noop,
 	onLinkChange = noop,
-	onSettingsChange = { noop },
+	onSettingsChange = noop,
 } ) {
 	// State
 	const [ inputValue, setInputValue ] = useState( '' );

--- a/packages/block-editor/src/components/link-control/settings-drawer.js
+++ b/packages/block-editor/src/components/link-control/settings-drawer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { partial } from 'lodash';
+import { partial, noop } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -11,7 +11,11 @@ import {
 	ToggleControl,
 } from '@wordpress/components';
 
-const LinkControlSettingsDrawer = ( { settings, onSettingChange } ) => {
+const defaultSettings = {
+	'new-tab': false,
+};
+
+const LinkControlSettingsDrawer = ( { settings = defaultSettings, onSettingChange = noop } ) => {
 	if ( ! settings || settings.length ) {
 		return null;
 	}

--- a/packages/block-editor/src/components/link-control/settings-drawer.js
+++ b/packages/block-editor/src/components/link-control/settings-drawer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { partial, noop } from 'lodash';
+import { noop } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -24,11 +24,15 @@ const LinkControlSettingsDrawer = ( { settings = defaultSettings, onSettingChang
 		return null;
 	}
 
+	const handleSettingChange = ( setting ) => ( value ) => {
+		onSettingChange( setting.id, value, settings );
+	};
+
 	const theSettings = settings.map( ( setting ) => (
 		<ToggleControl
 			key={ setting.id }
 			label={ setting.title }
-			onChange={ partial( onSettingChange, setting.id ) }
+			onChange={ handleSettingChange( setting ) }
 			checked={ setting.checked } />
 	) );
 

--- a/packages/block-editor/src/components/link-control/settings-drawer.js
+++ b/packages/block-editor/src/components/link-control/settings-drawer.js
@@ -15,7 +15,7 @@ const defaultSettings = [
 	{
 		id: 'newTab',
 		title: __( 'Open in New Tab' ),
-		value: false,
+		checked: false,
 	},
 ];
 
@@ -24,13 +24,21 @@ const LinkControlSettingsDrawer = ( { settings = defaultSettings, onSettingChang
 		return null;
 	}
 
+	const theSettings = settings.map( ( setting ) => (
+		<ToggleControl
+			key={ setting.id }
+			label={ setting.title }
+			onChange={ partial( onSettingChange, setting.id ) }
+			checked={ setting.checked } />
+	) );
+
 	return (
-		<div className="block-editor-link-control__settings">
-			<ToggleControl
-				label={ settings[ 0 ].title }
-				onChange={ partial( onSettingChange, settings[ 0 ].id ) }
-				checked={ settings[ 0 ].value } />
-		</div>
+		<fieldset className="block-editor-link-control__settings">
+			<legend className="screen-reader-text">
+				{ __( 'Currently selected link settings' ) }
+			</legend>
+			{ theSettings }
+		</fieldset>
 	);
 };
 

--- a/packages/block-editor/src/components/link-control/settings-drawer.js
+++ b/packages/block-editor/src/components/link-control/settings-drawer.js
@@ -12,7 +12,7 @@ import {
 } from '@wordpress/components';
 
 const defaultSettings = {
-	'new-tab': false,
+	newTab: false,
 };
 
 const LinkControlSettingsDrawer = ( { settings = defaultSettings, onSettingChange = noop } ) => {
@@ -24,8 +24,8 @@ const LinkControlSettingsDrawer = ( { settings = defaultSettings, onSettingChang
 		<div className="block-editor-link-control__settings">
 			<ToggleControl
 				label={ __( 'Open in New Tab' ) }
-				onChange={ partial( onSettingChange, 'new-tab' ) }
-				checked={ settings[ 'new-tab' ] } />
+				onChange={ partial( onSettingChange, 'newTab' ) }
+				checked={ settings.newTab } />
 		</div>
 	);
 };

--- a/packages/block-editor/src/components/link-control/settings-drawer.js
+++ b/packages/block-editor/src/components/link-control/settings-drawer.js
@@ -30,6 +30,7 @@ const LinkControlSettingsDrawer = ( { settings = defaultSettings, onSettingChang
 
 	const theSettings = settings.map( ( setting ) => (
 		<ToggleControl
+			className="block-editor-link-control__setting"
 			key={ setting.id }
 			label={ setting.title }
 			onChange={ handleSettingChange( setting ) }

--- a/packages/block-editor/src/components/link-control/settings-drawer.js
+++ b/packages/block-editor/src/components/link-control/settings-drawer.js
@@ -11,21 +11,25 @@ import {
 	ToggleControl,
 } from '@wordpress/components';
 
-const defaultSettings = {
-	newTab: false,
-};
+const defaultSettings = [
+	{
+		id: 'newTab',
+		title: __( 'Open in New Tab' ),
+		value: false,
+	},
+];
 
 const LinkControlSettingsDrawer = ( { settings = defaultSettings, onSettingChange = noop } ) => {
-	if ( ! settings || settings.length ) {
+	if ( ! settings || ! settings.length ) {
 		return null;
 	}
 
 	return (
 		<div className="block-editor-link-control__settings">
 			<ToggleControl
-				label={ __( 'Open in New Tab' ) }
-				onChange={ partial( onSettingChange, 'newTab' ) }
-				checked={ settings.newTab } />
+				label={ settings[ 0 ].title }
+				onChange={ partial( onSettingChange, settings[ 0 ].id ) }
+				checked={ settings[ 0 ].value } />
 		</div>
 	);
 };

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -178,6 +178,14 @@
 	}
 }
 
+.block-editor-link-control__setting {
+	margin-bottom: $grid-size-large;
+
+	:last-child {
+		margin-bottom: 0;
+	}
+}
+
 .block-editor-link-control .block-editor-link-control__search-input .components-spinner {
 	display: block;
 	z-index: 100;

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -559,6 +559,8 @@ describe( 'Addition Settings UI', () => {
 			);
 		} );
 
+		// console.log( container.innerHTML );
+
 		const newTabSettingLabel = Array.from( container.querySelectorAll( 'label' ) ).find( ( label ) => label.innerHTML && label.innerHTML.includes( expectedSettingText ) );
 		expect( newTabSettingLabel ).not.toBeUndefined(); // find() returns "undefined" if not found
 

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -536,3 +536,35 @@ describe( 'Selecting links', () => {
 		} );
 	} );
 } );
+
+describe( 'Addition Settings UI', () => {
+	it( 'should display "New Tab" setting (in "off" mode) by default when a link is selected', async () => {
+		const selectedLink = first( fauxEntitySuggestions );
+		const expectedSettingText = 'Open in New Tab';
+
+		const LinkControlConsumer = () => {
+			const [ link ] = useState( selectedLink );
+
+			return (
+				<LinkControl
+					currentLink={ link }
+					fetchSearchSuggestions={ fetchFauxEntitySuggestions }
+				/>
+			);
+		};
+
+		act( () => {
+			render(
+				<LinkControlConsumer />, container
+			);
+		} );
+
+		const newTabSettingLabel = Array.from( container.querySelectorAll( 'label' ) ).find( ( label ) => label.innerHTML && label.innerHTML.includes( expectedSettingText ) );
+		expect( newTabSettingLabel ).not.toBeUndefined(); // find() returns "undefined" if not found
+
+		const newTabSettingLabelForAttr = newTabSettingLabel.getAttribute( 'for' );
+		const newTabSettingInput = container.querySelector( `#${ newTabSettingLabelForAttr }` );
+		expect( newTabSettingInput ).not.toBeNull();
+		expect( newTabSettingInput.checked ).toBe( false );
+	} );
+} );

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -569,4 +569,61 @@ describe( 'Addition Settings UI', () => {
 		expect( newTabSettingInput ).not.toBeNull();
 		expect( newTabSettingInput.checked ).toBe( false );
 	} );
+
+	it( 'should display a setting control with correct default state for each of the custom settings provided', async () => {
+		const selectedLink = first( fauxEntitySuggestions );
+
+		const customSettings = [
+			{
+				id: 'newTab',
+				title: 'Open in New Tab',
+				checked: false,
+			},
+			{
+				id: 'noFollow',
+				title: 'No follow',
+				checked: true,
+			},
+		];
+
+		const customSettingsLabelsText = customSettings.map( ( setting ) => setting.title );
+
+		const LinkControlConsumer = () => {
+			const [ link ] = useState( selectedLink );
+
+			return (
+				<LinkControl
+					currentLink={ link }
+					fetchSearchSuggestions={ fetchFauxEntitySuggestions }
+					currentSettings={ customSettings }
+				/>
+			);
+		};
+
+		act( () => {
+			render(
+				<LinkControlConsumer />, container
+			);
+		} );
+
+		// Grab the elements using user perceivable DOM queries
+		const settingsLegend = Array.from( container.querySelectorAll( 'legend' ) ).find( ( legend ) => legend.innerHTML && legend.innerHTML.includes( 'Currently selected link settings' ) );
+		const settingsFieldset = settingsLegend.closest( 'fieldset' );
+		const settingControlsLabels = Array.from( settingsFieldset.querySelectorAll( 'label' ) );
+		const settingControlsInputs = settingControlsLabels.map( ( label ) => {
+			return settingsFieldset.querySelector( `#${ label.getAttribute( 'for' ) }` );
+		} );
+
+		const settingControlLabelsText = Array.from( settingControlsLabels ).map( ( label ) => label.innerHTML );
+
+		// Check we have the correct number of controls
+		expect( settingControlsLabels ).toHaveLength( 2 );
+
+		// Check the labels match
+		expect( settingControlLabelsText ).toEqual( expect.arrayContaining( customSettingsLabelsText ) );
+
+		// Assert the default "checked" states match the expected
+		expect( settingControlsInputs[ 0 ].checked ).toEqual( false );
+		expect( settingControlsInputs[ 1 ].checked ).toEqual( true );
+	} );
 } );

--- a/packages/block-library/src/navigation-menu-item/edit.js
+++ b/packages/block-library/src/navigation-menu-item/edit.js
@@ -45,7 +45,7 @@ import { Fragment, useState, useEffect } from '@wordpress/element';
  * @param {Function} setter Setter attribute function.
  */
 const updateLinkSetting = ( setter ) => ( setting, value ) => {
-	if ( setting === 'new-tab' ) {
+	if ( setting === 'newTab' ) {
 		setter( { opensInNewTab: value } );
 	}
 };
@@ -217,7 +217,13 @@ function NavigationMenuItemEdit( {
 							onClose={ () => {
 								onCloseTimerId = setTimeout( () => setIsLinkOpen( false ), 100 );
 							} }
-							currentSettings={ { 'new-tab': opensInNewTab } }
+							currentSettings={ [
+								{
+									id: 'newTab',
+									title: __( 'Open in New Tab' ),
+									checked: opensInNewTab,
+								},
+							] }
 							onSettingsChange={ updateLinkSetting( setAttributes ) }
 						/>
 					) }

--- a/packages/block-library/src/navigation-menu-item/edit.js
+++ b/packages/block-library/src/navigation-menu-item/edit.js
@@ -45,9 +45,7 @@ import { Fragment, useState, useEffect } from '@wordpress/element';
  * @param {Function} setter Setter attribute function.
  */
 const updateLinkSetting = ( setter ) => ( setting, value ) => {
-	if ( setting === 'newTab' ) {
-		setter( { opensInNewTab: value } );
-	}
+	setter( { opensInNewTab: value } );
 };
 
 /**
@@ -219,7 +217,7 @@ function NavigationMenuItemEdit( {
 							} }
 							currentSettings={ [
 								{
-									id: 'newTab',
+									id: 'opensInNewTab',
 									title: __( 'Open in New Tab' ),
 									checked: opensInNewTab,
 								},

--- a/packages/block-library/src/navigation-menu-item/edit.js
+++ b/packages/block-library/src/navigation-menu-item/edit.js
@@ -45,7 +45,7 @@ import { Fragment, useState, useEffect } from '@wordpress/element';
  * @param {Function} setter Setter attribute function.
  */
 const updateLinkSetting = ( setter ) => ( setting, value ) => {
-	setter( { opensInNewTab: value } );
+	setter( { [ setting ]: value } );
 };
 
 /**


### PR DESCRIPTION
Closes https://github.com/WordPress/gutenberg/issues/18206.

The new experimental Link UI provided by `LinkControl` allows for a currently selected link to have settings such as "Open in new tab"...etc

As things stand the only setting that is possible is "new tab" as this has been hard coded.

This PR updates so that multiple settings can be provided by passing the `currentSettings` prop to `LinkControl`:

```jsx
<LinkControl
	// ...other props here
	currentSettings={ [
		{
			id: 'newTab',
			title: 'Open in New Tab',
			checked: false,
		},
		{ // this is custom!
			id: 'noFollow',
			title: 'No follow',
			checked: true,
		},
	] }
/>

```

## How has this been tested?
Automated tests cover this change.

## Types of changes
Breaking change (fix or feature that would cause existing functionality to not work as expected).

As this updates `LinkControl` we can expect [this PR](https://github.com/WordPress/gutenberg/pull/18062) to break. It will need updating so that:

* `new-tab` becomes `newTab` in any settings provided.


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
