### PR TITLE
modify search block so empty searches aren't submitted 

### DIFF
--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -34,7 +34,7 @@ function render_block_core_search( $attributes ) {
 	}
 
 	$input_markup = sprintf(
-		'<input type="search" id="%s" class="wp-block-search__input" name="s" value="%s" placeholder="%s" />',
+		'<input type="search" id="%s" class="wp-block-search__input" name="s" value="%s" placeholder="%s" required />',
 		$input_id,
 		esc_attr( get_search_query() ),
 		esc_attr( $attributes['placeholder'] )


### PR DESCRIPTION
## Description

I'm beginning to tackle #15600 and would appreciate some accessibility feedback. 

To start, I've only added `required` to the search input in [this PR](https://github.com/skorasaurus/gutenberg/tree/add/required-input-search-block). 

## How has this been tested?

A test page with this PR is available at http://7ags7iqr.gutenberg.run/2019/12/30/a-test-new-post/
(EDIT: this link expires after 24 hours, no longer works)
I'll try to keep that page up to date with the latest commits in my branch https://github.com/skorasaurus/gutenberg/tree/add/required-input-search-block

(Because this is still a primarily PHP-based component, [there is not a storybook component for this.](https://wordpress.github.io/gutenberg/?path=/story/docs-introduction--page)). 

**Desired Effect:**
A user does not submit an search result without any input. In my humble opinion, there isn't a good use case to allow them to submit an empty search result. 

**What will when happen with this PR merged in:** 
 In a [previous PR](https://github.com/WordPress/gutenberg/pull/17983), I had set the default value of label to `search` (using an existing class for screen readers, `screen-reader-text`) when an editor removes the default label when editing a search block._ 

I've tested this with a couple browsers and screen readers ([NVDA and JAWS are two very popular screen readers](https://webaim.org/projects/screenreadersurvey8/)  - in my opinion, note that survey is arguably biased to self-selection although it's a very thorough survey and the most comprehensive one that I know of); in my professional work at Cleveland Public Library, a remarkable majority of our users who use a screen reader use JAWS. 

**(User attempts to submit empty search by clicking on search button or pressing enter, while focus is on search button):** 

_Below, I am using $label to describe the label that is set in the search block; if it is removed within the block-editor, a label of 'Search' is applied)_

On NVDA (default settings), Edge: 

screen reader announces: "$label edit required invalid entry, this is a required field, blank." 

On NVDA (default settings), chrome: 
screen reader announces: "please fill out this field alert"

On Android (using talkback, default screen reader), chrome: 
"please fill out this field alert"

On Android (using talkback, default screen reader), firefox: 
screen reader focus is placed back into the search box's input field; screen reader announces: "editing entry search" 
(this is problematic and unexpected; no announcement to user that the search was not successful :( 

## Additional Questions
Do we want block editors to be able to customize the default notification/alert from screen readers?

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
