### PR TITLE
NavigationMenu: set appender color

### DIFF
--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -57,6 +57,11 @@ $navigation-item-height: 46px;
 			background: none;
 		}
 	}
+
+	// Applies color to the appender if the background has been set.
+	.wp-block-navigation.has-background .block-list-appender .block-editor-button-block-appender {
+		color: inherit;
+	}
 }
 
 .wp-block-navigation__inserter-content {


### PR DESCRIPTION
## Description

It sets the appender color when the navigation menu has defined a text color.

## How has this been tested?
Apply text color from the colors selector and confirm that the color is being applied at the appender as well.

## Screenshots <!-- if applicable -->

**before**
<img width="882" alt="Screen Shot 2020-02-03 at 4 37 03 PM" src="https://user-images.githubusercontent.com/77539/73703029-7b45b180-46a3-11ea-9e82-2a9617df93fe.png">

**after**
![image](https://user-images.githubusercontent.com/77539/73702857-e773e580-46a2-11ea-8d85-52c8be8a1d8a.png)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->