### PR TITLE
Popover: fix expandOnMobile

### DIFF
--- a/packages/block-editor/src/components/block-switcher/style.scss
+++ b/packages/block-editor/src/components/block-switcher/style.scss
@@ -89,7 +89,7 @@
 	}
 }
 // We double the max-width for it to fit both the preview & content but we keep the min width the same for the border to work.
-.components-popover:not(.is-mobile).block-editor-block-switcher__popover .components-popover__content {
+.components-popover.block-editor-block-switcher__popover .components-popover__content {
 	min-width: 300px;
 	max-width: calc(340px * 2);
 	display: flex;

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -16,7 +16,7 @@ $block-inserter-search-height: 38px;
 	}
 }
 
-.block-editor-inserter__popover:not(.is-mobile) > .components-popover__content {
+.block-editor-inserter__popover > .components-popover__content {
 	@include break-medium {
 		overflow-y: visible;
 		height: $block-inserter-content-height + $block-inserter-tabs-height + $block-inserter-search-height;

--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -94,7 +94,7 @@
 }
 
 // Popover styles
-.components-popover:not(.is-mobile).wp-block-navigation-link__dropdown-content {
+.components-popover.wp-block-navigation-link__dropdown-content {
 	margin-top: -1px;
 	margin-left: -4px;
 }

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -301,10 +301,10 @@ const Popover = ( {
 			setClass( containerEl, 'is-without-arrow', noArrow || ( xAxis === 'center' && yAxis === 'middle' ) );
 			setAttribute( containerEl, 'data-x-axis', xAxis );
 			setAttribute( containerEl, 'data-y-axis', yAxis );
-			setStyle( containerEl, 'top', popoverTop ? popoverTop + 'px' : '' );
-			setStyle( containerEl, 'left', popoverLeft ? popoverLeft + 'px' : '' );
-			setStyle( contentEl, 'maxHeight', contentHeight ? contentHeight + 'px' : '' );
-			setStyle( contentEl, 'maxWidth', contentWidth ? contentWidth + 'px' : '' );
+			setStyle( containerEl, 'top', typeof popoverTop === 'number' ? popoverTop + 'px' : '' );
+			setStyle( containerEl, 'left', typeof popoverLeft === 'number' ? popoverLeft + 'px' : '' );
+			setStyle( contentEl, 'maxHeight', typeof contentHeight === 'number' ? contentHeight + 'px' : '' );
+			setStyle( contentEl, 'maxWidth', typeof contentWidth === 'number' ? contentWidth + 'px' : '' );
 
 			// Compute the animation position
 			const yAxisMapping = {

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -167,7 +167,15 @@ function useFocusContentOnMount( focusOnMount, contentRef ) {
 	}, [] );
 }
 
-function diffAttribute( element, name, value ) {
+/**
+ * Sets or removes an element attribute.
+ *
+ * @param {Element} element The element to modify.
+ * @param {string}  name    The attribute name to set or remove.
+ * @param {?string} value   The value to set. A falsy value will remove the
+ *                          attribute.
+ */
+function setAttribute( element, name, value ) {
 	if ( ! value ) {
 		if ( element.hasAttribute( name ) ) {
 			element.removeAttribute( name );
@@ -177,19 +185,34 @@ function diffAttribute( element, name, value ) {
 	}
 }
 
-function diffStyle( element, property, value = '' ) {
+/**
+ * Sets or removes an element style property.
+ *
+ * @param {Element} element  The element to modify.
+ * @param {string}  property The property to set or remove.
+ * @param {?string} value    The value to set. A falsy value will remove the
+ *                           property.
+ */
+function setStyle( element, property, value = '' ) {
 	if ( element.style[ property ] !== value ) {
 		element.style[ property ] = value;
 	}
 }
 
-function diffClass( element, name, toggle ) {
+/**
+ * Sets or removes an element class.
+ *
+ * @param {Element} element The element to modify.
+ * @param {string}  name    The class to set or remove.
+ * @param {boolean} toggle  True to set the class, false to remove.
+ */
+function setClass( element, name, toggle ) {
 	if ( toggle ) {
 		if ( ! element.classList.contains( name ) ) {
 			element.classList.add( name );
 		}
 	} else if ( element.classList.contains( name ) ) {
-		element.classList.add( name );
+		element.classList.remove( name );
 	}
 }
 
@@ -233,13 +256,13 @@ const Popover = ( {
 		const contentEl = contentRef.current;
 
 		if ( isExpanded ) {
-			diffClass( containerEl, 'is-without-arrow', noArrow );
-			diffAttribute( containerEl, 'data-x-axis' );
-			diffAttribute( containerEl, 'data-y-axis' );
-			diffStyle( containerEl, 'top' );
-			diffStyle( containerEl, 'left' );
-			diffStyle( contentEl, 'maxHeight' );
-			diffStyle( contentEl, 'maxWidth' );
+			setClass( containerEl, 'is-without-arrow', noArrow );
+			setAttribute( containerEl, 'data-x-axis' );
+			setAttribute( containerEl, 'data-y-axis' );
+			setStyle( containerEl, 'top' );
+			setStyle( containerEl, 'left' );
+			setStyle( contentEl, 'maxHeight' );
+			setStyle( contentEl, 'maxWidth' );
 			return;
 		}
 
@@ -275,13 +298,13 @@ const Popover = ( {
 				contentWidth,
 			} = computePopoverPosition( anchor, contentSize, position );
 
-			diffClass( containerEl, 'is-without-arrow', noArrow || ( xAxis === 'center' && yAxis === 'middle' ) );
-			diffAttribute( containerEl, 'data-x-axis', xAxis );
-			diffAttribute( containerEl, 'data-y-axis', yAxis );
-			diffStyle( containerEl, 'top', popoverTop ? popoverTop + 'px' : '' );
-			diffStyle( containerEl, 'left', popoverLeft ? popoverLeft + 'px' : '' );
-			diffStyle( contentEl, 'maxHeight', contentHeight ? contentHeight + 'px' : '' );
-			diffStyle( contentEl, 'maxWidth', contentWidth ? contentWidth + 'px' : '' );
+			setClass( containerEl, 'is-without-arrow', noArrow || ( xAxis === 'center' && yAxis === 'middle' ) );
+			setAttribute( containerEl, 'data-x-axis', xAxis );
+			setAttribute( containerEl, 'data-y-axis', yAxis );
+			setStyle( containerEl, 'top', popoverTop ? popoverTop + 'px' : '' );
+			setStyle( containerEl, 'left', popoverLeft ? popoverLeft + 'px' : '' );
+			setStyle( contentEl, 'maxHeight', contentHeight ? contentHeight + 'px' : '' );
+			setStyle( contentEl, 'maxWidth', contentWidth ? contentWidth + 'px' : '' );
 
 			// Compute the animation position
 			const yAxisMapping = {

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -167,6 +167,32 @@ function useFocusContentOnMount( focusOnMount, contentRef ) {
 	}, [] );
 }
 
+function diffAttribute( element, name, value ) {
+	if ( ! value ) {
+		if ( element.hasAttribute( name ) ) {
+			element.removeAttribute( name );
+		}
+	} else if ( element.getAttribute( name ) !== value ) {
+		element.setAttribute( name, value );
+	}
+}
+
+function diffStyle( element, property, value = '' ) {
+	if ( element.style[ property ] !== value ) {
+		element.style[ property ] = value;
+	}
+}
+
+function diffClass( element, name, toggle ) {
+	if ( toggle ) {
+		if ( ! element.classList.contains( name ) ) {
+			element.classList.add( name );
+		}
+	} else if ( element.classList.contains( name ) ) {
+		element.classList.add( name );
+	}
+}
+
 const Popover = ( {
 	headerTitle,
 	onClose,
@@ -203,14 +229,17 @@ const Popover = ( {
 	noArrow = isExpanded || noArrow;
 
 	useEffect( () => {
+		const containerEl = containerRef.current;
+		const contentEl = contentRef.current;
+
 		if ( isExpanded ) {
-			containerRef.current.removeAttribute( 'data-x-axis' );
-			containerRef.current.removeAttribute( 'data-y-axis' );
-			containerRef.current.style.top = '';
-			containerRef.current.style.left = '';
-			contentRef.current.style.maxHeight = '';
-			contentRef.current.style.maxWidth = '';
-			contentRef.current.classList.add( 'is-without-arrow' );
+			diffClass( containerEl, 'is-without-arrow', noArrow );
+			diffAttribute( containerEl, 'data-x-axis' );
+			diffAttribute( containerEl, 'data-y-axis' );
+			diffStyle( containerEl, 'top' );
+			diffStyle( containerEl, 'left' );
+			diffStyle( contentEl, 'maxHeight' );
+			diffStyle( contentEl, 'maxWidth' );
 			return;
 		}
 
@@ -234,8 +263,8 @@ const Popover = ( {
 			);
 
 			const contentSize = {
-				height: contentRef.current.scrollHeight,
-				width: contentRef.current.scrollWidth,
+				height: contentEl.scrollHeight,
+				width: contentEl.scrollWidth,
 			};
 			const {
 				popoverTop,
@@ -245,6 +274,14 @@ const Popover = ( {
 				contentHeight,
 				contentWidth,
 			} = computePopoverPosition( anchor, contentSize, position );
+
+			diffClass( containerEl, 'is-without-arrow', noArrow || ( xAxis === 'center' && yAxis === 'middle' ) );
+			diffAttribute( containerEl, 'data-x-axis', xAxis );
+			diffAttribute( containerEl, 'data-y-axis', yAxis );
+			diffStyle( containerEl, 'top', popoverTop ? popoverTop + 'px' : '' );
+			diffStyle( containerEl, 'left', popoverLeft ? popoverLeft + 'px' : '' );
+			diffStyle( contentEl, 'maxHeight', contentHeight ? contentHeight + 'px' : '' );
+			diffStyle( contentEl, 'maxWidth', contentWidth ? contentWidth + 'px' : '' );
 
 			// Compute the animation position
 			const yAxisMapping = {
@@ -257,19 +294,6 @@ const Popover = ( {
 			};
 			const animateYAxis = yAxisMapping[ yAxis ] || 'middle';
 			const animateXAxis = xAxisMapping[ xAxis ] || 'center';
-
-			containerRef.current.setAttribute( 'data-x-axis', xAxis );
-			containerRef.current.setAttribute( 'data-y-axis', yAxis );
-			containerRef.current.style.top = popoverTop + 'px';
-			containerRef.current.style.left = popoverLeft + 'px';
-			contentRef.current.style.maxHeight = contentHeight ? contentHeight + 'px' : '';
-			contentRef.current.style.maxWidth = contentWidth ? contentWidth + 'px' : '';
-
-			if ( noArrow || ( xAxis === 'center' && yAxis === 'middle' ) ) {
-				contentRef.current.classList.add( 'is-without-arrow' );
-			} else {
-				contentRef.current.classList.remove( 'is-without-arrow' );
-			}
 
 			setAnimateOrigin( animateXAxis + ' ' + animateYAxis );
 		};

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -198,9 +198,19 @@ const Popover = ( {
 	const containerRef = useRef();
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
 	const [ animateOrigin, setAnimateOrigin ] = useState();
+	const isExpanded = expandOnMobile && isMobileViewport;
+
+	noArrow = isExpanded || noArrow;
 
 	useEffect( () => {
-		if ( isMobileViewport && expandOnMobile ) {
+		if ( isExpanded ) {
+			containerRef.current.removeAttribute( 'data-x-axis' );
+			containerRef.current.removeAttribute( 'data-y-axis' );
+			containerRef.current.style.top = '';
+			containerRef.current.style.left = '';
+			contentRef.current.style.maxHeight = '';
+			contentRef.current.style.maxWidth = '';
+			contentRef.current.classList.add( 'is-without-arrow' );
 			return;
 		}
 
@@ -255,7 +265,7 @@ const Popover = ( {
 			contentRef.current.style.maxHeight = contentHeight ? contentHeight + 'px' : '';
 			contentRef.current.style.maxWidth = contentWidth ? contentWidth + 'px' : '';
 
-			if ( xAxis === 'center' && yAxis === 'middle' ) {
+			if ( noArrow || ( xAxis === 'center' && yAxis === 'middle' ) ) {
 				contentRef.current.classList.add( 'is-without-arrow' );
 			} else {
 				contentRef.current.classList.remove( 'is-without-arrow' );
@@ -283,8 +293,7 @@ const Popover = ( {
 			window.removeEventListener( 'scroll', refresh, true );
 		};
 	}, [
-		isMobileViewport,
-		expandOnMobile,
+		isExpanded,
 		anchorRect,
 		getAnchorRect,
 		anchorRef,
@@ -367,7 +376,7 @@ const Popover = ( {
 							className,
 							animateClassName,
 							{
-								'is-mobile': isMobileViewport && expandOnMobile,
+								'is-expanded': isExpanded,
 								'is-without-arrow': noArrow,
 							}
 						) }
@@ -375,7 +384,7 @@ const Popover = ( {
 						onKeyDown={ maybeClose }
 						ref={ containerRef }
 					>
-						{ isMobileViewport && expandOnMobile && (
+						{ isExpanded && (
 							<div className="components-popover__header">
 								<span className="components-popover__header-title">
 									{ headerTitle }

--- a/packages/components/src/popover/style.scss
+++ b/packages/components/src/popover/style.scss
@@ -147,17 +147,20 @@ $arrow-size: 8px;
 	background: $white;
 	height: 100%;
 
-	.components-popover.is-expanded & {
-		height: calc(100% - #{ $panel-header-height });
-		border: none;
-		border-top: $border-width solid $light-gray-500;
-	}
-
-	.components-popover[data-x-axis][data-y-axis] & {
+	.components-popover & {
 		position: absolute;
 		height: auto;
 		overflow-y: auto;
 		min-width: 260px;
+	}
+
+	.components-popover.is-expanded & {
+		position: static;
+		height: calc(100% - #{ $panel-header-height });
+		overflow-y: visible;
+		min-width: auto;
+		border: none;
+		border-top: $border-width solid $light-gray-500;
 	}
 
 	.components-popover[data-y-axis="top"] & {

--- a/packages/components/src/popover/style.scss
+++ b/packages/components/src/popover/style.scss
@@ -6,14 +6,25 @@ $arrow-size: 8px;
 	z-index: z-index(".components-popover");
 	left: 50%;
 
-	&.is-mobile {
+	// Hide the popover element until the position has been calculated. The position
+	// cannot be calculated until the popover element is rendered because the
+	// position depends on the size of the popover.
+	opacity: 0;
+
+	&.is-expanded,
+	&[data-x-axis][data-y-axis] {
+		opacity: 1;
+	}
+
+	&.is-expanded {
 		top: 0;
 		left: 0;
 		right: 0;
 		bottom: 0;
+		z-index: z-index(".components-popover") !important;
 	}
 
-	&:not(.is-without-arrow):not(.is-mobile) {
+	&:not(.is-without-arrow) {
 		margin-left: 2px;
 
 		&::before {
@@ -116,19 +127,17 @@ $arrow-size: 8px;
 		}
 	}
 
-	&:not(.is-mobile) {
-		&[data-y-axis="top"] {
-			bottom: 100%;
-		}
+	&[data-y-axis="top"] {
+		bottom: 100%;
+	}
 
-		&[data-y-axis="bottom"] {
-			top: 100%;
-		}
+	&[data-y-axis="bottom"] {
+		top: 100%;
+	}
 
-		&[data-y-axis="middle"] {
-			align-items: center;
-			display: flex;
-		}
+	&[data-y-axis="middle"] {
+		align-items: center;
+		display: flex;
 	}
 }
 
@@ -138,42 +147,43 @@ $arrow-size: 8px;
 	background: $white;
 	height: 100%;
 
-	.components-popover.is-mobile & {
+	.components-popover.is-expanded & {
 		height: calc(100% - #{ $panel-header-height });
-		border-top: 0;
+		border: none;
+		border-top: $border-width solid $light-gray-500;
 	}
 
-	.components-popover:not(.is-mobile) & {
+	.components-popover[data-x-axis][data-y-axis] & {
 		position: absolute;
 		height: auto;
 		overflow-y: auto;
 		min-width: 260px;
 	}
 
-	.components-popover:not(.is-mobile)[data-y-axis="top"] & {
+	.components-popover[data-y-axis="top"] & {
 		bottom: 100%;
 	}
 
-	.components-popover:not(.is-mobile)[data-x-axis="center"] & {
+	.components-popover[data-x-axis="center"] & {
 		left: 50%;
 		transform: translateX(-50%);
 	}
 
-	.components-popover:not(.is-mobile)[data-x-axis="right"] & {
+	.components-popover[data-x-axis="right"] & {
 		position: absolute;
 		left: 100%;
 	}
 
-	.components-popover:not(.is-mobile):not([data-y-axis="middle"])[data-x-axis="right"] & {
+	.components-popover:not([data-y-axis="middle"])[data-x-axis="right"] & {
 		margin-left: -24px;
 	}
 
-	.components-popover:not(.is-mobile)[data-x-axis="left"] & {
+	.components-popover[data-x-axis="left"] & {
 		position: absolute;
 		right: 100%;
 	}
 
-	.components-popover:not(.is-mobile):not([data-y-axis="middle"])[data-x-axis="left"] & {
+	.components-popover:not([data-y-axis="middle"])[data-x-axis="left"] & {
 		margin-right: -24px;
 	}
 }
@@ -183,21 +193,9 @@ $arrow-size: 8px;
 	height: 100%;
 }
 
-// Hide the popover element until the position has been calculated. The position
-// cannot be calculated until the popover element is rendered because the
-// position depends on the size of the popover.
-.components-popover {
-	opacity: 0;
-}
-
-.components-popover[data-x-axis][data-y-axis] {
-	opacity: 1;
-}
-
 .components-popover__header {
 	align-items: center;
 	background: $white;
-	border: $border-width solid $light-gray-500;
 	display: flex;
 	height: $panel-header-height;
 	justify-content: space-between;

--- a/packages/components/src/tooltip/style.scss
+++ b/packages/components/src/tooltip/style.scss
@@ -13,7 +13,7 @@
 		border-bottom-color: $dark-gray-900;
 	}
 
-	&:not(.is-mobile) .components-popover__content {
+	.components-popover__content {
 		min-width: 0;
 	}
 }

--- a/packages/editor/src/components/table-of-contents/style.scss
+++ b/packages/editor/src/components/table-of-contents/style.scss
@@ -1,4 +1,4 @@
-.table-of-contents__popover.components-popover:not(.is-mobile) .components-popover__content {
+.table-of-contents__popover.components-popover .components-popover__content {
 	min-width: 380px;
 }
 

--- a/packages/nux/src/components/dot-tip/style.scss
+++ b/packages/nux/src/components/dot-tip/style.scss
@@ -79,9 +79,9 @@ $dot-scale: 3;  // How much the pulse animation should scale up by in size
 	}
 
 	// Extra specificity so that we can override the styles in .component-popover
-	&:not(.is-mobile)[data-y-axis="left"],
-	&:not(.is-mobile)[data-y-axis="center"],
-	&:not(.is-mobile)[data-y-axis="right"] {
+	&[data-y-axis="left"],
+	&[data-y-axis="center"],
+	&[data-y-axis="right"] {
 		// Position tips above popovers
 		z-index: z-index(".nux-dot-tip");
 
@@ -99,22 +99,22 @@ $dot-scale: 3;  // How much the pulse animation should scale up by in size
 		}
 	}
 
-	&.components-popover:not(.is-mobile):not([data-y-axis="middle"])[data-y-axis="right"] .components-popover__content {
+	&.components-popover:not([data-y-axis="middle"])[data-y-axis="right"] .components-popover__content {
 		/*!rtl:ignore*/
 		margin-left: 0;
 	}
 
-	&.components-popover:not(.is-mobile):not([data-y-axis="middle"])[data-y-axis="left"] .components-popover__content {
+	&.components-popover:not([data-y-axis="middle"])[data-y-axis="left"] .components-popover__content {
 		/*!rtl:ignore*/
 		margin-right: 0;
 	}
 
-	&.components-popover.edit-post-more-menu__content:not(.is-mobile):not([data-y-axis="middle"])[data-y-axis="right"] .components-popover__content {
+	&.components-popover.edit-post-more-menu__content:not([data-y-axis="middle"])[data-y-axis="right"] .components-popover__content {
 		/*!rtl:ignore*/
 		margin-left: -12px;
 	}
 
-	&.components-popover.edit-post-more-menu__content:not(.is-mobile):not([data-y-axis="middle"])[data-y-axis="left"] .components-popover__content {
+	&.components-popover.edit-post-more-menu__content:not([data-y-axis="middle"])[data-y-axis="left"] .components-popover__content {
 		/*!rtl:ignore*/
 		margin-right: -12px;
 	}


### PR DESCRIPTION
## Description

* Fixes `expandOnMobile` to expand again.
* Only change the DOM when needed.
* `is-mobile` class => `is-expanded`

## How has this been tested?

Test the main inserter button popover on mobile.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
