### PR TITLE
Block Directory: Update the regular expression that determines whether the plugin is using an img URL or an icon slug.

### DIFF
--- a/packages/block-directory/src/components/downloadable-block-header/index.js
+++ b/packages/block-directory/src/components/downloadable-block-header/index.js
@@ -14,7 +14,7 @@ function DownloadableBlockHeader( { icon, title, rating, ratingCount, onClick } 
 	return (
 		<div className="block-directory-downloadable-block-header__row">
 			{
-				icon.match( /\.(jpeg|jpg|gif|png)$/ ) !== null ?
+				icon.match( /\.(jpeg|jpg|gif|png)(?:\?.*)?$/ ) !== null ?
 					// translators: %s: Name of the plugin e.g: "Akismet".
 					<img src={ icon } alt={ sprintf( __( '%s block icon' ), title ) } /> :
 					<span >

--- a/packages/block-directory/src/components/downloadable-block-header/test/fixtures/index.js
+++ b/packages/block-directory/src/components/downloadable-block-header/test/fixtures/index.js
@@ -1,0 +1,20 @@
+const pluginBase = {
+	name: 'boxer/boxer',
+	title: 'Boxer',
+	description: 'Boxer is a Block that puts your WordPress posts into boxes on a page.',
+	id: 'boxer-block',
+	rating: 5,
+	rating_count: 1,
+	active_installs: 0,
+	author_block_rating: 5,
+	author_block_count: '1',
+	author: 'CK Lee',
+	assets: [
+		'http://plugins.svn.wordpress.org/boxer-block/trunk/build/index.js',
+		'http://plugins.svn.wordpress.org/boxer-block/trunk/build/view.js',
+	],
+	humanized_updated: '3 months ago',
+};
+
+export const pluginWithIcon = { ...pluginBase, icon: 'block-default' };
+export const pluginWithImg = { ...pluginBase, icon: 'https://ps.w.org/listicles/assets/icon-128x128.png' };

--- a/packages/block-directory/src/components/downloadable-block-header/test/index.js
+++ b/packages/block-directory/src/components/downloadable-block-header/test/index.js
@@ -11,7 +11,6 @@ import { BlockIcon } from '@wordpress/block-editor';
 /**
  * Internal dependencies
  */
-
 import DownloadableBlockHeader from '../index';
 import { pluginWithImg, pluginWithIcon } from './fixtures';
 

--- a/packages/block-directory/src/components/downloadable-block-header/test/index.js
+++ b/packages/block-directory/src/components/downloadable-block-header/test/index.js
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+
+/**
+ * WordPress dependencies
+ */
+import { BlockIcon } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+
+import DownloadableBlockHeader from '../index';
+import { pluginWithImg, pluginWithIcon } from './fixtures';
+
+const getContainer = ( { icon, title, rating, ratingCount } ) => {
+	return shallow(
+		<DownloadableBlockHeader
+			icon={ icon }
+			onClick={ () => {} }
+			title={ title }
+			rating={ rating }
+			ratingCount={ ratingCount }
+		/>
+	);
+};
+
+describe( 'DownloadableBlockHeader', () => {
+	describe( 'icon rendering', () => {
+		test( 'should render an <img> tag', () => {
+			const wrapper = getContainer( pluginWithImg );
+			expect( wrapper.find( 'img' ).prop( 'src' ) ).toEqual( pluginWithImg.icon );
+		} );
+
+		test( 'should render an <img> tag if icon URL has query string', () => {
+			const iconURLwithQueryString = pluginWithImg.icon + '?rev=2011672&test=234234';
+			const plugin = { ...pluginWithImg, icon: iconURLwithQueryString };
+			const wrapper = getContainer( plugin );
+			expect( wrapper.find( 'img' ).prop( 'src' ) ).toEqual( plugin.icon );
+		} );
+
+		test( 'should render a <BlockIcon/> component', () => {
+			const wrapper = getContainer( pluginWithIcon );
+			expect( wrapper.find( BlockIcon ) ).toHaveLength( 1 );
+		} );
+	} );
+} );


### PR DESCRIPTION
## Description
The block directory API returns either an icon slug or a URL for the plugin's icon. This PR changes the regular expression to allow for an optional query string after the image URL. A detailed explanation of the issue can be found here:  #19264 .

Fixes: #19264 

## How has this been tested?
Unit tests have been added to test this change.

Currently testing 3 cases:
- `icon: https://ps.w.org/listicles/assets/icon-128x128.png` ✅
- `icon: https://ps.w.org/listicles/assets/icon-128x128.png?rev=2011672&test=234234` ✅
- `icon: block-default` ✅

## Types of changes
This is a bug fix. The current regular expression does not account for a query string being added by the CDN serving the plugins and its assets. Read more here: #19264

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
