### PR TITLE
Removes background shadow on drop down menu

### DIFF
--- a/packages/block-library/src/navigation-menu/style.scss
+++ b/packages/block-library/src/navigation-menu/style.scss
@@ -62,7 +62,6 @@
 			margin: 0;
 			position: absolute;
 			background: #fff;
-			box-shadow: 0 0 8px 2px rgba(0, 0, 0, 0.2);
 			left: 0;
 			top: 100%;
 			min-width: max-content;


### PR DESCRIPTION
Let's strip back the menu to simplest form for now as then themes can style dropdowns. This is part of a few smaller fixes bringing in for menu styling.