### PR TITLE
Block Library: Implement Template Part block editing.

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -33,6 +33,7 @@ $z-layers: (
 	".wp-block-cover.has-background-dim::before": 1, // Overlay area inside block cover need to be higher than the video background.
 	".wp-block-cover__video-background": 0, // Video background inside cover block.
 	".wp-block-site-title__save-button": 1,
+	".wp-block-template-part__save-button": 1,
 
 	// Active pill button
 	".components-button.is-button {:focus or .is-primary}": 1,

--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -33,6 +33,7 @@
 @import "./subhead/editor.scss";
 @import "./table/editor.scss";
 @import "./tag-cloud/editor.scss";
+@import "./template-part/editor.scss";
 @import "./text-columns/editor.scss";
 @import "./verse/editor.scss";
 @import "./video/editor.scss";

--- a/packages/block-library/src/template-part/edit.js
+++ b/packages/block-library/src/template-part/edit.js
@@ -1,3 +1,118 @@
-export default function TemplatePartEdit() {
-	return 'Template Part Placeholder';
+/**
+ * WordPress dependencies
+ */
+import {
+	useEntityProp,
+	__experimentalUseEntitySaving,
+	EntityProvider,
+} from '@wordpress/core-data';
+import { useMemo, useCallback } from '@wordpress/element';
+import { parse } from '@wordpress/blocks';
+import { serializeBlocks } from '@wordpress/editor';
+import { Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { InnerBlocks } from '@wordpress/block-editor';
+import { useSelect } from '@wordpress/data';
+
+const saveProps = [ 'content', 'status' ];
+function TemplatePart() {
+	const [ content, _setContent ] = useEntityProp(
+		'postType',
+		'wp_template_part',
+		'content'
+	);
+	const [ status, setStatus ] = useEntityProp(
+		'postType',
+		'wp_template_part',
+		'status'
+	);
+	const initialBlocks = useMemo( () => {
+		if ( status !== 'publish' ) {
+			// Publish if still an auto-draft.
+			setStatus( 'publish' );
+		}
+		if ( typeof content !== 'function' ) {
+			const parsedContent = parse( content );
+			return parsedContent.length ? parsedContent : undefined;
+		}
+	}, [] );
+	const [ blocks = initialBlocks, setBlocks ] = useEntityProp(
+		'postType',
+		'wp_template_part',
+		'blocks'
+	);
+	const [ isDirty, isSaving, save ] = __experimentalUseEntitySaving(
+		'postType',
+		'wp_template_part',
+		saveProps
+	);
+	const saveContent = useCallback( () => {
+		_setContent( content( { blocks } ) );
+		save();
+	}, [ content, blocks ] );
+	const setContent = useCallback( () => {
+		_setContent( ( { blocks: blocksForSerialization = [] } ) =>
+			serializeBlocks( blocksForSerialization )
+		);
+	}, [] );
+	return (
+		<>
+			<Button
+				isPrimary
+				className="wp-block-template-part__save-button"
+				disabled={ ! isDirty || ! content }
+				isBusy={ isSaving }
+				onClick={ saveContent }
+			>
+				{ __( 'Save' ) }
+			</Button>
+			<InnerBlocks value={ blocks } onChange={ setBlocks } onInput={ setContent } />
+		</>
+	);
+}
+
+export default function TemplatePartEdit( {
+	attributes: { postId: _postId, slug, theme },
+	setAttributes,
+} ) {
+	const postId = useSelect(
+		( select ) => {
+			if ( _postId ) {
+				// This is already a custom template part,
+				// use its CPT post.
+				return (
+					select( 'core' ).getEntityRecord(
+						'postType',
+						'wp_template_part',
+						_postId
+					) && _postId
+				);
+			}
+
+			// This is not a custom template part,
+			// load the auto-draft created from the
+			// relevant file.
+			const posts = select( 'core' ).getEntityRecords(
+				'postType',
+				'wp_template_part',
+				{
+					status: 'auto-draft',
+					slug,
+					meta: { theme },
+				}
+			);
+			if ( posts && posts[ 0 ].id ) {
+				// Set the post ID so that edits
+				// persist.
+				setAttributes( { postId: posts[ 0 ].id } );
+				return posts[ 0 ].id;
+			}
+		},
+		[ _postId, slug, theme ]
+	);
+	return postId ? (
+		<EntityProvider kind="postType" type="wp_template_part" id={ postId }>
+			<TemplatePart />
+		</EntityProvider>
+	) : null;
 }

--- a/packages/block-library/src/template-part/editor.scss
+++ b/packages/block-library/src/template-part/editor.scss
@@ -1,0 +1,6 @@
+.wp-block-template-part__save-button {
+	position: absolute;
+	right: 0;
+	top: 0;
+	z-index: z-index(".wp-block-template-part__save-button");
+}

--- a/packages/editor/src/utils/index.js
+++ b/packages/editor/src/utils/index.js
@@ -5,3 +5,5 @@ import mediaUpload from './media-upload';
 
 export { mediaUpload };
 export { cleanForSlug } from './url.js';
+
+export { default as serializeBlocks } from '../store/utils/serialize-blocks';


### PR DESCRIPTION
Depends on #18739
Follows #18736

## Description

This PR continues the block template part work by enabling the editing of existing block template part files as blocks in block templates.

It runs the block template override logic in the editor to find the relevant block template and create auto drafts for both the block template and its nested block template parts. This is done in the editor settings hook, to be able to send back context to the editor, like the current template's ID.

The edit implementation of the block template part block can then load the block template part CPT post directly if the block template part has already been customized or it can look for the latest auto draft which was created from the block template part files.

## How to test this?

- Set up the test environment described in #18736's testing instructions.
- Create a block template CPT post called "single" with `/block-templates/single.html`'s contents.
- Verify that editing the header block template part and saving both the block template and the block template part propagate the changes everywhere the header is used.

## Types of Changes

*New Feature:* The Template Part block now lets you edit the underlying block template part.

## Checklist:

- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
