### PR TITLE
E2E Tests: Add CPU/Network slowdown configuration options

### DIFF
--- a/docs/contributors/testing-overview.md
+++ b/docs/contributors/testing-overview.md
@@ -396,6 +396,25 @@ If you're using a different setup, you can provide the base URL, username and pa
 WP_BASE_URL=http://localhost:8888 WP_USERNAME=admin WP_PASSWORD=password npm run test-e2e
 ```
 
+If you find that end-to-end tests pass when run locally, but fail in Travis, you may be able to isolate a CPU- or netowrk-bound race condition by simulating a slow CPU or network:
+
+```
+THROTTLE_CPU=4 npm run test-e2e
+```
+
+`THROTTLE_CPU` is a slowdown factor (in this example, a 4x slowdown multiplier)
+
+Related: https://chromedevtools.github.io/devtools-protocol/tot/Emulation#method-setCPUThrottlingRate
+
+```
+DOWNLOAD_THROUGHPUT=125000 npm run test-e2e
+```
+
+`DOWNLOAD_THROUGHPUT` is a numeric value representing bytes-per-second network download (in this example, a 1Mbps download speed).
+
+Related: https://chromedevtools.github.io/devtools-protocol/tot/Network#method-emulateNetworkConditions
+
+
 ### Core Block Testing
 
 Every core block is required to have at least one set of fixture files for its main save function and one for each deprecation. These fixtures test the parsing and serialization of the block. See [the e2e tests fixtures readme](/packages/e2e-tests/fixtures/blocks/README.md) for more information and instructions.

--- a/packages/e2e-tests/CHANGELOG.md
+++ b/packages/e2e-tests/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Master
+
+### New Features
+
+- Added `THROTTLE_CPU` and `DOWNLOAD_THROUGHPUT` environment variable configuration options.
+
 ## 1.7.0 (2019-09-16)
 
 ## 1.6.0 (2019-09-03)

--- a/packages/e2e-tests/config/setup-test-framework.js
+++ b/packages/e2e-tests/config/setup-test-framework.js
@@ -239,7 +239,7 @@ beforeAll( async () => {
 	capturePageEventsForTearDown();
 	enablePageDialogAccept();
 	observeConsoleLogging();
-	simulateAdverseConditions();
+	await simulateAdverseConditions();
 
 	await trashExistingPosts();
 	await setupBrowser();


### PR DESCRIPTION
Closes #15677

This pull request seeks to add additional environment variable configuration options to the E2E test runner which can be used to simulate slow network or CPU conditions.

For more information, see included Testing Overview document description:

>If you find that end-to-end tests pass when run locally, but fail in Travis, you may be able to isolate a CPU- or netowrk-bound race condition by simulating a slow CPU or network:
>
>```
>THROTTLE_CPU=4 npm run test-e2e
>```
>
>`THROTTLE_CPU` is a slowdown factor (in this example, a 4x slowdown multiplier)
>
>Related: https://chromedevtools.github.io/devtools-protocol/tot/Emulation#method-setCPUThrottlingRate
>
>```
>DOWNLOAD_THROUGHPUT=125000 npm run test-e2e
>```
>
>`DOWNLOAD_THROUGHPUT` is a numeric value representing bytes-per-second network download (in this example, a 1Mbps download speed).
>
>Related: https://chromedevtools.github.io/devtools-protocol/tot/Network#method-emulateNetworkConditions

**Testing Instructions:**

You can observe that by providing a `THROTTLE_CPU` value when running `npm run test-e2e` for a test suite, it will likely take longer to complete than if the value is not provided.