### PR TITLE
Fix: Use Colors crashes if contrast checkers are not specified

### DIFF
--- a/packages/block-editor/src/components/colors/use-colors.js
+++ b/packages/block-editor/src/components/colors/use-colors.js
@@ -200,6 +200,9 @@ export default function __experimentalUseColors(
 	const detectedBackgroundColorRef = useRef();
 	const detectedColorRef = useRef();
 	const ColorDetector = useMemo( () => {
+		if ( ! contrastCheckers ) {
+			return undefined;
+		}
 		let needsBackgroundColor = false;
 		let needsColor = false;
 		for ( const { backgroundColor, textColor } of castArray( contrastCheckers ) ) {


### PR DESCRIPTION
## Description
Currently, useColors hook crashes in situations where contrast checking is not enabled.
This is making the navigation block crash right after being inserter and populated with menu items.
This PR adds a check to fix this issue.

## How has this been tested?
I added the navigation block.
I inserted menu items from top-level pages.
I verified the block does not crashes.
I tried to use the heading block normally, and it still worked as expected.