### PR TITLE
Make validation of block html tags and attributes case insensitive

### DIFF
--- a/packages/blocks/src/api/test/validation.js
+++ b/packages/blocks/src/api/test/validation.js
@@ -417,7 +417,7 @@ describe( 'validation', () => {
 
 		it( 'should return true for effectively equivalent html', () => {
 			const isEquivalent = isEquivalentHTML(
-				'<div>&quot; Hello<span   class="b a" id="foo" data-foo="here &mdash; there"> World! &#128517;</  span>  "</div>',
+				'<div>&quot; Hello<SPAN   class="b a" ID="foo" data-foo="here &mdash; there"> World! &#128517;</  SPAN>  "</div>',
 				'<div  >" Hello\n<span id="foo" class="a  b" data-foo="here — there">World! 😅</span>"</div>'
 			);
 

--- a/packages/blocks/src/api/test/validation.js
+++ b/packages/blocks/src/api/test/validation.js
@@ -274,6 +274,23 @@ describe( 'validation', () => {
 
 			expect( isEqual ).toBe( true );
 		} );
+
+		it( 'returns true if case-insensitive equal pairs', () => {
+			const isEqual = isEqualTagAttributePairs(
+				[
+					[ 'ID', 'foo' ],
+					[ 'class', 'a b' ],
+					[ 'Style', 'color: red;' ],
+				],
+				[
+					[ 'id', 'foo' ],
+					[ 'CLASS', 'a b' ],
+					[ 'style', 'color: red;' ],
+				]
+			);
+
+			expect( isEqual ).toBe( true );
+		} );
 	} );
 
 	describe( 'isEqualTokensOfType', () => {
@@ -323,6 +340,27 @@ describe( 'validation', () => {
 						attributes: [
 							[ 'class', 'c  a b' ],
 							[ 'style', 'background-image: url( "https://wordpress.org/img.png" ); color: red;' ],
+						],
+					}
+				);
+
+				expect( isEqual ).toBe( true );
+			} );
+
+			it( 'returns true if tag and attributes names are case insensitive the same', () => {
+				const isEqual = isEqualTokensOfType.StartTag(
+					{
+						tagName: 'P',
+						attributes: [
+							[ 'CLASS', 'a b' ],
+							[ 'style', 'color: red;' ],
+						],
+					},
+					{
+						tagName: 'p',
+						attributes: [
+							[ 'class', 'a b' ],
+							[ 'Style', 'color: red;' ],
 						],
 					}
 				);

--- a/packages/blocks/src/api/validation/index.js
+++ b/packages/blocks/src/api/validation/index.js
@@ -407,8 +407,13 @@ export function isEqualTagAttributePairs( actual, expected, logger = createLogge
 		return false;
 	}
 
-	// Convert tuples to object for ease of lookup
-	const [ actualAttributes, expectedAttributes ] = [ actual, expected ].map( fromPairs );
+	// Lower case attribute name and convert tuples to object for ease of lookup
+	const [ actualAttributes, expectedAttributes ] = [ actual, expected ]
+		.map( ( attributes ) => attributes.map( ( attribute ) => {
+			attribute[ 0 ] = attribute[ 0 ].toLowerCase();
+			return attribute;
+		} ) )
+		.map( fromPairs );
 
 	for ( const name in actualAttributes ) {
 		// As noted above, if missing member in B, assume different
@@ -444,7 +449,7 @@ export function isEqualTagAttributePairs( actual, expected, logger = createLogge
  */
 export const isEqualTokensOfType = {
 	StartTag: ( actual, expected, logger = createLogger() ) => {
-		if ( actual.tagName !== expected.tagName ) {
+		if ( actual.tagName.toLowerCase() !== expected.tagName.toLowerCase() ) {
 			logger.warning( 'Expected tag name `%s`, instead saw `%s`.', expected.tagName, actual.tagName );
 			return false;
 		}


### PR DESCRIPTION
## Description
Fixes #18666 by lower casing html tags and attributes before comparison is done.

## How has this been tested?

Have tested manually by modifying html tag and attribute casing in the block editor  'code editor' view and then switching back to 'visual editor' view. Have also updated the existing unit test to cover case differences

## Types of changes
Adds lower casing of strings before comparison checks are done.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
