### PR TITLE
Navigation Menu: improving applying colors

### DIFF
--- a/packages/block-library/src/navigation-menu-item/editor.scss
+++ b/packages/block-library/src/navigation-menu-item/editor.scss
@@ -9,11 +9,16 @@
 }
 
 .wp-block-navigation-menu-item {
+	margin-left: $grid-size;
 	margin-right: $grid-size;
 
 	.block-editor-block-list__layout {
 		display: block;
 		margin: $grid-size;
+	}
+
+	.wp-block-navigation-menu-item__link {
+		margin-left: $grid-size-large;
 	}
 
 	// Provide a base menu item margin.

--- a/packages/block-library/src/navigation-menu-item/editor.scss
+++ b/packages/block-library/src/navigation-menu-item/editor.scss
@@ -71,8 +71,6 @@
 .wp-block-navigation-menu-item {
 	&:not(.is-editing) {
 		font-family: inherit;
-		font-size: $text-editor-font-size;
-		font-weight: bold;
 	}
 
 	&.is-editing .components-text-control__input {

--- a/packages/block-library/src/navigation-menu/editor.scss
+++ b/packages/block-library/src/navigation-menu/editor.scss
@@ -63,6 +63,21 @@
 		padding: $grid-size-large;
 	}
 
+	// Handling item colors depending on the navigation.
+	.wp-block-navigation-menu {
+		&.has-background-color {
+			.wp-block-navigation-menu-item {
+				background-color: inherit; // it inherits the color defined in the navigation.
+			}
+		}
+
+		&.has-text-color {
+			.wp-block-navigation-menu-item {
+				color: inherit; // it inherits the color defined in the navigation.
+			}
+		}
+	}
+
 	/**
 	 * Colors Selector component
 	 */

--- a/packages/block-library/src/navigation-menu/editor.scss
+++ b/packages/block-library/src/navigation-menu/editor.scss
@@ -63,13 +63,6 @@
 		padding: $grid-size-large;
 	}
 
-	.wp-block-navigation-menu-item {
-		margin-left: $grid-size;
-		.wp-block-navigation-menu-item__link {
-			margin-left: $grid-size-large;
-		}
-	}
-
 	/**
 	 * Colors Selector component
 	 */

--- a/packages/block-library/src/navigation-menu/editor.scss
+++ b/packages/block-library/src/navigation-menu/editor.scss
@@ -52,79 +52,79 @@
 			background: none;
 		}
 	}
-}
 
