### PR TITLE
Package: Replace `fs-extra` with `rimraf`.

### DIFF
--- a/bin/commander.js
+++ b/bin/commander.js
@@ -8,7 +8,8 @@ const program = require( 'commander' );
 const inquirer = require( 'inquirer' );
 const semver = require( 'semver' );
 const chalk = require( 'chalk' );
-const fs = require( 'fs-extra' );
+const fs = require( 'fs' );
+const rimraf = require( 'rimraf' );
 const SimpleGit = require( 'simple-git/promise' );
 const childProcess = require( 'child_process' );
 const Octokit = require( '@octokit/rest' );
@@ -243,8 +244,8 @@ async function updateThePluginStableVersion( version, abortMessage ) {
  */
 async function runCleanLocalCloneStep( abortMessage ) {
 	await runStep( 'Cleaning the temporary folder', abortMessage, async () => {
-		await fs.remove( gitWorkingDirectoryPath );
-		await fs.remove( svnWorkingDirectoryPath );
+		await rimraf( gitWorkingDirectoryPath );
+		await rimraf( svnWorkingDirectoryPath );
 	} );
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -22079,7 +22079,7 @@
 			"dependencies": {
 				"clone-deep": {
 					"version": "0.2.4",
-					"resolved": "http://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
+					"resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
 					"integrity": "sha1-TnPdCen7lxzDhnDF3O2cGJZIHMY=",
 					"dev": true,
 					"requires": {
@@ -22113,7 +22113,7 @@
 					"dependencies": {
 						"kind-of": {
 							"version": "2.0.1",
-							"resolved": "http://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
 							"integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
 							"dev": true,
 							"requires": {

--- a/package.json
+++ b/package.json
@@ -119,7 +119,6 @@
 		"eslint-plugin-import": "2.18.2",
 		"fast-glob": "2.2.7",
 		"fbjs": "0.8.17",
-		"fs-extra": "8.0.1",
 		"glob": "7.1.2",
 		"husky": "3.0.5",
 		"inquirer": "6.3.1",


### PR DESCRIPTION
It surfaced in [this thread](https://github.com/WordPress/gutenberg/pull/18703#discussion_r351098016), that we only use `fs-extra` for its `remove` function. We already have `rimraf` which does the same thing, and we need it for its CLI, so it makes sense to replace `fs-extra` with `rimraf` and avoid pulling in an extra dependency.