### PR TITLE
Modify wp-scripts to transpile node_modules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9006,6 +9006,7 @@
 				"@babel/plugin-syntax-dynamic-import": "^7.7.4",
 				"@babel/plugin-transform-runtime": "^7.7.4",
 				"@babel/preset-env": "^7.7.4",
+				"@babel/runtime": "^7.7.4",
 				"@wordpress/babel-preset-default": "file:packages/babel-preset-default",
 				"@wordpress/browserslist-config": "file:packages/browserslist-config",
 				"@wordpress/dependency-extraction-webpack-plugin": "file:packages/dependency-extraction-webpack-plugin",
@@ -9697,6 +9698,15 @@
 						"invariant": "^2.2.2",
 						"js-levenshtein": "^1.1.3",
 						"semver": "^5.5.0"
+					}
+				},
+				"@babel/runtime": {
+					"version": "7.7.6",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.6.tgz",
+					"integrity": "sha512-BWAJxpNVa0QlE5gZdWjSxXtemZyZ9RmrmVozxt3NUXeZhVIJ5ANyqmMc0JDrivBZyxUuQvFxlvH4OWWOogGfUw==",
+					"dev": true,
+					"requires": {
+						"regenerator-runtime": "^0.13.2"
 					}
 				},
 				"@babel/template": {
@@ -23683,7 +23693,7 @@
 			"dependencies": {
 				"clone-deep": {
 					"version": "0.2.4",
-					"resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
+					"resolved": "http://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
 					"integrity": "sha1-TnPdCen7lxzDhnDF3O2cGJZIHMY=",
 					"dev": true,
 					"requires": {
@@ -23717,7 +23727,7 @@
 					"dependencies": {
 						"kind-of": {
 							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+							"resolved": "http://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
 							"integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
 							"dev": true,
 							"requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9003,8 +9003,11 @@
 			"version": "file:packages/scripts",
 			"dev": true,
 			"requires": {
+				"@babel/plugin-syntax-dynamic-import": "^7.7.4",
+				"@babel/plugin-transform-runtime": "^7.7.4",
 				"@babel/preset-env": "^7.7.4",
 				"@wordpress/babel-preset-default": "file:packages/babel-preset-default",
+				"@wordpress/browserslist-config": "file:packages/browserslist-config",
 				"@wordpress/dependency-extraction-webpack-plugin": "file:packages/dependency-extraction-webpack-plugin",
 				"@wordpress/eslint-plugin": "file:packages/eslint-plugin",
 				"@wordpress/jest-preset-default": "file:packages/jest-preset-default",
@@ -9566,6 +9569,18 @@
 					"dev": true,
 					"requires": {
 						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-runtime": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.7.4.tgz",
+					"integrity": "sha512-O8kSkS5fP74Ad/8pfsCMGa8sBRdLxYoSReaARRNSz3FbFQj3z/QUvoUmJ28gn9BO93YfnXc3j+Xyaqe8cKDNBQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-module-imports": "^7.7.4",
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"resolve": "^1.8.1",
+						"semver": "^5.5.1"
 					}
 				},
 				"@babel/plugin-transform-shorthand-properties": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -155,6 +155,102 @@
 				"@babel/helper-split-export-declaration": "^7.4.4"
 			}
 		},
+		"@babel/helper-create-regexp-features-plugin": {
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.7.4.tgz",
+			"integrity": "sha512-Mt+jBKaxL0zfOIWrfQpnfYCN7/rS6GKx6CCCfuoqVVd+17R8zNDlzVYmIi9qyb2wOk002NsmSTDymkIygDUH7A==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-regex": "^7.4.4",
+				"regexpu-core": "^4.6.0"
+			},
+			"dependencies": {
+				"regenerate-unicode-properties": {
+					"version": "8.1.0",
+					"resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.1.0.tgz",
+					"integrity": "sha512-LGZzkgtLY79GeXLm8Dp0BVLdQlWICzBnJz/ipWUgo59qBaZ+BHtq51P2q1uVZlppMuUAT37SDk39qUbjTWB7bA==",
+					"dev": true,
+					"requires": {
+						"regenerate": "^1.4.0"
+					}
+				},
+				"regexpu-core": {
+					"version": "4.6.0",
+					"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.6.0.tgz",
+					"integrity": "sha512-YlVaefl8P5BnFYOITTNzDvan1ulLOiXJzCNZxduTIosN17b87h3bvG9yHMoHaRuo88H4mQ06Aodj5VtYGGGiTg==",
+					"dev": true,
+					"requires": {
+						"regenerate": "^1.4.0",
+						"regenerate-unicode-properties": "^8.1.0",
+						"regjsgen": "^0.5.0",
+						"regjsparser": "^0.6.0",
+						"unicode-match-property-ecmascript": "^1.0.4",
+						"unicode-match-property-value-ecmascript": "^1.1.0"
+					}
+				}
+			}
+		},
+		"@babel/helper-define-map": {
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.7.4.tgz",
+			"integrity": "sha512-v5LorqOa0nVQUvAUTUF3KPastvUt/HzByXNamKQ6RdJRTV7j8rLL+WB5C/MzzWAwOomxDhYFb1wLLxHqox86lg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-function-name": "^7.7.4",
+				"@babel/types": "^7.7.4",
+				"lodash": "^4.17.13"
+			},
+			"dependencies": {
+				"@babel/helper-function-name": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.4.tgz",
+					"integrity": "sha512-AnkGIdiBhEuiwdoMnKm7jfPfqItZhgRaZfMg1XX3bS25INOnLPjPG1Ppnajh8eqgt5kPJnfqrRHqFqmjKDZLzQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.7.4",
+						"@babel/template": "^7.7.4",
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.4.tgz",
+					"integrity": "sha512-QTGKEdCkjgzgfJ3bAyRwF4yyT3pg+vDgan8DSivq1eS0gwi+KGKE5x8kRcbeFTb/673mkO5SN1IZfmCfA5o+EA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.4.tgz",
+					"integrity": "sha512-jIwvLO0zCL+O/LmEJQjWA75MQTWwx3c3u2JOTDK5D3/9egrWRRA0/0hk9XXywYnXZVVpzrBYeIQTmhwUaePI9g==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.4.tgz",
+					"integrity": "sha512-qUzihgVPguAzXCK7WXw8pqs6cEwi54s3E+HrejlkuWO6ivMKx9hZl3Y2fSXp9i5HgyWmj7RKP+ulaYnKM4yYxw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/parser": "^7.7.4",
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/types": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
+					"integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
+			}
+		},
 		"@babel/helper-explode-assignable-expression": {
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.1.0.tgz",
@@ -674,6 +770,15 @@
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
+		"@babel/plugin-syntax-top-level-await": {
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.7.4.tgz",
+			"integrity": "sha512-wdsOw0MvkL1UIgiQ/IFr3ETcfv1xb8RMM0H9wbiDyLaJFyiDg5oZvDLCXosIXmFeIlweML5iOBXAkqddkYNizg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
 		"@babel/plugin-syntax-typescript": {
 			"version": "7.3.3",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.3.3.tgz",
@@ -983,6 +1088,15 @@
 			"requires": {
 				"@babel/helper-module-transforms": "^7.1.0",
 				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-named-capturing-groups-regex": {
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.7.4.tgz",
+			"integrity": "sha512-jBUkiqLKvUWpv9GLSuHUFYdmHg0ujC1JEYoZUfeOOfNydZXp1sXObgyPatpcwjWgsdBGsagWW0cdJpX/DO2jMw==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-create-regexp-features-plugin": "^7.7.4"
 			}
 		},
 		"@babel/plugin-transform-new-target": {
@@ -8889,6 +9003,7 @@
 			"version": "file:packages/scripts",
 			"dev": true,
 			"requires": {
+				"@babel/preset-env": "^7.7.4",
 				"@wordpress/babel-preset-default": "file:packages/babel-preset-default",
 				"@wordpress/dependency-extraction-webpack-plugin": "file:packages/dependency-extraction-webpack-plugin",
 				"@wordpress/eslint-plugin": "file:packages/eslint-plugin",
@@ -8921,6 +9036,740 @@
 				"webpack-bundle-analyzer": "^3.3.2",
 				"webpack-cli": "^3.1.2",
 				"webpack-livereload-plugin": "^2.2.0"
+			},
+			"dependencies": {
+				"@babel/generator": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.4.tgz",
+					"integrity": "sha512-m5qo2WgdOJeyYngKImbkyQrnUN1mPceaG5BV+G0E3gWsa4l/jCSryWJdM2x8OuGAOyh+3d5pVYfZWCiNFtynxg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.7.4",
+						"jsesc": "^2.5.1",
+						"lodash": "^4.17.13",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-annotate-as-pure": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.7.4.tgz",
+					"integrity": "sha512-2BQmQgECKzYKFPpiycoF9tlb5HA4lrVyAmLLVK177EcQAqjVLciUb2/R+n1boQ9y5ENV3uz2ZqiNw7QMBBw1Og==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/helper-builder-binary-assignment-operator-visitor": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.7.4.tgz",
+					"integrity": "sha512-Biq/d/WtvfftWZ9Uf39hbPBYDUo986m5Bb4zhkeYDGUllF43D+nUe5M6Vuo6/8JDK/0YX/uBdeoQpyaNhNugZQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-explode-assignable-expression": "^7.7.4",
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/helper-call-delegate": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.7.4.tgz",
+					"integrity": "sha512-8JH9/B7J7tCYJ2PpWVpw9JhPuEVHztagNVuQAFBVFYluRMlpG7F1CgKEgGeL6KFqcsIa92ZYVj6DSc0XwmN1ZA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-hoist-variables": "^7.7.4",
+						"@babel/traverse": "^7.7.4",
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/helper-explode-assignable-expression": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.7.4.tgz",
+					"integrity": "sha512-2/SicuFrNSXsZNBxe5UGdLr+HZg+raWBLE9vC98bdYOKX/U6PY0mdGlYUJdtTDPSU0Lw0PNbKKDpwYHJLn2jLg==",
+					"dev": true,
+					"requires": {
+						"@babel/traverse": "^7.7.4",
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.4.tgz",
+					"integrity": "sha512-AnkGIdiBhEuiwdoMnKm7jfPfqItZhgRaZfMg1XX3bS25INOnLPjPG1Ppnajh8eqgt5kPJnfqrRHqFqmjKDZLzQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.7.4",
+						"@babel/template": "^7.7.4",
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.4.tgz",
+					"integrity": "sha512-QTGKEdCkjgzgfJ3bAyRwF4yyT3pg+vDgan8DSivq1eS0gwi+KGKE5x8kRcbeFTb/673mkO5SN1IZfmCfA5o+EA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/helper-hoist-variables": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.7.4.tgz",
+					"integrity": "sha512-wQC4xyvc1Jo/FnLirL6CEgPgPCa8M74tOdjWpRhQYapz5JC7u3NYU1zCVoVAGCE3EaIP9T1A3iW0WLJ+reZlpQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/helper-member-expression-to-functions": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.7.4.tgz",
+					"integrity": "sha512-9KcA1X2E3OjXl/ykfMMInBK+uVdfIVakVe7W7Lg3wfXUNyS3Q1HWLFRwZIjhqiCGbslummPDnmb7vIekS0C1vw==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/helper-module-imports": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.7.4.tgz",
+					"integrity": "sha512-dGcrX6K9l8258WFjyDLJwuVKxR4XZfU0/vTUgOQYWEnRD8mgr+p4d6fCUMq/ys0h4CCt/S5JhbvtyErjWouAUQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/helper-module-transforms": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.7.4.tgz",
+					"integrity": "sha512-ehGBu4mXrhs0FxAqN8tWkzF8GSIGAiEumu4ONZ/hD9M88uHcD+Yu2ttKfOCgwzoesJOJrtQh7trI5YPbRtMmnA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-module-imports": "^7.7.4",
+						"@babel/helper-simple-access": "^7.7.4",
+						"@babel/helper-split-export-declaration": "^7.7.4",
+						"@babel/template": "^7.7.4",
+						"@babel/types": "^7.7.4",
+						"lodash": "^4.17.13"
+					}
+				},
+				"@babel/helper-optimise-call-expression": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.7.4.tgz",
+					"integrity": "sha512-VB7gWZ2fDkSuqW6b1AKXkJWO5NyNI3bFL/kK79/30moK57blr6NbH8xcl2XcKCwOmJosftWunZqfO84IGq3ZZg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/helper-remap-async-to-generator": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.7.4.tgz",
+					"integrity": "sha512-Sk4xmtVdM9sA/jCI80f+KS+Md+ZHIpjuqmYPk1M7F/upHou5e4ReYmExAiu6PVe65BhJPZA2CY9x9k4BqE5klw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-annotate-as-pure": "^7.7.4",
+						"@babel/helper-wrap-function": "^7.7.4",
+						"@babel/template": "^7.7.4",
+						"@babel/traverse": "^7.7.4",
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/helper-replace-supers": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.7.4.tgz",
+					"integrity": "sha512-pP0tfgg9hsZWo5ZboYGuBn/bbYT/hdLPVSS4NMmiRJdwWhP0IznPwN9AE1JwyGsjSPLC364I0Qh5p+EPkGPNpg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-member-expression-to-functions": "^7.7.4",
+						"@babel/helper-optimise-call-expression": "^7.7.4",
+						"@babel/traverse": "^7.7.4",
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/helper-simple-access": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.7.4.tgz",
+					"integrity": "sha512-zK7THeEXfan7UlWsG2A6CI/L9jVnI5+xxKZOdej39Y0YtDYKx9raHk5F2EtK9K8DHRTihYwg20ADt9S36GR78A==",
+					"dev": true,
+					"requires": {
+						"@babel/template": "^7.7.4",
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.4.tgz",
+					"integrity": "sha512-guAg1SXFcVr04Guk9eq0S4/rWS++sbmyqosJzVs8+1fH5NI+ZcmkaSkc7dmtAFbHFva6yRJnjW3yAcGxjueDug==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/helper-wrap-function": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.7.4.tgz",
+					"integrity": "sha512-VsfzZt6wmsocOaVU0OokwrIytHND55yvyT4BPB9AIIgwr8+x7617hetdJTsuGwygN5RC6mxA9EJztTjuwm2ofg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-function-name": "^7.7.4",
+						"@babel/template": "^7.7.4",
+						"@babel/traverse": "^7.7.4",
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.4.tgz",
+					"integrity": "sha512-jIwvLO0zCL+O/LmEJQjWA75MQTWwx3c3u2JOTDK5D3/9egrWRRA0/0hk9XXywYnXZVVpzrBYeIQTmhwUaePI9g==",
+					"dev": true
+				},
+				"@babel/plugin-proposal-async-generator-functions": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.7.4.tgz",
+					"integrity": "sha512-1ypyZvGRXriY/QP668+s8sFr2mqinhkRDMPSQLNghCQE+GAkFtp+wkHVvg2+Hdki8gwP+NFzJBJ/N1BfzCCDEw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/helper-remap-async-to-generator": "^7.7.4",
+						"@babel/plugin-syntax-async-generators": "^7.7.4"
+					}
+				},
+				"@babel/plugin-proposal-dynamic-import": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.7.4.tgz",
+					"integrity": "sha512-StH+nGAdO6qDB1l8sZ5UBV8AC3F2VW2I8Vfld73TMKyptMU9DY5YsJAS8U81+vEtxcH3Y/La0wG0btDrhpnhjQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/plugin-syntax-dynamic-import": "^7.7.4"
+					}
+				},
+				"@babel/plugin-proposal-json-strings": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.7.4.tgz",
+					"integrity": "sha512-wQvt3akcBTfLU/wYoqm/ws7YOAQKu8EVJEvHip/mzkNtjaclQoCCIqKXFP5/eyfnfbQCDV3OLRIK3mIVyXuZlw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/plugin-syntax-json-strings": "^7.7.4"
+					}
+				},
+				"@babel/plugin-proposal-object-rest-spread": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.7.4.tgz",
+					"integrity": "sha512-rnpnZR3/iWKmiQyJ3LKJpSwLDcX/nSXhdLk4Aq/tXOApIvyu7qoabrige0ylsAJffaUC51WiBu209Q0U+86OWQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/plugin-syntax-object-rest-spread": "^7.7.4"
+					}
+				},
+				"@babel/plugin-proposal-optional-catch-binding": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.7.4.tgz",
+					"integrity": "sha512-DyM7U2bnsQerCQ+sejcTNZh8KQEUuC3ufzdnVnSiUv/qoGJp2Z3hanKL18KDhsBT5Wj6a7CMT5mdyCNJsEaA9w==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/plugin-syntax-optional-catch-binding": "^7.7.4"
+					}
+				},
+				"@babel/plugin-proposal-unicode-property-regex": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.7.4.tgz",
+					"integrity": "sha512-cHgqHgYvffluZk85dJ02vloErm3Y6xtH+2noOBOJ2kXOJH3aVCDnj5eR/lVNlTnYu4hndAPJD3rTFjW3qee0PA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-create-regexp-features-plugin": "^7.7.4",
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-syntax-async-generators": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.7.4.tgz",
+					"integrity": "sha512-Li4+EjSpBgxcsmeEF8IFcfV/+yJGxHXDirDkEoyFjumuwbmfCVHUt0HuowD/iGM7OhIRyXJH9YXxqiH6N815+g==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-syntax-dynamic-import": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.7.4.tgz",
+					"integrity": "sha512-jHQW0vbRGvwQNgyVxwDh4yuXu4bH1f5/EICJLAhl1SblLs2CDhrsmCk+v5XLdE9wxtAFRyxx+P//Iw+a5L/tTg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-syntax-json-strings": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.7.4.tgz",
+					"integrity": "sha512-QpGupahTQW1mHRXddMG5srgpHWqRLwJnJZKXTigB9RPFCCGbDGCgBeM/iC82ICXp414WeYx/tD54w7M2qRqTMg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-syntax-object-rest-spread": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.7.4.tgz",
+					"integrity": "sha512-mObR+r+KZq0XhRVS2BrBKBpr5jqrqzlPvS9C9vuOf5ilSwzloAl7RPWLrgKdWS6IreaVrjHxTjtyqFiOisaCwg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-syntax-optional-catch-binding": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.7.4.tgz",
+					"integrity": "sha512-4ZSuzWgFxqHRE31Glu+fEr/MirNZOMYmD/0BhBWyLyOOQz/gTAl7QmWm2hX1QxEIXsr2vkdlwxIzTyiYRC4xcQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-arrow-functions": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.7.4.tgz",
+					"integrity": "sha512-zUXy3e8jBNPiffmqkHRNDdZM2r8DWhCB7HhcoyZjiK1TxYEluLHAvQuYnTT+ARqRpabWqy/NHkO6e3MsYB5YfA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-async-to-generator": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.7.4.tgz",
+					"integrity": "sha512-zpUTZphp5nHokuy8yLlyafxCJ0rSlFoSHypTUWgpdwoDXWQcseaect7cJ8Ppk6nunOM6+5rPMkod4OYKPR5MUg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-module-imports": "^7.7.4",
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/helper-remap-async-to-generator": "^7.7.4"
+					}
+				},
+				"@babel/plugin-transform-block-scoped-functions": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.7.4.tgz",
+					"integrity": "sha512-kqtQzwtKcpPclHYjLK//3lH8OFsCDuDJBaFhVwf8kqdnF6MN4l618UDlcA7TfRs3FayrHj+svYnSX8MC9zmUyQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-block-scoping": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.7.4.tgz",
+					"integrity": "sha512-2VBe9u0G+fDt9B5OV5DQH4KBf5DoiNkwFKOz0TCvBWvdAN2rOykCTkrL+jTLxfCAm76l9Qo5OqL7HBOx2dWggg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"lodash": "^4.17.13"
+					}
+				},
+				"@babel/plugin-transform-classes": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.7.4.tgz",
+					"integrity": "sha512-sK1mjWat7K+buWRuImEzjNf68qrKcrddtpQo3swi9j7dUcG6y6R6+Di039QN2bD1dykeswlagupEmpOatFHHUg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-annotate-as-pure": "^7.7.4",
+						"@babel/helper-define-map": "^7.7.4",
+						"@babel/helper-function-name": "^7.7.4",
+						"@babel/helper-optimise-call-expression": "^7.7.4",
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/helper-replace-supers": "^7.7.4",
+						"@babel/helper-split-export-declaration": "^7.7.4",
+						"globals": "^11.1.0"
+					}
+				},
+				"@babel/plugin-transform-computed-properties": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.7.4.tgz",
+					"integrity": "sha512-bSNsOsZnlpLLyQew35rl4Fma3yKWqK3ImWMSC/Nc+6nGjC9s5NFWAer1YQ899/6s9HxO2zQC1WoFNfkOqRkqRQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-destructuring": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.7.4.tgz",
+					"integrity": "sha512-4jFMXI1Cu2aXbcXXl8Lr6YubCn6Oc7k9lLsu8v61TZh+1jny2BWmdtvY9zSUlLdGUvcy9DMAWyZEOqjsbeg/wA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-dotall-regex": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.7.4.tgz",
+					"integrity": "sha512-mk0cH1zyMa/XHeb6LOTXTbG7uIJ8Rrjlzu91pUx/KS3JpcgaTDwMS8kM+ar8SLOvlL2Lofi4CGBAjCo3a2x+lw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-create-regexp-features-plugin": "^7.7.4",
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-duplicate-keys": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.7.4.tgz",
+					"integrity": "sha512-g1y4/G6xGWMD85Tlft5XedGaZBCIVN+/P0bs6eabmcPP9egFleMAo65OOjlhcz1njpwagyY3t0nsQC9oTFegJA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-exponentiation-operator": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.7.4.tgz",
+					"integrity": "sha512-MCqiLfCKm6KEA1dglf6Uqq1ElDIZwFuzz1WH5mTf8k2uQSxEJMbOIEh7IZv7uichr7PMfi5YVSrr1vz+ipp7AQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-builder-binary-assignment-operator-visitor": "^7.7.4",
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-for-of": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.7.4.tgz",
+					"integrity": "sha512-zZ1fD1B8keYtEcKF+M1TROfeHTKnijcVQm0yO/Yu1f7qoDoxEIc/+GX6Go430Bg84eM/xwPFp0+h4EbZg7epAA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-function-name": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.7.4.tgz",
+					"integrity": "sha512-E/x09TvjHNhsULs2IusN+aJNRV5zKwxu1cpirZyRPw+FyyIKEHPXTsadj48bVpc1R5Qq1B5ZkzumuFLytnbT6g==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-function-name": "^7.7.4",
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-literals": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.7.4.tgz",
+					"integrity": "sha512-X2MSV7LfJFm4aZfxd0yLVFrEXAgPqYoDG53Br/tCKiKYfX0MjVjQeWPIhPHHsCqzwQANq+FLN786fF5rgLS+gw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-member-expression-literals": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.7.4.tgz",
+					"integrity": "sha512-9VMwMO7i69LHTesL0RdGy93JU6a+qOPuvB4F4d0kR0zyVjJRVJRaoaGjhtki6SzQUu8yen/vxPKN6CWnCUw6bA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-modules-amd": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.7.4.tgz",
+					"integrity": "sha512-/542/5LNA18YDtg1F+QHvvUSlxdvjZoD/aldQwkq+E3WCkbEjNSN9zdrOXaSlfg3IfGi22ijzecklF/A7kVZFQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-module-transforms": "^7.7.4",
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"babel-plugin-dynamic-import-node": "^2.3.0"
+					}
+				},
+				"@babel/plugin-transform-modules-commonjs": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.7.4.tgz",
+					"integrity": "sha512-k8iVS7Jhc367IcNF53KCwIXtKAH7czev866ThsTgy8CwlXjnKZna2VHwChglzLleYrcHz1eQEIJlGRQxB53nqA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-module-transforms": "^7.7.4",
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/helper-simple-access": "^7.7.4",
+						"babel-plugin-dynamic-import-node": "^2.3.0"
+					}
+				},
+				"@babel/plugin-transform-modules-systemjs": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.7.4.tgz",
+					"integrity": "sha512-y2c96hmcsUi6LrMqvmNDPBBiGCiQu0aYqpHatVVu6kD4mFEXKjyNxd/drc18XXAf9dv7UXjrZwBVmTTGaGP8iw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-hoist-variables": "^7.7.4",
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"babel-plugin-dynamic-import-node": "^2.3.0"
+					}
+				},
+				"@babel/plugin-transform-modules-umd": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.7.4.tgz",
+					"integrity": "sha512-u2B8TIi0qZI4j8q4C51ktfO7E3cQ0qnaXFI1/OXITordD40tt17g/sXqgNNCcMTcBFKrUPcGDx+TBJuZxLx7tw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-module-transforms": "^7.7.4",
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-new-target": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.7.4.tgz",
+					"integrity": "sha512-CnPRiNtOG1vRodnsyGX37bHQleHE14B9dnnlgSeEs3ek3fHN1A1SScglTCg1sfbe7sRQ2BUcpgpTpWSfMKz3gg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-object-super": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.7.4.tgz",
+					"integrity": "sha512-ho+dAEhC2aRnff2JCA0SAK7V2R62zJd/7dmtoe7MHcso4C2mS+vZjn1Pb1pCVZvJs1mgsvv5+7sT+m3Bysb6eg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/helper-replace-supers": "^7.7.4"
+					}
+				},
+				"@babel/plugin-transform-parameters": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.7.4.tgz",
+					"integrity": "sha512-VJwhVePWPa0DqE9vcfptaJSzNDKrWU/4FbYCjZERtmqEs05g3UMXnYMZoXja7JAJ7Y7sPZipwm/pGApZt7wHlw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-call-delegate": "^7.7.4",
+						"@babel/helper-get-function-arity": "^7.7.4",
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-property-literals": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.7.4.tgz",
+					"integrity": "sha512-MatJhlC4iHsIskWYyawl53KuHrt+kALSADLQQ/HkhTjX954fkxIEh4q5slL4oRAnsm/eDoZ4q0CIZpcqBuxhJQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-regenerator": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.7.4.tgz",
+					"integrity": "sha512-e7MWl5UJvmPEwFJTwkBlPmqixCtr9yAASBqff4ggXTNicZiwbF8Eefzm6NVgfiBp7JdAGItecnctKTgH44q2Jw==",
+					"dev": true,
+					"requires": {
+						"regenerator-transform": "^0.14.0"
+					}
+				},
+				"@babel/plugin-transform-reserved-words": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.7.4.tgz",
+					"integrity": "sha512-OrPiUB5s5XvkCO1lS7D8ZtHcswIC57j62acAnJZKqGGnHP+TIc/ljQSrgdX/QyOTdEK5COAhuc820Hi1q2UgLQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-shorthand-properties": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.7.4.tgz",
+					"integrity": "sha512-q+suddWRfIcnyG5YiDP58sT65AJDZSUhXQDZE3r04AuqD6d/XLaQPPXSBzP2zGerkgBivqtQm9XKGLuHqBID6Q==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-spread": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.7.4.tgz",
+					"integrity": "sha512-8OSs0FLe5/80cndziPlg4R0K6HcWSM0zyNhHhLsmw/Nc5MaA49cAsnoJ/t/YZf8qkG7fD+UjTRaApVDB526d7Q==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-sticky-regex": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.7.4.tgz",
+					"integrity": "sha512-Ls2NASyL6qtVe1H1hXts9yuEeONV2TJZmplLONkMPUG158CtmnrzW5Q5teibM5UVOFjG0D3IC5mzXR6pPpUY7A==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/helper-regex": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-template-literals": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.7.4.tgz",
+					"integrity": "sha512-sA+KxLwF3QwGj5abMHkHgshp9+rRz+oY9uoRil4CyLtgEuE/88dpkeWgNk5qKVsJE9iSfly3nvHapdRiIS2wnQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-annotate-as-pure": "^7.7.4",
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-typeof-symbol": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.7.4.tgz",
+					"integrity": "sha512-KQPUQ/7mqe2m0B8VecdyaW5XcQYaePyl9R7IsKd+irzj6jvbhoGnRE+M0aNkyAzI07VfUQ9266L5xMARitV3wg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-unicode-regex": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.7.4.tgz",
+					"integrity": "sha512-N77UUIV+WCvE+5yHw+oks3m18/umd7y392Zv7mYTpFqHtkpcc+QUz+gLJNTWVlWROIWeLqY0f3OjZxV5TcXnRw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-create-regexp-features-plugin": "^7.7.4",
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/preset-env": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.7.4.tgz",
+					"integrity": "sha512-Dg+ciGJjwvC1NIe/DGblMbcGq1HOtKbw8RLl4nIjlfcILKEOkWT/vRqPpumswABEBVudii6dnVwrBtzD7ibm4g==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-module-imports": "^7.7.4",
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/plugin-proposal-async-generator-functions": "^7.7.4",
+						"@babel/plugin-proposal-dynamic-import": "^7.7.4",
+						"@babel/plugin-proposal-json-strings": "^7.7.4",
+						"@babel/plugin-proposal-object-rest-spread": "^7.7.4",
+						"@babel/plugin-proposal-optional-catch-binding": "^7.7.4",
+						"@babel/plugin-proposal-unicode-property-regex": "^7.7.4",
+						"@babel/plugin-syntax-async-generators": "^7.7.4",
+						"@babel/plugin-syntax-dynamic-import": "^7.7.4",
+						"@babel/plugin-syntax-json-strings": "^7.7.4",
+						"@babel/plugin-syntax-object-rest-spread": "^7.7.4",
+						"@babel/plugin-syntax-optional-catch-binding": "^7.7.4",
+						"@babel/plugin-syntax-top-level-await": "^7.7.4",
+						"@babel/plugin-transform-arrow-functions": "^7.7.4",
+						"@babel/plugin-transform-async-to-generator": "^7.7.4",
+						"@babel/plugin-transform-block-scoped-functions": "^7.7.4",
+						"@babel/plugin-transform-block-scoping": "^7.7.4",
+						"@babel/plugin-transform-classes": "^7.7.4",
+						"@babel/plugin-transform-computed-properties": "^7.7.4",
+						"@babel/plugin-transform-destructuring": "^7.7.4",
+						"@babel/plugin-transform-dotall-regex": "^7.7.4",
+						"@babel/plugin-transform-duplicate-keys": "^7.7.4",
+						"@babel/plugin-transform-exponentiation-operator": "^7.7.4",
+						"@babel/plugin-transform-for-of": "^7.7.4",
+						"@babel/plugin-transform-function-name": "^7.7.4",
+						"@babel/plugin-transform-literals": "^7.7.4",
+						"@babel/plugin-transform-member-expression-literals": "^7.7.4",
+						"@babel/plugin-transform-modules-amd": "^7.7.4",
+						"@babel/plugin-transform-modules-commonjs": "^7.7.4",
+						"@babel/plugin-transform-modules-systemjs": "^7.7.4",
+						"@babel/plugin-transform-modules-umd": "^7.7.4",
+						"@babel/plugin-transform-named-capturing-groups-regex": "^7.7.4",
+						"@babel/plugin-transform-new-target": "^7.7.4",
+						"@babel/plugin-transform-object-super": "^7.7.4",
+						"@babel/plugin-transform-parameters": "^7.7.4",
+						"@babel/plugin-transform-property-literals": "^7.7.4",
+						"@babel/plugin-transform-regenerator": "^7.7.4",
+						"@babel/plugin-transform-reserved-words": "^7.7.4",
+						"@babel/plugin-transform-shorthand-properties": "^7.7.4",
+						"@babel/plugin-transform-spread": "^7.7.4",
+						"@babel/plugin-transform-sticky-regex": "^7.7.4",
+						"@babel/plugin-transform-template-literals": "^7.7.4",
+						"@babel/plugin-transform-typeof-symbol": "^7.7.4",
+						"@babel/plugin-transform-unicode-regex": "^7.7.4",
+						"@babel/types": "^7.7.4",
+						"browserslist": "^4.6.0",
+						"core-js-compat": "^3.1.1",
+						"invariant": "^2.2.2",
+						"js-levenshtein": "^1.1.3",
+						"semver": "^5.5.0"
+					}
+				},
+				"@babel/template": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.4.tgz",
+					"integrity": "sha512-qUzihgVPguAzXCK7WXw8pqs6cEwi54s3E+HrejlkuWO6ivMKx9hZl3Y2fSXp9i5HgyWmj7RKP+ulaYnKM4yYxw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/parser": "^7.7.4",
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.4.tgz",
+					"integrity": "sha512-P1L58hQyupn8+ezVA2z5KBm4/Zr4lCC8dwKCMYzsa5jFMDMQAzaBNy9W5VjB+KAmBjb40U7a/H6ao+Xo+9saIw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.5.5",
+						"@babel/generator": "^7.7.4",
+						"@babel/helper-function-name": "^7.7.4",
+						"@babel/helper-split-export-declaration": "^7.7.4",
+						"@babel/parser": "^7.7.4",
+						"@babel/types": "^7.7.4",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.13"
+					},
+					"dependencies": {
+						"@babel/code-frame": {
+							"version": "7.5.5",
+							"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
+							"integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+							"dev": true,
+							"requires": {
+								"@babel/highlight": "^7.0.0"
+							}
+						}
+					}
+				},
+				"@babel/types": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
+					"integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"globals": {
+					"version": "11.12.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+					"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+					"dev": true
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
+				},
+				"regenerator-transform": {
+					"version": "0.14.1",
+					"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.1.tgz",
+					"integrity": "sha512-flVuee02C3FKRISbxhXl9mGzdbWUVHubl1SMaknjxkFB1/iqpJhArQUvRxOOPEc/9tAiX0BaQ28FJH10E4isSQ==",
+					"dev": true,
+					"requires": {
+						"private": "^0.1.6"
+					}
+				},
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+					"dev": true
+				}
 			}
 		},
 		"@wordpress/server-side-render": {

--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -81,13 +81,41 @@ const config = {
 										[
 											require.resolve( '@babel/preset-env' ),
 											{
+
+												// don't transform import statements so webpack can perform treeshaking
 												modules: false,
+
+												useBuiltIns: 'entry',
+												corejs: 3,
+
+												// perform the minimum transforms for the targetted platforms
 												targets: {
 													node: mode === 'development' ? 'current' : undefined,
 													browsers: mode === 'production' ? require( '@wordpress/browserslist-config' ) : undefined,
 												},
+
+												// Exclude transforms that make all code slower, see https://github.com/facebook/create-react-app/pull/5278
+												exclude: [ 'transform-typeof-symbol' ],
+
 											},
 										],
+									],
+									plugins: [
+
+										// avoid duplication of helper functions by relying on a runtime
+										[
+											require.resolve( '@babel/plugin-transform-runtime' ),
+											{
+												corejs: false,
+												helpers: true,
+												regenerator: true,
+												useESModules: true,
+											},
+										],
+
+										// support use of dynamic import()s
+										require.resolve( '@babel/plugin-syntax-dynamic-import' ),
+
 									],
 									sourceMaps: true,
 									inputSourceMap: true,

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -32,7 +32,10 @@
 		"wp-scripts": "./bin/wp-scripts.js"
 	},
 	"dependencies": {
+		"@babel/plugin-syntax-dynamic-import": "^7.7.4",
+		"@babel/plugin-transform-runtime": "^7.7.4",
 		"@babel/preset-env": "^7.7.4",
+		"@babel/runtime": "^7.7.4",
 		"@wordpress/babel-preset-default": "file:../babel-preset-default",
 		"@wordpress/browserslist-config": "file:../browserslist-config",
 		"@wordpress/dependency-extraction-webpack-plugin": "file:../dependency-extraction-webpack-plugin",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -32,7 +32,9 @@
 		"wp-scripts": "./bin/wp-scripts.js"
 	},
 	"dependencies": {
+		"@babel/preset-env": "^7.7.4",
 		"@wordpress/babel-preset-default": "file:../babel-preset-default",
+		"@wordpress/browserslist-config": "file:../browserslist-config",
 		"@wordpress/dependency-extraction-webpack-plugin": "file:../dependency-extraction-webpack-plugin",
 		"@wordpress/eslint-plugin": "file:../eslint-plugin",
 		"@wordpress/jest-preset-default": "file:../jest-preset-default",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -54,7 +54,7 @@ module.exports = {
 			},
 			{
 				test: /\.js$/,
-				include: /node_modules/,
+				include: [],
 				exclude: /@babel(?:\/|\\{1,2})runtime/,
 				use: [
 					require.resolve( 'thread-loader' ),


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

I've modified `wp-scripts` to transpile modules imported from `node_modules` because a significant number of packages are transpiling down to the current JS standard instead of transpiling down to ES5. Importing these packages into an application built with `wp-scripts` breaks older browsers which are still supported by WordPress e.g. IE11.

This problem arises with many of [`sindresorhus`' packages where he primarily targets NodeJS](https://github.com/sindresorhus/ama/issues/446) as encountered [here](https://github.com/WordPress/gutenberg/pull/17963#discussion_r349374328).

[Create React App](https://github.com/facebook/create-react-app/issues/1125) and Parcel have already implemented similar solutions.

Aside: [There appears to be a broader effort](https://twitter.com/_developit/status/1196393947989512193) to solve the problems around dependencies and their targeted runtimes that doesn't affect bundle size like transpiling down to the lowest common denominator (ES5) does.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

I created a new `wp-scripts` app, imported `hex-rgb` and checked the build output for `let` and `const`.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

No external changes.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
