### PR TITLE
Storybook: Add TabPanel

### DIFF
--- a/packages/components/src/tab-panel/stories/index.js
+++ b/packages/components/src/tab-panel/stories/index.js
@@ -1,0 +1,34 @@
+/**
+ * External dependencies
+ */
+import { text } from '@storybook/addon-knobs';
+
+/**
+ * Internal dependencies
+ */
+import TabPanel from '../';
+
+export default { title: 'TabPanel', component: TabPanel };
+
+export const _default = () => {
+	return (
+		<TabPanel className="my-tab-panel"
+			activeClass="active-tab"
+			tabs={ [
+				{
+					name: 'tab1',
+					title: text( 'Tab 1 title', 'Tab 1' ),
+					className: 'tab-one',
+				},
+				{
+					name: 'tab2',
+					title: text( 'Tab 2 title', 'Tab 2' ),
+					className: 'tab-two',
+				},
+			] }>
+			{
+				( tab ) => <p>Selected tab: { tab.title }</p>
+			}
+		</TabPanel>
+	);
+};


### PR DESCRIPTION
## Description
This PR adds a story for the TabPanel component as part of #17973.

## How has this been tested?
run `npm run design-system:dev`
Browse to the local Storybook instance
See TabPanel is rendered when selected in the left-hand navigation