### PR TITLE
Docs: Add Gutenberg-specific JSDoc recommendations

### DIFF
--- a/docs/contributors/coding-guidelines.md
+++ b/docs/contributors/coding-guidelines.md
@@ -255,7 +255,7 @@ Since an imported type declaration can occupy an excess of the available line le
 
 Note that all custom types defined in another file can be imported.
 
-When considering which types should be made available from a WordPress package, the `@typedef` statements in the package's entrypoint script should be treated as effectively the same as its public API. It is important to be aware of this, both to avoid unintentionally exposing internal types on the public interface, and as the means by which to expose the public types of a project.
+When considering which types should be made available from a WordPress package, the `@typedef` statements in the package's entrypoint script should be treated as effectively the same as its public API. It is important to be aware of this, both to avoid unintentionally exposing internal types on the public interface, and as a way to expose the public types of a project.
 
 ```js
 // packages/data/src/index.js

--- a/docs/contributors/coding-guidelines.md
+++ b/docs/contributors/coding-guidelines.md
@@ -237,7 +237,7 @@ Custom types can also be beneficial when describing a set of predefined options.
 /**
  * Named breakpoint sizes.
  * 
- * @typedef {"huge"|"wide"|"large"|"medium"|"small"|"mobile"} WPBreakpoint
+ * @typedef {'huge'|'wide'|'large'|'medium'|'small'|'mobile'} WPBreakpoint
  */
 ```
 

--- a/docs/contributors/coding-guidelines.md
+++ b/docs/contributors/coding-guidelines.md
@@ -347,8 +347,8 @@ Similarly, use the `undefined` type only if you're expecting an explicit value o
 /**
  * Returns true if the next HTML token closes the current token.
  *
- * @param {Object}           currentToken Current token to compare with.
- * @param {Object|undefined} nextToken    Next token to compare against.
+ * @param {WPHTMLToken}           currentToken Current token to compare with.
+ * @param {WPHTMLToken|undefined} nextToken    Next token to compare against.
  *
  * @return {boolean} True if `nextToken` closes `currentToken`, false otherwise.
  */
@@ -415,7 +415,8 @@ When documenting an example, use the markdown <code>\`\`\`</code> code block to 
  * select( 'my-shop' ).getPrice( 'hammer' );
  * ```
  *
- * @return {Object} Object containing the store's selectors.
+ * @return {Object<string,WPDataSelector>} Object containing the store's
+ *                                         selectors.
  */
 ```
 

--- a/docs/contributors/coding-guidelines.md
+++ b/docs/contributors/coding-guidelines.md
@@ -231,7 +231,7 @@ Custom types should be named as succinctly as possible, while still retaining cl
  */
 ```
 
