### PR TITLE
Expose gradient presets through the REST API

### DIFF
--- a/lib/class-wp-rest-themes-controller-overrides.php
+++ b/lib/class-wp-rest-themes-controller-overrides.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * Overrides for the existing themes endpoint in Core
+ */
+class WP_REST_Themes_Controller_Overrides extends WP_REST_Themes_Controller {
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_items' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+					'args'                => $this->get_collection_params(),
+				),
+				'schema' => array( $this, 'get_item_schema' ),
+			),
+			true
+		);
+	}
+
+	public function get_item_schema() {
+		$schema = parent::get_item_schema();
+		$existing_properties = $schema['properties']['theme_supports']['properties'];
+		$overrides = array(
+			'__experimental-editor-gradient-presets' => array(
+				'description' => __( 'Whether the theme supports a custom color scheme.' ),
+				'type'        => array( 'array', 'bool' ),
+				'items'       => [
+					'type'       => 'object',
+					'properties' => array(
+						'name'  => 'string',
+						'gradient'  => 'string',
+						'color' => 'string,'
+					),
+					'required'   => [ 'name', 'gradient', 'color' ],
+				],
+				'readonly'    => true,
+			),
+		);
+		$schema['properties']['theme_supports']['properties'] = array_merge( $existing_properties, $overrides );
+		return $schema;
+	}
+
+	public function prepare_item_for_response( $theme, $request ) {
+		$response = parent::prepare_item_for_response( $theme, $request );
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$gradient_presets = get_theme_support( '__experimental-editor-gradient-presets' );
+		$response->data['theme_supports']['__experimental-editor-gradient-presets'] = $gradient_presets;
+
+		return $response;
+	}
+}

--- a/lib/load.php
+++ b/lib/load.php
@@ -42,6 +42,9 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	/**
 	* End: Include for phase 2
 	*/
+	if ( class_exists( 'WP_REST_Themes_Controller' ) ) {
+		require dirname( __FILE__ ) . '/class-wp-rest-themes-controller-overrides.php';
+	}
 
 	require dirname( __FILE__ ) . '/rest-api.php';
 }

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -93,3 +93,9 @@ function gutenberg_register_rest_block_directory() {
 	$block_directory_controller->register_routes();
 }
 add_filter( 'rest_api_init', 'gutenberg_register_rest_block_directory' );
+
+function gutenberg_override_rest_endpoints() {
+	$themes_controller = new WP_REST_Themes_Controller_Overrides();
+	$themes_controller->register_routes();
+}
+add_filter( 'rest_api_init', 'gutenberg_override_rest_endpoints' );


### PR DESCRIPTION
## Description

This adds the new `editor-gradient-presets` theme support to the `wp/v2/themes` endpoint response, similar to the one for colors in https://core.trac.wordpress.org/ticket/48798. This should become part of that endpoint when the gradients work graduates from experimental and lands in core.

I haven't done a lot of PHP recently so, while this is working, I'd appreciate some feedback on best practices there.

## How has this been tested?

I've edited the theme to add support for custom presets:

```php
add_theme_support(
	'__experimental-editor-gradient-presets',
	array(
		array(
			'name' => 'Blue Sky',
			'gradient' => 'linear-gradient(0deg,#56CCF2 0%,#2F80ED 100%)',
			'slug' => 'bluesky',
		),
	)
);
```

Then verified that the presets are exposed in the endpoint:

```
$ curl -su admin:password 'http://localhost:8889/wp-json/wp/v2/themes/?status=active&pretty' | jq .
[
  {
    "theme_supports": {
      "formats": [
        "standard"
      ],
      "post-thumbnails": true,
      "responsive-embeds": false,
      "__experimental-editor-gradient-presets": [
        [
          {
            "name": "Blue Sky",
            "gradient": "linear-gradient(0deg,#56CCF2 0%,#2F80ED 100%)",
            "slug": "bluesky"
          }
        ]
      ]
    }
  }
]
```

When the theme doesn't register custom gradients, it returns `false`:

```
$ curl -su admin:password 'http://localhost:8889/wp-json/wp/v2/themes/?status=active&pretty' | jq .
[
  {
    "theme_supports": {
      "formats": [
        "standard"
      ],
      "post-thumbnails": true,
      "responsive-embeds": false,
      "__experimental-editor-gradient-presets": false
    }
  }
]
```

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Checklist:
- [x] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
