### PR TITLE
Remove duplicate CSS from Navigation that is aleady in Navigation Link CSS

### DIFF
--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -39,14 +39,17 @@
 	}
 }
 
+/*
+ * Adjust Navigation Item.
+ */
 .wp-block-navigation-link {
+	margin-left: $grid-size;
 	margin-right: $grid-size;
 	// Provide a base menu item margin.
 	// This should be the same inside the field,
 	// and the edit container should compensate.
 	// This is to make sure the edit and view are the same.
 	padding: 0 $grid-size;
-	padding-right: 55px; // allow space for Block "mover"
 
 	.block-editor-block-list__layout {
 		display: block;

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -84,13 +84,7 @@
  * Adjust Navigation Item.
  */
 .wp-block-navigation .wp-block-navigation-link {
-	margin-right: $grid-size;
 	margin-left: $grid-size;
-
-	.block-editor-block-list__layout {
-		display: block;
-		margin: $grid-size;
-	}
 
 	// Provide a base navigation item margin.
 	// This should be the same inside the field,
@@ -98,14 +92,6 @@
 	// This is to make sure the edit and view are the same.
 	padding: 0 $grid-size;
 
-	// Only display inner blocks when the block is being edited.
-	.block-editor-inner-blocks {
-		display: none;
-	}
-
-	&.is-editing .block-editor-inner-blocks {
-		display: block;
-	}
 }
 
 /**

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -80,20 +80,6 @@
 	padding: $grid-size-large;
 }
 
-/*
- * Adjust Navigation Item.
- */
-.wp-block-navigation .wp-block-navigation-link {
-	margin-left: $grid-size;
-
-	// Provide a base navigation item margin.
-	// This should be the same inside the field,
-	// and the edit container should compensate.
-	// This is to make sure the edit and view are the same.
-	padding: 0 $grid-size;
-
-}
-
 /**
  * Colors Selector component
  */


### PR DESCRIPTION
Closes #19537

There was a bit of repeated code in navigation/editor.scss already appearing in navigation-link/editor.scss. The specificity will end up being a little lower now, but from my testing I don't see anything that overrides it.

## Description
I've removed CSS from the Navigation Block that already appeared in Navigation Link CSS.

## How has this been tested?
Manually

## Types of changes
Minor refactor of CSS.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->