### PR TITLE
Remove unnecessary color attributes from navigation block

### DIFF
--- a/packages/block-library/src/navigation-menu/block-colors-selector.js
+++ b/packages/block-library/src/navigation-menu/block-colors-selector.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import classnames from 'classnames';
 import { noop } from 'lodash';
 
 /**
@@ -24,20 +23,12 @@ const ColorSelectorSVGIcon = () => (
  * @param {Object} colorControlProps colorControl properties.
  * @return {*} React Icon component.
  */
-const ColorSelectorIcon = ( { textColor, textColorValue } ) => {
-	const iconClasses = classnames(
-		'block-library-colors-selector__state-selection',
-		'editor-styles-wrapper', {
-			'has-text-color': textColor && textColor.color,
-			[ textColor.class ]: textColor && textColor.class,
-		}
-	);
-
+const ColorSelectorIcon = ( { color } ) => {
 	return (
 		<div className="block-library-colors-selector__icon-container">
 			<div
-				className={ iconClasses }
-				style={ { ...( textColorValue && { color: textColorValue } ) } }
+				className="block-library-colors-selector__state-selection"
+				style={ { ...( color && { color } ) } }
 			>
 				<ColorSelectorSVGIcon />
 			</div>
@@ -51,7 +42,7 @@ const ColorSelectorIcon = ( { textColor, textColorValue } ) => {
  * @param {Object} colorControlProps colorControl properties.
  * @return {*} React toggle button component.
  */
-const renderToggleComponent = ( { textColor, textColorValue } ) => ( { onToggle, isOpen } ) => {
+const renderToggleComponent = ( { value } ) => ( { onToggle, isOpen } ) => {
 	const openOnArrowDown = ( event ) => {
 		if ( ! isOpen && event.keyCode === DOWN ) {
 			event.preventDefault();
@@ -67,24 +58,19 @@ const renderToggleComponent = ( { textColor, textColorValue } ) => ( { onToggle,
 				label={ __( 'Open Colors Selector' ) }
 				onClick={ onToggle }
 				onKeyDown={ openOnArrowDown }
-				icon={ <ColorSelectorIcon
-					textColor={ textColor }
-					textColorValue={ textColorValue }
-				/> }
+				icon={ <ColorSelectorIcon color={ value } /> }
 			/>
 		</Toolbar>
 	);
 };
 
-const renderContent = ( { textColor, onColorChange = noop } ) => ( () => {
-	const setColor = ( attr ) => ( value ) => onColorChange( { attr, value } );
-
+const renderContent = ( { value, onChange = noop } ) => ( () => {
 	return (
 		<>
 			<div className="color-palette-controller-container">
 				<ColorPaletteControl
-					value={ textColor.color }
-					onChange={ setColor( 'textColor' ) }
+					value={ value }
+					onChange={ onChange }
 					label={ __( 'Text Color' ) }
 				/>
 			</div>

--- a/packages/block-library/src/navigation-menu/edit.js
+++ b/packages/block-library/src/navigation-menu/edit.js
@@ -1,21 +1,15 @@
 /**
- * External dependencies
- */
-import classnames from 'classnames';
-
-/**
  * WordPress dependencies
  */
 import {
 	useMemo,
-	useEffect,
 	Fragment,
 } from '@wordpress/element';
 import {
 	InnerBlocks,
 	InspectorControls,
 	BlockControls,
-	withColors,
+	__experimentalUseColors,
 } from '@wordpress/block-editor';
 
 import { createBlock } from '@wordpress/blocks';
@@ -45,8 +39,6 @@ function NavigationMenu( {
 	pages,
 	isRequestingPages,
 	hasResolvedPages,
-	textColor,
-	setTextColor,
 	setAttributes,
 	hasExistingNavItems,
 	updateNavItemBlocks,
@@ -54,14 +46,12 @@ function NavigationMenu( {
 	//
 	// HOOKS
 	//
+	/* eslint-disable @wordpress/no-unused-vars-before-return */
+	const { TextColor } = __experimentalUseColors(
+		[ { name: 'textColor', property: 'color' } ],
+	);
+	/* eslint-enable @wordpress/no-unused-vars-before-return */
 	const { navigatorToolbarButton, navigatorModal } = useBlockNavigator( clientId );
-
-	useEffect( () => {
-		// Set/Unset colors CSS classes.
-		setAttributes( {
-			textColorCSSClass: textColor.class ? textColor.class : null,
-		} );
-	}, [ textColor.class ] );
 
 	// Builds menu items from default Pages
 	const defaultPagesMenuItems = useMemo(
@@ -153,22 +143,6 @@ function NavigationMenu( {
 		);
 	}
 
-	// Build Inline Styles
-	const navigationMenuInlineStyles = {
-		...( textColor && {
-			color: textColor.color,
-			borderColor: textColor.color,
-		} ),
-	};
-
-	// Build ClassNames
-	const navigationMenuClasses = classnames(
-		'wp-block-navigation-menu', {
-			'has-text-color': textColor.color,
-			[ attributes.textColorCSSClass ]: attributes && attributes.textColorCSSClass,
-		}
-	);
-
 	// UI State: rendered Block UI
 	return (
 		<Fragment>
@@ -177,12 +151,8 @@ function NavigationMenu( {
 					{ navigatorToolbarButton }
 				</Toolbar>
 				<BlockColorsStyleSelector
-					textColor={ textColor }
-					textColorValue={ attributes.textColorValue }
-					onColorChange={ ( { value } ) => {
-						setTextColor( value );
-						setAttributes( { textColorValue: value } );
-					} }
+					value={ TextColor.color }
+					onChange={ TextColor.setColor }
 				/>
 			</BlockControls>
 			{ navigatorModal }
@@ -205,23 +175,23 @@ function NavigationMenu( {
 					<BlockNavigationList clientId={ clientId } />
 				</PanelBody>
 			</InspectorControls>
+			<TextColor>
+				<div className="wp-block-navigation-menu">
+					{ ! hasExistingNavItems && isRequestingPages && <><Spinner /> { __( 'Loading Navigation…' ) } </> }
 
-			<div className={ navigationMenuClasses } style={ navigationMenuInlineStyles }>
-				{ ! hasExistingNavItems && isRequestingPages && <><Spinner /> { __( 'Loading Navigation…' ) } </> }
+					<InnerBlocks
+						allowedBlocks={ [ 'core/navigation-link' ] }
+						templateInsertUpdatesSelection={ false }
+						__experimentalMoverDirection={ 'horizontal' }
+					/>
 
-				<InnerBlocks
-					allowedBlocks={ [ 'core/navigation-link' ] }
-					templateInsertUpdatesSelection={ false }
-					__experimentalMoverDirection={ 'horizontal' }
-				/>
-
-			</div>
+				</div>
+			</TextColor>
 		</Fragment>
 	);
 }
 
 export default compose( [
-	withColors( { textColor: 'color' } ),
 	withSelect( ( select, { clientId } ) => {
 		const innerBlocks = select( 'core/block-editor' ).getBlocks( clientId );
 		const hasExistingNavItems = !! innerBlocks.length;


### PR DESCRIPTION
To have a text color setting in the navigation block, we relied on four color attributes. In other blocks, we only use two attributes. I think we had some redundancy in the attributes.
We also used some inline styles even when a user selects a preset color; this may colors not work as expected when switching the color associated with a given class.
This PR also tries to simplify the code by relying on when the new useColors hook. I noticed that I needed to fix a small thing in useColors and that change is here for testing purposes, but we should merge it in a different PR.

It also solves some bugs:
- When a color we add navigation block and don't choose any text color, we save null in one of the attributes: `<!-- wp:navigation-menu {"textColorCSSClass":null} -->`. This pollutes the markup and is unnecessary.
- When we create a navigation block, select a preset color, save the post and later change the value of color associated with a given class (e.g: using the customizer in 2020 theme to change the primary color ), after the reload the color indication shows the previous color while the block now has a new color. See the image bellow.
- Following the previous scenario, when changing a color associated with a given class, in the frontend, the new color is applied as expected. However, the markup of the nav element still applies an inline style with the previous color value. This inline style seems unnecessary.

<img width="416" alt="Screenshot 2019-11-15 at 12 51 08" src="https://user-images.githubusercontent.com/11271197/68945749-08feb880-07a9-11ea-86a1-165c360e8a23.png">


## Description
<!-- Please describe what you have changed or added -->

## How has this been tested?
I created multiple navigation blocks.
In some, I chose a preset color; in other, I picked a named color (at least one had accent color on 2020 theme).
I verified both blocks look as expected on the frontend and backend.
I changed the accent color on the customizer and verified the blocks correctly reflected the new color, including on the color indicator.