### PR TITLE
Try a narrow trash button

### DIFF
--- a/packages/editor/src/components/post-trash/style.scss
+++ b/packages/editor/src/components/post-trash/style.scss
@@ -1,5 +1,4 @@
 .editor-post-trash.components-button {
-	width: 100%;
 	color: darken($alert-red, 15%);
 	border-color: darken($alert-red, 15%);
 	justify-content: center;


### PR DESCRIPTION
The trash button right now is full width, which is not a pattern used a lot elsewhere. It also encourages you to move to trash almost as so large.

![3](https://user-images.githubusercontent.com/253067/70819199-8419b580-1dcd-11ea-97dc-0a310d15391c.png)

A little fix to this could be to explore just making it a normal button here:

![2](https://user-images.githubusercontent.com/253067/70819224-93006800-1dcd-11ea-8438-d5b59ec96032.png)

I would argue making it just a text link could also work, but let's see what feedback is about the button for now.