### PR TITLE
Navigation: Have submenu inherit background color

### DIFF
--- a/packages/block-library/src/navigation-menu/style.scss
+++ b/packages/block-library/src/navigation-menu/style.scss
@@ -61,7 +61,7 @@
 		& > li > ul {
 			margin: 0;
 			position: absolute;
-			background: #fff;
+			background: inherit;
 			box-shadow: 0 0 8px 2px rgba(0, 0, 0, 0.2);
 			left: 0;
 			top: 100%;

--- a/packages/block-library/src/navigation-menu/style.scss
+++ b/packages/block-library/src/navigation-menu/style.scss
@@ -61,7 +61,7 @@
 		& > li > ul {
 			margin: 0;
 			position: absolute;
-			background: inherit;
+			background: #fff;
 			box-shadow: 0 0 8px 2px rgba(0, 0, 0, 0.2);
 			left: 0;
 			top: 100%;
@@ -74,6 +74,10 @@
 				width: 100%;
 			}
 		}
+	}
+
+	.has-background-color + ul {
+		background: inherit;
 	}
 
 	// Menu Link


### PR DESCRIPTION
Fixes a bug in Twenty Twenty where list items are indented with margins, revealing the white background color of submenu `ul` elements.

## Screenshots <!-- if applicable -->
**Before:**
![Screen Shot 2019-11-12 at 2 12 49 PM](https://user-images.githubusercontent.com/1398304/68715420-d1003700-0556-11ea-999e-ecf83051aa70.png)

**After:**
![Screen Shot 2019-11-12 at 2 13 02 PM](https://user-images.githubusercontent.com/1398304/68715421-d198cd80-0556-11ea-9f80-68fb5f2ebac0.png)

## Types of changes
CSS-only bug fix (non-breaking change which fixes an issue)