### PR TITLE
Nav Block - show recent pages as default suggestions when creating Nav Links

### DIFF
--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -65,7 +65,7 @@ export function LinkControl( {
 
 		// Populate input searcher whether
 		// the current link has a title.
-		if ( value && value.title && mode === 'edit' ) {
+		if ( value && value.title && MODE_EDIT === mode ) {
 			setInputValue( value.title );
 		}
 	};

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -101,9 +101,11 @@ export function LinkControl( {
 		);
 	};
 
-	const handleEntitySearch = async ( val ) => {
+	const handleEntitySearch = async ( val, args ) => {
 		const results = await Promise.all( [
-			fetchSearchSuggestions( val ),
+			fetchSearchSuggestions( val, {
+				...( args.isInitialSuggestions ? { perPage: 3 } : {} ),
+			} ),
 			handleDirectEntry( val ),
 		] );
 
@@ -112,11 +114,11 @@ export function LinkControl( {
 		// If it's potentially a URL search then concat on a URL search suggestion
 		// just for good measure. That way once the actual results run out we always
 		// have a URL option to fallback on.
-		return couldBeURL ? results[ 0 ].concat( results[ 1 ] ) : results[ 0 ];
+		return couldBeURL && ! args.isInitialSuggestions ? results[ 0 ].concat( results[ 1 ] ) : results[ 0 ];
 	};
 
 	// Effects
-	const getSearchHandler = useCallback( ( val ) => {
+	const getSearchHandler = useCallback( ( val, args ) => {
 		const protocol = getProtocol( val ) || '';
 		const isMailto = protocol.includes( 'mailto' );
 		const isInternal = startsWith( val, '#' );
@@ -124,7 +126,7 @@ export function LinkControl( {
 
 		const handleManualEntry = isInternal || isMailto || isTel || isURL( val ) || ( val && val.includes( 'www.' ) );
 
-		return ( handleManualEntry ) ? handleDirectEntry( val ) : handleEntitySearch( val );
+		return ( handleManualEntry ) ? handleDirectEntry( val, args ) : handleEntitySearch( val, args );
 	}, [ handleDirectEntry, fetchSearchSuggestions ] );
 
 	// Render Components

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -36,7 +36,7 @@ export function LinkControl( {
 	value,
 	settings,
 	onChange = noop,
-	manualSearch,
+	initialSuggestions,
 } ) {
 	const instanceId = useInstanceId( LinkControl );
 	const [ inputValue, setInputValue ] = useState( '' );
@@ -189,20 +189,20 @@ export function LinkControl( {
 				</Fragment>
 			) }
 
-			{ isEditingLink && (
-				<LinkControlSearchInput
-					value={ inputValue }
-					onChange={ onInputChange }
-					onSelect={ ( suggestion ) => {
-						setIsEditingLink( false );
-						onChange( { ...value, ...suggestion } );
-					} }
-					renderSuggestions={ renderSearchResults }
-					fetchSuggestions={ getSearchHandler }
-					onReset={ resetInput }
-							manualSearch={ manualSearch }
-				/>
-			) }
+					{ isEditingLink && (
+						<LinkControlSearchInput
+							value={ inputValue }
+							onChange={ onInputChange }
+							onSelect={ ( suggestion ) => {
+								setIsEditingLink( false );
+								onChange( { ...value, ...suggestion } );
+							} }
+							renderSuggestions={ renderSearchResults }
+							fetchSuggestions={ getSearchHandler }
+							onReset={ resetInput }
+							initialSuggestions={ initialSuggestions }
+						/>
+					) }
 
 			{ ! isEditingLink && (
 				<LinkControlSettingsDrawer value={ value } settings={ settings } onChange={ onChange } />

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -35,7 +35,7 @@ export function LinkControl( {
 	value,
 	settings,
 	onChange = noop,
-	initialSuggestions,
+	showInitialSuggestions,
 	fetchSearchSuggestions,
 } ) {
 	const instanceId = useInstanceId( LinkControl );
@@ -202,7 +202,7 @@ export function LinkControl( {
 					renderSuggestions={ renderSearchResults }
 					fetchSuggestions={ getSearchHandler }
 					onReset={ resetInput }
-					initialSuggestions={ initialSuggestions }
+					showInitialSuggestions={ showInitialSuggestions }
 				/>
 			) }
 

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -36,6 +36,7 @@ export function LinkControl( {
 	settings,
 	onChange = noop,
 	initialSuggestions,
+	fetchSearchSuggestions,
 } ) {
 	const instanceId = useInstanceId( LinkControl );
 	const [ inputValue, setInputValue ] = useState( '' );
@@ -190,20 +191,20 @@ export function LinkControl( {
 				</Fragment>
 			) }
 
-					{ isEditingLink && (
-						<LinkControlSearchInput
-							value={ inputValue }
-							onChange={ onInputChange }
-							onSelect={ ( suggestion ) => {
-								setIsEditingLink( false );
-								onChange( { ...value, ...suggestion } );
-							} }
-							renderSuggestions={ renderSearchResults }
-							fetchSuggestions={ getSearchHandler }
-							onReset={ resetInput }
-							initialSuggestions={ initialSuggestions }
-						/>
-					) }
+			{ isEditingLink && (
+				<LinkControlSearchInput
+					value={ inputValue }
+					onChange={ onInputChange }
+					onSelect={ ( suggestion ) => {
+						setIsEditingLink( false );
+						onChange( { ...value, ...suggestion } );
+					} }
+					renderSuggestions={ renderSearchResults }
+					fetchSuggestions={ getSearchHandler }
+					onReset={ resetInput }
+					initialSuggestions={ initialSuggestions }
+				/>
+			) }
 
 			{ ! isEditingLink && (
 				<LinkControlSettingsDrawer value={ value } settings={ settings } onChange={ onChange } />

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -30,7 +30,6 @@ import LinkControlSearchItem from './search-item';
 import LinkControlSearchInput from './search-input';
 
 const MODE_EDIT = 'edit';
-// const MODE_SHOW = 'show';
 
 export function LinkControl( {
 	value,

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -36,7 +36,7 @@ export function LinkControl( {
 	value,
 	settings,
 	onChange = noop,
-	fetchSearchSuggestions,
+	manualSearch,
 } ) {
 	const instanceId = useInstanceId( LinkControl );
 	const [ inputValue, setInputValue ] = useState( '' );
@@ -200,6 +200,7 @@ export function LinkControl( {
 					renderSuggestions={ renderSearchResults }
 					fetchSuggestions={ getSearchHandler }
 					onReset={ resetInput }
+							manualSearch={ manualSearch }
 				/>
 			) }
 

--- a/packages/block-editor/src/components/link-control/search-input.js
+++ b/packages/block-editor/src/components/link-control/search-input.js
@@ -69,7 +69,7 @@ const LinkControlSearchInput = ( {
 				__experimentalRenderSuggestions={ renderSuggestions }
 				__experimentalFetchLinkSuggestions={ fetchSuggestions }
 				__experimentalHandleURLSuggestions={ true }
-				__experimentalInitialSuggestions={ initialSuggestions }
+				__experimentalShowInitialSuggestions={ initialSuggestions }
 			/>
 
 			<Button

--- a/packages/block-editor/src/components/link-control/search-input.js
+++ b/packages/block-editor/src/components/link-control/search-input.js
@@ -32,6 +32,7 @@ const handleLinkControlOnKeyPress = ( event ) => {
 
 const LinkControlSearchInput = ( {
 	value,
+	manualSearch,
 	onChange,
 	onSelect,
 	renderSuggestions,
@@ -68,6 +69,7 @@ const LinkControlSearchInput = ( {
 				__experimentalRenderSuggestions={ renderSuggestions }
 				__experimentalFetchLinkSuggestions={ fetchSuggestions }
 				__experimentalHandleURLSuggestions={ true }
+				manualSearch={ manualSearch }
 			/>
 
 			<Button

--- a/packages/block-editor/src/components/link-control/search-input.js
+++ b/packages/block-editor/src/components/link-control/search-input.js
@@ -32,12 +32,12 @@ const handleLinkControlOnKeyPress = ( event ) => {
 
 const LinkControlSearchInput = ( {
 	value,
-	manualSearch,
 	onChange,
 	onSelect,
 	renderSuggestions,
 	fetchSuggestions,
 	onReset,
+	initialSuggestions,
 } ) => {
 	const selectItemHandler = ( selection, suggestion ) => {
 		onChange( selection );
@@ -69,7 +69,7 @@ const LinkControlSearchInput = ( {
 				__experimentalRenderSuggestions={ renderSuggestions }
 				__experimentalFetchLinkSuggestions={ fetchSuggestions }
 				__experimentalHandleURLSuggestions={ true }
-				manualSearch={ manualSearch }
+				__experimentalInitialSuggestions={ initialSuggestions }
 			/>
 
 			<Button

--- a/packages/block-editor/src/components/link-control/search-input.js
+++ b/packages/block-editor/src/components/link-control/search-input.js
@@ -27,7 +27,13 @@ const handleLinkControlOnKeyDown = ( event ) => {
 };
 
 const handleLinkControlOnKeyPress = ( event ) => {
+	const { keyCode } = event;
+
 	event.stopPropagation();
+
+	if ( keyCode === ENTER ) {
+
+	}
 };
 
 const LinkControlSearchInput = ( {
@@ -37,7 +43,7 @@ const LinkControlSearchInput = ( {
 	renderSuggestions,
 	fetchSuggestions,
 	onReset,
-	initialSuggestions,
+	showInitialSuggestions,
 } ) => {
 	const selectItemHandler = ( selection, suggestion ) => {
 		onChange( selection );
@@ -69,7 +75,7 @@ const LinkControlSearchInput = ( {
 				__experimentalRenderSuggestions={ renderSuggestions }
 				__experimentalFetchLinkSuggestions={ fetchSuggestions }
 				__experimentalHandleURLSuggestions={ true }
-				__experimentalShowInitialSuggestions={ initialSuggestions }
+				__experimentalShowInitialSuggestions={ showInitialSuggestions }
 			/>
 
 			<Button

--- a/packages/block-editor/src/components/link-control/test/fixtures/index.js
+++ b/packages/block-editor/src/components/link-control/test/fixtures/index.js
@@ -34,7 +34,26 @@ export const fauxEntitySuggestions = [
 	},
 ];
 
-// export const fetchFauxEntitySuggestions = async () => fauxEntitySuggestions;
+export const fauxInitialSuggestions = [
+	{
+		id: uniqueId(),
+		title: 'Suggested Page 1',
+		type: 'Page',
+		url: `?p=${ uniqueId() }`,
+	},
+	{
+		id: uniqueId(),
+		title: 'Suggested Page 2',
+		type: 'Page',
+		url: `?p=${ uniqueId() }`,
+	},
+	{
+		id: uniqueId(),
+		title: 'Suggested Page 3',
+		type: 'Page',
+		url: `?p=${ uniqueId() }`,
+	},
+];
 
 export const fetchFauxEntitySuggestions = () => {
 	return Promise.resolve( fauxEntitySuggestions );

--- a/packages/block-editor/src/components/link-control/test/fixtures/index.js
+++ b/packages/block-editor/src/components/link-control/test/fixtures/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { uniqueId } from 'lodash';
+import { uniqueId, take } from 'lodash';
 
 export const fauxEntitySuggestions = [
 	{
@@ -34,27 +34,11 @@ export const fauxEntitySuggestions = [
 	},
 ];
 
-export const fauxInitialSuggestions = [
-	{
-		id: uniqueId(),
-		title: 'Suggested Page 1',
-		type: 'Page',
-		url: `?p=${ uniqueId() }`,
-	},
-	{
-		id: uniqueId(),
-		title: 'Suggested Page 2',
-		type: 'Page',
-		url: `?p=${ uniqueId() }`,
-	},
-	{
-		id: uniqueId(),
-		title: 'Suggested Page 3',
-		type: 'Page',
-		url: `?p=${ uniqueId() }`,
-	},
-];
-
-export const fetchFauxEntitySuggestions = () => {
-	return Promise.resolve( fauxEntitySuggestions );
+/* eslint-disable no-unused-vars */
+export const fetchFauxEntitySuggestions = ( val = '', {
+	perPage = null,
+} = {} ) => {
+	const suggestions = perPage ? take( fauxEntitySuggestions, perPage ) : fauxEntitySuggestions;
+	return Promise.resolve( suggestions );
 };
+/* eslint-enable no-unused-vars */

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -309,6 +309,36 @@ describe( 'Manual link entry', () => {
 	} );
 } );
 
+describe( 'Default search suggestions', () => {
+	it( 'should display a list of initial search suggestions if provided', async () => {
+		const searchSuggestionsSpy = jest.fn();
+		const expectedResultsLength = fauxInitialSuggestions.length;
+
+		act( () => {
+			render(
+				<LinkControl
+					fetchSearchSuggestions={ searchSuggestionsSpy }
+					initialSuggestions={ () => Promise.resolve( fauxInitialSuggestions ) }
+				/>, container
+			);
+		} );
+
+		await eventLoopTick();
+
+		// Search Input UI
+		const searchInput = container.querySelector( 'input[aria-label="URL"]' );
+
+		// TODO: select these by aria relationship to autocomplete rather than arbitary selector.
+		const initialSearchResultElements = container.querySelectorAll( '[role="listbox"] [role="option"]' );
+
+		expect( searchSuggestionsSpy ).not.toHaveBeenCalled(); // verify no search has occured
+		expect( searchInput.value ).toBe( '' ); // verify no search has occured
+
+		// Verify the search results already display the initial suggestions
+		expect( initialSearchResultElements ).toHaveLength( expectedResultsLength );
+	} );
+} );
+
 describe( 'Selecting links', () => {
 	it( 'should display a selected link corresponding to the provided "currentLink" prop', () => {
 		const selectedLink = first( fauxEntitySuggestions );

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -318,7 +318,7 @@ describe( 'Default search suggestions', () => {
 			render(
 				<LinkControl
 					fetchSearchSuggestions={ searchSuggestionsSpy }
-					initialSuggestions={ true }
+					showInitialSuggestions={ true }
 				/>, container
 			);
 		} );
@@ -355,7 +355,7 @@ describe( 'Default search suggestions', () => {
 			render(
 				<LinkControl
 					fetchSearchSuggestions={ searchSuggestionsSpy }
-					initialSuggestions={ true }
+					showInitialSuggestions={ true }
 					value={ fauxEntitySuggestions[ 0 ] }
 				/>, container
 			);

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -335,7 +335,10 @@ describe( 'Default search suggestions', () => {
 		// when this does not have a value
 		expect( searchInput.value ).toBe( '' );
 
-		expect( searchSuggestionsSpy ).toHaveBeenCalled();
+		// Ensure only called once as a guard against potential infinite
+		// re-render loop within `componentDidUpdate` calling `updateSuggestions`
+		// which has calls to `setState` within it.
+		expect( searchSuggestionsSpy ).toHaveBeenCalledTimes( 1 );
 
 		// Verify the search results already display the initial suggestions
 		expect( initialSearchResultElements ).toHaveLength( expectedResultsLength );
@@ -396,7 +399,10 @@ describe( 'Default search suggestions', () => {
 
 		expect( searchResultElements ).toHaveLength( 3 );
 
-		expect( searchSuggestionsSpy ).toHaveBeenCalled();
+		// Ensure only called once as a guard against potential infinite
+		// re-render loop within `componentDidUpdate` calling `updateSuggestions`
+		// which has calls to `setState` within it.
+		expect( searchSuggestionsSpy ).toHaveBeenCalledTimes( 1 );
 	} );
 } );
 

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -311,14 +311,14 @@ describe( 'Manual link entry', () => {
 
 describe( 'Default search suggestions', () => {
 	it( 'should display a list of initial search suggestions if provided', async () => {
-		const searchSuggestionsSpy = jest.fn();
-		const expectedResultsLength = fauxInitialSuggestions.length;
+		const searchSuggestionsSpy = jest.fn( fetchFauxEntitySuggestions );
+		const expectedResultsLength = 3; // set within `LinkControl`
 
 		act( () => {
 			render(
 				<LinkControl
 					fetchSearchSuggestions={ searchSuggestionsSpy }
-					initialSuggestions={ () => Promise.resolve( fauxInitialSuggestions ) }
+					initialSuggestions={ true }
 				/>, container
 			);
 		} );
@@ -331,8 +331,9 @@ describe( 'Default search suggestions', () => {
 		// TODO: select these by aria relationship to autocomplete rather than arbitary selector.
 		const initialSearchResultElements = container.querySelectorAll( '[role="listbox"] [role="option"]' );
 
-		expect( searchSuggestionsSpy ).not.toHaveBeenCalled(); // verify no search has occured
-		expect( searchInput.value ).toBe( '' ); // verify no search has occured
+		// Verify input has no value has default suggestions should only show
+		// when this does not have a value
+		expect( searchInput.value ).toBe( '' );
 
 		// Verify the search results already display the initial suggestions
 		expect( initialSearchResultElements ).toHaveLength( expectedResultsLength );

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -169,8 +169,7 @@ class URLInput extends Component {
 		// If the suggestions are not shown or loading, we shouldn't handle the arrow keys
 		// We shouldn't preventDefault to allow block arrow keys navigation
 		if (
-			( ! showSuggestions || ! suggestions.length || loading ) &&
-			this.props.value
+			( ! showSuggestions || ! suggestions.length || loading )
 		) {
 			// In the Windows version of Firefox the up and down arrows don't move the caret
 			// within an input field like they do for Mac Firefox/Chrome/Safari. This causes
@@ -260,7 +259,7 @@ class URLInput extends Component {
 		this.inputRef.current.focus();
 	}
 
-	static getDerivedStateFromProps( { value, disableSuggestions, __experimentalInitialSuggestions: manualSearch }, { showSuggestions, selectedSuggestion } ) {
+	static getDerivedStateFromProps( { value, disableSuggestions, __experimentalInitialSuggestions: manualSearch }, { showSuggestions } ) {
 		let shouldShowSuggestions = showSuggestions;
 
 		const hasValue = value && value.length;
@@ -274,7 +273,6 @@ class URLInput extends Component {
 		}
 
 		return {
-			selectedSuggestion: hasValue ? selectedSuggestion : null,
 			showSuggestions: shouldShowSuggestions,
 		};
 	}

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -44,7 +44,8 @@ class URLInput extends Component {
 	}
 
 	componentDidUpdate() {
-		const { showSuggestions, selectedSuggestion } = this.state;
+		const { showSuggestions, selectedSuggestion, suggestions } = this.state;
+		const { __experimentalInitialSuggestions = '', value } = this.props;
 		// only have to worry about scrolling selected suggestion into view
 		// when already expanded
 		if ( showSuggestions && selectedSuggestion !== null && ! this.scrollingIntoView ) {
@@ -57,6 +58,15 @@ class URLInput extends Component {
 			this.props.setTimeout( () => {
 				this.scrollingIntoView = false;
 			}, 100 );
+		}
+
+		// If there is no search text and no current suggestions
+		// then display the initial suggesitons if provided
+		// (being careful to avoid infinite re-render loop).
+		if ( __experimentalInitialSuggestions && ! ( value && value.length ) && ! ( suggestions && suggestions.length ) ) {
+			this.updateSuggestions( '', {
+				isManualSearch: true,
+			} );
 		}
 	}
 

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -60,6 +60,15 @@ class URLInput extends Component {
 		}
 	}
 
+	componentDidMount() {
+		const { manualSearch = '' } = this.props;
+		if ( manualSearch ) {
+			this.updateSuggestions( 'sdfsdfsdf', {
+				isManualSearch: true,
+			} );
+		}
+	}
+
 	componentWillUnmount() {
 		delete this.suggestionsRequest;
 	}
@@ -70,18 +79,22 @@ class URLInput extends Component {
 		};
 	}
 
-	updateSuggestions( value ) {
+	updateSuggestions( value, {
+		isManualSearch = false,
+	} = {} ) {
 		const {
 			__experimentalFetchLinkSuggestions: fetchLinkSuggestions,
 			__experimentalHandleURLSuggestions: handleURLSuggestions,
+			manualSearch,
 		} = this.props;
-		if ( ! fetchLinkSuggestions ) {
+
+		if ( ! fetchLinkSuggestions || ! manualSearch ) {
 			return;
 		}
 
 		// Show the suggestions after typing at least 2 characters
 		// and also for URLs
-		if ( value.length < 2 || ( ! handleURLSuggestions && isURL( value ) ) ) {
+		if ( ! isManualSearch && ( value.length < 2 || ( ! handleURLSuggestions && isURL( value ) ) ) ) {
 			this.setState( {
 				showSuggestions: false,
 				selectedSuggestion: null,
@@ -97,7 +110,7 @@ class URLInput extends Component {
 			loading: true,
 		} );
 
-		const request = fetchLinkSuggestions( value );
+		const request = isManualSearch ? manualSearch() : fetchLinkSuggestions( value );
 
 		request.then( ( suggestions ) => {
 			// A fetch Promise doesn't have an abort option. It's mimicked by
@@ -237,12 +250,12 @@ class URLInput extends Component {
 		this.inputRef.current.focus();
 	}
 
-	static getDerivedStateFromProps( { value, disableSuggestions }, { showSuggestions, selectedSuggestion } ) {
+	static getDerivedStateFromProps( { value, disableSuggestions, manualSearch }, { showSuggestions, selectedSuggestion } ) {
 		let shouldShowSuggestions = showSuggestions;
 
 		const hasValue = value && value.length;
 
-		if ( ! hasValue ) {
+		if ( ! manualSearch && ! hasValue ) {
 			shouldShowSuggestions = false;
 		}
 
@@ -275,6 +288,7 @@ class URLInput extends Component {
 			selectedSuggestion,
 			loading,
 		} = this.state;
+
 		const id = `url-input-control-${ instanceId }`;
 
 		const suggestionsListboxId = `block-editor-url-input-suggestions-${ instanceId }`;

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -61,9 +61,9 @@ class URLInput extends Component {
 	}
 
 	componentDidMount() {
-		const { manualSearch = '' } = this.props;
-		if ( manualSearch ) {
-			this.updateSuggestions( 'sdfsdfsdf', {
+		const { __experimentalInitialSuggestions = '' } = this.props;
+		if ( __experimentalInitialSuggestions ) {
+			this.updateSuggestions( '', {
 				isManualSearch: true,
 			} );
 		}
@@ -85,10 +85,10 @@ class URLInput extends Component {
 		const {
 			__experimentalFetchLinkSuggestions: fetchLinkSuggestions,
 			__experimentalHandleURLSuggestions: handleURLSuggestions,
-			manualSearch,
+			__experimentalInitialSuggestions: initialSuggestions,
 		} = this.props;
 
-		if ( ! fetchLinkSuggestions || ! manualSearch ) {
+		if ( ! fetchLinkSuggestions || ! initialSuggestions ) {
 			return;
 		}
 
@@ -110,7 +110,7 @@ class URLInput extends Component {
 			loading: true,
 		} );
 
-		const request = isManualSearch ? manualSearch() : fetchLinkSuggestions( value );
+		const request = isManualSearch ? initialSuggestions() : fetchLinkSuggestions( value );
 
 		request.then( ( suggestions ) => {
 			// A fetch Promise doesn't have an abort option. It's mimicked by
@@ -250,7 +250,7 @@ class URLInput extends Component {
 		this.inputRef.current.focus();
 	}
 
-	static getDerivedStateFromProps( { value, disableSuggestions, manualSearch }, { showSuggestions, selectedSuggestion } ) {
+	static getDerivedStateFromProps( { value, disableSuggestions, __experimentalInitialSuggestions: manualSearch }, { showSuggestions, selectedSuggestion } ) {
 		let shouldShowSuggestions = showSuggestions;
 
 		const hasValue = value && value.length;

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -98,7 +98,7 @@ class URLInput extends Component {
 			__experimentalInitialSuggestions: initialSuggestions,
 		} = this.props;
 
-		if ( ! fetchLinkSuggestions || ! initialSuggestions ) {
+		if ( ! fetchLinkSuggestions || ( isManualSearch && ! initialSuggestions ) ) {
 			return;
 		}
 
@@ -157,6 +157,7 @@ class URLInput extends Component {
 
 	onChange( event ) {
 		const inputValue = event.target.value;
+
 		this.props.onChange( inputValue );
 		if ( ! this.props.disableSuggestions ) {
 			this.updateSuggestions( inputValue );

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -64,18 +64,14 @@ class URLInput extends Component {
 		// then display the initial suggesitons if provided
 		// (being careful to avoid infinite re-render loop).
 		if ( __experimentalShowInitialSuggestions && ! ( value && value.length ) && ! ( suggestions && suggestions.length ) ) {
-			this.updateSuggestions( '', {
-				isManualSearch: true,
-			} );
+			this.updateSuggestions( '' );
 		}
 	}
 
 	componentDidMount() {
 		const { __experimentalShowInitialSuggestions = false } = this.props;
 		if ( __experimentalShowInitialSuggestions ) {
-			this.updateSuggestions( '', {
-				isManualSearch: true,
-			} );
+			this.updateSuggestions( '' );
 		}
 	}
 
@@ -89,9 +85,7 @@ class URLInput extends Component {
 		};
 	}
 
-	updateSuggestions( value, {
-		isManualSearch = false,
-	} = {} ) {
+	updateSuggestions( value = '' ) {
 		const {
 			__experimentalFetchLinkSuggestions: fetchLinkSuggestions,
 			__experimentalHandleURLSuggestions: handleURLSuggestions,
@@ -101,11 +95,13 @@ class URLInput extends Component {
 			return;
 		}
 
+		const isInitialSuggestions = ! value || ! value.length;
+
 		// Allow a suggestions request if:
 		// - there are at least 2 characters in the search input (except manual searches where
 		//   search input length is not required to trigger a fetch)
 		// - this is a direct entry (eg: a URL)
-		if ( ! isManualSearch && ( value.length < 2 || ( ! handleURLSuggestions && isURL( value ) ) ) ) {
+		if ( ! isInitialSuggestions && ( value.length < 2 || ( ! handleURLSuggestions && isURL( value ) ) ) ) {
 			this.setState( {
 				showSuggestions: false,
 				selectedSuggestion: null,
@@ -122,7 +118,7 @@ class URLInput extends Component {
 		} );
 
 		const request = fetchLinkSuggestions( value, {
-			isInitialSuggestions: isManualSearch,
+			isInitialSuggestions,
 		} );
 
 		request.then( ( suggestions ) => {

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -61,7 +61,7 @@ class URLInput extends Component {
 		}
 
 		// If there is no search text and no current suggestions
-		// then display the initial suggesitons if provided
+		// then display the initial suggestions if provided
 		// (being careful to avoid infinite re-render loop).
 		if ( __experimentalShowInitialSuggestions && ! ( value && value.length ) && ! ( suggestions && suggestions.length ) ) {
 			this.updateSuggestions( '' );

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -46,6 +46,7 @@ class URLInput extends Component {
 	componentDidUpdate() {
 		const { showSuggestions, selectedSuggestion, suggestions } = this.state;
 		const { __experimentalShowInitialSuggestions = false, value } = this.props;
+
 		// only have to worry about scrolling selected suggestion into view
 		// when already expanded
 		if ( showSuggestions && selectedSuggestion !== null && ! this.scrollingIntoView ) {
@@ -64,14 +65,15 @@ class URLInput extends Component {
 		// then display the initial suggestions if provided
 		// (being careful to avoid infinite re-render loop).
 		if ( __experimentalShowInitialSuggestions && ! ( value && value.length ) && ! ( suggestions && suggestions.length ) ) {
-			this.updateSuggestions( '' );
+			this.updateSuggestions();
 		}
 	}
 
 	componentDidMount() {
-		const { __experimentalShowInitialSuggestions = false } = this.props;
-		if ( __experimentalShowInitialSuggestions ) {
-			this.updateSuggestions( '' );
+		const { suggestions } = this.state;
+		const { __experimentalShowInitialSuggestions = false, value } = this.props;
+		if ( __experimentalShowInitialSuggestions && ! ( value && value.length ) && ! ( suggestions && suggestions.length ) ) {
+			this.updateSuggestions();
 		}
 	}
 
@@ -95,7 +97,7 @@ class URLInput extends Component {
 			return;
 		}
 
-		const isInitialSuggestions = ! value || ! value.length;
+		const isInitialSuggestions = ! ( value && value.length );
 
 		// Allow a suggestions request if:
 		// - there are at least 2 characters in the search input (except manual searches where

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -166,10 +166,10 @@ function NavigationLinkEdit( {
 					/>
 					{ isLinkOpen && (
 						<Popover position="bottom center">
-						<LinkControl
-							className="wp-block-navigation-link__inline-link-input"
-							value={ link }
-							initialSuggestions={ true }
+							<LinkControl
+								className="wp-block-navigation-link__inline-link-input"
+								value={ link }
+								initialSuggestions={ true }
 								onChange={ ( {
 									title: newTitle = '',
 									url: newURL = '',

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -214,7 +214,7 @@ export default compose( [
 		const queryForRecentPages = {
 			order: 'desc',
 			orderby: 'modified',
-			per_page: 5,
+			per_page: 3,
 		};
 
 		const pagesSelect = [ 'core', 'getEntityRecords', [ 'postType', 'page', queryForRecentPages ] ];

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -45,6 +45,7 @@ function NavigationLinkEdit( {
 	setAttributes,
 	insertLinkBlock,
 	recentPages = [],
+	hasResolvedPages,
 } ) {
 	const { label, opensInNewTab, title, url, nofollow, description } = attributes;
 	const link = {
@@ -170,18 +171,15 @@ function NavigationLinkEdit( {
 						<LinkControl
 							className="wp-block-navigation-link__inline-link-input"
 							value={ link }
-							initialSuggestions={ () => {
-								if ( ! recentPages ) {
-									return Promise.reject( recentPages );
+							initialSuggestions={ async () => {
+								if ( ! hasResolvedPages ) {
+									return [];
 								}
-
-								return Promise.resolve( recentPages.map( ( page ) => {
-									return {
-										id: page.id,
-										url: page.link,
-										title: escape( page.title.raw ) || __( '(no title)' ),
-										type: 'Page',
-									};
+								return recentPages.map( ( page ) => ( {
+									id: page.id,
+									url: page.link,
+									title: escape( page.title.raw ) || __( '(no title)' ),
+									type: 'Page',
 								} ) );
 							} }
 								onChange={ ( {
@@ -225,7 +223,6 @@ export default compose( [
 			isParentOfSelectedBlock: hasSelectedInnerBlock( clientId, true ),
 			hasDescendants: !! getClientIdsOfDescendants( [ clientId ] ).length,
 			recentPages: select( 'core' ).getEntityRecords( 'postType', 'page', queryForRecentPages ),
-			isRequestingPages: select( 'core/data' ).isResolving( ...pagesSelect ),
 			hasResolvedPages: select( 'core/data' ).hasFinishedResolution( ...pagesSelect ),
 		};
 	} ),

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -169,6 +169,14 @@ function NavigationLinkEdit( {
 							<LinkControl
 								className="wp-block-navigation-link__inline-link-input"
 								value={ link }
+							manualSearch={ () => {
+								return Promise.resolve( [ {
+									id: '-1',
+									title: 'Manual result',
+									url: 'https://manual.result.com',
+									type: 'URL',
+								} ] );
+							} }
 								onChange={ ( {
 									title: newTitle = '',
 									url: newURL = '',

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -166,10 +166,10 @@ function NavigationLinkEdit( {
 					/>
 					{ isLinkOpen && (
 						<Popover position="bottom center">
-							<LinkControl
-								className="wp-block-navigation-link__inline-link-input"
-								value={ link }
-							manualSearch={ () => {
+						<LinkControl
+							className="wp-block-navigation-link__inline-link-input"
+							value={ link }
+							initialSuggestions={ () => {
 								return Promise.resolve( [ {
 									id: '-1',
 									title: 'Manual result',

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -44,8 +44,6 @@ function NavigationLinkEdit( {
 	isParentOfSelectedBlock,
 	setAttributes,
 	insertLinkBlock,
-	recentPages = [],
-	hasResolvedPages,
 } ) {
 	const { label, opensInNewTab, title, url, nofollow, description } = attributes;
 	const link = {
@@ -171,17 +169,7 @@ function NavigationLinkEdit( {
 						<LinkControl
 							className="wp-block-navigation-link__inline-link-input"
 							value={ link }
-							initialSuggestions={ async () => {
-								if ( ! hasResolvedPages ) {
-									return [];
-								}
-								return recentPages.map( ( page ) => ( {
-									id: page.id,
-									url: page.link,
-									title: escape( page.title.raw ) || __( '(no title)' ),
-									type: 'Page',
-								} ) );
-							} }
+							initialSuggestions={ true }
 								onChange={ ( {
 									title: newTitle = '',
 									url: newURL = '',
@@ -211,19 +199,10 @@ export default compose( [
 		const { getClientIdsOfDescendants, hasSelectedInnerBlock } = select( 'core/block-editor' );
 		const { clientId } = ownProps;
 
-		const queryForRecentPages = {
-			order: 'desc',
-			orderby: 'modified',
-			per_page: 3,
-		};
-
-		const pagesSelect = [ 'core', 'getEntityRecords', [ 'postType', 'page', queryForRecentPages ] ];
-
 		return {
 			isParentOfSelectedBlock: hasSelectedInnerBlock( clientId, true ),
 			hasDescendants: !! getClientIdsOfDescendants( [ clientId ] ).length,
-			recentPages: select( 'core' ).getEntityRecords( 'postType', 'page', queryForRecentPages ),
-			hasResolvedPages: select( 'core/data' ).hasFinishedResolution( ...pagesSelect ),
+
 		};
 	} ),
 	withDispatch( ( dispatch, ownProps, registry ) => {

--- a/packages/e2e-tests/config/setup-test-framework.js
+++ b/packages/e2e-tests/config/setup-test-framework.js
@@ -167,7 +167,7 @@ function observeConsoleLogging() {
 		// (Posts > Add New) will display a console warning about
 		// non - unique IDs.
 		// See: https://core.trac.wordpress.org/ticket/23165
-		if ( text.includes( '[DOM] Found 2 elements with non-unique id #_wpnonce' ) ) {
+		if ( text.includes( 'elements with non-unique id #_wpnonce' ) ) {
 			return;
 		}
 

--- a/packages/e2e-tests/config/setup-test-framework.js
+++ b/packages/e2e-tests/config/setup-test-framework.js
@@ -163,6 +163,14 @@ function observeConsoleLogging() {
 			return;
 		}
 
+		// As of WordPress 5.3.2 in Chrome 79, navigating to the block editor
+		// (Posts > Add New) will display a console warning about
+		// non - unique IDs.
+		// See: https://core.trac.wordpress.org/ticket/23165
+		if ( text.includes( '[DOM] Found 2 elements with non-unique id #_wpnonce' ) ) {
+			return;
+		}
+
 		const logFunction = OBSERVED_CONSOLE_MESSAGE_TYPES[ type ];
 
 		// As of Puppeteer 1.6.1, `message.text()` wrongly returns an object of

--- a/packages/e2e-tests/specs/editor/blocks/__snapshots__/buttons.test.js.snap
+++ b/packages/e2e-tests/specs/editor/blocks/__snapshots__/buttons.test.js.snap
@@ -3,7 +3,7 @@
 exports[`Buttons can jump to the link editor using the keyboard shortcut 1`] = `
 "<!-- wp:buttons -->
 <div class=\\"wp-block-buttons\\"><!-- wp:button -->
-<div class=\\"wp-block-button\\"><a class=\\"wp-block-button__link\\">WordPress</a></div>
+<div class=\\"wp-block-button\\"><a class=\\"wp-block-button__link\\" href=\\"https://www.wordpress.org/\\" title=\\"https://www.wordpress.org/\\">WordPress</a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons -->"
 `;

--- a/packages/e2e-tests/specs/editor/blocks/__snapshots__/buttons.test.js.snap
+++ b/packages/e2e-tests/specs/editor/blocks/__snapshots__/buttons.test.js.snap
@@ -3,7 +3,7 @@
 exports[`Buttons can jump to the link editor using the keyboard shortcut 1`] = `
 "<!-- wp:buttons -->
 <div class=\\"wp-block-buttons\\"><!-- wp:button -->
-<div class=\\"wp-block-button\\"><a class=\\"wp-block-button__link\\" href=\\"https://www.wordpress.org/\\" title=\\"https://www.wordpress.org/\\">WordPress</a></div>
+<div class=\\"wp-block-button\\"><a class=\\"wp-block-button__link\\">WordPress</a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons -->"
 `;

--- a/packages/e2e-tests/specs/editor/blocks/buttons.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/buttons.test.js
@@ -26,7 +26,7 @@ describe( 'Buttons', () => {
 		await insertBlock( 'Buttons' );
 		await page.keyboard.type( 'WordPress' );
 		await pressKeyWithModifier( 'primary', 'k' );
-		await page.keyboard.type( 'https://wwww.wordpress.org/' );
+		await page.keyboard.type( 'https://www.wordpress.org/' );
 		await page.keyboard.press( 'Enter' );
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();

--- a/packages/e2e-tests/specs/editor/blocks/buttons.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/buttons.test.js
@@ -30,5 +30,11 @@ describe( 'Buttons', () => {
 		await page.keyboard.press( 'Enter' );
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
+		// TODO - this is needed currently because when adding a link using the suggestion list,
+		// a submit button is used. The form that the submit button is in is unmounted when submission
+		// occurs, resulting in a warning 'Form submission canceled because the form is not connected'
+		// in Chrome.
+		// Ideally, the suggestions wouldn't be implemented using submit buttons.
+		expect( console ).toHaveWarned();
 	} );
 } );

--- a/packages/e2e-tests/specs/editor/blocks/buttons.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/buttons.test.js
@@ -30,11 +30,5 @@ describe( 'Buttons', () => {
 		await page.keyboard.press( 'Enter' );
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
-		// TODO - this is needed currently because when adding a link using the suggestion list,
-		// a submit button is used. The form that the submit button is in is unmounted when submission
-		// occurs, resulting in a warning 'Form submission canceled because the form is not connected'
-		// in Chrome.
-		// Ideally, the suggestions wouldn't be implemented using submit buttons.
-		expect( console ).toHaveWarned();
 	} );
 } );

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -74,8 +74,8 @@ describe( 'Navigation', () => {
 		await createNewPost();
 	} );
 
-	afterEach( () => {
-		setUpResponseMocking( [] );
+	afterEach( async () => {
+		await setUpResponseMocking( [] );
 	} );
 
 	it( 'allows a navigation menu to be created using existing pages', async () => {

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -74,6 +74,10 @@ describe( 'Navigation', () => {
 		await createNewPost();
 	} );
 
+	afterEach( () => {
+		setUpResponseMocking( [] );
+	} );
+
 	it( 'allows a navigation menu to be created using existing pages', async () => {
 		// Mock the response from the Pages endpoint. This is done so that the pages returned are always
 		// consistent and to test the feature more rigorously than the single default sample page.

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -41,7 +41,7 @@ async function mockSearchResponse( items ) {
 
 	await setUpResponseMocking( [
 		{
-			match: ( request ) => request.url().includes( `rest_route=${ encodeURIComponent( '/wp/v2/search' ) }` ),
+			match: ( request ) => request.url().includes( `rest_route` ) && request.url().includes( `search` ),
 			onRequestMatch: createJSONResponse( mappedItems ),
 		},
 	] );

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -25,11 +25,13 @@ import { mediaUpload } from '../../utils';
 import ReusableBlocksButtons from '../reusable-blocks-buttons';
 import ConvertToGroupButtons from '../convert-to-group-buttons';
 
-const fetchLinkSuggestions = async ( search ) => {
+const fetchLinkSuggestions = async ( search, {
+	perPage = 20,
+} = {} ) => {
 	const posts = await apiFetch( {
 		path: addQueryArgs( '/wp/v2/search', {
 			search,
-			per_page: 20,
+			per_page: perPage,
 			type: 'post',
 		} ),
 	} );


### PR DESCRIPTION
<img width="535" alt="Screenshot 2020-01-08 at 11 37 27" src="https://user-images.githubusercontent.com/444434/71975222-4745b080-320b-11ea-922a-3627ee448041.png">

## Description
Closes https://github.com/WordPress/gutenberg/issues/18899.

When first creating a Nav Link ("item") Block the hyperlink UI presents a blank search field. To better serve the default use case of adding pages, this PR updates the implementation to display a list of the most recently created Pages.

This involves a refactor of the `URLInput` to add a new boolean prop `initialSuggestions` which (internally) ~affords the ability to trigger rendering of search results without anything being entered into the `<input>` field~ (for more on this [see the original Issue](https://github.com/WordPress/gutenberg/issues/18899#issuecomment-571520975)) triggers a call for default search results when the input field is empty.

## How has this been tested?
1. Add Nav Block
2. Insert new Nav Link Block.
3. See a list of most recently created Pages displayed as the default search results in the hyperlink creation UI.

## Screencapture <!-- if applicable -->

![Screen Capture on 2020-01-08 at 11-35-37](https://user-images.githubusercontent.com/444434/71975123-182f3f00-320b-11ea-8fc0-75f19aa111fe.gif)


## Types of changes
New feature (non-breaking change which adds functionality).

## Checklist:
- [x] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
