### PR TITLE
Block Editor: Fix multi-select inspector padding

### DIFF
--- a/packages/block-editor/src/components/multi-selection-inspector/style.scss
+++ b/packages/block-editor/src/components/multi-selection-inspector/style.scss
@@ -1,8 +1,7 @@
 .block-editor-multi-selection-inspector__card {
 	display: flex;
 	align-items: flex-start;
-	margin: -16px;
-	padding: 16px;
+	padding: $grid-size-large;
 }
 
 .block-editor-multi-selection-inspector__card-content {


### PR DESCRIPTION
Fixes #17975.
Possibly related: #17880 (cc @jorgefilipecosta ?)

This pull request seeks to resolve an issue where the block inspector does not have sufficient padding for multi-selections. It appears that the sidebar area previously had some default padding that was intended to be offset by the multi-inspector, and that this padding no longer exists. The inspector can simply apply its own padding.

These changes also use the variable `$grid-size-large` to align with that of the single block inspector card (see #17880). There should be no effective change, since `$grid-size-large` is the same `16px` value.

Before|After
---|---
![Before](https://user-images.githubusercontent.com/1779930/69904313-2b7cfe00-1373-11ea-9c62-3da7d5d7c53d.png)|![After](https://user-images.githubusercontent.com/1779930/69904306-1e600f00-1373-11ea-859d-88e05476aaae.png)

**Testing Instructions:**

1. Navigate to Posts > Add New
2. Insert multiple blocks
3. Select multiple blocks
4. Verify padding displays as expected in sidebar inspector title