### PR TITLE
Edit Post: Fix Welcome Guide modal display for Internet Explorer

### DIFF
--- a/packages/components/src/guide/style.scss
+++ b/packages/components/src/guide/style.scss
@@ -11,7 +11,6 @@
 	}
 
 	&__container {
-		align-items: center;
 		display: flex;
 		flex-direction: column;
 		margin-top: -$header-height;

--- a/packages/components/src/guide/style.scss
+++ b/packages/components/src/guide/style.scss
@@ -106,7 +106,7 @@
 		right: 0;
 
 		@include break-small() {
-			display: unset;
+			display: block;
 		}
 	}
 

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -68,9 +68,13 @@
 	background: $white;
 	align-items: center;
 	height: $header-height;
+	z-index: z-index(".components-modal__header");
+	// For z-index to take effect, the element must be positioned. A "sticky"
+	// element is positioned, but since this is not supported in IE11,
+	// "relative" is used as a fallback.
+	position: relative;
 	position: sticky;
 	top: 0;
-	z-index: z-index(".components-modal__header");
 	margin: 0 -#{$grid-size-xlarge} $grid-size-xlarge;
 
 	// Rules inside this query are only run by Microsoft Edge.

--- a/packages/edit-post/src/components/welcome-guide/style.scss
+++ b/packages/edit-post/src/components/welcome-guide/style.scss
@@ -28,10 +28,12 @@
 		margin: $grid-size 0;
 
 		@include break-small() {
-			height: $image-height;
-			left: 0;
 			position: absolute;
+			left: 0;
+			top: 50%;
+			height: $image-height;
 			width: $image-width;
+			margin-top: -0.5 * $image-height;
 		}
 	}
 


### PR DESCRIPTION
Fixes #19140

This pull request seeks to resolve a number of issues with the Welcome Guide as it is displayed in Internet Explorer. Most importantly, the modal can now be dismissed.

Before|After
---|---
![Before](https://user-images.githubusercontent.com/1779930/71015972-76607a80-20c2-11ea-83a0-008386bce9ba.png)|![After](https://user-images.githubusercontent.com/1779930/71015712-1669d400-20c2-11ea-8967-04d5480c60bc.png)

These fixes include:

- Text would overflow in the modal due a Flexbox bug associated with Internet Explorer and the use of `align-items: center` on Flex containers ([reference](https://github.com/philipwalton/flexbugs#flexbug-2)). Since this style did not appear to have a noticeable impact on the display of the modal, it was simply removed.
- The "Close" button could not be clicked because it relied on a `z-index` styling to appear "above" the rest of the content in the modal. However, since `z-index` only applies to [positioned elements](https://developer.mozilla.org/en-US/docs/Web/CSS/position#Types_of_positioning) ([reference](https://developer.mozilla.org/en-US/docs/Web/CSS/z-index)), it was not taking effect, because the only positioning applied to the element was `position: sticky`, not supported in Internet Explorer ([reference](https://developer.mozilla.org/en-US/docs/Web/CSS/position#Browser_compatibility)). This was resolved by applying `position: relative` as a "fallback" positioning, allowing the `z-index` to take effect as expected.
- The image was intended to appear as vertically centered using absolute positioning. There were no explicit styles used to actually apply the centering effect. While these did not seem to be necessary for other browsers, the explicit centering was introduced to ensure that the image is centered correctly in Internet Explorer.
- The "Finish" button would previously not appear in Internet Explorer, because it was expected to take effect using `display: unset`, a value unsupported in Internet Explorer ([reference](https://developer.mozilla.org/en-US/docs/Web/CSS/unset#Browser_compatibility)). Instead, `display: block` is used, derived from the effective ("computed") value otherwise expected from `display: unset`.

This does not include handling to allow the modal background to be clicked to dismiss the guide. I expect this may be a separate issue with the Modal component.

Additionally, I was tempted to remove this bit of styling:

https://github.com/WordPress/gutenberg/blob/6f6412a83aaa1243ce695ed1bb7a839b7a20c75b/packages/components/src/guide/style.scss#L17

...since it seems in contradiction with how a modal is expected to be styled, and assumes some vertical centering of the modal contents which otherwise isn't enforced (for Welcome modal, it is applied in the welcome modal styling). Since these were not directly relevant for the Internet Explorer fix, I opted to leave them for separate revision.

**Testing Instructions:**

Repeat testing instructions from #18041, in Internet Explorer and in your preferred browser.