### PR TITLE
Navigation block: adds in default and style variation

### DIFF
--- a/packages/block-library/src/navigation/index.js
+++ b/packages/block-library/src/navigation/index.js
@@ -30,7 +30,7 @@ export const settings = {
 	},
 
 	styles: [
-		{ name: 'default', label: __( 'Default' ), isDefault: true },
+		{ name: 'light', label: __( 'Light' ), isDefault: true },
 		{ name: 'dark', label: __( 'Dark' ) },
 	],
 

--- a/packages/block-library/src/navigation/index.js
+++ b/packages/block-library/src/navigation/index.js
@@ -29,6 +29,11 @@ export const settings = {
 		inserter: true,
 	},
 
+	styles: [
+		{ name: 'default', label: __( 'Default' ), isDefault: true },
+		{ name: 'dark', label: __( 'Dark' ) },
+	],
+
 	edit,
 
 	save,

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -15,7 +15,7 @@
 function build_css_colors( $attributes ) {
 	// CSS classes.
 	$colors = array(
-		'css_classes'   => '',
+		'css_classes'   => [],
 		'inline_styles' => '',
 	);
 
@@ -25,12 +25,12 @@ function build_css_colors( $attributes ) {
 	// If has text color.
 	if ( $has_custom_text_color || $has_named_text_color ) {
 		// Add has-text-color class.
-		$colors['css_classes'] .= 'has-text-color';
+		$colors['css_classes'][] = 'has-text-color';
 	}
 
 	if ( $has_named_text_color ) {
 		// Add the color class.
-		$colors['css_classes'] .= sprintf( ' has-%s-color', $attributes['textColor'] );
+		$colors['css_classes'][] = sprintf( ' has-%s-color', $attributes['textColor'] );
 	} elseif ( $has_custom_text_color ) {
 		// Add the custom color inline style.
 		$colors['inline_styles'] = sprintf( 'color: %s;', $attributes['customTextColor'] );
@@ -49,17 +49,19 @@ function build_css_colors( $attributes ) {
  * @return string Returns the post content with the legacy widget added.
  */
 function render_block_navigation( $attributes, $content, $block ) {
-	$colors  = build_css_colors( $attributes );
-	$classes = array( 'wp-block-navigation', $colors['css_classes'] );
-	if ( ! empty( $attributes['className'] ) ) {
-		$classes[] = $attributes['className'];
-	}
-	$classes = join( ' ', array_filter( $classes ) );
+	$colors          = build_css_colors( $attributes );
+	$classes         = array_merge(
+		$colors['css_classes'],
+		[ 'wp-block-navigation' ],
+		isset( $attributes['className'] ) ? [ $attributes['className'] ] : []
+	);
+	$class_attribute = sprintf( ' class="%s"', esc_attr( implode( ' ', $classes ) ) );
+	$style_attribute = $colors['inline_styles'] ? sprintf( ' style="%s"', esc_attr( $colors['inline_styles'] ) ) : '';
 
 	return sprintf(
-		'<nav class="%1$s" %2$s>%3$s</nav>',
-		esc_attr( $classes ),
-		$colors['inline_styles'] ? sprintf( 'style="%s"', esc_attr( $colors['inline_styles'] ) ) : '',
+		'<nav %1$s %2$s>%3$s</nav>',
+		$class_attribute,
+		$style_attribute,
 		build_navigation_html( $block, $colors )
 	);
 }

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -73,10 +73,11 @@
 			transition: opacity 0.15s linear, transform 0.15s linear, right 0s 0.15s;
 			transform: translateY(0.6rem);
 			visibility: hidden;
+			padding: 5px 0;
 
 
 			li {
-				margin: 10px;
+				margin: 2px 8px;
 			}
 
 			a {
@@ -124,7 +125,6 @@
 		margin-left: 0;
 
 		li a {
-
 			padding-top: 8px;
 			padding-bottom: 8px;
 		}

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -62,6 +62,7 @@
 			background: #fff;
 			-webkit-box-shadow: -2px 4px 4px -1px rgba(97, 97, 97, 0.153);
 			-moz-box-shadow: -2px 4px 4px -1px rgba(97, 97, 97, 0.153);
+			border-radius: 4px;
 			box-shadow: -2px 4px 4px -1px rgba(97, 97, 97, 0.153);
 			margin: 0;
 			position: absolute;
@@ -69,20 +70,34 @@
 			top: 80%;
 			min-width: max-content;
 			opacity: 0;
-			transition: all 0.5s ease;
+			transition: opacity 0.15s linear, transform 0.15s linear, right 0s 0.15s;
+			transform: translateY(0.6rem);
 			visibility: hidden;
+
+
+			li {
+				margin: 10px;
+			}
+
+			a {
+				text-decoration: none;
+
+				&:hover {
+					text-decoration: underline;
+				}
+			}
 
 			&::after {
 				bottom: 100%;
 				left: 50%;
 				border: solid transparent;
+				border-color: rgba(255, 255, 255, 0);
+				border-bottom-color: #fff;
 				content: " ";
 				height: 0;
 				width: 0;
 				position: absolute;
 				pointer-events: none;
-				border-color: rgba(255, 255, 255, 0);
-				border-bottom-color: #fff;
 				border-width: 10px;
 				margin-left: -10px;
 			}
@@ -127,4 +142,24 @@
 		}
 	}
 
+}
+
+.is-style-dark > ul > li > ul {
+	background: #333;
+	border-radius: 4px;
+
+	a {
+		text-decoration: none;
+		color: #fff;
+
+		&:hover {
+			text-decoration: underline;
+			color: #eee;
+		}
+	}
+
+	&::after {
+		border-color: rgba(24, 24, 24, 0);
+		border-bottom-color: #333;
+	}
 }

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -93,6 +93,7 @@
 				border: solid transparent;
 				border-color: rgba(255, 255, 255, 0);
 				border-bottom-color: #fff;
+				border-radius: 4px;
 				content: " ";
 				height: 0;
 				width: 0;

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -93,7 +93,6 @@
 				border: solid transparent;
 				border-color: rgba(255, 255, 255, 0);
 				border-bottom-color: #fff;
-				border-radius: 4px;
 				content: " ";
 				height: 0;
 				width: 0;

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -61,9 +61,8 @@
 		& > li > ul {
 			margin: 0;
 			position: absolute;
-			background: #fff;
 			left: 0;
-			top: 100%;
+			top: 80%;
 			min-width: max-content;
 			opacity: 0;
 			transition: all 0.5s ease;

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -59,6 +59,10 @@
 
 		// Sub-menus Flyout
 		& > li > ul {
+			background: #fff;
+			-webkit-box-shadow: -2px 4px 4px -1px rgba(97, 97, 97, 0.153);
+			-moz-box-shadow: -2px 4px 4px -1px rgba(97, 97, 97, 0.153);
+			box-shadow: -2px 4px 4px -1px rgba(97, 97, 97, 0.153);
 			margin: 0;
 			position: absolute;
 			left: 0;
@@ -67,6 +71,21 @@
 			opacity: 0;
 			transition: all 0.5s ease;
 			visibility: hidden;
+
+			&::after {
+				bottom: 100%;
+				left: 50%;
+				border: solid transparent;
+				content: " ";
+				height: 0;
+				width: 0;
+				position: absolute;
+				pointer-events: none;
+				border-color: rgba(255, 255, 255, 0);
+				border-bottom-color: #fff;
+				border-width: 10px;
+				margin-left: -10px;
+			}
 
 			ul {
 				width: 100%;

--- a/packages/block-library/src/navigation/theme.scss
+++ b/packages/block-library/src/navigation/theme.scss
@@ -30,3 +30,18 @@
 		}
 	}
 }
+
+.wp-block-navigation-menu.is-dark-style ul > li > ul {
+	background: #333;
+	border-radius: 4px;
+
+	& > a {
+		text-decoration: none;
+		color: #fff;
+	}
+
+	&::before {
+		border-color: rgba(24, 24, 24, 0);
+		border-bottom-color: #333;
+	}
+}

--- a/packages/block-library/src/navigation/theme.scss
+++ b/packages/block-library/src/navigation/theme.scss
@@ -3,4 +3,30 @@
 	ul li {
 		list-style: none;
 	}
+
+	ul > li > ul {
+		background: #e3e3e3;
+		border-radius: 4px;
+		transition: opacity 0.15s linear, transform 0.15s linear, right 0s 0.15s;
+		transform: translateY(0.6rem);
+
+		& > a {
+			text-decoration: none;
+		}
+
+		&::before {
+			border: solid transparent;
+			border-color: rgba(227, 227, 227, 0);
+			border-bottom-color: #e3e3e3;
+			border-width: 10px;
+			bottom: 100%;
+			content: " ";
+			height: 0;
+			left: 20%;
+			margin-left: -10px;
+			width: 0;
+			position: absolute;
+			pointer-events: none;
+		}
+	}
 }

--- a/packages/block-library/src/navigation/theme.scss
+++ b/packages/block-library/src/navigation/theme.scss
@@ -5,7 +5,7 @@
 	}
 
 	ul > li > ul {
-		background: #e3e3e3;
+		background: #fff;
 		border-radius: 4px;
 		transition: opacity 0.15s linear, transform 0.15s linear, right 0s 0.15s;
 		transform: translateY(0.6rem);
@@ -14,19 +14,9 @@
 			text-decoration: none;
 		}
 
