### PR TITLE
Packages: Mark build-styles as side-effectful

### DIFF
--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Master
+
+### Bug Fixes
+
+- Fixes a regression published in version 2.9.2 that would prevent some build tools from including
+  styles provided in the packages build-styles directory.
+
 ## 2.7.0 (2019-08-05)
 
 ### Enhancements

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -21,7 +21,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"sideEffects": [
-		"build-style"
+		"build-style/**"
 	],
 	"dependencies": {
 		"@babel/runtime": "^7.4.4",

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -20,7 +20,9 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"react-native": "src/index",
-	"sideEffects": false,
+	"sideEffects": [
+		"build-style"
+	],
 	"dependencies": {
 		"@babel/runtime": "^7.4.4",
 		"@wordpress/a11y": "file:../a11y",

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,11 +4,16 @@
 
 - Added a new `Guide` component which allows developers to easily present a user guide.
 
-### Breaking Change
+### Breaking Changes
 
 - `is-button` classname has been removed from the Button component.
 - The `is-default` classname is not applied automatically anymore.
 - By default Button components come with a fixed height and hover styles.
+
+### Bug Fixes
+
+- Fixes a regression published in version 8.5.0 that would prevent some build tools from including
+  styles provided in the packages build-styles directory.
 
 ### Deprecations
 

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -21,7 +21,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"sideEffects": [
-		"build-style"
+		"build-style/**"
 	],
 	"dependencies": {
 		"@babel/runtime": "^7.4.4",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -20,7 +20,9 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"react-native": "src/index",
-	"sideEffects": false,
+	"sideEffects": [
+		"build-style"
+	],
 	"dependencies": {
 		"@babel/runtime": "^7.4.4",
 		"@emotion/core": "^10.0.22",


### PR DESCRIPTION
## Description

In https://github.com/Automattic/wp-calypso/pull/38554 we observed some styling regressions when importing component styles from `@wordpress/components/build-styles`. This appears to be a regression introduced in #18911. Styles are side-effectful, and should be declared as such. Packages that include `build-styles` intended for use from the published package must be marked as such. The webpack docs on tree shaking mention this:

> Note that any imported file is subject to tree shaking. This means if you use something like `css-loader` in your project and import a CSS file, it needs to be added to the side effect list so it will not be unintentionally dropped in production mode:

[source](https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free)

This PR marks `build-style/**` as having side-effects for packages that were observed to produce a `build-style` directory and were marked `sideEffects: false`. An alternative would be to add `*.css` and `*.scss` to the list, however.

## How has this been tested?

When manually applying the change in this PR to the installed package where the regression was observed, the issue is fixed.

## Types of changes

Bug fix (non-breaking change which fixes an issue) 

- Fixes a regression published in `@wordpress/components@8.5.0` that would prevent some build tools from including styles provided in the packages `build-styles` directory.

- Fixes a regression published in `@wordpress/block-library@2.9.2` that would prevent some build tools from including styles provided in the packages `build-styles` directory.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
