### PR TITLE
Add missing actions and tests for lockPostAutosaving, unlockPostAutosaving

### DIFF
--- a/docs/designers-developers/developers/data/data-core-editor.md
+++ b/docs/designers-developers/developers/data/data-core-editor.md
@@ -1127,6 +1127,23 @@ _Related_
 
 -   insertDefaultBlock in core/block-editor store.
 
+<a name="lockPostAutosaving" href="#lockPostAutosaving">#</a> **lockPostAutosaving**
+
+Returns an action object used to signal that post autosaving is locked.
+
+_Usage_
+
+    // Lock post autosaving with the lock key `mylock`:
+    wp.data.dispatch( 'core/editor' ).lockPostAutosaving( 'mylock' );
+
+_Parameters_
+
+-   _lockName_ `string`: The lock name.
+
+_Returns_
+
+-   `Object`: Action object
+
 <a name="lockPostSaving" href="#lockPostSaving">#</a> **lockPostSaving**
 
 Returns an action object used to signal that post saving is locked.
@@ -1385,6 +1402,23 @@ Action generator for trashing the current post in the editor.
 <a name="undo" href="#undo">#</a> **undo**
 
 Returns an action object used in signalling that undo history should pop.
+
+<a name="unlockPostAutosaving" href="#unlockPostAutosaving">#</a> **unlockPostAutosaving**
+
+Returns an action object used to signal that post autosaving is unlocked.
+
+_Usage_
+
+    // Unlock post saving with the lock key `mylock`:
+    wp.data.dispatch( 'core/editor' ).unlockPostAutosaving( 'mylock' );
+
+_Parameters_
+
+-   _lockName_ `string`: The lock name.
+
+_Returns_
+
+-   `Object`: Action object
 
 <a name="unlockPostSaving" href="#unlockPostSaving">#</a> **unlockPostSaving**
 

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -638,6 +638,47 @@ export function unlockPostSaving( lockName ) {
 }
 
 /**
+ * Returns an action object used to signal that post autosaving is locked.
+ *
+ * @param  {string} lockName The lock name.
+ *
+ * @example
+ * ```
+ * // Lock post autosaving with the lock key `mylock`:
+ * wp.data.dispatch( 'core/editor' ).lockPostAutosaving( 'mylock' );
+ * ```
+ *
+ * @return {Object} Action object
+ */
+export function lockPostAutosaving( lockName ) {
+	return {
+		type: 'LOCK_POST_AUTOSAVING',
+		lockName,
+	};
+}
+
+
+/**
+ * Returns an action object used to signal that post autosaving is unlocked.
+ *
+ * @param  {string} lockName The lock name.
+ *
+ * @example
+ * ```
+ * // Unlock post saving with the lock key `mylock`:
+ * wp.data.dispatch( 'core/editor' ).unlockPostAutosaving( 'mylock' );
+ * ```
+ *
+ * @return {Object} Action object
+ */
+export function unlockPostAutosaving( lockName ) {
+	return {
+		type: 'UNLOCK_POST_AUTOSAVING',
+		lockName,
+	};
+}
+
+/**
  * Returns an action object used to signal that the blocks have been updated.
  *
  * @param {Array}   blocks  Block Array.

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -657,7 +657,6 @@ export function lockPostAutosaving( lockName ) {
 	};
 }
 
-
 /**
  * Returns an action object used to signal that post autosaving is unlocked.
  *

--- a/packages/editor/src/store/test/actions.js
+++ b/packages/editor/src/store/test/actions.js
@@ -634,4 +634,24 @@ describe( 'Editor actions', () => {
 			} );
 		} );
 	} );
+
+	describe( 'lockPostAutosaving', () => {
+		it( 'should return the LOCK_POST_AUTOSAVING action', () => {
+			const result = actions.lockPostAutosaving( 'test' );
+			expect( result ).toEqual( {
+				type: 'LOCK_POST_AUTOSAVING',
+				lockName: 'test',
+			} );
+		} );
+	} );
+
+	describe( 'unlockPostAutosaving', () => {
+		it( 'should return the UNLOCK_POST_AUTOSAVING action', () => {
+			const result = actions.unlockPostAutosaving( 'test' );
+			expect( result ).toEqual( {
+				type: 'UNLOCK_POST_AUTOSAVING',
+				lockName: 'test',
+			} );
+		} );
+	} );
 } );


### PR DESCRIPTION
## Description
Add missing actions for https://github.com/WordPress/gutenberg/pull/16249

The original PR was missing the actions for the post autosave lock. These are inbtroduced here along with tests.

## How has this been tested?
* Create a new post 
* Make changes and note autosave firing
* Lock autosaving: in the console, type `wp.data.dispatch( 'core/editor' ).lockPostAutosaving( 'mylock' );`
* Make changes, note autosaving does not occur. Regular updates work as expected (clicking the update button)
* Unlock autosaving: in the console, type `wp.data.dispatch( 'core/editor' ).unlockPostAutosaving( 'mylock' );`


## Types of changes
* Add actions for `lockPostAutosaving` and `unlockPostAutosaving` with matching tests.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
