### PR TITLE
Block Popover: editor canvas as boundary

### DIFF
--- a/packages/block-editor/src/components/block-list/block-popover.js
+++ b/packages/block-editor/src/components/block-list/block-popover.js
@@ -129,6 +129,9 @@ function BlockPopover( {
 			__unstableAllowVerticalSubpixelPosition={ moverDirection !== 'horizontal' && node }
 			__unstableAllowHorizontalSubpixelPosition={ moverDirection === 'horizontal' && node }
 			onBlur={ () => setIsToolbarForced( false ) }
+			// Popover calculates the width once. Trigger a reset by remounting
+			// the component.
+			key={ shouldShowContextualToolbar }
 		>
 			{ ( shouldShowContextualToolbar || isToolbarForced ) && (
 				<div

--- a/packages/block-editor/src/components/block-list/block-popover.js
+++ b/packages/block-editor/src/components/block-list/block-popover.js
@@ -124,6 +124,7 @@ function BlockPopover( {
 			className="block-editor-block-list__block-popover"
 			__unstableSticky={ showEmptyBlockSideInserter ? false : popoverIsSticky }
 			__unstableSlotName="block-toolbar"
+			__unstableBoundaryParent
 			// Allow subpixel positioning for the block movement animation.
 			__unstableAllowVerticalSubpixelPosition={ moverDirection !== 'horizontal' && node }
 			__unstableAllowHorizontalSubpixelPosition={ moverDirection === 'horizontal' && node }

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -228,6 +228,7 @@ const Popover = ( {
 	__unstableSlotName = SLOT_NAME,
 	__unstableAllowVerticalSubpixelPosition,
 	__unstableAllowHorizontalSubpixelPosition,
+	__unstableBoundaryParent,
 	/* eslint-enable no-unused-vars */
 	...contentProps
 } ) => {
@@ -280,7 +281,15 @@ const Popover = ( {
 				yAxis,
 				contentHeight,
 				contentWidth,
-			} = computePopoverPosition( anchor, contentRect.current, position, __unstableSticky, anchorRef );
+			} = computePopoverPosition(
+				anchor,
+				contentRect.current,
+				position,
+				__unstableSticky,
+				anchorRef,
+				// To do: get slot parent instead.
+				__unstableBoundaryParent ? document.querySelector( '.edit-post-editor-regions__content' ) : undefined
+			);
 
 			if ( typeof popoverTop === 'number' && typeof popoverLeft === 'number' ) {
 				if ( subpixels && __unstableAllowVerticalSubpixelPosition ) {
@@ -374,6 +383,7 @@ const Popover = ( {
 		__unstableSticky,
 		__unstableAllowVerticalSubpixelPosition,
 		__unstableAllowHorizontalSubpixelPosition,
+		__unstableBoundaryParent,
 	] );
 
 	useFocusContentOnMount( focusOnMount, contentRef );

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -274,6 +274,12 @@ const Popover = ( {
 				contentRect.current = contentRef.current.getBoundingClientRect();
 			}
 
+			let boundaryElement;
+
+			if ( __unstableBoundaryParent ) {
+				boundaryElement = containerRef.current.closest( '.popover-slot' ).parentNode;
+			}
+
 			const {
 				popoverTop,
 				popoverLeft,
@@ -287,8 +293,7 @@ const Popover = ( {
 				position,
 				__unstableSticky,
 				anchorRef,
-				// To do: get slot parent instead.
-				__unstableBoundaryParent ? document.querySelector( '.edit-post-editor-regions__content' ) : undefined
+				boundaryElement
 			);
 
 			if ( typeof popoverTop === 'number' && typeof popoverLeft === 'number' ) {
@@ -521,6 +526,6 @@ const Popover = ( {
 const PopoverContainer = Popover;
 
 PopoverContainer.Slot = ( { name = SLOT_NAME } ) =>
-	<Slot bubblesVirtually name={ name } />;
+	<Slot bubblesVirtually name={ name } className="popover-slot" />;
 
 export default PopoverContainer;

--- a/packages/components/src/popover/utils.js
+++ b/packages/components/src/popover/utils.js
@@ -19,10 +19,11 @@ const HEIGHT_OFFSET = 10; // used by the arrow and a bit of empty space
  *                              scroll container edge when part of the anchor
  *                              leaves view.
  * @param {string}  chosenYAxis yAxis to be used.
+ * @param {Element} boundaryElement
  *
  * @return {Object} Popover xAxis position and constraints.
  */
-export function computePopoverXAxisPosition( anchorRect, contentSize, xAxis, corner, sticky, chosenYAxis ) {
+export function computePopoverXAxisPosition( anchorRect, contentSize, xAxis, corner, sticky, chosenYAxis, boundaryElement = document.body ) {
 	const { width } = contentSize;
 	const isRTL = document.documentElement.dir === 'rtl';
 
@@ -45,7 +46,7 @@ export function computePopoverXAxisPosition( anchorRect, contentSize, xAxis, cor
 		popoverLeft: anchorMidPoint,
 		contentWidth: (
 			( anchorMidPoint - ( width / 2 ) > 0 ? ( width / 2 ) : anchorMidPoint ) +
-			( anchorMidPoint + ( width / 2 ) > window.innerWidth ? window.innerWidth - anchorMidPoint : ( width / 2 ) )
+			( anchorMidPoint + ( width / 2 ) > boundaryElement.clientWidth ? boundaryElement.clientWidth - anchorMidPoint : ( width / 2 ) )
 		),
 	};
 
@@ -71,7 +72,7 @@ export function computePopoverXAxisPosition( anchorRect, contentSize, xAxis, cor
 	};
 	const rightAlignment = {
 		popoverLeft: rightAlignmentX,
-		contentWidth: rightAlignmentX + width > window.innerWidth ? window.innerWidth - rightAlignmentX : width,
+		contentWidth: rightAlignmentX + width > boundaryElement.clientWidth ? boundaryElement.clientWidth - rightAlignmentX : width,
 	};
 
 	// Choosing the x axis
@@ -101,9 +102,11 @@ export function computePopoverXAxisPosition( anchorRect, contentSize, xAxis, cor
 		popoverLeft = rightAlignment.popoverLeft;
 	}
 
+	const boundaryRect = boundaryElement.getBoundingClientRect();
+
 	return {
 		xAxis: chosenXAxis,
-		popoverLeft,
+		popoverLeft: Math.min( popoverLeft, boundaryRect.right - width ),
 		contentWidth,
 	};
 }
@@ -119,10 +122,11 @@ export function computePopoverXAxisPosition( anchorRect, contentSize, xAxis, cor
  *                              scroll container edge when part of the anchor
  *                              leaves view.
  * @param {Element} anchorRef   The anchor element.
+ * @param {Element} boundaryElement
  *
  * @return {Object} Popover xAxis position and constraints.
  */
-export function computePopoverYAxisPosition( anchorRect, contentSize, yAxis, corner, sticky, anchorRef ) {
+export function computePopoverYAxisPosition( anchorRect, contentSize, yAxis, corner, sticky, anchorRef, boundaryElement = document.body ) {
 	const { height } = contentSize;
 
 	if ( sticky ) {
@@ -164,7 +168,7 @@ export function computePopoverYAxisPosition( anchorRect, contentSize, yAxis, cor
 		popoverTop: anchorMidPoint,
 		contentHeight: (
 			( anchorMidPoint - ( height / 2 ) > 0 ? ( height / 2 ) : anchorMidPoint ) +
-			( anchorMidPoint + ( height / 2 ) > window.innerHeight ? window.innerHeight - anchorMidPoint : ( height / 2 ) )
+			( anchorMidPoint + ( height / 2 ) > boundaryElement.clientHeight ? boundaryElement.clientHeight - anchorMidPoint : ( height / 2 ) )
 		),
 	};
 
@@ -174,7 +178,7 @@ export function computePopoverYAxisPosition( anchorRect, contentSize, yAxis, cor
 	};
 	const bottomAlignment = {
 		popoverTop: anchorRect.bottom,
-		contentHeight: anchorRect.bottom + HEIGHT_OFFSET + height > window.innerHeight ? window.innerHeight - HEIGHT_OFFSET - anchorRect.bottom : height,
+		contentHeight: anchorRect.bottom + HEIGHT_OFFSET + height > boundaryElement.clientHeight ? boundaryElement.clientHeight - HEIGHT_OFFSET - anchorRect.bottom : height,
 	};
 
 	// Choosing the y axis
@@ -222,14 +226,22 @@ export function computePopoverYAxisPosition( anchorRect, contentSize, yAxis, cor
  *                              scroll container edge when part of the anchor
  *                              leaves view.
  * @param {Element} anchorRef   The anchor element.
+ * @param {Element} boundaryElement
  *
  * @return {Object} Popover position and constraints.
  */
-export function computePopoverPosition( anchorRect, contentSize, position = 'top', sticky, anchorRef ) {
+export function computePopoverPosition(
+	anchorRect,
+	contentSize,
+	position = 'top',
+	sticky,
+	anchorRef,
+	boundaryElement
+) {
 	const [ yAxis, xAxis = 'center', corner ] = position.split( ' ' );
 
-	const yAxisPosition = computePopoverYAxisPosition( anchorRect, contentSize, yAxis, corner, sticky, anchorRef );
-	const xAxisPosition = computePopoverXAxisPosition( anchorRect, contentSize, xAxis, corner, sticky, yAxisPosition.yAxis );
+	const yAxisPosition = computePopoverYAxisPosition( anchorRect, contentSize, yAxis, corner, sticky, anchorRef, boundaryElement );
+	const xAxisPosition = computePopoverXAxisPosition( anchorRect, contentSize, xAxis, corner, sticky, yAxisPosition.yAxis, boundaryElement );
 
 	return {
 		...xAxisPosition,

--- a/packages/components/src/popover/utils.js
+++ b/packages/components/src/popover/utils.js
@@ -23,7 +23,7 @@ const HEIGHT_OFFSET = 10; // used by the arrow and a bit of empty space
  *
  * @return {Object} Popover xAxis position and constraints.
  */
-export function computePopoverXAxisPosition( anchorRect, contentSize, xAxis, corner, sticky, chosenYAxis, boundaryElement = document.body ) {
+export function computePopoverXAxisPosition( anchorRect, contentSize, xAxis, corner, sticky, chosenYAxis, boundaryElement ) {
 	const { width } = contentSize;
 	const isRTL = document.documentElement.dir === 'rtl';
 
@@ -46,7 +46,7 @@ export function computePopoverXAxisPosition( anchorRect, contentSize, xAxis, cor
 		popoverLeft: anchorMidPoint,
 		contentWidth: (
 			( anchorMidPoint - ( width / 2 ) > 0 ? ( width / 2 ) : anchorMidPoint ) +
-			( anchorMidPoint + ( width / 2 ) > boundaryElement.clientWidth ? boundaryElement.clientWidth - anchorMidPoint : ( width / 2 ) )
+			( anchorMidPoint + ( width / 2 ) > window.innerWidth ? window.innerWidth - anchorMidPoint : ( width / 2 ) )
 		),
 	};
 
@@ -72,7 +72,7 @@ export function computePopoverXAxisPosition( anchorRect, contentSize, xAxis, cor
 	};
 	const rightAlignment = {
 		popoverLeft: rightAlignmentX,
-		contentWidth: rightAlignmentX + width > boundaryElement.clientWidth ? boundaryElement.clientWidth - rightAlignmentX : width,
+		contentWidth: rightAlignmentX + width > window.innerWidth ? window.innerWidth - rightAlignmentX : width,
 	};
 
 	// Choosing the x axis
@@ -102,11 +102,14 @@ export function computePopoverXAxisPosition( anchorRect, contentSize, xAxis, cor
 		popoverLeft = rightAlignment.popoverLeft;
 	}
 
-	const boundaryRect = boundaryElement.getBoundingClientRect();
+	if ( boundaryElement ) {
+		const boundaryRect = boundaryElement.getBoundingClientRect();
+		popoverLeft = Math.min( popoverLeft, boundaryRect.right - width );
+	}
 
 	return {
 		xAxis: chosenXAxis,
-		popoverLeft: Math.min( popoverLeft, boundaryRect.right - width ),
+		popoverLeft,
 		contentWidth,
 	};
 }
@@ -122,11 +125,10 @@ export function computePopoverXAxisPosition( anchorRect, contentSize, xAxis, cor
  *                              scroll container edge when part of the anchor
  *                              leaves view.
  * @param {Element} anchorRef   The anchor element.
- * @param {Element} boundaryElement
  *
  * @return {Object} Popover xAxis position and constraints.
  */
-export function computePopoverYAxisPosition( anchorRect, contentSize, yAxis, corner, sticky, anchorRef, boundaryElement = document.body ) {
+export function computePopoverYAxisPosition( anchorRect, contentSize, yAxis, corner, sticky, anchorRef ) {
 	const { height } = contentSize;
 
 	if ( sticky ) {
@@ -168,7 +170,7 @@ export function computePopoverYAxisPosition( anchorRect, contentSize, yAxis, cor
 		popoverTop: anchorMidPoint,
 		contentHeight: (
 			( anchorMidPoint - ( height / 2 ) > 0 ? ( height / 2 ) : anchorMidPoint ) +
-			( anchorMidPoint + ( height / 2 ) > boundaryElement.clientHeight ? boundaryElement.clientHeight - anchorMidPoint : ( height / 2 ) )
+			( anchorMidPoint + ( height / 2 ) > window.innerHeight ? window.innerHeight - anchorMidPoint : ( height / 2 ) )
 		),
 	};
 
@@ -178,7 +180,7 @@ export function computePopoverYAxisPosition( anchorRect, contentSize, yAxis, cor
 	};
 	const bottomAlignment = {
 		popoverTop: anchorRect.bottom,
-		contentHeight: anchorRect.bottom + HEIGHT_OFFSET + height > boundaryElement.clientHeight ? boundaryElement.clientHeight - HEIGHT_OFFSET - anchorRect.bottom : height,
+		contentHeight: anchorRect.bottom + HEIGHT_OFFSET + height > window.innerHeight ? window.innerHeight - HEIGHT_OFFSET - anchorRect.bottom : height,
 	};
 
 	// Choosing the y axis
@@ -240,7 +242,7 @@ export function computePopoverPosition(
 ) {
 	const [ yAxis, xAxis = 'center', corner ] = position.split( ' ' );
 
-	const yAxisPosition = computePopoverYAxisPosition( anchorRect, contentSize, yAxis, corner, sticky, anchorRef, boundaryElement );
+	const yAxisPosition = computePopoverYAxisPosition( anchorRect, contentSize, yAxis, corner, sticky, anchorRef );
 	const xAxisPosition = computePopoverXAxisPosition( anchorRect, contentSize, xAxis, corner, sticky, yAxisPosition.yAxis, boundaryElement );
 
 	return {


### PR DESCRIPTION
## Description

This is just a proof of concept. I wouldn't recommend using it on its own as it may look a bit strange with the currently block selection style and the movers on the side.

Eventually we should rewrite `Popover` (or use an external component), but I'm trying to avoid that here so it unblocks other work being don.

<img width="419" alt="Screenshot 2019-12-24 at 13 47 15" src="https://user-images.githubusercontent.com/4710635/71413924-bf7d7500-2654-11ea-83ee-04ac59c4af26.png">

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
