### PR TITLE
Replace, on editing a navigation link, the current label with the title of page or post

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -177,7 +177,10 @@ function NavigationLinkEdit( {
 								} = {} ) => setAttributes( {
 									title: escape( newTitle ),
 									url: encodeURI( newURL ),
-									label: label || escape( newTitle ),
+									label: (
+										( newTitle !== '' && newTitle !== newURL && label !== newTitle ) ?
+											escape( newTitle ) : label
+									),
 									opensInNewTab: newOpensInNewTab,
 								} ) }
 								onClose={ () => setIsLinkOpen( false ) }

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -177,10 +177,17 @@ function NavigationLinkEdit( {
 								} = {} ) => setAttributes( {
 									title: escape( newTitle ),
 									url: encodeURI( newURL ),
-									label: (
-										( newTitle !== '' && newTitle !== newURL && label !== newTitle ) ?
-											escape( newTitle ) : label
-									),
+									label: ( () => {
+										const normalizedTitle = newTitle.replace( /http(s?):\/\//gi, '' );
+										const normalizedURL = newURL.replace( /http(s?):\/\//gi, '' );
+										if (
+											newTitle !== '' &&
+											normalizedTitle !== normalizedURL &&
+											label !== newTitle ) {
+											return escape( newTitle );
+										}
+										return label;
+									} )(),
 									opensInNewTab: newOpensInNewTab,
 								} ) }
 								onClose={ () => setIsLinkOpen( false ) }


### PR DESCRIPTION
## Description
Closes #18695

## How has this been tested?
Tested locally.

## Screenshots <!-- if applicable -->

![navigation-link-update](https://user-images.githubusercontent.com/107534/71895551-0346a300-315a-11ea-82c0-bce8319128f8.gif)


## Types of changes
Small non-breaking update of the navigation link component that sets the label on link change depending on whether the link is a page or post, or just a link.
