### PR TITLE
Navigation Menu: sub menu items design

### DIFF
--- a/packages/block-library/src/navigation-menu/style.scss
+++ b/packages/block-library/src/navigation-menu/style.scss
@@ -84,23 +84,13 @@
 
 	// Sub-menu depth indicators
 	ul ul {
-
 		list-style: none;
 		margin-left: 0;
-		// Reset the counter for each UL
-		counter-reset: nested-list;
 
 		li a {
 
 			padding-top: 8px;
 			padding-bottom: 8px;
-
-			&::before {
-				// Increment the dashes
-				counter-increment: nested-list;
-				// Insert dashes with spaces in between
-				content: "\2013\00a0" counters(nested-list, "\2013\00a0", none);
-			}
 		}
 	}
 

--- a/packages/block-library/src/navigation-menu/theme.scss
+++ b/packages/block-library/src/navigation-menu/theme.scss
@@ -1,0 +1,6 @@
+.wp-block-navigation-menu {
+	ul,
+	ul li {
+		list-style: none;
+	}
+}

--- a/packages/block-library/src/theme.scss
+++ b/packages/block-library/src/theme.scss
@@ -4,6 +4,7 @@
 @import "./gallery/theme.scss";
 @import "./image/theme.scss";
 @import "./pullquote/theme.scss";
+@import "./navigation-menu/theme.scss";
 @import "./quote/theme.scss";
 @import "./search/theme.scss";
 @import "./group/theme.scss";


### PR DESCRIPTION
## Description

This PR tweaks the navigation menu in order to make correspond to what the front-end and the Editor canvas show. It adds the `theme.scss` file to the block.

## How has this been tested?
Check how the menu looks on both sides.

## Screenshots <!-- if applicable -->

![image](https://user-images.githubusercontent.com/77539/68341605-92d2c580-00c7-11ea-8fcc-34a76fd62606.png)

![image](https://user-images.githubusercontent.com/77539/68341613-98301000-00c7-11ea-83fd-9bf711764a7d.png)


## Types of changes
* Adds the `theme.scss` file to the navigation menu block
* Implements very basic styles to the menu.

## Related Issues

https://github.com/WordPress/gutenberg/issues/18310

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
