### PR TITLE
Block Parser: Implement block schema numeric range validation

### DIFF
--- a/packages/block-library/src/column/block.json
+++ b/packages/block-library/src/column/block.json
@@ -7,8 +7,8 @@
 		},
 		"width": {
 			"type": "number",
-			"min": 0,
-			"max": 100
+			"minimum": 0,
+			"maximum": 100
 		}
 	}
 }

--- a/packages/blocks/src/api/test/parser.js
+++ b/packages/blocks/src/api/test/parser.js
@@ -17,8 +17,11 @@ import {
 	toBooleanAttributeMatcher,
 	isOfType,
 	isOfTypes,
+	isNumericType,
 	isValidByType,
 	isValidByEnum,
+	isInRange,
+	isValidSchemaValue,
 	serializeBlockNode,
 } from '../parser';
 import {
@@ -144,6 +147,18 @@ describe( 'block parser', () => {
 		} );
 	} );
 
+	describe( 'isNumericType', () => {
+		it( 'returns false for non-numeric type', () => {
+			expect( isNumericType( undefined ) ).toBe( false );
+			expect( isNumericType( 'string' ) ).toBe( false );
+		} );
+
+		it( 'returns true for numeric type', () => {
+			expect( isNumericType( 'integer' ) ).toBe( true );
+			expect( isNumericType( 'number' ) ).toBe( true );
+		} );
+	} );
+
 	describe( 'isValidByType', () => {
 		it( 'returns true if type undefined', () => {
 			expect( isValidByType( null ) ).toBe( true );
@@ -177,6 +192,73 @@ describe( 'block parser', () => {
 
 		it( 'returns true if value is of enum set', () => {
 			expect( isValidByEnum( 2, [ 1, 2, 3 ] ) ).toBe( true );
+		} );
+	} );
+
+	describe( 'isInRange', () => {
+		describe( 'minimum', () => {
+			it( 'is valid if undefined', () => {
+				expect( isInRange( 10, {} ) ).toBe( true );
+			} );
+
+			it( 'is valid by non-exclusive', () => {
+				expect( isInRange( 9, { minimum: 10 } ) ).toBe( false );
+				expect( isInRange( 10, { minimum: 10 } ) ).toBe( true );
+				expect( isInRange( 11, { minimum: 10 } ) ).toBe( true );
+			} );
+
+			it( 'is valid by exclusive', () => {
+				expect(
+					isInRange( 9, { minimum: 10, exclusiveMinimum: true } )
+				).toBe( false );
+				expect(
+					isInRange( 10, { minimum: 10, exclusiveMinimum: true } )
+				).toBe( false );
+				expect(
+					isInRange( 11, { minimum: 10, exclusiveMinimum: true } )
+				).toBe( true );
+			} );
+		} );
+
+		describe( 'maximum', () => {
+			it( 'is valid if undefined', () => {
+				expect( isInRange( 10, {} ) ).toBe( true );
+			} );
+
+			it( 'is valid by non-exclusive', () => {
+				expect( isInRange( 9, { maximum: 10 } ) ).toBe( true );
+				expect( isInRange( 10, { maximum: 10 } ) ).toBe( true );
+				expect( isInRange( 11, { maximum: 10 } ) ).toBe( false );
+			} );
+
+			it( 'is valid by exclusive', () => {
+				expect(
+					isInRange( 9, { maximum: 10, exclusiveMaximum: true } )
+				).toBe( true );
+				expect(
+					isInRange( 10, { maximum: 10, exclusiveMaximum: true } )
+				).toBe( false );
+				expect(
+					isInRange( 11, { maximum: 10, exclusiveMaximum: true } )
+				).toBe( false );
+			} );
+		} );
+	} );
+
+	describe( 'isValidSchemaValue', () => {
+		// These tests are intentionally sparse, since the bulk of the logic is
+		// deferred to separate schema-specific validation functions.
+
+		it( 'validates value by schema', () => {
+			expect( isValidSchemaValue( 2, { enum: [ 1, 2, 3 ] } ) ).toBe(
+				true
+			);
+			expect(
+				isValidSchemaValue( 2, { type: 'number', maximum: 2 } )
+			).toBe( true );
+			expect( isValidSchemaValue( 'foo', { type: 'string' } ) ).toBe(
+				true
+			);
 		} );
 	} );
 


### PR DESCRIPTION
Previously: https://github.com/WordPress/gutenberg/pull/16314#discussion_r300487658

This pull request seeks to enhance the block parser validation to support [JSON schema numeric ranges](https://json-schema.org/understanding-json-schema/reference/numeric.html#range). This follows existing validation behavior for enums (#14810) as precedent.

In doing so, it resolves a typo in the Column block schema use of the `minimum` (previously `min`) and `maximum` (previously `max`) schema keywords, which previously had no effect since the validation was not yet in place.

**Implementation Notes:** If and as this sort of validation becomes further enhanced, we should consider to improve developer communication of invalid values. For example, logging useful warning messages not unlike [the equivalent REST errors](https://github.com/WordPress/WordPress/blob/0be749362adbf568ff250c4686320776926d0969/wp-includes/rest-api.php#L1340-L1341). For the time being, I might consider this blocked by #19317, and worth considering for a subsequent pull request.

**Open Questions:** There's an open question as to just how far it makes sense to take this validation, given that to this point it's been implemented in an ad hoc fashion. Similarly, it begs the question whether we should consider leveraging an existing JSON schema validation solution (of which there are many) rather than to implement our own. Personally, I am mostly content to implement a subset of the validation features, considering the full extent of JSON schema is quite substantial (often manifesting itself [in code size](https://bundlephobia.com/result?p=ajv@6.10.2)). Ideally, the implementations of schema validation is consistent with the equivalent [`rest_validate_value_from_schema` implementation](https://developer.wordpress.org/reference/functions/rest_validate_value_from_schema/) to assure a consistent expected behavior. The supported validation should be documented as well.

**Testing Instructions:**

Ensure unit tests pass:

```
npm run test-unit
```

Verify that manually changing the width of a Column block (likely modifying the comment-delimited attributes using the "Code Editor" mode) to a value less than 0 or greater than 100, will result in the value to be reset to an `undefined` state.