### PR TITLE
Fix: Private post with future date becomes public on update

### DIFF
--- a/packages/e2e-tests/specs/editor/various/post-visibility.test.js
+++ b/packages/e2e-tests/specs/editor/various/post-visibility.test.js
@@ -8,6 +8,9 @@ import {
 } from '@wordpress/e2e-test-utils';
 
 describe( 'Post visibility', () => {
+	afterEach( async () => {
+		await setBrowserViewport( 'large' );
+	} );
 	[ 'large', 'small' ].forEach( ( viewport ) => {
 		it( `can be changed when the viewport is ${ viewport }`, async () => {
 			await setBrowserViewport( viewport );
@@ -27,5 +30,37 @@ describe( 'Post visibility', () => {
 
 			expect( currentStatus ).toBe( 'private' );
 		} );
+	} );
+
+	it( 'visibility remains private even if the publish date is in the future', async () => {
+		await createNewPost();
+
+		// Enter a title for this post.
+		await page.type( '.editor-post-title__input', 'Title' );
+
+		await openDocumentSettingsSidebar();
+
+		// Set a publish date for the next month.
+		await page.click( '.edit-post-post-schedule__toggle' );
+		await page.click( 'div[aria-label="Move forward to switch to the next month."]' );
+		await (
+			await page.$x( '//td[contains(concat(" ", @class, " "), " CalendarDay ")][text() = "15"]' )
+		)[ 0 ].click();
+
+		await page.click( '.edit-post-post-visibility__toggle' );
+
+		const [ privateLabel ] = await page.$x( '//label[text()="Private"]' );
+		await privateLabel.click();
+
+		// Enter a title for this post.
+		await page.type( '.editor-post-title__input', ' Changed' );
+
+		await page.click( '.editor-post-publish-button' );
+
+		const currentStatus = await page.evaluate( () => {
+			return wp.data.select( 'core/editor' ).getEditedPostAttribute( 'status' );
+		} );
+
+		expect( currentStatus ).toBe( 'private' );
 	} );
 } );

--- a/packages/editor/src/components/post-publish-button/index.js
+++ b/packages/editor/src/components/post-publish-button/index.js
@@ -64,10 +64,10 @@ export class PostPublishButton extends Component {
 		let publishStatus;
 		if ( ! hasPublishAction ) {
 			publishStatus = 'pending';
-		} else if ( isBeingScheduled ) {
-			publishStatus = 'future';
 		} else if ( visibility === 'private' ) {
 			publishStatus = 'private';
+		} else if ( isBeingScheduled ) {
+			publishStatus = 'future';
 		} else {
 			publishStatus = 'publish';
 		}


### PR DESCRIPTION
## Description
Fixes: https://github.com/WordPress/gutenberg/issues/13374

Currently, If we create a post set a future date and change the visibility to private, the post saves as private with a future publish date. When reloading, the information is right. After the reload, if we change something in the post and then press update, the post becomes public right away.

The problem is the order of the post status evaluation rules; we first see if the date is in the future, and if yes, we set a future status. We should first verify if the post is private and if yes, we should keep the status.

## How has this been tested?
I verified the bug I described above is fixed.
I verified https://github.com/WordPress/gutenberg/issues/13374 is fixed (requires classic editor plugin to test).