### PR TITLE
Colors Selector: fix applying inline styles

### DIFF
--- a/packages/block-library/src/navigation-menu/block-colors-selector.js
+++ b/packages/block-library/src/navigation-menu/block-colors-selector.js
@@ -25,15 +25,10 @@ const ColorSelectorSVGIcon = () => (
  * @return {*} React Icon component.
  */
 const ColorSelectorIcon = ( { backgroundColor, textColor, backgroundColorValue, textColorValue } ) => {
-	const iconStyle = {};
-
-	if ( backgroundColorValue ) {
-		iconStyle.backgroundColor = backgroundColorValue;
-	}
-
-	if ( textColorValue ) {
-		iconStyle.color = textColorValue;
-	}
+	const iconStyle = {
+		...( backgroundColorValue && { backgroundColor: backgroundColorValue } ),
+		...( textColorValue && { color: textColorValue } ),
+	};
 
 	const iconClasses = classnames( 'block-library-colors-selector__state-selection', {
 		'has-background-color': backgroundColor && backgroundColor.color,

--- a/packages/block-library/src/navigation-menu/edit.js
+++ b/packages/block-library/src/navigation-menu/edit.js
@@ -209,6 +209,8 @@ function NavigationMenu( {
 				<BlockColorsStyleSelector
 					backgroundColor={ backgroundColor }
 					textColor={ textColor }
+					backgroundColorValue={ attributes.backgroundColorValue }
+					textColorValue={ attributes.textColorValue }
 					onColorChange={ setColorType }
 				/>
 			</BlockControls>


### PR DESCRIPTION
## Description
This PR fixes an issue that happens when a new text and/or background color is selected. The Colors selector Icon doesn't reflect these changes. 

## How has this been tested?
Edit a navigation menu selecting different colors. The `Aa` should change according to these colores.

## Screenshots <!-- if applicable -->

<img width="580" alt="Screen Shot 2019-11-12 at 4 40 01 PM" src="https://user-images.githubusercontent.com/77539/68704489-23e3e980-056b-11ea-8354-487e7cce8d89.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->