-Custom types can also be beneficial when describing a set of predefined options. While the [type union](https://jsdoc.app/tags-type.html) can be used with literal values as an inline type, using it in a custom type can afford the opportunity to describe the purpose of these options, and avoids a situation where aligning tags while still respecting a maximum line length of 80 characters becomes challenging due to the space occupied by a literal values union.
+Custom types can also be used to describe a set of predefined options. While the [type union](https://jsdoc.app/tags-type.html) can be used with literal values as an inline type, it can be difficult to align tags while still respecting a maximum line length of 80 characters. Using a custom type to define a union type can afford the opportunity to describe the purpose of these options, and helps to avoid these line length issues.
 
 ```js
 /**

--- a/docs/contributors/coding-guidelines.md
+++ b/docs/contributors/coding-guidelines.md
@@ -434,7 +434,7 @@ Documenting a function component should be treated the same as any other functio
  * @example
  *
  * ```jsx
- * <BlockTitle clientId="afd1cb17-2c08-4e7a-91be-007ba7ddc3a1" />
+ * <BlockTitle name="my-plugin/my-block" />
  * ```
  *
  * @param {Object}  props      Component props.

--- a/docs/contributors/coding-guidelines.md
+++ b/docs/contributors/coding-guidelines.md
@@ -419,7 +419,7 @@ When documenting an example, use the markdown <code>\`\`\`</code> code block to 
 
 When possible, all components should be implemented as [function components](https://reactjs.org/docs/components-and-props.html#function-and-class-components), using [hooks](https://reactjs.org/docs/hooks-intro.html) for managing component lifecycle and state.
 
-For function components, documenting the component should be no different than as documenting any other function. The primary caveat in documenting a component is being aware that the function typically accepts only a single argument (the "props"), which may include many property members. Use the [dot syntax for parameter properties](https://jsdoc.app/tags-param.html#parameters-with-properties) to document individual prop types.
+Documenting a function component should be treated the same as any other function. The primary caveat in documenting a component is being aware that the function typically accepts only a single argument (the "props"), which may include many property members. Use the [dot syntax for parameter properties](https://jsdoc.app/tags-param.html#parameters-with-properties) to document individual prop types.
 
 ```js
 /**

--- a/docs/contributors/coding-guidelines.md
+++ b/docs/contributors/coding-guidelines.md
@@ -255,7 +255,7 @@ Since an imported type declaration can occupy an excess of the available line le
 
 Note that all custom types defined in another file can be imported.
 
-When considering which types should be made available from a WordPress package, the `@typedef` statements in the package's entrypoint script should be treated as effectively the same as its public API. It is important to be aware of this, both to avoid unintentionally exposing internal types on the public interface, and as a way to expose the public types of a project.
+When considering which types should be made available from a WordPress package, the `@typedef` statements in the package's entry point script should be treated as effectively the same as its public API. It is important to be aware of this, both to avoid unintentionally exposing internal types on the public interface, and as a way to expose the public types of a project.
 
 ```js
 // packages/data/src/index.js

--- a/docs/contributors/coding-guidelines.md
+++ b/docs/contributors/coding-guidelines.md
@@ -241,6 +241,8 @@ Custom types can also be beneficial when describing a set of predefined options.
  */
 ```
 
+Note the use of quotes when defining a set of string literals. As in the [JavaScript Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/), single quotes should be used when assigning a string literal either as the type or as a [default function parameter](#nullable-undefined-and-void-types), or when [specifying the path](#importing-and-exporting-types) of an imported type.
+
 ### Importing and Exporting Types
 
 Use the [TypeScript `import` function](https://www.typescriptlang.org/docs/handbook/type-checking-javascript-files.html#import-types) to import type declarations from other files or third-party dependencies.

--- a/docs/contributors/coding-guidelines.md
+++ b/docs/contributors/coding-guidelines.md
@@ -293,7 +293,9 @@ When documenting a generic type such as `Object`, `Function`, `Promise`, etc., a
 /** @type {Promise<string>} */
 ```
 
-When defining your custom types which can be described as a generic type, use the [TypeScript `@template` tag](https://www.typescriptlang.org/docs/handbook/type-checking-javascript-files.html#template).
+The function expression here uses TypeScript's syntax for function types, which can be useful in providing more detailed information about the names and types of the expected parameters. For more information, consult the [TypeScript `@type` tag function recommendations](https://www.typescriptlang.org/docs/handbook/type-checking-javascript-files.html#type).
+
+In more advanced cases, you may define your own custom types as a generic type using the [TypeScript `@template` tag](https://www.typescriptlang.org/docs/handbook/type-checking-javascript-files.html#template).
 
 Similar to the "Custom Types" advice concerning type unions and with literal values, you can consider to create a custom type `@typedef` to better describe expected key values for object records, or to extract a complex function signature.
 

--- a/docs/contributors/coding-guidelines.md
+++ b/docs/contributors/coding-guidelines.md
@@ -319,6 +319,78 @@ Similar to the "Custom Types" advice concerning type unions and with literal val
 const BREAKPOINTS = { /* ... */ };
 ```
 
+### Nullable, Undefined, and Void Types
+
+You can express a nullable type using a leading `?`. Use the nullable form of a type only if you're describing either the type or an explicit `null` value. Do not use the nullable form as an indicator of an optional parameter.
+
+```js
+/**
+ * Returns a configuration value for a given key, if exists. Returns null if
+ * there is no configured value.
+ * 
+ * @param {string} key Configuration key to retrieve.
+ * 
+ * @return {?*} Configuration value, if exists.
+ */
+function getConfigurationValue( key ) {
+	return config.hasOwnProperty( key ) ? config[ key ] : null;
+}
+```
+
+Similarly, use the `undefined` type only if you're expecting an explicit value of `undefined`.
+
+```js
+/**
+ * Returns true if the next HTML token closes the current token.
+ *
+ * @param {Object}           currentToken Current token to compare with.
+ * @param {Object|undefined} nextToken    Next token to compare against.
+ *
+ * @return {boolean} True if `nextToken` closes `currentToken`, false otherwise.
+ */
+```
+
+If a parameter is optional, use the [square-bracket notation](https://jsdoc.app/tags-param.html#optional-parameters-and-default-values). If an optional parameter has a default value which can be expressed as a [default parameter](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Default_parameters) in the function expression, it is not necesssary to include the value in JSDoc. If the function parameter has an effective default value which requires complex logic and cannot be expressed using the default parameters syntax, you can choose to include the default value in the JSDoc.
+
+```js
+/**
+ * Renders a toolbar.
+ *
+ * @param {Object} props             Component props.
+ * @param {string} [props.className] Class to set on the container `<div />`.
+ */
+```
+
+When a function does not include a `return` statement, it is said to have a `void` return value. It is not necessary to include a `@return` tag if the return type is `void`.
+
+If a function has multiple code paths where some (but not all) conditions result in a `return` statement, you can document this as a union type including the `void` type.
+
+```js
+/**
+ * Returns a configuration value for a given key, if exists.
+ * 
+ * @param {string} key Configuration key to retrieve.
+ * 
+ * @return {*|void} Configuration value, if exists.
+ */
+function getConfigurationValue( key ) {
+	if ( config.hasOwnProperty( key ) ) {
+		return config[ key ];
+	}
+}
+```
+
+When documenting a [function type](https://github.com/WordPress/gutenberg/blob/add/typescript-jsdoc-guidelines/docs/contributors/coding-guidelines.md#record-types), you must always include the `void` return value type, as otherwise the function is inferred to return a mixed ("any") value, not a void result.
+
+```js
+/**
+ * An apiFetch middleware handler. Passed the fetch options, the middleware is
+ * expected to call the `next` middleware once it has completed its handling.
+ *
+ * @typedef {(options:WPAPIFetchOptions,next:WPAPIFetchMiddleware)=>void} WPAPIFetchMiddleware
+ */
+```
+
 ### Documenting Examples
 
 Because the documentation generated using the `@wordpress/docgen` tool will include `@example` tags if they are defined, it is considered a best practice to include usage examples for functions and components. This is especially important for documented members of a package's public API.

--- a/docs/contributors/coding-guidelines.md
+++ b/docs/contributors/coding-guidelines.md
@@ -316,7 +316,7 @@ Similar to the "Custom Types" advice concerning type unions and with literal val
  * 
  * @type {Object<WPBreakpoint,number>}
  */
-const BREAKPOINTS = { /* ... */ };
+const BREAKPOINTS = { huge: 1440 /* , ... */ };
 ```
 
 ### Nullable, Undefined, and Void Types


### PR DESCRIPTION
Related: https://make.wordpress.org/core/2019/12/04/javascript-chat-summary-december-3-2019/
Related: #18838

This pull request seeks to add a new section to the [Coding Guidelines documentation](https://github.com/WordPress/gutenberg/blob/master/docs/contributors/coding-guidelines.md), describing specific extensions of the [WordPress JavaScript Documentation Standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/) relevant for Gutenberg's distinct use of [import semantics](https://github.com/WordPress/gutenberg/blob/master/docs/contributors/coding-guidelines.md#imports) in organizing files, the [use of TypeScript tooling](https://github.com/WordPress/gutenberg/blob/master/docs/contributors/testing-overview.md#javascript-testing) for types validation, and automated documentation generation using [`@wordpress/docgen`](https://github.com/WordPress/gutenberg/tree/master/packages/docgen).

→ **[Read the documentation](https://github.com/WordPress/gutenberg/blob/add/typescript-jsdoc-guidelines/docs/contributors/coding-guidelines.md#javascript-documentation-using-jsdoc)**

**Open Questions:**

There's a few things I chose not to include here, though might be relevant for additional detailing:

- ~Clarifying distinctions between nullable, undefined, and optional parameter types, and between undefined and "`void`" returns~ _(Added in ee70ae3)_
- Discouraging some of the core guidelines which are relevant mostly for older single-file scripts (file headers, etc)
- Clarifying correctness around `@see` and `@link` tags documented in the [core guidelines](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/) (I feel this should be a revision made to those core guidelines, upon clarification)
- Capitalization guidelines around `{Object}` vs. `{object}`, etc. Likewise to the above, this should be a revision made to the core guidelines. The current guidelines are consistent with what is enforced in Gutenberg with [`preferredTypes`](https://github.com/WordPress/gutenberg/blob/da54d11ed51db75d154f82f4f6ee972a9b1a4a2f/packages/eslint-plugin/configs/jsdoc.js#L72-L74), but the recommendation is not made explicit.

**Testing Instructions:**

As these changes only include edits to documentation, there is no expected impact on the application runtime.