### PR TITLE
Fixes vertical spacing between the color circle rows in Cover block placeholder

### DIFF
--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -119,6 +119,13 @@
 	object-fit: cover;
 }
 
+// Adjusted the vertical spacing of color circle rows in the placeholder setup screen.
+.wp-block-cover__placeholder-background-options {
+	.components-circular-option-picker {
+		margin-top: 0;
+	}
+}
+
 // Styles bellow only exist to support older versions of the block.
 // Versions that not had inner blocks and used an h2 heading had a section (and not a div) with a class wp-block-cover-image (and not a wp-block-cover).
 // We are using the previous referred differences to target old versions.


### PR DESCRIPTION
Fixes #19612. 
This fixes this vertical spacing of the color circle rows in the Cover block's placeholder screen.

## How has this been tested?
Locally.

## Screenshots <!-- if applicable -->

**BEFORE**

![72303102-0ab9f080-3621-11ea-8203-f9dd3a94f1ee](https://user-images.githubusercontent.com/617986/72303874-89179200-3623-11ea-9158-6106ef1d8068.png)

**AFTER**

![Screen Shot 2020-01-13 at 4 41 41 PM](https://user-images.githubusercontent.com/617986/72303888-99c80800-3623-11ea-9c4c-fa8d207e7bff.png)


## Types of changes
Non-breaking changes.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
