### PR TITLE
Fix modal component usage example code

### DIFF
--- a/packages/components/src/modal/README.md
+++ b/packages/components/src/modal/README.md
@@ -120,21 +120,21 @@ The following example shows you how to properly implement a modal. For the modal
 
 ```jsx
 import { Button, Modal } from '@wordpress/components';
-import { useState } from '@wordpress/compose';
+import { useState } from '@wordpress/element';
 
 const MyModal = () => {
 	const [ isOpen, setOpen ] = useState( false );
 	const openModal = () => setOpen( true );
 	const closeModal = () => setOpen( false );
-	
+
 	return (
 		<>
 			<Button isDefault onClick={ openModal }>Open Modal</Button>
 			{ isOpen && (
 				<Modal
 					title="This is my modal"
-					onRequestClose={ closeModal ) }>
-					<Button isDefault onClick={ closeModal ) }>
+					onRequestClose={ closeModal }>
+					<Button isDefault onClick={ closeModal }>
 						My custom close button
 					</Button>
 				</Modal>


### PR DESCRIPTION
## Description
This PR fixes some issues relate to the example [usage code](https://github.com/WordPress/gutenberg/blob/master/packages/components/src/modal/README.md#usage-1) for Modal component.

## Issues
- import `useState` from `@wordpress/compose`, which should be `@wordpress/element`. 
- There are two lines contain `{ closeModal ) }` that contains extra close parenthesis. 

## Types of changes
- import `useState` from `@wordpress/element`
- remove extra close parenthesis

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
