### PR TITLE
Blocks: Update default block categories

### DIFF
--- a/docs/designers-developers/developers/data/data-core-blocks.md
+++ b/docs/designers-developers/developers/data/data-core-blocks.md
@@ -85,20 +85,6 @@ _Returns_
 
 -   `Array<WPBlockCategory>`: Categories list.
 
-<a name="getCategory" href="#getCategory">#</a> **getCategory**
-
-Returns a single category by slug. Canonicalizes category by slug, using
-internal mapping of legacy category slugs to their updated normal form.
-
-_Parameters_
-
--   _state_ `Object`: Blocks state.
--   _slug_ `string`: Category slug.
-
-_Returns_
-
--   `(WPBlockCategory|undefined)`: Block category, if exists.
-
 <a name="getChildBlockNames" href="#getChildBlockNames">#</a> **getChildBlockNames**
 
 Returns an array with the child blocks of a given block.

--- a/docs/designers-developers/developers/data/data-core-blocks.md
+++ b/docs/designers-developers/developers/data/data-core-blocks.md
@@ -83,7 +83,21 @@ _Parameters_
 
 _Returns_
 
--   `Array`: Categories list.
+-   `Array<WPBlockCategory>`: Categories list.
+
+<a name="getCategory" href="#getCategory">#</a> **getCategory**
+
+Returns a single category by slug. Canonicalizes category by slug, using
+internal mapping of legacy category slugs to their updated normal form.
+
+_Parameters_
+
+-   _state_ `Object`: Blocks state.
+-   _slug_ `string`: Category slug.
+
+_Returns_
+
+-   `(WPBlockCategory|undefined)`: Block category, if exists.
 
 <a name="getChildBlockNames" href="#getChildBlockNames">#</a> **getChildBlockNames**
 

