### PR TITLE
Show errors in the media replace control

### DIFF
--- a/packages/block-editor/src/components/media-replace-flow/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { uniqueId } from 'lodash';
+import { uniqueId, debounce } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -48,8 +48,13 @@ const MediaReplaceFlow = ( {
 	const errorNoticeID = uniqueId();
 
 	const onError = ( message ) => {
-		createNotice( 'error', renderToString( message ), {
-			speak: true,
+		const renderMsg = renderToString( message );
+		const speakMsg = debounce(
+			() => speak( renderToString( message ) ),
+			5000
+		);
+		speakMsg();
+		createNotice( 'error', renderMsg, {
 			id: errorNoticeID,
 			isDismissible: true,
 			__unstableHTML: true,

--- a/packages/block-editor/src/components/media-replace-flow/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { uniqueId, debounce } from 'lodash';
+import { uniqueId } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -48,17 +48,17 @@ const MediaReplaceFlow = ( {
 	const errorNoticeID = uniqueId();
 
 	const onError = ( message ) => {
-		const renderMsg = renderToString( message );
-		const speakMsg = debounce(
-			() => speak( renderToString( message ) ),
-			5000
-		);
-		speakMsg();
-		createNotice( 'error', renderMsg, {
-			id: errorNoticeID,
-			isDismissible: true,
-			__unstableHTML: true,
-		} );
+		const errorElement = document.createElement( 'div' );
+		errorElement.innerHTML = renderToString( message );
+		const renderMsg =
+			errorElement.textContent || errorElement.innerText || '';
+		setTimeout( () => {
+			createNotice( 'error', renderMsg, {
+				speak: true,
+				id: errorNoticeID,
+				isDismissible: true,
+			} );
+		}, 1000 );
 	};
 
 	const selectMedia = ( media ) => {
@@ -72,11 +72,10 @@ const MediaReplaceFlow = ( {
 		onSelectURL( newURL );
 	};
 
-	const uploadFiles = ( event, closeDropdown ) => {
+	const uploadFiles = ( event ) => {
 		const files = event.target.files;
 		const setMedia = ( [ media ] ) => {
 			selectMedia( media );
-			closeDropdown();
 		};
 		mediaUpload( {
 			allowedTypes,

--- a/packages/block-editor/src/components/media-replace-flow/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/index.js
@@ -45,13 +45,25 @@ const MediaReplaceFlow = ( {
 		return select( 'core/block-editor' ).getSettings().mediaUpload;
 	}, [] );
 	const editMediaButtonRef = createRef();
-	const errorNoticeID = uniqueId();
+	const errorNoticeID = uniqueId(
+		'block-editor/media-replace-flow/error-notice/'
+	);
 
 	const onError = ( message ) => {
 		const errorElement = document.createElement( 'div' );
 		errorElement.innerHTML = renderToString( message );
+		// The default error contains some HTML that,
+		// for example, makes the filename bold.
+		// The notice, by default, accepts strings only and so
+		// I am removing the html from the error.
 		const renderMsg =
 			errorElement.textContent || errorElement.innerText || '';
+		// We need to set a timeout for showing the notice
+		// so that VoiceOver and possibly other screen readers
+		// can announce the error afer the toolbar button
+		// regains focus once the upload dialog closes.
+		// Otherwise VO simply skips over the notice and announces
+		// the focused element and the open menu.
 		setTimeout( () => {
 			createNotice( 'error', renderMsg, {
 				speak: true,

--- a/packages/block-editor/src/components/media-replace-flow/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/index.js
@@ -55,7 +55,7 @@ const MediaReplaceFlow = ( {
 		// The default error contains some HTML that,
 		// for example, makes the filename bold.
 		// The notice, by default, accepts strings only and so
-		// I am removing the html from the error.
+		// we need to remove the html from the error.
 		const renderMsg =
 			errorElement.textContent || errorElement.innerText || '';
 		// We need to set a timeout for showing the notice

--- a/packages/block-editor/src/components/media-replace-flow/style.scss
+++ b/packages/block-editor/src/components/media-replace-flow/style.scss
@@ -15,6 +15,24 @@
 	margin-left: 4px;
 }
 
+.block-editor-media-flow__error {
+	padding: 0 20px 20px 20px;
+	max-width: 255px;
+
+	.components-with-notices-ui {
+		max-width: 255px;
+
+		.components-notice__content {
+			overflow: hidden;
+			word-wrap: break-word;
+		}
+		.components-notice__dismiss {
+			position: absolute;
+			right: 10px;
+		}
+	}
+}
+
 .block-editor-media-flow__url-input {
 	margin-top: $grid-unit-20;
 

--- a/packages/block-editor/src/components/media-replace-flow/style.scss
+++ b/packages/block-editor/src/components/media-replace-flow/style.scss
@@ -15,24 +15,6 @@
 	margin-left: 4px;
 }
 
-.block-editor-media-flow__error {
-	padding: 0 20px 20px 20px;
-	max-width: 255px;
-
-	.components-with-notices-ui {
-		max-width: 255px;
-
-		.components-notice__content {
-			overflow: hidden;
-			word-wrap: break-word;
-		}
-		.components-notice__dismiss {
-			position: absolute;
-			right: 10px;
-		}
-	}
-}
-
 .block-editor-media-flow__url-input {
 	margin-top: $grid-unit-20;
 
@@ -65,6 +47,24 @@
 
 		.block-editor-link-control__search-actions {
 			right: 4px;
+		}
+	}
+}
+
+.block-editor-media-flow__error {
+	padding: 0 20px 20px 20px;
+	max-width: 255px;
+
+	.components-with-notices-ui {
+		max-width: 255px;
+
+		.components-notice__content {
+			overflow: hidden;
+			word-wrap: break-word;
+		}
+		.components-notice__dismiss {
+			position: absolute;
+			right: 10px;
 		}
 	}
 }


### PR DESCRIPTION
## Description
Closes #19156 
If there is an upload error in the media replace control this PR displays the error 

## How has this been tested?
Tested locally, desktop and mobile.

## Screenshots 
![media-flow-show-errors](https://user-images.githubusercontent.com/107534/71185564-57a9e180-2284-11ea-93fc-dddd2ffef7cc.gif)

## Types of changes
Non breaking, added the noticesUI.

