### PR TITLE
fix missing button-block-appender icon on Firefox 71 and Safari 13

### DIFF
--- a/packages/block-editor/src/components/button-block-appender/style.scss
+++ b/packages/block-editor/src/components/button-block-appender/style.scss
@@ -6,7 +6,7 @@
 	padding: $block-padding;
 	outline: $border-width dashed $dark-gray-150;
 	width: 100%;
-	height: 100%;
+	height: auto;
 	color: $dark-gray-500;
 	background: $light-opacity-background-fill;
 

--- a/packages/block-editor/src/components/button-block-appender/style.scss
+++ b/packages/block-editor/src/components/button-block-appender/style.scss
@@ -3,9 +3,10 @@
 	flex-direction: column;
 	align-items: center;
 	justify-content: center;
-	padding: $block-padding*1.5;
+	padding: $block-padding;
 	outline: $border-width dashed $dark-gray-150;
 	width: 100%;
+	height: 100%;
 	color: $dark-gray-500;
 	background: $light-opacity-background-fill;
 


### PR DESCRIPTION
## Description
Fixes #19246

## How has this been tested?
Manual testing using:
- Firefox 71
- Safari 13
- Chrome 79

## Screenshots <!-- if applicable -->
Before:
![image](https://user-images.githubusercontent.com/1191500/71582646-65285c80-2b0b-11ea-9e45-4f4f74d9a65c.png)

After:
![image](https://user-images.githubusercontent.com/1191500/71582703-a587da80-2b0b-11ea-8076-4e9bfab67d8f.png)


## Types of changes
Small style updates.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->