### PR TITLE
Fix ServerSideRender component showing className

### DIFF
--- a/packages/server-side-render/src/server-side-render.js
+++ b/packages/server-side-render/src/server-side-render.js
@@ -115,7 +115,7 @@ ServerSideRender.defaultProps = {
 		<Placeholder
 			className={ className }
 		>
-			{ __( 'Block rendered as empty.' ) + className }
+			{ __( 'Block rendered as empty.' ) }
 		</Placeholder>
 	),
 	ErrorResponsePlaceholder: ( { response, className } ) => {


### PR DESCRIPTION
Fixes #19554.

## Description
Remove `className` from the empty response placeholder string displayed in `<ServerSideRender>`.

## How has this been tested?
Rendering a `<ServerSideRender>` component like this:
```JSX
<ServerSideRender block={ name } attributes={ attributes } />
```

## Screenshots <!-- if applicable -->

_Before:_
![imatge](https://user-images.githubusercontent.com/3616980/72144367-cae0d800-3398-11ea-8b75-7252ade57abc.png)

_After:_
![imatge](https://user-images.githubusercontent.com/3616980/72144276-9705b280-3398-11ea-93f5-6d3fb9d05b2d.png)

## Types of changes
Bug fix: removes displaying a class name in the frontend.
