### PR TITLE
Raw handling: Skip shortcode if not on its own line

### DIFF
--- a/packages/blocks/src/api/raw-handling/shortcode-converter.js
+++ b/packages/blocks/src/api/raw-handling/shortcode-converter.js
@@ -36,9 +36,9 @@ function segmentHTMLToShortcodeBlock( HTML, lastIndex = 0, excludedBlockNames = 
 	const previousIndex = lastIndex;
 
 	if ( ( match = next( transformTag, HTML, lastIndex ) ) ) {
-		const beforeHTML = HTML.substr( 0, match.index );
-
 		lastIndex = match.index + match.content.length;
+		const beforeHTML = HTML.substr( 0, match.index );
+		const afterHTML = HTML.substr( lastIndex );
 
 		// If the shortcode content does not contain HTML and the shortcode is
 		// not on a new line (or in paragraph from Markdown converter),
@@ -46,7 +46,10 @@ function segmentHTMLToShortcodeBlock( HTML, lastIndex = 0, excludedBlockNames = 
 		// this segment.
 		if (
 			! includes( match.shortcode.content || '', '<' ) &&
-			! /(\n|<p>)\s*$/.test( beforeHTML )
+			! (
+				/(\n|<p>)\s*$/.test( beforeHTML ) &&
+				/^\s*(\n|<\/p>)/.test( afterHTML )
+			)
 		) {
 			return segmentHTMLToShortcodeBlock( HTML, lastIndex );
 		}

--- a/test/integration/shortcode-converter.test.js
+++ b/test/integration/shortcode-converter.test.js
@@ -219,6 +219,16 @@ describe( 'segmentHTMLToShortcodeBlock', () => {
 		expect( transformed ).toHaveLength( 9 );
 	} );
 
+	it( 'should not convert inline shortcodes', () => {
+		const originalInASentence = `<p>Here is a nice [foo shortcode].</p>`;
+		expect( segmentHTMLToShortcodeBlock( originalInASentence, 0 ) )
+			.toEqual( [ originalInASentence ] );
+
+		const originalMultipleShortcodes = `<p>[foo bar] [baz quux]</p>`;
+		expect( segmentHTMLToShortcodeBlock( originalMultipleShortcodes, 0 ) )
+			.toEqual( [ originalMultipleShortcodes ] );
+	} );
+
 	it( 'should convert regardless of shortcode alias', () => {
 		const original = `<p>[my-gallery ids="1,2,3"]</p>
 <p>[my-bunch-of-images ids="4,5,6"]</p>`;


### PR DESCRIPTION
## Description

Improves the existing logic for detection of "inline shortcodes" by ensuring that a shortcodes stands not only at the start of a line/paragraph, but also at the end of one.

## Example

The following classic input:

```
[foo]A[/foo] [foo]B[/foo]
```

yields:

Before | After
-|-
Shortcode block for `[foo]A[/foo]` followed by Paragraph block with content `[foo]B[/foo]`. | Paragraph block with content equal to input: `[foo]A[/foo] [foo]B[/foo]`.

## How has this been tested?
Addition of integration tests.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
