### PR TITLE
Block API: Allow block transforms to handle iframes for non-admin users.

### DIFF
--- a/packages/blocks/src/api/raw-handling/paste-handler.js
+++ b/packages/blocks/src/api/raw-handling/paste-handler.js
@@ -240,15 +240,17 @@ export function pasteHandler( { HTML = '', plainText = '', mode = 'AUTO', tagNam
 		const pieceBlocks = htmlToBlocks( { html: piece, rawTransforms } );
 
 		if ( ! canUserUseUnfilteredHTML ) {
-			// Should run before `figureContentReducer`.
-			filters.unshift( iframeRemover );
+			const iframeFilters = [
+				iframeRemover,
+				figureContentReducer,
+			];
 
 			return compact( map( pieceBlocks, ( pieceBlock ) => {
 				if ( pieceBlock.name !== 'core/html' ) {
 					return pieceBlock;
 				}
 
-				pieceBlock.attributes.content = deepFilterHTML( pieceBlock.attributes.content, filters, blockContentSchema );
+				pieceBlock.attributes.content = deepFilterHTML( pieceBlock.attributes.content, iframeFilters, blockContentSchema );
 				pieceBlock.attributes.content = removeInvalidHTML( pieceBlock.attributes.content, schema );
 
 				if ( ! pieceBlock.attributes.content ) {

--- a/test/integration/blocks-raw-handling.test.js
+++ b/test/integration/blocks-raw-handling.test.js
@@ -25,7 +25,6 @@ describe( 'Blocks raw handling', () => {
 	beforeAll( () => {
 		// Load all hooks that modify blocks
 		require( '../../packages/editor/src/hooks' );
-		registerCoreBlocks();
 		registerBlockType( 'test/gallery', {
 			title: 'Test Gallery',
 			category: 'common',
@@ -82,6 +81,28 @@ describe( 'Blocks raw handling', () => {
 			},
 			save: () => null,
 		} );
+
+		registerBlockType( 'test/iframe-handler', {
+			title: 'Test iframe Handler',
+			category: 'common',
+			transforms: {
+				from: [
+					{
+						type: 'raw',
+						isMatch: ( node ) => {
+							return node.nodeName === 'FIGURE' &&
+								node.innerHTML === '<iframe src="https://wordpress.org/"></iframe>';
+						},
+						transform: () => {
+							return "you can't iframe wordpress.org";
+						},
+					},
+				],
+			},
+			save: () => null,
+		} );
+
+		registerCoreBlocks();
 	} );
 
 	it( 'should filter inline content', () => {
@@ -308,6 +329,16 @@ describe( 'Blocks raw handling', () => {
 			plainText: block,
 			mode: 'AUTO',
 		} ) ) ).toBe( block );
+	} );
+
+	it( 'should allow iframes to be transformed', () => {
+		const filtered = pasteHandler( {
+			HTML: '<iframe src="https://wordpress.org/"></iframe>\n<br>',
+			mode: 'AUTO',
+		} ).join( '' );
+
+		expect( filtered ).toBe( "you can't iframe wordpress.org" );
+		expect( console ).toHaveLogged();
 	} );
 
 	describe( 'pasteHandler', () => {


### PR DESCRIPTION
## Description

Fixes #18389.

In the event that a block has a `raw` transform which turns an iframe into a block, it isn't able to do so for non-admin users, since the iframe is stripped from the content before `htmlToBlocks()` is run in `pasteHandler()`.

This PR allows `htmlToBlocks()` to run before stripping any iframes that weren't handled by block transforms.

## How has this been tested?

Testing in conjunction with #19084 and Automattic/jetpack#13999, Google Calendar iframes are transformed into Google Calendar blocks.

Alternatively, this can be tested with the routine described in #18389.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows the accessibility standards.
- [x] My code has proper inline documentation.
- [x] I've included developer documentation if appropriate.
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR.