### PR TITLE
MediaPlaceholder: Add custom action prop

### DIFF
--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -357,6 +357,7 @@ export class MediaPlaceholder extends Component {
 									</IconButton>
 									{ mediaLibraryButton }
 									{ this.renderUrlSelectionUI() }
+									{ this.props.extraActions && this.props.extraActions( this.props ) }
 									{ this.renderCancelLink() }
 								</>
 							);
@@ -386,6 +387,7 @@ export class MediaPlaceholder extends Component {
 					</FormFileUpload>
 					{ mediaLibraryButton }
 					{ this.renderUrlSelectionUI() }
+					{ this.props.extraActions && this.props.extraActions( this.props ) }
 					{ this.renderCancelLink() }
 				</>
 			);

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -663,6 +663,18 @@ export class ImageEdit extends Component {
 			className={ 'edit-image-preview' }
 			src={ url }
 		/> );
+
+		const renderLogoAction = () => {
+			return (
+				<Button
+					isLarge
+					href="https://unsplash.com"
+				>
+					{ __( 'Find an image' ) }
+				</Button>
+			);
+		};
+
 		const mediaPlaceholder = (
 			<MediaPlaceholder
 				icon={ <BlockIcon icon={ icon } /> }
@@ -679,6 +691,7 @@ export class ImageEdit extends Component {
 				value={ { id, src } }
 				mediaPreview={ mediaPreview }
 				disableMediaButtons={ ! isEditing && url }
+				extraActions={ renderLogoAction }
 			/>
 		);
 		if ( isEditing || ! url ) {


### PR DESCRIPTION
This makes it possible to add custom actions (for example buttons) to the `MediaPlaceholder` component.

## Description
There are cases when we might want to extend the options that are available in the media placeholder. This custom prop will allow blocks to extend the `MediaPlaceholder` rather than copy/pasting code.

We can't use a slot/fill in this case because there could be more than one `MediaPlaceholder` on the page at a time.

There is an existing filter for `MediaPlaceholder` but there's no robust way to modify the internals of the component using the filter.

## How has this been tested?
This PR contains a modification to the `Image` block which shows how it could be used and makes it possible to test. Just add an image block to a post and you should see the button:

## Screenshots <!-- if applicable -->
<img width="544" alt="Screenshot 2019-11-25 at 17 12 44" src="https://user-images.githubusercontent.com/275961/69562328-d9b92a00-0fa6-11ea-8859-be25caa1d813.png">

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
