### PR TITLE
Block toolbar: rewrite toolbar forcing

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -435,45 +435,34 @@ function BlockListBlock( {
 					// Allow subpixel positioning for the block movement animation.
 					__unstableAllowVerticalSubpixelPosition={ moverDirection !== 'horizontal' && wrapper.current }
 					__unstableAllowHorizontalSubpixelPosition={ moverDirection === 'horizontal' && wrapper.current }
+					onBlur={ () => setIsToolbarForced( false ) }
 				>
-					<div
-						onFocus={ () => setIsToolbarForced( true ) }
-						onBlur={ () => setIsToolbarForced( false ) }
-						// While ideally it would be enough to capture the
-						// bubbling focus event from the Inserter, due to the
-						// characteristics of click focusing of `button`s in
-						// Firefox and Safari, it is not reliable.
-						//
-						// See: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Clicking_and_focus
-						tabIndex={ -1 }
-					>
-						{ ! hasAncestorCapturingToolbars && ( shouldShowContextualToolbar || isToolbarForced ) && renderBlockContextualToolbar() }
-						{ hasAncestorCapturingToolbars && ( shouldShowContextualToolbar || isToolbarForced ) && (
-							// If the parent Block is set to consume toolbars of the child Blocks
-							// then render the child Block's toolbar into the Slot provided
-							// by the parent.
-							<ChildToolbar>
-								{ renderBlockContextualToolbar() }
-							</ChildToolbar>
-						) }
-						{ shouldShowBreadcrumb && (
-							<BlockBreadcrumb
+					{ ! hasAncestorCapturingToolbars && ( shouldShowContextualToolbar || isToolbarForced ) && renderBlockContextualToolbar() }
+					{ hasAncestorCapturingToolbars && ( shouldShowContextualToolbar || isToolbarForced ) && (
+						// If the parent Block is set to consume toolbars of the child Blocks
+						// then render the child Block's toolbar into the Slot provided
+						// by the parent.
+						<ChildToolbar>
+							{ renderBlockContextualToolbar() }
+						</ChildToolbar>
+					) }
+					{ shouldShowBreadcrumb && (
+						<BlockBreadcrumb
+							clientId={ clientId }
+							ref={ breadcrumb }
+							data-align={ wrapperProps ? wrapperProps[ 'data-align' ] : undefined }
+						/>
+					) }
+					{ showEmptyBlockSideInserter && (
+						<div className="block-editor-block-list__empty-block-inserter">
+							<Inserter
+								position="top right"
+								onToggle={ selectOnOpen }
+								rootClientId={ rootClientId }
 								clientId={ clientId }
-								ref={ breadcrumb }
-								data-align={ wrapperProps ? wrapperProps[ 'data-align' ] : undefined }
 							/>
-						) }
-						{ showEmptyBlockSideInserter && (
-							<div className="block-editor-block-list__empty-block-inserter">
-								<Inserter
-									position="top right"
-									onToggle={ selectOnOpen }
-									rootClientId={ rootClientId }
-									clientId={ clientId }
-								/>
-							</div>
-						) }
-					</div>
+						</div>
+					) }
 				</Popover>
 			) }
 			<div


### PR DESCRIPTION
## Description

This PR adjusts the logic that forces the toolbar to show on `Alt+F10`. Instead of using a reference, I've swapped it out with state. The flag will automatically be set to false if focus leaves the toolbar.

Current comment:

> The forcing of contextual toolbar should only be true during one update,  after the first update normal conditions should apply.

This doesn't make much sense though. The toolbar should be forced for as long as focus remains inside it.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
