### PR TITLE
Try: Default cursor for Select Tool

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -312,6 +312,10 @@
 		}
 	}
 
+	// Select tool/navigation mode shows the default cursor until an additional click edits.
+	&.is-navigate-mode {
+		cursor: default;
+	}
 
 	// Alignments.
 	&[data-align="left"],


### PR DESCRIPTION
The select tool doesn't let you select text. It's only until you click twice on the same block, press Enter, or select the Edit tool, that you edit text again. Therefore the text-beam cursor is inaccurate.

This PR changes that cursor to the default arrow cursor.

![Screenshot-2019-12-16-at-09 10 59](https://user-images.githubusercontent.com/1204802/70890000-3cb94200-1fe4-11ea-8974-fb94ad291208.png)

CC: @noisysocks I recall you asking about this?