### PR TITLE
chore: Fix: Paragraph block isRTL may not be boolean

### DIFF
--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -46,7 +46,7 @@ const applyFallbackStyles = withFallbackStyles( ( node, ownProps ) => {
 
 function ParagraphRTLToolbar( { direction, setDirection } ) {
 	const isRTL = useSelect( ( select ) => {
-		return select( 'core/block-editor' ).getSettings().isRTL;
+		return !! select( 'core/block-editor' ).getSettings().isRTL;
 	} );
 
 	return ( isRTL && (


### PR DESCRIPTION
## Description
If the block editor provider does not provide an isRTL setting, isRTL may be undefined. 
ParagraphRTLToolbar returns `isRTL && (...)`, so it may return undefined making the block crash.
It is possible to see this problem by opening the widget block screen and trying to use a paragraph, as the widgets screen does not provide an isRTL setting.
Widgets screen should provide isRTL that will be fixed in a different PR, but the paragraph block should not rely on isRTL being available, so this PR still fixes a problem.

## How has this been tested?
I opened the widget blocks screen.
I added a paragraph, wrote something, and verified the paragraph did not crash. 