### PR TITLE
Nav Block - improving initial state by adding Block placeholder and ability to create from existing Pages.

### DIFF
--- a/packages/block-library/src/navigation-menu/edit.js
+++ b/packages/block-library/src/navigation-menu/edit.js
@@ -130,11 +130,8 @@ function NavigationMenu( {
 				className="wp-block-navigation-menu-placeholder"
 				icon="menu"
 				label={ __( 'Navigation Menu' ) }
+				instructions={ __( 'Create a Menu from all existing pages, or create an empty one.' ) }
 			>
-				<p className="wp-block-navigation-menu-placeholder__instructions">
-					{ __( 'Create a Menu from all existing pages, or create an empty one.' ) }
-				</p>
-
 				<div className="wp-block-navigation-menu-placeholder__buttons">
 					<Button
 						isDefault

--- a/packages/block-library/src/navigation-menu/edit.js
+++ b/packages/block-library/src/navigation-menu/edit.js
@@ -47,6 +47,7 @@ function NavigationMenu( {
 	setBackgroundColor,
 	setTextColor,
 	setAttributes,
+	hasExistingNavItems,
 } ) {
 	const [ initialPlaceholder, setInitialPlaceholder ] = useState( true );
 	const { navigatorToolbarButton, navigatorModal } = useBlockNavigator( clientId );
@@ -128,7 +129,7 @@ function NavigationMenu( {
 		setInitialPlaceholder( false );
 	};
 
-	if ( initialPlaceholder ) {
+	if ( ! hasExistingNavItems && initialPlaceholder ) {
 		return (
 			<Placeholder
 				className="wp-block-navigation-menu-placeholder"
@@ -208,7 +209,13 @@ function NavigationMenu( {
 
 export default compose( [
 	withColors( { backgroundColor: 'background-color', textColor: 'color' } ),
-	withSelect( ( select ) => {
+	withSelect( ( select, ownProps, registry ) => {
+		const { clientId } = ownProps;
+		const { getBlocks } = registry.select( 'core/block-editor' );
+
+		const innerBlocks = getBlocks( clientId );
+		const hasExistingNavItems = innerBlocks && innerBlocks.filter( ( block ) => block.name === 'core/navigation-menu-item' ).length;
+
 		const { getEntityRecords } = select( 'core' );
 		const { isResolving } = select( 'core/data' );
 		const filterDefaultPages = {
@@ -217,6 +224,7 @@ export default compose( [
 			orderby: 'id',
 		};
 		return {
+			hasExistingNavItems: !! hasExistingNavItems,
 			pages: getEntityRecords( 'postType', 'page', filterDefaultPages ),
 			isRequesting: isResolving( 'core', 'getEntityRecords', [ 'postType', 'page', filterDefaultPages ] ),
 		};

--- a/packages/block-library/src/navigation-menu/edit.js
+++ b/packages/block-library/src/navigation-menu/edit.js
@@ -223,7 +223,7 @@ function NavigationMenu( {
 			</InspectorControls>
 
 			<div className={ navigationMenuClasses } style={ navigationMenuInlineStyles }>
-				{ isRequesting && <><Spinner /> { __( 'Loading Navigation…' ) } </> }
+				{ ! hasExistingNavItems && isRequesting && <><Spinner /> { __( 'Loading Navigation…' ) } </> }
 
 				<InnerBlocks
 					allowedBlocks={ [ 'core/navigation-menu-item' ] }

--- a/packages/block-library/src/navigation-menu/edit.js
+++ b/packages/block-library/src/navigation-menu/edit.js
@@ -227,13 +227,10 @@ export default compose( [
 	withColors( { backgroundColor: 'background-color', textColor: 'color' } ),
 	withSelect( ( select, ownProps, registry ) => {
 		const { clientId } = ownProps;
-		const { getBlocks } = registry.select( 'core/block-editor' );
 
-		const innerBlocks = getBlocks( clientId );
+		const innerBlocks = registry.select( 'core/block-editor' ).getBlocks( clientId );
 		const hasExistingNavItems = !! innerBlocks.length;
 
-		const { getEntityRecords } = select( 'core' );
-		const { isResolving } = select( 'core/data' );
 		const filterDefaultPages = {
 			parent: 0,
 			order: 'asc',
@@ -241,8 +238,8 @@ export default compose( [
 		};
 		return {
 			hasExistingNavItems,
-			pages: getEntityRecords( 'postType', 'page', filterDefaultPages ),
-			isRequesting: isResolving( 'core', 'getEntityRecords', [ 'postType', 'page', filterDefaultPages ] ),
+			pages: select( 'core' ).getEntityRecords( 'postType', 'page', filterDefaultPages ),
+			isRequesting: select( 'core/data' ).isResolving( 'core', 'getEntityRecords', [ 'postType', 'page', filterDefaultPages ] ),
 		};
 	} ),
 ] )( NavigationMenu );

--- a/packages/block-library/src/navigation-menu/edit.js
+++ b/packages/block-library/src/navigation-menu/edit.js
@@ -9,6 +9,7 @@ import classnames from 'classnames';
 import {
 	useMemo,
 	useEffect,
+	Fragment,
 } from '@wordpress/element';
 import {
 	InnerBlocks,
@@ -64,8 +65,6 @@ function NavigationMenu( {
 		} );
 	}, [ backgroundColor.class, textColor.class ] );
 
-	const emptyNavItemBlock = createBlock( 'core/navigation-menu-item' );
-
 	// Builds menu items from default Pages
 	const defaultPagesMenuItems = useMemo(
 		() => {
@@ -118,6 +117,7 @@ function NavigationMenu( {
 	};
 
 	const handleCreateEmpty = () => {
+		const emptyNavItemBlock = createBlock( 'core/navigation-menu-item' );
 		updateNavItemBlocks( [ emptyNavItemBlock ] );
 	};
 
@@ -125,32 +125,52 @@ function NavigationMenu( {
 		updateNavItemBlocks( defaultPagesMenuItems );
 	};
 
+	// If we don't have existing items or the User hasn't
+	// indicated they want to automatically add top level Pages
+	// then show the Placeholder
 	if ( ! hasExistingNavItems ) {
 		return (
-			<Placeholder
-				className="wp-block-navigation-menu-placeholder"
-				icon="menu"
-				label={ __( 'Navigation Menu' ) }
-				instructions={ __( 'Create a Menu from all existing pages, or create an empty one.' ) }
-			>
-				<div className="wp-block-navigation-menu-placeholder__buttons">
-					<Button
-						isDefault
-						className="wp-block-navigation-menu-placeholder__button"
-						onClick={ handleCreateFromExistingPages }
+			<Fragment>
+				<InspectorControls>
+					<PanelBody
+						title={ __( 'Menu Settings' ) }
 					>
-						{ __( 'Create from all top pages' ) }
-					</Button>
+						<CheckboxControl
+							value={ attributes.automaticallyAdd }
+							onChange={ ( automaticallyAdd ) => {
+								setAttributes( { automaticallyAdd } );
+								handleCreateFromExistingPages();
+							} }
+							label={ __( 'Automatically add new pages' ) }
+							help={ __( 'Automatically add new top level pages to this menu.' ) }
+						/>
+					</PanelBody>
+				</InspectorControls>
+				<Placeholder
+					className="wp-block-navigation-menu-placeholder"
+					icon="menu"
+					label={ __( 'Navigation Menu' ) }
+					instructions={ __( 'Create a Menu from all existing pages, or create an empty one.' ) }
+				>
+					<div className="wp-block-navigation-menu-placeholder__buttons">
+						<Button
+							isDefault
+							className="wp-block-navigation-menu-placeholder__button"
+							onClick={ handleCreateFromExistingPages }
+						>
+							{ __( 'Create from all top pages' ) }
+						</Button>
 
-					<Button
-						isLink
-						className="wp-block-navigation-menu-placeholder__button"
-						onClick={ handleCreateEmpty }
-					>
-						{ __( 'Create empty' ) }
-					</Button>
-				</div>
-			</Placeholder>
+						<Button
+							isLink
+							className="wp-block-navigation-menu-placeholder__button"
+							onClick={ handleCreateEmpty }
+						>
+							{ __( 'Create empty' ) }
+						</Button>
+					</div>
+				</Placeholder>
+			</Fragment>
 		);
 	}
 
@@ -172,7 +192,7 @@ function NavigationMenu( {
 
 	// UI State: rendered Block UI
 	return (
-		<>
+		<Fragment>
 			<BlockControls>
 				<Toolbar>
 					{ navigatorToolbarButton }
@@ -212,7 +232,7 @@ function NavigationMenu( {
 				/>
 
 			</div>
-		</>
+		</Fragment>
 	);
 }
 

--- a/packages/block-library/src/navigation-menu/edit.js
+++ b/packages/block-library/src/navigation-menu/edit.js
@@ -151,7 +151,9 @@ function NavigationMenu( {
 				icon="menu"
 				label={ __( 'Navigation Menu' ) }
 			>
-				<p className="wp-block-navigation-menu-placeholder__instructions">Create a Menu from all existing pages or create an empty one.</p>
+				<p className="wp-block-navigation-menu-placeholder__instructions">
+					{ __( 'Create a Menu from all existing pages, or create an empty one.' ) }
+				</p>
 
 				<div className="wp-block-navigation-menu-placeholder__buttons">
 					<Button
@@ -159,7 +161,7 @@ function NavigationMenu( {
 						isDefault={ true }
 						onClick={ handleCreateFromExisting }
 					>
-						Create menu from existing pages
+						{ __( 'Create from all top pages' ) }
 					</Button>
 
 					<Button
@@ -167,7 +169,7 @@ function NavigationMenu( {
 						isLink={ true }
 						onClick={ handleCreateEmpty }
 					>
-						Create an empty menu
+						{ __( 'Create empty' ) }
 					</Button>
 				</div>
 			</Placeholder>

--- a/packages/block-library/src/navigation-menu/edit.js
+++ b/packages/block-library/src/navigation-menu/edit.js
@@ -43,7 +43,8 @@ function NavigationMenu( {
 	attributes,
 	clientId,
 	pages,
-	isRequesting,
+	isRequestingPages,
+	hasResolvedPages,
 	backgroundColor,
 	textColor,
 	setBackgroundColor,
@@ -125,7 +126,7 @@ function NavigationMenu( {
 		updateNavItemBlocks( defaultPagesMenuItems );
 	};
 
-	const hasPages = pages && pages.length;
+	const hasPages = hasResolvedPages && pages && pages.length;
 
 	// If we don't have existing items or the User hasn't
 	// indicated they want to automatically add top level Pages
@@ -134,19 +135,21 @@ function NavigationMenu( {
 		return (
 			<Fragment>
 				<InspectorControls>
-					<PanelBody
-						title={ __( 'Menu Settings' ) }
-					>
-						<CheckboxControl
-							value={ attributes.automaticallyAdd }
-							onChange={ ( automaticallyAdd ) => {
-								setAttributes( { automaticallyAdd } );
-								handleCreateFromExistingPages();
-							} }
-							label={ __( 'Automatically add new pages' ) }
-							help={ __( 'Automatically add new top level pages to this menu.' ) }
-						/>
-					</PanelBody>
+					{ hasResolvedPages && (
+						<PanelBody
+							title={ __( 'Menu Settings' ) }
+						>
+							<CheckboxControl
+								value={ attributes.automaticallyAdd }
+								onChange={ ( automaticallyAdd ) => {
+									setAttributes( { automaticallyAdd } );
+									handleCreateFromExistingPages();
+								} }
+								label={ __( 'Automatically add new pages' ) }
+								help={ __( 'Automatically add new top level pages to this menu.' ) }
+							/>
+						</PanelBody>
+					) }
 				</InspectorControls>
 				<Placeholder
 					className="wp-block-navigation-menu-placeholder"
@@ -208,16 +211,18 @@ function NavigationMenu( {
 			</BlockControls>
 			{ navigatorModal }
 			<InspectorControls>
-				<PanelBody
-					title={ __( 'Menu Settings' ) }
-				>
-					<CheckboxControl
-						value={ attributes.automaticallyAdd }
-						onChange={ ( automaticallyAdd ) => setAttributes( { automaticallyAdd } ) }
-						label={ __( 'Automatically add new pages' ) }
-						help={ __( 'Automatically add new top level pages to this menu.' ) }
-					/>
-				</PanelBody>
+				{ hasPages && (
+					<PanelBody
+						title={ __( 'Menu Settings' ) }
+					>
+						<CheckboxControl
+							value={ attributes.automaticallyAdd }
+							onChange={ ( automaticallyAdd ) => setAttributes( { automaticallyAdd } ) }
+							label={ __( 'Automatically add new pages' ) }
+							help={ __( 'Automatically add new top level pages to this menu.' ) }
+						/>
+					</PanelBody>
+				) }
 				<PanelBody
 					title={ __( 'Navigation Structure' ) }
 				>
@@ -226,7 +231,7 @@ function NavigationMenu( {
 			</InspectorControls>
 
 			<div className={ navigationMenuClasses } style={ navigationMenuInlineStyles }>
-				{ ! hasExistingNavItems && isRequesting && <><Spinner /> { __( 'Loading Navigation…' ) } </> }
+				{ ! hasExistingNavItems && isRequestingPages && <><Spinner /> { __( 'Loading Navigation…' ) } </> }
 
 				<InnerBlocks
 					allowedBlocks={ [ 'core/navigation-menu-item' ] }
@@ -250,10 +255,14 @@ export default compose( [
 			order: 'asc',
 			orderby: 'id',
 		};
+
+		const pagesSelect = [ 'core', 'getEntityRecords', [ 'postType', 'page', filterDefaultPages ] ];
+
 		return {
 			hasExistingNavItems,
 			pages: select( 'core' ).getEntityRecords( 'postType', 'page', filterDefaultPages ),
-			isRequesting: select( 'core/data' ).isResolving( 'core', 'getEntityRecords', [ 'postType', 'page', filterDefaultPages ] ),
+			isRequestingPages: select( 'core/data' ).isResolving( ...pagesSelect ),
+			hasResolvedPages: select( 'core/data' ).hasFinishedResolution( ...pagesSelect ),
 		};
 	} ),
 	withDispatch( ( dispatch, { clientId } ) => {

--- a/packages/block-library/src/navigation-menu/edit.js
+++ b/packages/block-library/src/navigation-menu/edit.js
@@ -230,7 +230,7 @@ export default compose( [
 		const { getBlocks } = registry.select( 'core/block-editor' );
 
 		const innerBlocks = getBlocks( clientId );
-		const hasExistingNavItems = innerBlocks && innerBlocks.filter( ( block ) => block.name === 'core/navigation-menu-item' ).length;
+		const hasExistingNavItems = !! innerBlocks.length;
 
 		const { getEntityRecords } = select( 'core' );
 		const { isResolving } = select( 'core/data' );
@@ -240,7 +240,7 @@ export default compose( [
 			orderby: 'id',
 		};
 		return {
-			hasExistingNavItems: !! hasExistingNavItems,
+			hasExistingNavItems,
 			pages: getEntityRecords( 'postType', 'page', filterDefaultPages ),
 			isRequesting: isResolving( 'core', 'getEntityRecords', [ 'postType', 'page', filterDefaultPages ] ),
 		};

--- a/packages/block-library/src/navigation-menu/edit.js
+++ b/packages/block-library/src/navigation-menu/edit.js
@@ -49,8 +49,22 @@ function NavigationMenu( {
 	setAttributes,
 	hasExistingNavItems,
 } ) {
+	//
+	// HOOKS
+	//
 	const [ initialPlaceholder, setInitialPlaceholder ] = useState( true );
+	const [ blocksTemplate, setBlocksTemplate ] = useState( null );
 	const { navigatorToolbarButton, navigatorModal } = useBlockNavigator( clientId );
+
+	useEffect( () => {
+		// Set/Unset colors CSS classes.
+		setAttributes( {
+			backgroundColorCSSClass: backgroundColor.class ? backgroundColor.class : null,
+			textColorCSSClass: textColor.class ? textColor.class : null,
+		} );
+	}, [ backgroundColor.class, textColor.class ] );
+
+	// Builds default menu items
 	const defaultMenuItems = useMemo(
 		() => {
 			if ( ! pages ) {
@@ -71,23 +85,9 @@ function NavigationMenu( {
 		[ pages ]
 	);
 
-	const navigationMenuInlineStyles = {};
-	if ( attributes.textColorValue ) {
-		navigationMenuInlineStyles.color = attributes.textColorValue;
-	}
-
-	if ( attributes.backgroundColorValue ) {
-		navigationMenuInlineStyles.backgroundColor = attributes.backgroundColorValue;
-	}
-
-	const navigationMenuClasses = classnames(
-		'wp-block-navigation-menu', {
-			'has-text-color': textColor.color,
-			'has-background-color': backgroundColor.color,
-			[ attributes.backgroundColorCSSClass ]: attributes && attributes.backgroundColorCSSClass,
-			[ attributes.textColorCSSClass ]: attributes && attributes.textColorCSSClass,
-		}
-	);
+	//
+	// HANDLERS
+	//
 
 	/**
 	 * Set the color type according to the given values.
@@ -113,22 +113,37 @@ function NavigationMenu( {
 		}
 	};
 
-	useEffect( () => {
-		// Set/Unset colors CSS classes.
-		setAttributes( {
-			backgroundColorCSSClass: backgroundColor.class ? backgroundColor.class : null,
-			textColorCSSClass: textColor.class ? textColor.class : null,
-		} );
-	}, [ backgroundColor.class, textColor.class ] );
-
 	const handleCreateEmpty = () => {
+		setBlocksTemplate( null );
 		setInitialPlaceholder( false );
 	};
 
 	const handleCreateFromExisting = () => {
+		setBlocksTemplate( defaultMenuItems );
 		setInitialPlaceholder( false );
 	};
 
+	//
+	// MARKUP
+	//
+
+	// Build Inline Styles
+	const navigationMenuInlineStyles = {
+		...( textColor && { color: textColor.color } ),
+		...( backgroundColor && { backgroundColor: backgroundColor.color } ),
+	};
+
+	// Build ClassNames
+	const navigationMenuClasses = classnames(
+		'wp-block-navigation-menu', {
+			'has-text-color': textColor.color,
+			'has-background-color': backgroundColor.color,
+			[ attributes.backgroundColorCSSClass ]: attributes && attributes.backgroundColorCSSClass,
+			[ attributes.textColorCSSClass ]: attributes && attributes.textColorCSSClass,
+		}
+	);
+
+	// UI State: initial placeholder
 	if ( ! hasExistingNavItems && initialPlaceholder ) {
 		return (
 			<Placeholder
@@ -159,6 +174,7 @@ function NavigationMenu( {
 		);
 	}
 
+	// UI State: rendered Block UI
 	return (
 		<>
 			<BlockControls>
@@ -168,8 +184,6 @@ function NavigationMenu( {
 				<BlockColorsStyleSelector
 					backgroundColor={ backgroundColor }
 					textColor={ textColor }
-					backgroundColorValue={ attributes.backgroundColorValue }
-					textColorValue={ attributes.textColorValue }
 					onColorChange={ setColorType }
 				/>
 			</BlockControls>
@@ -196,7 +210,7 @@ function NavigationMenu( {
 				{ isRequesting && <><Spinner /> { __( 'Loading Navigation…' ) } </> }
 				{ pages &&
 					<InnerBlocks
-						template={ defaultMenuItems ? defaultMenuItems : null }
+						template={ blocksTemplate ? blocksTemplate : null }
 						allowedBlocks={ [ 'core/navigation-menu-item' ] }
 						templateInsertUpdatesSelection={ false }
 						__experimentalMoverDirection={ 'horizontal' }

--- a/packages/block-library/src/navigation-menu/edit.js
+++ b/packages/block-library/src/navigation-menu/edit.js
@@ -64,8 +64,8 @@ function NavigationMenu( {
 		} );
 	}, [ backgroundColor.class, textColor.class ] );
 
-	// Builds default menu items
-	const defaultMenuItems = useMemo(
+	// Builds menu items from default Pages
+	const defaultPagesMenuItems = useMemo(
 		() => {
 			if ( ! pages ) {
 				return null;
@@ -119,7 +119,7 @@ function NavigationMenu( {
 	};
 
 	const handleCreateFromExisting = () => {
-		setBlocksTemplate( defaultMenuItems );
+		setBlocksTemplate( defaultPagesMenuItems );
 		setInitialPlaceholder( false );
 	};
 

--- a/packages/block-library/src/navigation-menu/edit.js
+++ b/packages/block-library/src/navigation-menu/edit.js
@@ -218,8 +218,8 @@ function NavigationMenu( {
 
 export default compose( [
 	withColors( { backgroundColor: 'background-color', textColor: 'color' } ),
-	withSelect( ( select, { clientId }, registry ) => {
-		const innerBlocks = registry.select( 'core/block-editor' ).getBlocks( clientId );
+	withSelect( ( select, { clientId } ) => {
+		const innerBlocks = select( 'core/block-editor' ).getBlocks( clientId );
 		const hasExistingNavItems = !! innerBlocks.length;
 
 		const filterDefaultPages = {

--- a/packages/block-library/src/navigation-menu/edit.js
+++ b/packages/block-library/src/navigation-menu/edit.js
@@ -125,6 +125,8 @@ function NavigationMenu( {
 		updateNavItemBlocks( defaultPagesMenuItems );
 	};
 
+	const hasPages = pages && pages.length;
+
 	// If we don't have existing items or the User hasn't
 	// indicated they want to automatically add top level Pages
 	// then show the Placeholder
@@ -157,6 +159,7 @@ function NavigationMenu( {
 							isDefault
 							className="wp-block-navigation-menu-placeholder__button"
 							onClick={ handleCreateFromExistingPages }
+							disabled={ ! hasPages }
 						>
 							{ __( 'Create from all top pages' ) }
 						</Button>

--- a/packages/block-library/src/navigation-menu/edit.js
+++ b/packages/block-library/src/navigation-menu/edit.js
@@ -123,26 +123,6 @@ function NavigationMenu( {
 		setInitialPlaceholder( false );
 	};
 
-	//
-	// MARKUP
-	//
-
-	// Build Inline Styles
-	const navigationMenuInlineStyles = {
-		...( textColor && { color: textColor.color } ),
-		...( backgroundColor && { backgroundColor: backgroundColor.color } ),
-	};
-
-	// Build ClassNames
-	const navigationMenuClasses = classnames(
-		'wp-block-navigation-menu', {
-			'has-text-color': textColor.color,
-			'has-background-color': backgroundColor.color,
-			[ attributes.backgroundColorCSSClass ]: attributes && attributes.backgroundColorCSSClass,
-			[ attributes.textColorCSSClass ]: attributes && attributes.textColorCSSClass,
-		}
-	);
-
 	// UI State: initial placeholder
 	if ( ! hasExistingNavItems && initialPlaceholder ) {
 		return (
@@ -175,6 +155,22 @@ function NavigationMenu( {
 			</Placeholder>
 		);
 	}
+
+	// Build Inline Styles
+	const navigationMenuInlineStyles = {
+		...( textColor && { color: textColor.color } ),
+		...( backgroundColor && { backgroundColor: backgroundColor.color } ),
+	};
+
+	// Build ClassNames
+	const navigationMenuClasses = classnames(
+		'wp-block-navigation-menu', {
+			'has-text-color': textColor.color,
+			'has-background-color': backgroundColor.color,
+			[ attributes.backgroundColorCSSClass ]: attributes && attributes.backgroundColorCSSClass,
+			[ attributes.textColorCSSClass ]: attributes && attributes.textColorCSSClass,
+		}
+	);
 
 	// UI State: rendered Block UI
 	return (

--- a/packages/block-library/src/navigation-menu/edit.js
+++ b/packages/block-library/src/navigation-menu/edit.js
@@ -157,16 +157,16 @@ function NavigationMenu( {
 
 				<div className="wp-block-navigation-menu-placeholder__buttons">
 					<Button
+						isDefault
 						className="wp-block-navigation-menu-placeholder__button"
-						isDefault={ true }
 						onClick={ handleCreateFromExisting }
 					>
 						{ __( 'Create from all top pages' ) }
 					</Button>
 
 					<Button
+						isLink
 						className="wp-block-navigation-menu-placeholder__button"
-						isLink={ true }
 						onClick={ handleCreateEmpty }
 					>
 						{ __( 'Create empty' ) }
@@ -225,9 +225,7 @@ function NavigationMenu( {
 
 export default compose( [
 	withColors( { backgroundColor: 'background-color', textColor: 'color' } ),
-	withSelect( ( select, ownProps, registry ) => {
-		const { clientId } = ownProps;
-
+	withSelect( ( select, { clientId }, registry ) => {
 		const innerBlocks = registry.select( 'core/block-editor' ).getBlocks( clientId );
 		const hasExistingNavItems = !! innerBlocks.length;
 

--- a/packages/block-library/src/navigation-menu/edit.js
+++ b/packages/block-library/src/navigation-menu/edit.js
@@ -9,6 +9,7 @@ import classnames from 'classnames';
 import {
 	useMemo,
 	useEffect,
+	useState,
 } from '@wordpress/element';
 import {
 	InnerBlocks,
@@ -22,6 +23,8 @@ import {
 	PanelBody,
 	Spinner,
 	Toolbar,
+	Placeholder,
+	Button,
 } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 
@@ -45,6 +48,7 @@ function NavigationMenu( {
 	setTextColor,
 	setAttributes,
 } ) {
+	const [ initialPlaceholder, setInitialPlaceholder ] = useState( true );
 	const { navigatorToolbarButton, navigatorModal } = useBlockNavigator( clientId );
 	const defaultMenuItems = useMemo(
 		() => {
@@ -115,6 +119,44 @@ function NavigationMenu( {
 			textColorCSSClass: textColor.class ? textColor.class : null,
 		} );
 	}, [ backgroundColor.class, textColor.class ] );
+
+	const handleCreateEmpty = () => {
+		setInitialPlaceholder( false );
+	};
+
+	const handleCreateFromExisting = () => {
+		setInitialPlaceholder( false );
+	};
+
+	if ( initialPlaceholder ) {
+		return (
+			<Placeholder
+				className="wp-block-navigation-menu-placeholder"
+				icon="menu"
+				label={ __( 'Navigation Menu' ) }
+			>
+				<p className="wp-block-navigation-menu-placeholder__instructions">Create a Menu from all existing pages or create an empty one.</p>
+
+				<div className="wp-block-navigation-menu-placeholder__buttons">
+					<Button
+						className="wp-block-navigation-menu-placeholder__button"
+						isDefault={ true }
+						onClick={ handleCreateFromExisting }
+					>
+						Create menu from existing pages
+					</Button>
+
+					<Button
+						className="wp-block-navigation-menu-placeholder__button"
+						isLink={ true }
+						onClick={ handleCreateEmpty }
+					>
+						Create an empty menu
+					</Button>
+				</div>
+			</Placeholder>
+		);
+	}
 
 	return (
 		<>

--- a/packages/block-library/src/navigation-menu/editor.scss
+++ b/packages/block-library/src/navigation-menu/editor.scss
@@ -154,17 +154,3 @@ $color-control-label-height: 20px;
 		}
 	}
 }
-
-// Initial Placeholder
-
-.wp-block-navigation-menu-placeholder__buttons {
-	padding-bottom: $grid-size-large;
-}
-
-.wp-block-navigation-menu-placeholder__button {
-	margin-right: 14px;
-
-	:last-child {
-		margin-bottom: 0;
-	}
-}

--- a/packages/block-library/src/navigation-menu/editor.scss
+++ b/packages/block-library/src/navigation-menu/editor.scss
@@ -162,7 +162,7 @@ $color-control-label-height: 20px;
 }
 
 .wp-block-navigation-menu-placeholder__button {
-	margin-right: $grid-size-large;
+	margin-right: 14px;
 
 	:last-child {
 		margin-bottom: 0;

--- a/packages/block-library/src/navigation-menu/editor.scss
+++ b/packages/block-library/src/navigation-menu/editor.scss
@@ -154,3 +154,27 @@ $color-control-label-height: 20px;
 		}
 	}
 }
+
+// Initial Placeholder
+
+.wp-block-navigation-menu-placeholder {
+
+	.components-placeholder__fieldset {
+		// flex-direction: column;
+	}
+}
+
+.wp-block-navigation-menu-placeholder__buttons {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	padding-bottom: $grid-size-large;
+}
+
+.wp-block-navigation-menu-placeholder__button {
+	margin-bottom: $grid-size-large;
+
+	:last-child {
+		margin-bottom: 0;
+	}
+}

--- a/packages/block-library/src/navigation-menu/editor.scss
+++ b/packages/block-library/src/navigation-menu/editor.scss
@@ -157,22 +157,12 @@ $color-control-label-height: 20px;
 
 // Initial Placeholder
 
-.wp-block-navigation-menu-placeholder {
-
-	.components-placeholder__fieldset {
-		// flex-direction: column;
-	}
-}
-
 .wp-block-navigation-menu-placeholder__buttons {
-	display: flex;
-	flex-direction: column;
-	align-items: center;
 	padding-bottom: $grid-size-large;
 }
 
 .wp-block-navigation-menu-placeholder__button {
-	margin-bottom: $grid-size-large;
+	margin-right: $grid-size-large;
 
 	:last-child {
 		margin-bottom: 0;

--- a/packages/components/src/placeholder/style.scss
+++ b/packages/components/src/placeholder/style.scss
@@ -77,3 +77,25 @@
 	margin: 3%;
 	width: 50%;
 }
+
+.components-placeholder__fieldset .components-button {
+	margin-right: 4px;
+	margin-bottom: 10px; // if buttons wrap we need vertical space between
+
+	&:last-child {
+		margin-right: 0;
+	}
+}
+
+// Any `<Button />` component with `isLink` prop will need extra spacing if placed
+// immediately after a button which is *not* an `isLink` style button. This is because
+// `isLink` has no padding so we need to account for this to avoid the buttons butting
+// up against each other. If it's the last item we don't need a right margin.
+.components-placeholder__fieldset .components-button:not(.is-link) ~ .components-button.is-link {
+	margin-left: 10px; // equal to standard button inner padding
+	margin-right: 10px; // equal to standard button inner padding
+
+	&:last-child {
+		margin-right: 0;
+	}
+}


### PR DESCRIPTION
Closes https://github.com/WordPress/gutenberg/issues/18307.

This PR aims to improve the initial state of the Nav Block by adding a placeholder that affords the choice to:

1. Create a Menu from existing pages.
2. Create an empty Menu from scratch.

In future, this will be augmented to enable the creation of Menu from an existing Menu (but that is for another day!).

Note: if the Block _already_ has items within it (ie: you already created your menu) the placeholder will not show.

## Questions

* Would it be better to only request the Pages on demand rather than upfront? If so I'll need some advice on using `@wordpress/core-data` to achieve this as I can't seem to wrap my head around how I'd structure the code (cc @mtias ).

## How has this been tested?
Manual testing.

## Screenshots <!-- if applicable -->

![Screen Capture on 2019-11-08 at 14-34-38](https://user-images.githubusercontent.com/444434/68484386-152cc800-0235-11ea-94f3-ba630d4ecb6c.gif)



## Types of changes
New feature (non-breaking change which adds functionality).

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
