### PR TITLE
Try columns with grid and CSS vars

### DIFF
--- a/packages/block-library/src/column/edit.js
+++ b/packages/block-library/src/column/edit.js
@@ -107,24 +107,22 @@ export default compose(
 
 				const rootClientId = getBlockRootClientId( clientId );
 				const columns = getBlocks( rootClientId );
+				// Get all explicit, positive, column widths.
+				const columnWidths = columns.map( ( columnWidth ) => {
+					if ( ! columnWidth || columnWidth < 0 ) {
+						return null;
+					}
+					return columnWidth;
+				} );
+				// Check if sum of all column widths exceeds 100. (We are using 'fr' units but treating them as percentages.)
+				const resetAdjacentColumns = columnWidths.reduce( ( total, columnWidth ) => total + columnWidth ) > 100;
 
-				// Check if sum of all column widths exceeds 100.
-				const totalAdjacentWidths = columns.filter( ( column ) => column.attributes.width && column.clientId !== clientId ).reduce( ( total, column ) => total += column.attributes.width, 0 );
-				const resetAdjacentColumns = totalAdjacentWidths + width > 100;
-
-				// Create the updated template string. If needed, reset adjacent column widths.
-				let columnsTemplate = ``;
+				// If total widths exceed 100, reset adjacent column widths.
 				columns.forEach( ( column ) => {
 					if ( ( resetAdjacentColumns || ! column.attributes.width ) && column.clientId !== clientId ) {
-						columnsTemplate += `1fr `;
 						updateBlockAttributes( column.clientId, { width: '' } );
-					} else if ( ! column.attributes.width ) {
-						columnsTemplate += `1fr `;
-					} else {
-						columnsTemplate += `${ column.attributes.width }% `;
 					}
 				} );
-				updateBlockAttributes( rootClientId, { columnsTemplate } );
 			},
 		};
 	} )

--- a/packages/block-library/src/column/edit.js
+++ b/packages/block-library/src/column/edit.js
@@ -115,11 +115,17 @@ export default compose(
 					return columnWidth;
 				} );
 				// Check if sum of all column widths exceeds 100. (We are using 'fr' units but treating them as percentages.)
