### PR TITLE
Fix: wrong link to attachment page when replacing image.

### DIFF
--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -395,6 +395,12 @@ export class ImageEdit extends Component {
 			mediaAttributes.href = media.url;
 		}
 
+		// Check if the image is linked to the attachment page.
+		if ( linkDestination === LINK_DESTINATION_ATTACHMENT ) {
+			// Update the media link.
+			mediaAttributes.href = media.link;
+		}
+
 		this.props.setAttributes( {
 			...mediaAttributes,
 			...additionalAttributes,


### PR DESCRIPTION
## Description
Related: https://github.com/WordPress/gutenberg/issues/18231

When we replaced the image, we were replacing the media file link, but we were not replacing the link to the attachment page. This caused a bug on images with attachment page link after an image is replaced the link still points to the previous image.

## How has this been tested?
I added an image block.
I went to the link settings I selected the "Attachment Page" link setting.
I replaced the image with a new one from the media gallery.
I opened the link settings. I clicked on "Attachment Page" and verified the link points to the new image, on master, it points to the previous image.