### PR TITLE
Fix theme background regression.

### DIFF
--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -1,3 +1,9 @@
+// This min-height is there to ensure the editing canvas extends at least to the full height available.
+// This ensures a theme that uses a background color other than white doesn't look cropped without content.
+.edit-post-visual-editor {
+	min-height: 100%;
+}
+
 .edit-post-layout__metaboxes {
 	flex-shrink: 0;
 }

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -1,9 +1,3 @@
-// This min-height is there to ensure the editing canvas extends at least to the full height available.
-// This ensures a theme that uses a background color other than white doesn't look cropped without content.
-.edit-post-visual-editor {
-	min-height: 100%;
-}
-
 .edit-post-layout__metaboxes {
 	flex-shrink: 0;
 }

--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -14,6 +14,10 @@
 	@supports (position: sticky) {
 		flex-basis: 100%;
 	}
+
+	// This min-height is there to ensure the editing canvas extends at least to the full height available.
+	// This ensures a theme that uses a background color other than white doesn't look cropped without content.
+	min-height: 100%;
 }
 
 .edit-post-visual-editor .block-editor-writing-flow__click-redirect {


### PR DESCRIPTION
#18044 introduced a small regression where a theme with a non-white background, for example TwentyTwenty, looked cropped.

This PR fixes that by applying a min-height to the canvas.

Before:

<img width="1055" alt="Screenshot 2019-11-22 at 11 31 46" src="https://user-images.githubusercontent.com/1204802/69419239-5dabb180-0d1c-11ea-9ed5-2cb69ff946dc.png">

After:

<img width="1059" alt="Screenshot 2019-11-22 at 11 33 51" src="https://user-images.githubusercontent.com/1204802/69419256-656b5600-0d1c-11ea-8d6e-c60ed8817fce.png">