### PR TITLE
Block Directory: Update the action button label to read 'Add block'.

### DIFF
--- a/packages/block-directory/src/components/downloadable-block-header/index.js
+++ b/packages/block-directory/src/components/downloadable-block-header/index.js
@@ -35,7 +35,7 @@ function DownloadableBlockHeader( { icon, title, rating, ratingCount, onClick } 
 					onClick();
 				} }
 			>
-				{ __( 'Add' ) }
+				{ __( 'Add block' ) }
 			</Button>
 		</div>
 	);


### PR DESCRIPTION
## Description
This change was identified in a pull request that was ultimately merged with the plan to update this button's text afterwards. 

The PR exists here:
https://github.com/WordPress/gutenberg/pull/16524/files#r324217233

Before making this change, I opened up a thread in the slack Gutenberg design channel for input. `Add block` was identified as the preferred update.

## Types of changes
Accessbility improvement.

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
