### PR TITLE
Update: Removed editor store usage from native mobile block editor inserter

### DIFF
--- a/packages/block-editor/src/components/inserter/menu.native.js
+++ b/packages/block-editor/src/components/inserter/menu.native.js
@@ -116,6 +116,7 @@ export default compose(
 			getBlockName,
 			getBlockRootClientId,
 			getBlockSelectionEnd,
+			getSettings,
 		} = select( 'core/block-editor' );
 		const {
 			getChildBlockNames,
@@ -130,10 +131,13 @@ export default compose(
 		}
 		const destinationRootBlockName = getBlockName( destinationRootClientId );
 
+		const { __experimentalShouldInsertAtTheTop: shouldInsertAtTheTop } = getSettings();
+
 		return {
 			rootChildBlocks: getChildBlockNames( destinationRootBlockName ),
 			items: getInserterItems( destinationRootClientId ),
 			destinationRootClientId,
+			shouldInsertAtTheTop,
 		};
 	} ),
 	withDispatch( ( dispatch, ownProps, { select } ) => {
@@ -154,13 +158,10 @@ export default compose(
 				getBlockSelectionEnd,
 				getBlockOrder,
 			} = select( 'core/block-editor' );
-			const {
-				isPostTitleSelected,
-			} = select( 'core/editor' );
-			const { clientId, destinationRootClientId, isAppender } = ownProps;
+			const { clientId, destinationRootClientId, isAppender, shouldInsertAtTheTop } = ownProps;
 
 			// if post title is selected insert as first block
-			if ( isPostTitleSelected() ) {
+			if ( shouldInsertAtTheTop ) {
 				return 0;
 			}
 

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -83,6 +83,7 @@ class EditorProvider extends Component {
 		hasUploadPermissions,
 		canUserUseUnfilteredHTML,
 		undo,
+		shouldInsertAtTheTop,
 	) {
 		return {
 			...pick( settings, [
@@ -122,6 +123,7 @@ class EditorProvider extends Component {
 			__experimentalFetchLinkSuggestions: fetchLinkSuggestions,
 			__experimentalCanUserUseUnfilteredHTML: canUserUseUnfilteredHTML,
 			__experimentalUndo: undo,
+			__experimentalShouldInsertAtTheTop: shouldInsertAtTheTop,
 		};
 	}
 
@@ -167,6 +169,7 @@ class EditorProvider extends Component {
 			reusableBlocks,
 			resetEditorBlocksWithoutUndoLevel,
 			hasUploadPermissions,
+			isPostTitleSelected,
 			__experimentalFetchReusableBlocks,
 			undo,
 		} = this.props;
@@ -182,6 +185,7 @@ class EditorProvider extends Component {
 			hasUploadPermissions,
 			canUserUseUnfilteredHTML,
 			undo,
+			isPostTitleSelected,
 		);
 
 		return (
@@ -216,6 +220,7 @@ export default compose( [
 			getEditorSelectionStart,
 			getEditorSelectionEnd,
 			__experimentalGetReusableBlocks,
+			isPostTitleSelected,
 		} = select( 'core/editor' );
 		const { canUser } = select( 'core' );
 
@@ -227,6 +232,8 @@ export default compose( [
 			selectionEnd: getEditorSelectionEnd(),
 			reusableBlocks: __experimentalGetReusableBlocks(),
 			hasUploadPermissions: defaultTo( canUser( 'create', 'media' ), true ),
+			// This selector is only defined on mobile.
+			isPostTitleSelected: isPostTitleSelected && isPostTitleSelected(),
 		};
 	} ),
 	withDispatch( ( dispatch ) => {


### PR DESCRIPTION
We want to remove the usages of editor inside block editor as that module may not be available. E.g: it is not available on the widget screen.
This PR adds a new setting __experimentalShouldInsertAtTheTop that makes the native mobile inserter insert a block at the top. This setting is only used by native mobile applications.

cc: @Tug 

