### PR TITLE
Fix: Only show available image sizes

### DIFF
--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -240,8 +240,14 @@ class GalleryEdit extends Component {
 	}
 
 	getImagesSizeOptions() {
-		const { imageSizes } = this.props;
-		return map( imageSizes, ( { name, slug } ) => ( { value: slug, label: name } ) );
+		const { imageSizes, resizedImages } = this.props;
+		return map(
+			filter(
+				imageSizes,
+				( { slug } ) => some( resizedImages, ( sizes ) => ( sizes[ slug ] ) )
+			),
+			( { name, slug } ) => ( { value: slug, label: name } )
+		);
 	}
 
 	updateImagesSize( sizeSlug ) {

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -5,6 +5,7 @@ import classnames from 'classnames';
 import {
 	get,
 	isEmpty,
+	filter,
 	map,
 	last,
 	omit,
@@ -318,8 +319,11 @@ export class ImageEdit extends Component {
 	}
 
 	getImageSizeOptions() {
-		const { imageSizes } = this.props;
-		return map( imageSizes, ( { name, slug } ) => ( { value: slug, label: name } ) );
+		const { imageSizes, image } = this.props;
+		return map(
+			filter( imageSizes, ( { slug } ) => ( get( image, [ 'media_details', 'sizes', slug, 'source_url' ] ) ) ),
+			( { name, slug } ) => ( { value: slug, label: name } )
+		);
 	}
 
 	render() {


### PR DESCRIPTION
## Description
Currently, we are always showing the image size picker with all available sizes on the gallery and image block even if a size (or no size at all) is available. This means that on images inserted by URL, where it is not possible to choose a size we were still showing a size picker even though it does nothing.

This PR updates the computation of the available sizes to take into account what sizes are in fact available for the image, or available for some image on the image block.


## How has this been tested?
I inserted an image by URL.
I verified the option to choose an image size was not available.
I inserted an image using the media library. I verified the option to choose an image size was available.
I transformed the image inserted by URL into a gallery.
I verified the option to choose an image size was not available in the gallery.
I converted the gallery block back to an image. I multi-selected both image blocks (the one inserted by URL and the one inserted from the media library) and transformed the blocks into a gallery.
I verified the option to choose an image size was available in the gallery.