### PR TITLE
Remove block hover border accidentally reintroduced by #18867.

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -157,15 +157,6 @@
 		}
 	}
 
-	// Hover style.
-	&.is-hovered:not(.is-navigate-mode) > .block-editor-block-list__block-edit::before {
-		box-shadow: -$block-left-border-width 0 0 0 $dark-opacity-light-500;
-
-		.is-dark-theme & {
-			box-shadow: -$block-left-border-width 0 0 0 $light-opacity-light-400;
-		}
-	}
-
 	// Spotlight mode.
 	&.is-focus-mode:not(.is-multi-selected) {
 		opacity: 0.5;


### PR DESCRIPTION
## Description
#18862 removed the block hover styles, but then #18867 accidentally brought part of those styles back. This PR re-removes those styles.

## Screenshots
Before:
![image](https://user-images.githubusercontent.com/19592990/70177401-ecff8000-169f-11ea-9ab8-779aa576a1ec.png)

After:
![image](https://user-images.githubusercontent.com/19592990/70178091-3ac8b800-16a1-11ea-99ae-fab4f91e64f0.png)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows the accessibility standards.
- [x] My code has proper inline documentation.
- [x] I've included developer documentation if appropriate.
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR.