### PR TITLE
Remove unused `blocks-font-size` classname

### DIFF
--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -124,7 +124,7 @@ function ParagraphBlock( {
 				/>
 			</BlockControls>
 			<InspectorControls>
-				<PanelBody title={ __( 'Text Settings' ) } className="blocks-font-size">
+				<PanelBody title={ __( 'Text Settings' ) }>
 					<FontSizePicker
 						value={ fontSize.size }
 						onChange={ setFontSize }

--- a/packages/e2e-tests/specs/editor/various/font-size-picker.test.js
+++ b/packages/e2e-tests/specs/editor/various/font-size-picker.test.js
@@ -30,7 +30,7 @@ describe( 'Font Size Picker', () => {
 		await clickBlockAppender();
 		await page.keyboard.type( 'Paragraph to be made "small"' );
 
-		await page.click( '.blocks-font-size .components-range-control__number' );
+		await page.click( '.components-font-size-picker__controls .components-range-control__number' );
 		// This should be the "small" font-size of the editor defaults.
 		await page.keyboard.type( '13' );
 
@@ -44,7 +44,7 @@ describe( 'Font Size Picker', () => {
 		await clickBlockAppender();
 		await page.keyboard.type( 'Paragraph to be made "small"' );
 
-		await page.click( '.blocks-font-size .components-range-control__number' );
+		await page.click( '.components-font-size-picker__controls .components-range-control__number' );
 		await page.keyboard.type( '23' );
 
 		// Ensure content matches snapshot.
@@ -77,7 +77,7 @@ describe( 'Font Size Picker', () => {
 		await page.click( '.components-custom-select-control__item:nth-child(3)' );
 
 		// Clear the custom font size input.
-		await page.click( '.blocks-font-size .components-range-control__number' );
+		await page.click( '.components-font-size-picker__controls .components-range-control__number' );
 		await pressKeyTimes( 'ArrowRight', 5 );
 		await pressKeyTimes( 'Backspace', 5 );
 
@@ -91,12 +91,12 @@ describe( 'Font Size Picker', () => {
 		await clickBlockAppender();
 		await page.keyboard.type( 'Paragraph to be made "small"' );
 
-		await page.click( '.blocks-font-size .components-range-control__number' );
+		await page.click( '.components-font-size-picker__controls .components-range-control__number' );
 		await page.keyboard.type( '23' );
 
 		await page.keyboard.press( 'Backspace' );
 
-		await page.click( '.blocks-font-size .components-range-control__number' );
+		await page.click( '.components-font-size-picker__controls .components-range-control__number' );
 		await page.keyboard.press( 'Backspace' );
 		await page.keyboard.press( 'Backspace' );
 


### PR DESCRIPTION
## Description
This is a very tiny PR that removes a classname `blocks-font-sizes` from the paragraph block's Text Settings panel. 

The css for this classname seem to have been removed a while ago from the paragraph block, so removing it has no visual effect. The only usage was in an end-to-end test where it was used as part of a selector, but this was easily replaced with the font-size-picker classname.

## How has this been tested?
1. Add a paragraph block
2. Try changing the font size
3. Observe that the font size picker looks the same as it did previously

## Types of changes
Non-breaking task
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
