### PR TITLE
RichText: set correct selection on split

### DIFF
--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -286,7 +286,7 @@ function getBlocksWithDefaultStylesApplied( blocks, blockEditorSettings ) {
  *
  * @yield {Object} Action object.
  */
-export function* replaceBlocks( clientIds, blocks, indexToSelect ) {
+export function* replaceBlocks( clientIds, blocks, indexToSelect, attributeKey, offset ) {
 	clientIds = castArray( clientIds );
 	blocks = getBlocksWithDefaultStylesApplied(
 		castArray( blocks ),
@@ -319,6 +319,8 @@ export function* replaceBlocks( clientIds, blocks, indexToSelect ) {
 		blocks,
 		time: Date.now(),
 		indexToSelect,
+		attributeKey,
+		offset,
 	};
 	yield* ensureDefaultBlock();
 }

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1000,7 +1000,11 @@ function selection( state = {}, action ) {
 				return state;
 			}
 
-			return { clientId: blockToSelect.clientId };
+			return {
+				clientId: blockToSelect.clientId,
+				attributeKey: action.attributeKey,
+				offset: action.offset,
+			};
 		}
 	}
 

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -189,7 +189,7 @@ class RichText extends Component {
 	}
 
 	componentDidMount() {
-		this.applyRecord( this.record, { domOnly: true } );
+		this.applyRecord( this.record );
 	}
 
 	createRecord() {


### PR DESCRIPTION
## Description

Still a work in progress.

This PR makes it so that `RichText` sets the correct position selection when a block is split by `RichText` so the selection is directly set in the store instead of the block trying to query the first tabbable element inside the block (which may not be the element that has the split text). The technique is similar to the `MERGE_BLOCKS` effect.

I'll see if I can fix the selection on paste as well.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
