### PR TITLE
Env: Support running arbitrary commands and use it for linting and server registered fixtures.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ env:
     - INSTALL_COMPOSER: false
     - INSTALL_WORDPRESS: true
 
+# Make sure NodeGit gets the correct C libs.
 addons:
   apt:
     sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-dist: trusty
-
 language: generic
 
 services:
@@ -31,6 +29,13 @@ env:
     - LOCAL_SCRIPT_DEBUG: false
     - INSTALL_COMPOSER: false
     - INSTALL_WORDPRESS: true
+
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - libstdc++-4.9-dev
 
 before_install:
   - nvm install --latest-npm

--- a/package.json
+++ b/package.json
@@ -174,13 +174,13 @@
 		"dev:packages": "node ./bin/packages/watch.js",
 		"docs:build": "node ./docs/tool/index.js && node ./bin/update-readmes.js",
 		"fixtures:clean": "rimraf \"packages/e2e-tests/fixtures/blocks/*.+(json|serialized.html)\"",
-		"fixtures:server-registered": "wp-scripts env docker-run php ./bin/get-server-blocks.php > test/integration/full-content/server-registered.json",
+		"fixtures:server-registered": "npm run wp-env run tests-wordpress-phpunit './bin/get-server-blocks.php > test/integration/full-content/server-registered.json'",
 		"fixtures:generate": "npm run fixtures:server-registered && cross-env GENERATE_MISSING_FIXTURES=y npm run test-unit",
 		"fixtures:regenerate": "npm run fixtures:clean && npm run fixtures:generate",
 		"lint": "concurrently \"npm run lint-js\" \"npm run lint-pkg-json\" \"npm run lint-css\" \"npm run lint-types\"",
 		"lint-js": "wp-scripts lint-js",
 		"lint-js:fix": "npm run lint-js -- --fix",
-		"lint-php": "wp-scripts env lint-php",
+		"lint-php": "npm run wp-env run composer run-script lint",
 		"lint-pkg-json": "wp-scripts lint-pkg-json . 'packages/*/package.json'",
 		"lint-css": "wp-scripts lint-style '**/*.scss'",
 		"lint-css:fix": "npm run lint-css -- --fix",
@@ -212,7 +212,8 @@
 		"playground:build": "npm run storybook:build",
 		"playground:dev": "echo \"Please use storybook:dev instead.\"",
 		"preenv": "npm run check-engines",
-		"env": "wp-scripts env"
+		"env": "wp-scripts env",
+		"wp-env": "packages/env/bin/wp-env"
 	},
 	"husky": {
 		"hooks": {

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -14,17 +14,18 @@ $ wp-env --help
 wp-env <command>
 
 Commands:
-  wp-env start [ref]          Starts WordPress for development on port 8888
-                              (​http://localhost:8888​) (override with
-                              WP_ENV_PORT) and tests on port 8889
-                              (​http://localhost:8889​) (override with
-                              WP_ENV_TESTS_PORT). If the current working
-                              directory is a plugin and/or has e2e-tests with
-                              plugins and/or mu-plugins, they will be mounted
-                              appropriately.
-  wp-env stop                 Stops running WordPress for development and tests
-                              and frees the ports.
-  wp-env clean [environment]  Cleans the WordPress databases.
+  wp-env start [ref]                  Starts WordPress for development on port
+                                      8888 (​http://localhost:8888​) and tests
+                                      on port 8889 (​http://localhost:8889​). If
+                                      the current working directory is a plugin
+                                      and/or has e2e-tests with plugins and/or
+                                      mu-plugins, they will be mounted
+                                      appropiately.
+  wp-env stop                         Stops running WordPress for development
+                                      and tests and frees the ports.
+  wp-env clean [environment]          Cleans the WordPress databases.
+  wp-env run <container> [command..]  Runs an arbitrary command in one of the
+                                      underlying Docker containers.
 
 Options:
   --help     Show help                                                 [boolean]
@@ -65,6 +66,16 @@ Cleans the WordPress databases.
 Positionals:
   environment  Which environments' databases to clean.
             [string] [choices: "all", "development", "tests"] [default: "tests"]
+```
+
+### `$ wp-env run --help`
+
+```sh
+wp-env run <container> [command..]
+Runs an arbitrary command in one of the underlying Docker containers.
+Positionals:
+  container  The container to run the command on.            [string] [required]
+  command    The command to run.                           [array] [default: []]
 ```
 
 <br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>

--- a/packages/env/lib/cli.js
+++ b/packages/env/lib/cli.js
@@ -33,7 +33,12 @@ const withSpinner = ( command ) => ( ...args ) => {
 				) }ms)`
 			);
 		},
-		( err ) => spinner.fail( err.message || err.err )
+		( err ) => {
+			spinner.fail( err.message || err.err );
+			// eslint-disable-next-line no-console
+			console.error( `\n\n${ err.out || err.err }\n\n` );
+			process.exit( err.exitCode || 1 );
+		}
 	);
 };
 
