### PR TITLE
Update: Request only needed fields on parent page selector

### DIFF
--- a/packages/editor/src/components/page-attributes/parent.js
+++ b/packages/editor/src/components/page-attributes/parent.js
@@ -54,6 +54,7 @@ const applyWithSelect = withSelect( ( select ) => {
 		parent_exclude: postId,
 		orderby: 'menu_order',
 		order: 'asc',
+		_fields: 'id,parent,title',
 	};
 
 	return {


### PR DESCRIPTION
## Description
This PR comes as a result of the support topic https://wordpress.org/support/topic/slow-parent-page-attribute-for-websites-with-many-pages/.

Currently, we request a full page to compute the parent page UI. This may contain lots of information and make the request very slow to load.
This PR makes sure we request only the required fields.

## How has this been tested?
I verified that the parent page selector still works as expected.
I verified the on browser developer tools that the only fiends requested were id, parent, and title.