### PR TITLE
Removes reusable block option from navigation link

### DIFF
--- a/packages/block-library/src/navigation-link/index.js
+++ b/packages/block-library/src/navigation-link/index.js
@@ -22,6 +22,10 @@ export const settings = {
 
 	description: __( 'Add a page, link, or another item to your navigation.' ),
 
+	supports: {
+		reusable: false,
+	},
+
 	__experimentalDisplayName: 'label',
 
 	edit,


### PR DESCRIPTION
Fixes #18341 by removing reusable blocks.

![image](https://user-images.githubusercontent.com/253067/71200033-271b7500-228f-11ea-94d2-0b588ea0e45e.png)
