### PR TITLE
Fix array to string conversion in Navigation block server side rendering

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -76,8 +76,8 @@ function render_block_navigation( $attributes, $content, $block ) {
  */
 function build_navigation_html( $block, $colors ) {
 	$html = '';
-
-	$class_attribute = sprintf( ' class="%s"', esc_attr( $colors['css_classes'] ? 'wp-block-navigation-item__link ' . $colors['css_classes'] : 'wp-block-navigation-item__link' ) );
+	$css_classes = implode( ' ', $colors['css_classes'] );
+	$class_attribute = sprintf( ' class="%s"', esc_attr( ! empty ( $css_classes ) ? 'wp-block-navigation-item__link ' . $css_classes : 'wp-block-navigation-item__link' ) );
 	$style_attribute = $colors['inline_styles'] ? sprintf( ' style="%s"', esc_attr( $colors['inline_styles'] ) ) : '';
 
 	foreach ( (array) $block['innerBlocks'] as $key => $block ) {

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -30,7 +30,7 @@ function build_css_colors( $attributes ) {
 
 	if ( $has_named_text_color ) {
 		// Add the color class.
-		$colors['css_classes'][] = sprintf( ' has-%s-color', $attributes['textColor'] );
+		$colors['css_classes'][] = sprintf( 'has-%s-color', $attributes['textColor'] );
 	} elseif ( $has_custom_text_color ) {
 		// Add the custom color inline style.
 		$colors['inline_styles'] = sprintf( 'color: %s;', $attributes['customTextColor'] );
@@ -77,7 +77,7 @@ function render_block_navigation( $attributes, $content, $block ) {
 function build_navigation_html( $block, $colors ) {
 	$html = '';
 	$css_classes = implode( ' ', $colors['css_classes'] );
-	$class_attribute = sprintf( ' class="%s"', esc_attr( ! empty ( $css_classes ) ? 'wp-block-navigation-item__link ' . $css_classes : 'wp-block-navigation-item__link' ) );
+	$class_attribute = sprintf( ' class="%s"', esc_attr( ! empty( $css_classes ) ? 'wp-block-navigation-item__link ' . $css_classes : 'wp-block-navigation-item__link' ) );
 	$style_attribute = $colors['inline_styles'] ? sprintf( ' style="%s"', esc_attr( $colors['inline_styles'] ) ) : '';
 
 	foreach ( (array) $block['innerBlocks'] as $key => $block ) {

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -75,8 +75,8 @@ function render_block_navigation( $attributes, $content, $block ) {
  * @return string Returns  an HTML list from innerBlocks.
  */
 function build_navigation_html( $block, $colors ) {
-	$html = '';
-	$css_classes = implode( ' ', $colors['css_classes'] );
+	$html            = '';
+	$css_classes     = implode( ' ', $colors['css_classes'] );
 	$class_attribute = sprintf( ' class="%s"', esc_attr( ! empty( $css_classes ) ? 'wp-block-navigation-item__link ' . $css_classes : 'wp-block-navigation-item__link' ) );
 	$style_attribute = $colors['inline_styles'] ? sprintf( ' style="%s"', esc_attr( $colors['inline_styles'] ) ) : '';
 


### PR DESCRIPTION
## Description
Currently there is a bug in master where the server side rendering of the Navigation block does an array to string conversion and that generates a Notice.

## How has this been tested?
Tested locally,

## Types of changes
I `implode` the array in a string with each element glued by an empty space. The notice is gone. 