### PR TITLE
[RNMobile] Fix crash once adding Group

### DIFF
--- a/packages/components/src/button/index.native.js
+++ b/packages/components/src/button/index.native.js
@@ -125,8 +125,8 @@ export function Button( props ) {
 		)
 	);
 
-	const newIcon = cloneElement( ( icon && <Icon icon={ icon } size={ iconSize } /> ),
-		{ colorScheme: props.preferredColorScheme, isPressed } );
+	const newIcon = icon ? cloneElement( ( <Icon icon={ icon } size={ iconSize } /> ),
+		{ colorScheme: props.preferredColorScheme, isPressed } ) : null;
 
 	const element = (
 		<TouchableOpacity


### PR DESCRIPTION
## Description

Fix a crash once adding a `Group` block.

Ref to gutenberg mobile: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1755

## How has this been tested?

1. Add a `Group` block
2. Check if block is added correctly

## Screenshots <!-- if applicable -->

before | after
--- | ---
<img width="486" alt="Screenshot 2020-01-07 at 12 04 35" src="https://user-images.githubusercontent.com/22746080/71891029-ed2ee780-3145-11ea-93c2-cd89ca6ab1fd.png"> | <img width="486" alt="Screenshot 2020-01-07 at 12 02 24" src="https://user-images.githubusercontent.com/22746080/71891028-ec965100-3145-11ea-8162-c2b5547b5be6.png"> 


## Types of changes

Check if `icon` exists before passing into `cloneElement`.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
