### PR TITLE
Templates: Add demo templates directory and resolution logic.

### DIFF
--- a/lib/demo-block-templates/index.html
+++ b/lib/demo-block-templates/index.html
@@ -6,11 +6,14 @@
 	</div>
 	<!-- /wp:column -->
 
-	<!-- wp:column -->
-	<div class="wp-block-column">
+	<!-- wp:column {"verticalAlignment":"center"} -->
+	<div class="wp-block-column is-vertically-aligned-center">
 		<!-- wp:navigation-menu {"customTextColor":"#353fff"} -->
 			<!-- wp:navigation-link {"label":"One"} /-->
-			<!-- wp:navigation-link {"label":"Two"} /-->
+			<!-- wp:navigation-link {"label":"Two"} -->
+				<!-- wp:navigation-link {"label":"Sub 1"} /-->
+				<!-- wp:navigation-link {"label":"Sub 2"} /-->
+			<!-- /wp:navigation-link -->
 			<!-- wp:navigation-link {"label":"Three"} /-->
 		<!-- /wp:navigation-menu -->
 	</div>

--- a/lib/demo-block-templates/index.html
+++ b/lib/demo-block-templates/index.html
@@ -22,6 +22,26 @@
 <figure class="wp-block-image size-large"><img src="https://cldup.com/0BNcqkoMdq.jpg" alt=""/></figure>
 <!-- /wp:image -->
 
+<!-- wp:columns -->
+<div class="wp-block-columns">
+	<!-- wp:column -->
+	<div class="wp-block-column"></div>
+	<!-- /wp:column -->
+
+	<!-- wp:column -->
+	<div class="wp-block-column">
+		<!-- wp:paragraph {"customTextColor":"#66717e","fontSize":"large"} -->
+		<p style="color:#66717e" class="has-text-color has-large-font-size">With full-site editing you can modify all visual aspects of the site using the block editor.</p>
+		<!-- /wp:paragraph -->
+	</div>
+	<!-- /wp:column -->
+
+	<!-- wp:column -->
+	<div class="wp-block-column"></div>
+	<!-- /wp:column -->
+</div>
+<!-- /wp:columns -->
+
 <!-- wp:group -->
 <div class="wp-block-group">
   <div class="wp-block-group__inner-container">

--- a/lib/demo-block-templates/index.html
+++ b/lib/demo-block-templates/index.html
@@ -1,0 +1,31 @@
+<!-- wp:site-title /-->
+
+<!-- wp:group -->
+<div class="wp-block-group">
+  <div class="wp-block-group__inner-container">
+    <!-- wp:heading -->
+    <h2>Header</h2>
+    <!-- /wp:heading -->
+  </div>
+</div>
+<!-- /wp:group -->
+
+<!-- wp:group -->
+<div class="wp-block-group">
+  <div class="wp-block-group__inner-container">
+    <!-- wp:post-title /-->
+
+    <!-- wp:post-content /-->
+  </div>
+</div>
+<!-- /wp:group -->
+
+<!-- wp:group -->
+<div class="wp-block-group">
+  <div class="wp-block-group__inner-container">
+    <!-- wp:heading -->
+    <h2>Footer</h2>
+    <!-- /wp:heading -->
+  </div>
+</div>
+<!-- /wp:group -->

--- a/lib/demo-block-templates/index.html
+++ b/lib/demo-block-templates/index.html
@@ -1,4 +1,22 @@
-<!-- wp:site-title /-->
+<!-- wp:columns {"align":"wide"} -->
+<div class="wp-block-columns alignwide">
+	<!-- wp:column -->
+	<div class="wp-block-column">
+		<!-- wp:site-title /-->
+	</div>
+	<!-- /wp:column -->
+
+	<!-- wp:column -->
+	<div class="wp-block-column">
+		<!-- wp:navigation-menu {"customTextColor":"#353fff"} -->
+			<!-- wp:navigation-link {"label":"One"} /-->
+			<!-- wp:navigation-link {"label":"Two"} /-->
+			<!-- wp:navigation-link {"label":"Three"} /-->
+		<!-- /wp:navigation-menu -->
+	</div>
+	<!-- /wp:column -->
+</div>
+<!-- /wp:columns -->
 
 <!-- wp:group -->
 <div class="wp-block-group">

--- a/lib/demo-block-templates/index.html
+++ b/lib/demo-block-templates/index.html
@@ -18,21 +18,14 @@
 </div>
 <!-- /wp:columns -->
 
