### PR TITLE
Refactor withViewportMatch to use useViewportMatch

### DIFF
--- a/packages/viewport/src/test/if-viewport-matches.js
+++ b/packages/viewport/src/test/if-viewport-matches.js
@@ -4,29 +4,25 @@
 import TestRenderer, { act } from 'react-test-renderer';
 
 /**
+ * WordPress dependencies
+ */
+import { useViewportMatch as useViewportMatchMock } from '@wordpress/compose';
+
+/**
  * Internal dependencies
  */
 import '../store';
 import ifViewportMatches from '../if-viewport-matches';
 
-jest.mock( '@wordpress/compose', () => {
-	return {
-		...jest.requireActual( '@wordpress/compose' ),
-		useViewportMatch( breakPoint, operator ) {
-			if ( breakPoint === 'wide' && operator === '>=' ) {
-				return true;
-			}
-			if ( breakPoint === 'wide' && operator === '<' ) {
-				return false;
-			}
-		},
-	};
-} );
-
 describe( 'ifViewportMatches()', () => {
 	const Component = () => <div>Hello</div>;
 
+	afterEach( () => {
+		useViewportMatchMock.mockClear();
+	} );
+
 	it( 'should not render if query does not match', () => {
+		useViewportMatchMock.mockReturnValueOnce( false );
 		const EnhancedComponent = ifViewportMatches( '< wide' )( Component );
 
 		let testRenderer;
@@ -34,15 +30,21 @@ describe( 'ifViewportMatches()', () => {
 			testRenderer = TestRenderer.create( <EnhancedComponent /> );
 		} );
 
+		expect( useViewportMatchMock.mock.calls ).toEqual( [ [ 'wide', '<' ] ] );
+
 		expect( testRenderer.root.findAllByType( Component ) ).toHaveLength( 0 );
 	} );
 
 	it( 'should render if query does match', () => {
+		useViewportMatchMock.mockReturnValueOnce( true );
 		const EnhancedComponent = ifViewportMatches( '>= wide' )( Component );
 		let testRenderer;
 		act( () => {
 			testRenderer = TestRenderer.create( <EnhancedComponent /> );
 		} );
+
+		expect( useViewportMatchMock.mock.calls ).toEqual( [ [ 'wide', '>=' ] ] );
+
 		expect( testRenderer.root.findAllByType( Component ) ).toHaveLength( 1 );
 	} );
 } );

--- a/packages/viewport/src/test/if-viewport-matches.js
+++ b/packages/viewport/src/test/if-viewport-matches.js
@@ -4,22 +4,30 @@
 import TestRenderer, { act } from 'react-test-renderer';
 
 /**
- * WordPress dependencies
- */
-import { dispatch } from '@wordpress/data';
-
-/**
  * Internal dependencies
  */
 import '../store';
 import ifViewportMatches from '../if-viewport-matches';
 
