### PR TITLE
[RNMobile] Correct navigation toolbar

### DIFF
--- a/packages/block-editor/src/components/block-list/breadcrumb.native.js
+++ b/packages/block-editor/src/components/block-list/breadcrumb.native.js
@@ -37,7 +37,8 @@ const BlockBreadcrumb = ( { clientId, blockIcon, rootClientId, rootBlockIcon } )
 					maxFontSizeMultiplier={ 1.25 }
 					ellipsizeMode="tail"
 					numberOfLines={ 1 }
-					style={ styles.breadcrumbTitle }>
+					style={ styles.breadcrumbTitle }
+				>
 					<BlockTitle clientId={ clientId } />
 				</Text>
 			</TouchableOpacity>

--- a/packages/block-editor/src/components/block-list/breadcrumb.native.js
+++ b/packages/block-editor/src/components/block-list/breadcrumb.native.js
@@ -33,7 +33,13 @@ const BlockBreadcrumb = ( { clientId, blockIcon, rootClientId, rootBlockIcon } )
 					]
 				) }
 				<Icon size={ 24 } icon={ blockIcon.src } fill={ styles.icon.color } />
-				<Text style={ styles.breadcrumbTitle }><BlockTitle clientId={ clientId } /></Text>
+				<Text
+					maxFontSizeMultiplier={ 2 }
+					ellipsizeMode="tail"
+					numberOfLines={ 1 }
+					style={ styles.breadcrumbTitle }>
+					<BlockTitle clientId={ clientId } />
+				</Text>
 			</TouchableOpacity>
 		</View>
 	);

--- a/packages/block-editor/src/components/block-list/breadcrumb.native.js
+++ b/packages/block-editor/src/components/block-list/breadcrumb.native.js
@@ -34,7 +34,7 @@ const BlockBreadcrumb = ( { clientId, blockIcon, rootClientId, rootBlockIcon } )
 				) }
 				<Icon size={ 24 } icon={ blockIcon.src } fill={ styles.icon.color } />
 				<Text
-					maxFontSizeMultiplier={ 2 }
+					maxFontSizeMultiplier={ 1.25 }
 					ellipsizeMode="tail"
 					numberOfLines={ 1 }
 					style={ styles.breadcrumbTitle }>

--- a/packages/block-editor/src/components/block-list/breadcrumb.native.scss
+++ b/packages/block-editor/src/components/block-list/breadcrumb.native.scss
@@ -4,11 +4,13 @@
 	justify-content: flex-start;
 	padding-left: 5;
 	padding-right: 15;
+	flex-shrink: 1;
 }
 
 .breadcrumbTitle {
 	color: $white;
 	margin-left: 4;
+	flex-shrink: 1;
 }
 
 .icon {


### PR DESCRIPTION
## Description

PR is fixing [the issue](https://github.com/wordpress-mobile/gutenberg-mobile/issues/1677) where items are overlapping in `FloatingToolbar`

ref to gb-mobile: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1769

## How has this been tested?

1. Change font to the largest in device settings
2. Open mobile app
3. Add Media&Text block
4. Rotate device to horizontal mode
5. Press `Paragraph` block
6. Check if items are displayed properly in `FloatingToolbar` 

## Screenshots <!-- if applicable -->

**NOTE** In my screenshots block name is `VeryVeryLongParagraph` just for a proper example displaying

**Long block name with regular font size**

vertical nested | vertical root
--- | ---
<img width="507" alt="Screenshot 2020-01-10 at 14 08 40" src="https://user-images.githubusercontent.com/22746080/72155171-ce815880-33b2-11ea-94cf-ea292b273019.png">  | <img width="507" alt="Screenshot 2020-01-10 at 14 08 36" src="https://user-images.githubusercontent.com/22746080/72155175-cfb28580-33b2-11ea-877c-30d7fb96fb4d.png">

horizontal nested | horizontal root
--- | ---
<img width="895" alt="Screenshot 2020-01-10 at 14 10 37" src="https://user-images.githubusercontent.com/22746080/72155264-07b9c880-33b3-11ea-8fd4-d4be375cfc54.png"> | <img width="895" alt="Screenshot 2020-01-10 at 14 10 34" src="https://user-images.githubusercontent.com/22746080/72155266-08525f00-33b3-11ea-8704-a1c7196b65c8.png">

**Long block name with the largest font size**

vertical nested | vertical root
--- | ---
<img width="507" alt="Screenshot 2020-01-10 at 14 12 27" src="https://user-images.githubusercontent.com/22746080/72155385-52d3db80-33b3-11ea-8a42-3719d851e0ea.png"> | <img width="507" alt="Screenshot 2020-01-10 at 14 12 23" src="https://user-images.githubusercontent.com/22746080/72155390-54050880-33b3-11ea-8dde-e4c8869467ec.png">

horizontal nested | horizontal vertical
--- | ---
<img width="895" alt="Screenshot 2020-01-10 at 14 13 35" src="https://user-images.githubusercontent.com/22746080/72155440-726b0400-33b3-11ea-833c-f9b9908aef6c.png"> | <img width="895" alt="Screenshot 2020-01-10 at 14 13 33" src="https://user-images.githubusercontent.com/22746080/72155443-739c3100-33b3-11ea-9689-2dbdf4d594eb.png">

**Regular block name**

horizontal nested | horizontal root
--- | ---
<img width="895" alt="Screenshot 2020-01-10 at 14 16 07" src="https://user-images.githubusercontent.com/22746080/72155810-3be1b900-33b4-11ea-83fd-d32e01cfe6d2.png"> | <img width="895" alt="Screenshot 2020-01-10 at 14 16 05" src="https://user-images.githubusercontent.com/22746080/72155812-3d12e600-33b4-11ea-904d-9a310b930ad2.png">

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
