### PR TITLE
[RNMobile][Experimental][styled-components] Add button primitive

### DIFF
--- a/packages/block-editor/src/components/block-list/breadcrumb.native.js
+++ b/packages/block-editor/src/components/block-list/breadcrumb.native.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { Icon } from '@wordpress/components';
+import { Icon, StyledPrimitives } from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 import { getBlockType } from '@wordpress/blocks';
@@ -9,7 +9,7 @@ import { getBlockType } from '@wordpress/blocks';
 /**
  * External dependencies
  */
-import { View, Text, TouchableOpacity } from 'react-native';
+import { View, Text } from 'react-native';
 
 /**
  * Internal dependencies
@@ -22,7 +22,11 @@ import styles from './breadcrumb.scss';
 const BlockBreadcrumb = ( { clientId, blockIcon, rootClientId, rootBlockIcon } ) => {
 	return (
 		<View style={ styles.breadcrumbContainer }>
-			<TouchableOpacity style={ styles.button } onPress={ () => {/* Open BottomSheet with markup */} }>
+			<StyledPrimitives.Button
+				flexDirection="row"
+				alignItems="center"
+				onPress={ () => {/* Open BottomSheet with markup */} }
+			>
 				{ rootClientId && rootBlockIcon && (
 					[ <Icon key="parent-icon" size={ 20 } icon={ rootBlockIcon.src } fill={ styles.icon.color } />,
 						<View key="subdirectory-icon" style={ styles.arrow }><SubdirectorSVG fill={ styles.arrow.color } /></View>,
@@ -30,7 +34,7 @@ const BlockBreadcrumb = ( { clientId, blockIcon, rootClientId, rootBlockIcon } )
 				) }
 				<Icon size={ 24 } icon={ blockIcon.src } fill={ styles.icon.color } />
 				<Text style={ styles.breadcrumbTitle }><BlockTitle clientId={ clientId } /></Text>
-			</TouchableOpacity>
+			</StyledPrimitives.Button>
 		</View>
 	);
 };

