### PR TITLE
Chore: Update the lock file to hoist dependencies of local packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2352,33 +2352,684 @@
 			}
 		},
 		"@jest/reporters": {
-			"version": "24.7.1",
-			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-24.7.1.tgz",
-			"integrity": "sha512-bO+WYNwHLNhrjB9EbPL4kX/mCCG4ZhhfWmO3m4FSpbgr7N83MFejayz30kKjgqr7smLyeaRFCBQMbXpUgnhAJw==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-24.9.0.tgz",
+			"integrity": "sha512-mu4X0yjaHrffOsWmVLzitKmmmWSQ3GGuefgNscUSWNiUNcEOSEQk9k3pERKEQVBb0Cnn88+UESIsZEMH3o88Gw==",
 			"dev": true,
 			"requires": {
-				"@jest/environment": "^24.7.1",
-				"@jest/test-result": "^24.7.1",
-				"@jest/transform": "^24.7.1",
-				"@jest/types": "^24.7.0",
+				"@jest/environment": "^24.9.0",
+				"@jest/test-result": "^24.9.0",
+				"@jest/transform": "^24.9.0",
+				"@jest/types": "^24.9.0",
 				"chalk": "^2.0.1",
 				"exit": "^0.1.2",
 				"glob": "^7.1.2",
-				"istanbul-api": "^2.1.1",
 				"istanbul-lib-coverage": "^2.0.2",
 				"istanbul-lib-instrument": "^3.0.1",
+				"istanbul-lib-report": "^2.0.4",
 				"istanbul-lib-source-maps": "^3.0.1",
-				"jest-haste-map": "^24.7.1",
-				"jest-resolve": "^24.7.1",
-				"jest-runtime": "^24.7.1",
-				"jest-util": "^24.7.1",
+				"istanbul-reports": "^2.2.6",
+				"jest-haste-map": "^24.9.0",
+				"jest-resolve": "^24.9.0",
+				"jest-runtime": "^24.9.0",
+				"jest-util": "^24.9.0",
 				"jest-worker": "^24.6.0",
-				"node-notifier": "^5.2.1",
+				"node-notifier": "^5.4.2",
 				"slash": "^2.0.0",
 				"source-map": "^0.6.0",
 				"string-length": "^2.0.0"
 			},
 			"dependencies": {
+				"@jest/console": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/@jest/console/-/console-24.9.0.tgz",
+					"integrity": "sha512-Zuj6b8TnKXi3q4ymac8EQfc3ea/uhLeCGThFqXeC8H9/raaH8ARPUTdId+XyGd03Z4In0/VjD2OYFcBF09fNLQ==",
+					"dev": true,
+					"requires": {
+						"@jest/source-map": "^24.9.0",
+						"chalk": "^2.0.1",
+						"slash": "^2.0.0"
+					}
+				},
+				"@jest/environment": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-24.9.0.tgz",
+					"integrity": "sha512-5A1QluTPhvdIPFYnO3sZC3smkNeXPVELz7ikPbhUj0bQjB07EoE9qtLrem14ZUYWdVayYbsjVwIiL4WBIMV4aQ==",
+					"dev": true,
+					"requires": {
+						"@jest/fake-timers": "^24.9.0",
+						"@jest/transform": "^24.9.0",
+						"@jest/types": "^24.9.0",
+						"jest-mock": "^24.9.0"
+					}
+				},
+				"@jest/fake-timers": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-24.9.0.tgz",
+					"integrity": "sha512-eWQcNa2YSwzXWIMC5KufBh3oWRIijrQFROsIqt6v/NS9Io/gknw1jsAC9c+ih/RQX4A3O7SeWAhQeN0goKhT9A==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^24.9.0",
+						"jest-message-util": "^24.9.0",
+						"jest-mock": "^24.9.0"
+					}
+				},
+				"@jest/source-map": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-24.9.0.tgz",
+					"integrity": "sha512-/Xw7xGlsZb4MJzNDgB7PW5crou5JqWiBQaz6xyPd3ArOg2nfn/PunV8+olXbbEZzNl591o5rWKE9BRDaFAuIBg==",
+					"dev": true,
+					"requires": {
+						"callsites": "^3.0.0",
+						"graceful-fs": "^4.1.15",
+						"source-map": "^0.6.0"
+					}
+				},
+				"@jest/test-result": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-24.9.0.tgz",
+					"integrity": "sha512-XEFrHbBonBJ8dGp2JmF8kP/nQI/ImPpygKHwQ/SY+es59Z3L5PI4Qb9TQQMAEeYsThG1xF0k6tmG0tIKATNiiA==",
+					"dev": true,
+					"requires": {
+						"@jest/console": "^24.9.0",
+						"@jest/types": "^24.9.0",
+						"@types/istanbul-lib-coverage": "^2.0.0"
+					}
+				},
+				"@jest/test-sequencer": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-24.9.0.tgz",
+					"integrity": "sha512-6qqsU4o0kW1dvA95qfNog8v8gkRN9ph6Lz7r96IvZpHdNipP2cBcb07J1Z45mz/VIS01OHJ3pY8T5fUY38tg4A==",
+					"dev": true,
+					"requires": {
+						"@jest/test-result": "^24.9.0",
+						"jest-haste-map": "^24.9.0",
+						"jest-runner": "^24.9.0",
+						"jest-runtime": "^24.9.0"
+					}
+				},
+				"@jest/transform": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-24.9.0.tgz",
+					"integrity": "sha512-TcQUmyNRxV94S0QpMOnZl0++6RMiqpbH/ZMccFB/amku6Uwvyb1cjYX7xkp5nGNkbX4QPH/FcB6q1HBTHynLmQ==",
+					"dev": true,
+					"requires": {
+						"@babel/core": "^7.1.0",
+						"@jest/types": "^24.9.0",
+						"babel-plugin-istanbul": "^5.1.0",
+						"chalk": "^2.0.1",
+						"convert-source-map": "^1.4.0",
+						"fast-json-stable-stringify": "^2.0.0",
+						"graceful-fs": "^4.1.15",
+						"jest-haste-map": "^24.9.0",
+						"jest-regex-util": "^24.9.0",
+						"jest-util": "^24.9.0",
+						"micromatch": "^3.1.10",
+						"pirates": "^4.0.1",
+						"realpath-native": "^1.1.0",
+						"slash": "^2.0.0",
+						"source-map": "^0.6.1",
+						"write-file-atomic": "2.4.1"
+					}
+				},
+				"@jest/types": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-24.9.0.tgz",
+					"integrity": "sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^1.1.1",
+						"@types/yargs": "^13.0.0"
+					}
+				},
+				"@types/yargs": {
+					"version": "13.0.4",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.4.tgz",
+					"integrity": "sha512-Ke1WmBbIkVM8bpvsNEcGgQM70XcEh/nbpxQhW7FhrsbCsXSY9BmLB1+LHtD7r9zrsOcFlLiF+a/UeJsdfw3C5A==",
+					"dev": true,
+					"requires": {
+						"@types/yargs-parser": "*"
+					}
+				},
+				"ansi-regex": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+					"dev": true
+				},
+				"babel-jest": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-24.9.0.tgz",
+					"integrity": "sha512-ntuddfyiN+EhMw58PTNL1ph4C9rECiQXjI4nMMBKBaNjXvqLdkXpPRcMSr4iyBrJg/+wz9brFUD6RhOAT6r4Iw==",
+					"dev": true,
+					"requires": {
+						"@jest/transform": "^24.9.0",
+						"@jest/types": "^24.9.0",
+						"@types/babel__core": "^7.1.0",
+						"babel-plugin-istanbul": "^5.1.0",
+						"babel-preset-jest": "^24.9.0",
+						"chalk": "^2.4.2",
+						"slash": "^2.0.0"
+					}
+				},
+				"babel-plugin-jest-hoist": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.9.0.tgz",
+					"integrity": "sha512-2EMA2P8Vp7lG0RAzr4HXqtYwacfMErOuv1U3wrvxHX6rD1sV6xS3WXG3r8TRQ2r6w8OhvSdWt+z41hQNwNm3Xw==",
+					"dev": true,
+					"requires": {
+						"@types/babel__traverse": "^7.0.6"
+					}
+				},
+				"babel-preset-jest": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-24.9.0.tgz",
+					"integrity": "sha512-izTUuhE4TMfTRPF92fFwD2QfdXaZW08qvWTFCI51V8rW5x00UuPgc3ajRoWofXOuxjfcOM5zzSYsQS3H8KGCAg==",
+					"dev": true,
+					"requires": {
+						"@babel/plugin-syntax-object-rest-spread": "^7.0.0",
+						"babel-plugin-jest-hoist": "^24.9.0"
+					}
+				},
+				"camelcase": {
+					"version": "5.3.1",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+					"dev": true
+				},
+				"cliui": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+					"integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+					"dev": true,
+					"requires": {
+						"string-width": "^3.1.0",
+						"strip-ansi": "^5.2.0",
+						"wrap-ansi": "^5.1.0"
+					}
+				},
+				"diff-sequences": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-24.9.0.tgz",
+					"integrity": "sha512-Dj6Wk3tWyTE+Fo1rW8v0Xhwk80um6yFYKbuAxc9c3EZxIHFDYwbi34Uk42u1CdnIiVorvt4RmlSDjIPyzGC2ew==",
+					"dev": true
+				},
+				"expect": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/expect/-/expect-24.9.0.tgz",
+					"integrity": "sha512-wvVAx8XIol3Z5m9zvZXiyZOQ+sRJqNTIm6sGjdWlaZIeupQGO3WbYI+15D/AmEwZywL6wtJkbAbJtzkOfBuR0Q==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^24.9.0",
+						"ansi-styles": "^3.2.0",
+						"jest-get-type": "^24.9.0",
+						"jest-matcher-utils": "^24.9.0",
+						"jest-message-util": "^24.9.0",
+						"jest-regex-util": "^24.9.0"
+					}
+				},
+				"find-up": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^3.0.0"
+					}
+				},
+				"get-caller-file": {
+					"version": "2.0.5",
+					"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+					"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+					"dev": true
+				},
+				"graceful-fs": {
+					"version": "4.2.3",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+					"integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
+					"dev": true
+				},
+				"istanbul-reports": {
+					"version": "2.2.6",
+					"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.6.tgz",
+					"integrity": "sha512-SKi4rnMyLBKe0Jy2uUdx28h8oG7ph2PPuQPvIAh31d+Ci+lSiEu4C+h3oBPuJ9+mPKhOyW0M8gY4U5NM1WLeXA==",
+					"dev": true,
+					"requires": {
+						"handlebars": "^4.1.2"
+					}
+				},
+				"jest-config": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-24.9.0.tgz",
+					"integrity": "sha512-RATtQJtVYQrp7fvWg6f5y3pEFj9I+H8sWw4aKxnDZ96mob5i5SD6ZEGWgMLXQ4LE8UurrjbdlLWdUeo+28QpfQ==",
+					"dev": true,
+					"requires": {
+						"@babel/core": "^7.1.0",
+						"@jest/test-sequencer": "^24.9.0",
+						"@jest/types": "^24.9.0",
+						"babel-jest": "^24.9.0",
+						"chalk": "^2.0.1",
+						"glob": "^7.1.1",
+						"jest-environment-jsdom": "^24.9.0",
+						"jest-environment-node": "^24.9.0",
+						"jest-get-type": "^24.9.0",
+						"jest-jasmine2": "^24.9.0",
+						"jest-regex-util": "^24.3.0",
+						"jest-resolve": "^24.9.0",
+						"jest-util": "^24.9.0",
+						"jest-validate": "^24.9.0",
+						"micromatch": "^3.1.10",
+						"pretty-format": "^24.9.0",
+						"realpath-native": "^1.1.0"
+					}
+				},
+				"jest-diff": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.9.0.tgz",
+					"integrity": "sha512-qMfrTs8AdJE2iqrTp0hzh7kTd2PQWrsFyj9tORoKmu32xjPjeE4NyjVRDz8ybYwqS2ik8N4hsIpiVTyFeo2lBQ==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.1",
+						"diff-sequences": "^24.9.0",
+						"jest-get-type": "^24.9.0",
+						"pretty-format": "^24.9.0"
+					}
+				},
+				"jest-each": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-24.9.0.tgz",
+					"integrity": "sha512-ONi0R4BvW45cw8s2Lrx8YgbeXL1oCQ/wIDwmsM3CqM/nlblNCPmnC3IPQlMbRFZu3wKdQ2U8BqM6lh3LJ5Bsog==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^24.9.0",
+						"chalk": "^2.0.1",
+						"jest-get-type": "^24.9.0",
+						"jest-util": "^24.9.0",
+						"pretty-format": "^24.9.0"
+					}
+				},
+				"jest-environment-jsdom": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-24.9.0.tgz",
+					"integrity": "sha512-Zv9FV9NBRzLuALXjvRijO2351DRQeLYXtpD4xNvfoVFw21IOKNhZAEUKcbiEtjTkm2GsJ3boMVgkaR7rN8qetA==",
+					"dev": true,
+					"requires": {
+						"@jest/environment": "^24.9.0",
+						"@jest/fake-timers": "^24.9.0",
+						"@jest/types": "^24.9.0",
+						"jest-mock": "^24.9.0",
+						"jest-util": "^24.9.0",
+						"jsdom": "^11.5.1"
+					}
+				},
+				"jest-environment-node": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-24.9.0.tgz",
+					"integrity": "sha512-6d4V2f4nxzIzwendo27Tr0aFm+IXWa0XEUnaH6nU0FMaozxovt+sfRvh4J47wL1OvF83I3SSTu0XK+i4Bqe7uA==",
+					"dev": true,
+					"requires": {
+						"@jest/environment": "^24.9.0",
+						"@jest/fake-timers": "^24.9.0",
+						"@jest/types": "^24.9.0",
+						"jest-mock": "^24.9.0",
+						"jest-util": "^24.9.0"
+					}
+				},
+				"jest-get-type": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.9.0.tgz",
+					"integrity": "sha512-lUseMzAley4LhIcpSP9Jf+fTrQ4a1yHQwLNeeVa2cEmbCGeoZAtYPOIv8JaxLD/sUpKxetKGP+gsHl8f8TSj8Q==",
+					"dev": true
+				},
+				"jest-haste-map": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.9.0.tgz",
+					"integrity": "sha512-kfVFmsuWui2Sj1Rp1AJ4D9HqJwE4uwTlS/vO+eRUaMmd54BFpli2XhMQnPC2k4cHFVbB2Q2C+jtI1AGLgEnCjQ==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^24.9.0",
+						"anymatch": "^2.0.0",
+						"fb-watchman": "^2.0.0",
+						"fsevents": "^1.2.7",
+						"graceful-fs": "^4.1.15",
+						"invariant": "^2.2.4",
+						"jest-serializer": "^24.9.0",
+						"jest-util": "^24.9.0",
+						"jest-worker": "^24.9.0",
+						"micromatch": "^3.1.10",
+						"sane": "^4.0.3",
+						"walker": "^1.0.7"
+					},
+					"dependencies": {
+						"jest-worker": {
+							"version": "24.9.0",
+							"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.9.0.tgz",
+							"integrity": "sha512-51PE4haMSXcHohnSMdM42anbvZANYTqMrr52tVKPqqsPJMzoP6FYYDVqahX/HrAoKEKz3uUPzSvKs9A3qR4iVw==",
+							"dev": true,
+							"requires": {
+								"merge-stream": "^2.0.0",
+								"supports-color": "^6.1.0"
+							}
+						}
+					}
+				},
+				"jest-jasmine2": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-24.9.0.tgz",
+					"integrity": "sha512-Cq7vkAgaYKp+PsX+2/JbTarrk0DmNhsEtqBXNwUHkdlbrTBLtMJINADf2mf5FkowNsq8evbPc07/qFO0AdKTzw==",
+					"dev": true,
+					"requires": {
+						"@babel/traverse": "^7.1.0",
+						"@jest/environment": "^24.9.0",
+						"@jest/test-result": "^24.9.0",
+						"@jest/types": "^24.9.0",
+						"chalk": "^2.0.1",
+						"co": "^4.6.0",
+						"expect": "^24.9.0",
+						"is-generator-fn": "^2.0.0",
+						"jest-each": "^24.9.0",
+						"jest-matcher-utils": "^24.9.0",
+						"jest-message-util": "^24.9.0",
+						"jest-runtime": "^24.9.0",
+						"jest-snapshot": "^24.9.0",
+						"jest-util": "^24.9.0",
+						"pretty-format": "^24.9.0",
+						"throat": "^4.0.0"
+					}
+				},
+				"jest-leak-detector": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-24.9.0.tgz",
+					"integrity": "sha512-tYkFIDsiKTGwb2FG1w8hX9V0aUb2ot8zY/2nFg087dUageonw1zrLMP4W6zsRO59dPkTSKie+D4rhMuP9nRmrA==",
+					"dev": true,
+					"requires": {
+						"jest-get-type": "^24.9.0",
+						"pretty-format": "^24.9.0"
+					}
+				},
+				"jest-matcher-utils": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.9.0.tgz",
+					"integrity": "sha512-OZz2IXsu6eaiMAwe67c1T+5tUAtQyQx27/EMEkbFAGiw52tB9em+uGbzpcgYVpA8wl0hlxKPZxrly4CXU/GjHA==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.1",
+						"jest-diff": "^24.9.0",
+						"jest-get-type": "^24.9.0",
+						"pretty-format": "^24.9.0"
+					}
+				},
+				"jest-message-util": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-24.9.0.tgz",
+					"integrity": "sha512-oCj8FiZ3U0hTP4aSui87P4L4jC37BtQwUMqk+zk/b11FR19BJDeZsZAvIHutWnmtw7r85UmR3CEWZ0HWU2mAlw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@jest/test-result": "^24.9.0",
+						"@jest/types": "^24.9.0",
+						"@types/stack-utils": "^1.0.1",
+						"chalk": "^2.0.1",
+						"micromatch": "^3.1.10",
+						"slash": "^2.0.0",
+						"stack-utils": "^1.0.1"
+					}
+				},
+				"jest-mock": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-24.9.0.tgz",
+					"integrity": "sha512-3BEYN5WbSq9wd+SyLDES7AHnjH9A/ROBwmz7l2y+ol+NtSFO8DYiEBzoO1CeFc9a8DYy10EO4dDFVv/wN3zl1w==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^24.9.0"
+					}
+				},
+				"jest-regex-util": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-24.9.0.tgz",
+					"integrity": "sha512-05Cmb6CuxaA+Ys6fjr3PhvV3bGQmO+2p2La4hFbU+W5uOc479f7FdLXUWXw4pYMAhhSZIuKHwSXSu6CsSBAXQA==",
+					"dev": true
+				},
+				"jest-resolve": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-24.9.0.tgz",
+					"integrity": "sha512-TaLeLVL1l08YFZAt3zaPtjiVvyy4oSA6CRe+0AFPPVX3Q/VI0giIWWoAvoS5L96vj9Dqxj4fB5p2qrHCmTU/MQ==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^24.9.0",
+						"browser-resolve": "^1.11.3",
+						"chalk": "^2.0.1",
+						"jest-pnp-resolver": "^1.2.1",
+						"realpath-native": "^1.1.0"
+					}
+				},
+				"jest-runner": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-24.9.0.tgz",
+					"integrity": "sha512-KksJQyI3/0mhcfspnxxEOBueGrd5E4vV7ADQLT9ESaCzz02WnbdbKWIf5Mkaucoaj7obQckYPVX6JJhgUcoWWg==",
+					"dev": true,
+					"requires": {
+						"@jest/console": "^24.7.1",
+						"@jest/environment": "^24.9.0",
+						"@jest/test-result": "^24.9.0",
+						"@jest/types": "^24.9.0",
+						"chalk": "^2.4.2",
+						"exit": "^0.1.2",
+						"graceful-fs": "^4.1.15",
+						"jest-config": "^24.9.0",
+						"jest-docblock": "^24.3.0",
+						"jest-haste-map": "^24.9.0",
+						"jest-jasmine2": "^24.9.0",
+						"jest-leak-detector": "^24.9.0",
+						"jest-message-util": "^24.9.0",
+						"jest-resolve": "^24.9.0",
+						"jest-runtime": "^24.9.0",
+						"jest-util": "^24.9.0",
+						"jest-worker": "^24.6.0",
+						"source-map-support": "^0.5.6",
+						"throat": "^4.0.0"
+					}
+				},
+				"jest-runtime": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-24.9.0.tgz",
+					"integrity": "sha512-8oNqgnmF3v2J6PVRM2Jfuj8oX3syKmaynlDMMKQ4iyzbQzIG6th5ub/lM2bCMTmoTKM3ykcUYI2Pw9xwNtjMnw==",
+					"dev": true,
+					"requires": {
+						"@jest/console": "^24.7.1",
+						"@jest/environment": "^24.9.0",
+						"@jest/source-map": "^24.3.0",
+						"@jest/transform": "^24.9.0",
+						"@jest/types": "^24.9.0",
+						"@types/yargs": "^13.0.0",
+						"chalk": "^2.0.1",
+						"exit": "^0.1.2",
+						"glob": "^7.1.3",
+						"graceful-fs": "^4.1.15",
+						"jest-config": "^24.9.0",
+						"jest-haste-map": "^24.9.0",
+						"jest-message-util": "^24.9.0",
+						"jest-mock": "^24.9.0",
+						"jest-regex-util": "^24.3.0",
+						"jest-resolve": "^24.9.0",
+						"jest-snapshot": "^24.9.0",
+						"jest-util": "^24.9.0",
+						"jest-validate": "^24.9.0",
+						"realpath-native": "^1.1.0",
+						"slash": "^2.0.0",
+						"strip-bom": "^3.0.0",
+						"yargs": "^13.3.0"
+					},
+					"dependencies": {
+						"glob": {
+							"version": "7.1.6",
+							"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+							"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+							"dev": true,
+							"requires": {
+								"fs.realpath": "^1.0.0",
+								"inflight": "^1.0.4",
+								"inherits": "2",
+								"minimatch": "^3.0.4",
+								"once": "^1.3.0",
+								"path-is-absolute": "^1.0.0"
+							}
+						}
+					}
+				},
+				"jest-serializer": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-24.9.0.tgz",
+					"integrity": "sha512-DxYipDr8OvfrKH3Kel6NdED3OXxjvxXZ1uIY2I9OFbGg+vUkkg7AGvi65qbhbWNPvDckXmzMPbK3u3HaDO49bQ==",
+					"dev": true
+				},
+				"jest-snapshot": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-24.9.0.tgz",
+					"integrity": "sha512-uI/rszGSs73xCM0l+up7O7a40o90cnrk429LOiK3aeTvfC0HHmldbd81/B7Ix81KSFe1lwkbl7GnBGG4UfuDew==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.0.0",
+						"@jest/types": "^24.9.0",
+						"chalk": "^2.0.1",
+						"expect": "^24.9.0",
+						"jest-diff": "^24.9.0",
+						"jest-get-type": "^24.9.0",
+						"jest-matcher-utils": "^24.9.0",
+						"jest-message-util": "^24.9.0",
+						"jest-resolve": "^24.9.0",
+						"mkdirp": "^0.5.1",
+						"natural-compare": "^1.4.0",
+						"pretty-format": "^24.9.0",
+						"semver": "^6.2.0"
+					}
+				},
+				"jest-util": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-24.9.0.tgz",
+					"integrity": "sha512-x+cZU8VRmOJxbA1K5oDBdxQmdq0OIdADarLxk0Mq+3XS4jgvhG/oKGWcIDCtPG0HgjxOYvF+ilPJQsAyXfbNOg==",
+					"dev": true,
+					"requires": {
+						"@jest/console": "^24.9.0",
+						"@jest/fake-timers": "^24.9.0",
+						"@jest/source-map": "^24.9.0",
+						"@jest/test-result": "^24.9.0",
+						"@jest/types": "^24.9.0",
+						"callsites": "^3.0.0",
+						"chalk": "^2.0.1",
+						"graceful-fs": "^4.1.15",
+						"is-ci": "^2.0.0",
+						"mkdirp": "^0.5.1",
+						"slash": "^2.0.0",
+						"source-map": "^0.6.0"
+					}
+				},
+				"jest-validate": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.9.0.tgz",
+					"integrity": "sha512-HPIt6C5ACwiqSiwi+OfSSHbK8sG7akG8eATl+IPKaeIjtPOeBUd/g3J7DghugzxrGjI93qS/+RPKe1H6PqvhRQ==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^24.9.0",
+						"camelcase": "^5.3.1",
+						"chalk": "^2.0.1",
+						"jest-get-type": "^24.9.0",
+						"leven": "^3.1.0",
+						"pretty-format": "^24.9.0"
+					}
+				},
+				"leven": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+					"integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+					"dev": true
+				},
+				"locate-path": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^3.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"merge-stream": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+					"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+					"dev": true
+				},
+				"node-notifier": {
+					"version": "5.4.3",
+					"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.3.tgz",
+					"integrity": "sha512-M4UBGcs4jeOK9CjTsYwkvH6/MzuUmGCyTW+kCY7uO+1ZVr0+FHGdPdIf5CCLqAaxnRrWidyoQlNkMIIVwbKB8Q==",
+					"dev": true,
+					"requires": {
+						"growly": "^1.3.0",
+						"is-wsl": "^1.1.0",
+						"semver": "^5.5.0",
+						"shellwords": "^0.1.1",
+						"which": "^1.3.0"
+					},
+					"dependencies": {
+						"semver": {
+							"version": "5.7.1",
+							"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+							"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+							"dev": true
+						}
+					}
+				},
+				"p-limit": {
+					"version": "2.2.2",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
+					"integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
+					"dev": true,
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.0.0"
+					}
+				},
+				"p-try": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+					"dev": true
+				},
+				"pretty-format": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz",
+					"integrity": "sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^24.9.0",
+						"ansi-regex": "^4.0.0",
+						"ansi-styles": "^3.2.0",
+						"react-is": "^16.8.4"
+					}
+				},
+				"require-main-filename": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+					"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+					"dev": true
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				},
 				"slash": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
