### PR TITLE
Navigation Block: Add submenu chevron w/ setting

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -156,6 +156,7 @@ function NavigationLinkEdit( {
 			>
 				<div className="wp-block-navigation-link__content">
 					<RichText
+						tagName="span"
 						value={ label }
 						onChange={ ( labelValue ) => setAttributes( { label: labelValue } ) }
 						placeholder={ itemLabelPlaceholder }
@@ -168,9 +169,9 @@ function NavigationLinkEdit( {
 						] }
 					/>
 					{ showSubmenuIcon &&
-						<div className="wp-block-navigation-link__submenu-icon">
+						<span className="wp-block-navigation-link__submenu-icon">
 							{ itemSubmenuIcon }
-						</div>
+						</span>
 					}
 					{ isLinkOpen && (
 						<Popover position="bottom center">

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -156,10 +156,8 @@ function NavigationLinkEdit( {
 					'has-link': !! url,
 				} ) }
 			>
-				<div>
+				<div className="wp-block-navigation-link__content">
 					<RichText
-						tagName="span"
-						className="wp-block-navigation-link__content"
 						value={ label }
 						onChange={ ( labelValue ) => setAttributes( { label: labelValue } ) }
 						placeholder={ itemLabelPlaceholder }
@@ -172,9 +170,9 @@ function NavigationLinkEdit( {
 						] }
 					/>
 					{ showSubmenuIcon &&
-						<span className="wp-block-navigation-link__submenu-icon">
+						<div className="wp-block-navigation-link__submenu-icon">
 							{ submenuIcon }
-						</span>
+						</div>
 					}
 					{ isLinkOpen && (
 						<Popover position="bottom center">

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -14,9 +14,7 @@ import {
 	ExternalLink,
 	KeyboardShortcuts,
 	PanelBody,
-	Path,
 	Popover,
-	SVG,
 	TextareaControl,
 	TextControl,
 	ToggleControl,
@@ -40,7 +38,7 @@ import { Fragment, useState, useEffect } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { submenuIcon } from './icons';
+import { toolbarSubmenuIcon, itemSubmenuIcon } from './icons';
 
 function NavigationLinkEdit( {
 	attributes,
@@ -99,7 +97,7 @@ function NavigationLinkEdit( {
 					/>
 					<ToolbarButton
 						name="submenu"
-						icon={ <SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24"><Path d="M14 5h8v2h-8zm0 5.5h8v2h-8zm0 5.5h8v2h-8zM2 11.5C2 15.08 4.92 18 8.5 18H9v2l3-3-3-3v2h-.5C6.02 16 4 13.98 4 11.5S6.02 7 8.5 7H12V5H8.5C4.92 5 2 7.92 2 11.5z" /><Path fill="none" d="M0 0h24v24H0z" /></SVG> }
+						icon={ toolbarSubmenuIcon }
 						title={ __( 'Add submenu' ) }
 						onClick={ insertLinkBlock }
 					/>
@@ -171,7 +169,7 @@ function NavigationLinkEdit( {
 					/>
 					{ showSubmenuIcon &&
 						<div className="wp-block-navigation-link__submenu-icon">
-							{ submenuIcon }
+							{ itemSubmenuIcon }
 						</div>
 					}
 					{ isLinkOpen && (

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -157,6 +157,7 @@ function NavigationLinkEdit( {
 				<div className="wp-block-navigation-link__content">
 					<RichText
 						tagName="span"
+						className="wp-block-navigation-link__label"
 						value={ label }
 						onChange={ ( labelValue ) => setAttributes( { label: labelValue } ) }
 						placeholder={ itemLabelPlaceholder }

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -224,16 +224,16 @@ export default compose( [
 			hasSelectedInnerBlock,
 		} = select( 'core/block-editor' );
 		const { clientId } = ownProps;
-		const hasDescendants = !! getClientIdsOfDescendants( [ clientId ] ).length;
+		const rootBlock = getBlockParents( clientId )[ 0 ];
 		const parentBlock = getBlockParents( clientId, true )[ 0 ];
-		let showSubmenuIcon = false;
-
-		if ( hasDescendants && getBlockName( parentBlock ) === 'core/navigation' ) {
-			showSubmenuIcon = getBlockAttributes( parentBlock ).showSubmenuIcon;
-		}
+		const rootBlockAttributes = getBlockAttributes( rootBlock );
+		const hasDescendants = !! getClientIdsOfDescendants( [ clientId ] ).length;
+		const isLevelZero = getBlockName( parentBlock ) === 'core/navigation';
+		const showSubmenuIcon = rootBlockAttributes.showSubmenuIcon && isLevelZero && hasDescendants;
+		const isParentOfSelectedBlock = hasSelectedInnerBlock( clientId, true );
 
 		return {
-			isParentOfSelectedBlock: hasSelectedInnerBlock( clientId, true ),
+			isParentOfSelectedBlock,
 			hasDescendants,
 			showSubmenuIcon,
 		};

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -37,12 +37,18 @@ import {
 } from '@wordpress/block-editor';
 import { Fragment, useState, useEffect } from '@wordpress/element';
 
+/**
+ * Internal dependencies
+ */
+import { submenuIcon } from './icons';
+
 function NavigationLinkEdit( {
 	attributes,
 	hasDescendants,
 	isSelected,
 	isParentOfSelectedBlock,
 	setAttributes,
+	showSubmenuIcon,
 	insertLinkBlock,
 } ) {
 	const { label, opensInNewTab, title, url, nofollow, description } = attributes;
@@ -152,6 +158,7 @@ function NavigationLinkEdit( {
 			>
 				<div>
 					<RichText
+						tagName="span"
 						className="wp-block-navigation-link__content"
 						value={ label }
 						onChange={ ( labelValue ) => setAttributes( { label: labelValue } ) }
@@ -164,6 +171,11 @@ function NavigationLinkEdit( {
 							'core/strikethrough',
 						] }
 					/>
+					{ showSubmenuIcon &&
+						<span className="wp-block-navigation-link__submenu-icon">
+							{ submenuIcon }
+						</span>
+					}
 					{ isLinkOpen && (
 						<Popover position="bottom center">
 							<LinkControl
@@ -208,13 +220,26 @@ function NavigationLinkEdit( {
 
 export default compose( [
 	withSelect( ( select, ownProps ) => {
-		const { getClientIdsOfDescendants, hasSelectedInnerBlock } = select( 'core/block-editor' );
+		const {
+			getBlockName,
+			getBlockAttributes,
+			getBlockParents,
+			getClientIdsOfDescendants,
+			hasSelectedInnerBlock,
+		} = select( 'core/block-editor' );
 		const { clientId } = ownProps;
+		const hasDescendants = !! getClientIdsOfDescendants( [ clientId ] ).length;
+		const parentBlock = getBlockParents( clientId, true )[ 0 ];
+		let showSubmenuIcon = false;
+
+		if ( hasDescendants && getBlockName( parentBlock ) === 'core/navigation' ) {
+			showSubmenuIcon = getBlockAttributes( parentBlock ).showSubmenuIcon;
+		}
 
 		return {
 			isParentOfSelectedBlock: hasSelectedInnerBlock( clientId, true ),
-			hasDescendants: !! getClientIdsOfDescendants( [ clientId ] ).length,
-
+			hasDescendants,
+			showSubmenuIcon,
 		};
 	} ),
 	withDispatch( ( dispatch, ownProps, registry ) => {

--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -73,6 +73,10 @@
 		text-decoration: underline;
 	}
 
+	.wp-block-navigation-link__submenu-icon {
+		margin-left: 4px;
+	}
+
 	.block-editor-rich-text__editable.is-selected:not(.keep-placeholder-on-focus):not(:focus) [data-rich-text-placeholder]::after {
 		display: inline-block;
 	}

--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -70,6 +70,8 @@
 	}
 
 	&.has-link .wp-block-navigation-link__content {
+		display: flex;
+		align-items: center;
 		text-decoration: underline;
 	}
 

--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -7,37 +7,6 @@
 	min-height: $icon-button-size;
 }
 
-.wp-block-navigation-link__edit-container {
-	display: flex;
-	white-space: nowrap;
-
-	// Compensate for navigation link base padding.
-	margin-left: -$grid-size;
-
-	.wp-block-navigation-link__content {
-		margin-right: $grid-size;
-
-		// This should match the padding of the navigation link.
-		padding: 0 $grid-size;
-
-		// This make it look like an input field.
-		// We may want to not style this at all, but let's try this.
-		// We don't use the mixins because they increase the size of the input, which doesn't work with PlainText.
-		box-shadow: inset 0 0 0 1px $dark-gray-200;
-		transition: box-shadow 0.1s linear;
-		border-radius: $radius-round-rectangle;
-		@include reduce-motion("transition");
-
-		&:focus {
-			color: $dark-gray-900;
-			box-shadow: inset 0 0 0 2px $blue-medium-focus;
-
-			// Windows High Contrast mode will show this outline, but not the box-shadow.
-			outline: 2px solid transparent;
-		}
-	}
-}
-
 /*
  * Adjust Navigation Item.
  */
@@ -69,9 +38,12 @@
 		display: block;
 	}
 
-	&.has-link .wp-block-navigation-link__content {
+	.wp-block-navigation-link__content {
 		display: flex;
 		align-items: center;
+	}
+
+	&.has-link .wp-block-navigation-link__label {
 		text-decoration: underline;
 	}
 

--- a/packages/block-library/src/navigation-link/icons.js
+++ b/packages/block-library/src/navigation-link/icons.js
@@ -1,0 +1,10 @@
+/**
+ * WordPress dependencies
+ */
+import { Polygon, SVG } from '@wordpress/components';
+
+export const submenuIcon = (
+	<SVG width="18" height="18" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18">
+		<Polygon points="9,13.5 14.7,7.9 13.2,6.5 9,10.7 4.8,6.5 3.3,7.9 " />
+	</SVG>
+);

--- a/packages/block-library/src/navigation-link/icons.js
+++ b/packages/block-library/src/navigation-link/icons.js
@@ -1,9 +1,16 @@
 /**
  * WordPress dependencies
  */
-import { Polygon, SVG } from '@wordpress/components';
+import { Polygon, Path, SVG } from '@wordpress/components';
 
-export const submenuIcon = (
+export const toolbarSubmenuIcon = (
+	<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24">
+		<Path d="M14 5h8v2h-8zm0 5.5h8v2h-8zm0 5.5h8v2h-8zM2 11.5C2 15.08 4.92 18 8.5 18H9v2l3-3-3-3v2h-.5C6.02 16 4 13.98 4 11.5S6.02 7 8.5 7H12V5H8.5C4.92 5 2 7.92 2 11.5z" />
+		<Path fill="none" d="M0 0h24v24H0z" />
+	</SVG>
+);
+
+export const itemSubmenuIcon = (
 	<SVG width="18" height="18" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18">
 		<Polygon points="9,13.5 14.7,7.9 13.2,6.5 9,10.7 4.8,6.5 3.3,7.9 " />
 	</SVG>

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -226,7 +226,7 @@ function Navigation( {
 						onChange={ ( value ) => {
 							setAttributes( { showSubmenuIcon: value } );
 						} }
-						label={ __( 'Show submenu icon' ) }
+						label={ __( 'Show submenu icon for top-level items' ) }
 					/>
 				</PanelBody>
 			</InspectorControls>

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -28,6 +28,7 @@ import {
 	PanelBody,
 	Placeholder,
 	Spinner,
+	ToggleControl,
 	Toolbar,
 	ToolbarGroup,
 } from '@wordpress/components';
@@ -216,6 +217,17 @@ function Navigation( {
 				</PanelBody>
 			</InspectorControls>
 			{ InspectorControlsColorPanel }
+			<InspectorControls>
+				<PanelBody
+					title={ __( 'Display Settings' ) }
+				>
+					<ToggleControl
+						checked={ false } // ToDo: add 'showSubmenuChevron' attribute
+						onChange={ () => {} }
+						label={ __( 'Show submenu chevron' ) }
+					/>
+				</PanelBody>
+			</InspectorControls>
 			<TextColor>
 				<BackgroundColor>
 					<div

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -222,9 +222,11 @@ function Navigation( {
 					title={ __( 'Display Settings' ) }
 				>
 					<ToggleControl
-						checked={ false } // ToDo: add 'showSubmenuChevron' attribute
-						onChange={ () => {} }
-						label={ __( 'Show submenu chevron' ) }
+						checked={ attributes.showSubmenuIcon }
+						onChange={ ( value ) => {
+							setAttributes( { showSubmenuIcon: value } );
+						} }
+						label={ __( 'Show submenu icon' ) }
 					/>
 				</PanelBody>
 			</InspectorControls>

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -183,7 +183,7 @@ function build_navigation_html( $attributes, $block, $colors, $font_sizes, $is_l
 	foreach ( (array) $block['innerBlocks'] as $key => $block ) {
 		$has_submenu = count( (array) $block['innerBlocks'] ) > 0;
 
-		$html .= '<li class="wp-block-navigation-link' . ($has_submenu ? ' has-submenu' : '') . '">' .
+		$html .= '<li class="wp-block-navigation-link' . ( $has_submenu ? ' has-submenu' : '' ) . '">' .
 			'<a';
 
 		if ( $is_level_zero ) {

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -204,7 +204,7 @@ function build_navigation_html( $attributes, $block, $colors, $font_sizes, $is_l
 		// End appending HTML attributes to anchor tag.
 
 		// Start anchor tag content.
-		$html .= '><span>';
+		$html .= '><span>'; // Wrap title with span to isolate it from submenu icon.
 		if ( isset( $block['attrs']['label'] ) ) {
 			$html .= wp_kses(
 				$block['attrs']['label'],

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -110,7 +110,7 @@ function gutenberg_remove_empty_navigation_links_recursive( $blocks ) {
 	return $blocks;
 }
 
-/*
+/**
  * Returns the top-level submenu SVG chevron icon.
  *
  * @return string
@@ -161,9 +161,10 @@ function render_block_navigation( $attributes, $content, $block ) {
 /**
  * Walks the inner block structure and returns an HTML list for it.
  *
- * @param array $block      The block.
- * @param array $colors     Contains inline styles and CSS classes to apply to navigation item.
- * @param array $font_sizes Contains inline styles and CSS classes to apply to navigation item.
+ * @param array $attributes    The Navigation block attributes.
+ * @param array $block         The NavigationItem block.
+ * @param array $colors        Contains inline styles and CSS classes to apply to navigation item.
+ * @param array $font_sizes    Contains inline styles and CSS classes to apply to navigation item.
  * @param bool  $is_level_zero True whether is main menu (level zero). Otherwise, False.
  *
  * @return string Returns  an HTML list from innerBlocks.
@@ -229,7 +230,7 @@ function build_navigation_html( $attributes, $block, $colors, $font_sizes, $is_l
 
 		$html .= '</span>';
 
-		// Append submenu icon to top-level item
+		// Append submenu icon to top-level item.
 		if ( $attributes['showSubmenuIcon'] && $is_level_zero && $has_submenu ) {
 			$html .= '<span class="wp-block-navigation-link__submenu-icon">' . render_submenu_icon() . '</span>';
 		}
@@ -282,10 +283,10 @@ function register_block_core_navigation() {
 				'itemsJustification'    => array(
 					'type' => 'string',
 				),
-				'showSubmenuIcon'		 => array(
-					'type' => 'boolean',
+				'showSubmenuIcon'       => array(
+					'type'    => 'boolean',
 					'default' => false,
-				)
+				),
 			),
 
 			'render_callback' => 'render_block_navigation',

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -264,6 +264,10 @@ function register_block_core_navigation() {
 				'itemsJustification'    => array(
 					'type' => 'string',
 				),
+				'showSubmenuIcon'		 => array(
+					'type' => 'boolean',
+					'default' => false,
+				)
 			),
 
 			'render_callback' => 'render_block_navigation',

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -110,6 +110,15 @@ function gutenberg_remove_empty_navigation_links_recursive( $blocks ) {
 	return $blocks;
 }
 
+/*
+ * Returns the top-level submenu SVG chevron icon.
+ *
+ * @return string
+ */
+function render_submenu_icon() {
+	return '<svg width="18" height="18" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" role="img" aria-hidden="true" focusable="false"><polygon points="9,13.5 14.7,7.9 13.2,6.5 9,10.7 4.8,6.5 3.3,7.9 "></polygon></svg>';
+}
+
 /**
  * Renders the `core/navigation` block on server.
  *
@@ -145,7 +154,7 @@ function render_block_navigation( $attributes, $content, $block ) {
 		'<nav %1$s %2$s>%3$s</nav>',
 		$class_attribute,
 		$style_attribute,
-		build_navigation_html( $block, $colors, $font_sizes )
+		build_navigation_html( $attributes, $block, $colors, $font_sizes, true )
 	);
 }
 
@@ -159,7 +168,7 @@ function render_block_navigation( $attributes, $content, $block ) {
  *
  * @return string Returns  an HTML list from innerBlocks.
  */
-function build_navigation_html( $block, $colors, $font_sizes, $level_zero = true ) {
+function build_navigation_html( $attributes, $block, $colors, $font_sizes, $level_zero = true ) {
 	$html            = '';
 	$classes         = array_merge(
 		$colors['css_classes'],
@@ -172,8 +181,9 @@ function build_navigation_html( $block, $colors, $font_sizes, $level_zero = true
 		: '';
 
 	foreach ( (array) $block['innerBlocks'] as $key => $block ) {
+		$has_submenu = count( (array) $block['innerBlocks'] ) > 0;
 
-		$html .= '<li class="wp-block-navigation-link">' .
+		$html .= '<li class="wp-block-navigation-link' . ($has_submenu ? ' has-submenu' : '') . '">' .
 			'<a';
 
 		if ( $level_zero ) {
@@ -194,7 +204,7 @@ function build_navigation_html( $block, $colors, $font_sizes, $level_zero = true
 		// End appending HTML attributes to anchor tag.
 
 		// Start anchor tag content.
-		$html .= '>';
+		$html .= '><span>';
 		if ( isset( $block['attrs']['label'] ) ) {
 			$html .= wp_kses(
 				$block['attrs']['label'],
@@ -216,11 +226,19 @@ function build_navigation_html( $block, $colors, $font_sizes, $level_zero = true
 				)
 			);
 		}
+
+		$html .= '</span>';
+
+		// Append submenu icon to top-level item
+		if ( $attributes['showSubmenuIcon'] && $level_zero && $has_submenu ) {
+			$html .= '<span class="wp-block-navigation-link__submenu-icon">' . render_submenu_icon() . '</span>';
+		}
+
 		$html .= '</a>';
 		// End anchor tag content.
 
-		if ( count( (array) $block['innerBlocks'] ) > 0 ) {
-			$html .= build_navigation_html( $block, $colors, $font_sizes, false );
+		if ( $has_submenu ) {
+			$html .= build_navigation_html( $attributes, $block, $colors, $font_sizes, false );
 		}
 
 		$html .= '</li>';

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -164,11 +164,11 @@ function render_block_navigation( $attributes, $content, $block ) {
  * @param array $block      The block.
  * @param array $colors     Contains inline styles and CSS classes to apply to navigation item.
  * @param array $font_sizes Contains inline styles and CSS classes to apply to navigation item.
- * @param bool  $level_zero True whether is main menu (level zero). Otherwise, False.
+ * @param bool  $is_level_zero True whether is main menu (level zero). Otherwise, False.
  *
  * @return string Returns  an HTML list from innerBlocks.
  */
-function build_navigation_html( $attributes, $block, $colors, $font_sizes, $level_zero = true ) {
+function build_navigation_html( $attributes, $block, $colors, $font_sizes, $is_level_zero = true ) {
 	$html            = '';
 	$classes         = array_merge(
 		$colors['css_classes'],
@@ -186,7 +186,7 @@ function build_navigation_html( $attributes, $block, $colors, $font_sizes, $leve
 		$html .= '<li class="wp-block-navigation-link' . ($has_submenu ? ' has-submenu' : '') . '">' .
 			'<a';
 
-		if ( $level_zero ) {
+		if ( $is_level_zero ) {
 			$html .= $class_attribute . $style_attribute;
 		}
 
@@ -230,7 +230,7 @@ function build_navigation_html( $attributes, $block, $colors, $font_sizes, $leve
 		$html .= '</span>';
 
 		// Append submenu icon to top-level item
-		if ( $attributes['showSubmenuIcon'] && $level_zero && $has_submenu ) {
+		if ( $attributes['showSubmenuIcon'] && $is_level_zero && $has_submenu ) {
 			$html .= '<span class="wp-block-navigation-link__submenu-icon">' . render_submenu_icon() . '</span>';
 		}
 

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -205,7 +205,10 @@ function build_navigation_html( $attributes, $block, $colors, $font_sizes, $is_l
 		// End appending HTML attributes to anchor tag.
 
 		// Start anchor tag content.
-		$html .= '><span>'; // Wrap title with span to isolate it from submenu icon.
+		$html .= '>' .
+			// Wrap title with span to isolate it from submenu icon.
+			'<span class="wp-block-navigation-link__label">';
+
 		if ( isset( $block['attrs']['label'] ) ) {
 			$html .= wp_kses(
 				$block['attrs']['label'],

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -40,6 +40,8 @@
 		& > li {
 
 			& > a {
+				display: flex;
+				align-items: center;
 				padding-left: 0;
 
 				@include break-small {
@@ -53,6 +55,16 @@
 
 			&:last-of-type > a {
 				padding-right: 0;
+			}
+
+			// Make submenu icon inherit current text color
+			& > a svg {
+				fill: currentColor;
+			}
+
+			// Add some space between link text & submenu icon
+			& > a > span + span {
+				margin-left: 4px;
 			}
 		}
 
@@ -146,18 +158,6 @@
 			&:last-child {
 				padding-bottom: 13px;
 			}
-		}
-	}
-
-	// Top-level sub-menu indicators
-	& .has-sub-menu > a {
-
-		&::after {
-			content: "\00a0\25BC";
-			display: inline-block;
-			font-size: 0.6rem;
-			height: inherit;
-			width: inherit;
 		}
 	}
 

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -37,6 +37,7 @@
 			}
 		}
 
+		// ToDo: move navigation-link styles to navigation-link/style.scss
 		& > li {
 
 			& > a {
@@ -57,14 +58,12 @@
 				padding-right: 0;
 			}
 
-			// Make submenu icon inherit current text color
-			& > a svg {
-				fill: currentColor;
-			}
-
-			// Add some space between link text & submenu icon
-			& > a > span + span {
+			.wp-block-navigation-link__submenu-icon {
 				margin-left: 4px;
+
+				svg {
+					fill: currentColor;
+				}
 			}
 		}
 

--- a/packages/e2e-tests/specs/editor/blocks/__snapshots__/navigation.test.js.snap
+++ b/packages/e2e-tests/specs/editor/blocks/__snapshots__/navigation.test.js.snap
@@ -2,9 +2,9 @@
 
 exports[`Navigation allows a navigation menu to be created from an empty menu using a mixture of internal and external links 1`] = `
 "<!-- wp:navigation -->
-<!-- wp:navigation-link {\\"label\\":\\"WP\\",\\"title\\":\\"https://wordpress.org\\",\\"url\\":\\"https://wordpress.org\\"} /-->
+<!-- wp:navigation-link {\\"label\\":\\"WP\\",\\"title\\":\\"https://wordpress.org\\",\\"id\\":\\"-1\\",\\"url\\":\\"https://wordpress.org\\"} /-->
 
-<!-- wp:navigation-link {\\"label\\":\\"Get in touch\\",\\"title\\":\\"Contact Us\\",\\"url\\":\\"https://this/is/a/test/url/contact-us\\"} /-->
+<!-- wp:navigation-link {\\"label\\":\\"Get in touch\\",\\"title\\":\\"Contact Us\\",\\"id\\":1,\\"url\\":\\"https://this/is/a/test/url/contact-us\\"} /-->
 <!-- /wp:navigation -->"
 `;
 

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -59,7 +59,7 @@ async function updateActiveNavigationLink( { url, label } ) {
 	}
 
 	if ( label ) {
-		await page.click( '.wp-block-navigation-link__content.is-selected' );
+		await page.click( '.wp-block-navigation-link__label.is-selected' );
 
 		// Ideally this would be `await pressKeyWithModifier( 'primary', 'a' )`
 		// to select all text like other tests do.


### PR DESCRIPTION
## Description

Add optional submenu indication by appending chevron icon to top-level Navigation block items.

Closes #18396.

## How has this been tested?

- Add Navigation block
- Add Item and create a submenu for it
- Go to Navigation block's settings
- Under `Display settings`, switch on the `Show submenu icon for top-level items` toggle
- Top-level items that have submenu should have a chevron icon appended to them in both editor and view sides.

## Screenshots <!-- if applicable -->

Default (submenu icons are off):
<img width="1038" alt="Screenshot 2020-01-16 18 56 27" src="https://user-images.githubusercontent.com/1451471/72550058-342d8300-3892-11ea-8279-6aaf99249aa4.png">

Icons on:
<img width="1040" alt="Screenshot 2020-01-16 18 55 55" src="https://user-images.githubusercontent.com/1451471/72550057-3394ec80-3892-11ea-946e-d27b40e7956c.png">

Front-end:
<img width="614" alt="Screenshot 2020-01-16 18 57 27" src="https://user-images.githubusercontent.com/1451471/72550060-342d8300-3892-11ea-87ad-bc5053cda979.png">

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->