### PR TITLE
Block: Fix form element alignment for Embed + Table

### DIFF
--- a/packages/block-library/src/embed/style.scss
+++ b/packages/block-library/src/embed/style.scss
@@ -18,6 +18,14 @@
 	// The embed block is in a `figure` element, and many themes zero this out.
 	// This rule explicitly sets it, to ensure at least some bottom-margin in the flow.
 	margin-bottom: 1em;
+
+	.components-placeholder__input {
+		margin-bottom: 0;
+	}
+
+	.components-placeholder__fieldset .components-button {
+		margin-bottom: 0;
+	}
 }
 
 .wp-embed-responsive {

--- a/packages/components/src/placeholder/style.scss
+++ b/packages/components/src/placeholder/style.scss
@@ -66,7 +66,8 @@
 }
 
 .components-placeholder__input {
-	margin: 0 8px 0 0;
+	margin-top: 0;
+	margin-right: 8px;
 	flex: 1 1 auto;
 }
 
@@ -84,7 +85,6 @@
 	margin-bottom: $grid-size; // If buttons wrap we need vertical space between.
 
 	&:last-child {
-		margin-bottom: 0;
 		margin-right: 0;
 	}
 }


### PR DESCRIPTION
<img width="776" alt="Screen Shot 2020-01-07 at 3 45 10 PM" src="https://user-images.githubusercontent.com/2322354/71928409-7efa1d00-3165-11ea-969b-272d37172d05.png">

This update fixes the Input x Button alignment for both the Embed and
Table blocks via the internal Placeholder component.

The issue was caused by a recent update made to the base Placeholder
component which normalized its margins. However, due to the element/layout
rendering of the Table block, it required certain margin values for the
Placeholder button to align correctly.

The solution was to revert the globalized changes and apply the normalization
specifically to the Embed block.

I don't think this will be a permanent solution given how unpredictable
component combinations may affect the layout (via margin). For now, this
solution is adequate to resolve these 2 Blocks.


## How has this been tested?

Tested locally in Gutenberg dev environment

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.

Follow up to https://github.com/WordPress/gutenberg/pull/19438