### PR TITLE
Fix full-wide on mobile regression.

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -565,8 +565,13 @@
 		}
 
 		> .block-editor-block-list__block-edit {
-			margin-left: -$block-padding - $block-padding - $block-side-ui-width - $border-width - $border-width;
-			margin-right: -$block-padding - $block-padding - $block-side-ui-width - $border-width - $border-width;
+			margin-left: -$block-padding;
+			margin-right: -$block-padding;
+
+			@include break-small() {
+				margin-left: -$block-padding - $block-padding - $block-side-ui-width - $border-width - $border-width;
+				margin-right: -$block-padding - $block-padding - $block-side-ui-width - $border-width - $border-width;
+			}
 		}
 
 		> .block-editor-block-list__block-edit::before {


### PR DESCRIPTION
This is a followup to a regression found in #17875, specifically https://github.com/WordPress/gutenberg/pull/17877#discussion_r345191007.

The PR refactored horizontal margins, including for full-wide blocks. As a result, full-wide blocks would, on the mboile breakpoint, receive too much negative margin.

This PR addresses that.

To test, insert _any_ full wide block, though it's easier to see with the table block as it gets more visibly cropped. Test in TwentyTwenty and with vanilla styles. Test both on mobile (<600px) breaktpoint, and above. There should be no cropping, and no horizontal scrollbars. 

However please note that there is an issue with TwentyNineteen editor styles as a result of the PR, and those need to be fixed separately as they need new styles. That is trac'ed here: https://core.trac.wordpress.org/ticket/48526

Screenshots:

<img width="869" alt="Screenshot 2019-11-13 at 09 14 49" src="https://user-images.githubusercontent.com/1204802/68745054-32c3ae00-05f6-11ea-9994-555d8cbf81f4.png">

<img width="539" alt="Screenshot 2019-11-13 at 09 14 57" src="https://user-images.githubusercontent.com/1204802/68745056-348d7180-05f6-11ea-8b76-be27c6cbdc16.png">
