### PR TITLE
Editor: Separate editor notices by border instead of margin

### DIFF
--- a/packages/editor/src/components/editor-notices/style.scss
+++ b/packages/editor/src/components/editor-notices/style.scss
@@ -23,7 +23,8 @@
 .components-editor-notices__pinned {
 	.components-notice {
 		box-sizing: border-box;
-		margin: 0 0 5px;
+		margin: 0;
+		border-bottom: 1px solid rgba(0, 0, 0, 0.2);
 		padding: 6px 12px;
 
 		// Min-height matches the height of a single-line notice with an action button.


### PR DESCRIPTION
Closes #18762 

This pull request seeks to update the styling of editor notices, to use a border instead of margins to distinguish multiple stacked notices. As noted in #18762, this should help improve appearance when shown atop a themed editor background color. It also occupies less vertical space, in case there are many notices present.

Before|After
---|---
![Before](https://user-images.githubusercontent.com/1779930/69975299-ef71a680-14f4-11ea-9450-1c2557fc4705.png)|![After](https://user-images.githubusercontent.com/1779930/69975274-e41e7b00-14f4-11ea-848c-443d2b8ff5ae.png)

**Testing Instructions:**

1. Active a theme with background color (e.g. TwentyTwenty)
2. Navigate to Posts > Add New
3. Insert the following script in your Developer Tools Console to add a few notices to the screen:

```js
[ 'info', 'warning', 'error', 'success' ].forEach( ( status ) => wp.data.dispatch( 'core/notices' ).createNotice( status, status ) )
```

4. Verify notices appear nicely stacked