### PR TITLE
Editor keyboard shortcuts: fix Toggle Sidebar

### DIFF
--- a/packages/edit-post/src/components/keyboard-shortcuts/index.js
+++ b/packages/edit-post/src/components/keyboard-shortcuts/index.js
@@ -10,7 +10,7 @@ function KeyboardShortcuts() {
 	const {
 		getBlockSelectionStart,
 		getEditorMode,
-		isEditorSidebarOpen,
+		isEditorSidebarOpened,
 		richEditingEnabled,
 		codeEditingEnabled,
 	} = useSelect( ( select ) => {
@@ -110,7 +110,7 @@ function KeyboardShortcuts() {
 		// obscure shortcuts from triggering.
 		event.preventDefault();
 
-		if ( isEditorSidebarOpen ) {
+		if ( isEditorSidebarOpened() ) {
 			closeGeneralSidebar();
 		} else {
 			const sidebarToOpen = getBlockSelectionStart() ? 'edit-post/block' : 'edit-post/document';


### PR DESCRIPTION
## Description
Fixes <kbd>primaryShift + ,</kbd> shortcut for toggling the sidebar, a regression from 52000d7cba67a6226d47aade0fc3130c695fabdd (#19320).

## How has this been tested?
Make sure that the shortcut in question can both close and open the sidebar.