### PR TITLE
Try/hint of more blocks in inserter

### DIFF
--- a/packages/block-editor/src/components/inserter-list-item/style.scss
+++ b/packages/block-editor/src/components/inserter-list-item/style.scss
@@ -23,6 +23,7 @@
 	@include reduce-motion("transition");
 	position: relative;
 	height: auto;
+	line-height: 1;
 
 	&:disabled {
 		@include block-style__disabled();

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -19,7 +19,7 @@ $block-inserter-search-height: 38px;
 .block-editor-inserter__popover > .components-popover__content {
 	@include break-medium {
 		overflow-y: visible;
-		height: $block-inserter-content-height + $block-inserter-tabs-height + $block-inserter-search-height;
+		height: $block-inserter-content-height + $block-inserter-tabs-height + $block-inserter-search-height + 10px;
 	}
 }
 

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -19,7 +19,7 @@ $block-inserter-search-height: 38px;
 .block-editor-inserter__popover > .components-popover__content {
 	@include break-medium {
 		overflow-y: visible;
-		height: $block-inserter-content-height + $block-inserter-tabs-height + $block-inserter-search-height + 10px;
+		height: $block-inserter-content-height + $block-inserter-tabs-height + $block-inserter-search-height + 30px;
 	}
 }
 

--- a/packages/components/src/panel/style.scss
+++ b/packages/components/src/panel/style.scss
@@ -90,6 +90,7 @@
 	transition: 0.1s background ease-in-out;
 	@include reduce-motion("transition");
 	height: auto;
+	line-height: 1;
 
 	&:focus:not(:disabled):not([aria-disabled="true"]) {
 		@include menu-style__focus;


### PR DESCRIPTION
## Description
Closes #17872.

This PR explores setting `line-height: 1;` to some button elements in the block inserter and adding `10px` to the inserter's overall height in order to reveal more of the available blocks and categories, thus hinting to users that there's more content to scroll.

## How has this been tested?
Locally in MacOS Firefox, Safari and Chrome.

## Screenshots <!-- if applicable -->

**Before the change:** 
<img width="715" alt="66523022-7f2a4400-eab4-11e9-940c-f22a183959b2" src="https://user-images.githubusercontent.com/3276087/72297126-d6decb00-3620-11ea-870a-020aa546be82.png">


**After the change:**
<img width="729" alt="Screen Shot 2020-01-13 at 16 18 35" src="https://user-images.githubusercontent.com/3276087/72297376-6b492d80-3621-11ea-836e-54cd80c2ff42.png">


## Types of changes
CSS, visual.

