### PR TITLE
Docs: Snackbar `actions` remove className

### DIFF
--- a/packages/components/src/snackbar/README.md
+++ b/packages/components/src/snackbar/README.md
@@ -41,7 +41,7 @@ const MySnackbarNotice = () => (
 The following props are used to control the display of the component.
 
 * `onRemove`: function called when dismissing the notice.
-* `actions`: (array) an array of action objects. Each member object should contain a `label` and either a `url` link string or `onClick` callback function. A `className` property can be used to add custom classes to the button styles.
+* `actions`: (array) an array of action objects. Each member object should contain a `label` and either a `url` link string or `onClick` callback function.
 
 ## Related components
 


### PR DESCRIPTION
## Description
The className for the `actions` prop in the Snackbar component was removed in #16095, so we should update the Readme.