### PR TITLE
Fix Color Picker Format Toggle placement

### DIFF
--- a/packages/components/src/color-picker/inputs.js
+++ b/packages/components/src/color-picker/inputs.js
@@ -286,8 +286,9 @@ export class Inputs extends Component {
 		return (
 			<div className="components-color-picker__inputs-wrapper">
 				{ this.renderFields() }
-				<div className="components-color-picker__inputs-toggle">
+				<div className="components-color-picker__inputs-toggle-wrapper">
 					<PureButton
+						className="components-color-picker__inputs-toggle"
 						icon="arrow-down-alt2"
 						label={ __( 'Change color format' ) }
 						onClick={ this.toggleViews }

--- a/packages/components/src/color-picker/style.scss
+++ b/packages/components/src/color-picker/style.scss
@@ -241,6 +241,7 @@
 	/*rtl:ignore*/
 	direction: ltr;
 	flex-grow: 1;
+	margin-right: 4px;
 
 	.components-base-control + .components-base-control {
 		margin-bottom: 0;

--- a/packages/components/src/color-picker/style.scss
+++ b/packages/components/src/color-picker/style.scss
@@ -32,10 +32,6 @@
 	* {
 		box-sizing: border-box;
 	}
-
-	.components-button {
-		padding: 6px;
-	}
 }
 
 .components-color-picker__saturation {
@@ -121,8 +117,9 @@
 }
 
 .components-color-picker__saturation-pointer {
-	width: 8px;
-	height: 8px;
+	width: 14px;
+	height: 14px;
+	padding: 0;
 	box-shadow:
 		0 0 0 1.5px #fff,
 		inset 0 0 1px 1px rgba(0, 0, 0, 0.3),

--- a/packages/components/src/color-picker/style.scss
+++ b/packages/components/src/color-picker/style.scss
@@ -250,3 +250,7 @@
 		margin: 0 4px;
 	}
 }
+
+.components-color-picker__inputs-toggle {
+	height: 30px;
+}

--- a/packages/components/src/color-picker/style.scss
+++ b/packages/components/src/color-picker/style.scss
@@ -251,6 +251,8 @@
 	}
 }
 
+
 .components-color-picker__inputs-toggle {
 	height: 30px;
+	padding: 0 5px;
 }

--- a/packages/components/src/color-picker/test/__snapshots__/index.js.snap
+++ b/packages/components/src/color-picker/test/__snapshots__/index.js.snap
@@ -141,11 +141,11 @@ exports[`ColorPicker should commit changes to all views on blur 1`] = `
         </div>
       </div>
       <div
-        className="components-color-picker__inputs-toggle"
+        className="components-color-picker__inputs-toggle-wrapper"
       >
         <button
           aria-label="Change color format"
-          className="components-button has-icon"
+          className="components-button components-color-picker__inputs-toggle has-icon"
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
@@ -316,11 +316,11 @@ exports[`ColorPicker should commit changes to all views on keyDown = DOWN 1`] = 
         </div>
       </div>
       <div
-        className="components-color-picker__inputs-toggle"
+        className="components-color-picker__inputs-toggle-wrapper"
       >
         <button
           aria-label="Change color format"
-          className="components-button has-icon"
+          className="components-button components-color-picker__inputs-toggle has-icon"
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
@@ -491,11 +491,11 @@ exports[`ColorPicker should commit changes to all views on keyDown = ENTER 1`] =
         </div>
       </div>
       <div
-        className="components-color-picker__inputs-toggle"
+        className="components-color-picker__inputs-toggle-wrapper"
       >
         <button
           aria-label="Change color format"
-          className="components-button has-icon"
+          className="components-button components-color-picker__inputs-toggle has-icon"
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
@@ -666,11 +666,11 @@ exports[`ColorPicker should commit changes to all views on keyDown = UP 1`] = `
         </div>
       </div>
       <div
-        className="components-color-picker__inputs-toggle"
+        className="components-color-picker__inputs-toggle-wrapper"
       >
         <button
           aria-label="Change color format"
-          className="components-button has-icon"
+          className="components-button components-color-picker__inputs-toggle has-icon"
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
@@ -841,11 +841,11 @@ exports[`ColorPicker should only update input view for draft changes 1`] = `
         </div>
       </div>
       <div
-        className="components-color-picker__inputs-toggle"
+        className="components-color-picker__inputs-toggle-wrapper"
       >
         <button
           aria-label="Change color format"
-          className="components-button has-icon"
+          className="components-button components-color-picker__inputs-toggle has-icon"
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
@@ -1016,11 +1016,11 @@ exports[`ColorPicker should render color picker 1`] = `
         </div>
       </div>
       <div
-        className="components-color-picker__inputs-toggle"
+        className="components-color-picker__inputs-toggle-wrapper"
       >
         <button
           aria-label="Change color format"
-          className="components-button has-icon"
+          className="components-button components-color-picker__inputs-toggle has-icon"
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}

--- a/storybook/test/__snapshots__/index.js.snap
+++ b/storybook/test/__snapshots__/index.js.snap
@@ -2286,11 +2286,11 @@ exports[`Storyshots Components|ColorPicker Alpha Enabled 1`] = `
         </div>
       </div>
       <div
-        className="components-color-picker__inputs-toggle"
+        className="components-color-picker__inputs-toggle-wrapper"
       >
         <button
           aria-label="Change color format"
-          className="components-button has-icon"
+          className="components-button components-color-picker__inputs-toggle has-icon"
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
@@ -2461,11 +2461,11 @@ exports[`Storyshots Components|ColorPicker Default 1`] = `
         </div>
       </div>
       <div
-        className="components-color-picker__inputs-toggle"
+        className="components-color-picker__inputs-toggle-wrapper"
       >
         <button
           aria-label="Change color format"
-          className="components-button has-icon"
+          className="components-button components-color-picker__inputs-toggle has-icon"
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}


### PR DESCRIPTION
Closes https://github.com/WordPress/gutenberg/issues/18326 and https://github.com/WordPress/gutenberg/issues/8197

## Description
Minor style changes to the size and placement of the color picker color format toggle.

## How has this been tested?
Manually, in Chrome.

## Screenshots
Before:
<img width="287" alt="Screen Shot 2020-01-13 at 4 03 37 PM" src="https://user-images.githubusercontent.com/967608/72296006-4bfcd100-361e-11ea-8477-3d5b25a8278d.png">

After:
<img width="276" alt="Screen Shot 2020-01-13 at 3 52 23 PM" src="https://user-images.githubusercontent.com/967608/72295805-e6a8e000-361d-11ea-8994-c7402993cfc2.png">


## Types of changes
Bug fix

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