-.wp-block-navigation-menu .block-editor-block-list__layout,
-.wp-block-navigation-menu {
-	display: flex;
-	white-space: nowrap;
-}
-
-.wp-block-navigation-menu__inserter-content {
-	padding: $grid-size-large;
-}
-
-.wp-block-navigation-menu-item {
-	margin-left: $grid-size;
-	.wp-block-navigation-menu-item__link {
-		margin-left: $grid-size-large;
-	}
-}
-
-/**
- * Colors Selector component
- */
-$colors-selector-size: 22px;
-.block-library-colors-selector {
-	width: auto;
-
-	// Toolbar colors-selector button.
-	.block-library-colors-selector__toggle {
-		display: block;
-		margin: 0 auto;
-		padding: 3px;
-		width: auto;
-	}
-
-	// Button container.
-	.block-library-colors-selector__icon-container {
-		width: 42px;
-		height: 30px;
-		position: relative;
-		margin: 0 auto;
-		padding: 3px;
+	.wp-block-navigation-menu .block-editor-block-list__layout,
+	.wp-block-navigation-menu {
 		display: flex;
-		align-items: center;
-		border-radius: 4px;
+		white-space: nowrap;
+	}
 
-		// Add the button arrow.
-		&::after {
-			@include dropdown-arrow();
-		}
+	.wp-block-navigation-menu__inserter-content {
+		padding: $grid-size-large;
+	}
 
-		// Styling button states.
-		&:focus,
-		&:hover {
-			color: $dark-gray-500;
-			box-shadow: inset 0 0 0 1px $dark-gray-500, inset 0 0 0 2px #fff;
+	.wp-block-navigation-menu-item {
+		margin-left: $grid-size;
+		.wp-block-navigation-menu-item__link {
+			margin-left: $grid-size-large;
 		}
 	}
 
-	// colors-selector - selection status.
-	.block-library-colors-selector__state-selection {
-		border-radius: $colors-selector-size / 2;
-		box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.2);
+	/**
+	 * Colors Selector component
+	 */
+	$colors-selector-size: 22px;
+	.block-library-colors-selector {
+		width: auto;
 
-		width: $colors-selector-size;
-		min-width: $colors-selector-size;
-		height: $colors-selector-size;
-		min-height: $colors-selector-size;
-		line-height: ($colors-selector-size - 2);
-		padding: 2px;
+		// Toolbar colors-selector button.
+		.block-library-colors-selector__toggle {
+			display: block;
+			margin: 0 auto;
+			padding: 3px;
+			width: auto;
+		}
 
-		&:not(.has-background-color) {
-			background-image: linear-gradient(135deg, rgba(0, 0, 0, 0.08) 25%, transparent 25%, transparent 50%, rgba(0, 0, 0, 0.08) 50%, rgba(0, 0, 0, 0.08) 75%, transparent 75%, transparent 100%);
-			background-size: 12px 12px;
+		// Button container.
+		.block-library-colors-selector__icon-container {
+			width: 42px;
+			height: 30px;
+			position: relative;
+			margin: 0 auto;
+			padding: 3px;
+			display: flex;
+			align-items: center;
+			border-radius: 4px;
+
+			// Add the button arrow.
+			&::after {
+				@include dropdown-arrow();
+			}
+
+			// Styling button states.
+			&:focus,
+			&:hover {
+				color: $dark-gray-500;
+				box-shadow: inset 0 0 0 1px $dark-gray-500, inset 0 0 0 2px #fff;
+			}
+		}
+
+		// colors-selector - selection status.
+		.block-library-colors-selector__state-selection {
+			border-radius: $colors-selector-size / 2;
+			box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.2);
+
+			width: $colors-selector-size;
+			min-width: $colors-selector-size;
+			height: $colors-selector-size;
+			min-height: $colors-selector-size;
+			line-height: ($colors-selector-size - 2);
+			padding: 2px;
+
+			&:not(.has-background-color) {
+				background-image: linear-gradient(135deg, rgba(0, 0, 0, 0.08) 25%, transparent 25%, transparent 50%, rgba(0, 0, 0, 0.08) 50%, rgba(0, 0, 0, 0.08) 75%, transparent 75%, transparent 100%);
+				background-size: 12px 12px;
+			}
 		}
 	}
 }

--- a/packages/block-library/src/navigation-menu/index.php
+++ b/packages/block-library/src/navigation-menu/index.php
@@ -90,7 +90,12 @@ function render_block_navigation_menu( $attributes, $content, $block ) {
 		$css_classes .= ' ' .  $colors['text_css_classes'];
 	}
 
-	return "<nav class='{$css_classes}' {$comp_inline_styles}>" .
+	return sprintf(
+		'<nav class="%1$s" %2$s>%3$s</nav>',
+		esc_attr( $css_classes ),
+		$comp_inline_styles, // This should really be split out into attribute name and value to work like class above.
+		build_navigation_menu_html( $block )
+	);
 		build_navigation_menu_html( $block ) .
 	'</nav>';
 }

--- a/packages/block-library/src/navigation-menu/index.php
+++ b/packages/block-library/src/navigation-menu/index.php
@@ -23,7 +23,7 @@ function build_css_colors( $attributes ) {
 
 	// Background color.
 	// Background color - has text color.
-	if ( array_key_exists( 'backgroundColor', $attributes ) ) {
+	if ( array_key_exists( 'backgroundColorValue', $attributes ) ) {
 		$colors['bg_css_classes'] .= ' has-background-color';
 	}
 
@@ -38,7 +38,7 @@ function build_css_colors( $attributes ) {
 
 	// Text color.
 	// Text color - has text color.
-	if ( array_key_exists( 'textColor', $attributes ) ) {
+	if ( array_key_exists( 'textColorValue', $attributes ) ) {
 		$colors['text_css_classes'] .= ' has-text-color';
 	}
 	// Text color - add custom CSS class.
@@ -80,8 +80,18 @@ function render_block_navigation_menu( $attributes, $content, $block ) {
 
 	$colors = build_css_colors( $attributes );
 
-	return "<nav class='wp-block-navigation-menu' {$comp_inline_styles}>" .
-		build_navigation_menu_html( $block, $colors ) .
+	$css_classes = "wp-block-navigation-menu";
+
+	if ( ! empty( $colors['bg_css_classes'] ) ) {
+		$css_classes .= ' ' .  $colors['bg_css_classes'];
+	}
+
+	if ( ! empty( $colors['text_css_classes'] ) ) {
+		$css_classes .= ' ' .  $colors['text_css_classes'];
+	}
+
+	return "<nav class='{$css_classes}' {$comp_inline_styles}>" .
+		build_navigation_menu_html( $block ) .
 	'</nav>';
 }
 
@@ -89,18 +99,14 @@ function render_block_navigation_menu( $attributes, $content, $block ) {
  * Walks the inner block structure and returns an HTML list for it.
  *
  * @param array $block  The block.
- * @param array $colors Contains inline styles and CSS classes to apply to menu item.
- *
  * @return string Returns  an HTML list from innerBlocks.
  */
-function build_navigation_menu_html( $block, $colors ) {
+function build_navigation_menu_html( $block ) {
 	$html = '';
 	foreach ( (array) $block['innerBlocks'] as $key => $menu_item ) {
 
-		$html .= '<li class="wp-block-navigation-menu-item ' . $colors['bg_css_classes'] . '"' . $colors['bg_inline_styles'] . '>' .
-			'<a
-				class="wp-block-navigation-menu-item__link ' . $colors['text_css_classes'] . '"
-				' . $colors['text_inline_styles'];
+		$html .= '<li class="wp-block-navigation-menu-item">' .
+			'<a class="wp-block-navigation-menu-item__link" ';
 
 		// Start appending HTML attributes to anchor tag.
 		if ( isset( $menu_item['attrs']['url'] ) ) {
@@ -124,7 +130,7 @@ function build_navigation_menu_html( $block, $colors ) {
 		// End anchor tag content.
 
 		if ( count( (array) $menu_item['innerBlocks'] ) > 0 ) {
-			$html .= build_navigation_menu_html( $menu_item, $colors );
+			$html .= build_navigation_menu_html( $menu_item );
 		}
 
 		$html .= '</li>';

--- a/packages/block-library/src/navigation-menu/style.scss
+++ b/packages/block-library/src/navigation-menu/style.scss
@@ -1,5 +1,4 @@
 .wp-block-navigation-menu {
-
 	& > ul {
 		display: block;
 		list-style: none;
@@ -116,4 +115,22 @@
 		}
 	}
 
+	// Handling item colors depending on the navigation.
+	&.has-background-color {
+		li.wp-block-navigation-menu-item {
+			background-color: inherit;
+			a.wp-block-navigation-menu-item__link {
+				background-color: inherit;
+			}
+		}
+	}
+
+	&.has-text-color {
+		li.wp-block-navigation-menu-item {
+			color: inherit;
+			a.wp-block-navigation-menu-item__link {
+				color: inherit;
+			}
+		}
+	}
 }

--- a/packages/block-library/src/navigation-menu/style.scss
+++ b/packages/block-library/src/navigation-menu/style.scss
@@ -60,7 +60,7 @@
 		& > li > ul {
 			margin: 0;
 			position: absolute;
-			background: #fff;
+			//background: #fff;
 			box-shadow: 0 0 8px 2px rgba(0, 0, 0, 0.2);
 			left: 0;
 			top: 100%;
@@ -122,6 +122,10 @@
 			a.wp-block-navigation-menu-item__link {
 				background-color: inherit;
 			}
+		}
+
+		ul {
+			background-color: inherit;
 		}
 	}
 


### PR DESCRIPTION
## Description
This PR keeps improving how the colors are applied either in the Editor canvas as well as the front-end.

Fixes https://github.com/WordPress/gutenberg/issues/18377

## How has this been tested?
Apply `background` and `text` colors picking them up from the colors palette or with customs ones. Check that the colors applied are correctly implemented in the front-end.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
