### PR TITLE
Data: Remove unused forceRender argument

### DIFF
--- a/packages/data/src/components/use-select/index.js
+++ b/packages/data/src/components/use-select/index.js
@@ -135,7 +135,7 @@ export default function useSelect( _mapSelect, deps ) {
 				} catch ( error ) {
 					latestMapOutputError.current = error;
 				}
-				forceRender( {} );
+				forceRender();
 			}
 		};
 


### PR DESCRIPTION
This pull request seeks to remove an unused argument in the implementation of `useSelect`. When a change is detected in the result of a `mapSelect` callback, the hook will force a render using its internal `forceRender` reducer. Since `forceRender` is implemented using a `useReducer` which will always yield a new value and never considers the incoming argument, the empty object we currently pass is unused.

https://github.com/WordPress/gutenberg/blob/7a337cfeaaade6622d6bc9a08101b1b79a1579ea/packages/data/src/components/use-select/index.js#L82

In theory, the previous implementation could cause memory accumulation and/or extra load on garbage collection due to the initialization and subsequent destruction of the unused object references. The expected impact of this is not significant, but since this is a hot code path, it is worth the extra attention.

I expect this could have been lingering code from an earlier iteration of the hook, considering that this pattern is often used when forcing a render using the `setState` callback of a `useState` hook (where `setState( {} )` is equally as effective at forcing a render).

**Testing Instructions:**

Ensure unit tests pass:

```
npm run test-unit
```