### PR TITLE
[Tiny PR] Multi select: fix nested blocks

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -71,6 +71,7 @@ function BlockListBlock( {
 	clientId,
 	rootClientId,
 	isSelected,
+	isMultiSelected,
 	isPartOfMultiSelection,
 	isFirstMultiSelected,
 	isTypingWithinBlock,
@@ -466,7 +467,7 @@ function BlockListBlock( {
 			'has-warning': ! isValid || !! hasError || isUnregisteredBlock,
 			'is-selected': shouldAppearSelected,
 			'is-navigate-mode': isNavigationMode,
-			'is-multi-selected': isPartOfMultiSelection,
+			'is-multi-selected': isMultiSelected,
 			'is-hovered': shouldAppearHovered,
 			'is-reusable': isReusableBlock( blockType ),
 			'is-dragging': isDragging,
@@ -688,6 +689,7 @@ const applyWithSelect = withSelect(
 		const { name, attributes, isValid } = block || {};
 
 		return {
+			isMultiSelected: isBlockMultiSelected( clientId ),
 			isPartOfMultiSelection:
 				isBlockMultiSelected( clientId ) || isAncestorMultiSelected( clientId ),
 			isFirstMultiSelected: isFirstMultiSelectedBlock( clientId ),

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -183,6 +183,11 @@ class BlockList extends Component {
 
 	setSelection() {
 		const selection = window.getSelection();
+		const {
+			onStopMultiSelect,
+			onMultiSelect,
+			getBlockParents,
+		} = this.props;
 
 		// If no selection is found, end multi selection.
 		if ( ! selection.rangeCount || selection.isCollapsed ) {
@@ -204,12 +209,16 @@ class BlockList extends Component {
 		// If the final selection doesn't leave the block, there is no multi
 		// selection.
 		if ( this.startClientId === clientId ) {
-			this.props.onStopMultiSelect();
+			onStopMultiSelect();
 			return;
 		}
 
-		this.props.onMultiSelect( this.startClientId, clientId );
-		this.props.onStopMultiSelect();
+		const startPath = [ ...getBlockParents( this.startClientId ), this.startClientId ];
+		const endPath = [ ...getBlockParents( clientId ), clientId ];
+		const depth = Math.min( startPath.length, endPath.length ) - 1;
+
+		onMultiSelect( startPath[ depth ], endPath[ depth ] );
+		onStopMultiSelect();
 	}
 
 	render() {
@@ -291,6 +300,7 @@ export default compose( [
 			hasMultiSelection,
 			getGlobalBlockCount,
 			isTyping,
+			getBlockParents,
 		} = select( 'core/block-editor' );
 
 		const { rootClientId } = ownProps;
@@ -308,6 +318,7 @@ export default compose( [
 				! isTyping() &&
 				getGlobalBlockCount() <= BLOCK_ANIMATION_THRESHOLD
 			),
+			getBlockParents,
 		};
 	} ),
 	withDispatch( ( dispatch ) => {

--- a/packages/e2e-tests/specs/editor/various/multi-block-selection.test.js
+++ b/packages/e2e-tests/specs/editor/various/multi-block-selection.test.js
@@ -293,4 +293,39 @@ describe( 'Multi-block selection', () => {
 		await testNativeSelection();
 		expect( await getSelectedFlatIndices() ).toEqual( [ 1, 2 ] );
 	} );
+
+	it( 'should select by dragging into nested block', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( '1' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '/cover' );
+		await page.keyboard.press( 'Enter' );
+		await page.click( '.components-circular-option-picker__option' );
+		await page.keyboard.type( '2' );
+		await page.keyboard.press( 'ArrowUp' );
+
+		const [ coord1, coord2 ] = await page.evaluate( () => {
+			const elements = Array.from( document.querySelectorAll( '.wp-block-paragraph' ) );
+			const rect1 = elements[ 0 ].getBoundingClientRect();
+			const rect2 = elements[ 1 ].getBoundingClientRect();
+			return [
+				{
+					x: rect1.x + ( rect1.width / 2 ),
+					y: rect1.y + ( rect1.height / 2 ),
+				},
+				{
+					x: rect2.x + ( rect2.width / 2 ),
+					y: rect2.y + ( rect2.height / 2 ),
+				},
+			];
+		} );
+
+		await page.mouse.move( coord1.x, coord1.y );
+		await page.mouse.down();
+		await page.mouse.move( coord2.x, coord2.y, { steps: 10 } );
+		await page.mouse.up();
+
+		await testNativeSelection();
+		expect( await getSelectedFlatIndices() ).toEqual( [ 1, 2 ] );
+	} );
 } );


### PR DESCRIPTION
## Description

@jasmussen reported this issue to me. Currently, you cannot select multiple block when you start or end en a different root block. This PR fixes the issue by ensuring multi selection starts and ends in the same root block.

## How has this been tested?

Create a paragraph and a cover block. Start selecting from the paragraph towards the paragraph inside the cover block. All blocks should be selected properly. Also try the reverse.

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