--- a/docs/designers-developers/developers/tutorials/block-tutorial/applying-styles-with-stylesheets.md
+++ b/docs/designers-developers/developers/tutorials/block-tutorial/applying-styles-with-stylesheets.md
@@ -14,7 +14,7 @@ registerBlockType( 'gutenberg-examples/example-02-stylesheets', {
 
 	icon: 'universal-access-alt',
 
-	category: 'layout',
+	category: 'design',
 
 	example: {},
 
@@ -35,7 +35,7 @@ registerBlockType( 'gutenberg-examples/example-02-stylesheets', {
 	blocks.registerBlockType( 'gutenberg-examples/example-02-stylesheets', {
 		title: 'Example: Stylesheets',
 		icon: 'universal-access-alt',
-		category: 'layout',
+		category: 'design',
 		example: {},
 		edit: function( props ) {
 			return el(

--- a/docs/designers-developers/developers/tutorials/block-tutorial/block-controls-toolbar-and-sidebar.md
+++ b/docs/designers-developers/developers/tutorials/block-tutorial/block-controls-toolbar-and-sidebar.md
@@ -24,7 +24,7 @@ import {
 registerBlockType( 'gutenberg-examples/example-04-controls-esnext', {
 	title: 'Example: Controls (esnext)',
 	icon: 'universal-access-alt',
-	category: 'layout',
+	category: 'design',
 	attributes: {
 		content: {
 			type: 'array',
@@ -101,7 +101,7 @@ registerBlockType( 'gutenberg-examples/example-04-controls-esnext', {
 	blocks.registerBlockType( 'gutenberg-examples/example-04-controls', {
 		title: 'Example: Controls',
 		icon: 'universal-access-alt',
-		category: 'layout',
+		category: 'design',
 
 		attributes: {
 			content: {

--- a/docs/designers-developers/developers/tutorials/block-tutorial/introducing-attributes-and-editable-fields.md
+++ b/docs/designers-developers/developers/tutorials/block-tutorial/introducing-attributes-and-editable-fields.md
@@ -61,7 +61,7 @@ import { RichText } from '@wordpress/block-editor';
 registerBlockType( 'gutenberg-examples/example-03-editable-esnext', {
 	title: 'Example: Editable (esnext)',
 	icon: 'universal-access-alt',
-	category: 'layout',
+	category: 'design',
 	attributes: {
 		content: {
 			type: 'array',
@@ -102,7 +102,7 @@ registerBlockType( 'gutenberg-examples/example-03-editable-esnext', {
 	blocks.registerBlockType( 'gutenberg-examples/example-03-editable', {
 		title: 'Example: Editable',
 		icon: 'universal-access-alt',
-		category: 'layout',
+		category: 'design',
 
 		attributes: {
 			content: {

--- a/docs/designers-developers/developers/tutorials/block-tutorial/nested-blocks-inner-blocks.md
+++ b/docs/designers-developers/developers/tutorials/block-tutorial/nested-blocks-inner-blocks.md
@@ -15,7 +15,7 @@ Here is the basic InnerBlocks usage.
 
 	blocks.registerBlockType( 'gutenberg-examples/example-06', {
 		title: 'Example: Inner Blocks',
-		category: 'layout',
+		category: 'design',
 
 		edit: function( props ) {
 			return el(

--- a/docs/designers-developers/developers/tutorials/block-tutorial/writing-your-first-block-type.md
+++ b/docs/designers-developers/developers/tutorials/block-tutorial/writing-your-first-block-type.md
@@ -61,7 +61,7 @@ const blockStyle = {
 registerBlockType( 'gutenberg-examples/example-01-basic-esnext', {
 	title: 'Example: Basic (esnext)',
 	icon: 'universal-access-alt',
-	category: 'layout',
+	category: 'design',
 	example: {},
 	edit() {
 		return <div style={ blockStyle }>Hello World, step 1 (from the editor).</div>;
@@ -85,7 +85,7 @@ registerBlockType( 'gutenberg-examples/example-01-basic-esnext', {
 	blocks.registerBlockType( 'gutenberg-examples/example-01-basic', {
 		title: 'Example: Basic',
 		icon: 'universal-access-alt',
-		category: 'layout',
+		category: 'design',
 		example: {},
 		edit: function() {
 			return el(

--- a/docs/designers-developers/developers/tutorials/javascript/js-build-setup.md
+++ b/docs/designers-developers/developers/tutorials/javascript/js-build-setup.md
@@ -107,7 +107,7 @@ import { registerBlockType } from '@wordpress/blocks';
 registerBlockType( 'myguten/test-block', {
 	title: 'Basic Example',
 	icon: 'smiley',
-	category: 'layout',
+	category: 'design',
 	edit: () => <div>Hola, mundo!</div>,
 	save: () => <div>Hola, mundo!</div>,
 } );

--- a/docs/designers-developers/developers/tutorials/metabox/meta-block-3-add.md
+++ b/docs/designers-developers/developers/tutorials/metabox/meta-block-3-add.md
@@ -21,7 +21,7 @@ Add this code to your JavaScript file (this tutorial will call the file `myguten
 	registerBlockType( 'myguten/meta-block', {
 		title: 'Meta Block',
 		icon: 'smiley',
-		category: 'common',
+		category: 'text',
 
 		edit: function( props ) {
 			var className = props.className;
@@ -82,7 +82,7 @@ import { useEntityProp } from '@wordpress/core-data';
 registerBlockType( 'myguten/meta-block', {
 	title: 'Meta Block',
 	icon: 'smiley',
-	category: 'common',
+	category: 'text',
 
 	edit( { className, setAttributes, attributes } ) {
 		const postType = useSelect(

--- a/docs/rfc/block-registration.md
+++ b/docs/rfc/block-registration.md
@@ -64,7 +64,7 @@ To register a new block type, start by creating a `block.json` file. This file:
 {
 	"name": "my-plugin/notice",
 	"title": "Notice",
-	"category": "common",
+	"category": "text",
 	"parent": [ "core/group" ],
 	"icon": "star",
 	"description": "Shows warning, error or success notices  ...",
@@ -134,7 +134,7 @@ This is the display title for your block, which can be translated with our trans
 * Property: `category`
 
 ```json
-{ "category": "common" }
+{ "category": "text" }
 ```
 
 Blocks are grouped into categories to help users browse and discover them.
@@ -149,7 +149,7 @@ The core provided categories are:
 
 Plugins and Themes can also register [custom block categories](/docs/designers-developers/developers/filters/block-filters.md#managing-block-categories).
 
-An implementation should expect and tolerate unknown categories, providing some reasonable fallback behavior (e.g. a "common" category).
+An implementation should expect and tolerate unknown categories, providing some reasonable fallback behavior (e.g. a "text" category).
 
 ### Parent
 

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -210,8 +210,20 @@ function gutenberg_replace_default_block_categories( $default_categories ) {
 
 	/*
 	 * At this point, `$substitution` should contain only the categories which
-	 * could not be in-place substituted with a default category, presumably due
-	 * to earlier filtering of the default categories. These should be appended.
+	 * could not be in-place substituted with a default category, likely in the
+	 * case that core has since been updated to use the default categories.
+	 * Check to verify they exist.
+	 */
+	$default_category_slugs = wp_list_pluck( $default_categories, 'slug' );
+	foreach ( $substitution as $i => $substitute_category ) {
+		if ( in_array( $substitute_category['slug'], $default_category_slugs, true ) ) {
+			unset( $substitution[ $i ] );
+		}
+	}
+
+	/*
+	 * Any substitutes remaining should be appended, as they are not yet
+	 * assigned in the default categories array.
 	 */
 	return array_merge( $default_categories, array_values( $substitution ) );
 }

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -172,9 +172,9 @@ function gutenberg_get_post_from_context() {
  * Filters default block categories to substitute legacy category names with new
  * block categories.
  *
- * This can be removed when plugin support requires WordPress 5.4.0+.
+ * This can be removed when plugin support requires WordPress 5.5.0+.
  *
- * @see Trac Ticket TBD
+ * @see https://core.trac.wordpress.org/ticket/50278
  *
  * @param array[] $default_categories Array of block categories.
  *

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -169,6 +169,55 @@ function gutenberg_get_post_from_context() {
 }
 
 /**
+ * Filters default block categories to substitute legacy category names with new
+ * block categories.
+ *
+ * This can be removed when plugin support requires WordPress 5.4.0+.
+ *
+ * @see Trac Ticket TBD
+ *
+ * @param array[] $default_categories Array of block categories.
+ *
+ * @return array[] Filtered block categories.
+ */
+function gutenberg_replace_default_block_categories( $default_categories ) {
+	$substitution = array(
+		'common'     => array(
+			'slug'  => 'text',
+			'title' => __( 'Text', 'gutenberg' ),
+			'icon'  => null,
+		),
+		'formatting' => array(
+			'slug'  => 'media',
+			'title' => __( 'Media', 'gutenberg' ),
+			'icon'  => null,
+		),
+		'layout'     => array(
+			'slug'  => 'design',
+			'title' => __( 'Design', 'gutenberg' ),
+			'icon'  => null,
+		),
+	);
+
+	// Loop default categories to perform in-place substitution by legacy slug.
+	foreach ( $default_categories as $i => $default_category ) {
+		$slug = $default_category['slug'];
+		if ( isset( $substitution[ $slug ] ) ) {
+			$default_categories[ $i ] = $substitution[ $slug ];
+			unset( $substitution[ $slug ] );
+		}
+	}
+
+	/*
+	 * At this point, `$substitution` should contain only the categories which
+	 * could not be in-place substituted with a default category, presumably due
+	 * to earlier filtering of the default categories. These should be appended.
+	 */
+	return array_merge( $default_categories, array_values( $substitution ) );
+}
+add_filter( 'block_categories', 'gutenberg_replace_default_block_categories' );
+
+/**
  * Shim that hooks into `pre_render_block` so as to override `render_block` with
  * a function that assigns block context.
  *

--- a/packages/block-editor/src/autocompleters/test/block.js
+++ b/packages/block-editor/src/autocompleters/test/block.js
@@ -73,14 +73,14 @@ describe( 'block', () => {
 			name: 'core/foo',
 			title: 'foo',
 			keywords: [ 'foo-keyword-1', 'foo-keyword-2' ],
-			category: 'formatting',
+			category: 'design',
 		};
 		const inserterItemWithTitleAndEmptyKeywords = {
 			name: 'core/bar',
 			title: 'bar',
 			// Intentionally empty keyword list
 			keywords: [],
-			category: 'common',
+			category: 'text',
 		};
 		const inserterItemWithTitleAndUndefinedKeywords = {
 			name: 'core/baz',
@@ -91,12 +91,12 @@ describe( 'block', () => {
 
 		expect(
 			blockCompleter.getOptionKeywords( inserterItemWithTitleAndKeywords )
-		).toEqual( [ 'formatting', 'foo-keyword-1', 'foo-keyword-2', 'foo' ] );
+		).toEqual( [ 'design', 'foo-keyword-1', 'foo-keyword-2', 'foo' ] );
 		expect(
 			blockCompleter.getOptionKeywords(
 				inserterItemWithTitleAndEmptyKeywords
 			)
-		).toEqual( [ 'common', 'bar' ] );
+		).toEqual( [ 'text', 'bar' ] );
 		expect(
 			blockCompleter.getOptionKeywords(
 				inserterItemWithTitleAndUndefinedKeywords

--- a/packages/block-editor/src/components/block-edit/test/edit.js
+++ b/packages/block-editor/src/components/block-edit/test/edit.js
@@ -36,7 +36,7 @@ describe( 'Edit', () => {
 		const edit = () => <div />;
 		registerBlockType( 'core/test-block', {
 			save: noop,
-			category: 'common',
+			category: 'text',
 			title: 'block title',
 			edit,
 		} );
@@ -50,7 +50,7 @@ describe( 'Edit', () => {
 		const save = () => <div />;
 		registerBlockType( 'core/test-block', {
 			save,
-			category: 'common',
+			category: 'text',
 			title: 'block title',
 		} );
 
@@ -67,7 +67,7 @@ describe( 'Edit', () => {
 		registerBlockType( 'core/test-block', {
 			edit,
 			save: noop,
-			category: 'common',
+			category: 'text',
 			title: 'block title',
 		} );
 
@@ -84,7 +84,7 @@ describe( 'Edit', () => {
 	it( 'should assign context', () => {
 		const edit = ( { context } ) => context.value;
 		registerBlockType( 'core/test-block', {
-			category: 'common',
+			category: 'text',
 			title: 'block title',
 			context: [ 'value' ],
 			edit,
@@ -104,7 +104,7 @@ describe( 'Edit', () => {
 		it( 'should assign context', () => {
 			const edit = ( { context } ) => context.value;
 			registerBlockType( 'core/test-block', {
-				category: 'common',
+				category: 'text',
 				title: 'block title',
 				context: [ 'value' ],
 				supports: {

--- a/packages/block-editor/src/components/block-switcher/test/index.js
+++ b/packages/block-editor/src/components/block-switcher/test/index.js
@@ -49,7 +49,7 @@ describe( 'BlockSwitcher', () => {
 
 	beforeAll( () => {
 		registerBlockType( 'core/heading', {
-			category: 'common',
+			category: 'text',
 			title: 'Heading',
 			edit: () => {},
 			save: () => {},
@@ -71,7 +71,7 @@ describe( 'BlockSwitcher', () => {
 		} );
 
 		registerBlockType( 'core/paragraph', {
-			category: 'common',
+			category: 'text',
 			title: 'Paragraph',
 			edit: () => {},
 			save: () => {},

--- a/packages/block-editor/src/components/inner-blocks/test/index.js
+++ b/packages/block-editor/src/components/inner-blocks/test/index.js
@@ -25,7 +25,7 @@ describe( 'InnerBlocks', () => {
 
 	it( 'should return element as string, with inner blocks', () => {
 		registerBlockType( 'core/fruit', {
-			category: 'common',
+			category: 'text',
 
 			title: 'fruit',
 
@@ -88,7 +88,7 @@ describe( 'InnerBlocks', () => {
 					</p>
 				);
 			},
-			category: 'common',
+			category: 'text',
 			title: 'block title',
 		};
 		registerBlockType( 'core/test-block', blockType );

--- a/packages/block-editor/src/components/inserter/test/block-list.js
+++ b/packages/block-editor/src/components/inserter/test/block-list.js
@@ -104,7 +104,7 @@ describe( 'InserterMenu', () => {
 		expect( embedTabTitle.textContent ).toBe( 'Embeds' );
 		expect( blocks ).toHaveLength( 2 );
 		expect( blocks[ 0 ].textContent ).toBe( 'YouTube' );
-		expect( blocks[ 1 ].textContent ).toBe( 'A Text Embed' );
+		expect( blocks[ 1 ].textContent ).toBe( 'A Paragraph Embed' );
 
 		assertNoResultsMessageNotToBePresent( container );
 	} );
@@ -140,10 +140,10 @@ describe( 'InserterMenu', () => {
 			'.block-editor-block-types-list__item-title'
 		);
 
-		expect( commonTabTitle.textContent ).toBe( 'Common blocks' );
+		expect( commonTabTitle.textContent ).toBe( 'Text' );
 		expect( blocks ).toHaveLength( 3 );
-		expect( blocks[ 0 ].textContent ).toBe( 'Text' );
-		expect( blocks[ 1 ].textContent ).toBe( 'Advanced Text' );
+		expect( blocks[ 0 ].textContent ).toBe( 'Paragraph' );
+		expect( blocks[ 1 ].textContent ).toBe( 'Advanced Paragraph' );
 		expect( blocks[ 2 ].textContent ).toBe( 'Some Other Block' );
 
 		assertNoResultsMessageNotToBePresent( container );
@@ -164,7 +164,7 @@ describe( 'InserterMenu', () => {
 
 	it( 'should allow searching for items', () => {
 		const { container } = render(
-			<InserterBlockList filterValue="text" />
+			<InserterBlockList filterValue="paragraph" />
 		);
 
 		const matchingCategories = container.querySelectorAll(
@@ -172,7 +172,7 @@ describe( 'InserterMenu', () => {
 		);
 
 		expect( matchingCategories ).toHaveLength( 3 );
-		expect( matchingCategories[ 0 ].textContent ).toBe( 'Common blocks' );
+		expect( matchingCategories[ 0 ].textContent ).toBe( 'Text' );
 		expect( matchingCategories[ 1 ].textContent ).toBe( 'Embeds' );
 		expect( matchingCategories[ 2 ].textContent ).toBe( 'Core' ); // "Core" namespace collection
 
@@ -186,13 +186,13 @@ describe( 'InserterMenu', () => {
 		expect( debouncedSpeak ).toHaveBeenCalledWith( '3 results found.' );
 
 		// Default block results.
-		expect( blocks[ 0 ].textContent ).toBe( 'Text' );
-		expect( blocks[ 1 ].textContent ).toBe( 'Advanced Text' );
-		expect( blocks[ 2 ].textContent ).toBe( 'A Text Embed' );
+		expect( blocks[ 0 ].textContent ).toBe( 'Paragraph' );
+		expect( blocks[ 1 ].textContent ).toBe( 'Advanced Paragraph' );
+		expect( blocks[ 2 ].textContent ).toBe( 'A Paragraph Embed' );
 
 		// Collection results.
-		expect( blocks[ 3 ].textContent ).toBe( 'Text' );
-		expect( blocks[ 4 ].textContent ).toBe( 'Advanced Text' );
+		expect( blocks[ 3 ].textContent ).toBe( 'Paragraph' );
+		expect( blocks[ 4 ].textContent ).toBe( 'Advanced Paragraph' );
 
 		assertNoResultsMessageNotToBePresent( container );
 	} );
@@ -243,7 +243,7 @@ describe( 'InserterMenu', () => {
 
 	it( 'should trim whitespace of search terms', () => {
 		const { container } = render(
-			<InserterBlockList filterValue=" text" />
+			<InserterBlockList filterValue=" paragraph" />
 		);
 
 		const matchingCategories = container.querySelectorAll(
@@ -251,7 +251,7 @@ describe( 'InserterMenu', () => {
 		);
 
 		expect( matchingCategories ).toHaveLength( 3 );
-		expect( matchingCategories[ 0 ].textContent ).toBe( 'Common blocks' );
+		expect( matchingCategories[ 0 ].textContent ).toBe( 'Text' );
 		expect( matchingCategories[ 1 ].textContent ).toBe( 'Embeds' );
 
 		const blocks = container.querySelectorAll(
@@ -259,9 +259,9 @@ describe( 'InserterMenu', () => {
 		);
 
 		expect( blocks ).toHaveLength( 5 );
-		expect( blocks[ 0 ].textContent ).toBe( 'Text' );
-		expect( blocks[ 1 ].textContent ).toBe( 'Advanced Text' );
-		expect( blocks[ 2 ].textContent ).toBe( 'A Text Embed' );
+		expect( blocks[ 0 ].textContent ).toBe( 'Paragraph' );
+		expect( blocks[ 1 ].textContent ).toBe( 'Advanced Paragraph' );
+		expect( blocks[ 2 ].textContent ).toBe( 'A Paragraph Embed' );
 
 		assertNoResultsMessageNotToBePresent( container );
 	} );

--- a/packages/block-editor/src/components/inserter/test/fixtures/index.js
+++ b/packages/block-editor/src/components/inserter/test/fixtures/index.js
@@ -1,7 +1,7 @@
 export const categories = [
-	{ slug: 'common', title: 'Common blocks' },
-	{ slug: 'formatting', title: 'Formatting' },
-	{ slug: 'layout', title: 'Layout elements' },
+	{ slug: 'text', title: 'Text' },
+	{ slug: 'media', title: 'Media' },
+	{ slug: 'design', title: 'Design' },
 	{ slug: 'widgets', title: 'Widgets' },
 	{ slug: 'embed', title: 'Embeds' },
 	{ slug: 'reusable', title: 'Reusable blocks' },
@@ -14,12 +14,12 @@ export const collections = {
 	},
 };
 
-export const textItem = {
-	id: 'core/text-block',
-	name: 'core/text-block',
+export const paragraphItem = {
+	id: 'core/paragraph-block',
+	name: 'core/paragraph-block',
 	initialAttributes: {},
-	title: 'Text',
-	category: 'common',
+	title: 'Paragraph',
+	category: 'text',
 	isDisabled: false,
 	utility: 1,
 };
@@ -48,12 +48,12 @@ export const withVariationsItem = {
 	],
 };
 
-export const advancedTextItem = {
-	id: 'core/advanced-text-block',
-	name: 'core/advanced-text-block',
+export const advancedParagraphItem = {
+	id: 'core/advanced-paragraph-block',
+	name: 'core/advanced-paragraph-block',
 	initialAttributes: {},
-	title: 'Advanced Text',
-	category: 'common',
+	title: 'Advanced Paragraph',
+	category: 'text',
 	isDisabled: false,
 	utility: 1,
 };
@@ -63,7 +63,7 @@ export const someOtherItem = {
 	name: 'core/some-other-block',
 	initialAttributes: {},
 	title: 'Some Other Block',
-	category: 'common',
+	category: 'text',
 	isDisabled: false,
 	utility: 1,
 };
@@ -73,7 +73,7 @@ export const moreItem = {
 	name: 'core/more-block',
 	initialAttributes: {},
 	title: 'More',
-	category: 'layout',
+	category: 'design',
 	isDisabled: true,
 	utility: 1,
 };
@@ -89,11 +89,11 @@ export const youtubeItem = {
 	utility: 1,
 };
 
-export const textEmbedItem = {
-	id: 'core-embed/a-text-embed',
-	name: 'core-embed/a-text-embed',
+export const paragraphEmbedItem = {
+	id: 'core-embed/a-paragraph-embed',
+	name: 'core-embed/a-paragraph-embed',
 	initialAttributes: {},
-	title: 'A Text Embed',
+	title: 'A Paragraph Embed',
 	category: 'embed',
 	isDisabled: false,
 	utility: 1,
@@ -110,12 +110,12 @@ export const reusableItem = {
 };
 
 export default [
-	textItem,
 	withVariationsItem,
-	advancedTextItem,
+	paragraphItem,
+	advancedParagraphItem,
 	someOtherItem,
 	moreItem,
 	youtubeItem,
-	textEmbedItem,
+	paragraphEmbedItem,
 	reusableItem,
 ];

--- a/packages/block-editor/src/components/inserter/test/search-items.js
+++ b/packages/block-editor/src/components/inserter/test/search-items.js
@@ -4,11 +4,11 @@
 import items, {
 	categories,
 	collections,
-	textItem,
-	advancedTextItem,
+	paragraphItem,
+	advancedParagraphItem,
 	moreItem,
 	youtubeItem,
-	textEmbedItem,
+	paragraphEmbedItem,
 } from './fixtures';
 import { normalizeSearchTerm, searchBlockItems } from '../search-items';
 
@@ -45,8 +45,12 @@ describe( 'searchBlockItems', () => {
 
 	it( 'should search items using the title ignoring case', () => {
 		expect(
-			searchBlockItems( items, categories, collections, 'TEXT' )
-		).toEqual( [ textItem, advancedTextItem, textEmbedItem ] );
+			searchBlockItems( items, categories, collections, 'paragraph' )
+		).toEqual( [
+			paragraphItem,
+			advancedParagraphItem,
+			paragraphEmbedItem,
+		] );
 	} );
 
 	it( 'should search items using the keywords and partial terms', () => {
@@ -57,7 +61,7 @@ describe( 'searchBlockItems', () => {
 
 	it( 'should search items using the categories', () => {
 		expect(
-			searchBlockItems( items, categories, collections, 'LAYOUT' )
+			searchBlockItems( items, categories, collections, 'DESIGN' )
 		).toEqual( [ moreItem ] );
 	} );
 

--- a/packages/block-editor/src/components/inspector-controls/README.md
+++ b/packages/block-editor/src/components/inspector-controls/README.md
@@ -25,7 +25,7 @@ registerBlockType( 'my-plugin/inspector-controls-example', {
 
 	icon: 'universal-access-alt',
 
-	category: 'layout',
+	category: 'design',
 
 	attributes: {
 		content: {
@@ -253,7 +253,7 @@ registerBlockType( 'my-plugin/inspector-controls-example', {
 
 	icon: 'universal-access-alt',
 
-	category: 'layout',
+	category: 'design',
 
 	attributes: {
 		content: {

--- a/packages/block-editor/src/hooks/test/align.js
+++ b/packages/block-editor/src/hooks/test/align.js
@@ -28,7 +28,7 @@ import {
 describe( 'align', () => {
 	const blockSettings = {
 		save: noop,
-		category: 'common',
+		category: 'text',
 		title: 'block title',
 	};
 

--- a/packages/block-editor/src/hooks/test/custom-class-name.js
+++ b/packages/block-editor/src/hooks/test/custom-class-name.js
@@ -11,13 +11,13 @@ import { getHTMLRootElementClasses } from '../custom-class-name';
 describe( 'custom className', () => {
 	const blockSettings = {
 		save: () => <div className="default" />,
-		category: 'common',
+		category: 'text',
 		title: 'block title',
 	};
 
 	const dynamicBlockSettings = {
 		save: () => null,
-		category: 'common',
+		category: 'text',
 		title: 'block title',
 	};
 

--- a/packages/block-editor/src/hooks/test/generated-class-name.js
+++ b/packages/block-editor/src/hooks/test/generated-class-name.js
@@ -17,7 +17,7 @@ describe( 'generated className', () => {
 	const blockSettings = {
 		name: 'chicken/ribs',
 		save: noop,
-		category: 'common',
+		category: 'text',
 		title: 'block title',
 	};
 

--- a/packages/block-editor/src/hooks/test/utils.js
+++ b/packages/block-editor/src/hooks/test/utils.js
@@ -16,7 +16,7 @@ import '../anchor';
 describe( 'anchor', () => {
 	const blockSettings = {
 		save: noop,
-		category: 'common',
+		category: 'text',
 		title: 'block title',
 	};
 

--- a/packages/block-editor/src/store/test/effects.js
+++ b/packages/block-editor/src/store/test/effects.js
@@ -39,7 +39,7 @@ describe( 'effects', () => {
 			content: {},
 		},
 		save: () => 'Saved',
-		category: 'common',
+		category: 'text',
 		title: 'block title',
 	};
 
@@ -93,7 +93,7 @@ describe( 'effects', () => {
 					};
 				},
 				save: noop,
-				category: 'common',
+				category: 'text',
 				title: 'test block',
 			} );
 			const blockA = deepFreeze( {
@@ -165,7 +165,7 @@ describe( 'effects', () => {
 					};
 				},
 				save: noop,
-				category: 'common',
+				category: 'text',
 				title: 'test block',
 			} );
 			registerBlockType( 'core/test-block-2', defaultBlockSettings );
@@ -216,7 +216,7 @@ describe( 'effects', () => {
 					};
 				},
 				save: noop,
-				category: 'common',
+				category: 'text',
 				title: 'test block',
 			} );
 			registerBlockType( 'core/test-block-2', {
@@ -239,7 +239,7 @@ describe( 'effects', () => {
 					],
 				},
 				save: noop,
-				category: 'common',
+				category: 'text',
 				title: 'test block 2',
 			} );
 			const blockA = deepFreeze( {

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -169,7 +169,7 @@ describe( 'state', () => {
 			registerBlockType( 'core/test-block', {
 				save: noop,
 				edit: noop,
-				category: 'common',
+				category: 'text',
 				title: 'test block',
 			} );
 		} );
@@ -183,13 +183,13 @@ describe( 'state', () => {
 				registerBlockType( 'core/test-parent-block', {
 					save: noop,
 					edit: noop,
-					category: 'common',
+					category: 'text',
 					title: 'test parent block',
 				} );
 				registerBlockType( 'core/test-child-block', {
 					save: noop,
 					edit: noop,
-					category: 'common',
+					category: 'text',
 					title: 'test child block 1',
 					attributes: {
 						attr: {

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -84,7 +84,7 @@ describe( 'selectors', () => {
 
 		registerBlockType( 'core/test-block-a', {
 			save: ( props ) => props.attributes.text,
-			category: 'formatting',
+			category: 'design',
 			title: 'Test Block A',
 			icon: 'test',
 			keywords: [ 'testing' ],
@@ -92,7 +92,7 @@ describe( 'selectors', () => {
 
 		registerBlockType( 'core/test-block-b', {
 			save: ( props ) => props.attributes.text,
-			category: 'common',
+			category: 'text',
 			title: 'Test Block B',
 			icon: 'test',
 			keywords: [ 'testing' ],
@@ -103,7 +103,7 @@ describe( 'selectors', () => {
 
 		registerBlockType( 'core/test-block-c', {
 			save: ( props ) => props.attributes.text,
-			category: 'common',
+			category: 'text',
 			title: 'Test Block C',
 			icon: 'test',
 			keywords: [ 'testing' ],
@@ -112,7 +112,7 @@ describe( 'selectors', () => {
 
 		registerBlockType( 'core/test-freeform', {
 			save: ( props ) => <RawHTML>{ props.attributes.content }</RawHTML>,
-			category: 'common',
+			category: 'text',
 			title: 'Test Freeform Content Handler',
 			icon: 'test',
 			attributes: {
@@ -124,7 +124,7 @@ describe( 'selectors', () => {
 
 		registerBlockType( 'core/post-content-child', {
 			save: () => null,
-			category: 'common',
+			category: 'text',
 			title: 'Test Block Post Content Child',
 			icon: 'test',
 			keywords: [ 'testing' ],
@@ -2316,7 +2316,7 @@ describe( 'selectors', () => {
 				icon: {
 					src: 'test',
 				},
-				category: 'formatting',
+				category: 'design',
 				keywords: [ 'testing' ],
 				variations: [],
 				isDisabled: false,

--- a/packages/block-library/src/audio/block.json
+++ b/packages/block-library/src/audio/block.json
@@ -1,6 +1,6 @@
 {
 	"name": "core/audio",
-	"category": "common",
+	"category": "text",
 	"attributes": {
 		"src": {
 			"type": "string",

--- a/packages/block-library/src/audio/block.json
+++ b/packages/block-library/src/audio/block.json
@@ -1,6 +1,6 @@
 {
 	"name": "core/audio",
-	"category": "text",
+	"category": "media",
 	"attributes": {
 		"src": {
 			"type": "string",

--- a/packages/block-library/src/button/block.json
+++ b/packages/block-library/src/button/block.json
@@ -1,6 +1,6 @@
 {
 	"name": "core/button",
-	"category": "layout",
+	"category": "design",
 	"parent": [
 		"core/buttons"
 	],

--- a/packages/block-library/src/buttons/block.json
+++ b/packages/block-library/src/buttons/block.json
@@ -1,6 +1,6 @@
 {
 	"name": "core/buttons",
-	"category": "layout",
+	"category": "design",
 	"supports": {
 		"align": true,
 		"alignWide": false,

--- a/packages/block-library/src/classic/block.json
+++ b/packages/block-library/src/classic/block.json
@@ -1,6 +1,6 @@
 {
 	"name": "core/freeform",
-	"category": "formatting",
+	"category": "text",
 	"attributes": {
 		"content": {
 			"type": "string",

--- a/packages/block-library/src/code/block.json
+++ b/packages/block-library/src/code/block.json
@@ -1,6 +1,6 @@
 {
 	"name": "core/code",
-	"category": "formatting",
+	"category": "text",
 	"attributes": {
 		"content": {
 			"type": "string",

--- a/packages/block-library/src/column/block.json
+++ b/packages/block-library/src/column/block.json
@@ -1,6 +1,6 @@
 {
 	"name": "core/column",
-	"category": "common",
+	"category": "text",
 	"parent": [
 		"core/columns"
 	],

--- a/packages/block-library/src/columns/block.json
+++ b/packages/block-library/src/columns/block.json
@@ -1,6 +1,6 @@
 {
 	"name": "core/columns",
-	"category": "layout",
+	"category": "design",
 	"attributes": {
 		"verticalAlignment": {
 			"type": "string"

--- a/packages/block-library/src/cover/block.json
+++ b/packages/block-library/src/cover/block.json
@@ -1,6 +1,6 @@
 {
 	"name": "core/cover",
-	"category": "common",
+	"category": "text",
 	"attributes": {
 		"url": {
 			"type": "string"

--- a/packages/block-library/src/cover/block.json
+++ b/packages/block-library/src/cover/block.json
@@ -1,6 +1,6 @@
 {
 	"name": "core/cover",
-	"category": "text",
+	"category": "media",
 	"attributes": {
 		"url": {
 			"type": "string"

--- a/packages/block-library/src/file/block.json
+++ b/packages/block-library/src/file/block.json
@@ -1,6 +1,6 @@
 {
 	"name": "core/file",
-	"category": "text",
+	"category": "media",
 	"attributes": {
 		"id": {
 			"type": "number"

--- a/packages/block-library/src/file/block.json
+++ b/packages/block-library/src/file/block.json
@@ -1,6 +1,6 @@
 {
 	"name": "core/file",
-	"category": "common",
+	"category": "text",
 	"attributes": {
 		"id": {
 			"type": "number"

--- a/packages/block-library/src/gallery/block.json
+++ b/packages/block-library/src/gallery/block.json
@@ -1,6 +1,6 @@
 {
 	"name": "core/gallery",
-	"category": "common",
+	"category": "text",
 	"attributes": {
 		"images": {
 			"type": "array",

--- a/packages/block-library/src/gallery/block.json
+++ b/packages/block-library/src/gallery/block.json
@@ -1,6 +1,6 @@
 {
 	"name": "core/gallery",
-	"category": "text",
+	"category": "media",
 	"attributes": {
 		"images": {
 			"type": "array",

--- a/packages/block-library/src/group/block.json
+++ b/packages/block-library/src/group/block.json
@@ -1,6 +1,6 @@
 {
 	"name": "core/group",
-	"category": "layout",
+	"category": "design",
 	"attributes": {
 		"tagName": {
 			"type": "string",

--- a/packages/block-library/src/heading/block.json
+++ b/packages/block-library/src/heading/block.json
@@ -1,6 +1,6 @@
 {
 	"name": "core/heading",
-	"category": "common",
+	"category": "text",
 	"attributes": {
 		"align": {
 			"type": "string"

--- a/packages/block-library/src/html/block.json
+++ b/packages/block-library/src/html/block.json
@@ -1,6 +1,6 @@
 {
 	"name": "core/html",
-	"category": "text",
+	"category": "widgets",
 	"attributes": {
 		"content": {
 			"type": "string",

--- a/packages/block-library/src/html/block.json
+++ b/packages/block-library/src/html/block.json
@@ -1,6 +1,6 @@
 {
 	"name": "core/html",
-	"category": "formatting",
+	"category": "text",
 	"attributes": {
 		"content": {
 			"type": "string",

--- a/packages/block-library/src/image/block.json
+++ b/packages/block-library/src/image/block.json
@@ -1,6 +1,6 @@
 {
 	"name": "core/image",
-	"category": "common",
+	"category": "text",
 	"attributes": {
 		"align": {
 			"type": "string"

--- a/packages/block-library/src/image/block.json
+++ b/packages/block-library/src/image/block.json
@@ -1,6 +1,6 @@
 {
 	"name": "core/image",
-	"category": "text",
+	"category": "media",
 	"attributes": {
 		"align": {
 			"type": "string"

--- a/packages/block-library/src/list/block.json
+++ b/packages/block-library/src/list/block.json
@@ -1,6 +1,6 @@
 {
 	"name": "core/list",
-	"category": "common",
+	"category": "text",
 	"attributes": {
 		"ordered": {
 			"type": "boolean",

--- a/packages/block-library/src/media-text/block.json
+++ b/packages/block-library/src/media-text/block.json
@@ -1,6 +1,6 @@
 {
 	"name": "core/media-text",
-	"category": "design",
+	"category": "media",
 	"attributes": {
 		"align": {
 			"type": "string",

--- a/packages/block-library/src/media-text/block.json
+++ b/packages/block-library/src/media-text/block.json
@@ -1,6 +1,6 @@
 {
 	"name": "core/media-text",
-	"category": "layout",
+	"category": "design",
 	"attributes": {
 		"align": {
 			"type": "string",

--- a/packages/block-library/src/missing/block.json
+++ b/packages/block-library/src/missing/block.json
@@ -1,6 +1,6 @@
 {
 	"name": "core/missing",
-	"category": "common",
+	"category": "text",
 	"attributes": {
 		"originalName": {
 			"type": "string"

--- a/packages/block-library/src/more/block.json
+++ b/packages/block-library/src/more/block.json
@@ -1,6 +1,6 @@
 {
 	"name": "core/more",
-	"category": "layout",
+	"category": "design",
 	"attributes": {
 		"customText": {
 			"type": "string"

--- a/packages/block-library/src/navigation-link/block.json
+++ b/packages/block-library/src/navigation-link/block.json
@@ -1,6 +1,6 @@
 {
 	"name": "core/navigation-link",
-	"category": "layout",
+	"category": "design",
 	"parent": [
 		"core/navigation"
 	],

--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -1,6 +1,6 @@
 {
 	"name": "core/navigation",
-	"category": "layout",
+	"category": "design",
 	"attributes": {
 		"orientation": {
 			"type": "string"

--- a/packages/block-library/src/nextpage/block.json
+++ b/packages/block-library/src/nextpage/block.json
@@ -1,6 +1,6 @@
 {
 	"name": "core/nextpage",
-	"category": "layout",
+	"category": "design",
 	"parent": [ "core/post-content" ],
 	"supports": {
 		"customClassName": false,

--- a/packages/block-library/src/paragraph/block.json
+++ b/packages/block-library/src/paragraph/block.json
@@ -1,6 +1,6 @@
 {
 	"name": "core/paragraph",
-	"category": "common",
+	"category": "text",
 	"attributes": {
 		"align": {
 			"type": "string"

--- a/packages/block-library/src/post-author/block.json
+++ b/packages/block-library/src/post-author/block.json
@@ -1,6 +1,6 @@
 {
 	"name": "core/post-author",
-	"category": "layout",
+	"category": "design",
 	"attributes": {
 		"align": {
 			"type": "string"

--- a/packages/block-library/src/post-comments-count/block.json
+++ b/packages/block-library/src/post-comments-count/block.json
@@ -1,6 +1,6 @@
 {
 	"name": "core/post-comments-count",
-	"category": "layout",
+	"category": "design",
 	"context": [
 		"postId"
 	],

--- a/packages/block-library/src/post-comments-form/block.json
+++ b/packages/block-library/src/post-comments-form/block.json
@@ -1,6 +1,6 @@
 {
 	"name": "core/post-comments-form",
-	"category": "layout",
+	"category": "design",
 	"context": [
 		"postId"
 	],

--- a/packages/block-library/src/post-comments/block.json
+++ b/packages/block-library/src/post-comments/block.json
@@ -1,5 +1,5 @@
 {
 	"name": "core/post-comments",
-	"category": "layout",
+	"category": "design",
 	"context": [ "postId" ]
 }

--- a/packages/block-library/src/post-content/block.json
+++ b/packages/block-library/src/post-content/block.json
@@ -1,6 +1,6 @@
 {
 	"name": "core/post-content",
-	"category": "layout",
+	"category": "design",
 	"context": [
 		"postId",
 		"postType"

--- a/packages/block-library/src/post-date/block.json
+++ b/packages/block-library/src/post-date/block.json
@@ -1,6 +1,6 @@
 {
 	"name": "core/post-date",
-	"category": "layout",
+	"category": "design",
 	"attributes": {
 		"format": {
 			"type": "string"

--- a/packages/block-library/src/post-excerpt/block.json
+++ b/packages/block-library/src/post-excerpt/block.json
@@ -1,6 +1,6 @@
 {
 	"name": "core/post-excerpt",
-	"category": "layout",
+	"category": "design",
 	"attributes": {
 		"wordCount": {
 			"type": "number",

--- a/packages/block-library/src/post-featured-image/block.json
+++ b/packages/block-library/src/post-featured-image/block.json
@@ -1,6 +1,6 @@
 {
 	"name": "core/post-featured-image",
-	"category": "layout",
+	"category": "design",
 	"context": [
 		"postId"
 	],

--- a/packages/block-library/src/post-tags/block.json
+++ b/packages/block-library/src/post-tags/block.json
@@ -1,6 +1,6 @@
 {
 	"name": "core/post-tags",
-	"category": "layout",
+	"category": "design",
 	"context": [
 		"postId"
 	],

--- a/packages/block-library/src/post-title/block.json
+++ b/packages/block-library/src/post-title/block.json
@@ -1,6 +1,6 @@
 {
 	"name": "core/post-title",
-	"category": "layout",
+	"category": "design",
 	"context": [
 		"postId",
 		"postType"

--- a/packages/block-library/src/preformatted/block.json
+++ b/packages/block-library/src/preformatted/block.json
@@ -1,6 +1,6 @@
 {
 	"name": "core/preformatted",
-	"category": "formatting",
+	"category": "text",
 	"attributes": {
 		"content": {
 			"type": "string",

--- a/packages/block-library/src/pullquote/block.json
+++ b/packages/block-library/src/pullquote/block.json
@@ -1,6 +1,6 @@
 {
 	"name": "core/pullquote",
-	"category": "formatting",
+	"category": "text",
 	"attributes": {
 		"value": {
 			"type": "string",

--- a/packages/block-library/src/query-loop/block.json
+++ b/packages/block-library/src/query-loop/block.json
@@ -1,6 +1,6 @@
 {
 	"name": "core/query-loop",
-	"category": "layout",
+	"category": "design",
 	"context": [
 		"queryId",
 		"query",

--- a/packages/block-library/src/query-pagination/block.json
+++ b/packages/block-library/src/query-pagination/block.json
@@ -1,6 +1,6 @@
 {
 	"name": "core/query-pagination",
-	"category": "layout",
+	"category": "design",
 	"context": [
 		"queryId",
 		"query",

--- a/packages/block-library/src/query/block.json
+++ b/packages/block-library/src/query/block.json
@@ -1,6 +1,6 @@
 {
 	"name": "core/query",
-	"category": "layout",
+	"category": "design",
 	"attributes": {
 		"queryId": {
 			"type": "number"

--- a/packages/block-library/src/quote/block.json
+++ b/packages/block-library/src/quote/block.json
@@ -1,6 +1,6 @@
 {
 	"name": "core/quote",
-	"category": "common",
+	"category": "text",
 	"attributes": {
 		"value": {
 			"type": "string",

--- a/packages/block-library/src/separator/block.json
+++ b/packages/block-library/src/separator/block.json
@@ -1,6 +1,6 @@
 {
 	"name": "core/separator",
-	"category": "layout",
+	"category": "design",
 	"attributes": {
 		"color": {
 			"type": "string"

--- a/packages/block-library/src/site-title/block.json
+++ b/packages/block-library/src/site-title/block.json
@@ -1,6 +1,6 @@
 {
 	"name": "core/site-title",
-	"category": "layout",
+	"category": "design",
 	"attributes": {
 		"level": {
 			"type": "number",

--- a/packages/block-library/src/spacer/block.json
+++ b/packages/block-library/src/spacer/block.json
@@ -1,6 +1,6 @@
 {
 	"name": "core/spacer",
-	"category": "layout",
+	"category": "design",
 	"attributes": {
 		"height": {
 			"type": "number",

--- a/packages/block-library/src/subhead/block.json
+++ b/packages/block-library/src/subhead/block.json
@@ -1,6 +1,6 @@
 {
 	"name": "core/subhead",
-	"category": "common",
+	"category": "text",
 	"attributes": {
 		"align": {
 			"type": "string"

--- a/packages/block-library/src/table/block.json
+++ b/packages/block-library/src/table/block.json
@@ -1,6 +1,6 @@
 {
 	"name": "core/table",
-	"category": "formatting",
+	"category": "text",
 	"attributes": {
 		"hasFixedLayout": {
 			"type": "boolean",

--- a/packages/block-library/src/template-part/block.json
+++ b/packages/block-library/src/template-part/block.json
@@ -1,6 +1,6 @@
 {
 	"name": "core/template-part",
-	"category": "layout",
+	"category": "design",
 	"attributes": {
 		"postId": {
 			"type": "number"

--- a/packages/block-library/src/text-columns/block.json
+++ b/packages/block-library/src/text-columns/block.json
@@ -1,7 +1,7 @@
 {
 	"name": "core/text-columns",
 	"icon": "columns",
-	"category": "layout",
+	"category": "design",
 	"attributes": {
 		"content": {
 			"type": "array",

--- a/packages/block-library/src/verse/block.json
+++ b/packages/block-library/src/verse/block.json
@@ -1,6 +1,6 @@
 {
 	"name": "core/verse",
-	"category": "formatting",
+	"category": "text",
 	"attributes": {
 		"content": {
 			"type": "string",

--- a/packages/block-library/src/video/block.json
+++ b/packages/block-library/src/video/block.json
@@ -1,6 +1,6 @@
 {
 	"name": "core/video",
-	"category": "common",
+	"category": "text",
 	"attributes": {
 		"autoplay": {
 			"type": "boolean",

--- a/packages/block-library/src/video/block.json
+++ b/packages/block-library/src/video/block.json
@@ -1,6 +1,6 @@
 {
 	"name": "core/video",
-	"category": "text",
+	"category": "media",
 	"attributes": {
 		"autoplay": {
 			"type": "boolean",

--- a/packages/blocks/CHANGELOG.md
+++ b/packages/blocks/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+- Added a new function `getCategory` to retrieve a single category object by slug.
+
 ## 6.13.0 (2020-04-01)
 
 ### New Feature

--- a/packages/blocks/CHANGELOG.md
+++ b/packages/blocks/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## Unreleased
 
-### New Features
-
-- Added a new function `getCategory` to retrieve a single category object by slug.
-
 ## 6.13.0 (2020-04-01)
 
 ### New Feature

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -99,7 +99,7 @@ add_action( 'enqueue_block_editor_assets', 'random_image_enqueue_block_editor_as
 
 		icon: 'format-image',
 
-		category: 'common',
+		category: 'text',
 
 		attributes: {
 			category: {

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -354,7 +354,7 @@ Returns all the block categories.
 
 _Returns_
 
--   `Array<Object>`: Block categories.
+-   `Array<WPBlockCategory>`: Block categories.
 
 <a name="getChildBlockNames" href="#getChildBlockNames">#</a> **getChildBlockNames**
 
@@ -687,7 +687,7 @@ Sets the block categories.
 
 _Parameters_
 
--   _categories_ `Array<Object>`: Block categories.
+-   _categories_ `Array<WPBlockCategory>`: Block categories.
 
 <a name="setDefaultBlockName" href="#setDefaultBlockName">#</a> **setDefaultBlockName**
 
@@ -789,7 +789,7 @@ Updates a category.
 _Parameters_
 
 -   _slug_ `string`: Block category slug.
--   _category_ `Object`: Object containing the category properties that should be updated.
+-   _category_ `WPBlockCategory`: Object containing the category properties that should be updated.
 
 <a name="withBlockContentContext" href="#withBlockContentContext">#</a> **withBlockContentContext**
 

--- a/packages/blocks/src/api/categories.js
+++ b/packages/blocks/src/api/categories.js
@@ -3,19 +3,32 @@
  */
 import { dispatch, select } from '@wordpress/data';
 
+/** @typedef {import('../store/reducer').WPBlockCategory} WPBlockCategory */
+
 /**
  * Returns all the block categories.
  *
- * @return {Object[]} Block categories.
+ * @return {WPBlockCategory[]} Block categories.
  */
 export function getCategories() {
 	return select( 'core/blocks' ).getCategories();
 }
 
 /**
+ * Returns a single category by slug.
+ *
+ * @param {string} slug Category slug.
+ *
+ * @return {WPBlockCategory|undefined} Block category, if exists.
+ */
+export function getCategory( slug ) {
+	return select( 'core/blocks' ).getCategory( slug );
+}
+
+/**
  * Sets the block categories.
  *
- * @param {Object[]} categories Block categories.
+ * @param {WPBlockCategory[]} categories Block categories.
  */
 export function setCategories( categories ) {
 	dispatch( 'core/blocks' ).setCategories( categories );
@@ -24,8 +37,9 @@ export function setCategories( categories ) {
 /**
  * Updates a category.
  *
- * @param {string} slug          Block category slug.
- * @param {Object} category Object containing the category properties that should be updated.
+ * @param {string}          slug     Block category slug.
+ * @param {WPBlockCategory} category Object containing the category properties
+ *                                   that should be updated.
  */
 export function updateCategory( slug, category ) {
 	dispatch( 'core/blocks' ).updateCategory( slug, category );

--- a/packages/blocks/src/api/categories.js
+++ b/packages/blocks/src/api/categories.js
@@ -15,17 +15,6 @@ export function getCategories() {
 }
 
 /**
- * Returns a single category by slug.
- *
- * @param {string} slug Category slug.
- *
- * @return {WPBlockCategory|undefined} Block category, if exists.
- */
-export function getCategory( slug ) {
-	return select( 'core/blocks' ).getCategory( slug );
-}
-
-/**
  * Sets the block categories.
  *
  * @param {WPBlockCategory[]} categories Block categories.

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { get, isFunction, isPlainObject, omit, pick, some } from 'lodash';
+import { get, omit, pick, isFunction, isPlainObject } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -203,12 +203,9 @@ export function registerBlockType( name, settings ) {
 		console.error( 'The "edit" property must be a valid function.' );
 		return;
 	}
-	if (
-		'category' in settings &&
-		! some( select( 'core/blocks' ).getCategories(), {
-			slug: settings.category,
-		} )
-	) {
+
+	const category = select( 'core/blocks' ).getCategory( settings.category );
+	if ( ! category ) {
 		console.warn(
 			'The block "' +
 				name +
@@ -218,6 +215,12 @@ export function registerBlockType( name, settings ) {
 		);
 		delete settings.category;
 	}
+
+	// `getCategory` handles canonicalization of a category, which may yield a
+	// different slug from the provided settings. Ensure that the settings value
+	// references the normalized value.
+	settings.category = category?.slug;
+
 	if ( ! ( 'title' in settings ) || settings.title === '' ) {
 		console.error( 'The block "' + name + '" must have a title.' );
 		return;

--- a/packages/blocks/src/api/test/factory.js
+++ b/packages/blocks/src/api/test/factory.js
@@ -34,7 +34,7 @@ describe( 'block factory', () => {
 			},
 		},
 		save: noop,
-		category: 'common',
+		category: 'text',
 		title: 'block title',
 	};
 
@@ -66,7 +66,7 @@ describe( 'block factory', () => {
 					},
 				},
 				save: noop,
-				category: 'common',
+				category: 'text',
 				title: 'test block',
 			} );
 			const block = createBlock( 'core/test-block', { align: 'left' }, [
@@ -174,7 +174,7 @@ describe( 'block factory', () => {
 					},
 				},
 				save: noop,
-				category: 'common',
+				category: 'text',
 				title: 'test block',
 			} );
 			const block = deepFreeze(
@@ -209,7 +209,7 @@ describe( 'block factory', () => {
 					},
 				},
 				save: noop,
-				category: 'common',
+				category: 'text',
 				title: 'test block',
 			} );
 			const block = deepFreeze(
@@ -241,7 +241,7 @@ describe( 'block factory', () => {
 					},
 				},
 				save: noop,
-				category: 'common',
+				category: 'text',
 				title: 'test block',
 			} );
 			const block = deepFreeze(
@@ -293,7 +293,7 @@ describe( 'block factory', () => {
 					],
 				},
 				save: noop,
-				category: 'common',
+				category: 'text',
 				title: 'updated text block',
 			} );
 			registerBlockType( 'core/text-block', defaultBlockSettings );
@@ -329,7 +329,7 @@ describe( 'block factory', () => {
 					],
 				},
 				save: noop,
-				category: 'common',
+				category: 'text',
 				title: 'updated text block',
 			} );
 			registerBlockType( 'core/text-block', defaultBlockSettings );
@@ -363,7 +363,7 @@ describe( 'block factory', () => {
 					],
 				},
 				save: noop,
-				category: 'common',
+				category: 'text',
 				title: 'updated text block',
 			} );
 			registerBlockType( 'core/text-block', defaultBlockSettings );
@@ -401,7 +401,7 @@ describe( 'block factory', () => {
 					],
 				},
 				save: noop,
-				category: 'common',
+				category: 'text',
 				title: 'updated text block',
 			} );
 			registerBlockType(
@@ -443,7 +443,7 @@ describe( 'block factory', () => {
 					],
 				},
 				save: noop,
-				category: 'common',
+				category: 'text',
 				title: 'updated text block',
 			} );
 			registerBlockType( 'core/text-block', defaultBlockSettings );
@@ -485,7 +485,7 @@ describe( 'block factory', () => {
 					],
 				},
 				save: noop,
-				category: 'common',
+				category: 'text',
 				title: 'updated text block',
 			} );
 			registerBlockType(
@@ -536,7 +536,7 @@ describe( 'block factory', () => {
 					],
 				},
 				save: noop,
-				category: 'common',
+				category: 'text',
 				title: 'updated text block',
 			} );
 			registerBlockType( 'core/text-block', defaultBlockSettings );
@@ -578,7 +578,7 @@ describe( 'block factory', () => {
 					],
 				},
 				save: noop,
-				category: 'common',
+				category: 'text',
 				title: 'updated text block',
 			} );
 			registerBlockType( 'core/another-text-block', {
@@ -598,7 +598,7 @@ describe( 'block factory', () => {
 					],
 				},
 				save: noop,
-				category: 'common',
+				category: 'text',
 				title: 'another text block',
 			} );
 			registerBlockType( 'core/text-block', defaultBlockSettings );
@@ -640,7 +640,7 @@ describe( 'block factory', () => {
 					],
 				},
 				save: noop,
-				category: 'common',
+				category: 'text',
 				title: 'updated text block',
 			} );
 			registerBlockType( 'core/text-block', defaultBlockSettings );
@@ -682,7 +682,7 @@ describe( 'block factory', () => {
 					],
 				},
 				save: noop,
-				category: 'common',
+				category: 'text',
 				title: 'updated text block',
 			} );
 			registerBlockType( 'core/text-block', defaultBlockSettings );
@@ -719,7 +719,7 @@ describe( 'block factory', () => {
 					],
 				},
 				save: noop,
-				category: 'common',
+				category: 'text',
 				title: 'updated text block',
 			} );
 			registerBlockType( 'core/text-block', defaultBlockSettings );
@@ -753,7 +753,7 @@ describe( 'block factory', () => {
 					],
 				},
 				save: noop,
-				category: 'common',
+				category: 'text',
 				title: 'updated text block',
 			} );
 			registerBlockType( 'core/text-block', defaultBlockSettings );
@@ -788,7 +788,7 @@ describe( 'block factory', () => {
 					],
 				},
 				save: noop,
-				category: 'common',
+				category: 'text',
 				title: 'updated text block',
 			} );
 			registerBlockType( 'core/text-block', defaultBlockSettings );
@@ -824,7 +824,7 @@ describe( 'block factory', () => {
 					],
 				},
 				save: noop,
-				category: 'common',
+				category: 'text',
 				title: 'updated text block',
 			} );
 			registerBlockType( 'core/text-block', defaultBlockSettings );
@@ -859,7 +859,7 @@ describe( 'block factory', () => {
 					],
 				},
 				save: noop,
-				category: 'common',
+				category: 'text',
 				title: 'updated text block',
 			} );
 			registerBlockType( 'core/text-block', defaultBlockSettings );
@@ -898,7 +898,7 @@ describe( 'block factory', () => {
 						],
 					},
 					save: noop,
-					category: 'common',
+					category: 'text',
 					title: 'A block that groups other blocks.',
 				} );
 			} );
@@ -987,7 +987,7 @@ describe( 'block factory', () => {
 					],
 				},
 				save: noop,
-				category: 'common',
+				category: 'text',
 				title: 'updated text block',
 			} );
 			registerBlockType( 'core/text-block', defaultBlockSettings );
@@ -1037,7 +1037,7 @@ describe( 'block factory', () => {
 					],
 				},
 				save: noop,
-				category: 'common',
+				category: 'text',
 				title: 'text-block',
 			} );
 
@@ -1096,7 +1096,7 @@ describe( 'block factory', () => {
 					],
 				},
 				save: noop,
-				category: 'common',
+				category: 'text',
 				title: 'updated text block',
 			} );
 			registerBlockType( 'core/text-block', defaultBlockSettings );
@@ -1129,7 +1129,7 @@ describe( 'block factory', () => {
 					],
 				},
 				save: noop,
-				category: 'common',
+				category: 'text',
 				title: 'updated text block',
 			} );
 			registerBlockType( 'core/text-block', defaultBlockSettings );
@@ -1168,7 +1168,7 @@ describe( 'block factory', () => {
 					],
 				},
 				save: noop,
-				category: 'common',
+				category: 'text',
 				title: 'updated text block',
 			} );
 			registerBlockType( 'core/text-block', defaultBlockSettings );
@@ -1212,7 +1212,7 @@ describe( 'block factory', () => {
 					],
 				},
 				save: noop,
-				category: 'common',
+				category: 'text',
 				title: 'updated text block',
 			} );
 			registerBlockType( 'core/text-block', defaultBlockSettings );
@@ -1253,7 +1253,7 @@ describe( 'block factory', () => {
 					],
 				},
 				save: noop,
-				category: 'common',
+				category: 'text',
 				title: 'text block',
 			} );
 
@@ -1298,7 +1298,7 @@ describe( 'block factory', () => {
 					],
 				},
 				save: noop,
-				category: 'common',
+				category: 'text',
 				title: 'text block',
 			} );
 
@@ -1344,7 +1344,7 @@ describe( 'block factory', () => {
 					],
 				},
 				save: noop,
-				category: 'common',
+				category: 'text',
 				title: 'text block',
 			} );
 
@@ -1408,7 +1408,7 @@ describe( 'block factory', () => {
 					],
 				},
 				save: noop,
-				category: 'common',
+				category: 'text',
 				title: 'updated columns block',
 			} );
 			registerBlockType( 'core/columns-block', defaultBlockSettings );
@@ -1467,7 +1467,7 @@ describe( 'block factory', () => {
 					],
 				},
 				save: noop,
-				category: 'common',
+				category: 'text',
 				title: 'updated columns block',
 			} );
 			registerBlockType( 'core/columns-block', defaultBlockSettings );
@@ -1532,7 +1532,7 @@ describe( 'block factory', () => {
 					],
 				},
 				save: noop,
-				category: 'common',
+				category: 'text',
 				title: 'Test Group Block',
 			} );
 
@@ -1593,7 +1593,7 @@ describe( 'block factory', () => {
 					],
 				},
 				save: noop,
-				category: 'common',
+				category: 'text',
 				title: 'Test Group Block',
 			} );
 
@@ -1629,7 +1629,7 @@ describe( 'block factory', () => {
 					],
 				},
 				save: noop,
-				category: 'common',
+				category: 'text',
 				title: 'updated text block',
 			} );
 			registerBlockType( 'core/transform-from-text-block-2', {
@@ -1641,7 +1641,7 @@ describe( 'block factory', () => {
 					],
 				},
 				save: noop,
-				category: 'common',
+				category: 'text',
 				title: 'updated text block',
 			} );
 		} );
@@ -1811,7 +1811,7 @@ describe( 'block factory', () => {
 					],
 				},
 				save: noop,
-				category: 'common',
+				category: 'text',
 				title: 'A Block with InnerBlocks that supports grouping',
 			} );
 		} );

--- a/packages/blocks/src/api/test/parser.js
+++ b/packages/blocks/src/api/test/parser.js
@@ -39,12 +39,12 @@ describe( 'block parser', () => {
 			},
 		},
 		save: ( { attributes } ) => attributes.fruit || null,
-		category: 'common',
+		category: 'text',
 		title: 'block title',
 	};
 
 	const unknownBlockSettings = {
-		category: 'common',
+		category: 'text',
 		title: 'unknown block',
 		attributes: {
 			content: {
@@ -892,7 +892,7 @@ describe( 'block parser', () => {
 					chicken: { type: 'string' },
 				},
 				save: ( { attributes } ) => attributes.content,
-				category: 'common',
+				category: 'text',
 				title: 'test block',
 			} );
 
@@ -928,7 +928,7 @@ describe( 'block parser', () => {
 					},
 				},
 				save: ( { attributes } ) => attributes.content,
-				category: 'common',
+				category: 'text',
 				title: 'test block',
 			} );
 
@@ -1054,7 +1054,7 @@ describe( 'block parser', () => {
 
 		it( 'should parse with unicode escaped returned to original representation', () => {
 			registerBlockType( 'core/code', {
-				category: 'common',
+				category: 'text',
 				title: 'Code Block',
 				attributes: {
 					content: {

--- a/packages/blocks/src/api/test/registration.js
+++ b/packages/blocks/src/api/test/registration.js
@@ -41,7 +41,7 @@ import { DEPRECATED_ENTRY_KEYS } from '../constants';
 describe( 'blocks', () => {
 	const defaultBlockSettings = {
 		save: noop,
-		category: 'common',
+		category: 'text',
 		title: 'block title',
 	};
 
@@ -126,7 +126,7 @@ describe( 'blocks', () => {
 				attributes: {},
 				keywords: [],
 				save: noop,
-				category: 'common',
+				category: 'text',
 				title: 'block title',
 			} );
 		} );
@@ -160,7 +160,7 @@ describe( 'blocks', () => {
 			const blockType = {
 					save: noop,
 					edit: 'not-a-function',
-					category: 'common',
+					category: 'text',
 					title: 'block title',
 				},
 				block = registerBlockType(
@@ -194,7 +194,7 @@ describe( 'blocks', () => {
 			const blockType = {
 					settingName: 'settingValue',
 					save: noop,
-					category: 'common',
+					category: 'text',
 				},
 				block = registerBlockType(
 					'my-plugin/fancy-block-9',
@@ -210,7 +210,7 @@ describe( 'blocks', () => {
 			const blockType = {
 					settingName: 'settingValue',
 					save: noop,
-					category: 'common',
+					category: 'text',
 					title: '',
 				},
 				block = registerBlockType(
@@ -227,7 +227,7 @@ describe( 'blocks', () => {
 			const blockType = {
 					settingName: 'settingValue',
 					save: noop,
-					category: 'common',
+					category: 'text',
 					title: 12345,
 				},
 				block = registerBlockType(
@@ -243,13 +243,13 @@ describe( 'blocks', () => {
 		it( 'should assign default settings', () => {
 			registerBlockType( 'core/test-block-with-defaults', {
 				title: 'block title',
-				category: 'common',
+				category: 'text',
 			} );
 
 			expect( getBlockType( 'core/test-block-with-defaults' ) ).toEqual( {
 				name: 'core/test-block-with-defaults',
 				title: 'block title',
-				category: 'common',
+				category: 'text',
 				icon: {
 					src: blockIcon,
 				},
@@ -268,7 +268,7 @@ describe( 'blocks', () => {
 			const blockType = {
 				settingName: 'settingValue',
 				save: noop,
-				category: 'common',
+				category: 'text',
 				title: 'block title',
 			};
 			registerBlockType( 'core/test-block-with-attributes', blockType );
@@ -277,7 +277,7 @@ describe( 'blocks', () => {
 					name: 'core/test-block-with-attributes',
 					settingName: 'settingValue',
 					save: noop,
-					category: 'common',
+					category: 'text',
 					title: 'block title',
 					icon: {
 						src: blockIcon,
@@ -295,7 +295,7 @@ describe( 'blocks', () => {
 		it( 'should validate the icon', () => {
 			const blockType = {
 				save: noop,
-				category: 'common',
+				category: 'text',
 				title: 'block title',
 				icon: { chicken: 'ribs' },
 			};
@@ -310,7 +310,7 @@ describe( 'blocks', () => {
 		it( 'should normalize the icon containing an element', () => {
 			const blockType = {
 				save: noop,
-				category: 'common',
+				category: 'text',
 				title: 'block title',
 				icon: (
 					<svg width="20" height="20" viewBox="0 0 20 20">
@@ -334,7 +334,7 @@ describe( 'blocks', () => {
 			).toEqual( {
 				name: 'core/test-block-icon-normalize-element',
 				save: noop,
-				category: 'common',
+				category: 'text',
 				title: 'block title',
 				icon: {
 					src: (
@@ -358,7 +358,7 @@ describe( 'blocks', () => {
 		it( 'should normalize the icon containing a string', () => {
 			const blockType = {
 				save: noop,
-				category: 'common',
+				category: 'text',
 				title: 'block title',
 				icon: 'foo',
 			};
@@ -371,7 +371,7 @@ describe( 'blocks', () => {
 			).toEqual( {
 				name: 'core/test-block-icon-normalize-string',
 				save: noop,
-				category: 'common',
+				category: 'text',
 				title: 'block title',
 				icon: {
 					src: 'foo',
@@ -398,7 +398,7 @@ describe( 'blocks', () => {
 			};
 			const blockType = {
 				save: noop,
-				category: 'common',
+				category: 'text',
 				title: 'block title',
 				icon: MyTestIcon,
 			};
@@ -411,7 +411,7 @@ describe( 'blocks', () => {
 			).toEqual( {
 				name: 'core/test-block-icon-normalize-function',
 				save: noop,
-				category: 'common',
+				category: 'text',
 				title: 'block title',
 				icon: {
 					src: MyTestIcon,
@@ -424,7 +424,7 @@ describe( 'blocks', () => {
 		it( 'should correctly register an icon with background and a custom svg', () => {
 			const blockType = {
 				save: noop,
-				category: 'common',
+				category: 'text',
 				title: 'block title',
 				icon: {
 					background: '#f00',
@@ -451,7 +451,7 @@ describe( 'blocks', () => {
 			).toEqual( {
 				name: 'core/test-block-icon-normalize-background',
 				save: noop,
-				category: 'common',
+				category: 'text',
 				title: 'block title',
 				icon: {
 					background: '#f00',
@@ -479,7 +479,7 @@ describe( 'blocks', () => {
 			const blockType = {
 				settingName: 'settingValue',
 				save: noop,
-				category: 'common',
+				category: 'text',
 				title: 'block title',
 			};
 			registerBlockType( 'core/test-block-with-settings', blockType );
@@ -488,7 +488,7 @@ describe( 'blocks', () => {
 				name: 'core/test-block-with-settings',
 				settingName: 'settingValue',
 				save: noop,
-				category: 'common',
+				category: 'text',
 				title: 'block title',
 				icon: {
 					src: blockIcon,
@@ -684,7 +684,7 @@ describe( 'blocks', () => {
 				{
 					name: 'core/test-block',
 					save: noop,
-					category: 'common',
+					category: 'text',
 					title: 'block title',
 					icon: {
 						src: blockIcon,
@@ -699,7 +699,7 @@ describe( 'blocks', () => {
 			expect( oldBlock ).toEqual( {
 				name: 'core/test-block',
 				save: noop,
-				category: 'common',
+				category: 'text',
 				title: 'block title',
 				icon: {
 					src: blockIcon,
@@ -775,7 +775,7 @@ describe( 'blocks', () => {
 			expect( getBlockType( 'core/test-block' ) ).toEqual( {
 				name: 'core/test-block',
 				save: noop,
-				category: 'common',
+				category: 'text',
 				title: 'block title',
 				icon: {
 					src: blockIcon,
@@ -789,7 +789,7 @@ describe( 'blocks', () => {
 			const blockType = {
 				settingName: 'settingValue',
 				save: noop,
-				category: 'common',
+				category: 'text',
 				title: 'block title',
 			};
 			registerBlockType( 'core/test-block-with-settings', blockType );
@@ -797,7 +797,7 @@ describe( 'blocks', () => {
 				name: 'core/test-block-with-settings',
 				settingName: 'settingValue',
 				save: noop,
-				category: 'common',
+				category: 'text',
 				title: 'block title',
 				icon: {
 					src: blockIcon,
@@ -818,7 +818,7 @@ describe( 'blocks', () => {
 			const blockType = {
 				settingName: 'settingValue',
 				save: noop,
-				category: 'common',
+				category: 'text',
 				title: 'block title',
 			};
 			registerBlockType( 'core/test-block-with-settings', blockType );
@@ -826,7 +826,7 @@ describe( 'blocks', () => {
 				{
 					name: 'core/test-block',
 					save: noop,
-					category: 'common',
+					category: 'text',
 					title: 'block title',
 					icon: {
 						src: blockIcon,
@@ -839,7 +839,7 @@ describe( 'blocks', () => {
 					name: 'core/test-block-with-settings',
 					settingName: 'settingValue',
 					save: noop,
-					category: 'common',
+					category: 'text',
 					title: 'block title',
 					icon: {
 						src: blockIcon,

--- a/packages/blocks/src/api/test/registration.js
+++ b/packages/blocks/src/api/test/registration.js
@@ -173,6 +173,19 @@ describe( 'blocks', () => {
 			expect( block ).toBeUndefined();
 		} );
 
+		it( 'should canonicalize legacy block category.', () => {
+			const blockType = {
+					save: noop,
+					category: 'common',
+					title: 'block title',
+				},
+				block = registerBlockType(
+					'my-plugin/fancy-block-9',
+					blockType
+				);
+			expect( block.category ).toBe( 'text' );
+		} );
+
 		it( 'should unset category of blocks with non registered category.', () => {
 			const blockType = {
 					save: noop,

--- a/packages/blocks/src/api/test/serializer.js
+++ b/packages/blocks/src/api/test/serializer.js
@@ -245,7 +245,7 @@ describe( 'block serializer', () => {
 	describe( 'serializeBlock()', () => {
 		it( 'serializes the freeform content fallback block without comment delimiters', () => {
 			registerBlockType( 'core/freeform-block', {
-				category: 'common',
+				category: 'text',
 				title: 'freeform block',
 				attributes: {
 					fruit: {
@@ -265,7 +265,7 @@ describe( 'block serializer', () => {
 		} );
 		it( 'serializes the freeform content fallback block with comment delimiters in nested context', () => {
 			registerBlockType( 'core/freeform-block', {
-				category: 'common',
+				category: 'text',
 				title: 'freeform block',
 				attributes: {
 					fruit: {
@@ -289,7 +289,7 @@ describe( 'block serializer', () => {
 		} );
 		it( 'serializes the unregistered fallback block without comment delimiters', () => {
 			registerBlockType( 'core/unregistered-block', {
-				category: 'common',
+				category: 'text',
 				title: 'unregistered block',
 				attributes: {
 					fruit: {
@@ -335,7 +335,7 @@ describe( 'block serializer', () => {
 
 					return <p>{ attributes.content }</p>;
 				},
-				category: 'common',
+				category: 'text',
 				title: 'block title',
 			};
 			registerBlockType( 'core/test-block', blockType );
@@ -392,7 +392,7 @@ describe( 'block serializer', () => {
 				save( { attributes } ) {
 					return attributes.content;
 				},
-				category: 'common',
+				category: 'text',
 				title: 'block title',
 			};
 			registerBlockType( 'core/chicken', blockType );

--- a/packages/blocks/src/api/test/templates.js
+++ b/packages/blocks/src/api/test/templates.js
@@ -33,14 +33,14 @@ describe( 'templates', () => {
 		registerBlockType( 'core/test-block', {
 			attributes: {},
 			save: noop,
-			category: 'common',
+			category: 'text',
 			title: 'test block',
 		} );
 
 		registerBlockType( 'core/test-block-2', {
 			attributes: {},
 			save: noop,
-			category: 'common',
+			category: 'text',
 			title: 'test block',
 		} );
 	} );

--- a/packages/blocks/src/api/test/utils.js
+++ b/packages/blocks/src/api/test/utils.js
@@ -45,7 +45,7 @@ describe( 'block helpers', () => {
 					},
 				},
 				save: noop,
-				category: 'common',
+				category: 'text',
 				title: 'test block',
 			} );
 			setDefaultBlockName( 'core/test-block' );
@@ -65,7 +65,7 @@ describe( 'block helpers', () => {
 					},
 				},
 				save: noop,
-				category: 'common',
+				category: 'text',
 				title: 'test block',
 			} );
 			setDefaultBlockName( 'core/test-block' );
@@ -84,7 +84,7 @@ describe( 'block helpers', () => {
 					},
 				},
 				save: noop,
-				category: 'common',
+				category: 'text',
 				title: 'test block',
 			} );
 			registerBlockType( 'core/test-block2', {
@@ -95,7 +95,7 @@ describe( 'block helpers', () => {
 					},
 				},
 				save: noop,
-				category: 'common',
+				category: 'text',
 				title: 'test block',
 			} );
 			setDefaultBlockName( 'core/test-block1' );

--- a/packages/blocks/src/api/test/validation.js
+++ b/packages/blocks/src/api/test/validation.js
@@ -28,7 +28,7 @@ import {
 describe( 'validation', () => {
 	const defaultBlockSettings = {
 		save: ( { attributes } ) => attributes.fruit,
-		category: 'common',
+		category: 'text',
 		title: 'block title',
 	};
 	beforeAll( () => {

--- a/packages/blocks/src/store/reducer.js
+++ b/packages/blocks/src/store/reducer.js
@@ -20,12 +20,21 @@ import { combineReducers } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
 /**
- * Module Constants
+ * @typedef {Object} WPBlockCategory
+ *
+ * @property {string} slug  Unique category slug.
+ * @property {string} title Category label, for display in user interface.
+ */
+
+/**
+ * Default set of categories.
+ *
+ * @type {WPBlockCategory[]}
  */
 export const DEFAULT_CATEGORIES = [
-	{ slug: 'common', title: __( 'Common blocks' ) },
-	{ slug: 'formatting', title: __( 'Formatting' ) },
-	{ slug: 'layout', title: __( 'Layout elements' ) },
+	{ slug: 'text', title: __( 'Text' ) },
+	{ slug: 'media', title: __( 'Media' ) },
+	{ slug: 'design', title: __( 'Design' ) },
 	{ slug: 'widgets', title: __( 'Widgets' ) },
 	{ slug: 'embed', title: __( 'Embeds' ) },
 	{ slug: 'reusable', title: __( 'Reusable blocks' ) },
@@ -199,10 +208,10 @@ export const groupingBlockName = createBlockNameSetterReducer(
 /**
  * Reducer managing the categories
  *
- * @param {Object} state  Current state.
- * @param {Object} action Dispatched action.
+ * @param {WPBlockCategory[]} state  Current state.
+ * @param {Object}            action Dispatched action.
  *
- * @return {Object} Updated state.
+ * @return {WPBlockCategory[]} Updated state.
  */
 export function categories( state = DEFAULT_CATEGORIES, action ) {
 	switch ( action.type ) {

--- a/packages/blocks/src/store/selectors.js
+++ b/packages/blocks/src/store/selectors.js
@@ -12,24 +12,11 @@ import {
 	includes,
 	map,
 	some,
-	find,
 } from 'lodash';
 
 /** @typedef {import('../api/registration').WPBlockVariation} WPBlockVariation */
 /** @typedef {import('../api/registration').WPBlockVariationScope} WPBlockVariationScope */
 /** @typedef {import('./reducer').WPBlockCategory} WPBlockCategory */
-
-/**
- * Mapping of legacy category slugs to their latest normal values, used to
- * accommodate updates of the default set of block categories.
- *
- * @type {Map<string,string>}
- */
-const LEGACY_CATEGORY_MAPPING = new Map( [
-	[ 'common', 'text' ],
-	[ 'formatting', 'text' ],
-	[ 'layout', 'design' ],
-] );
 
 /**
  * Given a block name or block type object, returns the corresponding
@@ -134,24 +121,6 @@ export function getDefaultBlockVariation( state, blockName, scope ) {
  */
 export function getCategories( state ) {
 	return state.categories;
-}
-
-/**
- * Returns a single category by slug. Canonicalizes category by slug, using
- * internal mapping of legacy category slugs to their updated normal form.
- *
- * @param {Object} state Blocks state.
- * @param {string} slug  Category slug.
- *
- * @return {WPBlockCategory|undefined} Block category, if exists.
- */
-export function getCategory( state, slug ) {
-	if ( LEGACY_CATEGORY_MAPPING.has( slug ) ) {
-		return getCategory( state, LEGACY_CATEGORY_MAPPING.get( slug ) );
-	}
-
-	const categories = getCategories( state );
-	return find( categories, { slug } );
 }
 
 /**

--- a/packages/blocks/src/store/selectors.js
+++ b/packages/blocks/src/store/selectors.js
@@ -12,11 +12,24 @@ import {
 	includes,
 	map,
 	some,
+	find,
 } from 'lodash';
 
 /** @typedef {import('../api/registration').WPBlockVariation} WPBlockVariation */
-
 /** @typedef {import('../api/registration').WPBlockVariationScope} WPBlockVariationScope */
+/** @typedef {import('./reducer').WPBlockCategory} WPBlockCategory */
+
+/**
+ * Mapping of legacy category slugs to their latest normal values, used to
+ * accommodate updates of the default set of block categories.
+ *
+ * @type {Map<string,string>}
+ */
+const LEGACY_CATEGORY_MAPPING = new Map( [
+	[ 'common', 'text' ],
+	[ 'formatting', 'text' ],
+	[ 'layout', 'design' ],
+] );
 
 /**
  * Given a block name or block type object, returns the corresponding
@@ -117,10 +130,28 @@ export function getDefaultBlockVariation( state, blockName, scope ) {
  *
  * @param {Object} state Data state.
  *
- * @return {Array} Categories list.
+ * @return {WPBlockCategory[]} Categories list.
  */
 export function getCategories( state ) {
 	return state.categories;
+}
+
+/**
+ * Returns a single category by slug. Canonicalizes category by slug, using
+ * internal mapping of legacy category slugs to their updated normal form.
+ *
+ * @param {Object} state Blocks state.
+ * @param {string} slug  Category slug.
+ *
+ * @return {WPBlockCategory|undefined} Block category, if exists.
+ */
+export function getCategory( state, slug ) {
+	if ( LEGACY_CATEGORY_MAPPING.has( slug ) ) {
+		return getCategory( state, LEGACY_CATEGORY_MAPPING.get( slug ) );
+	}
+
+	const categories = getCategories( state );
+	return find( categories, { slug } );
 }
 
 /**

--- a/packages/blocks/src/store/test/selectors.js
+++ b/packages/blocks/src/store/test/selectors.js
@@ -15,7 +15,6 @@ import {
 	getGroupingBlockName,
 	isMatchingSearchTerm,
 	getCategories,
-	getCategory,
 } from '../selectors';
 
 describe( 'selectors', () => {
@@ -76,28 +75,6 @@ describe( 'selectors', () => {
 			const state = deepFreeze( { categories } );
 
 			expect( getCategories( state ) ).toEqual( categories );
-		} );
-	} );
-
-	describe( 'getCategory', () => {
-		it( 'returns a single category by slug', () => {
-			const category = { slug: 'text', text: 'Text' };
-			const state = deepFreeze( { categories: [ category ] } );
-
-			expect( getCategory( state, 'text' ) ).toEqual( category );
-		} );
-
-		it( 'returns undefined for a category which does not exist', () => {
-			const state = deepFreeze( { categories: [] } );
-
-			expect( getCategory( state, 'nonsense' ) ).toBe( undefined );
-		} );
-
-		it( 'returns a canonicalized category', () => {
-			const category = { slug: 'text', text: 'Text' };
-			const state = deepFreeze( { categories: [ category ] } );
-
-			expect( getCategory( state, 'common' ) ).toEqual( category );
 		} );
 	} );
 

--- a/packages/blocks/src/store/test/selectors.js
+++ b/packages/blocks/src/store/test/selectors.js
@@ -14,6 +14,8 @@ import {
 	getDefaultBlockVariation,
 	getGroupingBlockName,
 	isMatchingSearchTerm,
+	getCategories,
+	getCategory,
 } from '../selectors';
 
 describe( 'selectors', () => {
@@ -65,6 +67,37 @@ describe( 'selectors', () => {
 			expect(
 				getBlockSupport( state, blockName, 'features.foo.bar' )
 			).toBe( 'value' );
+		} );
+	} );
+
+	describe( 'getCategories', () => {
+		it( 'returns categories state', () => {
+			const categories = [ { slug: 'text', text: 'Text' } ];
+			const state = deepFreeze( { categories } );
+
+			expect( getCategories( state ) ).toEqual( categories );
+		} );
+	} );
+
+	describe( 'getCategory', () => {
+		it( 'returns a single category by slug', () => {
+			const category = { slug: 'text', text: 'Text' };
+			const state = deepFreeze( { categories: [ category ] } );
+
+			expect( getCategory( state, 'text' ) ).toEqual( category );
+		} );
+
+		it( 'returns undefined for a category which does not exist', () => {
+			const state = deepFreeze( { categories: [] } );
+
+			expect( getCategory( state, 'nonsense' ) ).toBe( undefined );
+		} );
+
+		it( 'returns a canonicalized category', () => {
+			const category = { slug: 'text', text: 'Text' };
+			const state = deepFreeze( { categories: [ category ] } );
+
+			expect( getCategory( state, 'common' ) ).toEqual( category );
 		} );
 	} );
 
@@ -284,8 +317,8 @@ describe( 'selectors', () => {
 		const name = 'core/paragraph';
 		const blockType = {
 			title: 'Paragraph',
-			category: 'common',
-			keywords: [ 'text' ],
+			category: 'text',
+			keywords: [ 'body' ],
 		};
 
 		const state = {
@@ -353,7 +386,7 @@ describe( 'selectors', () => {
 				const result = isMatchingSearchTerm(
 					state,
 					nameOrType,
-					'TEXT'
+					'BODY'
 				);
 
 				expect( result ).toBe( true );
@@ -364,7 +397,7 @@ describe( 'selectors', () => {
 					const result = isMatchingSearchTerm(
 						state,
 						nameOrType,
-						'COMMON'
+						'TEXT'
 					);
 
 					expect( result ).toBe( true );

--- a/packages/create-block/lib/prompts.js
+++ b/packages/create-block/lib/prompts.js
@@ -70,7 +70,7 @@ const category = {
 	type: 'list',
 	name: 'category',
 	message: 'The category name to help users browse and discover your block:',
-	choices: [ 'common', 'embed', 'formatting', 'layout', 'widgets' ],
+	choices: [ 'text', 'embed', 'media', 'design', 'widgets' ],
 };
 
 const author = {

--- a/packages/e2e-tests/plugins/align-hook/index.js
+++ b/packages/e2e-tests/plugins/align-hook/index.js
@@ -9,7 +9,7 @@
 
 	var baseBlock = {
 		icon: 'cart',
-		category: 'common',
+		category: 'text',
 		edit: function( props ) {
 			return el(
 				'div',
@@ -43,7 +43,7 @@
 				title: 'Test Align True',
 				supports: {
 					align: true,
-				}
+				},
 			},
 			baseBlock
 		)
@@ -56,7 +56,7 @@
 				title: 'Test Align Array',
 				supports: {
 					align: [ 'left', 'center' ],
-				}
+				},
 			},
 			baseBlock
 		)
@@ -75,7 +75,7 @@
 				},
 				supports: {
 					align: true,
-				}
+				},
 			},
 			baseBlock
 		)

--- a/packages/e2e-tests/plugins/block-context/index.js
+++ b/packages/e2e-tests/plugins/block-context/index.js
@@ -15,7 +15,7 @@
 			'gutenberg/recordId': 'recordId',
 		},
 
-		category: 'common',
+		category: 'text',
 
 		edit( { attributes, setAttributes } ) {
 			return el(
@@ -51,7 +51,7 @@
 		// `get_block_editor_server_block_settings`.
 		context: [ 'gutenberg/recordId' ],
 
-		category: 'common',
+		category: 'text',
 
 		edit( { context } ) {
 			return 'The record ID is: ' + context[ 'gutenberg/recordId' ];

--- a/packages/e2e-tests/plugins/block-icons/index.js
+++ b/packages/e2e-tests/plugins/block-icons/index.js
@@ -2,32 +2,53 @@
 	var registerBlockType = wp.blocks.registerBlockType;
 	var el = wp.element.createElement;
 	var InnerBlocks = wp.blockEditor.InnerBlocks;
-    var circle = el( 'circle', { cx: 10, cy: 10, r: 10, fill: 'red', stroke: 'blue', strokeWidth: '10' } );
-    var svg = el( 'svg', { width: 20, height: 20, viewBox: '0 0 20 20' }, circle );
+	var circle = el( 'circle', {
+		cx: 10,
+		cy: 10,
+		r: 10,
+		fill: 'red',
+		stroke: 'blue',
+		strokeWidth: '10',
+	} );
+	var svg = el(
+		'svg',
+		{ width: 20, height: 20, viewBox: '0 0 20 20' },
+		circle
+	);
 
 	registerBlockType( 'test/test-single-svg-icon', {
 		title: 'TestSimpleSvgIcon',
 		icon: svg,
-		category: 'common',
+		category: 'text',
 
 		edit: function() {
-			return el( 'div', { className: 'test-single-svg-icon', style: { outline: '1px solid gray', padding: 5 } },
-				el(
-					InnerBlocks,
-					{
-						allowedBlocks: [ 'core/paragraph', 'core/image' ],
-						template: [
-							[ 'core/paragraph', {
+			return el(
+				'div',
+				{
+					className: 'test-single-svg-icon',
+					style: { outline: '1px solid gray', padding: 5 },
+				},
+				el( InnerBlocks, {
+					allowedBlocks: [ 'core/paragraph', 'core/image' ],
+					template: [
+						[
+							'core/paragraph',
+							{
 								content: 'TestSimpleSvgIcon',
-							} ],
+							},
 						],
-					}
-				)
+					],
+				} )
 			);
 		},
 
 		save: function() {
-			return el( 'div', { className: 'test-single-svg-icon', style: { outline: '1px solid gray', padding: 5 } },
+			return el(
+				'div',
+				{
+					className: 'test-single-svg-icon',
+					style: { outline: '1px solid gray', padding: 5 },
+				},
 				el( InnerBlocks.Content, {} )
 			);
 		},
@@ -36,26 +57,36 @@
 	registerBlockType( 'test/test-dash-icon', {
 		title: 'TestDashIcon',
 		icon: 'cart',
-		category: 'common',
+		category: 'text',
 
 		edit: function() {
-			return el( 'div', { className: 'test-dash-icon', style: { outline: '1px solid gray', padding: 5 } },
-				el(
-					InnerBlocks,
-					{
-						allowedBlocks: [ 'core/paragraph', 'core/image' ],
-						template: [
-							[ 'core/paragraph', {
+			return el(
+				'div',
+				{
+					className: 'test-dash-icon',
+					style: { outline: '1px solid gray', padding: 5 },
+				},
+				el( InnerBlocks, {
+					allowedBlocks: [ 'core/paragraph', 'core/image' ],
+					template: [
+						[
+							'core/paragraph',
+							{
 								content: 'TestDashIcon',
-							} ],
+							},
 						],
-					}
-				)
+					],
+				} )
 			);
 		},
 
 		save: function() {
-			return el( 'div', { className: 'test-dash-icon', style: { outline: '1px solid gray', padding: 5 } },
+			return el(
+				'div',
+				{
+					className: 'test-dash-icon',
+					style: { outline: '1px solid gray', padding: 5 },
+				},
 				el( InnerBlocks.Content, {} )
 			);
 		},
@@ -63,29 +94,39 @@
 
 	registerBlockType( 'test/test-function-icon', {
 		title: 'TestFunctionIcon',
-		icon: function(){
+		icon: function() {
 			return svg;
 		},
-		category: 'common',
+		category: 'text',
 
 		edit: function() {
-			return el( 'div', { className: 'test-function-icon', style: { outline: '1px solid gray', padding: 5 } },
-				el(
-					InnerBlocks,
-					{
-						allowedBlocks: [ 'core/paragraph', 'core/image' ],
-						template: [
-							[ 'core/paragraph', {
+			return el(
+				'div',
+				{
+					className: 'test-function-icon',
+					style: { outline: '1px solid gray', padding: 5 },
+				},
+				el( InnerBlocks, {
+					allowedBlocks: [ 'core/paragraph', 'core/image' ],
+					template: [
+						[
+							'core/paragraph',
+							{
 								content: 'TestFunctionIcon',
-							} ],
+							},
 						],
-					}
-				)
+					],
+				} )
 			);
 		},
 
 		save: function() {
-			return el( 'div', { className: 'test-function-icon', style: { outline: '1px solid gray', padding: 5 } },
+			return el(
+				'div',
+				{
+					className: 'test-function-icon',
+					style: { outline: '1px solid gray', padding: 5 },
+				},
 				el( InnerBlocks.Content, {} )
 			);
 		},
@@ -98,26 +139,36 @@
 			foreground: '#fe0000',
 			src: 'cart',
 		},
-		category: 'common',
+		category: 'text',
 
 		edit: function() {
-			return el( 'div', { className: 'test-dash-icon-colors', style: { outline: '1px solid gray', padding: 5 } },
-				el(
-					InnerBlocks,
-					{
-						allowedBlocks: [ 'core/paragraph', 'core/image' ],
-						template: [
-							[ 'core/paragraph', {
+			return el(
+				'div',
+				{
+					className: 'test-dash-icon-colors',
+					style: { outline: '1px solid gray', padding: 5 },
+				},
+				el( InnerBlocks, {
+					allowedBlocks: [ 'core/paragraph', 'core/image' ],
+					template: [
+						[
+							'core/paragraph',
+							{
 								content: 'TestIconColors',
-							} ],
+							},
 						],
-					}
-				)
+					],
+				} )
 			);
 		},
 
 		save: function() {
-			return el( 'div', { className: 'test-dash-icon-colors', style: { outline: '1px solid gray', padding: 5 } },
+			return el(
+				'div',
+				{
+					className: 'test-dash-icon-colors',
+					style: { outline: '1px solid gray', padding: 5 },
+				},
 				el( InnerBlocks.Content, {} )
 			);
 		},
@@ -129,26 +180,36 @@
 			background: '#010000',
 			src: svg,
 		},
-		category: 'common',
+		category: 'text',
 
 		edit: function() {
-			return el( 'div', { className: 'test-svg-icon-background', style: { outline: '1px solid gray', padding: 5 } },
-				el(
-					InnerBlocks,
-					{
-						allowedBlocks: [ 'core/paragraph', 'core/image' ],
-						template: [
-							[ 'core/paragraph', {
+			return el(
+				'div',
+				{
+					className: 'test-svg-icon-background',
+					style: { outline: '1px solid gray', padding: 5 },
+				},
+				el( InnerBlocks, {
+					allowedBlocks: [ 'core/paragraph', 'core/image' ],
+					template: [
+						[
+							'core/paragraph',
+							{
 								content: 'TestIconColors',
-							} ],
+							},
 						],
-					}
-				)
+					],
+				} )
 			);
 		},
 
 		save: function() {
-			return el( 'div', { className: 'test-svg-icon-background', style: { outline: '1px solid gray', padding: 5 } },
+			return el(
+				'div',
+				{
+					className: 'test-svg-icon-background',
+					style: { outline: '1px solid gray', padding: 5 },
+				},
 				el( InnerBlocks.Content, {} )
 			);
 		},

--- a/packages/e2e-tests/plugins/container-without-paragraph/index.js
+++ b/packages/e2e-tests/plugins/container-without-paragraph/index.js
@@ -1,17 +1,19 @@
 ( function() {
-	wp.blocks.registerBlockType('test/container-without-paragraph', {
+	wp.blocks.registerBlockType( 'test/container-without-paragraph', {
 		title: 'Container without paragraph',
-		category: 'common',
+		category: 'text',
 		icon: 'yes',
 
 		edit() {
-			return wp.element.createElement(wp.blockEditor.InnerBlocks, {
-				allowedBlocks: ['core/image', 'core/gallery']
-			});
+			return wp.element.createElement( wp.blockEditor.InnerBlocks, {
+				allowedBlocks: [ 'core/image', 'core/gallery' ],
+			} );
 		},
 
 		save() {
-			return wp.element.createElement(wp.blockEditor.InnerBlocks.Content);
+			return wp.element.createElement(
+				wp.blockEditor.InnerBlocks.Content
+			);
 		},
-	})
+	} );
 } )();

--- a/packages/e2e-tests/plugins/custom-grouping-block/index.js
+++ b/packages/e2e-tests/plugins/custom-grouping-block/index.js
@@ -1,28 +1,42 @@
 ( function() {
 	wp.blocks.registerBlockType( 'test/alternative-group-block', {
 		title: 'Alternative Group Block',
-		category: 'layout',
+		category: 'design',
 		icon: 'yes',
 		edit() {
 			return wp.element.createElement( wp.blockEditor.InnerBlocks );
 		},
 
 		save() {
-			return wp.element.createElement( wp.blockEditor.InnerBlocks.Content );
+			return wp.element.createElement(
+				wp.blockEditor.InnerBlocks.Content
+			);
 		},
 		transforms: {
-			from: [ {
-				type: 'block',
-				blocks: [ '*' ],
-				isMultiBlock: true,
-				__experimentalConvert( blocks ) {
-					const groupInnerBlocks = blocks.map( ( { name, attributes, innerBlocks } ) => {
-						return wp.blocks.createBlock( name, attributes, innerBlocks );
-					} );
+			from: [
+				{
+					type: 'block',
+					blocks: [ '*' ],
+					isMultiBlock: true,
+					__experimentalConvert( blocks ) {
+						const groupInnerBlocks = blocks.map(
+							( { name, attributes, innerBlocks } ) => {
+								return wp.blocks.createBlock(
+									name,
+									attributes,
+									innerBlocks
+								);
+							}
+						);
 
-					return wp.blocks.createBlock( 'test/alternative-group-block', {}, groupInnerBlocks );
+						return wp.blocks.createBlock(
+							'test/alternative-group-block',
+							{},
+							groupInnerBlocks
+						);
+					},
 				},
-			} ],
+			],
 		},
 	} );
-}() );
+} )();

--- a/packages/e2e-tests/plugins/deprecated-node-matcher/index.js
+++ b/packages/e2e-tests/plugins/deprecated-node-matcher/index.js
@@ -12,7 +12,7 @@
 				selector: 'p',
 			},
 		},
-		category: 'formatting',
+		category: 'text',
 		edit: function( { attributes, setAttributes } ) {
 			return el( RichText, {
 				tagName: 'p',
@@ -58,9 +58,11 @@
 				},
 			},
 		},
-		category: 'formatting',
+		category: 'text',
 		edit: function( { attributes, setAttributes } ) {
-			return el( 'blockquote', {},
+			return el(
+				'blockquote',
+				{},
 				el( RichText, {
 					multiline: 'p',
 					value: toRichTextValue( attributes.value ),
@@ -73,7 +75,9 @@
 			);
 		},
 		save: function( { attributes } ) {
-			return el( 'blockquote', {},
+			return el(
+				'blockquote',
+				{},
 				el( RichText.Content, {
 					value: toRichTextValue( attributes.value ),
 				} )

--- a/packages/e2e-tests/plugins/inner-blocks-allowed-blocks/index.js
+++ b/packages/e2e-tests/plugins/inner-blocks-allowed-blocks/index.js
@@ -22,7 +22,7 @@
 	registerBlockType( 'test/allowed-blocks-unset', {
 		title: 'Allowed Blocks Unset',
 		icon: 'carrot',
-		category: 'common',
+		category: 'text',
 
 		edit() {
 			return el( 'div', divProps, el( InnerBlocks, { template } ) );
@@ -34,7 +34,7 @@
 	registerBlockType( 'test/allowed-blocks-set', {
 		title: 'Allowed Blocks Set',
 		icon: 'carrot',
-		category: 'common',
+		category: 'text',
 
 		edit() {
 			return el(
@@ -59,7 +59,7 @@
 	registerBlockType( 'test/allowed-blocks-dynamic', {
 		title: 'Allowed Blocks Dynamic',
 		icon: 'carrot',
-		category: 'common',
+		category: 'text',
 
 		edit: withSelect( function( select, ownProps ) {
 			var getBlockOrder = select( 'core/block-editor' ).getBlockOrder;

--- a/packages/e2e-tests/plugins/inner-blocks-locking-all-embed/index.js
+++ b/packages/e2e-tests/plugins/inner-blocks-locking-all-embed/index.js
@@ -4,10 +4,13 @@
 	var InnerBlocks = wp.blockEditor.InnerBlocks;
 	var __ = wp.i18n.__;
 	var TEMPLATE = [
-		[ 'core/paragraph', {
-			fontSize: 'large',
-			content: __( 'Content…' ),
-		} ],
+		[
+			'core/paragraph',
+			{
+				fontSize: 'large',
+				content: __( 'Content…' ),
+			},
+		],
 		[ 'core/embed' ],
 	];
 
@@ -18,16 +21,13 @@
 	registerBlockType( 'test/test-inner-blocks-locking-all-embed', {
 		title: 'Test Inner Blocks Locking All Embed',
 		icon: 'cart',
-		category: 'common',
+		category: 'text',
 
 		edit: function( props ) {
-			return el(
-				InnerBlocks,
-				{
-					template: TEMPLATE,
-					templateLock: 'all',
-				}
-			);
+			return el( InnerBlocks, {
+				template: TEMPLATE,
+				templateLock: 'all',
+			} );
 		},
 
 		save,

--- a/packages/e2e-tests/plugins/inner-blocks-render-appender/index.js
+++ b/packages/e2e-tests/plugins/inner-blocks-render-appender/index.js
@@ -8,36 +8,48 @@
 	var allowedBlocks = [ 'core/quote', 'core/video' ];
 
 	function myCustomAppender() {
-		return (
-			el( 'div', { className: 'my-custom-awesome-appender' },
-				el( 'span', {}, 'My custom awesome appender' ),
-				el( InnerBlocks.ButtonBlockAppender )
-			)
+		return el(
+			'div',
+			{ className: 'my-custom-awesome-appender' },
+			el( 'span', {}, 'My custom awesome appender' ),
+			el( InnerBlocks.ButtonBlockAppender )
 		);
 	}
 
 	function emptyBlockAppender() {
-		return (
-			el( 'div', { className: 'my-dynamic-blocks-appender' },
-				el( 'span', { className: 'empty-blocks-appender' }, 'Empty Blocks Appender' ),
-				el( InnerBlocks.ButtonBlockAppender )
-			)
+		return el(
+			'div',
+			{ className: 'my-dynamic-blocks-appender' },
+			el(
+				'span',
+				{ className: 'empty-blocks-appender' },
+				'Empty Blocks Appender'
+			),
+			el( InnerBlocks.ButtonBlockAppender )
 		);
 	}
 
 	function singleBlockAppender() {
-		return (
-			el( 'div', { className: 'my-dynamic-blocks-appender' },
-				el( 'span', { className: 'single-blocks-appender' }, 'Single Blocks Appender' ),
-				el( InnerBlocks.ButtonBlockAppender )
-			)
+		return el(
+			'div',
+			{ className: 'my-dynamic-blocks-appender' },
+			el(
+				'span',
+				{ className: 'single-blocks-appender' },
+				'Single Blocks Appender'
+			),
+			el( InnerBlocks.ButtonBlockAppender )
 		);
 	}
 
 	function multipleBlockAppender() {
-		return (
-			el( 'div', { className: 'my-dynamic-blocks-appender' },
-				el( 'span', { className: 'multiple-blocks-appender' }, 'Multiple Blocks Appender' ),
+		return el(
+			'div',
+			{ className: 'my-dynamic-blocks-appender' },
+			el(
+				'span',
+				{ className: 'multiple-blocks-appender' },
+				'Multiple Blocks Appender'
 			)
 		);
 	}
@@ -45,10 +57,12 @@
 	registerBlockType( 'test/inner-blocks-render-appender', {
 		title: 'InnerBlocks renderAppender',
 		icon: 'carrot',
-		category: 'common',
+		category: 'text',
 
 		edit() {
-			return el( 'div', { style: { outline: '1px solid gray', padding: 5 } },
+			return el(
+				'div',
+				{ style: { outline: '1px solid gray', padding: 5 } },
 				el( InnerBlocks, {
 					allowedBlocks: allowedBlocks,
 					renderAppender: myCustomAppender,
@@ -57,7 +71,9 @@
 		},
 
 		save() {
-			return el( 'div', { style: { outline: '1px solid gray', padding: 5 } },
+			return el(
+				'div',
+				{ style: { outline: '1px solid gray', padding: 5 } },
 				el( InnerBlocks.Content )
 			);
 		},
@@ -66,13 +82,16 @@
 	registerBlockType( 'test/inner-blocks-render-appender-dynamic', {
 		title: 'InnerBlocks renderAppender dynamic',
 		icon: 'carrot',
-		category: 'common',
+		category: 'text',
 
 		edit( props ) {
-			const numberOfChildren = useSelect( ( select ) => {
-				const { getBlockOrder } = select( 'core/block-editor' );
-				return getBlockOrder( props.clientId ).length;
-			}, [ props.clientId ] );
+			const numberOfChildren = useSelect(
+				( select ) => {
+					const { getBlockOrder } = select( 'core/block-editor' );
+					return getBlockOrder( props.clientId ).length;
+				},
+				[ props.clientId ]
+			);
 			switch ( numberOfChildren ) {
 				case 0:
 					renderAppender = emptyBlockAppender;
@@ -84,7 +103,9 @@
 					renderAppender = multipleBlockAppender;
 					break;
 			}
-			return el( 'div', { style: { outline: '1px solid gray', padding: 5 } },
+			return el(
+				'div',
+				{ style: { outline: '1px solid gray', padding: 5 } },
 				el( InnerBlocks, {
 					allowedBlocks,
 					renderAppender,
@@ -93,9 +114,11 @@
 		},
 
 		save() {
-			return el( 'div', { style: { outline: '1px solid gray', padding: 5 } },
+			return el(
+				'div',
+				{ style: { outline: '1px solid gray', padding: 5 } },
 				el( InnerBlocks.Content )
 			);
 		},
 	} );
-}() );
+} )();

--- a/packages/e2e-tests/plugins/inner-blocks-templates/index.js
+++ b/packages/e2e-tests/plugins/inner-blocks-templates/index.js
@@ -5,17 +5,23 @@
 	var InnerBlocks = wp.blockEditor.InnerBlocks;
 	var __ = wp.i18n.__;
 	var TEMPLATE = [
-		[ 'core/paragraph', {
-			fontSize: 'large',
-			content: 'Content…',
-		} ],
+		[
+			'core/paragraph',
+			{
+				fontSize: 'large',
+				content: 'Content…',
+			},
+		],
 	];
 
 	var TEMPLATE_PARAGRAPH_PLACEHOLDER = [
-		[ 'core/paragraph', {
-			fontSize: 'large',
-			placeholder: 'Content…',
-		} ],
+		[
+			'core/paragraph',
+			{
+				fontSize: 'large',
+				placeholder: 'Content…',
+			},
+		],
 	];
 
 	var save = function() {
@@ -25,15 +31,12 @@
 	registerBlockType( 'test/test-inner-blocks-no-locking', {
 		title: 'Test Inner Blocks no locking',
 		icon: 'cart',
-		category: 'common',
+		category: 'text',
 
 		edit: function( props ) {
-			return el(
-				InnerBlocks,
-				{
-					template: TEMPLATE,
-				}
-			);
+			return el( InnerBlocks, {
+				template: TEMPLATE,
+			} );
 		},
 
 		save,
@@ -42,16 +45,13 @@
 	registerBlockType( 'test/test-inner-blocks-locking-all', {
 		title: 'Test InnerBlocks locking all',
 		icon: 'cart',
-		category: 'common',
+		category: 'text',
 
 		edit: function( props ) {
-			return el(
-				InnerBlocks,
-				{
-					template: TEMPLATE,
-					templateLock: 'all',
-				}
-			);
+			return el( InnerBlocks, {
+				template: TEMPLATE,
+				templateLock: 'all',
+			} );
 		},
 
 		save,
@@ -60,15 +60,12 @@
 	registerBlockType( 'test/test-inner-blocks-paragraph-placeholder', {
 		title: 'Test Inner Blocks Paragraph Placeholder',
 		icon: 'cart',
-		category: 'common',
+		category: 'text',
 
 		edit: function( props ) {
-			return el(
-				InnerBlocks,
-				{
-					template: TEMPLATE_PARAGRAPH_PLACEHOLDER,
-				}
-			);
+			return el( InnerBlocks, {
+				template: TEMPLATE_PARAGRAPH_PLACEHOLDER,
+			} );
 		},
 
 		save,
@@ -77,7 +74,7 @@
 	registerBlockType( 'test/test-inner-blocks-transformer-target', {
 		title: 'Test Inner Blocks transformer target',
 		icon: 'cart',
-		category: 'common',
+		category: 'text',
 
 		transforms: {
 			from: [
@@ -87,10 +84,14 @@
 						'test/i-dont-exist',
 						'test/test-inner-blocks-no-locking',
 						'test/test-inner-blocks-locking-all',
-						'test/test-inner-blocks-paragraph-placeholder'
+						'test/test-inner-blocks-paragraph-placeholder',
 					],
 					transform: function( attributes, innerBlocks ) {
-						return createBlock( 'test/test-inner-blocks-transformer-target', attributes, innerBlocks );
+						return createBlock(
+							'test/test-inner-blocks-transformer-target',
+							attributes,
+							innerBlocks
+						);
 					},
 				},
 			],
@@ -99,22 +100,22 @@
 					type: 'block',
 					blocks: [ 'test/i-dont-exist' ],
 					transform: function( attributes, innerBlocks ) {
-						return createBlock( 'test/test-inner-blocks-transformer-target', attributes, innerBlocks );
+						return createBlock(
+							'test/test-inner-blocks-transformer-target',
+							attributes,
+							innerBlocks
+						);
 					},
-				}
-			]
+				},
+			],
 		},
 
 		edit: function( props ) {
-			return el(
-				InnerBlocks,
-				{
-					template: TEMPLATE,
-				}
-			);
+			return el( InnerBlocks, {
+				template: TEMPLATE,
+			} );
 		},
 
 		save,
 	} );
-
 } )();

--- a/packages/e2e-tests/plugins/meta-attribute-block/early.js
+++ b/packages/e2e-tests/plugins/meta-attribute-block/early.js
@@ -5,7 +5,7 @@
 	registerBlockType( 'test/test-meta-attribute-block-early', {
 		title: 'Test Meta Attribute Block (Early Registration)',
 		icon: 'star',
-		category: 'common',
+		category: 'text',
 
 		attributes: {
 			content: {

--- a/packages/e2e-tests/plugins/meta-attribute-block/late.js
+++ b/packages/e2e-tests/plugins/meta-attribute-block/late.js
@@ -5,7 +5,7 @@
 	registerBlockType( 'test/test-meta-attribute-block-late', {
 		title: 'Test Meta Attribute Block (Late Registration)',
 		icon: 'star',
-		category: 'common',
+		category: 'text',
 
 		attributes: {
 			content: {

--- a/packages/e2e-tests/specs/experiments/block-directory-add.test.js
+++ b/packages/e2e-tests/specs/experiments/block-directory-add.test.js
@@ -62,7 +62,7 @@ const block = `( function() {
 	registerBlockType( '${ MOCK_BLOCK1.name }', {
 		title: 'Test Block for Block Directory',
 		icon: 'hammer',
-		category: 'common',
+		category: 'text',
 		attributes: {},
 		edit: function( props ) {
 			return el( 'p', null, 'Test Copy' );

--- a/packages/editor/src/components/document-outline/test/index.js
+++ b/packages/editor/src/components/document-outline/test/index.js
@@ -25,7 +25,7 @@ describe( 'DocumentOutline', () => {
 	let paragraph, headingH1, headingParent, headingChild, nestedHeading;
 	beforeAll( () => {
 		registerBlockType( 'core/heading', {
-			category: 'common',
+			category: 'text',
 			title: 'Heading',
 			edit: () => {},
 			save: () => {},
@@ -41,14 +41,14 @@ describe( 'DocumentOutline', () => {
 		} );
 
 		registerBlockType( 'core/paragraph', {
-			category: 'common',
+			category: 'text',
 			title: 'Paragraph',
 			edit: () => {},
 			save: () => {},
 		} );
 
 		registerBlockType( 'core/columns', {
-			category: 'common',
+			category: 'text',
 			title: 'Paragraph',
 			edit: () => {},
 			save: () => {},

--- a/packages/editor/src/store/effects/test/reusable-blocks.js
+++ b/packages/editor/src/store/effects/test/reusable-blocks.js
@@ -44,7 +44,7 @@ describe( 'reusable blocks effects', () => {
 	beforeAll( () => {
 		registerBlockType( 'core/test-block', {
 			title: 'Test block',
-			category: 'common',
+			category: 'text',
 			save: () => null,
 			attributes: {
 				name: { type: 'string' },
@@ -53,7 +53,7 @@ describe( 'reusable blocks effects', () => {
 
 		registerBlockType( 'core/block', {
 			title: 'Reusable Block',
-			category: 'common',
+			category: 'text',
 			save: () => null,
 			attributes: {
 				ref: { type: 'string' },

--- a/packages/editor/src/store/test/selectors.js
+++ b/packages/editor/src/store/test/selectors.js
@@ -196,7 +196,7 @@ describe( 'selectors', () => {
 
 		registerBlockType( 'core/test-block-a', {
 			save: ( props ) => props.attributes.text,
-			category: 'formatting',
+			category: 'design',
 			title: 'Test Block A',
 			icon: 'test',
 			keywords: [ 'testing' ],
@@ -204,7 +204,7 @@ describe( 'selectors', () => {
 
 		registerBlockType( 'core/test-block-b', {
 			save: ( props ) => props.attributes.text,
-			category: 'common',
+			category: 'text',
 			title: 'Test Block B',
 			icon: 'test',
 			keywords: [ 'testing' ],
@@ -215,7 +215,7 @@ describe( 'selectors', () => {
 
 		registerBlockType( 'core/test-block-c', {
 			save: ( props ) => props.attributes.text,
-			category: 'common',
+			category: 'text',
 			title: 'Test Block C',
 			icon: 'test',
 			keywords: [ 'testing' ],
@@ -224,7 +224,7 @@ describe( 'selectors', () => {
 
 		registerBlockType( 'core/test-freeform', {
 			save: ( props ) => <RawHTML>{ props.attributes.content }</RawHTML>,
-			category: 'common',
+			category: 'text',
 			title: 'Test Freeform Content Handler',
 			icon: 'test',
 			supports: {
@@ -238,7 +238,7 @@ describe( 'selectors', () => {
 		} );
 
 		registerBlockType( 'core/test-default', {
-			category: 'common',
+			category: 'text',
 			title: 'default',
 			attributes: {
 				modified: {
@@ -2249,7 +2249,7 @@ describe( 'selectors', () => {
 			originalDefaultBlockName = getDefaultBlockName();
 
 			registerBlockType( 'core/default', {
-				category: 'common',
+				category: 'text',
 				title: 'default',
 				attributes: {
 					modified: {

--- a/test/integration/blocks-raw-handling.test.js
+++ b/test/integration/blocks-raw-handling.test.js
@@ -30,7 +30,7 @@ describe( 'Blocks raw handling', () => {
 		registerCoreBlocks();
 		registerBlockType( 'test/gallery', {
 			title: 'Test Gallery',
-			category: 'common',
+			category: 'text',
 			attributes: {
 				ids: {
 					type: 'array',
@@ -63,7 +63,7 @@ describe( 'Blocks raw handling', () => {
 
 		registerBlockType( 'test/non-inline-block', {
 			title: 'Test Non Inline Block',
-			category: 'common',
+			category: 'text',
 			supports: {
 				pasteTextInline: false,
 			},

--- a/test/integration/shortcode-converter.test.js
+++ b/test/integration/shortcode-converter.test.js
@@ -14,7 +14,7 @@ describe( 'segmentHTMLToShortcodeBlock', () => {
 		registerCoreBlocks();
 		registerBlockType( 'test/gallery', {
 			title: 'Test Gallery',
-			category: 'common',
+			category: 'text',
 			attributes: {
 				ids: {
 					type: 'array',
@@ -42,7 +42,7 @@ describe( 'segmentHTMLToShortcodeBlock', () => {
 		} );
 		registerBlockType( 'test/broccoli', {
 			title: 'Test Broccoli',
-			category: 'common',
+			category: 'text',
 			attributes: {
 				id: {
 					type: 'number',
@@ -70,7 +70,7 @@ describe( 'segmentHTMLToShortcodeBlock', () => {
 		} );
 		registerBlockType( 'test/fallback-broccoli', {
 			title: 'Test Fallback Broccoli',
-			category: 'common',
+			category: 'text',
 			attributes: {
 				id: {
 					type: 'number',


### PR DESCRIPTION
Closes #11406

This pull request seeks to propose to replace the existing set of default block categories with a new set of categories as proposed in #11406.

The updated set of block categories are:

- Text
- Media
- Design
- ~Tools~ **Edit:** Widgets _(Unchanged)_
- Embeds _(Unchanged)_
- Reusable _(Unchanged)_

![image](https://user-images.githubusercontent.com/1779930/71267560-e23c2080-2318-11ea-8eee-c56e8eb26db4.png)

<p><strong id="implementation-notes">Implementation Notes:</strong></p>

There is an attempt to preserve some backwards-compatibility here, based on the summarized findings at https://github.com/WordPress/gutenberg/issues/11406#issuecomment-567164861 .

Blocks which register to one of the existing categories will transparently map to one of the updated categories. As implemented, that mapping is proposed as follows:

Before|After
---|---
Common|**_Text_**
Formatting|**_Text_**
&nbsp;|Media
Layout|**_Design_**
Widgets|Widgets
Embeds|Embeds
Reusable blocks|Reusable blocks

<details><summary>Click to expand outdated notes from early iterations</summary>

Before|After
---|---
Common|Text
Formatting|Text
Layout|Design
Widgets|Tools

_(Suggested improvements to this are welcomed)_

Notably, I have not yet updated existing blocks to use an appropriate new category name, for the explicit purpose to effectively test the sensibility of this mapping arrangement, considering that this is expected to impact third-party blocks which register to one of the existing categories, at least until those plugins opt to update to a more appropriate updated category.

Prior to merge, we can consider to update the default set of core blocks to a more appropriate block category.
</details>

~As a follow-up task, I would like to explore improvements around allowing blocks to be registered without a category, or without a valid category. Such blocks should be shown in an "Uncategorized" block grouping. This could also be used to support usage where there are no default categories, and the inserter would show all blocks without any groupings. This could also be used to improve support for hypothetical future revisions to block categories, in order to better handle block registrations for plugins which support multiple older versions of WordPress.~ **Edit (2020-05-29):** This was implemented separately in #22280.

**Testing Instructions:**

Verify block categories are updated to new values, seen in the block inserter.

Verify there are no errors of block registration in your browsers Developer Tools console (i.e. all blocks should still be registered, with an appropriate category).

Optionally, verify you can change a block registration to use one of the new block category names, or a legacy category name. Legacy category usage should appear as categorized based on the mapping above.