### PR TITLE
Lib: Add template part CPTs and their theme resolution logic.

### DIFF
--- a/lib/load.php
+++ b/lib/load.php
@@ -54,6 +54,7 @@ require dirname( __FILE__ ) . '/compat.php';
 
 require dirname( __FILE__ ) . '/blocks.php';
 require dirname( __FILE__ ) . '/templates.php';
+require dirname( __FILE__ ) . '/template-parts.php';
 require dirname( __FILE__ ) . '/template-loader.php';
 require dirname( __FILE__ ) . '/client-assets.php';
 require dirname( __FILE__ ) . '/block-directory.php';

--- a/lib/template-parts.php
+++ b/lib/template-parts.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Block template part functions.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Registers block editor 'wp_template_part' post type.
+ */
+function gutenberg_register_template_part_post_type() {
+	if ( ! gutenberg_is_experiment_enabled( 'gutenberg-full-site-editing' ) ) {
+		return;
+	}
+
+	$labels = array(
+		'name'                  => __( 'Template Parts', 'gutenberg' ),
+		'singular_name'         => __( 'Template Part', 'gutenberg' ),
+		'menu_name'             => _x( 'Template Parts', 'Admin Menu text', 'gutenberg' ),
+		'add_new'               => _x( 'Add New', 'Template Part', 'gutenberg' ),
+		'add_new_item'          => __( 'Add New Template Part', 'gutenberg' ),
+		'new_item'              => __( 'New Template Part', 'gutenberg' ),
+		'edit_item'             => __( 'Edit Template Part', 'gutenberg' ),
+		'view_item'             => __( 'View Template Part', 'gutenberg' ),
+		'all_items'             => __( 'All Template Parts', 'gutenberg' ),
+		'search_items'          => __( 'Search Template Parts', 'gutenberg' ),
+		'parent_item_colon'     => __( 'Parent Template Part:', 'gutenberg' ),
+		'not_found'             => __( 'No template parts found.', 'gutenberg' ),
+		'not_found_in_trash'    => __( 'No template parts found in Trash.', 'gutenberg' ),
+		'archives'              => __( 'Template part archives', 'gutenberg' ),
+		'insert_into_item'      => __( 'Insert into template part', 'gutenberg' ),
+		'uploaded_to_this_item' => __( 'Uploaded to this template part', 'gutenberg' ),
+		'filter_items_list'     => __( 'Filter template parts list', 'gutenberg' ),
+		'items_list_navigation' => __( 'Template parts list navigation', 'gutenberg' ),
+		'items_list'            => __( 'Template parts list', 'gutenberg' ),
+	);
+
+	$args = array(
+		'labels'            => $labels,
+		'description'       => __( 'Template parts to include in your templates.', 'gutenberg' ),
+		'public'            => false,
+		'has_archive'       => false,
+		'show_ui'           => true,
+		'show_in_menu'      => 'themes.php',
+		'show_in_admin_bar' => false,
+		'show_in_rest'      => true,
+		'map_meta_cap'      => true,
+		'supports'          => array(
+			'title',
+			'slug',
+			'editor',
+			'revisions',
+		),
+	);
+
+	$meta_args = array(
+		'object_subtype' => 'wp_template_part',
+		'type'           => 'string',
+		'description'    => 'The theme that provided the template part, if any.',
+		'single'         => true,
+		'show_in_rest'   => true,
+	);
+
+	register_post_type( 'wp_template_part', $args );
+	register_meta( 'post', 'theme', $meta_args );
+}
+add_action( 'init', 'gutenberg_register_template_part_post_type' );
+
+/**
+ * Fixes the label of the 'wp_template_part' admin menu entry.
+ */
+function gutenberg_fix_template_part_admin_menu_entry() {
+	global $submenu;
+	if ( ! isset( $submenu['themes.php'] ) ) {
+		return;
+	}
+	$post_type = get_post_type_object( 'wp_template_part' );
+	if ( ! $post_type ) {
+		return;
+	}
+	foreach ( $submenu['themes.php'] as $key => $submenu_entry ) {
+		if ( $post_type->labels->all_items === $submenu['themes.php'][ $key ][0] ) {
+			$submenu['themes.php'][ $key ][0] = $post_type->labels->menu_name; // phpcs:ignore WordPress.WP.GlobalVariablesOverride
+			break;
+		}
+	}
+}
+add_action( 'admin_menu', 'gutenberg_fix_template_part_admin_menu_entry' );
+
+/**
+ * Filters the 'wp_template_part' post type columns in the admin list table.
+ *
+ * @param array $columns Columns to display.
+ * @return array Filtered $columns.
+ */
+function gutenberg_filter_template_part_list_table_columns( array $columns ) {
+	$columns['slug'] = __( 'Slug', 'gutenberg' );
+	if ( isset( $columns['date'] ) ) {
+		unset( $columns['date'] );
+	}
+	return $columns;
+}
+add_filter( 'manage_wp_template_part_posts_columns', 'gutenberg_filter_template_part_list_table_columns' );
+
+/**
+ * Renders column content for the 'wp_template_part' post type list table.
+ *
+ * @param string $column_name Column name to render.
+ * @param int    $post_id     Post ID.
+ */
+function gutenberg_render_template_part_list_table_column( $column_name, $post_id ) {
+	if ( 'slug' !== $column_name ) {
+		return;
+	}
+	$post = get_post( $post_id );
+	echo esc_html( $post->post_name );
+}
+add_action( 'manage_wp_template_part_posts_custom_column', 'gutenberg_render_template_part_list_table_column', 10, 2 );


### PR DESCRIPTION
Follows #17512

## Description

**This PR continues the template API work by introducing the concept of template parts.**

**Template parts are blocks** with the following attributes:

- `slug`: The name of the template, e.g. `'header'`.
- `theme`: The name of the theme that provided the part, if any, e.g. `'twentytwenty'` or `null` for no theme.
- `id`: After a template part has been modified, it will be saved as a `wp_template_part` post. This attribute references that post, if any, e.g. `8`.

**Themes provide template parts in a `/block-template-parts` directory** as html files where the name of the file matches their `'slug'` attribute.

For example:

`/block-templates/single.html`:
```html
<!-- wp:template-part {"slug":"header","theme":"twentytwenty"} /-->
<!-- wp:paragraph -->
<p>Single Template</p>
<!-- /wp:paragraph -->
```

`/block-template-parts/header.html`:
```html
<!-- wp:paragraph -->
<p>Header TwentyTwenty Template Part</p>
<!-- /wp:paragraph -->
```

**When loading in the editor**, all template parts without an `id` will get an auto draft with the relevant file's contents in them so that the editor can load the contents and potentially persist any changes. Once the block is implemented, this will have to also call the block's server rendering callback to check for any nested template parts.

**When loading in the front end**, the block's server rendering callback should output either the relevant file's content if there is no `id`, or the relevant post content if there is one.

We need a `theme` attribute to differentiate between template parts with the same slug originating from different themes. When you save changes to a given template, it and all its nested template parts will persist across theme switches. Even though by that point those template parts will have `id`s and will be renderable regardless of what the new active theme provides, we need a way for the user to insert new instances of them and that is where `theme` comes in handy. For now, we store the value in post meta so we can do meta queries.

## How has this been tested?

This was mainly a foundational change, but it was verified that the Full Site Editing experiment still works as expected and that nothing changes when it is not enabled.

## Checklist:

- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
