### PR TITLE
Core Data: Add entity prop locking and use it in the Site Title block.

### DIFF
--- a/docs/designers-developers/developers/data/data-core.md
+++ b/docs/designers-developers/developers/data/data-core.md
@@ -217,6 +217,23 @@ _Returns_
 
 -   `?Object`: The entity record's save error.
 
+<a name="getLockedEntityProps" href="#getLockedEntityProps">#</a> **getLockedEntityProps**
+
+Returns the specified entity record's locked properties object,
+with non-function values wrapped in a getter and function values
+pre-bound to `select`.
+
+_Parameters_
+
+-   _state_ `Object`: State tree.
+-   _kind_ `string`: Entity kind.
+-   _name_ `string`: Entity name.
+-   _recordId_ `number`: Record ID.
+
+_Returns_
+
+-   `Object`: The entity record's locked properties object.
+
 <a name="getRawEntityRecord" href="#getRawEntityRecord">#</a> **getRawEntityRecord**
 
 Returns the entity's record object by key,
@@ -611,6 +628,21 @@ _Parameters_
 -   _name_ `string`: Name of the received entity.
 -   _record_ `Object`: Record to be saved.
 -   _options_ `Object`: Saving options.
+
+<a name="setLockedEntityProps" href="#setLockedEntityProps">#</a> **setLockedEntityProps**
+
+Action triggered to set locked props for an entity record.
+
+The values of the locked props object can be literal booleans
+that will be wrapped in getters in `getLockedEntityProps`,
+or they can be functions that will be pre-bound to `select`.
+
+_Parameters_
+
+-   _kind_ `string`: Kind of the entity.
+-   _name_ `string`: Name of the entity.
+-   _recordId_ `Object`: ID of the record.
+-   _props_ `Object`: Locked props object.
 
 <a name="undo" href="#undo">#</a> **undo**
 

--- a/packages/block-library/src/site-title/edit.js
+++ b/packages/block-library/src/site-title/edit.js
@@ -5,9 +5,9 @@ import {
 	useEntityProp,
 	__experimentalUseEntitySaving,
 } from '@wordpress/core-data';
