### PR TITLE
Preserves style of menu items when in edit mode

### DIFF
--- a/packages/block-library/src/navigation-menu-item/editor.scss
+++ b/packages/block-library/src/navigation-menu-item/editor.scss
@@ -71,7 +71,6 @@
 
 	.block-editor-rich-text__editable.is-selected:not(.keep-placeholder-on-focus):not(:focus) [data-rich-text-placeholder]::after {
 		display: inherit;
-		min-width: 30px;
 	}
 }
 

--- a/packages/block-library/src/navigation-menu-item/editor.scss
+++ b/packages/block-library/src/navigation-menu-item/editor.scss
@@ -64,21 +64,6 @@
 }
 
 .wp-block-navigation-menu-item {
-	&:not(.is-editing) {
-		font-family: inherit;
-		font-size: inherit;
-	}
-
-	&.is-editing .components-text-control__input {
-		width: inherit;
-		background-color: inherit;
-		color: inherit;
-
-		&:focus {
-			color: inherit;
-		}
-	}
-
 	&.is-editing,
 	&.is-selected {
 		min-width: 20px;
@@ -87,8 +72,6 @@
 	.block-editor-rich-text__editable.is-selected:not(.keep-placeholder-on-focus):not(:focus) [data-rich-text-placeholder]::after {
 		display: inherit;
 		min-width: 30px;
-		font-family: inherit;
-		font-size: inherit;
 	}
 }
 

--- a/packages/block-library/src/navigation-menu-item/editor.scss
+++ b/packages/block-library/src/navigation-menu-item/editor.scss
@@ -66,7 +66,7 @@
 .wp-block-navigation-menu-item {
 	&:not(.is-editing) {
 		font-family: inherit;
-		font-size: $text-editor-font-size;
+		font-size: inherit;
 	}
 
 	&.is-editing .components-text-control__input {
@@ -88,7 +88,7 @@
 		display: inherit;
 		min-width: 30px;
 		font-family: inherit;
-		font-size: $text-editor-font-size;
+		font-size: inherit;
 	}
 }
 

--- a/packages/block-library/src/navigation-menu-item/editor.scss
+++ b/packages/block-library/src/navigation-menu-item/editor.scss
@@ -67,7 +67,6 @@
 	&:not(.is-editing) {
 		font-family: inherit;
 		font-size: $text-editor-font-size;
-		font-weight: bold;
 	}
 
 	&.is-editing .components-text-control__input {
@@ -87,6 +86,9 @@
 
 	.block-editor-rich-text__editable.is-selected:not(.keep-placeholder-on-focus):not(:focus) [data-rich-text-placeholder]::after {
 		display: inherit;
+		min-width: 30px;
+		font-family: inherit;
+		font-size: $text-editor-font-size;
 	}
 }
 


### PR DESCRIPTION
## Description
Closes #18331

## How has this been tested?
Tested locally

## Screenshots
<img width="596" alt="Screenshot 2019-11-07 at 13 46 56" src="https://user-images.githubusercontent.com/107534/68386612-17275600-0165-11ea-8c54-e2e9601f290a.png">


## Types of changes
Removed some CSS from the editor css of the navigation menu item component. Made the font styling inherit.

