### PR TITLE
Navigation Block: Define allowedFormats option for NavigationLink

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -155,6 +155,12 @@ function NavigationLinkEdit( {
 						onChange={ ( labelValue ) => setAttributes( { label: labelValue } ) }
 						placeholder={ itemLabelPlaceholder }
 						withoutInteractiveFormatting
+						allowedFormats={ [
+							'core/bold',
+							'core/italic',
+							'core/image',
+							'core/strikethrough',
+						] }
 					/>
 					{ isLinkOpen && (
 						<LinkControl


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

Defines the `allowedFormats` prop for the `NavigationLink` component. As discussed in #18318, the `Inline Code` option will no longer be available.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Check formatting options for a navigation item - they should include only:
- `Bold`
- `Italic`
- `Inline image`
- `Strikethrough`

## Screenshots <!-- if applicable -->

![image](https://user-images.githubusercontent.com/1451471/71984071-6acb2400-3228-11ea-9476-9ca8fcf9a47c.png)

## Types of changes
Non-breaking change. If the `Inline code` formatting was used for nav item before it will still render as inline code in both editor and view, but the option will no longer be available.

Closes: #18318