### PR TITLE
Block: reposition tabbable inserter

### DIFF
--- a/packages/block-editor/src/components/block-list/block-popover.js
+++ b/packages/block-editor/src/components/block-list/block-popover.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { findIndex } from 'lodash';
+import classnames from 'classnames';
 
 /**
  * WordPress dependencies
@@ -60,6 +61,7 @@ function BlockPopover( {
 	} = useSelect( selector, [] );
 	const isLargeViewport = useViewportMatch( 'medium' );
 	const [ isToolbarForced, setIsToolbarForced ] = useState( false );
+	const [ isInserterShown, setIsInserterShown ] = useState( false );
 
 	const showEmptyBlockSideInserter = ! isNavigationMode && isEmptyDefaultBlock && isValid;
 	const shouldShowBreadcrumb = isNavigationMode;
@@ -97,6 +99,14 @@ function BlockPopover( {
 		return null;
 	}
 
+	function onFocus() {
+		setIsInserterShown( true );
+	}
+
+	function onBlur() {
+		setIsInserterShown( false );
+	}
+
 	// Position above the anchor, pop out towards the right, and position in the
 	// left corner. For the side inserter, pop out towards the left, and
 	// position in the right corner.
@@ -119,6 +129,25 @@ function BlockPopover( {
 			__unstableAllowHorizontalSubpixelPosition={ moverDirection === 'horizontal' && node }
 			onBlur={ () => setIsToolbarForced( false ) }
 		>
+			{ ( shouldShowContextualToolbar || isToolbarForced ) && (
+				<div
+					onFocus={ onFocus }
+					onBlur={ onBlur }
+					// While ideally it would be enough to capture the
+					// bubbling focus event from the Inserter, due to the
+					// characteristics of click focusing of `button`s in
+					// Firefox and Safari, it is not reliable.
+					//
+					// See: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Clicking_and_focus
+					tabIndex={ -1 }
+					className={ classnames(
+						'block-editor-block-list__block-popover-inserter',
+						{ 'is-visible': isInserterShown }
+					) }
+				>
+					<Inserter clientId={ clientId } rootClientId={ rootClientId } />
+				</div>
+			) }
 			{ ( shouldShowContextualToolbar || isToolbarForced ) && (
 				<BlockContextualToolbar
 					// If the toolbar is being shown because of being forced

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -395,7 +395,20 @@
 	}
 
 	justify-content: center;
+}
 
+.block-editor-block-list__block-popover-inserter {
+	position: absolute;
+	top: -9999em;
+	margin-bottom: $block-padding;
+
+	&.is-visible {
+		position: static;
+	}
+}
+
+.block-editor-block-list__insertion-point-inserter,
+.block-editor-block-list__block-popover-inserter {
 	// Show a clickable plus.
 	.block-editor-inserter__toggle {
 		border-radius: 50%;

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -1,14 +1,7 @@
 /**
- * External dependencies
- */
-import classnames from 'classnames';
-
-/**
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { Toolbar } from '@wordpress/components';
-import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -20,14 +13,12 @@ import BlockSettingsMenu from '../block-settings-menu';
 import BlockSwitcher from '../block-switcher';
 import MultiBlocksSwitcher from '../block-switcher/multi-blocks-switcher';
 import BlockMover from '../block-mover';
-import Inserter from '../inserter';
 
 export default function BlockToolbar( { hasMovers = true } ) {
 	const {
 		blockClientIds,
 		isValid,
 		mode,
-		rootClientId,
 		moverDirection,
 	} = useSelect( ( select ) => {
 		const {
@@ -56,39 +47,10 @@ export default function BlockToolbar( { hasMovers = true } ) {
 			moverDirection: __experimentalMoverDirection,
 		};
 	}, [] );
-	const [ isInserterShown, setIsInserterShown ] = useState( false );
 
 	if ( blockClientIds.length === 0 ) {
 		return null;
 	}
-
-	function onFocus() {
-		setIsInserterShown( true );
-	}
-
-	function onBlur() {
-		setIsInserterShown( false );
-	}
-
-	const inserter = (
-		<Toolbar
-			onFocus={ onFocus }
-			onBlur={ onBlur }
-			// While ideally it would be enough to capture the
-			// bubbling focus event from the Inserter, due to the
-			// characteristics of click focusing of `button`s in
-			// Firefox and Safari, it is not reliable.
-			//
-			// See: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Clicking_and_focus
-			tabIndex={ -1 }
-			className={ classnames(
-				'block-editor-block-toolbar__inserter',
-				{ 'is-visible': isInserterShown }
-			) }
-		>
-			<Inserter clientId={ blockClientIds[ 0 ] } rootClientId={ rootClientId } />
-		</Toolbar>
-	);
 
 	if ( blockClientIds.length > 1 ) {
 		return (
@@ -99,7 +61,6 @@ export default function BlockToolbar( { hasMovers = true } ) {
 				/> ) }
 				<MultiBlocksSwitcher />
 				<BlockSettingsMenu clientIds={ blockClientIds } />
-				{ inserter }
 			</div>
 		);
 	}
@@ -118,7 +79,6 @@ export default function BlockToolbar( { hasMovers = true } ) {
 				</>
 			) }
 			<BlockSettingsMenu clientIds={ blockClientIds } />
-			{ inserter }
 		</div>
 	);
 }

--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -44,16 +44,6 @@
 			border-color: $light-gray-500;
 		}
 	}
-
-	&__inserter {
-		opacity: 0;
-		pointer-events: none;
-
-		&.is-visible {
-			opacity: 1;
-			pointer-events: all;
-		}
-	}
 }
 
 .block-editor-block-toolbar__slot {

--- a/packages/e2e-tests/specs/editor/various/keyboard-navigable-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/keyboard-navigable-blocks.test.js
@@ -23,6 +23,9 @@ const navigateToContentEditorTop = async () => {
 };
 
 const tabThroughParagraphBlock = async ( paragraphText, blockIndex ) => {
+	await page.keyboard.press( 'Tab' );
+	await expect( await getActiveLabel() ).toBe( 'Add block' );
+
 	await tabThroughBlockMoverControl();
 	await tabThroughBlockToolbar();
 
@@ -68,9 +71,6 @@ const tabThroughBlockToolbar = async () => {
 
 	await page.keyboard.press( 'Tab' );
 	await expect( await getActiveLabel() ).toBe( 'More options' );
-
-	await page.keyboard.press( 'Tab' );
-	await expect( await getActiveLabel() ).toBe( 'Add block' );
 };
 
 describe( 'Order of block keyboard navigation', () => {


### PR DESCRIPTION
## Description

Unblocks #19322.

This PR moves the tabbable inserter before the block toolbar.
In the future we can polish this by perhaps centring the button and add one below the block as well.

Why before the toolbar? Because technically you don't leave the block until you exit the block toolbar, and the inserter buttons make most sense on the edges of the block, before and after the block.

The following button normally invisible. It's only visible on focus.

<img width="360" alt="Screenshot 2020-01-13 at 14 12 08" src="https://user-images.githubusercontent.com/4710635/72258794-39c76680-360f-11ea-82b1-6054d9cae147.png">

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