-		&::before {
-			border: solid transparent;
-			border-color: rgba(227, 227, 227, 0);
-			border-bottom-color: #e3e3e3;
-			border-width: 10px;
-			bottom: 100%;
-			content: " ";
-			height: 0;
-			left: 20%;
-			margin-left: -10px;
-			width: 0;
-			position: absolute;
-			pointer-events: none;
+		&::after {
+			border-color: rgba(255, 255, 255, 0);
+			border-bottom-color: #fff;
 		}
 	}
 }

--- a/packages/block-library/src/navigation/theme.scss
+++ b/packages/block-library/src/navigation/theme.scss
@@ -3,35 +3,4 @@
 	ul li {
 		list-style: none;
 	}
-
-	ul > li > ul {
-		background: #fff;
-		border-radius: 4px;
-		transition: opacity 0.15s linear, transform 0.15s linear, right 0s 0.15s;
-		transform: translateY(0.6rem);
-
-		& > a {
-			text-decoration: none;
-		}
-
-		&::after {
-			border-color: rgba(255, 255, 255, 0);
-			border-bottom-color: #fff;
-		}
-	}
-}
-
-.wp-block-navigation-menu.is-dark-style ul > li > ul {
-	background: #333;
-	border-radius: 4px;
-
-	& > a {
-		text-decoration: none;
-		color: #fff;
-	}
-
-	&::before {
-		border-color: rgba(24, 24, 24, 0);
-		border-bottom-color: #333;
-	}
 }


### PR DESCRIPTION
Start of fixing #18552. The light style is a light grey to avoid it not being visible on light without a border. This is a very simple bubble drop down with a gentle arrow.

To do:

- [x] Dark style variation
- [x] Remove text-decoration (bug)