+jest.mock( '@wordpress/compose', () => {
+	return {
+		...jest.requireActual( '@wordpress/compose' ),
+		useViewportMatch( breakPoint, operator ) {
+			if ( breakPoint === 'wide' && operator === '>=' ) {
+				return true;
+			}
+			if ( breakPoint === 'wide' && operator === '<' ) {
+				return false;
+			}
+		},
+	};
+} );
+
 describe( 'ifViewportMatches()', () => {
 	const Component = () => <div>Hello</div>;
 
 	it( 'should not render if query does not match', () => {
-		dispatch( 'core/viewport' ).setIsMatching( { '> wide': false } );
-		const EnhancedComponent = ifViewportMatches( '> wide' )( Component );
+		const EnhancedComponent = ifViewportMatches( '< wide' )( Component );
 
 		let testRenderer;
 		act( () => {
@@ -30,10 +38,7 @@ describe( 'ifViewportMatches()', () => {
 	} );
 
 	it( 'should render if query does match', () => {
-		act( () => {
-			dispatch( 'core/viewport' ).setIsMatching( { '> wide': true } );
-		} );
-		const EnhancedComponent = ifViewportMatches( '> wide' )( Component );
+		const EnhancedComponent = ifViewportMatches( '>= wide' )( Component );
 		let testRenderer;
 		act( () => {
 			testRenderer = TestRenderer.create( <EnhancedComponent /> );

--- a/packages/viewport/src/with-viewport-match.js
+++ b/packages/viewport/src/with-viewport-match.js
@@ -6,7 +6,7 @@ import { mapValues } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { createHigherOrderComponent, useViewportMatch } from '@wordpress/compose';
+import { createHigherOrderComponent, pure, useViewportMatch } from '@wordpress/compose';
 
 /**
  * Higher-order component creator, creating a new component which renders with
@@ -46,7 +46,7 @@ const withViewportMatch = ( queries ) => {
 	} );
 	return createHigherOrderComponent(
 		( WrappedComponent ) => {
-			return ( props ) => {
+			return pure( ( props ) => {
 				const queriesResult = useViewPortQueriesResult();
 				return (
 					<WrappedComponent
@@ -54,7 +54,7 @@ const withViewportMatch = ( queries ) => {
 						{ ...queriesResult }
 					/>
 				);
-			};
+			} );
 		},
 		'withViewportMatch'
 	);

--- a/packages/viewport/src/with-viewport-match.js
+++ b/packages/viewport/src/with-viewport-match.js
@@ -6,8 +6,7 @@ import { mapValues } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { createHigherOrderComponent } from '@wordpress/compose';
-import { withSelect } from '@wordpress/data';
+import { createHigherOrderComponent, useViewportMatch } from '@wordpress/compose';
 
 /**
  * Higher-order component creator, creating a new component which renders with
@@ -32,13 +31,33 @@ import { withSelect } from '@wordpress/data';
  *
  * @return {Function} Higher-order component.
  */
-const withViewportMatch = ( queries ) => createHigherOrderComponent(
-	withSelect( ( select ) => {
-		return mapValues( queries, ( query ) => {
-			return select( 'core/viewport' ).isViewportMatch( query );
-		} );
-	} ),
-	'withViewportMatch'
-);
+const withViewportMatch = ( queries ) => {
+	const useViewPortQueriesResult = () => mapValues( queries, ( query ) => {
+		let [ operator, breakpointName ] = query.split( ' ' );
+		if ( breakpointName === undefined ) {
+			breakpointName = operator;
+			operator = '>=';
+		}
+		// Hooks should unconditionally execute in the same order,
+		// we are respecting that as from the static query of the HOC we generate
+		// a hook that calls other hooks always in the same order (because the query never changes).
+		// eslint-disable-next-line react-hooks/rules-of-hooks
+		return useViewportMatch( breakpointName, operator );
+	} );
+	return createHigherOrderComponent(
+		( WrappedComponent ) => {
+			return ( props ) => {
+				const queriesResult = useViewPortQueriesResult();
+				return (
+					<WrappedComponent
+						{ ...props }
+						{ ...queriesResult }
+					/>
+				);
+			};
+		},
+		'withViewportMatch'
+	);
+};
 
 export default withViewportMatch;

--- a/test/unit/config/global-mocks.js
+++ b/test/unit/config/global-mocks.js
@@ -1,0 +1,6 @@
+jest.mock( '@wordpress/compose', () => {
+	return {
+		...jest.requireActual( '@wordpress/compose' ),
+		useViewportMatch: jest.fn(),
+	};
+} );

--- a/test/unit/jest.config.js
+++ b/test/unit/jest.config.js
@@ -14,6 +14,7 @@ module.exports = {
 	},
 	preset: '@wordpress/jest-preset-default',
 	setupFiles: [
+		'<rootDir>/test/unit/config/global-mocks.js',
 		'<rootDir>/test/unit/config/gutenberg-phase.js',
 		'<rootDir>/test/unit/config/register-context.js',
 	],


### PR DESCRIPTION
## Description
This PR refactors withViewportMatch to use useViewportMatch. This allows us to implement a single simulation mechanism on the hook. And consolidates the different approaches we offer now.

cc: @youknowriad 

## How has this been tested?
I checked the unit tests pass.
I added an Image block I searched for the ImageEdit component, I verified isLargeViewPort is correctly passed by the HOC and that when I resize the window the prop changes.
