### PR TITLE
Multi-select: Polish further, move closer to previous selection style.

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -176,38 +176,15 @@
  */
 
 .block-editor-block-list__layout {
-
-	// The primary indicator of selection is the native selection marker.
-	// To indicate multiple blocks, we provide an additional selection indicator.
+	// Inside a text block, the primary indicator of selection is the native selection marker.
+	// To indicate multiple blocks, we paint a similar background.
 	.block-editor-block-list__block.is-multi-selected {
-
 		> .block-editor-block-list__block-edit::before {
-			border-left-color: $dark-opacity-light-800;
-			box-shadow: inset $block-left-border-width 0 0 0 $dark-gray-500;
-
-			.is-dark-theme & {
-				border-left-color: $light-opacity-light-800;
-				box-shadow: inset $block-left-border-width 0 0 0 $light-gray-600;
-			}
-
-			// Switch to outset borders on larger screens.
-			@include break-small() {
-				box-shadow: -$block-left-border-width 0 0 0 $dark-gray-500;
-
-				.is-dark-theme & {
-					box-shadow: -$block-left-border-width 0 0 0 $light-gray-600;
-				}
-			}
+			background: rgba(#157af1, 0.4); // This color is averaged between Windows and MacOS default selection colors to feel "at home" on both.
+			mix-blend-mode: multiply;
 		}
-	}
 
-	// The additional marker, we limit only to top level blocks.
-	.block-editor-block-list__block.is-multi-selected .block-editor-block-list__block.is-multi-selected > .block-editor-block-list__block-edit::before {
-		box-shadow: none;
-	}
-
-	// Provide exceptions for placeholders.
-	.components-placeholder {
+		// When multiple blocks are selected, hide the native selection marker.
 		::selection {
 			background: transparent;
 		}


### PR DESCRIPTION
The new native selection style is much faster and an important step on the path to various writing-flow improvements. However until we can get closer to those improvements, in the mean time selecting multiple blocks is currently slightly less clear than it was prior to the native selection change.

In https://github.com/WordPress/gutenberg/pull/18867 I tried to mitigate this, and it includes some mockups for how to improve the style longer term, with more thoughts being discussed in #18667.

But until that gets hashed out more clearly, perhaps we should rewind the visual style slightly, to be closer to what was, while still keeping the technical benefits of the native selection PR. This PR keeps those changes, but tweaks the visual style.

What it does is remove the left border style, and re-paints a cross-block background. But this time with a color that is closer to the default selection color on Windows and MacOS. Specifically, both those defaults are eye-dropped and averaged to create a new color that looks decently at home on both.

![averaged default colors](https://user-images.githubusercontent.com/1204802/70696049-3153d700-1cc3-11ea-90fe-0068b642999f.gif)

![select-color](https://user-images.githubusercontent.com/1204802/70696071-3d3f9900-1cc3-11ea-80d0-e4c1ee265361.png)

_Note that Windows 10 by default also changes the font-color to be white on the blue background. But the hue of the color is close to both, so the color shares DNA._

It is possible users can customize this select color, meaning the color of the selection marker inside text will diverge from that of multi-block selections. But this is unfortunately not something we can address. But the averaged color feels like a pretty good interim step towards a selection model that is perhaps closer to that of Figma, painting borders around each block instead of re-coloring the background.