### PR TITLE
Data: Invalidate store subscription on change in isAsync

### DIFF
--- a/packages/data/src/components/use-select/index.js
+++ b/packages/data/src/components/use-select/index.js
@@ -78,7 +78,7 @@ export default function useSelect( _mapSelect, deps ) {
 	const mapSelect = useCallback( _mapSelect, deps );
 	const registry = useRegistry();
 	const isAsync = useAsyncMode();
-	const queueContext = useMemo( () => ( { queue: true } ), [ registry ] );
+	const queueContext = useMemo( () => ( { queue: true } ), [ registry, isAsync ] );
 	const [ , forceRender ] = useReducer( ( s ) => s + 1, 0 );
 
 	const latestMapSelect = useRef();
@@ -160,7 +160,7 @@ export default function useSelect( _mapSelect, deps ) {
 			unsubscribe();
 			renderQueue.flush( queueContext );
 		};
-	}, [ registry ] );
+	}, [ registry, isAsync ] );
 
 	return mapOutput;
 }

--- a/packages/data/src/components/use-select/test/index.js
+++ b/packages/data/src/components/use-select/test/index.js
@@ -8,6 +8,7 @@ import TestRenderer, { act } from 'react-test-renderer';
  */
 import { createRegistry } from '../../../registry';
 import { RegistryProvider } from '../../registry-provider';
+import { AsyncModeProvider } from '../../async-mode-provider';
 import useSelect from '../index';
 
 describe( 'useSelect', () => {
@@ -132,6 +133,37 @@ describe( 'useSelect', () => {
 			children: 'bar',
 		} );
 	} );
+
+	it( 'updates when async mode changes', () => {
+		const selectSpy = jest.fn().mockImplementation( () => null );
+
+		function TestComponent() {
+			const data = useSelect( selectSpy );
+			return <div>{ data }</div>;
+		}
+
+		let renderer;
+		act( () => {
+			renderer = TestRenderer.create(
+				<AsyncModeProvider value={ true }>
+					<TestComponent />
+				</AsyncModeProvider>
+			);
+		} );
+
+		expect( selectSpy ).toHaveBeenCalledTimes( 1 );
+
+		act( () => {
+			renderer.update(
+				<AsyncModeProvider value={ false }>
+					<TestComponent />
+				</AsyncModeProvider>
+			);
+		} );
+
+		expect( selectSpy ).toHaveBeenCalledTimes( 2 );
+	} );
+
 	describe( 'rerenders as expected with various mapSelect return types', () => {
 		const getComponent = ( mapSelectSpy ) => () => {
 			const data = useSelect( mapSelectSpy, [] );


### PR DESCRIPTION
Closes #19199
Unblocks: #19007

This pull request seeks to update the behavior of `useSelect` to rerun selectors when the value of the `isAsync` context changes. Without these changes, there can be cases such as that described in #19199 where an updated selector value will not take effect when the context value changes.

It's unclear to me whether there might be a related issue with the implementation of the priority queue where flushes should be expected to force the `onStoreChange` callback (see https://github.com/WordPress/gutenberg/pull/13056#discussion_r359029819).

**Testing Instructions:**

Repeat steps to reproduce from #19199, verifying that each implementation of the block renders as expected.

Ensure unit tests pass:

```
npm run test-unit packages/data/src/components/use-select/test/index.js
```