### PR TITLE
Add supports html: false to new website blocks.

### DIFF
--- a/packages/block-library/src/post-author/index.js
+++ b/packages/block-library/src/post-author/index.js
@@ -14,5 +14,8 @@ export { metadata, name };
 
 export const settings = {
 	title: __( 'Post Author' ),
+	supports: {
+		html: false,
+	},
 	edit,
 };

--- a/packages/block-library/src/post-content/index.js
+++ b/packages/block-library/src/post-content/index.js
@@ -16,5 +16,8 @@ export { metadata, name };
 export const settings = {
 	title: __( 'Post Content' ),
 	icon,
+	supports: {
+		html: false,
+	},
 	edit,
 };

--- a/packages/block-library/src/post-date/index.js
+++ b/packages/block-library/src/post-date/index.js
@@ -14,5 +14,8 @@ export { metadata, name };
 
 export const settings = {
 	title: __( 'Post Date' ),
+	supports: {
+		html: false,
+	},
 	edit,
 };

--- a/packages/block-library/src/post-excerpt/index.js
+++ b/packages/block-library/src/post-excerpt/index.js
@@ -14,5 +14,8 @@ export { metadata, name };
 
 export const settings = {
 	title: __( 'Post Excerpt' ),
+	supports: {
+		html: false,
+	},
 	edit,
 };

--- a/packages/block-library/src/post-title/index.js
+++ b/packages/block-library/src/post-title/index.js
@@ -16,5 +16,8 @@ export { metadata, name };
 export const settings = {
 	title: __( 'Post Title' ),
 	icon,
+	supports: {
+		html: false,
+	},
 	edit,
 };

--- a/packages/block-library/src/site-title/index.js
+++ b/packages/block-library/src/site-title/index.js
@@ -16,5 +16,8 @@ export { metadata, name };
 export const settings = {
 	title: __( 'Site Title' ),
 	icon,
+	supports: {
+		html: false,
+	},
 	edit,
 };

--- a/packages/block-library/src/template-part/block.json
+++ b/packages/block-library/src/template-part/block.json
@@ -11,8 +11,5 @@
 		"theme": {
 			"type": "string"
 		}
-	},
-	"supports": {
-		"html": false
 	}
 }

--- a/packages/block-library/src/template-part/index.js
+++ b/packages/block-library/src/template-part/index.js
@@ -14,5 +14,8 @@ export { metadata, name };
 
 export const settings = {
 	title: __( 'Template Part' ),
+	supports: {
+		html: false,
+	},
 	edit,
 };


### PR DESCRIPTION
## Description
Disables the HTML mode for the new website editor blocks.