### PR TITLE
Adds justification controls to Social Block

### DIFF
--- a/packages/block-library/src/social-links/block.json
+++ b/packages/block-library/src/social-links/block.json
@@ -2,5 +2,9 @@
 	"name": "core/social-links",
 	"category": "widgets",
 	"icon": "share",
-	"attributes": {}
+	"attributes": {
+		"itemsJustification": {
+			"type": "string"
+		}
+	}
 }

--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -1,15 +1,29 @@
 /**
+ * External dependencies
+ */
+import { upperFirst } from 'lodash';
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 
 import {
 	InnerBlocks,
+	BlockControls,
 } from '@wordpress/block-editor';
+
+import {
+	Toolbar,
+} from '@wordpress/components';
+
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import socialList from '../social-link/social-list';
+import * as navIcons from '../navigation/icons';
 
 const ALLOWED_BLOCKS = Object.keys( socialList ).map( ( site ) => {
 	return 'core/social-link-' + site;
@@ -25,9 +39,38 @@ const TEMPLATE = [
 	[ 'core/social-link-youtube' ],
 ];
 
-export const SocialLinksEdit = function( { className } ) {
+export const SocialLinksEdit = function( { attributes, setAttributes, className } ) {
+	const { itemsJustification } = attributes;
+
+	const blockClassNames = classnames( className, {
+		[ `items-justification-${ itemsJustification }` ]: itemsJustification,
+	} );
+
+	function handleItemsAlignment( align ) {
+		return () => {
+			const itemsJustificationSetting = itemsJustification === align ? undefined : align;
+			setAttributes( {
+				itemsJustification: itemsJustificationSetting,
+			} );
+		};
+	}
+
 	return (
-		<div className={ className }>
+		<div className={ blockClassNames }>
+
+			<BlockControls>
+				<Toolbar
+					icon={ itemsJustification ? navIcons[ `justify${ upperFirst( itemsJustification ) }Icon` ] : navIcons.justifyLeftIcon }
+					label={ __( 'Change items justification' ) }
+					isCollapsed
+					controls={ [
+						{ icon: navIcons.justifyLeftIcon, title: __( 'Justify items left' ), isActive: 'left' === itemsJustification, onClick: handleItemsAlignment( 'left' ) },
+						{ icon: navIcons.justifyCenterIcon, title: __( 'Justify items center' ), isActive: 'center' === itemsJustification, onClick: handleItemsAlignment( 'center' ) },
+						{ icon: navIcons.justifyRightIcon, title: __( 'Justify items right' ), isActive: 'right' === itemsJustification, onClick: handleItemsAlignment( 'right' ) },
+					] }
+				/>
+			</BlockControls>
+
 			<InnerBlocks
 				allowedBlocks={ ALLOWED_BLOCKS }
 				templateLock={ false }

--- a/packages/block-library/src/social-links/editor.scss
+++ b/packages/block-library/src/social-links/editor.scss
@@ -26,6 +26,8 @@
 		width: auto;
 		padding-left: 0;
 		padding-right: 0;
+		margin-left: 0;
+		margin-right: 0;
 	}
 
 	// 3. Remove margins on subsequent Edit container.
@@ -140,4 +142,24 @@
 
 	// Windows High Contrast mode will show this outline, but not the box-shadow.
 	outline: 2px solid transparent;
+}
+
+
+.wp-block-social-links {
+
+	> .block-editor-inner-blocks {
+		flex: 1; // expand to fill available space required for justification
+	}
+
+	&.items-justification-left .block-editor-inner-blocks > .block-editor-block-list__layout {
+		justify-content: flex-start;
+	}
+
+	&.items-justification-center .block-editor-inner-blocks > .block-editor-block-list__layout {
+		justify-content: center;
+	}
+
+	&.items-justification-right .block-editor-inner-blocks > .block-editor-block-list__layout {
+		justify-content: flex-end;
+	}
 }

--- a/packages/block-library/src/social-links/save.js
+++ b/packages/block-library/src/social-links/save.js
@@ -2,10 +2,20 @@
  * WordPress dependencies
  */
 import { InnerBlocks } from '@wordpress/block-editor';
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
 
-export default function save( { className } ) {
+export default function save( { attributes, className } ) {
+	const { itemsJustification } = attributes;
+
+	const blockClassNames = classnames( className, {
+		[ `items-justified-${ itemsJustification }` ]: itemsJustification,
+	} );
+
 	return (
-		<ul className={ className }>
+		<ul className={ blockClassNames }>
 			<InnerBlocks.Content />
 		</ul>
 	);

--- a/packages/block-library/src/social-links/style.scss
+++ b/packages/block-library/src/social-links/style.scss
@@ -52,6 +52,21 @@
 	display: flex;
 }
 
+.wp-block-social-links {
+
+	&.items-justified-left {
+		justify-content: flex-start;
+	}
+
+	&.items-justified-center {
+		justify-content: center;
+	}
+
+	&.items-justified-right {
+		justify-content: flex-end;
+	}
+
+}
 
 // Provide colors for a range of icons.
 .wp-block-social-links:not(.is-style-logos-only) {


### PR DESCRIPTION
<img width="838" alt="Screen Shot 2020-01-02 at 14 07 35" src="https://user-images.githubusercontent.com/444434/71670900-5b039980-2d69-11ea-86c1-4e4e7648a232.png">

## Description

Closes https://github.com/WordPress/gutenberg/issues/18951.

Adds the ability to justify the horiztonal alignment of the Social Icons. This is achieved similarly to the Navigation Block.

As with [that example](https://github.com/WordPress/gutenberg/pull/18909), please note the distinction between "align" (which is really "float") and "justify" as terms. 

I have noted that _align_ (as opposed to _justify_) left/right is already available on this Block but it actually applies float left/right to the Block _as a whole_ rather than moving the inner items. 

Justification controls allow the user to manipulate the arrangement of the _inner_ items whilst preserving (or manipulating separately) the positioning of the outer Block. Note, however, that this causes some ambiguity in the UI within the Editor when align and justify are applied together. It would be great if @jasmussen were able to advise on this as he was involved in the Nav Block and has the requisite context.

## Questions

* how can we resolve the layout within the editor when applying align and justification at the same time?
* should we add align wide/full to this Block?
* should we create a reusable "BlockJustificationToolbar" as per the `BlockAlignmentToolbar` and `BlockVerticalAlignmentToolbar`?

## How has this been tested?

Manual testing.

1. Add Social Block
2. Add some items.
3. Toggle the Justification.

## Screenshots <!-- if applicable -->

#### Editor
![Screen Capture on 2020-01-02 at 14-08-13](https://user-images.githubusercontent.com/444434/71670921-68b91f00-2d69-11ea-9afa-d8f4da23c0ef.gif)

#### Frontend

Note: I've contained the Block within a Group Block with a background to show the boundaries of the justification:

<img width="792" alt="Screen Shot 2020-01-02 at 14 40 57" src="https://user-images.githubusercontent.com/444434/71672469-f3038200-2d6d-11ea-84dc-1817c19af974.png">



## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
