### PR TITLE
Docs: Reintroduce LTS support commitment

### DIFF
--- a/docs/contributors/getting-started.md
+++ b/docs/contributors/getting-started.md
@@ -2,7 +2,7 @@
 
 Gutenberg is a Node.js-based project, built primarily in JavaScript.
 
-The first step is to install the [current active LTS release](https://github.com/nodejs/Release#release-schedule) of Node. The easiest way (on MacOS, Linux, or Windows 10 with the Linux Subsystem) is by installing and running [nvm]. Once `nvm` is installed, you can install the correct version of Node by running `nvm install` in the Gutenberg directory.
+The first step is to install the [current active LTS release](https://github.com/nodejs/Release#release-schedule) of Node. The easiest way (on macOS, Linux, or Windows 10 with the Linux Subsystem) is by installing and running [nvm]. Once `nvm` is installed, you can install the correct version of Node by running `nvm install` in the Gutenberg directory.
 
 Once you have Node installed, run these scripts from within your local Gutenberg repository:
 

--- a/docs/contributors/getting-started.md
+++ b/docs/contributors/getting-started.md
@@ -2,7 +2,7 @@
 
 Gutenberg is a Node.js-based project, built primarily in JavaScript.
 
-The first step is to install a recent version of Node. The easiest way (on MacOS, Linux, or Windows 10 with the Linux Subsystem) is by installing and running [nvm]. Once `nvm` is installed, you can install the correct version of Node by running `nvm install` in the Gutenberg directory.
+The first step is to install the [current active LTS release](https://github.com/nodejs/Release#release-schedule) of Node. The easiest way (on MacOS, Linux, or Windows 10 with the Linux Subsystem) is by installing and running [nvm]. Once `nvm` is installed, you can install the correct version of Node by running `nvm install` in the Gutenberg directory.
 
 Once you have Node installed, run these scripts from within your local Gutenberg repository:
 

--- a/docs/contributors/getting-started.md
+++ b/docs/contributors/getting-started.md
@@ -2,7 +2,7 @@
 
 Gutenberg is a Node.js-based project, built primarily in JavaScript.
 
-The first step is to install the [current active LTS release](https://github.com/nodejs/Release#release-schedule) of Node. The easiest way (on macOS, Linux, or Windows 10 with the Linux Subsystem) is by installing and running [nvm]. Once `nvm` is installed, you can install the correct version of Node by running `nvm install` in the Gutenberg directory.
+The first step is to install the [latest active LTS release](https://github.com/nodejs/Release#release-schedule) of Node. The easiest way (on macOS, Linux, or Windows 10 with the Linux Subsystem) is by installing and running [nvm]. Once `nvm` is installed, you can install the correct version of Node by running `nvm install` in the Gutenberg directory.
 
 Once you have Node installed, run these scripts from within your local Gutenberg repository:
 


### PR DESCRIPTION
Previously: #17004

This pull request seeks to document the expected supported versions of Node required for running this project. Prior to #17004, we explicitly mentioned the current active LTS as being required. In order to avoid ambiguity on what is to be supported ([example](https://github.com/WordPress/gutenberg/pull/18840#issuecomment-561858587)), this support commitment should be documented. The "Getting Started" document may not be the best place for this, but it at least serves as a point of reference.

**Testing Instructions:**

The changes include only documentation changes. There is no expected impact on application runtime.