### PR TITLE
add white-space: pre to verse block instead of nowrap

### DIFF
--- a/packages/block-library/src/verse/style.scss
+++ b/packages/block-library/src/verse/style.scss
@@ -1,4 +1,4 @@
 pre.wp-block-verse {
-	white-space: nowrap;
+	white-space: pre;
 	overflow: auto;
 }


### PR DESCRIPTION
Fixes #18857 

## Description
Only a change from `white-space: normal`to `white-space: pre;` for the verse block.

## How has this been tested?
npm run test

## Screenshots <!-- if applicable -->
![vers_block_before](https://user-images.githubusercontent.com/1676202/70159486-47f1a100-16b9-11ea-8058-4e6a7f173058.jpg)
![vers_block_after](https://user-images.githubusercontent.com/1676202/70159499-4cb65500-16b9-11ea-878e-a80311ef793f.jpg)


## Types of changes
Only a bug-fixing change in CSS

## Checklist:
- [x] My code is tested.