### PR TITLE
Switch require_once to require for loading asset files

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -237,9 +237,7 @@ function gutenberg_register_packages_scripts( &$scripts ) {
 
 		// Replace `.js` extension with `.asset.php` to find the generated dependencies file.
 		$asset_file   = substr( $path, 0, -3 ) . '.asset.php';
-		$asset        = file_exists( $asset_file )
-			? require_once( $asset_file )
-			: null;
+		$asset        = include( $asset_file );
 		$dependencies = isset( $asset['dependencies'] ) ? $asset['dependencies'] : array();
 		$version      = isset( $asset['version'] ) ? $asset['version'] : filemtime( $path );
 

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -237,7 +237,9 @@ function gutenberg_register_packages_scripts( &$scripts ) {
 
 		// Replace `.js` extension with `.asset.php` to find the generated dependencies file.
 		$asset_file   = substr( $path, 0, -3 ) . '.asset.php';
-		$asset        = include( $asset_file );
+		$asset        = file_exists( $asset_file )
+			? require( $asset_file )
+			: null;
 		$dependencies = isset( $asset['dependencies'] ) ? $asset['dependencies'] : array();
 		$version      = isset( $asset['version'] ) ? $asset['version'] : filemtime( $path );
 


### PR DESCRIPTION
## Description

If the function gets called twice the dependency array will reset due to the `require_once()` return value. The asset_file is being included to a variable, not loaded like a class.

Fixes #18596 

I switched to use `include()` because the function is more clear what is happening. Plus will not throw a fatal if the file does not exist, it simply returns false with a warning. This also allows removing the extra check for file existence.

Additionally, if the `index.asset.php` file does not exist, then we have a build issue since it is part of the bundle. We shouldn't need to detect if it exists and swallow that error silently. This PR will properly throw a warning as it should with a missing file that is needed.

## How has this been tested?

Confirmed loading still works as expected.

Function reference: [PHP include documentation](https://www.php.net/manual/en/function.include.php)

## Types of changes

Fixes loading of asset_file and dependencies.
