### PR TITLE
Update package changelog with note about dependency file name changing

### DIFF
--- a/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
+++ b/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Breaking Changes
 
-- The plugin now adds, for each entry point, an asset file saved by default in PHP format that declares an object with the list of WordPress script dependencies for the entry point ([#17298](https://github.com/WordPress/gutenberg/pull/17298)). There is also an option to use JSON as the output format. The shape of metadata is also different from the previous version. Read more in the [README](./README.md) file.
+- The plugin now adds, for each entry point, an asset file saved by default in PHP format that declares an object with the list of WordPress script dependencies for the entry point ([#17298](https://github.com/WordPress/gutenberg/pull/17298)). There is also an option to use JSON as the output format. The shape of metadata is also different from the previous version. Note that the file name has also changed (`*.asset.json` or `*.asset.php` instead of `*.deps.json`); references to the `*.deps.json` file will need to be updated even if you choose to use the JSON formatted file. Read more in the [README](./README.md) file.
 
 ## 1.0.1 (2019-05-22)
 

--- a/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
+++ b/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Breaking Changes
 
-- The plugin now adds, for each entry point, an asset file saved by default in PHP format that declares an object with the list of WordPress script dependencies for the entry point ([#17298](https://github.com/WordPress/gutenberg/pull/17298)). There is also an option to use JSON as the output format. The shape of metadata is also different from the previous version. Note that the file name has also changed (`*.asset.json` or `*.asset.php` instead of `*.deps.json`); references to the `*.deps.json` file will need to be updated even if you choose to use the JSON formatted file. Read more in the [README](./README.md) file.
+- The plugin now adds, for each entry point, an asset file saved by default in PHP format that declares an object with the list of WordPress script dependencies for the entry point ([#17298](https://github.com/WordPress/gutenberg/pull/17298)). There is also an option to use JSON as the output format. The shape of metadata is also different from the previous version. Note that the file name has also changed from `*.deps.json` to `*.asset.json` or `*.asset.php`. References to the `*.deps.json` filename will need to be updated, even if you choose to use the JSON formatted file. Read more in the [README](./README.md) file.
 
 ## 1.0.1 (2019-05-22)
 


### PR DESCRIPTION
## Description

This PR adds a small note to the Dependency Extraction Webpack Plugin changelog to note that in addition to the default file format and file shape changing, the filename also changed.

This was discussed in the [#core-js WordPress Slack channel](https://wordpress.slack.com/archives/C5UNMSU4R/p1576256781007500) (registration required).

## How has this been tested?

No tests; documentation-only change.

## Screenshots

n/a

## Types of changes

Documentation change.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.