### PR TITLE
Updated getting-started.md

### DIFF
--- a/docs/contributors/getting-started.md
+++ b/docs/contributors/getting-started.md
@@ -4,7 +4,7 @@ Gutenberg is a Node.js-based project, built primarily in JavaScript.
 
 The first step is to install a recent version of Node. The easiest way (on MacOS, Linux, or Windows 10 with the Linux Subsystem) is by installing and running [nvm]. Once `nvm` is installed, you can install the correct version of Node by running `nvm install` in the Gutenberg directory.
 
-Once you have Node installed, run these scripts from within your local gutenberg repository:
+Once you have Node installed, run these scripts from within your local Gutenberg repository:
 
 Note: The install scripts require [Python](https://www.python.org/) to be installed and in the path of the local system.
 
@@ -17,7 +17,7 @@ This will build Gutenberg, ready to be used as a WordPress plugin!
 
 If you don't have a local WordPress environment to load Gutenberg in, we can help get that up and running, too.
 
-## Local Environment 
+## Local Environment
 
 ### Step 1: Installing a Local Environment
 #### Quickest Method: Using Docker
@@ -54,7 +54,7 @@ Whether you decided to use Docker or an existing local WordPress install, the Wo
 If this port is in use, you can override it using the `LOCAL_PORT` environment variable. For example running the below command on your computer will change the URL to
 `http://localhost:7777` .
 
-Linux/MacOS: `export LOCAL_PORT=7777`
+Linux/macOS: `export LOCAL_PORT=7777`
 Windows using Command Prompt: `setx LOCAL_PORT "7777"`
 Windows using PowerShell: `$env:LOCAL_PORT = "7777"`
 

--- a/docs/contributors/getting-started.md
+++ b/docs/contributors/getting-started.md
@@ -4,7 +4,7 @@ Gutenberg is a Node.js-based project, built primarily in JavaScript.
 
 The first step is to install a recent version of Node. The easiest way (on MacOS, Linux, or Windows 10 with the Linux Subsystem) is by installing and running [nvm]. Once `nvm` is installed, you can install the correct version of Node by running `nvm install` in the Gutenberg directory.
 
-Once you have Node installed, run these scripts:
+Once you have Node installed, run these scripts from within your local gutenberg repository:
 
 Note: The install scripts require [Python](https://www.python.org/) to be installed and in the path of the local system.
 
@@ -17,9 +17,10 @@ This will build Gutenberg, ready to be used as a WordPress plugin!
 
 If you don't have a local WordPress environment to load Gutenberg in, we can help get that up and running, too.
 
-## Local Environment
+## Local Environment 
 
-### Using Docker
+### Step 1: Installing a Local Environment
+#### Quickest Method: Using Docker
 
 The quickest way to get up and running is to use the provided Docker setup. If you don't already have it, you'll need to install Docker by following their instructions for [Windows 10 Pro](https://docs.docker.com/docker-for-windows/install/), [all other version of Windows](https://docs.docker.com/toolbox/toolbox_install_windows/), [macOS](https://docs.docker.com/docker-for-mac/install/), or [Linux](https://docs.docker.com/v17.12/install/linux/docker-ce/ubuntu/#install-using-the-convenience-script).
 
@@ -29,7 +30,7 @@ Once Docker is installed and running, run this script to install WordPress, and 
 npm run env install
 ```
 
-### Using an Existing Local WordPress Install
+#### Alternative Method: Using an Existing Local WordPress Install
 WordPress will be installed in the `wordpress` directory, if you need to access WordPress core files directly, you can find them there.
 
 If you already have WordPress checked out in a different directory, you can use that installation, instead, by running these commands:
@@ -46,22 +47,32 @@ In Windows, you can set the `WP_DEVELOP_DIR` environment variable using the appr
     CMD: set WP_DEVELOP_DIR=/path/to/wordpress-develop
     PowerShell: $env:WP_DEVELOP_DIR = "/path/to/wordpress-develop"
 	
-### Access the Local WordPress Install
+### Step 2: Accessing and Configuring the Local WordPress Install
+#### Accessing the Local WordPress Install
 
-The WordPress installation should be available at `http://localhost:8889` (**Username**: `admin`, **Password**: `password`).
-If this port is in use, you can override it using the `LOCAL_PORT` environment variable. For example, `export LOCAL_PORT=7777` will change the URL to `http://localhost:7777` . If you're running [e2e tests](/docs/contributors/testing-overview.md#end-to-end-testing), this change will be used correctly.
+Whether you decided to use Docker or an existing local WordPress install, the WordPress installation should now be available at `http://localhost:8889` (**Username**: `admin`, **Password**: `password`).
+If this port is in use, you can override it using the `LOCAL_PORT` environment variable. For example running the below command on your computer will change the URL to
+`http://localhost:7777` .
 
-To bring down this local WordPress instance later run `npm run env stop`. To bring it back up again, run `npm run env start`.
+Linux/MacOS: `export LOCAL_PORT=7777`
+Windows using Command Prompt: `setx LOCAL_PORT "7777"`
+Windows using PowerShell: `$env:LOCAL_PORT = "7777"`
 
-### Toggling Debug Systems
+If you're running [e2e tests](/docs/contributors/testing-overview.md#end-to-end-testing), this change will be used correctly.
+
+To shut down this local WordPress instance run `npm run env stop`. To start it back up again, run `npm run env start`.
+
+#### Toggling Debug Systems
 
 WordPress comes with specific [debug systems](https://wordpress.org/support/article/debugging-in-wordpress/) designed to simplify the process as well as standardize code across core, plugins and themes. It is possible to use environment variables (`LOCAL_WP_DEBUG` and `LOCAL_SCRIPT_DEBUG`) to update a site's configuration constants located in `wp-config.php` file. Both flags can be disabled at any time by running the following command:
+
+Example on Linux/MacOS:
 ```
 LOCAL_SCRIPT_DEBUG=false LOCAL_WP_DEBUG=false npm run env install
 ```
 By default, both flags will be set to `true`.
 
-### Troubleshooting
+#### Troubleshooting
 
 You might find yourself stuck on a screen stating that "you are running WordPress without JavaScript and CSS files". If you tried installing WordPress via `npm run env install`, it probably means that something went wrong during the process. To fix it, try removing the `/wordpress` folder and running `npm run env install` again.
 


### PR DESCRIPTION
## Description
Improvements to the getting-started.md documentation. Specifically:
1. Now explicitly note that when node is installed one must run the scripts from within the local gutenberg repo directory.
2. Broke into additional sections Local Environment.
   - Added Step 1: Installing a Local Environment
   - Changed "Using Docker" to "Quickest Method: Using Docker"
   - Prepended "Alternative Method:" to "Using an Existing Local WordPress Install"
   - Added Step 2: Accessing and Configuring the Local WordPress Install
3. Fleshed out the commands needed to add environment variables (especially on Windows, export will not work).
4. Changed verbiage regarding shutting down/starting up docker instance.
5. Clarified that the Toggling Debug Systems command will only work on Linux/MacOS (I do not have the correct command for Windows yet).
