### PR TITLE
fix: Import WritingFlow and ObserveTyping

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -17,8 +17,11 @@ _This package assumes that your code will run in an **ES2015+** environment. If 
 ```js
 import {
 	BlockEditorProvider,
-	BlockList
+	BlockList,
+	WritingFlow,
+	ObserveTyping
 } from '@wordpress/block-editor';
+import { Popover } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 
 function MyEditorComponent () {


### PR DESCRIPTION
## Description
Inside the block-editor “Usage” readme instructions, modules WritingFlow and ObserveTyping are used but not imported

## Types of changes
Bug fix (non-breaking change which fixes an issue) 

