### PR TITLE
Remove unused is-hovered class

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -125,59 +125,6 @@ function BlockListBlock( {
 
 	const breadcrumb = useRef();
 
-	// Keep track of touchstart to disable hover on iOS
-	const hadTouchStart = useRef( false );
-	const onTouchStart = () => {
-		hadTouchStart.current = true;
-	};
-	const onTouchStop = () => {
-		// Clear touchstart detection
-		// Browser will try to emulate mouse events also see https://www.html5rocks.com/en/mobile/touchandmouse/
-		hadTouchStart.current = false;
-	};
-
-	// Handling isHovered
-	const [ isBlockHovered, setBlockHoveredState ] = useState( false );
-
-	/**
-	 * Sets the block state as unhovered if currently hovering. There are cases
-	 * where mouseleave may occur but the block is not hovered (multi-select),
-	 * so to avoid unnecesary renders, the state is only set if hovered.
-	 */
-	const hideHoverEffects = () => {
-		if ( isBlockHovered ) {
-			setBlockHoveredState( false );
-		}
-	};
-	/**
-	 * A mouseover event handler to apply hover effect when a pointer device is
-	 * placed within the bounds of the block. The mouseover event is preferred
-	 * over mouseenter because it may be the case that a previous mouseenter
-	 * event was blocked from being handled by a IgnoreNestedEvents component,
-	 * therefore transitioning out of a nested block to the bounds of the block
-	 * would otherwise not trigger a hover effect.
-	 *
-	 * @see https://developer.mozilla.org/en-US/docs/Web/Events/mouseenter
-	 */
-	const maybeHover = () => {
-		if (
-			isBlockHovered ||
-			isPartOfMultiSelection ||
-			isSelected ||
-			hadTouchStart.current
-		) {
-			return;
-		}
-		setBlockHoveredState( true );
-	};
-
-	// Set hover to false once we start typing or select the block.
-	useEffect( () => {
-		if ( isTypingWithinBlock || isSelected ) {
-			hideHoverEffects();
-		}
-	} );
-
 	// Handling the error state
 	const [ hasError, setErrorState ] = useState( false );
 	const onBlockError = () => setErrorState( true );
@@ -389,8 +336,6 @@ function BlockListBlock( {
 		if ( isSelected && ( buttons || which ) === 1 ) {
 			onSelectionStart( clientId );
 		}
-
-		hideHoverEffects();
 	};
 
 	const selectOnOpen = ( open ) => {
@@ -413,7 +358,6 @@ function BlockListBlock( {
 	);
 
 	// Rendering the output
-	const isHovered = isBlockHovered && ! isPartOfMultiSelection;
 	const blockType = getBlockType( name );
 	// translators: %s: Type of block (i.e. Text, Image etc)
 	const blockLabel = sprintf( __( 'Block: %s' ), blockType.title );
@@ -424,17 +368,12 @@ function BlockListBlock( {
 
 	// If the block is selected and we're typing the block should not appear.
 	// Empty paragraph blocks should always show up as unselected.
-	const showEmptyBlockSideInserter = ! isNavigationMode && ( isSelected || isHovered || isLast ) && isEmptyDefaultBlock && isValid;
+	const showEmptyBlockSideInserter = ! isNavigationMode && ( isSelected || isLast ) && isEmptyDefaultBlock && isValid;
 	const shouldAppearSelected =
 		! isFocusMode &&
 		! showEmptyBlockSideInserter &&
 		isSelected &&
 		! isTypingWithinBlock;
-	const shouldAppearHovered =
-		! isFocusMode &&
-		! hasFixedToolbar &&
-		isHovered &&
-		! isEmptyDefaultBlock;
 	const shouldShowBreadcrumb = isNavigationMode && isSelected;
 	const shouldShowContextualToolbar =
 		! isNavigationMode &&
@@ -467,7 +406,6 @@ function BlockListBlock( {
 			'is-selected': shouldAppearSelected && hasSelectedUI,
 			'is-navigate-mode': isNavigationMode,
 			'is-multi-selected': isMultiSelected,
-			'is-hovered': shouldAppearHovered,
 			'is-reusable': isReusableBlock( blockType ),
 			'is-dragging': isDragging,
 			'is-typing': isTypingWithinBlock,
@@ -534,14 +472,9 @@ function BlockListBlock( {
 		<IgnoreNestedEvents
 			id={ blockElementId }
 			ref={ wrapper }
-			onMouseOver={ maybeHover }
-			onMouseOverHandled={ hideHoverEffects }
-			onMouseLeave={ hideHoverEffects }
 			className={ wrapperClassName }
 			data-type={ name }
-			onTouchStart={ onTouchStart }
 			onFocus={ onFocus }
-			onClick={ onTouchStop }
 			onKeyDown={ onKeyDown }
 			tabIndex="0"
 			aria-label={ blockLabel }

--- a/packages/block-editor/src/components/ignore-nested-events/test/index.js
+++ b/packages/block-editor/src/components/ignore-nested-events/test/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { mount } from 'enzyme';
+import { shallow } from 'enzyme';
 
 /**
  * Internal dependencies
@@ -10,24 +10,24 @@ import { IgnoreNestedEvents } from '../';
 
 describe( 'IgnoreNestedEvents', () => {
 	it( 'passes props to its rendered div', () => {
-		const wrapper = mount(
+		const wrapper = shallow(
 			<IgnoreNestedEvents className="foo" />
 		);
 
-		expect( wrapper.find( 'div' ) ).toHaveLength( 1 );
+		expect( wrapper.type() ).toBe( 'div' );
 		expect( wrapper.prop( 'className' ) ).toBe( 'foo' );
 	} );
 
 	it( 'stops propagation of events to ancestor IgnoreNestedEvents', () => {
 		const spyOuter = jest.fn();
 		const spyInner = jest.fn();
-		const wrapper = mount(
+		const wrapper = shallow(
 			<IgnoreNestedEvents onClick={ spyOuter }>
 				<IgnoreNestedEvents onClick={ spyInner } />
 			</IgnoreNestedEvents>
 		);
 
-		wrapper.find( 'div' ).last().simulate( 'click' );
+		wrapper.childAt( 0 ).simulate( 'click' );
 
 		expect( spyInner ).toHaveBeenCalled();
 		expect( spyOuter ).not.toHaveBeenCalled();
@@ -36,7 +36,7 @@ describe( 'IgnoreNestedEvents', () => {
 	it( 'stops propagation of child handled events', () => {
 		const spyOuter = jest.fn();
 		const spyInner = jest.fn();
-		const wrapper = mount(
+		const wrapper = shallow(
 			<IgnoreNestedEvents onClick={ spyOuter }>
 				<IgnoreNestedEvents childHandledEvents={ [ 'onClick' ] }>
 					<div />
@@ -50,24 +50,5 @@ describe( 'IgnoreNestedEvents', () => {
 
 		expect( spyInner ).not.toHaveBeenCalled();
 		expect( spyOuter ).not.toHaveBeenCalled();
-	} );
-
-	it( 'invokes callback of Handled-suffixed prop if handled', () => {
-		const spyOuter = jest.fn();
-		const spyInner = jest.fn();
-		const wrapper = mount(
-			<IgnoreNestedEvents onClickHandled={ spyOuter }>
-				<IgnoreNestedEvents childHandledEvents={ [ 'onClick' ] }>
-					<div />
-					<IgnoreNestedEvents onClick={ spyInner } />
-				</IgnoreNestedEvents>
-			</IgnoreNestedEvents>
-		);
-
-		const div = wrapper.childAt( 0 ).childAt( 0 );
-		div.simulate( 'click' );
-
-		expect( spyInner ).not.toHaveBeenCalled();
-		expect( spyOuter ).toHaveBeenCalled();
 	} );
 } );


### PR DESCRIPTION
## Description

This PR removed the `is-hovered` class on blocks when hovering over them. The styles had been removed in #18862.

It also removes the hover state in the block, which is only used for one thing: showing the side block inserter when the default block is empty. I would suggest to either:
* Only show it when the block is selected or last (as before, just not on hover).
* Show it all the time.

I chose the first option, but I don't mind changing it.

> One aspect of removing the hover effect is that it is intrinsically a desktop affordance, and one that is very much biased towards sighted users. Removing it might help us rely on other affordances that are more cross-platform and potentially, accessible.

-- @jasmussen 

It's also worth noting that this removes a number of event handlers that are added to every single block.

Also reverts 0d0c8e0 (from #5658) because this is no longer needed.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
