### PR TITLE
Add a backward compatibility document

### DIFF
--- a/docs/designers-developers/developers/backward-compatibility/README.md
+++ b/docs/designers-developers/developers/backward-compatibility/README.md
@@ -1,1 +1,57 @@
 # Backward Compatibility
+
+Gutenberg follows the WordPress backwards compatibility principles. This means Backward compatibility for producation public API is guaranteed. In some rare occasions breaking backward compatibility is unavoidable, in that case, the breakage should be as small as possible and the breakage should be documented as clearly as possible to third-party developpers using devnotes.
+
+## What qualifies as a production public API:
+
+Gutenberg code base is compased of two different types of packages: 
+ - **production packages**: these are packages that are shipped in WordPress scripts (example: wp-components, wp-editor...).
+ - **development packages**: these are made of developper tools that can be used by third-party developpers to lint, test, format and build their themes and plugins (example: @wordpress/scrips, @wordpress/env...). Typically, these are consumed as npm dependencies in third-party projects.
+
+ Backward compatibility guarantee only applies to the production packages as updates happen through WordPress upgrades.
+ 
+ Production packages use the `wp` global variable to provide APIs to third-party developpers. These APIs can be JavaScript functions, variables and React components.
+
+### How to guarantee backward compatibility for a JavaScript function
+
+* The name of the function should not change.
+* The order of the arguments of the function should not change.
+* The function's returned value type should not change.
+* Changes to arguments (new arguments, modification of semantics) is possible if we guarantee that all previous calls are still possible.
+
+### How to guarantee backward compatibility for a React Component
+
+* The name of the component should not change.
+* The props of the components should not be removed.
+* Existing prop values should continue to be supported. If a component accept a function as prop, we can update the component to accept a new type for the same prop, but it shouldn't break existing usage.
+* Adding new props is allowed.
+* React Context dependencies can only be added or removed if we ensure the previous context contract is not breaking.
+* Classnames, DOM nodes used inside the tree of the component are not considered part of the public API and can be modified. That said, changes to these should be done with caution as it can affect the styling. When classes need to be renamed, if possible keep the old ones. When possible, document these changes and write a devnote about the changes.
+
+### How to guarantee backward compatibility for a Block
+
+* Existing usage of the block should not break or be marked as invalid when the editor is loaded.
+* The styling of the existing blocks should be guaranteed.
+* Markup changes should be limited to the minimum but If a block need to change its saved markup making previous versions invalid, a **deprecated version** for the block should be added.
+
+## Deprecations
+
+As the project evolves, flaws to existing APIs are discovered, or updates are required to support new features. When this happens, we try to guarantee that existing APIs don't break and build new alternative APIs.
+
+To encourage third-party developpers to adopt the new APIs instead, we can use the **deprecated** helper to show a message explaining the deprecation and proposing the alternativewhenever the old API is used.
+
+## Dev Notes
+
+Dev Notes are posts published in the make/core site prior to WordPress releases to inform third-party developpers about important changes to the developper APIs, these changes can include:
+* Promote new APIs.
+* Explain how some changes to existing APIs might affect existing plugins and themes (Example: classname changes...)
+* When breaking backward compatibility is unavoidable, explain the reasons and the migration flow.
+* When important deprecations are introduced (even without breakage), explain why and how third-party developpers can update their code base in consequence.
+
+### Dev Note Workflow
+
+- When working on Pull-request and the need for a dev-note is noted/discovered, add the **Needs Dev Note** label to the PR.
+- If possible, add a comment to the PR explaining why the Dev Note is needed.
+- When the first beta of the next WordPress release is shipped, go throught the list of merged PRs included in this release and tagged with the **Needs Dev Note** label.
+- For each one of these PRs, write a Dev Note, coordinate with the WordPress release leads to publish the dev note.
+- Once the dev note for a PR is published, remove the **Needs Dev Note** label from the PR.

