### PR TITLE
Env: Run tests using the same version used for development.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7965,6 +7965,7 @@
 			"dev": true,
 			"requires": {
 				"chalk": "^2.4.2",
+				"copy-dir": "^1.2.0",
 				"docker-compose": "^0.22.2",
 				"nodegit": "^0.26.2",
 				"ora": "^4.0.2",
@@ -13446,6 +13447,12 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
 			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+			"dev": true
+		},
+		"copy-dir": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/copy-dir/-/copy-dir-1.2.0.tgz",
+			"integrity": "sha512-UeaUFUIHqGV4brjQ9bY2mHll/hoxyCak2emgmYG72LkGKABHBdBDKFw0H5nTKt5OzVBkBhkxCwnniJBAE7EGEw==",
 			"dev": true
 		},
 		"copy-to-clipboard": {

--- a/packages/env/lib/create-docker-compose-config.js
+++ b/packages/env/lib/create-docker-compose-config.js
@@ -1,13 +1,16 @@
 module.exports = function createDockerComposeConfig(
 	cwdTestsPath,
 	context,
-	dependencies,
+	dependencies
 ) {
 	const { path: cwd, pathBasename: cwdName } = context;
 
-	const dependencyMappings = [ ...dependencies, context ].map(
-		( { path, pathBasename, type } ) => `      - ${ path }/:/var/www/html/wp-content/${ type }s/${ pathBasename }/\n`
-	).join( '' );
+	const dependencyMappings = [ ...dependencies, context ]
+		.map(
+			( { path, pathBasename, type } ) =>
+				`      - ${ path }/:/var/www/html/wp-content/${ type }s/${ pathBasename }/\n`
+		)
+		.join( '' );
 	const commonVolumes = `
 ${ dependencyMappings }
       - ${ cwd }${ cwdTestsPath }/e2e-tests/mu-plugins/:/var/www/html/wp-content/mu-plugins/
@@ -15,10 +18,8 @@ ${ dependencyMappings }
 	const volumes = `
       - ${ cwd }/../${ cwdName }-wordpress/:/var/www/html/${ commonVolumes }`;
 	const testsVolumes = `
-      - tests-wordpress:/var/www/html/${ commonVolumes }`;
+      - ${ cwd }/../${ cwdName }-tests-wordpress/:/var/www/html/${ commonVolumes }`;
 	return `version: '2.1'
-volumes:
-  tests-wordpress:
 services:
   mysql:
     environment:

--- a/packages/env/lib/env.js
+++ b/packages/env/lib/env.js
@@ -105,6 +105,17 @@ module.exports = {
 		}
 
 		// Duplicate repo for the tests container.
+		let stashed = true; // Stash to avoid copying config changes.
+		try {
+			await NodeGit.Stash.save(
+				repo,
+				await NodeGit.Signature.default( repo ),
+				null,
+				NodeGit.Stash.FLAGS.INCLUDE_UNTRACKED
+			);
+		} catch ( err ) {
+			stashed = false;
+		}
 		await copyDir( repoPath, `../${ cwdName }-tests-wordpress/`, {
 			filter: ( stat, filepath ) =>
 				stat !== 'symbolicLink' &&
@@ -112,6 +123,11 @@ module.exports = {
 					( filepath !== `${ repoPath }.git` &&
 						! filepath.endsWith( 'node_modules' ) ) ),
 		} );
+		if ( stashed ) {
+			try {
+				await NodeGit.Stash.pop( repo, 0 );
+			} catch ( err ) {}
+		}
 		spinner.text = `Downloading WordPress@${ ref } 100/100%.`;
 
 		spinner.text = `Starting WordPress@${ ref }.`;

--- a/packages/env/lib/env.js
+++ b/packages/env/lib/env.js
@@ -2,11 +2,11 @@
 /**
  * External dependencies
  */
+const util = require( 'util' );
 const path = require( 'path' );
 const fs = require( 'fs' );
 const dockerCompose = require( 'docker-compose' );
 const NodeGit = require( 'nodegit' );
-const wait = require( 'util' ).promisify( setTimeout );
 
 /**
  * Internal dependencies
@@ -14,6 +14,12 @@ const wait = require( 'util' ).promisify( setTimeout );
 const createDockerComposeConfig = require( './create-docker-compose-config' );
 const detectContext = require( './detect-context' );
 const resolveDependencies = require( './resolve-dependencies' );
+
+/**
+ * Promisified dependencies
+ */
+const copyDir = util.promisify( require( 'copy-dir' ) );
+const wait = util.promisify( setTimeout );
 
 // Config Variables
 const cwd = process.cwd();
@@ -97,6 +103,15 @@ module.exports = {
 			// Some commit refs need to be set as detached.
 			await repo.setHeadDetached( ref );
 		}
+
+		// Duplicate repo for the tests container.
+		await copyDir( repoPath, `../${ cwdName }-tests-wordpress/`, {
+			filter: ( stat, filepath ) =>
+				stat !== 'symbolicLink' &&
+				( stat !== 'directory' ||
+					( filepath !== `${ repoPath }.git` &&
+						! filepath.endsWith( 'node_modules' ) ) ),
+		} );
 		spinner.text = `Downloading WordPress@${ ref } 100/100%.`;
 
 		spinner.text = `Starting WordPress@${ ref }.`;
@@ -146,7 +161,8 @@ module.exports = {
 	async clean( { environment, spinner } ) {
 		const context = await detectContext();
 		const dependencies = await resolveDependencies();
-		const activateDependencies = () => Promise.all( dependencies.map( activateContext ) );
+		const activateDependencies = () =>
+			Promise.all( dependencies.map( activateContext ) );
 
 		const description = `${ environment } environment${
 			environment === 'all' ? 's' : ''

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -33,6 +33,7 @@
 	},
 	"dependencies": {
 		"chalk": "^2.4.2",
+		"copy-dir": "^1.2.0",
 		"docker-compose": "^0.22.2",
 		"nodegit": "^0.26.2",
 		"ora": "^4.0.2",


### PR DESCRIPTION
## Description

`@wordpress/env`'s `wp-env start` command takes a `[ref]` positional argument, which defaults to `master`, to specify a version of https://github.com/WordPress/WordPress to run. This was being respected for the development environment, but not for the tests environment, which resulted in E2E tests being ran on the default version shipped with the WordPress Docker container, i.e. not `master` with TwentyTwenty which our tests expect.

This PR addresses the issue by mounting an isolated copy of the checked out WordPress used for development, in the tests container, so that it can use the same version.

## How has this been tested?

It was verified that after running `wp-env start`, both the development and tests containers are now running the same version of WordPress and all E2E tests pass as expected.

## Types of Changes

*Bug Fix:* `@wordpress/env` now respects the specified WordPress version for both development and tests environments.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
