### PR TITLE
Try/group block custom text color

### DIFF
--- a/packages/block-library/src/group/block.json
+++ b/packages/block-library/src/group/block.json
@@ -8,6 +8,9 @@
 		"customBackgroundColor": {
 			"type": "string"
 		},
+		"textColor": {
+			"type": "string"
+		},
 		"customTextColor": {
 			"type": "string"
 		}

--- a/packages/block-library/src/group/block.json
+++ b/packages/block-library/src/group/block.json
@@ -7,6 +7,9 @@
 		},
 		"customBackgroundColor": {
 			"type": "string"
+		},
+		"customTextColor": {
+			"type": "string"
 		}
 	}
 }

--- a/packages/block-library/src/group/edit.js
+++ b/packages/block-library/src/group/edit.js
@@ -58,24 +58,29 @@ function GroupEdit( {
 		'has-background': !! backgroundColor.color,
 	} );
 
-	const colorSettings = [
-		{
-			value: backgroundColor.color,
-			onChange: setBackgroundColor,
-			label: __( 'Background Color' ),
-		},
-	];
+	const backgroundColorSettings = {
+		value: backgroundColor.color,
+		onChange: setBackgroundColor,
+		label: __( 'Background Color' ),
+	};
+
+	let colorSettings;
 
 	if ( ! backgroundColor.name && ! backgroundColor.class ) {
-		const textContrastColor = getTextContrast( backgroundColor.color );
+		const textContrastColor = textColor && textColor.color ? textColor.color : getTextContrast( backgroundColor.color );
 		setTextColor( textContrastColor );
-		colorSettings.push( {
-			value: textContrastColor,
-			onChange: setTextColor,
-			label: __( 'Text Color' ),
-		} );
+		colorSettings = [
+			{
+				value: textContrastColor,
+				onChange: setTextColor,
+				label: __( 'Text Color' ),
+				colors: null,
+			},
+			backgroundColorSettings,
+		];
 	} else {
 		setTextColor( null );
+		colorSettings = [ backgroundColorSettings ];
 	}
 
 	return (

--- a/packages/block-library/src/group/edit.js
+++ b/packages/block-library/src/group/edit.js
@@ -1,95 +1,51 @@
 /**
- * External dependencies
- */
-import classnames from 'classnames';
-import tinycolor from 'tinycolor2';
-
-/**
  * WordPress dependencies
  */
 import { withSelect } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
-import { __ } from '@wordpress/i18n';
 import {
-	InspectorControls,
 	InnerBlocks,
-	PanelColorSettings,
-	withColors,
+	__experimentalUseColors,
 } from '@wordpress/block-editor';
 
-function hasCustomBackgroundColor( backgroundColor ) {
-	return ! backgroundColor.name && ! backgroundColor.class;
-}
-
-function hasCustomTextColor( textColor ) {
-	return textColor && tinycolor( textColor.color ).getFormat() === 'hex';
-}
-
-function getTextColor( textColor, backgroundColor ) {
-	if ( ! hasCustomTextColor( textColor ) ) {
-		return tinycolor( backgroundColor.color ).isDark() ? 'white' : 'black';
-	}
-	return textColor ? textColor.color : null;
-}
-
 function GroupEdit( {
-	className,
-	setBackgroundColor,
-	backgroundColor,
-	setTextColor,
-	textColor,
 	hasInnerBlocks,
 } ) {
-	const styles = {
-		backgroundColor: backgroundColor.color,
-		color: textColor.color,
-	};
-
-	const classes = classnames( className, backgroundColor.class, {
-		'has-background': !! backgroundColor.color,
-	} );
-
-	const colorSettings = [ {
-		value: backgroundColor.color,
-		onChange: setBackgroundColor,
-		label: __( 'Background Color' ),
-	} ];
-
-	if ( hasCustomBackgroundColor( backgroundColor ) ) {
-		const textContrastColor = getTextColor( textColor, backgroundColor );
-		setTextColor( textContrastColor );
-
-		colorSettings.push( {
-			value: textContrastColor,
-			onChange: setTextColor,
-			label: __( 'Text Color' ),
-			colors: null,
-		} );
-	} else {
-		setTextColor( null );
-	}
+	const {
+		TextColor,
+		BackgroundColor,
+		InspectorControlsColorPanel,
+		ColorDetector,
+	} = __experimentalUseColors(
+		[
+			{ name: 'textColor', property: 'color' },
+			{ name: 'backgroundColor', className: 'has-background' },
+		],
+		{
+			contrastCheckers: [ { backgroundColor: true, textColor: true } ],
+		}
+	);
 
 	return (
 		<>
-			<InspectorControls>
-				<PanelColorSettings
-					title={ __( 'Color Settings' ) }
-					colorSettings={ colorSettings }
-				/>
-			</InspectorControls>
-			<div className={ classes } style={ styles }>
-				<div className="wp-block-group__inner-container">
-					<InnerBlocks
-						renderAppender={ ! hasInnerBlocks && InnerBlocks.ButtonBlockAppender }
-					/>
-				</div>
-			</div>
+			{ InspectorControlsColorPanel }
+			<BackgroundColor>
+				<TextColor>
+					<ColorDetector querySelector=".wp-block-group" />
+					<div className="wp-block-group" >
+						<div className="wp-block-group__inner-container" >
+							<InnerBlocks
+								renderAppender={ ! hasInnerBlocks && InnerBlocks.ButtonBlockAppender }
+							/>
+						</div>
+					</div>
+				</TextColor>
+			</BackgroundColor>
 		</>
 	);
 }
 
 export default compose( [
-	withColors( 'backgroundColor', 'textColor' ),
 	withSelect( ( select, { clientId } ) => {
 		const {
 			getBlock,

--- a/packages/block-library/src/group/edit.js
+++ b/packages/block-library/src/group/edit.js
@@ -16,32 +16,74 @@ import {
 	withColors,
 } from '@wordpress/block-editor';
 
+function getTextContrast( hexcolor ) {
+	// If a leading # is provided, remove it
+	if ( hexcolor.slice( 0, 1 ) === '#' ) {
+		hexcolor = hexcolor.slice( 1 );
+	}
+
+	// If a three-character hexcode, make six-character
+	if ( hexcolor.length === 3 ) {
+		hexcolor = hexcolor.split( '' ).map( function( hex ) {
+			return hex + hex;
+		} ).join( '' );
+	}
+
+	// Convert to RGB value
+	const r = parseInt( hexcolor.substr( 0, 2 ), 16 );
+	const g = parseInt( hexcolor.substr( 2, 2 ), 16 );
+	const b = parseInt( hexcolor.substr( 4, 2 ), 16 );
+
+	// Get YIQ ratio
+	const yiq = ( ( r * 299 ) + ( g * 587 ) + ( b * 114 ) ) / 1000;
+
+	// Check contrast
+	return ( yiq >= 128 ) ? 'black' : 'white';
+}
+
 function GroupEdit( {
 	className,
 	setBackgroundColor,
 	backgroundColor,
+	setTextColor,
+	textColor,
 	hasInnerBlocks,
 } ) {
 	const styles = {
 		backgroundColor: backgroundColor.color,
+		color: textColor.color,
 	};
 
 	const classes = classnames( className, backgroundColor.class, {
 		'has-background': !! backgroundColor.color,
 	} );
 
+	const colorSettings = [
+		{
+			value: backgroundColor.color,
+			onChange: setBackgroundColor,
+			label: __( 'Background Color' ),
+		},
+	];
+
+	if ( ! backgroundColor.name && ! backgroundColor.class ) {
+		const textContrastColor = getTextContrast( backgroundColor.color );
+		setTextColor( textContrastColor );
+		colorSettings.push( {
+			value: textContrastColor,
+			onChange: setTextColor,
+			label: __( 'Text Color' ),
+		} );
+	} else {
+		setTextColor( null );
+	}
+
 	return (
 		<>
 			<InspectorControls>
 				<PanelColorSettings
 					title={ __( 'Color Settings' ) }
-					colorSettings={ [
-						{
-							value: backgroundColor.color,
-							onChange: setBackgroundColor,
-							label: __( 'Background Color' ),
-						},
-					] }
+					colorSettings={ colorSettings }
 				/>
 			</InspectorControls>
 			<div className={ classes } style={ styles }>
@@ -56,7 +98,7 @@ function GroupEdit( {
 }
 
 export default compose( [
-	withColors( 'backgroundColor' ),
+	withColors( 'backgroundColor', 'textColor' ),
 	withSelect( ( select, { clientId } ) => {
 		const {
 			getBlock,

--- a/packages/block-library/src/group/edit.js
+++ b/packages/block-library/src/group/edit.js
@@ -67,7 +67,7 @@ function GroupEdit( {
 	let colorSettings;
 
 	if ( ! backgroundColor.name && ! backgroundColor.class ) {
-		const textContrastColor = textColor && textColor.color ? textColor.color : getTextContrast( backgroundColor.color );
+		const textContrastColor = getTextContrast( backgroundColor.color );
 		setTextColor( textContrastColor );
 		colorSettings = [
 			{

--- a/packages/block-library/src/group/edit.js
+++ b/packages/block-library/src/group/edit.js
@@ -7,22 +7,24 @@ import {
 	InnerBlocks,
 	__experimentalUseColors,
 } from '@wordpress/block-editor';
+import { useRef } from '@wordpress/element';
 
 function GroupEdit( {
 	hasInnerBlocks,
 } ) {
+	const ref = useRef();
 	const {
 		TextColor,
 		BackgroundColor,
 		InspectorControlsColorPanel,
-		ColorDetector,
 	} = __experimentalUseColors(
 		[
 			{ name: 'textColor', property: 'color' },
 			{ name: 'backgroundColor', className: 'has-background' },
 		],
 		{
-			contrastCheckers: [ { backgroundColor: true, textColor: true } ],
+			contrastCheckers: { backgroundColor: true, textColor: true },
+			colorDetector: { targetRef: ref },
 		}
 	);
 
@@ -31,8 +33,7 @@ function GroupEdit( {
 			{ InspectorControlsColorPanel }
 			<BackgroundColor>
 				<TextColor>
-					<ColorDetector querySelector=".wp-block-group" />
-					<div className="wp-block-group" >
+					<div className="wp-block-group" ref={ ref } >
 						<div className="wp-block-group__inner-container" >
 							<InnerBlocks
 								renderAppender={ ! hasInnerBlocks && InnerBlocks.ButtonBlockAppender }

--- a/packages/block-library/src/group/index.js
+++ b/packages/block-library/src/group/index.js
@@ -25,6 +25,7 @@ export const settings = {
 	example: {
 		attributes: {
 			customBackgroundColor: '#ffffff',
+			customTextColor: '#000000',
 		},
 		innerBlocks: [
 			{

--- a/packages/block-library/src/group/save.js
+++ b/packages/block-library/src/group/save.js
@@ -9,16 +9,18 @@ import classnames from 'classnames';
 import { InnerBlocks, getColorClassName } from '@wordpress/block-editor';
 
 export default function save( { attributes } ) {
-	const { backgroundColor, customBackgroundColor, customTextColor } = attributes;
+	const { backgroundColor, customBackgroundColor, textColor, customTextColor } = attributes;
 
 	const backgroundClass = getColorClassName( 'background-color', backgroundColor );
+	const textClass = getColorClassName( 'color', textColor );
 	const className = classnames( backgroundClass, {
+		'has-text-color': textColor || customTextColor,
 		'has-background': backgroundColor || customBackgroundColor,
 	} );
 
 	const styles = {
 		backgroundColor: backgroundClass ? undefined : customBackgroundColor,
-		color: customTextColor ? customTextColor : null,
+		color: textClass ? undefined : customTextColor,
 	};
 
 	return (

--- a/packages/block-library/src/group/save.js
+++ b/packages/block-library/src/group/save.js
@@ -9,7 +9,7 @@ import classnames from 'classnames';
 import { InnerBlocks, getColorClassName } from '@wordpress/block-editor';
 
 export default function save( { attributes } ) {
-	const { backgroundColor, customBackgroundColor } = attributes;
+	const { backgroundColor, customBackgroundColor, customTextColor } = attributes;
 
 	const backgroundClass = getColorClassName( 'background-color', backgroundColor );
 	const className = classnames( backgroundClass, {
@@ -18,6 +18,7 @@ export default function save( { attributes } ) {
 
 	const styles = {
 		backgroundColor: backgroundClass ? undefined : customBackgroundColor,
+		color: customTextColor ? customTextColor : null,
 	};
 
 	return (


### PR DESCRIPTION
## Description

With the current group block, if a custom background colour is selected that does not contrast well with the text in child blocks there is no way to rectify this other than applying a suitable text colour to every child block within the group 

This PR adds a  text colour selector to the Group Block inspector controls in addition to the background colour selector. It also refactors the block to use the new useColors hook instead of withColours

The text colour gets applied to the children by the default css cascade, so applying a text colour to to a child block, at any level of nesting, will override the colour set on the parent group block, and moving the child block out of the parent will also remove the colour. 

Possible additions for follow on PRs, based on feedback to-date:

- Indicate in some way in the child component that a colour is being inherited from the parent
- Automatically select a contrasting text colour if a custom background colour is selected - but it would probably make more sense to add this as an option in the useColors hook than in this specific component

## How has this been tested?

Tested manually by: 

Adding children to a group block at multiple levels of nesting and making sure that text colour apply to group block is applied to text of children, and that any colour applied to child blocks overrides text colour from parent group block
Adding a group block from existing master branch and then opening/editing/saving to make sure there are no backwards compatibility issues.

If there is approval to proceed with this I will see what automated tests might make sense to add.

## Screenshots 

Before:

![tcolour-before](https://user-images.githubusercontent.com/3629020/70932024-99c4fe80-209d-11ea-81cb-ec392c94c8ae.gif)

After:

![manual-text](https://user-images.githubusercontent.com/3629020/71054945-b99d1500-21b8-11ea-8ebb-a0eb211909cc.gif)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows the accessibility standards. 
- [  ] My code has proper inline documentation.
- [  ] I've included developer documentation if appropriate. 
- [  ] I've updated all React Native files affected by any refactorings/renamings in this PR.

Fixes https://github.com/Automattic/wp-calypso/issues/37051
Closes #18530