### PR TITLE
Core Data: Add support for fetching permissions of custom actions

### DIFF
--- a/docs/designers-developers/developers/data/data-core-editor.md
+++ b/docs/designers-developers/developers/data/data-core-editor.md
@@ -12,18 +12,6 @@ _Related_
 
 -   canInsertBlockType in core/block-editor store.
 
-<a name="canUserUseUnfilteredHTML" href="#canUserUseUnfilteredHTML">#</a> **canUserUseUnfilteredHTML**
-
-Returns whether or not the user has the unfiltered_html capability.
-
-_Parameters_
-
--   _state_ `Object`: Editor state.
-
-_Returns_
-
--   `boolean`: Whether the user can or can't post unfiltered HTML.
-
 <a name="didPostSaveRequestFail" href="#didPostSaveRequestFail">#</a> **didPostSaveRequestFail**
 
 Returns true if a previous post save was attempted but failed, or false

--- a/packages/core-data/src/test/resolvers.js
+++ b/packages/core-data/src/test/resolvers.js
@@ -158,6 +158,32 @@ describe( 'canUser', () => {
 		expect( received.done ).toBe( true );
 		expect( received.value ).toBeUndefined();
 	} );
+
+	it( 'receives custom actions', () => {
+		const generator = canUser( 'publish', 'posts' );
+
+		let received = generator.next();
+		expect( received.done ).toBe( false );
+		expect( received.value ).toEqual( apiFetch( {
+			path: '/wp/v2/posts?context=edit',
+			method: 'GET',
+			parse: true,
+		} ) );
+
+		received = generator.next( {
+			_links: {
+				'wp:action-publish': [
+					{ href: 'http://localhost:8888/wp-json/wp/v2/posts' },
+				],
+			},
+		} );
+		expect( received.done ).toBe( false );
+		expect( received.value ).toEqual( receiveUserPermission( 'publish/posts', true ) );
+
+		received = generator.next();
+		expect( received.done ).toBe( true );
+		expect( received.value ).toBeUndefined();
+	} );
 } );
 
 describe( 'getAutosaves', () => {

--- a/packages/edit-post/src/components/header/post-publish-button-or-toggle.js
+++ b/packages/edit-post/src/components/header/post-publish-button-or-toggle.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { get } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { useViewportMatch, compose } from '@wordpress/compose';
@@ -76,11 +71,7 @@ export function PostPublishButtonOrToggle( {
 
 export default compose(
 	withSelect( ( select ) => ( {
-		hasPublishAction: get(
-			select( 'core/editor' ).getCurrentPost(),
-			[ '_links', 'wp:action-publish' ],
-			false
-		),
+		hasPublishAction: select( 'core' ).canUser( 'publish', 'posts', select( 'core/editor' ).getCurrentPostId() ),
 		isBeingScheduled: select( 'core/editor' ).isEditedPostBeingScheduled(),
 		isPending: select( 'core/editor' ).isCurrentPostPending(),
 		isPublished: select( 'core/editor' ).isCurrentPostPublished(),

--- a/packages/editor/src/components/post-author/check.js
+++ b/packages/editor/src/components/post-author/check.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { get } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { withInstanceId, compose } from '@wordpress/compose';
@@ -24,9 +19,9 @@ export function PostAuthorCheck( { hasAssignAuthorAction, authors, children } ) 
 
 export default compose( [
 	withSelect( ( select ) => {
-		const post = select( 'core/editor' ).getCurrentPost();
+		const postId = select( 'core/editor' ).getCurrentPostId();
 		return {
-			hasAssignAuthorAction: get( post, [ '_links', 'wp:action-assign-author' ], false ),
+			hasAssignAuthorAction: select( 'core' ).canUser( 'assign-author', 'posts', postId ),
 			postType: select( 'core/editor' ).getCurrentPostType(),
 			authors: select( 'core' ).getAuthors(),
 		};

--- a/packages/editor/src/components/post-pending-status/check.js
+++ b/packages/editor/src/components/post-pending-status/check.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { get } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { compose } from '@wordpress/compose';
@@ -19,9 +14,9 @@ export function PostPendingStatusCheck( { hasPublishAction, isPublished, childre
 
 export default compose(
 	withSelect( ( select ) => {
-		const { isCurrentPostPublished, getCurrentPostType, getCurrentPost } = select( 'core/editor' );
+		const { isCurrentPostPublished, getCurrentPostType, getCurrentPostId } = select( 'core/editor' );
 		return {
-			hasPublishAction: get( getCurrentPost(), [ '_links', 'wp:action-publish' ], false ),
+			hasPublishAction: select( 'core' ).canUser( 'publish', 'posts', getCurrentPostId() ),
 			isPublished: isCurrentPostPublished(),
 			postType: getCurrentPostType(),
 		};

--- a/packages/editor/src/components/post-publish-button/index.js
+++ b/packages/editor/src/components/post-publish-button/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { noop, get } from 'lodash';
+import { noop } from 'lodash';
 import classnames from 'classnames';
 import memoize from 'memize';
 import EquivalentKeyMap from 'equivalent-key-map';
@@ -201,11 +201,11 @@ export default compose( [
 			isEditedPostSaveable,
 			isEditedPostPublishable,
 			isPostSavingLocked,
-			getCurrentPost,
 			getCurrentPostType,
 			getCurrentPostId,
 			hasNonPostEntityChanges,
 		} = select( 'core/editor' );
+		const { canUser } = select( 'core' );
 		return {
 			isSaving: isSavingPost(),
 			isBeingScheduled: isEditedPostBeingScheduled(),
@@ -214,7 +214,7 @@ export default compose( [
 			isPostSavingLocked: isPostSavingLocked(),
 			isPublishable: isEditedPostPublishable(),
 			isPublished: isCurrentPostPublished(),
-			hasPublishAction: get( getCurrentPost(), [ '_links', 'wp:action-publish' ], false ),
+			hasPublishAction: canUser( 'publish', 'posts', getCurrentPostId() ),
 			postType: getCurrentPostType(),
 			postId: getCurrentPostId(),
 			hasNonPostEntityChanges: hasNonPostEntityChanges(),

--- a/packages/editor/src/components/post-publish-button/label.js
+++ b/packages/editor/src/components/post-publish-button/label.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { get } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -47,16 +42,17 @@ export default compose( [
 			isEditedPostBeingScheduled,
 			isSavingPost,
 			isPublishingPost,
-			getCurrentPost,
+			getCurrentPostId,
 			getCurrentPostType,
 			isAutosavingPost,
 		} = select( 'core/editor' );
+		const { canUser } = select( 'core' );
 		return {
 			isPublished: isCurrentPostPublished(),
 			isBeingScheduled: isEditedPostBeingScheduled(),
 			isSaving: forceIsSaving || isSavingPost(),
 			isPublishing: isPublishingPost(),
-			hasPublishAction: get( getCurrentPost(), [ '_links', 'wp:action-publish' ], false ),
+			hasPublishAction: canUser( 'publish', 'posts', getCurrentPostId() ),
 			postType: getCurrentPostType(),
 			isAutosaving: isAutosavingPost(),
 		};

--- a/packages/editor/src/components/post-publish-panel/index.js
+++ b/packages/editor/src/components/post-publish-panel/index.js
@@ -111,9 +111,9 @@ export class PostPublishPanel extends Component {
 
 export default compose( [
 	withSelect( ( select ) => {
-		const { getPostType } = select( 'core' );
+		const { canUser, getPostType } = select( 'core' );
 		const {
-			getCurrentPost,
+			getCurrentPostId,
 			getEditedPostAttribute,
 			isCurrentPostPublished,
 			isCurrentPostScheduled,
@@ -125,7 +125,7 @@ export default compose( [
 		const postType = getPostType( getEditedPostAttribute( 'type' ) );
 
 		return {
-			hasPublishAction: get( getCurrentPost(), [ '_links', 'wp:action-publish' ], false ),
+			hasPublishAction: canUser( 'publish', 'posts', getCurrentPostId() ),
 			isPostTypeViewable: get( postType, [ 'viewable' ], false ),
 			isBeingScheduled: isEditedPostBeingScheduled(),
 			isDirty: isEditedPostDirty(),

--- a/packages/editor/src/components/post-publish-panel/prepublish.js
+++ b/packages/editor/src/components/post-publish-panel/prepublish.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { get } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -68,11 +63,12 @@ function PostPublishPanelPrepublish( {
 export default withSelect(
 	( select ) => {
 		const {
-			getCurrentPost,
+			getCurrentPostId,
 			isEditedPostBeingScheduled,
 		} = select( 'core/editor' );
+		const { canUser } = select( 'core' );
 		return {
-			hasPublishAction: get( getCurrentPost(), [ '_links', 'wp:action-publish' ], false ),
+			hasPublishAction: canUser( 'publish', 'posts', getCurrentPostId() ),
 			isBeingScheduled: isEditedPostBeingScheduled(),
 		};
 	}

--- a/packages/editor/src/components/post-saved-state/index.js
+++ b/packages/editor/src/components/post-saved-state/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { get } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -44,7 +43,7 @@ export class PostSavedState extends Component {
 
 	render() {
 		const {
-			post,
+			hasPublishAction,
 			isNew,
 			isScheduled,
 			isPublished,
@@ -96,7 +95,6 @@ export class PostSavedState extends Component {
 
 		// Once the post has been submitted for review this button
 		// is not needed for the contributor role.
-		const hasPublishAction = get( post, [ '_links', 'wp:action-publish' ], false );
 		if ( ! hasPublishAction && isPending ) {
 			return null;
 		}
@@ -136,12 +134,13 @@ export default compose( [
 			isEditedPostDirty,
 			isSavingPost,
 			isEditedPostSaveable,
-			getCurrentPost,
+			getCurrentPostId,
 			isAutosavingPost,
 			getEditedPostAttribute,
 		} = select( 'core/editor' );
+		const { canUser } = select( 'core' );
 		return {
-			post: getCurrentPost(),
+			hasPublishAction: canUser( 'publish', 'posts', getCurrentPostId() ),
 			isNew: isEditedPostNew(),
 			isPublished: isCurrentPostPublished(),
 			isScheduled: isCurrentPostScheduled(),

--- a/packages/editor/src/components/post-schedule/check.js
+++ b/packages/editor/src/components/post-schedule/check.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { get } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { compose } from '@wordpress/compose';
@@ -19,9 +14,10 @@ export function PostScheduleCheck( { hasPublishAction, children } ) {
 
 export default compose( [
 	withSelect( ( select ) => {
-		const { getCurrentPost, getCurrentPostType } = select( 'core/editor' );
+		const { getCurrentPostId, getCurrentPostType } = select( 'core/editor' );
+		const { canUser } = select( 'core' );
 		return {
-			hasPublishAction: get( getCurrentPost(), [ '_links', 'wp:action-publish' ], false ),
+			hasPublishAction: canUser( 'publish', 'posts', getCurrentPostId() ),
 			postType: getCurrentPostType(),
 		};
 	} ),

--- a/packages/editor/src/components/post-sticky/check.js
+++ b/packages/editor/src/components/post-sticky/check.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { get } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { compose } from '@wordpress/compose';
@@ -22,10 +17,11 @@ export function PostStickyCheck( { hasStickyAction, postType, children } ) {
 
 export default compose( [
 	withSelect( ( select ) => {
-		const post = select( 'core/editor' ).getCurrentPost();
+		const { canUser } = select( 'core' );
+		const { getCurrentPostId, getCurrentPostType } = select( 'core/editor' );
 		return {
-			hasStickyAction: get( post, [ '_links', 'wp:action-sticky' ], false ),
-			postType: select( 'core/editor' ).getCurrentPostType(),
+			hasStickyAction: canUser( 'sticky', 'posts', getCurrentPostId() ),
+			postType: getCurrentPostType(),
 		};
 	} ),
 ] )( PostStickyCheck );

--- a/packages/editor/src/components/post-taxonomies/flat-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/flat-term-selector.js
@@ -244,12 +244,13 @@ class FlatTermSelector extends Component {
 
 export default compose(
 	withSelect( ( select, { slug } ) => {
-		const { getCurrentPost } = select( 'core/editor' );
-		const { getTaxonomy } = select( 'core' );
+		const { getCurrentPostId } = select( 'core/editor' );
+		const { getTaxonomy, canUser } = select( 'core' );
 		const taxonomy = getTaxonomy( slug );
+		const postId = getCurrentPostId();
 		return {
-			hasCreateAction: taxonomy ? get( getCurrentPost(), [ '_links', 'wp:action-create-' + taxonomy.rest_base ], false ) : false,
-			hasAssignAction: taxonomy ? get( getCurrentPost(), [ '_links', 'wp:action-assign-' + taxonomy.rest_base ], false ) : false,
+			hasCreateAction: taxonomy ? canUser( 'create-' + taxonomy.rest_base, 'posts', postId ) : false,
+			hasAssignAction: taxonomy ? canUser( 'assign-' + taxonomy.rest_base, 'posts', postId ) : false,
 			terms: taxonomy ? select( 'core/editor' ).getEditedPostAttribute( taxonomy.rest_base ) : [],
 			taxonomy,
 		};

--- a/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
@@ -453,12 +453,13 @@ class HierarchicalTermSelector extends Component {
 
 export default compose( [
 	withSelect( ( select, { slug } ) => {
-		const { getCurrentPost } = select( 'core/editor' );
-		const { getTaxonomy } = select( 'core' );
+		const { getCurrentPostId } = select( 'core/editor' );
+		const { getTaxonomy, canUser } = select( 'core' );
+		const postId = getCurrentPostId();
 		const taxonomy = getTaxonomy( slug );
 		return {
-			hasCreateAction: taxonomy ? get( getCurrentPost(), [ '_links', 'wp:action-create-' + taxonomy.rest_base ], false ) : false,
-			hasAssignAction: taxonomy ? get( getCurrentPost(), [ '_links', 'wp:action-assign-' + taxonomy.rest_base ], false ) : false,
+			hasCreateAction: taxonomy ? canUser( 'create-' + taxonomy.rest_base, 'posts', postId ) : false,
+			hasAssignAction: taxonomy ? canUser( 'assign-' + taxonomy.rest_base, 'posts', postId ) : false,
 			terms: taxonomy ? select( 'core/editor' ).getEditedPostAttribute( taxonomy.rest_base ) : [],
 			taxonomy,
 		};

--- a/packages/editor/src/components/post-visibility/check.js
+++ b/packages/editor/src/components/post-visibility/check.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { get } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { compose } from '@wordpress/compose';
@@ -16,9 +11,10 @@ export function PostVisibilityCheck( { hasPublishAction, render } ) {
 
 export default compose( [
 	withSelect( ( select ) => {
-		const { getCurrentPost, getCurrentPostType } = select( 'core/editor' );
+		const { canUser } = select( 'core' );
+		const { getCurrentPostId, getCurrentPostType } = select( 'core/editor' );
 		return {
-			hasPublishAction: get( getCurrentPost(), [ '_links', 'wp:action-publish' ], false ),
+			hasPublishAction: canUser( 'publish', 'posts', getCurrentPostId() ),
 			postType: getCurrentPostType(),
 		};
 	} ),

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -204,7 +204,7 @@ export default compose( [
 	withRegistryProvider,
 	withSelect( ( select ) => {
 		const {
-			canUserUseUnfilteredHTML,
+			getCurrentPostId,
 			__unstableIsEditorReady: isEditorReady,
 			getEditorBlocks,
 			getEditorSelectionStart,
@@ -214,7 +214,7 @@ export default compose( [
 		const { canUser } = select( 'core' );
 
 		return {
-			canUserUseUnfilteredHTML: canUserUseUnfilteredHTML(),
+			canUserUseUnfilteredHTML: canUser( 'unfiltered-html', 'posts', getCurrentPostId() ),
 			isReady: isEditorReady(),
 			blocks: getEditorBlocks(),
 			selectionStart: getEditorSelectionStart(),

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -4,7 +4,6 @@
 import {
 	find,
 	get,
-	has,
 	map,
 	pick,
 	mapValues,
@@ -1216,17 +1215,6 @@ export function getActivePostLock( state ) {
 }
 
 /**
- * Returns whether or not the user has the unfiltered_html capability.
- *
- * @param {Object} state Editor state.
- *
- * @return {boolean} Whether the user can or can't post unfiltered HTML.
- */
-export function canUserUseUnfilteredHTML( state ) {
-	return has( getCurrentPost( state ), [ '_links', 'wp:action-unfiltered-html' ] );
-}
-
-/**
  * Returns whether the pre-publish panel should be shown
  * or skipped when the user clicks the "publish" button.
  *
@@ -1306,6 +1294,24 @@ export function getEditorSettings( state ) {
 /*
  * Backward compatibility
  */
+
+/**
+ * Returns whether or not the user has the unfiltered_html capability.
+ *
+ * @deprecated
+ * @private
+ *
+ * @param {Object} state Editor state.
+ *
+ * @return {boolean} Whether the user can or can't post unfiltered HTML.
+ */
+export const canUserUseUnfilteredHTML = createRegistrySelector( ( select ) => ( state ) => {
+	deprecated( '`wp.data.select( \'core/editor\' ).canUserUseUnfilteredHTML`', {
+		alternative: '`wp.data.select( \'core\' ).canUser( \'unfiltered-html\', \'posts\', wp.data.select( \'core/editor\' ).getCurrentPostId() )`',
+	} );
+
+	return select( 'core' ).canUser( 'unfiltered-html', 'posts', getCurrentPostId( state ) );
+} );
 
 function getBlockEditorSelector( name ) {
 	return createRegistrySelector( ( select ) => ( state, ...args ) => {

--- a/packages/editor/src/store/test/selectors.js
+++ b/packages/editor/src/store/test/selectors.js
@@ -167,7 +167,6 @@ const {
 	getPermalinkParts,
 	isPostSavingLocked,
 	isPostAutosavingLocked,
-	canUserUseUnfilteredHTML,
 } = selectors;
 
 describe( 'selectors', () => {
@@ -2839,27 +2838,6 @@ describe( 'selectors', () => {
 			};
 
 			expect( getPermalinkParts( state ) ).toBeNull();
-		} );
-	} );
-
-	describe( 'canUserUseUnfilteredHTML', () => {
-		it( 'should return true if the _links object contains the property wp:action-unfiltered-html', () => {
-			const state = {
-				currentPost: {
-					_links: {
-						'wp:action-unfiltered-html': [],
-					},
-				},
-			};
-			expect( canUserUseUnfilteredHTML( state ) ).toBe( true );
-		} );
-		it( 'should return false if the _links object doesnt contain the property wp:action-unfiltered-html', () => {
-			const state = {
-				currentPost: {
-					_links: {},
-				},
-			};
-			expect( canUserUseUnfilteredHTML( state ) ).toBe( false );
 		} );
 	} );
 } );


### PR DESCRIPTION
Related: https://core.trac.wordpress.org/ticket/44287

This pull request seeks to enhance the `canUser` core data selector to handle custom user capabilities defined on REST endpoints via JSON Hyper Schema. This will allow a consistent interface to resolve user capabilities, removing the need to manually reference the `_links` property on a post object.

There are performance implications to this as well, since as of #16932, the result of `getCurrentPost` selector will update on every change to post content (every keystroke). Before these changes, any mounted component which depended on the current post (notably from checking these user permissions) would rerender on every key press.

**Open Questions:**

- Does it make sense to allow these "actions" to coexist in the same space, i.e. those verbs returned in the `Allow` response headers of an `OPTIONS` request, and those added as keys to a `_links` body? The changes here operate on an assumption that these can be equally considered as "action capability" keys.
- Currently, the REST API only adds these to the response of a singular post, and only in the `edit` context ([source](https://github.com/WordPress/wordpress-develop/blob/47e38ea2e97020e0ee022550dd1e3d22d5e3fa1a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php#L1836-L1891)). To me, it seems mostly incidental, and that any resource _could_ include these `_links` keys, including for requests on the root path (vs. providing an ID of a resource). For this reason, I didn't consider to include any guards to prevent an attempt to request `canUser` without an ID for a custom action, or to verify that the resource is `"posts"`.
- Could we reuse `getEntityRecord` here to avoid an additional request for the post? In existing editor usage, the proposed changes shouldn't regress, because the request should resolve immediately [since it is preloaded](https://github.com/WordPress/wordpress-develop/blob/47e38ea2e97020e0ee022550dd1e3d22d5e3fa1a/src/wp-admin/edit-form-blocks.php#L47). But for non-preloaded data, there may be redundant requests with `getEntityRecord`. However, it is difficult (impossible?) to map a ["resource" parameter](https://github.com/WordPress/gutenberg/blob/d721aca6a876d6cf951cc2c18c2a8f0aee47e5a6/packages/core-data/src/resolvers.js#L135) to an equivalent ["kind" and "name" parameter pair](https://github.com/WordPress/gutenberg/blob/d721aca6a876d6cf951cc2c18c2a8f0aee47e5a6/packages/core-data/src/resolvers.js#L50), and furthermore this would only support reuse of singular entities, not potential support for requesting capabilities on the root resource path (i.e. omitting the `id` argument).

**Testing Instructions:**

Verify there are no regressions in the behavior of capability testing for affected components:

A few examples:

- Contributors should see "Submit for Review" when hitting Publish; Administrators should see "Publish"
- Contributors should not have the option to assign an author to a post; Administrators should
- Contributors should be capable of assigning a category to a post, but not create a new one; Administrators can do both

Verify that the behavior of the `canUserUseUnfilteredHTML` selector still returns the same expected value, but logs a deprecation warning:

```js
wp.data.select( 'core/editor' ).canUserUseUnfilteredHTML();
// `wp.data.select( 'core/editor' ).canUserUseUnfilteredHTML` is deprecated. Please use `wp.data.select( 'core' ).canUser( 'unfiltered-html', 'posts', wp.data.select( 'core/editor' ).getCurrentPostId() )` instead.
// false
wp.data.select( 'core' ).canUser( 'unfiltered-html', 'posts', wp.data.select( 'core/editor' ).getCurrentPostId() )
// false
```