### PR TITLE
Accessibility: don't tab to block drag handle

### DIFF
--- a/packages/block-editor/src/components/block-mover/index.js
+++ b/packages/block-editor/src/components/block-mover/index.js
@@ -105,6 +105,9 @@ export class BlockMover extends Component {
 							icon={ dragHandle }
 							className="block-editor-block-mover__control-drag-handle block-editor-block-mover__control"
 							aria-hidden="true"
+							// Should not be able to tab to drag handle as this
+							// button can only be used with a pointer device.
+							tabIndex="-1"
 							onDragStart={ onDraggableStart }
 							onDragEnd={ onDraggableEnd }
 							draggable

--- a/packages/e2e-tests/specs/editor/various/keyboard-navigable-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/keyboard-navigable-blocks.test.js
@@ -58,9 +58,6 @@ const tabThroughBlockMoverControl = async () => {
 	);
 	await expect( isFocusedMoveUpControl ).toBe( true );
 
-	// Tab to focus the drag handle
-	await page.keyboard.press( 'Tab' );
-
 	// Tab to focus on the 'move down' control
 	await page.keyboard.press( 'Tab' );
 	const isFocusedMoveDownControl = await page.evaluate( () =>


### PR DESCRIPTION
## Description

As discussed with @MarcoZehe, the block drag handle should not be tabbable as the button can only be used with a pointer device.

## How has this been tested?

Tab through the block movers. The drag handle in the middle should be skipped.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
