### PR TITLE
Move popovers and modals to the right position in the dom

### DIFF
--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -82,11 +82,6 @@ function Layout( { isMobileViewport } ) {
 			<AutosaveMonitor />
 			<LocalAutosaveMonitor />
 			<EditorModeKeyboardShortcuts />
-			<ManageBlocksModal />
-			<OptionsModal />
-			<KeyboardShortcutHelpModal />
-			<Popover.Slot />
-			<PluginArea />
 			<FocusReturnProvider className={ className }>
 				<EditorRegions
 					className={ className }
@@ -138,6 +133,12 @@ function Layout( { isMobileViewport } ) {
 						</div>
 					) }
 				/>
+
+				<ManageBlocksModal />
+				<OptionsModal />
+				<KeyboardShortcutHelpModal />
+				<Popover.Slot />
+				<PluginArea />
 			</FocusReturnProvider>
 
 		</>


### PR DESCRIPTION
This PR restores the previous position for modals and popovers in the DOM. (before #18044)

It also ensures they are wrapped in `FocusReturnProvider` that way `withFocusReturn` should work properly there.