### PR TITLE
Site Title: Add a view mode for non-admins

### DIFF
--- a/packages/block-library/src/site-title/edit.js
+++ b/packages/block-library/src/site-title/edit.js
@@ -22,6 +22,8 @@ export function SiteTitleEdit( { isSelected } ) {
 		'title'
 	);
 
+	const [ viewTitle ] = useEntityProp( 'root', 'base', 'name' );
+
 	const editMode = (
 		<>
 			<Button
@@ -44,7 +46,7 @@ export function SiteTitleEdit( { isSelected } ) {
 	);
 
 	const viewMode = (
-		<h1>{ title }</h1>
+		<h1>{ title ? title : viewTitle }</h1>
 	);
 
 	return ( canUpdate && isSelected ) ? editMode : viewMode;

--- a/packages/block-library/src/site-title/edit.js
+++ b/packages/block-library/src/site-title/edit.js
@@ -11,7 +11,7 @@ import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { RichText } from '@wordpress/block-editor';
 
-export function SiteTitleEdit( props ) {
+export function SiteTitleEdit( { canUpdate, isSelected } ) {
 	const [ title, setTitle ] = useEntityProp( 'root', 'site', 'title' );
 	const [ isDirty, isSaving, save ] = __experimentalUseEntitySaving(
 		'root',
@@ -44,7 +44,7 @@ export function SiteTitleEdit( props ) {
 		<h1>{ title }</h1>
 	);
 
-	return ( props.canUpdate && props.isSelected ) ? editMode : viewMode;
+	return ( canUpdate && isSelected ) ? editMode : viewMode;
 }
 
 export default compose( [

--- a/packages/block-library/src/site-title/edit.js
+++ b/packages/block-library/src/site-title/edit.js
@@ -1,6 +1,8 @@
 /**
  * WordPress dependencies
  */
+import { compose } from '@wordpress/compose';
+import { withSelect } from '@wordpress/data';
 import {
 	useEntityProp,
 	__experimentalUseEntitySaving,
@@ -9,14 +11,15 @@ import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { RichText } from '@wordpress/block-editor';
 
-export default function SiteTitleEdit() {
+export function SiteTitleEdit( props ) {
 	const [ title, setTitle ] = useEntityProp( 'root', 'site', 'title' );
 	const [ isDirty, isSaving, save ] = __experimentalUseEntitySaving(
 		'root',
 		'site',
 		'title'
 	);
-	return (
+
+	const editMode = (
 		<>
 			<Button
 				isPrimary
@@ -36,4 +39,19 @@ export default function SiteTitleEdit() {
 			/>
 		</>
 	);
+
+	const viewMode = (
+		<h1>{ title }</h1>
+	);
+
+	return ( props.canUpdate && props.isSelected ) ? editMode : viewMode;
 }
+
+export default compose( [
+	withSelect( ( select, {} ) => {
+		const { canUser } = select( 'core' );
+		return {
+			canUpdate: canUser( 'update', 'settings' ),
+		};
+	} ),
+] )( SiteTitleEdit );

--- a/packages/block-library/src/site-title/edit.js
+++ b/packages/block-library/src/site-title/edit.js
@@ -1,8 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { compose } from '@wordpress/compose';
-import { withSelect } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import {
 	useEntityProp,
 	__experimentalUseEntitySaving,
@@ -11,7 +10,11 @@ import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { RichText } from '@wordpress/block-editor';
 
-export function SiteTitleEdit( { canUpdate, isSelected } ) {
+export function SiteTitleEdit( { isSelected } ) {
+	const canUpdate = useSelect( ( select ) => {
+		return select( 'core' ).canUser( 'update', 'settings' );
+	} );
+
 	const [ title, setTitle ] = useEntityProp( 'root', 'site', 'title' );
 	const [ isDirty, isSaving, save ] = __experimentalUseEntitySaving(
 		'root',
@@ -47,11 +50,4 @@ export function SiteTitleEdit( { canUpdate, isSelected } ) {
 	return ( canUpdate && isSelected ) ? editMode : viewMode;
 }
 
-export default compose( [
-	withSelect( ( select, {} ) => {
-		const { canUser } = select( 'core' );
-		return {
-			canUpdate: canUser( 'update', 'settings' ),
-		};
-	} ),
-] )( SiteTitleEdit );
+export default SiteTitleEdit;

--- a/packages/block-library/src/site-title/edit.js
+++ b/packages/block-library/src/site-title/edit.js
@@ -10,7 +10,7 @@ import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { RichText } from '@wordpress/block-editor';
 
-export function SiteTitleEdit( { isSelected } ) {
+export function SiteTitleEdit( { isSelected, className } ) {
 	const canUpdate = useSelect( ( select ) => {
 		return select( 'core' ).canUser( 'update', 'settings' );
 	} );
@@ -49,7 +49,11 @@ export function SiteTitleEdit( { isSelected } ) {
 		<h1>{ title ? title : viewTitle }</h1>
 	);
 
-	return ( canUpdate && isSelected ) ? editMode : viewMode;
+	return (
+		<div className={ className }>
+			{ ( canUpdate && isSelected ) ? editMode : viewMode }
+		</div>
+	);
 }
 
 export default SiteTitleEdit;

--- a/packages/block-library/src/site-title/editor.scss
+++ b/packages/block-library/src/site-title/editor.scss
@@ -1,3 +1,7 @@
+.wp-block-site-title {
+	cursor: not-allowed;
+}
+
 .wp-block-site-title__save-button {
 	position: absolute;
 	right: 0;

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -12,6 +12,7 @@ import { apiFetch, select } from './controls';
 export const DEFAULT_ENTITY_KEY = 'id';
 
 export const defaultEntities = [
+	{ name: 'base', kind: 'root', baseURL: '/' },
 	{ name: 'site', kind: 'root', baseURL: '/wp/v2/settings' },
 	{ name: 'postType', kind: 'root', key: 'slug', baseURL: '/wp/v2/types' },
 	{ name: 'media', kind: 'root', baseURL: '/wp/v2/media', plural: 'mediaItems' },


### PR DESCRIPTION
## Description
This updates the Site Title block to account for non-admins.

It's possible that this block could be added to a post that anyone has access to. Only admins should be able to edit the content, but all users should be able to see this block so that they have an accurate preview.

## How has this been tested?
Create a 'non-admin' account on your WordPress site. Add the Site Title block to a post. You should be able to see the site title, but not edit it:

## Screenshots
Admin (unchanged)
<img width="736" alt="Screenshot 2019-11-26 at 17 08 55" src="https://user-images.githubusercontent.com/275961/69655936-83fc8480-106f-11ea-9413-cfd0a7bceb18.png">

Non-admin
<img width="717" alt="Screenshot 2019-11-26 at 17 08 47" src="https://user-images.githubusercontent.com/275961/69655938-83fc8480-106f-11ea-8639-e9122a0bbf9f.png">

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
