### PR TITLE
chore: Fix: Image overlapping the boundary of the image block

### DIFF
--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -29,7 +29,8 @@
 
 	img {
 		display: block;
-		width: 100%;
+		width: inherit;
+		height: inherit;
 	}
 }
 


### PR DESCRIPTION
## Description
Fix: https://github.com/WordPress/gutenberg/issues/18174



## How has this been tested?
The image resizer applied the dimensions to a div but the image inside was not inheriting the dimensions so in some cases the image may overlap the block boundaries.

## Before
<img width="1000" alt="Untitled 6" src="https://user-images.githubusercontent.com/11271197/69567125-9499f580-0fb0-11ea-8136-22425d701cbc.png">

## After

<img width="1017" alt="Untitled 7" src="https://user-images.githubusercontent.com/11271197/69567138-9bc10380-0fb0-11ea-9887-a506fe57e94a.png">

