### PR TITLE
Avoid re-rendering the EditorRegions component on click

### DIFF
--- a/packages/components/src/higher-order/navigate-regions/index.js
+++ b/packages/components/src/higher-order/navigate-regions/index.js
@@ -48,11 +48,16 @@ export default createHigherOrderComponent(
 				}
 
 				nextRegion.focus();
-				this.setState( { isFocusingRegions: true } );
+
+				if ( ! this.state.isFocusingRegions ) {
+					this.setState( { isFocusingRegions: true } );
+				}
 			}
 
 			onClick() {
-				this.setState( { isFocusingRegions: false } );
+				if ( this.state.isFocusingRegions ) {
+					this.setState( { isFocusingRegions: false } );
+				}
 			}
 
 			render() {


### PR DESCRIPTION
This probably doesn't have a huge impact on performance but I noticed that when clicking anywhere on the canvas, the EditorRegions component re-renders for no particular reason (causing its subtree to rerender as well). This PR prevents that.