### PR TITLE
Fix Nav Menu overflow using flex-wrap approach

### DIFF
--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -67,25 +67,17 @@
 		display: block;
 	}
 
-    &.has-link .wp-block-navigation-link__content {
+	&.has-link .wp-block-navigation-link__content {
 		border-bottom-style: solid;
 		border-bottom-width: 1px;
 	}
 
-    .block-editor-rich-text__editable.is-selected:not(.keep-placeholder-on-focus):not(:focus) [data-rich-text-placeholder]::after {
+	.block-editor-rich-text__editable.is-selected:not(.keep-placeholder-on-focus):not(:focus) [data-rich-text-placeholder]::after {
 		display: inline-block;
 	}
 }
 
-[data-type="core/navigation-menu-item"] {
-
-	// Take mover out of flow to avoid layout jump on Block select
-	.block-editor-block-mover {
-		position: absolute;
-		bottom: 0;
-		right: 0;
-	}
-
+[data-type="core/navigation-link"] {
 	.block-editor-block-toolbar {
 		left: 15px;
 	}

--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -40,18 +40,54 @@
 }
 
 .wp-block-navigation-link {
+	margin-right: $grid-size;
+	// Provide a base menu item margin.
+	// This should be the same inside the field,
+	// and the edit container should compensate.
+	// This is to make sure the edit and view are the same.
+	padding: 0 $grid-size;
+	padding-right: 55px; // allow space for Block "mover"
+
+	.block-editor-block-list__layout {
+		display: block;
+		margin: $grid-size;
+	}
+
+	// Only display inner blocks when the block is being edited.
+	.block-editor-inner-blocks {
+		display: none;
+	}
+
 	&.is-editing,
 	&.is-selected {
 		min-width: 20px;
 	}
 
-	&.has-link .wp-block-navigation-link__content {
+	&.is-editing .block-editor-inner-blocks {
+		display: block;
+	}
+
+    &.has-link .wp-block-navigation-link__content {
 		border-bottom-style: solid;
 		border-bottom-width: 1px;
 	}
 
-	.block-editor-rich-text__editable.is-selected:not(.keep-placeholder-on-focus):not(:focus) [data-rich-text-placeholder]::after {
+    .block-editor-rich-text__editable.is-selected:not(.keep-placeholder-on-focus):not(:focus) [data-rich-text-placeholder]::after {
 		display: inline-block;
+	}
+}
+
+[data-type="core/navigation-menu-item"] {
+
+	// Take mover out of flow to avoid layout jump on Block select
+	.block-editor-block-mover {
+		position: absolute;
+		bottom: 0;
+		right: 0;
+	}
+
+	.block-editor-block-toolbar {
+		left: 15px;
 	}
 }
 

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -11,12 +11,11 @@
 
 	// 2. Remove paddings on subsequent immediate children.
 	.wp-block-navigation .block-editor-inner-blocks > .block-editor-block-list__layout > .wp-block {
-		display: flex;
-		flex: 1;
 		width: auto;
 		padding-left: 0;
 		padding-right: 0;
 		margin-left: 0;
+		margin-right: 0;
 		margin-bottom: 1em; // Useful for when items wrap.
 	}
 

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -6,10 +6,13 @@
 	.wp-block-navigation .block-editor-inner-blocks > .block-editor-block-list__layout {
 		margin-left: 0;
 		margin-right: 0;
+
 	}
 
 	// 2. Remove paddings on subsequent immediate children.
 	.wp-block-navigation .block-editor-inner-blocks > .block-editor-block-list__layout > .wp-block {
+		display: flex;
+		flex: 1;
 		width: auto;
 		padding-left: 0;
 		padding-right: 0;
@@ -27,6 +30,11 @@
 	.wp-block-navigation .block-editor-inner-blocks > .block-editor-block-list__layout .wp-block > .block-editor-block-list__block-edit > [data-block] {
 		margin-top: 0;
 		margin-bottom: 0;
+	}
+
+	.wp-block-navigation .block-editor-block-list__block-edit::before {
+		left: 0;
+		right: 0;
 	}
 
 	// Remove the dashed outlines for child blocks.

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -13,7 +13,8 @@
 		width: auto;
 		padding-left: 0;
 		padding-right: 0;
-		margin-left: 0; // something
+		margin-left: 0;
+		margin-bottom: 1em; // Useful for when items wrap.
 	}
 
 	// 3. Remove margins on subsequent Edit container.
@@ -57,7 +58,7 @@
 .wp-block-navigation .block-editor-block-list__layout,
 .wp-block-navigation {
 	display: flex;
-	white-space: nowrap;
+	flex-wrap: wrap;
 }
 
 .wp-block-navigation__inserter-content {


### PR DESCRIPTION
Closes https://github.com/WordPress/gutenberg/issues/18298

This PR handles navigation menu overflow by simply allowing wrapping of Nav Items. Please see [the Issue for more context about the decision making process](https://github.com/WordPress/gutenberg/issues/18298) behind this approach.

![Screenshot 2019-11-11 at 14 52 46](https://user-images.githubusercontent.com/1204802/68592479-7ce04e80-0493-11ea-8625-07055b9b0d82.png)

### Testing

1. Add new Post
2. Add Nav Block
3. Switch Editor to "Code Mode"
4. Copy testing Block (see below) markup
5. Paste into Editor code-view window.
6. Switch back to "Visual" mode.
7. See large Nav with many items.
8. Test it wraps and interacts as expected.

Here's a handy long nav for testing

```
<!-- wp:navigation-menu {"backgroundColorCSSClass":null,"textColorCSSClass":null} -->
<!-- wp:navigation-menu-item {"label":"Sample Page","title":"Sample Page","type":"page","url":"http://localhost:8889/sample-page/"} /-->

<!-- wp:navigation-menu-item {"label":"Test Page!","title":"Test Page!","type":"page","url":"http://localhost:8889/test-page/"} /-->

<!-- wp:navigation-menu-item {"label":"Sample Page","title":"Sample Page","url":"http://localhost:8889/sample-page/"} /-->

<!-- wp:navigation-menu-item {"label":"Sapiente repellendus eius quisquam odio corporis consequuntur","title":"Sapiente repellendus eius quisquam odio corporis consequuntur","url":"http://localhost:8889/sapiente-repellendus-eius-quisquam-odio-corporis-consequuntur/"} /-->

<!-- wp:navigation-menu-item {"label":"Saepe omdddnis commodi veniam dolores tempore est","title":"Saepe omnis commodi veniam dolores tempore est","url":"http://localhost:8889/saepe-omnis-commodi-veniam-dolores-tempore-est/"} /-->

<!-- wp:navigation-menu-item {"label":"Test Page!","title":"Test Page!","url":"http://localhost:8889/test-page/"} /-->

<!-- wp:navigation-menu-item {"label":"Qui ducimus mdddd dolestiae deserunt qui","title":"Qui ducimus molestiae deserunt qui","url":"http://localhost:8889/qui-ducimus-molestiae-deserunt-qui/"} /-->

<!-- wp:navigation-menu-item {"label":"Sapidddddente repellendus eius quisquam odio corporis consequuntur","title":"Sapiente repellendus eius quisquam odio corporis consequuntur","url":"http://localhost:8889/sapiente-repellendus-eius-quisquam-odio-corporis-consequuntur/"} /-->
<!-- /wp:navigation-menu -->

```