### PR TITLE
Storybook: Components: Apply style changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,6 +136,7 @@
 		"node-sass": "4.12.0",
 		"node-watch": "0.6.0",
 		"postcss": "7.0.13",
+		"postcss-loader": "3.0.0",
 		"progress": "2.0.3",
 		"react": "16.9.0",
 		"react-dom": "16.9.0",

--- a/storybook/config.js
+++ b/storybook/config.js
@@ -12,6 +12,11 @@ import { withKnobs } from '@storybook/addon-knobs';
 import '@wordpress/components/build-style/style.css';
 /* eslint-enable no-restricted-syntax */
 
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
 addDecorator( withA11y );
 addDecorator( withKnobs );
 configure(

--- a/storybook/stories/playground/index.js
+++ b/storybook/stories/playground/index.js
@@ -20,13 +20,6 @@ import {
 import { registerCoreBlocks } from '@wordpress/block-library';
 import '@wordpress/format-library';
 
-/* eslint-disable no-restricted-syntax */
-import '@wordpress/block-library/build-style/style.css';
-import '@wordpress/block-library/build-style/editor.css';
-import '@wordpress/block-library/build-style/theme.css';
-import '@wordpress/format-library/build-style/style.css';
-/* eslint-enable no-restricted-syntax */
-
 /**
  * Internal dependencies
  */

--- a/storybook/stories/playground/index.js
+++ b/storybook/stories/playground/index.js
@@ -21,7 +21,6 @@ import { registerCoreBlocks } from '@wordpress/block-library';
 import '@wordpress/format-library';
 
 /* eslint-disable no-restricted-syntax */
-import '@wordpress/block-editor/build-style/style.css';
 import '@wordpress/block-library/build-style/style.css';
 import '@wordpress/block-library/build-style/editor.css';
 import '@wordpress/block-library/build-style/theme.css';

--- a/storybook/stories/playground/index.js
+++ b/storybook/stories/playground/index.js
@@ -21,7 +21,6 @@ import { registerCoreBlocks } from '@wordpress/block-library';
 import '@wordpress/format-library';
 
 /* eslint-disable no-restricted-syntax */
-import '@wordpress/components/build-style/style.css';
 import '@wordpress/block-editor/build-style/style.css';
 import '@wordpress/block-library/build-style/style.css';
 import '@wordpress/block-library/build-style/editor.css';

--- a/storybook/style.scss
+++ b/storybook/style.scss
@@ -1,3 +1,5 @@
+// Loading @wordpress/base-styles as they have mixins and other dependencies
+// used within @wordpress/components/src/style.scss
 @import "~@wordpress/base-styles/animations";
 @import "~@wordpress/base-styles/breakpoints";
 @import "~@wordpress/base-styles/colors";
@@ -5,4 +7,5 @@
 @import "~@wordpress/base-styles/variables";
 @import "~@wordpress/base-styles/z-index";
 
+// @wordpress/components
 @import "../packages/components/src/style.scss";

--- a/storybook/style.scss
+++ b/storybook/style.scss
@@ -1,5 +1,5 @@
 // Loading @wordpress/base-styles as they have mixins and other dependencies
-// used within @wordpress/components/src/style.scss
+// used within @wordpress/*/src/*.scss
 @import "~@wordpress/base-styles/animations";
 @import "~@wordpress/base-styles/breakpoints";
 @import "~@wordpress/base-styles/colors";
@@ -7,5 +7,10 @@
 @import "~@wordpress/base-styles/variables";
 @import "~@wordpress/base-styles/z-index";
 
-// @wordpress/components
+// @wordpress package styles
 @import "../packages/components/src/style.scss";
+@import "../packages/block-editor/src/style.scss";
+@import "../packages/block-library/src/style.scss";
+@import "../packages/block-library/src/theme.scss";
+@import "../packages/block-library/src/editor.scss";
+@import "../packages/format-library/src/style.scss";

--- a/storybook/style.scss
+++ b/storybook/style.scss
@@ -1,0 +1,8 @@
+@import "~@wordpress/base-styles/animations";
+@import "~@wordpress/base-styles/breakpoints";
+@import "~@wordpress/base-styles/colors";
+@import "~@wordpress/base-styles/mixins";
+@import "~@wordpress/base-styles/variables";
+@import "~@wordpress/base-styles/z-index";
+
+@import "../packages/components/src/style.scss";

--- a/storybook/webpack.config.js
+++ b/storybook/webpack.config.js
@@ -1,4 +1,5 @@
 const path = require( 'path' );
+const postCssConfigPlugins = require( '../bin/packages/post-css-config' );
 
 module.exports = ( { config } ) => {
 	config.module.rules.push(
@@ -9,7 +10,22 @@ module.exports = ( { config } ) => {
 		},
 		{
 			test: /\.scss$/,
-			use: [ 'style-loader', 'css-loader', 'sass-loader' ],
+			use: [
+				'style-loader',
+				'css-loader',
+				/**
+				 * Configuring PostCSS with Webpack
+				 * https://github.com/postcss/postcss-loader#plugins
+				 */
+				{
+					loader: 'postcss-loader',
+					options: {
+						ident: 'postcss',
+						plugins: () => postCssConfigPlugins,
+					},
+				},
+				'sass-loader',
+			],
 			include: path.resolve( __dirname ),
 		}
 	);


### PR DESCRIPTION
## Description
This update fixes the Storybook x WP/Components workflow to enable for style changes made in `.scss` files to be reflected within Storybook. Previously, this was not supported due to the importing of the pre-build `.css`.

Storybook's webpack config was also enhanced with `postcss-loader`, allowing for PostCSS functions to execute on run time. This is necessary for functions like `color()` to work correctly.

## How has this been tested?
Storybook

## Screenshots

![Screen Capture on 2019-11-21 at 14-32-55](https://user-images.githubusercontent.com/2322354/69371310-9b053600-0c6d-11ea-8bc8-3a1b3acbc3fd.gif)


## Types of changes

Some things to consider would be how this may impact the build Storybook to be uploaded and served to Github pages. I don't think it would have too much of a negative impact.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.

Resolves: https://github.com/WordPress/gutenberg/issues/18675