### PR TITLE
Writing flow: simplify & fix tabbing out of block

### DIFF
--- a/packages/block-editor/src/components/writing-flow/index.js
+++ b/packages/block-editor/src/components/writing-flow/index.js
@@ -6,7 +6,7 @@ import { overEvery, find, findLast, reverse, first, last } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { Component, createRef } from '@wordpress/element';
+import { Component, createRef, forwardRef } from '@wordpress/element';
 import {
 	computeCaretRect,
 	focus,
@@ -77,13 +77,22 @@ export function isNavigationCandidate( element, keyCode, hasModifier ) {
  * Renders focus capturing areas to redirect focus to the selected block if not
  * in Navigation mode.
  */
-function FocusCapture( { selectedClientId, isReverse, containerRef } ) {
+const FocusCapture = forwardRef( ( {
+	selectedClientId,
+	isReverse,
+	containerRef,
+}, ref ) => {
 	const isNavigationMode = useSelect( ( select ) =>
 		select( 'core/block-editor' ).isNavigationMode()
 	);
 	const { setNavigationMode } = useDispatch( 'core/block-editor' );
 
 	function onFocus() {
+		if ( ref.noCapture ) {
+			delete ref.noCapture;
+			return;
+		}
+
 		if ( ! selectedClientId ) {
 			setNavigationMode( true );
 
@@ -112,6 +121,7 @@ function FocusCapture( { selectedClientId, isReverse, containerRef } ) {
 
 	return (
 		<div
+			ref={ ref }
 			tabIndex={ ! isNavigationMode ? '0' : undefined }
 			onFocus={ onFocus }
 			// Needs to be positioned within the viewport, so focus to this
@@ -119,7 +129,7 @@ function FocusCapture( { selectedClientId, isReverse, containerRef } ) {
 			style={ { position: 'fixed' } }
 		/>
 	);
-}
+} );
 
 class WritingFlow extends Component {
 	constructor() {
@@ -139,6 +149,8 @@ class WritingFlow extends Component {
 		this.verticalRect = null;
 
 		this.container = createRef();
+		this.focusCaptureBeforeRef = createRef();
+		this.focusCaptureAfterRef = createRef();
 	}
 
 	onMouseDown() {
@@ -335,20 +347,16 @@ class WritingFlow extends Component {
 
 			if ( isShift ) {
 				if ( target === wrapper ) {
-					const focusableParent = this.container.current.closest( '[tabindex]' );
-					const beforeEditorElement = focus.tabbable.findPrevious( focusableParent );
-					beforeEditorElement.focus();
-					event.preventDefault();
+					this.focusCaptureBeforeRef.noCapture = true;
+					this.focusCaptureBeforeRef.current.focus();
 					return;
 				}
 			} else {
 				const tabbables = focus.tabbable.find( wrapper );
 
 				if ( target === last( tabbables ) ) {
-					const focusableParent = this.container.current.closest( '[tabindex]' );
-					const afterEditorElement = focus.tabbable.findNext( focusableParent );
-					afterEditorElement.focus();
-					event.preventDefault();
+					this.focusCaptureAfterRef.noCapture = true;
+					this.focusCaptureAfterRef.current.focus();
 					return;
 				}
 			}
@@ -472,6 +480,7 @@ class WritingFlow extends Component {
 		return (
 			<div className="block-editor-writing-flow">
 				<FocusCapture
+					ref={ this.focusCaptureBeforeRef }
 					selectedClientId={ selectedClientId }
 					containerRef={ this.container }
 				/>
@@ -483,6 +492,7 @@ class WritingFlow extends Component {
 					{ children }
 				</div>
 				<FocusCapture
+					ref={ this.focusCaptureAfterRef }
 					selectedClientId={ selectedClientId }
 					containerRef={ this.container }
 					isReverse

--- a/packages/block-editor/src/components/writing-flow/index.js
+++ b/packages/block-editor/src/components/writing-flow/index.js
@@ -81,6 +81,7 @@ const FocusCapture = forwardRef( ( {
 	selectedClientId,
 	isReverse,
 	containerRef,
+	noCapture,
 }, ref ) => {
 	const isNavigationMode = useSelect( ( select ) =>
 		select( 'core/block-editor' ).isNavigationMode()
@@ -88,8 +89,8 @@ const FocusCapture = forwardRef( ( {
 	const { setNavigationMode } = useDispatch( 'core/block-editor' );
 
 	function onFocus() {
-		if ( ref.noCapture ) {
-			delete ref.noCapture;
+		if ( noCapture.current ) {
+			delete noCapture.current;
 			return;
 		}
 
@@ -151,6 +152,7 @@ class WritingFlow extends Component {
 		this.container = createRef();
 		this.focusCaptureBeforeRef = createRef();
 		this.focusCaptureAfterRef = createRef();
+		this.noCapture = {};
 	}
 
 	onMouseDown() {
@@ -347,7 +349,7 @@ class WritingFlow extends Component {
 
 			if ( isShift ) {
 				if ( target === wrapper ) {
-					this.focusCaptureBeforeRef.noCapture = true;
+					this.noCapture.current = true;
 					this.focusCaptureBeforeRef.current.focus();
 					return;
 				}
@@ -355,7 +357,7 @@ class WritingFlow extends Component {
 				const tabbables = focus.tabbable.find( wrapper );
 
 				if ( target === last( tabbables ) ) {
-					this.focusCaptureAfterRef.noCapture = true;
+					this.noCapture.current = true;
 					this.focusCaptureAfterRef.current.focus();
 					return;
 				}
@@ -483,6 +485,7 @@ class WritingFlow extends Component {
 					ref={ this.focusCaptureBeforeRef }
 					selectedClientId={ selectedClientId }
 					containerRef={ this.container }
+					noCapture={ this.noCapture }
 				/>
 				<div
 					ref={ this.container }
@@ -495,6 +498,7 @@ class WritingFlow extends Component {
 					ref={ this.focusCaptureAfterRef }
 					selectedClientId={ selectedClientId }
 					containerRef={ this.container }
+					noCapture={ this.noCapture }
 					isReverse
 				/>
 				<div


### PR DESCRIPTION
## Description

In #19235, I added logic for tabbing to move focus before or after the block list if focus leaves the block. This adjusts part of it to avoid searching tabbables and based on elements outside `WritingFlow`.

It also fixes Storybook. The block editor currently errors if you tab out of it.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
