### PR TITLE
useColors: directly pass ref for color detecting

### DIFF
--- a/packages/block-editor/src/components/colors/use-colors.js
+++ b/packages/block-editor/src/components/colors/use-colors.js
@@ -119,9 +119,11 @@ export default function __experimentalUseColors(
 		colorPanelProps,
 		contrastCheckers,
 		panelChildren,
-		targetRef,
-		backgroundColorTargetRef = targetRef,
-		textColorTargetRef = targetRef,
+		colorDetector: {
+			targetRef,
+			backgroundColorTargetRef = targetRef,
+			textColorTargetRef = targetRef,
+		} = {},
 	} = {
 		panelTitle: __( 'Color Settings' ),
 	},

--- a/packages/block-editor/src/components/colors/use-colors.js
+++ b/packages/block-editor/src/components/colors/use-colors.js
@@ -16,7 +16,7 @@ import {
 	useEffect,
 	Children,
 	cloneElement,
-	useRef,
+	useState,
 } from '@wordpress/element';
 
 /**
@@ -48,8 +48,8 @@ const ColorPanel = ( {
 	colorSettings,
 	colorPanelProps,
 	contrastCheckers,
-	detectedBackgroundColorRef,
-	detectedColorRef,
+	detectedBackgroundColor,
+	detectedColor,
 	panelChildren,
 } ) => (
 	<PanelColorSettings
@@ -64,12 +64,12 @@ const ColorPanel = ( {
 					backgroundColor = resolveContrastCheckerColor(
 						backgroundColor,
 						colorSettings,
-						detectedBackgroundColorRef.current
+						detectedBackgroundColor
 					);
 					textColor = resolveContrastCheckerColor(
 						textColor,
 						colorSettings,
-						detectedColorRef.current
+						detectedColor
 					);
 					return (
 						<ContrastChecker
@@ -85,12 +85,12 @@ const ColorPanel = ( {
 					backgroundColor = resolveContrastCheckerColor(
 						backgroundColor || value,
 						colorSettings,
-						detectedBackgroundColorRef.current
+						detectedBackgroundColor
 					);
 					textColor = resolveContrastCheckerColor(
 						textColor || value,
 						colorSettings,
-						detectedColorRef.current
+						detectedColor
 					);
 					return (
 						<ContrastChecker
@@ -198,8 +198,9 @@ export default function __experimentalUseColors(
 		[ setAttributes, colorConfigs.length ]
 	);
 
-	const detectedBackgroundColorRef = useRef();
-	const detectedColorRef = useRef();
+	const [ detectedBackgroundColor, setDetectedBackgroundColor ] = useState();
+	const [ detectedColor, setDetectedColor ] = useState();
+
 	useEffect( () => {
 		if ( ! contrastCheckers ) {
 			return undefined;
@@ -219,7 +220,7 @@ export default function __experimentalUseColors(
 		}
 
 		if ( needsColor ) {
-			detectedColorRef.current = getComputedStyle( targetRef.current ).color;
+			setDetectedColor( getComputedStyle( targetRef.current ).color );
 		}
 
 		if ( needsBackgroundColor ) {
@@ -236,7 +237,7 @@ export default function __experimentalUseColors(
 					.backgroundColor;
 			}
 
-			detectedBackgroundColorRef.current = backgroundColor;
+			setDetectedBackgroundColor( backgroundColor );
 		}
 	}, [
 		colorConfigs.reduce(
@@ -314,8 +315,8 @@ export default function __experimentalUseColors(
 			colorSettings,
 			colorPanelProps,
 			contrastCheckers,
-			detectedBackgroundColorRef,
-			detectedColorRef,
+			detectedBackgroundColor,
+			detectedColor,
 			panelChildren,
 		};
 		return {
@@ -325,5 +326,5 @@ export default function __experimentalUseColors(
 				<InspectorControlsColorPanel { ...wrappedColorPanelProps } />
 			),
 		};
-	}, [ attributes, setAttributes, ...deps ] );
+	}, [ attributes, setAttributes, detectedColor, detectedBackgroundColor, ...deps ] );
 }

--- a/packages/block-editor/src/components/colors/use-colors.js
+++ b/packages/block-editor/src/components/colors/use-colors.js
@@ -120,6 +120,8 @@ export default function __experimentalUseColors(
 		contrastCheckers,
 		panelChildren,
 		targetRef,
+		backgroundColorTargetRef = targetRef,
+		textColorTargetRef = targetRef,
 	} = {
 		panelTitle: __( 'Color Settings' ),
 	},
@@ -220,11 +222,11 @@ export default function __experimentalUseColors(
 		}
 
 		if ( needsColor ) {
-			setDetectedColor( getComputedStyle( targetRef.current ).color );
+			setDetectedColor( getComputedStyle( textColorTargetRef.current ).color );
 		}
 
 		if ( needsBackgroundColor ) {
-			let backgroundColorNode = targetRef.current;
+			let backgroundColorNode = backgroundColorTargetRef.current;
 			let backgroundColor = getComputedStyle( backgroundColorNode )
 				.backgroundColor;
 			while (

--- a/packages/block-editor/src/components/colors/use-colors.js
+++ b/packages/block-editor/src/components/colors/use-colors.js
@@ -13,6 +13,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import {
 	useCallback,
 	useMemo,
+	useEffect,
 	Children,
 	cloneElement,
 	useRef,
@@ -122,7 +123,8 @@ export default function __experimentalUseColors(
 	} = {
 		panelTitle: __( 'Color Settings' ),
 	},
-	deps = []
+	deps = [],
+	targetRef
 ) {
 	const { clientId } = useBlockEditContext();
 	const { attributes, settingsColors } = useSelect(
@@ -199,7 +201,7 @@ export default function __experimentalUseColors(
 
 	const detectedBackgroundColorRef = useRef();
 	const detectedColorRef = useRef();
-	const ColorDetector = useMemo( () => {
+	useEffect( () => {
 		if ( ! contrastCheckers ) {
 			return undefined;
 		}
@@ -219,26 +221,10 @@ export default function __experimentalUseColors(
 		return (
 			( needsBackgroundColor || needsColor ) &&
 			withFallbackStyles(
-				(
-					node,
-					{
-						querySelector,
-						backgroundColorSelector = querySelector,
-						textColorSelector = querySelector,
-					}
-				) => {
-					let backgroundColorNode = node;
-					let textColorNode = node;
-					if ( backgroundColorSelector ) {
-						backgroundColorNode = node.parentNode.querySelector(
-							backgroundColorSelector
-						);
-					}
-					if ( textColorSelector ) {
-						textColorNode = node.parentNode.querySelector( textColorSelector );
-					}
+				() => {
+					let backgroundColorNode = targetRef.current;
 					let backgroundColor;
-					const color = getComputedStyle( textColorNode ).color;
+					const color = getComputedStyle( targetRef.current ).color;
 					if ( needsBackgroundColor ) {
 						backgroundColor = getComputedStyle( backgroundColorNode )
 							.backgroundColor;
@@ -344,7 +330,6 @@ export default function __experimentalUseColors(
 			InspectorControlsColorPanel: (
 				<InspectorControlsColorPanel { ...wrappedColorPanelProps } />
 			),
-			ColorDetector,
 		};
 	}, [ attributes, setAttributes, ...deps ] );
 }

--- a/packages/block-editor/src/components/colors/use-colors.js
+++ b/packages/block-editor/src/components/colors/use-colors.js
@@ -18,7 +18,6 @@ import {
 	cloneElement,
 	useRef,
 } from '@wordpress/element';
-import { withFallbackStyles } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -218,32 +217,27 @@ export default function __experimentalUseColors(
 				break;
 			}
 		}
-		return (
-			( needsBackgroundColor || needsColor ) &&
-			withFallbackStyles(
-				() => {
-					let backgroundColorNode = targetRef.current;
-					let backgroundColor;
-					const color = getComputedStyle( targetRef.current ).color;
-					if ( needsBackgroundColor ) {
-						backgroundColor = getComputedStyle( backgroundColorNode )
-							.backgroundColor;
-						while (
-							backgroundColor === 'rgba(0, 0, 0, 0)' &&
-							backgroundColorNode.parentNode &&
-							backgroundColorNode.parentNode.nodeType === Node.ELEMENT_NODE
-						) {
-							backgroundColorNode = backgroundColorNode.parentNode;
-							backgroundColor = getComputedStyle( backgroundColorNode )
-								.backgroundColor;
-						}
-					}
-					detectedBackgroundColorRef.current = backgroundColor;
-					detectedColorRef.current = color;
-					return { backgroundColor, color };
-				}
-			)( () => <></> )
-		);
+
+		if ( needsColor ) {
+			detectedColorRef.current = getComputedStyle( targetRef.current ).color;
+		}
+
+		if ( needsBackgroundColor ) {
+			let backgroundColorNode = targetRef.current;
+			let backgroundColor = getComputedStyle( backgroundColorNode )
+				.backgroundColor;
+			while (
+				backgroundColor === 'rgba(0, 0, 0, 0)' &&
+				backgroundColorNode.parentNode &&
+				backgroundColorNode.parentNode.nodeType === Node.ELEMENT_NODE
+			) {
+				backgroundColorNode = backgroundColorNode.parentNode;
+				backgroundColor = getComputedStyle( backgroundColorNode )
+					.backgroundColor;
+			}
+
+			detectedBackgroundColorRef.current = backgroundColor;
+		}
 	}, [
 		colorConfigs.reduce(
 			( acc, colorConfig ) =>

--- a/packages/block-editor/src/components/colors/use-colors.js
+++ b/packages/block-editor/src/components/colors/use-colors.js
@@ -119,11 +119,11 @@ export default function __experimentalUseColors(
 		colorPanelProps,
 		contrastCheckers,
 		panelChildren,
+		targetRef,
 	} = {
 		panelTitle: __( 'Color Settings' ),
 	},
-	deps = [],
-	targetRef
+	deps = []
 ) {
 	const { clientId } = useBlockEditContext();
 	const { attributes, settingsColors } = useSelect(

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -7,7 +7,7 @@ import { omit } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { RawHTML, Component, createRef, Platform } from '@wordpress/element';
+import { RawHTML, Component, useRef, Platform, forwardRef } from '@wordpress/element';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { pasteHandler, children as childrenSource, getBlockTransforms, findTransform, isUnmodifiedDefaultBlock } from '@wordpress/blocks';
 import { withInstanceId, compose } from '@wordpress/compose';
@@ -58,7 +58,6 @@ function getMultilineTag( multiline ) {
 class RichTextWrapper extends Component {
 	constructor() {
 		super( ...arguments );
-		this.ref = createRef();
 		this.onEnter = this.onEnter.bind( this );
 		this.onSplit = this.onSplit.bind( this );
 		this.onPaste = this.onPaste.bind( this );
@@ -358,6 +357,7 @@ class RichTextWrapper extends Component {
 			style,
 			preserveWhiteSpace,
 			disabled,
+			forwardedRef,
 			...props
 		} = this.props;
 		const multilineTag = getMultilineTag( multiline );
@@ -378,7 +378,7 @@ class RichTextWrapper extends Component {
 		const content = (
 			<RichText
 				{ ...props }
-				ref={ this.ref }
+				ref={ forwardedRef }
 				value={ adjustedValue }
 				onChange={ adjustedOnChange }
 				selectionStart={ selectionStart }
@@ -414,7 +414,7 @@ class RichTextWrapper extends Component {
 				{ ( { isSelected, value, onChange, Editable } ) =>
 					<>
 						{ children && children( { value, onChange } ) }
-						{ isSelected && hasFormats && ( <FormatToolbarContainer inline={ inlineToolbar } anchorRef={ this.ref.current } /> ) }
+						{ isSelected && hasFormats && ( <FormatToolbarContainer inline={ inlineToolbar } anchorRef={ forwardedRef.current } /> ) }
 						{ isSelected && <RemoveBrowserShortcuts /> }
 						<Autocomplete
 							onReplace={ onReplace }
@@ -546,7 +546,12 @@ const RichTextContainer = compose( [
 	} ),
 ] )( RichTextWrapper );
 
-RichTextContainer.Content = ( { value, tagName: Tag, multiline, ...props } ) => {
+const ForwardedRichTextContainer = forwardRef( ( props, ref ) => {
+	const fallbackRef = useRef();
+	return <RichTextContainer { ...props } forwardedRef={ ref || fallbackRef } />;
+} );
+
+ForwardedRichTextContainer.Content = ( { value, tagName: Tag, multiline, ...props } ) => {
 	// Handle deprecated `children` and `node` sources.
 	if ( Array.isArray( value ) ) {
 		value = childrenSource.toHTML( value );
@@ -567,11 +572,11 @@ RichTextContainer.Content = ( { value, tagName: Tag, multiline, ...props } ) => 
 	return content;
 };
 
-RichTextContainer.isEmpty = ( value ) => {
+ForwardedRichTextContainer.isEmpty = ( value ) => {
 	return ! value || value.length === 0;
 };
 
-RichTextContainer.Content.defaultProps = {
+ForwardedRichTextContainer.Content.defaultProps = {
 	format: 'string',
 	value: '',
 };
@@ -579,7 +584,7 @@ RichTextContainer.Content.defaultProps = {
 /**
  * @see https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/rich-text/README.md
  */
