### PR TITLE
Use Colors: Add text color detection support.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21669,7 +21669,7 @@
 			"dependencies": {
 				"clone-deep": {
 					"version": "0.2.4",
-					"resolved": "http://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
+					"resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
 					"integrity": "sha1-TnPdCen7lxzDhnDF3O2cGJZIHMY=",
 					"dev": true,
 					"requires": {
@@ -21703,7 +21703,7 @@
 					"dependencies": {
 						"kind-of": {
 							"version": "2.0.1",
-							"resolved": "http://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
 							"integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
 							"dev": true,
 							"requires": {

--- a/packages/block-editor/src/components/colors/use-colors.js
+++ b/packages/block-editor/src/components/colors/use-colors.js
@@ -48,8 +48,8 @@ const ColorPanel = ( {
 	colorSettings,
 	colorPanelProps,
 	contrastCheckers,
-	detectedBackgroundColor,
-	detectedColor,
+	detectedBackgroundColorRef,
+	detectedColorRef,
 	panelChildren,
 } ) => (
 	<PanelColorSettings
@@ -64,12 +64,12 @@ const ColorPanel = ( {
 					backgroundColor = resolveContrastCheckerColor(
 						backgroundColor,
 						colorSettings,
-						detectedBackgroundColor
+						detectedBackgroundColorRef.current
 					);
 					textColor = resolveContrastCheckerColor(
 						textColor,
 						colorSettings,
-						detectedColor
+						detectedColorRef.current
 					);
 					return (
 						<ContrastChecker
@@ -85,12 +85,12 @@ const ColorPanel = ( {
 					backgroundColor = resolveContrastCheckerColor(
 						backgroundColor || value,
 						colorSettings,
-						detectedBackgroundColor
+						detectedBackgroundColorRef.current
 					);
 					textColor = resolveContrastCheckerColor(
 						textColor || value,
 						colorSettings,
-						detectedColor
+						detectedColorRef.current
 					);
 					return (
 						<ContrastChecker
@@ -330,8 +330,8 @@ export default function __experimentalUseColors(
 			colorSettings,
 			colorPanelProps,
 			contrastCheckers,
-			detectedBackgroundColor: detectedBackgroundColorRef.current,
-			detectedColor: detectedColorRef.current,
+			detectedBackgroundColorRef,
+			detectedColorRef,
 			panelChildren,
 		};
 		return {
@@ -342,11 +342,5 @@ export default function __experimentalUseColors(
 			),
 			ColorDetector,
 		};
-	}, [
-		attributes,
-		setAttributes,
-		detectedBackgroundColorRef.current,
-		detectedColorRef.current,
-		...deps,
-	] );
+	}, [ attributes, setAttributes, ...deps ] );
 }

--- a/packages/block-editor/src/components/colors/use-colors.js
+++ b/packages/block-editor/src/components/colors/use-colors.js
@@ -215,23 +215,44 @@ export default function __experimentalUseColors(
 		}
 		return (
 			( needsBackgroundColor || needsColor ) &&
-			withFallbackStyles( ( node, { querySelector } ) => {
-				if ( querySelector ) {
-					node = node.parentNode.querySelector( querySelector );
-				}
-				const computedStyle = getComputedStyle( node );
-				let backgroundColor = computedStyle.backgroundColor;
-				const color = computedStyle.color;
-				if ( needsBackgroundColor ) {
-					while ( backgroundColor === 'rgba(0, 0, 0, 0)' && node.parentNode ) {
-						node = node.parentNode;
-						backgroundColor = getComputedStyle( node ).backgroundColor;
+			withFallbackStyles(
+				(
+					node,
+					{
+						querySelector,
+						backgroundColorSelector = querySelector,
+						textColorSelector = querySelector,
 					}
+				) => {
+					let backgroundColorNode = node;
+					let textColorNode = node;
+					if ( backgroundColorSelector ) {
+						backgroundColorNode = node.parentNode.querySelector(
+							backgroundColorSelector
+						);
+					}
+					if ( textColorSelector ) {
+						textColorNode = node.parentNode.querySelector( textColorSelector );
+					}
+					let backgroundColor;
+					const color = getComputedStyle( textColorNode ).color;
+					if ( needsBackgroundColor ) {
+						backgroundColor = getComputedStyle( backgroundColorNode )
+							.backgroundColor;
+						while (
+							backgroundColor === 'rgba(0, 0, 0, 0)' &&
+							backgroundColorNode.parentNode
+						) {
+							backgroundColorNode = backgroundColorNode.parentNode;
+							backgroundColor = getComputedStyle( backgroundColorNode )
+								.backgroundColor;
+						}
+					}
+					detectedBackgroundColorRef.current = backgroundColor;
+					detectedColorRef.current = color;
+					return { backgroundColor, color };
 				}
-				detectedBackgroundColorRef.current = backgroundColor;
-				detectedColorRef.current = color;
-				return { backgroundColor };
-			} )( () => <></> )
+			)( () => <></> )
 		);
 	}, [
 		colorConfigs.reduce(

--- a/packages/block-library/src/heading/edit.js
+++ b/packages/block-library/src/heading/edit.js
@@ -29,7 +29,7 @@ function HeadingEdit( {
 	onReplace,
 	className,
 } ) {
-	const { TextColor, InspectorControlsColorPanel, BackgroundColorDetector } = __experimentalUseColors(
+	const { TextColor, InspectorControlsColorPanel, ColorDetector } = __experimentalUseColors(
 		[ { name: 'textColor', property: 'color' } ],
 		{
 			contrastCheckers: { backgroundColor: true },
@@ -56,7 +56,7 @@ function HeadingEdit( {
 			</InspectorControls>
 			{ InspectorControlsColorPanel }
 			<TextColor>
-				<BackgroundColorDetector querySelector='[contenteditable="true"]' />
+				<ColorDetector querySelector='[contenteditable="true"]' />
 				<RichText
 					identifier="content"
 					tagName={ tagName }

--- a/packages/block-library/src/heading/edit.js
+++ b/packages/block-library/src/heading/edit.js
@@ -32,7 +32,7 @@ function HeadingEdit( {
 	const { TextColor, InspectorControlsColorPanel, ColorDetector } = __experimentalUseColors(
 		[ { name: 'textColor', property: 'color' } ],
 		{
-			contrastCheckers: { backgroundColor: true },
+			contrastCheckers: { backgroundColor: true, textColor: true },
 		},
 		[]
 	);


### PR DESCRIPTION
Follows #18237

## Description

This PR adds support for detecting text colors using the `true` option introduced for `useColors` contrast checking by #18237.

## How has this been tested?

All uses of `useColors` were verified to continue to work as expected.

## Types of Changes

*New Feature:* `useColors` contrast checking now supports text color detection.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
