### PR TITLE
Block toolbar: fix hasMovers

### DIFF
--- a/packages/block-editor/src/components/block-list/block-contextual-toolbar.js
+++ b/packages/block-editor/src/components/block-list/block-contextual-toolbar.js
@@ -9,7 +9,7 @@ import { __ } from '@wordpress/i18n';
 import NavigableToolbar from '../navigable-toolbar';
 import { BlockToolbar } from '../';
 
-function BlockContextualToolbar( { focusOnMount, hasMovers, moverDirection, ...props } ) {
+function BlockContextualToolbar( { focusOnMount, ...props } ) {
 	return (
 		<NavigableToolbar
 			focusOnMount={ focusOnMount }
@@ -18,7 +18,7 @@ function BlockContextualToolbar( { focusOnMount, hasMovers, moverDirection, ...p
 			aria-label={ __( 'Block tools' ) }
 			{ ...props }
 		>
-			<BlockToolbar moverDirection={ moverDirection } hasMovers={ hasMovers } />
+			<BlockToolbar />
 		</NavigableToolbar>
 	);
 }

--- a/packages/block-editor/src/components/block-list/block-popover.js
+++ b/packages/block-editor/src/components/block-list/block-popover.js
@@ -49,7 +49,6 @@ function BlockPopover( {
 	moverDirection,
 	isEmptyDefaultBlock,
 	capturingClientId,
-	hasMovers = true,
 } ) {
 	const {
 		isNavigationMode,
@@ -155,7 +154,6 @@ function BlockPopover( {
 					focusOnMount={ isToolbarForced }
 					data-type={ name }
 					data-align={ align }
-					hasMovers={ hasMovers }
 				/>
 			) }
 			{ shouldShowBreadcrumb && (

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -73,16 +73,8 @@ function BlockList( {
 		enableAnimation,
 	} = useSelect( selector, [ rootClientId ] );
 
-	const uiParts = {
-		hasMovers: true,
-		hasSelectedUI: true,
-		...__experimentalUIParts,
-	};
-
 	const Container = rootClientId ? 'div' : RootContainer;
-
 	const ref = useRef();
-
 	const targetClientId = useBlockDropZone( {
 		element: ref,
 		rootClientId,
@@ -114,8 +106,7 @@ function BlockList( {
 							// otherwise there might be a small delay to trigger the animation.
 							animateOnChange={ index }
 							enableAnimation={ enableAnimation }
-							hasSelectedUI={ uiParts.hasSelectedUI }
-							hasMovers={ uiParts.hasMovers }
+							hasSelectedUI={ __experimentalUIParts.hasSelectedUI }
 							className={ clientId === targetClientId ? 'is-drop-target' : undefined }
 						/>
 					</AsyncModeProvider>

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -14,12 +14,13 @@ import BlockSwitcher from '../block-switcher';
 import MultiBlocksSwitcher from '../block-switcher/multi-blocks-switcher';
 import BlockMover from '../block-mover';
 
-export default function BlockToolbar( { hasMovers = true } ) {
+export default function BlockToolbar() {
 	const {
 		blockClientIds,
 		isValid,
 		mode,
 		moverDirection,
+		hasMovers = true,
 	} = useSelect( ( select ) => {
 		const {
 			getBlockMode,
@@ -33,6 +34,7 @@ export default function BlockToolbar( { hasMovers = true } ) {
 
 		const {
 			__experimentalMoverDirection,
+			__experimentalUIParts = {},
 		} = getBlockListSettings( blockRootClientId ) || {};
 
 		return {
@@ -45,6 +47,7 @@ export default function BlockToolbar( { hasMovers = true } ) {
 				getBlockMode( selectedBlockClientIds[ 0 ] ) :
 				null,
 			moverDirection: __experimentalMoverDirection,
+			hasMovers: __experimentalUIParts.hasMovers,
 		};
 	}, [] );
 

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -114,6 +114,7 @@ class InnerBlocks extends Component {
 			parentLock,
 			__experimentalCaptureToolbars,
 			__experimentalMoverDirection,
+			__experimentalUIParts,
 		} = this.props;
 
 		const newSettings = {
@@ -121,6 +122,7 @@ class InnerBlocks extends Component {
 			templateLock: templateLock === undefined ? parentLock : templateLock,
 			__experimentalCaptureToolbars: __experimentalCaptureToolbars || false,
 			__experimentalMoverDirection,
+			__experimentalUIParts,
 		};
 
 		if ( ! isShallowEqual( blockListSettings, newSettings ) ) {


### PR DESCRIPTION
## Description

See #18173.

`hasMovers` has never worked for the top or mobile toolbar. Additionally, it also broke recently when the contextual block toolbar was moved out of the block tree.

Additionally it removes the data- props from the contextual toolbar and breadcrumb and uses the popover instead.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
