### PR TITLE
Docs: MediaPlaceholder - Change import package.

### DIFF
--- a/packages/block-editor/src/components/media-placeholder/README.md
+++ b/packages/block-editor/src/components/media-placeholder/README.md
@@ -8,7 +8,7 @@ MediaPlaceholder
 An example usage which sets the URL of the selected image to `theImage` attributes.
 
 ```
-const { MediaPlaceholder } = wp.editor;
+const { MediaPlaceholder } = wp.blockEditor;
 
 ...
 


### PR DESCRIPTION
## Description
In #14112 the mediaPlaceholder component was moved from editor into the blockEditor package. We also have to update the import statement in the Readme of this component.