### PR TITLE
Paste: handle embed element

### DIFF
--- a/test/integration/__snapshots__/blocks-raw-handling.test.js.snap
+++ b/test/integration/__snapshots__/blocks-raw-handling.test.js.snap
@@ -111,6 +111,14 @@ exports[`rawHandler should convert a list with attributes 1`] = `
 <!-- /wp:list -->"
 `;
 
+exports[`rawHandler should handle embed element 1`] = `
+"<!-- wp:embed {\\"url\\":\\"http://v.wordpress.com/KllQxFVq\\"} -->
+<figure class=\\"wp-block-embed\\"><div class=\\"wp-block-embed__wrapper\\">
+http://v.wordpress.com/KllQxFVq
+</div></figure>
+<!-- /wp:embed -->"
+`;
+
 exports[`rawHandler should not strip any text-level elements 1`] = `
 "<!-- wp:paragraph -->
 <p>This is <u>ncorect</u></p>

--- a/test/integration/blocks-raw-handling.test.js
+++ b/test/integration/blocks-raw-handling.test.js
@@ -363,4 +363,9 @@ describe( 'rawHandler', () => {
 		const HTML = '<p style="text-align:center">center</p>';
 		expect( serialize( rawHandler( { HTML } ) ) ).toMatchSnapshot();
 	} );
+
+	it( 'should handle embed element', () => {
+		const HTML = '<embed src="http://v.wordpress.com/KllQxFVq" type="application/x-shockwave-flash" width="600" height="338"></embed>';
+		expect( serialize( rawHandler( { HTML } ) ) ).toMatchSnapshot();
+	} );
 } );


### PR DESCRIPTION
## Description

Alternative to #19186.
Handle the embed element with the embed block.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
