### PR TITLE
[RNMobile]: Image block: Hide Size options when Image object is undefined.

### DIFF
--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -296,7 +296,7 @@ export class ImageEdit extends React.Component {
 	}
 
 	render() {
-		const { attributes, isSelected } = this.props;
+		const { attributes, isSelected, image } = this.props;
 		const { align, url, height, width, alt, href, id, linkTarget, sizeSlug } = attributes;
 
 		const actions = [ { label: __( 'Clear All Settings' ), onPress: this.onClearSettings } ];
@@ -338,7 +338,7 @@ export class ImageEdit extends React.Component {
 						onChange={ this.onSetNewTab }
 					/>
 					{ // eslint-disable-next-line no-undef
-						__DEV__ &&
+						image && __DEV__ &&
 						<SelectControl
 							hideCancelButton
 							icon={ 'editor-expand' }


### PR DESCRIPTION
This PR fixes point 3 of https://github.com/wordpress-mobile/gutenberg-mobile/issues/1593

`gutenberg-mobile` side PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1669

When the image object is not present, the Image Size option won't be present in the Image Options.

The Image object is fetched on a network call for images stored in the WP Media Library. For images added via link, this object is never fetched.

Other cause of the object being missing is network call errors.

With this change we are looking to avoid the case when the ImageSize is displayed in the UI, but it does nothing.

To Test:
- Create a new post on Gutenberg Web.
- Add an image via link.
- Add a second image from WP Media Library.
- Save the post and open it in WPiOS/WPAndroid Gutenberg Mobile (running this branch in metro)
- Check that the Image Sizes options are displaying on the image from the Media Library.
- Check that the Image Size options are NOT displaying in the image added from external link.