### PR TITLE
Assign an explicit color to buttons

### DIFF
--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -15,6 +15,7 @@
 	padding: 0 8px;
 	overflow: hidden;
 	border-radius: 3px;
+	color: $dark-gray-500;
 
 	&:not(:disabled):not([aria-disabled="true"]):not(.is-secondary):not(.is-primary):not(.is-tertiary):not(.is-link):hover {
 		@include button-style__hover;


### PR DESCRIPTION
Related https://github.com/WordPress/gutenberg/pull/19058#discussion_r357631076