### PR TITLE
Audio Block: add a few keywords to improve discovery.

### DIFF
--- a/packages/block-library/src/audio/index.js
+++ b/packages/block-library/src/audio/index.js
@@ -19,6 +19,7 @@ export { metadata, name };
 export const settings = {
 	title: __( 'Audio' ),
 	description: __( 'Embed a simple audio player.' ),
+	keywords: [ __( 'music' ), __( 'sound' ), __( 'podcast' ), __( 'recording' ) ],
 	icon,
 	transforms,
 	supports: {


### PR DESCRIPTION
This adds a few keywords to the Audio block — "sound", "music", "recording", "podcast" — to help discoverability.

![image](https://user-images.githubusercontent.com/548849/69358650-78801680-0c87-11ea-8c26-15b522610821.png)
