### PR TITLE
Fix: useColors crash when themes remove the color pallete

### DIFF
--- a/packages/block-editor/src/components/colors/use-colors.js
+++ b/packages/block-editor/src/components/colors/use-colors.js
@@ -31,7 +31,6 @@ import InspectorControls from '../inspector-controls';
 import { useBlockEditContext } from '../block-edit';
 
 const DEFAULT_COLORS = [];
-
 const ColorPanel = ( {
 	title,
 	colorSettings,

--- a/packages/block-editor/src/components/colors/use-colors.js
+++ b/packages/block-editor/src/components/colors/use-colors.js
@@ -30,6 +30,8 @@ import ContrastChecker from '../contrast-checker';
 import InspectorControls from '../inspector-controls';
 import { useBlockEditContext } from '../block-edit';
 
+const DEFAULT_COLORS = [];
+
 const ColorPanel = ( {
 	title,
 	colorSettings,
@@ -79,9 +81,10 @@ export default function __experimentalUseColors(
 	const { attributes, settingsColors } = useSelect(
 		( select ) => {
 			const { getBlockAttributes, getSettings } = select( 'core/block-editor' );
+			const colors = getSettings().colors;
 			return {
 				attributes: getBlockAttributes( clientId ),
-				settingsColors: getSettings().colors,
+				settingsColors: ! colors || colors === true ? DEFAULT_COLORS : colors,
 			};
 		},
 		[ clientId ]


### PR DESCRIPTION
## Description
Fixes: https://github.com/WordPress/gutenberg/issues/18232

The useColors hook did not handle the case where themes disable color palette using:
```
add_theme_support( 'editor-color-palette' );
```

This PR fixes the issue.

## How has this been tested?
I added the following code to the functions.php file of the currently enabled theme (removing the code it contained setting a color palette):
```
add_theme_support( 'editor-color-palette' );
```
I opened the editor, added a heading block, verified the block did not crash (on master it crashes), verified no preset colors were available.