### PR TITLE
Fix: Navigation item toolbar buttons unaligned

### DIFF
--- a/packages/components/src/toolbar-button/style.scss
+++ b/packages/components/src/toolbar-button/style.scss
@@ -1,4 +1,7 @@
 .components-toolbar__control.components-button {
+	width: $icon-button-size;
+	height: $icon-button-size;
+
 	// Subscript for numbered icon buttons, like headings
 	&[data-subscript] svg {
 		padding: 5px 10px 5px 0;


### PR DESCRIPTION
## Description
Regressed in https://github.com/WordPress/gutenberg/pull/18631

The PR https://github.com/WordPress/gutenberg/pull/18631 removed some styles that caused a bug on the navigation block toolbar. This PR readds the relevant styles to avoid this bug.

## How has this been tested?
I added a navigation block and I verified the item toolbar looked as expected.

## Screenshots <!-- if applicable -->
After:
![image](https://user-images.githubusercontent.com/11271197/69627441-7da3e380-1042-11ea-98dd-76a564e83508.png)

Before: 
![image](https://user-images.githubusercontent.com/11271197/69627565-cc517d80-1042-11ea-94af-7b7b3dac5c87.png)


