### PR TITLE
Colors Selector: Add contrast checker

### DIFF
--- a/packages/block-library/src/navigation-menu/block-colors-selector.js
+++ b/packages/block-library/src/navigation-menu/block-colors-selector.js
@@ -11,6 +11,12 @@ import { IconButton, Dropdown, Toolbar, SVG, Path } from '@wordpress/components'
 import { __ } from '@wordpress/i18n';
 import { DOWN } from '@wordpress/keycodes';
 import { ColorPaletteControl } from '@wordpress/block-editor';
+import { useRef, useEffect } from '@wordpress/element';
+
+/**
+ * Browser dependencies
+ */
+const { getComputedStyle } = window;
 
 const ColorSelectorSVGIcon = () => (
 	<SVG xmlns="https://www.w3.org/2000/svg" viewBox="0 0 20 20">
@@ -25,6 +31,17 @@ const ColorSelectorSVGIcon = () => (
  * @return {*} React Icon component.
  */
 const ColorSelectorIcon = ( { textColor, textColorValue } ) => {
+	const ref = useRef();
+
+	useEffect( () => {
+	    if ( ! ref || ! ref.current ) {
+			return;
+	    }
+
+	    const style = getComputedStyle( ref.current );
+		const backgroundColor = style.getPropertyValue( 'background-color' );
+	}, [] );
+
 	const iconClasses = classnames(
 		'block-library-colors-selector__state-selection',
 		'editor-styles-wrapper', {
@@ -36,6 +53,7 @@ const ColorSelectorIcon = ( { textColor, textColorValue } ) => {
 	return (
 		<div className="block-library-colors-selector__icon-container">
 			<div
+				ref={ ref }
 				className={ iconClasses }
 				style={ { ...( textColorValue && { color: textColorValue } ) } }
 			>

--- a/packages/block-library/src/navigation-menu/edit.js
+++ b/packages/block-library/src/navigation-menu/edit.js
@@ -183,6 +183,7 @@ function NavigationMenu( {
 						setTextColor( value );
 						setAttributes( { textColorValue: value } );
 					} }
+
 				/>
 			</BlockControls>
 			{ navigatorModal }


### PR DESCRIPTION
## Description
This PR is an attempt to add the contrast checker to the color selector dropdown. The background-color comes from the `<ColorSelectorIcon />` which may be defined through the `editor-styles-wrapper` CSS class.

## How has this been tested?
Create/Edit a menu nav changing the text color. The contrast checker should appear when the contrast is not appropriate.

## Screenshots <!-- if applicable -->

![colors-selector-contrast-checker](https://user-images.githubusercontent.com/77539/68864366-c7e6a580-06cf-11ea-83e8-21fa9b16c9d3.gif)



## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->