### PR TITLE
Edit Post: Increase top toolbar breakpoint to avoid overflows in the header.

### DIFF
--- a/packages/edit-post/src/components/header/header-toolbar/style.scss
+++ b/packages/edit-post/src/components/header/header-toolbar/style.scss
@@ -54,7 +54,7 @@
 	}
 
 	// Move toolbar into top Editor Bar.
-	@include break-xlarge {
+	@include break-wide {
 		padding-left: $grid-size;
 		position: static;
 		left: auto;


### PR DESCRIPTION
## Description

The top toolbar's breakpoint for going from a second line in the header to a single one was too small, and content overflowed. This PR increases it.

## How has this been tested?

The header no longer overflows around 1100 pixels viewport width.

## Screenshots

<img width="972" alt="Screen Shot 2020-01-06 at 3 42 57 PM" src="https://user-images.githubusercontent.com/19157096/71847861-0a0ee080-309c-11ea-837f-14f0b0bdf898.png">

## Types of Changes

*Bug Fix:* The header's top toolbar no longer overflows content on some screen sizes.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.