### PR TITLE
Fix/navigation link special chars

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { escape } from 'lodash';
+import { escape, unescape } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -80,7 +80,7 @@ function NavigationLinkEdit( {
 	insertLinkBlock,
 } ) {
 	const { label, opensInNewTab, title, url, nofollow, description } = attributes;
-	const link = title ? { title, url } : null;
+	const link = title ? { title: unescape( title ), url } : null;
 	const [ isLinkOpen, setIsLinkOpen ] = useState( ! label && isSelected );
 
 	let onCloseTimerId = null;

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
+import { escape } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -60,13 +61,13 @@ const updateLinkSetting = ( setter ) => ( setting, value ) => {
  */
 const updateLink = ( setter, label ) => ( { title: newTitle = '', url: newURL = '' } = {} ) => {
 	setter( {
-		title: newTitle,
+		title: escape( newTitle ),
 		url: newURL,
 	} );
 
 	// Set the item label as well if it isn't already defined.
 	if ( ! label ) {
-		setter( { label: newTitle } );
+		setter( { label: escape( newTitle ) } );
 	}
 };
 

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -78,7 +78,7 @@ function NavigationLinkEdit( {
 	setAttributes,
 	insertLinkBlock,
 } ) {
-	const { label, opensInNewTab, title, url } = attributes;
+	const { label, opensInNewTab, title, url, nofollow, description } = attributes;
 	const link = title ? { title, url } : null;
 	const [ isLinkOpen, setIsLinkOpen ] = useState( ! label && isSelected );
 
@@ -162,16 +162,16 @@ function NavigationLinkEdit( {
 					title={ __( 'Link Settings' ) }
 				>
 					<ToggleControl
-						checked={ attributes.opensInNewTab }
+						checked={ opensInNewTab }
 						onChange={ ( newTab ) => {
 							setAttributes( { opensInNewTab: newTab } );
 						} }
 						label={ __( 'Open in new tab' ) }
 					/>
 					<TextareaControl
-						value={ attributes.description || '' }
-						onChange={ ( description ) => {
-							setAttributes( { description } );
+						value={ description || '' }
+						onChange={ ( descriptionValue ) => {
+							setAttributes( { description: descriptionValue } );
 						} }
 						label={ __( 'Description' ) }
 					/>
@@ -180,17 +180,17 @@ function NavigationLinkEdit( {
 					title={ __( 'SEO Settings' ) }
 				>
 					<TextControl
-						value={ attributes.title || '' }
-						onChange={ ( itemTitle ) => {
-							setAttributes( { title: itemTitle } );
+						value={ title || '' }
+						onChange={ ( titleValue ) => {
+							setAttributes( { title: titleValue } );
 						} }
 						label={ __( 'Title Attribute' ) }
 						help={ __( 'Provide more context about where the link goes.' ) }
 					/>
 					<ToggleControl
-						checked={ attributes.nofollow }
-						onChange={ ( nofollow ) => {
-							setAttributes( { nofollow } );
+						checked={ nofollow }
+						onChange={ ( nofollowValue ) => {
+							setAttributes( { nofollow: nofollowValue } );
 						} }
 						label={ __( 'Add nofollow to link' ) }
 						help={ (

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { escape } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import {
@@ -66,8 +71,8 @@ function Navigation( {
 						type,
 						id,
 						url,
-						label: title.rendered,
-						title: title.raw,
+						label: escape( title.rendered ),
+						title: escape( title.raw ),
 						opensInNewTab: false,
 					}
 				)


### PR DESCRIPTION
## Description
This PR fixes an issue when the navigation links come from blog posts/pages. We need to escape special chars when the title and label are propagated to the RichText component.

Fixes https://github.com/WordPress/gutenberg/issues/18613

## How has this been tested?

* Create a page setting special chars at the page title, for instance `<Navigation />`:
<img src="https://user-images.githubusercontent.com/77539/69174741-2604f580-0ae1-11ea-80b4-043eb5121e8e.png" width="400px" />

**Before**: Confirm that the link label is empty:
<img width="400" alt="Screen Shot 2019-11-19 at 3 28 22 PM" src="https://user-images.githubusercontent.com/77539/69174834-56e52a80-0ae1-11ea-9f44-b96408a6a5c4.png">

**After**
The link label should fill with the page title:

<img src="https://user-images.githubusercontent.com/77539/69174929-8dbb4080-0ae1-11ea-9c06-126405b3b59c.png" width="400px" />


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
