### PR TITLE
RichText: split out inline warning

### DIFF
--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -36,6 +36,7 @@ import { removeLineSeparator } from '../remove-line-separator';
 import { isEmptyLine } from '../is-empty';
 import withFormatTypes from './with-format-types';
 import { BoundaryStyle } from './boundary-style';
+import { InlineWarning } from './inline-warning';
 
 /**
  * Browser dependencies
@@ -188,15 +189,6 @@ class RichText extends Component {
 	}
 
 	componentDidMount() {
-		if ( process.env.NODE_ENV === 'development' ) {
-			const computedStyle = getComputedStyle( this.props.forwardedRef.current );
-
-			if ( computedStyle.display === 'inline' ) {
-				// eslint-disable-next-line no-console
-				console.warn( 'RichText cannot be used with an inline container. Please use a different tagName.' );
-			}
-		}
-
 		this.applyRecord( this.record, { domOnly: true } );
 	}
 
@@ -1073,6 +1065,7 @@ class RichText extends Component {
 					activeFormats={ activeFormats }
 					forwardedRef={ forwardedRef }
 				/>
+				<InlineWarning forwardedRef={ forwardedRef } />
 				{ isSelected && <FormatEdit
 					allowedFormats={ allowedFormats }
 					withoutInteractiveFormatting={ withoutInteractiveFormatting }

--- a/packages/rich-text/src/component/inline-warning.js
+++ b/packages/rich-text/src/component/inline-warning.js
@@ -1,0 +1,18 @@
+/**
+ * WordPress dependencies
+ */
+import { useEffect } from '@wordpress/element';
+
+export function InlineWarning( { forwardedRef } ) {
+	useEffect( () => {
+		if ( process.env.NODE_ENV === 'development' ) {
+			const computedStyle = window.getComputedStyle( forwardedRef.current );
+
+			if ( computedStyle.display === 'inline' ) {
+				// eslint-disable-next-line no-console
+				console.warn( 'RichText cannot be used with an inline container. Please use a different tagName.' );
+			}
+		}
+	}, [] );
+	return null;
+}


### PR DESCRIPTION
## Description

This is part of an effort to split RichText into smaller pieces and rewrite it with hooks. This component can later be converted to a hook.

## How has this been tested?

Change a rich text element's display property to inline and you should see the warning.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