-<!-- wp:group -->
-<div class="wp-block-group">
-  <div class="wp-block-group__inner-container">
-    <!-- wp:heading -->
-    <h2>Header</h2>
-    <!-- /wp:heading -->
-  </div>
-</div>
-<!-- /wp:group -->
+<!-- wp:image {"sizeSlug":"large"} -->
+<figure class="wp-block-image size-large"><img src="https://cldup.com/0BNcqkoMdq.jpg" alt=""/></figure>
+<!-- /wp:image -->
 
 <!-- wp:group -->
 <div class="wp-block-group">
   <div class="wp-block-group__inner-container">
     <!-- wp:post-title /-->
-
     <!-- wp:post-content /-->
   </div>
 </div>

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -73,6 +73,17 @@ function gutenberg_initialize_experiments_settings() {
 			'id'    => 'gutenberg-full-site-editing',
 		)
 	);
+	add_settings_field(
+		'gutenberg-full-site-editing-demo',
+		__( 'Full Site Editing Demo Templates', 'gutenberg' ),
+		'gutenberg_display_experiment_field',
+		'gutenberg-experiments',
+		'gutenberg_experiments_section',
+		array(
+			'label' => __( 'Enable Full Site Editing Demo Templates', 'gutenberg' ),
+			'id'    => 'gutenberg-full-site-editing-demo',
+		)
+	);
 	register_setting(
 		'gutenberg-experiments',
 		'gutenberg-experiments'
@@ -120,9 +131,10 @@ function gutenberg_display_experiment_section() {
  */
 function gutenberg_experiments_editor_settings( $settings ) {
 	$experiments_settings = array(
-		'__experimentalEnableLegacyWidgetBlock' => gutenberg_is_experiment_enabled( 'gutenberg-widget-experiments' ),
-		'__experimentalBlockDirectory'          => gutenberg_is_experiment_enabled( 'gutenberg-block-directory' ),
-		'__experimentalEnableFullSiteEditing'   => gutenberg_is_experiment_enabled( 'gutenberg-full-site-editing' ),
+		'__experimentalEnableLegacyWidgetBlock'   => gutenberg_is_experiment_enabled( 'gutenberg-widget-experiments' ),
+		'__experimentalBlockDirectory'            => gutenberg_is_experiment_enabled( 'gutenberg-block-directory' ),
+		'__experimentalEnableFullSiteEditing'     => gutenberg_is_experiment_enabled( 'gutenberg-full-site-editing' ),
+		'__experimentalEnableFullSiteEditingDemo' => gutenberg_is_experiment_enabled( 'gutenberg-full-site-editing-demo' ),
 	);
 
 	$gradient_presets = current( (array) get_theme_support( '__experimental-editor-gradient-presets' ) );

--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -151,7 +151,9 @@ function gutenberg_find_template( $template_file ) {
 	if ( is_child_theme() ) {
 			$block_template_files = array_merge( $block_template_files, glob( get_template_directory() . '/block-templates/*.html', 1 ) ?: array() );
 	}
-	$block_template_files = array_merge( $block_template_files, glob( dirname( __FILE__ ) . '/demo-block-templates/*.html', 1 ) ?: array() );
+	if ( gutenberg_is_experiment_enabled( 'gutenberg-full-site-editing-demo' ) ) {
+		$block_template_files = array_merge( $block_template_files, glob( dirname( __FILE__ ) . '/demo-block-templates/*.html', 1 ) ?: array() );
+	}
 	foreach ( $block_template_files as $path ) {
 		$theme_block_template_priority = $slug_priorities[ basename( $path, '.html' ) ];
 		if (
@@ -166,7 +168,7 @@ function gutenberg_find_template( $template_file ) {
 
 	// If there is, use it instead.
 	if ( isset( $higher_priority_block_template_path ) ) {
-		$post_name             = basename( $path, '.html' );
+		$post_name             = basename( $higher_priority_block_template_path, '.html' );
 		$current_template_post = array(
 			'post_content' => file_get_contents( $higher_priority_block_template_path ),
 			'post_title'   => ucfirst( $post_name ),

--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -138,58 +138,57 @@ function gutenberg_find_template( $template_file ) {
 		)
 	);
 
-	if ( $template_query->have_posts() ) {
-		$template_posts        = $template_query->get_posts();
-		$current_template_post = array_shift( $template_posts );
+	$template_posts        = $template_query->get_posts();
+	$current_template_post = array_shift( $template_posts );
 
-		// Build map of template slugs to their priority in the current hierarchy.
-		$slug_priorities = array_flip( $slugs );
+	// Build map of template slugs to their priority in the current hierarchy.
+	$slug_priorities = array_flip( $slugs );
 
-		// See if there is a theme block template with higher priority than the resolved template post.
-		$higher_priority_block_template_path     = null;
-		$higher_priority_block_template_priority = PHP_INT_MAX;
-		$block_template_files                    = glob( get_stylesheet_directory() . '/block-templates/*.html', 1 );
-		if ( is_child_theme() ) {
-				$block_template_files = array_merge( $block_template_files, glob( get_template_directory() . '/block-templates/*.html', 1 ) );
+	// See if there is a theme block template with higher priority than the resolved template post.
+	$higher_priority_block_template_path     = null;
+	$higher_priority_block_template_priority = PHP_INT_MAX;
+	$block_template_files                    = glob( get_stylesheet_directory() . '/block-templates/*.html', 1 );
+	if ( is_child_theme() ) {
+			$block_template_files = array_merge( $block_template_files, glob( get_template_directory() . '/block-templates/*.html', 1 ) );
+	}
+	$block_template_files = array_merge( $block_template_files, glob( dirname( __FILE__ ) . '/demo-block-templates/*.html', 1 ) );
+	foreach ( $block_template_files as $path ) {
+		$theme_block_template_priority = $slug_priorities[ basename( $path, '.html' ) ];
+		if (
+			isset( $theme_block_template_priority ) &&
+			$theme_block_template_priority < $higher_priority_block_template_priority &&
+			( empty( $current_template_post ) || $theme_block_template_priority < $slug_priorities[ $current_template_post->post_name ] )
+		) {
+			$higher_priority_block_template_path     = $path;
+			$higher_priority_block_template_priority = $theme_block_template_priority;
 		}
-		foreach ( $block_template_files as $path ) {
-			$theme_block_template_priority = $slug_priorities[ basename( $path, '.html' ) ];
-			if (
-				isset( $theme_block_template_priority ) &&
-				$theme_block_template_priority < $higher_priority_block_template_priority &&
-				$theme_block_template_priority < $slug_priorities[ $current_template_post->post_name ]
-			) {
-				$higher_priority_block_template_path     = $path;
-				$higher_priority_block_template_priority = $theme_block_template_priority;
-			}
-		}
+	}
 
-		// If there is, use it instead.
-		if ( isset( $higher_priority_block_template_path ) ) {
-			$post_name             = basename( $path, '.html' );
-			$current_template_post = array(
-				'post_content' => file_get_contents( $higher_priority_block_template_path ),
-				'post_title'   => ucfirst( $post_name ),
-				'post_status'  => 'auto-draft',
-				'post_type'    => 'wp_template',
-				'post_name'    => $post_name,
+	// If there is, use it instead.
+	if ( isset( $higher_priority_block_template_path ) ) {
+		$post_name             = basename( $path, '.html' );
+		$current_template_post = array(
+			'post_content' => file_get_contents( $higher_priority_block_template_path ),
+			'post_title'   => ucfirst( $post_name ),
+			'post_status'  => 'auto-draft',
+			'post_type'    => 'wp_template',
+			'post_name'    => $post_name,
+		);
+		if ( is_admin() ) {
+			// Only create auto-draft of block template for editing
+			// in admin screens, similarly to how we do it for new
+			// posts in the editor.
+			$current_template_post = get_post(
+				wp_insert_post( $current_template_post )
 			);
-			if ( is_admin() ) {
-				// Only create auto-draft of block template for editing
-				// in admin screens, similarly to how we do it for new
-				// posts in the editor.
-				$current_template_post = get_post(
-					wp_insert_post( $current_template_post )
-				);
 
-				foreach ( parse_blocks( $current_template_post->post_content ) as $block ) {
-					create_auto_draft_for_template_part_block( $block );
-				}
-			} else {
-				$current_template_post = new WP_Post(
-					(object) $current_template_post
-				);
+			foreach ( parse_blocks( $current_template_post->post_content ) as $block ) {
+				create_auto_draft_for_template_part_block( $block );
 			}
+		} else {
+			$current_template_post = new WP_Post(
+				(object) $current_template_post
+			);
 		}
 
 		$_wp_current_template_content = $current_template_post->post_content;

--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -147,11 +147,11 @@ function gutenberg_find_template( $template_file ) {
 	// See if there is a theme block template with higher priority than the resolved template post.
 	$higher_priority_block_template_path     = null;
 	$higher_priority_block_template_priority = PHP_INT_MAX;
-	$block_template_files                    = glob( get_stylesheet_directory() . '/block-templates/*.html', 1 );
+	$block_template_files                    = glob( get_stylesheet_directory() . '/block-templates/*.html', 1 ) ?: array();
 	if ( is_child_theme() ) {
-			$block_template_files = array_merge( $block_template_files, glob( get_template_directory() . '/block-templates/*.html', 1 ) );
+			$block_template_files = array_merge( $block_template_files, glob( get_template_directory() . '/block-templates/*.html', 1 ) ?: array() );
 	}
-	$block_template_files = array_merge( $block_template_files, glob( dirname( __FILE__ ) . '/demo-block-templates/*.html', 1 ) );
+	$block_template_files = array_merge( $block_template_files, glob( dirname( __FILE__ ) . '/demo-block-templates/*.html', 1 ) ?: array() );
 	foreach ( $block_template_files as $path ) {
 		$theme_block_template_priority = $slug_priorities[ basename( $path, '.html' ) ];
 		if (

--- a/lib/templates.php
+++ b/lib/templates.php
@@ -86,35 +86,6 @@ function gutenberg_grant_template_caps( array $allcaps ) {
 add_filter( 'user_has_cap', 'gutenberg_grant_template_caps' );
 
 /**
- * Filters capabilities to prevent deletion of the 'wp_template' post with slug 'index'.
- *
- * Similar to today's themes, this template should always exist.
- *
- * @param array  $caps    Array of the user's capabilities.
- * @param string $cap     Capability name.
- * @param int    $user_id The user ID.
- * @param array  $args    Adds the context to the cap. Typically the object ID.
- * @return array Filtered $caps.
- */
-function gutenberg_prevent_index_template_deletion( $caps, $cap, $user_id, $args ) {
-	if ( 'delete_post' !== $cap || ! isset( $args[0] ) ) {
-		return $caps;
-	}
-
-	$post = get_post( $args[0] );
-	if ( ! $post || 'wp_template' !== $post->post_type ) {
-		return $caps;
-	}
-
-	if ( 'index' === $post->post_name ) {
-		$caps[] = 'do_not_allow';
-	}
-
-	return $caps;
-}
-add_filter( 'map_meta_cap', 'gutenberg_prevent_index_template_deletion', 10, 4 );
-
-/**
  * Fixes the label of the 'wp_template' admin menu entry.
  */
 function gutenberg_fix_template_admin_menu_entry() {

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -410,6 +410,7 @@ _Properties_
 -   _\_\_experimentalEnableLegacyWidgetBlock_ `boolean`: Whether the user has enabled the Legacy Widget Block
 -   _\_\_experimentalBlockDirectory_ `boolean`: Whether the user has enabled the Block Directory
 -   _\_\_experimentalEnableFullSiteEditing_ `boolean`: Whether the user has enabled Full Site Editing
+-   _\_\_experimentalEnableFullSiteEditingDemo_ `boolean`: Whether the user has enabled Full Site Editing Demo Templates
 
 <a name="SkipToSelectedBlock" href="#SkipToSelectedBlock">#</a> **SkipToSelectedBlock**
 

--- a/packages/block-editor/src/store/defaults.js
+++ b/packages/block-editor/src/store/defaults.js
@@ -33,6 +33,7 @@ export const PREFERENCES_DEFAULTS = {
  * @property {boolean} __experimentalEnableLegacyWidgetBlock Whether the user has enabled the Legacy Widget Block
  * @property {boolean} __experimentalBlockDirectory Whether the user has enabled the Block Directory
  * @property {boolean} __experimentalEnableFullSiteEditing Whether the user has enabled Full Site Editing
+ * @property {boolean} __experimentalEnableFullSiteEditingDemo Whether the user has enabled Full Site Editing Demo Templates
  */
 export const SETTINGS_DEFAULTS = {
 	alignWide: false,
@@ -153,6 +154,7 @@ export const SETTINGS_DEFAULTS = {
 	__experimentalEnableLegacyWidgetBlock: false,
 	__experimentalBlockDirectory: false,
 	__experimentalEnableFullSiteEditing: false,
+	__experimentalEnableFullSiteEditingDemo: false,
 	gradients: [
 		{
 			name: __( 'Vivid cyan blue to vivid purple' ),

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -107,6 +107,7 @@ class EditorProvider extends Component {
 				'__experimentalEnableLegacyWidgetBlock',
 				'__experimentalBlockDirectory',
 				'__experimentalEnableFullSiteEditing',
+				'__experimentalEnableFullSiteEditingDemo',
 				'showInserterHelpPanel',
 				'gradients',
 			] ),


### PR DESCRIPTION
Closes #18538 

## Description

This PR adds a local fallback directory (`lib/demo-block-templates/`) to the theme block template resolution process. This way, we can bundle initial demo templates with Gutenberg.

This PR adds an `index` demo block template and that allows us to remove the filter that blocked users from deleting their own `index` templates.

## How has this been tested?

It was verified that block template resolution in the full site editing experiment now looks at the fallback demo directory as a last resort when resolving templates. E.g. deleting all template CPT posts should make your post render in `lib/demo-block-templates/index.html`, assuming your theme doesn't provide any matching, higher or equal priority templates.

## Types of Changes

*New Feature:* The full site editing experiment can now ship demo block templates.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
