### PR TITLE
Block: remove tabbable inserter button

### DIFF
--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -1,14 +1,7 @@
 /**
- * External dependencies
- */
-import classnames from 'classnames';
-
-/**
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { Toolbar } from '@wordpress/components';
-import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -20,14 +13,12 @@ import BlockSettingsMenu from '../block-settings-menu';
 import BlockSwitcher from '../block-switcher';
 import MultiBlocksSwitcher from '../block-switcher/multi-blocks-switcher';
 import BlockMover from '../block-mover';
-import Inserter from '../inserter';
 
 export default function BlockToolbar( { hasMovers = true } ) {
 	const {
 		blockClientIds,
 		isValid,
 		mode,
-		rootClientId,
 		moverDirection,
 	} = useSelect( ( select ) => {
 		const {
@@ -56,39 +47,10 @@ export default function BlockToolbar( { hasMovers = true } ) {
 			moverDirection: __experimentalMoverDirection,
 		};
 	}, [] );
-	const [ isInserterShown, setIsInserterShown ] = useState( false );
 
 	if ( blockClientIds.length === 0 ) {
 		return null;
 	}
-
-	function onFocus() {
-		setIsInserterShown( true );
-	}
-
-	function onBlur() {
-		setIsInserterShown( false );
-	}
-
-	const inserter = (
-		<Toolbar
-			onFocus={ onFocus }
-			onBlur={ onBlur }
-			// While ideally it would be enough to capture the
-			// bubbling focus event from the Inserter, due to the
-			// characteristics of click focusing of `button`s in
-			// Firefox and Safari, it is not reliable.
-			//
-			// See: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Clicking_and_focus
-			tabIndex={ -1 }
-			className={ classnames(
-				'block-editor-block-toolbar__inserter',
-				{ 'is-visible': isInserterShown }
-			) }
-		>
-			<Inserter clientId={ blockClientIds[ 0 ] } rootClientId={ rootClientId } />
-		</Toolbar>
-	);
 
 	if ( blockClientIds.length > 1 ) {
 		return (
@@ -99,7 +61,6 @@ export default function BlockToolbar( { hasMovers = true } ) {
 				/> ) }
 				<MultiBlocksSwitcher />
 				<BlockSettingsMenu clientIds={ blockClientIds } />
-				{ inserter }
 			</div>
 		);
 	}
@@ -118,7 +79,6 @@ export default function BlockToolbar( { hasMovers = true } ) {
 				</>
 			) }
 			<BlockSettingsMenu clientIds={ blockClientIds } />
-			{ inserter }
 		</div>
 	);
 }

--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -44,16 +44,6 @@
 			border-color: $light-gray-500;
 		}
 	}
-
-	&__inserter {
-		opacity: 0;
-		pointer-events: none;
-
-		&.is-visible {
-			opacity: 1;
-			pointer-events: all;
-		}
-	}
 }
 
 .block-editor-block-toolbar__slot {

--- a/packages/e2e-tests/specs/editor/various/keyboard-navigable-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/keyboard-navigable-blocks.test.js
@@ -68,9 +68,6 @@ const tabThroughBlockToolbar = async () => {
 
 	await page.keyboard.press( 'Tab' );
 	await expect( await getActiveLabel() ).toBe( 'More options' );
-
-	await page.keyboard.press( 'Tab' );
-	await expect( await getActiveLabel() ).toBe( 'Add block' );
 };
 
 describe( 'Order of block keyboard navigation', () => {


### PR DESCRIPTION
## Description

Unblocks #19322.

This PR removes the tabbable inserter button, since we already have two more descriptive buttons right next to it. It is a few more presses, but the goal was to eventually move this button _before_ the selected block toolbar, so that would be even more presses away. Additionally, every block has `Enter` handling on the block wrapper to insert a block after the currently selected one.

In the future we could add tabbable, visually hidden, inserter button before and after the selected block if easier access is wanted. Before

![image](https://user-images.githubusercontent.com/4710635/72253318-93289900-3601-11ea-9a7a-0ab6deda167d.png)

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