@@ -81,6 +86,21 @@ module.exports = function cli() {
 			} );
 		},
 		withSpinner( env.clean )
+	);
+	yargs.command(
+		'run <container> [command..]',
+		'Runs an arbitrary command in one of the underlying Docker containers.',
+		( args ) => {
+			args.positional( 'container', {
+				type: 'string',
+				describe: 'The container to run the command on.',
+			} );
+			args.positional( 'command', {
+				type: 'string',
+				describe: 'The command to run.',
+			} );
+		},
+		withSpinner( env.run )
 	);
 
 	return yargs;

--- a/packages/env/lib/create-docker-compose-config.js
+++ b/packages/env/lib/create-docker-compose-config.js
@@ -20,6 +20,8 @@ ${ dependencyMappings }
 	const testsVolumes = `
       - ${ cwd }/../${ cwdName }-tests-wordpress/:/var/www/html/${ commonVolumes }`;
 	return `version: '2.1'
+volumes:
+  tests-wordpress-phpunit:
 services:
   mysql:
     environment:
@@ -57,5 +59,18 @@ services:
       - tests-wordpress
     image: wordpress:cli
     volumes:${ testsVolumes }
-  `;
+  tests-wordpress-phpunit:
+    depends_on:
+      - mysql
+    environment:
+      PHPUNIT_DB_HOST: mysql
+    image: chriszarate/wordpress-phpunit
+    volumes:
+      - ${ cwd }/:/app/
+      - tests-wordpress-phpunit/:/tmp/
+  composer:
+    image: composer
+    volumes:
+      - ${ cwd }/:/app/
+`;
 };

--- a/packages/env/test/cli.js
+++ b/packages/env/test/cli.js
@@ -87,17 +87,45 @@ describe( 'env cli', () => {
 	} );
 
 	it( 'handles failed commands with messages.', async () => {
-		env.start.mockRejectedValueOnce( { message: 'failure message' } );
+		/* eslint-disable no-console */
+		env.start.mockRejectedValueOnce( {
+			message: 'failure message',
+			out: 'failure message',
+			exitCode: 2,
+		} );
+		const consoleError = console.error;
+		console.error = jest.fn();
+		const processExit = process.exit;
+		process.exit = jest.fn();
+
 		cli().parse( [ 'start' ] );
 		const { spinner } = env.start.mock.calls[ 0 ][ 0 ];
 		await env.start.mock.results[ 0 ].value.catch( () => {} );
+
 		expect( spinner.fail ).toHaveBeenCalledWith( 'failure message' );
+		expect( console.error ).toHaveBeenCalledWith( '\n\nfailure message\n\n' );
+		expect( process.exit ).toHaveBeenCalledWith( 2 );
+		console.error = consoleError;
+		process.exit = processExit;
+		/* eslint-enable no-console */
 	} );
 	it( 'handles failed commands with errors.', async () => {
+		/* eslint-disable no-console */
 		env.start.mockRejectedValueOnce( { err: 'failure error' } );
+		const consoleError = console.error;
+		console.error = jest.fn();
+		const processExit = process.exit;
+		process.exit = jest.fn();
+
 		cli().parse( [ 'start' ] );
 		const { spinner } = env.start.mock.calls[ 0 ][ 0 ];
 		await env.start.mock.results[ 0 ].value.catch( () => {} );
+
 		expect( spinner.fail ).toHaveBeenCalledWith( 'failure error' );
+		expect( console.error ).toHaveBeenCalledWith( '\n\nfailure error\n\n' );
+		expect( process.exit ).toHaveBeenCalledWith( 1 );
+		console.error = consoleError;
+		process.exit = processExit;
+		/* eslint-enable no-console */
 	} );
 } );


### PR DESCRIPTION
Follows: #17724

## Description

This PR adds support to `@wordpress/env` for running arbitrary commands in one of the underlying docker containers. It also adds 2 containers that will be started on-demand for things like linting, generating fixtures, and PHP unit tests, `composer` and `chriszarate/wordpress-phpunit`. These are currently used to run `npm run lint-php` and `npm run fixtures:server-registered`.

## How has this been tested?

It was verified that `npm run lint-php` and `npm run fixtures:server-registered` work as expected.

## Types of Changes

*New Feature:* `@wordpress/env` now supports a `run` command for running arbitrary commands in one of the underlying Docker containers and also has 2 new containers, `composer` and `chriszarate/wordpress-phpunit`.

## Checklist:

- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
