### PR TITLE
Correct typo in Example

### DIFF
--- a/packages/block-editor/src/components/rich-text/README.md
+++ b/packages/block-editor/src/components/rich-text/README.md
@@ -123,7 +123,7 @@ registerBlockType( /* ... */, {
 				tagName="h2"
 				className={ className }
 				value={ attributes.content }
-				onChange={ ( content ) => setAttributes( { content } ) }
+				onChange={ ( content ) => setAttributes( { content: content } ) }
 			/>
 		);
 	},


### PR DESCRIPTION
## Description
I found what appears to be a bug/typo in an example on the Readme, and this pull request fixes it.

## How has this been tested?
There has been no direct testing, because it's a readme example. However, in my code that is based on the example, the fixed version works and the live version breaks.

## Screenshots
N/A

## Types of changes
Bug fix in example.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
