### PR TITLE
Block top toolbar: fix mover direction

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -375,7 +375,6 @@ function BlockListBlock( {
 			focusOnMount={ isToolbarForced }
 			data-type={ name }
 			data-align={ wrapperProps ? wrapperProps[ 'data-align' ] : undefined }
-			moverDirection={ moverDirection }
 			hasMovers={ hasMovers }
 		/>
 	);

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -22,25 +22,38 @@ import MultiBlocksSwitcher from '../block-switcher/multi-blocks-switcher';
 import BlockMover from '../block-mover';
 import Inserter from '../inserter';
 
-export default function BlockToolbar( { moverDirection, hasMovers = true } ) {
-	const { blockClientIds, isValid, mode, rootClientId } = useSelect( ( select ) => {
+export default function BlockToolbar( { hasMovers = true } ) {
+	const {
+		blockClientIds,
+		isValid,
+		mode,
+		rootClientId,
+		moverDirection,
+	} = useSelect( ( select ) => {
 		const {
 			getBlockMode,
 			getSelectedBlockClientIds,
 			isBlockValid,
 			getBlockRootClientId,
+			getBlockListSettings,
 		} = select( 'core/block-editor' );
 		const selectedBlockClientIds = getSelectedBlockClientIds();
+		const blockRootClientId = getBlockRootClientId( selectedBlockClientIds[ 0 ] );
+
+		const {
+			__experimentalMoverDirection,
+		} = getBlockListSettings( blockRootClientId ) || {};
 
 		return {
 			blockClientIds: selectedBlockClientIds,
-			rootClientId: getBlockRootClientId( selectedBlockClientIds[ 0 ] ),
+			rootClientId: blockRootClientId,
 			isValid: selectedBlockClientIds.length === 1 ?
 				isBlockValid( selectedBlockClientIds[ 0 ] ) :
 				null,
 			mode: selectedBlockClientIds.length === 1 ?
 				getBlockMode( selectedBlockClientIds[ 0 ] ) :
 				null,
+			moverDirection: __experimentalMoverDirection,
 		};
 	}, [] );
 	const [ isInserterShown, setIsInserterShown ] = useState( false );

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -113,12 +113,14 @@ class InnerBlocks extends Component {
 			templateLock,
 			parentLock,
 			__experimentalCaptureToolbars,
+			__experimentalMoverDirection,
 		} = this.props;
 
 		const newSettings = {
 			allowedBlocks,
 			templateLock: templateLock === undefined ? parentLock : templateLock,
 			__experimentalCaptureToolbars: __experimentalCaptureToolbars || false,
+			__experimentalMoverDirection,
 		};
 
 		if ( ! isShallowEqual( blockListSettings, newSettings ) ) {


### PR DESCRIPTION
## Description

The movers are now correct:

<img width="592" alt="Screenshot 2020-01-11 at 00 11 35" src="https://user-images.githubusercontent.com/4710635/72192819-4aa58b80-3407-11ea-977c-14cb81b6ef52.png">


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
