### PR TITLE
Remove custom animations from Bottom-Sheet

### DIFF
--- a/packages/components/src/mobile/bottom-sheet/index.native.js
+++ b/packages/components/src/mobile/bottom-sheet/index.native.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { Text, View, Platform, PanResponder, Dimensions, Easing } from 'react-native';
+import { Text, View, Platform, PanResponder, Dimensions } from 'react-native';
 import Modal from 'react-native-modal';
 import SafeArea from 'react-native-safe-area';
 
@@ -98,38 +98,13 @@ class BottomSheet extends Component {
 			</View>
 		);
 
-		const { height } = Dimensions.get( 'window' );
-		const easing = Easing.bezier( 0.450, 0.000, 0.160, 1.020 );
-
-		const animationIn = {
-			easing,
-			from: {
-				translateY: height,
-			},
-			to: {
-				translateY: 0,
-			},
-		};
-
-		const animationOut = {
-			easing,
-			from: {
-				translateY: 0,
-			},
-			to: {
-				translateY: height,
-			},
-		};
-
 		const backgroundStyle = getStylesFromColorScheme( styles.background, styles.backgroundDark );
 
 		return (
 			<Modal
 				isVisible={ isVisible }
 				style={ styles.bottomModal }
-				animationIn={ animationIn }
 				animationInTiming={ 600 }
-				animationOut={ animationOut }
 				animationOutTiming={ 250 }
 				backdropTransitionInTiming={ 50 }
 				backdropTransitionOutTiming={ 50 }


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/1522

`gutenberg-mobile` side PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1628

## Description
The root cause goes like this:

- Our bottom-sheet uses a custom animation to[ modify the easing curve](https://github.com/WordPress/gutenberg/blob/06a65028d33297dfe75e40c1938d540332881109/packages/components/src/mobile/bottom-sheet/index.native.js#L102)
- This animation uses the window's height as a parameter.
- Since the window's height changes when the device is rotated, there's a new set of animation definition after rotation, that is given to `Modal` via props.
- `react-native-modal` uses a package called `react-native-animatable` to manage animations.
- When a new custom animation is given to `Modal`, it won't be "attached" right away to the view, but it will be[ registered on a global set of animations](https://github.com/oblador/react-native-animatable/blob/0c0c50132d8621a3f08644738085fdb8163c3945/registry.js#L3-L7). 
- When the (animatable) content view is created, the registered global animations are fetched and added to the view.
- The issue occurs when we present the bottom-sheet with the `portrait-mode` set of animations, and rotate de device. 
- The new set of animations will get registered globally, but not added to the current animatable view already present.
- When trying to dismiss, `react-native-modal` will fail on fetching the `portrait-mode` animation, since it's registered globally but not added to the current content view.
- 💥

To solve this root cause, we might need to modify both dependencies in some way.
Thinking about a workaround, we could try to not update the animations on rotation, or make the bottom-sheet dismiss and re-present it on rotation.

I opted for the simpler solution that is to remove this custom animations. The difference is minimal and almost imperceptible, and effectively solves the crash.


