### PR TITLE
Block Directory: Use the block's title for alt text on block directory plugin items.

### DIFF
--- a/packages/block-directory/src/components/downloadable-block-header/index.js
+++ b/packages/block-directory/src/components/downloadable-block-header/index.js
@@ -15,6 +15,7 @@ function DownloadableBlockHeader( { icon, title, rating, ratingCount, onClick } 
 		<div className="block-directory-downloadable-block-header__row">
 			{
 				icon.match( /\.(jpeg|jpg|gif|png)$/ ) !== null ?
+					// translators: %s: Name of the plugin e.g: "Akismet".
 					<img src={ icon } alt={ sprintf( __( '%s block icon' ), title ) } /> :
 					<span >
 						<BlockIcon icon={ icon } showColors />

--- a/packages/block-directory/src/components/downloadable-block-header/index.js
+++ b/packages/block-directory/src/components/downloadable-block-header/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { Button } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -15,7 +15,7 @@ function DownloadableBlockHeader( { icon, title, rating, ratingCount, onClick } 
 		<div className="block-directory-downloadable-block-header__row">
 			{
 				icon.match( /\.(jpeg|jpg|gif|png)$/ ) !== null ?
-					<img src={ icon } alt="block icon" /> :
+					<img src={ icon } alt={ sprintf( __( '%s block icon' ), title ) } /> :
 					<span >
 						<BlockIcon icon={ icon } showColors />
 					</span>


### PR DESCRIPTION
## Description
We currently have a less than useful placeholder text ( 'block icon' ) for the icon that is associated to the block directory plugin. This PR grabs the blocks title, which cannot be blank, localizes it and adds it as the alt text.

This suggestion was spun out of a PR that was accepted and closed. See here:
https://github.com/WordPress/gutenberg/pull/16524/files#r324268820

### Considerations:
I considered removing the alt tag altogether but this image feels more like content than something ornamental. (ref: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/)

## How has this been tested?
The only applicable test is to inspect the `<img>` tag and locate the `alt` attribute.

## Screenshots <!-- if applicable -->
None

## Types of changes
Bug fix 

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
