### PR TITLE
[Monorepo] Setup Jitpack

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,8 @@
+before_install:
+   - yes | $ANDROID_HOME/tools/bin/sdkmanager "platforms;android-27"
+   - yes | $ANDROID_HOME/tools/bin/sdkmanager "build-tools;27.0.3"
+install:
+   - export TMPDIR=`dirname $(mktemp)`
+   - echo "Changing into the android folder of the Bridge module"
+   - pushd packages/react-native-bridge/android && ./gradlew --stacktrace clean -Pgroup=com.github.wordpress.gutenberg -Pversion=$VERSION install && popd
+   - pushd packages/react-native-aztec/android && ./gradlew --stacktrace clean -Pgroup=com.github.wordpress.gutenberg -Pversion=$VERSION install && popd

--- a/package.json
+++ b/package.json
@@ -188,6 +188,7 @@
 		"prebuild": "npm run check-engines",
 		"clean:packages": "rimraf ./packages/*/build ./packages/*/build-module ./packages/*/build-style ./packages/*/node_modules",
 		"prebuild:packages": "npm run clean:packages && lerna run build",
+		"jitpack:bundle:android": "npm run native bundle:android",
 		"build:packages": "node ./bin/packages/build.js",
 		"build": "npm run build:packages && wp-scripts build",
 		"check-engines": "wp-scripts check-engines",

--- a/packages/react-native-aztec/android/build.gradle
+++ b/packages/react-native-aztec/android/build.gradle
@@ -34,7 +34,7 @@ apply plugin: 'com.github.dcendents.android-maven'
 // import the `readReactNativeVersion()` function
 apply from: 'https://gist.githubusercontent.com/hypest/742448b9588b3a0aa580a5e80ae95bdf/raw/8eb62d40ee7a5104d2fcaeff21ce6f29bd93b054/readReactNativeVersion.gradle'
 
-group='com.github.wordpress-mobile.gutenberg-mobile'
+group='com.github.wordpress.gutenberg'
 
 // fallback flag value for when lib is compiled individually (e.g. via jitpack)
 project.ext.buildGutenbergFromSource = false

--- a/packages/react-native-bridge/android/build.gradle
+++ b/packages/react-native-bridge/android/build.gradle
@@ -39,9 +39,6 @@ if (isJitPack) {
         // Version of npm to use.
         npmVersion = '6.3.0'
 
-        // Version of Yarn to use.
-        yarnVersion = '1.10.1'
-
         // Base URL for fetching node distributions (change if you have a mirror).
         distBaseUrl = 'https://nodejs.org/dist'
 
@@ -57,11 +54,8 @@ if (isJitPack) {
         // Set the work directory for NPM
         npmWorkDir = file("${tmpdir}/npm")
 
-        // Set the work directory for Yarn
-        yarnWorkDir = file("${tmpdir}/yarn")
-
         // Set the work directory where node_modules should be located
-        nodeModulesDir = file("${project.projectDir}/../../")
+        nodeModulesDir = file("${project.projectDir}/../../../")
     }
 }
 
@@ -74,14 +68,13 @@ apply from: 'https://gist.githubusercontent.com/hypest/ceaf20a8e7d9b8404e4a5ff2e
 // import the `waitJitpack()` function
 apply from: 'https://gist.githubusercontent.com/hypest/f526fe0775dedce0ce0133f1400d22a4/raw/0008b271a0d28fc79957fd3c2a027f57e98f796a/wait-jitpack.gradle'
 
