### PR TITLE
Block Editor: Flatten, shortcut align hook rendering if unaligned

### DIFF
--- a/packages/block-editor/src/hooks/test/align.js
+++ b/packages/block-editor/src/hooks/test/align.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { noop } from 'lodash';
-import renderer from 'react-test-renderer';
+import renderer, { act } from 'react-test-renderer';
 
 /**
  * WordPress dependencies
@@ -17,10 +17,11 @@ import {
 /**
  * Internal dependencies
  */
+import BlockEditorProvider from '../../components/provider';
 import {
 	getValidAlignments,
 	withToolbarControls,
-	insideSelectWithDataAlign,
+	withDataAlign,
 	addAssignedAlign,
 } from '../align';
 
@@ -169,19 +170,24 @@ describe( 'align', () => {
 				},
 			} );
 
-			const EnhancedComponent = insideSelectWithDataAlign( ( { wrapperProps } ) => (
+			const EnhancedComponent = withDataAlign( ( { wrapperProps } ) => (
 				<div { ...wrapperProps } />
 			) );
 
-			const wrapper = renderer.create(
-				<EnhancedComponent
-					attributes={ {
-						align: 'wide',
-					} }
-					name="core/foo"
-				/>
-			);
-			expect( wrapper.toTree().rendered.props.wrapperProps ).toEqual( {
+			let wrapper;
+			act( () => {
+				wrapper = renderer.create(
+					<BlockEditorProvider settings={ { alignWide: true } } value={ [] }>
+						<EnhancedComponent
+							attributes={ {
+								align: 'wide',
+							} }
+							name="core/foo"
+						/>
+					</BlockEditorProvider>
+				);
+			} );
+			expect( wrapper.root.findByType( 'div' ).props ).toEqual( {
 				'data-align': 'wide',
 			} );
 		} );
@@ -195,20 +201,24 @@ describe( 'align', () => {
 				},
 			} );
 
-			const EnhancedComponent = insideSelectWithDataAlign( ( { wrapperProps } ) => (
+			const EnhancedComponent = withDataAlign( ( { wrapperProps } ) => (
 				<div { ...wrapperProps } />
 			) );
 
-			const wrapper = renderer.create(
-				<EnhancedComponent
-					name="core/foo"
-					attributes={ {
-						align: 'wide',
-					} }
-					hasWideEnabled={ false }
-				/>
-			);
-			expect( wrapper.toTree().rendered.props.wrapperProps ).toEqual( undefined );
+			let wrapper;
+			act( () => {
+				wrapper = renderer.create(
+					<BlockEditorProvider settings={ { alignWide: false } } value={ [] }>
+						<EnhancedComponent
+							name="core/foo"
+							attributes={ {
+								align: 'wide',
+							} }
+						/>
+					</BlockEditorProvider>
+				);
+			} );
+			expect( wrapper.root.findByType( 'div' ).props ).toEqual( {} );
 		} );
 
 		it( 'should not render invalid align', () => {
@@ -220,20 +230,24 @@ describe( 'align', () => {
 				},
 			} );
 
-			const EnhancedComponent = insideSelectWithDataAlign( ( { wrapperProps } ) => (
+			const EnhancedComponent = withDataAlign( ( { wrapperProps } ) => (
 				<div { ...wrapperProps } />
 			) );
 
-			const wrapper = renderer.create(
-				<EnhancedComponent
-					name="core/foo"
-					attributes={ {
-						align: 'wide',
-					} }
-				/>
-			);
-
-			expect( wrapper.toTree().props.wrapperProps ).toBeUndefined();
+			let wrapper;
+			act( () => {
+				wrapper = renderer.create(
+					<BlockEditorProvider settings={ { alignWide: true } } value={ [] }>
+						<EnhancedComponent
+							name="core/foo"
+							attributes={ {
+								align: 'wide',
+							} }
+						/>
+					</BlockEditorProvider>
+				);
+			} );
+			expect( wrapper.root.findByType( 'div' ).props ).toEqual( {} );
 		} );
 	} );
 


### PR DESCRIPTION
This pull request seeks to optimize the implementation of the block alignment `BlockListBlock` filtered higher-order component.

It seeks to improve performance in two ways:

- Flatten the component hierarchy by refactoring the `compose` flow of `withSelect` and an inner component, to a single component using `useSelect`.
- Shortcuts the rendering early if the block does not have an assigned `align` attribute, in order to skip logic involved in validating alignment value (skips calls to `getValidAlignments`, `getBlockSupport`, `hasBlockSupport`, and an `includes` iteration on the `validAlignments` result).

The aim here is to optimize that the majority of blocks will not have an alignment value, and can skip this hook logic.

There might be some way to optimize this even further:

- If we could detect the absence of an attribute even earlier than when the `useSelect` hook is rendered, to avoid another store subscription. Since the hook [cannot be conditionally rendered](https://reactjs.org/docs/hooks-rules.html#only-call-hooks-at-the-top-level), this might have to be part of a separate component or higher-order component, which loses some of the benefit in flattening the hierarchy.
- Move the logic to be handled directly in `BlockEditBlock`, rather than filtering at all. The advantage of the filtering here is in colocating all of the alignments behavior, but there may be an alternative approach we could consider which doesn't have the same overhead as the filter.

**Testing Instructions:**

Verify there are no regressions in the rendering of a block, notably on valid alignments of a block, e.g. in themes with and without wide alignment support (should not show as wide-aligned in the editor if the theme doesn't support it).

Ensure unit tests pass:

```
npm run test-unit packages/block-editor/src/hooks/test/align.js
```