### PR TITLE
Add side effects property to components package.json

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -20,6 +20,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"react-native": "src/index",
+	"sideEffects": false,
 	"dependencies": {
 		"@babel/runtime": "^7.4.4",
 		"@emotion/core": "10.0.22",


### PR DESCRIPTION
## Description
This PR adds `sideEffects: false` to `@wordpress/components` in order to enable tree-shaking for that library, having tree shaking reduces build sizes by a significant amount.

before `sideEffects`
```
File sizes after gzip:

  256.37 KB  build/static/js/2.7889de9e.chunk.js
  15.45 KB   build/static/css/2.8225445d.chunk.css
  780 B      build/static/js/runtime-main.c4aaabd0.js
  317 B      build/static/js/main.e8a8781c.chunk.js
``` 

after `sideEffects`

```
File sizes after gzip:

  40.61 KB (-215.77 KB)  build/static/js/2.0646c13c.chunk.js
  15.45 KB               build/static/css/2.8225445d.chunk.css
  780 B                  build/static/js/runtime-main.c4aaabd0.js
  305 B (-12 B)          build/static/js/main.fa03990e.chunk.js
```
