### PR TITLE
Storybook: Snackbar - Add Actions prop story

### DIFF
--- a/packages/components/src/snackbar/stories/index.js
+++ b/packages/components/src/snackbar/stories/index.js
@@ -19,3 +19,14 @@ export const _default = () => {
 		</Snackbar>
 	);
 };
+
+export const withActions = () => {
+	const content = text( 'Content', 'Use Snackbars with an action link to an external page.' );
+	const actions = [ { url: 'https://wordpress.org', label: 'Open WP.org' } ];
+
+	return (
+		<Snackbar actions={ actions }>
+			{ content }
+		</Snackbar>
+	);
+};

--- a/packages/components/src/snackbar/stories/index.js
+++ b/packages/components/src/snackbar/stories/index.js
@@ -22,7 +22,7 @@ export const _default = () => {
 
 export const withActions = () => {
 	const content = text( 'Content', 'Use Snackbars with an action link to an external page.' );
-	const actions = [ { url: text( 'URL', 'https://wordpress.org' ), label: text( 'label', 'Open WP.org' ) } ];
+	const actions = [ { label: text( 'Label', 'Open WP.org' ), url: text( 'URL', 'https://wordpress.org' ) } ];
 
 	return (
 		<Snackbar actions={ actions }>

--- a/packages/components/src/snackbar/stories/index.js
+++ b/packages/components/src/snackbar/stories/index.js
@@ -22,7 +22,7 @@ export const _default = () => {
 
 export const withActions = () => {
 	const content = text( 'Content', 'Use Snackbars with an action link to an external page.' );
-	const actions = [ { url: 'https://wordpress.org', label: 'Open WP.org' } ];
+	const actions = [ { url: text( 'URL', 'https://wordpress.org' ), label: text( 'label', 'Open WP.org' ) } ];
 
 	return (
 		<Snackbar actions={ actions }>


### PR DESCRIPTION
## Description
Add the `With Actions` story to the Snackbar.

## How has this been tested?
run `npm run design-system:dev`
Browse to the local Storybook instance
See Snackbar `With Actions` story is rendered when selected in the left-hand navigation

## Types of changes
New feature (non-breaking change which adds functionality)