### PR TITLE
Fix sidebar on mobile.

### DIFF
--- a/packages/edit-post/src/components/editor-regions/style.scss
+++ b/packages/edit-post/src/components/editor-regions/style.scss
@@ -76,7 +76,7 @@ html {
 .edit-post-editor-regions__sidebar {
 	width: auto; // Keep the sidebar width flexible.
 	flex-shrink: 0;
-	position: fixed !important; // Need to override the default relative positionning
+	position: absolute;
 	z-index: z-index(".edit-post-editor-regions__sidebar");
 	top: 0;
 	right: 0;

--- a/packages/edit-post/src/components/sidebar/settings-header/style.scss
+++ b/packages/edit-post/src/components/sidebar/settings-header/style.scss
@@ -3,8 +3,6 @@
 	padding-left: 0;
 	padding-right: $grid-size-small;
 	border-top: 0;
-	position: sticky;
-	top: 0;
 
 	ul {
 		display: flex;

--- a/packages/edit-post/src/components/sidebar/style.scss
+++ b/packages/edit-post/src/components/sidebar/style.scss
@@ -17,7 +17,7 @@
 	> .components-panel {
 		border-left: none;
 		border-right: none;
-		overflow: visible;
+		overflow: auto;
 		-webkit-overflow-scrolling: touch;
 		height: auto;
 		max-height: calc(100vh - #{ $admin-bar-height-big + $panel-header-height });


### PR DESCRIPTION
Scrolling is broken in the sidebar on mobile. This is likely related to the recent refactor, and because some delicate behavior is there. This PR fixes it:

![sidebar](https://user-images.githubusercontent.com/1204802/70226635-76bb5600-1751-11ea-90a3-6c54e14b3fae.gif)

So, what happened? I'm not entirely sure, and therefore it would be good to get lots of testing on this. It tests well for me, but still. 

The behavior, best as I can tell, that we want is for the modal sidebar to scroll, but the document title and close button should stay fixed at the top, as should the two tabs. 