### PR TITLE
Block Editor: Remove (more) legacy "editor-" class name compatibility

### DIFF
--- a/packages/block-editor/src/components/block-settings-menu/block-convert-button.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-convert-button.js
@@ -12,7 +12,6 @@ export default function BlockConvertButton( { shouldRender, onClick, small } ) {
 	const label = __( 'Convert to Blocks' );
 	return (
 		<MenuItem
-			className="block-editor-block-settings-menu__control"
 			onClick={ onClick }
 			icon="screenoptions"
 		>

--- a/packages/block-editor/src/components/block-settings-menu/block-mode-toggle.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-mode-toggle.js
@@ -23,7 +23,6 @@ export function BlockModeToggle( { blockType, mode, onToggleMode, small = false,
 
 	return (
 		<MenuItem
-			className="block-editor-block-settings-menu__control"
 			onClick={ onToggleMode }
 			icon="html"
 		>

--- a/packages/block-editor/src/components/block-settings-menu/index.js
+++ b/packages/block-editor/src/components/block-settings-menu/index.js
@@ -81,7 +81,6 @@ export function BlockSettingsMenu( { clientIds } ) {
 									) }
 									{ canDuplicate && (
 										<MenuItem
-											className="block-editor-block-settings-menu__control"
 											onClick={ flow( onClose, onDuplicate ) }
 											icon="admin-page"
 											shortcut={ shortcuts.duplicate }
@@ -92,7 +91,6 @@ export function BlockSettingsMenu( { clientIds } ) {
 									{ canInsertDefaultBlock && (
 										<>
 											<MenuItem
-												className="block-editor-block-settings-menu__control"
 												onClick={ flow( onClose, onInsertBefore ) }
 												icon="insert-before"
 												shortcut={ shortcuts.insertBefore }
@@ -100,7 +98,6 @@ export function BlockSettingsMenu( { clientIds } ) {
 												{ __( 'Insert Before' ) }
 											</MenuItem>
 											<MenuItem
-												className="block-editor-block-settings-menu__control"
 												onClick={ flow( onClose, onInsertAfter ) }
 												icon="insert-after"
 												shortcut={ shortcuts.insertAfter }
@@ -122,7 +119,6 @@ export function BlockSettingsMenu( { clientIds } ) {
 								<MenuGroup>
 									{ ! isLocked && (
 										<MenuItem
-											className="block-editor-block-settings-menu__control"
 											onClick={ flow( onClose, onRemove ) }
 											icon="trash"
 											shortcut={ shortcuts.remove }

--- a/packages/block-editor/src/components/url-popover/image-url-input-ui.js
+++ b/packages/block-editor/src/components/url-popover/image-url-input-ui.js
@@ -276,7 +276,7 @@ const ImageURLInputUI = ( {
 				>
 					{ ( ! url || isEditingLink ) && (
 						<URLPopover.LinkEditor
-							className="editor-format-toolbar__link-container-content block-editor-format-toolbar__link-container-content"
+							className="block-editor-format-toolbar__link-container-content"
 							value={ linkEditorValue }
 							onChangeInputValue={ setUrlInput }
 							onKeyDown={ stopPropagationRelevantKeys }
@@ -288,7 +288,7 @@ const ImageURLInputUI = ( {
 					{ ( url && ! isEditingLink ) && (
 						<>
 							<URLPopover.LinkViewer
-								className="editor-format-toolbar__link-container-content block-editor-format-toolbar__link-container-content"
+								className="block-editor-format-toolbar__link-container-content"
 								onKeyPress={ stopPropagation }
 								url={ url }
 								onEditLinkClick={ startEditLink }

--- a/packages/block-library/src/social-link/edit.js
+++ b/packages/block-library/src/social-link/edit.js
@@ -63,7 +63,7 @@ const SocialLinkEdit = ( { attributes, setAttributes, isSelected } ) => {
 								event.preventDefault();
 								setPopover( false );
 							} } >
-							<div className="editor-url-input block-editor-url-input">
+							<div className="block-editor-url-input">
 								<URLInput
 									value={ url }
 									onChange={ ( nextURL ) => setAttributes( { url: nextURL } ) }

--- a/packages/edit-post/src/components/block-settings-menu/plugin-block-settings-menu-item.js
+++ b/packages/edit-post/src/components/block-settings-menu/plugin-block-settings-menu-item.js
@@ -90,7 +90,6 @@ const PluginBlockSettingsMenuItem = ( { allowedBlocks, icon, label, onClick, sma
 				return null;
 			}
 			return ( <MenuItem
-				className="editor-block-settings-menu__control block-editor-block-settings-menu__control"
 				onClick={ compose( onClick, onClose ) }
 				icon={ icon || 'admin-plugins' }
 				label={ small ? label : undefined }

--- a/packages/edit-post/src/components/visual-editor/block-inspector-button.js
+++ b/packages/edit-post/src/components/visual-editor/block-inspector-button.js
@@ -33,7 +33,6 @@ export function BlockInspectorButton( {
 
 	return (
 		<MenuItem
-			className="block-editor-block-settings-menu__control"
 			onClick={ () => {
 				if ( areAdvancedSettingsOpened ) {
 					closeGeneralSidebar();

--- a/packages/editor/src/components/convert-to-group-buttons/convert-button.js
+++ b/packages/editor/src/components/convert-to-group-buttons/convert-button.js
@@ -28,7 +28,6 @@ export function ConvertToGroupButton( {
 		<Fragment>
 			{ isGroupable && (
 				<MenuItem
-					className="editor-block-settings-menu__control block-editor-block-settings-menu__control"
 					icon={ Group }
 					onClick={ onConvertToGroup }
 				>
@@ -37,7 +36,6 @@ export function ConvertToGroupButton( {
 			) }
 			{ isUngroupable && (
 				<MenuItem
-					className="editor-block-settings-menu__control block-editor-block-settings-menu__control"
 					icon={ Ungroup }
 					onClick={ onConvertFromGroup }
 				>

--- a/packages/editor/src/components/reusable-blocks-buttons/reusable-block-convert-button.js
+++ b/packages/editor/src/components/reusable-blocks-buttons/reusable-block-convert-button.js
@@ -26,7 +26,6 @@ export function ReusableBlockConvertButton( {
 		<>
 			{ ! isReusable && (
 				<MenuItem
-					className="editor-block-settings-menu__control block-editor-block-settings-menu__control"
 					icon="controls-repeat"
 					onClick={ onConvertToReusable }
 				>
@@ -35,7 +34,6 @@ export function ReusableBlockConvertButton( {
 			) }
 			{ isReusable && (
 				<MenuItem
-					className="editor-block-settings-menu__control block-editor-block-settings-menu__control"
 					icon="controls-repeat"
 					onClick={ onConvertToStatic }
 				>

--- a/packages/editor/src/components/reusable-blocks-buttons/reusable-block-delete-button.js
+++ b/packages/editor/src/components/reusable-blocks-buttons/reusable-block-delete-button.js
@@ -19,7 +19,6 @@ export function ReusableBlockDeleteButton( { isVisible, isDisabled, onDelete } )
 
 	return (
 		<MenuItem
-			className="editor-block-settings-menu__control block-editor-block-settings-menu__control"
 			icon="no"
 			disabled={ isDisabled }
 			onClick={ () => onDelete() }

--- a/packages/editor/src/components/reusable-blocks-buttons/test/__snapshots__/reusable-block-delete-button.js.snap
+++ b/packages/editor/src/components/reusable-blocks-buttons/test/__snapshots__/reusable-block-delete-button.js.snap
@@ -2,7 +2,6 @@
 
 exports[`ReusableBlockDeleteButton matches the snapshot 1`] = `
 <MenuItem
-  className="editor-block-settings-menu__control block-editor-block-settings-menu__control"
   disabled={false}
   icon="no"
   onClick={[Function]}

--- a/packages/format-library/src/image/index.js
+++ b/packages/format-library/src/image/index.js
@@ -124,7 +124,7 @@ export const image = {
 							{ // Disable reason: KeyPress must be suppressed so the block doesn't hide the toolbar
 							/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */ }
 							<form
-								className="editor-format-toolbar__image-container-content block-editor-format-toolbar__image-container-content"
+								className="block-editor-format-toolbar__image-container-content"
 								onKeyPress={ stopKeyPropagation }
 								onKeyDown={ this.onKeyDown }
 								onSubmit={ ( event ) => {
@@ -147,7 +147,7 @@ export const image = {
 								} }
 							>
 								<TextControl
-									className="editor-format-toolbar__image-container-value block-editor-format-toolbar__image-container-value"
+									className="block-editor-format-toolbar__image-container-value"
 									type="number"
 									label={ __( 'Width' ) }
 									value={ this.state.width }

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -211,7 +211,7 @@ class InlineLinkUI extends Component {
 			>
 				{ showInput ? (
 					<URLPopover.LinkEditor
-						className="editor-format-toolbar__link-container-content block-editor-format-toolbar__link-container-content"
+						className="block-editor-format-toolbar__link-container-content"
 						value={ inputValue }
 						onChangeInputValue={ this.onChangeInputValue }
 						onKeyDown={ this.onKeyDown }
@@ -221,7 +221,7 @@ class InlineLinkUI extends Component {
 					/>
 				) : (
 					<URLPopover.LinkViewer
-						className="editor-format-toolbar__link-container-content block-editor-format-toolbar__link-container-content"
+						className="block-editor-format-toolbar__link-container-content"
 						onKeyPress={ stopKeyPropagation }
 						url={ url }
 						onEditLinkClick={ this.editLink }


### PR DESCRIPTION
Previously: #19050

This pull request seeks to remove more instances of `editor-`-prefixed legacy className compatibility.

These fall under one of two reasons for not having been included as part of #19050:

- The classes were assigned to components in such a way that they violated [CSS naming guidelines](https://github.com/WordPress/gutenberg/blob/master/docs/contributors/coding-guidelines.md#naming), where the classes were used in packages or components where they were not appropriate to be used (i.e. not in `block-editor`, or not consistent with the containing directory name).
- The classes were reintroduced in subsequent merges, in some cases in similar violation of the first point (see https://github.com/WordPress/gutenberg/pull/18139#discussion_r363893820, https://github.com/WordPress/gutenberg/pull/18651#discussion_r363894684)

**Implementation Notes:**

In the case of `block-editor-block-settings-menu__control`, the use was quite widespread, and it turned out that there are no styles or tests which reference this class name. For this reason, it was simply removed altogether.

**Testing Instructions:**

Verify there are no regressions in affected components (block options menu items, link editing form).