### PR TITLE
Block Directory: Change 'update' icon to text to be more communicative.

### DIFF
--- a/packages/block-directory/src/components/downloadable-block-info/index.js
+++ b/packages/block-directory/src/components/downloadable-block-info/index.js
@@ -16,7 +16,11 @@ function DownloadableBlockInfo( { description, activeInstalls, humanizedUpdated 
 					<Icon icon="chart-line" className="label"></Icon>{ sprintf( _n( '%d active installation', '%d active installations', activeInstalls ), activeInstalls ) }
 				</div>
 				<div className="block-directory-downloadable-block-info__column">
-					<strong className="label">{ __( 'Updated: ' ) }</strong> { humanizedUpdated }
+					<Icon icon="update"></Icon>
+					{
+						// translators: %s: Humanized date of last update e.g: "2 months ago".
+						sprintf( __( 'Updated %s' ), humanizedUpdated )
+					}
 				</div>
 			</div>
 		</Fragment>

--- a/packages/block-directory/src/components/downloadable-block-info/index.js
+++ b/packages/block-directory/src/components/downloadable-block-info/index.js
@@ -16,7 +16,9 @@ function DownloadableBlockInfo( { description, activeInstalls, humanizedUpdated 
 					<Icon icon="chart-line"></Icon>{ sprintf( _n( '%d active installation', '%d active installations', activeInstalls ), activeInstalls ) }
 				</div>
 				<div className="block-directory-downloadable-block-info__column">
-					<Icon icon="update"></Icon><span aria-label={ sprintf( __( 'Updated %s' ), humanizedUpdated ) }>{ humanizedUpdated }</span>
+					<span aria-label={ sprintf( __( 'Updated %s' ), humanizedUpdated ) }>
+						<strong>{ __( 'Updated: ', 'gutenberg' ) }</strong> { humanizedUpdated }
+					</span>
 				</div>
 			</div>
 		</Fragment>

--- a/packages/block-directory/src/components/downloadable-block-info/index.js
+++ b/packages/block-directory/src/components/downloadable-block-info/index.js
@@ -13,12 +13,10 @@ function DownloadableBlockInfo( { description, activeInstalls, humanizedUpdated 
 			</p>
 			<div className="block-directory-downloadable-block-info__row">
 				<div className="block-directory-downloadable-block-info__column">
-					<Icon icon="chart-line"></Icon>{ sprintf( _n( '%d active installation', '%d active installations', activeInstalls ), activeInstalls ) }
+					<Icon icon="chart-line" className="label"></Icon>{ sprintf( _n( '%d active installation', '%d active installations', activeInstalls ), activeInstalls ) }
 				</div>
 				<div className="block-directory-downloadable-block-info__column">
-					<span aria-label={ sprintf( __( 'Updated %s' ), humanizedUpdated ) }>
-						<strong>{ __( 'Updated: ', 'gutenberg' ) }</strong> { humanizedUpdated }
-					</span>
+					<strong className="label">{ __( 'Updated: ' ) }</strong> { humanizedUpdated }
 				</div>
 			</div>
 		</Fragment>

--- a/packages/block-directory/src/components/downloadable-block-info/index.js
+++ b/packages/block-directory/src/components/downloadable-block-info/index.js
@@ -13,7 +13,7 @@ function DownloadableBlockInfo( { description, activeInstalls, humanizedUpdated 
 			</p>
 			<div className="block-directory-downloadable-block-info__row">
 				<div className="block-directory-downloadable-block-info__column">
-					<Icon icon="chart-line" className="label"></Icon>{ sprintf( _n( '%d active installation', '%d active installations', activeInstalls ), activeInstalls ) }
+					<Icon icon="chart-line"></Icon>{ sprintf( _n( '%d active installation', '%d active installations', activeInstalls ), activeInstalls ) }
 				</div>
 				<div className="block-directory-downloadable-block-info__column">
 					<Icon icon="update"></Icon>

--- a/packages/block-directory/src/components/downloadable-block-info/style.scss
+++ b/packages/block-directory/src/components/downloadable-block-info/style.scss
@@ -7,16 +7,14 @@
 	justify-content: space-between;
 	color: $dark-gray-400;
 	margin-top: $grid-size;
+	font-size: 12px;
 
 	.block-directory-downloadable-block-info__column {
 		display: flex;
-		align-items: flex-start;
+		align-items: center;
 
 		.dashicon {
 			font-size: 16px;
-		}
-
-		.label {
 			margin-right: 4px;
 		}
 	}

--- a/packages/block-directory/src/components/downloadable-block-info/style.scss
+++ b/packages/block-directory/src/components/downloadable-block-info/style.scss
@@ -14,6 +14,9 @@
 
 		.dashicon {
 			font-size: 16px;
+		}
+
+		.label {
 			margin-right: 4px;
 		}
 	}


### PR DESCRIPTION
## Description
The 'update' dashicon does not do a very good job communicating the "Last Update" date. This PR changes that icon to a copy. This brings in more alignment with the Plugin Directory and its UI as well.

## How has this been tested?
Tested manually.

## Screenshots 
### Before:
![alt text](https://d.pr/i/8zeJqF.png "Before Image")
### After:
![alt text](https://d.pr/i/y1yFxv.png "After Image")


## Types of changes
Copy Update.

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
