### PR TITLE
Multi select: onSelectionStart may trigger too much

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -380,10 +380,12 @@ function BlockListBlock( {
 		}
 	};
 
-	const onMouseLeave = ( event ) => {
-		// The primary button must be pressed to initiate selection.
+	const onMouseLeave = ( { which, buttons = which } ) => {
+		// The primary button must be pressed to initiate selection. Fall back
+		// to `which` if the standard `buttons` property is not supported.
 		// See https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/buttons
-		if ( event.buttons === 1 ) {
+		// See https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/which
+		if ( buttons === 1 ) {
 			onSelectionStart( clientId );
 		}
 
@@ -427,7 +429,7 @@ function BlockListBlock( {
 		! showEmptyBlockSideInserter &&
 		! isPartOfMultiSelection &&
 		! isTypingWithinBlock;
-	const shouldShowBreadcrumb = isNavigationMode && isSelected && ! isMultiSelecting;
+	const shouldShowBreadcrumb = isNavigationMode && isSelected;
 	const shouldShowContextualToolbar =
 		! isNavigationMode &&
 		! hasFixedToolbar &&

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -344,8 +344,6 @@ function BlockListBlock( {
 		}
 	};
 
-	const isPointerDown = useRef( false );
-
 	/**
 	 * Begins tracking cursor multi-selection when clicking down within block.
 	 *
@@ -372,34 +370,24 @@ function BlockListBlock( {
 				event.preventDefault();
 			}
 
-		// Avoid triggering multi-selection if we click toolbars/inspectors
-		// and all elements that are outside the Block Edit DOM tree.
-		} else if ( blockNodeRef.current.contains( event.target ) ) {
-			isPointerDown.current = true;
-
-			// Allow user to escape out of a multi-selection to a singular
-			// selection of a block via click. This is handled here since
-			// onFocus excludes blocks involved in a multiselection, as
-			// focus can be incurred by starting a multiselection (focus
-			// moved to first block's multi-controls).
-			if ( isPartOfMultiSelection ) {
-				onSelect();
-			}
+		// Allow user to escape out of a multi-selection to a singular
+		// selection of a block via click. This is handled here since
+		// onFocus excludes blocks involved in a multiselection, as
+		// focus can be incurred by starting a multiselection (focus
+		// moved to first block's multi-controls).
+		} else if ( isPartOfMultiSelection ) {
+			onSelect();
 		}
 	};
 
-	const onMouseUp = () => {
-		isPointerDown.current = false;
-	};
-
-	const onMouseLeave = () => {
-		if ( isPointerDown.current ) {
+	const onMouseLeave = ( event ) => {
+		// The primary button must be pressed to initiate selection.
+		// See https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/buttons
+		if ( event.buttons === 1 ) {
 			onSelectionStart( clientId );
 		}
 
 		hideHoverEffects();
-
-		isPointerDown.current = false;
 	};
 
 	const selectOnOpen = ( open ) => {
@@ -606,7 +594,6 @@ function BlockListBlock( {
 					ref={ blockNodeRef }
 					onDragStart={ preventDrag }
 					onMouseDown={ onMouseDown }
-					onMouseUp={ onMouseUp }
 					onMouseLeave={ onMouseLeave }
 					data-block={ clientId }
 				>

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -386,7 +386,7 @@ function BlockListBlock( {
 		// cases where Firefox might always set `buttons` to `0`.
 		// See https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/buttons
 		// See https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/which
-		if ( ( buttons || which ) === 1 ) {
+		if ( isSelected && ( buttons || which ) === 1 ) {
 			onSelectionStart( clientId );
 		}
 

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -380,12 +380,13 @@ function BlockListBlock( {
 		}
 	};
 
-	const onMouseLeave = ( { which, buttons = which } ) => {
+	const onMouseLeave = ( { which, buttons } ) => {
 		// The primary button must be pressed to initiate selection. Fall back
-		// to `which` if the standard `buttons` property is not supported.
+		// to `which` if the standard `buttons` property is falsy. There are
+		// cases where Firefox might always set `buttons` to `0`.
 		// See https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/buttons
 		// See https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/which
-		if ( buttons === 1 ) {
+		if ( ( buttons || which ) === 1 ) {
 			onSelectionStart( clientId );
 		}
 


### PR DESCRIPTION
## Description

Fixes #18881.
This fixes a JS error.

## How has this been tested?

Create a column block with two inserters.
Select one of the empty columns.
Escape to enter navigation mode.
Click right _above_ the inserter in the other column. You'll see that the breadcrumb doesn't show because `isMultiSelecting` is `true`. Strange!
Now select again above the first inserter. JS error!

Why is `isMultiSelecting` `true`? It looks like `onMouseUp` is not triggering for some reason, so when the mouse leaves the block, we think that the pointer is pressed. I removed this logic in favour of a more reliable way to check if a button is pressed. `event.buttons` will tell us what button is pressed. We only want to trigger multi selection if the primary button is pressed.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
