### PR TITLE
Mobile fixed toolbar: prevent whitespace and toolbar being scrolled off-screen

### DIFF
--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -86,10 +86,10 @@ export function initializeEditor( id, postType, postId, settings, initialEdits )
 
 	const isIphone = window.navigator.userAgent.indexOf( 'iPhone' ) !== -1;
 	if ( isIphone ) {
-		document.addEventListener( 'focusin', function( ) {
-			setTimeout( () => {
+		window.addEventListener( 'scroll', function( event ) {
+			if ( event.target === document ) {
 				window.scrollTo( 0, 0 );
-			}, 150 );
+			}
 		} );
 	}
 


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

This is a followup PR to https://github.com/WordPress/gutenberg/pull/18686 which added a fixed toolbar to mobile.

This PR updates the hack we're using to make this work on mobile Safari (see https://github.com/WordPress/gutenberg/issues/18632 for more context). The updated hack has the advantage that it also prevents the toolbar from being scrolled off-screen when scrolling directly on the toolbar. It also prevents the whitespace that mobile Safari erroneously adds on scroll bounce when scrolling beyond the end of the document.


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Tested in mobile Safari on a physical iPhone 11 with iOS 13.2.3 installed.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
