### PR TITLE
Broken link for e2e fixtures readme in wordpress.org documentation

### DIFF
--- a/docs/contributors/testing-overview.md
+++ b/docs/contributors/testing-overview.md
@@ -422,7 +422,7 @@ Related: https://chromedevtools.github.io/devtools-protocol/tot/Network#method-e
 
 ### Core Block Testing
 
-Every core block is required to have at least one set of fixture files for its main save function and one for each deprecation. These fixtures test the parsing and serialization of the block. See [the e2e tests fixtures readme](/packages/e2e-tests/fixtures/blocks/README.md) for more information and instructions.
+Every core block is required to have at least one set of fixture files for its main save function and one for each deprecation. These fixtures test the parsing and serialization of the block. See [the e2e tests fixtures readme](https://github.com/WordPress/gutenberg/tree/master/packages/e2e-tests/fixtures/blocks) for more information and instructions.
 
 ## PHP Testing
 


### PR DESCRIPTION
## Description

Changed the location of the link labeled "e2e tests fixtures readme".

## How has this been tested?

Go to the [Block Editor Handbook - Testing Overview page, section *Core Block Testing*](https://developer.wordpress.org/block-editor/contributors/develop/testing-overview/#core-block-testing), and click the link "the e2e tests fixtures readme". It leads to a "page not found" error.

## Types of changes

**Documentation only**: As a "readme" is mentioned, I assumed the intended link was heading towards Gutenberg's GitHub repository. But maybe the block fixtures should have their own section/page in the documentation?
