### PR TITLE
Fix: Predefined colors do not appear on the navigation block

### DIFF
--- a/packages/block-editor/src/components/color-palette/control.js
+++ b/packages/block-editor/src/components/color-palette/control.js
@@ -4,15 +4,13 @@
 import ColorGradientControl from '../colors-gradients/control';
 
 export default function ColorPaletteControl( {
-	colors,
-	disableCustomColors,
-	label,
 	onChange,
 	value,
+	...otherProps
 } ) {
 	return (
 		<ColorGradientControl
-			{ ...{ colors, disableCustomColors, label } }
+			{ ...otherProps }
 			onColorChange={ onChange }
 			colorValue={ value }
 			gradients={ [] }


### PR DESCRIPTION
## Description
Fixes: https://github.com/WordPress/gutenberg/issues/19444
The problem was caused in ColorPaletteControl instead of not passing colors, disableCustomColors, and label properties to ColorGradientControl, the component was passing undefined values when it did not receive these properties.

## How has this been tested?
I verified I could use the predefined color palette on the navigation block.