### PR TITLE
Polish the new multi-select style

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -157,9 +157,43 @@
 		}
 	}
 
-	// Selected style.
-	&.is-multi-selected {
+	// Hover style.
+	&.is-hovered:not(.is-navigate-mode) > .block-editor-block-list__block-edit::before {
+		box-shadow: -$block-left-border-width 0 0 0 $dark-opacity-light-500;
+
+		.is-dark-theme & {
+			box-shadow: -$block-left-border-width 0 0 0 $light-opacity-light-400;
+		}
+	}
+
+	// Spotlight mode.
+	&.is-focus-mode:not(.is-multi-selected) {
+		opacity: 0.5;
+		transition: opacity 0.1s linear;
+		@include reduce-motion("transition");
+
+		&:not(.is-focused) .block-editor-block-list__block,
+		&.is-focused {
+			opacity: 1;
+		}
+	}
+}
+
+
+/**
+ * Cross-Block Selection
+ */
+
+.block-editor-block-list__layout {
+
+	// The primary indicator of selection is the native selection marker.
+	// To indicate multiple blocks, we provide an additional selection indicator.
+	.block-editor-block-list__block.is-multi-selected {
+
 		> .block-editor-block-list__block-edit::before {
+			// Todo: start by limiting it to not nest
+			// Then hide selection in placeholders and do something else
+			// Then make a mockup for multi block selection for the new UI — this includes an exception for contiguous paragraphs
 			border-left-color: $dark-opacity-light-800;
 			box-shadow: inset $block-left-border-width 0 0 0 $dark-gray-500;
 
@@ -179,22 +213,11 @@
 		}
 	}
 
-	// Spotlight mode.
-	&.is-focus-mode:not(.is-multi-selected) {
-		opacity: 0.5;
-		transition: opacity 0.1s linear;
-		@include reduce-motion("transition");
-
-		&:not(.is-focused) .block-editor-block-list__block,
-		&.is-focused {
-			opacity: 1;
-		}
+	// The additional marker, we limit only to top level blocks.
+	.block-editor-block-list__block.is-multi-selected .block-editor-block-list__block.is-multi-selected > .block-editor-block-list__block-edit::before {
+		box-shadow: none;
 	}
 }
-
-/**
- * Cross-block selection
- */
 
 
 /**

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -191,9 +191,6 @@
 	.block-editor-block-list__block.is-multi-selected {
 
 		> .block-editor-block-list__block-edit::before {
-			// Todo: start by limiting it to not nest
-			// Then hide selection in placeholders and do something else
-			// Then make a mockup for multi block selection for the new UI — this includes an exception for contiguous paragraphs
 			border-left-color: $dark-opacity-light-800;
 			box-shadow: inset $block-left-border-width 0 0 0 $dark-gray-500;
 
@@ -216,6 +213,13 @@
 	// The additional marker, we limit only to top level blocks.
 	.block-editor-block-list__block.is-multi-selected .block-editor-block-list__block.is-multi-selected > .block-editor-block-list__block-edit::before {
 		box-shadow: none;
+	}
+
+	// Provide exceptions for placeholders.
+	.components-placeholder {
+		::selection {
+			background: transparent;
+		}
 	}
 }
 


### PR DESCRIPTION
In #16835, a new native selection style was introduced when selecting across blocks. This solves an accessibility issue with coloring the selection style, and enables the "inactive browser selection color" to work. 

It also surfaced some small issues, notably one around nested blocks reported in https://github.com/WordPress/gutenberg/pull/16835#issuecomment-559908451, and one with the placeholder selection seeming off. 

In this PR I tried to tackle both. Worth noting that with multi-selection, we offer _two_ indicators of selection:

1. The native selection marker. This is the usually-blue marker behind text.
2. An additional left border, matching the one of individual blocks being edited.

To improve the nesting situation, I limited that style to top level blocks:

![Screenshot 2019-12-02 at 12 19 15](https://user-images.githubusercontent.com/1204802/69956169-978c6d00-14ff-11ea-99a1-a31c790f9578.png)
![Screenshot 2019-12-02 at 12 19 41](https://user-images.githubusercontent.com/1204802/69956174-99563080-14ff-11ea-94ac-f0c7bd644605.png)

To improve the placeholder issue, I made the selection style transparent there, as it is misleading, suggesting you copy the text from the placeholder description. Given the presence of the additional marker, the one referred to in 2 above, it shouldn't be necessary:

![Screenshot 2019-12-02 at 12 26 26](https://user-images.githubusercontent.com/1204802/69956290-dd493580-14ff-11ea-94dc-715377189f59.png)

---

To me, the above feels like a good first step at polishing the multi-select experience. However it also highlights some issues that perhaps deserve more love, notably:

- In full-wide blocks, the left border is invisible.
- While the placeholder does look selected, it could look _more_ selected.

It seems like some of the efforts being explored in #18667 could inspire a better visual style for multi-selection. In that vein, I explored using the suggested visuals to imagine some new options. 

**Selecting Text**:

_It remains to be seen how feasible this is_. We discussed it a bit in https://github.com/WordPress/gutenberg/pull/16811#issuecomment-537825651, but if it is possible, then selecting between two text blocks should look as it does in every other text editor — like so:

<img width="1440" alt="Multi Selection, Between Text Blocks" src="https://user-images.githubusercontent.com/1204802/69957382-de2f9680-1502-11ea-890b-9ed4c9a07ffe.png">

As suggested, text blocks would make up the exception to the multi select rules, and as soon as you select beyond text and into another type of block, you'd get something more familiar. Perhaps something like this:

<img width="1440" alt="Multi Selection, Mixed Blocks, V1" src="https://user-images.githubusercontent.com/1204802/69957443-f7384780-1502-11ea-84bb-0865414f7ffa.png">

The above is inspired by Navigation/Selection mode, and works to establish a singular style for when a block is actually selected (i.e. where when you press Delete, the blocks are removed). 

I don't believe the following is possible, because it might need an additional wrapper around selections, and being aware of wide/fullwide scenarios. But if it were possible (JS positioned border?), It seems like the following would be even better:

<img width="1440" alt="Multi Selection, Mixed Blocks, V2" src="https://user-images.githubusercontent.com/1204802/69957543-2c449a00-1503-11ea-86ad-059804d88940.png">

... that is, 1px borders around each individual blocks, and a 2px border that surrounds the whole selection. @ellatrix would appreciate your thoughts!