### PR TITLE
Linting Documentation

### DIFF
--- a/docs/designers-developers/developers/tutorials/block-tutorial/applying-styles-with-stylesheets.md
+++ b/docs/designers-developers/developers/tutorials/block-tutorial/applying-styles-with-stylesheets.md
@@ -24,7 +24,7 @@ registerBlockType( 'gutenberg-examples/example-02-stylesheets', {
 
 	save() {
 		return <p>Hello World, step 2 (from the frontend, in red).</p>;
-	}
+	},
 } );
 ```
 {% ES5 %}

--- a/docs/designers-developers/developers/tutorials/block-tutorial/creating-dynamic-blocks.md
+++ b/docs/designers-developers/developers/tutorials/block-tutorial/creating-dynamic-blocks.md
@@ -30,10 +30,9 @@ registerBlockType( 'gutenberg-examples/example-dynamic', {
 
 	edit: withSelect( ( select ) => {
 		return {
-			posts: select( 'core' ).getEntityRecords( 'postType', 'post' )
+			posts: select( 'core' ).getEntityRecords( 'postType', 'post' ),
 		};
 	} )( ( { posts, className } ) => {
-
 		if ( ! posts ) {
 			return 'Loading...';
 		}
@@ -42,7 +41,7 @@ registerBlockType( 'gutenberg-examples/example-dynamic', {
 			return 'No posts';
 		}
 
-		let post = posts[ 0 ];
+		const post = posts[ 0 ];
 
 		return <a className={ className } href={ post.link }>
 			{ post.title.rendered }
@@ -53,28 +52,25 @@ registerBlockType( 'gutenberg-examples/example-dynamic', {
 {% ES5 %}
 ```js
 ( function( blocks, element, data ) {
-
 	var el = element.createElement,
-	registerBlockType = blocks.registerBlockType,
-	withSelect = data.withSelect;
+		registerBlockType = blocks.registerBlockType,
+		withSelect = data.withSelect;
 
 	registerBlockType( 'gutenberg-examples/example-dynamic', {
 		title: 'Example: last post',
 		icon: 'megaphone',
 		category: 'widgets',
-		
 		edit: withSelect( function( select ) {
 			return {
-				posts: select( 'core' ).getEntityRecords( 'postType', 'post' )
+				posts: select( 'core' ).getEntityRecords( 'postType', 'post' ),
 			};
 		} )( function( props ) {
-
 			if ( ! props.posts ) {
-				return "Loading...";
+				return 'Loading...';
 			}
 
 			if ( props.posts.length === 0 ) {
-				return "No posts";
+				return 'No posts';
 			}
 			var className = props.className;
 			var post = props.posts[ 0 ];
@@ -177,10 +173,9 @@ registerBlockType( 'gutenberg-examples/example-dynamic', {
 {% ES5 %}
 ```js
 ( function( blocks, element, serverSideRender ) {
-
 	var el = element.createElement,
-	registerBlockType = blocks.registerBlockType,
-	ServerSideRender = serverSideRender;
+		registerBlockType = blocks.registerBlockType,
+		ServerSideRender = serverSideRender;
 
 	registerBlockType( 'gutenberg-examples/example-dynamic', {
 		title: 'Example: last post',
@@ -188,11 +183,10 @@ registerBlockType( 'gutenberg-examples/example-dynamic', {
 		category: 'widgets',
 
 		edit: function( props ) {
-
 			return (
-				el(ServerSideRender, {
-					block: "gutenberg-examples/example-dynamic",
-					attributes: props.attributes
+				el( ServerSideRender, {
+					block: 'gutenberg-examples/example-dynamic',
+					attributes: props.attributes,
 				} )
 			);
 		},

--- a/docs/designers-developers/developers/tutorials/block-tutorial/nested-blocks-inner-blocks.md
+++ b/docs/designers-developers/developers/tutorials/block-tutorial/nested-blocks-inner-blocks.md
@@ -95,7 +95,6 @@ const MY_TEMPLATE = [
 //...
 
 	edit: function( props ) {
-
 		return el(
 			InnerBlocks,
 			{
@@ -116,7 +115,6 @@ const MY_TEMPLATE = [
 //...
 
 	edit: () => {
-
 		return (
 			<InnerBlocks
 				template={ MY_TEMPLATE }
@@ -145,7 +143,6 @@ add_action( 'init', function() {
 	);
 } );
 ```
-
 
 ## Parent-Child InnerBlocks
 

--- a/docs/designers-developers/developers/tutorials/javascript/extending-the-block-editor.md
+++ b/docs/designers-developers/developers/tutorials/javascript/extending-the-block-editor.md
@@ -6,8 +6,8 @@ Replace the existing `console.log()` code in your `myguten.js` file with:
 
 ```js
 wp.blocks.registerBlockStyle( 'core/quote', {
-    name: 'fancy-quote',
-    label: 'Fancy Quote'
+	name: 'fancy-quote',
+	label: 'Fancy Quote',
 } );
 ```
 
@@ -64,4 +64,3 @@ add_action( 'enqueue_block_assets', 'myguten_stylesheet' );
 Now when you view in the editor and publish, you will see your Fancy Quote style, a delicious tomato color text:
 
 ![Fancy Quote with Style](https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/assets/fancy-quote-with-style.png)
-

--- a/docs/designers-developers/developers/tutorials/metabox/meta-block-3-add.md
+++ b/docs/designers-developers/developers/tutorials/metabox/meta-block-3-add.md
@@ -27,8 +27,8 @@ Add this code to your JavaScript file (this tutorial will call the file `myguten
 			blockValue: {
 				type: 'string',
 				source: 'meta',
-				meta: 'myguten_meta_block_field'
-			}
+				meta: 'myguten_meta_block_field',
+			},
 		},
 
 		edit: function( props ) {
@@ -36,7 +36,7 @@ Add this code to your JavaScript file (this tutorial will call the file `myguten
 			var setAttributes = props.setAttributes;
 
 			function updateBlockValue( blockValue ) {
-				setAttributes({ blockValue });
+				setAttributes( { blockValue } );
 			}
 
 			return el(
@@ -45,7 +45,7 @@ Add this code to your JavaScript file (this tutorial will call the file `myguten
 				el( TextControl, {
 					label: 'Meta Block Field',
 					value: props.attributes.blockValue,
-					onChange: updateBlockValue
+					onChange: updateBlockValue,
 				} )
 			);
 		},
@@ -54,7 +54,7 @@ Add this code to your JavaScript file (this tutorial will call the file `myguten
 		// Data is saved to post meta via attributes
 		save: function() {
 			return null;
-		}
+		},
 	} );
 } )( window.wp );
 ```
@@ -77,7 +77,6 @@ registerBlockType( 'myguten/meta-block', {
 	},
 
 	edit( { className, setAttributes, attributes } ) {
-
 		function updateBlockValue( blockValue ) {
 			setAttributes( { blockValue } );
 		}
@@ -97,7 +96,7 @@ registerBlockType( 'myguten/meta-block', {
 	// Data is saved to post meta via attributes
 	save() {
 		return null;
-	}
+	},
 } );
 ```
 {% end %}

--- a/docs/designers-developers/developers/tutorials/notices/README.md
+++ b/docs/designers-developers/developers/tutorials/notices/README.md
@@ -45,7 +45,7 @@ Producing an equivalent "Post published" notice would require code like this:
 
 ```js
 ( function( wp ) {
-	wp.data.dispatch('core/notices').createNotice(
+	wp.data.dispatch( 'core/notices' ).createNotice(
 		'success', // Can be one of: success, info, warning, error.
 		'Post published.', // Text string to display.
 		{
@@ -54,9 +54,9 @@ Producing an equivalent "Post published" notice would require code like this:
 			actions: [
 				{
 					url: '#',
-					label: 'View post'
-				}
-			]
+					label: 'View post',
+				},
+			],
 		}
 	);
 } )( window.wp );


### PR DESCRIPTION
## Description

A first pass on seeing what errors the new `npm run lint-md` command introduces with #19518 

The commas, quotes, and whitespace all seem to be accurate lint issues. 

One issue is the mix of ES5 code and ESNext together, the function and variable definitions don't match the lint rules, for example using `var` instead of `let.

## How has this been tested?

Run `npm run lint-md` to see recommendations
This PR reduces the issues on a small set of files

## Types of changes

Documentation lint changes.

