### PR TITLE
Navigation Block: Hide the toolbar when NavigationLink popup is opened

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -42,6 +42,7 @@ function NavigationLinkEdit( {
 	isSelected,
 	isParentOfSelectedBlock,
 	setAttributes,
+	hideToolbar,
 	insertLinkBlock,
 } ) {
 	const { label, opensInNewTab, title, url, nofollow, description } = attributes;
@@ -72,6 +73,16 @@ function NavigationLinkEdit( {
 			setIsLinkOpen( false );
 		}
 	}, [ isSelected ] );
+
+	if ( isLinkOpen ) {
+		/**
+		 * Hide the toolbar when the NavigationLink popup is opened. Note that this
+		 * doesn't force the toolbar to remain hidden until the popup is closed - it
+		 * will become visible on e.g. any mouse movement regardless of the popup
+		 * visibility.
+		 */
+		hideToolbar();
+	}
 
 	return (
 		<Fragment>
@@ -202,6 +213,9 @@ export default compose( [
 	} ),
 	withDispatch( ( dispatch, ownProps, registry ) => {
 		return {
+			hideToolbar() {
+				dispatch( 'core/block-editor' ).startTyping();
+			},
 			insertLinkBlock() {
 				const { clientId } = ownProps;
 


### PR DESCRIPTION
## Description

Closes: #18315

Hide the `BlockToolbar` when the `NavigationLink` popup is opened. This happens in 2 instances:

1. After clicking the ⊕ button,
2. After clicking the 🔗 button (or pressing `CMD/CTRL-K`).

Note that this doesn't force the `BlockToolbar` to remain hidden until the popup is closed - it will become visible on e.g. any mouse movement regardless of the popup visibility.

## How has this been tested?

In the `Navigation` block, click on the ⊕ button to add a new item. An empty item should be appended with link popup opened and its input focused and the `BlockToolbar` should be hidden. 

## Screenshots

![nav block toolbar visibility](https://user-images.githubusercontent.com/1451471/72075465-142b1c00-32f4-11ea-9a82-6be2cde178c0.gif)

## Types of changes
Non-breaking change.

## Checklist:
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->