### PR TITLE
Add a `type=submit` to the search suggestion buttons

### DIFF
--- a/packages/block-editor/src/components/link-control/search-item.js
+++ b/packages/block-editor/src/components/link-control/search-item.js
@@ -17,6 +17,7 @@ import {
 export const LinkControlSearchItem = ( { itemProps, suggestion, isSelected = false, onClick, isURL = false, searchTerm = '' } ) => {
 	return (
 		<Button
+			type="submit"
 			{ ...itemProps }
 			onClick={ onClick }
 			className={ classnames( 'block-editor-link-control__search-item', {


### PR DESCRIPTION
## Description
Recently pressing enter to submit a url as a navigation link in the nav block stopped working. It looks like the `LinkControlSearchItem` previously relied on being a `type="submit"` button. It was recently changed to use the `Button` component, which has a default `type="button"`. This PR changes it back to a `submit` button to restore the functionality.

## How has this been tested?
e2e tests are being worked on in https://github.com/WordPress/gutenberg/pull/18929, which is how this was discovered.

1. Add a Navigation Block.
2. Select 'Create empty'.
3. Type a URL (e.g. 'https://wordpress.org') and press enter
4. Expect that the URL is submitted.

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->


## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
