### PR TITLE
Blocks: Fix typo in the blockPatterns reducer

### DIFF
--- a/packages/blocks/src/store/reducer.js
+++ b/packages/blocks/src/store/reducer.js
@@ -114,7 +114,7 @@ export function blockPatterns( state = {}, action ) {
 					return uniqBy( [
 						...get( blockType, [ 'patterns' ], [] ),
 						...get( state, [ blockType.name ], [] ),
-					], ( style ) => style.name );
+					], ( pattern ) => pattern.name );
 				} ),
 			};
 		case 'ADD_BLOCK_PATTERNS':


### PR DESCRIPTION
## Description
This should fix the copy and paste issues raised by @mcsf in https://github.com/WordPress/gutenberg/pull/18270#discussion_r344191106:

> I think this should read `( pattern ) => pattern.name` :)

I originally planned to fix it with refactor proposed in #18398. However, it looks like this is not going to happen.