### PR TITLE
[RNMobile] Simplify bridge requestMediaPick methods

### DIFF
--- a/packages/block-editor/src/components/media-upload/index.native.js
+++ b/packages/block-editor/src/components/media-upload/index.native.js
@@ -3,11 +3,8 @@
  */
 import React from 'react';
 import {
-	requestMediaPickFromMediaLibrary,
-	requestMediaPickFromDeviceLibrary,
-	requestMediaPickFromDeviceCamera,
 	getOtherMediaOptions,
-	requestOtherMediaPickFrom,
+	requestMediaPicker,
 } from 'react-native-gutenberg-bridge';
 
 /**
@@ -19,9 +16,9 @@ import { Picker } from '@wordpress/components';
 export const MEDIA_TYPE_IMAGE = 'image';
 export const MEDIA_TYPE_VIDEO = 'video';
 
-export const MEDIA_UPLOAD_BOTTOM_SHEET_VALUE_CHOOSE_FROM_DEVICE = 'choose_from_device';
-export const MEDIA_UPLOAD_BOTTOM_SHEET_VALUE_TAKE_MEDIA = 'take_media';
-export const MEDIA_UPLOAD_BOTTOM_SHEET_VALUE_WORD_PRESS_LIBRARY = 'wordpress_media_library';
+export const MEDIA_UPLOAD_BOTTOM_SHEET_VALUE_CHOOSE_FROM_DEVICE = 'DEVICE_MEDIA_LIBRARY';
+export const MEDIA_UPLOAD_BOTTOM_SHEET_VALUE_TAKE_MEDIA = 'DEVICE_CAMERA';
+export const MEDIA_UPLOAD_BOTTOM_SHEET_VALUE_WORD_PRESS_LIBRARY = 'SITE_MEDIA_LIBRARY';
 
 export const OPTION_TAKE_VIDEO = __( 'Take a Video' );
 export const OPTION_TAKE_PHOTO = __( 'Take a Photo' );
@@ -31,7 +28,6 @@ export class MediaUpload extends React.Component {
 	constructor( props ) {
 		super( props );
 		this.onPickerPresent = this.onPickerPresent.bind( this );
-		this.onPickerChange = this.onPickerChange.bind( this );
 		this.onPickerSelect = this.onPickerSelect.bind( this );
 
 		this.state = {
@@ -104,30 +100,13 @@ export class MediaUpload extends React.Component {
 		}
 	}
 
-	onPickerSelect( requestFunction ) {
+	onPickerSelect( source ) {
 		const { allowedTypes = [], onSelect, multiple = false } = this.props;
-		requestFunction( allowedTypes, multiple, ( media ) => {
+		requestMediaPicker( source, allowedTypes, multiple, ( media ) => {
 			if ( ( multiple && media ) || ( media && media.id ) ) {
 				onSelect( media );
 			}
 		} );
-	}
-
-	onPickerChange( value ) {
-		if ( value === MEDIA_UPLOAD_BOTTOM_SHEET_VALUE_CHOOSE_FROM_DEVICE ) {
-			this.onPickerSelect( requestMediaPickFromDeviceLibrary );
-		} else if ( value === MEDIA_UPLOAD_BOTTOM_SHEET_VALUE_TAKE_MEDIA ) {
-			this.onPickerSelect( requestMediaPickFromDeviceCamera );
-		} else if ( value === MEDIA_UPLOAD_BOTTOM_SHEET_VALUE_WORD_PRESS_LIBRARY ) {
-			this.onPickerSelect( requestMediaPickFromMediaLibrary );
-		} else {
-			const { onSelect, multiple = false } = this.props;
-			requestOtherMediaPickFrom( value, multiple, ( media ) => {
-				if ( ( multiple && media ) || ( media && media.id ) ) {
-					onSelect( media );
-				}
-			} );
-		}
 	}
 
 	render() {
@@ -142,7 +121,7 @@ export class MediaUpload extends React.Component {
 				hideCancelButton
 				ref={ ( instance ) => this.picker = instance }
 				options={ mediaOptions }
-				onChange={ this.onPickerChange }
+				onChange={ this.onPickerSelect }
 			/>
 		);
 

--- a/packages/block-editor/src/components/media-upload/index.native.js
+++ b/packages/block-editor/src/components/media-upload/index.native.js
@@ -65,7 +65,7 @@ export class MediaUpload extends React.Component {
 		return [
 			{ icon: this.getChooseFromDeviceIcon(), value: mediaSources.deviceLibrary, label: __( 'Choose from device' ) },
 			{ icon: this.getTakeMediaIcon(), value: mediaSources.deviceCamera, label: this.getTakeMediaLabel() },
-			{ icon: this.getWordPressLibraryIcon(), value: mediaSources.siteMediaLirary, label: __( 'WordPress Media Library' ) },
+			{ icon: this.getWordPressLibraryIcon(), value: mediaSources.siteMediaLibrary, label: __( 'WordPress Media Library' ) },
 		];
 	}
 

--- a/packages/block-editor/src/components/media-upload/index.native.js
+++ b/packages/block-editor/src/components/media-upload/index.native.js
@@ -5,6 +5,7 @@ import React from 'react';
 import {
 	getOtherMediaOptions,
 	requestMediaPicker,
+	mediaSources,
 } from 'react-native-gutenberg-bridge';
 
 /**
@@ -15,10 +16,6 @@ import { Picker } from '@wordpress/components';
 
 export const MEDIA_TYPE_IMAGE = 'image';
 export const MEDIA_TYPE_VIDEO = 'video';
-
-export const MEDIA_UPLOAD_BOTTOM_SHEET_VALUE_CHOOSE_FROM_DEVICE = 'DEVICE_MEDIA_LIBRARY';
-export const MEDIA_UPLOAD_BOTTOM_SHEET_VALUE_TAKE_MEDIA = 'DEVICE_CAMERA';
-export const MEDIA_UPLOAD_BOTTOM_SHEET_VALUE_WORD_PRESS_LIBRARY = 'SITE_MEDIA_LIBRARY';
 
 export const OPTION_TAKE_VIDEO = __( 'Take a Video' );
 export const OPTION_TAKE_PHOTO = __( 'Take a Photo' );
@@ -66,9 +63,9 @@ export class MediaUpload extends React.Component {
 
 	getMediaOptionsItems() {
 		return [
-			{ icon: this.getChooseFromDeviceIcon(), value: MEDIA_UPLOAD_BOTTOM_SHEET_VALUE_CHOOSE_FROM_DEVICE, label: __( 'Choose from device' ) },
-			{ icon: this.getTakeMediaIcon(), value: MEDIA_UPLOAD_BOTTOM_SHEET_VALUE_TAKE_MEDIA, label: this.getTakeMediaLabel() },
-			{ icon: this.getWordPressLibraryIcon(), value: MEDIA_UPLOAD_BOTTOM_SHEET_VALUE_WORD_PRESS_LIBRARY, label: __( 'WordPress Media Library' ) },
+			{ icon: this.getChooseFromDeviceIcon(), value: mediaSources.deviceLibrary, label: __( 'Choose from device' ) },
+			{ icon: this.getTakeMediaIcon(), value: mediaSources.deviceCamera, label: this.getTakeMediaLabel() },
+			{ icon: this.getWordPressLibraryIcon(), value: mediaSources.siteMediaLirary, label: __( 'WordPress Media Library' ) },
 		];
 	}
 

--- a/packages/block-editor/src/components/media-upload/test/index.native.js
+++ b/packages/block-editor/src/components/media-upload/test/index.native.js
@@ -4,9 +4,7 @@
 import { shallow } from 'enzyme';
 import { TouchableWithoutFeedback } from 'react-native';
 import {
-	requestMediaPickFromMediaLibrary,
-	requestMediaPickFromDeviceLibrary,
-	requestMediaPickFromDeviceCamera,
+	requestMediaPicker,
 } from 'react-native-gutenberg-bridge';
 
 /**
@@ -67,7 +65,7 @@ describe( 'MediaUpload component', () => {
 	} );
 
 	const expectMediaPickerForOption = ( option, allowMultiple, requestFunction ) => {
-		requestFunction.mockImplementation( ( mediaTypes, multiple, callback ) => {
+		requestFunction.mockImplementation( ( source, mediaTypes, multiple, callback ) => {
 			expect( mediaTypes[ 0 ] ).toEqual( MEDIA_TYPE_VIDEO );
 			if ( multiple ) {
 				callback( [ { id: MEDIA_ID, url: MEDIA_URL } ] );
@@ -101,22 +99,22 @@ describe( 'MediaUpload component', () => {
 	};
 
 	it( 'can select media from device library', () => {
-		expectMediaPickerForOption( MEDIA_UPLOAD_BOTTOM_SHEET_VALUE_CHOOSE_FROM_DEVICE, false, requestMediaPickFromDeviceLibrary );
+		expectMediaPickerForOption( MEDIA_UPLOAD_BOTTOM_SHEET_VALUE_CHOOSE_FROM_DEVICE, false, requestMediaPicker );
 	} );
 
 	it( 'can select media from WP media library', () => {
-		expectMediaPickerForOption( MEDIA_UPLOAD_BOTTOM_SHEET_VALUE_WORD_PRESS_LIBRARY, false, requestMediaPickFromMediaLibrary );
+		expectMediaPickerForOption( MEDIA_UPLOAD_BOTTOM_SHEET_VALUE_WORD_PRESS_LIBRARY, false, requestMediaPicker );
 	} );
 
 	it( 'can select media by capturig', () => {
-		expectMediaPickerForOption( MEDIA_UPLOAD_BOTTOM_SHEET_VALUE_TAKE_MEDIA, false, requestMediaPickFromDeviceCamera );
+		expectMediaPickerForOption( MEDIA_UPLOAD_BOTTOM_SHEET_VALUE_TAKE_MEDIA, false, requestMediaPicker );
 	} );
 
 	it( 'can select multiple media from device library', () => {
-		expectMediaPickerForOption( MEDIA_UPLOAD_BOTTOM_SHEET_VALUE_CHOOSE_FROM_DEVICE, true, requestMediaPickFromDeviceLibrary );
+		expectMediaPickerForOption( MEDIA_UPLOAD_BOTTOM_SHEET_VALUE_CHOOSE_FROM_DEVICE, true, requestMediaPicker );
 	} );
 
 	it( 'can select multiple media from WP media library', () => {
-		expectMediaPickerForOption( MEDIA_UPLOAD_BOTTOM_SHEET_VALUE_WORD_PRESS_LIBRARY, true, requestMediaPickFromMediaLibrary );
+		expectMediaPickerForOption( MEDIA_UPLOAD_BOTTOM_SHEET_VALUE_WORD_PRESS_LIBRARY, true, requestMediaPicker );
 	} );
 } );

--- a/test/native/setup.js
+++ b/test/native/setup.js
@@ -16,11 +16,8 @@ jest.mock( 'react-native-gutenberg-bridge', () => {
 		editorDidMount: jest.fn(),
 		editorDidAutosave: jest.fn(),
 		subscribeMediaUpload: jest.fn(),
-		requestMediaPickFromMediaLibrary: jest.fn(),
-		requestMediaPickFromDeviceLibrary: jest.fn(),
-		requestMediaPickFromDeviceCamera: jest.fn(),
 		getOtherMediaOptions: jest.fn(),
-		requestOtherMediaPickFrom: jest.fn(),
+		requestMediaPicker: jest.fn(),
 	};
 } );
 

--- a/test/native/setup.js
+++ b/test/native/setup.js
@@ -18,6 +18,11 @@ jest.mock( 'react-native-gutenberg-bridge', () => {
 		subscribeMediaUpload: jest.fn(),
 		getOtherMediaOptions: jest.fn(),
 		requestMediaPicker: jest.fn(),
+		mediaSources: {
+			deviceLibrary: 'DEVICE_MEDIA_LIBRARY',
+			deviceCamera: 'DEVICE_CAMERA',
+			siteMediaLibrary: 'SITE_MEDIA_LIBRARY',
+		},
 	};
 } );
 


### PR DESCRIPTION
This PR simplifies and merges all `requestMediaPick...` methods into one `requestMediaPick`, including the new `requestOtherMediaPickFrom` method.

This allow us to handle media pick request from any source in the same way, and giving the same parameters.

Passing the filter parameter to `requestOtherMediaPickFrom` was needed for https://github.com/wordpress-mobile/WordPress-iOS/pull/12883 to work properly, so I decided to do this extra enhancement.

`gutenberg-mobile` side PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1547
`WPiOS` PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/12883