### PR TITLE
Custom Select: Change prop names to align better with other components.

### DIFF
--- a/packages/components/src/custom-select/index.js
+++ b/packages/components/src/custom-select/index.js
@@ -18,18 +18,6 @@ const stateReducer = (
 	{ selectedItem },
 	{ type, changes, props: { items } }
 ) => {
-	// TODO: Remove this.
-	// eslint-disable-next-line no-console
-	console.debug(
-		'Selected Item: ',
-		selectedItem,
-		'Type: ',
-		type,
-		'Changes: ',
-		changes,
-		'Items: ',
-		items
-	);
 	switch ( type ) {
 		case useSelect.stateChangeTypes.ToggleButtonKeyDownArrowDown:
 			// If we already have a selected item, try to select the next one,
@@ -61,9 +49,9 @@ export default function CustomSelect( {
 	className,
 	hideLabelFromVision,
 	label,
-	items,
-	onSelectedItemChange,
-	selectedItem: _selectedItem,
+	options: items,
+	onChange: onSelectedItemChange,
+	value: _selectedItem,
 } ) {
 	const {
 		getLabelProps,

--- a/packages/components/src/custom-select/stories/index.js
+++ b/packages/components/src/custom-select/stories/index.js
@@ -5,7 +5,7 @@ import CustomSelect from '../';
 
 export default { title: 'CustomSelect', component: CustomSelect };
 
-const items = [
+const options = [
 	{
 		key: 'small',
 		name: 'Small',
@@ -27,4 +27,6 @@ const items = [
 		style: { fontSize: '300%' },
 	},
 ];
-export const _default = () => <CustomSelect label="Font Size" items={ items } />;
+export const _default = () => (
+	<CustomSelect label="Font Size" options={ options } />
+);

--- a/packages/components/src/font-size-picker/index.js
+++ b/packages/components/src/font-size-picker/index.js
@@ -70,7 +70,7 @@ function FontSizePicker( {
 		setCurrentSelectValue( getSelectValueFromFontSize( fontSizes, sliderValue ) );
 	};
 
-	const items = getSelectOptions( fontSizes, disableCustomFontSizes );
+	const options = getSelectOptions( fontSizes, disableCustomFontSizes );
 	const rangeControlNumberId = `components-range-control__number#${ instanceId }`;
 	return (
 		<fieldset className="components-font-size-picker">
@@ -78,15 +78,18 @@ function FontSizePicker( {
 				{ __( 'Font Size' ) }
 			</legend>
 			<div className="components-font-size-picker__controls">
-				{ ( fontSizes.length > 0 ) &&
+				{ fontSizes.length > 0 && (
 					<CustomSelect
 						className={ 'components-font-size-picker__select' }
 						label={ __( 'Preset Size' ) }
-						items={ items }
-						selectedItem={ items.find( ( item ) => item.key === currentSelectValue ) || items[ 0 ] }
-						onSelectedItemChange={ onSelectChangeValue }
+						options={ options }
+						value={
+							options.find( ( option ) => option.key === currentSelectValue ) ||
+							options[ 0 ]
+						}
+						onChange={ onSelectChangeValue }
 					/>
-				}
+				) }
 				{ ( ! withSlider && ! disableCustomFontSizes ) &&
 					<div className="components-range-control__number-container">
 						<label htmlFor={ rangeControlNumberId }>{ __( 'Custom' ) }</label>


### PR DESCRIPTION
## Description

This PR tweaks the new `CustomSelect` component introduced in #17926 to better align its prop names with already existing components.

Relevant discussion: https://github.com/WordPress/gutenberg/pull/17926#discussion_r351895373.

## How has this been tested?

It was verified that the font size picker and the storybook for the component still work as expected.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
