### PR TITLE
Fix incorrect example for ServerSideRender docs

### DIFF
--- a/packages/server-side-render/README.md
+++ b/packages/server-side-render/README.md
@@ -79,7 +79,7 @@ This is a [render prop](https://reactjs.org/docs/render-props.html). While the r
 Render core/archives preview.
 
 ```jsx
-import { ServerSideRender } from '@wordpress/server-side-render';
+import ServerSideRender from '@wordpress/server-side-render';
 
 const MyServerSideRender = () => (
 	<ServerSideRender


### PR DESCRIPTION
## Description
`ServerSideRender` is exported on the default so the import example was wrong.

## How has this been tested?

No runtime code is affected, this is a documentation change only.
