### PR TITLE
Block API: Deprecate block `transform` function in favor of `convert`

### DIFF
--- a/docs/designers-developers/developers/block-api/block-registration.md
+++ b/docs/designers-developers/developers/block-api/block-registration.md
@@ -331,6 +331,94 @@ transforms: {
 ```
 {% end %}
 
+It can also be transformed to multiple blocks by returning an array of blocks from the `convert` function.
+
+{% codetabs %}
+{% ES5 %}
+```js
+transforms: {
+	to: [
+		{
+			type: 'block',
+			blocks: [ 'core/paragraph' ],
+			convert: function( block ) {
+				var words = block.attributes.content.split( ' ' );
+
+				return words.map( function( word ) {
+					return createBlock( 'core/paragraph', {
+						content: word,
+					} );
+				} );
+			},
+		},
+	],
+},
+```
+{% ESNext %}
+```js
+transforms: {
+	to: [
+		{
+			type: 'block',
+			blocks: [ 'core/paragraph' ],
+			convert( block ) {
+				const words = block.attributes.content.split( ' ' );
+
+				return words.map( ( word ) => {
+					return createBlock( 'core/paragraph', {
+						content: word,
+					} );
+				} );
+			},
+		},
+	],
+},
+```
+{% end %}
+
+Similarly, multiple blocks can be transformed to one or more blocks. Including an `isMultiBlock` property value of `true` will indicate that the `convert` function should receive an array of blocks. Currently, multi-block transforms are only supported for blocks of the same type. For example, multiple Paragraph blocks can be converted to a List block.
+
+{% codetabs %}
+{% ES5 %}
+```js
+transforms: {
+	to: [
+		{
+			type: 'block',
+			isMultiBlock: true,
+			blocks: [ 'core/paragraph' ],
+			convert: function( blocks ) {
+				return createBlock( 'core/list', {
+					values: blocks.reduce( function( result, block ) {
+						return result + '<li>' + block.attributes.content + '</li>';
+					}, '' ),
+				} );
+			},
+		},
+	],
+},
+```
+{% ESNext %}
+```js
+transforms: {
+	to: [
+		{
+			type: 'block',
+			isMultiBlock: true,
+			blocks: [ 'core/paragraph' ],
+			convert( blocks ) {
+				return createBlock( 'core/list', {
+					values: blocks.reduce( ( result, block ) => {
+						return result + '<li>' + block.attributes.content + '</li>';
+					}, '' ),
+				} );
+			},
+		},
+	],
+},
+```
+{% end %}
+
 In addition to accepting an array of known block types, the `blocks` option also accepts a "wildcard" (`"*"`). This allows for transformations which apply to _all_ block types (eg: all blocks can transform into `core/group`):
 
 {% codetabs %}

--- a/docs/designers-developers/developers/block-api/block-registration.md
+++ b/docs/designers-developers/developers/block-api/block-registration.md
@@ -364,40 +364,6 @@ transforms: {
 ```
 {% end %}
 
-
-A block with InnerBlocks can also be transformed from and to another block with InnerBlocks.
-
-{% codetabs %}
-{% ES5 %}
-```js
-transforms: {
-    to: [
-        {
-            type: 'block',
-            blocks: [ 'some/block-with-innerblocks' ],
-            convert: function( block ) {
-                return createBlock( 'some/other-block-with-innerblocks', block.attributes, block.innerBlocks );
-            },
-        },
-    ],
-},
-```
-{% ESNext %}
-```js
-transforms: {
-    to: [
-        {
-            type: 'block',
-            blocks: [ 'some/block-with-innerblocks' ],
-            convert: ( block ) => {
-                return createBlock( 'some/other-block-with-innerblocks', block.attributes, block.innerBlocks );
-            },
-        },
-    ],
-},
-```
-{% end %}
-
 An optional `isMatch` function can be specified on a transform object. This provides an opportunity to perform additional checks on whether a transform should be possible. Returning `false` from this function will prevent the transform from being displayed as an option to the user.
 
 {% codetabs %}

--- a/docs/designers-developers/developers/block-api/block-registration.md
+++ b/docs/designers-developers/developers/block-api/block-registration.md
@@ -303,7 +303,7 @@ transforms: {
     to: [
         {
             type: 'block',
-            blocks: [ 'core/paragraph' ],
+            blocks: [ 'core/heading' ],
             convert: function( block ) {
                 return createBlock( 'core/paragraph', {
                     content: block.attributes.content,
@@ -319,7 +319,7 @@ transforms: {
     to: [
         {
             type: 'block',
-            blocks: [ 'core/paragraph' ],
+            blocks: [ 'core/heading' ],
             convert( block ) {
                 return createBlock( 'core/paragraph', {
                     content: block.attributes.content,

--- a/docs/designers-developers/developers/block-api/block-registration.md
+++ b/docs/designers-developers/developers/block-api/block-registration.md
@@ -204,9 +204,9 @@ transforms: {
         {
             type: 'block',
             blocks: [ 'core/paragraph' ],
-            transform: function ( attributes ) {
+            convert: function ( block ) {
                 return createBlock( 'core/heading', {
-                    content: attributes.content,
+                    content: block.attributes.content,
                 } );
             },
         },
@@ -220,7 +220,7 @@ transforms: {
         {
             type: 'block',
             blocks: [ 'core/paragraph' ],
-            transform: ( { content } ) => {
+            convert( { attributes: { content } } ) {
                 return createBlock( 'core/heading', {
                     content,
                 } );
@@ -304,9 +304,9 @@ transforms: {
         {
             type: 'block',
             blocks: [ 'core/paragraph' ],
-            transform: function( attributes ) {
+            convert: function( block ) {
                 return createBlock( 'core/paragraph', {
-                    content: attributes.content,
+                    content: block.attributes.content,
                 } );
             },
         },
@@ -320,7 +320,7 @@ transforms: {
         {
             type: 'block',
             blocks: [ 'core/paragraph' ],
-            transform: ( { content } ) => {
+            convert( { attributes: { content } } ) {
                 return createBlock( 'core/paragraph', {
                     content,
                 } );
@@ -341,7 +341,7 @@ transforms: {
         {
             type: 'block',
             blocks: [ '*' ], // wildcard - match any block
-            transform: function( attributes, innerBlocks ) {
+            convert: function( block ) {
                 // transform logic here
             },
         },
@@ -355,7 +355,7 @@ transforms: {
         {
             type: 'block',
             blocks: [ '*' ], // wildcard - match any block
-            transform: ( attributes, innerBlocks ) => {
+            convert( block ) {
                 // transform logic here
             },
         },
@@ -375,8 +375,8 @@ transforms: {
         {
             type: 'block',
             blocks: [ 'some/block-with-innerblocks' ],
-            transform: function( attributes, innerBlocks ) {
-                return createBlock( 'some/other-block-with-innerblocks', attributes, innerBlocks );
+            convert: function( block ) {
+                return createBlock( 'some/other-block-with-innerblocks', block.attributes, block.innerBlocks );
             },
         },
     ],
@@ -389,8 +389,8 @@ transforms: {
         {
             type: 'block',
             blocks: [ 'some/block-with-innerblocks' ],
-            transform: ( attributes, innerBlocks ) => {
-                return createBlock( 'some/other-block-with-innerblocks', attributes, innerBlocks);
+            convert: ( block ) => {
+                return createBlock( 'some/other-block-with-innerblocks', block.attributes, block.innerBlocks );
             },
         },
     ],
@@ -411,9 +411,9 @@ transforms: {
 			isMatch: function( attributes ) {
 				return attributes.isText;
 			},
-            transform: function( attributes ) {
+            convert: function( block ) {
                 return createBlock( 'core/paragraph', {
-                    content: attributes.content,
+                    content: block.attributes.content,
                 } );
             },
         },
@@ -428,7 +428,7 @@ transforms: {
             type: 'block',
 			blocks: [ 'core/paragraph' ],
 			isMatch: ( { isText } ) => isText,
-            transform: ( { content } ) => {
+            convert( { attributes: { content } } ) {
                 return createBlock( 'core/paragraph', {
                     content,
                 } );
@@ -474,7 +474,7 @@ transforms: {
 			// We define a lower priority (higher number) than the default of 10. This
 			// ensures that the File block is only created as a fallback.
 			priority: 15,
-			transform: function( files ) {
+			convert: function( files ) {
 				var file = files[ 0 ];
 				var blobURL = createBlobURL( file );
 
@@ -499,7 +499,7 @@ transforms: {
 			// We define a lower priority (higher number) than the default of 10. This
 			// ensures that the File block is only created as a fallback.
 			priority: 15,
-			transform: ( files ) => {
+			convert( files ) {
 				const file = files[ 0 ];
 				const blobURL = createBlobURL( file );
 
@@ -526,7 +526,7 @@ transforms: {
         {
             type: 'prefix',
             prefix: '?',
-            transform: function( content ) {
+            convert: function( content ) {
                 return createBlock( 'my-plugin/question', {
                     content,
                 } );
@@ -542,7 +542,7 @@ transforms: {
         {
             type: 'prefix',
             prefix: '?',
-            transform( content ) {
+            convert( content ) {
                 return createBlock( 'my-plugin/question', {
                     content,
                 } );

--- a/docs/designers-developers/developers/block-api/block-registration.md
+++ b/docs/designers-developers/developers/block-api/block-registration.md
@@ -220,9 +220,9 @@ transforms: {
         {
             type: 'block',
             blocks: [ 'core/paragraph' ],
-            convert( { attributes: { content } } ) {
+            convert( block ) {
                 return createBlock( 'core/heading', {
-                    content,
+                    content: block.attributes.content,
                 } );
             },
         },
@@ -320,9 +320,9 @@ transforms: {
         {
             type: 'block',
             blocks: [ 'core/paragraph' ],
-            convert( { attributes: { content } } ) {
+            convert( block ) {
                 return createBlock( 'core/paragraph', {
-                    content,
+                    content: block.attributes.content,
                 } );
             },
         },
@@ -394,9 +394,9 @@ transforms: {
             type: 'block',
 			blocks: [ 'core/paragraph' ],
 			isMatch: ( { isText } ) => isText,
-            convert( { attributes: { content } } ) {
+            convert( block ) {
                 return createBlock( 'core/paragraph', {
-                    content,
+                    content: block.attributes.content,
                 } );
             },
         },

--- a/packages/block-editor/src/components/block-drop-zone/index.js
+++ b/packages/block-editor/src/components/block-drop-zone/index.js
@@ -68,7 +68,7 @@ class BlockDropZone extends Component {
 
 		if ( transformation ) {
 			const insertIndex = this.getInsertIndex( position );
-			const blocks = transformation.transform( files, this.props.updateBlockAttributes );
+			const blocks = transformation.convert( files, this.props.updateBlockAttributes );
 			this.props.insertBlocks( blocks, insertIndex );
 		}
 	}

--- a/packages/block-editor/src/components/block-switcher/test/index.js
+++ b/packages/block-editor/src/components/block-switcher/test/index.js
@@ -58,12 +58,12 @@ describe( 'BlockSwitcher', () => {
 					{
 						type: 'block',
 						blocks: [ 'core/paragraph' ],
-						transform: () => {},
+						convert: () => {},
 					},
 					{
 						type: 'block',
 						blocks: [ 'core/paragraph' ],
-						transform: () => {},
+						convert: () => {},
 						isMultiBlock: true,
 					},
 				],
@@ -79,7 +79,7 @@ describe( 'BlockSwitcher', () => {
 				to: [ {
 					type: 'block',
 					blocks: [ 'core/heading' ],
-					transform: () => {},
+					convert: () => {},
 				} ],
 			},
 		} );

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -84,7 +84,7 @@ class RichTextWrapper extends Component {
 
 			if ( transformation ) {
 				onReplace( [
-					transformation.transform( { content: value.text } ),
+					transformation.convert( { content: value.text } ),
 				] );
 				markAutomaticChange();
 			}
@@ -290,7 +290,7 @@ class RichTextWrapper extends Component {
 		}
 
 		const content = valueToFormat( slice( value, start, text.length ) );
-		const block = transformation.transform( content );
+		const block = transformation.convert( content );
 
 		onReplace( [ block ] );
 		markAutomaticChange();

--- a/packages/block-editor/src/store/test/effects.js
+++ b/packages/block-editor/src/store/test/effects.js
@@ -206,7 +206,7 @@ describe( 'effects', () => {
 					to: [ {
 						type: 'block',
 						blocks: [ 'core/test-block' ],
-						transform: ( { content2 } ) => {
+						convert: ( { attributes: { content2 } } ) => {
 							return createBlock( 'core/test-block', {
 								content: content2,
 							} );

--- a/packages/block-library/src/audio/transforms.js
+++ b/packages/block-library/src/audio/transforms.js
@@ -11,7 +11,7 @@ const transforms = {
 			isMatch( files ) {
 				return files.length === 1 && files[ 0 ].type.indexOf( 'audio/' ) === 0;
 			},
-			transform( files ) {
+			convert( files ) {
 				const file = files[ 0 ];
 				// We don't need to upload the media directly here
 				// It's already done as part of the `componentDidMount`

--- a/packages/block-library/src/code/transforms.js
+++ b/packages/block-library/src/code/transforms.js
@@ -8,7 +8,7 @@ const transforms = {
 		{
 			type: 'enter',
 			regExp: /^```$/,
-			transform: () => createBlock( 'core/code' ),
+			convert: () => createBlock( 'core/code' ),
 		},
 		{
 			type: 'raw',

--- a/packages/block-library/src/cover/transforms.js
+++ b/packages/block-library/src/cover/transforms.js
@@ -13,7 +13,7 @@ const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'core/image' ],
-			transform: ( { caption, url, align, id } ) => (
+			convert: ( { attributes: { caption, url, align, id } } ) => (
 				createBlock( 'core/cover', {
 					title: caption,
 					url,
@@ -25,7 +25,7 @@ const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'core/video' ],
-			transform: ( { caption, src, align, id } ) => (
+			convert: ( { attributes: { caption, src, align, id } } ) => (
 				createBlock( 'core/cover', {
 					title: caption,
 					url: src,
@@ -48,7 +48,7 @@ const transforms = {
 				// If a url is not set the transform could happen if the cover has no background color or gradient;
 				return ! overlayColor && ! customOverlayColor && ! gradient && ! customGradient;
 			},
-			transform: ( { title, url, align, id } ) => (
+			convert: ( { attributes: { title, url, align, id } } ) => (
 				createBlock( 'core/image', {
 					caption: title,
 					url,
@@ -68,7 +68,7 @@ const transforms = {
 				// If a url is not set the transform could happen if the cover has no background color or gradient;
 				return ! overlayColor && ! customOverlayColor && ! gradient && ! customGradient;
 			},
-			transform: ( { title, url, align, id } ) => (
+			convert: ( { attributes: { title, url, align, id } } ) => (
 				createBlock( 'core/video', {
 					caption: title,
 					src: url,

--- a/packages/block-library/src/embed/core-embeds.js
+++ b/packages/block-library/src/embed/core-embeds.js
@@ -155,10 +155,10 @@ export const others = [
 			title: 'Crowdsignal',
 			icon: embedContentIcon,
 			keywords: [ 'polldaddy' ],
-			transform: [ {
+			convert: [ {
 				type: 'block',
 				blocks: [ 'core-embed/polldaddy' ],
-				transform: ( content ) => {
+				convert: ( content ) => {
 					return createBlock( 'core-embed/crowdsignal', {
 						content,
 					} );
@@ -316,10 +316,10 @@ export const others = [
 		settings: {
 			title: 'Speaker Deck',
 			icon: embedContentIcon,
-			transform: [ {
+			convert: [ {
 				type: 'block',
 				blocks: [ 'core-embed/speaker' ],
-				transform: ( content ) => {
+				convert: ( content ) => {
 					return createBlock( 'core-embed/speaker-deck', {
 						content,
 					} );

--- a/packages/block-library/src/embed/index.js
+++ b/packages/block-library/src/embed/index.js
@@ -24,7 +24,7 @@ export const settings = getEmbedBlockSettings( {
 			{
 				type: 'raw',
 				isMatch: ( node ) => node.nodeName === 'P' && /^\s*(https?:\/\/\S+)\s*$/i.test( node.textContent ),
-				transform: ( node ) => {
+				convert: ( node ) => {
 					return createBlock( 'core/embed', {
 						url: node.textContent.trim(),
 					} );

--- a/packages/block-library/src/file/transforms.js
+++ b/packages/block-library/src/file/transforms.js
@@ -20,7 +20,7 @@ const transforms = {
 			// We define a lower priorty (higher number) than the default of 10. This
 			// ensures that the File block is only created as a fallback.
 			priority: 15,
-			transform: ( files ) => {
+			convert: ( files ) => {
 				const blocks = [];
 
 				files.forEach( ( file ) => {
@@ -40,36 +40,36 @@ const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'core/audio' ],
-			transform: ( attributes ) => {
+			convert: ( block ) => {
 				return createBlock( 'core/file', {
-					href: attributes.src,
-					fileName: attributes.caption,
-					textLinkHref: attributes.src,
-					id: attributes.id,
+					href: block.attributes.src,
+					fileName: block.attributes.caption,
+					textLinkHref: block.attributes.src,
+					id: block.attributes.id,
 				} );
 			},
 		},
 		{
 			type: 'block',
 			blocks: [ 'core/video' ],
-			transform: ( attributes ) => {
+			convert: ( block ) => {
 				return createBlock( 'core/file', {
-					href: attributes.src,
-					fileName: attributes.caption,
-					textLinkHref: attributes.src,
-					id: attributes.id,
+					href: block.attributes.src,
+					fileName: block.attributes.caption,
+					textLinkHref: block.attributes.src,
+					id: block.attributes.id,
 				} );
 			},
 		},
 		{
 			type: 'block',
 			blocks: [ 'core/image' ],
-			transform: ( attributes ) => {
+			convert: ( block ) => {
 				return createBlock( 'core/file', {
-					href: attributes.url,
-					fileName: attributes.caption,
-					textLinkHref: attributes.url,
-					id: attributes.id,
+					href: block.attributes.url,
+					fileName: block.attributes.caption,
+					textLinkHref: block.attributes.url,
+					id: block.attributes.id,
 				} );
 			},
 		},
@@ -86,11 +86,11 @@ const transforms = {
 				const media = getMedia( id );
 				return !! media && includes( media.mime_type, 'audio' );
 			},
-			transform: ( attributes ) => {
+			convert: ( block ) => {
 				return createBlock( 'core/audio', {
-					src: attributes.href,
-					caption: attributes.fileName,
-					id: attributes.id,
+					src: block.attributes.href,
+					caption: block.attributes.fileName,
+					id: block.attributes.id,
 				} );
 			},
 		},
@@ -105,11 +105,11 @@ const transforms = {
 				const media = getMedia( id );
 				return !! media && includes( media.mime_type, 'video' );
 			},
-			transform: ( attributes ) => {
+			convert: ( block ) => {
 				return createBlock( 'core/video', {
-					src: attributes.href,
-					caption: attributes.fileName,
-					id: attributes.id,
+					src: block.attributes.href,
+					caption: block.attributes.fileName,
+					id: block.attributes.id,
 				} );
 			},
 		},
@@ -124,11 +124,11 @@ const transforms = {
 				const media = getMedia( id );
 				return !! media && includes( media.mime_type, 'image' );
 			},
-			transform: ( attributes ) => {
+			convert: ( block ) => {
 				return createBlock( 'core/image', {
-					url: attributes.href,
-					caption: attributes.fileName,
-					id: attributes.id,
+					url: block.attributes.href,
+					caption: block.attributes.fileName,
+					id: block.attributes.id,
 				} );
 			},
 		},

--- a/packages/block-library/src/gallery/transforms.js
+++ b/packages/block-library/src/gallery/transforms.js
@@ -30,14 +30,14 @@ const transforms = {
 			type: 'block',
 			isMultiBlock: true,
 			blocks: [ 'core/image' ],
-			transform: ( attributes ) => {
+			convert: ( blocks ) => {
 				// Init the align and size from the first item which may be either the placeholder or an image.
-				let { align, sizeSlug } = attributes[ 0 ];
+				let { align, sizeSlug } = blocks[ 0 ].attributes;
 				// Loop through all the images and check if they have the same align and size.
-				align = every( attributes, [ 'align', align ] ) ? align : undefined;
-				sizeSlug = every( attributes, [ 'sizeSlug', sizeSlug ] ) ? sizeSlug : undefined;
+				align = every( blocks, [ 'attributes', 'align', align ] ) ? align : undefined;
+				sizeSlug = every( blocks, [ 'attributes', 'sizeSlug', sizeSlug ] ) ? sizeSlug : undefined;
 
-				const validImages = filter( attributes, ( { url } ) => url );
+				const validImages = filter( blocks, ( { attributes } ) => attributes.url );
 
 				return createBlock( 'core/gallery', {
 					images: validImages.map( ( { id, url, alt, caption } ) => ( {
@@ -90,7 +90,7 @@ const transforms = {
 			isMatch( files ) {
 				return files.length !== 1 && every( files, ( file ) => file.type.indexOf( 'image/' ) === 0 );
 			},
-			transform( files ) {
+			convert( files ) {
 				const block = createBlock( 'core/gallery', {
 					images: files.map( ( file ) => pickRelevantMediaFiles( {
 						url: createBlobURL( file ),
@@ -104,7 +104,7 @@ const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'core/image' ],
-			transform: ( { images, align, sizeSlug } ) => {
+			convert: ( { attributes: { images, align, sizeSlug } } ) => {
 				if ( images.length > 0 ) {
 					return images.map( ( { id, url, alt, caption } ) => createBlock( 'core/image', {
 						id,

--- a/packages/block-library/src/group/index.js
+++ b/packages/block-library/src/group/index.js
@@ -88,7 +88,7 @@ export const settings = {
 				type: 'block',
 				isMultiBlock: true,
 				blocks: [ '*' ],
-				__experimentalConvert( blocks ) {
+				convert( blocks ) {
 					// Avoid transforming a single `core/group` Block
 					if ( blocks.length === 1 && blocks[ 0 ].name === 'core/group' ) {
 						return;

--- a/packages/block-library/src/heading/transforms.js
+++ b/packages/block-library/src/heading/transforms.js
@@ -17,7 +17,7 @@ const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'core/paragraph' ],
-			transform: ( { content } ) => {
+			convert: ( { attributes: { content } } ) => {
 				return createBlock( name, {
 					content,
 				} );
@@ -40,7 +40,7 @@ const transforms = {
 					h6: schema,
 				};
 			},
-			transform( node ) {
+			convert( node ) {
 				const attributes = getBlockAttributes( name, node.outerHTML );
 				const { textAlign } = node.style || {};
 
@@ -60,7 +60,7 @@ const transforms = {
 		...[ 2, 3, 4, 5, 6 ].map( ( level ) => ( {
 			type: 'prefix',
 			prefix: Array( level + 1 ).join( '#' ),
-			transform( content ) {
+			convert( content ) {
 				return createBlock( name, {
 					level,
 					content,
@@ -72,7 +72,7 @@ const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'core/paragraph' ],
-			transform: ( { content } ) => {
+			convert: ( { attributes: { content } } ) => {
 				return createBlock( 'core/paragraph', {
 					content,
 				} );

--- a/packages/block-library/src/image/transforms.js
+++ b/packages/block-library/src/image/transforms.js
@@ -70,7 +70,7 @@ const transforms = {
 			type: 'raw',
 			isMatch: ( node ) => node.nodeName === 'FIGURE' && !! node.querySelector( 'img' ),
 			schema,
-			transform: ( node ) => {
+			convert: ( node ) => {
 				// Search both figure and image classes. Alignment could be
 				// set on either. ID is set on the image.
 				const className = node.className + ' ' + node.querySelector( 'img' ).className;
@@ -92,7 +92,7 @@ const transforms = {
 			isMatch( files ) {
 				return files.length === 1 && files[ 0 ].type.indexOf( 'image/' ) === 0;
 			},
-			transform( files ) {
+			convert( files ) {
 				const file = files[ 0 ];
 				// We don't need to upload the media directly here
 				// It's already done as part of the `componentDidMount`

--- a/packages/block-library/src/list/transforms.js
+++ b/packages/block-library/src/list/transforms.js
@@ -41,13 +41,14 @@ const transforms = {
 			type: 'block',
 			isMultiBlock: true,
 			blocks: [ 'core/paragraph' ],
-			transform: ( blockAttributes ) => {
+			convert: ( blocks ) => {
 				return createBlock( 'core/list', {
 					values: toHTMLString( {
-						value: join( blockAttributes.map( ( { content } ) => {
+						value: join( blocks.map( ( block ) => {
+							const { content } = block.attributes;
 							const value = create( { html: content } );
 
-							if ( blockAttributes.length > 1 ) {
+							if ( blocks.length > 1 ) {
 								return value;
 							}
 
@@ -63,7 +64,7 @@ const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'core/quote' ],
-			transform: ( { value } ) => {
+			convert: ( { attributes: { value } } ) => {
 				return createBlock( 'core/list', {
 					values: toHTMLString( {
 						value: create( { html: value, multilineTag: 'p' } ),
@@ -79,7 +80,7 @@ const transforms = {
 				ol: getListContentSchema( args ).ol,
 				ul: getListContentSchema( args ).ul,
 			} ),
-			transform( node ) {
+			convert( node ) {
 				const attributes = {
 					ordered: node.nodeName === 'OL',
 				};
@@ -115,7 +116,7 @@ const transforms = {
 		...[ '*', '-' ].map( ( prefix ) => ( {
 			type: 'prefix',
 			prefix,
-			transform( content ) {
+			convert( content ) {
 				return createBlock( 'core/list', {
 					values: `<li>${ content }</li>`,
 				} );
@@ -124,7 +125,7 @@ const transforms = {
 		...[ '1.', '1)' ].map( ( prefix ) => ( {
 			type: 'prefix',
 			prefix,
-			transform( content ) {
+			convert( content ) {
 				return createBlock( 'core/list', {
 					ordered: true,
 					values: `<li>${ content }</li>`,
@@ -136,7 +137,7 @@ const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'core/paragraph' ],
-			transform: ( { values } ) =>
+			convert: ( { attributes: { values } } ) =>
 				split( create( {
 					html: values,
 					multilineTag: 'li',
@@ -151,7 +152,7 @@ const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'core/quote' ],
-			transform: ( { values } ) => {
+			convert: ( { attributes: { values } } ) => {
 				return createBlock( 'core/quote', {
 					value: toHTMLString( {
 						value: create( {

--- a/packages/block-library/src/media-text/transforms.js
+++ b/packages/block-library/src/media-text/transforms.js
@@ -8,7 +8,7 @@ const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'core/image' ],
-			transform: ( { alt, url, id } ) => (
+			convert: ( { attributes: { alt, url, id } } ) => (
 				createBlock( 'core/media-text', {
 					mediaAlt: alt,
 					mediaId: id,
@@ -20,7 +20,7 @@ const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'core/video' ],
-			transform: ( { src, id } ) => (
+			convert: ( { attributes: { src, id } } ) => (
 				createBlock( 'core/media-text', {
 					mediaId: id,
 					mediaUrl: src,
@@ -36,7 +36,7 @@ const transforms = {
 			isMatch: ( { mediaType, mediaUrl } ) => {
 				return ! mediaUrl || mediaType === 'image';
 			},
-			transform: ( { mediaAlt, mediaId, mediaUrl } ) => {
+			convert: ( { attributes: { mediaAlt, mediaId, mediaUrl } } ) => {
 				return createBlock( 'core/image', {
 					alt: mediaAlt,
 					id: mediaId,
@@ -50,7 +50,7 @@ const transforms = {
 			isMatch: ( { mediaType, mediaUrl } ) => {
 				return ! mediaUrl || mediaType === 'video';
 			},
-			transform: ( { mediaId, mediaUrl } ) => {
+			convert: ( { attributes: { mediaId, mediaUrl } } ) => {
 				return createBlock( 'core/video', {
 					id: mediaId,
 					src: mediaUrl,

--- a/packages/block-library/src/more/transforms.js
+++ b/packages/block-library/src/more/transforms.js
@@ -11,7 +11,7 @@ const transforms = {
 				'wp-block': { attributes: [ 'data-block' ] },
 			},
 			isMatch: ( node ) => node.dataset && node.dataset.block === 'core/more',
-			transform( node ) {
+			convert( node ) {
 				const { customText, noTeaser } = node.dataset;
 				const attrs = {};
 				// Don't copy unless defined and not an empty string

--- a/packages/block-library/src/nextpage/transforms.js
+++ b/packages/block-library/src/nextpage/transforms.js
@@ -11,7 +11,7 @@ const transforms = {
 				'wp-block': { attributes: [ 'data-block' ] },
 			},
 			isMatch: ( node ) => node.dataset && node.dataset.block === 'core/nextpage',
-			transform() {
+			convert() {
 				return createBlock( 'core/nextpage', {} );
 			},
 		},

--- a/packages/block-library/src/paragraph/transforms.js
+++ b/packages/block-library/src/paragraph/transforms.js
@@ -21,7 +21,7 @@ const transforms = {
 					attributes: isPaste ? [] : [ 'style' ],
 				},
 			} ),
-			transform( node ) {
+			convert( node ) {
 				const attributes = getBlockAttributes( name, node.outerHTML );
 				const { textAlign } = node.style || {};
 

--- a/packages/block-library/src/preformatted/transforms.js
+++ b/packages/block-library/src/preformatted/transforms.js
@@ -8,7 +8,7 @@ const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'core/code', 'core/paragraph' ],
-			transform: ( { content } ) =>
+			convert: ( { attributes: { content } } ) =>
 				createBlock( 'core/preformatted', {
 					content,
 				} ),
@@ -33,8 +33,8 @@ const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'core/paragraph' ],
-			transform: ( attributes ) =>
-				createBlock( 'core/paragraph', attributes ),
+			convert: ( block ) =>
+				createBlock( 'core/paragraph', block.attributes ),
 		},
 	],
 };

--- a/packages/block-library/src/quote/transforms.js
+++ b/packages/block-library/src/quote/transforms.js
@@ -10,11 +10,11 @@ const transforms = {
 			type: 'block',
 			isMultiBlock: true,
 			blocks: [ 'core/paragraph' ],
-			transform: ( attributes ) => {
+			convert: ( blocks ) => {
 				return createBlock( 'core/quote', {
 					value: toHTMLString( {
-						value: join( attributes.map( ( { content } ) =>
-							create( { html: content } )
+						value: join( blocks.map( ( block ) =>
+							create( { html: block.attributes.content } )
 						), '\u2028' ),
 						multilineTag: 'p',
 					} ),
@@ -24,7 +24,7 @@ const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'core/heading' ],
-			transform: ( { content } ) => {
+			convert: ( { attributes: { content } } ) => {
 				return createBlock( 'core/quote', {
 					value: `<p>${ content }</p>`,
 				} );
@@ -33,7 +33,7 @@ const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'core/pullquote' ],
-			transform: ( { value, citation } ) => createBlock( 'core/quote', {
+			convert: ( { attributes: { value, citation } } ) => createBlock( 'core/quote', {
 				value,
 				citation,
 			} ),
@@ -41,7 +41,7 @@ const transforms = {
 		{
 			type: 'prefix',
 			prefix: '>',
-			transform: ( content ) => {
+			convert: ( content ) => {
 				return createBlock( 'core/quote', {
 					value: `<p>${ content }</p>`,
 				} );
@@ -92,7 +92,7 @@ const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'core/paragraph' ],
-			transform: ( { value, citation } ) => {
+			convert: ( { attributes: { value, citation } } ) => {
 				const paragraphs = [];
 				if ( value && value !== '<p></p>' ) {
 					paragraphs.push(
@@ -124,7 +124,7 @@ const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'core/heading' ],
-			transform: ( { value, citation, ...attrs } ) => {
+			convert: ( { attributes: { value, citation, ...attrs } } ) => {
 				// If there is no quote content, use the citation as the
 				// content of the resulting heading. A nonexistent citation
 				// will result in an empty heading.
@@ -162,7 +162,7 @@ const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'core/pullquote' ],
-			transform: ( { value, citation } ) => {
+			convert: ( { attributes: { value, citation } } ) => {
 				return createBlock( 'core/pullquote', {
 					value,
 					citation,

--- a/packages/block-library/src/separator/transforms.js
+++ b/packages/block-library/src/separator/transforms.js
@@ -8,7 +8,7 @@ const transforms = {
 		{
 			type: 'enter',
 			regExp: /^-{3,}$/,
-			transform: () => createBlock( 'core/separator' ),
+			convert: () => createBlock( 'core/separator' ),
 		},
 		{
 			type: 'raw',

--- a/packages/block-library/src/subhead/transforms.js
+++ b/packages/block-library/src/subhead/transforms.js
@@ -8,8 +8,8 @@ const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'core/paragraph' ],
-			transform: ( attributes ) =>
-				createBlock( 'core/paragraph', attributes ),
+			convert: ( block ) =>
+				createBlock( 'core/paragraph', block.attributes ),
 		},
 	],
 };

--- a/packages/block-library/src/text-columns/transforms.js
+++ b/packages/block-library/src/text-columns/transforms.js
@@ -8,7 +8,7 @@ const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'core/columns' ],
-			transform: ( { className, columns, content, width } ) => (
+			convert: ( { attributes: { className, columns, content, width } } ) => (
 				createBlock(
 					'core/columns',
 					{

--- a/packages/block-library/src/verse/transforms.js
+++ b/packages/block-library/src/verse/transforms.js
@@ -8,16 +8,16 @@ const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'core/paragraph' ],
-			transform: ( attributes ) =>
-				createBlock( 'core/verse', attributes ),
+			convert: ( block ) =>
+				createBlock( 'core/verse', block.attributes ),
 		},
 	],
 	to: [
 		{
 			type: 'block',
 			blocks: [ 'core/paragraph' ],
-			transform: ( attributes ) =>
-				createBlock( 'core/paragraph', attributes ),
+			convert: ( block ) =>
+				createBlock( 'core/paragraph', block.attributes ),
 		},
 	],
 };

--- a/packages/block-library/src/video/transforms.js
+++ b/packages/block-library/src/video/transforms.js
@@ -11,7 +11,7 @@ const transforms = {
 			isMatch( files ) {
 				return files.length === 1 && files[ 0 ].type.indexOf( 'video/' ) === 0;
 			},
-			transform( files ) {
+			convert( files ) {
 				const file = files[ 0 ];
 				// We don't need to upload the media directly here
 				// It's already done as part of the `componentDidMount`

--- a/packages/blocks/CHANGELOG.md
+++ b/packages/blocks/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Master
+
+### New features
+
+- Added `convert()` method option to `transforms` definition. It receives complete block object(s) as it's argument (as an array of blocks only if `isMultiBlock` is also defined on the transformation). It is now preferred in place of the `transform` method.
+
 ## 6.4.0 (2019-08-05)
 
 ### Improvements

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -27,6 +27,7 @@
 		"@wordpress/block-serialization-default-parser": "file:../block-serialization-default-parser",
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/data": "file:../data",
+		"@wordpress/deprecated": "file:../deprecated",
 		"@wordpress/dom": "file:../dom",
 		"@wordpress/element": "file:../element",
 		"@wordpress/hooks": "file:../hooks",

--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -405,16 +405,16 @@ export function switchToBlockType( blocks, name ) {
 	let transformationResults;
 
 	if ( transformation.isMultiBlock ) {
-		if ( has( transformation, '__experimentalConvert' ) ) {
-			transformationResults = transformation.__experimentalConvert( blocksArray );
+		if ( has( transformation, 'convert' ) ) {
+			transformationResults = transformation.convert( blocksArray );
 		} else {
 			transformationResults = transformation.transform(
 				blocksArray.map( ( currentBlock ) => currentBlock.attributes ),
 				blocksArray.map( ( currentBlock ) => currentBlock.innerBlocks ),
 			);
 		}
-	} else if ( has( transformation, '__experimentalConvert' ) ) {
-		transformationResults = transformation.__experimentalConvert( firstBlock );
+	} else if ( has( transformation, 'convert' ) ) {
+		transformationResults = transformation.convert( firstBlock );
 	} else {
 		transformationResults = transformation.transform( firstBlock.attributes, firstBlock.innerBlocks );
 	}

--- a/packages/blocks/src/api/raw-handling/index.js
+++ b/packages/blocks/src/api/raw-handling/index.js
@@ -64,10 +64,10 @@ function htmlToBlocks( { html, rawTransforms } ) {
 			);
 		}
 
-		const { transform, blockName } = rawTransform;
+		const { convert, blockName } = rawTransform;
 
-		if ( transform ) {
-			return transform( node );
+		if ( convert ) {
+			return convert( node );
 		}
 
 		return createBlock(

--- a/packages/blocks/src/api/raw-handling/paste-handler.js
+++ b/packages/blocks/src/api/raw-handling/paste-handler.js
@@ -99,10 +99,10 @@ function htmlToBlocks( { html, rawTransforms } ) {
 			);
 		}
 
-		const { transform, blockName } = rawTransform;
+		const { convert, blockName } = rawTransform;
 
-		if ( transform ) {
-			return transform( node );
+		if ( convert ) {
+			return convert( node );
 		}
 
 		return createBlock(

--- a/packages/blocks/src/api/test/factory.js
+++ b/packages/blocks/src/api/test/factory.js
@@ -1302,7 +1302,7 @@ describe( 'block factory', () => {
 			expect( transformedBlocks[ 1 ].innerBlocks[ 0 ].attributes.value ).toBe( 'after1' );
 		} );
 
-		it( 'should pass entire block object(s) to the "__experimentalConvert" method if defined', () => {
+		it( 'should pass entire block object(s) to the "convert" method if defined', () => {
 			registerBlockType( 'core/test-group-block', {
 				attributes: {
 					value: {
@@ -1314,7 +1314,7 @@ describe( 'block factory', () => {
 						type: 'block',
 						blocks: [ '*' ],
 						isMultiBlock: true,
-						__experimentalConvert( blocks ) {
+						convert( blocks ) {
 							const groupInnerBlocks = blocks.map( ( { name, attributes, innerBlocks } ) => {
 								return createBlock( name, attributes, innerBlocks );
 							} );
@@ -1344,7 +1344,7 @@ describe( 'block factory', () => {
 			expect( transformedBlocks[ 0 ].innerBlocks ).toHaveLength( numOfBlocksToGroup );
 		} );
 
-		it( 'should prefer "__experimentalConvert" method over "transform" method when running a transformation', () => {
+		it( 'should prefer "convert" method over "transform" method when running a transformation', () => {
 			const convertSpy = jest.fn( ( blocks ) => {
 				const groupInnerBlocks = blocks.map( ( { name, attributes, innerBlocks } ) => {
 					return createBlock( name, attributes, innerBlocks );
@@ -1365,7 +1365,7 @@ describe( 'block factory', () => {
 						type: 'block',
 						blocks: [ '*' ],
 						isMultiBlock: true,
-						__experimentalConvert: convertSpy,
+						convert: convertSpy,
 						transform: transformSpy,
 					} ],
 				},

--- a/packages/blocks/src/api/test/factory.js
+++ b/packages/blocks/src/api/test/factory.js
@@ -5,6 +5,11 @@ import deepFreeze from 'deep-freeze';
 import { noop, times } from 'lodash';
 
 /**
+ * WordPress dependencies
+ */
+import deprecated from '@wordpress/deprecated';
+
+/**
  * Internal dependencies
  */
 import {
@@ -25,6 +30,12 @@ import {
 	unregisterBlockType,
 	setGroupingBlockName,
 } from '../registration';
+
+// Disable reason: The mock is intentional in calling `console.warn` to flag
+// unexpected deprecated calls.
+//
+// eslint-disable-next-line no-console
+jest.mock( '@wordpress/deprecated', () => jest.fn( require.requireActual( '@wordpress/deprecated' ).default ) );
 
 describe( 'block factory', () => {
 	const defaultBlockSettings = {
@@ -285,7 +296,7 @@ describe( 'block factory', () => {
 					from: [ {
 						type: 'block',
 						blocks: [ 'core/text-block' ],
-						transform: noop,
+						convert: noop,
 					} ],
 				},
 				save: noop,
@@ -315,7 +326,7 @@ describe( 'block factory', () => {
 					to: [ {
 						type: 'block',
 						blocks: [ 'core/text-block' ],
-						transform: noop,
+						convert: noop,
 					} ],
 				},
 				save: noop,
@@ -345,7 +356,7 @@ describe( 'block factory', () => {
 					from: [ {
 						type: 'block',
 						blocks: [ 'core/text-block' ],
-						transform: noop,
+						convert: noop,
 					} ],
 				},
 				save: noop,
@@ -378,7 +389,7 @@ describe( 'block factory', () => {
 					to: [ {
 						type: 'block',
 						blocks: [ 'core/updated-text-block' ],
-						transform: noop,
+						convert: noop,
 					} ],
 				},
 				save: noop,
@@ -411,7 +422,7 @@ describe( 'block factory', () => {
 					from: [ {
 						type: 'block',
 						blocks: [ 'core/text-block' ],
-						transform: noop,
+						convert: noop,
 						isMultiBlock: true,
 					} ],
 				},
@@ -446,7 +457,7 @@ describe( 'block factory', () => {
 					to: [ {
 						type: 'block',
 						blocks: [ 'core/updated-text-block' ],
-						transform: noop,
+						convert: noop,
 						isMultiBlock: true,
 					} ],
 				},
@@ -481,12 +492,12 @@ describe( 'block factory', () => {
 					to: [ {
 						type: 'block',
 						blocks: [ 'core/text-block' ],
-						transform: noop,
+						convert: noop,
 						isMultiBlock: true,
 					}, {
 						type: 'block',
 						blocks: [ 'core/another-text-block' ],
-						transform: noop,
+						convert: noop,
 						isMultiBlock: true,
 					} ],
 				},
@@ -519,7 +530,7 @@ describe( 'block factory', () => {
 					from: [ {
 						type: 'block',
 						blocks: [ 'core/text-block' ],
-						transform: noop,
+						convert: noop,
 						isMultiBlock: false,
 					} ],
 				},
@@ -537,7 +548,7 @@ describe( 'block factory', () => {
 					from: [ {
 						type: 'block',
 						blocks: [ 'core/text-block' ],
-						transform: noop,
+						convert: noop,
 						isMultiBlock: true,
 					} ],
 				},
@@ -569,7 +580,7 @@ describe( 'block factory', () => {
 					to: [ {
 						type: 'block',
 						blocks: [ 'core/text-block', 'core/another-text-block' ],
-						transform: noop,
+						convert: noop,
 					} ],
 				},
 				save: noop,
@@ -601,7 +612,7 @@ describe( 'block factory', () => {
 					from: [ {
 						type: 'block',
 						blocks: [ 'core/text-block' ],
-						transform: noop,
+						convert: noop,
 						isMatch: () => true,
 					} ],
 				},
@@ -632,7 +643,7 @@ describe( 'block factory', () => {
 					from: [ {
 						type: 'block',
 						blocks: [ 'core/text-block' ],
-						transform: noop,
+						convert: noop,
 						isMatch: () => false,
 					} ],
 				},
@@ -662,7 +673,7 @@ describe( 'block factory', () => {
 					to: [ {
 						type: 'block',
 						blocks: [ 'core/text-block' ],
-						transform: noop,
+						convert: noop,
 						isMatch: () => true,
 					} ],
 				},
@@ -693,7 +704,7 @@ describe( 'block factory', () => {
 					to: [ {
 						type: 'block',
 						blocks: [ 'core/text-block' ],
-						transform: noop,
+						convert: noop,
 						isMatch: () => false,
 					} ],
 				},
@@ -725,7 +736,7 @@ describe( 'block factory', () => {
 					to: [ {
 						type: 'block',
 						blocks: [ 'core/text-block' ],
-						transform: noop,
+						convert: noop,
 						isMatch,
 					} ],
 				},
@@ -757,7 +768,7 @@ describe( 'block factory', () => {
 					to: [ {
 						type: 'block',
 						blocks: [ 'core/text-block' ],
-						transform: noop,
+						convert: noop,
 						isMultiBlock: true,
 						isMatch,
 					} ],
@@ -793,7 +804,7 @@ describe( 'block factory', () => {
 						from: [ {
 							type: 'block',
 							blocks: [ '*' ],
-							transform: noop,
+							convert: noop,
 						} ],
 					},
 					save: noop,
@@ -858,7 +869,7 @@ describe( 'block factory', () => {
 	} );
 
 	describe( 'switchToBlockType()', () => {
-		it( 'should switch the blockType of a block using the "transform form"', () => {
+		it( 'should switch the blockType of a block using the "transform from"', () => {
 			registerBlockType( 'core/updated-text-block', {
 				attributes: {
 					value: {
@@ -869,9 +880,9 @@ describe( 'block factory', () => {
 					from: [ {
 						type: 'block',
 						blocks: [ 'core/text-block' ],
-						transform: ( { value } ) => {
+						convert( block ) {
 							return createBlock( 'core/updated-text-block', {
-								value: 'chicken ' + value,
+								value: 'chicken ' + block.attributes.value,
 							} );
 						},
 					} ],
@@ -909,9 +920,9 @@ describe( 'block factory', () => {
 					to: [ {
 						type: 'block',
 						blocks: [ 'core/updated-text-block' ],
-						transform: ( { value } ) => {
+						convert( block ) {
 							return createBlock( 'core/updated-text-block', {
-								value: 'chicken ' + value,
+								value: 'chicken ' + block.attributes.value,
 							} );
 						},
 					} ],
@@ -959,7 +970,7 @@ describe( 'block factory', () => {
 				transforms: {
 					from: [ {
 						blocks: [ 'core/text-block' ],
-						transform: () => null,
+						convert: () => null,
 					} ],
 				},
 				save: noop,
@@ -987,7 +998,7 @@ describe( 'block factory', () => {
 				transforms: {
 					from: [ {
 						blocks: [ 'core/text-block' ],
-						transform: () => [],
+						convert: () => [],
 					} ],
 				},
 				save: noop,
@@ -1015,10 +1026,10 @@ describe( 'block factory', () => {
 				transforms: {
 					from: [ {
 						blocks: [ 'core/text-block' ],
-						transform: ( { value } ) => {
+						convert( block ) {
 							return {
 								attributes: {
-									value: 'chicken ' + value,
+									value: 'chicken ' + block.attributes.value,
 								},
 							};
 						},
@@ -1049,14 +1060,14 @@ describe( 'block factory', () => {
 				transforms: {
 					from: [ {
 						blocks: [ 'core/text-block' ],
-						transform: ( { value } ) => {
+						convert( block ) {
 							return [
 								createBlock( 'core/updated-text-block', {
-									value: 'chicken ' + value,
+									value: 'chicken ' + block.attributes.value,
 								} ),
 								{
 									attributes: {
-										value: 'smoked ' + value,
+										value: 'smoked ' + block.attributes.value,
 									},
 								},
 							];
@@ -1089,9 +1100,9 @@ describe( 'block factory', () => {
 				transforms: {
 					to: [ {
 						blocks: [ 'core/updated-text-block' ],
-						transform: ( { value } ) => {
+						convert( block ) {
 							return createBlock( 'core/text-block', {
-								value: 'chicken ' + value,
+								value: 'chicken ' + block.attributes,
 							} );
 						},
 					} ],
@@ -1121,13 +1132,13 @@ describe( 'block factory', () => {
 				transforms: {
 					to: [ {
 						blocks: [ 'core/updated-text-block' ],
-						transform: ( { value } ) => {
+						convert( block ) {
 							return [
 								createBlock( 'core/text-block', {
-									value: 'chicken ' + value,
+									value: 'chicken ' + block.attributes.value,
 								} ),
 								createBlock( 'core/text-block', {
-									value: 'smoked ' + value,
+									value: 'smoked ' + block.attributes.value,
 								} ),
 							];
 						},
@@ -1159,13 +1170,13 @@ describe( 'block factory', () => {
 					to: [ {
 						type: 'block',
 						blocks: [ 'core/updated-text-block' ],
-						transform: ( { value } ) => {
+						convert( block ) {
 							return [
 								createBlock( 'core/text-block', {
-									value: 'chicken ' + value,
+									value: 'chicken ' + block.attributes.value,
 								} ),
 								createBlock( 'core/updated-text-block', {
-									value: 'smoked ' + value,
+									value: 'smoked ' + block.attributes.value,
 								} ),
 							];
 						},
@@ -1202,51 +1213,7 @@ describe( 'block factory', () => {
 			} );
 		} );
 
-		it( 'should pass through inner blocks to transform', () => {
-			registerBlockType( 'core/updated-columns-block', {
-				attributes: {
-					value: {
-						type: 'string',
-					},
-				},
-				transforms: {
-					from: [ {
-						type: 'block',
-						blocks: [ 'core/columns-block' ],
-						transform( attributes, innerBlocks ) {
-							return createBlock(
-								'core/updated-columns-block',
-								attributes,
-								innerBlocks.map( ( innerBlock ) => {
-									return cloneBlock( innerBlock, {
-										value: 'after',
-									} );
-								} ),
-							);
-						},
-					} ],
-				},
-				save: noop,
-				category: 'common',
-				title: 'updated columns block',
-			} );
-			registerBlockType( 'core/columns-block', defaultBlockSettings );
-			registerBlockType( 'core/column-block', defaultBlockSettings );
-
-			const block = createBlock(
-				'core/columns-block',
-				{},
-				[ createBlock( 'core/column-block', { value: 'before' } ) ]
-			);
-
-			const transformedBlocks = switchToBlockType( block, 'core/updated-columns-block' );
-
-			expect( transformedBlocks ).toHaveLength( 1 );
-			expect( transformedBlocks[ 0 ].innerBlocks ).toHaveLength( 1 );
-			expect( transformedBlocks[ 0 ].innerBlocks[ 0 ].attributes.value ).toBe( 'after' );
-		} );
-
-		it( 'should pass through inner blocks to transform (multi)', () => {
+		it( 'should pass multiple blocks to transform (multi)', () => {
 			registerBlockType( 'core/updated-columns-block', {
 				attributes: {
 					value: {
@@ -1258,12 +1225,12 @@ describe( 'block factory', () => {
 						type: 'block',
 						blocks: [ 'core/columns-block' ],
 						isMultiBlock: true,
-						transform( blocksAttributes, blocksInnerBlocks ) {
-							return blocksAttributes.map( ( attributes, i ) => {
+						convert( blocks ) {
+							return blocks.map( ( { attributes, innerBlocks }, i ) => {
 								return createBlock(
 									'core/updated-columns-block',
 									attributes,
-									blocksInnerBlocks[ i ].map( ( innerBlock ) => {
+									innerBlocks.map( ( innerBlock ) => {
 										return cloneBlock( innerBlock, {
 											value: 'after' + i,
 										} );
@@ -1302,131 +1269,195 @@ describe( 'block factory', () => {
 			expect( transformedBlocks[ 1 ].innerBlocks[ 0 ].attributes.value ).toBe( 'after1' );
 		} );
 
-		it( 'should pass the entire block object to the "convert" method if defined', () => {
-			registerBlockType( 'core/updated-text-block', {
-				attributes: {
-					value: {
-						type: 'string',
-					},
-				},
-				transforms: {
-					from: [ {
-						type: 'block',
-						blocks: [ 'core/text-block' ],
-						convert( block ) {
-							return createBlock( 'core/updated-text-block', {
-								value: 'chicken ' + block.attributes.value,
-							} );
+		describe( 'deprecated `transform`', () => {
+			beforeEach( () => {
+				// Since deprecations are expected, disable default console warn
+				// implementation and verify call, restore original after test.
+				deprecated.mockImplementation( () => {} );
+			} );
+
+			afterEach( () => {
+				expect( deprecated ).toHaveBeenCalled();
+				deprecated.mockReset();
+			} );
+
+			it( 'should switch the blockType of a block using the "transform from"', () => {
+				registerBlockType( 'core/updated-text-block', {
+					attributes: {
+						value: {
+							type: 'string',
 						},
-					} ],
-				},
-				save: noop,
-				category: 'common',
-				title: 'updated text block',
-			} );
-			registerBlockType( 'core/text-block', defaultBlockSettings );
-
-			const block = createBlock( 'core/text-block', {
-				value: 'ribs',
-			} );
-
-			const transformedBlocks = switchToBlockType( block, 'core/updated-text-block' );
-
-			expect( transformedBlocks ).toHaveLength( 1 );
-			expect( transformedBlocks[ 0 ] ).toHaveProperty( 'clientId' );
-			expect( transformedBlocks[ 0 ].name ).toBe( 'core/updated-text-block' );
-			expect( transformedBlocks[ 0 ].isValid ).toBe( true );
-			expect( transformedBlocks[ 0 ].attributes ).toEqual( {
-				value: 'chicken ribs',
-			} );
-		} );
-
-		it( 'should pass entire block objects to the "convert" method if defined (multi)', () => {
-			registerBlockType( 'core/test-group-block', {
-				attributes: {
-					value: {
-						type: 'string',
 					},
-				},
-				transforms: {
-					from: [ {
-						type: 'block',
-						blocks: [ '*' ],
-						isMultiBlock: true,
-						convert( blocks ) {
-							const groupInnerBlocks = blocks.map( ( { name, attributes, innerBlocks } ) => {
-								return createBlock( name, attributes, innerBlocks );
-							} );
+					transforms: {
+						from: [ {
+							type: 'block',
+							blocks: [ 'core/text-block' ],
+							transform: ( { value } ) => {
+								return createBlock( 'core/updated-text-block', {
+									value: 'chicken ' + value,
+								} );
+							},
+						} ],
+					},
+					save: noop,
+					category: 'common',
+					title: 'updated text block',
+				} );
+				registerBlockType( 'core/text-block', defaultBlockSettings );
 
-							return createBlock( 'core/test-group-block', {}, groupInnerBlocks );
+				const block = createBlock( 'core/text-block', {
+					value: 'ribs',
+				} );
+
+				const transformedBlocks = switchToBlockType( block, 'core/updated-text-block' );
+
+				expect( transformedBlocks ).toHaveLength( 1 );
+				expect( transformedBlocks[ 0 ] ).toHaveProperty( 'clientId' );
+				expect( transformedBlocks[ 0 ].name ).toBe( 'core/updated-text-block' );
+				expect( transformedBlocks[ 0 ].isValid ).toBe( true );
+				expect( transformedBlocks[ 0 ].attributes ).toEqual( {
+					value: 'chicken ribs',
+				} );
+			} );
+
+			it( 'should switch the blockType of a block using the "transform to"', () => {
+				registerBlockType( 'core/updated-text-block', defaultBlockSettings );
+				registerBlockType( 'core/text-block', {
+					attributes: {
+						value: {
+							type: 'string',
 						},
-					} ],
-				},
-				save: noop,
-				category: 'common',
-				title: 'Test Group Block',
-			} );
-
-			registerBlockType( 'core/text-block', defaultBlockSettings );
-
-			const numOfBlocksToGroup = 4;
-			const blocks = times( numOfBlocksToGroup, ( index ) => {
-				return createBlock( 'core/text-block', {
-					value: `textBlock${ index + 1 }`,
-				} );
-			} );
-
-			const transformedBlocks = switchToBlockType( blocks, 'core/test-group-block' );
-
-			expect( transformedBlocks ).toHaveLength( 1 );
-			expect( transformedBlocks[ 0 ].name ).toBe( 'core/test-group-block' );
-			expect( transformedBlocks[ 0 ].innerBlocks ).toHaveLength( numOfBlocksToGroup );
-		} );
-
-		it( 'should prefer "convert" method over "transform" method when running a transformation', () => {
-			const convertSpy = jest.fn( ( blocks ) => {
-				const groupInnerBlocks = blocks.map( ( { name, attributes, innerBlocks } ) => {
-					return createBlock( name, attributes, innerBlocks );
-				} );
-
-				return createBlock( 'core/test-group-block', {}, groupInnerBlocks );
-			} );
-			const transformSpy = jest.fn();
-
-			registerBlockType( 'core/test-group-block', {
-				attributes: {
-					value: {
-						type: 'string',
 					},
-				},
-				transforms: {
-					from: [ {
-						type: 'block',
-						blocks: [ '*' ],
-						isMultiBlock: true,
-						convert: convertSpy,
-						transform: transformSpy,
-					} ],
-				},
-				save: noop,
-				category: 'common',
-				title: 'Test Group Block',
-			} );
+					transforms: {
+						to: [ {
+							type: 'block',
+							blocks: [ 'core/updated-text-block' ],
+							transform: ( { value } ) => {
+								return createBlock( 'core/updated-text-block', {
+									value: 'chicken ' + value,
+								} );
+							},
+						} ],
+					},
+					save: noop,
+					category: 'common',
+					title: 'text-block',
+				} );
 
-			registerBlockType( 'core/text-block', defaultBlockSettings );
+				const block = createBlock( 'core/text-block', {
+					value: 'ribs',
+				} );
 
-			const numOfBlocksToGroup = 4;
-			const blocks = times( numOfBlocksToGroup, ( index ) => {
-				return createBlock( 'core/text-block', {
-					value: `textBlock${ index + 1 }`,
+				const transformedBlocks = switchToBlockType( block, 'core/updated-text-block' );
+
+				expect( transformedBlocks ).toHaveLength( 1 );
+				expect( transformedBlocks[ 0 ] ).toHaveProperty( 'clientId' );
+				expect( transformedBlocks[ 0 ].name ).toBe( 'core/updated-text-block' );
+				expect( transformedBlocks[ 0 ].isValid ).toBe( true );
+				expect( transformedBlocks[ 0 ].attributes ).toEqual( {
+					value: 'chicken ribs',
 				} );
 			} );
 
-			const transformedBlocks = switchToBlockType( blocks, 'core/test-group-block' );
+			it( 'should pass through inner blocks to transform', () => {
+				registerBlockType( 'core/updated-columns-block', {
+					attributes: {
+						value: {
+							type: 'string',
+						},
+					},
+					transforms: {
+						from: [ {
+							type: 'block',
+							blocks: [ 'core/columns-block' ],
+							transform( attributes, innerBlocks ) {
+								return createBlock(
+									'core/updated-columns-block',
+									attributes,
+									innerBlocks.map( ( innerBlock ) => {
+										return cloneBlock( innerBlock, {
+											value: 'after',
+										} );
+									} ),
+								);
+							},
+						} ],
+					},
+					save: noop,
+					category: 'common',
+					title: 'updated columns block',
+				} );
+				registerBlockType( 'core/columns-block', defaultBlockSettings );
+				registerBlockType( 'core/column-block', defaultBlockSettings );
 
-			expect( transformedBlocks ).toHaveLength( 1 );
-			expect( convertSpy.mock.calls ).toHaveLength( 1 );
-			expect( transformSpy.mock.calls ).toHaveLength( 0 );
+				const block = createBlock(
+					'core/columns-block',
+					{},
+					[ createBlock( 'core/column-block', { value: 'before' } ) ]
+				);
+
+				const transformedBlocks = switchToBlockType( block, 'core/updated-columns-block' );
+
+				expect( transformedBlocks ).toHaveLength( 1 );
+				expect( transformedBlocks[ 0 ].innerBlocks ).toHaveLength( 1 );
+				expect( transformedBlocks[ 0 ].innerBlocks[ 0 ].attributes.value ).toBe( 'after' );
+			} );
+
+			it( 'should pass through inner blocks to transform (multi)', () => {
+				registerBlockType( 'core/updated-columns-block', {
+					attributes: {
+						value: {
+							type: 'string',
+						},
+					},
+					transforms: {
+						from: [ {
+							type: 'block',
+							blocks: [ 'core/columns-block' ],
+							isMultiBlock: true,
+							transform( blocksAttributes, blocksInnerBlocks ) {
+								return blocksAttributes.map( ( attributes, i ) => {
+									return createBlock(
+										'core/updated-columns-block',
+										attributes,
+										blocksInnerBlocks[ i ].map( ( innerBlock ) => {
+											return cloneBlock( innerBlock, {
+												value: 'after' + i,
+											} );
+										} ),
+									);
+								} );
+							},
+						} ],
+					},
+					save: noop,
+					category: 'common',
+					title: 'updated columns block',
+				} );
+				registerBlockType( 'core/columns-block', defaultBlockSettings );
+				registerBlockType( 'core/column-block', defaultBlockSettings );
+
+				const blocks = [
+					createBlock(
+						'core/columns-block',
+						{},
+						[ createBlock( 'core/column-block', { value: 'before' } ) ]
+					),
+					createBlock(
+						'core/columns-block',
+						{},
+						[ createBlock( 'core/column-block', { value: 'before' } ) ]
+					),
+				];
+
+				const transformedBlocks = switchToBlockType( blocks, 'core/updated-columns-block' );
+
+				expect( transformedBlocks ).toHaveLength( 2 );
+				expect( transformedBlocks[ 0 ].innerBlocks ).toHaveLength( 1 );
+				expect( transformedBlocks[ 0 ].innerBlocks[ 0 ].attributes.value ).toBe( 'after0' );
+				expect( transformedBlocks[ 1 ].innerBlocks ).toHaveLength( 1 );
+				expect( transformedBlocks[ 1 ].innerBlocks[ 0 ].attributes.value ).toBe( 'after1' );
+			} );
 		} );
 	} );
 
@@ -1437,6 +1468,7 @@ describe( 'block factory', () => {
 				transforms: {
 					from: [ {
 						blocks: [ 'core/text-block' ],
+						convert() {},
 					} ],
 				},
 				save: noop,
@@ -1447,6 +1479,7 @@ describe( 'block factory', () => {
 				transforms: {
 					from: [ {
 						blocks: [ 'core/text-block' ],
+						convert() {},
 					} ],
 				},
 				save: noop,
@@ -1462,10 +1495,12 @@ describe( 'block factory', () => {
 				{
 					blocks: [ 'core/text-block' ],
 					blockName: 'core/transform-from-text-block-1',
+					convert: expect.any( Function ),
 				},
 				{
 					blocks: [ 'core/text-block' ],
 					blockName: 'core/transform-from-text-block-2',
+					convert: expect.any( Function ),
 				},
 			] );
 		} );
@@ -1489,6 +1524,7 @@ describe( 'block factory', () => {
 				{
 					blocks: [ 'core/text-block' ],
 					blockName: 'core/transform-from-text-block-1',
+					convert: expect.any( Function ),
 				},
 			] );
 		} );
@@ -1503,6 +1539,7 @@ describe( 'block factory', () => {
 				{
 					blocks: [ 'core/text-block' ],
 					blockName: 'core/transform-from-text-block-1',
+					convert: expect.any( Function ),
 				},
 			] );
 		} );
@@ -1514,15 +1551,18 @@ describe( 'block factory', () => {
 				blocks: [ 'core/text-block' ],
 				priority: 20,
 				blockName: 'core/transform-from-text-block-1',
+				convert() {},
 			},
 			{
 				blocks: [ 'core/text-block' ],
 				blockName: 'core/transform-from-text-block-3',
 				priority: 5,
+				convert() {},
 			},
 			{
 				blocks: [ 'core/text-block' ],
 				blockName: 'core/transform-from-text-block-2',
+				convert() {},
 			},
 		];
 
@@ -1533,6 +1573,7 @@ describe( 'block factory', () => {
 				blocks: [ 'core/text-block' ],
 				blockName: 'core/transform-from-text-block-3',
 				priority: 5,
+				convert: expect.any( Function ),
 			} );
 		} );
 
@@ -1605,7 +1646,7 @@ describe( 'block factory', () => {
 					from: [ {
 						type: 'block',
 						blocks: [ '*' ],
-						transform: noop,
+						convert: noop,
 					} ],
 				},
 				save: noop,

--- a/packages/blocks/src/api/test/factory.js
+++ b/packages/blocks/src/api/test/factory.js
@@ -1302,7 +1302,46 @@ describe( 'block factory', () => {
 			expect( transformedBlocks[ 1 ].innerBlocks[ 0 ].attributes.value ).toBe( 'after1' );
 		} );
 
-		it( 'should pass entire block object(s) to the "convert" method if defined', () => {
+		it( 'should pass the entire block object to the "convert" method if defined', () => {
+			registerBlockType( 'core/updated-text-block', {
+				attributes: {
+					value: {
+						type: 'string',
+					},
+				},
+				transforms: {
+					from: [ {
+						type: 'block',
+						blocks: [ 'core/text-block' ],
+						convert( block ) {
+							return createBlock( 'core/updated-text-block', {
+								value: 'chicken ' + block.attributes.value,
+							} );
+						},
+					} ],
+				},
+				save: noop,
+				category: 'common',
+				title: 'updated text block',
+			} );
+			registerBlockType( 'core/text-block', defaultBlockSettings );
+
+			const block = createBlock( 'core/text-block', {
+				value: 'ribs',
+			} );
+
+			const transformedBlocks = switchToBlockType( block, 'core/updated-text-block' );
+
+			expect( transformedBlocks ).toHaveLength( 1 );
+			expect( transformedBlocks[ 0 ] ).toHaveProperty( 'clientId' );
+			expect( transformedBlocks[ 0 ].name ).toBe( 'core/updated-text-block' );
+			expect( transformedBlocks[ 0 ].isValid ).toBe( true );
+			expect( transformedBlocks[ 0 ].attributes ).toEqual( {
+				value: 'chicken ribs',
+			} );
+		} );
+
+		it( 'should pass entire block objects to the "convert" method if defined (multi)', () => {
 			registerBlockType( 'core/test-group-block', {
 				attributes: {
 					value: {

--- a/packages/e2e-tests/plugins/custom-grouping-block/index.js
+++ b/packages/e2e-tests/plugins/custom-grouping-block/index.js
@@ -15,7 +15,7 @@
 				type: 'block',
 				blocks: [ '*' ],
 				isMultiBlock: true,
-				__experimentalConvert( blocks ) {
+				convert( blocks ) {
 					const groupInnerBlocks = blocks.map( ( { name, attributes, innerBlocks } ) => {
 						return wp.blocks.createBlock( name, attributes, innerBlocks );
 					} );

--- a/packages/e2e-tests/plugins/inner-blocks-templates/index.js
+++ b/packages/e2e-tests/plugins/inner-blocks-templates/index.js
@@ -89,8 +89,8 @@
 						'test/test-inner-blocks-locking-all',
 						'test/test-inner-blocks-paragraph-placeholder'
 					],
-					transform: function( attributes, innerBlocks ) {
-						return createBlock( 'test/test-inner-blocks-transformer-target', attributes, innerBlocks );
+					convert: function( block ) {
+						return createBlock( 'test/test-inner-blocks-transformer-target', block.attributes, block.innerBlocks );
 					},
 				},
 			],
@@ -98,8 +98,8 @@
 				{
 					type: 'block',
 					blocks: [ 'test/i-dont-exist' ],
-					transform: function( attributes, innerBlocks ) {
-						return createBlock( 'test/test-inner-blocks-transformer-target', attributes, innerBlocks );
+					convert: function( block ) {
+						return createBlock( 'test/test-inner-blocks-transformer-target', block.attributes, block.innerBlocks );
 					},
 				}
 			]

--- a/test/integration/blocks-raw-handling.test.js
+++ b/test/integration/blocks-raw-handling.test.js
@@ -72,7 +72,7 @@ describe( 'Blocks raw handling', () => {
 						isMatch: ( node ) => {
 							return 'words to live by' === node.textContent.trim();
 						},
-						transform: () => {
+						convert() {
 							return createBlock( 'core-embed/youtube', {
 								url: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
 							} );


### PR DESCRIPTION
Closes #15972
Related: #17743
Previously: #14908, #11979

This pull request seeks to stabilize and promote what is currently implemented as the `__experimentalConvert` function member of a block transformation. In doing so, it deprecates the existing `transform` method. `convert` differs from `transform` in that it will receive the full block object (or an array of block objects if the transform has `isMultiBlock: true`). By contrast, the `transform` function would receive an `attributes` object and `innerBlocks` array (or an array of `attributes` objects and an array of `innerBlocks` arrays if the transform has `isMultiBlock: true`). The multi-block transform signature was especially cumbersome to use, a consequence of the fact that it was added at a later time (#11979, see also a similar reflection on this at the time at https://github.com/WordPress/gutenberg/pull/11979#pullrequestreview-196198010).

Existing use of `transform` should be unaffected, but will log with a deprecation warning. All existing core block transforms have been updated. Likewise, the documentation has been updated to reflect the recommended usage. Furthermore, it has been enhanced to detail supported usage of either transforming _from or to_ multiple blocks.

**Needs Decision:** Throughout the process of putting together this branch, I've rediscovered the many inconsistencies we've carried with us in how we support transforms of varying types and use-cases. Much of this was summarized at https://github.com/WordPress/gutenberg/issues/15972#issuecomment-570248868 and subsequent comments. There are also related enhancement requests at #17758 and #14755. Even with these changes, there are still some inconsistencies around how we perform various block operations, where some functions (transform `isMatch`, deprecation `migrate`, shortcode transform `convert` will still receive an "attributes" object). I don't know that all of these would make sense to similarly port to a signature which receives a full block object. In the case of the shortcode transform, "attributes" holds a different meaning, and it and the "files" transform don't operate on blocks as the source. But, as mentioned in #17758, a shortcode does have a similar need for an "inner value" as part of its transformation. It would be worth having a discussion to settle on a clear picture for if and how we consider block operations in how it makes sense to devise a function signature.

**Testing Instructions:**

Verify there are no regressions in the behavior of block transforms.