### PR TITLE
Format Library: Make sure link UI state resets when switching between links.

### DIFF
--- a/packages/format-library/src/link/index.js
+++ b/packages/format-library/src/link/index.js
@@ -124,6 +124,7 @@ export const link = {
 						shortcutCharacter="k"
 					/> }
 					<InlineLinkUI
+						key={ isActive } // Make sure link UI state resets when switching between links.
 						addingLink={ this.state.addingLink }
 						stopAddingLink={ this.stopAddingLink }
 						isActive={ isActive }


### PR DESCRIPTION
Fixes #19394

## Description

When editing a link's URL, if you click on another link, the popover will move to the new link, but keep the state and value from the old link. The cause was that the link UI only resets its state when closed through a loss of focus or the popover's close event. When switching between two links in the same block, it's the format library's `isActive` prop that does the toggling, so this PR uses it as a key for the link UI so that its state resets appropriately.

## How has this been tested?

Testing instructions in #19394.

## Types of Changes

*Bug Fix:* The link UI no longer keeps the old link's value when switching to another link in the same block.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
