### PR TITLE
[Tiny PR] Multi selection: fix scroll alter select

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -338,7 +338,8 @@ Undocumented declaration.
 
 <a name="MultiSelectScrollIntoView" href="#MultiSelectScrollIntoView">#</a> **MultiSelectScrollIntoView**
 
-Scrolls the multi block selection end into view if not in view already.
+Scrolls the multi block selection end into view if not in view already. This
+is important to do after selection by keyboard.
 
 <a name="NavigableToolbar" href="#NavigableToolbar">#</a> **NavigableToolbar**
 

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -338,7 +338,7 @@ Undocumented declaration.
 
 <a name="MultiSelectScrollIntoView" href="#MultiSelectScrollIntoView">#</a> **MultiSelectScrollIntoView**
 
-Undocumented declaration.
+Scrolls the multi block selection end into view if not in view already.
 
 <a name="NavigableToolbar" href="#NavigableToolbar">#</a> **NavigableToolbar**
 

--- a/packages/block-editor/src/components/multi-select-scroll-into-view/index.js
+++ b/packages/block-editor/src/components/multi-select-scroll-into-view/index.js
@@ -16,7 +16,8 @@ import { getScrollContainer } from '@wordpress/dom';
 import { getBlockDOMNode } from '../../utils/dom';
 
 /**
- * Scrolls the multi block selection end into view if not in view already.
+ * Scrolls the multi block selection end into view if not in view already. This
+ * is important to do after selection by keyboard.
  */
 export default function MultiSelectScrollIntoView() {
 	const selector = ( select ) => {

--- a/packages/block-editor/src/components/multi-select-scroll-into-view/index.js
+++ b/packages/block-editor/src/components/multi-select-scroll-into-view/index.js
@@ -6,8 +6,8 @@ import scrollIntoView from 'dom-scroll-into-view';
 /**
  * WordPress dependencies
  */
-import { Component } from '@wordpress/element';
-import { withSelect } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
 import { getScrollContainer } from '@wordpress/dom';
 
 /**
@@ -15,24 +15,30 @@ import { getScrollContainer } from '@wordpress/dom';
  */
 import { getBlockDOMNode } from '../../utils/dom';
 
-class MultiSelectScrollIntoView extends Component {
-	componentDidUpdate() {
-		// Relies on expectation that `componentDidUpdate` will only be called
-		// if value of `extentClientId` changes.
-		this.scrollIntoView();
-	}
+/**
+ * Scrolls the multi block selection end into view if not in view already.
+ */
+export default function MultiSelectScrollIntoView() {
+	const selector = ( select ) => {
+		const {
+			getBlockSelectionEnd,
+			isMultiSelecting,
+		} = select( 'core/block-editor' );
 
-	/**
-	 * Ensures that if a multi-selection exists, the extent of the selection is
-	 * visible within the nearest scrollable container.
-	 */
-	scrollIntoView() {
-		const { extentClientId, isMultiSelecting } = this.props;
-		if ( ! extentClientId || isMultiSelecting ) {
+		return {
+			selectionEnd: getBlockSelectionEnd(),
+			isMultiSelecting: isMultiSelecting(),
+		};
+	};
+	const { selectionEnd, isMultiSelecting } = useSelect( selector );
+
+	useEffect( () => {
+		if ( ! selectionEnd || isMultiSelecting ) {
 			return;
 		}
 
-		const extentNode = getBlockDOMNode( extentClientId );
+		const extentNode = getBlockDOMNode( selectionEnd );
+
 		if ( ! extentNode ) {
 			return;
 		}
@@ -48,21 +54,7 @@ class MultiSelectScrollIntoView extends Component {
 		scrollIntoView( extentNode, scrollContainer, {
 			onlyScrollIfNeeded: true,
 		} );
-	}
+	}, [ selectionEnd, isMultiSelecting ] );
 
-	render() {
-		return null;
-	}
+	return null;
 }
-
-export default withSelect( ( select ) => {
-	const {
-		getLastMultiSelectedBlockClientId,
-		isMultiSelecting,
-	} = select( 'core/block-editor' );
-
-	return {
-		extentClientId: getLastMultiSelectedBlockClientId(),
-		isMultiSelecting: isMultiSelecting(),
-	};
-} )( MultiSelectScrollIntoView );


### PR DESCRIPTION
## Description

During upward mouse selection, the page always gets scrolled. This is because `MultiSelectScrollIntoView` looks at the wrong block ID, the last one in the DOM order. Instead, it should be looking at the end of the selection.

Also rewrites the component with hooks.

## How has this been tested?

Selecting upwards with the mouse should not scroll the page when you let go.
Selecting with keyboard up and down should scroll appropriately.

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
