### PR TITLE
Fix: Focal points are not rounded

### DIFF
--- a/packages/components/src/focal-point-picker/index.js
+++ b/packages/components/src/focal-point-picker/index.js
@@ -102,8 +102,8 @@ export class FocalPointPicker extends Component {
 				)
 			);
 			const percentages = {
-				x: ( left - bounds.left ) / ( pickerDimensions.width - ( bounds.left * 2 ) ),
-				y: ( top - bounds.top ) / ( pickerDimensions.height - ( bounds.top * 2 ) ),
+				x: ( ( left - bounds.left ) / ( pickerDimensions.width - ( bounds.left * 2 ) ) ).toFixed( 2 ),
+				y: ( ( top - bounds.top ) / ( pickerDimensions.height - ( bounds.top * 2 ) ) ).toFixed( 2 ),
 			};
 			this.setState( { percentages }, function() {
 				onChange( {
@@ -126,7 +126,7 @@ export class FocalPointPicker extends Component {
 		const { onChange } = this.props;
 		const { percentages } = this.state;
 		const cleanValue = Math.max( Math.min( parseInt( value ), 100 ), 0 );
-		percentages[ axis ] = cleanValue ? cleanValue / 100 : 0;
+		percentages[ axis ] = ( cleanValue ? cleanValue / 100 : 0 ).toFixed( 2 );
 		this.setState( { percentages }, function() {
 			onChange( {
 				x: this.state.percentages.x,


### PR DESCRIPTION
## Description
Fixes: https://github.com/WordPress/gutenberg/issues/18665

Currently, the focal point is not rounded. That makes the cover block markup contain attributes and styles with many decimal places.
That precision is not required and rounding to two decimal places makes the markup cleaner and reduces some bytes on each cover block created.

## How has this been tested?
I added a cover block with an image background.
I used the focal point picker and changed it using the mouse.
I switched to code editor mode, and verified the attributes and markup contained only two decimal places.