### PR TITLE
Change Detection: Add a test case for post trashing.

### DIFF
--- a/packages/e2e-test-utils/src/is-current-url.js
+++ b/packages/e2e-test-utils/src/is-current-url.js
@@ -20,5 +20,5 @@ export function isCurrentURL( WPPath, query = '' ) {
 
 	currentURL.search = query;
 
-	return createURL( WPPath ) === currentURL.href;
+	return createURL( WPPath, query ) === currentURL.href;
 }

--- a/packages/e2e-tests/specs/editor/various/change-detection.test.js
+++ b/packages/e2e-tests/specs/editor/various/change-detection.test.js
@@ -7,6 +7,8 @@ import {
 	pressKeyWithModifier,
 	ensureSidebarOpened,
 	publishPost,
+	saveDraft,
+	openDocumentSettingsSidebar,
 } from '@wordpress/e2e-test-utils';
 
 describe( 'Change detection', () => {
@@ -159,13 +161,7 @@ describe( 'Change detection', () => {
 	it( 'Should not prompt if changes saved', async () => {
 		await page.type( '.editor-post-title__input', 'Hello World' );
 
-		await Promise.all( [
-			// Wait for "Saved" to confirm save complete.
-			page.waitForSelector( '.editor-post-saved-state.is-saved' ),
-
-			// Keyboard shortcut Ctrl+S save.
-			pressKeyWithModifier( 'primary', 'S' ),
-		] );
+		await saveDraft();
 
 		await assertIsDirty( false );
 	} );
@@ -174,13 +170,7 @@ describe( 'Change detection', () => {
 		await clickBlockAppender();
 		await page.keyboard.type( 'Hello World' );
 
-		await Promise.all( [
-			// Wait for "Saved" to confirm save complete.
-			page.waitForSelector( '.editor-post-saved-state.is-saved' ),
-
-			// Keyboard shortcut Ctrl+S save.
-			pressKeyWithModifier( 'primary', 'S' ),
-		] );
+		await saveDraft();
 
 		await assertIsDirty( false );
 	} );
@@ -188,13 +178,7 @@ describe( 'Change detection', () => {
 	it( 'Should not save if all changes saved', async () => {
 		await page.type( '.editor-post-title__input', 'Hello World' );
 
-		await Promise.all( [
-			// Wait for "Saved" to confirm save complete.
-			page.waitForSelector( '.editor-post-saved-state.is-saved' ),
-
-			// Keyboard shortcut Ctrl+S save.
-			pressKeyWithModifier( 'primary', 'S' ),
-		] );
+		await saveDraft();
 
 		await interceptSave();
 
@@ -330,13 +314,7 @@ describe( 'Change detection', () => {
 		await page.keyboard.type( 'Paragraph' );
 
 		// Save
-		await Promise.all( [
-			// Wait for "Saved" to confirm save complete.
-			page.waitForSelector( '.editor-post-saved-state.is-saved' ),
-
-			// Keyboard shortcut Ctrl+S save.
-			pressKeyWithModifier( 'primary', 'S' ),
-		] );
+		await saveDraft();
 
 		// Verify that the title is empty.
 		const title = await page.$eval(
@@ -346,6 +324,24 @@ describe( 'Change detection', () => {
 		expect( title ).toBe( '' );
 
 		// Verify that the post is not dirty.
+		await assertIsDirty( false );
+	} );
+
+	it( 'should not prompt to confirm unsaved changes when trashing an existing post', async () => {
+		// Enter title.
+		await page.type( '.editor-post-title__input', 'Hello World' );
+
+		// Save
+		await saveDraft();
+
+		// Trash post.
+		await openDocumentSettingsSidebar();
+		await page.click( '.editor-post-trash.components-button' );
+
+		// Wait for "Saved" to confirm save complete.
+		await page.waitForSelector( '.editor-post-saved-state.is-saved' );
+
+		// Check that the dialog didn't show.
 		await assertIsDirty( false );
 	} );
 } );

--- a/packages/e2e-tests/specs/editor/various/change-detection.test.js
+++ b/packages/e2e-tests/specs/editor/various/change-detection.test.js
@@ -9,6 +9,7 @@ import {
 	publishPost,
 	saveDraft,
 	openDocumentSettingsSidebar,
+	isCurrentURL,
 } from '@wordpress/e2e-test-utils';
 
 describe( 'Change detection', () => {
@@ -341,7 +342,8 @@ describe( 'Change detection', () => {
 		// Wait for "Saved" to confirm save complete.
 		await page.waitForSelector( '.editor-post-saved-state.is-saved' );
 
-		// Check that the dialog didn't show.
-		await assertIsDirty( false );
+		// Make sure redirection happens.
+		await page.waitForNavigation();
+		isCurrentURL( 'edit.php' );
 	} );
 } );

--- a/packages/e2e-tests/specs/editor/various/change-detection.test.js
+++ b/packages/e2e-tests/specs/editor/various/change-detection.test.js
@@ -344,6 +344,6 @@ describe( 'Change detection', () => {
 
 		// Make sure redirection happens.
 		await page.waitForNavigation();
-		isCurrentURL( 'edit.php' );
+		expect( isCurrentURL( 'edit.php' ) ).toBe( true );
 	} );
 } );

--- a/packages/e2e-tests/specs/editor/various/change-detection.test.js
+++ b/packages/e2e-tests/specs/editor/various/change-detection.test.js
@@ -334,16 +334,22 @@ describe( 'Change detection', () => {
 
 		// Save
 		await saveDraft();
+		const postId = await page.evaluate(
+			() => window.wp.data.select( 'core/editor' ).getCurrentPostId()
+		);
 
 		// Trash post.
 		await openDocumentSettingsSidebar();
 		await page.click( '.editor-post-trash.components-button' );
 
-		// Wait for "Saved" to confirm save complete.
-		await page.waitForSelector( '.editor-post-saved-state.is-saved' );
+		await Promise.all( [
+			// Wait for "Saved" to confirm save complete.
+			await page.waitForSelector( '.editor-post-saved-state.is-saved' ),
 
-		// Make sure redirection happens.
-		await page.waitForNavigation();
-		expect( isCurrentURL( 'edit.php' ) ).toBe( true );
+			// Make sure redirection happens.
+			await page.waitForNavigation(),
+		] );
+
+		expect( isCurrentURL( '/wp-admin/edit.php', `post_type=post&ids=${ postId }` ) ).toBe( true );
 	} );
 } );


### PR DESCRIPTION
Follows #18275

## Description

This PR fixes and reintroduces the test case from #18275.

It also replaces some ad-hoc saving code with the correct e2e test util, `saveDraft`.

## How has this been tested?

The new tests were verified to test for the issue fixed in #18275.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
