### PR TITLE
Add Inserter testID

### DIFF
--- a/packages/block-editor/src/components/inserter/index.native.js
+++ b/packages/block-editor/src/components/inserter/index.native.js
@@ -19,7 +19,12 @@ const defaultRenderToggle = ( { onToggle, disabled, style } ) => (
 		title={ __( 'Add block' ) }
 		icon={ ( <Dashicon icon="plus-alt" style={ style } color={ style.color } /> ) }
 		onClick={ onToggle }
-		extraProps={ { hint: __( 'Double tap to add a block' ), testID: 'add-block-button' } }
+		extraProps={ {
+			hint: __( 'Double tap to add a block' ),
+			// testID is present to disambiguate this element for native UI tests. It's not
+			// usually required for components. See: https://git.io/JeQ7G.
+			testID: 'add-block-button',
+		} }
 		isDisabled={ disabled }
 	/>
 );

--- a/packages/block-editor/src/components/inserter/index.native.js
+++ b/packages/block-editor/src/components/inserter/index.native.js
@@ -19,7 +19,7 @@ const defaultRenderToggle = ( { onToggle, disabled, style } ) => (
 		title={ __( 'Add block' ) }
 		icon={ ( <Dashicon icon="plus-alt" style={ style } color={ style.color } /> ) }
 		onClick={ onToggle }
-		extraProps={ { hint: __( 'Double tap to add a block' ) } }
+		extraProps={ { hint: __( 'Double tap to add a block' ), testID: 'add-block-button' } }
 		isDisabled={ disabled }
 	/>
 );

--- a/packages/block-editor/src/components/inserter/test/index.native.js
+++ b/packages/block-editor/src/components/inserter/test/index.native.js
@@ -1,0 +1,18 @@
+/**
+ * External dependencies
+ */
+import renderer from 'react-test-renderer';
+
+/**
+ * Internal dependencies
+ */
+import Inserter from '../index';
+import '../../..'; // Ensure store dependencies are imported via root.
+
+describe( 'Inserter', () => {
+	it( 'button contains the testID "add-block-button"', () => {
+		const component = renderer.create( <Inserter /> );
+		const rendered = component.toJSON();
+		expect( rendered.children[ 0 ].props.testID ).toEqual( 'add-block-button' );
+	} );
+} );

--- a/packages/components/src/button/index.native.js
+++ b/packages/components/src/button/index.native.js
@@ -71,6 +71,7 @@ export function Button( props ) {
 		'aria-disabled': ariaDisabled,
 		'aria-label': ariaLabel,
 		'data-subscript': subscript,
+		testID,
 	} = props;
 
 	const isDisabled = ariaDisabled || disabled;
@@ -107,6 +108,7 @@ export function Button( props ) {
 			onPress={ onClick }
 			style={ styles.container }
 			disabled={ isDisabled }
+			testID={ testID }
 		>
 			<View style={ buttonViewStyle }>
 				<View style={ { flexDirection: 'row' } }>


### PR DESCRIPTION
## Description
Adds a testID to the inserter button on mobile – this allows it to be targeted by automated test tools without having to first localize the string for different device locales.

## How has this been tested?
- This PR adds a test case to ensure that the testID is present on the element
- I've run unit tests locally, both `yarn run test-unit:native` and `yarn test`. Additionally, this PR's CI checks should be green.
- Tested this PR in the `gutenberg-mobile` project, using this branch as the submodule reference, referenced in the screenshot below. 

## Screenshots
<img width="1981" alt="Screen Shot 2019-11-29 at 2 05 56 PM" src="https://user-images.githubusercontent.com/1123407/69890086-88b07b00-12b1-11ea-9fce-785a229d0f3e.png">

## Types of changes
- Small testability improvement on mobile

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
