### PR TITLE
Fix/title encoding bug

### DIFF
--- a/packages/editor/src/components/post-title/index.js
+++ b/packages/editor/src/components/post-title/index.js
@@ -123,7 +123,7 @@ class PostTitle extends Component {
 							<Textarea
 								id={ `post-title-${ instanceId }` }
 								className="editor-post-title__input"
-								value={ unescape( title ) }
+								value={ title }
 								onChange={ this.onChange }
 								placeholder={ decodedPlaceholder || __( 'Add title' ) }
 								onFocus={ this.onSelect }

--- a/packages/editor/src/components/post-title/index.js
+++ b/packages/editor/src/components/post-title/index.js
@@ -123,7 +123,7 @@ class PostTitle extends Component {
 							<Textarea
 								id={ `post-title-${ instanceId }` }
 								className="editor-post-title__input"
-								value={ title }
+								value={ decodeEntities( title ) }
 								onChange={ this.onChange }
 								placeholder={ decodedPlaceholder || __( 'Add title' ) }
 								onFocus={ this.onSelect }

--- a/packages/editor/src/components/post-title/index.js
+++ b/packages/editor/src/components/post-title/index.js
@@ -3,7 +3,7 @@
  */
 import Textarea from 'react-autosize-textarea';
 import classnames from 'classnames';
-import { get, escape, unescape } from 'lodash';
+import { get, escape } from 'lodash';
 
 /**
  * WordPress dependencies

--- a/packages/html-entities/src/test/entities.js
+++ b/packages/html-entities/src/test/entities.js
@@ -19,9 +19,9 @@ describe( 'decodeEntities', () => {
 		const expected = 'This post&rsquo;s title.';
 		expect( decodeEntities( html ) ).toEqual( expected );
 	} );
-	it( 'should decode varitions of same entity codes, eg. single quote can be &#39s or &#039;', () => {
-		const html = 'Jim&#039;s post&#39s title.';
-		const expected = 'Jim\'s post\'s title.';
+	it( 'should not care about leading zeros on entity codes', () => {
+		const html = 'Jim&#0039;s mother&#039s post&#39s title.';
+		const expected = 'Jim\'s mother\'s post\'s title.';
 		expect( decodeEntities( html ) ).toEqual( expected );
 	} );
 } );

--- a/packages/html-entities/src/test/entities.js
+++ b/packages/html-entities/src/test/entities.js
@@ -19,4 +19,9 @@ describe( 'decodeEntities', () => {
 		const expected = 'This post&rsquo;s title.';
 		expect( decodeEntities( html ) ).toEqual( expected );
 	} );
+	it( 'should decode varitions of same entity codes, eg. single quote can be &#39s or &#039;', () => {
+		const html = 'Jim&#039;s post&#39s title.';
+		const expected = 'Jim\'s post\'s title.';
+		expect( decodeEntities( html ) ).toEqual( expected );
+	} );
 } );


### PR DESCRIPTION
## Description

The encoding that was recently added to the post title block works fine on standalone wp installs, but not on wpcom - https://github.com/Automattic/wp-calypso/issues/38362  - this is because for some reason wpcom adds leading zeros to the html entity codes, and lodash unescape does not account for this.

Switching from the lodash unescape to WordPress decodeEntities resolves the issue without causing any problems that I can see.

## How has this been tested?
Tested manually, and also added an additional unit test to make sure decodeEntities accounts for leading zeros.

## Screenshots

Before:

<img width="895" alt="encode-before" src="https://user-images.githubusercontent.com/3629020/70954487-47ea9b80-20d2-11ea-8c4a-6ce269dc1d05.png">

After:

<img width="888" alt="encode-after" src="https://user-images.githubusercontent.com/3629020/70954497-5042d680-20d2-11ea-8e87-b6adb08c5c5c.png">


## Types of changes

Change string decoding method

Fixes https://github.com/Automattic/wp-calypso/issues/38362
