### PR TITLE
Navigation Menu: apply colors using block attributes

### DIFF
--- a/packages/block-library/src/navigation-menu/block-colors-selector.js
+++ b/packages/block-library/src/navigation-menu/block-colors-selector.js
@@ -24,14 +24,15 @@ const ColorSelectorSVGIcon = () => (
  * @param {Object} colorControlProps colorControl properties.
  * @return {*} React Icon component.
  */
-const ColorSelectorIcon = ( { backgroundColor, textColor } ) => {
+const ColorSelectorIcon = ( { backgroundColor, textColor, backgroundColorValue, textColorValue } ) => {
 	const iconStyle = {};
-	if ( textColor && ! textColor.class ) {
-		iconStyle.color = textColor.color;
+
+	if ( backgroundColorValue ) {
+		iconStyle.backgroundColor = backgroundColorValue;
 	}
 
-	if ( backgroundColor && ! backgroundColor.class ) {
-		iconStyle.backgroundColor = backgroundColor.color;
+	if ( textColorValue ) {
+		iconStyle.color = textColorValue;
 	}
 
 	const iconClasses = classnames( 'block-library-colors-selector__state-selection', {
@@ -56,7 +57,7 @@ const ColorSelectorIcon = ( { backgroundColor, textColor } ) => {
  * @param {Object} colorControlProps colorControl properties.
  * @return {*} React toggle button component.
  */
-const renderToggleComponent = ( { backgroundColor, textColor } ) => ( { onToggle, isOpen } ) => {
+const renderToggleComponent = ( { backgroundColor, textColor, backgroundColorValue, textColorValue } ) => ( { onToggle, isOpen } ) => {
 	const openOnArrowDown = ( event ) => {
 		if ( ! isOpen && event.keyCode === DOWN ) {
 			event.preventDefault();
@@ -72,7 +73,12 @@ const renderToggleComponent = ( { backgroundColor, textColor } ) => ( { onToggle
 				label={ __( 'Open Colors Selector' ) }
 				onClick={ onToggle }
 				onKeyDown={ openOnArrowDown }
-				icon={ <ColorSelectorIcon backgroundColor={ backgroundColor } textColor={ textColor } /> }
+				icon={ <ColorSelectorIcon
+					backgroundColor={ backgroundColor }
+					textColor={ textColor }
+					backgroundColorValue={ backgroundColorValue }
+					textColorValue={ textColorValue }
+				/> }
 			/>
 		</Toolbar>
 	);

--- a/packages/block-library/src/navigation-menu/edit.js
+++ b/packages/block-library/src/navigation-menu/edit.js
@@ -67,12 +67,12 @@ function NavigationMenu( {
 	);
 
 	const navigationMenuInlineStyles = {};
-	if ( textColor ) {
-		navigationMenuInlineStyles.color = textColor.color;
+	if ( attributes.textColorValue ) {
+		navigationMenuInlineStyles.color = attributes.textColorValue;
 	}
 
-	if ( backgroundColor ) {
-		navigationMenuInlineStyles.backgroundColor = backgroundColor.color;
+	if ( attributes.backgroundColorValue ) {
+		navigationMenuInlineStyles.backgroundColor = attributes.backgroundColorValue;
 	}
 
 	const navigationMenuClasses = classnames(
@@ -125,6 +125,8 @@ function NavigationMenu( {
 				<BlockColorsStyleSelector
 					backgroundColor={ backgroundColor }
 					textColor={ textColor }
+					backgroundColorValue={ attributes.backgroundColorValue }
+					textColorValue={ attributes.textColorValue }
 					onColorChange={ setColorType }
 				/>
 			</BlockControls>


### PR DESCRIPTION
## Description
It applies the colors using the block attributes instead of using the textColor and backgroundColor properties. 

Fixes https://github.com/WordPress/gutenberg/issues/18366

## How has this been tested?
Following the issue instructions:

**To reproduce**
Steps to reproduce the behavior:
1. Create a post
2. Create a navigation menu block
3. Set background and foreground colors
4. Save and publish the post
5. Go to Appearance -> Themes and change the theme
6. Go back to the post you created with the navigation block
7. See error -> colours are not there anymore

**Expected behavior**
I expect the colours to be saved even if I switch themes.

## Checklist:
- [x] My code is tested. 
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
