### PR TITLE
Data: Provide dependencies from withSelect to useSelect

### DIFF
--- a/packages/data/src/components/with-select/index.js
+++ b/packages/data/src/components/with-select/index.js
@@ -56,7 +56,7 @@ const withSelect = ( mapSelectToProps ) => createHigherOrderComponent(
 					ownProps,
 					registry
 				);
-			const mergeProps = useSelect( mapSelect );
+			const mergeProps = useSelect( mapSelect, [] );
 			return <WrappedComponent { ...ownProps } { ...mergeProps } />;
 		}
 	),

--- a/packages/data/src/components/with-select/index.js
+++ b/packages/data/src/components/with-select/index.js
@@ -56,7 +56,7 @@ const withSelect = ( mapSelectToProps ) => createHigherOrderComponent(
 					ownProps,
 					registry
 				);
-			const mergeProps = useSelect( mapSelect, [] );
+			const mergeProps = useSelect( mapSelect, [ ownProps ] );
 			return <WrappedComponent { ...ownProps } { ...mergeProps } />;
 		}
 	),

--- a/packages/data/src/components/with-select/test/index.js
+++ b/packages/data/src/components/with-select/test/index.js
@@ -135,8 +135,7 @@ describe( 'withSelect', () => {
 		// - 1 on initial render
 		// - 1 on effect before subscription set.
 		// - 1 on click triggering subscription firing.
-		// - 1 on rerender.
-		expect( mapSelectToProps ).toHaveBeenCalledTimes( 4 );
+		expect( mapSelectToProps ).toHaveBeenCalledTimes( 3 );
 		// verifies component only renders twice.
 		expect( OriginalComponent ).toHaveBeenCalledTimes( 2 );
 	} );
@@ -206,11 +205,10 @@ describe( 'withSelect', () => {
 		testInstance = testRenderer.root;
 		it( 'should rerun if had dispatched action during mount', () => {
 			expect( testInstance.findByType( 'div' ).props.children ).toBe( 2 );
-			// Expected 3 times because:
+			// Expected 2 times because:
 			// - 1 on initial render
-			// - 1 on effect before subscription set.
-			// - 1 for the rerender because of the mapOutput change detected.
-			expect( mapSelectToProps ).toHaveBeenCalledTimes( 3 );
+			// - 1 on effect before subscription set, accounting for dispatch.
+			expect( mapSelectToProps ).toHaveBeenCalledTimes( 2 );
 			expect( renderSpy ).toHaveBeenCalledTimes( 2 );
 		} );
 		it( 'should rerun on unmount and mount', () => {
@@ -220,11 +218,10 @@ describe( 'withSelect', () => {
 			} );
 			testInstance = testRenderer.root;
 			expect( testInstance.findByType( 'div' ).props.children ).toBe( 4 );
-			// Expected an additional 3 times because of the unmount and remount:
+			// Expected an additional 2 times because of the unmount and remount:
 			// - 1 on initial render
 			// - 1 on effect before subscription set.
-			// - once for the rerender because of the mapOutput change detected.
-			expect( mapSelectToProps ).toHaveBeenCalledTimes( 6 );
+			expect( mapSelectToProps ).toHaveBeenCalledTimes( 4 );
 			expect( renderSpy ).toHaveBeenCalledTimes( 4 );
 		} );
 	} );
@@ -612,7 +609,7 @@ describe( 'withSelect', () => {
 		// - 1 on effect before subscription set.
 		// - 1 child subscription fires.
 		expect( childMapSelectToProps ).toHaveBeenCalledTimes( 3 );
-		expect( parentMapSelectToProps ).toHaveBeenCalledTimes( 4 );
+		expect( parentMapSelectToProps ).toHaveBeenCalledTimes( 3 );
 		expect( ChildOriginalComponent ).toHaveBeenCalledTimes( 1 );
 		expect( ParentOriginalComponent ).toHaveBeenCalledTimes( 2 );
 	} );
