### PR TITLE
Capitalizing 'Manager' because Block Manager is a proper noun

### DIFF
--- a/packages/e2e-tests/specs/editor/plugins/allowed-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/allowed-blocks.test.js
@@ -41,7 +41,7 @@ describe( 'Allowed Blocks Filter', () => {
 	} );
 
 	it( 'should remove not allowed blocks from the block manager', async () => {
-		await clickOnMoreMenuItem( 'Block manager' );
+		await clickOnMoreMenuItem( 'Block Manager' );
 
 		const BLOCK_LABEL_SELECTOR = '.edit-post-manage-blocks-modal__checklist-item .components-checkbox-control__label';
 		await page.waitForSelector( BLOCK_LABEL_SELECTOR );

--- a/packages/edit-post/src/components/manage-blocks-modal/index.js
+++ b/packages/edit-post/src/components/manage-blocks-modal/index.js
@@ -26,7 +26,7 @@ export function ManageBlocksModal( { isActive, closeModal } ) {
 	return (
 		<Modal
 			className="edit-post-manage-blocks-modal"
-			title={ __( 'Block manager' ) }
+			title={ __( 'Block Manager' ) }
 			closeLabel={ __( 'Close' ) }
 			onRequestClose={ closeModal }
 		>

--- a/packages/edit-post/src/plugins/manage-blocks-menu-item/index.js
+++ b/packages/edit-post/src/plugins/manage-blocks-menu-item/index.js
@@ -12,7 +12,7 @@ export function ManageBlocksMenuItem( { openModal } ) {
 				openModal( 'edit-post/manage-blocks' );
 			} }
 		>
-			{ __( 'Block manager' ) }
+			{ __( 'Block Manager' ) }
 		</MenuItem>
 	);
 }


### PR DESCRIPTION
## Description
Similarly to "Block Editor", the "Block Manager" is a proper noun and should be capitalized. 

## How has this been tested?
Tested locally. 

## Screenshots <!-- if applicable -->

<img width="421" alt="Screen Shot 2019-12-31 at 11 32 23 AM" src="https://user-images.githubusercontent.com/617986/71632072-4389ac80-2bc1-11ea-9a9a-10349ccbfe44.png">


## Types of changes
Non-breaking changes.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
