### PR TITLE
Fixes to append items via toolbar

### DIFF
--- a/packages/block-library/src/navigation-menu-item/edit.js
+++ b/packages/block-library/src/navigation-menu-item/edit.js
@@ -245,7 +245,7 @@ export default compose( [
 			hasDescendants: !! getClientIdsOfDescendants( [ clientId ] ).length,
 		};
 	} ),
-	withDispatch( ( dispatch, ownProps ) => {
+	withDispatch( ( dispatch, ownProps, registry ) => {
 		return {
 			insertMenuItemBlock() {
 				const { clientId } = ownProps;
@@ -254,10 +254,15 @@ export default compose( [
 					insertBlock,
 				} = dispatch( 'core/block-editor' );
 
+				const { getClientIdsOfDescendants } = registry.select( 'core/block-editor' );
+				const navItems = getClientIdsOfDescendants( [ clientId ] );
+				const insertionPoint = navItems.length ? navItems.length : 0;
+
 				const blockToInsert = createBlock( 'core/navigation-menu-item' );
+
 				insertBlock(
 					blockToInsert,
-					0,
+					insertionPoint,
 					clientId,
 				);
 			},


### PR DESCRIPTION
Closes https://github.com/WordPress/gutenberg/issues/18299

Updates the Nav Block toolbar "insert" button to _append_ items at the end of the currently selected Nav Block Item.

Previously this was hardcoded to `0` which meant they were always prepended.

## How has this been tested?
Manual testing.

## Screenshots <!-- if applicable -->

![Screen Capture on 2019-11-08 at 17-31-26](https://user-images.githubusercontent.com/444434/68498098-f555ce00-024d-11ea-826e-97e21387eee7.gif)


## Types of changes
Bug fix (non-breaking change which fixes an issue) 

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
