### PR TITLE
Block: unified toolbar

### DIFF
--- a/packages/block-editor/src/components/block-list/block-contextual-toolbar.js
+++ b/packages/block-editor/src/components/block-list/block-contextual-toolbar.js
@@ -7,7 +7,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import NavigableToolbar from '../navigable-toolbar';
-import { BlockToolbar } from '../';
+import { BlockToolbar } from '../block-toolbar';
 
 function BlockContextualToolbar( { focusOnMount, ...props } ) {
 	return (

--- a/packages/block-editor/src/components/block-list/block-popover.js
+++ b/packages/block-editor/src/components/block-list/block-popover.js
@@ -12,12 +12,10 @@ import { isUnmodifiedDefaultBlock } from '@wordpress/blocks';
 import { Popover } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { useShortcut } from '@wordpress/keyboard-shortcuts';
-import { useViewportMatch } from '@wordpress/compose';
 
 /**
  * Internal dependencies
  */
-import BlockBreadcrumb from './breadcrumb';
 import BlockContextualToolbar from './block-contextual-toolbar';
 import Inserter from '../inserter';
 
@@ -58,16 +56,14 @@ function BlockPopover( {
 		hasMultiSelection,
 		hasFixedToolbar,
 	} = useSelect( selector, [] );
-	const isLargeViewport = useViewportMatch( 'medium' );
 	const [ isToolbarForced, setIsToolbarForced ] = useState( false );
 	const [ isInserterShown, setIsInserterShown ] = useState( false );
 
-	const showEmptyBlockSideInserter = ! isNavigationMode && isEmptyDefaultBlock && isValid;
-	const shouldShowBreadcrumb = isNavigationMode;
-	const shouldShowContextualToolbar =
+	const showEmptyBlockSideInserter =
 		! isNavigationMode &&
-		! hasFixedToolbar &&
-		isLargeViewport &&
+		isEmptyDefaultBlock &&
+		isValid;
+	const shouldShowContextualToolbar =
 		! showEmptyBlockSideInserter &&
 		! isMultiSelecting &&
 		( ! isTyping || isCaretWithinFormattedText );
@@ -84,7 +80,6 @@ function BlockPopover( {
 	);
 
 	if (
-		! shouldShowBreadcrumb &&
 		! shouldShowContextualToolbar &&
 		! isToolbarForced &&
 		! showEmptyBlockSideInserter
@@ -153,12 +148,6 @@ function BlockPopover( {
 					// it should focus the toolbar right after the mount.
 					focusOnMount={ isToolbarForced }
 					data-type={ name }
-					data-align={ align }
-				/>
-			) }
-			{ shouldShowBreadcrumb && (
-				<BlockBreadcrumb
-					clientId={ clientId }
 					data-align={ align }
 				/>
 			) }

--- a/packages/block-editor/src/components/block-list/root-container.js
+++ b/packages/block-editor/src/components/block-list/root-container.js
@@ -10,7 +10,6 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import useMultiSelection from './use-multi-selection';
 import { getBlockClientId } from '../../utils/dom';
 import InsertionPoint from './insertion-point';
-import BlockPopover from './block-popover';
 
 /** @typedef {import('@wordpress/element').WPSyntheticEvent} WPSyntheticEvent */
 
@@ -79,7 +78,6 @@ function RootContainer( { children, className }, ref ) {
 			isMultiSelecting={ isMultiSelecting }
 			selectedBlockClientId={ selectedBlockClientId }
 		>
-			<BlockPopover />
 			<div
 				ref={ ref }
 				className={ className }

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -13,25 +13,29 @@ import BlockSettingsMenu from '../block-settings-menu';
 import BlockSwitcher from '../block-switcher';
 import MultiBlocksSwitcher from '../block-switcher/multi-blocks-switcher';
 import BlockMover from '../block-mover';
+import BlockPopover from '../block-list/block-popover';
+import BlockBreadcrumb from '../block-list/breadcrumb';
 
-export default function BlockToolbar() {
-	const {
-		blockClientIds,
-		isValid,
-		mode,
-		moverDirection,
-		hasMovers = true,
-	} = useSelect( ( select ) => {
+export default function BlockToolbarWrapper( { contextual } ) {
+	if ( contextual ) {
+		return <BlockPopover />;
+	}
+
+	return <BlockToolbar />;
+}
+
+export function BlockToolbar() {
+	function selector( select ) {
 		const {
 			getBlockMode,
 			getSelectedBlockClientIds,
 			isBlockValid,
 			getBlockRootClientId,
 			getBlockListSettings,
+			isNavigationMode,
 		} = select( 'core/block-editor' );
 		const selectedBlockClientIds = getSelectedBlockClientIds();
 		const blockRootClientId = getBlockRootClientId( selectedBlockClientIds[ 0 ] );
-
 		const {
 			__experimentalMoverDirection,
 			__experimentalUIParts = {},
@@ -48,8 +52,18 @@ export default function BlockToolbar() {
 				null,
 			moverDirection: __experimentalMoverDirection,
 			hasMovers: __experimentalUIParts.hasMovers,
+			isNavigationMode: isNavigationMode(),
 		};
-	}, [] );
+	}
+
+	const {
+		blockClientIds,
+		isValid,
+		mode,
+		moverDirection,
+		hasMovers = true,
+		isNavigationMode,
+	} = useSelect( selector, [] );
 
 	if ( blockClientIds.length === 0 ) {
 		return null;
@@ -65,6 +79,15 @@ export default function BlockToolbar() {
 				<MultiBlocksSwitcher />
 				<BlockSettingsMenu clientIds={ blockClientIds } />
 			</div>
+		);
+	}
+
+	if ( isNavigationMode ) {
+		return (
+			<BlockBreadcrumb
+				clientId={ blockClientIds[ 0 ] }
+				// data-align={ align }
+			/>
 		);
 	}
 

--- a/packages/edit-post/src/components/header/header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.js
@@ -43,11 +43,9 @@ function HeaderToolbar() {
 			<TableOfContents hasOutlineItemsDisabled={ isTextModeEnabled } />
 			<BlockNavigationDropdown isDisabled={ isTextModeEnabled } />
 			<ToolSelector />
-			{ ( hasFixedToolbar || ! isLargeViewport ) && (
-				<div className="edit-post-header-toolbar__block-toolbar">
-					<BlockToolbar />
-				</div>
-			) }
+			<div className="edit-post-header-toolbar__block-toolbar">
+				<BlockToolbar contextual={ ! hasFixedToolbar && isLargeViewport } />
+			</div>
 		</NavigableToolbar>
 	);
 }

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -108,7 +108,6 @@ function Layout() {
 					content={
 						<>
 							<EditorNotices />
-							<Popover.Slot name="block-toolbar" />
 							{ ( mode === 'text' || ! isRichEditingEnabled ) && <TextEditor /> }
 							{ isRichEditingEnabled && mode === 'visual' && <VisualEditor /> }
 							<div className="edit-post-layout__metaboxes">


### PR DESCRIPTION
## Description

This PR unifies the fixed toolbar (used for mobile and top toolbar setting) with the contextual toolbar.

* The toolbar is now rendered in the same place in the DOM.
* Gets rid of the special popover slot.

To do: move the empty default block inserter to a separate popover and fix styling.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
