### PR TITLE
[FIX] rich text focus loop

### DIFF
--- a/packages/rich-text/src/component/index.native.js
+++ b/packages/rich-text/src/component/index.native.js
@@ -411,6 +411,10 @@ export class RichText extends Component {
 	onBlur( event ) {
 		this.isTouched = false;
 
+		if ( event.nativeEvent.text !== this.props.value ) {
+			this.onTextUpdate( event );
+		}
+
 		if ( this.props.onBlur ) {
 			this.props.onBlur( event );
 		}

--- a/packages/rich-text/src/component/index.native.js
+++ b/packages/rich-text/src/component/index.native.js
@@ -411,7 +411,8 @@ export class RichText extends Component {
 	onBlur( event ) {
 		this.isTouched = false;
 
-		if ( event.nativeEvent.text !== this.props.value ) {
+		// Check if value is up to date with latest state of native AztecView
+		if ( event.nativeEvent.text && event.nativeEvent.text !== this.props.value ) {
 			this.onTextUpdate( event );
 		}
 

--- a/packages/rich-text/src/component/index.native.js
+++ b/packages/rich-text/src/component/index.native.js
@@ -440,16 +440,7 @@ export class RichText extends Component {
 			this.setState( { activeFormats } );
 		}
 
-		// Aztec can send us selection change events after it has lost focus.
-		// For instance the autocorrect feature will complete a partially written
-		// word when resigning focus, causing a selection change event.
-		// Forwarding this selection change could cause this RichText to regain
-		// focus and start a focus loop.
-		//
-		// See https://github.com/wordpress-mobile/gutenberg-mobile/issues/1696
-		if ( this.props.__unstableIsSelected ) {
-			this.props.onSelectionChange( start, end );
-		}
+		this.props.onSelectionChange( start, end );
 	}
 
 	onSelectionChangeFromAztec( start, end, text, event ) {
@@ -471,8 +462,16 @@ export class RichText extends Component {
 		// Make sure there are changes made to the content before upgrading it upward
 		this.onTextUpdate( event );
 
-		this.onSelectionChange( realStart, realEnd );
-
+		// Aztec can send us selection change events after it has lost focus.
+		// For instance the autocorrect feature will complete a partially written
+		// word when resigning focus, causing a selection change event.
+		// Forwarding this selection change could cause this RichText to regain
+		// focus and start a focus loop.
+		//
+		// See https://github.com/wordpress-mobile/gutenberg-mobile/issues/1696
+		if ( this.props.__unstableIsSelected ) {
+			this.onSelectionChange( realStart, realEnd );
+		}
 		// Update lastEventCount to prevent Aztec from re-rendering the content it just sent
 		this.lastEventCount = event.nativeEvent.eventCount;
 

--- a/packages/rich-text/src/component/index.native.js
+++ b/packages/rich-text/src/component/index.native.js
@@ -442,7 +442,7 @@ export class RichText extends Component {
 
 		// Aztec can send us selection change events after it has lost focus.
 		// For instance the autocorrect feature will complete a partially written
-		// word when resiging focus, causing a selection change event.
+		// word when resigning focus, causing a selection change event.
 		// Forwarding this selection change could cause this RichText to regain
 		// focus and start a focus loop.
 		//

--- a/packages/rich-text/src/component/index.native.js
+++ b/packages/rich-text/src/component/index.native.js
@@ -440,7 +440,16 @@ export class RichText extends Component {
 			this.setState( { activeFormats } );
 		}
 
-		this.props.onSelectionChange( start, end );
+		// Aztec can send us selection change events after it has lost focus.
+		// For instance the autocorrect feature will complete a partially written
+		// word when resiging focus, causing a selection change event.
+		// Forwarding this selection change could cause this RichText to regain
+		// focus and start a focus loop.
+		//
+		// See https://github.com/wordpress-mobile/gutenberg-mobile/issues/1696
+		if ( this.props.__unstableIsSelected ) {
+			this.props.onSelectionChange( start, end );
+		}
 	}
 
 	onSelectionChangeFromAztec( start, end, text, event ) {


### PR DESCRIPTION
## Description
This PR contains also changes from https://github.com/WordPress/gutenberg/pull/19234 

Gutenberg-mobile PR - https://github.com/wordpress-mobile/gutenberg-mobile/pull/1702

This is an only iOS issue.  Aztec doesn't trigger the `onChange` event with the new value when lost its focus while the suggestion is visible. We see the text from autocorrection but we have te written value in the store. The workaround for this is to pass text to the `onBlur` and update the value on the JS side if that one from onBlur is different.

## How has this been tested?
Tested with the steps in https://github.com/wordpress-mobile/gutenberg-mobile/issues/1696

- Have a media-text block
- Start typing some text in the paragraph until iOS suggests a completion
- Tap on the image
- There should not be a focus loop
- Switch to HTML mode and check if the text in the paragraph is correct

Please try 2 different scenarios:
- text from autocorrection has the same length as written text
- text from autocorrection has a different length as written text


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
