### PR TITLE
Image Block: Revert circle mask, add "rounded"

### DIFF
--- a/packages/block-library/src/image/index.js
+++ b/packages/block-library/src/image/index.js
@@ -34,7 +34,7 @@ export const settings = {
 	},
 	styles: [
 		{ name: 'default', label: _x( 'Default', 'block style' ), isDefault: true },
-		{ name: 'circle-mask', label: _x( 'Circle Mask', 'block style' ) },
+		{ name: 'rounded', label: _x( 'Rounded', 'block style' ) },
 	],
 	transforms,
 	getEditWrapperProps( attributes ) {

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -62,21 +62,8 @@
 }
 
 // Variations
-.is-style-circle-mask img {
+.is-style-rounded img {
 	// We use an absolute pixel to prevent the oval shape that a value of 50% would give
 	// to rectangular images. A pill-shape is better than otherwise.
 	border-radius: 9999px;
-
-	// If a browser supports it, we will switch to using a circular SVG mask.
-	// The stylelint override is necessary to use the SVG inline here.
-	@supports (mask-image: none) or (-webkit-mask-image: none) {
-		/* stylelint-disable */
-		mask-image: url('data:image/svg+xml;utf8,<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg"><circle cx="50" cy="50" r="50"/></svg>');
-		/* stylelint-enable */
-		mask-mode: alpha;
-		mask-repeat: no-repeat;
-		mask-size: contain;
-		mask-position: center;
-		border-radius: none;
-	}
 }

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -67,3 +67,24 @@
 	// to rectangular images. A pill-shape is better than otherwise.
 	border-radius: 9999px;
 }
+
+// The following variation is deprecated.
+// The CSS is kept here for the time being, to support blocks using the old variation.
+.is-style-circle-mask img {
+	// We use an absolute pixel to prevent the oval shape that a value of 50% would give
+	// to rectangular images. A pill-shape is better than otherwise.
+	border-radius: 9999px;
+
+	// If a browser supports it, we will switch to using a circular SVG mask.
+	// The stylelint override is necessary to use the SVG inline here.
+	@supports (mask-image: none) or (-webkit-mask-image: none) {
+		/* stylelint-disable */
+		mask-image: url('data:image/svg+xml;utf8,<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg"><circle cx="50" cy="50" r="50"/></svg>');
+		/* stylelint-enable */
+		mask-mode: alpha;
+		mask-repeat: no-repeat;
+		mask-size: contain;
+		mask-position: center;
+		border-radius: none;
+	}
+}


### PR DESCRIPTION
Fixes #16130, notably a followup to the issue outlined in https://github.com/WordPress/gutenberg/issues/16130#issuecomment-555451523.

The "circle mask" variation has the benefit of creating a perfect circle out of any shape image. However it doesn't change the dimensions of the image, so the tradeoff is that the image footprint is still large, and resize handles now float in air.

This PR changes it to a "rounded" style, which sets a very high border radius ensuring that the smallest sides on a rectangular image are perfectly rounded, creating a pill-shape. When the image is perfectly square, the variation will be perfectly circular. This ensures that the variation is useful both when images are rectangular, it ensures the resize handles are appropriately placed, it fixes an issue where Microsoft Edge did not render the mask properly, and it indicates to the user that if they want a perfect circle, they can upload a square image, or change the dimensions in the sidebar.

Before:

![Screenshot 2019-12-10 at 09 39 53](https://user-images.githubusercontent.com/1204802/70512994-089bd800-1b31-11ea-9ac1-7f59297ec9bd.png)

After:

![Screenshot 2019-12-10 at 09 35 25](https://user-images.githubusercontent.com/1204802/70512953-f3bf4480-1b30-11ea-9fa2-23ede7cf90c8.png)

