### PR TITLE
Docs: Add link to JavaScript Build Step to TOC

### DIFF
--- a/docs/designers-developers/developers/tutorials/javascript/readme.md
+++ b/docs/designers-developers/developers/tutorials/javascript/readme.md
@@ -11,9 +11,11 @@ The block editor introduced in WordPress 5.0 is written in JavaScript, with the 
 
 ### Table of Contents
 
-1. [Plugins Background](/docs/designers-developers/developers/tutorials/javascript/plugins-background.md)
-2. [Loading JavaScript](/docs/designers-developers/developers/tutorials/javascript/loading-javascript.md)
-3. [Extending the Block Editor](/docs/designers-developers/developers/tutorials/javascript/extending-the-block-editor.md)
-4. [Troubleshooting](/docs/designers-developers/developers/tutorials/javascript/troubleshooting.md)
-5. [JavaScript Versions and Building](/docs/designers-developers/developers/tutorials/javascript/versions-and-building.md)
-6. [Scope your code](/docs/designers-developers/developers/tutorials/javascript/scope-your-code.md)
+1. [Plugins Background](plugins-background.md)
+2. [Loading JavaScript](loading-javascript.md)
+3. [Extending the Block Editor](extending-the-block-editor.md)
+4. [Troubleshooting](troubleshooting.md)
+5. [JavaScript Versions and Building](versions-and-building.md)
+6. [Scope your code](scope-your-code.md)
+7. [JavaScript Build Step](js-build-setup.md)
+


### PR DESCRIPTION
## Description

Updates the Table of Contents for JavaScript tutorial.

1. Adds link to JavaScript Build Step page, missed when page was added.

2. Updates links to be relative, shorter and easier to code. Previously the docs required all links to start from `/docs` There was an update at some point that supports relative links in same directory.

## How has this been tested?

Verify documentation and links, [view on branch here](https://github.com/WordPress/gutenberg/tree/docs/toc-js/docs/designers-developers/developers/tutorials/javascript).

## Types of changes

Documentation.
