### PR TITLE
Add: isRTL setting to the widget screen.

### DIFF
--- a/lib/widgets-page.php
+++ b/lib/widgets-page.php
@@ -74,6 +74,7 @@ function gutenberg_widgets_init( $hook ) {
 			'disableCustomColors'    => get_theme_support( 'disable-custom-colors' ),
 			'disableCustomFontSizes' => get_theme_support( 'disable-custom-font-sizes' ),
 			'imageSizes'             => $available_image_sizes,
+			'isRTL'                  => is_rtl(),
 			'maxUploadFileSize'      => $max_upload_size,
 		),
 		gutenberg_get_legacy_widget_settings()


### PR DESCRIPTION
## Description
Widgets screen missed the isRTL setting.
The Paragraph block allows selecting the direction in the block toolbar if the isRTL is true. As the setting was not set on widgets screen this option was not available on paragraphs there.

## How has this been tested?
I went to the widgets screen in RTL (by using RTL tester plugin).
I verified the paragraph block toolbar has an option that allows us to change the text direction.

