### PR TITLE
Navigation mode: fix tabbing to title

### DIFF
--- a/packages/block-editor/src/components/writing-flow/index.js
+++ b/packages/block-editor/src/components/writing-flow/index.js
@@ -304,19 +304,28 @@ class WritingFlow extends Component {
 			const navigateDown = ( isTab && ! isShift ) || isDown;
 			const focusedBlockUid = navigateUp ? selectionBeforeEndClientId : selectionAfterEndClientId;
 
-			if (
-				( navigateDown || navigateUp ) &&
-				focusedBlockUid
-			) {
-				event.preventDefault();
-				this.props.onSelectBlock( focusedBlockUid );
+			if ( navigateDown || navigateUp ) {
+				if ( focusedBlockUid ) {
+					event.preventDefault();
+					this.props.onSelectBlock( focusedBlockUid );
+				} else if ( isTab && selectedBlockClientId ) {
+					const wrapper = getBlockFocusableWrapper( selectedBlockClientId );
+					let nextTabbable;
+
+					if ( navigateDown ) {
+						nextTabbable = focus.tabbable.findNext( wrapper );
+					} else {
+						nextTabbable = focus.tabbable.findPrevious( wrapper );
+					}
+
+					if ( nextTabbable ) {
+						event.preventDefault();
+						nextTabbable.focus();
+						this.props.clearSelectedBlock();
+					}
+				}
 			}
 
-			// Special case when reaching the end of the blocks (navigate to the next tabbable outside of the writing flow)
-			if ( navigateDown && selectedBlockClientId && ! selectionAfterEndClientId && [ UP, DOWN ].indexOf( keyCode ) === -1 ) {
-				this.props.clearSelectedBlock();
-				this.appender.current.focus();
-			}
 			return;
 		}
 

--- a/packages/block-editor/src/components/writing-flow/index.js
+++ b/packages/block-editor/src/components/writing-flow/index.js
@@ -139,13 +139,6 @@ class WritingFlow extends Component {
 		this.verticalRect = null;
 
 		this.container = createRef();
-
-		/**
-		 * Reference of the writing flow appender element.
-		 * The reference is used to focus the first tabbable element after the block list
-		 * once we hit `tab` on the last block in navigation mode.
-		 */
-		this.appender = createRef();
 	}
 
 	onMouseDown() {
@@ -495,7 +488,6 @@ class WritingFlow extends Component {
 					isReverse
 				/>
 				<div
-					ref={ this.appender }
 					aria-hidden
 					tabIndex={ -1 }
 					onClick={ this.focusLastTextField }

--- a/packages/e2e-tests/specs/editor/various/keyboard-navigable-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/keyboard-navigable-blocks.test.js
@@ -156,12 +156,6 @@ describe( 'Order of block keyboard navigation', () => {
 		await expect( await getActiveLabel() ).toBe( 'Paragraph' );
 
 		await pressKeyWithModifier( 'shift', 'Tab' );
-		await expect( await getActiveLabel() ).toBe( 'Add block' );
-
-		await pressKeyWithModifier( 'shift', 'Tab' );
-		await expect( await getActiveLabel() ).toBe( 'Block: Paragraph' );
-
-		await pressKeyWithModifier( 'shift', 'Tab' );
 		await expect( await page.evaluate( () => {
 			return document.activeElement.placeholder;
 		} ) ).toBe( 'Add title' );


### PR DESCRIPTION
## Description

Currently in navigation mode, reverse tabbing from the first block does not work correctly. It's supposed to focus the title, but right now it focusses the block appender, then the block wrapper, and then the title. Instead, we focus look at the tabbable element before the block (title element).

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

In navigation mode, pressing `Shift+Tab` from the first block should focus the title.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
