### PR TITLE
Fix: Media & Text: "Crop image to fill entire column" reset on image change

### DIFF
--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -80,7 +80,6 @@ class MediaTextEdit extends Component {
 			mediaId: media.id,
 			mediaType,
 			mediaUrl: src || media.url,
-			imageFill: undefined,
 			focalPoint: undefined,
 		} );
 	}


### PR DESCRIPTION
Fix: https://github.com/WordPress/gutenberg/issues/18684

## Description
The image block was resetting the "Crop image to fill entire column" setting when an image was changed.


## How has this been tested?
I added a media and text block.
I enabled "Crop image to fill entire column".
I changed the image.
I verified "Crop image to fill entire column" option was still enabled.

