### PR TITLE
Fixes broken links in JavaScript Tutorial TOC links

### DIFF
--- a/docs/designers-developers/developers/tutorials/javascript/readme.md
+++ b/docs/designers-developers/developers/tutorials/javascript/readme.md
@@ -11,11 +11,11 @@ The block editor introduced in WordPress 5.0 is written in JavaScript, with the 
 
 ### Table of Contents
 
-1. [Plugins Background](plugins-background.md)
-2. [Loading JavaScript](loading-javascript.md)
-3. [Extending the Block Editor](extending-the-block-editor.md)
-4. [Troubleshooting](troubleshooting.md)
-5. [JavaScript Versions and Building](versions-and-building.md)
-6. [Scope your code](scope-your-code.md)
-7. [JavaScript Build Step](js-build-setup.md)
+1. [Plugins Background](/docs/designers-developers/developers/tutorials/javascript/plugins-background.md)
+2. [Loading JavaScript](/docs/designers-developers/developers/tutorials/javascript/loading-javascript.md)
+3. [Extending the Block Editor](/docs/designers-developers/developers/tutorials/javascript/extending-the-block-editor.md)
+4. [Troubleshooting](/docs/designers-developers/developers/tutorials/javascript/troubleshooting.md)
+5. [JavaScript Versions and Building](/docs/designers-developers/developers/tutorials/javascript/versions-and-building.md)
+6. [Scope your code](/docs/designers-developers/developers/tutorials/javascript/scope-your-code.md)
+7. [JavaScript Build Step](/docs/designers-developers/developers/tutorials/javascript/js-build-setup.md)
 


### PR DESCRIPTION
## Description

I attempted changing the links to relative in #18707, which appears to work elsewhere. This did not work when published to Gutenberg Handbook.

Broken links here: https://developer.wordpress.org/block-editor/tutorials/javascript/

@gziolo @chrisvanpatten 
This confirm links must start from `/docs/

## How has this been tested?

Confirmed links work via Github, can not be tested until published in Handbook.

## Types of changes

Documentation.
