### PR TITLE
Jest Preset Default: Update preset file extension for inclusion in NPM deployments.

### DIFF
--- a/packages/jest-preset-default/package.json
+++ b/packages/jest-preset-default/package.json
@@ -27,7 +27,7 @@
 	"files": [
 		"scripts",
 		"index.js",
-		"jest-preset.json"
+		"jest-preset.js"
 	],
 	"main": "index.js",
 	"dependencies": {


### PR DESCRIPTION
We switched to using a `.js` file preset without updating the relevant deploy whitelist entry in `package.json`.