### PR TITLE
Docs: Fix link to loading javascript page

### DIFF
--- a/docs/designers-developers/developers/tutorials/javascript/js-build-setup.md
+++ b/docs/designers-developers/developers/tutorials/javascript/js-build-setup.md
@@ -123,7 +123,7 @@ To configure npm to run a script, you use the scripts section in `package.json` 
 
 You can then run the build using: `npm run build`.
 
-After the build finishes, you will see the built file created at `build/index.js`. Enqueue this file in the admin screen as you would any JavaScript in WordPress, see [Step 2 in this tutorial](readme.md), and the block will load in the editor.
+After the build finishes, you will see the built file created at `build/index.js`. Enqueue this file in the admin screen as you would any JavaScript in WordPress, see [loading JavaScript step in this tutorial](/docs/designers-developers/developers/tutorials/javascript/loading-javascript.md), and the block will load in the editor.
 
 ## Finishing Touches
 


### PR DESCRIPTION
## Description

Fixes the link to the loading JavaScript page, I also changed it to remove reference to "Step 2" because the order of pages and steps may change, and not relevant in the link.

## How has this been tested?

Confirm link works <a href="https://github.com/WordPress/gutenberg/blob/fix/doc-js-link/docs/designers-developers/developers/tutorials/javascript/js-build-setup.md">from this page on the branch</a>

## Types of changes

Docs.
