### PR TITLE
Fix: Customiser block editor crashes because setSelectedArea is missing

### DIFF
--- a/packages/edit-widgets/src/components/customizer-edit-widgets-initializer/index.js
+++ b/packages/edit-widgets/src/components/customizer-edit-widgets-initializer/index.js
@@ -7,6 +7,7 @@ import {
 	navigateRegions,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -16,6 +17,7 @@ import WidgetAreas from '../widget-areas';
 import './sync-customizer';
 
 function CustomizerEditWidgetsInitializer( { settings } ) {
+	const [ selectedArea, setSelectedArea ] = useState( null );
 	return (
 		<SlotFillProvider>
 			<div
@@ -24,7 +26,11 @@ function CustomizerEditWidgetsInitializer( { settings } ) {
 				aria-label={ __( 'Widgets screen content' ) }
 				tabIndex="-1"
 			>
-				<WidgetAreas blockEditorSettings={ settings } />
+				<WidgetAreas
+					selectedArea={ selectedArea }
+					setSelectedArea={ setSelectedArea }
+					blockEditorSettings={ settings }
+				/>
 			</div>
 			<Popover.Slot />
 		</SlotFillProvider>

--- a/packages/edit-widgets/src/components/widget-areas/index.js
+++ b/packages/edit-widgets/src/components/widget-areas/index.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { useMemo } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
 
@@ -13,17 +12,10 @@ import WidgetArea from '../widget-area';
 const EMPTY_ARRAY = [];
 
 function WidgetAreas( { areas, blockEditorSettings, selectedArea, setSelectedArea } ) {
-	const onBlockSelectedInArea = useMemo(
-		() => areas.map( ( value, index ) => ( () => {
-			setSelectedArea( index );
-		} ) ),
-		[ areas, setSelectedArea ]
-	);
-
 	return areas.map( ( { id }, index ) => (
 		<WidgetArea
 			isSelectedArea={ index === selectedArea }
-			onBlockSelected={ onBlockSelectedInArea[ index ] }
+			onBlockSelected={ () => setSelectedArea( index ) }
 			blockEditorSettings={ blockEditorSettings }
 			key={ id }
 			id={ id }


### PR DESCRIPTION
When we select a block on the customizer blocks the editor crashes because a function being called is missing.
This PR fixes the problem.


## How has this been tested?
I opened the Blocks in the customizer, I selected blocks in different widget areas and verified the editor does not crashes.
