### PR TITLE
Fix focus loop when autocompleting text on iOS

### DIFF
--- a/packages/rich-text/src/component/index.native.js
+++ b/packages/rich-text/src/component/index.native.js
@@ -437,7 +437,7 @@ export class RichText extends Component {
 
 		// Aztec can send us selection change events after it has lost focus.
 		// For instance the autocorrect feature will complete a partially written
-		// word when resiging focus, causing a selection change event.
+		// word when resigning focus, causing a selection change event.
 		// Forwarding this selection change could cause this RichText to regain
 		// focus and start a focus loop.
 		//

--- a/packages/rich-text/src/component/index.native.js
+++ b/packages/rich-text/src/component/index.native.js
@@ -435,7 +435,16 @@ export class RichText extends Component {
 			this.setState( { activeFormats } );
 		}
 
-		this.props.onSelectionChange( start, end );
+		// Aztec can send us selection change events after it has lost focus.
+		// For instance the autocorrect feature will complete a partially written
+		// word when resiging focus, causing a selection change event.
+		// Forwarding this selection change could cause this RichText to regain
+		// focus and start a focus loop.
+		//
+		// See https://github.com/wordpress-mobile/gutenberg-mobile/issues/1696
+		if ( this.props.__unstableIsSelected ) {
+			this.props.onSelectionChange( start, end );
+		}
 	}
 
 	onSelectionChangeFromAztec( start, end, text, event ) {


### PR DESCRIPTION
## Description

Aztec can send us selection change events after it has lost focus.

For instance the autocorrect feature will complete a partially written word when resigning focus, causing a selection change event. Forwarding this selection change could cause this RichText to regain focus and start a focus loop.

This PR prevents that selection forwarding when the RichText component isn't already selected.

I'm not sure what other side effects this could have, so pinging several people on this one 😬 

Fixes: https://github.com/wordpress-mobile/gutenberg-mobile/issues/1696

## How has this been tested?

gutenberg-mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1698

Tested with the steps in https://github.com/wordpress-mobile/gutenberg-mobile/issues/1696:

1. Have a media-text block
2. Start typing some text in the paragraph until iOS suggest a completion
3. Tap on the image

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
