### PR TITLE
Verse block: fix white space

### DIFF
--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -23,7 +23,6 @@
 @import "./subhead/style.scss";
 @import "./table/style.scss";
 @import "./text-columns/style.scss";
-@import "./verse/style.scss";
 @import "./video/style.scss";
 
 // The following selectors have increased specificity (using the :root prefix)

--- a/packages/block-library/src/verse/style.scss
+++ b/packages/block-library/src/verse/style.scss
@@ -1,4 +1,0 @@
-pre.wp-block-verse {
-	white-space: nowrap;
-	overflow: auto;
-}


### PR DESCRIPTION
## Description

Fixes #19083. Since #18372, the verse block uses character line breaks instead of element line breaks. Unfortunately, I seem to have missed correcting the styles on the front end to be `pre`-style.

## How has this been tested?

Create a verse block with two lines. View the front end. There should be two lines.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
