### PR TITLE
Block Directory: Refactor the reducer by breaking out the block management actions into their own reducer.

### DIFF
--- a/packages/block-directory/src/store/reducer.js
+++ b/packages/block-directory/src/store/reducer.js
@@ -16,7 +16,6 @@ export const downloadableBlocks = ( state = {
 	hasPermission: true,
 	filterValue: undefined,
 	isRequestingDownloadableBlocks: true,
-	installedBlockTypes: [],
 }, action ) => {
 	switch ( action.type ) {
 		case 'FETCH_DOWNLOADABLE_BLOCKS' :
@@ -33,6 +32,24 @@ export const downloadableBlocks = ( state = {
 				hasPermission: true,
 				isRequestingDownloadableBlocks: false,
 			};
+	}
+	return state;
+};
+
+/**
+ * Reducer managing the installation and deletion of blocks.
+ *
+ * @param {Object} state  Current state.
+ * @param {Object} action Dispatched action.
+ *
+ * @return {Object} Updated state.
+ */
+export const blockManagement = ( state = {
+	hasPermission: true,
+	installedBlockTypes: [],
+	items: [],
+}, action ) => {
+	switch ( action.type ) {
 		case 'SET_INSTALL_BLOCKS_PERMISSION' :
 			return {
 				...state,
@@ -44,7 +61,6 @@ export const downloadableBlocks = ( state = {
 				...state,
 				installedBlockTypes: [ ...state.installedBlockTypes, action.item ],
 			};
-
 		case 'REMOVE_INSTALLED_BLOCK_TYPE' :
 			return {
 				...state,
@@ -56,4 +72,5 @@ export const downloadableBlocks = ( state = {
 
 export default combineReducers( {
 	downloadableBlocks,
+	blockManagement,
 } );

--- a/packages/block-directory/src/store/reducer.js
+++ b/packages/block-directory/src/store/reducer.js
@@ -13,7 +13,6 @@ import { combineReducers } from '@wordpress/data';
  */
 export const downloadableBlocks = ( state = {
 	results: {},
-	hasPermission: true,
 	filterValue: undefined,
 	isRequestingDownloadableBlocks: true,
 }, action ) => {
@@ -29,7 +28,6 @@ export const downloadableBlocks = ( state = {
 				results: Object.assign( {}, state.results, {
 					[ action.filterValue ]: action.downloadableBlocks,
 				} ),
-				hasPermission: true,
 				isRequestingDownloadableBlocks: false,
 			};
 	}
@@ -45,17 +43,9 @@ export const downloadableBlocks = ( state = {
  * @return {Object} Updated state.
  */
 export const blockManagement = ( state = {
-	hasPermission: true,
 	installedBlockTypes: [],
-	items: [],
 }, action ) => {
 	switch ( action.type ) {
-		case 'SET_INSTALL_BLOCKS_PERMISSION' :
-			return {
-				...state,
-				items: action.hasPermission ? state.items : [],
-				hasPermission: action.hasPermission,
-			};
 		case 'ADD_INSTALLED_BLOCK_TYPE' :
 			return {
 				...state,
@@ -70,7 +60,24 @@ export const blockManagement = ( state = {
 	return state;
 };
 
+/**
+ * Reducer returns whether the user can install blocks.
+ *
+ * @param {Object} state  Current state.
+ * @param {Object} action Dispatched action.
+ *
+ * @return {Object} Updated state.
+ */
+export function hasPermission( state = true, action ) {
+	if ( action.type === 'SET_INSTALL_BLOCKS_PERMISSION' ) {
+		return action.hasPermission;
+	}
+
+	return state;
+}
+
 export default combineReducers( {
 	downloadableBlocks,
 	blockManagement,
+	hasPermission,
 } );

--- a/packages/block-directory/src/store/selectors.js
+++ b/packages/block-directory/src/store/selectors.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { get } from 'lodash';
-
-/**
  * Returns true if application is requesting for downloadable blocks.
  *
  * @param {Object} state       Global application state.
@@ -48,5 +43,5 @@ export function hasInstallBlocksPermission( state ) {
  * @return {Array} Block type items.
  */
 export function getInstalledBlockTypes( state ) {
-	return get( state, [ 'blockManagement', 'installedBlockTypes' ], [] );
+	return state.blockManagement.installedBlockTypes;
 }

--- a/packages/block-directory/src/store/selectors.js
+++ b/packages/block-directory/src/store/selectors.js
@@ -48,5 +48,5 @@ export function hasInstallBlocksPermission( state ) {
  * @return {Array} Block type items.
  */
 export function getInstalledBlockTypes( state ) {
-	return get( state, [ 'downloadableBlocks', 'installedBlockTypes' ], [] );
+	return get( state, [ 'blockManagement', 'installedBlockTypes' ], [] );
 }

--- a/packages/block-directory/src/store/selectors.js
+++ b/packages/block-directory/src/store/selectors.js
@@ -37,7 +37,7 @@ export function getDownloadableBlocks( state, filterValue ) {
  * @return {boolean} User has permission to install blocks.
  */
 export function hasInstallBlocksPermission( state ) {
-	return state.downloadableBlocks.hasPermission;
+	return state.hasPermission;
 }
 
 /**

--- a/packages/block-directory/src/store/test/fixtures/index.js
+++ b/packages/block-directory/src/store/test/fixtures/index.js
@@ -1,0 +1,23 @@
+export const downloadableBlock = {
+	name: 'boxer/boxer',
+	title: 'Boxer',
+	description: 'Boxer is a Block that puts your WordPress posts into boxes on a page.',
+	id: 'boxer-block',
+	rating: 5,
+	ratingCount: 1,
+	activeInstalls: 0,
+	authorBlockRating: 5,
+	authorBlockCount: '1',
+	author: 'CK Lee',
+	icon: 'block-default',
+	assets: [
+		'https://plugins.svn.wordpress.org/boxer-block/trunk/build/index.js',
+		'https://plugins.svn.wordpress.org/boxer-block/trunk/build/view.js',
+	],
+	humanizedUpdated: '3 months ago',
+};
+
+export const installedItem = {
+	id: 'boxer-block',
+	name: 'boxer/boxer',
+};

--- a/packages/block-directory/src/store/test/reducer.js
+++ b/packages/block-directory/src/store/test/reducer.js
@@ -1,0 +1,107 @@
+/**
+ * External dependencies
+ */
+import deepFreeze from 'deep-freeze';
+
+/**
+ * Internal dependencies
+ */
+import {
+	downloadableBlocks,
+	blockManagement,
+} from '../reducer';
+import { installedItem, downloadableBlock } from './fixtures';
+
+describe( 'state', () => {
+	describe( 'downloadableBlocks()', () => {
+		it( 'should update state to reflect active search', () => {
+			const initialState = deepFreeze( {
+				isRequestingDownloadableBlocks: false,
+			} );
+			const state = downloadableBlocks( initialState, {
+				type: 'FETCH_DOWNLOADABLE_BLOCKS',
+			} );
+
+			expect( state.isRequestingDownloadableBlocks ).toBe( true );
+		} );
+
+		it( 'should update state to reflect search results have returned', () => {
+			const state = downloadableBlocks( undefined, {
+				type: 'RECEIVE_DOWNLOADABLE_BLOCKS',
+				filterValue: downloadableBlock.title,
+				downloadableBlocks: [ downloadableBlock ],
+			} );
+
+			expect( state.isRequestingDownloadableBlocks ).toBe( false );
+		} );
+
+		it( 'should set user\'s search term and save results', () => {
+			const state = downloadableBlocks( undefined, {
+				type: 'RECEIVE_DOWNLOADABLE_BLOCKS',
+				filterValue: downloadableBlock.title,
+				downloadableBlocks: [ downloadableBlock ],
+			} );
+			expect( state.results ).toHaveProperty( downloadableBlock.title );
+			expect( state.results[ downloadableBlock.title ] ).toHaveLength( 1 );
+
+			// It should append to the results
+			const updatedState = downloadableBlocks( state, {
+				type: 'RECEIVE_DOWNLOADABLE_BLOCKS',
+				filterValue: 'Test 1',
+				downloadableBlocks: [ downloadableBlock ],
+			} );
+
+			expect( Object.keys( updatedState.results ) ).toHaveLength( 2 );
+		} );
+	} );
+
+	describe( 'blockManagement()', () => {
+		it( 'should set state to reflect user not having permissions', () => {
+			const initialState = deepFreeze( {
+				items: [ downloadableBlock ],
+			} );
+			const state = blockManagement( initialState, {
+				type: 'SET_INSTALL_BLOCKS_PERMISSION',
+				hasPermission: false,
+			} );
+
+			expect( state.hasPermission ).toBe( false );
+			expect( state.items ).toHaveLength( 0 );
+		} );
+
+		it( 'should set state to reflect user having permissions', () => {
+			const initialState = deepFreeze( {
+				items: [ downloadableBlock ],
+			} );
+			const state = blockManagement( initialState, {
+				type: 'SET_INSTALL_BLOCKS_PERMISSION',
+				hasPermission: true,
+			} );
+
+			expect( state.hasPermission ).toBe( true );
+			expect( state.items ).toHaveLength( 1 );
+		} );
+
+		it( 'should add item to the installedBlockTypesList', () => {
+			const initialState = deepFreeze( { installedBlockTypes: [] } );
+			const state = blockManagement( initialState, {
+				type: 'ADD_INSTALLED_BLOCK_TYPE',
+				item: installedItem,
+			} );
+
+			expect( state.installedBlockTypes ).toHaveLength( 1 );
+		} );
+
+		it( 'should remove item from the installedBlockTypesList', () => {
+			const initialState = deepFreeze( {
+				installedBlockTypes: [ installedItem ],
+			} );
+			const state = blockManagement( initialState, {
+				type: 'REMOVE_INSTALLED_BLOCK_TYPE',
+				item: installedItem,
+			} );
+
+			expect( state.installedBlockTypes ).toHaveLength( 0 );
+		} );
+	} );
+} );

--- a/packages/block-directory/src/store/test/reducer.js
+++ b/packages/block-directory/src/store/test/reducer.js
@@ -9,6 +9,7 @@ import deepFreeze from 'deep-freeze';
 import {
 	downloadableBlocks,
 	blockManagement,
+	hasPermission,
 } from '../reducer';
 import { installedItem, downloadableBlock } from './fixtures';
 
@@ -56,32 +57,6 @@ describe( 'state', () => {
 	} );
 
 	describe( 'blockManagement()', () => {
-		it( 'should set state to reflect user not having permissions', () => {
-			const initialState = deepFreeze( {
-				items: [ downloadableBlock ],
-			} );
-			const state = blockManagement( initialState, {
-				type: 'SET_INSTALL_BLOCKS_PERMISSION',
-				hasPermission: false,
-			} );
-
-			expect( state.hasPermission ).toBe( false );
-			expect( state.items ).toHaveLength( 0 );
-		} );
-
-		it( 'should set state to reflect user having permissions', () => {
-			const initialState = deepFreeze( {
-				items: [ downloadableBlock ],
-			} );
-			const state = blockManagement( initialState, {
-				type: 'SET_INSTALL_BLOCKS_PERMISSION',
-				hasPermission: true,
-			} );
-
-			expect( state.hasPermission ).toBe( true );
-			expect( state.items ).toHaveLength( 1 );
-		} );
-
 		it( 'should add item to the installedBlockTypesList', () => {
 			const initialState = deepFreeze( { installedBlockTypes: [] } );
 			const state = blockManagement( initialState, {
@@ -102,6 +77,17 @@ describe( 'state', () => {
 			} );
 
 			expect( state.installedBlockTypes ).toHaveLength( 0 );
+		} );
+	} );
+
+	describe( 'hasPermission()', () => {
+		it( 'should update permissions appropriately', () => {
+			const state = hasPermission( true, {
+				type: 'SET_INSTALL_BLOCKS_PERMISSION',
+				hasPermission: false,
+			} );
+
+			expect( state ).toBe( false );
 		} );
 	} );
 } );

--- a/packages/block-directory/src/store/test/reducer.js
+++ b/packages/block-directory/src/store/test/reducer.js
@@ -57,6 +57,13 @@ describe( 'state', () => {
 	} );
 
 	describe( 'blockManagement()', () => {
+		it( 'should start with an empty installedBlockTypes List', () => {
+			const state = blockManagement( undefined, {
+				type: 'NOOP_TYPE',
+			} );
+			expect( state.installedBlockTypes ).toEqual( [] );
+		} );
+
 		it( 'should add item to the installedBlockTypesList', () => {
 			const initialState = deepFreeze( { installedBlockTypes: [] } );
 			const state = blockManagement( initialState, {

--- a/packages/block-directory/src/store/test/selectors.js
+++ b/packages/block-directory/src/store/test/selectors.js
@@ -15,7 +15,7 @@ describe( 'selectors', () => {
 			expect( installedBlockTypes ).toEqual( [] );
 		} );
 
-		it( 'should retrieve the blocks types that are installed', () => {
+		it( 'should retrieve the block types that are installed', () => {
 			const blockTypes = [ 'fake-type' ];
 			const state = {
 				blockManagement: {

--- a/packages/block-directory/src/store/test/selectors.js
+++ b/packages/block-directory/src/store/test/selectors.js
@@ -1,0 +1,29 @@
+/**
+ * Internal dependencies
+ */
+import {
+	getInstalledBlockTypes,
+} from '../selectors';
+
+describe( 'selectors', () => {
+	describe( 'getInstalledBlockTypes', () => {
+		it( 'should return an empty array as a default value', () => {
+			const state = {
+				blockManagement: { },
+			};
+			const installedBlockTypes = getInstalledBlockTypes( state );
+			expect( installedBlockTypes ).toEqual( [] );
+		} );
+
+		it( 'should retrieve the blocks types that are installed', () => {
+			const blockTypes = [ 'fake-type' ];
+			const state = {
+				blockManagement: {
+					installedBlockTypes: blockTypes,
+				},
+			};
+			const installedBlockTypes = getInstalledBlockTypes( state );
+			expect( installedBlockTypes ).toEqual( blockTypes );
+		} );
+	} );
+} );

--- a/packages/block-directory/src/store/test/selectors.js
+++ b/packages/block-directory/src/store/test/selectors.js
@@ -7,14 +7,6 @@ import {
 
 describe( 'selectors', () => {
 	describe( 'getInstalledBlockTypes', () => {
-		it( 'should return an empty array as a default value', () => {
-			const state = {
-				blockManagement: { },
-			};
-			const installedBlockTypes = getInstalledBlockTypes( state );
-			expect( installedBlockTypes ).toEqual( [] );
-		} );
-
 		it( 'should retrieve the block types that are installed', () => {
 			const blockTypes = [ 'fake-type' ];
 			const state = {


### PR DESCRIPTION
## Description
This PR will separate out the actions that manage the installing and deleting of blocks from the reducer function that is tasked with the searching for blocks. 

@talldan mentioned that he would be making this PR, but i went ahead and completed it. 

### Notes
- `hasPermissions` is now separated between the 2 reducers. This should be temporary as another refactor has been identified related to how the `block-directory` deals with permissions. We would like to refactor  to make use of `core-data`'s `canUser` function as opposed to the current approach (or use something similar). (Thread: https://github.com/WordPress/gutenberg/pull/16524/files#r315493053)
- There is an `items` list that exist. It doesn't appear to be used anywhere in the code base. I think it may be a relic. I left it in the reducer at any rate. 

## How has this been tested?
This PR was tested using the unit testing framework and data examples from production.
Manual testing has also be done with WordPress (WordPress 5.4-alpha-46582-src), although this change introduces very little change to functionality.

## Types of changes
As mentioned in the description, this change separates out some actions that didn't make sense within their current reducer. This reducer initially made it into master because of a deadline with the note to come back and make this change.

You can read about it here: https://github.com/WordPress/gutenberg/pull/16524/files#r324233060

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
