### PR TITLE
Regions: position publish region after sidebar

### DIFF
--- a/packages/e2e-tests/specs/editor/various/block-hierarchy-navigation.test.js
+++ b/packages/e2e-tests/specs/editor/various/block-hierarchy-navigation.test.js
@@ -81,7 +81,6 @@ describe( 'Navigating the block hierarchy', () => {
 		await pressKeyWithModifier( 'ctrl', '`' );
 		await pressKeyWithModifier( 'ctrl', '`' );
 		await pressKeyWithModifier( 'ctrl', '`' );
-		await pressKeyWithModifier( 'ctrl', '`' );
 		await pressKeyTimes( 'Tab', 4 );
 
 		// Tweak the columns count by increasing it by one.

--- a/packages/e2e-tests/specs/editor/various/keyboard-navigable-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/keyboard-navigable-blocks.test.js
@@ -39,7 +39,7 @@ const tabThroughParagraphBlock = async ( paragraphText, blockIndex ) => {
 	) ).toBe( paragraphText );
 
 	await page.keyboard.press( 'Tab' );
-	await expect( await getActiveLabel() ).toBe( 'Open publish panel' );
+	await expect( await getActiveLabel() ).toBe( 'Document' );
 };
 
 const tabThroughBlockMoverControl = async () => {
@@ -128,7 +128,7 @@ describe( 'Order of block keyboard navigation', () => {
 		await expect( await getActiveLabel() ).toBe( 'Paragraph' );
 
 		await page.keyboard.press( 'Tab' );
-		await expect( await getActiveLabel() ).toBe( 'Open publish panel' );
+		await expect( await getActiveLabel() ).toBe( 'Document (selected)' );
 	} );
 
 	it( 'allows tabbing in navigation mode if no block is selected (reverse)', async () => {
@@ -145,9 +145,6 @@ describe( 'Order of block keyboard navigation', () => {
 			document.querySelector( '.edit-post-visual-editor' ).focus();
 			document.querySelector( '.edit-post-editor-regions__sidebar' ).focus();
 		} );
-
-		await pressKeyWithModifier( 'shift', 'Tab' );
-		await expect( await getActiveLabel() ).toBe( 'Open publish panel' );
 
 		await pressKeyWithModifier( 'shift', 'Tab' );
 		await expect( await getActiveLabel() ).toBe( 'Paragraph' );

--- a/packages/e2e-tests/specs/editor/various/sidebar.test.js
+++ b/packages/e2e-tests/specs/editor/various/sidebar.test.js
@@ -96,7 +96,6 @@ describe( 'Sidebar', () => {
 		await pressKeyWithModifier( 'ctrl', '`' );
 		await pressKeyWithModifier( 'ctrl', '`' );
 		await pressKeyWithModifier( 'ctrl', '`' );
-		await pressKeyWithModifier( 'ctrl', '`' );
 
 		// Tab lands at first (presumed selected) option "Document".
 		await page.keyboard.press( 'Tab' );

--- a/packages/edit-post/src/components/editor-regions/index.js
+++ b/packages/edit-post/src/components/editor-regions/index.js
@@ -33,6 +33,16 @@ function EditorRegions( { footer, header, sidebar, content, publish, className }
 				>
 					{ content }
 				</div>
+				{ !! sidebar && (
+					<div
+						className="edit-post-editor-regions__sidebar"
+						role="region"
+						aria-label={ 'Editor settings' }
+						tabIndex="-1"
+					>
+						{ sidebar }
+					</div>
+				) }
 				{ !! publish && (
 					<div
 						className="edit-post-editor-regions__publish"
@@ -42,16 +52,6 @@ function EditorRegions( { footer, header, sidebar, content, publish, className }
 						tabIndex="-1"
 					>
 						{ publish }
-					</div>
-				) }
-				{ !! sidebar && (
-					<div
-						className="edit-post-editor-regions__sidebar"
-						role="region"
-						aria-label={ 'Editor settings' }
-						tabIndex="-1"
-					>
-						{ sidebar }
 					</div>
 				) }
 			</div>

--- a/packages/edit-post/src/components/editor-regions/index.js
+++ b/packages/edit-post/src/components/editor-regions/index.js
@@ -37,7 +37,8 @@ function EditorRegions( { footer, header, sidebar, content, publish, className }
 					<div
 						className="edit-post-editor-regions__sidebar"
 						role="region"
-						aria-label={ 'Editor settings' }
+						/* translators: accessibility text for the settings landmark region. */
+						aria-label={ __( 'Editor settings' ) }
 						tabIndex="-1"
 					>
 						{ sidebar }
@@ -59,7 +60,8 @@ function EditorRegions( { footer, header, sidebar, content, publish, className }
 				<div
 					className="edit-post-editor-regions__footer"
 					role="region"
-					aria-label={ 'Editor footer' }
+					/* translators: accessibility text for the footer landmark region. */
+					aria-label={ __( 'Editor footer' ) }
 					tabIndex="-1"
 				>
 					{ footer }


### PR DESCRIPTION
## Description

Currently the button for opening the publish area is positioned right between the block and the block inspector/sidebar. This is a bit of an awkward place for it. I moved the button after the inspector instead. This makes visual sense as well, as the publish area slides in from the left (seemingly positioned after the sidebar).

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
