### PR TITLE
Try: Remove hover styles

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -179,15 +179,6 @@
 		}
 	}
 
-	// Hover style.
-	&.is-hovered:not(.is-navigate-mode) > .block-editor-block-list__block-edit::before {
-		box-shadow: -$block-left-border-width 0 0 0 $dark-opacity-light-500;
-
-		.is-dark-theme & {
-			box-shadow: -$block-left-border-width 0 0 0 $light-opacity-light-400;
-		}
-	}
-
 	// Spotlight mode.
 	&.is-focus-mode:not(.is-multi-selected) {
 		opacity: 0.5;

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -451,11 +451,6 @@
 			}
 		}
 
-		// If the block movers are visible, push the breadcrumb down to make room for them.
-		.block-editor-block-mover.is-visible + .block-editor-block-list__breadcrumb {
-			top: (-$block-padding - $block-left-border-width - ($grid-size-small / 2));
-		}
-
 		// Align block toolbar to floated content.
 		// Extra specificity is needed to avoid applying this to innerblocks.
 		@include break-small() {
@@ -486,11 +481,6 @@
 
 	// Full-wide.
 	&[data-align="full"] {
-		// Position hover label on the left for the top level block.
-		> .block-editor-block-list__block-edit > .block-editor-block-list__breadcrumb {
-			left: 0;
-		}
-
 		> .block-editor-block-list__block-edit {
 			margin-left: -$block-padding;
 			margin-right: -$block-padding;
@@ -945,60 +935,24 @@
 
 
 /**
- * Hover label
+ * Block Label for Navigation/Selection Mode
  */
 
 .block-editor-block-list__breadcrumb {
-	position: absolute;
-	line-height: 1;
-	z-index: z-index(".block-editor-block-list__breadcrumb");
+	display: none;
 
-	// Position in the top left of the border.
-	left: -$block-padding - $block-left-border-width;
-	top: (($block-padding * -2) - $block-left-border-width);
-
-	.components-toolbar {
-		border: none;
-		line-height: 1;
-		font-family: $default-font;
-		font-size: 11px;
-		padding: 4px 4px;
-		background: $light-gray-500;
-		color: $dark-gray-900;
-		transition: box-shadow 0.1s linear;
-		@include reduce-motion("transition");
-
-		.components-button {
-			font-size: inherit;
-			line-height: inherit;
-			padding: 0;
-		}
-
-		.is-dark-theme & {
-			background: $dark-gray-600;
-			color: $white;
-		}
-	}
-
-	// Remove negative left breadcrumb position for left aligned blocks.
-	[data-align="left"] & {
-		left: 0;
-	}
-
-	// Right-align the breadcrumb for right-aligned blocks.
-	[data-align="right"] & {
-		left: auto;
-		right: 0;
-	}
-
-	// In navigation mode, this should appear similarly to the block toolbar.
 	.is-navigate-mode & {
+		display: block;
+		position: absolute;
+		line-height: 1;
+		z-index: z-index(".block-editor-block-list__breadcrumb");
 
 		// Position in the top left of the border.
 		left: -$block-padding;
 		top: -$block-toolbar-height - $block-padding;
 
 		.components-toolbar {
+			display: flex;
 			background: $white;
 			border: $border-width solid $blue-medium-focus;
 			border-left: none;

--- a/packages/block-library/src/classic/editor.scss
+++ b/packages/block-library/src/classic/editor.scss
@@ -254,11 +254,6 @@ div[data-type="core/freeform"] {
 		border-left-color: transparent;
 	}
 
-	// Don't show block type label for classic block
-	&.is-hovered .block-editor-block-list__breadcrumb {
-		display: none;
-	}
-
 	.editor-block-contextual-toolbar + div {
 		margin-top: 0;
 		padding-top: 0;

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -35,10 +35,8 @@
 		border-color: transparent !important; // !important used to keep the selector from growing any more complex.
 	}
 
-	// Hide the breadcrumb.
 	// Hide the sibling inserter.
-	.wp-block-navigation .block-editor-block-list__insertion-point,
-	.wp-block-navigation .block-editor-block-list__breadcrumb {
+	.wp-block-navigation .block-editor-block-list__insertion-point {
 		display: none;
 	}
 

--- a/packages/block-library/src/social-links/editor.scss
+++ b/packages/block-library/src/social-links/editor.scss
@@ -58,11 +58,9 @@
 		margin-bottom: 0;
 	}
 
-	// Hide the breadcrumb.
 	// Hide the mover.
 	// Hide the sibling inserter.
-	.wp-block-social-links .block-editor-block-list__insertion-point,
-	.wp-block-social-links .block-editor-block-list__breadcrumb { // Needs specificity.
+	.wp-block-social-links .block-editor-block-list__insertion-point { // Needs specificity.
 		display: none;
 	}
 }

--- a/packages/editor/src/components/post-title/style.scss
+++ b/packages/editor/src/components/post-title/style.scss
@@ -82,16 +82,6 @@
 		}
 	}
 
-	&:not(.is-focus-mode):not(.has-fixed-toolbar):not(.is-selected) {
-		.editor-post-title__input:hover {
-			box-shadow: -$block-left-border-width 0 0 0 $dark-opacity-light-500;
-
-			.is-dark-theme & {
-				box-shadow: -$block-left-border-width 0 0 0 $light-opacity-light-400;
-			}
-		}
-	}
-
 	&.is-focus-mode .editor-post-title__input {
 		opacity: 0.5;
 		transition: opacity 0.1s linear;


### PR DESCRIPTION
As part of ongoing efforts to improve block selection navigation mode has recieved some visual enhancements and ability to "drill down" through nested blocks (#17088). In addition to this, a breadcrumb bar has been added (#17089), which provides a permanently visible visual indicator of which block you're editing, and a quick tool to let you pick the parent. 

In light of that, there is less reason to have a hover style for blocks at all. So this PR removes it, and with it, the block breadrumb. 

![hvoer](https://user-images.githubusercontent.com/1204802/69950749-3ad78500-14f4-11ea-941b-5fdf464d024f.gif)

There are a number of reasons for considering this. 

1. It drastically reduces the cognitive load of mousing over a document. This is especially visible as it helps surface the sibling inserter instead:

![sibling](https://user-images.githubusercontent.com/1204802/69950757-3d39df00-14f4-11ea-972e-beac284f1563.gif)

2. The breadcrumb on hover has not proven that useful in practice. Given that it's plenty visible in Navigation Mode, and the block type including the parent hierarchy is surfaced in the breadcrumb, the hover label is redundant.

![navigation mode](https://user-images.githubusercontent.com/1204802/69950245-60b05a00-14f3-11ea-93ff-f8cd35fdfd4d.gif)

**3. Perhaps most importantly, it helps suggest the best interface for selecting parent blocks.**

In comlex nesting situations, the hover style would "flicker on" when tiny hit areas were hovered. But this is not the best way to select the parent block, as it requires extremely fine motor skills. The presence of the hover effect seemed to suggest that this is the primary interface for selecting parent blocks, when in fact the breadcrumb bar, or the selection tool are far better equipped methods to do so.

![columns](https://user-images.githubusercontent.com/1204802/69950881-74a88b80-14f4-11ea-8998-04325a777470.gif)

Would love your thoughts, thank you!