### PR TITLE
Update/base control component

### DIFF
--- a/packages/components/src/base-control/index.js
+++ b/packages/components/src/base-control/index.js
@@ -12,16 +12,22 @@ function BaseControl( { id, label, hideLabelFromVision, help, className, childre
 	return (
 		<div className={ classnames( 'components-base-control', className ) }>
 			<div className="components-base-control__field">
-				{ label && id && hideLabelFromVision && <VisuallyHidden
-					as="label"
-					htmlFor={ id }>{ label }</VisuallyHidden> }
-				{ label && id && ! hideLabelFromVision && <label
-					className="components-base-control__label"
-					htmlFor={ id }>{ label }</label> }
-				{ label && ! id && hideLabelFromVision && <VisuallyHidden
-					as="label">{ label }</VisuallyHidden> }
-				{ label && ! id && ! hideLabelFromVision &&
-					<BaseControl.VisualLabel>{ label }</BaseControl.VisualLabel> }
+				{ label && id && ( hideLabelFromVision ?
+					<VisuallyHidden
+						as="label"
+						htmlFor={ id }>{ label }
+					</VisuallyHidden> :
+					<label
+						className="components-base-control__label"
+						htmlFor={ id }>{ label }
+					</label>
+				) }
+				{ label && ! id && ( hideLabelFromVision ?
+					<VisuallyHidden
+						as="label">{ label }
+					</VisuallyHidden> :
+					<BaseControl.VisualLabel>{ label }</BaseControl.VisualLabel>
+				) }
 				{ children }
 			</div>
 			{ !! help && <p id={ id + '__help' } className="components-base-control__help">{ help }</p> }

--- a/packages/components/src/base-control/index.js
+++ b/packages/components/src/base-control/index.js
@@ -18,7 +18,11 @@ function BaseControl( { id, label, hideLabelFromVision, help, className, childre
 				{ label && id && ! hideLabelFromVision && <label
 					className="components-base-control__label"
 					htmlFor={ id }>{ label }</label> }
-				{ label && ! id && <BaseControl.VisualLabel>{ label }</BaseControl.VisualLabel> }
+				{ label && ! id && hideLabelFromVision && <VisuallyHidden
+					as="label"
+					htmlFor={ id }>{ label }</VisuallyHidden> }
+				{ label && ! id && ! hideLabelFromVision &&
+					<BaseControl.VisualLabel>{ label }</BaseControl.VisualLabel> }
 				{ children }
 			</div>
 			{ !! help && <p id={ id + '__help' } className="components-base-control__help">{ help }</p> }

--- a/packages/components/src/base-control/index.js
+++ b/packages/components/src/base-control/index.js
@@ -15,17 +15,14 @@ function BaseControl( { id, label, hideLabelFromVision, help, className, childre
 				{ label && id && ( hideLabelFromVision ?
 					<VisuallyHidden
 						as="label"
-						htmlFor={ id }>{ label }
-					</VisuallyHidden> :
+						htmlFor={ id }>{ label }</VisuallyHidden> :
 					<label
 						className="components-base-control__label"
-						htmlFor={ id }>{ label }
-					</label>
+						htmlFor={ id }>{ label }</label>
 				) }
 				{ label && ! id && ( hideLabelFromVision ?
 					<VisuallyHidden
-						as="label">{ label }
-					</VisuallyHidden> :
+						as="label">{ label }</VisuallyHidden> :
 					<BaseControl.VisualLabel>{ label }</BaseControl.VisualLabel>
 				) }
 				{ children }

--- a/packages/components/src/base-control/index.js
+++ b/packages/components/src/base-control/index.js
@@ -19,8 +19,7 @@ function BaseControl( { id, label, hideLabelFromVision, help, className, childre
 					className="components-base-control__label"
 					htmlFor={ id }>{ label }</label> }
 				{ label && ! id && hideLabelFromVision && <VisuallyHidden
-					as="label"
-					htmlFor={ id }>{ label }</VisuallyHidden> }
+					as="label">{ label }</VisuallyHidden> }
 				{ label && ! id && ! hideLabelFromVision &&
 					<BaseControl.VisualLabel>{ label }</BaseControl.VisualLabel> }
 				{ children }


### PR DESCRIPTION
## Description
This PR addresses a missing case in base-control specified in #18166. When id is not passed and hideLabelFromVision is passed in the label will still be visually displayed.

## How has this been tested?
I've created a story in Storybook to confirm that the component are rendered correctly. I'll submit another PR for it.

## Types of changes
Included a new condition to prevent the label from showing when hideLabelFromVision is true and no id is passed.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->