### PR TITLE
Core Data: Add Suspense compatible `__experimentalReadSelect` and use it in refactoring the `PostAuthor` component.

### DIFF
--- a/packages/components/src/custom-select/index.js
+++ b/packages/components/src/custom-select/index.js
@@ -18,18 +18,6 @@ const stateReducer = (
 	{ selectedItem },
 	{ type, changes, props: { items } }
 ) => {
-	// TODO: Remove this.
-	// eslint-disable-next-line no-console
-	console.debug(
-		'Selected Item: ',
-		selectedItem,
-		'Type: ',
-		type,
-		'Changes: ',
-		changes,
-		'Items: ',
-		items
-	);
 	switch ( type ) {
 		case useSelect.stateChangeTypes.ToggleButtonKeyDownArrowDown:
 			// If we already have a selected item, try to select the next one,

--- a/packages/data/src/index.js
+++ b/packages/data/src/index.js
@@ -109,6 +109,50 @@ export const select = defaultRegistry.select;
 export const __experimentalResolveSelect = defaultRegistry.__experimentalResolveSelect;
 
 /**
+ * Given the name of a registered store, returns an object containing the store's
+ * selectors as Suspense compatible resource creators.
+ *
+ * When a resource creator is called, the arguments are forwarded to the relevant
+ * selector and an object with a `read` and a `useRead` method is returned.
+ *
+ * `read` attempts to read the selector's resolved value, but suspends up to the
+ * nearest Suspense boundary if its resolver is still running. It will also throw
+ * any errors in the selector or resolver.
+ *
+ * `useRead` is a hook that calls and subscribes to the selector. It's useful when you
+ * expect a selector's value to change and you want a component tree to rerender
+ * when it does so that `.read` calls run again.
+ *
+ * @see https://reactjs.org/docs/concurrent-mode-suspense.html
+ *
+ * @param {string} name Store name.
+ *
+ * @example
+ * ```js
+ * const { __experimentalReadSelect } = wp.data;
+ * const { Suspense } = wp.element;
+ *
+ * const hammerPrice = __experimentalReadSelect( 'my-shop' ).getPrice( 'hammer' );
+ * function Hammer() {
+ * 	return <div>{ hammerPrice.read() }</div>;
+ * }
+ *
+ * export default function MyShop() {
+ * 	// hammerPrice.useRead() // Optionally subscribe to changes.
+ * 	return (
+ * 		<Suspense fallback={ <div>Loading...</div> }>
+ * 			<Hammer />
+ * 		</Suspense>
+ * 	);
+ * }
+ * ```
+ *
+ * @return {Object} Object containing the store's Suspense selector resource creators.
+ */
+export const __experimentalReadSelect =
+	defaultRegistry.__experimentalReadSelect;
+
+/**
  * Given the name of a registered store, returns an object of the store's action creators.
  * Calling an action creator will cause it to be dispatched, updating the state value accordingly.
  *

--- a/packages/editor/src/components/post-author/index.js
+++ b/packages/editor/src/components/post-author/index.js
@@ -1,67 +1,46 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
-import { withInstanceId, compose } from '@wordpress/compose';
-import { Component } from '@wordpress/element';
-import { withSelect, withDispatch } from '@wordpress/data';
+import { __experimentalReadSelect, useDispatch } from '@wordpress/data';
 import { decodeEntities } from '@wordpress/html-entities';
+import { CustomSelect, Spinner } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { Suspense } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import PostAuthorCheck from './check';
 
-export class PostAuthor extends Component {
-	constructor() {
-		super( ...arguments );
+const authorId = __experimentalReadSelect( 'core/editor' ).getEditedPostAttribute(
+	'author'
+);
+const authors = __experimentalReadSelect( 'core' ).getAuthors();
+const PostAuthor = () => {
+	authorId.useRead(); // Subscribe to changes.
+	const { editPost } = useDispatch( 'core/editor' );
+	const setAuthorId = ( { selectedItem: { key: author } } ) =>
+		editPost( { author } );
+	const items = authors
+		.read()
+		.map( ( author ) => ( { key: author.id, name: decodeEntities( author.name ) } ) );
+	return (
+		<PostAuthorCheck>
+			<CustomSelect
+				className="editor-post-author__select"
+				label={ __( 'Author' ) }
+				items={ items }
+				onSelectedItemChange={ setAuthorId }
+				selectedItem={ items.find( ( item ) => item.key === authorId.read() ) }
+			/>
+		</PostAuthorCheck>
+	);
+};
 
-		this.setAuthorId = this.setAuthorId.bind( this );
-	}
-
-	setAuthorId( event ) {
-		const { onUpdateAuthor } = this.props;
-		const { value } = event.target;
-		onUpdateAuthor( Number( value ) );
-	}
-
-	render() {
-		const { postAuthor, instanceId, authors } = this.props;
-		const selectId = 'post-author-selector-' + instanceId;
-
-		// Disable reason: A select with an onchange throws a warning
-
-		/* eslint-disable jsx-a11y/no-onchange */
-		return (
-			<PostAuthorCheck>
-				<label htmlFor={ selectId }>{ __( 'Author' ) }</label>
-				<select
-					id={ selectId }
-					value={ postAuthor }
-					onChange={ this.setAuthorId }
-					className="editor-post-author__select"
-				>
-					{ authors.map( ( author ) => (
-						<option key={ author.id } value={ author.id }>{ decodeEntities( author.name ) }</option>
-					) ) }
-				</select>
-			</PostAuthorCheck>
-		);
-		/* eslint-enable jsx-a11y/no-onchange */
-	}
-}
-
-export default compose( [
-	withSelect( ( select ) => {
-		return {
-			postAuthor: select( 'core/editor' ).getEditedPostAttribute( 'author' ),
-			authors: select( 'core' ).getAuthors(),
-		};
-	} ),
-	withDispatch( ( dispatch ) => ( {
-		onUpdateAuthor( author ) {
-			dispatch( 'core/editor' ).editPost( { author } );
-		},
-	} ) ),
-	withInstanceId,
-] )( PostAuthor );
+export default () => {
+	return (
+		<Suspense fallback={ <Spinner /> }>
+			<PostAuthor />
+		</Suspense>
+	);
+};


