### PR TITLE
Fixed the top margin and border for the first item in the keyboard shortcuts modal

### DIFF
--- a/packages/edit-post/src/components/keyboard-shortcut-help-modal/style.scss
+++ b/packages/edit-post/src/components/keyboard-shortcut-help-modal/style.scss
@@ -5,7 +5,7 @@
 
 	&__main-shortcuts .edit-post-keyboard-shortcut-help__shortcut-list {
 		// Push the shortcut to be flush with top modal header.
-		margin-top: -$panel-padding -$border-width;
+		margin-top: -$grid-size-xlarge -$border-width;
 	}
 
 	&__section-title {


### PR DESCRIPTION
## Description
The first item in the keyboard shortcuts was still showing its border and looked funky. I've basically pushed the item up so that the border doesn't show anymore. Fixes #17588 

**Before:**

![68354301-db3ab500-00c0-11ea-98b1-5858063c67ed](https://user-images.githubusercontent.com/617986/68355599-9add3600-00c4-11ea-9082-439a3d76a4ae.png)

**After:**

![Screen Shot 2019-11-06 at 6 38 31 PM](https://user-images.githubusercontent.com/617986/68355620-aa5c7f00-00c4-11ea-99ba-73db71451c50.png)


## How has this been tested?
Locally on FF and Chrome.

## Types of changes
CSS non-breaking changes.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
