### PR TITLE
Image Block - Fix scaling image outside block parent in editor.

### DIFF
--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -103,9 +103,7 @@ export class ImageEdit extends Component {
 		this.updateMaxWidth = this.updateMaxWidth.bind( this );
 		// With the current implementation of ResizableBox, an image needs an explicit pixel value for the max-width.
 		// In absence of being able to set the content-width, this max-width is currently dictated by the vanilla editor style.
-		// The following variable adds a buffer to this vanilla style, so 3rd party themes have some wiggleroom.
-		// This does, in most cases, allow you to scale the image beyond the width of the main column, though not infinitely.
-		// @todo It would be good to revisit this once a content-width variable becomes available.
+		// The following variable adds a buffer to this vanilla style, to create a large buffer until updateMaxWidth is called.
 		this.maxWidthBuffer = this.props.maxWidth * 2.5;
 		// To limit scaling the image beyond the width of the main column, we will use resizeRef to find the parent block's width.
 		// This will then be used to reduce the maxWidth from the buffer value to a definitive value in componentDidUpdate.

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -677,17 +677,17 @@ export class ImageEdit extends Component {
 											delta
 										) => {
 											onResizeStop();
-											setAttributes( {
-												width: parseInt(
-													currentWidth + delta.width,
-													10
-												),
-												height: parseInt(
-													currentHeight +
-														delta.height,
-													10
-												),
-											} );
+											if ( currentWidth > maxWidth ) {
+												setAttributes( {
+													width: parseInt( maxWidth + delta.width, 10 ),
+													height: parseInt( ( maxWidth / ratio ) + delta.height, 10 ),
+												} );
+											} else {
+												setAttributes( {
+													width: parseInt( currentWidth + delta.width, 10 ),
+													height: parseInt( currentHeight + delta.height, 10 ),
+												} );
+											}
 										} }
 									>
 										{ img }

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -139,11 +139,12 @@ export class ImageEdit extends Component {
 		}
 
 		// Set updates for maxWidth once resizeRef is ready.
-		const someInterval = setInterval( () => {
+		const waitForRef = setInterval( () => {
 			if ( this.resizeRef.current ) {
 				this.updateMaxWidth();
+				// Listener will update maxWidth on resize for fluid-width themes.
 				window.addEventListener( 'resize', this.updateMaxWidth );
-				clearInterval( someInterval );
+				clearInterval( waitForRef );
 			}
 		}, 100 );
 	}
@@ -175,6 +176,7 @@ export class ImageEdit extends Component {
 		}
 	}
 
