### PR TITLE
Remove draggable from all navigation-link blocks

### DIFF
--- a/packages/block-editor/src/components/block-mover/style.scss
+++ b/packages/block-editor/src/components/block-mover/style.scss
@@ -78,3 +78,11 @@
 .block-editor-block-mover__description {
 	display: none;
 }
+
+.block-editor-block-mover {
+	&.is-horizontal {
+		.block-editor-block-mover__control-drag-handle {
+			display: none;
+		}
+	}
+}

--- a/packages/block-editor/src/components/block-mover/style.scss
+++ b/packages/block-editor/src/components/block-mover/style.scss
@@ -79,10 +79,6 @@
 	display: none;
 }
 
-.block-editor-block-mover {
-	&.is-horizontal {
-		.block-editor-block-mover__control-drag-handle {
-			display: none;
-		}
-	}
+.block-editor-block-mover.is-horizontal .block-editor-block-mover__control-drag-handle {
+	display: none;
 }

--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -1,4 +1,14 @@
 
+[data-type="core/navigation-link"] {
+
+	// Hide the draggable mover until functionality for positioning it on drag correctly is added
+	.block-editor-block-toolbar .components-toolbar.block-editor-block-mover {
+		.components-button.block-editor-block-mover__control-drag-handle {
+			display: none;
+		}
+	}
+}
+
 // Normalize navigation link and edit containers, to look mostly the same.
 .wp-block-navigation-link__field .components-text-control__input.components-text-control__input,
 .wp-block-navigation-link__container {

--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -83,7 +83,7 @@
 		left: $block-padding;
 	}
 
-	// Hide the draggable mover until functionality for positioning it on drag correctly is added
+	// Hide the draggable mover until functionality for positioning it on drag correctly is added: https://github.com/WordPress/gutenberg/issues/19703
 	.block-editor-block-toolbar .components-toolbar.block-editor-block-mover {
 		.components-button.block-editor-block-mover__control-drag-handle {
 			display: none;

--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -1,14 +1,3 @@
-
-[data-type="core/navigation-link"] {
-
-	// Hide the draggable mover until functionality for positioning it on drag correctly is added
-	.block-editor-block-toolbar .components-toolbar.block-editor-block-mover {
-		.components-button.block-editor-block-mover__control-drag-handle {
-			display: none;
-		}
-	}
-}
-
 // Normalize navigation link and edit containers, to look mostly the same.
 .wp-block-navigation-link__field .components-text-control__input.components-text-control__input,
 .wp-block-navigation-link__container {
@@ -92,6 +81,13 @@
 [data-type="core/navigation-link"] {
 	.block-editor-block-toolbar {
 		left: $block-padding;
+	}
+
+	// Hide the draggable mover until functionality for positioning it on drag correctly is added
+	.block-editor-block-toolbar .components-toolbar.block-editor-block-mover {
+		.components-button.block-editor-block-mover__control-drag-handle {
+			display: none;
+		}
 	}
 }
 

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -151,11 +151,3 @@ $color-control-label-height: 20px;
 		margin-top: 2px;
 	}
 }
-
-.block-editor-block-mover {
-	&.is-horizontal {
-		.block-editor-block-mover__control-drag-handle {
-			display: none;
-		}
-	}
-}


### PR DESCRIPTION
Closes https://github.com/WordPress/gutenberg/issues/19478

* Hides draggable on all navigation-link blocks via CSS
* Moved the CSS that hid `.is-horizontal` draggable to the Block Mover CSS from the Navigation CSS as it applied to all horizontal movers, not just the Navigation.

## How has this been tested?
Manually, via Chrome so far

## Screenshots
![Navigation block mover hide draggable](https://user-images.githubusercontent.com/967608/72379614-66e04b80-36d9-11ea-8dda-131d688382b1.gif)


## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->