### PR TITLE
Writing flow: allow paste on multiple selected blocks

### DIFF
--- a/packages/block-editor/src/components/copy-handler/index.js
+++ b/packages/block-editor/src/components/copy-handler/index.js
@@ -1,14 +1,19 @@
 /**
  * WordPress dependencies
  */
-import { serialize } from '@wordpress/blocks';
+import { serialize, pasteHandler } from '@wordpress/blocks';
 import { documentHasSelection } from '@wordpress/dom';
 import { withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 
-function CopyHandler( { children, onCopy, onCut } ) {
+/**
+ * Internal dependencies
+ */
+import { getPasteEventData } from '../../utils/get-paste-event-data';
+
+function CopyHandler( { children, handler } ) {
 	return (
-		<div onCopy={ onCopy } onCut={ onCut }>
+		<div onCopy={ handler } onCut={ handler } onPaste={ handler }>
 			{ children }
 		</div>
 	);
@@ -20,38 +25,49 @@ export default compose( [
 			getBlocksByClientId,
 			getSelectedBlockClientIds,
 			hasMultiSelection,
+			getSettings,
 		} = select( 'core/block-editor' );
-		const { removeBlocks } = dispatch( 'core/block-editor' );
-
-		const onCopy = ( event ) => {
-			const selectedBlockClientIds = getSelectedBlockClientIds();
-
-			if ( selectedBlockClientIds.length === 0 ) {
-				return;
-			}
-
-			// Let native copy behaviour take over in input fields.
-			if ( ! hasMultiSelection() && documentHasSelection() ) {
-				return;
-			}
-
-			const serialized = serialize( getBlocksByClientId( selectedBlockClientIds ) );
-
-			event.clipboardData.setData( 'text/plain', serialized );
-			event.clipboardData.setData( 'text/html', serialized );
-
-			event.preventDefault();
-		};
+		const { removeBlocks, replaceBlocks } = dispatch( 'core/block-editor' );
+		const {
+			__experimentalCanUserUseUnfilteredHTML: canUserUseUnfilteredHTML,
+		} = getSettings();
 
 		return {
-			onCopy,
-			onCut( event ) {
-				onCopy( event );
+			handler( event ) {
+				const selectedBlockClientIds = getSelectedBlockClientIds();
 
-				if ( hasMultiSelection() ) {
-					const selectedBlockClientIds = getSelectedBlockClientIds();
+				if ( selectedBlockClientIds.length === 0 ) {
+					return;
+				}
 
+				// Always handle multiple selected blocks.
+				// Let native copy behaviour take over in input fields.
+				if ( ! hasMultiSelection() && documentHasSelection() ) {
+					return;
+				}
+
+				event.preventDefault();
+
+				if ( event.type === 'copy' || event.type === 'cut' ) {
+					const blocks = getBlocksByClientId( selectedBlockClientIds );
+					const serialized = serialize( blocks );
+
+					event.clipboardData.setData( 'text/plain', serialized );
+					event.clipboardData.setData( 'text/html', serialized );
+				}
+
+				if ( event.type === 'cut' ) {
 					removeBlocks( selectedBlockClientIds );
+				} else if ( event.type === 'paste' ) {
+					const { plainText, html } = getPasteEventData( event );
+					const blocks = pasteHandler( {
+						HTML: html,
+						plainText,
+						mode: 'BLOCKS',
+						canUserUseUnfilteredHTML,
+					} );
+
+					replaceBlocks( selectedBlockClientIds, blocks );
 				}
 			},
 		};

--- a/packages/block-editor/src/utils/get-paste-event-data.js
+++ b/packages/block-editor/src/utils/get-paste-event-data.js
@@ -1,0 +1,71 @@
+/**
+ * External dependencies
+ */
+import { find, isNil } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { createBlobURL } from '@wordpress/blob';
+
+export function getPasteEventData( { clipboardData } ) {
+	let { items, files } = clipboardData;
+
+	// In Edge these properties can be null instead of undefined, so a more
+	// rigorous test is required over using default values.
+	items = isNil( items ) ? [] : items;
+	files = isNil( files ) ? [] : files;
+
+	let plainText = '';
+	let html = '';
+
+	// IE11 only supports `Text` as an argument for `getData` and will
+	// otherwise throw an invalid argument error, so we try the standard
+	// arguments first, then fallback to `Text` if they fail.
+	try {
+		plainText = clipboardData.getData( 'text/plain' );
+		html = clipboardData.getData( 'text/html' );
+	} catch ( error1 ) {
+		try {
+			html = clipboardData.getData( 'Text' );
+		} catch ( error2 ) {
+			// Some browsers like UC Browser paste plain text by default and
+			// don't support clipboardData at all, so allow default
+			// behaviour.
+			return;
+		}
+	}
+
+	files = Array.from( files );
+
+	Array.from( items ).forEach( ( item ) => {
+		if ( ! item.getAsFile ) {
+			return;
+		}
+
+		const file = item.getAsFile();
+
+		if ( ! file ) {
+			return;
+		}
+
+		const { name, type, size } = file;
+
+		if ( ! find( files, { name, type, size } ) ) {
+			files.push( file );
+		}
+	} );
+
+	files = files.filter( ( { type } ) => /^image\/(?:jpe?g|png|gif)$/.test( type ) );
+
+	// Only process files if no HTML is present.
+	// A pasted file may have the URL as plain text.
+	if ( files.length && ! html ) {
+		html = files
+			.map( ( file ) => `<img src="${ createBlobURL( file ) }">` )
+			.join( '' );
+		plainText = '';
+	}
+
+	return { html, plainText };
+}

--- a/packages/e2e-test-utils/src/press-key-with-modifier.js
+++ b/packages/e2e-test-utils/src/press-key-with-modifier.js
@@ -80,6 +80,35 @@ async function emulateSelectAll() {
 	} );
 }
 
+async function emulateClipboard( type ) {
+	await page.evaluate( ( _type ) => {
+		if ( _type !== 'paste' ) {
+			window._clipboardData = new DataTransfer();
+
+			const selection = window.getSelection();
+			const plainText = selection.toString();
+			let html = plainText;
+
+			if ( selection.rangeCount ) {
+				const range = selection.getRangeAt( 0 );
+				const fragment = range.cloneContents();
+
+				html = Array.from( fragment.childNodes )
+					.map( ( node ) => node.outerHTML || node.nodeValue )
+					.join( '' );
+			}
+
+			window._clipboardData.setData( 'text/plain', plainText );
+			window._clipboardData.setData( 'text/html', html );
+		}
+
+		document.activeElement.dispatchEvent( new ClipboardEvent( _type, {
+			bubbles: true,
+			clipboardData: window._clipboardData,
+		} ) );
+	}, type );
+}
+
 /**
  * Performs a key press with modifier (Shift, Control, Meta, Alt), where each modifier
  * is normalized to platform-specific modifier.
@@ -90,6 +119,18 @@ async function emulateSelectAll() {
 export async function pressKeyWithModifier( modifier, key ) {
 	if ( modifier.toLowerCase() === 'primary' && key.toLowerCase() === 'a' ) {
 		return await emulateSelectAll();
+	}
+
+	if ( modifier.toLowerCase() === 'primary' && key.toLowerCase() === 'c' ) {
+		return await emulateClipboard( 'copy' );
+	}
+
+	if ( modifier.toLowerCase() === 'primary' && key.toLowerCase() === 'x' ) {
+		return await emulateClipboard( 'cut' );
+	}
+
+	if ( modifier.toLowerCase() === 'primary' && key.toLowerCase() === 'v' ) {
+		return await emulateClipboard( 'paste' );
 	}
 
 	const isAppleOS = () => process.platform === 'darwin';

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/multi-block-selection.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/multi-block-selection.test.js.snap
@@ -8,6 +8,40 @@ exports[`Multi-block selection should allow selecting outer edge if there is no 
 
 exports[`Multi-block selection should always expand single line selection 1`] = `""`;
 
+exports[`Multi-block selection should copy and paste 1`] = `
+"<!-- wp:paragraph -->
+<p>1</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>2</p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`Multi-block selection should copy and paste 2`] = `""`;
+
+exports[`Multi-block selection should copy and paste 3`] = `
+"<!-- wp:paragraph -->
+<p>1</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>2</p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`Multi-block selection should cut and paste 1`] = `""`;
+
+exports[`Multi-block selection should cut and paste 2`] = `
+"<!-- wp:paragraph -->
+<p>1</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>2</p>
+<!-- /wp:paragraph -->"
+`;
+
 exports[`Multi-block selection should only trigger multi-selection when at the end 1`] = `
 "<!-- wp:paragraph -->
 <p>1.</p>

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/rich-text.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/rich-text.test.js.snap
@@ -48,6 +48,18 @@ exports[`RichText should not lose selection direction 1`] = `
 <!-- /wp:paragraph -->"
 `;
 
+exports[`RichText should not split rich text on inline paste 1`] = `
+"<!-- wp:paragraph -->
+<p>123</p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`RichText should not split rich text on inline paste with formatting 1`] = `
+"<!-- wp:paragraph -->
+<p>a1<strong>2</strong>3b</p>
+<!-- /wp:paragraph -->"
+`;
+
 exports[`RichText should not undo backtick transform with backspace after selection change 1`] = `""`;
 
 exports[`RichText should not undo backtick transform with backspace after typing 1`] = `""`;
@@ -64,6 +76,24 @@ exports[`RichText should return focus when pressing formatting button 1`] = `
 <!-- /wp:paragraph -->"
 `;
 
+exports[`RichText should split rich text on paste 1`] = `
+"<!-- wp:paragraph -->
+<p>a</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>1</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>2</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>b</p>
+<!-- /wp:paragraph -->"
+`;
+
 exports[`RichText should transform backtick to code 1`] = `
 "<!-- wp:paragraph -->
 <p>A <code>backtick</code></p>
@@ -76,14 +106,14 @@ exports[`RichText should transform backtick to code 2`] = `
 <!-- /wp:paragraph -->"
 `;
 
-exports[`RichText should update internal selection after fresh focus 1`] = `
-"<!-- wp:paragraph -->
-<p>1<strong>2</strong></p>
-<!-- /wp:paragraph -->"
-`;
-
 exports[`RichText should undo backtick transform with backspace 1`] = `
 "<!-- wp:paragraph -->
 <p>\`a\`</p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`RichText should update internal selection after fresh focus 1`] = `
+"<!-- wp:paragraph -->
+<p>1<strong>2</strong></p>
 <!-- /wp:paragraph -->"
 `;

--- a/packages/e2e-tests/specs/editor/various/multi-block-selection.test.js
+++ b/packages/e2e-tests/specs/editor/various/multi-block-selection.test.js
@@ -328,4 +328,40 @@ describe( 'Multi-block selection', () => {
 		await testNativeSelection();
 		expect( await getSelectedFlatIndices() ).toEqual( [ 1, 2 ] );
 	} );
+
+	it( 'should cut and paste', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( '1' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '2' );
+		await pressKeyWithModifier( 'primary', 'a' );
+		await pressKeyWithModifier( 'primary', 'a' );
+		await pressKeyWithModifier( 'primary', 'x' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+
+		await pressKeyWithModifier( 'primary', 'v' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'should copy and paste', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( '1' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '2' );
+		await pressKeyWithModifier( 'primary', 'a' );
+		await pressKeyWithModifier( 'primary', 'a' );
+		await pressKeyWithModifier( 'primary', 'c' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+
+		await page.keyboard.press( 'Backspace' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+
+		await pressKeyWithModifier( 'primary', 'v' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
 } );

--- a/packages/e2e-tests/specs/editor/various/rich-text.test.js
+++ b/packages/e2e-tests/specs/editor/various/rich-text.test.js
@@ -282,4 +282,47 @@ describe( 'RichText', () => {
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
+
+	it( 'should split rich text on paste', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( '1' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '2' );
+		await pressKeyWithModifier( 'primary', 'a' );
+		await pressKeyWithModifier( 'primary', 'a' );
+		await pressKeyWithModifier( 'primary', 'x' );
+		await page.keyboard.type( 'ab' );
+		await page.keyboard.press( 'ArrowLeft' );
+		await pressKeyWithModifier( 'primary', 'v' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'should not split rich text on inline paste', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( '2' );
+		await pressKeyWithModifier( 'primary', 'a' );
+		await pressKeyWithModifier( 'primary', 'x' );
+		await page.keyboard.type( '13' );
+		await page.keyboard.press( 'ArrowLeft' );
+		await pressKeyWithModifier( 'primary', 'v' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'should not split rich text on inline paste with formatting', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( '1' );
+		await pressKeyWithModifier( 'primary', 'b' );
+		await page.keyboard.type( '2' );
+		await pressKeyWithModifier( 'primary', 'b' );
+		await page.keyboard.type( '3' );
+		await pressKeyWithModifier( 'primary', 'a' );
+		await pressKeyWithModifier( 'primary', 'x' );
+		await page.keyboard.type( 'ab' );
+		await page.keyboard.press( 'ArrowLeft' );
+		await pressKeyWithModifier( 'primary', 'v' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
 } );

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -244,7 +244,17 @@ class RichText extends Component {
 	 * @param {ClipboardEvent} event The paste event.
 	 */
 	onPaste( event ) {
-		const { formatTypes, onPaste } = this.props;
+		const {
+			formatTypes,
+			onPaste,
+			__unstableIsSelected: isSelected,
+		} = this.props;
+
+		if ( ! isSelected ) {
+			event.preventDefault();
+			return;
+		}
+
 		const clipboardData = event.clipboardData;
 		let { items, files } = clipboardData;
 


### PR DESCRIPTION
## Description

Fixes #17931.

Currently pasting on multiple selected blocks is buggy. It will leave the selected blocks and split one of them, pasting the content between the split pieces. This is because `RichText` is handling paste. Instead, the block editor should handle paste.

Adds e2e tests. Until now we did not have any e2e test for cut/copy/paste.

## How has this been tested?

Select multiple blocks and paste.
Select a single block without putting focus somewhere and paste.

## Screenshots <!-- if applicable -->

## Types of changes

Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
