### PR TITLE
Fix: Gallery crashes on contributor roles

### DIFF
--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -237,7 +237,11 @@ class GalleryEdit extends Component {
 	componentDidMount() {
 		const { attributes, mediaUpload } = this.props;
 		const { images } = attributes;
-		if ( Platform.OS === 'web' && every( images, ( { url } ) => isBlobURL( url ) ) ) {
+		if (
+			Platform.OS === 'web' &&
+			images && images.length > 0 &&
+			every( images, ( { url } ) => isBlobURL( url ) )
+		) {
 			const filesList = map( images, ( { url } ) => getBlobByURL( url ) );
 			forEach( images, ( { url } ) => revokeBlobURL( url ) );
 			mediaUpload( {


### PR DESCRIPTION
## Description
Currently, the gallery block is crashing on contributor roles. This PR fixes this problem by ensuring the upload mechanism only executes if, in fact, we have images to upload.

## How has this been tested?
With a contributor user, I added a gallery block and verified it does not crashes (although the user can not do anything).
I tried to drag & drop images to the editor and verified it was not possible.
