### PR TITLE
Docs: Fix typo at "Block Gradient Presets"

### DIFF
--- a/docs/designers-developers/developers/themes/theme-support.md
+++ b/docs/designers-developers/developers/themes/theme-support.md
@@ -134,7 +134,7 @@ Themes are responsible for creating the classes that apply the colors in differe
 
 The class name is built appending 'has-', followed by the class name _using_ kebab case and ending with the context name.
 
-### Block Gradient Presents
+### Block Gradient Presets
 
 Different blocks have the possibility of selecting from a list of predined of gradients. The block editor provides a default gradient presets, but a theme can overwrite them and provide its own:
 


### PR DESCRIPTION
Typo reported here:

https://make.wordpress.org/core/2019/11/13/whats-new-in-gutenberg-13-november/#comment-37259