### PR TITLE
[Tiny PR] Multi selection: hide toolbar when multi selecting

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -446,6 +446,7 @@ function BlockListBlock( {
 		! isNavigationMode &&
 		! hasFixedToolbar &&
 		! showEmptyBlockSideInserter &&
+		! isMultiSelecting &&
 		(
 			( isSelected && ( ! isTypingWithinBlock || isCaretWithinFormattedText ) ) ||
 			isFirstMultiSelected


### PR DESCRIPTION
## Description

This was raised in #16835, though it has been the behaviour for a long time. It does make more sense to hide the block toolbar during multi block selection so that it doesn't interfere when selecting upwards.

## How has this been tested?

Select two block dragging from the bottom to the top one. The toolbar should disappear when moving over the block boundary.

## Screenshots <!-- if applicable -->

![select-up](https://user-images.githubusercontent.com/4710635/69892317-8297ba00-1304-11ea-886e-ae1e6d6c751a.gif)

## Types of changes


## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