+	// Required to set maxWidth based on block parent.
 	updateMaxWidth() {
 		// Check resizeRef's block parents to set an accurate width restriction.
 		// This is used to limit the resizer from resizing the image beyond the block parent's width.

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -162,7 +162,7 @@ export class ImageEdit extends Component {
 
 		// Check resizeRef's block parents to set an accurate width restriction.
 		// This is used to limit the resizer from resizing the image beyond the block parent's width.
-		if ( this.resizeRef.current && this.state.maxWidth === this.bufferWidth ) {
+		if ( this.resizeRef.current && this.state.maxWidth === this.maxWidthBuffer ) {
 			let parentBlock = this.resizeRef.current.parentNode;
 			// Traverse 'up' in parent nodes until we find the block parent.
 			while ( ! parentBlock.classList.contains( 'block-editor-block-list__block' ) ) {

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -162,7 +162,7 @@ export class ImageEdit extends Component {
 
 		// Check resizeRef's block parents to set an accurate width restriction.
 		// This is used to limit the resizer from resizing the image beyond the block parent's width.
-		if ( this.resizeRef.current && this.state.maxWidth === this.maxWidthBuffer ) {
+		if ( this.resizeRef.current ) {
 			let parentBlock = this.resizeRef.current.parentNode;
 			// Traverse 'up' in parent nodes until we find the block parent.
 			while ( ! parentBlock.classList.contains( 'block-editor-block-list__block' ) ) {

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -677,6 +677,8 @@ export class ImageEdit extends Component {
 											delta
 										) => {
 											onResizeStop();
+											// Images saved with width (currentWidth) larger than the width of their parent block (maxWidth),
+											// will resize with poor behavior if we do not resize based on maxWidth in that circumstance.
 											if ( currentWidth > maxWidth ) {
 												setAttributes( {
 													width: parseInt( maxWidth + delta.width, 10 ),

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -100,7 +100,7 @@ export class ImageEdit extends Component {
 		this.getFilename = this.getFilename.bind( this );
 		this.onUploadError = this.onUploadError.bind( this );
 		this.onImageError = this.onImageError.bind( this );
-
+		this.updateMaxWidth = this.updateMaxWidth.bind( this );
 		// With the current implementation of ResizableBox, an image needs an explicit pixel value for the max-width.
 		// In absence of being able to set the content-width, this max-width is currently dictated by the vanilla editor style.
 		// The following variable adds a buffer to this vanilla style, so 3rd party themes have some wiggleroom.
@@ -137,6 +137,20 @@ export class ImageEdit extends Component {
 				} );
 			}
 		}
+
+		// Set updates for maxWidth once resizeRef is ready.
+		const someInterval = setInterval( () => {
+			if ( this.resizeRef.current ) {
+				this.updateMaxWidth();
+				window.addEventListener( 'resize', this.updateMaxWidth );
+				clearInterval( someInterval );
+			}
+		}, 100 );
+	}
+
+	componentWillUnmount() {
+		// Remove listener to update maxWidth on resize.
+		window.removeEventListener( 'resize', this.updateMaxWidth );
 	}
 
 	componentDidUpdate( prevProps ) {
@@ -159,7 +173,9 @@ export class ImageEdit extends Component {
 				captionFocused: false,
 			} );
 		}
+	}
 
+	updateMaxWidth() {
 		// Check resizeRef's block parents to set an accurate width restriction.
 		// This is used to limit the resizer from resizing the image beyond the block parent's width.
 		if ( this.resizeRef.current ) {

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -583,7 +583,7 @@ export class ImageEdit extends Component {
 							// The following variable adds a buffer to this vanilla style, so 3rd party themes have some wiggleroom.
 							// This does, in most cases, allow you to scale the image beyond the width of the main column, though not infinitely.
 							// @todo It would be good to revisit this once a content-width variable becomes available.
-							const maxWidthBuffer = maxWidth * 2.5;
+							const maxWidthBuffer = maxWidth;
 
 							let showRightHandle = false;
 							let showLeftHandle = false;

--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -40,6 +40,28 @@
 	z-index: z-index(".block-library-image__resize-handlers");
 }
 
+// Limit width of image to size of block
+.block-editor-block-list__block[data-type="core/image"] {
+	div {
+		max-width: inherit;
+
+		.wp-block-image {
+			max-width: inherit;
+
+			div {
+				max-width: inherit;
+
+				.components-resizable-box__container {
+					max-width: inherit !important;
+					max-height: inherit !important;
+					// transform: scale(1, 1/attr(data-ratio));
+				}
+			}
+		}
+	}
+}
+
+
 .block-editor-block-list__block[data-type="core/image"][data-align="center"] {
 	.wp-block-image {
 		margin-left: auto;

--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -40,28 +40,6 @@
 	z-index: z-index(".block-library-image__resize-handlers");
 }
 
-// Limit width of image to size of block
-.block-editor-block-list__block[data-type="core/image"] {
-	div {
-		max-width: inherit;
-
-		.wp-block-image {
-			max-width: inherit;
-
-			div {
-				max-width: inherit;
-
-				.components-resizable-box__container {
-					max-width: inherit !important;
-					max-height: inherit !important;
-					// transform: scale(1, 1/attr(data-ratio));
-				}
-			}
-		}
-	}
-}
-
-
 .block-editor-block-list__block[data-type="core/image"][data-align="center"] {
 	.wp-block-image {
 		margin-left: auto;

--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -40,6 +40,14 @@
 	z-index: z-index(".block-library-image__resize-handlers");
 }
 
+// Ensures image ratio is respected on resizing viewport.
+.block-editor-block-list__block[data-type="core/image"]
+.wp-block-image
+.components-resizable-box__container
+img {
+	height: auto;
+}
+
 .block-editor-block-list__block[data-type="core/image"][data-align="center"] {
 	.wp-block-image {
 		margin-left: auto;


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
This component will now change the `maxWidth` property given to the `ResizableBox` component based on the width of the block parent containing it.  This will prevent the image from being scaled beyond the size of the parent block.

Addresses issue #19424 (some more explanation is contained here) and issue #12168.

Previously `maxWidthBuffer` was used as the `maxWidth` property of the `ResizableBox` component.  This buffer was in place to ensure 3rd party themes would be able to resize images larger than the standard column size if necessary.  The side effect of this buffer enabled the resizer to resize the image larger than the parent block.  Now instead of using this buffer we replace it with a specific value as soon as we are able to, allowing the image to be resized to whatever the width of the block parent may be (and not any further).

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Tested on local docker setup with standard image block as well as image block nested in a smaller column.

## Screenshots <!-- if applicable -->
### Before
**Standard Size**
![resize-standard-before](https://user-images.githubusercontent.com/28742426/72103403-2195d580-32f7-11ea-8fde-c70dd191175f.gif)
**In a smaller column**
![resize-small-before](https://user-images.githubusercontent.com/28742426/72103397-1e024e80-32f7-11ea-8342-8850fc98e7ac.gif)

### After
**Standard Size**
![resize-standard-after](https://user-images.githubusercontent.com/28742426/72103409-26f32000-32f7-11ea-8c0f-178cf7b6262a.gif)
**In a smaller column**
![resize-small-after](https://user-images.githubusercontent.com/28742426/72103418-2c506a80-32f7-11ea-8aa5-a63ab9695439.gif)


## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
