### PR TITLE
LinkControl: Open popup with cmd+k shortcut

### DIFF
--- a/packages/block-library/src/navigation-menu-item/edit.js
+++ b/packages/block-library/src/navigation-menu-item/edit.js
@@ -11,6 +11,7 @@ import { createBlock } from '@wordpress/blocks';
 import { withDispatch, withSelect } from '@wordpress/data';
 import {
 	ExternalLink,
+	KeyboardShortcuts,
 	PanelBody,
 	Path,
 	SVG,
@@ -27,6 +28,8 @@ import {
 	DOWN,
 	BACKSPACE,
 	ENTER,
+	rawShortcut,
+	displayShortcut,
 } from '@wordpress/keycodes';
 import { __ } from '@wordpress/i18n';
 import {
@@ -99,6 +102,17 @@ function NavigationMenuItemEdit( {
 	}, [ isSelected ] );
 
 	/**
+	 * Opens the LinkControl popup
+	 */
+	const openLinkControl = () => {
+		if ( isLinkOpen ) {
+			return;
+		}
+
+		setIsLinkOpen( ! isLinkOpen );
+	};
+
+	/**
 	 * `onKeyDown` LinkControl handler.
 	 * It takes over to stop the event propagation to make the
 	 * navigation work, avoiding undesired behaviors.
@@ -122,16 +136,18 @@ function NavigationMenuItemEdit( {
 		<Fragment>
 			<BlockControls>
 				<Toolbar>
+					<KeyboardShortcuts
+						bindGlobal
+						shortcuts={ {
+							[ rawShortcut.primary( 'k' ) ]: openLinkControl,
+						} }
+					/>
 					<ToolbarButton
 						name="link"
 						icon="admin-links"
 						title={ __( 'Link' ) }
-						onClick={ () => {
-							if ( isLinkOpen ) {
-								return;
-							}
-							setIsLinkOpen( ! isLinkOpen );
-						} }
+						shortcut={ displayShortcut.primary( 'k' ) }
+						onClick={ openLinkControl }
 					/>
 					<ToolbarButton
 						name="submenu"


### PR DESCRIPTION
## Description
Added the `cmd/ctrl+k` shortcut handling to the LinkControl popup. It should work the same way as it has in the RichText block. 

## Screenshots <!-- if applicable -->

![](https://cld.wthms.co/WDM8VR+)

## Types of changes
- New feature (non-breaking change which adds functionality)

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.

## Closes:
- https://github.com/WordPress/gutenberg/issues/18306