### PR TITLE
Fix: Bug on URLInput & Intermitent end to end test on the buttons block

### DIFF
--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -143,6 +143,10 @@ class URLInput extends Component {
 	onKeyDown( event ) {
 		const { showSuggestions, selectedSuggestion, suggestions, loading } = this.state;
 
+		const setCurrentInputAsLink = () => {
+			const { value } = this.props;
+			this.selectLink( { url: value, title: value } );
+		};
 		// If the suggestions are not shown or loading, we shouldn't handle the arrow keys
 		// We shouldn't preventDefault to allow block arrow keys navigation
 		if (
@@ -178,6 +182,10 @@ class URLInput extends Component {
 						event.target.setSelectionRange( this.props.value.length, this.props.value.length );
 					}
 					break;
+				}
+				case ENTER: {
+					// If pressing enter before suggestions are loaded use the current input as the link.
+					setCurrentInputAsLink();
 				}
 			}
 
@@ -215,8 +223,10 @@ class URLInput extends Component {
 			}
 			case ENTER: {
 				if ( this.state.selectedSuggestion !== null ) {
-					event.stopPropagation();
 					this.selectLink( suggestion );
+				} else {
+					// If pressing enter and no suggestion is selected use the current input as the link.
+					setCurrentInputAsLink();
 				}
 				break;
 			}

--- a/packages/e2e-tests/specs/editor/blocks/__snapshots__/buttons.test.js.snap
+++ b/packages/e2e-tests/specs/editor/blocks/__snapshots__/buttons.test.js.snap
@@ -3,7 +3,7 @@
 exports[`Buttons can jump to the link editor using the keyboard shortcut 1`] = `
 "<!-- wp:buttons -->
 <div class=\\"wp-block-buttons\\"><!-- wp:button -->
-<div class=\\"wp-block-button\\"><a class=\\"wp-block-button__link\\">WordPress</a></div>
+<div class=\\"wp-block-button\\"><a class=\\"wp-block-button__link\\" href=\\"https://www.wordpress.org/\\" title=\\"https://www.wordpress.org/\\">WordPress</a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons -->"
 `;

--- a/packages/e2e-tests/specs/editor/blocks/buttons.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/buttons.test.js
@@ -24,9 +24,8 @@ describe( 'Buttons', () => {
 		await insertBlock( 'Buttons' );
 		await page.keyboard.type( 'WordPress' );
 		await pressKeyWithModifier( 'primary', 'k' );
-		await page.keyboard.type( 'https://wwww.wordpress.org/' );
+		await page.keyboard.type( 'https://www.wordpress.org/' );
 		await page.keyboard.press( 'Enter' );
-
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 } );

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -52,6 +52,7 @@ async function updateActiveNavigationLink( { url, label } ) {
 		await page.type( 'input[placeholder="Search or type url"]', url );
 		// Wait for the autocomplete suggestion item to appear.
 		await page.waitForXPath( `//span[@class="block-editor-link-control__search-item-title"]/mark[text()="${ url }"]` );
+		await page.keyboard.press( 'ArrowDown' );
 		await page.keyboard.press( 'Enter' );
 	}
 
@@ -134,12 +135,5 @@ describe( 'Navigation', () => {
 
 		// Expect a Navigation Block with two Navigation Links in the snapshot.
 		expect( await getEditedPostContent() ).toMatchSnapshot();
-
-		// TODO - this is needed currently because when adding a link using the suggestion list,
-		// a submit button is used. The form that the submit button is in is unmounted when submission
-		// occurs, resulting in a warning 'Form submission canceled because the form is not connected'
-		// in Chrome.
-		// Ideally, the suggestions wouldn't be implemented using submit buttons.
-		expect( console ).toHaveWarned();
 	} );
 } );


### PR DESCRIPTION
## Description
Buttons had an end to end test that fails from time to time.
This PR adds a waitForSelector call to avoid this failure.

## How has this been tested?
I executed the end to end tests for the buttons block multiple times and verified they consistently pass. 
