### PR TITLE
Navigation: Remove from experimental

### DIFF
--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -52,17 +52,6 @@ function gutenberg_initialize_experiments_settings() {
 		)
 	);
 	add_settings_field(
-		'gutenberg-menu-block',
-		__( 'Menu Block', 'gutenberg' ),
-		'gutenberg_display_experiment_field',
-		'gutenberg-experiments',
-		'gutenberg_experiments_section',
-		array(
-			'label' => __( 'Enable Navigation Menu Block', 'gutenberg' ),
-			'id'    => 'gutenberg-menu-block',
-		)
-	);
-	add_settings_field(
 		'gutenberg-block-directory',
 		__( 'Block Directory', 'gutenberg' ),
 		'gutenberg_display_experiment_field',
@@ -132,10 +121,8 @@ function gutenberg_display_experiment_section() {
 function gutenberg_experiments_editor_settings( $settings ) {
 	$experiments_settings = array(
 		'__experimentalEnableLegacyWidgetBlock' => gutenberg_is_experiment_enabled( 'gutenberg-widget-experiments' ),
-		'__experimentalEnableMenuBlock'         => gutenberg_is_experiment_enabled( 'gutenberg-menu-block' ),
 		'__experimentalBlockDirectory'          => gutenberg_is_experiment_enabled( 'gutenberg-block-directory' ),
 		'__experimentalEnableFullSiteEditing'   => gutenberg_is_experiment_enabled( 'gutenberg-full-site-editing' ),
-
 	);
 
 	$gradient_presets = current( (array) get_theme_support( '__experimental-editor-gradient-presets' ) );

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -408,7 +408,6 @@ _Properties_
 -   _showInserterHelpPanel_ `boolean`: Whether or not the inserter help panel is shown
 -   _\_\_experimentalCanUserUseUnfilteredHTML_ `boolean`: Whether the user should be able to use unfiltered HTML or the HTML should be filtered e.g., to remove elements considered insecure like iframes.
 -   _\_\_experimentalEnableLegacyWidgetBlock_ `boolean`: Whether the user has enabled the Legacy Widget Block
--   _\_\_experimentalEnableMenuBlock_ `boolean`: Whether the user has enabled the Menu Block
 -   _\_\_experimentalBlockDirectory_ `boolean`: Whether the user has enabled the Block Directory
 -   _\_\_experimentalEnableFullSiteEditing_ `boolean`: Whether the user has enabled Full Site Editing
 

--- a/packages/block-editor/src/store/defaults.js
+++ b/packages/block-editor/src/store/defaults.js
@@ -31,7 +31,6 @@ export const PREFERENCES_DEFAULTS = {
  * @property {boolean} showInserterHelpPanel Whether or not the inserter help panel is shown
  * @property {boolean} __experimentalCanUserUseUnfilteredHTML Whether the user should be able to use unfiltered HTML or the HTML should be filtered e.g., to remove elements considered insecure like iframes.
  * @property {boolean} __experimentalEnableLegacyWidgetBlock Whether the user has enabled the Legacy Widget Block
- * @property {boolean} __experimentalEnableMenuBlock Whether the user has enabled the Menu Block
  * @property {boolean} __experimentalBlockDirectory Whether the user has enabled the Block Directory
  * @property {boolean} __experimentalEnableFullSiteEditing Whether the user has enabled Full Site Editing
  */
@@ -152,7 +151,6 @@ export const SETTINGS_DEFAULTS = {
 	showInserterHelpPanel: true,
 	__experimentalCanUserUseUnfilteredHTML: false,
 	__experimentalEnableLegacyWidgetBlock: false,
-	__experimentalEnableMenuBlock: false,
 	__experimentalBlockDirectory: false,
 	__experimentalEnableFullSiteEditing: false,
 	gradients: [

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -128,6 +128,8 @@ export const registerCoreBlocks = () => {
 		latestPosts,
 		missing,
 		more,
+		navigation,
+		navigationLink,
 		nextpage,
 		preformatted,
 		pullquote,
@@ -172,14 +174,11 @@ export const __experimentalRegisterExperimentalCoreBlocks =
 		( settings ) => {
 			const {
 				__experimentalEnableLegacyWidgetBlock,
-				__experimentalEnableMenuBlock,
 				__experimentalEnableFullSiteEditing,
 			} = settings
 
 				;[
 				__experimentalEnableLegacyWidgetBlock ? legacyWidget : null,
-				__experimentalEnableMenuBlock ? navigation : null,
-				__experimentalEnableMenuBlock ? navigationLink : null,
 				socialLinks,
 				...socialLink.sites,
 

--- a/packages/block-library/src/navigation/index.js
+++ b/packages/block-library/src/navigation/index.js
@@ -20,6 +20,8 @@ export const settings = {
 
 	keywords: [ __( 'menu' ), __( 'navigation' ), __( 'links' ) ],
 
+	category: 'layout',
+
 	supports: {
 		align: [ 'wide', 'full' ],
 		anchor: true,

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -128,7 +128,6 @@ function register_block_core_navigation() {
 	register_block_type(
 		'core/navigation',
 		array(
-			'category'        => 'layout',
 			'attributes'      => array(
 				'className'        => array(
 					'type' => 'string',

--- a/packages/e2e-tests/specs/experimental/block-transforms.test.js
+++ b/packages/e2e-tests/specs/experimental/block-transforms.test.js
@@ -109,7 +109,6 @@ describe( 'Block transforms', () => {
 	beforeAll( async () => {
 		await enableExperimentalFeatures( [
 			'#gutenberg-widget-experiments',
-			'#gutenberg-menu-block',
 			'#gutenberg-full-site-editing',
 		] );
 		await createNewPost();
@@ -131,7 +130,6 @@ describe( 'Block transforms', () => {
 		async () => {
 			await disableExperimentalFeatures( [
 				'#gutenberg-widget-experiments',
-				'#gutenberg-menu-block',
 				'#gutenberg-full-site-editing',
 			] );
 		}

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -104,7 +104,6 @@ class EditorProvider extends Component {
 				'titlePlaceholder',
 				'onUpdateDefaultBlockStyles',
 				'__experimentalEnableLegacyWidgetBlock',
-				'__experimentalEnableMenuBlock',
 				'__experimentalBlockDirectory',
 				'__experimentalEnableFullSiteEditing',
 				'showInserterHelpPanel',

--- a/test/integration/full-content/full-content.test.js
+++ b/test/integration/full-content/full-content.test.js
@@ -51,7 +51,6 @@ describe( 'full post content fixture', () => {
 		unstable__bootstrapServerSideBlockDefinitions( require( './server-registered.json' ) );
 		const settings = {
 			__experimentalEnableLegacyWidgetBlock: true,
-			__experimentalEnableMenuBlock: true,
 			__experimentalEnableFullSiteEditing: true,
 		};
 		// Load all hooks that modify blocks


### PR DESCRIPTION
## Description
Removes the Navigation block from the experiments page and makes it accessible to anyone.

Depends on #18551. 
Fixes #18550. 

## How has this been tested?

No more `Navigation Block` in the experimental Gutenberg section:

<img src="https://user-images.githubusercontent.com/77539/69262689-ad666d80-0ba2-11ea-84d2-02a557b9a08a.png" width="300px" />

<img src="https://user-images.githubusercontent.com/77539/69262723-b7886c00-0ba2-11ea-9875-118f8d7034fb.png" width="300px" />

Loading menus in Editor and front-end on local test environment.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
