### PR TITLE
Expose custom gradient picker

### DIFF
--- a/packages/components/src/gradient-picker/index.js
+++ b/packages/components/src/gradient-picker/index.js
@@ -13,6 +13,7 @@ import { useCallback, useMemo } from '@wordpress/element';
  * Internal dependencies
  */
 import CircularOptionPicker from '../circular-option-picker';
+import CustomGradientPicker from '../custom-gradient-picker';
 
 export default function GradientPicker( {
 	className,
@@ -20,6 +21,7 @@ export default function GradientPicker( {
 	onChange,
 	value,
 	clearable = true,
+	disableCustomGradients = false,
 } ) {
 	const clearGradient = useCallback(
 		() => onChange( undefined ),
@@ -62,6 +64,13 @@ export default function GradientPicker( {
 					{ __( 'Clear' ) }
 				</CircularOptionPicker.ButtonAction>
 			) }
-		/>
+		>
+			{ ! disableCustomGradients && (
+				<CustomGradientPicker
+					value={ value }
+					onChange={ onChange }
+				/>
+			) }
+		</CircularOptionPicker>
 	);
 }


### PR DESCRIPTION
## Description
This PR exposes the custom gradient picker that we decided to hide until the gradient and color tabs were implemented.

## How has this been tested?
I verified I could use the custom gradient picker on the buttons and cover block.
I verified that on the cover block placeholder (not the inspector), we list the predefined gradients, but the custom gradient picker does not appear on the placeholder.