### PR TITLE
[Tiny PR] Move in-between inserter between blocks

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -457,6 +457,10 @@ function BlockListBlock( {
 
 	const shouldRenderDropzone = shouldShowInsertionPoint;
 	const isDragging = isDraggingBlocks && ( isSelected || isPartOfMultiSelection );
+	const isFocussed = isFocusMode && ( isSelected || isParentOfSelectedBlock );
+	const hidePreviousInserter = ! hasFixedToolbar && (
+		shouldAppearSelected || isFocussed
+	);
 
 	// The wp-block className is important for editor styles.
 	// Generate the wrapper class names handling the different states of the block.
@@ -471,7 +475,7 @@ function BlockListBlock( {
 			'is-reusable': isReusableBlock( blockType ),
 			'is-dragging': isDragging,
 			'is-typing': isTypingWithinBlock,
-			'is-focused': isFocusMode && ( isSelected || isParentOfSelectedBlock ),
+			'is-focused': isFocussed,
 			'is-focus-mode': isFocusMode,
 			'has-child-selected': isParentOfSelectedBlock,
 		},
@@ -519,7 +523,7 @@ function BlockListBlock( {
 	return <>
 		{ shouldShowInsertionPoint && (
 			<BlockInsertionPoint
-				isSelected={ isSelected }
+				hidden={ hidePreviousInserter }
 				clientId={ clientId }
 				rootClientId={ rootClientId }
 			/>

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -45,6 +45,7 @@ import BlockHtml from './block-html';
 import BlockBreadcrumb from './breadcrumb';
 import BlockContextualToolbar from './block-contextual-toolbar';
 import BlockMultiControls from './multi-controls';
+import BlockInsertionPoint from './insertion-point';
 import IgnoreNestedEvents from '../ignore-nested-events';
 import InserterWithShortcuts from '../inserter-with-shortcuts';
 import Inserter from '../inserter';
@@ -447,11 +448,14 @@ function BlockListBlock( {
 			isFirstMultiSelected
 		);
 
-	const shouldRenderDropzone = ! isMultiSelecting && (
+	// Insertion point can only be made visible if the block is at the
+	// the extent of a multi-selection, or not in a multi-selection.
+	const shouldShowInsertionPoint = ! isMultiSelecting && (
 		( isPartOfMultiSelection && isFirstMultiSelected ) ||
 		! isPartOfMultiSelection
 	);
 
+	const shouldRenderDropzone = shouldShowInsertionPoint;
 	const isDragging = isDraggingBlocks && ( isSelected || isPartOfMultiSelection );
 
 	// The wp-block className is important for editor styles.
@@ -512,7 +516,13 @@ function BlockListBlock( {
 		blockEdit = <div style={ { display: 'none' } }>{ blockEdit }</div>;
 	}
 
-	return (
+	return <>
+		{ shouldShowInsertionPoint && (
+			<BlockInsertionPoint
+				clientId={ clientId }
+				rootClientId={ rootClientId }
+			/>
+		) }
 		<IgnoreNestedEvents
 			id={ blockElementId }
 			ref={ wrapper }
@@ -631,7 +641,7 @@ function BlockListBlock( {
 				</div>
 			) }
 		</IgnoreNestedEvents>
-	);
+	</>;
 }
 
 const applyWithSelect = withSelect(

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -519,6 +519,7 @@ function BlockListBlock( {
 	return <>
 		{ shouldShowInsertionPoint && (
 			<BlockInsertionPoint
+				isSelected={ isSelected }
 				clientId={ clientId }
 				rootClientId={ rootClientId }
 			/>

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -45,7 +45,6 @@ import BlockHtml from './block-html';
 import BlockBreadcrumb from './breadcrumb';
 import BlockContextualToolbar from './block-contextual-toolbar';
 import BlockMultiControls from './multi-controls';
-import BlockInsertionPoint from './insertion-point';
 import IgnoreNestedEvents from '../ignore-nested-events';
 import InserterWithShortcuts from '../inserter-with-shortcuts';
 import Inserter from '../inserter';
@@ -448,14 +447,11 @@ function BlockListBlock( {
 			isFirstMultiSelected
 		);
 
-	// Insertion point can only be made visible if the block is at the
-	// the extent of a multi-selection, or not in a multi-selection.
-	const shouldShowInsertionPoint = ! isMultiSelecting && (
+	const shouldRenderDropzone = ! isMultiSelecting && (
 		( isPartOfMultiSelection && isFirstMultiSelected ) ||
 		! isPartOfMultiSelection
 	);
 
-	const shouldRenderDropzone = shouldShowInsertionPoint;
 	const isDragging = isDraggingBlocks && ( isSelected || isPartOfMultiSelection );
 
 	// The wp-block className is important for editor styles.
@@ -543,12 +539,6 @@ function BlockListBlock( {
 					animationStyle
 			}
 		>
-			{ shouldShowInsertionPoint && (
-				<BlockInsertionPoint
-					clientId={ clientId }
-					rootClientId={ rootClientId }
-				/>
-			) }
 			{ shouldRenderDropzone && <BlockDropZone
 				clientId={ clientId }
 				rootClientId={ rootClientId }

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -21,6 +21,7 @@ import BlockAsyncModeProvider from './block-async-mode-provider';
 import BlockListBlock from './block';
 import BlockListAppender from '../block-list-appender';
 import __experimentalBlockListFooter from '../block-list-footer';
+import BlockInsertionPoint from './insertion-point';
 
 /**
  * If the block count exceeds the threshold, we disable the reordering animation
@@ -254,6 +255,12 @@ class BlockList extends Component {
 							clientId={ clientId }
 							isBlockInSelection={ isBlockInSelection }
 						>
+							{ ! isMultiSelecting && ! isBlockInSelection && (
+								<BlockInsertionPoint
+									clientId={ clientId }
+									rootClientId={ rootClientId }
+								/>
+							) }
 							<BlockListBlock
 								rootClientId={ rootClientId }
 								clientId={ clientId }

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -248,6 +248,11 @@ class BlockList extends Component {
 					const isBlockInSelection = hasMultiSelection ?
 						multiSelectedBlockClientIds.includes( clientId ) :
 						selectedBlockClientId === clientId;
+					const isFirstMultiSelected = multiSelectedBlockClientIds[ 0 ] === clientId;
+					const shouldShowInsertionPoint = ! isMultiSelecting && (
+						( isBlockInSelection && isFirstMultiSelected ) ||
+						! isBlockInSelection
+					);
 
 					return (
 						<BlockAsyncModeProvider
@@ -255,7 +260,7 @@ class BlockList extends Component {
 							clientId={ clientId }
 							isBlockInSelection={ isBlockInSelection }
 						>
-							{ ! isMultiSelecting && ! isBlockInSelection && (
+							{ shouldShowInsertionPoint && (
 								<BlockInsertionPoint
 									clientId={ clientId }
 									rootClientId={ rootClientId }

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -21,7 +21,6 @@ import BlockAsyncModeProvider from './block-async-mode-provider';
 import BlockListBlock from './block';
 import BlockListAppender from '../block-list-appender';
 import __experimentalBlockListFooter from '../block-list-footer';
-import BlockInsertionPoint from './insertion-point';
 
 /**
  * If the block count exceeds the threshold, we disable the reordering animation
@@ -248,11 +247,6 @@ class BlockList extends Component {
 					const isBlockInSelection = hasMultiSelection ?
 						multiSelectedBlockClientIds.includes( clientId ) :
 						selectedBlockClientId === clientId;
-					const isFirstMultiSelected = multiSelectedBlockClientIds[ 0 ] === clientId;
-					const shouldShowInsertionPoint = ! isMultiSelecting && (
-						( isBlockInSelection && isFirstMultiSelected ) ||
-						! isBlockInSelection
-					);
 
 					return (
 						<BlockAsyncModeProvider
@@ -260,12 +254,6 @@ class BlockList extends Component {
 							clientId={ clientId }
 							isBlockInSelection={ isBlockInSelection }
 						>
-							{ shouldShowInsertionPoint && (
-								<BlockInsertionPoint
-									clientId={ clientId }
-									rootClientId={ rootClientId }
-								/>
-							) }
 							<BlockListBlock
 								rootClientId={ rootClientId }
 								clientId={ clientId }

--- a/packages/block-editor/src/components/block-list/insertion-point.js
+++ b/packages/block-editor/src/components/block-list/insertion-point.js
@@ -43,7 +43,7 @@ class BlockInsertionPoint extends Component {
 			showInsertionPoint,
 			rootClientId,
 			clientId,
-			isSelected,
+			hidden,
 		} = this.props;
 
 		return (
@@ -64,7 +64,7 @@ class BlockInsertionPoint extends Component {
 					className={
 						classnames( 'editor-block-list__insertion-point-inserter block-editor-block-list__insertion-point-inserter', {
 							'is-visible': isInserterFocused,
-							'is-hidden': isSelected,
+							'is-hidden': hidden && ! isInserterFocused,
 						} )
 					}
 				>

--- a/packages/block-editor/src/components/block-list/insertion-point.js
+++ b/packages/block-editor/src/components/block-list/insertion-point.js
@@ -43,6 +43,7 @@ class BlockInsertionPoint extends Component {
 			showInsertionPoint,
 			rootClientId,
 			clientId,
+			isSelected,
 		} = this.props;
 
 		return (
@@ -63,6 +64,7 @@ class BlockInsertionPoint extends Component {
 					className={
 						classnames( 'editor-block-list__insertion-point-inserter block-editor-block-list__insertion-point-inserter', {
 							'is-visible': isInserterFocused,
+							'is-hidden': isSelected,
 						} )
 					}
 				>

--- a/packages/block-editor/src/components/block-list/insertion-point.js
+++ b/packages/block-editor/src/components/block-list/insertion-point.js
@@ -25,12 +25,7 @@ class BlockInsertionPoint extends Component {
 		this.onFocusInserter = this.onFocusInserter.bind( this );
 	}
 
-	onFocusInserter( event ) {
-		// Stop propagation of the focus event to avoid selecting the current
-		// block while inserting a new block, as it is not relevant to sibling
-		// insertion and conflicts with contextual toolbar placement.
-		event.stopPropagation();
-
+	onFocusInserter() {
 		this.setState( {
 			isInserterFocused: true,
 		} );

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -677,6 +677,7 @@
 .block-editor-block-list__insertion-point {
 	position: relative;
 	z-index: z-index(".block-editor-block-list__insertion-point");
+	top: -$block-padding;
 }
 
 .block-editor-block-list__insertion-point-indicator {
@@ -697,11 +698,17 @@
 	}
 
 	position: absolute;
-	bottom: -100%;
+	bottom: auto;
 	left: 0;
 	right: 0;
 	justify-content: center;
-	height: 2 * $block-padding;
+	flex-direction: column;
+	height: $block-padding + 8px;
+	transform: translateY(-50%);
+
+	.block-editor-inserter {
+		margin: auto;
+	}
 
 	// Show a clickable plus.
 	.block-editor-inserter__toggle {

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -729,7 +729,11 @@
 	transition: opacity 0.1s linear;
 	@include reduce-motion("transition");
 
-	&:not(.is-hidden):hover,
+	&.is-hidden {
+		pointer-events: none;
+	}
+
+	&:hover,
 	&.is-visible {
 		opacity: 1;
 	}

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -677,7 +677,6 @@
 .block-editor-block-list__insertion-point {
 	position: relative;
 	z-index: z-index(".block-editor-block-list__insertion-point");
-	margin-top: -$block-padding;
 }
 
 .block-editor-block-list__insertion-point-indicator {
@@ -698,11 +697,11 @@
 	}
 
 	position: absolute;
-	bottom: auto;
+	bottom: -100%;
 	left: 0;
 	right: 0;
 	justify-content: center;
-	height: $block-padding + 8px;
+	height: 2 * $block-padding;
 
 	// Show a clickable plus.
 	.block-editor-inserter__toggle {

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -729,25 +729,9 @@
 	transition: opacity 0.1s linear;
 	@include reduce-motion("transition");
 
-	&:hover,
+	&:not(.is-hidden):hover,
 	&.is-visible {
 		opacity: 1;
-	}
-}
-
-// Don't show the sibling inserter before the selected block.
-.edit-post-layout:not(.has-fixed-toolbar) {
-	// The child selector is necessary for this to work properly in nested contexts.
-	.is-selected > .block-editor-block-list__insertion-point > .block-editor-block-list__insertion-point-inserter,
-	.is-focused > .block-editor-block-list__insertion-point > .block-editor-block-list__insertion-point-inserter {
-		opacity: 0;
-		pointer-events: none;
-
-		&:hover,
-		&.is-visible {
-			opacity: 1;
-			pointer-events: auto;
-		}
 	}
 }
 

--- a/packages/e2e-tests/specs/editor/blocks/__snapshots__/table.test.js.snap
+++ b/packages/e2e-tests/specs/editor/blocks/__snapshots__/table.test.js.snap
@@ -20,7 +20,7 @@ exports[`Table allows adding and deleting columns across the table header, body 
 
 exports[`Table allows cells to be selected when the cell area outside of the RichText is clicked 1`] = `
 "<!-- wp:table {\\"hasFixedLayout\\":true} -->
-<figure class=\\"wp-block-table\\"><table class=\\"has-fixed-layout\\"><tbody><tr><td><br><br><br><br></td><td></td></tr><tr><td>Third cell.</td><td></td></tr></tbody></table></figure>
+<figure class=\\"wp-block-table\\"><table class=\\"has-fixed-layout\\"><tbody><tr><td><br><br><br><br></td><td>Second cell.</td></tr><tr><td></td><td></td></tr></tbody></table></figure>
 <!-- /wp:table -->"
 `;
 

--- a/packages/e2e-tests/specs/editor/blocks/__snapshots__/table.test.js.snap
+++ b/packages/e2e-tests/specs/editor/blocks/__snapshots__/table.test.js.snap
@@ -20,7 +20,7 @@ exports[`Table allows adding and deleting columns across the table header, body 
 
 exports[`Table allows cells to be selected when the cell area outside of the RichText is clicked 1`] = `
 "<!-- wp:table {\\"hasFixedLayout\\":true} -->
-<figure class=\\"wp-block-table\\"><table class=\\"has-fixed-layout\\"><tbody><tr><td><br><br><br><br></td><td>Second cell.</td></tr><tr><td></td><td></td></tr></tbody></table></figure>
+<figure class=\\"wp-block-table\\"><table class=\\"has-fixed-layout\\"><tbody><tr><td><br><br><br><br></td><td></td></tr><tr><td>Third cell.</td><td></td></tr></tbody></table></figure>
 <!-- /wp:table -->"
 `;
 

--- a/packages/e2e-tests/specs/editor/blocks/table.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/table.test.js
@@ -215,19 +215,19 @@ describe( 'Table', () => {
 		await page.click( 'td' );
 		await page.keyboard.type( '\n\n\n\n' );
 
-		// Get the bounding client rect for the second cell.
-		const { x: secondCellX, y: secondCellY } = await page.evaluate( () => {
-			const secondCell = document.querySelectorAll( '.wp-block-table td' )[ 1 ];
+		// Get the bounding client rect for the third cell.
+		const rect = await page.evaluate( () => {
+			const secondCell = document.querySelectorAll( '.wp-block-table td' )[ 2 ];
 			// Page.evaluate can only return a serializable value to the
 			// parent process, so destructure and restructure the result
 			// into an object.
-			const { x, y } = secondCell.getBoundingClientRect();
-			return { x, y };
+			const { x, y, height } = secondCell.getBoundingClientRect();
+			return { x, y, height };
 		} );
 
-		// Click in the top left corner of the second cell and type some text.
-		await page.mouse.click( secondCellX, secondCellY );
-		await page.keyboard.type( 'Second cell.' );
+		// Click in the top left corner of the third cell and type some text.
+		await page.mouse.click( rect.x, rect.y );
+		await page.keyboard.type( 'Third cell.' );
 
 		// Expect that the snapshot shows the text in the second cell.
 		expect( await getEditedPostContent() ).toMatchSnapshot();

--- a/packages/e2e-tests/specs/editor/blocks/table.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/table.test.js
@@ -215,19 +215,19 @@ describe( 'Table', () => {
 		await page.click( 'td' );
 		await page.keyboard.type( '\n\n\n\n' );
 
-		// Get the bounding client rect for the third cell.
-		const rect = await page.evaluate( () => {
-			const secondCell = document.querySelectorAll( '.wp-block-table td' )[ 2 ];
+		// Get the bounding client rect for the second cell.
+		const { x: secondCellX, y: secondCellY } = await page.evaluate( () => {
+			const secondCell = document.querySelectorAll( '.wp-block-table td' )[ 1 ];
 			// Page.evaluate can only return a serializable value to the
 			// parent process, so destructure and restructure the result
 			// into an object.
-			const { x, y, height } = secondCell.getBoundingClientRect();
-			return { x, y, height };
+			const { x, y } = secondCell.getBoundingClientRect();
+			return { x, y };
 		} );
 
-		// Click in the top left corner of the third cell and type some text.
-		await page.mouse.click( rect.x, rect.y );
-		await page.keyboard.type( 'Third cell.' );
+		// Click in the top left corner of the second cell and type some text.
+		await page.mouse.click( secondCellX, secondCellY );
+		await page.keyboard.type( 'Second cell.' );
 
 		// Expect that the snapshot shows the text in the second cell.
 		expect( await getEditedPostContent() ).toMatchSnapshot();

--- a/packages/e2e-tests/specs/editor/blocks/table.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/table.test.js
@@ -216,17 +216,18 @@ describe( 'Table', () => {
 		await page.keyboard.type( '\n\n\n\n' );
 
 		// Get the bounding client rect for the second cell.
-		const { x: secondCellX, y: secondCellY } = await page.evaluate( () => {
+		const rect = await page.evaluate( () => {
 			const secondCell = document.querySelectorAll( '.wp-block-table td' )[ 1 ];
 			// Page.evaluate can only return a serializable value to the
 			// parent process, so destructure and restructure the result
 			// into an object.
-			const { x, y } = secondCell.getBoundingClientRect();
-			return { x, y };
+			const { x, y, height } = secondCell.getBoundingClientRect();
+			return { x, y, height };
 		} );
 
-		// Click in the top left corner of the second cell and type some text.
-		await page.mouse.click( secondCellX, secondCellY );
+		// Click in the bottom left corner of the second cell and type some text.
+		// Avoid the top as it might clash with inserter.
+		await page.mouse.click( rect.x, rect.y + rect.height );
 		await page.keyboard.type( 'Second cell.' );
 
 		// Expect that the snapshot shows the text in the second cell.

--- a/packages/e2e-tests/specs/editor/blocks/table.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/table.test.js
@@ -215,9 +215,9 @@ describe( 'Table', () => {
 		await page.click( 'td' );
 		await page.keyboard.type( '\n\n\n\n' );
 
-		// Get the bounding client rect for the second cell.
+		// Get the bounding client rect for the third cell.
 		const rect = await page.evaluate( () => {
-			const secondCell = document.querySelectorAll( '.wp-block-table td' )[ 1 ];
+			const secondCell = document.querySelectorAll( '.wp-block-table td' )[ 2 ];
 			// Page.evaluate can only return a serializable value to the
 			// parent process, so destructure and restructure the result
 			// into an object.
@@ -225,10 +225,9 @@ describe( 'Table', () => {
 			return { x, y, height };
 		} );
 
-		// Click in the bottom left corner of the second cell and type some text.
-		// Avoid the top as it might clash with inserter.
-		await page.mouse.click( rect.x, rect.y + rect.height );
-		await page.keyboard.type( 'Second cell.' );
+		// Click in the top left corner of the third cell and type some text.
+		await page.mouse.click( rect.x, rect.y );
+		await page.keyboard.type( 'Third cell.' );
 
 		// Expect that the snapshot shows the text in the second cell.
 		expect( await getEditedPostContent() ).toMatchSnapshot();

--- a/packages/e2e-tests/specs/editor/various/adding-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/adding-blocks.test.js
@@ -91,12 +91,12 @@ describe( 'adding blocks', () => {
 		// Unselect blocks to avoid conflicts with the inbetween inserter
 		await page.click( '.editor-post-title__input' );
 
-		// Using the between inserter
-		const insertionPoint = await page.$( '[data-type="core/quote"] .block-editor-inserter__toggle' );
+		// Using the inserter between paragraph and quote
+		const insertionPoint = await page.$( '[data-type="core/paragraph"] ~ .block-editor-block-list__insertion-point .block-editor-inserter__toggle' );
 		const rect = await insertionPoint.boundingBox();
 		await page.mouse.move( rect.x + ( rect.width / 2 ), rect.y + ( rect.height / 2 ), { steps: 10 } );
-		await page.waitForSelector( '[data-type="core/quote"] .block-editor-inserter__toggle' );
-		await page.click( '[data-type="core/quote"] .block-editor-inserter__toggle' );
+		await page.waitForSelector( '[data-type="core/paragraph"] ~ .block-editor-block-list__insertion-point .block-editor-inserter__toggle' );
+		await page.click( '[data-type="core/paragraph"] ~ .block-editor-block-list__insertion-point .block-editor-inserter__toggle' );
 		// [TODO]: Search input should be focused immediately. It shouldn't be
 		// necessary to have `waitForFunction`.
 		await page.waitForFunction( () => (

--- a/packages/e2e-tests/specs/editor/various/keyboard-navigable-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/keyboard-navigable-blocks.test.js
@@ -17,6 +17,13 @@ const navigateToContentEditorTop = async () => {
 };
 
 const tabThroughParagraphBlock = async ( paragraphText ) => {
+	// Tab causes 'add block' button to receive focus
+	await page.keyboard.press( 'Tab' );
+	const isFocusedParagraphInserterToggle = await page.evaluate( () =>
+		document.activeElement.classList.contains( 'block-editor-inserter__toggle' )
+	);
+	await expect( isFocusedParagraphInserterToggle ).toBe( true );
+
 	// Tab to the next paragraph block
 	await page.keyboard.press( 'Tab' );
 
@@ -25,13 +32,6 @@ const tabThroughParagraphBlock = async ( paragraphText ) => {
 		() => document.activeElement.dataset.type
 	);
 	await expect( isFocusedParagraphBlock ).toEqual( 'core/paragraph' );
-
-	// Tab causes 'add block' button to receive focus
-	await page.keyboard.press( 'Tab' );
-	const isFocusedParagraphInserterToggle = await page.evaluate( () =>
-		document.activeElement.classList.contains( 'block-editor-inserter__toggle' )
-	);
-	await expect( isFocusedParagraphInserterToggle ).toBe( true );
 
 	await tabThroughBlockMoverControl();
 	await tabThroughBlockToolbar();

--- a/packages/e2e-tests/specs/editor/various/preview.test.js
+++ b/packages/e2e-tests/specs/editor/various/preview.test.js
@@ -243,6 +243,7 @@ describe( 'Preview with Custom Fields enabled', () => {
 		await editorPage.keyboard.press( 'Delete' );
 		await editorPage.keyboard.type( 'title 2' );
 		await editorPage.keyboard.press( 'Tab' );
+		await editorPage.keyboard.press( 'Tab' );
 		await pressKeyWithModifier( 'primary', 'a' );
 		await editorPage.keyboard.press( 'Delete' );
 		await editorPage.keyboard.type( 'content 2' );

--- a/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
@@ -118,6 +118,7 @@ describe( 'Reusable Blocks', () => {
 		// Tab three times to navigate to the block's content
 		await page.keyboard.press( 'Tab' );
 		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'Tab' );
 
 		// Quickly focus the paragraph block
 		await page.keyboard.press( 'Escape' ); // Enter navigation mode

--- a/packages/e2e-tests/specs/editor/various/writing-flow.test.js
+++ b/packages/e2e-tests/specs/editor/various/writing-flow.test.js
@@ -39,8 +39,8 @@ describe( 'Writing Flow', () => {
 		// TODO: ArrowDown should traverse into the second column. In slower
 		// CPUs, it can sometimes remain in the first column paragraph. This
 		// is a temporary solution.
-		await page.focus( '.wp-block[data-type="core/column"]:nth-child(2)' );
-		await page.click( ':focus .block-editor-button-block-appender' );
+		await pressKeyTimes( 'Tab', 4 ); // Tab to next inserter.
+		await page.keyboard.press( 'Enter' );
 		await page.waitForSelector( ':focus.block-editor-inserter__search' );
 		await page.keyboard.type( 'Paragraph' );
 		await pressKeyTimes( 'Tab', 3 ); // Tab to paragraph result.


### PR DESCRIPTION
## Description

Split out from #18779, an effort to lighten the block component and DOM.
I believe this partly resolves #13571.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
