### PR TITLE
Add a header menu to switch between edit and select tool

### DIFF
--- a/docs/designers-developers/developers/data/data-core-block-editor.md
+++ b/docs/designers-developers/developers/data/data-core-block-editor.md
@@ -1141,15 +1141,11 @@ _Parameters_
 
 <a name="setNavigationMode" href="#setNavigationMode">#</a> **setNavigationMode**
 
-Returns an action object used to enable or disable the navigation mode.
+Generators that triggers an action used to enable or disable the navigation mode.
 
 _Parameters_
 
 -   _isNavigationMode_ `string`: Enable/Disable navigation mode.
-
-_Returns_
-
--   `Object`: Action object
 
 <a name="setTemplateValidity" href="#setTemplateValidity">#</a> **setTemplateValidity**
 

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -344,10 +344,6 @@ Undocumented declaration.
 
 Undocumented declaration.
 
-<a name="ToolSelector" href="#ToolSelector">#</a> **ToolSelector**
-
-Undocumented declaration.
-
 <a name="ObserveTyping" href="#ObserveTyping">#</a> **ObserveTyping**
 
 _Related_
@@ -430,6 +426,10 @@ _Related_
 _Type_
 
 -   `Object` 
+
+<a name="ToolSelector" href="#ToolSelector">#</a> **ToolSelector**
+
+Undocumented declaration.
 
 <a name="transformStyles" href="#transformStyles">#</a> **transformStyles**
 

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -344,7 +344,7 @@ Undocumented declaration.
 
 Undocumented declaration.
 
-<a name="NavigationToolSelector" href="#NavigationToolSelector">#</a> **NavigationToolSelector**
+<a name="ToolSelector" href="#ToolSelector">#</a> **ToolSelector**
 
 Undocumented declaration.
 

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -344,6 +344,10 @@ Undocumented declaration.
 
 Undocumented declaration.
 
