### PR TITLE
Add documentation for wp-env.json config file

### DIFF
--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -69,12 +69,11 @@ Positionals:
 
 <br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>
 
-## The Configuration File
+## Additional Configuration and Running with Multiple Plugins/Themes
 
-You may also specify a configuration file for `wp-env`. This can be useful for loading other themes and plugins that you are developing simultaneously. The script will attach the specified theme and plugin directories as volumes on the docker container so that changes you make to them exist in the WordPress instance.
+`wp-env` also supports a configuration file. At the moment, this is only used for loading extra themes and plugins that you may be developing together with your main one. The script will attach the specified theme and plugin directories as volumes on the docker containers so that changes you make to them exist in the WordPress instance.
 
 ### Example:
-The config file is plain JSON with the name `wp-env.json`. The format of the file looks like this:
 
 `wp-env.json`
 ```json
@@ -88,8 +87,8 @@ The config file is plain JSON with the name `wp-env.json`. The format of the fil
 }
 ```
 
-### Specifc Usage:
+### Caveats:
 
-This file should be located in the same directory from which you run `wp-env` commands for a project. So if you are running `wp-env` in the root directory of a plugin, `wp-env.json` should also be located there. 
+The file should be located in the same directory from which you run `wp-env` commands for a project. So if you are running `wp-env` in the root directory of a plugin, `wp-env.json` should also be located there. 
 
-Each item in the `themes` or `plugins` array should be an absolute or relative path to the root of a different theme or plugin directory. Relative paths will be resolved from the current working directory of the script, which means they are resolved from the location of the `wp-env.json` file.
+Each item in the `themes` or `plugins` array should be an absolute or relative path to the root of a different theme or plugin directory. Relative paths will be resolved from the current working directory, which means they will be resolved from the location of the `wp-env.json` file.

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -68,3 +68,28 @@ Positionals:
 ```
 
 <br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>
+
+## The Configuration File
+
+You may also specify a configuration file for `wp-env`. This can be useful for loading other themes and plugins that you are developing simultaneously. The script will attach the specified theme and plugin directories as volumes on the docker container so that changes you make to them exist in the WordPress instance.
+
+### Example:
+The config file is plain JSON with the name `wp-env.json`. The format of the file looks like this:
+
+`wp-env.json`
+```json
+{
+  "themes": [
+    "../path/to/theme/dir"
+  ],
+  "plugins": [
+    "../path/to/plugin/dir"
+  ]
+}
+```
+
+### Specifc Usage:
+
+This file should be located in the same directory from which you run `wp-env` commands for a project. So if you are running `wp-env` in the root directory of a plugin, `wp-env.json` should also be located there. 
+
+Each item in the `themes` or `plugins` array should be an absolute or relative path to the root of a different theme or plugin directory. Relative paths will be resolved from the current working directory of the script, which means they are resolved from the location of the `wp-env.json` file.


### PR DESCRIPTION
## Description
Added documentation for using the `wp-env.json` file. (See https://github.com/WordPress/gutenberg/pull/18121).

## How has this been tested?
n/a

## Screenshots <!-- if applicable -->
n/a

## Types of changes
Documentation

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
