### PR TITLE
Try adding more permissive block validation modes

### DIFF
--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -540,7 +540,6 @@ _Parameters_
 -   _blockTypeOrName_ `(string|Object)`: Block type.
 -   _attributes_ `Object`: Parsed block attributes.
 -   _originalBlockContent_ `string`: Original block content.
--   _mode_ `string`: Validation mode.
 
 _Returns_
 

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -540,6 +540,7 @@ _Parameters_
 -   _blockTypeOrName_ `(string|Object)`: Block type.
 -   _attributes_ `Object`: Parsed block attributes.
 -   _originalBlockContent_ `string`: Original block content.
+-   _mode_ `string`: Validation mode.
 
 _Returns_
 

--- a/packages/blocks/src/api/test/validation.js
+++ b/packages/blocks/src/api/test/validation.js
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import { addFilter, removeFilter } from '@wordpress/hooks';
+
+/**
  * Internal dependencies
  */
 import {
@@ -613,6 +618,14 @@ describe( 'validation', () => {
 
 	describe( 'isValidBlockContent()', () => {
 		describe( 'no-save-error', () => {
+			beforeAll( () => {
+				addFilter( 'editor.blockValidationMode', 'testNoSaveError', () => ( 'no-save-error' ) );
+			} );
+
+			afterAll( () => {
+				removeFilter( 'editor.blockValidationMode', 'testNoSaveError' );
+			} );
+
 			it( 'returns true if block serializes but does not match original content', () => {
 				const blockName = 'core/test-block';
 				const blockAttributes = { fruit: 'Bananas' };
@@ -622,7 +635,6 @@ describe( 'validation', () => {
 					blockName,
 					blockAttributes,
 					'Apples',
-					'no-save-error',
 				);
 
 				const blockType = normalizeBlockType( blockName );
@@ -645,7 +657,6 @@ describe( 'validation', () => {
 					'core/test-block',
 					{ fruit: 'Bananas' },
 					'Bananas',
-					'no-save-error',
 				);
 
 				expect( console ).toHaveErrored();
@@ -671,7 +682,6 @@ describe( 'validation', () => {
 					blockName,
 					blockAttributes,
 					'<div class="foo bar baz">Bananas</div>',
-					'no-save-error',
 				);
 
 				const blockType = normalizeBlockType( blockName );
@@ -701,7 +711,6 @@ describe( 'validation', () => {
 					blockName,
 					blockAttributes,
 					'<div class="sugar">Blueberries</div>',
-					'no-save-error',
 				);
 
 				const blockType = normalizeBlockType( blockName );

--- a/packages/blocks/src/api/test/validation.js
+++ b/packages/blocks/src/api/test/validation.js
@@ -612,7 +612,7 @@ describe( 'validation', () => {
 	} );
 
 	describe( 'isValidBlockContent()', () => {
-		describe( 'permissive', () => {
+		describe( 'no-save-error', () => {
 			it( 'returns true if block serializes but does not match original content', () => {
 				const blockName = 'core/test-block';
 				const blockAttributes = { fruit: 'Bananas' };
@@ -622,7 +622,7 @@ describe( 'validation', () => {
 					blockName,
 					blockAttributes,
 					'Apples',
-					'permissive',
+					'no-save-error',
 				);
 
 				const blockType = normalizeBlockType( blockName );
@@ -645,14 +645,14 @@ describe( 'validation', () => {
 					'core/test-block',
 					{ fruit: 'Bananas' },
 					'Bananas',
-					'permissive',
+					'no-save-error',
 				);
 
 				expect( console ).toHaveErrored();
 				expect( isValid ).toBe( false );
 			} );
 		} );
-		describe( 'exact-match', () => {
+		describe( 'strict', () => {
 			it( 'returns false if block is not valid', () => {
 				registerBlockType( 'core/test-block', defaultBlockSettings );
 

--- a/packages/blocks/src/api/test/validation.js
+++ b/packages/blocks/src/api/test/validation.js
@@ -832,6 +832,50 @@ describe( 'validation', () => {
 				expect( getSaveContent( blockType, blockAttributes ) ).toBe( '<div class="bar foo">Bananas</div>' );
 			} );
 
+			it( 'returns false if tags do not match', () => {
+				const blockName = 'core/test-block';
+				const blockAttributes = { fruit: 'Bananas', level: 2 };
+				registerBlockType( blockName, {
+					...defaultBlockSettings,
+					save: ( { attributes } ) => {
+						if ( attributes.level === 1 ) {
+							return (
+								<h1>
+									{ attributes.fruit }
+								</h1>
+							);
+						}
+
+						if ( attributes.level === 2 ) {
+							return (
+								<h2>
+									{ attributes.fruit }
+								</h2>
+							);
+						}
+
+						return (
+							<h3>
+								{ attributes.fruit }
+							</h3>
+						);
+					},
+				} );
+
+				const isValid = isValidBlockContent(
+					blockName,
+					blockAttributes,
+					'<h3 class="foo bar" data-foo="baz">Bananas</h3>',
+				);
+
+				const blockType = normalizeBlockType( blockName );
+
+				expect( console ).toHaveWarned();
+				expect( console ).toHaveErrored();
+				expect( isValid ).toBe( false );
+				expect( getSaveContent( blockType, blockAttributes ) ).toBe( '<h2>Bananas</h2>' );
+			} );
+
 			it( 'returns false if there are floating point rounding errors', () => {
 				const blockName = 'core/test-block';
 				const blockAttributes = { fruit: 'Bananas', x: 0.07, y: 0.07 };

--- a/packages/blocks/src/api/validation/index.js
+++ b/packages/blocks/src/api/validation/index.js
@@ -9,13 +9,13 @@ import {
 	isEqual,
 	includes,
 	stubTrue,
-	get,
 } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { decodeEntities } from '@wordpress/html-entities';
+import { applyFilters } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -601,11 +601,10 @@ export function isEquivalentHTML( actual, expected, logger = createLogger() ) {
  * @param {Object}        attributes           Parsed block attributes.
  * @param {string}        originalBlockContent Original block content.
  * @param {Object}        logger           	   Validation logger object.
- * @param {string}        mode           	   Validation mode.
  *
  * @return {Object} Whether block is valid and contains validation messages.
  */
-export function getBlockContentValidationResult( blockTypeOrName, attributes, originalBlockContent, logger = createQueuedLogger(), mode = ( get( global, [ 'wp', 'blockValidationMode' ], null ) || 'strict' ) ) {
+export function getBlockContentValidationResult( blockTypeOrName, attributes, originalBlockContent, logger = createQueuedLogger() ) {
 	const blockType = normalizeBlockType( blockTypeOrName );
 	let generatedBlockContent;
 	try {
@@ -618,6 +617,13 @@ export function getBlockContentValidationResult( blockTypeOrName, attributes, or
 			validationIssues: logger.getItems(),
 		};
 	}
+
+	/**
+	 * Filters the current block validation mode
+	 *
+	 * @param {string} Validation Mode
+	 */
+	const mode = applyFilters( 'editor.blockValidationMode', 'strict' );
 
 	if ( mode === 'no-save-error' ) {
 		return {
@@ -653,11 +659,10 @@ export function getBlockContentValidationResult( blockTypeOrName, attributes, or
  * @param {string|Object} blockTypeOrName      Block type.
  * @param {Object}        attributes           Parsed block attributes.
  * @param {string}        originalBlockContent Original block content.
- * @param {string}        mode                 Validation mode.
  * @return {boolean} Whether block is valid.
  */
-export function isValidBlockContent( blockTypeOrName, attributes, originalBlockContent, mode = ( get( global, [ 'wp', 'blockValidationMode' ], null ) || 'strict' ) ) {
-	const { isValid } = getBlockContentValidationResult( blockTypeOrName, attributes, originalBlockContent, createLogger(), mode );
+export function isValidBlockContent( blockTypeOrName, attributes, originalBlockContent ) {
+	const { isValid } = getBlockContentValidationResult( blockTypeOrName, attributes, originalBlockContent, createLogger() );
 
 	return isValid;
 }

--- a/packages/blocks/src/api/validation/index.js
+++ b/packages/blocks/src/api/validation/index.js
@@ -600,10 +600,11 @@ export function isEquivalentHTML( actual, expected, logger = createLogger() ) {
  * @param {Object}        attributes           Parsed block attributes.
  * @param {string}        originalBlockContent Original block content.
  * @param {Object}        logger           	   Validation logger object.
+ * @param {string}        mode           	   Validation mode.
  *
  * @return {Object} Whether block is valid and contains validation messages.
  */
-export function getBlockContentValidationResult( blockTypeOrName, attributes, originalBlockContent, logger = createQueuedLogger() ) {
+export function getBlockContentValidationResult( blockTypeOrName, attributes, originalBlockContent, logger = createQueuedLogger(), mode = 'exact-match' ) {
 	const blockType = normalizeBlockType( blockTypeOrName );
 	let generatedBlockContent;
 	try {
@@ -613,6 +614,13 @@ export function getBlockContentValidationResult( blockTypeOrName, attributes, or
 
 		return {
 			isValid: false,
+			validationIssues: logger.getItems(),
+		};
+	}
+
+	if ( mode === 'permissive' ) {
+		return {
+			isValid: true,
 			validationIssues: logger.getItems(),
 		};
 	}
@@ -644,11 +652,11 @@ export function getBlockContentValidationResult( blockTypeOrName, attributes, or
  * @param {string|Object} blockTypeOrName      Block type.
  * @param {Object}        attributes           Parsed block attributes.
  * @param {string}        originalBlockContent Original block content.
- *
+ * @param {string}        mode                 Validation mode.
  * @return {boolean} Whether block is valid.
  */
-export function isValidBlockContent( blockTypeOrName, attributes, originalBlockContent ) {
-	const { isValid } = getBlockContentValidationResult( blockTypeOrName, attributes, originalBlockContent, createLogger() );
+export function isValidBlockContent( blockTypeOrName, attributes, originalBlockContent, mode = 'exact-match' ) {
+	const { isValid } = getBlockContentValidationResult( blockTypeOrName, attributes, originalBlockContent, createLogger(), mode );
 
 	return isValid;
 }

--- a/packages/blocks/src/api/validation/index.js
+++ b/packages/blocks/src/api/validation/index.js
@@ -9,6 +9,7 @@ import {
 	isEqual,
 	includes,
 	stubTrue,
+	get,
 } from 'lodash';
 
 /**
@@ -604,7 +605,7 @@ export function isEquivalentHTML( actual, expected, logger = createLogger() ) {
  *
  * @return {Object} Whether block is valid and contains validation messages.
  */
-export function getBlockContentValidationResult( blockTypeOrName, attributes, originalBlockContent, logger = createQueuedLogger(), mode = 'strict' ) {
+export function getBlockContentValidationResult( blockTypeOrName, attributes, originalBlockContent, logger = createQueuedLogger(), mode = ( get( global, [ 'wp', 'blockValidationMode' ], null ) || 'strict' ) ) {
 	const blockType = normalizeBlockType( blockTypeOrName );
 	let generatedBlockContent;
 	try {
@@ -655,7 +656,7 @@ export function getBlockContentValidationResult( blockTypeOrName, attributes, or
  * @param {string}        mode                 Validation mode.
  * @return {boolean} Whether block is valid.
  */
-export function isValidBlockContent( blockTypeOrName, attributes, originalBlockContent, mode = 'strict' ) {
+export function isValidBlockContent( blockTypeOrName, attributes, originalBlockContent, mode = ( get( global, [ 'wp', 'blockValidationMode' ], null ) || 'strict' ) ) {
 	const { isValid } = getBlockContentValidationResult( blockTypeOrName, attributes, originalBlockContent, createLogger(), mode );
 
 	return isValid;

--- a/packages/blocks/src/api/validation/index.js
+++ b/packages/blocks/src/api/validation/index.js
@@ -604,7 +604,7 @@ export function isEquivalentHTML( actual, expected, logger = createLogger() ) {
  *
  * @return {Object} Whether block is valid and contains validation messages.
  */
-export function getBlockContentValidationResult( blockTypeOrName, attributes, originalBlockContent, logger = createQueuedLogger(), mode = 'exact-match' ) {
+export function getBlockContentValidationResult( blockTypeOrName, attributes, originalBlockContent, logger = createQueuedLogger(), mode = 'strict' ) {
 	const blockType = normalizeBlockType( blockTypeOrName );
 	let generatedBlockContent;
 	try {
@@ -618,7 +618,7 @@ export function getBlockContentValidationResult( blockTypeOrName, attributes, or
 		};
 	}
 
-	if ( mode === 'permissive' ) {
+	if ( mode === 'no-save-error' ) {
 		return {
 			isValid: true,
 			validationIssues: logger.getItems(),
@@ -655,7 +655,7 @@ export function getBlockContentValidationResult( blockTypeOrName, attributes, or
  * @param {string}        mode                 Validation mode.
  * @return {boolean} Whether block is valid.
  */
-export function isValidBlockContent( blockTypeOrName, attributes, originalBlockContent, mode = 'exact-match' ) {
+export function isValidBlockContent( blockTypeOrName, attributes, originalBlockContent, mode = 'strict' ) {
 	const { isValid } = getBlockContentValidationResult( blockTypeOrName, attributes, originalBlockContent, createLogger(), mode );
 
 	return isValid;

--- a/packages/edit-post/src/components/options-modal/index.js
+++ b/packages/edit-post/src/components/options-modal/index.js
@@ -47,6 +47,7 @@ export function OptionsModal( { isModalActive, isViewable, closeModal } ) {
 			<Section title={ __( 'General' ) }>
 				<EnablePublishSidebarOption label={ __( 'Pre-publish Checks' ) } />
 				<EnableFeature feature="showInserterHelpPanel" label={ __( 'Inserter Help Panel' ) } />
+				<EnableFeature feature="noBlockValidation" label={ __( 'Disable Block Validation' ) } />
 			</Section>
 			<Section title={ __( 'Document Panels' ) }>
 				<EnablePluginDocumentSettingPanelOption.Slot />

--- a/packages/edit-post/src/components/options-modal/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/options-modal/test/__snapshots__/index.js.snap
@@ -16,6 +16,10 @@ exports[`OptionsModal should match snapshot when the modal is active 1`] = `
       feature="showInserterHelpPanel"
       label="Inserter Help Panel"
     />
+    <WithSelect(WithDispatch(BaseOption))
+      feature="noBlockValidation"
+      label="Disable Block Validation"
+    />
   </Section>
   <Section
     title="Document Panels"

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -44,6 +44,7 @@ class Editor extends Component {
 		preferredStyleVariations,
 		__experimentalLocalAutosaveInterval,
 		updatePreferredStyleVariations,
+		noBlockValidation,
 	) {
 		settings = {
 			...settings,
@@ -55,6 +56,7 @@ class Editor extends Component {
 			focusMode,
 			showInserterHelpPanel,
 			__experimentalLocalAutosaveInterval,
+			noBlockValidation,
 		};
 
 		// Omit hidden block types if exists and non-empty.
@@ -92,6 +94,7 @@ class Editor extends Component {
 			__experimentalLocalAutosaveInterval,
 			showInserterHelpPanel,
 			updatePreferredStyleVariations,
+			noBlockValidation,
 			...props
 		} = this.props;
 
@@ -109,6 +112,7 @@ class Editor extends Component {
 			preferredStyleVariations,
 			__experimentalLocalAutosaveInterval,
 			updatePreferredStyleVariations,
+			noBlockValidation,
 		);
 
 		return (
@@ -148,6 +152,7 @@ export default compose( [
 			showInserterHelpPanel: isFeatureActive( 'showInserterHelpPanel' ),
 			hasFixedToolbar: isFeatureActive( 'fixedToolbar' ),
 			focusMode: isFeatureActive( 'focusMode' ),
+			noBlockValidation: isFeatureActive( 'noBlockValidation' ),
 			post: getEntityRecord( 'postType', postType, postId ),
 			preferredStyleVariations: getPreference( 'preferredStyleVariations' ),
 			hiddenBlockTypes: getPreference( 'hiddenBlockTypes' ),

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -56,6 +56,10 @@ class EditorProvider extends Component {
 		}
 
 		props.updatePostLock( props.settings.postLock );
+
+		//TODO temp until we can pass through the block validation mde better. Parser is only created on load so I can't pass through properly
+		global.wp.blockValidationMode = props.settings.noBlockValidation ? 'no-save-error' : 'strict';
+
 		props.setupEditor( props.post, props.initialEdits, props.settings.template );
 
 		if ( props.settings.autosave ) {
@@ -112,6 +116,7 @@ class EditorProvider extends Component {
 				'__experimentalEnablePageTemplates',
 				'showInserterHelpPanel',
 				'gradients',
+				'noBlockValidation',
 			] ),
 			mediaUpload: hasUploadPermissions ? mediaUpload : undefined,
 			__experimentalReusableBlocks: reusableBlocks,

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -16,6 +16,7 @@ import { BlockEditorProvider, transformStyles } from '@wordpress/block-editor';
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
 import { decodeEntities } from '@wordpress/html-entities';
+import { addFilter } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -57,8 +58,9 @@ class EditorProvider extends Component {
 
 		props.updatePostLock( props.settings.postLock );
 
-		//TODO temp until we can pass through the block validation mde better. Parser is only created on load so I can't pass through properly
-		global.wp.blockValidationMode = props.settings.noBlockValidation ? 'no-save-error' : 'strict';
+		addFilter( 'editor.blockValidationMode', 'editorProviderSetMode', () => {
+			return props.settings.noBlockValidation ? 'no-save-error' : 'strict';
+		} );
 
 		props.setupEditor( props.post, props.initialEdits, props.settings.template );
 


### PR DESCRIPTION
One option as part of iterating on block-invalidation https://github.com/WordPress/gutenberg/issues/7604 is to create a less strict validation mode. As a first pass I'm calling this "strict" vs "no-save-error".

- "strict" follows current behavior, where we try and see if blocks serialize mostly exactly to expected output
- "no-save-error" which basically allows anything provided that the block save does not throw an error. (mimics behavior of "attempt block recovery" without prompting the user)

<img width="374" alt="Screen Shot 2019-12-18 at 1 41 35 PM" src="https://user-images.githubusercontent.com/1270189/71125639-3372d580-219c-11ea-832b-14cca7fe608d.png">

I've added unit tests that mimic real bug reports I've spotted in the wild. 
<img width="699" alt="Screen Shot 2019-12-18 at 12 54 14 PM" src="https://user-images.githubusercontent.com/1270189/71122479-8bf2a480-2195-11ea-9ed5-63b1c3d8f437.png">
1. Most folks don't understand what this error means
2. This error is almost all of the time is not caused by the user. (Can be a side-effect of older customizations that modify post content directly, downgrading editor versions, and so on).

*New Option (Not Final)*
<img width="571" alt="Screen Shot 2019-12-18 at 12 34 12 PM" src="https://user-images.githubusercontent.com/1270189/71121651-b9d6e980-2193-11ea-8df1-3fb464d3d723.png">

| strict | no-save-error |
| ------------- | ------------- |
|  <img width="1325" alt="Screen Shot 2019-12-18 at 12 35 16 PM" src="https://user-images.githubusercontent.com/1270189/71121693-cc512300-2193-11ea-9d4d-09f48479452d.png"> | <img width="1325" alt="Screen Shot 2019-12-18 at 12 35 51 PM" src="https://user-images.githubusercontent.com/1270189/71121752-e7bc2e00-2193-11ea-81fd-7ab341e35f15.png"> |

Overall I'm thinking there are two main cases for block validation:

### Block Development
- Current behavior makes a lot of sense while creating new blocks. It's very easy to mess up serialization, and data hydration without these guards and warnings in place.
- In the process of creating a new block, can I add a block, modify the it, and reload the editor without the editor complaining in a tightly controlled environment?
- We shouldn't have any surprises here with attributes, and it can help catch non-deterministic behavior like surprises with floating point rounding errors (we should round to some precision value).

### Production or For Everyday Use
- We should be more permissive for this use case. Basically when someone sets up a site (likely with misc customizations that are not Gutenberg aware) it's incredibly easy for block invalidations to be triggered on trivial changes, by adding unexpected attributes or CSS classes
- For this first pass, I think letting the block try to salvage and update serialized content here is fine. 
Post updates still require a manual save, and folks can use revision history to roll back if needed. With the current data structures, it's in my opinion too expensive to define what is a mostly harmless change, and what is not, even if said changes look trivial to human eyes. This would require faster and more accurate parsing and likely very strict definition of types.
- We should only show this UI when the block is broken and cannot properly serialize (throws an error on save). At that point it's reasonable to ask if we should change this to an HTML block or try to convert to something else.
- For super-users that want control, using HTML blocks directly is still possible
- Folks of course might note that this is _too_ permissive, but I'm open to discussion. 
- Validation, here I suspect is also not very performant on large posts. I'll see if I can move the sanity check (see if things throw on save) async if folks are open to this, as a follow up.

## Testing Instructions
- Install the Classic Editor Plugin
- Add some invalid block content to a post and publish. An easy one is adding an extra CSS class or modifying a header block and updating the "levels" attribute to a different number.
- Load the post in the block editor, verify that we see the block invalidation warning
- In the Editor Options Modal > Toggle "Disable Block Validation"
- Reload the editor by pressing refresh
- Verify that the Block is valid 

```
 npm run test-unit ~/yourcheckout/gutenberg/packages/blocks/src/api/test/validation.js
```

