### PR TITLE
E2E Test Utils: Try improved stability for transformBlockTo

### DIFF
--- a/packages/e2e-test-utils/src/transform-block-to.js
+++ b/packages/e2e-test-utils/src/transform-block-to.js
@@ -1,21 +1,31 @@
 /**
+ * Internal dependencies
+ */
+import { pressKeyWithModifier } from './press-key-with-modifier';
+
+/**
  * Converts editor's block type.
  *
  * @param {string} name Block name.
  */
 export async function transformBlockTo( name ) {
-	await page.mouse.move( 200, 300, { steps: 10 } );
-	await page.mouse.move( 250, 350, { steps: 10 } );
-	await page.click( '.block-editor-block-switcher__toggle' );
-	const insertButton = ( await page.$x(
-		`//button//span[contains(text(), '${ name }')]`
-	) )[ 0 ];
+	// Transition to block toolbar by key combination.
+	await pressKeyWithModifier( 'alt', 'F10' );
+
+	// Press Enter in the focused toggle button.
+	const switcherToggle = await page.waitForSelector( '.editor-block-switcher__toggle:focus' );
+	await switcherToggle.press( 'Enter' );
+
+	// Find the block button option within the switcher popover.
+	const switcher = await page.$( '.block-editor-block-switcher__container' );
+	const insertButton = ( await switcher.$x( `//button[.='${ name }']` ) )[ 0 ];
+
+	// Clicks may fail if the button is out of view. Assure it is before click.
 	await insertButton.evaluate( ( element ) => element.scrollIntoView() );
 	await insertButton.click();
+
+	// Wait for the transformed block to appear.
 	const BLOCK_SELECTOR = '.block-editor-block-list__block';
 	const BLOCK_NAME_SELECTOR = `[aria-label="Block: ${ name }"]`;
-	// Wait for the transformed block to appear.
-	await page.waitForSelector(
-		`${ BLOCK_SELECTOR }${ BLOCK_NAME_SELECTOR }`
-	);
+	await page.waitForSelector( `${ BLOCK_SELECTOR }${ BLOCK_NAME_SELECTOR }` );
 }

--- a/packages/e2e-test-utils/src/transform-block-to.js
+++ b/packages/e2e-test-utils/src/transform-block-to.js
@@ -13,7 +13,7 @@ export async function transformBlockTo( name ) {
 	await pressKeyWithModifier( 'alt', 'F10' );
 
 	// Press Enter in the focused toggle button.
-	const switcherToggle = await page.waitForSelector( '.editor-block-switcher__toggle:focus' );
+	const switcherToggle = await page.waitForSelector( '.block-editor-block-switcher__toggle:focus' );
 	await switcherToggle.press( 'Enter' );
 
 	// Find the block button option within the switcher popover.


### PR DESCRIPTION
This pull request attempts to try to resolve some intermittent E2E test failures, where test failures often occur in the `transformBlockTo` utility.

Example:

```
  ● Quote › can be created by converting a paragraph
    TimeoutError: waiting for selector ".block-editor-block-list__block[aria-label="Block: Quote"]" failed: timeout 30000ms exceeded
      at new WaitTask (../../node_modules/puppeteer/lib/DOMWorld.js:549:28)
      at DOMWorld._waitForSelectorOrXPath (../../node_modules/puppeteer/lib/DOMWorld.js:478:22)
      at DOMWorld.waitForSelector (../../node_modules/puppeteer/lib/DOMWorld.js:432:17)
      at Frame.waitForSelector (../../node_modules/puppeteer/lib/FrameManager.js:627:47)
      at Frame.<anonymous> (../../node_modules/puppeteer/lib/helper.js:112:23)
      at Page.waitForSelector (../../node_modules/puppeteer/lib/Page.js:1125:29)
      at page (../e2e-test-utils/build/@wordpress/e2e-test-utils/src/transform-block-to.js:18:8)
      ...
```

While I was never able to reproduce the issue locally, I attempted to make revisions based on the above information, specifically the fact that it became stuck at the last line of the function ([`waitForSelector`](https://github.com/WordPress/gutenberg/blob/be671eaaec240b51b92110f68c0f03bcafe3842a/packages/e2e-test-utils/src/transform-block-to.js#L18)) means that all of the preceding interactions were successful (display the switcher, find a button with the text "Quote" and click it).

The proposed changes aren't guaranteed to improve the tests, but are based on the following observations:

- The previous XPath selector was selecting the `span` of the button on which to perform the click, not the `button` itself where the event handler is bound. With these changes, it now matches the `button`.
   - Hypothesis: Maybe it was clicking the `span` but not registering as a click on the button?
- The previous XPath selector would match _any button_ _anywhere_ on the page that happened to have a `span` descendent which included the text "Quote". With these changes, the XPath selector is limited to match within the switcher popover.
   - Hypothesis: It was potentially clicking some other button on the page; though, again, in my local testing there were no other buttons which match this selector.
- The previous XPath selector would use `[contains(text(), '...')]` to match the text. With these change, the text is now matched using `[.='...']`.
   - Hypothesis: The behavior of `text()` is reasonably strict about placement of text nodes. Perhaps there were some unexpected conditions where additional DOM nodes might be added? Looking at the code, it doesn't appear it should be the case. But for the purposes of the utility, it's not really concerned with strict conformance. Contrast with the proposed `.=`, which is both simpler and more lenient about queried text in that it queries on the string concatenation of all text nodes in the parent ([reference](https://stackoverflow.com/a/34595441)).

I also included a change to use keyboard commands to navigate to the block toolbar and expand the switcher container, in place of the "mouse wiggle" interaction. As noted, since the function was able to successfully reach the final line of its execution, I don't expect this should have an impact one way or the other, but generally I would find the `page.mouse.move` approach to be less reliable overall.