### PR TITLE
Tweak RadioControl spacing for consistent UI

### DIFF
--- a/packages/components/src/radio-control/style.scss
+++ b/packages/components/src/radio-control/style.scss
@@ -5,6 +5,10 @@
 	.components-base-control__help {
 		margin-top: 0;
 	}
+
+	.components-base-control__field {
+		margin-bottom: 4px;
+	}
 }
 
 .components-radio-control__option:not(:last-child) {


### PR DESCRIPTION
## Description
Closes #17929 by tweaking the margin-bottom of the `.components-base-control__field` within the RadioControl to ensure the same amount of spacing exists below the RadioControl as any other control within the Settings Sidebar.

## How has this been tested?
Tested in all supported browsers.

## Screenshots <!-- if applicable -->
Before:
![before](https://user-images.githubusercontent.com/1813435/68623569-ce440a00-04a2-11ea-8be7-6c02d46251ca.png)

After: 
![after](https://user-images.githubusercontent.com/1813435/68623566-cbe1b000-04a2-11ea-88f2-741824698537.png)

## Types of changes
Bug fix, scss only.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->