### PR TITLE
useColors: fix contrast check

### DIFF
--- a/packages/block-editor/src/components/colors/use-colors.js
+++ b/packages/block-editor/src/components/colors/use-colors.js
@@ -245,7 +245,7 @@ export default function __experimentalUseColors(
 						while (
 							backgroundColor === 'rgba(0, 0, 0, 0)' &&
 							backgroundColorNode.parentNode &&
-							backgroundColorNode.parentNode === Node.ELEMENT_NODE
+							backgroundColorNode.parentNode.nodeType === Node.ELEMENT_NODE
 						) {
 							backgroundColorNode = backgroundColorNode.parentNode;
 							backgroundColor = getComputedStyle( backgroundColorNode )


### PR DESCRIPTION
## Description

Introduced in #19046.
Props to @epiqueras for finding the problem in https://github.com/WordPress/gutenberg/pull/19474#issuecomment-571650351.

Instead of checking the node type, the node itself is checked.

## How has this been tested?

Create a paragraph and make the text colour white (with a light inherited background). Type something in the block to trigger a change (it's strange that this is necessary). The contrast warning should be displayed.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
