### PR TITLE
Add URL preview to Link UI

### DIFF
--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -56,8 +56,8 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 	 * response.
 	 *
 	 * @access public
-	 * @param  WP_REST_REQUEST $request Full details about the request.
-	 * @return String|WP_Error          the title text or an error.
+	 * @param WP_REST_REQUEST $request Full details about the request.
+	 * @return String|WP_Error The title text or an error.
 	 */
 	public function get_title( $request ) {
 		$url   = $request->get_param( 'url' );
@@ -87,9 +87,9 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Retrieves the document title from a remote URL
+	 * Retrieves the document title from a remote URL.
 	 *
-	 * @param  String $url the website url whose HTML we want to access.
+	 * @param string $url The website url whose HTML we want to access.
 	 * @return string|WP_Error The URL's document title on success, WP_Error on failure.
 	 */
 	private function get_remote_url_title( $url ) {
@@ -97,12 +97,11 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 		$cache_key = 'g_url_details_response_' . hash( 'crc32b', $url );
 
 		// Attempt to retrieve cached response.
-		$title = null;//get_transient( $cache_key );
+		$title = get_transient( $cache_key );
 
 		if ( empty( $title ) ) {
 			$request                = wp_safe_remote_get( $url, array(
 				'timeout'             => 10,
-			//	'redirection'         => 0,
 				'limit_response_size' => 153600, // 150 KB
 			) );
 			$remote_source = wp_remote_retrieve_body( $request );

--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ *
+ *
+ * @package gutenberg
+ * @since 5.?.0
+ */
+
+/**
+ * Controller which provides REST endpoint for the widget areas.
+ *
+ * @since 5.?.0
+ *
+ * @see WP_REST_Controller
+ */
+class WP_REST_URL_Details_Controller extends WP_REST_Controller {
+
+	/**
+	 * Constructs the controller.
+	 *
+	 * @access public
+	 */
+	public function __construct() {
+		$this->namespace = '__experimental';
+		$this->rest_base = 'url-details';
+	}
+
+	/**
+	 * Registers the necessary REST API routes.
+	 *
+	 * @access public
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_remote_url' ),
+					// 'permission_callback' => array( $this, 'get_remote_url_permissions_check' ),
+				),
+				// 'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+
+	}
+
+	/**
+	 * Retrieves the comment's schema, conforming to JSON Schema.
+	 *
+	 * @since 6.1.0
+	 *
+	 * @return array
+	 */
+	public function get_item_schema() {
+		$schema = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'widget-area',
+			'type'       => 'object',
+			'properties' => array(
+				'id'      => array(
+					'description' => __( 'Unique identifier for the object.', 'gutenberg' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit', 'embed' ),
+					'readonly'    => true,
+				),
+				'content' => array(
+					'description' => __( 'The content for the object.', 'gutenberg' ),
+					'type'        => 'object',
+					'context'     => array( 'view', 'edit', 'embed' ),
+					'arg_options' => array(
+						'sanitize_callback' => null,
+						'validate_callback' => null,
+					),
+					'properties'  => array(
+						'raw'           => array(
+							'description' => __( 'Content for the object, as it exists in the database.', 'gutenberg' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit', 'embed' ),
+						),
+						'rendered'      => array(
+							'description' => __( 'HTML content for the object, transformed for display.', 'gutenberg' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit', 'embed' ),
+							'readonly'    => true,
+						),
+						'block_version' => array(
+							'description' => __( 'Version of the content block format used by the object.', 'gutenberg' ),
+							'type'        => 'integer',
+							'context'     => array( 'view', 'edit', 'embed' ),
+							'readonly'    => true,
+						),
+					),
+				),
+			),
+		);
+
+		return $schema;
+	}
+
+	/**
+	 * Checks whether a given request has permission to read widget areas.
+	 *
+	 * @since 5.7.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|bool True if the request has read access, WP_Error object otherwise.
+	 *
+	 * This function is overloading a function defined in WP_REST_Controller so it should have the same parameters.
+	 * phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+	 */
+	public function get_items_permissions_check( $request ) {
+		if ( ! current_user_can( 'edit_theme_options' ) ) {
+			return new WP_Error(
+				'rest_user_cannot_view',
+				__( 'Sorry, you are not allowed to read sidebars.', 'gutenberg' )
+			);
+		}
+
+		return true;
+	}
+	/* phpcs:enable */
+
+	/**
+	 * Retrieves all widget areas.
+	 *
+	 * @since 5.7.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|WP_REST_Response Response object on success, or WP_Error object on failure.
+	 */
+	public function get_remote_url( $request ) {
+
+		$data = [ 'hello-world' ];
+
+		return rest_ensure_response( $data );
+	}
+}

--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -69,13 +69,9 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 	/**
 	 * Checks whether a given request has permission to read remote urls.
 	 *
-	 * phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-	 *
-	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_Error|bool True if the request has access, WP_Error object otherwise.
 	 */
-	public function get_remote_url_permissions_check( $request ) {
-		/* phpcs:enable */
+	public function get_remote_url_permissions_check() {
 		if ( ! current_user_can( 'edit_posts' ) ) {
 			return new WP_Error(
 				'rest_user_cannot_view',
@@ -102,7 +98,7 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 		if ( empty( $title ) ) {
 			$request                = wp_safe_remote_get( $url, array(
 				'timeout'             => 10,
-				'limit_response_size' => 153600, // 150 KB
+				'limit_response_size' => 153600, // 150 KB.
 			) );
 			$remote_source = wp_remote_retrieve_body( $request );
 
@@ -110,13 +106,9 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 				return new WP_Error( 'no_response', __( 'The source URL does not exist.', 'gutenberg' ), array( 'status' => 404 ) );
 			}
 
-			// Work around bug in strip_tags():
-			$remote_source = str_replace( '<!DOC', '<DOC', $remote_source );
-			$remote_source = preg_replace( '/[\r\n\t ]+/', ' ', $remote_source ); // Normalize spaces.
-			$remote_source = preg_replace( '/<\/*(h1|h2|h3|h4|h5|h6|p|th|td|li|dt|dd|pre|caption|input|textarea|button|body)[^>]*>/', "\n\n", $remote_source );
-
 			preg_match( '|<title>([^<]*?)</title>|is', $remote_source, $match_title );
-			$title = isset( $match_title[1] ) ? $match_title[1] : '';
+			$title = isset( $match_title[1] ) ? trim( $match_title[1] ) : '';
+
 			if ( empty( $title ) ) {
 				return new WP_Error( 'no_title', __( 'No document title at remote url.', 'gutenberg' ), array( 'status' => 404 ) );
 			}

--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -7,7 +7,8 @@
  */
 
 /**
- * Controller which provides REST endpoint for the widget areas.
+ * Controller which provides REST endpoint for retrieving information
+ * from a remote site's HTML response.
  *
  * @since 5.?.0
  *
@@ -57,16 +58,22 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 
 
 
-
+	/**
+	 * Retrieves the contents of the <title> tag from the HTML
+	 * response.
+	 *
+	 * @access public
+	 * @param  WP_REST_REQUEST $request Full details about the request.
+	 * @return String|WP_Error          the title text or an error.
+	 */
 	public function get_title( $request ) {
 
-		// TODO: Sanitize and validate
 		$url = $request->get_param( 'url' );
 
 		$html_response = $this->get_remote_url_html( $url );
 
 		if ( is_wp_error( $html_response ) ) {
-			return new WP_Error( 'no_title', 'Unable to retrieve title tag. ' . $html_response->get_error_message(), array( 'status' => 404 ) );
+			return new WP_Error( 'no_title', __( 'Unable to retrieve title tag.', 'gutenberg' ) . $html_response->get_error_message(), array( 'status' => 404 ) );
 		}
 
 		$title_list = $html_response->getElementsByTagName( 'title' );
@@ -74,7 +81,7 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 		$title = $title_list->item( 0 );
 
 		if ( empty( $title ) ) {
-			return new WP_Error( 'no_title', 'No title tag at remote url.', array( 'status' => 404 ) );
+			return new WP_Error( 'no_title', __( 'No title tag at remote url.', 'gutenberg' ), array( 'status' => 404 ) );
 		}
 
 		$title_text = $title->nodeValue;
@@ -82,18 +89,28 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 		return rest_ensure_response( $title_text );
 	}
 
+	/**
+	 * Validates a given URL
+	 *
+	 * @param  String $url the url to validate
+	 * @return Boolean      whether or not the URL is considered valid.
+	 */
 	public function validate_url( $url ) {
 		return wp_http_validate_url( $url );
 	}
 
+	/**
+	 * Sanitizes a given URL.
+	 *
+	 * @param  String $url the URL to sanitize.
+	 * @return String      the sanitized version of the URL.
+	 */
 	public function sanitize_url( $url ) {
 		return esc_url_raw( $url );
 	}
 
 	/**
 	 * Checks whether a given request has permission to read remote urls.
-	 *
-	 * @since 5.7.0
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_Error|bool True if the request has access, WP_Error object otherwise.
@@ -117,17 +134,24 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 	/* phpcs:enable */
 
 
+	/**
+	 * Retrives a DOMDocument representation of the
+	 * HTML from a remote URL
+	 *
+	 * @param  String $url the website url whose HTML we want to access.
+	 * @return DOMDocument      the loaded HTML response.
+	 */
 	private function get_remote_url_html( $url ) {
 
 		$response = wp_remote_get( $url );
 
 		if ( is_wp_error( $response ) || ! is_array( $response ) ) {
-			return new WP_Error( 'no_response', 'Unable to contact remote url . ' . $response->get_error_message(), array( 'status' => 404 ) );
+			return new WP_Error( 'no_response', __( 'Unable to contact remote url.', 'gutenberg' ) . $response->get_error_message(), array( 'status' => 404 ) );
 		}
 
 		$body = wp_remote_retrieve_body( $response );
 
-		$dom = new DOMDocument( '1.0', 'UTF - 8' );
+		$dom = new DOMDocument( '1.0', 'UTF-8' );
 
 		// set error level
 		$internalErrors = libxml_use_internal_errors( true );

--- a/lib/load.php
+++ b/lib/load.php
@@ -43,6 +43,11 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	* End: Include for phase 2
 	*/
 
+	if ( ! class_exists( 'WP_REST_URL_Details_Controller' ) ) {
+		require dirname( __FILE__ ) . '/class-wp-rest-url-details-controller.php';
+	}
+
+
 	require dirname( __FILE__ ) . '/rest-api.php';
 }
 

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -55,6 +55,17 @@ add_filter( 'rest_request_after_callbacks', 'gutenberg_filter_oembed_result', 10
 
 
 /**
+ * Registers the REST API routes for URL Details.
+ *
+ * @since 5.0.0
+ */
+function gutenberg_register_url_details_routes() {
+	$url_details_controller = new WP_REST_URL_Details_Controller();
+	$url_details_controller->register_routes();
+}
+add_action( 'rest_api_init', 'gutenberg_register_url_details_routes' );
+
+/**
  * Start: Include for phase 2
  */
 /**

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -112,7 +112,7 @@ function LinkControl( {
 		setInputValue( '' );
 	};
 
-	const handleDirectEntry = async ( value ) => {
+	const handleDirectEntry = async ( value, { fetchUrlInfo = true } = {} ) => {
 		let type = 'URL';
 
 		const protocol = getProtocol( value ) || '';
@@ -140,7 +140,7 @@ function LinkControl( {
 		// Todo:
 		// * avoid invalid requests for incomplete URLS
 		// * avoid concurrent requests - cancel existing AJAX requests if already pending
-		if ( type === 'URL' && isURL( prependHTTP( value ) ) ) {
+		if ( fetchUrlInfo && type === 'URL' && isURL( prependHTTP( value ) ) && value.length > 3 ) {
 			try {
 				const urlTitle = await fetchRemoteURLTitle( value );
 				return [ {
@@ -156,12 +156,14 @@ function LinkControl( {
 	};
 
 	const handleEntitySearch = async ( value ) => {
+		const couldBeURL = ! value.includes( ' ' );
+
 		const results = await Promise.all( [
 			fetchSearchSuggestions( value ),
-			handleDirectEntry( value ),
+			handleDirectEntry( value, {
+				fetchUrlInfo: couldBeURL,
+			} ),
 		] );
-
-		const couldBeURL = ! value.includes( ' ' );
 
 		// If it's potentially a URL search then concat on a URL search suggestion
 		// just for good measure. That way once the actual results run out we always

--- a/packages/block-editor/src/components/link-control/search-item.js
+++ b/packages/block-editor/src/components/link-control/search-item.js
@@ -36,7 +36,7 @@ export const LinkControlSearchItem = ( { itemProps, suggestion, isSelected = fal
 				<span aria-hidden={ ! isURL } className="block-editor-link-control__search-item-info">
 					{ ! isURL && ( safeDecodeURI( suggestion.url ) || '' ) }
 					{ isURL && (
-						__( 'Press ENTER to add this link' )
+						`${ safeDecodeURI( suggestion.url ) } - ${ __( 'press ENTER to add this link' ) }`
 					) }
 				</span>
 			</span>

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -14,7 +14,7 @@ import { __ } from '@wordpress/i18n';
 import { EntityProvider } from '@wordpress/core-data';
 import { BlockEditorProvider, transformStyles } from '@wordpress/block-editor';
 import apiFetch from '@wordpress/api-fetch';
-import { addQueryArgs } from '@wordpress/url';
+import { addQueryArgs, prependHTTP } from '@wordpress/url';
 import { decodeEntities } from '@wordpress/html-entities';
 
 /**
@@ -40,6 +40,18 @@ const fetchLinkSuggestions = async ( search ) => {
 		title: decodeEntities( post.title ) || __( '(no title)' ),
 		type: post.subtype || post.type,
 	} ) );
+};
+
+const fetchRemoteURLTitle = async ( url ) => {
+	const endpoint = '/__experimental/url-details/title';
+
+	const args = {
+		url: prependHTTP( url ),
+	};
+
+	return apiFetch( {
+		path: addQueryArgs( endpoint, args ),
+	} );
 };
 
 class EditorProvider extends Component {
@@ -118,6 +130,7 @@ class EditorProvider extends Component {
 			__experimentalFetchReusableBlocks,
 			__experimentalFetchLinkSuggestions: fetchLinkSuggestions,
 			__experimentalCanUserUseUnfilteredHTML: canUserUseUnfilteredHTML,
+			__experimentalFetchRemoteURLTitle: fetchRemoteURLTitle,
 		};
 	}
 


### PR DESCRIPTION
<img width="576" alt="Screen Shot 2020-01-02 at 15 45 34" src="https://user-images.githubusercontent.com/444434/71675964-ef282d80-2d76-11ea-86ab-1c273e1d9861.png">

## Description
Builds on https://github.com/WordPress/gutenberg/pull/18042. When using the `LinkControl` component to search for a URL, this PR utilises a new REST API endpoint to display the contents of the`<title>` tag of the remote site in the search results.

This is largely a POC and will need a lot of UX and Design thought (not to mention technical refinement) before it's ready to go.

This relies on https://github.com/WordPress/gutenberg/pull/18042 being merged.


## How has this been tested?

Manual testing.

## Screenshots <!-- if applicable -->

![Screen Capture on 2020-01-02 at 15-42-30](https://user-images.githubusercontent.com/444434/71675919-d6b81300-2d76-11ea-8c1a-9f3642ab0551.gif)



## Types of changes
New feature (non-breaking change which adds functionality) 

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
