### PR TITLE
eslint-plugin: Include WordPress plugin in React ruleset

### DIFF
--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Master
+
+### Bug Fixes
+
+- The React ruleset now correctly references the WordPress ESLint plugin, resolving an error about an unfound rule.
+
 ## 3.0.0 (2019-08-29)
 
 ### Breaking Changes

--- a/packages/eslint-plugin/configs/react.js
+++ b/packages/eslint-plugin/configs/react.js
@@ -8,6 +8,7 @@ module.exports = {
 		},
 	},
 	plugins: [
+		'@wordpress',
 		'react',
 		'react-hooks',
 	],


### PR DESCRIPTION
Fixes #17635

This pull request resolves an issue where using the React ruleset may cause an error, since the configured rules references a custom WordPress rule, without also including the plugin in the `plugins` array. Any reference to our custom rules in rulesets must also include `plugins: [ '@wordpress' ]`, for when those rulesets are used in isolation.

See `custom.js`:

https://github.com/WordPress/gutenberg/blob/21023095b6671665f85cf49188fbc049421743d2/packages/eslint-plugin/configs/custom.js#L2-L4

**Testing Instructions:**

Repeat steps to reproduce from #17635, verifying that no error occurs.