### PR TITLE
Framework: Configure ESLint JSDoc plugin to target TypeScript mode

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -39,6 +39,11 @@ module.exports = {
 	globals: {
 		wp: 'off',
 	},
+	settings: {
+		jsdoc: {
+			mode: 'typescript',
+		},
+	},
 	rules: {
 		'@wordpress/dependency-group': 'error',
 		'@wordpress/gutenberg-phase': 'error',


### PR DESCRIPTION
Related: #18838

This pull request seeks to update the project ESLint configuration to specify the "TypeScript" mode for the ESLint-JSDoc plugin.

See also: https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-settings-mode

I have chosen to include this in the project-specific `.eslintrc.js` file, rather than in the [published default ESLint configuration](https://github.com/WordPress/gutenberg/blob/2924efa87ad909648888a49745d33f4100dae3de/packages/eslint-plugin/configs/jsdoc.js#L70-L80) because the newly-introduced TypeScript JSDoc guidelines (#18920) are currently specific to the Gutenberg project, and not necessarily representative of what would be expected for all JSDoc usage conforming to the [WordPress JavaScript documentation standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/). In the future, it may be worth reevaluating this decision.

While on a general level, this mode configuration should represent our intended targeting of TypeScript syntax support in JSDoc, it more specifically appears to impact only the following:

- [Ability to use `@template` tag](https://github.com/gajus/eslint-plugin-jsdoc/blob/master/src/tagNames.js)

(This may change over time, but in a way we would expect to want)

**Testing Instructions:**

There should be no change in behavior of the result of `npm run lint-js`.