### PR TITLE
Navigation Block: vertically align items.

### DIFF
--- a/packages/block-library/src/navigation-menu/editor.scss
+++ b/packages/block-library/src/navigation-menu/editor.scss
@@ -58,6 +58,7 @@
 .wp-block-navigation-menu {
 	display: flex;
 	white-space: nowrap;
+	align-items: center;
 }
 
 .wp-block-navigation-menu__inserter-content {


### PR DESCRIPTION
This ensures items are properly aligned — depending on the font size the inserter can be misplaced.

Before:
![image](https://user-images.githubusercontent.com/548849/68477239-38537980-022d-11ea-8093-acf5e56010a3.png)

After:
![image](https://user-images.githubusercontent.com/548849/68477249-3f7a8780-022d-11ea-9407-2a3a90c48707.png)

Might still need some work when selecting an item.