### PR TITLE
Make dateI18n returns be affected by `gmt` parameter

### DIFF
--- a/packages/date/README.md
+++ b/packages/date/README.md
@@ -18,26 +18,30 @@ _This package assumes that your code will run in an **ES2015+** environment. If 
 
 <a name="date" href="#date">#</a> **date**
 
-Formats a date (like `date()` in PHP), in the site's timezone.
+Formats a date (like `date()` in PHP).
 
 _Parameters_
 
 -   _dateFormat_ `string`: PHP-style formatting string. See php.net/date.
 -   _dateValue_ `(Date|string|Moment|null)`: Date object or string, parsable by moment.js.
+-   _timezone_ `(string|number|null)`: Timezone to output result in or a UTC offset. Defaults to timezone from site. See momentjs.com.
 
 _Returns_
 
--   `string`: Formatted date.
+-   `string`: Formatted date in English.
 
 <a name="dateI18n" href="#dateI18n">#</a> **dateI18n**
 
-Formats a date (like `date_i18n()` in PHP).
+Formats a date (like `wp_date()` in PHP), translating it into site's locale.
+
+Backward Compatibility Notice: if `timezone` is set to `true`, the function
+behaves like `gmdateI18n`.
 
 _Parameters_
 
 -   _dateFormat_ `string`: PHP-style formatting string. See php.net/date.
 -   _dateValue_ `(Date|string|Moment|null)`: Date object or string, parsable by moment.js.
--   _gmt_ `boolean`: True for GMT/UTC, false for site's timezone.
+-   _timezone_ `(string|number|null)`: Timezone to output result in or a UTC offset. Defaults to timezone from site. See momentjs.com.
 
 _Returns_
 
@@ -71,6 +75,20 @@ _Returns_
 <a name="gmdate" href="#gmdate">#</a> **gmdate**
 
 Formats a date (like `date()` in PHP), in the UTC timezone.
+
+_Parameters_
+
+-   _dateFormat_ `string`: PHP-style formatting string. See php.net/date.
+-   _dateValue_ `(Date|string|Moment|null)`: Date object or string, parsable by moment.js.
+
+_Returns_
+
+-   `string`: Formatted date in English.
+
+<a name="gmdateI18n" href="#gmdateI18n">#</a> **gmdateI18n**
+
+Formats a date (like `wp_date()` in PHP), translating it into site's locale
+and using the UTC timezone.
 
 _Parameters_
 

--- a/packages/date/README.md
+++ b/packages/date/README.md
@@ -20,11 +20,16 @@ _This package assumes that your code will run in an **ES2015+** environment. If 
 
 Formats a date (like `date()` in PHP).
 
