### PR TITLE
Templates: Remove duplicate queries fetching template parts

### DIFF
--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -155,6 +155,7 @@ function gutenberg_find_template( $template_file ) {
 			'post_name__in'  => $slugs,
 			'orderby'        => 'post_name__in',
 			'posts_per_page' => 1,
+			'no_found_rows'  => true,
 		)
 	);
 

--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -158,8 +158,7 @@ function gutenberg_find_template( $template_file ) {
 		)
 	);
 
-	$template_posts        = $template_query->get_posts();
-	$current_template_post = array_shift( $template_posts );
+	$current_template_post = $template_query->next_post();
 
 	// Build map of template slugs to their priority in the current hierarchy.
 	$slug_priorities = array_flip( $slugs );

--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -159,7 +159,7 @@ function gutenberg_find_template( $template_file ) {
 		)
 	);
 
-	$current_template_post = $template_query->next_post();
+	$current_template_post = $template_query->have_posts() ? $template_query->next_post() : null;
 
 	// Build map of template slugs to their priority in the current hierarchy.
 	$slug_priorities = array_flip( $slugs );


### PR DESCRIPTION
## Description

The `get_posts()` method of `WP_Query` re-runs the main query. It's not the correct method to use when fetching posts inside a loop or once the main query has run.

As we're only fetching one post inside `gutenberg_find_template()`, we can use the `next_post()` method to fetch it. This removes the duplicated main query.

In addition, `no_found_rows` can be used in this query to improve query performance.

## How has this been tested?

Prior to this change, the main query to fetch the template post was run twice. This can be verified using a debugging plugin such as Query Monitor.

## Screenshots

### Before (4 relevant queries)

<img width="1319" alt="" src="https://user-images.githubusercontent.com/208434/69997903-19ef4e00-154d-11ea-81f9-f5e7c2212f62.png">

### After (1 relevant query)

<img width="1320" alt="Screenshot 2019-12-02 at 21 50 36" src="https://user-images.githubusercontent.com/208434/69998267-d21cf680-154d-11ea-86d4-804f4082f0f4.png">


## Types of changes

Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
