### PR TITLE
Navigation: Fix issue creating front-end markup

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -89,10 +89,10 @@ function build_navigation_html( $block, $colors ) {
 
 		// Start appending HTML attributes to anchor tag.
 		if ( isset( $block['attrs']['url'] ) ) {
-			$html .= ' href="' . $block['attrs']['url'] . '"';
+			$html .= ' href="' . esc_attr( $block['attrs']['url'] ) . '"';
 		}
 		if ( isset( $block['attrs']['title'] ) ) {
-			$html .= ' title="' . $block['attrs']['title'] . '"';
+			$html .= ' title="' . esc_attr( $block['attrs']['title'] ) . '"';
 		}
 
 		if ( isset( $block['attrs']['opensInNewTab'] ) && true === $block['attrs']['opensInNewTab'] ) {
@@ -103,7 +103,7 @@ function build_navigation_html( $block, $colors ) {
 		// Start anchor tag content.
 		$html .= '>';
 		if ( isset( $block['attrs']['label'] ) ) {
-			$html .= $block['attrs']['label'];
+			$html .= esc_attr( $block['attrs']['label'] );
 		}
 		$html .= '</a>';
 		// End anchor tag content.

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -103,7 +103,7 @@ function build_navigation_html( $block, $colors ) {
 		// Start anchor tag content.
 		$html .= '>';
 		if ( isset( $block['attrs']['label'] ) ) {
-			$html .= esc_attr( $block['attrs']['label'] );
+			$html .= esc_html( $block['attrs']['label'] );
 		}
 		$html .= '</a>';
 		// End anchor tag content.

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -89,7 +89,7 @@ function build_navigation_html( $block, $colors ) {
 
 		// Start appending HTML attributes to anchor tag.
 		if ( isset( $block['attrs']['url'] ) ) {
-			$html .= ' href="' . esc_attr( $block['attrs']['url'] ) . '"';
+			$html .= ' href="' . esc_url( $block['attrs']['url'] ) . '"';
 		}
 		if ( isset( $block['attrs']['title'] ) ) {
 			$html .= ' title="' . esc_attr( $block['attrs']['title'] ) . '"';


### PR DESCRIPTION
## Description

It fixes a bug when the link has special chars escaping them applying the esc_attr() function.

Fixes https://github.com/WordPress/gutenberg/issues/18604

## How has this been tested?

Add a link from a post or page where its menu has a special char, for instance `<`, `>`, etc

**Before**
Confirm that it breaks the markup in the front-end:

<img width="1345" alt="Screen Shot 2019-11-19 at 9 33 04 AM" src="https://user-images.githubusercontent.com/77539/69146977-baeefb00-0aaf-11ea-8634-0c0a4385ca7f.png">



**After**
The markup should be ok.

<img width="1345" alt="Screen Shot 2019-11-19 at 9 34 35 AM" src="https://user-images.githubusercontent.com/77539/69147015-d22de880-0aaf-11ea-871a-dfe6bac2d792.png">


## Screenshots <!-- if applicable -->


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->