### PR TITLE
Writing flow: improved tabbing for Edit mode

### DIFF
--- a/packages/dom/src/tabbable.js
+++ b/packages/dom/src/tabbable.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { without } from 'lodash';
+import { without, first, last } from 'lodash';
 
 /**
  * Internal dependencies
@@ -125,11 +125,56 @@ function compareObjectTabbables( a, b ) {
 	return aTabIndex - bTabIndex;
 }
 
-export function find( context ) {
-	return findFocusable( context )
+/**
+ * Givin focusable elements, filters out tabbable element.
+ *
+ * @param {Array} focusables Focusable elements to filter.
+ *
+ * @return {Array} Tabbable elements.
+ */
+function filterTabbable( focusables ) {
+	return focusables
 		.filter( isTabbableIndex )
 		.map( mapElementToObjectTabbable )
 		.sort( compareObjectTabbables )
 		.map( mapObjectTabbableToElement )
 		.reduce( createStatefulCollapseRadioGroup(), [] );
+}
+
+export function find( context ) {
+	return filterTabbable( findFocusable( context ) );
+}
+
+/**
+ * Given a focusable element, find the preceding tabbable element.
+ *
+ * @param {Element} element The focusable element before which to look. Defaults
+ *                          to the active element.
+ */
+export function findPrevious( element = document.activeElement ) {
+	const focusables = findFocusable( document.body );
+	const index = focusables.indexOf( element );
+
+	// Remove all focusables after and including `element`.
+	focusables.length = index;
+
+	return last( filterTabbable( focusables ) );
+}
+
+/**
+ * Given a focusable element, find the next tabbable element.
+ *
+ * @param {Element} element The focusable element after which to look. Defaults
+ *                          to the active element.
+ */
+export function findNext( element = document.activeElement ) {
+	const focusables = findFocusable( document.body );
+	const index = focusables.indexOf( element );
+
+	// Remove all focusables before and inside `element`.
+	const remaining = focusables
+		.slice( index + 1 )
+		.filter( ( node ) => ! element.contains( node ) );
+
+	return first( filterTabbable( remaining ) );
 }

--- a/packages/e2e-tests/specs/editor/blocks/preformatted.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/preformatted.test.js
@@ -39,7 +39,7 @@ describe( 'Preformatted', () => {
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( '2' );
 		await page.keyboard.press( 'Enter' );
-		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'ArrowDown' );
 		await page.keyboard.type( '3' );
 		await page.keyboard.press( 'ArrowLeft' );
 		await page.keyboard.press( 'Backspace' );


### PR DESCRIPTION
## Description

Spit out from #18779.
Blocks #18779.

This PR changes block navigation (tabbing) behaviour for Edit mode, which is needed for #18779. This turns out to be a drastic improvement from the current tabbing experience.

* When in Edit mode, pressing Tab will focus the next focusable element after the content, which is normally the inspector controls (sidebar which contain block controls), and pressing Shift+Tab will focus the focusable element before the content, which will be the block toolbar in #18779.
* When in Edit mode, pressing the arrow keys will navigate across blocks as before.
* When in Navigation mode (press Esc), pressing Tab will still focus the next block, and pressing Shift+Tab will focus the previous block.

I believe the new tabbing behaviour creates a beautiful balance between edit mode (super easy access to block controls), navigation mode (easy access to other blocks), and traditional editor navigation (arrow keys to access other blocks).

It also reduces the need for the obscure region shortcut `Ctrl+~` and toolbar shortcut `Alt+F10`.

From @MarcoZehe:

> I tested the latest and greatest from this pull request on gutenberg.run [#18779], and must say I am totally sold on this new tabbing behavior. This makes everything much more consistent than it was, and also makes everything reachable in a linear fashion. Moreover, if stuck in the side bar, there already is a Skip Link back to the main edit area, so one can nicely get around.
>
> I am all for taking this and deal with any fall-out in followups, also with improving the toolbar experience so it is ARIA authoring practices compliant. This is an enormous step forward from the current master.

## How has this been tested?

Tab around in Edit and Navigation mode.

## Screenshots <!-- if applicable -->

## Types of changes

Enhancement

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
