### PR TITLE
Fix crash which occurs after deleting image or page break block

### DIFF
--- a/packages/element/src/platform.android.js
+++ b/packages/element/src/platform.android.js
@@ -5,6 +5,7 @@ import { Platform as OriginalPlatform } from 'react-native';
 
 const Platform = {
 	...OriginalPlatform,
+	OS: 'native',
 	select: ( spec ) => {
 		if ( 'android' in spec ) {
 			return spec.android;

--- a/packages/element/src/platform.ios.js
+++ b/packages/element/src/platform.ios.js
@@ -5,6 +5,7 @@ import { Platform as OriginalPlatform } from 'react-native';
 
 const Platform = {
 	...OriginalPlatform,
+	OS: 'native',
 	select: ( spec ) => {
 		if ( 'ios' in spec ) {
 			return spec.ios;


### PR DESCRIPTION
Fixes: https://github.com/wordpress-mobile/WordPress-Android/issues/10491

## How has this been tested?

Follow instructions from the gb-mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1582#issue-341454458

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
