### PR TITLE
Added 'top-level' to the label of create navigation

### DIFF
--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -129,7 +129,7 @@ function Navigation( {
 							onClick={ handleCreateFromExistingPages }
 							disabled={ ! hasPages }
 						>
-							{ __( 'Create from all top pages' ) }
+							{ __( 'Create from all top-level pages' ) }
 						</Button>
 
 						<Button


### PR DESCRIPTION
## Description
Closes #18522

## How has this been tested?
As @apeatling noticed the button "Create from all top pages" is ambiguous.

## Types of changes
Changed the button to read "Create from all top-level pages" which is consistent to the current naming in WordPress.