### PR TITLE
Navigation: Add font size attribute

### DIFF
--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -15,6 +15,8 @@ import {
 	InnerBlocks,
 	InspectorControls,
 	BlockControls,
+	FontSizePicker,
+	withFontSizes,
 	__experimentalUseColors,
 } from '@wordpress/block-editor';
 
@@ -43,12 +45,14 @@ import * as navIcons from './icons';
 function Navigation( {
 	attributes,
 	clientId,
-	pages,
-	isRequestingPages,
-	hasResolvedPages,
+	fontSize,
 	hasExistingNavItems,
-	updateNavItemBlocks,
+	hasResolvedPages,
+	isRequestingPages,
+	pages,
 	setAttributes,
+	setFontSize,
+	updateNavItemBlocks,
 } ) {
 	//
 	// HOOKS
@@ -108,7 +112,11 @@ function Navigation( {
 
 	const blockClassNames = classnames( 'wp-block-navigation', {
 		[ `items-justification-${ attributes.itemsJustification }` ]: attributes.itemsJustification,
+		[ fontSize.class ]: fontSize.class,
 	} );
+	const blockInlineStyles = {
+		fontSize: fontSize.size ? fontSize.size + 'px' : undefined,
+	};
 
 	// If we don't have existing items or the User hasn't
 	// indicated they want to automatically add top level Pages
@@ -175,9 +183,15 @@ function Navigation( {
 				>
 					<BlockNavigationList clientId={ clientId } />
 				</PanelBody>
+				<PanelBody title={ __( 'Text Settings' ) } className="blocks-font-size">
+					<FontSizePicker
+						value={ fontSize.size }
+						onChange={ setFontSize }
+					/>
+				</PanelBody>
 			</InspectorControls>
 			<TextColor>
-				<div className={ blockClassNames }>
+				<div className={ blockClassNames } style={ blockInlineStyles }>
 					{ ! hasExistingNavItems && isRequestingPages && <><Spinner /> { __( 'Loading Navigation…' ) } </> }
 
 					<InnerBlocks
@@ -193,6 +207,7 @@ function Navigation( {
 }
 
 export default compose( [
+	withFontSizes( 'fontSize' ),
 	withSelect( ( select, { clientId } ) => {
 		const innerBlocks = select( 'core/block-editor' ).getBlocks( clientId );
 

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -183,7 +183,7 @@ function Navigation( {
 				>
 					<BlockNavigationList clientId={ clientId } />
 				</PanelBody>
-				<PanelBody title={ __( 'Text Settings' ) } className="blocks-font-size">
+				<PanelBody title={ __( 'Text Settings' ) }>
 					<FontSizePicker
 						value={ fontSize.size }
 						onChange={ setFontSize }

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -113,7 +113,7 @@ function build_navigation_html( $block, $colors, $font_sizes ) {
 	$html            = '';
 	$classes         = array_merge(
 		$colors['css_classes'],
-		$font_sizes['css_classes'],
+		$font_sizes['css_classes']
 	);
 	$css_classes     = implode( ' ', $classes );
 	$class_attribute = sprintf( ' class="wp-block-navigation-link__content %s"', esc_attr( trim( $css_classes ) ) );
@@ -177,13 +177,13 @@ function register_block_core_navigation() {
 				'customTextColor'    => array(
 					'type' => 'string',
 				),
-				'fontSize'              => array(
+				'fontSize'           => array(
 					'type' => 'string',
 				),
-				'customFontSize'        => array(
+				'customFontSize'     => array(
 					'type' => 'number',
 				),
-				'itemsJustification'    => array(
+				'itemsJustification' => array(
 					'type' => 'string',
 				),
 			),

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -148,7 +148,7 @@ function build_navigation_html( $block, $colors, $font_sizes ) {
 		// End anchor tag content.
 
 		if ( count( (array) $block['innerBlocks'] ) > 0 ) {
-			$html .= build_navigation_html( $block, $colors );
+			$html .= build_navigation_html( $block, $colors, $font_sizes );
 		}
 
 		$html .= '</li>';


### PR DESCRIPTION
## Description

Adds the font size style attributes (both named and custom) to the Navigation block.

## How has this been tested?
Tested on macOS 10.15.2, Chrome 78, Gutenberg Docker environment, Twenty Twenty theme.

## Screenshots

| Before | After |
| - | - |
| <img width="1189" alt="Screenshot 2019-12-13 at 15 53 36" src="https://user-images.githubusercontent.com/2070010/70813138-ecae6580-1dc0-11ea-94e3-457fbd24e5ac.png"> | <img width="1190" alt="Screenshot 2019-12-13 at 15 54 02" src="https://user-images.githubusercontent.com/2070010/70813151-f041ec80-1dc0-11ea-9655-4d290ce1a589.png"> |
| <img width="1328" alt="Screenshot 2019-12-13 at 15 51 58" src="https://user-images.githubusercontent.com/2070010/70813166-f768fa80-1dc0-11ea-8c19-2f6775e4f7a6.png"> | <img width="1335" alt="Screenshot 2019-12-13 at 15 54 22" src="https://user-images.githubusercontent.com/2070010/70813178-fa63eb00-1dc0-11ea-8af4-d23a323f5427.png"> |

## Testing instructions

- Edit a post and add a Navigation block.
- Try changing the block's font size.
- Make sure the block looks as expected.
- Preview the post, and make sure the block looks as expected in the front end too.
- Repeat the previous steps, but this time check if the font size _custom_ attribute work as expected.

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
