### PR TITLE
Fix: useColors crashes on storybook

### DIFF
--- a/packages/block-editor/src/components/colors/use-colors.js
+++ b/packages/block-editor/src/components/colors/use-colors.js
@@ -30,7 +30,7 @@ import { useBlockEditContext } from '../block-edit';
 /**
  * Browser dependencies
  */
-const { getComputedStyle } = window;
+const { getComputedStyle, Node } = window;
 
 const DEFAULT_COLORS = [];
 
@@ -244,7 +244,8 @@ export default function __experimentalUseColors(
 							.backgroundColor;
 						while (
 							backgroundColor === 'rgba(0, 0, 0, 0)' &&
-							backgroundColorNode.parentNode
+							backgroundColorNode.parentNode &&
+							backgroundColorNode.parentNode === Node.ELEMENT_NODE
 						) {
 							backgroundColorNode = backgroundColorNode.parentNode;
 							backgroundColor = getComputedStyle( backgroundColorNode )


### PR DESCRIPTION
## Description
We were verifying if a parent node exists to use a background color, but we were not verifying the node type and getComputedStyle can not be used with some node types (e.g: document).
Currently adding paragraphs or headings on the storybook playground is impossible, this PR fixes the issue by adding a simple check.

## How has this been tested?
I executed npm run storybook:dev.
I opened the playground and verified I could add paragraphs and headings.
