### PR TITLE
[RNMobile] Merge mobile release v1.19.0 back into master

### DIFF
--- a/packages/viewport/src/with-viewport-match.native.js
+++ b/packages/viewport/src/with-viewport-match.native.js
@@ -1,0 +1,44 @@
+/**
+ * External dependencies
+ */
+import { mapValues } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { withSelect } from '@wordpress/data';
+
+/**
+ * Higher-order component creator, creating a new component which renders with
+ * the given prop names, where the value passed to the underlying component is
+ * the result of the query assigned as the object's value.
+ *
+ * @see isViewportMatch
+ *
+ * @param {Object} queries  Object of prop name to viewport query.
+ *
+ * @example
+ *
+ * ```jsx
+ * function MyComponent( { isMobile } ) {
+ * 	return (
+ * 		<div>Currently: { isMobile ? 'Mobile' : 'Not Mobile' }</div>
+ * 	);
+ * }
+ *
+ * MyComponent = withViewportMatch( { isMobile: '< small' } )( MyComponent );
+ * ```
+ *
+ * @return {Function} Higher-order component.
+ */
+const withViewportMatch = ( queries ) => createHigherOrderComponent(
+	withSelect( ( select ) => {
+		return mapValues( queries, ( query ) => {
+			return select( 'core/viewport' ).isViewportMatch( query );
+		} );
+	} ),
+	'withViewportMatch'
+);
+
+export default withViewportMatch;


### PR DESCRIPTION
## Description

Related PR in gutenberg-mobile: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1667

Details:
- Fixed an issue with Gallery Block number of columns (https://github.com/WordPress/gutenberg/pull/19027)

## How has this been tested?

This should be tested in this gutenberg-mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1667 and in the WP apps directly (WPAndroid - https://github.com/wordpress-mobile/WordPress-Android/pull/10926, WPiOS - https://github.com/wordpress-mobile/WordPress-iOS/pull/13065.

## Types of changes

No new changes, everything was introduced in separate PRs already.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
