### PR TITLE
Edit Post: Render metaboxes as single seamless unit

### DIFF
--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -105,8 +105,6 @@ function Layout( { isMobileViewport } ) {
 							{ isRichEditingEnabled && mode === 'visual' && <VisualEditor /> }
 							<div className="edit-post-layout__metaboxes">
 								<MetaBoxes location="normal" />
-							</div>
-							<div className="edit-post-layout__metaboxes">
 								<MetaBoxes location="advanced" />
 							</div>
 							{ isMobileViewport && sidebarIsOpened && <ScrollLock /> }

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -3,7 +3,6 @@
 }
 .edit-post-layout__metaboxes:not(:empty) {
 	border-top: $border-width solid $light-gray-500;
-	margin-top: 10px;
 	padding: 10px 0 10px;
 	clear: both;
 


### PR DESCRIPTION
Related: #18044, #18762

This pull request seeks to improve styling interoperability between the meta box area and a themed editor background. As seen in the "Before" screenshot below, there is a plain-white margin gap which appears above the meta box area. With these changes, the margin is removed, and meta boxes changed to being contained within a single container element.

Before|After
---|---
![Before](https://user-images.githubusercontent.com/1779930/69978301-3746fc80-14fa-11ea-83cc-c1afb8f5fda1.png)|![After](https://user-images.githubusercontent.com/1779930/69978282-2f875800-14fa-11ea-806d-e16b30fe6c63.png)

**Testing Instructions:**

In the default development environment, you can enable the "Gutenberg Test Plugin, Meta Box" plugin to display a meta box in the metabox area.

Furthermore, I used Advanced Custom Fields to add many more meta boxes. ACF does not appear to have the option to make a meta box for the ["advanced" context](https://developer.wordpress.org/reference/functions/add_meta_box/), so I tested this by manually editing [this line](https://github.com/WordPress/gutenberg/blob/2fd13b663ef82778e0f4fcfe963ff178fa0e0b6d/packages/e2e-tests/plugins/meta-box.php#L26) to `'advanced',`.

1. Navigate to Posts > Add New
2. Verify with meta boxes shown, or with no meta boxes shown, that there is no gap between meta box area (if present) and the rest of the editor canvas