### PR TITLE
Template Loader: Use `glob` constant instead of numeric value.

### DIFF
--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -147,12 +147,12 @@ function gutenberg_find_template( $template_file ) {
 	// See if there is a theme block template with higher priority than the resolved template post.
 	$higher_priority_block_template_path     = null;
 	$higher_priority_block_template_priority = PHP_INT_MAX;
-	$block_template_files                    = glob( get_stylesheet_directory() . '/block-templates/*.html', GLOB_NOSORT ) ?: array();
+	$block_template_files                    = glob( get_stylesheet_directory() . '/block-templates/*.html' ) ?: array();
 	if ( is_child_theme() ) {
-			$block_template_files = array_merge( $block_template_files, glob( get_template_directory() . '/block-templates/*.html', GLOB_NOSORT ) ?: array() );
+			$block_template_files = array_merge( $block_template_files, glob( get_template_directory() . '/block-templates/*.html' ) ?: array() );
 	}
 	if ( gutenberg_is_experiment_enabled( 'gutenberg-full-site-editing-demo' ) ) {
-		$block_template_files = array_merge( $block_template_files, glob( dirname( __FILE__ ) . '/demo-block-templates/*.html', GLOB_NOSORT ) ?: array() );
+		$block_template_files = array_merge( $block_template_files, glob( dirname( __FILE__ ) . '/demo-block-templates/*.html' ) ?: array() );
 	}
 	foreach ( $block_template_files as $path ) {
 		$theme_block_template_priority = $slug_priorities[ basename( $path, '.html' ) ];

--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -147,12 +147,12 @@ function gutenberg_find_template( $template_file ) {
 	// See if there is a theme block template with higher priority than the resolved template post.
 	$higher_priority_block_template_path     = null;
 	$higher_priority_block_template_priority = PHP_INT_MAX;
-	$block_template_files                    = glob( get_stylesheet_directory() . '/block-templates/*.html', 1 ) ?: array();
+	$block_template_files                    = glob( get_stylesheet_directory() . '/block-templates/*.html', GLOB_NOSORT ) ?: array();
 	if ( is_child_theme() ) {
-			$block_template_files = array_merge( $block_template_files, glob( get_template_directory() . '/block-templates/*.html', 1 ) ?: array() );
+			$block_template_files = array_merge( $block_template_files, glob( get_template_directory() . '/block-templates/*.html', GLOB_NOSORT ) ?: array() );
 	}
 	if ( gutenberg_is_experiment_enabled( 'gutenberg-full-site-editing-demo' ) ) {
-		$block_template_files = array_merge( $block_template_files, glob( dirname( __FILE__ ) . '/demo-block-templates/*.html', 1 ) ?: array() );
+		$block_template_files = array_merge( $block_template_files, glob( dirname( __FILE__ ) . '/demo-block-templates/*.html', GLOB_NOSORT ) ?: array() );
 	}
 	foreach ( $block_template_files as $path ) {
 		$theme_block_template_priority = $slug_priorities[ basename( $path, '.html' ) ];


### PR DESCRIPTION
Fixes #18876

## Description

This PR changes the calls to `glob` in the template loader to use the constant `GLOB_NOSORT` instead of the literal `1` which seems to have been causing issues in certain environments.

## How has this been tested?

It was verified that template loading still works as expected.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
