### PR TITLE
Link Control: fix setting rich-text placeholder

### DIFF
--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -3,9 +3,10 @@
 	min-width: $modal-min-width;
 }
 
+// LinkControl popover.
 .block-editor-link-control__search .block-editor-link-control__search-input {
-	// Specificity overide
-	&.block-editor-link-control__search-input > input[type="text"] {
+	// Specificity override.
+	&.block-editor-link-control__search-input input[type="text"] {
 		width: calc(100% - #{$grid-size-large*2});
 		display: block;
 		padding: 11px $grid-size-large;

--- a/packages/block-library/src/navigation-menu-item/editor.scss
+++ b/packages/block-library/src/navigation-menu-item/editor.scss
@@ -75,7 +75,7 @@
 	}
 
 	.block-editor-rich-text__editable.is-selected:not(.keep-placeholder-on-focus):not(:focus) [data-rich-text-placeholder]::after {
-		display: inherit;
+		display: inline-block;
 	}
 }
 


### PR DESCRIPTION
## Description
~We need to make stronger the CSS rule which overrides the styles for the `<URLInput >` block properly. It's doable prefixing the rule with the `.components-popover` CSS class.~

After this change 8e13521 is mandatory to remove the `>` from the CSS rule to make it work, since it is not a straightforward child of the CSS class anymore.


<!-- Please describe what you have changed or added -->

## How has this been tested?

Testing with a navigation menu, confirm that the link popover is broken when the item doesn't have defined a link:

<img src="https://user-images.githubusercontent.com/77539/68800083-2b24f900-0638-11ea-8a62-37e771a05a33.png" width="400px" />

Applying this change, the popover should look good again:

<img src="https://user-images.githubusercontent.com/77539/68803854-47786400-063f-11ea-9560-b6a87d973d79.png" width="400px" />

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
