### PR TITLE
Multi block selection: more responsive UI

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -254,11 +254,11 @@ function BlockListBlock( {
 	// Focus the selected block's wrapper or inner input on mount and update
 	const isMounting = useRef( true );
 	useEffect( () => {
-		if ( isSelected ) {
+		if ( isSelected && ! isMultiSelecting ) {
 			focusTabbable( ! isMounting.current );
 		}
 		isMounting.current = false;
-	}, [ isSelected ] );
+	}, [ isSelected, isMultiSelecting ] );
 
 	// Focus the first multi selected block
 	useEffect( () => {
@@ -445,6 +445,7 @@ function BlockListBlock( {
 		! hasFixedToolbar &&
 		isLargeViewport &&
 		! showEmptyBlockSideInserter &&
+		! isMultiSelecting &&
 		(
 			( isSelected && ( ! isTypingWithinBlock || isCaretWithinFormattedText ) ) ||
 			isFirstMultiSelected

--- a/packages/block-editor/src/components/multi-select-scroll-into-view/index.js
+++ b/packages/block-editor/src/components/multi-select-scroll-into-view/index.js
@@ -27,8 +27,8 @@ class MultiSelectScrollIntoView extends Component {
 	 * visible within the nearest scrollable container.
 	 */
 	scrollIntoView() {
-		const { extentClientId } = this.props;
-		if ( ! extentClientId ) {
+		const { extentClientId, isMultiSelecting } = this.props;
+		if ( ! extentClientId || isMultiSelecting ) {
 			return;
 		}
 
@@ -56,9 +56,13 @@ class MultiSelectScrollIntoView extends Component {
 }
 
 export default withSelect( ( select ) => {
-	const { getLastMultiSelectedBlockClientId } = select( 'core/block-editor' );
+	const {
+		getLastMultiSelectedBlockClientId,
+		isMultiSelecting,
+	} = select( 'core/block-editor' );
 
 	return {
 		extentClientId: getLastMultiSelectedBlockClientId(),
+		isMultiSelecting: isMultiSelecting(),
 	};
 } )( MultiSelectScrollIntoView );


### PR DESCRIPTION
## Description

Alternative to #18836.

This PR makes the multi selection UI feel more responsive by instantly changing it when the selection changes.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
Enhancement

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
