### PR TITLE
Fix alignment of ToggleControl label by removing inherited line-height

### DIFF
--- a/packages/components/src/toggle-control/style.scss
+++ b/packages/components/src/toggle-control/style.scss
@@ -2,6 +2,7 @@
 	display: flex;
 	margin-bottom: $grid-size-small * 3;
 	line-height: initial;
+	align-items: center;
 
 	.components-form-toggle {
 		margin-right: $grid-size-large;
@@ -9,6 +10,5 @@
 
 	.components-toggle-control__label {
 		display: block;
-		margin-bottom: 4px;
 	}
 }

--- a/packages/components/src/toggle-control/style.scss
+++ b/packages/components/src/toggle-control/style.scss
@@ -1,6 +1,7 @@
 .components-toggle-control .components-base-control__field {
 	display: flex;
 	margin-bottom: $grid-size-small * 3;
+	line-height: initial;
 
 	.components-form-toggle {
 		margin-right: $grid-size-large;


### PR DESCRIPTION
## Description

As noted in #17127, the alignment of the ToggleControl label is incorrect if used used outside of an InspectorControls element. This is due to the component inheriting a different line height from `.editor-styles-wrapper`. This introduces a minor css change to prevent the toggle element inheriting the line height.

## How has this been tested?

Visually tested in browser - see screenshots below.

## Screenshots 

Before:

<img width="741" alt="toggle2-before" src="https://user-images.githubusercontent.com/3629020/69918165-77df4f80-14d3-11ea-915e-3a05e0758b81.png">

After:

<img width="743" alt="toggle2-after" src="https://user-images.githubusercontent.com/3629020/69918162-71e96e80-14d3-11ea-82cc-df3c493110dd.png">

Multi line label before:

<img width="742" alt="multi-line-before" src="https://user-images.githubusercontent.com/3629020/69918103-d821c180-14d2-11ea-81ce-7eca78efe37e.png">

Multi line label after:

<img width="741" alt="multiline-after" src="https://user-images.githubusercontent.com/3629020/69918107-dfe16600-14d2-11ea-815f-dd89f8b9b3a5.png">

Fixes #17127

