### PR TITLE
Fix: Disable HTML on navigation link

### DIFF
--- a/packages/block-library/src/navigation-link/index.js
+++ b/packages/block-library/src/navigation-link/index.js
@@ -24,6 +24,7 @@ export const settings = {
 
 	supports: {
 		reusable: false,
+		html: false,
 	},
 
 	__experimentalDisplayName: 'label',


### PR DESCRIPTION
## Description
Fixes: https://github.com/WordPress/gutenberg/issues/19475

We should not allow HTML edit on the navigation link block because that block is dynamic, and the markup is generated on the server.

## How has this been tested?
I added a navigation block.
I added a navigation link inside, and I verified the Edit HTML option is not available on the block menu (ellipsis menu).