### PR TITLE
Framework: Resolve WordPress package type imports

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
 		"baseUrl": ".",
 		"paths": {
 			"@wordpress/*": [
+				"packages/*/index.js",
 				"packages/*/src/index.js"
 			]
 		},

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,14 @@
 		"resolveJsonModule": true,
 		"target": "esnext",
 
+		/* Project Imports */
+		"baseUrl": ".",
+		"paths": {
+			"@wordpress/*": [
+				"packages/*/src/index.js"
+			]
+		},
+
 		/* Strict Type-Checking Options */
 		"strict": true,                        /* Enable all strict type-checking options. */
 		"noImplicitAny": false,                /* Raise error on expressions and declarations with an implied 'any' type. */


### PR DESCRIPTION
Previously suggested by @dsifford at https://github.com/WordPress/gutenberg/issues/18838#issuecomment-560014005

This pull request seeks to add necessary configuration to resolve cross-package type imports.

**In Progress:** This may be problematic to implement until existing issues can be resolved, since an `import` of a type will subject the entire dependency hierarchy to types checking, even if the module is not part of the `includes` set in the configuration.

**Testing Instructions:**

As an example, include a type reference to a file covered by types checking:

```diff
diff --git a/packages/url/src/index.js b/packages/url/src/index.js
index e39d95f28..d6af6b547 100644
--- a/packages/url/src/index.js
+++ b/packages/url/src/index.js
@@ -1,3 +1,5 @@
+/** @type {import('@wordpress/element').WPComponent} */
+
 export { isURL } from './is-url';
 export { isEmail } from './is-email';
 export { getProtocol } from './get-protocol';
```

If you have an editor integration, you can observe that the type is resolved:

![image](https://user-images.githubusercontent.com/1779930/70201840-c9f7bf00-16e5-11ea-9448-de2974d60d58.png)

However, when running `npm run lint-types`, you will also see ~26 new errors introduced through the analyzed result of the `@wordpress/element` dependency hierarchy.