### PR TITLE
Link UI: Fix focus styles w/ suggestions showing

### DIFF
--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -53,14 +53,14 @@
 
 	&::before {
 		height: $grid-size-large/2;
-		top: -1px;
+		top: 0;
 		bottom: auto;
 		background: linear-gradient(to bottom, rgba(255, 255, 255, 1) 0%, rgba(255, 255, 255, 0) 100%);
 	}
 
 	&::after {
 		height: 20px;
-		bottom: -1px;
+		bottom: 0;
 		top: auto;
 		background: linear-gradient(to bottom, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 1) 100%);
 	}

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -59,7 +59,7 @@
 	}
 
 	&::after {
-		height: 20px;
+		height: $grid-size-large;
 		bottom: 0;
 		top: auto;
 		background: linear-gradient(to bottom, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 1) 100%);
@@ -68,7 +68,7 @@
 
 .block-editor-link-control__search-results {
 	margin: 0;
-	padding: $grid-size-large/2 $grid-size-large;
+	padding: $grid-size-large/2 $grid-size-large $grid-size-large;
 	max-height: 200px;
 	overflow-y: scroll; // allow results list to scroll
 


### PR DESCRIPTION
## Description
Limits the height of the suggestion list's top & bottom gradient.

## How has this been tested?
* Checked out #18062 and cherry picked this commit.
* Created a new menu item and started a search for "page" to get a list of suggestions.

## Screenshots

#### Before:
<img width="372" alt="Screen Shot 2019-11-05 at 2 02 28 PM" src="https://user-images.githubusercontent.com/1398304/68251083-4445fe00-ffd7-11e9-93b6-a31b49cc37cc.png">

#### After:
<img width="372" alt="Screen Shot 2019-11-05 at 2 02 55 PM" src="https://user-images.githubusercontent.com/1398304/68251104-4c05a280-ffd7-11e9-9b3a-a45b980e6a40.png">


## Types of changes
Bug fix (non-breaking change which fixes an issue) as described in #18135.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
