### PR TITLE
Support reduced-motion for Social Links transitions

### DIFF
--- a/packages/block-library/src/social-links/editor.scss
+++ b/packages/block-library/src/social-links/editor.scss
@@ -124,6 +124,7 @@
 // Unconfigured placeholder links are semitransparent.
 .wp-social-link.wp-social-link__is-incomplete {
 	opacity: 0.5;
+	@include reduce-motion("transition");
 }
 
 .wp-block-social-links .is-selected .wp-social-link__is-incomplete,

--- a/packages/block-library/src/social-links/style.scss
+++ b/packages/block-library/src/social-links/style.scss
@@ -22,6 +22,7 @@
 	border-radius: 36px; // This makes it pill-shaped instead of oval, in cases where the image fed is not perfectly sized.
 	margin-right: 8px;
 	transition: transform 0.1s ease;
+	@include reduce-motion("transition");
 
 	a {
 		padding: 6px;


### PR DESCRIPTION
## Description
This PR closes #18749 by adding the [`reduce-motion`](https://github.com/WordPress/gutenberg/blob/995aa3ac442585da716d994dae991d478cd3b97a/packages/base-styles/_mixins.scss#L351) mixin to the social links, adhering to the Ally considerations from the [Animations doc](https://github.com/WordPress/gutenberg/blob/bc8adf7378255c0ed54d72b699c4c74bb2968704/docs/designers-developers/designers/animation.md#accessibility-considerations).

## How has this been tested?
Tested via supported browsers.

## Screenshots <!-- if applicable -->
**Edit:**
![ScreenFlow](https://user-images.githubusercontent.com/1813435/69633577-7d91ec80-101e-11ea-869c-f0a4176de7e9.gif)

**Save:**
![ScreenFlow-save](https://user-images.githubusercontent.com/1813435/69633571-7bc82900-101e-11ea-8d12-5000a8df9471.gif)

## Types of changes
This PR only affects SCSS files, enhancing support for the reduced-motion OS-level setting.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->