### PR TITLE
Block list appender: use prevent default to prevent block selection

### DIFF
--- a/packages/block-editor/src/components/block-list-appender/index.js
+++ b/packages/block-editor/src/components/block-list-appender/index.js
@@ -15,8 +15,8 @@ import { getDefaultBlockName } from '@wordpress/blocks';
 import DefaultBlockAppender from '../default-block-appender';
 import ButtonBlockAppender from '../button-block-appender';
 
-function stopPropagation( event ) {
-	event.stopPropagation();
+function preventDefault( event ) {
+	event.preventDefault();
 }
 
 function BlockListAppender( {
@@ -65,9 +65,9 @@ function BlockListAppender( {
 			//
 			// See: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Clicking_and_focus
 			tabIndex={ -1 }
-			// Prevent the block from being selected when the appender is
-			// clicked.
-			onFocus={ stopPropagation }
+			// Prevent the default behaviour of selecting the block when the
+			// appender is clicked.
+			onFocus={ preventDefault }
 			className="block-list-appender"
 		>
 			{ appender }

--- a/packages/block-editor/src/components/block-list/root-container.js
+++ b/packages/block-editor/src/components/block-list/root-container.js
@@ -58,7 +58,7 @@ export default function RootContainer( { children, className } ) {
 	 * @param {WPSyntheticEvent} event
 	 */
 	function onFocus( event ) {
-		if ( hasMultiSelection ) {
+		if ( hasMultiSelection || event.defaultPrevented ) {
 			return;
 		}
 


### PR DESCRIPTION
## Description

In #19397, I replaced `<IgnoreNestedEvents />` in the block list appender with `event.stopPropagation()` on the focus event. After thinking about the problem a bit, I realised that maybe we could use `event.preventDefault()` to do the same thing, where the default behaviour would be to select the block. Normally `event.preventDefault()` is used to prevent native default behaviour, but nothing stops an application from using the mechanism for its own default behaviours. The focus event is not cancellable, so normally `event.preventDefault()` is not used on a focus event. It exclusively cancels only our own selection behaviour.

It's worth noting that the event will now bubble further. `event.stopPropagation()` would prevent this from happening.

A cool side effect of this is that any block could now prevent blocks selection if it wanted to, but I wouldn't advertise this as an official API.

I think either we should do something like this, or find a way to both focus the appender and select the block in the same click.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
