### PR TITLE
Adds always on display of media URL

### DIFF
--- a/packages/block-editor/src/components/link-control/README.md
+++ b/packages/block-editor/src/components/link-control/README.md
@@ -92,6 +92,14 @@ Value change handler, called with the updated value if the user selects a new li
 />
 ```
 
+### showSuggestions
+
+- Type: `boolean`
+- Required: No
+- Default: `true`
+
+Whether to present suggestions when typing the URL.
+
 ### showInitialSuggestions
 
 - Type: `boolean`

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -347,6 +347,10 @@ function LinkControl( {
 	// Effects
 	const getSearchHandler = useCallback(
 		( val, args ) => {
+			if ( ! showSuggestions ) {
+				return Promise.resolve( [] );
+			}
+
 			return isURLLike( val )
 				? handleDirectEntry( val, args )
 				: handleEntitySearch( val, args );
@@ -547,7 +551,7 @@ function LinkControl( {
 						}
 					} }
 					renderSuggestions={
-						showSuggestions ? renderSearchResults : noop
+						showSuggestions ? renderSearchResults : false
 					}
 					fetchSuggestions={ getSearchHandler }
 					showInitialSuggestions={ showInitialSuggestions }

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -139,6 +139,7 @@ const makeCancelable = ( promise ) => {
  * @property {WPLinkControlValue=}                  value                  Current link value.
  * @property {WPLinkControlOnChangeProp=}           onChange               Value change handler, called with the updated value if
  *                                                                         the user selects a new link or updates settings.
+ * @property {boolean=}                             showSuggestions        Whether to present suggestions when typing the URL.
  * @property {boolean=}                             showInitialSuggestions Whether to present initial suggestions immediately.
  * @property {WPLinkControlCreateSuggestionProp=}   createSuggestion       Handler to manage creation of link value from suggestion.
  */
@@ -154,6 +155,7 @@ function LinkControl( {
 	value,
 	settings,
 	onChange = noop,
+	showSuggestions = true,
 	showInitialSuggestions,
 	forceIsEditingLink,
 	createSuggestion,
@@ -544,7 +546,9 @@ function LinkControl( {
 							stopEditing();
 						}
 					} }
-					renderSuggestions={ renderSearchResults }
+					renderSuggestions={
+						showSuggestions ? renderSearchResults : noop
+					}
 					fetchSuggestions={ getSearchHandler }
 					showInitialSuggestions={ showInitialSuggestions }
 					errorMessage={ errorMessage }

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -551,7 +551,7 @@ function LinkControl( {
 						}
 					} }
 					renderSuggestions={
-						showSuggestions ? renderSearchResults : false
+						showSuggestions ? renderSearchResults : null
 					}
 					fetchSuggestions={ getSearchHandler }
 					showInitialSuggestions={ showInitialSuggestions }

--- a/packages/block-editor/src/components/link-control/search-input.js
+++ b/packages/block-editor/src/components/link-control/search-input.js
@@ -4,28 +4,13 @@
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Button, Notice } from '@wordpress/components';
-import { LEFT, RIGHT, UP, DOWN, BACKSPACE, ENTER } from '@wordpress/keycodes';
+import { ENTER } from '@wordpress/keycodes';
 import { keyboardReturn } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
 import { URLInput } from '../';
-
-const handleLinkControlOnKeyDown = ( event ) => {
-	const { keyCode } = event;
-	if ( [ LEFT, DOWN, RIGHT, UP, BACKSPACE, ENTER ].indexOf( keyCode ) > -1 ) {
-		// Stop the key event from propagating up to ObserveTyping.startTypingInTextField.
-		event.stopPropagation();
-	}
-};
-
-const handleLinkControlOnKeyPress = ( event ) => {
-	const { keyCode } = event;
-	event.stopPropagation();
-	if ( keyCode === ENTER ) {
-	}
-};
 
 const LinkControlSearchInput = ( {
 	value,
@@ -64,12 +49,15 @@ const LinkControlSearchInput = ( {
 		<form
 			onSubmit={ selectSuggestionOrCurrentInputValue }
 			onKeyDown={ ( event ) => {
-				if ( event.keyCode === ENTER ) {
-					return;
-				}
-				handleLinkControlOnKeyDown( event );
+				event.stopPropagation();
 			} }
-			onKeyPress={ handleLinkControlOnKeyPress }
+			onKeyPress={ ( event ) => {
+				const { keycode } = event;
+				if ( keycode === ENTER ) {
+					selectSuggestionOrCurrentInputValue();
+				}
+				event.stopPropagation();
+			} }
 		>
 			<div className="block-editor-link-control__search-input-wrapper">
 				<URLInput

--- a/packages/block-editor/src/components/link-control/search-input.js
+++ b/packages/block-editor/src/components/link-control/search-input.js
@@ -4,12 +4,28 @@
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Button, Notice } from '@wordpress/components';
+import { LEFT, RIGHT, UP, DOWN, BACKSPACE, ENTER } from '@wordpress/keycodes';
 import { keyboardReturn } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
 import { URLInput } from '../';
+
+const handleLinkControlOnKeyDown = ( event ) => {
+	const { keyCode } = event;
+	if ( [ LEFT, DOWN, RIGHT, UP, BACKSPACE, ENTER ].indexOf( keyCode ) > -1 ) {
+		// Stop the key event from propagating up to ObserveTyping.startTypingInTextField.
+		event.stopPropagation();
+	}
+};
+
+const handleLinkControlOnKeyPress = ( event ) => {
+	const { keyCode } = event;
+	event.stopPropagation();
+	if ( keyCode === ENTER ) {
+	}
+};
 
 const LinkControlSearchInput = ( {
 	value,
@@ -44,7 +60,17 @@ const LinkControlSearchInput = ( {
 	}
 
 	return (
-		<form onSubmit={ selectSuggestionOrCurrentInputValue }>
+		// eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
+		<form
+			onSubmit={ selectSuggestionOrCurrentInputValue }
+			onKeyDown={ ( event ) => {
+				if ( event.keyCode === ENTER ) {
+					return;
+				}
+				handleLinkControlOnKeyDown( event );
+			} }
+			onKeyPress={ handleLinkControlOnKeyPress }
+		>
 			<div className="block-editor-link-control__search-input-wrapper">
 				<URLInput
 					className="block-editor-link-control__search-input"

--- a/packages/block-editor/src/components/link-control/search-input.js
+++ b/packages/block-editor/src/components/link-control/search-input.js
@@ -4,7 +4,7 @@
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Button, Notice } from '@wordpress/components';
-import { ENTER } from '@wordpress/keycodes';
+import { ENTER, ESCAPE } from '@wordpress/keycodes';
 import { keyboardReturn } from '@wordpress/icons';
 
 /**
@@ -56,7 +56,9 @@ const LinkControlSearchInput = ( {
 				if ( keycode === ENTER ) {
 					selectSuggestionOrCurrentInputValue();
 				}
-				event.stopPropagation();
+				if ( keycode !== ESCAPE ) {
+					event.stopPropagation();
+				}
 			} }
 		>
 			<div className="block-editor-link-control__search-input-wrapper">

--- a/packages/block-editor/src/components/link-control/search-input.js
+++ b/packages/block-editor/src/components/link-control/search-input.js
@@ -4,7 +4,6 @@
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Button, Notice } from '@wordpress/components';
-import { ENTER, ESCAPE } from '@wordpress/keycodes';
 import { keyboardReturn } from '@wordpress/icons';
 
 /**
@@ -45,22 +44,7 @@ const LinkControlSearchInput = ( {
 	}
 
 	return (
-		// eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
-		<form
-			onSubmit={ selectSuggestionOrCurrentInputValue }
-			onKeyDown={ ( event ) => {
-				event.stopPropagation();
-			} }
-			onKeyPress={ ( event ) => {
-				const { keycode } = event;
-				if ( keycode === ENTER ) {
-					selectSuggestionOrCurrentInputValue();
-				}
-				if ( keycode !== ESCAPE ) {
-					event.stopPropagation();
-				}
-			} }
-		>
+		<form onSubmit={ selectSuggestionOrCurrentInputValue }>
 			<div className="block-editor-link-control__search-input-wrapper">
 				<URLInput
 					className="block-editor-link-control__search-input"

--- a/packages/block-editor/src/components/media-replace-flow/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/index.js
@@ -123,7 +123,16 @@ const MediaReplaceFlow = ( {
 						</MediaUploadCheck>
 					</NavigableMenu>
 					{ onSelectURL && (
-						<div className="block-editor-media-flow__url-input">
+						// eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
+						<form
+							className="block-editor-media-flow__url-input"
+							onKeyDown={ ( event ) => {
+								event.stopPropagation();
+							} }
+							onKeyPress={ ( event ) => {
+								event.stopPropagation();
+							} }
+						>
 							<span className="block-editor-media-replace-flow__image-url-label">
 								{ __( 'Current media URL:' ) }
 							</span>
@@ -137,7 +146,7 @@ const MediaReplaceFlow = ( {
 									editMediaButtonRef.current.focus();
 								} }
 							/>
-						</div>
+						</form>
 					) }
 				</>
 			) }

--- a/packages/block-editor/src/components/media-replace-flow/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/index.js
@@ -125,7 +125,7 @@ const MediaReplaceFlow = ( {
 					{ onSelectURL && (
 						<div className="block-editor-media-flow__url-input">
 							<span className="block-editor-media-replace-flow__image-url-label">
-								{ __( ' Current media URL:' ) }
+								{ __( 'Current media URL:' ) }
 							</span>
 							<LinkControl
 								value={ { url: mediaURLValue } }

--- a/packages/block-editor/src/components/media-replace-flow/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/index.js
@@ -129,7 +129,7 @@ const MediaReplaceFlow = ( {
 							</span>
 							<LinkControl
 								value={ { url: mediaURLValue } }
-								settings={ false }
+								settings={ [] }
 								showSuggestions={ false }
 								onChange={ ( { url } ) => {
 									setMediaURLValue( url );

--- a/packages/block-editor/src/components/media-replace-flow/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/index.js
@@ -13,18 +13,17 @@ import {
 	Dropdown,
 	withNotices,
 } from '@wordpress/components';
-import { LEFT, RIGHT, UP, DOWN, BACKSPACE, ENTER } from '@wordpress/keycodes';
+import { DOWN } from '@wordpress/keycodes';
 import { useSelect } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
-import { link, upload, media as mediaIcon } from '@wordpress/icons';
+import { upload, media as mediaIcon } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
 import MediaUpload from '../media-upload';
 import MediaUploadCheck from '../media-upload/check';
-import LinkEditor from '../url-popover/link-editor';
-import LinkViewer from '../url-popover/link-viewer';
+import LinkControl from '../link-control';
 
 const MediaReplaceFlow = ( {
 	mediaURL,
@@ -36,28 +35,11 @@ const MediaReplaceFlow = ( {
 	onError,
 	name = __( 'Replace' ),
 } ) => {
-	const [ showURLInput, setShowURLInput ] = useState( false );
-	const [ showEditURLInput, setShowEditURLInput ] = useState( false );
 	const [ mediaURLValue, setMediaURLValue ] = useState( mediaURL );
 	const mediaUpload = useSelect( ( select ) => {
 		return select( 'core/block-editor' ).getSettings().mediaUpload;
 	}, [] );
 	const editMediaButtonRef = createRef();
-
-	const stopPropagation = ( event ) => {
-		event.stopPropagation();
-	};
-
-	const stopPropagationRelevantKeys = ( event ) => {
-		if (
-			[ LEFT, DOWN, RIGHT, UP, BACKSPACE, ENTER ].indexOf(
-				event.keyCode
-			) > -1
-		) {
-			// Stop the key event from propagating up to ObserveTyping.startTypingInTextField.
-			event.stopPropagation();
-		}
-	};
 
 	const selectMedia = ( media ) => {
 		onSelect( media );
@@ -67,7 +49,6 @@ const MediaReplaceFlow = ( {
 
 	const selectURL = ( newURL ) => {
 		onSelectURL( newURL );
-		setShowEditURLInput( false );
 	};
 
 	const uploadFiles = ( event, closeDropdown ) => {
@@ -91,36 +72,6 @@ const MediaReplaceFlow = ( {
 			event.target.click();
 		}
 	};
-
-	let urlInputUIContent;
-	if ( showEditURLInput ) {
-		urlInputUIContent = (
-			<LinkEditor
-				onKeyDown={ stopPropagationRelevantKeys }
-				onKeyPress={ stopPropagation }
-				value={ mediaURLValue }
-				isFullWidthInput={ true }
-				hasInputBorder={ true }
-				onChangeInputValue={ ( url ) => setMediaURLValue( url ) }
-				onSubmit={ ( event ) => {
-					event.preventDefault();
-					selectURL( mediaURLValue );
-					editMediaButtonRef.current.focus();
-				} }
-			/>
-		);
-	} else {
-		urlInputUIContent = (
-			<LinkViewer
-				isFullWidth={ true }
-				className="block-editor-media-replace-flow__link-viewer"
-				url={ mediaURLValue }
-				onEditLinkClick={ () =>
-					setShowEditURLInput( ! showEditURLInput )
-				}
-			/>
-		);
-	}
 
 	return (
 		<Dropdown
@@ -170,21 +121,22 @@ const MediaReplaceFlow = ( {
 								} }
 							/>
 						</MediaUploadCheck>
-						{ onSelectURL && (
-							<MenuItem
-								icon={ link }
-								onClick={ () =>
-									setShowURLInput( ! showURLInput )
-								}
-								aria-expanded={ showURLInput }
-							>
-								<div> { __( 'Insert from URL' ) } </div>
-							</MenuItem>
-						) }
 					</NavigableMenu>
-					{ showURLInput && (
+					{ onSelectURL && (
 						<div className="block-editor-media-flow__url-input">
-							{ urlInputUIContent }
+							<span className="block-editor-media-replace-flow__image-url-label">
+								{ __( ' Current media URL:' ) }
+							</span>
+							<LinkControl
+								value={ { url: mediaURLValue } }
+								settings={ false }
+								showSuggestions={ false }
+								onChange={ ( { url } ) => {
+									setMediaURLValue( url );
+									selectURL( url );
+									editMediaButtonRef.current.focus();
+								} }
+							/>
 						</div>
 					) }
 				</>

--- a/packages/block-editor/src/components/media-replace-flow/style.scss
+++ b/packages/block-editor/src/components/media-replace-flow/style.scss
@@ -5,17 +5,56 @@
 	display: none;
 }
 
-.block-editor-media-flow__url-input {
-	padding: 0 15px;
-	max-width: 255px;
-	padding-bottom: 10px;
+// Forcing some space above the list of options in
+// the dropdown to visually balance them.
+.block-editor-media-replace-flow__options .components-popover__content {
+	padding-top: 8px;
+}
 
-	input {
-		max-width: 180px;
+.block-editor-media-replace-flow__indicator {
+	margin-left: 4px;
+
+	&::after {
+		@include dropdown-arrow();
+	}
+}
+
+.block-editor-media-flow__url-input {
+
+	border-top: 1px solid $light-gray-800;
+	margin-top: 8px;
+
+	.block-editor-media-replace-flow__image-url-label {
+		color: $dark-gray-300;
+		font-size: $default-font-size;
+		display: block;
+		position: relative;
+		top: $grid-size-large;
+		padding-left: $grid-size-large;
+	}
+
+	.block-editor-link-control {
+		min-width: auto;
+		margin-top: -16px;
+		.block-editor-link-control__search-item-title {
+			max-width: 180px;
+			margin-top: $grid-size-large;
+		}
+		.block-editor-link-control__search-item.is-current {
+			width: auto;
+			padding: $grid-size-large;
+		}
 	}
 }
 
 .block-editor-media-replace-flow__link-viewer {
+	align-items: center;
+
+	.block-editor-url-popover__link-viewer-url {
+		margin: 0;
+		margin-right: 4px;
+	}
+
 	// Overflow is not working properly if we show the icon.
 	.components-external-link__icon {
 		display: none;
@@ -25,5 +64,10 @@
 	}
 	.components-button {
 		flex-shrink: 0;
+	}
+
+	button {
+		position: relative;
+		top: -8px;
 	}
 }

--- a/packages/block-editor/src/components/media-replace-flow/style.scss
+++ b/packages/block-editor/src/components/media-replace-flow/style.scss
@@ -26,6 +26,10 @@
 		margin-top: -16px;
 		width: auto;
 
+		.components-base-control .components-base-control__field {
+			margin-bottom: 0;
+		}
+
 		.block-editor-link-control__search-item-title {
 			max-width: 180px;
 			margin-top: $grid-unit-20;
@@ -34,6 +38,15 @@
 		.block-editor-link-control__search-item.is-current {
 			width: auto;
 			padding: 0;
+		}
+
+		.block-editor-link-control__search-input.block-editor-link-control__search-input input[type="text"] {
+			margin: 16px 0 0 0;
+			width: 100%;
+		}
+
+		.block-editor-link-control__search-actions {
+			right: 4px;
 		}
 	}
 }

--- a/packages/block-editor/src/components/media-replace-flow/style.scss
+++ b/packages/block-editor/src/components/media-replace-flow/style.scss
@@ -42,7 +42,7 @@
 		}
 		.block-editor-link-control__search-item.is-current {
 			width: auto;
-			padding: $grid-size-large;
+			padding: $grid-unit-20;
 		}
 	}
 }

--- a/packages/block-editor/src/components/media-replace-flow/style.scss
+++ b/packages/block-editor/src/components/media-replace-flow/style.scss
@@ -30,7 +30,7 @@
 		display: block;
 		position: relative;
 		top: $grid-size-large;
-		padding-left: $grid-size-large;
+		padding-left: $grid-unit-20;
 	}
 
 	.block-editor-link-control {

--- a/packages/block-editor/src/components/media-replace-flow/style.scss
+++ b/packages/block-editor/src/components/media-replace-flow/style.scss
@@ -29,7 +29,7 @@
 		font-size: $default-font-size;
 		display: block;
 		position: relative;
-		top: $grid-size-large;
+		top: $grid-unit-20;
 		padding-left: $grid-unit-20;
 	}
 

--- a/packages/block-editor/src/components/media-replace-flow/style.scss
+++ b/packages/block-editor/src/components/media-replace-flow/style.scss
@@ -13,10 +13,6 @@
 
 .block-editor-media-replace-flow__indicator {
 	margin-left: 4px;
-
-	&::after {
-		@include dropdown-arrow();
-	}
 }
 
 .block-editor-media-flow__url-input {

--- a/packages/block-editor/src/components/media-replace-flow/style.scss
+++ b/packages/block-editor/src/components/media-replace-flow/style.scss
@@ -50,28 +50,3 @@
 		}
 	}
 }
-
-.block-editor-media-replace-flow__link-viewer {
-	align-items: center;
-
-	.block-editor-url-popover__link-viewer-url {
-		margin: 0;
-		margin-right: 4px;
-	}
-
-	// Overflow is not working properly if we show the icon.
-	.components-external-link__icon {
-		display: none;
-	}
-	.components-visually-hidden {
-		position: initial;
-	}
-	.components-button {
-		flex-shrink: 0;
-	}
-
-	button {
-		position: relative;
-		top: -8px;
-	}
-}

--- a/packages/block-editor/src/components/media-replace-flow/style.scss
+++ b/packages/block-editor/src/components/media-replace-flow/style.scss
@@ -38,7 +38,7 @@
 		margin-top: -16px;
 		.block-editor-link-control__search-item-title {
 			max-width: 180px;
-			margin-top: $grid-size-large;
+			margin-top: $grid-unit-20;
 		}
 		.block-editor-link-control__search-item.is-current {
 			width: auto;

--- a/packages/block-editor/src/components/media-replace-flow/style.scss
+++ b/packages/block-editor/src/components/media-replace-flow/style.scss
@@ -8,7 +8,7 @@
 // Forcing some space above the list of options in
 // the dropdown to visually balance them.
 .block-editor-media-replace-flow__options .components-popover__content {
-	padding-top: 8px;
+	padding-top: $grid-unit-20;
 }
 
 .block-editor-media-replace-flow__indicator {
@@ -16,29 +16,24 @@
 }
 
 .block-editor-media-flow__url-input {
-
-	border-top: 1px solid $light-gray-800;
-	margin-top: 8px;
+	margin-top: $grid-unit-20;
 
 	.block-editor-media-replace-flow__image-url-label {
-		color: $dark-gray-300;
-		font-size: $default-font-size;
-		display: block;
-		position: relative;
 		top: $grid-unit-20;
-		padding-left: $grid-unit-20;
 	}
 
 	.block-editor-link-control {
-		min-width: auto;
 		margin-top: -16px;
+		width: auto;
+
 		.block-editor-link-control__search-item-title {
 			max-width: 180px;
 			margin-top: $grid-unit-20;
 		}
+
 		.block-editor-link-control__search-item.is-current {
 			width: auto;
-			padding: $grid-unit-20;
+			padding: 0;
 		}
 	}
 }


### PR DESCRIPTION
## Description
Implementation of one of the variants in #18992 about always showing the URL of the current media in the media replace control.

## How has this been tested?
Tested locally.

## Screenshots <!-- if applicable -->

![media-replace-url](https://user-images.githubusercontent.com/107534/73757711-4f453180-4772-11ea-8090-242a13aa6b06.gif)



## Types of changes
Updated `MediaReplaceFlow` and `LinkViewer`.
This should eventually use the new `LinkControl` instead.

cc: @shaunandrews 
