### PR TITLE
Removed the bottom-margin for the radio-control

### DIFF
--- a/packages/components/src/radio-control/style.scss
+++ b/packages/components/src/radio-control/style.scss
@@ -5,6 +5,10 @@
 	.components-base-control__help {
 		margin-top: 0;
 	}
+
+	.components-base-control__field {
+		margin-bottom: 0;
+	}
 }
 
 .components-radio-control__option:not(:last-child) {


### PR DESCRIPTION
## Description
Fixes #17929.
There was an extra bottom-margin on the `radio-control` as indicated in #17929. I edited the `radio-control` to remove this margin.

## How has this been tested?
Tested locally. I checked through some settings, although the Latest Posts block may be the only block settings that utilize this particular combination of cascaded styles.

## Screenshots 

![radio-control 2019-12-26 22_06_53](https://user-images.githubusercontent.com/617986/71503922-12f5eb80-282c-11ea-84c6-e8ae1f1eb118.gif)


## Types of changes
Non-breaking CSS changes.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
