### PR TITLE
Use correct classnames for navigation link block save output

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -208,7 +208,7 @@ function NavigationLinkEdit( {
 					'has-link': !! url,
 				} ) }
 			>
-				<div className="wp-block-navigation-link__inner">
+				<div>
 					<RichText
 						className="wp-block-navigation-link__content"
 						value={ label }

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -77,7 +77,7 @@ function render_block_navigation( $attributes, $content, $block ) {
 function build_navigation_html( $block, $colors ) {
 	$html            = '';
 	$css_classes     = implode( ' ', $colors['css_classes'] );
-	$class_attribute = sprintf( ' class="wp-block-navigation-link__link %s"', esc_attr( trim( $css_classes ) ) );
+	$class_attribute = sprintf( ' class="wp-block-navigation-link__content %s"', esc_attr( trim( $css_classes ) ) );
 	$style_attribute = $colors['inline_styles'] ? sprintf( ' style="%s"', esc_attr( $colors['inline_styles'] ) ) : '';
 
 	foreach ( (array) $block['innerBlocks'] as $key => $block ) {

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -77,12 +77,12 @@ function render_block_navigation( $attributes, $content, $block ) {
 function build_navigation_html( $block, $colors ) {
 	$html            = '';
 	$css_classes     = implode( ' ', $colors['css_classes'] );
-	$class_attribute = sprintf( ' class="%s"', esc_attr( ! empty( $css_classes ) ? 'wp-block-navigation-item__link ' . $css_classes : 'wp-block-navigation-item__link' ) );
+	$class_attribute = sprintf( ' class="wp-block-navigation-link__link %s"', esc_attr( trim( $css_classes ) ) );
 	$style_attribute = $colors['inline_styles'] ? sprintf( ' style="%s"', esc_attr( $colors['inline_styles'] ) ) : '';
 
 	foreach ( (array) $block['innerBlocks'] as $key => $block ) {
 
-		$html .= '<li class="wp-block-navigation-item">' .
+		$html .= '<li class="wp-block-navigation-link">' .
 			'<a' . $class_attribute . $style_attribute;
 
 		// Start appending HTML attributes to anchor tag.


### PR DESCRIPTION
## Description
This PR tidies up some of the classnames in the Navigation Link block:
- Fixes the incorrectly named `wp-block-navigation-item` class to be `wp-block-navigation-link`.
- Renames `wp-block-navigation-item__link` to `wp-block-navigation-link__content`, which matches the classname used in the block edit for the link text.
- Removes the unused `wp-block-navigation-item__inner` class from the block edit.

This doesn't affect any styles as the block's save output is styled using element selectors.

Fixes #18914.

## How has this been tested?
1. Add a Navigation block
2. Add multiple inner Navigation Link blocks
3. Inspect the editor html in the dev tools. 
4. Observe that the class `wp-block-navigation-link__inner` no longer appears
5. Preview the post and inspect the post html
4. Expect that the correct classnames appear (`wp-block-navigation-link` and `wp-block-navigation-link__content`).
5. Expect that the block still appears the same visually.

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
