### PR TITLE
Add: Block editor keyboard shortcuts on the widgets screen

### DIFF
--- a/packages/edit-widgets/src/components/layout/index.js
+++ b/packages/edit-widgets/src/components/layout/index.js
@@ -24,7 +24,7 @@ function Layout( { blockEditorSettings } ) {
 	return (
 		<SlotFillProvider>
 			<DropZoneProvider>
-				<BlockEditorKeyboardShortcuts.Register />;
+				<BlockEditorKeyboardShortcuts.Register />
 				<Header />
 				<Sidebar />
 				<Notices />

--- a/packages/edit-widgets/src/components/layout/index.js
+++ b/packages/edit-widgets/src/components/layout/index.js
@@ -9,6 +9,7 @@ import {
 	SlotFillProvider,
 } from '@wordpress/components';
 import { useState } from '@wordpress/element';
+import { BlockEditorKeyboardShortcuts } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -23,6 +24,7 @@ function Layout( { blockEditorSettings } ) {
 	return (
 		<SlotFillProvider>
 			<DropZoneProvider>
+				<BlockEditorKeyboardShortcuts.Register />;
 				<Header />
 				<Sidebar />
 				<Notices />


### PR DESCRIPTION
## Description
This PR adds the normal block editor shortcuts to the widgets screen.

## How has this been tested?
On the widgets screen:
I verified I could duplicate blocks using cmd + shift + d.
I multi-selected some blocks and verified I could delete them using backspace.
