### PR TITLE
Fix: End 2 end tests failure; Update transforms structure

### DIFF
--- a/packages/e2e-tests/fixtures/block-transforms.js
+++ b/packages/e2e-tests/fixtures/block-transforms.js
@@ -376,6 +376,18 @@ export const EXPECTED_TRANSFORMS = {
 			'Verse',
 		],
 	},
+	'core__post-content': {
+		availableTransforms: [
+			'Group',
+		],
+		originalBlock: 'Post Content',
+	},
+	'core__post-title': {
+		availableTransforms: [
+			'Group',
+		],
+		originalBlock: 'Post Title',
+	},
 	core__preformatted: {
 		originalBlock: 'Preformatted',
 		availableTransforms: [


### PR DESCRIPTION
## Description
We merged new blocks on master but did not update the end 2 end test transform structure.
This PR updates the structure and fixes the current failures happening on the master.

## How has this been tested?
I verified the end 2 end tests are passing.