### PR TITLE
Components: List component that ensures that the role is properly handled

### DIFF
--- a/packages/components/src/custom-select-control/index.js
+++ b/packages/components/src/custom-select-control/index.js
@@ -7,7 +7,9 @@ import classnames from 'classnames';
 /**
  * Internal dependencies
  */
-import { Button, Dashicon } from '../';
+import Button from '../button';
+import Dashicon from '../dashicon';
+import List from '../list';
 
 const itemToString = ( item ) => item && item.name;
 // This is needed so that in Windows, where
@@ -107,7 +109,7 @@ export default function CustomSelectControl( {
 					className="components-custom-select-control__button-icon"
 				/>
 			</Button>
-			<ul { ...menuProps }>
+			<List { ...menuProps }>
 				{ isOpen &&
 					items.map( ( item, index ) => (
 						// eslint-disable-next-line react/jsx-key
@@ -134,7 +136,7 @@ export default function CustomSelectControl( {
 							{ item.name }
 						</li>
 					) ) }
-			</ul>
+			</List>
 		</div>
 	);
 }

--- a/packages/components/src/form-token-field/suggestions-list.js
+++ b/packages/components/src/form-token-field/suggestions-list.js
@@ -11,6 +11,11 @@ import classnames from 'classnames';
 import { Component } from '@wordpress/element';
 import { withSafeTimeout } from '@wordpress/compose';
 
+/**
+ * Internal dependencies
+ */
+import List from '../list';
+
 class SuggestionsList extends Component {
 	constructor() {
 		super( ...arguments );
@@ -73,12 +78,8 @@ class SuggestionsList extends Component {
 	}
 
 	render() {
-		// We set `tabIndex` here because otherwise Firefox sets focus on this
-		// div when tabbing off of the input in `TokenField` -- not really sure
-		// why, since usually a div isn't focusable by default
-		// TODO does this still apply now that it's a <ul> and not a <div>?
 		return (
-			<ul
+			<List
 				ref={ this.bindList }
 				className="components-form-token-field__suggestions-list"
 				id={ `components-form-token-suggestions-${ this.props.instanceId }` }
@@ -120,7 +121,7 @@ class SuggestionsList extends Component {
 						/* eslint-enable jsx-a11y/click-events-have-key-events */
 					} )
 				}
-			</ul>
+			</List>
 		);
 	}
 }

--- a/packages/components/src/guide/page-control.js
+++ b/packages/components/src/guide/page-control.js
@@ -12,11 +12,15 @@ import { __, sprintf } from '@wordpress/i18n';
  * Internal dependencies
  */
 import IconButton from '../icon-button';
+import List from '../list';
 import { PageControlIcon } from './icons';
 
 export default function PageControl( { currentPage, numberOfPages, setCurrentPage } ) {
 	return (
-		<ul className="components-guide__page-control" aria-label={ __( 'Guide controls' ) }>
+		<List
+			className="components-guide__page-control"
+			accessibilityLabel={ __( 'Guide controls' ) }
+		>
 			{ times( numberOfPages, ( page ) => (
 				<li key={ page }>
 					<IconButton
@@ -28,6 +32,6 @@ export default function PageControl( { currentPage, numberOfPages, setCurrentPag
 					/>
 				</li>
 			) ) }
-		</ul>
+		</List>
 	);
 }

--- a/packages/components/src/list/index.js
+++ b/packages/components/src/list/index.js
@@ -1,0 +1,16 @@
+/**
+ * WordPress dependencies
+ */
+import { createElement, forwardRef } from '@wordpress/element';
+
+const List = ( { type = 'unordered', accessibilityLabel, ...props }, ref ) => {
+	const tagName = type === 'ordered' ? 'ol' : 'ul';
+	return createElement( tagName, {
+		role: 'list',
+		'aria-label': accessibilityLabel,
+		...props,
+		ref,
+	} );
+};
+
+export default forwardRef( List );


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

This PR proposes that we introduce `List` component which will handle some accessibility concerns behind the scenes. It's quite common that the following code needs to be written:

https://github.com/WordPress/gutenberg/blob/ee3e0b28a6a325d216cf6ae24d75d7e9573a1486/packages/block-directory/src/components/downloadable-blocks-list/index.js#L24-L29

You can find it in a few places. In other places, it's probably missing. The idea is to have a common abstraction that automates it.

We would have to expose `List` as part of public API and discourage direct usage of `ul` and `ol` tags as components. It can be implemented similar to how `button` or `svg` tags are detected by ESLint:

https://github.com/WordPress/gutenberg/blob/ee3e0b28a6a325d216cf6ae24d75d7e9573a1486/.eslintrc.js#L130-L145

This will make it easier to write cross-platform lists in the long run.

## How has this been tested?
`npm run test-e2e`
`npm run test-unit`

## Types of changes
Refactoring, no visual changes.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
