### PR TITLE
Handle non-existant wp-env.json file

### DIFF
--- a/packages/env/lib/resolve-dependencies.js
+++ b/packages/env/lib/resolve-dependencies.js
@@ -26,7 +26,14 @@ const readFile = util.promisify( fs.readFile );
  * @return {Array<detectContext.Context>} An array of dependencies in the context format.
  */
 module.exports = async function resolveDependencies() {
-	const envFile = await readFile( './wp-env.json' );
+	let envFile;
+
+	try {
+		envFile = await readFile( './wp-env.json' );
+	} catch ( error ) {
+		return [];
+	}
+
 	const { themes, plugins } = JSON.parse( envFile );
 
 	const dependencyResolvers = [];

--- a/packages/env/lib/resolve-dependencies.js
+++ b/packages/env/lib/resolve-dependencies.js
@@ -27,7 +27,6 @@ const readFile = util.promisify( fs.readFile );
  */
 module.exports = async function resolveDependencies() {
 	let envFile;
-
 	try {
 		envFile = await readFile( './wp-env.json' );
 	} catch ( error ) {


### PR DESCRIPTION
## Description
Attempted to restart my gutenberg env `npx wp-env start` on the latest mater, but it looks like since #18121 a wp-env.json file is expected, the following error occurred:
```
ENOENT: no such file or directory, open './wp-env.json'
```

I think either this file should be defined in gutenberg or the code could handle the file not being there. Not sure which! This PR is my naive attempt at a fix 😄

From a brief look at the code it seems like it should be optional.

## How has this been tested?
Ran `npx wp-env start`, didn't receive the error and my environment was created.
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
