### PR TITLE
Block: clean up after control removal

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -154,10 +154,10 @@ function BlockListBlock( {
 
 		// Find all tabbables within node.
 		const textInputs = focus.tabbable
-			.find( blockNodeRef.current )
+			.find( wrapper.current )
 			.filter( isTextField )
 			// Exclude inner blocks
-			.filter( ( node ) => ! ignoreInnerBlocks || isInsideRootBlock( blockNodeRef.current, node ) );
+			.filter( ( node ) => ! ignoreInnerBlocks || isInsideRootBlock( wrapper.current, node ) );
 
 		// If reversed (e.g. merge via backspace), use the last in the set of
 		// tabbables.
@@ -311,6 +311,8 @@ function BlockListBlock( {
 			data-type={ name }
 			// Only allow shortcuts when a blocks is selected and not locked.
 			onKeyDown={ isSelected && ! isLocked ? onKeyDown : undefined }
+			// Only allow selection to be started from a selected block.
+			onMouseLeave={ isSelected ? onMouseLeave : undefined }
 			tabIndex="0"
 			aria-label={ blockAriaLabel }
 			role="group"
@@ -324,12 +326,7 @@ function BlockListBlock( {
 					animationStyle
 			}
 		>
-			<div
-				ref={ blockNodeRef }
-				// Only allow selection to be started from a selected block.
-				onMouseLeave={ isSelected ? onMouseLeave : undefined }
-				data-block={ clientId }
-			>
+			<div ref={ blockNodeRef } data-block={ clientId }>
 				<BlockCrashBoundary onError={ onBlockError }>
 					{ isValid && blockEdit }
 					{ isValid && mode === 'html' && (

--- a/packages/block-editor/src/components/block-preview/index.js
+++ b/packages/block-editor/src/components/block-preview/index.js
@@ -37,7 +37,7 @@ function ScaledBlockPreview( { blocks, viewportWidth, padding = 0 } ) {
 			// If we're previewing a single block, scale the preview to fit it.
 			if ( blocks.length === 1 ) {
 				const block = blocks[ 0 ];
-				const previewElement = getBlockPreviewContainerDOMNode( block.clientId, containerElement );
+				const previewElement = getBlockPreviewContainerDOMNode( block.clientId );
 				if ( ! previewElement ) {
 					return;
 				}

--- a/packages/block-editor/src/components/inner-blocks/style.scss
+++ b/packages/block-editor/src/components/inner-blocks/style.scss
@@ -13,7 +13,7 @@
 }
 
 // On fullwide blocks, don't go beyond the canvas.
-[data-align="full"] > [data-block] .has-overlay::after {
+[data-align="full"] .has-overlay::after {
 	right: 0;
 	left: 0;
 }

--- a/packages/block-editor/src/components/skip-to-selected-block/index.js
+++ b/packages/block-editor/src/components/skip-to-selected-block/index.js
@@ -8,11 +8,11 @@ import { Button } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-import { getBlockFocusableWrapper } from '../../utils/dom';
+import { getBlockDOMNode } from '../../utils/dom';
 
 const SkipToSelectedBlock = ( { selectedBlockClientId } ) => {
 	const onClick = () => {
-		const selectedBlockElement = getBlockFocusableWrapper( selectedBlockClientId );
+		const selectedBlockElement = getBlockDOMNode( selectedBlockClientId );
 		selectedBlockElement.focus();
 	};
 

--- a/packages/block-editor/src/components/writing-flow/focus-capture.js
+++ b/packages/block-editor/src/components/writing-flow/focus-capture.js
@@ -13,7 +13,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { getBlockFocusableWrapper } from '../../utils/dom';
+import { getBlockDOMNode } from '../../utils/dom';
 
 /**
  * Renders focus capturing areas to redirect focus to the selected block if not
@@ -69,7 +69,7 @@ const FocusCapture = forwardRef( ( {
 
 		// If there is a selected block, move focus to the first or last
 		// tabbable element depending on the direction.
-		const wrapper = getBlockFocusableWrapper( selectedClientId );
+		const wrapper = getBlockDOMNode( selectedClientId );
 
 		if ( isReverse ) {
 			const tabbables = focus.tabbable.find( wrapper );

--- a/packages/block-editor/src/components/writing-flow/index.js
+++ b/packages/block-editor/src/components/writing-flow/index.js
@@ -27,7 +27,6 @@ import {
 	isBlockFocusStop,
 	isInSameBlock,
 	hasInnerBlocksContext,
-	getBlockFocusableWrapper,
 	isInsideRootBlock,
 	getBlockDOMNode,
 	getBlockClientId,
@@ -329,7 +328,7 @@ export default function WritingFlow( { children } ) {
 					event.preventDefault();
 					selectBlock( focusedBlockUid );
 				} else if ( isTab && selectedBlockClientId ) {
-					const wrapper = getBlockFocusableWrapper( selectedBlockClientId );
+					const wrapper = getBlockDOMNode( selectedBlockClientId );
 					let nextTabbable;
 
 					if ( navigateDown ) {
@@ -358,7 +357,7 @@ export default function WritingFlow( { children } ) {
 		// Arrow keys can be used, and Tab and arrow keys can be used in
 		// Navigation mode (press Esc), to navigate through blocks.
 		if ( clientId ) {
-			const wrapper = getBlockFocusableWrapper( clientId );
+			const wrapper = getBlockDOMNode( clientId );
 
 			if ( isTab ) {
 				if ( isShift ) {

--- a/packages/block-editor/src/utils/dom.js
+++ b/packages/block-editor/src/utils/dom.js
@@ -8,32 +8,18 @@
  *
  * @return {Element} Block DOM node.
  */
-export function getBlockDOMNode( clientId, scope = document ) {
-	return scope.querySelector( '[data-block="' + clientId + '"]' );
+export function getBlockDOMNode( clientId ) {
+	return document.getElementById( 'block-' + clientId );
 }
 
-export function getBlockPreviewContainerDOMNode( clientId, scope ) {
-	const domNode = getBlockDOMNode( clientId, scope );
+export function getBlockPreviewContainerDOMNode( clientId ) {
+	const domNode = getBlockDOMNode( clientId );
 
 	if ( ! domNode ) {
 		return;
 	}
 
 	return domNode.firstChild || domNode;
-}
-
-/**
- * Given a block client ID, returns the corresponding DOM node for the block
- * focusable wrapper, if exists. As much as possible, this helper should be
- * avoided, and used only in cases where isolated behaviors need remote access
- * to a block node.
- *
- * @param {string} clientId Block client ID.
- *
- * @return {Element} Block DOM node.
- */
-export function getBlockFocusableWrapper( clientId ) {
-	return getBlockDOMNode( clientId ).closest( '.block-editor-block-list__block' );
 }
 
 /**
@@ -57,7 +43,7 @@ export function isBlockFocusStop( element ) {
  * @return {boolean} Whether elements are in the same block.
  */
 export function isInSameBlock( a, b ) {
-	return a.closest( '[data-block]' ) === b.closest( '[data-block]' );
+	return a.closest( '.block-editor-block-list__block' ) === b.closest( '.block-editor-block-list__block' );
 }
 
 /**


### PR DESCRIPTION
## Description

This PR contains some clean up that is possible now that all the block controls have been removed from the block DOM. This is split out from #19593 so it makes review of it easier.

* The multi selection event listener can now be attached to the outer wrapper since there's no need to ignore any block controls.
* Similarly, the outer wrapper can be used to look for focusable elements in the content, since there are no longer any controls in the wrapper.
* `getBlockDOMNode` can be optimised to directly get the element wrapper by ID.
* There's no longer a need for `getBlockFocusableWrapper` since `getBlockDOMNode` does the same thing.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
