### PR TITLE
Fix button toggles.

### DIFF
--- a/packages/components/src/toolbar-button/style.scss
+++ b/packages/components/src/toolbar-button/style.scss
@@ -1,6 +1,36 @@
 .components-toolbar__control.components-button {
+	display: inline-flex;
+	align-items: flex-end;
+	margin: 0;
+	padding: 3px;
+	outline: none;
+	cursor: pointer;
+	position: relative;
 	width: $icon-button-size;
 	height: $icon-button-size;
+
+	// Unset icon button styles
+	&:not([aria-disabled="true"]):not(.is-default):active,
+	&:not([aria-disabled="true"]):hover,
+	&:not([aria-disabled="true"]):focus {
+		outline: none;
+		box-shadow: none;
+		background: none;
+		border: none;
+	}
+
+	// Disabled
+	&:disabled {
+		cursor: default;
+	}
+
+	& > svg {
+		padding: 5px;
+		border-radius: $radius-round-rectangle;
+		height: 30px;
+		width: 30px;
+		box-sizing: border-box;
+	}
 
 	// Subscript for numbered icon buttons, like headings
 	&[data-subscript] svg {
@@ -21,4 +51,39 @@
 	&:not(:disabled).is-active[data-subscript]::after {
 		color: $white;
 	}
+
+
+	// Assign hover style to child element, not the button itself
+	&:not(:disabled):not([aria-disabled="true"]):hover {
+		box-shadow: none;
+	}
+
+	&:not(:disabled).is-active > svg,
+	&:not(:disabled):hover > svg {
+		@include formatting-button-style__hover;
+	}
+
+	// Active & toggled style
+	&:not(:disabled).is-active > svg {
+		@include formatting-button-style__active;
+	}
+
+	// Focus style
+	&:not(:disabled):focus > svg {
+		@include formatting-button-style__focus;
+		// Remove outline from SVG to apply on focused element - see below.
+		outline: 0;
+	}
+
+	// Microsoft Edge in high contrast mode only displays outlines on focused elements, not their children.
+	&:not(:disabled).is-active {
+		outline: 1px dotted transparent;
+		outline-offset: -2px;
+	}
+
+	// Microsoft Edge in high contrast mode only displays outlines on focused elements, not their children.
+	&:not(:disabled):focus {
+		outline: 2px solid transparent;
+	}
+
 }


### PR DESCRIPTION
Fixes #18825.

![buttons](https://user-images.githubusercontent.com/1204802/69942043-8a15b980-14e4-11ea-940e-4e9a880c1626.gif)

This restores the rules necessary for the delicate formatting. I know it's not pretty code, but I think we should restore it for now. We can revisit and very probably improve it a great deal if we look at the improvements from #18667. But that should be separate.