### PR TITLE
Storybook: Categorize "Other" components

### DIFF
--- a/packages/components/src/popover/stories/index.js
+++ b/packages/components/src/popover/stories/index.js
@@ -9,7 +9,7 @@ import { boolean, select, text } from '@storybook/addon-knobs';
 import { DraggableWrapper } from './_utils';
 import Popover from '../';
 
-export default { title: 'Popover', component: Popover };
+export default { title: 'Components|Popover', component: Popover };
 
 export const _default = () => {
 	const show = boolean( 'Example: Show', true );

--- a/packages/components/src/tab-panel/stories/index.js
+++ b/packages/components/src/tab-panel/stories/index.js
@@ -8,7 +8,7 @@ import { text } from '@storybook/addon-knobs';
  */
 import TabPanel from '../';
 
-export default { title: 'TabPanel', component: TabPanel };
+export default { title: 'Components|TabPanel', component: TabPanel };
 
 export const _default = () => {
 	return (


### PR DESCRIPTION
## Description
Fixes `Popover` and `TabPanel` categorization for Storybook.

## How has this been tested?
Tested in Storybook

## Screenshots
<img width="426" alt="Screen Shot 2019-11-21 at 10 16 42 AM" src="https://user-images.githubusercontent.com/2322354/69350871-54e9ab80-0c48-11ea-9d95-4c2e20ae0b38.png">

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.

Resolves https://github.com/WordPress/gutenberg/issues/18670