### PR TITLE
Saving head and foot values on the state upon toggling

### DIFF
--- a/packages/block-library/src/table/edit.js
+++ b/packages/block-library/src/table/edit.js
@@ -260,7 +260,7 @@ export class TableEdit extends Component {
 
 			return { [ sectionName ]: [ ...sectionSaved ] };
 		}
-		// If the head section never existed, or was deleted, insert an empty row.
+		// If the section never existed, or was deleted, insert an empty row.
 		return toggleSection( attributes, sectionName );
 	}
 

--- a/packages/block-library/src/table/edit.js
+++ b/packages/block-library/src/table/edit.js
@@ -109,6 +109,7 @@ export class TableEdit extends Component {
 		this.onToggleFooterSection = this.onToggleFooterSection.bind( this );
 		this.onChangeColumnAlignment = this.onChangeColumnAlignment.bind( this );
 		this.getCellAlignment = this.getCellAlignment.bind( this );
+		this.toggleSectionByName = this.toggleSectionByName.bind( this );
 
 		this.state = {
 			initialRowCount: 2,
@@ -232,19 +233,51 @@ export class TableEdit extends Component {
 	}
 
 	/**
+  * Get the data needed to toggle a section
+  *
+  * @param {string} sectionName the section name to hide.
+  * @return {Object} The new table state
+  */
+	toggleSectionByName( sectionName ) {
+		const { attributes } = this.props;
+		const section = attributes[ sectionName ];
+		const sectionSavedName = `${ sectionName }Saved`;
+		const sectionSaved = this.state[ sectionSavedName ];
+
+		if ( ! isEmptyTableSection( section ) ) {
+			// If the section has some data, save it to the state.
+			this.setState( {
+				[ sectionSavedName ]: [ ...section ],
+			} );
+
+			return toggleSection( attributes, sectionName );
+		} else if ( sectionSaved && sectionSaved.length ) {
+			// If there is a saved version of the section, use it instead of an empty row.
+			this.setState( ( state ) => {
+				delete state[ sectionSavedName ];
+				return state;
+			} );
+
+			return { [ sectionName ]: [ ...sectionSaved ] };
+		}
+		// If the head section never existed, or was deleted, insert an empty row.
+		return toggleSection( attributes, sectionName );
+	}
+
+	/**
 	 * Add or remove a `head` table section.
 	 */
 	onToggleHeaderSection() {
-		const { attributes, setAttributes } = this.props;
-		setAttributes( toggleSection( attributes, 'head' ) );
+		const { setAttributes } = this.props;
+		setAttributes( this.toggleSectionByName( 'head' ) );
 	}
 
 	/**
 	 * Add or remove a `foot` table section.
 	 */
 	onToggleFooterSection() {
-		const { attributes, setAttributes } = this.props;
-		setAttributes( toggleSection( attributes, 'foot' ) );
+		const { setAttributes } = this.props;
+		setAttributes( this.toggleSectionByName( 'foot' ) );
 	}
 
 	/**

--- a/packages/block-library/src/table/edit.js
+++ b/packages/block-library/src/table/edit.js
@@ -233,10 +233,10 @@ export class TableEdit extends Component {
 	}
 
 	/**
-  * Get the data needed to toggle a section
+  * Get the data needed to toggle a section.
   *
   * @param {string} sectionName the section name to hide.
-  * @return {Object} The new table state
+  * @return {Object} The new table state.
   */
 	toggleSectionByName( sectionName ) {
 		const { attributes } = this.props;

--- a/packages/block-library/src/table/state.js
+++ b/packages/block-library/src/table/state.js
@@ -276,16 +276,25 @@ export function deleteColumn( state, {
  * @return {Object} New table state.
  */
 export function toggleSection( state, sectionName ) {
-	// Section exists, replace it with an empty row to remove it.
+	const sectionSaved = `${ sectionName }Saved`;
+
+	// Section exists, save it and replace it with an empty row to remove it.
 	if ( ! isEmptyTableSection( state[ sectionName ] ) ) {
-		return { [ sectionName ]: [] };
+		return { [ sectionName ]: [], [ sectionSaved ]: [ ...state[ sectionName ] ] };
+	}
+
+	// Check if we already have this section
+	if ( state[ sectionSaved ] ) {
+		return {
+			[ sectionName ]: [ ...state[ sectionSaved ] ],
+		};
 	}
 
 	// Get the length of the first row of the body to use when creating the header.
 	const columnCount = get( state, [ 'body', 0, 'cells', 'length' ], 1 );
-
 	// Section doesn't exist, insert an empty row to create the section.
-	return insertRow( state, { sectionName, rowIndex: 0, columnCount } );
+	const row = insertRow( state, { sectionName, rowIndex: 0, columnCount } );
+	return row;
 }
 
 /**

--- a/packages/block-library/src/table/state.js
+++ b/packages/block-library/src/table/state.js
@@ -276,25 +276,15 @@ export function deleteColumn( state, {
  * @return {Object} New table state.
  */
 export function toggleSection( state, sectionName ) {
-	const sectionSaved = `${ sectionName }Saved`;
-
-	// Section exists, save it and replace it with an empty row to remove it.
+	// Section exists, replace it with an empty row to remove it.
 	if ( ! isEmptyTableSection( state[ sectionName ] ) ) {
-		return { [ sectionName ]: [], [ sectionSaved ]: [ ...state[ sectionName ] ] };
-	}
-
-	// Check if we already have this section
-	if ( state[ sectionSaved ] ) {
-		return {
-			[ sectionName ]: [ ...state[ sectionSaved ] ],
-		};
+		return { [ sectionName ]: [] };
 	}
 
 	// Get the length of the first row of the body to use when creating the header.
 	const columnCount = get( state, [ 'body', 0, 'cells', 'length' ], 1 );
 	// Section doesn't exist, insert an empty row to create the section.
-	const row = insertRow( state, { sectionName, rowIndex: 0, columnCount } );
-	return row;
+	return insertRow( state, { sectionName, rowIndex: 0, columnCount } );
 }
 
 /**


### PR DESCRIPTION
## Description
Fixes #18919 

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- Bug fix (non-breaking change which fixes an issue) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
