### PR TITLE
navigation-menu-item: rename link ID to `id`

### DIFF
--- a/packages/block-library/src/navigation-menu-item/block.json
+++ b/packages/block-library/src/navigation-menu-item/block.json
@@ -18,7 +18,7 @@
 		"description": {
 			"type": "string"
 		},
-		"linkId": {
+		"id": {
 			"type": "number"
 		},
 		"opensInNewTab": {

--- a/packages/block-library/src/navigation-menu/edit.js
+++ b/packages/block-library/src/navigation-menu/edit.js
@@ -52,12 +52,12 @@ function NavigationMenu( {
 				return null;
 			}
 
-			return pages.map( ( { title, type, link: url, id: linkId } ) => (
+			return pages.map( ( { title, type, link: url, id } ) => (
 				[ 'core/navigation-menu-item', {
 					label: title.rendered,
 					title: title.raw,
 					type,
-					linkId,
+					id,
 					url,
 					opensInNewTab: false,
 				} ]


### PR DESCRIPTION
## Description
This PR simply rename the `linkId` attribute of the `<NavigationMenuItem />` by `id`.

## How has this been tested?
Once the changes are applied check that the Navigation menu works as expected. Additionally, you can check that the attribute name has been updated using the dev tool.

<img width="612" alt="Screen Shot 2019-11-06 at 4 19 15 PM" src="https://user-images.githubusercontent.com/77539/68330147-788ded00-00b1-11ea-8a75-53d2beaa9fe0.png">