### PR DESCRIPTION
## Description

This PR starts to explore `core-data` integration with the new [React Suspense APIs from Concurrent Mode](https://reactjs.org/docs/concurrent-mode-intro.html), by implementing a Suspense-boundary compatible version of `select`, `__experimentalReadSelect`, that suspends while resolvers are still running, and using it in refactoring the `PostAuthor` component:

```js
/**
 * WordPress dependencies
 */
import { __experimentalReadSelect, useDispatch } from '@wordpress/data';
import { decodeEntities } from '@wordpress/html-entities';
import { CustomSelect, Spinner } from '@wordpress/components';
import { __ } from '@wordpress/i18n';
import { Suspense } from '@wordpress/element';

/**
 * Internal dependencies
 */
import PostAuthorCheck from './check';

const authorId = __experimentalReadSelect( 'core/editor' ).getEditedPostAttribute(
	'author'
);
const authors = __experimentalReadSelect( 'core' ).getAuthors();
const PostAuthor = () => {
	authorId.useRead(); // Subscribe to changes.
	const { editPost } = useDispatch( 'core/editor' );
	const setAuthorId = ( { selectedItem: { key: author } } ) =>
		editPost( { author } );
	const items = authors
		.read()
		.map( ( author ) => ( { key: author.id, name: decodeEntities( author.name ) } ) );
	return (
		<PostAuthorCheck>
			<CustomSelect
				className="editor-post-author__select"
				label={ __( 'Author' ) }
				items={ items }
				onSelectedItemChange={ setAuthorId }
				selectedItem={ items.find( ( item ) => item.key === authorId.read() ) }
			/>
		</PostAuthorCheck>
	);
};

export default () => {
	return (
		<Suspense fallback={ <Spinner /> }>
			<PostAuthor />
		</Suspense>
	);
};
```

The doc explains what it returns and how it behaves:

```js
/**
 * Given the name of a registered store, returns an object containing the store's
 * selectors as Suspense compatible resource creators.
 *
 * When a resource creator is called, the arguments are forwarded to the relevant
 * selector and an object with a `read` and a `useRead` method is returned.
 *
 * `read` attempts to read the selector's resolved value, but suspends up to the
 * nearest Suspense boundary if its resolver is still running. It will also throw
 * any errors in the selector or resolver.
 *
 * `useRead` is a hook that calls and subscribes to the selector. It's useful when you
 * expect a selector's value to change and you want a component tree to rerender
 * when it does so that `.read` calls run again.
 *
 * @see https://reactjs.org/docs/concurrent-mode-suspense.html
 *
 * @param {string} name Store name.
 *
 * @example
 * ```js
 * const { __experimentalReadSelect } = wp.data;
 * const { Suspense } = wp.element;
 *
 * const hammerPrice = __experimentalReadSelect( 'my-shop' ).getPrice( 'hammer' );
 * function Hammer() {
 * 	return <div>{ hammerPrice.read() }</div>;
 * }
 *
 * export default function MyShop() {
 * 	// hammerPrice.useRead() // Optionally subscribe to changes.
 * 	return (
 * 		<Suspense fallback={ <div>Loading...</div> }>
 * 			<Hammer />
 * 		</Suspense>
 * 	);
 * }
 * ```
 *
 * @return {Object} Object containing the store's Suspense selector resource creators.
 */
export const __experimentalReadSelect =
	defaultRegistry.__experimentalReadSelect;
```

## How has this been tested?

It was verified that the `PostAuthor` component still works as expected after the refactor.

## Types of Changes

*New Feature:* `core-data` now has an experimental Suspense-boundary compatible version of `select`, `__experimentalReadSelect`, for managing resolver loading states more declaratively.

## Checklist:

- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
