### PR TITLE
Block: Fix toolbar capturing

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -411,17 +411,20 @@ function BlockListBlock( {
 				clientId={ clientId }
 				rootClientId={ rootClientId }
 			/> }
-			{ ( isCapturingDescendantToolbars ) && (
-				// A slot made available on all ancestors of the selected Block
-				// to allow child Blocks to render their toolbars into the DOM
-				// of the appropriate parent.
-				<ChildToolbarSlot />
+			{ hasAncestorCapturingToolbars && ( shouldShowContextualToolbar || isToolbarForced ) && (
+				// If the parent Block is set to consume toolbars of the child Blocks
+				// then render the child Block's toolbar into the Slot provided
+				// by the parent.
+				<ChildToolbar>
+					{ renderBlockContextualToolbar() }
+				</ChildToolbar>
 			) }
 			{ (
 				shouldShowBreadcrumb ||
 				shouldShowContextualToolbar ||
 				isToolbarForced ||
-				showEmptyBlockSideInserter
+				showEmptyBlockSideInserter ||
+				isCapturingDescendantToolbars
 			) && (
 				<Popover
 					noArrow
@@ -438,13 +441,11 @@ function BlockListBlock( {
 					onBlur={ () => setIsToolbarForced( false ) }
 				>
 					{ ! hasAncestorCapturingToolbars && ( shouldShowContextualToolbar || isToolbarForced ) && renderBlockContextualToolbar() }
-					{ hasAncestorCapturingToolbars && ( shouldShowContextualToolbar || isToolbarForced ) && (
-						// If the parent Block is set to consume toolbars of the child Blocks
-						// then render the child Block's toolbar into the Slot provided
-						// by the parent.
-						<ChildToolbar>
-							{ renderBlockContextualToolbar() }
-						</ChildToolbar>
+					{ ( isCapturingDescendantToolbars ) && (
+						// A slot made available on all ancestors of the selected Block
+						// to allow child Blocks to render their toolbars into the DOM
+						// of the appropriate parent.
+						<ChildToolbarSlot />
 					) }
 					{ shouldShowBreadcrumb && (
 						<BlockBreadcrumb


### PR DESCRIPTION
## Description

Currently toolbar capturing is broken since the toolbars are rendered in popovers.

## How has this been tested?

Add e.g. `__experimentalCaptureToolbars` to the column block's `InnerBlocks` and test the toolbars.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
