### PR TITLE
Project management: Add prepublish packages command for npm releases

### DIFF
--- a/bin/commander.js
+++ b/bin/commander.js
@@ -757,8 +757,8 @@ program
 		await prepublishPackages();
 
 		console.log(
-			'\n>> 🎉 WordPress packages have been successfully published.\n',
-			'Thanks for performing the publish process! and don\'t forget to let people know on WordPress Slack.'
+			'\n>> 🎉 WordPress packages are ready to publish.\n',
+			'Thanks for performing the prepublish process! and don\'t forget to run Lerna and let people know on WordPress Slack afterward.'
 		);
 	} );
 

--- a/bin/commander.js
+++ b/bin/commander.js
@@ -732,7 +732,7 @@ async function prepublishPackages() {
 	// Cloning the Git repository.
 	await runGitRepositoryCloneStep( abortMessage );
 
-	// Checking out the WordPres release branch and doing sync with the last plugin relase.
+	// Checking out the WordPress release branch and doing sync with the last plugin release.
 	const { releaseBranch } = await runWordPressReleaseBranchSyncStep( abortMessage );
 
 	// Push the local changes

--- a/bin/commander.js
+++ b/bin/commander.js
@@ -237,8 +237,18 @@ async function updateThePluginStableVersion( version, abortMessage ) {
  */
 async function runCleanLocalCloneStep( abortMessage ) {
 	await runStep( 'Cleaning the temporary folder', abortMessage, async () => {
-		await rimraf( gitWorkingDirectoryPath );
-		await rimraf( svnWorkingDirectoryPath );
+		await Promise.all( [
+			gitWorkingDirectoryPath,
+			svnWorkingDirectoryPath,
+		].map( async ( directoryPath ) => {
+			if ( fs.existsSync( directoryPath ) ) {
+				await rimraf( directoryPath, ( err ) => {
+					if ( err ) {
+						throw err;
+					}
+				} );
+			}
+		} ) );
 	} );
 }
 
@@ -758,7 +768,8 @@ program
 
 		console.log(
 			'\n>> 🎉 WordPress packages are ready to publish.\n',
-			'Thanks for performing the prepublish process! and don\'t forget to run Lerna and let people know on WordPress Slack afterward.'
+			'Thanks for performing the prepublish process! You still need to run "npm run publish:prod" to perform the actual release.\n',
+			'Let also people know on WordPress Slack when everything is finished.'
 		);
 	} );
 


### PR DESCRIPTION
## Description
This PR adds a new command which handles prepublish to npm steps for a stable version of WordPress packages.

At the moment it only covers those steps which handle git management before Lerna takes over publishing to npm.

Check more details about the manual process in https://github.com/WordPress/gutenberg/blob/master/docs/contributors/release.md#synchronizing-wordpress-trunk.

## How has this been tested?
`./bin/commander.js prepublish-packages-stable`

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
