### PR TITLE
API Fetch: Normalize keys of incoming preloaded data

### DIFF
--- a/packages/api-fetch/CHANGELOG.md
+++ b/packages/api-fetch/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Master
+
+### Bug Fixes
+
+- Resolves an issue with `createPreloadingMiddleware` where the preloaded data is assumed to be provided with keys matching the internal normalized value.
+
 ## 3.0.0 (2019-03-06)
 
 ### Breaking Changes

--- a/packages/api-fetch/src/middlewares/preloading.js
+++ b/packages/api-fetch/src/middlewares/preloading.js
@@ -1,49 +1,65 @@
-const createPreloadingMiddleware = ( preloadedData ) => ( options, next ) => {
-	function getStablePath( path ) {
-		const splitted = path.split( '?' );
-		const query = splitted[ 1 ];
-		const base = splitted[ 0 ];
-		if ( ! query ) {
-			return base;
-		}
-
-		// 'b=1&c=2&a=5'
-		return base + '?' + query
-			// [ 'b=1', 'c=2', 'a=5' ]
-			.split( '&' )
-			// [ [ 'b, '1' ], [ 'c', '2' ], [ 'a', '5' ] ]
-			.map( function( entry ) {
-				return entry.split( '=' );
-			} )
-			// [ [ 'a', '5' ], [ 'b, '1' ], [ 'c', '2' ] ]
-			.sort( function( a, b ) {
-				return a[ 0 ].localeCompare( b[ 0 ] );
-			} )
-			// [ 'a=5', 'b=1', 'c=2' ]
-			.map( function( pair ) {
-				return pair.join( '=' );
-			} )
-			// 'a=5&b=1&c=2'
-			.join( '&' );
+/**
+ * Given a path, returns a normalized path where equal query parameter values
+ * will be treated as identical, regardless of order they appear in the original
+ * text.
+ *
+ * @param {string} path Original path.
+ *
+ * @return {string} Normalized path.
+ */
+export function getStablePath( path ) {
+	const splitted = path.split( '?' );
+	const query = splitted[ 1 ];
+	const base = splitted[ 0 ];
+	if ( ! query ) {
+		return base;
 	}
 
-	const { parse = true } = options;
-	if ( typeof options.path === 'string' ) {
-		const method = options.method || 'GET';
-		const path = getStablePath( options.path );
+	// 'b=1&c=2&a=5'
+	return base + '?' + query
+		// [ 'b=1', 'c=2', 'a=5' ]
+		.split( '&' )
+		// [ [ 'b, '1' ], [ 'c', '2' ], [ 'a', '5' ] ]
+		.map( function( entry ) {
+			return entry.split( '=' );
+		} )
+		// [ [ 'a', '5' ], [ 'b, '1' ], [ 'c', '2' ] ]
+		.sort( function( a, b ) {
+			return a[ 0 ].localeCompare( b[ 0 ] );
+		} )
+		// [ 'a=5', 'b=1', 'c=2' ]
+		.map( function( pair ) {
+			return pair.join( '=' );
+		} )
+		// 'a=5&b=1&c=2'
+		.join( '&' );
+}
 
-		if ( parse && 'GET' === method && preloadedData[ path ] ) {
-			return Promise.resolve( preloadedData[ path ].body );
-		} else if (
-			'OPTIONS' === method &&
-			preloadedData[ method ] &&
-			preloadedData[ method ][ path ]
-		) {
-			return Promise.resolve( preloadedData[ method ][ path ] );
+function createPreloadingMiddleware( preloadedData ) {
+	const cache = Object.keys( preloadedData ).reduce( ( result, path ) => {
+		result[ getStablePath( path ) ] = preloadedData[ path ];
+		return result;
+	}, {} );
+
+	return ( options, next ) => {
+		const { parse = true } = options;
+		if ( typeof options.path === 'string' ) {
+			const method = options.method || 'GET';
+			const path = getStablePath( options.path );
+
+			if ( parse && 'GET' === method && cache[ path ] ) {
+				return Promise.resolve( cache[ path ].body );
+			} else if (
+				'OPTIONS' === method &&
+				cache[ method ] &&
+				cache[ method ][ path ]
+			) {
+				return Promise.resolve( cache[ method ][ path ] );
+			}
 		}
-	}
 
-	return next( options );
-};
+		return next( options );
+	};
+}
 
 export default createPreloadingMiddleware;

--- a/packages/api-fetch/src/middlewares/test/preloading.js
+++ b/packages/api-fetch/src/middlewares/test/preloading.js
@@ -13,13 +13,13 @@ describe( 'Preloading Middleware', () => {
 				body,
 			},
 		};
-		const prelooadingMiddleware = createPreloadingMiddleware( preloadedData );
+		const preloadingMiddleware = createPreloadingMiddleware( preloadedData );
 		const requestOptions = {
 			method: 'GET',
 			path: 'wp/v2/posts',
 		};
 
-		const response = prelooadingMiddleware( requestOptions );
+		const response = preloadingMiddleware( requestOptions );
 		return response.then( ( value ) => {
 			expect( value ).toEqual( body );
 		} );

--- a/packages/api-fetch/src/middlewares/test/preloading.js
+++ b/packages/api-fetch/src/middlewares/test/preloading.js
@@ -1,9 +1,32 @@
 /**
  * Internal dependencies
  */
-import createPreloadingMiddleware from '../preloading';
+import createPreloadingMiddleware, { getStablePath } from '../preloading';
 
 describe( 'Preloading Middleware', () => {
+	describe( 'getStablePath', () => {
+		it( 'returns same value if no query parameters', () => {
+			const path = '/foo/bar';
+
+			expect( getStablePath( path ) ).toBe( path );
+		} );
+
+		it( 'returns a stable path', () => {
+			const abc = getStablePath( '/foo/bar?a=5&b=1&c=2' );
+			const bca = getStablePath( '/foo/bar?b=1&c=2&a=5' );
+			const bac = getStablePath( '/foo/bar?b=1&a=5&c=2' );
+			const acb = getStablePath( '/foo/bar?a=5&c=2&b=1' );
+			const cba = getStablePath( '/foo/bar?c=2&b=1&a=5' );
+			const cab = getStablePath( '/foo/bar?c=2&a=5&b=1' );
+
+			expect( abc ).toBe( bca );
+			expect( bca ).toBe( bac );
+			expect( bac ).toBe( acb );
+			expect( acb ).toBe( cba );
+			expect( cba ).toBe( cab );
+		} );
+	} );
+
 	it( 'should return the preloaded data if provided', () => {
 		const body = {
 			status: 'this is the preloaded response',
@@ -23,6 +46,31 @@ describe( 'Preloading Middleware', () => {
 		return response.then( ( value ) => {
 			expect( value ).toEqual( body );
 		} );
+	} );
+
+	it( 'should normalize on stable path', async () => {
+		const body = { content: 'example' };
+		const preloadedData = {
+			'wp/v2/demo-reverse-alphabetical?foo=bar&baz=quux': { body },
+			'wp/v2/demo-alphabetical?baz=quux&foo=bar': { body },
+		};
+		const preloadingMiddleware = createPreloadingMiddleware( preloadedData );
+
+		let requestOptions = {
+			method: 'GET',
+			path: 'wp/v2/demo-reverse-alphabetical?baz=quux&foo=bar',
+		};
+
+		let value = await preloadingMiddleware( requestOptions, () => {} );
+		expect( value ).toEqual( body );
+
+		requestOptions = {
+			method: 'GET',
+			path: 'wp/v2/demo-alphabetical?foo=bar&baz=quux',
+		};
+
+		value = await preloadingMiddleware( requestOptions, () => {} );
+		expect( value ).toEqual( body );
 	} );
 
 	describe.each( [


### PR DESCRIPTION
This pull request seeks to resolve an issue where preloaded data using `createPreloadingMiddleware` makes assumptions about the paths provided in the preloaded data, which if not met, can lead to unintentional cache misses when later API fetches attempt to reference the preloaded data.

**Example:**

```js
createPreloadingMiddleware( {
    'wp/v2/demo?foo=bar&baz=quux': { body: { /* ... */ } }
} );

// ...

apiFetch( 'wp/v2/demo?baz=quux&foo=bar' );
```

Prior to these changes, the `apiFetch` call above would not use the preloaded data.

The preloading middleware internally normalizes paths to reference identical query parameters as the same, regardless of their original order. However, this normalization was not applied to incoming preloaded data. Thus, since the preloaded data above assigns keys in the non-normalized form, they would never be matched.

**Testing Instructions:**

Verify unit tests pass:

```
npm run test-unit packages/api-fetch/src/middlewares/test/preloading.js
```