### PR TITLE
Adding keyword 'download' to the file block for easier searching.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "gutenberg",
-	"version": "7.0.0",
+	"version": "7.1.0-rc.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -18242,9 +18242,9 @@
 			}
 		},
 		"handlebars": {
-			"version": "4.5.3",
-			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
-			"integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.0.tgz",
+			"integrity": "sha512-xkRtOt3/3DzTKMOt3xahj2M/EqNhY988T+imYSlMgs5fVhLN2fmKVVj0LtEGmb+3UUYV5Qmm1052Mm3dIQxOvw==",
 			"dev": true,
 			"requires": {
 				"neo-async": "^2.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18242,9 +18242,9 @@
 			}
 		},
 		"handlebars": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.0.tgz",
-			"integrity": "sha512-xkRtOt3/3DzTKMOt3xahj2M/EqNhY988T+imYSlMgs5fVhLN2fmKVVj0LtEGmb+3UUYV5Qmm1052Mm3dIQxOvw==",
+			"version": "4.5.3",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
+			"integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
 			"dev": true,
 			"requires": {
 				"neo-async": "^2.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "gutenberg",
-	"version": "7.1.0-rc.1",
+	"version": "7.0.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/block-library/src/file/index.js
+++ b/packages/block-library/src/file/index.js
@@ -20,7 +20,7 @@ export const settings = {
 	title: __( 'File' ),
 	description: __( 'Add a link to a downloadable file.' ),
 	icon,
-	keywords: [ __( 'document' ), __( 'pdf' ) ],
+	keywords: [ __( 'document' ), __( 'pdf' ), __( 'download' ) ],
 	supports: {
 		align: true,
 	},


### PR DESCRIPTION
## Description
Added a new keyword to the File block for easier searching: `download`.

## How has this been tested?
Tested locally.

## Screenshots

![Screen Shot 2019-12-07 at 10 04 01 AM](https://user-images.githubusercontent.com/617986/70378741-ef98ea00-18d8-11ea-86c2-495836c06eba.png)


## Types of changes
Non-breaking changes.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
