### PR TITLE
Fix: Widget screen margins

### DIFF
--- a/packages/edit-widgets/src/components/widget-area/style.scss
+++ b/packages/edit-widgets/src/components/widget-area/style.scss
@@ -4,8 +4,8 @@
 
 	// Reduce padding inside widget areas
 	.block-editor-block-list__layout {
-		padding-left: 0;
-		padding-right: 0;
+		padding-left: $block-side-ui-width + $block-padding;
+		padding-right: $block-side-ui-width + $block-padding;
 	}
 	// By default the default block appender inserter has a negative position,
 	// but given that on the widget screen we have 0 padding we need to remove the negative position.
@@ -15,12 +15,9 @@
 	}
 }
 .edit-widgets-main-block-list {
-	padding-top: $block-toolbar-height + 2 * $grid-size;
+	padding-top: $grid-size-xlarge;
 }
 
 .edit-widgets-main-block-list > .block-list-appender {
 	padding-top: $panel-padding;
-	// Add a margin equivalent to block side UI so the appender is aligned with the blocks.
-	margin-left: $block-side-ui-width;
-	margin-right: $block-side-ui-width;
 }


### PR DESCRIPTION
## Description
There was a change in the block editor margins and this change had the side effect of making the block editor not work as expected on the widget screen.
This PR fixes the problem.
cc: @mapk 

## How has this been tested?
I Verified the block editor on widgets screen looks as expected.

## Screenshots <!-- if applicable -->
Before:
<img width="763" alt="Screenshot 2019-11-14 at 18 37 19" src="https://user-images.githubusercontent.com/11271197/68886048-46623800-070e-11ea-8544-933adf9973dd.png">


After:
<img width="771" alt="Screenshot 2019-11-14 at 18 34 48" src="https://user-images.githubusercontent.com/11271197/68886053-49f5bf00-070e-11ea-9313-135ee1d85520.png">
