### PR TITLE
Post Title: fix special chars

### DIFF
--- a/packages/editor/src/components/post-title/index.js
+++ b/packages/editor/src/components/post-title/index.js
@@ -3,7 +3,7 @@
  */
 import Textarea from 'react-autosize-textarea';
 import classnames from 'classnames';
-import { get } from 'lodash';
+import { get, escape, unescape } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -123,7 +123,7 @@ class PostTitle extends Component {
 							<Textarea
 								id={ `post-title-${ instanceId }` }
 								className="editor-post-title__input"
-								value={ title }
+								value={ unescape( title ) }
 								onChange={ this.onChange }
 								placeholder={ decodedPlaceholder || __( 'Add title' ) }
 								onFocus={ this.onSelect }
@@ -181,7 +181,7 @@ const applyWithDispatch = withDispatch( ( dispatch ) => {
 			insertDefaultBlock( undefined, undefined, 0 );
 		},
 		onUpdate( title ) {
-			editPost( { title } );
+			editPost( { title: escape( title ) } );
 		},
 		onUndo: undo,
 		onRedo: redo,


### PR DESCRIPTION
## Description
This commit ensures setting rightly of the title content, escaping and unescaping from special chars.

## How has this been tested?
Add special chars in the post title. Save. Check that the chars are not rightly escaped in the front-end.
It's possible to inject javascript from the title of the post:

## Checklist:
- [x] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
