### PR TITLE
Update: Use gradient classes in cover block

### DIFF
--- a/packages/block-library/src/cover/block.json
+++ b/packages/block-library/src/cover/block.json
@@ -32,6 +32,9 @@
 		"minHeight": {
 			"type": "number"
 		},
+		"gradient": {
+			"type": "string"
+		},
 		"customGradient": {
 			"type": "string"
 		}

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -38,6 +38,7 @@ import {
 	PanelColorSettings,
 	withColors,
 	ColorPalette,
+	__experimentalUseGradient,
 	__experimentalGradientPickerControl,
 	__experimentalGradientPicker,
 } from '@wordpress/block-editor';
@@ -257,7 +258,6 @@ function CoverEdit( {
 } ) {
 	const {
 		backgroundType,
-		customGradient,
 		dimRatio,
 		focalPoint,
 		hasParallax,
@@ -265,6 +265,11 @@ function CoverEdit( {
 		minHeight,
 		url,
 	} = attributes;
+	const {
+		gradientClass,
+		gradientValue,
+		setGradient,
+	} = __experimentalUseGradient();
 	const onSelectMedia = onCoverSelectMedia( setAttributes );
 
 	const toggleParallax = () => {
@@ -291,15 +296,15 @@ function CoverEdit( {
 		minHeight: ( temporaryMinHeight || minHeight ),
 	};
 
-	if ( customGradient && ! url ) {
-		style.background = customGradient;
+	if ( gradientValue && ! url ) {
+		style.background = gradientValue;
 	}
 
 	if ( focalPoint ) {
 		style.backgroundPosition = `${ focalPoint.x * 100 }% ${ focalPoint.y * 100 }%`;
 	}
 
-	const hasBackground = !! ( url || overlayColor.color || customGradient );
+	const hasBackground = !! ( url || overlayColor.color || gradientValue );
 
 	const controls = (
 		<>
@@ -389,14 +394,13 @@ function CoverEdit( {
 								label={ __( 'Overlay Gradient' ) }
 								onChange={
 									( newGradient ) => {
+										setGradient( newGradient );
 										setAttributes( {
-											customGradient: newGradient,
-											customOverlayColor: undefined,
 											overlayColor: undefined,
 										} );
 									}
 								}
-								value={ customGradient }
+								value={ gradientValue }
 							/>
 							{ !! url && (
 								<RangeControl
@@ -451,14 +455,13 @@ function CoverEdit( {
 						<__experimentalGradientPicker
 							onChange={
 								( newGradient ) => {
+									setGradient( newGradient );
 									setAttributes( {
-										customGradient: newGradient,
-										customOverlayColor: undefined,
 										overlayColor: undefined,
 									} );
 								}
 							}
-							value={ customGradient }
+							value={ gradientValue }
 							clearable={ false }
 						/>
 					</div>
@@ -475,7 +478,8 @@ function CoverEdit( {
 			'has-background-dim': dimRatio !== 0,
 			'has-parallax': hasParallax,
 			[ overlayColor.class ]: overlayColor.class,
-			'has-background-gradient': customGradient,
+			'has-background-gradient': gradientValue,
+			[ gradientClass ]: ! url && gradientClass,
 		}
 	);
 
@@ -515,11 +519,14 @@ function CoverEdit( {
 							src={ url }
 						/>
 					) }
-					{ url && customGradient && dimRatio !== 0 && (
+					{ url && gradientValue && dimRatio !== 0 && (
 						<span
 							aria-hidden="true"
-							className="wp-block-cover__gradient-background"
-							style={ { background: customGradient } }
+							className={ classnames(
+								'wp-block-cover__gradient-background',
+								gradientClass,
+							) }
+							style={ { background: gradientValue } }
 						/>
 					) }
 					{ VIDEO_BACKGROUND_TYPE === backgroundType && (

--- a/packages/block-library/src/cover/save.js
+++ b/packages/block-library/src/cover/save.js
@@ -9,6 +9,7 @@ import classnames from 'classnames';
 import {
 	InnerBlocks,
 	getColorClassName,
+	__experimentalGetGradientClass,
 } from '@wordpress/block-editor';
 
 /**
@@ -24,6 +25,7 @@ import {
 export default function save( { attributes } ) {
 	const {
 		backgroundType,
+		gradient,
 		customGradient,
 		customOverlayColor,
 		dimRatio,
@@ -34,6 +36,8 @@ export default function save( { attributes } ) {
 		minHeight,
 	} = attributes;
 	const overlayColorClass = getColorClassName( 'background-color', overlayColor );
+	const gradientClass = __experimentalGetGradientClass( gradient );
+
 	const style = backgroundType === IMAGE_BACKGROUND_TYPE ?
 		backgroundImageStyles( url ) :
 		{};
@@ -55,16 +59,20 @@ export default function save( { attributes } ) {
 			'has-background-dim': dimRatio !== 0,
 			'has-parallax': hasParallax,
 			'has-background-gradient': customGradient,
+			[ gradientClass ]: ! url && gradientClass,
 		},
 	);
 
 	return (
 		<div className={ classes } style={ style }>
-			{ url && customGradient && dimRatio !== 0 && (
+			{ url && ( gradient || customGradient ) && dimRatio !== 0 && (
 				<span
 					aria-hidden="true"
-					className="wp-block-cover__gradient-background"
-					style={ { background: customGradient } }
+					className={ classnames(
+						'wp-block-cover__gradient-background',
+						gradientClass
+					) }
+					style={ customGradient ? { background: customGradient } : undefined }
 				/>
 			) }
 			{ VIDEO_BACKGROUND_TYPE === backgroundType && url && ( <video


### PR DESCRIPTION
## Description
This PR makes cover block use gradient classes. It was not possible to do it from the start because the block needed to be refactored into a functional component.
cc: @youknowriad 

## How has this been tested?
I added a cover block with a simple gradient background.
I added a cover block with an image and gradient overlay.
I added a video block with an image and gradient overlay.
I published the post with the three blocks and verified it looked as expected. On the code editor, the editor used classes and not inline styles to specify the gradient.