### PR TITLE
Block Library: Add a Post Author block.

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -56,6 +56,7 @@ function gutenberg_reregister_core_block_types() {
 		'template-part.php'   => 'core/template-part',
 		'post-title.php'      => 'core/post-title',
 		'post-content.php'    => 'core/post-content',
+		'post-author.php'     => 'core/post-author',
 		'post-excerpt.php'    => 'core/post-excerpt',
 	);
 

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -68,6 +68,7 @@ import * as siteTitle from './site-title';
 import * as templatePart from './template-part';
 import * as postTitle from './post-title';
 import * as postContent from './post-content';
+import * as postAuthor from './post-author';
 import * as postExcerpt from './post-excerpt';
 
 /**
@@ -188,7 +189,14 @@ export const __experimentalRegisterExperimentalCoreBlocks =
 
 				// Register Full Site Editing Blocks.
 				...( __experimentalEnableFullSiteEditing ?
-					[ siteTitle, templatePart, postTitle, postContent, postExcerpt ] :
+					[
+						siteTitle,
+						templatePart,
+						postTitle,
+						postContent,
+						postAuthor,
+						postExcerpt,
+					] :
 					[] ),
 			].forEach( registerBlock );
 		} :

--- a/packages/block-library/src/post-author/block.json
+++ b/packages/block-library/src/post-author/block.json
@@ -1,0 +1,4 @@
+{
+	"name": "core/post-author",
+	"category": "layout"
+}

--- a/packages/block-library/src/post-author/edit.js
+++ b/packages/block-library/src/post-author/edit.js
@@ -2,11 +2,10 @@
  * WordPress dependencies
  */
 import { useEntityProp, useEntityId } from '@wordpress/core-data';
