### PR TITLE
Blocks: Use selectors to fetch details about for patterns and styles …

### DIFF
--- a/docs/designers-developers/developers/data/data-core-blocks.md
+++ b/docs/designers-developers/developers/data/data-core-blocks.md
@@ -9,11 +9,13 @@ Namespace: `core/blocks`.
 <a name="getBlockStyles" href="#getBlockStyles">#</a> **getBlockStyles**
 
 Returns block styles by block name.
+It combines styles registered with the block together with
+the block styles registered separately.
 
 _Parameters_
 
 -   _state_ `Object`: Data state.
--   _name_ `string`: Block type name.
+-   _blockName_ `string`: Block type name.
 
 _Returns_
 

--- a/packages/blocks/src/store/reducer.js
+++ b/packages/blocks/src/store/reducer.js
@@ -8,7 +8,6 @@ import {
 	isEmpty,
 	keyBy,
 	map,
-	mapValues,
 	omit,
 	uniqBy,
 } from 'lodash';
@@ -66,16 +65,6 @@ export function blockTypes( state = {}, action ) {
  */
 export function blockStyles( state = {}, action ) {
 	switch ( action.type ) {
-		case 'ADD_BLOCK_TYPES':
-			return {
-				...state,
-				...mapValues( keyBy( action.blockTypes, 'name' ), ( blockType ) => {
-					return uniqBy( [
-						...get( blockType, [ 'styles' ], [] ),
-						...get( state, [ blockType.name ], [] ),
-					], ( style ) => style.name );
-				} ),
-			};
 		case 'ADD_BLOCK_STYLES':
 			return {
 				...state,
@@ -107,16 +96,6 @@ export function blockStyles( state = {}, action ) {
  */
 export function blockPatterns( state = {}, action ) {
 	switch ( action.type ) {
-		case 'ADD_BLOCK_TYPES':
-			return {
-				...state,
-				...mapValues( keyBy( action.blockTypes, 'name' ), ( blockType ) => {
-					return uniqBy( [
-						...get( blockType, [ 'patterns' ], [] ),
-						...get( state, [ blockType.name ], [] ),
-					], ( style ) => style.name );
-				} ),
-			};
 		case 'ADD_BLOCK_PATTERNS':
 			return {
 				...state,

--- a/packages/blocks/src/store/selectors.js
+++ b/packages/blocks/src/store/selectors.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import createSelector from 'rememo';
-import { filter, get, includes, map, some, flow, deburr } from 'lodash';
+import { compact, concat, filter, get, includes, map, some, flow, deburr } from 'lodash';
 
 /**
  * Given a block name or block type object, returns the corresponding
@@ -47,27 +47,53 @@ export function getBlockType( state, name ) {
 
 /**
  * Returns block styles by block name.
+ * It combines styles registered with the block together with
+ * the block styles registered separately.
  *
  * @param {Object} state Data state.
- * @param {string} name  Block type name.
+ * @param {string} blockName  Block type name.
  *
  * @return {Array?} Block Styles.
  */
-export function getBlockStyles( state, name ) {
-	return state.blockStyles[ name ];
-}
+export const getBlockStyles = createSelector(
+	( state, blockName ) => {
+		const blockType = getBlockType( state, blockName );
+
+		if ( ! blockType ) {
+			return;
+		}
+
+		return compact(
+			concat( blockType.styles, state.blockStyles[ blockName ] )
+		);
+	},
+	( state ) => [ state.blockTypes, state.blockStyles ]
+);
 
 /**
  * Returns block patterns by block name.
+ * It combines patterns registered with the block together with
+ * the block patterns registered separately.
  *
  * @param {Object} state      Data state.
  * @param {string} blockName  Block type name.
  *
  * @return {(WPBlockPattern[]|void)} Block patterns.
  */
-export function __experimentalGetBlockPatterns( state, blockName ) {
-	return state.blockPatterns[ blockName ];
-}
+export const __experimentalGetBlockPatterns = createSelector(
+	( state, blockName ) => {
+		const blockType = getBlockType( state, blockName );
+
+		if ( ! blockType ) {
+			return;
+		}
+
+		return compact(
+			concat( blockType.patterns, state.blockPatterns[ blockName ] )
+		);
+	},
+	( state ) => [ state.blockTypes, state.blockPatterns ]
+);
 
 /**
  * Returns all the available categories.

--- a/packages/blocks/src/store/test/reducer.js
+++ b/packages/blocks/src/store/test/reducer.js
@@ -8,7 +8,6 @@ import deepFreeze from 'deep-freeze';
  */
 import {
 	__experimentalAddBlockPatterns,
-	addBlockTypes,
 	__experimentalRemoveBlockPatterns,
 } from '../actions';
 import {
@@ -95,31 +94,6 @@ describe( 'blockStyles', () => {
 		} );
 	} );
 
-	it( 'should add block styles when adding a block', () => {
-		const original = deepFreeze( {
-			'core/image': [
-				{ name: 'fancy' },
-			],
-		} );
-
-		const state = blockStyles( original, {
-			type: 'ADD_BLOCK_TYPES',
-			blockTypes: [ {
-				name: 'core/image',
-				styles: [
-					{ name: 'original' },
-				],
-			} ],
-		} );
-
-		expect( state ).toEqual( {
-			'core/image': [
-				{ name: 'original' },
-				{ name: 'fancy' },
-			],
-		} );
-	} );
-
 	it( 'should remove block styles', () => {
 		const original = deepFreeze( {
 			'core/image': [
@@ -163,7 +137,7 @@ describe( 'blockPatterns', () => {
 		expect( state ).toEqual( {} );
 	} );
 
-	it( 'should add a new block pattern when no pattern register', () => {
+	it( 'should add a new block pattern when no pattern registered', () => {
 		const initialState = deepFreeze( {} );
 
 		const state = blockPatterns(
@@ -188,31 +162,6 @@ describe( 'blockPatterns', () => {
 		const state = blockPatterns(
 			initialState,
 			__experimentalAddBlockPatterns( blockName, secondBlockPattern ),
-		);
-
-		expect( state ).toEqual( {
-			[ blockName ]: [
-				blockPattern,
-				secondBlockPattern,
-			],
-		} );
-	} );
-
-	it( 'should prepend block patterns added when adding a block', () => {
-		const initialState = deepFreeze( {
-			[ blockName ]: [
-				secondBlockPattern,
-			],
-		} );
-
-		const state = blockPatterns(
-			initialState,
-			addBlockTypes( {
-				name: blockName,
-				patterns: [
-					blockPattern,
-				],
-			} )
 		);
 
 		expect( state ).toEqual( {

--- a/packages/blocks/src/store/test/selectors.js
+++ b/packages/blocks/src/store/test/selectors.js
@@ -1,13 +1,204 @@
 /**
+ * External dependencies
+ */
+import deepFreeze from 'deep-freeze';
+
+/**
  * Internal dependencies
  */
 import {
+	getBlockStyles,
+	__experimentalGetBlockPatterns,
 	getChildBlockNames,
 	isMatchingSearchTerm,
 	getGroupingBlockName,
 } from '../selectors';
 
 describe( 'selectors', () => {
+	const blockName = 'block/name';
+
+	describe( 'getBlockStyles', () => {
+		const blockStyleName = 'style-name';
+		const blockStyle = {
+			name: blockStyleName,
+			label: 'My Style',
+		};
+
+		const secondBlockStyleName = 'style-name';
+		const secondBlockStyle = {
+			name: secondBlockStyleName,
+			label: 'My Second Style',
+		};
+
+		it( 'should return undefined if the state is empty', () => {
+			const state = deepFreeze( {
+				blockTypes: {},
+				blockStyles: {},
+			} );
+
+			expect( getBlockStyles( state ) ).toBeUndefined();
+		} );
+
+		it( 'should return undefined for a given block type with styles when it is not registered', () => {
+			const state = deepFreeze( {
+				blockTypes: {},
+				blockStyles: {
+					[ blockName ]: [
+						blockStyle,
+						secondBlockStyle,
+					],
+				},
+			} );
+
+			expect( getBlockStyles( state, blockName ) ).toBeUndefined();
+		} );
+
+		it( 'should return registered block styles for a given block type which is registered', () => {
+			const state = deepFreeze( {
+				blockTypes: {
+					[ blockName ]: {
+						name: blockName,
+					},
+				},
+				blockStyles: {
+					[ blockName ]: [
+						blockStyle,
+						secondBlockStyle,
+					],
+				},
+			} );
+
+			expect( getBlockStyles( state, blockName ) ).toEqual(
+				[
+					blockStyle,
+					secondBlockStyle,
+				]
+			);
+		} );
+
+		it( 'should merge registered block styles for a given block type with its definition', () => {
+			const thirdBlockStyleName = 'style-name';
+			const thirdBlockStyle = {
+				name: thirdBlockStyleName,
+				label: 'My Third Style',
+			};
+
+			const state = deepFreeze( {
+				blockTypes: {
+					[ blockName ]: {
+						name: blockName,
+						styles: thirdBlockStyle,
+					},
+				},
+				blockStyles: {
+					[ blockName ]: [
+						blockStyle,
+						secondBlockStyle,
+					],
+				},
+			} );
+
+			expect( getBlockStyles( state, blockName ) ).toEqual(
+				[
+					thirdBlockStyle,
+					blockStyle,
+					secondBlockStyle,
+				]
+			);
+		} );
+	} );
+
+	describe( '__experimentalGetBlockPatterns', () => {
+		const blockPatternName = 'pattern-name';
+		const blockPattern = {
+			name: blockPatternName,
+			label: 'My pattern',
+		};
+
+		const secondBlockPatternName = 'second-pattern-name';
+		const secondBlockPattern = {
+			name: secondBlockPatternName,
+			label: 'My Second Pattern',
+		};
+
+		it( 'should return undefined if the state is empty', () => {
+			const state = deepFreeze( {
+				blockTypes: {},
+				blockPatterns: {},
+			} );
+
+			expect( __experimentalGetBlockPatterns( state ) ).toBeUndefined();
+		} );
+
+		it( 'should return undefined for a given block type with patterns when it is not registered', () => {
+			const state = deepFreeze( {
+				blockTypes: {},
+				blockPatterns: {
+					[ blockName ]: [
+						blockPattern,
+						secondBlockPattern,
+					],
+				},
+			} );
+
+			expect( __experimentalGetBlockPatterns( state, blockName ) ).toBeUndefined();
+		} );
+
+		it( 'should return registered block patterns for a given block type which is registered', () => {
+			const state = deepFreeze( {
+				blockTypes: {
+					[ blockName ]: {
+						name: blockName,
+					},
+				},
+				blockPatterns: {
+					[ blockName ]: [
+						blockPattern,
+						secondBlockPattern,
+					],
+				},
+			} );
+
+			expect( __experimentalGetBlockPatterns( state, blockName ) ).toEqual(
+				[
+					blockPattern,
+					secondBlockPattern,
+				]
+			);
+		} );
+
+		it( 'should merge registered block patterns for a given block type with its definition', () => {
+			const thirdBlockPatternName = 'second-pattern-name';
+			const thirdBlockPattern = {
+				name: thirdBlockPatternName,
+				label: 'My Third Pattern',
+			};
+
+			const state = deepFreeze( {
+				blockTypes: {
+					[ blockName ]: {
+						name: blockName,
+						patterns: thirdBlockPattern,
+					},
+				},
+				blockPatterns: {
+					[ blockName ]: [
+						blockPattern,
+						secondBlockPattern,
+					],
+				},
+			} );
+
+			expect( __experimentalGetBlockPatterns( state, blockName ) ).toEqual(
+				[
+					thirdBlockPattern,
+					blockPattern,
+					secondBlockPattern,
+				]
+			);
+		} );
+	} );
+
 	describe( 'getChildBlockNames', () => {
 		it( 'should return an empty array if state is empty', () => {
 			const state = {};


### PR DESCRIPTION
…from block types

## Description
<!-- Please describe what you have changed or added -->

Based on the comment from @aduth in https://github.com/WordPress/gutenberg/pull/18270#discussion_r343901794:

> Since we're inheriting the logic, I'm not overly concerned with addressing it here, but a point for both this and the `blockStyles` upon which it's based:
> 
> - Do we really need to track a value for each registered block type? Can't this be something where we just manage the normalization to an empty array from the selector? Seems like it may make the implementation a little simpler, and avoid the (albeit minimal) memory usage involved with tracking a bunch of key/values for blocks without patterns.

This should also fix the copy and paste issues raised by @mcsf in https://github.com/WordPress/gutenberg/pull/18270#discussion_r344191106:

> I think this should read `( pattern ) => pattern.name` :)

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

`npm run test-unit`

I also tested manually in the browser by executing the following code on JS console:

```js
wp.blocks.registerBlockStyle( 'core/quote', { name: 'test', label: 'Test' } );
```

and checked that this new style got properly registered for the Quote block:

![Screen Shot 2019-11-26 at 14 27 49](https://user-images.githubusercontent.com/699132/69637454-f6ae3580-1058-11ea-923b-992fd3e8d89f.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Refactoring.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
