### PR TITLE
[RNMobile] Instruct haste/jest to look for modules in RN/Libraries/Utilities too

### DIFF
--- a/test/native/jest.config.js
+++ b/test/native/jest.config.js
@@ -38,6 +38,7 @@ module.exports = {
 		'/__device-tests__/',
 	],
 	testURL: 'http://localhost/',
+	// Add the `Libraries/Utilities` subfolder to the module directories, otherwise haste/jest doesn't find Platform.js on Travis
 	moduleDirectories: [ 'node_modules', 'node_modules/react-native/Libraries/Utilities' ],
 	moduleNameMapper: {
 		// Mock the CSS modules. See https://facebook.github.io/jest/docs/en/webpack.html#handling-static-assets

--- a/test/native/jest.config.js
+++ b/test/native/jest.config.js
@@ -38,7 +38,7 @@ module.exports = {
 		'/__device-tests__/',
 	],
 	testURL: 'http://localhost/',
-	moduleDirectories: [ 'node_modules' ],
+	moduleDirectories: [ 'node_modules', 'node_modules/react-native/Libraries/Utilities' ],
 	moduleNameMapper: {
 		// Mock the CSS modules. See https://facebook.github.io/jest/docs/en/webpack.html#handling-static-assets
 		'\\.(scss)$': '<rootDir>/' + configPath + '/__mocks__/styleMock.js',


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/1356

For some reason, on Linux and Travis, Jest can't properly resolve the `Platform` module which is defined in the Libraries/Utilities folder inside the react-native package. Providing it as an extra module path seems to fix the issue.

## Description
Added a nested module path to Haste/Jest for the mobile tests.

## How has this been tested?
Locally on an Ubuntu VM. The Travis run in this PR should hopefully be "green" too.

## Types of changes
Added a nested module path to Haste/Jest for the mobile tests.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
