### PR TITLE
Nav Block: adds basic items justification controls

### DIFF
--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -176,12 +176,12 @@ function Navigation( {
 
 				<Toolbar
 					icon={ attributes.itemsJustification ? `editor-align${ attributes.itemsJustification }` : 'editor-alignleft' }
-					label="Change items justification"
+					label={ __( 'Change items justification' ) }
 					isCollapsed
 					controls={ [
-						{ icon: 'editor-alignleft', title: 'Justify items left', isActive: 'left' === attributes.itemsJustification, onClick: handleItemsAlignment( 'left' ) },
-						{ icon: 'editor-aligncenter', title: 'Justify items center', isActive: 'center' === attributes.itemsJustification, onClick: handleItemsAlignment( 'center' ) },
-						{ icon: 'editor-alignright', title: 'Justify items right', isActive: 'right' === attributes.itemsJustification, onClick: handleItemsAlignment( 'right' ) },
+						{ icon: 'editor-alignleft', title: __( 'Justify items left' ), isActive: 'left' === attributes.itemsJustification, onClick: handleItemsAlignment( 'left' ) },
+						{ icon: 'editor-aligncenter', title: __( 'Justify items center' ), isActive: 'center' === attributes.itemsJustification, onClick: handleItemsAlignment( 'center' ) },
+						{ icon: 'editor-alignright', title: __( 'Justify items right' ), isActive: 'right' === attributes.itemsJustification, onClick: handleItemsAlignment( 'right' ) },
 					] }
 				/>
 

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -26,8 +26,8 @@ import {
 	PanelBody,
 	Placeholder,
 	Spinner,
-	ToolbarGroup,
 	Toolbar,
+	ToolbarGroup,
 } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { escape } from 'lodash';
+import { escape, upperFirst } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -39,6 +39,7 @@ import { __ } from '@wordpress/i18n';
 import useBlockNavigator from './use-block-navigator';
 import BlockNavigationList from './block-navigation-list';
 import BlockColorsStyleSelector from './block-colors-selector';
+import * as navIcons from './icons';
 
 function Navigation( {
 	attributes,
@@ -167,13 +168,13 @@ function Navigation( {
 		<Fragment>
 			<BlockControls>
 				<Toolbar
-					icon={ attributes.itemsJustification ? `editor-align${ attributes.itemsJustification }` : 'editor-alignleft' }
+					icon={ attributes.itemsJustification ? navIcons[ `justify${ upperFirst( attributes.itemsJustification ) }Icon` ] : navIcons.justifyLeftIcon }
 					label={ __( 'Change items justification' ) }
 					isCollapsed
 					controls={ [
-						{ icon: 'editor-alignleft', title: __( 'Justify items left' ), isActive: 'left' === attributes.itemsJustification, onClick: handleItemsAlignment( 'left' ) },
-						{ icon: 'editor-aligncenter', title: __( 'Justify items center' ), isActive: 'center' === attributes.itemsJustification, onClick: handleItemsAlignment( 'center' ) },
-						{ icon: 'editor-alignright', title: __( 'Justify items right' ), isActive: 'right' === attributes.itemsJustification, onClick: handleItemsAlignment( 'right' ) },
+						{ icon: navIcons.justifyLeftIcon, title: __( 'Justify items left' ), isActive: 'left' === attributes.itemsJustification, onClick: handleItemsAlignment( 'left' ) },
+						{ icon: navIcons.justifyCenterIcon, title: __( 'Justify items center' ), isActive: 'center' === attributes.itemsJustification, onClick: handleItemsAlignment( 'center' ) },
+						{ icon: navIcons.justifyRightIcon, title: __( 'Justify items right' ), isActive: 'right' === attributes.itemsJustification, onClick: handleItemsAlignment( 'right' ) },
 					] }
 				/>
 				<ToolbarGroup>

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -88,9 +88,9 @@ function Navigation( {
 	//
 	const handleItemsAlignment = ( align ) => {
 		return () => {
-			const itemAlignment = attributes.itemAlignment === align ? undefined : align;
+			const itemsJustification = attributes.itemsJustification === align ? undefined : align;
 			setAttributes( {
-				itemAlignment,
+				itemsJustification,
 			} );
 		};
 	};
@@ -159,7 +159,7 @@ function Navigation( {
 	}
 
 	const blockClassNames = classnames( 'wp-block-navigation', {
-		[ `items-alignment-${ attributes.itemAlignment }` ]: attributes.itemAlignment,
+		[ `items-justification-${ attributes.itemsJustification }` ]: attributes.itemsJustification,
 	} );
 
 	// UI State: rendered Block UI
@@ -175,13 +175,13 @@ function Navigation( {
 				/>
 
 				<Toolbar
-					icon={ attributes.itemAlignment ? `editor-align${ attributes.itemAlignment }` : 'editor-alignleft' }
-					label="Change items alignment"
+					icon={ attributes.itemsJustification ? `editor-align${ attributes.itemsJustification }` : 'editor-alignleft' }
+					label="Change items justification"
 					isCollapsed
 					controls={ [
-						{ icon: 'editor-alignleft', title: 'Align items left', isActive: 'left' === attributes.itemAlignment, onClick: handleItemsAlignment( 'left' ) },
-						{ icon: 'editor-aligncenter', title: 'Align items center', isActive: 'center' === attributes.itemAlignment, onClick: handleItemsAlignment( 'center' ) },
-						{ icon: 'editor-alignright', title: 'Align items right', isActive: 'right' === attributes.itemAlignment, onClick: handleItemsAlignment( 'right' ) },
+						{ icon: 'editor-alignleft', title: 'Justify items left', isActive: 'left' === attributes.itemsJustification, onClick: handleItemsAlignment( 'left' ) },
+						{ icon: 'editor-aligncenter', title: 'Justify items center', isActive: 'center' === attributes.itemsJustification, onClick: handleItemsAlignment( 'center' ) },
+						{ icon: 'editor-alignright', title: 'Justify items right', isActive: 'right' === attributes.itemsJustification, onClick: handleItemsAlignment( 'right' ) },
 					] }
 				/>
 

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -166,14 +166,6 @@ function Navigation( {
 	return (
 		<Fragment>
 			<BlockControls>
-				<ToolbarGroup>
-					{ navigatorToolbarButton }
-				</ToolbarGroup>
-				<BlockColorsStyleSelector
-					value={ TextColor.color }
-					onChange={ TextColor.setColor }
-				/>
-
 				<Toolbar
 					icon={ attributes.itemsJustification ? `editor-align${ attributes.itemsJustification }` : 'editor-alignleft' }
 					label={ __( 'Change items justification' ) }
@@ -183,6 +175,13 @@ function Navigation( {
 						{ icon: 'editor-aligncenter', title: __( 'Justify items center' ), isActive: 'center' === attributes.itemsJustification, onClick: handleItemsAlignment( 'center' ) },
 						{ icon: 'editor-alignright', title: __( 'Justify items right' ), isActive: 'right' === attributes.itemsJustification, onClick: handleItemsAlignment( 'right' ) },
 					] }
+				/>
+				<ToolbarGroup>
+					{ navigatorToolbarButton }
+				</ToolbarGroup>
+				<BlockColorsStyleSelector
+					value={ TextColor.color }
+					onChange={ TextColor.setColor }
 				/>
 
 			</BlockControls>

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { escape } from 'lodash';
+import classnames from 'classnames';
 
 /**
  * WordPress dependencies
@@ -26,6 +27,7 @@ import {
 	Placeholder,
 	Spinner,
 	ToolbarGroup,
+	Toolbar,
 } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 
@@ -84,6 +86,14 @@ function Navigation( {
 	//
 	// HANDLERS
 	//
+	const handleItemsAlignment = ( align ) => {
+		return () => {
+			const itemAlignment = attributes.itemAlignment === align ? undefined : align;
+			setAttributes( {
+				itemAlignment,
+			} );
+		};
+	};
 
 	const handleCreateEmpty = () => {
 		const emptyNavLinkBlock = createBlock( 'core/navigation-link' );
@@ -148,6 +158,10 @@ function Navigation( {
 		);
 	}
 
+	const blockClassNames = classnames( 'wp-block-navigation', {
+		[ `items-alignment-${ attributes.itemAlignment }` ]: attributes.itemAlignment,
+	} );
+
 	// UI State: rendered Block UI
 	return (
 		<Fragment>
@@ -159,6 +173,18 @@ function Navigation( {
 					value={ TextColor.color }
 					onChange={ TextColor.setColor }
 				/>
+
+				<Toolbar
+					icon={ attributes.itemAlignment ? `editor-align${ attributes.itemAlignment }` : 'editor-alignleft' }
+					label="Change items alignment"
+					isCollapsed
+					controls={ [
+						{ icon: 'editor-alignleft', title: 'Align items left', isActive: 'left' === attributes.itemAlignment, onClick: handleItemsAlignment( 'left' ) },
+						{ icon: 'editor-aligncenter', title: 'Align items center', isActive: 'center' === attributes.itemAlignment, onClick: handleItemsAlignment( 'center' ) },
+						{ icon: 'editor-alignright', title: 'Align items right', isActive: 'right' === attributes.itemAlignment, onClick: handleItemsAlignment( 'right' ) },
+					] }
+				/>
+
 			</BlockControls>
 			{ navigatorModal }
 			<InspectorControls>
@@ -181,7 +207,7 @@ function Navigation( {
 				</PanelBody>
 			</InspectorControls>
 			<TextColor>
-				<div className="wp-block-navigation">
+				<div className={ blockClassNames }>
 					{ ! hasExistingNavItems && isRequestingPages && <><Spinner /> { __( 'Loading Navigation…' ) } </> }
 
 					<InnerBlocks

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -87,25 +87,29 @@ function Navigation( {
 	//
 	// HANDLERS
 	//
-	const handleItemsAlignment = ( align ) => {
+	function handleItemsAlignment( align ) {
 		return () => {
 			const itemsJustification = attributes.itemsJustification === align ? undefined : align;
 			setAttributes( {
 				itemsJustification,
 			} );
 		};
-	};
+	}
 
-	const handleCreateEmpty = () => {
+	function handleCreateEmpty() {
 		const emptyNavLinkBlock = createBlock( 'core/navigation-link' );
 		updateNavItemBlocks( [ emptyNavLinkBlock ] );
-	};
+	}
 
-	const handleCreateFromExistingPages = () => {
+	function handleCreateFromExistingPages() {
 		updateNavItemBlocks( defaultPagesNavigationItems );
-	};
+	}
 
 	const hasPages = hasResolvedPages && pages && pages.length;
+
+	const blockClassNames = classnames( 'wp-block-navigation', {
+		[ `items-justification-${ attributes.itemsJustification }` ]: attributes.itemsJustification,
+	} );
 
 	// If we don't have existing items or the User hasn't
 	// indicated they want to automatically add top level Pages
@@ -158,10 +162,6 @@ function Navigation( {
 			</Fragment>
 		);
 	}
-
-	const blockClassNames = classnames( 'wp-block-navigation', {
-		[ `items-justification-${ attributes.itemsJustification }` ]: attributes.itemsJustification,
-	} );
 
 	// UI State: rendered Block UI
 	return (

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -6,7 +6,18 @@
 	.wp-block-navigation .block-editor-inner-blocks > .block-editor-block-list__layout {
 		margin-left: 0;
 		margin-right: 0;
+	}
 
+	.wp-block-navigation.items-alignment-left .block-editor-inner-blocks > .block-editor-block-list__layout {
+		justify-content: flex-start;
+	}
+
+	.wp-block-navigation.items-alignment-center .block-editor-inner-blocks > .block-editor-block-list__layout {
+		justify-content: center;
+	}
+
+	.wp-block-navigation.items-alignment-right .block-editor-inner-blocks > .block-editor-block-list__layout {
+		justify-content: flex-end;
 	}
 
 	// 2. Remove paddings on subsequent immediate children.

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -2,6 +2,11 @@
 // @todo: eventually we may add a feature that lets a parent container absorb the block UI of a child block.
 // When that happens, leverage that instead of the following overrides.
 [data-type="core/navigation"] {
+
+	.wp-block-navigation .block-editor-inner-blocks {
+		flex: 1; // expand to fill available space required for justification
+	}
+
 	// 1. Reset margins on immediate innerblocks container.
 	.wp-block-navigation .block-editor-inner-blocks > .block-editor-block-list__layout {
 		margin-left: 0;

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -8,15 +8,15 @@
 		margin-right: 0;
 	}
 
-	.wp-block-navigation.items-alignment-left .block-editor-inner-blocks > .block-editor-block-list__layout {
+	.wp-block-navigation.items-justification-left .block-editor-inner-blocks > .block-editor-block-list__layout {
 		justify-content: flex-start;
 	}
 
-	.wp-block-navigation.items-alignment-center .block-editor-inner-blocks > .block-editor-block-list__layout {
+	.wp-block-navigation.items-justification-center .block-editor-inner-blocks > .block-editor-block-list__layout {
 		justify-content: center;
 	}
 
-	.wp-block-navigation.items-alignment-right .block-editor-inner-blocks > .block-editor-block-list__layout {
+	.wp-block-navigation.items-justification-right .block-editor-inner-blocks > .block-editor-block-list__layout {
 		justify-content: flex-end;
 	}
 

--- a/packages/block-library/src/navigation/icons.js
+++ b/packages/block-library/src/navigation/icons.js
@@ -1,0 +1,20 @@
+/**
+ * WordPress dependencies
+ */
+import { Path, SVG } from '@wordpress/components';
+
+export const justifyLeftIcon = (
+	<SVG width="20" height="20" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+		<Path d="M11 16v-3h10v-2H11V8l-4 4 4 4zM5 4H3v16h2V4z" />
+	</SVG>
+);
+
+export const justifyCenterIcon = (
+	<SVG width="20" height="20" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+		<Path d="M5 8v3H1v2h4v3l4-4-4-4zm14 8v-3h4v-2h-4V8l-4 4 4 4zM13 4h-2v16h2V4z" />
+	</SVG>
+);
+
+export const justifyRightIcon = (
+	<SVG width="20" height="20" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><Path d="M13 8v3H3v2h10v3l4-4-4-4zm8-4h-2v16h2V4z" /></SVG>
+);

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -54,7 +54,7 @@ function render_block_navigation( $attributes, $content, $block ) {
 		$colors['css_classes'],
 		array( 'wp-block-navigation' ),
 		isset( $attributes['className'] ) ? array( $attributes['className'] ) : array(),
-		isset( $attributes['itemsJustification'] ) ? array( 'items-justification-' . $attributes['itemsJustification'] ) : array(),
+		isset( $attributes['itemsJustification'] ) ? array( 'items-justification-' . $attributes['itemsJustification'] ) : array()
 	);
 	$class_attribute = sprintf( ' class="%s"', esc_attr( implode( ' ', $classes ) ) );
 	$style_attribute = $colors['inline_styles'] ? sprintf( ' style="%s"', esc_attr( $colors['inline_styles'] ) ) : '';

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -54,7 +54,7 @@ function render_block_navigation( $attributes, $content, $block ) {
 		$colors['css_classes'],
 		array( 'wp-block-navigation' ),
 		isset( $attributes['className'] ) ? array( $attributes['className'] ) : array(),
-		isset( $attributes['itemsJustification'] ) ? array( 'items-justification-' . $attributes['itemsJustification'] ) : array(),
+		isset( $attributes['itemsJustification'] ) ? array( 'items-justified-' . $attributes['itemsJustification'] ) : array(),
 		isset( $attributes['align'] ) ? array( 'align' . $attributes['align'] ) : array()
 	);
 	$class_attribute = sprintf( ' class="%s"', esc_attr( implode( ' ', $classes ) ) );

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -127,20 +127,20 @@ function register_block_core_navigation() {
 		'core/navigation',
 		array(
 			'attributes'      => array(
-				'className'        => array(
+				'className'          => array(
 					'type' => 'string',
 				),
-				'automaticallyAdd' => array(
+				'automaticallyAdd'   => array(
 					'type'    => 'boolean',
 					'default' => false,
 				),
-				'textColor'        => array(
+				'textColor'          => array(
 					'type' => 'string',
 				),
-				'customTextColor'  => array(
+				'customTextColor'    => array(
 					'type' => 'string',
 				),
-				'itemAlignment'    => array(
+				'itemsJustification' => array(
 					'default' => 'left',
 					'type'    => 'string',
 				),

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -15,7 +15,7 @@
 function build_css_colors( $attributes ) {
 	// CSS classes.
 	$colors = array(
-		'css_classes'   => [],
+		'css_classes'   => array(),
 		'inline_styles' => '',
 	);
 
@@ -52,8 +52,8 @@ function render_block_navigation( $attributes, $content, $block ) {
 	$colors          = build_css_colors( $attributes );
 	$classes         = array_merge(
 		$colors['css_classes'],
-		[ 'wp-block-navigation' ],
-		isset( $attributes['className'] ) ? [ $attributes['className'] ] : []
+		array( 'wp-block-navigation' ),
+		isset( $attributes['className'] ) ? array( $attributes['className'] ) : array()
 	);
 	$class_attribute = sprintf( ' class="%s"', esc_attr( implode( ' ', $classes ) ) );
 	$style_attribute = $colors['inline_styles'] ? sprintf( ' style="%s"', esc_attr( $colors['inline_styles'] ) ) : '';
@@ -139,6 +139,10 @@ function register_block_core_navigation() {
 				),
 				'customTextColor'  => array(
 					'type' => 'string',
+				),
+				'itemAlignment'    => array(
+					'default' => 'left',
+					'type'    => 'string',
 				),
 			),
 

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -142,8 +142,7 @@ function register_block_core_navigation() {
 					'type' => 'string',
 				),
 				'itemsJustification' => array(
-					'default' => 'left',
-					'type'    => 'string',
+					'type' => 'string',
 				),
 			),
 

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -54,7 +54,8 @@ function render_block_navigation( $attributes, $content, $block ) {
 		$colors['css_classes'],
 		array( 'wp-block-navigation' ),
 		isset( $attributes['className'] ) ? array( $attributes['className'] ) : array(),
-		isset( $attributes['itemsJustification'] ) ? array( 'items-justification-' . $attributes['itemsJustification'] ) : array()
+		isset( $attributes['itemsJustification'] ) ? array( 'items-justification-' . $attributes['itemsJustification'] ) : array(),
+		isset( $attributes['align'] ) ? array( 'align' . $attributes['align'] ) : array()
 	);
 	$class_attribute = sprintf( ' class="%s"', esc_attr( implode( ' ', $classes ) ) );
 	$style_attribute = $colors['inline_styles'] ? sprintf( ' style="%s"', esc_attr( $colors['inline_styles'] ) ) : '';

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -53,7 +53,8 @@ function render_block_navigation( $attributes, $content, $block ) {
 	$classes         = array_merge(
 		$colors['css_classes'],
 		array( 'wp-block-navigation' ),
-		isset( $attributes['className'] ) ? array( $attributes['className'] ) : array()
+		isset( $attributes['className'] ) ? array( $attributes['className'] ) : array(),
+		isset( $attributes['itemsJustification'] ) ? array( 'items-justification-' . $attributes['itemsJustification'] ) : array(),
 	);
 	$class_attribute = sprintf( ' class="%s"', esc_attr( implode( ' ', $classes ) ) );
 	$style_attribute = $colors['inline_styles'] ? sprintf( ' style="%s"', esc_attr( $colors['inline_styles'] ) ) : '';

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -142,22 +142,16 @@
 		}
 	}
 
-	&.items-justification-left {
-		> ul {
-			justify-content: flex-start;
-		}
+	&.items-justification-left > ul {
+		justify-content: flex-start;
 	}
 
-	&.items-justification-center {
-		> ul {
-			justify-content: center;
-		}
+	&.items-justification-center > ul {
+		justify-content: center;
 	}
 
-	&.items-justification-right {
-		> ul {
-			justify-content: flex-end;
-		}
+	&.items-justification-right > ul {
+		justify-content: flex-end;
 	}
 }
 

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -142,15 +142,15 @@
 		}
 	}
 
-	&.items-justification-left > ul {
+	&.items-justified-left > ul {
 		justify-content: flex-start;
 	}
 
-	&.items-justification-center > ul {
+	&.items-justified-center > ul {
 		justify-content: center;
 	}
 
-	&.items-justification-right > ul {
+	&.items-justified-right > ul {
 		justify-content: flex-end;
 	}
 }

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -142,6 +142,23 @@
 		}
 	}
 
+	&.items-justification-left {
+		> ul {
+			justify-content: flex-start;
+		}
+	}
+
+	&.items-justification-center {
+		> ul {
+			justify-content: center;
+		}
+	}
+
+	&.items-justification-right {
+		> ul {
+			justify-content: flex-end;
+		}
+	}
 }
 
 .is-style-dark > ul > li > ul {


### PR DESCRIPTION
Closes https://github.com/WordPress/gutenberg/issues/18557.
Closes #18898.

Enables the ability to _justify_ the items within the Nav Block to the:

* left (technically `flex-start`)
* center
* right (technically `flex-end`)

This is not the same as _alignment_ controls which actually [shift the _entire_ Block](https://github.com/WordPress/gutenberg/issues/18557#issuecomment-561214391). This approach was avoided because:

1. When `left` or `right` alignment was applied the _whole_ Block became "full width".
2. It was not possible to have a block which was _both_ `full-wide` and with the items aligned to the left/right.

The approach in this PR works around that by adding a custom _justification_ control which controls the alignment of individual _items_ (taken as a whole) rather than the Block as a unit.

## Questions

* Do we need custom icons for item justification or are the text justification ones we're using ok?
* Shall we add further flexbox layout options for `space-around`, `space-between`...etc? I'm tempted to say we save that for a future PR and just get the basics merged.

## How has this been tested?

Before testing/reviewing please read [the background discussion in the Issue](https://github.com/WordPress/gutenberg/issues/18557) to understand the motivation behind the justification approach.

This has been manually tested. 

1. Add Nav Block.
2. Add lots of items.
3. Use controls to justify the items.
4. Use alignment to modify the alignment widths whilst also toggling the item justification. 
5. Check visual output corresponds correctly in both the **Editor** _and_ on the **front of site** (Theme).

### Deprecation Testing

This PR doesn't need to add a deprecation because we don't change the output of the Block until the user selects a justification option (ie: the default is don't change anything).

You can test this by

1. Switch to `master`.
2. Add Post with Nav Block with items.
3. Switch to this branch.
4. Reload your Page from `#2`.
5. Ensure the Block does not error.

## Screenshots <!-- if applicable -->
![Screen Capture on 2019-12-04 at 12-41-01](https://user-images.githubusercontent.com/444434/70143446-8a07ec00-1693-11ea-9890-cf72a4b22fcc.gif)

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
