### PR TITLE
Fix small visual select glitch

### DIFF
--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -428,7 +428,7 @@
 	}
 
 	select {
-		padding: 2px;
+		padding: 3px 24px 3px 8px;
 		font-size: $default-font-size;
 		color: $dark-gray-500;
 


### PR DESCRIPTION
Selects didn't have the correct padding on the right causing the text to be cut.

closes #19414 
closes #19415

**Testing instructions**

 - check the design of the select boxes across the interface.