### PR TITLE
Block Editor: Add Toolbar visibility to store

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -79,7 +79,7 @@ const useDebouncedAccessibleBlockLabel = ( blockType, attributes, index, moverDi
 function BlockListBlock( {
 	mode,
 	isFocusMode,
-	isToolbarHidden,
+	isToolbarVisible,
 	hasFixedToolbar,
 	moverDirection,
 	isLocked,
@@ -292,13 +292,14 @@ function BlockListBlock( {
 	// Empty paragraph blocks should always show up as unselected.
 	const showEmptyBlockSideInserter = ! isNavigationMode && ( isSelected || isLast ) && isEmptyDefaultBlock && isValid;
 	const shouldAppearSelected =
-		! isToolbarHidden &&
+		isToolbarVisible &&
 		! isFocusMode &&
 		! showEmptyBlockSideInserter &&
 		isSelected &&
 		! isTypingWithinBlock;
 	const shouldShowBreadcrumb = isNavigationMode && isSelected;
 	const shouldShowContextualToolbar =
+		isToolbarVisible &&
 		! isNavigationMode &&
 		! hasFixedToolbar &&
 		isLargeViewport &&
@@ -515,7 +516,7 @@ const applyWithSelect = withSelect(
 			isTyping,
 			isCaretWithinFormattedText,
 			getBlockMode,
-			isToolbarHidden,
+			isToolbarVisible,
 			isSelectionEnabled,
 			getSelectedBlocksInitialCaretPosition,
 			getSettings,
@@ -577,7 +578,7 @@ const applyWithSelect = withSelect(
 			isCaretWithinFormattedText: isSelected && isCaretWithinFormattedText(),
 
 			mode: getBlockMode( clientId ),
-			isToolbarHidden: isToolbarHidden(),
+			isToolbarVisible: isToolbarVisible(),
 			isSelectionEnabled: isSelectionEnabled(),
 			initialPosition: isSelected ? getSelectedBlocksInitialCaretPosition() : null,
 			isEmptyDefaultBlock:

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -79,6 +79,7 @@ const useDebouncedAccessibleBlockLabel = ( blockType, attributes, index, moverDi
 function BlockListBlock( {
 	mode,
 	isFocusMode,
+	isToolbarHidden,
 	hasFixedToolbar,
 	moverDirection,
 	isLocked,
@@ -291,6 +292,7 @@ function BlockListBlock( {
 	// Empty paragraph blocks should always show up as unselected.
 	const showEmptyBlockSideInserter = ! isNavigationMode && ( isSelected || isLast ) && isEmptyDefaultBlock && isValid;
 	const shouldAppearSelected =
+		! isToolbarHidden &&
 		! isFocusMode &&
 		! showEmptyBlockSideInserter &&
 		isSelected &&
@@ -513,6 +515,7 @@ const applyWithSelect = withSelect(
 			isTyping,
 			isCaretWithinFormattedText,
 			getBlockMode,
+			isToolbarHidden,
 			isSelectionEnabled,
 			getSelectedBlocksInitialCaretPosition,
 			getSettings,
@@ -574,6 +577,7 @@ const applyWithSelect = withSelect(
 			isCaretWithinFormattedText: isSelected && isCaretWithinFormattedText(),
 
 			mode: getBlockMode( clientId ),
+			isToolbarHidden: isToolbarHidden(),
 			isSelectionEnabled: isSelectionEnabled(),
 			initialPosition: isSelected ? getSelectedBlocksInitialCaretPosition() : null,
 			isEmptyDefaultBlock:

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -23,11 +23,12 @@ import BlockMover from '../block-mover';
 import Inserter from '../inserter';
 
 export default function BlockToolbar( { moverDirection, hasMovers = true } ) {
-	const { blockClientIds, isValid, mode, rootClientId } = useSelect( ( select ) => {
+	const { blockClientIds, isHidden, isValid, mode, rootClientId } = useSelect( ( select ) => {
 		const {
 			getBlockMode,
 			getSelectedBlockClientIds,
 			isBlockValid,
+			isToolbarHidden,
 			getBlockRootClientId,
 		} = select( 'core/block-editor' );
 		const selectedBlockClientIds = getSelectedBlockClientIds();
@@ -35,6 +36,7 @@ export default function BlockToolbar( { moverDirection, hasMovers = true } ) {
 		return {
 			blockClientIds: selectedBlockClientIds,
 			rootClientId: getBlockRootClientId( selectedBlockClientIds[ 0 ] ),
+			isHidden: isToolbarHidden(),
 			isValid: selectedBlockClientIds.length === 1 ?
 				isBlockValid( selectedBlockClientIds[ 0 ] ) :
 				null,
@@ -45,7 +47,7 @@ export default function BlockToolbar( { moverDirection, hasMovers = true } ) {
 	}, [] );
 	const [ isInserterShown, setIsInserterShown ] = useState( false );
 
-	if ( blockClientIds.length === 0 ) {
+	if ( blockClientIds.length === 0 || isHidden ) {
 		return null;
 	}
 

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -23,12 +23,11 @@ import BlockMover from '../block-mover';
 import Inserter from '../inserter';
 
 export default function BlockToolbar( { moverDirection, hasMovers = true } ) {
-	const { blockClientIds, isHidden, isValid, mode, rootClientId } = useSelect( ( select ) => {
+	const { blockClientIds, isValid, mode, rootClientId } = useSelect( ( select ) => {
 		const {
 			getBlockMode,
 			getSelectedBlockClientIds,
 			isBlockValid,
-			isToolbarHidden,
 			getBlockRootClientId,
 		} = select( 'core/block-editor' );
 		const selectedBlockClientIds = getSelectedBlockClientIds();
@@ -36,7 +35,6 @@ export default function BlockToolbar( { moverDirection, hasMovers = true } ) {
 		return {
 			blockClientIds: selectedBlockClientIds,
 			rootClientId: getBlockRootClientId( selectedBlockClientIds[ 0 ] ),
-			isHidden: isToolbarHidden(),
 			isValid: selectedBlockClientIds.length === 1 ?
 				isBlockValid( selectedBlockClientIds[ 0 ] ) :
 				null,
@@ -47,7 +45,7 @@ export default function BlockToolbar( { moverDirection, hasMovers = true } ) {
 	}, [] );
 	const [ isInserterShown, setIsInserterShown ] = useState( false );
 
-	if ( blockClientIds.length === 0 || isHidden ) {
+	if ( blockClientIds.length === 0 ) {
 		return null;
 	}
 

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -786,6 +786,28 @@ export function updateSettings( settings ) {
 }
 
 /**
+ * Returns an action object used in signalling that the Toolbar is hidden.
+ *
+ * @return {Object} Action object.
+ */
+export function hideToolbar() {
+	return {
+		type: 'HIDE_TOOLBAR',
+	};
+}
+
+/**
+ * Returns an action object used in signalling that the Toolbar is visible.
+ *
+ * @return {Object} Action object.
+ */
+export function showToolbar() {
+	return {
+		type: 'SHOW_TOOLBAR',
+	};
+}
+
+/**
  * Returns an action object used in signalling that a temporary reusable blocks have been saved
  * in order to switch its temporary id with the real id.
  *

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -786,7 +786,7 @@ export function updateSettings( settings ) {
 }
 
 /**
- * Returns an action object used in signalling that the Toolbar is hidden.
+ * Returns an action object used in signalling the Toolbar visibility.
  *
  * @return {Object} Action object.
  */
@@ -797,7 +797,7 @@ export function hideToolbar() {
 }
 
 /**
- * Returns an action object used in signalling that the Toolbar is visible.
+ * Returns an action object used in signalling the Toolbar visibility.
  *
  * @return {Object} Action object.
  */

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1359,13 +1359,13 @@ export function automaticChangeStatus( state, action ) {
  *
  * @return {boolean} Updated state.
  */
-export function isToolbarHidden( state = false, action ) {
+export function isToolbarVisible( state = true, action ) {
 	switch ( action.type ) {
 		case 'HIDE_TOOLBAR':
-			return true;
+			return false;
 
 		case 'SHOW_TOOLBAR':
-			return false;
+			return true;
 	}
 
 	return state;
@@ -1373,7 +1373,7 @@ export function isToolbarHidden( state = false, action ) {
 
 export default combineReducers( {
 	blocks,
-	isToolbarHidden,
+	isToolbarVisible,
 	isTyping,
 	isDraggingBlocks,
 	isCaretWithinFormattedText,

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1351,8 +1351,29 @@ export function automaticChangeStatus( state, action ) {
 	// Reset the state by default (for any action not handled).
 }
 
+/**
+ * Reducer returning Toolbar visibility state.
+ *
+ * @param {boolean} state  Current state.
+ * @param {Object}  action Dispatched action.
+ *
+ * @return {boolean} Updated state.
+ */
+export function isToolbarHidden( state = false, action ) {
+	switch ( action.type ) {
+		case 'HIDE_TOOLBAR':
+			return true;
+
+		case 'SHOW_TOOLBAR':
+			return false;
+	}
+
+	return state;
+}
+
 export default combineReducers( {
 	blocks,
+	isToolbarHidden,
 	isTyping,
 	isDraggingBlocks,
 	isCaretWithinFormattedText,

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1534,6 +1534,6 @@ export function didAutomaticChange( state ) {
  *
  * @return {boolean} Whether the Toolbar is hidden.
  */
-export function isToolbarHidden( state ) {
-	return state.isToolbarHidden;
+export function isToolbarVisible( state ) {
+	return state.isToolbarVisible;
 }

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1526,3 +1526,14 @@ export function isNavigationMode( state ) {
 export function didAutomaticChange( state ) {
 	return !! state.automaticChangeStatus;
 }
+
+/**
+ * Returns true if the Toolbar is hidden, or false otherwise.
+ *
+ * @param {Object} state Global application state.
+ *
+ * @return {boolean} Whether the Toolbar is hidden.
+ */
+export function isToolbarHidden( state ) {
+	return state.isToolbarHidden;
+}

--- a/packages/block-editor/src/store/test/actions.js
+++ b/packages/block-editor/src/store/test/actions.js
@@ -6,6 +6,7 @@ import {
 	enterFormattedText,
 	exitFormattedText,
 	hideInsertionPoint,
+	hideToolbar,
 	insertBlock,
 	insertBlocks,
 	mergeBlocks,
@@ -20,6 +21,7 @@ import {
 	selectBlock,
 	selectPreviousBlock,
 	showInsertionPoint,
+	showToolbar,
 	startMultiSelect,
 	startTyping,
 	stopMultiSelect,
@@ -960,6 +962,22 @@ describe( 'actions', () => {
 				rootClientId: 'root',
 				time: expect.any( Number ),
 				updateSelection: false,
+			} );
+		} );
+	} );
+
+	describe( 'hideToolbar', () => {
+		it( 'should return the HIDE_TOOLBAR action', () => {
+			expect( hideToolbar() ).toEqual( {
+				type: 'HIDE_TOOLBAR',
+			} );
+		} );
+	} );
+
+	describe( 'showToolbar', () => {
+		it( 'should return the SHOW_TOOLBAR action', () => {
+			expect( showToolbar() ).toEqual( {
+				type: 'SHOW_TOOLBAR',
 			} );
 		} );
 	} );

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -32,7 +32,7 @@ import {
 	template,
 	blockListSettings,
 	lastBlockAttributesChange,
-	isToolbarHidden,
+	isToolbarVisible,
 } from '../reducer';
 
 describe( 'state', () => {
@@ -2405,18 +2405,18 @@ describe( 'state', () => {
 		} );
 	} );
 
-	describe( 'isToolbarHidden()', () => {
-		it( 'should set the Toolbar hidden flag to true', () => {
-			const state = isToolbarHidden( false, {
-				type: 'HIDE_TOOLBAR',
+	describe( 'isToolbarVisible()', () => {
+		it( 'should set the Toolbar visible flag to true', () => {
+			const state = isToolbarVisible( false, {
+				type: 'SHOW_TOOLBAR',
 			} );
 
 			expect( state ).toBe( true );
 		} );
 
-		it( 'should set the Toolbar hidden flag to false', () => {
-			const state = isToolbarHidden( false, {
-				type: 'SHOW_TOOLBAR',
+		it( 'should set the Toolbar visible flag to false', () => {
+			const state = isToolbarVisible( true, {
+				type: 'HIDE_TOOLBAR',
 			} );
 
 			expect( state ).toBe( false );

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -32,6 +32,7 @@ import {
 	template,
 	blockListSettings,
 	lastBlockAttributesChange,
+	isToolbarHidden,
 } from '../reducer';
 
 describe( 'state', () => {
@@ -2401,6 +2402,24 @@ describe( 'state', () => {
 			} );
 
 			expect( state ).toBe( null );
+		} );
+	} );
+
+	describe( 'isToolbarHidden()', () => {
+		it( 'should set the Toolbar hidden flag to true', () => {
+			const state = isToolbarHidden( false, {
+				type: 'HIDE_TOOLBAR',
+			} );
+
+			expect( state ).toBe( true );
+		} );
+
+		it( 'should set the Toolbar hidden flag to false', () => {
+			const state = isToolbarHidden( false, {
+				type: 'SHOW_TOOLBAR',
+			} );
+
+			expect( state ).toBe( false );
 		} );
 	} );
 } );

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -58,6 +58,7 @@ const {
 	getTemplate,
 	getTemplateLock,
 	getBlockListSettings,
+	isToolbarHidden,
 	__experimentalGetBlockListSettingsForBlocks,
 	__experimentalGetLastBlockAttributeChanges,
 	INSERTER_UTILITY_HIGH,
@@ -2366,6 +2367,24 @@ describe( 'selectors', () => {
 			};
 
 			expect( getBlockListSettings( state, 'chicken' ) ).toBe( undefined );
+		} );
+	} );
+
+	describe( 'isToolbarHidden', () => {
+		it( 'should return the hidden flag if the Toolbar is hidden', () => {
+			const state = {
+				isToolbarHidden: true,
+			};
+
+			expect( isToolbarHidden( state ) ).toBe( true );
+		} );
+
+		it( 'should return false if the Toolbar is visible', () => {
+			const state = {
+				isToolbarHidden: false,
+			};
+
+			expect( isToolbarHidden( state ) ).toBe( false );
 		} );
 	} );
 

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -58,7 +58,7 @@ const {
 	getTemplate,
 	getTemplateLock,
 	getBlockListSettings,
-	isToolbarHidden,
+	isToolbarVisible,
 	__experimentalGetBlockListSettingsForBlocks,
 	__experimentalGetLastBlockAttributeChanges,
 	INSERTER_UTILITY_HIGH,
@@ -2370,21 +2370,21 @@ describe( 'selectors', () => {
 		} );
 	} );
 
-	describe( 'isToolbarHidden', () => {
-		it( 'should return the hidden flag if the Toolbar is hidden', () => {
+	describe( 'isToolbarVisible', () => {
+		it( 'should return the visible flag if the Toolbar is visible', () => {
 			const state = {
-				isToolbarHidden: true,
+				isToolbarVisible: true,
 			};
 
-			expect( isToolbarHidden( state ) ).toBe( true );
+			expect( isToolbarVisible( state ) ).toBe( true );
 		} );
 
-		it( 'should return false if the Toolbar is visible', () => {
+		it( 'should return false if the Toolbar is hidden', () => {
 			const state = {
-				isToolbarHidden: false,
+				isToolbarVisible: false,
 			};
 
-			expect( isToolbarHidden( state ) ).toBe( false );
+			expect( isToolbarVisible( state ) ).toBe( false );
 		} );
 	} );
 


### PR DESCRIPTION
## Description
Allow the Toolbar visibility to be managed via the Block Editor store.

Added actions:
- `hideToolbar()`
- `showToolbar()`

Added reducers:
- `isToolbarVisible()`

Added selectors:
- `isToolbarVisible()`

## How has this been tested?

- Add any block to the editor
- Focus it so the Toolbar is visible
- Go to JS console & run:
   - `window.wp.data.dispatch('core/block-editor').hideToolbar()` to hide the toolbar and
   - `window.wp.data.dispatch('core/block-editor').showToolbar()` to bring it back.

## Screenshots <!-- if applicable -->

Visible state:
<img width="530" alt="Screenshot 2020-01-10 14 53 10" src="https://user-images.githubusercontent.com/1451471/72157749-fb386e80-33b8-11ea-91bf-9163ac95c605.png">

Hidden state:
<img width="544" alt="Screenshot 2020-01-10 14 53 20" src="https://user-images.githubusercontent.com/1451471/72157753-fbd10500-33b8-11ea-9ff6-fb91bb019b68.png">

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
