### PR TITLE
Fix: Video block crashes right after insert

### DIFF
--- a/packages/block-library/src/video/edit.js
+++ b/packages/block-library/src/video/edit.js
@@ -54,7 +54,6 @@ class VideoEdit extends Component {
 
 		this.videoPlayer = createRef();
 		this.posterImageButton = createRef();
-		this.toggleAttribute = this.toggleAttribute.bind( this );
 		this.onSelectURL = this.onSelectURL.bind( this );
 		this.onSelectPoster = this.onSelectPoster.bind( this );
 		this.onRemovePoster = this.onRemovePoster.bind( this );


### PR DESCRIPTION
## Description
toggleAttribute was removed in https://github.com/WordPress/gutenberg/pull/18660/, but we were still defining the toggleAttribute with a bind in the constructor. This made all video blocks crash after being inserted or when rendered on the editor.

## How has this been tested?
I added a video block
I verified the block does not crashes.