### PR TITLE
Blob: Add types

### DIFF
--- a/packages/blob/README.md
+++ b/packages/blob/README.md
@@ -38,7 +38,7 @@ _Parameters_
 
 _Returns_
 
--   `?File`: The file for the blob URL.
+-   `(File|undefined)`: The file for the blob URL.
 
 <a name="isBlobURL" href="#isBlobURL">#</a> **isBlobURL**
 

--- a/packages/blob/src/index.js
+++ b/packages/blob/src/index.js
@@ -3,6 +3,9 @@
  */
 const { createObjectURL, revokeObjectURL } = window.URL;
 
+/**
+ * @type {{[key: string]: File|undefined}}
+ */
 const cache = {};
 
 /**
@@ -27,7 +30,7 @@ export function createBlobURL( file ) {
  *
  * @param {string} url The blob URL.
  *
- * @return {?File} The file for the blob URL.
+ * @return {File|undefined} The file for the blob URL.
  */
 export function getBlobByURL( url ) {
 	return cache[ url ];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,7 @@
 		"noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
 	},
 	"include": [
+		"./packages/blob/**/*.js",
 		"./packages/dom-ready/**/*.js",
 		"./packages/i18n/**/*.js",
 		"./packages/is-shallow-equal/**/*.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
 
 		/* Strict Type-Checking Options */
 		"strict": true,                        /* Enable all strict type-checking options. */
+		"strictNullChecks": true,
 		"noImplicitAny": false,                /* Raise error on expressions and declarations with an implied 'any' type. */
 
 		/* Additional Checks */


### PR DESCRIPTION
## Description

Part of #18838
Extracted from #18942 

Add types to `blob` package.

**Testing Instructions:**

Verify type checking passes:

```
npm run lint-types
```