### PR TITLE
Update the float on the Spinner to `none`

### DIFF
--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -191,7 +191,6 @@
 .block-editor-link-control .block-editor-link-control__search-input .components-spinner {
 	display: block;
 	z-index: 100;
-	float: none;
 
 	&.components-spinner { // Specificity override.
 		position: absolute;

--- a/packages/components/src/spinner/style.scss
+++ b/packages/components/src/spinner/style.scss
@@ -4,7 +4,6 @@
 	width: 18px;
 	height: 18px;
 	opacity: 0.7;
-	float: right;
 	margin: 5px 11px 0;
 	border-radius: 100%;
 	position: relative;

--- a/packages/editor/src/components/post-publish-panel/style.scss
+++ b/packages/editor/src/components/post-publish-panel/style.scss
@@ -8,7 +8,6 @@
 
 	.components-spinner {
 		display: block;
-		float: none;
 		margin: 100px auto 0;
 	}
 }


### PR DESCRIPTION
## Description
Fixes #18199. It appears that changing the float on the spinner component to `none` instead of `right` seems to work fine. 

## How has this been tested?
I tested the visual change in a few places like: 

- Uploading an image to a block.
- Switching to the Media Library from an Image block.
- Publishing a post.

Each instance there seemed to work just fine visually. I only tested in Firefox 71.0.

## Screenshots 

**Image block**

![Screen Shot 2019-12-26 at 5 15 35 PM](https://user-images.githubusercontent.com/617986/71495790-8e43a700-2804-11ea-9820-0263da734afe.png)

**Storybook** 

![spinner 2019-12-26 17_19_47](https://user-images.githubusercontent.com/617986/71495799-9996d280-2804-11ea-83e7-51537461413a.gif)


## Types of changes
Non-breaking CSS changes.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
