### PR TITLE
Social Links Block: GitHub Typo

### DIFF
--- a/packages/block-library/src/social-link/social-list.js
+++ b/packages/block-library/src/social-link/social-list.js
@@ -109,7 +109,7 @@ const socialList = {
 		icon: GoogleIcon,
 	},
 	github: {
-		name: 'Github',
+		name: 'GitHub',
 		icon: GithubIcon,
 	},
 	instagram: {

--- a/packages/e2e-tests/fixtures/block-transforms.js
+++ b/packages/e2e-tests/fixtures/block-transforms.js
@@ -560,7 +560,7 @@ export const EXPECTED_TRANSFORMS = {
 		availableTransforms: [
 			'Group',
 		],
-		originalBlock: 'Github',
+		originalBlock: 'GitHub',
 	},
 	'core__social-link-goodreads': {
 		availableTransforms: [


### PR DESCRIPTION
## Description
Small typo I noticed, the Social Links block has GitHub spelt as "Github".

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Just a very simple change, which inserting a Social Links block is enough to test.

## Screenshots <!-- if applicable -->

<img width="148" alt="Screenshot 2019-11-24 at 18 32 58" src="https://user-images.githubusercontent.com/43215253/69499336-dbbcb380-0ee8-11ea-8e7a-1f5b242399d7.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
