### PR TITLE
[Tiny PR] Verse: save line breaks as characters

### DIFF
--- a/packages/block-library/src/verse/block.json
+++ b/packages/block-library/src/verse/block.json
@@ -6,7 +6,8 @@
 			"type": "string",
 			"source": "html",
 			"selector": "pre",
-			"default": ""
+			"default": "",
+			"__unstablePreserveWhiteSpace": true
 		},
 		"textAlign": {
 			"type": "string"

--- a/packages/block-library/src/verse/edit.js
+++ b/packages/block-library/src/verse/edit.js
@@ -28,10 +28,14 @@ export default function VerseEdit( { attributes, setAttributes, className, merge
 			</BlockControls>
 			<RichText
 				tagName="pre"
-				value={ content }
+				// Ensure line breaks are normalised to HTML.
+				value={ content.replace( /\n/g, '<br>' ) }
 				onChange={ ( nextContent ) => {
 					setAttributes( {
-						content: nextContent,
+						// Ensure line breaks are normalised to characters. This
+						// saves space, is easier to read, and ensures display
+						// filters work correctly.
+						content: nextContent.replace( /<br ?\/?>/g, '\n' ),
 					} );
 				} }
 				placeholder={ __( 'Write…' ) }

--- a/packages/block-library/src/verse/edit.js
+++ b/packages/block-library/src/verse/edit.js
@@ -28,14 +28,11 @@ export default function VerseEdit( { attributes, setAttributes, className, merge
 			</BlockControls>
 			<RichText
 				tagName="pre"
-				// Ensure line breaks are normalised to HTML.
-				value={ content.replace( /\n/g, '<br>' ) }
+				preserveWhiteSpace
+				value={ content }
 				onChange={ ( nextContent ) => {
 					setAttributes( {
-						// Ensure line breaks are normalised to characters. This
-						// saves space, is easier to read, and ensures display
-						// filters work correctly.
-						content: nextContent.replace( /<br ?\/?>/g, '\n' ),
+						content: nextContent,
 					} );
 				} }
 				placeholder={ __( 'Write…' ) }

--- a/packages/block-library/src/verse/index.js
+++ b/packages/block-library/src/verse/index.js
@@ -23,6 +23,7 @@ export const settings = {
 	icon,
 	example: {
 		attributes: {
+			// translators: Sample content for the Verse block. Can be replaced with a locale-appropriate work.
 			content: __( 'WHAT was he doing, the great god Pan,\n	Down in the reeds by the river?\nSpreading ruin and scattering ban,\nSplashing and paddling with hoofs of a goat,\nAnd breaking the golden lilies afloat\n    With the dragon-fly on the river.' ),
 		},
 	},

--- a/packages/block-library/src/verse/index.js
+++ b/packages/block-library/src/verse/index.js
@@ -23,8 +23,7 @@ export const settings = {
 	icon,
 	example: {
 		attributes: {
-			// translators: Sample content for the Verse block. Can be replaced with a locale-appropriate work.
-			content: __( 'WHAT was he doing, the great god Pan,<br>    Down in the reeds by the river?<br>Spreading ruin and scattering ban,<br>Splashing and paddling with hoofs of a goat,<br>And breaking the golden lilies afloat<br>    With the dragon-fly on the river.' ),
+			content: __( 'WHAT was he doing, the great god Pan,\n	Down in the reeds by the river?\nSpreading ruin and scattering ban,\nSplashing and paddling with hoofs of a goat,\nAnd breaking the golden lilies afloat\n    With the dragon-fly on the river.' ),
 		},
 	},
 	keywords: [ __( 'poetry' ) ],


### PR DESCRIPTION
## Description

Same as #14653, but for verse.
Related: #18099.
Fixes #18364.

This should be the behaviour when using `pre`, which makes me wonder if we should build it in `RichText` if the `tagName` is set to `pre`. Thoughts? I do like to keep complexity out of `RichText`, but maybe it just makes more sense.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
