### PR TITLE
Make Nav Link Block text also editable from within the hyperlinklink creation UI

### DIFF
--- a/packages/block-editor/src/components/link-control/README.md
+++ b/packages/block-editor/src/components/link-control/README.md
@@ -35,20 +35,6 @@ An array of settings objects. Each object will used to render a `ToggleControl` 
 
 ## Event handlers
 
-### onChangeMode
-
-- Type: `Function`
-- Required: No
-
-Use this callback to know when the LinkControl component changes its mode to `edit` or `show`
-through of its function parameter.
-
-```es6
-<LinkControl
-	onChangeMode={ ( mode ) => { console.log( `Mode change to ${ mode } mode.` ) }
-/> 
-```  
-
 ### onClose
 
 - Type: `Function`

--- a/packages/block-editor/src/components/link-control/README.md
+++ b/packages/block-editor/src/components/link-control/README.md
@@ -7,12 +7,12 @@
 - Type: `String`
 - Required: Yes
 
-### currentLink
+### value
 
 - Type: `Object`
 - Required: Yes
 
-### currentSettings
+### settings
 
 - Type: `Array`
 - Required: No
@@ -22,12 +22,11 @@
 	{
 		id: 'newTab',
 		title: 'Open in New Tab',
-		checked: false,
 	},
 ];
 ```
 
-An array of settings objects. Each object will used to render a `ToggleControl` for that setting. See also `onSettingsChange`.
+An array of settings objects. Each object will used to render a `ToggleControl` for that setting.
 
 ### fetchSearchSuggestions
 
@@ -65,7 +64,7 @@ through of its function parameter.
 - Type: `Function`
 - Required: No
 
-### onLinkChange
+### onChange
 
 - Type: `Function`
 - Required: No
@@ -81,29 +80,5 @@ The function callback will receive the selected item, or Null.
 			: console.warn( 'No Item selected.' );
 	}
 /> 
-```  
-
-### onSettingsChange
-
-- Type: `Function`
-- Required: No
-- Args:
-  - `id` - the `id` property of the setting that changed (eg: `newTab`).
-  - `value` - the `checked` value of the control.
-  - `settings` - the current settings object.
-
-Called when any of the settings supplied as `currentSettings` are changed/toggled. May be used to attribute a Block's `attributes` with the current state of the control.
-
-```
-<LinkControl
-	currentSettings={ [
-		{
-			id: 'opensInNewTab',
-			title: __( 'Open in New Tab' ),
-			checked: attributes.opensInNewTab, // Block attributes persist control state
-		},
-	] }
-	onSettingsChange={ ( setting, value ) => setAttributes( { [ setting ]: value } ) }
-/>
 ```
 

--- a/packages/block-editor/src/components/link-control/README.md
+++ b/packages/block-editor/src/components/link-control/README.md
@@ -54,16 +54,6 @@ through of its function parameter.
 - Type: `Function`
 - Required: No
 
