### PR TITLE
Makes appenders visible only for the current selection

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -38,6 +38,7 @@ import { Fragment, useState, useEffect } from '@wordpress/element';
 
 function NavigationLinkEdit( {
 	attributes,
+	hasDescendants,
 	isSelected,
 	isParentOfSelectedBlock,
 	setAttributes,
@@ -182,7 +183,7 @@ function NavigationLinkEdit( {
 				</div>
 				<InnerBlocks
 					allowedBlocks={ [ 'core/navigation-link' ] }
-					renderAppender={ isSelected ? InnerBlocks.ButtonBlockAppender : false }
+					renderAppender={ ( hasDescendants && isSelected ) ? InnerBlocks.DefaultAppender : false }
 				/>
 			</div>
 		</Fragment>
@@ -191,11 +192,12 @@ function NavigationLinkEdit( {
 
 export default compose( [
 	withSelect( ( select, ownProps ) => {
-		const { hasSelectedInnerBlock } = select( 'core/block-editor' );
+		const { getClientIdsOfDescendants, hasSelectedInnerBlock } = select( 'core/block-editor' );
 		const { clientId } = ownProps;
 
 		return {
 			isParentOfSelectedBlock: hasSelectedInnerBlock( clientId, true ),
+			hasDescendants: !! getClientIdsOfDescendants( [ clientId ] ).length,
 		};
 	} ),
 	withDispatch( ( dispatch, ownProps, registry ) => {

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -38,7 +38,6 @@ import { Fragment, useState, useEffect } from '@wordpress/element';
 
 function NavigationLinkEdit( {
 	attributes,
-	hasDescendants,
 	isSelected,
 	isParentOfSelectedBlock,
 	setAttributes,
@@ -183,7 +182,7 @@ function NavigationLinkEdit( {
 				</div>
 				<InnerBlocks
 					allowedBlocks={ [ 'core/navigation-link' ] }
-					renderAppender={ hasDescendants ? InnerBlocks.ButtonBlockAppender : false }
+					renderAppender={ isSelected ? InnerBlocks.ButtonBlockAppender : false }
 				/>
 			</div>
 		</Fragment>
@@ -192,12 +191,11 @@ function NavigationLinkEdit( {
 
 export default compose( [
 	withSelect( ( select, ownProps ) => {
-		const { getClientIdsOfDescendants, hasSelectedInnerBlock } = select( 'core/block-editor' );
+		const { hasSelectedInnerBlock } = select( 'core/block-editor' );
 		const { clientId } = ownProps;
 
 		return {
 			isParentOfSelectedBlock: hasSelectedInnerBlock( clientId, true ),
-			hasDescendants: !! getClientIdsOfDescendants( [ clientId ] ).length,
 		};
 	} ),
 	withDispatch( ( dispatch, ownProps, registry ) => {

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -48,6 +48,7 @@ function Navigation( {
 	fontSize,
 	hasExistingNavItems,
 	hasResolvedPages,
+	isSelected,
 	isRequestingPages,
 	pages,
 	setAttributes,
@@ -198,6 +199,7 @@ function Navigation( {
 						allowedBlocks={ [ 'core/navigation-link' ] }
 						templateInsertUpdatesSelection={ false }
 						__experimentalMoverDirection={ 'horizontal' }
+						renderAppender={ isSelected ? InnerBlocks.ButtonBlockAppender : false }
 					/>
 
 				</div>

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -48,7 +48,6 @@ function Navigation( {
 	fontSize,
 	hasExistingNavItems,
 	hasResolvedPages,
-	isSelected,
 	isRequestingPages,
 	pages,
 	setAttributes,
@@ -199,7 +198,6 @@ function Navigation( {
 						allowedBlocks={ [ 'core/navigation-link' ] }
 						templateInsertUpdatesSelection={ false }
 						__experimentalMoverDirection={ 'horizontal' }
-						renderAppender={ isSelected ? InnerBlocks.ButtonBlockAppender : false }
 					/>
 
 				</div>

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -61,11 +61,17 @@
 	// Polish the Appender.
 	.wp-block-navigation .block-list-appender {
 		margin: 0;
+		width: 28px;
+		height: 28px;
+		margin-top: $grid-size/2;
 
 		.block-editor-button-block-appender {
 			padding: $grid-size;
+			padding-bottom: $grid-size/2;
+			padding-top: $grid-size/2;
 			outline: none;
 			background: none;
+			border-radius: 50%;
 		}
 	}
 }

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -63,15 +63,15 @@
 		margin: 0;
 		width: 28px;
 		height: 28px;
-		margin-top: $grid-size/2;
+		margin-top: $grid-size-small;
+		margin-left: $grid-size + $block-side-ui-clearance;
 
 		.block-editor-button-block-appender {
 			padding: $grid-size;
-			padding-bottom: $grid-size/2;
-			padding-top: $grid-size/2;
+			padding-bottom: $grid-size-small;
+			padding-top: $grid-size-small;
 			outline: none;
 			background: none;
-			border-radius: 50%;
 		}
 	}
 }

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -1,5 +1,4 @@
 .wp-block-navigation {
-
 	& > ul {
 		display: block;
 		list-style: none;


### PR DESCRIPTION
## Description
Makes the problem in #18333 a bit better. Also I think it will help when implementing the stuff discussed in #18310.

## How has this been tested?
Tested locally.

## Screenshots <!-- if applicable -->

![appender-fix](https://user-images.githubusercontent.com/107534/72265926-03491600-3626-11ea-8619-4c591f80a56d.gif)


## Types of changes
Updated when the appender is shown for innerBlocks in the navigation and navigation-link blocks.

