### PR TITLE
Fix reusable blocks being too tall

### DIFF
--- a/packages/block-library/src/block/editor.scss
+++ b/packages/block-library/src/block/editor.scss
@@ -1,3 +1,3 @@
 .edit-post-visual-editor .block-library-block__reusable-block-container .block-editor-writing-flow__click-redirect {
-	height: auto;
+	min-height: auto;
 }


### PR DESCRIPTION
## Description
Fixes #18901. The issue was caused by #18732 changing a `height` style rule to a `min-height` rule, while not changing the styling in `packages/block-library/src/block/editor.scss` that was intended to override it.

## Screenshots
Before:
![image](https://user-images.githubusercontent.com/19592990/70106740-1241af00-160a-11ea-8fc6-788178e19b6b.png)

After:
![image](https://user-images.githubusercontent.com/19592990/70107554-76657280-160c-11ea-95d7-8e3598ba0a96.png)