### PR TITLE
Remove core editor usage from block editor rich text

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -486,7 +486,10 @@ const RichTextContainer = compose( [
 
 		const selectionStart = getSelectionStart();
 		const selectionEnd = getSelectionEnd();
-		const { __experimentalCanUserUseUnfilteredHTML } = getSettings();
+		const {
+			__experimentalCanUserUseUnfilteredHTML,
+			__experimentalUndo: undo,
+		} = getSettings();
 		if ( isSelected === undefined ) {
 			isSelected = (
 				selectionStart.clientId === clientId &&
@@ -516,6 +519,7 @@ const RichTextContainer = compose( [
 			isSelected,
 			didAutomaticChange: didAutomaticChange(),
 			disabled: isMultiSelecting() || hasMultiSelection(),
+			undo,
 			...extraProps,
 		};
 	} ),
@@ -531,7 +535,6 @@ const RichTextContainer = compose( [
 			selectionChange,
 			__unstableMarkAutomaticChange,
 		} = dispatch( 'core/block-editor' );
-		const { undo } = dispatch( 'core/editor' );
 
 		return {
 			onCreateUndoLevel: __unstableMarkLastChangeAsPersistent,
@@ -541,7 +544,6 @@ const RichTextContainer = compose( [
 				selectionChange( clientId, identifier, start, end );
 			},
 			markAutomaticChange: __unstableMarkAutomaticChange,
-			undo,
 		};
 	} ),
 ] )( RichTextWrapper );

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -79,7 +79,8 @@ class EditorProvider extends Component {
 		reusableBlocks,
 		__experimentalFetchReusableBlocks,
 		hasUploadPermissions,
-		canUserUseUnfilteredHTML
+		canUserUseUnfilteredHTML,
+		undo,
 	) {
 		return {
 			...pick( settings, [
@@ -118,6 +119,7 @@ class EditorProvider extends Component {
 			__experimentalFetchReusableBlocks,
 			__experimentalFetchLinkSuggestions: fetchLinkSuggestions,
 			__experimentalCanUserUseUnfilteredHTML: canUserUseUnfilteredHTML,
+			__experimentalUndo: undo,
 		};
 	}
 
@@ -164,6 +166,7 @@ class EditorProvider extends Component {
 			resetEditorBlocksWithoutUndoLevel,
 			hasUploadPermissions,
 			__experimentalFetchReusableBlocks,
+			undo,
 		} = this.props;
 
 		if ( ! isReady ) {
@@ -176,6 +179,7 @@ class EditorProvider extends Component {
 			__experimentalFetchReusableBlocks,
 			hasUploadPermissions,
 			canUserUseUnfilteredHTML,
+			undo,
 		);
 
 		return (
@@ -231,6 +235,7 @@ export default compose( [
 			updateEditorSettings,
 			__experimentalFetchReusableBlocks,
 			__experimentalTearDownEditor,
+			undo,
 		} = dispatch( 'core/editor' );
 		const { createWarningNotice } = dispatch( 'core/notices' );
 
@@ -248,6 +253,7 @@ export default compose( [
 			},
 			tearDownEditor: __experimentalTearDownEditor,
 			__experimentalFetchReusableBlocks,
+			undo,
 		};
 	} ),
 ] )( EditorProvider );


### PR DESCRIPTION
We want to remove the usages of editor inside block editor as that module may not be available. E.g: it is not available on the widget screen.
This PR adds a new setting __experimentalUndo that allows the block editor to trigger an undo.

## How has this been tested?
I added a paragraph.
I wrote "* ", and verified the paragraph was transformed into a list.
I typed backspace and verified the transform was reverted.
