### PR TITLE
i18n: Add ‘translators’ note to Code block example

### DIFF
--- a/packages/block-library/src/code/index.js
+++ b/packages/block-library/src/code/index.js
@@ -22,6 +22,7 @@ export const settings = {
 	icon,
 	example: {
 		attributes: {
+			// translators: Preserve \n markers for line breaks
 			content: '// A "block" is the abstract term used\n// to describe units of markup that\n// when composed together, form the\n// content or layout of a page.\nregisterBlockType( name, settings );',
 		},
 	},


### PR DESCRIPTION
Follows #18964.