### PR TITLE
(i18n) Verse: Example: Fix string concatenation, add `translators` string

### DIFF
--- a/packages/block-library/src/verse/index.js
+++ b/packages/block-library/src/verse/index.js
@@ -23,12 +23,8 @@ export const settings = {
 	icon,
 	example: {
 		attributes: {
-			content: __( 'WHAT was he doing, the great god Pan,' ) + '<br>' +
-			__( '    Down in the reeds by the river?' ) + '<br>' +
-			__( 'Spreading ruin and scattering ban,' ) + '<br>' +
-			__( 'Splashing and paddling with hoofs of a goat,' ) + '<br>' +
-			__( 'And breaking the golden lilies afloat' ) + '<br>' +
-			__( '    With the dragon-fly on the river.' ),
+			// translators: Sample content for the Verse block. Can be replaced with a locale-appropriate work.
+			content: __( 'WHAT was he doing, the great god Pan,<br>    Down in the reeds by the river?<br>Spreading ruin and scattering ban,<br>Splashing and paddling with hoofs of a goat,<br>And breaking the golden lilies afloat<br>    With the dragon-fly on the river.' ),
 		},
 	},
 	keywords: [ __( 'poetry' ) ],


### PR DESCRIPTION
## Description

See #18364 for full context. In particular, this pull request explores the following point:

> However, when dealing with block examples, we are in the unusual case of translating not UI, not code in a stricter sense, but serialised data representing user content. Thus, the example strings can in fact contain HTML elements. In fact, I'd argue that this is the most correct thing to do, as it fits the idea that we're letting content be translated.