### PR TITLE
Social Links Block: SoundCloud Typo 

### DIFF
--- a/packages/block-library/src/social-link/social-list.js
+++ b/packages/block-library/src/social-link/social-list.js
@@ -161,7 +161,7 @@ const socialList = {
 		icon: SnapchatIcon,
 	},
 	soundcloud: {
-		name: 'Soundcloud',
+		name: 'SoundCloud',
 		icon: SoundcloudIcon,
 	},
 	spotify: {

--- a/packages/e2e-tests/fixtures/block-transforms.js
+++ b/packages/e2e-tests/fixtures/block-transforms.js
@@ -650,7 +650,7 @@ export const EXPECTED_TRANSFORMS = {
 		availableTransforms: [
 			'Group',
 		],
-		originalBlock: 'Soundcloud',
+		originalBlock: 'SoundCloud',
 	},
 	'core__social-link-spotify': {
 		availableTransforms: [


### PR DESCRIPTION
## Description
Small typo I noticed, the Social Links block has SoundCloud spelt as "Soundcloud".

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Just a very simple change, which inserting a Social Links block is enough to test.

## Screenshots <!-- if applicable -->

<img width="147" alt="Screenshot 2019-12-07 at 15 07 45" src="https://user-images.githubusercontent.com/43215253/70376679-72cf3580-1903-11ea-9bff-cb52a2ff2f50.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
