### PR TITLE
E2E Tests: Fix theme colors and font sizes.

### DIFF
--- a/packages/e2e-tests/mu-plugins/normalize-theme.php
+++ b/packages/e2e-tests/mu-plugins/normalize-theme.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Plugin Name: Gutenberg Test Plugin, Normalize Theme
+ * Plugin URI: https://github.com/WordPress/gutenberg
+ * Author: Gutenberg Team
+ *
+ * @package gutenberg-test-normalize-theme
+ */
+
+/**
+ * Fixes colors and font sizes so that tests
+ * are consistent across different themes.
+ */
+function normalize_theme_init() {
+	add_theme_support(
+		'editor-color-palette',
+		array(
+			array(
+				'name'  => __( 'Accent Color', 'gutenberg' ),
+				'slug'  => 'accent',
+				'color' => '#cd2653',
+			),
+			array(
+				'name'  => __( 'Primary', 'gutenberg' ),
+				'slug'  => 'primary',
+				'color' => '#0073a8',
+			),
+			array(
+				'name'  => __( 'Secondary', 'gutenberg' ),
+				'slug'  => 'secondary',
+				'color' => '#005075',
+			),
+			array(
+				'name'  => __( 'Subtle Background', 'gutenberg' ),
+				'slug'  => 'subtle-background',
+				'color' => '#dcd7ca',
+			),
+			array(
+				'name'  => __( 'Background Color', 'gutenberg' ),
+				'slug'  => 'background',
+				'color' => '#' . 'f5efe0',
+			),
+		)
+	);
+
+	add_theme_support(
+		'editor-font-sizes',
+		array(
+			array(
+				'name'      => _x( 'Small', 'Name of the small font size in the block editor', 'gutenberg' ),
+				'shortName' => _x( 'S', 'Short name of the small font size in the block editor.', 'gutenberg' ),
+				'size'      => 18,
+				'slug'      => 'small',
+			),
+			array(
+				'name'      => _x( 'Regular', 'Name of the regular font size in the block editor', 'gutenberg' ),
+				'shortName' => _x( 'M', 'Short name of the regular font size in the block editor.', 'gutenberg' ),
+				'size'      => 21,
+				'slug'      => 'normal',
+			),
+			array(
+				'name'      => _x( 'Large', 'Name of the large font size in the block editor', 'gutenberg' ),
+				'shortName' => _x( 'L', 'Short name of the large font size in the block editor.', 'gutenberg' ),
+				'size'      => 26.25,
+				'slug'      => 'large',
+			),
+			array(
+				'name'      => _x( 'Larger', 'Name of the larger font size in the block editor', 'gutenberg' ),
+				'shortName' => _x( 'XL', 'Short name of the larger font size in the block editor.', 'gutenberg' ),
+				'size'      => 32,
+				'slug'      => 'larger',
+			),
+		)
+	);
+}
+add_action( 'init', 'normalize_theme_init' );

--- a/packages/e2e-tests/mu-plugins/normalize-theme.php
+++ b/packages/e2e-tests/mu-plugins/normalize-theme.php
@@ -12,65 +12,7 @@
  * are consistent across different themes.
  */
 function normalize_theme_init() {
-	add_theme_support(
-		'editor-color-palette',
-		array(
-			array(
-				'name'  => __( 'Accent Color', 'gutenberg' ),
-				'slug'  => 'accent',
-				'color' => '#cd2653',
-			),
-			array(
-				'name'  => __( 'Primary', 'gutenberg' ),
-				'slug'  => 'primary',
-				'color' => '#0073a8',
-			),
-			array(
-				'name'  => __( 'Secondary', 'gutenberg' ),
-				'slug'  => 'secondary',
-				'color' => '#005075',
-			),
-			array(
-				'name'  => __( 'Subtle Background', 'gutenberg' ),
-				'slug'  => 'subtle-background',
-				'color' => '#dcd7ca',
-			),
-			array(
-				'name'  => __( 'Background Color', 'gutenberg' ),
-				'slug'  => 'background',
-				'color' => '#' . 'f5efe0',
-			),
-		)
-	);
-
-	add_theme_support(
-		'editor-font-sizes',
-		array(
-			array(
-				'name'      => _x( 'Small', 'Name of the small font size in the block editor', 'gutenberg' ),
-				'shortName' => _x( 'S', 'Short name of the small font size in the block editor.', 'gutenberg' ),
-				'size'      => 18,
-				'slug'      => 'small',
-			),
-			array(
-				'name'      => _x( 'Regular', 'Name of the regular font size in the block editor', 'gutenberg' ),
-				'shortName' => _x( 'M', 'Short name of the regular font size in the block editor.', 'gutenberg' ),
-				'size'      => 21,
-				'slug'      => 'normal',
-			),
-			array(
-				'name'      => _x( 'Large', 'Name of the large font size in the block editor', 'gutenberg' ),
-				'shortName' => _x( 'L', 'Short name of the large font size in the block editor.', 'gutenberg' ),
-				'size'      => 26.25,
-				'slug'      => 'large',
-			),
-			array(
-				'name'      => _x( 'Larger', 'Name of the larger font size in the block editor', 'gutenberg' ),
-				'shortName' => _x( 'XL', 'Short name of the larger font size in the block editor.', 'gutenberg' ),
-				'size'      => 32,
-				'slug'      => 'larger',
-			),
-		)
-	);
+	remove_theme_support( 'editor-color-palette' );
+	remove_theme_support( 'editor-font-sizes' );
 }
 add_action( 'init', 'normalize_theme_init' );

