### PR TITLE
[RNMobile] Implement bold and italic keyboard Shortcuts

### DIFF
--- a/packages/block-editor/src/components/rich-text/shortcut.native.js
+++ b/packages/block-editor/src/components/rich-text/shortcut.native.js
@@ -2,9 +2,27 @@
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
+import { KeyboardShortcuts } from '@wordpress/components';
 
 export class RichTextShortcut extends Component {
+	constructor() {
+		super( ...arguments );
+		this.onUse = this.onUse.bind( this );
+	}
+
+	onUse() {
+		this.props.onUse();
+		return false;
+	}
+
 	render() {
-		return null;
+		const { character } = this.props;
+
+		return (
+			<KeyboardShortcuts
+				onUse={ this.onUse }
+				character={ character }
+			/>
+		);
 	}
 }

--- a/packages/components/src/index.native.js
+++ b/packages/components/src/index.native.js
@@ -20,6 +20,7 @@ export { default as TextControl } from './text-control';
 export { default as ToggleControl } from './toggle-control';
 export { default as SelectControl } from './select-control';
 export { default as RangeControl } from './range-control';
+export { default as KeyboardShortcuts } from './keyboard-shortcuts';
 
 // Higher-Order Components
 export { default as withConstrainedTabbing } from './higher-order/with-constrained-tabbing';

--- a/packages/components/src/keyboard-shortcuts/index.native.js
+++ b/packages/components/src/keyboard-shortcuts/index.native.js
@@ -1,2 +1,36 @@
-const KeyboardShortcuts = () => null;
+/**
+ * WordPress dependencies
+ */
+import { useEffect } from '@wordpress/element';
+/**
+ * External dependencies
+ */
+import { NativeModules, NativeEventEmitter } from 'react-native';
+const { RNReactNativeGutenbergBridge } = NativeModules;
+const gutenbergBridgeEvents = new NativeEventEmitter( RNReactNativeGutenbergBridge );
+
+const mapFromCharacterToEvent = ( character ) => {
+	switch ( character ) {
+		case 'b': return 'toggleBold';
+		case 'i': return 'toggleItalic';
+		case 'k': return 'addEditLink';
+	}
+};
+
+const KeyboardShortcuts = ( { character, onUse } ) => {
+	useEffect( () => {
+		const event = mapFromCharacterToEvent( character );
+		if ( ! event ) {
+			return;
+		}
+		if ( gutenbergBridgeEvents.listeners( event ).length > 0 ) {
+			return;
+		}
+		gutenbergBridgeEvents.addListener( event, onUse );
+		return () => {
+			gutenbergBridgeEvents.removeListener( onUse );
+		};
+	} );
+	return null;
+};
 export default KeyboardShortcuts;

--- a/packages/format-library/src/link/index.native.js
+++ b/packages/format-library/src/link/index.native.js
@@ -10,7 +10,7 @@ import { Clipboard } from 'react-native';
 import { __ } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
 import { withSpokenMessages } from '@wordpress/components';
-import { RichTextToolbarButton } from '@wordpress/block-editor';
+import { RichTextToolbarButton, RichTextShortcut } from '@wordpress/block-editor';
 import {
 	applyFormat,
 	getActiveFormat,
@@ -132,6 +132,11 @@ export const link = {
 			}
 			return (
 				<>
+					<RichTextShortcut
+						type="primary"
+						character="k"
+						onUse={ this.addLink }
+					/>
 					<ModalLinkUI
 						isVisible={ this.state.addingLink }
 						isActive={ isActive }

--- a/test/native/setup.js
+++ b/test/native/setup.js
@@ -86,6 +86,7 @@ const mockNativeModules = {
 		...NativeModules.UIManager,
 		getViewManagerConfig: jest.fn( () => ( { Commands: {} } ) ),
 	},
+	NativeEventEmitter: jest.fn(),
 };
 
 Object.keys( mockNativeModules ).forEach( ( module ) => {


### PR DESCRIPTION
## Description

This pr pairs with [changes to the gutenberg-mobile](https://github.com/wordpress-mobile/gutenberg-mobile/pull/1733) repo to implement bold and italic keyboard shortcuts. It follows the proposal I laid out [here](https://href.li/?https://hogwartsp2.wordpress.com/2019/12/21/shortcuts-implementation-proposal/).

## How has this been tested?
I tested keyboard shortcuts with an iOS simulator configured to send keyboard shortcuts from my mac's keyboard. 

I also tested android with a real phone and with [the hacker's keyboard](https://play.google.com/store/apps/details?id=org.pocketworkstation.pckeyboard) (which has a Control key)

## Types of changes
* New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
