### PR TITLE
Fix triggering navigation mode from non-textual blocks

### DIFF
--- a/packages/block-editor/src/components/keyboard-shortcuts/index.js
+++ b/packages/block-editor/src/components/keyboard-shortcuts/index.js
@@ -93,7 +93,7 @@ function KeyboardShortcuts() {
 			clearSelectedBlock();
 			window.getSelection().removeAllRanges();
 		}, [ clientIds, clearSelectedBlock ] ),
-		{ isDisabled: clientIds.length < 1 }
+		{ isDisabled: clientIds.length < 2 }
 	);
 
 	return null;


### PR DESCRIPTION
Small PR that avoids clearing the block selection when triggering the navigation mode using "Escape" from a non-textual block.