### PR TITLE
Navigation mode: polish enabling when no block is selected

### DIFF
--- a/packages/e2e-tests/specs/editor/various/keyboard-navigable-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/keyboard-navigable-blocks.test.js
@@ -101,4 +101,69 @@ describe( 'Order of block keyboard navigation', () => {
 		await navigateToContentEditorTop();
 		await tabThroughParagraphBlock( 'Paragraph 1' );
 	} );
+
+	it( 'allows tabbing in navigation mode if no block is selected', async () => {
+		const paragraphBlocks = [ '0', '1' ];
+
+		// Create 2 paragraphs blocks with some content.
+		for ( const paragraphBlock of paragraphBlocks ) {
+			await insertBlock( 'Paragraph' );
+			await page.keyboard.type( paragraphBlock );
+		}
+
+		// Clear the selected block and put focus in front of the block list.
+		await page.evaluate( () => {
+			document.querySelector( '.edit-post-visual-editor' ).focus();
+		} );
+
+		await page.keyboard.press( 'Tab' );
+		await expect( await page.evaluate( () => {
+			return document.activeElement.placeholder;
+		} ) ).toBe( 'Add title' );
+
+		await page.keyboard.press( 'Tab' );
+		await expect( await getActiveLabel() ).toBe( 'Paragraph' );
+
+		await page.keyboard.press( 'Tab' );
+		await expect( await getActiveLabel() ).toBe( 'Paragraph' );
+
+		await page.keyboard.press( 'Tab' );
+		await expect( await getActiveLabel() ).toBe( 'Open publish panel' );
+	} );
+
+	it( 'allows tabbing in navigation mode if no block is selected (reverse)', async () => {
+		const paragraphBlocks = [ '0', '1' ];
+
+		// Create 2 paragraphs blocks with some content.
+		for ( const paragraphBlock of paragraphBlocks ) {
+			await insertBlock( 'Paragraph' );
+			await page.keyboard.type( paragraphBlock );
+		}
+
+		// Clear the selected block and put focus behind the block list.
+		await page.evaluate( () => {
+			document.querySelector( '.edit-post-visual-editor' ).focus();
+			document.querySelector( '.edit-post-editor-regions__sidebar' ).focus();
+		} );
+
+		await pressKeyWithModifier( 'shift', 'Tab' );
+		await expect( await getActiveLabel() ).toBe( 'Open publish panel' );
+
+		await pressKeyWithModifier( 'shift', 'Tab' );
+		await expect( await getActiveLabel() ).toBe( 'Paragraph' );
+
+		await pressKeyWithModifier( 'shift', 'Tab' );
+		await expect( await getActiveLabel() ).toBe( 'Paragraph' );
+
+		await pressKeyWithModifier( 'shift', 'Tab' );
+		await expect( await getActiveLabel() ).toBe( 'Add block' );
+
+		await pressKeyWithModifier( 'shift', 'Tab' );
+		await expect( await getActiveLabel() ).toBe( 'Block: Paragraph' );
+
+		await pressKeyWithModifier( 'shift', 'Tab' );
+		await expect( await page.evaluate( () => {
+			return document.activeElement.placeholder;
+		} ) ).toBe( 'Add title' );
+	} );
 } );


### PR DESCRIPTION
## Description

Polishes #19238: don't enable navigation mode on tab, but rather use the `FocusCapture` elements to detect incoming keyboard navigation. This fixes an issue where navigation mode is enabled after tabbing outside the block list (e.g. document sidebar) and then clicking on a block.

To do: add e2e tests.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
