### PR TITLE
Navigation Block: Rename the LinkControl's edit button title

### DIFF
--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -208,7 +208,7 @@ function LinkControl( {
 								</span>
 
 								<Button isSecondary onClick={ setMode( MODE_EDIT ) } className="block-editor-link-control__search-item-action block-editor-link-control__search-item-action--edit">
-									{ __( 'Change' ) }
+									{ __( 'Edit' ) }
 								</Button>
 							</div>
 						</Fragment>

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -337,7 +337,7 @@ describe( 'Selecting links', () => {
 
 		expect( currentLinkHTML ).toEqual( expect.stringContaining( selectedLink.title ) );
 		expect( currentLinkHTML ).toEqual( expect.stringContaining( selectedLink.type ) );
-		expect( currentLinkHTML ).toEqual( expect.stringContaining( 'Change' ) );
+		expect( currentLinkHTML ).toEqual( expect.stringContaining( 'Edit' ) );
 		expect( currentLinkAnchor ).not.toBeNull();
 	} );
 
@@ -435,7 +435,7 @@ describe( 'Selecting links', () => {
 
 			// Check that this suggestion is now shown as selected
 			expect( currentLinkHTML ).toEqual( expect.stringContaining( selectedLink.title ) );
-			expect( currentLinkHTML ).toEqual( expect.stringContaining( 'Change' ) );
+			expect( currentLinkHTML ).toEqual( expect.stringContaining( 'Edit' ) );
 			expect( currentLinkAnchor ).not.toBeNull();
 		} );
 	} );
@@ -528,7 +528,7 @@ describe( 'Selecting links', () => {
 			const currentLinkAnchor = currentLink.querySelector( `[href="${ selectedLink.url }"]` );
 
 			expect( currentLinkHTML ).toEqual( expect.stringContaining( selectedLink.title ) );
-			expect( currentLinkHTML ).toEqual( expect.stringContaining( 'Change' ) );
+			expect( currentLinkHTML ).toEqual( expect.stringContaining( 'Edit' ) );
 			expect( currentLinkAnchor ).not.toBeNull();
 		} );
 	} );


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

Renamed the `LinkControl`'s "Change" button title to "Edit".

## Screenshots <!-- if applicable -->

Before:
<img width="513" alt="Screenshot 2020-01-08 12 17 47" src="https://user-images.githubusercontent.com/1451471/71974096-ec16bc80-3210-11ea-96bc-7db5e9bc675e.png">

After:
<img width="521" alt="Screenshot 2020-01-08 12 09 07" src="https://user-images.githubusercontent.com/1451471/71973990-a659f400-3210-11ea-827e-2683f294c541.png">

## Checklist:
- [x] My code is tested.

Closes: #18321