### PR TITLE
Fix the multiple list block shortcuts

### DIFF
--- a/packages/block-library/src/list/edit.js
+++ b/packages/block-library/src/list/edit.js
@@ -33,40 +33,43 @@ export default function ListEdit( {
 	mergeBlocks,
 	onReplace,
 	className,
+	isSelected,
 } ) {
 	const { ordered, values, type, reversed, start } = attributes;
 	const tagName = ordered ? 'ol' : 'ul';
 
 	const controls = ( { value, onChange } ) => (
 		<>
-			<RichTextShortcut
-				type="primary"
-				character="["
-				onUse={ () => {
-					onChange( outdentListItems( value ) );
-				} }
-			/>
-			<RichTextShortcut
-				type="primary"
-				character="]"
-				onUse={ () => {
-					onChange( indentListItems( value, { type: tagName } ) );
-				} }
-			/>
-			<RichTextShortcut
-				type="primary"
-				character="m"
-				onUse={ () => {
-					onChange( indentListItems( value, { type: tagName } ) );
-				} }
-			/>
-			<RichTextShortcut
-				type="primaryShift"
-				character="m"
-				onUse={ () => {
-					onChange( outdentListItems( value ) );
-				} }
-			/>
+			{ ( isSelected && <>
+				<RichTextShortcut
+					type="primary"
+					character="["
+					onUse={ () => {
+						onChange( outdentListItems( value ) );
+					} }
+				/>
+				<RichTextShortcut
+					type="primary"
+					character="]"
+					onUse={ () => {
+						onChange( indentListItems( value, { type: tagName } ) );
+					} }
+				/>
+				<RichTextShortcut
+					type="primary"
+					character="m"
+					onUse={ () => {
+						onChange( indentListItems( value, { type: tagName } ) );
+					} }
+				/>
+				<RichTextShortcut
+					type="primaryShift"
+					character="m"
+					onUse={ () => {
+						onChange( outdentListItems( value ) );
+					} }
+				/>
+			</> ) }
 			<BlockControls>
 				<ToolbarGroup
 					controls={ [


### PR DESCRIPTION
I noticed two things:

 - List indent/outdent shortcuts don't work properly when you have multiple list blocks (callbacks are triggered in all list blocks while they should only affect the selected blocks)
 - Also this has some impact on performance since keydown handlers number grow significantly as we add list blocks to the post.

This PR wraps those shortcuts in an `isSelected` check to fix that.

That said, I also took a look at the RichtextShortcut component and after some thinking I concluded that this component is useless and also misleading.

 - I wonder whether I should wrap the component automatically in `ifBlockEditSelected` like block controls... but that's not a good approach because conceptually speaking, you can have a RichText outside a block or multiple RichText in the same block, so this won't solve anything really.
 - It gives you the impression that it tied to RichText somehow but in reality, it's not it's just a proxy to the `KeyboardShortcuts` component. 
 - I think ideally, we should just deprecate that component. I didn't do that yet.