@@ -2390,6 +3041,87 @@
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 					"dev": true
+				},
+				"string-width": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^7.0.1",
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^5.1.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^4.1.0"
+					}
+				},
+				"strip-bom": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				},
+				"wrap-ansi": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+					"integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.0",
+						"string-width": "^3.0.0",
+						"strip-ansi": "^5.0.0"
+					}
+				},
+				"write-file-atomic": {
+					"version": "2.4.1",
+					"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.1.tgz",
+					"integrity": "sha512-TGHFeZEZMnv+gBFRfjAcxL5bPHrsGKtnb4qsFAws7/vlh+QfwAaySIw4AXP9ZskTTh5GWu3FLuJhsWVdiJPGvg==",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.11",
+						"imurmurhash": "^0.1.4",
+						"signal-exit": "^3.0.2"
+					}
+				},
+				"y18n": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+					"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+					"dev": true
+				},
+				"yargs": {
+					"version": "13.3.0",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
+					"integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
+					"dev": true,
+					"requires": {
+						"cliui": "^5.0.0",
+						"find-up": "^3.0.0",
+						"get-caller-file": "^2.0.1",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^2.0.0",
+						"set-blocking": "^2.0.0",
+						"string-width": "^3.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^4.0.0",
+						"yargs-parser": "^13.1.1"
+					}
 				}
 			}
 		},
