### PR TITLE
Popover: remove buffer options

### DIFF
--- a/packages/block-editor/src/components/rich-text/format-toolbar-container.js
+++ b/packages/block-editor/src/components/rich-text/format-toolbar-container.js
@@ -17,7 +17,6 @@ const FormatToolbarContainer = ( { inline, anchorRef } ) => {
 				noArrow
 				position="top center"
 				focusOnMount={ false }
-				anchorVerticalBuffer={ 6 }
 				anchorRef={ anchorRef }
 				className="block-editor-rich-text__inline-format-toolbar"
 			>

--- a/packages/block-editor/src/components/rich-text/style.scss
+++ b/packages/block-editor/src/components/rich-text/style.scss
@@ -55,6 +55,7 @@ figcaption.block-editor-rich-text__editable [data-rich-text-placeholder]::before
 
 	.components-popover__content {
 		min-width: auto;
+		margin-bottom: 6px;
 	}
 
 	.components-toolbar {

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -85,19 +85,6 @@ function computeAnchorRect(
 	return withoutPadding( rect, parentNode );
 }
 
-function addBuffer( rect, verticalBuffer = 0, horizontalBuffer = 0 ) {
-	return {
-		x: rect.left - horizontalBuffer,
-		y: rect.top - verticalBuffer,
-		width: rect.width + ( 2 * horizontalBuffer ),
-		height: rect.height + ( 2 * verticalBuffer ),
-		left: rect.left - horizontalBuffer,
-		right: rect.right + horizontalBuffer,
-		top: rect.top - verticalBuffer,
-		bottom: rect.bottom + verticalBuffer,
-	};
-}
-
 function withoutPadding( rect, element ) {
 	const {
 		paddingTop,
@@ -231,8 +218,6 @@ const Popover = ( {
 	focusOnMount = 'firstElement',
 	anchorRef,
 	shouldAnchorIncludePadding,
-	anchorVerticalBuffer,
-	anchorHorizontalBuffer,
 	anchorRect,
 	getAnchorRect,
 	expandOnMobile,
@@ -268,7 +253,7 @@ const Popover = ( {
 		}
 
 		const refresh = () => {
-			let anchor = computeAnchorRect(
+			const anchor = computeAnchorRect(
 				anchorRefFallback,
 				anchorRect,
 				getAnchorRect,
@@ -279,12 +264,6 @@ const Popover = ( {
 			if ( ! anchor ) {
 				return;
 			}
-
-			anchor = addBuffer(
-				anchor,
-				anchorVerticalBuffer,
-				anchorHorizontalBuffer
-			);
 
 			if ( ! contentRect.current ) {
 				contentRect.current = contentEl.getBoundingClientRect();
@@ -357,8 +336,6 @@ const Popover = ( {
 		getAnchorRect,
 		anchorRef,
 		shouldAnchorIncludePadding,
-		anchorVerticalBuffer,
-		anchorHorizontalBuffer,
 		position,
 	] );
 


### PR DESCRIPTION
## Description

These options were added in #17867, but I realised recently that we could just use a margin. 🙈
These options were not documented and not part of any WordPress release, so they are safe to remove.

## How has this been tested?

Check the inline toolbar position for the image block. There should be some space between the caption text and the toolbar.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