--- a/packages/e2e-tests/specs/editor/blocks/__snapshots__/heading.test.js.snap
+++ b/packages/e2e-tests/specs/editor/blocks/__snapshots__/heading.test.js.snap
@@ -19,8 +19,8 @@ exports[`Heading it should correctly apply custom colors 1`] = `
 `;
 
 exports[`Heading it should correctly apply named colors 1`] = `
-"<!-- wp:heading {\\"textColor\\":\\"accent\\"} -->
-<h2 class=\\"has-accent-color has-text-color\\">Heading</h2>
+"<!-- wp:heading {\\"textColor\\":\\"very-dark-gray\\"} -->
+<h2 class=\\"has-very-dark-gray-color has-text-color\\">Heading</h2>
 <!-- /wp:heading -->"
 `;
 

--- a/packages/e2e-tests/specs/editor/blocks/heading.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/heading.test.js
@@ -77,11 +77,11 @@ describe( 'Heading', () => {
 		const [ colorPanelToggle ] = await page.$x( COLOR_PANEL_TOGGLE_X_SELECTOR );
 		await colorPanelToggle.click();
 
-		const accentColorButtonSelector = `${ TEXT_COLOR_UI_X_SELECTOR }//button[@aria-label='Color: Accent Color']`;
-		const [ accentColorButton ] = await page.$x( accentColorButtonSelector );
-		await accentColorButton.click();
+		const colorButtonSelector = `${ TEXT_COLOR_UI_X_SELECTOR }//button[@aria-label='Color: Very dark gray']`;
+		const [ colorButton ] = await page.$x( colorButtonSelector );
+		await colorButton.click();
 		await page.click( '[data-type="core/heading"] h2' );
-		await page.waitForXPath( `${ accentColorButtonSelector }[@aria-pressed='true']` );
+		await page.waitForXPath( `${ colorButtonSelector }[@aria-pressed='true']` );
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 } );

--- a/packages/e2e-tests/specs/editor/various/editor-modes.test.js
+++ b/packages/e2e-tests/specs/editor/various/editor-modes.test.js
@@ -79,7 +79,7 @@ describe( 'Editing modes (visual/HTML)', () => {
 
 		// Change the font size using the sidebar.
 		await page.click( '.components-font-size-picker__select' );
-		await page.click( '.components-custom-select__item:nth-child(3)' );
+		await page.click( '.components-custom-select__item:nth-child(4)' );
 
 		// Make sure the HTML content updated.
 		htmlBlockContent = await page.$eval( '.block-editor-block-list__layout .block-editor-block-list__block .block-editor-block-list__block-html-textarea', ( node ) => node.textContent );

--- a/packages/e2e-tests/specs/editor/various/font-size-picker.test.js
+++ b/packages/e2e-tests/specs/editor/various/font-size-picker.test.js
@@ -18,7 +18,7 @@ describe( 'Font Size Picker', () => {
 		await clickBlockAppender();
 		await page.keyboard.type( 'Paragraph to be made "large"' );
 		await page.click( '.components-font-size-picker__select' );
-		await page.click( '.components-custom-select__item:nth-child(3)' );
+		await page.click( '.components-custom-select__item:nth-child(4)' );
 
 		// Ensure content matches snapshot.
 		const content = await getEditedPostContent();
@@ -31,8 +31,8 @@ describe( 'Font Size Picker', () => {
 		await page.keyboard.type( 'Paragraph to be made "small"' );
 
 		await page.click( '.blocks-font-size .components-range-control__number' );
-		// This should be the "small" font-size of the current theme.
-		await page.keyboard.type( '18' );
+		// This should be the "small" font-size of the editor defaults.
+		await page.keyboard.type( '13' );
 
 		// Ensure content matches snapshot.
 		const content = await getEditedPostContent();


### PR DESCRIPTION
## Description

This PR takes an alternative approach to #18699, in improving the developer experience of E2E tests.

Instead of allowing tests to specify a required active theme, this PR seeks to normalize themes so that tests are mostly theme agnostic.

The first logical step for this was fixing editor colors and font sizes.

## How has this been tested?

It was verified that tests that were failing in twentynineteen now pass.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
