### PR TITLE
Base Styles: Import colors into variables

### DIFF
--- a/packages/base-styles/CHANGELOG.md
+++ b/packages/base-styles/CHANGELOG.md
@@ -1,0 +1,3 @@
+## master
+
+- Import `colors` into `variables` since the latter depends on the former.

--- a/packages/base-styles/CHANGELOG.md
+++ b/packages/base-styles/CHANGELOG.md
@@ -1,3 +1,5 @@
 ## master
 
+### Bug Fix
+
 - Import `colors` into `variables` since the latter depends on the former.

--- a/packages/base-styles/_variables.scss
+++ b/packages/base-styles/_variables.scss
@@ -1,3 +1,5 @@
+@import './colors';
+
 /**
  * Often re-used variables
  */

--- a/packages/base-styles/_variables.scss
+++ b/packages/base-styles/_variables.scss
@@ -1,4 +1,4 @@
-@import './colors';
+@import "./colors";
 
 /**
  * Often re-used variables


### PR DESCRIPTION
## Description

`@import "./colors";` from within `_variables.scss`, since the latter [depends](https://github.com/WordPress/gutenberg/blob/3687e8b992b6462044eead19944cf0c6ea41a1e3/packages/base-styles/_variables.scss#L36-L40) on `$dark-gray-900` which is [defined](https://github.com/WordPress/gutenberg/blob/bfd1117846c7802d62dbba046c27968d961781e7/packages/base-styles/_colors.scss#L7) in the former.

Found while working on https://github.com/Automattic/wp-calypso/pull/38445.

## How has this been tested?

Try importing _just_ `@wordpress/base-styles/variables` in your app, using the currently released package. You'll get a build error saying something like

```
    Module build failed (from ./node_modules/sass-loader/dist/cjs.js):
    SassError: Undefined variable: "$dark-gray-900".
```

Now try with the changes that this PR makes. Your style files should build successfully :+1: 

## Types of changes

Bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
