### PR TITLE
RNMobile: Consolidate logic hiding blocks from release builds to one location

### DIFF
--- a/packages/block-library/src/index.native.js
+++ b/packages/block-library/src/index.native.js
@@ -118,6 +118,10 @@ const registerBlock = ( block ) => {
 	} );
 };
 
+// only enable code block for development
+// eslint-disable-next-line no-undef
+const devOnly = ( block ) => !! __DEV__ ? block : null;
+
 /**
  * Function to register core blocks provided by the block editor.
  *
@@ -132,7 +136,7 @@ export const registerCoreBlocks = () => {
 	[
 		paragraph,
 		heading,
-		code,
+		devOnly( code ),
 		missing,
 		more,
 		image,
@@ -144,8 +148,7 @@ export const registerCoreBlocks = () => {
 		mediaText,
 		preformatted,
 		gallery,
-		// eslint-disable-next-line no-undef
-		!! __DEV__ ? group : null,
+		devOnly( group ),
 		spacer,
 	].forEach( registerBlock );
 

--- a/packages/edit-post/src/index.native.js
+++ b/packages/edit-post/src/index.native.js
@@ -7,7 +7,6 @@ import '@wordpress/editor';
 import '@wordpress/viewport';
 import '@wordpress/notices';
 import { registerCoreBlocks } from '@wordpress/block-library';
-import { unregisterBlockType } from '@wordpress/blocks';
 import '@wordpress/format-library';
 
 /**
@@ -27,13 +26,6 @@ export function initializeEditor() {
 
 	// register and setup blocks
 	registerCoreBlocks();
-
-	// disable Code block for the release
-	// eslint-disable-next-line no-undef
-	if ( typeof __DEV__ === 'undefined' || ! __DEV__ ) {
-		unregisterBlockType( 'core/code' );
-	}
-
 	blocksRegistered = true;
 }
 


### PR DESCRIPTION
[related gutenberg-mobile PR](https://github.com/wordpress-mobile/gutenberg-mobile/pull/1763)

### Summary

The purpose of this PR is to address a bit of technical debt by consolidating our handling of restricting blocks to dev mode to a single location. Before this PR we registered the code block in all builds and later unregistered it if it was a release build, whereas the gallery block was never registered in release builds. This made it necessary to check two different locations to see whether a block was enabled for release builds. Now we take the same approach with both blocks and never register them if it is a release build.

### How has this been tested?
Verify that code and gallery blocks appear in development builds, but not in release builds.

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [X] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
