### PR TITLE
[Mobile] Disable gallery block for now

### DIFF
--- a/packages/block-library/src/index.native.js
+++ b/packages/block-library/src/index.native.js
@@ -151,8 +151,6 @@ export const registerCoreBlocks = () => {
 		// eslint-disable-next-line no-undef
 		!! __DEV__ ? group : null,
 		spacer,
-		// eslint-disable-next-line no-undef
-		!! __DEV__ ? gallery : null,
 	].forEach( registerBlock );
 
 	setDefaultBlockName( paragraph.name );


### PR DESCRIPTION
## Description
This PR temporarily disables mobile gallery block (will re-enable in the main gallery PR).

Related gutenberg-mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1647

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
