### PR TITLE
Fix alignment on left border between menu navigation controls and menu item

### DIFF
--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -79,7 +79,7 @@
 
 [data-type="core/navigation-link"] {
 	.block-editor-block-toolbar {
-		left: 15px;
+		left: $block-padding;
 	}
 }
 


### PR DESCRIPTION
Closes https://github.com/WordPress/gutenberg/issues/19510



## Description
I added 1px to the left alignment on the psuedo element that controls the left border on the menu item.

This was the best way I could see to fix this. Nothing else indicated a good option for adjusting spacing, and this should not affect the positioning of any other blocks or increase the CSS file size substantially (two added characters). 

I did not need to add any additional selectors or CSS (just changed a number that already existed in the CSS).

## How has this been tested?
Manually, via Chrome. I need to test additionally in more browsers.

## Screenshots
**Before**
<img width="258" alt="Left alignment off between block control and block" src="https://user-images.githubusercontent.com/967608/72001983-3184bb00-320c-11ea-9112-5952b9577ae0.png">

**After**
<img width="592" alt="Screen Shot 2020-01-08 at 11 20 44 AM" src="https://user-images.githubusercontent.com/967608/72002031-45c8b800-320c-11ea-9981-207f2e551c4d.png">

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
