### PR TITLE
Framework: Migrate/remove temporary compatibility script initialization

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -432,19 +432,6 @@ add_action( 'wp_default_styles', 'gutenberg_register_packages_styles' );
  * @since 0.1.0
  */
 function gutenberg_enqueue_block_editor_assets() {
-	wp_add_inline_script(
-		'wp-api-fetch',
-		sprintf(
-			'wp.apiFetch.nonceMiddleware = wp.apiFetch.createNonceMiddleware( "%s" );' .
-			'wp.apiFetch.use( wp.apiFetch.nonceMiddleware );' .
-			'wp.apiFetch.nonceEndpoint = "%s";' .
-			'wp.apiFetch.use( wp.apiFetch.mediaUploadMiddleware );',
-			( wp_installing() && ! is_multisite() ) ? '' : wp_create_nonce( 'wp_rest' ),
-			admin_url( 'admin-ajax.php?action=gutenberg_rest_nonce' )
-		),
-		'after'
-	);
-
 	if ( defined( 'GUTENBERG_LIVE_RELOAD' ) && GUTENBERG_LIVE_RELOAD ) {
 		$live_reload_url = ( GUTENBERG_LIVE_RELOAD === true ) ? 'http://localhost:35729/livereload.js' : GUTENBERG_LIVE_RELOAD;
 


### PR DESCRIPTION
This pull request seeks to...

1. ~Remove a persistence script initialization which was incorporated in core as part of WordPress 5.2.0~ **Edit:** This was removed separately as part of #18981.
   - See: https://core.trac.wordpress.org/ticket/46429
   - This can be removed because the plugin currently [requires WordPress 5.2.0 and newer](https://github.com/WordPress/gutenberg/blob/ab8af23410f9f89f5a57064b43758b157f392d55/readme.txt#L3).
2. ~Migrate remaining compatibility scripts to `compat.php` with notes relevant for future removal. This affects API fetch nonce middleware, media upload middleware.~ **Edit:** This is now removed altogether in this branch. It was originally slated for removal once support reached WordPress 5.3.0+ minimum (see original commit 3aac8162f786e139daf350bdf4454f863fb5e82b and associated Trac tickets [Trac#48310](https://core.trac.wordpress.org/ticket/48310) and [Trac#48076](https://core.trac.wordpress.org/ticket/48076)). Since version support was bumped in #20628 to 5.3.0, it can be assumed to be safely removed.

**Implementation Notes:**

_(**Edit:** This section does not apply anymore per latest updates)_

The rationale for this change is based on the assumption that `client-assets.php` should be used for the bootstrapping of scripts relevant for Gutenberg, notably:

- Overriding core WordPress and vendor scripts
- Overriding core editor initialization

These scripts will always need to exist in the plugin.

Conversely, scripts and filtering which serve a temporary purpose should be isolated in a way that it can be easily removed in future versions as compatibility requirements change. Currently, these are maintained in the `lib/compat.php` file. 

**Testing Instructions:**

Verify there are no regressions in the behavior of the nonce middleware, media uploads.

