### PR TITLE
Introduce PluginManager class

### DIFF
--- a/packages/plugins/src/api/index.js
+++ b/packages/plugins/src/api/index.js
@@ -1,14 +1,19 @@
 /* eslint no-console: [ 'error', { allow: [ 'error' ] } ] */
 
 /**
+ * External dependencies
+ */
+import { isFunction } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { applyFilters, doAction } from '@wordpress/hooks';
 
 /**
- * External dependencies
+ * Internal dependencies
  */
-import { isFunction } from 'lodash';
+import PluginManager from '../api/plugin-manager';
 
 /**
  * Defined behavior of a plugin type.
@@ -27,11 +32,11 @@ import { isFunction } from 'lodash';
  */
 
 /**
- * Plugin definitions keyed by plugin name.
+ * Plugin manager class
  *
- * @type {Object.<string,WPPlugin>}
+ * @typedef {Object} PluginManager
  */
-const plugins = {};
+const pluginManager = applyFilters( 'plugins.pluginManager', new PluginManager() );
 
 /**
  * Registers a plugin to the editor.
@@ -125,7 +130,7 @@ export function registerPlugin( name, settings ) {
 		);
 		return null;
 	}
-	if ( plugins[ name ] ) {
+	if ( pluginManager.getPlugin( name ) ) {
 		console.error(
 			`Plugin "${ name }" is already registered.`
 		);
@@ -140,11 +145,13 @@ export function registerPlugin( name, settings ) {
 		return null;
 	}
 
-	plugins[ name ] = {
+	pluginManager.addPlugin(
 		name,
-		icon: 'admin-plugins',
-		...settings,
-	};
+		{
+			icon: 'admin-plugins',
+			...settings,
+		}
+	);
 
 	doAction( 'plugins.pluginRegistered', settings, name );
 
@@ -176,14 +183,14 @@ export function registerPlugin( name, settings ) {
  *                     successfully unregistered; otherwise `undefined`.
  */
 export function unregisterPlugin( name ) {
-	if ( ! plugins[ name ] ) {
+	if ( ! pluginManager.getPlugin( name ) ) {
 		console.error(
 			'Plugin "' + name + '" is not registered.'
 		);
 		return;
 	}
-	const oldPlugin = plugins[ name ];
-	delete plugins[ name ];
+	const oldPlugin = pluginManager.getPlugin( name );
+	pluginManager.removePlugin( name );
 
 	doAction( 'plugins.pluginUnregistered', oldPlugin, name );
 
@@ -198,7 +205,7 @@ export function unregisterPlugin( name ) {
  * @return {?WPPlugin} Plugin setting.
  */
 export function getPlugin( name ) {
-	return plugins[ name ];
+	return pluginManager.getPlugin( name );
 }
 
 /**
@@ -207,5 +214,5 @@ export function getPlugin( name ) {
  * @return {WPPlugin[]} Plugin settings.
  */
 export function getPlugins() {
-	return Object.values( plugins );
+	return Object.values( pluginManager.getPlugins() );
 }

--- a/packages/plugins/src/api/index.js
+++ b/packages/plugins/src/api/index.js
@@ -36,7 +36,7 @@ import PluginManager from '../api/plugin-manager';
  *
  * @typedef {Object} PluginManager
  */
-const pluginManager = applyFilters( 'plugins.pluginManager', new PluginManager() );
+const pluginManager = PluginManager();
 
 /**
  * Registers a plugin to the editor.

--- a/packages/plugins/src/api/plugin-manager/index.js
+++ b/packages/plugins/src/api/plugin-manager/index.js
@@ -1,0 +1,50 @@
+export default class PluginManager {
+	/**
+	 * Create a PluginManager
+	 */
+	constructor() {
+		this.plugins = {};
+	}
+
+	/**
+	 * Adds a new plugin.
+	 *
+	 * @param {string} name Plugin name.
+	 * @param {Object} settings The settings for this plugin.
+	 */
+	addPlugin( name, settings ) {
+		this.plugins[ name ] = {
+			name,
+			...settings,
+		};
+	}
+
+	/**
+	 * Removes a plugin
+	 *
+	 * @param {string} name Plugin name.
+	 */
+	removePlugin( name ) {
+		delete this.plugins[ name ];
+	}
+
+	/**
+	 * Return settings for a single plugin.
+	 *
+	 * @param {string} name Plugin name.
+	 *
+	 * @return {Object} The plugin settings
+	 */
+	getPlugin( name ) {
+		return this.plugins[ name ];
+	}
+
+	/**
+	 * Returns settings for all registered plugins
+	 *
+	 * @return {Array} All registered plugin settings.
+	 */
+	getPlugins() {
+		return this.plugins;
+	}
+}


### PR DESCRIPTION
## Description
This PR introduces a new PluginManager class that is meant to disconnect the plugin API function calls from direct access to the low-level datatype.

This intermediary makes the API more semantic, allows for future changes/updates more easily and is meant to address @youknowriad 's [concerns](https://github.com/WordPress/gutenberg/pull/16384#issuecomment-530423509) about the API not being fully semantic.

This PR would be a precursor to changes to the API such as #16384.

As a nice-to-have, I have introduced a new filter to allow the PluginManager class to be filtered. This will allow for ease of testing new API features and underlying data types but is not the main purpose of this PR and is easily removed.

## How has this been tested?
This has been tested locally.

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
