### PR TITLE
Add linting task to check IE compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -106,7 +106,7 @@ jobs:
         - npm ci
         - npm run build
       script:
-        - npm run lint-es5-only
+        - npx eslint --parser-options=ecmaVersion:5 --no-eslintrc --no-ignore ./build/**/*.js
 
     - name: Build artifacts
       install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -101,6 +101,13 @@ jobs:
       script:
         - npm run lint
 
+    - name: Lint ES5 only
+      install:
+        - npm ci
+        - npm run build
+      script:
+        - npm run lint-es5-only
+
     - name: Build artifacts
       install:
         # A "full" install is executed, since `npm ci` does not always exit

--- a/package.json
+++ b/package.json
@@ -178,6 +178,7 @@
 		"fixtures:generate": "npm run fixtures:server-registered && cross-env GENERATE_MISSING_FIXTURES=y npm run test-unit",
 		"fixtures:regenerate": "npm run fixtures:clean && npm run fixtures:generate",
 		"lint": "concurrently \"npm run lint-js\" \"npm run lint-pkg-json\" \"npm run lint-css\" \"npm run lint-types\"",
+		"lint-es5-only": "npx eslint --parser-options=ecmaVersion:5 --no-eslintrc --no-ignore ./build/**/*.js",
 		"lint-js": "wp-scripts lint-js",
 		"lint-js:fix": "npm run lint-js -- --fix",
 		"lint-php": "wp-scripts env lint-php",

--- a/package.json
+++ b/package.json
@@ -178,7 +178,6 @@
 		"fixtures:generate": "npm run fixtures:server-registered && cross-env GENERATE_MISSING_FIXTURES=y npm run test-unit",
 		"fixtures:regenerate": "npm run fixtures:clean && npm run fixtures:generate",
 		"lint": "concurrently \"npm run lint-js\" \"npm run lint-pkg-json\" \"npm run lint-css\" \"npm run lint-types\"",
-		"lint-es5-only": "npx eslint --parser-options=ecmaVersion:5 --no-eslintrc --no-ignore ./build/**/*.js",
 		"lint-js": "wp-scripts lint-js",
 		"lint-js:fix": "npm run lint-js -- --fix",
 		"lint-php": "wp-scripts env lint-php",


### PR DESCRIPTION
## Description

Added a script to lint built JS files checking for any ES > 5 that might break on IE11. 
Added task to run script in Travis.

## How has this been tested?

Tested locally by running `npm run build` followed by `npm run lint-es5-only`. On latest master, no errors should appear. 
Checking out `69e7fc7060651c65b394944bda00759e232ade33` (or any commit before `hex-rgb` was removed) and re-running the above commands should result in an error traceable to the `hex-rgb` package.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
