### PR TITLE
Core Data: Add checks to actions and selectors to avoid throwing errors when the relevant config is not loaded.

### DIFF
--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -136,8 +136,11 @@ export function receiveEmbedPreview( url, preview ) {
  * @return {Object} Action object.
  */
 export function* editEntityRecord( kind, name, recordId, edits, options = {} ) {
-	const { transientEdits = {}, mergedEdits = {} } =
-		( yield select( 'getEntity', kind, name ) ) || {};
+	const entity = yield select( 'getEntity', kind, name );
+	if ( ! entity ) {
+		throw new Error( `The entity being edited (${ kind }, ${ name }) does not have a loaded config.` );
+	}
+	const { transientEdits = {}, mergedEdits = {} } = entity;
 	const record = yield select( 'getRawEntityRecord', kind, name, recordId );
 	const editedRecord = yield select(
 		'getEditedEntityRecord',

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -136,11 +136,8 @@ export function receiveEmbedPreview( url, preview ) {
  * @return {Object} Action object.
  */
 export function* editEntityRecord( kind, name, recordId, edits, options = {} ) {
-	const { transientEdits = {}, mergedEdits = {} } = yield select(
-		'getEntity',
-		kind,
-		name
-	);
+	const { transientEdits = {}, mergedEdits = {} } =
+		( yield select( 'getEntity', kind, name ) ) || {};
 	const record = yield select( 'getRawEntityRecord', kind, name, recordId );
 	const editedRecord = yield select(
 		'getEditedEntityRecord',

--- a/packages/core-data/src/selectors.js
+++ b/packages/core-data/src/selectors.js
@@ -184,7 +184,7 @@ export function getEntityRecordEdits( state, kind, name, recordId ) {
 export const getEntityRecordNonTransientEdits = createSelector(
 	( state, kind, name, recordId ) => {
 		const { transientEdits } = getEntity( state, kind, name ) || {};
-		const edits = getEntityRecordEdits( state, kind, name, recordId ) || [];
+		const edits = getEntityRecordEdits( state, kind, name, recordId ) || {};
 		if ( ! transientEdits ) {
 			return edits;
 		}

--- a/packages/core-data/src/selectors.js
+++ b/packages/core-data/src/selectors.js
@@ -183,8 +183,11 @@ export function getEntityRecordEdits( state, kind, name, recordId ) {
  */
 export const getEntityRecordNonTransientEdits = createSelector(
 	( state, kind, name, recordId ) => {
-		const { transientEdits = {} } = getEntity( state, kind, name );
+		const { transientEdits } = getEntity( state, kind, name ) || {};
 		const edits = getEntityRecordEdits( state, kind, name, recordId ) || [];
+		if ( ! transientEdits ) {
+			return edits;
+		}
 		return Object.keys( edits ).reduce( ( acc, key ) => {
 			if ( ! transientEdits[ key ] ) {
 				acc[ key ] = edits[ key ];

--- a/packages/core-data/src/test/actions.js
+++ b/packages/core-data/src/test/actions.js
@@ -1,7 +1,34 @@
 /**
  * Internal dependencies
  */
-import { saveEntityRecord, receiveEntityRecords, receiveUserPermission, receiveAutosaves, receiveCurrentUser } from '../actions';
+import {
+	editEntityRecord,
+	saveEntityRecord,
+	receiveEntityRecords,
+	receiveUserPermission,
+	receiveAutosaves,
+	receiveCurrentUser,
+} from '../actions';
+import { select } from '../controls';
+
+describe( 'editEntityRecord', () => {
+	it( 'throws when the edited entity does not have a loaded config.', () => {
+		const entity = { kind: 'someKind', name: 'someName', id: 'someId' };
+		const fulfillment = editEntityRecord(
+			entity.kind,
+			entity.name,
+			entity.id,
+			{}
+		);
+		expect( fulfillment.next().value ).toEqual(
+			select( 'getEntity', entity.kind, entity.name )
+		);
+		// Don't pass back an entity config.
+		expect( fulfillment.next.bind( fulfillment ) ).toThrow(
+			`The entity being edited (${ entity.kind }, ${ entity.name }) does not have a loaded config.`
+		);
+	} );
+} );
 
 describe( 'saveEntityRecord', () => {
 	it( 'triggers a POST request for a new record', async () => {

--- a/packages/core-data/src/test/selectors.js
+++ b/packages/core-data/src/test/selectors.js
@@ -9,6 +9,7 @@ import deepFreeze from 'deep-freeze';
 import {
 	getEntityRecord,
 	getEntityRecords,
+	getEntityRecordNonTransientEdits,
 	getEmbedPreview,
 	isPreviewEmbedFallback,
 	canUser,
@@ -101,6 +102,17 @@ describe( 'getEntityRecords', () => {
 			{ slug: 'post' },
 			{ slug: 'page' },
 		] );
+	} );
+} );
+
+describe( 'getEntityRecordNonTransientEdits', () => {
+	it( 'should return an empty object when the entity does not have a loaded config.', () => {
+		const state = deepFreeze( {
+			entities: { config: {}, data: {} },
+		} );
+		expect(
+			getEntityRecordNonTransientEdits( state, 'someKind', 'someName', 'someId' )
+		).toEqual( {} );
 	} );
 } );
 


### PR DESCRIPTION
## Description

This PR adds some checks and guards to avoid throwing errors when `editEntityRecord` or `isEditedPostDirty` are called without the relevant entity config being loaded.

## How has this been tested?

It was verified that running:

```
wp.data.dispatch( 'core' ).editEntityRecord( 'someKind', 'someName', 'someId', {} )
```

and

```
wp.data.select( 'core' ).getEntityRecordNonTransientEdits( 'someKind', 'someName', 'someId' )
```

for inexistent entity configs is handled gracefully.

## Types of Changes

*Bug Fix:* `editEntityRecord` and `isEditedPostDirty` no longer throw an error when called before `core-data` is initialized.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
