### PR TITLE
Fix/18582 z index for snackbar

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -24,6 +24,7 @@ $z-layers: (
 	".block-editor-warning": 5,
 	".block-library-gallery-item__inline-menu": 20,
 	".block-editor-url-input__suggestions": 30,
+	".edit-post-layout__content": 35,
 	".edit-post-layout__footer": 30,
 	".edit-post-editor-regions__header": 30,
 	".edit-widgets-header": 30,

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -12,6 +12,11 @@
 	}
 }
 
+
+.edit-post-layout__content {
+	overflow-x: hidden;
+}
+
 // Adjust the position of the notices
 .edit-post-layout__content .components-editor-notices__snackbar {
 	position: fixed;


### PR DESCRIPTION
## Description
Fix #18582 for Snackbar notices. It was showing up under the footer and under the horizontal scrollbar.

## How has this been tested?
Tested locally, by manual tests. 
Wordpress 5.3.0.
Steps: 
I:
- Add normal block
- Click Save
- Snackbar is showing up properly.
II:
- Add block which is more than 1920px
- Click save
- Snackbar is showing up properly.

## Screenshots
![Zrzut ekranu z 2019-11-22 14-33-25](https://user-images.githubusercontent.com/15144546/69430662-64472280-0d36-11ea-8651-fe9ff702d6ef.png)

## Types of changes
+ add z-index 35 for editor layout in z-index file
+ add overflow-x: hidden for editor layout 

## Checklist:
- [+] My code is tested.
- [+] My code follows the WordPress code style. <!-- Check code: `npm run lint` -->
- [+] My code follows the accessibility standards.
- [+] RWD checked.
