### PR TITLE
[RNMobile] Remove Reset button from Spacer settings

### DIFF
--- a/packages/components/src/mobile/bottom-sheet/range-cell.native.js
+++ b/packages/components/src/mobile/bottom-sheet/range-cell.native.js
@@ -140,7 +140,6 @@ class BottomSheetRangeCell extends Component {
 			maximumTrackTintColor = Platform.OS === 'ios' ? '#e9eff3' : '#909090',
 			thumbTintColor = Platform.OS === 'android' && '#00669b',
 			getStylesFromColorScheme,
-			allowReset = true,
 			...cellProps
 		} = this.props;
 
@@ -154,8 +153,6 @@ class BottomSheetRangeCell extends Component {
 		);
 
 		const defaultSliderStyle = getStylesFromColorScheme( styles.sliderTextInput, styles.sliderDarkTextInput );
-		const resetButtonText = Platform.OS === 'ios' ? __( 'Reset' ) : __( 'RESET' );
-		const resetButton = { title: resetButtonText, handler: this.handleReset };
 
 		return (
 			<Cell
@@ -163,11 +160,11 @@ class BottomSheetRangeCell extends Component {
 				cellContainerStyle={ styles.cellContainerStyles }
 				cellRowContainerStyle={ styles.cellRowStyles }
 				accessibilityRole={ 'none' }
+				value={ '' }
 				editable={ false }
 				accessible={ accessible }
 				onPress={ this.onCellPress }
 				accessibilityLabel={ accessibilityLabel }
-				customActionButton={ allowReset ? resetButton : undefined }
 				accessibilityHint={
 					/* translators: accessibility text (hint for focusing a slider) */
 					__( 'Double tap to change the value using slider' )

--- a/packages/components/src/mobile/bottom-sheet/range-cell.native.js
+++ b/packages/components/src/mobile/bottom-sheet/range-cell.native.js
@@ -24,7 +24,6 @@ class BottomSheetRangeCell extends Component {
 		this.handleToggleFocus = this.handleToggleFocus.bind( this );
 		this.handleChange = this.handleChange.bind( this );
 		this.handleValueSave = this.handleValueSave.bind( this );
-		this.handleReset = this.handleReset.bind( this );
 		this.onChangeValue = this.onChangeValue.bind( this );
 		this.onCellPress = this.onCellPress.bind( this );
 		this.handleChangePixelRatio = this.handleChangePixelRatio.bind( this );
@@ -33,13 +32,6 @@ class BottomSheetRangeCell extends Component {
 		const fontScale = this.getFontScale();
 
 		this.state = { accessible: true, sliderValue: initialValue, initialValue, hasFocus: false, fontScale };
-	}
-
-	componentDidUpdate( ) {
-		const reset = this.props.value === null;
-		if ( reset ) {
-			this.handleReset();
-		}
 	}
 
 	componentDidMount() {
@@ -66,10 +58,6 @@ class BottomSheetRangeCell extends Component {
 			this.setState( { sliderValue: text } );
 			this.announceCurrentValue( text );
 		}
-	}
-
-	handleReset() {
-		this.handleValueSave( this.props.defaultValue || this.state.initialValue );
 	}
 
 	handleToggleFocus( validateInput = true ) {


### PR DESCRIPTION
## Description

Fixes: https://github.com/wordpress-mobile/gutenberg-mobile/issues/1644
ref to gb-mobile:: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1670
This PR removed `Reset` button from `Spacer` component to be coherent with the web.

## How has this been tested?

1. Run the app
2. Add `Spacer` block
3. Open settings
4. Check if there is no `Reset` button

## Screenshots <!-- if applicable -->
android | ios | ios dark mode
--- | --- | --- 
<img width="451" alt="Screenshot 2019-12-10 at 15 55 21" src="https://user-images.githubusercontent.com/22746080/70542944-f1c5a780-1b69-11ea-867e-eb42b053b9ff.png"> | <img width="511" alt="Screenshot 2019-12-10 at 15 51 36" src="https://user-images.githubusercontent.com/22746080/70542950-f4c09800-1b69-11ea-9dbe-0a8515c9bd21.png"> | <img width="467" alt="Screenshot 2019-12-10 at 15 51 09" src="https://user-images.githubusercontent.com/22746080/70542957-f5f1c500-1b69-11ea-99ed-d80c5c91f92f.png">


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
