### PR TITLE
Add the new media flow to the media text block

### DIFF
--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -45,7 +45,6 @@ const applyWidthConstraints = ( width ) => Math.max( WIDTH_CONSTRAINT_PERCENTAGE
 
 const LINK_DESTINATION_MEDIA = 'media';
 const LINK_DESTINATION_ATTACHMENT = 'attachment';
-const DEFAULT_SIZE_SLUG = 'large';
 
 class MediaTextEdit extends Component {
 	constructor() {
@@ -138,7 +137,6 @@ class MediaTextEdit extends Component {
 				mediaUrl: newURL,
 				href: newHref,
 				mediaId: undefined,
-				sizeSlug: DEFAULT_SIZE_SLUG,
 			} );
 		}
 	}

--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -43,8 +43,9 @@ const TEMPLATE = [
 const WIDTH_CONSTRAINT_PERCENTAGE = 15;
 const applyWidthConstraints = ( width ) => Math.max( WIDTH_CONSTRAINT_PERCENTAGE, Math.min( width, 100 - WIDTH_CONSTRAINT_PERCENTAGE ) );
 
-export const LINK_DESTINATION_MEDIA = 'media';
-export const LINK_DESTINATION_ATTACHMENT = 'attachment';
+const LINK_DESTINATION_MEDIA = 'media';
+const LINK_DESTINATION_ATTACHMENT = 'attachment';
+const DEFAULT_SIZE_SLUG = 'large';
 
 class MediaTextEdit extends Component {
 	constructor() {
@@ -57,6 +58,7 @@ class MediaTextEdit extends Component {
 			mediaWidth: null,
 		};
 		this.onSetHref = this.onSetHref.bind( this );
+		this.onSelectURL = this.onSelectURL.bind( this );
 	}
 
 	onSelectMedia( media ) {
@@ -117,6 +119,30 @@ class MediaTextEdit extends Component {
 		this.props.setAttributes( props );
 	}
 
+	onSelectURL( newURL ) {
+		const { mediaUrl, linkDestination, href } = this.props.attributes;
+
+		if ( newURL !== mediaUrl ) {
+			let newHref = href;
+			if ( linkDestination === LINK_DESTINATION_MEDIA ) {
+				// Update the media link.
+				newHref = newURL;
+			}
+
+			// Check if the image is linked to the attachment page.
+			if ( linkDestination === LINK_DESTINATION_ATTACHMENT ) {
+				// Update the media link.
+				newHref = undefined;
+			}
+			this.props.setAttributes( {
+				mediaUrl: newURL,
+				href: newHref,
+				mediaId: undefined,
+				sizeSlug: DEFAULT_SIZE_SLUG,
+			} );
+		}
+	}
+
 	commitWidthChange( width ) {
 		const { setAttributes } = this.props;
 
@@ -135,6 +161,7 @@ class MediaTextEdit extends Component {
 			<MediaContainer
 				className="block-library-media-text__media-container"
 				onSelectMedia={ this.onSelectMedia }
+				onSelectURL={ this.onSelectURL }
 				onWidthChange={ this.onWidthChange }
 				commitWidthChange={ this.commitWidthChange }
 				{ ...{ mediaAlt, mediaId, mediaType, mediaUrl, mediaPosition, mediaWidth, imageFill, focalPoint } }

--- a/packages/block-library/src/media-text/media-container.js
+++ b/packages/block-library/src/media-text/media-container.js
@@ -1,12 +1,12 @@
 /**
  * WordPress dependencies
  */
-import { Button, ResizableBox, ToolbarGroup, withNotices } from '@wordpress/components';
+import { ResizableBox, withNotices } from '@wordpress/components';
 import {
 	BlockControls,
 	BlockIcon,
 	MediaPlaceholder,
-	MediaUpload,
+	MediaReplaceFlow,
 } from '@wordpress/block-editor';
 import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -45,24 +45,16 @@ class MediaContainer extends Component {
 	}
 
 	renderToolbarEditButton() {
-		const { mediaId, onSelectMedia } = this.props;
+		const { onSelectMedia, onSelectURL, mediaUrl } = this.props;
 		return (
 			<BlockControls>
-				<ToolbarGroup>
-					<MediaUpload
-						onSelect={ onSelectMedia }
-						allowedTypes={ ALLOWED_MEDIA_TYPES }
-						value={ mediaId }
-						render={ ( { open } ) => (
-							<Button
-								className="components-toolbar__control"
-								label={ __( 'Edit media' ) }
-								icon="edit"
-								onClick={ open }
-							/>
-						) }
-					/>
-				</ToolbarGroup>
+				<MediaReplaceFlow
+					mediaURL={ mediaUrl }
+					allowedTypes={ ALLOWED_MEDIA_TYPES }
+					accept="image/*,video/*"
+					onSelect={ onSelectMedia }
+					onSelectURL={ onSelectURL }
+				/>
 			</BlockControls>
 		);
 	}


### PR DESCRIPTION
## Description
Requires #18139 There is a new replace flow offered by a component which is currently implemented in the Image Block. This PR implements the new flow in the Media + Text block.

## How has this been tested?
Tested locally.

## Screenshots <!-- if applicable -->

<img width="754" alt="Screenshot 2019-12-17 at 17 06 37" src="https://user-images.githubusercontent.com/107534/71007394-9c504400-20ef-11ea-8f18-a4ca1633320b.png">
