### PR TITLE
Navigation Menu Item: fix showing input placeholder

### DIFF
--- a/packages/block-library/src/navigation-menu-item/editor.scss
+++ b/packages/block-library/src/navigation-menu-item/editor.scss
@@ -82,9 +82,11 @@
 
 	&.is-editing,
 	&.is-selected {
-		box-shadow: 0 0 1px $light-gray-900 inset;
-		border-radius: 4px;
-		min-width: 30px;
+		min-width: 20px;
+	}
+
+	.block-editor-rich-text__editable.is-selected:not(.keep-placeholder-on-focus):not(:focus) [data-rich-text-placeholder]::after {
+		display: inherit;
 	}
 }
 


### PR DESCRIPTION
## Description
It fixes the visual issue which happens when the input is selected but not focused not showing the `Add Item...` placeholder.

Fixes https://github.com/WordPress/gutenberg/issues/18368

## How has this been tested?

1) Apply these changes
2) Create / Edit a new item. Just be sure the item content is empty.
3) If the input is focused confirm you see the caret and be able to type
4) If not focused, you should see the `Add item...` placeholder. For this, open the LinkControl popover, for instance.


## Screenshots <!-- if applicable -->

![item-text-placeholder](https://user-images.githubusercontent.com/77539/68398386-6795b800-0153-11ea-856d-0c141eb76cb2.gif)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->