### PR TITLE
Refactor block toolbar to use hooks.

### DIFF
--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -1,18 +1,37 @@
 /**
  * WordPress dependencies
  */
-import { withSelect } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
-import BlockSwitcher from '../block-switcher';
-import MultiBlocksSwitcher from '../block-switcher/multi-blocks-switcher';
 import BlockControls from '../block-controls';
 import BlockFormatControls from '../block-format-controls';
 import BlockSettingsMenu from '../block-settings-menu';
+import BlockSwitcher from '../block-switcher';
+import MultiBlocksSwitcher from '../block-switcher/multi-blocks-switcher';
 
-function BlockToolbar( { blockClientIds, isValid, mode } ) {
+export default function BlockToolbar() {
+	const { blockClientIds, isValid, mode } = useSelect( ( select ) => {
+		const {
+			getBlockMode,
+			getSelectedBlockClientIds,
+			isBlockValid,
+		} = select( 'core/block-editor' );
+		const selectedBlockClientIds = getSelectedBlockClientIds();
+
+		return {
+			blockClientIds: selectedBlockClientIds,
+			isValid: selectedBlockClientIds.length === 1 ?
+				isBlockValid( selectedBlockClientIds[ 0 ] ) :
+				null,
+			mode: selectedBlockClientIds.length === 1 ?
+				getBlockMode( selectedBlockClientIds[ 0 ] ) :
+				null,
+		};
+	} );
+
 	if ( blockClientIds.length === 0 ) {
 		return null;
 	}
@@ -39,18 +58,3 @@ function BlockToolbar( { blockClientIds, isValid, mode } ) {
 		</div>
 	);
 }
-
-export default withSelect( ( select ) => {
-	const {
-		getBlockMode,
-		getSelectedBlockClientIds,
-		isBlockValid,
-	} = select( 'core/block-editor' );
-	const blockClientIds = getSelectedBlockClientIds();
-
-	return {
-		blockClientIds,
-		isValid: blockClientIds.length === 1 ? isBlockValid( blockClientIds[ 0 ] ) : null,
-		mode: blockClientIds.length === 1 ? getBlockMode( blockClientIds[ 0 ] ) : null,
-	};
-} )( BlockToolbar );

--- a/packages/block-editor/src/components/block-toolbar/index.native.js
+++ b/packages/block-editor/src/components/block-toolbar/index.native.js
@@ -1,20 +1,35 @@
 /**
  * WordPress dependencies
  */
-import { withSelect } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import BlockControls from '../block-controls';
 import BlockFormatControls from '../block-format-controls';
-
-/**
- * Internal dependencies
- */
 import UngroupButton from '../ungroup-button';
 
-export const BlockToolbar = ( { blockClientIds, isValid, mode } ) => {
+export default function BlockToolbar() {
+	const { blockClientIds, isValid, mode } = useSelect( ( select ) => {
+		const {
+			getBlockMode,
+			getSelectedBlockClientIds,
+			isBlockValid,
+		} = select( 'core/block-editor' );
+		const selectedBlockClientIds = getSelectedBlockClientIds();
+
+		return {
+			blockClientIds: selectedBlockClientIds,
+			isValid: selectedBlockClientIds.length === 1 ?
+				isBlockValid( selectedBlockClientIds[ 0 ] ) :
+				null,
+			mode: selectedBlockClientIds.length === 1 ?
+				getBlockMode( selectedBlockClientIds[ 0 ] ) :
+				null,
+		};
+	} );
+
 	if ( blockClientIds.length === 0 ) {
 		return null;
 	}
@@ -30,19 +45,4 @@ export const BlockToolbar = ( { blockClientIds, isValid, mode } ) => {
 			) }
 		</>
 	);
-};
-
-export default withSelect( ( select ) => {
-	const {
-		getBlockMode,
-		getSelectedBlockClientIds,
-		isBlockValid,
-	} = select( 'core/block-editor' );
-	const blockClientIds = getSelectedBlockClientIds();
-
-	return {
-		blockClientIds,
-		isValid: blockClientIds.length === 1 ? isBlockValid( blockClientIds[ 0 ] ) : null,
-		mode: blockClientIds.length === 1 ? getBlockMode( blockClientIds[ 0 ] ) : null,
-	};
-} )( BlockToolbar );
+}


### PR DESCRIPTION
## Description
I refactored `BlockToolbar` (both standard and native versions) to use React hooks. There should be no behavioral changes in this PR.

## How has this been tested?
I tested to make sure everything was working on desktop. I am unable to test the native version, but I can see no reason why it wouldn't work.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->