### PR TITLE
RichText: split out boundary style calculation

### DIFF
--- a/packages/rich-text/src/component/boundary-style.js
+++ b/packages/rich-text/src/component/boundary-style.js
@@ -7,10 +7,15 @@ import { useEffect } from '@wordpress/element';
  * Global stylesheet shared by all RichText instances.
  */
 const globalStyle = document.createElement( 'style' );
+
 const boundarySelector = '*[data-rich-text-format-boundary]';
 
 document.head.appendChild( globalStyle );
 
+/**
+ * Calculates and renders the format boundary style when the active formats
+ * change.
+ */
 export function BoundaryStyle( { activeFormats, forwardedRef } ) {
 	useEffect( () => {
 		// There's no need to recalculate the boundary styles if no formats are

--- a/packages/rich-text/src/component/boundary-style.js
+++ b/packages/rich-text/src/component/boundary-style.js
@@ -1,0 +1,41 @@
+/**
+ * WordPress dependencies
+ */
+import { useEffect } from '@wordpress/element';
+
+/**
+ * Global stylesheet shared by all RichText instances.
+ */
+const globalStyle = document.createElement( 'style' );
+const boundarySelector = '*[data-rich-text-format-boundary]';
+
+document.head.appendChild( globalStyle );
+
+export function BoundaryStyle( { activeFormats, forwardedRef } ) {
+	useEffect( () => {
+		// There's no need to recalculate the boundary styles if no formats are
+		// active, because no boundary styles will be visible.
+		if ( ! activeFormats || ! activeFormats.length ) {
+			return;
+		}
+
+		const element = forwardedRef.current.querySelector( boundarySelector );
+
+		if ( ! element ) {
+			return;
+		}
+
+		const computedStyle = window.getComputedStyle( element );
+		const newColor = computedStyle.color
+			.replace( ')', ', 0.2)' )
+			.replace( 'rgb', 'rgba' );
+		const selector = `.rich-text:focus ${ boundarySelector }`;
+		const rule = `background-color: ${ newColor }`;
+		const style = `${ selector } {${ rule }}`;
+
+		if ( globalStyle.innerHTML !== style ) {
+			globalStyle.innerHTML = style;
+		}
+	}, [ activeFormats ] );
+	return null;
+}

--- a/packages/rich-text/src/create.js
+++ b/packages/rich-text/src/create.js
@@ -421,11 +421,28 @@ function createFromElement( {
 				} );
 			}
 		} else {
+			// Indices should share a reference to the same formats array.
+			// Only create a new reference if `formats` changes.
+			function mergeFormats( formats ) {
+				if ( mergeFormats.formats === formats ) {
+					return mergeFormats.newFormats;
+				}
+
+				const newFormats = formats ? [ format, ...formats ] : [ format ];
+
+				mergeFormats.formats = formats;
+				mergeFormats.newFormats = newFormats;
+
+				return newFormats;
+			}
+
+			// Since the formats parameter can be `undefined`, preset
+			// `mergeFormats` with a new reference.
+			mergeFormats.newFormats = [ format ];
+
 			mergePair( accumulator, {
 				...value,
-				formats: Array.from( value.formats, ( formats ) =>
-					formats ? [ format, ...formats ] : [ format ]
-				),
+				formats: Array.from( value.formats, mergeFormats ),
 			} );
 		}
 	}

--- a/packages/rich-text/src/get-active-formats.js
+++ b/packages/rich-text/src/get-active-formats.js
@@ -1,13 +1,20 @@
 /**
  * Gets the all format objects at the start of the selection.
  *
- * @param {Object} value Value to inspect.
+ * @param {Object} value                Value to inspect.
+ * @param {Array}  EMPTY_ACTIVE_FORMATS Array to return if there are no active
+ *                                      formats.
  *
  * @return {?Object} Active format objects.
  */
-export function getActiveFormats( { formats, start, end, activeFormats } ) {
+export function getActiveFormats( {
+	formats,
+	start,
+	end,
+	activeFormats,
+}, EMPTY_ACTIVE_FORMATS = [] ) {
 	if ( start === undefined ) {
-		return [];
+		return EMPTY_ACTIVE_FORMATS;
 	}
 
 	if ( start === end ) {
@@ -16,8 +23,8 @@ export function getActiveFormats( { formats, start, end, activeFormats } ) {
 			return activeFormats;
 		}
 
-		const formatsBefore = formats[ start - 1 ] || [];
-		const formatsAfter = formats[ start ] || [];
+		const formatsBefore = formats[ start - 1 ] || EMPTY_ACTIVE_FORMATS;
+		const formatsAfter = formats[ start ] || EMPTY_ACTIVE_FORMATS;
 
 		// By default, select the lowest amount of formats possible (which means
 		// the caret is positioned outside the format boundary). The user can
@@ -29,5 +36,5 @@ export function getActiveFormats( { formats, start, end, activeFormats } ) {
 		return formatsAfter;
 	}
 
-	return formats[ start ] || [];
+	return formats[ start ] || EMPTY_ACTIVE_FORMATS;
 }

--- a/packages/rich-text/src/test/create.js
+++ b/packages/rich-text/src/test/create.js
@@ -85,18 +85,33 @@ describe( 'create', () => {
 			text: 'test',
 		} );
 
+		// Format objects.
 		expect( value.formats[ 0 ][ 0 ] ).toBe( value.formats[ 1 ][ 0 ] );
 		expect( value.formats[ 0 ][ 0 ] ).toBe( value.formats[ 2 ][ 0 ] );
 		expect( value.formats[ 2 ][ 1 ] ).toBe( value.formats[ 3 ][ 1 ] );
+
+		// Format arrays per index.
+		expect( value.formats[ 0 ] ).toBe( value.formats[ 1 ] );
+		expect( value.formats[ 2 ] ).toBe( value.formats[ 3 ] );
 	} );
 
 	it( 'should use same reference for equal format', () => {
 		const value = create( { html: '<a href="#">a</a><a href="#">a</a>' } );
+
+		// Format objects.
 		expect( value.formats[ 0 ][ 0 ] ).toBe( value.formats[ 1 ][ 0 ] );
+
+		// Format arrays per index.
+		expect( value.formats[ 0 ] ).not.toBe( value.formats[ 1 ] );
 	} );
 
 	it( 'should use different reference for different format', () => {
 		const value = create( { html: '<a href="#">a</a><a href="#a">a</a>' } );
+
+		// Format objects.
 		expect( value.formats[ 0 ][ 0 ] ).not.toBe( value.formats[ 1 ][ 0 ] );
+
+		// Format arrays per index.
+		expect( value.formats[ 0 ] ).not.toBe( value.formats[ 1 ] );
 	} );
 } );


### PR DESCRIPTION
## Description

This is part of an ongoing effort to split RichText into smaller chunks to make it more readable and accessible.

This PR creates a `BoundaryStyle` component which reacts to the `activeFormats` by recalculating the right colour. Since it now depends the `activeFormats` reference, I made some changes to ensure the same reference is used across different indices.

## How has this been tested?

Add some (nested) rich text formatting, ideally with different colours (like the link format). Use different ways to make it active: arrow keys, click, focus across instances...

## Screenshots <!-- if applicable -->

## Types of changes

Refactor

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
