### PR TITLE
Inserter: Add keyboard shortcut styling to "/" in the default tip

### DIFF
--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -23,7 +23,11 @@ import classnames from 'classnames';
  */
 import { speak } from '@wordpress/a11y';
 import { __, _n, _x, sprintf } from '@wordpress/i18n';
-import { Component, createRef } from '@wordpress/element';
+import {
+	Component,
+	__experimentalCreateInterpolateElement,
+	createRef,
+} from '@wordpress/element';
 import {
 	PanelBody,
 	withSpokenMessages,
@@ -435,8 +439,9 @@ export class InserterMenu extends Component {
 									</p>
 								</div>
 								<Tip>
-									{ __(
-										'While writing, you can press "/" to quickly insert new blocks.'
+									{ __experimentalCreateInterpolateElement(
+										__( 'While writing, you can press <kbd>/</kbd> to quickly insert new blocks.' ),
+										{ kbd: <kbd /> }
 									) }
 								</Tip>
 							</div>


### PR DESCRIPTION
## Description
Fixes: #17111.

Alternative approach to #17222. Props to @enriquesanchez for initial efforts.

It uses new experimental API added in #17376: 
`__experimentalCreateInterpolateElement`
Props to @nerrad 😍 

This PR adds keyboard shortcut styling to the "/" in the default tip in the inserter modal.

**Before:**
<img width="397" alt="63377650-7e035300-c35e-11e9-9af5-6383f554b1fc" src="https://user-images.githubusercontent.com/3276087/63805395-f4640000-c8de-11e9-9a25-698c00c1d9ac.png">

**After:**
<img width="710" alt="Screen Shot 2019-08-27 at 3 11 01 PM" src="https://user-images.githubusercontent.com/3276087/63805411-fded6800-c8de-11e9-8251-ec1f2c19dbb8.png">
