### PR TITLE
Ability to specify RadioControl options as disabled.

### DIFF
--- a/packages/components/src/radio-control/README.md
+++ b/packages/components/src/radio-control/README.md
@@ -106,6 +106,7 @@ The value property of the currently selected option.
 An array of objects containing the following properties:
 * `label`: (string) The label to be shown to the user.
 * `value`: (Object) The internal value compared against select and passed to onChange.
+* `disabled`: (boolean) Whether or not the input should have the disabled attribute.
 
 - Type: `Array`
 - Required: No

--- a/packages/components/src/radio-control/index.js
+++ b/packages/components/src/radio-control/index.js
@@ -34,6 +34,7 @@ function RadioControl( { label, className, selected, help, instanceId, onChange,
 						onChange={ onChangeValue }
 						checked={ option.value === selected }
 						aria-describedby={ !! help ? `${ id }__help` : undefined }
+						disabled={ option.disabled }
 					/>
 					<label htmlFor={ `${ id }-${ index }` }>
 						{ option.label }

--- a/packages/components/src/radio-control/stories/index.js
+++ b/packages/components/src/radio-control/stories/index.js
@@ -47,3 +47,16 @@ export const withHelp = () => {
 	);
 };
 
+export const withDisabledOption = () => {
+	const optionsWithDisabled = [
+		...options,
+		{ label: 'Disabled Option', value: 'disabled', disabled: true },
+	];
+
+	return (
+		<RadioControlWithState
+			label="Post visibility"
+			options={ optionsWithDisabled }
+		/>
+	);
+};

--- a/storybook/test/__snapshots__/index.js.snap
+++ b/storybook/test/__snapshots__/index.js.snap
@@ -2677,6 +2677,96 @@ exports[`Storyshots Components|RadioControl Default 1`] = `
 </div>
 `;
 
+exports[`Storyshots Components|RadioControl With Disabled Option 1`] = `
+<div
+  className="components-base-control components-radio-control"
+>
+  <div
+    className="components-base-control__field"
+  >
+    <label
+      className="components-base-control__label"
+      htmlFor="inspector-radio-control-2"
+    >
+      Post visibility
+    </label>
+    <div
+      className="components-radio-control__option"
+    >
+      <input
+        checked={true}
+        className="components-radio-control__input"
+        id="inspector-radio-control-2-0"
+        name="inspector-radio-control-2"
+        onChange={[Function]}
+        type="radio"
+        value="public"
+      />
+      <label
+        htmlFor="inspector-radio-control-2-0"
+      >
+        Public
+      </label>
+    </div>
+    <div
+      className="components-radio-control__option"
+    >
+      <input
+        checked={false}
+        className="components-radio-control__input"
+        id="inspector-radio-control-2-1"
+        name="inspector-radio-control-2"
+        onChange={[Function]}
+        type="radio"
+        value="private"
+      />
+      <label
+        htmlFor="inspector-radio-control-2-1"
+      >
+        Private
+      </label>
+    </div>
+    <div
+      className="components-radio-control__option"
+    >
+      <input
+        checked={false}
+        className="components-radio-control__input"
+        id="inspector-radio-control-2-2"
+        name="inspector-radio-control-2"
+        onChange={[Function]}
+        type="radio"
+        value="password"
+      />
+      <label
+        htmlFor="inspector-radio-control-2-2"
+      >
+        Password Protected
+      </label>
+    </div>
+    <div
+      className="components-radio-control__option"
+    >
+      <input
+        checked={false}
+        className="components-radio-control__input"
+        disabled={true}
+        id="inspector-radio-control-2-3"
+        name="inspector-radio-control-2"
+        onChange={[Function]}
+        type="radio"
+        value="disabled"
+      />
+      <label
+        htmlFor="inspector-radio-control-2-3"
+      >
+        Disabled Option
+      </label>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storyshots Components|RadioControl With Help 1`] = `
 <div
   className="components-base-control components-radio-control"


### PR DESCRIPTION
## Description
The current `RadioControl` component does not allow you to add disabled options. This PR enables that.

## How has this been tested?
Locally.

## Screenshots

![pizza-toppings](https://user-images.githubusercontent.com/1527164/70205703-09232000-1779-11ea-99d7-260fe2426607.gif)

## Types of changes
Modified the existing `options` prop for the `RadioControl` component. Non-breaking change, the new `disabled` key is optional.

The `SelectControl` component supports disabled options so I mostly followed that pattern.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
