### PR TITLE
Navigation mode: enable on tab if no block is selected

### DIFF
--- a/packages/block-editor/src/components/writing-flow/index.js
+++ b/packages/block-editor/src/components/writing-flow/index.js
@@ -6,7 +6,7 @@ import { overEvery, find, findLast, reverse, first, last } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { Component, createRef } from '@wordpress/element';
+import { Component, createRef, useEffect } from '@wordpress/element';
 import {
 	computeCaretRect,
 	focus,
@@ -18,7 +18,7 @@ import {
 	isEntirelySelected,
 } from '@wordpress/dom';
 import { UP, DOWN, LEFT, RIGHT, TAB, isKeyboardEvent } from '@wordpress/keycodes';
-import { withSelect, withDispatch } from '@wordpress/data';
+import { withSelect, withDispatch, useDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 
 /**
@@ -98,6 +98,27 @@ function FocusCapture( { isReverse, clientId, isNavigationMode } ) {
 			style={ { position: 'fixed' } }
 		/>
 	);
+}
+
+/**
+ * Enables navigation mode as soon as tab is pressed.
+ * Meant to be rendered if there is no block selected.
+ */
+function EnableNavigationModeOnTab() {
+	const { setNavigationMode } = useDispatch( 'core/block-editor' );
+	useEffect( () => {
+		function handleTab( event ) {
+			if ( event.keyCode === TAB ) {
+				setNavigationMode( true );
+			}
+		}
+
+		window.addEventListener( 'keydown', handleTab );
+		return () => {
+			window.removeEventListener( 'keydown', handleTab );
+		};
+	}, [ setNavigationMode ] );
+	return null;
 }
 
 class WritingFlow extends Component {
@@ -475,6 +496,7 @@ class WritingFlow extends Component {
 					onClick={ this.focusLastTextField }
 					className="block-editor-writing-flow__click-redirect"
 				/>
+				{ ! clientId && <EnableNavigationModeOnTab /> }
 			</div>
 		);
 		/* eslint-enable jsx-a11y/no-static-element-interactions */

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1277,6 +1277,11 @@ export const blockListSettings = ( state = {}, action ) => {
  * @return {string} Updated state.
  */
 export function isNavigationMode( state = false, action ) {
+	// Let inserting block always trigger Edit mode.
+	if ( action.type === 'INSERT_BLOCKS' ) {
+		return false;
+	}
+
 	if ( action.type === 'SET_NAVIGATION_MODE' ) {
 		return action.isNavigationMode;
 	}

--- a/packages/editor/src/components/post-title/index.js
+++ b/packages/editor/src/components/post-title/index.js
@@ -169,7 +169,6 @@ const applyWithDispatch = withDispatch( ( dispatch ) => {
 	const {
 		insertDefaultBlock,
 		clearSelectedBlock,
-		setNavigationMode,
 	} = dispatch( 'core/block-editor' );
 	const {
 		editPost,
@@ -179,8 +178,6 @@ const applyWithDispatch = withDispatch( ( dispatch ) => {
 
 	return {
 		onEnterPress() {
-			// Ensure we're in edit mode when inserting paragraph to edit.
-			setNavigationMode( false );
 			insertDefaultBlock( undefined, undefined, 0 );
 		},
 		onUpdate( title ) {

--- a/packages/editor/src/components/post-title/index.js
+++ b/packages/editor/src/components/post-title/index.js
@@ -169,6 +169,7 @@ const applyWithDispatch = withDispatch( ( dispatch ) => {
 	const {
 		insertDefaultBlock,
 		clearSelectedBlock,
+		setNavigationMode,
 	} = dispatch( 'core/block-editor' );
 	const {
 		editPost,
@@ -178,6 +179,8 @@ const applyWithDispatch = withDispatch( ( dispatch ) => {
 
 	return {
 		onEnterPress() {
+			// Ensure we're in edit mode when inserting paragraph to edit.
+			setNavigationMode( false );
 			insertDefaultBlock( undefined, undefined, 0 );
 		},
 		onUpdate( title ) {


### PR DESCRIPTION
## Description

Following up on https://github.com/WordPress/gutenberg/pull/19235#pullrequestreview-334581972.

Currently, Edit mode is enabled by default. With the new tabbing behaviour, it might be a bit strange to immediately enter Edit mode when you first tab in the editor and to a block.

Instead, I would suggest to enable Navigation mode if the user navigates with `Tab` and if there are no blocks selected (yet).

The idea is that Navigation mode is in some way the default mode that you `Escape` to, and Edit mode the mode that you `Enter`.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
