### PR TITLE
Try - add close button visible label

### DIFF
--- a/packages/edit-post/src/components/header/fullscreen-mode-close/index.js
+++ b/packages/edit-post/src/components/header/fullscreen-mode-close/index.js
@@ -29,7 +29,9 @@ function FullscreenModeClose( { isActive, postType } ) {
 				href={ addQueryArgs( 'edit.php', { post_type: postType.slug } ) }
 				label={ label }
 			>
-				{ label }
+				<div className="edit-post-fullscreen-mode-close__label">
+					{ label }
+				</div>
 			</IconButton>
 		</Toolbar>
 	);

--- a/packages/edit-post/src/components/header/fullscreen-mode-close/index.js
+++ b/packages/edit-post/src/components/header/fullscreen-mode-close/index.js
@@ -16,17 +16,21 @@ function FullscreenModeClose( { isActive, postType } ) {
 		return null;
 	}
 
+	const label = get(
+		postType,
+		[ 'labels', 'view_items' ],
+		__( 'Back' ),
+	);
+
 	return (
 		<Toolbar className="edit-post-fullscreen-mode-close__toolbar">
 			<IconButton
 				icon="arrow-left-alt2"
 				href={ addQueryArgs( 'edit.php', { post_type: postType.slug } ) }
-				label={ get(
-					postType,
-					[ 'labels', 'view_items' ],
-					__( 'Back' )
-				) }
-			/>
+				label={ label }
+			>
+				{ label }
+			</IconButton>
 		</Toolbar>
 	);
 }

--- a/packages/edit-post/src/components/header/fullscreen-mode-close/style.scss
+++ b/packages/edit-post/src/components/header/fullscreen-mode-close/style.scss
@@ -11,4 +11,8 @@
 		margin: -9px 10px -8px -10px;
 		padding: 9px 10px;
 	}
+
+	.edit-post-fullscreen-mode-close__label {
+		padding-right: 7px;
+	}
 }


### PR DESCRIPTION
## Edit 

This PR has been edited to reduce much of the functionality shown/requested below, but I am leaving the original PR description for transparency.  A [comment below](https://github.com/WordPress/gutenberg/pull/18387#issuecomment-557683869)  describes the limited changes now being requested.  TLDR - Adds the current "label" attribute of the close button as a visible child.



-----------original PR description below----------
## Description
<!-- Please describe what you have changed or added -->
I have added two new preferences to the `core/edit-post` store to be used by the `FullscreenModeClose` component.  Additionally this component has been updated to allow some conditional rendering for these preferences.  These new preferences are:

1 - `alwaysShowCloseButton` - (default: false) when turned on the close button will be rendered in non-fullscreen mode and at all screen widths.  In working with dotcom Full Site Editing, we found it would be useful to allow access to this close button from the windowed wp-admin mode.

2 - `showCloseButtonLabel` - (default: false) when turned on the label will be rendered alongside the chevron icon.  In new user testing sessions it was found that the unlabeled chevron did not meaningfully convey where that button would lead, causing users to fumble for a while in fullscreen mode not being sure of how to go back to the page selection screen.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. Run this PR.
2. Navigate to open the page or posts editor.
3. Verify initial behavior is unchanged, that close button:
     a.  is visible in the fullscreen editor.
     b.  is not visible in windowed editor.
     c.  does not render a label.
     d.  is not rendered below medium screen width ( 782px ).
4.  In the browser console, run `wp.data.dispatch( 'core/edit-post' ).toggleFeature( 'alwaysShowCloseButton' )`
5.  Verify that the close button now renders when:
     a.  editor is in windowed mode.
     b.  screen width is below medium width ( 782px ).
6.  In the browser console, run `wp.data.dispatch( 'core/edit-post' ).toggleFeature( 'showCloseButtonLabel' )`
7.  Verify that the close button now displays its label to the right of the chevron icon.
## Screenshots <!-- if applicable -->
**Initial Windowed View**
![Screen Shot 2019-11-07 at 6 08 12 PM](https://user-images.githubusercontent.com/28742426/68435764-1c4acc00-018a-11ea-99a3-47617514e33c.png)

**alwaysShow toggled on in windowed mode**
![Screen Shot 2019-11-07 at 6 08 31 PM](https://user-images.githubusercontent.com/28742426/68435783-2967bb00-018a-11ea-81cb-9fe218c2df12.png)

**alwaysShow toggled on in fullscren mobile width**
![Screen Shot 2019-11-07 at 6 09 19 PM](https://user-images.githubusercontent.com/28742426/68435831-54520f00-018a-11ea-976d-e5d86041b182.png)

**showLabel toggled on in windowed mode**
![Screen Shot 2019-11-07 at 6 08 45 PM](https://user-images.githubusercontent.com/28742426/68435847-5fa53a80-018a-11ea-87e7-b3fe11d9e0a1.png)


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
