### PR TITLE
Documentation: Do not expose documentation for mobily only components

### DIFF
--- a/docs/manifest-devhub.json
+++ b/docs/manifest-devhub.json
@@ -840,12 +840,6 @@
 		"parent": "components"
 	},
 	{
-		"title": "StepperControl",
-		"slug": "stepper-control",
-		"markdown_source": "../packages/components/src/mobile/stepper-control/README.md",
-		"parent": "components"
-	},
-	{
 		"title": "Modal",
 		"slug": "modal",
 		"markdown_source": "../packages/components/src/modal/README.md",

--- a/docs/tool/manifest.js
+++ b/docs/tool/manifest.js
@@ -6,7 +6,10 @@ const fs = require( 'fs' );
 const glob = require( 'glob' ).sync;
 
 const baseRepoUrl = '..';
-const componentPaths = glob( 'packages/components/src/*/**/README.md' );
+const componentPaths = glob( 'packages/components/src/*/**/README.md', {
+	// Don't expose documentation for mobile only components just yet.
+	ignore: '**/mobile/*/README.md',
+} );
 const packagePaths = glob( 'packages/*/package.json' ).map(
 	( fileName ) => fileName.split( '/' )[ 1 ]
 );


### PR DESCRIPTION
## Description
Follow up for https://github.com/WordPress/gutenberg/pull/18864.

We aren't ready to with exposing the mobile-only components in the developer documentation for WordPress. This PR blacklists all components in the `mobile` folder and prevents them from being exposed to the public.

In particular, we don't want to have them listed at:

https://developer.wordpress.org/block-editor/components/