### PR TITLE
Fix hidden post schedule popover on  mobile

### DIFF
--- a/packages/components/src/date-time/style.scss
+++ b/packages/components/src/date-time/style.scss
@@ -232,9 +232,3 @@
 .components-popover .components-datetime__date {
 	padding-left: 4px;
 }
-
-// Used to prevent z-index issues on mobile.
-// See: https://github.com/WordPress/gutenberg/pull/7621#issuecomment-424322735
-.components-popover.edit-post-post-schedule__dialog.is-bottom.is-left {
-	z-index: 100000;
-}


### PR DESCRIPTION
closes #18649 

We had a special z-index hack introduced in https://github.com/WordPress/gutenberg/pull/7621#issuecomment-424322735 

It looks like this regressed with #18044 but the good news is that removing the hack is the fix for the same issue it was introduced for :). It nice when hacky fixes remove them selves.

**Testing instructions**

 - Try opening the Post Schedule popover on mobile, it should show up properly.