### PR TITLE
Lighter block DOM: put sibling inserter in popover

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -44,7 +44,6 @@ import BlockCrashBoundary from './block-crash-boundary';
 import BlockHtml from './block-html';
 import BlockBreadcrumb from './breadcrumb';
 import BlockContextualToolbar from './block-contextual-toolbar';
-import BlockInsertionPoint from './insertion-point';
 import Inserter from '../inserter';
 import { isInsideRootBlock } from '../../utils/dom';
 import useMovingAnimation from './moving-animation';
@@ -418,12 +417,6 @@ function BlockListBlock( {
 					animationStyle
 			}
 		>
-			{ shouldShowInsertionPoint && (
-				<BlockInsertionPoint
-					clientId={ clientId }
-					rootClientId={ rootClientId }
-				/>
-			) }
 			{ shouldRenderDropzone && <BlockDropZone
 				clientId={ clientId }
 				rootClientId={ rootClientId }

--- a/packages/block-editor/src/components/block-list/insertion-point.js
+++ b/packages/block-editor/src/components/block-list/insertion-point.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { useState, useCallback } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import { Popover } from '@wordpress/components';
 
 /**
@@ -37,10 +37,11 @@ function selector( select ) {
 	return select( 'core/block-editor' ).getBlockRootClientId;
 }
 
-export default function useInsertionPoint( {
+export default function InsertionPoint( {
 	className,
 	isMultiSelecting,
 	selectedBlockClientId,
+	children,
 } ) {
 	const getBlockRootClientId = useSelect( selector, [] );
 	const [ isInserterShown, setIsInserterShown ] = useState( false );
@@ -88,50 +89,39 @@ export default function useInsertionPoint( {
 		setInserterRootClientId( getBlockRootClientId( clientId ) );
 	}
 
-	const InsertionPoint = useCallback( () => {
-		return (
-			<Popover
-				noArrow
-				animate={ false }
-				anchorRef={ inserterElement }
-				position="top right left"
-				focusOnMount={ false }
-				className="block-editor-block-list__block-popover"
-				__unstableSlotName="block-toolbar"
-			>
-				<div className="block-editor-block-list__insertion-point" style={ { width: inserterElement.offsetWidth } }>
-					<Indicator clientId={ inserterClientId } rootClientId={ inserterRootClientId } />
-					<div
-						onFocus={ () => setIsInserterForced( true ) }
-						onBlur={ () => setIsInserterForced( false ) }
-						// While ideally it would be enough to capture the
-						// bubbling focus event from the Inserter, due to the
-						// characteristics of click focusing of `button`s in
-						// Firefox and Safari, it is not reliable.
-						//
-						// See: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Clicking_and_focus
-						tabIndex={ -1 }
-						className="block-editor-block-list__insertion-point-inserter"
-					>
-						<Inserter
-							rootClientId={ inserterRootClientId }
-							clientId={ inserterClientId }
-						/>
-					</div>
+	return <>
+		{ ! isMultiSelecting && ( isInserterShown || isInserterForced ) && <Popover
+			noArrow
+			animate={ false }
+			anchorRef={ inserterElement }
+			position="top right left"
+			focusOnMount={ false }
+			className="block-editor-block-list__block-popover"
+			__unstableSlotName="block-toolbar"
+		>
+			<div className="block-editor-block-list__insertion-point" style={ { width: inserterElement.offsetWidth } }>
+				<Indicator clientId={ inserterClientId } rootClientId={ inserterRootClientId } />
+				<div
+					onFocus={ () => setIsInserterForced( true ) }
+					onBlur={ () => setIsInserterForced( false ) }
+					// While ideally it would be enough to capture the
+					// bubbling focus event from the Inserter, due to the
+					// characteristics of click focusing of `button`s in
+					// Firefox and Safari, it is not reliable.
+					//
+					// See: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Clicking_and_focus
+					tabIndex={ -1 }
+					className="block-editor-block-list__insertion-point-inserter"
+				>
+					<Inserter
+						rootClientId={ inserterRootClientId }
+						clientId={ inserterClientId }
+					/>
 				</div>
-			</Popover>
-		);
-	}, [ inserterClientId ] );
-
-	const props = {};
-
-	if ( ! isInserterForced && ! isMultiSelecting ) {
-		props.onMouseMove = onMouseMove;
-	}
-
-	if ( ! isMultiSelecting && ( isInserterShown || isInserterForced ) ) {
-		props.InsertionPoint = InsertionPoint;
-	}
-
-	return props;
+			</div>
+		</Popover> }
+		<div onMouseMove={ ! isInserterForced && ! isMultiSelecting ? onMouseMove : undefined }>
+			{ children }
+		</div>
+	</>;
 }

--- a/packages/block-editor/src/components/block-list/insertion-point.js
+++ b/packages/block-editor/src/components/block-list/insertion-point.js
@@ -10,13 +10,15 @@ import { Popover } from '@wordpress/components';
  */
 import Inserter from '../inserter';
 
-function Indicator( { rootClientId, clientId } ) {
+function Indicator( { clientId } ) {
 	const showInsertionPoint = useSelect( ( select ) => {
 		const {
 			getBlockIndex,
 			getBlockInsertionPoint,
 			isBlockInsertionPointVisible,
+			getBlockRootClientId,
 		} = select( 'core/block-editor' );
+		const rootClientId = getBlockRootClientId( clientId );
 		const blockIndex = getBlockIndex( clientId, rootClientId );
 		const insertionPoint = getBlockInsertionPoint();
 		return (
@@ -24,7 +26,7 @@ function Indicator( { rootClientId, clientId } ) {
 			insertionPoint.index === blockIndex &&
 			insertionPoint.rootClientId === rootClientId
 		);
-	}, [ clientId, rootClientId ] );
+	}, [ clientId ] );
 
 	if ( ! showInsertionPoint ) {
 		return null;
@@ -33,22 +35,16 @@ function Indicator( { rootClientId, clientId } ) {
 	return <div className="block-editor-block-list__insertion-point-indicator" />;
 }
 
-function selector( select ) {
-	return select( 'core/block-editor' ).getBlockRootClientId;
-}
-
 export default function InsertionPoint( {
 	className,
 	isMultiSelecting,
 	selectedBlockClientId,
 	children,
 } ) {
-	const getBlockRootClientId = useSelect( selector, [] );
 	const [ isInserterShown, setIsInserterShown ] = useState( false );
 	const [ isInserterForced, setIsInserterForced ] = useState( false );
 	const [ inserterElement, setInserterElement ] = useState( null );
 	const [ inserterClientId, setInserterClientId ] = useState( null );
-	const [ inserterRootClientId, setInserterRootClientId ] = useState( null );
 
 	function onMouseMove( event ) {
 		if ( event.target.className !== className ) {
@@ -86,7 +82,6 @@ export default function InsertionPoint( {
 		setIsInserterShown( true );
 		setInserterElement( element );
 		setInserterClientId( clientId );
-		setInserterRootClientId( getBlockRootClientId( clientId ) );
 	}
 
 	return <>
@@ -100,7 +95,7 @@ export default function InsertionPoint( {
 			__unstableSlotName="block-toolbar"
 		>
 			<div className="block-editor-block-list__insertion-point" style={ { width: inserterElement.offsetWidth } }>
-				<Indicator clientId={ inserterClientId } rootClientId={ inserterRootClientId } />
+				<Indicator clientId={ inserterClientId } />
 				<div
 					onFocus={ () => setIsInserterForced( true ) }
 					onBlur={ () => setIsInserterForced( false ) }
@@ -113,10 +108,7 @@ export default function InsertionPoint( {
 					tabIndex={ -1 }
 					className="block-editor-block-list__insertion-point-inserter"
 				>
-					<Inserter
-						rootClientId={ inserterRootClientId }
-						clientId={ inserterClientId }
-					/>
+					<Inserter clientId={ inserterClientId } />
 				</div>
 			</div>
 		</Popover> }

--- a/packages/block-editor/src/components/block-list/insertion-point.js
+++ b/packages/block-editor/src/components/block-list/insertion-point.js
@@ -1,12 +1,6 @@
 /**
- * External dependencies
- */
-import classnames from 'classnames';
-
-/**
  * WordPress dependencies
  */
-import { useState } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 
 /**
@@ -14,8 +8,7 @@ import { useSelect } from '@wordpress/data';
  */
 import Inserter from '../inserter';
 
-export default function BlockInsertionPoint( { rootClientId, clientId } ) {
-	const [ isInserterFocused, setInserterFocused ] = useState( false );
+export default function BlockInsertionPoint( { rootClientId, clientId, onBlur, onFocus, width } ) {
 	const showInsertionPoint = useSelect( ( select ) => {
 		const {
 			getBlockIndex,
@@ -31,20 +24,8 @@ export default function BlockInsertionPoint( { rootClientId, clientId } ) {
 		);
 	}, [ clientId, rootClientId ] );
 
-	function onFocus( event ) {
-		// Stop propagation of the focus event to avoid selecting the current
-		// block while inserting a new block, as it is not relevant to sibling
-		// insertion and conflicts with contextual toolbar placement.
-		event.stopPropagation();
-		setInserterFocused( true );
-	}
-
-	function onBlur() {
-		setInserterFocused( false );
-	}
-
 	return (
-		<div className="block-editor-block-list__insertion-point">
+		<div className="block-editor-block-list__insertion-point" style={ { width } }>
 			{ showInsertionPoint && (
 				<div className="block-editor-block-list__insertion-point-indicator" />
 			) }
@@ -58,11 +39,7 @@ export default function BlockInsertionPoint( { rootClientId, clientId } ) {
 				//
 				// See: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Clicking_and_focus
 				tabIndex={ -1 }
-				className={
-					classnames( 'block-editor-block-list__insertion-point-inserter', {
-						'is-visible': isInserterFocused,
-					} )
-				}
+				className="block-editor-block-list__insertion-point-inserter"
 			>
 				<Inserter
 					rootClientId={ rootClientId }

--- a/packages/block-editor/src/components/block-list/insertion-point.js
+++ b/packages/block-editor/src/components/block-list/insertion-point.js
@@ -2,13 +2,15 @@
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
+import { useState, useCallback } from '@wordpress/element';
+import { Popover } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import Inserter from '../inserter';
 
-export default function BlockInsertionPoint( { rootClientId, clientId, onBlur, onFocus, width } ) {
+function Indicator( { rootClientId, clientId } ) {
 	const showInsertionPoint = useSelect( ( select ) => {
 		const {
 			getBlockIndex,
@@ -24,28 +26,112 @@ export default function BlockInsertionPoint( { rootClientId, clientId, onBlur, o
 		);
 	}, [ clientId, rootClientId ] );
 
-	return (
-		<div className="block-editor-block-list__insertion-point" style={ { width } }>
-			{ showInsertionPoint && (
-				<div className="block-editor-block-list__insertion-point-indicator" />
-			) }
-			<div
-				onFocus={ onFocus }
-				onBlur={ onBlur }
-				// While ideally it would be enough to capture the
-				// bubbling focus event from the Inserter, due to the
-				// characteristics of click focusing of `button`s in
-				// Firefox and Safari, it is not reliable.
-				//
-				// See: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Clicking_and_focus
-				tabIndex={ -1 }
-				className="block-editor-block-list__insertion-point-inserter"
+	if ( ! showInsertionPoint ) {
+		return null;
+	}
+
+	return <div className="block-editor-block-list__insertion-point-indicator" />;
+}
+
+function selector( select ) {
+	return select( 'core/block-editor' ).getBlockRootClientId;
+}
+
+export default function useInsertionPoint( {
+	className,
+	isMultiSelecting,
+	selectedBlockClientId,
+} ) {
+	const getBlockRootClientId = useSelect( selector, [] );
+	const [ isInserterShown, setIsInserterShown ] = useState( false );
+	const [ isInserterForced, setIsInserterForced ] = useState( false );
+	const [ inserterElement, setInserterElement ] = useState( null );
+	const [ inserterClientId, setInserterClientId ] = useState( null );
+	const [ inserterRootClientId, setInserterRootClientId ] = useState( null );
+
+	function onMouseMove( event ) {
+		if ( event.target.className !== className ) {
+			if ( isInserterShown ) {
+				setIsInserterShown( false );
+			}
+			return;
+		}
+
+		const rect = event.target.getBoundingClientRect();
+		const offset = event.clientY - rect.top;
+		const element = Array.from( event.target.children ).find( ( blockEl ) => {
+			return blockEl.offsetTop > offset;
+		} );
+
+		if ( ! element ) {
+			return;
+		}
+
+		const clientId = element.id.slice( 'block-'.length );
+
+		if ( ! clientId || clientId === selectedBlockClientId ) {
+			return;
+		}
+
+		const elementRect = element.getBoundingClientRect();
+
+		if ( event.clientX > elementRect.right || event.clientX < elementRect.left ) {
+			if ( isInserterShown ) {
+				setIsInserterShown( false );
+			}
+			return;
+		}
+
+		setIsInserterShown( true );
+		setInserterElement( element );
+		setInserterClientId( clientId );
+		setInserterRootClientId( getBlockRootClientId( clientId ) );
+	}
+
+	const InsertionPoint = useCallback( () => {
+		return (
+			<Popover
+				noArrow
+				animate={ false }
+				anchorRef={ inserterElement }
+				position="top right left"
+				focusOnMount={ false }
+				className="block-editor-block-list__block-popover"
+				__unstableSlotName="block-toolbar"
 			>
-				<Inserter
-					rootClientId={ rootClientId }
-					clientId={ clientId }
-				/>
-			</div>
-		</div>
-	);
+				<div className="block-editor-block-list__insertion-point" style={ { width: inserterElement.offsetWidth } }>
+					<Indicator clientId={ inserterClientId } rootClientId={ inserterRootClientId } />
+					<div
+						onFocus={ () => setIsInserterForced( true ) }
+						onBlur={ () => setIsInserterForced( false ) }
+						// While ideally it would be enough to capture the
+						// bubbling focus event from the Inserter, due to the
+						// characteristics of click focusing of `button`s in
+						// Firefox and Safari, it is not reliable.
+						//
+						// See: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Clicking_and_focus
+						tabIndex={ -1 }
+						className="block-editor-block-list__insertion-point-inserter"
+					>
+						<Inserter
+							rootClientId={ inserterRootClientId }
+							clientId={ inserterClientId }
+						/>
+					</div>
+				</div>
+			</Popover>
+		);
+	}, [ inserterClientId ] );
+
+	const props = {};
+
+	if ( ! isInserterForced && ! isMultiSelecting ) {
+		props.onMouseMove = onMouseMove;
+	}
+
+	if ( ! isMultiSelecting && ( isInserterShown || isInserterForced ) ) {
+		props.InsertionPoint = InsertionPoint;
+	}
+
+	return props;
 }

--- a/packages/block-editor/src/components/block-list/root-container.js
+++ b/packages/block-editor/src/components/block-list/root-container.js
@@ -84,30 +84,37 @@ export default function RootContainer( { children, className } ) {
 	const [ inserterRootClientId, setInserterRootClientId ] = useState( null );
 
 	function onMouseMove( event ) {
-		if ( event.target.className === className ) {
-			const rect = event.target.getBoundingClientRect();
-			const offset = event.clientY - rect.top;
-			const afterIndex = Array.from( event.target.children ).find( ( blockEl ) => {
-				return blockEl.offsetTop > offset;
-			} );
-
-			if ( ! afterIndex ) {
-				return;
+		if ( event.target.className !== className ) {
+			if ( isInserterShown ) {
+				setIsInserterShown( false );
 			}
-
-			const clientId = afterIndex.id.slice( 'block-'.length );
-
-			if ( ! clientId ) {
-				return;
-			}
-
-			setIsInserterShown( true );
-			setInserterPosition( afterIndex );
-			setInserterClientId( clientId );
-			setInserterRootClientId( getBlockRootClientId( clientId ) );
-		} else {
-			setIsInserterShown( false );
+			return;
 		}
+
+		if ( isInserterShown ) {
+			return;
+		}
+
+		const rect = event.target.getBoundingClientRect();
+		const offset = event.clientY - rect.top;
+		const afterIndex = Array.from( event.target.children ).find( ( blockEl ) => {
+			return blockEl.offsetTop > offset;
+		} );
+
+		if ( ! afterIndex ) {
+			return;
+		}
+
+		const clientId = afterIndex.id.slice( 'block-'.length );
+
+		if ( ! clientId ) {
+			return;
+		}
+
+		setIsInserterShown( true );
+		setInserterPosition( afterIndex );
+		setInserterClientId( clientId );
+		setInserterRootClientId( getBlockRootClientId( clientId ) );
 	}
 
 	return <>

--- a/packages/block-editor/src/components/block-list/root-container.js
+++ b/packages/block-editor/src/components/block-list/root-container.js
@@ -9,7 +9,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
  */
 import useMultiSelection from './use-multi-selection';
 import { getBlockClientId } from '../../utils/dom';
-import useInsertionPoint from './insertion-point';
+import InsertionPoint from './insertion-point';
 
 /** @typedef {import('@wordpress/element').WPSyntheticEvent} WPSyntheticEvent */
 
@@ -77,24 +77,22 @@ export default function RootContainer( { children, className } ) {
 		}
 	}
 
-	const { onMouseMove, InsertionPoint } = useInsertionPoint( {
-		className,
-		isMultiSelecting,
-		selectedBlockClientId,
-	} );
-
-	return <>
-		{ InsertionPoint && <InsertionPoint /> }
-		<div
-			ref={ ref }
+	return (
+		<InsertionPoint
 			className={ className }
-			onFocus={ onFocus }
-			onDragStart={ onDragStart }
-			onMouseMove={ onMouseMove }
+			isMultiSelecting={ isMultiSelecting }
+			selectedBlockClientId={ selectedBlockClientId }
 		>
-			<Context.Provider value={ onSelectionStart }>
-				{ children }
-			</Context.Provider>
-		</div>
-	</>;
+			<div
+				ref={ ref }
+				className={ className }
+				onFocus={ onFocus }
+				onDragStart={ onDragStart }
+			>
+				<Context.Provider value={ onSelectionStart }>
+					{ children }
+				</Context.Provider>
+			</div>
+		</InsertionPoint>
+	);
 }

--- a/packages/block-editor/src/components/block-list/root-container.js
+++ b/packages/block-editor/src/components/block-list/root-container.js
@@ -1,16 +1,15 @@
 /**
  * WordPress dependencies
  */
-import { useRef, createContext, useState } from '@wordpress/element';
+import { useRef, createContext } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { Popover } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import useMultiSelection from './use-multi-selection';
 import { getBlockClientId } from '../../utils/dom';
-import BlockInsertionPoint from './insertion-point';
+import useInsertionPoint from './insertion-point';
 
 /** @typedef {import('@wordpress/element').WPSyntheticEvent} WPSyntheticEvent */
 
@@ -55,8 +54,6 @@ export default function RootContainer( { children, className } ) {
 		selectedBlockClientId,
 		hasMultiSelection,
 		isMultiSelecting,
-		getBlockRootClientId,
-		isBlockSelected,
 	} = useSelect( selector, [] );
 	const { selectBlock } = useDispatch( 'core/block-editor' );
 	const onSelectionStart = useMultiSelection( ref );
@@ -80,77 +77,20 @@ export default function RootContainer( { children, className } ) {
 		}
 	}
 
-	const [ isInserterShown, setIsInserterShown ] = useState( false );
-	const [ isInserterForced, setIsInserterForced ] = useState( false );
-	const [ inserterElement, setInserterElement ] = useState( null );
-	const [ inserterClientId, setInserterClientId ] = useState( null );
-	const [ inserterRootClientId, setInserterRootClientId ] = useState( null );
-
-	function onMouseMove( event ) {
-		if ( event.target.className !== className ) {
-			if ( isInserterShown ) {
-				setIsInserterShown( false );
-			}
-			return;
-		}
-
-		const rect = event.target.getBoundingClientRect();
-		const offset = event.clientY - rect.top;
-		const element = Array.from( event.target.children ).find( ( blockEl ) => {
-			return blockEl.offsetTop > offset;
-		} );
-
-		if ( ! element ) {
-			return;
-		}
-
-		const clientId = element.id.slice( 'block-'.length );
-
-		if ( ! clientId || isBlockSelected( clientId ) ) {
-			return;
-		}
-
-		const elementRect = element.getBoundingClientRect();
-
-		if ( event.clientX > elementRect.right || event.clientX < elementRect.left ) {
-			if ( isInserterShown ) {
-				setIsInserterShown( false );
-			}
-			return;
-		}
-
-		setIsInserterShown( true );
-		setInserterElement( element );
-		setInserterClientId( clientId );
-		setInserterRootClientId( getBlockRootClientId( clientId ) );
-	}
+	const { onMouseMove, InsertionPoint } = useInsertionPoint( {
+		className,
+		isMultiSelecting,
+		selectedBlockClientId,
+	} );
 
 	return <>
-		{ ( isInserterShown || isInserterForced ) && ! isMultiSelecting &&
-			<Popover
-				noArrow
-				animate={ false }
-				anchorRef={ inserterElement }
-				position="top right left"
-				focusOnMount={ false }
-				className="block-editor-block-list__block-popover"
-				__unstableSlotName="block-toolbar"
-			>
-				<BlockInsertionPoint
-					rootClientId={ inserterRootClientId }
-					clientId={ inserterClientId }
-					onFocus={ () => setIsInserterForced( true ) }
-					onBlur={ () => setIsInserterForced( false ) }
-					width={ inserterElement.offsetWidth }
-				/>
-			</Popover>
-		}
+		{ InsertionPoint && <InsertionPoint /> }
 		<div
 			ref={ ref }
 			className={ className }
 			onFocus={ onFocus }
 			onDragStart={ onDragStart }
-			onMouseMove={ ( isInserterForced || isMultiSelecting ) ? undefined : onMouseMove }
+			onMouseMove={ onMouseMove }
 		>
 			<Context.Provider value={ onSelectionStart }>
 				{ children }

--- a/packages/block-editor/src/components/block-list/root-container.js
+++ b/packages/block-editor/src/components/block-list/root-container.js
@@ -20,16 +20,12 @@ function selector( select ) {
 		getSelectedBlockClientId,
 		hasMultiSelection,
 		isMultiSelecting,
-		getBlockRootClientId,
-		isBlockSelected,
 	} = select( 'core/block-editor' );
 
 	return {
 		selectedBlockClientId: getSelectedBlockClientId(),
 		hasMultiSelection: hasMultiSelection(),
 		isMultiSelecting: isMultiSelecting(),
-		getBlockRootClientId,
-		isBlockSelected,
 	};
 }
 

--- a/packages/block-editor/src/components/block-list/root-container.js
+++ b/packages/block-editor/src/components/block-list/root-container.js
@@ -22,6 +22,7 @@ function selector( select ) {
 		hasMultiSelection,
 		isMultiSelecting,
 		getBlockRootClientId,
+		isBlockSelected,
 	} = select( 'core/block-editor' );
 
 	return {
@@ -29,6 +30,7 @@ function selector( select ) {
 		hasMultiSelection: hasMultiSelection(),
 		isMultiSelecting: isMultiSelecting(),
 		getBlockRootClientId,
+		isBlockSelected,
 	};
 }
 
@@ -54,6 +56,7 @@ export default function RootContainer( { children, className } ) {
 		hasMultiSelection,
 		isMultiSelecting,
 		getBlockRootClientId,
+		isBlockSelected,
 	} = useSelect( selector, [] );
 	const { selectBlock } = useDispatch( 'core/block-editor' );
 	const onSelectionStart = useMultiSelection( ref );
@@ -103,7 +106,7 @@ export default function RootContainer( { children, className } ) {
 
 		const clientId = element.id.slice( 'block-'.length );
 
-		if ( ! clientId ) {
+		if ( ! clientId || isBlockSelected( clientId ) ) {
 			return;
 		}
 

--- a/packages/block-editor/src/components/block-list/root-container.js
+++ b/packages/block-editor/src/components/block-list/root-container.js
@@ -79,7 +79,7 @@ export default function RootContainer( { children, className } ) {
 
 	const [ isInserterShown, setIsInserterShown ] = useState( false );
 	const [ isInserterForced, setIsInserterForced ] = useState( false );
-	const [ inserterPosition, setInserterPosition ] = useState( null );
+	const [ inserterElement, setInserterElement ] = useState( null );
 	const [ inserterClientId, setInserterClientId ] = useState( null );
 	const [ inserterRootClientId, setInserterRootClientId ] = useState( null );
 
@@ -91,28 +91,33 @@ export default function RootContainer( { children, className } ) {
 			return;
 		}
 
-		if ( isInserterShown ) {
-			return;
-		}
-
 		const rect = event.target.getBoundingClientRect();
 		const offset = event.clientY - rect.top;
-		const afterIndex = Array.from( event.target.children ).find( ( blockEl ) => {
+		const element = Array.from( event.target.children ).find( ( blockEl ) => {
 			return blockEl.offsetTop > offset;
 		} );
 
-		if ( ! afterIndex ) {
+		if ( ! element ) {
 			return;
 		}
 
-		const clientId = afterIndex.id.slice( 'block-'.length );
+		const clientId = element.id.slice( 'block-'.length );
 
 		if ( ! clientId ) {
 			return;
 		}
 
+		const elementRect = element.getBoundingClientRect();
+
+		if ( event.clientX > elementRect.right || event.clientX < elementRect.left ) {
+			if ( isInserterShown ) {
+				setIsInserterShown( false );
+			}
+			return;
+		}
+
 		setIsInserterShown( true );
-		setInserterPosition( afterIndex );
+		setInserterElement( element );
 		setInserterClientId( clientId );
 		setInserterRootClientId( getBlockRootClientId( clientId ) );
 	}
@@ -122,7 +127,7 @@ export default function RootContainer( { children, className } ) {
 			<Popover
 				noArrow
 				animate={ false }
-				anchorRef={ inserterPosition }
+				anchorRef={ inserterElement }
 				position="top right left"
 				focusOnMount={ false }
 				className="block-editor-block-list__block-popover"
@@ -133,7 +138,7 @@ export default function RootContainer( { children, className } ) {
 					clientId={ inserterClientId }
 					onFocus={ () => setIsInserterForced( true ) }
 					onBlur={ () => setIsInserterForced( false ) }
-					width={ inserterPosition.offsetWidth }
+					width={ inserterElement.offsetWidth }
 				/>
 			</Popover>
 		}

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -420,22 +420,6 @@
 	}
 }
 
-// Don't show the sibling inserter before the selected block.
-.edit-post-layout:not(.has-fixed-toolbar) {
-	// The child selector is necessary for this to work properly in nested contexts.
-	.is-selected > .block-editor-block-list__insertion-point > .block-editor-block-list__insertion-point-inserter,
-	.is-focused > .block-editor-block-list__insertion-point > .block-editor-block-list__insertion-point-inserter {
-		opacity: 0;
-		pointer-events: none;
-
-		&:hover,
-		&.is-visible {
-			opacity: 1;
-			pointer-events: auto;
-		}
-	}
-}
-
 // This is the edge-to-edge hover area that contains the plus.
 .block-editor-block-list__block {
 	> .block-editor-block-list__insertion-point {

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -31,6 +31,7 @@
 .block-editor-block-list__layout {
 	padding-left: $block-padding;
 	padding-right: $block-padding;
+	position: relative;
 
 	// Beyond the mobile breakpoint, compensate for side UI.
 	@include break-small() {
@@ -402,12 +403,7 @@
 		display: flex;
 	}
 
-	position: absolute;
-	bottom: auto;
-	left: 0;
-	right: 0;
 	justify-content: center;
-	height: $block-padding + 8px;
 
 	// Show a clickable plus.
 	.block-editor-inserter__toggle {
@@ -421,16 +417,6 @@
 		&:not(:disabled):not([aria-disabled="true"]):hover {
 			box-shadow: none;
 		}
-	}
-
-	// Hide both the button until hovered.
-	opacity: 0;
-	transition: opacity 0.1s linear;
-	@include reduce-motion("transition");
-
-	&:hover,
-	&.is-visible {
-		opacity: 1;
 	}
 }
 

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -1,7 +1,14 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
+import { Toolbar } from '@wordpress/components';
+import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -13,18 +20,21 @@ import BlockSettingsMenu from '../block-settings-menu';
 import BlockSwitcher from '../block-switcher';
 import MultiBlocksSwitcher from '../block-switcher/multi-blocks-switcher';
 import BlockMover from '../block-mover';
+import Inserter from '../inserter';
 
 export default function BlockToolbar( { moverDirection, hasMovers = true } ) {
-	const { blockClientIds, isValid, mode } = useSelect( ( select ) => {
+	const { blockClientIds, isValid, mode, rootClientId } = useSelect( ( select ) => {
 		const {
 			getBlockMode,
 			getSelectedBlockClientIds,
 			isBlockValid,
+			getBlockRootClientId,
 		} = select( 'core/block-editor' );
 		const selectedBlockClientIds = getSelectedBlockClientIds();
 
 		return {
 			blockClientIds: selectedBlockClientIds,
+			rootClientId: getBlockRootClientId( selectedBlockClientIds[ 0 ] ),
 			isValid: selectedBlockClientIds.length === 1 ?
 				isBlockValid( selectedBlockClientIds[ 0 ] ) :
 				null,
@@ -33,6 +43,7 @@ export default function BlockToolbar( { moverDirection, hasMovers = true } ) {
 				null,
 		};
 	}, [] );
+	const [ isInserterShown, setIsInserterShown ] = useState( false );
 
 	if ( blockClientIds.length === 0 ) {
 		return null;
@@ -51,6 +62,14 @@ export default function BlockToolbar( { moverDirection, hasMovers = true } ) {
 		);
 	}
 
+	function onFocus() {
+		setIsInserterShown( true );
+	}
+
+	function onBlur() {
+		setIsInserterShown( false );
+	}
+
 	return (
 		<div className="block-editor-block-toolbar">
 			{ hasMovers && ( <BlockMover
@@ -65,6 +84,23 @@ export default function BlockToolbar( { moverDirection, hasMovers = true } ) {
 				</>
 			) }
 			<BlockSettingsMenu clientIds={ blockClientIds } />
+			<Toolbar
+				onFocus={ onFocus }
+				onBlur={ onBlur }
+				// While ideally it would be enough to capture the
+				// bubbling focus event from the Inserter, due to the
+				// characteristics of click focusing of `button`s in
+				// Firefox and Safari, it is not reliable.
+				//
+				// See: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Clicking_and_focus
+				tabIndex={ -1 }
+				className={ classnames(
+					'block-editor-block-toolbar__inserter',
+					{ 'is-visible': isInserterShown }
+				) }
+			>
+				<Inserter clientId={ blockClientIds[ 0 ] } rootClientId={ rootClientId } />
+			</Toolbar>
 		</div>
 	);
 }

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -49,6 +49,34 @@ export default function BlockToolbar( { moverDirection, hasMovers = true } ) {
 		return null;
 	}
 
+	function onFocus() {
+		setIsInserterShown( true );
+	}
+
+	function onBlur() {
+		setIsInserterShown( false );
+	}
+
+	const inserter = (
+		<Toolbar
+			onFocus={ onFocus }
+			onBlur={ onBlur }
+			// While ideally it would be enough to capture the
+			// bubbling focus event from the Inserter, due to the
+			// characteristics of click focusing of `button`s in
+			// Firefox and Safari, it is not reliable.
+			//
+			// See: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Clicking_and_focus
+			tabIndex={ -1 }
+			className={ classnames(
+				'block-editor-block-toolbar__inserter',
+				{ 'is-visible': isInserterShown }
+			) }
+		>
+			<Inserter clientId={ blockClientIds[ 0 ] } rootClientId={ rootClientId } />
+		</Toolbar>
+	);
+
 	if ( blockClientIds.length > 1 ) {
 		return (
 			<div className="block-editor-block-toolbar">
@@ -58,16 +86,9 @@ export default function BlockToolbar( { moverDirection, hasMovers = true } ) {
 				/> ) }
 				<MultiBlocksSwitcher />
 				<BlockSettingsMenu clientIds={ blockClientIds } />
+				{ inserter }
 			</div>
 		);
-	}
-
-	function onFocus() {
-		setIsInserterShown( true );
-	}
-
-	function onBlur() {
-		setIsInserterShown( false );
 	}
 
 	return (
@@ -84,23 +105,7 @@ export default function BlockToolbar( { moverDirection, hasMovers = true } ) {
 				</>
 			) }
 			<BlockSettingsMenu clientIds={ blockClientIds } />
-			<Toolbar
-				onFocus={ onFocus }
-				onBlur={ onBlur }
-				// While ideally it would be enough to capture the
-				// bubbling focus event from the Inserter, due to the
-				// characteristics of click focusing of `button`s in
-				// Firefox and Safari, it is not reliable.
-				//
-				// See: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Clicking_and_focus
-				tabIndex={ -1 }
-				className={ classnames(
-					'block-editor-block-toolbar__inserter',
-					{ 'is-visible': isInserterShown }
-				) }
-			>
-				<Inserter clientId={ blockClientIds[ 0 ] } rootClientId={ rootClientId } />
-			</Toolbar>
+			{ inserter }
 		</div>
 	);
 }

--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -44,6 +44,16 @@
 			border-color: $light-gray-500;
 		}
 	}
+
+	&__inserter {
+		opacity: 0;
+		pointer-events: none;
+
+		&.is-visible {
+			opacity: 1;
+			pointer-events: all;
+		}
+	}
 }
 
 .block-editor-block-toolbar__slot {

--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -141,7 +141,7 @@ export default compose( [
 			__experimentalGetAllowedBlocks,
 		} = select( 'core/block-editor' );
 
-		rootClientId = rootClientId || getBlockRootClientId( clientId );
+		rootClientId = rootClientId || getBlockRootClientId( clientId ) || undefined;
 
 		const allowedBlocks = __experimentalGetAllowedBlocks( rootClientId );
 
@@ -157,6 +157,7 @@ export default compose( [
 			hasSingleBlockType,
 			blockTitle: allowedBlockType ? allowedBlockType.title : '',
 			allowedBlockType,
+			rootClientId,
 		};
 	} ),
 	withDispatch( ( dispatch, ownProps, { select } ) => {

--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -134,11 +134,14 @@ class Inserter extends Component {
 }
 
 export default compose( [
-	withSelect( ( select, { rootClientId } ) => {
+	withSelect( ( select, { clientId, rootClientId } ) => {
 		const {
+			getBlockRootClientId,
 			hasInserterItems,
 			__experimentalGetAllowedBlocks,
 		} = select( 'core/block-editor' );
+
+		rootClientId = rootClientId || getBlockRootClientId( clientId );
 
 		const allowedBlocks = __experimentalGetAllowedBlocks( rootClientId );
 

--- a/packages/components/src/toolbar-group/toolbar-group-container.js
+++ b/packages/components/src/toolbar-group/toolbar-group-container.js
@@ -1,6 +1,6 @@
-const ToolbarGroupContainer = ( props ) => (
-	<div className={ props.className }>
-		{ props.children }
+const ToolbarGroupContainer = ( { className, children, ...props } ) => (
+	<div className={ className } { ...props }>
+		{ children }
 	</div>
 );
 export default ToolbarGroupContainer;

--- a/packages/e2e-tests/specs/editor/various/adding-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/adding-blocks.test.js
@@ -92,11 +92,11 @@ describe( 'adding blocks', () => {
 		await page.click( '.editor-post-title__input' );
 
 		// Using the between inserter
-		const insertionPoint = await page.$( '[data-type="core/quote"] .block-editor-inserter__toggle' );
+		const insertionPoint = await page.$( '[data-type="core/quote"]' );
 		const rect = await insertionPoint.boundingBox();
-		await page.mouse.move( rect.x + ( rect.width / 2 ), rect.y + ( rect.height / 2 ), { steps: 10 } );
-		await page.waitForSelector( '[data-type="core/quote"] .block-editor-inserter__toggle' );
-		await page.click( '[data-type="core/quote"] .block-editor-inserter__toggle' );
+		await page.mouse.move( rect.x + ( rect.width / 2 ), rect.y - 10, { steps: 10 } );
+		await page.waitForSelector( '.block-editor-block-list__insertion-point .block-editor-inserter__toggle' );
+		await page.click( '.block-editor-block-list__insertion-point .block-editor-inserter__toggle' );
 		// [TODO]: Search input should be focused immediately. It shouldn't be
 		// necessary to have `waitForFunction`.
 		await page.waitForFunction( () => (

--- a/packages/e2e-tests/specs/editor/various/keyboard-navigable-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/keyboard-navigable-blocks.test.js
@@ -30,9 +30,6 @@ const tabThroughParagraphBlock = async ( paragraphText ) => {
 	await expect( await getActiveLabel() ).toBe( 'Block: Paragraph' );
 
 	await page.keyboard.press( 'Tab' );
-	await expect( await getActiveLabel() ).toBe( 'Add block' );
-
-	await page.keyboard.press( 'Tab' );
 	await expect( await getActiveLabel() ).toBe( 'Paragraph block' );
 	await expect( await page.evaluate( () =>
 		document.activeElement.innerHTML
@@ -71,6 +68,9 @@ const tabThroughBlockToolbar = async () => {
 
 	await page.keyboard.press( 'Tab' );
 	await expect( await getActiveLabel() ).toBe( 'More options' );
+
+	await page.keyboard.press( 'Tab' );
+	await expect( await getActiveLabel() ).toBe( 'Add block' );
 };
 
 describe( 'Order of block keyboard navigation', () => {

--- a/packages/e2e-tests/specs/editor/various/multi-block-selection.test.js
+++ b/packages/e2e-tests/specs/editor/various/multi-block-selection.test.js
@@ -302,7 +302,6 @@ describe( 'Multi-block selection', () => {
 		await page.keyboard.press( 'Enter' );
 		await page.click( '.components-circular-option-picker__option' );
 		await page.keyboard.type( '2' );
-		await page.keyboard.press( 'ArrowUp' );
 
 		const [ coord1, coord2 ] = await page.evaluate( () => {
 			const elements = Array.from( document.querySelectorAll( '.wp-block-paragraph' ) );


### PR DESCRIPTION
## Description

This results in a performance gain of 26% for typing. It also improves loading time. The big post we're testing loads 20% faster.

This PR moves the sibling inserter out of the block DOM. Currently it is rendered for every block on the page, selected or not, so it can be shown on hover. This PR takes a different approach: it looks at mouse movement between the block and then renders an inserter in the right place. Only one inserter is ever rendered.

* Way less inserters rendered, so this solution is more performant.
* Much better hover target: the hove target is now exactly as big as the space between the blocks. Previously it has a fixed height.

In order for it to work for keyboard users, an inserter button is visually hidden in the toolbar, but shows when it receives focus. This is similar to other shortcuts in Gutenberg like the "open publish panel" button.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
