### PR TITLE
Optimize useShortcut performance.

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -404,11 +404,11 @@ function BlockListBlock( {
 		! hasFixedToolbar &&
 		! isEmptyDefaultBlock
 	);
-	useShortcut( 'core/block-editor/focus-toolbar', useCallback( () => {
-		if ( canFocusHiddenToolbar ) {
-			forceFocusedContextualToolbar();
-		}
-	}, [ canFocusHiddenToolbar ] ), { bindGlobal: true, eventName: 'keydown' } );
+	useShortcut(
+		'core/block-editor/focus-toolbar',
+		useCallback( forceFocusedContextualToolbar, [] ),
+		{ bindGlobal: true, eventName: 'keydown', isDisabled: ! canFocusHiddenToolbar }
+	);
 
 	// Rendering the output
 	const isHovered = isBlockHovered && ! isPartOfMultiSelection;

--- a/packages/block-editor/src/components/block-navigation/dropdown.js
+++ b/packages/block-editor/src/components/block-navigation/dropdown.js
@@ -19,11 +19,7 @@ const MenuIcon = (
 );
 
 function BlockNavigationDropdownToggle( { isEnabled, onToggle, isOpen } ) {
-	useShortcut( 'core/edit-post/toggle-block-navigation', useCallback( () => {
-		if ( isEnabled ) {
-			onToggle();
-		}
-	}, [ onToggle, isEnabled ] ), { bindGlobal: true } );
+	useShortcut( 'core/edit-post/toggle-block-navigation', useCallback( onToggle, [ onToggle ] ), { bindGlobal: true, isDisabled: ! isEnabled } );
 	const shortcut = useSelect( ( select ) =>
 		select( 'core/keyboard-shortcuts' ).getShortcutRepresentation( 'core/edit-post/toggle-block-navigation' ), []
 	);

--- a/packages/block-editor/src/components/keyboard-shortcuts/index.js
+++ b/packages/block-editor/src/components/keyboard-shortcuts/index.js
@@ -31,50 +31,70 @@ function KeyboardShortcuts() {
 
 	// Prevents bookmark all Tabs shortcut in Chrome when devtools are closed.
 	// Prevents reposition Chrome devtools pane shortcut when devtools are open.
-	useShortcut( 'core/block-editor/duplicate', useCallback( ( event ) => {
-		event.preventDefault();
-		duplicateBlocks( clientIds );
-	}, [ clientIds, duplicateBlocks ] ), { bindGlobal: true } );
+	useShortcut(
+		'core/block-editor/duplicate',
+		useCallback( ( event ) => {
+			event.preventDefault();
+			duplicateBlocks( clientIds );
+		}, [ clientIds, duplicateBlocks ] ),
+		{ bindGlobal: true, isDisabled: clientIds.length === 0 }
+	);
 
 	// Does not clash with any known browser/native shortcuts, but preventDefault
 	// is used to prevent any obscure unknown shortcuts from triggering.
-	useShortcut( 'core/block-editor/remove', useCallback( ( event ) => {
-		event.preventDefault();
-		removeBlocks( clientIds );
-	}, [ clientIds, removeBlocks ] ), { bindGlobal: true } );
-
-	// Does not clash with any known browser/native shortcuts, but preventDefault
-	// is used to prevent any obscure unknown shortcuts from triggering.
-	useShortcut( 'core/block-editor/insert-after', useCallback( ( event ) => {
-		event.preventDefault();
-		insertAfterBlock( last( clientIds ) );
-	}, [ clientIds, insertAfterBlock ] ), { bindGlobal: true } );
-
-	// Prevent 'view recently closed tabs' in Opera using preventDefault.
-	useShortcut( 'core/block-editor/insert-before', useCallback( ( event ) => {
-		event.preventDefault();
-		insertBeforeBlock( first( clientIds ) );
-	}, [ clientIds, insertBeforeBlock ] ), { bindGlobal: true } );
-
-	useShortcut( 'core/block-editor/delete-multi-selection', useCallback( ( event ) => {
-		if ( clientIds.length > 0 ) {
+	useShortcut(
+		'core/block-editor/remove',
+		useCallback( ( event ) => {
 			event.preventDefault();
 			removeBlocks( clientIds );
-		}
-	}, [ clientIds, removeBlocks ] ) );
+		}, [ clientIds, removeBlocks ] ),
+		{ bindGlobal: true, isDisabled: clientIds.length === 0 }
+	);
+
+	// Does not clash with any known browser/native shortcuts, but preventDefault
+	// is used to prevent any obscure unknown shortcuts from triggering.
+	useShortcut(
+		'core/block-editor/insert-after',
+		useCallback( ( event ) => {
+			event.preventDefault();
+			insertAfterBlock( last( clientIds ) );
+		}, [ clientIds, insertAfterBlock ] ),
+		{ bindGlobal: true, isDisabled: clientIds.length === 0 }
+	);
+
+	// Prevent 'view recently closed tabs' in Opera using preventDefault.
+	useShortcut(
+		'core/block-editor/insert-before',
+		useCallback( ( event ) => {
+			event.preventDefault();
+			insertBeforeBlock( first( clientIds ) );
+		}, [ clientIds, insertBeforeBlock ] ),
+		{ bindGlobal: true, isDisabled: clientIds.length === 0 }
+	);
+
+	useShortcut(
+		'core/block-editor/delete-multi-selection',
+		useCallback( ( event ) => {
+			event.preventDefault();
+			removeBlocks( clientIds );
+		}, [ clientIds, removeBlocks ] ),
+		{ isDisabled: clientIds.length < 1 }
+	);
 
 	useShortcut( 'core/block-editor/select-all', useCallback( ( event ) => {
 		event.preventDefault();
 		multiSelect( first( rootBlocksClientIds ), last( rootBlocksClientIds ) );
 	}, [ rootBlocksClientIds, multiSelect ] ) );
 
-	useShortcut( 'core/block-editor/unselect', useCallback( ( event ) => {
-		if ( clientIds.length > 1 ) {
+	useShortcut(
+		'core/block-editor/unselect',
+		useCallback( ( event ) => {
 			event.preventDefault();
 			clearSelectedBlock();
 			window.getSelection().removeAllRanges();
-		}
-	}, [ clientIds, clearSelectedBlock ] ) );
+		}, [ clientIds, clearSelectedBlock ] ),
+		{ isDisabled: clientIds.length < 1 }
+	);
 
 	return null;
 }

--- a/packages/compose/src/hooks/use-keyboard-shortcut/index.js
+++ b/packages/compose/src/hooks/use-keyboard-shortcut/index.js
@@ -34,9 +34,13 @@ function isAppleOS( _window = window ) {
 function useKeyboardShortcut( shortcuts, callback, {
 	bindGlobal = false,
 	eventName = 'keydown',
+	isDisabled = false, // This is important for performance considerations.
 	target,
 } = {} ) {
 	useEffect( () => {
+		if ( isDisabled ) {
+			return;
+		}
 		const mousetrap = new Mousetrap( target ? target.current : document );
 		castArray( shortcuts ).forEach( ( shortcut ) => {
 			const keys = shortcut.split( '+' );
@@ -64,7 +68,7 @@ function useKeyboardShortcut( shortcuts, callback, {
 		return () => {
 			mousetrap.reset();
 		};
-	}, [ shortcuts, bindGlobal, eventName, callback, target ] );
+	}, [ shortcuts, bindGlobal, eventName, callback, target, isDisabled ] );
 }
 
 export default useKeyboardShortcut;

--- a/packages/edit-post/src/components/keyboard-shortcuts/index.js
+++ b/packages/edit-post/src/components/keyboard-shortcuts/index.js
@@ -9,15 +9,18 @@ import { __ } from '@wordpress/i18n';
 function KeyboardShortcuts() {
 	const {
 		getBlockSelectionStart,
-		getEditorSettings,
 		getEditorMode,
 		isEditorSidebarOpen,
+		richEditingEnabled,
+		codeEditingEnabled,
 	} = useSelect( ( select ) => {
+		const settings = select( 'core/editor' ).getEditorSettings();
 		return {
 			getBlockSelectionStart: select( 'core/block-editor' ).getBlockSelectionStart,
-			getEditorSettings: select( 'core/editor' ).getEditorSettings,
 			getEditorMode: select( 'core/edit-post' ).getEditorMode,
 			isEditorSidebarOpened: select( 'core/edit-post' ).isEditorSidebarOpened,
+			richEditingEnabled: settings.richEditingEnabled,
+			codeEditingEnabled: settings.codeEditingEnabled,
 		};
 	} );
 
@@ -99,12 +102,8 @@ function KeyboardShortcuts() {
 	}, [] );
 
 	useShortcut( 'core/edit-post/toggle-mode', () => {
-		const { richEditingEnabled, codeEditingEnabled } = getEditorSettings();
-		if ( ! richEditingEnabled || ! codeEditingEnabled ) {
-			return;
-		}
 		switchEditorMode( getEditorMode() === 'visual' ? 'text' : 'visual' );
-	}, { bindGlobal: true } );
+	}, { bindGlobal: true, isDisabled: ! richEditingEnabled || ! codeEditingEnabled } );
 
 	useShortcut( 'core/edit-post/toggle-sidebar', ( event ) => {
 		// This shortcut has no known clashes, but use preventDefault to prevent any


### PR DESCRIPTION
#19332 introduced some performance regressions because of the high number of mousetrap event handlers triggers in the block list.

This PR adds a way to disable the handlers and we're back to similar performance results compared to master.