### PR TITLE
Block Editor: Implement a responsive grid mode for `InnerBlocks` and a basic grid block that leverages it.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7262,12 +7262,21 @@
 				"lodash": "^4.17.15",
 				"memize": "^1.0.5",
 				"react-autosize-textarea": "^3.0.2",
+				"react-grid-layout": "^0.17.1",
 				"react-spring": "^8.0.19",
 				"redux-multi": "^0.1.12",
 				"refx": "^3.0.0",
 				"rememo": "^3.0.0",
 				"tinycolor2": "^1.4.1",
-				"traverse": "^0.6.6"
+				"traverse": "^0.6.6",
+				"uuid": "^3.3.3"
+			},
+			"dependencies": {
+				"uuid": {
+					"version": "3.3.3",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+					"integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
+				}
 			}
 		},
 		"@wordpress/block-library": {
@@ -21331,8 +21340,7 @@
 		"lodash.isequal": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-			"integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
-			"dev": true
+			"integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
 		},
 		"lodash.ismatch": {
 			"version": "4.4.0",
@@ -27637,7 +27645,6 @@
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.0.3.tgz",
 			"integrity": "sha512-4vD6zms+9QGeZ2RQXzlUBw8PBYUXy+dzYX5r22idjp9YwQKIIvD/EojL0rbjS1GK4C3P0rAJnmKa8gDQYWUDyA==",
-			"dev": true,
 			"requires": {
 				"classnames": "^2.2.5",
 				"prop-types": "^15.6.0"
@@ -27665,6 +27672,18 @@
 				"focus-lock": "^0.6.3",
 				"prop-types": "^15.6.2",
 				"react-clientside-effect": "^1.2.0"
+			}
+		},
+		"react-grid-layout": {
+			"version": "0.17.1",
+			"resolved": "https://registry.npmjs.org/react-grid-layout/-/react-grid-layout-0.17.1.tgz",
+			"integrity": "sha512-L+wHFevK+klKvoAHuHn4Q5qHtrW+4zCj0F3QnpR7wZbkZPmrdaWC7cztFLXwINq6WnOWGE22BCTCDCHJi7dVDw==",
+			"requires": {
+				"classnames": "2.x",
+				"lodash.isequal": "^4.0.0",
+				"prop-types": "^15.0.0",
+				"react-draggable": "^4.0.0",
+				"react-resizable": "^1.9.0"
 			}
 		},
 		"react-helmet-async": {
@@ -28339,6 +28358,15 @@
 			"resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.2.0.tgz",
 			"integrity": "sha512-ITw8t/HOFNose2yf1y9pPFSSeB9ISOq2JdHpuZvj/Qb+iSsLml8GkkHdDlURzieO7B3dFDtMrrneZLl3N5z/hg==",
 			"dev": true
+		},
+		"react-resizable": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/react-resizable/-/react-resizable-1.9.0.tgz",
+			"integrity": "sha512-YAls7H4+34MMDg2cPnhVfLtes//XWvrLNuxbVwawwJFIGlPvhGi8BLCcIsDdLJ2CCCxtymVotk2Hq4RtPJ7t5g==",
+			"requires": {
+				"prop-types": "15.x",
+				"react-draggable": "^4.0.3"
+			}
 		},
 		"react-select": {
 			"version": "3.0.8",

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -49,12 +49,14 @@
 		"lodash": "^4.17.15",
 		"memize": "^1.0.5",
 		"react-autosize-textarea": "^3.0.2",
+		"react-grid-layout": "^0.17.1",
 		"react-spring": "^8.0.19",
 		"redux-multi": "^0.1.12",
 		"refx": "^3.0.0",
 		"rememo": "^3.0.0",
 		"tinycolor2": "^1.4.1",
-		"traverse": "^0.6.6"
+		"traverse": "^0.6.6",
+		"uuid": "^3.3.3"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -618,7 +618,7 @@ function BlockListBlock( {
 }
 
 const applyWithSelect = withSelect(
-	( select, { clientId, rootClientId, isLargeViewport } ) => {
+	( select, { clientId, rootClientId, isLargeViewport, isLocked } ) => {
 		const {
 			isBlockSelected,
 			isAncestorMultiSelected,
@@ -661,11 +661,13 @@ const applyWithSelect = withSelect(
 			isCaretWithinFormattedText: isCaretWithinFormattedText(),
 			mode: getBlockMode( clientId ),
 			isSelectionEnabled: isSelectionEnabled(),
-			initialPosition: isSelected ? getSelectedBlocksInitialCaretPosition() : null,
+			initialPosition: isSelected ?
+				getSelectedBlocksInitialCaretPosition() :
+				null,
 			isEmptyDefaultBlock:
 				name && isUnmodifiedDefaultBlock( { name, attributes } ),
 			isMovable: 'all' !== templateLock,
-			isLocked: !! templateLock,
+			isLocked: isLocked || !! templateLock,
 			isFocusMode: focusMode && isLargeViewport,
 			hasFixedToolbar: hasFixedToolbar && isLargeViewport,
 			isLast: index === blockOrder.length - 1,

--- a/packages/block-editor/src/components/block-list/grid-utils.js
+++ b/packages/block-editor/src/components/block-list/grid-utils.js
@@ -1,0 +1,203 @@
+/**
+ * External dependencies
+ */
+import uuid from 'uuid/v4';
+
+export const BREAKPOINTS = { lg: 1200, md: 996, sm: 768, xs: 480, xxs: 0 };
+export const COLS = { lg: 12, md: 10, sm: 6, xs: 4, xxs: 2 };
+export const MIN_ROWS = 2;
+
+export function createInitialLayouts( grid, blockClientIds ) {
+	return Object.keys( BREAKPOINTS ).reduce( ( acc, breakpoint ) => {
+		// Hydrate grid layouts, if any, with new block client IDs.
+		acc[ breakpoint ] =
+			grid && grid[ breakpoint ] ?
+				grid[ breakpoint ].map( ( item, i ) => ( {
+					...item,
+					i: `block-${ blockClientIds[ i ] }`,
+				} ) ) :
+				[];
+		return acc;
+	}, {} );
+}
+
+export function appendNewBlocks(
+	nextLayouts,
+	breakpoint,
+	lastClickedBlockAppenderId,
+	prevBlockClientIds,
+	blockClientIds
+) {
+	if (
+		blockClientIds.length &&
+		! prevBlockClientIds.includes( blockClientIds[ blockClientIds.length - 1 ] )
+	) {
+		// If a block client ID has been added, make its block's position and dimensions
+		// that of the last clicked block appender, since it must be the one that added it.
+		const appenderItem = nextLayouts[ breakpoint ].find(
+			( item ) => item.i === lastClickedBlockAppenderId
+		);
+		nextLayouts = Object.keys( nextLayouts ).reduce( ( acc, _breakpoint ) => {
+			acc[ _breakpoint ] = nextLayouts[ _breakpoint ]
+				.map( ( item ) => {
+					switch ( item.i ) {
+						case lastClickedBlockAppenderId:
+							return {
+								...appenderItem,
+								i: `block-${ blockClientIds[ blockClientIds.length - 1 ] }`,
+							};
+						case blockClientIds[ blockClientIds.length - 1 ]:
+							return null;
+						default:
+							return item;
+					}
+				} )
+				.filter( Boolean );
+			return acc;
+		}, {} );
+	}
+
+	return nextLayouts;
+}
+
+export function resizeOverflowingBlocks( nextLayouts, breakpoint, nodes ) {
+	const cellChanges = {};
+	const itemsMap = nextLayouts[ breakpoint ].reduce( ( acc, item ) => {
+		acc[ item.i ] = item;
+		return acc;
+	}, {} );
+
+	for ( const node of Object.values( nodes ) ) {
+		if ( ! itemsMap[ node.id ] ) {
+			continue;
+		}
+		const { clientWidth, clientHeight } = node.parentNode;
+		const minCols = Math.ceil(
+			node.offsetWidth / ( clientWidth / itemsMap[ node.id ].w )
+		);
+		const minRows = Math.ceil(
+			( node.offsetHeight - 20 ) / ( clientHeight / itemsMap[ node.id ].h )
+		);
+		if ( itemsMap[ node.id ].w < minCols || itemsMap[ node.id ].h < minRows ) {
+			cellChanges[ node.id ] = {
+				w: Math.max( itemsMap[ node.id ].w, minCols ),
+				h: Math.max( itemsMap[ node.id ].h, minRows ),
+			};
+		}
+	}
+	if ( Object.keys( cellChanges ).length ) {
+		nextLayouts = {
+			...nextLayouts,
+			[ breakpoint ]: nextLayouts[ breakpoint ].map( ( item ) =>
+				cellChanges[ item.i ] ? { ...item, ...cellChanges[ item.i ] } : item
+			),
+		};
+	}
+
+	return nextLayouts;
+}
+
+export function cropAndFillEmptyCells( nextLayouts, breakpoint ) {
+	const maxRow =
+		Math.max(
+			MIN_ROWS,
+			...nextLayouts[ breakpoint ]
+				.filter( ( item ) => ! item.i.startsWith( 'block-appender' ) )
+				.map( ( item ) => item.y + item.h )
+		) - 1;
+	if ( nextLayouts[ breakpoint ].some( ( item ) => item.y > maxRow ) ) {
+		// Crop extra rows.
+		nextLayouts = {
+			...nextLayouts,
+			[ breakpoint ]: nextLayouts[ breakpoint ].filter( ( item ) => item.y <= maxRow ),
+		};
+	}
+
+	const emptyCells = {};
+	for (
+		let col = 0;
+		col <=
+		Math.max(
+			COLS[ breakpoint ],
+			...nextLayouts[ breakpoint ].map( ( item ) => item.x + item.w )
+		) -
+			1;
+		col++
+	) {
+		for ( let row = 0; row <= maxRow; row++ ) {
+			emptyCells[ `${ col } | ${ row }` ] = true;
+		}
+	}
+	for ( const item of nextLayouts[ breakpoint ] ) {
+		for ( let col = item.x; col < item.x + item.w; col++ ) {
+			for ( let row = item.y; row < item.y + item.h; row++ ) {
+				delete emptyCells[ `${ col } | ${ row }` ];
+			}
+		}
+	}
+	if ( Object.keys( emptyCells ).length ) {
+		// Fill empty cells with block appenders.
+		nextLayouts = {
+			...nextLayouts,
+			[ breakpoint ]: [
+				...nextLayouts[ breakpoint ],
+				...Object.keys( emptyCells ).map( ( emptyCell ) => {
+					const [ col, row ] = emptyCell.split( ' | ' );
+					return {
+						i: `block-appender-${ uuid() }`,
+						x: Number( col ),
+						y: Number( row ),
+						w: 1,
+						h: 1,
+					};
+				} ),
+			],
+		};
+	}
+
+	return nextLayouts;
+}
+
+export function hashGrid( grid ) {
+	return Object.values( JSON.stringify( grid ) ).reduce( ( acc, char ) => {
+		/* eslint-disable no-bitwise */
+		acc = ( acc << 5 ) - acc + char.charCodeAt( 0 );
+		return acc & acc;
+		/* eslint-enable no-bitwise */
+	} );
+}
+
+function createGridItemsStyleRules( gridId, items ) {
+	return items
+		.map(
+			( item, i ) => `#${ gridId } > #editor-block-list__grid-content-item-${ i } {
+		grid-area: ${ item.y + 1 } / ${ item.x + 1 } / ${ item.y + 1 + item.h } / ${ item.x +
+				1 +
+				item.w }
+	}`
+		)
+		.join( '\n\n	' );
+}
+export function createGridStyleRules( gridId, grid ) {
+	return Object.keys( grid )
+		.sort( ( a, b ) => BREAKPOINTS[ a ] - BREAKPOINTS[ b ] )
+		.map( ( breakpoint ) => {
+			const maxCol =
+				Math.max(
+					COLS[ breakpoint ],
+					...grid[ breakpoint ].map( ( item ) => item.x + item.w )
+				) - 1;
+			const maxRow =
+				Math.max( MIN_ROWS, ...grid[ breakpoint ].map( ( item ) => item.y + item.h ) ) - 1;
+			return `@media (min-width: ${ BREAKPOINTS[ breakpoint ] }px) {
+	#${ gridId } {
+		grid-template-columns: repeat(${ maxCol + 1 }, 1fr);
+		grid-template-rows: repeat(${ maxRow + 1 }, 1fr);
+
+	}
+
+	${ createGridItemsStyleRules( gridId, grid[ breakpoint ] ) }
+}`;
+		} )
+		.join( '\n\n' );
+}

--- a/packages/block-editor/src/components/block-list/grid.js
+++ b/packages/block-editor/src/components/block-list/grid.js
@@ -1,0 +1,224 @@
+/**
+ * External dependencies
+ */
+import _ReactGridLayout, { WidthProvider } from 'react-grid-layout';
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { useSelect, useDispatch } from '@wordpress/data';
+import { useState, useRef, useEffect, RawHTML } from '@wordpress/element';
+import { Toolbar } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { serialize } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import BlockListAppender from '../block-list-appender';
+import ButtonBlockAppender from '../inner-blocks/button-block-appender';
+import BlockAsyncModeProvider from './block-async-mode-provider';
+import BlockListBlock from './block';
+import BlockControls from '../block-controls';
+import {
+	createInitialLayouts,
+	appendNewBlocks,
+	resizeOverflowingBlocks,
+	cropAndFillEmptyCells,
+	COLS,
+	BREAKPOINTS,
+	hashGrid,
+	createGridStyleRules,
+} from './grid-utils';
+
+const ReactGridLayout = WidthProvider( _ReactGridLayout );
+function BlockGrid( {
+	rootClientId,
+	blockClientIds,
+	nodes,
+	className,
+	hasMultiSelection,
+	multiSelectedBlockClientIds,
+	selectedBlockClientId,
+	setBlockRef,
+	onSelectionStart,
+} ) {
+	const { grid } = useSelect(
+		( select ) => select( 'core/block-editor' ).getBlockAttributes( rootClientId ),
+		[ rootClientId ]
+	);
+	const { updateBlockAttributes } = useDispatch( 'core/block-editor' );
+
+	const [ breakpoint, setBreakpoint ] = useState( 'xxs' );
+	const [ layouts, setLayouts ] = useState(
+		createInitialLayouts( grid, blockClientIds )
+	);
+
+	const lastClickedBlockAppenderIdRef = useRef();
+	const blockClientIdsRef = useRef( blockClientIds );
+
+	useEffect(
+		() => {
+			let nextLayouts = layouts;
+
+			nextLayouts = appendNewBlocks(
+				nextLayouts,
+				breakpoint,
+				lastClickedBlockAppenderIdRef.current,
+				blockClientIdsRef.current,
+				blockClientIds
+			);
+			nextLayouts = resizeOverflowingBlocks( nextLayouts, breakpoint, nodes );
+			nextLayouts = cropAndFillEmptyCells( nextLayouts, breakpoint );
+
+			if ( layouts !== nextLayouts ) {
+				setLayouts( nextLayouts );
+			}
+
+			blockClientIdsRef.current = blockClientIds;
+		},
+		// We reference `grid` here instead of `layouts` to avoid
+		// potential chained updates when block appenders are being displaced
+		// and overflows happen. `grid` will only change with
+		// persistent user changes and not when block appenders
+		// are displaced.
+		[ grid, blockClientIds, nodes, breakpoint ]
+	);
+
+	return (
+		<div
+			className={ classnames(
+				'editor-block-list__layout block-editor-block-list__layout block-editor-block-list__grid',
+				className
+			) }
+		>
+			<ReactGridLayout
+				cols={ COLS[ breakpoint ] }
+				draggableCancel='input,textarea,[contenteditable=""],[contenteditable="true"]'
+				layout={ layouts[ breakpoint ] }
+				margin={ [ 0, 0 ] }
+				onLayoutChange={ ( nextLayout ) => {
+					setLayouts( { ...layouts, [ breakpoint ]: nextLayout } );
+					updateBlockAttributes( rootClientId, {
+						grid: {
+							...grid,
+							[ breakpoint ]: nextLayout.filter(
+								( item ) => ! item.i.startsWith( 'block-appender' )
+							),
+						},
+					} );
+				} }
+				rowHeight={ 200 }
+				style={ {
+					minWidth: BREAKPOINTS[ breakpoint ],
+				} }
+				verticalCompact={ false }
+			>
+				{ [
+					...layouts[ breakpoint ]
+						.filter( ( item ) => item.i.startsWith( 'block-appender' ) )
+						.map( ( item ) => (
+							<div
+								key={ item.i }
+								id={ item.i }
+								onClick={ ( { currentTarget: { id } } ) =>
+									( lastClickedBlockAppenderIdRef.current = id )
+								}
+								onKeyPress={ ( { currentTarget: { id } } ) =>
+									( lastClickedBlockAppenderIdRef.current = id )
+								}
+								role="button"
+								tabIndex="0"
+							>
+								<BlockListAppender
+									rootClientId={ rootClientId }
+									renderAppender={ ButtonBlockAppender }
+								/>
+							</div>
+						) ),
+					...blockClientIds.map( ( blockClientId ) => {
+						const isBlockInSelection = hasMultiSelection ?
+							multiSelectedBlockClientIds.includes( blockClientId ) :
+							selectedBlockClientId === blockClientId;
+						return (
+							<div
+								key={ `block-${ blockClientId }` }
+								className="block-editor-block-list__grid-item"
+							>
+								<BlockAsyncModeProvider
+									clientId={ blockClientId }
+									isBlockInSelection={ isBlockInSelection }
+								>
+									<BlockListBlock
+										rootClientId={ rootClientId }
+										clientId={ blockClientId }
+										blockRef={ setBlockRef }
+										onSelectionStart={ onSelectionStart }
+										isLocked
+									/>
+								</BlockAsyncModeProvider>
+							</div>
+						);
+					} ),
+				] }
+			</ReactGridLayout>
+			<BlockControls>
+				<Toolbar
+					icon="smartphone"
+					label={ __( 'Change breakpoint' ) }
+					controls={ Object.keys( BREAKPOINTS ).map( ( _breakpoint ) => ( {
+						title: `${ _breakpoint } (>= ${ BREAKPOINTS[ _breakpoint ] }px)`,
+						isActive: breakpoint === _breakpoint,
+						onClick: setBreakpoint.bind( null, _breakpoint ),
+					} ) ) }
+					isCollapsed
+				/>
+			</BlockControls>
+		</div>
+	);
+}
+
+BlockGrid.Content = ( { attributes: { grid, align }, innerBlocks } ) => {
+	const gridId = `editor-block-list__grid-content-${ hashGrid( grid ) }`;
+	return (
+		<div id={ gridId } className={ `align${ align }` }>
+			<RawHTML>
+				{ `<style>
+#${ gridId } {
+	display: grid;
+}
+
+${ createGridStyleRules( gridId, grid ) }
+</style>` }
+			</RawHTML>
+			{ /**
+      * We loop over the grid and not inner blocks directly,
+      * because inner blocks are not provided during validation,
+      * so this block would never pass validation if its
+      * own markup depended on its inner blocks.
+      */ }
+			{ Object.keys( grid )
+				.reduce(
+					( acc, breakpoint ) =>
+						// We use the breakpoint with the most blocks as its set of
+						// blocks will be a superset of the others' and therefore
+						// allow us to render all blocks once.
+						grid[ breakpoint ].length > acc.length ? grid[ breakpoint ] : acc,
+					grid.xxs
+				)
+				.map( ( _item, i ) => (
+					<div id={ `editor-block-list__grid-content-item-${ i }` } key={ i }>
+						{ /* Guard here, because inner blocks are not available during validation. */ }
+						{ innerBlocks[ i ] && (
+							<RawHTML>
+								{ serialize( innerBlocks[ i ], { isInnerBlocks: true } ) }
+							</RawHTML>
+						) }
+					</div>
+				) ) }
+		</div>
+	);
+};
+
+export default BlockGrid;

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -28,6 +28,7 @@ import BlockAsyncModeProvider from './block-async-mode-provider';
 import BlockListBlock from './block';
 import BlockListAppender from '../block-list-appender';
 import { getBlockDOMNode } from '../../utils/dom';
+import BlockGrid from './grid';
 
 /**
  * If the block count exceeds the threshold, we disable the reordering animation
@@ -202,7 +203,19 @@ class BlockList extends Component {
 			hasMultiSelection,
 			renderAppender,
 			enableAnimation,
+			__experimentalGridMode,
 		} = this.props;
+
+		if ( __experimentalGridMode ) {
+			return (
+				<BlockGrid
+					{ ...this.props }
+					nodes={ this.nodes }
+					setBlockRef={ this.setBlockRef }
+					onSelectionStart={ this.onSelectionStart }
+				/>
+			);
+		}
 
 		return (
 			<div className={
@@ -249,7 +262,7 @@ class BlockList extends Component {
 	}
 }
 
-export default compose( [
+BlockList = compose( [
 	// This component needs to always be synchronous
 	// as it's the one changing the async mode
 	// depending on the block selection.
@@ -299,3 +312,7 @@ export default compose( [
 		};
 	} ),
 ] )( BlockList );
+
+BlockList.GridContent = BlockGrid.Content;
+
+export default BlockList;

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -1153,3 +1153,33 @@
 		margin-bottom: auto;
 	}
 }
+
+/**
+ * Block Grid
+ */
+@import "node_modules/react-grid-layout/css/styles";
+@import "node_modules/react-resizable/css/styles";
+
+.block-editor-block-list__grid {
+	overflow: scroll;
+
+	.react-grid-item.react-grid-placeholder {
+		background-color: $blue-medium-highlight;
+	}
+
+	.block-list-appender {
+		&.block-list-appender {
+			margin: 0;
+		}
+
+		&,
+		& > *,
+		& > * > * {
+			height: 100%;
+		}
+	}
+}
+
+.block-editor-block-list__grid-item {
+	padding: 0 20px;
+}

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -111,6 +111,7 @@ class InnerBlocks extends Component {
 			__experimentalTemplateOptions: templateOptions,
 			__experimentalOnSelectTemplateOption: onSelectTemplateOption,
 			__experimentalAllowTemplateOptionSkip: allowTemplateOptionSkip,
+			__experimentalGridMode,
 		} = this.props;
 		const { templateInProcess } = this.state;
 
@@ -133,6 +134,7 @@ class InnerBlocks extends Component {
 							rootClientId={ clientId }
 							renderAppender={ renderAppender }
 							__experimentalMoverDirection={ moverDirection }
+							__experimentalGridMode={ __experimentalGridMode }
 						/>
 				) }
 			</div>
@@ -186,7 +188,12 @@ InnerBlocks.DefaultBlockAppender = DefaultBlockAppender;
 InnerBlocks.ButtonBlockAppender = ButtonBlockAppender;
 
 InnerBlocks.Content = withBlockContentContext(
-	( { BlockContent } ) => <BlockContent />
+	( { BlockContent, __experimentalGridMode } ) =>
+		__experimentalGridMode ? (
+			<BlockList.GridContent attributes={ BlockContent.attributes } innerBlocks={ BlockContent.innerBlocks } />
+		) : (
+			<BlockContent />
+		)
 );
 
 /**

--- a/packages/block-library/src/grid/block.json
+++ b/packages/block-library/src/grid/block.json
@@ -1,0 +1,10 @@
+{
+	"name": "core/grid",
+	"category": "layout",
+	"supports": { "align": true },
+	"attributes": {
+		"grid": {
+			"type": "object"
+		}
+	}
+}

--- a/packages/block-library/src/grid/edit.js
+++ b/packages/block-library/src/grid/edit.js
@@ -1,0 +1,8 @@
+/**
+ * WordPress dependencies
+ */
+import { InnerBlocks } from '@wordpress/block-editor';
+
+export default function GridEdit() {
+	return <InnerBlocks __experimentalGridMode />;
+}

--- a/packages/block-library/src/grid/index.js
+++ b/packages/block-library/src/grid/index.js
@@ -1,0 +1,20 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+import edit from './edit';
+import save from './save';
+
+const { name } = metadata;
+export { metadata, name };
+
+export const settings = {
+	title: __( 'Grid' ),
+	edit,
+	save,
+};

--- a/packages/block-library/src/grid/save.js
+++ b/packages/block-library/src/grid/save.js
@@ -1,0 +1,8 @@
+/**
+ * WordPress dependencies
+ */
+import { InnerBlocks } from '@wordpress/block-editor';
+
+export default function GridSave() {
+	return <InnerBlocks.Content __experimentalGridMode />;
+}

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -48,6 +48,7 @@ import * as pullquote from './pullquote';
 import * as reusableBlock from './block';
 import * as rss from './rss';
 import * as search from './search';
+import * as grid from './grid';
 import * as group from './group';
 import * as separator from './separator';
 import * as shortcode from './shortcode';
@@ -118,6 +119,7 @@ export const registerCoreBlocks = () => {
 		...embed.common,
 		...embed.others,
 		file,
+		grid,
 		group,
 		window.wp && window.wp.oldEditor ? classic : null, // Only add the classic block in WP Context
 		html,

--- a/packages/blocks/src/api/serializer.js
+++ b/packages/blocks/src/api/serializer.js
@@ -111,7 +111,7 @@ export function getSaveElement( blockTypeOrName, attributes, innerBlocks = [] ) 
 	element = applyFilters( 'blocks.getSaveElement', element, blockType, attributes );
 
 	return (
-		<BlockContentProvider innerBlocks={ innerBlocks }>
+		<BlockContentProvider attributes={ attributes } innerBlocks={ innerBlocks }>
 			{ element }
 		</BlockContentProvider>
 	);

--- a/packages/blocks/src/block-content-provider/index.js
+++ b/packages/blocks/src/block-content-provider/index.js
@@ -28,7 +28,7 @@ const { Consumer, Provider } = createContext( () => {} );
  *
  * @return {WPComponent} Element with BlockContent injected via context.
  */
-const BlockContentProvider = ( { children, innerBlocks } ) => {
+const BlockContentProvider = ( { children, attributes, innerBlocks } ) => {
 	const BlockContent = () => {
 		// Value is an array of blocks, so defer to block serializer
 		const html = serialize( innerBlocks, { isInnerBlocks: true } );
@@ -36,6 +36,8 @@ const BlockContentProvider = ( { children, innerBlocks } ) => {
 		// Use special-cased raw HTML tag to avoid default escaping
 		return <RawHTML>{ html }</RawHTML>;
 	};
+	BlockContent.attributes = attributes;
+	BlockContent.innerBlocks = innerBlocks;
 
 	return (
 		<Provider value={ BlockContent }>


### PR DESCRIPTION
## Description

This PR seeks to introduce an experimental responsive grid mode for `InnerBlocks`. This mode could be used to power a myriad of grid based blocks, where each one tunes the UI to what is most appropriate for each context.

It can be enabled using a new `__experimentalGridMode` boolean prop on `InnerBlocks` and `InnerBlocks.Content`. When enabled, it will render the inner blocks in a responsive, `min-width` breakpoint based grid layout.

In the editor you can toggle between breakpoints, add, remove, move, and resize blocks, etc. The layouts will be persisted as an attribute of the parent block. In the front end, the saved layouts are rendered using a combination of media queries and CSS grid.

There is a lot more potential for customization that I felt would have made this PR too expansive, but I imagine that in the future we could even support customizing things like the number of columns and the row height, per breakpoint, and even the breakpoints themselves.

It's also worth noting that the interactions are far from perfect, but I think it's usable enough to share now.

The main library used for the editor portion of this PR is a somewhat low level grid editing library used by lots of large projects, like AWS, HubSpot, Monday, etc.

https://github.com/STRML/react-grid-layout#projects-using-react-grid-layout

## How has this been tested?

It hasn't been thoroughly tested yet.

## Screenshots

https://youtu.be/1CacV2MYF_A

<a href="http://www.youtube.com/watch?feature=player_embedded&v=1CacV2MYF_A" target="_blank"><img src="http://img.youtube.com/vi/1CacV2MYF_A/1.jpg" 
alt="Demo Video" width="240" height="180" border="10" /></a>

## Types of Changes

*New Feature:* `InnerBlocks` now supports a grid mode for building grid based layouts and there is a new basic grid block that leverages it.

## Checklist:

- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
