### PR TITLE
[Tiny PR] Text patterns: fix undo after mouse move

### DIFF
--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1315,6 +1315,12 @@ export function automaticChangeStatus( state, action ) {
 			if ( state !== 'final' ) {
 				return state;
 			}
+
+			return;
+		// Undoing an automatic change should still be possible after mouse
+		// move.
+		case 'STOP_TYPING':
+			return state;
 	}
 
 	// Reset the state by default (for any action not handled).

--- a/packages/e2e-tests/specs/editor/blocks/__snapshots__/list.test.js.snap
+++ b/packages/e2e-tests/specs/editor/blocks/__snapshots__/list.test.js.snap
@@ -308,6 +308,12 @@ exports[`List should undo asterisk transform with backspace 1`] = `
 <!-- /wp:paragraph -->"
 `;
 
+exports[`List should undo asterisk transform with backspace after mouse move 1`] = `
+"<!-- wp:paragraph -->
+<p>* </p>
+<!-- /wp:paragraph -->"
+`;
+
 exports[`List should undo asterisk transform with backspace after selection changes 1`] = `
 "<!-- wp:paragraph -->
 <p>* </p>

--- a/packages/e2e-tests/specs/editor/blocks/list.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/list.test.js
@@ -72,6 +72,15 @@ describe( 'List', () => {
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 
+	it( 'should undo asterisk transform with backspace after mouse move', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( '* ' );
+		await page.mouse.move( 0, 0, { steps: 10 } );
+		await page.keyboard.press( 'Backspace' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
 	it( 'should undo asterisk transform with backspace after selection changes without requestIdleCallback', async () => {
 		await clickBlockAppender();
 		await page.evaluate( () => delete window.requestIdleCallback );


### PR DESCRIPTION
## Description
Fixes #18492.

## How has this been tested?

1. Type `1. `  inside a paragraph. The block should convert to a list block.
2. Move the mouse outside the block.
3. Press `Backspace`. The block transform should be undone.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