-### onKeyDown
-
-- Type: `Function`
-- Required: No
-
-### onKeyPress
-
-- Type: `Function`
-- Required: No
-
 ### onChange
 
 - Type: `Function`

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -82,7 +82,7 @@ function LinkControl( {
 
 		// Populate input searcher whether
 		// the current link has a title.
-		if ( value && value.title ) {
+		if ( value && value.title && mode === 'edit' ) {
 			setInputValue( value.title );
 		}
 
@@ -113,7 +113,7 @@ function LinkControl( {
 			type = 'tel';
 		}
 
-		if ( startsWith( value, '#' ) ) {
+		if ( startsWith( val, '#' ) ) {
 			type = 'internal';
 		}
 
@@ -121,7 +121,7 @@ function LinkControl( {
 			[ {
 				id: '-1',
 				title: val,
-				url: type === 'URL' ? prependHTTP( value ) : value,
+				url: type === 'URL' ? prependHTTP( val ) : val,
 				type,
 			} ]
 		);

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -11,6 +11,7 @@ import {
 	Button,
 	ExternalLink,
 	Popover,
+	TextControl,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
@@ -30,7 +31,14 @@ import {
 
 import { withInstanceId, compose } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
-
+import {
+	LEFT,
+	RIGHT,
+	UP,
+	DOWN,
+	BACKSPACE,
+	ENTER,
+} from '@wordpress/keycodes';
 /**
  * Internal dependencies
  */
@@ -49,6 +57,8 @@ function LinkControl( {
 	instanceId,
 	onClose = noop,
 	onChange = noop,
+	text = '',
+	onTextChange = noop,
 } ) {
 	// State
 	const [ inputValue, setInputValue ] = useState( '' );
@@ -133,6 +143,19 @@ function LinkControl( {
 		return couldBeURL ? results[ 0 ].concat( results[ 1 ] ) : results[ 0 ];
 	};
 
+	const handleTextControlOnKeyDown = ( event ) => {
+		const { keyCode } = event;
+
+		if ( [ LEFT, DOWN, RIGHT, UP, BACKSPACE, ENTER ].indexOf( keyCode ) > -1 ) {
+			// Stop the key event from propagating up to ObserveTyping.startTypingInTextField.
+			event.stopPropagation();
+		}
+	};
+
+	const handleTextControlOnKeyPress = ( event ) => {
+		event.stopPropagation();
+	};
+
 	// Effects
 	const getSearchHandler = useCallback( ( val ) => {
 		const protocol = getProtocol( val ) || '';
@@ -215,17 +238,33 @@ function LinkControl( {
 					) }
 
 					{ isEditingLink && (
-						<LinkControlSearchInput
-							value={ inputValue }
-							onChange={ onInputChange }
-							onSelect={ ( suggestion ) => {
-								setIsEditingLink( false );
-								onChange( { ...value, ...suggestion } );
-							} }
-							renderSuggestions={ renderSearchResults }
-							fetchSuggestions={ getSearchHandler }
-							onReset={ resetInput }
-						/>
+						<>
+							<LinkControlSearchInput
+								value={ inputValue }
+								onChange={ onInputChange }
+								onSelect={ ( suggestion ) => {
+									setIsEditingLink( false );
+									onChange( { ...value, ...suggestion } );
+								} }
+								renderSuggestions={ renderSearchResults }
+								fetchSuggestions={ getSearchHandler }
+								onReset={ resetInput }
+							/>
+
+							<TextControl
+								className="block-editor-link-control__text-content"
+								label="Text content"
+								value={ text }
+								onChange={ onTextChange }
+								onKeyDown={ ( event ) => {
+									if ( event.keyCode === ENTER ) {
+										return;
+									}
+									handleTextControlOnKeyDown( event );
+								} }
+								onKeyPress={ handleTextControlOnKeyPress }
+							/>
+						</>
 					) }
 
 					{ ! isEditingLink && (

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -49,8 +49,6 @@ function LinkControl( {
 	instanceId,
 	onClose = noop,
 	onChangeMode = noop,
-	onKeyDown = noop,
-	onKeyPress = noop,
 	onChange = noop,
 } ) {
 	// State
@@ -233,8 +231,6 @@ function LinkControl( {
 							renderSuggestions={ renderSearchResults }
 							fetchSuggestions={ getSearchHandler }
 							onReset={ resetInput }
-							onKeyDown={ onKeyDown }
-							onKeyPress={ onKeyPress }
 						/>
 					) }
 

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -17,7 +17,6 @@ import { __ } from '@wordpress/i18n';
 import {
 	useCallback,
 	useState,
-	useEffect,
 	Fragment,
 } from '@wordpress/element';
 
@@ -44,40 +43,29 @@ const MODE_EDIT = 'edit';
 
 function LinkControl( {
 	className,
-	currentLink,
-	currentSettings,
+	value,
+	settings,
 	fetchSearchSuggestions,
 	instanceId,
 	onClose = noop,
 	onChangeMode = noop,
 	onKeyDown = noop,
 	onKeyPress = noop,
-	onLinkChange = noop,
-	onSettingsChange = noop,
+	onChange = noop,
 } ) {
 	// State
 	const [ inputValue, setInputValue ] = useState( '' );
-	const [ isEditingLink, setIsEditingLink ] = useState( false );
-
-	// Effects
-	useEffect( () => {
-		// If we have a link then stop editing mode
-		if ( currentLink ) {
-			setIsEditingLink( false );
-		} else {
-			setIsEditingLink( true );
-		}
-	}, [ currentLink ] );
+	const [ isEditingLink, setIsEditingLink ] = useState( ! value || ! value.url );
 
 	// Handlers
 
 	/**
 	 * onChange LinkControlSearchInput event handler
 	 *
-	 * @param {string} value Current value returned by the search.
+	 * @param {string} val Current value returned by the search.
 	 */
-	const onInputChange = ( value = '' ) => {
-		setInputValue( value );
+	const onInputChange = ( val = '' ) => {
+		setInputValue( val );
 	};
 
 	// Utils
@@ -94,8 +82,8 @@ function LinkControl( {
 
 		// Populate input searcher whether
 		// the current link has a title.
-		if ( currentLink && currentLink.title ) {
-			setInputValue( currentLink.title );
+		if ( value && value.title ) {
+			setInputValue( value.title );
 		}
 
 		if ( isFunction( onChangeMode ) ) {
@@ -112,10 +100,10 @@ function LinkControl( {
 		setInputValue( '' );
 	};
 
-	const handleDirectEntry = ( value ) => {
+	const handleDirectEntry = ( val ) => {
 		let type = 'URL';
 
-		const protocol = getProtocol( value ) || '';
+		const protocol = getProtocol( val ) || '';
 
 		if ( protocol.includes( 'mailto' ) ) {
 			type = 'mailto';
@@ -132,20 +120,20 @@ function LinkControl( {
 		return Promise.resolve(
 			[ {
 				id: '-1',
-				title: value,
+				title: val,
 				url: type === 'URL' ? prependHTTP( value ) : value,
 				type,
 			} ]
 		);
 	};
 
-	const handleEntitySearch = async ( value ) => {
+	const handleEntitySearch = async ( val ) => {
 		const results = await Promise.all( [
-			fetchSearchSuggestions( value ),
-			handleDirectEntry( value ),
+			fetchSearchSuggestions( val ),
+			handleDirectEntry( val ),
 		] );
 
-		const couldBeURL = ! value.includes( ' ' );
+		const couldBeURL = ! val.includes( ' ' );
 
 		// If it's potentially a URL search then concat on a URL search suggestion
 		// just for good measure. That way once the actual results run out we always
@@ -154,15 +142,15 @@ function LinkControl( {
 	};
 
 	// Effects
-	const getSearchHandler = useCallback( ( value ) => {
-		const protocol = getProtocol( value ) || '';
+	const getSearchHandler = useCallback( ( val ) => {
+		const protocol = getProtocol( val ) || '';
 		const isMailto = protocol.includes( 'mailto' );
-		const isInternal = startsWith( value, '#' );
+		const isInternal = startsWith( val, '#' );
 		const isTel = protocol.includes( 'tel' );
 
-		const handleManualEntry = isInternal || isMailto || isTel || isURL( value ) || ( value && value.includes( 'www.' ) );
+		const handleManualEntry = isInternal || isMailto || isTel || isURL( val ) || ( val && val.includes( 'www.' ) );
 
-		return ( handleManualEntry ) ? handleDirectEntry( value ) : handleEntitySearch( value );
+		return ( handleManualEntry ) ? handleDirectEntry( val ) : handleEntitySearch( val );
 	}, [ handleDirectEntry, fetchSearchSuggestions ] );
 
 	// Render Components
@@ -181,7 +169,10 @@ function LinkControl( {
 							key={ `${ suggestion.id }-${ suggestion.type }` }
 							itemProps={ buildSuggestionItemProps( suggestion, index ) }
 							suggestion={ suggestion }
-							onClick={ () => onLinkChange( suggestion ) }
+							onClick={ () => {
+								setIsEditingLink( false );
+								onChange( { ...value, ...suggestion } );
+							} }
 							isSelected={ index === selectedSuggestion }
 							isURL={ manualLinkEntryTypes.includes( suggestion.type.toLowerCase() ) }
 							searchTerm={ inputValue }
@@ -202,7 +193,7 @@ function LinkControl( {
 			<div className="block-editor-link-control__popover-inner">
 				<div className="block-editor-link-control__search">
 
-					{ ( ! isEditingLink && currentLink ) && (
+					{ ( ! isEditingLink ) && (
 						<Fragment>
 							<p className="screen-reader-text" id={ `current-link-label-${ instanceId }` }>
 								{ __( 'Currently selected' ) }:
@@ -215,14 +206,13 @@ function LinkControl( {
 								} ) }
 							>
 								<span className="block-editor-link-control__search-item-header">
-
 									<ExternalLink
 										className="block-editor-link-control__search-item-title"
-										href={ currentLink.url }
+										href={ value.url }
 									>
-										{ currentLink.title }
+										{ value.title }
 									</ExternalLink>
-									<span className="block-editor-link-control__search-item-info">{ filterURLForDisplay( safeDecodeURI( currentLink.url ) ) || '' }</span>
+									<span className="block-editor-link-control__search-item-info">{ filterURLForDisplay( safeDecodeURI( value.url ) ) || '' }</span>
 								</span>
 
 								<Button isSecondary onClick={ setMode( MODE_EDIT ) } className="block-editor-link-control__search-item-action block-editor-link-control__search-item-action--edit">
@@ -236,7 +226,10 @@ function LinkControl( {
 						<LinkControlSearchInput
 							value={ inputValue }
 							onChange={ onInputChange }
-							onSelect={ onLinkChange }
+							onSelect={ ( suggestion ) => {
+								setIsEditingLink( false );
+								onChange( { ...value, ...suggestion } );
+							} }
 							renderSuggestions={ renderSearchResults }
 							fetchSuggestions={ getSearchHandler }
 							onReset={ resetInput }
@@ -246,7 +239,7 @@ function LinkControl( {
 					) }
 
 					{ ! isEditingLink && (
-						<LinkControlSettingsDrawer settings={ currentSettings } onSettingChange={ onSettingsChange } />
+						<LinkControlSettingsDrawer value={ value } settings={ settings } onChange={ onChange } />
 					) }
 				</div>
 			</div>

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -48,7 +48,6 @@ function LinkControl( {
 	fetchSearchSuggestions,
 	instanceId,
 	onClose = noop,
-	onChangeMode = noop,
 	onChange = noop,
 } ) {
 	// State
@@ -71,7 +70,6 @@ function LinkControl( {
 	/**
 	 * Handler function which switches the mode of the component,
 	 * between `edit` and `show` mode.
-	 * Also, it calls `onChangeMode` callback function.
 	 *
 	 * @param {string} mode Component mode: `show` or `edit`.
 	 */
@@ -82,10 +80,6 @@ function LinkControl( {
 		// the current link has a title.
 		if ( value && value.title && mode === 'edit' ) {
 			setInputValue( value.title );
-		}
-
-		if ( isFunction( onChangeMode ) ) {
-			onChangeMode( mode );
 		}
 	};
 

--- a/packages/block-editor/src/components/link-control/search-input.js
+++ b/packages/block-editor/src/components/link-control/search-input.js
@@ -4,12 +4,31 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
-import { ENTER } from '@wordpress/keycodes';
+import { LEFT,
+	RIGHT,
+	UP,
+	DOWN,
+	BACKSPACE,
+	ENTER,
+} from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
  */
 import { URLInput } from '../';
+
+const handleLinkControlOnKeyDown = ( event ) => {
+	const { keyCode } = event;
+
+	if ( [ LEFT, DOWN, RIGHT, UP, BACKSPACE, ENTER ].indexOf( keyCode ) > -1 ) {
+		// Stop the key event from propagating up to ObserveTyping.startTypingInTextField.
+		event.stopPropagation();
+	}
+};
+
+const handleLinkControlOnKeyPress = ( event ) => {
+	event.stopPropagation();
+};
 
 const LinkControlSearchInput = ( {
 	value,
@@ -18,8 +37,6 @@ const LinkControlSearchInput = ( {
 	renderSuggestions,
 	fetchSuggestions,
 	onReset,
-	onKeyDown,
-	onKeyPress,
 } ) => {
 	const selectItemHandler = ( selection, suggestion ) => {
 		onChange( selection );
@@ -44,9 +61,9 @@ const LinkControlSearchInput = ( {
 					if ( event.keyCode === ENTER ) {
 						return;
 					}
-					onKeyDown( event );
+					handleLinkControlOnKeyDown( event );
 				} }
-				onKeyPress={ onKeyPress }
+				onKeyPress={ handleLinkControlOnKeyPress }
 				placeholder={ __( 'Search or type url' ) }
 				__experimentalRenderSuggestions={ renderSuggestions }
 				__experimentalFetchLinkSuggestions={ fetchSuggestions }

--- a/packages/block-editor/src/components/link-control/settings-drawer.js
+++ b/packages/block-editor/src/components/link-control/settings-drawer.js
@@ -25,7 +25,7 @@ const LinkControlSettingsDrawer = ( { value, onChange = noop, settings = default
 
 	const handleSettingChange = ( setting ) => ( newValue ) => {
 		onChange( {
-			...settings,
+			...value,
 			[ setting.id ]: newValue,
 		} );
 	};

--- a/packages/block-editor/src/components/link-control/settings-drawer.js
+++ b/packages/block-editor/src/components/link-control/settings-drawer.js
@@ -15,17 +15,19 @@ const defaultSettings = [
 	{
 		id: 'newTab',
 		title: __( 'Open in New Tab' ),
-		checked: false,
 	},
 ];
 
-const LinkControlSettingsDrawer = ( { settings = defaultSettings, onSettingChange = noop } ) => {
+const LinkControlSettingsDrawer = ( { value, onChange = noop, settings = defaultSettings } ) => {
 	if ( ! settings || ! settings.length ) {
 		return null;
 	}
 
-	const handleSettingChange = ( setting ) => ( value ) => {
-		onSettingChange( setting.id, value, settings );
+	const handleSettingChange = ( setting ) => ( newValue ) => {
+		onChange( {
+			...settings,
+			[ setting.id ]: newValue,
+		} );
 	};
 
 	const theSettings = settings.map( ( setting ) => (
@@ -34,7 +36,7 @@ const LinkControlSettingsDrawer = ( { settings = defaultSettings, onSettingChang
 			key={ setting.id }
 			label={ setting.title }
 			onChange={ handleSettingChange( setting ) }
-			checked={ setting.checked } />
+			checked={ value ? value[ setting.id ] : false } />
 	) );
 
 	return (

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -30,6 +30,10 @@
 	}
 }
 
+.block-editor-link-control__text-content {
+	margin: $grid-size-large;
+}
+
 .block-editor-link-control__search-reset {
 	position: absolute;
 	top: 19px; // has to be hard coded as form expands with search suggestions

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -343,7 +343,6 @@ describe( 'Selecting links', () => {
 
 	it( 'should hide "selected" link UI and display search UI prepopulated with previously selected link title when "Change" button is clicked', () => {
 		const selectedLink = first( fauxEntitySuggestions );
-		const spyOnEditMode = jest.fn();
 
 		const LinkControlConsumer = () => {
 			const [ link, setLink ] = useState( selectedLink );
@@ -353,7 +352,6 @@ describe( 'Selecting links', () => {
 					value={ link }
 					onChange={ ( suggestion ) => setLink( suggestion ) }
 					fetchSearchSuggestions={ fetchFauxEntitySuggestions }
-					onChangeMode={ spyOnEditMode( 'edit' ) }
 				/>
 			);
 		};
@@ -380,7 +378,6 @@ describe( 'Selecting links', () => {
 		expect( searchInput ).not.toBeNull();
 		expect( searchInput.value ).toBe( selectedLink.title ); // prepopulated with previous link's title
 		expect( currentLinkUI ).toBeNull();
-		expect( spyOnEditMode ).toHaveBeenCalled();
 	} );
 
 	describe( 'Selection using mouse click', () => {

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -318,7 +318,7 @@ describe( 'Selecting links', () => {
 
 			return (
 				<LinkControl
-					currentLink={ link }
+					value={ link }
 					fetchSearchSuggestions={ fetchFauxEntitySuggestions }
 				/>
 			);
@@ -350,8 +350,8 @@ describe( 'Selecting links', () => {
 
 			return (
 				<LinkControl
-					currentLink={ link }
-					onLinkChange={ ( suggestion ) => setLink( suggestion ) }
+					value={ link }
+					onChange={ ( suggestion ) => setLink( suggestion ) }
 					fetchSearchSuggestions={ fetchFauxEntitySuggestions }
 					onChangeMode={ spyOnEditMode( 'edit' ) }
 				/>
@@ -398,8 +398,8 @@ describe( 'Selecting links', () => {
 
 				return (
 					<LinkControl
-						currentLink={ link }
-						onLinkChange={ ( suggestion ) => setLink( suggestion ) }
+						value={ link }
+						onChange={ ( suggestion ) => setLink( suggestion ) }
 						fetchSearchSuggestions={ fetchFauxEntitySuggestions }
 					/>
 				);
@@ -458,8 +458,8 @@ describe( 'Selecting links', () => {
 
 				return (
 					<LinkControl
-						currentLink={ link }
-						onLinkChange={ ( suggestion ) => setLink( suggestion ) }
+						value={ link }
+						onChange={ ( suggestion ) => setLink( suggestion ) }
 						fetchSearchSuggestions={ fetchFauxEntitySuggestions }
 					/>
 				);
@@ -547,7 +547,7 @@ describe( 'Addition Settings UI', () => {
 
 			return (
 				<LinkControl
-					currentLink={ link }
+					value={ link }
 					fetchSearchSuggestions={ fetchFauxEntitySuggestions }
 				/>
 			);
@@ -577,12 +577,10 @@ describe( 'Addition Settings UI', () => {
 			{
 				id: 'newTab',
 				title: 'Open in New Tab',
-				checked: false,
 			},
 			{
 				id: 'noFollow',
 				title: 'No follow',
-				checked: true,
 			},
 		];
 
@@ -593,9 +591,9 @@ describe( 'Addition Settings UI', () => {
 
 			return (
 				<LinkControl
-					currentLink={ link }
+					value={ { ...link, newTab: false, noFollow: true } }
 					fetchSearchSuggestions={ fetchFauxEntitySuggestions }
-					currentSettings={ customSettings }
+					settings={ customSettings }
 				/>
 			);
 		};

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -54,39 +54,19 @@ function NavigationLinkEdit( {
 	const link = {
 		title: title ? unescape( title ) : '',
 		url,
-		opensInNewTab,
+		newTab: opensInNewTab,
 	};
-	const [ isLinkOpen, setIsLinkOpen ] = useState( ! label && isSelected );
-
-	let onCloseTimerId = null;
+	const [ isLinkOpen, setIsLinkOpen ] = useState( ! url && isSelected );
 
 	/**
-	 * It's a kind of hack to handle closing the LinkControl popover
-	 * clicking on the ToolbarButton link.
+	 * This hack shouldn't be necessary but due to a focus loss happening
+	 * when selecting a suggestion in the link popover, we force close on block unselection.
 	 */
 	useEffect( () => {
 		if ( ! isSelected ) {
 			setIsLinkOpen( false );
 		}
-
-		return () => {
-			// Clear LinkControl.OnClose timeout.
-			if ( onCloseTimerId ) {
-				clearTimeout( onCloseTimerId );
-			}
-		};
 	}, [ isSelected ] );
-
-	/**
-	 * Opens the LinkControl popup
-	 */
-	const openLinkControl = () => {
-		if ( isLinkOpen ) {
-			return;
-		}
-
-		setIsLinkOpen( ! isLinkOpen );
-	};
 
 	/**
 	 * `onKeyDown` LinkControl handler.
@@ -115,7 +95,7 @@ function NavigationLinkEdit( {
 					<KeyboardShortcuts
 						bindGlobal
 						shortcuts={ {
-							[ rawShortcut.primary( 'k' ) ]: openLinkControl,
+							[ rawShortcut.primary( 'k' ) ]: () => setIsLinkOpen( true ),
 						} }
 					/>
 					<ToolbarButton
@@ -123,7 +103,7 @@ function NavigationLinkEdit( {
 						icon="admin-links"
 						title={ __( 'Link' ) }
 						shortcut={ displayShortcut.primary( 'k' ) }
-						onClick={ openLinkControl }
+						onClick={ () => setIsLinkOpen( true ) }
 					/>
 					<ToolbarButton
 						name="submenu"
@@ -200,16 +180,14 @@ function NavigationLinkEdit( {
 							onChange={ ( {
 								title: newTitle = '',
 								url: newURL = '',
-								opensInNewTab: newTab,
+								newTab,
 							} = {} ) => setAttributes( {
 								title: escape( newTitle ),
 								url: newURL,
 								label: label || escape( newTitle ),
 								opensInNewTab: newTab,
 							} ) }
-							onClose={ () => {
-								onCloseTimerId = setTimeout( () => setIsLinkOpen( false ), 100 );
-							} }
+							onClose={ () => setIsLinkOpen( false ) }
 						/>
 					) }
 				</div>

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -42,35 +42,6 @@ import {
 } from '@wordpress/block-editor';
 import { Fragment, useState, useEffect } from '@wordpress/element';
 
-/**
- * It updates the link attribute when the
- * link settings changes.
- *
- * @param {Function} setter Setter attribute function.
- */
-const updateLinkSetting = ( setter ) => ( setting, value ) => {
-	setter( { [ setting ]: value } );
-};
-
-/**
- * Updates the link attribute when it changes
- * through of the `onLinkChange` LinkControl callback.
- *
- * @param {Function} setter Setter attribute function.
- * @param {string} label Link label.
- */
-const updateLink = ( setter, label ) => ( { title: newTitle = '', url: newURL = '' } = {} ) => {
-	setter( {
-		title: escape( newTitle ),
-		url: newURL,
-	} );
-
-	// Set the item label as well if it isn't already defined.
-	if ( ! label ) {
-		setter( { label: escape( newTitle ) } );
-	}
-};
-
 function NavigationLinkEdit( {
 	attributes,
 	hasDescendants,
@@ -80,7 +51,11 @@ function NavigationLinkEdit( {
 	insertLinkBlock,
 } ) {
 	const { label, opensInNewTab, title, url, nofollow, description } = attributes;
-	const link = title ? { title: unescape( title ), url } : null;
+	const link = {
+		title: title ? unescape( title ) : '',
+		url,
+		opensInNewTab,
+	};
 	const [ isLinkOpen, setIsLinkOpen ] = useState( ! label && isSelected );
 
 	let onCloseTimerId = null;
@@ -221,19 +196,20 @@ function NavigationLinkEdit( {
 							className="wp-block-navigation-link__inline-link-input"
 							onKeyDown={ handleLinkControlOnKeyDown }
 							onKeyPress={ ( event ) => event.stopPropagation() }
-							currentLink={ link }
-							onLinkChange={ updateLink( setAttributes, label ) }
+							value={ link }
+							onChange={ ( {
+								title: newTitle = '',
+								url: newURL = '',
+								opensInNewTab: newTab,
+							} = {} ) => setAttributes( {
+								title: escape( newTitle ),
+								url: newURL,
+								label: label || escape( newTitle ),
+								opensInNewTab: newTab,
+							} ) }
 							onClose={ () => {
 								onCloseTimerId = setTimeout( () => setIsLinkOpen( false ), 100 );
 							} }
-							currentSettings={ [
-								{
-									id: 'opensInNewTab',
-									title: __( 'Open in new tab' ),
-									checked: opensInNewTab,
-								},
-							] }
-							onSettingsChange={ updateLinkSetting( setAttributes ) }
 						/>
 					) }
 				</div>

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -23,12 +23,6 @@ import {
 	ToolbarGroup,
 } from '@wordpress/components';
 import {
-	LEFT,
-	RIGHT,
-	UP,
-	DOWN,
-	BACKSPACE,
-	ENTER,
 	rawShortcut,
 	displayShortcut,
 } from '@wordpress/keycodes';
@@ -67,24 +61,6 @@ function NavigationLinkEdit( {
 			setIsLinkOpen( false );
 		}
 	}, [ isSelected ] );
-
-	/**
-	 * `onKeyDown` LinkControl handler.
-	 * It takes over to stop the event propagation to make the
-	 * navigation work, avoiding undesired behaviors.
-	 * For instance, it will block to move between link blocks
-	 * when the LinkControl is focused.
-	 *
-	 * @param {Event} event
-	 */
-	const handleLinkControlOnKeyDown = ( event ) => {
-		const { keyCode } = event;
-
-		if ( [ LEFT, DOWN, RIGHT, UP, BACKSPACE, ENTER ].indexOf( keyCode ) > -1 ) {
-			// Stop the key event from propagating up to ObserveTyping.startTypingInTextField.
-			event.stopPropagation();
-		}
-	};
 
 	const itemLabelPlaceholder = __( 'Add link…' );
 
@@ -174,8 +150,6 @@ function NavigationLinkEdit( {
 					{ isLinkOpen && (
 						<LinkControl
 							className="wp-block-navigation-link__inline-link-input"
-							onKeyDown={ handleLinkControlOnKeyDown }
-							onKeyPress={ ( event ) => event.stopPropagation() }
 							value={ link }
 							onChange={ ( {
 								title: newTitle = '',

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -162,6 +162,8 @@ function NavigationLinkEdit( {
 								opensInNewTab: newTab,
 							} ) }
 							onClose={ () => setIsLinkOpen( false ) }
+							text={ label }
+							onTextChange={ ( labelValue ) => setAttributes( { label: labelValue } ) }
 						/>
 					) }
 				</div>


### PR DESCRIPTION
<img width="543" alt="linkuiwithtext" src="https://user-images.githubusercontent.com/444434/71811832-935aee80-306d-11ea-8f58-9da4d90969f9.png">

**Experimental**.

In the current Navigation Block, it could be argued that there is something of a disconnect between adding link _text_ and creating the _hyperlink_ destination of the link. when creating a Nav Link. 

To add a hyperlink you interact with a `LinkControl` popover. This affords the ability to add a URL by direct entry or searching for an existing Post. However it does not enable editing of the link _text_ itself.

To edit link text you need to switch away from the `LInKControl` popover and edit within the Block richtext directly. Whilst it is obviously desirable to retain the direct manipulation pattern established on blocks, it can feel a little clunky (and somewhat confusing) to have to switch between hyperlink UI and the block itself in order to create a link.

This PR is an experiment to see whether introducing the ability to edit the Nav Item text from within the hyperlink UI _as well as_ the block richtext would improve the usability.

This follows established UI patterns such as that found in Google Docs (see screenshot below) which enables manipulation of the link text within the hyperlink UI:

<img width="514" alt="Screenshot 2020-01-06 at 10 18 57" src="https://user-images.githubusercontent.com/444434/71812021-0a908280-306e-11ea-9692-8ae0ae39e0b8.png">

I'm expecting that this will be rejected on the grounds of breaking the direct manipulation paradigm, but I felt it was worth exploring so we can at least rule it out and have documented evidence of this process having occurred.

**Please note there is a currently a major bug** in this implementation whereby [editing the text within the hyperlink UI will cause focus to immediately jump back to the block richtext](https://github.com/WordPress/gutenberg/issues/17505). This is likely due to a "bug" in `RichText` which would need to be fixed in order for this to work (cc @ellatrix ). Therefore please suspend disbelief when testing this PR or just take the screenshot at face value.



## How has this been tested?

Manual for now.

## Screenshots <!-- if applicable -->

![72170288-84a36d00-33c8-11ea-99a5-2eda07b53133](https://user-images.githubusercontent.com/444434/80192331-e6ea4b80-860e-11ea-851c-bfa80db3bb31.gif)



## Types of changes
New feature (non-breaking change which adds functionality).

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
