### PR TITLE
Added "poem" to the keywords for the Verse block

### DIFF
--- a/packages/block-library/src/verse/index.js
+++ b/packages/block-library/src/verse/index.js
@@ -27,7 +27,7 @@ export const settings = {
 			content: __( 'WHAT was he doing, the great god Pan,\n	Down in the reeds by the river?\nSpreading ruin and scattering ban,\nSplashing and paddling with hoofs of a goat,\nAnd breaking the golden lilies afloat\n    With the dragon-fly on the river.' ),
 		},
 	},
-	keywords: [ __( 'poetry' ) ],
+	keywords: [ __( 'poetry' ), __( 'poem' ) ],
 	transforms,
 	deprecated,
 	merge( attributes, attributesToMerge ) {


### PR DESCRIPTION
## Description
Fixes #8336.
I've added "poem" to the keywords for the Verse block. There were also some other suggestions on that issue that have already been addressed, so I'm closing out the issue.

## How has this been tested?
Locally.

## Screenshots 

![verse-block 2019-12-27 16_41_41](https://user-images.githubusercontent.com/617986/71536800-2f476600-28c8-11ea-8f1a-bb00be2bf3f0.gif)


## Types of changes
Non-breaking changes.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
