### PR TITLE
[WIP] Navigation Menu: dropdown activation mode

### DIFF
--- a/packages/block-library/src/navigation-menu/edit.js
+++ b/packages/block-library/src/navigation-menu/edit.js
@@ -38,6 +38,7 @@ import { __ } from '@wordpress/i18n';
 import useBlockNavigator from './use-block-navigator';
 import BlockNavigationList from './block-navigation-list';
 import BlockColorsStyleSelector from './block-colors-selector';
+import MenuActivation from './inspector-control-menu-activation';
 
 function NavigationMenu( {
 	attributes,
@@ -226,11 +227,15 @@ function NavigationMenu( {
 						/>
 					</PanelBody>
 				) }
-				<PanelBody
-					title={ __( 'Navigation Structure' ) }
-				>
+				<PanelBody title={ __( 'Navigation Structure' ) }>
 					<BlockNavigationList clientId={ clientId } />
 				</PanelBody>
+
+				<MenuActivation
+					selected={ attributes.menuEventActivation }
+					onChange={ ( menuEventActivation ) => setAttributes( { menuEventActivation } ) }
+				/>
+
 			</InspectorControls>
 
 			<div className={ navigationMenuClasses } style={ navigationMenuInlineStyles }>

--- a/packages/block-library/src/navigation-menu/edit.js
+++ b/packages/block-library/src/navigation-menu/edit.js
@@ -74,7 +74,7 @@ function NavigationMenu( {
 				return null;
 			}
 
-			return pages.map( ( { title, type, link: url, id } ) => (
+			return pages.map( ( { title, type, link: url, id, menuEventActivation } ) => (
 				createBlock( 'core/navigation-menu-item',
 					{
 						type,
@@ -83,6 +83,7 @@ function NavigationMenu( {
 						label: title.rendered,
 						title: title.raw,
 						opensInNewTab: false,
+						menuEventActivation,
 					}
 				)
 			) );

--- a/packages/block-library/src/navigation-menu/index.php
+++ b/packages/block-library/src/navigation-menu/index.php
@@ -80,7 +80,11 @@ function render_block_navigation_menu( $attributes, $content, $block ) {
 
 	$colors = build_css_colors( $attributes );
 
-	return "<nav class='wp-block-navigation-menu' {$comp_inline_styles}>" .
+	$menu_activation_css_class = ! empty( $attributes['menuEventActivation'] ) && 'onHover' === $attributes['menuEventActivation']
+		? 'is-activated-by-hover'
+		: 'is-activated-by-click';
+
+	return "<nav class='wp-block-navigation-menu {$menu_activation_css_class}' {$comp_inline_styles}>" .
 		build_navigation_menu_html( $block, $colors ) .
 	'</nav>';
 }

--- a/packages/block-library/src/navigation-menu/index.php
+++ b/packages/block-library/src/navigation-menu/index.php
@@ -185,6 +185,11 @@ function register_block_core_navigation_menu() {
 				'textColorCSSClass'       => array(
 					'type' => 'string',
 				),
+
+				'menuEventActivation'  => array(
+					'type' => 'string',
+					'default' => 'onHover',
+				),
 			),
 
 			'render_callback' => 'render_block_navigation_menu',

--- a/packages/block-library/src/navigation-menu/index.php
+++ b/packages/block-library/src/navigation-menu/index.php
@@ -98,10 +98,29 @@ function render_block_navigation_menu( $attributes, $content, $block ) {
  * @return string Returns  an HTML list from innerBlocks.
  */
 function build_navigation_menu_html( $block, $colors ) {
+	$on_hover_mode = ! empty( $attributes['menuEventActivation'] ) && 'onHover' === $attributes['menuEventActivation'];
+
 	$html = '';
+	$level = 0;
 	foreach ( (array) $block['innerBlocks'] as $key => $menu_item ) {
+		$has_sub_items = count( (array) $menu_item['innerBlocks'] ) > 0;
 
 		$html .= '<li class="wp-block-navigation-menu-item ' . $colors['bg_css_classes'] . '"' . $colors['bg_inline_styles'] . '>' .
+			(
+				( $has_sub_items && ! $on_hover_mode )
+					? (
+						'<input
+							id="toggle-handler-' . $level . '-' . $key . '"
+							class="wp-block-navigation-menu-item__toggle-handler"
+							type="checkbox"
+						>' .
+						'<label
+							for="toggle-handler-' . $level . '-' . $key . '" 
+							class="wp-block-navigation-menu-item__toggle-for"
+						>'
+					)
+					: ''
+			) .
 			'<a
 				class="wp-block-navigation-menu-item__link ' . $colors['text_css_classes'] . '"
 				' . $colors['text_inline_styles'];
@@ -117,18 +136,21 @@ function build_navigation_menu_html( $block, $colors ) {
 		if ( isset( $menu_item['attrs']['opensInNewTab'] ) && true === $menu_item['attrs']['opensInNewTab'] ) {
 			$html .= ' target="_blank"  ';
 		}
-		// End appending HTML attributes to anchor tag.
 
 		// Start anchor tag content.
 		$html .= '>';
+
 		if ( isset( $menu_item['attrs']['label'] ) ) {
 			$html .= $menu_item['attrs']['label'];
 		}
 		$html .= '</a>';
 		// End anchor tag content.
 
-		if ( count( (array) $menu_item['innerBlocks'] ) > 0 ) {
-			$html .= build_navigation_menu_html( $menu_item, $colors );
+		$html .= ( $has_sub_items && ! $on_hover_mode ) ? '</label>' : '';
+
+		if ( $has_sub_items ) {
+			$level = $level + 1;
+			$html .= build_navigation_menu_html( $menu_item, $colors, $level );
 		}
 
 		$html .= '</li>';

--- a/packages/block-library/src/navigation-menu/inspector-control-menu-activation.js
+++ b/packages/block-library/src/navigation-menu/inspector-control-menu-activation.js
@@ -1,0 +1,32 @@
+/**
+ * External dependencies
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { RadioControl, PanelBody } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+export default ( { selected, onChange } ) => {
+	return (
+		<PanelBody title={ __( 'Dropdown Menu Activation' ) }>
+			<RadioControl
+				options={ [
+					{
+						label: __('Hover / Focus Event.' ),
+						value: 'onHover',
+					},
+					{
+						label: __('Click / Tap Event.' ),
+						value: 'onClick',
+					}
+				] }
+				selected={ selected }
+				onChange={ onChange }
+				label={ __( 'Dropdown menu activation' ) }
+				help={ __( 'Select the way of how the dropdown menu will be activated.' ) }
+			/>
+		</PanelBody>
+	)
+};

--- a/packages/block-library/src/navigation-menu/style.scss
+++ b/packages/block-library/src/navigation-menu/style.scss
@@ -20,22 +20,6 @@
 		li {
 			position: relative;
 			z-index: 1;
-
-			&:hover,
-			&:focus-within {
-				cursor: pointer;
-				z-index: 99999;
-			}
-
-			// Submenu Display
-			&:hover > ul,
-			&:focus-within > ul,
-			& ul:hover,
-			& ul:focus {
-				visibility: visible;
-				opacity: 1;
-				display: block;
-			}
 		}
 
 		& > li {
@@ -106,4 +90,22 @@
 		}
 	}
 
+	// Menu event activation.
+	&.is-activated-by-hover li {
+		&:hover,
+		&:focus-within {
+			cursor: pointer;
+			z-index: 99999;
+		}
+
+		// Submenu Display
+		&:hover > ul,
+		&:focus-within > ul,
+		& ul:hover,
+		& ul:focus {
+			visibility: visible;
+			opacity: 1;
+			display: block;
+		}
+	}
 }

--- a/packages/block-library/src/navigation-menu/style.scss
+++ b/packages/block-library/src/navigation-menu/style.scss
@@ -108,4 +108,24 @@
 			display: block;
 		}
 	}
+
+	&.is-activated-by-click li {
+		input.wp-block-navigation-menu-item__toggle-handler {
+			display: none;
+		}
+
+		label.wp-block-navigation-menu-item__toggle-for {
+			font-size: inherit;
+			display: block;
+			padding: 0;
+			margin: 0;
+			cursor: pointer;
+		}
+
+		input.wp-block-navigation-menu-item__toggle-handler:checked + label.wp-block-navigation-menu-item__toggle-for + ul {
+			visibility: visible;
+			opacity: 1;
+			display: block;
+		}
+	}
 }


### PR DESCRIPTION
## Description
This PR implements the ability to set the event which opens the dropdown menu in the front-end, adding a section in the inspector control.

Fixes https://github.com/WordPress/gutenberg/issues/18395

Notes:

* I'm not totally unconfident about the text defined on this block. Feedback is more than welcome!
* ~`onClick` should be handled also with js since it isn't possible with just CSS.~

## How has this been tested?
Once these changes are applied, you should be able to see the `Dropdown Menu Activation` block in the inspector control:

<img width="1033" alt="Screen Shot 2019-11-11 at 4 49 17 PM" src="https://user-images.githubusercontent.com/77539/68616161-3eeb2680-04a3-11ea-8b90-419fcf466426.png">

It allows changing the behavior of how the dropdown menu shows in the front-end through of the selected event: `hover` or `click`.


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
