### PR TITLE
Navigation: set item ID

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -174,11 +174,13 @@ function NavigationLinkEdit( {
 									title: newTitle = '',
 									url: newURL = '',
 									opensInNewTab: newOpensInNewTab,
+									id,
 								} = {} ) => setAttributes( {
 									title: escape( newTitle ),
 									url: encodeURI( newURL ),
 									label: label || escape( newTitle ),
 									opensInNewTab: newOpensInNewTab,
+									id,
 								} ) }
 								onClose={ () => setIsLinkOpen( false ) }
 							/>


### PR DESCRIPTION
## Description
This PR sets the page id in the `<NavigationLink />` `id` attribute.

### Background
Each Navigation item gets its own page `ID` when the menu is (initially) created from the current blog pages. It means that each item `ID` gets the same value that its associated page `ID`.
However, it doesn't happen the same when the item is edited/created once the menu is already created. The item doesn't update its ID. It's an issue because if it doesn't update the ID will produce an incoherence between the item and the association with its page.

## How has this been tested?
Add a new link from a page to an existing menu. Confirm that the `id` is propagated into the `attributes` component object:

<img width="540" alt="Screen Shot 2019-11-20 at 4 18 04 PM" src="https://user-images.githubusercontent.com/77539/69270464-bb6fba80-0bb1-11ea-847f-eb290f61836e.png">

<img width="435" alt="Screen Shot 2019-11-20 at 4 18 37 PM" src="https://user-images.githubusercontent.com/77539/69270381-967b4780-0bb1-11ea-8063-5c9cc7a30178.png">

<img width="552" alt="Screen Shot 2019-11-20 at 4 19 30 PM" src="https://user-images.githubusercontent.com/77539/69270379-967b4780-0bb1-11ea-8d02-9abf8791ce83.png">



## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
