### PR TITLE
Adjustments for welcome guide

### DIFF
--- a/packages/edit-post/src/components/welcome-guide/style.scss
+++ b/packages/edit-post/src/components/welcome-guide/style.scss
@@ -46,4 +46,8 @@
 		position: relative;
 		top: 4px;
 	}
+
+	@include break-small() {
+		width: 600px;
+	}
 }

--- a/packages/edit-post/src/components/welcome-guide/style.scss
+++ b/packages/edit-post/src/components/welcome-guide/style.scss
@@ -16,8 +16,8 @@
 
 	&__heading {
 		font-family: $editor-font;
-		font-size: 32px;
-		line-height: 44px;
+		font-size: 21px;
+		line-height: 1.4;
 		margin: $grid-size 0;
 	}
 
@@ -37,7 +37,7 @@
 
 	&__text {
 		font-size: $editor-font-size;
-		line-height: 1.5;
+		line-height: 1.4;
 		margin: $grid-size 0;
 	}
 


### PR DESCRIPTION
- Reduces header to have text on desktop on one line.
- Reduces line-height on header and makes it number over px.
- Tried to avoid widows but needs longer lasting solution.

Before

![image](https://user-images.githubusercontent.com/253067/70990742-110a8a80-20be-11ea-9f89-20352b2771dd.png)

After

![image](https://user-images.githubusercontent.com/253067/70990763-1e277980-20be-11ea-9088-d64c7255f489.png)

