### PR TITLE
Add toggle control component to Storybook

### DIFF
--- a/packages/components/src/toggle-control/stories/index.js
+++ b/packages/components/src/toggle-control/stories/index.js
@@ -1,0 +1,52 @@
+/**
+ * External dependencies
+ */
+import { text } from '@storybook/addon-knobs';
+
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import ToggleControl from '../';
+
+export default { title: 'ToggleControl', component: ToggleControl };
+
+const ToggleControlWithState = ( { helpTextChecked, helpTextUnchecked, ...props } ) => {
+	const [ hasFixedBackground, setHasFixedBackground ] = useState( true );
+	return (
+		<ToggleControl
+			{ ...props }
+			help={ hasFixedBackground ? helpTextChecked : helpTextUnchecked }
+			checked={ hasFixedBackground }
+			onChange={ setHasFixedBackground }
+		/>
+	);
+};
+
+export const _default = () => {
+	const label = text( 'Label', 'Does this have a fixed background?' );
+
+	return (
+		<ToggleControlWithState
+			label={ label }
+		/>
+	);
+};
+
+export const withHelpText = () => {
+	const label = text( 'Label', 'Does this have a fixed background?' );
+	const helpTextChecked = text( 'Help When Checked', 'Has fixed background.' );
+	const helpTextUnchecked = text( 'Help When Unchecked', 'No fixed background.' );
+
+	return (
+		<ToggleControlWithState
+			label={ label }
+			helpTextChecked={ helpTextChecked }
+			helpTextUnchecked={ helpTextUnchecked }
+		/>
+	);
+};


### PR DESCRIPTION
## Description
Adds the ToggleControl component to Storybook as part of #17973.

I added two stories, one with just the toggle control and one with variable help text based on the checked status.

## How has this been tested?
run `npm run design-system:dev`
Browse to the local Storybook instance
See toggle control is rendered when selected in the left-hand navigation

## Types of changes
New feature (non-breaking change which adds functionality)