### PR TITLE
Site Title: Access the new API endpoint for editing the site title

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22812,7 +22812,7 @@
 			"dependencies": {
 				"clone-deep": {
 					"version": "0.2.4",
-					"resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
+					"resolved": "http://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
 					"integrity": "sha1-TnPdCen7lxzDhnDF3O2cGJZIHMY=",
 					"dev": true,
 					"requires": {
@@ -22846,7 +22846,7 @@
 					"dependencies": {
 						"kind-of": {
 							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+							"resolved": "http://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
 							"integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
 							"dev": true,
 							"requires": {

--- a/packages/block-library/src/site-title/edit.js
+++ b/packages/block-library/src/site-title/edit.js
@@ -10,10 +10,10 @@ import { __ } from '@wordpress/i18n';
 import { RichText } from '@wordpress/block-editor';
 
 export default function SiteTitleEdit() {
-	const [ title, setTitle ] = useEntityProp( 'root', 'site', 'title' );
+	const [ title, setTitle ] = useEntityProp( 'root', 'siteTitle', 'title' );
 	const [ isDirty, isSaving, save ] = __experimentalUseEntitySaving(
 		'root',
-		'site',
+		'siteTitle',
 		'title'
 	);
 	return (

--- a/packages/block-library/src/site-title/edit.js
+++ b/packages/block-library/src/site-title/edit.js
@@ -10,10 +10,10 @@ import { __ } from '@wordpress/i18n';
 import { RichText } from '@wordpress/block-editor';
 
 export default function SiteTitleEdit() {
-	const [ title, setTitle ] = useEntityProp( 'root', 'siteTitle', 'title' );
+	const [ title, setTitle ] = useEntityProp( 'root', 'public', 'title' );
 	const [ isDirty, isSaving, save ] = __experimentalUseEntitySaving(
 		'root',
-		'siteTitle',
+		'public',
 		'title'
 	);
 	return (

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -13,6 +13,7 @@ export const DEFAULT_ENTITY_KEY = 'id';
 
 export const defaultEntities = [
 	{ name: 'site', kind: 'root', baseURL: '/wp/v2/settings' },
+	{ name: 'siteTitle', kind: 'root', baseURL: '/wp/v2/settings/title' },
 	{ name: 'postType', kind: 'root', key: 'slug', baseURL: '/wp/v2/types' },
 	{ name: 'media', kind: 'root', baseURL: '/wp/v2/media', plural: 'mediaItems' },
 	{ name: 'taxonomy', kind: 'root', key: 'slug', baseURL: '/wp/v2/taxonomies', plural: 'taxonomies' },

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -13,7 +13,7 @@ export const DEFAULT_ENTITY_KEY = 'id';
 
 export const defaultEntities = [
 	{ name: 'site', kind: 'root', baseURL: '/wp/v2/settings' },
-	{ name: 'siteTitle', kind: 'root', baseURL: '/wp/v2/settings/title' },
+	{ name: 'public', kind: 'root', baseURL: '/wp/v2/settings/public' },
 	{ name: 'postType', kind: 'root', key: 'slug', baseURL: '/wp/v2/types' },
 	{ name: 'media', kind: 'root', baseURL: '/wp/v2/media', plural: 'mediaItems' },
 	{ name: 'taxonomy', kind: 'root', key: 'slug', baseURL: '/wp/v2/taxonomies', plural: 'taxonomies' },


### PR DESCRIPTION
## Description
This implement the new REST API endpoints added here: 
https://core.trac.wordpress.org/ticket/48885

## How has this been tested?
Create a new post and add the site title block. You should be able to view and edit the site title.
Now log in as an "Editor". You should be able to view the site title, but not edit it.

## Types of changes
New feature (non-breaking change which adds functionality) 

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