-import { RichText } from '@wordpress/block-editor';
 
 function PostAuthorDisplay() {
 	const [ author ] = useEntityProp( 'postType', 'post', 'author' );
-	return <RichText.Content tagName="h6" value={ String( author ) } />;
+	return <address>{ author }</address>;
 }
 
 export default function PostAuthorEdit() {

--- a/packages/block-library/src/post-author/edit.js
+++ b/packages/block-library/src/post-author/edit.js
@@ -1,0 +1,17 @@
+/**
+ * WordPress dependencies
+ */
+import { useEntityProp, useEntityId } from '@wordpress/core-data';
+import { RichText } from '@wordpress/block-editor';
+
+function PostAuthorDisplay() {
+	const [ author ] = useEntityProp( 'postType', 'post', 'author' );
+	return <RichText.Content tagName="h6" value={ String( author ) } />;
+}
+
+export default function PostAuthorEdit() {
+	if ( ! useEntityId( 'postType', 'post' ) ) {
+		return 'Post Author Placeholder';
+	}
+	return <PostAuthorDisplay />;
+}

--- a/packages/block-library/src/post-author/edit.js
+++ b/packages/block-library/src/post-author/edit.js
@@ -2,10 +2,16 @@
  * WordPress dependencies
  */
 import { useEntityProp, useEntityId } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
+import { sprintf, __ } from '@wordpress/i18n';
 
 function PostAuthorDisplay() {
-	const [ author ] = useEntityProp( 'postType', 'post', 'author' );
-	return <address>{ author }</address>;
+	const [ authorId ] = useEntityProp( 'postType', 'post', 'author' );
+	const author = useSelect(
+		( select ) => select( 'core' ).getEntityRecord( 'root', 'user', authorId ),
+		[ authorId ]
+	);
+	return author ? <address>{ sprintf( __( 'By %s' ), author.name ) }</address> : null;
 }
 
 export default function PostAuthorEdit() {

--- a/packages/block-library/src/post-author/index.js
+++ b/packages/block-library/src/post-author/index.js
@@ -1,0 +1,18 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+import edit from './edit';
+
+const { name } = metadata;
+export { metadata, name };
+
+export const settings = {
+	title: __( 'Post Author' ),
+	edit,
+};

--- a/packages/block-library/src/post-author/index.php
+++ b/packages/block-library/src/post-author/index.php
@@ -15,7 +15,7 @@ function render_block_core_post_author() {
 	if ( ! $post ) {
 		return '';
 	}
-	return '<h6> By ' . get_the_author( $post ) . '</h6>';
+	return '<h6>' . __( 'By ' ) . get_the_author( $post ) . '</h6>';
 }
 
 /**

--- a/packages/block-library/src/post-author/index.php
+++ b/packages/block-library/src/post-author/index.php
@@ -15,7 +15,7 @@ function render_block_core_post_author() {
 	if ( ! $post ) {
 		return '';
 	}
-	return '<h6>' . __( 'By ' ) . get_the_author( $post ) . '</h6>';
+	return '<address>' . __( 'By ' ) . get_the_author() . '</address>';
 }
 
 /**

--- a/packages/block-library/src/post-author/index.php
+++ b/packages/block-library/src/post-author/index.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Server-side rendering of the `core/post-author` block.
+ *
+ * @package WordPress
+ */
+
+/**
+ * Renders the `core/post-author` block on the server.
+ *
+ * @return string Returns the filtered post author for the current post wrapped inside "h6" tags.
+ */
+function render_block_core_post_author() {
+	$post = gutenberg_get_post_from_context();
+	if ( ! $post ) {
+		return '';
+	}
+	return '<h6> By ' . get_the_author( $post ) . '</h6>';
+}
+
+/**
+ * Registers the `core/post-author` block on the server.
+ */
+function register_block_core_post_author() {
+	register_block_type(
+		'core/post-author',
+		array(
+			'render_callback' => 'render_block_core_post_author',
+		)
+	);
+}
+add_action( 'init', 'register_block_core_post_author' );

--- a/packages/block-library/src/post-author/index.php
+++ b/packages/block-library/src/post-author/index.php
@@ -15,7 +15,8 @@ function render_block_core_post_author() {
 	if ( ! $post ) {
 		return '';
 	}
-	return '<address>' . __( 'By ' ) . get_the_author() . '</address>';
+	// translators: %s: The author.
+	return sprintf( __( '<address>By %s</address>' ), get_the_author() );
 }
 
 /**

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -17,6 +17,7 @@ export const defaultEntities = [
 	{ name: 'media', kind: 'root', baseURL: '/wp/v2/media', plural: 'mediaItems' },
 	{ name: 'taxonomy', kind: 'root', key: 'slug', baseURL: '/wp/v2/taxonomies', plural: 'taxonomies' },
 	{ name: 'widgetArea', kind: 'root', baseURL: '/__experimental/widget-areas', plural: 'widgetAreas', transientEdits: { blocks: true } },
+	{ name: 'user', kind: 'root', baseURL: '/wp/v2/users', plural: 'users' },
 ];
 
 export const kinds = [

--- a/packages/e2e-tests/fixtures/blocks/core__post-author.html
+++ b/packages/e2e-tests/fixtures/blocks/core__post-author.html
@@ -1,0 +1,1 @@
+<!-- wp:post-author /-->

--- a/packages/e2e-tests/fixtures/blocks/core__post-author.json
+++ b/packages/e2e-tests/fixtures/blocks/core__post-author.json
@@ -1,0 +1,10 @@
+[
+    {
+        "clientId": "_clientId_0",
+        "name": "core/post-author",
+        "isValid": true,
+        "attributes": {},
+        "innerBlocks": [],
+        "originalContent": ""
+    }
+]

--- a/packages/e2e-tests/fixtures/blocks/core__post-author.parsed.json
+++ b/packages/e2e-tests/fixtures/blocks/core__post-author.parsed.json
@@ -1,0 +1,18 @@
+[
+    {
+        "blockName": "core/post-author",
+        "attrs": {},
+        "innerBlocks": [],
+        "innerHTML": "",
+        "innerContent": []
+    },
+    {
+        "blockName": null,
+        "attrs": {},
+        "innerBlocks": [],
+        "innerHTML": "\n",
+        "innerContent": [
+            "\n"
+        ]
+    }
+]

--- a/packages/e2e-tests/fixtures/blocks/core__post-author.serialized.html
+++ b/packages/e2e-tests/fixtures/blocks/core__post-author.serialized.html
@@ -1,0 +1,1 @@
+<!-- wp:post-author /-->


### PR DESCRIPTION
## Description

This PR adds a new Post Author block akin to the Post Title and Post Content blocks.

## How has this been tested?

- Inserted Post Author block in a post.
- Confirmed post author rendered in the editor and front end.
- Inserted Post Author block in a template.
- Confirmed post author placeholder rendered in the editor and the relevant post author rendered in the front end.

## Types of Changes

*New Feature:* There is a new Post Author block for template building.

## Checklist:

- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