+<a name="NavigationToolSelector" href="#NavigationToolSelector">#</a> **NavigationToolSelector**
+
+Undocumented declaration.
+
 <a name="ObserveTyping" href="#ObserveTyping">#</a> **ObserveTyping**
 
 _Related_

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -101,7 +101,7 @@ function BlockListBlock( {
 	animateOnChange,
 	enableAnimation,
 	isNavigationMode,
-	enableNavigationMode,
+	setNavigationMode,
 } ) {
 	// Random state used to rerender the component if needed, ideally we don't need this
 	const [ , updateRerenderState ] = useState( {} );
@@ -326,7 +326,7 @@ function BlockListBlock( {
 					isSelected &&
 					isEditMode
 				) {
-					enableNavigationMode();
+					setNavigationMode( true );
 					wrapper.current.focus();
 				}
 				break;
@@ -343,6 +343,14 @@ function BlockListBlock( {
 		// https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/button
 		if ( event.button !== 0 ) {
 			return;
+		}
+
+		if (
+			isNavigationMode &&
+			isSelected &&
+			isInsideRootBlock( blockNodeRef.current, event.target )
+		) {
+			setNavigationMode( false );
 		}
 
 		if ( event.shiftKey ) {
@@ -778,9 +786,7 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps, { select } ) => {
 		toggleSelection( selectionEnabled ) {
 			toggleSelection( selectionEnabled );
 		},
-		enableNavigationMode() {
-			setNavigationMode( true );
-		},
+		setNavigationMode,
 	};
 } );
 

--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -30,6 +30,7 @@ export { default as __experimentalLinkControl } from './link-control';
 export { default as MediaPlaceholder } from './media-placeholder';
 export { default as MediaUpload } from './media-upload';
 export { default as MediaUploadCheck } from './media-upload/check';
+export { default as NavigationToolSelector } from './navigation-mode-selector';
 export { default as PanelColorSettings } from './panel-color-settings';
 export { default as PlainText } from './plain-text';
 export { default as __experimentalResponsiveBlockControl } from './responsive-block-control';

--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -30,7 +30,6 @@ export { default as __experimentalLinkControl } from './link-control';
 export { default as MediaPlaceholder } from './media-placeholder';
 export { default as MediaUpload } from './media-upload';
 export { default as MediaUploadCheck } from './media-upload/check';
-export { default as NavigationToolSelector } from './navigation-mode-selector';
 export { default as PanelColorSettings } from './panel-color-settings';
 export { default as PlainText } from './plain-text';
 export { default as __experimentalResponsiveBlockControl } from './responsive-block-control';
@@ -40,6 +39,7 @@ export {
 	RichTextToolbarButton,
 	__unstableRichTextInputEvent,
 } from './rich-text';
+export { default as ToolSelector } from './tool-selector';
 export { default as URLInput } from './url-input';
 export { default as URLInputButton } from './url-input/button';
 export { default as URLPopover } from './url-popover';

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { withViewportMatch } from '@wordpress/viewport'; // Temporary click-through disable on desktop.
+import { withViewportMatch } from '@wordpress/viewport';
 import { Component } from '@wordpress/element';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { synchronizeBlocksWithTemplate, withBlockContentContext } from '@wordpress/blocks';
@@ -102,7 +102,7 @@ class InnerBlocks extends Component {
 
 	render() {
 		const {
-			isSmallScreen, // Temporary click-through disable on desktop.
+			enableClickThrough,
 			clientId,
 			hasOverlay,
 			renderAppender,
@@ -117,7 +117,7 @@ class InnerBlocks extends Component {
 		const isPlaceholder = template === null && !! templateOptions;
 
 		const classes = classnames( 'editor-inner-blocks block-editor-inner-blocks', {
-			'has-overlay': isSmallScreen && ( hasOverlay && ! isPlaceholder ), // Temporary click-through disable on desktop.
+			'has-overlay': enableClickThrough && ( hasOverlay && ! isPlaceholder ),
 		} );
 
 		return (
@@ -141,7 +141,7 @@ class InnerBlocks extends Component {
 }
 
 InnerBlocks = compose( [
-	withViewportMatch( { isSmallScreen: '< medium' } ), // Temporary click-through disable on desktop.
+	withViewportMatch( { isSmallScreen: '< medium' } ),
 	withBlockEditContext( ( context ) => pick( context, [ 'clientId' ] ) ),
 	withSelect( ( select, ownProps ) => {
 		const {
@@ -151,8 +151,9 @@ InnerBlocks = compose( [
 			getBlockListSettings,
 			getBlockRootClientId,
 			getTemplateLock,
+			isNavigationMode,
 		} = select( 'core/block-editor' );
-		const { clientId } = ownProps;
+		const { clientId, isSmallScreen } = ownProps;
 		const block = getBlock( clientId );
 		const rootClientId = getBlockRootClientId( clientId );
 
@@ -161,6 +162,7 @@ InnerBlocks = compose( [
 			blockListSettings: getBlockListSettings( clientId ),
 			hasOverlay: block.name !== 'core/template' && ! isBlockSelected( clientId ) && ! hasSelectedInnerBlock( clientId, true ),
 			parentLock: getTemplateLock( rootClientId ),
+			enableClickThrough: isNavigationMode() || isSmallScreen,
 		};
 	} ),
 	withDispatch( ( dispatch, ownProps ) => {

--- a/packages/block-editor/src/components/navigation-mode-selector/index.js
+++ b/packages/block-editor/src/components/navigation-mode-selector/index.js
@@ -1,7 +1,14 @@
 /**
  * WordPress dependencies
  */
-import { Dropdown, IconButton, MenuGroup, MenuItemsChoice, SVG, Path } from '@wordpress/components';
+import {
+	Dropdown,
+	IconButton,
+	MenuItemsChoice,
+	SVG,
+	Path,
+	NavigableMenu,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 
@@ -22,13 +29,14 @@ function NavigationToolSelector() {
 					icon={ isNavigationTool ? selectIcon : editIcon }
 					aria-expanded={ isOpen }
 					onClick={ onToggle }
-					label={ __( 'Select navigation tool' ) }
+					label={ __( 'Navigation Tool' ) }
 				/>
 			) }
 			renderContent={ () => (
 				<>
-					<MenuGroup
-						label={ __( 'Navigation Tool' ) }
+					<NavigableMenu
+						role="menu"
+						aria-label={ __( 'Navigation Tool' ) }
 					>
 						<MenuItemsChoice
 							value={ isNavigationTool ? 'select' : 'edit' }
@@ -56,7 +64,7 @@ function NavigationToolSelector() {
 								},
 							] }
 						/>
-					</MenuGroup>
+					</NavigableMenu>
 					<div className="block-editor-navigation-mode-selector__help">
 						{ __( 'Tools offer different block interactions to optimize block selection & editing tasks' ) }
 					</div>

--- a/packages/block-editor/src/components/navigation-mode-selector/index.js
+++ b/packages/block-editor/src/components/navigation-mode-selector/index.js
@@ -14,7 +14,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { ifViewportMatches } from '@wordpress/viewport';
 
 const editIcon = <SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><Path fill="none" d="M0 0h24v24H0V0z" /><Path d="M14.06 9.02l.92.92L5.92 19H5v-.92l9.06-9.06M17.66 3c-.25 0-.51.1-.7.29l-1.83 1.83 3.75 3.75 1.83-1.83c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.2-.2-.45-.29-.71-.29zm-3.6 3.19L3 17.25V21h3.75L17.81 9.94l-3.75-3.75z" /></SVG>;
-const selectIcon = <SVG xmlns="http://www.w3.org/2000/svg" fill="#000000" viewBox="0 0 24 24" width="24px" height="24px"><Path d="M 7 2 L 7 18.5 L 11.09375 14.605469 L 14.300781 22 L 16.5 21 L 13.195312 13.701172 L 13.199219 13.699219 L 19 13.199219 L 7 2 z M 9 6.6015625 L 14.347656 11.59375 L 13.029297 11.707031 L 12.708984 11.734375 L 12.412109 11.861328 L 10.3125 12.761719 L 9.9824219 12.904297 L 9.7226562 13.152344 L 9 13.837891 L 9 6.6015625 z" /></SVG>;
+const selectIcon = <SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><Path d="M6.5 1v21.5l6-6.5H21L6.5 1zm5.1 13l-3.1 3.4V5.9l7.8 8.1h-4.7z" /></SVG>;
 
 function NavigationToolSelector() {
 	const isNavigationTool = useSelect( ( select ) => select( 'core/block-editor' ).isNavigationMode() );

--- a/packages/block-editor/src/components/navigation-mode-selector/index.js
+++ b/packages/block-editor/src/components/navigation-mode-selector/index.js
@@ -11,6 +11,7 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
+import { ifViewportMatches } from '@wordpress/viewport';
 
 const editIcon = <SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><Path fill="none" d="M0 0h24v24H0V0z" /><Path d="M14.06 9.02l.92.92L5.92 19H5v-.92l9.06-9.06M17.66 3c-.25 0-.51.1-.7.29l-1.83 1.83 3.75 3.75 1.83-1.83c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.2-.2-.45-.29-.71-.29zm-3.6 3.19L3 17.25V21h3.75L17.81 9.94l-3.75-3.75z" /></SVG>;
 const selectIcon = <SVG xmlns="http://www.w3.org/2000/svg" fill="#000000" viewBox="0 0 24 24" width="24px" height="24px"><Path d="M 7 2 L 7 18.5 L 11.09375 14.605469 L 14.300781 22 L 16.5 21 L 13.195312 13.701172 L 13.199219 13.699219 L 19 13.199219 L 7 2 z M 9 6.6015625 L 14.347656 11.59375 L 13.029297 11.707031 L 12.708984 11.734375 L 12.412109 11.861328 L 10.3125 12.761719 L 9.9824219 12.904297 L 9.7226562 13.152344 L 9 13.837891 L 9 6.6015625 z" /></SVG>;
@@ -74,4 +75,4 @@ function NavigationToolSelector() {
 	);
 }
 
-export default NavigationToolSelector;
+export default ifViewportMatches( 'medium' )( NavigationToolSelector );

--- a/packages/block-editor/src/components/navigation-mode-selector/index.js
+++ b/packages/block-editor/src/components/navigation-mode-selector/index.js
@@ -1,0 +1,69 @@
+/**
+ * WordPress dependencies
+ */
+import { Dropdown, IconButton, MenuGroup, MenuItemsChoice, SVG, Path } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useSelect, useDispatch } from '@wordpress/data';
+
+const editIcon = <SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><Path fill="none" d="M0 0h24v24H0V0z" /><Path d="M14.06 9.02l.92.92L5.92 19H5v-.92l9.06-9.06M17.66 3c-.25 0-.51.1-.7.29l-1.83 1.83 3.75 3.75 1.83-1.83c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.2-.2-.45-.29-.71-.29zm-3.6 3.19L3 17.25V21h3.75L17.81 9.94l-3.75-3.75z" /></SVG>;
+const selectIcon = <SVG xmlns="http://www.w3.org/2000/svg" fill="#000000" viewBox="0 0 24 24" width="24px" height="24px"><Path d="M 7 2 L 7 18.5 L 11.09375 14.605469 L 14.300781 22 L 16.5 21 L 13.195312 13.701172 L 13.199219 13.699219 L 19 13.199219 L 7 2 z M 9 6.6015625 L 14.347656 11.59375 L 13.029297 11.707031 L 12.708984 11.734375 L 12.412109 11.861328 L 10.3125 12.761719 L 9.9824219 12.904297 L 9.7226562 13.152344 L 9 13.837891 L 9 6.6015625 z" /></SVG>;
+
+function NavigationToolSelector() {
+	const isNavigationTool = useSelect( ( select ) => select( 'core/block-editor' ).isNavigationMode() );
+	const { setNavigationMode } = useDispatch( 'core/block-editor' );
+	const onSwitchMode = ( mode ) => {
+		setNavigationMode( mode === 'edit' ? false : true );
+	};
+
+	return (
+		<Dropdown
+			renderToggle={ ( { isOpen, onToggle } ) => (
+				<IconButton
+					icon={ isNavigationTool ? selectIcon : editIcon }
+					aria-expanded={ isOpen }
+					onClick={ onToggle }
+					label={ __( 'Select navigation tool' ) }
+				/>
+			) }
+			renderContent={ () => (
+				<>
+					<MenuGroup
+						label={ __( 'Navigation Tool' ) }
+					>
+						<MenuItemsChoice
+							value={ isNavigationTool ? 'select' : 'edit' }
+							onSelect={ onSwitchMode }
+							choices={ [
+								{
+									value: 'edit',
+									label: (
+										<>
+											{ editIcon }
+											{ __( 'Edit' ) }
+										</>
+									),
+									shortcut: isNavigationTool ? 'Enter' : undefined,
+								},
+								{
+									value: 'select',
+									label: (
+										<>
+											{ selectIcon }
+											{ __( 'Select' ) }
+										</>
+									),
+									shortcut: isNavigationTool ? undefined : 'Esc',
+								},
+							] }
+						/>
+					</MenuGroup>
+					<div className="block-editor-navigation-mode-selector__help">
+						{ __( 'Tools offer different block interactions to optimize block selection & editing tasks' ) }
+					</div>
+				</>
+			) }
+		/>
+	);
+}
+
+export default NavigationToolSelector;

--- a/packages/block-editor/src/components/navigation-mode-selector/style.scss
+++ b/packages/block-editor/src/components/navigation-mode-selector/style.scss
@@ -1,0 +1,5 @@
+.block-editor-navigation-mode-selector__help {
+	padding: $grid-size-large;
+	border-top: 1px solid $light-gray-500;
+	color: $dark-gray-300;
+}

--- a/packages/block-editor/src/components/tool-selector/index.js
+++ b/packages/block-editor/src/components/tool-selector/index.js
@@ -67,7 +67,7 @@ function ToolSelector() {
 						/>
 					</NavigableMenu>
 					<div className="block-editor-tool-selector__help">
-						{ __( 'Tools offer different block interactions to optimize block selection & editing tasks' ) }
+						{ __( 'Tools offer different interactions for block selection & editing. To select, press Escape, to go back to editing, press Enter.' ) }
 					</div>
 				</>
 			) }

--- a/packages/block-editor/src/components/tool-selector/index.js
+++ b/packages/block-editor/src/components/tool-selector/index.js
@@ -16,7 +16,7 @@ import { ifViewportMatches } from '@wordpress/viewport';
 const editIcon = <SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><Path fill="none" d="M0 0h24v24H0V0z" /><Path d="M14.06 9.02l.92.92L5.92 19H5v-.92l9.06-9.06M17.66 3c-.25 0-.51.1-.7.29l-1.83 1.83 3.75 3.75 1.83-1.83c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.2-.2-.45-.29-.71-.29zm-3.6 3.19L3 17.25V21h3.75L17.81 9.94l-3.75-3.75z" /></SVG>;
 const selectIcon = <SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><Path d="M6.5 1v21.5l6-6.5H21L6.5 1zm5.1 13l-3.1 3.4V5.9l7.8 8.1h-4.7z" /></SVG>;
 
-function NavigationToolSelector() {
+function ToolSelector() {
 	const isNavigationTool = useSelect( ( select ) => select( 'core/block-editor' ).isNavigationMode() );
 	const { setNavigationMode } = useDispatch( 'core/block-editor' );
 	const onSwitchMode = ( mode ) => {
@@ -30,14 +30,14 @@ function NavigationToolSelector() {
 					icon={ isNavigationTool ? selectIcon : editIcon }
 					aria-expanded={ isOpen }
 					onClick={ onToggle }
-					label={ __( 'Navigation Tool' ) }
+					label={ __( 'Tools' ) }
 				/>
 			) }
 			renderContent={ () => (
 				<>
 					<NavigableMenu
 						role="menu"
-						aria-label={ __( 'Navigation Tool' ) }
+						aria-label={ __( 'Tools' ) }
 					>
 						<MenuItemsChoice
 							value={ isNavigationTool ? 'select' : 'edit' }
@@ -66,7 +66,7 @@ function NavigationToolSelector() {
 							] }
 						/>
 					</NavigableMenu>
-					<div className="block-editor-navigation-mode-selector__help">
+					<div className="block-editor-tool-selector__help">
 						{ __( 'Tools offer different block interactions to optimize block selection & editing tasks' ) }
 					</div>
 				</>
@@ -75,4 +75,4 @@ function NavigationToolSelector() {
 	);
 }
 
-export default ifViewportMatches( 'medium' )( NavigationToolSelector );
+export default ifViewportMatches( 'medium' )( ToolSelector );

--- a/packages/block-editor/src/components/tool-selector/index.js
+++ b/packages/block-editor/src/components/tool-selector/index.js
@@ -51,7 +51,6 @@ function ToolSelector() {
 											{ __( 'Edit' ) }
 										</>
 									),
-									shortcut: isNavigationTool ? 'Enter' : undefined,
 								},
 								{
 									value: 'select',
@@ -61,7 +60,6 @@ function ToolSelector() {
 											{ __( 'Select' ) }
 										</>
 									),
-									shortcut: isNavigationTool ? undefined : 'Esc',
 								},
 							] }
 						/>

--- a/packages/block-editor/src/components/tool-selector/style.scss
+++ b/packages/block-editor/src/components/tool-selector/style.scss
@@ -1,4 +1,4 @@
-.block-editor-navigation-mode-selector__help {
+.block-editor-tool-selector__help {
 	padding: $grid-size-large;
 	border-top: 1px solid $light-gray-500;
 	color: $dark-gray-300;

--- a/packages/block-editor/src/components/writing-flow/index.js
+++ b/packages/block-editor/src/components/writing-flow/index.js
@@ -104,13 +104,6 @@ class WritingFlow extends Component {
 
 	onMouseDown() {
 		this.verticalRect = null;
-		this.disableNavigationMode();
-	}
-
-	disableNavigationMode() {
-		if ( this.props.isNavigationMode ) {
-			this.props.disableNavigationMode();
-		}
 	}
 
 	/**
@@ -377,7 +370,6 @@ class WritingFlow extends Component {
 	 * Sets focus to the end of the last tabbable text field, if one exists.
 	 */
 	focusLastTextField() {
-		this.disableNavigationMode();
 		const focusableNodes = focus.focusable.find( this.container );
 		const target = findLast( focusableNodes, isTabbableTextField );
 		if ( target ) {
@@ -445,11 +437,10 @@ export default compose( [
 		};
 	} ),
 	withDispatch( ( dispatch ) => {
-		const { multiSelect, selectBlock, setNavigationMode, clearSelectedBlock } = dispatch( 'core/block-editor' );
+		const { multiSelect, selectBlock, clearSelectedBlock } = dispatch( 'core/block-editor' );
 		return {
 			onMultiSelect: multiSelect,
 			onSelectBlock: selectBlock,
-			disableNavigationMode: () => setNavigationMode( false ),
 			clearSelectedBlock,
 		};
 	} ),

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -7,6 +7,8 @@ import { castArray, first, get, includes } from 'lodash';
  * WordPress dependencies
  */
 import { getDefaultBlockName, createBlock } from '@wordpress/blocks';
+import { speak } from '@wordpress/a11y';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -793,15 +795,19 @@ export function __unstableMarkAutomaticChange() {
 }
 
 /**
- * Returns an action object used to enable or disable the navigation mode.
+ * Generators that triggers an action used to enable or disable the navigation mode.
  *
  * @param {string} isNavigationMode Enable/Disable navigation mode.
- *
- * @return {Object} Action object
  */
-export function setNavigationMode( isNavigationMode = true ) {
-	return {
+export function * setNavigationMode( isNavigationMode = true ) {
+	yield {
 		type: 'SET_NAVIGATION_MODE',
 		isNavigationMode,
 	};
+
+	if ( isNavigationMode ) {
+		speak( __( 'You are currently in navigation mode. Navigate blocks using arrow keys. To exit navigation mode and edit the selected block, press Enter.' ) );
+	} else {
+		speak( __( 'You are currently in edit mode. To return to the navigation mode, press Escape.' ) );
+	}
 }

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1256,7 +1256,7 @@ export const blockListSettings = ( state = {}, action ) => {
  *
  * @return {string} Updated state.
  */
-export function isNavigationMode( state = true, action ) {
+export function isNavigationMode( state = false, action ) {
 	if ( action.type === 'SET_NAVIGATION_MODE' ) {
 		return action.isNavigationMode;
 	}

--- a/packages/block-editor/src/style.scss
+++ b/packages/block-editor/src/style.scss
@@ -26,13 +26,13 @@
 @import "./components/inserter-list-item/style.scss";
 @import "./components/media-placeholder/style.scss";
 @import "./components/multi-selection-inspector/style.scss";
-@import "./components/navigation-mode-selector/style.scss";
 @import "./components/panel-color-settings/style.scss";
 @import "./components/plain-text/style.scss";
 @import "./components/responsive-block-control/style.scss";
 @import "./components/rich-text/format-toolbar/style.scss";
 @import "./components/rich-text/style.scss";
 @import "./components/skip-to-selected-block/style.scss";
+@import "./components/tool-selector/style.scss";
 @import "./components/url-input/style.scss";
 @import "./components/url-popover/style.scss";
 @import "./components/warning/style.scss";

--- a/packages/block-editor/src/style.scss
+++ b/packages/block-editor/src/style.scss
@@ -26,6 +26,7 @@
 @import "./components/inserter-list-item/style.scss";
 @import "./components/media-placeholder/style.scss";
 @import "./components/multi-selection-inspector/style.scss";
+@import "./components/navigation-mode-selector/style.scss";
 @import "./components/panel-color-settings/style.scss";
 @import "./components/plain-text/style.scss";
 @import "./components/responsive-block-control/style.scss";

--- a/packages/components/src/menu-items-choice/index.js
+++ b/packages/components/src/menu-items-choice/index.js
@@ -17,6 +17,7 @@ export default function MenuItemsChoice( {
 				icon={ isSelected && 'yes' }
 				isSelected={ isSelected }
 				shortcut={ item.shortcut }
+				className="components-menu-items-choice"
 				onClick={ () => {
 					if ( ! isSelected ) {
 						onSelect( item.value );

--- a/packages/components/src/menu-items-choice/style.scss
+++ b/packages/components/src/menu-items-choice/style.scss
@@ -1,0 +1,12 @@
+.components-menu-items-choice,
+.components-menu-items-choice.components-icon-button {
+	padding-left: 2rem;
+
+	&.has-icon {
+		padding-left: 0.5rem;
+	}
+
+	.dashicon {
+		margin-right: 4px;
+	}
+}

--- a/packages/components/src/style.scss
+++ b/packages/components/src/style.scss
@@ -25,6 +25,7 @@
 @import "./icon-button/style.scss";
 @import "./menu-group/style.scss";
 @import "./menu-item/style.scss";
+@import "./menu-items-choice/style.scss";
 @import "./modal/style.scss";
 @import "./notice/style.scss";
 @import "./panel/style.scss";

--- a/packages/e2e-test-utils/CHANGELOG.md
+++ b/packages/e2e-test-utils/CHANGELOG.md
@@ -1,3 +1,9 @@
+## master
+
+### Breaking Changes
+
+- The disableNavigationMode utility was removed. By default, the editor is in edit mode now.
+
 ## 3.0.0 (2019-11-14)
 
 ### Breaking Changes

--- a/packages/e2e-test-utils/README.md
+++ b/packages/e2e-test-utils/README.md
@@ -137,14 +137,6 @@ _Parameters_
 
 -   _slug_ `string`: Plugin slug.
 
-<a name="disableNavigationMode" href="#disableNavigationMode">#</a> **disableNavigationMode**
-
-Triggers edit mode if not already active.
-
-_Returns_
-
--   `Promise`: Promise resolving after enabling the keyboard edit mode.
-
 <a name="disablePrePublishChecks" href="#disablePrePublishChecks">#</a> **disablePrePublishChecks**
 
 Disables Pre-publish checks.

--- a/packages/e2e-test-utils/src/create-new-post.js
+++ b/packages/e2e-test-utils/src/create-new-post.js
@@ -7,7 +7,6 @@ import { addQueryArgs } from '@wordpress/url';
  * Internal dependencies
  */
 import { visitAdminPage } from './visit-admin-page';
-import { disableNavigationMode } from './keyboard-mode';
 
 /**
  * Creates new post.
@@ -37,6 +36,4 @@ export async function createNewPost( {
 	if ( enableTips ) {
 		await page.reload();
 	}
-
-	await disableNavigationMode();
 }

--- a/packages/e2e-test-utils/src/index.js
+++ b/packages/e2e-test-utils/src/index.js
@@ -42,7 +42,6 @@ export { selectBlockByClientId } from './select-block-by-client-id';
 export { setBrowserViewport } from './set-browser-viewport';
 export { setPostContent } from './set-post-content';
 export { switchEditorModeTo } from './switch-editor-mode-to';
-export { disableNavigationMode } from './keyboard-mode';
 export { switchUserToAdmin } from './switch-user-to-admin';
 export { switchUserToTest } from './switch-user-to-test';
 export { toggleMoreMenu } from './toggle-more-menu';

--- a/packages/e2e-test-utils/src/keyboard-mode.js
+++ b/packages/e2e-test-utils/src/keyboard-mode.js
@@ -1,12 +1,1 @@
-/**
- * Triggers edit mode if not already active.
- *
- * @return {Promise} Promise resolving after enabling the keyboard edit mode.
- */
-export async function disableNavigationMode() {
-	const focusedElement = await page.$( ':focus' );
-	await page.click( '.editor-post-title' );
-	if ( focusedElement ) {
-		await focusedElement.focus();
-	}
-}
+

--- a/packages/e2e-tests/specs/editor/various/preview.test.js
+++ b/packages/e2e-tests/specs/editor/various/preview.test.js
@@ -15,7 +15,6 @@ import {
 	saveDraft,
 	clickOnMoreMenuItem,
 	pressKeyWithModifier,
-	disableNavigationMode,
 } from '@wordpress/e2e-test-utils';
 
 async function openPreviewPage( editorPage ) {
@@ -206,7 +205,6 @@ describe( 'Preview with Custom Fields enabled', () => {
 	beforeEach( async () => {
 		await createNewPost();
 		await toggleCustomFieldsOption( true );
-		await disableNavigationMode();
 	} );
 
 	afterEach( async () => {

--- a/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
@@ -118,6 +118,9 @@ describe( 'Reusable Blocks', () => {
 		// Tab three times to navigate to the block's content
 		await page.keyboard.press( 'Tab' );
 		await page.keyboard.press( 'Tab' );
+
+		// Quickly focus the paragraph block
+		await page.keyboard.press( 'Escape' ); // Enter navigation mode
 		await page.keyboard.press( 'Enter' ); // Enter edit mode
 
 		// Change the block's content

--- a/packages/e2e-tests/specs/editor/various/undo.test.js
+++ b/packages/e2e-tests/specs/editor/various/undo.test.js
@@ -10,7 +10,6 @@ import {
 	getAllBlocks,
 	saveDraft,
 	publishPost,
-	disableNavigationMode,
 } from '@wordpress/e2e-test-utils';
 
 const getSelection = async () => {
@@ -331,7 +330,6 @@ describe( 'undo', () => {
 		await page.keyboard.type( 'original' );
 		await saveDraft();
 		await page.reload();
-		await disableNavigationMode();
 
 		// Issue is demonstrated by forcing state merges (multiple inputs) on
 		// an existing text after a fresh reload.

--- a/packages/e2e-tests/specs/performance/performance.test.js
+++ b/packages/e2e-tests/specs/performance/performance.test.js
@@ -11,7 +11,6 @@ import {
 	createNewPost,
 	saveDraft,
 	insertBlock,
-	disableNavigationMode,
 } from '@wordpress/e2e-test-utils';
 
 function readFile( filePath ) {
@@ -54,7 +53,6 @@ describe( 'Performance', () => {
 		while ( i-- ) {
 			startTime = new Date();
 			await page.reload( { waitUntil: [ 'domcontentloaded', 'load' ] } );
-			await disableNavigationMode();
 		}
 
 		await insertBlock( 'Paragraph' );

--- a/packages/edit-post/src/components/header/header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.js
@@ -11,7 +11,7 @@ import {
 	BlockToolbar,
 	NavigableToolbar,
 	BlockNavigationDropdown,
-	NavigationToolSelector,
+	ToolSelector,
 } from '@wordpress/block-editor';
 import {
 	TableOfContents,
@@ -41,7 +41,7 @@ function HeaderToolbar( { hasFixedToolbar, isLargeViewport, showInserter, isText
 			<EditorHistoryRedo />
 			<TableOfContents hasOutlineItemsDisabled={ isTextModeEnabled } />
 			<BlockNavigationDropdown isDisabled={ isTextModeEnabled } />
-			<NavigationToolSelector />
+			<ToolSelector />
 			{ hasFixedToolbar && isLargeViewport && (
 				<div className="edit-post-header-toolbar__block-toolbar">
 					<BlockToolbar />

--- a/packages/edit-post/src/components/header/header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.js
@@ -11,6 +11,7 @@ import {
 	BlockToolbar,
 	NavigableToolbar,
 	BlockNavigationDropdown,
+	NavigationToolSelector,
 } from '@wordpress/block-editor';
 import {
 	TableOfContents,
@@ -45,6 +46,7 @@ function HeaderToolbar( { hasFixedToolbar, isLargeViewport, showInserter, isText
 					<BlockToolbar />
 				</div>
 			) }
+			<NavigationToolSelector />
 		</NavigableToolbar>
 	);
 }

--- a/packages/edit-post/src/components/header/header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.js
@@ -41,12 +41,12 @@ function HeaderToolbar( { hasFixedToolbar, isLargeViewport, showInserter, isText
 			<EditorHistoryRedo />
 			<TableOfContents hasOutlineItemsDisabled={ isTextModeEnabled } />
 			<BlockNavigationDropdown isDisabled={ isTextModeEnabled } />
+			<NavigationToolSelector />
 			{ hasFixedToolbar && isLargeViewport && (
 				<div className="edit-post-header-toolbar__block-toolbar">
 					<BlockToolbar />
 				</div>
 			) }
-			<NavigationToolSelector />
 		</NavigableToolbar>
 	);
 }


### PR DESCRIPTION
closes #17088  
closes #17847
closes #18583 

First attempt at making the select/edit tool more visible in the UI.

This PR does:

 - Adds a dropdown into the header to switch between select and edit tools.
 - Remove the explicit switch to the edit tool as soon as you click the canvas.
 - Enables the edit tool by default.
 - Enables clickthrough in select tool.

<img width="409" alt="Capture d’écran 2019-11-20 à 10 20 11 AM" src="https://user-images.githubusercontent.com/272444/69225796-5b602080-0b7f-11ea-9707-c6516dc3e6ce.png">

