### PR TITLE
Navigation: Description for the Link Settings Description  in the Link Block settings

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -108,6 +108,7 @@ function NavigationLinkEdit( {
 							setAttributes( { description: descriptionValue } );
 						} }
 						label={ __( 'Description' ) }
+						help={ __( 'The description will be displayed in the menu if the current theme supports it.' ) }
 					/>
 				</PanelBody>
 				<PanelBody


### PR DESCRIPTION
## Description
In the navigation menu item block, I've added a description for the description textarea. Closes https://github.com/WordPress/gutenberg/issues/18334

## How has this been tested?
Manually, by looking at a menu item in the navigation block, then going to its Block settings sidebar -> Link Settings. 

I'm not familiar with all the naming of the components yet, so sorry for being overly wordy here :)

## Screenshots

<img width="284" alt="Navigation Block menu item Link Settings description" src="https://user-images.githubusercontent.com/967608/71999132-786fb200-3206-11ea-9532-cb9b0054cd18.png">


## Types of changes
Bug fix/Update (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->

