### PR TITLE
E2E Tests: Verify the expected theme is active.

### DIFF
--- a/packages/e2e-test-utils/README.md
+++ b/packages/e2e-test-utils/README.md
@@ -510,6 +510,14 @@ _Parameters_
 
 -   _slug_ `string`: Plugin slug.
 
+<a name="verifyActiveTheme" href="#verifyActiveTheme">#</a> **verifyActiveTheme**
+
+Verifies that the expected theme for the tests is active.
+
+_Parameters_
+
+-   _theme_ `string`: The expected theme's slug.
+
 <a name="visitAdminPage" href="#visitAdminPage">#</a> **visitAdminPage**
 
 Visits admin page; if user is not logged in then it logging in it first, then visits admin page.

--- a/packages/e2e-test-utils/src/index.js
+++ b/packages/e2e-test-utils/src/index.js
@@ -50,6 +50,7 @@ export { toggleOfflineMode, isOfflineMode } from './offline-mode';
 export { toggleScreenOption } from './toggle-screen-option';
 export { transformBlockTo } from './transform-block-to';
 export { uninstallPlugin } from './uninstall-plugin';
+export { verifyActiveTheme } from './verify-active-theme';
 export { visitAdminPage } from './visit-admin-page';
 export { waitForWindowDimensions } from './wait-for-window-dimensions';
 

--- a/packages/e2e-test-utils/src/verify-active-theme.js
+++ b/packages/e2e-test-utils/src/verify-active-theme.js
@@ -1,0 +1,16 @@
+/**
+ * Internal dependencies
+ */
+import { createURL } from './create-url';
+
+/**
+ * Verifies that the expected theme for the tests is active.
+ *
+ * @param {string} theme The expected theme's slug.
+ */
+export async function verifyActiveTheme( theme ) {
+	await page.goto( createURL( '' ) );
+	if ( ( await page.$( `#${ theme }-style-css` ) ) === null ) {
+		process.exit( `Test suite must be run using the ${ theme } theme.` );
+	}
+}

--- a/packages/e2e-tests/specs/editor/blocks/heading.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/heading.test.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import {
+	verifyActiveTheme,
 	clickBlockAppender,
 	createNewPost,
 	getEditedPostContent,
@@ -9,6 +10,8 @@ import {
 } from '@wordpress/e2e-test-utils';
 
 describe( 'Heading', () => {
+	beforeAll( verifyActiveTheme.bind( null, 'twentytwenty' ) );
+
 	const TEXT_COLOR_TEXT = 'Text Color';
 	const CUSTOM_COLOR_TEXT = 'Custom Color';
 	const TEXT_COLOR_UI_X_SELECTOR = `//div[./span[contains(text(),'${ TEXT_COLOR_TEXT }')]]`;

--- a/packages/e2e-tests/specs/editor/various/change-detection.test.js
+++ b/packages/e2e-tests/specs/editor/various/change-detection.test.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import {
+	verifyActiveTheme,
 	clickBlockAppender,
 	createNewPost,
 	pressKeyWithModifier,
@@ -14,6 +15,8 @@ import {
 
 describe( 'Change detection', () => {
 	let handleInterceptedRequest, hadInterceptedSave;
+
+	beforeAll( verifyActiveTheme.bind( null, 'twentytwenty' ) );
 
 	beforeEach( async () => {
 		hadInterceptedSave = false;

--- a/packages/e2e-tests/specs/editor/various/font-size-picker.test.js
+++ b/packages/e2e-tests/specs/editor/various/font-size-picker.test.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import {
+	verifyActiveTheme,
 	clickBlockAppender,
 	getEditedPostContent,
 	createNewPost,
@@ -9,6 +10,8 @@ import {
 } from '@wordpress/e2e-test-utils';
 
 describe( 'Font Size Picker', () => {
+	beforeAll( verifyActiveTheme.bind( null, 'twentytwenty' ) );
+
 	beforeEach( async () => {
 		await createNewPost();
 	} );

--- a/packages/e2e-tests/specs/editor/various/preview.test.js
+++ b/packages/e2e-tests/specs/editor/various/preview.test.js
@@ -8,6 +8,7 @@ import { parse } from 'url';
  * WordPress dependencies
  */
 import {
+	verifyActiveTheme,
 	clickOnCloseModalButton,
 	createNewPost,
 	createURL,
@@ -83,6 +84,8 @@ async function toggleCustomFieldsOption( shouldBeChecked ) {
 }
 
 describe( 'Preview', () => {
+	beforeAll( verifyActiveTheme.bind( null, 'twentytwenty' ) );
+
 	beforeEach( async () => {
 		await createNewPost();
 	} );


### PR DESCRIPTION
## Description

This PR adds a check before all E2E tests are ran that verifies that the theme the tests expect is active.

Sometimes, contributors run tests locally with different themes and are confused as to why they fail. This check will surface those situations. See [this comment](https://github.com/WordPress/gutenberg/pull/17917#issuecomment-557596676) for an example.

## How has this been tested?

It was verified that running the E2E tests with a theme other than the currently expected one, twentytwenty, throws a descriptive error before all tests are run.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
