### PR TITLE
Prototype: Server-side block attributes sourcing

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -87,7 +87,7 @@ add_action( 'admin_menu', 'gutenberg_menu' );
 function gutenberg_wordpress_version_notice() {
 	echo '<div class="error"><p>';
 	/* translators: %s: Minimum required version */
-	printf( __( 'Gutenberg requires WordPress %s or later to function properly. Please upgrade WordPress before activating Gutenberg.', 'gutenberg' ), '5.0.0' );
+	printf( __( 'Gutenberg requires WordPress %s or later to function properly. Please upgrade WordPress before activating Gutenberg.', 'gutenberg' ), '5.2.0' );
 	echo '</p></div>';
 
 	deactivate_plugins( array( 'gutenberg/gutenberg.php' ) );
@@ -122,7 +122,7 @@ function gutenberg_pre_init() {
 	// Strip '-src' from the version string. Messes up version_compare().
 	$version = str_replace( '-src', '', $wp_version );
 
-	if ( version_compare( $version, '5.0.0', '<' ) ) {
+	if ( version_compare( $version, '5.2.0', '<' ) ) {
 		add_action( 'admin_notices', 'gutenberg_wordpress_version_notice' );
 		return;
 	}

--- a/lib/class-wp-sourced-attributes-block-parser.php
+++ b/lib/class-wp-sourced-attributes-block-parser.php
@@ -93,7 +93,9 @@ class WP_Sourced_Attributes_Block_Parser extends WP_Block_Parser {
 	function get_html_sourced_attribute( $block, $attribute_schema ) {
 		$document = new DOMDocument();
 		try {
-			$document->loadHTML( '<html><body>' . $block['innerHTML'] . '</body></html>' );
+			// loadHTML may log warnings for unexpected markup.
+			// phpcs:ignore
+			@$document->loadHTML( '<html><body>' . $block['innerHTML'] . '</body></html>' );
 		} catch ( Exception $e ) {
 			return null;
 		}

--- a/lib/class-wp-sourced-attributes-block-parser.php
+++ b/lib/class-wp-sourced-attributes-block-parser.php
@@ -1,0 +1,198 @@
+<?php
+/**
+ * Block Serialization Parser
+ *
+ * @package Gutenberg
+ */
+
+/**
+ * Class WP_Sourced_Attributes_Block_Parser
+ *
+ * Parses a document and constructs a list of parsed block objects
+ *
+ * @since 6.9.0
+ */
+class WP_Sourced_Attributes_Block_Parser extends WP_Block_Parser {
+
+	/**
+	 * Parses a document and returns a list of block structures
+	 *
+	 * When encountering an invalid parse will return a best-effort
+	 * parse. In contrast to the specification parser this does not
+	 * return an error on invalid inputs.
+	 *
+	 * @since 6.9.0
+	 *
+	 * @param string                 $document Input document being parsed.
+	 * @param WP_Block_Type_Registry $registry Block type registry from which
+	 *                                         block attributes schema can be
+	 *                                         retrieved.
+	 * @param int|null               $post_id  Optional post ID.
+	 * @return WP_Block_Parser_Block[]
+	 */
+	function parse( $document, $registry = null, $post_id = null ) {
+		if ( is_null( $registry ) ) {
+			$registry = WP_Block_Type_Registry::get_instance();
+		}
+
+		$blocks = parent::parse( $document );
+
+		foreach ( $blocks as $i => $block ) {
+			$block_type = $registry->get_registered( $block['blockName'] );
+			if ( is_null( $block_type ) || ! isset( $block_type->attributes ) ) {
+				continue;
+			}
+
+			$sourced_attributes = $this->get_sourced_attributes(
+				$block,
+				$block_type->attributes,
+				$post_id
+			);
+
+			$blocks[ $i ]['attrs'] = array_merge( $block['attrs'], $sourced_attributes );
+		}
+
+		return $blocks;
+	}
+
+	/**
+	 * Returns an array of sourced attribute values for a block.
+	 *
+	 * @param WP_Block_Parser_Block $block             Parsed block object.
+	 * @param array                 $attributes_schema Attributes of registered
+	 *                                                 block type for block.
+	 * @param int|null              $post_id           Optional post ID.
+	 * @return array                                   Sourced attribute values.
+	 */
+	function get_sourced_attributes( $block, $attributes_schema, $post_id ) {
+		$attributes = array();
+
+		foreach ( $attributes_schema as $key => $attribute_schema ) {
+			if ( isset( $attribute_schema['source'] ) ) {
+				$attributes[ $key ] = $this->get_sourced_attribute(
+					$block,
+					$attribute_schema,
+					$post_id
+				);
+			}
+		}
+
+		return $attributes;
+	}
+
+	/**
+	 * Returns a sourced attribute value for a block, for attribute type which
+	 * sources from HTML.
+	 *
+	 * @param WP_Block_Parser_Block $block            Parsed block object.
+	 * @param array                 $attribute_schema Attribute schema for
+	 *                                                individual attribute to
+	 *                                                be parsed.
+	 * @return mixed                                  Sourced attribute value.
+	 */
+	function get_html_sourced_attribute( $block, $attribute_schema ) {
+		$document = new DOMDocument();
+		try {
+			$document->loadHTML( '<html><body>' . $block['innerHTML'] . '</body></html>' );
+		} catch ( Exception $e ) {
+			return null;
+		}
+
+		$selector = 'body';
+		if ( isset( $attribute_schema['selector'] ) ) {
+			$selector .= ' ' . $attribute_schema['selector'];
+		}
+
+		$xpath_selector = _wp_css_selector_to_xpath( $selector );
+		$xpath          = new DOMXpath( $document );
+		$match          = $xpath->evaluate( $xpath_selector );
+
+		if ( 0 === $match->count() ) {
+			return null;
+		}
+
+		$element = $match->item( 0 );
+
+		switch ( $attribute_schema['source'] ) {
+			case 'text':
+				/*
+				 * See: https://github.com/WordPress/WordPress-Coding-Standards/issues/574
+				 */
+				// phpcs:ignore
+				return $element->textContent;
+
+			case 'html':
+				$inner_html = '';
+
+				/*
+				 * See: https://github.com/WordPress/WordPress-Coding-Standards/issues/574
+				 */
+				// phpcs:ignore
+				foreach ( $element->childNodes as $child ) {
+					/*
+					 * See: https://github.com/WordPress/WordPress-Coding-Standards/issues/574
+					 */
+					// phpcs:ignore
+					$inner_html .= $child->ownerDocument->saveXML( $child );
+				}
+
+				return $inner_html;
+
+			case 'attribute':
+				if ( ! isset( $attribute_schema['attribute'] ) ||
+						is_null( $element->attributes ) ) {
+					return null;
+				}
+
+				$attribute = $element->attributes->getNamedItem( $attribute_schema['attribute'] );
+
+				/*
+				 * See: https://github.com/WordPress/WordPress-Coding-Standards/issues/574
+				 */
+				// phpcs:ignore
+				return is_null( $attribute ) ? null : $attribute->nodeValue;
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns a sourced attribute value for a block.
+	 *
+	 * @param WP_Block_Parser_Block $block            Parsed block object.
+	 * @param array                 $attribute_schema Attribute schema for
+	 *                                                individual attribute to
+	 *                                                be parsed.
+	 * @param int|null              $post_id          Optional post ID.
+	 * @return mixed                                  Sourced attribute value.
+	 */
+	function get_sourced_attribute( $block, $attribute_schema, $post_id ) {
+		switch ( $attribute_schema['source'] ) {
+			case 'text':
+			case 'html':
+			case 'attribute':
+				return $this->get_html_sourced_attribute( $block, $attribute_schema );
+
+			case 'query':
+				// TODO: Implement.
+				return null;
+
+			case 'property':
+			case 'node':
+			case 'children':
+			case 'tag':
+				// Unsupported or deprecated.
+				return null;
+
+			case 'meta':
+				if ( ! is_null( $post_id ) && isset( $attribute_schema['meta'] ) ) {
+					return get_post_meta( $post_id, $attribute_schema['meta'] );
+				}
+
+				return null;
+		}
+
+		return null;
+	}
+
+}

--- a/lib/load.php
+++ b/lib/load.php
@@ -51,7 +51,8 @@ if ( ! class_exists( 'WP_Block_Styles_Registry' ) ) {
 }
 
 require dirname( __FILE__ ) . '/compat.php';
-
+require dirname( __FILE__ ) . '/class-wp-sourced-attributes-block-parser.php';
+require dirname( __FILE__ ) . '/parser.php';
 require dirname( __FILE__ ) . '/blocks.php';
 require dirname( __FILE__ ) . '/templates.php';
 require dirname( __FILE__ ) . '/template-loader.php';

--- a/lib/parser.php
+++ b/lib/parser.php
@@ -17,6 +17,50 @@ function gutenberg_replace_block_parser_class() {
 add_filter( 'block_parser_class', 'gutenberg_replace_block_parser_class' );
 
 /**
+ * Given a registered block type settings array, assigns default attributes.
+ * This must be called manually, as there is currently no way to hook to block
+ * registration.
+ *
+ * @since 6.9.0
+ *
+ * @param array $block_settings Block settings.
+ * @return array                Block settings with default attributes.
+ */
+function gutenberg_add_default_attributes( $block_settings ) {
+	$supports   = isset( $block_settings['supports'] ) ? $block_settings['supports'] : array();
+	$attributes = isset( $block_settings['attributes'] ) ? $block_settings['attributes'] : array();
+
+	if ( ! empty( $supports['align'] ) ) {
+		if ( ! isset( $attributes['align'] ) ) {
+			$attributes['align'] = array();
+		}
+
+		$attributes['align']['type'] = 'string';
+	}
+
+	if ( ! empty( $supports['anchor'] ) ) {
+		if ( ! isset( $attributes['anchor'] ) ) {
+			$attributes['anchor'] = array();
+		}
+
+		$attributes['anchor']['type']      = 'string';
+		$attributes['anchor']['source']    = 'attribute';
+		$attributes['anchor']['attribute'] = 'id';
+		$attributes['anchor']['selector']  = '*';
+	}
+
+	if ( ! isset( $supports['customClassName'] ) || false !== $supports['customClassName'] ) {
+		if ( ! isset( $attributes['className'] ) ) {
+			$attributes['className'] = array();
+		}
+
+		$attributes['className']['type'] = 'string';
+	}
+
+	return $block_settings;
+}
+
+/**
  * Given a CSS selector string, returns an equivalent XPath selector.
  *
  * @access private

--- a/lib/parser.php
+++ b/lib/parser.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * Includes revisions to the block parser not yet proposed for core adoption.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Filters to override default block parser with Gutenberg's custom
+ * implementation.
+ *
+ * @since 6.9.0
+ */
+function gutenberg_replace_block_parser_class() {
+	return 'WP_Sourced_Attributes_Block_Parser';
+}
+add_filter( 'block_parser_class', 'gutenberg_replace_block_parser_class' );
+
+/**
+ * Given a CSS selector string, returns an equivalent XPath selector.
+ *
+ * @access private
+ * @since 6.9.0
+ *
+ * @param string $selector CSS selector.
+ * @return string          Equivalent XPath selector.
+ */
+function _wp_css_selector_to_xpath( $selector ) {
+	/*
+	 * Modified from PHP Selector, released under the MIT License.
+	 * https://github.com/tj/php-selector
+	 * Copyright © 2008 - 2009 TJ Holowaychuk <tj@vision-media.ca>
+	 */
+
+	// Remove spaces around operators.
+	$selector  = preg_replace( '/\s*>\s*/', '>', $selector );
+	$selector  = preg_replace( '/\s*~\s*/', '~', $selector );
+	$selector  = preg_replace( '/\s*\+\s*/', '+', $selector );
+	$selector  = preg_replace( '/\s*,\s*/', ',', $selector );
+	$selectors = preg_split( '/\s+(?![^\[]+\])/', $selector );
+
+	foreach ( $selectors as &$selector ) {
+		/* , */
+		$selector = preg_replace( '/,/', '|descendant-or-self::', $selector );
+		/* input:checked, :disabled, etc. */
+		$selector = preg_replace( '/(.+)?:(checked|disabled|required|autofocus)/', '\1[@\2="\2"]', $selector );
+		/* input:autocomplete, :autocomplete */
+		$selector = preg_replace( '/(.+)?:(autocomplete)/', '\1[@\2="on"]', $selector );
+		/* input:button, input:submit, etc. */
+		$selector = preg_replace( '/:(text|password|checkbox|radio|button|submit|reset|file|hidden|image|datetime|datetime-local|date|month|time|week|number|range|email|url|search|tel|color)/', 'input[@type="\1"]', $selector );
+		/* foo[id] */
+		$selector = preg_replace( '/(\w+)\[([_\w-]+[_\w\d-]*)\]/', '\1[@\2]', $selector );
+		/* [id] */
+		$selector = preg_replace( '/\[([_\w-]+[_\w\d-]*)\]/', '*[@\1]', $selector );
+		/* foo[id=foo] */
+		$selector = preg_replace( '/\[([_\w-]+[_\w\d-]*)=[\'"]?(.*?)[\'"]?\]/', '[@\1="\2"]', $selector );
+		/* [id=foo] */
+		$selector = preg_replace( '/^\[/', '*[', $selector );
+		/* div#foo */
+		$selector = preg_replace( '/([_\w-]+[_\w\d-]*)\#([_\w-]+[_\w\d-]*)/', '\1[@id="\2"]', $selector );
+		/* #foo */
+		$selector = preg_replace( '/\#([_\w-]+[_\w\d-]*)/', '*[@id="\1"]', $selector );
+		/* div.foo */
+		$selector = preg_replace( '/([_\w-]+[_\w\d-]*)\.([_\w-]+[_\w\d-]*)/', '\1[contains(concat(" ",@class," ")," \2 ")]', $selector );
+		/* .foo */
+		$selector = preg_replace( '/\.([_\w-]+[_\w\d-]*)/', '*[contains(concat(" ",@class," ")," \1 ")]', $selector );
+		/* div:first-child */
+		$selector = preg_replace( '/([_\w-]+[_\w\d-]*):first-child/', '*/\1[position()=1]', $selector );
+		/* div:last-child */
+		$selector = preg_replace( '/([_\w-]+[_\w\d-]*):last-child/', '*/\1[position()=last()]', $selector );
+		/* :first-child */
+		$selector = str_replace( ':first-child', '*/*[position()=1]', $selector );
+		/* :last-child */
+		$selector = str_replace( ':last-child', '*/*[position()=last()]', $selector );
+		/* :nth-last-child */
+		$selector = preg_replace( '/:nth-last-child\((\d+)\)/', '[position()=(last() - (\1 - 1))]', $selector );
+		/* div:nth-child */
+		$selector = preg_replace( '/([_\w-]+[_\w\d-]*):nth-child\((\d+)\)/', '*/*[position()=\2 and self::\1]', $selector );
+		/* :nth-child */
+		$selector = preg_replace( '/:nth-child\((\d+)\)/', '*/*[position()=\1]', $selector );
+		/* :contains(Foo) */
+		$selector = preg_replace( '/([_\w-]+[_\w\d-]*):contains\((.*?)\)/', '\1[contains(string(.),"\2")]', $selector );
+		/* > */
+		$selector = preg_replace( '/>/', '/', $selector );
+		/* ~ */
+		$selector = preg_replace( '/~/', '/following-sibling::', $selector );
+		/* + */
+		$selector = preg_replace( '/\+([_\w-]+[_\w\d-]*)/', '/following-sibling::\1[position()=1]', $selector );
+		$selector = str_replace( ']*', ']', $selector );
+		$selector = str_replace( ']/*', ']', $selector );
+	}
+
+	// ' '
+	$selector = implode( '/descendant::', $selectors );
+	$selector = 'descendant-or-self::' . $selector;
+	// :scope
+	$selector = preg_replace( '/(((\|)?descendant-or-self::):scope)/', '.\3', $selector );
+	// $element
+	$sub_selectors = explode( ',', $selector );
+
+	foreach ( $sub_selectors as $key => $sub_selector ) {
+		$parts        = explode( '$', $sub_selector );
+		$sub_selector = array_shift( $parts );
+
+		if ( count( $parts ) && preg_match_all( '/((?:[^\/]*\/?\/?)|$)/', $parts[0], $matches ) ) {
+			$results       = $matches[0];
+			$results[]     = str_repeat( '/..', count( $results ) - 2 );
+			$sub_selector .= implode( '', $results );
+		}
+
+		$sub_selectors[ $key ] = $sub_selector;
+	}
+
+	$selector = implode( ',', $sub_selectors );
+
+	return $selector;
+}

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -52,7 +52,74 @@ function gutenberg_filter_oembed_result( $response, $handler, $request ) {
 }
 add_filter( 'rest_request_after_callbacks', 'gutenberg_filter_oembed_result', 10, 3 );
 
+/**
+ * Reducer callback operating on an array of block results for REST response.
+ * Given a block entity, adds an array formatted for use in the response, if
+ * the block is named.
+ *
+ * @param array $result Blocks to include.
+ * @param array $block  The parsed block to format.
+ * @return array        Block formatted for REST response.
+ */
+function gutenberg_format_block_for_rest( $result, $block ) {
+	if ( ! empty( $block['blockName'] ) ) {
+		$result[] = array(
+			'name'         => $block['blockName'],
+			'attributes'   => (object) $block['attrs'],
+			'inner_blocks' => array_reduce(
+				$block['innerBlocks'],
+				'gutenberg_format_block_for_rest',
+				array()
+			),
+		);
+	}
 
+	return $result;
+}
+
+/**
+ * Augments REST Posts controller response to include blocks data, only if
+ * response already includes `content.raw`.
+ *
+ * In a more correct implementation, this would use item schema as basis for
+ * whether `content.blocks` is included in a response.
+ *
+ * @since 6.9.0
+ *
+ * @param WP_REST_Response $response The response object.
+ * @return WP_HTTP_Response          The filtered response object.
+ */
+function gutenberg_add_blocks_to_rest_posts_content( $response ) {
+	if ( ! empty( $response->data['content']['raw'] ) ) {
+		$response->data['content']['blocks'] = array_reduce(
+			parse_blocks( $response->data['content']['raw'] ),
+			'gutenberg_format_block_for_rest',
+			array()
+		);
+	}
+
+	return $response;
+}
+
+/**
+ * Adds filter for all registered post types to augment REST API responses for
+ * that post type to include blocks data.
+ *
+ * In a core implementation, this would not be necessary, as the logic for
+ * including blocks data would be part of the controller implementation.
+ *
+ * @since 6.9.0
+ */
+function gutenberg_filter_rest_prepare_post_types() {
+	$post_types = get_post_types();
+	foreach ( $post_types as $post_type ) {
+		add_filter(
+			'rest_prepare_' . $post_type,
+			'gutenberg_add_blocks_to_rest_posts_content'
+		);
+	}
+}
+add_action( 'rest_pre_dispatch', 'gutenberg_filter_rest_prepare_post_types' );
 
 /**
  * Start: Include for phase 2

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -3,7 +3,7 @@
 	<description>Sniffs for WordPress plugins, with minor modifications for Gutenberg</description>
 
 	<rule ref="PHPCompatibility"/>
-	<config name="testVersion" value="5.2-"/>
+	<config name="testVersion" value="5.6-"/>
 
 	<rule ref="WordPress-Core"/>
 	<rule ref="WordPress-Docs"/>


### PR DESCRIPTION
This pull request seeks to explore an approach to block attributes sourcing on the server. In other words, it seeks to account for attributes whose values are derived from HTML (or post meta). It should be considered a prototype, but it currently implements most all of the current source supports.

Example:

```bash
curl 'http://localhost:8889/wp-json/wp/v2/posts/95?context=edit&_fields=content'  -H 'X-WP-Nonce: [...]' -H 'Cookie: wordpress_logged_in_[...]=[...]' | jq .
```

```json
{
  "content": {
    "raw": "<!-- wp:paragraph {\"align\":\"center\",\"className\":\"my-custom-class\"} -->\n<p class=\"has-text-align-center my-custom-class\">Hello world</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:image {\"id\":20,\"sizeSlug\":\"large\"} -->\n<figure class=\"wp-block-image size-large\"><img src=\"http://localhost:8889/wp-content/uploads/2019/11/stars-1024x681.jpeg\" alt=\"\" class=\"wp-image-20\"/><figcaption>Caption!</figcaption></figure>\n<!-- /wp:image -->",
    "rendered": "\n<p class=\"has-text-align-center my-custom-class\">Hello world</p>\n\n\n\n<figure class=\"wp-block-image size-large\"><img src=\"http://localhost:8889/wp-content/uploads/2019/11/stars-1024x681.jpeg\" alt=\"\" class=\"wp-image-20\" srcset=\"http://localhost:8889/wp-content/uploads/2019/11/stars-1024x681.jpeg 1024w, http://localhost:8889/wp-content/uploads/2019/11/stars-300x199.jpeg 300w, http://localhost:8889/wp-content/uploads/2019/11/stars-768x510.jpeg 768w, http://localhost:8889/wp-content/uploads/2019/11/stars-1536x1021.jpeg 1536w, http://localhost:8889/wp-content/uploads/2019/11/stars-2048x1361.jpeg 2048w\" sizes=\"(max-width: 1024px) 100vw, 1024px\" /><figcaption>Caption!</figcaption></figure>\n",
    "protected": false,
    "block_version": 1,
    "blocks": [
      {
        "name": "core/paragraph",
        "attributes": {
          "align": "center",
          "className": "my-custom-class",
          "content": "Hello world"
        },
        "inner_blocks": []
      },
      {
        "name": "core/image",
        "attributes": {
          "id": 20,
          "sizeSlug": "large",
          "url": "http://localhost:8889/wp-content/uploads/2019/11/stars-1024x681.jpeg",
          "alt": "",
          "caption": "Caption!",
          "title": null,
          "href": null,
          "rel": null,
          "linkClass": null,
          "linkTarget": null
        },
        "inner_blocks": []
      }
    ]
  },
}
```

**Implementation Notes:**

The parsing relies on [`DOMDocument`](https://www.php.net/manual/en/class.domdocument.php), querying using [`DOMXPath`](https://www.php.net/manual/en/class.domxpath.php) by first converting the block type attribute selector to an equivalent XPath selector using a bundled, modified version of a third-party library [PHP Selector](https://github.com/tj/php-selector).

In an effort to best demonstrate its usage, additional changes include:

- A mechanism for server-registering all Gutenberg `block.json` manifests
- Include a new `content.blocks` field on the REST API posts responses
- Defining default-supported attributes for blocks registered on the server (`className`, `align`, `anchor`)

**Open Questions:**

For me, the main questions and concerns surrounding this approach include:

- Is it performant enough?
- Are `DOMDocument` and the PHP Selector utilities resilient enough, and do they account for modern HTML and CSS?
   - There may be other options to explore here, including [`symfony/css-selector`](https://github.com/symfony/css-selector)
- What permissions would we require for access to this raw data?