### PR TITLE
Block: move keydown event to rootContainer

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -14,7 +14,6 @@ import {
 	isTextField,
 	placeCaretAtHorizontalEdge,
 } from '@wordpress/dom';
-import { BACKSPACE, DELETE, ENTER } from '@wordpress/keycodes';
 import {
 	getBlockType,
 	getSaveElement,
@@ -107,8 +106,6 @@ function BlockListBlock( {
 	onInsertBlocksAfter,
 	onMerge,
 	onSelect,
-	onRemove,
-	onInsertDefaultBlockAfter,
 	toggleSelection,
 	animateOnChange,
 	enableAnimation,
@@ -203,39 +200,6 @@ function BlockListBlock( {
 			focusTabbable( true );
 		}
 	}, [ isSelected, isNavigationMode ] );
-
-	// Other event handlers
-
-	/**
-	 * Interprets keydown event intent to remove or insert after block if key
-	 * event occurs on wrapper node. This can occur when the block has no text
-	 * fields of its own, particularly after initial insertion, to allow for
-	 * easy deletion and continuous writing flow to add additional content.
-	 *
-	 * @param {KeyboardEvent} event Keydown event.
-	 */
-	const onKeyDown = ( event ) => {
-		const { keyCode, target } = event;
-
-		switch ( keyCode ) {
-			case ENTER:
-				if ( target === wrapper.current ) {
-					// Insert default block after current block if enter and event
-					// not already handled by descendant.
-					onInsertDefaultBlockAfter();
-					event.preventDefault();
-				}
-				break;
-			case BACKSPACE:
-			case DELETE:
-				if ( target === wrapper.current ) {
-					// Remove block on backspace.
-					onRemove( clientId );
-					event.preventDefault();
-				}
-				break;
-		}
-	};
 
 	const onMouseLeave = ( { which, buttons } ) => {
 		// The primary button must be pressed to initiate selection. Fall back
@@ -376,8 +340,6 @@ function BlockListBlock( {
 			ref={ wrapper }
 			className={ wrapperClassName }
 			data-type={ name }
-			// Only allow shortcuts when a blocks is selected and not locked.
-			onKeyDown={ isSelected && ! isLocked ? onKeyDown : undefined }
 			tabIndex="0"
 			aria-label={ blockAriaLabel }
 			role="group"
@@ -576,8 +538,6 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps, { select } ) => {
 		updateBlockAttributes,
 		selectBlock,
 		insertBlocks,
-		insertDefaultBlock,
-		removeBlock,
 		mergeBlocks,
 		replaceBlocks,
 		toggleSelection,
@@ -596,14 +556,6 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps, { select } ) => {
 			const { rootClientId } = ownProps;
 			insertBlocks( blocks, index, rootClientId );
 		},
-		onInsertDefaultBlockAfter() {
-			const { clientId, rootClientId } = ownProps;
-			const {
-				getBlockIndex,
-			} = select( 'core/block-editor' );
-			const index = getBlockIndex( clientId, rootClientId );
-			insertDefaultBlock( {}, rootClientId, index + 1 );
-		},
 		onInsertBlocksAfter( blocks ) {
 			const { clientId, rootClientId } = ownProps;
 			const {
@@ -611,9 +563,6 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps, { select } ) => {
 			} = select( 'core/block-editor' );
 			const index = getBlockIndex( clientId, rootClientId );
 			insertBlocks( blocks, index + 1, rootClientId );
-		},
-		onRemove( clientId ) {
-			removeBlock( clientId );
 		},
 		onMerge( forward ) {
 			const { clientId } = ownProps;

--- a/packages/block-editor/src/utils/dom.js
+++ b/packages/block-editor/src/utils/dom.js
@@ -12,6 +12,10 @@ export function getBlockDOMNode( clientId, scope = document ) {
 	return scope.querySelector( '[data-block="' + clientId + '"]' );
 }
 
+export function getBlockWrapperNode( clientId ) {
+	return document.getElementById( 'block-' + clientId );
+}
+
 export function getBlockPreviewContainerDOMNode( clientId, scope ) {
 	const domNode = getBlockDOMNode( clientId, scope );
 


### PR DESCRIPTION
## Description

Continuation of #19397. This PR moves keydown event handler to the root container so it's only created once.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
