### PR TITLE
Priority Queue: Invoke callback when flushing queue

### DIFF
--- a/packages/priority-queue/CHANGELOG.md
+++ b/packages/priority-queue/CHANGELOG.md
@@ -1,3 +1,9 @@
-### 1.0.0 (2019-03-06)
+## Master
+
+### Bug Fixes
+
+- Resolves an issue where `flush` would not invoke the callback associated with the given element. The previous implementation would simply remove the element from the queue. The updated behavior adheres to what one would expect from a flush as in to complete the deferred execution immediately. With these changes, all callbacks will always (eventually) be invoked unless the application is abruptly terminated. A future version could introduce support for a `remove` function to replicate the previous behavior of `flush`.
+
+## 1.0.0 (2019-03-06)
 
 Initial release.

--- a/packages/priority-queue/src/index.js
+++ b/packages/priority-queue/src/index.js
@@ -127,9 +127,11 @@ export const createQueue = () => {
 			return false;
 		}
 
-		elementsMap.delete( element );
 		const index = waitingList.indexOf( element );
 		waitingList.splice( index, 1 );
+		const callback = /** @type {WPPriorityQueueCallback} */ ( elementsMap.get( element ) );
+		elementsMap.delete( element );
+		callback();
 
 		return true;
 	};

--- a/packages/priority-queue/src/index.js
+++ b/packages/priority-queue/src/index.js
@@ -1,4 +1,9 @@
 /**
+ * Internal dependencies
+ */
+import requestIdleCallback from './request-idle-callback';
+
+/**
  * Enqueued callback to invoke once idle time permits.
  *
  * @typedef {()=>void} WPPriorityQueueCallback
@@ -30,9 +35,6 @@
  * @property {WPPriorityQueueAdd}   add   Add callback to queue for context.
  * @property {WPPriorityQueueFlush} flush Flush queue for context.
  */
-
-/** @type {typeof window.requestIdleCallback|typeof window.requestAnimationFrame} */
-const requestIdleCallback = window.requestIdleCallback ? window.requestIdleCallback : window.requestAnimationFrame;
 
 /**
  * Creates a context-aware queue that only executes

--- a/packages/priority-queue/src/request-idle-callback.js
+++ b/packages/priority-queue/src/request-idle-callback.js
@@ -1,0 +1,14 @@
+/**
+ * @return {typeof window.requestIdleCallback|typeof window.requestAnimationFrame|((callback:(timestamp:number)=>void)=>void)}
+ */
+export function createRequestIdleCallback() {
+	if ( typeof 'window' === undefined ) {
+		return ( callback ) => {
+			setTimeout( () => callback( Date.now() ), 0 );
+		};
+	}
+
+	return window.requestIdleCallback || window.requestAnimationFrame;
+}
+
+export default createRequestIdleCallback();

--- a/packages/priority-queue/src/test/index.js
+++ b/packages/priority-queue/src/test/index.js
@@ -19,11 +19,41 @@ describe( 'createQueue', () => {
 		queue = createQueue();
 	} );
 
