### PR TITLE
Fix excess theme styling on Social Links block links

### DIFF
--- a/packages/block-library/src/social-links/style.scss
+++ b/packages/block-library/src/social-links/style.scss
@@ -5,6 +5,14 @@
 	padding-right: 0;
 	// Some themes give all <ul> default margin instead of padding.
 	margin-left: 0;
+
+	// Some themes add underlines, false underlines (via shadows), and borders to <a>.
+	.wp-social-link a,
+	.wp-social-link a:hover {
+		text-decoration: none;
+		border-bottom: 0;
+		box-shadow: none;
+	}
 }
 
 .wp-social-link {
@@ -19,9 +27,6 @@
 		padding: 6px;
 		display: block;
 		line-height: 0;
-		text-decoration: none;
-		border-bottom: 0 !important;
-		box-shadow: none !important;
 		transition: transform 0.1s ease;
 	}
 

--- a/packages/block-library/src/social-links/style.scss
+++ b/packages/block-library/src/social-links/style.scss
@@ -19,6 +19,9 @@
 		padding: 6px;
 		display: block;
 		line-height: 0;
+		text-decoration: none;
+		border-bottom: 0 !important;
+		box-shadow: none !important;
 		transition: transform 0.1s ease;
 	}
 


### PR DESCRIPTION
## Description
Fixes #18115 by adding styles to remove excess underlines, false underlines (via 1px solid shadows), and borders to the `<a>` elements within the Social Links block. 

## How has this been tested?
Tested in supported browsers and with core themes that have been reported with this issue.

## Screenshots <!-- if applicable -->
Twenty Fifteen theme before/after:
<img width="747" alt="2015-before" src="https://user-images.githubusercontent.com/1813435/68488916-13064180-0214-11ea-8d19-2f8ec050c45f.png">
<img width="711" alt="2015-after" src="https://user-images.githubusercontent.com/1813435/68488919-14376e80-0214-11ea-8fb2-e535907aab26.png">

Twenty Seventeen theme before/after:
<img width="1060" alt="2017-before" src="https://user-images.githubusercontent.com/1813435/68488957-27e2d500-0214-11ea-9f90-99c3307dd691.png">
<img width="928" alt="2017-after" src="https://user-images.githubusercontent.com/1813435/68488958-29ac9880-0214-11ea-9554-a2276822b2db.png">

## Types of changes
Style-only changes within the block's style.scss stylesheet.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->