### PR TITLE
Checks if caption is empty in media lib and keeps the one written

### DIFF
--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -175,15 +175,13 @@ export class ImageEdit extends Component {
 
 		let mediaAttributes = pickRelevantMediaFiles( media );
 
-		// If the current image is temporary but an alt or caption text was meanwhile written by the user,
-		// make sure the text is not overwritten.
-		if ( isTemporaryImage( id, url ) ) {
-			if ( alt ) {
-				mediaAttributes = omit( mediaAttributes, [ 'alt' ] );
-			}
-			if ( caption ) {
-				mediaAttributes = omit( mediaAttributes, [ 'caption' ] );
-			}
+		// If an alt or caption text was meanwhile written by the user,
+		// make sure the text is not overwritten by empty captions
+		if ( alt || ! get( mediaAttributes, [ 'alt' ] ) ) {
+			mediaAttributes = omit( mediaAttributes, [ 'alt' ] );
+		}
+		if ( caption || ! get( mediaAttributes, [ 'caption' ] ) ) {
+			mediaAttributes = omit( mediaAttributes, [ 'caption' ] );
 		}
 
 		let additionalAttributes;

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -175,12 +175,17 @@ export class ImageEdit extends Component {
 
 		let mediaAttributes = pickRelevantMediaFiles( media );
 
-		// If an alt or caption text was meanwhile written by the user,
-		// make sure the text is not overwritten by empty captions
-		if ( alt || ! get( mediaAttributes, [ 'alt' ] ) ) {
-			mediaAttributes = omit( mediaAttributes, [ 'alt' ] );
+		// If the current image is temporary but an alt text was meanwhile written by the user,
+		// make sure the text is not overwritten.
+		if ( isTemporaryImage( id, url ) ) {
+			if ( alt ) {
+				mediaAttributes = omit( mediaAttributes, [ 'alt' ] );
+			}
 		}
-		if ( caption || ! get( mediaAttributes, [ 'caption' ] ) ) {
+
+		// If a caption text was meanwhile written by the user,
+		// make sure the text is not overwritten by empty captions
+		if ( caption && ! get( mediaAttributes, [ 'caption' ] ) ) {
 			mediaAttributes = omit( mediaAttributes, [ 'caption' ] );
 		}
 


### PR DESCRIPTION
## Description
Closes #19636

## How has this been tested?
Tested locally.

## Screenshots

![caption-preserved](https://user-images.githubusercontent.com/107534/72366241-8b9ce900-3702-11ea-8e97-e4fdad286ab7.gif)


## Types of changes
Basically the behavior was there already but only for the temporary preview.