### PR TITLE
Block examples: concatenate strings and add translators notes

### DIFF
--- a/packages/block-library/src/image/index.js
+++ b/packages/block-library/src/image/index.js
@@ -29,6 +29,7 @@ export const settings = {
 		attributes: {
 			sizeSlug: 'large',
 			url: 'https://s.w.org/images/core/5.3/MtBlanc1.jpg',
+			// translators: Caption accompanying an image of the Mont Blanc, which serves as an example for the Image block.
 			caption: __( 'Mont Blanc appears—still, snowy, and serene.' ),
 		},
 	},

--- a/packages/block-library/src/preformatted/index.js
+++ b/packages/block-library/src/preformatted/index.js
@@ -22,9 +22,8 @@ export const settings = {
 	icon,
 	example: {
 		attributes: {
-			content: __( 'EXT. XANADU - FAINT DAWN - 1940 (MINIATURE)' ) + '\n' +
-			__( 'Window, very small in the distance, illuminated.' ) + '\n' +
-			__( 'All around this is an almost totally black screen. Now, as the camera moves slowly towards the window which is almost a postage stamp in the frame, other forms appear;' ),
+			// translators: Sample content for the Preformatted block. Can be replaced with a more locale-adequate work.
+			content: __( 'EXT. XANADU - FAINT DAWN - 1940 (MINIATURE)\nWindow, very small in the distance, illuminated.\nAll around this is an almost totally black screen. Now, as the camera moves slowly towards the window which is almost a postage stamp in the frame, other forms appear;' ),
 		},
 	},
 	transforms,

--- a/packages/block-library/src/pullquote/index.js
+++ b/packages/block-library/src/pullquote/index.js
@@ -23,8 +23,11 @@ export const settings = {
 	icon,
 	example: {
 		attributes: {
-			value: '<p>' + __( 'One of the hardest things to do in technology is disrupt yourself.' ) + '</p>',
-			citation: 'Matt Mullenweg',
+			value: '<p>' +
+			// translators: Quote serving as example for the Pullquote block. Attributed to Matt Mullenweg.
+			__( 'One of the hardest things to do in technology is disrupt yourself.' ) +
+			'</p>',
+			citation: __( 'Matt Mullenweg' ),
 		},
 	},
 	styles: [

--- a/packages/block-library/src/verse/index.js
+++ b/packages/block-library/src/verse/index.js
@@ -23,7 +23,7 @@ export const settings = {
 	icon,
 	example: {
 		attributes: {
-			// translators: Sample content for the Verse block. Can be replaced with a locale-appropriate work.
+			// translators: Sample content for the Verse block. Can be replaced with a more locale-adequate work.
 			content: __( 'WHAT was he doing, the great god Pan,\n	Down in the reeds by the river?\nSpreading ruin and scattering ban,\nSplashing and paddling with hoofs of a goat,\nAnd breaking the golden lilies afloat\n    With the dragon-fly on the river.' ),
 		},
 	},


### PR DESCRIPTION
## Description

Addresses feedback from https://github.com/WordPress/gutenberg/issues/17810#issuecomment-563013409.

## How has this been tested?
Try viewing the affected block examples using the global block inserter.  No change should be observed.

## Types of changes
i18n improvements.