### PR TITLE
Lighter block DOM: remove extra div wrapper

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -3,7 +3,7 @@
 // value is designed to work with).
 
 $z-layers: (
-	".block-editor-block-list__block-edit::before": 0,
+	".block-editor-block-list__block::before": 0,
 	".block-editor-block-switcher__arrow": 1,
 	".block-editor-block-list__block {core/image aligned wide or fullwide}": 20,
 	".block-library-classic__toolbar": 10,
@@ -41,7 +41,7 @@ $z-layers: (
 
 	// Should have higher index than the inset/underlay used for dragging
 	".components-placeholder__fieldset": 1,
-	".block-editor-block-list__block-edit .reusable-block-edit-panel *": 1,
+	".block-editor-block-list__block .reusable-block-edit-panel *": 1,
 
 	// Show drop zone above most standard content, but below any overlays
 	".components-drop-zone": 40,

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -501,73 +501,71 @@ function BlockListBlock( {
 				clientId={ clientId }
 				rootClientId={ rootClientId }
 			/> }
-			<div className="block-editor-block-list__block-edit">
-				{ ( isCapturingDescendantToolbars ) && (
-					// A slot made available on all ancestors of the selected Block
-					// to allow child Blocks to render their toolbars into the DOM
-					// of the appropriate parent.
-					<ChildToolbarSlot />
-				) }
-				{ ( shouldShowBreadcrumb || shouldShowContextualToolbar || isForcingContextualToolbar.current ) && (
-					<Popover
-						noArrow
-						animate={ false }
-						// Position above the anchor, pop out towards the right,
-						// and position in the left corner.
-						// To do: refactor `Popover` to make this prop clearer.
-						position="top right left"
-						focusOnMount={ false }
-						anchorRef={ blockNodeRef.current }
-						className="block-editor-block-list__block-popover"
-						__unstableSticky={ isPartOfMultiSelection ? '.wp-block.is-multi-selected' : true }
-						__unstableSlotName="block-toolbar"
-						// Allow subpixel positioning for the block movement animation.
-						__unstableAllowVerticalSubpixelPosition={ moverDirection !== 'horizontal' && wrapper.current }
-						__unstableAllowHorizontalSubpixelPosition={ moverDirection === 'horizontal' && wrapper.current }
-					>
-						{ ! hasAncestorCapturingToolbars && ( shouldShowContextualToolbar || isForcingContextualToolbar.current ) && renderBlockContextualToolbar() }
-						{ hasAncestorCapturingToolbars && ( shouldShowContextualToolbar || isForcingContextualToolbar.current ) && (
-							// If the parent Block is set to consume toolbars of the child Blocks
-							// then render the child Block's toolbar into the Slot provided
-							// by the parent.
-							<ChildToolbar>
-								{ renderBlockContextualToolbar() }
-							</ChildToolbar>
-						) }
-						{ shouldShowBreadcrumb && (
-							<BlockBreadcrumb
-								clientId={ clientId }
-								ref={ breadcrumb }
-								data-align={ wrapperProps ? wrapperProps[ 'data-align' ] : undefined }
-							/>
-						) }
-					</Popover>
-				) }
-				<IgnoreNestedEvents
-					ref={ blockNodeRef }
-					onDragStart={ preventDrag }
-					onMouseDown={ onMouseDown }
-					onMouseLeave={ onMouseLeave }
-					data-block={ clientId }
+			{ ( isCapturingDescendantToolbars ) && (
+				// A slot made available on all ancestors of the selected Block
+				// to allow child Blocks to render their toolbars into the DOM
+				// of the appropriate parent.
+				<ChildToolbarSlot />
+			) }
+			{ ( shouldShowBreadcrumb || shouldShowContextualToolbar || isForcingContextualToolbar.current ) && (
+				<Popover
+					noArrow
+					animate={ false }
+					// Position above the anchor, pop out towards the right,
+					// and position in the left corner.
+					// To do: refactor `Popover` to make this prop clearer.
+					position="top right left"
+					focusOnMount={ false }
+					anchorRef={ blockNodeRef.current }
+					className="block-editor-block-list__block-popover"
+					__unstableSticky={ isPartOfMultiSelection ? '.wp-block.is-multi-selected' : true }
+					__unstableSlotName="block-toolbar"
+					// Allow subpixel positioning for the block movement animation.
+					__unstableAllowVerticalSubpixelPosition={ moverDirection !== 'horizontal' && wrapper.current }
+					__unstableAllowHorizontalSubpixelPosition={ moverDirection === 'horizontal' && wrapper.current }
 				>
-					<BlockCrashBoundary onError={ onBlockError }>
-						{ isValid && blockEdit }
-						{ isValid && mode === 'html' && (
-							<BlockHtml clientId={ clientId } />
-						) }
-						{ ! isValid && [
-							<BlockInvalidWarning
-								key="invalid-warning"
-								clientId={ clientId }
-							/>,
-							<div key="invalid-preview">
-								{ getSaveElement( blockType, attributes ) }
-							</div>,
-						] }
-					</BlockCrashBoundary>
-					{ !! hasError && <BlockCrashWarning /> }
-				</IgnoreNestedEvents>
-			</div>
+					{ ! hasAncestorCapturingToolbars && ( shouldShowContextualToolbar || isForcingContextualToolbar.current ) && renderBlockContextualToolbar() }
+					{ hasAncestorCapturingToolbars && ( shouldShowContextualToolbar || isForcingContextualToolbar.current ) && (
+						// If the parent Block is set to consume toolbars of the child Blocks
+						// then render the child Block's toolbar into the Slot provided
+						// by the parent.
+						<ChildToolbar>
+							{ renderBlockContextualToolbar() }
+						</ChildToolbar>
+					) }
+					{ shouldShowBreadcrumb && (
+						<BlockBreadcrumb
+							clientId={ clientId }
+							ref={ breadcrumb }
+							data-align={ wrapperProps ? wrapperProps[ 'data-align' ] : undefined }
+						/>
+					) }
+				</Popover>
+			) }
+			<IgnoreNestedEvents
+				ref={ blockNodeRef }
+				onDragStart={ preventDrag }
+				onMouseDown={ onMouseDown }
+				onMouseLeave={ onMouseLeave }
+				data-block={ clientId }
+			>
+				<BlockCrashBoundary onError={ onBlockError }>
+					{ isValid && blockEdit }
+					{ isValid && mode === 'html' && (
+						<BlockHtml clientId={ clientId } />
+					) }
+					{ ! isValid && [
+						<BlockInvalidWarning
+							key="invalid-warning"
+							clientId={ clientId }
+						/>,
+						<div key="invalid-preview">
+							{ getSaveElement( blockType, attributes ) }
+						</div>,
+					] }
+				</BlockCrashBoundary>
+				{ !! hasError && <BlockCrashWarning /> }
+			</IgnoreNestedEvents>
 			{ showEmptyBlockSideInserter && (
 				<div className="block-editor-block-list__empty-block-inserter">
 					<Inserter

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -1,21 +1,21 @@
 .block-editor-block-list__layout .block-editor-block-list__block.is-selected { // Needs specificity to override inherited styles.
 	// While block is being dragged, dim the slot dragged from, and hide some UI.
 	&.is-dragging {
-		.block-editor-block-list__block-edit::before {
+		&::before {
 			border: none;
 		}
 
-		> .block-editor-block-list__block-edit > * {
+		> * {
 			background: $light-gray-100;
 		}
 
-		> .block-editor-block-list__block-edit > * > * {
+		> * > * {
 			visibility: hidden;
 		}
 	}
 
-	> .block-editor-block-list__block-edit .reusable-block-edit-panel * {
-		z-index: z-index(".block-editor-block-list__block-edit .reusable-block-edit-panel *");
+	.reusable-block-edit-panel * {
+		z-index: z-index(".block-editor-block-list__block .reusable-block-edit-panel *");
 	}
 }
 
@@ -56,6 +56,10 @@
 	// Break long strings of text without spaces so they don't overflow the block.
 	overflow-wrap: break-word;
 
+	[data-block] {
+		position: relative;
+	}
+
 	/**
 	 * Notices
 	 */
@@ -83,34 +87,30 @@
 	 * Block border layout
 	 */
 
-	.block-editor-block-list__block-edit {
-		position: relative;
+	&::before {
+		z-index: z-index(".block-editor-block-list__block::before");
+		content: "";
+		position: absolute;
+		border: $border-width solid transparent;
+		border-left: none;
+		box-shadow: none;
+		pointer-events: none;
+		transition: border-color 0.1s linear, border-style 0.1s linear, box-shadow 0.1s linear;
+		@include reduce-motion("transition");
 
-		&::before {
-			z-index: z-index(".block-editor-block-list__block-edit::before");
-			content: "";
-			position: absolute;
-			border: $border-width solid transparent;
-			border-left: none;
-			box-shadow: none;
-			pointer-events: none;
-			transition: border-color 0.1s linear, border-style 0.1s linear, box-shadow 0.1s linear;
-			@include reduce-motion("transition");
+		// Include a transparent outline for Windows High Contrast mode.
+		outline: $border-width solid transparent;
 
-			// Include a transparent outline for Windows High Contrast mode.
-			outline: $border-width solid transparent;
-
-			// Go edge-to-edge on mobile.
-			right: -$block-padding;
-			left: -$block-padding;
-			top: -$block-padding;
-			bottom: -$block-padding;
-		}
+		// Go edge-to-edge on mobile.
+		right: -$block-padding;
+		left: -$block-padding;
+		top: -$block-padding;
+		bottom: -$block-padding;
 	}
 
 	// Selected style.
 	&.is-selected {
-		> .block-editor-block-list__block-edit::before {
+		&::before {
 			// Use opacity to work in various editor styles.
 			border-color: $dark-opacity-light-800;
 			box-shadow: inset $block-left-border-width 0 0 0 $dark-gray-500;
@@ -130,7 +130,7 @@
 			}
 		}
 
-		&.is-navigate-mode > .block-editor-block-list__block-edit::before {
+		&.is-navigate-mode::before {
 			border-color: $blue-medium-focus;
 			box-shadow: inset $block-left-border-width 0 0 0 $blue-medium-focus;
 
@@ -164,7 +164,7 @@
 	// When selecting multiple blocks, we provide an additional selection indicator.
 	.block-editor-block-list__block.is-multi-selected {
 		// Show selection borders around every non-nested block's actual footprint.
-		> .block-editor-block-list__block-edit > [data-block] {
+		> [data-block] {
 			box-shadow: 0 0 0 2px $blue-medium-focus;
 			border-radius: 1px;
 
@@ -186,7 +186,7 @@
 	}
 
 	// Toolbar is captured
-	&.has-toolbar-captured > .block-editor-block-list__block-edit::before {
+	&.has-toolbar-captured::before {
 		left: 0; // place "selected" indicator closer to block due to no toolbar
 	}
 }
@@ -202,7 +202,7 @@
 	}
 
 	// Warnings
-	&.has-warning .block-editor-block-list__block-edit {
+	&.has-warning [data-block] {
 		// When a block has a warning, you shouldn't be able to manipulate the contents.
 		> * {
 			pointer-events: none;
@@ -215,7 +215,7 @@
 		}
 	}
 
-	&.has-warning .block-editor-block-list__block-edit::before {
+	&.has-warning::before {
 		// Use opacity to work in various editor styles.
 		border-color: $dark-opacity-light-500;
 		border-left: $border-width solid $dark-opacity-light-500;
@@ -225,7 +225,7 @@
 		}
 	}
 
-	&.has-warning.is-selected .block-editor-block-list__block-edit::before {
+	&.has-warning.is-selected::before {
 		// Use opacity to work in various editor styles.
 		border-color: $dark-opacity-light-800;
 		border-left-color: transparent;
@@ -235,7 +235,7 @@
 		}
 	}
 
-	&.has-warning .block-editor-block-list__block-edit::after {
+	&.has-warning::after {
 		content: "";
 		position: absolute;
 		background-color: rgba($light-gray-100, 0.4);
@@ -247,11 +247,11 @@
 	}
 
 	// Avoid conflict with the multi-selection highlight color.
-	&.has-warning.is-multi-selected .block-editor-block-list__block-edit::after {
+	&.has-warning.is-multi-selected::after {
 		background-color: transparent;
 	}
 
-	&.has-warning.is-selected .block-editor-block-list__block-edit::after {
+	&.has-warning.is-selected::after {
 		bottom: ( $block-toolbar-height - $block-padding - $border-width );
 
 		@include break-small() {
@@ -260,14 +260,14 @@
 	}
 
 	// Reusable blocks.
-	&.is-reusable.is-selected > .block-editor-block-list__block-edit::before {
+	&.is-reusable.is-selected::before {
 		border-left-color: transparent;
 		border-style: dashed;
 		border-width: $border-width;
 	}
 
 	// Reusable blocks clickthrough overlays.
-	&.is-reusable > .block-editor-block-list__block-edit .block-editor-inner-blocks.has-overlay {
+	&.is-reusable > .block-editor-inner-blocks.has-overlay {
 		// Remove only the top click overlay.
 		&::after {
 			display: none;
@@ -294,21 +294,15 @@
 		// When images are floated, the block itself should collapse to zero height.
 		height: 0;
 
-		// Hide block border when an image is floated.
-		.block-editor-block-list__block-edit {
-			&::before {
-				content: none;
-			}
-
-			// This margin won't collapse on its own, so zero it out.
-			margin-top: 0;
+		&::before {
+			content: none;
 		}
 	}
 
 	// Left.
 	&[data-align="left"] {
 		// This is in the editor only; the image should be floated on the frontend.
-		> .block-editor-block-list__block-edit {
+		> [data-block] {
 			/*!rtl:begin:ignore*/
 			float: left;
 			margin-right: 2em;
@@ -319,7 +313,7 @@
 	// Right.
 	&[data-align="right"] {
 		// Right: This is in the editor only; the image should be floated on the frontend.
-		> .block-editor-block-list__block-edit {
+		> [data-block] {
 			/*!rtl:begin:ignore*/
 			float: right;
 			margin-left: 2em;
@@ -335,7 +329,7 @@
 
 	// Full-wide.
 	&[data-align="full"] {
-		> .block-editor-block-list__block-edit {
+		> [data-block] {
 			margin-left: -$block-padding;
 			margin-right: -$block-padding;
 
@@ -345,7 +339,7 @@
 			}
 		}
 
-		> .block-editor-block-list__block-edit::before {
+		::before {
 			left: 0;
 			right: 0;
 			border-left-width: 0;

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -329,17 +329,15 @@
 
 	// Full-wide.
 	&[data-align="full"] {
-		> [data-block] {
-			margin-left: -$block-padding;
-			margin-right: -$block-padding;
+		margin-left: -$block-padding;
+		margin-right: -$block-padding;
 
-			@include break-small() {
-				margin-left: -$block-padding - $block-padding - $block-side-ui-width - $border-width - $border-width;
-				margin-right: -$block-padding - $block-padding - $block-side-ui-width - $border-width - $border-width;
-			}
+		@include break-small() {
+			margin-left: -$block-padding - $block-padding - $block-side-ui-width - $border-width - $border-width;
+			margin-right: -$block-padding - $block-padding - $block-side-ui-width - $border-width - $border-width;
 		}
 
-		::before {
+		&::before {
 			left: 0;
 			right: 0;
 			border-left-width: 0;

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -543,38 +543,6 @@
 	}
 }
 
-.block-editor-block-list__block {
-	@include break-small {
-		// Increase the hover and selection area around blocks.
-		// This makes the blue hover line and the settings button appear even if
-		// the mouse cursor is technically outside the block.
-		// This improves usability by making it possible to click somewhat outside
-		// the block and select it. (eg. A fuzzy click target.)
-		&::before {
-			bottom: 0;
-			content: "";
-			left: -$block-padding * 2;
-			position: absolute;
-			right: -$block-padding * 2;
-			top: 0;
-		}
-
-		// Remove the fuzzy click area effect set above on nested blocks.
-		// It should only applies to top-level blocks; applying this rule to
-		// nested blocks will result in difficult-to-use and possibly overlapping
-		// click targets.
-		& &::before {
-			left: 0;
-			right: 0;
-		}
-
-		// Don't use this for full-wide blocks, as there's no clearance to accommodate extra area on the side.
-		&[data-align="full"]::before {
-			content: none;
-		}
-	}
-}
-
 .block-editor-block-list__block .block-editor-warning {
 	z-index: z-index(".block-editor-warning");
 	position: relative;

--- a/packages/block-editor/src/components/block-preview/style.scss
+++ b/packages/block-editor/src/components/block-preview/style.scss
@@ -39,7 +39,7 @@
 		padding: 0;
 	}
 
-	.block-editor-block-list__block-edit [data-block] {
+	[data-block] {
 		margin: 0;
 	}
 

--- a/packages/block-editor/src/components/inner-blocks/style.scss
+++ b/packages/block-editor/src/components/inner-blocks/style.scss
@@ -13,7 +13,7 @@
 }
 
 // On fullwide blocks, don't go beyond the canvas.
-[data-align="full"] > .block-editor-block-list__block-edit > [data-block] .has-overlay::after {
+[data-align="full"] > [data-block] .has-overlay::after {
 	right: 0;
 	left: 0;
 }

--- a/packages/block-library/src/classic/editor.scss
+++ b/packages/block-library/src/classic/editor.scss
@@ -240,7 +240,7 @@
 }
 
 div[data-type="core/freeform"] {
-	.block-editor-block-list__block-edit::before {
+	&::before {
 		transition: border-color 0.1s linear, box-shadow 0.1s linear;
 		@include reduce-motion("transition");
 		border: $border-width solid $light-gray-500;
@@ -249,7 +249,7 @@ div[data-type="core/freeform"] {
 		outline: $border-width solid transparent;
 	}
 
-	&.is-selected .block-editor-block-list__block-edit::before {
+	&.is-selected::before {
 		border-color: $light-gray-800;
 		border-left-color: transparent;
 	}
@@ -372,4 +372,3 @@ div[data-type="core/freeform"] {
 		display: block;
 	}
 }
-

--- a/packages/block-library/src/columns/editor.scss
+++ b/packages/block-library/src/columns/editor.scss
@@ -30,9 +30,8 @@
 		}
 		// Set full heights on Columns to enable vertical alignment preview
 		> [data-type="core/column"],
-		> [data-type="core/column"] > .block-editor-block-list__block-edit,
-		> [data-type="core/column"] > .block-editor-block-list__block-edit > div[data-block],
-		> [data-type="core/column"] > .block-editor-block-list__block-edit .block-core-columns {
+		> [data-type="core/column"] > div[data-block],
+		> [data-type="core/column"] .block-core-columns {
 			display: flex;
 			flex-direction: column;
 
@@ -88,29 +87,24 @@
 				}
 			}
 
-			> .block-editor-block-list__block-edit {
+			// Remove Block "padding" so individual Column is flush with parent Columns
+			&::before {
+				left: 0;
+				right: 0;
+			}
+
+			// Zero out margins.
+			> [data-block] {
 				margin-top: 0;
 				margin-bottom: 0;
+			}
 
-				// Remove Block "padding" so individual Column is flush with parent Columns
-				&::before {
-					left: 0;
-					right: 0;
-				}
-
-				// Zero out margins.
-				> [data-block] {
-					margin-top: 0;
-					margin-bottom: 0;
-				}
-
-				// The Columns block is a flex-container, therefore it nullifies margin collapsing.
-				// Therefore, blocks inside this will appear to create a double margin.
-				// We compensate for this using negative margins.
-				> div > .block-core-columns > .block-editor-inner-blocks {
-					margin-top: -$default-block-margin;
-					margin-bottom: -$default-block-margin;
-				}
+			// The Columns block is a flex-container, therefore it nullifies margin collapsing.
+			// Therefore, blocks inside this will appear to create a double margin.
+			// We compensate for this using negative margins.
+			> div > .block-core-columns > .block-editor-inner-blocks {
+				margin-top: -$default-block-margin;
+				margin-bottom: -$default-block-margin;
 			}
 		}
 	}
@@ -155,7 +149,7 @@ div.block-core-columns.is-vertically-aligned-bottom {
 /**
  * Fixes single Column breadcrumb position.
  */
-[data-type="core/column"] > .block-editor-block-list__block-edit > .editor-block-list__breadcrumb {
+[data-type="core/column"] > .editor-block-list__breadcrumb {
 	left: -$block-left-border-width;
 }
 

--- a/packages/block-library/src/embed/style.scss
+++ b/packages/block-library/src/embed/style.scss
@@ -1,6 +1,6 @@
 // Apply max-width to floated items that have no intrinsic width
-.block-editor-block-list__block[data-type="core/embed"][data-align="left"] .block-editor-block-list__block-edit,
-.block-editor-block-list__block[data-type="core/embed"][data-align="right"] .block-editor-block-list__block-edit,
+.block-editor-block-list__block[data-type="core/embed"][data-align="left"] > [data-block],
+.block-editor-block-list__block[data-type="core/embed"][data-align="right"] > [data-block],
 .wp-block-embed.alignleft,
 .wp-block-embed.alignright {
 	// Instagram widgets have a min-width of 326px, so go a bit beyond that.

--- a/packages/block-library/src/group/editor.scss
+++ b/packages/block-library/src/group/editor.scss
@@ -11,14 +11,14 @@
 	}
 
 	// Only applied when background is added to cancel out padding
-	> .block-editor-block-list__block-edit > div > .wp-block-group.has-background > .wp-block-group__inner-container > .block-editor-inner-blocks {
+	> div > .wp-block-group.has-background > .wp-block-group__inner-container > .block-editor-inner-blocks {
 		margin-top: -#{$block-padding*2 + $block-spacing};
 		margin-bottom: -#{$block-padding*2 + $block-spacing};
 	}
 
 	// Full Width Blocks
 	// specificity required to only target immediate child Blocks of a Group
-	> .block-editor-block-list__block-edit > div > .wp-block-group > .wp-block-group__inner-container > .block-editor-inner-blocks > .block-editor-block-list__layout > .wp-block[data-align="full"] {
+	> div > .wp-block-group > .wp-block-group__inner-container > .block-editor-inner-blocks > .block-editor-block-list__layout > .wp-block[data-align="full"] {
 		margin-left: auto;
 		margin-right: auto;
 		padding-left: $block-padding*2;
@@ -31,7 +31,7 @@
 	}
 
 	// Full Width Blocks with a background (ie: has padding)
-	> .block-editor-block-list__block-edit > div > .wp-block-group.has-background > .wp-block-group__inner-container > .block-editor-inner-blocks > .block-editor-block-list__layout > .wp-block[data-align="full"] {
+	> div > .wp-block-group.has-background > .wp-block-group__inner-container > .block-editor-inner-blocks > .block-editor-block-list__layout > .wp-block[data-align="full"] {
 		// note: using position `left` causes hoz scrollbars so
 		// we opt to use margin instead
 		// the 30px matches the hoz padding applied in `theme.scss`
@@ -51,7 +51,7 @@
 .wp-block[data-type="core/group"][data-align="full"] {
 
 	// First tier of InnerBlocks must act like the container of the standard canvas
-	> .block-editor-block-list__block-edit > div > .wp-block-group > .wp-block-group__inner-container > .block-editor-inner-blocks {
+	> div > .wp-block-group > .wp-block-group__inner-container > .block-editor-inner-blocks {
 		margin-left: auto;
 		margin-right: auto;
 		padding-left: 0;
@@ -65,23 +65,17 @@
 
 	// Full Width Blocks
 	// specificity required to only target immediate child Blocks of Group
-	> .block-editor-block-list__block-edit > div > .wp-block-group > .wp-block-group__inner-container > .block-editor-inner-blocks > .block-editor-block-list__layout > .wp-block[data-align="full"] {
+	> div > .wp-block-group > .wp-block-group__inner-container > .block-editor-inner-blocks > .block-editor-block-list__layout > .wp-block[data-align="full"] {
 		padding-right: 0;
 		padding-left: 0;
 		left: 0;
 		width: 100%;
 		max-width: none;
-
-		// Allow to be flush with the edges of the canvas
-		> .block-editor-block-list__block-edit {
-			margin-left: 0;
-			margin-right: 0;
-		}
 	}
 
 	// Full Width Blocks with a background (ie: has padding)
 	// note: also duplicated above for all Group widths
-	> .block-editor-block-list__block-edit > div > .wp-block-group.has-background > .wp-block-group__inner-container > .block-editor-inner-blocks > .block-editor-block-list__layout > .wp-block[data-align="full"] {
+	> div > .wp-block-group.has-background > .wp-block-group__inner-container > .block-editor-inner-blocks > .block-editor-block-list__layout > .wp-block[data-align="full"] {
 		width: calc(100% + 60px);
 	}
 }

--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -97,7 +97,7 @@
 [data-type="core/image"][data-align="center"],
 [data-type="core/image"][data-align="left"],
 [data-type="core/image"][data-align="right"] {
-	.block-editor-block-list__block-edit {
+	[data-block] {
 		figure {
 			margin: 0;
 		}
@@ -112,6 +112,6 @@
 }
 
 // This is similar to above but for resized unfloated images only, where the markup is different.
-[data-type="core/image"] .block-editor-block-list__block-edit figure.is-resized {
+[data-type="core/image"] figure.is-resized {
 	margin: 0;
 }

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -35,27 +35,21 @@
 		margin-bottom: 1em; // Useful for when items wrap.
 	}
 
-	// 3. Remove margins on subsequent Edit container.
-	.wp-block-navigation .block-editor-inner-blocks > .block-editor-block-list__layout > .wp-block > .block-editor-block-list__block-edit {
-		margin-left: 0;
-		margin-right: 0;
-	}
-
-	// 4. Remove vertical margins on subsequent block container.
-	.wp-block-navigation .block-editor-inner-blocks > .block-editor-block-list__layout .wp-block > .block-editor-block-list__block-edit > [data-block] {
+	// 3. Remove vertical margins on subsequent block container.
+	.wp-block-navigation .block-editor-inner-blocks > .block-editor-block-list__layout .wp-block > [data-block] {
 		margin-top: 0;
 		margin-bottom: 0;
 	}
 
-	.wp-block-navigation .block-editor-block-list__block-edit::before {
+	.wp-block-navigation::before {
 		left: 0;
 		right: 0;
 	}
 
 	// Remove the dashed outlines for child blocks.
-	&.is-hovered .wp-block-navigation .block-editor-block-list__block-edit::before,
-	&.is-selected .wp-block-navigation .block-editor-block-list__block-edit::before,
-	&.has-child-selected .wp-block-navigation .block-editor-block-list__block-edit::before {
+	&.is-hovered .wp-block-navigation::before,
+	&.is-selected .wp-block-navigation::before,
+	&.has-child-selected .wp-block-navigation::before {
 		border-color: transparent !important; // !important used to keep the selector from growing any more complex.
 	}
 

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -41,15 +41,15 @@
 		margin-bottom: 0;
 	}
 
-	.wp-block-navigation::before {
+	.wp-block-navigation .block-editor-block-list__block::before {
 		left: 0;
 		right: 0;
 	}
 
 	// Remove the dashed outlines for child blocks.
-	&.is-hovered .wp-block-navigation::before,
-	&.is-selected .wp-block-navigation::before,
-	&.has-child-selected .wp-block-navigation::before {
+	&.is-hovered .wp-block-navigation .block-editor-block-list__block::before,
+	&.is-selected .wp-block-navigation .block-editor-block-list__block::before,
+	&.has-child-selected .wp-block-navigation .block-editor-block-list__block::before {
 		border-color: transparent !important; // !important used to keep the selector from growing any more complex.
 	}
 

--- a/packages/block-library/src/social-links/editor.scss
+++ b/packages/block-library/src/social-links/editor.scss
@@ -42,9 +42,9 @@
 	}
 
 	// 4. Remove the dashed outlines for child blocks.
-	&.is-hovered .wp-block-social-links::before,
-	&.is-selected .wp-block-social-links::before,
-	&.has-child-selected .wp-block-social-links::before {
+	&.is-hovered .wp-block-social-links .block-editor-block-list__block::before,
+	&.is-selected .wp-block-social-links .block-editor-block-list__block::before,
+	&.has-child-selected .wp-block-social-links .block-editor-block-list__block::before {
 		border-color: transparent !important; // !important used to keep the selector from growing any more complex.
 	}
 

--- a/packages/block-library/src/social-links/editor.scss
+++ b/packages/block-library/src/social-links/editor.scss
@@ -26,34 +26,30 @@
 		width: auto;
 		padding-left: 0;
 		padding-right: 0;
-	}
-
-	// 3. Remove margins on subsequent Edit container.
-	.wp-block-social-links > .block-editor-inner-blocks > .block-editor-block-list__layout > .wp-block > .block-editor-block-list__block-edit {
 		margin-left: 0;
 		margin-right: 0;
 	}
 
-	// 4. Minimize the block outlines.
-	.wp-block-social-links > .block-editor-inner-blocks > .block-editor-block-list__layout > .wp-block > .block-editor-block-list__block-edit::before {
+	// 3. Minimize the block outlines.
+	.wp-block-social-links > .block-editor-inner-blocks > .block-editor-block-list__layout > .wp-block::before {
 		border-right: none;
 		border-top: none;
 		border-bottom: none;
 	}
 
-	.wp-block-social-links > .block-editor-inner-blocks > .block-editor-block-list__layout > .wp-block.is-hovered:not(.is-navigate-mode) > .block-editor-block-list__block-edit::before {
+	.wp-block-social-links > .block-editor-inner-blocks > .block-editor-block-list__layout > .wp-block.is-hovered:not(.is-navigate-mode)::before {
 		box-shadow: none;
 	}
 
-	// 5. Remove the dashed outlines for child blocks.
-	&.is-hovered .wp-block-social-links .block-editor-block-list__block-edit::before,
-	&.is-selected .wp-block-social-links .block-editor-block-list__block-edit::before,
-	&.has-child-selected .wp-block-social-links .block-editor-block-list__block-edit::before {
+	// 4. Remove the dashed outlines for child blocks.
+	&.is-hovered .wp-block-social-links::before,
+	&.is-selected .wp-block-social-links::before,
+	&.has-child-selected .wp-block-social-links::before {
 		border-color: transparent !important; // !important used to keep the selector from growing any more complex.
 	}
 
-	// 6. Remove vertical margins on subsequent block container.
-	.wp-block-social-links > .block-editor-inner-blocks > .block-editor-block-list__layout > .wp-block > .block-editor-block-list__block-edit > [data-block] {
+	// 5. Remove vertical margins on subsequent block container.
+	.wp-block-social-links > .block-editor-inner-blocks > .block-editor-block-list__layout > .wp-block > [data-block] {
 		margin-top: 0;
 		margin-bottom: 0;
 	}

--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -37,36 +37,6 @@
 .edit-post-visual-editor .block-editor-block-list__block {
 	margin-left: auto;
 	margin-right: auto;
-
-	@include break-small() {
-		// Center the block toolbar on wide and full-wide blocks.
-		// Use specific selector to not affect nested block toolbars.
-		&[data-align="wide"] > .block-editor-block-contextual-toolbar,
-		&[data-align="full"] > .block-editor-block-contextual-toolbar {
-			height: 0; // This collapses the container to an invisible element without margin.
-			width: calc(100% - #{$block-side-ui-width * 3} - #{$grid-size-small * 1.5}); // -90px to account for inner element left position value causing overflow-x scrollbars
-			margin-left: 0;
-			margin-right: 0;
-			text-align: center;
-			// This float rule takes the toolbar out of the flow, without it having to be absolute positioned.
-			// This is necessary because otherwise the mere presence of the toolbar can push down content.
-			// Pairs with relative rule on line 49.
-			float: left;
-
-			@include break-xlarge() {
-				width: calc(100% - #{$block-padding * 2} + #{$border-width * 2}); // On the largest screens, line the toolbar up with standard-aligned block controls.
-			}
-
-			.block-editor-block-toolbar {
-				max-width: $content-width;
-				width: 100%;
-
-				// Necessary for the toolbar to be centered.
-				// This unsets an absolute position that will otherwise left align the toolbar.
-				position: relative;
-			}
-		}
-	}
 }
 
 

--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -41,8 +41,8 @@
 	@include break-small() {
 		// Center the block toolbar on wide and full-wide blocks.
 		// Use specific selector to not affect nested block toolbars.
-		&[data-align="wide"] > .block-editor-block-list__block-edit > .block-editor-block-contextual-toolbar,
-		&[data-align="full"] > .block-editor-block-list__block-edit > .block-editor-block-contextual-toolbar {
+		&[data-align="wide"] > .block-editor-block-contextual-toolbar,
+		&[data-align="full"] > .block-editor-block-contextual-toolbar {
 			height: 0; // This collapses the container to an invisible element without margin.
 			width: calc(100% - #{$block-side-ui-width * 3} - #{$grid-size-small * 1.5}); // -90px to account for inner element left position value causing overflow-x scrollbars
 			margin-left: 0;


### PR DESCRIPTION
## Description

This PR removes an unnecessary `div` element wrapper from the block DOM, and simplifies the CSS selectors. Currently there are three `div` wrapper elements around blocks in master. This PR reduces it to two (outer and inner).

The main change is that the block border is now set with `:before` on the outer block wrapper instead of the removed middle wrapper.

It's easiest to review this PR when hiding whitespace changes: https://github.com/WordPress/gutenberg/pull/19010/files?utf8=✓&diff=unified&w=1

## How has this been tested?

All block styles need to remain the same.

* It's important to check all different block states: hover, select, warning...
* All the alignments: left, right, centre, wide, full.
* Blocks that move horizontally (in navigation block)
* Classic, columns, embed, group, image, navigation, social links.

## Screenshots <!-- if applicable -->

## Types of changes
Refactor

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
