### PR TITLE
Contain selection logic in useMultiSelection

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -123,19 +123,6 @@ function BlockListBlock( {
 	 * @param {boolean} ignoreInnerBlocks Should not focus inner blocks.
 	 */
 	const focusTabbable = ( ignoreInnerBlocks ) => {
-		const selection = window.getSelection();
-
-		if ( selection.rangeCount && ! selection.isCollapsed ) {
-			const { startContainer, endContainer } = selection.getRangeAt( 0 );
-
-			if (
-				! blockNodeRef.current.contains( startContainer ) ||
-				! blockNodeRef.current.contains( endContainer )
-			) {
-				selection.removeAllRanges();
-			}
-		}
-
 		// Focus is captured by the wrapper node, so while focus transition
 		// should only consider tabbables within editable display, since it
 		// may be the wrapper itself or a side control which triggered the

--- a/packages/block-editor/src/components/block-list/use-multi-selection.js
+++ b/packages/block-editor/src/components/block-list/use-multi-selection.js
@@ -42,6 +42,7 @@ function selector( select ) {
 		getMultiSelectedBlockClientIds,
 		hasMultiSelection,
 		getBlockParents,
+		getSelectedBlockClientId,
 	} = select( 'core/block-editor' );
 
 	return {
@@ -50,6 +51,7 @@ function selector( select ) {
 		multiSelectedBlockClientIds: getMultiSelectedBlockClientIds(),
 		hasMultiSelection: hasMultiSelection(),
 		getBlockParents,
+		selectedBlockClientId: getSelectedBlockClientId(),
 	};
 }
 
@@ -60,6 +62,7 @@ export default function useMultiSelection( ref ) {
 		multiSelectedBlockClientIds,
 		hasMultiSelection,
 		getBlockParents,
+		selectedBlockClientId,
 	} = useSelect( selector, [] );
 	const {
 		startMultiSelect,
@@ -76,6 +79,25 @@ export default function useMultiSelection( ref ) {
 	 */
 	useEffect( () => {
 		if ( ! hasMultiSelection || isMultiSelecting ) {
+			const selection = window.getSelection();
+
+			if ( selection.rangeCount && ! selection.isCollapsed ) {
+				const { startContainer, endContainer } = selection.getRangeAt( 0 );
+
+				if ( ! selectedBlockClientId ) {
+					return;
+				}
+
+				const blockNode = getBlockDOMNode( selectedBlockClientId );
+
+				if (
+					! blockNode.contains( startContainer ) ||
+					! blockNode.contains( endContainer )
+				) {
+					selection.removeAllRanges();
+				}
+			}
+
 			return;
 		}
 
@@ -110,6 +132,7 @@ export default function useMultiSelection( ref ) {
 		isMultiSelecting,
 		multiSelectedBlockClientIds,
 		selectBlock,
+		selectedBlockClientId,
 	] );
 
 	const onSelectionChange = useCallback( () => {

--- a/packages/block-editor/src/components/block-list/use-multi-selection.js
+++ b/packages/block-editor/src/components/block-list/use-multi-selection.js
@@ -79,16 +79,15 @@ export default function useMultiSelection( ref ) {
 	 */
 	useEffect( () => {
 		if ( ! hasMultiSelection || isMultiSelecting ) {
+			if ( ! selectedBlockClientId ) {
+				return;
+			}
+
 			const selection = window.getSelection();
 
 			if ( selection.rangeCount && ! selection.isCollapsed ) {
-				const { startContainer, endContainer } = selection.getRangeAt( 0 );
-
-				if ( ! selectedBlockClientId ) {
-					return;
-				}
-
 				const blockNode = getBlockDOMNode( selectedBlockClientId );
+				const { startContainer, endContainer } = selection.getRangeAt( 0 );
 
 				if (
 					! blockNode.contains( startContainer ) ||


### PR DESCRIPTION
## Description

This is another effort to keep multi selection logic contained. `useMultiSelection` should handle selection cleanup itself.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
