### PR TITLE
RNMobile: Remove unneeded/duplicate css

### DIFF
--- a/packages/block-editor/src/components/block-list/block-mobile-floating-toolbar.native.scss
+++ b/packages/block-editor/src/components/block-list/block-mobile-floating-toolbar.native.scss
@@ -1,3 +1,5 @@
+$floating-toolbar-height: 44;
+
 .floatingToolbar {
 	background-color: $dark-gray-500;
 	margin: auto;

--- a/packages/block-library/src/gallery/gallery-image-style.native.scss
+++ b/packages/block-library/src/gallery/gallery-image-style.native.scss
@@ -121,7 +121,6 @@ $get-caption-background-color: rgba(0, 0, 0, 0.4);
 	background-color: #0000;
 	color: #fff;
 	font-family: $default-regular-font;
-	min-height: $min-height-paragraph;
 	text-align: center;
 }
 

--- a/packages/block-library/src/heading/edit.native.js
+++ b/packages/block-library/src/heading/edit.native.js
@@ -2,7 +2,6 @@
  * Internal dependencies
  */
 import HeadingToolbar from './heading-toolbar';
-import styles from './editor.scss';
 
 /**
  * External dependencies
@@ -38,10 +37,7 @@ const HeadingEdit = ( {
 			identifier="content"
 			tagName={ 'h' + attributes.level }
 			value={ attributes.content }
-			style={ {
-				...style,
-				minHeight: styles[ 'wp-block-heading' ].minHeight,
-			} }
+			style={ style }
 			onChange={ ( value ) => setAttributes( { content: value } ) }
 			onMerge={ mergeBlocks }
 			onSplit={ ( value ) => {

--- a/packages/block-library/src/heading/editor.native.scss
+++ b/packages/block-library/src/heading/editor.native.scss
@@ -1,4 +1,0 @@
-
-.wp-block-heading {
-	min-height: $min-height-heading;
-}

--- a/packages/block-library/src/heading/style.native.scss
+++ b/packages/block-library/src/heading/style.native.scss
@@ -1,4 +1,0 @@
-
-.blockText {
-	min-height: $min-height-heading;
-}

--- a/packages/block-library/src/paragraph/style.native.scss
+++ b/packages/block-library/src/paragraph/style.native.scss
@@ -1,4 +1,0 @@
-
-.blockText {
-	min-height: $min-height-paragraph;
-}

--- a/packages/editor/src/components/post-title/style.native.scss
+++ b/packages/editor/src/components/post-title/style.native.scss
@@ -2,8 +2,8 @@
 .titleContainer {
 	padding-left: 16;
 	padding-right: 16;
-	padding-top: $title-block-padding-top;
-	padding-bottom: $title-block-padding-bottom;
+	padding-top: 12;
+	padding-bottom: 12;
 	margin-top: 24;
 }
 

--- a/packages/rich-text/src/component/index.native.js
+++ b/packages/rich-text/src/component/index.native.js
@@ -662,11 +662,6 @@ export class RichText extends Component {
 		const record = this.getRecord();
 		const html = this.getHtmlToRender( record, tagName );
 
-		let minHeight = styles.richText.minHeight;
-		if ( style && style.minHeight ) {
-			minHeight = style.minHeight;
-		}
-
 		const placeholderStyle = getStylesFromColorScheme( styles.richTextPlaceholder, styles.richTextPlaceholderDark );
 
 		const {
@@ -742,7 +737,7 @@ export class RichText extends Component {
 					} }
 					style={ {
 						...style,
-						minHeight: Math.max( minHeight, this.state.height ),
+						minHeight: this.state.height,
 					} }
 					text={ { text: html, eventCount: this.lastEventCount, selection } }
 					placeholder={ this.props.placeholder }

--- a/packages/rich-text/src/component/style.native.scss
+++ b/packages/rich-text/src/component/style.native.scss
@@ -1,7 +1,6 @@
 
 .richText {
 	font-family: $default-regular-font;
-	min-height: $min-height-paragraph;
 	color: $gray-900;
 	text-decoration-color: $blue-500;
 }


### PR DESCRIPTION
## Description
This is some css cleanup that was included as a part of the fix for https://github.com/wordpress-mobile/gutenberg-mobile/issues/992 in https://github.com/wordpress-mobile/gutenberg-mobile/pull/1560/files.

## How has this been tested?

Inusure that the following components display properly with no excess padding:
* post-title
* heading
* paragraph
* floating-toolbar

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [X] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