@@ -671,13 +668,12 @@ describe( 'withSelect', () => {
 				</RegistryProvider>
 			);
 		} );
-		// 4 times:
+		// 3 times:
 		// - 1 on initial render
 		// - 1 on effect before subscription set.
-		// - 1 on re-render
 		// - 1 on effect before new subscription set (because registry has changed)
-		expect( mapSelectToProps ).toHaveBeenCalledTimes( 4 );
-		expect( OriginalComponent ).toHaveBeenCalledTimes( 2 );
+		expect( mapSelectToProps ).toHaveBeenCalledTimes( 3 );
+		expect( OriginalComponent ).toHaveBeenCalledTimes( 3 );
 
 		expect( testInstance.findByType( 'div' ).props ).toEqual( {
 			children: 'second',


### PR DESCRIPTION
Previously: #15737

This pull request proposes to include a dependencies array in `withSelect`'s rendering of `useSelect`. The goal here is to reduce the number of calls to `mapSelectToProps`, since otherwise the mapping callback would be called in every render. From my reading of #15737, I see that there is pretty extensive discussion of how dependencies should be managed, so perhaps I am overlooking some context here. I see that `pure` is used to avoid unnecessary renders of the `withSelect` higher-order component. Since `mapSelectToProps` depends on `ownProps`, it must be defined as a dependency of the `useSelect` hook if dependencies are passed. Given `pure` should enforce that `ownProps` reference changes only upon an effective shallow change in props, it should be enough to pass this object directly as the sole dependency to `useSelect`. I think there may have been some expectation that `pure` would be enough to avoid excessive calls to `mapSelect`, but since the component could render for reasons other than just `withSelect`, [`useSelect`'s internal reference of `useCallback`](https://github.com/WordPress/gutenberg/blob/fe22b9d890dbb51b1d7cc48326867f8d1f7dea3f/packages/data/src/components/use-select/index.js#L78) would _always_ [change](https://github.com/WordPress/gutenberg/blob/fe22b9d890dbb51b1d7cc48326867f8d1f7dea3f/packages/data/src/components/use-select/index.js#L93) when provided an `undefined` `deps` array, and thus always call `mapSelect` even without a change in props or global state.

With these changes, I observe a decrease of [`mapSelect` calls](https://github.com/WordPress/gutenberg/blob/fe22b9d890dbb51b1d7cc48326867f8d1f7dea3f/packages/data/src/components/use-select/index.js#L94) on an initial rendering of the editor from 157 to 112. This is intended to serve as a simple reference point; it's expected this benefit should sustain over lifetime of the editor session.

This follows some discussion at https://github.com/WordPress/gutenberg/pull/18960#discussion_r354621607 and for me is something of a personal study of if and how dependencies should apply to hooks, or if dependencies should always be provided when supported by a hook.

**Performance Results:**

In recent performance testing of other pull request, I've struggled to find any measurable difference (better or worse) using `npm run test-performance`. I'm not sure if this is an issue with my environment, the tests as written, or the fact that there's truly little benefit to these changes.

For exhaustiveness' sake, I dove into the React source to seek some insight into whether the overhead of comparing dependencies in renders might incur a higher cost than any benefit to be gained by avoiding a call to `mapSelect`. This operation appears to be very trivial; not much more than a simple loop of the before/after deps [[1]](https://github.com/facebook/react/blob/b43eec7eaad14747d24ef24a06b27cb2a5653bbc/packages/react-reconciler/src/ReactFiberHooks.js#L1072-L1079) [[2]](https://github.com/facebook/react/blob/b43eec7eaad14747d24ef24a06b27cb2a5653bbc/packages/react-reconciler/src/ReactFiberHooks.js#L360-L366) [[3]](https://github.com/facebook/react/blob/b43eec7eaad14747d24ef24a06b27cb2a5653bbc/packages/shared/objectIs.js#L20).

**Testing Instructions:**

It's assumed unit tests and end-to-end test cases should protect against regressions here.