### PR TITLE
Gallery block / media-placeholder - Preserve changes made while upload in progress.

### DIFF
--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -128,9 +128,8 @@ export class MediaPlaceholder extends Component {
 					if ( dynamicAlteration ) {
 						// If currentValue contains things not in props.value, remove them.
 						currentValue = currentValue.filter( ( item ) => {
-							return this.props.value.some( ( propItem ) => propItem.id === item.id );
+							return this.props.value.some( ( propItem ) => propItem.id === item.id && propItem.url === item.url );
 						} );
-						let loadingBlobsCount = 0;
 						// If props.value has completed items not in currentValue, add them.
 						this.props.value.forEach( ( propItem ) => {
 							if (	// Id on propItem implies uploaded item.
@@ -141,15 +140,8 @@ export class MediaPlaceholder extends Component {
 									! newMedia.some( ( item ) => item.id === propItem.id )
 							) {
 								currentValue.push( propItem );
-							} else if ( ! propItem.id ) {
-								// Count loading blobs.
-								loadingBlobsCount++;
 							}
 						} );
-						// Are there new loading blobs?
-						if ( loadingBlobsCount > newMedia.length ) {
-							// console.log( 'new loaders' );
-						}
 					}
 					onSelect( currentValue.concat( newMedia ) );
 				};

--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -139,10 +139,14 @@ export class MediaPlaceholder extends Component {
 					const filteredMedia = currentMedia.filter( ( item ) => {
 						// If Item has id, only remove it if lastMediaPassed has an item with that id.
 						if ( item.id ) {
-							return ! lastMediaPassed.some( ( { id } ) => id === item.id );
+							return ! lastMediaPassed.some(
+								( { id } ) => id === item.id
+							);
 						}
 						// Compare transient images via .includes since gallery may append extra info onto the url.
-						return ! lastMediaPassed.some( ( { urlSlug } ) => item.url.includes( urlSlug ) );
+						return ! lastMediaPassed.some( ( { urlSlug } ) =>
+							item.url.includes( urlSlug )
+						);
 					} );
 					// Return the filtered media array along with newMedia.
 					onSelect( filteredMedia.concat( newMedia ) );

--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -117,31 +117,28 @@ export class MediaPlaceholder extends Component {
 			onError,
 			onSelect,
 			value = [],
-			dynamicAlteration,
 		} = this.props;
 		let setMedia;
 		if ( multiple ) {
 			if ( addToGallery ) {
 				let mediaToReturn = value;
 				setMedia = ( newMedia ) => {
-					if ( dynamicAlteration ) {
-						const currentMedia = this.props.value || [];
-						// If mediaToReturn contains things not in currentMedia, remove them.
-						mediaToReturn = mediaToReturn.filter( ( item ) => {
-							return currentMedia.some( ( currentItem ) => currentItem.id === item.id && currentItem.url === item.url );
-						} );
-						// If currentMedia has completed items not in mediaToReturn, add them.
-						currentMedia.forEach( ( currentItem ) => {
-							if ( currentItem.id &&
-									// Item is not already in mediaToReturn set.
-									! mediaToReturn.some( ( item ) => item.id === currentItem.id ) &&
-									// Item is not a member of our upload group.
-									! newMedia.some( ( item ) => item.id === currentItem.id )
-							) {
-								mediaToReturn.push( currentItem );
-							}
-						} );
-					}
+					const currentMedia = this.props.value || [];
+					// If mediaToReturn contains things not in currentMedia, remove them.
+					mediaToReturn = mediaToReturn.filter( ( item ) => {
+						return currentMedia.some( ( currentItem ) => currentItem.id === item.id && currentItem.url === item.url );
+					} );
+					// If currentMedia has completed items not in mediaToReturn, add them.
+					currentMedia.forEach( ( currentItem ) => {
+						if ( currentItem.id &&
+								// Item is not already in mediaToReturn set.
+								! mediaToReturn.some( ( item ) => item.id === currentItem.id ) &&
+								// Item is not a member of our upload group.
+								! newMedia.some( ( item ) => item.id === currentItem.id )
+						) {
+							mediaToReturn.push( currentItem );
+						}
+					} );
 					onSelect( mediaToReturn.concat( newMedia ) );
 				};
 			} else {

--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -137,12 +137,17 @@ export class MediaPlaceholder extends Component {
 					// Remove any images this upload group is responsible for (lastMediaPassed).
 					// Their replacements are contained in newMedia.
 					const filteredMedia = currentMedia.filter( ( item ) => {
-						return ! lastMediaPassed.some( ( temporaryMediaURL ) => temporaryMediaURL === item.url );
+						// Compare via .includes since gallery adds a ratio to the url after returned from this function.
+						return ! lastMediaPassed.some( ( temporaryMediaSlug ) => item.url.includes( temporaryMediaSlug ) );
 					} );
 					// Return the filtered media array along with newMedia.
 					onSelect( filteredMedia.concat( newMedia ) );
 					// Reset lastMediaPassed and set it with urls from newMedia.
-					lastMediaPassed = newMedia.map( ( media ) => media.url );
+					lastMediaPassed = newMedia.map( ( media ) => {
+						// Add everything up to '.fileType' to compare via .includes.
+						const cutOffIndex = media.url.lastIndexOf( '.' );
+						return media.url.slice( 0, cutOffIndex );
+					} );
 				};
 			} else {
 				setMedia = onSelect;

--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -123,18 +123,17 @@ export class MediaPlaceholder extends Component {
 		if ( multiple ) {
 			if ( addToGallery ) {
 				let currentValue = value;
-				// if ( dynamicAlteration ) {
 				setMedia = ( newMedia ) => {
 					if ( dynamicAlteration ) {
-						// If currentValue contains things not in props.value, remove them.
+						const galleryValue = this.props.value;
+						// If currentValue contains things not in galleryValue, remove them.
 						currentValue = currentValue.filter( ( item ) => {
-							return this.props.value.some( ( propItem ) => propItem.id === item.id && propItem.url === item.url );
+							return galleryValue.some( ( propItem ) => propItem.id === item.id && propItem.url === item.url );
 						} );
-						// If props.value has completed items not in currentValue, add them.
-						this.props.value.forEach( ( propItem ) => {
-							if (	// Id on propItem implies uploaded item.
-								propItem.id &&
-									// Item is not in currentValue set.
+						// If galleryValue has completed items not in currentValue, add them.
+						galleryValue.forEach( ( propItem ) => {
+							if ( propItem.id &&
+									// Item is not already in currentValue set.
 									! currentValue.some( ( item ) => item.id === propItem.id ) &&
 									// Item is not a member of our upload group.
 									! newMedia.some( ( item ) => item.id === propItem.id )

--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -123,7 +123,7 @@ export class MediaPlaceholder extends Component {
 				// To allow changes to a gallery to be made while uploads are in progress
 				// (including trigging multiple upload groups and removing already in place images),
 				// we must be able to add newMedia based on the current value of the Gallery
-				// whenever the setMedia function runs (given by getValue).
+				// whenever the setMedia function runs (not destructuring 'value' from props).
 				// Additionally, since the setMedia function runs multiple times per upload group
 				// and is passed newMedia containing every item in its group each time, we must
 				// also filter out whatever this upload group had previously returned to the

--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -110,7 +110,6 @@ export class MediaPlaceholder extends Component {
 
 	onFilesUpload( files ) {
 		const {
-			addToGallery,
 			allowedTypes,
 			mediaUpload,
 			multiple,
@@ -119,48 +118,46 @@ export class MediaPlaceholder extends Component {
 		} = this.props;
 		let setMedia;
 		if ( multiple ) {
-			if ( addToGallery ) {
-				// To allow changes to a gallery to be made while uploads are in progress
-				// (including trigging multiple upload groups and removing already in place images),
-				// we must be able to add newMedia based on the current value of the Gallery
-				// whenever the setMedia function runs. Since the setMedia function runs multiple
-				// times per upload group and is passed newMedia containing every item in its
-				// group each time, we must also filter out whatever this upload group had
-				// previously returned to the gallery before adding and returning the image
-				// array with replacement newMedia values.
+			// To allow changes to a gallery to be made while uploads are in progress
+			// (including trigging multiple upload groups and removing already in place images),
+			// we must be able to add newMedia based on the current value of the Gallery
+			// whenever the setMedia function runs. Since the setMedia function runs multiple
+			// times per upload group and is passed newMedia containing every item in its
+			// group each time, we must also filter out whatever this upload group had
+			// previously returned to the gallery before adding and returning the image
+			// array with replacement newMedia values.
 
-				// Define an array to store urls from newMedia between subsequent function calls.
-				let lastMediaPassed = [];
-				setMedia = ( newMedia ) => {
-					// Get the current array of images on the Gallery.
-					const currentMedia = this.props.value || [];
-					// Remove any images this upload group is responsible for (lastMediaPassed).
-					// Their replacements are contained in newMedia.
-					const filteredMedia = currentMedia.filter( ( item ) => {
-						// If Item has id, only remove it if lastMediaPassed has an item with that id.
-						if ( item.id ) {
-							return ! lastMediaPassed.some(
-								( { id } ) => id === item.id
-							);
-						}
-						// Compare transient images via .includes since gallery may append extra info onto the url.
-						return ! lastMediaPassed.some( ( { urlSlug } ) =>
-							item.url.includes( urlSlug )
+			// Get a reference to the image array on the Gallery.
+			const currentMedia = this.props.value;
+
+			// Define an array to store urls from newMedia between subsequent function calls.
+			let lastMediaPassed = [];
+			setMedia = ( newMedia ) => {
+				// Remove any images this upload group is responsible for (lastMediaPassed).
+				// Their replacements are contained in newMedia.
+				const filteredMedia = currentMedia.filter( ( item ) => {
+					// If Item has id, only remove it if lastMediaPassed has an item with that id.
+					if ( item.id ) {
+						return ! lastMediaPassed.some(
+							// Soft equal since int can get turned to string in gallery.
+							( { id } ) => id == item.id
 						);
-					} );
-					// Return the filtered media array along with newMedia.
-					onSelect( filteredMedia.concat( newMedia ) );
-					// Reset lastMediaPassed and set it with ids and urls from newMedia.
-					lastMediaPassed = newMedia.map( ( media ) => {
-						// Add everything up to '.fileType' to compare via .includes.
-						const cutOffIndex = media.url.lastIndexOf( '.' );
-						const urlSlug = media.url.slice( 0, cutOffIndex );
-						return { id: media.id, urlSlug };
-					} );
-				};
-			} else {
-				setMedia = onSelect;
-			}
+					}
+					// Compare transient images via .includes since gallery may append extra info onto the url.
+					return ! lastMediaPassed.some( ( { urlSlug } ) =>
+						item.url.includes( urlSlug )
+					);
+				} );
+				// Return the filtered media array along with newMedia.
+				onSelect( filteredMedia.concat( newMedia ) );
+				// Reset lastMediaPassed and set it with ids and urls from newMedia.
+				lastMediaPassed = newMedia.map( ( media ) => {
+					// Add everything up to '.fileType' to compare via .includes.
+					const cutOffIndex = media.url.lastIndexOf( '.' );
+					const urlSlug = media.url.slice( 0, cutOffIndex );
+					return { id: media.id, urlSlug };
+				} );
+			};
 		} else {
 			setMedia = ( [ media ] ) => onSelect( media );
 		}

--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -128,7 +128,7 @@ export class MediaPlaceholder extends Component {
 			// array with replacement newMedia values.
 
 			// Get a reference to the image array on the Gallery.
-			const currentMedia = this.props.value;
+			const currentMedia = this.props.value || [];
 
 			// Define an array to store urls from newMedia between subsequent function calls.
 			let lastMediaPassed = [];
@@ -140,7 +140,7 @@ export class MediaPlaceholder extends Component {
 					if ( item.id ) {
 						return ! lastMediaPassed.some(
 							// Soft equal since int can get turned to string in gallery.
-							( { id } ) => id == item.id
+							( { id } ) => Number( id ) === Number( item.id )
 						);
 					}
 					// Compare transient images via .includes since gallery may append extra info onto the url.

--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -123,25 +123,36 @@ export class MediaPlaceholder extends Component {
 		if ( multiple ) {
 			if ( addToGallery ) {
 				let currentValue = value;
-				if ( dynamicAlteration ) {
-					setMedia = ( newMedia ) => {
+				// if ( dynamicAlteration ) {
+				setMedia = ( newMedia ) => {
+					if ( dynamicAlteration ) {
 						// If currentValue contains things not in props.value, remove them.
 						currentValue = currentValue.filter( ( item ) => {
 							return this.props.value.some( ( propItem ) => propItem.id === item.id );
 						} );
+						let loadingBlobsCount = 0;
 						// If props.value has completed items not in currentValue, add them.
 						this.props.value.forEach( ( propItem ) => {
-							if ( propItem.id && ! currentValue.some( ( item ) => item.id === propItem.id ) ) {
+							if (	// Id on propItem implies uploaded item.
+								propItem.id &&
+									// Item is not in currentValue set.
+									! currentValue.some( ( item ) => item.id === propItem.id ) &&
+									// Item is not a member of our upload group.
+									! newMedia.some( ( item ) => item.id === propItem.id )
+							) {
 								currentValue.push( propItem );
+							} else if ( ! propItem.id ) {
+								// Count loading blobs.
+								loadingBlobsCount++;
 							}
 						} );
-						onSelect( currentValue.concat( newMedia ) );
-					};
-				} else {
-					setMedia = ( newMedia ) => {
-						onSelect( currentValue.concat( newMedia ) );
-					};
-				}
+						// Are there new loading blobs?
+						if ( loadingBlobsCount > newMedia.length ) {
+							// console.log( 'new loaders' );
+						}
+					}
+					onSelect( currentValue.concat( newMedia ) );
+				};
 			} else {
 				setMedia = onSelect;
 			}

--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -137,16 +137,16 @@ export class MediaPlaceholder extends Component {
 					// Remove any images this upload group is responsible for (lastMediaPassed).
 					// Their replacements are contained in newMedia.
 					const filteredMedia = currentMedia.filter( ( item ) => {
-						// If Item has ID, only remove it if lastMediaPassed has an item with that ID.
+						// If Item has id, only remove it if lastMediaPassed has an item with that id.
 						if ( item.id ) {
 							return ! lastMediaPassed.some( ( { id } ) => id === item.id );
 						}
-						// Compare via .includes since gallery can add a ratio to the url after returned from this function.
+						// Compare transient images via .includes since gallery may append extra info onto the url.
 						return ! lastMediaPassed.some( ( { urlSlug } ) => item.url.includes( urlSlug ) );
 					} );
 					// Return the filtered media array along with newMedia.
 					onSelect( filteredMedia.concat( newMedia ) );
-					// Reset lastMediaPassed and set it with urls from newMedia.
+					// Reset lastMediaPassed and set it with ids and urls from newMedia.
 					lastMediaPassed = newMedia.map( ( media ) => {
 						// Add everything up to '.fileType' to compare via .includes.
 						const cutOffIndex = media.url.lastIndexOf( '.' );

--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -125,7 +125,7 @@ export class MediaPlaceholder extends Component {
 				let currentValue = value;
 				setMedia = ( newMedia ) => {
 					if ( dynamicAlteration ) {
-						const galleryValue = this.props.value;
+						const galleryValue = this.props.value || [];
 						// If currentValue contains things not in galleryValue, remove them.
 						currentValue = currentValue.filter( ( item ) => {
 							return galleryValue.some( ( propItem ) => propItem.id === item.id && propItem.url === item.url );

--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -65,6 +65,7 @@ export class MediaPlaceholder extends Component {
 		this.onFilesUpload = this.onFilesUpload.bind( this );
 		this.openURLInput = this.openURLInput.bind( this );
 		this.closeURLInput = this.closeURLInput.bind( this );
+		this.defaultGetValue = this.defaultGetValue.bind( this );
 	}
 
 	onlyAllowsImages() {
@@ -108,6 +109,10 @@ export class MediaPlaceholder extends Component {
 		this.onFilesUpload( event.target.files );
 	}
 
+	defaultGetValue() {
+		return this.props.value || [];
+	}
+
 	onFilesUpload( files ) {
 		const {
 			addToGallery,
@@ -116,6 +121,7 @@ export class MediaPlaceholder extends Component {
 			multiple,
 			onError,
 			onSelect,
+			getValue = this.defaultGetValue,
 		} = this.props;
 		let setMedia;
 		if ( multiple ) {
@@ -129,15 +135,12 @@ export class MediaPlaceholder extends Component {
 				// previously returned to the gallery before adding and returning the image
 				// array with replacement newMedia values.
 
-				// Get a reference to the image array on the Gallery.
-				const currentMedia = this.props.value || [];
-
 				// Define an array to store urls from newMedia between subsequent function calls.
 				let lastMediaPassed = [];
 				setMedia = ( newMedia ) => {
 					// Remove any images this upload group is responsible for (lastMediaPassed).
 					// Their replacements are contained in newMedia.
-					const filteredMedia = currentMedia.filter( ( item ) => {
+					const filteredMedia = getValue().filter( ( item ) => {
 						// If Item has id, only remove it if lastMediaPassed has an item with that id.
 						if ( item.id ) {
 							return ! lastMediaPassed.some(

--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -137,8 +137,12 @@ export class MediaPlaceholder extends Component {
 					// Remove any images this upload group is responsible for (lastMediaPassed).
 					// Their replacements are contained in newMedia.
 					const filteredMedia = currentMedia.filter( ( item ) => {
-						// Compare via .includes since gallery adds a ratio to the url after returned from this function.
-						return ! lastMediaPassed.some( ( temporaryMediaSlug ) => item.url.includes( temporaryMediaSlug ) );
+						// If Item has ID, only remove it if lastMediaPassed has an item with that ID.
+						if ( item.id ) {
+							return ! lastMediaPassed.some( ( { id } ) => id === item.id );
+						}
+						// Compare via .includes since gallery can add a ratio to the url after returned from this function.
+						return ! lastMediaPassed.some( ( { urlSlug } ) => item.url.includes( urlSlug ) );
 					} );
 					// Return the filtered media array along with newMedia.
 					onSelect( filteredMedia.concat( newMedia ) );
@@ -146,7 +150,8 @@ export class MediaPlaceholder extends Component {
 					lastMediaPassed = newMedia.map( ( media ) => {
 						// Add everything up to '.fileType' to compare via .includes.
 						const cutOffIndex = media.url.lastIndexOf( '.' );
-						return media.url.slice( 0, cutOffIndex );
+						const urlSlug = media.url.slice( 0, cutOffIndex );
+						return { id: media.id, urlSlug };
 					} );
 				};
 			} else {

--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -142,8 +142,7 @@ export class MediaPlaceholder extends Component {
 					// Return the filtered media array along with newMedia.
 					onSelect( filteredMedia.concat( newMedia ) );
 					// Reset lastMediaPassed and set it with urls from newMedia.
-					lastMediaPassed = [];
-					newMedia.forEach( ( media ) => lastMediaPassed.push( media.url ) );
+					lastMediaPassed = newMedia.map( ( media ) => media.url );
 				};
 			} else {
 				setMedia = onSelect;

--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -116,29 +116,21 @@ export class MediaPlaceholder extends Component {
 			multiple,
 			onError,
 			onSelect,
-			value = [],
 		} = this.props;
 		let setMedia;
 		if ( multiple ) {
 			if ( addToGallery ) {
-				let mediaToReturn = value;
+				let lastMediaPassed = [];
 				setMedia = ( newMedia ) => {
 					const currentMedia = this.props.value || [];
-					// If mediaToReturn contains things not in currentMedia, remove them.
-					mediaToReturn = mediaToReturn.filter( ( item ) => {
-						return currentMedia.some( ( currentItem ) => currentItem.id === item.id && currentItem.url === item.url );
+					// Remove lastMediaPassed from currentMedia.
+					const mediaToReturn = currentMedia.filter( ( item ) => {
+						return ! lastMediaPassed.some( ( temporaryMediaURL ) => temporaryMediaURL === item.url );
 					} );
-					// If currentMedia has completed items not in mediaToReturn, add them.
-					currentMedia.forEach( ( currentItem ) => {
-						if ( currentItem.id &&
-								// Item is not already in mediaToReturn set.
-								! mediaToReturn.some( ( item ) => item.id === currentItem.id ) &&
-								// Item is not a member of our upload group.
-								! newMedia.some( ( item ) => item.id === currentItem.id )
-						) {
-							mediaToReturn.push( currentItem );
-						}
-					} );
+					// Reset lastMediaPassed and set it with urls from newMedia.
+					lastMediaPassed = [];
+					newMedia.forEach( ( media ) => lastMediaPassed.push( media.url ) );
+
 					onSelect( mediaToReturn.concat( newMedia ) );
 				};
 			} else {

--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -117,14 +117,21 @@ export class MediaPlaceholder extends Component {
 			onError,
 			onSelect,
 			value = [],
+			dynamicAlteration,
 		} = this.props;
 		let setMedia;
 		if ( multiple ) {
 			if ( addToGallery ) {
-				const currentValue = value;
-				setMedia = ( newMedia ) => {
-					onSelect( currentValue.concat( newMedia ) );
-				};
+				if ( dynamicAlteration ) {
+					setMedia = ( newMedia ) => {
+						onSelect( this.props.value.concat( newMedia ) );
+					};
+				} else {
+					const currentValue = value;
+					setMedia = ( newMedia ) => {
+						onSelect( currentValue.concat( newMedia ) );
+					};
+				}
 			} else {
 				setMedia = onSelect;
 			}

--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -125,11 +125,11 @@ export class MediaPlaceholder extends Component {
 				let currentValue = value;
 				if ( dynamicAlteration ) {
 					setMedia = ( newMedia ) => {
-						// If currentValue contains things not in t.p.value, remove them.
+						// If currentValue contains things not in props.value, remove them.
 						currentValue = currentValue.filter( ( item ) => {
 							return this.props.value.some( ( propItem ) => propItem.id === item.id );
 						} );
-						// If t.p.value has completed items not in currentValue, add them.
+						// If props.value has completed items not in currentValue, add them.
 						this.props.value.forEach( ( propItem ) => {
 							if ( propItem.id && ! currentValue.some( ( item ) => item.id === propItem.id ) ) {
 								currentValue.push( propItem );

--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -120,18 +120,30 @@ export class MediaPlaceholder extends Component {
 		let setMedia;
 		if ( multiple ) {
 			if ( addToGallery ) {
+				// To allow changes to a gallery to be made while uploads are in progress
+				// (including trigging multiple upload groups and removing already in place images),
+				// we must be able to add newMedia based on the current value of the Gallery
+				// whenever the setMedia function runs. Since the setMedia function runs multiple
+				// times per upload group and is passed newMedia containing every item in its
+				// group each time, we must also filter out whatever this upload group had
+				// previously returned to the gallery before adding and returning the image
+				// array with replacement newMedia values.
+
+				// Define an array to store urls from newMedia between subsequent function calls.
 				let lastMediaPassed = [];
 				setMedia = ( newMedia ) => {
+					// Get the current array of images on the Gallery.
 					const currentMedia = this.props.value || [];
-					// Remove lastMediaPassed from currentMedia.
-					const mediaToReturn = currentMedia.filter( ( item ) => {
+					// Remove any images this upload group is responsible for (lastMediaPassed).
+					// Their replacements are contained in newMedia.
+					const filteredMedia = currentMedia.filter( ( item ) => {
 						return ! lastMediaPassed.some( ( temporaryMediaURL ) => temporaryMediaURL === item.url );
 					} );
+					// Return the filtered media array along with newMedia.
+					onSelect( filteredMedia.concat( newMedia ) );
 					// Reset lastMediaPassed and set it with urls from newMedia.
 					lastMediaPassed = [];
 					newMedia.forEach( ( media ) => lastMediaPassed.push( media.url ) );
-
-					onSelect( mediaToReturn.concat( newMedia ) );
 				};
 			} else {
 				setMedia = onSelect;

--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -139,7 +139,7 @@ export class MediaPlaceholder extends Component {
 					// If Item has id, only remove it if lastMediaPassed has an item with that id.
 					if ( item.id ) {
 						return ! lastMediaPassed.some(
-							// Soft equal since int can get turned to string in gallery.
+							// Be sure to convert to number for comparison.
 							( { id } ) => Number( id ) === Number( item.id )
 						);
 					}

--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -129,11 +129,12 @@ export class MediaPlaceholder extends Component {
 				// To allow changes to a gallery to be made while uploads are in progress
 				// (including trigging multiple upload groups and removing already in place images),
 				// we must be able to add newMedia based on the current value of the Gallery
-				// whenever the setMedia function runs. Since the setMedia function runs multiple
-				// times per upload group and is passed newMedia containing every item in its
-				// group each time, we must also filter out whatever this upload group had
-				// previously returned to the gallery before adding and returning the image
-				// array with replacement newMedia values.
+				// whenever the setMedia function runs (given by getValue).
+				// Additionally, since the setMedia function runs multiple times per upload group
+				// and is passed newMedia containing every item in its group each time, we must
+				// also filter out whatever this upload group had previously returned to the
+				// gallery before adding and returning the image array with replacement newMedia
+				// values.
 
 				// Define an array to store urls from newMedia between subsequent function calls.
 				let lastMediaPassed = [];

--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -122,12 +122,22 @@ export class MediaPlaceholder extends Component {
 		let setMedia;
 		if ( multiple ) {
 			if ( addToGallery ) {
+				let currentValue = value;
 				if ( dynamicAlteration ) {
 					setMedia = ( newMedia ) => {
-						onSelect( this.props.value.concat( newMedia ) );
+						// If currentValue contains things not in t.p.value, remove them.
+						currentValue = currentValue.filter( ( item ) => {
+							return this.props.value.some( ( propItem ) => propItem.id === item.id );
+						} );
+						// If t.p.value has completed items not in currentValue, add them.
+						this.props.value.forEach( ( propItem ) => {
+							if ( propItem.id && ! currentValue.some( ( item ) => item.id === propItem.id ) ) {
+								currentValue.push( propItem );
+							}
+						} );
+						onSelect( currentValue.concat( newMedia ) );
 					};
 				} else {
-					const currentValue = value;
 					setMedia = ( newMedia ) => {
 						onSelect( currentValue.concat( newMedia ) );
 					};

--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -122,27 +122,27 @@ export class MediaPlaceholder extends Component {
 		let setMedia;
 		if ( multiple ) {
 			if ( addToGallery ) {
-				let currentValue = value;
+				let mediaToReturn = value;
 				setMedia = ( newMedia ) => {
 					if ( dynamicAlteration ) {
-						const galleryValue = this.props.value || [];
-						// If currentValue contains things not in galleryValue, remove them.
-						currentValue = currentValue.filter( ( item ) => {
-							return galleryValue.some( ( propItem ) => propItem.id === item.id && propItem.url === item.url );
+						const currentMedia = this.props.value || [];
+						// If mediaToReturn contains things not in currentMedia, remove them.
+						mediaToReturn = mediaToReturn.filter( ( item ) => {
+							return currentMedia.some( ( currentItem ) => currentItem.id === item.id && currentItem.url === item.url );
 						} );
-						// If galleryValue has completed items not in currentValue, add them.
-						galleryValue.forEach( ( propItem ) => {
-							if ( propItem.id &&
-									// Item is not already in currentValue set.
-									! currentValue.some( ( item ) => item.id === propItem.id ) &&
+						// If currentMedia has completed items not in mediaToReturn, add them.
+						currentMedia.forEach( ( currentItem ) => {
+							if ( currentItem.id &&
+									// Item is not already in mediaToReturn set.
+									! mediaToReturn.some( ( item ) => item.id === currentItem.id ) &&
 									// Item is not a member of our upload group.
-									! newMedia.some( ( item ) => item.id === propItem.id )
+									! newMedia.some( ( item ) => item.id === currentItem.id )
 							) {
-								currentValue.push( propItem );
+								mediaToReturn.push( currentItem );
 							}
 						} );
 					}
-					onSelect( currentValue.concat( newMedia ) );
+					onSelect( mediaToReturn.concat( newMedia ) );
 				};
 			} else {
 				setMedia = onSelect;

--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -65,7 +65,6 @@ export class MediaPlaceholder extends Component {
 		this.onFilesUpload = this.onFilesUpload.bind( this );
 		this.openURLInput = this.openURLInput.bind( this );
 		this.closeURLInput = this.closeURLInput.bind( this );
-		this.defaultGetValue = this.defaultGetValue.bind( this );
 	}
 
 	onlyAllowsImages() {
@@ -109,10 +108,6 @@ export class MediaPlaceholder extends Component {
 		this.onFilesUpload( event.target.files );
 	}
 
-	defaultGetValue() {
-		return this.props.value || [];
-	}
-
 	onFilesUpload( files ) {
 		const {
 			addToGallery,
@@ -121,7 +116,6 @@ export class MediaPlaceholder extends Component {
 			multiple,
 			onError,
 			onSelect,
-			getValue = this.defaultGetValue,
 		} = this.props;
 		let setMedia;
 		if ( multiple ) {
@@ -141,19 +135,22 @@ export class MediaPlaceholder extends Component {
 				setMedia = ( newMedia ) => {
 					// Remove any images this upload group is responsible for (lastMediaPassed).
 					// Their replacements are contained in newMedia.
-					const filteredMedia = getValue().filter( ( item ) => {
-						// If Item has id, only remove it if lastMediaPassed has an item with that id.
-						if ( item.id ) {
-							return ! lastMediaPassed.some(
-								// Be sure to convert to number for comparison.
-								( { id } ) => Number( id ) === Number( item.id )
+					const filteredMedia = ( this.props.value || [] ).filter(
+						( item ) => {
+							// If Item has id, only remove it if lastMediaPassed has an item with that id.
+							if ( item.id ) {
+								return ! lastMediaPassed.some(
+									// Be sure to convert to number for comparison.
+									( { id } ) =>
+										Number( id ) === Number( item.id )
+								);
+							}
+							// Compare transient images via .includes since gallery may append extra info onto the url.
+							return ! lastMediaPassed.some( ( { urlSlug } ) =>
+								item.url.includes( urlSlug )
 							);
 						}
-						// Compare transient images via .includes since gallery may append extra info onto the url.
-						return ! lastMediaPassed.some( ( { urlSlug } ) =>
-							item.url.includes( urlSlug )
-						);
-					} );
+					);
 					// Return the filtered media array along with newMedia.
 					onSelect( filteredMedia.concat( newMedia ) );
 					// Reset lastMediaPassed and set it with ids and urls from newMedia.

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -90,6 +90,8 @@ class GalleryEdit extends Component {
 		this.onFocusGalleryCaption = this.onFocusGalleryCaption.bind( this );
 		this.getImagesSizeOptions = this.getImagesSizeOptions.bind( this );
 		this.updateImagesSize = this.updateImagesSize.bind( this );
+		// We need to keep a consistent reference to this array for the MediaPlaceholder.
+		this.images = [];
 
 		this.state = {
 			selectedImage: null,
@@ -315,6 +317,14 @@ class GalleryEdit extends Component {
 		this.setAttributes( { images: updatedImages, sizeSlug } );
 	}
 
+	/**
+	 * Sets the images in our array without redifining reference.
+	 */
+	setImages() {
+		this.images.length = 0;
+		this.images.push( ...this.props.attributes.images );
+	}
+
 	componentDidMount() {
 		const { attributes, mediaUpload } = this.props;
 		const { images } = attributes;
@@ -332,6 +342,7 @@ class GalleryEdit extends Component {
 				allowedTypes: [ 'image' ],
 			} );
 		}
+		this.setImages();
 	}
 
 	componentDidUpdate( prevProps ) {
@@ -341,6 +352,9 @@ class GalleryEdit extends Component {
 				selectedImage: null,
 				captionSelected: false,
 			} );
+		}
+		if ( this.props.attributes.images !== prevProps.attributes.images ) {
+			this.setImages();
 		}
 	}
 
@@ -372,7 +386,7 @@ class GalleryEdit extends Component {
 				accept="image/*"
 				allowedTypes={ ALLOWED_MEDIA_TYPES }
 				multiple
-				value={ hasImagesWithId ? images : undefined }
+				value={ this.images }
 				onError={ this.onUploadError }
 				notices={ hasImages ? undefined : noticeUI }
 				onFocus={ this.props.onFocus }

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -372,7 +372,8 @@ class GalleryEdit extends Component {
 				accept="image/*"
 				allowedTypes={ ALLOWED_MEDIA_TYPES }
 				multiple
-				value={ hasImagesWithId ? images : undefined }
+				dynamicAlteration
+				value={ hasImagesWithId ? images : [] }
 				onError={ this.onUploadError }
 				notices={ hasImages ? undefined : noticeUI }
 				onFocus={ this.props.onFocus }

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -369,11 +369,10 @@ class GalleryEdit extends Component {
 		} = attributes;
 
 		const hasImages = !! images.length;
-		const hasImagesWithId = hasImages && some( images, ( { id } ) => id );
 
 		const mediaPlaceholder = (
 			<MediaPlaceholder
-				addToGallery={ hasImagesWithId }
+				addToGallery={ true }
 				isAppender={ hasImages }
 				className={ className }
 				disableMediaButtons={ hasImages && ! isSelected }

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -90,7 +90,6 @@ class GalleryEdit extends Component {
 		this.onFocusGalleryCaption = this.onFocusGalleryCaption.bind( this );
 		this.getImagesSizeOptions = this.getImagesSizeOptions.bind( this );
 		this.updateImagesSize = this.updateImagesSize.bind( this );
-		this.getValue = this.getValue.bind( this );
 
 		this.state = {
 			selectedImage: null,
@@ -345,10 +344,6 @@ class GalleryEdit extends Component {
 		}
 	}
 
-	getValue() {
-		return this.props.attributes.images;
-	}
-
 	render() {
 		const { attributes, className, isSelected, noticeUI } = this.props;
 		const {
@@ -377,7 +372,6 @@ class GalleryEdit extends Component {
 				allowedTypes={ ALLOWED_MEDIA_TYPES }
 				multiple
 				value={ images }
-				getValue={ this.getValue }
 				onError={ this.onUploadError }
 				notices={ hasImages ? undefined : noticeUI }
 				onFocus={ this.props.onFocus }

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -373,7 +373,7 @@ class GalleryEdit extends Component {
 				allowedTypes={ ALLOWED_MEDIA_TYPES }
 				multiple
 				dynamicAlteration
-				value={ hasImagesWithId ? images : [] }
+				value={ hasImagesWithId ? images : undefined }
 				onError={ this.onUploadError }
 				notices={ hasImages ? undefined : noticeUI }
 				onFocus={ this.props.onFocus }

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -90,8 +90,7 @@ class GalleryEdit extends Component {
 		this.onFocusGalleryCaption = this.onFocusGalleryCaption.bind( this );
 		this.getImagesSizeOptions = this.getImagesSizeOptions.bind( this );
 		this.updateImagesSize = this.updateImagesSize.bind( this );
-		// We need to keep a consistent reference to this array for the MediaPlaceholder.
-		this.images = [];
+		this.getValue = this.getValue.bind( this );
 
 		this.state = {
 			selectedImage: null,
@@ -317,14 +316,6 @@ class GalleryEdit extends Component {
 		this.setAttributes( { images: updatedImages, sizeSlug } );
 	}
 
-	/**
-	 * Sets the images in our array without redifining reference.
-	 */
-	setImages() {
-		this.images.length = 0;
-		this.images.push( ...this.props.attributes.images );
-	}
-
 	componentDidMount() {
 		const { attributes, mediaUpload } = this.props;
 		const { images } = attributes;
@@ -342,7 +333,6 @@ class GalleryEdit extends Component {
 				allowedTypes: [ 'image' ],
 			} );
 		}
-		this.setImages();
 	}
 
 	componentDidUpdate( prevProps ) {
@@ -353,9 +343,10 @@ class GalleryEdit extends Component {
 				captionSelected: false,
 			} );
 		}
-		if ( this.props.attributes.images !== prevProps.attributes.images ) {
-			this.setImages();
-		}
+	}
+
+	getValue() {
+		return this.props.attributes.images;
 	}
 
 	render() {
@@ -385,7 +376,8 @@ class GalleryEdit extends Component {
 				accept="image/*"
 				allowedTypes={ ALLOWED_MEDIA_TYPES }
 				multiple
-				value={ this.images }
+				value={ images }
+				getValue={ this.getValue }
 				onError={ this.onUploadError }
 				notices={ hasImages ? undefined : noticeUI }
 				onFocus={ this.props.onFocus }

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -372,7 +372,6 @@ class GalleryEdit extends Component {
 				accept="image/*"
 				allowedTypes={ ALLOWED_MEDIA_TYPES }
 				multiple
-				dynamicAlteration
 				value={ hasImagesWithId ? images : undefined }
 				onError={ this.onUploadError }
 				notices={ hasImages ? undefined : noticeUI }


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
This PR aims to fix 3 bugs related to the Gallery block component.

### Before - The bugs that exist.

#### 1 - When Images are removed while another is uploading, they are re-added once upload is complete.
![master-caseC](https://user-images.githubusercontent.com/28742426/70823213-5886d300-1dad-11ea-9704-72779f54dd4a.gif)

#### 2 - When two images are uploaded separately, if the first finishes after the second then the second one is removed once the first finishes its upload.
![master-caseA](https://user-images.githubusercontent.com/28742426/70823317-94ba3380-1dad-11ea-9c0c-7457e6480f19.gif)

#### 3 - When two images are uploaded separately, if the first finishes before the second then the loader for the second disappears.  Once the second finishes, "empty" loading image replaces the first.
![master-caseB](https://user-images.githubusercontent.com/28742426/70823400-ccc17680-1dad-11ea-8eaa-44cbf55846b2.gif)

### How do we go about fixing the above bugs?

Currently, the `media-placeholder` component destructures the `value` from props and adds this into the `setMedia` function as `currentValue`.  This is never updated during the lifetime of the function which is why the above issues exist.  In case 1, since these images are initially added to the function in `currentValue`, they remain in `currentValue` even after they are deleted from the screen.  Once the `setMedia` function runs when the uploading image completes, it returns `currentValue` with those unwanted deleted images.

To fix this, I have added another reference to `this.props.value` (named `currentMedia`) but declared inside the `setMedia` function itself.  This allows us to compare `currentValue` (the 'snapshot' of the gallery's images at the beginning of the upload, now renamed `mediaToReturn` ) with the values that are in the gallery at the time the function is run.

This now allows us to do 2 important checks when the `setMedia` function runs:

1. Have items been removed from the gallery since the upload started?
2. Have completed items been added to the gallery since the upload started?

With these checks we are then able to add/remove items from `mediaToReturn` as necessary so that once the upload completes, we are able to return a state representative of changes that have happened since it started.

##### Note: Why update `mediaToReturn` and not just use the current values in `this.props.value` altogether?
You will find that `this.props.value` contains temporary items returned from the `setMedia` function, such as the loading placeholders.  We don't want to return these placeholders with their corresponding completed uploads, so they would need to be filtered out in that case.  Since currently there is not a good way to tell which placeholders correspond to which completed uploads, it is more simple to add items to `mediaToReturn` than to remove the correctly corresponding ones from the current value of the gallery.

### After the described changes.

#### 1 - When Images are removed while another is uploading, they are not re-added once the upload completes.
![branch-caseC](https://user-images.githubusercontent.com/28742426/70823439-e5319100-1dad-11ea-997b-6fc2422af3e7.gif)

#### 2 - When two images uploaded separately, if the first finishes after the second they will both remain in the gallery.
![branch-caseA](https://user-images.githubusercontent.com/28742426/70823533-1ad67a00-1dae-11ea-86e0-be61fbb57082.gif)

#### 3 - When two images are uploaded separately, if the first finishes before the second the loader for the second still disappears.  However, once it finishes its upload they both are present in the gallery with no empty loading placeholder.
![branch-caseB](https://user-images.githubusercontent.com/28742426/70823608-48232800-1dae-11ea-9452-b1a2ceaff029.gif)

### Some comments on the code itself

1.  There is an adjactent `*.native.js` file to the `media-placeholder` index file.  This has yet to be updated as I am not currently set up to test functionality on native and wanted to get the discussion on this moving before then.  None of the changes made should break any functionality on native, but since the logic in the native file has not been updated there should be no change to how the gallery block works on native until this is similarly updated.  It may also be worth noting that cases 2 & 3 may be much less commonly experienced through the mobile workflow.

2. For comparisons we are using `id`s (and in some cases `url`s) of the media.  My first thought was to use lodash `isEqual` to compare the objects, but noticed there could be some inconsistencies on which properties were present on the objects throughout the lifetime of the function ( `fullUrl: undefined` for example may be present in the values on the first pass of the function, but absent from the copies returned with the loading placeholder causing `isEqual` to always return `false` on a second pass. ).

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Tested on local gutenberg docker environment.
Run this PR and test initiating different uploads simultaneously, removing images from the gallery during an upload, etc.  Recreate the above scenarios listed and test with group uploads as well.  

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
