### PR TITLE
DropDownMenu: Make the active item in the drop down bold

### DIFF
--- a/packages/components/src/dropdown-menu/style.scss
+++ b/packages/components/src/dropdown-menu/style.scss
@@ -40,7 +40,7 @@
 		}
 
 		&.is-active {
-			font-weight: bold;
+			@include formatting-button-style__active();
 		}
 
 		// Plain menu styles.

--- a/packages/components/src/dropdown-menu/style.scss
+++ b/packages/components/src/dropdown-menu/style.scss
@@ -39,6 +39,10 @@
 			height: 1px;
 		}
 
+		&.is-active {
+			font-weight: bold;
+		}
+
 		// Plain menu styles.
 		&:focus:not(:disabled):not([aria-disabled="true"]):not(.is-secondary) {
 			@include menu-style__focus();


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
This makes the text of the active item in a DropDownMenu component bold. This means you can use the dropdownmenu without icons, but it should be better for accessibility too.

## Screenshots
Before:
<img width="258" alt="Screenshot 2020-01-14 at 12 01 20" src="https://user-images.githubusercontent.com/275961/72342950-a00ec080-36c5-11ea-94e7-ba3775578da4.png">

After:
<img width="264" alt="Screenshot 2020-01-14 at 12 00 03" src="https://user-images.githubusercontent.com/275961/72342962-a866fb80-36c5-11ea-8376-22357385ae7d.png">

## How has this been tested?
- Add an image block
- Change the alignment
- Check that the selected alignment is bold in the dropdown menu

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