+_Related_
+
+-   {@link <https://en.wikipedia.org/wiki/List_of_tz_database_time_zones|Timezones}>
+-   {@link <https://en.wikipedia.org/wiki/ISO_8601#Time_offsets_from_UTC|UTC> Offsets}
+
 _Parameters_
 
 -   _dateFormat_ `string`: PHP-style formatting string. See php.net/date.
 -   _dateValue_ `(Date|string|Moment|null)`: Date object or string, parsable by moment.js.
--   _timezone_ `(string|number|null)`: Timezone to output result in or a UTC offset. Defaults to timezone from site. See momentjs.com.
+-   _timezone_ `(string|number|null)`: Timezone to output result in or a UTC offset. Defaults to timezone from site.
 
 _Returns_
 
@@ -37,11 +42,16 @@ Formats a date (like `wp_date()` in PHP), translating it into site's locale.
 Backward Compatibility Notice: if `timezone` is set to `true`, the function
 behaves like `gmdateI18n`.
 
+_Related_
+
+-   {@link <https://en.wikipedia.org/wiki/List_of_tz_database_time_zones|Timezones}>
+-   {@link <https://en.wikipedia.org/wiki/ISO_8601#Time_offsets_from_UTC|UTC> Offsets}
+
 _Parameters_
 
 -   _dateFormat_ `string`: PHP-style formatting string. See php.net/date.
 -   _dateValue_ `(Date|string|Moment|null)`: Date object or string, parsable by moment.js.
--   _timezone_ `(string|number|null)`: Timezone to output result in or a UTC offset. Defaults to timezone from site. See momentjs.com.
+-   _timezone_ `(string|number|boolean|null)`: Timezone to output result in or a UTC offset. Defaults to timezone from site. Notice: `boolean` is effectively deprecated, but still supported for backward compatibility reasons.
 
 _Returns_
 

--- a/packages/date/README.md
+++ b/packages/date/README.md
@@ -22,8 +22,8 @@ Formats a date (like `date()` in PHP).
 
 _Related_
 
--   {@link <https://en.wikipedia.org/wiki/List_of_tz_database_time_zones|Timezones}>
--   {@link <https://en.wikipedia.org/wiki/ISO_8601#Time_offsets_from_UTC|UTC> Offsets}
+-   <https://en.wikipedia.org/wiki/List_of_tz_database_time_zones>
+-   <https://en.wikipedia.org/wiki/ISO_8601#Time_offsets_from_UTC>
 
 _Parameters_
 
@@ -44,8 +44,8 @@ behaves like `gmdateI18n`.
 
 _Related_
 
--   {@link <https://en.wikipedia.org/wiki/List_of_tz_database_time_zones|Timezones}>
--   {@link <https://en.wikipedia.org/wiki/ISO_8601#Time_offsets_from_UTC|UTC> Offsets}
+-   <https://en.wikipedia.org/wiki/List_of_tz_database_time_zones>
+-   <https://en.wikipedia.org/wiki/ISO_8601#Time_offsets_from_UTC>
 
 _Parameters_
 

--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -475,19 +475,21 @@ export function getDate( dateString ) {
  * @return {Moment}  a moment instance.
  */
 function buildMoment( dateValue, timezone ) {
+	const dateMoment = momentLib( dateValue );
+
 	if ( timezone && ! isUTCOffset( timezone ) ) {
-		return momentLib( dateValue ).tz( timezone );
+		return dateMoment.tz( timezone );
 	}
 
 	if ( timezone && isUTCOffset( timezone ) ) {
-		return momentLib( dateValue ).utcOffset( timezone );
+		return dateMoment.utcOffset( timezone );
 	}
 
 	if ( settings.timezone.string ) {
-		return momentLib( dateValue ).tz( settings.timezone.string );
+		return dateMoment.tz( settings.timezone.string );
 	}
 
-	return momentLib( dateValue ).utcOffset( settings.timezone.offset );
+	return dateMoment.utcOffset( settings.timezone.offset );
 }
 
 const VALID_UTC_OFFSET = /^[+-][0-1][0-9](:[0-9][0-9])?$/;

--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -371,8 +371,8 @@ export function format( dateFormat, dateValue = new Date() ) {
  *                                             UTC offset. Defaults to timezone from
  *                                             site.
  *
- * @see {@link https://en.wikipedia.org/wiki/List_of_tz_database_time_zones|Timezones}
- * @see {@link https://en.wikipedia.org/wiki/ISO_8601#Time_offsets_from_UTC|UTC Offsets}
+ * @see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+ * @see https://en.wikipedia.org/wiki/ISO_8601#Time_offsets_from_UTC
  *
  * @return {string} Formatted date in English.
  */
@@ -412,8 +412,8 @@ export function gmdate( dateFormat, dateValue = new Date() ) {
  *                                                deprecated, but still supported for
  *                                                backward compatibility reasons.
  *
- * @see {@link https://en.wikipedia.org/wiki/List_of_tz_database_time_zones|Timezones}
- * @see {@link https://en.wikipedia.org/wiki/ISO_8601#Time_offsets_from_UTC|UTC Offsets}
+ * @see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+ * @see https://en.wikipedia.org/wiki/ISO_8601#Time_offsets_from_UTC
  *
  * @return {string} Formatted date.
  */
@@ -486,8 +486,8 @@ export function getDate( dateString ) {
  *                                            UTC offset. Defaults to timezone from
  *                                            site.
  *
- * @see {@link https://en.wikipedia.org/wiki/List_of_tz_database_time_zones|Timezones}
- * @see {@link https://en.wikipedia.org/wiki/ISO_8601#Time_offsets_from_UTC|UTC Offsets}
+ * @see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+ * @see https://en.wikipedia.org/wiki/ISO_8601#Time_offsets_from_UTC
  *
  * @return {Moment} a moment instance.
  */

--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -475,11 +475,11 @@ export function getDate( dateString ) {
  * @return {Moment}  a moment instance.
  */
 function buildMoment( dateValue, timezone ) {
-	if ( timezone && ! isUtcOffset( timezone ) ) {
+	if ( timezone && ! isUTCOffset( timezone ) ) {
 		return momentLib( dateValue ).tz( timezone );
 	}
 
-	if ( timezone && isUtcOffset( timezone ) ) {
+	if ( timezone && isUTCOffset( timezone ) ) {
 		return momentLib( dateValue ).utcOffset( timezone );
 	}
 
@@ -499,10 +499,10 @@ const VALID_UTC_OFFSET = /^[+-][0-1][0-9](:[0-9][0-9])?$/;
  *
  * @return {boolean} whether a certain UTC offset is valid or not.
  */
-function isUtcOffset( offset ) {
+function isUTCOffset( offset ) {
 	if ( 'number' === typeof offset ) {
 		return true;
-	} //end if
+	}
 
 	offset = `${ offset }`;
 	return VALID_UTC_OFFSET.test( offset );

--- a/packages/date/src/test/index.js
+++ b/packages/date/src/test/index.js
@@ -2,10 +2,14 @@
  * Internal dependencies
  */
 import {
-	isInTheFuture,
-	getDate,
-	setSettings,
 	__experimentalGetSettings,
+	date as dateNoI18n,
+	dateI18n,
+	getDate,
+	gmdate,
+	gmdateI18n,
+	isInTheFuture,
+	setSettings,
 } from '../';
 
 describe( 'isInTheFuture', () => {
@@ -16,7 +20,7 @@ describe( 'isInTheFuture', () => {
 		expect( isInTheFuture( date ) ).toBe( true );
 	} );
 
-	it( 'should return true if the date is in the past', () => {
+	it( 'should return false if the date is in the past', () => {
 		// Create a Date object 1 minute in the past.
 		const date = new Date( Number( getDate() ) - 1000 * 60 );
 
@@ -38,6 +42,433 @@ describe( 'isInTheFuture', () => {
 		// Create a Date object 1 minute in the future.
 		date = new Date( Number( getDate() ) + 1000 * 60 );
 		expect( isInTheFuture( date ) ).toBe( true );
+
+		// Restore default settings
+		setSettings( settings );
+	} );
+} );
+
+describe( 'Function date', () => {
+	it( 'should format date in English, ignoring locale settings', () => {
+		const settings = __experimentalGetSettings();
+
+		// Simulate different locale
+		const l10n = settings.l10n;
+		setSettings( {
+			...settings,
+			l10n: {
+				...l10n,
+				locale: 'es',
+				months: l10n.months.map( ( month ) => `es_${ month }` ),
+				monthsShort: l10n.monthsShort.map(
+					( month ) => `es_${ month }`
+				),
+				weekdays: l10n.weekdays.map( ( weekday ) => `es_${ weekday }` ),
+				weekdaysShort: l10n.weekdaysShort.map(
+					( weekday ) => `es_${ weekday }`
+				),
+			},
+		} );
+
+		// Check
+		const formattedDate = dateNoI18n(
+			'F M l D',
+			'2019-06-18T11:00:00.000Z'
+		);
+		expect( formattedDate ).toBe( 'June Jun Tuesday Tue' );
+
+		// Restore default settings
+		setSettings( settings );
+	} );
+
+	it( 'should format date into a date that uses site’s timezone, if no timezone was provided and there’s a site timezone set', () => {
+		const settings = __experimentalGetSettings();
+
+		// Simulate different timezone
+		setSettings( {
+			...settings,
+			timezone: { offset: -4, string: 'America/New_York' },
+		} );
+
+		// Check
+		const winterFormattedDate = dateNoI18n(
+			'Y-m-d H:i',
+			'2019-01-18T11:00:00.000Z'
+		);
+		expect( winterFormattedDate ).toBe( '2019-01-18 06:00' );
+
+		const summerFormattedDate = dateNoI18n(
+			'Y-m-d H:i',
+			'2019-06-18T11:00:00.000Z'
+		);
+		expect( summerFormattedDate ).toBe( '2019-06-18 07:00' );
+
+		// Restore default settings
+		setSettings( settings );
+	} );
+
+	it( 'should format date into a date that uses site’s UTC offset setting, if no timezone was provided and there isn’t a timezone set in the site', () => {
+		const settings = __experimentalGetSettings();
+
+		// Simulate different timezone
+		setSettings( {
+			...settings,
+			timezone: { offset: -4, string: '' },
+		} );
+
+		// Check
+		const winterFormattedDate = dateNoI18n(
+			'Y-m-d H:i',
+			'2019-01-18T11:00:00.000Z'
+		);
+		expect( winterFormattedDate ).toBe( '2019-01-18 07:00' );
+
+		const summerFormattedDate = dateNoI18n(
+			'Y-m-d H:i',
+			'2019-06-18T11:00:00.000Z'
+		);
+		expect( summerFormattedDate ).toBe( '2019-06-18 07:00' );
+
+		// Restore default settings
+		setSettings( settings );
+	} );
+
+	it( 'should format date into a date that uses the given timezone, if said timezone is valid', () => {
+		const settings = __experimentalGetSettings();
+
+		// Simulate different timezone
+		setSettings( {
+			...settings,
+			timezone: { offset: -4, string: 'America/New_York' },
+		} );
+
+		// Check
+		const formattedDate = dateNoI18n(
+			'Y-m-d H:i',
+			'2019-06-18T11:00:00.000Z',
+			'Asia/Macau'
+		);
+		expect( formattedDate ).toBe( '2019-06-18 19:00' );
+
+		// Restore default settings
+		setSettings( settings );
+	} );
+
+	it( 'should format date into a date that uses the given UTC offset, if given timezone is actually a UTC offset', () => {
+		const settings = __experimentalGetSettings();
+
+		// Simulate different timezone
+		setSettings( {
+			...settings,
+			timezone: { offset: -4, string: 'America/New_York' },
+		} );
+
+		// Check
+		let formattedDate;
+		formattedDate = dateNoI18n(
+			'Y-m-d H:i',
+			'2019-06-18T11:00:00.000Z',
+			'+08:00'
+		);
+		expect( formattedDate ).toBe( '2019-06-18 19:00' );
+
+		formattedDate = dateNoI18n(
+			'Y-m-d H:i',
+			'2019-06-18T11:00:00.000Z',
+			8
+		);
+		expect( formattedDate ).toBe( '2019-06-18 19:00' );
+
+		formattedDate = dateNoI18n(
+			'Y-m-d H:i',
+			'2019-06-18T11:00:00.000Z',
+			480
+		);
+		expect( formattedDate ).toBe( '2019-06-18 19:00' );
+
+		// Restore default settings
+		setSettings( settings );
+	} );
+} );
+
+describe( 'Function gmdate', () => {
+	it( 'should format date in English, ignoring locale settings', () => {
+		const settings = __experimentalGetSettings();
+
+		// Simulate different locale
+		const l10n = settings.l10n;
+		setSettings( {
+			...settings,
+			l10n: {
+				...l10n,
+				locale: 'es',
+				months: l10n.months.map( ( month ) => `es_${ month }` ),
+				monthsShort: l10n.monthsShort.map(
+					( month ) => `es_${ month }`
+				),
+				weekdays: l10n.weekdays.map( ( weekday ) => `es_${ weekday }` ),
+				weekdaysShort: l10n.weekdaysShort.map(
+					( weekday ) => `es_${ weekday }`
+				),
+			},
+		} );
+
+		// Check
+		const formattedDate = gmdate( 'F M l D', '2019-06-18T11:00:00.000Z' );
+		expect( formattedDate ).toBe( 'June Jun Tuesday Tue' );
+
+		// Restore default settings
+		setSettings( settings );
+	} );
+
+	it( 'should format date into a UTC date', () => {
+		const settings = __experimentalGetSettings();
+
+		// Simulate different timezone
+		setSettings( {
+			...settings,
+			timezone: { offset: -4, string: 'America/New_York' },
+		} );
+
+		// Check
+		const formattedDate = gmdate( 'Y-m-d H:i', '2019-06-18T11:00:00.000Z' );
+		expect( formattedDate ).toBe( '2019-06-18 11:00' );
+
+		// Restore default settings
+		setSettings( settings );
+	} );
+} );
+
+describe( 'Function dateI18n', () => {
+	it( 'should format date using locale settings', () => {
+		const settings = __experimentalGetSettings();
+
+		// Simulate different locale
+		const l10n = settings.l10n;
+		setSettings( {
+			...settings,
+			l10n: {
+				...l10n,
+				locale: 'es',
+				months: l10n.months.map( ( month ) => `es_${ month }` ),
+				monthsShort: l10n.monthsShort.map(
+					( month ) => `es_${ month }`
+				),
+				weekdays: l10n.weekdays.map( ( weekday ) => `es_${ weekday }` ),
+				weekdaysShort: l10n.weekdaysShort.map(
+					( weekday ) => `es_${ weekday }`
+				),
+			},
+		} );
+
+		// Check
+		const formattedDate = dateI18n(
+			'F M l D',
+			'2019-06-18T11:00:00.000Z',
+			true
+		);
+		expect( formattedDate ).toBe( 'es_June es_Jun es_Tuesday es_Tue' );
+
+		// Restore default settings
+		setSettings( settings );
+	} );
+
+	it( 'should format date into a date that uses site’s timezone, if no timezone was provided and there’s a site timezone set', () => {
+		const settings = __experimentalGetSettings();
+
+		// Simulate different timezone
+		setSettings( {
+			...settings,
+			timezone: { offset: -4, string: 'America/New_York' },
+		} );
+
+		// Check
+		const winterFormattedDate = dateI18n(
+			'Y-m-d H:i',
+			'2019-01-18T11:00:00.000Z'
+		);
+		expect( winterFormattedDate ).toBe( '2019-01-18 06:00' );
+
+		const summerFormattedDate = dateI18n(
+			'Y-m-d H:i',
+			'2019-06-18T11:00:00.000Z'
+		);
+		expect( summerFormattedDate ).toBe( '2019-06-18 07:00' );
+
+		// Restore default settings
+		setSettings( settings );
+	} );
+
+	it( 'should format date into a date that uses site’s UTC offset setting, if no timezone was provided and there isn’t a timezone set in the site', () => {
+		const settings = __experimentalGetSettings();
+
+		// Simulate different timezone
+		setSettings( {
+			...settings,
+			timezone: { offset: -4, string: '' },
+		} );
+
+		// Check
+		const winterFormattedDate = dateI18n(
+			'Y-m-d H:i',
+			'2019-01-18T11:00:00.000Z'
+		);
+		expect( winterFormattedDate ).toBe( '2019-01-18 07:00' );
+
+		const summerFormattedDate = dateI18n(
+			'Y-m-d H:i',
+			'2019-06-18T11:00:00.000Z'
+		);
+		expect( summerFormattedDate ).toBe( '2019-06-18 07:00' );
+
+		// Restore default settings
+		setSettings( settings );
+	} );
+
+	it( 'should format date into a date that uses the given timezone, if said timezone is valid', () => {
+		const settings = __experimentalGetSettings();
+
+		// Simulate different timezone
+		setSettings( {
+			...settings,
+			timezone: { offset: -4, string: 'America/New_York' },
+		} );
+
+		// Check
+		const formattedDate = dateI18n(
+			'Y-m-d H:i',
+			'2019-06-18T11:00:00.000Z',
+			'Asia/Macau'
+		);
+		expect( formattedDate ).toBe( '2019-06-18 19:00' );
+
+		// Restore default settings
+		setSettings( settings );
+	} );
+
+	it( 'should format date into a date that uses the given UTC offset, if given timezone is actually a UTC offset', () => {
+		const settings = __experimentalGetSettings();
+
+		// Simulate different timezone
+		setSettings( {
+			...settings,
+			timezone: { offset: -4, string: 'America/New_York' },
+		} );
+
+		// Check
+		let formattedDate;
+		formattedDate = dateI18n(
+			'Y-m-d H:i',
+			'2019-06-18T11:00:00.000Z',
+			'+08:00'
+		);
+		expect( formattedDate ).toBe( '2019-06-18 19:00' );
+
+		formattedDate = dateI18n( 'Y-m-d H:i', '2019-06-18T11:00:00.000Z', 8 );
+		expect( formattedDate ).toBe( '2019-06-18 19:00' );
+
+		formattedDate = dateI18n(
+			'Y-m-d H:i',
+			'2019-06-18T11:00:00.000Z',
+			480
+		);
+		expect( formattedDate ).toBe( '2019-06-18 19:00' );
+
+		// Restore default settings
+		setSettings( settings );
+	} );
+
+	it( 'should format date into a UTC date if `gmt` is set to `true`', () => {
+		const settings = __experimentalGetSettings();
+
+		// Simulate different timezone
+		setSettings( {
+			...settings,
+			timezone: { offset: -4, string: 'America/New_York' },
+		} );
+
+		// Check
+		const formattedDate = dateI18n(
+			'Y-m-d H:i',
+			'2019-06-18T11:00:00.000Z',
+			true
+		);
+		expect( formattedDate ).toBe( '2019-06-18 11:00' );
+
+		// Restore default settings
+		setSettings( settings );
+	} );
+
+	it( 'should format date into a date that uses site’s timezone if `gmt` is set to `false`', () => {
+		const settings = __experimentalGetSettings();
+
+		// Simulate different timezone
+		setSettings( {
+			...settings,
+			timezone: { offset: -4, string: 'America/New_York' },
+		} );
+
+		// Check
+		const formattedDate = dateI18n(
+			'Y-m-d H:i',
+			'2019-06-18T11:00:00.000Z',
+			false
+		);
+		expect( formattedDate ).toBe( '2019-06-18 07:00' );
+
+		// Restore default settings
+		setSettings( settings );
+	} );
+} );
+
+describe( 'Function gmdateI18n', () => {
+	it( 'should format date using locale settings', () => {
+		const settings = __experimentalGetSettings();
+
+		// Simulate different locale
+		const l10n = settings.l10n;
+		setSettings( {
+			...settings,
+			l10n: {
+				...l10n,
+				locale: 'es',
+				months: l10n.months.map( ( month ) => `es_${ month }` ),
+				monthsShort: l10n.monthsShort.map(
+					( month ) => `es_${ month }`
+				),
+				weekdays: l10n.weekdays.map( ( weekday ) => `es_${ weekday }` ),
+				weekdaysShort: l10n.weekdaysShort.map(
+					( weekday ) => `es_${ weekday }`
+				),
+			},
+		} );
+
+		// Check
+		const formattedDate = gmdateI18n(
+			'F M l D',
+			'2019-06-18T11:00:00.000Z'
+		);
+		expect( formattedDate ).toBe( 'es_June es_Jun es_Tuesday es_Tue' );
+
+		// Restore default settings
+		setSettings( settings );
+	} );
+
+	it( 'should format date into a UTC date', () => {
+		const settings = __experimentalGetSettings();
+
+		// Simulate different timezone
+		setSettings( {
+			...settings,
+			timezone: { offset: -4, string: 'America/New_York' },
+		} );
+
+		// Check
+		const formattedDate = gmdateI18n(
+			'Y-m-d H:i',
+			'2019-06-18T11:00:00.000Z'
+		);
+		expect( formattedDate ).toBe( '2019-06-18 11:00' );
 
 		// Restore default settings
 		setSettings( settings );


### PR DESCRIPTION
## Description
The PR adds a couple of tests to reproduce the issue #16218 reported by @iandunn and proposes a simple fix.

## Types of changes
Bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
