### PR TITLE
[Try] Remove WritingFlow from reusable block editor

### DIFF
--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -16,7 +16,6 @@ import { __ } from '@wordpress/i18n';
 import {
 	BlockEditorProvider,
 	BlockList,
-	WritingFlow,
 } from '@wordpress/block-editor';
 import { compose } from '@wordpress/compose';
 import { parse, serialize } from '@wordpress/blocks';
@@ -122,9 +121,7 @@ class ReusableBlockEdit extends Component {
 				onChange={ this.setBlocks }
 				onInput={ this.setBlocks }
 			>
-				<WritingFlow>
-					<BlockList />
-				</WritingFlow>
+				<BlockList />
 			</BlockEditorProvider>
 		);
 


### PR DESCRIPTION
## Description

Just a test to see what would be failing: we should create additional tests if nothing is?

I'm not sure if `WritingFlow` is currently made to be nested. Without nesting it, does it not handle nested blocks correctly?

Currently the new tab behaviour is broken in reusable blocks because additional focus capture areas are created.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
