### PR TITLE
Consolidate web/native BlockEditorProvider

### DIFF
--- a/packages/block-editor/src/components/provider/index.native.js
+++ b/packages/block-editor/src/components/provider/index.native.js
@@ -1,40 +1,28 @@
 /**
+ * External dependencies
+ */
+import { last, noop } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
-import { SlotFillProvider } from '@wordpress/components';
-import { withDispatch, RegistryConsumer } from '@wordpress/data';
-import { createHigherOrderComponent, compose } from '@wordpress/compose';
-
-/** @typedef {import('@wordpress/data').WPDataRegistry} WPDataRegistry */
+import { withDispatch } from '@wordpress/data';
+import { compose } from '@wordpress/compose';
 
 /**
- * Higher-order component which renders the original component with the current
- * registry context passed as its `registry` prop.
- *
- * @param {WPComponent} OriginalComponent Original component.
- *
- * @return {WPComponent} Enhanced component.
+ * Internal dependencies
  */
-const withRegistry = createHigherOrderComponent(
-	( OriginalComponent ) => ( props ) => (
-		<RegistryConsumer>
-			{ ( registry ) => (
-				<OriginalComponent
-					{ ...props }
-					registry={ registry }
-				/>
-			) }
-		</RegistryConsumer>
-	),
-	'withRegistry'
-);
+import withRegistryProvider from './with-registry-provider';
+
+/** @typedef {import('@wordpress/data').WPDataRegistry} WPDataRegistry */
 
 class BlockEditorProvider extends Component {
 	componentDidMount() {
 		this.props.updateSettings( this.props.settings );
 		this.props.resetBlocks( this.props.value );
 		this.attachChangeObserver( this.props.registry );
+		this.isSyncingOutcomingValue = [];
 	}
 
 	componentDidUpdate( prevProps ) {
@@ -43,6 +31,9 @@ class BlockEditorProvider extends Component {
 			updateSettings,
 			value,
 			resetBlocks,
+			selectionStart,
+			selectionEnd,
+			resetSelection,
 			registry,
 		} = this.props;
 
@@ -54,11 +45,28 @@ class BlockEditorProvider extends Component {
 			this.attachChangeObserver( registry );
 		}
 
-		if ( this.isSyncingOutcomingValue ) {
-			this.isSyncingOutcomingValue = false;
+		if ( this.isSyncingOutcomingValue.includes( value ) ) {
+			// Skip block reset if the value matches expected outbound sync
+			// triggered by this component by a preceding change detection.
+			// Only skip if the value matches expectation, since a reset should
+			// still occur if the value is modified (not equal by reference),
+			// to allow that the consumer may apply modifications to reflect
+			// back on the editor.
+			if ( last( this.isSyncingOutcomingValue ) === value ) {
+				this.isSyncingOutcomingValue = [];
+			}
 		} else if ( value !== prevProps.value ) {
-			this.isSyncingIncomingValue = true;
+			// Reset changing value in all other cases than the sync described
+			// above. Since this can be reached in an update following an out-
+			// bound sync, unset the outbound value to avoid considering it in
+			// subsequent renders.
+			this.isSyncingOutcomingValue = [];
+			this.isSyncingIncomingValue = value;
 			resetBlocks( value );
+
+			if ( selectionStart && selectionEnd ) {
+				resetSelection( selectionStart, selectionEnd );
+			}
 		}
 	}
 
@@ -87,7 +95,10 @@ class BlockEditorProvider extends Component {
 
 		const {
 			getBlocks,
+			getSelectionStart,
+			getSelectionEnd,
 			isLastBlockChangePersistent,
+			__unstableIsLastBlockChangeIgnored,
 		} = registry.select( 'core/block-editor' );
 
 		let blocks = getBlocks();
@@ -95,13 +106,20 @@ class BlockEditorProvider extends Component {
 
 		this.unsubscribe = registry.subscribe( () => {
 			const {
-				onChange,
-				onInput,
+				onChange = noop,
+				onInput = noop,
 			} = this.props;
+
 			const newBlocks = getBlocks();
 			const newIsPersistent = isLastBlockChangePersistent();
-			if ( newBlocks !== blocks && this.isSyncingIncomingValue ) {
-				this.isSyncingIncomingValue = false;
+
+			if (
+				newBlocks !== blocks && (
+					this.isSyncingIncomingValue ||
+					__unstableIsLastBlockChangeIgnored()
+				)
+			) {
+				this.isSyncingIncomingValue = null;
 				blocks = newBlocks;
 				isPersistent = newIsPersistent;
 				return;
@@ -112,14 +130,22 @@ class BlockEditorProvider extends Component {
 				// This happens when a previous input is explicitely marked as persistent.
 				( newIsPersistent && ! isPersistent )
 			) {
+				// When knowing the blocks value is changing, assign instance
+				// value to skip reset in subsequent `componentDidUpdate`.
+				if ( newBlocks !== blocks ) {
+					this.isSyncingOutcomingValue.push( newBlocks );
+				}
+
 				blocks = newBlocks;
 				isPersistent = newIsPersistent;
 
-				this.isSyncingOutcomingValue = true;
+				const selectionStart = getSelectionStart();
+				const selectionEnd = getSelectionEnd();
+
 				if ( isPersistent ) {
-					onChange( blocks );
+					onChange( blocks, { selectionStart, selectionEnd } );
 				} else {
-					onInput( blocks );
+					onInput( blocks, { selectionStart, selectionEnd } );
 				}
 			}
 		} );
@@ -128,25 +154,23 @@ class BlockEditorProvider extends Component {
 	render() {
 		const { children } = this.props;
 
-		return (
-			<SlotFillProvider>
-				{ children }
-			</SlotFillProvider>
-		);
+		return children;
 	}
 }
 
 export default compose( [
+	withRegistryProvider,
 	withDispatch( ( dispatch ) => {
 		const {
 			updateSettings,
 			resetBlocks,
+			resetSelection,
 		} = dispatch( 'core/block-editor' );
 
 		return {
 			updateSettings,
 			resetBlocks,
+			resetSelection,
 		};
 	} ),
-	withRegistry,
 ] )( BlockEditorProvider );


### PR DESCRIPTION
## Description

We have a native variant of `BlockEditorProvider`, introduced in #14375 (although having that generic PR squashed doesn't help figure out why)

As part of https://github.com/wordpress-mobile/gutenberg-mobile/issues/1466, I'm implementing `BlockPreview` (or a variant of it) on native, which requires us to be able to have more than one provider at once. The newer web version seems to be using a subregistry to handle this.

I haven't found anything that looks mobile specific, so in this PR I've just copied the web version into the native file, so it's easier to diff, but before merging I would just delete the native file.

## How has this been tested?

I did some basic testing inserting, moving, deleting blocks, typing, changing selection... Everything seems to work fine, but I'm not sure if there's anything else we should be testing

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
