### PR TITLE
[RNMobile] Add separate options for capturing photo and video

### DIFF
--- a/packages/block-editor/src/components/media-upload/index.native.js
+++ b/packages/block-editor/src/components/media-upload/index.native.js
@@ -52,7 +52,7 @@ const siteLibrarySource = {
 	icon: 'wordpress-alt',
 };
 
-const internalSources = [ deviceLibrarySource, cameraImageSource, cameraVideoSource, , siteLibrarySource ];
+const internalSources = [ deviceLibrarySource, cameraImageSource, cameraVideoSource, siteLibrarySource ];
 
 export class MediaUpload extends React.Component {
 	constructor( props ) {

--- a/packages/block-editor/src/components/media-upload/index.native.js
+++ b/packages/block-editor/src/components/media-upload/index.native.js
@@ -25,12 +25,14 @@ const cameraImageSource = {
 	value: mediaSource.device,
 	label: __( 'Take a Photo' ),
 	types: [MEDIA_TYPE_IMAGE],
+	icon: 'camera',
 };
 
 const cameraVideoSource = {
 	value: mediaSource.device,
 	label: __( 'Take a Video' ),
 	type: [MEDIA_TYPE_VIDEO],
+	icon: 'camera',
 };
 
 const deviceLibrarySource = {
@@ -43,6 +45,7 @@ const siteLibrarySource = {
 	value: mediaSource.device,
 	label: __( 'WordPress Media Library' ),
 	type: [MEDIA_TYPE_IMAGE, MEDIA_TYPE_VIDEO],
+	icon: 'wordpress-alt',
 };
 
 const localSources = [cameraImageSource, cameraVideoSource, deviceLibrarySource, siteLibrarySource];
@@ -88,21 +91,14 @@ export class MediaUpload extends React.Component {
 		const { allowedTypes = [] } = this.props;
 
 		// multiple capture options for media text
-		const captureMediaOptionsItems = allowedTypes.filter( ( allowedType ) => {
-			return allowedType === MEDIA_TYPE_IMAGE || allowedType === MEDIA_TYPE_VIDEO;
-		} ).map( ( mediaType ) => {
+		return allowedTypes.filter( ( allowedType ) => {
+			return localSources.filter( (source) => source.types.includes( allowedType ) );
+		} ).map( ( source ) => {
 			return {
-				icon: this.getTakeMediaIcon(),
-				value: captureMediaMap.get( mediaType ),
-				label: this.getTakeMediaLabel( mediaType ),
+				...source,
+				icon: source.icon || this.getTakeMediaIcon(),
 			};
 		} );
-
-		return [
-			{ icon: this.getChooseFromDeviceIcon(), value: mediaSources.deviceLibrary, label: __( 'Choose from device' ) },
-			...captureMediaOptionsItems,
-			{ icon: this.getWordPressLibraryIcon(), value: mediaSources.siteMediaLibrary, label: __( 'WordPress Media Library' ) },
-		];
 	}
 
 	getChooseFromDeviceIcon() {

--- a/packages/block-editor/src/components/media-upload/index.native.js
+++ b/packages/block-editor/src/components/media-upload/index.native.js
@@ -20,12 +20,17 @@ export const MEDIA_TYPE_IMAGE = 'image';
 export const MEDIA_TYPE_VIDEO = 'video';
 
 export const MEDIA_UPLOAD_BOTTOM_SHEET_VALUE_CHOOSE_FROM_DEVICE = 'choose_from_device';
-export const MEDIA_UPLOAD_BOTTOM_SHEET_VALUE_TAKE_MEDIA = 'take_media';
+export const MEDIA_UPLOAD_BOTTOM_SHEET_VALUE_TAKE_PHOTO = 'take_photo';
+export const MEDIA_UPLOAD_BOTTOM_SHEET_VALUE_TAKE_VIDEO = 'take_video';
 export const MEDIA_UPLOAD_BOTTOM_SHEET_VALUE_WORD_PRESS_LIBRARY = 'wordpress_media_library';
 
 export const OPTION_TAKE_VIDEO = __( 'Take a Video' );
 export const OPTION_TAKE_PHOTO = __( 'Take a Photo' );
 export const OPTION_TAKE_PHOTO_OR_VIDEO = __( 'Take a Photo or Video' );
+
+const captureMediaMap = new Map();
+captureMediaMap.set( MEDIA_TYPE_IMAGE, MEDIA_UPLOAD_BOTTOM_SHEET_VALUE_TAKE_PHOTO );
+captureMediaMap.set( MEDIA_TYPE_VIDEO, MEDIA_UPLOAD_BOTTOM_SHEET_VALUE_TAKE_VIDEO );
 
 export class MediaUpload extends React.Component {
 	constructor( props ) {
@@ -54,24 +59,34 @@ export class MediaUpload extends React.Component {
 		} );
 	}
 
-	getTakeMediaLabel() {
-		const { allowedTypes = [] } = this.props;
+	getTakeMediaLabel( mediaType ) {
+		switch ( mediaType ) {
+			case MEDIA_TYPE_IMAGE:
+				return OPTION_TAKE_PHOTO;
+			case MEDIA_TYPE_VIDEO:
+				return OPTION_TAKE_VIDEO;
+		}
 
-		const isOneType = allowedTypes.length === 1;
-		const isImage = isOneType && allowedTypes.includes( MEDIA_TYPE_IMAGE );
-		const isVideo = isOneType && allowedTypes.includes( MEDIA_TYPE_VIDEO );
-
-		if ( isImage ) {
-			return OPTION_TAKE_PHOTO;
-		} else if ( isVideo ) {
-			return OPTION_TAKE_VIDEO;
-		} return OPTION_TAKE_PHOTO_OR_VIDEO;
+		return OPTION_TAKE_PHOTO;
 	}
 
 	getMediaOptionsItems() {
+		const { allowedTypes = [] } = this.props;
+
+		// multiple capture options for media text
+		const captureMediaOptionsItems = allowedTypes.filter( ( allowedType ) => {
+			return allowedType === MEDIA_TYPE_IMAGE || allowedType === MEDIA_TYPE_VIDEO;
+		} ).map( ( mediaType ) => {
+			return {
+				icon: this.getTakeMediaIcon(),
+				value: captureMediaMap.get( mediaType ),
+				label: this.getTakeMediaLabel( mediaType ),
+			};
+		} );
+
 		return [
 			{ icon: this.getChooseFromDeviceIcon(), value: MEDIA_UPLOAD_BOTTOM_SHEET_VALUE_CHOOSE_FROM_DEVICE, label: __( 'Choose from device' ) },
-			{ icon: this.getTakeMediaIcon(), value: MEDIA_UPLOAD_BOTTOM_SHEET_VALUE_TAKE_MEDIA, label: this.getTakeMediaLabel() },
+			...captureMediaOptionsItems,
 			{ icon: this.getWordPressLibraryIcon(), value: MEDIA_UPLOAD_BOTTOM_SHEET_VALUE_WORD_PRESS_LIBRARY, label: __( 'WordPress Media Library' ) },
 		];
 	}
@@ -113,20 +128,39 @@ export class MediaUpload extends React.Component {
 		} );
 	}
 
+	// request a single image or video from camera
+	requestSpecificMediaTypeFromDeviceCamera( mediaType ) {
+		const { onSelect } = this.props;
+
+		requestMediaPickFromDeviceCamera( [ mediaType ], false, ( media ) => {
+			if ( media && media.id ) {
+				onSelect( media );
+			}
+		} );
+	}
+
 	onPickerChange( value ) {
-		if ( value === MEDIA_UPLOAD_BOTTOM_SHEET_VALUE_CHOOSE_FROM_DEVICE ) {
-			this.onPickerSelect( requestMediaPickFromDeviceLibrary );
-		} else if ( value === MEDIA_UPLOAD_BOTTOM_SHEET_VALUE_TAKE_MEDIA ) {
-			this.onPickerSelect( requestMediaPickFromDeviceCamera );
-		} else if ( value === MEDIA_UPLOAD_BOTTOM_SHEET_VALUE_WORD_PRESS_LIBRARY ) {
-			this.onPickerSelect( requestMediaPickFromMediaLibrary );
-		} else {
-			const { onSelect, multiple = false } = this.props;
-			requestOtherMediaPickFrom( value, multiple, ( media ) => {
-				if ( ( multiple && media ) || ( media && media.id ) ) {
-					onSelect( media );
-				}
-			} );
+		switch ( value ) {
+			case MEDIA_UPLOAD_BOTTOM_SHEET_VALUE_CHOOSE_FROM_DEVICE:
+				this.onPickerSelect( requestMediaPickFromDeviceLibrary );
+				break;
+			case MEDIA_UPLOAD_BOTTOM_SHEET_VALUE_TAKE_PHOTO:
+				this.requestSpecificMediaTypeFromDeviceCamera( MEDIA_TYPE_IMAGE );
+				break;
+			case MEDIA_UPLOAD_BOTTOM_SHEET_VALUE_TAKE_VIDEO:
+				this.requestSpecificMediaTypeFromDeviceCamera( MEDIA_TYPE_VIDEO );
+				break;
+			case MEDIA_UPLOAD_BOTTOM_SHEET_VALUE_WORD_PRESS_LIBRARY:
+				this.onPickerSelect( requestMediaPickFromMediaLibrary );
+				break;
+			default:
+				const { onSelect, multiple = false } = this.props;
+				requestOtherMediaPickFrom( value, multiple, ( media ) => {
+					if ( ( multiple && media ) || ( media && media.id ) ) {
+						onSelect( media );
+					}
+				} );
+				break;
 		}
 	}
 

--- a/packages/block-editor/src/components/media-upload/index.native.js
+++ b/packages/block-editor/src/components/media-upload/index.native.js
@@ -22,10 +22,10 @@ export const OPTION_TAKE_PHOTO = __( 'Take a Photo' );
 export const OPTION_TAKE_PHOTO_OR_VIDEO = __( 'Take a Photo or Video' );
 
 const cameraImageSource = {
-	id: mediaSources.deviceCamera,
-	value: mediaSources.deviceCamera + '-IMAGE',
+	id: mediaSources.deviceCamera, // ID is the value sent to native
+	value: mediaSources.deviceCamera + '-IMAGE', // This is needed to diferenciate image-camera from video-camera sources.
 	label: __( 'Take a Photo' ),
-	types: [MEDIA_TYPE_IMAGE],
+	types: [ MEDIA_TYPE_IMAGE ],
 	icon: 'camera',
 };
 
@@ -33,7 +33,7 @@ const cameraVideoSource = {
 	id: mediaSources.deviceCamera,
 	value: mediaSources.deviceCamera,
 	label: __( 'Take a Video' ),
-	types: [MEDIA_TYPE_VIDEO],
+	types: [ MEDIA_TYPE_VIDEO ],
 	icon: 'camera',
 };
 
@@ -41,14 +41,14 @@ const deviceLibrarySource = {
 	id: mediaSources.deviceLibrary,
 	value: mediaSources.deviceLibrary,
 	label: __( 'Choose from device' ),
-	types: [MEDIA_TYPE_IMAGE, MEDIA_TYPE_VIDEO],
+	types: [ MEDIA_TYPE_IMAGE, MEDIA_TYPE_VIDEO ],
 };
 
 const siteLibrarySource = {
 	id: mediaSources.siteMediaLibrary,
 	value: mediaSources.siteMediaLibrary,
 	label: __( 'WordPress Media Library' ),
-	types: [MEDIA_TYPE_IMAGE, MEDIA_TYPE_VIDEO],
+	types: [ MEDIA_TYPE_IMAGE, MEDIA_TYPE_VIDEO ],
 	icon: 'wordpress-alt',
 };
 
@@ -82,7 +82,7 @@ export class MediaUpload extends React.Component {
 	}
 
 	getAllSources() {
-		return internalSources.concat( this.state.otherMediaOptions )
+		return internalSources.concat( this.state.otherMediaOptions );
 	}
 
 	getMediaOptionsItems() {
@@ -120,21 +120,10 @@ export class MediaUpload extends React.Component {
 
 	onPickerSelect( value ) {
 		const { allowedTypes = [], onSelect, multiple = false } = this.props;
-		const source = this.getAllSources().filter( ( source ) => source.value === value ).shift();
-		const types = allowedTypes.filter( ( type ) => source.types.includes( type ) );
-		requestMediaPicker( source.id, types, multiple, ( media ) => {
+		const mediaSource = this.getAllSources().filter( ( source ) => source.value === value ).shift();
+		const types = allowedTypes.filter( ( type ) => mediaSource.types.includes( type ) );
+		requestMediaPicker( mediaSource.id, types, multiple, ( media ) => {
 			if ( ( multiple && media ) || ( media && media.id ) ) {
-				onSelect( media );
-			}
-		} );
-	}
-
-	// request a single image or video from camera
-	requestSpecificMediaTypeFromDeviceCamera( mediaType ) {
-		const { onSelect } = this.props;
-
-		requestMediaPickFromDeviceCamera( [ mediaType ], false, ( media ) => {
-			if ( media && media.id ) {
 				onSelect( media );
 			}
 		} );

--- a/packages/block-editor/src/components/media-upload/index.native.js
+++ b/packages/block-editor/src/components/media-upload/index.native.js
@@ -22,33 +22,37 @@ export const OPTION_TAKE_PHOTO = __( 'Take a Photo' );
 export const OPTION_TAKE_PHOTO_OR_VIDEO = __( 'Take a Photo or Video' );
 
 const cameraImageSource = {
-	value: mediaSource.device,
+	id: mediaSources.deviceCamera,
+	value: mediaSources.deviceCamera + '-IMAGE',
 	label: __( 'Take a Photo' ),
 	types: [MEDIA_TYPE_IMAGE],
 	icon: 'camera',
 };
 
 const cameraVideoSource = {
-	value: mediaSource.device,
+	id: mediaSources.deviceCamera,
+	value: mediaSources.deviceCamera,
 	label: __( 'Take a Video' ),
-	type: [MEDIA_TYPE_VIDEO],
+	types: [MEDIA_TYPE_VIDEO],
 	icon: 'camera',
 };
 
 const deviceLibrarySource = {
-	value: mediaSource.device,
+	id: mediaSources.deviceLibrary,
+	value: mediaSources.deviceLibrary,
 	label: __( 'Choose from device' ),
-	type: [MEDIA_TYPE_IMAGE, MEDIA_TYPE_VIDEO],
+	types: [MEDIA_TYPE_IMAGE, MEDIA_TYPE_VIDEO],
 };
 
 const siteLibrarySource = {
-	value: mediaSource.device,
+	id: mediaSources.siteMediaLibrary,
+	value: mediaSources.siteMediaLibrary,
 	label: __( 'WordPress Media Library' ),
-	type: [MEDIA_TYPE_IMAGE, MEDIA_TYPE_VIDEO],
+	types: [MEDIA_TYPE_IMAGE, MEDIA_TYPE_VIDEO],
 	icon: 'wordpress-alt',
 };
 
-const localSources = [cameraImageSource, cameraVideoSource, deviceLibrarySource, siteLibrarySource];
+const localSources = [ deviceLibrarySource, cameraImageSource, cameraVideoSource, , siteLibrarySource ];
 
 export class MediaUpload extends React.Component {
 	constructor( props ) {
@@ -91,8 +95,8 @@ export class MediaUpload extends React.Component {
 		const { allowedTypes = [] } = this.props;
 
 		// multiple capture options for media text
-		return allowedTypes.filter( ( allowedType ) => {
-			return localSources.filter( (source) => source.types.includes( allowedType ) );
+		return localSources.filter( ( source ) => {
+			return allowedTypes.filter( ( allowedType ) => source.types.includes( allowedType ) ).length > 0;
 		} ).map( ( source ) => {
 			return {
 				...source,
@@ -129,9 +133,11 @@ export class MediaUpload extends React.Component {
 		}
 	}
 
-	onPickerSelect( source ) {
+	onPickerSelect( value ) {
 		const { allowedTypes = [], onSelect, multiple = false } = this.props;
-		requestMediaPicker( source, allowedTypes, multiple, ( media ) => {
+		const source = localSources.filter( ( source ) => source.value === value ).shift();
+		const types = allowedTypes.filter( ( type ) => source.types.includes( type ) );
+		requestMediaPicker( source.id, types, multiple, ( media ) => {
 			if ( ( multiple && media ) || ( media && media.id ) ) {
 				onSelect( media );
 			}

--- a/packages/block-editor/src/components/media-upload/test/index.native.js
+++ b/packages/block-editor/src/components/media-upload/test/index.native.js
@@ -5,6 +5,7 @@ import { shallow } from 'enzyme';
 import { TouchableWithoutFeedback } from 'react-native';
 import {
 	requestMediaPicker,
+	mediaSources,
 } from 'react-native-gutenberg-bridge';
 
 /**
@@ -12,9 +13,6 @@ import {
  */
 import {
 	MediaUpload,
-	MEDIA_UPLOAD_BOTTOM_SHEET_VALUE_CHOOSE_FROM_DEVICE,
-	MEDIA_UPLOAD_BOTTOM_SHEET_VALUE_TAKE_MEDIA,
-	MEDIA_UPLOAD_BOTTOM_SHEET_VALUE_WORD_PRESS_LIBRARY,
 	MEDIA_TYPE_IMAGE,
 	MEDIA_TYPE_VIDEO,
 	OPTION_TAKE_VIDEO,
@@ -99,22 +97,22 @@ describe( 'MediaUpload component', () => {
 	};
 
 	it( 'can select media from device library', () => {
-		expectMediaPickerForOption( MEDIA_UPLOAD_BOTTOM_SHEET_VALUE_CHOOSE_FROM_DEVICE, false, requestMediaPicker );
+		expectMediaPickerForOption( mediaSources.deviceLibrary, false, requestMediaPicker );
 	} );
 
 	it( 'can select media from WP media library', () => {
-		expectMediaPickerForOption( MEDIA_UPLOAD_BOTTOM_SHEET_VALUE_WORD_PRESS_LIBRARY, false, requestMediaPicker );
+		expectMediaPickerForOption( mediaSources.siteMediaLibrary, false, requestMediaPicker );
 	} );
 
 	it( 'can select media by capturig', () => {
-		expectMediaPickerForOption( MEDIA_UPLOAD_BOTTOM_SHEET_VALUE_TAKE_MEDIA, false, requestMediaPicker );
+		expectMediaPickerForOption( mediaSources.deviceCamera, false, requestMediaPicker );
 	} );
 
 	it( 'can select multiple media from device library', () => {
-		expectMediaPickerForOption( MEDIA_UPLOAD_BOTTOM_SHEET_VALUE_CHOOSE_FROM_DEVICE, true, requestMediaPicker );
+		expectMediaPickerForOption( mediaSources.deviceLibrary, true, requestMediaPicker );
 	} );
 
 	it( 'can select multiple media from WP media library', () => {
-		expectMediaPickerForOption( MEDIA_UPLOAD_BOTTOM_SHEET_VALUE_WORD_PRESS_LIBRARY, true, requestMediaPicker );
+		expectMediaPickerForOption( mediaSources.siteMediaLibrary, true, requestMediaPicker );
 	} );
 } );


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
This PR adds separate options for capturing a photo or a video for the media-text block.

Fixes: https://github.com/wordpress-mobile/gutenberg-mobile/issues/1571

### Related PRs:
gutenberg-mobile: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1579

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
I've tested this out via WordPress-Android develop: `8088889a2992d75bed0a9ac7ef042b83b53b654a`

### To test:


**Steps:**
1. Create a post in WordPress-Android (and WordPress-iOS)
2. Add "Media & Text" block
3. Click on it
4. Choose "Take a photo or video"

**Expected:**
* Separate options should exist for "Take a Photo" and "Take a Video"
* These options should work as expected and bring you to the relevant camera.
* After capturing a photo or video (video on sites that allow it), the file should upload and be displayed in the block.