### PR TITLE
Promote Attempt Block Recovery as primary action on block invalidation warning

### DIFF
--- a/packages/block-editor/src/components/block-list/block-invalid-warning.js
+++ b/packages/block-editor/src/components/block-list/block-invalid-warning.js
@@ -41,7 +41,7 @@ export class BlockInvalidWarning extends Component {
 		const { compare } = this.state;
 		const hiddenActions = [
 			{ title: __( 'Convert to Classic Block' ), onClick: convertToClassic },
-			{ title: __( 'Attempt Block Recovery' ), onClick: attemptBlockRecovery },
+			{ title: __( 'Convert to HTML Block' ), onClick: convertToHTML },
 		];
 
 		return (
@@ -55,8 +55,8 @@ export class BlockInvalidWarning extends Component {
 							}
 						</Button>,
 						hasHTMLBlock && (
-							<Button key="edit" onClick={ convertToHTML } isPrimary>
-								{ __( 'Convert to HTML' ) }
+							<Button key="edit" onClick={ attemptBlockRecovery } isPrimary>
+								{ __( 'Attempt Block Recovery' ) }
 							</Button>
 						),
 					] }


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/7604

<img width="896" alt="Screen Shot 2020-01-06 at 4 31 27 PM" src="https://user-images.githubusercontent.com/1270189/71854075-bfdd2d80-30a2-11ea-8abb-94644b1725b5.png">

Proposed changes here are to:
1. Move "Attempt Block Recovery" as primary action. We're in the block-editor, so why not favor the block attributes in recovery?
2. Move Convert to HTML down to the more menu as an advanced option.
3. (Not implemented yet) Under "Resolve", provide clearer options. Keep as HTML, prefer HTML to convert to Blocks, or prefer Block Attributes.

 I think displaying the edit view might be more useful (as folks are usually confused by the HTML block interface). If we want to display markup, we should show the full block markup including comment attributes. Otherwise it turns into a "why???" pretty easily when there's no difference in markup or visual changes:

<img width="477" alt="Screen Shot 2020-01-06 at 4 30 11 PM" src="https://user-images.githubusercontent.com/1270189/71854328-645f6f80-30a3-11ea-8911-b0b96b76ee4f.png">

^^ The Resolve Modal for a heading tag where markup doesn't match the block attribute, H2 vs H3.
```
<!-- wp:heading {"level":3} -->
<h2>Hello World</h2>
<!-- /wp:heading -->
```

I'm open to early copy feedback (this is pretty awkward to describe to folks) as well as feedback on shuffling around options.

cc @apeatling @aduth 




