### PR TITLE
Editor: Fix Block Embed Input size

### DIFF
--- a/packages/components/src/placeholder/style.scss
+++ b/packages/components/src/placeholder/style.scss
@@ -66,8 +66,7 @@
 }
 
 .components-placeholder__input {
-	margin-top: 0;
-	margin-right: 8px;
+	margin: 0 8px 0 0;
 	flex: 1 1 auto;
 }
 
@@ -85,6 +84,7 @@
 	margin-bottom: $grid-size; // If buttons wrap we need vertical space between.
 
 	&:last-child {
+		margin-bottom: 0;
 		margin-right: 0;
 	}
 }


### PR DESCRIPTION
This update fixes the Input vs. Button sizing and alignment as seen in Embed
blocks, such as Instagram, Twitter, or YouTube.

The problem stemmed from the Placeholder component from `@wordpress/components`.
The `display: flex` container caused the `input` to grow responsively
(height wise), which was triggered by the mysterious margin below the button.

The solution involved neutralizing the margins for both the `input` and `button`
elements, allowing for their heights and alignments to match.


## How has this been tested?
Tested locally in Gutenberg

## Screenshots

##### Before

<img width="646" alt="Screen Shot 2020-01-06 at 12 23 51 PM" src="https://user-images.githubusercontent.com/2322354/71835639-0d946e80-3080-11ea-9a06-e61f38b5a156.png">

##### After

<img width="645" alt="Screen Shot 2020-01-06 at 12 23 26 PM" src="https://user-images.githubusercontent.com/2322354/71835649-138a4f80-3080-11ea-81b1-5cc758bf0b3a.png">

---

##### Margin inconsistencies

<img width="1112" alt="Screen Shot 2020-01-06 at 12 22 48 PM" src="https://user-images.githubusercontent.com/2322354/71835673-213fd500-3080-11ea-8888-091b54cd191a.png">

<img width="1104" alt="Screen Shot 2020-01-06 at 12 22 31 PM" src="https://user-images.githubusercontent.com/2322354/71835682-23a22f00-3080-11ea-9a3c-8d67d4c02bd9.png">


## Types of changes
The code was introduced in the `@wordpress/components` layer, for the `Placeholder` component. Given how this Component is used within Gutenberg, I feel like this adjustment in margins is a safe fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.

---

Resolves https://github.com/WordPress/gutenberg/issues/19420