### PR TITLE
[RNMobile] Add content alignment options to paragraph block (#17577)

### DIFF
--- a/packages/block-editor/src/components/alignment-toolbar/index.native.js
+++ b/packages/block-editor/src/components/alignment-toolbar/index.native.js
@@ -1,5 +1,0 @@
-const AlignmentToolbar = () => {
-	return null;
-};
-
-export default AlignmentToolbar;

--- a/packages/block-library/src/paragraph/edit.native.js
+++ b/packages/block-library/src/paragraph/edit.native.js
@@ -9,7 +9,7 @@ import { View } from 'react-native';
 import { __ } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
 import { createBlock } from '@wordpress/blocks';
-import { RichText } from '@wordpress/block-editor';
+import { AlignmentToolbar, BlockControls, RichText } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -47,12 +47,22 @@ class ParagraphEdit extends Component {
 		} = this.props;
 
 		const {
-			placeholder,
+			align,
 			content,
+			placeholder,
 		} = attributes;
 
 		return (
 			<View>
+				<BlockControls>
+					<AlignmentToolbar
+						isCollapsed={ false }
+						value={ align }
+						onChange={ ( nextAlign ) => {
+							setAttributes( { align: nextAlign } );
+						} }
+					/>
+				</BlockControls>
 				<RichText
 					identifier="content"
 					tagName="p"
@@ -78,6 +88,7 @@ class ParagraphEdit extends Component {
 					onReplace={ onReplace }
 					onRemove={ onReplace ? () => onReplace( [] ) : undefined }
 					placeholder={ placeholder || __( 'Start writing…' ) }
+					textAlign={ align }
 				/>
 			</View>
 		);


### PR DESCRIPTION
## Description
Mobile 1.16.1 Release ([main PR](https://github.com/wordpress-mobile/gutenberg-mobile/pull/1553))

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
