### PR TITLE
Regions: move publish button etc. to publish region

### DIFF
--- a/packages/edit-post/src/components/editor-regions/style.scss
+++ b/packages/edit-post/src/components/editor-regions/style.scss
@@ -130,6 +130,6 @@ html {
 .edit-post-editor-regions__publish {
 	z-index: z-index(".edit-post-editor-regions__publish");
 	position: absolute !important; // Need to override the default relative positionning
-	top: 10px;
+	top: $grid-size;
 	right: $grid-size;
 }

--- a/packages/edit-post/src/components/editor-regions/style.scss
+++ b/packages/edit-post/src/components/editor-regions/style.scss
@@ -129,15 +129,7 @@ html {
 
 .edit-post-editor-regions__publish {
 	z-index: z-index(".edit-post-editor-regions__publish");
-	position: fixed !important; // Need to override the default relative positionning
-	top: -9999em;
-	bottom: auto;
-	left: auto;
-	right: 0;
-	width: $sidebar-width;
-
-	&:focus {
-		top: auto;
-		bottom: 0;
-	}
+	position: absolute !important; // Need to override the default relative positionning
+	top: 10px;
+	right: $grid-size;
 }

--- a/packages/edit-post/src/components/header/index.js
+++ b/packages/edit-post/src/components/header/index.js
@@ -1,81 +1,15 @@
 /**
- * WordPress dependencies
- */
-import { __ } from '@wordpress/i18n';
-import { Button } from '@wordpress/components';
-import {
-	PostPreviewButton,
-	PostSavedState,
-} from '@wordpress/editor';
-import { useSelect, useDispatch } from '@wordpress/data';
-
-/**
  * Internal dependencies
  */
 import FullscreenModeClose from './fullscreen-mode-close';
 import HeaderToolbar from './header-toolbar';
-import MoreMenu from './more-menu';
-import PinnedPlugins from './pinned-plugins';
-import PostPublishButtonOrToggle from './post-publish-button-or-toggle';
 
 function Header() {
-	const {
-		shortcut,
-		hasActiveMetaboxes,
-		isEditorSidebarOpened,
-		isPublishSidebarOpened,
-		isSaving,
-		getBlockSelectionStart,
-	} = useSelect( ( select ) => ( {
-		shortcut: select( 'core/keyboard-shortcuts' ).getShortcutRepresentation( 'core/edit-post/toggle-sidebar' ),
-		hasActiveMetaboxes: select( 'core/edit-post' ).hasMetaBoxes(),
-		isEditorSidebarOpened: select( 'core/edit-post' ).isEditorSidebarOpened(),
-		isPublishSidebarOpened: select( 'core/edit-post' ).isPublishSidebarOpened(),
-		isSaving: select( 'core/edit-post' ).isSavingMetaBoxes(),
-		getBlockSelectionStart: select( 'core/block-editor' ).getBlockSelectionStart,
-	} ), [] );
-	const { openGeneralSidebar, closeGeneralSidebar } = useDispatch( 'core/edit-post' );
-
-	const toggleGeneralSidebar = isEditorSidebarOpened ?
-		closeGeneralSidebar :
-		() => openGeneralSidebar( getBlockSelectionStart() ? 'edit-post/block' : 'edit-post/document' );
-
 	return (
 		<div className="edit-post-header">
 			<div className="edit-post-header__toolbar">
 				<FullscreenModeClose />
 				<HeaderToolbar />
-			</div>
-			<div className="edit-post-header__settings">
-				{ ! isPublishSidebarOpened && (
-					// This button isn't completely hidden by the publish sidebar.
-					// We can't hide the whole toolbar when the publish sidebar is open because
-					// we want to prevent mounting/unmounting the PostPublishButtonOrToggle DOM node.
-					// We track that DOM node to return focus to the PostPublishButtonOrToggle
-					// when the publish sidebar has been closed.
-					<PostSavedState
-						forceIsDirty={ hasActiveMetaboxes }
-						forceIsSaving={ isSaving }
-					/>
-				) }
-				<PostPreviewButton
-					forceIsAutosaveable={ hasActiveMetaboxes }
-					forcePreviewLink={ isSaving ? null : undefined }
-				/>
-				<PostPublishButtonOrToggle
-					forceIsDirty={ hasActiveMetaboxes }
-					forceIsSaving={ isSaving }
-				/>
-				<Button
-					icon="admin-generic"
-					label={ __( 'Settings' ) }
-					onClick={ toggleGeneralSidebar }
-					isPressed={ isEditorSidebarOpened }
-					aria-expanded={ isEditorSidebarOpened }
-					shortcut={ shortcut }
-				/>
-				<PinnedPlugins.Slot />
-				<MoreMenu />
 			</div>
 		</div>
 	);

--- a/packages/edit-post/src/components/header/style.scss
+++ b/packages/edit-post/src/components/header/style.scss
@@ -47,6 +47,7 @@
 	flex-wrap: wrap;
 }
 
+.edit-post-header__settings .components-button,
 .edit-post-header .components-button {
 	// Header toggle buttons.
 	&.is-pressed {


### PR DESCRIPTION
## Description

This PR moves the publish, save, preview, and setting buttons to the publish region in the DOM. Visually, they remain in the same place.

Why is this better?

* Visually the page is split in two columns: the big editing area and the sidebar. The publish button is displayed in the second column, so the tabbing order makes sense.
* It's also a good logical order: write content, then publish. See #3697. Currently there's even a shortcut to the publish panel after the content. With this change, the shortcut is no necessary.
* When the "Top toolbar" is enabled, reverse tabbing should bring you to the block toolbar, not the publish toolbar.
* It's easier to access button such as undo and redo from the selected block.
* It's easier to access the save button from the selected block (tab once).
* It gets rid of a hack to hide the save button. This hack is now no longer needed since the buttons are in their right place.
* It will enable us to unify the block toolbar (top, mobile, contextual) and simplify things.
* The tab order is now very similar to the classic editor, where the publish button also appears after the content.

![publish-flow](https://user-images.githubusercontent.com/4710635/72347718-094bff00-36d9-11ea-8812-2a1a2a9477fd.gif)

Now tab order also makes sense when the block toolbar (when the top toolbar is enabled) wraps downwards for smaller screens.

<img width="990" alt="Screenshot 2020-01-14 at 14 22 40" src="https://user-images.githubusercontent.com/4710635/72347905-6e9ff000-36d9-11ea-8179-4ea13442cd56.png">

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
