### PR TITLE
Fix reusable block dark theme select tool outline

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -297,11 +297,6 @@
 		border-left-color: transparent;
 		border-style: dashed;
 		border-width: $border-width;
-
-		.is-dark-theme & {
-			border-color: $light-opacity-light-800;
-			border-left-color: transparent;
-		}
 	}
 
 	// Reusable Blocks clickthrough overlays.

--- a/packages/block-library/src/block/edit-panel/editor.scss
+++ b/packages/block-library/src/block/edit-panel/editor.scss
@@ -78,4 +78,9 @@
 .is-selected.is-navigate-mode .reusable-block-edit-panel {
 	border-color: $blue-medium-focus;
 	border-left-color: transparent;
+
+	.is-dark-theme & {
+		border-color: $blue-medium-focus;
+		border-left-color: transparent;
+	}
 }


### PR DESCRIPTION
## Description
The select tool block outline wasn't blue for reusable blocks in dark theme mode. This PR fixes that inconsistency.

## Screenshots
Before:
![image](https://user-images.githubusercontent.com/19592990/70282135-9cad1e80-1782-11ea-98ab-5932cbfbb5ba.png)

After:
![image](https://user-images.githubusercontent.com/19592990/70281583-06c4c400-1781-11ea-9b9b-d47aacb9147a.png)