### PR TITLE
[Tiny PR] Add updated README files during precommit

### DIFF
--- a/package.json
+++ b/package.json
@@ -230,7 +230,8 @@
 			"node ./docs/tool/index.js"
 		],
 		"packages/**/*.js": [
-			"node ./bin/update-readmes.js"
+			"node ./bin/update-readmes.js",
+			"git add ."
 		]
 	},
 	"wp-env": {


### PR DESCRIPTION
## Description

Currently, `README.md` files are updated during `precommit`, but the changes are not added. This has been annoying me for a while. Only later on you realise that there are unstaged changes created by `./bin/update-readmes.js` and then you need to commit them separately.

Here I've added `git add .` after `node ./bin/update-readmes.js`. Note that this doesn't add any other unstaged changes as they are stashed.

## How has this been tested?

Update some documentation that would be added to a `README.md` file. Commit the change. Ensure that the automated `README.md` change is part of the commit.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
