### PR TITLE
Adds the new replace flow to the video block

### DIFF
--- a/packages/block-library/src/video/edit.js
+++ b/packages/block-library/src/video/edit.js
@@ -7,7 +7,6 @@ import {
 	Button,
 	Disabled,
 	PanelBody,
-	ToolbarGroup,
 	withNotices,
 } from '@wordpress/components';
 import {
@@ -17,6 +16,7 @@ import {
 	MediaPlaceholder,
 	MediaUpload,
 	MediaUploadCheck,
+	MediaReplaceFlow,
 	RichText,
 } from '@wordpress/block-editor';
 import { Component, createRef } from '@wordpress/element';
@@ -146,16 +146,11 @@ class VideoEdit extends Component {
 			attributes,
 			setAttributes,
 		} = this.props;
-		const { editing } = this.state;
-		const switchToEditing = () => {
-			this.setState( { editing: true } );
-		};
 		const onSelectVideo = ( media ) => {
 			if ( ! media || ! media.url ) {
 				// in this case there was an error and we should continue in the editing state
 				// previous attributes should be removed because they may be temporary blob urls
 				setAttributes( { src: undefined, id: undefined } );
-				switchToEditing();
 				return;
 			}
 			// sets the block's attribute and updates the edit component from the
@@ -164,7 +159,7 @@ class VideoEdit extends Component {
 			this.setState( { src: media.url, editing: false } );
 		};
 
-		if ( editing ) {
+		if ( ! src ) {
 			return (
 				<MediaPlaceholder
 					icon={ <BlockIcon icon={ icon } /> }
@@ -184,14 +179,14 @@ class VideoEdit extends Component {
 		return (
 			<>
 				<BlockControls>
-					<ToolbarGroup>
-						<Button
-							className="components-toolbar__control"
-							label={ __( 'Edit video' ) }
-							onClick={ switchToEditing }
-							icon="edit"
-						/>
-					</ToolbarGroup>
+					<MediaReplaceFlow
+						mediaURL={ src }
+						allowedTypes={ ALLOWED_MEDIA_TYPES }
+						accept="video/*"
+						onSelect={ onSelectVideo }
+						onSelectURL={ this.onSelectURL }
+						onError={ this.onUploadError }
+					/>
 				</BlockControls>
 				<InspectorControls>
 					<PanelBody title={ __( 'Video Settings' ) }>

--- a/packages/block-library/src/video/edit.js
+++ b/packages/block-library/src/video/edit.js
@@ -47,10 +47,6 @@ class VideoEdit extends Component {
 		super( ...arguments );
 		// edit component has its own src in the state so it can be edited
 		// without setting the actual value outside of the edit UI
-		this.state = {
-			editing: ! this.props.attributes.src,
-		};
-
 		this.videoPlayer = createRef();
 		this.posterImageButton = createRef();
 		this.onSelectURL = this.onSelectURL.bind( this );
@@ -76,7 +72,6 @@ class VideoEdit extends Component {
 						setAttributes( { src: url } );
 					},
 					onError: ( message ) => {
-						this.setState( { editing: true } );
 						noticeOperations.createErrorNotice( message );
 					},
 					allowedTypes: ALLOWED_MEDIA_TYPES,
@@ -95,8 +90,7 @@ class VideoEdit extends Component {
 		const { attributes, setAttributes } = this.props;
 		const { src } = attributes;
 
-		// Set the block's src from the edit component's state, and switch off
-		// the editing UI.
+		// Set the block's src from the edit component's state
 		if ( newSrc !== src ) {
 			// Check if there's an embed block that handles this URL.
 			const embedBlock = createUpgradedEmbedBlock(
@@ -108,8 +102,6 @@ class VideoEdit extends Component {
 			}
 			setAttributes( { src: newSrc, id: undefined } );
 		}
-
-		this.setState( { editing: false } );
 	}
 
 	onSelectPoster( image ) {
@@ -148,15 +140,15 @@ class VideoEdit extends Component {
 		} = this.props;
 		const onSelectVideo = ( media ) => {
 			if ( ! media || ! media.url ) {
-				// in this case there was an error and we should continue in the editing state
-				// previous attributes should be removed because they may be temporary blob urls
+				// in this case there was an error
+				// previous attributes should be removed
+				// because they may be temporary blob urls
 				setAttributes( { src: undefined, id: undefined } );
 				return;
 			}
 			// sets the block's attribute and updates the edit component from the
-			// selected media, then switches off the editing UI
+			// selected media
 			setAttributes( { src: media.url, id: media.id } );
-			this.setState( { src: media.url, editing: false } );
 		};
 
 		if ( ! src ) {

--- a/packages/block-library/src/video/edit.js
+++ b/packages/block-library/src/video/edit.js
@@ -45,8 +45,6 @@ const VIDEO_POSTER_ALLOWED_MEDIA_TYPES = [ 'image' ];
 class VideoEdit extends Component {
 	constructor() {
 		super( ...arguments );
-		// edit component has its own src in the state so it can be edited
-		// without setting the actual value outside of the edit UI
 		this.videoPlayer = createRef();
 		this.posterImageButton = createRef();
 		this.onSelectURL = this.onSelectURL.bind( this );
@@ -90,7 +88,6 @@ class VideoEdit extends Component {
 		const { attributes, setAttributes } = this.props;
 		const { src } = attributes;
 
-		// Set the block's src from the edit component's state
 		if ( newSrc !== src ) {
 			// Check if there's an embed block that handles this URL.
 			const embedBlock = createUpgradedEmbedBlock(


### PR DESCRIPTION
## Description
There is a new replace flow offered by a component which is currently implemented in the Image Block. This PR implements the new flow in the Audio Block.

## How has this been tested?
Tested locally.

## Screenshots <!-- if applicable -->

<img width="642" alt="Screenshot 2019-12-16 at 13 27 34" src="https://user-images.githubusercontent.com/107534/70903605-e3630a00-2007-11ea-83dd-859ee439b1ab.png">

