### PR TITLE
Block: simplify node id

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -472,7 +472,7 @@ function BlockListBlock( {
 				ref={ blockNodeRef }
 				// Only allow selection to be started from a selected block.
 				onMouseLeave={ isSelected ? onMouseLeave : undefined }
-				data-block={ clientId }
+				data-block
 			>
 				<BlockCrashBoundary onError={ onBlockError }>
 					{ isValid && blockEdit }

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -353,7 +353,6 @@ function BlockListBlock( {
 			...blockType.getEditWrapperProps( attributes ),
 		};
 	}
-	const blockElementId = `block-${ clientId }`;
 
 	// We wrap the BlockEdit component in a div that hides it when editing in
 	// HTML mode. This allows us to render all of the ancillary pieces
@@ -399,7 +398,7 @@ function BlockListBlock( {
 
 	return (
 		<animated.div
-			id={ blockElementId }
+			id={ clientId }
 			ref={ wrapper }
 			className={ wrapperClassName }
 			data-type={ name }

--- a/packages/block-editor/src/components/block-preview/index.js
+++ b/packages/block-editor/src/components/block-preview/index.js
@@ -37,7 +37,7 @@ function ScaledBlockPreview( { blocks, viewportWidth, padding = 0 } ) {
 			// If we're previewing a single block, scale the preview to fit it.
 			if ( blocks.length === 1 ) {
 				const block = blocks[ 0 ];
-				const previewElement = getBlockPreviewContainerDOMNode( block.clientId, containerElement );
+				const previewElement = getBlockPreviewContainerDOMNode( block.clientId );
 				if ( ! previewElement ) {
 					return;
 				}

--- a/packages/block-editor/src/utils/dom.js
+++ b/packages/block-editor/src/utils/dom.js
@@ -4,18 +4,17 @@
  * in cases where isolated behaviors need remote access to a block node.
  *
  * @param {string} clientId Block client ID.
- * @param {Element} scope an optional DOM Element to which the selector should be scoped
  *
  * @return {Element} Block DOM node.
  */
-export function getBlockDOMNode( clientId, scope = document ) {
-	return scope
+export function getBlockDOMNode( clientId ) {
+	return document
 		.getElementById( clientId )
 		.querySelector( '[data-block]' );
 }
 
-export function getBlockPreviewContainerDOMNode( clientId, scope ) {
-	const domNode = getBlockDOMNode( clientId, scope );
+export function getBlockPreviewContainerDOMNode( clientId ) {
+	const domNode = getBlockDOMNode( clientId );
 
 	if ( ! domNode ) {
 		return;

--- a/packages/block-editor/src/utils/dom.js
+++ b/packages/block-editor/src/utils/dom.js
@@ -105,5 +105,5 @@ export function getBlockClientId( node ) {
 		return;
 	}
 
-	return blockNode.id.slice( 'block-'.length );
+	return blockNode.id;
 }

--- a/packages/block-editor/src/utils/dom.js
+++ b/packages/block-editor/src/utils/dom.js
@@ -9,7 +9,9 @@
  * @return {Element} Block DOM node.
  */
 export function getBlockDOMNode( clientId, scope = document ) {
-	return scope.querySelector( '[data-block="' + clientId + '"]' );
+	return scope
+		.getElementById( clientId )
+		.querySelector( '[data-block]' );
 }
 
 export function getBlockPreviewContainerDOMNode( clientId, scope ) {


### PR DESCRIPTION
## Description

Until now the block node id has always been `block-{clientId}`. I wonder if we can simplify this to just been the id. I'm not sure what value the `block-` prefix brings. It only makes it harder to query the element by id or to retrieve the id.

I also removed the id from `data-block` since it's not needed.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
