### PR TITLE
Update the error in the image block to use snackbars

### DIFF
--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -33,7 +33,6 @@ import {
 	TextControl,
 	ToggleControl,
 	ToolbarGroup,
-	withNotices,
 } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import {
@@ -297,8 +296,8 @@ export class ImageEdit extends Component {
 	componentDidMount() {
 		const {
 			attributes,
+			createNotice,
 			mediaUpload,
-			noticeOperations,
 		} = this.props;
 		const { id, url = '' } = attributes;
 
@@ -313,7 +312,14 @@ export class ImageEdit extends Component {
 					},
 					allowedTypes: ALLOWED_MEDIA_TYPES,
 					onError: ( message ) => {
-						noticeOperations.createErrorNotice( message );
+						createNotice(
+							'error',
+							message[ 2 ] ? message[ 2 ] : __( 'Sorry an error occourred.' ),
+							{
+								type: 'snackbar',
+							},
+						);
+
 						this.setState( { isEditing: true } );
 					},
 				} );
@@ -337,9 +343,15 @@ export class ImageEdit extends Component {
 	}
 
 	onUploadError( message ) {
-		const { noticeOperations } = this.props;
-		noticeOperations.removeAllNotices();
-		noticeOperations.createErrorNotice( message );
+		const { createNotice } = this.props;
+		createNotice(
+			'error',
+			message[ 2 ] ? message[ 2 ] : __( 'Sorry an error occourred.' ),
+			{
+				type: 'snackbar',
+			},
+		);
+
 		this.setState( {
 			isEditing: true,
 		} );
@@ -583,7 +595,6 @@ export class ImageEdit extends Component {
 			isSelected,
 			className,
 			maxWidth,
-			noticeUI,
 			isRTL,
 			onResizeStart,
 			onResizeStop,
@@ -678,7 +689,6 @@ export class ImageEdit extends Component {
 				onSelectURL={ this.onSelectURL }
 				onDoubleClick={ this.toggleIsEditing }
 				onCancel={ !! url && this.toggleIsEditing }
-				notices={ noticeUI }
 				onError={ this.onUploadError }
 				accept="image/*"
 				allowedTypes={ ALLOWED_MEDIA_TYPES }
@@ -957,10 +967,12 @@ export class ImageEdit extends Component {
 export default compose( [
 	withDispatch( ( dispatch ) => {
 		const { toggleSelection } = dispatch( 'core/block-editor' );
+		const { createNotice } = dispatch( 'core/notices' );
 
 		return {
 			onResizeStart: () => toggleSelection( false ),
 			onResizeStop: () => toggleSelection( true ),
+			createNotice,
 		};
 	} ),
 	withSelect( ( select, props ) => {
@@ -983,5 +995,4 @@ export default compose( [
 		};
 	} ),
 	withViewportMatch( { isLargeViewport: 'medium' } ),
-	withNotices,
 ] )( ImageEdit );


### PR DESCRIPTION
## Description
Now we have snackbar messages available we can use this in the image block for notifying users when their upload fails.

## How has this been tested?
Try uploading an SVG to the image block. You should see a snackbar message telling you that it didn't work.

## Screenshots <!-- if applicable -->
<img width="607" alt="Screenshot 2019-12-06 at 14 56 15" src="https://user-images.githubusercontent.com/275961/70332039-9d07f100-1838-11ea-9aee-50ee10ba715e.png">

## Types of changes
UI Improvement

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
