### PR TITLE
Fix alignment of date picker days when used in block

### DIFF
--- a/packages/components/src/date-time/style.scss
+++ b/packages/components/src/date-time/style.scss
@@ -85,6 +85,11 @@
 
 	.DayPicker_weekHeader {
 		top: 50px;
+		.DayPicker_weekHeader_ul {
+			margin: 1px 0;
+			padding-left: 0;
+			padding-right: 0;
+		}
 	}
 
 	&.is-description-visible .DayPicker,


### PR DESCRIPTION
## Description

Currently if the date picker component is used within a block the day header is misaligned due to inherited editor styles. This PR applies specific margin and padding styles at a higher specificity to prevent this overriding.

## How has this been tested?
Tested visually

## Screenshots 

Before:

<img width="474" alt="before-date" src="https://user-images.githubusercontent.com/3629020/69924662-6a48ba80-1511-11ea-8846-9651fc7c3cc6.png">

After: 

<img width="408" alt="after-date" src="https://user-images.githubusercontent.com/3629020/69924664-6ddc4180-1511-11ea-8b94-d695a7ba2f47.png">

## Types of changes
CSS only change

Fixes #17129