### PR TITLE
URLInput: check suggestions enabled before update

### DIFF
--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -133,9 +133,12 @@ class URLInput extends Component {
 	}
 
 	onChange( event ) {
+		const { showSuggestions } = this.state;
 		const inputValue = event.target.value;
 		this.props.onChange( inputValue );
-		this.updateSuggestions( inputValue );
+		if ( showSuggestions ) {
+			this.updateSuggestions( inputValue );
+		}
 	}
 
 	onKeyDown( event ) {

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -135,7 +135,7 @@ class URLInput extends Component {
 	onChange( event ) {
 		const inputValue = event.target.value;
 		this.props.onChange( inputValue );
-		if ( this.state.showSuggestions ) {
+		if ( ! this.props.disableSuggestions ) {
 			this.updateSuggestions( inputValue );
 		}
 	}

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -133,10 +133,9 @@ class URLInput extends Component {
 	}
 
 	onChange( event ) {
-		const { showSuggestions } = this.state;
 		const inputValue = event.target.value;
 		this.props.onChange( inputValue );
-		if ( showSuggestions ) {
+		if ( this.state.showSuggestions ) {
 			this.updateSuggestions( inputValue );
 		}
 	}


### PR DESCRIPTION
## Description

The URLInput has a diableSuggestions option, this changes prevents calling the function that checks for suggestions if it is disabled.

This prevents extra API calls and does not show the loader. Both of which should improve performance for entering URLs when suggestions are disabled.

Use case is in Social Links, see: #18946 

## How has this been tested?

1. Add Social Link
2. When typing URL, confirm loader does not show
3. Add another link, for example in a Paragraph block, confirm suggestions/loader does show.

## Types of changes

Adds a check for `disableSuggestions` and if set, does not trigger the updateSuggestions

