### PR TITLE
Build Tooling: Skip package for build if package.json unreadable

### DIFF
--- a/bin/packages/get-packages.js
+++ b/bin/packages/get-packages.js
@@ -38,8 +38,8 @@ function hasModuleField( file ) {
 	} catch {
 		// If, for whatever reason, the package's `package.json` cannot be read,
 		// consider it as an invalid candidate. In most cases, this can happen
-		// wehn lingering (empty) directories are left in the working path when
-		// changing to an older branch where a package did not yet exist.
+		// when lingering directories are left in the working path when changing
+		// to an older branch where a package did not yet exist.
 		return false;
 	}
 

--- a/bin/packages/get-packages.js
+++ b/bin/packages/get-packages.js
@@ -32,9 +32,18 @@ function isDirectory( file ) {
  * @return {boolean} Whether file is a directory.
  */
 function hasModuleField( file ) {
-	const { module } = require( path.resolve( PACKAGES_DIR, file, 'package.json' ) );
+	let pkg;
+	try {
+		pkg = require( path.resolve( PACKAGES_DIR, file, 'package.json' ) );
+	} catch {
+		// If, for whatever reason, the package's `package.json` cannot be read,
+		// consider it as an invalid candidate. In most cases, this can happen
+		// wehn lingering (empty) directories are left in the working path when
+		// changing to an older branch where a package did not yet exist.
+		return false;
+	}
 
-	return ! isEmpty( module );
+	return ! isEmpty( pkg.module );
 }
 
 /**


### PR DESCRIPTION
This pull request seeks to resolve an issue where `npm run dev` can log errors for missing packages, typically when changing branches to an older branch:

```
⇒ npm run dev

> gutenberg@7.2.0-rc.1 dev:packages /Users/andrew/Documents/Code/gutenberg
> node ./bin/packages/watch.js

internal/modules/cjs/loader.js:797
    throw err;
    ^

Error: Cannot find module '/Users/andrew/Documents/Code/gutenberg/packages/foo/package.json'
...
```

The problem is that when switching to older branches where a package may not have yet been implemented, the package may be left lingering in the working directory, presumably because its built contents are considered in `.gitignore`.

In these cases, it should be safe to simply ignore the package. The implementation here generalizes this to ignore any directory in `packages` for which the `package.json` file cannot be read.

**Testing Instructions:**

Verify that an empty directory under `packages` does not cause a build failure on `npm run dev:packages`:

1. `mkdir packages/foo`
2. `npm run dev:packages`
3. Note that "-> Watching for changes..." is logged, changes to valid packages still cause a rebuild