### PR TITLE
Navigation: formatting the allowed styles

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -142,22 +142,25 @@ function build_navigation_html( $block, $colors, $font_sizes ) {
 		// Start anchor tag content.
 		$html .= '>';
 		if ( isset( $block['attrs']['label'] ) ) {
-			$html .= wp_kses( $block['attrs']['label'], array(
-				'code'   => array(),
-				'em'     => array(),
-				'img'    => array(
-					'scale' => array(),
-					'class' => array(),
-					'style' => array(),
-					'src'   => array(),
-					'alt'   => array(),
-				),
-				's'      => array(),
-				'span'   => array(
-					'style' => array(),
-				),
-				'strong' => array(),
-			) );
+			$html .= wp_kses(
+				$block['attrs']['label'],
+				array(
+					'code'   => array(),
+					'em'     => array(),
+					'img'    => array(
+						'scale' => array(),
+						'class' => array(),
+						'style' => array(),
+						'src'   => array(),
+						'alt'   => array(),
+					),
+					's'      => array(),
+					'span'   => array(
+						'style' => array(),
+					),
+					'strong' => array(),
+				)
+			);
 		}
 		$html .= '</a>';
 		// End anchor tag content.

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -142,7 +142,22 @@ function build_navigation_html( $block, $colors, $font_sizes ) {
 		// Start anchor tag content.
 		$html .= '>';
 		if ( isset( $block['attrs']['label'] ) ) {
-			$html .= esc_html( $block['attrs']['label'] );
+			$html .= wp_kses( $block['attrs']['label'], array(
+				'code'   => array(),
+				'em'     => array(),
+				'img'    => array(
+					'scale' => array(),
+					'class' => array(),
+					'style' => array(),
+					'src'   => array(),
+					'alt'   => array(),
+				),
+				's'      => array(),
+				'span'   => array(
+					'style' => array(),
+				),
+				'strong' => array(),
+			) );
 		}
 		$html .= '</a>';
 		// End anchor tag content.


### PR DESCRIPTION
## Description
This PR handles rightly applying HTML format to menu items, avoiding escape HTML characters for those ones which are allowed.

Fixes https://github.com/WordPress/gutenberg/issues/19473

## How has this been tested?
You can format the menu items using the toolbar of the navigation menu. So far, it's possible to set up bold, italic, code, underline, strikethrough, span text, and inline-image.

![image](https://user-images.githubusercontent.com/77539/71905926-de493480-3147-11ea-8a8f-e060ad02326e.png)

In order to test it, just apply some format to the navigation item and confirm that the format s applied as expected in the front-end.

## Screenshots <!-- if applicable -->

![image](https://user-images.githubusercontent.com/77539/71906332-9ecf1800-3148-11ea-81a0-e88b95601ae2.png)


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
