### PR TITLE
Editor: Shim meta attribute source on registered `edit` component

### DIFF
--- a/packages/e2e-tests/plugins/meta-attribute-block.php
+++ b/packages/e2e-tests/plugins/meta-attribute-block.php
@@ -8,20 +8,9 @@
  */
 
 /**
- * Registers a custom script and a custom meta for the plugin.
+ * Registers a custom meta for use by the test block.
  */
 function init_test_meta_attribute_block_plugin() {
-	wp_enqueue_script(
-		'gutenberg-test-meta-attribute-block',
-		plugins_url( 'meta-attribute-block/index.js', __FILE__ ),
-		array(
-			'wp-blocks',
-			'wp-element',
-		),
-		filemtime( plugin_dir_path( __FILE__ ) . 'meta-attribute-block/index.js' ),
-		true
-	);
-
 	register_meta(
 		'post',
 		'my_meta',
@@ -34,3 +23,20 @@ function init_test_meta_attribute_block_plugin() {
 }
 
 add_action( 'init', 'init_test_meta_attribute_block_plugin' );
+
+/**
+ * Enqueues block assets for the custom meta test block.
+ */
+function enqueue_test_meta_attribute_block() {
+	wp_enqueue_script(
+		'gutenberg-test-meta-attribute-block',
+		plugins_url( 'meta-attribute-block/index.js', __FILE__ ),
+		array(
+			'wp-blocks',
+			'wp-element',
+		),
+		filemtime( plugin_dir_path( __FILE__ ) . 'meta-attribute-block/index.js' ),
+		true
+	);
+}
+add_action( 'enqueue_block_assets', 'enqueue_test_meta_attribute_block' );

--- a/packages/editor/src/hooks/custom-sources-backwards-compatibility.js
+++ b/packages/editor/src/hooks/custom-sources-backwards-compatibility.js
@@ -13,7 +13,6 @@ import { createHigherOrderComponent } from '@wordpress/compose';
 import { addFilter } from '@wordpress/hooks';
 
 /** @typedef {import('@wordpress/compose').WPHigherOrderComponent} WPHigherOrderComponent */
-
 /** @typedef {import('@wordpress/blocks').WPBlockSettings} WPBlockSettings */
 
 /**

--- a/packages/editor/src/hooks/custom-sources-backwards-compatibility.js
+++ b/packages/editor/src/hooks/custom-sources-backwards-compatibility.js
@@ -32,7 +32,7 @@ import { addFilter } from '@wordpress/hooks';
  * @return {WPHigherOrderComponent} Higher-order component.
  */
 const createWithMetaAttributeSource = ( metaKeys ) => createHigherOrderComponent(
-	( BlockEdit ) => ( { attributes, setAttributes, name, ...props } ) => {
+	( BlockEdit ) => ( { attributes, setAttributes, ...props } ) => {
 		const postType = useSelect( ( select ) => select( 'core/editor' ).getCurrentPostType() );
 		const [ meta, setMeta ] = useEntityProp( 'postType', postType, 'meta' );
 
@@ -63,7 +63,6 @@ const createWithMetaAttributeSource = ( metaKeys ) => createHigherOrderComponent
 
 					setAttributes( nextAttributes );
 				} }
-				name={ name }
 				{ ...props }
 			/>
 		);

--- a/packages/editor/src/hooks/custom-sources-backwards-compatibility.js
+++ b/packages/editor/src/hooks/custom-sources-backwards-compatibility.js
@@ -17,7 +17,10 @@ import { addFilter } from '@wordpress/hooks';
 /** @typedef {import('@wordpress/blocks').WPBlockSettings} WPBlockSettings */
 
 /**
- * Object mapping an attribute key to its corresponding meta property.
+ * Object whose keys are the names of block attributes, where each value
+ * represents the meta key to which the block attribute is intended to save.
+ *
+ * @see https://developer.wordpress.org/reference/functions/register_meta/
  *
  * @typedef {Object<string,string>} WPMetaAttributeMapping
  */

--- a/packages/editor/src/hooks/custom-sources-backwards-compatibility.js
+++ b/packages/editor/src/hooks/custom-sources-backwards-compatibility.js
@@ -26,9 +26,10 @@ import { addFilter } from '@wordpress/hooks';
  */
 
 /**
- * Given a meta attribute mapping, returns a new higher-order component which
- * manages attribute merging and updating to consume from and mirror to the
- * associated entity record.
+ * Given a mapping of attribute names (meta source attributes) to their
+ * associated meta key, returns a higher order component that overrides its
+ * `attributes` and `setAttributes` props to sync any changes with the edited
+ * post's meta keys.
  *
  * @param {WPMetaAttributeMapping} metaKeys Meta attribute mapping.
  *

--- a/packages/editor/src/hooks/custom-sources-backwards-compatibility.js
+++ b/packages/editor/src/hooks/custom-sources-backwards-compatibility.js
@@ -37,7 +37,7 @@ import { addFilter } from '@wordpress/hooks';
  */
 const createWithMetaAttributeSource = ( metaKeys ) => createHigherOrderComponent(
 	( BlockEdit ) => ( { attributes, setAttributes, ...props } ) => {
-		const postType = useSelect( ( select ) => select( 'core/editor' ).getCurrentPostType() );
+		const postType = useSelect( ( select ) => select( 'core/editor' ).getCurrentPostType(), [] );
 		const [ meta, setMeta ] = useEntityProp( 'postType', postType, 'meta' );
 
 		const mergedAttributes = useMemo(

--- a/packages/editor/src/hooks/custom-sources-backwards-compatibility.js
+++ b/packages/editor/src/hooks/custom-sources-backwards-compatibility.js
@@ -24,7 +24,7 @@ import { addFilter } from '@wordpress/hooks';
 
 /**
  * Given a meta attribute mapping, returns a new higher-order component which
- * manages attributes merging and updates to consume from and mirror to the
+ * manages attribute merging and updating to consume from and mirror to the
  * associated entity record.
  *
  * @param {WPMetaAttributeMapping} metaKeys Meta attribute mapping.

--- a/packages/editor/src/hooks/custom-sources-backwards-compatibility.js
+++ b/packages/editor/src/hooks/custom-sources-backwards-compatibility.js
@@ -31,11 +31,11 @@ import { addFilter } from '@wordpress/hooks';
  * `attributes` and `setAttributes` props to sync any changes with the edited
  * post's meta keys.
  *
- * @param {WPMetaAttributeMapping} metaKeys Meta attribute mapping.
+ * @param {WPMetaAttributeMapping} metaAttributes Meta attribute mapping.
  *
  * @return {WPHigherOrderComponent} Higher-order component.
  */
-const createWithMetaAttributeSource = ( metaKeys ) => createHigherOrderComponent(
+const createWithMetaAttributeSource = ( metaAttributes ) => createHigherOrderComponent(
 	( BlockEdit ) => ( { attributes, setAttributes, ...props } ) => {
 		const postType = useSelect( ( select ) => select( 'core/editor' ).getCurrentPostType(), [] );
 		const [ meta, setMeta ] = useEntityProp( 'postType', postType, 'meta' );
@@ -43,7 +43,7 @@ const createWithMetaAttributeSource = ( metaKeys ) => createHigherOrderComponent
 		const mergedAttributes = useMemo(
 			() => ( {
 				...attributes,
-				...mapValues( metaKeys, ( metaKey ) => meta[ metaKey ] ),
+				...mapValues( metaAttributes, ( metaKey ) => meta[ metaKey ] ),
 			} ),
 			[ attributes, meta ]
 		);
@@ -55,10 +55,10 @@ const createWithMetaAttributeSource = ( metaKeys ) => createHigherOrderComponent
 					const nextMeta = mapKeys(
 						// Filter to intersection of keys between the updated
 						// attributes and those with an associated meta key.
-						pickBy( nextAttributes, ( value, key ) => metaKeys[ key ] ),
+						pickBy( nextAttributes, ( value, key ) => metaAttributes[ key ] ),
 
 						// Rename the keys to the expected meta key name.
-						( value, attributeKey ) => metaKeys[ attributeKey ],
+						( value, attributeKey ) => metaAttributes[ attributeKey ],
 					);
 
 					if ( ! isEmpty( nextMeta ) ) {

--- a/packages/editor/src/hooks/custom-sources-backwards-compatibility.js
+++ b/packages/editor/src/hooks/custom-sources-backwards-compatibility.js
@@ -75,8 +75,8 @@ const createWithMetaAttributeSource = ( metaAttributes ) => createHigherOrderCom
 );
 
 /**
- * Filters a registered block settings to enhance a block's `edit` component to
- * upgrade meta-sourced attributes to use the post's meta entity property.
+ * Filters a registered block's settings to enhance a block's `edit` component
+ * to upgrade meta-sourced attributes to use the post's meta entity property.
  *
  * @param {WPBlockSettings} settings Registered block settings.
  *


### PR DESCRIPTION
Previously: #17153

This pull request seeks to revise the implementation of custom meta source compatibility by filtering on the block registration to enhance the registered `edit` component if and only if the block includes an meta-sourced attribute.

The advantage here is to optimize for the majority of blocks that do not register any meta-sourced attributes. Previously, the [logic to determine whether a block needs a shim](https://github.com/WordPress/gutenberg/blob/5e68cdce7c8ed4c5fb831c4ccd89ade97524f073/packages/editor/src/hooks/custom-sources-backwards-compatibility.js#L13-L17) would run for each block in the page (at initial load, and on every change of `isTyping` flag), regardless of whether any blocks in content used meta attributes, or even if there were no registered block types which source from meta attributes.

**Implementation Notes:**

It was necessary to change the test plugin to enqueue at `'enqueue_block_assets'` instead of `'init'` for this to work correctly, as otherwise the hook was added too late to enhance the block registration. However, I'd argue this is an error in the implementation of the test plugin, and not symptomatic of a larger concern.

- Per [`wp_enqueue_script`](https://developer.wordpress.org/reference/functions/wp_enqueue_script/#notes) documentation, it is not expected to call the function _for any script_ during `init`, but rather in general use via either the `wp_enqueue_scripts` or `admin_enqueue_scripts` actions.
- It is (and always has been the case) that the documented recommendation for enqueueing block scripts is do so either during the [`enqueue_block_assets`](https://developer.wordpress.org/reference/hooks/enqueue_block_assets/) hook, or by [providing an `editor_script` property to `register_block_type`](https://developer.wordpress.org/block-editor/tutorials/block-tutorial/writing-your-first-block-type/#enqueuing-block-scripts) (which performs the enqueue during `enqueue_block_assets` on behalf of the developer).
- There are already many existing hooks on `blocks.registerBlockType` which would otherwise be subject to the same assumptions of correct script enqueue timing:
  - https://github.com/WordPress/gutenberg/blob/5e68cdce7c8ed4c5fb831c4ccd89ade97524f073/packages/block-editor/src/hooks/align.js#L208
  - https://github.com/WordPress/gutenberg/blob/5e68cdce7c8ed4c5fb831c4ccd89ade97524f073/packages/block-editor/src/hooks/anchor.js#L119
  - https://github.com/WordPress/gutenberg/blob/5e68cdce7c8ed4c5fb831c4ccd89ade97524f073/packages/block-editor/src/hooks/custom-class-name.js#L155

**Performance Results:**

I've been struggling to get the performance test suite to perform stably today. However, I expect that the results as provided by this suite may be misleading, since as noted above, the issue is not as concerning when in an unbroken sequence of typing; a more real-world scenario of start/stop typing would be prove to demonstrate a bigger difference.

Ultimately, I still don't expect it to have a drastic improvement on performance. My attention was originally drawn to it in an [Performance recording bottom-up entry](https://developers.google.com/web/tools/chrome-devtools/evaluate-performance/reference#bottom-up) accounting for a few milliseconds of self-time, so I think it would be fair to assess we could save upwards of a few milliseconds at initial render or keypresses which result in a change in the `isTyping` flag.

**Testing Instructions:**

Verify there is no regression in the behavior of meta-sourced attributes. This is easiest if you are using the local development environment, by activating the "Gutenberg Test Meta Attribute Block" plugin. You should be able to insert the block "Test Meta Attribute Block", update its value, and see the value persist between page loads.