### PR TITLE
Update serverSideRender docs to include how to use from the wp global

### DIFF
--- a/packages/server-side-render/README.md
+++ b/packages/server-side-render/README.md
@@ -91,6 +91,21 @@ const MyServerSideRender = () => (
 	/>
 );
 ```
+If imported from the `wp` global, an alias is required to work in JSX.
+
+```jsx 
+const { serverSideRender: ServerSideRender } = wp;
+
+const MyServerSideRender = () => (
+	<ServerSideRender
+		block="core/archives"
+		attributes={ {
+			showPostCounts: true,
+			displayAsDropdown: false,
+		} }
+	/>
+);
+```
 
 ## Output
 


### PR DESCRIPTION
## Description
If accessing `ServerSideRender` from the `wp` global, due the the name change ( `serverSideRender` vs `ServerSideRender` ) an alias is required to work in JSX. This PR adds an example for that.

## How has this been tested?
Documentation only.

