### PR TITLE
Colors Selector: set icon background-color

### DIFF
--- a/packages/block-library/src/navigation-menu/block-colors-selector.js
+++ b/packages/block-library/src/navigation-menu/block-colors-selector.js
@@ -25,12 +25,6 @@ const ColorSelectorSVGIcon = () => (
  * @return {*} React Icon component.
  */
 const ColorSelectorIcon = ( { textColor, textColorValue } ) => {
-	const iconStyle = {};
-
-	if ( textColorValue ) {
-		iconStyle.color = textColorValue;
-	}
-
 	const iconClasses = classnames( 'block-library-colors-selector__state-selection', {
 		'has-text-color': textColor && textColor.color,
 		[ textColor.class ]: textColor && textColor.class,
@@ -38,7 +32,10 @@ const ColorSelectorIcon = ( { textColor, textColorValue } ) => {
 
 	return (
 		<div className="block-library-colors-selector__icon-container">
-			<div className={ iconClasses } style={ iconStyle }>
+			<div
+				className={ iconClasses }
+				style={ { ...( textColorValue && { color: textColorValue } ) } }
+			>
 				<ColorSelectorSVGIcon />
 			</div>
 		</div>

--- a/packages/block-library/src/navigation-menu/block-colors-selector.js
+++ b/packages/block-library/src/navigation-menu/block-colors-selector.js
@@ -25,7 +25,9 @@ const ColorSelectorSVGIcon = () => (
  * @return {*} React Icon component.
  */
 const ColorSelectorIcon = ( { textColor, textColorValue } ) => {
-	const iconClasses = classnames( 'block-library-colors-selector__state-selection', {
+	const iconClasses = classnames(
+		'block-library-colors-selector__state-selection',
+		'editor-styles-wrapper', {
 		'has-text-color': textColor && textColor.color,
 		[ textColor.class ]: textColor && textColor.class,
 	} );

--- a/packages/block-library/src/navigation-menu/block-colors-selector.js
+++ b/packages/block-library/src/navigation-menu/block-colors-selector.js
@@ -28,9 +28,10 @@ const ColorSelectorIcon = ( { textColor, textColorValue } ) => {
 	const iconClasses = classnames(
 		'block-library-colors-selector__state-selection',
 		'editor-styles-wrapper', {
-		'has-text-color': textColor && textColor.color,
-		[ textColor.class ]: textColor && textColor.class,
-	} );
+			'has-text-color': textColor && textColor.color,
+			[ textColor.class ]: textColor && textColor.class,
+		}
+	);
 
 	return (
 		<div className="block-library-colors-selector__icon-container">

--- a/packages/block-library/src/navigation-menu/editor.scss
+++ b/packages/block-library/src/navigation-menu/editor.scss
@@ -123,8 +123,11 @@ $colors-selector-size: 22px;
 		padding: 2px;
 
 		// Styling icon color.
-		> svg {
-			color: inherit;
+		&.has-text-color {
+			> svg,
+			> svg path {
+				color: inherit;
+			}
 		}
 	}
 }

--- a/packages/block-library/src/navigation-menu/editor.scss
+++ b/packages/block-library/src/navigation-menu/editor.scss
@@ -121,6 +121,11 @@ $colors-selector-size: 22px;
 		min-height: $colors-selector-size;
 		line-height: ($colors-selector-size - 2);
 		padding: 2px;
+
+		// Styling icon color.
+		> svg {
+			color: inherit;
+		}
 	}
 }
 


### PR DESCRIPTION
## Description

This PR just sets the background color defined by the `editor-styles-wrapper` CSS class as an attempt to be more consistent with the theme styles.


## How has this been tested?

Switching the theme the colors selector icon should get the background defined by it. 

## Screenshots <!-- if applicable -->

### Twenty twenty
<img width="732" alt="Screen Shot 2019-11-13 at 3 18 03 PM" src="https://user-images.githubusercontent.com/77539/68791853-e9d91d00-0628-11ea-87c8-4dccdc213e60.png">

### Twenty twelve
<img width="752" alt="Screen Shot 2019-11-13 at 3 19 38 PM" src="https://user-images.githubusercontent.com/77539/68791931-23118d00-0629-11ea-94a3-dc69973098da.png">

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
