### PR TITLE
Block: try merging effects

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -191,13 +191,6 @@ function BlockListBlock( {
 	// Block Reordering animation
 	const animationStyle = useMovingAnimation( wrapper, isSelected || isPartOfMultiSelection, isSelected || isFirstMultiSelected, enableAnimation, animateOnChange );
 
-	// Focus the first editable or the wrapper if edit mode.
-	useLayoutEffect( () => {
-		if ( isSelected && ! isNavigationMode ) {
-			focusTabbable( true );
-		}
-	}, [ isSelected, isNavigationMode ] );
-
 	// Other event handlers
 
 	/**

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -174,19 +174,23 @@ function BlockListBlock( {
 
 	// Focus the selected block's wrapper or inner input on mount and update
 	const isMounting = useRef( true );
-	useEffect( () => {
-		if ( isSelected && ! isMultiSelecting && ! isNavigationMode ) {
-			focusTabbable( ! isMounting.current );
-		}
-		isMounting.current = false;
-	}, [ isSelected, isMultiSelecting, isNavigationMode ] );
 
-	// Focus the first multi selected block
 	useEffect( () => {
-		if ( isFirstMultiSelected ) {
-			wrapper.current.focus();
+		if ( ! isMultiSelecting && ! isNavigationMode ) {
+			if ( isSelected ) {
+				focusTabbable( ! isMounting.current );
+			} else if ( isFirstMultiSelected ) {
+				wrapper.current.focus();
+			}
 		}
-	}, [ isFirstMultiSelected ] );
+
+		isMounting.current = false;
+	}, [
+		isSelected,
+		isFirstMultiSelected,
+		isMultiSelecting,
+		isNavigationMode,
+	] );
 
 	// Block Reordering animation
 	const animationStyle = useMovingAnimation( wrapper, isSelected || isPartOfMultiSelection, isSelected || isFirstMultiSelected, enableAnimation, animateOnChange );


### PR DESCRIPTION
## Description

Currently there's a `useEffect` and `useLayoutEffect` to set focus on the block. I'm curious to see if any tests will fail if we take away `useLayoutEffect`.

I also merged the effect setting focus for multi selection.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
