### PR TITLE
Use support align for image block

### DIFF
--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -46,7 +46,6 @@ import {
 } from '@wordpress/keycodes';
 import { withSelect, withDispatch } from '@wordpress/data';
 import {
-	BlockAlignmentToolbar,
 	BlockControls,
 	BlockIcon,
 	InspectorControls,
@@ -268,7 +267,6 @@ export class ImageEdit extends Component {
 	constructor( { attributes } ) {
 		super( ...arguments );
 		this.updateAlt = this.updateAlt.bind( this );
-		this.updateAlignment = this.updateAlignment.bind( this );
 		this.onFocusCaption = this.onFocusCaption.bind( this );
 		this.onImageClick = this.onImageClick.bind( this );
 		this.onSelectImage = this.onSelectImage.bind( this );
@@ -484,13 +482,6 @@ export class ImageEdit extends Component {
 		this.props.setAttributes( { alt: newAlt } );
 	}
 
-	updateAlignment( nextAlign ) {
-		const extraUpdatedAttributes = [ 'wide', 'full' ].indexOf( nextAlign ) !== -1 ?
-			{ width: undefined, height: undefined } :
-			{};
-		this.props.setAttributes( { ...extraUpdatedAttributes, align: nextAlign } );
-	}
-
 	updateImage( sizeSlug ) {
 		const { image } = this.props;
 
@@ -597,10 +588,6 @@ export class ImageEdit extends Component {
 		const isExternal = isExternalImage( id, url );
 		const controls = (
 			<BlockControls>
-				<BlockAlignmentToolbar
-					value={ align }
-					onChange={ this.updateAlignment }
-				/>
 				{ url && (
 					<>
 						<Toolbar>

--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -33,7 +33,6 @@ import {
 	MEDIA_TYPE_IMAGE,
 	BlockControls,
 	InspectorControls,
-	BlockAlignmentToolbar,
 } from '@wordpress/block-editor';
 import { __, sprintf } from '@wordpress/i18n';
 import { isURL } from '@wordpress/url';
@@ -90,7 +89,6 @@ export class ImageEdit extends React.Component {
 		this.onImagePressed = this.onImagePressed.bind( this );
 		this.onClearSettings = this.onClearSettings.bind( this );
 		this.onFocusCaption = this.onFocusCaption.bind( this );
-		this.updateAlignment = this.updateAlignment.bind( this );
 	}
 
 	componentDidMount() {
@@ -189,10 +187,6 @@ export class ImageEdit extends React.Component {
 		this.props.setAttributes( { url, width: undefined, height: undefined } );
 	}
 
-	updateAlignment( nextAlign ) {
-		this.props.setAttributes( { align: nextAlign } );
-	}
-
 	onSetLinkDestination( href ) {
 		this.props.setAttributes( {
 			linkDestination: LINK_DESTINATION_CUSTOM,
@@ -262,11 +256,6 @@ export class ImageEdit extends React.Component {
 						onClick={ open }
 					/>
 				</Toolbar>
-				<BlockAlignmentToolbar
-					value={ align }
-					onChange={ this.updateAlignment }
-					isCollapsed={ false }
-				/>
 			</BlockControls>
 		);
 

--- a/packages/block-library/src/image/index.js
+++ b/packages/block-library/src/image/index.js
@@ -37,6 +37,9 @@ export const settings = {
 		{ name: 'circle-mask', label: _x( 'Circle Mask', 'block style' ) },
 	],
 	transforms,
+	supports: {
+		align: true,
+	},
 	getEditWrapperProps( attributes ) {
 		const { align, width } = attributes;
 		if ( 'left' === align || 'center' === align || 'right' === align || 'wide' === align || 'full' === align ) {


### PR DESCRIPTION
## Description
Use support align for image block instead of implementing manually. 

Fixes #13780 
Related #17799 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
