### PR TITLE
Navigation: fix adding CSS custom class issue

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -49,21 +49,17 @@ function build_css_colors( $attributes ) {
  * @return string Returns the post content with the legacy widget added.
  */
 function render_block_navigation( $attributes, $content, $block ) {
-	$colors          = build_css_colors( $attributes );
-	$class_attribute = sprintf( ' class="%s"', esc_attr( $colors['css_classes'] ? 'wp-block-navigation ' . $colors['css_classes'] : 'wp-block-navigation' ) );
-	$style_attribute = $colors['inline_styles'] ? sprintf( ' style="%s"', esc_attr( $colors['inline_styles'] ) ) : '';
+	$colors  = build_css_colors( $attributes );
+	$classes = array( 'wp-block-navigation', $colors['css_classes'] );
+	if ( ! empty( $attributes['className'] ) ) {
+		$classes[] = $attributes['className'];
+	}
+	$classes = join( ' ', array_filter( $classes ) );
 
 	return sprintf(
-		implode(
-			"\n",
-			array(
-				'<nav%s%s>',
-				'	%s',
-				'</nav>',
-			)
-		),
-		$class_attribute,
-		$style_attribute,
+		'<nav class="%1$s" %2$s>%3$s</nav>',
+		esc_attr( $classes ),
+		$colors['inline_styles'] ? sprintf( 'style="%s"', esc_attr( $colors['inline_styles'] ) ) : '',
 		build_navigation_html( $block, $colors )
 	);
 }


### PR DESCRIPTION
## Description
It's a regression done by mistake. The original issue was taken over by @obenland (props!)

## How has this been tested?

* Create a navigation menu.
* Set a custom color (from colors palette).
![image](https://user-images.githubusercontent.com/77539/69238166-0ff54480-0b76-11ea-9027-0852bfde5199.png)

* Set a custom CSS class
<img width="983" alt="Screen Shot 2019-11-20 at 9 17 11 AM" src="https://user-images.githubusercontent.com/77539/69238370-9447c780-0b76-11ea-902c-2d724912e2db.png">

* Save the post

Confirm that the HTML markup has both CSS classes:
<img width="628" alt="Screen Shot 2019-11-20 at 9 17 57 AM" src="https://user-images.githubusercontent.com/77539/69238429-c22d0c00-0b76-11ea-82b9-5e07f0cb2f3d.png">

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->