### PR TITLE
Split WritingFlow: ToolAccess component

### DIFF
--- a/packages/block-editor/src/components/writing-flow/index.js
+++ b/packages/block-editor/src/components/writing-flow/index.js
@@ -397,8 +397,8 @@ export default function WritingFlow( { children } ) {
 	// bubbling events from children to determine focus transition intents.
 	/* eslint-disable jsx-a11y/no-static-element-interactions */
 	return (
-		<ToolAccess>
-			<div className="block-editor-writing-flow">
+		<div className="block-editor-writing-flow">
+			<ToolAccess>
 				<div
 					ref={ container }
 					onKeyDown={ onKeyDown }
@@ -406,14 +406,14 @@ export default function WritingFlow( { children } ) {
 				>
 					{ children }
 				</div>
-				<div
-					aria-hidden
-					tabIndex={ -1 }
-					onClick={ focusLastTextField }
-					className="block-editor-writing-flow__click-redirect"
-				/>
-			</div>
-		</ToolAccess>
+			</ToolAccess>
+			<div
+				aria-hidden
+				tabIndex={ -1 }
+				onClick={ focusLastTextField }
+				className="block-editor-writing-flow__click-redirect"
+			/>
+		</div>
 	);
 	/* eslint-enable jsx-a11y/no-static-element-interactions */
 }

--- a/packages/block-editor/src/components/writing-flow/tool-access.js
+++ b/packages/block-editor/src/components/writing-flow/tool-access.js
@@ -81,6 +81,10 @@ export default function ToolAccess( { children } ) {
 
 	return (
 		<>
+			{
+			// This slot in a temporary solution. In the future, the toolbar
+			// should be rendered here instead of inside the block.
+			}
 			<Popover.Slot name="block-toolbar" />
 			<FocusCapture
 				ref={ focusCaptureBeforeRef }

--- a/packages/block-editor/src/components/writing-flow/tool-access.js
+++ b/packages/block-editor/src/components/writing-flow/tool-access.js
@@ -93,7 +93,10 @@ export default function ToolAccess( { children } ) {
 				noCapture={ noCapture }
 			/>
 			{ /* eslint-disable-next-line jsx-a11y/no-static-element-interactions */ }
-			<div onKeyDown={ isNavigationMode ? undefined : onKeydown }>
+			<div
+				ref={ container }
+				onKeyDown={ isNavigationMode ? undefined : onKeydown }
+			>
 				{ children }
 			</div>
 			<FocusCapture

--- a/packages/block-editor/src/components/writing-flow/tool-access.js
+++ b/packages/block-editor/src/components/writing-flow/tool-access.js
@@ -1,0 +1,104 @@
+/**
+ * External dependencies
+ */
+import { last } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { useRef } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+import { focus } from '@wordpress/dom';
+import { TAB } from '@wordpress/keycodes';
+import { Popover } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { getBlockFocusableWrapper } from '../../utils/dom';
+import FocusCapture from './focus-capture';
+
+function selector( select ) {
+	const {
+		getSelectedBlockClientId,
+		getMultiSelectedBlocksStartClientId,
+		isNavigationMode,
+	} = select( 'core/block-editor' );
+
+	return {
+		selectedBlockClientId: getSelectedBlockClientId(),
+		selectionStartClientId: getMultiSelectedBlocksStartClientId(),
+		isNavigationMode: isNavigationMode(),
+	};
+}
+
+export default function ToolAccess( { children } ) {
+	const container = useRef();
+	const focusCaptureBeforeRef = useRef();
+	const focusCaptureAfterRef = useRef();
+
+	// Reference that holds the a flag for enabling or disabling
+	// capturing on the focus capture elements.
+	const noCapture = useRef();
+
+	const {
+		selectedBlockClientId,
+		selectionStartClientId,
+		isNavigationMode,
+	} = useSelect( selector );
+
+	const selectedClientId = selectedBlockClientId || selectionStartClientId;
+
+	// In Edit mode, Tab should focus the first tabbable element after the
+	// content, which is normally the sidebar (with block controls) and
+	// Shift+Tab should focus the first tabbable element before the content,
+	// which is normally the block toolbar.
+	// Arrow keys can be used, and Tab and arrow keys can be used in
+	// Navigation mode (press Esc), to navigate through blocks.
+	function onKeydown( { target, keyCode, shiftKey } ) {
+		if ( keyCode === TAB && selectedClientId ) {
+			const wrapper = getBlockFocusableWrapper( selectedClientId );
+
+			if ( shiftKey ) {
+				if ( target === wrapper ) {
+					// Disable focus capturing on the focus capture element, so
+					// it doesn't refocus this block and so it allows default
+					// behaviour (moving focus to the next tabbable element).
+					noCapture.current = true;
+					focusCaptureBeforeRef.current.focus();
+				}
+			} else {
+				const tabbables = focus.tabbable.find( wrapper );
+
+				if ( target === last( tabbables ) ) {
+					// See comment above.
+					noCapture.current = true;
+					focusCaptureAfterRef.current.focus();
+				}
+			}
+		}
+	}
+
+	return (
+		<>
+			<Popover.Slot name="block-toolbar" />
+			<FocusCapture
+				ref={ focusCaptureBeforeRef }
+				selectedClientId={ selectedClientId }
+				containerRef={ container }
+				noCapture={ noCapture }
+			/>
+			{ /* eslint-disable-next-line jsx-a11y/no-static-element-interactions */ }
+			<div onKeyDown={ isNavigationMode ? undefined : onKeydown }>
+				{ children }
+			</div>
+			<FocusCapture
+				ref={ focusCaptureAfterRef }
+				selectedClientId={ selectedClientId }
+				containerRef={ container }
+				noCapture={ noCapture }
+				isReverse
+			/>
+		</>
+	);
+}

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -108,7 +108,6 @@ function Layout() {
 					content={
 						<>
 							<EditorNotices />
-							<Popover.Slot name="block-toolbar" />
 							{ ( mode === 'text' || ! isRichEditingEnabled ) && <TextEditor /> }
 							{ isRichEditingEnabled && mode === 'visual' && <VisualEditor /> }
 							<div className="edit-post-layout__metaboxes">


### PR DESCRIPTION
## Description

This PR splits logic around accessing block tools to a separate component for `WritingFlow` to consume. For now, I left it to be part of `WritingFlow` to avoid creating any new public APIs and to leave everything the same. In the future we should figure out which parts make sense on their own, but that's out of scope for this PR. This PR merely separates logic.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
