### PR TITLE
Fix: Not possible to manage page break on the block manager

### DIFF
--- a/packages/edit-post/src/components/manage-blocks-modal/manager.js
+++ b/packages/edit-post/src/components/manage-blocks-modal/manager.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { filter, isArray } from 'lodash';
+import { filter, includes, isArray } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -31,7 +31,7 @@ function BlockManager( {
 	blockTypes = blockTypes.filter( ( blockType ) => (
 		hasBlockSupport( blockType, 'inserter', true ) &&
 		( ! search || isMatchingSearchTerm( blockType, search ) ) &&
-		! blockType.parent
+		( ! blockType.parent || includes( blockType.parent, 'core/post-content' ) )
 	) );
 
 	return (


### PR DESCRIPTION
## Description
Currently, if we go to the block manager, we can not disable the page break block. That happens because the page break block is a child block of core/post-content. The block manager does not allow managing child blocks. This PR opens an exception and makes sure we can manage blocks that are a child of core/post-content.

## How has this been tested?
I verified I could enable and disable the page break block.