### PR TITLE
Adds new replace flow to the file block

### DIFF
--- a/packages/block-library/src/file/edit.js
+++ b/packages/block-library/src/file/edit.js
@@ -14,8 +14,6 @@ import {
 import {
 	Animate,
 	ClipboardButton,
-	Button,
-	ToolbarGroup,
 	withNotices,
 } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
@@ -23,9 +21,8 @@ import { withSelect } from '@wordpress/data';
 import {
 	BlockControls,
 	BlockIcon,
-	MediaUpload,
-	MediaUploadCheck,
 	MediaPlaceholder,
+	MediaReplaceFlow,
 	RichText,
 } from '@wordpress/block-editor';
 import { Component } from '@wordpress/element';
@@ -151,7 +148,6 @@ class FileEdit extends Component {
 			textLinkTarget,
 			showDownloadButton,
 			downloadButtonText,
-			id,
 		} = attributes;
 		const { hasError, showCopyConfirmation } = this.state;
 		const attachmentPage = media && media.link;
@@ -189,22 +185,12 @@ class FileEdit extends Component {
 					} }
 				/>
 				<BlockControls>
-					<MediaUploadCheck>
-						<ToolbarGroup>
-							<MediaUpload
-								onSelect={ this.onSelectFile }
-								value={ id }
-								render={ ( { open } ) => (
-									<Button
-										className="components-toolbar__control"
-										label={ __( 'Edit file' ) }
-										onClick={ open }
-										icon="edit"
-									/>
-								) }
-							/>
-						</ToolbarGroup>
-					</MediaUploadCheck>
+					<MediaReplaceFlow
+						mediaURL={ href }
+						accept="*"
+						onSelect={ this.onSelectFile }
+						onError={ this.onUploadError }
+					/>
 				</BlockControls>
 				<Animate type={ isBlobURL( href ) ? 'loading' : null }>
 					{ ( { className: animateClassName } ) => (


### PR DESCRIPTION
## Description
Requires #19063 There is a new replace flow offered by a component which is currently implemented in the Image Block. This PR implements the new flow in the File Block.

## How has this been tested?
Tested locally.

## Screenshots <!-- if applicable -->

<img width="676" alt="Screenshot 2019-12-16 at 18 00 19" src="https://user-images.githubusercontent.com/107534/70921980-f8529400-202d-11ea-9c40-57e6e0884e2f.png">
