### PR TITLE
Social Links: Add disableSuggestions to URLInput

### DIFF
--- a/packages/block-library/src/social-link/edit.js
+++ b/packages/block-library/src/social-link/edit.js
@@ -51,6 +51,7 @@ const SocialLinkEdit = ( { attributes, setAttributes, isSelected } ) => {
 							value={ url }
 							onChange={ ( nextURL ) => setAttributes( { url: nextURL } ) }
 							placeholder={ __( 'Enter Address' ) }
+							disableSuggestions={ true }
 						/>
 						<IconButton icon="editor-break" label={ __( 'Apply' ) } type="submit" />
 					</form>


### PR DESCRIPTION
## Description

In #18905 Social Links was switched from a generic input field to using URLInput, this change adds disableSuggetions to prevent the field to suggest internal links or pages since Social Links are typically an external link.

Related, but not dependent, the Social Links can probably also benefit from this issue
https://github.com/WordPress/gutenberg/issues/11852


## How has this been tested?

1. Base Case. Add a Social Links block, insert a link and in the URL field type "About" or other page or post name and you should see a list of suggestions.

2. Apply PR. Repeat 1 and as you start typing you should not see the suggestions


## Types of changes

Adds disableSuggestions parameter to URLInput component for Social Links.

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
