### PR TITLE
Fix mobile paste crash by adding activeFormats for onPaste call

### DIFF
--- a/packages/rich-text/src/component/index.native.js
+++ b/packages/rich-text/src/component/index.native.js
@@ -345,6 +345,7 @@ export class RichText extends Component {
 			onPaste,
 			onChange,
 		} = this.props;
+		const { activeFormats = [] } = this.state;
 
 		const { pastedText, pastedHtml, files } = event.nativeEvent;
 		const currentRecord = this.createRecord();
@@ -381,6 +382,7 @@ export class RichText extends Component {
 				html: pastedHtml,
 				plainText: pastedText,
 				files,
+				activeFormats,
 			} );
 		}
 	}


### PR DESCRIPTION
## Description
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/1687

## How has this been tested?

1. Checkout gutenberg-mobile master, and gutenberg master commit f92fed76e073424f42aa89244264839ec98897b1 and run the example app. 
2. Copy and paste text within a paragraph block.
3. Note the crash with error undefined `(evaluating activeFormats.length)`
4. Apply changes from this PR and rerun example app
5. Note copy and paste now works
6. Note test case from https://github.com/WordPress/gutenberg/pull/14815 works as well, seen in video below.



## Screenshots 
![fix-link-paste-style](https://user-images.githubusercontent.com/1103838/70968814-44bac580-2068-11ea-9d14-14f678d25625.gif)

## Checklist:
- [ X ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
