### PR TITLE
Fix padding regression with appender

### DIFF
--- a/packages/block-editor/src/components/block-list-appender/style.scss
+++ b/packages/block-editor/src/components/block-list-appender/style.scss
@@ -1,7 +1,7 @@
 // These styles are only applied to the appender when it appears inside of a block.
 // Otherwise the default appender may be improperly positioned in some themes.
 .block-editor-block-list__block .block-list-appender {
-	margin: $block-padding;
+	margin: $block-padding 0;
 
 	// Add additional margin to the appender when inside a group with a background color.
 	// If changing this, be sure to sync up with group/editor.scss line 13.

--- a/packages/block-library/src/columns/editor.scss
+++ b/packages/block-library/src/columns/editor.scss
@@ -126,12 +126,6 @@
 		margin-top: $block-padding*2;
 		margin-bottom: $block-padding*2;
 	}
-
-	// When the individual column block is selected, the nested padding overrules
-	// some of this margin. We need to adjust the appender spacing again as a result.
-	[data-type="core/column"].is-selected .block-list-appender {
-		margin: $block-padding 0;
-	}
 }
 
 /**


### PR DESCRIPTION
Earlier today, I merged #18105. As part of that, two existing issues were visually surfaced. Technically the bugs were already present, but the issues were masked by the padding rules.

The issue existed in the first place because the appender component compensated for horizontal margins that were refactored away in #17877. 

This affected groups and columns that had the placeholder appender. 

Group, before:

![group before](https://user-images.githubusercontent.com/1204802/69952636-ea622680-14f7-11ea-8064-2c636355e6b3.gif)

Group, after:

![group after](https://user-images.githubusercontent.com/1204802/69952642-ecc48080-14f7-11ea-8e89-ca23b86c5a9c.gif)

Columns before:

![cols before](https://user-images.githubusercontent.com/1204802/69952651-f0580780-14f7-11ea-9dd8-769ba386c28d.gif)

Columns after:

![cols after](https://user-images.githubusercontent.com/1204802/69952658-f2ba6180-14f7-11ea-836e-6e7fc55f84f5.gif)