@@ -8081,707 +8813,6 @@
 				"enzyme": "^3.9.0",
 				"enzyme-adapter-react-16": "^1.10.0",
 				"enzyme-to-json": "^3.3.5"
-			},
-			"dependencies": {
-				"@jest/environment": {
-					"version": "24.8.0",
-					"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-24.8.0.tgz",
-					"integrity": "sha512-vlGt2HLg7qM+vtBrSkjDxk9K0YtRBi7HfRFaDxoRtyi+DyVChzhF20duvpdAnKVBV6W5tym8jm0U9EfXbDk1tw==",
-					"dev": true,
-					"requires": {
-						"@jest/fake-timers": "^24.8.0",
-						"@jest/transform": "^24.8.0",
-						"@jest/types": "^24.8.0",
-						"jest-mock": "^24.8.0"
-					}
-				},
-				"@jest/fake-timers": {
-					"version": "24.8.0",
-					"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-24.8.0.tgz",
-					"integrity": "sha512-2M4d5MufVXwi6VzZhJ9f5S/wU4ud2ck0kxPof1Iz3zWx6Y+V2eJrES9jEktB6O3o/oEyk+il/uNu9PvASjWXQw==",
-					"dev": true,
-					"requires": {
-						"@jest/types": "^24.8.0",
-						"jest-message-util": "^24.8.0",
-						"jest-mock": "^24.8.0"
-					}
-				},
-				"@jest/reporters": {
-					"version": "24.8.0",
-					"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-24.8.0.tgz",
-					"integrity": "sha512-eZ9TyUYpyIIXfYCrw0UHUWUvE35vx5I92HGMgS93Pv7du+GHIzl+/vh8Qj9MCWFK/4TqyttVBPakWMOfZRIfxw==",
-					"dev": true,
-					"requires": {
-						"@jest/environment": "^24.8.0",
-						"@jest/test-result": "^24.8.0",
-						"@jest/transform": "^24.8.0",
-						"@jest/types": "^24.8.0",
-						"chalk": "^2.0.1",
-						"exit": "^0.1.2",
-						"glob": "^7.1.2",
-						"istanbul-lib-coverage": "^2.0.2",
-						"istanbul-lib-instrument": "^3.0.1",
-						"istanbul-lib-report": "^2.0.4",
-						"istanbul-lib-source-maps": "^3.0.1",
-						"istanbul-reports": "^2.1.1",
-						"jest-haste-map": "^24.8.0",
-						"jest-resolve": "^24.8.0",
-						"jest-runtime": "^24.8.0",
-						"jest-util": "^24.8.0",
-						"jest-worker": "^24.6.0",
-						"node-notifier": "^5.2.1",
-						"slash": "^2.0.0",
-						"source-map": "^0.6.0",
-						"string-length": "^2.0.0"
-					}
-				},
-				"@jest/test-result": {
-					"version": "24.8.0",
-					"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-24.8.0.tgz",
-					"integrity": "sha512-+YdLlxwizlfqkFDh7Mc7ONPQAhA4YylU1s529vVM1rsf67vGZH/2GGm5uO8QzPeVyaVMobCQ7FTxl38QrKRlng==",
-					"dev": true,
-					"requires": {
-						"@jest/console": "^24.7.1",
-						"@jest/types": "^24.8.0",
-						"@types/istanbul-lib-coverage": "^2.0.0"
-					}
-				},
-				"@jest/test-sequencer": {
-					"version": "24.8.0",
-					"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-24.8.0.tgz",
-					"integrity": "sha512-OzL/2yHyPdCHXEzhoBuq37CE99nkme15eHkAzXRVqthreWZamEMA0WoetwstsQBCXABhczpK03JNbc4L01vvLg==",
-					"dev": true,
-					"requires": {
-						"@jest/test-result": "^24.8.0",
-						"jest-haste-map": "^24.8.0",
-						"jest-runner": "^24.8.0",
-						"jest-runtime": "^24.8.0"
-					}
-				},
-				"@jest/transform": {
-					"version": "24.8.0",
-					"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-24.8.0.tgz",
-					"integrity": "sha512-xBMfFUP7TortCs0O+Xtez2W7Zu1PLH9bvJgtraN1CDST6LBM/eTOZ9SfwS/lvV8yOfcDpFmwf9bq5cYbXvqsvA==",
-					"dev": true,
-					"requires": {
-						"@babel/core": "^7.1.0",
-						"@jest/types": "^24.8.0",
-						"babel-plugin-istanbul": "^5.1.0",
-						"chalk": "^2.0.1",
-						"convert-source-map": "^1.4.0",
-						"fast-json-stable-stringify": "^2.0.0",
-						"graceful-fs": "^4.1.15",
-						"jest-haste-map": "^24.8.0",
-						"jest-regex-util": "^24.3.0",
-						"jest-util": "^24.8.0",
-						"micromatch": "^3.1.10",
-						"realpath-native": "^1.1.0",
-						"slash": "^2.0.0",
-						"source-map": "^0.6.1",
-						"write-file-atomic": "2.4.1"
-					}
-				},
-				"@jest/types": {
-					"version": "24.8.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-24.8.0.tgz",
-					"integrity": "sha512-g17UxVr2YfBtaMUxn9u/4+siG1ptg9IGYAYwvpwn61nBg779RXnjE/m7CxYcIzEt0AbHZZAHSEZNhkE2WxURVg==",
-					"dev": true,
-					"requires": {
-						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/istanbul-reports": "^1.1.1",
-						"@types/yargs": "^12.0.9"
-					}
-				},
-				"ansi-regex": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-					"dev": true
-				},
-				"camelcase": {
-					"version": "5.3.1",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-					"dev": true
-				},
-				"ci-info": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
-					"integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
-					"dev": true
-				},
-				"cross-spawn": {
-					"version": "6.0.5",
-					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-					"dev": true,
-					"requires": {
-						"nice-try": "^1.0.4",
-						"path-key": "^2.0.1",
-						"semver": "^5.5.0",
-						"shebang-command": "^1.2.0",
-						"which": "^1.2.9"
-					}
-				},
-				"execa": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
-					"integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
-					"dev": true,
-					"requires": {
-						"cross-spawn": "^6.0.0",
-						"get-stream": "^4.0.0",
-						"is-stream": "^1.1.0",
-						"npm-run-path": "^2.0.0",
-						"p-finally": "^1.0.0",
-						"signal-exit": "^3.0.0",
-						"strip-eof": "^1.0.0"
-					}
-				},
-				"expect": {
-					"version": "24.8.0",
-					"resolved": "https://registry.npmjs.org/expect/-/expect-24.8.0.tgz",
-					"integrity": "sha512-/zYvP8iMDrzaaxHVa724eJBCKqSHmO0FA7EDkBiRHxg6OipmMn1fN+C8T9L9K8yr7UONkOifu6+LLH+z76CnaA==",
-					"dev": true,
-					"requires": {
-						"@jest/types": "^24.8.0",
-						"ansi-styles": "^3.2.0",
-						"jest-get-type": "^24.8.0",
-						"jest-matcher-utils": "^24.8.0",
-						"jest-message-util": "^24.8.0",
-						"jest-regex-util": "^24.3.0"
-					}
-				},
-				"find-up": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-					"dev": true,
-					"requires": {
-						"locate-path": "^3.0.0"
-					}
-				},
-				"get-stream": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-					"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-					"dev": true,
-					"requires": {
-						"pump": "^3.0.0"
-					}
-				},
-				"graceful-fs": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz",
-					"integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg==",
-					"dev": true
-				},
-				"invert-kv": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
-					"integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
-					"dev": true
-				},
-				"is-ci": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
-					"integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
-					"dev": true,
-					"requires": {
-						"ci-info": "^2.0.0"
-					}
-				},
-				"jest-config": {
-					"version": "24.8.0",
-					"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-24.8.0.tgz",
-					"integrity": "sha512-Czl3Nn2uEzVGsOeaewGWoDPD8GStxCpAe0zOYs2x2l0fZAgPbCr3uwUkgNKV3LwE13VXythM946cd5rdGkkBZw==",
-					"dev": true,
-					"requires": {
-						"@babel/core": "^7.1.0",
-						"@jest/test-sequencer": "^24.8.0",
-						"@jest/types": "^24.8.0",
-						"babel-jest": "^24.8.0",
-						"chalk": "^2.0.1",
-						"glob": "^7.1.1",
-						"jest-environment-jsdom": "^24.8.0",
-						"jest-environment-node": "^24.8.0",
-						"jest-get-type": "^24.8.0",
-						"jest-jasmine2": "^24.8.0",
-						"jest-regex-util": "^24.3.0",
-						"jest-resolve": "^24.8.0",
-						"jest-util": "^24.8.0",
-						"jest-validate": "^24.8.0",
-						"micromatch": "^3.1.10",
-						"pretty-format": "^24.8.0",
-						"realpath-native": "^1.1.0"
-					}
-				},
-				"jest-diff": {
-					"version": "24.8.0",
-					"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.8.0.tgz",
-					"integrity": "sha512-wxetCEl49zUpJ/bvUmIFjd/o52J+yWcoc5ZyPq4/W1LUKGEhRYDIbP1KcF6t+PvqNrGAFk4/JhtxDq/Nnzs66g==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.0.1",
-						"diff-sequences": "^24.3.0",
-						"jest-get-type": "^24.8.0",
-						"pretty-format": "^24.8.0"
-					}
-				},
-				"jest-each": {
-					"version": "24.8.0",
-					"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-24.8.0.tgz",
-					"integrity": "sha512-NrwK9gaL5+XgrgoCsd9svsoWdVkK4gnvyhcpzd6m487tXHqIdYeykgq3MKI1u4I+5Zf0tofr70at9dWJDeb+BA==",
-					"dev": true,
-					"requires": {
-						"@jest/types": "^24.8.0",
-						"chalk": "^2.0.1",
-						"jest-get-type": "^24.8.0",
-						"jest-util": "^24.8.0",
-						"pretty-format": "^24.8.0"
-					}
-				},
-				"jest-environment-jsdom": {
-					"version": "24.8.0",
-					"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-24.8.0.tgz",
-					"integrity": "sha512-qbvgLmR7PpwjoFjM/sbuqHJt/NCkviuq9vus9NBn/76hhSidO+Z6Bn9tU8friecegbJL8gzZQEMZBQlFWDCwAQ==",
-					"dev": true,
-					"requires": {
-						"@jest/environment": "^24.8.0",
-						"@jest/fake-timers": "^24.8.0",
-						"@jest/types": "^24.8.0",
-						"jest-mock": "^24.8.0",
-						"jest-util": "^24.8.0",
-						"jsdom": "^11.5.1"
-					}
-				},
-				"jest-environment-node": {
-					"version": "24.8.0",
-					"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-24.8.0.tgz",
-					"integrity": "sha512-vIGUEScd1cdDgR6sqn2M08sJTRLQp6Dk/eIkCeO4PFHxZMOgy+uYLPMC4ix3PEfM5Au/x3uQ/5Tl0DpXXZsJ/Q==",
-					"dev": true,
-					"requires": {
-						"@jest/environment": "^24.8.0",
-						"@jest/fake-timers": "^24.8.0",
-						"@jest/types": "^24.8.0",
-						"jest-mock": "^24.8.0",
-						"jest-util": "^24.8.0"
-					}
-				},
-				"jest-get-type": {
-					"version": "24.8.0",
-					"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.8.0.tgz",
-					"integrity": "sha512-RR4fo8jEmMD9zSz2nLbs2j0zvPpk/KCEz3a62jJWbd2ayNo0cb+KFRxPHVhE4ZmgGJEQp0fosmNz84IfqM8cMQ==",
-					"dev": true
-				},
-				"jest-haste-map": {
-					"version": "24.8.1",
-					"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.8.1.tgz",
-					"integrity": "sha512-SwaxMGVdAZk3ernAx2Uv2sorA7jm3Kx+lR0grp6rMmnY06Kn/urtKx1LPN2mGTea4fCT38impYT28FfcLUhX0g==",
-					"dev": true,
-					"requires": {
-						"@jest/types": "^24.8.0",
-						"anymatch": "^2.0.0",
-						"fb-watchman": "^2.0.0",
-						"fsevents": "^1.2.7",
-						"graceful-fs": "^4.1.15",
-						"invariant": "^2.2.4",
-						"jest-serializer": "^24.4.0",
-						"jest-util": "^24.8.0",
-						"jest-worker": "^24.6.0",
-						"micromatch": "^3.1.10",
-						"sane": "^4.0.3",
-						"walker": "^1.0.7"
-					}
-				},
-				"jest-jasmine2": {
-					"version": "24.8.0",
-					"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-24.8.0.tgz",
-					"integrity": "sha512-cEky88npEE5LKd5jPpTdDCLvKkdyklnaRycBXL6GNmpxe41F0WN44+i7lpQKa/hcbXaQ+rc9RMaM4dsebrYong==",
-					"dev": true,
-					"requires": {
-						"@babel/traverse": "^7.1.0",
-						"@jest/environment": "^24.8.0",
-						"@jest/test-result": "^24.8.0",
-						"@jest/types": "^24.8.0",
-						"chalk": "^2.0.1",
-						"co": "^4.6.0",
-						"expect": "^24.8.0",
-						"is-generator-fn": "^2.0.0",
-						"jest-each": "^24.8.0",
-						"jest-matcher-utils": "^24.8.0",
-						"jest-message-util": "^24.8.0",
-						"jest-runtime": "^24.8.0",
-						"jest-snapshot": "^24.8.0",
-						"jest-util": "^24.8.0",
-						"pretty-format": "^24.8.0",
-						"throat": "^4.0.0"
-					}
-				},
-				"jest-leak-detector": {
-					"version": "24.8.0",
-					"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-24.8.0.tgz",
-					"integrity": "sha512-cG0yRSK8A831LN8lIHxI3AblB40uhv0z+SsQdW3GoMMVcK+sJwrIIyax5tu3eHHNJ8Fu6IMDpnLda2jhn2pD/g==",
-					"dev": true,
-					"requires": {
-						"pretty-format": "^24.8.0"
-					}
-				},
-				"jest-matcher-utils": {
-					"version": "24.8.0",
-					"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.8.0.tgz",
-					"integrity": "sha512-lex1yASY51FvUuHgm0GOVj7DCYEouWSlIYmCW7APSqB9v8mXmKSn5+sWVF0MhuASG0bnYY106/49JU1FZNl5hw==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.0.1",
-						"jest-diff": "^24.8.0",
-						"jest-get-type": "^24.8.0",
-						"pretty-format": "^24.8.0"
-					}
-				},
-				"jest-message-util": {
-					"version": "24.8.0",
-					"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-24.8.0.tgz",
-					"integrity": "sha512-p2k71rf/b6ns8btdB0uVdljWo9h0ovpnEe05ZKWceQGfXYr4KkzgKo3PBi8wdnd9OtNh46VpNIJynUn/3MKm1g==",
-					"dev": true,
-					"requires": {
-						"@babel/code-frame": "^7.0.0",
-						"@jest/test-result": "^24.8.0",
-						"@jest/types": "^24.8.0",
-						"@types/stack-utils": "^1.0.1",
-						"chalk": "^2.0.1",
-						"micromatch": "^3.1.10",
-						"slash": "^2.0.0",
-						"stack-utils": "^1.0.1"
-					}
-				},
-				"jest-mock": {
-					"version": "24.8.0",
-					"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-24.8.0.tgz",
-					"integrity": "sha512-6kWugwjGjJw+ZkK4mDa0Df3sDlUTsV47MSrT0nGQ0RBWJbpODDQ8MHDVtGtUYBne3IwZUhtB7elxHspU79WH3A==",
-					"dev": true,
-					"requires": {
-						"@jest/types": "^24.8.0"
-					}
-				},
-				"jest-resolve": {
-					"version": "24.8.0",
-					"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-24.8.0.tgz",
-					"integrity": "sha512-+hjSzi1PoRvnuOICoYd5V/KpIQmkAsfjFO71458hQ2Whi/yf1GDeBOFj8Gxw4LrApHsVJvn5fmjcPdmoUHaVKw==",
-					"dev": true,
-					"requires": {
-						"@jest/types": "^24.8.0",
-						"browser-resolve": "^1.11.3",
-						"chalk": "^2.0.1",
-						"jest-pnp-resolver": "^1.2.1",
-						"realpath-native": "^1.1.0"
-					}
-				},
-				"jest-runner": {
-					"version": "24.8.0",
-					"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-24.8.0.tgz",
-					"integrity": "sha512-utFqC5BaA3JmznbissSs95X1ZF+d+4WuOWwpM9+Ak356YtMhHE/GXUondZdcyAAOTBEsRGAgH/0TwLzfI9h7ow==",
-					"dev": true,
-					"requires": {
-						"@jest/console": "^24.7.1",
-						"@jest/environment": "^24.8.0",
-						"@jest/test-result": "^24.8.0",
-						"@jest/types": "^24.8.0",
-						"chalk": "^2.4.2",
-						"exit": "^0.1.2",
-						"graceful-fs": "^4.1.15",
-						"jest-config": "^24.8.0",
-						"jest-docblock": "^24.3.0",
-						"jest-haste-map": "^24.8.0",
-						"jest-jasmine2": "^24.8.0",
-						"jest-leak-detector": "^24.8.0",
-						"jest-message-util": "^24.8.0",
-						"jest-resolve": "^24.8.0",
-						"jest-runtime": "^24.8.0",
-						"jest-util": "^24.8.0",
-						"jest-worker": "^24.6.0",
-						"source-map-support": "^0.5.6",
-						"throat": "^4.0.0"
-					},
-					"dependencies": {
-						"chalk": {
-							"version": "2.4.2",
-							"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-							"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-							"dev": true,
-							"requires": {
-								"ansi-styles": "^3.2.1",
-								"escape-string-regexp": "^1.0.5",
-								"supports-color": "^5.3.0"
-							}
-						}
-					}
-				},
-				"jest-runtime": {
-					"version": "24.8.0",
-					"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-24.8.0.tgz",
-					"integrity": "sha512-Mq0aIXhvO/3bX44ccT+czU1/57IgOMyy80oM0XR/nyD5zgBcesF84BPabZi39pJVA6UXw+fY2Q1N+4BiVUBWOA==",
-					"dev": true,
-					"requires": {
-						"@jest/console": "^24.7.1",
-						"@jest/environment": "^24.8.0",
-						"@jest/source-map": "^24.3.0",
-						"@jest/transform": "^24.8.0",
-						"@jest/types": "^24.8.0",
-						"@types/yargs": "^12.0.2",
-						"chalk": "^2.0.1",
-						"exit": "^0.1.2",
-						"glob": "^7.1.3",
-						"graceful-fs": "^4.1.15",
-						"jest-config": "^24.8.0",
-						"jest-haste-map": "^24.8.0",
-						"jest-message-util": "^24.8.0",
-						"jest-mock": "^24.8.0",
-						"jest-regex-util": "^24.3.0",
-						"jest-resolve": "^24.8.0",
-						"jest-snapshot": "^24.8.0",
-						"jest-util": "^24.8.0",
-						"jest-validate": "^24.8.0",
-						"realpath-native": "^1.1.0",
-						"slash": "^2.0.0",
-						"strip-bom": "^3.0.0",
-						"yargs": "^12.0.2"
-					},
-					"dependencies": {
-						"glob": {
-							"version": "7.1.4",
-							"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-							"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
-							"dev": true,
-							"requires": {
-								"fs.realpath": "^1.0.0",
-								"inflight": "^1.0.4",
-								"inherits": "2",
-								"minimatch": "^3.0.4",
-								"once": "^1.3.0",
-								"path-is-absolute": "^1.0.0"
-							}
-						}
-					}
-				},
-				"jest-snapshot": {
-					"version": "24.8.0",
-					"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-24.8.0.tgz",
-					"integrity": "sha512-5ehtWoc8oU9/cAPe6fez6QofVJLBKyqkY2+TlKTOf0VllBB/mqUNdARdcjlZrs9F1Cv+/HKoCS/BknT0+tmfPg==",
-					"dev": true,
-					"requires": {
-						"@babel/types": "^7.0.0",
-						"@jest/types": "^24.8.0",
-						"chalk": "^2.0.1",
-						"expect": "^24.8.0",
-						"jest-diff": "^24.8.0",
-						"jest-matcher-utils": "^24.8.0",
-						"jest-message-util": "^24.8.0",
-						"jest-resolve": "^24.8.0",
-						"mkdirp": "^0.5.1",
-						"natural-compare": "^1.4.0",
-						"pretty-format": "^24.8.0",
-						"semver": "^5.5.0"
-					}
-				},
-				"jest-util": {
-					"version": "24.8.0",
-					"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-24.8.0.tgz",
-					"integrity": "sha512-DYZeE+XyAnbNt0BG1OQqKy/4GVLPtzwGx5tsnDrFcax36rVE3lTA5fbvgmbVPUZf9w77AJ8otqR4VBbfFJkUZA==",
-					"dev": true,
-					"requires": {
-						"@jest/console": "^24.7.1",
-						"@jest/fake-timers": "^24.8.0",
-						"@jest/source-map": "^24.3.0",
-						"@jest/test-result": "^24.8.0",
-						"@jest/types": "^24.8.0",
-						"callsites": "^3.0.0",
-						"chalk": "^2.0.1",
-						"graceful-fs": "^4.1.15",
-						"is-ci": "^2.0.0",
-						"mkdirp": "^0.5.1",
-						"slash": "^2.0.0",
-						"source-map": "^0.6.0"
-					}
-				},
-				"jest-validate": {
-					"version": "24.8.0",
-					"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.8.0.tgz",
-					"integrity": "sha512-+/N7VOEMW1Vzsrk3UWBDYTExTPwf68tavEPKDnJzrC6UlHtUDU/fuEdXqFoHzv9XnQ+zW6X3qMZhJ3YexfeLDA==",
-					"dev": true,
-					"requires": {
-						"@jest/types": "^24.8.0",
-						"camelcase": "^5.0.0",
-						"chalk": "^2.0.1",
-						"jest-get-type": "^24.8.0",
-						"leven": "^2.1.0",
-						"pretty-format": "^24.8.0"
-					}
-				},
-				"lcid": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
-					"integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
-					"dev": true,
-					"requires": {
-						"invert-kv": "^2.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-					"dev": true,
-					"requires": {
-						"p-locate": "^3.0.0",
-						"path-exists": "^3.0.0"
-					}
-				},
-				"mem": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
-					"integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
-					"dev": true,
-					"requires": {
-						"map-age-cleaner": "^0.1.1",
-						"mimic-fn": "^2.0.0",
-						"p-is-promise": "^2.0.0"
-					}
-				},
-				"mimic-fn": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-					"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-					"dev": true
-				},
-				"os-locale": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
-					"integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
-					"dev": true,
-					"requires": {
-						"execa": "^1.0.0",
-						"lcid": "^2.0.0",
-						"mem": "^4.0.0"
-					}
-				},
-				"p-is-promise": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
-					"integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
-					"dev": true
-				},
-				"p-limit": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
-					"integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
-					"dev": true,
-					"requires": {
-						"p-try": "^2.0.0"
-					}
-				},
-				"p-locate": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-					"dev": true,
-					"requires": {
-						"p-limit": "^2.0.0"
-					}
-				},
-				"p-try": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-					"dev": true
-				},
-				"pretty-format": {
-					"version": "24.8.0",
-					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.8.0.tgz",
-					"integrity": "sha512-P952T7dkrDEplsR+TuY7q3VXDae5Sr7zmQb12JU/NDQa/3CH7/QW0yvqLcGN6jL+zQFKaoJcPc+yJxMTGmosqw==",
-					"dev": true,
-					"requires": {
-						"@jest/types": "^24.8.0",
-						"ansi-regex": "^4.0.0",
-						"ansi-styles": "^3.2.0",
-						"react-is": "^16.8.4"
-					}
-				},
-				"pump": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-					"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-					"dev": true,
-					"requires": {
-						"end-of-stream": "^1.1.0",
-						"once": "^1.3.1"
-					}
-				},
-				"semver": {
-					"version": "5.7.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-					"dev": true
-				},
-				"slash": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
-					"integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
-					"dev": true
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"strip-bom": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-					"dev": true
-				},
-				"write-file-atomic": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.1.tgz",
-					"integrity": "sha512-TGHFeZEZMnv+gBFRfjAcxL5bPHrsGKtnb4qsFAws7/vlh+QfwAaySIw4AXP9ZskTTh5GWu3FLuJhsWVdiJPGvg==",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.11",
-						"imurmurhash": "^0.1.4",
-						"signal-exit": "^3.0.2"
-					}
-				},
-				"yargs": {
-					"version": "12.0.5",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
-					"integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
-					"dev": true,
-					"requires": {
-						"cliui": "^4.0.0",
-						"decamelize": "^1.2.0",
-						"find-up": "^3.0.0",
-						"get-caller-file": "^1.0.1",
-						"os-locale": "^3.0.0",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^1.0.1",
-						"set-blocking": "^2.0.0",
-						"string-width": "^2.0.0",
-						"which-module": "^2.0.0",
-						"y18n": "^3.2.1 || ^4.0.0",
-						"yargs-parser": "^11.1.1"
-					}
-				},
-				"yargs-parser": {
-					"version": "11.1.1",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
-					"integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
-					"dev": true,
-					"requires": {
-						"camelcase": "^5.0.0",
-						"decamelize": "^1.2.0"
-					}
-				}
 			}
 		},
 		"@wordpress/jest-puppeteer-axe": {
@@ -9427,15 +9458,6 @@
 			"resolved": "https://registry.npmjs.org/app-root-dir/-/app-root-dir-1.0.2.tgz",
 			"integrity": "sha1-OBh+wt6nV3//Az/8sSFyaS/24Rg=",
 			"dev": true
-		},
-		"append-transform": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/append-transform/-/append-transform-1.0.0.tgz",
-			"integrity": "sha512-P009oYkeHyU742iSZJzZZywj4QRJdnTWffaKuJQLablCZ1uz6/cW4yaRgcDaoQ+uwOxxnt0gRUcwfsNP2ri0gw==",
-			"dev": true,
-			"requires": {
-				"default-require-extensions": "^2.0.0"
-			}
 		},
 		"aproba": {
 			"version": "1.2.0",
@@ -12734,12 +12756,6 @@
 				}
 			}
 		},
