### PR TITLE
Removes title case from alignments for text and image

### DIFF
--- a/packages/block-editor/src/components/alignment-toolbar/index.js
+++ b/packages/block-editor/src/components/alignment-toolbar/index.js
@@ -12,17 +12,17 @@ import { Toolbar } from '@wordpress/components';
 const DEFAULT_ALIGNMENT_CONTROLS = [
 	{
 		icon: 'editor-alignleft',
-		title: __( 'Align Text Left' ),
+		title: __( 'Align text left' ),
 		align: 'left',
 	},
 	{
 		icon: 'editor-aligncenter',
-		title: __( 'Align Text Center' ),
+		title: __( 'Align text center' ),
 		align: 'center',
 	},
 	{
 		icon: 'editor-alignright',
-		title: __( 'Align Text Right' ),
+		title: __( 'Align text right' ),
 		align: 'right',
 	},
 ];

--- a/packages/block-editor/src/components/alignment-toolbar/test/__snapshots__/index.js.snap
+++ b/packages/block-editor/src/components/alignment-toolbar/test/__snapshots__/index.js.snap
@@ -38,7 +38,7 @@ exports[`AlignmentToolbar should match snapshot 1`] = `
         "isActive": true,
         "onClick": [Function],
         "role": "menuitemradio",
-        "title": "Align Text Left",
+        "title": "Align text left",
       },
       Object {
         "align": "center",
@@ -46,7 +46,7 @@ exports[`AlignmentToolbar should match snapshot 1`] = `
         "isActive": false,
         "onClick": [Function],
         "role": "menuitemradio",
-        "title": "Align Text Center",
+        "title": "Align text center",
       },
       Object {
         "align": "right",
@@ -54,7 +54,7 @@ exports[`AlignmentToolbar should match snapshot 1`] = `
         "isActive": false,
         "onClick": [Function],
         "role": "menuitemradio",
-        "title": "Align Text Right",
+        "title": "Align text right",
       },
     ]
   }

--- a/packages/block-editor/src/components/block-alignment-toolbar/index.js
+++ b/packages/block-editor/src/components/block-alignment-toolbar/index.js
@@ -14,23 +14,23 @@ import { withBlockEditContext } from '../block-edit/context';
 const BLOCK_ALIGNMENTS_CONTROLS = {
 	left: {
 		icon: 'align-left',
-		title: __( 'Align Left' ),
+		title: __( 'Align left' ),
 	},
 	center: {
 		icon: 'align-center',
-		title: __( 'Align Center' ),
+		title: __( 'Align center' ),
 	},
 	right: {
 		icon: 'align-right',
-		title: __( 'Align Right' ),
+		title: __( 'Align right' ),
 	},
 	wide: {
 		icon: 'align-wide',
-		title: __( 'Wide Width' ),
+		title: __( 'Wide width' ),
 	},
 	full: {
 		icon: 'align-full-width',
-		title: __( 'Full Width' ),
+		title: __( 'Full width' ),
 	},
 };
 

--- a/packages/block-editor/src/components/block-alignment-toolbar/test/__snapshots__/index.js.snap
+++ b/packages/block-editor/src/components/block-alignment-toolbar/test/__snapshots__/index.js.snap
@@ -9,21 +9,21 @@ exports[`BlockAlignmentToolbar should match snapshot 1`] = `
         "isActive": true,
         "onClick": [Function],
         "role": "menuitemradio",
-        "title": "Align Left",
+        "title": "Align left",
       },
       Object {
         "icon": "align-center",
         "isActive": false,
         "onClick": [Function],
         "role": "menuitemradio",
-        "title": "Align Center",
+        "title": "Align center",
       },
       Object {
         "icon": "align-right",
         "isActive": false,
         "onClick": [Function],
         "role": "menuitemradio",
-        "title": "Align Right",
+        "title": "Align right",
       },
     ]
   }

--- a/packages/e2e-tests/specs/editor/plugins/align-hook.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/align-hook.test.js
@@ -166,8 +166,8 @@ describe( 'Align Hook Works As Expected', () => {
 		const BLOCK_NAME = 'Test Align Array';
 
 		createShowsTheExpectedButtonsTest( BLOCK_NAME, [
-			'Align Left',
-			'Align Center',
+			'Align left',
+			'Align center',
 		] );
 
 		createDoesNotApplyAlignmentByDefaultTest( BLOCK_NAME );
@@ -179,11 +179,11 @@ describe( 'Align Hook Works As Expected', () => {
 		const BLOCK_NAME = 'Test Default Align';
 		const SELECTED_ALIGNMENT_CONTROL_SELECTOR = '//div[contains(@class, "components-dropdown-menu__menu")]//button[contains(@class, "is-active")][text()="Align Right"]';
 		createShowsTheExpectedButtonsTest( BLOCK_NAME, [
-			'Align Left',
-			'Align Center',
-			'Align Right',
-			'Wide Width',
-			'Full Width',
+			'Align left',
+			'Align center',
+			'Align right',
+			'Wide width',
+			'Full width',
 		] );
 
 		it( 'Applies the selected alignment by default', async () => {

--- a/packages/e2e-tests/specs/editor/plugins/align-hook.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/align-hook.test.js
@@ -150,11 +150,11 @@ describe( 'Align Hook Works As Expected', () => {
 		const BLOCK_NAME = 'Test Align True';
 
 		createShowsTheExpectedButtonsTest( BLOCK_NAME, [
-			'Align Left',
-			'Align Center',
-			'Align Right',
-			'Wide Width',
-			'Full Width',
+			'Align left',
+			'Align center',
+			'Align right',
+			'Wide width',
+			'Full width',
 		] );
 
 		createDoesNotApplyAlignmentByDefaultTest( BLOCK_NAME );

--- a/packages/e2e-tests/specs/editor/plugins/align-hook.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/align-hook.test.js
@@ -177,7 +177,7 @@ describe( 'Align Hook Works As Expected', () => {
 
 	describe( 'Block with default align', () => {
 		const BLOCK_NAME = 'Test Default Align';
-		const SELECTED_ALIGNMENT_CONTROL_SELECTOR = '//div[contains(@class, "components-dropdown-menu__menu")]//button[contains(@class, "is-active")][text()="Align Right"]';
+		const SELECTED_ALIGNMENT_CONTROL_SELECTOR = '//div[contains(@class, "components-dropdown-menu__menu")]//button[contains(@class, "is-active")][text()="Align right"]';
 		createShowsTheExpectedButtonsTest( BLOCK_NAME, [
 			'Align left',
 			'Align center',


### PR DESCRIPTION
In response to #16764 this brings these back to sentence case.