### PR TITLE
Docs: Add Developer Tools setup in Getting Started

### DIFF
--- a/docs/contributors/getting-started.md
+++ b/docs/contributors/getting-started.md
@@ -114,8 +114,8 @@ To use Prettier, you should install the **Prettier - Code formatter** extension 
 },
 ```
 
-This will use the `.prettierrc` file. To test it out prior to PR #18048 being merged, you should:
+This will use the `.prettierrc.js` file in the root folder of the Gutenberg repository and the version of Prettier that is installed in the root `node_modules` folder. To test it out prior to PR #18048 being merged, you should:
 
 1. git switch add/prettier
-2. npm install
+2. npm ci
 3. Edit a JavaScript file and on save it will format it as defined

--- a/docs/contributors/getting-started.md
+++ b/docs/contributors/getting-started.md
@@ -99,7 +99,7 @@ You can also test Storybook for the current `master` branch on GitHub Pages: [ht
 
 ## Developer Tools
 
-It is recommended to configure your editor to automatically check for syntax, and lint errors. This will help you save time as you develop to fix minor formating styles. Here are some directions for setting up Visual Studio Code, a popular editor used by many of the core developers.
+We recommend configuring your editor to automatically check for syntax and lint errors. This will help you save time as you develop by automatically fixing minor formatting issues. Here are some directions for setting up Visual Studio Code, a popular editor used by many of the core developers.
 
 [EditorConfig](https://editorconfig.org/) defines a standard configuration for setting up your editor, for example uses tabs instead of spaces. You should install the **EditorConfig for VS Code** extension and it will automatically configure your editor to match the rules defined in [.editorconfig](https://github.com/WordPress/gutenberg/blob/master/.editorconfig).
 

--- a/docs/contributors/getting-started.md
+++ b/docs/contributors/getting-started.md
@@ -99,13 +99,29 @@ You can also test Storybook for the current `master` branch on GitHub Pages: [ht
 
 ## Developer Tools
 
-We recommend configuring your editor to automatically check for syntax and lint errors. This will help you save time as you develop by automatically fixing minor formatting issues. Here are some directions for setting up Visual Studio Code, a popular editor used by many of the core developers.
+We recommend configuring your editor to automatically check for syntax and lint errors. This will help you save time as you develop by automatically fixing minor formatting issues. Here are some directions for setting up Visual Studio Code, a popular editor used by many of the core developers, these tools are also available for other editors.
 
-[EditorConfig](https://editorconfig.org/) defines a standard configuration for setting up your editor, for example uses tabs instead of spaces. You should install the **EditorConfig for VS Code** extension and it will automatically configure your editor to match the rules defined in [.editorconfig](https://github.com/WordPress/gutenberg/blob/master/.editorconfig).
+### EditorConfig
 
-[Prettier](https://prettier.io/) is a tool that allows you to define an opinionated format, and automate fixing the code to match that format. Work is underway to use Prettier within Gutenberg, see [PR #18048](https://github.com/WordPress/gutenberg/pull/18048).
+[EditorConfig](https://editorconfig.org/) defines a standard configuration for setting up your editor, for example using tabs instead of spaces. You should install the [EditorConfig for VS Code](https://marketplace.visualstudio.com/items?itemName=editorconfig.editorconfig) extension and it will automatically configure your editor to match the rules defined in [.editorconfig](https://github.com/WordPress/gutenberg/blob/master/.editorconfig).
 
-To use Prettier, you should install the **Prettier - Code formatter** extension in Visual Studio Code. You can then configure it to be the default formatter and to automatically fix issues on save, by adding the following to your settings.
+### ESLint
+
+[ESLint](https://eslint.org/) statically analyzes the code to find problems. The lint rules are integrated in the continuous integration process and must pass to be able to commit. You should install the [ESLint Extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) for Visual Studio Code, see eslint docs for [more editor integrations](https://eslint.org/docs/user-guide/integrations).
+
+With the extension installed, ESLint will use the [.eslintrc.js](https://github.com/WordPress/gutenberg/blob/master/.eslintrc.js) file in the root of the Gutenberg repository for formatting rules. It will highlight issues as you develop, you can also set the following preference to fix lint rules on save.
+
+```json
+    "editor.codeActionsOnSave": {
+        "source.fixAll.eslint": true
+    },
+```
+
+### Prettier
+
+[Prettier](https://prettier.io/) is a tool that allows you to define an opinionated format, and automate fixing the code to match that format. Prettier and ESlint are similar, Prettier is more about formatting and style, while ESlint is for detecting coding errors.
+
+To use Prettier, you should install the [Prettier - Code formatter extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) in Visual Studio Code. You can then configure it to be the default formatter and to automatically fix issues on save, by adding the following to your settings.
 
 ```json
 "[javascript]": {
@@ -119,3 +135,7 @@ This will use the `.prettierrc.js` file in the root folder of the Gutenberg repo
 1. git switch add/prettier
 2. npm ci
 3. Edit a JavaScript file and on save it will format it as defined
+
+### TypeScript
+
+**TypeScript** is a typed superset of JavaScript language. The Gutenberg project uses TypeScript via JSDoc to [type check JavaScript files](https://www.typescriptlang.org/docs/handbook/type-checking-javascript-files.html). If you use Visual Studio Code, TypeScript support is built-in, otherwise see [TypeScript Editor Support](https://github.com/Microsoft/TypeScript/wiki/TypeScript-Editor-Support) for editor integrations.

--- a/docs/contributors/getting-started.md
+++ b/docs/contributors/getting-started.md
@@ -96,3 +96,26 @@ You can launch Storybook by running `npm run storybook:dev` locally. It will ope
 You can also test Storybook for the current `master` branch on GitHub Pages: [https://wordpress.github.io/gutenberg/](https://wordpress.github.io/gutenberg/)
 
 [Storybook]: https://storybook.js.org/
+
+## Developer Tools
+
+It is recommended to configure your editor to automatically check for syntax, and lint errors. This will help you save time as you develop to fix minor formating styles. Here are some directions for setting up Visual Studio Code, a popular editor used by many of the core developers.
+
+[EditorConfig](https://editorconfig.org/) defines a standard configuration for setting up your editor, for example uses tabs instead of spaces. You should install the **EditorConfig for VS Code** extension and it will automatically configure your editor to match the rules defined in [.editorconfig](https://github.com/WordPress/gutenberg/blob/master/.editorconfig).
+
+[Prettier](https://prettier.io/) is a tool that allows you to define an opinionated format, and automate fixing the code to match that format. Work is underway to use Prettier within Gutenberg, see [PR #18048](https://github.com/WordPress/gutenberg/pull/18048).
+
+To use Prettier, you should install the **Prettier - Code formatter** extension in Visual Studio Code. You can then configure it to be the default formatter and to automatically fix issues on save, by adding the following to your settings.
+
+```json
+"[javascript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true
+},
+```
+
+This will use the `.prettierrc` file. To test it out prior to PR #18048 being merged, you should:
+
+1. git switch add/prettier
+2. npm install
+3. Edit a JavaScript file and on save it will format it as defined

--- a/docs/contributors/testing-overview.md
+++ b/docs/contributors/testing-overview.md
@@ -29,10 +29,7 @@ npm test
 
 Linting is static code analysis used to enforce coding standards and to avoid potential errors. This project uses [ESLint](http://eslint.org/) and [TypeScript's JavaScript type-checking](https://www.typescriptlang.org/docs/handbook/type-checking-javascript-files.html) to capture these issues. While the above `npm test` will execute both unit tests and code linting, code linting can be verified independently by running `npm run lint`. Some issues can be fixed automatically by running `npm run lint:fix`.
 
-To improve your developer workflow, you're encouraged to install an editor linting integration.
-
-- [ESLint Editor Integrations](https://eslint.org/docs/user-guide/integrations)
-- [TypeScript Editor Support](https://github.com/Microsoft/TypeScript/wiki/TypeScript-Editor-Support)
+To improve your developer workflow, you should setup an editor linting integration. See the [getting started documentation](/docs/contributors/getting-started.md) for additional information.
 
 To run unit tests only, without the linter, use `npm run test-unit` instead.
 


### PR DESCRIPTION
## Description

Adds a new section for Developer Tools for setting up an editor to the Getting Started page in the Contributors Handbook. The section recommends setting up EditorConfig and Prettier extensions.

This can precede the Prettier PR #18048 to help people get setup prior, wording will just need to be updated after that release to remove references to the PR in the doc.

## How has this been tested?

Follow directions on documentation page, [found on branch here](https://github.com/WordPress/gutenberg/blob/add/doc-prettier/docs/contributors/getting-started.md)

## Types of changes

Developer docs.

