### PR TITLE
Media Replace Flow: Don't show the URL option unless there is a handler

### DIFF
--- a/packages/block-editor/src/components/media-replace-flow/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/index.js
@@ -174,13 +174,13 @@ const MediaReplaceFlow = (
 								} }
 							/>
 						</MediaUploadCheck>
-						<MenuItem
+						{ onSelectURL && <MenuItem
 							icon="admin-links"
 							onClick={ () => ( setShowURLInput( ! showURLInput ) ) }
 							aria-expanded={ showURLInput }
 						>
 							<div> { __( 'Insert from URL' ) } </div>
-						</MenuItem>
+						</MenuItem> }
 					</NavigableMenu>
 					{ showURLInput && <div className="block-editor-media-flow__url-input">
 						{ urlInputUIContent }


### PR DESCRIPTION
## Description
In the [site logo block](https://github.com/WordPress/gutenberg/pull/18811) we want to use the MediaReplaceFlow component, but we don't want to offer the URL option. This change ensures that the "Insert From URL" option only shows when a `onSelectURL` handler is passed. This is what we do in `MediaPlaceholder`

## How has this been tested?
- Use the site logo branch (https://github.com/WordPress/gutenberg/pull/18811)
- Then apply this change on top
- Check that the site logo block doesn't have an "Insert From URL" option
- Check that the image block still has a "Insert From URL" option

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
