### PR TITLE
RangeControl: Fix initialPosition to accept 0

### DIFF
--- a/packages/components/src/range-control/index.js
+++ b/packages/components/src/range-control/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isFinite } from 'lodash';
+import { isFinite, isUndefined } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -64,9 +64,12 @@ function RangeControl( {
 			parseFloat( newValue )
 		);
 	};
+
+	const initialFallbackValue = ! isUndefined( initialPosition ) ?
+		initialPosition : '';
+
 	const initialSliderValue = isFinite( currentInputValue ) ?
-		currentInputValue :
-		initialPosition || '';
+		currentInputValue : initialFallbackValue;
 
 	return (
 		<BaseControl

--- a/packages/components/src/range-control/index.js
+++ b/packages/components/src/range-control/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isFinite, isUndefined } from 'lodash';
+import { isFinite } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -65,7 +65,7 @@ function RangeControl( {
 		);
 	};
 
-	const initialFallbackValue = ! isUndefined( initialPosition ) ?
+	const initialFallbackValue = isFinite( initialPosition ) ?
 		initialPosition : '';
 
 	const initialSliderValue = isFinite( currentInputValue ) ?

--- a/packages/components/src/range-control/stories/index.js
+++ b/packages/components/src/range-control/stories/index.js
@@ -16,7 +16,8 @@ import RangeControl from '../';
 export default { title: 'Components|RangeControl', component: RangeControl };
 
 const RangeControlWithState = ( props ) => {
-	const [ value, setValue ] = useState( 5 );
+	const initialValue = props.value === undefined ? 5 : props.value;
+	const [ value, setValue ] = useState( initialValue );
 
 	return (
 		<RangeControl
@@ -33,6 +34,20 @@ export const _default = () => {
 	return (
 		<RangeControlWithState
 			label={ label }
+		/>
+	);
+};
+
+export const WithoutInitialValue = () => {
+	const label = text( 'Label', 'How many columns should this use?' );
+
+	return (
+		<RangeControlWithState
+			initialPosition={ 0 }
+			label={ label }
+			max={ 20 }
+			min={ 0 }
+			value={ null }
 		/>
 	);
 };

--- a/packages/components/src/range-control/stories/index.js
+++ b/packages/components/src/range-control/stories/index.js
@@ -38,7 +38,7 @@ export const _default = () => {
 	);
 };
 
-export const WithoutInitialValue = () => {
+export const InitialValueZero = () => {
 	const label = text( 'Label', 'How many columns should this use?' );
 
 	return (


### PR DESCRIPTION
## Description

![Screen Shot 2019-11-19 at 9 13 12 AM](https://user-images.githubusercontent.com/2322354/69154517-23d57380-0aae-11ea-9338-385ffc76a2f7.png)


This update fixes the `initialPosition` prop for `RangeControl` to properly handle a value of `0`. Previously, the fallback value was checking for truthiness, which does not allow for `0` to work.

Being able to set the value to `0` is important with something like a range slider, as you may not have
an initial value, but you would like the slider to start from the very beginning (with an example range of 0-20).

## How has this been tested?

Tested in Storybook. Added new story specifically for this use case.

## Types of changes

This update changes how `RangeControl` handles `initialPosition` of `0`, if there are no values defined. This fix will impact all of the places where this scenario exists with `RangeControl`.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->

Resolves https://github.com/WordPress/gutenberg/issues/18610
