### PR TITLE
Updates to Documentation

### DIFF
--- a/docs/contributors/getting-started.md
+++ b/docs/contributors/getting-started.md
@@ -17,6 +17,8 @@ If you don't have a local WordPress environment to load Gutenberg in, we can hel
 
 ## Local Environment
 
+### Using Docker
+
 The quickest way to get up and running is to use the provided Docker setup. If you don't already have it, you'll need to install Docker by following their instructions for [Windows 10 Pro](https://docs.docker.com/docker-for-windows/install/), [all other version of Windows](https://docs.docker.com/toolbox/toolbox_install_windows/), [macOS](https://docs.docker.com/docker-for-mac/install/), or [Linux](https://docs.docker.com/v17.12/install/linux/docker-ce/ubuntu/#install-using-the-convenience-script).
 
 Once Docker is installed and running, run this script to install WordPress, and build your local environment:
@@ -25,6 +27,7 @@ Once Docker is installed and running, run this script to install WordPress, and 
 npm run env install
 ```
 
+### Using an Existing Local WordPress Install
 WordPress will be installed in the `wordpress` directory, if you need to access WordPress core files directly, you can find them there.
 
 If you already have WordPress checked out in a different directory, you can use that installation, instead, by running these commands:
@@ -40,11 +43,15 @@ In Windows, you can set the `WP_DEVELOP_DIR` environment variable using the appr
 
     CMD: set WP_DEVELOP_DIR=/path/to/wordpress-develop
     PowerShell: $env:WP_DEVELOP_DIR = "/path/to/wordpress-develop"
+	
+### Access the Local WordPress Install
 
 The WordPress installation should be available at `http://localhost:8889` (**Username**: `admin`, **Password**: `password`).
 If this port is in use, you can override it using the `LOCAL_PORT` environment variable. For example, `export LOCAL_PORT=7777` will change the URL to `http://localhost:7777` . If you're running [e2e tests](/docs/contributors/testing-overview.md#end-to-end-testing), this change will be used correctly.
 
 To bring down this local WordPress instance later run `npm run env stop`. To bring it back up again, run `npm run env start`.
+
+### Toggling Debug Systems
 
 WordPress comes with specific [debug systems](https://wordpress.org/support/article/debugging-in-wordpress/) designed to simplify the process as well as standardize code across core, plugins and themes. It is possible to use environment variables (`LOCAL_WP_DEBUG` and `LOCAL_SCRIPT_DEBUG`) to update a site's configuration constants located in `wp-config.php` file. Both flags can be disabled at any time by running the following command:
 ```

--- a/docs/designers-developers/developers/tutorials/javascript/js-build-setup.md
+++ b/docs/designers-developers/developers/tutorials/javascript/js-build-setup.md
@@ -4,19 +4,23 @@ This page covers how to set up your development environment to use the ESNext an
 
 This documentation covers development for your plugin to work with the Gutenberg project (ie: the block editor). If you want to develop Gutenberg itself, see the [Getting Started](/docs/contributors/getting-started.md) documentation.
 
-Most browsers can not interpret or run ESNext and JSX syntaxes, so we use a transformation step to convert these syntaxes to code that browsers can understand.
+Most browsers cannot interpret or run ESNext and JSX syntaxes, so we use a transformation step to convert these syntaxes to code that browsers can understand.
 
-There are a few reasons to use ESNext and the extra step. First, it makes for simpler code that is easier to read and write. Using a transformation step allows for tools to optimize the code to work on the widest variety of browsers. Also, by using a build step you can organize your code into smaller modules and files that can be bundled together into a single download.
+There are a few reasons to use ESNext and this extra step of transformation:
+
+- It makes for simpler code that is easier to read and write. 
+- Using a transformation step allows for tools to optimize the code to work on the widest variety of browsers.
+- By using a build step you can organize your code into smaller modules and files that can be bundled together into a single download.
 
 There are different tools that can perform this transformation or build step; WordPress uses webpack and Babel.
 
-[webpack](https://webpack.js.org/) is a pluggable tool that processes JavaScript, creating a compiled bundle that runs in a browser. [Babel](https://babeljs.io/) transforms JavaScript from one format to another. You use Babel as a plugin to webpack to transform both ESNext and JSX to JavaScript.
+[webpack](https://webpack.js.org/) is a pluggable tool that processes JavaScript and creates a compiled bundle that runs in a browser. [Babel](https://babeljs.io/) transforms JavaScript from one format to another. You use Babel as a plugin to webpack to transform both ESNext and JSX to JavaScript.
 
-The [@wordpress/scripts](https://www.npmjs.com/package/@wordpress/scripts) package abstracts these libraries away to standardize and simplify development, so you won't need to handle the details for configuring those libraries. See the package documentation for configuration details.
+The [@wordpress/scripts](https://www.npmjs.com/package/@wordpress/scripts) package abstracts these libraries away to standardize and simplify development, so you won't need to handle the details for configuring webpack or babel. See the [@wordpress/scripts package documentation](https://developer.wordpress.org/block-editor/packages/packages-scripts/) for configuration details.
 
 ## Quick Start
 
-For a quick start, you can use one of the examples from the [Gutenberg Examples repository](https://github.com/wordpress/gutenberg-examples/). Each one of the `-esnext` directories contain the necessary files for working with ESNext and JSX.
+If you prefer a quick start, you can use one of the examples from the [Gutenberg Examples repository](https://github.com/wordpress/gutenberg-examples/) and skip below. Each one of the `-esnext` directories in the examples repository contain the necessary files for working with ESNext and JSX.
 
 ## Setup
 
@@ -24,7 +28,7 @@ Both webpack and Babel are tools written in JavaScript and run using [Node.js](h
 
 First, you need to set up Node.js for your development environment. The steps required depend on your operating system, if you have a package manager installed, setup can be as straightforward as:
 
-- Ubuntu: `apt install node`
+- Ubuntu: `apt install nodejs` & `apt install npm`
 - macOS: `brew install node`
 - Windows: `choco install node`
 
@@ -91,7 +95,7 @@ Also, if you look at package.json file it will include a new section:
 }
 ```
 
-## Webpack & Babel
+## Setting Up wp-scripts build
 
 The `@wordpress/scripts` package handles the dependencies and default configuration for webpack and Babel. The scripts package expects the source file to compile to be found at `src/index.js`, and will save the compiled output to `build/index.js`.
 
@@ -119,7 +123,7 @@ To configure npm to run a script, you use the scripts section in `package.json` 
 
 You can then run the build using: `npm run build`.
 
-After the build finishes, you will see the built file created at `build/index.js`. Enqueue this file in the admin screen as you would any JavaScript in WordPress, see [Step 2 in this tutorial](loading-javascript.md), and the block will load in the editor.
+After the build finishes, you will see the built file created at `build/index.js`. Enqueue this file in the admin screen as you would any JavaScript in WordPress, see [Step 2 Loading JavaScript](loading-javascript.md), and the block will load in the editor.
 
 ## Finishing Touches
 
@@ -148,7 +152,7 @@ Likewise, you do not need to include `node_modules` or any of the above configur
 
 ### Dependency Management
 
-Using wp-scripts ver 5.0.0+ build step will also produce a `index.asset.php` file that contains an array of dependencies and version number for your block. For our simple example above is something like:
+Using wp-scripts ver 5.0.0+ the build step will also produce a `index.asset.php` file that contains an array of dependencies and version number for your block. For our simple example above is something like:
 `array('dependencies' => array('wp-element', 'wp-polyfill'), 'version' => 'fc93c4a9675c108725227db345898bcc');`
 
 Here is how to use this asset file to automatically set the dependency list for enqueuing the script. This prevents having to manually update the dependencies, it will be created based on the package imports used within your block.

--- a/docs/designers-developers/developers/tutorials/javascript/js-build-setup.md
+++ b/docs/designers-developers/developers/tutorials/javascript/js-build-setup.md
@@ -28,7 +28,7 @@ Both webpack and Babel are tools written in JavaScript and run using [Node.js](h
 
 First, you need to set up Node.js for your development environment. The steps required depend on your operating system, if you have a package manager installed, setup can be as straightforward as:
 
-- Ubuntu: `apt install nodejs` & `apt install npm`
+- Ubuntu: `apt install nodejs npm`
 - macOS: `brew install node`
 - Windows: `choco install node`
 


### PR DESCRIPTION
I've made changes to contributors/getting-started.md and /developers/tutorials/javascript/js-build-setup.md.

getting-started.md
- Added subheadings under Local Environment to clarify instructions: "Using Docker", "Using an Existing Local WordPress Install", "Access the Local WordPress Install" and "Toggling Debug Systems".

js-build-setup.md
- Minor spelling/grammar improvements.
- Broke out inline list of advantages of ESNext into a separate list
- Changed a reference to "those libraries" to "webpack or babel" to clarify.
- Added a link to the @wordpress/scripts documentation (previously referenced but no link).
- Attempted to clarify that the "Quick Start" is not what follows but following directions in examples.
- Ubuntu will not install node using `apt install node`, updated to `apt install nodejs` & `apt install npm`
- Changed "Webpack & Babel" heading to "Setting Up wp-scripts build" to clarify the subject covered.
- Changed reference to "in this tutorial" to actual tutorial name: "Loading JavaScript" to clarify.