### PR TITLE
Framework: Remove unused Travis install dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,8 +71,9 @@ install:
         /tmp/wordpress-develop-master/*config-sample.php \
         /tmp/wordpress-develop-master/package.json wordpress
 
-      # Install WordPress.
+      # Install WordPress. The additional dependencies are required by the copied `wordpress-develop` tools.
       cd wordpress
+      npm install dotenv wait-on
       npm run env:start
       sleep 10
       npm run env:install

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,6 @@ install:
 
       # Install WordPress.
       cd wordpress
-      npm install dotenv wait-on
       npm run env:start
       sleep 10
       npm run env:install


### PR DESCRIPTION
Previously: #17004

This pull request seeks to remove the installation step of two seemingly unused dependencies from the Travis configuration `install` stage. There are no other references to either `dotenv` or `wait-on` anywhere in Gutenberg or [`wordpress-develop`](https://github.com/WordPress/wordpress-develop), so as best I can tell, they should not be necessary. My assumption is that they were considered in early iterations of #17004 as an alternative to the `sleep 10` command which follows a few lines after the removed line.

**Testing Instructions:**

Travis build should pass.