### PR TITLE
Navigation: Add background color

### DIFF
--- a/packages/block-editor/src/components/colors/use-colors.js
+++ b/packages/block-editor/src/components/colors/use-colors.js
@@ -51,10 +51,11 @@ const ColorPanel = ( {
 	detectedBackgroundColor,
 	detectedColor,
 	panelChildren,
+	initialOpen,
 } ) => (
 	<PanelColorSettings
 		title={ title }
-		initialOpen={ false }
+		initialOpen={ initialOpen }
 		colorSettings={ Object.values( colorSettings ) }
 		{ ...colorPanelProps }
 	>
@@ -316,6 +317,7 @@ export default function __experimentalUseColors(
 
 		const wrappedColorPanelProps = {
 			title: panelTitle,
+			initialOpen: false,
 			colorSettings,
 			colorPanelProps,
 			contrastCheckers,

--- a/packages/block-library/src/navigation/block-colors-selector.js
+++ b/packages/block-library/src/navigation/block-colors-selector.js
@@ -1,7 +1,3 @@
-/**
- * External dependencies
- */
-import { noop } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -9,7 +5,6 @@ import { noop } from 'lodash';
 import { Button, Dropdown, ToolbarGroup, SVG, Path } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { DOWN } from '@wordpress/keycodes';
-import { ColorPaletteControl } from '@wordpress/block-editor';
 
 const ColorSelectorSVGIcon = () => (
 	<SVG xmlns="https://www.w3.org/2000/svg" viewBox="0 0 20 20">
@@ -23,12 +18,12 @@ const ColorSelectorSVGIcon = () => (
  * @param {Object} colorControlProps colorControl properties.
  * @return {*} React Icon component.
  */
-const ColorSelectorIcon = ( { color } ) => {
+const ColorSelectorIcon = ( { style, className } ) => {
 	return (
 		<div className="block-library-colors-selector__icon-container">
 			<div
-				className="block-library-colors-selector__state-selection"
-				style={ { ...( color && { color } ) } }
+				className={ `${ className } block-library-colors-selector__state-selection` }
+				style={ style }
 			>
 				<ColorSelectorSVGIcon />
 			</div>
@@ -42,7 +37,7 @@ const ColorSelectorIcon = ( { color } ) => {
  * @param {Object} colorControlProps colorControl properties.
  * @return {*} React toggle button component.
  */
-const renderToggleComponent = ( { value } ) => ( { onToggle, isOpen } ) => {
+const renderToggleComponent = ( { TextColor, BackgroundColor } ) => ( { onToggle, isOpen } ) => {
 	const openOnArrowDown = ( event ) => {
 		if ( ! isOpen && event.keyCode === DOWN ) {
 			event.preventDefault();
@@ -58,32 +53,26 @@ const renderToggleComponent = ( { value } ) => ( { onToggle, isOpen } ) => {
 				label={ __( 'Open Colors Selector' ) }
 				onClick={ onToggle }
 				onKeyDown={ openOnArrowDown }
-				icon={ <ColorSelectorIcon color={ value } /> }
+				icon={
+					<BackgroundColor>
+						<TextColor>
+							<ColorSelectorIcon />
+						</TextColor>
+					</BackgroundColor>
+				}
 			/>
 		</ToolbarGroup>
 	);
 };
 
-const renderContent = ( { value, onChange = noop } ) => ( () => {
-	return (
-		<>
-			<div className="color-palette-controller-container">
-				<ColorPaletteControl
-					value={ value }
-					onChange={ onChange }
-					label={ __( 'Text Color' ) }
-				/>
-			</div>
-		</>
-	);
-} );
-
-export default ( colorControlProps ) => (
+const BlockColorsStyleSelector = ( { children, ...other } ) => (
 	<Dropdown
 		position="bottom right"
 		className="block-library-colors-selector"
 		contentClassName="block-library-colors-selector__popover"
-		renderToggle={ renderToggleComponent( colorControlProps ) }
-		renderContent={ renderContent( colorControlProps ) }
+		renderToggle={ renderToggleComponent( other ) }
+		renderContent={ () => children }
 	/>
 );
+
+export default BlockColorsStyleSelector;

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -10,6 +10,7 @@ import classnames from 'classnames';
 import {
 	useMemo,
 	Fragment,
+	useRef,
 } from '@wordpress/element';
 import {
 	InnerBlocks,
@@ -58,9 +59,28 @@ function Navigation( {
 	// HOOKS
 	//
 	/* eslint-disable @wordpress/no-unused-vars-before-return */
-	const { TextColor } = __experimentalUseColors(
-		[ { name: 'textColor', property: 'color' } ],
+	const ref = useRef();
+
+	const {
+		TextColor,
+		BackgroundColor,
+		InspectorControlsColorPanel,
+		ColorPanel,
+	} = __experimentalUseColors(
+		[
+			{ name: 'textColor', property: 'color' },
+			{ name: 'backgroundColor', className: 'background-color' },
+		],
+		{
+			contrastCheckers: [ { backgroundColor: true, textColor: true, fontSize: fontSize.size } ],
+			colorDetector: { targetRef: ref },
+			colorPanelProps: {
+				initialOpen: true,
+			},
+		},
+		[ fontSize.size ]
 	);
+
 	/* eslint-enable @wordpress/no-unused-vars-before-return */
 	const { navigatorToolbarButton, navigatorModal } = useBlockNavigator( clientId );
 
@@ -130,7 +150,10 @@ function Navigation( {
 					label={ __( 'Navigation' ) }
 					instructions={ __( 'Create a Navigation from all existing pages, or create an empty one.' ) }
 				>
-					<div className="wp-block-navigation-placeholder__buttons">
+					<div
+						ref={ ref }
+						className="wp-block-navigation-placeholder__buttons"
+					>
 						<Button
 							isSecondary
 							className="wp-block-navigation-placeholder__button"
@@ -170,11 +193,13 @@ function Navigation( {
 				<ToolbarGroup>
 					{ navigatorToolbarButton }
 				</ToolbarGroup>
-				<BlockColorsStyleSelector
-					value={ TextColor.color }
-					onChange={ TextColor.setColor }
-				/>
 
+				<BlockColorsStyleSelector
+					TextColor={ TextColor }
+					BackgroundColor={ BackgroundColor }
+				>
+					{ ColorPanel }
+				</BlockColorsStyleSelector>
 			</BlockControls>
 			{ navigatorModal }
 			<InspectorControls>
@@ -190,17 +215,24 @@ function Navigation( {
 					/>
 				</PanelBody>
 			</InspectorControls>
+			{ InspectorControlsColorPanel }
 			<TextColor>
-				<div className={ blockClassNames } style={ blockInlineStyles }>
-					{ ! hasExistingNavItems && isRequestingPages && <><Spinner /> { __( 'Loading Navigation…' ) } </> }
+				<BackgroundColor>
+					<div
+						ref={ ref }
+						className={ blockClassNames }
+						style={ blockInlineStyles }
+					>
+						{ ! hasExistingNavItems && isRequestingPages && <><Spinner /> { __( 'Loading Navigation…' ) } </> }
 
-					<InnerBlocks
-						allowedBlocks={ [ 'core/navigation-link' ] }
-						templateInsertUpdatesSelection={ false }
-						__experimentalMoverDirection={ 'horizontal' }
-					/>
+						<InnerBlocks
+							allowedBlocks={ [ 'core/navigation-link' ] }
+							templateInsertUpdatesSelection={ false }
+							__experimentalMoverDirection={ 'horizontal' }
+						/>
 
-				</div>
+					</div>
+				</BackgroundColor>
 			</TextColor>
 		</Fragment>
 	);

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -1,3 +1,6 @@
+$navigation-height: 60px;
+$navigation-item-height: 46px;
+
 // Reduce the paddings, margins, and UI of inner-blocks.
 // @todo: eventually we may add a feature that lets a parent container absorb the block UI of a child block.
 // When that happens, leverage that instead of the following overrides.
@@ -30,10 +33,13 @@
 		width: auto;
 		padding-left: 0;
 		padding-right: 0;
-		margin-left: 0;
-		margin-right: 0;
-		margin-top: 0;
-		margin-bottom: 1em; // Useful for when items wrap.
+		margin: 0;
+	}
+
+	// 3. Set a min height for nav items.
+	// It's needed in order to hide the sub-items when the navigation is not selected.
+	.wp-block-navigation .block-editor-inner-blocks > .block-editor-block-list__layout .wp-block > [data-block] {
+		min-height: $navigation-item-height;
 	}
 
 	.wp-block-navigation .block-editor-block-list__block::before {
@@ -69,6 +75,14 @@
 .wp-block-navigation {
 	display: flex;
 	flex-wrap: wrap;
+}
+
+// Vertical aligment.
+.wp-block-navigation {
+	min-height: $navigation-height;
+	padding-top: 7px;
+	padding-bottom: 7px;
+	align-items: center;
 }
 
 .wp-block-navigation__inserter-content {
@@ -144,6 +158,10 @@ $color-control-label-height: 20px;
 	.component-color-indicator {
 		float: right;
 		margin-top: 2px;
+	}
+
+	.components-panel__body-title {
+		display: none;
 	}
 }
 

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -13,12 +13,12 @@
  * @return array Colors CSS classes and inline styles.
  */
 function build_css_colors( $attributes ) {
-	// CSS classes.
 	$colors = array(
 		'css_classes'   => array(),
 		'inline_styles' => '',
 	);
 
+	// Text color.
 	$has_named_text_color  = array_key_exists( 'textColor', $attributes );
 	$has_custom_text_color = array_key_exists( 'customTextColor', $attributes );
 
@@ -33,7 +33,25 @@ function build_css_colors( $attributes ) {
 		$colors['css_classes'][] = sprintf( 'has-%s-color', $attributes['textColor'] );
 	} elseif ( $has_custom_text_color ) {
 		// Add the custom color inline style.
-		$colors['inline_styles'] = sprintf( 'color: %s;', $attributes['customTextColor'] );
+		$colors['inline_styles'] .= sprintf( 'color: %s;', $attributes['customTextColor'] );
+	}
+
+	// Background color.
+	$has_named_background_color  = array_key_exists( 'backgroundColor', $attributes );
+	$has_custom_background_color = array_key_exists( 'customBackgroundColor', $attributes );
+
+	// If has background color.
+	if ( $has_custom_background_color || $has_named_background_color ) {
+		// Add has-background-color class.
+		$colors['css_classes'][] = 'has-background-color';
+	}
+
+	if ( $has_named_background_color ) {
+		// Add the background-color class.
+		$colors['css_classes'][] = sprintf( 'has-%s-background-color', $attributes['backgroundColor'] );
+	} elseif ( $has_custom_background_color ) {
+		// Add the custom background-color inline style.
+		$colors['inline_styles'] .= sprintf( 'background-color: %s;', $attributes['customBackgroundColor'] );
 	}
 
 	return $colors;
@@ -106,10 +124,11 @@ function render_block_navigation( $attributes, $content, $block ) {
  * @param array $block      The block.
  * @param array $colors     Contains inline styles and CSS classes to apply to navigation item.
  * @param array $font_sizes Contains inline styles and CSS classes to apply to navigation item.
+ * @param bool  $level_zero True whether is main menu (level zero). Otherwise, False.
  *
  * @return string Returns  an HTML list from innerBlocks.
  */
-function build_navigation_html( $block, $colors, $font_sizes ) {
+function build_navigation_html( $block, $colors, $font_sizes, $level_zero = true ) {
 	$html            = '';
 	$classes         = array_merge(
 		$colors['css_classes'],
@@ -124,7 +143,11 @@ function build_navigation_html( $block, $colors, $font_sizes ) {
 	foreach ( (array) $block['innerBlocks'] as $key => $block ) {
 
 		$html .= '<li class="wp-block-navigation-link">' .
-			'<a' . $class_attribute . $style_attribute;
+			'<a';
+
+		if ( $level_zero ) {
+			$html .= $class_attribute . $style_attribute;
+		}
 
 		// Start appending HTML attributes to anchor tag.
 		if ( isset( $block['attrs']['url'] ) ) {
@@ -166,7 +189,7 @@ function build_navigation_html( $block, $colors, $font_sizes ) {
 		// End anchor tag content.
 
 		if ( count( (array) $block['innerBlocks'] ) > 0 ) {
-			$html .= build_navigation_html( $block, $colors, $font_sizes );
+			$html .= build_navigation_html( $block, $colors, $font_sizes, false );
 		}
 
 		$html .= '</li>';
@@ -186,22 +209,28 @@ function register_block_core_navigation() {
 		'core/navigation',
 		array(
 			'attributes'      => array(
-				'className'          => array(
+				'className'             => array(
 					'type' => 'string',
 				),
-				'textColor'          => array(
+				'textColor'             => array(
 					'type' => 'string',
 				),
-				'customTextColor'    => array(
+				'customTextColor'       => array(
 					'type' => 'string',
 				),
-				'fontSize'           => array(
+				'backgroundColor'       => array(
 					'type' => 'string',
 				),
-				'customFontSize'     => array(
+				'customBackgroundColor' => array(
+					'type' => 'string',
+				),
+				'fontSize'              => array(
+					'type' => 'string',
+				),
+				'customFontSize'        => array(
 					'type' => 'number',
 				),
-				'itemsJustification' => array(
+				'itemsJustification'    => array(
 					'type' => 'string',
 				),
 			),

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -59,13 +59,14 @@
 
 		// Sub-menus Flyout
 		& > li > ul {
-			background: #fff;
 			-webkit-box-shadow: 0 3px 30px rgba(25, 30, 35, 0.1);
 			-moz-box-shadow: 0 3px 30px rgba(25, 30, 35, 0.1);
 			border-radius: 3px;
 			box-shadow: 0 3px 30px rgba(25, 30, 35, 0.1);
-			border: 1px solid #e2e4e7;
+			border-width: 1px;
+			border-style: solid;
 			margin: 0;
+			padding: 0 30px 0 10px;
 			position: absolute;
 			left: 0;
 			top: 80%;
@@ -74,11 +75,13 @@
 			transition: opacity 0.15s linear, transform 0.15s linear, right 0s 0.15s;
 			transform: translateY(0.6rem);
 			visibility: hidden;
-			padding: 5px 0;
-
 
 			li {
-				margin: 2px 8px;
+				margin: 0;
+
+				& > ul {
+					padding-left: 10px;
+				}
 			}
 
 			a {
@@ -89,10 +92,12 @@
 				}
 			}
 
+			// Sub menu arrow.
+			$light-style-sub-menu-arrow-width: 20px;
 			&::after,
 			&::before {
 				bottom: 100%;
-				left: 50%;
+				left: 22px;
 				border: solid transparent;
 				content: " ";
 				height: 0;
@@ -101,28 +106,23 @@
 				pointer-events: none;
 			}
 
+			// Sub menu arrow. Background.
 			&::after {
-				border-color: rgba(255, 255, 255, 0);
-				border-bottom-color: #fff;
-				border-width: 10px;
-				margin-left: -10px;
+				border-width: $light-style-sub-menu-arrow-width / 2;
+				margin-left: -($light-style-sub-menu-arrow-width / 2);
+				bottom: calc(100% - 1px);
 			}
 
+			// Sub menu arrow. Border.
 			&::before {
-				border-color: rgba(226, 228, 231, 0);
-				border-bottom-color: #e2e4e7;
-				border-width: 11px;
-				margin-left: -11px;
+				border-width: $light-style-sub-menu-arrow-width / 2 + 1px;
+				margin-left: -($light-style-sub-menu-arrow-width / 2 + 1px);
 			}
 
 			ul {
 				width: 100%;
 			}
 		}
-	}
-
-	.has-background-color + ul {
-		background: inherit;
 	}
 
 	// Navigation Link
@@ -139,6 +139,14 @@
 		li a {
 			padding-top: 8px;
 			padding-bottom: 8px;
+
+			&:first-child {
+				padding-top: 13px;
+			}
+
+			&:last-child {
+				padding-bottom: 13px;
+			}
 		}
 	}
 
@@ -165,29 +173,66 @@
 	&.items-justified-right > ul {
 		justify-content: flex-end;
 	}
-}
 
-.is-style-dark > ul > li > ul {
-	background: #333;
-	border: 1px solid #111;
+	// Colors.
+	$light-style-sub-menu-background-color: #fff;
+	$light-style-sub-menu-border-color: #e2e4e7;
+	$light-style-sub-menu-text-color: #111;
+	$light-style-sub-menu-text-color-hover: #333;
 
-	a {
-		text-decoration: none;
-		color: #fff;
+	$dark-style-sub-menu-background-color: #333;
+	$dark-style-sub-menu-border-color: #111;
+	$dark-style-sub-menu-text-color: #fff;
+	$dark-style-sub-menu-text-color-hover: #eee;
 
-		&:hover {
-			text-decoration: underline;
-			color: #eee;
+	// Default Style / Ligth style.
+	& > ul > li > ul,
+	&.is-light-style > ul > li > ul {
+		background-color: $light-style-sub-menu-background-color;
+		border-color: $light-style-sub-menu-border-color;
+
+		a {
+			color: $light-style-sub-menu-text-color;
+
+			&:hover {
+				color: $light-style-sub-menu-text-color-hover;
+			}
+		}
+
+		// Sub menu arrow - background color.
+		&::after {
+			border-color: transparent;
+			border-bottom-color: $light-style-sub-menu-background-color;
+		}
+
+		// Sub menu arrow - border color.
+		&::before {
+			border-color: transparent;
+			border-bottom-color: $light-style-sub-menu-border-color;
 		}
 	}
 
-	&::after {
-		border-color: rgba(51, 51, 51, 0);
-		border-bottom-color: #333;
-	}
+	// Dark Style.
+	&.is-style-dark > ul > li > ul {
+		background-color: $dark-style-sub-menu-background-color;
+		border-color: $dark-style-sub-menu-border-color;
 
-	&::before {
-		border-color: rgba(17, 17, 17, 0);
-		border-bottom-color: #111;
+		a {
+			color: $dark-style-sub-menu-text-color;
+
+			&:hover {
+				color: $dark-style-sub-menu-text-color-hover;
+			}
+		}
+
+		// Sub menu arrow - background color.
+		&::after {
+			border-bottom-color: $dark-style-sub-menu-background-color;
+		}
+
+		// Sub menu arrow - border color.
+		&::before {
+			border-bottom-color: $dark-style-sub-menu-border-color;
+		}
 	}
 }


### PR DESCRIPTION
## Description
This PR adds the ability to set the background color to the Navigation menu. The scope of the current approach is:

* Sets the background color only in the Navigation menu.
* Sets the background color only in the menu at the top (level 0).
* It adds contrast checker. 
* For submenus, it applies default colors, supporting light/dark styles.

## How has this been tested?

Just create a Navigation menu and set the background color, click on the color selector button.

<img width="400" alt="Screen Shot 2020-01-10 at 6 36 18 PM" src="https://user-images.githubusercontent.com/77539/72188267-a60c5500-33d8-11ea-9a22-ebd956f533b8.png">

Confirm that the contrast checker works as expected.

<img width="400" alt="Screen Shot 2020-01-10 at 6 37 20 PM" src="https://user-images.githubusercontent.com/77539/72188407-026f7480-33d9-11ea-8f62-23caa0673c23.png">

Once you've set up the colors, check that it reflects them in the front-end.

Also, check how it looks in light/dark styles. You can set it up from the `styles` section in the sidebar.
<img width="663" alt="Screen Shot 2020-01-10 at 6 39 43 PM" src="https://user-images.githubusercontent.com/77539/72188972-68a8c700-33da-11ea-85e3-8030e9b70017.png">


**Light style (default)**
<img src="https://user-images.githubusercontent.com/77539/72188513-48c4d380-33d9-11ea-9da4-530f5ed7678f.png" width="300px" />

**Dark style**
<img src="https://user-images.githubusercontent.com/77539/72189096-ba515180-33da-11ea-980f-a396d2513fa3.png" width="300px" />


Additionally, it fixes a visual bug about a really thin line in the arrow of a submenu.
<img src="https://user-images.githubusercontent.com/77539/72189195-04d2ce00-33db-11ea-903a-5ffc356444c6.png" width="300px" />


## Checklist:
- [x] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
