### PR TITLE
Add changelog.txt and readme.txt to GitHub repository

### DIFF
--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -120,6 +120,8 @@ zip -r gutenberg.zip \
 	post-content.php \
 	$vendor_scripts \
 	$build_files \
+	readme.txt \
+	changelog.txt \
 	README.md
 
 # Reset `gutenberg.php`.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,0 +1,5800 @@
+== Changelog ==
+
+= 7.0.0 =
+
+### Features
+
+*   Add a new Navigation block (previously available as an experiment)
+    *   [Highlight menu items](https://github.com/WordPress/gutenberg/pull/18435) without defined URL.
+    *   Prevent [error in Firefox](https://github.com/WordPress/gutenberg/pull/18455) when removing the block.
+    *   [Remove background color](https://github.com/WordPress/gutenberg/pull/18407) from the Navigation block and rely on the Group block.
+    *   Remove the [background shadow](https://github.com/WordPress/gutenberg/pull/18485) for the submenus dropdown.
+    *   [Rename "Navigation Menu Item"](https://github.com/WordPress/gutenberg/pull/18422https://github.com/WordPress/gutenberg/pull/18422) block to "Link".
+    *   Remove [unnecessary color attributes](https://github.com/WordPress/gutenberg/pull/18540).
+    *   Allow [addition CSS](https://github.com/WordPress/gutenberg/pull/18466) [classes](https://github.com/WordPress/gutenberg/pull/18629).
+    *   Drop the [“menu” suffix from the block name](https://github.com/WordPress/gutenberg/pull/18551).
+    *   [Escape special](https://github.com/WordPress/gutenberg/pull/18607) [characters](https://github.com/WordPress/gutenberg/pull/18617) in the frontend.
+    *   Remove from [experimental features](https://github.com/WordPress/gutenberg/pull/18594).
+    *   Add [style variations](https://github.com/WordPress/gutenberg/pull/18553).
+
+### Enhancements
+
+*   Use [gradient classnames](https://github.com/WordPress/gutenberg/pull/18590) instead of inline styles for the Cover block.
+*   Inserter: Add [keyboard shortcut styling](https://github.com/WordPress/gutenberg/pull/18623) to "/" in the default tip.
+*   [Restore the caret position](https://github.com/WordPress/gutenberg/pull/17824) properly on undo.
+*   Add keywords to improve the [discoverability of the Audio block](https://github.com/WordPress/gutenberg/pull/18673).
+*   Show [video preview on Cover block](https://github.com/WordPress/gutenberg/pull/18009) inspector panel.
+
+### Bug Fixes
+
+*   Fix [hidden nested images](https://github.com/WordPress/gutenberg/pull/18347) in the content column.
+*   Fix [double border issue](https://github.com/WordPress/gutenberg/pull/18358) in the keyboard shortcuts modal.
+*   Fix [off-centered publish button](https://github.com/WordPress/gutenberg/pull/17726).
+*   Fix [error when isRTL config is not provided](https://github.com/WordPress/gutenberg/pull/18526) in the block editor settings.
+*   Fix [full width Table block](https://github.com/WordPress/gutenberg/pull/18469) mobile regression.
+*   A11y: Add a screen reader text [label for the Search block](https://github.com/WordPress/gutenberg/pull/17983).
+*   Fix [text patterns undo](https://github.com/WordPress/gutenberg/pull/18533) after mouse move.
+*   Fix block [drag and drop for the  contributor role](https://github.com/WordPress/gutenberg/pull/15054).
+*   [Update the link when switching the image used](https://github.com/WordPress/gutenberg/pull/17226) in the Image block.
+*   Fix php [error triggered when **gutenberg_register_packages_scripts**](https://github.com/WordPress/gutenberg/pull/18599) is run more than once.
+*   Fix special characters [escaping for the post title](https://github.com/WordPress/gutenberg/pull/18616).
+*   Fix [JavaScript errors triggered when selectors are called](https://github.com/WordPress/gutenberg/pull/18559) before the editor being initialized.
+*   Fix [BaseControl component label](https://github.com/WordPress/gutenberg/pull/18646) when no id is passed.
+*   [Preserve whitespace](https://github.com/WordPress/gutenberg/pull/18656) when converting blocks Preformatted and Paragraph blocks.
+*   Fix [multiple paste issues](https://github.com/WordPress/gutenberg/pull/17470) creating unnecessary empty spaces.
+
+### New APIs
+
+*   Add a new [Card component](https://github.com/WordPress/gutenberg/pull/17963) [to](https://github.com/WordPress/gutenberg/pull/18681) @wordpress/components.
+*   Add [label support for the URLInput](https://github.com/WordPress/gutenberg/pull/15669) [component](https://github.com/WordPress/gutenberg/pull/18488).
+*   Support the [isMatch option for the shorcode transforms](https://github.com/WordPress/gutenberg/pull/18459).
+
+### Experiments
+
+*   Block Content areas:
+    *   Add [Post Title and Post Content](https://github.com/WordPress/gutenberg/pull/18461) [blocks](https://github.com/WordPress/gutenberg/pull/18543).
+    *   Add [template parts](https://github.com/WordPress/gutenberg/pull/18339) CPT and the theme resolution logic.
+*   Widgets Screen:
+    *   [Refactor the legacy widgets block](https://github.com/WordPress/gutenberg/pull/15801) to support all blocks.
+    *   Fix [widget areas margins](https://github.com/WordPress/gutenberg/pull/18528).
+    *   Add [isRTL setting](https://github.com/WordPress/gutenberg/pull/18545).
+*   APIs
+    *   **useColors** hook: Enhance the [contrast checking API](https://github.com/WordPress/gutenberg/pull/18237) and provide [access to the color value](https://github.com/WordPress/gutenberg/pull/18544).
+    *   Introduce [createInterpolateElement](https://github.com/WordPress/gutenberg/pull/17376) to allow translation of complex strings with HTML content.
+    *   A11y: Refactor the [accessibility behavior of the Toolbar](https://github.com/WordPress/gutenberg/pull/18534) component.
+*   Social Links:
+    *   [Capitalize LinkedIn](https://github.com/WordPress/gutenberg/pull/18638) and [GitHub](https://github.com/WordPress/gutenberg/pull/18714) properly.
+    *   Fix frontend [styling](https://github.com/WordPress/gutenberg/pull/18410).
+
+### Documentation
+
+*   Add a [Backward Compatibility policy](https://github.com/WordPress/gutenberg/pull/18499) document.
+*   Clarify the [npm packages release](https://github.com/WordPress/gutenberg/pull/18516) documentation.
+*   Add documentation for the [@wordpress/env wp-env.json config file](https://github.com/WordPress/gutenberg/pull/18643).
+*   Typos and tweaks: [1](https://github.com/WordPress/gutenberg/pull/18400), [2](https://github.com/WordPress/gutenberg/pull/18404), [3](https://github.com/WordPress/gutenberg/pull/18449), [4](https://github.com/WordPress/gutenberg/pull/18403), [5](https://github.com/WordPress/gutenberg/pull/18452), [6](https://github.com/WordPress/gutenberg/pull/18460), [7](https://github.com/WordPress/gutenberg/pull/18475), [8](https://github.com/WordPress/gutenberg/pull/18507), [9](https://github.com/WordPress/gutenberg/pull/18059), [10](https://github.com/WordPress/gutenberg/pull/17911), [11](https://github.com/WordPress/gutenberg/pull/18558), [12](https://github.com/WordPress/gutenberg/pull/18277), [13](https://github.com/WordPress/gutenberg/pull/18572), [14](https://github.com/WordPress/gutenberg/pull/18587), [15](https://github.com/WordPress/gutenberg/pull/18592), [16](https://github.com/WordPress/gutenberg/pull/18436), [17](https://github.com/WordPress/gutenberg/pull/18446), [18](https://github.com/WordPress/gutenberg/pull/18707), [19](https://github.com/WordPress/gutenberg/pull/18450), [20](https://github.com/WordPress/gutenberg/pull/18713).
+
+### Various
+
+*   Refactor the [RichText component](https://github.com/WordPress/gutenberg/pull/17779): Remove the inner Editable component.
+*   Integrate [the](https://github.com/WordPress/gutenberg/pull/18514) [Gutenberg Playground](https://github.com/WordPress/gutenberg/pull/18191) into Storybook.
+*   Increase [WordPress minimum supported](https://github.com/WordPress/gutenberg/pull/15809) by the plugin to 5.2.0.
+*   Refactor the [Paragraph block edit function](https://github.com/WordPress/gutenberg/pull/18125) as a functional component.
+*   Refactor the [Cover block edit function](https://github.com/WordPress/gutenberg/pull/18116) as a functional component.
+*   Add new components to Storybook.
+    *   [RadioControl](https://github.com/WordPress/gutenberg/pull/18474) component.
+    *   [TabPanel](https://github.com/WordPress/gutenberg/pull/18402) component.
+    *   [Popover](https://github.com/WordPress/gutenberg/pull/18096) component.
+    *   [BaseControl](https://github.com/WordPress/gutenberg/pull/18648) component.
+    *   [Tip](https://github.com/WordPress/gutenberg/pull/18542) component.
+*   Include [WordPress eslint plugin](https://github.com/WordPress/gutenberg/pull/18457) in React eslint ruleset in @wordpress/eslint-plugin.
+*   [Block PRs  on mobile unit test failures](https://github.com/WordPress/gutenberg/pull/18454) in Travis.
+*   Polish the [PostSchedule popover styling](https://github.com/WordPress/gutenberg/pull/18235).
+*   Fix the [API documentation generation tool](https://github.com/WordPress/gutenberg/pull/18253) when spaces are used in folder names.
+*   Add [missing @babel/runtime dependency](https://github.com/WordPress/gutenberg/pull/18626) to the @wordpress/jest-puppeteer-axe.
+*   [Refactor the Layout component](https://github.com/WordPress/gutenberg/pull/18044) [to](https://github.com/WordPress/gutenberg/pull/18658) [separate](https://github.com/WordPress/gutenberg/pull/18683) the UI from the content.
+*   Align [Dropdown and DropdownMenu](https://github.com/WordPress/gutenberg/pull/18631) components styling.
+*   Remove [max-width style from the Image block](https://github.com/WordPress/gutenberg/pull/14911).
+*   Remove the [CollegeHumor embed](https://github.com/WordPress/gutenberg/pull/18591) block.
+*   Add unit tests: 
+    *   Ensure [consecutive edits](https://github.com/WordPress/gutenberg/pull/17917) to the same attribute are considered persistent.
+    *   Test the [core-data undo reducer](https://github.com/WordPress/gutenberg/pull/18642).
+
+= 6.9.0 =
+
+### Features
+
+* Support changing the [image title attribute](https://github.com/WordPress/gutenberg/pull/11070) in the Image block.
+
+### Bugs
+
+* Fix  [invalid Pullquote blocks](https://github.com/WordPress/gutenberg/pull/18194) when setting a color from the palette presets.
+* Fix the columns left/right [full-width margins](https://github.com/WordPress/gutenberg/pull/18021).
+* Prevent [fast consecutive updates](https://github.com/WordPress/gutenberg/pull/18219) from triggering blocks reset.
+* Fix block [movers for floated blocks](https://github.com/WordPress/gutenberg/pull/18230).
+* Fix [Radio buttons styling](https://github.com/WordPress/gutenberg/pull/18183) in meta boxes.
+* Fix the [default image sizes used for featured images](https://github.com/WordPress/gutenberg/pull/15844) displayed in the editor.
+* Prevent the unsaved changes warning from popping-up when [deleting posts](https://github.com/WordPress/gutenberg/pull/18275).
+* Revert [img and iframe styles](https://github.com/WordPress/gutenberg/pull/18287) to block editor container scope.
+* Block Merge: guard for [undefined attribute definition](https://github.com/WordPress/gutenberg/pull/17937).
+
+### Enhancements
+
+* Inserter: [Immediately insert block](https://github.com/WordPress/gutenberg/pull/16708) when only one block type is allowed.
+* Update the list of the [default available gradients](https://github.com/WordPress/gutenberg/pull/18214).
+* [Disable indent/outdent buttons](https://github.com/WordPress/gutenberg/pull/17819) when necessary in the List block.
+
+### New APIs
+
+* Add theme support API to define [custom gradients presets](https://github.com/WordPress/gutenberg/pull/17841).
+* Mark the [AsyncMode](https://github.com/WordPress/gutenberg/pull/18154) data module API as stable.
+* Mark the [mediaUpload @wordpress/block-editor setting](https://github.com/WordPress/gutenberg/pull/18156) as stable.
+* Add a **wpenv.json** [config file support for](https://github.com/WordPress/gutenberg/pull/18121) [@wordpress/env](https://github.com/WordPress/gutenberg/pull/18294).
+
+### Various
+
+* Refactor the way [HTML is escaped by the RichText](https://github.com/WordPress/gutenberg/pull/17994) component.
+* Refactor and [simplify the block margins CSS](https://github.com/WordPress/gutenberg/pull/18346) in the editor.
+* Use [HTTPS git clone](https://github.com/WordPress/gutenberg/pull/18136) in the Gutenberg release tool for more stability.
+* Update [ExternalLink](https://github.com/WordPress/gutenberg/pull/18142), [BaseControl and FormTokenField](https://github.com/WordPress/gutenberg/pull/18165) components to use the VisuallyHidden component for the screen reader text.
+* Add several components to Storybook: 
+  * [Spinner](https://github.com/WordPress/gutenberg/pull/18145),
+  * [Draggable](https://github.com/WordPress/gutenberg/pull/18070),
+  * [RangeControl](https://github.com/WordPress/gutenberg/pull/17846),
+  * [FontSizePicker](https://github.com/WordPress/gutenberg/pull/18149),
+  * [Modal](https://github.com/WordPress/gutenberg/pull/18083),
+  * [Snackbar](https://github.com/WordPress/gutenberg/pull/18386),
+  * [ToggleControl](https://github.com/WordPress/gutenberg/pull/18388),
+  * [ResizableBox](https://github.com/WordPress/gutenberg/pull/18097/files).
+* Refactor the [block-directory search to insert](https://github.com/WordPress/gutenberg/pull/17576) as an Inserter plugin.
+* Improve the experimental [useColors React](https://github.com/WordPress/gutenberg/pull/18147) [hook](https://github.com/WordPress/gutenberg/pull/18286).
+* Upgrade [Puppeteer](https://github.com/WordPress/gutenberg/pull/18205) to the last version.
+* Update to the [last version of npm-package-json-lint](https://github.com/WordPress/gutenberg/pull/18160).
+* **i18n**: Fix string concatenation in the [Verse block example](https://github.com/WordPress/gutenberg/pull/18365) and add `translators` string.
+* Change Detection: Add an [e2e test case for post trashing](https://github.com/WordPress/gutenberg/pull/18290).
+* Fix the [e2e tests watch command](https://github.com/WordPress/gutenberg/pull/18391).
+
+### Experimental
+
+* Block Content Areas:
+  * Support [loading block templates](https://github.com/WordPress/gutenberg/pull/18247) from themes.
+* Navigation block:
+  * Add [default frontend styles](https://github.com/WordPress/gutenberg/pull/18094) for the Navigation block.
+  * Use [RichText for navigation menu item](https://github.com/WordPress/gutenberg/pull/18182) instead of TextControl.
+  * Add [block navigator](https://github.com/WordPress/gutenberg/pull/18202) to the inspector panel.
+  * Use an [SVG icon](https://github.com/WordPress/gutenberg/pull/18222) for the color selector.
+  * Add a new API for [horizontal movers](https://github.com/WordPress/gutenberg/pull/16615) and [use](https://github.com/WordPress/gutenberg/pull/18234) it for the navigation block.
+  * Add a new [Link creation](https://github.com/WordPress/gutenberg/pull/17846) [and](https://github.com/WordPress/gutenberg/pull/18405) [edition](https://github.com/WordPress/gutenberg/pull/18225) [UI](https://github.com/WordPress/gutenberg/pull/18285) and [use](https://github.com/WordPress/gutenberg/pull/18062) it for the navigation block.
+  * Add an [appender](https://github.com/WordPress/gutenberg/pull/18100) to the block navigator.
+  * Add a block [placeholder](https://github.com/WordPress/gutenberg/pull/18363).
+  * Various fixes and refactorings: [1](https://github.com/WordPress/gutenberg/pull/18189), [2](https://github.com/WordPress/gutenberg/pull/18178), [3](https://github.com/WordPress/gutenberg/pull/18188), [4](https://github.com/WordPress/gutenberg/pull/18153), [5](https://github.com/WordPress/gutenberg/pull/18221), [6](https://github.com/WordPress/gutenberg/pull/18278), [7](https://github.com/WordPress/gutenberg/pull/18172), [8](https://github.com/WordPress/gutenberg/pull/18346), [9](https://github.com/WordPress/gutenberg/pull/18376), [10](https://github.com/WordPress/gutenberg/pull/18150), [11](https://github.com/WordPress/gutenberg/pull/18292), [12](https://github.com/WordPress/gutenberg/pull/18374), [13](https://github.com/WordPress/gutenberg/pull/18367), [14](https://github.com/WordPress/gutenberg/pull/18350), [15](https://github.com/WordPress/gutenberg/pull/18412).
+* Add [ResponsiveBlockControl](https://github.com/WordPress/gutenberg/pull/16790) component.
+* Add initial [API for block patterns](https://github.com/WordPress/gutenberg/pull/18270).
+
+### Documentation
+
+* Add an introduction [README for Storybook](https://github.com/WordPress/gutenberg/pull/18245).
+* Typos and fixes: [1](https://github.com/WordPress/gutenberg/pull/18187), [2](https://github.com/WordPress/gutenberg/pull/18198), [3](https://github.com/WordPress/gutenberg/pull/18204https://github.com/WordPress/gutenberg/pull/18204), [4](https://github.com/WordPress/gutenberg/pull/18218), [5](https://github.com/WordPress/gutenberg/pull/18221), [6](https://github.com/WordPress/gutenberg/pull/18226).
+
+
+= 6.8.0 =
+
+### Features
+
+*   [Support gradients](https://github.com/WordPress/gutenberg/pull/18001) in Cover block.
+*   Add a breadcrumb bar to support [block hierarchy selection](https://github.com/WordPress/gutenberg/pull/17838).
+
+### Enhancements
+
+*   Cover block: change the [minimum height input step size](https://github.com/WordPress/gutenberg/pull/17927) to one.
+*   Allow setting a [display name for blocks](https://github.com/WordPress/gutenberg/pull/17519) based on their content in the BlockNavigator.
+*   [Hide the gradients panel](https://github.com/WordPress/gutenberg/pull/18091) if an empty set of gradients is explicitly defined.
+*   [Do not transform list items into paragraphs](https://github.com/WordPress/gutenberg/pull/18032) when deleting first list item and list is not empty.
+*   Replace inline styles with [classnames for the gradient palette](https://github.com/WordPress/gutenberg/pull/18008).
+*   [Preserve list attributes](https://github.com/WordPress/gutenberg/pull/17144) (start, type and reversed) when pasting or converting HTML to blocks. 
+
+### Bugs
+
+*   [Clear local autosaves](https://github.com/WordPress/gutenberg/pull/18051) after successful saves.
+*   Fix the [columns block](https://github.com/WordPress/gutenberg/pull/17968) width overflow issue when using more than two columns.
+*   Fix the [Link Rel input](https://github.com/WordPress/gutenberg/pull/17398) not showing the saved value of the link rel attribute.
+*   Fix JavaScript errors triggered when using [links without href](https://github.com/WordPress/gutenberg/pull/17928) in HTML mode.
+*   Move the [default list styles](https://github.com/WordPress/gutenberg/pull/17958) to the theme editor styles.
+*   Fix [Invalid import](https://github.com/WordPress/gutenberg/pull/17969) statement for deprecated call in the Modal component.
+*   Fix a small visual glitch in the [Publish button](https://github.com/WordPress/gutenberg/pull/18016).
+*   Prevent blank page when using the [Media Modal Edit Image "back"](https://github.com/WordPress/gutenberg/pull/18007) button.
+*   Allow the [shortcode transform](https://github.com/WordPress/gutenberg/pull/17925) to apply to all the provided shortcode aliases. 
+*   Fix JavaScript error triggered when using arrows on an [empty URLInput](https://github.com/WordPress/gutenberg/pull/18088).
+*   Fix [extra margins added to Gallery blocks](https://github.com/WordPress/gutenberg/pull/18019) by list editor styles.
+*   Fix [custom button background color](https://github.com/WordPress/gutenberg/pull/18037) not reflected on reload.
+*   [Preserve List block attributes](https://github.com/WordPress/gutenberg/pull/18102) when splitting into multiple lists. 
+*   Fix [checkbox styles](https://github.com/WordPress/gutenberg/pull/18108) when used in metaboxes.
+*   Make the [FontSizePicker style](https://github.com/WordPress/gutenberg/pull/18078) independent from WordPress core styles.
+*   Fix overlapping controls in the [Inline Image formatting toolbar](https://github.com/WordPress/gutenberg/pull/18090).
+*   Fix [strikethrough formatting](https://github.com/WordPress/gutenberg/pull/17187) when copy/pasting from Google Docs in Safari.
+*   Allow [media upload post processing](https://github.com/WordPress/gutenberg/pull/18106) for all 5xx REST API responses.
+
+## Experiments
+
+*   Navigation block:
+    *   Support [color customization](https://github.com/WordPress/gutenberg/pull/17832).
+    *   Improve the [Link edition UI](https://github.com/WordPress/gutenberg/pull/17986).
+*   Block Content Areas:
+    *   Implement a frontend [template loader](https://github.com/WordPress/gutenberg/pull/17626) based on the  **wp_template** CPT.
+    *   Add a temporary [UI to edit **wp_template**](https://github.com/WordPress/gutenberg/pull/17625) CPT posts.
+    *   Add a [Site title block](https://github.com/WordPress/gutenberg/pull/17207).
+
+### New APIs
+
+*   Add [VisuallyHidden](https://github.com/WordPress/gutenberg/pull/18022) component.
+*   Add [**@wordpress/base-styles**](https://github.com/WordPress/gutenberg/pull/17883) package to share the common variables/mixins used by the WordPress packages.
+*   Add [Platform component](https://github.com/WordPress/gutenberg/pull/18058) to allow writing platform (web, mobile) specific logic.
+*   Add isInvalidDate prop to [DatePicker](https://github.com/WordPress/gutenberg/pull/17498).
+*   @wordpress/env improvements:
+    *   Support [custom ports](https://github.com/WordPress/gutenberg/pull/17697).
+    *   Support using it for [themes](https://github.com/WordPress/gutenberg/pull/17732).
+*   Add a new experimental React  hook to [support colors in blocks](https://github.com/WordPress/gutenberg/pull/16781).
+*   Add a new experimental [DimentionControl](https://github.com/WordPress/gutenberg/pull/16791) component.
+
+### Various
+
+*   Storybook:
+    *   Add a story for the [CheckboxControl](https://github.com/WordPress/gutenberg/pull/17891) component.
+    *   Add a story for the [Dashicon](https://github.com/WordPress/gutenberg/pull/18027) component.
+    *   Add a story for the [ColorPalette](https://github.com/WordPress/gutenberg/pull/17997) component.
+    *   Add a story for the [ColorPicker](https://github.com/WordPress/gutenberg/pull/18013) component.
+    *   Add a story for the [ExternalLink](https://github.com/WordPress/gutenberg/pull/18084) component.
+
+Add knobs to the [ColorIndicator Story](https://github.com/WordPress/gutenberg/pull/18015).
+
+*   Several other [enhancements to existing stories](https://github.com/WordPress/gutenberg/pull/18030).
+*   [Linting fixes](https://github.com/WordPress/gutenberg/pull/17981) for Storybook config.
+*   Fix Lint warnings triggered by [JSDoc definitions](https://github.com/WordPress/gutenberg/pull/18025).
+*   [Reorganize e2e tests](https://github.com/WordPress/gutenberg/pull/17990) [specs](https://github.com/WordPress/gutenberg/pull/18020) into three folders: editor, experimental and plugin.
+*   Cleanup [skipped e2e tests](https://github.com/WordPress/gutenberg/pull/18003).
+*   Add a [link to Storybook](https://github.com/WordPress/gutenberg/pull/17982) from the Gutenberg playground.
+*   Optimize the **@wordpress/compose** package to [support tree-shaking](https://github.com/WordPress/gutenberg/pull/17945).
+*   Code Quality:
+    *   Refactor the [Button block edit function](https://github.com/WordPress/gutenberg/pull/18006) to use a functional component.
+    *   Change the name of the [accumulated variables](https://github.com/WordPress/gutenberg/pull/17893) in reduce functions.
+    *   Remove wrapper around the [Table block cells](https://github.com/WordPress/gutenberg/pull/17711).
+*   Fix several issues related to [Node 12](https://github.com/WordPress/gutenberg/pull/18054) [becoming](https://github.com/WordPress/gutenberg/pull/18057) LTS.
+*   Add the [Block Inspector](https://github.com/WordPress/gutenberg/pull/18077) to the Gutenberg playground.
+
+### Documentation
+
+*   Enhance the [Git workflow](https://github.com/WordPress/gutenberg/pull/17662) documentation.
+*   Clarify [block naming conventions](https://github.com/WordPress/gutenberg/pull/18117).
+*   Tweaks and typos: [1](https://github.com/WordPress/gutenberg/pull/17980), [2](https://github.com/WordPress/gutenberg/pull/18039).
+
+= 6.7.0 =
+
+### Features
+
+*   Add [gradient backgrounds support](https://github.com/WordPress/gutenberg/pull/17169) to the Button block.
+
+### Bug Fixes
+
+*   i18n : Include the plural version of the “[remove block](https://github.com/WordPress/gutenberg/pull/17665)” string.
+*   Update dropdown menu items to match [hover](https://github.com/WordPress/gutenberg/pull/17621) [style](https://github.com/WordPress/gutenberg/pull/17581) in other places.
+*   Smoothly [reposition Popovers on scroll](https://github.com/WordPress/gutenberg/pull/17699).
+*   Fix [margin styles for Gallery](https://github.com/WordPress/gutenberg/pull/17694) and Social links blocks.
+*   Fix [popovers hidden on mobile](https://github.com/WordPress/gutenberg/pull/17696).
+*   Ensure [sidebar plugins do not get auto-closed](https://github.com/WordPress/gutenberg/pull/17712) when opened on small screens.
+*   Fix the design of the [Checkbox component in IE11](https://github.com/WordPress/gutenberg/pull/17714).
+*   Add [has-text-color](https://github.com/WordPress/gutenberg/pull/17742) classname to heading block.
+*   Prevent [figure margin reset CSS](https://github.com/WordPress/gutenberg/pull/17737) from being included in the frontend.
+*   Fix the [scaling of the pinned plugins menu icons](https://github.com/WordPress/gutenberg/pull/17752).
+*   Fix [Heading and paragraph colors](https://github.com/WordPress/gutenberg/pull/17728) not applied inside the cover block.
+*   [Close Nux tips](https://github.com/WordPress/gutenberg/pull/17663) when clicking outside the tip.
+*   Fix [meta attribute source](https://github.com/WordPress/gutenberg/pull/17820) for post types other than post.
+*   Fix ”[Open in New Tab](https://github.com/WordPress/gutenberg/pull/17794)” not being persisted.
+*   Fix [redo](https://github.com/WordPress/gutenberg/pull/17827) [behavior](https://github.com/WordPress/gutenberg/pull/17861) and expand test coverage.
+*   I18n: Fix missing translation for the [“All content copied” string](https://github.com/WordPress/gutenberg/pull/17828).
+*   Fix the [block preview padding](https://github.com/WordPress/gutenberg/pull/17807) in themes with custom backgrounds.
+*   Fix [merging list blocks](https://github.com/WordPress/gutenberg/pull/17845) with indented list items.
+*   Fix [inline image controls](https://github.com/WordPress/gutenberg/pull/17750) display condition.
+*   Fix clicking the [redirect element](https://github.com/WordPress/gutenberg/pull/17798) focuses the inserted paragraph.
+*   Fix [editing meta attributes](https://github.com/WordPress/gutenberg/pull/17850) with multiple set to true.
+*   Add [No Preview Available](https://github.com/WordPress/gutenberg/pull/17848) text to the inserter preview panel.
+*   [Prevent block controls from disappearing](https://github.com/WordPress/gutenberg/pull/17876) when switching the List block type.
+*   Avoid [trailing space](https://github.com/WordPress/gutenberg/pull/17842) at the end of a translatable string.
+*   Fix [left aligned nested blocks](https://github.com/WordPress/gutenberg/pull/17804).
+*   Fix the top margin of the [RadioControl help text](https://github.com/WordPress/gutenberg/pull/17677).
+*   Fix [invalid HTML](https://github.com/WordPress/gutenberg/pull/17754) used in the Featured Image panel.
+*   Make sure that all [edits after saving](https://github.com/WordPress/gutenberg/pull/17888) are considered persistent by default.
+*   Ensure that [sidebar is closed on the first visit](https://github.com/WordPress/gutenberg/pull/17902) on small screens.
+*   Update the [columns block example](https://github.com/WordPress/gutenberg/pull/17904) to avoid overlapping issues.
+*   Remove unnecessary default styles for [H2 heading inside Cover blocks](https://github.com/WordPress/gutenberg/pull/17815).
+*   Fix [Media & Text block alignment](https://github.com/WordPress/gutenberg/pull/10812) in IE11.
+*   Remove [unnecessary padding](https://github.com/WordPress/gutenberg/pull/17907https://github.com/WordPress/gutenberg/pull/17907) in the Columns block.
+*   Fix the [Columns block height](https://github.com/WordPress/gutenberg/pull/17901) in IE11.
+*   Correctly update [RichText value after undo](https://github.com/WordPress/gutenberg/pull/17840).
+*   Prevent the [snackbar link components](https://github.com/WordPress/gutenberg/pull/17887) from hiding on focus.
+*   Fix [block toolbar position](https://github.com/WordPress/gutenberg/pull/17894) in IE11.
+*   Retry [uploading images](https://github.com/WordPress/gutenberg/pull/17858) on failures.
+
+### Performance
+
+*   Avoid [continuously reset browser selection](https://github.com/WordPress/gutenberg/pull/17869) (improve typing performance in iOS).
+
+### Enhancements
+
+*   Polish [FontSize Picker design](https://github.com/WordPress/gutenberg/pull/17647).
+*   Use body color for the [post publish panel](https://github.com/WordPress/gutenberg/pull/17731).
+*   Limit the width and height of the [pinnable plugins icons](https://github.com/WordPress/gutenberg/pull/17722).
+*   Add a [max width to the Search block](https://github.com/WordPress/gutenberg/pull/17648) input.
+
+### Experiments
+
+*   Menu Navigation block:
+*   Implement initial state containing [top level pages](https://github.com/WordPress/gutenberg/pull/17637).
+*   Fix [menu alignment](https://github.com/WordPress/gutenberg/pull/17630).
+*   Fix the [classname](https://github.com/WordPress/gutenberg/pull/17853) in frontend.
+*   Block Directory
+*   Change the [relative time string](https://github.com/WordPress/gutenberg/pull/17535).
+*   Widgets Screen
+*   Fix the [styling of the inspector panel](https://github.com/WordPress/gutenberg/pull/17880).
+
+### Documentation
+
+*   Fix [@wordpress/data-controls examples](https://github.com/WordPress/gutenberg/pull/17773).
+*   Typos and tweaks: [1](https://github.com/WordPress/gutenberg/pull/17821), [2](https://github.com/WordPress/gutenberg/pull/17909).
+
+### Various
+
+*   Introduce the [@wordpress/env](https://github.com/WordPress/gutenberg/pull/17668) package, A zero-config, self-contained local WordPress environment for development and testing.
+*   Add [Storybook](https://github.com/WordPress/gutenberg/pull/17475) [to](https://github.com/WordPress/gutenberg/pull/17762) develop and showcase UI components:
+*   [Add](https://github.com/WordPress/gutenberg/pull/17910) [ButtonGroup](https://github.com/WordPress/gutenberg/pull/17884) component.
+*   Add [ScrollLock](https://github.com/WordPress/gutenberg/pull/17886) component.
+*   Add [Animate](https://github.com/WordPress/gutenberg/pull/17890https://github.com/WordPress/gutenberg/pull/17890) component.
+*   Add [Icon and IconButton](https://github.com/WordPress/gutenberg/pull/17868) components.
+*   Add [ClipboardButton](https://github.com/WordPress/gutenberg/pull/17913) component.
+*   Add [ColorIndicator](https://github.com/WordPress/gutenberg/pull/17924) component.
+*   [Remove RichText](https://github.com/WordPress/gutenberg/pull/17607) [wrapper](https://github.com/WordPress/gutenberg/pull/17713) and use Popover for the inline toolbar.
+*   Improve the way the [lock file](https://github.com/WordPress/gutenberg/pull/17705) handles local dependencies.
+*   Refactor [ColorPalette](https://github.com/WordPress/gutenberg/pull/17154) by extracting its design.
+*   Improve [E2E test reliability](https://github.com/WordPress/gutenberg/pull/17679) by consuming synchronous data and bailing on save failure.
+*   Replace the [isDismissable prop with isDismissible](https://github.com/WordPress/gutenberg/pull/17689) in the Modal component.
+*   Add eslint-plugin-jest to the default @wordpress/scripts [linting config](https://github.com/WordPress/gutenberg/pull/17744).
+*   Update @wordpress/scripts to use the [latest version of webpack](https://github.com/WordPress/gutenberg/pull/17753) for build and start commands.
+*   Cleanup [Dashicon component](https://github.com/WordPress/gutenberg/pull/17741).
+*   Update the [Excerpt help link](https://github.com/WordPress/gutenberg/pull/17753).
+*   [Release tool](https://github.com/WordPress/gutenberg/pull/17717): fix wrong package.json used when bumping the stable released version.
+*   Fix several [typos](https://github.com/WordPress/gutenberg/pull/17666) in [code](https://github.com/WordPress/gutenberg/pull/17800) and [files](https://github.com/WordPress/gutenberg/pull/17782).
+*   Update [E2E tests](https://github.com/WordPress/gutenberg/pull/17859) to accommodate WP 5.3 Beta 3 changes.
+*   Define the “[sideEffects](https://github.com/WordPress/gutenberg/pull/17862)” property for @wordpress packages.
+*   Add [nested embed e2e test](https://github.com/WordPress/gutenberg/pull/15909).
+*   I18N: Always return the [translation file](https://github.com/WordPress/gutenberg/pull/17900) prefixed with `gutenberg-`.
+*   Use [wp.org CDN for images](https://github.com/WordPress/gutenberg/pull/17935) used in block preview.
+
+= 6.6.0 =
+
+### Enhancements
+
+-   Turn [Stack on mobile toggle on by default](https://github.com/WordPress/gutenberg/pull/14364) in the Media & Text block.
+-   Only show the Inserter [help panel in the topbar inserter](https://github.com/WordPress/gutenberg/pull/17545).
+-   Use minimum height instead of height for [Cover height control label](https://github.com/WordPress/gutenberg/pull/17634).
+-   Update the [buttons](https://github.com/WordPress/gutenberg/pull/17645)  [styling](https://github.com/WordPress/gutenberg/pull/17651) to match core.
+-   Add [preview examples](https://github.com/WordPress/gutenberg/pull/17493) for multiple core blocks.
+
+### New APIs
+
+-   Implement [EntityProvider](https://github.com/WordPress/gutenberg/pull/17153) and use it to refactor the meta block attributes.
+
+### Experimental
+
+-   Introduce the [wp_template custom post type](https://github.com/WordPress/gutenberg/pull/17513) to preempt the block content areas work.
+-   Use the [entities store for the widgets](https://github.com/WordPress/gutenberg/pull/17319) screen.
+
+### Bugs
+
+-   Fix javascript error potentially triggered when using [saveEntityRecord action](https://github.com/WordPress/gutenberg/pull/17492).
+-   Avoid marking the [post as dirty when forcing an undo level](https://github.com/WordPress/gutenberg/pull/17487) (RichText).
+-   Fix [Post Publish Panel overlapping the user profile](https://github.com/WordPress/gutenberg/pull/17075) dropdown menu.
+-   Fix and align [collapsing logic for Save Draft and Saved](https://github.com/WordPress/gutenberg/pull/17506) button states.
+-   [Remove Reusable block name and description](https://github.com/WordPress/gutenberg/pull/17530) from the inserter help panel.
+-   Fix spacing issues in the [inserter panel previews](https://github.com/WordPress/gutenberg/pull/17531).
+-   Gallery block: [Don't show the caption gradient overlay](https://github.com/WordPress/gutenberg/pull/17561) unless image is selected or a caption is set.
+-   Gallery block: Fix [custom alignment layouts](https://github.com/WordPress/gutenberg/pull/17586)
+-   Fix [dirtiness detection when server-side saving filters](https://github.com/WordPress/gutenberg/pull/17532) are used.
+-   Remove [wrong i18n](https://github.com/WordPress/gutenberg/pull/17546)  [domain](https://github.com/WordPress/gutenberg/pull/17591).
+-   Fix [invalid block warning](https://github.com/WordPress/gutenberg/pull/17572) panel.
+-   Fix various issues in related to the [BlockDirectory inserter](https://github.com/WordPress/gutenberg/pull/17517).
+-   Cover block: [Show Height control](https://github.com/WordPress/gutenberg/pull/17371) only if an image background is selected.
+-   Fix [RichText composition input](https://github.com/WordPress/gutenberg/pull/17610) issues.
+-   Fix [block placeholders spacing](https://github.com/WordPress/gutenberg/pull/17616) after Core inputs updates.
+-   Fix [checkbox design](https://github.com/WordPress/gutenberg/pull/17571) (color and background) after Core updates.
+-   Fix [radio buttons design](https://github.com/WordPress/gutenberg/pull/17613) after Core updates.
+-   Remove any existing subscriptions before adding a new save metaboxes sub to [prevent multiple saves](https://github.com/WordPress/gutenberg/pull/17522).
+-   [Clear auto-draft titles](https://github.com/WordPress/gutenberg/pull/17633) on save if not changed explicitly.
+-   Fix [block error boundary](https://github.com/WordPress/gutenberg/pull/17602).
+-   Fix [select elements](https://github.com/WordPress/gutenberg/pull/17646) design in the sidebar after Core updates.
+-   Allow using [space with modifier keys](https://github.com/WordPress/gutenberg/pull/17611) at the beginning of list items.
+-   Fix the [inputs height](https://github.com/WordPress/gutenberg/pull/17659) after Core updates.
+-   fix conflict between [remote and local autosaves](https://github.com/WordPress/gutenberg/pull/17501).
+
+### Performance
+
+-   Request the [Image block’s metadata](https://github.com/WordPress/gutenberg/pull/17504) only if the block is selected.
+-   Improve the performance of the [block reordering animation in Safari](https://github.com/WordPress/gutenberg/pull/17573).
+-   Remove [Autocomplete component wrappers](https://github.com/WordPress/gutenberg/pull/17580).
+
+### Various
+
+-   [Replace registered social links blocks](https://github.com/WordPress/gutenberg/pull/17494) if already registered in Core.
+-   More stable [List block e2e](https://github.com/WordPress/gutenberg/pull/17482)  [tests](https://github.com/WordPress/gutenberg/pull/17599).
+-   Add e2e tests to validate the [date picker UI](https://github.com/WordPress/gutenberg/pull/17490) behavior.
+-   Add e2e tests to validate the [local auto-save](https://github.com/WordPress/gutenberg/pull/17503) behavior.
+-   Mark the [social links block as experimental](https://github.com/WordPress/gutenberg/pull/17526).
+-   [Update the e2e tests](https://github.com/WordPress/gutenberg/pull/17566) to accommodate the new theme.
+-   Align the [version of lodash](https://github.com/WordPress/gutenberg/pull/17528) with WordPress core.
+-   Add phpcs rule to [detect unused variables](https://github.com/WordPress/gutenberg/pull/17300).
+-   Simplify [Block Selection Reducer](https://github.com/WordPress/gutenberg/pull/17467).
+-   Add [has-background classes](https://github.com/WordPress/gutenberg/pull/17529) to pullquote and Media & Text blocks for consistency.
+-   Tidy up [button vertical align styles](https://github.com/WordPress/gutenberg/pull/17601).
+-   Update [browserslist](https://github.com/WordPress/gutenberg/pull/17643) dependency.
+
+### Documentation
+
+-   Add [scripts/styles dependency management](https://github.com/WordPress/gutenberg/pull/17489) documentation.
+-   Update [docs with the example property](https://github.com/WordPress/gutenberg/pull/17507) used for Inserter previews.
+-   Typos and tweaks: [1](https://github.com/WordPress/gutenberg/pull/17449), [2](https://github.com/WordPress/gutenberg/pull/17499), [3](https://github.com/WordPress/gutenberg/pull/17514), [4](https://github.com/WordPress/gutenberg/pull/17502), [5](https://github.com/WordPress/gutenberg/pull/17595).
+
+### Mobile
+
+-   Add [rounded corners on media placeholder](https://github.com/WordPress/gutenberg/pull/16729) and unsupported blocks.
+-   Fix link editing when the [cursor is at the beginning of a link](https://github.com/WordPress/gutenberg/pull/17631).
+
+= 6.5.0 =
+
+### Features
+*   Add a [new](https://github.com/WordPress/gutenberg/pull/17402) [Social links](https://github.com/WordPress/gutenberg/pull/16897) [block](https://github.com/WordPress/gutenberg/pull/17380).
+*   Support [border radius changes](https://github.com/WordPress/gutenberg/pull/17253) in the Button block.
+*   Support [adding a caption to the Gallery block](https://github.com/WordPress/gutenberg/pull/17101).
+*   Support [local autosaves](https://github.com/WordPress/gutenberg/pull/16490).
+### Enhancements
+*   [Disable the click-through](https://github.com/WordPress/gutenberg/pull/17239) behavior in desktop.
+*   Update the [labels width](https://github.com/WordPress/gutenberg/pull/14478) to fit their content.
+*   Avoid displaying console warnings when [blocks are upgraded using deprecated versions](https://github.com/WordPress/gutenberg/pull/16862).
+*   Reduce the [padding around the in-between block inserter](https://github.com/WordPress/gutenberg/pull/17136).
+*   Improve the design of [the](https://github.com/WordPress/gutenberg/pull/17315) [block movers](https://github.com/WordPress/gutenberg/pull/17216).
+*   Align the [Gallery block image](https://github.com/WordPress/gutenberg/pull/17316) [controls](https://github.com/WordPress/gutenberg/pull/17374) with the block movers design.
+*   [Remove child blocks](https://github.com/WordPress/gutenberg/pull/17128) from the block manager.
+*   [Remove duplicated "Enable" label](https://github.com/WordPress/gutenberg/pull/17375) from the options panel.
+*   Use [sentence case](https://github.com/WordPress/gutenberg/pull/17336) for all tooltips.
+*   [Remove the forced gray scale](https://github.com/WordPress/gutenberg/pull/17415) from the category icons.
+*   Move the [alignment controls to toolbar of the Heading](https://github.com/WordPress/gutenberg/pull/17419) block.
+*   Use the [featured image frame](https://github.com/WordPress/gutenberg/pull/17410) in the Media modal.
+### Bug Fixes
+*   Update the [Post Schedule label](https://github.com/WordPress/gutenberg/pull/15757) to correctly reflect the date and time display settings.
+*   Clean up the [block toolbar position](https://github.com/WordPress/gutenberg/pull/17197) for wide full blocks.
+*   Fix the [cropped focus indicator](https://github.com/WordPress/gutenberg/pull/17215) in the block inserter.
+*   Browser incompatibilities: 
+    *   [Fallback to setTimeout in RichText](https://github.com/WordPress/gutenberg/pull/17213) if no requestIdleCallback is not supported.
+    *   [Block toolbar fixes](https://github.com/WordPress/gutenberg/pull/17214) for IE11.
+    *   Fix [Backspace usage in RichText](https://github.com/WordPress/gutenberg/pull/17256) for IE11.
+*   Prevent clicking the [next/previous month in the Post Schedule](https://github.com/WordPress/gutenberg/pull/17201) popover from closing it.
+*   Prevent the [private posts from triggering the unsaved changes](https://github.com/WordPress/gutenberg/pull/17210) [warnings](https://github.com/WordPress/gutenberg/pull/17257) after saving.
+*   Fix the usage of the [useReducedMotion hook in Node.js](https://github.com/WordPress/gutenberg/pull/17165) context.
+*   A11y: 
+    *   Use [darker form field borders](https://github.com/WordPress/gutenberg/pull/17218).
+    *   Fix the [modal escape key propagation](https://github.com/WordPress/gutenberg/pull/17297).
+    *   [Move focus back from the Modal to the More Menu](https://github.com/WordPress/gutenberg/pull/16964) when it was used to open the Modal.
+*   [Trim leading and trailing whitespaces](https://github.com/WordPress/gutenberg/pull/17320) when inserting links.
+*   Prevent using the paragraph block when [pasting unformatted text into RichText](https://github.com/WordPress/gutenberg/pull/17140).
+*   Fix styling of [classic block's block controls](https://github.com/WordPress/gutenberg/pull/17323).
+*   Fix the [showing/hiding logic of the **Group** menu item](https://github.com/WordPress/gutenberg/pull/17353) in the block settings menu.
+*   Fix [invalid HTML nesting](https://github.com/WordPress/gutenberg/pull/17342) of buttons.
+*   Fix [React warning when using withFocusReturn](https://github.com/WordPress/gutenberg/pull/17354) Higher-order component.
+*   Fix [lengthy content cuts](https://github.com/WordPress/gutenberg/pull/17365) in the Cover block.
+*   Disable [multi-selection when resizing](https://github.com/WordPress/gutenberg/pull/17359).
+*   Fix the [permalink UI in RTL](https://github.com/WordPress/gutenberg/pull/13919) languages.
+*   Fix multiple issues related to the [reusable blocks](https://github.com/WordPress/gutenberg/pull/14367) editing/previewing UI.
+*   Remove filter that [unsets auto-draft titles](https://github.com/WordPress/gutenberg/pull/17317).
+*   Fix the [Move to trash](https://github.com/WordPress/gutenberg/pull/17427) button redirection.
+*   Prevent [undo/redo history cleaning on autosaves](https://github.com/WordPress/gutenberg/pull/17420).
+*   Add i18n support for title [Content Blocks string](https://github.com/WordPress/gutenberg/pull/17435).
+*   Add missing extra [classnames to the Column block](https://github.com/WordPress/gutenberg/pull/17422).
+*   Fix  JavaScript error triggered when using a [multi-line RichText](https://github.com/WordPress/gutenberg/pull/17447).
+*   Fix [RichText](https://github.com/WordPress/gutenberg/pull/17451) [focus](https://github.com/WordPress/gutenberg/pull/17450) related issues.
+*   Fix [undo levels](https://github.com/WordPress/gutenberg/pull/17259) [inconsistencies](https://github.com/WordPress/gutenberg/pull/17452).
+*   Fix [multiple post meta fields edits](https://github.com/WordPress/gutenberg/pull/17455).
+*   Fix [selecting custom colors](https://github.com/WordPress/gutenberg/pull/17381) in RTL languages.
+### Experiments
+*   Add [one-click search and install blocks](https://github.com/WordPress/gutenberg/pull/17431) from the block directory to the inserter.
+*   Refactor the [Navigation block](https://github.com/WordPress/gutenberg/pull/16796) [to](https://github.com/WordPress/gutenberg/pull/17343) [be](https://github.com/WordPress/gutenberg/pull/17328) a dynamic block.
+*   Add a [block navigator to the Navigation](https://github.com/WordPress/gutenberg/pull/17265) [block](https://github.com/WordPress/gutenberg/pull/17446).
+*   Only show the [customizer block based widgets](https://github.com/WordPress/gutenberg/pull/16956) if the experimental widget screen is enabled.
+### APIs
+*   Add a [disableDropZone prop for MediaPlaceholder](https://github.com/WordPress/gutenberg/pull/17077) component.
+*   Add [post autosave locking](https://github.com/WordPress/gutenberg/pull/16249).
+*   [PluginPrePublishPanel](https://github.com/WordPress/gutenberg/pull/16378) and [PluginPostPublishPanel](https://github.com/WordPress/gutenberg/pull/16383) support icon prop and inherits from registerPlugin.
+*   Allow [disabling the Post Status](https://github.com/WordPress/gutenberg/pull/17117) settings panel.
+*   Restore the [keepPlaceholderOnFocus](https://github.com/WordPress/gutenberg/pull/17439) [RichText](https://github.com/WordPress/gutenberg/pull/17445) prop.
+### Various
+*   Upgrade [React and React DOM](https://github.com/WordPress/gutenberg/pull/16982) to 16.9.0.
+*   Add [TypeScript JSDoc linting](https://github.com/WordPress/gutenberg/pull/17014) to the @wordpress/url package.
+*   Run [npm audit](https://github.com/WordPress/gutenberg/pull/17192) to fix the reported vulnerabilities.
+*   Switch the local environment to an [environment based on the](https://github.com/WordPress/gutenberg/pull/17004) [Core setup](https://github.com/WordPress/gutenberg/pull/17296).
+*   Set a constant namespace for [module sourcemaps](https://github.com/WordPress/gutenberg/pull/17024).
+*   [Refactor the loading animation](https://github.com/WordPress/gutenberg/pull/17106) to rely on the Animate component.
+*   Code improvements to [block PHP files](https://github.com/WordPress/gutenberg/pull/17288).
+*   Enable the [duplicate style property](https://github.com/WordPress/gutenberg/pull/17287) linting rule.
+*   Update [Husky & Lint-staged](https://github.com/WordPress/gutenberg/pull/17310) to the latest versions.
+*   Restore the usage of the [latest npm version](https://github.com/WordPress/gutenberg/pull/17171) in CI.
+*   Add [ESLint as peer dependency to eslint-plugin](https://github.com/WordPress/gutenberg/pull/17417).
+*   [Conditionally include the block styles](https://github.com/WordPress/gutenberg/pull/17429) functionality to avoid conflicts with Core.
+*   Add missing [deprecated setFocusedElement prop](https://github.com/WordPress/gutenberg/pull/17421) to the RichText component.
+*   Support [generating assets in PHP format](https://github.com/WordPress/gutenberg/pull/17298) in the webpack dependency extraction plugin.
+### Documentation
+*   Update the [reviews and merging documentation](https://github.com/WordPress/gutenberg/pull/16915).
+*   Fix [type docs](https://github.com/WordPress/gutenberg/pull/17206) for the Notices package.
+*   Add a link to the [fixtures tests document](https://github.com/WordPress/gutenberg/pull/17283) in the Testing Overview.
+*   Adds documentation for the [onClose prop of MediaUpload](https://github.com/WordPress/gutenberg/pull/17403).
+*   Tweaks and typos: [1](https://github.com/WordPress/gutenberg/pull/17097), [2](https://github.com/WordPress/gutenberg/pull/17285), [3](https://github.com/WordPress/gutenberg/pull/17292), [4](https://github.com/WordPress/gutenberg/pull/17286), [5](https://github.com/WordPress/gutenberg/pull/17304), [6](https://github.com/WordPress/gutenberg/pull/17349), [7](https://github.com/WordPress/gutenberg/pull/17377), [8](https://github.com/WordPress/gutenberg/pull/17436).
+
+
+= 6.4.0 =
+
+### Features
+- Add the option to [select the style that is automatically applied](https://github.com/WordPress/gutenberg/pull/16465).
+- Add the option to [resize Cover Block ](https://github.com/WordPress/gutenberg/pull/17143).
+- Allow directly setting a [solid background color on Cover](https://github.com/WordPress/gutenberg/pull/17041) block.
+- Add [list start, reversed settings](https://github.com/WordPress/gutenberg/pull/15113).
+- Add a [help panel to the inserter available in all blocks](https://github.com/WordPress/gutenberg/pull/16813).  
+- [Typewriter experience](https://github.com/WordPress/gutenberg/pull/16460). 
+- Add [circle-crop variation](https://github.com/WordPress/gutenberg/pull/16475) to Image block.
+
+### Enhancements
+-   Add [overflow support inside block switcher](https://github.com/WordPress/gutenberg/pull/16984). 
+-   Update [GitHub action exit codes.](https://github.com/WordPress/gutenberg/pull/17002) 
+-   Core Data: [return updated record in saveEntityRecord](https://github.com/WordPress/gutenberg/pull/17030).  
+-   Latest Posts Block: [(no title) instead of (Untitled) for a post without a title](https://github.com/WordPress/gutenberg/pull/17074).  
+-   [Remove borders around inserter items for blocks with children blocks](https://github.com/WordPress/gutenberg/pull/17083).  
+-   Add [disabled block count](https://github.com/WordPress/gutenberg/pull/17103) in the block manager.  
+-   Writing Flow:  
+	-   Add [splitting in the quote block](https://github.com/WordPress/gutenberg/pull/17121).   
+	-   Allow [undoing of patterns with BACKSPACE and ESC.](https://github.com/WordPress/gutenberg/pull/14776)   
+
+### Experiments
+-   Widgets Screen:
+	-   Fix: [Blocks are too close together](https://github.com/WordPress/gutenberg/issues/16992).
+	-   Add [Button block appender](https://github.com/WordPress/gutenberg/pull/16971).
+
+### New APIs
+- Add [callbacks to ServerSideRenderer](https://github.com/WordPress/gutenberg/pull/16512) to handle failures with custom renderers.  
+- Add the [block example API](https://github.com/WordPress/gutenberg/pull/17124) and use it for inserter and switcher previews.
+- Enable an [optional namespace parameter for hasAction & hasFilter ](https://github.com/WordPress/gutenberg/pull/15362).
+    
+
+### Bug Fixes
+- The [duplicate button appears even if the block is not allowed](https://github.com/WordPress/gutenberg/pull/17007).
+- [Double scrollbar appearing](https://github.com/WordPress/gutenberg/pull/17031) in full-screen mode.
+- RichText: [ignore selection changes during composition](https://github.com/WordPress/gutenberg/pull/16960)
+- Missing [default functions as props in BlockEditorProvider](https://github.com/WordPress/gutenberg/pull/17036).
+- [Button block does not center](https://github.com/WordPress/gutenberg/pull/17063)  on the editor.
+- Guard [block component against zombie state](https://github.com/WordPress/gutenberg/pull/17092) bug.
+- Add [truthy check for the Popover component](https://github.com/WordPress/gutenberg/pull/17100) onClose prop before calling it.
+- Make InnerBlocks [only force the template on directly set lockings](https://github.com/WordPress/gutenberg/pull/16973).
+- Check to [ensure focus has intentionally left the wrapped component in withFocusOutside](https://github.com/WordPress/gutenberg/pull/17051) HOC.
+- Correctly [transform images with external sources](https://github.com/WordPress/gutenberg/pull/16548) into a gallery.
+- [Block toolbar appears above sidebar](https://github.com/WordPress/gutenberg/pull/17108) on medium viewports.
+- [Basecontrol name undefined](https://github.com/WordPress/gutenberg/pull/17044/files) triggring eslint-plugin TypeError.
+- [Image flickering & focus lose](https://github.com/WordPress/gutenberg/pull/17175) on resizing.
+- Add [get_item_schema function to WP_REST_Widget_Areas_Controller ](https://github.com/WordPress/gutenberg/pull/15981).
+- [Empty Classic Editor inside innerBlock fatal error](https://github.com/WordPress/gutenberg/pull/17164).
+- [Changing month in post publish date closes the popover](https://github.com/WordPress/gutenberg/pull/17164).
+
+### Various
+
+-   Update [re-resizable dependency](https://github.com/WordPress/gutenberg/pull/17011) 
+-   Use [mixins in button styles instead of media queries.](https://github.com/WordPress/gutenberg/pull/17012)  
+-   [Fix performance tests with the introduction of the navigation mode](https://github.com/WordPress/gutenberg/pull/17034)  
+-   RichText code improvements: [#16905](https://github.com/WordPress/gutenberg/pull/16905), [#16962](https://github.com/WordPress/gutenberg/pull/16962).
+-   Scripts:
+	- Improve the way [test files are discovered](https://github.com/WordPress/gutenberg/pull/17033).
+	- Improve [recommended settings](https://github.com/WordPress/gutenberg/pull/17027) included in the package.
+	- Use [the SCSS shared stylelint-config-wordpress config](https://github.com/WordPress/gutenberg/pull/17060).  
+-   [Ignore the WordPress directory](https://github.com/WordPress/gutenberg/pull/16243) in stylelint.
+-   Fix: [edit post sets some default block appender styles](https://github.com/WordPress/gutenberg/pull/16943).
+-   Build: [remove global install of latest npm](https://github.com/WordPress/gutenberg/pull/17134).
+-   Project automation:
+    - Rewrite [actions using JavaScript](https://github.com/WordPress/gutenberg/pull/17080).
+    - Fix: [Add first-time contributor label](https://github.com/WordPress/gutenberg/pull/17156).
+    - Fix: [Add milestone](https://github.com/WordPress/gutenberg/pull/17157).
+-   Remove [unused CSS from ColorPalette](https://github.com/WordPress/gutenberg/pull/17152) component.
+    
+
+### Documentation
+-   Add [examples for the lockPostSaving and unlockPostSaving](https://github.com/WordPress/gutenberg/pull/16713)actions.
+-   Add guidance for [adding/proposing/suggesting new components](https://github.com/WordPress/gutenberg/pull/16845) to the wordpress/components npm package.
+-   Add section about [updating package after new releases](https://github.com/WordPress/gutenberg/pull/17026).
+-   Add [ESNext examples to format API](https://github.com/WordPress/gutenberg/pull/16804) tutorial.
+-   Document [server-side functions that allow registering block styles](https://github.com/WordPress/gutenberg/pull/16997).
+    
+
+### Mobile
+-   [Reset toolbar scroll on content change](https://github.com/WordPress/gutenberg/pull/16945).
+-   [Extract caption component](https://github.com/WordPress/gutenberg/pull/16825).
+-   [Not use ListEdit](https://github.com/WordPress/gutenberg/pull/17070).
+-   [Hide replaceable blocks when adding blocks](https://github.com/WordPress/gutenberg/pull/16931).
+-   Make [tapping at the end of post always insert at the end of the post.](https://github.com/WordPress/gutenberg/pull/16934)
+= 6.3.0 =
+
+### Features
+
+-   A11y: Support [Navigation and Edit modes](https://github.com/WordPress/gutenberg/pull/16500) to ease navigating between blocks.
+-   [Support text alignments](https://github.com/WordPress/gutenberg/pull/16111) in Table block columns.
+-   Support changing the [separator block color](https://github.com/WordPress/gutenberg/pull/16784).
+
+### Enhancements
+
+-   Improvements to the BlockPreview component:
+	-   Support [previewing a multiple blocks](https://github.com/WordPress/gutenberg/pull/16033) (a template).
+	-   [Unify BlockPreview and BlockPreviewContent](https://github.com/WordPress/gutenberg/pull/16801) into a unique component.
+	-   Hide [block appenders](https://github.com/WordPress/gutenberg/pull/16887).
+	-   [Expose the component](https://github.com/WordPress/gutenberg/pull/16834) in the block-editor module.
+	-   [Scale the preview content](https://github.com/WordPress/gutenberg/pull/16873) according to the width of the preview container.
+-   Improvements to the Modal component design:
+	-   Increase the [padding of the Modal component](https://github.com/WordPress/gutenberg/pull/16690).
+	-   Correct the [position of the close button](https://github.com/WordPress/gutenberg/pull/16883).
+-   Use classnames instead of inline styles for text alignments in:
+	-   [Verse block](https://github.com/WordPress/gutenberg/pull/16777).
+	-   [Quote block](https://github.com/WordPress/gutenberg/pull/16779).
+	-   [Paragraph block](https://github.com/WordPress/gutenberg/pull/16794).
+-   Add a [purple color option](https://github.com/WordPress/gutenberg/pull/16833) to the default color palette.
+-   A11y: Visible [focus and active styles for Windows high contrast mode](https://github.com/WordPress/gutenberg/pull/16554).
+-   Improve the design of the [inline image controls](https://github.com/WordPress/gutenberg/pull/16793) in the Gallery block.
+-   I18n: Align the [Read more string](https://github.com/WordPress/gutenberg/pull/16865) with WordPress Core.
+-   Removes the word-break :break-all CSS rule from the [table cells](https://github.com/WordPress/gutenberg/pull/16741).
+-   Update the [Notice dismiss button](https://github.com/WordPress/gutenberg/pull/16926) to match other Gutenberg UI (color and icon).
+-   Modifies the shortcut hierarchy in the [keyboard shortcuts modal](https://github.com/WordPress/gutenberg/pull/16724).
+-   Remove [edit gallery toolbar button](https://github.com/WordPress/gutenberg/pull/16778).
+-   Add the possibility to [disable document settings panels registered by plugins](https://github.com/WordPress/gutenberg/pull/16900).
+-   [ESLint plugin: Enable `wp` global by default](https://github.com/WordPress/gutenberg/pull/16904) in the `recommended` config.
+
+### Experiments
+
+-   Add a settings page to the plugin to [enable/disable experimental features](https://github.com/WordPress/gutenberg/pull/16626).
+-   Add [padding when interacting with](https://github.com/WordPress/gutenberg/pull/14961)  [nested blocks](https://github.com/WordPress/gutenberg/pull/16820) to ease parent block selections.
+-   Widgets Screen:
+	-   Prevent the [block toolbar from overlapping](https://github.com/WordPress/gutenberg/pull/16765) the widget area header.
+	-   Add the [BlockEditorKeyboardShortcuts](https://github.com/WordPress/gutenberg/pull/16972) component.
+	-   Fixed [block paddings](https://github.com/WordPress/gutenberg/pull/16944).
+
+### New APIs
+
+-   Support [Entities](https://github.com/WordPress/gutenberg/pull/16823)  [Local Edits](https://github.com/WordPress/gutenberg/pull/16867) in the Core Data Module.
+-   Support [autosaving entities](https://github.com/WordPress/gutenberg/pull/16903) in the Core Data Module.
+-   Add support for [disabled dropdown items](https://github.com/WordPress/gutenberg/pull/15976) in SelectControl.
+-   Add [onFocusOutside](https://github.com/WordPress/gutenberg/pull/14851) prop as a replacement to Popover onClickOutside.
+-   [Stop using unstable props on DropdownMenu.](https://github.com/WordPress/gutenberg/pull/15968)
+
+### Bug Fixes
+
+-   [Prevent tooltips from appearing](https://github.com/WordPress/gutenberg/pull/16800) on mouse down.
+-   Avoid passing event object to [save button onSave prop](https://github.com/WordPress/gutenberg/pull/16770).
+-   Prevent [image captions loss](https://github.com/WordPress/gutenberg/pull/15004) when editing a Gallery block.
+-   Rerender [FormtTokenField](https://github.com/WordPress/gutenberg/pull/14819) component when the suggestions prop changes.
+-   Handle scalar [return types values in useSelect](https://github.com/WordPress/gutenberg/pull/16669).
+-   Fix [php notice](https://github.com/WordPress/gutenberg/pull/16189) that can be triggered while using the Search block.
+-   Fix the [Resolve Block Modal](https://github.com/WordPress/gutenberg/pull/15581) columns sizes.
+-   Fix [duplicate content when pasting](https://github.com/WordPress/gutenberg/pull/16857) text into newly focused RichText.
+-   Fix [Table block cell selection](https://github.com/WordPress/gutenberg/pull/16653) when clicking on the edge of the cells.
+-   Prevent the [CSS reset](https://github.com/WordPress/gutenberg/pull/16856) from applying to the meta boxes.
+-   Fix [misaligned Block toolbars](https://github.com/WordPress/gutenberg/pull/16858) on floated blocks.
+-   Fix the [Notice component](https://github.com/WordPress/gutenberg/pull/16861) close button alignment and [height](https://github.com/WordPress/gutenberg/pull/16891).
+-   [Link to the full size images](https://github.com/WordPress/gutenberg/pull/16011) in the Gallery block.
+-   Avoid leaking CSS transforms when [disabling block animations](https://github.com/WordPress/gutenberg/pull/16893).
+-   A11y: Avoid focusing the PostTitle component when [switching between code and visual editor](https://github.com/WordPress/gutenberg/pull/16874).
+-   A11y: Add a [confirmation step to enable the Custom Fields](https://github.com/WordPress/gutenberg/pull/15688)  [option](https://github.com/WordPress/gutenberg/pull/16918).
+-   [Disable block insertion buttons](https://github.com/WordPress/gutenberg/pull/15024) and [prevent moving blocks](https://github.com/WordPress/gutenberg/pull/14924) depending on the contextual restrictions (template locking and default block availability).
+-   Fix [Block manager not honoring the allowed_block_types](https://github.com/WordPress/gutenberg/pull/16586) hook.
+-   [Keep the Image block alt and caption attributes](https://github.com/WordPress/gutenberg/pull/16051) while uploading a new image.
+-   Don't render [drop zone below the default block appender](https://github.com/WordPress/gutenberg/pull/16119).
+-   Prevent horizontal [arrow navigation errors](https://github.com/WordPress/gutenberg/pull/16846).
+-   Fix [shifting menu items on DropdownMenu](https://github.com/WordPress/gutenberg/pull/16871).
+-   Make API Fetch [refresh nonces as soon as they expired](https://github.com/WordPress/gutenberg/pull/16683).
+
+### Various
+-   Github actions:
+	-   [Automatically assign issues](https://github.com/WordPress/gutenberg/pull/16700) to PR authors.
+	-   Automatically assign the [First-time Contributor label](https://github.com/WordPress/gutenberg/pull/16762).
+-   Avoid [unguarded getRangeAt usage](https://github.com/WordPress/gutenberg/pull/16212) and add eslint rule.
+-   Make the [e2e transforms tests](https://github.com/WordPress/gutenberg/pull/16739) more stable.
+-   [ESLint no-unused-vars-before-return rule](https://github.com/WordPress/gutenberg/pull/16799): Exempt destructuring only if to multiple properties.
+-   Output an [informational message for deprecations](https://github.com/WordPress/gutenberg/pull/16774) when no version provided.
+-   Refactor [registry selectors](https://github.com/WordPress/gutenberg/pull/16692) to allow calling them from other regular selectors.
+-   Bail early in the [deactivatePlugin e2e test utility](https://github.com/WordPress/gutenberg/pull/16816) if plugin is already inactive.
+-   Fix the [CheckboxControl](https://github.com/WordPress/gutenberg/pull/16551)  [styles](https://github.com/WordPress/gutenberg/pull/16863) in a WordPress agnostic context.
+-   Move the [auto-draft status and default title handling](https://github.com/WordPress/gutenberg/pull/16814) to the server.
+-   Code quality tweaks to the [Table block e2e tests](https://github.com/WordPress/gutenberg/pull/16872).
+-   [Fix JSDocs errors](https://github.com/WordPress/gutenberg/pull/16870) across the entire repository.
+-   [Upgrade Lerna](https://github.com/WordPress/gutenberg/pull/16919) to the latest version (3.16.4).
+-   [Upgrade](https://github.com/WordPress/gutenberg/pull/16875)  [Puppeteer](https://github.com/WordPress/gutenberg/pull/16937) to the latest version (1.19.0).
+-   [Upgrade ESLint](https://github.com/WordPress/gutenberg/pull/16921) to the latest version (6.1.0).
+-   Run [npm audit fix](https://github.com/WordPress/gutenberg/pull/16963) to fix dependency vulnerabilities.
+-   Audit and fix all [missing or obsolete package dependencies](https://github.com/WordPress/gutenberg/pull/16969).
+-   Fix issue with [jest caching of block.json](https://github.com/WordPress/gutenberg/pull/16899) files.
+-   Add [eslint-plugin-jsdoc lint rule](https://github.com/WordPress/gutenberg/pull/16869) for better JSDoc linting.
+-   Fix [intermittent RichText e2e test failures](https://github.com/WordPress/gutenberg/pull/16952).
+-   [Replace the react-click-outside dependency usage](https://github.com/WordPress/gutenberg/pull/16878) with our own Higher-order component withFocusOutside.
+-   Improve the [usage of eslint-disable directives](https://github.com/WordPress/gutenberg/pull/16941).
+-   Migrate the [Github Actions](https://github.com/WordPress/gutenberg/pull/16981) to the new YAML syntax.
+
+### Documentation
+
+-   Enhance the components Design Documentation and guidelines:
+	-   [DateTime](https://github.com/WordPress/gutenberg/pull/16757) component.
+	-   [Spinner](https://github.com/WordPress/gutenberg/pull/16760) component.
+	-   [ClipboardButton](https://github.com/WordPress/gutenberg/pull/16758) component.
+-   Add section about adding [new dependencies to WordPress](https://github.com/WordPress/gutenberg/pull/16876)  [packages](https://github.com/WordPress/gutenberg/pull/16923).
+-   Add [Figma ressources](https://github.com/WordPress/gutenberg/pull/16892) to the Design documentation.
+-   Document [URL inputs reusable components](https://github.com/WordPress/gutenberg/pull/16566).
+-   Typos and tweaks: [1](https://github.com/WordPress/gutenberg/pull/16852), [2](https://github.com/WordPress/gutenberg/pull/16832), [3](https://github.com/WordPress/gutenberg/pull/16908).
+
+### Mobile
+
+-   Refactor [BlockToolbar out of](https://github.com/WordPress/gutenberg/pull/16677)  [BlockList](https://github.com/WordPress/gutenberg/pull/16906).    
+-   Fix [toolbar bottom inset for iPhone X](https://github.com/WordPress/gutenberg/pull/16961) devices.
+
+= 6.2.0 =
+
+### Enhancements
+- Introduce [Link Target](https://github.com/WordPress/gutenberg/pull/10128)  [support](https://github.com/WordPress/gutenberg/pull/16497) in Button block.  
+- Limit the [maximum height of the HTML block](https://github.com/WordPress/gutenberg/pull/16187).
+- Show the [preview button on mobile viewports](http://update/show-post-preview-button-on-mobile).
+- [Remove nested block restrictions](https://github.com/WordPress/gutenberg/pull/16751) from the Cover and Media & Text blocks.
+- A11y: Improving and standardize the [block styles focus and active states](https://github.com/WordPress/gutenberg/pull/16545).
+- Always [collapse block alignment toolbars](https://github.com/WordPress/gutenberg/pull/16557).
+
+### Bug Fixes
+- Fix using the [Classic block in nested contexts](https://github.com/WordPress/gutenberg/pull/16477).
+- Fix [lost nested blocks](https://github.com/WordPress/gutenberg/pull/14443) if the container block is missing.
+- Fix [pasting content into nested blocks](https://github.com/WordPress/gutenberg/pull/16717).
+- Fix [race condition in the block moving animation](https://github.com/WordPress/gutenberg/pull/16750) causing blocks to overlap.
+- A11y: Make the [Table block accessible](https://github.com/WordPress/gutenberg/pull/16324) at high zoom levels.
+- A11y: Change the [font size picker markup](https://github.com/WordPress/gutenberg/pull/16148) to use select.
+- A11y: Match the [primary button disabled](https://github.com/WordPress/gutenberg/pull/16103)  [state](https://github.com/WordPress/gutenberg/pull/16769) to Core's color contrast.
+- Fix the [z-index of the block toolbars](https://github.com/WordPress/gutenberg/pull/16530) for blocks following wide aligned blocks.
+- [Hide the columns count control](https://github.com/WordPress/gutenberg/pull/16476) when the columns block placeholder is shown.
+- [Prevent the block movers from disappearing](https://github.com/WordPress/gutenberg/pull/16579) on middle breakpoints for full/wide blocks.
+- [Slimmer top/bottom spacing inside notices](https://github.com/WordPress/gutenberg/pull/16589) shown outside the editor canvas.
+- Fix [converting video shortcode into video blocks](https://github.com/WordPress/gutenberg/pull/16588) when file type sources are used.
+- [Localize the read more link](https://github.com/WordPress/gutenberg/pull/16665) in the latest posts block.
+- Fix issue with [inconsistent nesting appender](https://github.com/WordPress/gutenberg/pull/16453).
+- Fix styling of [IconButton used in ButtonGroup](https://github.com/WordPress/gutenberg/pull/16686) components.
+- [Remove Change Permalinks button](https://github.com/WordPress/gutenberg/pull/16395) when permalink is not editable.
+- Fix [aspect ratio typo and recalculate padding](https://github.com/WordPress/gutenberg/pull/16573) in embed block.
+- Ensure [hour/minute fields are always shown left to right](https://github.com/WordPress/gutenberg/pull/16375) in RTL languages.
+- Refactor the empty line padding in the RichText component. This fixes [padding issues in the list block in Firefox](https://github.com/WordPress/gutenberg/pull/14846).
+- Improve the stability of the [RichText placeholder](https://github.com/WordPress/gutenberg/pull/16733).
+- Add [custom placeholder support](https://github.com/WordPress/gutenberg/pull/16783) for the button block.
+- Show the [image size labels on the block-based widget screen](https://github.com/WordPress/gutenberg/pull/16763).
+
+### Documentation
+- Clarify the [block title and description conventions](https://github.com/WordPress/gutenberg/pull/16458).
+- Add [RichText component documentation](https://github.com/WordPress/gutenberg/pull/15956) to the Block Editor Handbook.
+- Improve the [repository triage docs](https://github.com/WordPress/gutenberg/pull/16234).
+- Adds documentation for the [PluginDocumentSettingPanel SlotFill](https://github.com/WordPress/gutenberg/pull/16620).
+- Tweaks and typos: [1](https://github.com/WordPress/gutenberg/pull/16438), [2](https://github.com/WordPress/gutenberg/pull/16455), [3](https://github.com/WordPress/gutenberg/pull/16468), [4](https://github.com/WordPress/gutenberg/pull/16456), [5](https://github.com/WordPress/gutenberg/pull/16470), [6](https://github.com/WordPress/gutenberg/pull/16469), [7](https://github.com/WordPress/gutenberg/pull/16526), [8](https://github.com/WordPress/gutenberg/pull/16531), [9](https://github.com/WordPress/gutenberg/pull/16528), [10](https://github.com/WordPress/gutenberg/pull/16610), [11](https://github.com/WordPress/gutenberg/pull/16450), [12](https://github.com/WordPress/gutenberg/pull/16756) , [13](https://github.com/WordPress/gutenberg/pull/16693), [14](https://github.com/WordPress/gutenberg/pull/16787).
+
+### Divers
+- Add a [simple API to register block style variations](https://github.com/WordPress/gutenberg/pull/16356) on the server.
+- Allow alternative blocks to be used to handle [Grouping interactions](https://github.com/WordPress/gutenberg/pull/16278).
+- Fix Travis instability by [waiting for MySQL availability](https://github.com/WordPress/gutenberg/pull/16461) before install the plugin.
+- Continue the [generic RichText component](https://github.com/WordPress/gutenberg/pull/16309) refactoring.
+- Remove the [usage of the editor store](https://github.com/WordPress/gutenberg/pull/16184) from the block editor module.
+- Update the [MilestoneIt Github action](https://github.com/WordPress/gutenberg/pull/16511) to read the plugin version from master.
+- Refactor the post meta block attributes to use a generic [custom sources mechanism](https://github.com/WordPress/gutenberg/pull/16402).
+- Expose [position prop in DotTip](https://github.com/WordPress/gutenberg/pull/14972) component.
+- Avoid docker [containers automatic restart](https://github.com/WordPress/gutenberg/pull/16547).
+- Bump [Lodash dependencies to 4.17.14](https://github.com/WordPress/gutenberg/pull/16567).
+- Fix the [build command on Windows](https://github.com/WordPress/gutenberg/pull/16029) environments.
+- Add allowedFormats and withoutInteractiveFormats props to the RichText component to [control the available formats per RichText](https://github.com/WordPress/gutenberg/pull/14542).
+- Remove [inappropriate executable permissions](https://github.com/WordPress/gutenberg/pull/16687) from core-data package files.
+- ESLint Plugin: [Exempt React hooks from no-unused-vars-before-return](https://github.com/WordPress/gutenberg/pull/16737).
+- Use React [Portal based slots for the block toolbar](https://github.com/WordPress/gutenberg/pull/16421).
+- Use [combineReducers utility from the data module](https://github.com/WordPress/gutenberg/pull/16752) instead of redux.
+- Support [hideLabelFromVision prop](https://github.com/WordPress/gutenberg/pull/16701) in all control components.
+- Adds missing [babel-jest and core-js](https://github.com/WordPress/gutenberg/pull/16259) dependencies to the scripts package.
+
+### Mobile
+- [Tapping on an empty editor](https://github.com/WordPress/gutenberg/pull/16439) area creates a new paragraph block.
+- [Fix video uploads](https://github.com/WordPress/gutenberg/pull/16331) when the connection is lost and restored.
+- Track [unsupported block list](https://github.com/WordPress/gutenberg/pull/16434).
+- Insert [new block below the post title](https://github.com/WordPress/gutenberg/pull/16440) if the post title is selected.
+- Run the [mobile tests in the Gutenberg CI](https://github.com/WordPress/gutenberg/pull/16404) server.
+- Replace use of [deprecated componentWillReceiveProps](https://github.com/WordPress/gutenberg/pull/16577) in ImageEdit.
+- Show placeholder when [adding block from the post title](https://github.com/WordPress/gutenberg/pull/16539).
+- [Blur post title](https://github.com/WordPress/gutenberg/pull/16642) any time another block is selected.
+- Inserting block from the post title [replaces empty blocks](https://github.com/WordPress/gutenberg/pull/16574).
+- [Update Video caption placeholder color](https://github.com/WordPress/gutenberg/pull/16716) to match other placeholder text styles.
+- Move the [post title selection state](https://github.com/WordPress/gutenberg/pull/16704) to the store.
+
+
+= 6.1.1 =
+
+### Bug Fixes
+
+- Prevent automatic conversion of widgets to blocks when using the customizer.
+- Fix missing block properties on block registration filters used for the deprecated versions.
+
+= 6.1.0 =
+
+### Enhancements
+
+*   [Introduce motion](https://github.com/WordPress/gutenberg/pull/16065)/animation when reordering/adding/removing blocks.
+*   Improve the [Image block link settings](https://github.com/WordPress/gutenberg/pull/15570) and move it to the block toolbar.
+*   Use a snackbar notice when clicking “[Copy all content](https://github.com/WordPress/gutenberg/pull/16265)”.
+*   Show [REST API error messages](https://github.com/WordPress/gutenberg/pull/15657) as notices.
+*   Clarify the wording of the view link in the [Permalink panel](https://github.com/WordPress/gutenberg/pull/16041).
+*   [Hide the “Copy all content”](https://github.com/WordPress/gutenberg/pull/16286) button if the post is empty.
+*   [Hide the ungroup action](https://github.com/WordPress/gutenberg/pull/16332) when there are no inner blocks.
+*   Use admin schemes dependent [focus state for primary buttons](https://github.com/WordPress/gutenberg/pull/16275).
+*   Add support for the [table cells scope attribute](https://github.com/WordPress/gutenberg/pull/16154) when pasting.
+
+### Experiments
+
+*   Introduce a new [Customizer Panel](https://github.com/WordPress/gutenberg/pull/16204) to edit block-based widget areas.
+*   Add the [block inspector](https://github.com/WordPress/gutenberg/pull/16203) to the widgets screen.
+*   Add a [global inserter](http://add/inserter-widget-areas) to the widgets screen.
+
+### Bug Fixes
+
+*   Show the [pre-publish panel for contributors](https://github.com/WordPress/gutenberg/pull/16424).
+*   Fix the [save in progress state](https://github.com/WordPress/gutenberg/pull/16303) of the Publish/Update Button.
+*   Fix [adding/removing columns from the table block](https://github.com/WordPress/gutenberg/pull/16410) when using header/footer sections.
+*   Fix Image block not [preserving custom dimensions](https://github.com/WordPress/gutenberg/pull/16125) when opening the media library.
+*   [Resize Image blocks](https://github.com/WordPress/gutenberg/pull/16398) properly when changing the width from the inspector.
+*   Fix php error that can potentially be triggered by [gutenberg_is_block_editor](https://github.com/WordPress/gutenberg/pull/16201).
+*   Fix error when using the [“tag” block attribute source type](https://github.com/WordPress/gutenberg/pull/16290).
+*   Fix [chrome rendering bug](https://github.com/WordPress/gutenberg/pull/16325) happening when resizing images.
+*   Fix the [data-block style selector](https://github.com/WordPress/gutenberg/pull/16207) to avoid affecting third-party components.
+*   Allow the [columns layout options](https://github.com/WordPress/gutenberg/pull/16371) to wrap on small screens.
+*   Fix [isShallowEqual](https://github.com/WordPress/gutenberg/pull/16329) edge case when the second argument is undefined.
+*   Prevent the [disabled block switcher icon](https://github.com/WordPress/gutenberg/pull/16390) from becoming unreadable.
+*   Fix [Group Block deprecation](https://github.com/WordPress/gutenberg/pull/16348) and any deprecation relying on hooks.
+*   A11y:
+    *   Make the [top toolbar wrap](https://github.com/WordPress/gutenberg/pull/16250) at high zoom levels.
+    *   Fix the [sticky notices](https://github.com/WordPress/gutenberg/pull/16255) at high zoom levels.
+
+### Performance
+
+*   Improve the performance of the [i18n Tannin library](https://github.com/WordPress/gutenberg/pull/16337).
+*   Track the [block parent](https://github.com/WordPress/gutenberg/pull/16392) in the state to optimize hierarchy selectors.
+*   Add a [cache key](https://github.com/WordPress/gutenberg/pull/16407) tracked in state to optimize the getBlock selector.
+
+### Documentation
+
+*   Document the [plugin release tool](https://github.com/WordPress/gutenberg/pull/16366).
+*   Document the use-cases of the [dynamic blocks](https://github.com/WordPress/gutenberg/pull/16228).
+*   Tweaks and typos: [1](https://github.com/WordPress/gutenberg/pull/16267), [2](https://github.com/WordPress/gutenberg/pull/16153), [3](https://github.com/WordPress/gutenberg/pull/16170), [4](https://github.com/WordPress/gutenberg/pull/16312), [5](https://github.com/WordPress/gutenberg/pull/16320), [6](https://github.com/WordPress/gutenberg/pull/16138).
+
+### Various
+
+*   Introduce a [PluginDocumentSettingPanel](https://github.com/WordPress/gutenberg/pull/13361) slot to allow third-party plugins to add panels to the document sidebar tab.
+*   [Deploy the playground](https://github.com/WordPress/gutenberg/pull/16345) automatically to Github Pages. [https://wordpress.github.io/gutenberg/](https://wordpress.github.io/gutenberg/)
+*   Extract a [generic RichText](http://try/move-rich-text) [component](https://github.com/WordPress/gutenberg/pull/16299) to the @wordpress/rich-text package.
+*   Refactor the [editor initialization](https://github.com/WordPress/gutenberg/pull/15444) to rely on a component.
+*   Remove unused internal [asType utility](https://github.com/WordPress/gutenberg/pull/16291).
+*   Fix [react-no-unsafe-timeout ESlint rule](https://github.com/WordPress/gutenberg/pull/16292) when using variable assignment.
+*   Add support for [watching block.json files](https://github.com/WordPress/gutenberg/pull/16150) when running “npm run dev”.
+*   Remove: experimental status from [blockEditor.transformStyles](https://github.com/WordPress/gutenberg/pull/16126).
+*   Upgrade [PHPCS composer dependencies](https://github.com/WordPress/gutenberg/pull/16387) and use [strict comparisons](https://github.com/WordPress/gutenberg/pull/16381) to align with the PHPCS guidelines.
+*   Fix a small console warning when running [performance tests](https://github.com/WordPress/gutenberg/pull/16409).
+
+### Mobile
+
+*   Correct the position of the [block insertion indicator](https://github.com/WordPress/gutenberg/pull/16272).
+*   Unify [Editor and Layout](https://github.com/WordPress/gutenberg/pull/16260) components with the web component hierarchy.
+
+
+= 6.0.0 =
+
+### Features
+
+* Support choosing a [pre-defined layout for the Columns block](https://github.com/WordPress/gutenberg/pull/16129). 
+
+### Enhancements
+
+* Add [Snackbar notices](https://github.com/WordPress/gutenberg/pull/16020) support to the widgets screen.
+* Add an [inner container to the Group](https://github.com/WordPress/gutenberg/pull/15210) [block](https://github.com/WordPress/gutenberg/pull/16202) to simplify theme styling.
+* Avoid stacking successive [MediaPlaceholder errors](https://github.com/WordPress/gutenberg/pull/14721).
+* Adjust the [DatePicker margins](https://github.com/WordPress/gutenberg/pull/16097).
+* Update the [Tag Cloud block](https://github.com/WordPress/gutenberg/pull/16098) [copy](https://github.com/WordPress/gutenberg/pull/16107) when no terms are found.
+* Add descriptive text and a link to [documentation in embed blocks](https://github.com/WordPress/gutenberg/pull/16101).
+* Improve placeholder text [phrasing for media blocks](https://github.com/WordPress/gutenberg/pull/16135).
+* Use classnames for the [text alignments in the heading block](https://github.com/WordPress/gutenberg/pull/16035).
+* Make the [inserter category icons grayscale](https://github.com/WordPress/gutenberg/pull/16163).
+* A11y: Make the [modal overlay scrim darker](https://github.com/WordPress/gutenberg/pull/15974).
+
+### Bug Fixes
+
+* Fix [warning messages triggered by the Group block](https://github.com/WordPress/gutenberg/pull/16096) icons.
+* Fix [horizontal scrollbar on full-wide blocks](https://github.com/WordPress/gutenberg/pull/16085) with nesting.
+* A11y: 
+  * Re-enable the [menu item hover state](https://github.com/WordPress/gutenberg/pull/16168) on small screens.
+  * Correct text zoom issue in the [Content Structure popover](https://github.com/WordPress/gutenberg/pull/15984).
+* Fix the [Popovers position](https://github.com/WordPress/gutenberg/pull/15949) in the widgets screen.
+* Fix the behavior of the [block toolbars in the widgets screen](https://github.com/WordPress/gutenberg/pull/15470).
+* Fix the editor in IE11 (use the [CJS version of react-spring](https://github.com/WordPress/gutenberg/pull/16196)).
+* Fix formatting of the [validation error messages](https://github.com/WordPress/gutenberg/pull/16173) in the console.
+* Fix breakage when the [CPT doesn’t support title](https://github.com/WordPress/gutenberg/pull/16236).
+
+### Various
+
+* Document and simplify the [multi-entrypoints support](https://github.com/WordPress/gutenberg/pull/15982) in the @wordpress/scripts package. 
+* Create sub-registry automatically when using [EditorProvider](https://github.com/WordPress/gutenberg/pull/15989).
+* Use classnames utility instead of concatenating [classnames in the TabPanel](https://github.com/WordPress/gutenberg/pull/16081) component.
+* Remove the default value for the [required onRequestClose prop](https://github.com/WordPress/gutenberg/pull/16074) in the Modal component.
+* Remove the [editor package dependency](https://github.com/WordPress/gutenberg/pull/15548) from the media blocks.
+* Fix the [playground build](https://github.com/WordPress/gutenberg/pull/15947) script.
+* Fix the [Github action assigning milestones](https://github.com/WordPress/gutenberg/pull/16084).
+* Fix [naming conventions](https://github.com/WordPress/gutenberg/pull/16091) for function containing CLI keyword.
+* Fix the [Travis build artifacts job](http://update/build-artifacts-npm-install) to use a full npm install while building.
+* Make [Calendar block resilient](https://github.com/WordPress/gutenberg/pull/16161) to the editor module not being present.
+* Ensure the Snackbar component is only used with a [single action button](https://github.com/WordPress/gutenberg/pull/16095).
+* Remove [SlotFillProvider and DropZoneProvider](https://github.com/WordPress/gutenberg/pull/15988) from the BlockEditorProvider.
+* Add the initial version of the [Block Registration RFC](https://github.com/WordPress/gutenberg/pull/13693).
+* Add [popoverProps prop to the Dropdown](https://github.com/WordPress/gutenberg/pull/14867) component.
+* Update [Image Block's image classes](https://github.com/WordPress/gutenberg/pull/15464) with dimensions.
+* Support registering [custom grouping blocks](https://github.com/WordPress/gutenberg/pull/15774).
+* Fix h1 heading typo so [h1 is same size as title](https://github.com/WordPress/gutenberg/pull/16253).
+* Remove the [custom class support from the legacy widget](https://github.com/WordPress/gutenberg/pull/16231) block.
+
+### Documentation
+
+* Prefer [register\_post\_meta](https://github.com/WordPress/gutenberg/pull/16032) over register\_meta.
+* Add [mention of Figma](https://github.com/WordPress/gutenberg/pull/16140) to the design contributing docs.
+* Add [supported attribute types](https://github.com/WordPress/gutenberg/pull/16220) for the Blocks API.
+* Enhance the [Annotations API](https://github.com/WordPress/gutenberg/pull/16233) documentation.
+* Tweaks and typos: [1](https://github.com/WordPress/gutenberg/pull/16083), [2](https://github.com/WordPress/gutenberg/pull/16073), [3](https://github.com/WordPress/gutenberg/pull/16087), [4](https://github.com/WordPress/gutenberg/pull/16102), [5](https://github.com/WordPress/gutenberg/pull/16145), [6](https://github.com/WordPress/gutenberg/pull/16143), [7](https://github.com/WordPress/gutenberg/pull/16144), [8](https://github.com/WordPress/gutenberg/pull/16232), [9](https://github.com/WordPress/gutenberg/pull/16121), [10](https://github.com/WordPress/gutenberg/pull/16235), [11](https://github.com/WordPress/gutenberg/pull/15394).
+
+### Mobile
+
+* Fix [multiline Image block captions](https://github.com/WordPress/gutenberg/pull/16071) in iOS.
+* Avoid unnecessary [div elements in the content of Quote](https://github.com/WordPress/gutenberg/pull/16072) blocks.
+* Update the default [colors used in the RichText](https://github.com/WordPress/gutenberg/pull/16016) component.
+* Fix [pasting text on Post Title](https://github.com/WordPress/gutenberg/pull/16116).
+* Unify the web and mobile components hierarchy:
+  * [BlockPicker and Inserter](https://github.com/WordPress/gutenberg/pull/16114).
+  * [BlockToolbar](https://github.com/WordPress/gutenberg/pull/16213).
+  * [BlockMobileToolbar](https://github.com/WordPress/gutenberg/pull/16177).
+  * [BlockListBlock](https://github.com/WordPress/gutenberg/pull/16223).
+  * [BlockList](https://github.com/WordPress/gutenberg/pull/16239).
+* Add native component [HTMLTextInput](https://github.com/WordPress/gutenberg/pull/16226).
+* Update the video player to [open the URL by browser](https://github.com/WordPress/gutenberg/pull/16089) on Android.
+* Re-enable the [Video block on Android](https://github.com/WordPress/gutenberg/pull/16215).
+
+= 5.9.2 =
+
+### Bug Fixes
+
+ - Fix Regression for blocks using InnerBlocks.Content from the editor package (support forwardRef components in the block serializer).
+
+= 5.9.1 =
+
+### Bug Fixes
+
+* Fix the issue where [statics for deprecated components were not hoisted](https://github.com/WordPress/gutenberg/pull/16152)
+
+= 5.9.0 =
+
+### Features
+
+*   Allow [grouping/ungrouping blocks](https://github.com/WordPress/gutenberg/pull/14908) using the Group block.
+
+### Enhancements
+
+*   Improve the selection of inner blocks: [Clickthrough selection](https://github.com/WordPress/gutenberg/pull/15537).
+*   Introduce the [snackbar notices](https://github.com/WordPress/gutenberg/pull/15594) and use them for the save success notices.
+*   Use [consistent colors in the different menus](https://github.com/WordPress/gutenberg/pull/15531) items.
+*   [Consolidate the different dropdown menus](https://github.com/WordPress/gutenberg/pull/14843) to use the DropdownMenu component.
+*   Expand the [**prefered-reduced-motion** support](https://github.com/WordPress/gutenberg/pull/15850) to all the animations.
+*   Add a subtle [animation to the snackbar](https://github.com/WordPress/gutenberg/pull/15908) notices and provide new React hooks for media queries.
+*   Redesign the [Table block placeholder](https://github.com/WordPress/gutenberg/pull/15903).
+*   [Always show the side inserter](https://github.com/WordPress/gutenberg/pull/15864) on the last empty paragraph block.
+*   Widgets Screen:
+    *   Add the [in progress state](https://github.com/WordPress/gutenberg/pull/16019) to the save button.
+    *   Add the RichText [Format Library](https://github.com/WordPress/gutenberg/pull/15948).
+*   Improve the [Group and Ungroup icons](https://github.com/WordPress/gutenberg/pull/16001).
+*   The [Spacer block clears all](https://github.com/WordPress/gutenberg/pull/15874) the previous floated blocks.
+
+### Bug Fixes
+
+*   [Focus the Button block’s input](https://github.com/WordPress/gutenberg/pull/15951) upon creation.
+*   Prevent [Embed block crashes](https://github.com/WordPress/gutenberg/pull/15866) when used inside locked containers.
+*   Properly [center the default appender placeholder](https://github.com/WordPress/gutenberg/pull/15868).
+*   Correct [default appender icon transition jump](https://github.com/WordPress/gutenberg/pull/15892) in Safari.
+*   Only apply [appender margins](https://github.com/WordPress/gutenberg/pull/15888) when the appender is inside of a block.
+*   Avoid loading [reusable blocks editor styles](https://github.com/WordPress/gutenberg/pull/14607) in the frontend.
+*   Correct [position of the "Remove Featured Image" button](https://github.com/WordPress/gutenberg/pull/15928) on small screens.
+*   Allow the [legacy widget block to render core widgets](https://github.com/WordPress/gutenberg/pull/15396).
+*   A11y:
+    *   Fix [wrong tab order in the data picker](https://github.com/WordPress/gutenberg/pull/15936) component.
+    *   Remove the [access keyboard shortcuts](https://github.com/WordPress/gutenberg/pull/15191) from the Format Library.
+*   Bail early in [createUpgradedEmbedBlock](https://github.com/WordPress/gutenberg/pull/15885) for invalid block types.
+*   Fix [DateTimePicker styles](https://github.com/WordPress/gutenberg/pull/15389) when used outside the WordPress context.
+*   Prevent the [Spacer block from being deselected](https://github.com/WordPress/gutenberg/pull/15884) when resized.
+*   Remove the [word breaking from the Media & Text](https://github.com/WordPress/gutenberg/pull/15871) block.
+*   [Keep the seconds value untouched](https://github.com/WordPress/gutenberg/pull/15495) when editing dates using the DateTimePicker component.
+*   Fix [tooltips styles](https://github.com/WordPress/gutenberg/pull/16043) specificity.
+*   Fix php errors happening when [calling get_current_screen](https://github.com/WordPress/gutenberg/pull/15983).
+
+### Various
+
+*   Introduce [useSelect](https://github.com/WordPress/gutenberg/pull/15737) and [useDispatch](https://github.com/WordPress/gutenberg/pull/15896) hooks to the data module.
+*   Adding embedded [performance tests](https://github.com/WordPress/gutenberg/pull/14506) to the repository.
+*   Support the [full plugin release process](https://github.com/WordPress/gutenberg/pull/15848) in the automated release tool.
+*   Speed up the [packages build](https://github.com/WordPress/gutenberg/pull/15230) [tool](https://github.com/WordPress/gutenberg/pull/15920) script and the [Gutenberg plugin build](https://github.com/WordPress/gutenberg/pull/15226) config.
+*   Extract media upload logic part into a new [@wordpress/media-utils package](https://github.com/WordPress/gutenberg/pull/15521).
+*   Introduce [**Milestone-It** Github Action](https://github.com/WordPress/gutenberg/pull/15826) to auto-assign milestones to merged PRs.
+*   Move the [transformStyles function](https://github.com/WordPress/gutenberg/pull/15572) to the block-editor package to use in the widgets screen.
+*   Allow plugin authors to [override the default anchor attribute](https://github.com/WordPress/gutenberg/pull/15959) definition.
+*   Add [overlayColor classname to cover blocks](https://github.com/WordPress/gutenberg/pull/15939) editor markup.
+*   [Skip downloading chromium](https://github.com/WordPress/gutenberg/pull/15886) when building the plugin zip.
+*   Add an [e2e test to check the heading colors](https://github.com/WordPress/gutenberg/pull/15784) [feature](https://github.com/WordPress/gutenberg/pull/15917).
+*   [Lint the ESlint config file](https://github.com/WordPress/gutenberg/pull/15887) (meta).
+*   Fix [i18n ESlint rules](https://github.com/WordPress/gutenberg/pull/15839) and use them in the [Gutenberg setup](https://github.com/WordPress/gutenberg/pull/15877).
+*   Fix error in the [plugin release tool](https://github.com/WordPress/gutenberg/pull/15840) when switching branches.
+*   Remove [unused stylesheet file](https://github.com/WordPress/gutenberg/pull/15845).
+*   Improve the setup of the WordPress packages [package.json files](https://github.com/WordPress/gutenberg/pull/15879).
+*   Remove the use of [popular plugins in e2e tests](https://github.com/WordPress/gutenberg/pull/15940).
+*   Ignore [linting files located in build](https://github.com/WordPress/gutenberg/pull/15977) folders by default.
+*   Add [default file patterns for the lint command](https://github.com/WordPress/gutenberg/pull/15890) of @wordpress/scripts.
+*   Extract the [ServerSideRender](https://github.com/WordPress/gutenberg/pull/15635) component to an independent package.
+*   Refactor the [HoverArea component as a React Hook](https://github.com/WordPress/gutenberg/pull/15038) instead.
+*   Remove [useless dependency](https://github.com/WordPress/gutenberg/pull/16034) from the @wordpress/edit-post package.
+*   [Deprecate components/selectors and actions](https://github.com/WordPress/gutenberg/pull/15770) moved to the editor package.
+*   Update [browserslist](https://github.com/WordPress/gutenberg/pull/16066) dependency.
+
+### Documentation
+
+*   Document the [remaining APIs](https://github.com/WordPress/gutenberg/pull/15176) of the data module.
+*   Add an [ESNext example](https://github.com/WordPress/gutenberg/pull/15828) to the i18n docs.
+*   Fix inline docs and add tests for [color utils](https://github.com/WordPress/gutenberg/pull/15861).
+*   Document missing [MenuItem prop](https://github.com/WordPress/gutenberg/pull/16061).
+*   Typos and tweaks: [1](https://github.com/WordPress/gutenberg/pull/15835), [2](https://github.com/WordPress/gutenberg/pull/15836), [3](https://github.com/WordPress/gutenberg/pull/15831), [4](https://github.com/WordPress/gutenberg/pull/15697), [5](https://github.com/WordPress/gutenberg/pull/14841), [6](https://github.com/WordPress/gutenberg/pull/15717), [7](https://github.com/WordPress/gutenberg/pull/15942), [8](https://github.com/WordPress/gutenberg/pull/15950), [9](https://github.com/WordPress/gutenberg/pull/16059).
+
+### Mobile
+
+*   Fix [caret position](https://github.com/WordPress/gutenberg/pull/15833) when splitting text blocks.
+*   Fix the initial value of the [“Open in New Tab” toggle](https://github.com/WordPress/gutenberg/pull/15812).
+*   Fix [Video block crash](https://github.com/WordPress/gutenberg/pull/15857) on drawing on Android.
+*   Fix caret position after [inline paste](https://github.com/WordPress/gutenberg/pull/15701).
+*   [Focus the RichText component](https://github.com/WordPress/gutenberg/pull/15878) on block mount.
+*   Port [KeyboardAvoidingView, KeyboardAwareFlatList and ReadableContentView](https://github.com/WordPress/gutenberg/pull/15913) to the @wordpress/components package.
+*   Fix [press of Enter on post title](https://github.com/WordPress/gutenberg/pull/15944).
+*   Move the [native unit tests](https://github.com/WordPress/gutenberg/pull/15589) to the Gutenberg repository.
+*   Improve the [styling of the Quote block](https://github.com/WordPress/gutenberg/pull/15990).
+*   Share [RichText line separator logic](https://github.com/WordPress/gutenberg/pull/15946) between web and native implementations.
+*   Fix [Video block showing a black background](https://github.com/WordPress/gutenberg/pull/15991) when upload is in progress or upload has failed.
+*   Allow passing a [style prop to the Icon](https://github.com/WordPress/gutenberg/pull/15778) component.
+*   Enable [sound on the Video block](https://github.com/WordPress/gutenberg/pull/15997).
+*   [Start playback immediately](https://github.com/WordPress/gutenberg/pull/15998) after video goes full screen.
+*   Fix [mobile quotes](https://github.com/WordPress/gutenberg/pull/16013) insertion and removal of empty lines.
+*   Move [unselected block accessibility handling](https://github.com/WordPress/gutenberg/pull/15225) to block-holder.
+*   Make the [More block ready-only](https://github.com/WordPress/gutenberg/pull/16005).
+*   Fix crash when [deleting all content of RichText](https://github.com/WordPress/gutenberg/pull/16018) based block.
+*   Fix for [extra BR tag on Title field](https://github.com/WordPress/gutenberg/pull/16021) on Android.
+*   Open [Video, Quote and More blocks](https://github.com/WordPress/gutenberg/pull/16031) to public.
+
+= 5.8.0 =
+
+# Features
+
+- Support changing the text color in the Heading block.
+- Support reordering gallery images.
+- Complete the initial version of the widgets screen POC
+  - Add an experimental endpoint to fetch the block-based widget areas.
+  - Connect the screen to the widget areas endpoint.
+  - Load the widget scripts.
+  - Load colors, font sizes and file upload settings in the widgets screen.
+  - Render the block based widget areas in the frontend.
+
+# Enhancements
+
+- Clarify the label of the custom classname inspector panel.
+- Update Calendar block icon for better alignment with the Archives block icon.
+- Add width constraints to the Media & Text block.
+- Allow dropping blocks into container blocks using the new block appender.
+- Provide default margins for the Latest Posts block excerpts.
+
+# Bug Fixes
+
+- Support block style variations for container blocks.
+- A11y
+  - Use semantic markup for the document outline.
+  - Fix the reading order of the keyboard shortcuts modal.
+  - Add a visible help text to the tags input.
+  - Update the icon of the Heading block.
+  - Move the View Posts anchor out of the toolbar section in the header.
+  - Close the block settings menu after removing the block.
+- Fix the blurriness of the disabled block switcher icons.
+- Fix missing template validation warning.
+- Fix several content spitting issues and make the onSplit prop stable.
+- Allow the Shortcode block field to expand automatically.
+- Left pad the DateTimePicker minutes input.
+- Fix the frontend classname used for the Latest Posts block excerpts.
+- Fix error happening when deleting the last block if the paragraph block is unregistered.
+- Fix focus jumps when typing in meta block fields.
+
+# Documentation
+
+- Improve the Slot/Fill documentation.
+- Document the Github teams used in the repository.
+- Document the icon prop for the MediaPlaceholder component.
+- Update the changelogs maintenance documentation.
+- Clarify the save function documentation to discourage side effects.
+- Clarify the block attributes documentation.
+- Replace @link with @see in JSDocs.
+- Fixes and tweaks to the API docs generation tool.
+- Typos and tweaks: 1, 2, 3, 4, 5, 6, 7, 8.
+
+# Various
+
+- Add a new editor setting to allow disabling the code editor.
+- Add a new @wordpress/data-controls package.
+- Add an automation tool to simplify the Gutenberg release process.
+- Support the all hook in non-production environments.
+- Expose hasResolver property on the data module selectors.
+- Support multiple pattern replacement for the custom-templated-path-webpack-plugin package.
+- Update node-sass dependency to support the latest Node.js version. 
+- Fix React warning showing when loading the editor (Fill component).
+- Fix React warning message when using the Image block.
+- Refactor the popover component using React Hooks.
+- Remove WebpackRTLPlugin usage.
+- Remove an outdated chrome fix for iframes drag and drop.
+- Skip Chromium download in Travis by default.
+- Rewrite Node.js packages to use CommonJS exports.
+- Speed up Docker and e2e tests setup Travis.
+- Extracted the deprecated block version declarations to their own files.
+- Add missing file from the published @wordpress/dependency-extraction-webpack-plugin-files package. 
+- Upgrade package dependencies: Lerna and Webpack Bundle Analyzer. 
+
+# Mobile
+
+- Add the Quote block.
+- Make the Video block publicly available.
+- Fix bug when merging blocks.
+- Improve the UI/UX of the different media blocks.
+- Support nested lists.
+- Fix Image block with an undefined url.
+- Support rich captions in the Image block.
+- Improve screen reader support on BottomSheet’s cells.
+- Fix several focus related bugs.
+- Fix undo related issue.
+- Update onSplit method on the native RichText component to the latest version.
+- Move the BottomSheet component to the @wordpress/components package.
+- Handle the iOS z-gesture to exit modals and block selection.
+- Implement the invalid block content UI.
+
+= 5.7.0 =
+
+## Features
+
+*   Support setting a [width to the column block](https://github.com/WordPress/gutenberg/pull/15499).
+*   Support showing [Post Content or excerpt in the Latest Posts](https://github.com/WordPress/gutenberg/pull/14627) [block](https://github.com/WordPress/gutenberg/pull/15453).
+*   Support [headers and footers in the Table block](https://github.com/WordPress/gutenberg/pull/15409).
+
+## Enhancement
+
+*   Improve the UX of the Group block by using the [individual block appender](https://github.com/WordPress/gutenberg/pull/14943).
+*   Support [updating images using Drag & Drop](https://github.com/WordPress/gutenberg/pull/14983).
+*   Clarify the name of the [inline code format](https://github.com/WordPress/gutenberg/pull/15199).
+*   Add a usability [warning when audio/video autoplay](https://github.com/WordPress/gutenberg/pull/15575) is applied.
+*   Replace the [Page Break block icon](https://github.com/WordPress/gutenberg/pull/15627) with Material version.
+
+## Bug Fixes
+
+*   A11y:
+    *   Fix [focal point picker input labels](https://github.com/WordPress/gutenberg/pull/15255).
+    *   Add role to the [copy all content menu item](https://github.com/WordPress/gutenberg/pull/15383).
+    *   Add [focus style to the document outline](https://github.com/WordPress/gutenberg/pull/15479) panel.
+    *   Update the [save indicator contrast](https://github.com/WordPress/gutenberg/pull/15514) to pass AA.
+    *   Fix The [tabbing order in the Gallery Block](https://github.com/WordPress/gutenberg/pull/15540).
+    *   Improve the [contrast of the button focus styles](https://github.com/WordPress/gutenberg/pull/15544).
+    *   Fixed [focus state of pressed AM/PM buttons](https://github.com/WordPress/gutenberg/pull/15582).
+    *   Fix the [URLInput aria properties](https://github.com/WordPress/gutenberg/pull/15564).
+    *   Avoid showing [pre-publish panel buttons](https://github.com/WordPress/gutenberg/pull/15460) as links.
+    *   Fix the [focus state of the links shown as buttons](https://github.com/WordPress/gutenberg/pull/15601).
+*   Fix [RTL keyboard interactions](https://github.com/WordPress/gutenberg/pull/15496).
+*   Fix [updates to RichText formats not being reflected in the UI](https://github.com/WordPress/gutenberg/pull/15573) synchronously.
+*   Fix extra line breaks added when [pasting from Google Docs](https://github.com/WordPress/gutenberg/pull/15557).
+*   Fix [copy, paste JavaScript errors](https://github.com/WordPress/gutenberg/pull/14712) in paragraph blocks with locking enabled.
+*   Fix [format buttons incorrectly toggled](https://github.com/WordPress/gutenberg/pull/15466) on RichText blur.
+*   Preserve the [caret’s horizontal position](https://github.com/WordPress/gutenberg/pull/15624) when navigating blocks.
+*   [Case-insensitive search](https://github.com/WordPress/gutenberg/pull/14786) for existing categories.
+*   Prevent the [Code block from rendering embeds](https://github.com/WordPress/gutenberg/pull/13996) or shortcodes.
+*   Fix the [SandBox component usage outside the WP-admin](https://github.com/WordPress/gutenberg/pull/15415) context.
+*   Fix the  [Cover block’s deprecated version](https://github.com/WordPress/gutenberg/pull/15449) attributes.
+*   Fix the [webpack dependency plugin](https://github.com/WordPress/gutenberg/pull/15430): filename function handling.
+*   Support [watching block.json changes](https://github.com/WordPress/gutenberg/pull/15455) in our build tool.
+*   Fix [ServerSideRender remaining in loading state](https://github.com/WordPress/gutenberg/pull/15412) when nothing is rendered.
+*   Fix the [server-side registered blocks](https://github.com/WordPress/gutenberg/pull/15414) in the widgets screen.
+*   Show the [block movers in the widgets](https://github.com/WordPress/gutenberg/pull/15076) screen.
+*   Decode the [HTML entities in the post author selector](https://github.com/WordPress/gutenberg/pull/15090).
+*   Fix [inconsistent heading sizes](https://github.com/WordPress/gutenberg/pull/15393) between the classic and the heading blocks.
+*   Add [check for author in post data before meta boxes save](https://github.com/WordPress/gutenberg/pull/15375) request submission.
+*   [Allow blocks drag & drop](https://github.com/WordPress/gutenberg/pull/14521) if locking is set to "insert".
+*   Fix [Youtube embed styles](https://github.com/WordPress/gutenberg/pull/14748) when used multiple times in a post.
+*   [Proxy the code/block-editor replaceBlock](https://github.com/WordPress/gutenberg/pull/15528) action in the core/editor package.
+*   Use [block-editor instead of editor in cover block](https://github.com/WordPress/gutenberg/pull/15547).
+*   Fix [block showing an error in Safari](https://github.com/WordPress/gutenberg/pull/15576) when focused.
+*   Fix small visual error in the [active state of the formatting buttons](https://github.com/WordPress/gutenberg/pull/15592).
+*   Fix the pinned [plugins buttons styles](https://github.com/WordPress/gutenberg/pull/15609) when toggled.
+*   Set caret position correctly when [merging blocks using the Delete key](https://github.com/WordPress/gutenberg/pull/15599).
+
+## Documentation
+
+*   Clarify [best practices pertaining to Color Palette](https://github.com/WordPress/gutenberg/pull/15006) values.
+*   Use [Block Editor instead of Gutenberg](https://github.com/WordPress/gutenberg/pull/15411) when appropriate in the Handbook.
+*   [Omit docblocks with private tag](https://github.com/WordPress/gutenberg/pull/15173) in the API Docs generation.
+*   Update docs for [selectors & actions moved to block-editor](https://github.com/WordPress/gutenberg/pull/15424).
+*   Update i18n docs to use [make-json command](https://github.com/WordPress/gutenberg/pull/15303) from wp-cli.
+*   Consolidate [doc generation tools](https://github.com/WordPress/gutenberg/pull/15421).
+*   Fix [next/previous links issue](https://github.com/WordPress/gutenberg/pull/15456).
+*   Webpack dependency plugin: Document [unsupported multiple instances](https://github.com/WordPress/gutenberg/pull/15451).
+*   Add a [DevHub manifest file](https://github.com/WordPress/gutenberg/pull/15254) to allow synchronizing the documentation to the DevHub.
+*   Typos and tweaks: [1](https://github.com/WordPress/gutenberg/pull/15251), [2](https://github.com/WordPress/gutenberg/pull/15204), [3](https://github.com/WordPress/gutenberg/pull/15260), [4](https://github.com/WordPress/gutenberg/pull/15262), [5](https://github.com/WordPress/gutenberg/pull/15170), [6](https://github.com/WordPress/gutenberg/pull/15386), [7](https://github.com/WordPress/gutenberg/pull/15423), [8](https://github.com/WordPress/gutenberg/pull/15448), [9](https://github.com/WordPress/gutenberg/pull/15454), [10](https://github.com/WordPress/gutenberg/pull/15494), [11](https://github.com/WordPress/gutenberg/pull/15506), [12](https://github.com/WordPress/gutenberg/pull/15527), [13](https://github.com/WordPress/gutenberg/pull/15508), [14](https://github.com/WordPress/gutenberg/pull/15505), [15](https://github.com/WordPress/gutenberg/pull/15612).
+
+## Various
+
+*   Support and use the [shorthand Fragment](https://github.com/WordPress/gutenberg/pull/15120) [syntax](https://github.com/WordPress/gutenberg/pull/15261).
+*   Update to [Babel 7.4 and core-js 3](https://github.com/WordPress/gutenberg/pull/15139).
+*   Upgrade [simple-html-tokenizer](https://github.com/WordPress/gutenberg/pull/15246) dependency.
+*   Pass individual files as arguments from watch to [build script](https://github.com/WordPress/gutenberg/pull/15219).
+*   Automate the [scripts dependencies](https://github.com/WordPress/gutenberg/pull/15124) generation.
+*   [Clean DropZone](https://github.com/WordPress/gutenberg/pull/15224) component’s unused state.
+*   remove [\_\_unstablePositionedAtSelection](https://github.com/WordPress/gutenberg/pull/15035) component.
+*   Refactor core/edit-post [INIT effect to use action-generators](https://github.com/WordPress/gutenberg/pull/14740) and controls.
+*   Improve [eslint disable comments](https://github.com/WordPress/gutenberg/pull/15384).
+*   Fix NaN [warning when initializing the FocalPointPicker](https://github.com/WordPress/gutenberg/pull/15400) component.
+*   [Export React.memo](https://github.com/WordPress/gutenberg/pull/15385) in the @wordpress/element package.
+*   Improve the [specificity of the custom colors styles](https://github.com/WordPress/gutenberg/pull/15167).
+*   [Preload the autosaves endpoint](https://github.com/WordPress/gutenberg/pull/15067) to avoid request when loading the editor.
+*   A11y: Add support for [Axe verification in e2e tests](https://github.com/WordPress/gutenberg/pull/15018).
+*   Refactor the [File block to use the block.json](https://github.com/WordPress/gutenberg/pull/14862) syntax.
+*   Remove [redundant duplicated reducers](https://github.com/WordPress/gutenberg/pull/15142).
+*   Add [integration tests for blocks with deprecations](https://github.com/WordPress/gutenberg/pull/15268).
+*   Allow [non-production env in wp-scripts build](https://github.com/WordPress/gutenberg/pull/15480).
+*   Use [React Hooks in the BlockListBlock component](https://github.com/WordPress/gutenberg/pull/14985).
+*   Add an [e2e test for custom taxonomies](https://github.com/WordPress/gutenberg/pull/15151).
+*   Fix [intermittent failures on block transforms](https://github.com/WordPress/gutenberg/pull/15485) tests.
+*   Remove [componentWillReceiveProps usage from ColorPicker](https://github.com/WordPress/gutenberg/pull/11772).
+*   Add an [experimental](https://github.com/WordPress/gutenberg/pull/15563) [CPT to be used in the block based widgets screen](https://github.com/WordPress/gutenberg/pull/15014).
+*   Split [JavaScript CI tasks to individual jobs](https://github.com/WordPress/gutenberg/pull/15229).
+*   Remove [unnecessary aria-label from the block inserter](https://github.com/WordPress/gutenberg/pull/15382) list items.
+
+## Mobile
+
+*   Add a first version of the [video block](https://github.com/WordPress/gutenberg/pull/14912).
+*   Fix the [Auto-scroll behavior on List](https://github.com/WordPress/gutenberg/pull/15048) block.
+*   Fix the [list handling on Android](https://github.com/WordPress/gutenberg/pull/15168).
+*   Improve [accessibility of the missing block](https://github.com/WordPress/gutenberg/pull/15457).
+
+= 5.6.1 =
+
+## Miscellaneous
+
+- Republish Gutenberg 5.6.0.
+
+= 5.6.0 =
+
+## Enhancements
+
+- Improve [focus state for button block](https://github.com/WordPress/gutenberg/pull/15058).
+- [Reduce specificity of block styles](https://github.com/WordPress/gutenberg/pull/14407) to make it easier for themes to style the editor.
+- Optimize data subscribers to [avoid unnecessary work](https://github.com/WordPress/gutenberg/pull/15041) on each editor change.
+- Avoid [overlapping block breadcrumb](https://github.com/WordPress/gutenberg/pull/15112) when block movers are visible for full- and wide-aligned blocks.
+- Preload [user permissions for reusable blocks](https://github.com/WordPress/gutenberg/pull/15061) to avoid UI flickering for block settings menu options.
+- Remove [unnecessary bottom padding](https://github.com/WordPress/gutenberg/pull/15158) for nested lists.
+- Restore [block movers to focus mode](https://github.com/WordPress/gutenberg/pull/15109).
+- Improve display of [categories list panel](https://github.com/WordPress/gutenberg/pull/15075).
+
+## Bug Fixes
+
+- [Restore block movers](https://github.com/WordPress/gutenberg/pull/15022) to full- and wide-aligned blocks.
+- Always show [drag handles](https://github.com/WordPress/gutenberg/pull/15025) for nested blocks, even when only a single block exists.
+- Improve [HTML output for formatted text](https://github.com/WordPress/gutenberg/pull/14555).
+- Fix an [error preventing registerFormatType to be called](https://github.com/WordPress/gutenberg/pull/15072) wrongly indicated as duplicate.
+- Resolve problematic [post lock release behavior](https://github.com/WordPress/gutenberg/pull/14994) when leaving the editor when using newer versions of Chrome.
+- Resolve an issue to [detect autosave presence at editor load](https://github.com/WordPress/gutenberg/pull/7945) in considering saveability.
+- Resolve a typo which could interfere with [audio shortcode transforms](https://github.com/WordPress/gutenberg/pull/15118).
+- [Apply RichText attributes correctly](https://github.com/WordPress/gutenberg/pull/15070) to resolve an issue with registerFormatType.
+- [Preserve attributes](https://github.com/WordPress/gutenberg/pull/15128) of a multi-line classic block paragraph.
+- Resolve an issue for Windows and Linux development mode due to a [access key safeguard](https://github.com/WordPress/gutenberg/pull/15044).
+
+## Various
+
+- Refactor a number of core blocks toward better interoperability with the Blocks RFC: [[1]](https://github.com/WordPress/gutenberg/pull/14979), [[2]](https://github.com/WordPress/gutenberg/pull/14902), [[3]](https://github.com/WordPress/gutenberg/pull/14903), [[4]](https://github.com/WordPress/gutenberg/pull/14899).
+- [Move selection state](https://github.com/WordPress/gutenberg/pull/14640) for RichText components to the block editor store, to enable future work to resolve or improve selection behavior.
+- Change the behavior of reusable blocks autocomplete to [fetch upon input](https://github.com/WordPress/gutenberg/pull/14915), improving reliability of tests and avoiding unnecessary network requests.
+- Allow [development mode constant](https://github.com/WordPress/gutenberg/pull/14165) to be redefined by plugins.
+- Improve reliability of e2e tests: [[1]](https://github.com/WordPress/gutenberg/pull/13161), [[2]](https://github.com/WordPress/gutenberg/pull/15046), [[3]](https://github.com/WordPress/gutenberg/pull/15063).
+- Avoid running [files contained in the git subfolder](https://github.com/WordPress/gutenberg/pull/14997) as tests.
+- Resolve an [issue with e2e errors](https://github.com/WordPress/gutenberg/pull/14998) related to dependencies updates.
+- Add a new ESLint rule to [enforce accessible use of BaseControl](https://github.com/WordPress/gutenberg/pull/14151).
+- Remove [redundant CSS styles](https://github.com/WordPress/gutenberg/pull/14520).
+- Add e2e tests for [dynamic allowed blocks](https://github.com/WordPress/gutenberg/pull/14992), [transforms from media to embed block](https://github.com/WordPress/gutenberg/pull/13997), [explicit persistence undo regression](https://github.com/WordPress/gutenberg/pull/15049).
+- Add a new [`wpDataSelect` e2e test utility](https://github.com/WordPress/gutenberg/pull/15052).
+- Include a [React hooks ESLint configuration](https://github.com/WordPress/gutenberg/pull/14995).
+- Add a [new Webpack plugin](https://github.com/WordPress/gutenberg/pull/14869) to help externalize and extract script dependencies (not yet published).
+
+## Documentation
+
+- Include auto-generated documentation for [core data module actions and selectors](https://github.com/WordPress/gutenberg/pull/15200).
+- Update [contributing documentation](https://github.com/WordPress/gutenberg/pull/15187) to extract detailed sections to their own documents.
+- Document the [withGlobalEvents](https://github.com/WordPress/gutenberg/pull/15175) higher-order component creator.
+- Add [related resources](https://github.com/WordPress/gutenberg/pull/15194) for BlockEditor components.
+- Clarify [requirements for e2e-test-utils](https://github.com/WordPress/gutenberg/pull/15171) package.
+- [Exclude private, experimental, and unstable APIs](https://github.com/WordPress/gutenberg/pull/15188) from auto-generated data documentation.
+- Include [missing DropZone component props](https://github.com/WordPress/gutenberg/pull/15223) in documentation.
+- Mention [component stylesheets](https://github.com/WordPress/gutenberg/pull/15241) in usage instructions.
+- Update [copy/paste support list](https://github.com/WordPress/gutenberg/pull/15149) to reflect paste support of images from Microsoft Word and Libre/Open Office.
+- Add [missing "Code is Poetry" footers](https://github.com/WordPress/gutenberg/pull/15140).
+- Improve [wording of JavaScript Tutorial](https://github.com/WordPress/gutenberg/pull/14838) document.
+- Improve [Travis build performance](https://github.com/WordPress/gutenberg/pull/15228) by expanding containers for e2e tests.
+
+## Mobile
+
+- [Refine transitions](https://github.com/WordPress/gutenberg/pull/14831) for bottom sheets.
+- Extract a [HorizontalRule component](https://github.com/WordPress/gutenberg/pull/14361) for use in a cross-platform separator block.
+- Fix an [error with changing list types](https://github.com/WordPress/gutenberg/pull/15010).
+- [Avoid setting caret](https://github.com/WordPress/gutenberg/pull/15021) when rich-text text will be trimmed.
+- Fix [title not focusing](https://github.com/WordPress/gutenberg/pull/15069).
+- Improve [post title accessibility](https://github.com/WordPress/gutenberg/pull/15106).
+- Improve image block accessibility for [deselected](https://github.com/WordPress/gutenberg/pull/14713), and [selected](https://github.com/WordPress/gutenberg/pull/15122) states.
+- Add [accessibility label for unselected paragraph](https://github.com/WordPress/gutenberg/pull/15126).
+- Fix [history stack when not empty](https://github.com/WordPress/gutenberg/pull/15055) on a fresh start of the editor.
+- Improve [Heading block accessibility](https://github.com/WordPress/gutenberg/pull/15144).
+- Make [accessibility string properly localizable](https://github.com/WordPress/gutenberg/pull/15161).
+- [Update string concatenation](https://github.com/WordPress/gutenberg/pull/15181) for accessibility labels.
+
+= 5.5.0 =
+
+## Features
+
+- Add a new [Group](https://github.com/WordPress/gutenberg/pull/13964) [block](https://github.com/WordPress/gutenberg/pull/14920).
+- Add [vertical alignment](https://github.com/WordPress/gutenberg/pull/13989) support to the Media & Text block.
+- Add [the image fill option](https://github.com/WordPress/gutenberg/pull/14445) to the Media & Text block.
+
+## Enhancements
+
+- Improvements to the [Image Block](https://github.com/WordPress/gutenberg/pull/14142) [flows](https://github.com/WordPress/gutenberg/pull/14807).
+- Automatically [add `mailto:` to email addresses](https://github.com/WordPress/gutenberg/pull/14857) when linking.
+- Add [visual handles for side resizers](https://github.com/WordPress/gutenberg/pull/14543) for various blocks.
+- Improve the [performance of the](https://github.com/WordPress/gutenberg/pull/14664) [annotations](https://github.com/WordPress/gutenberg/pull/14808) by avoiding excessive memoization.
+- Announce the [color accessibility issues](https://github.com/WordPress/gutenberg/pull/14649) to screen readers.
+- Add [enum block attributes validation](https://github.com/WordPress/gutenberg/pull/14810) to browser block parser.
+- Use a [consistent grey background](https://github.com/WordPress/gutenberg/pull/14719) in the Shortcode block.
+- Improve accessibility of video block [select poster image](https://github.com/WordPress/gutenberg/pull/14752).
+- Respect [prefers-reduced-motion for fixed backgrounds](https://github.com/WordPress/gutenberg/pull/14848) in Cover block.
+- Prevent ArrowLeft key press in multi-line selection from [prematurely triggering multi-selection](https://github.com/WordPress/gutenberg/pull/14906).
+
+## Bug Fixes
+
+- Avoid keeping the [RichText value in cache](https://github.com/WordPress/gutenberg/pull/14750) indefinitely.
+- Fix the [post title input borders](https://github.com/WordPress/gutenberg/pull/14771) in the code editor.
+- Fix the [block restrictions](https://github.com/WordPress/gutenberg/pull/14003) to insert, replace or move blocks.
+- [Select gallery images](https://github.com/WordPress/gutenberg/pull/14813) on focus.
+- Fix [removing gallery images](https://github.com/WordPress/gutenberg/pull/14822) on delete/backspace key press.
+- Fix small visual regression in the [block autocompete popover](https://github.com/WordPress/gutenberg/pull/14772).
+- Fix the data module[ resolver resolution status](https://github.com/WordPress/gutenberg/pull/14711).
+- Avoid [saving metaboxes when previewing](https://github.com/WordPress/gutenberg/pull/14877) [changes](https://github.com/WordPress/gutenberg/pull/14894).
+- Fix [selecting the separator block](https://github.com/WordPress/gutenberg/pull/14854).
+- Fix displaying the [color palette](https://github.com/WordPress/gutenberg/pull/14693) [tooltips](https://github.com/WordPress/gutenberg/pull/14944) on hover.
+- Fix Firefox/NVDA bug not [announcing the toggle settings](https://github.com/WordPress/gutenberg/pull/14475) button.
+- Fix [arrow navigation in paragraph](https://github.com/WordPress/gutenberg/pull/14804) blocks with backgrounds.
+- Fix the [columns block click to select](https://github.com/WordPress/gutenberg/pull/14876).
+- Fix [post dirtiness](https://github.com/WordPress/gutenberg/pull/14916) after fetching reusable blocks.
+- Fix the hover and focus styles for [buttons with the isBusy](https://github.com/WordPress/gutenberg/pull/14469) prop.
+- Remove the box [shadow from the side inserter](https://github.com/WordPress/gutenberg/pull/14936) button.
+- Changing the [region navigation shortcuts](https://github.com/WordPress/gutenberg/pull/14681) to avoid conflicts.
+- Fix [space insertion in the Button block](https://github.com/WordPress/gutenberg/pull/14925) in Firefox.
+- Prevent the [link popover from animating constantly](https://github.com/WordPress/gutenberg/pull/14938) as we type. 
+- Fix the warning triggered by [clearing the height of the spacer block](https://github.com/WordPress/gutenberg/pull/14785).
+- Fix [undo behavior](https://github.com/WordPress/gutenberg/pull/14955) after fresh post loading.
+
+## Documentation
+
+- Add design documentation to the [Modal component](https://github.com/WordPress/gutenberg/pull/14757).
+- Clarify the [CSS naming coding guidelines](https://github.com/WordPress/gutenberg/pull/14556).
+- Add [InspectorControls usage example](https://github.com/WordPress/gutenberg/pull/11736).
+- Tweaks and typos: [1](https://github.com/WordPress/gutenberg/pull/14736), [2](https://github.com/WordPress/gutenberg/pull/14737), [3](https://github.com/WordPress/gutenberg/pull/14762), [4](https://github.com/WordPress/gutenberg/pull/14741), [5](https://github.com/WordPress/gutenberg/pull/14756), [6](https://github.com/WordPress/gutenberg/pull/14778), [7](https://github.com/WordPress/gutenberg/pull/14827), [8](https://github.com/WordPress/gutenberg/pull/14895), [9](https://github.com/WordPress/gutenberg/pull/14909), [10](https://github.com/WordPress/gutenberg/pull/14917), [11](https://github.com/WordPress/gutenberg/pull/14940), [12](https://github.com/WordPress/gutenberg/pull/14941), [13](https://github.com/WordPress/gutenberg/pull/14964).
+
+## Various
+
+- Bootstrap the design of the [new widgets screen](https://github.com/WordPress/gutenberg/pull/14612) (non functional yet).
+- Reorganization of the block-library code base:
+    - Use a babel plugin to [load block.json files](https://github.com/WordPress/gutenberg/pull/14551).
+    - Introduce [block.json metadata](https://github.com/WordPress/gutenberg/pull/14770) [for](https://github.com/WordPress/gutenberg/pull/14863) all client side blocks.
+    - Move [the edit functions and the icons](https://github.com/WordPress/gutenberg/pull/14743) to separate files.
+    - Move the [transforms and save functions](https://github.com/WordPress/gutenberg/pull/14882) to separate files.
+- Add [forwardRef support to the PlainText](https://github.com/WordPress/gutenberg/pull/14866) component.
+- Support [Button Block Appender](https://github.com/WordPress/gutenberg/pull/14241) in the InnerBlocks component.
+- [Unset the focal point attributes](https://github.com/WordPress/gutenberg/pull/14746) from the Cover block if not needed.
+- [Consistently return promises](https://github.com/WordPress/gutenberg/pull/14830) from the data module action calls.
+- Remove obsolete [CSS currentColor](https://github.com/WordPress/gutenberg/pull/14119) usage.
+- Improve the [e2e test CLI arguments](https://github.com/WordPress/gutenberg/pull/14717) and docs.
+- Improve the [e2e test login stability](https://github.com/WordPress/gutenberg/pull/14243) on MacOS.
+- Remove [is-plain-obj package](https://github.com/WordPress/gutenberg/pull/14751) dependency.
+- Remove invalid urls and ids from [media test](https://github.com/WordPress/gutenberg/pull/14625/files) [fixtures](https://github.com/WordPress/gutenberg/pull/14790).
+- Remove the [deprecated Gutenberg plugin functions](https://github.com/WordPress/gutenberg/pull/14806) slated for 5.4 and 5.5.
+- remove or rename [undocumented RichText package functions](https://github.com/WordPress/gutenberg/pull/14239) and constants.
+- Adjust [paragraph block spacing](https://github.com/WordPress/gutenberg/pull/14679) to use standardised variables.
+- Allow [spaces in file paths](https://github.com/WordPress/gutenberg/pull/14789) for package build process. 
+- Update pre-commit to [check modified files only](https://github.com/WordPress/gutenberg/pull/14971).
+- Improve the [performance of the webpack build](https://github.com/WordPress/gutenberg/pull/14860) configuration.
+- [Update dependencies](https://github.com/WordPress/gutenberg/pull/14978) with known vulnerabilities.
+- Fix [typo in variable names](https://github.com/WordPress/gutenberg/pull/14970).
+
+## Mobile
+
+- [Accessibility improvements to the Button](https://github.com/WordPress/gutenberg/pull/14697) component.
+- Enhance the [unsupported block type](https://github.com/WordPress/gutenberg/pull/14577). 
+- Fix [image upload progress](https://github.com/WordPress/gutenberg/pull/14799) not being displayed consistently.
+- Support [copy/pasting images](https://github.com/WordPress/gutenberg/pull/14802).
+- Add [the](https://github.com/WordPress/gutenberg/pull/14865) [list block](https://github.com/WordPress/gutenberg/pull/14636).
+- Visual [refinements for the native nextpage](https://github.com/WordPress/gutenberg/pull/14826) block.
+- Fix [importing the column](https://github.com/WordPress/gutenberg/pull/14880) block.
+- Remove DOM logic from the [list block toolbar](https://github.com/WordPress/gutenberg/pull/14840).
+- Put the caret at the end of the text field after [merging blocks](https://github.com/WordPress/gutenberg/pull/14820).
+- Fix caret position [after](https://github.com/WordPress/gutenberg/pull/14957) [inline paste](https://github.com/WordPress/gutenberg/pull/14893).
+
+= 5.4.0 =
+
+### Features
+
+- Add [vertical alignment support for the columns](https://github.com/WordPress/gutenberg/pull/13899) [block](https://github.com/WordPress/gutenberg/pull/14614).
+- Add [playsinline support](https://github.com/WordPress/gutenberg/pull/14500) for the video block.
+
+### Enhancements
+
+- Add the [Media Library button](https://github.com/WordPress/gutenberg/issues/8309) to the gallery block appender.
+- Improve appearance of the block [hover state on colored backgrounds](https://github.com/WordPress/gutenberg/pull/14501).
+- Move the [color and font size caption styles](https://github.com/WordPress/gutenberg/pull/14366) into theme styles.
+- Replace the [verse block icon](https://github.com/WordPress/gutenberg/pull/14622).
+- Standardize [align and className attributes](https://github.com/WordPress/gutenberg/pull/14533) for dynamic blocks.
+- Remove the [title from mobile inserters](https://github.com/WordPress/gutenberg/pull/14493).
+- Capitalize [button labels](https://github.com/WordPress/gutenberg/pull/14591).
+- [Remove menu toggling](https://github.com/WordPress/gutenberg/pull/14456) on checkbox, radio buttons clicks.
+- Make the [invisible image resize handlers](https://github.com/WordPress/gutenberg/pull/14481) bigger.
+- Improve the [alt text field description](https://github.com/WordPress/gutenberg/pull/14668).
+
+### Bug Fixes
+
+- Improve the [format boundary styles](https://github.com/WordPress/gutenberg/pull/14519).
+- [Convert void blocks properly](https://github.com/WordPress/gutenberg/pull/14536) when converting or pasting content.
+- Fix the [ClipboardButton](https://github.com/WordPress/gutenberg/pull/7106) component behavior in Safari.
+- Fix [expanding the text selection](https://github.com/WordPress/gutenberg/pull/14487) when using shift + vertical arrows.
+- Fix the alignment of the [third-party block settings items](https://github.com/WordPress/gutenberg/pull/14569).
+- Fix [invalid HTML](https://github.com/WordPress/gutenberg/pull/14423) [in](https://github.com/WordPress/gutenberg/pull/14599) some more menu items.
+- Fix [JavaScript error in the columns](https://github.com/WordPress/gutenberg/pull/14605) block.
+- Fix [radio button](https://github.com/WordPress/gutenberg/pull/14624) [appearance](https://github.com/WordPress/gutenberg/pull/14684) on small screens.
+- Save [line breaks in the preformatted](https://github.com/WordPress/gutenberg/pull/14653) block.
+- Fix edge case in the [is_gutenberg_page](https://github.com/WordPress/gutenberg/pull/14558) plugin function.
+- Fix [toolbar position](https://github.com/WordPress/gutenberg/pull/14669) in full size aligned blocks on small screens.
+- Fix [double scrollbar issue](https://github.com/WordPress/gutenberg/pull/14677) in Full Screen mode.
+- Fix JavaScript error when [downgrading to an old Gutenberg version](https://github.com/WordPress/gutenberg/pull/14691).
+- Fix the [WordPress embed block](https://github.com/WordPress/gutenberg/pull/14658) resolution.
+- Fix embedding [links with trailing slashes](https://github.com/WordPress/gutenberg/pull/14705).
+- Fix the [preloading apiFetch middleware](https://github.com/WordPress/gutenberg/pull/14714) when initialized empty.
+- Fix php notice when using [widgets without](https://github.com/WordPress/gutenberg/pull/14587) [description](https://github.com/WordPress/gutenberg/pull/14615).
+- Better [horizontal edge detection](https://github.com/WordPress/gutenberg/pull/14462) to fix the arrow key navigation in the table block.
+- Fix error in [API Fetch initialization](https://github.com/WordPress/gutenberg/pull/14714).
+- Fix [unwanted margin](https://github.com/WordPress/gutenberg/pull/14614) in Column block.
+- Fixes [issue where emoji would be destroyed](https://github.com/WordPress/gutenberg/pull/14411).
+
+### Documentation
+
+- Document the [block editor module](https://github.com/WordPress/gutenberg/pull/14566).
+- Add design documentation for the [Panel](https://github.com/WordPress/gutenberg/pull/14504) component.
+- Document [webpack config extensibility](https://github.com/WordPress/gutenberg/pull/14590).
+- Clarify [experimental and unstable API](https://github.com/WordPress/gutenberg/pull/14557) guidelines.
+- Setup automatic [API documentation for the data](https://github.com/WordPress/gutenberg/pull/14277) module.
+- Improve the [automatic](https://github.com/WordPress/gutenberg/pull/14549) [API](https://github.com/WordPress/gutenberg/pull/14656) documentation tool.
+- Enhance the components documentation:
+  - [FormFileUpload](https://github.com/WordPress/gutenberg/pull/14661) component.
+  - [MediaPlaceholder](https://github.com/WordPress/gutenberg/pull/14645) component.
+  - [Notice](https://github.com/WordPress/gutenberg/pull/14514) component.
+  - [TextControl](https://github.com/WordPress/gutenberg/pull/14710) component.
+- Updates the [blocks creation tutorial](https://github.com/WordPress/gutenberg/pull/14584).
+- Typos & tweaks: [1](https://github.com/WordPress/gutenberg/pull/14490), [2](https://github.com/WordPress/gutenberg/pull/14516), [3](https://github.com/WordPress/gutenberg/pull/14530), [4](https://github.com/WordPress/gutenberg/pull/14565), [5](https://github.com/WordPress/gutenberg/pull/14597), [6](https://github.com/WordPress/gutenberg/pull/14368), [7](https://github.com/WordPress/gutenberg/pull/14666), [8](https://github.com/WordPress/gutenberg/pull/14686), [9](https://github.com/WordPress/gutenberg/pull/14690).
+
+### Various
+
+- Implement a built-in static [Gutenberg Playground](https://github.com/WordPress/gutenberg/pull/14497).
+- [Override core block server-side code](https://github.com/WordPress/gutenberg/pull/13521) when using the plugin.
+- Make the [block](https://github.com/WordPress/gutenberg/pull/14527) [editor](https://github.com/WordPress/gutenberg/pull/14387) [module](https://github.com/WordPress/gutenberg/pull/14548) [more](https://github.com/WordPress/gutenberg/pull/14678) reusable.
+- Expose the [lazy and Suspence](https://github.com/WordPress/gutenberg/pull/14412) React features in the element package.
+- Avoid assuming persisted [preferences state shape](https://github.com/WordPress/gutenberg/pull/14692).
+- Remove dead code from the [calendar block renderer](https://github.com/WordPress/gutenberg/pull/14546).
+- Extract [global CSS resets](https://github.com/WordPress/gutenberg/pull/14509) [into](https://github.com/WordPress/gutenberg/pull/14572) reusable mixins.
+- Replace [image urls by base 64 encoded images](https://github.com/WordPress/gutenberg/pull/14544) in reusable CSS files.
+- Add default empty implementation for the [block types save](https://github.com/WordPress/gutenberg/pull/14510) [function](https://github.com/WordPress/gutenberg/pull/14529).
+- Add a new data action to [replace the inner blocks](https://github.com/WordPress/gutenberg/pull/14291).
+- Support [parent data registry inheritance](https://github.com/WordPress/gutenberg/pull/14369) in the data module.
+- Add [extra props support for the Dashicon](https://github.com/WordPress/gutenberg/pull/14631) component.
+- Add a [BaseControl.VisualLabel](https://github.com/WordPress/gutenberg/pull/14179) component for purely visual labels.
+- Refactor [setupEditor effects to actions](https://github.com/WordPress/gutenberg/pull/14513).
+- Refactor the [core/data store](https://github.com/WordPress/gutenberg/pull/14634) to be independent from the registry object.
+- Remove [componentWillMount](https://github.com/WordPress/gutenberg/pull/14637) usage from LatestPostEdit component.
+- Add a generic [e2e test for block transforms](https://github.com/WordPress/gutenberg/pull/12336) and work on its [stability](https://github.com/WordPress/gutenberg/pull/14632).
+- Allow e2e test failures for [php versions lower than 5.6](https://github.com/WordPress/gutenberg/pull/14541).
+- Add eslint rule to prevent [incorrect truthy length property](https://github.com/WordPress/gutenberg/pull/14579/) checks.
+- Add eslint rule to [prevent unsafe setTimeout usage](https://github.com/WordPress/gutenberg/pull/14650) in components.
+- Run the local gutenberg environment in [debug mode](https://github.com/WordPress/gutenberg/pull/14371).
+- Disable [debug mode in local e2e tests](https://github.com/WordPress/gutenberg/pull/14638).
+- [Exclude test files](https://github.com/WordPress/gutenberg/pull/14468) while rebuilding packages.
+- [Make E2E tests resilient](https://github.com/WordPress/gutenberg/pull/14632) against transforms added by plugins.
+- Add [LGPL](https://github.com/WordPress/gutenberg/pull/14734) as an OSS license.
+
+= 5.3.0 =
+
+### Features
+
+ - Add the [block management modal](https://github.com/WordPress/gutenberg/pull/14224): Ability to hide/show blocks in the inserter.
+ - Support [nested blocks for the Cover Block](https://github.com/WordPress/gutenberg/pull/13822).
+ - Add an experimental [Legacy Widget Block](https://github.com/WordPress/gutenberg/pull/13511) (enabled only in the plugin for the moment).
+
+### Enhancements
+
+ - Update the [block outlines](https://github.com/WordPress/gutenberg/pull/14145) for the hover and selected states.
+ - Allow [undoing automatic pattern block transformations](https://github.com/WordPress/gutenberg/pull/13917).
+ - Add a [RichText collapsed format toolbar](https://github.com/WordPress/gutenberg/pull/14233) for code, inline image and strikethrough formats.
+ - Allow [collapsing inserter panels](https://github.com/WordPress/gutenberg/pull/13884) when searching.
+ - Add ability to transform [video shortcodes to video blocks](https://github.com/WordPress/gutenberg/pull/14042).
+ - Add ability to transform [audio shortcodes to audio blocks](https://github.com/WordPress/gutenberg/pull/14045).
+ - Add new @wordpress/data actions to [invalidate the resolvers cache](https://github.com/WordPress/gutenberg/pull/14225).
+ - Support [custom classNames in the ToggleControl](https://github.com/WordPress/gutenberg/pull/13804) component.
+ - Clarify the [button to exit the post lock](https://github.com/WordPress/gutenberg/pull/14347) modal.
+ - Improve the [block validation error message](https://github.com/WordPress/gutenberg/pull/13499).
+ - [Automatically use the WordPress](https://github.com/WordPress/gutenberg/pull/13877)  [babel config](https://github.com/WordPress/gutenberg/pull/14168) when using @wordpress/scripts CLI.
+ - Add keyboard [shortcuts to indent/outdent](https://github.com/WordPress/gutenberg/pull/14343) list items.
+ - Use [links instead of buttons](https://github.com/WordPress/gutenberg/pull/10815) in the document outline.
+ - Use [`<s>` for strikethrough](https://github.com/WordPress/gutenberg/pull/14389), [not `<del>`](https://github.com/WordPress/gutenberg/pull/14430).
+ - Center the [tooltips content](https://github.com/WordPress/gutenberg/pull/14473).
+ - Update wording of the [block switcher tooltip](https://github.com/WordPress/gutenberg/pull/14470).
+ - Add [support for the reduced motion](https://github.com/WordPress/gutenberg/pull/14021) browser mode.
+
+### Bug Fixes
+
+ - Always show the [current month in the Calendar](https://github.com/WordPress/gutenberg/pull/13873) block for All CPTs but post.
+ - In the Latest posts block, [avoid full line clickable titles](https://github.com/WordPress/gutenberg/pull/14109).
+ - Avoid relying on DOM nodes to add the [empty line in RichText](https://github.com/WordPress/gutenberg/pull/13850)  [component](https://github.com/WordPress/gutenberg/pull/14315). This fixes a number of lingering empty lines.
+ - Fix the [MediaPlaceholder icon color](https://github.com/WordPress/gutenberg/pull/14257) on dark backgrounds.
+ - Fix the [Classic block toolbar in RTL](https://github.com/WordPress/gutenberg/pull/14088) languages.
+ - Fix the [more tag in the Classic block](https://github.com/WordPress/gutenberg/pull/14173).
+ - Fix the [quote to heading](https://github.com/WordPress/gutenberg/pull/14348) block transformation.
+ - Fix “null” appearing when [merging empty headings](https://github.com/WordPress/gutenberg/pull/13981) and paragraphs.
+ - Fix the [block insertion restrictions](https://github.com/WordPress/gutenberg/pull/14020) in the global inserter.
+ - Fix the [prepareEditableTree](https://github.com/WordPress/gutenberg/pull/14284) custom RichText Format API.
+ - [Changes to the internal RichText format](https://github.com/WordPress/gutenberg/pull/14380) representation to separate objects (inline image..) from formats (bold…). This fixes a number of RichText issues.
+ - Fix the [Spinner component styling](https://github.com/WordPress/gutenberg/pull/14418) in RTL languages.
+ - Fix [focus loss when using the Set Featured Image](https://github.com/WordPress/gutenberg/pull/14415) buttons.
+ - Fix [template lock](https://github.com/WordPress/gutenberg/pull/14390) not being taken into consideration.
+ - Fix [composed characters](https://github.com/WordPress/gutenberg/pull/14449) at the beginning of RichText.
+ - Fix several [block multi-selection](https://github.com/WordPress/gutenberg/pull/14448)  [bugs](https://github.com/WordPress/gutenberg/pull/14453).
+ - Allow using a [float number as a step](https://github.com/WordPress/gutenberg/pull/14322) when using the RangeControl component.
+ - Fix error when pasting a [caption shortcode without an image](https://github.com/WordPress/gutenberg/pull/14365) tag.
+ - Fix [focus loss](https://github.com/WordPress/gutenberg/pull/14444) when combining sidebars and modals (or popovers).
+ - Escape the [greater than character](https://github.com/WordPress/gutenberg/pull/9963) when serializing the blocks content into HTML.
+ - Fix [pasting links into the classic block](https://github.com/WordPress/gutenberg/pull/14485).
+ - Include missing [CSS in the classic block](https://github.com/WordPress/gutenberg/pull/12441).
+
+### Documentation
+
+ - Enhance the [i18n process documentation](https://github.com/WordPress/gutenberg/pull/13909) with a complete example.
+ - Add design guidelines to several components:
+ - The [Button](https://github.com/WordPress/gutenberg/pull/14194) component
+ - The [CheckboxControl](https://github.com/WordPress/gutenberg/pull/14153) component
+ - The [MenuItemsChoice](https://github.com/WordPress/gutenberg/pull/14465) component.
+ - The [MenuGroup](https://github.com/WordPress/gutenberg/pull/14466) component.
+ - Update the [JavaScript setup tutorial](https://github.com/WordPress/gutenberg/pull/14440) to rely on the @wordpress/scripts package.
+ - Lowercase [block editor](https://github.com/WordPress/gutenberg/pull/14205) and [classic editor](https://github.com/WordPress/gutenberg/pull/14203) terms to conform to the copy guidelines.
+ - Use [a central script](https://github.com/WordPress/gutenberg/pull/14216) to generate the JavaScript API documentation and run [in parallel](https://github.com/WordPress/gutenberg/pull/14295).
+ - Update the [packages release](https://github.com/WordPress/gutenberg/pull/14136)  [process](https://github.com/WordPress/gutenberg/pull/14260).
+ - Update the plugin release docs to rely on a [lighter SVN checkout](https://github.com/WordPress/gutenberg/pull/14259).
+ - Add automatic generation of JavaScript API documentation for:
+   - [@wordpress/element](https://github.com/WordPress/gutenberg/pull/14269)
+   - [@wordpress/escape-html](https://github.com/WordPress/gutenberg/pull/14268)
+   - [@wordpress/html-entities](https://github.com/WordPress/gutenberg/pull/14267)
+   - [@wordpress/keycodes](https://github.com/WordPress/gutenberg/pull/14265)
+   - [@wordpress/a11y](https://github.com/WordPress/gutenberg/pull/14288)
+   - [@wordpress/blob](https://github.com/WordPress/gutenberg/pull/14286)
+   - [@wordpress/block-library](https://github.com/WordPress/gutenberg/pull/14282)
+   - [@wordpress/compose](https://github.com/WordPress/gutenberg/pull/14278)
+   - [@wordpress/dom](https://github.com/WordPress/gutenberg/pull/14273)
+   - [@wordpress/i18n](https://github.com/WordPress/gutenberg/pull/14266)
+   - [@wordpress/autop](https://github.com/WordPress/gutenberg/pull/14287)
+   - [@wordpress/dom-ready](https://github.com/WordPress/gutenberg/pull/14272)
+   - [@wordpress/block-editor](https://github.com/WordPress/gutenberg/pull/14285)
+   - [@wordpress/rich-text](https://github.com/WordPress/gutenberg/pull/14220)
+   - [@wordpress/blocks](https://github.com/WordPress/gutenberg/pull/14279)
+   - [@wordpress/deprecated](https://github.com/WordPress/gutenberg/pull/14275)
+   - [@wordpress/priority-queue](https://github.com/WordPress/gutenberg/pull/14262)
+   - [@wordpress/shortcode](https://github.com/WordPress/gutenberg/pull/14218)
+   - [@wordpress/viewport](https://github.com/WordPress/gutenberg/pull/14214)
+   - [@wordpress/url](https://github.com/WordPress/gutenberg/pull/14217)
+   - [@wordpress/redux-routine](https://github.com/WordPress/gutenberg/pull/14228)
+   - [@wordpress/date](https://github.com/WordPress/gutenberg/pull/14276)
+   - [@wordpress/block-serialization-default-parser](https://github.com/WordPress/gutenberg/pull/14280)
+   - [@wordpress/plugins](https://github.com/WordPress/gutenberg/pull/14263)
+   - [@wordpress/wordcount](https://github.com/WordPress/gutenberg/pull/14213)
+   - [@wordpress/edit-post](https://github.com/WordPress/gutenberg/pull/14271)
+ - Link to the [editor user documentation](https://github.com/WordPress/gutenberg/pull/14316) and remove the user documentation [markdown file](https://github.com/WordPress/gutenberg/pull/14318/files).
+ - Typos and tweaks: [1](https://github.com/WordPress/gutenberg/pull/14321), [2](https://github.com/WordPress/gutenberg/pull/14355), [3](https://github.com/WordPress/gutenberg/pull/14382), [4](https://github.com/WordPress/gutenberg/pull/14439), [5](https://github.com/WordPress/gutenberg/pull/14471).
+
+### Various
+
+ - Upgrade to [React 16.8.4](https://github.com/WordPress/gutenberg/pull/14400) ([React Hooks](https://github.com/WordPress/gutenberg/pull/14425)).
+ - Fix the [dependencies of the e2e-tests](https://github.com/WordPress/gutenberg/pull/14212) and the [e2e-test-utils](https://github.com/WordPress/gutenberg/pull/14374) npm packages.
+ - Avoid disabling [regeneratorRuntime in the babel config](https://github.com/WordPress/gutenberg/pull/14130) to avoid globals in npm packages.
+ - [Work](https://github.com/WordPress/gutenberg/pull/14244)  [on](https://github.com/WordPress/gutenberg/pull/14247)  [various](https://github.com/WordPress/gutenberg/pull/14340)  [e2e tests](https://github.com/WordPress/gutenberg/pull/14219)  [stability](https://github.com/WordPress/gutenberg/pull/14230) improvements.
+ - Regenerate RSS/Search block [test fixtures](https://github.com/WordPress/gutenberg/pull/14122).
+ - [Move to travis.com](https://github.com/WordPress/gutenberg/pull/14250) as a CI server.
+ - Add [clickBlockToolbarButton](https://github.com/WordPress/gutenberg/pull/14254) e2e test utility.
+ - Add e2e tests:
+   - to check the [keyboard navigation](https://github.com/WordPress/gutenberg/pull/13455) through blocks.
+   - to verify that [the default block is selected](https://github.com/WordPress/gutenberg/pull/14191) after removing all the blocks.
+   - to check the InnerBlocks [allowed blocks restrictions](https://github.com/WordPress/gutenberg/pull/14054).
+ - Add unit tests [for the isKeyboardEvent](https://github.com/WordPress/gutenberg/pull/14073) utility.
+ - Remove [CC-BY-3.0](https://github.com/WordPress/gutenberg/pull/14329) from the GPLv2 compatible licenses.
+ - Polish the @wordpress/block-editor module:
+   - Move the [block specific components](https://github.com/WordPress/gutenberg/pull/14112) to the package.
+   - [Update the classnames](https://github.com/WordPress/gutenberg/pull/14420) to follow the CSS guidelines.
+ - Update [eslint rules npm](https://github.com/WordPress/gutenberg/pull/14077)  [packages](https://github.com/WordPress/gutenberg/pull/14339).
+ - Simplify the [hierarchical term selector strings](https://github.com/WordPress/gutenberg/pull/13938).
+ - Update the [Latest comments block to use the “align support config”](https://github.com/WordPress/gutenberg/pull/11411) instead of a custom implementation.
+ - Remove the [block snapshots tests](https://github.com/WordPress/gutenberg/pull/14349).
+ - Remove [post install scripts](https://github.com/WordPress/gutenberg/pull/14353) and only run these in CI to improve test performance.
+ - Tweak the plugin build zip script to [avoid prompting](https://github.com/WordPress/gutenberg/pull/14352) when the build environment is clean.
+ - Add [withRegistry](https://github.com/WordPress/gutenberg/pull/14370) higher-order component to the @wordpress/data module.
+ - Add missing [module entry point to the notices](https://github.com/WordPress/gutenberg/pull/14388) package.json.
+ - Remove the Gutenberg [5.3 deprecated functions](https://github.com/WordPress/gutenberg/pull/14380).
+ - Ensure [sourcemaps published to npm](https://github.com/WordPress/gutenberg/pull/14409) contain safe relative paths.
+ - Remove the [replace_block filter usage](https://github.com/WordPress/gutenberg/pull/13569) and extend core editor settings instead.
+ - Improve handling of [transpiled packages in unit tests](https://github.com/WordPress/gutenberg/pull/14432).
+ - Add CLI arguments to launch [e2e tests in interactive mode](https://github.com/WordPress/gutenberg/pull/14129) more easily.
+ -  Select a [unique radio input](https://github.com/WordPress/gutenberg/pull/14128) in a group when using the tabbables utility.
+
+= 5.2.0 =
+
+### Enhancements
+
+- Update the [button block description](https://github.com/WordPress/gutenberg/pull/13933) wording.
+- Design and a11y [improvements for the custom color picker](https://github.com/WordPress/gutenberg/pull/13708).
+- Tweak the [FontSizePicker height](https://github.com/WordPress/gutenberg/pull/11555) to match regular select elements.
+- Improvements to the [local state persistence](https://github.com/WordPress/gutenberg/pull/13951) behavior.
+- Improvements to the [URL input popove](https://github.com/WordPress/gutenberg/pull/13973) [design](https://github.com/WordPress/gutenberg/pull/14015).
+- Disable [block navigation and document outline items](https://github.com/WordPress/gutenberg/pull/14081) in text mode.
+- Improve the [quote block icons](https://github.com/WordPress/gutenberg/pull/14091).
+- Animate the [sidebar tabs switching](https://github.com/WordPress/gutenberg/pull/13956).
+
+### Bug Fixes
+
+- Select [the last block](https://github.com/WordPress/gutenberg/pull/13294) when pasting content.
+- Fix the block validation when the [default attribute value](https://github.com/WordPress/gutenberg/pull/12757) of a block is changed.
+- Forces the [min/max value validation](https://github.com/WordPress/gutenberg/pull/12952) in the RangeControl component.
+- Display HTML properly in [the post titles](https://github.com/WordPress/gutenberg/pull/13622) of the latest posts block.
+- Fix drag and [dropping a column](https://github.com/WordPress/gutenberg/pull/13941) block on itself.
+- Fix [new lines](https://github.com/WordPress/gutenberg/pull/13799) in the preformatted block.
+- Fix [text underline shortcut](https://github.com/WordPress/gutenberg/pull/14008).
+- Fix calling [gutenberg plugin functions in the frontend](https://github.com/WordPress/gutenberg/pull/14096) context.
+- Fix [pasting a single line](https://github.com/WordPress/gutenberg/pull/14138) from Google Docs (ignoring the strong element).
+- Fix FocalPointPicker rendering [unlabelled input fields](https://github.com/WordPress/gutenberg/pull/14152).
+- Show the [images uploaded in the gallery block](https://github.com/WordPress/gutenberg/pull/12435) in the media modal.
+- Fix [wordwise selection](https://github.com/WordPress/gutenberg/pull/14184) on Windows.
+- [Preserve empty table cells](https://github.com/WordPress/gutenberg/pull/14137) when pasting content.
+- Fix [focus loss](https://github.com/WordPress/gutenberg/pull/14189) when deleting the last block.
+
+### Documentation
+
+- Add [the Block specific toolbar button](https://github.com/WordPress/gutenberg/pull/14113) sample to the format api tutorial.
+- Introduce a package to automatically generate the [API documentation](https://github.com/WordPress/gutenberg/pull/13329).
+- Tweaks: [1](https://github.com/WordPress/gutenberg/pull/13906), [2](https://github.com/WordPress/gutenberg/pull/13920), [3](https://github.com/WordPress/gutenberg/pull/13940), [4](https://github.com/WordPress/gutenberg/pull/13954), [5](https://github.com/WordPress/gutenberg/pull/13993), [6](https://github.com/WordPress/gutenberg/pull/13995), [7](https://github.com/WordPress/gutenberg/pull/14083), [8](https://github.com/WordPress/gutenberg/pull/14099), [9](https://github.com/WordPress/gutenberg/pull/14089), [10](https://github.com/WordPress/gutenberg/pull/14177).
+
+### Various
+
+- Introduce [a](https://github.com/WordPress/gutenberg/pull/14082) [generic](https://github.com/WordPress/gutenberg/pull/13088) [block](https://github.com/WordPress/gutenberg/pull/13105) [editor](https://github.com/WordPress/gutenberg/pull/14116) [module](https://github.com/WordPress/gutenberg/pull/14161).
+- Creates [an empty page](https://github.com/WordPress/gutenberg/pull/13912) that will contain the future widget screen explorations.
+- Fix [emoji in the demo content](https://github.com/WordPress/gutenberg/pull/13969).
+- Warn when the user is using an [inline element as a RichText container](https://github.com/WordPress/gutenberg/pull/13921).
+- Make Babel [import JSX pragma plugin](https://github.com/WordPress/gutenberg/pull/13809/) [aware](https://github.com/WordPress/gutenberg/pull/14106) of the createElement usage.
+- [Include the JSX pragma plugin](https://github.com/WordPress/gutenberg/pull/13540) into the default WordPress babel config.
+- Update the [non-embeddable URLs](https://github.com/WordPress/gutenberg/pull/13715) wording.
+
+### Chore
+
+- Refactoring of the [block fixtures tests](https://github.com/WordPress/gutenberg/pull/13658).
+- Refactoring the eslint [custom import lint rule](https://github.com/WordPress/gutenberg/pull/13937).
+- Refactoring the selection of [previous/next blocks actions](https://github.com/WordPress/gutenberg/pull/13924).
+- Refactoring the [post editor effects](https://github.com/WordPress/gutenberg/pull/13716) to use actions and resolvers instead.
+- Use [forEach instead of map](https://github.com/WordPress/gutenberg/pull/13953) when appropriate and enforce it with an [eslint rule](https://github.com/WordPress/gutenberg/pull/14154).
+- Remove [TinyMCE external dependency](https://github.com/WordPress/gutenberg/pull/13971) mapping.
+- Extract [webpack config](https://github.com/WordPress/gutenberg/pull/13814) into the scripts package.
+- Improve [e2e](https://github.com/WordPress/gutenberg/pull/14048) [tests](https://github.com/WordPress/gutenberg/pull/14108) stability.t
+- Avoid mutating [webpack imported config](https://github.com/WordPress/gutenberg/pull/14039).
+- [Upgrade Jest](https://github.com/WordPress/gutenberg/pull/13922) to version 24.
+- Add [repository.directory field](https://github.com/WordPress/gutenberg/pull/14059) to the npm packages and an [linting rule](https://github.com/WordPress/gutenberg/pull/14200) to enforce it.
+- Update [server blocks script to use core](https://github.com/WordPress/gutenberg/pull/14097) equivalent function.
+- Remove the [vendor scripts registration](https://github.com/WordPress/gutenberg/pull/13573).
+- Use the editor settings to pass a [mediaUpload handler](https://github.com/WordPress/gutenberg/pull/14115).
+- Remove [deprecated Gutenberg plugin functions](https://github.com/WordPress/gutenberg/pull/14090) and [features](https://github.com/WordPress/gutenberg/pull/14144) moved to core.
+- Remove unnecessary [Enzyme React 16 workarounds](https://github.com/WordPress/gutenberg/pull/14156) from the unit tests.
+- Remove [wp-editor-font stylesheet override](https://github.com/WordPress/gutenberg/pull/14176).
+- [Preserve inline scripts](https://github.com/WordPress/gutenberg/pull/13581) when overriding core scripts.
+- Support [referencing the IconButton](https://github.com/WordPress/gutenberg/pull/14163) component.
+- Refactor the [i18n setup](https://github.com/WordPress/gutenberg/pull/12559) of the Gutenberg plugin.
+
+### Mobile
+
+- Add an [image placeholder](https://github.com/WordPress/gutenberg/pull/13777) when the size is being computed.
+- Update the [image thumbnail](https://github.com/WordPress/gutenberg/pull/13764) when the image is being uploaded.
+- Support the [Format Library](https://github.com/WordPress/gutenberg/pull/12249).
+- Bottom Sheet [design](https://github.com/WordPress/gutenberg/pull/13855) [improvements](https://github.com/WordPress/gutenberg/pull/13882).
+- Update the default [block appender placehoder](https://github.com/WordPress/gutenberg/pull/13880).
+- Support [pasting content](https://github.com/WordPress/gutenberg/pull/13841) using the Gutenberg paste handler.
+- Fix [alignment issues](https://github.com/WordPress/gutenberg/pull/13945) for the appender and paragraph block placeholders.
+
+= 5.1.1 =
+
+## Bug Fixes
+
+- Fixes a [Firefox regression](https://github.com/WordPress/gutenberg/pull/13986) causing block content to be deleted.
+
+= 5.1.0 =
+
+## Features
+
+*   Add a new [Search block](https://github.com/WordPress/gutenberg/pull/13583).
+*   Add a new [Calendar](https://github.com/WordPress/gutenberg/pull/13772) block.
+*   Add a new [Tag Cloud](https://github.com/WordPress/gutenberg/pull/7875) block.
+
+## Enhancements
+
+*   Add micro-animations to the editor UI:
+    *   Opening [Popovers](https://github.com/WordPress/gutenberg/pull/13617).
+    *   Opening [Sidebars](https://github.com/WordPress/gutenberg/pull/13635).
+*   [Restore the block movers](https://github.com/WordPress/gutenberg/pull/12758) for the floated blocks.
+*   [Consistency in alignment options](https://github.com/WordPress/gutenberg/pull/9469) between archives and categories blocks.
+*   Set the minimum size for [form fields on mobile](https://github.com/WordPress/gutenberg/pull/13639).
+*   [Disable the block navigation](https://github.com/WordPress/gutenberg/pull/12185) in the code editor mode.
+*   Consistency for the [modal styles](https://github.com/WordPress/gutenberg/pull/13669).
+*   Improve the [FormToggle](https://github.com/WordPress/gutenberg/pull/12385) styling when used outside of WordPress context.
+*   Use the block [icons in the media placeholders](https://github.com/WordPress/gutenberg/pull/11788).
+*   Fix [rounded corners](https://github.com/WordPress/gutenberg/pull/13659) for the block svg icons.
+*   Improve the [CSS specificity](https://github.com/WordPress/gutenberg/pull/13025) [of the paragraph](https://github.com/WordPress/gutenberg/pull/12998) block [styles](https://github.com/WordPress/gutenberg/pull/13821).
+*   Require an initial [click on embed previews](https://github.com/WordPress/gutenberg/pull/12981) before being interactive.
+*   Improve the [disabled block switcher](https://github.com/WordPress/gutenberg/pull/13721) styles.
+*   [Do not split paragraph line breaks](https://github.com/WordPress/gutenberg/pull/13832) when transforming multiple paragraphs to a list.
+*   Enhance the Quote block styling for [different text alignments](https://github.com/WordPress/gutenberg/pull/13248).
+*   Remove the [left padding from the Quote](https://github.com/WordPress/gutenberg/pull/13846) block when it’s centered.
+*   A11y:
+    *   Improve the [permalink field label](https://github.com/WordPress/gutenberg/pull/12959).
+    *   Improve the [region navigation](https://github.com/WordPress/gutenberg/pull/8554) styling.
+*   Remove the [3 keywords limit](https://github.com/WordPress/gutenberg/pull/13848) for the block registration.
+*   Add consistent background colors to the [hovered menu items](https://github.com/WordPress/gutenberg/pull/13732).
+*   Allow the [editor notices to push down](https://github.com/WordPress/gutenberg/pull/13614) the content.
+*   Rename the [default block styles](https://github.com/WordPress/gutenberg/pull/13670).
+
+## Bug Fixes
+
+*   Fix a number of formatting issues:
+    *   [Multiple formats](https://github.com/WordPress/gutenberg/issues/12973).
+    *   [Flashing backgrounds](https://github.com/WordPress/gutenberg/issues/12978) when typing.
+    *   [Highlighted format](https://github.com/WordPress/gutenberg/issues/11091) buttons.
+    *   [Inline code](https://github.com/WordPress/gutenberg/pull/13807) with [backticks](https://github.com/WordPress/gutenberg/issues/11276).
+    *   [Spaces deleted](https://github.com/WordPress/gutenberg/issues/12529) after formats.
+    *   Inline [boundaries styling](https://github.com/WordPress/gutenberg/issues/11423) issues.
+    *   [Touch Bar](https://github.com/WordPress/gutenberg/pull/13833) format buttons.
+*   Fix a number of list block writing flow issues:
+    *   Allow [line breaks](https://github.com/WordPress/gutenberg/pull/13546) in list items.
+    *   [Empty items](https://github.com/WordPress/gutenberg/issues/13864) not being removed.
+    *   Backspace [merging list items](https://github.com/WordPress/gutenberg/issues/12398).
+    *   [Selecting formats](https://github.com/WordPress/gutenberg/issues/11741) at the beginning of list items.
+*   Fix the [color picker styling](https://github.com/WordPress/gutenberg/pull/12747).
+*   Set default values for the [image dimensions inputs](https://github.com/WordPress/gutenberg/pull/7687).
+*   Fix [sidebar panels spacing](https://github.com/WordPress/gutenberg/pull/13181).
+*   Fix [wording of the nux tip](https://github.com/WordPress/gutenberg/pull/12911) nudging about the sidebar settings.
+*   Fix [the translator comments](https://github.com/WordPress/gutenberg/pull/9440) pot extraction.
+*   Fix the [plugins icons](https://github.com/WordPress/gutenberg/pull/13719) color overriding.
+*   Fix [conflicting notices styles](https://github.com/WordPress/gutenberg/pull/13817) when using editor styles.
+*   Fix [controls recursion](https://github.com/WordPress/gutenberg/pull/13818) in the redux-routine package.
+*   Fix the generic embed block when using [Giphy as provider](https://github.com/WordPress/gutenberg/pull/13825).
+*   Fix the [i18n message](https://github.com/WordPress/gutenberg/pull/13830) used in the Gallery block edit button.
+*   Fix the [icon size](https://github.com/WordPress/gutenberg/pull/13767) of the block switcher menu.
+*   Fix the [loading state](https://github.com/WordPress/gutenberg/pull/13758) of the FlatTermSelector (tags selector).
+*   Fix the [embed placeholders](https://github.com/WordPress/gutenberg/pull/13590) styling.
+*   Fix incorrectly triggered [auto-saves for published posts](https://github.com/WordPress/gutenberg/pull/12624).
+*   Fix [missing classname](https://github.com/WordPress/gutenberg/pull/13834) in the Latest comments block.
+*   Fix [HTML in shortcodes](https://github.com/WordPress/gutenberg/pull/13609) breaking block validation.
+*   Fix JavaScript errors when [typing quickly](https://github.com/WordPress/gutenberg/pull/11209) and creating undo levels.
+*   Fix issue with [mover colors](https://github.com/WordPress/gutenberg/pull/13869) in dark themes.
+*   Fix [internationalisation issue](https://github.com/WordPress/gutenberg/pull/13551) with permalink slugs.
+
+## Various
+
+*   Implement the [inline format boundaries](https://github.com/WordPress/gutenberg/pull/13697) without relying on the DOM.
+*   Introduce the [Registry Selectors](https://github.com/WordPress/gutenberg/pull/13662) in the data module.
+*   Introduce the [Registry Controls](https://github.com/WordPress/gutenberg/pull/13722) in the data module.
+*   Allow extending the [latest posts block query](https://github.com/WordPress/gutenberg/pull/11984) by using get_posts.
+*   Extend the [range of allowed years](https://github.com/WordPress/gutenberg/pull/13602) in the DateTime component.
+*   Allow [null values](https://github.com/WordPress/gutenberg/pull/12963) for the DateTime component.
+*   Do not render the [FontSizePicker](https://github.com/WordPress/gutenberg/pull/13782) if [no sizes](https://github.com/WordPress/gutenberg/pull/13824) [defined](https://github.com/WordPress/gutenberg/pull/13844).
+*   Add className prop support to the [UrlInput](https://github.com/WordPress/gutenberg/pull/13800) component.
+*   Add [inline image resizing UI](https://github.com/WordPress/gutenberg/pull/13737).
+
+## Chore
+
+*   Update [lodash](https://github.com/WordPress/gutenberg/pull/13651) and [deasync](https://github.com/WordPress/gutenberg/pull/13839) [dependencies](https://github.com/WordPress/gutenberg/pull/13876).
+*   Use [addQueryArgs](https://github.com/WordPress/gutenberg/pull/13653) consistently to generate WordPress links.
+*   Remove merged PHP code:
+    *   jQuery to Hooks [heartbeat proxyfying](https://github.com/WordPress/gutenberg/pull/13576).
+    *   References to the [classic editor](https://github.com/WordPress/gutenberg/pull/13544).
+    *   [gutenberg_can_edit_post](https://github.com/WordPress/gutenberg/pull/13470) function.
+*   [Disable CSS](https://github.com/WordPress/gutenberg/pull/13769) [animations](https://github.com/WordPress/gutenberg/pull/13779) in e2e tests.
+*   ESLint
+    *   Add a rule to ensure the [consistency](https://github.com/WordPress/gutenberg/pull/13785) [of the import groups](https://github.com/WordPress/gutenberg/pull/13757).
+    *   Add a rule to protect against [invalid sprintf use](https://github.com/WordPress/gutenberg/pull/13756).
+*   Remove [obsolete](https://github.com/WordPress/gutenberg/pull/13871) [CSS](https://github.com/WordPress/gutenberg/pull/13867) rules.
+*   Add e2e tests for [tags creation](https://github.com/WordPress/gutenberg/pull/13129).
+*   Add the [feature flags](https://github.com/WordPress/gutenberg/pull/13324) setup.
+*   Implement [block editor styles](https://github.com/WordPress/gutenberg/pull/13625) using a filter.
+
+## Documentation
+
+*   Add a new [tutorial about the editor notices](https://github.com/WordPress/gutenberg/pull/13703).
+*   Add JavaScript [build tools](https://github.com/WordPress/gutenberg/pull/13629) [documentation](https://github.com/WordPress/gutenberg/pull/13853).
+*   Enhance the block’s [edit/save documentation](https://github.com/WordPress/gutenberg/pull/13578) and code examples.
+*   Use [Title Case](https://github.com/WordPress/gutenberg/pull/13714) consistently.
+*   Add [e2e test utils](https://github.com/WordPress/gutenberg/pull/13856) documentation.
+*   Small enhancements and typos: [1](https://github.com/WordPress/gutenberg/pull/13593), [2](https://github.com/WordPress/gutenberg/pull/13671), [3](https://github.com/WordPress/gutenberg/pull/13711), [4](https://github.com/WordPress/gutenberg/pull/13746), [5](https://github.com/WordPress/gutenberg/pull/13742), [6](https://github.com/WordPress/gutenberg/pull/13733), [7](https://github.com/WordPress/gutenberg/pull/13744), [8](https://github.com/WordPress/gutenberg/pull/13752), [9](https://github.com/WordPress/gutenberg/pull/13574), [10](https://github.com/WordPress/gutenberg/pull/13745), [11](https://github.com/WordPress/gutenberg/pull/13781), [12](https://github.com/WordPress/gutenberg/pull/13694), [13](https://github.com/WordPress/gutenberg/pull/13810), [14](https://github.com/WordPress/gutenberg/pull/13891).
+
+## Mobile
+
+*   Add bottom sheet settings for the image block:
+    *   [alt description](https://github.com/WordPress/gutenberg/pull/13631).
+    *   [Links](https://github.com/WordPress/gutenberg/pull/13654).
+*   Implement [the media upload options](https://github.com/WordPress/gutenberg/pull/13656) sheet.
+*   Implementing [Clear All Settings](https://github.com/WordPress/gutenberg/pull/13753) button on Image Settings.
+*   [Avoid hard-coded font family](https://github.com/WordPress/gutenberg/pull/13677) styling for the image blocks.
+*   Improve [the post title](https://github.com/WordPress/gutenberg/pull/13548) [component](https://github.com/WordPress/gutenberg/pull/13874).
+*   Fix the bottom sheet [styling for RTL](https://github.com/WordPress/gutenberg/pull/13815) layouts.
+*   Support the [placeholder](https://github.com/WordPress/gutenberg/pull/13699) [prop](https://github.com/WordPress/gutenberg/pull/13738) in the RichText component.
+
+= 5.0.0 =
+
+### Features
+- Add a new [RSS block](https://github.com/WordPress/gutenberg/pull/7966) and follow-up improvements: [1](https://github.com/WordPress/gutenberg/pull/13501), [2](https://github.com/WordPress/gutenberg/pull/13502).
+- Add a new [Amazon Kindle embed block](https://github.com/WordPress/gutenberg/pull/13510).
+- Add a new [FocalPointPicker](https://github.com/WordPress/gutenberg/pull/10925) component and use it to define the focal point of the Cover block background.
+
+### Enhancements
+- Optimize the re-rendering performance when [inserting/removing blocks](https://github.com/WordPress/gutenberg/pull/13067).
+- Improve the [Reusable Blocks UX](https://github.com/WordPress/gutenberg/pull/12378) for contributor users.
+- Disable [embed previews](https://github.com/WordPress/gutenberg/pull/12961) for the smugmug provider.
+- Make [the fullscreen mode](https://github.com/WordPress/gutenberg/pull/13425) a desktop-only feature.
+- Accessibility: Add [speak messages](https://github.com/WordPress/gutenberg/pull/13385) when using the FeatureToggle component.
+- Accessibility:  Change the inserter [search result message](https://github.com/WordPress/gutenberg/pull/13388) from assertive to polite.
+- Accessibility:  Remove [duplicate aria label](https://github.com/WordPress/gutenberg/pull/12955) from menu items.
+- Remove the "[Show Download Button](https://github.com/WordPress/gutenberg/pull/13485)" toggle help text in the File block.
+- Render [the block switcher as disabled](https://github.com/WordPress/gutenberg/pull/13431) if not available in a multi-selection.
+- Use a back arrow icon to clarify the [Fullscreen mode exit button](https://github.com/WordPress/gutenberg/pull/13403).
+- Limit the [Gallery block columns count](https://github.com/WordPress/gutenberg/pull/13488) to the images count.
+- Automatically set a [default block style](https://github.com/WordPress/gutenberg/pull/12519) if missing.
+- Hide [empty categories](https://github.com/WordPress/gutenberg/pull/13549) from the Categories block in the editor.
+- Increase the padding of [the gallery captions](https://github.com/WordPress/gutenberg/pull/13623).
+- Add [left/right alignments](https://github.com/WordPress/gutenberg/pull/8814) to the latest posts block.
+- Improve the [columns margins](https://github.com/WordPress/gutenberg/pull/12199).
+- Add a [help text for the hide teaser toggle](https://github.com/WordPress/gutenberg/pull/13630) in the More block.
+- Improve the wording of the [embed block messages](https://github.com/WordPress/gutenberg/pull/13644).
+
+### Bug Fixes
+- Accessibility: Fix [the tab order](https://github.com/WordPress/gutenberg/pull/11863) of the date picker component.
+- Support [non hierarchical taxonomies](https://github.com/WordPress/gutenberg/pull/13076) in the category selector component.
+- Fix blocks [marked invalid incorrectly](https://github.com/WordPress/gutenberg/pull/13512) due to special HTML characters.
+- Fix the [Notice component styling](https://github.com/WordPress/gutenberg/pull/13371).
+- Fix the [:root selector](https://github.com/WordPress/gutenberg/pull/13325) in the editor styles.
+- Fix [duplicate block](https://github.com/WordPress/gutenberg/pull/12882) toolbars.
+- Fix [warning message](https://github.com/WordPress/gutenberg/pull/12933) when using the DateTimePicker component.
+- Fix the [File block](https://github.com/WordPress/gutenberg/pull/13432) and [Categories block](https://github.com/WordPress/gutenberg/pull/13439) style when applying custom classnames.
+- Fix the [Gallery block styling](https://github.com/WordPress/gutenberg/pull/13326) in Microsoft Edge.
+- Fix the [Button block styling](https://github.com/WordPress/gutenberg/pull/12183) when links are visited.
+- Fix Block Style [preview not dismissed](https://github.com/WordPress/gutenberg/pull/12317) after selection.
+- Fix [TabPanel buttons](https://github.com/WordPress/gutenberg/pull/11944) incorrectly submitting forms.
+- Fix [hierarchical dropdown](https://github.com/WordPress/gutenberg/pull/13567) in the Categories block.
+- Fix [wording](https://github.com/WordPress/gutenberg/pull/13479) for the color picker saturation.
+- Fix the [save keyboard shortcut](https://github.com/WordPress/gutenberg/pull/13159) while in the code editor mode.
+- Fix the [Google Docs table](https://github.com/WordPress/gutenberg/pull/13543) pasting.
+- Fix [jumps when indenting/outdenting](https://github.com/WordPress/gutenberg/pull/12941) list items.
+- Fix [FontSizePicker max width](https://github.com/WordPress/gutenberg/pull/13264) on mobile.
+- Fix PHP 5.2.2 [Parser issue](https://github.com/WordPress/gutenberg/pull/13369).
+- Fix [plural messages](https://github.com/WordPress/gutenberg/pull/13577) POT generation.
+
+### Various
+- Add [ESnext build setup](https://github.com/WordPress/gutenberg/pull/12837) and commands to the @wordpress/scripts package.
+- Add "[focus on mount](https://github.com/WordPress/gutenberg/pull/12855)" config to the DropDown component.
+- Improve [the error handling](https://github.com/WordPress/gutenberg/pull/13315) in the data module resulting in clearer messages displayed in the console.
+- Support [marking days as invalid](https://github.com/WordPress/gutenberg/pull/12962) in the DatePicker component.
+- Support [block transforms](https://github.com/WordPress/gutenberg/pull/11979) with inner blocks.
+- Improve the styles of the [editor notices with actions](https://github.com/WordPress/gutenberg/pull/13116).
+- Replace Polldaddy embed block with [Crowdsignal](https://github.com/WordPress/gutenberg/pull/12854).
+- Avoid [setting the generic Edit Post](https://github.com/WordPress/gutenberg/pull/13552) Title on load.
+- Deprecate [window._wpLoadGutenbergEditor](https://github.com/WordPress/gutenberg/pull/13547).
+- [Avoid an empty classname](https://github.com/WordPress/gutenberg/pull/11831) when deleting custom classnames.
+- Add [className prop support](https://github.com/WordPress/gutenberg/pull/13568) to the ServerSideRender component.
+
+### Documentation
+- Improve the components README files DropdownMenu & RangeControl.
+- Add code example of the [MediaPlaceholder](https://github.com/WordPress/gutenberg/pull/13389) component.
+- Add a [accessibility dedicated](https://github.com/WordPress/gutenberg/pull/13169) page.
+- Add a [Git workflow](https://github.com/WordPress/gutenberg/pull/13534) documentation page.
+- Reorganize [the contributors guide](https://github.com/WordPress/gutenberg/pull/13352).
+- Mention [the dark theme support](https://github.com/WordPress/gutenberg/pull/13375) in the design docs.
+- Enhance [the compose package](https://github.com/WordPress/gutenberg/pull/13496)  [documentation](https://github.com/WordPress/gutenberg/pull/13504).
+- Expand [the block templates](https://github.com/WordPress/gutenberg/pull/13494/) code examples.
+- Fix [unregisterBlockType](https://github.com/WordPress/gutenberg/pull/13273) code examples.
+- Clarify the block styles [isDefault property](https://github.com/WordPress/gutenberg/pull/11478).
+- Move the [npm packages management](https://github.com/WordPress/gutenberg/pull/13418/) documentation to a dedicated page.
+- Add a section explaining [the links usage](https://github.com/WordPress/gutenberg/pull/13422) in the documentation.
+- Add a note about the [wp-editor dependency](https://github.com/WordPress/gutenberg/pull/12731) when using RichText.
+- Update the [isShallowEqual package](https://github.com/WordPress/gutenberg/pull/13526) documentation and tests.
+- Refresh the [repository management](https://github.com/WordPress/gutenberg/pull/13495) doc.
+- Typos: [1](https://github.com/WordPress/gutenberg/pull/13409), [2](https://github.com/WordPress/gutenberg/pull/13302), [3](https://github.com/WordPress/gutenberg/pull/13541), [4](https://github.com/WordPress/gutenberg/pull/13524), [5](https://github.com/WordPress/gutenberg/pull/13531), [6](https://github.com/WordPress/gutenberg/pull/13582), [7](https://github.com/WordPress/gutenberg/pull/13595).
+
+### Chore
+- Remove PHP Code maintained in Core and bump [minimum WordPress version](https://github.com/WordPress/gutenberg/pull/13370):
+  - [Block registration](https://github.com/WordPress/gutenberg/pull/13412).
+  - [REST API](https://github.com/WordPress/gutenberg/pull/13408) Endpoints.
+  - [Markdown](https://github.com/WordPress/gutenberg/pull/13473) support fix.
+  - Gutenberg [body classname](https://github.com/WordPress/gutenberg/pull/13572) and [responsive classname](https://github.com/WordPress/gutenberg/pull/13461).
+  - [Preloading](https://github.com/WordPress/gutenberg/pull/13453) API calls.
+  - [Block detection utilities](https://github.com/WordPress/gutenberg/pull/13467).
+  - [List screen](https://github.com/WordPress/gutenberg/pull/13459)  [integration](https://github.com/WordPress/gutenberg/pull/13471).
+  - [Block content version](https://github.com/WordPress/gutenberg/pull/13469).
+  - [Block categories](https://github.com/WordPress/gutenberg/pull/13454) hook.
+  - [TinyMCE scripts](https://github.com/WordPress/gutenberg/pull/13466) registration.
+  - [Reusable blocks post type](https://github.com/WordPress/gutenberg/pull/13468)  [labels](https://github.com/WordPress/gutenberg/pull/13472) and [listing page](https://github.com/WordPress/gutenberg/pull/13456).
+  - [Block Types Initialization](https://github.com/WordPress/gutenberg/pull/13457).
+  - [PHP Unit tests](https://github.com/WordPress/gutenberg/pull/13513).
+  - [Compatibility](https://github.com/WordPress/gutenberg/pull/13442) script.
+  - [Meta boxes](https://github.com/WordPress/gutenberg/pull/13449) support.
+  - [Polyfills](https://github.com/WordPress/gutenberg/pull/13536).
+  - [oEmbed Proxy](https://github.com/WordPress/gutenberg/pull/13575) Endpoint filter.
+  - [Visual Editing](https://github.com/WordPress/gutenberg/pull/13608) Disabling.
+- Update [browserlist dependency](https://github.com/WordPress/gutenberg/pull/13395).
+- New E2E tests: [Date floating for pending posts](https://github.com/WordPress/gutenberg/pull/13281).
+- New ESlint rules:
+  - Enforce ES6 [object shorthand](https://github.com/WordPress/gutenberg/pull/13400) syntax.
+  - [Declare variables](https://github.com/WordPress/gutenberg/pull/12828) only when used.
+- Use [ES5 eslint config](https://github.com/WordPress/gutenberg/pull/13428) for the is-shallow-equal package.
+- Mark the eslint config as [a root config](https://github.com/WordPress/gutenberg/pull/13483).
+- Remove [the feedback form](https://github.com/WordPress/gutenberg/pull/10705) from the plugin.
+- I18n:
+  - Use [a placeholder](https://github.com/WordPress/gutenberg/pull/13487) for the WordPress minimum version.
+  - Use [Sentence case](https://github.com/WordPress/gutenberg/pull/12239) in toolbar tooltips.
+- Add [the FontAwesome licenses](https://github.com/WordPress/gutenberg/pull/12929) to the GPL 2 compatible licenses.
+- Move the [generated spec parser](https://github.com/WordPress/gutenberg/pull/13493) to the corresponding package.
+- Refactor the [nonce  apiFetch middleware](https://github.com/WordPress/gutenberg/pull/13451).
+- Refactor the list block [indent/outdent buttons](https://github.com/WordPress/gutenberg/pull/12667).
+- Fix [watching file changes](https://github.com/WordPress/gutenberg/pull/13448) on Linux.
+- Update [the question issue template](https://github.com/WordPress/gutenberg/pull/13351) in GitHub to redirect help requests.
+- Fix [wp-settings permissions](https://github.com/WordPress/gutenberg/pull/13539) in the local development environment.
+- Use a filter to [populate the demo content](https://github.com/WordPress/gutenberg/pull/13553).
+
+### Mobile
+- Improve the [hide keyboard](https://github.com/WordPress/gutenberg/pull/13415) button.
+- Add the [PostTitle](https://github.com/WordPress/gutenberg/pull/13199) component support.
+- Support [Enter key press](https://github.com/WordPress/gutenberg/pull/13500) in the post title.
+- Support [native Media Upload](https://github.com/WordPress/gutenberg/pull/13128).
+- Support [undo/redo](https://github.com/WordPress/gutenberg/pull/13514) in the post title.
+- Make the [InspectorControls](https://github.com/WordPress/gutenberg/pull/13597) available for mobile blocks.
+- Add [failed media upload](https://github.com/WordPress/gutenberg/pull/13615) support and cancel buttons.
+- Introduce the [BottomSheet](https://github.com/WordPress/gutenberg/pull/13612)  [component](https://github.com/WordPress/gutenberg/pull/13633).
+
+= 4.9.0 =
+
+### Performance
+- Implement an async rendering mode for the data module updates.
+- Avoid rerendering the block components when selecting a block.
+- Improve the performance of isEditorEmptyPost selector (13% typing performance improvement).
+- Data Module: Avoid persisting unchanged values.
+- Update withSelect to use type-optimized isShallowEqual.
+- Move data selection to event handlers (called only when necessary).
+- Improve the initial rendering time by optimizing the withFilters Higher-order component.
+
+### Bug Fixes
+- Fix RichText toolbar when using multiline=”li”.
+- Correct the margin of the block icons in the inserter.
+- Fix ampersand in post tags causing editor crash.
+- Remove alignundefined class from gallery block edit markup.
+- Disable the button to open the publish sidebar if locked.
+- Correct the default margin for buttons with icons.
+- Keep the date floating when for posts with "pending" status.
+- Fix using the EXIF title when uploading images.
+- Fix font size picker on mobile.
+- Fix z-index of the Reusable Block Inserter button.
+- Fix autop behavior when a text is followed by a div.
+- Fix warning when returning null from a data module generator.
+- Announce the screen reader messages in the correct order in Safari.
+- Check Post Type support in the options modal.
+
+### Enhancements
+- Support customizing the table background colors.
+- Support underlining text using the keyboard shortcut ctrl+U.
+- Apply the editor styles to the HTML Block Preview.
+- Improve the color swatch selection indicator.
+- Improve scrolling behavior in Fullscreen Mode in Edge.
+- Remove deprecated embed providers.
+- Refactor the alignements support in the Cover Block and the Categories Block.
+- Code quality improvement to getBlockContentSchema
+- Internationalize the excerpt documentation link.
+- Improve pasting of quotes with citations.
+- A11y
+   - Add a tooltip to the block list appender.
+   - Improve the color contrast of the inserter shortcuts.
+   - Remove the label from the Warning component’s menu.
+- Add an option to overwrite the block in the Warning component.
+
+### Extensibility
+- Support custom fetch handlers for wp.apiFetch.
+- Support additional data passed to the mediaUpload utility.
+- Add filter for the preview interstitial markup.
+- Avoid appending empty query string in wp.url.addQueryArgs.
+- Dispatch heartbeat events as hook actions to avoid the jQuery dependency.
+- Support adding classnames to the plugins sidebar panels.
+- Add a className to the parent page selector.
+
+### Documentation
+- Add tutorials for
+   - Creating sidebar plugins.
+   - Using the Format API.
+   - Creating meta blocks.
+- Reorganize the tutorials page.
+- Improve the UI component documentation:
+   - The ButtonGroup component.
+   - The IconButton component.
+   - The SelectControl component.
+   - The TextareaControl component.
+   - The TabPanel component.
+   - The Toolbar component.
+   - The FormToggle component.
+- Update the Gutenberg Release and the Repository Management docs.
+- Add new section on scoping JS code.
+- Use Block Editor instead of Gutenberg in the docs.
+- Mention the Advanced Controls Panel in the design guidelines.
+- Clarify the unregisterBlockStyle documentation.
+- Clarify the difference between the button block and the button component.
+- Scope JavaScript ES5 code example.
+- Fix incorrect code example.
+- Clarify the deprecated APIs.
+- Fix typos 1 2 3 4 5 6 7.
+
+### Chore
+- Improve CI build times.
+- Extract error messages from console logging in E2E tests.
+- Reorganization of the E2E tests setup and expose it as npm packages.
+- Add aXe accessibility E2E tests support.
+- Add E2E tests for the excerpt meta box plugin.
+
+### Mobile
+- Fix the Image Size implementation.
+- Fix scrolling long text content.
+
+= 4.8.0 =
+
+### Performance
+
+ - Improve page initialization time by optimizing the addHook function and the viewport state initialization.
+ - Improve typing performance by splitting the state tree.
+ - Optimize partial application of runSelector.
+ - Move selector calls to the event handles to avoid useless component rerenders.
+ - Render DropZone children only when dragging elements over it.
+ - Initialize variables only when needed.
+
+### Enhancements
+
+ - Add error messages to the image block on upload failures.
+ - Merge similar i18n strings.
+ - Disable clipboard button in file block during upload.
+ - Persist alignment when transforming a gallery to an image and vice-versa.
+ - Copy enhancement to the embed block help text.
+ - Improve the scrolling of the WordPress navigation menu.
+
+### Bug Fixes
+
+ - Fix RTL support for the DatePicker component.
+ - Change the header level in the BlockCompare component.
+ - Show all the taxonomies in the sidebar.
+ - Fix the latest posts date className.
+ - Fix the “align center” button in Latest Posts block in the backend.
+ - Fix block height when DropCap is used.
+ - Fix converting caption shortcode with link.
+ - Fix edge case in addQueryArgs function.
+ - Don’t return the permalink if the CPT is not publicly viewable.
+ - Fix error when saving non public CPTs.
+ - Properly disable the Publish button when saving is disabled.
+
+### Various
+
+ - Show a message in the browser’s console when in Quirks Mode.
+ - Improvements to the @wordpress/scripts package: A new a check-engines command, a lint-style command and an update to lint-js.
+
+### Documentation
+
+ - Add a getting started with JavaScript tutorial.
+ - Document the blocks’ setup states in the design guidelines.
+ - Add content to Contributors index page.
+ - Improve the components documentation:
+    - The MenuItem component.
+    - The RadioControl component.
+    - The ServerSideRender component.
+ - Organise the documentation assets in a dedicated folder.
+ - Clarify immutability of the block attributes.
+ - Fix the metabox back compat code example.
+ - Fix incorrect data module example.
+ - Improve the plugin release docs.
+ - Remove useless property from the colors code example.
+ - Improve the contributing documentation.
+ - Fix npm README links.
+ - Update the design resources link.
+ - Typo fixes.
+
+### Chore
+
+ - Run e2e tests with popular plugins enabled.
+ - Add new e2e tests:
+    - The permalink panel.
+    - The categories panel.
+    - Blocks with meta attributes.
+ - Update node-sass to fix Node 11 support.
+ - Move the dev dependencies to the root package.json.
+ - Improve the Pull Request Template.
+ - More logs to the CI jobs.
+ - Code style fixes and expand the phpcs coverage.
+ - Disable fragile e2e tests.
+ - Avoid PHP notices when running the e2e tests in debug mode.
+
+### Mobile
+
+ - Make a simple version of DefaultBlockAppender.
+ - Stop using classname-to-style autotransform in react native.
+ - Fix SVG styles.
+ - Implement Enter press to add a default block.
+ - Hide keyboard when non textual block is selected.
+ - Fix undo/redo on new blocks.
+ - Pass the blockType prop to RNAztecView.
+ - Expose unregisterBlockType.
+
+= 4.7.1 =
+
+### Bug fix
+
+* Editor: Restore the block prop in the BlockListBlock filter
+
+= 4.7.0 =
+
+### Performance improvements
+
+* Optimize isViewportMatch
+* Performance: BlockListAppender: 1.7x increase on key press
+* Date: Optimize the usage of moment-timezone to save some kilobytes
+* RichText: selectionChange: bind on focus, unbind on blur
+* RichText: only replace range and nodes if different
+* Cache createBlock call in isUnmodifiedDefaultBlock
+* Edit Post: Select blocks only once multiple verified
+* RichText: Do not run valueToEditableHTML on every render
+* RichText: Reuse DOM document across calls to createEmpty
+* Only initialise TinyMCE once per instance
+* Optimize the insertion point component
+* Avoid rerending the current block if the previous block change
+* Avoid getBlock in block-list/block
+* Pass the registry argument to withDispatch to allow selectors to be used
+
+### Bug fixes
+
+* Annotations: Apply annotation className as string
+* RichText: Ensure instance is selected before setting back selection
+* Meta Boxes: Don’t hide disabled meta boxes by modifying DOM
+* Fix: Problems on Media & Text block resizing; Load wp-block-library styles before wp-edit-blocks
+* When a post is saved, check for tinymce and save any editors.
+* Fix: Undoing Image Selection from Media Library in Image Block breaks it
+* Add an end-to-end test for the HTML block
+* Fix regression when copying or cutting content in the editor
+* Fix issue where default appender has icons overlaying the text
+* Set document title for preview loading interstitial
+* Fix: Upload permissions error on end-to-end inline tokens test
+* Ensure classic block caret is in correct position after blur
+* Fix tab navigation sometimes skipping block UI
+* Improve font size picker accessibility: Use a menuitemradio role and better labels
+* Don’t show trashed reusable blocks in the editor or frontend
+* Rename functions, removing gutenberg_ prefix
+* Add block switcher end-to-end tests
+* Allow links in plugin group in the editor more menu
+* Introduce searching of block categories from slash inserter
+* Convert HTML formatting whitespace to spaces
+* Label link format with selected text, not full text
+* Ensure permalink panel is only displayed when a permalink is allowed
+* Allow the user to convert unembeddable URLs to links and try embedding again
+* Improve the top bar tools interaction and consistency
+* Fix overflowing content in the facebook embed preview screen
+* Add an action to set a category icon and correct block categories documentation
+* Fix: pasting a tag that is part of a transform and not matched ignores the content.
+* Packages: Extract Eslint config package
+* Add end-to-end test to catch revert of title during a preview after saving a draft
+* Avoid react warnings when merging two adjacent paragraphs
+* Avoid PHP notice in the recent comments block
+
+= 4.6.1 =
+
+* Parser: Make attribute parsing possessive (Fix High CPU usage).
+
+= 4.6.0 =
+
+* Fix issue with drag-and-drop in columns.
+* Fix TinyMCE list plugin registration.
+* Fix IE11 flexbox alignment when min-width is set.
+* Fix IE11 focus loss after TinyMCE init. Add IE check.
+* Fix getSelectedBlockClientId selector.
+* Fix issue where unregistering a block type would cause blocks that convert to it to break.
+* Fix Classic block not showing galleries on a grid.
+* Fix visual issues with Button block text wrap.
+* Fix modals in Edge.
+* Fix Categories block filter effect on the front-end.
+* Fix an issue where the block toolbar would cause an image to jump downwards when the wide or full - alignments were activated.
+* Apply IE11 input fix only when mounting TinyMCE.
+* Improve block preview styling.
+* Make the Image Link URL field readonly.
+* Disable HTML edit from Media & Text block.
+* Avoid loading theme editor styles if not existing (RTL languages).
+* Improve scoping of nested paragraph right-padding CSS rule.
+* Add e2e tests for the format API.
+* Merge similar text strings for i18n.
+* Move editor specific styles from style.scss to editor.scss in Cover block.
+* Simplify sidebar tabs aria-labels.
+* Remove onSplit from RichText docs.
+* Remove textdomain from the block library.
+* Avoid rendering AdminNotices compatibility component.
+* Avoid changing default wpautop priority.
+* Change @package names to WordPress.
+* Update published packages changelogs.
+
+= 4.5.1 =
+
+* Raw Handling: fix consecutive lists with one item
+* Avoid showing draft revert message on autosaves
+* Honor the Disable Visual Editor setting in the Gutenberg editor page
+* Docs: Fix dead links in CONTRIBUTING.md
+* Fix undefined index warnings in Latest Comments & Latest Posts
+* Add `react-native` module property to html-entities package.json
+* RichText: List: Sync DOM after editor command
+* Fix RichText infinte rerendering
+* Fix keycodes package missing i18n dependencies
+
+= 4.5.0 =
+
+* Add relevant attribute data from images to be used server side to handle things like theme specific responsive media.
+* In order to be able to use srcset and sizes on the front end, wp-image-### CSS class has been added to the media and text block.
+* Add minimal multi-selection block panel to replace “Coming Soon” message. It shows word and block count for the selection.
+* Exclude reusable blocks from the global block count in Document Outline.
+* Upgrade admin notices to use Notices module at runtime. It attempts to seamlessly upgrade notices output via an admin_notices or all_admin_notices action server-side.
+* Adjust the prefix transforms so that they only execute when they match text right at the caret so that they are undoable. Also makes it faster by checking if the previous character is a space.
+* Add ability to specify a different default editor font per locale.
+* Add link rel and link class settings to Image block inspector.
+* Transform an Image and Audio block to an Embed block if the URL matches an embed.
+* Respect the “Disable Visual Editor” setting per user.
+* Make it easy to access image IDs server-side on the Gallery block.
+* Recursively step through edits to track individually changed post meta in Block API. This prevents saving the default value for each registered meta when only one of them is changed.
+* Perform a complete draft save on preview.
+* Save all meta-boxes when clicking the preview button. Set preview URL only after saving is complete.
+* Disable hover interaction on mobile to improve scrolling.
+* Update the displayed permalink when the slug is cleared.
+* When converting to blocks, place unhandled HTML within an HTML block.
+* Ensure content that cannot be handled in quotes is preserved within an HTML block.
+* Localize the DateTimePicker Component.
+* Fixes the behavior of link validation including properly handling URL fragments, validating forward slashes in HTTP URLs, more strictness to match getProtocol, addressing false positives in E2E tests.
+* Fix issue where existing reusable blocks on a post would not render if the user was an author or a contributor. This happens because requests to fetch a single block or post are blocked when ?context=edit is passed and the current user is not an editor.
+* Make sure the media library collection is refreshed when a user uploads media outside of the Media Library workflow (i.e. file drops, file uploads, etc).
+* Update the editor reducer so that RESET_BLOCKS will only remove blocks that are actually in the post.
+* It used to be possible to add a reusable block inside the same reusable block in the UI, e.g. someone could create a column block inside another column block. Now it is not.
+* Deleting after certain types of selection was causing the caret to appear in the wrong place, now that it fixed, along with unexpected behavior of Ctrl+A after other kinds of selection, and the associated E2E tests updated.
+* Remove permalink-based features from non-public CPTs.
+* Address various issues with post locking modal.
+* Fix issue with duplicating blocks and undo on Top Toolbar mode.
+* Visual fix of margin on icons that are not dashicons in placeholders.
+* Visual fix for centre-aligned text on coverblocks.
+* Visual fix for embeds that are wider than the mobile breakpoint, cropping them to fit within the screen.
+* Adds MediaUploadCheck before some MediaUpload components where it was not being checked in time, creating a confusing experience for users in the “contributor” role.
+* Fix undefined variable warning in gutenberg.php.
+* Add missing stringifier and iterator in TokenList component.
+* Address i18n issue in MultiSelectionInspector.
+* Fix small visual regression with button variation preview.
+* Fix interaction regression with Sibling Inserter.
+* Fix issue with the Privacy Policy help notice.
+* Fix post visibility popover not appearing on mobile.
+* Fix issue with toolbar in IE11.
+* Fix small gap in style variation button.
+* Fix popovers position in RTL languages.
+* Fix double border issue with disabled toggle control.
+* Fix the TinyMCE init array.
+* RichText content that comes from headings content attribute should use the RichText.Content instead of rendering it directly.
+* Makes the escape key consistently exit the inline link popover – previously this could behave unexpectedly depending on focus.
+* Improve accessibility of permalink sidebar panel using external link component.
+* Display selected block outlines on Top Toolbar mode.
+* Avoid responding to componentDidUpdate in withDispatch.
+* Allow previewing changes to the post featured image.
+* Preserve unknown attributes and respect null in server attributes preparation
+* Adds missing periods to notification that another user has control of the post.
+* Restore the help modal in the Classic block.
+* Reduce specificity in core button styles to reduce conflicts with theme styles.
+* Update name of “Unified Toolbar” to “Top Toolbar” for extra clarity.
+* Make it possible to have an editor-only annotation format that stays in
+* position when typing inside RichText.
+* Adds missing periods to notification that the user does not have permission to read the blocks of the post.
+* Only add data-align for wide/full aligns if editor/theme supports them.
+* Updates jest to latest version to address vulnerabilities.
+* Removes redundant code now that TinyMCE is not being used to handle paste events.
+* Remove the gutenberg text-domain from dynamic blocks.
+* Remove redundant word from media and text block description.
+* Makes the URL for the classic editor translatable, so that the appropriate translated version can be linked to.
+* Update More block description.
+* Avoid .default on browser global assignments.
+* Mirror packages dependencies registration with core.
+* Remove absolute positions in the link popover E2E test.
+* Improve keyboard mappings in E2E tests, replacing custom utils with modifiers from the keycodes package.
+* Add missing imports on some E2E test utilities.
+* Update API Fetch documentation – removes unnecessary wp-json.
+* Remove iOS scroll adjusting now that enter behavior is more smooth.
+* Register the paragraph block as the default block.
+* Handle isSelected in plain text blocks (currently Code and More blocks).
+
+= 4.4.0 =
+
+* Improves discoverability of permalinks by adding permalink panel to the document sidebar.
+* Improves margins, column child block, and mobile display of columns.
+* Allow for programmatically removing editor document panels.
+* Replaces the uploading indicator of images and galleries with a spinner and faded out image.
+* Toolbar for floats was a little offset beyond the mobile breakpoint, now fixed.
+* Text and code editing blocks did not have width set, now set to fill the space.
+* Correctly align URL input autocomplete.
+* Improve animations: new, consistent naming convention, adds editor prefix, and moves keyframe animations (which don’t work well with mixins) into the edit post style.
+* Hover styles were showing on mobile, where hover is not available – now disabled.
+* Click and drag was incorrectly triggering a selection event in the block list under the popover, resulting in the popover dismissing. This was causing blocks to be selected when trying to set links to open in a new tab, for example. Fixed by preventing the mouse down event from propagating.
+* Adds some padding to the block inserter so that it never overlaps text in nested contexts or mobile views.
+* Better handle images larger than the editor by allowing a 2.5x buffer. Allows images inserted in TwentyNineteen and other themes that have a wider than 580px editor width, to look as expected, but prevents infinite resizing of images.
+* Stop mousedown event propagating through the toolbar, fixing problem of unexpectedly selecting blocks.
+* Improve the way that long words are broken on multiple lines, using word-break: keep-all;
+* Preserve the ratio of video backgrounds in cover blocks, videos may be cropped to fit but will keep their original ratio.
+* It was not possible to scroll a long menu on first load of Gutenberg, fixed by removing sticky-menu.
+* Properly check for allowed types of Media in Media Placeholder components.
+* “Resolve” and “Convert to HTML” buttons were not clickable (regression), now resolved.
+* Exclude HTML editing from Columns and Column blocks.
+* Better handle links without href, which were showing as `undefined`.
+* Renders block appender after the template is processed, to prevent incorrectly inserting new paragraphs.
+* Parent pages were being lost when draft pages were autosaved, fixed by removing parent pages from autosave requests and refactoring to stop using “parent” as the path argument name.
+* Adding line breaks in formatted content in quote blocks were not working correctly, fixed by persisting formats when new lines are added.
+* Prevent users in the contributor role from using blocks that require upload privileges.
+* Fix block selection in removing blocks, correct typo in comparison.
+* Japanese text (double byte characters) was not usable in the list block, fixed by changing handling of composition events.
+* Better handles different text encodings (e.g. emoji) within a block in block validation.
+* Use a query argument instead of data to prevent error being thrown on post refresh.
+* Keyboard navigation was not working as expected in Firefox, added extra key binding.
+* Adds missing alt values to images when editing.
+* Better communicate block nesting level by using unordered lists.
+* Fix sidebar icons being incorrectly announced in NVDA by adding a span with `aria-hidden=”true”`.
+* Fixes block toolbar aria label to announce “block tools toolbar” rather than “block toolbar (a11y).
+* Adjusts focus on media and text blocks to select the overall block, not the child paragraph block.
+* Refactors i18n module to replaces Jed with Tannin for significant performance improvements.
+* Replace `getSelectedBlock` and `getMultiSelectedBlocks` with more performant `getSelectedBlockClientId` and a `getBlocks` selectors in copy handler.
+* Replace `getBlock` selector in favor of the more performant `getBlockName`.
+* Replace `getSelectedBlock` with more performant `getSelectedBlockClientId` and new `isBlockValid` selectors in the BlockToolbar.
+* Replace `getSelectedBlock` with more performant `getSelectedBlockClientId` and new `isBlockValid` selectors in the Block Inspector.
+* Replaces `getInserterItems` with a new `hasInserterItems` selector which is more performant, and makes some adjustments to memorization.
+* Avoid using the `getSelectedBlock` selector in autocompleters.
+* Remove use of `getBlock` selector in the DefaultBlockAppender and EditorKeyboardShortcuts components.
+* Move undo handling out of TinyMCE and into the RichText component.
+* `is_gutenberg_page` incorrectly assumes `get_current_screen` exists, add check.
+* Brings code inline with CSS standards by switching font weight to numeric values.
+* Wrapped component would not the most up-to-date store values if it incurred a store state change during its own mount (e.g. dispatching during its own constructor), resolved by rerunning selection.
+* Display an error message if Javascript is disabled.
+* Update to React 16.6.3.
+* Adds missing components dependency for RichText.
+* Refactors list block to remove previously exposed RichText/TinyMCE logic.
+* Removes `focusOnMount` prop from NavigableToolbar components, which was generating a warning.
+* Refactor checks for upload permissions, removing unnecessary checks for store permissions.
+* Use the large image size when inserting images in both galleries and image blocks.
+* Fixes dependency of `wp-polyfill` which needs to be registered before React and React-Dom when plugins (like Yoast) rely on Gutenberg’s React.
+* Mark `onSplit` as unstable as it is pending refactor.
+* Remove 4.4 deprecated features.
+* Fix SCSS syntax error.
+* Remove export of previously removed function.
+* Add an E2E test for unsupported blocks.
+* Refactor E2E utility functions.
+* Formatting updates to copy guidelines.
+* Makes headings consistent in the dropdown documentation.
+* Removes outdated documentation referring to function support in `registerBlockType`.
+* Fixes some typos and line breaks in block design documentation.
+* Fixes some typos and improves readability of README.
+* Adds toolbar to the editing block, and edit button.
+* Passes the `isSelected` prop down to the implementation of RichText components to make them respond properly to focus changes.
+
+= 4.3.0 =
+
+* Allow toggling the core custom fields meta box.
+* Introduce Annotations API across Block and Formatting.
+* Allow using a YouTube URL (or other sources) in the Video block and transparently convert it to Embed.
+* Allow Alt+F10 keyboard shortcut to navigate to block toolbar regardless of the toolbar visibility (isTyping, etc).
+* Return focus to element that opened the post publish panel after it is closed.
+* Avoid unnecessary re-renders when navigating between blocks.
+* Improve interactions around Columns block.
+* Improve keyboard navigation through the Gallery block.
+* Use full parser in do_blocks with nested block support. This switch will allow dynamic blocks which contain nested blocks inside of them and it will pave the way for a filtering API to structurally process blocks.
+* Refactor contextual toolbar to work better with floats.
+* Auto-refresh Popovers position but only refresh if the anchor position changes.
+* Add min-width to audio block.
+* Avoid auto-saving with empty post content.
+* Display correct Taxonomy labels.
+* Fix incorrect import name.
+* Fix styling issue with checkboxes.
+* Add full set of reusable block post type labels (addresses “no blocks found” state).
+* Fix right to left block alignment.
+* Fix “updating failed” notices showing on long-open tabs.
+* Fix default PHP parser to cast inner blocks as arrays.
+* Fix JS/PHP inconsistencies with empty attributes on parsing.
+* Link to the source image in the media block.
+* Fix select all keyboard shortcut for Safari and Firefox.
+* Create multiple blocks when multiple files are drag and dropped.
+* Fixes potential theme syle.css clash.
+* Makes preview button a link (a11y).
+* Stop re-rendering all blocks on arrow navigation.
+* Add constraint tabbing to post publish panel (a11y).
+* Fix image uploading bug (incorrect JSON in apiFetch).
+* Fix taxonomy visibility for contributors.
+* Adds aria labels to images in gallery blocks during editing (a11y).
+* Formatting fix for blockquotes.
+* Hide custom fields when meta box is disabled.
+* Limits blockquote color auto-selection to solid color blocks for readability.
+* Fixes announcement on multi-selection of blocks (a11y).
+* Display upload errors in the image block.
+* Fixes selection of embed type blocks.
+* Fixes JSON attribute parsing.
+* Fixes post publish focus (a11y).
+* Resolve macOS Firefox / Safari sibling inserter behavior.
+* Fix visibility of sibling inserter on tab focus.
+* Fix issue with pasting from Word where an image would be created instead of text.
+* Fix multi-selection for float elements.
+* Fetch all tag terms, not just first 100.
+* Correctly displays media on the right.
+* Only show named image sizes.
+* Improves handling of paste action.
+* Updates displayed permalink after permalink is edited.
+* Adjust font size for contrast warning (a11y).
+* Better handles formatting – nested and Google Docs.
+* Fixes suggestion list scrolling when using keyboard (a11y).
+* Fixes block and menu navigation a11y.
+* Click to close dropdown popover.
+* Fix save lock control.
+* Timezone handling fix.
+* Improve a11y of empty text blocks.
+* Fix states for publish buttons.
+* Fix backspace behavior.
+* Change aria labels for paragraph blocks (a11y).
+* Add support for prepare RichText tree.
+* With this change we force the browser to treat the textarea for the
+* code editor as auto when handling direction for its display to preserve the ability to interact with the block delimiters.
+* Rename parentClientId to rootClientId.
+* Remove deprecated findDOMNode call from Tooltip component.
+* Remove unused ref assignment to RichText.
+* Remove redundant onClickOutside handler from Dropdown.
+* Refactor block state.
+* Remove Cloudflare warning for blocked API calls.
+* Remove _wpGutenbergCodeEditorSettings (dead code).
+* Adds periods to block a11y descriptions.
+* Refactor embed block.
+* Handle metabox warning exceptions.
+* Refactor RichText to update formatting bar on format availability changes.
+* Rename wp-polyfill-ecmascript.
+* Update translator comments for quote and pullquote.
+* Remove findDOMNode useage from NavigableToolbar.
+* Changes handling of dates to properly handling scheduling.
+* Remove findDomNode from withHoverAreas.
+* Fixes missing translator comments.
+* Refactor to import Format API components.
+* Refactor of change detection: initial edits.
+* Adds better translation comments to “resolve” and “resolve block”.
+* Adds option for blocks with child blocks to change selection behavior.
+* Allows blocks to disable being converted to reusable blocks.
+* Improve undo/redo states.
+* Updates parsing to better handle nested content.
+* Remove undefined className argument from save().
+* Use different tooltips for different alignment buttons.
+* Improve performance and handling of autosave.
+* Improve gallery upload for multiple images: load one by one.
+* Adds context variable to RichText component.
+* Avoid calling missing get_current_screen function.
+* Make cssnano remove all style comments.
+* Refactor normalizeBlockType.
+* Shows icon in block toolbar.
+* Makes kitchensink button removable from plugins.
+* Fix popover sizing on screen change (autorefresh)
+* Improvement to Columns block.
+* Update block description for consistency.
+* Refactor block styles registration.
+* Use apostrophe instead of single-quote character in strings.
+* Add transformations between video and media and text block.
+* Version update for NPM packages.
+* Update Lerna to latest version.
+* Validates link format in RichText.
+* Refactor contextual toolbar to work better with floats.
+* Move wp-polyfill-ecmascript override to scripts registration.
+* Improves consistency of parser tests.
+* Remove code coverage.
+* Adds mocking helpers for E2E tests.
+* Runs E2E tests with the user in author role.
+* Adds tests for Format API.
+* Adds E2E test for rapid enter presses.
+* Fix typo in documentation.
+* Fix typos in block API documentation.
+* Improved documentation and examples for withFilters.
+* Fix some broken links in documentation.
+* Fix typo and quote consistency.
+* Remove duplicated word.
+* Adds custom block icon instructions.
+* Update documentation on keyboard shortcuts.
+* Updates isSelectionEnabledDocumentation.
+* Update FontSizePicker component documentation.
+* Export `switchToBlockType` function.
+* Remove mobile RN test suite (temporary measure).
+* Improve styling of next page block.
+* Removes fixed cover on iOS (unsupported in mobile Safari).
+* Adds support for native media picker.
+* Remove onChange delay.
+* Exposes slot/fill pattern to mobile.
+* Expose @wordpress/editor to mobile.
+* Refreshes native post block merge.
+* Properly handle cancel on the media picker.
+
+= 4.2.0 =
+
+* Introduce the Formatting API for extending RichText.
+* Use default Inserter for sibling block insertion.
+* Support adding and updating entities in data module.
+* Update block descriptions for added clarity and consistency.
+* Add support for displaying icons in new block categories.
+* Append registered toolbar buttons in RichText.
+* Optimize SlotFill rendering to avoid props destructuring.
+* Optimize Inserter props generation and reconciliation.
+* Improve writing flow by unsetting typing flag if Escape pressed.
+* Add support for non-Latin inputs in slash autocomplete block inserter.
+* Use an animated WP logo for preview screen.
+* Add “img” as a keyword for the Image block.
+* Delay TinyMCE initialisation to focus.
+* Announce number of filtered results from block inserter to screen readers.
+* Add audible feedback for link editing.
+* Avoid focus loss on active tab change within the Sidebar.
+* Add Alt + F10 (navigate to the nearest toolbar) to the shortcut docs and modal.
+* Add some more URL helpers to the url package.
+* Add has-dates class to Latest Posts block if applicable.
+* Improve mobile display of “options” modal.
+* Add “link target” option in Image block.
+* Use currentcolor as border-color for outline button style.
+* Introduce a new middleware to the api-fetch package which adds ?_locale=user to every REST API request.
+* Refactor and optimize withSelect, withDispatch handling of registry change.
+* Refactor and update DropZone context API.
+* Rephrase description of responsive toggle.
+* Ensure buttons on end of row in media-placeholder have no margin on the right.
+* Include implicit core styles in SelectControl.
+* Use better help text for ALT text input.
+* Flatten Inserter mapSelectToProps to optimize rendering.
+* Cleanup Embed code and add better test coverage.
+* Add space above exit code editor button.
+* Return 0 in WordCount if text is empty.
+* Avoid setting a value on the File block download attribute.
+* Set download attribute on File block as empty.
+* Remove Cover block ‘strong’ style.
+* Reduce frequency of actions updating isCaretWithinFormattedText.
+* Add a function to unregister a block style variation.
+* Add lodash deburr to autocomplete so that is works with diacritics.
+* Avoid making WordPress post embeds responsive.
+* Improve handling of centered 1-column galleries with small images.
+* Make pre-publish prompts more generic.
+* Improve the style variation control aria-label.
+* Improve preloading request code.
+* Add missing context to various i18n strings.
+* Add post saving lock APIs so plugins can add and remove locks.
+* Take the viewport size into account when it comes to decide whether to show the button or toggle logic for “submit for review”.
+* Improve accessibility of settings sidebar tabs.
+* Improve the header toolbar aria-label.
+* Add styles to stop Classic block buttons from inheriting italics from themes.
+* Add aria-label to links that open in new windows.
+* Add more descriptive aria-labels for the open and closed states of sidebar settings.
+* Add key event handler to activate block styles with keyboard.
+* Add field that allows changing image alt text from the sidebar in Media & Text.
+* Add aria-label to describe action of featured image update button.
+* Restore displaying formatting shortcuts in toolbar.
+* Add i18n context to “Resolve” button for invalid blocks.
+* Update the editor styles wrapper to avoid specificity issues.
+* Fix converting a reusable block with nested blocks into a static block.
+* Fix regression with mobile toolbar spacing.
+* Fix size regression in block icon.
+* Fix multi-selected warning block highlight.
+* Fix: Show resizer on “Media & Text” block on unified toolbar mode
+* Fix some RichText shortcuts and add e2e tests.
+* Fix issue with tertiary button hit areas.
+* Fix issue with unified toolbar not always fitting in smaller viewports.
+* Fix issue with “remove tag” button in long tag names.
+* Fix rich text value for nested lists.
+* Use color function for defining the background in DateTimePicker.
+* Fix usage of preg_quote() in block parsing.
+* Fix flow of scheduling and then publishing.
+* Fix focus issue on Gallery remove button.
+* Fix keyboard interaction (up/down arrow keys) causing focus to transfer out of the default block’s insertion menu.
+* Fix regression causing dynamic blocks not rendering in the frontend.
+* Fix vertical alignment issue on Media & Text block.
+* Fix some linter errors in master branch.
+* Fix dash line in More/Next-Page blocks.
+* Fix missing Categories block label.
+* Fix embedding and demo tests.
+* Fix issue with vanilla stylesheet.
+* Fix documentation for openModal() and closeModal().
+* Fix blocks navigation menu SVG icon size.
+* Fix link popover keyboard accessibility.
+* Fix issue with multiselect using shift + arrow.
+* Fix issue with format placeholder.
+* Fix Safari issue where hover outlines sometimes linger.
+* Resolve an issue where the “Copy Post Text” button in the error boundary would not actually copy post text, since it used a legacy retrieval method for post content.
+* Make preview placeholder text translatable.
+* Load translations in the reusable block listing page.
+* Avoid adding isDirty prop to DOM.
+* Improve translation string and replace placeholder handling for MediaPlaceholder instructions.
+* Refactor rich text package to avoid using blocks packages as a dependency.
+* Handle 204 response code in API Fetch.
+* Remove HTML source string normalization.
+* Normalize function arguments in Block API.
+* Remove unused code path.
+* Deprecate layout attribute.
+* Add class for -dropdown/-list in Archives block.
+* Update registration method signature of RichText.
+* Add filter for preloading API paths.
+* Add missing @return tag to gutenberg_meta_box_save_redirect() function.
+* Rename id attribute to tipId in DotTip.
+* Only silence REST errors if the REST server is present
+* Use consistent help text in DatePicker.
+* Export both the DropZone and MediaPlaceholder editor components with the withFilters HOC.
+* Remove “half” keyword from Media & Text block.
+* Remove redundant hooks initialization.
+* Mark getSettings in Date package as experimental.
+* Remove unused variable fallbacks in RichText.
+* Improve the Toggle Control elements DOM order for better accessibility.
+* Mark Reusable blocks API as experimental pending future refactor.
+* Set correct media type for video poster image and manage focus properly.
+* Avoid PHP notices due to non-available meta boxes.
+* Implement fetchAllMiddleware to handle per_page=-1 through pagination in wp.apiFetch.
+* Add do’s and don’ts to block design documentation.
+* Update creating-dynamic-blocks.md.
+* Update editor package changelog.
+* Add notices package.
+* Add styles property to block-api.md.
+* Add documentation for responsive-embeds theme option.
+* Add missing e2e tests for Plugins API.
+* Add an eslint rule to use cross-environment SVG primitives.
+* Use turbo-combine-reducers in place of Redux
+* Update react-click-outside to 3.0.
+* Update @wordpress/hooks README to include namespace mention.
+* Fix Heading blocks validation errors after block splitting
+* Expose setUnregisteredTypeHandlerName / getUnregisteredTypeHandlerName for mobile.
+* Fix a refresh issue with iOS when splitting blocks.
+* Simplify onEnter handling.
+* Hook onBackSpace in RichText component.
+* Introduce the ability to merge two blocks together on Backspace.
+* Properly refresh blocks when merging them under iOS.
+* Port nextpage block to the ReactNative mobile app.
+* RichText: fix buggy enter/delete behaviour (Extra br elements).
+* Fix showing categories for contributors.
+
+= 4.1.1 =
+
+* Fix dynamic blocks not rendering in the frontend when meta-boxes present.
+
+= 4.1.0 =
+
+* Implement a block navigation system that allows selecting child or parent blocks within nested blocks (like folder path traversal) as well as functioning as a general fast navigation system when a root block is selected.
+* Add a Media & Text block that can facilitate the creation of split column content and allows the split to be resizable.
+* Show block style selector in the block inspector.
+* Rename Cover Image to just Cover and add support for video backgrounds.
+* Add a new accessible Date Picker. This was months in the works.
+* Reimplement the Color Picker component to greatly improve keyboard navigation and screenreader operations.
+* Add style variation for Table block with stripe design.
+* Add “Options” modal to toggle on/off the different document panels.
+* Allow toggling visibility of registered meta-boxes from the “Options” modal.
+* Handle cases where a block is on the page but the block is not registered by showing a dialog with the available options.
+* Ensure compatibility with WordPress 5.0.
+* When pasting single lines of text, treat them as inline text.
+* Add ability to insert images from URL directly in the Image block.
+* Make Columns block responsive.
+* Make responsive embeds a theme option.
+* Add direction attribute / LTR button to the Paragraph block.
+* Display accurate updated and publish notices based on post type.
+* Update buttons in the editor header area to improve consistency (save, revert to draft, etc).
+* Avoid horizontal writing flow navigation in native inputs.
+* Move toggle buttons to the left of their control handle.
+* Add explicit bottom margin to figure elements (like image and embed).
+* Allow transforming a Pullquote to a Quote and viceversa.
+* Allow block inserter to search for blocks by typing their category.
+* Add a label to the URL field in the Publishing Flow panel.
+* Use the stored date format in settings for the LatestPosts block.
+* Remove the placeholder text and use visible label instead in TokenField.
+* Add translator comment for “View” menu label.
+* Make YouTube embed classes consistent between front-end and back-end.
+* Take into account citation when transforming a Quote to a Paragraph.
+* Restore ⌘A’s “select all blocks” behaviour.
+* Allow themes to disable custom font size functionality.
+* Make missing custom font sizes labels translatable.
+* Ensure cite is string when merging quote.
+* Defer fetching non-hierarchical terms in FlatTermSelector.
+* Move the theme support data previously exposed at the REST API index into a read-only theme controller for the active theme.
+* Detect oEmbed responses where the oEmbed provider is missing.
+* Use “Save as Pending” when the Pending checkbox is active.
+* Use the post type’s REST controller class as autosave parent controller.
+* Use post type labels in PostFeaturedImage component.
+* Enforce text color within inline boundaries to ensure contrast and legibility.
+* Add self-closing tag support (like path element) when comparing HTML.
+* Make sure autocomplete triggers are regex safe.
+* Silence PHP errors on REST API responses.
+* Show permalink label as bold text.
+* Change the block renderer controller endpoint and namespace from /gutenberg/v1/block-renderer/ to /wp/v2/block-renderer/.
+* Hide “edit image” toolbar buttons when no image is selected.
+* Hide “Add to Reusable Blocks” action when ‘core/block’ is disabled.
+* Handle blocks passing null as RichText value.
+* Improve validation for attribute names in rich-text toHTMLString.
+* Allow to globally overwrite defined colors in PanelColorSettings.
+* Fix regressions with Button block preview display.
+* Fix issue with color picker not appearing on mobile.
+* Fix publish buttons with long text.
+* Fix link to manifest file in contributing file.
+* Fix demo content crash on malformed URL.
+* Fix issue in docs manifest.
+* Fix media caption processing with the new RichText structure.
+* Fix problem with Gallery losing assigned columns when alignments are applied.
+* Fix an issue where the Categories block would always use the center class alignment regardless of what was set.
+* Fix scroll issue on small viewports.
+* Fix formatting in getEditorSettings docs and update getTokenSettings docs.
+* Fix padding in block validation modal.
+* Fix extra instances of old rich text value source.
+* Fix issue with adding links from the auto-completer.
+* Fix outdated docs for RichText.
+* Fix pre-publish panel overflow issue.
+* Fix missing styles for medium and huge font size classes.
+* Fix autocomplete keyboard navigation in link popover.
+* Fix a text selection exception in Safari.
+* Fix WordPress embed URL resolution and embeds as reusable blocks.
+* Avoid triggering a redirect when creating a new Table block.
+* Only use rich text value internally to the RichText component.
+* Ensure multiline prop is either “p” or “li” in RichText.
+* Do not use dangerouslySetInnerHTML with i18n string.
+* Account for null value in redux-routine createRuntime.
+* Extract link container from RichText.
+* Allow default_title, default_content, and default_excerpt filters to function as expected.
+* Replace gutenberg in classNames with block-editor.
+* Restore the order of actions usually fired in edit-form-advanced.php.
+* Update REST Search controller to use ‘wp/v2’ namespace.
+* Improve keyboard shortcuts section in FAQ.
+* Change all occurrences of ‘new window’ to ‘new tab’.
+* Conditionally load PHP classes in preparation for inclusion in core.
+* Update rich-text source mentions in docs.
+* Deprecate PanelColor components.
+* Use mock response for demo test if Vimeo is down.
+* Adding a bit more verbosity to the install script instructions.
+* Document isDefault option for block styles.
+* Update docs for new REST API namespace.
+* Update shortcut docs with new block navigation menu shortcut.
+* Further improve Release docs.
+* Updated custom icon documentation links.
+* Add all available script handles to documentation.
+* Add wp-polyfill to scripts.md.
+* Add e2e tests for List and Quote transformations.
+* Fail CI build if local changes exist.
+* Attempt to always use the latest version of nvm.
+* Add bare handling for lint-js script.
+* Add support for Webpack bundle analyzer.
+* Improve setup of Lerna.
+* Update clipboard dependency to at least 2.0.1.
+* Recreate the demo content post as an e2e test using keyboard commands.
+* Add mobile SVG compatibility for SVG block icons.
+* Fix className style in SVG primitive.
+* Split Paragraph and Heading blocks on enter.KEY. Refactor block splitting code on paragraph and heading blocks.
+* Add caption support for image block.
+* Rename PHP functions to prevent conflict with core
+* Fix some typos
+* Improve the Toggle Control elements DOM order for better accessibility
+* Set correct media type for video poster image and manage focus properly.
+* Implement fetchAllMiddleware to handle per_page=-1 through pagination in wp.apiFetch
+* Fix Slash autocomplete: Support non-Latin inputs
+* Add WordPress logo animation for preview
+
+= 4.0.0 =
+
+### New Features
+* Add ability to change overlay color in Cover Image.
+* Introduce new Font Size Picker with clear labels and size comparison.
+* Introduce new RichText data structure to allow better manipulation of inline content.
+* Add Pullquote style variation and color palette support.
+* Add support for post locking when multiple authors interact with the editor.
+* Add an alternative block appender when the container doesn’t support the default block (paragraph).
+* Improve the UI and interactions around floats.
+* Add option to skip PublishSidebar on publishing.
+* Add support for shortcode embeds that enqueue scripts.
+* Add a button to exit the Code Editor.
+* Introduce a reusable ResizableBox component.
+* Style nested `<ul>`s with circles instead of normal bullets.
+* Show hierarchical terms sorted by name and allow them to be filterable through search. Hide the filter box if there are fewer than 8 terms.
+* Improve messaging around invalid block detection.
+* Use text color for links when a paragraph has a color applied.
+* Allow extended usage of the controls API in resolvers within data layer.
+* Ensure that a default block is inserted (and selected) when all other blocks are removed.
+* Enhance the block parser to support multiple type, in accordance with JSON schema.
+* Add a larger target area for resize drag handles.
+* Add media button to classic block.
+* Add control to toggle responsive mechanism on embed blocks.
+* Update sidebar design to have a lighter feeling.
+* Update resolvers in data layer to rely on controls instead of async generators.
+* Set template validity on block reset.
+* Remove dirty detection from Meta Boxes to reduce false positives of “unsaved changes”.
+* Show “Publish: Immediately” for new drafts by inferring floating date.
+* Add a slight transition to Full Screen mode.
+* Improve spacing setup in Gallery Block.
+* Remove additional side padding from blocks.
+* Improve the reusable blocks “Export as JSON” link.
+* Enforce a default block icon size to allow flex alignment and fix unaligned labels.
+* Consider single unmodified default block as empty content.
+* Only display URL input field when “Link To” is set for Image Block.
+* Make backspace behavior consistent among Quote, Verse and Preformatted.
+* Expose refresh method from Dropdown component.
+* Omit style tags when pasting.
+* Use best fitting embed aspect ratio if exact match doesn’t exist.
+* Avoid dispatching undefined results in promise middleware.
+* Change keyboard shortcut for removing a block to access + z.
+* Replace the Full Screen mode “x” icon with a back arrow.
+* Make drag handle visible on hover while in nested contexts.
+* Pass the tab title to the TabPanel component for situations where it may need to be highlighted.
+* Allow setting no alignment when a default alignment exists.
+* Improve title and appender margin fix.
+* Avoid focusing on the close button on modal and try a modal appear animation.
+* Change the URL Input label to match Classic.
+* Adjust media upload source for RichText.
+* Handle edge cases in with-constrained-tabbing and add tests.
+* Set a consistent input field width in media placeholders.
+* Add a hover state to sidebar panel headers.
+* Change settings title from “Writing” to “View”.
+* Convert the “tools” menu group into internal plugin.
+* Normalize data types and fix default implementation in parser.
+* Cleanup CSS specificity issues on Button component for portability.
+* Display error when attempting to embed URLs that can’t be embedded and don’t generate a fallback.
+* Update some edit and save button labels and styles for consistency.
+* Make “Manage Reusable Blocks” a link instead of an icon button.
+
+### Bug Fixes
+* Fix issue with Enter and the Read More block.
+* Fix menu item hover colors.
+* Fix issue with editor styles and fullscreen mode.
+* Fix popover link repositioning.
+* Fix Space Block layout issues on small screens.
+* Fix custom classNames for dynamic blocks.
+* Fix spacing of post-publish close button in other languages.
+* Fix Async Generator resolvers resolution.
+* Fix issue with Spacer Block not being resizable when using unified toolbar and spotlight mode.
+* Fix grammar.md manifest entry and update data docs.
+* Fix issue with region focus on the header area on IE11.
+* Fix reusable block broken button dimensions on IE11.
+* Fix issues with dropping blocks after dragging when calculating new block index.
+* Fix InnerBlock templates sync conditions to avoid a forced locking.
+* Fix typo in @wordpress/api-fetch README.md.
+* Fix regression with Button Block placeholder text.
+* Fix dropzone issue in Edge (event.dataTransfer.types not being an array).
+* Fix documentation for registerBlockStyle arguments and clarify getSaveElement filter.
+* Fix raw transforms not working in Edge when pasting content.
+* Fix a regression where wide images would cause horizontal scrollbars.
+* Fix issue with gallery margin while typing a caption.
+* Fix Block alignment CSS rules affecting nested blocks.
+* Fix CSS issue with nested paragraph placeholder.
+* Fix links in docs and add documentation for isPublishSidebarEnabled.
+* Fix shortcode package dependencies.
+* Fix overscroll issues locking scroll up on long pages.
+* Fix reference to SVG component in docs.
+* Fix Table Block header and body column misalignment.
+* Fix an issue where inserting like breaks would throw an error.
+* Fix regressions with placeholder text color (Cover Image, captions).
+* Fix Editor Styles regression.
+* Fix faulty Jed state after setLocaleData.
+* Fix small line-height issue in editor style.
+* Fix Pullquote margin regressions.
+* Fix issues with File Block and new RichText structures.
+* Fix Writing Flow E2E test.
+* Fix issues with “tips” popup margins.
+* Fix issue with mentions after rich text value merge.
+* Fix clipping issue with Instagram embed.
+* Fix ESNext example code.
+* Fix usage of tabs / spaces in parser code.
+* Fix Classic Block toolbar regression.
+* Fix issues with Table Block alignments.
+* Fix inserter misalignment regression.
+
+### Other Changes
+* Minor i18n fixes after deprecations were removed.
+* Rename parameter from mapStateToProps to mapSelectToProps in withSelect.
+* Rename AccessibleSVG to SVG and make it work with React Native.
+* Change createObjectUrl to createBlobURL.
+* Clean up Sass variables, comments, reduce complexity.
+* Move Classic Block to packages.
+* Move HTML Block into the blocks library package.
+* Move embed scripts into the body in preview documents.
+* Ensure that the return value of apiFetch is always a valid Promise object in Firefox.
+* Allow negative numbers in order field for Page Attributes.
+* Make sure the demo page loads without marking itself as having changes.
+* Refactor MediaUpload, MediaPlaceholder, and mediaUpload to support arrays with multiple supported types.
+* Add new icons to dashicons package.
+* Add link to “add_theme_support” docs.
+* Remove glob and just include necessary files.
+* Remove unused isButton prop.
+* Remove Vine embed.
+* Replace length check with RichText.isEmpty in Image Block.
+* Replace TinyMCE function to decode entities with existing Gutenberg package.
+* Extract the edit-post module as a reusable package.
+* Pass editor initial settings as direct argument.
+* Pass feature image ID to media upload component.
+* Pass all available properties in the media object.
+* Replace element-closest with registered vendor script.
+* Add new handbook introduction and docs about “blocks as the interface”.
+* Add utils to the wp-data script dependencies.
+* Disable alternate diff drivers in setup script.
+* Clarify RichText.Content readme docs.
+* Document `isDefault` option for block styles.
+* Update Panel component documentation.
+* Update full post content test fixtures.
+* Add ESLint rule about not allowing string literals in IDs.
+* Add a test for the new Code → Preformatted transform and use snapshots.
+* Add E2E test to visit demo page and verify errors.
+* Add E2E tests for list creation.
+* Update Redux to the latest version.
+
+### Mobile
+* Add the React Native entry point to more packages.
+* Need to define isRichTextValueEmpty for mobile.
+* Have Travis run mobile tests that use the parent code.
+* Wire onEnter to requestHTMLWithCursor command in RichText.
+
+= 3.9.0 =
+
+* 🏗 Add support for creating reusable blocks out of multi-selected groups of blocks not just individual blocks. This means the ability to easily save templates out of an existing set of blocks.
+* 🚀 Add support for importing and exporting reusable blocks (using a JSON file transport). Note that locality of resources can be a problem if importing on a separate WordPress site.
+* 🔍 Allow to visually show differences between conversion options when a block is detected as invalid.
+* Add a clear drag handle next to the block arrow controls to drag and move a block. Also further polishes the drag and drop experience.
+* Instrument collapsible groups for the block toolbar. It allows to display groups of options as a dropdown and reduce the length and imposition of the toolbar as a whole.
+* Allow conversion from Cover Image to Image and back, using caption if it exists as the main text.
+* Move the reusable block UI options to the top of the block or block group.
+* Focus the title when loading the editor if it’s empty.
+* Adjust margin rules for nested blocks.
+* Preserve aspect ratio on embedded content at different alignments and widths.
+* Unselect blocks and disable inserter when switching to Code Editor.
+* Add new default block icon (used when no icon is defined).
+* Avoid showing stacked icon group on parent blocks if all of its children are meant to be hidden from the inserter.
+* Add dark editor style support.
+* Add a figure wrapper to Pullquote block.
+* Add needed attributes to kses allowed tags for the Gallery block.
+* Improve visual display of Classic block toolbar.
+* Adjust unified block toolbar padding at medium breakpoints.
+* Better align the close, chevrons, and ellipsis icons in the sidebar panel.
+* Improve cropping of galleries in IE11.
+* Adjust gallery caption flex alignment.
+* Include Caption Styles in Video Block.
+* Update RichText usage to avoid inline elements.
+* Add shortcut aria label for unreadable shortcuts.
+* Avoid triggering invalid block mechanisms on empty HTML content.
+* Rename the Speaker block to Speaker Deck.
+* Disable inserter on Column block and avoid showing stacked icon on columns.
+* Send post_id to the REST API in the ServerSideRender component within the editor. This ensures the global $post object is set properly.
+* Use pseudo element to prevent inspector tab width from changing when selected.
+* Apply consistent spacing on the post visibility menu.
+* Fix notice styling regression.
+* Fix ability to select small table cells.
+* Fix issue with drag and drop in Chrome when the document has iframes.
+* Fix HTML validation issues.
+* Fix margin style regression with block appender.
+* Fix link source for outreach/articles.
+* Fix Archives block alignment and issue with custom classes.
+* Fix error when a taxonomy has no attached post type.
+* Fix invalid block scrim overflowing toolbar on mobile.
+* Fix block settings menu appearance in non wp-admin contexts.
+* Fix incorrect unlink shortcut.
+* Fix placeholder text contrast.
+* Fix issue with shortcut inserter on invalid paragraphs.
+* Fix camelCase and cross-component class name.
+* Fix qs dependency typo.
+* Pluralize “kind” to fix typo.
+* Remove isButton prop.
+* Remove wrapper div from Categories block.
+* Remove prop-type-like check in Popover component.
+* Remove unnecessary duplicated class from Embed placeholder.
+* Flatten BlockListLayout into base BlockList.
+* Add isEmptyElement utility function under wp.Element.
+* Use HTML Document for finding iframe in embed previews.
+* Add wp-polyfill as central polyfill.
+* Update docke-compose setup order to create MySQL container before WordPress container.
+* Improve comments in transforms object of Quote block.
+* Do not assume that singular form in _n() is used just for single item.
+* Update examples for components to look according to guidelines.
+* Update release docs to include process for RC.
+* Add simplified block grammar spec to the handbook.
+* Add lint rule for path on Lodash property functions.
+* Add user for cli image in docker-compose.
+* Show lint errors when there are lint problems.
+* Minor updates and improvements to documents and code references.
+* Improve docs build to consider memoized selectors.
+* Add Heading toolbar for changing heading sizes.
+* Save level to heading block attributes for parsing.
+* Add onEnter callback and function placeholder to RichText implementation.
+* Add Image block placeholder.
+* Avoid propagating eventCount to components.
+* Parser: Output freeform content before void blocks.
+* Fix export block as JSON in IE11 and Firefox.
+* Update demo content to avoid invalidations or automated post updates.
+
+= 3.8.0 =
+
+* Add Full Screen mode. 📺
+* Add UI for bulk managing reusable blocks.
+* Implement a more sophisticated Editor Styles mechanism. 🖍 It allows themes to register editor styles for blocks by targeting the blocks themselves without having to fight CSS specificity, and without having to know the internal DOM structure for the editor.
+* Move the block settings menu to the block toolbar, further consolidating the UI elements.
+* Switch to a new hand-coded default block parser implementation and expand documentation.
+* - Implemented in both PHP and JS.
+* - Brings great performance improvements in both time and memory.
+* - Makes server-side parsing in PHP viable for accessing blocks as a tree.
+* Use flex-box to render the block inserter layout to address different issues with spacing.
+* Show a warning when a disallowed filetype is dropped on a MediaUpload.
+* Show "no archives to show" message on Archives Block.
+* Add AccessibleSVG component and use consistently for block icons.
+* Improve Classic editor and Cloudflare notification modals.
+* Refactor Draggable component to decouple the drag handle from the DOM node being dragged.
+* Move video caption styles to style.scss.
+* Treat Verse lines consistently on the front-end.
+* Make sure all available taxonomies are loaded in the editor.
+* Improve empty elements filters in Slot implementation.
+* Fix case with PostTextEditor where intended state value is not always reflected in the rendered textarea when empty.
+* Fix background clashing with some themes in Separator alternative styles.
+* Fix case where hasSelectedInnerBlock did not account for multi-selected innerBlocks. This caused an edge case in Spotlight mode where multiple blocks selected inside a column would appear unfocused.
+* Fix regression with margins around image captions.
+* Fix issue with author select overflowing on IE11.
+* Fix the publish panel top position in FullScreen mode.
+* Fix radio button alignment in post visibility menu.
+* Fix issues with centering of images.
+* Fix BlockIcon usage in embed placeholder when resource cannot be previewed.
+* Fix font size regression in PostTitle.
+* Fix codetabs block in extensibility documentation.
+* Fix import source of RangeControl in Readme file.
+* Fix broken link in documentation inside element/README.md.
+* Deprecate usage of RichText provider component.
+* Deprecate getI18n, dcnpgettext.
+* Remove deprecated selectors from docs.
+* Revert shortcut change in block-deletion e2e test.
+* Pin fetch polyfill to 3.0 UMD distributable to resolve an issue where it was no longer usable in IE11.
+* Ensure Gutenberg repository is clean after install.
+* Include block serialization default parser in plugin.
+* Change how required built-ins are polyfilled with Babel 7.
+
+= 3.7.0 =
+
+* New “Spotlight Mode” that focuses on a single block at a time and an updated “Unified Toolbar” design. Both can be combined.
+* Refactor to how image floats are handled.
+* Improve visual clarity of block switcher menu.
+* Add a delay to the block type label when hovering.
+* Allow converting a multiline-paragraph into a list with corresponding items.
+* Position caret at end of previous block for any type of block removal.
+* Automatically create an Audio block when drag-and-dropping an audio file.
+* Update icons used for Paragraph, Heading, and Subheading blocks for added clarity.
+* Adhere to OS guidelines when showing keyboard shortcuts (icons for Mac).
+* Improve link insertion by continuing to show highlighted text when URL input is toggled.
+* Automatically create a link when selected text is a URL.
+* Expand on capabilities of invalid block actions by adding an ellipsis menu and an option to convert to classic block.
+* Ignore leading slash when searching blocks in the inserter.
+* Pass the title attribute when uploading an image.
+* Allow blocks which support alignments to have a default option.
+* Add poster image support for Video Block.
+* Add support for preload attribute in Video Block.
+* Add description for Reusable Blocks, show in the inspector.
+* Update Heading Block description for clarity.
+* Small design update to the editor fixed toolbar.
+* Improve visual display of post visibility settings.
+* Apply enhancements to the coloring mechanism and the exposed components (withColors).
+* Only show transforms for blocks that can be inserted on the root block. Also orders them by frequency / use.
+* Remove margin-bottom from the last element on panel body.
+* Store and restore the global post object around dynamic block callbacks to allow for loops.
+* Move first editor tip about inserter to the toolbar.
+* Use double quotes in all NUX tips.
+* Use sentence case for text in Tooltips.
+* Only request embed preview if there is a URL.
+* Change keyboard shortcut for remove block to Cmd+Shift+X / Ctrl+Shift+X.
+* Reset value of RangeControl when setting it to empty.
+* Add Text Columns → Columns transform.
+* Add Code → Preformatted transform.
+* Add “blockquote” as a keyword for the Quote block.
+* Clear the floating element for clearing color values. Update the appearance so that it’s consistent with other button settings.
+* Rewrite Table Block to use a simpler RichText value.
+* Add RichText.isEmpty API.
+* Allow disabling Google Fonts URL by translators.
+* Refactor post format block implementation to assign as template setting.
+* Improve settings consistency of blocks under widget category.
+* Fix issue where pasting malformed HTML into a block the HTML tokenizer could break by wrapping it with an exception handler.
+* Restore option to add links within a Verse Block.
+* Fix excess whitespace in block style class name.
+* Fix issue where hit-area for the inserter between blocks was not perfectly centered.
+* Fix incorrect example code for withSelect higher-order component.
+* Fix flex-box issue on IE11 for keyboard shortcuts help panel.
+* Fix lint issues found in block-serialization-spec-parser packages.
+* Fix malformed SVGs for Facebook.
+* Fix small alignment issue with the inserter arrow.
+* Fix issue with recent blocks showing on mobile.
+* Fix another issue with page publishing.
+* Fix issue with string that was not showing up for translation.
+* Fix left margin of Archives Block.
+* Fix styling issue with block inserter.
+* Fix regression with missing SVG roles and attributes.
+* Fix script registration of TinyMCE to account for compression.
+* Fix embed block pattern mismatch.
+* Fix issue with tooltips not being shown on IconButtons with DotTip children.
+* Fix some regressions with Table Block and make sure it behaves responsibly.
+* Fix regression with textbox spacing and a focus issue.
+* Resolve an issue where removing all blocks from a post with a template assigned would reintroduce the template blocks after saving and reloading the editor.
+* Switch order of operations so that post content is parsed first regardless of the presence of a template.
+* Add doAction when a deprecated feature is encountered.
+* Deprecate Subheading block.
+* Change title and description of Text Columns to include deprecation notice.
+* Remove extra classNames from integration test.
+* Make sure property for gallery=multiple is only set when type of media is image.
+* Avoid changing the public API of the warning component to avoid potential backwards compatibility issues.
+* Check for window in data registry.
+* Update FocusableIframe component URL example.
+* Drop explicit window reference from withSafeTimeout in compose.
+* Prevent case where early editor checks might bail out preventing hidden meta-boxes from being actually hidden.
+* Use “post” instead of “page” in the warning when the post contains blocks.
+* Make alt text for image in example post translatable.
+* Remove TinyMCE paste plugin as it’s absorbed in raw handling modules.
+* Extract LinkContainer from FormatToolbar.
+* Document how to add block style variations.
+* Add mention of Material Design icons to the design docs.
+* Update documentation for block controls.
+* Extend guidelines for managing packages and publishing them to npm.
+* Update contributing guidelines to include local wp dev instructions.
+* Update FAQ doc with info about keyboard shortcuts.
+* Update package-lock.json to expected values.
+* Deprecate onSetup and getSettings as unstable APIs from RichText.
+* Some general updates to handbook documents.
+* Add documentation about floats.
+* Add e2e test for font size mechanism.
+* Make usage of core-data explicit.
+* Create new spec-parser package.
+* Restores the test URL we should be using for e2e tests.
+* Upgrade WP Coding Standards to 1.0.0.
+* Update npm-package-json-lint lock to 3.3.1.
+* Update stylelint to 9.5.0 and stylelint-config-wordpress to 13.1.0.
+* Update lint-staged and docs/manifest.js.
+* Mobile Native
+* - Initial implementation of Toolbar.
+* - Add basic text toolbar actions.
+* - Update on the event interface for contentSizeChange on Aztec component.
+* - Fix toolbar status when pressing buttons on Android (and iOS).
+
+= 3.6.2 =
+
+* Restore min-width to popover.
+* Fix wide toolbar regression
+* Add e2e test for publishing a page
+* Fix typo for removing excerpt block stripping
+
+= 3.6.1 =
+
+* Fixed an issue that caused page publishing to fail.
+* Fixed an issue with the block options menu appearing too narrow.
+
+= 3.6.0 =
+
+* Updated block inserter and library with new icons for all core blocks.
+* Allow showing the sidebar and inspector controls when editing a block in HTML mode.
+* Add new block keyboard shortcuts and consolidate their display in menus:
+* * Insert Before / After block.
+* * Duplicating block.
+* * Toggling the inspector.
+* * Remove block keyboard shortcut.
+* Updated block inserter and library with new icons for all core blocks.
+* Allow showing the sidebar and inspector controls when editing a block in HTML mode.
+* Add new block keyboard shortcuts and consolidate their display in menus:
+* Insert Before / After block.
+* Duplicating block.
+* Toggling the inspector.
+* Remove block keyboard shortcut.
+* Add new keyboard shortcuts help modal documenting available shortcuts.
+* Hide keyboard shortcuts on mobile screens.
+* Open new window if prior preview window has been closed.
+* Bring the preview tab to the front when clicking the preview button.
+* Avoid changing the label of the “publish” button if an auto-save is being performed.
+* Update the Block Inserter to allow searching for terms that contain diacritics.
+* Take into account children blocks when handling disabled blocks.
+* Offer chance to add and revise Tags and Post Format during pre-publish flow.
+* Let menus grow based on the length of its elements.
+* Add visual padding to menus.
+* Avoid scrollbars on Audio block when shown full-width.
+* Improve permalink UI and make it responsive.
+* Change color of links in gallery block caption.
+* Simplify the styling of the “Toggle publish panel” aria-region to avoid content jumps.
+* Make active pill button look pressed.
+* Make sure Latest Posts alignment class behaviour is consistent.
+* Show drop-zone background when file is dragged.
+* Reset active sidebar tab on initial load.
+* Apply new checkbox CSS to radio buttons and fix border radius.
+* Add a couple new dashicons for insert before / after block.
+* Add styles for Spinner component (was relying on core before).
+* Add styles for Notice component.
+* Refactor template select field to use SelectControl.
+* Correctly handle per_page=-1 in the queried data state.
+* Create dummy context components for type switch.
+* Add RegistryConsumer export to data module.
+* Add has_blocks function to the repertoire.
+* Add has_block function and unit tests.
+* Add has_block function and unit tests for it.
+* Introduce strip_dynamic_blocks() for excerpts.
+* Fix issue with default appender placeholder on IE11.
+* Fix issue with shortcode block UI on IE11.
+* Fix tag input interface on IE11.
+* Fix issue with custom element serializer on IE11.
+* Fix issue with meta boxes overlapping the content on IE11.
+* Fix invalidation case of custom block classes.
+* Fix unhandled error dialog styling issue.
+* Fix paragraph splits on react native implementation.
+* Fix code block style regression.
+* Fix issue with code font-size on heading contexts.
+* Fix case where crashed block would overlap with surrounding blocks.
+* Fix issue with block styles on IE11.
+* Fix the heading level buttons on IE11.
+* Fix issues with drag and drop over text.
+* Fix small bug with recent blocks hover style.
+* Use argument swapping instead of named arguments for string placeholders.
+* Pass the the search result object to props.onChange on UrlInput.
+* Add localization context to occurrences of “More” string.
+* Add a Heading block implementation for mobile app.
+* Add the react-native entrypoint to all runtime packages.
+* Move MoreMenu specific styling away from Popover CSS.
+* Ensure meta box functions are available in editor context.
+* Ensure the full content integration test is run.
+* Remove client-side document title updates.
+* Remove TinyMCE shim that was removed in WP 4.9.7.
+* Remove the workaround for intermittent multiple-tab preview test failure.
+* Remove Promise.resolve call that’s already handled by the JS runtime.
+* Remove redundant event handlers from default block appender.
+* Deprecate withContext HOC and remove its usage.
+* Some localization & spelling fixes.
+* Update docs for templateLock’s insert option.
+* Extract Core Blocks to a block-library npm package.
+* Add a license checker script.
+* Allow access to the WordPress installation if DOCKER_ENV=localwpdev.
+* Bring the handbook design up to date.
+
+= 3.5.0 =
+
+* Add an edit button to embed blocks to modify the source.
+* Improve margin collapse within column blocks.
+* De-emphasize inline tokens within the inserter for a better user experience.
+* Polish focus and active styles around buttons and inputs.
+* Polish styles for checkbox component, update usages of toggle to checkbox where appropriate. Update documentation.
+* Improve pre-publish panel styling and textual copy.
+* Prevent duplicate DotTips from appearing.
+* Integrate "queries data" into the entities abstraction for data module.
+* Hide block movers if there are no blocks before and after.
+* Initial improvements for responsive image handling in galleries.
+* Use correct color for primary button bottom border.
+* Allow transitioning post status from scheduled to draft.
+* Improvements for auto-completer keyboard interactions.
+* Place strikethrough formatting button after link as it's less important.
+* Resolve issue with preview sometimes opening redundant tabs.
+* Align timepicker with calendar on pre-publish panel.
+* Expand date filter select box width within media library.
+* Constrain media blocks to content area width in front-end.
+* Reapply box-sizing to slider thumbs.
+* Avoid showing line separator in block settings menu when it's the last item.
+* Introduce additional keyboard shortcuts to navigate through the navigateRegions component.
+* shift+alt+n to go to the next region.
+* shift+alt+p to go to the previous region.
+* Replace all withAPIData usage and deprecate the higher-order component.
+* Add persistence via data plugin interface.
+* Introduce new redux-routine package for synchronous generator in data module.
+* Move embed API call out of block and into data module.
+* Remove no longer needed workaround targeted at resolving a TinyMCE error.
+* Abort selection range set on unset range target. Resolves an issue when merging two empty paragraph blocks created while at the end of an inline boundary.
+* Removing or merging RichText should only trigger if the selection is collapsed:
+* Fix issue with backspace not working as expected when deleting text content from the first block.
+* Fix case where paragraph content could move to previous paragraph when deleted.
+* Remove provisional block behaviour to improve reliability of various interactions.
+* Restore horizontal edge traversal implementation to address issue where pressing Backspace may not place the caret in the correct position if within or after a RichText field.
+* Ensure Gutenberg is disabled when editing the assigned blog posts page.
+* Initialize the Autosaves controller even if revisions are disabled. Fixes several bugs around saving with revisions turned off.
+* Display warning when Cloudflare blocks REST API requests.
+* Improve validation for attribute names in serializer.
+* Add Slot to block menu settings for extensibility.
+* Fix File Block center align behavior.
+* Fix behaviours when deleting on an empty RichText field.
+* Fix parent-dropdown missing for custom post-types.
+* Fix import style statements in ColorIndicator.
+* Fix height of used-once block warning.
+* Fix link for innerBlocks docs.
+* Fix link to server-side-render component.
+* Fix race condition with DomReady.
+* Fix awkward capitalisation in demo post content.
+* Fix warning for unrecognised forwardedRef prop.
+* Fix regression with URL input focus box.
+* Fix error in custom HTML preview when block is empty.
+* Fix colspan bug in table block for tables with thead tags.
+* Fix issue with image inspector controls disappearing once an image block is set to wide/full alignment.
+* Fix issue when image size remains blurry if manually set to a smaller size (i.e., medium) and then changed alignment to wide/full.
+* Fix issue with meta boxes being absent when script enqueued in head depends on wp-edit-post.
+* Resolve an issue where removing all text from a Button block by backspace would cause subsequent text changes to not be accurately reflected. Broader issue with TinyMCE inline elements as containers.
+* Avoid using remove() because it's unavailable in IE11.
+* Address further feedback on duplicated DotTips implementation.
+* Update re-resizable to version 4.7.1 — fix image & spacer blocks resizing on IE.
+* Use a unique querystring package instead of three different ones.
+* Introduce filters to allow developers the ability to customize the Taxonomy Selector UI for custom taxonomies.
+* Introduce RichText component for mobile native and implement the Paragraph Block with it.
+* Use standard label for Alt Text input.
+* Consolidate similar i18n strings.
+* Remove title attributes from the Classic Editor warning.
+* Remove unused code in taxonomies panel.
+* Remove oEmbed fixture files.
+* Remove jQuery dependency from @wordpress/api-fetch.
+* Remove filler spaces from empty constructs.
+* Remove REST API shims for code introduced in WP 4.9.8.
+* Remove unused terms, taxonomies, and categories code.
+* Replace the apiRequest module with api-fetch module.
+* Add inline comment that explains a stopPropagation() within tips implementation.
+* Add gutenberg_can_edit_post filter.
+* Add watch support for stylesheets in packages.
+* Add JSDoc comment to Popover's focus() method.
+* Add readme docs for all components.
+* Autogenerate documentation from readme files.
+* Add doc note about automatically applied attributes in save.
+* Add test for block mover.
+* Allow demo content to be translatable.
+* Update CSS selectors from :before to ::before.
+* Export the description for server-registered blocks.
+* Export getBlockTypes on react native interface.
+* Expose redux-routine to react native.
+* Expose unknown-type handler methods for mobile.
+* Specify missing wp-url dependencies.
+* Improve JS packages descriptions.
+* Downgrade Docker image version for WordPress for test validation.
+* Move CI back to latest WordPress version and bump minimum version to 4.9.8
+* Use @wordpress/compose instead of @wordpress/components.
+* Update docs for Button component.
+* Update package-lock.json.
+* Updated dependencies: jest, npm-package-json-lint and read-pkg-up.
+* Add Babel runtime dependency to redux routine.
+* Prevent Travis from running when changes are only made to .md files.
+* Add stylelint for SCSS linting.
+* Set babel dependencies to fixed version and add core-js2 support.
+* Trigger E2E test failure on console logging.
+* Update doc links to resources moved to packages folder.
+* Update api-fetch package documentation.
+* Update Lerna to 3.0.0-rc.0.
+* Generate source maps and read those from the webpack build.
+* Rewrite e2e tests using jest-puppeter preset.
+* Introduce a new Extending Editor document specific to editor filters.
+* Improve test configuration and mocking strategy.
+
+= 3.4.0 =
+
+* Add the Inline Blocks API.
+* Rename Shared Blocks to Reusable Blocks.
+* Add a Modal component.
+* Add a REST API Search controller.
+* Add a warning in the classic editor when attempting to edit a post that contains blocks.
+* Add ability for themes to configure font sizes.
+* Add RTL CSS to all packages.
+* Add an edit button to embed blocks.
+* Remove all wp.api usage from the editor package.
+* Add error handling for file block drag-and-drop.
+* Add registerBlockStyleVariation, for registering block style variations.
+* Add a border between panels in the block sidebar.
+* Add a editor.PostFeaturedImage.imageSize filter for the Featured Image.
+* Create a video block when dropping a video on an insertion point.
+* Expose a custom class name hook for mobile.
+* Add a React Native entrypoint for mobile.
+* Only disable wpautop on the main classic editor instance.
+* Retain the id attribute when converting heading tags to heading blocks.
+* Retain target="_blank" on links in converted paragraphs.
+* Improve the handling of imported shortcode blocks.
+* Replace the File block’s filename editor with a RichText.
+* Tweak the block warning style.
+* Add a max-height to the table of contents.
+* Remove the inset shadow from the table of contents.
+* Fix the tag placeholder text for long translations.
+* Fix the table of contents sometimes causing JavaScript errors.
+* Fix the link suggestion dropdown not allowing the first suggestion to be selected by keyboard.
+* Make tooltips persist when hovering them.
+* Add missing aria-labels to the audio and video block UIs.
+* Add an icon and accessibility text to links that open in a new tab.
+* Fixed shared blocks adding unnecessary rewrite rules.
+* Fix a regression in the colour picker width.
+* Fix the colour picker focus border being off-centre.
+* Combine ColorPalettes into a single panel for Button and Paragraph blocks.
+* Fix the ColorIndicator style import.
+* Fix auto-linking a URL pasted on top of another URL.
+* Add persistent store support to the data module.
+* Fix the Latest Comments block using admin imports.
+* Fix a warning when adding an image block.
+* Fix the classic block toolbar alignment.
+* Fix a warning in the block menu.
+* Change all blocks to use supports: align, instead of the align attribute.
+* Improve the ContrastChecker logic for large font sizes.
+* Update the is-shallow-equal package to use ES5 code.
+* Deprecate getMimeTypesArray, mediaUpload, and preloadImage.
+* Deprecate wideAlign in favour of alignWide.
+* Document Node version switching in the testing documentation.
+* Document examples of the registerBlockType hook.
+* Document an example of the block transforms property.
+* Document Gutenberg’s camelCase coding style.
+* Improved all of the package descriptions.
+* Update coding standards to allow double quoted strings to avoid escaping single quotes.
+* Standardise the package descriptions and titles.
+* Extract the editor package.
+* Isolate and reset e2e tests every run.
+* Improve test configuration and mocking strategy.
+* Fix test coverage configuration.
+* Fix the block icons e2e tests.
+* Bump the Puppeteer version.
+* Use simpler jest.fn() mocks for api-fetch calls in unit tests.
+
+= 3.3.0 =
+
+* Add new Archives block for displaying site archives.
+* Add new Latest Comments block to widgets category.
+* Add “Convert to blocks” option in HTML block.
+* Correct caret placement when merging to inline boundary.
+* Move block switcher from header to multi-block toolbar for multiselection.
+* Add video block attributes for Autoplay, Controls, Loop, Muted.
+* Remove HTML beautification and preserve whitespace on save.
+* Formalize RichText children value abstraction.
+* Allow transformation of image block to file block and vice-versa.
+* Support preload attribute for Audio Block.
+* Avoid popover refresh on Tip mount.
+* Introduce “registry” concept to the Data Module.
+* Convert successive shortcodes properly.
+* Hide “Convert to Shared Block” button on Classic blocks.
+* Update spacing in pre-publish panel titles.
+* Use do_blocks to render core blocks content.
+* Remove restoreContentAndSplit in RichText.
+* Hide insertion point when it is not possible to insert the default block.
+* Refactor block converters to share common UI functionality.
+* Replace the apiRequest module with api-fetch module.
+* Add audio/video settings title to settings panel.
+* Normalize the behavior of BlockListBlock’s “Enter” key handling to insert the default block.
+* Rename baseUrl entities property as baseURL in entities.
+* Rename UrlInput component as URLInput.
+* Give File block a low files transform priority.
+* Make tooltips persist when hovering them.
+* Optimise design of heading line heights.
+* Add a filter(‘editor.FeaturedImage’) for the FeaturedImage component.
+* Fix vertical arrow navigation skips in writing flow.
+* Fix incorrect polyfill script handles.
+* Fix template example so that it is correct.
+* Fix exception error when saving a new shared block.
+* Fix getInserterItems caching bug and add new test case.
+* Fix issue with spacer block resizing and sibling inserter.
+* Fix files configuration entry in package.json for wordpress/babel-preset-default.
+* Fix config and regenerate updated docs.
+* Fix dependency mistake in api-fetch.
+* Fix metaboxes save request (parse: false).
+* Fix issue with name field not being focused when a shared block is created.
+* Fix box sizing for pseudo elements.
+* Fix an error which occurs when assigning the URL of a Button block.
+* Improve usage and documentation of the landmark region labels.
+* Substitute the remaining uses of unfiltered_html capability and withAPIData.
+* Remove the “Extended Settings” meta box wrapper.
+* Remove NewBlock event handling from RichText.
+* Remove legacy context API child context from Block API.
+* Remove Text Columns block from insertion menus in preparation for Try outreach.
+* Remove unused autocompleter backcompat case.
+* Change label in Cover Image block for background opacity.
+* Change the text label on Image block from “Source Type” to “Image Size”.
+* Backup and restore global $post when preloading API data.
+* Move packages repository into Gutenberg with its history.
+* Enhance the deprecated module to log a message only once per session.
+* Switch tests away from using enzyme (enzyme.shallow, enzyme.mount, etc).
+* Unblock tests from being skipped.
+* Add basic test for shortcode transformation.
+* Add e2e test for block icons.
+* Add e2e tests for the NUX tips.
+* Add e2e tests for shared blocks.
+* Remove data-test attribute from UrlInputButton output.
+* Deprecate id prop in favor of clientId.
+* Rename MediaPlaceholder onSelectUrl prop as onSelectURL.
+* Remove unnecessary default prop from test.
+* Point the package entry to src directly for native mobile.
+* Use clearer filenames for saved vendor scripts.
+* Update local install instructions and add add more verbose instructions when node versions don’t match.
+* Reorder package.json devDependencies alphabetically.
+* Coding Guidelines: Prescribe specific camelCasing behaviors.
+* Regenerate docs using docs:build command.
+* Add documentation for ALLOWED_BLOCKS in Columns.
+* Add link to support forum in plugin menu.
+* Deprecate buildTermTree function in utilities.
+* Deprecate property source in Block API.
+* Deprecate uid in favor of clientId.
+* Deprecate grouped inner blocks layouts.
+* Improve eslint checks for deep imports.
+* Improve IntelliSense support when using VS Code.
+* Move the components module partially to the packages folder.
+* Add the blocks module to the packages folder.
+* Add wp-deprecated dependency to wp-element.
+* Add @babel/runtime as a dependency to wordpress/components.
+* Add @babel/runtime as a dependency for packages.
+* Add a new compose package.
+* Extract entities package.
+* Extract viewport package.
+* Extract @wordpress/nux package.
+* Create new spec-parser package.
+* Update Dashicons to latest build.
+* Update test for babel-preset-default.
+* Update code to work with Babel 7.
+* Update package-lock.json with eslint-scope version 3.7.3.
+* Update node-sass.
+
+= 3.2.0 =
+
+* Add block styles variations to the Block API.
+* Add support for Inline Images and Inline Blocks API.
+* Convert Columns to a set of parent and child blocks, including a wrapper element and more reliable front-end presentation.
+* Allow registering new block categories.
+* Add support for locking Inner Block areas.
+* Add File Block for uploading and listing documents, with drag and drop support.
+* Introduce Modal component to expand the extensibility suite of UI components.
+* Redesign block transformation menu.
+* Improve style display of region focus areas.
+* Prevent blocks from being draggable if a template lock exists.
+* Parse superfluous classes as custom classes preventing a block being considered invalid for such cases.
+* Support “Autoplay” and “Loop” in Audio Block “Playback Controls”.
+* Always show “new gallery item” below the gallery.
+* When dragging images to create a gallery, immediately show the images while uploading is happening.
+* Optimize withSelect to avoid generating merge props on equal props.
+* Remove the “scroll shadow” at the bottom of the inserter library.
+* Remove the bottom border on the last collapsible panel.
+* Remove wrapping div from paragraph block (in the editor) for performance audit.
+* Add Image Block ‘Link to’ setting.
+* Allow margins to collapse & refactor block toolbar.
+* Keep NUX tips open when the user clicks outside.
+* Add initialTabName prop to Tab Panel component.
+* Add higher order component to constrain Tab keyboard navigation.
+* Display server error message on media upload when one exists.
+* Improve “add block” text in NUX onboarding.
+* Improve experience of using image resize handles — placing them at the middle of the edges instead of the corners.
+* Update color of the Shared panel icon to be the same as all other icons.
+* Verify if block icon background and foreground colors are readable. Warn in the console otherwise.
+* Address various design details on Plugin API icon treatment in header and popover.
+* Include all image sizes on the media upload object when they exist.
+* Move the delete block action to the ellipsis menu for the block. Introduce separator in the menu.
+* Make the inserter results panel focusable and improve accessibility.
+* Improve publish panel accessibility and add new publish landmark region.
+* Open preview to previewLink if not autosaveable.
+* Make sure autocompleted values make it into the block’s saved content.
+* Avoid setAttributes on end-of-paragraph seeking to resolve unnecessary performance degradations.
+* Avoid re-render and subsequent action dispatch by adopting module constant.
+* Avoid focusing link in new NUX tooltip
+* Avoid showing hover effect if the ancestor of a block is multi-selected.
+* Schedule render by store update via setState. Fixes condition where appender would insert two copies of a block.
+* Inner Blocks refactor:
+* * Update deprecated componentWillReceiveProps to equivalent componentDidUpdate.
+* * Avoid deep equality check on flat allowedBlocks prop shape.
+* * Avoid handling unexpected case where UPDATE_BLOCK_LIST_SETTINGS is not passed an id.
+* * Avoid creating new references for blockListSettings when settings not set, but the id never existed in state anyways.
+* * Avoid switch fallthrough on case where previous updateIsRequired condition would be false, which could have introduced future maintainability issues if additional case statements were added.
+* * Add test to verify state reference is not changed when no update is needed.
+* * Consistently name allowedBlocks (previously also referred to as supportedBlocks).
+* Consider horizontal handled by stopPropagation in RichText. Fixes edge case with inline boundaries at the end of lines﻿. With further improvements﻿.
+* Ensure ellipsis icon button is visible when block settings menu is open.
+* Simplify RichText to have a single function for setting content vs. the current updateContent and setContent, by removing updateContent.
+* Optimize RichText by removing the creation of undo levels at split and merge steps.
+* Simplify the RichText component’s getContent function to remove a call to TinyMCE’s isEmpty function, which incurs a DOM walk to determine emptiness.
+* Optimize the RichText component to avoid needing to keep a focusPosition state.
+* Reenable pointer events on insertion point hover for Firefox.
+* Introduce colors slugs in color palette definitions to ensure localization.
+* Respect inner blocks locking when displaying default block appender.
+* Use color styles on the editor even if the classes were not set.
+* Move “opinionated” Gutenberg block styles to theme.scss.
+* Don’t allow negative values in image dimensions.
+* Fix IE11 formatting toolbar visibility.
+* Fix issues with gallery block in IE11.
+* Fix import statement for InnerBlocks.
+* Fix broken links in documentation.
+* Fix text wrapping issues in Firefox.
+* Fix showing the permalink edit box on the title element.
+* Fix focus logic error in Tips and tidy up docs.
+* Fix instance of keycode package import.
+* Fix case where an explicit string value assigned as an attribute would be wrongly interpreted as false when assigned as a boolean attribute type in the parser.
+* Fix the data module docs by moving them to the root level of the handbook.
+* Fix specificity issue with button group selector.
+* Fix CSS property serialization.
+* Fix left / right alignments of blocks.
+* Fix CSS vendor-prefixed property serialization.
+* Fix arrows navigation in the block more options menu.
+* Let ⌘A’s select all blocks again.
+* Check for forwardedRef in withGlobalEvents.
+* Address issues with left / right align improvements in RTL.
+* Different approach for fixing sibling inserter in Firefox.
+* Correctly handle case where ‘post-thumbnails’ is array of post types.
+* Remove blocks/index.native as the default is compatible with React Native app.
+* Allow editor color palette to be empty.
+* Support setup with single array argument in Color Palette registration.
+* Only save metaboxes when it’s not an autosave.
+* Force the display of hidden meta boxes.
+* Implement core style of including revisions data on Post response.
+* Remove post type ‘viewable’ compatibility shim.
+* Remove unused block-transformations component.
+* Use withSafeTimeout in NUX tips﻿ to handle cases where plugins modify the $post global.
+* Update HOCs to use createHigherOrderComponent.
+* Deprecate property source in Block API.
+* Documentation: fix rich-text markdown source.
+* Tweak release docs and improve release build script.
+* Add focusOnMount change to deprecations.
+* Add e2e test for sidebar behaviours on mobile and desktop.
+* Add e2e test for PluginPostStatusInfo.
+* Add snapshot update script.
+* Update import from @wordpress/deprecated.
+* Extract “keycodes” into its own package and rework the Readme file.
+* Add shortcode package instead of global.
+* Add package: @wordpress/babel-plugin-import-jsx-pragma.
+* Update nested templates to new columns format.
+* Generate the manifest dynamically to include the data module docs in the handbook.
+* Expose the grammar parser to the mobile app.
+* Drop the .js extension from @wordpress/element’s package.json entry-point so when used in the mobile RN app the correct module (index.native.js﻿) can be resolved by Metro.
+* Add packages Readme files to the handbook.
+* Add link in documentation to supported browsers.
+* Add initial document on copy guidelines.
+* Add missing documentation for InnerBlocks props.
+* Regenerate package-lock.json to address unintentional changes.
+* Use cross-env for plugin build scripts to address issues on Windows machines.
+* Invert JSX pragma application condition.
+* Ignore non-JS file events in packages.
+* Drop deprecations slated for 3.2 removal.
+* Publish multiple new versions of packages.
+
+= 3.1.1 =
+
+* Fix permalink editor not appearing.
+* Fix sibling block inserter not working in Firefox and Safari.
+
+= 3.1.0 =
+
+* Implement Tips Interface to guide a user in the new editor interface.
+* New design version of sibling inserter (the ability to insert blocks between other blocks).
+* Allow users to re-enable Tips.
+* Allow the user to preview changes to a published post without first updating the post.
+* Show the preview mode for HTML blocks converted into shared blocks. This streamlines the process of creating straightforward HTML blocks and letting users insert them visually.
+* Exclude the currently focused block from the block completer options. (i.e. don’t show paragraph as an option if already on a paragraph)
+* Trigger autosave as standard save for draft by current user.
+* Add mime type checking to the pre-upload error messaging system when uploading media.
+* Allow block hover outlines to draw color from admin theme.
+* Allow transforming multiple paragraph blocks into a single quote block.
+* Block API: move useOnce block configuration to supports.multiple = false.
+* Add strikethrough support for Markdown conversion when pasting.
+* Add yAxis=middle support to Popover to allow showing arrows vertically centered for NUX tips.
+* Add BlockIconWithColors component and use it for the block header with description in the inspector.
+* Add error notices mechanism directly to media placeholder.
+* Refactor the initialization of the editor to only require a post ID.
+* Optimize the default column width for character length and use the same width for the text editor.
+* Incremental improvements and polish to the mobile block toolbar.
+* Visually compensate nested blocks for block padding.
+* Prevent slash autocompleter from letting users insert two cases of a useOnce block.
+* Let screen readers announce the block aria label.
+* Improve the accessibility of featured images.
+* Make aria-multiline true by default in RichText so the content field is properly announced.
+* Add back role textbox to the List block and improve aria-multiline usage.
+* Replace the renderBlockMenu prop with Slot/Fill.
+* Hide disabled blocks from shortcut inserter.
+* Avoid deprecated React Lifecycle hooks in withAPIData.
+* Improve the element serializer to avoid double ampersand encoding of valid character references.
+* Update drop-cap design to better balance line length.
+* Describe expanded state of “more options” panel.
+* Improve DotTip positioning fix.
+* Implement Button component as assigning ref via forwardRef (new React API).
+* Improve serialising JSON to PHP-compatible query strings.
+* Introduce rendererPathWithAttributes() for ServerSideRender.
+* Refactor the getPostEdits selector to avoid relying on Lodash’s _.get.
+* Refactor withSelect to use getDerivedStateFromProps.
+* Replace JSON-escaped quotation mark with unicode escape sequence in Block API. Fixes PlainText component not properly escaping attributes under some specific user roles.
+* Fix regression in Columns block’s front-end style.
+* Fix regression in SVG support for block icons.
+* Fix PHP 5.2 notice by ensuring $memo is always an array.
+* Fix margins of embed block content.
+* Fix autocomplete behaviour in IE11.
+* Fix regression with formatting toolbar not showing divider between some block controls.
+* Fix issue where pasting an inline shortcode would produce a separate shortcode block.
+* Fix issue when copy pasting images in Chrome.
+* Fix typos in code comments.
+* Fix consistency of hover styles in toolbars.
+* Fix option for linking to attachment page on gallery block.
+* Fix Classic Editor adding paragraphs from block boundaries.
+* Fix post publish panel showing incorrect UX for contributors who don’t have publishing capability.
+* Fix issues with floats and the side UI on wide and full-wide.
+* Fix issue where server side upload errors disappear automatically.
+* Fix block inserter popover in RTL mode.
+* Fix mp3 uploads on chrome.
+* Fix getMimeTypesArray return documentation.
+* Avoid showing error if autosave runs and there are no changes to save.
+* Prevent any disabled button from changing the cursor to pointer.
+* Remove ‘who’=>’authors’ compatibility shim as it’s part of WP 4.9.6.
+* Remove confusing “wrap text” from Button settings.
+* Remove the usage of the componentWillMount lifecycle.
+* Remove the componentWillReceiveProps lifecycle usage.
+* Remove createInnerBlockList utility / context. This should be a simplification of block context, potentially with some performance and/or memory improvements, as an intermediary component is no longer created.
+* Improve translatable strings containing “%s” to have a translator comment.
+* Move trash post URL change to the BrowserUrl component. Consolidates all browser navigation (url changes and actual navigation).
+* Simplify the withColors HOC so we can avoid the usage of memoize while still having a correct implementation without unnecessary rerenders.
+* Refactor Higher-order components in data module to avoid the use of componentWillMount.
+* Use mdash for block description in cover image.
+* Ensure that only the latest promise updates the autocompleter state for more predictable behaviour.
+* Wrap PluginPostStatusInfo with PanelRow rather than Slot. Fix issue with hard to style divs.
+* Update demo content to avoid dirtying embed.
+* Allow using ServerSideRender component without defined attributes.
+* Avoid loading Gutenberg assets in other admin pages.
+* Add a new @wordpress/api-request package. Instead of relying on globals to set the nonce/rootURL, it users configurable middlewares. Preloading support is also built as a middleware.
+* Move the Core Data Module to packages.
+* Move Plugins module to packages.
+* Rename all the hooks moved from blocks to editor.
+* Add NUX e2e tests.
+* Add e2e tests for Plugins API.
+* Add es5 samples to edit-post and plugins.
+* Add e2e test to blocks.BlockEdit filter.
+* Add snapshot test for MoreMenu component.
+* Fix broken links in readme files.
+* Build tooling: add linting for package.json files.
+* Further explanation for why .normalize() is optional in raw-handling.
+* Update icon color readme example.
+* Generate docs for the data module.
+* Enable Strict-Mode of React.
+* Publish new versions of WP packages.
+* Regenerate integrity checks to sha512.
+* Drop deprecations slated for 3.1 removal.
+* Upgrade React 16.3.2 to React 16.4.1.
+
+= 3.0.1 =
+
+* Fix regression in Columns block's front-end style
+* Fix regression in SVG support for block icons
+* Build tooling: Add linting for package.json files
+
+= 3.0.0 =
+
+* Redesign the inserter with collapsible panels.
+* Add support for Child Blocks. These create a relationship between blocks and updates the inserter to show blocks based on context.
+* Implement a new block hover and select approach to improve nested block selection and clarity.
+* Allow expanding selection on consecutive Meta+A presses.
+* Add shared blocks to the blocks autocompleter.
+* Iterate on behaviour of the “between blocks inserter”.
+* Multiple longstanding fixes to the UrlInput box by using Popover component instead of custom positioning.
+* Allow themes to opt-in to the visual styles provided by core blocks.
+* Allow custom colors in block icons.
+* When focused on a parent with InnerBlocks set, show available child blocks clearly at the top. Blocks with children are marked visually in the root inserter.
+* Add publish panels support for plugins.
+* Scroll the inserter menu to the relevant position when opening a panel.
+* Expand matching categories when searching the block library.
+* Introduce a dedicated autosaves endpoint for handling autosave behavior. Improves general handling of revisions through REST API saves.
+* Show autosave notice when autosave exists.
+* Send all fields when transmitting an autosave, fixing missing titles.
+* Allow clicking the block’s input fields.
+* Move “Saved” blocks to the bottom and show distinct icon on the panel name.
+* Improve max-upload size error message.
+* Normalize unicode in raw handling.
+* Allow inserting a link with no text selected.
+* Center the background of the cover image block.
+* Make the Classic block toolbar sticky while scrolling.
+* Make Button component styles independent from Core Styles.
+* Use new "theme" style mechanism to restore Quote styles on the front.
+* Make various greys less dull when used with opacity.
+* Set the correct min-width for the ChromePicker popover.
+* Unify all the media blocks placeholders under a unique component.
+* Address focus style regression in menu and improve display of keyboard shortcut.
+* Refactor popover to clarify computations and address multiple cases of overflow issues.
+* Avoid URL redirect for published post autosave.
+* Refactor URL redirect as BrowserURL component and ensure redirect for new posts.
+* Avoid superfluous changes in RichText.
+* Improve performance for PublishPanel and extensions.
+* Unselect blocks when opening the document settings.
+* Add text alignment options to verse block toolbar.
+* Make sure the Title element uses the same max-width as blocks.
+* Improve title component so it works with and without editor styles.
+* Properly associate the spacer height input label.
+* Further visual polish to new inserter design.
+* Simplify inserter accessibility.
+* Fix block icon alignment in block inspector.
+* Fix issue with excerpt textarea height overflow.
+* Fix typo in withRehydration function call.
+* Fix Post Formats UI not showing.
+* Fix regressions with Button component after PostCSS.
+* Fix issue with applied formats being lost.
+* Fix unset background-color on sidebar headings.
+* Fix case where inbetweenserter would linger if you clicked to insert and then clicked away.
+* Fix issue with rich text toolbar being gone in captions.
+* Fix padding and outline style for expander panel.
+* Fix CodeEditor component not loading when WordPress is installed in a subfolder.
+* Fix regression with sticky toolbar border.
+* Fix some intermittent E2E test failures.
+* Fix “no results” message within inserter.
+* Fix visual issue with normal buttons with icons.
+* Fix issue where the sidebar would remain open on mobile when the page loaded if it was opened before.
+* Fix fileName not being respected when the image is uploaded via drag & drop.
+* Fix regression in spacer block.
+* Fix getInserterItems cache.
+* Fix intermittent adding-blocks E2E test failure.
+* Fix issue with shared block preview being rendered hidden.
+* Fix alignment issue with hover label on wide and full-wide.
+* Fix Windows-unfriendly theme.scss loader rule.
+* Fix issue where pasting would fail in IE11.
+* Fix issue with editing paragraph blocks in shared blocks.
+* Address small code style fixes on the core-data module.
+* Add support for getEntityRecords selectors/resolvers to the core data module to avoid duplication across the different entities.
+* Remove drag handle from block breadcrumb.
+* Improve Child Blocks code footprint.
+* Address package issues with npm audit fix.
+* Use Core’s TinyMCE version to avoid conflicts.
+* Scope the rule adding a white background to the html element.
+* Remove onFocus from core blocks’ RichText usage.
+* Remove post type capabilities from the user object.
+* Remove the dependency on the editor module code from blocks tests.
+* Expose preview_link through the REST API and use within client.
+* Only load Gutenberg Polyfill in editor pages.
+* Refine code statement of image classes.
+* Add support for the default_page_template_title filter in page-attributes meta-box.
+* Add additional condition to “Available templates” meta-box logic.
+* Ensure the wp-editor script is also enqueued soon using the enqueue_block_assets hook.
+* Cleanup shared block tests.
+* Provide cross-browser node containment checking.
+* Add unit tests for core-blocks/more/edit.js components.
+* Add documentation about ServerSideRender.
+* Auto-generate human-readable version of Gutenberg block grammar.
+* Doc Block cleanup for rich-text component.
+* Address multiple typos in code comments.
+* Skip test files when generating build folders for packages.
+* Fail E2E tests when uncaught page error occurs.
+* Extract new blob package out of utils module.
+* Update the wait function name to discourage its use in E2E tests.
+* Introduce new module with deprecation utility.
+* Introduce insertBlock() utility for E2E tests.
+* Move data module to the package maintained by Lerna.
+* Avoid using spread for objects to work with all node 8x versions.
+* Add lint rule to check that memize() is used.
+* Add global guard against ZWSP in E2E content retrieval.
+* Add building/watching support to Gutenberg packages.
+* Add further explanation for why .normalize() is optional.
+* Add new webpack plugin to handle library default export.
+* Reload the page after webpack watch compile.
+* Publish numerous WP packages updates from repository.
+* Drop deprecations slated for 3.0 removal.
+* Always publish main and module distributions in packages.
+* Upgrade mousetrap to 1.6.2.
+* Update all WordPress packages to the latest version.
+* Bump WordPress requirements to 4.9.6.
+
+= 2.9.2 =
+
+* Ensure the Title uses the same max-width as blocks
+* Center the background of the cover image block
+* Fix formatting controls regression
+* Fix classic editor visual mode regression
+
+= 2.9.1 =
+
+* Ensure the wp-editor script is also enqueued soon using the `enqueue_block_assets` hook
+* Allow clicking the block's input fields (regression fix)
+* Remove post type capabilities from the user object
+
+= 2.9.0 =
+
+* Add support for pinning plugin items in the main editor header. This is an important part of the editor Plugin API seeking to both grant plugins high visibility while offering users a consistent and flexible UI that can scale better.
+* Add shortcut tooltips for main toolbar.
+* Add remaining RichText shortcuts for formatting toolbar. Display them in tooltips.
+* Display the block toolbar and controls below the block on mobile.
+* Add automatic handling of focus for RichText component.
+* New reusable component: FontSizePicker. Example use in paragraph block.
+* Query for all authors with an unbounded per_page=-1 request. Makes sure no users appear missing.
+* Make the editor canvas friendly towards colored backgrounds. Improves support of nested structures over backgrounds as well.
+* Remove block alignment from paragraph block with deprecation handling.
+* Ensure contributors can create tags and manage categories.
+* Exclude private blocks from the slash autocompleter.
+* Close the post publish panel only when the post becomes dirty.
+* Add toggle to set fixed widths in Table block.
+* Surface and style the resizing tool in Table block.
+* Iterate on table block front-end styles.
+* Transform into the correct embed block based on URL patterns.
+* Allow resetting the permalink by saving it as empty.
+* Add text alignment options to Subhead block.
+* Move Heading block alignment options from the inspector to the toolbar.
+* Writing Flow: consider tabbable edge if no adjacent tabbable.
+* Implement Button as assigning ref via forwardRef.
+* Avoid adding terms when tabbing away from the tag selector field.
+* Add a max-height to Table of Contents menu.
+* Make any iframe embed responsive in the editor.
+* Update PostExcerpt component to use TextareaControl.
+* Show block remove button on empty paragraph blocks.
+* Introduce wp:action-publish and update corresponding UI to reference it. Use wp:action-publish to determine whether to display publish UI.
+* Use wp:action-assign-author to indicate if user can assign authors. Fixes issues with author selector not appearing under certain circumstances.
+* Permit unbounded per_page=-1 requests for Pages and Shared Blocks. Removes limit on how many items are retrieved.
+* Permit unbounded per_page=-1 requests for Categories and Tags.
+* Improve written descriptions of core blocks.
+* Show caption and description settings in featured image modal.
+* Make sidebar toggle button open the block inspector if a block is selected.
+* Avoid setting font-style when using dropcap.
+* Preserve image ID in raw handling.
+* Add a data store to manage the block/categories registration.
+* Avoid change in RichText when possible. It prevents unnecessary history records.
+* Stop unnecessary re-renders caused by withColors. Also solve memoize problems.
+* Move components from the blocks to the editor module.
+* Move editorMediaUpload to the editor module.
+* Move the editor settings into the editor’s store.
+* Change subhead block to subheading.
+* Add cache to getUserQueryResults and avoid authors rerender on every key press.
+* Rename isPrivate → supports.inserter in Block API.
+* Fix multi selection with arrows + shift.
+* Fix caretRangeFromPoint for Firefox.
+* Fix a PHP Notice in REST API responses.
+* Fix broken example in withAPIData README.
+* Fix issue with UrlInput autofocus when used in a custom block.
+* Fix issue with high contrast indicator in Edge.
+* Fix and update block fixture regeneration.
+* Fix gallery width to match width of other elements.
+* Fix Fragment render error on empty children.
+* Fix ServerSideRender bug with Columns block.
+* Fix block icon alignment.
+* Fix absent editor styles in Classic block.
+* Fix state variable name in core-data.
+* Fix generating admin schemes styles.
+* Fix captions on resized images.
+* Fix case where link modal would hide on rerender.
+* Fix paste with selection/caret at start or end.
+* Fix appender height to match paragraph block.
+* Use core-blocks prefix for class names.
+* Prevent classname override﻿ when passing className as argument.
+* Remove document outline from the sidebar.
+* Framework work to support React Native mobile app explorations:
+* Refactor the Code block .
+* Refactor “More” block.
+* Extract edit to their own file (part 1, part 2).
+* Use targetSchema of JSON Hyper Schema to communicate sticky action.
+* Tweak targetSchema Response for sticky posts.
+* Load additional REST API files if controller is defined.
+* Restore the wp-blocks stylesheet for backwards compatibility concerns.
+* Add documentation for title and modalClass props in MediaUpload.
+* Copy edits to theme extensibility.
+* Add a lint rule for enforcing ellipsis use.
+* Use a postcss plugin to generate the admin-schemes styles.
+* Move date module to packages maintained by Lerna. Move element to packages maintained by Lerna.
+* Extract dom package and make it maintained with Lerna.
+* Move blocks raw handling tests to test/integration folder.
+* Remove skipped tests which fail, enable those that pass.
+* Add missing unit test for received entity records.
+* Update Notice README.
+* Update wordcount package to prevent crash.
+* Update dom-react to 2.2.1.
+* Update React to 16.3.2.
+* Update packages to pass npm audit.
+* Upgrade rememo dependency to 3.0.0.
+* Updates the minimum required version of npm to version 6.0.0 or greater.
+* Update testing-overview document.
+* Update package-lock.json for fsevents﻿.
+* Avoid tail-ing the PHP 5.2/3 build logs.
+* Remove Docker compose deprecated parallel option.
+* Remove fsevents from optionalDependencies.
+* Remove %s from Lerna publish message.
+* Deprecate isExtraSmall utility function.
+* Add npm update to build script.
+* Make lerna a dependency rather than a devDependency.
+* Support adding a human-readable deprecation hint.
+* Drop features slated for 2.9 removal.
+* Introduce the common build folder to be used by all modules.
+
+= 2.8.0 =
+
+* Add a pasting schema in raw content handling. It simplifies whitelisting and reduces the amount of filters run. Should improve reliability, clarity, markdown conversion, and usage in blocks.
+* Add “Spacer” block to create empty areas.
+* Add Server Side Render component.
+* Expand public InnerBlocks API with support for template configuration and allowedBlocks logic.
+* ColorPalette improvements:
+	* Implement mechanism to use classes for configured colors instead of inline styles. Use it in Button block as well.
+	* Use color name in ColorPalette aria-label for making color selection more accessible.
+	* Improve accessibility of PanelColor by announcing currently set color by name.
+	* Hide color pickers in paragraph and button if no colors are available.
+* Add a format prop to allow HTML string values to be used in RichText component. This should be a useful API addition for plugin developers.
+* Improve the make gallery modal and allow it to use the correct mode when editing.
+* Improve performance by avoiding creating a new uids prop on each block rerender.
+* Make sure createInnerBlockList never updates when passed using context.
+* Introduce initial “entities” data model abstraction to automatically build state selectors.
+* Hide the movers and the block menu when typing.
+* Optimize the shouldComponentUpdate path of withSelect.
+* Use support: align API in Columns block, fixes issue with alignment.
+* Filter the PostFormat list to those supported by the theme.
+* Used fallback styles to compute font size slider initial position.
+* Indent serialized block output with tabs as part of Block API.
+* Add a RichText.Content component to be used in conjunction with RichText.
+* Determine emptiness by value in RichText.
+* Call resolver isFulfilled once per argument set in data modules.
+* Extend BlockEdit context with name and use it for autocompleters.
+* Improve order of block shortcuts within inline inserter.
+* Improve terms token feedback and accessibility.
+* Introduce theme_supports with formats to REST API index.
+* Switch post-author component to use /wp/v2/users/?who=authors. Related #42202.
+* Further harden who=authors check by author support for post type.
+* Disable link suggestions when value is URL.
+* Make CodeEditor component more extensible.
+* Allow the new “block remove” button appear on focus.
+* Add new “pure” higher order component to wp/element.
+* Add Embed Preview support for classic embed providers. This handled legacy embeds.
+* Add missing label and focus style to the code editor textarea.
+* Introduce editorMediaUpload wrapper and fix issue with images not being attached to a post.
+* Used editorMediaUpload in Gallery files transform (images drag&drop).
+* Make URL creation mechanism smarter around relative links.
+* Add a type attribute to input elements.
+* Add missing custom class in latest posts & categories block.
+* Add visible label to shared block name input.
+* Add ref="noreferrer noopener" for target="_blank" links.
+* Add drop cap help text in paragraph block.
+* Remove the text alignment from the block inspector in Cover Image.
+* Make sure aria-disabled buttons (movers) stay disabled on focus.
+* Simplify the BlockBreadcrumb component and its semantics.
+* Only display featured image UI when theme supports it﻿.
+* Improve display of URL input.
+* Improve consistency in how + icon is shown on the inserters.
+* Extract block library to separate module.
+* Improve handling of admin theme colors.
+* Avoid calculating the closest positioned parent by binding the RichText wrapper div.
+* Use IconButton on breadcrumbs to increase consistency and accessibility.
+* Reset change detection on post update, resolving an issue where changes made while a post is saving are not accurately reflected in change detection.
+* Hide inspector controls if no image is selected in Cover Image.
+* Minor improvements for the permalink “Copy to clipboard” button.
+* Fix scrolling issues with very long and multi-line captions.
+* Fix problem with front-end output of LatestsPosts block.
+* Fix issue with using zero min value in RangeControl.
+* Fix Markdown paste containing HTML.
+* Fix permalink linking to preview URL instead of live.
+* Fix issue with update button becoming invisible on mobile on already published posts.
+* Fix showing/hiding the right block side UI on RTL languages.
+* Fix Classic block regression after extraction of the blocks into a separate script.
+* Fix issue where when creating a new post would default to the block sidebar if it was opened before.
+* Fix issue when pasting content with inline shortcodes would produce a separate block.
+* Fix BlockEdit hooks not working properly with context.
+* Fix regression with select box.
+* Fix translation strings in embed block.
+* Fix regression with formatting button hover/focus style.
+* Fix arrow navigation in the shared block more options menu.
+* Fix orderby typo in latest posts block.
+* Fix the clipboard button as IconButton usage.
+* Restore hiding drop cap on focus to prevent bugs with contenteditable.
+* Restore priority on embed block for raw transforming.
+* Remove no longer mandatory use of isSelected in block edit.
+* Remove permalink_structure from REST API index as per #42465.
+* Remove old solution for focus after deprecation period.
+* Refactor withColors HOC to allow configuring the mapping when instantiating the component.
+* Refactor PanelColor to avoid the need for the colorName prop.
+* Use a “users” reducer combined with a “queries” sub state to map authors to users.
+* Make sure block assets are always registered before wp-edit-post script.
+* Expose Gutenberg Data Format version in the REST API response.
+* Split loading of API actions and filters to its own file.
+* Switch to rest_get_server() for compatibility with trunk.
+* Pre-load REST API index data to avoid flash of missing data.
+* Deprecate event proxying in RichText.
+* Avoid duplicate save request in shared block which could cause race conditions.
+* Update docs folder structure and make all internal handbook links relative.
+* Update theme extensibility documentation to include editor widths.
+* Add section about translating the plugin﻿ to the contributing doc.
+* Improve documentation and clarity of the Toolbar component.
+* Add documentation for undefined attribute source.
+* Add isDebounced prop in autocompleter doc.
+* Add arrow-spacing rule to eslint config.
+* Add arrow-parens rule to eslint config.
+* Enforce array as Lodash path argument.
+* Upgrade react-datepicker to 1.4.1.
+* Upgrade showdown to 1.8.6.
+* Drop deprecations slated for 2.8 removal.
+* Use the @wordpress/word-count package.
+* Use @wordpress/is-shallow-equal for shallow equality.
+* Build Tools: Fix the package plugin script.
+* Improve the G in Gutenberg ASCII
+
+= 2.7.0 =
+
+* Add pagination block (handles page breaks core functionality).
+* Add left/right block hover areas for displaying contextual block tools. This aims to reduce the visual UI and make it more aware of intention when hovering around blocks.
+* Improve emulated caret positioning in writing flow, which places caret at the right position when clicking below the editor.
+* Several updates to link insertion interface:
+  * Restore the "Open in new window" setting.
+  * Remove the Unlink button. Instead, links can be removed by toggling off the Link button in the formatting toolbar.
+  * Move link settings to the left.
+  * Update suggested links dropdown design.
+  * Allow UI to expand to fit long URLs when not in editing mode.
+  * Improve visibility of insertion UI when selecting a link
+* Rework Classic block visual display to show old style toolbar. This aims to help clarify when you have content being displayed through a Classic block.
+* Add ability to edit post permalinks from the post title area.
+* Improve display of image placeholder buttons to accommodate i18n and smaller screens.
+* Add nesting support to document outline feature.
+* Refactor and expose PluginSidebar as final API.
+* Refactor and expose SidebarMoreMenuItem as part of Plugins API.
+* Simplify block development by leveraging context API to let block controls render on their own when a block is selected.
+* Add ability to manage innerBlocks while migrating deprecated blocks.
+* Add a "Skip link" to jump back from the inspector to the selected block.
+* Add preloading support to wp.apiRequest.
+* Add isFulfilled API for advanced resolver use cases in data module.
+* Add support for custom icon in Placeholder component.
+* Disable Drag & Drop into empty placeholders.
+* Refine the UI of the sides of a block.
+* Assure the "saved" message is shown for at least a second when meta-boxes are present.
+* Make sure block controls don't show over the sidebar on small viewport.
+* Add ability to manually set image dimensions.
+* Make Popover initial focus work with screen readers.
+* Improve Disabled component (disabled attribute, tabindex removal, pointer-events).
+* Improve visual display of captions within galleries.
+* Remove default font weight from Pullquote block.
+* Keep "advanced" block settings panel closed by default.
+* Use fallback styles to compute font size slider initial value.
+* Allow filtering of allowed_block_types based on post object.
+* Allow really long captions to scroll in galleries.
+* Redesign toggle switch UI component to add clarity.
+* Improve handling of empty containers in DOM utilities.
+* Filter out private taxonomies from sidebar UI.
+* Make input styles consistent.
+* Update inline "code" background color when part of multi-selection.
+* Replace TextControl with TextareaControl for image alt attribute.
+* Allow mod+shift+alt+m (toggle between Visual and Code modes) keyboard shortcut to work regardless of focus area and context.
+* Allow ctrl+backtick and ctrl+shift+backtick (navigate across regions) keyboard shortcuts to work regardless of focus area and context.
+* Improve Classic block accessibility by supporting keyboard (alt+f10 and arrows) navigation.
+* Apply wrapper div for RawHTML with non-children props.
+* Improve and clarify allowedBlockTypes in inserter.
+* Improve handling of block hover areas.
+* Improve figure widths and floats in imagery blocks, improving theming experience.
+* Eliminate obsolete call to onChange when RichText componentWillUnmount.
+* Unify styling of Read More and Pagination blocks.
+* Replace instances of smaller font with default font size.
+* Fix styling issue with nested blocks ghost.
+* Fix CSS bug that made it impossible to close the sidebar on mobile with meta-boxes present.
+* Fix disappearing input when adding link to image.
+* Fix issue with publish button text occasionally showing HTML entity.
+* Fix issue with side UI not showing as expected on selected blocks.
+* Fix sticky post saving when using meta-boxes.
+* Fix nested blocks' contextual toolbar not being fixed to top when requested.
+* Fix centered image caption toolbar on IE11.
+* Fix issue with meta-box saving case by only attempt apiRequest preload if path is set. Also improve tests for meta-boxes.
+* Fix JS error when wp.apiRequest has no preload data.
+* Fix regression with image link UI, and another.
+* Fix regression with columns appender.
+* Avoid focus losses in Shared block form.
+* Fix ability to select Embed blocks via clicking.
+* Fix handling of long strings in permalink container.
+* Fix resizing behavior of Image block upon browser resize.
+* Show Image block with external image URL and support resizing.
+* Fix hiding of update/publish confirmation notices under WP-Admin sidebar.
+* Fix ID and key generation in SelectControl and RadioControl components.
+* Fix z-index of link UI.
+* Fix default width of embeds in the editor.
+* Revert unintended changes in default font size handling on Paragraph.
+* Disable the Preview button when post type isn't viewable.
+* Remove unused variable.
+* Rename "advanced settings" in block menu to "block settings". Update labels and docs accordingly.
+* Improve description of embed blocks.
+* Default to empty object for previous defined wp-utils.
+* Finalize renaming of reusable blocks to shared blocks.
+* Update 20 components from the editor module to use wp.data's withSelect and withDispatch instead of react-redux's connect.
+* Update another batch of components from the editor module to use wp.data's tools.
+* Replace remaining uses of react-redux in the editor module.
+* Update a batch of core blocks to drop explicit management of isSelected thanks to new context API.
+* Attempt to avoid triggering modsec rules.
+* Use wp-components script handle to pass locale data to wp.i18n.
+* Reference lodash as an external module. This also reduces bundle size.
+* Use border-box on input and textarea within meta-boxes to restore radio buttons to normal appearance.
+* Clarify demo instructions on wide image support.
+* Update docs to address broken sketch file links.
+* Reduce and rename rules in Gutenberg block grammar for clarity.
+* Add test confirming that withFilters does not rerender.
+* Allow E2E tests to work in a larger variety of environments.
+* Add mention of JSON workaround to including structured data in attributes.
+* Document use of GitHub projects in Repository Management.
+* Fix some documentation links.
+* Add accessibility standards checkbox and reference to the project's pull request template.
+* Remove emoji script as it causes different issues. Pending resolution on how to introduce it back.
+* Avoid needing navigation timeout in Puppeteer.
+* Disable login screen autofocus in Puppeteer tests.
+* Allow developers to opt out from some devtool settings to speed up incremental builds.
+* Use the WordPress i18n package and remove the built-in implementation. Update to 1.1.0.
+* Remove deprecated function `getWrapperDisplayName`.
+
+= 2.6.0 =
+
+* Add drag and drop functionality to reorder blocks (in addition to arrow movers).
+* Improve side UI around nested groups and introduce a block name label on hover.
+* Focus the block inspector automatically when a block is selected.
+* Allow extending auto-completers via filters — this also exposes the "user" auto-complete to all RichText component instances, making it much easier to leverage for external blocks.
+* Use debounced search request in user auto-complete mechanism improving the experience of mentioning in sites with more than 100 users.
+* Use custom serializer for texturize compatibility. This removes dependency on react-dom/server and integrates better with wptexturize expectations.
+* Group advanced block settings (class name and anchor) in a panel.
+* Move Post Types Data Fetching to the core-data module.
+* Refactor DocumentOutline to use the data module.
+* Improve performance of drag and drop by avoiding excessive re-rendering.
+* Various UI improvements to controls and components in Block Inspector.
+* Remove react-redux usage from the edit-post module, replacing it with the data module. Also improves performance on some block operations.
+* Add role=menuitem to the More Options menu items.
+* Renamed "Frequent" to "Suggested" in block inserter tab.
+* Invert speak messages in block inspector button.
+* Include only known terms in rendered Terms selector, fixing issue with occasional empty tags.
+* Apply centering style to the theme style output.
+* Avoid term request if term set is empty array.
+* Provide createHigherOrderComponent helper to Element abstraction.
+* Reset block selection when replacing with empty set.
+* Prevent unnecessary state updates to edit-post preferences.
+* Update Sidebar and Menu Item implementations to use React 16.3 context API.
+* Generalise and comment on DOMRect calculation and storage.
+* Reopen sidebar when going to viewport sizes larger than medium.
+* Widen dropzone indicator to match block width.
+* Reset margin and padding values for gallery.
+* More defensive checks when accessing capabilities and terms.
+* Fix autosave condition while editing a post using the Text Mode editor.
+* Fix block movers aria-label info on multi-select groups.
+* Fix centered multiline labels in the block settings menu.
+* Fix issue with Publish button caused by moment timezone configuration.
+* Fix arrow movement inside search input in Inserter.
+* Fix broken translation in FormTokenField placeholder.
+* Fix issue with invalid string value passed to caption in Image block.
+* Fix findDOMNode lint warning.
+* Fix error when DOCKER is not defined.
+* Fix Safari flashing a white screen just before the editor is loaded.
+* Fix problem with meta-boxes toggling.
+* Fix WordCounter error when loading meta boxes.
+* Fix clone function to allow cloning nested blocks.
+* Fix issue with meta-boxes and file inputs.
+* Fix issue with block more button when multi selected.
+* Handle post ID and WP_Post objects passed to gutenberg_can_edit_post().
+* Clear attribute and reset text back to default when cleared in the "More" block.
+* Remove an invalid test case from isCurrentPostScheduled.
+* Remove code transform for uppercase text in Tooltip component.
+* Remove unused PrismJS dependency.
+* Remove redundant z-index in block mover.
+* Remove background color from paragraph and fixed contrast checker on transparent colors.
+* Make block preview title translatable.
+* Make the click-redirector responsive﻿ (handles clicking on the bottom area of the editor to focus on last field).
+* Replace cases of bold font weight with weight 600.
+* Various Sass code improvements.
+* Add E2E test for splitting/merging paragraph blocks with Enter/Backspace.
+* Add test to check CPT templates initialization in E2E tests.
+* Add helpers to install/activate/deactivate and remove plugins in E2E tests.
+* Re-incorporate Webpack devtool into development build for improved debugging.
+* Add $HOME/.npm to Travis cache after addition of Puppeteer library.
+* Improve MediaUpload docs.
+* Rework all the extensibility related docs to add structure and clarity.
+* Remove deprecations slated for 2.6.
+* Upgrade React to version 16.3.0.
+* Migrate to Webpack 4.
+
+= 2.5.0 =
+
+* Add support for sharing nested blocks.
+* Introduce a declarative approach to handling display of sidebar content to the Plugin API with PluginSidebar component and portals.
+* Introduce menu item and related components to handle entry point for editor plugin operations, further extending capabilities and available tools in the Plugin API.
+* Add block template validation and ability to reset a template.
+* Add new abstracted data querying interface that provides better handling of declarative data needs and side effects. Introduces registerResolvers enhanced by withSelect.
+* Add predefined sets of font sizes and corresponding UI controls.
+* Improve block margin implementation in order to simplify work needed for nesting blocks.
+* Don't show insertion point between blocks when a template is locked.
+* Update shared block UI to better indicate that a block is reusable.
+* Add support for transforms prioritization to the block API.
+* Improve initial focus allocation within content structure popover for accessibility.
+* Add visibile text to gallery "add item" button for accessibility.
+* Update post taxonomies wp.apiRequest to not depend on ajax specific implementation.
+* Some visual refinements to the main block library inserter.
+* Include custom classes in the block markup within the editor, matching the final render on the front-end.
+* Improve display of block transformation options.
+* Fine-tune the pre- and post-publish flows depending on post status and user role.
+* Improve the accessibility of the MenuItemsToggle buttons and add a speak message for screen reader users to confirm when they switch editor mode.
+* Improve the accessibility of RichText elements by providing textbox roles and aria-multiline attributes.
+* Improve the accessibility of inserter items by providing aria-label attributes.
+* Clear selected block on canvas focus only if it is selected.
+* Avoid styling meta-boxes inputs to look like Gutenberg UI.
+* Use "perfect fourth" rule of typographic scale for heading display.
+* Inherit color styling on meta-boxes area.
+* Increase width of meta-boxes area.
+* Default to content-box box-sizing for the meta-box area.
+* Improve handling of transformations (backticks for Code and dashes for Separator) when pressing enter.
+* Expose combineReducer helper in data module.
+* Make it possible to override the default class name generation logic.
+* Remove edit-post styles from editor components.
+* Ignore mid-word underscores when pasting markdown text.
+* Add label element to the post title.
+* Improve block mover labels for speech recognition software.
+* Correct onChange handler in SelectControl component to support multi-value changes.
+* Make MediaUpload component extensible.
+* Improve display of color palette items (like white) by adding a subtle transparent inset shadow.
+* Ignore "Disable visual editor" setting to address case where Classic block would not load for the user.
+* Improve display of sidebar heights on mobile.
+* Update blockSelection reducer to clear selection when removing the selected block.
+* Show "no title" placeholder on the mobile sidebar when post title is empty.
+* Address case where cancelling edits on a shared block not discarding unsaved changes that have been made to that block.
+* Introduce new MenuGroup and MenuItem components and refactor for clarity.
+* Improve the block inserter UI on mobile by displaying the post title in a header above the search bar. Extends as optional support for all popovers.
+* Refactor media fetching to use the core data module. Shields from REST API specific nomenclature.
+* Add a label and a role to the block appender to make it discoverable by text readers.
+* Use up and down arrow icons for the meta boxes panels.
+* Hide reusable block indicator from the inserter preview.
+* Fix issue with embed placeholder breaking on reload.
+* Fix error when collapsing categories panel.
+* Fix case where inserting a block after removal inserts it at the top of the post.
+* Fix issue with Button block text wrap.
+* Fix bug with meta-boxes data collection that occasionally prevented them from showing.
+* Fix meta-box configuration persistence to be per postType.
+* Fix issue with multiple previews in Firefox by unsetting popup window upon close.
+* Fix scroll bleed when displaying modal UI on mobile.
+* Fix z-index issue with admin bar quick links and content structure tooltip.
+* Fix image href attribute matcher to not interfere with anchors inside the caption.
+* Fix help text position on toggle control and range control.
+* Fix centering of small videos.
+* Fix timezone conflicts when setting global moment default timezone.
+* Fix issue with getDocumentTitle and undefined titles.
+* Fix missing rerender of plugin area upon registration or unregistration.
+* Remove title from Table of Contents and warn user if theme doesn't support titles.
+* Prevent potential fatal error when registering shared block post type if a specific core user role has been removed.
+* Avoid collecting meta-box information on non-Gutenberg screens.
+* Update contrast checker to respect recent changes on Notice component.
+* Rename isProvisionalBlock action property to selectPrevious in removeBlock and removeBlocks functions.
+* Address issue with heartbeat dependency (only use when available).
+* Allow calling functions passed as props in the Fill.
+* Improve style handling and specificity of dashicon SVGs.
+* Unify "citation" translatable strings for quotes and pullquotes.
+* Clean up nomenclature inconsistencies in blocks and components modules.
+* Correct documentation example for withDispatch.
+* Update documentation on extending the editor via PluginSidebar and PluginMoreMenuItem.
+* Dynamically pick JS/CSS build files for plugin ZIP generation.
+* Copy improvements to documentation.
+* Attempt to avoid cases where hosts block certain HTTP verbs on wp-api.js requests. This is part of similar issues being exposed by Gutenberg being the first Core WordPress feature that makes significant use of the REST API.
+* Add a shim to override wp.apiRequest, allowing HTTP/1.0 emulation.
+* Update react-autosize-textarea package.
+* Update @wordpress/hooks to v1.1.6.
+* Use CustomTemplatedPathPlugin which was extracted and updated for Webpack 4.
+* Use wordpress/es6 ESLint config.
+* Add Gutenberg Hub to the resources.
+* Properly detect NVM path on macOS using homebrew.
+* Remove Cypress for E2E testing in favor of Puppeteer. Refactor all existing tests and integrations.
+* Remove deprecations slated for 2.5.0 removal.
+
+= 2.4.0 =
+
+* Show the full block inserter (+ button) to the left of empty paragraphs and the default appender. Quick block options (based on compound frequency and recency) remain on the right.
+* Insert default block as provisional — this reduces the proliferation of empty blocks as the editor removes these provisional blocks when unfocusing.
+* When pressing enter from post title, insert initial block as provisional.
+* Fade out the side inserter when typing on the newly created block.
+* Group common block definition on inserters. Use 'frecency' to sort items on top of it.
+* Improve the visual focus style for inbetween inserter.
+* Move isTyping behaviour to a separate component.
+* Inserting a block should only shift focus to a text field, otherwise focusing the block's "focus stop".
+* Example: Inserting an image should focus the top-level placeholder.
+* Pressing backspace or enter from the block's focus stop should respectively delete or insert a subsequent paragraph block.
+* Example: Pressing enter or delete on an image placeholder.
+* Pressing down arrow from a non-text-field should proceed with a tab transition as expected.
+* Multi-selection at the last text field in a block now accounts for non-contenteditable text fields.
+* Better internal identification of text fields for writing flow transitions. Previously, if a block contained a checkbox, radio, or other non-text input tags, they would be erroneously included in the writing flow sequence.
+* Inserting paragraph block (quote, etc; those with text fields) via autocomplete should move focus to the cursor.
+* Shift-arrow from a text field engages multi-selection, but not if there are other text fields in the intended direction in the same block.
+* Cancel isTyping state when focusing non text field.
+* Improve reliability of the block click-to-clear behavior.
+* When clicking below the editor move focus to last text field — this includes creating a new provisional block if last block is not text. This is equivalent to the default block appender spanning the entire viewport height of the editable canvas.
+* Introduce same undo buffering for general text to the post title (and other post properties).
+* Allow breaking out of List block upon Enter on last empty line.
+* Address conflicts between WritingFlow's selection transitioning and nested blocks by moving selection to the block's focus handler.
+* Improve reusable block creation flow by focusing the title field and allowing the user to name their block immediately.
+* Avoid calling callbacks on DropZone component if a file is dropped on another dropzone.
+* Improve settings UI on mobile devices.
+* Allow text to wrap within Button block.
+* Restrict Popover focusOnMount to keyboard interaction. This seeks to improve the experience of interacting with popovers and popover menus based on usability and accessibility concerns.
+* Optimize the behavior of subscribe to avoid calling a listener except in the case that state has in-fact changed.
+* Move the behaviors to transition focus to a newly selected block from the WritingFlow component to the BlockListBlock component.
+* Extract scroll preservation from ﻿BlockList as non-visual component
+* Add Upload button to audio and video blocks.
+* Refactor image uploads and added auto-filled captions using the image metadata.
+* Limit CSS rules for lists to the visual editor area.
+* Add aria-label to the post title.
+* Add new distinctive icon for Cover Image block.
+* Refactor PostTitle for easier select, deselect.
+* Use ifViewportMatches HoC to render BlockMobileToolbar as appropriate.
+* Introduce a new reusable Disabled component which intends to manage all field disabling automatically.
+* Expand editor canvas as flex region improving deselect behaviour.
+* Bump minimum font-size to 13px.
+* Allow emojis to be displayed in permalink visual component.
+* Respect HTML when readding paragraph-tags.
+* Allow undefined return from withSelect mapSelectToProps.
+* Update datepicker styling to inherit font-family/colour scheme.
+* Move QueryControls and expose them for general use under components module.
+* Address design issues with block dialog warnings on blocks that are too tall.
+* Preserve "More" order during block conversion.
+* Add capabilities handling for reusable blocks mapping to default roles.
+* Add a "Write your story" filter.
+* Return focus from Toolbar to selection when escape is pressed.
+* Improve keyboard interaction on inserter tab panels.
+* Simplify state management for the sidebar to make it easier to maintain.
+* Update cover image markup and CSS.
+* Fix sent parameter in onChange function of CheckboxControl.
+* Fix errors in some localized strings.
+* Fix problem with arrow navigation within Block Menu buttons.
+* Fix issue with demo page being marked immediately as unsaved (and the subsequent autosave).
+* Fix issue with a Reusable Blocks being keyboard navigable even when it is not supposed to be edited.
+* Fix focusable matching elements with "contenteditable=false".
+* Fix issue with empty paragraphs appearing after images when the images are inside an anchor.
+* Fix issue when a block cannot be removed after being transformed into another block type.
+* Fix issue with updating the author on published posts.
+* Fix edgecases in Windows high contrast mode.
+* Fix regression with inserter tabs colors.
+* Fix handling of HTML captions on gallery and image.
+* Fix heading subscript regression.
+* Resolve a performance regression caused by a bailout condition in our chosen shallow-equality library.
+* Handle calculateFrequency﻿ edge case on upgrading.
+* Use lodash includes in NavigableMenu to address IE11 issue.
+* Refer to reusable blocks as 'Shared Blocks'.
+* Add domain argument to localization functions. Allow setting locale data by domain.
+* Update localization functions to absorb errors from Jed.
+* Make UrlInput a controlled component.
+* Decode HTML entities in placeholders.
+* Only allow whitespace around URL when attempting to transform pasted Embeds.
+* Make preferences reducer deterministic.
+* Remove max-width for meta boxes area inputs.
+* Default to content-box box-sizing for the metabox area.
+* Adjust inside padding of meta boxes to better accommodate plugins.
+* Remove !important clauses from button styles.
+* Keep update button enabled when there are metaboxes present.
+* Clarify some inner workings of Block API functionality with comments.
+* Rewrite data document as a walkthrough of wordpress/data.
+* Revert the eslint --fix Git precommit hook.
+* Extract shared eslint config.
+* Add tests for the BlockSwitcher component.
+* Add test cases for REQUEST_POST_UPDATE_FAILURE effect.
+* Fail the build via ESLint error when deprecations marked for removal in a given version change are not removed.
+* Update redux-optmist to 1.0.0.
+* Update package-lock.json.
+* Remove Deprecated Features planned for this release and start documenting them in a deprecated document.
+
+= 2.3.0 =
+
+* Continue editing flow iterations by adding a line between blocks to insert new content — it also works within nested groups.
+* Add support for nested templates.
+* Allow duplicating a block through a menu button.
+* Automatically set a matching block as the default when a post format is set and the post is empty. This continues the path of matching blocks with post formats.
+* Add CodeMirror (core library) to the HTML block for syntax highlighting.
+* Simplify design presentation of editor header area for better consistency. (Add label for "Preview" action.)
+* Introduce new API for allowing plugins to register sidebars. ⭐  It allows plugins to further extend Gutenberg natively with non-content functionality. Note: the public facing functions are marked as experimental as they are being iterated in the context of the major extensibility work going on outside of blocks.
+* Improve the "invalid block" dialog by reducing the options and adding a new convert to blocks feature as we have solidified the transformations.
+* Allow adding images to a gallery without going through the media library.
+* Show the block appender even if the last block is non empty paragraph.
+* Show the side inserter on empty paragraphs within nested blocks.
+* Add a script that creates a PHP file based on a POT to make the plugin translatable.
+* Refactor float alignment to avoid margin calculations and simplify rendering.
+* Support registering and invoking actions in the data module.
+* Add hook to validate useOnce blocks.
+* Add viewport module. (Showing explorations with data module.)
+* Provide a fix for apiRequest in sites configured to use plain permalinks. (Reported several times!)
+* Remove specific grammar support for more tag as we consolidate the syntax and reduce weight.
+* Move filter for registering block types before validation happens.
+* Allow removing the selected image in a gallery block using backspace/delete keys.
+* Make saved blocks preview available to keyboard users.
+* Refactor reducer enhancers as higher-order reducer creators.
+* Refactor query HOC usage with withSelect.
+* Refactor API calls in Gutenberg to always use wp.apiRequest.
+* Register core blocks on init hook.
+* Removed DefaultBlockAppender when a template Lock exits.
+* Reduce and simplify float code.
+* Refactor and cleanup for the Ellipsis and More Menu components.
+* Add focus styles for Windows High Contrast mode.
+* Move meta boxes out of the generic editor module.
+* Make the "more" tag visible in the Classic block.
+* Expose ImagePlaceholder component in wp.blocks.
+* Rename TermTreeSelect to TreeSelect and move it to components.
+* Reuse isHorizontalEdge for RichText component and remove duplication.
+* Improve CSS for gallery caption and avoid UI shifts.
+* Use TreeSelect in HierarchicalTermSelector.
+* Flatten components modes directory organization.
+* Mutate editor store reference in middlewares application.
+* Consider term names as case insensitive.
+* Resolve an issue where removing a block which had contained inner blocks would not clear those inner blocks from state.
+* Make sure block usage is incremented (for calculating frequency and recency) when adding blocks with the side inserter.
+* Hide non editor specific notices, pending further improvements.
+* Update shortcode block icon.
+* Disable post format input if the theme does not support post formats.
+* Remove margin from initial insertion point and fix misalignment.
+* Polish header for mobile and accommodate other more languages.
+* Show taxonomies in the document inspector separately, uncoupling Categories & Tags.
+* Improve handling of block toolbar on mobile.
+* Fix issue with gallery images not cropping within link wrappers.
+* Fix bug in paragraph blocks affecting input behaviour when block is positioned on left or right.
+* Fix minor inconsistency with block margins and the default appender.
+* Fix description typo in freeform block.
+* Fix issue with focus transfering between citation and content.
+* Fix issue with floated block toolbar on adjacent floats.
+* Fix duplicate upload of media on drag.
+* Fix issue that prevented adding new rows or columns in Table block.
+* Fix issues with z-index and the sidebar.
+* Fix accessibility issues with mover icons.
+* Fix issue with default block replace resulting in incorrect order.
+* Fix sidebar tab padding.
+* Fix certain conflicts with markdown plugins.
+* Fix IconButton indent regression.
+* Fix issue with self embedding WP posts and the processing of the embed markup.
+* Fix extraction of _nx translation function.
+* Fix wp.data.query backwards compatibility with props.
+* Fix problem with delete key in empty contentEditables.
+* Resolve an issue with the data module's unsubscribe behavior which can result in a listener callback being invoked even after its been unsubscribed.
+* Remove the api-request JavaScript shim which had existed while WordPress 4.9 was in pre-release.
+* Remove explicit handling of "bottom reached" within writing flow as redundant.
+* Remove invalid reference to WeakMap polyfill.
+* Remove unused wpautop fixture files.
+* Remove non-functional custom taxonomies meta boxes.
+* Remove is- prefix from embed alignment class.
+* Switch get_locale() to get_user_locale().
+* Remove unnecessary $current_screen code.
+* Reduce duplication in 'No saved blocks' and 'No blocks found' component messages.
+* Include string extraction in production build.
+* Add deprecation helper functions for consistent messaging.
+* Improve string cast render test.
+* Add Gutenberg svg to docs.
+* Add documentation describing block transforms.
+* Add documentation for nested template definitions.
+* Add documentation for registering sidebar APIs. Move them to extensibility docs.
+* Update WordPress packages to the latest versions.
+
+= 2.2.0 =
+
+* Block Nesting is live! It comes with an experimental Columns block. (Note: converting a nested block into a reusable block is disabled on this first version.) Furthermore, this is not a specific implementation for columns alone — any block author can take advantage of defining nested areas.
+* Refined block insertion experience:
+* Introduce block shortcuts on every empty paragraph block. This also temporarily disables the sibling inserter as we work on refining this interaction.
+* Add trailing text area at the bottom of a post to continue writing.
+* Preview saved blocks while hovering on the inserter. Allows users to quickly see what they are inserting before inserting.
+* Enable triggering onChange events within RichText component on every keystroke. This was an enforced limitation that prevented saved post checks from being faithful.
+* Rework undo levels to use history "buffer" and leverage the mechanism to aid in continuous syncing of RichText history records.
+* Collapse the publish sidebar when making edits to a published post automatically.
+* Improve writing flow by triggering isTyping mode as soon as the user clicks on the default text appender.
+* Hide hover effects when typing.
+* Add a confirmation message before reverting a published post to draft.
+* When using the inserter, replace the selected block if it's empty.
+* Display reusable blocks in the "recent blocks" tab.
+* Make sure blue line indicators appear consistently when using dropzones.
+* Ensure that hitting enter at the end of a paragraph creates an empty paragraph when using RichText.
+* Ensure the block settings menu and the block movers are shown when the default block is selected and user is not typing.
+* Deselect individual gallery images when clicking outside the block or selecting another image.
+* Add support for setting a page template.
+* Add support for individual image captions in galleries.
+* Add support for saving a post with Cmd/Ctrl+S shortcuts. This is possible after these RichText changes.
+* Support unwrapped paragraph text via native block deprecation mechanism. (Ensures paragraphs without p tags are correctly interpreted.) Also readdresses code that was applying autop selectively on the server for posts made with gutenberg as it is handled at the block level when needed.
+* Add raw handling (pasting mechanism) for iframes (e.g. Google Maps).
+* Allow WP to make images responsive via class.
+* Drop focus/setFocus props in favor of isSelected prop.
+* New PlainText component for raw content that is styled as editable text. Renamed Editable to RichText for extra clarity and separation.
+* Add RawHTML component, drop support for HTML string block save.
+* Absorb multiple-image uploads in generic image placeholder component and reuse it for galleries.
+* Refactor Default Colors and the ColorPalette component. Moves the default colors to the frontend making the Editor script more reusable without the need of the server-side bootstraping.
+* Reimplement block alignment as a common extension.
+* Use block API functions in reusable block effects.
+* Check for duplication in addGeneratedClassName.
+* Assign default for all allowed blockTypes.
+* Update ToggleControl to pass boolean onChange.
+* Add withSafeTimeout higher-order component.
+* Expose getEditedPostAttribute selector.
+* Move selected block focus to BlockListBlock.
+* Allow themes to disable custom color functionality across blocks.
+* Added slug selector to data modules collection.
+* Defer registration of all core blocks until editor loads. Generally useful for extensibility hooks.
+* Add a subscribe function to the editor data module. Also, separate reducers into multiple stores to avoid unallowed access to the actions.
+* Support multiple stores in data module for the redux dev tools.
+* Expose registered selectors as functions.
+* Remove Popover isOpen prop, render by presence.
+* Fix issue with store persistence and switching to fixed toolbar.
+* Fix issue with formatting toolbar hover.
+* Fix block menu render when multi-selecting.
+* Fix TinyMCE custom buttons width in Classic block.
+* Fix sidebar tab admin theme regression.
+* Fix center alignment on resized images.
+* Fix some float issues.
+* Fix type error when merging blocks.
+* Fix regression when converting gallery from shortcode.
+* Fix unset variable in meta-boxes functions.
+* Fix code error in blocks-control.md.
+* Fix loss of focus when navigating from multi-selection.
+* Fix scrollbars on blank preview loading screen.
+* Fix broken nested lists and Evernote test in pasting functionality.
+* Fix lingering dropzone placeholder at the end of the editor.
+* Fix Button block line break presentation.
+* Fix lingering visual editor classes.
+* Fix codepen embeds width.
+* Fix merging blocks after nested blocks refactoring.
+* Fix Cypress path checks to allow sub-directory.
+* Fix error when pasting image inside caption.
+* Fix some issues when pasting from Word.
+* Fix bug when pasting content with custom styles in a paragraph block.
+* Fix image caption select behaviour.
+* Fix broken nested content caused by overly aggressive cache.
+* Fix issue with comments and pingbacks being set to off on new posts.
+* Fix regression with RichText placeholder whitespace.
+* Fix incorrect directory to load text domain.
+* Fix issue with quote to heading transformation.
+* Fix focus transfer between citation and content.
+* Fix gallery link attribute selector.
+* Attempt to correct Slack's Markdown code block variant.
+* Disable customClassName support on Classic block.
+* Avoid autofocus behavior for blocks without focusable elements.
+* Ignore focus if explicitOriginalTarget is not node (Firefox issue).
+* Extract "edit-post" to its own module — this is preparation work for the eventual template editor in v2 onwards.
+* Remove redundant handling of inserter position, simplifying the implementation for nesting.
+* Prioritize specific block handling over generic shortcode catch-all transform.
+* Avoid running a full-parse when rendering a post, instead only intercepting dynamic blocks to handle their callbacks.
+* Ensure string return value from render_callback.
+* Avoid parameters in memoized selectors getDependants.
+* Guard against falsey block container in WritingFlow.
+* Refactor BlockList to use minimal block UIDs array.
+* Pass selection start as UID in BlockList to prevent unnecessary rerenders.
+* Refactor TableOfContents panel to separate component for performance improvements.
+* Restore new post setup as non-dirtying change. This resolves an issue where saving a new post which has an empty title will set the title as "Auto Draft".
+* Center spinner when images are loading in the gallery block.
+* Use isTypingInBlock to avoid unnecessary block rerenders.
+* Add the i18n messages to the built plugin.
+* General design improvements to the full-post code editor. Also removes the dummy quicktag buttons that were non-functional.
+* Only start multi selection from inside the content.
+* Cache columns layouts configurations.
+* General polish to the Classic block and some quote block style errors.
+* Remove wrapper from image raw transform and added tests.
+* Make sure reusable blocks models exist before initializing.
+* Persist withFocusOutside event for async usage.
+* Pass selected block UID as string on WritingFlow.
+* Add label to range control.
+* Remove throttling inputs on RichText.
+* Replace global hover state with local component state. This reduces excesive dispatching of mouse events.
+* Simplify Editor State initialization using a single action to fix undo/redo initialization.
+* Access state paths directly in selector dependants for getBlock.
+* Refactor insertion point to include rootUID and layout.
+* Set new post status to draft in initialization.
+* Strip comment demarcations in content filtering for the front-end after refactoring work.
+* Improve presentation of List block.
+* Optimize getMultiSelectedBlocks by returning shared array reference in empty multi-selection.
+* Increase maximum number of recent blocks to nine in order to accommodate the current design.
+* Avoid cases of rerendering when the previous or next block updates.
+* Restore missing selectionStart props in BlockList.
+* Improve edit and insert link label display.
+* Extract copy and scroll-into-view logic to separate non-visual components in BlockList.
+* Make sure that styles do not contain duplicates in development mode.
+* Use trivial block count check to determine emptiness.
+* Use proper labels provided by the rest API on taxonomies.
+* Use menu order to order pages in the parent page dropdown.
+* Persist link attribute to fix invalid galleries.
+* Update the Dashicons component with new icons.
+* Use correct label on Featured Image Panel.
+* Small improvement to the meta-box partial page file.
+* Delete unused global import in gutenberg_menu function.
+* Improve serialize persistence action name.
+* Improve logic around replacing the editor in PHP.
+* Improve consistency of tooltips text.
+* Improve sandbox component readme.
+* Improve gutenberg_intercept_* functions.
+* Improve "Add New" button logic.
+* Revert updates giving Meta Boxes' #poststuff div a broader scope.
+* Simplify "New Post" button logic.
+* Simplify scripts registration.
+* Replace focus with isSelected verification on hooks.
+* Automate memoized selector setup clear.
+* Consolidate module build JS, CSS, map inclusion.
+* Remove unused code after WP 4.9.
+* Update deprecated BlockDescription in Subhead.
+* Add doc explaining the deprecated block API. (Handbook.)
+* Add doc for Editable component (now RichText).
+* Document block validation, clarify extensibility validation.
+* JSDoc: prefer @return over @retuns.
+* Integrate dependencies from WordPress packages. Brings wp-scriptsinto gutenberg.
+* Move components in wp.blocks.InspectorControls to wp.components.
+* Add lint:fix ESLint "fix" npm script.
+* Add an eslint --fix Git precommit hook.
+* Add reusable block render tests.
+* Add tests for ContrastChecker component.
+* Add more details about unit testing JavaScript code.
+* Add mention to create-guten-block repo.
+* Add partial test coverage to RichText component.
+* Add first version of repository management doc.
+* Assign preferred JSDoc tags and types.
+* Assign edit-post global as wp.editPost.
+* Assign explicit user for Docker WordPress install in tests.
+* Mention installing docker-compose in local dev setup.
+* Update refx to version 3.x.
+* Update memize and rememo dependencies.
+* Code is Poetry footer to main readme.
+
+= 2.1.0 =
+
+* Iterate on the design of up/down arrows and how focus is managed. This seeks to further reduce the visual and cognitive weight of the up/down movers.
+* Show immediate visual feedback when dragging and dropping images into the editor. (Expands on the previous release work.)
+* Expose state through data module using selectors. This is an important piece of the extensibility puzzle.
+* New button outline and focus styles.
+* Show original block icon after converting to reusable block. Also hides the generic reusable block from inserters. This moves data logic out of the inserter.
+* Introduce a migration function for block versioning.
+* Add HTML handler to dropzone. Allows drag and dropping images from other web pages directly.
+* Trigger typing mode when ENTER or BACKSPACE are pressed. This improves the writing flow but engaging the UI-less mode more frequently.
+* Added ability to align the text content of a cover image to the right, left, or center of the image.
+* Refactor CopyContentButton as a core extension to illustrate how to add functionality to the editor outside of blocks.
+* Allow collapsing/sorting meta-boxes panels.
+* Remove dirty-checking from meta-boxes state, fixes issues with default values and updating certain text fields.
+* Defer registration of all core blocks until editor loads. Improves ability to hook into registerBlockType.
+* Only trigger select block action when block is unselected.
+* Try new markup for Galleries using lists.
+* Try new subheading editorial block.
+* Reduce sibling inserter initial height.
+* Force an update when a new filter is added or removed while using withFilters higher-order component. This improves the rendering flow of filters.
+* Refactor the MediaUploadButton to be agnostic to its rendered UI.
+* Change "size" label to "level" in Heading block settings.
+* Remove breaking spaces logic on List block.
+* Update progress button color state based on theme used.
+* Update Video block description.
+* Refactor the multi-selection behavior to dispatch the multi-selection start action only after the cursor begins to move after a mousedown event.
+* Avoid persisting mobile and publish sidebars.
+* Move drag handling to instance-bound handler.
+* Remove "Open in new window" link option.
+* Use username slug instead of name and remove ephemeral link from it.
+* Ensure isLoading set to false after request error.
+* Allow copying individual text from a block that is not purely text without copying the whole block.
+* Match consistency of tooltip text with Classic Editor.
+* Fix issue with Lists having additional lines when used in a reusable block.
+* Fix errors when adding duplicate tags.
+* Fix inconsistency with applyOrUnset().
+* Fix incorrect display when loading a saved block with no content.
+* Fix issue where black rectangle would briefly blink on new paragraphs.
+* Fix cursor jumps in link-editing dialog.
+* Fix post content validation.
+* Fix scrolling issues around nav menus.
+* Remove Vine embed support as it's no longer supported.
+* Ensure editor still exists after timeout.
+* Add regression check for block edit interface using snapshots.
+* Add missing alt attributes to image (and gallery) blocks when alt returns an empty value.
+* Better build tools with Docker.
+* Register Gutenberg scripts & styles before enqueuing.
+* Force wp-api.js to use HTTP/1.0 for better compatibility.
+* Avoid the deprecated (from 5.0 to 5.2) is_a() function.
+* Remove unused dependency.
+* Update contributing instructions with steps.
+* Consistency cleanup in doc return statements.
+* Include how to assign a template to a default Post Type in the documentation. Also add more context to the code.
+* Improve incremental development build performance by only minimizing -rtl files for production builds.
+* More JSDoc fixes.
+* Remove warning from plugin header.
+* Add new page explaining how to create a block using WP-CLI.
+* Add security reporting instructions.
+* Improve useOnce documentation.
+* Bump copyright year to 2018 in license.md.
+* Disable Travis branch builds except for master.
+
+= 2.0.0 =
+
+* Replace publish dropdown menu with a sidebar panel.
+* Expand latest post blocks with more querying options — order by and category.
+* Allow dragging multiple images to create a gallery.
+* Improve markdown pasting (allows lists to be interpreted).
+* Allow pasting copied images directly.
+* Pasting within lists and headings.
+* Improve handling of inline spans.
+* Allow copying a single block.
+* Make sure inline pasting mechanism does not take place if pasting shortcodes.
+* Preserve alignment classes during raw transformations (like pasting an old WordPress post).
+* Support shortcode synonyms.
+* Allow continued writing when pressing down arrow at the end of a post.
+* Mobile design: move block controls to the bottom of a block.
+* Allow deleting reusable blocks globally.
+* Display description and type on the sidebar. (Also replace BlockDescription component with a property.)
+* New table of contents and document counts design.
+* Add button to copy the full document quickly.
+* Expand inserter to three columns and a wider container.
+* Allow using down-arrow keys directly to navigate when searching a block in the inserter.
+* Deselect images in Gallery block when losing focus.
+* Include post title in document outline feature.
+* Rework display of notices and address various issues with overlaps.
+* Added keyboard shortcut to toggle editor mode. Also displays the relevant keyboard combination next to the menu item.
+* Improve deleting empty paragraphs when backspacing into a block that has no merge function (example, deleting a paragraph after an image).
+* Improve the way scroll-position is updated when moving a block.
+* Show block transformations in ellipsis menu.
+* Add drag and drop support for cover image.
+* Allow transforming operations between Heading and Cover Image blocks.
+* Add focus outline for blocks that don't have focusable fields.
+* Allow both navigation orientations in NavigableContainer.
+* Improve the behavior of focusing embed blocks.
+* Unify UI of audio and video blocks.
+* Show message on the inserter when no blocks are found.
+* Show message when no saved blocks are available.
+* Do not show the publish panel when updating / scheduling / submitting a post.
+* Update quote style in front-end.
+* Convert text columns to a div using grid layout.
+* Update button block CSS and add class to link.
+* Allow text in Button block to wrap.
+* Prevent useOnce blocks from being inserted using the convenient blocks shortcut menu.
+* Show correct symbol (⌘ or Ctrl) depending on system context.
+* Rename "insert" to "add" in the UI.
+* Clear block selection when opening sibling or bottom inserter.
+* Always show the insertion point when the inserter is opened.
+* Increase padding on "more options" block toggle.
+* Rename "Classic Text" to "Classic".
+* Improve display of dotted outline around reusable blocks.
+* Updated messages around reusable blocks interactions.
+* Align both the quote and the citation in the visual editor.
+* Exit edit mode when unfocusing a reusable block.
+* Set floated image width (when unresized) in % value.
+* Add withState higher-order component.
+* Initial introduction of wp.data module.
+* Restrict the state access to the module registering the reducer only.
+* Refactor PostSchedule to make Calendar and Clock available as reusable components.
+* Allow overwriting colors (defaults and theme provided) when consuming ColorPalette component.
+* Switch orientation of popover component only if there is more space for the new position.
+* New ImagePlaceholder reusable component that handles upload buttons and draggable areas for the block author.
+* Add speak message when a category is added.
+* Announce notices to assertive technologies with speak.
+* Add aria-labels to Code and HTML blocks.
+* Warn if multiple h1 headings are being used.
+* Add speak message and make "block settings" button label dynamic.
+* Make excerpt functionality more accessible.
+* Add various headings around editor areas for screen-readers.
+* Improve accessibility of menu items in the main ellipsis menu.
+* Add missing tooltips to icon buttons.
+* Render toolbar always by the block on mobile.
+* Improve performance of responsive calculations using matchMedia.
+* Avoid shifts around toolbar and scrolling issues on mobile.
+* Improve how the fixed-to-block toolbar looks on mobile. Change how the fixed position toolbars behave, making them sticky.
+* Prevent Mobile Safari from zooming the entire page when you open the inserter.
+* Initial explorations to migrate to server-registered blocks as part of raising awareness of available blocks.
+* Move supportHTML property into the general "support" object.
+* Replace getLatestPosts usage with withAPIData HOC.
+* Convert all filters for components to behave like HOCs (withFilters).
+* Replace flowRight usage with compose for HOCs.
+* Apply filters without function wrappers.
+* Improve Tags/Categories response size by limiting the requested fields.
+* Limit requested fields in category feature of "latest posts".
+* Request only required post fields in latest posts.
+* Replace getCategories usage with withAPIData component.
+* Don't show fields that are not used in media modal when adding a featured image.
+* Polish inserter tabs so the focus style isn't clipped.
+* Make inspector controls available when categories are loading.
+* Improve overlay over meta-boxes during save operations.
+* Hide excerpts panel if not supported by the CPT.
+* Hide Taxonomies panel if no taxonomy is available for the current CPT.
+* Hide several other panels when the CPT doesn't support them.
+* Use _.includes to find available taxonomies. Mitigates non-schema-conforming taxonomy registrations.
+* Defer applying filters for component until it is about to be mounted.
+* Prevent "Add New" dropdown from overriding other plugin functionality.
+* Improve paragraph block description.
+* Refactor to simplify block toolbar rendering.
+* Add missing aligment classes to cover image.
+* Add parent page dropdown to page attributes panel.
+* Allow pressing ENTER to change Reusable Block name.
+* Disable HTML mode for reusable blocks.
+* Add support for the "advanced" meta-box location.
+* Make sure super admins can publish in any site of the network.
+* Rename theme support for wide images to align-wide.
+* Move selectors and actions files to the store folder.
+* Center arrows of popovers relative to their parent.
+* Use fainter disabled state.
+* Add breakpoint grid to latest posts block and update color of date.
+* Move logic for auto-generating the block class name to BlockEdit.
+* Respect the "enter_title_here" hook.
+* Prevent meta-box hooks from running multiple times.
+* Don't set font-family on pullquotes.
+* Remove superfluous parentheses from include statements.
+* Remove redundant CSS property updates.
+* Use "columns-x" class only for grid layout in latest posts.
+* Use flatMap for mapping toolbar controls for a small performance gain.
+* Introduce jest matchers for console object.
+* Updated various npm packages; update Jest. Update node-sass. Update WordPress packages.
+* Switch TinyMCE to unpkg.
+* Reorganize handbook docs navigation.
+* Added FAQ section for meta-boxes compatibility.
+* Added initial "templates" document.
+* Add documentation about dynamic blocks.
+* Updated "outreach" docs.
+* Improve block-controls document.
+* Display a hint that files need to be built.
+* Add WordPress JSDoc ESLint configuration.
+* Update licenses in package.json & composer.json to adhere to SPDX v3.0 specification.
+* Add tests to cover REQUEST_POST_UPDATE_SUCCESS effect.
+* Add tests for color palette component.
+* Add tests for Editable.getSettings and adaptFormatter.
+* Use newly published jest-console package in test setup.
+* Update info about test fixtures generation.
+* Also style footer in quote blocks to ensure backwards compatibility.
+* Add a PHPUnit Docker Container.
+* Fix wrong "return to editor" link when comparing revisions.
+* Fix error when pressing enter from a heading block.
+* Fix error with merging lists into paragraphs.
+* Fix revisions button target area.
+* Remove duplicated styles.
+* Fix z-index rebase issues.
+* Fix tag name warning ordering in validation.
+* Fix text encoding of titles in url-input.
+* Fix endless loop in reusable blocks code.
+* Fix edit button in Audio block using invalid buttonProps attribute.
+* Fix block creation with falsey default attribute.
+* Fix radio control checked property.
+* Fix styling issues of blocks when they are used as part of a reusable block.
+* Fix list wrapping issues.
+* Fix problem when converting shortcodes due to sorting.
+* Fix issue with time-picker not working.
+* Fix hide advanced settings interaction in block menu.
+* Fix issue with url input on images.
+* Fix style regression in textual placeholder on cover image.
+* Fix return type hint in gutenberg_get_rest_link().
+* Fix bug when changing number of Latests Posts rapidly was leading to some numbers being defunct.
+* Fix isInputField check and add tests.
+* Fix unsetting block alignment flagging block as invalid.
+* Fix CSS bleed from admin-specific gallery styles.
+* Fix image handlers at the top from being unclickable.
+* Fix unexpected keyboard navigations behaviour on some nodes.
+* Fix inserter position for floated blocks.
+* Fix bug on empty cover image placeholder used on a saved block.
+* Fix errors when adding duplicate categories.
+* Fix broken custom color bubble in ColorPalette.
+
+= 1.9.1 =
+
+* Fix error in Safari when loading Gutenberg with meta boxes present.
+* Fix error / incompatibility with Yoast SEO Premium terms display.
+* Resolve incorrect modal and tooltip layering.
+* Remove unintended commas from Page Options content.
+
+= 1.9.0 =
+
+* Introducing reusable global blocks. (Stored in a wp_blocks post type.)
+* Add ability to lock down the editor when using templates so edits can happen but blocks can't be removed, moved, nor added.
+* Handle and upgrade deprecated blocks. This allows to migrate attributes without invalidating blocks and an important part of the block API.
+* Drag and drop upload support to gallery block.
+* Extensibility:
+* Expose packages/hooks public API under wp.hooks.
+* Introduces withFilters higher-order component to make component filtering easier.
+* Introduces getWrapperDisplayName helper function to make debugging React tree easier.
+* Introduces compose function to unify composing higher-order components.
+* Exposes hook for Block component.
+* Updated demo post with a nicer presentation for people to test with.
+* Added automated RTL support.
+* Convert unknown shortcodes to Shortcode block when pasting.
+* Avoid splitting blocks during rich text pasting.
+* Disable block selection when resizing image.
+* Prefetch meta-boxes and don't reload them on save.
+* Support for all admin color schemes.
+* Close sidebar when resizing from non mobile breakpoints to mobile sizes.
+* Apply content autop disabling filter before do_blocks. Also fixes case where server-side rendered blocks produce extraneous whitespace in output.
+* Use cite element instead of footer for quote and pull-quote source markup.
+* Respect recency order when displaying Recent blocks.
+* Update the behavior of notices reducer to respect ID as a unique identifier, removing duplicate entries.
+* Improve quote to paragraph transformations. Fixes cases where quote would be split into two.
+* Use two flex rows instead of one wrapped row in Url modal for cleaner and more consistent display.
+* Avoid restricting endpoints to /wp/v2 in withApiData.
+* Remove duplicated and simplify inserter between blocks styles.
+* Remove unnecessary padding on top of editor when fixed toolbar is off.
+* Avoid intercepting rendering of removed meta boxes.
+* Replace redux-responsive with a simpler custom alternative, fixing a bug with IE11.
+* Fix issues with bullet-point positioning affecting block display.
+* Fix meta attributes selector not returning the correct value if edited.
+* Fix inconsistent animation on settings button.
+* Fix style issues on Custom HTML block's toolbar.
+* Fix broken styles in "edit as HTML" mode.
+* Fix image block description when no image is set.
+* Fix horizontal overflow for selects with long names in sidebar.
+* Fix case where link modal closes upon typing into UrlInput when toolbar is docked to the paragraph.
+* Fix webpack config issue on Node 6.
+* Fix issue with vertical arrow keys leaking to horizontal menu when toolbar is fixed to block.
+* Fix keyboard trap in the form token component and improve accessibility.
+* Fix React warning when saving reusable blocks.
+* Fix issue with horizontal arrow key closing link dialog in fixed toolbar mode.
+* Fix image resize handlers in RTL mode.
+* Prevent "Add New" dropdown from overriding other plugin functionality.
+* Split Sass variables file into multiple files.
+* Updated blue links for better contrast.
+* Resolve notice when template variable is not set.
+* Added unit tests for row panel, color panel (snapshot), and warning components.
+* Add unit tests for editor actions (with further cleanup).
+* Added snapshots tests for BlockControls.
+* Added documentation for Editable component.
+* Avoid caching vendor directory in Travis.
+* Add document on snapshot testing.
+* Add node and npm version check before build gets started.
+* Update cypress and use the newly introduced Cypress.platform functionality.
+* Improve composer.json setup.
+* Improve testing overview document.
+
+= 1.8.1 =
+
+* Add ability to switch published post back to draft.
+* Fix issue with when changing column count in "text columns" block.
+* Prioritize common items in the autocomplete inserter.
+* Avoid changing publish/update button label when saving draft.
+* Add bottom padding to the editor container to improve experience of writing long posts.
+* Adjust the Classic block toolbar so it's doesn't jump.
+* Colorize the little arrow on the left of the admin menu to white to match body content.
+* Abort focus update when editor is not yet initialized.
+* Update autocomplete suggestions colors to have a sufficient color contrast ratio.
+
+= 1.8.0 =
+
+* Introduce block-templates as a list of blocks specification. Allows a custom post type to define a pre-configured set of blocks to be render upon creation of a new item.
+* New tools menu design, preparing the way for more extensibility options.
+* Block API change: use simpler JS object notation for declaring attribute sources.
+* Add function to allow filtering allowed block types.
+* Show popovers full screen on mobile, improving several mobile interactions.
+* Began work on publishing flow improvements with an indication of publishing (or updating a published post) action by introducing a button state and label updates.
+* Made docked-toolbar the default after different rounds of feedback and testing. Both options are still present.
+* Provide mechanism for plugin authors to fallback to classic editor when registering meta-boxes. Also includes the ability to disable a specific meta-box in the context of Gutenberg alone.
+* Updated color pickers with color indications and collapsible panels.
+* Update icon and tooltip for table of contents menu.
+* Added contrast checker for paragraph color options.
+* Improve pasting plaintext and shortcode data.
+* Convert unknown shortcode into shortcode block when pasting.
+* Updated notices design and positioning.
+* Move the URL handler when pasting to the raw handler mechanism.
+* Define custom classNames support for blocks using the new extensibility hooks with opt-out behaviour.
+* Add reusable blocks state effects.
+* Remove sibling inserter from inside multi-selection blocks.
+* Image block alt text enhancements.
+* Increase minimum width and height of resized images.
+* Allow using escape key to deselect a multi-selection.
+* Preserve settings when rebooting from crash.
+* Improve structure of store persist mechanism.
+* Extract reusable BlockList component to allow nesting compositions.
+* Extract BlockToolbar, BlockMover, BlockSwitcher, PostTitle, WritingFlow, TableOfContents, Undo/Redo Buttons, MultiBlockSwitcher, PostPublishWithDropdown, KeyboardShortcuts, DocumentOutlineCheck, PostTrashCheck, Notices,  as reusable components.
+* Consolidate block naming requirements.
+* Avoid persisting sidebar state on mobile devices.
+* Ensure backwards compatibility to matchers syntax.
+* Show untitled posts as (no title) in url auto-complete.
+* Extract fixedToolbar as a prop of BlockList.
+* Restore insertion point blue line.
+* Display outline tree even if only one heading is used.
+* Allow media upload button to specify a custom title (and fix grammar issue).
+* Fix issue with block mover showing on top of url input.
+* Fix case where tooltips would get stuck on buttons.
+* Fix transformations between quote and list blocks.
+* Fix issue with converting empty classic text to multiple blocks.
+* Fix issue with audio block not updating the toolbar area.
+* Fix contrast issues in button block.
+* Fix change detection to maintain multiple instances of state.
+* Fix text columns focus style.
+* Fix embed category example in docs.
+* Fix button link modal not closing.
+* Fix styling issue with sibling inserter.
+* Fix alignment of block toolbar in wide and full-width.
+* Fix issue when inserting image with empty caption.
+* Fix issue with sibling inserter not appearing in IE11.
+* Fix issue when inserting pullquotes.
+* Fix horizontal scrollbar when floating images to the left.
+* Fix alignment issue with embed videos.
+* Drop withContext optional mapSettingsToProps and fix issue when inserting new image.
+* Require @wordpress import path for application entry points.
+* Resolve errors in IE11 when using the inserter.
+* Added tests for Notice and UrlInput components.
+* Added tests for DefaultBlockAppender.
+* Log debugging messages for invalid blocks.
+* Reduce build size significantly by fixing import statements.
+* Update re-resizeable dependency.
+* Initial document page for extensibility purposes.
+* Added documentation for Editable component.
+* Move all components related to the specific post-edit page into its own folder.
+* Introduce snapshots for testing.
+
+= 1.7.0 =
+
+* Add toggle to switch between top-level toolbar and toolbars attached to each block. We have gotten great feedback on the benefits of both approaches and want to expand testing of each.
+* Ability to transform multiple-selected blocks at once — multiple images into a gallery, multiple paragraphs into lists.
+* Add @-mention autocomplete for users in a site.
+* Add data layer for reusable blocks and wp_blocks post type name.
+* Allow pasting standalone images and uploading them (also supports pasting base64 encoded images).
+* Allow block nesting from a parser point of view. This is the foundation for handling nested blocks in the UI.
+* Full design update to focus styles around the UI.
+* Block Extensibility (Hooks): filters may inspect and mutate block settings before the block is registered using hooks available at wp.blocks.addFilter. Testing with internal functionality first.
+* Moved docs to https://wordpress.org/gutenberg/handbook/
+* Refactor "changed post" functionality into higher order component and fix issue with wrongly reporting unsaved changes.
+* Refactor meta-boxes to render inline, without iframes.
+* Disable auto-p for block based posts, solving various issues around conflicting paragraph structures, freeform content, and text blocks.
+* Placed "table of contents" button in the header area and disable when there are no blocks in the content.
+* Redesigned the button block with inline URL field.
+* Improve performance by refactoring block-multi-controls out of VisualEditorBlock.
+* Replace react-slot-fill with our own first-party implementation. Part one, and part two for better handling of event bubbling within portals.
+* Improve autocomplete behaviour by using focus outside utility. This solves an issue with selecting items on mobile.
+* Capture and recover from application errors, offering the option to copy the existing contents to the clipboard.
+* Expose editor reusable components. These will allow editor variations to be constructed with more ease.
+* Add polyfill for permalink_structure option to wp-json. (Corresponding trac ticket.) Several REST API compat issues are going to be addressed like this. This allows Gutenberg to implement permalink editing.
+* Unslash post content before parsing during save, fixing bugs with block attributes.
+* Keyboard navigation overhaul of the inserter with accessibility improvements (accessing tabs, etc).
+* Add paragraph count to table of contents element.
+* General Navigable family of components.
+* Add contrast checker message when color combinations are hard to read.
+* Add "no posts found" message to latest posts block.
+* Improve color highlight selection and browser consistency.
+* Add aria-expanded attribute to settings button.
+* Add loading message to preview window.
+* Extract PostFeaturedImage, PostLastRevision, PostComments, PostTaxonomies, PageAttributes, PostTextEditor, BlockInspector, into reusable modules.
+* Collapse advanced block controls by default.
+* Update max number of columns when removing an image from a gallery.
+* Prevent the post schedule component from having invalid dates.
+* Make sure the inspector for a gallery block is shown when it has just one image.
+* Accessibility improvements for inline autocomplete components.
+* Update caption color for contrast.
+* Update visual display of the "remove x" button on gallery-items.
+* Improve classic block toolbar display and behaviour.
+* Dismiss tooltip when clicking a button or when wrapper node becomes disabled.
+* Restore block movers on floated items.
+* Add spacing around date and label.
+* Adjust raw handler "mode" option for readability.
+* Improve e2e testing performance.
+* Add fixture for undelimited freeform block.
+* Hold jQuery ready only when there are metaboxes and ignore advanced ones.
+* Make sure image size values are integers.
+* Fix floated gallery styles in the front-end.
+* Fix issue with image block not loading properly.
+* Fix issue with missing function in IE11.
+* Fix transformation of empty images into gallery and back.
+* Fix overflow issues on mobile.
+* Fix accidental block hover on iOS.
+* Fix toolbar state issue with slot-fill utility.
+* Fix case of too many undo levels building up.
+* Fix stylesheet load ordering issue.
+* Prevent input events from URLInput from being captured by Editable.
+* Force onChange to be updated with TinyMCE content before merge.
+* Polish heading toolbar buttons.
+* Remove image resizing on mobile.
+* Remove findDOMNode usage from Autocomplete component.
+* Rename references of rawContent as innerHTML.
+* Add tests and handle empty fills in slot-fill.
+* Add tests for block mover.
+* Add multi-select e2e test and fix issue with escape key.
+* Bump node version to active LTS.
+* Update TinyMCE to 4.7.2, fixing several bugs like toolbar flickering, visible placeholders when there is text, navigation breaks when encountering format boundaries, typing in FF after starting a bullet-list.
+
+= 1.6.1 =
+
+* Handle pasting shortcodes and converting to blocks.
+* Show loading message when opening preview.
+* Fix inline pasting (auto-link feature).
+* Fix undoing multi-selection delete operation.
+* Remove focus state after a selection is finished during multi-select.
+* Remove the "command" shortcut to navigate to the editor toolbar.
+
+= 1.6.0 =
+
+* Move the block toolbar to the editor's top header. This experiment seeks to reduce the presence of UI obscuring content.
+* Alternate style for block boundaries and multi-selection. Also engages "edit" mode when using arrow keys (hides UI).
+* Complete rework of arrow keys navigation between blocks—faster, clearer, and respects caret position while traversing text blocks.
+* Added keyboard shortcuts to navigate regions.
+* Implement multi-selection mode using just arrow with shift keys and support horizontal arrows.
+* Suggest a post format for additional blocks (embeds, gallery, audio, video) and expand on the heuristics to include case of one format-block at the top plus a paragraph of text below as valid.
+* Allow converting a classic block (post) into several Gutenblocks.
+* Several performance improvements 🎉
+* * Avoid re-rendering all blocks on selection changes.
+* * Add memoization for multi-select selectors.
+* * Rework implementation of blockRef to avoid render cascade from block list.
+* * Use flatMap when allocating the block list for rendering.
+* * Reorganize logic to determine when a post can be saved to be less expensive.
+* Refactor handling of revisions to avoid loading them up-front, significantly reducing load time on long posts with many revisions.
+* Further memoization on selectors based on specific state keys.
+* Render meta-boxes as part of the main column, not as a collapsible box.
+* Improve handling of undo action stack by resetting only on setup. This makes undo a lot more usable in general.
+* Changes to block inserter design positioning tabs at the top. (1.5.1)
+* Remove multi-select buffer zone and throttle delay for a faster response.
+* API for handling custom formats/tokens in Editable.
+* Improve withApiData component to be able to serve cached data (if available) during an initial render.
+* Show block toolbar in HTML mode for mobile.
+* Update Shortcode block to use a textarea instead of single line input.
+* Increase width of invalid block message.
+* Avoid redirecting to Gutenberg when saving on classic editor. (1.5.2)
+* Don't show "edit as HTML" for the Code and Shortcode blocks.
+* Refactor notices state reducer as array optimizing performance.
+* Disable front-end styles for basic quote block.
+* Reorganize the meta-boxes components for code clarity.
+* Extract reusable PostSticky, PostFormat, PostPendingStatus, PostAuthor, PostTrash, PostExcerpt components.
+* Resolve issue with having to tab twice on the toolbar due to focusReturn utility interfering with button tooltips.
+* Reset min-width of Tooltip component.
+* Avoid function instantiation in render of WritingFlow component.
+* Add the gutenberg_can_edit_post_type filter for plugins to add or remove support for custom post types.
+* Update header toolbar keyboard navigation to include undo and redo buttons.
+* Don't show the classic editor dropdown on unsupported post types.
+* Drop resizable-box in favor of re-resizable to use in the image block resize handlers.
+* Correct placement of link-dialog after moving toolbar to the top.
+* Adjust revisions logic to link to latest entry.
+* Allow editable to accept aria attributes.
+* Add generic focus effect to popovers.
+* Remove unused focus prop from Button component.
+* Remove core namespace from demo content.
+* Enable iOS smooth scrolling within scroll containers.
+* Make sure link menu appears above sibling inserter.
+* Improve layout paneling for short-height viewports.
+* Fix problem with multi-select not working again after a group of blocks has been moved.
+* Fix problem with deleting a block in HTML mode.
+* Fix issue with keyboard navigation entering textareas (non contentEditable) and losing caret position.
+* Fix issue where clicking on an item within autocomplete would dismiss the popover and not select anything.
+* Fix visual issue with the document info popover. (1.5.2)
+* Fix bug with deleting featured image on a post.
+* Fix error with removing a block placeholder.
+* Fix problem with FF and meta-boxes.
+* Fix issue with Classic Text description showing all the time.
+* Fix issue with the color picker width.
+* Fix quick inserter display of custom block icons.
+* Fix missing node check when blurring a paragraph block.
+* Warn about misuses of z-index mappings.
+* Make use of the "build stages" feature in the travis config file.
+* Upgrade ESLint dependencies.
+* Move test configuration files to test/unit.
+* Add easy local environment setup and Cypress e2e tests.
+
+= 1.5.2 =
+
+* Add the `gutenberg_can_edit_post_type` filter for plugins to add or remove support for custom post types.
+* Fix Classic Editor redirecting to Gutenberg when saving a post.
+* Fix Classic Editor dropdown showing on post types that don't support Gutenberg.
+* Fix Classic Editor dropdown hiding behind notices.
+* Fix an issue with collapsing popover content.
+
+= 1.5.1 =
+
+* New design for the inserter with tabs at the top and more space for text.
+* Fix problem with Firefox and the meta-boxes resize script.
+* Fix issue with Classic Text description showing without focus.
+
+= 1.5.0 =
+
+* Set Gutenberg as the default editor (still allow creating new posts in Classic Editor).
+* Add metabox support—this is an initial pass at supporting existing meta-boxes without intervention.
+* Display inserter button between blocks.
+* Improve block navigation performance.
+* Hide core namespace in comment serialization. wp:core/gallery becomes wp:gallery.
+* Implement a dropdown for Publish flow.
+* Allow multiselect to work on shift-click.
+* Insert new block from title on enter.
+* Use a dropdown for the block menu (settings, delete, edit as HTML).
+* Add expandable panel for post visibility.
+* Add expandable panel for post scheduling.
+* Implement more inline formatting boundaries.
+* Better clearing of block selection.
+* Show placeholder hint for slash autocomplete on new text blocks.
+* Remove multi-selection header in favor of default block controls (mover and menu).
+* Allow blocks to disable HTML edit mode.
+* Adjust transition and delay of inserter between blocks.
+* Added text color option for button block.
+* Hide extended settings if sidebar is closed.
+* New embed icons.
+* Move the store initialization to a dedicated component.
+* Improve scroll position of scrollable elements.
+* Drop undefined blocks from recent blocks.
+* Update HTML block description.
+* Update embed block description.
+* Add description for classic block.
+* PHPCS-specific improvements.
+* Add a default block icon.
+* Adjust line height of classic text to match paragraph blocks.
+* Adjust filter order in classic block so plugins that extend it can work properly.
+* Set textarea value as prop and not children.
+* Fix mobile issues with block setting menu.
+* Fix undefined colors warning.
+* Fix broken upload button on image placeholder.
+* Fix post edit URL when saving a post/page/CPT.
+* Fix conflict with new TinyMCE version and heading blocks.
+* Tweak block sibling element for better target surface.
+* Avoid loading Gutenberg assets on non-Gutenberg pages.
+* Adjust Jest configuration.
+* Document supportAnchor in block API.
+* Updated TinyMCE to latest.
+* Document block name usage in serialization and add example of serialized block.
+* Updated FAQ section.
+* Upgrade React and Enzyme dependencies.
+
+= 1.4.0 =
+
+* Redesigned the header area of the editor for clarity—groups content actions in the left, and post action in the right.
+* Initial REST API infrastructure for reusable global blocks.
+* Group block settings (delete, inspector, edit HTML) on an ellipsis button.
+* Added new reusable Dropdown component.
+* Show frequently used blocks in the inserter shortcuts (at the bottom of the post).
+* Offer option for the button block to clear content.
+* Refactor block toolbar component in preparation for some iterations (docked toolbar, for example).
+* Allow partial URLs in link input.
+* Avoid using state for tracking arrow key navigation in WritingFlow to prevent re-renders.
+* Improve mobile header after design cleanup.
+* Add focusReturn for Dropdown component.
+* Updated Audio block markup to use figure element.
+* Removed transition on multi-select affecting the perception of speed of the interaction.
+* Show Gallery block description even if there are no images.
+* Persist custom class names.
+* Merge initialization actions into a single action.
+* Fix scroll position when reordering blocks.
+* Fix case where the responsive treatment of the header area was hiding valuable actions.
+* Fix focus styles on the inserter.
+* Fix submenu visibility issue for certain users.
+* Cleanup no longer used code.
+* Document useOnce block API feature.
+
+= 1.3.0 =
+
+* Add an opacity range slider to the cover image block.
+* Offer the option to convert a single block to an HTML block when conflicting content is detected.
+* Persist recently used blocks through sessions.
+* Added support for pasting plain text markdown content and converting to blocks.
+* The block inspector groups features and settings in expandable panels.
+* Accessibility improvements to the color palette component.
+* Added a “feedback” link in the Gutenberg side menu.
+* Use expandable panels for advanced block features (class name and anchor).
+* Removed touch listeners from multi select.
+* Added block descriptions to blocks that didn’t have them.
+* Allow stored values to be updated with new defaults.
+* Refactor image block to use withApiData and fix issues with .tiff images.
+* Clean up non inline elements when pasting inline content.
+* Remove unused code in BlockList component.
+* Added “transform into” text to block switcher.
+* Fixed sidebar overflow causing extra scrollbars.
+* Fixed multi-select inside new scroll container.
+* Fixed image block error with .tiff image.
+* Fixed the content overflowing outside the verse block container.
+* Fixed issues with sticky quick toolbar position.
+* Fixed hitting enter when a block is selected creating a default block after selected block.
+* Fixed teaser markup in demo content.
+* Clean working directory before packaging plugin.
+* Updated Webpack dependencies.
+* Updated Jest and React.
+
+= 1.2.1 =
+
+* Fix issue where invalid block resolution options were not clickable.
+
+= 1.2.0 =
+
+* Resolve block conflicts when editing a block post in the classic editor. Gutenberg's strict content validation has helped identify formatting incompatibilities, and continued improvements are planned for future releases.
+* Add word and block count to table of contents.
+* Add support for meta attributes (custom fields) in block attributes. This allows block authors to specify attributes to live outside of post_content entirely.
+* Allow Gutenberg to be the default editor for posts with blocks and add links to classic editor.
+* Accessibility: add landmark regions.
+* Add metabox placeholder shell.
+* Add crash recovery for blocks which error while saving.
+* Hide Sidebar panels if the user doesn't have the right capabilities.
+* Refactor PostTaxonomies to use 'withApiData'.
+* Create 'withApiData' higher order component for managing API data.
+* Make casing consistent.
+* Allow toolbar wrapper to be clicked through.
+* Support and bootstrap server-registered block attribute schemas.
+* Shift focus into popover when opened.
+* Reuse the tabbable utility to retrieve the tabbables elements in WritingFlow.
+* Change placeholder text on button.
+* Persist the sate of the sidebar across refresh.
+* Use a small multiselect buffer zone, improving multiple block selection.
+* Close popover by escape keypress.
+* Improve dropzone contrast ratio.
+* Improve search message to add context.
+* Improve string extraction for localized strings.
+* Fixed z-index issue of gallery image inline menu.
+* Fixed image block resizing to set the figure wrapper.
+* Fixed column widths in gallery block.
+* Fixed parsing in do_blocks() and rendering of blocks on frontend in the_content.
+* Fixed position of upload svg on mobile.
+
+= 1.1.0 =
+
+* Add blocks "slash" autocomplete—shortcut to continue adding new block without leaving the keyboard.
+* Add ability to remove an image from a gallery from within the block (selecting image).
+* Add option to open a created link in a new window.
+* Support and bootstrap server-registered block attribute schemas.
+* Improve accessibility of add-new-category form.
+* Documentation gets an updated design and content improvements.
+* Adjust column width calculation in gallery block to properly respect column count.
+* Move pending review control together with sticky toggle at the bottom.
+* Add caption styling for video block.
+* Allow removing a "classic text" block with backspaces.
+* Allow Button block to show placeholder text.
+* Drop the deprecated button-secondary class name.
+* Fix link dialog not showing in Safari when caret is in the middle of the word.
+* Fix adding new categories and position newly added term at the top.
+* Fix the resetting of drop-zone states after dropping a file.
+* Fix embed saving "undefined" text when URL is not set.
+* Fix placeholder styling on Text when background color is set.
+* Update Composer + PHPCS.
+* Rename default block handlers.
+* Update code syntax tabs in docutron.
+* Link to plugin download and github repo from docutron.
+* Added block API document.
+* Add "Edit and Save" document.
+
+= 1.0.0 =
+* Restored keyboard navigation with more robust implementation, addressing previous browser issues.
+* Added drag and drop for media with pointer to create new blocks.
+* Merged paragraph and cover text blocks (includes the colors and font size options).
+* Reworked color palette picker with a "clear" and a "custom color" option.
+* Further improvements to inline pasting and fixing errant empty blocks.
+* Added thumbnail size selector to image blocks.
+* Added support for url input and align and edit buttons to audio block.
+* Persist the state of the sidebar across page refresh.
+* Persist state of sidebar panels on page refresh.
+* Persist editor mode on page refresh.
+* New withAPIData higher-order component for making it easier to manage data needs.
+* Preserve unknown block and remove "freeform" comment delimiters (unrecognized HTML is handled without comment delimiters).
+* Show "add new term" in hierarchical taxonomies (including categories).
+* Show tooltip only after mouseover delay.
+* Show post formats only if the post type supports them.
+* Added align and edit buttons to video block.
+* Preload data in withApiData to improve perceived performance.
+* Improve accessibility of sidebar modes.
+* Allow changing cover-image settings before uploading an image.
+* Improve validation leniency around non-meaningful differences.
+* Take into account capabilities for publishing action.
+* Update author selector to show only users capable of authoring posts.
+* Normalize pasted blockquote contents.
+* Refactored featured image, page attributes to use withApiData
+* Added a fix to avoid cloning nodes by passing pasted HTML string.
+* Added a fix to avoid re-encoding on encoded posts.
+* Fixed resetting the focus config when block already selected.
+* Allowing adding of plain text after insert link at the end of a paragraph.
+* Update to latest TinyMCE version.
+* Show only users capable of authoring posts.
+* Add submit for review to publish for contributor.
+* Delete or backspace in an empty "classic text" block now removes it.
+* Check for type in block transformations logic.
+* Fixed drop-down menu issue on classic text.
+* Added filter to allow post types to disable "edit in gutenberg" links.
+* Made UrlInput and UrlInputButton available as reusable components.
+* Use wordpress/a11y package instead of global.
+* Added npm5 package-lock.
+* We welcome all your feedback and contributions on the project repository, or ping us in #core-editor. Follow the "gutenberg" tag for past updates.
+
+= 0.9.0 =
+* Added ability to change font-size in cover text using slider and number input.
+* Added support for custom anchors (ids) on blocks, allowing to link directly to a section of the post.
+* Updated pull-quote design.
+* Created custom color palette component with "clear" option and "custom color" option. (And better markup and accessibility.)
+* Improve pasting: recognizing more elements, adding tests, stripping non-semantic markup, etc.
+* Improve gallery visual design and fix cropping in Safari.
+* Allow selecting a heading block from the table-of-contents panel directly.
+* Make toolbar slide horizontally for mobile.
+* Improve range-input control with a number input.
+* Fix pasting problems (handling of block attributes).
+* More stripping of unhandled elements during paste.
+* Show post format selector only for posts.
+* Display nicer URLs when editing links.
+* More compact save indicator.
+* Disabled arrow key navigation between blocks as we refine implementation.
+* Removed blank target from "view post" in notices.
+* Fix empty links still rendering ont he front-end.
+* Fix shadow on inline toolbars.
+* Fix problem with inserting pull-quotes.
+* Fix drag and drop on image block.
+* Removed warning when publishing.
+* Don't provide version for vendor scripts.
+* Clean category code in block registration.
+* Added history and resources docs.
+
+= 0.8.0 =
+* New Categories Block (based on existing widget).
+* New Text Columns Block (initial exploration of text-only multiple columns).
+* New Video Block.
+* New Shortcode Block.
+* New Audio Block.
+* Added resizing handlers to Image Block.
+* Added direct image upload button to Image Block and Gallery Block.
+* Give option to transform a block to Classic when it encounters problems.
+* Give option to Overwrite changes on a block detected as invalid.
+* Added "link to" option in galleries.
+* Added support for custom taxonomies.
+* Added post formats selector to post settings.
+* Added keywords support (aliases) to various blocks to improve search discovery.
+* Significant improvements to the way attributes are specified in the Block API and its clarity (handles defaults and types).
+* Added Tooltip component displaying aria-labels from buttons.
+* Removed stats tracking code.
+* Updated design document.
+* Capture and recover from block rendering runtime errors.
+* Handle enter when focusing on outer boundary of a block.
+* Reduce galleries json attributes data to a minimum.
+* Added caption styles to the front-end for images and embeds.
+* Added missing front-end alignment classes for table and cover-text blocks.
+* Only reset blocks on initial load to prevent state fluctuations.
+* Improve calculation of dirty state by making a diff against saved post.
+* Improve visual weight of toolbar by reducing its silhouette.
+* Improve rendering of galleries on the front-end.
+* Improve Cover Image placeholder visual presentation.
+* Improve front-end display of quotes.
+* Improve responsive design of galleries on the front-end.
+* Allow previewing new posts that are yet to be saved.
+* Reset scrolling position within inserter when switching tabs.
+* Refactor popover to render at root of document.
+* Refactor withFocusReturn to handle accessibility better in more contexts.
+* Prevent overlap between multi-selection and within-block selection.
+* Clear save notices when triggering a new save.
+* Disable "preview" button if post is not saveable.
+* Renamed blocks.query to blocks.source for clarity and updated documentation.
+* Rearrange block stylesheets to reflect display and editor styles.
+* Use @wordpress dependencies consistently.
+* Added validation checks for specifying a block's category.
+* Fix problems with quote initialization and list transformation.
+* Fix issue where Cover Image was being considered invalid after edits.
+* Fix errors in editable coming from Table block commands.
+* Fix error in latest posts block when date is not set for a post.
+* Fix issue with active color in ColorPalette component.
+* Prevent class=false serialization issue in covert-text.
+* Treat range control value as numeric.
+* Added warning when using Editable and passing non-array values.
+* Show block switcher above link input.
+* Updated rememo dependency.
+* Start consuming from separate @wordpress dependencies.
+* Fix problem with inserting new galleries.
+* Fix issue with embeds and missing captions.
+* Added outreach section to docs.
+
+= 0.7.1 =
+* Address problem with the freeform block and Jetpack's contact form.
+
+= 0.7.0 =
+* Hide placeholders on focus—reduces visual distractions while writing.
+* Add PostAuthor dropdown to the UI.
+* Add theme support for customized color palettes and a shared component (applies to cover text and button blocks).
+* Add theme support for wide images.
+* Report on missing headings in the document outline feature.
+* Update block validation to make it less prone to over-eagerness with trivial changes (like whitespace and new lines).
+* Attempt to create an embed block automatically when pasting URL on a single line.
+* Save post before previewing.
+* Improve operations with "lists", enter on empty item creates new paragraph block, handling backspace, etc.
+* Don't serialize attributes that match default attributes.
+* Order link suggestions by relevance.
+* Order embeds for easier discoverability.
+* Added "keywords" property for searching blocks with aliases.
+* Added responsive styles for Table block in the front end.
+* Set default list type to be unordered list.
+* Improve accessibility of UrlInput component.
+* Improve accessibility and keyboard interaction of DropdownMenu.
+* Improve Popover component and use for PostVisibility.
+* Added higher order component for managing spoken messages.
+* Localize schema for WP API, avoiding initialization delay if schema is present.
+* Do not expose editor.settings to block authors.
+* Do not remove tables on pasting.
+* Consolidate block server-side files with client ones in the same directory.
+* Removed array of paragraphs structure from text block.
+* Trim whitespace when searching for blocks.
+* Document, test, and refactor DropdownMenu component.
+* Use separate mousetrap instance per component instance.
+* Add npm organization scope to WordPress dependencies.
+* Expand utilities around fixture regeneration.
+* Renamed "Text" to "Paragraph".
+* Fix multi-selection "delete" functionality.
+* Fix text color inline style.
+* Fix issue caused by changes with React build process.
+* Fix splitting editable without child nodes.
+* Use addQueryArgs in oEmbed proxy url.
+* Update dashicons with new icons.
+* Clarify enqueuing block assets functions.
+* Added code coverage information to docs.
+* Document how to create new docs.
+* Add example of add_theme_support in docs.
+* Added opt-in mechanism for learning what blocks are being added to the content.
+
+= 0.6.0 =
+* Split paragraphs on enter—we have been exploring different behaviours here.
+* Added grid layout option for latest posts with columns slider control.
+* Show internal posts / pages results when creating links.
+* Added "Cover Text" block with background, text color, and full-width options.
+* Autosaving drafts.
+* Added "Read More" block.
+* Added color options to the button block.
+* Added mechanism for validating and protecting blocks that may have suffered unrecognized edits.
+* Add patterns plugin for text formatting shortcuts: create lists by adding * at the beginning of a text line, use # to create headings, and backticks for code.
+* Implement initial support for Cmd/Ctrl+Z (undo) and Cmd/Ctrl+Shift+Z (redo).
+* Improve pasting experience from outside editors by transforming content before converting to blocks.
+* Improve gallery creation flow by opening into "gallery" mode from placeholder.
+* Added page attributes with menu order setting.
+* Use two distinct icons for quote style variations.
+* Created KeyboardShortcuts component to handle keyboard events.
+* Add support for custom icons (non dashicons) on blocks.
+* Initialize new posts with auto-draft to match behaviour of existing editor.
+* Don't display "save" button for published posts.
+* Added ability to set a block as "use once" only (example: "read more" block).
+* Hide gallery display settings in media modal.
+* Simplify "cover image" markup and resolve conflict state in demo.
+* Introduce PHP classes for interacting with block types.
+* Announce block search results to assistive technologies.
+* Reveal "continue writing" shortcuts on focus.
+* Update document.title when the post title changes.
+* Added focus styles to several elements in the UI.
+* Added external-link component to handle links opening in new tabs or windows.
+* Improve responsive video on embed previews.
+* Improve "speak" messages for tag suggestions.
+* Make sure newly created blocks are marked as valid.
+* Preserve valid state during transformations.
+* Allow tabbing away from table.
+* Improve display of focused panel titles.
+* Adjust padding and margins across various design elements for consistency and normalization.
+* Fix pasting freeform content.
+* Fix proper propagation of updated block attributes.
+* Fix parsing and serialization of multi-paragraph pullquotes.
+* Fix a case where toggling pending preview would consider post as saved.
+* Fix positioning of block mover on full-width blocks.
+* Fix line height regression in quote styles.
+* Fix IE11 with polyfill for fetch method.
+* Fix case where blocks are created with isTyping and it never clears.
+* Fix block warning display in IE11.
+* Polish inspector visual design.
+* Prevent unhandled actions from returning new state reference.
+* Prevent unintentionally clearing link input value.
+* Added focus styles to switch toggle components.
+* Avoid navigating outside the editor with arrow keys.
+* Add short description to Verse block.
+* Initialize demo content only for new demo posts.
+* Improve insert link accessibility.
+* Improve version compare checks for plugin compatibility.
+* Clean up obsolete poststoshowattribute in LatestPosts block.
+* Consolidate addQueryArgs usage.
+* Add unit tests to inserter.
+* Update fixtures with latest modifications and ensure all end in newlines.
+* Added codecov for code coverage.
+* Clean up JSDoc comments.
+* Link to new docs within main readme.
+
+= 0.5.0 =
+* New tabs mode for the sidebar to switch between post settings and block inspector.
+* Implement recent blocks display.
+* Mobile implementation of block mover, settings, and delete actions.
+* Search through all tabs on the inserter and hide tabs.
+* New documentation app to serve all tutorials, faqs, docs, etc.
+* Enable ability to add custom classes to blocks (via inspector).
+* Add ability to drag-and-drop on image block placeholders to upload images.
+* Add "table of contents" document outline for headings (with empty heading validation).
+* Refactor tests to use Jest API.
+* New block: Verse (intended for poetry, respecting whitespace).
+* Avoid showing UI when typing and starting a new paragraph (text block).
+* Display warning message when navigating away from the editor with unsaved changes.
+* Use old editor as "freeform".
+* Improve PHP parser compatibility with different server configurations ("mbstring" extension and PCRE settings).
+* Improve PostVisibility markup and accessibility.
+* Add shortcuts to manage indents and levels in List block.
+* Add alignment options to latest posts block.
+* Add focus styles for quick tags buttons in text mode.
+* Add way to report PHP parsing performance.
+* Add labels and roles to UrlInput.
+* Add ability to set custom placeholders for text and headings as attributes.
+* Show error message when trashing action fails.
+* Pass content to dynamic block render functions in PHP.
+* Fix various z-index issues and clarify reasonings.
+* Fix DropdownMenu arrows navigation and add missing aria-label.
+* Update sandboxed iframe size calculations.
+* Export inspector controls component under wp.blocks.
+* Adjust Travis JS builds to improve task allocation.
+* Fix warnings during tests.
+* Fix caret jumping when switching formatting in Editable.
+* Explicitly define prop-types as dependency.
+* Update list of supported browsers for consistency with core.
+
+= 0.4.0 =
+* Initial FAQ (in progress).
+* API for handling pasted content. (Aim is to have specific handling for converting Word, Markdown, Google Docs to native WordPress blocks.)
+* Added support for linking to a url on image blocks.
+* Navigation between blocks using arrow keys.
+* Added alternate Table block with TinyMCE functionality for adding/removing rows/cells, etc. Retired previous one.
+* Parse more/noteaser comment tokens from core.
+* Re-engineer the approach for rendering embed frames.
+* First pass at adding aria-labels to blocks list.
+* Setting up Jest for better testing environment.
+* Improve performance of server-side parsing.
+* Update blocks documentation with latest API functions and clearer examples.
+* Use fixed position for notices.
+* Make inline mode the default for Editable.
+* Add actions for plugins to register frontend and editor assets.
+* Supress gallery settings sidebar on media library when editing gallery.
+* Validate save and edit render when registering a block.
+* Prevent media library modal from opening when loading placeholders.
+* Update to sidebar design and behaviour on mobile.
+* Improve font-size in inserter and latest posts block.
+* Improve rendering of button block in the front end.
+* Add aria-label to edit image button.
+* Add aria-label to embed input url input.
+* Use pointer cursor for tabs in inserter.
+* Update design docs with regard to selected/unselected states.
+* Improve generation of wp-block-* classes for consistency.
+* Select first cell of table block when initializing.
+* Fix wide and full alignment on the front-end when images have no caption.
+* Fix initial state of freeform block.
+* Fix ability to navigate to resource on link viewer.
+* Fix clearing floats on inserter.
+* Fix loading of images in library.
+* Fix auto-focusing on table block being too agressive.
+* Clean double reference to pegjs in dependencies.
+* Include messages to ease debugging parser.
+* Check for exact match for serialized content in parser tests.
+* Add allow-presentation to fix issue with sandboxed iframe in Chrome.
+* Declare use of classnames module consistently.
+* Add translation to embed title.
+* Add missing text domains and adjust PHPCS to warn about them.
+* Added template for creating new issues including mentions of version number.
+
+= 0.3.0 =
+* Added framework for notices and implemented publishing and saving ones.
+* Implemented tabs on the inserter.
+* Added text and image quick inserts next to inserter icon at the end of the post.
+* Generate front-end styles for core blocks and enqueue them.
+* Include generated block classname in edit environment.
+* Added "edit image" button to image and cover image blocks.
+* Added option to visually crop images in galleries for nicer alignment.
+* Added option to disable dimming the background in cover images.
+* Added buffer for multi-select flows.
+* Added option to display date and to configure number of posts in LatestPosts block.
+* Added PHP parser based on PEG.js to unify grammars.
+* Split block styles for display so they can be loaded on the theme.
+* Auto-focusing for inserter search field.
+* Added text formatting to CoverImage block.
+* Added toggle option for fixed background in CoverImage.
+* Switched to store attributes in unescaped JSON format within the comments.
+* Added placeholder for all text blocks.
+* Added placeholder text for headings, quotes, etc.
+* Added BlockDescription component and applied it to several blocks.
+* Implemented sandboxing iframe for embeds.
+* Include alignment classes on embeds with wrappers.
+* Changed the block name declaration for embeds to be "core-embed/name-of-embed".
+* Simplified and made more robust the rendering of embeds.
+* Different fixes for quote blocks (parsing and transformations).
+* Improve display of text within cover image.
+* Fixed placeholder positioning in several blocks.
+* Fixed parsing of HTML block.
+* Fixed toolbar calculations on blocks without toolbars.
+* Added heading alignments and levels to inspector.
+* Added sticky post setting and toggle.
+* Added focus styles to inserter search.
+* Add design blueprints and principles to the storybook.
+* Enhance FormTokenField with accessibility improvements.
+* Load word-count module.
+* Updated icons for trash button, and Custom HTML.
+* Design tweaks for inserter, placeholders, and responsiveness.
+* Improvements to sidebar headings and gallery margins.
+* Allow deleting selected blocks with "delete" key.
+* Return more than 10 categories/tags in post settings.
+* Accessibility improvements with FormToggle.
+* Fix media button in gallery placeholder.
+* Fix sidebar breadcrumb.
+* Fix for block-mover when blocks are floated.
+* Fixed inserting Freeform block (now classic text).
+* Fixed missing keys on inserter.
+* Updated drop-cap class implementation.
+* Showcasing full-width cover image in demo content.
+* Copy fixes on demo content.
+* Hide meta-boxes icons for screen readers.
+* Handle null values in link attributes.
+
+= 0.2.0 =
+* Include "paste" as default plugin in Editable.
+* Extract block alignment controls as a reusable component.
+* Added button to delete a block.
+* Added button to open block settings in the inspector.
+* New block: Custom HTML (to write your own HTML and preview it).
+* New block: Cover Image (with text over image support).
+* Rename "Freeform" block to "Classic Text".
+* Added support for pages and custom post types.
+* Improve display of "saving" label while saving.
+* Drop usage of controls property in favor of components in render.
+* Add ability to select all blocks with ctrl/command+A.
+* Automatically generate wrapper class for styling blocks.
+* Avoid triggering multi-select on right click.
+* Improve target of post previewing.
+* Use imports instead of accessing the wp global.
+* Add block alignment and proper placeholders to pullquote block.
+* Wait for wp.api before loading the editor. (Interim solution.)
+* Adding several reusable inspector controls.
+* Design improvements to floats, switcher, and headings.
+* Add width classes on figure wrapper when using captions in images.
+* Add image alt attributes.
+* Added html generation for photo type embeds.
+* Make sure plugin is run on WP 4.8.
+* Update revisions button to only show when there are revisions.
+* Parsing fixes on do_blocks.
+* Avoid being keyboard trapped on editor content.
+* Don't show block toolbars when pressing modifier keys.
+* Fix overlapping controls in Button block.
+* Fix post-title line height.
+* Fix parsing void blocks.
+* Fix splitting inline Editable instances with shift+enter.
+* Fix transformation between text and list, and quote and list.
+* Fix saving new posts by making post-type mandatory.
+* Render popovers above all elements.
+* Improvements to block deletion using backspace.
+* Changing the way block outlines are rendered on hover.
+* Updated PHP parser to handle shorthand block syntax, and fix newlines.
+* Ability to cancel adding a link from link menu.
+
+= 0.1.0 =
+* First release of the plugin.

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: matveb, joen, karmatosed
 Requires at least: 5.2.0
 Tested up to: 5.3
-Stable tag: 7.0.0
+Stable tag: V.V.V
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,0 +1,178 @@
+=== Gutenberg ===
+Contributors: matveb, joen, karmatosed
+Requires at least: 5.2.0
+Tested up to: 5.3
+Stable tag: 7.0.0
+License: GPLv2 or later
+License URI: http://www.gnu.org/licenses/gpl-2.0.html
+
+The block editor was introduced in core WordPress with version 5.0. This beta plugin allows you to test bleeding-edge features around editing and customization projects before they land in future WordPress releases.
+
+== Description ==
+
+The block editor was introduced in core WordPress with version 5.0 but the Gutenberg project will ultimately impact the entire publishing experience including customization (the next focus area). This beta plugin allows you to test bleeding-edge features around editing and customization projects before they land in future WordPress releases.
+
+<a href="https://wordpress.org/gutenberg">Discover more about the project</a>.
+
+= Editing focus =
+
+> The editor will create a new page- and post-building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery. — Matt Mullenweg
+
+One thing that sets WordPress apart from other systems is that it allows you to create as rich a post layout as you can imagine -- but only if you know HTML and CSS and build your own custom theme. By thinking of the editor as a tool to let you write rich posts and create beautiful layouts, we can transform WordPress into something users _love_ WordPress, as opposed something they pick it because it's what everyone else uses.
+
+Gutenberg looks at the editor as more than a content field, revisiting a layout that has been largely unchanged for almost a decade.This allows us to holistically design a modern editing experience and build a foundation for things to come.
+
+Here's why we're looking at the whole editing screen, as opposed to just the content field:
+
+1. The block unifies multiple interfaces. If we add that on top of the existing interface, it would _add_ complexity, as opposed to remove it.
+2. By revisiting the interface, we can modernize the writing, editing, and publishing experience, with usability and simplicity in mind, benefitting both new and casual users.
+3. When singular block interface takes center stage, it demonstrates a clear path forward for developers to create premium blocks, superior to both shortcodes and widgets.
+4. Considering the whole interface lays a solid foundation for the next focus, full site customization.
+5. Looking at the full editor screen also gives us the opportunity to drastically modernize the foundation, and take steps towards a more fluid and JavaScript powered future that fully leverages the WordPress REST API.
+
+= Blocks =
+
+Blocks are the unifying evolution of what is now covered, in different ways, by shortcodes, embeds, widgets, post formats, custom post types, theme options, meta-boxes, and other formatting elements. They embrace the breadth of functionality WordPress is capable of, with the clarity of a consistent user experience.
+
+Imagine a custom “employee” block that a client can drag to an About page to automatically display a picture, name, and bio. A whole universe of plugins that all extend WordPress in the same way. Simplified menus and widgets. Users who can instantly understand and use WordPress  -- and 90% of plugins. This will allow you to easily compose beautiful posts like <a href="http://moc.co/sandbox/example-post/">this example</a>.
+
+Check out the <a href="https://wordpress.org/gutenberg/handbook/reference/faq/">FAQ</a> for answers to the most common questions about the project.
+
+= Compatibility =
+
+Posts are backwards compatible, and shortcodes will still work. We are continuously exploring how highly-tailored metaboxes can be accommodated, and are looking at solutions ranging from a plugin to disable Gutenberg to automatically detecting whether to load Gutenberg or not. While we want to make sure the new editing experience from writing to publishing is user-friendly, we’re committed to finding  a good solution for highly-tailored existing sites.
+
+= The stages of Gutenberg =
+
+Gutenberg has three planned stages. The first, aimed for inclusion in WordPress 5.0, focuses on the post editing experience and the implementation of blocks. This initial phase focuses on a content-first approach. The use of blocks, as detailed above, allows you to focus on how your content will look without the distraction of other configuration options. This ultimately will help all users present their content in a way that is engaging, direct, and visual.
+
+These foundational elements will pave the way for stages two and three, planned for the next year, to go beyond the post into page templates and ultimately, full site customization.
+
+Gutenberg is a big change, and there will be ways to ensure that existing functionality (like shortcodes and meta-boxes) continue to work while allowing developers the time and paths to transition effectively. Ultimately, it will open new opportunities for plugin and theme developers to better serve users through a more engaging and visual experience that takes advantage of a toolset supported by core.
+
+= Contributors =
+
+Gutenberg is built by many contributors and volunteers. Please see the full list in <a href="https://github.com/WordPress/gutenberg/blob/master/CONTRIBUTORS.md">CONTRIBUTORS.md</a>.
+
+== Frequently Asked Questions ==
+
+= How can I send feedback or get help with a bug? =
+
+We'd love to hear your bug reports, feature suggestions and any other feedback! Please head over to <a href="https://github.com/WordPress/gutenberg/issues">the GitHub issues page</a> to search for existing issues or open a new one. While we'll try to triage issues reported here on the plugin forum, you'll get a faster response (and reduce duplication of effort) by keeping everything centralized in the GitHub repository.
+
+= How can I contribute? =
+
+We’re calling this editor project "Gutenberg" because it's a big undertaking. We are working on it every day in GitHub, and we'd love your help building it.You’re also welcome to give feedback, the easiest is to join us in <a href="https://make.wordpress.org/chat/">our Slack channel</a>, `#core-editor`.
+
+See also <a href="https://github.com/WordPress/gutenberg/blob/master/CONTRIBUTING.md">CONTRIBUTING.md</a>.
+
+= Where can I read more about Gutenberg? =
+
+- <a href="http://matiasventura.com/post/gutenberg-or-the-ship-of-theseus/">Gutenberg, or the Ship of Theseus</a>, with examples of what Gutenberg might do in the future
+- <a href="https://make.wordpress.org/core/2017/01/17/editor-technical-overview/">Editor Technical Overview</a>
+- <a href="https://wordpress.org/gutenberg/handbook/reference/design-principles/">Design Principles and block design best practices</a>
+- <a href="https://github.com/Automattic/wp-post-grammar">WP Post Grammar Parser</a>
+- <a href="https://make.wordpress.org/core/tag/gutenberg/">Development updates on make.wordpress.org</a>
+- <a href="https://wordpress.org/gutenberg/handbook/">Documentation: Creating Blocks, Reference, and Guidelines</a>
+- <a href="https://wordpress.org/gutenberg/handbook/reference/faq/">Additional frequently asked questions</a>
+
+
+== Changelog ==
+
+### Features
+
+*   Add a new Navigation block (previously available as an experiment)
+    *   [Highlight menu items](https://github.com/WordPress/gutenberg/pull/18435) without defined URL.
+    *   Prevent [error in Firefox](https://github.com/WordPress/gutenberg/pull/18455) when removing the block.
+    *   [Remove background color](https://github.com/WordPress/gutenberg/pull/18407) from the Navigation block and rely on the Group block.
+    *   Remove the [background shadow](https://github.com/WordPress/gutenberg/pull/18485) for the submenus dropdown.
+    *   [Rename "Navigation Menu Item"](https://github.com/WordPress/gutenberg/pull/18422https://github.com/WordPress/gutenberg/pull/18422) block to "Link".
+    *   Remove [unnecessary color attributes](https://github.com/WordPress/gutenberg/pull/18540).
+    *   Allow [addition CSS](https://github.com/WordPress/gutenberg/pull/18466) [classes](https://github.com/WordPress/gutenberg/pull/18629).
+    *   Drop the [“menu” suffix from the block name](https://github.com/WordPress/gutenberg/pull/18551).
+    *   [Escape special](https://github.com/WordPress/gutenberg/pull/18607) [characters](https://github.com/WordPress/gutenberg/pull/18617) in the frontend.
+    *   Remove from [experimental features](https://github.com/WordPress/gutenberg/pull/18594).
+    *   Add [style variations](https://github.com/WordPress/gutenberg/pull/18553).
+
+### Enhancements
+
+*   Use [gradient classnames](https://github.com/WordPress/gutenberg/pull/18590) instead of inline styles for the Cover block.
+*   Inserter: Add [keyboard shortcut styling](https://github.com/WordPress/gutenberg/pull/18623) to "/" in the default tip.
+*   [Restore the caret position](https://github.com/WordPress/gutenberg/pull/17824) properly on undo.
+*   Add keywords to improve the [discoverability of the Audio block](https://github.com/WordPress/gutenberg/pull/18673).
+*   Show [video preview on Cover block](https://github.com/WordPress/gutenberg/pull/18009) inspector panel.
+
+### Bug Fixes
+
+*   Fix [hidden nested images](https://github.com/WordPress/gutenberg/pull/18347) in the content column.
+*   Fix [double border issue](https://github.com/WordPress/gutenberg/pull/18358) in the keyboard shortcuts modal.
+*   Fix [off-centered publish button](https://github.com/WordPress/gutenberg/pull/17726).
+*   Fix [error when isRTL config is not provided](https://github.com/WordPress/gutenberg/pull/18526) in the block editor settings.
+*   Fix [full width Table block](https://github.com/WordPress/gutenberg/pull/18469) mobile regression.
+*   A11y: Add a screen reader text [label for the Search block](https://github.com/WordPress/gutenberg/pull/17983).
+*   Fix [text patterns undo](https://github.com/WordPress/gutenberg/pull/18533) after mouse move.
+*   Fix block [drag and drop for the  contributor role](https://github.com/WordPress/gutenberg/pull/15054).
+*   [Update the link when switching the image used](https://github.com/WordPress/gutenberg/pull/17226) in the Image block.
+*   Fix php [error triggered when **gutenberg_register_packages_scripts**](https://github.com/WordPress/gutenberg/pull/18599) is run more than once.
+*   Fix special characters [escaping for the post title](https://github.com/WordPress/gutenberg/pull/18616).
+*   Fix [JavaScript errors triggered when selectors are called](https://github.com/WordPress/gutenberg/pull/18559) before the editor being initialized.
+*   Fix [BaseControl component label](https://github.com/WordPress/gutenberg/pull/18646) when no id is passed.
+*   [Preserve whitespace](https://github.com/WordPress/gutenberg/pull/18656) when converting blocks Preformatted and Paragraph blocks.
+*   Fix [multiple paste issues](https://github.com/WordPress/gutenberg/pull/17470) creating unnecessary empty spaces.
+
+### New APIs
+
+*   Add a new [Card component](https://github.com/WordPress/gutenberg/pull/17963) [to](https://github.com/WordPress/gutenberg/pull/18681) @wordpress/components.
+*   Add [label support for the URLInput](https://github.com/WordPress/gutenberg/pull/15669) [component](https://github.com/WordPress/gutenberg/pull/18488).
+*   Support the [isMatch option for the shorcode transforms](https://github.com/WordPress/gutenberg/pull/18459).
+
+### Experiments
+
+*   Block Content areas:
+    *   Add [Post Title and Post Content](https://github.com/WordPress/gutenberg/pull/18461) [blocks](https://github.com/WordPress/gutenberg/pull/18543).
+    *   Add [template parts](https://github.com/WordPress/gutenberg/pull/18339) CPT and the theme resolution logic.
+*   Widgets Screen:
+    *   [Refactor the legacy widgets block](https://github.com/WordPress/gutenberg/pull/15801) to support all blocks.
+    *   Fix [widget areas margins](https://github.com/WordPress/gutenberg/pull/18528).
+    *   Add [isRTL setting](https://github.com/WordPress/gutenberg/pull/18545).
+*   APIs
+    *   **useColors** hook: Enhance the [contrast checking API](https://github.com/WordPress/gutenberg/pull/18237) and provide [access to the color value](https://github.com/WordPress/gutenberg/pull/18544).
+    *   Introduce [createInterpolateElement](https://github.com/WordPress/gutenberg/pull/17376) to allow translation of complex strings with HTML content.
+    *   A11y: Refactor the [accessibility behavior of the Toolbar](https://github.com/WordPress/gutenberg/pull/18534) component.
+*   Social Links:
+    *   [Capitalize LinkedIn](https://github.com/WordPress/gutenberg/pull/18638) and [GitHub](https://github.com/WordPress/gutenberg/pull/18714) properly.
+    *   Fix frontend [styling](https://github.com/WordPress/gutenberg/pull/18410).
+
+### Documentation
+
+*   Add a [Backward Compatibility policy](https://github.com/WordPress/gutenberg/pull/18499) document.
+*   Clarify the [npm packages release](https://github.com/WordPress/gutenberg/pull/18516) documentation.
+*   Add documentation for the [@wordpress/env wp-env.json config file](https://github.com/WordPress/gutenberg/pull/18643).
+*   Typos and tweaks: [1](https://github.com/WordPress/gutenberg/pull/18400), [2](https://github.com/WordPress/gutenberg/pull/18404), [3](https://github.com/WordPress/gutenberg/pull/18449), [4](https://github.com/WordPress/gutenberg/pull/18403), [5](https://github.com/WordPress/gutenberg/pull/18452), [6](https://github.com/WordPress/gutenberg/pull/18460), [7](https://github.com/WordPress/gutenberg/pull/18475), [8](https://github.com/WordPress/gutenberg/pull/18507), [9](https://github.com/WordPress/gutenberg/pull/18059), [10](https://github.com/WordPress/gutenberg/pull/17911), [11](https://github.com/WordPress/gutenberg/pull/18558), [12](https://github.com/WordPress/gutenberg/pull/18277), [13](https://github.com/WordPress/gutenberg/pull/18572), [14](https://github.com/WordPress/gutenberg/pull/18587), [15](https://github.com/WordPress/gutenberg/pull/18592), [16](https://github.com/WordPress/gutenberg/pull/18436), [17](https://github.com/WordPress/gutenberg/pull/18446), [18](https://github.com/WordPress/gutenberg/pull/18707), [19](https://github.com/WordPress/gutenberg/pull/18450), [20](https://github.com/WordPress/gutenberg/pull/18713).
+
+### Various
+
+*   Refactor the [RichText component](https://github.com/WordPress/gutenberg/pull/17779): Remove the inner Editable component.
+*   Integrate [the](https://github.com/WordPress/gutenberg/pull/18514) [Gutenberg Playground](https://github.com/WordPress/gutenberg/pull/18191) into Storybook.
+*   Increase [WordPress minimum supported](https://github.com/WordPress/gutenberg/pull/15809) by the plugin to 5.2.0.
+*   Refactor the [Paragraph block edit function](https://github.com/WordPress/gutenberg/pull/18125) as a functional component.
+*   Refactor the [Cover block edit function](https://github.com/WordPress/gutenberg/pull/18116) as a functional component.
+*   Add new components to Storybook.
+    *   [RadioControl](https://github.com/WordPress/gutenberg/pull/18474) component.
+    *   [TabPanel](https://github.com/WordPress/gutenberg/pull/18402) component.
+    *   [Popover](https://github.com/WordPress/gutenberg/pull/18096) component.
+    *   [BaseControl](https://github.com/WordPress/gutenberg/pull/18648) component.
+    *   [Tip](https://github.com/WordPress/gutenberg/pull/18542) component.
+*   Include [WordPress eslint plugin](https://github.com/WordPress/gutenberg/pull/18457) in React eslint ruleset in @wordpress/eslint-plugin.
+*   [Block PRs  on mobile unit test failures](https://github.com/WordPress/gutenberg/pull/18454) in Travis.
+*   Polish the [PostSchedule popover styling](https://github.com/WordPress/gutenberg/pull/18235).
+*   Fix the [API documentation generation tool](https://github.com/WordPress/gutenberg/pull/18253) when spaces are used in folder names.
+*   Add [missing @babel/runtime dependency](https://github.com/WordPress/gutenberg/pull/18626) to the @wordpress/jest-puppeteer-axe.
+*   [Refactor the Layout component](https://github.com/WordPress/gutenberg/pull/18044) [to](https://github.com/WordPress/gutenberg/pull/18658) [separate](https://github.com/WordPress/gutenberg/pull/18683) the UI from the content.
+*   Align [Dropdown and DropdownMenu](https://github.com/WordPress/gutenberg/pull/18631) components styling.
+*   Remove [max-width style from the Image block](https://github.com/WordPress/gutenberg/pull/14911).
+*   Remove the [CollegeHumor embed](https://github.com/WordPress/gutenberg/pull/18591) block.
+*   Add unit tests: 
+    *   Ensure [consecutive edits](https://github.com/WordPress/gutenberg/pull/17917) to the same attribute are considered persistent.
+    *   Test the [core-data undo reducer](https://github.com/WordPress/gutenberg/pull/18642).
+


### PR DESCRIPTION
## Description
Closes: https://github.com/WordPress/gutenberg/issues/6004
Sometimes we want to merge a change that requires an update to changelog.txt and readme.txt e.g: https://github.com/WordPress/gutenberg/pull/16674.
Having the files here allows us to in a single PR/commit change something and update these files.

The release tool was updated, as now we also need to update these files on Github.

## How has this been tested?
I used a Gutenberg fork to test the Git iteractions available at https://github.com/jorgefilipecosta/gutenberg (with the test changes made still there).

I used a free svn repository powered by riouxsvn.com to test the svn iteractions.