### PR TITLE
Fix Nav Block to allow overflow scroll when there are many horizontal nav items

### DIFF
--- a/packages/block-library/src/navigation-menu/edit.js
+++ b/packages/block-library/src/navigation-menu/edit.js
@@ -48,10 +48,10 @@ function NavigationMenu( {
 	setTextColor,
 	setAttributes,
 } ) {
-	const navMenuRef = useRef();
+	const scrollContainerRef = useRef();
 	const [ hasScrollX, setHasScrollX ] = useState( false );
-	const clientWidth = navMenuRef.current ? navMenuRef.current.clientWidth : 0;
-	const scrollWidth = navMenuRef.current ? navMenuRef.current.scrollWidth : 0;
+	const clientWidth = scrollContainerRef.current ? scrollContainerRef.current.clientWidth : 0;
+	const scrollWidth = scrollContainerRef.current ? scrollContainerRef.current.scrollWidth : 0;
 
 	useLayoutEffect( () => {
 		if ( scrollWidth > clientWidth ) {
@@ -164,16 +164,18 @@ function NavigationMenu( {
 				</PanelBody>
 			</InspectorControls>
 
-			<div ref={ navMenuRef } className={ navigationMenuClasses } style={ navigationMenuInlineStyles }>
-				{ isRequesting && <><Spinner /> { __( 'Loading Navigation…' ) } </> }
-				{ pages &&
+			<div className={ navigationMenuClasses } style={ navigationMenuInlineStyles }>
+				<div ref={ scrollContainerRef } className="wp-block-navigation-menu__scroll-container">
+					{ isRequesting && <><Spinner /> { __( 'Loading Navigation…' ) } </> }
+					{ pages &&
 					<InnerBlocks
 						template={ defaultMenuItems ? defaultMenuItems : null }
 						allowedBlocks={ [ 'core/navigation-menu-item' ] }
 						templateInsertUpdatesSelection={ false }
 						__experimentalMoverDirection={ 'horizontal' }
 					/>
-				}
+					}
+				</div>
 			</div>
 		</>
 	);

--- a/packages/block-library/src/navigation-menu/edit.js
+++ b/packages/block-library/src/navigation-menu/edit.js
@@ -50,18 +50,16 @@ function NavigationMenu( {
 } ) {
 	const navMenuRef = useRef();
 	const [ hasScrollX, setHasScrollX ] = useState( false );
+	const clientWidth = navMenuRef.current ? navMenuRef.current.clientWidth : 0;
+	const scrollWidth = navMenuRef.current ? navMenuRef.current.scrollWidth : 0;
 
 	useLayoutEffect( () => {
-		if ( navMenuRef && navMenuRef.current ) {
-			const navMenu = navMenuRef.current;
-
-			if ( navMenu.scrollWidth > navMenu.clientWidth ) {
-				setHasScrollX( true );
-			} else {
-				setHasScrollX( false );
-			}
+		if ( scrollWidth > clientWidth ) {
+			setHasScrollX( true );
+		} else {
+			setHasScrollX( false );
 		}
-	} );
+	}, [ clientWidth, scrollWidth ] );
 
 	const { navigatorToolbarButton, navigatorModal } = useBlockNavigator( clientId );
 	const defaultMenuItems = useMemo(

--- a/packages/block-library/src/navigation-menu/edit.js
+++ b/packages/block-library/src/navigation-menu/edit.js
@@ -9,6 +9,9 @@ import classnames from 'classnames';
 import {
 	useMemo,
 	useEffect,
+	useLayoutEffect,
+	useRef,
+	useState,
 } from '@wordpress/element';
 import {
 	InnerBlocks,
@@ -45,6 +48,21 @@ function NavigationMenu( {
 	setTextColor,
 	setAttributes,
 } ) {
+	const navMenuRef = useRef();
+	const [ hasScrollX, setHasScrollX ] = useState( false );
+
+	useLayoutEffect( () => {
+		if ( navMenuRef && navMenuRef.current ) {
+			const navMenu = navMenuRef.current;
+
+			if ( navMenu.scrollWidth > navMenu.clientWidth ) {
+				setHasScrollX( true );
+			} else {
+				setHasScrollX( false );
+			}
+		}
+	} );
+
 	const { navigatorToolbarButton, navigatorModal } = useBlockNavigator( clientId );
 	const defaultMenuItems = useMemo(
 		() => {
@@ -79,6 +97,7 @@ function NavigationMenu( {
 		'wp-block-navigation-menu', {
 			'has-text-color': textColor.color,
 			'has-background-color': backgroundColor.color,
+			'has-scroll-x': hasScrollX,
 			[ attributes.backgroundColorCSSClass ]: attributes && attributes.backgroundColorCSSClass,
 			[ attributes.textColorCSSClass ]: attributes && attributes.textColorCSSClass,
 		}
@@ -147,7 +166,7 @@ function NavigationMenu( {
 				</PanelBody>
 			</InspectorControls>
 
-			<div className={ navigationMenuClasses } style={ navigationMenuInlineStyles }>
+			<div ref={ navMenuRef } className={ navigationMenuClasses } style={ navigationMenuInlineStyles }>
 				{ isRequesting && <><Spinner /> { __( 'Loading Navigation…' ) } </> }
 				{ pages &&
 					<InnerBlocks

--- a/packages/block-library/src/navigation-menu/editor.scss
+++ b/packages/block-library/src/navigation-menu/editor.scss
@@ -4,13 +4,25 @@
 [data-type="core/navigation-menu"] {
 
 	// Allow overflowing items to scroll container
-	.wp-block-navigation-menu {
+	.wp-block-navigation-menu > .wp-block-navigation-menu__scroll-container {
+		// if X is "auto" or "scroll" then spec says Y must also assume this value
+		// therefore the Y overflow is effectively "clipped" meaning that the toolbar
+		// of child Blocks cannot display correctly. We "fix" this below.
+		// Note: as Y will be "auto" anyway we need to hide the scroll bars
+		// created by the artificial spacing.
 		overflow-x: auto;
+		overflow-y: hidden; // required for FF
+
+		// Hack: create artificial overflow space within the element which has its Y
+		// value clipped (see above). This value is equal to that of the positioned
+		// toolbar element (usually `top: -51px`).
+		padding-top: 51px;
+		margin-top: -51px;
 	}
 
-	// Allow more space on RHS when scroll is present
-	.wp-block-navigation-menu.has-scroll-x .block-editor-block-list__layout {
-		padding-right: 25%;
+	[data-type="core/navigation-menu-item"] > .block-editor-block-list__block-edit .block-editor-block-contextual-toolbar {
+		// Hack - see above. Reset top position value.
+		top: 0;
 	}
 
 	// 1. Reset margins on immediate innerblocks container.

--- a/packages/block-library/src/navigation-menu/editor.scss
+++ b/packages/block-library/src/navigation-menu/editor.scss
@@ -8,11 +8,15 @@
 		overflow-x: auto;
 	}
 
+	// Allow more space on RHS when scroll is present
+	.wp-block-navigation-menu.has-scroll-x .block-editor-block-list__layout {
+		padding-right: 25%;
+	}
+
 	// 1. Reset margins on immediate innerblocks container.
 	.wp-block-navigation-menu .block-editor-inner-blocks > .block-editor-block-list__layout {
 		margin-left: 0;
 		margin-right: 0;
-		padding-right: 25%;
 	}
 
 	// 2. Remove paddings on subsequent immediate children.

--- a/packages/block-library/src/navigation-menu/editor.scss
+++ b/packages/block-library/src/navigation-menu/editor.scss
@@ -2,10 +2,17 @@
 // @todo: eventually we may add a feature that lets a parent container absorb the block UI of a child block.
 // When that happens, leverage that instead of the following overrides.
 [data-type="core/navigation-menu"] {
+
+	// Allow overflowing items to scroll container
+	.wp-block-navigation-menu {
+		overflow-x: auto;
+	}
+
 	// 1. Reset margins on immediate innerblocks container.
 	.wp-block-navigation-menu .block-editor-inner-blocks > .block-editor-block-list__layout {
 		margin-left: 0;
 		margin-right: 0;
+		padding-right: 25%;
 	}
 
 	// 2. Remove paddings on subsequent immediate children.
@@ -13,7 +20,7 @@
 		width: auto;
 		padding-left: 0;
 		padding-right: 0;
-		margin-left: 0; // something
+		margin-left: 0;
 	}
 
 	// 3. Remove margins on subsequent Edit container.

--- a/packages/block-library/src/navigation-menu/style.scss
+++ b/packages/block-library/src/navigation-menu/style.scss
@@ -117,13 +117,3 @@
 	}
 
 }
-
-
-/**
- * Editor Only Styles
- */
-.block-editor-block-list__block-edit {
-	.wp-block-navigation-menu {
-		overflow-x: auto; // allow overflowing items to cause scroll
-	}
-}

--- a/packages/block-library/src/navigation-menu/style.scss
+++ b/packages/block-library/src/navigation-menu/style.scss
@@ -117,3 +117,13 @@
 	}
 
 }
+
+
+/**
+ * Editor Only Styles
+ */
+.block-editor-block-list__block-edit {
+	.wp-block-navigation-menu {
+		overflow: auto; // allow overflowing items to cause scroll
+	}
+}

--- a/packages/block-library/src/navigation-menu/style.scss
+++ b/packages/block-library/src/navigation-menu/style.scss
@@ -124,6 +124,6 @@
  */
 .block-editor-block-list__block-edit {
 	.wp-block-navigation-menu {
-		overflow: auto; // allow overflowing items to cause scroll
+		overflow-x: auto; // allow overflowing items to cause scroll
 	}
 }


### PR DESCRIPTION
Closes https://github.com/WordPress/gutenberg/issues/18298

Currently, in the new Nav Block, if many nav items are created then it forces the editor canvas to "expand" and it is broken.

This PR addresses this by allowing overflow to be controlled by scrollbars when the number of items exceeds the width of the Nav Block within the Editor canvas.

This is _only_ applied to the Block within the Editor.

## Questions/Problems

* There is a question for @karmatosed and @shaunandrews regarding if/how we indicate the presence of "off-screen" items. For example if you have a lot of items yuo have to start scrolling to know they are there.
* What happens when the block appender is hidden offscreen because it's always on the far RHS of the items.
* ~You will notice if you focus the rightmost item then the toolbar is cut off. Could/should we add some extra spacing to the far RHS of the Block when it is focused in anticipation of this happening?~ I've added RHS spacing of 25% only if there is hoz scroll. 

## How has this been tested?
1. Enable Nav Block in experiments.
2. Add a Nav Block with loads of Nav items.
3. See the Nav Block does not expand the Editor canvas but rather shows hoz scrollbars.
4. You should be able to access all Nav Items as before without the Editor looking "broken".

## Screenshots

![Screen Capture on 2019-11-06 at 16-56-03](https://user-images.githubusercontent.com/444434/68319549-6498ba00-00b6-11ea-86a4-52794a399042.gif)



## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
