### PR TITLE
Paste: don't unwrap inline images

### DIFF
--- a/packages/blocks/src/api/raw-handling/figure-content-reducer.js
+++ b/packages/blocks/src/api/raw-handling/figure-content-reducer.js
@@ -6,7 +6,7 @@ import { has } from 'lodash';
 /**
  * Internal dependencies
  */
-import { isPhrasingContent } from './phrasing-content';
+import { isTextContent } from './phrasing-content';
 
 /**
  * Whether or not the given node is figure content.
@@ -21,7 +21,7 @@ function isFigureContent( node, schema ) {
 
 	// We are looking for tags that can be a child of the figure tag, excluding
 	// `figcaption` and any phrasing content.
-	if ( tag === 'figcaption' || isPhrasingContent( node ) ) {
+	if ( tag === 'figcaption' || isTextContent( node ) ) {
 		return false;
 	}
 
@@ -40,6 +40,18 @@ function canHaveAnchor( node, schema ) {
 	const tag = node.nodeName.toLowerCase();
 
 	return has( schema, [ 'figure', 'children', 'a', 'children', tag ] );
+}
+
+/**
+ * Wraps the given element in a figure element.
+ *
+ * @param {Element} element       The element to wrap.
+ * @param {Element} beforeElement The element before which to place the figure.
+ */
+function wrapFigureContent( element, beforeElement = element ) {
+	const figure = element.ownerDocument.createElement( 'figure' );
+	beforeElement.parentNode.insertBefore( figure, beforeElement );
+	figure.appendChild( element );
 }
 
 /**
@@ -70,19 +82,20 @@ export default function( node, doc, schema ) {
 		nodeToInsert = node.parentNode;
 	}
 
-	let wrapper = nodeToInsert;
+	const wrapper = nodeToInsert.closest( 'p,div' );
 
-	while ( wrapper && wrapper.nodeName !== 'P' ) {
-		wrapper = wrapper.parentElement;
-	}
-
-	const figure = doc.createElement( 'figure' );
-
+	// If wrapped in a paragraph or div, only extract if it's aligned or if
+	// there is no text content.
+	// Otherwise, if directly at the root, wrap in a figure element.
 	if ( wrapper ) {
-		wrapper.parentNode.insertBefore( figure, wrapper );
-	} else {
-		nodeToInsert.parentNode.insertBefore( figure, nodeToInsert );
+		if (
+			node.classList.contains( 'alignright' ) ||
+			node.classList.contains( 'alignleft' ) ||
+			! wrapper.textContent.trim()
+		) {
+			wrapFigureContent( nodeToInsert, wrapper );
+		}
+	} else if ( nodeToInsert.parentNode.nodeName === 'BODY' ) {
+		wrapFigureContent( nodeToInsert );
 	}
-
-	figure.appendChild( nodeToInsert );
 }

--- a/packages/blocks/src/api/raw-handling/figure-content-reducer.js
+++ b/packages/blocks/src/api/raw-handling/figure-content-reducer.js
@@ -91,6 +91,7 @@ export default function( node, doc, schema ) {
 		if (
 			node.classList.contains( 'alignright' ) ||
 			node.classList.contains( 'alignleft' ) ||
+			node.classList.contains( 'aligncenter' ) ||
 			! wrapper.textContent.trim()
 		) {
 			wrapFigureContent( nodeToInsert, wrapper );

--- a/packages/blocks/src/api/raw-handling/is-inline-content.js
+++ b/packages/blocks/src/api/raw-handling/is-inline-content.js
@@ -6,7 +6,7 @@ import { difference } from 'lodash';
 /**
  * Internal dependencies
  */
