### PR TITLE
Writing Flow: Stretch "Click Redirect" to occupy full height of content

### DIFF
--- a/packages/block-editor/src/components/typewriter/index.js
+++ b/packages/block-editor/src/components/typewriter/index.js
@@ -235,6 +235,7 @@ class Typewriter extends Component {
 				onKeyUp={ this.maintainCaretPosition }
 				onMouseDown={ this.addSelectionChangeListener }
 				onTouchStart={ this.addSelectionChangeListener }
+				className="block-editor__typewriter"
 			>
 				{ this.props.children }
 			</div>

--- a/packages/e2e-test-utils/CHANGELOG.md
+++ b/packages/e2e-test-utils/CHANGELOG.md
@@ -1,8 +1,12 @@
-## master
+## Master
 
 ### Breaking Changes
 
 - The disableNavigationMode utility was removed. By default, the editor is in edit mode now.
+
+### Improvements
+
+- `setBrowserViewport` accepts an object of `width`, `height` values, to assign a viewport of arbitrary size.
 
 ## 3.0.0 (2019-11-14)
 

--- a/packages/e2e-test-utils/README.md
+++ b/packages/e2e-test-utils/README.md
@@ -408,7 +408,7 @@ Sets browser viewport to specified type.
 
 _Parameters_
 
--   _type_ `string`: String to represent dimensions type; can be either small or large.
+-   _viewport_ `WPViewport`: Viewport name or dimensions object to assign.
 
 <a name="setPostContent" href="#setPostContent">#</a> **setPostContent**
 

--- a/packages/e2e-test-utils/src/set-browser-viewport.js
+++ b/packages/e2e-test-utils/src/set-browser-viewport.js
@@ -4,17 +4,49 @@
 import { waitForWindowDimensions } from './wait-for-window-dimensions';
 
 /**
+ * Named viewport options.
+ *
+ * @typedef {"large"|"medium"|"small"} WPDimensionsName
+ */
+
+/**
+ * Viewport dimensions object.
+ *
+ * @typedef {Object} WPViewportDimensions
+ *
+ * @property {number} width  Width, in pixels.
+ * @property {number} height Height, in pixels.
+ */
+
+/**
+ * Predefined viewport dimensions to reference by name.
+ *
+ * @enum {WPViewportDimensions}
+ *
+ * @type {Object<WPDimensionsName,WPViewportDimensions>}
+ */
+const PREDEFINED_DIMENSIONS = {
+	large: { width: 960, height: 700 },
+	medium: { width: 768, height: 700 },
+	small: { width: 600, height: 700 },
+};
+
+/**
+ * Valid argument argument type from which to derive viewport dimensions.
+ *
+ * @typedef {WPDimensionsName|WPViewportDimensions} WPViewport
+ */
+
+/**
  * Sets browser viewport to specified type.
  *
- * @param {string} type String to represent dimensions type; can be either small or large.
+ * @param {WPViewport} viewport Viewport name or dimensions object to assign.
  */
-export async function setBrowserViewport( type ) {
-	const allowedDimensions = {
-		large: { width: 960, height: 700 },
-		medium: { width: 768, height: 700 },
-		small: { width: 600, height: 700 },
-	};
-	const currentDimension = allowedDimensions[ type ];
-	await page.setViewport( currentDimension );
-	await waitForWindowDimensions( currentDimension.width, currentDimension.height );
+export async function setBrowserViewport( viewport ) {
+	const dimensions = typeof viewport === 'string' ?
+		PREDEFINED_DIMENSIONS[ viewport ] :
+		viewport;
+
+	await page.setViewport( dimensions );
+	await waitForWindowDimensions( dimensions.width, dimensions.height );
 }

--- a/packages/e2e-tests/specs/editor/various/adding-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/adding-blocks.test.js
@@ -7,6 +7,7 @@ import {
 	getEditedPostContent,
 	pressKeyTimes,
 	switchEditorModeTo,
+	setBrowserViewport,
 } from '@wordpress/e2e-test-utils';
 
 describe( 'adding blocks', () => {
@@ -21,10 +22,10 @@ describe( 'adding blocks', () => {
 	 *
 	 * @return {Promise} Promise resolving when click occurs.
 	 */
-	async function clickBelow( elementHandle ) {
+	async function clickAtBottom( elementHandle ) {
 		const box = await elementHandle.boundingBox();
 		const x = box.x + ( box.width / 2 );
-		const y = box.y + box.height + 100;
+		const y = box.y + box.height - 50;
 		return page.mouse.click( x, y );
 	}
 
@@ -32,8 +33,13 @@ describe( 'adding blocks', () => {
 		// This ensures the editor is loaded in navigation mode.
 		await page.reload();
 
+		// Set a tall viewport. The typewriter's intrinsic height can be enough
+		// to scroll the page on a shorter viewport, thus obscuring the presence
+		// of any potential buggy behavior with the "stretched" click redirect.
+		await setBrowserViewport( { width: 960, height: 1400 } );
+
 		// Click below editor to focus last field (block appender)
-		await clickBelow( await page.$( '.block-editor-default-block-appender' ) );
+		await clickAtBottom( await page.$( '.edit-post-editor-regions__content' ) );
 		expect( await page.$( '[data-type="core/paragraph"]' ) ).not.toBeNull();
 		await page.keyboard.type( 'Paragraph block' );
 

--- a/packages/edit-post/src/components/editor-regions/style.scss
+++ b/packages/edit-post/src/components/editor-regions/style.scss
@@ -38,6 +38,11 @@
 .edit-post-editor-regions__content {
 	flex-grow: 1;
 
+	// Treat as flex container to allow children to grow to occupy full
+	// available height of the content area.
+	display: flex;
+	flex-direction: column;
+
 	// On Mobile the header is fixed to keep HTML as scrollable.
 	@include break-medium() {
 		overflow: auto;

--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -16,7 +16,6 @@
 	}
 }
 
-.edit-post-visual-editor,
 .edit-post-visual-editor > .block-editor__typewriter,
 .edit-post-visual-editor > .block-editor__typewriter > .block-editor-writing-flow,
 .edit-post-visual-editor > .block-editor__typewriter > .block-editor-writing-flow > .block-editor-writing-flow__click-redirect {

--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -16,9 +16,16 @@
 	}
 }
 
+.edit-post-visual-editor,
+.edit-post-visual-editor > .block-editor__typewriter,
+.edit-post-visual-editor > .block-editor__typewriter > .block-editor-writing-flow,
+.edit-post-visual-editor > .block-editor__typewriter > .block-editor-writing-flow > .block-editor-writing-flow__click-redirect {
+	height: 100%;
+}
+
 .edit-post-visual-editor .block-editor-writing-flow__click-redirect {
 	// Allow the page to be scrolled with the last block in the middle.
-	height: 50vh;
+	min-height: 50vh;
 	width: 100%;
 }
 


### PR DESCRIPTION
This pull request seeks to resolve an issue where the editor canvas is not stretched enough on taller viewports.

Before|After
---|---
![Before](https://user-images.githubusercontent.com/1779930/69573044-57733a80-0f93-11ea-8280-e4ad8b203f1d.png)|![After](https://user-images.githubusercontent.com/1779930/69573015-45919780-0f93-11ea-80f2-196be148de0c.png)

The issue manifests itself in two ways:

- Editor styles do not occupy the full height (see TwentyTwenty background color cuts off about 75% down the page)
- The "Click Redirect" behavior (clicking below the editor to focus or create a last default block) does not work beyond the cut-off

This has caused some trouble for us in the past, typically around the nesting of elements within the `EditPostVisualEditor` component (most recently with typewriter revisions in #16460). I'm open to options for better ways to "stretch" descendents of this component, but as long as there is good test coverage, I'm not overly concerned with the nested selectors for `height: 100%` styling.

There existed tests previously which were meant to protect against regressions here ("clicking below the default block appender"). However, with the intrinsic height of the typewriter click appender, this test was not failing as it should have been. The tests have been updated here to (a) assure there is enough viewport height to allow for this gap to exist and (b) click at the bottom of the editor content area to confirm the expected behavior.

**Testing Instructions:**

Verify that, with a tall viewport, both editor styles and click redirect stretch to the bottom of the content area. You can use [Chrome Responsive Viewport Mode](https://developers.google.com/web/tools/chrome-devtools/device-mode#responsive) if you do not have a tall enough monitor.

Ensure end-to-end tests pass:

```
npm run test-e2e packages/e2e-tests/specs/editor/various/adding-blocks.test.js
```