### PR TITLE
Block Library: Implement Post block and Post blocks editing.

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -32,6 +32,7 @@ function gutenberg_reregister_core_block_types() {
 		'tag-cloud.php'           => 'core/tag-cloud',
 		'site-title.php'          => 'core/site-title',
 		'template-part.php'       => 'core/template-part',
+		'post.php'                => 'core/post',
 		'post-title.php'          => 'core/post-title',
 		'post-content.php'        => 'core/post-content',
 		'post-author.php'         => 'core/post-author',

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -125,3 +125,75 @@ function gutenberg_get_post_from_context() {
 	}
 	return get_post();
 }
+
+/**
+ * Shim that hooks into `pre_render_block` so as to override `render_block`
+ * with a function that passes `render_callback` the block object as an
+ * argument and adds support for block context attributes.
+ *
+ * @param string $pre_render The pre-rendered content. Defaults to null.
+ * @param array  $block      The block being rendered.
+ * @param array  $context    The block context.
+ *
+ * @return string String of rendered HTML.
+ */
+function gutenberg_provide_render_callback_with_block_object( $pre_render, $block, $context = array() ) {
+	global $post;
+
+	$source_block = $block;
+	/** This filter is documented in src/wp-includes/blocks.php */
+	$block         = apply_filters( 'render_block_data', $block, $source_block );
+	$block_type    = WP_Block_Type_Registry::get_instance()->get_registered( $block['blockName'] );
+	$is_dynamic    = $block['blockName'] && null !== $block_type && $block_type->is_dynamic();
+	$block_content = '';
+	$index         = 0;
+
+	if ( ! is_array( $block['attrs'] ) ) {
+		$block['attrs'] = array();
+	}
+
+	$block['context'] = array();
+	$next_context     = $context;
+	if ( $block_type ) {
+		if ( isset( $block_type->context ) ) {
+			foreach ( $block_type->context as $attribute_name => $block_names ) {
+				$block_names = is_array( $block_names ) ? $block_names : array( $block_names );
+				foreach ( $block_names as $block_name ) {
+					if ( isset( $context[ $block_name ][ $attribute_name ] ) ) {
+						$block['context'][ $attribute_name ] = $context[ $block_name ][ $attribute_name ];
+					}
+				}
+			}
+		}
+		if ( isset( $block_type->attributes ) ) {
+			foreach ( $block_type->attributes as $attribute_name => $attribute_config ) {
+				if ( $attribute_config['context'] && isset( $block['attrs'][ $attribute_name ] ) ) {
+					if ( ! isset( $next_context[ $block['blockName'] ] ) ) {
+						$next_context[ $block['blockName'] ] = array();
+					}
+					$next_context[ $block['blockName'] ][ $attribute_name ] = $block['attrs'][ $attribute_name ];
+				}
+			}
+		}
+	}
+
+	foreach ( $block['innerContent'] as $chunk ) {
+		if ( is_string( $chunk ) ) {
+			$block_content .= $chunk;
+		} else {
+			$inner_block    = $block['innerBlocks'][ $index++ ];
+			$block_content .= gutenberg_provide_render_callback_with_block_object( null, $inner_block, $next_context );
+		}
+	}
+
+	if ( $is_dynamic ) {
+		$global_post = $post;
+
+		$prepared_attributes = $block_type->prepare_attributes_for_render( $block['attrs'] );
+		$block_content       = (string) call_user_func( $block_type->render_callback, $prepared_attributes, $block_content, $block );
+		$post                = $global_post;
+	}
+	/** This filter is documented in src/wp-includes/blocks.php */
+	return apply_filters( 'render_block', $block_content, $block );
+}
+add_filter( 'pre_render_block', 'gutenberg_provide_render_callback_with_block_object', 10, 2 );

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -167,7 +167,7 @@ function gutenberg_provide_render_callback_with_block_object( $pre_render, $bloc
 		}
 		if ( isset( $block_type->attributes ) ) {
 			foreach ( $block_type->attributes as $attribute_name => $attribute_config ) {
-				if ( $attribute_config['context'] && isset( $block['attrs'][ $attribute_name ] ) ) {
+				if ( isset( $attribute_config['context'] ) && $attribute_config['context'] && isset( $block['attrs'][ $attribute_name ] ) ) {
 					if ( ! isset( $next_context[ $block['blockName'] ] ) ) {
 						$next_context[ $block['blockName'] ] = array();
 					}

--- a/packages/block-editor/src/components/block-list/block-context.js
+++ b/packages/block-editor/src/components/block-list/block-context.js
@@ -1,0 +1,69 @@
+/**
+ * External dependencies
+ */
+import { castArray } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { createContext, useContext, useMemo } from '@wordpress/element';
+
+const context = {};
+const getContext = ( blockName, attributeName ) => {
+	if ( ! context[ blockName ] ) {
+		context[ blockName ] = {};
+	}
+	if ( ! context[ blockName ][ attributeName ] ) {
+		context[ blockName ][ attributeName ] = createContext();
+	}
+	return context[ blockName ][ attributeName ];
+};
+
+function Providers( { blockType, blockAttributes, children } ) {
+	for ( const [ attributeName, attributeConfig ] of Object.entries(
+		blockType.attributes
+	) ) {
+		if (
+			attributeConfig.context &&
+			blockAttributes[ attributeName ] !== undefined
+		) {
+			const Provider = getContext( blockType.name, attributeName ).Provider;
+			children = (
+				<Provider value={ blockAttributes[ attributeName ] }>{ children }</Provider>
+			);
+		}
+	}
+	return children;
+}
+function BlockContext( {
+	blockType,
+	blockAttributes,
+	Component,
+	...componentProps
+} ) {
+	const blockContext = {};
+	if ( blockType.context ) {
+		for ( const [ attributeName, blockNameOrBlockNames ] of Object.entries(
+			blockType.context
+		) ) {
+			const blockNames = castArray( blockNameOrBlockNames );
+			for ( const blockName of blockNames ) {
+				// eslint-disable-next-line react-hooks/rules-of-hooks
+				const contextValue = useContext( getContext( blockName, attributeName ) );
+				if ( contextValue !== undefined ) {
+					blockContext[ attributeName ] = contextValue;
+				}
+			}
+		}
+	}
+	return (
+		<Providers blockType={ blockType } blockAttributes={ blockAttributes }>
+			<Component
+				{ ...componentProps }
+				context={ useMemo( () => blockContext, Object.values( blockContext ) ) }
+			/>
+		</Providers>
+	);
+}
+BlockContext.Providers = Providers;
+export default BlockContext;

--- a/packages/block-editor/src/components/block-list/block-context.js
+++ b/packages/block-editor/src/components/block-list/block-context.js
@@ -27,9 +27,12 @@ function Providers( { blockType, blockAttributes, children } ) {
 			attributeConfig.context &&
 			blockAttributes[ attributeName ] !== undefined
 		) {
-			const Provider = getContext( blockType.name, attributeName ).Provider;
+			const Provider = getContext( blockType.name, attributeName )
+				.Provider;
 			children = (
-				<Provider value={ blockAttributes[ attributeName ] }>{ children }</Provider>
+				<Provider value={ blockAttributes[ attributeName ] }>
+					{ children }
+				</Provider>
 			);
 		}
 	}
@@ -49,7 +52,9 @@ function BlockContext( {
 			const blockNames = castArray( blockNameOrBlockNames );
 			for ( const blockName of blockNames ) {
 				// eslint-disable-next-line react-hooks/rules-of-hooks
-				const contextValue = useContext( getContext( blockName, attributeName ) );
+				const contextValue = useContext(
+					getContext( blockName, attributeName )
+				);
 				if ( contextValue !== undefined ) {
 					blockContext[ attributeName ] = contextValue;
 				}
@@ -60,7 +65,10 @@ function BlockContext( {
 		<Providers blockType={ blockType } blockAttributes={ blockAttributes }>
 			<Component
 				{ ...componentProps }
-				context={ useMemo( () => blockContext, Object.values( blockContext ) ) }
+				context={ useMemo(
+					() => blockContext,
+					Object.values( blockContext )
+				) }
 			/>
 		</Providers>
 	);

--- a/packages/block-editor/src/components/block-list/block-context.js
+++ b/packages/block-editor/src/components/block-list/block-context.js
@@ -20,24 +20,28 @@ const getContext = ( blockName, attributeName ) => {
 };
 
 function Providers( { blockType, blockAttributes, children } ) {
-	for ( const [ attributeName, attributeConfig ] of Object.entries(
-		blockType.attributes
-	) ) {
-		if (
-			attributeConfig.context &&
-			blockAttributes[ attributeName ] !== undefined
-		) {
-			const Provider = getContext( blockType.name, attributeName )
-				.Provider;
-			children = (
-				<Provider value={ blockAttributes[ attributeName ] }>
-					{ children }
-				</Provider>
-			);
+	if ( blockType ) {
+		for ( const [ attributeName, attributeConfig ] of Object.entries(
+			blockType.attributes
+		) ) {
+			if (
+				attributeConfig.context &&
+				blockAttributes[ attributeName ] !== undefined
+			) {
+				const Provider = getContext( blockType.name, attributeName )
+					.Provider;
+				children = (
+					<Provider value={ blockAttributes[ attributeName ] }>
+						{ children }
+					</Provider>
+				);
+			}
 		}
 	}
+
 	return children;
 }
+
 function BlockContext( {
 	blockType,
 	blockAttributes,

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -24,7 +24,7 @@ import { compose, pure, ifCondition } from '@wordpress/compose';
 /**
  * Internal dependencies
  */
-import BlockContext from './block-context';
+import _BlockContext from './block-context';
 import BlockEdit from '../block-edit';
 import BlockInvalidWarning from './block-invalid-warning';
 import BlockCrashWarning from './block-crash-warning';
@@ -131,7 +131,7 @@ function BlockListBlock( {
 	// (InspectorControls, etc.) which are inside `BlockEdit` but not
 	// `BlockHTML`, even in HTML mode.
 	let blockEdit = (
-		<BlockContext
+		<_BlockContext
 			blockType={ blockType }
 			blockAttributes={ attributes }
 			Component={ BlockEdit }

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -24,6 +24,7 @@ import { compose, pure, ifCondition } from '@wordpress/compose';
 /**
  * Internal dependencies
  */
+import BlockContext from './block-context';
 import BlockEdit from '../block-edit';
 import BlockInvalidWarning from './block-invalid-warning';
 import BlockCrashWarning from './block-crash-warning';
@@ -130,7 +131,10 @@ function BlockListBlock( {
 	// (InspectorControls, etc.) which are inside `BlockEdit` but not
 	// `BlockHTML`, even in HTML mode.
 	let blockEdit = (
-		<BlockEdit
+		<BlockContext
+			blockType={ blockType }
+			blockAttributes={ attributes }
+			Component={ BlockEdit }
 			name={ name }
 			isSelected={ isSelected }
 			attributes={ attributes }

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -16,6 +16,7 @@ import BlockListBlock from './block';
 import BlockListAppender from '../block-list-appender';
 import RootContainer from './root-container';
 import useBlockDropZone from '../block-drop-zone';
+import BlockContext from './block-context';
 
 /**
  * If the block count exceeds the threshold, we disable the reordering animation
@@ -129,7 +130,7 @@ const ForwardedBlockList = forwardRef( BlockList );
 // This component needs to always be synchronous
 // as it's the one changing the async mode
 // depending on the block selection.
-export default forwardRef( ( props, ref ) => {
+BlockList = forwardRef( ( props, ref ) => {
 	const fallbackRef = useRef();
 	return (
 		<AsyncModeProvider value={ false }>
@@ -137,3 +138,5 @@ export default forwardRef( ( props, ref ) => {
 		</AsyncModeProvider>
 	);
 } );
+BlockList.BlockContext = BlockContext;
+export default BlockList;

--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -28,6 +28,7 @@
 @import "./navigation-link/editor.scss";
 @import "./nextpage/editor.scss";
 @import "./paragraph/editor.scss";
+@import "./post/editor.scss";
 @import "./post-excerpt/editor.scss";
 @import "./pullquote/editor.scss";
 @import "./quote/editor.scss";

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -65,6 +65,7 @@ import * as socialLink from './social-link';
 // Full Site Editing Blocks
 import * as siteTitle from './site-title';
 import * as templatePart from './template-part';
+import * as post from './post';
 import * as postTitle from './post-title';
 import * as postContent from './post-content';
 import * as postAuthor from './post-author';
@@ -197,6 +198,7 @@ export const __experimentalRegisterExperimentalCoreBlocks =
 						? [
 								siteTitle,
 								templatePart,
+								post,
 								postTitle,
 								postContent,
 								postAuthor,

--- a/packages/block-library/src/post-content/block.json
+++ b/packages/block-library/src/post-content/block.json
@@ -1,4 +1,8 @@
 {
 	"name": "core/post-content",
-	"category": "layout"
+	"category": "layout",
+	"context": {
+		"postType": "core/post",
+		"postId": "core/post"
+	}
 }

--- a/packages/block-library/src/post-content/edit.js
+++ b/packages/block-library/src/post-content/edit.js
@@ -1,13 +1,16 @@
 /**
  * WordPress dependencies
  */
-import { useEntityBlockEditor, useEntityId } from '@wordpress/core-data';
+import { useEntityBlockEditor } from '@wordpress/core-data';
 import { InnerBlocks } from '@wordpress/block-editor';
 
-function PostContentInnerBlocks() {
+function PostContentInnerBlocks( { postType, postId } ) {
 	const [ blocks, onInput, onChange ] = useEntityBlockEditor(
 		'postType',
-		'post'
+		postType,
+		{
+			id: postId,
+		}
 	);
 	return (
 		<InnerBlocks
@@ -18,10 +21,10 @@ function PostContentInnerBlocks() {
 	);
 }
 
-export default function PostContentEdit() {
-	if ( ! useEntityId( 'postType', 'post' ) ) {
+export default function PostContentEdit( { context: { postType, postId } } ) {
+	if ( ! postType || ! postId ) {
 		return 'Post Content Placeholder';
 	}
 
-	return <PostContentInnerBlocks />;
+	return <PostContentInnerBlocks postType={ postType } postId={ postId } />;
 }

--- a/packages/block-library/src/post-content/edit.js
+++ b/packages/block-library/src/post-content/edit.js
@@ -1,9 +1,27 @@
-export default function PostContentEdit() {
-	return (
-		<p>
-			{
-				'Welcome to WordPress and the wonderful world of blocks. This content represents how a post would look when editing block templates.'
-			}
-		</p>
+/**
+ * WordPress dependencies
+ */
+import { useEntityBlockEditor, useEntityId } from '@wordpress/core-data';
+import { InnerBlocks } from '@wordpress/block-editor';
+
+function PostContentInnerBlocks() {
+	const [ blocks, onInput, onChange ] = useEntityBlockEditor(
+		'postType',
+		'post'
 	);
+	return (
+		<InnerBlocks
+			__experimentalBlocks={ blocks }
+			onInput={ onInput }
+			onChange={ onChange }
+		/>
+	);
+}
+
+export default function PostContentEdit() {
+	if ( ! useEntityId( 'postType', 'post' ) ) {
+		return 'Post Content Placeholder';
+	}
+
+	return <PostContentInnerBlocks />;
 }

--- a/packages/block-library/src/post-content/index.php
+++ b/packages/block-library/src/post-content/index.php
@@ -8,16 +8,20 @@
 /**
  * Renders the `core/post-content` block on the server.
  *
+ * @param array $attributes The block attributes.
+ * @param array $content    The saved content.
+ * @param array $block      The parsed block.
+ *
  * @return string Returns the filtered post content of the current post.
  */
-function render_block_core_post_content() {
-	$post = gutenberg_get_post_from_context();
+function render_block_core_post_content( $attributes, $content, $block ) {
+	$post = isset( $block['context']['postId'] ) ? $block['context']['postId'] : gutenberg_get_post_from_context();
 	if ( ! $post ) {
 		return '';
 	}
 	return (
 		'<div class="entry-content">' .
-			apply_filters( 'the_content', str_replace( ']]>', ']]&gt;', get_the_content( $post ) ) ) .
+			apply_filters( 'the_content', str_replace( ']]>', ']]&gt;', get_the_content( null, false, $post ) ) ) .
 		'</div>'
 	);
 }
@@ -34,6 +38,10 @@ function register_block_core_post_content() {
 		array_merge(
 			$metadata,
 			array(
+				'context'         => array(
+					'postType' => 'core/post',
+					'postId'   => 'core/post',
+				),
 				'render_callback' => 'render_block_core_post_content',
 			)
 		)

--- a/packages/block-library/src/post-title/block.json
+++ b/packages/block-library/src/post-title/block.json
@@ -1,4 +1,8 @@
 {
 	"name": "core/post-title",
-	"category": "layout"
+	"category": "layout",
+	"context": {
+		"postType": "core/post",
+		"postId": "core/post"
+	}
 }

--- a/packages/block-library/src/post-title/edit.js
+++ b/packages/block-library/src/post-title/edit.js
@@ -1,12 +1,17 @@
 /**
  * WordPress dependencies
  */
-import { useEntityProp, useEntityId } from '@wordpress/core-data';
+import { useEntityProp } from '@wordpress/core-data';
 import { RichText } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 
-function PostTitleInput() {
-	const [ title, setTitle ] = useEntityProp( 'postType', 'post', 'title' );
+function PostTitleInput( { postType, postId } ) {
+	const [ title, setTitle ] = useEntityProp(
+		'postType',
+		postType,
+		'title',
+		postId
+	);
 	return (
 		<RichText
 			tagName="h2"
@@ -18,10 +23,10 @@ function PostTitleInput() {
 	);
 }
 
-export default function PostTitleEdit() {
-	if ( ! useEntityId( 'postType', 'post' ) ) {
+export default function PostTitleEdit( { context: { postType, postId } } ) {
+	if ( ! postType || ! postId ) {
 		return 'Post Title Placeholder';
 	}
 
-	return <PostTitleInput />;
+	return <PostTitleInput postType={ postType } postId={ postId } />;
 }

--- a/packages/block-library/src/post-title/edit.js
+++ b/packages/block-library/src/post-title/edit.js
@@ -1,3 +1,27 @@
+/**
+ * WordPress dependencies
+ */
+import { useEntityProp, useEntityId } from '@wordpress/core-data';
+import { RichText } from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
+
+function PostTitleInput() {
+	const [ title, setTitle ] = useEntityProp( 'postType', 'post', 'title' );
+	return (
+		<RichText
+			tagName="h2"
+			placeholder={ __( 'Post Title' ) }
+			value={ title }
+			onChange={ setTitle }
+			allowedFormats={ [] }
+		/>
+	);
+}
+
 export default function PostTitleEdit() {
-	return <h2>{ 'Hello world!' }</h2>;
+	if ( ! useEntityId( 'postType', 'post' ) ) {
+		return 'Post Title Placeholder';
+	}
+
+	return <PostTitleInput />;
 }

--- a/packages/block-library/src/post-title/index.php
+++ b/packages/block-library/src/post-title/index.php
@@ -8,10 +8,14 @@
 /**
  * Renders the `core/post-title` block on the server.
  *
+ * @param array $attributes The block attributes.
+ * @param array $content    The saved content.
+ * @param array $block      The parsed block.
+ *
  * @return string Returns the filtered post title for the current post wrapped inside "h1" tags.
  */
-function render_block_core_post_title() {
-	$post = gutenberg_get_post_from_context();
+function render_block_core_post_title( $attributes, $content, $block ) {
+	$post = isset( $block['context']['postId'] ) ? $block['context']['postId'] : gutenberg_get_post_from_context();
 	if ( ! $post ) {
 		return '';
 	}
@@ -30,6 +34,10 @@ function register_block_core_post_title() {
 		array_merge(
 			$metadata,
 			array(
+				'context'         => array(
+					'postType' => 'core/post',
+					'postId'   => 'core/post',
+				),
 				'render_callback' => 'render_block_core_post_title',
 			)
 		)

--- a/packages/block-library/src/post/block.json
+++ b/packages/block-library/src/post/block.json
@@ -1,0 +1,4 @@
+{
+	"name": "core/post",
+	"category": "layout"
+}

--- a/packages/block-library/src/post/block.json
+++ b/packages/block-library/src/post/block.json
@@ -1,4 +1,14 @@
 {
 	"name": "core/post",
-	"category": "layout"
+	"category": "layout",
+	"attributes": {
+		"postType": {
+			"type": "string",
+			"context": true
+		},
+		"postId": {
+			"type": "string",
+			"context": true
+		}
+	}
 }

--- a/packages/block-library/src/post/edit/index.js
+++ b/packages/block-library/src/post/edit/index.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { EntityProvider } from '@wordpress/core-data';
 import { InnerBlocks } from '@wordpress/block-editor';
 
 /**
@@ -10,27 +9,26 @@ import { InnerBlocks } from '@wordpress/block-editor';
  */
 import PostPlaceholder from './placeholder';
 
-export default function PostEdit( { attributes: { postId }, setAttributes } ) {
+export default function PostEdit( {
+	attributes: { postType, postId },
+	setAttributes,
+} ) {
 	const loaded = useSelect(
 		( select ) => {
-			if ( ! postId ) {
+			if ( ! postType || ! postId ) {
 				return false;
 			}
 			return Boolean(
-				select( 'core' ).getEntityRecord( 'postType', 'post', postId )
+				select( 'core' ).getEntityRecord( 'postType', postType, postId )
 			);
 		},
-		[ postId ]
+		[ postType, postId ]
 	);
-	if ( postId ) {
+	if ( postType && postId ) {
 		if ( ! loaded ) {
 			return null;
 		}
-		return (
-			<EntityProvider kind="postType" type="post" id={ postId }>
-				<InnerBlocks />
-			</EntityProvider>
-		);
+		return <InnerBlocks />;
 	}
 	return <PostPlaceholder setAttributes={ setAttributes } />;
 }

--- a/packages/block-library/src/post/edit/index.js
+++ b/packages/block-library/src/post/edit/index.js
@@ -1,0 +1,36 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { EntityProvider } from '@wordpress/core-data';
+import { InnerBlocks } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import PostPlaceholder from './placeholder';
+
+export default function PostEdit( { attributes: { postId }, setAttributes } ) {
+	const loaded = useSelect(
+		( select ) => {
+			if ( ! postId ) {
+				return false;
+			}
+			return Boolean(
+				select( 'core' ).getEntityRecord( 'postType', 'post', postId )
+			);
+		},
+		[ postId ]
+	);
+	if ( postId ) {
+		if ( ! loaded ) {
+			return null;
+		}
+		return (
+			<EntityProvider kind="postType" type="post" id={ postId }>
+				<InnerBlocks />
+			</EntityProvider>
+		);
+	}
+	return <PostPlaceholder setAttributes={ setAttributes } />;
+}

--- a/packages/block-library/src/post/edit/placeholder.js
+++ b/packages/block-library/src/post/edit/placeholder.js
@@ -1,15 +1,17 @@
 /**
  * WordPress dependencies
  */
-import { useEntityBlockEditor, EntityProvider } from '@wordpress/core-data';
+import { useEntityBlockEditor } from '@wordpress/core-data';
 import { __ } from '@wordpress/i18n';
 import { BlockPreview } from '@wordpress/block-editor';
 import { useState, useCallback } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { Placeholder, TextControl, Button } from '@wordpress/components';
 
-function PostPreview() {
-	const [ blocks ] = useEntityBlockEditor( 'postType', 'post' );
+function PostPreview( { postType, postId } ) {
+	const [ blocks ] = useEntityBlockEditor( 'postType', postType, {
+		id: postId,
+	} );
 	return (
 		<div className="wp-block-post__placeholder-preview">
 			<div className="wp-block-post__placeholder-preview-title">
@@ -21,24 +23,28 @@ function PostPreview() {
 }
 
 export default function PostPlaceholder( { setAttributes } ) {
+	const [ postType, setPostType ] = useState( 'post' );
 	const [ postId, setPostId ] = useState();
 	const preview = useSelect(
 		( select ) => {
-			if ( ! postId ) {
+			if ( ! postType || ! postId ) {
 				return null;
 			}
-			const post = select( 'core' ).getEntityRecord( 'postType', 'post', postId );
+			const post = select( 'core' ).getEntityRecord(
+				'postType',
+				postType,
+				postId
+			);
 			if ( post ) {
-				return (
-					<EntityProvider kind="postType" type="post" id={ postId }>
-						<PostPreview />
-					</EntityProvider>
-				);
+				return <PostPreview postType={ postType } postId={ postId } />;
 			}
 		},
-		[ postId ]
+		[ postType, postId ]
 	);
-	const choosePostId = useCallback( () => setAttributes( { postId } ), [ postId ] );
+	const choosePost = useCallback(
+		() => setAttributes( { postType, postId } ),
+		[ postType, postId ]
+	);
 	return (
 		<Placeholder
 			icon="media-document"
@@ -47,15 +53,27 @@ export default function PostPlaceholder( { setAttributes } ) {
 		>
 			<div className="wp-block-post__placeholder-input-container">
 				<TextControl
+					label={ __( 'Post Type' ) }
+					placeholder={ __( 'post' ) }
+					value={ postType }
+					onChange={ setPostType }
+					className="wp-block-post__placeholder-input"
+				/>
+				<TextControl
 					label={ __( 'Post ID' ) }
 					placeholder={ __( '1' ) }
 					value={ postId }
 					onChange={ setPostId }
 					help={ preview === undefined && __( 'Post not found.' ) }
+					className="wp-block-post__placeholder-input"
 				/>
 			</div>
 			{ preview }
-			<Button isPrimary disabled={ ! postId || ! preview } onClick={ choosePostId }>
+			<Button
+				isPrimary
+				disabled={ ! postType || ! postId || ! preview }
+				onClick={ choosePost }
+			>
 				{ __( 'Choose' ) }
 			</Button>
 		</Placeholder>

--- a/packages/block-library/src/post/edit/placeholder.js
+++ b/packages/block-library/src/post/edit/placeholder.js
@@ -1,0 +1,63 @@
+/**
+ * WordPress dependencies
+ */
+import { useEntityBlockEditor, EntityProvider } from '@wordpress/core-data';
+import { __ } from '@wordpress/i18n';
+import { BlockPreview } from '@wordpress/block-editor';
+import { useState, useCallback } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+import { Placeholder, TextControl, Button } from '@wordpress/components';
+
+function PostPreview() {
+	const [ blocks ] = useEntityBlockEditor( 'postType', 'post' );
+	return (
+		<div className="wp-block-post__placeholder-preview">
+			<div className="wp-block-post__placeholder-preview-title">
+				{ __( 'Preview' ) }
+			</div>
+			<BlockPreview blocks={ blocks } />
+		</div>
+	);
+}
+
+export default function PostPlaceholder( { setAttributes } ) {
+	const [ postId, setPostId ] = useState();
+	const preview = useSelect(
+		( select ) => {
+			if ( ! postId ) {
+				return null;
+			}
+			const post = select( 'core' ).getEntityRecord( 'postType', 'post', postId );
+			if ( post ) {
+				return (
+					<EntityProvider kind="postType" type="post" id={ postId }>
+						<PostPreview />
+					</EntityProvider>
+				);
+			}
+		},
+		[ postId ]
+	);
+	const choosePostId = useCallback( () => setAttributes( { postId } ), [ postId ] );
+	return (
+		<Placeholder
+			icon="media-document"
+			label={ __( 'Post' ) }
+			instructions={ __( 'Choose a post by post ID.' ) }
+		>
+			<div className="wp-block-post__placeholder-input-container">
+				<TextControl
+					label={ __( 'Post ID' ) }
+					placeholder={ __( '1' ) }
+					value={ postId }
+					onChange={ setPostId }
+					help={ preview === undefined && __( 'Post not found.' ) }
+				/>
+			</div>
+			{ preview }
+			<Button isPrimary disabled={ ! postId || ! preview } onClick={ choosePostId }>
+				{ __( 'Choose' ) }
+			</Button>
+		</Placeholder>
+	);
+}

--- a/packages/block-library/src/post/editor.scss
+++ b/packages/block-library/src/post/editor.scss
@@ -1,0 +1,24 @@
+.wp-block-post__placeholder-input-container {
+	display: flex;
+	flex-wrap: wrap;
+	width: 100%;
+}
+
+.wp-block-post__placeholder-preview {
+	margin-bottom: 15px;
+	width: 100%;
+
+	.block-editor-block-preview__container {
+		padding: 1px;
+	}
+
+	.block-editor-block-preview__content {
+		position: initial;
+	}
+}
+
+.wp-block-post__placeholder-preview-title {
+	font-size: 15px;
+	font-weight: 600;
+	margin-bottom: 4px;
+}

--- a/packages/block-library/src/post/editor.scss
+++ b/packages/block-library/src/post/editor.scss
@@ -4,6 +4,10 @@
 	width: 100%;
 }
 
+.wp-block-post__placeholder-input {
+	margin: 5px;
+}
+
 .wp-block-post__placeholder-preview {
 	margin-bottom: 15px;
 	width: 100%;

--- a/packages/block-library/src/post/index.js
+++ b/packages/block-library/src/post/index.js
@@ -1,0 +1,18 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+import edit from './edit';
+
+const { name } = metadata;
+export { metadata, name };
+
+export const settings = {
+	title: __( 'Post' ),
+	edit,
+};

--- a/packages/block-library/src/post/index.js
+++ b/packages/block-library/src/post/index.js
@@ -8,6 +8,7 @@ import { __ } from '@wordpress/i18n';
  */
 import metadata from './block.json';
 import edit from './edit';
+import save from './save';
 
 const { name } = metadata;
 export { metadata, name };
@@ -15,4 +16,5 @@ export { metadata, name };
 export const settings = {
 	title: __( 'Post' ),
 	edit,
+	save,
 };

--- a/packages/block-library/src/post/index.php
+++ b/packages/block-library/src/post/index.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Server-side registration of the `core/post` block.
+ *
+ * @package WordPress
+ */
+
+/**
+ * Registers the `core/post` block on the server.
+ */
+function register_block_core_post() {
+	register_block_type(
+		'core/post',
+		array(
+			'attributes' => array(
+				'postType' => array(
+					'type'    => 'string',
+					'context' => true,
+				),
+				'postId'   => array(
+					'type'    => 'string',
+					'context' => true,
+				),
+			),
+		)
+	);
+}
+add_action( 'init', 'register_block_core_post' );

--- a/packages/block-library/src/post/index.php
+++ b/packages/block-library/src/post/index.php
@@ -9,20 +9,11 @@
  * Registers the `core/post` block on the server.
  */
 function register_block_core_post() {
+	$path     = __DIR__ . '/post/block.json';
+	$metadata = json_decode( file_get_contents( $path ), true );
 	register_block_type(
-		'core/post',
-		array(
-			'attributes' => array(
-				'postType' => array(
-					'type'    => 'string',
-					'context' => true,
-				),
-				'postId'   => array(
-					'type'    => 'string',
-					'context' => true,
-				),
-			),
-		)
+		$metadata['name'],
+		$metadata
 	);
 }
 add_action( 'init', 'register_block_core_post' );

--- a/packages/block-library/src/post/save.js
+++ b/packages/block-library/src/post/save.js
@@ -1,0 +1,8 @@
+/**
+ * WordPress dependencies
+ */
+import { InnerBlocks } from '@wordpress/block-editor';
+
+export default function PostSave() {
+	return <InnerBlocks.Content />;
+}

--- a/packages/core-data/src/entity-provider.js
+++ b/packages/core-data/src/entity-provider.js
@@ -74,16 +74,25 @@ export function useEntityId( kind, type ) {
  * specified property of the nearest provided
  * entity of the specified type.
  *
- * @param {string} kind The entity kind.
- * @param {string} type The entity type.
- * @param {string} prop The property name.
+ * You may optionally override the provided ID
+ * using the last parameter.
+ *
+ * @param {string} kind                           The entity kind.
+ * @param {string} type                           The entity type.
+ * @param {string} prop                           The property name.
+ * @param {string} [id=useEntityId( kind, type )] The optional entity ID override.
  *
  * @return {[*, Function]} A tuple where the first item is the
  *                          property value and the second is the
  *                          setter.
  */
-export function useEntityProp( kind, type, prop ) {
-	const id = useEntityId( kind, type );
+export function useEntityProp(
+	kind,
+	type,
+	prop,
+	// eslint-disable-next-line react-hooks/rules-of-hooks
+	id = useEntityId( kind, type )
+) {
 	const { value, fullValue } = useSelect(
 		( select ) => {
 			const { getEntityRecord, getEditedEntityRecord } = select( 'core' );
@@ -122,24 +131,38 @@ export function useEntityProp( kind, type, prop ) {
  * `BlockEditorProvider` and are intended to be used with it,
  * or similar components or hooks.
  *
- * @param {string} kind                            The entity kind.
- * @param {string} type                            The entity type.
+ * You may optionally override the provided ID
+ * using the last parameter.
+ *
+ * @param {string} kind                                    The entity kind.
+ * @param {string} type                                    The entity type.
  * @param {Object} options
- * @param {Object} [options.initialEdits]          Initial edits object for the entity record.
- * @param {string} [options.blocksProp='blocks']   The name of the entity prop that holds the blocks array.
- * @param {string} [options.contentProp='content'] The name of the entity prop that holds the serialized blocks.
+ * @param {Object} [options.initialEdits]                  Initial edits object for the entity record.
+ * @param {string} [options.blocksProp='blocks']           The name of the entity prop that holds the blocks array.
+ * @param {string} [options.contentProp='content']         The name of the entity prop that holds the serialized blocks.
+ * @param {string} [options.id=useEntityId( kind, type )]  The optional entity ID override.
  *
  * @return {[WPBlock[], Function, Function]} The block array and setters.
  */
 export function useEntityBlockEditor(
 	kind,
 	type,
-	{ initialEdits, blocksProp = 'blocks', contentProp = 'content' } = {}
+	{
+		initialEdits,
+		blocksProp = 'blocks',
+		contentProp = 'content',
+		// eslint-disable-next-line react-hooks/rules-of-hooks
+		id = useEntityId( kind, type ),
+	} = {}
 ) {
-	const [ content, setContent ] = useEntityProp( kind, type, contentProp );
+	const [ content, setContent ] = useEntityProp(
+		kind,
+		type,
+		contentProp,
+		id
+	);
 
 	const { editEntityRecord } = useDispatch( 'core' );
-	const id = useEntityId( kind, type );
 	const initialBlocks = useMemo( () => {
 		if ( initialEdits ) {
 			editEntityRecord( kind, type, id, initialEdits, {
@@ -157,7 +180,8 @@ export function useEntityBlockEditor(
 	const [ blocks = initialBlocks, onInput ] = useEntityProp(
 		kind,
 		type,
-		blocksProp
+		blocksProp,
+		id
 	);
 
 	const onChange = useCallback(

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -15,10 +15,12 @@ import { EntityProvider } from '@wordpress/core-data';
 import {
 	BlockEditorProvider,
 	__unstableEditorStyles as EditorStyles,
+	BlockList,
 } from '@wordpress/block-editor';
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
 import { decodeEntities } from '@wordpress/html-entities';
+import { getBlockType } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -193,19 +195,27 @@ class EditorProvider extends Component {
 						type={ post.type }
 						id={ post.id }
 					>
-						<BlockEditorProvider
-							value={ blocks }
-							onInput={ resetEditorBlocksWithoutUndoLevel }
-							onChange={ resetEditorBlocks }
-							selectionStart={ selectionStart }
-							selectionEnd={ selectionEnd }
-							settings={ editorSettings }
-							useSubRegistry={ false }
+						<BlockList.BlockContext.Providers
+							blockType={ getBlockType( 'core/post' ) }
+							blockAttributes={ {
+								postType: post.type,
+								postId: post.id,
+							} }
 						>
-							{ children }
-							<ReusableBlocksButtons />
-							<ConvertToGroupButtons />
-						</BlockEditorProvider>
+							<BlockEditorProvider
+								value={ blocks }
+								onInput={ resetEditorBlocksWithoutUndoLevel }
+								onChange={ resetEditorBlocks }
+								selectionStart={ selectionStart }
+								selectionEnd={ selectionEnd }
+								settings={ editorSettings }
+								useSubRegistry={ false }
+							>
+								{ children }
+								<ReusableBlocksButtons />
+								<ConvertToGroupButtons />
+							</BlockEditorProvider>
+						</BlockList.BlockContext.Providers>
 					</EntityProvider>
 				</EntityProvider>
 			</>


### PR DESCRIPTION
Closes #19685

## Description

This PR adds a new Post block for setting a specific post context in a block subtree.

Currently, the post is selected by ID. In the future, we should implement a Combobox post searching input.

To test this, it also implements editing modes in the Post Content and Post Title blocks. I.e. when provided a post context, these blocks now allow you to edit the post's content and title respectively.

The question remains of how to approach server-side rendering here. I propose we enhance `do_blocks` to support reading parent block attributes in a React Context like manner. That way things like Post Content blocks can opt-out of reading from the post loop if they detect they are nested under a Post block with an explicit post context.

## How has this been tested?

- Inserted a Post block in a template.
- Set a known post ID.
- Inserted Post Content and Post Title blocks at the top level in the template.
- Verified placeholders were shown.
- Moved blocks inside the Post block.
- Verified content and title editing were now possible.

## Screenshots

![gif](https://user-images.githubusercontent.com/19157096/72187388-828bdf00-33c5-11ea-9823-f202d011de14.gif)

(We need to improve the dropzone logic there.)

## Types of Changes

*New Feature:* The Post Content and Title blocks now support editing post content and titles.
*New Feature:* There is a new Post block for rendering specific posts.

## Checklist:

- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
