### PR TITLE
Is Shallow Equal: Add types

### DIFF
--- a/packages/is-shallow-equal/arrays.js
+++ b/packages/is-shallow-equal/arrays.js
@@ -3,8 +3,8 @@
 /**
  * Returns true if the two arrays are shallow equal, or false otherwise.
  *
- * @param {Array} a First array to compare.
- * @param {Array} b Second array to compare.
+ * @param {any[]} a First array to compare.
+ * @param {any[]} b Second array to compare.
  *
  * @return {boolean} Whether the two arrays are shallow equal.
  */

--- a/packages/is-shallow-equal/index.js
+++ b/packages/is-shallow-equal/index.js
@@ -9,11 +9,15 @@ var isShallowEqualArrays = require( './arrays' );
 var isArray = Array.isArray;
 
 /**
+ * @typedef {{[key: string]: any}} ComparableObject
+ */
+
+/**
  * Returns true if the two arrays or objects are shallow equal, or false
  * otherwise.
  *
- * @param {(Array|Object)} a First object or array to compare.
- * @param {(Array|Object)} b Second object or array to compare.
+ * @param {any[]|ComparableObject} a First object or array to compare.
+ * @param {any[]|ComparableObject} b Second object or array to compare.
  *
  * @return {boolean} Whether the two values are shallow equal.
  */

--- a/packages/is-shallow-equal/objects.js
+++ b/packages/is-shallow-equal/objects.js
@@ -5,8 +5,8 @@ var keys = Object.keys;
 /**
  * Returns true if the two objects are shallow equal, or false otherwise.
  *
- * @param {Object} a First object to compare.
- * @param {Object} b Second object to compare.
+ * @param {import('.').ComparableObject} a First object to compare.
+ * @param {import('.').ComparableObject} b Second object to compare.
  *
  * @return {boolean} Whether the two objects are shallow equal.
  */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,6 +23,7 @@
 	},
 	"include": [
 		"./packages/i18n/**/*.js",
+		"./packages/is-shallow-equal/**/*.js",
 		"./packages/priority-queue/**/*.js",
 		"./packages/token-list/**/*.js",
 		"./packages/url/**/*.js"


### PR DESCRIPTION
## Description

Part of #18838
Extracted from #18942 

Add types to `is-shallow-equal` package.

**Testing Instructions:**

Verify type checking passes:

```
npm run lint-types
```