### PR TITLE
[DOCS] Bump @wordpress/scripts version

### DIFF
--- a/docs/designers-developers/developers/tutorials/javascript/js-build-setup.md
+++ b/docs/designers-developers/developers/tutorials/javascript/js-build-setup.md
@@ -87,7 +87,7 @@ Also, if you look at package.json file it will include a new section:
 
 ```json
 "devDependencies": {
-  "@wordpress/scripts": "5.0.0"
+  "@wordpress/scripts": "6.0.0"
 }
 ```
 


### PR DESCRIPTION
## Description
I was working my way through this tutorial and noticed `@wordpress/scripts` is now 6.0.0. 

Thought I'd open a baby PR. 
