### PR TITLE
Breadcrumb: add accessibility label

### DIFF
--- a/packages/block-editor/src/components/block-list/block-popover.js
+++ b/packages/block-editor/src/components/block-list/block-popover.js
@@ -159,6 +159,8 @@ function BlockPopover( {
 			{ shouldShowBreadcrumb && (
 				<BlockBreadcrumb
 					clientId={ clientId }
+					rootClientId={ rootClientId }
+					moverDirection={ moverDirection }
 					data-align={ align }
 				/>
 			) }

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -21,7 +21,6 @@ import {
 	isReusableBlock,
 	isUnmodifiedDefaultBlock,
 	getUnregisteredTypeHandlerName,
-	__experimentalGetAccessibleBlockLabel as getAccessibleBlockLabel,
 } from '@wordpress/blocks';
 import { withFilters } from '@wordpress/components';
 import {
@@ -45,36 +44,9 @@ import { isInsideRootBlock } from '../../utils/dom';
 import useMovingAnimation from './moving-animation';
 import { Context } from './root-container';
 
-/**
- * A debounced version of getAccessibleBlockLabel, avoids unnecessary updates to the aria-label attribute
- * when typing in some blocks, like the paragraph.
- *
- * @param {Object} blockType      The block type object representing the block's definition.
- * @param {Object} attributes     The block's attribute values.
- * @param {number} index          The index of the block in the block list.
- * @param {string} moverDirection A string representing whether the movers are displayed vertically or horizontally.
- * @param {number} delay          The debounce delay.
- */
-const useDebouncedAccessibleBlockLabel = ( blockType, attributes, index, moverDirection, delay ) => {
-	const [ blockLabel, setBlockLabel ] = useState( '' );
-
-	useEffect( () => {
-		const timeoutId = setTimeout( () => {
-			setBlockLabel( getAccessibleBlockLabel( blockType, attributes, index + 1, moverDirection ) );
-		}, delay );
-
-		return () => {
-			clearTimeout( timeoutId );
-		};
-	}, [ blockType, attributes, index, moverDirection, delay ] );
-
-	return blockLabel;
-};
-
 function BlockListBlock( {
 	mode,
 	isFocusMode,
-	moverDirection,
 	isLocked,
 	clientId,
 	isSelected,
@@ -87,7 +59,6 @@ function BlockListBlock( {
 	isSelectionEnabled,
 	className,
 	name,
-	index,
 	isValid,
 	attributes,
 	initialPosition,
@@ -134,7 +105,6 @@ function BlockListBlock( {
 	const onBlockError = () => setErrorState( true );
 
 	const blockType = getBlockType( name );
-	const blockAriaLabel = useDebouncedAccessibleBlockLabel( blockType, attributes, index, moverDirection, 400 );
 
 	// Handing the focus of the block on creation and update
 
@@ -314,7 +284,6 @@ function BlockListBlock( {
 			// Only allow selection to be started from a selected block.
 			onMouseLeave={ isSelected ? onMouseLeave : undefined }
 			tabIndex="0"
-			aria-label={ blockAriaLabel }
 			role="group"
 			{ ...wrapperProps }
 			style={

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -105,6 +105,10 @@ function BlockListBlock( {
 	const [ hasError, setErrorState ] = useState( false );
 	const onBlockError = () => setErrorState( true );
 
+	const blockType = getBlockType( name );
+	// translators: %s: Type of block (i.e. Text, Image etc)
+	const blockLabel = sprintf( __( 'Block: %s' ), blockType.title );
+
 	// Handing the focus of the block on creation and update
 
 	/**
@@ -207,13 +211,6 @@ function BlockListBlock( {
 			onSelectionStart( clientId );
 		}
 	};
-
-	// Rendering the output
-	const blockType = getBlockType( name );
-	// translators: %s: Type of block (i.e. Text, Image etc)
-	const blockLabel = sprintf( __( 'Block: %s' ), blockType.title );
-	// The block as rendered in the editor is composed of general block UI
-	// (mover, toolbar, wrapper) and the display of the block content.
 
 	const isUnregisteredBlock = name === getUnregisteredTypeHandlerName();
 

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -23,6 +23,7 @@ import {
 	getUnregisteredTypeHandlerName,
 } from '@wordpress/blocks';
 import { withFilters } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
 import {
 	withDispatch,
 	withSelect,
@@ -103,8 +104,6 @@ function BlockListBlock( {
 	// Handling the error state
 	const [ hasError, setErrorState ] = useState( false );
 	const onBlockError = () => setErrorState( true );
-
-	const blockType = getBlockType( name );
 
 	// Handing the focus of the block on creation and update
 
@@ -209,6 +208,13 @@ function BlockListBlock( {
 		}
 	};
 
+	// Rendering the output
+	const blockType = getBlockType( name );
+	// translators: %s: Type of block (i.e. Text, Image etc)
+	const blockLabel = sprintf( __( 'Block: %s' ), blockType.title );
+	// The block as rendered in the editor is composed of general block UI
+	// (mover, toolbar, wrapper) and the display of the block content.
+
 	const isUnregisteredBlock = name === getUnregisteredTypeHandlerName();
 
 	// If the block is selected and we're typing the block should not appear.
@@ -284,6 +290,7 @@ function BlockListBlock( {
 			// Only allow selection to be started from a selected block.
 			onMouseLeave={ isSelected ? onMouseLeave : undefined }
 			tabIndex="0"
+			aria-label={ blockLabel }
 			role="group"
 			{ ...wrapperProps }
 			style={
@@ -331,7 +338,6 @@ const applyWithSelect = withSelect(
 			getSettings,
 			hasSelectedInnerBlock,
 			getTemplateLock,
-			getBlockIndex,
 			__unstableGetBlockWithoutInnerBlocks,
 			isNavigationMode,
 		} = select( 'core/block-editor' );
@@ -344,7 +350,6 @@ const applyWithSelect = withSelect(
 
 		// "ancestor" is the more appropriate label due to "deep" check
 		const isAncestorOfSelectedBlock = hasSelectedInnerBlock( clientId, checkDeep );
-		const index = getBlockIndex( clientId, rootClientId );
 
 		// The fallback to `{}` is a temporary fix.
 		// This function should never be called when a block is not present in the state.
@@ -370,7 +375,6 @@ const applyWithSelect = withSelect(
 			isLocked: !! templateLock,
 			isFocusMode: focusMode && isLargeViewport,
 			isNavigationMode: isNavigationMode(),
-			index,
 			isRTL,
 
 			// Users of the editor.BlockListBlock filter used to be able to access the block prop

--- a/packages/block-editor/src/components/block-list/breadcrumb.js
+++ b/packages/block-editor/src/components/block-list/breadcrumb.js
@@ -26,7 +26,7 @@ import BlockTitle from '../block-title';
  * @return {WPComponent} The component to be rendered.
  */
 function BlockBreadcrumb( { clientId, rootClientId, moverDirection, ...props } ) {
-	function selector( select ) {
+	const selected = useSelect( ( select ) => {
 		const {
 			__unstableGetBlockWithoutInnerBlocks,
 			getBlockIndex,
@@ -34,13 +34,8 @@ function BlockBreadcrumb( { clientId, rootClientId, moverDirection, ...props } )
 		const index = getBlockIndex( clientId, rootClientId );
 		const { name, attributes } = __unstableGetBlockWithoutInnerBlocks( clientId );
 		return { index, name, attributes };
-	}
-
-	const {
-		index,
-		name,
-		attributes,
-	} = useSelect( selector, [ clientId, rootClientId ] );
+	}, [ clientId, rootClientId ] );
+	const { index, name, attributes } = selected;
 	const {
 		setNavigationMode,
 		removeBlock,

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -35,7 +35,6 @@ const forceSyncUpdates = ( WrappedComponent ) => ( props ) => {
 function BlockList( {
 	className,
 	rootClientId,
-	__experimentalMoverDirection: moverDirection = 'vertical',
 	isDraggable,
 	renderAppender,
 	__experimentalUIParts = {},
@@ -99,7 +98,6 @@ function BlockList( {
 							rootClientId={ rootClientId }
 							clientId={ clientId }
 							isDraggable={ isDraggable }
-							moverDirection={ moverDirection }
 							isMultiSelecting={ isMultiSelecting }
 							// This prop is explicitely computed and passed down
 							// to avoid being impacted by the async mode

--- a/packages/e2e-test-utils/src/transform-block-to.js
+++ b/packages/e2e-test-utils/src/transform-block-to.js
@@ -18,7 +18,7 @@ export async function transformBlockTo( name ) {
 	await insertButton.click();
 
 	// Wait for the transformed block to appear.
-	const BLOCK_SELECTOR = '[contains(@class, "block-editor-block-list__block")]';
-	const BLOCK_NAME_SELECTOR = `[contains(@aria-label, "${ name } Block")]`;
-	await page.waitForXPath( `//*${ BLOCK_SELECTOR }${ BLOCK_NAME_SELECTOR }` );
+	const BLOCK_SELECTOR = '.block-editor-block-list__block';
+	const BLOCK_NAME_SELECTOR = `[aria-label="Block: ${ name }"]`;
+	await page.waitForSelector( `${ BLOCK_SELECTOR }${ BLOCK_NAME_SELECTOR }` );
 }

--- a/packages/e2e-tests/specs/editor/various/keyboard-navigable-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/keyboard-navigable-blocks.test.js
@@ -22,7 +22,7 @@ const navigateToContentEditorTop = async () => {
 	await pressKeyWithModifier( 'ctrl', '`' );
 };
 
-const tabThroughParagraphBlock = async ( paragraphText, blockIndex ) => {
+const tabThroughParagraphBlock = async ( paragraphText ) => {
 	await page.keyboard.press( 'Tab' );
 	await expect( await getActiveLabel() ).toBe( 'Add block' );
 
@@ -30,7 +30,7 @@ const tabThroughParagraphBlock = async ( paragraphText, blockIndex ) => {
 	await tabThroughBlockToolbar();
 
 	await page.keyboard.press( 'Tab' );
-	await expect( await getActiveLabel() ).toBe( `Paragraph Block. Row ${ blockIndex + 1 }. ${ paragraphText }` );
+	await expect( await getActiveLabel() ).toBe( 'Block: Paragraph' );
 
 	await page.keyboard.press( 'Tab' );
 	await expect( await getActiveLabel() ).toBe( 'Paragraph block' );
@@ -94,12 +94,12 @@ describe( 'Order of block keyboard navigation', () => {
 		await page.mouse.move( 10, 10 );
 
 		await navigateToContentEditorTop();
-		await tabThroughParagraphBlock( 'Paragraph 1', 1 );
+		await tabThroughParagraphBlock( 'Paragraph 1' );
 
 		// Repeat the same steps to ensure that there is no change introduced in how the focus is handled.
 		// This prevents the previous regression explained in: https://github.com/WordPress/gutenberg/issues/11773.
 		await navigateToContentEditorTop();
-		await tabThroughParagraphBlock( 'Paragraph 1', 1 );
+		await tabThroughParagraphBlock( 'Paragraph 1' );
 	} );
 
 	it( 'allows tabbing in navigation mode if no block is selected', async () => {
@@ -122,10 +122,10 @@ describe( 'Order of block keyboard navigation', () => {
 		} ) ).toBe( 'Add title' );
 
 		await page.keyboard.press( 'Tab' );
-		await expect( await getActiveLabel() ).toBe( 'Paragraph' );
+		await expect( await getActiveLabel() ).toBe( 'Paragraph Block. Row 1. 0' );
 
 		await page.keyboard.press( 'Tab' );
-		await expect( await getActiveLabel() ).toBe( 'Paragraph' );
+		await expect( await getActiveLabel() ).toBe( 'Paragraph Block. Row 2. 1' );
 
 		await page.keyboard.press( 'Tab' );
 		await expect( await getActiveLabel() ).toBe( 'Document (selected)' );
@@ -147,10 +147,10 @@ describe( 'Order of block keyboard navigation', () => {
 		} );
 
 		await pressKeyWithModifier( 'shift', 'Tab' );
-		await expect( await getActiveLabel() ).toBe( 'Paragraph' );
+		await expect( await getActiveLabel() ).toBe( 'Paragraph Block. Row 2. 1' );
 
 		await pressKeyWithModifier( 'shift', 'Tab' );
-		await expect( await getActiveLabel() ).toBe( 'Paragraph' );
+		await expect( await getActiveLabel() ).toBe( 'Paragraph Block. Row 1. 0' );
 
 		await pressKeyWithModifier( 'shift', 'Tab' );
 		await expect( await page.evaluate( () => {


### PR DESCRIPTION
## Description

See https://github.com/WordPress/gutenberg/pull/18132#issuecomment-573633017.

The block label doesn't make se much sense on the block wrapper, as it's right next to the block content and we'd like the remove this wrapper eventually. The block label makes a lot more sense in navigation mode.

Example:

```html
<button type="button" class="components-button" aria-label="Paragraph Block. Row 16. Imagine everything that WordPress can do is available to you quickly and in the same place on the interface. No need to figure out HTML tags, classes, or remember complicated shortcode syntax. That’s the spirit behind the inserter—the (+) button you’ll see around the editor—which allows you to browse all available content blocks and add them into your post. Plugins and themes are able to register their own, opening up all sort of possibilities for rich editing and publishing.">Paragraph</button>
```

<img width="736" alt="Screenshot 2020-01-13 at 14 48 43" src="https://user-images.githubusercontent.com/4710635/72260756-d429a900-3613-11ea-8111-976ffce91596.png">

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
