### PR TITLE
chore: Remove one place for open in new window on menu item

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -162,13 +162,6 @@ function NavigationLinkEdit( {
 				<PanelBody
 					title={ __( 'Link Settings' ) }
 				>
-					<ToggleControl
-						checked={ opensInNewTab }
-						onChange={ ( newTab ) => {
-							setAttributes( { opensInNewTab: newTab } );
-						} }
-						label={ __( 'Open in new tab' ) }
-					/>
 					<TextareaControl
 						value={ description || '' }
 						onChange={ ( descriptionValue ) => {
@@ -236,7 +229,7 @@ function NavigationLinkEdit( {
 							currentSettings={ [
 								{
 									id: 'opensInNewTab',
-									title: __( 'Open in New Tab' ),
+									title: __( 'Open in new tab' ),
 									checked: opensInNewTab,
 								},
 							] }


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
Fixes: https://github.com/WordPress/gutenberg/issues/18320



## How has this been tested?
I verified the UI to change Open in new tab now does not appear on the block inspector.
I verified the UI to change Open in new tab part of link popover is now on sentence case.
cc: @karmatosed 