### PR TITLE
LinkControl: Prevent space being reserved for scrollbar when items fit box

### DIFF
--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -71,7 +71,7 @@
 	margin: 0;
 	padding: $grid-size-large/2 $grid-size-large $grid-size-large;
 	max-height: 200px;
-	overflow-y: scroll; // allow results list to scroll
+	overflow-y: auto; // allow results list to scroll
 
 	&.is-loading {
 		opacity: 0.2;


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

This is a minor fix for a visual issue described in https://github.com/WordPress/gutenberg/issues/19627 where the LinkControl search results box always reserves space for the scrollbar even when the results fit the box.

Please note that in order to test/observe the issue on master an external mouse must be connected.

Fixes https://github.com/WordPress/gutenberg/issues/19627

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

- Connect an external mouse
- Add the navigation block
- Add a new link and find a search result that has three or less results
- Observe whether space for the scrollbar is reserved

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

#### Before: 

<img width="300" alt="Screenshot 2020-01-14 at 15 23 17" src="https://user-images.githubusercontent.com/1562646/72352991-9005d980-36e3-11ea-92cb-e2f257aea60e.png">

#### After:

<img width="300" alt="Screenshot 2020-01-14 at 15 24 46" src="https://user-images.githubusercontent.com/1562646/72352959-82505400-36e3-11ea-9613-9470a3edce2b.png">


## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
