### PR TITLE
[RNMobile] Merge mobile release v1.20.0 back into master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ branches:
   only:
     - master
     - rnmobile/master
-    - rnmobile/releases
+    - /rnmobile\/release.*/
     - /wp\/.*/
 
 env:

--- a/packages/base-styles/_variables.scss
+++ b/packages/base-styles/_variables.scss
@@ -74,7 +74,7 @@ $block-selected-child-border-width: 1px;
 $block-selected-child-padding: 0;
 $block-selected-to-content: $block-edge-to-content - $block-selected-margin - $block-selected-border-width;
 $block-selected-child-to-content: $block-selected-to-content - $block-selected-child-margin - $block-selected-child-border-width;
-$block-custom-appender-to-content: $block-edge-to-content - $block-selected-margin - $block-selected-child-margin + $block-selected-border-width;
+$block-custom-appender-to-content: $block-selected-margin - $block-selected-border-width;
 $block-media-container-to-content: $block-selected-child-margin + $block-selected-border-width;
 
 // Buttons & UI Widgets

--- a/packages/block-editor/src/components/block-list/block.native.js
+++ b/packages/block-editor/src/components/block-list/block.native.js
@@ -14,7 +14,7 @@ import { Component } from '@wordpress/element';
 import { ToolbarButton, Toolbar } from '@wordpress/components';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { compose, withPreferredColorScheme } from '@wordpress/compose';
