### PR TITLE
Format library: link: remove aria-label

### DIFF
--- a/packages/e2e-tests/specs/editor/various/__snapshots__/links.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/links.test.js.snap
@@ -20,7 +20,7 @@ exports[`Links can be created by selecting text and using keyboard shortcuts 1`]
 
 exports[`Links can be created by selecting text and using keyboard shortcuts 2`] = `
 "<!-- wp:paragraph -->
-<p>This is <a href=\\"https://wordpress.org/gutenberg\\" target=\\"_blank\\" rel=\\"noreferrer noopener\\" aria-label=\\"Gutenberg (opens in a new tab)\\">Gutenberg</a></p>
+<p>This is <a href=\\"https://wordpress.org/gutenberg\\" target=\\"_blank\\" rel=\\"noreferrer noopener\\">Gutenberg</a></p>
 <!-- /wp:paragraph -->"
 `;
 

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/links.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/links.test.js.snap
@@ -62,7 +62,7 @@ exports[`Links can be removed 1`] = `
 
 exports[`Links should contain a label when it should open in a new tab 1`] = `
 "<!-- wp:paragraph -->
-<p>This is <a href=\\"http://w.org\\" target=\\"_blank\\" rel=\\"noreferrer noopener\\" aria-label=\\"WordPress (opens in a new tab)\\">WordPress</a></p>
+<p>This is <a href=\\"http://w.org\\" target=\\"_blank\\" rel=\\"noreferrer noopener\\">WordPress</a></p>
 <!-- /wp:paragraph -->"
 `;
 

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -10,14 +10,7 @@ import { useMemo, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { withSpokenMessages, Popover } from '@wordpress/components';
 import { prependHTTP } from '@wordpress/url';
-import {
-	create,
-	insert,
-	isCollapsed,
-	applyFormat,
-	getTextContent,
-	slice,
-} from '@wordpress/rich-text';
+import { create, insert, isCollapsed, applyFormat } from '@wordpress/rich-text';
 import { __experimentalLinkControl as LinkControl } from '@wordpress/block-editor';
 
 /**
@@ -120,11 +113,9 @@ function InlineLinkUI( {
 		}
 
 		const newUrl = prependHTTP( nextValue.url );
-		const selectedText = getTextContent( slice( value ) );
 		const format = createLinkFormat( {
 			url: newUrl,
 			opensInNewWindow: nextValue.opensInNewTab,
-			text: selectedText,
 		} );
 
 		if ( isCollapsed( value ) && ! isActive ) {

--- a/packages/format-library/src/link/utils.js
+++ b/packages/format-library/src/link/utils.js
@@ -18,7 +18,6 @@ import {
 	getFragment,
 	isValidFragment,
 } from '@wordpress/url';
-import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Check for issues with the provided href.
@@ -93,7 +92,7 @@ export function isValidHref( href ) {
  *
  * @return {Object} The final format object.
  */
-export function createLinkFormat( { url, opensInNewWindow, text } ) {
+export function createLinkFormat( { url, opensInNewWindow } ) {
 	const format = {
 		type: 'core/link',
 		attributes: {
@@ -102,12 +101,8 @@ export function createLinkFormat( { url, opensInNewWindow, text } ) {
 	};
 
 	if ( opensInNewWindow ) {
-		// translators: accessibility label for external links, where the argument is the link text
-		const label = sprintf( __( '%s (opens in a new tab)' ), text );
-
 		format.attributes.target = '_blank';
 		format.attributes.rel = 'noreferrer noopener';
-		format.attributes[ 'aria-label' ] = label;
 	}
 
 	return format;


### PR DESCRIPTION
## Description

Fixes #12325.

I'm removing the `aria-label` from user created links as the current implementation is broken. The label text can go out of sync, it doesn't apply if you don't select any text, the language may be incorrect, and it doesn't apply consistently for all links in the post content.

The fact that the text may go out of sync is the most serious issue as this enhancement can do more damage than good, incorrectly announcing link content, so I think it's better to remove it until we find a better solution.

Generally, the whole things seems strange to me. This text should be something for the user agent to add, not the content creator. Ideally it shouldn't be inserted in the source at all. It should be added to every web page viewed in the browser. We also can't make it perfect. The user agent will know the language the user has set, which is not necessarily the language of the web page. (I may open a page in a language I don't understand.) The user agent will also know if the link opens in a new tab or window, and adjust the text accordingly.

Safari does this well it seems:

<img width="449" alt="Screenshot 2019-11-26 at 10 06 49" src="https://user-images.githubusercontent.com/4710635/69615480-3b27da00-1035-11ea-8a2b-bdfca4424a76.png">

If browsers are reluctant to fix the issue, a better place to fix the behaviour would be in a browser extension or screen reader software.

If we really, really want to do this, we should append screen reader text in PHP display filters, even though we lack context (browser language and tab/window setting).

The last place it should be added is at link creation with the link UI, if we want to label consistently.

## How has this been tested?

Insert a link that opens in a new window. Make sure the source code doesn't have an `aria-label`.

## Screenshots <!-- if applicable -->

## Types of changes

Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
