### PR TITLE
Embeds: Transform VideoPress <embed> tags into VideoPress blocks.

### DIFF
--- a/packages/block-library/src/embed/core-embeds.js
+++ b/packages/block-library/src/embed/core-embeds.js
@@ -354,6 +354,32 @@ export const others = [
 			icon: embedVideoIcon,
 			keywords: [ __( 'video' ) ],
 			description: __( 'Embed a VideoPress video.' ),
+			transforms: {
+				from: [
+					{
+						type: 'raw',
+						isMatch: ( node ) => {
+							if ( node.nodeName !== 'P' ) {
+								return false;
+							}
+
+							if ( node.childNodes.length !== 1 || node.childNodes[ 0 ].nodeName !== 'EMBED' ) {
+								return false;
+							}
+
+							return /^https?:\/\/v\.wordpress\.com\//i.test( node.childNodes[ 0 ].src );
+						},
+						transform: ( node ) => {
+							return createBlock( 'core-embed/videopress', {
+								url: node.childNodes[ 0 ].src.replace(
+									/^https?:\/\/v\.wordpress\.com\//,
+									'https://videopress.com/v/',
+								),
+							} );
+						},
+					},
+				],
+			},
 		},
 		patterns: [ /^https?:\/\/videopress\.com\/.+/i ],
 	},


### PR DESCRIPTION
## Description

I remember a dark time of the internet. A terrible time, when embedding content was fraught with copy/paste errors, awful HTML hacks, and security issues. Before oEmbed, there was `<embed>`.

As folks go to upgrade old posts to blocks, they're likely to encounter such embeds, and the UX of transforming them to blocks is... sub-optimal. 🙂 I think it's reasonable for us to handle these transforms auto-magically.

I'm wary of creating a generic form for this too early, without more examples of other old embeds that can be transformed. Ideally, however, we should be able to have a property like the `patterns` option for embeds that handles generating the `isMatch` and `transform` functions.

## How has this been tested?

- Create a classic post with an old style VideoPress embed `<embed src="http://v.wordpress.com/KllQxFVq" type="application/x-shockwave-flash" width="600" height="338"></embed>`
- Open that post in the block editor, and convert it to blocks.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows the accessibility standards.
- [x] My code has proper inline documentation.
- [x] I've included developer documentation if appropriate.
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR.