### PR TITLE
Show new block indicator in default appender too

### DIFF
--- a/packages/block-editor/src/components/block-list/index.native.js
+++ b/packages/block-editor/src/components/block-list/index.native.js
@@ -60,7 +60,7 @@ export class BlockList extends Component {
 
 	renderDefaultBlockAppender() {
 		const { blockClientIds, shouldShowInsertionPoint } = this.props;
-		const willShowInsertionPoint = blockClientIds.length === 0 && shouldShowInsertionPoint();
+		const willShowInsertionPoint = shouldShowInsertionPoint();
 
 		return (
 			<ReadableContentView>

--- a/packages/block-editor/src/components/block-list/index.native.js
+++ b/packages/block-editor/src/components/block-list/index.native.js
@@ -59,12 +59,18 @@ export class BlockList extends Component {
 	}
 
 	renderDefaultBlockAppender() {
+		const { blockClientIds, shouldShowInsertionPoint } = this.props;
+		const willShowInsertionPoint = blockClientIds.length === 0 && shouldShowInsertionPoint();
+
 		return (
 			<ReadableContentView>
-				<BlockListAppender
-					rootClientId={ this.props.rootClientId }
-					renderAppender={ this.props.renderAppender }
-				/>
+				{ willShowInsertionPoint && this.renderAddBlockSeparator() }
+				{ ! willShowInsertionPoint &&
+					<BlockListAppender
+						rootClientId={ this.props.rootClientId }
+						renderAppender={ this.props.renderAppender }
+					/>
+				}
 			</ReadableContentView>
 		);
 	}
@@ -182,7 +188,7 @@ export default compose( [
 			return (
 				blockInsertionPointIsVisible &&
 				insertionPoint.rootClientId === rootClientId &&
-				blockClientIds[ insertionPoint.index ] === clientId
+				( blockClientIds.length === 0 || blockClientIds[ insertionPoint.index ] === clientId )
 			);
 		};
 

--- a/packages/block-editor/src/components/block-list/index.native.js
+++ b/packages/block-editor/src/components/block-list/index.native.js
@@ -63,9 +63,9 @@ export class BlockList extends Component {
 		const willShowInsertionPoint = shouldShowInsertionPointBefore(); // call without the client_id argument since this is the appender
 		return (
 			<ReadableContentView>
-				{ willShowInsertionPoint && this.renderAddBlockSeparator() }
-				{ ! willShowInsertionPoint &&
-					<BlockListAppender
+				{ willShowInsertionPoint ?
+					this.renderAddBlockSeparator() :	// show the new-block indicator when we're inserting a block or
+					<BlockListAppender				// show the default appender, as normal, when not inserting a block
 						rootClientId={ this.props.rootClientId }
 						renderAppender={ this.props.renderAppender }
 					/>

--- a/packages/block-editor/src/components/block-list/index.native.js
+++ b/packages/block-editor/src/components/block-list/index.native.js
@@ -59,7 +59,7 @@ export class BlockList extends Component {
 	}
 
 	renderDefaultBlockAppender() {
-		const { blockClientIds, shouldShowInsertionPointBefore } = this.props;
+		const { shouldShowInsertionPointBefore } = this.props;
 		const willShowInsertionPoint = shouldShowInsertionPointBefore(); // call without the client_id argument since this is the appender
 		return (
 			<ReadableContentView>


### PR DESCRIPTION
## Description
Showing the "ADD BLOCK HERE" block insertion point indicator when the block list is fully empty too. Also, at the end of the list when not empty

Gutenberg-mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1542

## How has this been tested?
Using the gutenberg-mobile PR.

## Types of changes
1. Revised the default mobile block appender to show the new-block insertion point indicator instead of the default paragraph block, when the related flag is true and the block list is empty.
2. Introduced a method to check if the indicator at the end of the block should appear, when the insertion point is at the end of the list.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
