### PR TITLE
Remove parent block title from block hover title.

### DIFF
--- a/packages/block-editor/src/components/block-list/breadcrumb.js
+++ b/packages/block-editor/src/components/block-list/breadcrumb.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { Toolbar, Button } from '@wordpress/components';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useDispatch } from '@wordpress/data';
 import { forwardRef } from '@wordpress/element';
 
 /**
@@ -20,21 +20,10 @@ import BlockTitle from '../block-title';
  */
 const BlockBreadcrumb = forwardRef( ( { clientId }, ref ) => {
 	const { setNavigationMode } = useDispatch( 'core/block-editor' );
-	const { rootClientId } = useSelect( ( select ) => {
-		return {
-			rootClientId: select( 'core/block-editor' ).getBlockRootClientId( clientId ),
-		};
-	} );
 
 	return (
 		<div className="editor-block-list__breadcrumb block-editor-block-list__breadcrumb">
 			<Toolbar>
-				{ rootClientId && (
-					<>
-						<BlockTitle clientId={ rootClientId } />
-						<span className="editor-block-list__descendant-arrow block-editor-block-list__descendant-arrow" />
-					</>
-				) }
 				<Button ref={ ref } onClick={ () => setNavigationMode( false ) }>
 					<BlockTitle clientId={ clientId } />
 				</Button>

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -1097,16 +1097,6 @@
 	}
 }
 
-.block-editor-block-list__descendant-arrow::before {
-	content: "→";
-	display: inline-block;
-	padding: 0 4px;
-
-	.rtl & {
-		content: "←";
-	}
-}
-
 .block-editor-block-list__block {
 	@include break-small {
 		// Increase the hover and selection area around blocks.


### PR DESCRIPTION
## Description
Since the editor now has a status bar containing block breadcrumbs, I think the block hover breadcrumb can be simplified to only show the title of the block being hovered. I think this makes the UI a bit clearer; I often found myself getting momentarily confused by the hover title, as the first word you see is _not_ the title of the block you're hovering, but the immediate parent. Since the status bar provides a full breadcrumb of the selected block, I think the hover title should be simplified to only show the title of the hovered block.

## How has this been tested?
I checked to make sure the breadcrumb was functional and looked right in both the navigation and standard (what is it called again?) modes.

I am unable to test the mobile version of the UI, but I have not modified the mobile version, and as far as I can tell, none of the changes in this PR should affect the mobile UI.

## Screenshots
![image](https://user-images.githubusercontent.com/19592990/69755194-4f470680-111d-11ea-9f58-7d3d230f1ca2.png)
![image](https://user-images.githubusercontent.com/19592990/69755239-68e84e00-111d-11ea-9da9-520308c7674a.png)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
