### PR TITLE
Block API: Pasting content that results in a new block shouldn't be treated as inline content.

### DIFF
--- a/docs/designers-developers/developers/block-api/block-registration.md
+++ b/docs/designers-developers/developers/block-api/block-registration.md
@@ -654,3 +654,12 @@ By default all blocks can be converted to a reusable block. If supports reusable
 reusable: false,
 ```
 
+- `pasteTextInline` (default `false`): If a single line of text is pasted into the block editor, resulting
+in this block being created, setting `pasteTextInline` to `true` will instead extract the text content of
+what is being pasted, and insert that into the currently selected block, instead.
+
+```js
+// Allow the block to be replaced by inline text when a single line of text is pasted.
+pasteTextInline: true,
+```
+

--- a/docs/designers-developers/developers/block-api/block-registration.md
+++ b/docs/designers-developers/developers/block-api/block-registration.md
@@ -653,13 +653,3 @@ By default all blocks can be converted to a reusable block. If supports reusable
 // Don't allow the block to be converted into a reusable block.
 reusable: false,
 ```
-
-- `pasteTextInline` (default `false`): If a single line of text is pasted into the block editor, resulting
-in this block being created, setting `pasteTextInline` to `true` will instead extract the text content of
-what is being pasted, and insert that into the currently selected block, instead.
-
-```js
-// Allow the block to be replaced by inline text when a single line of text is pasted.
-pasteTextInline: true,
-```
-

