### PR TITLE
Convert to blocks: preserve alignment

### DIFF
--- a/packages/block-library/src/heading/transforms.js
+++ b/packages/block-library/src/heading/transforms.js
@@ -10,6 +10,7 @@ import {
  * Internal dependencies
  */
 import { getLevelFromHeadingNodeName } from './shared';
+import { name } from './block.json';
 
 const transforms = {
 	from: [
@@ -17,7 +18,7 @@ const transforms = {
 			type: 'block',
 			blocks: [ 'core/paragraph' ],
 			transform: ( { content } ) => {
-				return createBlock( 'core/heading', {
+				return createBlock( name, {
 					content,
 				} );
 			},
@@ -25,29 +26,42 @@ const transforms = {
 		{
 			type: 'raw',
 			selector: 'h1,h2,h3,h4,h5,h6',
-			schema: ( { phrasingContentSchema } ) => ( {
-				h1: { children: phrasingContentSchema },
-				h2: { children: phrasingContentSchema },
-				h3: { children: phrasingContentSchema },
-				h4: { children: phrasingContentSchema },
-				h5: { children: phrasingContentSchema },
-				h6: { children: phrasingContentSchema },
-			} ),
+			schema: ( { phrasingContentSchema, isPaste } ) => {
+				const schema = {
+					children: phrasingContentSchema,
+					attributes: isPaste ? [] : [ 'style' ],
+				};
+				return {
+					h1: schema,
+					h2: schema,
+					h3: schema,
+					h4: schema,
+					h5: schema,
+					h6: schema,
+				};
+			},
 			transform( node ) {
-				return createBlock( 'core/heading', {
-					...getBlockAttributes(
-						'core/heading',
-						node.outerHTML
-					),
-					level: getLevelFromHeadingNodeName( node.nodeName ),
-				} );
+				const attributes = getBlockAttributes( name, node.outerHTML );
+				const { textAlign } = node.style;
+
+				attributes.level = getLevelFromHeadingNodeName( node.nodeName );
+
+				if (
+					textAlign === 'left' ||
+					textAlign === 'center' ||
+					textAlign === 'right'
+				) {
+					attributes.align = textAlign;
+				}
+
+				return createBlock( name, attributes );
 			},
 		},
 		...[ 2, 3, 4, 5, 6 ].map( ( level ) => ( {
 			type: 'prefix',
 			prefix: Array( level + 1 ).join( '#' ),
 			transform( content ) {
-				return createBlock( 'core/heading', {
+				return createBlock( name, {
 					level,
 					content,
 				} );

--- a/packages/block-library/src/paragraph/transforms.js
+++ b/packages/block-library/src/paragraph/transforms.js
@@ -1,3 +1,13 @@
+/**
+ * WordPress dependencies
+ */
+import { createBlock, getBlockAttributes } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import { name } from './block.json';
+
 const transforms = {
 	from: [
 		{
@@ -5,11 +15,26 @@ const transforms = {
 			// Paragraph is a fallback and should be matched last.
 			priority: 20,
 			selector: 'p',
-			schema: ( { phrasingContentSchema } ) => ( {
+			schema: ( { phrasingContentSchema, isPaste } ) => ( {
 				p: {
 					children: phrasingContentSchema,
+					attributes: isPaste ? [] : [ 'style' ],
 				},
 			} ),
+			transform( node ) {
+				const attributes = getBlockAttributes( name, node.outerHTML );
+				const align = node.style.textAlign;
+
+				if (
+					align === 'left' ||
+					align === 'center' ||
+					align === 'right'
+				) {
+					return createBlock( name, { ...attributes, align } );
+				}
+
+				return createBlock( name, attributes );
+			},
 		},
 	],
 };

--- a/packages/block-library/src/paragraph/transforms.js
+++ b/packages/block-library/src/paragraph/transforms.js
@@ -23,14 +23,14 @@ const transforms = {
 			} ),
 			transform( node ) {
 				const attributes = getBlockAttributes( name, node.outerHTML );
-				const align = node.style.textAlign;
+				const { textAlign } = node.style;
 
 				if (
-					align === 'left' ||
-					align === 'center' ||
-					align === 'right'
+					textAlign === 'left' ||
+					textAlign === 'center' ||
+					textAlign === 'right'
 				) {
-					return createBlock( name, { ...attributes, align } );
+					attributes.align = textAlign;
 				}
 
 				return createBlock( name, attributes );

--- a/packages/blocks/src/api/raw-handling/paste-handler.js
+++ b/packages/blocks/src/api/raw-handling/paste-handler.js
@@ -197,7 +197,7 @@ export function pasteHandler( { HTML = '', plainText = '', mode = 'AUTO', tagNam
 
 	const rawTransforms = getRawTransformations();
 	const phrasingContentSchema = getPhrasingContentSchema( 'paste' );
-	const blockContentSchema = getBlockContentSchema( rawTransforms, phrasingContentSchema );
+	const blockContentSchema = getBlockContentSchema( rawTransforms, phrasingContentSchema, true );
 
 	const blocks = compact( flatMap( pieces, ( piece ) => {
 		// Already a block from shortcode.

--- a/packages/blocks/src/api/raw-handling/utils.js
+++ b/packages/blocks/src/api/raw-handling/utils.js
@@ -24,7 +24,7 @@ const { ELEMENT_NODE, TEXT_NODE } = window.Node;
  *
  * @param {Array}  transforms            Block transforms, of the `raw` type.
  * @param {Object} phrasingContentSchema The phrasing content schema.
- * @param {Object} isPaste               Whether the conttext is pasting or not.
+ * @param {Object} isPaste               Whether the context is pasting or not.
  *
  * @return {Object} A complete block content schema.
  */

--- a/packages/blocks/src/api/raw-handling/utils.js
+++ b/packages/blocks/src/api/raw-handling/utils.js
@@ -24,14 +24,15 @@ const { ELEMENT_NODE, TEXT_NODE } = window.Node;
  *
  * @param {Array}  transforms            Block transforms, of the `raw` type.
  * @param {Object} phrasingContentSchema The phrasing content schema.
+ * @param {Object} isPaste               Whether the conttext is pasting or not.
  *
  * @return {Object} A complete block content schema.
  */
-export function getBlockContentSchema( transforms, phrasingContentSchema ) {
+export function getBlockContentSchema( transforms, phrasingContentSchema, isPaste ) {
 	const schemas = transforms.map( ( { isMatch, blockName, schema } ) => {
 		const hasAnchorSupport = hasBlockSupport( blockName, 'anchor' );
 
-		schema = isFunction( schema ) ? schema( { phrasingContentSchema } ) : schema;
+		schema = isFunction( schema ) ? schema( { phrasingContentSchema, isPaste } ) : schema;
 
 		// If the block does not has anchor support and the transform does not
 		// provides an isMatch we can return the schema right away.

--- a/test/integration/__snapshots__/blocks-raw-handling.test.js.snap
+++ b/test/integration/__snapshots__/blocks-raw-handling.test.js.snap
@@ -116,3 +116,9 @@ exports[`rawHandler should not strip any text-level elements 1`] = `
 <p>This is <u>ncorect</u></p>
 <!-- /wp:paragraph -->"
 `;
+
+exports[`rawHandler should preserve alignment 1`] = `
+"<!-- wp:paragraph {\\"align\\":\\"center\\"} -->
+<p class=\\"has-text-align-center\\">center</p>
+<!-- /wp:paragraph -->"
+`;

--- a/test/integration/blocks-raw-handling.test.js
+++ b/test/integration/blocks-raw-handling.test.js
@@ -358,4 +358,9 @@ describe( 'rawHandler', () => {
 		const HTML = '<p>This is <u>ncorect</u></p>';
 		expect( serialize( rawHandler( { HTML } ) ) ).toMatchSnapshot();
 	} );
+
+	it( 'should preserve alignment', () => {
+		const HTML = '<p style="text-align:center">center</p>';
+		expect( serialize( rawHandler( { HTML } ) ) ).toMatchSnapshot();
+	} );
 } );


### PR DESCRIPTION
## Description

Fixes #11676. When converting to blocks from legacy content, preserve alignment on paragraphs and headings.

## How has this been tested?

Add a classic block, then add a paragraph and align it. Convert to blocks. Alignment should be preserved.

## Screenshots <!-- if applicable -->

![align](https://user-images.githubusercontent.com/4710635/70703320-22275600-1cd0-11ea-8177-39233b023a40.gif)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
