### PR TITLE
Block Editor: Consistently render IgnoreNestedEvents for block appender

### DIFF
--- a/packages/block-editor/src/components/block-list-appender/index.js
+++ b/packages/block-editor/src/components/block-list-appender/index.js
@@ -51,11 +51,11 @@ function BlockListAppender( {
 		);
 	}
 
-	// IgnoreNestedEvents is used to treat interactions within the appender the
-	// same as subject to the same conditions as those which can occur within
-	// nested blocks. Notably, this effectively prevents event bubbling to block
-	// ancestors which can otherwise interfere with the intended behavior of the
-	// appender (e.g. focus handler on the ancestor block).
+	// IgnoreNestedEvents is used to treat interactions within the appender as
+	// subject to the same conditions as those which occur within nested blocks.
+	// Notably, this effectively prevents event bubbling to block ancestors
+	// which can otherwise interfere with the intended behavior of the appender
+	// (e.g. focus handler on the ancestor block).
 	return (
 		<IgnoreNestedEvents childHandledEvents={ [ 'onFocus', 'onClick', 'onKeyDown' ] }>
 			<div className="block-list-appender">

--- a/packages/block-editor/src/components/block-list-appender/index.js
+++ b/packages/block-editor/src/components/block-list-appender/index.js
@@ -56,9 +56,18 @@ function BlockListAppender( {
 	// Notably, this effectively prevents event bubbling to block ancestors
 	// which can otherwise interfere with the intended behavior of the appender
 	// (e.g. focus handler on the ancestor block).
+	//
+	// A `tabIndex` is used on the wrapping `div` element in order to force a
+	// focus event to occur when an appender `button` element is clicked. In
+	// some browsers (Firefox, Safari), button clicks do not emit a focus event,
+	// which could cause this event to propagate unexpectedly. The `tabIndex`
+	// ensures that the interaction is captured as a focus, without also adding
+	// an extra tab stop.
+	//
+	// See: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Clicking_and_focus
 	return (
 		<IgnoreNestedEvents childHandledEvents={ [ 'onFocus', 'onClick', 'onKeyDown' ] }>
-			<div className="block-list-appender">
+			<div tabIndex={ -1 } className="block-list-appender">
 				{ appender }
 			</div>
 		</IgnoreNestedEvents>

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -290,7 +290,7 @@ function BlockListBlock( {
 	 * (via `setFocus`), typically if there is no focusable input in the block.
 	 */
 	const onFocus = () => {
-		if ( ! isSelected && ! isAncestorOfSelectedBlock && ! isPartOfMultiSelection ) {
+		if ( ! isSelected && ! isPartOfMultiSelection ) {
 			onSelect();
 		}
 	};

--- a/packages/block-editor/src/components/inner-blocks/default-block-appender.js
+++ b/packages/block-editor/src/components/inner-blocks/default-block-appender.js
@@ -12,18 +12,15 @@ import { withSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import IgnoreNestedEvents from '../ignore-nested-events';
 import BaseDefaultBlockAppender from '../default-block-appender';
 import withClientId from './with-client-id';
 
 export const DefaultBlockAppender = ( { clientId, lastBlockClientId } ) => {
 	return (
-		<IgnoreNestedEvents childHandledEvents={ [ 'onFocus', 'onClick', 'onKeyDown' ] }>
-			<BaseDefaultBlockAppender
-				rootClientId={ clientId }
-				lastBlockClientId={ lastBlockClientId }
-			/>
-		</IgnoreNestedEvents>
+		<BaseDefaultBlockAppender
+			rootClientId={ clientId }
+			lastBlockClientId={ lastBlockClientId }
+		/>
 	);
 };
 

--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -33,10 +33,6 @@ const defaultRenderToggle = ( { onToggle, disabled, isOpen, blockTitle, hasSingl
 			icon="insert"
 			label={ label }
 			labelPosition="bottom"
-			onMouseDown={ ( event ) => {
-				event.preventDefault();
-				event.currentTarget.focus();
-			} }
 			onClick={ onToggle }
 			className="block-editor-inserter__toggle"
 			aria-haspopup={ ! hasSingleBlockType ? 'true' : false }


### PR DESCRIPTION
Fixes #18928 
Related: #18379 

This pull request seeks to consistently apply the behavior of `IgnoreNestedEvents` for the block appender component. Previously, the wrapper would have applied to the rendering of the default block appender, and was intended to prevent conflicted interactions between the appender and an ancestor block's focus handlers. Since this was only applied to the default appender and not custom or button appenders, those same conflicts could occur in the latter cases (see #18329). With these changes, `IgnoreNestedEvents` is now used to wrap each possible rendering of the block appender. This also serves as a simplification of the component to unify the render logic.

This also updates the associated `writing-flow.test.js` end-to-end test. Previously, there were assertions which were made to try to verify the intended behavior. However, those assertions relied on the DOM as the source of truth. For the scenario described in #18928, the conflicting focus behavior was such that the active DOM element would be the correct node (the column), but the UI would reflect the incorrect block toolbar (the paragraph), because the selected block in block editor state was prevented from being updated. As of these changes, assertions are made against both the DOM and block editor state to verify correctness.

**Testing Instructions:**

Repeat steps to reproduce from #18928, verifying that you can <kbd>ArrowUp</kbd> from the first block within a column to navigate to the parent Column block.

As described in https://github.com/WordPress/gutenberg/pull/18379#issuecomment-565366937, verify that in a Cover block, you can click the cover block background to select the parent block.

Verify that the end-to-end test included as part of #18379 still passes:

```
npm run test-e2e packages/e2e-tests/specs/editor/blocks/navigation.test.js
```

Verify that the enhanced end-to-end test for writing flow still passes:

```
npm run test-e2e packages/e2e-tests/specs/editor/various/writing-flow.test.js
```