### PR TITLE
Block Editor: Align Hook: Pass empty deps to useSelect

### DIFF
--- a/packages/block-editor/src/hooks/align.js
+++ b/packages/block-editor/src/hooks/align.js
@@ -147,9 +147,10 @@ export const withToolbarControls = createHigherOrderComponent(
 export const withDataAlign = createHigherOrderComponent( ( BlockListBlock ) => ( props ) => {
 	const { name, attributes } = props;
 	const { align } = attributes;
-	const hasWideEnabled = useSelect( ( select ) => (
-		!! select( 'core/block-editor' ).getSettings().alignWide
-	) );
+	const hasWideEnabled = useSelect(
+		( select ) => !! select( 'core/block-editor' ).getSettings().alignWide,
+		[]
+	);
 
 	// If an alignment is not assigned, there's no need to go through the
 	// effort to validate or assign its value.


### PR DESCRIPTION
Follow-up of #18963

This pull request seeks to revise the use of `useSelect` in the newly-refactored align hook to pass an (empty) dependencies array as the second argument, used as an indicator that the select callback does not use any scoped dependencies. Without this argument, the `mapSelect` callback would be unnecessarily called on every render.

This is intended as a minor optimization.

**Testing Instructions:**

Repeat testing instructions from #18963