### PR TITLE
E2E Tests: Remove unnecessary font warning exception

### DIFF
--- a/packages/e2e-tests/config/setup-test-framework.js
+++ b/packages/e2e-tests/config/setup-test-framework.js
@@ -129,19 +129,6 @@ function observeConsoleLogging() {
 			return;
 		}
 
-		// A bug present in WordPress 5.2 will produce console warnings when
-		// loading the Dashicons font. These can be safely ignored, as they do
-		// not otherwise regress on application behavior. This logic should be
-		// removed once the associated ticket has been closed.
-		//
-		// See: https://core.trac.wordpress.org/ticket/47183
-		if (
-			text.startsWith( 'Failed to decode downloaded font:' ) ||
-			text.startsWith( 'OTS parsing error:' )
-		) {
-			return;
-		}
-
 		const logFunction = OBSERVED_CONSOLE_MESSAGE_TYPES[ type ];
 
 		// As of Puppeteer 1.6.1, `message.text()` wrongly returns an object of


### PR DESCRIPTION
Previously: #15502
See: https://core.trac.wordpress.org/ticket/47183

This pull request seeks to remove an exception added to the E2E test console log monitoring. In the initial release of WordPress 5.2, a warning could occur due to a duplicate `font-face` declaration in the Dashicons stylesheet. This has since been fixed, and was included in the [WordPress 5.2.1 maintenance release](https://wordpress.org/news/2019/05/wordpress-5-2-1-maintenance-release/).

**Testing Instructions:**

The Travis build should not fail.