--- a/packages/block-library/src/heading/index.js
+++ b/packages/block-library/src/heading/index.js
@@ -24,7 +24,7 @@ export const settings = {
 	supports: {
 		className: false,
 		anchor: true,
-		pasteTextInline: true,
+		__unstablePasteTextInline: true,
 	},
 	example: {
 		attributes: {

--- a/packages/block-library/src/heading/index.js
+++ b/packages/block-library/src/heading/index.js
@@ -24,6 +24,7 @@ export const settings = {
 	supports: {
 		className: false,
 		anchor: true,
+		pasteTextInline: true,
 	},
 	example: {
 		attributes: {

--- a/packages/block-library/src/list/index.js
+++ b/packages/block-library/src/list/index.js
@@ -23,7 +23,7 @@ export const settings = {
 	keywords: [ __( 'bullet list' ), __( 'ordered list' ), __( 'numbered list' ) ],
 	supports: {
 		className: false,
-		pasteTextInline: true,
+		__unstablePasteTextInline: true,
 	},
 	example: {
 		attributes: {

--- a/packages/block-library/src/list/index.js
+++ b/packages/block-library/src/list/index.js
@@ -23,6 +23,7 @@ export const settings = {
 	keywords: [ __( 'bullet list' ), __( 'ordered list' ), __( 'numbered list' ) ],
 	supports: {
 		className: false,
+		pasteTextInline: true,
 	},
 	example: {
 		attributes: {

--- a/packages/block-library/src/paragraph/index.js
+++ b/packages/block-library/src/paragraph/index.js
@@ -31,6 +31,7 @@ export const settings = {
 	},
 	supports: {
 		className: false,
+		pasteTextInline: true,
 	},
 	transforms,
 	deprecated,

--- a/packages/block-library/src/paragraph/index.js
+++ b/packages/block-library/src/paragraph/index.js
@@ -31,7 +31,7 @@ export const settings = {
 	},
 	supports: {
 		className: false,
-		pasteTextInline: true,
+		__unstablePasteTextInline: true,
 	},
 	transforms,
 	deprecated,

--- a/packages/blocks/src/api/raw-handling/paste-handler.js
+++ b/packages/blocks/src/api/raw-handling/paste-handler.js
@@ -244,10 +244,10 @@ export function pasteHandler( { HTML = '', plainText = '', mode = 'AUTO', tagNam
 		return htmlToBlocks( { html: piece, rawTransforms } );
 	} ) );
 
-	// If we're allowed to return inline content and there is only one block
+	// If we're allowed to return inline content, and there is only one paragraph block,
 	// and the original plain text content does not have any line breaks, then
 	// treat it as inline paste.
-	if ( mode === 'AUTO' && blocks.length === 1 ) {
+	if ( mode === 'AUTO' && blocks.length === 1 && blocks[ 0 ].name === 'core/paragraph' ) {
 		const trimmedPlainText = plainText.trim();
 
 		if ( trimmedPlainText !== '' && trimmedPlainText.indexOf( '\n' ) === -1 ) {

--- a/packages/blocks/src/api/raw-handling/paste-handler.js
+++ b/packages/blocks/src/api/raw-handling/paste-handler.js
@@ -7,6 +7,7 @@ import { flatMap, filter, compact } from 'lodash';
  * Internal dependencies
  */
 import { createBlock, getBlockTransforms, findTransform } from '../factory';
+import { hasBlockSupport } from '../registration';
 import { getBlockContent } from '../serializer';
 import { getBlockAttributes, parseWithGrammar } from '../parser';
 import normaliseBlocks from './normalise-blocks';
@@ -244,17 +245,10 @@ export function pasteHandler( { HTML = '', plainText = '', mode = 'AUTO', tagNam
 		return htmlToBlocks( { html: piece, rawTransforms } );
 	} ) );
 
-	// If `blocks` contains a single entry of one of these blocks,
-	// it can potentially be treated as an inline paste.
-	const inlineableBlocks = [
-		'core/paragraph',
-		'core/list',
-	];
-
 	// If we're allowed to return inline content, and there is only one inlineable block,
 	// and the original plain text content does not have any line breaks, then
 	// treat it as inline paste.
-	if ( mode === 'AUTO' && blocks.length === 1 && inlineableBlocks.includes( blocks[ 0 ].name ) ) {
+	if ( mode === 'AUTO' && blocks.length === 1 && hasBlockSupport( blocks[ 0 ].name, 'pasteTextInline', false ) ) {
 		const trimmedPlainText = plainText.trim();
 
 		if ( trimmedPlainText !== '' && trimmedPlainText.indexOf( '\n' ) === -1 ) {

--- a/packages/blocks/src/api/raw-handling/paste-handler.js
+++ b/packages/blocks/src/api/raw-handling/paste-handler.js
@@ -248,7 +248,11 @@ export function pasteHandler( { HTML = '', plainText = '', mode = 'AUTO', tagNam
 	// If we're allowed to return inline content, and there is only one inlineable block,
 	// and the original plain text content does not have any line breaks, then
 	// treat it as inline paste.
-	if ( mode === 'AUTO' && blocks.length === 1 && hasBlockSupport( blocks[ 0 ].name, 'pasteTextInline', false ) ) {
+	if (
+		mode === 'AUTO' &&
+		blocks.length === 1 &&
+		hasBlockSupport( blocks[ 0 ].name, '__unstablePasteTextInline', false )
+	) {
 		const trimmedPlainText = plainText.trim();
 
 		if ( trimmedPlainText !== '' && trimmedPlainText.indexOf( '\n' ) === -1 ) {

--- a/packages/blocks/src/api/raw-handling/paste-handler.js
+++ b/packages/blocks/src/api/raw-handling/paste-handler.js
@@ -244,10 +244,17 @@ export function pasteHandler( { HTML = '', plainText = '', mode = 'AUTO', tagNam
 		return htmlToBlocks( { html: piece, rawTransforms } );
 	} ) );
 
-	// If we're allowed to return inline content, and there is only one paragraph block,
+	// If `blocks` contains a single entry of one of these blocks,
+	// it can potentially be treated as an inline paste.
+	const inlineableBlocks = [
+		'core/paragraph',
+		'core/list',
+	];
+
+	// If we're allowed to return inline content, and there is only one inlineable block,
 	// and the original plain text content does not have any line breaks, then
 	// treat it as inline paste.
-	if ( mode === 'AUTO' && blocks.length === 1 && blocks[ 0 ].name === 'core/paragraph' ) {
+	if ( mode === 'AUTO' && blocks.length === 1 && inlineableBlocks.includes( blocks[ 0 ].name ) ) {
 		const trimmedPlainText = plainText.trim();
 
 		if ( trimmedPlainText !== '' && trimmedPlainText.indexOf( '\n' ) === -1 ) {

--- a/test/integration/blocks-raw-handling.test.js
+++ b/test/integration/blocks-raw-handling.test.js
@@ -8,6 +8,7 @@ import path from 'path';
  * WordPress dependencies
  */
 import {
+	createBlock,
 	getBlockContent,
 	pasteHandler,
 	rawHandler,
@@ -52,6 +53,30 @@ describe( 'Blocks raw handling', () => {
 							},
 						},
 						priority: 9,
+					},
+				],
+			},
+			save: () => null,
+		} );
+
+		registerBlockType( 'test/non-inline-block', {
+			title: 'Test Non Inline Block',
+			category: 'common',
+			supports: {
+				pasteTextInline: false,
+			},
+			transforms: {
+				from: [
+					{
+						type: 'raw',
+						isMatch: ( node ) => {
+							return 'words to live by' === node.textContent.trim();
+						},
+						transform: () => {
+							return createBlock( 'core-embed/youtube', {
+								url: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+							} );
+						},
 					},
 				],
 			},
@@ -150,6 +175,29 @@ describe( 'Blocks raw handling', () => {
 		} );
 
 		expect( filtered ).toBe( 'schön' );
+		expect( console ).toHaveLogged();
+	} );
+
+	it( 'should not treat single non-inlineable block as inline text', () => {
+		const filtered = pasteHandler( {
+			HTML: '<p>words to live by</p>',
+			plainText: 'words to live by\n',
+			mode: 'AUTO',
+		} );
+
+		expect( filtered ).toHaveLength( 1 );
+		expect( filtered[ 0 ].name ).toBe( 'core-embed/youtube' );
+		expect( console ).toHaveLogged();
+	} );
+
+	it( 'should treat single heading as inline text', () => {
+		const filtered = pasteHandler( {
+			HTML: '<h1>FOO</h1>',
+			plainText: 'FOO\n',
+			mode: 'AUTO',
+		} );
+
+		expect( filtered ).toBe( 'FOO' );
 		expect( console ).toHaveLogged();
 	} );
 


### PR DESCRIPTION
## Description

When pasting text, the paste handler currently assumes that if the text doesn't have a line break, and it results in one block, it can be treated as inline text, instead.

This may be correct for core, but is not necessarily correct for plugins that may wish to transform a single line of text into a custom block.

This PR tightens the paste handler assumption to only allow a selection of blocks to be treated as an inline paste.

Fixes #18390.

## How has this been tested?

Tested with the sample plugin in #18390.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows the accessibility standards.
- [x] My code has proper inline documentation.
- [x] I've included developer documentation if appropriate.
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR.