### PR TITLE
Add `initialOpen` support for `PluginDocumentSettingPanel` component.

### DIFF
--- a/packages/edit-post/README.md
+++ b/packages/edit-post/README.md
@@ -150,6 +150,7 @@ _Parameters_
 -   _props.className_ `[string]`: An optional class name added to the row.
 -   _props.title_ `[string]`: The title of the panel
 -   _props.icon_ `[WPBlockTypeIconRender]`: The [Dashicon](https://developer.wordpress.org/resource/dashicons/) icon slug string, or an SVG WP element, to be rendered when the sidebar is pinned to toolbar.
+-   _props.initialOpen_ `[boolean]`: An optional behavior to always start with panel open.
 
 _Returns_
 

--- a/packages/edit-post/src/components/sidebar/plugin-document-setting-panel/index.js
+++ b/packages/edit-post/src/components/sidebar/plugin-document-setting-panel/index.js
@@ -17,7 +17,7 @@ import { EnablePluginDocumentSettingPanelOption } from '../../options-modal/opti
 
 export const { Fill, Slot } = createSlotFill( 'PluginDocumentSettingPanel' );
 
-const PluginDocumentSettingFill = ( { isEnabled, panelName, opened, onToggle, className, title, icon, children } ) => {
+const PluginDocumentSettingFill = ( { isEnabled, panelName, opened, onToggle, className, title, icon, children, initialOpen } ) => {
 	return (
 		<>
 			<EnablePluginDocumentSettingPanelOption
@@ -30,8 +30,9 @@ const PluginDocumentSettingFill = ( { isEnabled, panelName, opened, onToggle, cl
 						className={ className }
 						title={ title }
 						icon={ icon }
-						opened={ opened }
-						onToggle={ onToggle }
+						initialOpen={ initialOpen }
+						opened={ initialOpen ? undefined : opened }
+						onToggle={ initialOpen ? undefined : onToggle }
 					>
 						{ children }
 					</PanelBody>

--- a/packages/edit-post/src/components/sidebar/plugin-document-setting-panel/index.js
+++ b/packages/edit-post/src/components/sidebar/plugin-document-setting-panel/index.js
@@ -50,6 +50,7 @@ const PluginDocumentSettingFill = ( { isEnabled, panelName, opened, onToggle, cl
  * @param {string} [props.className] An optional class name added to the row.
  * @param {string} [props.title] The title of the panel
  * @param {WPBlockTypeIconRender} [props.icon=inherits from the plugin] The [Dashicon](https://developer.wordpress.org/resource/dashicons/) icon slug string, or an SVG WP element, to be rendered when the sidebar is pinned to toolbar.
+ * @param {boolean} [props.initialOpen] An optional behavior to always start with panel open.
  *
  * @example <caption>ES5</caption>
  * ```js


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
Added an optional `initialOpen` prop to the `PluginDocumentSettingPanel` component.  

This component is defined using the `PanelBody` as a child.  Since the `PanelBody` already has support for the `initialOpen` prop, we are just adding support for that prop to be passed in from the `PluginDocumentSettingPanel` parent.

When `initialOpen` is defined and passed a truthy value, it will always start open and will ignore its `opened` and `onToggle` properties from the data store connection.  Otherwise, behavior remains as it was prior to this change.

### Why?
Last week I found the case where we wanted to have a `PluginDocumentSettingPanel` always open by default.  In digging I found that the `PanelBody` had support for an `initialOpen` property but that the `PluginDocumentSettingPanel` was not set up to pass this prop down to the `PanelBody`.  This was disappointing as it would have made things very simple, so I figured I would update it and see what others think about adding this optional functionality.

Without this our fix had to be a temporary subscription to the data store.  A function to check if the state was closed and to dispatch the toggle runs once and is then unsubscribed.  While this is a fairly simple thing to do, adding support for `initialOpen` will allow this component to be more robust and more easily usable for other cases in the future.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
* Run this PR.
* Add a `PluginDocumentSettingPanel`(I added this in an active plugin).
* Test its behavior without adding the `initialOpen` prop, verify there are no changes in functionality.
* Add the `initialOpen` prop and give it a falsey value.  Verify again there are no changes in functionality.
* Give the `initialOpen` a truthy value.  Verify that the panel always starts open when returning to the editor regardless of its last state.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x]  I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
