### PR TITLE
Fix: Update CSS rule on the widgets screen required for drag & drop

### DIFF
--- a/packages/edit-widgets/src/components/widget-area/style.scss
+++ b/packages/edit-widgets/src/components/widget-area/style.scss
@@ -18,7 +18,7 @@
 	padding-top: $grid-size-xlarge;
 }
 
-.edit-widgets-main-block-list > .block-list-appender {
+.edit-widgets-main-block-list > div > .block-list-appender {
 	padding-top: $panel-padding;
 	position: relative;
 }


### PR DESCRIPTION
## Description
The block-list-appender element got a div wrapper, and a CSS rule required for the drag & drop to work on the widgets screen stopped working.
This PR updates the rule to take into account the new wrapper.

## How has this been tested?
I checked that I could drag & drop blocks on the widget screen.