### PR TITLE
Update: Return the color value on useColors

### DIFF
--- a/packages/block-editor/src/components/colors/use-colors.js
+++ b/packages/block-editor/src/components/colors/use-colors.js
@@ -175,19 +175,23 @@ export default function __experimentalUseColors(
 				color: attributes[ colorConfig.name ],
 			};
 
+			const customColor = attributes[ camelCase( `custom ${ name }` ) ];
 			// We memoize the non-primitives to avoid unnecessary updates
 			// when they are used as props for other components.
-			const _color = colors.find( ( __color ) => __color.slug === color );
+			const _color = ! customColor ?
+				colors.find( ( __color ) => __color.slug === color ) :
+				undefined;
 			acc[ componentName ] = createComponent(
 				name,
 				property,
 				className,
 				color,
 				_color && _color.color,
-				attributes[ camelCase( `custom ${ name }` ) ]
+				customColor
 			);
 			acc[ componentName ].displayName = componentName;
-			acc[ componentName ].color = color;
+			acc[ componentName ].color = customColor ? customColor : ( _color && _color.color );
+			acc[ componentName ].slug = color;
 			acc[ componentName ].setColor = createSetColor( name, colors );
 
 			colorSettings[ componentName ] = {


### PR DESCRIPTION
## Description
The useColors hook does not provide a way to access the color value.
If we want to create a slightly different color UI like the navigation block needs we need to access the color value.
Themes set the color property as the color value, and slug as the named color value, previously withColor also did that. Currently, useColors returns color as the named color.
This PR changes useColors to also return a color property in the color components, and returns the color slug in the slug property.

## How has this been tested?
I verified the color on the heading block works as expected.
I used the debugger and verified the color and slug property contain the expected values for the three different cases: no color selected, custom color selected, preset color selected.