### PR TITLE
Add nav block e2e tests

### DIFF
--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -114,14 +114,6 @@ function Navigation( {
 	// indicated they want to automatically add top level Pages
 	// then show the Placeholder
 	if ( ! hasExistingNavItems ) {
-		if ( isRequestingPages ) {
-			return (
-				<>
-					<Spinner /> { __( 'Loading Navigation…' ) }
-				</>
-			);
-		}
-
 		return (
 			<Fragment>
 				<Placeholder

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -114,6 +114,14 @@ function Navigation( {
 	// indicated they want to automatically add top level Pages
 	// then show the Placeholder
 	if ( ! hasExistingNavItems ) {
+		if ( isRequestingPages ) {
+			return (
+				<>
+					<Spinner /> { __( 'Loading Navigation…' ) }
+				</>
+			);
+		}
+
 		return (
 			<Fragment>
 				<Placeholder

--- a/packages/e2e-test-utils/src/press-key-with-modifier.js
+++ b/packages/e2e-test-utils/src/press-key-with-modifier.js
@@ -75,7 +75,7 @@ async function emulateSelectAll() {
 				charCode: 0,
 				keyCode: isMac ? 93 : 17,
 				which: isMac ? 93 : 17,
-			} ),
+			} )
 		);
 	} );
 }

--- a/packages/e2e-tests/specs/editor/blocks/__snapshots__/navigation.test.js.snap
+++ b/packages/e2e-tests/specs/editor/blocks/__snapshots__/navigation.test.js.snap
@@ -4,7 +4,7 @@ exports[`Navigation allows a navigation menu to be created from an empty menu us
 "<!-- wp:navigation -->
 <!-- wp:navigation-link {\\"label\\":\\"WP\\",\\"title\\":\\"https://wordpress.org\\",\\"url\\":\\"https://wordpress.org\\"} /-->
 
-<!-- wp:navigation-link {\\"label\\":\\"Sample\\",\\"title\\":\\"Sample Page\\",\\"url\\":\\"http://localhost:8889/?page_id=2\\"} /-->
+<!-- wp:navigation-link {\\"label\\":\\"Get in touch\\",\\"title\\":\\"Contact Us\\",\\"url\\":\\"https://this/is/a/test/url/contact-us\\"} /-->
 <!-- /wp:navigation -->"
 `;
 

--- a/packages/e2e-tests/specs/editor/blocks/__snapshots__/navigation.test.js.snap
+++ b/packages/e2e-tests/specs/editor/blocks/__snapshots__/navigation.test.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Navigation allows a navigation menu to be created using existing pages 1`] = `
+"<!-- wp:navigation -->
+<!-- wp:navigation-link {\\"label\\":\\"Sample Page\\",\\"title\\":\\"Sample Page\\",\\"type\\":\\"page\\",\\"id\\":2,\\"url\\":\\"http://localhost:8889/?page_id=2\\"} /-->
+<!-- /wp:navigation -->"
+`;

--- a/packages/e2e-tests/specs/editor/blocks/__snapshots__/navigation.test.js.snap
+++ b/packages/e2e-tests/specs/editor/blocks/__snapshots__/navigation.test.js.snap
@@ -1,5 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Navigation allows a navigation menu to be created from an empty menu using a mixture of internal and external links 1`] = `
+"<!-- wp:navigation -->
+<!-- wp:navigation-link {\\"label\\":\\"WP\\",\\"title\\":\\"https://wordpress.org\\",\\"url\\":\\"https://wordpress.org\\"} /-->
+
+<!-- wp:navigation-link {\\"label\\":\\"Sample\\",\\"title\\":\\"Sample Page\\",\\"url\\":\\"http://localhost:8889/?page_id=2\\"} /-->
+<!-- /wp:navigation -->"
+`;
+
 exports[`Navigation allows a navigation menu to be created using existing pages 1`] = `
 "<!-- wp:navigation -->
 <!-- wp:navigation-link {\\"label\\":\\"Sample Page\\",\\"title\\":\\"Sample Page\\",\\"type\\":\\"page\\",\\"id\\":2,\\"url\\":\\"http://localhost:8889/?page_id=2\\"} /-->

--- a/packages/e2e-tests/specs/editor/blocks/__snapshots__/navigation.test.js.snap
+++ b/packages/e2e-tests/specs/editor/blocks/__snapshots__/navigation.test.js.snap
@@ -10,6 +10,10 @@ exports[`Navigation allows a navigation menu to be created from an empty menu us
 
 exports[`Navigation allows a navigation menu to be created using existing pages 1`] = `
 "<!-- wp:navigation -->
-<!-- wp:navigation-link {\\"label\\":\\"Sample Page\\",\\"title\\":\\"Sample Page\\",\\"type\\":\\"page\\",\\"id\\":2,\\"url\\":\\"http://localhost:8889/?page_id=2\\"} /-->
+<!-- wp:navigation-link {\\"label\\":\\"Home\\",\\"title\\":\\"Home\\",\\"type\\":\\"page\\",\\"id\\":1,\\"url\\":\\"https://this/is/a/test/url/home\\"} /-->
+
+<!-- wp:navigation-link {\\"label\\":\\"About\\",\\"title\\":\\"About\\",\\"type\\":\\"page\\",\\"id\\":2,\\"url\\":\\"https://this/is/a/test/url/about\\"} /-->
+
+<!-- wp:navigation-link {\\"label\\":\\"Contact Us\\",\\"title\\":\\"Contact Us\\",\\"type\\":\\"page\\",\\"id\\":3,\\"url\\":\\"https://this/is/a/test/url/contact\\"} /-->
 <!-- /wp:navigation -->"
 `;

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -4,26 +4,51 @@
  */
 import {
 	createNewPost,
+	getEditedPostContent,
 	insertBlock,
 } from '@wordpress/e2e-test-utils';
 
-describe( 'Adds Navigation links', () => {
+describe( 'Navigation', () => {
 	beforeEach( async () => {
 		await createNewPost();
 	} );
 
-	it( 'Should add a link with one click', async () => {
+	it( 'allows a navigation menu to be created using existing pages', async () => {
+		// Add the navigation block.
 		await insertBlock( 'Navigation' );
+
+		// Create an empty nav block.
+		const [ createFromExistingButton ] = await page.$x( '//button[text()="Create from all top pages"]' );
+		await createFromExistingButton.click();
+
+		// Snapshot should contain the default 'Sample Page'.
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'allows a navigation menu to be created from an empty menu using a mixture of internal and external links', async () => {
+		// Add the navigation block.
+		await insertBlock( 'Navigation' );
+
+		// Create an empty nav block.
 		const [ createEmptyButton ] = await page.$x( '//button[text()="Create empty"]' );
 		await createEmptyButton.click();
-		await page.waitForSelector( 'input[placeholder="Search or type url"]' );
-		await page.type( 'input[placeholder="Search or type url"]', 'http://example.com' );
 
+		// Add a link to the default Navigation Link block.
+		await page.type( 'input[placeholder="Search or type url"]', 'https://wordpress.org' );
 		await page.keyboard.press( 'Enter' );
+		await page.type( '.wp-block-navigation-link__content.is-selected', 'Home' );
+
+		// Add another Navigation Link block.
+		// Using 'click' here checks for regressions of https://github.com/WordPress/gutenberg/issues/18329,
+		// an issue where the block appender requires two clicks.
 		await page.click( '.wp-block-navigation .block-list-appender' );
 
-		const navigationLinkCount = await page.$$eval( '.wp-block-navigation-link', ( navigationLinks ) => navigationLinks.length );
+		// Add a link to the default Navigation Link block.
+		await page.type( 'input[placeholder="Search or type url"]', 'Sample Page' );
+		await page.keyboard.press( 'Enter' );
+		await page.type( '.wp-block-navigation-link__content.is-selected', 'Sample' );
 
-		expect( navigationLinkCount ).toBe( 2 );
+		// Expect a Navigation Block with two Navigation Links in the snapshot.
+		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 } );

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -97,8 +97,8 @@ describe( 'Navigation', () => {
 
 		// Create an empty nav block. The 'create' button is disabled until pages are loaded,
 		// so we must wait for it to become not-disabled.
-		await page.waitForXPath( '//button[text()="Create from all top pages"][not(@disabled)]' );
-		const [ createFromExistingButton ] = await page.$x( '//button[text()="Create from all top pages"][not(@disabled)]' );
+		await page.waitForXPath( '//button[text()="Create from all top-level pages"][not(@disabled)]' );
+		const [ createFromExistingButton ] = await page.$x( '//button[text()="Create from all top-level pages"][not(@disabled)]' );
 		await createFromExistingButton.click();
 
 		// Snapshot should contain the mocked pages.

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -67,5 +67,12 @@ describe( 'Navigation', () => {
 
 		// Expect a Navigation Block with two Navigation Links in the snapshot.
 		expect( await getEditedPostContent() ).toMatchSnapshot();
+
+		// TODO - this is needed currently because when adding a link using the suggestion list,
+		// a submit button is used. The form that the submit button is in is unmounted when submission
+		// occurs, resulting in a warning 'Form submission canceled because the form is not connected'
+		// in Chrome.
+		// Ideally, the suggestions wouldn't be implemented using submit buttons.
+		expect( console ).toHaveWarned();
 	} );
 } );

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -6,7 +6,20 @@ import {
 	createNewPost,
 	getEditedPostContent,
 	insertBlock,
+	pressKeyWithModifier,
 } from '@wordpress/e2e-test-utils';
+
+async function updateActiveNavigationLink( { url, label } ) {
+	if ( url ) {
+		await page.type( 'input[placeholder="Search or type url"]', url );
+		await page.keyboard.press( 'Enter' );
+	}
+	if ( label ) {
+		await page.click( '.wp-block-navigation-link__content.is-selected' );
+		await pressKeyWithModifier( 'primary', 'a' );
+		await page.keyboard.type( label );
+	}
+}
 
 describe( 'Navigation', () => {
 	beforeEach( async () => {
@@ -18,6 +31,7 @@ describe( 'Navigation', () => {
 		await insertBlock( 'Navigation' );
 
 		// Create an empty nav block.
+		await page.waitForSelector( '.wp-block-navigation-placeholder' );
 		const [ createFromExistingButton ] = await page.$x( '//button[text()="Create from all top pages"]' );
 		await createFromExistingButton.click();
 
@@ -30,13 +44,15 @@ describe( 'Navigation', () => {
 		await insertBlock( 'Navigation' );
 
 		// Create an empty nav block.
+		await page.waitForSelector( '.wp-block-navigation-placeholder' );
 		const [ createEmptyButton ] = await page.$x( '//button[text()="Create empty"]' );
 		await createEmptyButton.click();
 
 		// Add a link to the default Navigation Link block.
-		await page.type( 'input[placeholder="Search or type url"]', 'https://wordpress.org' );
-		await page.keyboard.press( 'Enter' );
-		await page.type( '.wp-block-navigation-link__content.is-selected', 'Home' );
+		await updateActiveNavigationLink( { url: 'https://wordpress.org', label: 'WP' } );
+
+		// Move the mouse to reveal the block movers. Without this the test seems to fail.
+		await page.mouse.move( 10, 10 );
 
 		// Add another Navigation Link block.
 		// Using 'click' here checks for regressions of https://github.com/WordPress/gutenberg/issues/18329,
@@ -44,9 +60,7 @@ describe( 'Navigation', () => {
 		await page.click( '.wp-block-navigation .block-list-appender' );
 
 		// Add a link to the default Navigation Link block.
-		await page.type( 'input[placeholder="Search or type url"]', 'Sample Page' );
-		await page.keyboard.press( 'Enter' );
-		await page.type( '.wp-block-navigation-link__content.is-selected', 'Sample' );
+		await updateActiveNavigationLink( { url: 'Sample Page', label: 'Sample' } );
 
 		// Expect a Navigation Block with two Navigation Links in the snapshot.
 		expect( await getEditedPostContent() ).toMatchSnapshot();

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -54,9 +54,17 @@ async function updateActiveNavigationLink( { url, label } ) {
 		await page.waitForXPath( `//span[@class="block-editor-link-control__search-item-title"]/mark[text()="${ url }"]` );
 		await page.keyboard.press( 'Enter' );
 	}
+
 	if ( label ) {
 		await page.click( '.wp-block-navigation-link__content.is-selected' );
-		await pressKeyWithModifier( 'primary', 'a' );
+
+		// Ideally this would be `await pressKeyWithModifier( 'primary', 'a' )`
+		// to select all text like other tests do.
+		// Unfortunately, these tests don't seem to pass on Travis CI when
+		// using that approach, while using `Home` and `End` they do pass.
+		await page.keyboard.press( 'Home' );
+		await pressKeyWithModifier( 'shift', 'End' );
+		await page.keyboard.press( 'Backspace' );
 		await page.keyboard.type( label );
 	}
 }
@@ -110,7 +118,7 @@ describe( 'Navigation', () => {
 		await updateActiveNavigationLink( { url: 'https://wordpress.org', label: 'WP' } );
 
 		// Move the mouse to reveal the block movers. Without this the test seems to fail.
-		await page.mouse.move( 10, 10 );
+		await page.mouse.move( 100, 100 );
 
 		// Add another Navigation Link block.
 		// Using 'click' here checks for regressions of https://github.com/WordPress/gutenberg/issues/18329,

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -12,6 +12,8 @@ import {
 async function updateActiveNavigationLink( { url, label } ) {
 	if ( url ) {
 		await page.type( 'input[placeholder="Search or type url"]', url );
+		// Wait for the autocomplete suggestion item to appear.
+		await page.waitForXPath( `//span[@class="block-editor-link-control__search-item-title"]/mark[text()="${ url }"]` );
 		await page.keyboard.press( 'Enter' );
 	}
 	if ( label ) {
@@ -30,9 +32,10 @@ describe( 'Navigation', () => {
 		// Add the navigation block.
 		await insertBlock( 'Navigation' );
 
-		// Create an empty nav block.
-		await page.waitForSelector( '.wp-block-navigation-placeholder' );
-		const [ createFromExistingButton ] = await page.$x( '//button[text()="Create from all top pages"]' );
+		// Create an empty nav block. The 'create' button is disabled until pages are loaded,
+		// so we must wait for it to become not-disabled.
+		await page.waitForXPath( '//button[text()="Create from all top pages"][not(@disabled)]' );
+		const [ createFromExistingButton ] = await page.$x( '//button[text()="Create from all top pages"][not(@disabled)]' );
 		await createFromExistingButton.click();
 
 		// Snapshot should contain the default 'Sample Page'.


### PR DESCRIPTION
## Description
This adds back the e2e tests that were originally merged in https://github.com/WordPress/gutenberg/pull/18929, but then reverted in https://github.com/WordPress/gutenberg/pull/19119 as they were causing failures.

I discovered that just before the original PR was merged some button text that the tests depend on was updated in https://github.com/WordPress/gutenberg/pull/19105, which then caused them to fail. I've updated this text in 316bb1e.

As the original PR already had approval I don't think there's any need to wait for a review, I'll merge once the tests are passing.
