### PR TITLE
RNMobile: Pass formatTypes to FormatEdit component

### DIFF
--- a/packages/rich-text/src/component/index.native.js
+++ b/packages/rich-text/src/component/index.native.js
@@ -643,6 +643,7 @@ export class RichText extends Component {
 			__unstableIsSelected: isSelected,
 			children,
 			getStylesFromColorScheme,
+			formatTypes,
 		} = this.props;
 
 		const record = this.getRecord();
@@ -756,7 +757,11 @@ export class RichText extends Component {
 					isMultiline={ this.isMultiline }
 					textAlign={ this.props.textAlign }
 				/>
-				{ isSelected && <FormatEdit value={ record } onChange={ this.onFormatChange } /> }
+				{ isSelected && <FormatEdit
+					formatTypes={ formatTypes }
+					value={ record }
+					onChange={ this.onFormatChange }
+				/> }
 			</View>
 		);
 	}


### PR DESCRIPTION
## Description
Fixes a recently introduced crash that occurred because `FormatEdit` now requires a `formatTypes` prop, but we were not passing that prop on mobile. 

[relevant Gutenberg-Mobile issue](https://github.com/wordpress-mobile/gutenberg-mobile/issues/1693)

## To Test
You can use this seemingly unrelated [gutenberg-mobile PR](https://github.com/wordpress-mobile/gutenberg-mobile/pull/1631) to test this. It's gutenberg ref has been updated to point at this PR. Or you can test using 'develop` and pointing to this branch.

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [X] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