--- a/packages/block-editor/src/components/button-block-appender/index.native.js
+++ b/packages/block-editor/src/components/button-block-appender/index.native.js
@@ -25,6 +25,8 @@ function ButtonBlockAppender( { rootClientId, getStylesFromColorScheme } ) {
 				rootClientId={ rootClientId }
 				renderToggle={ ( { onToggle, disabled, isOpen } ) => (
 					<Button
+						isLarge
+						isPrimary
 						onClick={ onToggle }
 						aria-expanded={ isOpen }
 						disabled={ disabled }

--- a/packages/components/src/button/index.native.js
+++ b/packages/components/src/button/index.native.js
@@ -57,11 +57,23 @@ export function Button( props ) {
 		fixedRatio = true,
 		getStylesFromColorScheme,
 		isPressed,
+		isLarge,
+		isSmall,
+		isPrimary,
 		'aria-disabled': ariaDisabled,
 		'aria-label': ariaLabel,
 		'data-subscript': subscript,
 		...otherProps
 	} = props;
+
+	// Support some of props from the web just to demonstrate.
+	// The markup is a bit different than on web and we style the View inside the Touchable instead.
+	let pd = 3;
+	if ( isSmall ) {
+		pd = 8;
+	} else if ( isLarge ) {
+		pd = 12;
+	}
 
 	const isDisabled = ariaDisabled || disabled;
 
@@ -97,7 +109,9 @@ export function Button( props ) {
 			accessibilityHint={ hint }
 			onPress={ onClick }
 			flex={ 1 }
-			pd={ 3 }
+			p={ pd }
+			color={ isPrimary && 'white' }
+			backgroundColor={ isPrimary && 'primary' }
 			justifyContent={ 'center' }
 			alignItems={ 'center' }
 			disabled={ isDisabled }
@@ -106,9 +120,9 @@ export function Button( props ) {
 			<View style={ buttonViewStyle }>
 				{ newChildren }
 				{ subscript &&
-				( <Text style={ [ subscriptDefault, isPressed && styles.subscriptActive ] }>
-					{ subscript }
-				</Text> )
+					( <Text style={ [ subscriptDefault, isPressed && styles.subscriptActive ] }>
+						{ subscript }
+					</Text> )
 				}
 			</View>
 		</PrimitiveButton>

--- a/packages/components/src/button/index.native.js
+++ b/packages/components/src/button/index.native.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { StyleSheet, TouchableOpacity, Text, View, Platform } from 'react-native';
+import { StyleSheet, Text, View, Platform } from 'react-native';
 
 /**
  * WordPress dependencies
@@ -9,17 +9,16 @@ import { StyleSheet, TouchableOpacity, Text, View, Platform } from 'react-native
 import { Children, cloneElement } from '@wordpress/element';
 import { withPreferredColorScheme } from '@wordpress/compose';
 
+/**
+ * Internal dependencies
+ */
+import { Button as PrimitiveButton } from '../styled-primitives/button';
+
 const isAndroid = Platform.OS === 'android';
 const marginBottom = isAndroid ? -0.5 : 0;
 const marginLeft = -3;
 
 const styles = StyleSheet.create( {
-	container: {
-		flex: 1,
-		padding: 3,
-		justifyContent: 'center',
-		alignItems: 'center',
-	},
 	buttonInactive: {
 		flex: 1,
 		flexDirection: 'row',
@@ -97,7 +96,7 @@ export function Button( props ) {
 	} );
 
 	return (
-		<TouchableOpacity
+		<PrimitiveButton
 			activeOpacity={ 0.7 }
 			accessible={ true }
 			accessibilityLabel={ ariaLabel }
@@ -105,7 +104,10 @@ export function Button( props ) {
 			accessibilityRole={ 'button' }
 			accessibilityHint={ hint }
 			onPress={ onClick }
-			style={ styles.container }
+			flex={ 1 }
+			pd={ 3 }
+			justifyContent={ 'center' }
+			alignItems={ 'center' }
 			disabled={ isDisabled }
 		>
 			<View style={ buttonViewStyle }>
@@ -114,7 +116,7 @@ export function Button( props ) {
 					{ subscript && ( <Text style={ isPressed ? styles.subscriptActive : subscriptInactive }>{ subscript }</Text> ) }
 				</View>
 			</View>
-		</TouchableOpacity>
+		</PrimitiveButton>
 	);
 }
 

--- a/packages/components/src/button/index.native.js
+++ b/packages/components/src/button/index.native.js
@@ -16,10 +16,9 @@ import { Button as PrimitiveButton } from '../styled-primitives/button';
 
 const isAndroid = Platform.OS === 'android';
 const marginBottom = isAndroid ? -0.5 : 0;
-const marginLeft = -3;
 
 const styles = StyleSheet.create( {
-	buttonInactive: {
+	button: {
 		flex: 1,
 		flexDirection: 'row',
 		justifyContent: 'center',
@@ -29,32 +28,23 @@ const styles = StyleSheet.create( {
 		aspectRatio: 1,
 	},
 	buttonActive: {
-		flex: 1,
-		flexDirection: 'row',
-		justifyContent: 'center',
-		alignItems: 'center',
 		borderRadius: 6,
 		borderColor: '#2e4453',
 		backgroundColor: '#2e4453',
 	},
-	subscriptInactive: {
+	subscript: {
 		color: '#7b9ab1',
 		fontWeight: 'bold',
 		fontSize: 13,
 		alignSelf: 'flex-end',
-		marginLeft,
+		marginLeft: -3,
 		marginBottom,
 	},
-	subscriptInactiveDark: {
+	subscriptDark: {
 		color: '#a7aaad', // $gray_20
 	},
 	subscriptActive: {
 		color: 'white',
-		fontWeight: 'bold',
-		fontSize: 13,
-		alignSelf: 'flex-end',
-		marginLeft,
-		marginBottom,
 	},
 } );
 
@@ -75,11 +65,12 @@ export function Button( props ) {
 
 	const isDisabled = ariaDisabled || disabled;
 
-	const buttonViewStyle = {
-		opacity: isDisabled ? 0.3 : 1,
-		...( fixedRatio && styles.fixedRatio ),
-		...( isPressed ? styles.buttonActive : styles.buttonInactive ),
-	};
+	const buttonViewStyle = [
+		styles.button,
+		{ opacity: isDisabled ? 0.3 : 1 },
+		fixedRatio && styles.fixedRatio,
+		isPressed && styles.buttonActive,
+	];
 
 	const states = [];
 	if ( isPressed ) {
@@ -90,7 +81,7 @@ export function Button( props ) {
 		states.push( 'disabled' );
 	}
 
-	const subscriptInactive = getStylesFromColorScheme( styles.subscriptInactive, styles.subscriptInactiveDark );
+	const subscriptDefault = getStylesFromColorScheme( styles.subscript, styles.subscriptDark );
 
 	const newChildren = Children.map( children, ( child ) => {
 		return child ? cloneElement( child, { colorScheme: props.preferredColorScheme, isPressed } ) : child;
@@ -113,10 +104,12 @@ export function Button( props ) {
 			{ ...otherProps }
 		>
 			<View style={ buttonViewStyle }>
-				<View style={ { flexDirection: 'row' } }>
-					{ newChildren }
-					{ subscript && ( <Text style={ isPressed ? styles.subscriptActive : subscriptInactive }>{ subscript }</Text> ) }
-				</View>
+				{ newChildren }
+				{ subscript &&
+				( <Text style={ [ subscriptDefault, isPressed && styles.subscriptActive ] }>
+					{ subscript }
+				</Text> )
+				}
 			</View>
 		</PrimitiveButton>
 	);

--- a/packages/components/src/button/index.native.js
+++ b/packages/components/src/button/index.native.js
@@ -70,6 +70,7 @@ export function Button( props ) {
 		'aria-disabled': ariaDisabled,
 		'aria-label': ariaLabel,
 		'data-subscript': subscript,
+		...otherProps
 	} = props;
 
 	const isDisabled = ariaDisabled || disabled;
@@ -109,6 +110,7 @@ export function Button( props ) {
 			justifyContent={ 'center' }
 			alignItems={ 'center' }
 			disabled={ isDisabled }
+			{ ...otherProps }
 		>
 			<View style={ buttonViewStyle }>
 				<View style={ { flexDirection: 'row' } }>

--- a/packages/components/src/index.native.js
+++ b/packages/components/src/index.native.js
@@ -29,6 +29,7 @@ export { default as withFocusOutside } from './higher-order/with-focus-outside';
 export { default as withFocusReturn } from './higher-order/with-focus-return';
 export { default as withNotices } from './higher-order/with-notices';
 export { default as withSpokenMessages } from './higher-order/with-spoken-messages';
+export { withTheme, default as ThemeProvider } from './theme-provider';
 
 // Mobile Components
 export { default as BottomSheet } from './mobile/bottom-sheet';
@@ -37,3 +38,6 @@ export { default as KeyboardAvoidingView } from './mobile/keyboard-avoiding-view
 export { default as KeyboardAwareFlatList } from './mobile/keyboard-aware-flat-list';
 export { default as Picker } from './mobile/picker';
 export { default as ReadableContentView } from './mobile/readable-content-view';
+
+// Styled Primitives
+export { default as StyledPrimitives, styled } from './styled-primitives';

--- a/packages/components/src/styled-primitives/button/index.native.js
+++ b/packages/components/src/styled-primitives/button/index.native.js
@@ -6,7 +6,7 @@ import styled from 'styled-components/native';
 import { color, space, layout, flexbox, background, border, position, shadow }
 	from 'styled-system';
 
-export const Button = styled.TouchableWithoutFeedback`
+export const Button = styled.TouchableOpacity`
 ${ color }
 ${ space }
 ${ layout }

--- a/packages/components/src/styled-primitives/button/index.native.js
+++ b/packages/components/src/styled-primitives/button/index.native.js
@@ -1,0 +1,18 @@
+
+/**
+ * External dependencies
+ */
+import styled from 'styled-components/native';
+import { color, space, layout, flexbox, background, border, position, shadow }
+	from 'styled-system';
+
+export const Button = styled.TouchableWithoutFeedback`
+${ color }
+${ space }
+${ layout }
+${ flexbox }
+${ background }
+${ border }
+${ position }
+${ shadow }
+`;

--- a/packages/components/src/styled-primitives/index.native.js
+++ b/packages/components/src/styled-primitives/index.native.js
@@ -1,0 +1,13 @@
+/**
+ * External dependencies
+ */
+export { default as styled } from 'styled-components/native';
+
+/**
+ * Internal dependencies
+ */
+import { Button } from './button';
+
+export default {
+	Button,
+};

--- a/packages/edit-post/src/editor.native.js
+++ b/packages/edit-post/src/editor.native.js
@@ -13,7 +13,7 @@ import { EditorProvider } from '@wordpress/editor';
 import { parse, serialize } from '@wordpress/blocks';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
-import { SlotFillProvider } from '@wordpress/components';
+import { SlotFillProvider, ThemeProvider } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -133,7 +133,9 @@ class Editor extends Component {
 					useSubRegistry={ false }
 					{ ...props }
 				>
-					<Layout setTitleRef={ this.setTitleRef } />
+					<ThemeProvider>
+						<Layout setTitleRef={ this.setTitleRef } />
+					</ThemeProvider>
 				</EditorProvider>
 			</SlotFillProvider>
 		);


### PR DESCRIPTION
## Description
This is an exploration of x-platform style system. https://github.com/wordpress-mobile/gutenberg-mobile/issues/1411
This is the second iteration on https://github.com/wordpress-mobile/gutenberg-mobile/issues/1386

In this PR I used `styled-system` with `styled-components` to create a primitive Button component that can be used in web and mobile and can be styled via props. That PR contains the mobile part.

- I added the `button` primitive component (`TouchableOpacity`) that can be used with `styled-system`
- I added the theme provider and theme values (they can be a bit outdated since I took them from my previous PR https://github.com/WordPress/gutenberg/pull/17614 )
- I used created primitive in `@components/Button`
- I added `isSmall`, `isLarge` and `isPrimary` props and set button style related to them (just to demonstrate)
- I used Button primitive in breadcrumbs
- I set `isLarge` and `isPrimary` to `@components/Button` in `ButtonBlockAppender` component to demonstrate they work :)

## How has this been tested?
- Run `gutenberg-mobile` app
- All buttons should look the same as before
- Check if breadcrumbs are rendered properly
- Check if block appender has `blue` background and additional padding (because of `isLarge` and `isPrimary`)

## Screenshots <!-- if applicable -->
### without `isLarge` and `isPrimary`
![Simulator Screen Shot - iPhone X - 2019-12-16 at 12 06 35](https://user-images.githubusercontent.com/16336501/71001923-8be39d80-20de-11ea-8ead-3ff2cd097156.png)

### with `isLarge` and `isPrimary`
![Simulator Screen Shot - iPhone X - 2019-12-16 at 13 52 30](https://user-images.githubusercontent.com/16336501/71001973-a61d7b80-20de-11ea-9941-b9b4f4a4fc3e.png)
## Types of changes
Experimenting with `styled-components` and `styled-system`



