### PR TITLE
Moved "Welcome guide" link to options modal dialog

### DIFF
--- a/packages/edit-post/src/components/options-modal/index.js
+++ b/packages/edit-post/src/components/options-modal/index.js
@@ -47,6 +47,7 @@ export function OptionsModal( { isModalActive, isViewable, closeModal } ) {
 			<Section title={ __( 'General' ) }>
 				<EnablePublishSidebarOption label={ __( 'Pre-publish checks' ) } />
 				<EnableFeature feature="showInserterHelpPanel" label={ __( 'Inserter help panel' ) } />
+				<EnableFeature feature="welcomeGuide" label={ __( 'Welcome guide' ) } />
 			</Section>
 			<Section title={ __( 'Document panels' ) }>
 				<EnablePluginDocumentSettingPanelOption.Slot />

--- a/packages/edit-post/src/plugins/index.js
+++ b/packages/edit-post/src/plugins/index.js
@@ -13,7 +13,6 @@ import CopyContentMenuItem from './copy-content-menu-item';
 import ManageBlocksMenuItem from './manage-blocks-menu-item';
 import KeyboardShortcutsHelpMenuItem from './keyboard-shortcuts-help-menu-item';
 import ToolsMoreMenuGroup from '../components/header/tools-more-menu-group';
-import WelcomeGuideMenuItem from './welcome-guide-menu-item';
 
 registerPlugin( 'edit-post', {
 	render() {
@@ -30,7 +29,6 @@ registerPlugin( 'edit-post', {
 								{ __( 'Manage all reusable blocks' ) }
 							</MenuItem>
 							<KeyboardShortcutsHelpMenuItem onSelect={ onClose } />
-							<WelcomeGuideMenuItem />
 							<CopyContentMenuItem />
 							<MenuItem
 								role="menuitem"


### PR DESCRIPTION
## Description
Fixes #19443. 

Move the Welcome Guide link to the Option modal dialog. It is now under the "General" category next to the "Inserter Help Panel" which seems fitting. This is in an effort to help alleviate the redundancy of two "Tools" sections in the interface as recorded in https://github.com/WordPress/gutenberg/issues/19409.

## How has this been tested?
Tested locally.

## Screenshots

**Option modal dialog**

![Screen Shot 2020-01-07 at 2 25 37 PM](https://user-images.githubusercontent.com/617986/71934582-a1863900-3159-11ea-8c6c-fd7463dbe61a.png)

**Gif of interaction**

![welcome-guide 2020-01-07 14_21_28](https://user-images.githubusercontent.com/617986/71934603-ab0fa100-3159-11ea-8fe0-ee6b4743b351.gif)


## Types of changes
Moving a link from one location to another. Non-breaking, maybe?

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
