### PR TITLE
[RNMobile] - Fix failed tests on Gutenberg mobile repo

### DIFF
--- a/packages/components/src/button/index.native.js
+++ b/packages/components/src/button/index.native.js
@@ -76,7 +76,6 @@ export function Button( props ) {
 		getStylesFromColorScheme,
 		isPressed,
 		'aria-disabled': ariaDisabled,
-		'aria-label': ariaLabel,
 		'data-subscript': subscript,
 		testID,
 		icon,
@@ -133,7 +132,7 @@ export function Button( props ) {
 		<TouchableOpacity
 			activeOpacity={ 0.7 }
 			accessible={ true }
-			accessibilityLabel={ ariaLabel }
+			accessibilityLabel={ label }
 			accessibilityStates={ states }
 			accessibilityRole={ 'button' }
 			accessibilityHint={ hint }

--- a/packages/components/src/toolbar-button/index.js
+++ b/packages/components/src/toolbar-button/index.js
@@ -35,6 +35,7 @@ function ToolbarButton( {
 
 	const button = (
 		<Button
+			aria-label={ title }
 			icon={ icon }
 			label={ title }
 			shortcut={ shortcut }

--- a/packages/components/src/toolbar-button/index.js
+++ b/packages/components/src/toolbar-button/index.js
@@ -35,7 +35,6 @@ function ToolbarButton( {
 
 	const button = (
 		<Button
-			aria-label={ title }
 			icon={ icon }
 			label={ title }
 			shortcut={ shortcut }


### PR DESCRIPTION
## Description
This PR fixes the problem with UI tests which are running on the gb-mobile repository

## How has this been tested?
This PR should have ✅ tests on gb-mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1722

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
