### PR TITLE
Block Editor: Make initial inner blocks non-dirtying.

### DIFF
--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -41,6 +41,7 @@ class InnerBlocks extends Component {
 			templateLock,
 			__experimentalBlocks,
 			replaceInnerBlocks,
+			__unstableMarkNextChangeAsNotPersistent,
 		} = this.props;
 		const { innerBlocks } = block;
 		// Only synchronize innerBlocks with template if innerBlocks are empty or a locking all exists directly on the block.
@@ -56,6 +57,7 @@ class InnerBlocks extends Component {
 
 		// Set controlled blocks value from parent, if any.
 		if ( __experimentalBlocks ) {
+			__unstableMarkNextChangeAsNotPersistent();
 			replaceInnerBlocks( __experimentalBlocks );
 		}
 	}
@@ -184,6 +186,7 @@ InnerBlocks = compose( [
 	withDispatch( ( dispatch, ownProps ) => {
 		const {
 			replaceInnerBlocks,
+			__unstableMarkNextChangeAsNotPersistent,
 			updateBlockListSettings,
 		} = dispatch( 'core/block-editor' );
 		const { block, clientId, templateInsertUpdatesSelection = true } = ownProps;
@@ -198,6 +201,7 @@ InnerBlocks = compose( [
 						blocks.length !== 0
 				);
 			},
+			__unstableMarkNextChangeAsNotPersistent,
 			updateNestedSettings( settings ) {
 				dispatch( updateBlockListSettings( clientId, settings ) );
 			},

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -812,6 +812,15 @@ export function __unstableMarkLastChangeAsPersistent() {
 }
 
 /**
+ * Returns an action object used in signalling that the next block change should be marked explicitly as not persistent.
+ *
+ * @return {Object} Action object.
+ */
+export function __unstableMarkNextChangeAsNotPersistent() {
+	return { type: 'MARK_NEXT_CHANGE_AS_NOT_PERSISTENT' };
+}
+
+/**
  * Returns an action object used in signalling that the last block change is
  * an automatic change, meaning it was not performed by the user, and can be
  * undone using the `Escape` and `Backspace` keys. This action must be called

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -384,6 +384,7 @@ function withPersistentBlockChange( reducer ) {
 		// would have qualified as one which would have been ignored or not
 		// have resulted in a changed state.
 		lastAction = action;
+		markNextChangeAsNotPersistent = action.type === 'MARK_NEXT_CHANGE_AS_NOT_PERSISTENT';
 
 		return nextState;
 	};


### PR DESCRIPTION
Follows #19203

## Description

This PR makes the new experimental initial blocks value bootstrap added to `InnerBlocks` by #19203 a non-dirtying operation. Without this, any posts that have a block that uses it would be dirty upon opening.

## How has this been tested?

Posts with template parts are no longer dirty before making any changes.

## Types of Changes

*New Feature:* The `InnerBlocks` controlled mode no longer makes the post dirty before making any changes.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
