### PR TITLE
Format Library: Refactor inline link component to use React hooks

### DIFF
--- a/packages/format-library/src/link/index.js
+++ b/packages/format-library/src/link/index.js
@@ -92,6 +92,7 @@ export const link = {
 
 		render() {
 			const { isActive, activeAttributes, value, onChange } = this.props;
+			const { addingLink } = this.state;
 
 			return (
 				<>
@@ -123,15 +124,16 @@ export const link = {
 						shortcutType="primary"
 						shortcutCharacter="k"
 					/> }
-					<InlineLinkUI
-						key={ isActive } // Make sure link UI state resets when switching between links.
-						addingLink={ this.state.addingLink }
-						stopAddingLink={ this.stopAddingLink }
-						isActive={ isActive }
-						activeAttributes={ activeAttributes }
-						value={ value }
-						onChange={ onChange }
-					/>
+					{ ( isActive || addingLink ) && (
+						<InlineLinkUI
+							addingLink={ addingLink }
+							stopAddingLink={ this.stopAddingLink }
+							isActive={ isActive }
+							activeAttributes={ activeAttributes }
+							value={ value }
+							onChange={ onChange }
+						/>
+					) }
 				</>
 			);
 		}

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -26,7 +26,7 @@ import { createLinkFormat, isValidHref } from './utils';
 
 const stopKeyPropagation = ( event ) => event.stopPropagation();
 
-const URLPopoverAtLink = ( { isActive, addingLink, value, ...props } ) => {
+export const URLPopoverAtLink = ( { isActive, addingLink, value, ...props } ) => {
 	const anchorRef = useMemo( () => {
 		const selection = window.getSelection();
 

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -83,10 +83,6 @@ function InlineLinkUI( {
 		}
 	} );
 
-	if ( ! isActive && ! addingLink ) {
-		return null;
-	}
-
 	function onKeyDown( event ) {
 		if ( [ LEFT, DOWN, RIGHT, UP, BACKSPACE, ENTER ].indexOf( event.keyCode ) > -1 ) {
 			// Stop the key event from propagating up to ObserveTyping.startTypingInTextField.

--- a/packages/format-library/src/link/test/inline.js
+++ b/packages/format-library/src/link/test/inline.js
@@ -1,38 +1,70 @@
 /**
- * Internal dependencies
- */
-import InlineLinkUI from '../inline';
-/**
  * External dependencies
  */
-import { shallow } from 'enzyme';
+import TestRenderer, { act } from 'react-test-renderer';
+
+/**
+ * WordPress dependencies
+ */
+import { create } from '@wordpress/rich-text';
+
+/**
+ * Internal dependencies
+ */
+import InlineLinkUI, { URLPopoverAtLink } from '../inline';
 
 describe( 'InlineLinkUI', () => {
-	it( 'InlineLinkUI renders', () => {
-		const wrapper = shallow(
-			<InlineLinkUI />
-		);
-		expect( wrapper ).toBeTruthy();
+	const defaultProps = {
+		value: create( { text: '' } ),
+		activeAttributes: {},
+	};
+
+	// TODO: At the time of writing, JSDOM has just implemented Selection APIs,
+	// but they are not yet published in a publicly-available release. This
+	// `window.getSelection` assignment should be non-harmful but also redundant
+	// once this becomes available. In other words, once the next JSDOM feature
+	// release is published, this lifecycle code should be able to be removed.
+	//
+	// See: https://github.com/jsdom/jsdom/pull/2719
+	let originalWindowGetSelection;
+	beforeAll( () => {
+		originalWindowGetSelection = window.getSelection;
+		window.getSelection = () => ( { rangeCount: 0 } );
 	} );
 
-	it( 'should set state.opensInNewWindow to false by default', () => {
-		const wrapper = shallow(
-			<InlineLinkUI activeAttributes={ {} } />
-		).dive();
-
-		expect( wrapper.state( 'opensInNewWindow' ) ).toEqual( false );
+	afterAll( () => {
+		window.getSelection = originalWindowGetSelection;
 	} );
 
-	it( 'should set state.opensInNewWindow to true if props.activeAttributes.target is _blank', () => {
-		const givenProps = {
-			addingLink: false,
-			activeAttributes: { url: 'http://www.google.com', target: '_blank' },
-		};
+	it( 'should set "Opens in New Tab" toggle to unchecked by default', () => {
+		let renderer;
+		act( () => {
+			renderer = TestRenderer.create( <InlineLinkUI { ...defaultProps } /> );
+		} );
 
-		const wrapper = shallow(
-			<InlineLinkUI activeAttributes={ {} } />
-		).dive();
-		wrapper.setProps( givenProps );
-		expect( wrapper.state( 'opensInNewWindow' ) ).toEqual( true );
+		const openInNewTabToggle = renderer.root.findByType( URLPopoverAtLink ).props.renderSettings();
+		expect( openInNewTabToggle.props.checked ).toBe( false );
+	} );
+
+	it( 'should set "Opens in New Tab" toggle to checked if props.activeAttributes.target is _blank', () => {
+		let renderer;
+		act( () => {
+			renderer = TestRenderer.create( <InlineLinkUI { ...defaultProps } /> );
+		} );
+
+		act( () => {
+			renderer.update(
+				<InlineLinkUI
+					{ ...defaultProps }
+					activeAttributes={ {
+						url: 'http://www.google.com',
+						target: '_blank',
+					} }
+				/>
+			);
+		} );
+
+		const openInNewTabToggle = renderer.root.findByType( URLPopoverAtLink ).props.renderSettings();
+		expect( openInNewTabToggle.props.checked ).toBe( true );
 	} );
 } );


### PR DESCRIPTION
Related: #19440

This pull request seeks to refactor the inline link UI component (used for adding, viewing, and editing links in a RichText field) as a function component. Originally this was planned as a blocking change to allow for the implementation of additional custom React hooks to be used in this component as a resolution of #18755. This is planned to be addressed separately, and may ultimately not use hooks.

The changes here are intended to be a one-to-one port of the existing component, with the exception of the revisions mentioned at https://github.com/WordPress/gutenberg/pull/19440#issuecomment-571309612. I may plan to extract this (6523f57) as a separate pull request in order to simplify review.

**Testing Instructions:**

Verify there are no regressions in viewing, adding, editing, or removing a link.