### PR TITLE
Adds media replace flow to the cover block

### DIFF
--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -22,7 +22,6 @@ import {
 	RangeControl,
 	ResizableBox,
 	ToggleControl,
-	ToolbarGroup,
 	withNotices,
 } from '@wordpress/components';
 import { compose, withInstanceId } from '@wordpress/compose';
@@ -32,8 +31,7 @@ import {
 	InnerBlocks,
 	InspectorControls,
 	MediaPlaceholder,
-	MediaUpload,
-	MediaUploadCheck,
+	MediaReplaceFlow,
 	withColors,
 	ColorPalette,
 	__experimentalUseGradient,
@@ -259,7 +257,6 @@ function CoverEdit( {
 		dimRatio,
 		focalPoint,
 		hasParallax,
-		id,
 		minHeight,
 		url,
 	} = attributes;
@@ -308,25 +305,12 @@ function CoverEdit( {
 		<>
 			<BlockControls>
 				{ hasBackground && (
-					<>
-						<MediaUploadCheck>
-							<ToolbarGroup>
-								<MediaUpload
-									onSelect={ onSelectMedia }
-									allowedTypes={ ALLOWED_MEDIA_TYPES }
-									value={ id }
-									render={ ( { open } ) => (
-										<Button
-											className="components-toolbar__control"
-											label={ __( 'Edit media' ) }
-											icon="edit"
-											onClick={ open }
-										/>
-									) }
-								/>
-							</ToolbarGroup>
-						</MediaUploadCheck>
-					</>
+					<MediaReplaceFlow
+						mediaURL={ url }
+						allowedTypes={ ALLOWED_MEDIA_TYPES }
+						accept="image/*"
+						onSelect={ onSelectMedia }
+					/>
 				) }
 			</BlockControls>
 			<InspectorControls>

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -308,7 +308,7 @@ function CoverEdit( {
 					<MediaReplaceFlow
 						mediaURL={ url }
 						allowedTypes={ ALLOWED_MEDIA_TYPES }
-						accept="image/*"
+						accept="image/*,video/*"
 						onSelect={ onSelectMedia }
 					/>
 				) }


### PR DESCRIPTION
## Description
Adds the new media replace control to the toolbar of the cover block.

## How has this been tested?
Tested locally.

## Screenshots <!-- if applicable -->

![cover-media-replace](https://user-images.githubusercontent.com/107534/72206202-a6b5f180-3493-11ea-8da9-6ddbbd94adb2.gif)


## Types of changes
Non breaking enhancement.
