### PR TITLE
[RNMobile] Fix Image Size when url for slug doesn't exist.

### DIFF
--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -136,7 +136,7 @@ export class ImageEdit extends React.Component {
 	componentDidUpdate( previousProps ) {
 		if ( ! previousProps.image && this.props.image ) {
 			const { image, attributes } = this.props;
-			const url = getUrlForSlug( image, attributes );
+			const url = getUrlForSlug( image, attributes ) || image.source_url;
 			this.props.setAttributes( { url } );
 		}
 	}


### PR DESCRIPTION
## Description
Fixes n7 from https://github.com/wordpress-mobile/gutenberg-mobile/issues/1593

`gutenberg-mobile` PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1611

This issue has been possible to be reproduce on Pressable sites:
- When the image uploaded is small, it won't generate a `Large` size image, so there won't be url for the Large image option. In the same way, when the image is big enough, it generates many other size options not shown on the UI (including on web).

An example from a small image:
```json
{
  "width": 499,
  "height": 333,
  "file": "2019/11/11769619264_5e93c3e4d2-1.jpg",
  "sizes": {
    "medium": {
      "file": "11769619264_5e93c3e4d2-1-300x200.jpg",
      "width": 300,
      "height": 200,
      "mime_type": "image/jpeg",
      "source_url": "https://testingsiteetoledom.mystagingwebsite.com/wp-content/uploads/2019/11/11769619264_5e93c3e4d2-1-300x200.jpg"
    },
    "thumbnail": {
      "file": "11769619264_5e93c3e4d2-1-150x150.jpg",
      "width": 150,
      "height": 150,
      "mime_type": "image/jpeg",
      "source_url": "https://testingsiteetoledom.mystagingwebsite.com/wp-content/uploads/2019/11/11769619264_5e93c3e4d2-1-150x150.jpg"
    },
    "full": {
      "file": "11769619264_5e93c3e4d2-1.jpg",
      "width": 499,
      "height": 333,
      "mime_type": "image/jpeg",
      "source_url": "https://testingsiteetoledom.mystagingwebsite.com/wp-content/uploads/2019/11/11769619264_5e93c3e4d2-1.jpg"
    }
  },
}
```

This is a big image:
```json
{
  "width": 2560,
  "height": 1440,
  "file": "2019/11/beautiful-blur-bright-326055-1-scaled.jpg",
  "sizes": {
    "medium": {
      "file": "beautiful-blur-bright-326055-1-300x169.jpg",
      "width": 300,
      "height": 169,
      "mime_type": "image/jpeg",
      "source_url": "https://testingsiteetoledom.mystagingwebsite.com/wp-content/uploads/2019/11/beautiful-blur-bright-326055-1-300x169.jpg"
    },
    "large": {
      "file": "beautiful-blur-bright-326055-1-1024x576.jpg",
      "width": 1024,
      "height": 576,
      "mime_type": "image/jpeg",
      "source_url": "https://testingsiteetoledom.mystagingwebsite.com/wp-content/uploads/2019/11/beautiful-blur-bright-326055-1-1024x576.jpg"
    },
    "thumbnail": {
      "file": "beautiful-blur-bright-326055-1-150x150.jpg",
      "width": 150,
      "height": 150,
      "mime_type": "image/jpeg",
      "source_url": "https://testingsiteetoledom.mystagingwebsite.com/wp-content/uploads/2019/11/beautiful-blur-bright-326055-1-150x150.jpg"
    },
    "medium_large": {
      "file": "beautiful-blur-bright-326055-1-768x432.jpg",
      "width": 768,
      "height": 432,
      "mime_type": "image/jpeg",
      "source_url": "https://testingsiteetoledom.mystagingwebsite.com/wp-content/uploads/2019/11/beautiful-blur-bright-326055-1-768x432.jpg"
    },
    "1536x1536": {
      "file": "beautiful-blur-bright-326055-1-1536x864.jpg",
      "width": 1536,
      "height": 864,
      "mime_type": "image/jpeg",
      "source_url": "https://testingsiteetoledom.mystagingwebsite.com/wp-content/uploads/2019/11/beautiful-blur-bright-326055-1-1536x864.jpg"
    },
    "2048x2048": {
      "file": "beautiful-blur-bright-326055-1-2048x1152.jpg",
      "width": 2048,
      "height": 1152,
      "mime_type": "image/jpeg",
      "source_url": "https://testingsiteetoledom.mystagingwebsite.com/wp-content/uploads/2019/11/beautiful-blur-bright-326055-1-2048x1152.jpg"
    },
    "post-thumbnail": {
      "file": "beautiful-blur-bright-326055-1-1568x882.jpg",
      "width": 1568,
      "height": 882,
      "mime_type": "image/jpeg",
      "source_url": "https://testingsiteetoledom.mystagingwebsite.com/wp-content/uploads/2019/11/beautiful-blur-bright-326055-1-1568x882.jpg"
    },
    "full": {
      "file": "beautiful-blur-bright-326055-1-scaled.jpg",
      "width": 2560,
      "height": 1440,
      "mime_type": "image/jpeg",
      "source_url": "https://testingsiteetoledom.mystagingwebsite.com/wp-content/uploads/2019/11/beautiful-blur-bright-326055-1-scaled.jpg"
    }
  },
}
```

The changes on this PR are just to avoid the issue where the image disappears if the url doesn't exist for the Large slug (the default one), leaving the original url instead. This is how currently "works" on web.

**To test:**
- On a Pressable self-hosted site (not linked via Jetpack):
- Upload a small image (around 500x300) using the app.
- When it finishes upload, check that the image is still in place.
- Check that the URL is the remote URL.
