### PR TITLE
Enable Spacer block in production for the mobile apps

### DIFF
--- a/packages/block-library/src/index.native.js
+++ b/packages/block-library/src/index.native.js
@@ -150,8 +150,7 @@ export const registerCoreBlocks = () => {
 		( ( Platform.OS === 'ios' ) || ( !! __DEV__ ) ) ? preformatted : null,
 		// eslint-disable-next-line no-undef
 		!! __DEV__ ? group : null,
-		// eslint-disable-next-line no-undef
-		!! __DEV__ ? spacer : null,
+		spacer,
 	].forEach( registerBlock );
 
 	setDefaultBlockName( paragraph.name );


### PR DESCRIPTION
## Description
This enables the `Spacer` block in production for the mobile apps.

`Gutenberg Mobile` -> https://github.com/wordpress-mobile/gutenberg-mobile/pull/1594

## How has this been tested?
`WordPress iOS` -> https://github.com/wordpress-mobile/WordPress-iOS/pull/12970
`WordPress Android` -> https://github.com/wordpress-mobile/WordPress-Android/pull/10817

## Types of changes
New feature (Mobile)