### PR TITLE
[RNMobile] Fix saving changes when exiting from HTML mode

### DIFF
--- a/packages/components/src/mobile/html-text-input/index.native.js
+++ b/packages/components/src/mobile/html-text-input/index.native.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { TextInput } from 'react-native';
+import RNReactNativeGutenbergBridge from 'react-native-gutenberg-bridge';
 
 /**
  * WordPress dependencies
@@ -25,10 +26,7 @@ export class HTMLTextInput extends Component {
 		this.edit = this.edit.bind( this );
 		this.stopEditing = this.stopEditing.bind( this );
 
-		this.state = {
-			isDirty: false,
-			value: '',
-		};
+		this.state = {};
 	}
 
 	static getDerivedStateFromProps( props, state ) {
@@ -106,9 +104,8 @@ export default compose( [
 			value: getEditedPostContent(),
 		};
 	} ),
-	withDispatch( ( dispatch ) => {
-		const { resetBlocks } = dispatch( 'core/block-editor' );
-		const { editPost } = dispatch( 'core/editor' );
+	withDispatch( ( dispatch, ownProps ) => {
+		const { editPost, resetEditorBlocks } = dispatch( 'core/editor' );
 		return {
 			editTitle( title ) {
 				editPost( { title } );
@@ -117,7 +114,10 @@ export default compose( [
 				editPost( { content } );
 			},
 			onPersist( content ) {
-				resetBlocks( parse( content ) );
+				const blocks = parse( content );
+				const hasChanges = ownProps.value !== content;
+				resetEditorBlocks( blocks );
+				RNReactNativeGutenbergBridge.provideToNative_Html( content, ownProps.title, hasChanges );
 			},
 		};
 	} ),

--- a/packages/components/src/mobile/html-text-input/index.native.js
+++ b/packages/components/src/mobile/html-text-input/index.native.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { TextInput } from 'react-native';
-import RNReactNativeGutenbergBridge from 'react-native-gutenberg-bridge';
 
 /**
  * WordPress dependencies
@@ -11,6 +10,7 @@ import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { parse } from '@wordpress/blocks';
 import { withDispatch, withSelect } from '@wordpress/data';
+import { addAction, removeAction } from '@wordpress/hooks';
 import { withInstanceId, compose, withPreferredColorScheme } from '@wordpress/compose';
 
 /**
@@ -25,6 +25,7 @@ export class HTMLTextInput extends Component {
 
 		this.edit = this.edit.bind( this );
 		this.stopEditing = this.stopEditing.bind( this );
+		addAction( 'native-editor.persist-html', 'core/editor', this.stopEditing );
 
 		this.state = {};
 	}
@@ -41,6 +42,7 @@ export class HTMLTextInput extends Component {
 	}
 
 	componentWillUnmount() {
+		removeAction( 'native-editor.persist-html', 'core/editor' );
 		//TODO: Blocking main thread
 		this.stopEditing();
 	}
@@ -104,7 +106,7 @@ export default compose( [
 			value: getEditedPostContent(),
 		};
 	} ),
-	withDispatch( ( dispatch, ownProps ) => {
+	withDispatch( ( dispatch ) => {
 		const { editPost, resetEditorBlocks } = dispatch( 'core/editor' );
 		return {
 			editTitle( title ) {
@@ -115,9 +117,7 @@ export default compose( [
 			},
 			onPersist( content ) {
 				const blocks = parse( content );
-				const hasChanges = ownProps.value !== content;
 				resetEditorBlocks( blocks );
-				RNReactNativeGutenbergBridge.provideToNative_Html( content, ownProps.title, hasChanges );
 			},
 		};
 	} ),

--- a/packages/editor/src/components/provider/index.native.js
+++ b/packages/editor/src/components/provider/index.native.js
@@ -16,6 +16,7 @@ import { Component } from '@wordpress/element';
 import { parse, serialize, getUnregisteredTypeHandlerName, createBlock } from '@wordpress/blocks';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
+import { doAction } from '@wordpress/hooks';
 
 const postTypeEntities = [
 	{ name: 'post', baseURL: '/wp/v2/posts' },
@@ -112,7 +113,9 @@ class NativeEditorProvider extends Component {
 
 	serializeToNativeAction() {
 		if ( this.props.mode === 'text' ) {
-			this.updateHtmlAction( this.props.getEditedPostContent() );
+			// The HTMLTextInput component does not update the store when user is doing changes
+			// Let's request a store update when parent is asking for it
+			doAction( 'native-editor.persist-html', 'core/editor' );
 		}
 
 		const html = serialize( this.props.blocks );


### PR DESCRIPTION
## Description
This PR updates the onPersist function that is called when exiting the HTML editor, by calling the bridge directly with the HTML that has just been edited. This is necessary as the store currently does not store this value anywhere.

## Testing Instructions
- Try using WPAndroid `develop` branch with `gutenberg-mobile` develop as well
- Run `yarn start:reset` in `libs/gutenberg-mobile` after switching `libs/gutenberg-mobile/gutenberg` to this branch
- Run `yarn wpandroid` from `libs/gutenberg-mobile` in another terminal
- Try loading a post or a page from the app
- Switch to HTML
- Try going back to visual (no changes)
- Switch to HTML again, edit the HTML
- Go back, reopen the post/page
- Notice the changes are persisted

## Types of changes
Fixing an issue in the native version of the editor related to not persisting changes when going "Back" to the previous page from the block editor in HTML mode.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
