### PR TITLE
Add storybook for Tip component

### DIFF
--- a/packages/components/src/tip/stories/index.js
+++ b/packages/components/src/tip/stories/index.js
@@ -1,3 +1,7 @@
+/**
+ * External dependencies
+ */
+import { text } from '@storybook/addon-knobs';
 
 /**
  * Internal dependencies
@@ -6,8 +10,11 @@ import Tip from '../';
 
 export default { title: 'Components|Tip', component: Tip };
 
-export const _default = () => (
-	<Tip>
-		<p>An example tip.</p>
-	</Tip>
-);
+export const _default = () => {
+	const tipText = text( 'Text', 'An example tip' );
+	return (
+		<Tip>
+			<p>{ tipText }</p>
+		</Tip>
+	);
+};

--- a/packages/components/src/tip/stories/index.js
+++ b/packages/components/src/tip/stories/index.js
@@ -1,0 +1,13 @@
+
+/**
+ * Internal dependencies
+ */
+import Tip from '../';
+
+export default { title: 'Components|Tip', component: Tip };
+
+export const _default = () => (
+	<Tip>
+		<p>An example tip.</p>
+	</Tip>
+);


### PR DESCRIPTION
## Description

Adds a storybook story for the Tip component.

Is this component still used? I found it referenced in the Inserter tip menu but didn't see it in action when viewing the welcome tips.

## How has this been tested?
 
Run `npm run storybook:dev`

## Types of changes
Storybook.

