### PR TITLE
Popover: render in scroll container

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -24,8 +24,9 @@ $z-layers: (
 	".block-editor-warning": 5,
 	".block-library-gallery-item__inline-menu": 20,
 	".block-editor-url-input__suggestions": 30,
-	".edit-post-layout__footer": 30,
-	".edit-post-editor-regions__header": 30,
+	// Above any content.
+	".edit-post-layout__footer": 63,
+	".edit-post-editor-regions__header": 63,
 	".edit-widgets-header": 30,
 	".block-library-button__inline-link .block-editor-url-input__suggestions": 6, // URL suggestions for button block above sibling inserter
 	".block-library-image__resize-handlers": 1, // Resize handlers above sibling inserter
@@ -47,6 +48,9 @@ $z-layers: (
 	// Show drop zone above most standard content, but below any overlays
 	".components-drop-zone": 40,
 	".components-drop-zone__content": 50,
+
+	// Under the region header and footer.
+	".edit-post-editor-regions__content .components-popover": 62,
 
 	// The block mover for floats should overlap the controls of adjacent blocks.
 	".block-editor-block-list__block {core/image aligned left or right}": 21,

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { useRef, useState, useEffect } from '@wordpress/element';
+import { useRef, useState, useEffect, createContext, useContext } from '@wordpress/element';
 import { focus, getRectangleFromRange } from '@wordpress/dom';
 import { ESCAPE } from '@wordpress/keycodes';
 import deprecated from '@wordpress/deprecated';
@@ -216,6 +216,7 @@ function setClass( element, name, toggle ) {
 	}
 }
 
+const Context = createContext( SLOT_NAME );
 const Popover = ( {
 	headerTitle,
 	onClose,
@@ -249,6 +250,7 @@ const Popover = ( {
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
 	const [ animateOrigin, setAnimateOrigin ] = useState();
 	const isExpanded = expandOnMobile && isMobileViewport;
+	const slotName = useContext( Context );
 
 	noArrow = isExpanded || noArrow;
 
@@ -466,8 +468,8 @@ const Popover = ( {
 			{ ( { getSlot } ) => {
 				// In case there is no slot context in which to render,
 				// default to an in-place rendering.
-				if ( getSlot && getSlot( SLOT_NAME ) ) {
-					content = <Fill name={ SLOT_NAME }>{ content }</Fill>;
+				if ( getSlot && getSlot( slotName ) ) {
+					content = <Fill name={ slotName }>{ content }</Fill>;
 				}
 
 				return (
@@ -483,6 +485,24 @@ const Popover = ( {
 
 const PopoverContainer = Popover;
 
-PopoverContainer.Slot = () => <Slot bubblesVirtually name={ SLOT_NAME } />;
+let index = 0;
+
+PopoverContainer.ContextProvider = Context.Provider;
+PopoverContainer.Slot = ( { children } ) => {
+	if ( ! children ) {
+		return <Slot bubblesVirtually name={ SLOT_NAME } />;
+	}
+
+	index++;
+
+	const slotName = SLOT_NAME + index;
+
+	return (
+		<Context.Provider value={ slotName }>
+			{ children }
+			<Slot bubblesVirtually name={ slotName } />
+		</Context.Provider>
+	);
+};
 
 export default PopoverContainer;

--- a/packages/edit-post/src/components/editor-regions/index.js
+++ b/packages/edit-post/src/components/editor-regions/index.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { navigateRegions } from '@wordpress/components';
+import { navigateRegions, Popover } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 function EditorRegions( { footer, header, sidebar, content, publish, className } ) {
@@ -31,7 +31,9 @@ function EditorRegions( { footer, header, sidebar, content, publish, className }
 					aria-label={ __( 'Editor content' ) }
 					tabIndex="-1"
 				>
-					{ content }
+					<Popover.Slot>
+						{ content }
+					</Popover.Slot>
 				</div>
 				{ !! publish && (
 					<div

--- a/packages/edit-post/src/components/editor-regions/style.scss
+++ b/packages/edit-post/src/components/editor-regions/style.scss
@@ -71,6 +71,10 @@ html {
 	@include break-medium() {
 		overflow: auto;
 	}
+
+	.components-popover {
+		z-index: z-index(".edit-post-editor-regions__content .components-popover");
+	}
 }
 
 .edit-post-editor-regions__sidebar {


### PR DESCRIPTION
## Description

This PR fixes popover z-index issues by rendering popovers in a slot within the closest scrollable parent.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
