### PR TITLE
Simplify the block selected state

### DIFF
--- a/packages/base-styles/_colors.scss
+++ b/packages/base-styles/_colors.scss
@@ -88,3 +88,5 @@ $blue-medium-focus: #007cba;
 $alert-yellow: #f0b849;
 $alert-red: #d94f4f;
 $alert-green: #4ab866;
+
+$border-default-color: $black;

--- a/packages/base-styles/_variables.scss
+++ b/packages/base-styles/_variables.scss
@@ -54,7 +54,6 @@ $resize-handler-size: 15px;
 $resize-handler-container-size: $resize-handler-size + ($grid-size-small * 2); // Make the resize handle container larger so there's a larger grabbable area.
 
 // Blocks
-$block-left-border-width: $border-width * 3;
 $block-padding: 14px; // Space between block footprint and focus boundaries. These are drawn outside the block footprint, and do not affect the size.
 $block-spacing: 4px; // Vertical space between blocks.
 $block-side-ui-width: 28px; // Width of the movers/drag handle UI.

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -108,7 +108,6 @@
 			content: "";
 			position: absolute;
 			border: $border-width solid transparent;
-			border-left: none;
 			box-shadow: none;
 			pointer-events: none;
 			transition: border-color 0.1s linear, border-style 0.1s linear, box-shadow 0.1s linear;
@@ -130,30 +129,14 @@
 		> .block-editor-block-list__block-edit::before {
 			// Use opacity to work in various editor styles.
 			border-color: $dark-opacity-light-800;
-			box-shadow: inset $block-left-border-width 0 0 0 $dark-gray-500;
 
 			.is-dark-theme & {
 				border-color: $light-opacity-light-800;
-				box-shadow: inset $block-left-border-width 0 0 0 $light-gray-600;
-			}
-
-			// Switch to outset borders on larger screens.
-			@include break-small() {
-				box-shadow: -$block-left-border-width 0 0 0 $dark-gray-500;
-
-				.is-dark-theme & {
-					box-shadow: -$block-left-border-width 0 0 0 $light-gray-600;
-				}
 			}
 		}
 
 		&.is-navigate-mode > .block-editor-block-list__block-edit::before {
 			border-color: $blue-medium-focus;
-			box-shadow: inset $block-left-border-width 0 0 0 $blue-medium-focus;
-
-			@include break-small() {
-				box-shadow: -$block-left-border-width 0 0 0 $blue-medium-focus;
-			}
 		}
 	}
 
@@ -183,20 +166,9 @@
 
 		> .block-editor-block-list__block-edit::before {
 			border-left-color: $dark-opacity-light-800;
-			box-shadow: inset $block-left-border-width 0 0 0 $dark-gray-500;
 
 			.is-dark-theme & {
 				border-left-color: $light-opacity-light-800;
-				box-shadow: inset $block-left-border-width 0 0 0 $light-gray-600;
-			}
-
-			// Switch to outset borders on larger screens.
-			@include break-small() {
-				box-shadow: -$block-left-border-width 0 0 0 $dark-gray-500;
-
-				.is-dark-theme & {
-					box-shadow: -$block-left-border-width 0 0 0 $light-gray-600;
-				}
 			}
 		}
 	}
@@ -812,20 +784,6 @@
 	&[data-align="right"] .block-editor-block-contextual-toolbar {
 		margin-bottom: $border-width;
 		margin-top: -$block-toolbar-height;
-
-		// Display the box-shadow on the parent element.
-		box-shadow: -$block-left-border-width 0 0 0 $dark-gray-500;
-		.is-dark-theme & {
-			box-shadow: -$block-left-border-width 0 0 0 $light-gray-600;
-		}
-
-		@include break-small() {
-			box-shadow: none;
-		}
-
-		.block-editor-block-toolbar {
-			border-left: none;
-		}
 	}
 
 	// Make block toolbar full width on mobile.
