### PR TITLE
Core Data: Test entity undo reducer.

### DIFF
--- a/packages/core-data/src/reducer.js
+++ b/packages/core-data/src/reducer.js
@@ -314,7 +314,13 @@ export function undo( state = UNDO_INITIAL_STATE, action ) {
 				! isCreateUndoLevel && ( action.meta.isUndo || action.meta.isRedo );
 			if ( isCreateUndoLevel ) {
 				action = lastEditAction;
-			} else if ( ! isUndoOrRedo ) {
+			} else if (
+				! isUndoOrRedo &&
+				// Don't update the last edit cache if the new one only has transient edits.
+				// Transient edits don't create new levels so updating the cache would make
+				// us skip an edit later when creating levels explicitly.
+				Object.keys( action.edits ).some( ( key ) => ! action.transientEdits[ key ] )
+			) {
 				lastEditAction = action;
 			}
 

--- a/packages/core-data/src/reducer.js
+++ b/packages/core-data/src/reducer.js
@@ -314,14 +314,18 @@ export function undo( state = UNDO_INITIAL_STATE, action ) {
 				! isCreateUndoLevel && ( action.meta.isUndo || action.meta.isRedo );
 			if ( isCreateUndoLevel ) {
 				action = lastEditAction;
-			} else if (
-				! isUndoOrRedo &&
-				// Don't update the last edit cache if the new one only has transient edits.
+			} else if ( ! isUndoOrRedo ) {
+				// Don't lose the last edit cache if the new one only has transient edits.
 				// Transient edits don't create new levels so updating the cache would make
 				// us skip an edit later when creating levels explicitly.
-				Object.keys( action.edits ).some( ( key ) => ! action.transientEdits[ key ] )
-			) {
-				lastEditAction = action;
+				if ( Object.keys( action.edits ).some( ( key ) => ! action.transientEdits[ key ] ) ) {
+					lastEditAction = action;
+				} else {
+					lastEditAction = {
+						...action,
+						edits: { ...( lastEditAction && lastEditAction.edits ), ...action.edits },
+					};
+				}
 			}
 
 			let nextState;

--- a/packages/core-data/src/test/reducer.js
+++ b/packages/core-data/src/test/reducer.js
@@ -281,7 +281,7 @@ describe( 'undo', () => {
 		expect( undoState ).toEqual( expectedUndoState );
 	} );
 
-	it( 'explicitly creates an undo level when undoing with pending transient edits', () => {
+	it( 'explicitly creates an undo level when undoing while there are pending transient edits', () => {
 		undoState = createNextUndoState();
 		undoState = createNextUndoState( { value: 1 } );
 		undoState = createNextUndoState(

--- a/packages/core-data/src/test/reducer.js
+++ b/packages/core-data/src/test/reducer.js
@@ -7,7 +7,15 @@ import { filter } from 'lodash';
 /**
  * Internal dependencies
  */
-import { terms, entities, embedPreviews, userPermissions, autosaves, currentUser } from '../reducer';
+import {
+	terms,
+	entities,
+	undo,
+	embedPreviews,
+	userPermissions,
+	autosaves,
+	currentUser,
+} from '../reducer';
 
 describe( 'terms()', () => {
 	it( 'returns an empty object by default', () => {
@@ -96,6 +104,206 @@ describe( 'entities', () => {
 		expect( filter( state.config, { kind: 'postType' } ) ).toEqual( [
 			{ kind: 'postType', name: 'posts' },
 		] );
+	} );
+} );
+
+describe( 'undo', () => {
+	let lastEdits;
+	let undoState;
+	let expectedUndoState;
+	const createEditActionPart = ( edits ) => ( {
+		kind: 'someKind',
+		name: 'someName',
+		recordId: 'someRecordId',
+		edits,
+	} );
+	const createNextEditAction = ( edits, transientEdits = {} ) => {
+		let action = {
+			...createEditActionPart( edits ),
+			transientEdits,
+		};
+		action = {
+			type: 'EDIT_ENTITY_RECORD',
+			...action,
+			meta: {
+				undo: { ...action, edits: lastEdits },
+			},
+		};
+		lastEdits = { ...lastEdits, ...edits };
+		return action;
+	};
+	const createNextUndoState = ( ...args ) => {
+		let action = {};
+		if ( args[ 0 ] === 'isUndo' || args[ 0 ] === 'isRedo' ) {
+			// We need to "apply" the undo level here and build
+			// the action to move the offset.
+			lastEdits =
+				undoState[
+					undoState.length + undoState.offset - ( args[ 0 ] === 'isUndo' ? 2 : 0 )
+				].edits;
+			action = {
+				type: 'EDIT_ENTITY_RECORD',
+				meta: {
+					[ args[ 0 ] ]: true,
+				},
+			};
+		} else if ( args[ 0 ] === 'isCreate' ) {
+			action = { type: 'CREATE_UNDO_LEVEL' };
+		} else if ( args.length ) {
+			action = createNextEditAction( ...args );
+		}
+		return deepFreeze( undo( undoState, action ) );
+	};
+	beforeEach( () => {
+		lastEdits = {};
+		undoState = undefined;
+		expectedUndoState = [];
+		expectedUndoState.offset = 0;
+	} );
+
+	it( 'initializes', () => {
+		expect( createNextUndoState() ).toEqual( expectedUndoState );
+	} );
+
+	it( 'stacks undo levels', () => {
+		undoState = createNextUndoState();
+
+		// Check that the first edit creates an undo level for the current state and
+		// one for the new one.
+		undoState = createNextUndoState( { value: 1 } );
+		expectedUndoState.push(
+			createEditActionPart( {} ),
+			createEditActionPart( { value: 1 } )
+		);
+		expect( undoState ).toEqual( expectedUndoState );
+
+		// Check that the second and third edits just create an undo level for
+		// themselves.
+		undoState = createNextUndoState( { value: 2 } );
+		expectedUndoState.push( createEditActionPart( { value: 2 } ) );
+		expect( undoState ).toEqual( expectedUndoState );
+		undoState = createNextUndoState( { value: 3 } );
+		expectedUndoState.push( createEditActionPart( { value: 3 } ) );
+		expect( undoState ).toEqual( expectedUndoState );
+	} );
+
+	it( 'handles undos/redos', () => {
+		undoState = createNextUndoState();
+		undoState = createNextUndoState( { value: 1 } );
+		undoState = createNextUndoState( { value: 2 } );
+		undoState = createNextUndoState( { value: 3 } );
+		expectedUndoState.push(
+			createEditActionPart( {} ),
+			createEditActionPart( { value: 1 } ),
+			createEditActionPart( { value: 2 } ),
+			createEditActionPart( { value: 3 } )
+		);
+		expect( undoState ).toEqual( expectedUndoState );
+
+		// Check that undoing and redoing an equal
+		// number of steps does not lose edits.
+		undoState = createNextUndoState( 'isUndo' );
+		expectedUndoState.offset--;
+		expect( undoState ).toEqual( expectedUndoState );
+		undoState = createNextUndoState( 'isUndo' );
+		expectedUndoState.offset--;
+		expect( undoState ).toEqual( expectedUndoState );
+		undoState = createNextUndoState( 'isRedo' );
+		expectedUndoState.offset++;
+		expect( undoState ).toEqual( expectedUndoState );
+		undoState = createNextUndoState( 'isRedo' );
+		expectedUndoState.offset++;
+		expect( undoState ).toEqual( expectedUndoState );
+
+		// Check that another edit will go on top when there
+		// is no undo level offset.
+		undoState = createNextUndoState( { value: 4 } );
+		expectedUndoState.push( createEditActionPart( { value: 4 } ) );
+		expect( undoState ).toEqual( expectedUndoState );
+
+		// Check that undoing and editing will slice of
+		// all the levels after the current one.
+		undoState = createNextUndoState( 'isUndo' );
+		undoState = createNextUndoState( 'isUndo' );
+		undoState = createNextUndoState( { value: 5 } );
+		expectedUndoState.pop();
+		expectedUndoState.pop();
+		expectedUndoState.push( createEditActionPart( { value: 5 } ) );
+		expect( undoState ).toEqual( expectedUndoState );
+	} );
+
+	it( 'handles flattened undos/redos', () => {
+		undoState = createNextUndoState();
+		undoState = createNextUndoState( { value: 1 } );
+		undoState = createNextUndoState(
+			{ transientValue: 2 },
+			{ transientValue: true }
+		);
+		undoState = createNextUndoState( { value: 3 } );
+		expectedUndoState.push(
+			createEditActionPart( {} ),
+			createEditActionPart( { value: 1, transientValue: 2 } ),
+			createEditActionPart( { value: 3 } )
+		);
+		expect( undoState ).toEqual( expectedUndoState );
+	} );
+
+	it( 'handles explicit undo level creation', () => {
+		undoState = createNextUndoState();
+
+		// Check that nothing happens if there are no pending
+		// transient edits.
+		undoState = createNextUndoState( { value: 1 } );
+		undoState = createNextUndoState( 'isCreate' );
+		expectedUndoState.push(
+			createEditActionPart( {} ),
+			createEditActionPart( { value: 1 } )
+		);
+		expect( undoState ).toEqual( expectedUndoState );
+
+		// Check that transient edits are merged into the last
+		// edits.
+		undoState = createNextUndoState(
+			{ transientValue: 2 },
+			{ transientValue: true }
+		);
+		undoState = createNextUndoState( 'isCreate' );
+		expectedUndoState[ expectedUndoState.length - 1 ].edits.transientValue = 2;
+		expect( undoState ).toEqual( expectedUndoState );
+
+		// Check that undo levels are created with the latest action,
+		// even if undone.
+		undoState = createNextUndoState( { value: 3 } );
+		undoState = createNextUndoState( 'isUndo' );
+		undoState = createNextUndoState( 'isCreate' );
+		expectedUndoState.pop();
+		expectedUndoState.push( createEditActionPart( { value: 3 } ) );
+		expect( undoState ).toEqual( expectedUndoState );
+	} );
+
+	it( 'explicitly creates an undo level when undoing with pending transient edits', () => {
+		undoState = createNextUndoState();
+		undoState = createNextUndoState( { value: 1 } );
+		undoState = createNextUndoState(
+			{ transientValue: 2 },
+			{ transientValue: true }
+		);
+		undoState = createNextUndoState( 'isUndo' );
+		expectedUndoState.push(
+			createEditActionPart( {} ),
+			createEditActionPart( { value: 1, transientValue: 2 } )
+		);
+		expectedUndoState.offset--;
+		expect( undoState ).toEqual( expectedUndoState );
+	} );
+
+	it( 'does not create new levels for the same function edits', () => {
+		const value = () => {};
+		undoState = createNextUndoState();
+		undoState = createNextUndoState( { value } );
+		undoState = createNextUndoState( { value: () => {} } );
+		expectedUndoState.push( createEditActionPart( { value } ) );
+		expect( undoState ).toEqual( expectedUndoState );
 	} );
 } );
 


### PR DESCRIPTION
Closes #17434

## Description

This PR adds unit tests for `core-data`'s new undo reducer.

It also fixes a minor edge case where we were updating a reference to the last edit action even if the new action only contained transient edits. This was causing us to skip/delete an undo level when explicitly marking the last changes as persistent.

## How has this been tested?

They are tests :smile:

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
