### PR TITLE
Data: Persist user preferences via user meta

### DIFF
--- a/lib/compat.php
+++ b/lib/compat.php
@@ -238,12 +238,18 @@ function gutenberg_user_settings_data_persistence_inline_script() {
 
 	$persistence_script = <<<JS
 ( function() {
+	locallyPersistentValues = {};
 	wp.data.use( wp.data.plugins.persistence, {
 		storage: {
-			getItem: function() {
+			getItem: function( key ) {
+				console.log( locallyPersistentValues );
+				if ( locallyPersistentValues[ key ] ) {
+					return locallyPersistentValues[ key ];
+				}
 				return {$persisted_value};
 			},
 			setItem: function( key, value ) {
+				locallyPersistentValues[ key ] = value;
 				wp.apiFetch( {
 					path: '/wp/v2/users/me',
 					method: 'POST',

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -183,11 +183,16 @@ function gutenberg_register_data_persistence_user_meta() {
 		'user',
 		$wpdb->prefix . 'data_persistence',
 		array(
-			'type'         => 'string',
+			'type'         => 'object',
 			'single'       => true,
 			'show_in_rest' => array(
-				'name' => 'data_persistence',
-				'type' => 'string',
+				'name'   => 'data_persistence',
+				'type'   => 'object',
+				'schema' => array(
+					'type'                 => 'object',
+					'properties'           => array(),
+					'additionalProperties' => true,
+				),
 			),
 		)
 	);
@@ -211,8 +216,10 @@ function gutenberg_user_settings_data_persistence_inline_script() {
 		$persisted_value = sprintf( 'localStorage.getItem( "WP_DATA_USER_%s" );', $user_id );
 	} else {
 		// Otherwise, encode the string value for interpolation in the storage
-		// implementation script.
-		$persisted_value = json_encode( $persisted_value );
+		// implementation script. The first `json_encode` will is responsible
+		// for producing a JSON encoding of the persisted meta object, and the
+		// second will apply quoting to that string result.
+		$persisted_value = json_encode( json_encode( $persisted_value ) );
 	}
 
 	$persistence_script = <<<JS
@@ -228,7 +235,7 @@ function gutenberg_user_settings_data_persistence_inline_script() {
 					method: 'POST',
 					data: {
 						meta: {
-							data_persistence: value,
+							data_persistence: JSON.parse( value ),
 						}
 					}
 				} );

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -181,7 +181,7 @@ function gutenberg_register_data_persistence_user_meta() {
 	global $wpdb;
 	register_meta(
 		'user',
-		$wpdb->prefix . 'data_persistence',
+		$wpdb->get_blog_prefix() . 'data_persistence',
 		array(
 			'type'         => 'object',
 			'single'       => true,

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -219,7 +219,7 @@ function gutenberg_user_settings_data_persistence_inline_script() {
 		// implementation script. The first `json_encode` will is responsible
 		// for producing a JSON encoding of the persisted meta object, and the
 		// second will apply quoting to that string result.
-		$persisted_value = json_encode( json_encode( $persisted_value ) );
+		$persisted_value = wp_json_encode( wp_json_encode( $persisted_value ) );
 	}
 
 	$persistence_script = <<<JS

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -178,13 +178,17 @@ add_filter( 'post_type_labels_wp_block', 'gutenberg_override_reusable_block_post
  * it is made accessible for read and write via the REST API.
  */
 function gutenberg_register_data_persistence_user_meta() {
+	global $wpdb;
 	register_meta(
 		'user',
-		'wp_data_persistence',
+		$wpdb->prefix . 'data_persistence',
 		array(
 			'type'         => 'string',
 			'single'       => true,
-			'show_in_rest' => true,
+			'show_in_rest' => array(
+				'name' => 'data_persistence',
+				'type' => 'string',
+			),
 		)
 	);
 }
@@ -197,10 +201,10 @@ add_action( 'init', 'gutenberg_register_data_persistence_user_meta' );
  * and updated via the REST API on change.
  */
 function gutenberg_user_settings_data_persistence_inline_script() {
-	global $wp_scripts;
+	global $wp_scripts, $wpdb;
 
 	$user_id         = get_current_user_id();
-	$persisted_value = get_user_meta( $user_id, 'wp_data_persistence', true );
+	$persisted_value = get_user_meta( $user_id, $wpdb->prefix . 'data_persistence', true );
 	if ( empty( $persisted_value ) ) {
 		// If there's no explicit metadata assigned, fall back to a value which
 		// was persisted using browser storage, prior to user meta persistence.
@@ -224,7 +228,7 @@ function gutenberg_user_settings_data_persistence_inline_script() {
 					method: 'POST',
 					data: {
 						meta: {
-							wp_data_persistence: value,
+							data_persistence: value,
 						}
 					}
 				} );

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -209,7 +209,7 @@ function gutenberg_user_settings_data_persistence_inline_script() {
 	global $wp_scripts, $wpdb;
 
 	$user_id         = get_current_user_id();
-	$persisted_value = get_user_meta( $user_id, $wpdb->prefix . 'data_persistence', true );
+	$persisted_value = get_user_meta( $user_id, $wpdb->get_blog_prefix() . 'data_persistence', true );
 	if ( empty( $persisted_value ) ) {
 		// If there's no explicit metadata assigned, fall back to a value which
 		// was persisted using browser storage, prior to user meta persistence.

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -178,11 +178,15 @@ add_filter( 'post_type_labels_wp_block', 'gutenberg_override_reusable_block_post
  * it is made accessible for read and write via the REST API.
  */
 function gutenberg_register_data_persistence_user_meta() {
-	register_meta( 'user', 'wp_data_persistence', array(
-		'type'         => 'string',
-		'single'       => true,
-		'show_in_rest' => true,
-	) );
+	register_meta(
+		'user',
+		'wp_data_persistence',
+		array(
+			'type'         => 'string',
+			'single'       => true,
+			'show_in_rest' => true,
+		)
+	);
 }
 add_action( 'init', 'gutenberg_register_data_persistence_user_meta' );
 

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -173,6 +173,63 @@ function gutenberg_override_reusable_block_post_type_labels() {
 add_filter( 'post_type_labels_wp_block', 'gutenberg_override_reusable_block_post_type_labels', 10, 0 );
 
 /**
+ * Registers the user meta property responsible for storing preferences for the
+ * data script persistence middleware. The meta is explicitly registered so that
+ * it is made accessible for read and write via the REST API.
+ */
+function gutenberg_register_data_persistence_user_meta() {
+	register_meta( 'user', 'wp_data_persistence', array(
+		'type'         => 'string',
+		'single'       => true,
+		'show_in_rest' => true,
+	) );
+}
+add_action( 'init', 'gutenberg_register_data_persistence_user_meta' );
+
+/**
+ * Enqueues inline scripts used to provide a custom storage interface for the
+ * data script persistence middleware. The custom storage implementation stores
+ * persisted values using user meta, bootstrapped for initial read at load-time,
+ * and updated via the REST API on change.
+ */
+function gutenberg_user_settings_data_persistence_inline_script() {
+	global $wp_scripts;
+
+	$persisted_value = get_user_meta( get_current_user_id(), 'wp_data_persistence', true );
+	if ( empty( $persisted_value ) ) {
+		$persisted_value = '{}';
+	}
+	$persisted_value = json_encode( $persisted_value );
+
+	$persistence_script = <<<JS
+( function() {
+	wp.data.use( wp.data.plugins.persistence, {
+		storage: {
+			getItem: function() {
+				return {$persisted_value};
+			},
+			setItem: function( key, value ) {
+				wp.apiFetch( {
+					path: '/wp/v2/users/me',
+					method: 'POST',
+					data: {
+						meta: {
+							wp_data_persistence: value,
+						}
+					}
+				} );
+			}
+		}
+	} );
+} )();
+JS;
+
+	$wp_scripts->registered['wp-data']->extra['after'] = array();
+	wp_add_inline_script( 'wp-data', $persistence_script );
+}
+add_action( 'enqueue_block_editor_assets', 'gutenberg_user_settings_data_persistence_inline_script', 20 );
+
+/**
  * Update allowed inline style attributes list.
  *
  * Note: This should be removed when the minimum required WP version is >= 5.8.

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -208,7 +208,17 @@ add_action( 'init', 'gutenberg_register_data_persistence_user_meta' );
 function gutenberg_user_settings_data_persistence_inline_script() {
 	global $wp_scripts, $wpdb;
 
-	$user_id         = get_current_user_id();
+	$user_id = get_current_user_id();
+	if ( empty( $user_id ) ) {
+		/*
+		 * In most cases, it should be expected that this would only be reached
+		 * while logged in and viewing the block editor. However, there may be
+		 * edge cases where a plugin is calling to enqueue block assets outside
+		 * the editor and when a user may not be logged in.
+		 */
+		return;
+	}
+
 	$persisted_value = get_user_meta( $user_id, $wpdb->get_blog_prefix() . 'data_persistence', true );
 	if ( empty( $persisted_value ) ) {
 		// If there's no explicit metadata assigned, fall back to a value which

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -221,14 +221,18 @@ function gutenberg_user_settings_data_persistence_inline_script() {
 
 	$persisted_value = get_user_meta( $user_id, $wpdb->get_blog_prefix() . 'data_persistence', true );
 	if ( empty( $persisted_value ) ) {
-		// If there's no explicit metadata assigned, fall back to a value which
-		// was persisted using browser storage, prior to user meta persistence.
+		/*
+		 * If there's no explicit metadata assigned, fall back to a value which
+		 * was persisted using browser storage, prior to user meta persistence.
+		 */
 		$persisted_value = sprintf( 'localStorage.getItem( "WP_DATA_USER_%s" );', $user_id );
 	} else {
-		// Otherwise, encode the string value for interpolation in the storage
-		// implementation script. The first `json_encode` will is responsible
-		// for producing a JSON encoding of the persisted meta object, and the
-		// second will apply quoting to that string result.
+		/*
+		 * Otherwise, encode the string value for interpolation in the storage
+		 * implementation script. The first `json_encode` will is responsible
+		 * for producing a JSON encoding of the persisted meta object, and the
+		 * second will apply quoting to that string result.
+		 */
 		$persisted_value = wp_json_encode( wp_json_encode( $persisted_value ) );
 	}
 

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -252,7 +252,7 @@ function gutenberg_user_settings_data_persistence_inline_script() {
 				locallyPersistentValues[ key ] = value;
 				wp.apiFetch( {
 					path: '/wp/v2/users/me',
-					method: 'POST',
+					method: 'PUT',
 					data: {
 						meta: {
 							data_persistence: JSON.parse( value ),

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -195,11 +195,17 @@ add_action( 'init', 'gutenberg_register_data_persistence_user_meta' );
 function gutenberg_user_settings_data_persistence_inline_script() {
 	global $wp_scripts;
 
-	$persisted_value = get_user_meta( get_current_user_id(), 'wp_data_persistence', true );
+	$user_id         = get_current_user_id();
+	$persisted_value = get_user_meta( $user_id, 'wp_data_persistence', true );
 	if ( empty( $persisted_value ) ) {
-		$persisted_value = '{}';
+		// If there's no explicit metadata assigned, fall back to a value which
+		// was persisted using browser storage, prior to user meta persistence.
+		$persisted_value = sprintf( 'localStorage.getItem( "WP_DATA_USER_%s" );', $user_id );
+	} else {
+		// Otherwise, encode the string value for interpolation in the storage
+		// implementation script.
+		$persisted_value = json_encode( $persisted_value );
 	}
-	$persisted_value = json_encode( $persisted_value );
 
 	$persistence_script = <<<JS
 ( function() {


### PR DESCRIPTION
Closes #15105

This pull request seeks to implement a custom data persistence storage implementation for the purpose of storing preferences via user metadata. This uses existing REST API functionality for updating metadata via a registered meta key. The storage implementation bootstraps the stored metadata value for use in the initialization of the store. When a preference update occurs, it is saved to the REST API using the users endpoint for the current user.

**Implementation Notes:**

- From a data permissions perspective, it isn't clear to me whether we should want this data to be shown to anyone but the current user. The users endpoint does require higher capabilities in order to retrieve details about other users on the site, but even then, the preferences specific to a user seem to be information which isn't necessary to include on the endpoint except for the current user. Searching through [the implementation of REST API meta fields handling](https://github.com/WordPress/wordpress-develop/blob/master/src/wp-includes/rest-api/fields/class-wp-rest-meta-fields.php), there doesn't seem to be very many options for such explicit control over this behavior, except via the `prepare_value` property of `show_in_rest`, which still isn't provided with the specific user ID of the meta value being served (in order to distinguish whether it should be served based on matching the current user). I may be over-thinking this, and it may be perfectly fine to assume that if a user has permissions to request details of other users on the site, they should also be permitted to view persisted preferences details of that user.
- This does not yet handle site-specific settings, which could be implemented in a future pull request. It is not yet clear how we would want to express this from a store that persists state values in a way which could be generalized. I expect if this were needed, it could apply as a post-processing transform on the metadata save, where filtering occurs on the saved metadata to "pick" values which should apply specific to the current site.

**Follow-up Tasks:**

At the earliest opportunity, this code should be migrated into the core codebase.

The inline script should take the place of this segment of code:

https://github.com/WordPress/wordpress-develop/blob/8a88cfa/src/wp-includes/script-loader.php#L679-L693

As far as I can find, there is no prior art for explicit meta registration in core. Most meta is not referenced without being registered. This meta value must be registered in order for it to be accessible via the REST API. It's unclear to me where this should reside in the core codebase (`rest-api.php`? something akin to `post.php`'s `create_initial_post_types`, but for users and their meta?).

**Testing Instructions:**

1. Navigate to Posts > Add New
2. Note that the Welcome modal is not shown, because there is backwards-compatibility in place which assures that existing persistence value is preserved.
3. Clear `localStorage` by entering `localStorage.clear()` in your browser console (or [follow these instructions to manage Application Storage in Chrome](https://developers.google.com/web/tools/chrome-devtools/storage/localstorage))
4. Reload the page
5. Note that the Welcome modal is shown
6. Dismiss the Welcome modal
7. Reload the page
8. Note that the Welcome modal is not shown, because the preference has persisted from prior to the reload (this time using user meta)
9. In your browser's "Private Browsing" ("Incognito") mode, log in and navigate to Posts > Add New
10. Note that the Welcome modal is still not shown