-import { isPhrasingContent } from './phrasing-content';
+import { isTextContent } from './phrasing-content';
 
 /**
  * Checks if the given node should be considered inline content, optionally
@@ -18,7 +18,7 @@ import { isPhrasingContent } from './phrasing-content';
  * @return {boolean} True if the node is inline content, false if nohe.
  */
 function isInline( node, contextTag ) {
-	if ( isPhrasingContent( node ) ) {
+	if ( isTextContent( node ) ) {
 		return true;
 	}
 

--- a/packages/blocks/src/api/raw-handling/phrasing-content.js
+++ b/packages/blocks/src/api/raw-handling/phrasing-content.js
@@ -4,11 +4,17 @@
 import { omit, without } from 'lodash';
 
 /**
+ * All phrasing content elements.
+ *
+ * @see https://www.w3.org/TR/2011/WD-html5-20110525/content-models.html#phrasing-content-0
+ */
+
+/**
  * All text-level semantic elements.
  *
  * @see https://html.spec.whatwg.org/multipage/text-level-semantics.html
  */
-const phrasingContentSchema = {
+const textContentSchema = {
 	strong: {},
 	em: {},
 	s: {},
@@ -46,9 +52,34 @@ const phrasingContentSchema = {
 // Recursion is needed.
 // Possible: strong > em > strong.
 // Impossible: strong > strong.
-without( Object.keys( phrasingContentSchema ), '#text', 'br' ).forEach( ( tag ) => {
-	phrasingContentSchema[ tag ].children = omit( phrasingContentSchema, tag );
+without( Object.keys( textContentSchema ), '#text', 'br' ).forEach( ( tag ) => {
+	textContentSchema[ tag ].children = omit( textContentSchema, tag );
 } );
+
+/**
+ * Embedded content elements.
+ *
+ * @see https://www.w3.org/TR/2011/WD-html5-20110525/content-models.html#embedded-content-0
+ */
+const embeddedContentSchema = {
+	audio: { attributes: [ 'src', 'preload', 'autoplay', 'mediagroup', 'loop', 'muted' ] },
+	canvas: { attributes: [ 'width', 'height' ] },
+	embed: { attributes: [ 'src', 'type', 'width', 'height' ] },
+	iframe: { attributes: [ 'src', 'srcdoc', 'name', 'sandbox', 'seamless', 'width', 'height' ] },
+	img: { attributes: [ 'alt', 'src', 'srcset', 'usemap', 'ismap', 'width', 'height' ] },
+	object: { attributes: [ 'data', 'type', 'name', 'usemap', 'form', 'width', 'height' ] },
+	video: { attributes: [ 'src', 'poster', 'preload', 'autoplay', 'mediagroup', 'loop', 'muted', 'controls', 'width', 'height' ] },
+};
+
+/**
+ * Phrasing content elements.
+ *
+ * @see https://www.w3.org/TR/2011/WD-html5-20110525/content-models.html#phrasing-content-0
+ */
+const phrasingContentSchema = {
+	...textContentSchema,
+	...embeddedContentSchema,
+};
 
 /**
  * Get schema of possible paths for phrasing content.
@@ -94,4 +125,9 @@ export function getPhrasingContentSchema( context ) {
 export function isPhrasingContent( node ) {
 	const tag = node.nodeName.toLowerCase();
 	return getPhrasingContentSchema().hasOwnProperty( tag ) || tag === 'span';
+}
+
+export function isTextContent( node ) {
+	const tag = node.nodeName.toLowerCase();
+	return textContentSchema.hasOwnProperty( tag ) || tag === 'span';
 }

--- a/packages/blocks/src/api/raw-handling/test/figure-content-reducer.js
+++ b/packages/blocks/src/api/raw-handling/test/figure-content-reducer.js
@@ -18,23 +18,69 @@ describe( 'figureContentReducer', () => {
 		},
 	};
 
-	it( 'should move embedded content from paragraph', () => {
-		const input = '<p><strong>test<img class="one"></strong><img class="two"></p>';
-		const output = '<figure><img class="one"></figure><figure><img class="two"></figure><p><strong>test</strong></p>';
+	it( 'should wrap image in figure', () => {
+		const input = '<img>';
+		const output = '<figure><img></figure>';
 
 		expect( deepFilterHTML( input, [ figureContentReducer ], schema ) ).toEqual( output );
 	} );
 
-	it( 'should move an anchor with just an image from paragraph', () => {
-		const input = '<p><a href="#"><img class="one"></a><strong>test</strong></p>';
-		const output = '<figure><a href="#"><img class="one"></a></figure><p><strong>test</strong></p>';
+	it( 'should move lone embedded content from paragraph', () => {
+		const input = '<p><img></p>';
+		const output = '<figure><img></figure><p></p>';
 
 		expect( deepFilterHTML( input, [ figureContentReducer ], schema ) ).toEqual( output );
 	} );
 
-	it( 'should move multiple images', () => {
-		const input = '<p><a href="#"><img class="one"></a><img class="two"><strong>test</strong></p>';
-		const output = '<figure><a href="#"><img class="one"></a></figure><figure><img class="two"></figure><p><strong>test</strong></p>';
+	it( 'should move multiple lone embedded content from paragraph', () => {
+		const input = '<p><img><img></p>';
+		const output = '<figure><img></figure><figure><img></figure><p></p>';
+
+		expect( deepFilterHTML( input, [ figureContentReducer ], schema ) ).toEqual( output );
+	} );
+
+	it( 'should move aligned embedded content from paragraph (1)', () => {
+		const input = '<p><img class="alignright">test</p>';
+		const output = '<figure><img class="alignright"></figure><p>test</p>';
+
+		expect( deepFilterHTML( input, [ figureContentReducer ], schema ) ).toEqual( output );
+	} );
+
+	it( 'should move aligned embedded content from paragraph (2)', () => {
+		const input = '<p>test<img class="alignright"></p>';
+		const output = '<figure><img class="alignright"></figure><p>test</p>';
+
+		expect( deepFilterHTML( input, [ figureContentReducer ], schema ) ).toEqual( output );
+	} );
+
+	it( 'should move aligned embedded content from paragraph (3)', () => {
+		const input = '<p>test<img class="alignright">test</p>';
+		const output = '<figure><img class="alignright"></figure><p>testtest</p>';
+
+		expect( deepFilterHTML( input, [ figureContentReducer ], schema ) ).toEqual( output );
+	} );
+
+	it( 'should not move embedded content from paragraph (1)', () => {
+		const input = '<p><img>test</p>';
+
+		expect( deepFilterHTML( input, [ figureContentReducer ], schema ) ).toEqual( input );
+	} );
+
+	it( 'should not move embedded content from paragraph (2)', () => {
+		const input = '<p>test<img></p>';
+
+		expect( deepFilterHTML( input, [ figureContentReducer ], schema ) ).toEqual( input );
+	} );
+
+	it( 'should not move embedded content from paragraph (3)', () => {
+		const input = '<p>test<img>test</p>';
+
+		expect( deepFilterHTML( input, [ figureContentReducer ], schema ) ).toEqual( input );
+	} );
+
+	it( 'should move an anchor with an image', () => {
+		const input = '<p><a href="#"><img class="alignleft"></a>test</p>';
+		const output = '<figure><a href="#"><img class="alignleft"></a></figure><p>test</p>';
 
 		expect( deepFilterHTML( input, [ figureContentReducer ], schema ) ).toEqual( output );
 	} );

--- a/test/integration/fixtures/wordpress-in.html
+++ b/test/integration/fixtures/wordpress-in.html
@@ -4,3 +4,6 @@
 <p><!--more--></p>
 <h3>Shortcode</h3>
 <p>[gallery ids="1"]</p>
+<p><img class="alignnone wp-image-5114" src="block.png" alt="" /></p>
+<p><img class="alignright wp-image-5114" src="aligned.png" alt="" /> test</p>
+<p><img class="alignnone wp-image-5114" src="not-aligned.png" alt="" /> test</p>

--- a/test/integration/fixtures/wordpress-out.html
+++ b/test/integration/fixtures/wordpress-out.html
@@ -21,3 +21,19 @@
 <!-- wp:gallery {"ids":[1],"columns":3,"linkTo":"attachment"} -->
 <figure class="wp-block-gallery columns-3 is-cropped"><ul class="blocks-gallery-grid"><li class="blocks-gallery-item"><figure><img data-id="1" class="wp-image-1"/></figure></li></ul></figure>
 <!-- /wp:gallery -->
+
+<!-- wp:image {"id":5114} -->
+<figure class="wp-block-image"><img src="block.png" alt="" class="wp-image-5114"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:image {"align":"right","id":5114} -->
+<div class="wp-block-image"><figure class="alignright"><img src="aligned.png" alt="" class="wp-image-5114"/></figure></div>
+<!-- /wp:image -->
+
+<!-- wp:paragraph -->
+<p>test</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p><img src="not-aligned.png" alt=""> test</p>
+<!-- /wp:paragraph -->


### PR DESCRIPTION
## Description

Fixes #4859.

Currently, on paste or raw-to-block conversion, images (and any other figure content) are extracted from its context and placed in the root. This behaviour is obviously not the best. The reason for this was that aligned images are often nested in a paragraph but _appear_ to be a block (as we want it in Gutenberg). The solution is to only extract aligned images and leave the rest alone.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
