### PR TITLE
Edit Post: Fix sidebar scroll overflow.

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -12,6 +12,7 @@ $z-layers: (
 	".components-form-toggle__input": 1,
 	".components-panel__header.edit-post-sidebar__panel-tabs": -1,
 	".edit-post-sidebar .components-panel": -2,
+	".edit-post-sidebar-header__container": 1,
 	".block-editor-inserter__tabs": 1,
 	".block-editor-inserter__tab.is-active": 1,
 	".components-panel__header": 1,

--- a/packages/components/src/panel/style.scss
+++ b/packages/components/src/panel/style.scss
@@ -42,6 +42,7 @@
 	height: 50px;
 	border-top: $border-width solid $light-gray-500;
 	border-bottom: $border-width solid $light-gray-500;
+	z-index: z-index(".components-panel__header");
 
 	h2 {
 		margin: 0;

--- a/packages/components/src/panel/style.scss
+++ b/packages/components/src/panel/style.scss
@@ -42,7 +42,6 @@
 	height: 50px;
 	border-top: $border-width solid $light-gray-500;
 	border-bottom: $border-width solid $light-gray-500;
-	z-index: z-index(".components-panel__header");
 
 	h2 {
 		margin: 0;

--- a/packages/edit-post/src/components/editor-regions/style.scss
+++ b/packages/edit-post/src/components/editor-regions/style.scss
@@ -83,6 +83,7 @@ html {
 	bottom: 0;
 	left: 0;
 	background: $white;
+	overflow: auto;
 
 	&:empty {
 		display: none;

--- a/packages/edit-post/src/components/sidebar/sidebar-header/index.js
+++ b/packages/edit-post/src/components/sidebar/sidebar-header/index.js
@@ -18,7 +18,7 @@ const SidebarHeader = ( { children, className, closeLabel } ) => {
 	const { closeGeneralSidebar } = useDispatch( 'core/edit-post' );
 
 	return (
-		<>
+		<div className="edit-post-sidebar-header__container">
 			<div className="components-panel__header edit-post-sidebar-header__small">
 				<span className="edit-post-sidebar-header__title">
 					{ title || __( '(no title)' ) }
@@ -38,7 +38,7 @@ const SidebarHeader = ( { children, className, closeLabel } ) => {
 					shortcut={ shortcut }
 				/>
 			</div>
-		</>
+		</div>
 	);
 };
 

--- a/packages/edit-post/src/components/sidebar/sidebar-header/style.scss
+++ b/packages/edit-post/src/components/sidebar/sidebar-header/style.scss
@@ -39,5 +39,5 @@
 	flex-direction: column;
 	position: sticky;
 	top: 0;
-	z-index: z-index(".components-panel__header");
+	z-index: z-index(".edit-post-sidebar-header__container");
 }

--- a/packages/edit-post/src/components/sidebar/sidebar-header/style.scss
+++ b/packages/edit-post/src/components/sidebar/sidebar-header/style.scss
@@ -33,3 +33,11 @@
 		}
 	}
 }
+
+.edit-post-sidebar-header__container {
+	display: flex;
+	flex-direction: column;
+	position: sticky;
+	top: 0;
+	z-index: z-index(".components-panel__header");
+}


### PR DESCRIPTION
## Description

A combination of #17926 and #18044 broke the block inspector controls sidebar scrolling behavior. The sidebar content covered the header when scrolling and on mobile it did not scroll at all.

This PR fixes the issues.

## How to test this?

Check that scrolling the sidebar works as expected on all screen sizes and that the header sticks to the top like it should.

## Types of Changes

*Bug Fix:* Fix sidebar scroll overflow issues.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