-				const resetAdjacentColumns = columnWidths.reduce( ( total, columnWidth ) => total + columnWidth ) > 100;
+				const resetAdjacentColumns =
+					columnWidths.reduce(
+						( total, columnWidth ) => total + columnWidth
+					) > 100;
 
 				// If total widths exceed 100, reset adjacent column widths.
 				columns.forEach( ( column ) => {
-					if ( ( resetAdjacentColumns || ! column.attributes.width ) && column.clientId !== clientId ) {
+					if (
+						( resetAdjacentColumns || ! column.attributes.width ) &&
+						column.clientId !== clientId
+					) {
 						updateBlockAttributes( column.clientId, { width: '' } );
 					}
 				} );

--- a/packages/block-library/src/column/edit.js
+++ b/packages/block-library/src/column/edit.js
@@ -43,6 +43,7 @@ function ColumnEdit( {
 					<RangeControl
 						label={ __( 'Percentage width' ) }
 						value={ width || '' }
+						initialPosition={ 0 }
 						onChange={ updateWidth }
 						min={ 0 }
 						max={ 100 }

--- a/packages/block-library/src/columns/block.json
+++ b/packages/block-library/src/columns/block.json
@@ -2,6 +2,9 @@
 	"name": "core/columns",
 	"category": "layout",
 	"attributes": {
+		"columnsTemplate": {
+			"type": "string"
+		},
 		"verticalAlignment": {
 			"type": "string"
 		},

--- a/packages/block-library/src/columns/edit.js
+++ b/packages/block-library/src/columns/edit.js
@@ -73,16 +73,21 @@ function ColumnsEditContainer( {
 		[ `are-vertically-aligned-${ verticalAlignment }` ]: verticalAlignment,
 	} );
 
-	const { childColumnsWidths } = useSelect( ( select ) => {
-		const { getBlockOrder, getBlockAttributes } = select( 'core/block-editor' );
-		const childColumns = getBlockOrder( clientId );
+	const { childColumnsWidths } = useSelect(
+		( select ) => {
+			const { getBlockOrder, getBlockAttributes } = select(
+				'core/block-editor'
+			);
+			const childColumns = getBlockOrder( clientId );
 
-		return {
-
-			childColumnsWidths: childColumns.map( ( block ) => getBlockAttributes( block ).width ),
-
-		};
-	}, [ clientId ] );
+			return {
+				childColumnsWidths: childColumns.map(
+					( block ) => getBlockAttributes( block ).width
+				),
+			};
+		},
+		[ clientId ]
+	);
 
 	let gridTemplateColumns = ``;
 	// Remove any negative widths.
@@ -92,12 +97,15 @@ function ColumnsEditContainer( {
 		}
 		return width;
 	} );
-	const colsWithoutWidth = cleanedWidths.filter( ( width ) => ! width ).length;
+	const colsWithoutWidth = cleanedWidths.filter( ( width ) => ! width )
+		.length;
 
 	// We're not checking if total col width is > 100 because there's no way of deciding which columns to reset at this point.
 	// This logic will work like percentage widths (taking into account the grid-gap) for all columns with total width <= 100.
 	// For columns with total width > 100, the fr units work as a fraction of whatever the total is, so the layout never breaks.
-	const leftoverWidth = Math.abs( 100 - cleanedWidths.reduce( ( total, column ) => total + column ) );
+	const leftoverWidth = Math.abs(
+		100 - cleanedWidths.reduce( ( total, column ) => total + column )
+	);
 
 	cleanedWidths.forEach( ( width ) => {
 		if ( ! width ) {
@@ -114,8 +122,13 @@ function ColumnsEditContainer( {
 
 	const wrapper = wrapperRef.current;
 	if ( wrapper ) {
-		const layoutWrapper = wrapper.querySelector( '.block-editor-block-list__layout' );
-		layoutWrapper.style.setProperty( '--columns-template', gridTemplateColumns );
+		const layoutWrapper = wrapper.querySelector(
+			'.block-editor-block-list__layout'
+		);
+		layoutWrapper.style.setProperty(
+			'--columns-template',
+			gridTemplateColumns
+		);
 	}
 
 	return (

--- a/packages/block-library/src/columns/edit.js
+++ b/packages/block-library/src/columns/edit.js
@@ -87,10 +87,10 @@ function ColumnsEditContainer( {
 	let columnsTemplateString = ``;
 
 	childColumnsAttributes.forEach( ( column ) => {
-		if ( column.width ) {
-			columnsTemplateString += `${ column.width }% `;
-		} else {
+		if ( ! column.width || column.width < 0 ) {
 			columnsTemplateString += `1fr `;
+		} else {
+			columnsTemplateString += `${ column.width }% `;
 		}
 	} );
 

--- a/packages/block-library/src/columns/editor.scss
+++ b/packages/block-library/src/columns/editor.scss
@@ -20,14 +20,13 @@
 	display: block;
 
 	> .block-editor-inner-blocks > .block-editor-block-list__layout {
-		display: flex;
-
-		// Responsiveness: Allow wrapping on mobile.
-		flex-wrap: wrap;
-
+		--columns-template: 1fr;
+		display: grid;
+		grid-gap: $grid-size-large * 2;
 		@include break-medium() {
-			flex-wrap: nowrap;
+			grid-template-columns: var(--columns-template);
 		}
+
 		// Set full heights on Columns to enable vertical alignment preview
 		> [data-type="core/column"],
 		> [data-type="core/column"] .block-core-columns {
@@ -45,64 +44,9 @@
 
 		// Adjust the individual column block.
 		> [data-type="core/column"] {
-
-			// On mobile, only a single column is shown, so match adjacent block paddings.
-			padding-left: 0;
-			padding-right: 0;
-			margin-left: -$block-padding;
-			margin-right: -$block-padding;
-
-			// Zero out margins.
-			margin-top: 0;
-			margin-bottom: 0;
-
-			// Prevent the columns from growing wider than their distributed sizes.
-			min-width: 0;
-
 			// Prevent long unbroken words from overflowing.
 			word-break: break-word; // For back-compat.
 			overflow-wrap: break-word; // New standard.
-
-			// Responsiveness: Show at most one columns on mobile.
-			flex-basis: 100%;
-
-			// Beyond mobile, allow 2 columns.
-			@include break-small() {
-				flex-basis: calc(50% - (#{$grid-size-large}));
-				flex-grow: 0;
-				margin-left: 0;
-				margin-right: 0;
-			}
-
-			// Add space between columns. Themes can customize this if they wish to work differently.
-			// This has to match the same padding applied in style.scss.
-			// Only apply this beyond the mobile breakpoint, as there's only a single column on mobile.
-			@include break-small() {
-				&:nth-child(even) {
-					margin-left: calc(#{$grid-size-large * 2});
-				}
-			}
-
-			// When columns are in a single row, add space before all except the first.
-			@include break-medium() {
-				&:not(:first-child) {
-					margin-left: calc(#{$grid-size-large * 2});
-				}
-			}
-
-			// Remove Block "padding" so individual Column is flush with parent Columns
-			&::before {
-				left: 0;
-				right: 0;
-			}
-
-			// The Columns block is a flex-container, therefore it nullifies margin collapsing.
-			// Therefore, blocks inside this will appear to create a double margin.
-			// We compensate for this using negative margins.
-			> .block-core-columns > .block-editor-inner-blocks {
-				margin-top: -$default-block-margin;
-				margin-bottom: -$default-block-margin;
-			}
 		}
 	}
 }

--- a/packages/block-library/src/columns/editor.scss
+++ b/packages/block-library/src/columns/editor.scss
@@ -20,11 +20,33 @@
 	display: block;
 
 	> .block-editor-inner-blocks > .block-editor-block-list__layout {
-		--columns-template: 1fr;
-		display: grid;
-		grid-gap: $grid-size-large * 2;
+		display: flex;
+		flex-wrap: wrap;
+		margin-bottom: $default-block-margin;
+
 		@include break-medium() {
-			grid-template-columns: var(--columns-template);
+			flex-wrap: nowrap;
+		}
+
+		@supports (display: grid) {
+			--columns-template: 1fr;
+			display: grid;
+			grid-gap: $grid-size-large * 2;
+			@include break-medium() {
+				grid-template-columns: var(--columns-template);
+			}
+		}
+
+		> [data-type="core/column"] {
+			@include break-medium() {
+				+ [data-type="core/column"] {
+					margin-left: $grid-size-large * 2;
+
+					@supports (display: grid) {
+						margin-left: 0;
+					}
+				}
+			}
 		}
 
 		// Set full heights on Columns to enable vertical alignment preview

--- a/packages/block-library/src/columns/editor.scss
+++ b/packages/block-library/src/columns/editor.scss
@@ -31,13 +31,15 @@
 		@supports (display: grid) {
 			--columns-template: 1fr;
 			display: grid;
-			grid-gap: $grid-size-large * 2;
+			column-gap: $grid-size-large * 2;
 			@include break-medium() {
 				grid-template-columns: var(--columns-template);
 			}
 		}
 
 		> [data-type="core/column"] {
+			margin: 0;
+
 			@include break-medium() {
 				+ [data-type="core/column"] {
 					margin-left: $grid-size-large * 2;
@@ -70,21 +72,6 @@
 			word-break: break-word; // For back-compat.
 			overflow-wrap: break-word; // New standard.
 		}
-	}
-}
-
-/**
- * Columns act as as a "passthrough container"
- * and therefore has its vertical margins/padding removed via negative margins
- * therefore we need to compensate for this here by doubling the spacing on the
- * vertical to ensure there is equal visual spacing around the inserter. Note there
- * is no formal API for a "passthrough" Block so this is an edge case overide
- */
-[data-type="core/columns"] {
-
-	.block-list-appender {
-		margin-top: $block-padding*2;
-		margin-bottom: $block-padding*2;
 	}
 }
 

--- a/packages/block-library/src/columns/save.js
+++ b/packages/block-library/src/columns/save.js
@@ -12,6 +12,7 @@ export default function save( { attributes } ) {
 	const {
 		verticalAlignment,
 		backgroundColor,
+		columnsTemplate,
 		customBackgroundColor,
 	} = attributes;
 
@@ -28,6 +29,7 @@ export default function save( { attributes } ) {
 
 	const style = {
 		backgroundColor: backgroundClass ? undefined : customBackgroundColor,
+		'--columns-template': columnsTemplate,
 	};
 
 	return (

--- a/packages/block-library/src/columns/style.scss
+++ b/packages/block-library/src/columns/style.scss
@@ -1,12 +1,11 @@
-.wp-block-columns {
-	--columns-template: 1fr;
 
-	display: grid;
-	grid-gap: $grid-size-large * 2;
+.wp-block-columns {
+	display: flex;
+	flex-wrap: wrap;
 	margin-bottom: $default-block-margin;
 
 	@include break-medium() {
-		grid-template-columns: var(--columns-template);
+		flex-wrap: nowrap;
 	}
 
 	&.has-background {
@@ -18,7 +17,35 @@
 	// Prevent long unbroken words from overflowing.
 	word-break: break-word; // For back-compat.
 	overflow-wrap: break-word; // New standard.
+
+	@include break-medium() {
+		+ .wp-block-column {
+			margin-left: $grid-size-large * 2;
+		}
+	}
 }
+
+@supports (display: grid) {
+	.wp-block-columns {
+		--columns-template: 1fr;
+
+		display: grid;
+		grid-gap: $grid-size-large * 2;
+
+		@include break-medium() {
+			grid-template-columns: var(--columns-template);
+		}
+	}
+
+	.wp-block-column {
+		@include break-medium() {
+			+ .wp-block-column {
+				margin-left: 0;
+			}
+		}
+	}
+}
+
 
 /**
  * All Columns Alignment

--- a/packages/block-library/src/columns/style.scss
+++ b/packages/block-library/src/columns/style.scss
@@ -30,7 +30,7 @@
 		--columns-template: 1fr;
 
 		display: grid;
-		grid-gap: $grid-size-large * 2;
+		column-gap: $grid-size-large * 2;
 
 		@include break-medium() {
 			grid-template-columns: var(--columns-template);

--- a/packages/block-library/src/columns/style.scss
+++ b/packages/block-library/src/columns/style.scss
@@ -1,12 +1,12 @@
 .wp-block-columns {
-	display: flex;
+	--columns-template: 1fr;
+
+	display: grid;
+	grid-gap: $grid-size-large * 2;
 	margin-bottom: $default-block-margin;
 
-	// Responsiveness: Allow wrapping on mobile.
-	flex-wrap: wrap;
-
 	@include break-medium() {
-		flex-wrap: nowrap;
+		grid-template-columns: var(--columns-template);
 	}
 
 	&.has-background {
@@ -15,41 +15,9 @@
 }
 
 .wp-block-column {
-	flex-grow: 1;
-
-	@media (max-width: #{ ($break-small - 1) }) {
-		// Responsiveness: Show at most one columns on mobile. This must be
-		// important since the Column assigns its own width as an inline style.
-		flex-basis: 100% !important;
-	}
-
-	// Prevent the columns from growing wider than their distributed sizes.
-	min-width: 0;
-
 	// Prevent long unbroken words from overflowing.
 	word-break: break-word; // For back-compat.
 	overflow-wrap: break-word; // New standard.
-
-	@include break-small() {
-
-		// Beyond mobile, allow 2 columns.
-		flex-basis: calc(50% - #{$grid-size-large});
-		flex-grow: 0;
-
-		// Add space between the multiple columns. Themes can customize this if they wish to work differently.
-		// Only apply this beyond the mobile breakpoint, as there's only a single column on mobile.
-		&:nth-child(even) {
-			margin-left: $grid-size-large * 2;
-		}
-	}
-
-	@include break-medium() {
-
-		// When columns are in a single row, add space before all except the first.
-		&:not(:first-child) {
-			margin-left: $grid-size-large * 2;
-		}
-	}
 }
 
 /**

--- a/packages/e2e-tests/specs/editor/plugins/__snapshots__/templates.test.js.snap
+++ b/packages/e2e-tests/specs/editor/plugins/__snapshots__/templates.test.js.snap
@@ -13,8 +13,8 @@ exports[`templates Using a CPT with a predefined template Should add a custom po
 <blockquote class=\\"wp-block-quote\\"><p></p></blockquote>
 <!-- /wp:quote -->
 
-<!-- wp:columns -->
-<div class=\\"wp-block-columns\\"><!-- wp:column -->
+<!-- wp:columns {\\"columnsTemplate\\":\\"50fr 50fr \\"} -->
+<div class=\\"wp-block-columns\\" style=\\"--columns-template:50fr 50fr \\"><!-- wp:column -->
 <div class=\\"wp-block-column\\"><!-- wp:image -->
 <figure class=\\"wp-block-image\\"><img alt=\\"\\"/></figure>
 <!-- /wp:image --></div>
@@ -39,8 +39,8 @@ exports[`templates Using a CPT with a predefined template Should respect user ed
 <blockquote class=\\"wp-block-quote\\"><p></p></blockquote>
 <!-- /wp:quote -->
 
-<!-- wp:columns -->
-<div class=\\"wp-block-columns\\"><!-- wp:column -->
+<!-- wp:columns {\\"columnsTemplate\\":\\"50fr 50fr \\"} -->
+<div class=\\"wp-block-columns\\" style=\\"--columns-template:50fr 50fr \\"><!-- wp:column -->
 <div class=\\"wp-block-column\\"><!-- wp:image -->
 <figure class=\\"wp-block-image\\"><img alt=\\"\\"/></figure>
 <!-- /wp:image --></div>

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/block-hierarchy-navigation.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/block-hierarchy-navigation.test.js.snap
@@ -11,8 +11,8 @@ exports[`Navigating the block hierarchy should appear and function even without 
 `;
 
 exports[`Navigating the block hierarchy should navigate block hierarchy using only the keyboard 1`] = `
-"<!-- wp:columns -->
-<div class=\\"wp-block-columns\\"><!-- wp:column -->
+"<!-- wp:columns {\\"columnsTemplate\\":\\"50fr 50fr \\"} -->
+<div class=\\"wp-block-columns\\" style=\\"--columns-template:50fr 50fr \\"><!-- wp:column -->
 <div class=\\"wp-block-column\\"><!-- wp:paragraph -->
 <p>First column</p>
 <!-- /wp:paragraph --></div>
@@ -31,8 +31,8 @@ exports[`Navigating the block hierarchy should navigate block hierarchy using on
 `;
 
 exports[`Navigating the block hierarchy should navigate using the block hierarchy dropdown menu 1`] = `
-"<!-- wp:columns -->
-<div class=\\"wp-block-columns\\"><!-- wp:column -->
+"<!-- wp:columns {\\"columnsTemplate\\":\\"50fr 50fr \\"} -->
+<div class=\\"wp-block-columns\\" style=\\"--columns-template:50fr 50fr \\"><!-- wp:column -->
 <div class=\\"wp-block-column\\"><!-- wp:paragraph -->
 <p>First column</p>
 <!-- /wp:paragraph --></div>

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/writing-flow.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/writing-flow.test.js.snap
@@ -5,8 +5,8 @@ exports[`Writing Flow Should navigate inner blocks with arrow keys 1`] = `
 <p>First paragraph</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:columns -->
-<div class=\\"wp-block-columns\\"><!-- wp:column -->
+<!-- wp:columns {\\"columnsTemplate\\":\\"50fr 50fr \\"} -->
+<div class=\\"wp-block-columns\\" style=\\"--columns-template:50fr 50fr \\"><!-- wp:column -->
 <div class=\\"wp-block-column\\"><!-- wp:paragraph -->
 <p>1st col</p>
 <!-- /wp:paragraph --></div>


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

This is a proposal for drastically simplifying Columns/Column blocks styling with CSS grid and variables. 

The main reason for this is getting rid of the need to set inline styles in blocks as much as possible, because inline styles break the resizable editor (#19082).

This work will incidentally also fix #18416 and #19112 / #19515.

* Column width is now set in the columns block with CSS grid, but each column still computes its own width and may reset the width of the adjacent columns if total column widths exceed 100%.

* Columns without an explicit width are set to 1fr, so remaining width is distributed equally among all columns without explicit widths.

* I have added a basic flexbox fallback for IE, because this grid implementation depends on CSS variables to work. This means that IE users won't be able to preview columns with custom widths. 

* This setup is much easier to override by themes, because it doesn't depend as much on inline styles. E.g. themes can now cleanly override the grid-gap width with a single line of code. 


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Tested across browsers. IE maintains basic functionality.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
