### PR TITLE
Try/navigation menu group

### DIFF
--- a/packages/block-library/src/navigation-menu/block-colors-selector.js
+++ b/packages/block-library/src/navigation-menu/block-colors-selector.js
@@ -10,7 +10,7 @@ import { noop } from 'lodash';
 import { IconButton, Dropdown, Toolbar, SVG, Path } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { DOWN } from '@wordpress/keycodes';
-import { ColorPaletteControl, ContrastChecker } from '@wordpress/block-editor';
+import { ColorPaletteControl } from '@wordpress/block-editor';
 
 const ColorSelectorSVGIcon = () => (
 	<SVG xmlns="https://www.w3.org/2000/svg" viewBox="0 0 20 20">
@@ -24,21 +24,15 @@ const ColorSelectorSVGIcon = () => (
  * @param {Object} colorControlProps colorControl properties.
  * @return {*} React Icon component.
  */
-const ColorSelectorIcon = ( { backgroundColor, textColor, backgroundColorValue, textColorValue } ) => {
+const ColorSelectorIcon = ( { textColor, textColorValue } ) => {
 	const iconStyle = {};
-
-	if ( backgroundColorValue ) {
-		iconStyle.backgroundColor = backgroundColorValue;
-	}
 
 	if ( textColorValue ) {
 		iconStyle.color = textColorValue;
 	}
 
 	const iconClasses = classnames( 'block-library-colors-selector__state-selection', {
-		'has-background-color': backgroundColor && backgroundColor.color,
-		'has-text-color': backgroundColor && backgroundColor.color,
-		[ backgroundColor.class ]: backgroundColor && backgroundColor.class,
+		'has-text-color': textColor && textColor.color,
 		[ textColor.class ]: textColor && textColor.class,
 	} );
 
@@ -57,7 +51,7 @@ const ColorSelectorIcon = ( { backgroundColor, textColor, backgroundColorValue, 
  * @param {Object} colorControlProps colorControl properties.
  * @return {*} React toggle button component.
  */
-const renderToggleComponent = ( { backgroundColor, textColor, backgroundColorValue, textColorValue } ) => ( { onToggle, isOpen } ) => {
+const renderToggleComponent = ( { textColor, textColorValue } ) => ( { onToggle, isOpen } ) => {
 	const openOnArrowDown = ( event ) => {
 		if ( ! isOpen && event.keyCode === DOWN ) {
 			event.preventDefault();
@@ -74,9 +68,7 @@ const renderToggleComponent = ( { backgroundColor, textColor, backgroundColorVal
 				onClick={ onToggle }
 				onKeyDown={ openOnArrowDown }
 				icon={ <ColorSelectorIcon
-					backgroundColor={ backgroundColor }
 					textColor={ textColor }
-					backgroundColorValue={ backgroundColorValue }
 					textColorValue={ textColorValue }
 				/> }
 			/>
@@ -84,19 +76,11 @@ const renderToggleComponent = ( { backgroundColor, textColor, backgroundColorVal
 	);
 };
 
-const renderContent = ( { backgroundColor, textColor, onColorChange = noop } ) => ( () => {
+const renderContent = ( { textColor, onColorChange = noop } ) => ( () => {
 	const setColor = ( attr ) => ( value ) => onColorChange( { attr, value } );
 
 	return (
 		<>
-			<div className="color-palette-controller-container">
-				<ColorPaletteControl
-					value={ backgroundColor.color }
-					onChange={ setColor( 'backgroundColor' ) }
-					label={ __( 'Background Color' ) }
-				/>
-			</div>
-
 			<div className="color-palette-controller-container">
 				<ColorPaletteControl
 					value={ textColor.color }
@@ -104,12 +88,6 @@ const renderContent = ( { backgroundColor, textColor, onColorChange = noop } ) =
 					label={ __( 'Text Color' ) }
 				/>
 			</div>
-
-			<ContrastChecker
-				textColor={ textColor.color }
-				backgroundColor={ backgroundColor.color }
-				isLargeText={ false }
-			/>
 		</>
 	);
 } );

--- a/packages/block-library/src/navigation-menu/edit.js
+++ b/packages/block-library/src/navigation-menu/edit.js
@@ -45,9 +45,7 @@ function NavigationMenu( {
 	pages,
 	isRequestingPages,
 	hasResolvedPages,
-	backgroundColor,
 	textColor,
-	setBackgroundColor,
 	setTextColor,
 	setAttributes,
 	hasExistingNavItems,
@@ -161,7 +159,6 @@ function NavigationMenu( {
 			color: textColor.color,
 			borderColor: textColor.color,
 		} ),
-		...( backgroundColor && { backgroundColor: backgroundColor.color } ),
 	};
 
 	// Build ClassNames
@@ -224,7 +221,7 @@ function NavigationMenu( {
 }
 
 export default compose( [
-	withColors( { backgroundColor: 'background-color', textColor: 'color' } ),
+	withColors( { textColor: 'color' } ),
 	withSelect( ( select, { clientId } ) => {
 		const innerBlocks = select( 'core/block-editor' ).getBlocks( clientId );
 		const hasExistingNavItems = !! innerBlocks.length;

--- a/packages/block-library/src/navigation-menu/edit.js
+++ b/packages/block-library/src/navigation-menu/edit.js
@@ -168,8 +168,6 @@ function NavigationMenu( {
 	const navigationMenuClasses = classnames(
 		'wp-block-navigation-menu', {
 			'has-text-color': textColor.color,
-			'has-background-color': backgroundColor.color,
-			[ attributes.backgroundColorCSSClass ]: attributes && attributes.backgroundColorCSSClass,
 			[ attributes.textColorCSSClass ]: attributes && attributes.textColorCSSClass,
 		}
 	);

--- a/packages/block-library/src/navigation-menu/edit.js
+++ b/packages/block-library/src/navigation-menu/edit.js
@@ -93,30 +93,6 @@ function NavigationMenu( {
 	// HANDLERS
 	//
 
-	/**
-	 * Set the color type according to the given values.
-	 * It propagate the color values into the attributes object.
-	 * Both `backgroundColorValue` and `textColorValue` are
-	 * using the inline styles.
-	 *
-	 * @param {Object}  colorsData       Arguments passed by BlockColorsStyleSelector onColorChange.
-	 * @param {string}  colorsData.attr  Color attribute.
-	 * @param {boolean} colorsData.value Color attribute value.
-	 */
-	const setColorType = ( { attr, value } ) => {
-		switch ( attr ) {
-			case 'backgroundColor':
-				setBackgroundColor( value );
-				setAttributes( { backgroundColorValue: value } );
-				break;
-
-			case 'textColor':
-				setTextColor( value );
-				setAttributes( { textColorValue: value } );
-				break;
-		}
-	};
-
 	const handleCreateEmpty = () => {
 		const emptyNavItemBlock = createBlock( 'core/navigation-menu-item' );
 		updateNavItemBlocks( [ emptyNavItemBlock ] );
@@ -209,7 +185,10 @@ function NavigationMenu( {
 				<BlockColorsStyleSelector
 					textColor={ textColor }
 					textColorValue={ attributes.textColorValue }
-					onColorChange={ setColorType }
+					onColorChange={ ( { value } ) => {
+						setTextColor( value );
+						setAttributes( { textColorValue: value } );
+					} }
 				/>
 			</BlockControls>
 			{ navigatorModal }

--- a/packages/block-library/src/navigation-menu/edit.js
+++ b/packages/block-library/src/navigation-menu/edit.js
@@ -61,10 +61,9 @@ function NavigationMenu( {
 	useEffect( () => {
 		// Set/Unset colors CSS classes.
 		setAttributes( {
-			backgroundColorCSSClass: backgroundColor.class ? backgroundColor.class : null,
 			textColorCSSClass: textColor.class ? textColor.class : null,
 		} );
-	}, [ backgroundColor.class, textColor.class ] );
+	}, [ textColor.class ] );
 
 	// Builds menu items from default Pages
 	const defaultPagesMenuItems = useMemo(

--- a/packages/block-library/src/navigation-menu/edit.js
+++ b/packages/block-library/src/navigation-menu/edit.js
@@ -207,8 +207,8 @@ function NavigationMenu( {
 					{ navigatorToolbarButton }
 				</Toolbar>
 				<BlockColorsStyleSelector
-					backgroundColor={ backgroundColor }
 					textColor={ textColor }
+					textColorValue={ attributes.textColorValue }
 					onColorChange={ setColorType }
 				/>
 			</BlockControls>

--- a/packages/block-library/src/navigation-menu/editor.scss
+++ b/packages/block-library/src/navigation-menu/editor.scss
@@ -121,11 +121,6 @@ $colors-selector-size: 22px;
 		min-height: $colors-selector-size;
 		line-height: ($colors-selector-size - 2);
 		padding: 2px;
-
-		&:not(.has-background-color) {
-			background-image: linear-gradient(135deg, rgba(0, 0, 0, 0.08) 25%, transparent 25%, transparent 50%, rgba(0, 0, 0, 0.08) 50%, rgba(0, 0, 0, 0.08) 75%, transparent 75%, transparent 100%);
-			background-size: 12px 12px;
-		}
 	}
 }
 

--- a/packages/block-library/src/navigation-menu/index.php
+++ b/packages/block-library/src/navigation-menu/index.php
@@ -15,26 +15,9 @@
 function build_css_colors( $attributes ) {
 	// CSS classes.
 	$colors = array(
-		'bg_css_classes'     => '',
-		'bg_inline_styles'   => '',
 		'text_css_classes'   => '',
 		'text_inline_styles' => '',
 	);
-
-	// Background color.
-	// Background color - has text color.
-	if ( array_key_exists( 'backgroundColor', $attributes ) ) {
-		$colors['bg_css_classes'] .= ' has-background-color';
-	}
-
-	// Background color - add custom CSS class.
-	if ( array_key_exists( 'backgroundColorCSSClass', $attributes ) ) {
-		$colors['bg_css_classes'] .= " {$attributes['backgroundColorCSSClass']}";
-
-	} elseif ( array_key_exists( 'customBackgroundColor', $attributes ) ) {
-		// Background color - or add inline `background-color` style.
-		$colors['bg_inline_styles'] = ' style="background-color: ' . esc_attr( $attributes['customBackgroundColor'] ) . ';"';
-	}
 
 	// Text color.
 	// Text color - has text color.
@@ -50,7 +33,6 @@ function build_css_colors( $attributes ) {
 		$colors['text_inline_styles'] = ' style="color: ' . esc_attr( $attributes['customTextColor'] ) . ';"';
 	}
 
-	$colors['bg_css_classes']   = esc_attr( trim( $colors['bg_css_classes'] ) );
 	$colors['text_css_classes'] = esc_attr( trim( $colors['text_css_classes'] ) );
 
 	return $colors;
@@ -67,9 +49,6 @@ function build_css_colors( $attributes ) {
 function render_block_navigation_menu( $attributes, $content, $block ) {
 	// Inline computed colors.
 	$comp_inline_styles = '';
-	if ( array_key_exists( 'backgroundColorValue', $attributes ) ) {
-		$comp_inline_styles .= ' background-color: ' . esc_attr( $attributes['backgroundColorValue'] ) . ';';
-	}
 
 	if ( array_key_exists( 'textColorValue', $attributes ) ) {
 		$comp_inline_styles .= ' color: ' . esc_attr( $attributes['textColorValue'] ) . ';';
@@ -97,7 +76,7 @@ function build_navigation_menu_html( $block, $colors ) {
 	$html = '';
 	foreach ( (array) $block['innerBlocks'] as $key => $menu_item ) {
 
-		$html .= '<li class="wp-block-navigation-menu-item ' . $colors['bg_css_classes'] . '"' . $colors['bg_inline_styles'] . '>' .
+		$html .= '<li class="wp-block-navigation-menu-item">' .
 			'<a
 				class="wp-block-navigation-menu-item__link ' . $colors['text_css_classes'] . '"
 				' . $colors['text_inline_styles'];

--- a/packages/block-library/src/navigation-menu/index.php
+++ b/packages/block-library/src/navigation-menu/index.php
@@ -154,15 +154,7 @@ function register_block_core_navigation_menu() {
 					'default' => false,
 				),
 
-				'backgroundColor'         => array(
-					'type' => 'string',
-				),
-
 				'textColor'               => array(
-					'type' => 'string',
-				),
-
-				'backgroundColorValue'    => array(
 					'type' => 'string',
 				),
 
@@ -170,15 +162,7 @@ function register_block_core_navigation_menu() {
 					'type' => 'string',
 				),
 
-				'customBackgroundColor'   => array(
-					'type' => 'string',
-				),
-
 				'customTextColor'         => array(
-					'type' => 'string',
-				),
-
-				'backgroundColorCSSClass' => array(
 					'type' => 'string',
 				),
 

--- a/packages/block-library/src/navigation-menu/index.php
+++ b/packages/block-library/src/navigation-menu/index.php
@@ -124,28 +124,28 @@ function register_block_core_navigation_menu() {
 		array(
 			'category'        => 'layout',
 			'attributes'      => array(
-				'className'               => array(
+				'className'         => array(
 					'type' => 'string',
 				),
 
-				'automaticallyAdd'        => array(
+				'automaticallyAdd'  => array(
 					'type'    => 'boolean',
 					'default' => false,
 				),
 
-				'textColor'               => array(
+				'textColor'         => array(
 					'type' => 'string',
 				),
 
-				'textColorValue'          => array(
+				'textColorValue'    => array(
 					'type' => 'string',
 				),
 
-				'customTextColor'         => array(
+				'customTextColor'   => array(
 					'type' => 'string',
 				),
 
-				'textColorCSSClass'       => array(
+				'textColorCSSClass' => array(
 					'type' => 'string',
 				),
 			),


### PR DESCRIPTION
## Description
This PR removes the ability to set the background color of the navigation menu. The suggestion here is to group the whole menu and then be able to set the background color.

## How has this been tested?

* Setting the text color using the colors selector
![image](https://user-images.githubusercontent.com/77539/68486538-05ef4f80-0220-11ea-838a-6a8635e99612.png)


* Grouping the navigation menu

![image](https://user-images.githubusercontent.com/77539/68486519-fe2fab00-021f-11ea-9411-83f9de89c263.png)


* Apply the background-color from the group

![image](https://user-images.githubusercontent.com/77539/68486597-25867800-0220-11ea-8497-f71739ead94f.png)

* Check the menu in the front-end

![image](https://user-images.githubusercontent.com/77539/68486726-7ac28980-0220-11ea-8b76-02a81083cff8.png)


## Screenshots <!-- if applicable -->


## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