@@ -947,24 +905,14 @@
 		display: flex;
 		background: $white;
 		border: $border-width solid $blue-medium-focus;
-		border-left: none;
-		box-shadow: inset $block-left-border-width 0 0 0 $blue-medium-focus;
 		height: $block-toolbar-height + $border-width;
 		font-size: $default-font-size;
 		line-height: $block-toolbar-height - $grid-size;
 		padding-left: $grid-size;
 		padding-right: $grid-size;
 
-		.components-button {
-			box-shadow: none;
-		}
-
 		.is-dark-theme & {
 			border-color: $light-opacity-light-800;
-		}
-
-		@include break-small() {
-			box-shadow: -$block-left-border-width 0 0 0 $blue-medium-focus;
 		}
 	}
 }

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -128,7 +128,7 @@
 	&.is-selected {
 		> .block-editor-block-list__block-edit::before {
 			// Use opacity to work in various editor styles.
-			border-color: $dark-opacity-light-800;
+			border-color: $border-default-color;
 
 			.is-dark-theme & {
 				border-color: $light-opacity-light-800;
@@ -165,7 +165,7 @@
 	.block-editor-block-list__block.is-multi-selected {
 
 		> .block-editor-block-list__block-edit::before {
-			border-left-color: $dark-opacity-light-800;
+			border-left-color: $border-default-color;
 
 			.is-dark-theme & {
 				border-left-color: $light-opacity-light-800;
@@ -222,8 +222,7 @@
 
 	&.has-warning.is-selected .block-editor-block-list__block-edit::before {
 		// Use opacity to work in various editor styles.
-		border-color: $dark-opacity-light-800;
-		border-left-color: transparent;
+		border-color: $border-default-color;
 
 		.is-dark-theme & {
 			border-color: $light-opacity-light-800;
@@ -266,7 +265,6 @@
 
 	// Reusable blocks.
 	&.is-reusable.is-selected > .block-editor-block-list__block-edit::before {
-		border-left-color: transparent;
 		border-style: dashed;
 		border-width: $border-width;
 	}
@@ -313,7 +311,7 @@
 		// Position toolbar better on mobile.
 		.block-editor-block-contextual-toolbar {
 			width: auto;
-			border-bottom: $border-width solid $light-gray-800;
+			border-bottom: $border-width solid $border-default-color;
 			bottom: auto;
 
 			@include break-small() {
@@ -764,7 +762,7 @@
 		right: -$block-padding;
 
 		// Paint the borders on the toolbar itself on mobile.
-		border-top: $border-width solid $light-gray-800;
+		border-top: $border-width solid $border-default-color;
 		.components-toolbar {
 			border-top: none;
 			border-bottom: none;
@@ -773,8 +771,8 @@
 		@include break-small() {
 			border-top: none;
 			.components-toolbar {
-				border-top: $border-width solid $light-gray-800;
-				border-bottom: $border-width solid $light-gray-800;
+				border-top: $border-width solid $border-default-color;
+				border-bottom: $border-width solid $border-default-color;
 			}
 		}
 	}
@@ -873,6 +871,14 @@
 // Position the block toolbar when contextual.
 .block-editor-block-contextual-toolbar .block-editor-block-toolbar {
 	width: 100%;
+
+	// Remove the next four lines once all toolbars (top toolbar) use the dark borders.
+	border-left: $border-width solid $border-default-color;
+	.components-toolbar {
+		border-top: $border-width solid $border-default-color;
+		border-bottom: $border-width solid $border-default-color;
+		border-right: $border-width solid $border-default-color;
+	}
 
 	@include break-small() {
 		width: auto;

--- a/packages/block-editor/src/components/block-mover/style.scss
+++ b/packages/block-editor/src/components/block-mover/style.scss
@@ -2,7 +2,7 @@
 	@include break-small() {
 		opacity: 0;
 		background: $white;
-		border: 1px solid $dark-opacity-light-800;
+		border: 1px solid $border-default-color;
 		border-radius: $radius-round-rectangle;
 		transition: box-shadow 0.2s ease-out;
 		@include reduce-motion("transition");

--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -11,15 +11,6 @@
 	@include break-small() {
 		// Allow overflow on desktop.
 		overflow: inherit;
-
-		// Show a left border on the parent container.
-		border-left: none;
-		box-shadow: -$block-left-border-width 0 0 0 $dark-gray-500;
-
-		// Show a lighter version for dark themes.
-		.is-dark-theme & {
-			box-shadow: -$block-left-border-width 0 0 0 $light-gray-600;
-		}
 	}
 
 	// The component is born with a border, but we only need some of them.

--- a/packages/block-editor/src/components/warning/style.scss
+++ b/packages/block-editor/src/components/warning/style.scss
@@ -10,11 +10,7 @@
 
 	.is-selected & {
 		// Use opacity to work in various editor styles.
-		border-color: $dark-opacity-light-800;
-
-		@include break-small {
-			border-left-color: transparent;
-		}
+		border-color: $border-default-color;
 
 		.is-dark-theme & {
 			border-color: $light-opacity-light-800;

--- a/packages/block-library/src/block/edit-panel/editor.scss
+++ b/packages/block-library/src/block/edit-panel/editor.scss
@@ -66,21 +66,17 @@
 }
 
 .editor-block-list__layout .is-selected .reusable-block-edit-panel {
-	border-color: $dark-opacity-light-800;
-	border-left-color: transparent;
+	border-color: $border-default-color;
 
 	.is-dark-theme & {
 		border-color: $light-opacity-light-800;
-		border-left-color: transparent;
 	}
 }
 
 .is-selected.is-navigate-mode .reusable-block-edit-panel {
 	border-color: $blue-medium-focus;
-	border-left-color: transparent;
 
 	.is-dark-theme & {
 		border-color: $blue-medium-focus;
-		border-left-color: transparent;
 	}
 }

--- a/packages/block-library/src/classic/editor.scss
+++ b/packages/block-library/src/classic/editor.scss
@@ -251,7 +251,6 @@ div[data-type="core/freeform"] {
 
 	&.is-selected .block-editor-block-list__block-edit::before {
 		border-color: $light-gray-800;
-		border-left-color: transparent;
 	}
 
 	.editor-block-contextual-toolbar + div {

--- a/packages/block-library/src/columns/editor.scss
+++ b/packages/block-library/src/columns/editor.scss
@@ -150,13 +150,6 @@ div.block-core-columns.is-vertically-aligned-bottom {
 }
 
 /**
- * Fixes single Column breadcrumb position.
- */
-[data-type="core/column"] > .editor-block-list__block-edit > .editor-block-list__breadcrumb {
-	left: -$block-left-border-width;
-}
-
-/**
  * Make single Column overlay not extend past boundaries of parent
  */
 .block-core-columns > .block-editor-inner-blocks.has-overlay::after {

--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -42,7 +42,7 @@ figure.wp-block-gallery {
 	.is-selected .block-library-gallery-item__move-menu,
 	.is-selected .block-library-gallery-item__inline-menu {
 		background: $white;
-		border: 1px solid $dark-opacity-light-800;
+		border: 1px solid $border-default-color;
 		border-radius: $radius-round-rectangle;
 		transition: box-shadow 0.2s ease-out;
 		@include reduce-motion("transition");

--- a/packages/edit-post/src/components/text-editor/style.scss
+++ b/packages/edit-post/src/components/text-editor/style.scss
@@ -33,7 +33,7 @@
 		// Hide the thick left border in the code editor.
 		box-shadow: none;
 		border: none;
-		outline: $border-width solid $light-gray-800;
+		outline: $border-width solid $border-default-color;
 	}
 
 	@include break-small() {

--- a/packages/editor/src/components/post-permalink/style.scss
+++ b/packages/editor/src/components/post-permalink/style.scss
@@ -11,15 +11,6 @@
 	border: $border-width solid $light-gray-800;
 	background-clip: padding-box;
 
-	// Show a thick left border to match the left border on the title field.
-	border-left: 0;
-	box-shadow: -$block-left-border-width 0 0 0 $dark-gray-500;
-
-	// Use a lighter border for dark themes.
-	.is-dark-theme & {
-		box-shadow: -$block-left-border-width 0 0 0 $light-gray-600;
-	}
-
 	// Include transparent outline for Windows High Contrast mode.
 	outline: $border-width solid transparent;
 

--- a/packages/editor/src/components/post-permalink/style.scss
+++ b/packages/editor/src/components/post-permalink/style.scss
@@ -8,7 +8,7 @@
 	font-size: $default-font-size;
 	height: 40px;
 	white-space: nowrap;
-	border: $border-width solid $light-gray-800;
+	border: $border-width solid $border-default-color;
 	background-clip: padding-box;
 
 	// Include transparent outline for Windows High Contrast mode.

--- a/packages/editor/src/components/post-text-editor/style.scss
+++ b/packages/editor/src/components/post-text-editor/style.scss
@@ -18,7 +18,7 @@
 
 	&:hover,
 	&:focus {
-		border: $border-width solid $light-gray-800 !important;
+		border: $border-width solid $border-default-color !important;
 		box-shadow: none !important;
 		// Emulate the effect used on the post title.
 		outline-offset: -2px !important;

--- a/packages/editor/src/components/post-title/style.scss
+++ b/packages/editor/src/components/post-title/style.scss
@@ -32,7 +32,6 @@
 
 		@include break-small() {
 			border-width: $border-width;
-			border-left-width: 0;
 		}
 
 		// Match h1 heading.
@@ -54,7 +53,6 @@
 
 		&:focus {
 			border: $border-width solid transparent;
-			border-left-width: 0;
 			outline: $border-width solid transparent;
 			box-shadow: none;
 		}
@@ -64,20 +62,9 @@
 		&.is-selected .editor-post-title__input {
 			// use opacity to work in various editor styles.
 			border-color: $dark-opacity-light-800;
-			box-shadow: inset $block-left-border-width 0 0 0 $dark-gray-500;
 
 			.is-dark-theme & {
 				border-color: $light-opacity-light-800;
-				box-shadow: inset $block-left-border-width 0 0 0 $light-gray-600;
-			}
-
-			// Switch to outset borders on larger screens.
-			@include break-small() {
-				box-shadow: -$block-left-border-width 0 0 0 $dark-gray-500;
-
-				.is-dark-theme & {
-					box-shadow: -$block-left-border-width 0 0 0 $light-gray-600;
-				}
 			}
 		}
 	}
@@ -98,9 +85,9 @@
 	color: $dark-gray-900;
 	height: auto;
 	position: relative;
-	left: $block-left-border-width;
+	left: 0;
 	top: -2px;
-	width: calc(100% - #{$block-left-border-width});
+	width: 100%;
 
 	@include break-mobile() {
 		position: absolute;

--- a/packages/editor/src/components/post-title/style.scss
+++ b/packages/editor/src/components/post-title/style.scss
@@ -61,7 +61,7 @@
 	&:not(.is-focus-mode) {
 		&.is-selected .editor-post-title__input {
 			// use opacity to work in various editor styles.
-			border-color: $dark-opacity-light-800;
+			border-color: $border-default-color;
 
 			.is-dark-theme & {
 				border-color: $light-opacity-light-800;


### PR DESCRIPTION
Related #18667 

Now that there's no hover state, is there any reason to keep the large left border?
This PR removes it.

<img width="711" alt="Capture d’écran 2019-12-10 à 2 06 49 PM" src="https://user-images.githubusercontent.com/272444/70531984-60990580-1b56-11ea-9383-04f04286562f.png">
