### PR TITLE
Guide Accessibility: Change the aria-current expression to be a step instead of a boolean

### DIFF
--- a/packages/components/src/guide/page-control.js
+++ b/packages/components/src/guide/page-control.js
@@ -20,6 +20,7 @@ export default function PageControl( { currentPage, numberOfPages, setCurrentPag
 			{ times( numberOfPages, ( page ) => (
 				<li
 					key={ page }
+					// Set aria-current="step" on the active page, see https://www.w3.org/TR/wai-aria-1.1/#aria-current
 					aria-current={ page === currentPage ? 'step' : undefined }
 				>
 					<IconButton

--- a/packages/components/src/guide/page-control.js
+++ b/packages/components/src/guide/page-control.js
@@ -20,7 +20,7 @@ export default function PageControl( { currentPage, numberOfPages, setCurrentPag
 			{ times( numberOfPages, ( page ) => (
 				<li
 					key={ page }
-					aria-current={ page === currentPage }
+					aria-current={ page === currentPage ? 'step' : undefined }
 				>
 					<IconButton
 						key={ page }


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

Change the attribute value that is set for aria-current to be "step", not "true" or "false".

This is in accordance with the [documentation of aria-current](https://www.w3.org/TR/wai-aria-1.1/#aria-current):

> A step token used to indicate a link within a step indicator for a step-based process, where the link is visually styled to represent the current step.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Tested in StoryBook using NVDA and Firefox.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Enhancement.

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
