### PR TITLE
Docs: fix typo and improve clarity for "Keeping Your Fork Up To Date" section

### DIFF
--- a/docs/contributors/git-workflow.md
+++ b/docs/contributors/git-workflow.md
@@ -54,7 +54,7 @@ upstream	https://github.com/WordPress/gutenberg.git (fetch)
 upstream	https://github.com/WordPress/gutenberg.git (push)
 ```
 
-To sync your fork, you need to first fetch the upstream changes and merge them into your local copy. These are the corresponding commands:
+To sync your fork, you first need to fetch the upstream changes and merge them into your local copy:
 
 ``` sh
 git fetch upstream

--- a/docs/contributors/git-workflow.md
+++ b/docs/contributors/git-workflow.md
@@ -54,7 +54,7 @@ upstream	https://github.com/WordPress/gutenberg.git (fetch)
 upstream	https://github.com/WordPress/gutenberg.git (push)
 ```
 
-To sync your fork you need to fetch the upstream changes and merge them into your fork. These are the corresponding commands:
+To sync your fork, you need to first fetch the upstream changes and merge them into your local copy. These are the corresponding commands:
 
 ``` sh
 git fetch upstream
@@ -62,7 +62,7 @@ git checkout master
 git merge upstream/master
 ```
 
-This will update you local copy to update your fork on github push your changes
+Once your local copy is updated, push your changes to update your fork on github:
 
 ```
 git push

--- a/docs/contributors/git-workflow.md
+++ b/docs/contributors/git-workflow.md
@@ -62,7 +62,7 @@ git checkout master
 git merge upstream/master
 ```
 
-Once your local copy is updated, push your changes to update your fork on github:
+Once your local copy is updated, push your changes to update your fork on GitHub:
 
 ```
 git push


### PR DESCRIPTION
Instructions provided for [syncing your Fork](https://github.com/WordPress/gutenberg/blob/master/docs/contributors/git-workflow.md) might seem a bit confusing as the commands given are for syncing your Local copy instead:
```sh
git fetch upstream
git checkout master
git merge upstream/master
```

To improve clarity, we can mention that users need to first sync their Local copy using the commands above. After that's done, they can do a `git push` to push the changes and sync their Fork.