### PR TITLE
[RNMobile] Image Size improvements mark I

### DIFF
--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -343,7 +343,7 @@ export class ImageEdit extends React.Component {
 							hideCancelButton
 							icon={ 'editor-expand' }
 							label={ __( 'Size' ) }
-							value={ sizeSlug }
+							value={ sizeOptionLabels[ sizeSlug || DEFAULT_SIZE_SLUG ] }
 							onChangeValue={ ( newValue ) => this.onSetSizeSlug( newValue ) }
 							options={ sizeOptions }
 						/> }

--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -71,6 +71,10 @@ const sizeOptions = map( sizeOptionLabels, ( label, option ) => ( { value: optio
 // Default Image ratio 4:3
 const IMAGE_ASPECT_RATIO = 4 / 3;
 
+const getUrlForSlug = ( image, { sizeSlug } ) => {
+	return get( image, [ 'media_details', 'sizes', sizeSlug, 'source_url' ] );
+};
+
 export class ImageEdit extends React.Component {
 	constructor( props ) {
 		super( props );
@@ -126,6 +130,14 @@ export class ImageEdit extends React.Component {
 		// this action will only exist if the user pressed the trash button on the block holder
 		if ( hasAction( 'blocks.onRemoveBlockCheckUpload' ) && this.state.isUploadInProgress ) {
 			doAction( 'blocks.onRemoveBlockCheckUpload', this.props.attributes.id );
+		}
+	}
+
+	componentDidUpdate( previousProps ) {
+		if ( ! previousProps.image && this.props.image ) {
+			const { image, attributes } = this.props;
+			const url = getUrlForSlug( image, attributes );
+			this.props.setAttributes( { url } );
 		}
 	}
 
@@ -212,7 +224,7 @@ export class ImageEdit extends React.Component {
 	onSetSizeSlug( sizeSlug ) {
 		const { image } = this.props;
 
-		const url = get( image, [ 'media_details', 'sizes', sizeSlug, 'source_url' ] );
+		const url = getUrlForSlug( image, { sizeSlug } );
 		if ( ! url ) {
 			return null;
 		}
@@ -236,9 +248,31 @@ export class ImageEdit extends React.Component {
 		} );
 	}
 
-	onSelectMediaUploadOption( { id, url } ) {
-		const { setAttributes } = this.props;
-		setAttributes( { id, url } );
+	onSelectMediaUploadOption( media ) {
+		const { id, url } = this.props.attributes;
+
+		const mediaAttributes = {
+			id: media.id,
+			url: media.url,
+		};
+
+		let additionalAttributes;
+		// Reset the dimension attributes if changing to a different image.
+		if ( ! media.id || media.id !== id ) {
+			additionalAttributes = {
+				width: undefined,
+				height: undefined,
+				sizeSlug: DEFAULT_SIZE_SLUG,
+			};
+		} else {
+			// Keep the same url when selecting the same file, so "Image Size" option is not changed.
+			additionalAttributes = { url };
+		}
+
+		this.props.setAttributes( {
+			...mediaAttributes,
+			...additionalAttributes,
+		} );
 	}
 
 	onFocusCaption() {
@@ -309,7 +343,7 @@ export class ImageEdit extends React.Component {
 							hideCancelButton
 							icon={ 'editor-expand' }
 							label={ __( 'Size' ) }
-							value={ sizeOptionLabels[ sizeSlug || DEFAULT_SIZE_SLUG ] }
+							value={ sizeSlug }
 							onChangeValue={ ( newValue ) => this.onSetSizeSlug( newValue ) }
 							options={ sizeOptions }
 						/> }


### PR DESCRIPTION
This PR fixes 4 and 5 from https://github.com/wordpress-mobile/gutenberg-mobile/issues/1593

On web, then the selected image object is received, it already has all the information needed (image sizes details) to set the proper url for the default slug. But in our case, we only get the original image URL.

For this reason it was needed to use `componentDidUpdate` to capture the new `image` object from props when it is set and update the image url.

One step-back of this approach is that we will load two images, the original one, and the large one when we get the Image object.

`gutenberg-mobile` side PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1598
Related `WPiOS` PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/12984

**To test:**

- On WPiOS or WPAndroid.
- IF WPiOS: Checkout https://github.com/wordpress-mobile/WordPress-iOS/pull/12984
- Set a new Image block.
- Set add an image to the block (any source should work).
- Switch to HTML mode.
  - IF WPCom: Check that the image URL has the `?w=xxx` property.
  - IF Self-Hosted: Check that the image URL is the proper resized variant: `...img_2782-768x1024.jpg` or similar.