-export default RichTextContainer;
+export default ForwardedRichTextContainer;
 export { RichTextShortcut } from './shortcut';
 export { RichTextToolbarButton } from './toolbar-button';
 export { __unstableRichTextInputEvent } from './input-event';

--- a/packages/block-library/src/heading/edit.js
+++ b/packages/block-library/src/heading/edit.js
@@ -21,6 +21,7 @@ import {
 	RichText,
 	__experimentalUseColors,
 } from '@wordpress/block-editor';
+import { useRef } from '@wordpress/element';
 
 function HeadingEdit( {
 	attributes,
@@ -29,12 +30,14 @@ function HeadingEdit( {
 	onReplace,
 	className,
 } ) {
-	const { TextColor, InspectorControlsColorPanel, ColorDetector } = __experimentalUseColors(
+	const ref = useRef();
+	const { TextColor, InspectorControlsColorPanel } = __experimentalUseColors(
 		[ { name: 'textColor', property: 'color' } ],
 		{
 			contrastCheckers: { backgroundColor: true, textColor: true },
 		},
-		[]
+		[],
+		ref
 	);
 
 	const { align, content, level, placeholder } = attributes;
@@ -56,8 +59,8 @@ function HeadingEdit( {
 			</InspectorControls>
 			{ InspectorControlsColorPanel }
 			<TextColor>
-				<ColorDetector querySelector='[contenteditable="true"]' />
 				<RichText
+					ref={ ref }
 					identifier="content"
 					tagName={ tagName }
 					value={ content }

--- a/packages/block-library/src/heading/edit.js
+++ b/packages/block-library/src/heading/edit.js
@@ -35,7 +35,7 @@ function HeadingEdit( {
 		[ { name: 'textColor', property: 'color' } ],
 		{
 			contrastCheckers: { backgroundColor: true, textColor: true },
-			targetRef: ref,
+			colorDetector: { targetRef: ref },
 		},
 		[]
 	);

--- a/packages/block-library/src/heading/edit.js
+++ b/packages/block-library/src/heading/edit.js
@@ -35,9 +35,9 @@ function HeadingEdit( {
 		[ { name: 'textColor', property: 'color' } ],
 		{
 			contrastCheckers: { backgroundColor: true, textColor: true },
+			targetRef: ref,
 		},
-		[],
-		ref
+		[]
 	);
 
 	const { align, content, level, placeholder } = attributes;

--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -107,9 +107,9 @@ function ParagraphBlock( {
 		],
 		{
 			contrastCheckers: [ { backgroundColor: true, textColor: true, fontSize: fontSize.size } ],
+			targetRef: ref,
 		},
-		[ fontSize.size ],
-		ref
+		[ fontSize.size ]
 	);
 
 	return (

--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -24,7 +24,7 @@ import {
 import { createBlock } from '@wordpress/blocks';
 import { compose } from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
-import { useEffect, useState } from '@wordpress/element';
+import { useEffect, useState, useRef } from '@wordpress/element';
 
 /**
  * Browser dependencies
@@ -94,12 +94,12 @@ function ParagraphBlock( {
 		direction,
 	} = attributes;
 
+	const ref = useRef();
 	const dropCapMinimumHeight = useDropCapMinimumHeight( dropCap, [ fontSize.size ] );
 	const {
 		TextColor,
 		BackgroundColor,
 		InspectorControlsColorPanel,
-		ColorDetector,
 	} = __experimentalUseColors(
 		[
 			{ name: 'textColor', property: 'color' },
@@ -108,7 +108,8 @@ function ParagraphBlock( {
 		{
 			contrastCheckers: [ { backgroundColor: true, textColor: true, fontSize: fontSize.size } ],
 		},
-		[ fontSize.size ]
+		[ fontSize.size ],
+		ref
 	);
 
 	return (
@@ -143,8 +144,8 @@ function ParagraphBlock( {
 			{ InspectorControlsColorPanel }
 			<BackgroundColor>
 				<TextColor>
-					<ColorDetector querySelector='[contenteditable="true"]' />
 					<RichText
+						ref={ ref }
 						identifier="content"
 						tagName="p"
 						className={ classnames( 'wp-block-paragraph', className, {

--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -107,7 +107,7 @@ function ParagraphBlock( {
 		],
 		{
 			contrastCheckers: [ { backgroundColor: true, textColor: true, fontSize: fontSize.size } ],
-			targetRef: ref,
+			colorDetector: { targetRef: ref },
 		},
 		[ fontSize.size ]
 	);


### PR DESCRIPTION
## Description

See #18148.

This PR removes the `<ColorDetector />` component in favour of passing a reference of the target element directly to `useColors`.

* Removes an additional `div` element that is rendered for each paragraph.
* Avoids needing to query the DOM for the target node.
* Avoids the use of `withFallbackStyles`.
* I also swapped out the detected color references for state, so the warnings are displayed immediately instead of delayed to the next rerender.

## How has this been tested?

Trigger the contrast warning on the paragraph and heading block by selecting a text or background color together with inherited colours (detected).

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