--- a/docs/designers-developers/developers/backward-compatibility/README.md
+++ b/docs/designers-developers/developers/backward-compatibility/README.md
@@ -52,7 +52,7 @@ To encourage third-party developers to adopt the new APIs instead, we can use th
 
 Dev notes are [posts published on the make/core site](https://make.wordpress.org/core/tag/dev-notes/) prior to WordPress releases to inform third-party developers about important changes to the developer APIs, these changes can include:
 * New APIs.
-* Explain how some changes to existing APIs might affect existing plugins and themes (Example: classname changes...)
+* Changes to existing APIs that might affect existing plugins and themes. (Example: classname changes...)
 * When breaking backward compatibility is unavoidable, explain the reasons and the migration flow.
 * When important deprecations are introduced (even without breakage), explain why and how third-party developers can update their code base in consequence.
 

--- a/docs/designers-developers/developers/backward-compatibility/README.md
+++ b/docs/designers-developers/developers/backward-compatibility/README.md
@@ -26,7 +26,7 @@ Production packages use the `wp` global variable to provide APIs to third-party 
 
 * The name of the component should not change.
 * The props of the component should not be removed.
-* Existing prop values should continue to be supported. If a component accepts a function as prop, we can update the component to accept a new type for the same prop, but it shouldn't break existing usage.
+* Existing prop values should continue to be supported. If a component accepts a function as a prop, we can update the component to accept a new type for the same prop, but it shouldn't break existing usage.
 * Adding new props is allowed.
 * React Context dependencies can only be added or removed if we ensure the previous context contract is not breaking.
 

--- a/docs/designers-developers/developers/backward-compatibility/README.md
+++ b/docs/designers-developers/developers/backward-compatibility/README.md
@@ -54,7 +54,7 @@ Dev notes are [posts published on the make/core site](https://make.wordpress.org
 * New APIs.
 * Changes to existing APIs that might affect existing plugins and themes. (Example: classname changes...)
 * Unavoidable backward compatibility breakage, with reasoning and migration flows.
-* When important deprecations are introduced (even without breakage), explain why and how third-party developers can update their code base in consequence.
+* Important deprecations (even without breakage), with reasoning and migration flows.
 
 ### Dev Note Workflow
 

--- a/docs/designers-developers/developers/backward-compatibility/README.md
+++ b/docs/designers-developers/developers/backward-compatibility/README.md
@@ -53,7 +53,7 @@ To encourage third-party developers to adopt the new APIs instead, we can use th
 Dev notes are [posts published on the make/core site](https://make.wordpress.org/core/tag/dev-notes/) prior to WordPress releases to inform third-party developers about important changes to the developer APIs, these changes can include:
 * New APIs.
 * Changes to existing APIs that might affect existing plugins and themes. (Example: classname changes...)
-* When breaking backward compatibility is unavoidable, explain the reasons and the migration flow.
+* Unavoidable backward compatibility breakage, with reasoning and migration flows.
 * When important deprecations are introduced (even without breakage), explain why and how third-party developers can update their code base in consequence.
 
 ### Dev Note Workflow

--- a/docs/designers-developers/developers/backward-compatibility/README.md
+++ b/docs/designers-developers/developers/backward-compatibility/README.md
@@ -8,7 +8,7 @@ The Gutenberg code base is composed of two different types of packages:
  - **production packages**: these are packages that are shipped as WordPress scripts (example: wp-components, wp-editor...).
  - **development packages**: these are made out of developer tools that can be used by third-party developers to lint, test, format and build their themes and plugins (example: @wordpress/scrips, @wordpress/env...). Typically, these are consumed as npm dependencies in third-party projects.
 
- Backward compatibility guarantee only applies to the production packages as updates happen through WordPress upgrades.
+Backward compatibility guarantee only applies to the production packages as updates happen through WordPress upgrades.
  
  Production packages use the `wp` global variable to provide APIs to third-party developpers. These APIs can be JavaScript functions, variables and React components.
 

--- a/docs/designers-developers/developers/backward-compatibility/README.md
+++ b/docs/designers-developers/developers/backward-compatibility/README.md
@@ -6,7 +6,7 @@ Gutenberg follows the WordPress backward compatibility principles. This means ba
 
 The Gutenberg code base is composed of two different types of packages: 
  - **production packages**: these are packages that are shipped as WordPress scripts (example: wp-components, wp-editor...).
- - **development packages**: these are made of developper tools that can be used by third-party developpers to lint, test, format and build their themes and plugins (example: @wordpress/scrips, @wordpress/env...). Typically, these are consumed as npm dependencies in third-party projects.
+ - **development packages**: these are made out of developer tools that can be used by third-party developers to lint, test, format and build their themes and plugins (example: @wordpress/scrips, @wordpress/env...). Typically, these are consumed as npm dependencies in third-party projects.
 
  Backward compatibility guarantee only applies to the production packages as updates happen through WordPress upgrades.
  

--- a/docs/designers-developers/developers/backward-compatibility/README.md
+++ b/docs/designers-developers/developers/backward-compatibility/README.md
@@ -52,6 +52,6 @@ Dev notes are [posts published on the make/core site](https://make.wordpress.org
 
 - When working on a pull request and the need for a dev note is discovered, add the **Needs Dev Note** label to the PR.
 - If possible, add a comment to the PR explaining why the dev note is needed.
-- When the first beta of the next WordPress release is shipped, go throught the list of merged PRs included in this release and tagged with the **Needs Dev Note** label.
+- When the first beta of the upcoming WordPress release is shipped, go through the list of merged PRs included in the release and tagged with the **Needs Dev Note** label.
 - For each one of these PRs, write a Dev Note, coordinate with the WordPress release leads to publish the dev note.
 - Once the dev note for a PR is published, remove the **Needs Dev Note** label from the PR.

--- a/docs/designers-developers/developers/backward-compatibility/README.md
+++ b/docs/designers-developers/developers/backward-compatibility/README.md
@@ -11,7 +11,7 @@ The Gutenberg code base is composed of two different types of packages:
  - **production packages**: these are packages that are shipped as WordPress scripts (example: wp-components, wp-editor...).
  - **development packages**: these are made out of developer tools that can be used by third-party developers to lint, test, format and build their themes and plugins (example: @wordpress/scrips, @wordpress/env...). Typically, these are consumed as npm dependencies in third-party projects.
 
-Backward compatibility guarantee only applies to the production packages as updates happen through WordPress upgrades.
+Backward compatibility guarantees only apply to the production packages, as updates happen through WordPress upgrades.
  
 Production packages use the `wp` global variable to provide APIs to third-party developers. These APIs can be JavaScript functions, variables and React components.
 

--- a/docs/designers-developers/developers/backward-compatibility/README.md
+++ b/docs/designers-developers/developers/backward-compatibility/README.md
@@ -50,7 +50,7 @@ Dev notes are [posts published on the make/core site](https://make.wordpress.org
 
 ### Dev Note Workflow
 
-- When working on Pull-request and the need for a dev-note is noted/discovered, add the **Needs Dev Note** label to the PR.
+- When working on a pull request and the need for a dev note is discovered, add the **Needs Dev Note** label to the PR.
 - If possible, add a comment to the PR explaining why the Dev Note is needed.
 - When the first beta of the next WordPress release is shipped, go throught the list of merged PRs included in this release and tagged with the **Needs Dev Note** label.
 - For each one of these PRs, write a Dev Note, coordinate with the WordPress release leads to publish the dev note.

--- a/docs/designers-developers/developers/backward-compatibility/README.md
+++ b/docs/designers-developers/developers/backward-compatibility/README.md
@@ -40,7 +40,7 @@ Production packages use the `wp` global variable to provide APIs to third-party 
 
 Class names and DOM nodes used inside the tree of React components are not considered part of the public API and can be modified. 
 
-Changes to these should be done with caution as it can affect the styling and behavior of third-party code (Even if they should not rely use these in first place). Keep the old ones if possible. If not, document these changes and write a dev note about the changes.
+Changes to these should be done with caution as it can affect the styling and behavior of third-party code (Even if they should not rely on these in the first place). Keep the old ones if possible. If not, document the changes and write a dev note.
 
 ## Deprecations
 

--- a/docs/designers-developers/developers/backward-compatibility/README.md
+++ b/docs/designers-developers/developers/backward-compatibility/README.md
@@ -3,7 +3,7 @@
 Historically, WordPress has been known for preserving backward compatibility across versions. Gutenberg follows this example wherever possible in its production public APIs. There are rare occasions where breaking backward compatibility is unavoidable and in those cases the breakage:
 
 * should be constrained as much as possible to a small surface area of the API.
-* should be documented as clearly as possible to third-party developers using dev notes.
+* Should be documented as clearly as possible to third-party developers using Dev Notes.
 
 ## What qualifies as a production public API
 

--- a/docs/designers-developers/developers/backward-compatibility/README.md
+++ b/docs/designers-developers/developers/backward-compatibility/README.md
@@ -2,7 +2,7 @@
 
 Historically, WordPress has been known for preserving backward compatibility across versions. Gutenberg follows this example wherever possible in its production public APIs. There are rare occasions where breaking backward compatibility is unavoidable and in those cases the breakage:
 
-* should be constrained as much as possible to a small surface area of the API.
+* Should be constrained as much as possible to a small surface area of the API.
 * Should be documented as clearly as possible to third-party developers using Dev Notes.
 
 ## What qualifies as a production public API

--- a/docs/designers-developers/developers/backward-compatibility/README.md
+++ b/docs/designers-developers/developers/backward-compatibility/README.md
@@ -51,7 +51,7 @@ Dev notes are [posts published on the make/core site](https://make.wordpress.org
 ### Dev Note Workflow
 
 - When working on a pull request and the need for a dev note is discovered, add the **Needs Dev Note** label to the PR.
-- If possible, add a comment to the PR explaining why the Dev Note is needed.
+- If possible, add a comment to the PR explaining why the dev note is needed.
 - When the first beta of the next WordPress release is shipped, go throught the list of merged PRs included in this release and tagged with the **Needs Dev Note** label.
 - For each one of these PRs, write a Dev Note, coordinate with the WordPress release leads to publish the dev note.
 - Once the dev note for a PR is published, remove the **Needs Dev Note** label from the PR.

--- a/docs/designers-developers/developers/backward-compatibility/README.md
+++ b/docs/designers-developers/developers/backward-compatibility/README.md
@@ -1,6 +1,6 @@
 # Backward Compatibility
 
-Historically WordPress has been known for preserving backward compatibility across versions. Gutenberg follows this example wherever possible in its production public APIs. There are rare occasions where breaking backward compatibility is unavoidable and in those cases the breakage:
+Historically, WordPress has been known for preserving backward compatibility across versions. Gutenberg follows this example wherever possible in its production public APIs. There are rare occasions where breaking backward compatibility is unavoidable and in those cases the breakage:
 
 * should be constrained as much as possible to a small surface area of the API.
 * should be documented as clearly as possible to third-party developers using dev notes.

--- a/docs/designers-developers/developers/backward-compatibility/README.md
+++ b/docs/designers-developers/developers/backward-compatibility/README.md
@@ -44,7 +44,7 @@ Changes to these should be done with caution as it can affect the styling and be
 
 ## Deprecations
 
-As the project evolves, flaws to existing APIs are discovered, or updates are required to support new features. When this happens, we try to guarantee that existing APIs don't break and build new alternative APIs.
+As the project evolves, flaws of existing APIs are discovered, or updates are required to support new features. When this happens, we try to guarantee that existing APIs don't break and build new alternative APIs.
 
 To encourage third-party developers to adopt the new APIs instead, we can use the [**deprecated**](/packages/deprecated/README.md) helper to show a message explaining the deprecation and proposing the alternative whenever the old API is used.
 

--- a/docs/designers-developers/developers/backward-compatibility/README.md
+++ b/docs/designers-developers/developers/backward-compatibility/README.md
@@ -46,7 +46,7 @@ Dev notes are [posts published on the make/core site](https://make.wordpress.org
 * Promote new APIs.
 * Explain how some changes to existing APIs might affect existing plugins and themes (Example: classname changes...)
 * When breaking backward compatibility is unavoidable, explain the reasons and the migration flow.
-* When important deprecations are introduced (even without breakage), explain why and how third-party developpers can update their code base in consequence.
+* When important deprecations are introduced (even without breakage), explain why and how third-party developers can update their code base in consequence.
 
 ### Dev Note Workflow
 

--- a/docs/designers-developers/developers/backward-compatibility/README.md
+++ b/docs/designers-developers/developers/backward-compatibility/README.md
@@ -60,6 +60,6 @@ Dev notes are [posts published on the make/core site](https://make.wordpress.org
 
 * When working on a pull request and the need for a dev note is discovered, add the **Needs Dev Note** label to the PR.
 * If possible, add a comment to the PR explaining why the dev note is needed.
-* When the first beta of the upcoming WordPress release is shipped, go through the list of merged PRs included in the release and tagged with the **Needs Dev Note** label.
+* When the first beta of the upcoming WordPress release is shipped, go through the list of merged PRs included in the release that are tagged with the **Needs Dev Note** label.
 * For each one of these PRs, write a dev note and coordinate with the WordPress release leads to publish the dev note.
 * Once the dev note for a PR is published, remove the **Needs Dev Note** label from the PR.

--- a/docs/designers-developers/developers/backward-compatibility/README.md
+++ b/docs/designers-developers/developers/backward-compatibility/README.md
@@ -38,7 +38,7 @@ Production packages use the `wp` global variable to provide APIs to third-party 
 
 As the project evolves, flaws to existing APIs are discovered, or updates are required to support new features. When this happens, we try to guarantee that existing APIs don't break and build new alternative APIs.
 
-To encourage third-party developpers to adopt the new APIs instead, we can use the **deprecated** helper to show a message explaining the deprecation and proposing the alternativewhenever the old API is used.
+To encourage third-party developers to adopt the new APIs instead, we can use the **deprecated** helper to show a message explaining the deprecation and proposing the alternative whenever the old API is used.
 
 ## Dev Notes
 

--- a/docs/designers-developers/developers/backward-compatibility/README.md
+++ b/docs/designers-developers/developers/backward-compatibility/README.md
@@ -23,7 +23,7 @@ Production packages use the `wp` global variable to provide APIs to third-party 
 
 * The name of the component should not change.
 * The props of the components should not be removed.
-* Existing prop values should continue to be supported. If a component accept a function as prop, we can update the component to accept a new type for the same prop, but it shouldn't break existing usage.
+* Existing prop values should continue to be supported. If a component accepts a function as prop, we can update the component to accept a new type for the same prop, but it shouldn't break existing usage.
 * Adding new props is allowed.
 * React Context dependencies can only be added or removed if we ensure the previous context contract is not breaking.
 * Class names and DOM nodes used inside the tree of the component are not considered part of the public API and can be modified. That said, changes to these should be done with caution as it can affect the styling. Keep the old ones if possible. If not, document these changes and write a dev note about the changes.

--- a/docs/designers-developers/developers/backward-compatibility/README.md
+++ b/docs/designers-developers/developers/backward-compatibility/README.md
@@ -9,7 +9,7 @@ Historically, WordPress has been known for preserving backward compatibility acr
 
 The Gutenberg code base is composed of two different types of packages: 
  - **production packages**: these are packages that are shipped as WordPress scripts (example: wp-components, wp-editor...).
- - **development packages**: these are made out of developer tools that can be used by third-party developers to lint, test, format and build their themes and plugins (example: @wordpress/scrips, @wordpress/env...). Typically, these are consumed as npm dependencies in third-party projects.
+ - **development packages**: these are made up of developer tools that can be used by third-party developers to lint, test, format and build their themes and plugins (example: @wordpress/scrips, @wordpress/env...). Typically, these are consumed as npm dependencies in third-party projects.
 
 Backward compatibility guarantees only apply to the production packages, as updates happen through WordPress upgrades.
  

--- a/docs/designers-developers/developers/backward-compatibility/README.md
+++ b/docs/designers-developers/developers/backward-compatibility/README.md
@@ -25,7 +25,7 @@ Production packages use the `wp` global variable to provide APIs to third-party 
 ### How to preserve backward compatibility for a React Component
 
 * The name of the component should not change.
-* The props of the components should not be removed.
+* The props of the component should not be removed.
 * Existing prop values should continue to be supported. If a component accepts a function as prop, we can update the component to accept a new type for the same prop, but it shouldn't break existing usage.
 * Adding new props is allowed.
 * React Context dependencies can only be added or removed if we ensure the previous context contract is not breaking.

--- a/docs/designers-developers/developers/backward-compatibility/README.md
+++ b/docs/designers-developers/developers/backward-compatibility/README.md
@@ -51,7 +51,7 @@ To encourage third-party developers to adopt the new APIs instead, we can use th
 ## Dev Notes
 
 Dev notes are [posts published on the make/core site](https://make.wordpress.org/core/tag/dev-notes/) prior to WordPress releases to inform third-party developers about important changes to the developer APIs, these changes can include:
-* Promote new APIs.
+* New APIs.
 * Explain how some changes to existing APIs might affect existing plugins and themes (Example: classname changes...)
 * When breaking backward compatibility is unavoidable, explain the reasons and the migration flow.
 * When important deprecations are introduced (even without breakage), explain why and how third-party developers can update their code base in consequence.

--- a/docs/designers-developers/developers/backward-compatibility/README.md
+++ b/docs/designers-developers/developers/backward-compatibility/README.md
@@ -4,7 +4,7 @@ Gutenberg follows the WordPress backward compatibility principles. This means ba
 
 ## What qualifies as a production public API:
 
-Gutenberg code base is compased of two different types of packages: 
+The Gutenberg code base is composed of two different types of packages: 
  - **production packages**: these are packages that are shipped in WordPress scripts (example: wp-components, wp-editor...).
  - **development packages**: these are made of developper tools that can be used by third-party developpers to lint, test, format and build their themes and plugins (example: @wordpress/scrips, @wordpress/env...). Typically, these are consumed as npm dependencies in third-party projects.
 

--- a/docs/designers-developers/developers/backward-compatibility/README.md
+++ b/docs/designers-developers/developers/backward-compatibility/README.md
@@ -5,7 +5,7 @@ Gutenberg follows the WordPress backward compatibility principles. This means ba
 ## What qualifies as a production public API:
 
 The Gutenberg code base is composed of two different types of packages: 
- - **production packages**: these are packages that are shipped in WordPress scripts (example: wp-components, wp-editor...).
+ - **production packages**: these are packages that are shipped as WordPress scripts (example: wp-components, wp-editor...).
  - **development packages**: these are made of developper tools that can be used by third-party developpers to lint, test, format and build their themes and plugins (example: @wordpress/scrips, @wordpress/env...). Typically, these are consumed as npm dependencies in third-party projects.
 
  Backward compatibility guarantee only applies to the production packages as updates happen through WordPress upgrades.

--- a/docs/designers-developers/developers/backward-compatibility/README.md
+++ b/docs/designers-developers/developers/backward-compatibility/README.md
@@ -46,7 +46,7 @@ Changes to these should be done with caution as it can affect the styling and be
 
 As the project evolves, flaws of existing APIs are discovered, or updates are required to support new features. When this happens, we try to guarantee that existing APIs don't break and build new alternative APIs.
 
-To encourage third-party developers to adopt the new APIs instead, we can use the [**deprecated**](/packages/deprecated/README.md) helper to show a message explaining the deprecation and proposing the alternative whenever the old API is used.
+To encourage third-party developers to adopt the new APIs instead, we can use the [**deprecated**](/packages/deprecated/README.md) helper to show a message explaining the deprecation and propose the alternative whenever the old API is used.
 
 ## Dev Notes
 

--- a/docs/designers-developers/developers/backward-compatibility/README.md
+++ b/docs/designers-developers/developers/backward-compatibility/README.md
@@ -53,5 +53,5 @@ Dev notes are [posts published on the make/core site](https://make.wordpress.org
 - When working on a pull request and the need for a dev note is discovered, add the **Needs Dev Note** label to the PR.
 - If possible, add a comment to the PR explaining why the dev note is needed.
 - When the first beta of the upcoming WordPress release is shipped, go through the list of merged PRs included in the release and tagged with the **Needs Dev Note** label.
-- For each one of these PRs, write a Dev Note, coordinate with the WordPress release leads to publish the dev note.
+- For each one of these PRs, write a dev note and coordinate with the WordPress release leads to publish the dev note.
 - Once the dev note for a PR is published, remove the **Needs Dev Note** label from the PR.

--- a/docs/designers-developers/developers/backward-compatibility/README.md
+++ b/docs/designers-developers/developers/backward-compatibility/README.md
@@ -42,7 +42,7 @@ To encourage third-party developpers to adopt the new APIs instead, we can use t
 
 ## Dev Notes
 
-Dev Notes are posts published in the make/core site prior to WordPress releases to inform third-party developpers about important changes to the developper APIs, these changes can include:
+Dev notes are [posts published on the make/core site](https://make.wordpress.org/core/tag/dev-notes/) prior to WordPress releases to inform third-party developers about important changes to the developer APIs, these changes can include:
 * Promote new APIs.
 * Explain how some changes to existing APIs might affect existing plugins and themes (Example: classname changes...)
 * When breaking backward compatibility is unavoidable, explain the reasons and the migration flow.

--- a/docs/designers-developers/developers/backward-compatibility/README.md
+++ b/docs/designers-developers/developers/backward-compatibility/README.md
@@ -1,6 +1,6 @@
 # Backward Compatibility
 
-Gutenberg follows the WordPress backwards compatibility principles. This means Backward compatibility for producation public API is guaranteed. In some rare occasions breaking backward compatibility is unavoidable, in that case, the breakage should be as small as possible and the breakage should be documented as clearly as possible to third-party developpers using devnotes.
+Gutenberg follows the WordPress backward compatibility principles. This means backward compatibility for production public API is guaranteed. In some rare occasions breaking backward compatibility is unavoidable, in that case, the breakage should be as small as possible and be documented as clearly as possible to third-party developers using dev notes.
 
 ## What qualifies as a production public API:
 

--- a/docs/designers-developers/developers/backward-compatibility/README.md
+++ b/docs/designers-developers/developers/backward-compatibility/README.md
@@ -26,7 +26,7 @@ Production packages use the `wp` global variable to provide APIs to third-party 
 * Existing prop values should continue to be supported. If a component accept a function as prop, we can update the component to accept a new type for the same prop, but it shouldn't break existing usage.
 * Adding new props is allowed.
 * React Context dependencies can only be added or removed if we ensure the previous context contract is not breaking.
-* Classnames, DOM nodes used inside the tree of the component are not considered part of the public API and can be modified. That said, changes to these should be done with caution as it can affect the styling. When classes need to be renamed, if possible keep the old ones. When possible, document these changes and write a devnote about the changes.
+* Class names and DOM nodes used inside the tree of the component are not considered part of the public API and can be modified. That said, changes to these should be done with caution as it can affect the styling. Keep the old ones if possible. If not, document these changes and write a dev note about the changes.
 
 ### How to guarantee backward compatibility for a Block
 

--- a/docs/designers-developers/developers/backward-compatibility/README.md
+++ b/docs/designers-developers/developers/backward-compatibility/README.md
@@ -1,8 +1,11 @@
 # Backward Compatibility
 
-Gutenberg follows the WordPress backward compatibility principles. This means backward compatibility for production public API is guaranteed. In some rare occasions breaking backward compatibility is unavoidable, in that case, the breakage should be as small as possible and be documented as clearly as possible to third-party developers using dev notes.
+Historically WordPress has been known for preserving backward compatibility across versions. Gutenberg follows this example wherever possible in its production public APIs. There are rare occasions where breaking backward compatibility is unavoidable and in those cases the breakage:
 
-## What qualifies as a production public API:
+* should be constrained as much as possible to a small surface area of the API.
+* should be documented as clearly as possible to third-party developers using dev notes.
+
+## What qualifies as a production public API
 
 The Gutenberg code base is composed of two different types of packages: 
  - **production packages**: these are packages that are shipped as WordPress scripts (example: wp-components, wp-editor...).
@@ -12,33 +15,38 @@ Backward compatibility guarantee only applies to the production packages as upda
  
 Production packages use the `wp` global variable to provide APIs to third-party developers. These APIs can be JavaScript functions, variables and React components.
 
-### How to guarantee backward compatibility for a JavaScript function
+### How to preserve backward compatibility for a JavaScript function
 
 * The name of the function should not change.
 * The order of the arguments of the function should not change.
 * The function's returned value type should not change.
 * Changes to arguments (new arguments, modification of semantics) is possible if we guarantee that all previous calls are still possible.
 
-### How to guarantee backward compatibility for a React Component
+### How to preserve backward compatibility for a React Component
 
 * The name of the component should not change.
 * The props of the components should not be removed.
 * Existing prop values should continue to be supported. If a component accepts a function as prop, we can update the component to accept a new type for the same prop, but it shouldn't break existing usage.
 * Adding new props is allowed.
 * React Context dependencies can only be added or removed if we ensure the previous context contract is not breaking.
-* Class names and DOM nodes used inside the tree of the component are not considered part of the public API and can be modified. That said, changes to these should be done with caution as it can affect the styling. Keep the old ones if possible. If not, document these changes and write a dev note about the changes.
 
-### How to guarantee backward compatibility for a Block
+### How to preserve backward compatibility for a Block
 
 * Existing usage of the block should not break or be marked as invalid when the editor is loaded.
 * The styling of the existing blocks should be guaranteed.
-* Markup changes should be limited to the minimum but If a block need to change its saved markup making previous versions invalid, a **deprecated version** for the block should be added.
+* Markup changes should be limited to the minimum but If a block need to change its saved markup making previous versions invalid, a [**deprecated version**](/docs/designers-developers/developers/block-api/block-deprecation.md) for the block should be added.
+
+## Class names and DOM updates
+
+Class names and DOM nodes used inside the tree of React components are not considered part of the public API and can be modified. 
+
+Changes to these should be done with caution as it can affect the styling and behavior of third-party code (Even if they should not rely use these in first place). Keep the old ones if possible. If not, document these changes and write a dev note about the changes.
 
 ## Deprecations
 
 As the project evolves, flaws to existing APIs are discovered, or updates are required to support new features. When this happens, we try to guarantee that existing APIs don't break and build new alternative APIs.
 
-To encourage third-party developers to adopt the new APIs instead, we can use the **deprecated** helper to show a message explaining the deprecation and proposing the alternative whenever the old API is used.
+To encourage third-party developers to adopt the new APIs instead, we can use the [**deprecated**](/packages/deprecated/README.md) helper to show a message explaining the deprecation and proposing the alternative whenever the old API is used.
 
 ## Dev Notes
 
@@ -50,8 +58,8 @@ Dev notes are [posts published on the make/core site](https://make.wordpress.org
 
 ### Dev Note Workflow
 
-- When working on a pull request and the need for a dev note is discovered, add the **Needs Dev Note** label to the PR.
-- If possible, add a comment to the PR explaining why the dev note is needed.
-- When the first beta of the upcoming WordPress release is shipped, go through the list of merged PRs included in the release and tagged with the **Needs Dev Note** label.
-- For each one of these PRs, write a dev note and coordinate with the WordPress release leads to publish the dev note.
-- Once the dev note for a PR is published, remove the **Needs Dev Note** label from the PR.
+* When working on a pull request and the need for a dev note is discovered, add the **Needs Dev Note** label to the PR.
+* If possible, add a comment to the PR explaining why the dev note is needed.
+* When the first beta of the upcoming WordPress release is shipped, go through the list of merged PRs included in the release and tagged with the **Needs Dev Note** label.
+* For each one of these PRs, write a dev note and coordinate with the WordPress release leads to publish the dev note.
+* Once the dev note for a PR is published, remove the **Needs Dev Note** label from the PR.

--- a/docs/designers-developers/developers/backward-compatibility/README.md
+++ b/docs/designers-developers/developers/backward-compatibility/README.md
@@ -34,7 +34,7 @@ Production packages use the `wp` global variable to provide APIs to third-party 
 
 * Existing usage of the block should not break or be marked as invalid when the editor is loaded.
 * The styling of the existing blocks should be guaranteed.
-* Markup changes should be limited to the minimum but If a block need to change its saved markup making previous versions invalid, a [**deprecated version**](/docs/designers-developers/developers/block-api/block-deprecation.md) for the block should be added.
+* Markup changes should be limited to the minimum possible, but if a block needs to change its saved markup, making previous versions invalid, a [**deprecated version**](/docs/designers-developers/developers/block-api/block-deprecation.md) of the block should be added.
 
 ## Class names and DOM updates
 

--- a/docs/designers-developers/developers/backward-compatibility/README.md
+++ b/docs/designers-developers/developers/backward-compatibility/README.md
@@ -10,7 +10,7 @@ The Gutenberg code base is composed of two different types of packages:
 
 Backward compatibility guarantee only applies to the production packages as updates happen through WordPress upgrades.
  
- Production packages use the `wp` global variable to provide APIs to third-party developpers. These APIs can be JavaScript functions, variables and React components.
+Production packages use the `wp` global variable to provide APIs to third-party developers. These APIs can be JavaScript functions, variables and React components.
 
 ### How to guarantee backward compatibility for a JavaScript function
 


### PR DESCRIPTION
closes #4738

Among team members and WordPress developers, there's a lot of assumptions on backward compatibility and knowledge that is not shared properly to all contributors.

While this first document is probably unperfect, it is at least a good starting point to understand the backward compatibility policy in Gutenberg and WordPress.
