### PR TITLE
Decode HTML entities for publish link

### DIFF
--- a/packages/editor/src/components/post-publish-panel/postpublish.js
+++ b/packages/editor/src/components/post-publish-panel/postpublish.js
@@ -11,6 +11,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { Component, createRef } from '@wordpress/element';
 import { withSelect } from '@wordpress/data';
 import { safeDecodeURIComponent } from '@wordpress/url';
+import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
@@ -67,7 +68,7 @@ class PostPublishPanelPostpublish extends Component {
 		return (
 			<div className="post-publish-panel__postpublish">
 				<PanelBody className="post-publish-panel__postpublish-header">
-					<a ref={ this.postLink } href={ post.link }>{ post.title || __( '(no title)' ) }</a> { postPublishNonLinkHeader }
+					<a ref={ this.postLink } href={ post.link }>{ decodeEntities( post.title ) || __( '(no title)' ) }</a> { postPublishNonLinkHeader }
 				</PanelBody>
 				<PanelBody>
 					<p className="post-publish-panel__postpublish-subheader">


### PR DESCRIPTION
Follow up to https://github.com/WordPress/gutenberg/pull/19187, this PR decodes HTML entities in the post title on the publish panel.

Note the explicit use of `decodeEntities` vs lodash `unescape`. The `unescape` function does not handle leading zeros in HTML entities correctly and should be avoided.

| Before | After |
| ------------- | ------------- |
| <img width="821" alt="Screen Shot 2020-01-08 at 4 45 05 PM" src="https://user-images.githubusercontent.com/1270189/72022747-d5835c00-3236-11ea-969b-769d0b163f38.png"> | <img width="815" alt="Screen Shot 2020-01-08 at 4 45 40 PM" src="https://user-images.githubusercontent.com/1270189/72022695-b2f14300-3236-11ea-9169-1e24fb6118a1.png"> |

### Testing Instructions
- Create a new post and add a title that is an HTML entity like `'` or `&`
- Publish the post
- Verify in the pre-publish panel that the link is correct