-		"compare-versions": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.4.0.tgz",
-			"integrity": "sha512-tK69D7oNXXqUW3ZNo/z7NXTEz22TCF0pTE+YF9cxvaAM9XnkLo1fV621xCLrRR6aevJlKxExkss0vWqUCUpqdg==",
-			"dev": true
-		},
 		"component-emitter": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
@@ -14297,23 +14313,6 @@
 			"version": "1.5.2",
 			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-1.5.2.tgz",
 			"integrity": "sha512-95k0GDqvBjZavkuvzx/YqVLv/6YYa17fz6ILMSf7neqQITCPbnfEnQvEgMPNjH4kgobe7+WIL0yJEHku+H3qtQ=="
-		},
-		"default-require-extensions": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-2.0.0.tgz",
-			"integrity": "sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=",
-			"dev": true,
-			"requires": {
-				"strip-bom": "^3.0.0"
-			},
-			"dependencies": {
-				"strip-bom": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-					"dev": true
-				}
-			}
 		},
 		"defaults": {
 			"version": "1.0.3",
@@ -16624,16 +16623,6 @@
 					"integrity": "sha1-oAGr7bP/YQd9T/HVd9RN536NCjU=",
 					"dev": true
 				}
-			}
-		},
-		"fileset": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/fileset/-/fileset-2.0.3.tgz",
-			"integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
-			"dev": true,
-			"requires": {
-				"glob": "^7.0.3",
-				"minimatch": "^3.0.3"
 			}
 		},
 		"filesize": {
@@ -19852,81 +19841,11 @@
 			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
 			"dev": true
 		},
