### PR TITLE
Update/nav menu item add link style

### DIFF
--- a/packages/block-library/src/navigation-menu-item/edit.js
+++ b/packages/block-library/src/navigation-menu-item/edit.js
@@ -211,6 +211,7 @@ function NavigationMenuItemEdit( {
 				'wp-block-navigation-menu-item', {
 					'is-editing': isSelected || isParentOfSelectedBlock,
 					'is-selected': isSelected,
+					'has-link': !! url,
 				} ) }
 			>
 				<div className="wp-block-navigation-menu-item__inner">

--- a/packages/block-library/src/navigation-menu-item/editor.scss
+++ b/packages/block-library/src/navigation-menu-item/editor.scss
@@ -64,8 +64,6 @@
 }
 
 .wp-block-navigation-menu-item {
-	border: 0;
-
 	&.is-editing,
 	&.is-selected {
 		min-width: 20px;

--- a/packages/block-library/src/navigation-menu-item/editor.scss
+++ b/packages/block-library/src/navigation-menu-item/editor.scss
@@ -64,9 +64,16 @@
 }
 
 .wp-block-navigation-menu-item {
+	border: 0;
+
 	&.is-editing,
 	&.is-selected {
 		min-width: 20px;
+	}
+
+	&.has-link:not(.is-selected) {
+		border-bottom-style: solid;
+		border-bottom-width: 1px;
 	}
 
 	.block-editor-rich-text__editable.is-selected:not(.keep-placeholder-on-focus):not(:focus) [data-rich-text-placeholder]::after {

--- a/packages/block-library/src/navigation-menu-item/editor.scss
+++ b/packages/block-library/src/navigation-menu-item/editor.scss
@@ -71,7 +71,7 @@
 		min-width: 20px;
 	}
 
-	&.has-link:not(.is-selected) {
+	&.has-link .wp-block-navigation-menu-item__content {
 		border-bottom-style: solid;
 		border-bottom-width: 1px;
 	}

--- a/packages/block-library/src/navigation-menu/edit.js
+++ b/packages/block-library/src/navigation-menu/edit.js
@@ -182,7 +182,10 @@ function NavigationMenu( {
 
 	// Build Inline Styles
 	const navigationMenuInlineStyles = {
-		...( textColor && { color: textColor.color } ),
+		...( textColor && {
+			color: textColor.color,
+			borderColor: textColor.color,
+		} ),
 		...( backgroundColor && { backgroundColor: backgroundColor.color } ),
 	};
 


### PR DESCRIPTION
## Description
This PR adds styles to the menu items when they have defined a link. The link color is the same that the text color.

Fixes https://github.com/WordPress/gutenberg/issues/18305

## How has this been tested?
Edit menu item adding/removing a/the link. It should show/hide the line border-bottom on it.

## Screenshots <!-- if applicable -->

![nav-menu-no-link](https://user-images.githubusercontent.com/77539/68595678-af308280-0478-11ea-8023-35e2e659c235.gif)


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