-	it( 'runs callback after processing waiting queue', () => {
-		const callback = jest.fn();
-		queue.add( {}, callback );
-		expect( callback ).not.toHaveBeenCalled();
-		requestIdleCallback.tick();
-		expect( callback ).toHaveBeenCalled();
+	describe( 'add', () => {
+		it( 'runs callback after processing waiting queue', () => {
+			const callback = jest.fn();
+
+			queue.add( {}, callback );
+
+			expect( callback ).not.toHaveBeenCalled();
+			requestIdleCallback.tick();
+			expect( callback ).toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'flush', () => {
+		it( 'invokes all callbacks associated with element', () => {
+			const elementA = {};
+			const elementB = {};
+			const callbackElementA = jest.fn();
+			const callbackElementB = jest.fn();
+			queue.add( elementA, callbackElementA );
+			queue.add( elementB, callbackElementB );
+
+			expect( callbackElementA ).not.toHaveBeenCalled();
+			expect( callbackElementB ).not.toHaveBeenCalled();
+
+			queue.flush( elementA );
+
+			// Only ElementA callback should have been called (synchronously).
+			expect( callbackElementA ).toHaveBeenCalledTimes( 1 );
+			expect( callbackElementB ).not.toHaveBeenCalled();
+
+			// Verify that callback still called only once after tick (verify
+			// removal).
+			requestIdleCallback.tick();
+			expect( callbackElementA ).toHaveBeenCalledTimes( 1 );
+			expect( callbackElementB ).toHaveBeenCalledTimes( 1 );
+		} );
 	} );
 } );

--- a/packages/priority-queue/src/test/index.js
+++ b/packages/priority-queue/src/test/index.js
@@ -22,6 +22,7 @@ describe( 'createQueue', () => {
 	it( 'runs callback after processing waiting queue', () => {
 		const callback = jest.fn();
 		queue.add( {}, callback );
+		expect( callback ).not.toHaveBeenCalled();
 		requestIdleCallback.tick();
 		expect( callback ).toHaveBeenCalled();
 	} );

--- a/packages/priority-queue/src/test/index.js
+++ b/packages/priority-queue/src/test/index.js
@@ -1,0 +1,34 @@
+/**
+ * External dependencies
+ */
+import { EventEmitter } from 'events';
+
+/**
+ * Internal dependencies
+ */
+import { createQueue } from '../';
+import requestIdleCallback from '../request-idle-callback';
+
+const emitter = new EventEmitter();
+
+const tick = () => emitter.emit( 'tick' );
+
+jest.mock( '../request-idle-callback', () => jest.fn() );
+
+requestIdleCallback.mockImplementation( ( callback ) => {
+	emitter.once( 'tick', () => callback( Date.now() ) );
+} );
+
+describe( 'createQueue', () => {
+	let queue;
+	beforeEach( () => {
+		queue = createQueue();
+	} );
+
+	it( 'runs callback after processing waiting queue', () => {
+		const callback = jest.fn();
+		queue.add( {}, callback );
+		tick();
+		expect( callback ).toHaveBeenCalled();
+	} );
+} );

--- a/packages/priority-queue/src/test/index.js
+++ b/packages/priority-queue/src/test/index.js
@@ -29,6 +29,43 @@ describe( 'createQueue', () => {
 			requestIdleCallback.tick();
 			expect( callback ).toHaveBeenCalled();
 		} );
+
+		it( 'runs callbacks in order by distinct added element', () => {
+			const elementA = {};
+			const elementB = {};
+			const callbackElementA = jest.fn();
+			const callbackElementB = jest.fn();
+			queue.add( elementA, callbackElementA );
+			queue.add( elementB, callbackElementB );
+
+			expect( callbackElementA ).not.toHaveBeenCalled();
+			expect( callbackElementB ).not.toHaveBeenCalled();
+
+			// ElementA was added first, and should be called first after tick.
+			requestIdleCallback.tick();
+			expect( callbackElementA ).toHaveBeenCalledTimes( 1 );
+			expect( callbackElementB ).not.toHaveBeenCalled();
+
+			// ElementB will be be processed after second tick.
+			requestIdleCallback.tick();
+			expect( callbackElementA ).toHaveBeenCalledTimes( 1 );
+			expect( callbackElementB ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'calls most recently added callback if added for same element', () => {
+			const element = {};
+			const callbackOne = jest.fn();
+			const callbackTwo = jest.fn();
+			queue.add( element, callbackOne );
+			queue.add( element, callbackTwo );
+
+			expect( callbackOne ).not.toHaveBeenCalled();
+			expect( callbackTwo ).not.toHaveBeenCalled();
+
+			requestIdleCallback.tick();
+			expect( callbackOne ).not.toHaveBeenCalled();
+			expect( callbackTwo ).toHaveBeenCalledTimes( 1 );
+		} );
 	} );
 
 	describe( 'flush', () => {


### PR DESCRIPTION
Related: #19199, #19205

This pull request seeks to update the behavior of the priority queue module to invoke a queued member's callback when flushing it from the waiting list. As noted at https://github.com/WordPress/gutenberg/pull/13056#discussion_r359029819, the previous behavior behaved more like a pure deletion than it did a flush, in that a flush would be expected to complete the deferred execution immediately.

Aside from being a desired behavior, it does not seem that this has an immediate benefit on the scenario described in #19199. While the callback is executed, the component still fails to re-render as expected. Interestingly, when stepping through the queue flush using the DevTools debugger, the render does occur. It's unclear to me why this inconsistency occurs.

**Testing Instructions:**

There are no unit tests for this module. If this is a desired solution, I could seek to include some.

Repeat Steps to Reproduce from #19199