### PR TITLE
Fix #18825: Styles for the toggled state in the ToolbarButton added back

### DIFF
--- a/packages/components/src/icon-button/style.scss
+++ b/packages/components/src/icon-button/style.scss
@@ -38,3 +38,17 @@
 		box-shadow: none;
 	}
 }
+
+.components-icon-button.is-active {
+	padding: 3px;
+	outline: none;
+
+	& > svg {
+		padding: 5px;
+		border-radius: $radius-round-rectangle;
+		height: 30px;
+		width: 30px;
+		box-sizing: border-box;
+		@include formatting-button-style__active;
+	}
+}

--- a/packages/components/src/icon-button/style.scss
+++ b/packages/components/src/icon-button/style.scss
@@ -38,17 +38,3 @@
 		box-shadow: none;
 	}
 }
-
-.components-icon-button.is-active {
-	padding: 3px;
-	outline: none;
-
-	& > svg {
-		padding: 5px;
-		border-radius: $radius-round-rectangle;
-		height: 30px;
-		width: 30px;
-		box-sizing: border-box;
-		@include formatting-button-style__active;
-	}
-}

--- a/packages/components/src/toolbar-button/style.scss
+++ b/packages/components/src/toolbar-button/style.scss
@@ -21,4 +21,19 @@
 	&:not(:disabled).is-active[data-subscript]::after {
 		color: $white;
 	}
+
+	&.is-active {
+		padding: 3px;
+		outline: none;
+	}
+
+	&.is-active > svg {
+		padding: 5px;
+		border-radius: $radius-round-rectangle;
+		height: 30px;
+		width: 30px;
+		box-sizing: border-box;
+		@include formatting-button-style__active;
+	}
 }
+


### PR DESCRIPTION
## Description
Fixes #18825.

> I noticed that this change created regression for toolbar buttons:
> ![toggled-buttons](https://user-images.githubusercontent.com/699132/69875740-26aa4280-12be-11ea-94f9-9289ad0cb71f.gif)
> 
> When they are toggled they no longer change their visual appearance. This is how it worked before 7.0:
> 
> ![Screen Shot 2019-11-29 at 15 38 14](https://user-images.githubusercontent.com/699132/69875808-47729800-12be-11ea-88aa-d3f6bdd294a2.png)
> 
> It was introduced in #18631.

An alternative to #18860.

### After

![Screen Shot 2019-12-02 at 13 10 48](https://user-images.githubusercontent.com/699132/69958479-31a2e400-1505-11ea-979b-38f5e059d1e1.png)

![Screen Shot 2019-12-02 at 13 11 15](https://user-images.githubusercontent.com/699132/69958507-3ff10000-1505-11ea-8815-6d271e511faa.png)
![Screen Shot 2019-12-02 at 13 11 35](https://user-images.githubusercontent.com/699132/69958519-48e1d180-1505-11ea-9440-635ea14e96a7.png)


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
