### PR TITLE
Fix post tag height (#19217)

### DIFF
--- a/packages/components/src/form-token-field/style.scss
+++ b/packages/components/src/form-token-field/style.scss
@@ -152,6 +152,7 @@
 	color: $dark-gray-500;
 	line-height: 10px;
 	overflow: initial;
+	height: 24px;
 
 	&:hover {
 		color: $dark-gray-700;


### PR DESCRIPTION
## Description
Fix issue #19217, bringing tag height back to appropriate dimensions.

## How has this been tested?
Mobile and desktop UI validation on Chrome and Firefox. 

## Screenshots 
![image](https://user-images.githubusercontent.com/5367401/71134314-840a2300-21dc-11ea-8d5c-fcc5c3f8ac51.png)
![image](https://user-images.githubusercontent.com/5367401/71134360-bfa4ed00-21dc-11ea-807d-c73c1a0bee80.png)


## Types of changes
One line CSS fix at `.components-form-token-field__remove-token.components-icon-button`

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
