### PR TITLE
Add ESLint rule to wrap multiline JSX in parentheses

### DIFF
--- a/packages/block-directory/src/components/downloadable-blocks-list/index.js
+++ b/packages/block-directory/src/components/downloadable-blocks-list/index.js
@@ -27,7 +27,7 @@ function DownloadableBlocksList( { items, onHover = noop, children, downloadAndI
 		 */
 		/* eslint-disable jsx-a11y/no-redundant-roles */
 		<ul role="list" className="block-directory-downloadable-blocks-list">
-			{ items && items.map( ( item ) =>
+			{ items && items.map( ( item ) => (
 				<DownloadableBlockListItem
 					key={ item.id }
 					className={ getBlockMenuDefaultClassName( item.id ) }
@@ -42,7 +42,7 @@ function DownloadableBlocksList( { items, onHover = noop, children, downloadAndI
 					onBlur={ () => onHover( null ) }
 					item={ item }
 				/>
-			) }
+			) ) }
 			{ children }
 		</ul>
 		/* eslint-enable jsx-a11y/no-redundant-roles */

--- a/packages/block-editor/src/components/block-list/subdirectory-icon.js
+++ b/packages/block-editor/src/components/block-list/subdirectory-icon.js
@@ -12,7 +12,8 @@ const Subdirectory = ( { ...extraProps } ) => (
 		{ ...extraProps }
 	>
 		<Path d="M19 15l-6 6-1.42-1.42L15.17 16H4V4h2v10h9.17l-3.59-3.58L13 9l6 6z" />
-	</SVG> )
+	</SVG>
+)
 ;
 
 export default Subdirectory;

--- a/packages/block-editor/src/components/block-settings/button.native.js
+++ b/packages/block-editor/src/components/block-settings/button.native.js
@@ -7,12 +7,13 @@ import { withDispatch } from '@wordpress/data';
 
 const { Fill, Slot } = createSlotFill( 'SettingsToolbarButton' );
 
-const SettingsButton = ( { openGeneralSidebar } ) =>
+const SettingsButton = ( { openGeneralSidebar } ) => (
 	<ToolbarButton
 		title={ __( 'Open Settings' ) }
 		icon="admin-generic"
 		onClick={ openGeneralSidebar }
-	/>;
+	/>
+);
 
 const SettingsButtonFill = ( props ) => (
 	<Fill>

--- a/packages/block-editor/src/components/block-types-list/index.js
+++ b/packages/block-editor/src/components/block-types-list/index.js
@@ -16,7 +16,7 @@ function BlockTypesList( { items, onSelect, onHover = () => {}, children } ) {
 		 */
 		/* eslint-disable jsx-a11y/no-redundant-roles */
 		<ul role="list" className="editor-block-types-list block-editor-block-types-list">
-			{ items && items.map( ( item ) =>
+			{ items && items.map( ( item ) => (
 				<InserterListItem
 					key={ item.id }
 					className={ getBlockMenuDefaultClassName( item.id ) }
@@ -32,7 +32,7 @@ function BlockTypesList( { items, onSelect, onHover = () => {}, children } ) {
 					isDisabled={ item.isDisabled }
 					title={ item.title }
 				/>
-			) }
+			) ) }
 			{ children }
 		</ul>
 		/* eslint-enable jsx-a11y/no-redundant-roles */

--- a/packages/block-editor/src/components/inserter/menu.native.js
+++ b/packages/block-editor/src/components/inserter/menu.native.js
@@ -86,7 +86,7 @@ export class InserterMenu extends Component {
 						<View style={ styles.rowSeparator } />
 					}
 					keyExtractor={ ( item ) => item.name }
-					renderItem={ ( { item } ) =>
+					renderItem={ ( { item } ) => (
 						<TouchableHighlight
 							style={ styles.touchableArea }
 							underlayColor="transparent"
@@ -102,7 +102,7 @@ export class InserterMenu extends Component {
 								<Text style={ modalItemLabelStyle }>{ item.title }</Text>
 							</View>
 						</TouchableHighlight>
-					}
+					) }
 				/>
 			</BottomSheet>
 		);

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -397,7 +397,7 @@ class RichTextWrapper extends Component {
 				__unstableDidAutomaticChange={ didAutomaticChange }
 				__unstableUndo={ undo }
 			>
-				{ ( { isSelected, value, onChange, Editable } ) =>
+				{ ( { isSelected, value, onChange, Editable } ) => (
 					<>
 						{ children && children( { value, onChange } ) }
 						{ isSelected && hasFormats && ( <FormatToolbarContainer inline={ inlineToolbar } anchorObj={ this.ref } /> ) }
@@ -409,7 +409,7 @@ class RichTextWrapper extends Component {
 							onChange={ onChange }
 							isSelected={ isSelected }
 						>
-							{ ( { listBoxId, activeId, onKeyDown } ) =>
+							{ ( { listBoxId, activeId, onKeyDown } ) => (
 								<Editable
 									aria-autocomplete={ listBoxId ? 'list' : undefined }
 									aria-owns={ listBoxId }
@@ -418,10 +418,10 @@ class RichTextWrapper extends Component {
 									reversed={ reversed }
 									onKeyDown={ onKeyDown }
 								/>
-							}
+							) }
 						</Autocomplete>
 					</>
-				}
+				) }
 			</RichText>
 		);
 

--- a/packages/block-editor/src/components/warning/index.js
+++ b/packages/block-editor/src/components/warning/index.js
@@ -41,11 +41,11 @@ function Warning( { className, actions, children, secondaryActions } ) {
 					) }
 					renderContent={ () => (
 						<MenuGroup>
-							{ secondaryActions.map( ( item, pos ) =>
+							{ secondaryActions.map( ( item, pos ) => (
 								<MenuItem onClick={ item.onClick } key={ pos }>
 									{ item.title }
 								</MenuItem>
-							) }
+							) ) }
 						</MenuGroup>
 					) }
 				/>

--- a/packages/block-library/src/list/edit.js
+++ b/packages/block-library/src/list/edit.js
@@ -114,32 +114,34 @@ export default function ListEdit( {
 		</>
 	);
 
-	return <>
-		<RichText
-			identifier="values"
-			multiline="li"
-			tagName={ tagName }
-			onChange={ ( nextValues ) => setAttributes( { values: nextValues } ) }
-			value={ values }
-			className={ className }
-			placeholder={ __( 'Write list…' ) }
-			onMerge={ mergeBlocks }
-			onSplit={ ( value ) => createBlock( name, { ...attributes, values: value } ) }
-			__unstableOnSplitMiddle={ () => createBlock( 'core/paragraph' ) }
-			onReplace={ onReplace }
-			onRemove={ () => onReplace( [] ) }
-			start={ start }
-			reversed={ reversed }
-			type={ type }
-		>
-			{ controls }
-		</RichText>
-		{ ordered && (
-			<OrderedListSettings
-				setAttributes={ setAttributes }
-				ordered={ ordered }
-				reversed={ reversed }
+	return (
+		<>
+			<RichText
+				identifier="values"
+				multiline="li"
+				tagName={ tagName }
+				onChange={ ( nextValues ) => setAttributes( { values: nextValues } ) }
+				value={ values }
+				className={ className }
+				placeholder={ __( 'Write list…' ) }
+				onMerge={ mergeBlocks }
+				onSplit={ ( value ) => createBlock( name, { ...attributes, values: value } ) }
+				__unstableOnSplitMiddle={ () => createBlock( 'core/paragraph' ) }
+				onReplace={ onReplace }
+				onRemove={ () => onReplace( [] ) }
 				start={ start }
-			/> ) }
-	</>;
+				reversed={ reversed }
+				type={ type }
+			>
+				{ controls }
+			</RichText>
+			{ ordered && (
+				<OrderedListSettings
+					setAttributes={ setAttributes }
+					ordered={ ordered }
+					reversed={ reversed }
+					start={ start }
+				/> ) }
+		</>
+	);
 }

--- a/packages/block-library/src/list/ordered-list-settings.js
+++ b/packages/block-library/src/list/ordered-list-settings.js
@@ -38,6 +38,7 @@ const OrderedListSettings = ( { setAttributes, reversed, start } ) => (
 				} }
 			/>
 		</PanelBody>
-	</InspectorControls> );
+	</InspectorControls>
+);
 
 export default OrderedListSettings;

--- a/packages/block-library/src/media-text/media-container.native.js
+++ b/packages/block-library/src/media-text/media-container.native.js
@@ -271,26 +271,28 @@ class MediaContainer extends Component {
 						allowedTypes={ ALLOWED_MEDIA_TYPES }
 						value={ mediaId }
 						render={ ( { open, getMediaOptions } ) => {
-							return <>
-								{ getMediaOptions() }
-								{ this.renderToolbarEditButton( open ) }
+							return (
+								<>
+									{ getMediaOptions() }
+									{ this.renderToolbarEditButton( open ) }
 
-								<MediaUploadProgress
-									coverUrl={ coverUrl }
-									mediaId={ mediaId }
-									onUpdateMediaProgress={ this.updateMediaProgress }
-									onFinishMediaUploadWithSuccess={ this.finishMediaUploadWithSuccess }
-									onFinishMediaUploadWithFailure={ this.finishMediaUploadWithFailure }
-									onMediaUploadStateReset={ this.mediaUploadStateReset }
-									renderContent={ ( params ) => {
-										return (
-											<View style={ styles.content }>
-												{ this.renderContent( params, open ) }
-											</View>
-										);
-									} }
-								/>
-							</>;
+									<MediaUploadProgress
+										coverUrl={ coverUrl }
+										mediaId={ mediaId }
+										onUpdateMediaProgress={ this.updateMediaProgress }
+										onFinishMediaUploadWithSuccess={ this.finishMediaUploadWithSuccess }
+										onFinishMediaUploadWithFailure={ this.finishMediaUploadWithFailure }
+										onMediaUploadStateReset={ this.mediaUploadStateReset }
+										renderContent={ ( params ) => {
+											return (
+												<View style={ styles.content }>
+													{ this.renderContent( params, open ) }
+												</View>
+											);
+										} }
+									/>
+								</>
+							);
 						} }
 					/>
 				</View>

--- a/packages/block-library/src/navigation-menu/block-colors-selector.js
+++ b/packages/block-library/src/navigation-menu/block-colors-selector.js
@@ -23,7 +23,7 @@ const ColorSelectorSVGIcon = () => (
  *
  * @return {*} React Icon component.
  */
-const ColorSelectorIcon = ( { style } ) =>
+const ColorSelectorIcon = ( { style } ) => (
 	<div className="block-library-colors-selector__icon-container">
 		<div
 			className="block-library-colors-selector__state-selection"
@@ -31,7 +31,8 @@ const ColorSelectorIcon = ( { style } ) =>
 		>
 			<ColorSelectorSVGIcon />
 		</div>
-	</div>;
+	</div>
+);
 
 /**
  * Renders the Colors Selector Toolbar with the icon button.
@@ -91,11 +92,12 @@ const renderContent = ( { backgroundColor, textColor, onColorChange = noop } ) =
 	);
 } );
 
-export default ( { style, className, ...colorControlProps } ) =>
+export default ( { style, className, ...colorControlProps } ) => (
 	<Dropdown
 		position="bottom right"
 		className={ classnames( 'block-library-colors-selector', className ) }
 		contentClassName="block-library-colors-selector__popover"
 		renderToggle={ renderToggleComponent( style ) }
 		renderContent={ renderContent( colorControlProps ) }
-	/>;
+	/>
+);

--- a/packages/block-library/src/separator/save.js
+++ b/packages/block-library/src/separator/save.js
@@ -34,8 +34,10 @@ export default function separatorSave( { attributes } ) {
 		color: colorClass ? undefined : customColor,
 	};
 
-	return ( <hr
-		className={ separatorClasses }
-		style={ separatorStyle }
-	/> );
+	return (
+		<hr
+			className={ separatorClasses }
+			style={ separatorStyle }
+		/>
+	);
 }

--- a/packages/block-library/src/table/deprecated.js
+++ b/packages/block-library/src/table/deprecated.js
@@ -53,14 +53,14 @@ const deprecated = [
 					<Tag>
 						{ rows.map( ( { cells }, rowIndex ) => (
 							<tr key={ rowIndex }>
-								{ cells.map( ( { content, tag, scope }, cellIndex ) =>
+								{ cells.map( ( { content, tag, scope }, cellIndex ) => (
 									<RichText.Content
 										tagName={ tag }
 										value={ content }
 										key={ cellIndex }
 										scope={ tag === 'th' ? scope : undefined }
 									/>
-								) }
+								) ) }
 							</tr>
 						) ) }
 					</Tag>

--- a/packages/block-library/src/text-columns/save.js
+++ b/packages/block-library/src/text-columns/save.js
@@ -12,11 +12,11 @@ export default function save( { attributes } ) {
 	const { width, content, columns } = attributes;
 	return (
 		<div className={ `align${ width } columns-${ columns }` }>
-			{ times( columns, ( index ) =>
+			{ times( columns, ( index ) => (
 				<div className="wp-block-column" key={ `column-${ index }` }>
 					<RichText.Content tagName="p" value={ get( content, [ index, 'children' ] ) } />
 				</div>
-			) }
+			) ) }
 		</div>
 	);
 }

--- a/packages/blocks/src/api/test/registration.js
+++ b/packages/blocks/src/api/test/registration.js
@@ -273,10 +273,12 @@ describe( 'blocks', () => {
 
 		it( 'should normalize the icon containing a function', () => {
 			const MyTestIcon = () => {
-				return <svg width="20" height="20" viewBox="0 0 20 20">
-					<circle cx="10" cy="10" r="10"
-						fill="red" stroke="blue" strokeWidth="10" />
-				</svg>;
+				return (
+					<svg width="20" height="20" viewBox="0 0 20 20">
+						<circle cx="10" cy="10" r="10"
+							fill="red" stroke="blue" strokeWidth="10" />
+					</svg>
+				);
 			};
 			const blockType = {
 				save: noop,

--- a/packages/components/src/mobile/picker/index.android.js
+++ b/packages/components/src/mobile/picker/index.android.js
@@ -48,7 +48,7 @@ export default class Picker extends Component {
 				hideHeader
 			>
 				<View>
-					{ this.props.options.map( ( option, index ) =>
+					{ this.props.options.map( ( option, index ) => (
 						<BottomSheet.Cell
 							icon={ option.icon }
 							key={ index }
@@ -57,7 +57,7 @@ export default class Picker extends Component {
 							separatorType={ 'none' }
 							onPress={ () => this.onCellPress( option.value ) }
 						/>
-					) }
+					) ) }
 					{ ! this.props.hideCancelButton && <BottomSheet.Cell
 						label={ __( 'Cancel' ) }
 						onPress={ this.onClose }

--- a/packages/components/src/radio-control/index.js
+++ b/packages/components/src/radio-control/index.js
@@ -20,7 +20,7 @@ function RadioControl( { label, className, selected, help, instanceId, onChange,
 
 	return ! isEmpty( options ) && (
 		<BaseControl label={ label } id={ id } help={ help } className={ classnames( className, 'components-radio-control' ) }>
-			{ options.map( ( option, index ) =>
+			{ options.map( ( option, index ) => (
 				<div
 					key={ `${ id }-${ index }` }
 					className="components-radio-control__option"
@@ -39,7 +39,7 @@ function RadioControl( { label, className, selected, help, instanceId, onChange,
 						{ option.label }
 					</label>
 				</div>
-			) }
+			) ) }
 		</BaseControl>
 	);
 }

--- a/packages/components/src/select-control/index.js
+++ b/packages/components/src/select-control/index.js
@@ -48,7 +48,7 @@ function SelectControl( {
 				multiple={ multiple }
 				{ ...props }
 			>
-				{ options.map( ( option, index ) =>
+				{ options.map( ( option, index ) => (
 					<option
 						key={ `${ option.label }-${ option.value }-${ index }` }
 						value={ option.value }
@@ -56,7 +56,7 @@ function SelectControl( {
 					>
 						{ option.label }
 					</option>
-				) }
+				) ) }
 			</select>
 		</BaseControl>
 	);

--- a/packages/edit-post/src/components/block-settings-menu/plugin-block-settings-menu-item.js
+++ b/packages/edit-post/src/components/block-settings-menu/plugin-block-settings-menu-item.js
@@ -89,15 +89,17 @@ const PluginBlockSettingsMenuItem = ( { allowedBlocks, icon, label, onClick, sma
 			if ( ! shouldRenderItem( selectedBlocks, allowedBlocks ) ) {
 				return null;
 			}
-			return ( <MenuItem
-				className="editor-block-settings-menu__control block-editor-block-settings-menu__control"
-				onClick={ compose( onClick, onClose ) }
-				icon={ icon || 'admin-plugins' }
-				label={ small ? label : undefined }
-				role={ role }
-			>
-				{ ! small && label }
-			</MenuItem> );
+			return (
+				<MenuItem
+					className="editor-block-settings-menu__control block-editor-block-settings-menu__control"
+					onClick={ compose( onClick, onClose ) }
+					icon={ icon || 'admin-plugins' }
+					label={ small ? label : undefined }
+					role={ role }
+				>
+					{ ! small && label }
+				</MenuItem>
+			);
 		} }
 	</PluginBlockSettingsMenuGroup>
 );

--- a/packages/edit-post/src/components/editor-initialization/test/listener-hooks.js
+++ b/packages/edit-post/src/components/editor-initialization/test/listener-hooks.js
@@ -60,9 +60,11 @@ describe( 'listener hook tests', () => {
 			testedHook( postId );
 			return null;
 		};
-		const TestedOutput = <RegistryProvider value={ registry }>
-			<TestComponent postId={ id } />
-		</RegistryProvider>;
+		const TestedOutput = (
+			<RegistryProvider value={ registry }>
+				<TestComponent postId={ id } />
+			</RegistryProvider>
+		);
 		return renderer === null ?
 			TestRenderer.create( TestedOutput ) :
 			renderer.update( TestedOutput );

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Master
+
+### Breaking Changes
+
+- The recommended `react` configuration now enforces [`react/jsx-wrap-multilines`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-wrap-multilines.md).
+
 ## 3.0.0 (2019-08-29)
 
 ### Breaking Changes

--- a/packages/eslint-plugin/configs/react.js
+++ b/packages/eslint-plugin/configs/react.js
@@ -25,6 +25,12 @@ module.exports = {
 		'react/jsx-indent-props': [ 'error', 'tab' ],
 		'react/jsx-key': 'error',
 		'react/jsx-tag-spacing': 'error',
+		'react/jsx-wrap-multilines': [ 'error', {
+			declaration: 'parens-new-line',
+			assignment: 'parens-new-line',
+			return: 'parens-new-line',
+			arrow: 'parens-new-line',
+		} ],
 		'react/no-children-prop': 'off',
 		'react/prop-types': 'off',
 		'react/react-in-jsx-scope': 'off',


### PR DESCRIPTION
## Description

I noticed this is the prevalent style across the codebase but it's not currently enforced by ESLint.

I added [react/jsx-wrap-multilines](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-wrap-multilines.md) to the recommended set of rules.

I also changed the default configuration to ensure new lines after the parentheses. There were 18 violations with the default settings and 23 with the new-line setting.

The `condition`, `logical`, and `prop` configurations also seemed nicer to me, but enabling them bumped the violation count to 118, so it doesn't seem there's enough consensus on that one.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
