### PR TITLE
Fix #18151

### DIFF
--- a/packages/block-library/src/code/index.js
+++ b/packages/block-library/src/code/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -22,10 +22,7 @@ export const settings = {
 	icon,
 	example: {
 		attributes: {
-			content: sprintf(
-				__( '// A "block" is the abstract term used%1$s// to describe units of markup that%1$s// when composed together, form the%1$s// content or layout of a page.%1$sregisterBlockType( name, settings );' ),
-				'\n'
-			),
+			content: '// A "block" is the abstract term used\n// to describe units of markup that\n// when composed together, form the\n// content or layout of a page.\nregisterBlockType( name, settings );',
 		},
 	},
 	supports: {

--- a/packages/block-library/src/code/index.js
+++ b/packages/block-library/src/code/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -22,11 +22,10 @@ export const settings = {
 	icon,
 	example: {
 		attributes: {
-			content: __( '// A "block" is the abstract term used' ) + '\n' +
-			__( '// to describe units of markup that,' ) + '\n' +
-			__( '// when composed together, form the' ) + '\n' +
-			__( '// content or layout of a page.' ) + '\n' +
-			__( 'registerBlockType( name, settings );' ),
+			content: sprintf(
+				__( '// A "block" is the abstract term used%1$s// to describe units of markup that%1$s// when composed together, form the%1$s// content or layout of a page.%1$sregisterBlockType( name, settings );' ),
+				'\n'
+			),
 		},
 	},
 	supports: {


### PR DESCRIPTION
## Description
It was difficult to translate because of a line break problem.
Fixes #18151

## How has this been tested?
`npm run test` and check actual display

## Screenshots <!-- if applicable -->
<img width="279" alt="スクリーンショット 2019-12-06 14 13 00" src="https://user-images.githubusercontent.com/3748763/70297743-8eb6d680-1832-11ea-8b3f-a85fabed90c7.png">

## Types of changes
Bug fix (non-breaking change which fixes an issue)
