### PR TITLE
Block: side inserter in Popover

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -396,6 +396,13 @@ function BlockListBlock( {
 		/>
 	);
 
+	// Position above the anchor, pop out towards the right, and position in the
+	// left corner. For the side inserter, pop out towards the left, and
+	// position in the right corner.
+	// To do: refactor `Popover` to make this prop clearer.
+	const popoverPosition = showEmptyBlockSideInserter ? 'top left right' : 'top right left';
+	const popoverIsSticky = isPartOfMultiSelection ? '.wp-block.is-multi-selected' : true;
+
 	return (
 		<animated.div
 			id={ blockElementId }
@@ -427,18 +434,20 @@ function BlockListBlock( {
 				// of the appropriate parent.
 				<ChildToolbarSlot />
 			) }
-			{ ( shouldShowBreadcrumb || shouldShowContextualToolbar || isForcingContextualToolbar.current ) && (
+			{ (
+				shouldShowBreadcrumb ||
+				shouldShowContextualToolbar ||
+				isForcingContextualToolbar.current ||
+				showEmptyBlockSideInserter
+			) && (
 				<Popover
 					noArrow
 					animate={ false }
-					// Position above the anchor, pop out towards the right,
-					// and position in the left corner.
-					// To do: refactor `Popover` to make this prop clearer.
-					position="top right left"
+					position={ popoverPosition }
 					focusOnMount={ false }
 					anchorRef={ blockNodeRef.current }
 					className="block-editor-block-list__block-popover"
-					__unstableSticky={ isPartOfMultiSelection ? '.wp-block.is-multi-selected' : true }
+					__unstableSticky={ showEmptyBlockSideInserter ? false : popoverIsSticky }
 					__unstableSlotName="block-toolbar"
 					// Allow subpixel positioning for the block movement animation.
 					__unstableAllowVerticalSubpixelPosition={ moverDirection !== 'horizontal' && wrapper.current }
@@ -459,6 +468,16 @@ function BlockListBlock( {
 							ref={ breadcrumb }
 							data-align={ wrapperProps ? wrapperProps[ 'data-align' ] : undefined }
 						/>
+					) }
+					{ showEmptyBlockSideInserter && (
+						<div className="block-editor-block-list__empty-block-inserter">
+							<Inserter
+								position="top right"
+								onToggle={ selectOnOpen }
+								rootClientId={ rootClientId }
+								clientId={ clientId }
+							/>
+						</div>
 					) }
 				</Popover>
 			) }
@@ -485,16 +504,6 @@ function BlockListBlock( {
 				</BlockCrashBoundary>
 				{ !! hasError && <BlockCrashWarning /> }
 			</div>
-			{ showEmptyBlockSideInserter && (
-				<div className="block-editor-block-list__empty-block-inserter">
-					<Inserter
-						position="top right"
-						onToggle={ selectOnOpen }
-						rootClientId={ rootClientId }
-						clientId={ clientId }
-					/>
-				</div>
-			) }
 		</animated.div>
 	);
 }

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -361,7 +361,6 @@
 	// This essentially duplicates the mobile styles for the appender component.
 	// It would be nice to be able to use element queries in that component instead https://github.com/tomhodgins/element-queries-spec
 	.block-editor-block-list__layout {
-		.block-editor-block-list__empty-block-inserter,
 		.block-editor-default-block-appender .block-editor-inserter {
 			left: auto;
 			right: $grid-size;
@@ -535,7 +534,7 @@
 	z-index: z-index(".block-editor-block-list__block-popover");
 
 	.components-popover__content {
-		margin-left: 0 !important;
+		margin: 0 !important;
 		min-width: auto;
 		background: none;
 		border: none;

--- a/packages/block-editor/src/components/default-block-appender/style.scss
+++ b/packages/block-editor/src/components/default-block-appender/style.scss
@@ -62,7 +62,6 @@
 	.components-button.has-icon {
 		width: $block-side-ui-width;
 		height: $block-side-ui-width;
-		margin-right: 12px;
 		padding: 0;
 	}
 
@@ -89,10 +88,7 @@
 
 	@include break-small {
 		display: flex;
-		align-items: center;
 		height: 100%;
-		left: -$block-side-ui-width - $block-padding - $block-side-ui-clearance;
-		right: auto;
 	}
 
 	&:disabled {
@@ -112,5 +108,11 @@
 				color: $light-opacity-500;
 			}
 		}
+	}
+}
+
+.block-editor-default-block-appender .block-editor-inserter {
+	@include break-small {
+		align-items: center;
 	}
 }


### PR DESCRIPTION
## Description

This PR moves the "side inserter" to the block controls popover.
It also consistently places it on the right side. Currently we place it on the right side on mobile and in nested context, but on the left on wide screens if the block is at the root. See https://github.com/WordPress/gutenberg/pull/19045#issuecomment-564134075.

Either we should consistently place it on the right side, or we could consider moving it to the left side but within the block boundary. I picked the first option because we're already doing that on mobile and for nested paragraphs. If needed, we can explore the inside-left option separately.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
