### PR TITLE
Fix: Buttons block Link shortcut does not work with multiple buttons 

### DIFF
--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -127,12 +127,14 @@ function URLPicker( { isSelected, url, title, setAttributes, opensInNewTab, onTo
 					/>
 				</ToolbarGroup>
 			</BlockControls>
-			<KeyboardShortcuts
-				bindGlobal
-				shortcuts={ {
-					[ rawShortcut.primary( 'k' ) ]: openLinkControl,
-				} }
-			/>
+			{ isSelected && (
+				<KeyboardShortcuts
+					bindGlobal
+					shortcuts={ {
+						[ rawShortcut.primary( 'k' ) ]: openLinkControl,
+					} }
+				/>
+			) }
 			{ linkControl }
 		</>
 	);


### PR DESCRIPTION
We were rendering the keyboard shortcuts unconditionally instead of rendering only if the block is the selected one.

## How has this been tested?
I added a buttons block.
I added three buttons inside.
For each button, I selected it, pressed cmd+k and verified the link editor for that button opened.
