### PR TITLE
[RNMobile] Merge mobile release v1.18.0 back into master

### DIFF
--- a/packages/block-editor/src/components/caption/index.native.js
+++ b/packages/block-editor/src/components/caption/index.native.js
@@ -29,7 +29,7 @@ const Caption = ( { accessible, accessibilityLabel, onBlur, onChange, onFocus, i
 			fontSize={ 14 }
 			underlineColorAndroid="transparent"
 			textAlign={ 'center' }
-			tagName={ '' }
+			tagName={ 'p' }
 		/>
 	</View>
 );

--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -136,7 +136,7 @@ export class ImageEdit extends React.Component {
 	componentDidUpdate( previousProps ) {
 		if ( ! previousProps.image && this.props.image ) {
 			const { image, attributes } = this.props;
-			const url = getUrlForSlug( image, attributes );
+			const url = getUrlForSlug( image, attributes ) || image.source_url;
 			this.props.setAttributes( { url } );
 		}
 	}

--- a/packages/block-library/src/index.native.js
+++ b/packages/block-library/src/index.native.js
@@ -150,8 +150,7 @@ export const registerCoreBlocks = () => {
 		( ( Platform.OS === 'ios' ) || ( !! __DEV__ ) ) ? preformatted : null,
 		// eslint-disable-next-line no-undef
 		!! __DEV__ ? group : null,
-		// eslint-disable-next-line no-undef
-		!! __DEV__ ? spacer : null,
+		spacer,
 	].forEach( registerBlock );
 
 	setDefaultBlockName( paragraph.name );


### PR DESCRIPTION
## Description

Related PR in gutenberg-mobile: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1627

Details:
- Enable Spacer block in production #1594
- Fix an alignment issue with Image caption

## How has this been tested?

This should be tested in this gutenberg-mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1627 and in the apps directly.

## Types of changes

No new changes, everything was introduced in separate PRs already.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
