### PR TITLE
Navigation Block: Use underline instead of bottom border for nav links

### DIFF
--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -68,8 +68,7 @@
 	}
 
 	&.has-link .wp-block-navigation-link__content {
-		border-bottom-style: solid;
-		border-bottom-width: 1px;
+		text-decoration: underline;
 	}
 
 	.block-editor-rich-text__editable.is-selected:not(.keep-placeholder-on-focus):not(:focus) [data-rich-text-placeholder]::after {


### PR DESCRIPTION
## Description

Closes: #19025

## How has this been tested?

Every navigation item that is a link should use `text-decoration: underline` instead of `1px` bottom border.

## Screenshots <!-- if applicable -->

Before:
<img width="691" alt="Screenshot 2020-01-09 19 32 26" src="https://user-images.githubusercontent.com/1451471/72094477-cc69bc00-3316-11ea-906d-b6058aa7bdb2.png">

After:
<img width="711" alt="Screenshot 2020-01-09 19 26 24" src="https://user-images.githubusercontent.com/1451471/72094329-80b71280-3316-11ea-9fa7-cd1117e0da74.png">

## Types of changes

Style update (non-breaking change)