### PR TITLE
Add missing z-index override to the autocomplete component

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -101,6 +101,7 @@ $z-layers: (
 	".components-popover.block-editor-block-navigation__popover": 99998,
 	".components-popover.edit-post-more-menu__content": 99998,
 	".components-popover.block-editor-rich-text__inline-format-toolbar": 99998,
+	".components-popover.components-autocomplete__popover": 99998,
 
 	".components-autocomplete__results": 1000000,
 

--- a/packages/components/src/autocomplete/style.scss
+++ b/packages/components/src/autocomplete/style.scss
@@ -1,3 +1,7 @@
+.components-popover.components-autocomplete__popover {
+	z-index: z-index(".components-popover.components-autocomplete__popover");
+}
+
 .components-autocomplete__popover .components-popover__content {
 	min-width: 200px;
 }


### PR DESCRIPTION
## Description
Fixes #19353 by adding missing z-index override for autocomplete component.

## How has this been tested?
Manual testing using:
Firefox 71
Chrome 79.0.3945.88
Safari 13.0.4

## Types of changes
Small style updates.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->