### PR TITLE
Remove the text color button double border on the navigation block toolbar

### DIFF
--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -138,13 +138,6 @@ $colors-selector-size: 22px;
 		&::after {
 			@include dropdown-arrow();
 		}
-
-		// Styling button states.
-		&:focus,
-		&:hover {
-			color: $dark-gray-500;
-			box-shadow: inset 0 0 0 1px $dark-gray-500, inset 0 0 0 2px #fff;
-		}
 	}
 
 	// colors-selector - selection status.


### PR DESCRIPTION
Removed CSS that gave a focus and hover border on the text color selection in the navigation toolbar.

This border is already handled by the wrapping toolbar button, so there was a double border on this item when it was hovered or focused.

## Description
There was a double border on the text color button in the navigation toolbar.
![double-border-on-color-menu](https://user-images.githubusercontent.com/967608/72169932-9fa8b980-3395-11ea-97b0-ffff2b3e413e.gif)

I removed the CSS for the inner border from the navigation CSS.
![no-double-border-on-text-color-button-on-hover-focus](https://user-images.githubusercontent.com/967608/72170541-ab48b000-3396-11ea-8f24-d90f3666345a.gif)

## How has this been tested?
Manually, in Chrome

## Types of changes
CSS Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->


