### PR TITLE
Keycodes: Add, enhance types

### DIFF
--- a/packages/keycodes/CHANGELOG.md
+++ b/packages/keycodes/CHANGELOG.md
@@ -2,11 +2,15 @@
 
 ## Unreleased
 
+### Enhancement
+
+-   Include TypeScript type declarations ([#19520](https://github.com/WordPress/gutenberg/pull/19520))
+
 ## 2.12.0 (2020-04-30)
 
 ### Bug Fixes
 
-- `isKeyboardEvent` now tests expected modifiers as an exclusive set, fixing an issue where additional modifiers would wrongly report as satisfying a test for a subset of those modifiers [#20733](https://github.com/WordPress/gutenberg/pull/20733).
+-   `isKeyboardEvent` now tests expected modifiers as an exclusive set, fixing an issue where additional modifiers would wrongly report as satisfying a test for a subset of those modifiers [#20733](https://github.com/WordPress/gutenberg/pull/20733).
 
 ## 2.0.5 (2018-11-21)
 
@@ -18,4 +22,4 @@
 
 ### Breaking Change
 
-- Change how required built-ins are polyfilled with Babel 7 ([#9171](https://github.com/WordPress/gutenberg/pull/9171)). If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods.
+-   Change how required built-ins are polyfilled with Babel 7 ([#9171](https://github.com/WordPress/gutenberg/pull/9171)). If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods.

--- a/packages/keycodes/README.md
+++ b/packages/keycodes/README.md
@@ -42,6 +42,10 @@ onKeyDown( event ) {
 
 Keycode for ALT key.
 
+_Type_
+
+-   `WPModifierPart` 
+
 <a name="BACKSPACE" href="#BACKSPACE">#</a> **BACKSPACE**
 
 Keycode for BACKSPACE key.
@@ -50,9 +54,17 @@ Keycode for BACKSPACE key.
 
 Keycode for COMMAND/META key.
 
+_Type_
+
+-   `WPModifierPart` 
+
 <a name="CTRL" href="#CTRL">#</a> **CTRL**
 
 Keycode for CTRL key.
+
+_Type_
+
+-   `WPModifierPart` 
 
 <a name="DELETE" href="#DELETE">#</a> **DELETE**
 
@@ -61,20 +73,30 @@ Keycode for DELETE key.
 <a name="displayShortcut" href="#displayShortcut">#</a> **displayShortcut**
 
 An object that contains functions to display shortcuts.
-E.g. displayShortcut.primary( 'm' ) will return '⌘M' on Mac.
+
+_Usage_
+
+    // Assuming macOS:
+    E.g. displayShortcut.primary( 'm' );
+    // "⌘M"
 
 _Type_
 
--   `WPKeycodeHandlerByModifier` Keyed map of functions to display shortcuts.
+-   `WPModifierHandler<WPKeyHandler<string>>` Keyed map of functions to display shortcuts.
 
 <a name="displayShortcutList" href="#displayShortcutList">#</a> **displayShortcutList**
 
-Return an array of the parts of a keyboard shortcut chord for display
-E.g displayShortcutList.primary( 'm' ) will return [ '⌘', 'M' ] on Mac.
+Return an array of the parts of a keyboard shortcut chord for display.
+
+_Usage_
+
+    // Assuming macOS:
+    displayShortcutList.primary( 'm' );
+    // [ "⌘", "M" ]
 
 _Type_
 
--   `WPKeycodeHandlerByModifier` Keyed map of functions to shortcut sequences.
+-   `WPModifierHandler<WPKeyHandler<Array<string>>>` Keyed map of functions to shortcut sequences.
 
 <a name="DOWN" href="#DOWN">#</a> **DOWN**
 
@@ -96,12 +118,16 @@ Keycode for F10 key.
 
 An object that contains functions to check if a keyboard event matches a
 predefined shortcut combination.
-E.g. isKeyboardEvent.primary( event, 'm' ) will return true if the event
-signals pressing ⌘M.
+
+_Usage_
+
+    // Assuming an event for ⌘M key press:
+    isKeyboardEvent.primary( event, 'm' );
+    // true
 
 _Type_
 
--   `WPKeycodeHandlerByModifier` Keyed map of functions to match events.
+-   `WPModifierHandler<WPEventKeyHandler<boolean>>` Keyed map of functions to match events.
 
 <a name="LEFT" href="#LEFT">#</a> **LEFT**
 
@@ -112,26 +138,25 @@ Keycode for LEFT key.
 Object that contains functions that return the available modifier
 depending on platform.
 
--   `primary`: takes a isApple function as a parameter.
--   `primaryShift`: takes a isApple function as a parameter.
--   `primaryAlt`: takes a isApple function as a parameter.
--   `secondary`: takes a isApple function as a parameter.
--   `access`: takes a isApple function as a parameter.
--   `ctrl`
--   `alt`
--   `ctrlShift`
--   `shift`
--   `shiftAlt`
+_Type_
+
+-   `null` 
 
 <a name="rawShortcut" href="#rawShortcut">#</a> **rawShortcut**
 
 An object that contains functions to get raw shortcuts.
-E.g. rawShortcut.primary( 'm' ) will return 'meta+m' on Mac.
-These are intended for user with the KeyboardShortcuts component or TinyMCE.
+
+These are intended for user with the KeyboardShortcuts.
+
+_Usage_
+
+    // Assuming macOS:
+    rawShortcut.primary( 'm' )
+    // "meta+m""
 
 _Type_
 
--   `WPKeycodeHandlerByModifier` Keyed map of functions to raw shortcuts.
+-   `WPModifierHandler<WPKeyHandler<string>>` Keyed map of functions to raw shortcuts.
 
 <a name="RIGHT" href="#RIGHT">#</a> **RIGHT**
 
@@ -141,14 +166,24 @@ Keycode for RIGHT key.
 
 Keycode for SHIFT key.
 
+_Type_
+
+-   `WPModifierPart` 
+
 <a name="shortcutAriaLabel" href="#shortcutAriaLabel">#</a> **shortcutAriaLabel**
 
-An object that contains functions to return an aria label for a keyboard shortcut.
-E.g. shortcutAriaLabel.primary( '.' ) will return 'Command + Period' on Mac.
+An object that contains functions to return an aria label for a keyboard
+shortcut.
+
+_Usage_
+
+    // Assuming macOS:
+    shortcutAriaLabel.primary( '.' );
+    // "Command + Period"
 
 _Type_
 
--   `WPKeycodeHandlerByModifier` Keyed map of functions to shortcut ARIA labels.
+-   `WPModifierHandler<WPKeyHandler<string>>` Keyed map of functions to shortcut ARIA labels.
 
 <a name="SPACE" href="#SPACE">#</a> **SPACE**
 

--- a/packages/keycodes/README.md
+++ b/packages/keycodes/README.md
@@ -42,10 +42,6 @@ onKeyDown( event ) {
 
 Keycode for ALT key.
 
-_Type_
-
--   `WPModifierPart` 
-
 <a name="BACKSPACE" href="#BACKSPACE">#</a> **BACKSPACE**
 
 Keycode for BACKSPACE key.
@@ -54,17 +50,9 @@ Keycode for BACKSPACE key.
 
 Keycode for COMMAND/META key.
 
-_Type_
-
--   `WPModifierPart` 
-
 <a name="CTRL" href="#CTRL">#</a> **CTRL**
 
 Keycode for CTRL key.
-
-_Type_
-
--   `WPModifierPart` 
 
 <a name="DELETE" href="#DELETE">#</a> **DELETE**
 
@@ -140,7 +128,7 @@ depending on platform.
 
 _Type_
 
--   `null` 
+-   (unknown type) 
 
 <a name="rawShortcut" href="#rawShortcut">#</a> **rawShortcut**
 
@@ -165,10 +153,6 @@ Keycode for RIGHT key.
 <a name="SHIFT" href="#SHIFT">#</a> **SHIFT**
 
 Keycode for SHIFT key.
-
-_Type_
-
--   `WPModifierPart` 
 
 <a name="shortcutAriaLabel" href="#shortcutAriaLabel">#</a> **shortcutAriaLabel**
 

--- a/packages/keycodes/README.md
+++ b/packages/keycodes/README.md
@@ -64,9 +64,11 @@ An object that contains functions to display shortcuts.
 
 _Usage_
 
-    // Assuming macOS:
-    E.g. displayShortcut.primary( 'm' );
-    // "⌘M"
+```js
+// Assuming macOS:
+displayShortcut.primary( 'm' );
+// "⌘M"
+```
 
 _Type_
 
@@ -78,9 +80,11 @@ Return an array of the parts of a keyboard shortcut chord for display.
 
 _Usage_
 
-    // Assuming macOS:
-    displayShortcutList.primary( 'm' );
-    // [ "⌘", "M" ]
+```js
+// Assuming macOS:
+displayShortcutList.primary( 'm' );
+// [ "⌘", "M" ]
+```
 
 _Type_
 
@@ -109,9 +113,11 @@ predefined shortcut combination.
 
 _Usage_
 
-    // Assuming an event for ⌘M key press:
-    isKeyboardEvent.primary( event, 'm' );
-    // true
+```js
+// Assuming an event for ⌘M key press:
+isKeyboardEvent.primary( event, 'm' );
+// true
+```
 
 _Type_
 
@@ -138,9 +144,11 @@ These are intended for user with the KeyboardShortcuts.
 
 _Usage_
 
-    // Assuming macOS:
-    rawShortcut.primary( 'm' )
-    // "meta+m""
+```js
+// Assuming macOS:
+rawShortcut.primary( 'm' )
+// "meta+m""
+```
 
 _Type_
 
@@ -161,9 +169,11 @@ shortcut.
 
 _Usage_
 
-    // Assuming macOS:
-    shortcutAriaLabel.primary( '.' );
-    // "Command + Period"
+```js
+// Assuming macOS:
+shortcutAriaLabel.primary( '.' );
+// "Command + Period"
+```
 
 _Type_
 

--- a/packages/keycodes/README.md
+++ b/packages/keycodes/README.md
@@ -115,7 +115,7 @@ _Usage_
 
 _Type_
 
--   `WPModifierHandler<WPEventKeyHandler<boolean>>` Keyed map of functions to match events.
+-   `WPModifierHandler<WPEventKeyHandler>` Keyed map of functions to match events.
 
 <a name="LEFT" href="#LEFT">#</a> **LEFT**
 

--- a/packages/keycodes/package.json
+++ b/packages/keycodes/package.json
@@ -20,6 +20,7 @@
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",
+	"types": "build-types",
 	"react-native": "src/index",
 	"sideEffects": false,
 	"dependencies": {

--- a/packages/keycodes/package.json
+++ b/packages/keycodes/package.json
@@ -20,8 +20,8 @@
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",
-	"types": "build-types",
 	"react-native": "src/index",
+	"types": "build-types",
 	"sideEffects": false,
 	"dependencies": {
 		"@babel/runtime": "^7.12.5",

--- a/packages/keycodes/src/index.js
+++ b/packages/keycodes/src/index.js
@@ -24,9 +24,9 @@ import { __ } from '@wordpress/i18n';
  */
 import { isAppleOS } from './platform';
 
-/** @typedef {'alt'|'ctrl'|'meta'|'shift'} WPModifierPart */
+/** @typedef {'alt' | 'ctrl' | 'meta' | 'shift'} WPModifierPart */
 
-/** @typedef {'primary'|'primaryShift'|'primaryAlt'|'secondary'|'access'|'ctrl'|'alt'|'ctrlShift'|'shift'|'shiftAlt'} WPKeycodeModifier */
+/** @typedef {'primary' | 'primaryShift' | 'primaryAlt' | 'secondary' | 'access' | 'ctrl' | 'alt' | 'ctrlShift' | 'shift' | 'shiftAlt'} WPKeycodeModifier */
 
 /**
  * An object of handler functions for each of the possible modifier
@@ -34,20 +34,20 @@ import { isAppleOS } from './platform';
  *
  * @template T
  *
- * @typedef {Record<WPKeycodeModifier,T>} WPModifierHandler
+ * @typedef {Record<WPKeycodeModifier, T>} WPModifierHandler
  */
 
 /* eslint-disable jsdoc/valid-types */
 /**
  * @template T
  *
- * @typedef {(character:string,isApple?:()=>boolean)=>T} WPKeyHandler
+ * @typedef {(character: string, isApple?: () => boolean) => T} WPKeyHandler
  */
 
 /**
  * @template T
  *
- * @typedef {(event:KeyboardEvent,character:string,isApple?:()=>boolean)=>T} WPEventKeyHandler
+ * @typedef {(event: KeyboardEvent, character: string, isApple?: () => boolean) => T} WPEventKeyHandler
  */
 /* eslint-enable jsdoc/valid-types */
 
@@ -300,7 +300,7 @@ function getEventModifiers( event ) {
 	] ).filter(
 		( key ) =>
 			event[
-				/** @type {'altKey'|'ctrlKey'|'metaKey'|'shiftKey'} */ ( `${ key }Key` )
+				/** @type {'altKey' | 'ctrlKey' | 'metaKey' | 'shiftKey'} */ ( `${ key }Key` )
 			]
 	);
 }

--- a/packages/keycodes/src/index.js
+++ b/packages/keycodes/src/index.js
@@ -287,11 +287,19 @@ export const shortcutAriaLabel = mapValues( modifiers, ( modifier ) => {
  *
  * @param {KeyboardEvent} event Keyboard event.
  *
- * @return {Array<ALT|CTRL|COMMAND|SHIFT>} Active modifier constants.
+ * @return {Array<WPModifierPart>} Active modifier constants.
  */
 function getEventModifiers( event ) {
-	return [ ALT, CTRL, COMMAND, SHIFT ].filter(
-		( key ) => event[ `${ key }Key` ]
+	return /** @type {WPModifierPart[]} */ ( [
+		ALT,
+		CTRL,
+		COMMAND,
+		SHIFT,
+	] ).filter(
+		( key ) =>
+			event[
+				/** @type {'altKey'|'ctrlKey'|'metaKey'|'shiftKey'} */ ( `${ key }Key` )
+			]
 	);
 }
 

--- a/packages/keycodes/src/index.js
+++ b/packages/keycodes/src/index.js
@@ -34,9 +34,10 @@ import { isAppleOS } from './platform';
  *
  * @template T
  *
- * @typedef {{[M in WPKeycodeModifier]:T}} WPModifierHandler
+ * @typedef {Record<WPKeycodeModifier,T>} WPModifierHandler
  */
 
+/* eslint-disable jsdoc/valid-types */
 /**
  * @template T
  *
@@ -48,6 +49,7 @@ import { isAppleOS } from './platform';
  *
  * @typedef {(event:KeyboardEvent,character:string,isApple?:()=>boolean)=>T} WPEventKeyHandler
  */
+/* eslint-enable jsdoc/valid-types */
 
 /**
  * Keycode for BACKSPACE key.
@@ -133,7 +135,7 @@ export const ZERO = 48;
  * Object that contains functions that return the available modifier
  * depending on platform.
  *
- * @type {{[M in WPKeycodeModifier]:(isApple:()=>boolean)=>WPModifierPart[]}}
+ * @type {Record<WPKeycodeModifier, ( isApple: () => boolean ) => WPModifierPart[]>}
  */
 export const modifiers = {
 	primary: ( _isApple ) => ( _isApple() ? [ COMMAND ] : [ CTRL ] ),

--- a/packages/keycodes/src/index.js
+++ b/packages/keycodes/src/index.js
@@ -106,29 +106,21 @@ export const F10 = 121;
 
 /**
  * Keycode for ALT key.
- *
- * @type {WPModifierPart}
  */
 export const ALT = 'alt';
 
 /**
  * Keycode for CTRL key.
- *
- * @type {WPModifierPart}
  */
 export const CTRL = 'ctrl';
 
 /**
  * Keycode for COMMAND/META key.
- *
- * @type {WPModifierPart}
  */
 export const COMMAND = 'meta';
 
 /**
  * Keycode for SHIFT key.
- *
- * @type {WPModifierPart}
  */
 export const SHIFT = 'shift';
 

--- a/packages/keycodes/src/index.js
+++ b/packages/keycodes/src/index.js
@@ -130,7 +130,7 @@ export const ZERO = 48;
  * Object that contains functions that return the available modifier
  * depending on platform.
  *
- * @type {Record<WPKeycodeModifier, ( isApple: () => boolean ) => WPModifierPart[]>}
+ * @type {WPModifierHandler< ( isApple: () => boolean ) => WPModifierPart[]>}
  */
 export const modifiers = {
 	primary: ( _isApple ) => ( _isApple() ? [ COMMAND ] : [ CTRL ] ),

--- a/packages/keycodes/src/index.js
+++ b/packages/keycodes/src/index.js
@@ -24,7 +24,7 @@ import { __ } from '@wordpress/i18n';
  */
 import { isAppleOS } from './platform';
 
-/** @typedef {'alt' | 'ctrl' | 'meta' | 'shift'} WPModifierPart */
+/** @typedef {typeof ALT | CTRL | COMMAND | SHIFT } WPModifierPart */
 
 /** @typedef {'primary' | 'primaryShift' | 'primaryAlt' | 'secondary' | 'access' | 'ctrl' | 'alt' | 'ctrlShift' | 'shift' | 'shiftAlt'} WPKeycodeModifier */
 

--- a/packages/keycodes/src/index.js
+++ b/packages/keycodes/src/index.js
@@ -43,12 +43,7 @@ import { isAppleOS } from './platform';
  *
  * @typedef {(character: string, isApple?: () => boolean) => T} WPKeyHandler
  */
-
-/**
- * @template T
- *
- * @typedef {(event: KeyboardEvent, character: string, isApple?: () => boolean) => T} WPEventKeyHandler
- */
+/** @typedef {(event: KeyboardEvent, character: string, isApple?: () => boolean) => boolean} WPEventKeyHandler */
 /* eslint-enable jsdoc/valid-types */
 
 /**
@@ -316,11 +311,11 @@ function getEventModifiers( event ) {
  * // true
  * ```
  *
- * @type {WPModifierHandler<WPEventKeyHandler<boolean>>} Keyed map of functions
+ * @type {WPModifierHandler<WPEventKeyHandler>} Keyed map of functions
  *                                                       to match events.
  */
 export const isKeyboardEvent = mapValues( modifiers, ( getModifiers ) => {
-	return /** @type {WPEventKeyHandler<boolean>} */ (
+	return /** @type {WPEventKeyHandler} */ (
 		event,
 		character,
 		_isApple = isAppleOS

--- a/packages/keycodes/src/index.js
+++ b/packages/keycodes/src/index.js
@@ -154,7 +154,7 @@ export const modifiers = {
  * These are intended for user with the KeyboardShortcuts.
  *
  * @example
- * ```
+ * ```js
  * // Assuming macOS:
  * rawShortcut.primary( 'm' )
  * // "meta+m""
@@ -176,7 +176,7 @@ export const rawShortcut = mapValues( modifiers, ( modifier ) => {
  * Return an array of the parts of a keyboard shortcut chord for display.
  *
  * @example
- * ```
+ * ```js
  * // Assuming macOS:
  * displayShortcutList.primary( 'm' );
  * // [ "⌘", "M" ]
@@ -220,9 +220,9 @@ export const displayShortcutList = mapValues( modifiers, ( modifier ) => {
  * An object that contains functions to display shortcuts.
  *
  * @example
- * ```
+ * ```js
  * // Assuming macOS:
- * E.g. displayShortcut.primary( 'm' );
+ * displayShortcut.primary( 'm' );
  * // "⌘M"
  * ```
  *
@@ -244,7 +244,7 @@ export const displayShortcut = mapValues(
  * shortcut.
  *
  * @example
- * ```
+ * ```js
  * // Assuming macOS:
  * shortcutAriaLabel.primary( '.' );
  * // "Command + Period"
@@ -305,7 +305,7 @@ function getEventModifiers( event ) {
  * predefined shortcut combination.
  *
  * @example
- * ```
+ * ```js
  * // Assuming an event for ⌘M key press:
  * isKeyboardEvent.primary( event, 'm' );
  * // true

--- a/packages/keycodes/src/platform.js
+++ b/packages/keycodes/src/platform.js
@@ -6,9 +6,9 @@ import { includes } from 'lodash';
 /**
  * Return true if platform is MacOS.
  *
- * @param {Object} _window   window object by default; used for DI testing.
+ * @param {Window} _window window object by default; used for DI testing.
  *
- * @return {boolean}         True if MacOS; false otherwise.
+ * @return {boolean} True if MacOS; false otherwise.
  */
 export function isAppleOS( _window = window ) {
 	const { platform } = _window.navigator;

--- a/packages/keycodes/src/platform.native.js
+++ b/packages/keycodes/src/platform.native.js
@@ -6,7 +6,7 @@ import { Platform } from 'react-native';
 /**
  * Return true if platform is iOS.
  *
- * @return {boolean}         True if iOS; false otherwise.
+ * @return {boolean} True if iOS; false otherwise.
  */
 export function isAppleOS() {
 	return Platform.OS === 'ios';

--- a/packages/keycodes/tsconfig.json
+++ b/packages/keycodes/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"rootDir": "src",
+		"declarationDir": "build-types"
+	},
+	"references": [ { "path": "../i18n" } ],
+	"include": [ "src/**/*" ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
 		{ "path": "packages/i18n" },
 		{ "path": "packages/icons" },
 		{ "path": "packages/is-shallow-equal" },
+		{ "path": "packages/keycodes" },
 		{ "path": "packages/lazy-import" },
 		{ "path": "packages/prettier-config" },
 		{ "path": "packages/primitives" },


### PR DESCRIPTION
Part of: #18838

This pull request seeks to enable type checking for the `@wordpress/keycodes` package.

**Current Status:**

As we start to use more TypeScript-specific types, the ability to document these sufficiently is beginning to suffer, due to the fact that the current Doctrine parser cannot make sense of these types. The issue at #18045 tracks the ongoing effort to replace the (defunct) Doctrine project with an alternative implementation (which I've proposed to be the TypeScript parser). In the meantime, however, the generated documentation suffers. Worse than if it simply did not document the types at all, it documents them as the `null` type, which is flatly misleading. Therefore, I'd want to try to come to a solution to this problem before pushing forward with much more use of the custom TypeScript types.

**Testing Instructions:**

Verify no regressions in modified behavior:

```
npm run test-unit
```

Verify types checking passes:

```
npm run build:package-types 
```