### PR TITLE
Do not output navigation links with empty labels

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -86,34 +86,26 @@ function build_css_font_sizes( $attributes ) {
 }
 
 /**
- * Filters out links with no labels.
- *
- * @param array $block Block to check label attribute on.
- *
- * @return boolean
- */
-function gutenberg_has_navigation_label( $block ) {
-	return ! empty( $block['attrs']['label'] );
-}
-
-/**
  * Recursively filters out links with no labels to build a clean navigation block structure.
  *
  * @param array $blocks Navigation link inner blocks from the Navigation block.
  *
- * @return boolean
+ * @return array
  */
 function gutenberg_remove_empty_navigation_links_recursive( $blocks ) {
 
-	$blocks = array_filter( $blocks, 'gutenberg_has_navigation_label' );
+	$blocks = array_filter(
+		$blocks,
+		function( $block ) {
+			return ! empty( $block['attrs']['label'] );
+		}
+	);
 
-	if ( empty( $blocks ) ) {
-		return $blocks;
-	}
-
-	foreach ( $blocks as $key => $val ) {
-		if ( ! empty( $blocks[ $key ]['innerBlocks'] ) ) {
-			$blocks[ $key ]['innerBlocks'] = gutenberg_remove_empty_navigation_links_recursive( $blocks[ $key ]['innerBlocks'] );
+	if ( ! empty( $blocks ) ) {
+		foreach ( $blocks as $key => $block ) {
+			if ( ! empty( $block['innerBlocks'] ) ) {
+				$blocks[ $key ]['innerBlocks'] = gutenberg_remove_empty_navigation_links_recursive( $block['innerBlocks'] );
+			}
 		}
 	}
 
@@ -134,7 +126,7 @@ function render_block_navigation( $attributes, $content, $block ) {
 	$block['innerBlocks'] = gutenberg_remove_empty_navigation_links_recursive( $block['innerBlocks'] );
 
 	if ( empty( $block['innerBlocks'] ) ) {
-		return;
+		return '';
 	}
 
 	$colors          = build_css_colors( $attributes );

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -87,9 +87,9 @@ function build_css_font_sizes( $attributes ) {
 
 /**
  * Filters out links with no labels
- * 
- * @param array $block
- * 
+ *
+ * @param array $block Block to check label attribute on.
+ *
  * @return boolean
  */
 function has_navigation_label( $block ) {
@@ -151,8 +151,8 @@ function build_navigation_html( $block, $colors, $font_sizes, $level_zero = true
 		? sprintf( ' style="%s"', esc_attr( $colors['inline_styles'] ) . esc_attr( $font_sizes['inline_styles'] ) )
 		: '';
 
-	// Only include link blocks that have a label set
-	foreach ( (array) array_filter( $block['innerBlocks'], "has_navigation_label" ) as $key => $block ) {
+	// Only include link blocks that have a label set.
+	foreach ( (array) array_filter( $block['innerBlocks'], 'has_navigation_label' ) as $key => $block ) {
 
 		$html .= '<li class="wp-block-navigation-link">' .
 			'<a';
@@ -205,7 +205,7 @@ function build_navigation_html( $block, $colors, $font_sizes, $level_zero = true
 			$html .= build_navigation_html( $block, $colors, $font_sizes, false );
 =======
 		// Only include innerBlocks that have a label set in the count. Otherwise a submenu with no links will be rendered.
-		if ( count( (array) array_filter( $block['innerBlocks'], "has_navigation_label" ) ) > 0 ) {
+		if ( count( (array) array_filter( $block['innerBlocks'], 'has_navigation_label' ) ) > 0 ) {
 			$html .= build_navigation_html( $block, $colors, $font_sizes );
 >>>>>>> Added filter for only getting blocks with a non-empty label for ouptputting in the navigation html.
 		}

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -86,6 +86,17 @@ function build_css_font_sizes( $attributes ) {
 }
 
 /**
+ * Filters out links with no labels
+ * 
+ * @param array $block
+ * 
+ * @return boolean
+ */
+function has_navigation_label( $block ) {
+	return ! empty( $block['attrs']['label'] );
+}
+
+/**
  * Renders the `core/navigation` block on server.
  *
  * @param array $attributes The block attributes.
@@ -140,7 +151,8 @@ function build_navigation_html( $block, $colors, $font_sizes, $level_zero = true
 		? sprintf( ' style="%s"', esc_attr( $colors['inline_styles'] ) . esc_attr( $font_sizes['inline_styles'] ) )
 		: '';
 
-	foreach ( (array) $block['innerBlocks'] as $key => $block ) {
+	// Only include link blocks that have a label set
+	foreach ( (array) array_filter( $block['innerBlocks'], "has_navigation_label" ) as $key => $block ) {
 
 		$html .= '<li class="wp-block-navigation-link">' .
 			'<a';
@@ -188,8 +200,14 @@ function build_navigation_html( $block, $colors, $font_sizes, $level_zero = true
 		$html .= '</a>';
 		// End anchor tag content.
 
+<<<<<<< HEAD
 		if ( count( (array) $block['innerBlocks'] ) > 0 ) {
 			$html .= build_navigation_html( $block, $colors, $font_sizes, false );
+=======
+		// Only include innerBlocks that have a label set in the count. Otherwise a submenu with no links will be rendered.
+		if ( count( (array) array_filter( $block['innerBlocks'], "has_navigation_label" ) ) > 0 ) {
+			$html .= build_navigation_html( $block, $colors, $font_sizes );
+>>>>>>> Added filter for only getting blocks with a non-empty label for ouptputting in the navigation html.
 		}
 
 		$html .= '</li>';

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -93,7 +93,6 @@ function build_css_font_sizes( $attributes ) {
  * @return array
  */
 function gutenberg_remove_empty_navigation_links_recursive( $blocks ) {
-
 	$blocks = array_filter(
 		$blocks,
 		function( $block ) {
@@ -122,7 +121,6 @@ function gutenberg_remove_empty_navigation_links_recursive( $blocks ) {
  * @return string Returns the post content with the legacy widget added.
  */
 function render_block_navigation( $attributes, $content, $block ) {
-
 	$block['innerBlocks'] = gutenberg_remove_empty_navigation_links_recursive( $block['innerBlocks'] );
 
 	if ( empty( $block['innerBlocks'] ) ) {
@@ -222,18 +220,8 @@ function build_navigation_html( $block, $colors, $font_sizes, $level_zero = true
 		$html .= '</a>';
 		// End anchor tag content.
 
-<<<<<<< HEAD
-<<<<<<< HEAD
 		if ( count( (array) $block['innerBlocks'] ) > 0 ) {
 			$html .= build_navigation_html( $block, $colors, $font_sizes, false );
-=======
-		// Only include innerBlocks that have a label set in the count. Otherwise a submenu with no links will be rendered.
-		if ( count( (array) array_filter( $block['innerBlocks'], 'has_navigation_label' ) ) > 0 ) {
-=======
-		if ( count( (array) $block['innerBlocks'] ) > 0 ) {
->>>>>>> Adds recursive function for effectively sanitizing the navigation block from outputting empty links.
-			$html .= build_navigation_html( $block, $colors, $font_sizes );
->>>>>>> Added filter for only getting blocks with a non-empty label for ouptputting in the navigation html.
 		}
 
 		$html .= '</li>';

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -86,14 +86,38 @@ function build_css_font_sizes( $attributes ) {
 }
 
 /**
- * Filters out links with no labels
+ * Filters out links with no labels.
  *
  * @param array $block Block to check label attribute on.
  *
  * @return boolean
  */
-function has_navigation_label( $block ) {
+function gutenberg_has_navigation_label( $block ) {
 	return ! empty( $block['attrs']['label'] );
+}
+
+/**
+ * Recursively filters out links with no labels to build a clean navigation block structure.
+ *
+ * @param array $blocks Navigation link inner blocks from the Navigation block.
+ *
+ * @return boolean
+ */
+function gutenberg_remove_empty_navigation_links_recursive( $blocks ) {
+
+	$blocks = array_filter( $blocks, 'gutenberg_has_navigation_label' );
+
+	if ( empty( $blocks ) ) {
+		return $blocks;
+	}
+
+	foreach ( $blocks as $key => $val ) {
+		if ( ! empty( $blocks[ $key ]['innerBlocks'] ) ) {
+			$blocks[ $key ]['innerBlocks'] = gutenberg_remove_empty_navigation_links_recursive( $blocks[ $key ]['innerBlocks'] );
+		}
+	}
+
+	return $blocks;
 }
 
 /**
@@ -106,6 +130,13 @@ function has_navigation_label( $block ) {
  * @return string Returns the post content with the legacy widget added.
  */
 function render_block_navigation( $attributes, $content, $block ) {
+
+	$block['innerBlocks'] = gutenberg_remove_empty_navigation_links_recursive( $block['innerBlocks'] );
+
+	if ( empty( $block['innerBlocks'] ) ) {
+		return;
+	}
+
 	$colors          = build_css_colors( $attributes );
 	$font_sizes      = build_css_font_sizes( $attributes );
 	$classes         = array_merge(
@@ -151,8 +182,7 @@ function build_navigation_html( $block, $colors, $font_sizes, $level_zero = true
 		? sprintf( ' style="%s"', esc_attr( $colors['inline_styles'] ) . esc_attr( $font_sizes['inline_styles'] ) )
 		: '';
 
-	// Only include link blocks that have a label set.
-	foreach ( (array) array_filter( $block['innerBlocks'], 'has_navigation_label' ) as $key => $block ) {
+	foreach ( (array) $block['innerBlocks'] as $key => $block ) {
 
 		$html .= '<li class="wp-block-navigation-link">' .
 			'<a';
@@ -201,11 +231,15 @@ function build_navigation_html( $block, $colors, $font_sizes, $level_zero = true
 		// End anchor tag content.
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 		if ( count( (array) $block['innerBlocks'] ) > 0 ) {
 			$html .= build_navigation_html( $block, $colors, $font_sizes, false );
 =======
 		// Only include innerBlocks that have a label set in the count. Otherwise a submenu with no links will be rendered.
 		if ( count( (array) array_filter( $block['innerBlocks'], 'has_navigation_label' ) ) > 0 ) {
+=======
+		if ( count( (array) $block['innerBlocks'] ) > 0 ) {
+>>>>>>> Adds recursive function for effectively sanitizing the navigation block from outputting empty links.
 			$html .= build_navigation_html( $block, $colors, $font_sizes );
 >>>>>>> Added filter for only getting blocks with a non-empty label for ouptputting in the navigation html.
 		}

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -89,8 +89,7 @@ function build_css_font_sizes( $attributes ) {
  * Recursively filters out links with no labels to build a clean navigation block structure.
  *
  * @param array $blocks Navigation link inner blocks from the Navigation block.
- *
- * @return array
+ * @return array Blocks that had valid labels
  */
 function gutenberg_remove_empty_navigation_links_recursive( $blocks ) {
 	$blocks = array_filter(


### PR DESCRIPTION
Closes https://github.com/WordPress/gutenberg/issues/19603

Previously all links from the navigation blocks were output on the frontend, even if they had no label content. This PR removes links with empty labels so they are not output.

## How has this been tested?
Manually, with empty labels in both the top level and submenu.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
