### PR TITLE
[RNMobile] Media & Text - Adds missing imageFillStyles

### DIFF
--- a/packages/block-library/src/media-text/media-container.native.js
+++ b/packages/block-library/src/media-text/media-container.native.js
@@ -44,14 +44,7 @@ import SvgIconRetry from './icon-retry';
  */
 const ALLOWED_MEDIA_TYPES = [ MEDIA_TYPE_IMAGE, MEDIA_TYPE_VIDEO ];
 
-export function imageFillStyles( url, focalPoint ) {
-	return url ?
-		{
-			backgroundImage: `url(${ url })`,
-			backgroundPosition: focalPoint ? `${ focalPoint.x * 100 }% ${ focalPoint.y * 100 }%` : `50% 50%`,
-		} :
-		{};
-}
+export { imageFillStyles } from './media-container.js';
 
 class MediaContainer extends Component {
 	constructor() {

--- a/packages/block-library/src/media-text/media-container.native.js
+++ b/packages/block-library/src/media-text/media-container.native.js
@@ -44,6 +44,15 @@ import SvgIconRetry from './icon-retry';
  */
 const ALLOWED_MEDIA_TYPES = [ MEDIA_TYPE_IMAGE, MEDIA_TYPE_VIDEO ];
 
+export function imageFillStyles( url, focalPoint ) {
+	return url ?
+		{
+			backgroundImage: `url(${ url })`,
+			backgroundPosition: focalPoint ? `${ focalPoint.x * 100 }% ${ focalPoint.y * 100 }%` : `50% 50%`,
+		} :
+		{};
+}
+
 class MediaContainer extends Component {
 	constructor() {
 		super( ...arguments );


### PR DESCRIPTION
## Description
Adds the missing `imageFillStyles` in the mobile implementation of the Media & Text block.

`Gutenberg-mobile` PR -> https://github.com/wordpress-mobile/gutenberg-mobile/pull/1646

## Types of changes
Bug fix https://github.com/wordpress-mobile/gutenberg-mobile/issues/1650

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows the accessibility standards.
- [x] My code has proper inline documentation.
- [x] I've included developer documentation if appropriate.
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR.