### PR TITLE
Paste: strip HTML formatting space for inline text

### DIFF
--- a/packages/blocks/src/api/raw-handling/paste-handler.js
+++ b/packages/blocks/src/api/raw-handling/paste-handler.js
@@ -50,6 +50,7 @@ const { console } = window;
 function filterInlineHTML( HTML ) {
 	HTML = deepFilterHTML( HTML, [ googleDocsUIDRemover, phrasingContentReducer, commentRemover ] );
 	HTML = removeInvalidHTML( HTML, getPhrasingContentSchema( 'paste' ), { inline: true } );
+	HTML = deepFilterHTML( HTML, [ htmlFormattingRemover, brRemover ] );
 
 	// Allows us to ask for this information when we get a report.
 	console.log( 'Processed inline HTML:\n\n', HTML );

--- a/test/integration/__snapshots__/blocks-raw-handling.test.js.snap
+++ b/test/integration/__snapshots__/blocks-raw-handling.test.js.snap
@@ -10,6 +10,8 @@ exports[`Blocks raw handling pasteHandler should remove extra blank lines 1`] = 
 <!-- /wp:paragraph -->"
 `;
 
+exports[`Blocks raw handling pasteHandler should strip HTML formatting space from inline text 1`] = `"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent a elit eget tortor molestie egestas. Donec pretium urna vitae mattis imperdiet. Praesent et lorem iaculis, volutpat odio vitae, ornare lacus. Donec ut felis tristique, pharetra erat id, viverra justo. Integer sit amet elementum arcu, eget pharetra felis. In malesuada enim est, sed placerat nulla feugiat at. Vestibulum feugiat vitae elit sit amet tincidunt. Pellentesque finibus sed dolor non facilisis. Curabitur accumsan ante ac hendrerit vestibulum."`;
+
 exports[`Blocks raw handling pasteHandler should strip some text-level elements 1`] = `
 "<!-- wp:paragraph -->
 <p>This is ncorect</p>

--- a/test/integration/blocks-raw-handling.test.js
+++ b/test/integration/blocks-raw-handling.test.js
@@ -319,6 +319,12 @@ describe( 'Blocks raw handling', () => {
 			const HTML = readFile( path.join( __dirname, 'fixtures/windows.html' ) );
 			expect( serialize( pasteHandler( { HTML } ) ) ).toMatchSnapshot();
 		} );
+
+		it( 'should strip HTML formatting space from inline text', () => {
+			const HTML = readFile( path.join( __dirname, 'fixtures/inline-with-html-formatting-space.html' ) );
+			expect( pasteHandler( { HTML } ) ).toMatchSnapshot();
+			expect( console ).toHaveLogged();
+		} );
 	} );
 } );
 

--- a/test/integration/fixtures/inline-with-html-formatting-space.html
+++ b/test/integration/fixtures/inline-with-html-formatting-space.html
@@ -1,0 +1,11 @@
+<html><body>
+    <!--StartFragment-->Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent a elit
+     eget tortor molestie egestas. Donec pretium urna vitae mattis
+    imperdiet. Praesent et lorem iaculis, volutpat odio vitae, ornare lacus.
+     Donec ut felis tristique, pharetra erat id, viverra justo. Integer sit
+    amet elementum arcu, eget pharetra felis. In malesuada enim est, sed
+    placerat nulla feugiat at. Vestibulum feugiat vitae elit sit amet
+    tincidunt. Pellentesque finibus sed dolor non facilisis. Curabitur
+    accumsan ante ac hendrerit vestibulum.
+    <!--EndFragment-->
+    </body>


### PR DESCRIPTION
## Description

Fixes #16172.
Since #17470 HTML formatting space is cleaned up on paste, but I forgot to add this for inline paste.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
