### PR TITLE
Update: Round position attributes on cover focal point save

### DIFF
--- a/packages/block-library/src/cover/deprecated.js
+++ b/packages/block-library/src/cover/deprecated.js
@@ -11,6 +11,8 @@ import { createBlock } from '@wordpress/blocks';
 import {
 	RichText,
 	getColorClassName,
+	InnerBlocks,
+	__experimentalGetGradientClass,
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 
@@ -55,6 +57,95 @@ const blockAttributes = {
 };
 
 const deprecated = [
+	{
+		attributes: {
+			...blockAttributes,
+			title: {
+				type: 'string',
+				source: 'html',
+				selector: 'p',
+			},
+			contentAlign: {
+				type: 'string',
+				default: 'center',
+			},
+			minHeight: {
+				type: 'number',
+			},
+			gradient: {
+				type: 'string',
+			},
+			customGradient: {
+				type: 'string',
+			},
+		},
+		save( { attributes } ) {
+			const {
+				backgroundType,
+				gradient,
+				customGradient,
+				customOverlayColor,
+				dimRatio,
+				focalPoint,
+				hasParallax,
+				overlayColor,
+				url,
+				minHeight,
+			} = attributes;
+			const overlayColorClass = getColorClassName( 'background-color', overlayColor );
+			const gradientClass = __experimentalGetGradientClass( gradient );
+
+			const style = backgroundType === IMAGE_BACKGROUND_TYPE ?
+				backgroundImageStyles( url ) :
+				{};
+			if ( ! overlayColorClass ) {
+				style.backgroundColor = customOverlayColor;
+			}
+			if ( focalPoint && ! hasParallax ) {
+				style.backgroundPosition = `${ focalPoint.x * 100 }% ${ focalPoint.y * 100 }%`;
+			}
+			if ( customGradient && ! url ) {
+				style.background = customGradient;
+			}
+			style.minHeight = minHeight || undefined;
+
+			const classes = classnames(
+				dimRatioToClass( dimRatio ),
+				overlayColorClass,
+				{
+					'has-background-dim': dimRatio !== 0,
+					'has-parallax': hasParallax,
+					'has-background-gradient': customGradient,
+					[ gradientClass ]: ! url && gradientClass,
+				},
+			);
+
+			return (
+				<div className={ classes } style={ style }>
+					{ url && ( gradient || customGradient ) && dimRatio !== 0 && (
+						<span
+							aria-hidden="true"
+							className={ classnames(
+								'wp-block-cover__gradient-background',
+								gradientClass
+							) }
+							style={ customGradient ? { background: customGradient } : undefined }
+						/>
+					) }
+					{ VIDEO_BACKGROUND_TYPE === backgroundType && url && ( <video
+						className="wp-block-cover__video-background"
+						autoPlay
+						muted
+						loop
+						src={ url }
+					/> ) }
+					<div className="wp-block-cover__inner-container">
+						<InnerBlocks.Content />
+					</div>
+				</div>
+			);
+		},
+	},
 	{
 		attributes: {
 			...blockAttributes,

--- a/packages/block-library/src/cover/save.js
+++ b/packages/block-library/src/cover/save.js
@@ -45,7 +45,7 @@ export default function save( { attributes } ) {
 		style.backgroundColor = customOverlayColor;
 	}
 	if ( focalPoint && ! hasParallax ) {
-		style.backgroundPosition = `${ focalPoint.x * 100 }% ${ focalPoint.y * 100 }%`;
+		style.backgroundPosition = `${ Math.round( focalPoint.x * 100 ) }% ${ Math.round( focalPoint.y * 100 ) }%`;
 	}
 	if ( customGradient && ! url ) {
 		style.background = customGradient;

--- a/packages/e2e-tests/fixtures/blocks/core__cover__deprecated-4.html
+++ b/packages/e2e-tests/fixtures/blocks/core__cover__deprecated-4.html
@@ -1,0 +1,9 @@
+<!-- wp:cover {"url":"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==","id":35,"focalPoint":{"x":"0.07","y":"0.07"}} -->
+<div class="wp-block-cover has-background-dim" style="background-image:url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==);background-position:7.000000000000001% 7.000000000000001%">
+	<div class="wp-block-cover__inner-container">
+		<!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
+		<p class="has-text-align-center has-large-font-size"><strong>Cover Block</strong></p>
+		<!-- /wp:paragraph -->
+	</div>
+</div>
+<!-- /wp:cover -->

--- a/packages/e2e-tests/fixtures/blocks/core__cover__deprecated-4.json
+++ b/packages/e2e-tests/fixtures/blocks/core__cover__deprecated-4.json
@@ -1,0 +1,37 @@
+[
+    {
+        "clientId": "_clientId_0",
+        "name": "core/cover",
+        "isValid": true,
+        "attributes": {
+            "url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==",
+            "id": 35,
+            "hasParallax": false,
+            "dimRatio": 50,
+            "backgroundType": "image",
+            "focalPoint": {
+                "x": "0.07",
+                "y": "0.07"
+            },
+            "title": "",
+            "contentAlign": "center"
+        },
+        "innerBlocks": [
+            {
+                "clientId": "_clientId_0",
+                "name": "core/paragraph",
+                "isValid": true,
+                "attributes": {
+                    "align": "center",
+                    "content": "<strong>Cover Block</strong>",
+                    "dropCap": false,
+                    "placeholder": "Write title…",
+                    "fontSize": "large"
+                },
+                "innerBlocks": [],
+                "originalContent": "<p class=\"has-text-align-center has-large-font-size\"><strong>Cover Block</strong></p>"
+            }
+        ],
+        "originalContent": "<div class=\"wp-block-cover has-background-dim\" style=\"background-image:url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==);background-position:7.000000000000001% 7.000000000000001%\">\n\t<div class=\"wp-block-cover__inner-container\">\n\t\t\n\t</div>\n</div>"
+    }
+]

--- a/packages/e2e-tests/fixtures/blocks/core__cover__deprecated-4.parsed.json
+++ b/packages/e2e-tests/fixtures/blocks/core__cover__deprecated-4.parsed.json
@@ -1,0 +1,43 @@
+[
+    {
+        "blockName": "core/cover",
+        "attrs": {
+            "url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==",
+            "id": 35,
+            "focalPoint": {
+                "x": "0.07",
+                "y": "0.07"
+            }
+        },
+        "innerBlocks": [
+            {
+                "blockName": "core/paragraph",
+                "attrs": {
+                    "align": "center",
+                    "placeholder": "Write title…",
+                    "fontSize": "large"
+                },
+                "innerBlocks": [],
+                "innerHTML": "\n\t\t<p class=\"has-text-align-center has-large-font-size\"><strong>Cover Block</strong></p>\n\t\t",
+                "innerContent": [
+                    "\n\t\t<p class=\"has-text-align-center has-large-font-size\"><strong>Cover Block</strong></p>\n\t\t"
+                ]
+            }
+        ],
+        "innerHTML": "\n<div class=\"wp-block-cover has-background-dim\" style=\"background-image:url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==);background-position:7.000000000000001% 7.000000000000001%\">\n\t<div class=\"wp-block-cover__inner-container\">\n\t\t\n\t</div>\n</div>\n",
+        "innerContent": [
+            "\n<div class=\"wp-block-cover has-background-dim\" style=\"background-image:url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==);background-position:7.000000000000001% 7.000000000000001%\">\n\t<div class=\"wp-block-cover__inner-container\">\n\t\t",
+            null,
+            "\n\t</div>\n</div>\n"
+        ]
+    },
+    {
+        "blockName": null,
+        "attrs": {},
+        "innerBlocks": [],
+        "innerHTML": "\n",
+        "innerContent": [
+            "\n"
+        ]
+    }
+]

--- a/packages/e2e-tests/fixtures/blocks/core__cover__deprecated-4.serialized.html
+++ b/packages/e2e-tests/fixtures/blocks/core__cover__deprecated-4.serialized.html
@@ -1,0 +1,5 @@
+<!-- wp:cover {"url":"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==","id":35,"focalPoint":{"x":"0.07","y":"0.07"}} -->
+<div class="wp-block-cover has-background-dim" style="background-image:url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==);background-position:7% 7%"><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
+<p class="has-text-align-center has-large-font-size"><strong>Cover Block</strong></p>
+<!-- /wp:paragraph --></div></div>
+<!-- /wp:cover -->


### PR DESCRIPTION
## Description
As @mmtr noted in https://github.com/WordPress/gutenberg/issues/18665#issuecomment-566097929, the rounding problem on the cover block was not totally fixed. During the save we should also round the value.
This PR fixes the problem and introduces the deprecation logic to keep current blocks valid.

## How has this been tested?
On the master branch, I inserted a cover block with an image background.
I set the focal point coordinates to seven.
I checked on the code view that the background-position was "7.000000000000001%".
I saved the post.
I switched to this branch and reloaded the post.
I verified the block was still valid and in the code editor, I verified the background-position was now 7%.
I inserted another block with 7 as the focal point position and verified in the code editor that the position was 7%.
