### PR TITLE
Prevent focus steal on clicking the inserter

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -289,7 +289,7 @@ function BlockListBlock( {
 	 * (via `setFocus`), typically if there is no focusable input in the block.
 	 */
 	const onFocus = () => {
-		if ( ! isSelected && ! isPartOfMultiSelection ) {
+		if ( ! isSelected && ! isParentOfSelectedBlock && ! isPartOfMultiSelection ) {
 			onSelect();
 		}
 	};

--- a/packages/block-editor/src/components/button-block-appender/index.js
+++ b/packages/block-editor/src/components/button-block-appender/index.js
@@ -35,9 +35,6 @@ function ButtonBlockAppender( { rootClientId, className, __experimentalSelectBlo
 						<Tooltip text={ label }>
 							<Button
 								className={ classnames( className, 'block-editor-button-block-appender' ) }
-								onMouseDown={ ( event ) => {
-									event.preventDefault();
-								} }
 								onClick={ onToggle }
 								aria-haspopup={ isToggleButton ? 'true' : undefined }
 								aria-expanded={ isToggleButton ? isOpen : undefined }

--- a/packages/block-editor/src/components/button-block-appender/index.js
+++ b/packages/block-editor/src/components/button-block-appender/index.js
@@ -35,6 +35,9 @@ function ButtonBlockAppender( { rootClientId, className, __experimentalSelectBlo
 						<Tooltip text={ label }>
 							<Button
 								className={ classnames( className, 'block-editor-button-block-appender' ) }
+								onMouseDown={ ( event ) => {
+									event.preventDefault();
+								} }
 								onClick={ onToggle }
 								aria-haspopup={ isToggleButton ? 'true' : undefined }
 								aria-expanded={ isToggleButton ? isOpen : undefined }

--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -33,6 +33,10 @@ const defaultRenderToggle = ( { onToggle, disabled, isOpen, blockTitle, hasSingl
 			icon="insert"
 			label={ label }
 			labelPosition="bottom"
+			onMouseDown={ ( event ) => {
+				event.preventDefault();
+				event.currentTarget.focus();
+			} }
 			onClick={ onToggle }
 			className="editor-inserter__toggle block-editor-inserter__toggle"
 			aria-haspopup={ ! hasSingleBlockType ? 'true' : false }

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -14,14 +14,17 @@ describe( 'Adds Navigation links', () => {
 
 	it( 'Should add a link with one click', async () => {
 		const navigationAppender = '.wp-block-navigation .block-list-appender';
-		const existingPagesOption = '.wp-block-navigation-placeholder__button.is-default';
+		const emptyOption = '.wp-block-navigation-placeholder__button.is-link';
+		const linkInput = '.block-editor-link-control__search-input';
 		const navigationLink = '.wp-block-navigation-link';
 
 		await insertBlock( 'Navigation' );
 
-		await page.waitForSelector( existingPagesOption );
-		await page.click( existingPagesOption );
-		await page.waitForSelector( navigationAppender );
+		await page.waitForSelector( emptyOption );
+		await page.click( emptyOption );
+		await page.waitForSelector( linkInput );
+		await page.type( linkInput, 'http://example.com' );
+		await page.keyboard.press( 'Enter' );
 		await page.click( navigationAppender );
 
 		const navigationLinkCount = await page.$$eval( navigationLink, ( navigationLinks ) => navigationLinks.length );

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -13,21 +13,16 @@ describe( 'Adds Navigation links', () => {
 	} );
 
 	it( 'Should add a link with one click', async () => {
-		const navigationAppender = '.wp-block-navigation .block-list-appender';
-		const emptyOption = '.wp-block-navigation-placeholder__button.is-link';
-		const linkInput = '.block-editor-link-control__search-input';
-		const navigationLink = '.wp-block-navigation-link';
-
 		await insertBlock( 'Navigation' );
+		const [ createEmptyButton ] = await page.$x( '//button[text()="Create empty"]' );
+		await createEmptyButton.click();
+		await page.waitForSelector( 'input[placeholder="Search or type url"]' );
+		await page.type( 'input[placeholder="Search or type url"]', 'http://example.com' );
 
-		await page.waitForSelector( emptyOption );
-		await page.click( emptyOption );
-		await page.waitForSelector( linkInput );
-		await page.type( linkInput, 'http://example.com' );
 		await page.keyboard.press( 'Enter' );
-		await page.click( navigationAppender );
+		await page.click( '.wp-block-navigation .block-list-appender' );
 
-		const navigationLinkCount = await page.$$eval( navigationLink, ( navigationLinks ) => navigationLinks.length );
+		const navigationLinkCount = await page.$$eval( '.wp-block-navigation-link', ( navigationLinks ) => navigationLinks.length );
 
 		expect( navigationLinkCount ).toBe( 2 );
 	} );

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -1,0 +1,31 @@
+
+/**
+ * WordPress dependencies
+ */
+import {
+	createNewPost,
+	insertBlock,
+} from '@wordpress/e2e-test-utils';
+
+describe( 'Adds Navigation links', () => {
+	beforeEach( async () => {
+		await createNewPost();
+	} );
+
+	it( 'Should add a link with one click', async () => {
+		const navigationAppender = '.wp-block-navigation .block-list-appender';
+		const existingPagesOption = '.wp-block-navigation-placeholder__button.is-default';
+		const navigationLink = '.wp-block-navigation-link';
+
+		await insertBlock( 'Navigation' );
+
+		await page.waitForSelector( existingPagesOption );
+		await page.click( existingPagesOption );
+		await page.waitForSelector( navigationAppender );
+		await page.click( navigationAppender );
+
+		const navigationLinkCount = await page.$$eval( navigationLink, ( navigationLinks ) => navigationLinks.length );
+
+		expect( navigationLinkCount ).toBe( 2 );
+	} );
+} );


### PR DESCRIPTION
## Description
Fixes #18329

The problem was that the inserter sometimes stole focus from the currently selected block depending on which appender it used. The insertion point appender handled it correctly:

![inserter-weirdness](https://user-images.githubusercontent.com/107534/68483507-64c6c000-0244-11ea-82f3-2bcaeff45dbe.gif)

I have copied the same technique to all the other situations by creating a new appender exposed by `InnerBlocks` named ... `InnerBlocks.UnfocusableButtonBlockAppender`.

![solved-appender](https://user-images.githubusercontent.com/107534/68488059-efabb880-024c-11ea-8a98-faf957021c74.gif)


## How has this been tested?
Tested locally

## Types of changes
All the appenders need to have their focus event stopped from propagating and their tab index set to -1. 

## Changes to navigation:
I have been unable to keep the movers from stealing the focus of RichText using the same event technique from above, so as a solution (temporary?) I found the `keepPlaceholderOnFocus` option for RichText and the result is that we no longer have an issue.

I also think it looks better :) @karmatosed what do you think?

Before:

![mover-focus-before](https://user-images.githubusercontent.com/107534/68493371-0bb35800-0255-11ea-9d29-86653e8e584e.gif)

After:

![mover-focus-after](https://user-images.githubusercontent.com/107534/68493406-179f1a00-0255-11ea-8103-2d3585b5560f.gif)


