### PR TITLE
Fix crash on mobile when pasting formatted text.

### DIFF
--- a/packages/blocks/src/api/raw-handling/html-formatting-remover.js
+++ b/packages/blocks/src/api/raw-handling/html-formatting-remover.js
@@ -42,7 +42,7 @@ export default function( node ) {
 	}
 
 	// Ignore pre content.
-	if ( node.parentElement.closest( 'pre' ) ) {
+	if ( node.parentElement.closest && node.parentElement.closest( 'pre' ) ) {
 		return;
 	}
 


### PR DESCRIPTION
## Description
Adding a check for undefined `node.parentElement.closest` which was caught [in this failing test](https://app.circleci.com/jobs/github/wordpress-mobile/gutenberg-mobile/17951/tests) causing a crash on mobile when pasting formatted (bold) text

## How has this been tested?
I tested on gutenberg web, and was not able to reproduce the error that I was seeing on mobile. I tested that the check for `undefined` fixes the pasting of formatted text crash on mobile. 

See Gutenberg mobile PR is now showing a pass on the test for pasting formatted text: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1617

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [X] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
