### PR TITLE
chore: Fix: Disable HTML edit on cover

### DIFF
--- a/packages/block-library/src/cover/index.js
+++ b/packages/block-library/src/cover/index.js
@@ -23,6 +23,7 @@ export const settings = {
 	icon,
 	supports: {
 		align: true,
+		html: false,
 	},
 	example: {
 		attributes: {


### PR DESCRIPTION
## Description
Fix: https://github.com/WordPress/gutenberg/issues/18228

Blocks with InnerBlocks don't support HTML edit, and they crash when we open the block HTML edit functionality. In the other blocks with InnerBlocks we disabled the HTML editor to avoid these crashes, we missed the disable on the cover block.

## How has this been tested?
I added a cover block.
I selected a background color.
I verified the "Edit as HTML" option was not available, on master it is and the block crashes when we go back to the visual edit.