### PR TITLE
Block Library: Add a Post Comments block.

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -35,6 +35,7 @@ function gutenberg_reregister_core_block_types() {
 		'post-title.php'          => 'core/post-title',
 		'post-content.php'        => 'core/post-content',
 		'post-author.php'         => 'core/post-author',
+		'post-comments.php'       => 'core/post-comments',
 		'post-comments-count.php' => 'core/post-comments-count',
 		'post-comments-form.php'  => 'core/post-comments-form',
 		'post-date.php'           => 'core/post-date',

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -68,6 +68,7 @@ import * as templatePart from './template-part';
 import * as postTitle from './post-title';
 import * as postContent from './post-content';
 import * as postAuthor from './post-author';
+import * as postComments from './post-comments';
 import * as postCommentsCount from './post-comments-count';
 import * as postCommentsForm from './post-comments-form';
 import * as postDate from './post-date';
@@ -199,6 +200,7 @@ export const __experimentalRegisterExperimentalCoreBlocks =
 								postTitle,
 								postContent,
 								postAuthor,
+								postComments,
 								postCommentsCount,
 								postCommentsForm,
 								postDate,

--- a/packages/block-library/src/post-comments/block.json
+++ b/packages/block-library/src/post-comments/block.json
@@ -1,0 +1,4 @@
+{
+	"name": "core/post-comments",
+	"category": "layout"
+}

--- a/packages/block-library/src/post-comments/edit.js
+++ b/packages/block-library/src/post-comments/edit.js
@@ -1,0 +1,28 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { useEntityId } from '@wordpress/core-data';
+
+function PostCommentsDisplay( { postId } ) {
+	return useSelect(
+		( select ) => {
+			const comments = select( 'core' ).getEntityRecords( 'root', 'comment', {
+				post: postId,
+			} );
+			return (
+				comments &&
+				comments.map( ( comment ) => <p key={ comment.id }>{ comment.content.raw }</p> )
+			);
+		},
+		[ postId ]
+	);
+}
+
+export default function PostCommentsEdit() {
+	const postId = useEntityId( 'postType', 'post' );
+	if ( ! postId ) {
+		return 'Post Comments Placeholder';
+	}
+	return <PostCommentsDisplay postId={ postId } />;
+}

--- a/packages/block-library/src/post-comments/edit.js
+++ b/packages/block-library/src/post-comments/edit.js
@@ -7,12 +7,18 @@ import { useEntityId } from '@wordpress/core-data';
 function PostCommentsDisplay( { postId } ) {
 	return useSelect(
 		( select ) => {
-			const comments = select( 'core' ).getEntityRecords( 'root', 'comment', {
-				post: postId,
-			} );
+			const comments = select( 'core' ).getEntityRecords(
+				'root',
+				'comment',
+				{
+					post: postId,
+				}
+			);
 			return (
 				comments &&
-				comments.map( ( comment ) => <p key={ comment.id }>{ comment.content.raw }</p> )
+				comments.map( ( comment ) => (
+					<p key={ comment.id }>{ comment.content.raw }</p>
+				) )
 			);
 		},
 		[ postId ]

--- a/packages/block-library/src/post-comments/edit.js
+++ b/packages/block-library/src/post-comments/edit.js
@@ -16,7 +16,7 @@ function PostCommentsDisplay( { postId } ) {
 				}
 			);
 			// TODO: "No Comments" placeholder should be editable.
-			return comments
+			return comments && comments.length
 				? comments.map( ( comment ) => (
 						<p key={ comment.id }>{ comment.content.raw }</p>
 				  ) )

--- a/packages/block-library/src/post-comments/edit.js
+++ b/packages/block-library/src/post-comments/edit.js
@@ -27,6 +27,7 @@ function PostCommentsDisplay( { postId } ) {
 }
 
 export default function PostCommentsEdit() {
+	// TODO: Update to handle multiple post types.
 	const postId = useEntityId( 'postType', 'post' );
 	if ( ! postId ) {
 		return 'Post Comments Placeholder';

--- a/packages/block-library/src/post-comments/edit.js
+++ b/packages/block-library/src/post-comments/edit.js
@@ -3,6 +3,7 @@
  */
 import { useSelect } from '@wordpress/data';
 import { useEntityId } from '@wordpress/core-data';
+import { __ } from '@wordpress/i18n';
 
 function PostCommentsDisplay( { postId } ) {
 	return useSelect(
@@ -14,12 +15,12 @@ function PostCommentsDisplay( { postId } ) {
 					post: postId,
 				}
 			);
-			return (
-				comments &&
-				comments.map( ( comment ) => (
-					<p key={ comment.id }>{ comment.content.raw }</p>
-				) )
-			);
+			// TODO: "No Comments" placeholder should be editable.
+			return comments
+				? comments.map( ( comment ) => (
+						<p key={ comment.id }>{ comment.content.raw }</p>
+				  ) )
+				: __( 'No comments.' );
 		},
 		[ postId ]
 	);

--- a/packages/block-library/src/post-comments/index.js
+++ b/packages/block-library/src/post-comments/index.js
@@ -1,0 +1,18 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+import edit from './edit';
+
+const { name } = metadata;
+export { metadata, name };
+
+export const settings = {
+	title: __( 'Post Comments' ),
+	edit,
+};

--- a/packages/block-library/src/post-comments/index.php
+++ b/packages/block-library/src/post-comments/index.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Server-side rendering of the `core/post-comments` block.
+ *
+ * @package WordPress
+ */
+
+/**
+ * Renders the `core/post-comments` block on the server.
+ *
+ * @return string Returns the filtered post comments for the current post wrapped inside "p" tags.
+ */
+function render_block_core_post_comments() {
+	$post = gutenberg_get_post_from_context();
+	if ( ! $post ) {
+		return '';
+	}
+	$comments = get_comments(
+		array(
+			'post_id' => $post->ID,
+		)
+	);
+	$output   = '';
+	foreach ( $comments as $comment ) {
+		$output .= '<p>' . $comment->comment_author . '<br />' . $comment->comment_content . '</p>';
+	}
+	return $output;
+}
+
+/**
+ * Registers the `core/post-comments` block on the server.
+ */
+function register_block_core_post_comments() {
+	register_block_type(
+		'core/post-comments',
+		array(
+			'render_callback' => 'render_block_core_post_comments',
+		)
+	);
+}
+add_action( 'init', 'register_block_core_post_comments' );

--- a/packages/block-library/src/post-comments/index.php
+++ b/packages/block-library/src/post-comments/index.php
@@ -21,6 +21,7 @@ function render_block_core_post_comments() {
 		)
 	);
 	$output   = '';
+	// TODO: Handle nested comments.
 	foreach ( $comments as $comment ) {
 		$output .= '<p>' . $comment->comment_author . '<br />' . $comment->comment_content . '</p>';
 	}

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -60,6 +60,13 @@ export const defaultEntities = [
 		baseURL: '/wp/v2/users',
 		plural: 'users',
 	},
+	{
+		name: 'comment',
+		kind: 'root',
+		baseURL: '/wp/v2/comments',
+		plural: 'comments',
+		label: __( 'Comment' ),
+	},
 ];
 
 export const kinds = [

--- a/packages/e2e-tests/fixtures/blocks/core__post-comments.html
+++ b/packages/e2e-tests/fixtures/blocks/core__post-comments.html
@@ -1,0 +1,1 @@
+<!-- wp:post-comments /-->

--- a/packages/e2e-tests/fixtures/blocks/core__post-comments.json
+++ b/packages/e2e-tests/fixtures/blocks/core__post-comments.json
@@ -1,0 +1,10 @@
+[
+    {
+        "clientId": "_clientId_0",
+        "name": "core/post-comments",
+        "isValid": true,
+        "attributes": {},
+        "innerBlocks": [],
+        "originalContent": ""
+    }
+]

--- a/packages/e2e-tests/fixtures/blocks/core__post-comments.parsed.json
+++ b/packages/e2e-tests/fixtures/blocks/core__post-comments.parsed.json
@@ -1,0 +1,18 @@
+[
+    {
+        "blockName": "core/post-comments",
+        "attrs": {},
+        "innerBlocks": [],
+        "innerHTML": "",
+        "innerContent": []
+    },
+    {
+        "blockName": null,
+        "attrs": {},
+        "innerBlocks": [],
+        "innerHTML": "\n",
+        "innerContent": [
+            "\n"
+        ]
+    }
+]

--- a/packages/e2e-tests/fixtures/blocks/core__post-comments.serialized.html
+++ b/packages/e2e-tests/fixtures/blocks/core__post-comments.serialized.html
@@ -1,0 +1,1 @@
+<!-- wp:post-comments /-->


### PR DESCRIPTION
## Description

This PR adds a new Post Comments block akin to the Post Title and Post Content blocks.

## How has this been tested?

- Inserted Post Comments block in a post.
- Confirmed post comments rendered in the editor and front end.
- Inserted Post Comments block in a template.
- Confirmed post comments placeholder rendered in the editor and the relevant post comments rendered in the front end.

## Types of Changes

*New Feature:* There is a new Post Comments block for template building.

## Checklist:

- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
