### PR TITLE
E2E Tests: Ignore Chrome SameSite cookies warning

### DIFF
--- a/packages/e2e-tests/config/setup-test-framework.js
+++ b/packages/e2e-tests/config/setup-test-framework.js
@@ -117,6 +117,16 @@ function observeConsoleLogging() {
 			return;
 		}
 
+		// A chrome advisory warning about SameSite cookies is informational
+		// about future changes, tracked separately for improvement in core.
+		//
+		// See: https://core.trac.wordpress.org/ticket/37000
+		// See: https://www.chromestatus.com/feature/5088147346030592
+		// See: https://www.chromestatus.com/feature/5633521622188032
+		if ( text.includes( 'A cookie associated with a cross-site resource' ) ) {
+			return;
+		}
+
 		// Viewing posts on the front end can result in this error, which
 		// has nothing to do with Gutenberg.
 		if ( text.includes( 'net::ERR_UNKNOWN_URL_SCHEME' ) ) {


### PR DESCRIPTION
See: https://core.trac.wordpress.org/ticket/37000
See: https://www.chromestatus.com/feature/5088147346030592
See: https://www.chromestatus.com/feature/5633521622188032

This pull request seeks to add an exception to our E2E console log monitoring for Chrome's new console warning about SameSite cookies. This should resolve some instances of intermittent failures in the end-to-end tests.

```
  ● Embedding content › should switch to the WordPress block correctly
    expect(jest.fn()).not.toHaveWarned(expected)
    Expected mock function not to be called but it was called with:
    ["A cookie associated with a cross-site resource at http://localhost/ was set without the `SameSite` attribute. A future release of Chrome will only deliver cookies with cross-site requests if they are set with `SameSite=None` and `Secure`. You can review cookies in developer tools under Application>Storage>Cookies and see more details at https://www.chromestatus.com/feature/5088147346030592 and https://www.chromestatus.com/feature/5633521622188032."]
      at Object.expect (../jest-console/build/@wordpress/jest-console/src/index.js:34:4)
          at runMicrotasks (<anonymous>)
```

**Testing Instructions:**

It would be difficult to test, since the failure only occurs occasionally, and usually during the Travis build. Instead, you could check that adding a `console.warn` anywhere in the editor code run by the end-to-end tests still yields a failure as expected.