### PR TITLE
Docs: Include TypeScript type checking in Testing Overview

### DIFF
--- a/docs/contributors/testing-overview.md
+++ b/docs/contributors/testing-overview.md
@@ -27,7 +27,12 @@ Assuming you've followed the [instructions](/docs/contributors/getting-started.m
 npm test
 ```
 
-Code style in JavaScript is enforced using [ESLint](http://eslint.org/). The above `npm test` will execute both unit tests and code linting. Code linting can be verified independently by running `npm run lint`. ESLint can also fix not all, but many issues automatically by running `npm run lint:fix`. To reduce the likelihood of unexpected build failures caused by code styling issues, you're encouraged to [install an ESLint integration for your editor](https://eslint.org/docs/user-guide/integrations) and/or create a [git pre-commit hook](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks) containing the `npm run lint:fix` command.
+Linting is static code analysis used to enforce coding standards and to avoid potential errors. This project uses [ESLint](http://eslint.org/) and [TypeScript's JavaScript type-checking](https://www.typescriptlang.org/docs/handbook/type-checking-javascript-files.html) to capture these issues. While the above `npm test` will execute both unit tests and code linting, code linting can be verified independently by running `npm run lint`. Some issues can be fixed automatically by running `npm run lint:fix`.
+
+To improve your developer workflow, you're encouraged to install an editor linting integration.
+
+- [ESLint Editor Integrations](https://eslint.org/docs/user-guide/integrations)
+- [TypeScript Editor Support](https://github.com/Microsoft/TypeScript/wiki/TypeScript-Editor-Support)
 
 To run unit tests only, without the linter, use `npm run test-unit` instead.
 


### PR DESCRIPTION
Previously: #17014

This pull request seeks to include testing details about the TypeScript type checking added in #17014, as an extension of the existing documentation for linting overview. This can also serve as a reference for developers in suggesting appropriate editor integrations for TypeScript error highlighting.

**Testing Instructions:**

As this only includes documentation changes, there is no expected impact on the application runtime.