### PR TITLE
Add support for React defaultValue prop

### DIFF
--- a/packages/components/src/text-control/index.js
+++ b/packages/components/src/text-control/index.js
@@ -8,13 +8,14 @@ import { withInstanceId } from '@wordpress/compose';
  */
 import BaseControl from '../base-control';
 
-function TextControl( { label, hideLabelFromVision, value, help, className, instanceId, onChange, type = 'text', ...props } ) {
+function TextControl( { defaultValue, label, hideLabelFromVision, value, help, className, instanceId, onChange, type = 'text', ...props } ) {
 	const id = `inspector-text-control-${ instanceId }`;
 	const onChangeValue = ( event ) => onChange( event.target.value );
 
 	return (
 		<BaseControl label={ label } hideLabelFromVision={ hideLabelFromVision } id={ id } help={ help } className={ className }>
 			<input className="components-text-control__input"
+				defaultValue={ defaultValue }
 				type={ type }
 				id={ id }
 				value={ value }


### PR DESCRIPTION
Add support for default value via React defaultValue prop to fill in the controlled input initial value without the need to use withState component or React hook/class.

More here: [https://reactjs.org/docs/uncontrolled-components.html#default-values](https://reactjs.org/docs/uncontrolled-components.html#default-values)

## Description
Added defaultValue prop to the input field.

## Types of changes
New feature (non-breaking change which adds functionality)
