### PR TITLE
Nav block: handle overflowing items using wrap on Block selection

### DIFF
--- a/packages/block-library/src/navigation-menu/edit.js
+++ b/packages/block-library/src/navigation-menu/edit.js
@@ -50,18 +50,16 @@ function NavigationMenu( {
 } ) {
 	const navMenuRef = useRef();
 	const [ hasScrollX, setHasScrollX ] = useState( false );
+	const clientWidth = navMenuRef.current ? navMenuRef.current.clientWidth : 0;
+	const scrollWidth = navMenuRef.current ? navMenuRef.current.scrollWidth : 0;
 
 	useLayoutEffect( () => {
-		if ( navMenuRef && navMenuRef.current ) {
-			const navMenu = navMenuRef.current;
-
-			if ( navMenu.scrollWidth > navMenu.clientWidth ) {
-				setHasScrollX( true );
-			} else {
-				setHasScrollX( false );
-			}
+		if ( scrollWidth > clientWidth ) {
+			setHasScrollX( true );
+		} else {
+			setHasScrollX( false );
 		}
-	} );
+	}, [ clientWidth, scrollWidth ] );
 
 	const { navigatorToolbarButton, navigatorModal } = useBlockNavigator( clientId );
 	const defaultMenuItems = useMemo(

--- a/packages/block-library/src/navigation-menu/edit.js
+++ b/packages/block-library/src/navigation-menu/edit.js
@@ -9,6 +9,9 @@ import classnames from 'classnames';
 import {
 	useMemo,
 	useEffect,
+	useLayoutEffect,
+	useRef,
+	useState,
 } from '@wordpress/element';
 import {
 	InnerBlocks,
@@ -45,6 +48,21 @@ function NavigationMenu( {
 	setTextColor,
 	setAttributes,
 } ) {
+	const navMenuRef = useRef();
+	const [ hasScrollX, setHasScrollX ] = useState( false );
+
+	useLayoutEffect( () => {
+		if ( navMenuRef && navMenuRef.current ) {
+			const navMenu = navMenuRef.current;
+
+			if ( navMenu.scrollWidth > navMenu.clientWidth ) {
+				setHasScrollX( true );
+			} else {
+				setHasScrollX( false );
+			}
+		}
+	} );
+
 	const { navigatorToolbarButton, navigatorModal } = useBlockNavigator( clientId );
 	const defaultMenuItems = useMemo(
 		() => {
@@ -79,6 +97,7 @@ function NavigationMenu( {
 		'wp-block-navigation-menu', {
 			'has-text-color': textColor.color,
 			'has-background-color': backgroundColor.color,
+			'has-scroll-x': hasScrollX,
 			[ attributes.backgroundColorCSSClass ]: attributes && attributes.backgroundColorCSSClass,
 			[ attributes.textColorCSSClass ]: attributes && attributes.textColorCSSClass,
 		}
@@ -149,7 +168,7 @@ function NavigationMenu( {
 				</PanelBody>
 			</InspectorControls>
 
-			<div className={ navigationMenuClasses } style={ navigationMenuInlineStyles }>
+			<div ref={ navMenuRef } className={ navigationMenuClasses } style={ navigationMenuInlineStyles }>
 				{ isRequesting && <><Spinner /> { __( 'Loading Navigation…' ) } </> }
 				{ pages &&
 					<InnerBlocks

--- a/packages/block-library/src/navigation-menu/editor.scss
+++ b/packages/block-library/src/navigation-menu/editor.scss
@@ -8,11 +8,15 @@
 		overflow-x: auto;
 	}
 
+	// Allow more space on RHS when scroll is present
+	.wp-block-navigation-menu.has-scroll-x .block-editor-block-list__layout {
+		padding-right: 25%;
+	}
+
 	// 1. Reset margins on immediate innerblocks container.
 	.wp-block-navigation-menu .block-editor-inner-blocks > .block-editor-block-list__layout {
 		margin-left: 0;
 		margin-right: 0;
-		padding-right: 25%;
 	}
 
 	// 2. Remove paddings on subsequent immediate children.

--- a/packages/block-library/src/navigation-menu/editor.scss
+++ b/packages/block-library/src/navigation-menu/editor.scss
@@ -2,10 +2,17 @@
 // @todo: eventually we may add a feature that lets a parent container absorb the block UI of a child block.
 // When that happens, leverage that instead of the following overrides.
 [data-type="core/navigation-menu"] {
+
+	// Allow overflowing items to scroll container
+	.wp-block-navigation-menu {
+		overflow-x: auto;
+	}
+
 	// 1. Reset margins on immediate innerblocks container.
 	.wp-block-navigation-menu .block-editor-inner-blocks > .block-editor-block-list__layout {
 		margin-left: 0;
 		margin-right: 0;
+		padding-right: 25%;
 	}
 
 	// 2. Remove paddings on subsequent immediate children.
@@ -13,7 +20,7 @@
 		width: auto;
 		padding-left: 0;
 		padding-right: 0;
-		margin-left: 0; // something
+		margin-left: 0;
 	}
 
 	// 3. Remove margins on subsequent Edit container.

--- a/packages/block-library/src/navigation-menu/editor.scss
+++ b/packages/block-library/src/navigation-menu/editor.scss
@@ -3,14 +3,30 @@
 // When that happens, leverage that instead of the following overrides.
 [data-type="core/navigation-menu"] {
 
-	// Allow overflowing items to scroll container
+	// State: "unselected" - allow overflowing items to scroll container
 	.wp-block-navigation-menu {
 		overflow-x: auto;
 	}
 
-	// Allow more space on RHS when scroll is present
-	.wp-block-navigation-menu.has-scroll-x .block-editor-block-list__layout {
-		padding-right: 25%;
+	// State: "selected" - wrap all items to allow for better editing UX
+	&.is-selected,
+	&.has-child-selected {
+
+		.wp-block-navigation-menu {
+			overflow: visible; // cancel "auto" above to ensure toolbars can display correctly
+		}
+
+		.wp-block-navigation-menu .block-editor-block-list__layout {
+			display: flex;
+			flex-wrap: wrap;
+
+			.wp-block {
+				display: flex;
+				flex: 1; // grow to own content width only
+				// margin-top: $block-padding*2;
+				// margin-bottom: $block-padding*2; // push wrapped items away from toolbars
+			}
+		}
 	}
 
 	// 1. Reset margins on immediate innerblocks container.

--- a/packages/block-library/src/navigation-menu/style.scss
+++ b/packages/block-library/src/navigation-menu/style.scss
@@ -107,13 +107,3 @@
 	}
 
 }
-
-
-/**
- * Editor Only Styles
- */
-.block-editor-block-list__block-edit {
-	.wp-block-navigation-menu {
-		overflow-x: auto; // allow overflowing items to cause scroll
-	}
-}

--- a/packages/block-library/src/navigation-menu/style.scss
+++ b/packages/block-library/src/navigation-menu/style.scss
@@ -114,6 +114,6 @@
  */
 .block-editor-block-list__block-edit {
 	.wp-block-navigation-menu {
-		overflow: auto; // allow overflowing items to cause scroll
+		overflow-x: auto; // allow overflowing items to cause scroll
 	}
 }

--- a/packages/block-library/src/navigation-menu/style.scss
+++ b/packages/block-library/src/navigation-menu/style.scss
@@ -107,3 +107,13 @@
 	}
 
 }
+
+
+/**
+ * Editor Only Styles
+ */
+.block-editor-block-list__block-edit {
+	.wp-block-navigation-menu {
+		overflow: auto; // allow overflowing items to cause scroll
+	}
+}


### PR DESCRIPTION
An alternative attempt at https://github.com/WordPress/gutenberg/issues/18298.

See also https://github.com/WordPress/gutenberg/pull/18336#issuecomment-551534767

This approach avoids retaining the overflow scroll when the Block is in edit mode. Instead the items are allowed to wrap thereby improving the editing experience.

The major issue is that there is quite a big change in layout when the Block is selected.

## How has this been tested?
Manual testing.



## Screenshots <!-- if applicable -->


![Screen Capture on 2019-11-11 at 12-04-16](https://user-images.githubusercontent.com/444434/68585940-780fa080-047b-11ea-9dd3-b87e3f22520c.gif)


## Types of changes
Bug fix (non-breaking change which fixes an issue).

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
