### PR TITLE
Fix the height of the tags tokens

### DIFF
--- a/packages/components/src/form-token-field/style.scss
+++ b/packages/components/src/form-token-field/style.scss
@@ -132,6 +132,7 @@
 .components-form-token-field__remove-token.components-button {
 	display: inline-block;
 	line-height: 24px;
+	height: auto;
 	background: $light-gray-500;
 	transition: all 0.2s cubic-bezier(0.4, 1, 0.4, 1);
 	@include reduce-motion;


### PR DESCRIPTION
Before

<img width="268" alt="Capture d’écran 2020-01-13 à 11 45 07 AM" src="https://user-images.githubusercontent.com/272444/72249691-2eb60b80-35fa-11ea-8450-249b594e2baa.png">

After

<img width="284" alt="Capture d’écran 2020-01-13 à 11 44 44 AM" src="https://user-images.githubusercontent.com/272444/72249700-34abec80-35fa-11ea-9084-3d8f992f5f33.png">
