### PR TITLE
Transforms: Shortcode: Support `isMatch` predicate

### DIFF
--- a/docs/designers-developers/developers/block-api/block-registration.md
+++ b/docs/designers-developers/developers/block-api/block-registration.md
@@ -439,6 +439,24 @@ transforms: {
 ```
 {% end %}
 
+In the case of shortcode transforms, `isMatch` receives shortcode attributes per the [Shortcode API](https://codex.wordpress.org/Shortcode_API):
+
+{% codetabs %}
+{% ES5 %}
+```js
+isMatch: function( attributes ) {
+	return attributes.named.id === 'my-id';
+},
+```
+{% ESNext %}
+```js
+isMatch( { named: { id } } ) {
+	return id === 'my-id';
+},
+```
+{% end %}
+
+
 To control the priority with which a transform is applied, define a `priority` numeric property on your transform object, where a lower value will take precedence over higher values. This behaves much like a [WordPress hook](https://codex.wordpress.org/Plugin_API#Hook_to_WordPress). Like hooks, the default priority is `10` when not otherwise set.
 
 A file can be dropped into the editor and converted into a block with a matching transform.

--- a/packages/blocks/src/api/raw-handling/shortcode-converter.js
+++ b/packages/blocks/src/api/raw-handling/shortcode-converter.js
@@ -15,11 +15,12 @@ import { createBlock, getBlockTransforms, findTransform } from '../factory';
 import { getBlockType } from '../registration';
 import { getBlockAttributes } from '../parser';
 
-function segmentHTMLToShortcodeBlock( HTML, lastIndex = 0 ) {
+function segmentHTMLToShortcodeBlock( HTML, lastIndex = 0, excludedBlockNames = [] ) {
 	// Get all matches.
 	const transformsFrom = getBlockTransforms( 'from' );
 
 	const transformation = findTransform( transformsFrom, ( transform ) => (
+		excludedBlockNames.indexOf( transform.blockName ) === -1 &&
 		transform.type === 'shortcode' &&
 		some( castArray( transform.tag ), ( tag ) => regexp( tag ).test( HTML ) )
 	) );
@@ -32,6 +33,7 @@ function segmentHTMLToShortcodeBlock( HTML, lastIndex = 0 ) {
 	const transformTag = find( transformTags, ( tag ) => regexp( tag ).test( HTML ) );
 
 	let match;
+	const previousIndex = lastIndex;
 
 	if ( ( match = next( transformTag, HTML, lastIndex ) ) ) {
 		const beforeHTML = HTML.substr( 0, match.index );
@@ -47,6 +49,22 @@ function segmentHTMLToShortcodeBlock( HTML, lastIndex = 0 ) {
 			! /(\n|<p>)\s*$/.test( beforeHTML )
 		) {
 			return segmentHTMLToShortcodeBlock( HTML, lastIndex );
+		}
+
+		// If a transformation's `isMatch` predicate fails for the inbound
+		// shortcode, try again by excluding the current block type.
+		//
+		// This is the only call to `segmentHTMLToShortcodeBlock` that should
+		// ever carry over `excludedBlockNames`. Other calls in the module
+		// should skip that argument as a way to reset the exclusion state, so
+		// that one `isMatch` fail in an HTML fragment doesn't prevent any
+		// valid matches in subsequent fragments.
+		if ( transformation.isMatch && ! transformation.isMatch( match.shortcode.attrs ) ) {
+			return segmentHTMLToShortcodeBlock(
+				HTML,
+				previousIndex,
+				[ ...excludedBlockNames, transformation.blockName ],
+			);
 		}
 
 		const attributes = mapValues(

--- a/test/integration/blocks-raw-handling.test.js
+++ b/test/integration/blocks-raw-handling.test.js
@@ -281,13 +281,17 @@ describe( 'Blocks raw handling', () => {
 			'markdown',
 			'wordpress',
 			'gutenberg',
-			'caption-shortcode',
 			'shortcode-matching',
 		].forEach( ( type ) => {
 			it( type, () => {
 				const HTML = readFile( path.join( __dirname, `fixtures/${ type }-in.html` ) );
 				const plainText = readFile( path.join( __dirname, `fixtures/${ type }-in.txt` ) );
 				const output = readFile( path.join( __dirname, `fixtures/${ type }-out.html` ) );
+
+				if ( ! ( HTML || plainText ) || ! output ) {
+					throw new Error( `Expected fixtures for type ${ type }` );
+				}
+
 				const converted = pasteHandler( { HTML, plainText, canUserUseUnfilteredHTML: true } );
 				const serialized = typeof converted === 'string' ? converted : serialize( converted );
 

--- a/test/integration/blocks-raw-handling.test.js
+++ b/test/integration/blocks-raw-handling.test.js
@@ -11,6 +11,7 @@ import {
 	getBlockContent,
 	pasteHandler,
 	rawHandler,
+	registerBlockType,
 	serialize,
 } from '@wordpress/blocks';
 import { registerCoreBlocks } from '@wordpress/block-library';
@@ -24,6 +25,38 @@ describe( 'Blocks raw handling', () => {
 		// Load all hooks that modify blocks
 		require( '../../packages/editor/src/hooks' );
 		registerCoreBlocks();
+		registerBlockType( 'test/gallery', {
+			title: 'Test Gallery',
+			category: 'common',
+			attributes: {
+				ids: {
+					type: 'array',
+					default: [],
+				},
+			},
+			transforms: {
+				from: [
+					{
+						type: 'shortcode',
+						tag: 'gallery',
+						isMatch( { named: { ids } } ) {
+							return ids.indexOf( 42 ) > -1;
+						},
+						attributes: {
+							ids: {
+								type: 'array',
+								shortcode: ( { named: { ids } } ) =>
+									ids.split( ',' ).map( ( id ) => (
+										parseInt( id, 10 )
+									) ),
+							},
+						},
+						priority: 9,
+					},
+				],
+			},
+			save: () => null,
+		} );
 	} );
 
 	it( 'should filter inline content', () => {
@@ -249,6 +282,7 @@ describe( 'Blocks raw handling', () => {
 			'wordpress',
 			'gutenberg',
 			'caption-shortcode',
+			'shortcode-matching',
 		].forEach( ( type ) => {
 			it( type, () => {
 				const HTML = readFile( path.join( __dirname, `fixtures/${ type }-in.html` ) );

--- a/test/integration/fixtures/shortcode-matching-in.html
+++ b/test/integration/fixtures/shortcode-matching-in.html
@@ -1,0 +1,3 @@
+<p>[gallery ids="40,41,42"]</p>
+<p>[gallery ids="1000"]</p>
+<p>[gallery ids="42"]</p>

--- a/test/integration/fixtures/shortcode-matching-out.html
+++ b/test/integration/fixtures/shortcode-matching-out.html
@@ -1,0 +1,7 @@
+<!-- wp:test/gallery {"ids":[40,41,42]} /-->
+
+<!-- wp:gallery {"ids":[1000],"columns":3,"linkTo":"attachment"} -->
+<figure class="wp-block-gallery columns-3 is-cropped"><ul class="blocks-gallery-grid"><li class="blocks-gallery-item"><figure><img data-id="1000" class="wp-image-1000"/></figure></li></ul></figure>
+<!-- /wp:gallery -->
+
+<!-- wp:test/gallery {"ids":[42]} /-->


### PR DESCRIPTION
## Description

Fixes #10674

## How has this been tested?

Expanded unit tests for shortcode conversion.

## Types of changes
Enhancement, API.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
