### PR TITLE
Block Library: Add a Post Excerpt block.

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -56,6 +56,7 @@ function gutenberg_reregister_core_block_types() {
 		'template-part.php'   => 'core/template-part',
 		'post-title.php'      => 'core/post-title',
 		'post-content.php'    => 'core/post-content',
+		'post-excerpt.php'    => 'core/post-excerpt',
 	);
 
 	$registry = WP_Block_Type_Registry::get_instance();

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -68,6 +68,7 @@ import * as siteTitle from './site-title';
 import * as templatePart from './template-part';
 import * as postTitle from './post-title';
 import * as postContent from './post-content';
+import * as postExcerpt from './post-excerpt';
 
 /**
  * Function to register an individual block.
@@ -187,7 +188,7 @@ export const __experimentalRegisterExperimentalCoreBlocks =
 
 				// Register Full Site Editing Blocks.
 				...( __experimentalEnableFullSiteEditing ?
-					[ siteTitle, templatePart, postTitle, postContent ] :
+					[ siteTitle, templatePart, postTitle, postContent, postExcerpt ] :
 					[] ),
 			].forEach( registerBlock );
 		} :

--- a/packages/block-library/src/post-excerpt/block.json
+++ b/packages/block-library/src/post-excerpt/block.json
@@ -1,0 +1,4 @@
+{
+	"name": "core/post-excerpt",
+	"category": "layout"
+}

--- a/packages/block-library/src/post-excerpt/edit.js
+++ b/packages/block-library/src/post-excerpt/edit.js
@@ -2,11 +2,11 @@
  * WordPress dependencies
  */
 import { useEntityProp, useEntityId } from '@wordpress/core-data';
-import { RichText } from '@wordpress/block-editor';
+import { PlainText } from '@wordpress/block-editor';
 
 function PostExcerptDisplay() {
-	const [ excerpt ] = useEntityProp( 'postType', 'post', 'excerpt' );
-	return <RichText.Content tagName="p" value={ excerpt } />;
+	const [ excerpt, setExcerpt ] = useEntityProp( 'postType', 'post', 'excerpt' );
+	return <PlainText value={ excerpt } onChange={ setExcerpt } />;
 }
 
 export default function PostExcerptEdit() {

--- a/packages/block-library/src/post-excerpt/edit.js
+++ b/packages/block-library/src/post-excerpt/edit.js
@@ -1,0 +1,17 @@
+/**
+ * WordPress dependencies
+ */
+import { useEntityProp, useEntityId } from '@wordpress/core-data';
+import { RichText } from '@wordpress/block-editor';
+
+function PostExcerptDisplay() {
+	const [ excerpt ] = useEntityProp( 'postType', 'post', 'excerpt' );
+	return <RichText.Content tagName="p" value={ excerpt } />;
+}
+
+export default function PostExcerptEdit() {
+	if ( ! useEntityId( 'postType', 'post' ) ) {
+		return 'Post Excerpt Placeholder';
+	}
+	return <PostExcerptDisplay />;
+}

--- a/packages/block-library/src/post-excerpt/index.js
+++ b/packages/block-library/src/post-excerpt/index.js
@@ -1,0 +1,18 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+import edit from './edit';
+
+const { name } = metadata;
+export { metadata, name };
+
+export const settings = {
+	title: __( 'Post Excerpt' ),
+	edit,
+};

--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Server-side rendering of the `core/post-excerpt` block.
+ *
+ * @package WordPress
+ */
+
+/**
+ * Renders the `core/post-excerpt` block on the server.
+ *
+ * @return string Returns the filtered post excerpt for the current post wrapped inside "p" tags.
+ */
+function render_block_core_post_excerpt() {
+	$post = gutenberg_get_post_from_context();
+	if ( ! $post ) {
+		return '';
+	}
+	return '<p>' . get_the_excerpt( $post ) . '</p>';
+}
+
+/**
+ * Registers the `core/post-excerpt` block on the server.
+ */
+function register_block_core_post_excerpt() {
+	register_block_type(
+		'core/post-excerpt',
+		array(
+			'render_callback' => 'render_block_core_post_excerpt',
+		)
+	);
+}
+add_action( 'init', 'register_block_core_post_excerpt' );

--- a/packages/e2e-tests/fixtures/blocks/core__post-excerpt.html
+++ b/packages/e2e-tests/fixtures/blocks/core__post-excerpt.html
@@ -1,0 +1,1 @@
+<!-- wp:post-excerpt /-->

--- a/packages/e2e-tests/fixtures/blocks/core__post-excerpt.json
+++ b/packages/e2e-tests/fixtures/blocks/core__post-excerpt.json
@@ -1,0 +1,10 @@
+[
+    {
+        "clientId": "_clientId_0",
+        "name": "core/post-excerpt",
+        "isValid": true,
+        "attributes": {},
+        "innerBlocks": [],
+        "originalContent": ""
+    }
+]

--- a/packages/e2e-tests/fixtures/blocks/core__post-excerpt.parsed.json
+++ b/packages/e2e-tests/fixtures/blocks/core__post-excerpt.parsed.json
@@ -1,0 +1,18 @@
+[
+    {
+        "blockName": "core/post-excerpt",
+        "attrs": {},
+        "innerBlocks": [],
+        "innerHTML": "",
+        "innerContent": []
+    },
+    {
+        "blockName": null,
+        "attrs": {},
+        "innerBlocks": [],
+        "innerHTML": "\n",
+        "innerContent": [
+            "\n"
+        ]
+    }
+]

--- a/packages/e2e-tests/fixtures/blocks/core__post-excerpt.serialized.html
+++ b/packages/e2e-tests/fixtures/blocks/core__post-excerpt.serialized.html
@@ -1,0 +1,1 @@
+<!-- wp:post-excerpt /-->


### PR DESCRIPTION
## Description

This PR adds a new Post Excerpt block akin to the Post Title and Post Content blocks.

## How has this been tested?

- Inserted Post Excerpt block in a post.
- Confirmed post excerpt rendered in the editor and front end.
- Inserted Post Excerpt block in a template.
- Confirmed post excerpt placeholder rendered in the editor and the relevant post excerpt rendered in the front end.

## Types of Changes

*New Feature:* There is a new Post Excerpt block for template building.

## Checklist:

- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
