### PR TITLE
Adds a "(no title)" label to links to pages or posts with no title

### DIFF
--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -79,7 +79,7 @@
 
 [data-type="core/navigation-link"] {
 	.block-editor-block-toolbar {
-		left: 15px;
+		//left: 15px;
 	}
 }
 

--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -79,7 +79,7 @@
 
 [data-type="core/navigation-link"] {
 	.block-editor-block-toolbar {
-		//left: 15px;
+		left: 15px;
 	}
 }
 

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -71,18 +71,18 @@ function Navigation( {
 				return null;
 			}
 
-			return pages.map( ( { title, type, link: url, id } ) => (
-				createBlock( 'core/navigation-link',
+			return pages.map( ( { title, type, link: url, id } ) => {
+				return createBlock( 'core/navigation-link',
 					{
 						type,
 						id,
 						url,
-						label: escape( title.rendered ),
-						title: escape( title.raw ),
+						label: title.rendered === '' ? __( '(no title)' ) : escape( title.rendered ),
+						title: title.raw === '' ? __( '(no title)' ) : escape( title.raw ),
 						opensInNewTab: false,
 					}
-				)
-			) );
+				);
+			} );
 		},
 		[ pages ]
 	);

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -71,18 +71,18 @@ function Navigation( {
 				return null;
 			}
 
-			return pages.map( ( { title, type, link: url, id } ) => {
-				return createBlock( 'core/navigation-link',
+			return pages.map( ( { title, type, link: url, id } ) => (
+				createBlock( 'core/navigation-link',
 					{
 						type,
 						id,
 						url,
-						label: title.rendered === '' ? __( '(no title)' ) : escape( title.rendered ),
-						title: title.raw === '' ? __( '(no title)' ) : escape( title.raw ),
+						label: ! title.rendered ? __( '(no title)' ) : escape( title.rendered ),
+						title: ! title.raw ? __( '(no title)' ) : escape( title.raw ),
 						opensInNewTab: false,
 					}
-				);
-			} );
+				)
+			) );
 		},
 		[ pages ]
 	);


### PR DESCRIPTION
## Description
Closes: #18897

## How has this been tested?
Tested locally by:

- created a page with no title
- in a post inserted a navigation block
- chose create from existing pages

## Screenshots <!-- if applicable -->

![no-title](https://user-images.githubusercontent.com/107534/72072089-e3e47d00-32f5-11ea-9e7e-79e005395ae7.gif)



## Types of changes
Non breaking change to how default links are created in a navigation block.