### PR TITLE
Components: Bump Downshift dependency to 4.0.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8473,7 +8473,7 @@
 				"classnames": "^2.2.5",
 				"clipboard": "^2.0.1",
 				"dom-scroll-into-view": "^1.2.1",
-				"downshift": "^3.3.4",
+				"downshift": "^4.0.5",
 				"gradient-parser": "^0.1.5",
 				"lodash": "^4.17.15",
 				"memize": "^1.0.5",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -42,7 +42,7 @@
 		"classnames": "^2.2.5",
 		"clipboard": "^2.0.1",
 		"dom-scroll-into-view": "^1.2.1",
-		"downshift": "^3.3.4",
+		"downshift": "^4.0.5",
 		"gradient-parser": "^0.1.5",
 		"lodash": "^4.17.15",
 		"memize": "^1.0.5",


### PR DESCRIPTION
This pull request seeks to update the Downshift dependency in `packages/components` from `^3.3.4` to `^4.0.5`.

**Testing Instructions:**

TBD