### PR TITLE
Try bold parent breadcrumbs.

### DIFF
--- a/packages/block-editor/src/components/block-breadcrumb/style.scss
+++ b/packages/block-editor/src/components/block-breadcrumb/style.scss
@@ -8,7 +8,8 @@
 		margin: 0;
 
 		&:not(:last-child)::after {
-			content: "\2192"; // This becomes →.
+			content: "\00B7"; // This becomes ·.
+			font-weight: bold;
 		}
 	}
 }
@@ -17,6 +18,7 @@
 	height: $icon-button-size-small;
 	line-height: $icon-button-size-small;
 	padding: 0;
+	font-weight: 600;
 
 	&:hover {
 		text-decoration: underline;


### PR DESCRIPTION
This PR attempts to distinguish the breadcrumb for the current block, from the parent, by making the parent breadcrumb bold.

It also cleans up the visual by replacing the arrow with a middle dot. The hover state for the parent button retains an underline.

GIF:

![crumbs](https://user-images.githubusercontent.com/1204802/70534976-74e00100-1b5c-11ea-88c2-7cf80a4c6005.gif)

The very delicate balance to reach here is between one of differentiating between a clickable breadcrumb and the current block, yet still providing a simple overall appearance given it's a permanently visible interface. If it screams at the sky, it will only add stress. It is also important to keep in mind that this interface is not, and cannot, be the only affordance for selecting parent blocks. The select tool exists, and #18667 ponders a button in the toolbar to "go up in the hierarchy", like the Up arrow in Windows Explorer.

So I'm hoping this strikes a balance between being more useful additional affordance, yet still simple so as to not distract. 