### PR TITLE
[RNMobile] Avoid setting alignSelf for image placeholders

### DIFF
--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -417,7 +417,13 @@ export class ImageEdit extends React.Component {
 							);
 
 							return (
-								<View style={ { flex: 1, alignSelf: alignToFlex[ align ] } } >
+								<View style={ {
+									flex: 1,
+									// only set alignSelf if an image exists because alignSelf causes the placeholder
+									// to disappear when an aligned image can't be downloaded
+									// https://github.com/wordpress-mobile/gutenberg-mobile/issues/1592
+									alignSelf: imageWidthWithinContainer && alignToFlex[ align ] }
+								} >
 									{ ! imageWidthWithinContainer &&
 										<View style={ [ styles.imageContainer, { height: imageContainerHeight } ] } >
 											{ this.getIcon( false ) }


### PR DESCRIPTION
## Description
This fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/1592, where image placeholders would not be shown if there was a failure downloading an _aligned_ image. This was caused by the setting of the `alignSelf` attribute. Since that attribute is not being used for the placeholder, only setting it when an image is present fixes the issue.

[Related gutenberg-mobile PR](https://github.com/wordpress-mobile/gutenberg-mobile/pull/1631)

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [X] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
