### PR TITLE
Adding border to table header & footer

### DIFF
--- a/packages/block-library/src/table/edit.js
+++ b/packages/block-library/src/table/edit.js
@@ -450,6 +450,13 @@ export class TableEdit extends Component {
 								[ `has-text-align-${ align }` ]: align,
 							}, 'wp-block-table__cell-content' );
 
+							let placeholder = '';
+							if ( name === 'head' ) {
+								placeholder = __( 'Header label' );
+							} else if ( name === 'foot' ) {
+								placeholder = __( 'Footer label' );
+							}
+
 							return (
 								<RichText
 									tagName={ CellTag }
@@ -459,6 +466,7 @@ export class TableEdit extends Component {
 									value={ content }
 									onChange={ this.onChange }
 									unstableOnFocus={ this.createOnFocus( cellLocation ) }
+									placeholder={ placeholder }
 								/>
 							);
 						} ) }

--- a/packages/block-library/src/table/theme.scss
+++ b/packages/block-library/src/table/theme.scss
@@ -1,6 +1,14 @@
 .wp-block-table {
 	border-collapse: collapse;
 
+	thead {
+		border-bottom: 3px solid;
+	}
+
+	tfoot {
+		border-top: 3px solid;
+	}
+
 	td,
 	th {
 		padding: 0.5em;


### PR DESCRIPTION
## Description
Added 2px border-bottom to header and border-top to footer. Design suggested by @shaunandrews in #18767 
![image](https://user-images.githubusercontent.com/7881389/70829991-fd9cae00-1da3-11ea-8534-75747baa3ce0.png)
Closes #18767.

## Screenshots <!-- if applicable -->
<img width="585" alt="Screen Shot 2020-01-06 at 3 09 11 PM" src="https://user-images.githubusercontent.com/7881389/71855718-ac2bca00-3096-11ea-944f-7c75b702896a.png">

## Types of changes
CSS changes limited to theme.scss view.

## Checklist:
- [x] My code is tested (manually).
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->.
