### PR TITLE
Fixes the FontSizePicker Custom option

### DIFF
--- a/packages/components/src/font-size-picker/index.js
+++ b/packages/components/src/font-size-picker/index.js
@@ -28,13 +28,11 @@ function getSelectOptions( optionsArray, disableCustomFontSizes ) {
 			{ slug: 'custom', name: __( 'Custom' ) },
 		];
 	}
-	return [
-		...optionsArray.map( ( option ) => ( {
-			key: option.slug,
-			name: option.name,
-			style: { fontSize: option.size },
-		} ) ),
-	];
+	return optionsArray.map( ( option ) => ( {
+		key: option.slug,
+		name: option.name,
+		style: { fontSize: option.size },
+	} ) );
 }
 
 function FontSizePicker( {

--- a/packages/components/src/font-size-picker/index.js
+++ b/packages/components/src/font-size-picker/index.js
@@ -21,14 +21,19 @@ function getSelectValueFromFontSize( fontSizes, value ) {
 	return 'normal';
 }
 
-function getSelectOptions( optionsArray ) {
+function getSelectOptions( optionsArray, disableCustomFontSizes ) {
+	if ( ! disableCustomFontSizes ) {
+		optionsArray = [
+			...optionsArray,
+			{ slug: 'custom', name: __( 'Custom' ) },
+		];
+	}
 	return [
 		...optionsArray.map( ( option ) => ( {
 			key: option.slug,
 			name: option.name,
 			style: { fontSize: option.size },
 		} ) ),
-		{ key: 'custom', name: __( 'Custom' ) },
 	];
 }
 
@@ -62,7 +67,7 @@ function FontSizePicker( {
 		onChange( selectedItem.style && selectedItem.style.fontSize );
 	};
 
-	const items = getSelectOptions( fontSizes );
+	const items = getSelectOptions( fontSizes, disableCustomFontSizes );
 	const rangeControlNumberId = `components-range-control__number#${ instanceId }`;
 	return (
 		<fieldset className="components-font-size-picker">

--- a/packages/components/src/font-size-picker/index.js
+++ b/packages/components/src/font-size-picker/index.js
@@ -65,6 +65,11 @@ function FontSizePicker( {
 		onChange( selectedItem.style && selectedItem.style.fontSize );
 	};
 
+	const onSliderChangeValue = ( sliderValue ) => {
+		onChange( sliderValue );
+		setCurrentSelectValue( getSelectValueFromFontSize( fontSizes, sliderValue ) );
+	};
+
 	const items = getSelectOptions( fontSizes, disableCustomFontSizes );
 	const rangeControlNumberId = `components-range-control__number#${ instanceId }`;
 	return (
@@ -115,7 +120,7 @@ function FontSizePicker( {
 					label={ __( 'Custom Size' ) }
 					value={ value || '' }
 					initialPosition={ fallbackFontSize }
-					onChange={ onChange }
+					onChange={ onSliderChangeValue }
 					min={ 12 }
 					max={ 100 }
 					beforeIcon="editor-textcolor"

--- a/packages/components/src/font-size-picker/index.js
+++ b/packages/components/src/font-size-picker/index.js
@@ -65,11 +65,6 @@ function FontSizePicker( {
 		onChange( selectedItem.style && selectedItem.style.fontSize );
 	};
 
-	const onSliderChangeValue = ( sliderValue ) => {
-		onChange( sliderValue );
-		setCurrentSelectValue( getSelectValueFromFontSize( fontSizes, sliderValue ) );
-	};
-
 	const items = getSelectOptions( fontSizes, disableCustomFontSizes );
 	const rangeControlNumberId = `components-range-control__number#${ instanceId }`;
 	return (
@@ -120,7 +115,7 @@ function FontSizePicker( {
 					label={ __( 'Custom Size' ) }
 					value={ value || '' }
 					initialPosition={ fallbackFontSize }
-					onChange={ onSliderChangeValue }
+					onChange={ onChange }
 					min={ 12 }
 					max={ 100 }
 					beforeIcon="editor-textcolor"


### PR DESCRIPTION
Fixes #18716 
This commit prevent the "Custom" option still showing up in the font sizes drop down when  a WordPress theme uses the `add_theme_support( 'disable-custom-font-sizes' )` feature.

## Description
There was no check on the `disableCustomFontSizes`variable. The custom object `{ slug: 'custom', name: __( 'Custom' ) }` was then always added even when not wanted.

## How has this been tested?
Tested with Storybook and npm test

## Types of changes
Bug Fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.