-import { RichText } from '@wordpress/block-editor';
+import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { Disabled, Button } from '@wordpress/components';
+import { RichText } from '@wordpress/block-editor';
 
 export default function SiteTitleEdit() {
 	const [ title, setTitle, titleIsLocked ] = useEntityProp(
@@ -21,15 +21,6 @@ export default function SiteTitleEdit() {
 		'title'
 	);
 
-	const input = (
-		<RichText
-			tagName="h1"
-			placeholder={ __( 'Site Title' ) }
-			value={ title }
-			onChange={ setTitle }
-			allowedFormats={ [] }
-		/>
-	);
 	return (
 		<>
 			<Button
@@ -41,7 +32,14 @@ export default function SiteTitleEdit() {
 			>
 				{ __( 'Update' ) }
 			</Button>
-			{ titleIsLocked ? <Disabled>{ input }</Disabled> : input }
+			<RichText
+				tagName="h1"
+				placeholder={ __( 'Site Title' ) }
+				value={ title }
+				onChange={ setTitle }
+				allowedFormats={ [] }
+				disabled={ titleIsLocked }
+			/>
 		</>
 	);
 }

--- a/packages/block-library/src/site-title/edit.js
+++ b/packages/block-library/src/site-title/edit.js
@@ -5,35 +5,43 @@ import {
 	useEntityProp,
 	__experimentalUseEntitySaving,
 } from '@wordpress/core-data';
-import { Button } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
 import { RichText } from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
+import { Disabled, Button } from '@wordpress/components';
 
 export default function SiteTitleEdit() {
-	const [ title, setTitle ] = useEntityProp( 'root', 'site', 'title' );
+	const [ title, setTitle, titleIsLocked ] = useEntityProp(
+		'root',
+		'site',
+		'title'
+	);
 	const [ isDirty, isSaving, save ] = __experimentalUseEntitySaving(
 		'root',
 		'site',
 		'title'
+	);
+
+	const input = (
+		<RichText
+			tagName="h1"
+			placeholder={ __( 'Site Title' ) }
+			value={ title }
+			onChange={ setTitle }
+			allowedFormats={ [] }
+		/>
 	);
 	return (
 		<>
 			<Button
 				isPrimary
 				className="wp-block-site-title__save-button"
-				disabled={ ! isDirty || ! title }
+				disabled={ ! isDirty || ! title || titleIsLocked }
 				isBusy={ isSaving }
 				onClick={ save }
 			>
 				{ __( 'Update' ) }
 			</Button>
-			<RichText
-				tagName="h1"
-				placeholder={ __( 'Site Title' ) }
-				value={ title }
-				onChange={ setTitle }
-				allowedFormats={ [] }
-			/>
+			{ titleIsLocked ? <Disabled>{ input }</Disabled> : input }
 		</>
 	);
 }

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -206,6 +206,21 @@ _Parameters_
 -   _record_ `Object`: Record to be saved.
 -   _options_ `Object`: Saving options.
 
+<a name="setLockedEntityProps" href="#setLockedEntityProps">#</a> **setLockedEntityProps**
+
+Action triggered to set locked props for an entity record.
+
+The values of the locked props object can be literal booleans
+that will be wrapped in getters in `getLockedEntityProps`,
+or they can be functions that will be pre-bound to `select`.
+
+_Parameters_
+
+-   _kind_ `string`: Kind of the entity.
+-   _name_ `string`: Name of the entity.
+-   _recordId_ `Object`: ID of the record.
+-   _props_ `Object`: Locked props object.
+
 <a name="undo" href="#undo">#</a> **undo**
 
 Action triggered to undo the last edit to
@@ -429,6 +444,23 @@ _Parameters_
 _Returns_
 
 -   `?Object`: The entity record's save error.
+
+<a name="getLockedEntityProps" href="#getLockedEntityProps">#</a> **getLockedEntityProps**
+
+Returns the specified entity record's locked properties object,
+with non-function values wrapped in a getter and function values
+pre-bound to `select`.
+
+_Parameters_
+
+-   _state_ `Object`: State tree.
+-   _kind_ `string`: Entity kind.
+-   _name_ `string`: Entity name.
+-   _recordId_ `number`: Record ID.
+
+_Returns_
+
+-   `Object`: The entity record's locked properties object.
 
 <a name="getRawEntityRecord" href="#getRawEntityRecord">#</a> **getRawEntityRecord**
 

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -415,6 +415,28 @@ export function* saveEditedEntityRecord( kind, name, recordId, options ) {
 }
 
 /**
+ * Action triggered to set locked props for an entity record.
+ *
+ * The values of the locked props object can be literal booleans
+ * that will be wrapped in getters in `getLockedEntityProps`,
+ * or they can be functions that will be pre-bound to `select`.
+ *
+ * @param {string} kind     Kind of the entity.
+ * @param {string} name     Name of the entity.
+ * @param {Object} recordId ID of the record.
+ * @param {Object} props    Locked props object.
+ */
+export function setLockedEntityProps( kind, name, recordId, props ) {
+	return {
+		type: 'SET_LOCKED_ENTITY_PROPS',
+		kind,
+		name,
+		recordId,
+		props,
+	};
+}
+
+/**
  * Returns an action object used in signalling that Upload permissions have been received.
  *
  * @param {boolean} hasUploadPermissions Does the user have permission to upload files?

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -12,11 +12,40 @@ import { apiFetch, select } from './controls';
 export const DEFAULT_ENTITY_KEY = 'id';
 
 export const defaultEntities = [
-	{ name: 'site', kind: 'root', baseURL: '/wp/v2/settings' },
-	{ name: 'postType', kind: 'root', key: 'slug', baseURL: '/wp/v2/types' },
-	{ name: 'media', kind: 'root', baseURL: '/wp/v2/media', plural: 'mediaItems' },
-	{ name: 'taxonomy', kind: 'root', key: 'slug', baseURL: '/wp/v2/taxonomies', plural: 'taxonomies' },
-	{ name: 'widgetArea', kind: 'root', baseURL: '/__experimental/widget-areas', plural: 'widgetAreas', transientEdits: { blocks: true } },
+	{
+		name: 'site',
+		kind: 'root',
+		baseURL: '/wp/v2/settings',
+		lockedProps: {
+			title: ( _select ) => ! _select( 'core' ).canUser( 'update', 'settings' ),
+		},
+	},
+	{
+		name: 'postType',
+		kind: 'root',
+		key: 'slug',
+		baseURL: '/wp/v2/types',
+	},
+	{
+		name: 'media',
+		kind: 'root',
+		baseURL: '/wp/v2/media',
+		plural: 'mediaItems',
+	},
+	{
+		name: 'taxonomy',
+		kind: 'root',
+		key: 'slug',
+		baseURL: '/wp/v2/taxonomies',
+		plural: 'taxonomies',
+	},
+	{
+		name: 'widgetArea',
+		kind: 'root',
+		baseURL: '/__experimental/widget-areas',
+		plural: 'widgetAreas',
+		transientEdits: { blocks: true },
+	},
 ];
 
 export const kinds = [

--- a/packages/core-data/src/reducer.js
+++ b/packages/core-data/src/reducer.js
@@ -224,6 +224,21 @@ function entity( entityConfig ) {
 
 				return state;
 			},
+
+			lockedProps: ( state = {}, action ) => {
+				switch ( action.type ) {
+					case 'SET_LOCKED_ENTITY_PROPS':
+						return {
+							...state,
+							[ action.recordId ]: {
+								...state[ action.recordId ],
+								...action.props,
+							},
+						};
+				}
+
+				return state;
+			},
 		} )
 	);
 }


### PR DESCRIPTION
## Description

This PR addresses a need found by #18760 and is an alternative to it.

Certain entity props, like a site's title, should not always be editable depending on editing context and/or user permissions. The framework should provide a declarative way of "locking" these props.

This PR provides a way to define default "locked" values for different entity types in their configs, and a way to track and edit these values on a per-entity-record basis. The "locked" values can either be literals that will be wrapped in getters, i.e. `true`, becomes `() => true` and means a prop is locked, `false` or `undefined` means it's not, or they can be functions that will be pre-bound to `select`.

This approach allows for simplicity and the flexibility for consumers to derive the values based on any state, like the site entity config does in this PR with `canUser`.

Additionally, `useEntityProp`'s setter now throws a warning when trying to set a value for a locked prop, and it also returns a third variable, the evaluated "locked" value for the specified prop. This made the changes needed in the Site Title block minimal and it made it really easy to avoid forking the rendering path when the site title is locked.

## How has this been tested?

It was verified that using the Site Title block logged in as a contributor renders it disabled.

## Types of Changes

*New Feature:* `core-data` entities now support locked entity props for managing props that shouldn't be editable under certain context and/or with certain user permission levels.

## Checklist:

- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
