### PR TITLE
Update getting-started.md

### DIFF
--- a/docs/contributors/getting-started.md
+++ b/docs/contributors/getting-started.md
@@ -6,6 +6,8 @@ The first step is to install a recent version of Node. The easiest way (on MacOS
 
 Once you have Node installed, run these scripts:
 
+Note: The install scripts require [Python](https://www.python.org/) to be installed and in the path of the local system.
+
 ```
 npm install
 npm run build


### PR DESCRIPTION


## Description
Added note that python is a prerequisite to installation using npm install

npm install requires Python to install successfully. While this is included automatically with most Linux variations it is not included with Windows and Apple is removing it from MacOS.

## How has this been tested?
On local Windows 10 Pro system.

## Screenshots <!-- if applicable -->

## Types of changes
Change in documentation.
