### PR TITLE
Playground: Fix useEffect to only registerCoreBlocks once

### DIFF
--- a/storybook/stories/playground/index.js
+++ b/storybook/stories/playground/index.js
@@ -39,7 +39,7 @@ function App() {
 
 	useEffect( () => {
 		registerCoreBlocks();
-	} );
+	}, [] );
 
 	return (
 		<div className="playground">


### PR DESCRIPTION
## Description
<img width="802" alt="Screen Shot 2019-11-14 at 3 22 33 PM" src="https://user-images.githubusercontent.com/2322354/68865239-c9759500-06f2-11ea-9695-4046fd449312.png">

Fix console/render issues in Playground (Storybook). The issue was the `useEffect` hook was firing multiple times, causing the `registerCoreBlocks` to re-register over and over.


## How has this been tested?
Tested in Storybook!

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.

Resolves: https://github.com/WordPress/gutenberg/issues/18512