### PR TITLE
[RNMobile] Fork native variant of withViewportMatch HOC to use withSelect again

### DIFF
--- a/packages/viewport/src/with-viewport-match.native.js
+++ b/packages/viewport/src/with-viewport-match.native.js
@@ -1,0 +1,44 @@
+/**
+ * External dependencies
+ */
+import { mapValues } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { withSelect } from '@wordpress/data';
+
+/**
+ * Higher-order component creator, creating a new component which renders with
+ * the given prop names, where the value passed to the underlying component is
+ * the result of the query assigned as the object's value.
+ *
+ * @see isViewportMatch
+ *
+ * @param {Object} queries  Object of prop name to viewport query.
+ *
+ * @example
+ *
+ * ```jsx
+ * function MyComponent( { isMobile } ) {
+ * 	return (
+ * 		<div>Currently: { isMobile ? 'Mobile' : 'Not Mobile' }</div>
+ * 	);
+ * }
+ *
+ * MyComponent = withViewportMatch( { isMobile: '< small' } )( MyComponent );
+ * ```
+ *
+ * @return {Function} Higher-order component.
+ */
+const withViewportMatch = ( queries ) => createHigherOrderComponent(
+	withSelect( ( select ) => {
+		return mapValues( queries, ( query ) => {
+			return select( 'core/viewport' ).isViewportMatch( query );
+		} );
+	} ),
+	'withViewportMatch'
+);
+
+export default withViewportMatch;


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
This PR forks `with-viewport-match.js` to a native variant (`with-viewport-match.native.js`) to revert changes introduced in this PR: https://github.com/WordPress/gutenberg/pull/18950 for mobile only.

Related gutenberg-mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1668

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
The withViewportMatch HOC is used in Gallery to limit _displayed_ columns to 2 in portrait mode. This has been tested by adding 3 or more images to a gallery block and ensuring that only 2 columns are displayed in portrait mode (up to 4 in landscape). Also, using the debugger, `isNarrow` flag is confirmed to be true for portrait.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
