### PR TITLE
Add support for TikTok video Embeds

### DIFF
--- a/packages/block-library/src/embed/core-embeds.js
+++ b/packages/block-library/src/embed/core-embeds.js
@@ -330,6 +330,15 @@ export const others = [
 		patterns: [ /^https?:\/\/(www\.)?speakerdeck\.com\/.+/i ],
 	},
 	{
+		name: 'core-embed/tiktok',
+		settings: {
+			title: 'TikTok',
+			icon: embedVideoIcon,
+			description: __( 'Embed a TikTok video.' ),
+		},
+		patterns: [ /^https?:\/\/(www\.)?tiktok\.com\/.+/i ],
+	},
+	{
 		name: 'core-embed/ted',
 		settings: {
 			title: 'TED',


### PR DESCRIPTION
## Description
Fixes #19342

This Pull Request adds TikTok oEmbed support.
For reference, see the related Trac ticket for WP 5.4: https://core.trac.wordpress.org/ticket/49083

## How has this been tested?
Copy this test URL into the editor: https://www.tiktok.com/@scout2015/video/6718335390845095173

For reference: 
TikTok oEmbed developer documentation: https://developers.tiktok.com/doc/Embed

## Screenshots <!-- if applicable -->
![screencapture-localhost-8888-testing-features-test4-wp-admin-post-php-2019-12-27-11_48_18](https://user-images.githubusercontent.com/1590998/71515309-e9c47200-28a2-11ea-9b4e-9b5a540ae5d3.png)

## Types of changes
**New feature (non-breaking change which adds functionality)**
Introduce a oEmbed block support for a new resource: TikTok.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->