-group='com.github.wordpress-mobile.gutenberg-mobile'
+group='com.github.wordpress.gutenberg'
 
 // fallback flag value for when lib is compiled individually (e.g. via jitpack)
 project.ext.buildGutenbergFromSource = false
 
 android {
     compileSdkVersion 28
-
     defaultConfig {
         minSdkVersion 21
         targetSdkVersion 28
@@ -101,7 +94,7 @@ repositories {
 
     if (rootProject.ext.buildGutenbergFromSource) {
         // If building from source, use the local sources from node_modules
-        def nodeModulesPath = "${project.buildDir}/../../../../node_modules/"
+        def nodeModulesPath = "${project.projectDir}/../../../node_modules/"
         maven { url "${nodeModulesPath}/react-native/android" }
         maven { url "${nodeModulesPath}/jsc-android/dist" }
     } else {
@@ -128,9 +121,9 @@ dependencies {
 
         implementation 'com.facebook.react:react-native:+'
     } else {
-        implementation (waitJitpack('com.github.wordpress-mobile', 'react-native-svg', readHashedVersion('../../package.json', 'react-native-svg', 'dependencies')))
+        implementation (waitJitpack('com.github.wordpress-mobile', 'react-native-svg', readHashedVersion('../../react-native-editor/package.json', 'react-native-svg', 'dependencies')))
         implementation (waitJitpack('com.github.wordpress-mobile', 'react-native-recyclerview-list', 'f845b3c2c4411b8e97db23724bf1a535530c5435'))
-        implementation (waitJitpack('com.github.wordpress-mobile', 'react-native-video', readHashedVersion('../../package.json', 'react-native-video', 'dependencies')))
+        implementation (waitJitpack('com.github.wordpress-mobile', 'react-native-video', readHashedVersion('../../react-native-editor/package.json', 'react-native-video', 'dependencies')))
 
         def rnVersion = readReactNativeVersion('../package.json', 'peerDependencies')
         implementation "com.facebook.react:react-native:${rnVersion}"
@@ -140,8 +133,8 @@ dependencies {
 if (isJitPack) {
     def assetsFolder = 'src/main/assets'
 
-    task buildJSBundle(type: YarnTask) {
-        args = ['bundle:android']
+    task buildJSBundle(type: NpmTask) {
+        args = ['run', 'jitpack:bundle:android']
     }
 
     task ensureAssetsDirectory << {
@@ -150,7 +143,7 @@ if (isJitPack) {
 
     task copyJSBundle(type: Copy) {
         def origFileName = 'App.js'
-        def origWithPath = "../../bundle/android/${origFileName}"
+        def origWithPath = "../../react-native-editor/bundle/android/${origFileName}"
         def target = 'index.android.bundle'
         from origWithPath
         into assetsFolder
@@ -160,13 +153,13 @@ if (isJitPack) {
     }
 
     task cleanupNodeModulesFolder(type: Delete) {
-        delete '../../node_modules'
+        delete '../../../node_modules'
     }
 
     if (isJitPack) {
         preBuild.dependsOn(cleanupNodeModulesFolder)
         cleanupNodeModulesFolder.dependsOn(copyJSBundle)
         copyJSBundle.dependsOn(buildJSBundle)
-        buildJSBundle.dependsOn(yarn_install, ensureAssetsDirectory)
+        buildJSBundle.dependsOn(npm_install, ensureAssetsDirectory)
     }
 }

--- a/packages/react-native-editor/jitpack.yml
+++ b/packages/react-native-editor/jitpack.yml
@@ -1,9 +1,0 @@
-before_install:
-   - yes | $ANDROID_HOME/tools/bin/sdkmanager "platforms;android-27"
-   - yes | $ANDROID_HOME/tools/bin/sdkmanager "build-tools;27.0.3"
-install:
-   - export TMPDIR=`dirname $(mktemp)`
-   - echo "Changing into the android folder of the Bridge module"
-   - pushd react-native-gutenberg-bridge/android && ./gradlew --stacktrace clean -Pgroup=com.github.wordpress-mobile.gutenberg-mobile -Pversion=$VERSION install && popd
-   - pushd react-native-aztec/android && ./gradlew --stacktrace clean -Pgroup=com.github.wordpress-mobile.gutenberg-mobile -Pversion=$VERSION install && popd
-


### PR DESCRIPTION
## Description
This is a part of migration gutenberg-mobile to gutenberg repo.

In this PR I moved `jitpack.yml` file to the root level.

According to documentation https://jitpack.io/docs/BUILDING/ -> `Custom commands`
>You can create a jitpack.yml file in the root of your repository and override the build commands:

I also changed `yarn` to `npm` in the jitpack script that builds the JS bundle.

## How has this been tested?
- change submodule URL in `Wordpress-Android` to `gutenberg` repo
- checkout to the latest commit on the branch from this PR
- set `wp.BUILD_GUTENBERG_FROM_SOURCE = false` in `gradle.properites` file
- The app should build without issues

## Types of changes
move `jitpack.yml` to the root level and fix jitpack build scripts

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
