### PR TITLE
docs: add standalone npm package release docs

### DIFF
--- a/docs/contributors/release.md
+++ b/docs/contributors/release.md
@@ -314,7 +314,7 @@ Begin updating the _changelogs_ based on the [Maintaining Changelogs](https://gi
 > ```
 1. `git push`
 
-Now that the changes have been committed to the `wp/trunk` branch adnd the Travis CI builds for the `wp/trunk` [branch are passing](https://travis-ci.com/WordPress/gutenberg/branches) it's time to publish the packages to npm:
+Now that the changes have been committed to the `wp/trunk` branch and the Travis CI builds for the `wp/trunk` [branch are passing](https://travis-ci.com/WordPress/gutenberg/branches) it's time to publish the packages to npm:
 1. Once again run `npm run publish:check` to confirm there are no unexpected packages ready to be published:
 > Example
 > ```shell

--- a/docs/contributors/release.md
+++ b/docs/contributors/release.md
@@ -298,21 +298,14 @@ Begin updating the _changelogs_ based on the [Maintaining Changelogs](https://gi
 
 1. `git checkout wp/trunk`
 2. Update each of the `CHANGELOG.md` files
-3. Make a note of each packages new version, you will require these when it comes time to publish the packages with Lerna to npm:
-> Example
-> ```
-> @packages/e2e-tests/CHANGELOG.md           - @1.9.1
-> @packages/jest-preset-default/CHANGELOG.md - @5.3.1
-> @packages/scripts/CHANGELOG.md             - @6.1.1
-> ```
-4. Stage the _changelog_ changes `git add packages/`
-5. `git commit -m "Update changelogs"`
-6. Make a note of the commit hash of this commit
+3. Stage the _changelog_ changes `git add packages/`
+4. `git commit -m "Update changelogs"`
+5. Make a note of the commit hash of this commit
 > Example
 > ```
 > [master 278f524f16] Update changelogs` 278f524
 > ```
-1. `git push`
+6. `git push`
 
 Now that the changes have been committed to the `wp/trunk` branch and the Travis CI builds for the `wp/trunk` [branch are passing](https://travis-ci.com/WordPress/gutenberg/branches) it's time to publish the packages to npm:
 1. Once again run `npm run publish:check` to confirm there are no unexpected packages ready to be published:

--- a/docs/contributors/release.md
+++ b/docs/contributors/release.md
@@ -253,6 +253,135 @@ Now, the branch is ready to be used to publish the npm packages.
 
 Now, the npm packages should be ready and a patch can be created and committed into the corresponding WordPress SVN branch.
 
+
+### Standalone Package Releases 
+
+The following workflow is needed when packages require bug fixes or security releases to be published to _npm_ outside of a WordPress release cycle.
+
+Note: Both the `master` and `wp/trunk` branches are restricted and can only be _pushed_ to by the Gutenberg Core team.
+
+Identify the commit hashes from the pull requests that need to be ported from the repo `master` branch to `wp/trunk`
+
+The `wp/trunk` branch now needs to be prepared to release and publish the packages to _npm_.
+
+Open a terminal and perform the following steps:
+1. `git checkout master`
+1. `git pull`
+1. `git checkout wp/trunk`
+1. `git pull`
+
+Before porting commits check that the `wp/trunk` branch does not have any outstanding packages waiting to be published:
+1. `git checkout wp/trunk`
+1. `npm run publish:check`
+
+Now _cherry-pick_ the commits from `master` to `wp/trunk`, use `-m 1 commithash` if the commit was a pull request merge commit:
+1. `git cherry-pick -m 1 cb150a2`
+1. `git push` 
+
+Whilst waiting for the Travis CI build for  `wp/trunk` [branch to pass](https://travis-ci.com/WordPress/gutenberg/branches) identify and begin updating the `CHANGELOG.md` files:
+1. `git checkout wp/trunk`
+1. `npm run publish:check`
+> Example
+> ```shell
+> npm run publish:check
+> @wordpress/e2e-tests
+> @wordpress/jest-preset-default
+> @wordpress/scripts
+> lerna success found 3 packages ready to publish
+> ```
+
+Check the versions listed in the current `CHANGELOG.md` file, looking through the commit history of a package e.g [@wordpress/scripts](https://github.com/WordPress/gutenberg/commits/master/packages/scripts) and look out for _"chore(release): publish"_ and _"Update changelogs"_ commits to determine recent version bumps, then looking at the commits since the most recent release should aid with discovering what changes have occurred since the last release.
+
+Note: You may discover the current version of each package is not up to date, if so updating the previous released versions would be appreciated.
+
+Begin updating the _changelogs_ based on the [Maintaining Changelogs](https://github.com/WordPress/gutenberg/blob/master/packages/README.md#maintaining-changelogs) documentation and commit the changes:
+
+1. `git checkout wp/trunk`
+1. Update each of the `CHANGELOG.md` files
+1. Make a note of each packages new version, you will require these when it comes time to publish the packages with Lerna to npm:
+> Example
+> ```
+> @packages/e2e-tests/CHANGELOG.md           - @1.9.1
+> @packages/jest-preset-default/CHANGELOG.md - @5.3.1
+> @packages/scripts/CHANGELOG.md             - @6.1.1
+> ```
+5. Stage the _changelog_ changes `git add packages/`
+1. `git commit -m "Update changelogs"`
+1. Make a note of the commit hash of this commit
+> Example
+> ```
+> [master 278f524f16] Update changelogs` 278f524
+> ```
+1. `git push`
+
+Now that the changes have been committed to the `wp/trunk` branch adnd the Travis CI builds for the `wp/trunk` [branch are passing](https://travis-ci.com/WordPress/gutenberg/branches) it's time to publish the packages to npm:
+1. Once again run `npm run publish:check` to confirm there are no unexpected packages ready to be published:
+> Example
+> ```shell
+> npm run publish:check
+> @wordpress/e2e-tests
+> @wordpress/jest-preset-default
+> @wordpress/scripts
+> lerna success found 3 packages ready to publish
+> ```
+2. Run the [package release process](https://github.com/WordPress/gutenberg/blob/master/packages/README.md#releasing-packages) but when asked for the version numbers to choose for each package use the versions you made note of above when updating each packages `CHANGELOG.md` file.
+> Truncated example of publishing process output
+> ```
+> npm run publish:prod
+> 
+> Build Progress: [==============================] 100%
+> lerna notice cli v3.18.2
+> lerna info versioning independent
+> ? Select a new version for @wordpress/e2e-tests (currently 1.9.0) Patch (1.9.1)
+> ? Select a new version for @wordpress/jest-preset-default (currently 5.3.0) Patch (5.3.1)
+> ? Select a new version for @wordpress/scripts (currently 6.1.0) Patch (6.1.1)
+> 
+> Changes:
+>  - @wordpress/e2e-tests: 1.9.0 => 1.9.1
+>  - @wordpress/jest-preset-default: 5.3.0 => 5.3.1
+>  - @wordpress/scripts: 6.1.0 => 6.1.1
+> 
+> ? Are you sure you want to publish these packages? Yes
+> lerna info execute Skipping releases
+> lerna info git Pushing tags...
+> lerna info publish Publishing packages to npm...
+> lerna info Verifying npm credentials
+> lerna info Checking two-factor auth mode
+> ? Enter OTP: 753566
+> lerna success published @wordpress/jest-preset-default 5.3.1
+> lerna success published @wordpress/scripts 6.1.1
+> lerna success published @wordpress/e2e-tests 1.9.1
+> Successfully published:
+>  - @wordpress/e2e-tests@1.9.1
+>  - @wordpress/jest-preset-default@5.3.1
+>  - @wordpress/scripts@6.1.1
+> lerna success published 3 packages
+> ```
+
+Now that the packages have been published the _"chore(release): publish"_ and _"Update changelogs"_ commits to `wp/trunk` need to be ported to the `master` branch:
+1. `git checkout master`
+1. `git pull`
+1. Cherry-pick the `278f524`hash you noted above from the _"Update changelogs"_ commit made to `wp/trunk`
+1. `git cherry-pick 278f524`
+1. Get the commit hash from the the lerna publish commit either from the terminal or [wp/trunk commits](https://github.com/WordPress/gutenberg/commits/wp/trunk)
+1. Cherry-pick the `fe6ae0d` "chore(release): publish"_ commit made to `wp/trunk`
+1. `git cherry-pick fe6ae0d`
+1. `git push` 
+
+Confirm the packages dependancies do not contain `file://` links in the `dependencies` or `devdependencies` section of the packages released, e.g:
+> https://unpkg.com/browse/@wordpress/jest-preset-default@5.3.1/package.json
+> https://unpkg.com/browse/@wordpress/scripts@6.1.1/package.json
+> https://unpkg.com/browse/@wordpress/jest-preset-default@5.3.1/package.json
+
+Time to announce the published changes in the #core-js and #core-editor Slack channels 
+> ```
+> 📣 Successfully published:
+> • @wordpress/e2e-tests@1.9.1
+> • @wordpress/jest-preset-default@5.3.1
+> • @wordpress/scripts@6.1.1
+> Lerna success published 3 packages
+```
+
 ---------
 
 Ta-da! 🎉

--- a/docs/contributors/release.md
+++ b/docs/contributors/release.md
@@ -266,21 +266,21 @@ The `wp/trunk` branch now needs to be prepared to release and publish the packag
 
 Open a terminal and perform the following steps:
 1. `git checkout master`
-1. `git pull`
-1. `git checkout wp/trunk`
-1. `git pull`
+2. `git pull`
+3. `git checkout wp/trunk`
+4. `git pull`
 
 Before porting commits check that the `wp/trunk` branch does not have any outstanding packages waiting to be published:
 1. `git checkout wp/trunk`
-1. `npm run publish:check`
+2. `npm run publish:check`
 
 Now _cherry-pick_ the commits from `master` to `wp/trunk`, use `-m 1 commithash` if the commit was a pull request merge commit:
 1. `git cherry-pick -m 1 cb150a2`
-1. `git push` 
+2. `git push` 
 
 Whilst waiting for the Travis CI build for  `wp/trunk` [branch to pass](https://travis-ci.com/WordPress/gutenberg/branches) identify and begin updating the `CHANGELOG.md` files:
 1. `git checkout wp/trunk`
-1. `npm run publish:check`
+2. `npm run publish:check`
 > Example
 > ```shell
 > npm run publish:check
@@ -297,17 +297,17 @@ Note: You may discover the current version of each package is not up to date, if
 Begin updating the _changelogs_ based on the [Maintaining Changelogs](https://github.com/WordPress/gutenberg/blob/master/packages/README.md#maintaining-changelogs) documentation and commit the changes:
 
 1. `git checkout wp/trunk`
-1. Update each of the `CHANGELOG.md` files
-1. Make a note of each packages new version, you will require these when it comes time to publish the packages with Lerna to npm:
+2. Update each of the `CHANGELOG.md` files
+3. Make a note of each packages new version, you will require these when it comes time to publish the packages with Lerna to npm:
 > Example
 > ```
 > @packages/e2e-tests/CHANGELOG.md           - @1.9.1
 > @packages/jest-preset-default/CHANGELOG.md - @5.3.1
 > @packages/scripts/CHANGELOG.md             - @6.1.1
 > ```
-5. Stage the _changelog_ changes `git add packages/`
-1. `git commit -m "Update changelogs"`
-1. Make a note of the commit hash of this commit
+4. Stage the _changelog_ changes `git add packages/`
+5. `git commit -m "Update changelogs"`
+6. Make a note of the commit hash of this commit
 > Example
 > ```
 > [master 278f524f16] Update changelogs` 278f524
@@ -360,13 +360,13 @@ Now that the changes have been committed to the `wp/trunk` branch and the Travis
 
 Now that the packages have been published the _"chore(release): publish"_ and _"Update changelogs"_ commits to `wp/trunk` need to be ported to the `master` branch:
 1. `git checkout master`
-1. `git pull`
-1. Cherry-pick the `278f524`hash you noted above from the _"Update changelogs"_ commit made to `wp/trunk`
-1. `git cherry-pick 278f524`
-1. Get the commit hash from the the lerna publish commit either from the terminal or [wp/trunk commits](https://github.com/WordPress/gutenberg/commits/wp/trunk)
-1. Cherry-pick the `fe6ae0d` "chore(release): publish"_ commit made to `wp/trunk`
-1. `git cherry-pick fe6ae0d`
-1. `git push` 
+2. `git pull`
+3. Cherry-pick the `278f524`hash you noted above from the _"Update changelogs"_ commit made to `wp/trunk`
+4. `git cherry-pick 278f524`
+5. Get the commit hash from the the lerna publish commit either from the terminal or [wp/trunk commits](https://github.com/WordPress/gutenberg/commits/wp/trunk)
+6. Cherry-pick the `fe6ae0d` "chore(release): publish"_ commit made to `wp/trunk`
+7. `git cherry-pick fe6ae0d`
+8. `git push` 
 
 Confirm the packages dependancies do not contain `file://` links in the `dependencies` or `devdependencies` section of the packages released, e.g:
 > https://unpkg.com/browse/@wordpress/jest-preset-default@5.3.1/package.json


### PR DESCRIPTION
## Description

This pull requests adds a new section to the [Packages Releases and WordPress Core Updates](https://github.com/WordPress/gutenberg/blob/master/docs/contributors/release.md#packages-releases-and-wordpress-core-updates) documentation detailing the steps required to publish packages to _npm_ outside of a WordPress release.


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Documentation was written during the process of releasing packages to npm 🤠

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Docs
## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
