### PR TITLE
Site Title: Remove save button.

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -32,7 +32,6 @@ $z-layers: (
 	".wp-block-cover__inner-container": 1, // InnerBlocks area inside cover image block
 	".wp-block-cover.has-background-dim::before": 1, // Overlay area inside block cover need to be higher than the video background.
 	".wp-block-cover__video-background": 0, // Video background inside cover block.
-	".wp-block-site-title__save-button": 1,
 
 	// Active pill button
 	".components-button {:focus or .is-primary}": 1,

--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -36,7 +36,6 @@
 @import "./text-columns/editor.scss";
 @import "./verse/editor.scss";
 @import "./video/editor.scss";
-@import "./site-title/editor.scss";
 
 /**
  * Import styles from internal editor components used by the blocks.

--- a/packages/block-library/src/site-title/edit.js
+++ b/packages/block-library/src/site-title/edit.js
@@ -1,39 +1,19 @@
 /**
  * WordPress dependencies
  */
-import {
-	useEntityProp,
-	__experimentalUseEntitySaving,
-} from '@wordpress/core-data';
-import { Button } from '@wordpress/components';
+import { useEntityProp } from '@wordpress/core-data';
 import { __ } from '@wordpress/i18n';
 import { RichText } from '@wordpress/block-editor';
 
 export default function SiteTitleEdit() {
 	const [ title, setTitle ] = useEntityProp( 'root', 'site', 'title' );
-	const [ isDirty, isSaving, save ] = __experimentalUseEntitySaving(
-		'root',
-		'site',
-		'title'
-	);
 	return (
-		<>
-			<Button
-				isPrimary
-				className="wp-block-site-title__save-button"
-				disabled={ ! isDirty || ! title }
-				isBusy={ isSaving }
-				onClick={ save }
-			>
-				{ __( 'Update' ) }
-			</Button>
-			<RichText
-				tagName="h1"
-				placeholder={ __( 'Site Title' ) }
-				value={ title }
-				onChange={ setTitle }
-				allowedFormats={ [] }
-			/>
-		</>
+		<RichText
+			tagName="h1"
+			placeholder={ __( 'Site Title' ) }
+			value={ title }
+			onChange={ setTitle }
+			allowedFormats={ [] }
+		/>
 	);
 }

--- a/packages/block-library/src/site-title/editor.scss
+++ b/packages/block-library/src/site-title/editor.scss
@@ -1,6 +1,0 @@
-.wp-block-site-title__save-button {
-	position: absolute;
-	right: 0;
-	top: 0;
-	z-index: z-index(".wp-block-site-title__save-button");
-}


### PR DESCRIPTION
The Site Title block doesn't need its makeshift save button after #18029 was merged. Changes can now be saved through the multi-entity saving modal.