### PR TITLE
Block Library: Avoid column width auto-adjustment when sibling width changes

### DIFF
--- a/packages/block-library/src/column/edit.js
+++ b/packages/block-library/src/column/edit.js
@@ -48,6 +48,7 @@ function ColumnEdit( {
 						} }
 						min={ 0 }
 						max={ 100 }
+						step={ 0.1 }
 						required
 						allowReset
 					/>

--- a/packages/block-library/src/column/edit.js
+++ b/packages/block-library/src/column/edit.js
@@ -51,6 +51,9 @@ function ColumnEdit( {
 						step={ 0.1 }
 						required
 						allowReset
+						placeholder={
+							width === undefined ? __( 'Auto' ) : undefined
+						}
 					/>
 				</PanelBody>
 			</InspectorControls>

--- a/packages/block-library/src/column/edit.js
+++ b/packages/block-library/src/column/edit.js
@@ -12,20 +12,10 @@ import {
 	BlockVerticalAlignmentToolbar,
 	InspectorControls,
 } from '@wordpress/block-editor';
-import {
-	PanelBody,
-	RangeControl,
-	RadioControl,
-	Notice,
-} from '@wordpress/components';
+import { PanelBody, RangeControl, Notice } from '@wordpress/components';
 import { withDispatch, withSelect, useSelect } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 import { __, sprintf } from '@wordpress/i18n';
-
-/**
- * Internal dependencies
- */
-import { toWidthPrecision } from '../columns/utils';
 
 /**
  * Component which renders a notice if the sum total width of columns of the
@@ -83,10 +73,8 @@ function ColumnEdit( {
 	className,
 	updateAlignment,
 	hasChildBlocks,
-	totalColumns,
 } ) {
 	const { verticalAlignment, width } = attributes;
-	const hasExplicitWidth = width !== undefined;
 
 	const classes = classnames( className, 'block-core-columns', {
 		[ `is-vertically-aligned-${ verticalAlignment }` ]: verticalAlignment,
@@ -102,46 +90,19 @@ function ColumnEdit( {
 			</BlockControls>
 			<InspectorControls>
 				<PanelBody title={ __( 'Column settings' ) }>
-					<RadioControl
-						label={ __( 'Width' ) }
-						selected={ hasExplicitWidth ? 'manual' : 'auto' }
-						options={ [
-							{
-								label: __(
-									'Automatically adjust to occupy available space'
-								),
-								value: 'auto',
-							},
-							{
-								label: __( 'Manual width' ),
-								value: 'manual',
-							},
-						] }
-						onChange={ ( nextValue ) => {
-							setAttributes( {
-								width:
-									nextValue === 'manual'
-										? toWidthPrecision( 100 / totalColumns )
-										: undefined,
-							} );
+					<RangeControl
+						label={ __( 'Percentage width' ) }
+						value={ width || '' }
+						onChange={ ( nextWidth ) => {
+							setAttributes( { width: nextWidth } );
 						} }
+						min={ 0 }
+						max={ 100 }
+						step={ 0.1 }
+						required
+						allowReset
 					/>
-					{ hasExplicitWidth && (
-						<>
-							<RangeControl
-								label={ __( 'Percentage width' ) }
-								value={ width }
-								onChange={ ( nextWidth ) => {
-									setAttributes( { width: nextWidth } );
-								} }
-								min={ 0 }
-								max={ 100 }
-								step={ 0.1 }
-								required
-							/>
-							<InvalidWidthNotice clientId={ clientId } />
-						</>
-					) }
+					<InvalidWidthNotice clientId={ clientId } />
 				</PanelBody>
 			</InspectorControls>
 			<InnerBlocks
@@ -159,14 +120,10 @@ function ColumnEdit( {
 export default compose(
 	withSelect( ( select, ownProps ) => {
 		const { clientId } = ownProps;
-		const { getBlockOrder, getBlockRootClientId } = select(
-			'core/block-editor'
-		);
+		const { getBlockOrder } = select( 'core/block-editor' );
 
 		return {
 			hasChildBlocks: getBlockOrder( clientId ).length > 0,
-			totalColumns: getBlockOrder( getBlockRootClientId( clientId ) )
-				.length,
 		};
 	} ),
 	withDispatch( ( dispatch, ownProps, registry ) => {

--- a/packages/block-library/src/column/edit.js
+++ b/packages/block-library/src/column/edit.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { forEach, find, difference } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -18,22 +17,11 @@ import { withDispatch, withSelect } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 
-/**
- * Internal dependencies
- */
-import {
-	toWidthPrecision,
-	getTotalColumnsWidth,
-	getColumnWidths,
-	getAdjacentBlocks,
-	getRedistributedColumnWidths,
-} from '../columns/utils';
-
 function ColumnEdit( {
 	attributes,
+	setAttributes,
 	className,
 	updateAlignment,
-	updateWidth,
 	hasChildBlocks,
 } ) {
 	const { verticalAlignment, width } = attributes;
@@ -55,7 +43,9 @@ function ColumnEdit( {
 					<RangeControl
 						label={ __( 'Percentage width' ) }
 						value={ width || '' }
-						onChange={ updateWidth }
+						onChange={ ( nextWidth ) => {
+							setAttributes( { width: nextWidth } );
+						} }
 						min={ 0 }
 						max={ 100 }
 						required
@@ -103,54 +93,6 @@ export default compose(
 				updateBlockAttributes( rootClientId, {
 					verticalAlignment: null,
 				} );
-			},
-			updateWidth( width ) {
-				const { clientId } = ownProps;
-				const { updateBlockAttributes } = dispatch(
-					'core/block-editor'
-				);
-				const { getBlockRootClientId, getBlocks } = registry.select(
-					'core/block-editor'
-				);
-
-				// Constrain or expand siblings to account for gain or loss of
-				// total columns area.
-				const columns = getBlocks( getBlockRootClientId( clientId ) );
-				const adjacentColumns = getAdjacentBlocks( columns, clientId );
-
-				// The occupied width is calculated as the sum of the new width
-				// and the total width of blocks _not_ in the adjacent set.
-				const occupiedWidth =
-					width +
-					getTotalColumnsWidth(
-						difference( columns, [
-							find( columns, { clientId } ),
-							...adjacentColumns,
-						] )
-					);
-
-				// Compute _all_ next column widths, in case the updated column
-				// is in the middle of a set of columns which don't yet have
-				// any explicit widths assigned (include updates to those not
-				// part of the adjacent blocks).
-				const nextColumnWidths = {
-					...getColumnWidths( columns, columns.length ),
-					[ clientId ]: toWidthPrecision( width ),
-					...getRedistributedColumnWidths(
-						adjacentColumns,
-						100 - occupiedWidth,
-						columns.length
-					),
-				};
-
-				forEach(
-					nextColumnWidths,
-					( nextColumnWidth, columnClientId ) => {
-						updateBlockAttributes( columnClientId, {
-							width: nextColumnWidth,
-						} );
-					}
-				);
 			},
 		};
 	} )

--- a/packages/block-library/src/column/edit.js
+++ b/packages/block-library/src/column/edit.js
@@ -12,62 +12,12 @@ import {
 	BlockVerticalAlignmentToolbar,
 	InspectorControls,
 } from '@wordpress/block-editor';
-import { PanelBody, RangeControl, Notice } from '@wordpress/components';
-import { withDispatch, withSelect, useSelect } from '@wordpress/data';
+import { PanelBody, RangeControl } from '@wordpress/components';
+import { withDispatch, withSelect } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
-import { __, sprintf } from '@wordpress/i18n';
-
-/**
- * Component which renders a notice if the sum total width of columns of the
- * root block (the Columns parent) are all explicitly assigned and not equal
- * to 100%.
- *
- * @param {Object} props          Component props.
- * @param {string} props.clientId Client ID of the selected column.
- *
- * @return {WPElement?} Notice element, if invalid.
- */
-function InvalidWidthNotice( { clientId } ) {
-	const sumWidth = useSelect(
-		( select ) => {
-			const {
-				getBlockOrder,
-				getBlockAttributes,
-				getBlockRootClientId,
-			} = select( 'core/block-editor' );
-
-			const columns = getBlockOrder( getBlockRootClientId( clientId ) );
-			return columns.reduce(
-				( result, columnClientId ) =>
-					result + getBlockAttributes( columnClientId ).width,
-				0
-			);
-		},
-		[ clientId ]
-	);
-
-	// A value of `NaN` is anticipated when any of the columns do not have an
-	// explicit width assigned, since `result + undefined` in the `Array#reduce`
-	// above would taint the numeric result (intended and leveraged here). Round
-	// sum to allow some tolerance +/- 0.5%, which also ensures that the notice
-	// message would never display "100%" as an invalid width if e.g. 100.4%
-	// sum total width.
-	if ( isNaN( sumWidth ) || Math.round( sumWidth ) === 100 ) {
-		return null;
-	}
-
-	return (
-		<Notice status="warning" isDismissible={ false }>
-			{ sprintf(
-				__( 'The total width of columns (%d%%) does not equal 100%%.' ),
-				Math.round( sumWidth )
-			) }
-		</Notice>
-	);
-}
+import { __ } from '@wordpress/i18n';
 
 function ColumnEdit( {
-	clientId,
 	attributes,
 	setAttributes,
 	className,
@@ -102,7 +52,6 @@ function ColumnEdit( {
 						required
 						allowReset
 					/>
-					<InvalidWidthNotice clientId={ clientId } />
 				</PanelBody>
 			</InspectorControls>
 			<InnerBlocks

--- a/packages/block-library/src/column/index.js
+++ b/packages/block-library/src/column/index.js
@@ -32,6 +32,7 @@ export const settings = {
 				style: {
 					flexBasis: width + '%',
 				},
+				'data-has-explicit-width': true,
 			};
 		}
 	},

--- a/packages/block-library/src/columns/editor.scss
+++ b/packages/block-library/src/columns/editor.scss
@@ -66,10 +66,18 @@
 			// Responsiveness: Show at most one columns on mobile.
 			flex-basis: 100%;
 
-			// Beyond mobile, allow 2 columns.
 			@include break-small() {
-				flex-basis: calc(50% - (#{$grid-size-large}));
-				flex-grow: 0;
+				flex-grow: 1;
+				flex-basis: auto;
+
+				// Beyond mobile, allow columns. Columns with an explicitly-
+				// assigned width should maintain their `flex-basis` width and
+				// not grow. All other blocks should automatically inherit the
+				// `flex-grow` to occupy the available space.
+				&[data-has-explicit-width] {
+					flex-grow: 0;
+				}
+
 				margin-left: 0;
 				margin-right: 0;
 			}

--- a/packages/block-library/src/columns/style.scss
+++ b/packages/block-library/src/columns/style.scss
@@ -32,9 +32,13 @@
 
 	@include break-small() {
 
-		// Beyond mobile, allow 2 columns.
-		flex-basis: calc(50% - #{$grid-size-large});
-		flex-grow: 0;
+		// Beyond mobile, allow columns. Columns with an explicitly-assigned
+		// width should maintain their `flex-basis` width and not grow. All
+		// other blocks should automatically inherit the `flex-grow` to occupy
+		// the available space.
+		&[style] {
+			flex-grow: 0;
+		}
 
 		// Add space between the multiple columns. Themes can customize this if they wish to work differently.
 		// Only apply this beyond the mobile breakpoint, as there's only a single column on mobile.

--- a/packages/block-library/src/columns/test/utils.js
+++ b/packages/block-library/src/columns/test/utils.js
@@ -3,7 +3,6 @@
  */
 import {
 	toWidthPrecision,
-	getAdjacentBlocks,
 	getEffectiveColumnWidth,
 	getTotalColumnsWidth,
 	getColumnWidths,
@@ -22,25 +21,6 @@ describe( 'toWidthPrecision', () => {
 	it( 'should return undefined for invalid number', () => {
 		expect( toWidthPrecision( null ) ).toBe( undefined );
 		expect( toWidthPrecision( undefined ) ).toBe( undefined );
-	} );
-} );
-
-describe( 'getAdjacentBlocks', () => {
-	const blockA = { clientId: 'a' };
-	const blockB = { clientId: 'b' };
-	const blockC = { clientId: 'c' };
-	const blocks = [ blockA, blockB, blockC ];
-
-	it( 'should return blocks after clientId', () => {
-		const result = getAdjacentBlocks( blocks, 'b' );
-
-		expect( result ).toEqual( [ blockC ] );
-	} );
-
-	it( 'should return blocks before clientId if clientId is last', () => {
-		const result = getAdjacentBlocks( blocks, 'c' );
-
-		expect( result ).toEqual( [ blockA, blockB ] );
 	} );
 } );
 

--- a/packages/block-library/src/columns/test/utils.js
+++ b/packages/block-library/src/columns/test/utils.js
@@ -166,7 +166,29 @@ describe( 'hasExplicitColumnWidths', () => {
 	} );
 
 	it( 'returns true if a block has explicit width', () => {
-		const blocks = [ { attributes: { width: 10 } } ];
+		const blocks = [ { attributes: { width: 100 } } ];
+
+		const result = hasExplicitColumnWidths( blocks );
+
+		expect( result ).toBe( true );
+	} );
+
+	it( 'returns false if some, not all blocks have explicit width', () => {
+		const blocks = [
+			{ attributes: { width: 10 } },
+			{ attributes: { width: undefined } },
+		];
+
+		const result = hasExplicitColumnWidths( blocks );
+
+		expect( result ).toBe( false );
+	} );
+
+	it( 'returns true if all blocks have explicit width', () => {
+		const blocks = [
+			{ attributes: { width: 10 } },
+			{ attributes: { width: 90 } },
+		];
 
 		const result = hasExplicitColumnWidths( blocks );
 

--- a/packages/block-library/src/columns/utils.js
+++ b/packages/block-library/src/columns/utils.js
@@ -97,7 +97,7 @@ export function getRedistributedColumnWidths(
  * @return {boolean} Whether columns have explicit widths.
  */
 export function hasExplicitColumnWidths( blocks ) {
-	return blocks.some( ( block ) =>
+	return blocks.every( ( block ) =>
 		Number.isFinite( block.attributes.width )
 	);
 }

--- a/packages/block-library/src/columns/utils.js
+++ b/packages/block-library/src/columns/utils.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { findIndex, sumBy, merge, mapValues } from 'lodash';
+import { sumBy, merge, mapValues } from 'lodash';
 
 /**
  * Returns a column width attribute value rounded to standard precision.
@@ -13,24 +13,6 @@ import { findIndex, sumBy, merge, mapValues } from 'lodash';
  */
 export const toWidthPrecision = ( value ) =>
 	Number.isFinite( value ) ? parseFloat( value.toFixed( 2 ) ) : undefined;
-
-/**
- * Returns the considered adjacent to that of the specified `clientId` for
- * resizing consideration. Adjacent blocks are those occurring after, except
- * when the given block is the last block in the set. For the last block, the
- * behavior is reversed.
- *
- * @param {WPBlock[]} blocks   Block objects.
- * @param {string}    clientId Client ID to consider for adjacent blocks.
- *
- * @return {WPBlock[]} Adjacent block objects.
- */
-export function getAdjacentBlocks( blocks, clientId ) {
-	const index = findIndex( blocks, { clientId } );
-	const isLastBlock = index === blocks.length - 1;
-
-	return isLastBlock ? blocks.slice( 0, index ) : blocks.slice( index + 1 );
-}
 
 /**
  * Returns an effective width for a given block. An effective width is equal to

--- a/packages/edit-post/src/components/sidebar/style.scss
+++ b/packages/edit-post/src/components/sidebar/style.scss
@@ -48,11 +48,6 @@
 		}
 	}
 
-	> .components-panel .components-notice {
-		margin-left: 0;
-		margin-right: 0;
-	}
-
 	p {
 		margin-top: 0;
 	}

--- a/packages/edit-post/src/components/sidebar/style.scss
+++ b/packages/edit-post/src/components/sidebar/style.scss
@@ -48,6 +48,11 @@
 		}
 	}
 
+	> .components-panel .components-notice {
+		margin-left: 0;
+		margin-right: 0;
+	}
+
 	p {
 		margin-top: 0;
 	}


### PR DESCRIPTION
Partially addresses #16370

This pull request seeks to remove auto-adjustment of column widths when updating the width of another column. The intention is to remedy current confusion which can occur when trying to set each column to a specific width, where currently the auto-adjustment can yield an unexpected behavior. With these changes, the auto-adjustment behavior still exists to reallocate space when adding or removing a column from the Columns wrapper block, but specific width updates to individual columns should no longer have any side effects.

This also means there is no longer a guarantee that the sum total of widths of the columns are necessarily equal to 100%. In some cases, this can yield some benefit. For example, it is now fairly simple to create a set of columns which only occupy a fraction of the available space. Additionally, given that columns are not assigned with an explicit width, it allows for columns which are not assigned an explicit width to grow to occupy the available space, rather than forcefully being assigned an explicit width value.

To this last point, this can potentially cause some confusion of its own, since when adjusting the width of a column, you may still observe that the other columns grow or shrink automatically, but only because they are not (yet) assigned with an explicit width, and thus adjust themselves flexibly.

In the discussion of #16370, it was mentioned to consider including a warning notice when the columns were set to widths which did not sum to 100%. This has not yet been implemented in this branch. It could be included here, or as part of a separate pull request, or not at all (depending on feedback to the usability of the proposed changes).

**Testing Instructions:**

Repeat scenarios from #16370, #19112, or #17918, observing whether you encounter any challenges.