### PR TITLE
Chore: Remove group block test code merged by mistake

### DIFF
--- a/packages/block-library/src/group/edit.js
+++ b/packages/block-library/src/group/edit.js
@@ -48,10 +48,6 @@ function GroupEdit( {
 				<div className="wp-block-group__inner-container">
 					<InnerBlocks
 						renderAppender={ ! hasInnerBlocks && InnerBlocks.ButtonBlockAppender }
-						__experimentalUIParts={ {
-							hasSelectedUI: false,
-							hasMovers: false,
-						} }
 					/>
 				</div>
 			</div>


### PR DESCRIPTION
## Description
This code was used to test https://github.com/WordPress/gutenberg/pull/18173 but it should have been removed before the merge.
This PR reverts the group block test change from https://github.com/WordPress/gutenberg/pull/18173.

