### PR TITLE
Fix: Drag & Drop does not work on the widgets screen

### DIFF
--- a/packages/edit-widgets/src/components/layout/index.js
+++ b/packages/edit-widgets/src/components/layout/index.js
@@ -4,6 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import {
 	navigateRegions,
+	DropZoneProvider,
 	Popover,
 	SlotFillProvider,
 } from '@wordpress/components';
@@ -21,25 +22,27 @@ function Layout( { blockEditorSettings } ) {
 	const [ selectedArea, setSelectedArea ] = useState( null );
 	return (
 		<SlotFillProvider>
-			<Header />
-			<Sidebar />
-			<Notices />
-			<div
-				className="edit-widgets-layout__content"
-				role="region"
-				aria-label={ __( 'Widgets screen content' ) }
-				tabIndex="-1"
-				onFocus={ () => {
-					setSelectedArea( null );
-				} }
-			>
-				<WidgetAreas
-					selectedArea={ selectedArea }
-					setSelectedArea={ setSelectedArea }
-					blockEditorSettings={ blockEditorSettings }
-				/>
-			</div>
-			<Popover.Slot />
+			<DropZoneProvider>
+				<Header />
+				<Sidebar />
+				<Notices />
+				<div
+					className="edit-widgets-layout__content"
+					role="region"
+					aria-label={ __( 'Widgets screen content' ) }
+					tabIndex="-1"
+					onFocus={ () => {
+						setSelectedArea( null );
+					} }
+				>
+					<WidgetAreas
+						selectedArea={ selectedArea }
+						setSelectedArea={ setSelectedArea }
+						blockEditorSettings={ blockEditorSettings }
+					/>
+				</div>
+				<Popover.Slot />
+			</DropZoneProvider>
 		</SlotFillProvider>
 	);
 }

--- a/packages/edit-widgets/src/components/widget-area/style.scss
+++ b/packages/edit-widgets/src/components/widget-area/style.scss
@@ -20,4 +20,5 @@
 
 .edit-widgets-main-block-list > .block-list-appender {
 	padding-top: $panel-padding;
+	position: relative;
 }


### PR DESCRIPTION
## Description
Currently, Drag & Drop does not work on the widgets screen. That happens not only because DropZoneProvider was not being. Adding DropZoneProvider does not immediately fix the problem and it was not easy to find the cause. I started debugging the Drag & Drop mechanism but the problem was not there. The problem was that the drop-zone appender took all the widgets to screen so when dragging & dropping a block the triggered area was not the blocks but the appender(which did nothing). This PR fixes that problem with a simple CSS rule that does not changes the visual.

## How has this been tested?
I verified I could use drag & drop on the widgets screen.