### PR TITLE
Revert img, iframe styles to block editor container scope

### DIFF
--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -332,6 +332,11 @@
  */
 
 // These are additional styles for all captions, when the theme opts in to block styles.
+@mixin caption-style() {
+	margin-top: 0.5em;
+	margin-bottom: 1em;
+}
+
 @mixin caption-style-theme() {
 	color: $dark-gray-500;
 	font-size: $default-font-size;

--- a/packages/block-library/src/audio/style.scss
+++ b/packages/block-library/src/audio/style.scss
@@ -1,4 +1,11 @@
 .wp-block-audio {
+	// Supply caption styles to audio blocks, even if the theme hasn't opted in.
+	// Reason being: the new markup, <figcaptions>, are not likely to be styled in the majority of existing themes,
+	// so we supply the styles so as to not appear broken or unstyled in those themes.
+	figcaption {
+		@include caption-style();
+	}
+
 	// Show full-width when not aligned.
 	audio {
 		width: 100%;

--- a/packages/block-library/src/embed/style.scss
+++ b/packages/block-library/src/embed/style.scss
@@ -9,6 +9,12 @@
 }
 
 .wp-block-embed {
+	// Supply caption styles to embeds, even if the theme hasn't opted in.
+	// Reason being: the new markup, figcaptions, are not likely to be styled in the majority of existing themes,
+	// so we supply the styles so as to not appear broken or unstyled in those.
+	figcaption {
+		@include caption-style();
+	}
 	// The embed block is in a `figure` element, and many themes zero this out.
 	// This rule explicitly sets it, to ensure at least some bottom-margin in the flow.
 	margin-bottom: 1em;

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -54,6 +54,13 @@
 		margin-left: auto;
 		margin-right: auto;
 	}
+
+	// Supply caption styles to images, even if the theme hasn't opted in.
+	// Reason being: the new markup, <figcaptions>, are not likely to be styled in the majority of existing themes,
+	// so we supply the styles so as to not appear broken or unstyled in those themes.
+	figcaption {
+		@include caption-style();
+	}
 }
 
 // Variations

--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -247,17 +247,3 @@
 	/*rtl:ignore*/
 	text-align: right;
 }
-
-/**
- * Vanilla Block Styles
- * These are base styles that apply across blocks, meant to provide a baseline.
- * They are applied both to the editor and the theme, so we should have as few of these as possible.
- * Please note that some styles are stored in packages/editor/src/editor-styles.scss, as they pertain to CSS bleed for the editor only.
- */
-
-// Caption styles.
-// Supply these even if the theme hasn't opted in, because the figcaption element is not likely to be styled in the majority of existing themes.
-// By providing a minimum of margin styles, we ensure it doesn't look broken or unstyled in those themes.
-figcaption {
-	margin-top: 0.5em;
-}

--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -261,13 +261,3 @@
 figcaption {
 	margin-top: 0.5em;
 }
-
-// Apply some base styles to blocks that need them.
-img {
-	max-width: 100%;
-	height: auto;
-}
-
-iframe {
-	width: 100%;
-}

--- a/packages/block-library/src/video/style.scss
+++ b/packages/block-library/src/video/style.scss
@@ -16,4 +16,11 @@
 	&.aligncenter {
 		text-align: center;
 	}
+
+	// Supply caption styles to videos, even if the theme hasn't opted in.
+	// Reason being: the new markup, <figcaptions>, are not likely to be styled in the majority of existing themes,
+	// so we supply the styles so as to not appear broken or unstyled in those themes.
+	figcaption {
+		@include caption-style();
+	}
 }

--- a/packages/edit-post/src/style.scss
+++ b/packages/edit-post/src/style.scss
@@ -83,6 +83,15 @@ body.block-editor-page {
 		}
 	}
 
+	img {
+		max-width: 100%;
+		height: auto;
+	}
+
+	iframe {
+		width: 100%;
+	}
+
 	.components-navigate-regions {
 		height: 100%;
 	}


### PR DESCRIPTION
Previously: #14407
Alternative to: #18240, #18281

This pull request seeks to revert styling applied globally to `img` and `iframe` (**Update:** and `figcaption`) to that which existed prior to #14407. Prior to #14407, these styles were scoped to only apply within the editor. As of #14407, they apply to these elements globally (including on the front-end), thus introducing some conflict.

There is discussion on an ideal solution to this scenario in #18240. However, for the purposes of a release in time for 5.3, the proposed changes here limit the scope to reverting a previously-known state.

Specific change being reverted: https://github.com/WordPress/gutenberg/pull/14407/files#diff-556b1933de5650dc555c469c584accc2L91