### PR TITLE
Media & Text: Remove "Insert from URL" from the replacement flow.

### DIFF
--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -57,7 +57,6 @@ class MediaTextEdit extends Component {
 			mediaWidth: null,
 		};
 		this.onSetHref = this.onSetHref.bind( this );
-		this.onSelectURL = this.onSelectURL.bind( this );
 	}
 
 	onSelectMedia( media ) {
@@ -118,29 +117,6 @@ class MediaTextEdit extends Component {
 		this.props.setAttributes( props );
 	}
 
-	onSelectURL( newURL ) {
-		const { mediaUrl, linkDestination, href } = this.props.attributes;
-
-		if ( newURL !== mediaUrl ) {
-			let newHref = href;
-			if ( linkDestination === LINK_DESTINATION_MEDIA ) {
-				// Update the media link.
-				newHref = newURL;
-			}
-
-			// Check if the image is linked to the attachment page.
-			if ( linkDestination === LINK_DESTINATION_ATTACHMENT ) {
-				// Update the media link.
-				newHref = undefined;
-			}
-			this.props.setAttributes( {
-				mediaUrl: newURL,
-				href: newHref,
-				mediaId: undefined,
-			} );
-		}
-	}
-
 	commitWidthChange( width ) {
 		const { setAttributes } = this.props;
 
@@ -159,7 +135,6 @@ class MediaTextEdit extends Component {
 			<MediaContainer
 				className="block-library-media-text__media-container"
 				onSelectMedia={ this.onSelectMedia }
-				onSelectURL={ this.onSelectURL }
 				onWidthChange={ this.onWidthChange }
 				commitWidthChange={ this.commitWidthChange }
 				{ ...{ mediaAlt, mediaId, mediaType, mediaUrl, mediaPosition, mediaWidth, imageFill, focalPoint } }

--- a/packages/block-library/src/media-text/media-container.js
+++ b/packages/block-library/src/media-text/media-container.js
@@ -45,7 +45,7 @@ class MediaContainer extends Component {
 	}
 
 	renderToolbarEditButton() {
-		const { onSelectMedia, onSelectURL, mediaUrl } = this.props;
+		const { onSelectMedia, mediaUrl } = this.props;
 		return (
 			<BlockControls>
 				<MediaReplaceFlow
@@ -53,7 +53,6 @@ class MediaContainer extends Component {
 					allowedTypes={ ALLOWED_MEDIA_TYPES }
 					accept="image/*,video/*"
 					onSelect={ onSelectMedia }
-					onSelectURL={ onSelectURL }
 				/>
 			</BlockControls>
 		);


### PR DESCRIPTION
## Description
Removes the "Insert from URL" from the `MediaReplaceFlow` in the Media & Text block, because this Block doesn't support this feature yet. If we add an URL, we can't detect if it's an image or a video. If we first add a video and then replace it with an image, it breaks.

We already have #14397 to add this feature the block.

**Placeholder**:
<img width="640" alt="Bildschirmfoto 2020-01-13 um 22 25 06" src="https://user-images.githubusercontent.com/695201/72293406-c09e3280-3653-11ea-9e32-fba74d30ecad.png">
**Replacement**
Before
<img width="283" alt="Bildschirmfoto 2020-01-13 um 22 29 02" src="https://user-images.githubusercontent.com/695201/72293634-34d8d600-3654-11ea-9c83-cba113990bf9.png">
After
<img width="301" alt="Bildschirmfoto 2020-01-13 um 22 25 23" src="https://user-images.githubusercontent.com/695201/72293410-c267f600-3653-11ea-8ce0-af3af6e3cea8.png">



@draganescu 