### PR TITLE
Update getting-started.md

### DIFF
--- a/docs/contributors/getting-started.md
+++ b/docs/contributors/getting-started.md
@@ -52,6 +52,10 @@ LOCAL_SCRIPT_DEBUG=false LOCAL_WP_DEBUG=false npm run env install
 ```
 By default, both flags will be set to `true`.
 
+### Troubleshooting
+
+You might find yourself stuck on a screen stating that "you are running WordPress without JavaScript and CSS files". If you tried installing WordPress via `npm run env install`, it probably means that something went wrong during the process. To fix it, try removing the `/wordpress` folder and running `npm run env install` again.
+
 ## On A Remote Server
 
 Open a terminal (or if on Windows, a command prompt) and navigate to the repository you cloned. Now type `npm install` to get the dependencies all set up. Once that finishes, you can type `npm run build`. You can now upload the entire repository to your `wp-content/plugins` directory on your web server and activate the plugin from the WordPress admin.


### PR DESCRIPTION
All the setup seemed to complete successfully, yet I was stuck on this screen:

`http://localhost:8889`
![image](https://user-images.githubusercontent.com/1451471/68761768-108d5880-0615-11ea-85a7-444f67681838.png)

Removing the `/wordpress` folder and re-running `npm run env install` did the trick. Thought this tip might be helpful for other folks.

/cc @gziolo @getdave 