### PR TITLE
Chore: Skip intermittent end to end test on the button block

### DIFF
--- a/packages/e2e-tests/specs/editor/blocks/buttons.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/buttons.test.js
@@ -20,7 +20,9 @@ describe( 'Buttons', () => {
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 
-	it( 'can jump to the link editor using the keyboard shortcut', async () => {
+	// Todo: Fix this intermittent test.
+	// eslint-disable-next-line jest/no-disabled-tests
+	it.skip( 'can jump to the link editor using the keyboard shortcut', async () => {
 		await insertBlock( 'Buttons' );
 		await page.keyboard.type( 'WordPress' );
 		await pressKeyWithModifier( 'primary', 'k' );


### PR DESCRIPTION
## Description
This PR skips a problematic end to end test that is blocking the merge of some PR's. A proper fix to the test/code is being worked on https://github.com/WordPress/gutenberg/pull/19490.
