### PR TITLE
Render preview in a modal with responsive sizes.

### DIFF
--- a/packages/e2e-tests/specs/editor/various/preview.test.js
+++ b/packages/e2e-tests/specs/editor/various/preview.test.js
@@ -23,6 +23,8 @@ async function openPreviewPage( editorPage ) {
 	let openTabs = await browser.pages();
 	const expectedTabsCount = openTabs.length + 1;
 	await editorPage.click( '.editor-post-preview' );
+	await editorPage.waitForSelector( '.editor-block-preview__new-tab' );
+	await editorPage.click( '.editor-block-preview__new-tab' );
 
 	// Wait for the new tab to open.
 	while ( openTabs.length < expectedTabsCount ) {
@@ -31,9 +33,7 @@ async function openPreviewPage( editorPage ) {
 	}
 
 	const previewPage = last( openTabs );
-	// Wait for the preview to load. We can't do interstitial detection here,
-	// because it might load too quickly for us to pick up, so we wait for
-	// the preview to load by waiting for the title to appear.
+	// Wait for the preview to load by waiting for the title to appear.
 	await previewPage.waitForSelector( '.entry-title' );
 	return previewPage;
 }
@@ -48,6 +48,8 @@ async function openPreviewPage( editorPage ) {
  */
 async function waitForPreviewNavigation( previewPage ) {
 	await page.click( '.editor-post-preview' );
+	await page.waitForSelector( '.editor-block-preview__new-tab' );
+	await page.click( '.editor-block-preview__new-tab' );
 	return previewPage.waitForNavigation();
 }
 
@@ -117,6 +119,7 @@ describe( 'Preview', () => {
 
 		// Return to editor to change title.
 		await editorPage.bringToFront();
+		await editorPage.click( '[aria-label="Close dialog"' );
 		await editorPage.type( '.editor-post-title__input', '!' );
 		await waitForPreviewNavigation( previewPage );
 
@@ -127,12 +130,14 @@ describe( 'Preview', () => {
 		// Pressing preview without changes should bring same preview window to
 		// front and reload, but should not show interstitial.
 		await editorPage.bringToFront();
+		await editorPage.click( '[aria-label="Close dialog"' );
 		await waitForPreviewNavigation( previewPage );
 		previewTitle = await previewPage.$eval( '.entry-title', ( node ) => node.textContent );
 		expect( previewTitle ).toBe( 'Hello World!' );
 
 		// Preview for published post (no unsaved changes) directs to canonical URL for post.
 		await editorPage.bringToFront();
+		await editorPage.click( '[aria-label="Close dialog"' );
 		await publishPost();
 
 		// Return to editor to change title.
@@ -156,6 +161,7 @@ describe( 'Preview', () => {
 		//
 		// See: https://github.com/WordPress/gutenberg/issues/7561
 		await editorPage.bringToFront();
+		await editorPage.click( '[aria-label="Close dialog"' );
 		await waitForPreviewNavigation( previewPage );
 
 		// Title in preview should match updated input.
@@ -185,6 +191,7 @@ describe( 'Preview', () => {
 
 		// Return to editor.
 		await editorPage.bringToFront();
+		await editorPage.click( '[aria-label="Close dialog"' );
 
 		// Append bbbbb to the title, and tab away from the title so blur event is triggered.
 		await editorPage.type( '.editor-post-title__input', 'bbbbb' );
@@ -238,6 +245,7 @@ describe( 'Preview with Custom Fields enabled', () => {
 
 		// Return to editor and modify the title and content.
 		await editorPage.bringToFront();
+		await editorPage.click( '[aria-label="Close dialog"' );
 		await editorPage.click( '.editor-post-title__input' );
 		await pressKeyWithModifier( 'primary', 'a' );
 		await editorPage.keyboard.press( 'Delete' );
@@ -258,5 +266,6 @@ describe( 'Preview with Custom Fields enabled', () => {
 
 		// Make sure the editor is active for the afterEach function.
 		await editorPage.bringToFront();
+		await editorPage.click( '[aria-label="Close dialog"' );
 	} );
 } );

--- a/packages/e2e-tests/specs/editor/various/preview.test.js
+++ b/packages/e2e-tests/specs/editor/various/preview.test.js
@@ -23,8 +23,8 @@ async function openPreviewPage( editorPage ) {
 	let openTabs = await browser.pages();
 	const expectedTabsCount = openTabs.length + 1;
 	await editorPage.click( '.editor-post-preview' );
-	await editorPage.waitForSelector( '.editor-block-preview__new-tab' );
-	await editorPage.click( '.editor-block-preview__new-tab' );
+	await editorPage.waitForSelector( '.editor-post-preview__new-tab' );
+	await editorPage.click( '.editor-post-preview__new-tab' );
 
 	// Wait for the new tab to open.
 	while ( openTabs.length < expectedTabsCount ) {
@@ -48,8 +48,8 @@ async function openPreviewPage( editorPage ) {
  */
 async function waitForPreviewNavigation( previewPage ) {
 	await page.click( '.editor-post-preview' );
-	await page.waitForSelector( '.editor-block-preview__new-tab' );
-	await page.click( '.editor-block-preview__new-tab' );
+	await page.waitForSelector( '.editor-post-preview__new-tab' );
+	await page.click( '.editor-post-preview__new-tab' );
 	return previewPage.waitForNavigation();
 }
 

--- a/packages/editor/src/components/post-preview-button/index.js
+++ b/packages/editor/src/components/post-preview-button/index.js
@@ -154,9 +154,12 @@ export class PostPreviewButton extends Component {
 				>
 					{ _x( 'Preview', 'imperative verb' ) }
 
-					<DotTip tipId="core/editor.preview">
-						{ __( 'Click “Preview” to load a preview of this page, so you can make sure you’re happy with your blocks.' ) }
-					</DotTip>
+					<span className="screen-reader-text">
+						{
+						/* translators: accessibility text */
+							__( '(opens in a new tab)' )
+						}
+					</span>
 				</Button>
 				{ this.state.isPreviewOpen &&
 				<Modal

--- a/packages/editor/src/components/post-preview-button/index.js
+++ b/packages/editor/src/components/post-preview-button/index.js
@@ -165,7 +165,7 @@ export class PostPreviewButton extends Component {
 					<Modal
 						title={
 							// translators: Preview dialog title.
-							__( 'Preview dialog' )
+							_x( 'Preview', 'noun' )
 						}
 						onRequestClose={ this.closePreviewModal }
 						// Needed so the Modal doesn't close when tabbing into the iframe.
@@ -198,10 +198,15 @@ export class PostPreviewButton extends Component {
 								{ __( 'Open preview in new tab' ) }
 							</Button>
 						</div>
-						<div className="editor-post-preview__frame-container">
+						<div
+							className="editor-post-preview__frame-container"
+							tabIndex="0"
+							role="region"
+							aria-label={ _x( 'Preview', 'noun' ) }
+						>
 							<iframe
 								className="editor-post-preview__frame"
-								title={ __( 'Responsive preview frame' ) }
+								title={ __( 'Responsive preview' ) }
 								src={ href }
 								style={
 									{

--- a/packages/editor/src/components/post-preview-button/index.js
+++ b/packages/editor/src/components/post-preview-button/index.js
@@ -94,7 +94,7 @@ export class PostPreviewButton extends Component {
 
 		// Open up a Preview tab if needed. This is where we'll show the preview.
 		if ( ! this.previewWindow || this.previewWindow.closed ) {
-			this.previewWindow = window.open( '', this.getWindowTarget() );
+			this.previewWindow = window.open( '', '_blank' );
 		}
 
 		// Focus the Preview tab. This might not do anything, depending on the browser's

--- a/packages/editor/src/components/post-preview-button/index.js
+++ b/packages/editor/src/components/post-preview-button/index.js
@@ -30,8 +30,8 @@ export class PostPreviewButton extends Component {
 		this.openPreviewInNewTab = this.openPreviewInNewTab.bind( this );
 		this.getWindowTarget = this.getWindowTarget.bind( this );
 		this.setPreviewWindowLink = this.setPreviewWindowLink.bind( this );
-		this.openPreviewOverlay = this.openPreviewOverlay.bind( this );
-		this.closePreviewWindow = this.closePreviewWindow.bind( this );
+		this.openPreviewModal = this.openPreviewModal.bind( this );
+		this.closePreviewModal = this.closePreviewModal.bind( this );
 		this.setDesktopPreview = this.setDesktopPreview.bind( this );
 		this.setTabletPreview = this.setTabletPreview.bind( this );
 		this.setMobilePreview = this.setMobilePreview.bind( this );
@@ -67,7 +67,7 @@ export class PostPreviewButton extends Component {
 		return `wp-preview-${ postId }`;
 	}
 
-	openPreviewOverlay() {
+	openPreviewModal() {
 		this.setState( { isPreviewOpen: true } );
 
 		// If we don't need to autosave the post before previewing, do nothing.
@@ -133,7 +133,7 @@ export class PostPreviewButton extends Component {
 		} );
 	}
 
-	closePreviewWindow() {
+	closePreviewModal() {
 		this.setState( { isPreviewOpen: false } );
 	}
 
@@ -150,7 +150,7 @@ export class PostPreviewButton extends Component {
 					isLarge
 					className="editor-post-preview"
 					disabled={ ! isSaveable }
-					onClick={ this.openPreviewOverlay }
+					onClick={ this.openPreviewModal }
 				>
 					{ _x( 'Preview', 'imperative verb' ) }
 
@@ -162,56 +162,56 @@ export class PostPreviewButton extends Component {
 					</span>
 				</Button>
 				{ this.state.isPreviewOpen &&
-				<Modal
-					title={
-					// translators: Preview dialog title.
-						__( 'Preview' )
-					}
-					onRequestClose={ this.closePreviewWindow }
-					// Needed so the Modal doesn't close when tabbing into the iframe.
-					shouldCloseOnClickOutside={ false }
-					className="editor-block-preview"
-				>
-					<div className="editor-block-preview__controls">
-						<IconButton
-							icon={ DesktopIcon }
-							onClick={ this.setDesktopPreview }
-							label={ __( 'Preview desktop screen' ) }
-						/>
-						<IconButton
-							icon={ TabletIcon }
-							onClick={ this.setTabletPreview }
-							label={ __( 'Preview tablet screen' ) }
-						/>
-						<IconButton
-							icon={ MobileIcon }
-							onClick={ this.setMobilePreview }
-							label={ __( 'Preview phone screen' ) }
-						/>
-						<Button
-							isLarge
-							className="editor-block-preview__new-tab"
-							href={ href }
-							target={ this.getWindowTarget() }
-							onClick={ this.openPreviewInNewTab }
-						>
-							{ _x( 'Open preview in new tab', 'imperative verb' ) }
-						</Button>
-					</div>
-					<div className="editor-block-preview__frame-container">
-						<iframe
-							className="editor-block-preview__frame"
-							title={ __( 'Responsive preview frame' ) }
-							src={ href }
-							style={
-								{
-									width: this.state.previewSize.width,
-									height: this.state.previewSize.height,
+					<Modal
+						title={
+							// translators: Preview dialog title.
+							__( 'Preview dialog' )
+						}
+						onRequestClose={ this.closePreviewModal }
+						// Needed so the Modal doesn't close when tabbing into the iframe.
+						shouldCloseOnClickOutside={ false }
+						className="editor-post-preview-button__preview-modal"
+					>
+						<div className="editor-post-preview__controls">
+							<IconButton
+								icon={ DesktopIcon }
+								onClick={ this.setDesktopPreview }
+								label={ __( 'Preview desktop screen' ) }
+							/>
+							<IconButton
+								icon={ TabletIcon }
+								onClick={ this.setTabletPreview }
+								label={ __( 'Preview tablet screen' ) }
+							/>
+							<IconButton
+								icon={ MobileIcon }
+								onClick={ this.setMobilePreview }
+								label={ __( 'Preview phone screen' ) }
+							/>
+							<Button
+								isLarge
+								className="editor-post-preview__new-tab"
+								href={ href }
+								target={ this.getWindowTarget() }
+								onClick={ this.openPreviewInNewTab }
+							>
+								{ __( 'Open preview in new tab' ) }
+							</Button>
+						</div>
+						<div className="editor-post-preview__frame-container">
+							<iframe
+								className="editor-post-preview__frame"
+								title={ __( 'Responsive preview frame' ) }
+								src={ href }
+								style={
+									{
+										width: this.state.previewSize.width,
+										height: this.state.previewSize.height,
+									}
 								}
-							}
-						></iframe>
-					</div>
-				</Modal>
+							></iframe>
+						</div>
+					</Modal>
 				}
 			</>
 		);

--- a/packages/editor/src/components/post-preview-button/index.js
+++ b/packages/editor/src/components/post-preview-button/index.js
@@ -190,7 +190,6 @@ export class PostPreviewButton extends Component {
 							className="editor-block-preview__new-tab"
 							href={ href }
 							target={ this.getWindowTarget() }
-							disabled={ ! isSaveable }
 							onClick={ this.openPreviewInNewTab }
 						>
 							{ _x( 'Open preview in new tab', 'imperative verb' ) }
@@ -200,7 +199,7 @@ export class PostPreviewButton extends Component {
 						<iframe
 							className="editor-block-preview__frame"
 							title={ __( 'Responsive preview frame' ) }
-							src={ previewLink }
+							src={ href }
 							style={
 								{
 									width: this.state.previewSize.width,

--- a/packages/editor/src/components/post-preview-button/index.js
+++ b/packages/editor/src/components/post-preview-button/index.js
@@ -6,96 +6,28 @@ import { get } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { Component, renderToString } from '@wordpress/element';
-import { Button, Path, SVG } from '@wordpress/components';
+import { Component } from '@wordpress/element';
+import { Button, Modal } from '@wordpress/components';
 import { __, _x } from '@wordpress/i18n';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { ifCondition, compose } from '@wordpress/compose';
-import { applyFilters } from '@wordpress/hooks';
-
-function writeInterstitialMessage( targetDocument ) {
-	let markup = renderToString(
-		<div className="editor-post-preview-button__interstitial-message">
-			<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 96">
-				<Path className="outer" d="M48 12c19.9 0 36 16.1 36 36S67.9 84 48 84 12 67.9 12 48s16.1-36 36-36" fill="none" />
-				<Path className="inner" d="M69.5 46.4c0-3.9-1.4-6.7-2.6-8.8-1.6-2.6-3.1-4.9-3.1-7.5 0-2.9 2.2-5.7 5.4-5.7h.4C63.9 19.2 56.4 16 48 16c-11.2 0-21 5.7-26.7 14.4h2.1c3.3 0 8.5-.4 8.5-.4 1.7-.1 1.9 2.4.2 2.6 0 0-1.7.2-3.7.3L40 67.5l7-20.9L42 33c-1.7-.1-3.3-.3-3.3-.3-1.7-.1-1.5-2.7.2-2.6 0 0 5.3.4 8.4.4 3.3 0 8.5-.4 8.5-.4 1.7-.1 1.9 2.4.2 2.6 0 0-1.7.2-3.7.3l11.5 34.3 3.3-10.4c1.6-4.5 2.4-7.8 2.4-10.5zM16.1 48c0 12.6 7.3 23.5 18 28.7L18.8 35c-1.7 4-2.7 8.4-2.7 13zm32.5 2.8L39 78.6c2.9.8 5.9 1.3 9 1.3 3.7 0 7.3-.6 10.6-1.8-.1-.1-.2-.3-.2-.4l-9.8-26.9zM76.2 36c0 3.2-.6 6.9-2.4 11.4L64 75.6c9.5-5.5 15.9-15.8 15.9-27.6 0-5.5-1.4-10.8-3.9-15.3.1 1 .2 2.1.2 3.3z" fill="none" />
-			</SVG>
-			<p>{ __( 'Generating preview…' ) }</p>
-		</div>
-	);
-
-	markup += `
-		<style>
-			body {
-				margin: 0;
-			}
-			.editor-post-preview-button__interstitial-message {
-				display: flex;
-				flex-direction: column;
-				align-items: center;
-				justify-content: center;
-				height: 100vh;
-				width: 100vw;
-			}
-			@-webkit-keyframes paint {
-				0% {
-					stroke-dashoffset: 0;
-				}
-			}
-			@-moz-keyframes paint {
-				0% {
-					stroke-dashoffset: 0;
-				}
-			}
-			@-o-keyframes paint {
-				0% {
-					stroke-dashoffset: 0;
-				}
-			}
-			@keyframes paint {
-				0% {
-					stroke-dashoffset: 0;
-				}
-			}
-			.editor-post-preview-button__interstitial-message svg {
-				width: 192px;
-				height: 192px;
-				stroke: #555d66;
-				stroke-width: 0.75;
-			}
-			.editor-post-preview-button__interstitial-message svg .outer,
-			.editor-post-preview-button__interstitial-message svg .inner {
-				stroke-dasharray: 280;
-				stroke-dashoffset: 280;
-				-webkit-animation: paint 1.5s ease infinite alternate;
-				-moz-animation: paint 1.5s ease infinite alternate;
-				-o-animation: paint 1.5s ease infinite alternate;
-				animation: paint 1.5s ease infinite alternate;
-			}
-			p {
-				text-align: center;
-				font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-			}
-		</style>
-	`;
-
-	/**
-	 * Filters the interstitial message shown when generating previews.
-	 *
-	 * @param {string} markup The preview interstitial markup.
-	 */
-	markup = applyFilters( 'editor.PostPreview.interstitialMarkup', markup );
-
-	targetDocument.write( markup );
-	targetDocument.title = __( 'Generating preview…' );
-	targetDocument.close();
-}
 
 export class PostPreviewButton extends Component {
 	constructor() {
 		super( ...arguments );
 
+		this.state = {
+			isPreviewOpen: false,
+			previewSize: {
+				width: '1200px',
+				height: '800px',
+			},
+		};
 		this.openPreviewWindow = this.openPreviewWindow.bind( this );
+		this.closePreviewWindow = this.closePreviewWindow.bind( this );
+		this.setDesktopPreview = this.setDesktopPreview.bind( this );
+		this.setTabletPreview = this.setTabletPreview.bind( this );
+		this.setMobilePreview = this.setMobilePreview.bind( this );
 	}
 
 	componentDidUpdate( prevProps ) {
@@ -128,69 +60,87 @@ export class PostPreviewButton extends Component {
 		return `wp-preview-${ postId }`;
 	}
 
-	openPreviewWindow( event ) {
-		// Our Preview button has its 'href' and 'target' set correctly for a11y
-		// purposes. Unfortunately, though, we can't rely on the default 'click'
-		// handler since sometimes it incorrectly opens a new tab instead of reusing
-		// the existing one.
-		// https://github.com/WordPress/gutenberg/pull/8330
-		event.preventDefault();
+	openPreviewWindow( ) {
+		this.setState( { isPreviewOpen: true } );
+	}
 
-		// Open up a Preview tab if needed. This is where we'll show the preview.
-		if ( ! this.previewWindow || this.previewWindow.closed ) {
-			this.previewWindow = window.open( '', this.getWindowTarget() );
-		}
+	setDesktopPreview() {
+		this.setState( {
+			previewSize: {
+				width: '1200px',
+				height: '800px',
+			},
+		} );
+	}
 
-		// Focus the Preview tab. This might not do anything, depending on the browser's
-		// and user's preferences.
-		// https://html.spec.whatwg.org/multipage/interaction.html#dom-window-focus
-		this.previewWindow.focus();
+	setTabletPreview() {
+		this.setState( {
+			previewSize: {
+				width: '768px',
+				height: '1024px',
+			},
+		} );
+	}
 
-		// If we don't need to autosave the post before previewing, then we simply
-		// load the Preview URL in the Preview tab.
-		if ( ! this.props.isAutosaveable ) {
-			this.setPreviewWindowLink( event.target.href );
-			return;
-		}
+	setMobilePreview() {
+		this.setState( {
+			previewSize: {
+				width: '375px',
+				height: '812px',
+			},
+		} );
+	}
 
-		// Request an autosave. This happens asynchronously and causes the component
-		// to update when finished.
-		if ( this.props.isDraft ) {
-			this.props.savePost( { isPreview: true } );
-		} else {
-			this.props.autosave( { isPreview: true } );
-		}
-
-		// Display a 'Generating preview' message in the Preview tab while we wait for the
-		// autosave to finish.
-		writeInterstitialMessage( this.previewWindow.document );
+	closePreviewWindow() {
+		this.setState( { isPreviewOpen: false } );
 	}
 
 	render() {
-		const { previewLink, currentPostLink, isSaveable } = this.props;
+		const { previewLink, isSaveable } = this.props;
 
 		// Link to the `?preview=true` URL if we have it, since this lets us see
 		// changes that were autosaved since the post was last published. Otherwise,
 		// just link to the post's URL.
-		const href = previewLink || currentPostLink;
 
 		return (
-			<Button
-				isLarge
-				className="editor-post-preview"
-				href={ href }
-				target={ this.getWindowTarget() }
-				disabled={ ! isSaveable }
-				onClick={ this.openPreviewWindow }
-			>
-				{ _x( 'Preview', 'imperative verb' ) }
-				<span className="screen-reader-text">
-					{
-						/* translators: accessibility text */
-						__( '(opens in a new tab)' )
+			<>
+				<Button
+					isLarge
+					className="editor-post-preview"
+					disabled={ ! isSaveable }
+					onClick={ this.openPreviewWindow }
+				>
+					{ _x( 'Preview', 'imperative verb' ) }
+
+					<DotTip tipId="core/editor.preview">
+						{ __( 'Click “Preview” to load a preview of this page, so you can make sure you’re happy with your blocks.' ) }
+					</DotTip>
+				</Button>
+				{ this.state.isPreviewOpen &&
+				<Modal
+					title={
+					// translators: Preview dialog title.
+						__( 'Preview' )
 					}
-				</span>
-			</Button>
+					onRequestClose={ this.closePreviewWindow }
+					className="editor-block-preview"
+				>
+					<button onClick={ this.setDesktopPreview }>Desktop</button>
+					<button onClick={ this.setTabletPreview }>Tablet</button>
+					<button onClick={ this.setMobilePreview }>Mobile</button>
+					<iframe
+						title="tehPreview"
+						src={ previewLink }
+						style={
+							{
+								width: this.state.previewSize.width,
+								height: this.state.previewSize.height,
+							}
+						}
+					></iframe>
+				</Modal>
+				}
+			</>
 		);
 	}
 }

--- a/packages/editor/src/components/post-preview-button/index.js
+++ b/packages/editor/src/components/post-preview-button/index.js
@@ -125,19 +125,23 @@ export class PostPreviewButton extends Component {
 					onRequestClose={ this.closePreviewWindow }
 					className="editor-block-preview"
 				>
-					<button onClick={ this.setDesktopPreview }>Desktop</button>
-					<button onClick={ this.setTabletPreview }>Tablet</button>
-					<button onClick={ this.setMobilePreview }>Mobile</button>
-					<iframe
-						title="tehPreview"
-						src={ previewLink }
-						style={
-							{
-								width: this.state.previewSize.width,
-								height: this.state.previewSize.height,
+					<div className="editor-block-preview__controls">
+						<button onClick={ this.setDesktopPreview }>Desktop</button>
+						<button onClick={ this.setTabletPreview }>Tablet</button>
+						<button onClick={ this.setMobilePreview }>Mobile</button>
+					</div>
+					<div className="editor-block-preview__frame">
+						<iframe
+							title="tehPreview"
+							src={ previewLink }
+							style={
+								{
+									width: this.state.previewSize.width,
+									height: this.state.previewSize.height,
+								}
 							}
-						}
-					></iframe>
+						></iframe>
+					</div>
 				</Modal>
 				}
 			</>

--- a/packages/editor/src/components/post-preview-button/style.scss
+++ b/packages/editor/src/components/post-preview-button/style.scss
@@ -1,4 +1,4 @@
-.editor-block-preview {
+.editor-post-preview-button__preview-modal {
 	@include break-small() {
 		top: 5%;
 		right: 5%;
@@ -8,7 +8,7 @@
 	}
 }
 
-.editor-block-preview__controls {
+.editor-post-preview__controls {
 	display: flex;
 	align-items: center;
 	margin: $grid-size-large 0;
@@ -18,16 +18,16 @@
 	}
 }
 
-.editor-block-preview__new-tab {
+.editor-post-preview__new-tab {
 	margin-left: $grid-size-large;
 }
 
-.editor-block-preview__frame-container {
+.editor-post-preview__frame-container {
 	overflow-x: auto;
 	margin-bottom: 40px;
 }
 
-.editor-block-preview__frame {
+.editor-post-preview__frame {
 	display: block;
 	margin: 0 auto;
 }

--- a/packages/editor/src/components/post-preview-button/style.scss
+++ b/packages/editor/src/components/post-preview-button/style.scss
@@ -1,0 +1,18 @@
+.editor-block-preview {
+	@include break-small() {
+		top: 5%;
+		right: 5%;
+		bottom: 5%;
+		left: 5%;
+		transform: none;
+	}
+}
+
+.editor-block-preview__controls {
+	margin: $grid-size-large 0;
+}
+
+.editor-block-preview__frame {
+	display: flex;
+	justify-content: center;
+}

--- a/packages/editor/src/components/post-preview-button/style.scss
+++ b/packages/editor/src/components/post-preview-button/style.scss
@@ -1,9 +1,9 @@
 .editor-post-preview-button__preview-modal {
 	@include break-small() {
-		top: 5%;
-		right: 5%;
-		bottom: 5%;
-		left: 5%;
+		top: 60px;
+		right: 60px;
+		bottom: 60px;
+		left: 60px;
 		transform: none;
 	}
 }
@@ -24,10 +24,10 @@
 
 .editor-post-preview__frame-container {
 	overflow-x: auto;
-	margin-bottom: 40px;
 }
 
 .editor-post-preview__frame {
 	display: block;
 	margin: 0 auto;
+	max-height: calc(100vh - 280px);
 }

--- a/packages/editor/src/components/post-preview-button/style.scss
+++ b/packages/editor/src/components/post-preview-button/style.scss
@@ -9,10 +9,25 @@
 }
 
 .editor-block-preview__controls {
+	display: flex;
+	align-items: center;
 	margin: $grid-size-large 0;
+
+	* + * {
+		margin-left: $grid-size;
+	}
+}
+
+.editor-block-preview__new-tab {
+	margin-left: $grid-size-large;
+}
+
+.editor-block-preview__frame-container {
+	overflow-x: auto;
+	margin-bottom: 40px;
 }
 
 .editor-block-preview__frame {
-	display: flex;
-	justify-content: center;
+	display: block;
+	margin: 0 auto;
 }

--- a/packages/editor/src/components/post-preview-button/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/post-preview-button/test/__snapshots__/index.js.snap
@@ -1,37 +1,111 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`PostPreviewButton render() should render currentPostLink otherwise 1`] = `
-<ForwardRef(Button)
-  className="editor-post-preview"
-  disabled={false}
-  href="https://wordpress.org/?p=1"
-  isLarge={true}
-  onClick={[Function]}
-  target="wp-preview-1"
->
-  Preview
-  <span
-    className="screen-reader-text"
+exports[`PostPreviewButton render() should render overlay when state is open 1`] = `
+<Fragment>
+  <ForwardRef(Button)
+    className="editor-post-preview"
+    disabled={true}
+    isLarge={true}
+    onClick={[Function]}
   >
-    (opens in a new tab)
-  </span>
-</ForwardRef(Button)>
-`;
-
-exports[`PostPreviewButton render() should render previewLink if provided 1`] = `
-<ForwardRef(Button)
-  className="editor-post-preview"
-  disabled={false}
-  href="https://wordpress.org/?p=1&preview=true"
-  isLarge={true}
-  onClick={[Function]}
-  target="wp-preview-1"
->
-  Preview
-  <span
-    className="screen-reader-text"
+    Preview
+    <WithSelect(WithDispatch(DotTip))
+      tipId="core/editor.preview"
+    >
+      Click “Preview” to load a preview of this page, so you can make sure you’re happy with your blocks.
+    </WithSelect(WithDispatch(DotTip))>
+  </ForwardRef(Button)>
+  <WithInstanceId(Modal)
+    className="editor-block-preview"
+    onRequestClose={[Function]}
+    shouldCloseOnClickOutside={false}
+    title="Preview"
   >
-    (opens in a new tab)
-  </span>
-</ForwardRef(Button)>
+    <div
+      className="editor-block-preview__controls"
+    >
+      <ForwardRef(IconButton)
+        icon={
+          <SVG
+            height="24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <Path
+              d="M0 0h24v24H0z"
+              fill="none"
+            />
+            <Path
+              d="M21 2H3c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h7v2H8v2h8v-2h-2v-2h7c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm0 14H3V4h18v12z"
+            />
+          </SVG>
+        }
+        label="Preview desktop screen"
+        onClick={[Function]}
+      />
+      <ForwardRef(IconButton)
+        icon={
+          <SVG
+            height="24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <Path
+              d="M0 0h24v24H0z"
+              fill="none"
+            />
+            <Path
+              d="M21 4H3c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h18c1.1 0 1.99-.9 1.99-2L23 6c0-1.1-.9-2-2-2zm-2 14H5V6h14v12z"
+            />
+          </SVG>
+        }
+        label="Preview tablet screen"
+        onClick={[Function]}
+      />
+      <ForwardRef(IconButton)
+        icon={
+          <SVG
+            height="24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <Path
+              d="M0 0h24v24H0z"
+              fill="none"
+            />
+            <Path
+              d="M17 1.01L7 1c-1.1 0-2 .9-2 2v18c0 1.1.9 2 2 2h10c1.1 0 2-.9 2-2V3c0-1.1-.9-1.99-2-1.99zM17 19H7V5h10v14z"
+            />
+          </SVG>
+        }
+        label="Preview phone screen"
+        onClick={[Function]}
+      />
+      <ForwardRef(Button)
+        className="editor-block-preview__new-tab"
+        href="https://wordpress.org/?p=1"
+        isLarge={true}
+        onClick={[Function]}
+        target="wp-preview-1"
+      >
+        Open preview in new tab
+      </ForwardRef(Button)>
+    </div>
+    <div
+      className="editor-block-preview__frame-container"
+    >
+      <iframe
+        className="editor-block-preview__frame"
+        src="https://wordpress.org/?p=1"
+        style={
+          Object {
+            "height": "800px",
+            "width": "1200px",
+          }
+        }
+        title="Responsive preview frame"
+      />
+    </div>
+  </WithInstanceId(Modal)>
+</Fragment>
 `;

--- a/packages/editor/src/components/post-preview-button/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/post-preview-button/test/__snapshots__/index.js.snap
@@ -9,20 +9,20 @@ exports[`PostPreviewButton render() should render overlay when state is open 1`]
     onClick={[Function]}
   >
     Preview
-    <WithSelect(WithDispatch(DotTip))
-      tipId="core/editor.preview"
+    <span
+      className="screen-reader-text"
     >
-      Click “Preview” to load a preview of this page, so you can make sure you’re happy with your blocks.
-    </WithSelect(WithDispatch(DotTip))>
+      (opens in a new tab)
+    </span>
   </ForwardRef(Button)>
   <WithInstanceId(Modal)
-    className="editor-block-preview"
+    className="editor-post-preview-button__preview-modal"
     onRequestClose={[Function]}
     shouldCloseOnClickOutside={false}
-    title="Preview"
+    title="Preview dialog"
   >
     <div
-      className="editor-block-preview__controls"
+      className="editor-post-preview__controls"
     >
       <ForwardRef(IconButton)
         icon={
@@ -82,7 +82,7 @@ exports[`PostPreviewButton render() should render overlay when state is open 1`]
         onClick={[Function]}
       />
       <ForwardRef(Button)
-        className="editor-block-preview__new-tab"
+        className="editor-post-preview__new-tab"
         href="https://wordpress.org/?p=1"
         isLarge={true}
         onClick={[Function]}
@@ -92,10 +92,10 @@ exports[`PostPreviewButton render() should render overlay when state is open 1`]
       </ForwardRef(Button)>
     </div>
     <div
-      className="editor-block-preview__frame-container"
+      className="editor-post-preview__frame-container"
     >
       <iframe
-        className="editor-block-preview__frame"
+        className="editor-post-preview__frame"
         src="https://wordpress.org/?p=1"
         style={
           Object {

--- a/packages/editor/src/components/post-preview-button/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/post-preview-button/test/__snapshots__/index.js.snap
@@ -19,7 +19,7 @@ exports[`PostPreviewButton render() should render overlay when state is open 1`]
     className="editor-post-preview-button__preview-modal"
     onRequestClose={[Function]}
     shouldCloseOnClickOutside={false}
-    title="Preview dialog"
+    title="Preview"
   >
     <div
       className="editor-post-preview__controls"
@@ -92,7 +92,10 @@ exports[`PostPreviewButton render() should render overlay when state is open 1`]
       </ForwardRef(Button)>
     </div>
     <div
+      aria-label="Preview"
       className="editor-post-preview__frame-container"
+      role="region"
+      tabIndex="0"
     >
       <iframe
         className="editor-post-preview__frame"
@@ -103,7 +106,7 @@ exports[`PostPreviewButton render() should render overlay when state is open 1`]
             "width": "1200px",
           }
         }
-        title="Responsive preview frame"
+        title="Responsive preview"
       />
     </div>
   </WithInstanceId(Modal)>

--- a/packages/editor/src/components/post-preview-button/test/index.js
+++ b/packages/editor/src/components/post-preview-button/test/index.js
@@ -71,7 +71,7 @@ describe( 'PostPreviewButton', () => {
 		} );
 	} );
 
-	describe( 'openPreviewOverlay()', () => {
+	describe( 'openPreviewModal()', () => {
 		it( 'behaves like a regular link if not autosaveable', () => {
 			const autosave = jest.fn();
 
@@ -82,7 +82,7 @@ describe( 'PostPreviewButton', () => {
 				/>
 			);
 
-			wrapper.instance().openPreviewOverlay();
+			wrapper.instance().openPreviewModal();
 
 			expect( autosave ).not.toHaveBeenCalled();
 		} );
@@ -98,7 +98,7 @@ describe( 'PostPreviewButton', () => {
 				/>
 			);
 
-			wrapper.instance().openPreviewOverlay();
+			wrapper.instance().openPreviewModal();
 
 			expect( autosave ).toHaveBeenCalled();
 		} );
@@ -165,7 +165,7 @@ describe( 'PostPreviewButton', () => {
 				/>
 			).setState( { isPreviewOpen: true } );
 
-			const frameSrc = wrapper.find( '.editor-block-preview__frame' ).prop( 'src' );
+			const frameSrc = wrapper.find( '.editor-post-preview__frame' ).prop( 'src' );
 			expect( frameSrc ).toEqual( previewLink );
 		} );
 
@@ -178,7 +178,7 @@ describe( 'PostPreviewButton', () => {
 				/>
 			).setState( { isPreviewOpen: true } );
 
-			const frameSrc = wrapper.find( '.editor-block-preview__frame' ).prop( 'src' );
+			const frameSrc = wrapper.find( '.editor-post-preview__frame' ).prop( 'src' );
 			expect( frameSrc ).toEqual( currentPostLink );
 		} );
 

--- a/packages/editor/src/style.scss
+++ b/packages/editor/src/style.scss
@@ -9,6 +9,7 @@
 @import "./components/post-last-revision/style.scss";
 @import "./components/post-locked-modal/style.scss";
 @import "./components/post-permalink/style.scss";
+@import "./components/post-preview-button/style.scss";
 @import "./components/post-publish-panel/style.scss";
 @import "./components/post-saved-state/style.scss";
 @import "./components/post-taxonomies/style.scss";


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

Addresses #13203 

* Render post preview inside a modal with a resizable iframe.
* Add toggles to change preview size between desktop, tablet and mobile.
* Add link to preview in a new tab (current behaviour).

I removed the interstitial screen for now because the autosave now happens when the overlay is opened so opening new tab is quicker.

Further iterations/ things to consider:

* It would be nice if initial preview size matched the size of user's device, so if post was being edited on a tablet preview would open up in tablet mode. Make sure this works when users are zoomed in on desktop.

* Figure out what the best experience is to show previews for devices larger than what the user is on. If viewing on a phone, should desktop preview be really zoomed out and tiny, or have a horizontal scroll?

* Should preview sizes be customisable by themes, or should we make a call on what the most standard device sizes are?

* Is interstitial markup still necessary now we're rendering preview in a modal?

* Anything else I've forgotten?

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Tested in multiple browsers, keyboard navigation checked and also checked with VoiceOver and NVDA.

Updated unit and e2e tests. 

## Screenshots <!-- if applicable -->
<img width="1592" alt="Screen Shot 2019-12-04 at 5 27 52 pm" src="https://user-images.githubusercontent.com/8096000/70118138-72dcf480-16bb-11ea-81b5-295636b9feb5.png">
<img width="1583" alt="Screen Shot 2019-12-04 at 5 28 02 pm" src="https://user-images.githubusercontent.com/8096000/70118159-7d978980-16bb-11ea-9732-87dce33ce246.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
