### PR TITLE
Fixes e2e test failures via console log exception to handle temp `wpnonce` error

### DIFF
--- a/packages/e2e-tests/config/setup-test-framework.js
+++ b/packages/e2e-tests/config/setup-test-framework.js
@@ -155,6 +155,14 @@ function observeConsoleLogging() {
 			return;
 		}
 
+		// As of WordPress 5.3.2 in Chrome 79, navigating to the block editor
+		// (Posts > Add New) will display a console warning about
+		// non - unique IDs.
+		// See: https://core.trac.wordpress.org/ticket/23165
+		if ( text.includes( '[DOM] Found 2 elements with non-unique id #_wpnonce' ) ) {
+			return;
+		}
+
 		const logFunction = OBSERVED_CONSOLE_MESSAGE_TYPES[ type ];
 
 		// As of Puppeteer 1.6.1, `message.text()` wrongly returns an object of

--- a/packages/e2e-tests/config/setup-test-framework.js
+++ b/packages/e2e-tests/config/setup-test-framework.js
@@ -159,7 +159,7 @@ function observeConsoleLogging() {
 		// (Posts > Add New) will display a console warning about
 		// non - unique IDs.
 		// See: https://core.trac.wordpress.org/ticket/23165
-		if ( text.includes( '[DOM] Found 2 elements with non-unique id #_wpnonce' ) ) {
+		if ( text.includes( 'elements with non-unique id #_wpnonce' ) ) {
 			return;
 		}
 


### PR DESCRIPTION
>  [DOM] Found 2 elements with non-unique id #_wpnonce: (More info: https://goo.gl/9p2vKq)

This error was getting logged to console when running e2e tests locally and causing my tests to fail. It’s a known issue with WordPress:
https://core.trac.wordpress.org/ticket/23165.

This commit adds a new condition to console log exception handling in e2e tests to ensure console logs containing this message are ignored and do not trigger test failures.

See also https://wordpress.slack.com/archives/C02QB2JS7/p1578578973183100 (requires registration)

[Originally committed here](https://github.com/WordPress/gutenberg/pull/19458/commits/65bb0528cc04c27cc3cf73590f7d02df62499ce6).

## How has this been tested?
Difficult to test but requires running the e2e tests.

Best way is to check out this [branch](https://github.com/WordPress/gutenberg/pull/19458) and run the e2e tests. You will see that the e2e tests pass when code from this PR is added and they fail when it is removed.



## Types of changes
Bug fix (non-breaking change which fixes an issue) 

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