-import { getBlockType } from '@wordpress/blocks';
+import { getBlockType, getUnregisteredTypeHandlerName } from '@wordpress/blocks';
 import { __, sprintf } from '@wordpress/i18n';
 
 /**
@@ -188,6 +188,17 @@ class BlockListBlock extends Component {
 		];
 	}
 
+	applyToolbarStyle() {
+		const {
+			hasChildren,
+			isUnregisteredBlock,
+		} = this.props;
+
+		if ( ! hasChildren || isUnregisteredBlock ) {
+			return styles.neutralToolbar;
+		}
+	}
+
 	render() {
 		const {
 			clientId,
@@ -228,7 +239,7 @@ class BlockListBlock extends Component {
 						style={ this.applyBlockStyle() }
 					>
 						{ isValid ? this.getBlockForType() : <BlockInvalidWarning blockTitle={ title } icon={ icon } /> }
-						{ isSelected && <BlockMobileToolbar clientId={ clientId } /> }
+						<View style={ this.applyToolbarStyle() } >{ isSelected && <BlockMobileToolbar clientId={ clientId } /> }</View>
 					</View>
 				</TouchableWithoutFeedback>
 			</>
@@ -261,6 +272,8 @@ export default compose( [
 		const isLastBlock = order === getBlocks().length - 1;
 		const block = __unstableGetBlockWithoutInnerBlocks( clientId );
 		const { name, attributes, isValid } = block || {};
+
+		const isUnregisteredBlock = name === getUnregisteredTypeHandlerName();
 		const blockType = getBlockType( name || 'core/missing' );
 		const title = blockType.title;
 		const icon = blockType.icon;
@@ -281,7 +294,7 @@ export default compose( [
 		const commonAncestorIndex = parents.indexOf( commonAncestor ) - 1;
 		const firstToSelectId = commonAncestor ? parents[ commonAncestorIndex ] : parents[ parents.length - 1 ];
 
-		const hasChildren = !! getBlockCount( clientId );
+		const hasChildren = ! isUnregisteredBlock && !! getBlockCount( clientId );
 		const hasParent = !! parentId;
 		const isParentSelected = selectedBlockClientId && selectedBlockClientId === parentId;
 		const isAncestorSelected = selectedBlockClientId && parents.includes( selectedBlockClientId );
@@ -317,6 +330,7 @@ export default compose( [
 			isTouchable,
 			isDimmed,
 			isRootListInnerBlockHolder,
+			isUnregisteredBlock,
 		};
 	} ),
 	withDispatch( ( dispatch, ownProps, { select } ) => {

--- a/packages/block-editor/src/components/block-list/block.native.scss
+++ b/packages/block-editor/src/components/block-list/block.native.scss
@@ -75,12 +75,16 @@
 
 .selectedLeaf {
 	margin: $block-selected-margin;
-	padding: $block-selected-to-content;
+	padding-left: $block-selected-to-content;
+	padding-right: $block-selected-to-content;
+	padding-top: $block-selected-to-content;
 }
 
 .selectedRootLeaf {
 	margin: 0;
-	padding: $block-edge-to-content;
+	padding-left: $block-edge-to-content;
+	padding-right: $block-edge-to-content;
+	padding-top: $block-edge-to-content;
 }
 
 .selectedParent {
@@ -129,4 +133,9 @@
 	width: 1px;
 	background-color: #e9eff3;
 	opacity: 0.4;
+}
+
+.neutralToolbar {
+	margin-left: -$block-edge-to-content;
+	margin-right: -$block-edge-to-content;
 }

--- a/packages/block-editor/src/components/block-list/breadcrumb.native.js
+++ b/packages/block-editor/src/components/block-list/breadcrumb.native.js
@@ -22,7 +22,11 @@ import styles from './breadcrumb.scss';
 const BlockBreadcrumb = ( { clientId, blockIcon, rootClientId, rootBlockIcon } ) => {
 	return (
 		<View style={ styles.breadcrumbContainer }>
-			<TouchableOpacity style={ styles.button } onPress={ () => {/* Open BottomSheet with markup */} }>
+			<TouchableOpacity
+				style={ styles.button }
+				onPress={ () => {/* Open BottomSheet with markup */} }
+				disabled={ true } /* Disable temporarily since onPress function is empty */
+			>
 				{ rootClientId && rootBlockIcon && (
 					[ <Icon key="parent-icon" size={ 20 } icon={ rootBlockIcon.src } fill={ styles.icon.color } />,
 						<View key="subdirectory-icon" style={ styles.arrow }><SubdirectorSVG fill={ styles.arrow.color } /></View>,

--- a/packages/block-library/src/media-text/style.native.scss
+++ b/packages/block-library/src/media-text/style.native.scss
@@ -34,7 +34,6 @@
 
 .contentCentered {
 	flex: 1;
-	justify-content: center;
 	align-items: center;
 }
 

--- a/packages/block-library/src/missing/index.js
+++ b/packages/block-library/src/missing/index.js
@@ -16,7 +16,7 @@ export { metadata, name };
 
 export const settings = {
 	name,
-	title: __( 'Unrecognized Block' ),
+	title: __( 'Unsupported' ),
 	description: __( 'Your site doesn’t include support for this block.' ),
 	supports: {
 		className: false,

--- a/packages/components/src/button/index.native.js
+++ b/packages/components/src/button/index.native.js
@@ -125,8 +125,8 @@ export function Button( props ) {
 		)
 	);
 
-	const newIcon = cloneElement( ( icon && <Icon icon={ icon } size={ iconSize } /> ),
-		{ colorScheme: props.preferredColorScheme, isPressed } );
+	const newIcon = icon ? cloneElement( ( <Icon icon={ icon } size={ iconSize } /> ),
+		{ colorScheme: props.preferredColorScheme, isPressed } ) : null;
 
 	const element = (
 		<TouchableOpacity


### PR DESCRIPTION
## Description
Related PR in gutenberg-mobile: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1752

## Details:

- Fix styting after navigation feature merge (#19455) 
- Fix rich text focus loop (#19240)
- Fix displaying photo during upload (#19502)
- Fix crash when adding Group (#19457)

## How has this been tested?
This should be tested in this gutenberg-mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1752 and in the WP apps directly (WPAndroid - wordpress-mobile/WordPress-Android#11052, WPiOS - wordpress-mobile/WordPress-iOS#13190).

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
