### PR TITLE
Revert "[Tiny PR] Add updated README files during precommit"

### DIFF
--- a/package.json
+++ b/package.json
@@ -230,8 +230,7 @@
 			"node ./docs/tool/index.js"
 		],
 		"packages/**/*.js": [
-			"node ./bin/update-readmes.js",
-			"git add ."
+			"node ./bin/update-readmes.js"
 		]
 	},
 	"wp-env": {


### PR DESCRIPTION
Reverts WordPress/gutenberg#18657.

I don't know how to fix the problem. It's super annoying that the recommit hook creates changes though.

* Either we should add them to the commit, but only the changes created by the `docgen` command.
* Or we should error when `docgen` changed any files so the changes can be added manually.

@nosolosw, do you have any idea on how to approach this?

In the meantime this PR reverts #18657.
