### PR TITLE
Fix the snackbar notices position

### DIFF
--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -13,14 +13,14 @@
 }
 
 // Adjust the position of the notices
-.edit-post-layout__content .components-editor-notices__snackbar {
+.edit-post-layout .components-editor-notices__snackbar {
 	position: fixed;
 	right: 0;
 	bottom: 20px;
 	padding-left: 16px;
 	padding-right: 16px;
 }
-@include editor-left(".edit-post-layout__content .components-editor-notices__snackbar");
+@include editor-left(".edit-post-layout.components-editor-notices__snackbar");
 
 .edit-post-layout .editor-post-publish-panel {
 	position: fixed;
@@ -108,32 +108,5 @@
 		padding: 0 $grid-size;
 		align-items: center;
 		font-size: $default-font-size;
-	}
-}
-
-.edit-post-layout__scrollable-container {
-	// On mobile the main content (html or body) area has to scroll.
-	// If, like we do on the desktop, scroll an element (.edit-post-layout__content) you can invoke
-	// the overscroll bounce on the non-scrolling container, causing for a frustrating scrolling experience.
-	// The following rule enables this scrolling beyond the mobile breakpoint, because on the desktop
-	// breakpoints scrolling an isolated element helps avoid scroll bleed.
-	@include break-small() {
-		overflow-y: auto;
-	}
-	-webkit-overflow-scrolling: touch;
-
-	// This rule ensures that if you've scrolled to the end of a container,
-	// then pause, then keep scrolling downwards, the browser doesn't try to scroll
-	// the parent element, usually invoking a "bounce" effect and then preventing you
-	// from scrolling upwards until you pause again.
-	// This is only necessary beyond the small breakpoint because that's when the scroll container changes.
-	@include break-small() {
-		overscroll-behavior-y: none;
-	}
-
-	// Pad the scroll box so content on the bottom can be scrolled up.
-	padding-bottom: 50vh;
-	@include break-small {
-		padding-bottom: 0;
 	}
 }


### PR DESCRIPTION
This PR fixes another small regression caused by #18044 where the snackbar notices were positioned at the top instead of the bottom left of the page.

Basically the `edit-post-layout__content` className has been removed. Fortunately, this is the only place it was used. I'm also removing some useless styles I found.

I'm also adding a "Needs dev note" label to document this change in the next WordPress release.