-		"istanbul-api": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-2.1.1.tgz",
-			"integrity": "sha512-kVmYrehiwyeBAk/wE71tW6emzLiHGjYIiDrc8sfyty4F8M02/lrgXSm+R1kXysmF20zArvmZXjlE/mg24TVPJw==",
-			"dev": true,
-			"requires": {
-				"async": "^2.6.1",
-				"compare-versions": "^3.2.1",
-				"fileset": "^2.0.3",
-				"istanbul-lib-coverage": "^2.0.3",
-				"istanbul-lib-hook": "^2.0.3",
-				"istanbul-lib-instrument": "^3.1.0",
-				"istanbul-lib-report": "^2.0.4",
-				"istanbul-lib-source-maps": "^3.0.2",
-				"istanbul-reports": "^2.1.1",
-				"js-yaml": "^3.12.0",
-				"make-dir": "^1.3.0",
-				"minimatch": "^3.0.4",
-				"once": "^1.4.0"
-			},
-			"dependencies": {
-				"istanbul-lib-instrument": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.1.0.tgz",
-					"integrity": "sha512-ooVllVGT38HIk8MxDj/OIHXSYvH+1tq/Vb38s8ixt9GoJadXska4WkGY+0wkmtYCZNYtaARniH/DixUGGLZ0uA==",
-					"dev": true,
-					"requires": {
-						"@babel/generator": "^7.0.0",
-						"@babel/parser": "^7.0.0",
-						"@babel/template": "^7.0.0",
-						"@babel/traverse": "^7.0.0",
-						"@babel/types": "^7.0.0",
-						"istanbul-lib-coverage": "^2.0.3",
-						"semver": "^5.5.0"
-					},
-					"dependencies": {
-						"semver": {
-							"version": "5.7.0",
-							"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-							"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-							"dev": true
-						}
-					}
-				},
-				"make-dir": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
-					"integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
-					"dev": true,
-					"requires": {
-						"pify": "^3.0.0"
-					}
-				},
-				"pify": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-					"dev": true
-				}
-			}
-		},
 		"istanbul-lib-coverage": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
 			"integrity": "sha512-dKWuzRGCs4G+67VfW9pBFFz2Jpi4vSp/k7zBcJ888ofV5Mi1g5CUML5GvMvV6u9Cjybftu+E8Cgp+k0dI1E5lw==",
 			"dev": true
-		},
-		"istanbul-lib-hook": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-2.0.3.tgz",
-			"integrity": "sha512-CLmEqwEhuCYtGcpNVJjLV1DQyVnIqavMLFHV/DP+np/g3qvdxu3gsPqYoJMXm15sN84xOlckFB3VNvRbf5yEgA==",
-			"dev": true,
-			"requires": {
-				"append-transform": "^1.0.0"
-			}
 		},
 		"istanbul-lib-instrument": {
 			"version": "3.1.0",
@@ -20037,15 +19956,6 @@
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 					"dev": true
 				}
-			}
-		},
-		"istanbul-reports": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.1.1.tgz",
-			"integrity": "sha512-FzNahnidyEPBCI0HcufJoSEoKykesRlFcSzQqjH9x0+LC8tnnE/p/90PBLu8iZTxr8yYZNyTtiAujUqyN+CIxw==",
-			"dev": true,
-			"requires": {
-				"handlebars": "^4.1.0"
 			}
 		},
 		"jest": {


### PR DESCRIPTION
## Description
This patch ensures that `node_modules` is no longer installed in `packages/jest-preset-default`.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
