### PR TITLE
Remove clearing the block selection on sidebar tab switch

### DIFF
--- a/packages/edit-post/src/components/sidebar/settings-header/index.js
+++ b/packages/edit-post/src/components/sidebar/settings-header/index.js
@@ -57,11 +57,9 @@ const SettingsHeader = ( { openDocumentSettings, openBlockSettings, sidebarName 
 
 export default withDispatch( ( dispatch ) => {
 	const { openGeneralSidebar } = dispatch( 'core/edit-post' );
-	const { clearSelectedBlock } = dispatch( 'core/block-editor' );
 	return {
 		openDocumentSettings() {
 			openGeneralSidebar( 'edit-post/document' );
-			clearSelectedBlock();
 		},
 		openBlockSettings() {
 			openGeneralSidebar( 'edit-post/block' );


### PR DESCRIPTION
## Description
Closes #18239

## How has this been tested?
Tested locally.

## Screenshots
![no-selection-clearing](https://user-images.githubusercontent.com/107534/69215920-8e9cb280-0b73-11ea-9038-f28f88249584.gif)

## Types of changes
It is a simple update of the `settings-header` that removes the call to `clearSelectedBlock`.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
