### PR TITLE
Popover: don't render fallback anchor if anchorRef is defined

### DIFF
--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -494,7 +494,7 @@ const Popover = ( {
 					content = <Fill name={ __unstableSlotName }>{ content }</Fill>;
 				}
 
-				if ( anchorRef ) {
+				if ( anchorRef || anchorRect ) {
 					return content;
 				}
 

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -457,6 +457,7 @@ const Popover = ( {
 						onKeyDown={ maybeClose }
 						ref={ containerRef }
 					>
+						{ isExpanded && <ScrollLock /> }
 						{ isExpanded && (
 							<div className="components-popover__header">
 								<span className="components-popover__header-title">
@@ -493,10 +494,13 @@ const Popover = ( {
 					content = <Fill name={ __unstableSlotName }>{ content }</Fill>;
 				}
 
+				if ( anchorRef ) {
+					return content;
+				}
+
 				return (
 					<span ref={ anchorRefFallback }>
 						{ content }
-						{ isMobileViewport && expandOnMobile && <ScrollLock /> }
 					</span>
 				);
 			} }


### PR DESCRIPTION
## Description

Currently a `span` element is always rendered for a `Popover` to use as a fallback if there is no `anchorRef` or `anchorRect`. It's not needed to render this element if either of these is defined.

## How has this been tested?

Popover should render as before. I also tested that the scroll lock still works for the inserter on small screens.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
