### PR TITLE
Refine multiselect.

### DIFF
--- a/packages/base-styles/_colors.scss
+++ b/packages/base-styles/_colors.scss
@@ -83,9 +83,7 @@ $blue-medium-200: #bfe7f3;
 $blue-medium-100: #e5f5fa;
 $blue-medium-highlight: #b3e7fe;
 $blue-medium-focus: #007cba;
-
-$blue-blueberry: #5f7efd;
-
+$blue-medium-focus-dark: #fff;
 
 // Alert colors.
 $alert-yellow: #f0b849;

--- a/packages/base-styles/_colors.scss
+++ b/packages/base-styles/_colors.scss
@@ -84,6 +84,9 @@ $blue-medium-100: #e5f5fa;
 $blue-medium-highlight: #b3e7fe;
 $blue-medium-focus: #007cba;
 
+$blue-blueberry: #5f7efd;
+
+
 // Alert colors.
 $alert-yellow: #f0b849;
 $alert-red: #d94f4f;

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -182,7 +182,7 @@
 	.block-editor-block-list__block.is-multi-selected {
 		// Show selection borders around every non-nested block's actual footprint.
 		> .block-editor-block-list__block-edit > [data-block] {
-			box-shadow: 0 0 0 2px #057cba;
+			box-shadow: 0 0 0 2px $blue-blueberry, 0 0 0 4px $white;
 			border-radius: 1px;
 
 			// Windows High Contrast mode will show this outline.
@@ -195,9 +195,11 @@
 			margin-left: $block-padding;
 		}
 
-		// Hide the native selection marker once we select multiple blocks.
-		::selection {
-			background: transparent;
+		// Provide exceptions for placeholders.
+		.components-placeholder {
+			::selection {
+				background: transparent;
+			}
 		}
 	}
 }

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -182,11 +182,16 @@
 	.block-editor-block-list__block.is-multi-selected {
 		// Show selection borders around every non-nested block's actual footprint.
 		> .block-editor-block-list__block-edit > [data-block] {
-			box-shadow: 0 0 0 2px $blue-blueberry, 0 0 0 4px $white;
+			box-shadow: 0 0 0 2px $blue-medium-focus;
 			border-radius: 1px;
 
 			// Windows High Contrast mode will show this outline.
 			outline: 2px solid transparent;
+
+			// Show a lighter blue for dark themes.
+			.is-dark-theme & {
+				box-shadow: 0 0 0 2px $blue-medium-focus-dark;
+			}
 		}
 		.block-editor-block-toolbar {
 			left: $border-width + $border-width + $block-padding;


### PR DESCRIPTION
This restores the native selection in addition to the borders.

Based on feedback by @ellatrix in https://github.com/WordPress/gutenberg/pull/19094#issuecomment-565401539 here's some refinement. GIFS:

![twenty](https://user-images.githubusercontent.com/1204802/70796566-e7422280-1da2-11ea-9cb3-1187391f0aea.gif)

![dark](https://user-images.githubusercontent.com/1204802/70796568-e8734f80-1da2-11ea-8451-13b50514e5da.gif)

![purple](https://user-images.githubusercontent.com/1204802/70796570-e9a47c80-1da2-11ea-9d9d-0a5f21094299.gif)

> Why not leave the text selection for extra clarity (it's really visible, works on all kinds of backgrounds)?

This is both a solid point, but also something that was the intent of the #19094. We can't always rely on the text selection marker being sufficient to indicate selection, for example a Cover block with no text will not show as selected because it has only a background. 19094 took the extreme and removed the text selection entirely, due to the idea that having _two_ selection indicators might be confusing. 

The efforts are inspired by these mockups:

<img width="1440" alt="69957382-de2f9680-1502-11ea-890b-9ed4c9a07ffe" src="https://user-images.githubusercontent.com/1204802/70796795-73ece080-1da3-11ea-9e9a-2689598388af.png">

<img width="1440" alt="69957443-f7384780-1502-11ea-84bb-0865414f7ffa" src="https://user-images.githubusercontent.com/1204802/70796796-751e0d80-1da3-11ea-9dd8-9d45b9c3f630.png">

In those, an exception is made for consecutive paragraphs, which if combined with improvements to the writing flow would be just delightful. But as soon as selection enters a non-text block, it converts to a fully bordered selection instead. The reason being that when you _copy_, you copy the blocks, not just the text inside.

So going back to the question, how do we ensure the selection color is visible on all backgrounds? We can't use `mix-blend-mode` or `filter`, as there are no colors that always are contrasty to their backgrounds, regardless of configuration. 

Even the native selection color is not always visible. Here, the editor background is the same color as the MacOS selection color:

![Screenshot 2019-12-13 at 12 30 00](https://user-images.githubusercontent.com/1204802/70797211-55d3b000-1da4-11ea-8c7d-de9b38d9fc7d.png)

You can _barely_ make out the selection. 

What does Figma do?

By default they have a lovely blue, like us:

![Screenshot 2019-12-13 at 12 28 05](https://user-images.githubusercontent.com/1204802/70797242-6552f900-1da4-11ea-82aa-2f6195bcd4d0.png)

What if the background is that blue?

![Screenshot 2019-12-13 at 12 28 20](https://user-images.githubusercontent.com/1204802/70797250-6ab04380-1da4-11ea-80aa-13cef3ab65be.png)

Only the rectangles are visible. So maybe two colors is an option, I'll follow up with a comment. 