### PR TITLE
Embed block: only convert pasted url for pattern match

### DIFF
--- a/packages/block-library/src/embed/index.js
+++ b/packages/block-library/src/embed/index.js
@@ -9,36 +9,26 @@ import { getEmbedBlockSettings } from './settings';
  * WordPress dependencies
  */
 import { __, _x } from '@wordpress/i18n';
-import { createBlock } from '@wordpress/blocks';
 
 export const name = 'core/embed';
 
 export const settings = getEmbedBlockSettings( {
-	title: _x( 'Embed', 'block title' ),
-	description: __( 'Embed videos, images, tweets, audio, and other content from external sources.' ),
-	icon: embedContentIcon,
-	// Unknown embeds should not be responsive by default.
-	responsive: false,
-	transforms: {
-		from: [
-			{
-				type: 'raw',
-				isMatch: ( node ) => node.nodeName === 'P' && /^\s*(https?:\/\/\S+)\s*$/i.test( node.textContent ),
-				transform: ( node ) => {
-					return createBlock( 'core/embed', {
-						url: node.textContent.trim(),
-					} );
-				},
-			},
-		],
+	name,
+	settings: {
+		title: _x( 'Embed', 'block title' ),
+		description: __( 'Embed videos, images, tweets, audio, and other content from external sources.' ),
+		icon: embedContentIcon,
+		// Unknown embeds should not be responsive by default.
+		responsive: false,
 	},
+	patterns: [],
 } );
 
 export const common = commonEmbeds.map(
 	( embedDefinition ) => {
 		return {
 			...embedDefinition,
-			settings: getEmbedBlockSettings( embedDefinition.settings ),
+			settings: getEmbedBlockSettings( embedDefinition ),
 		};
 	}
 );
@@ -47,7 +37,7 @@ export const others = otherEmbeds.map(
 	( embedDefinition ) => {
 		return {
 			...embedDefinition,
-			settings: getEmbedBlockSettings( embedDefinition.settings ),
+			settings: getEmbedBlockSettings( embedDefinition ),
 		};
 	}
 );


### PR DESCRIPTION
## Description

Currently, when pasting a URL, the embed block captures it and tries to embed it. This lets the embed block only capture the URL if it matches any of the registered patterns.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
