### PR TITLE
Address PR feedback on block labels

### DIFF
--- a/docs/designers-developers/developers/data/data-core-block-editor.md
+++ b/docs/designers-developers/developers/data/data-core-block-editor.md
@@ -32,6 +32,20 @@ _Returns_
 
 -   `boolean`: Whether the last change was automatic.
 
+<a name="getAccessibleBlockLabel" href="#getAccessibleBlockLabel">#</a> **getAccessibleBlockLabel**
+
+Get a label for the block for use by screenreaders, this can include the block title, the
+position of the block, and the value of the `getAccessibilityLabel` function if it's specified.
+
+_Parameters_
+
+-   _state_ `Object`: Store state.
+-   _clientId_ `string`: ClientId for the block.
+
+_Returns_
+
+-   `string`: The accessibility label for the block.
+
 <a name="getAdjacentBlockClientId" href="#getAdjacentBlockClientId">#</a> **getAdjacentBlockClientId**
 
 Returns the client ID of the block adjacent one at the given reference
@@ -132,6 +146,20 @@ _Parameters_
 _Returns_
 
 -   `Object`: Insertion point object with `rootClientId`, `index`.
+
+<a name="getBlockLabel" href="#getBlockLabel">#</a> **getBlockLabel**
+
+Get the label for the block, usually this is either the block title,
+or the value of the attribute denoted by the block's `label` property.
+
+_Parameters_
+
+-   _state_ `Object`: Store state.
+-   _clientId_ `string`: ClientId for the block.
+
+_Returns_
+
+-   `string`: The block label.
 
 <a name="getBlockListSettings" href="#getBlockListSettings">#</a> **getBlockListSettings**
 

--- a/packages/block-editor/src/components/block-list/block-popover.js
+++ b/packages/block-editor/src/components/block-list/block-popover.js
@@ -206,8 +206,6 @@ function BlockPopover( {
 			{ shouldShowBreadcrumb && (
 				<BlockBreadcrumb
 					clientId={ clientId }
-					rootClientId={ rootClientId }
-					moverDirection={ moverDirection }
 					data-align={ align }
 				/>
 			) }

--- a/packages/block-editor/src/components/block-list/block.native.js
+++ b/packages/block-editor/src/components/block-list/block.native.js
@@ -13,7 +13,6 @@ import { compose, withPreferredColorScheme } from '@wordpress/compose';
 import {
 	getBlockType,
 	getUnregisteredTypeHandlerName,
-	__experimentalGetAccessibleBlockLabel as getAccessibleBlockLabel,
 } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 
@@ -194,24 +193,16 @@ class BlockListBlock extends Component {
 
 	render() {
 		const {
-			attributes,
-			blockType,
+			accessibilityLabel,
 			clientId,
 			icon,
 			isSelected,
 			isValid,
-			order,
 			title,
 			showFloatingToolbar,
 			parentId,
 			isTouchable,
 		} = this.props;
-
-		const accessibilityLabel = getAccessibleBlockLabel(
-			blockType,
-			attributes,
-			order + 1
-		);
 
 		return (
 			<>
@@ -263,6 +254,7 @@ class BlockListBlock extends Component {
 export default compose( [
 	withSelect( ( select, { clientId, rootClientId } ) => {
 		const {
+			getAccessibleBlockLabel,
 			getBlockIndex,
 			isBlockSelected,
 			__unstableGetBlockWithoutInnerBlocks,
@@ -281,7 +273,7 @@ export default compose( [
 		const isSelected = isBlockSelected( clientId );
 		const isLastBlock = order === getBlockCount( rootClientId ) - 1;
 		const block = __unstableGetBlockWithoutInnerBlocks( clientId );
-		const { name, attributes, isValid } = block || {};
+		const { name, isValid } = block || {};
 
 		const isUnregisteredBlock = name === getUnregisteredTypeHandlerName();
 		const blockType = getBlockType( name || 'core/missing' );
@@ -341,13 +333,13 @@ export default compose( [
 		const isRootListInnerBlockHolder =
 			! isSelectedBlockNested && isInnerBlockHolder;
 
+		const accessibilityLabel = getAccessibleBlockLabel( clientId );
+
 		return {
 			icon,
 			name: name || 'core/missing',
-			order,
+			accessibilityLabel,
 			title,
-			attributes,
-			blockType,
 			isLastBlock,
 			isSelected,
 			isValid,

--- a/packages/block-editor/src/components/block-list/breadcrumb.js
+++ b/packages/block-editor/src/components/block-list/breadcrumb.js
@@ -5,10 +5,6 @@ import { Toolbar, Button } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect, useRef } from '@wordpress/element';
 import { BACKSPACE, DELETE } from '@wordpress/keycodes';
-import {
-	getBlockType,
-	__experimentalGetAccessibleBlockLabel as getAccessibleBlockLabel,
-} from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -25,27 +21,12 @@ import BlockTitle from '../block-title';
  *
  * @return {WPComponent} The component to be rendered.
  */
-function BlockBreadcrumb( {
-	clientId,
-	rootClientId,
-	moverDirection,
-	...props
-} ) {
-	const selected = useSelect(
-		( select ) => {
-			const {
-				__unstableGetBlockWithoutInnerBlocks,
-				getBlockIndex,
-			} = select( 'core/block-editor' );
-			const index = getBlockIndex( clientId, rootClientId );
-			const { name, attributes } = __unstableGetBlockWithoutInnerBlocks(
-				clientId
-			);
-			return { index, name, attributes };
-		},
-		[ clientId, rootClientId ]
+function BlockBreadcrumb( { clientId, ...props } ) {
+	const label = useSelect(
+		( select ) =>
+			select( 'core/block-editor' ).getAccessibleBlockLabel( clientId ),
+		[ clientId ]
 	);
-	const { index, name, attributes } = selected;
 	const { setNavigationMode, removeBlock } = useDispatch(
 		'core/block-editor'
 	);
@@ -64,14 +45,6 @@ function BlockBreadcrumb( {
 			event.preventDefault();
 		}
 	}
-
-	const blockType = getBlockType( name );
-	const label = getAccessibleBlockLabel(
-		blockType,
-		attributes,
-		index + 1,
-		moverDirection
-	);
 
 	return (
 		<div className="block-editor-block-list__breadcrumb" { ...props }>

--- a/packages/block-editor/src/components/block-navigation/item.js
+++ b/packages/block-editor/src/components/block-navigation/item.js
@@ -1,0 +1,60 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { Button } from '@wordpress/components';
+import {
+	getBlockType,
+} from '@wordpress/blocks';
+import { useSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import BlockIcon from '../block-icon';
+import ButtonBlockAppender from '../button-block-appender';
+
+export default function BlockNavigationItem( { block, isSelected, onClick, children } ) {
+	const { clientId, name } = block;
+	const blockIcon = getBlockType( name ).icon;
+	const blockLabel = useSelect(
+		( select ) => select( 'core/block-editor' ).getBlockLabel( clientId ),
+		[ clientId ]
+	);
+
+	return (
+		<li>
+			<div className="block-editor-block-navigation-item__block">
+				<Button
+					className={ classnames( 'block-editor-block-navigation-item__button', {
+						'is-selected': isSelected,
+					} ) }
+					onClick={ onClick }
+				>
+					<BlockIcon icon={ blockIcon } showColors />
+					{ blockLabel }
+					{ isSelected && <span className="screen-reader-text">{ __( '(selected block)' ) }</span> }
+				</Button>
+			</div>
+			{ children }
+		</li>
+	);
+}
+
+BlockNavigationItem.Appender = function( { parentBlockClientId } ) {
+	return (
+		<li>
+			<div className="block-editor-block-navigation-item__appender">
+				<ButtonBlockAppender
+					rootClientId={ parentBlockClientId }
+					__experimentalSelectBlockOnInsert={ false }
+				/>
+			</div>
+		</li>
+	);
+};

--- a/packages/block-editor/src/components/block-navigation/list.js
+++ b/packages/block-editor/src/components/block-navigation/list.js
@@ -2,23 +2,11 @@
  * External dependencies
  */
 import { isNil, map, omitBy } from 'lodash';
-import classnames from 'classnames';
-
-/**
- * WordPress dependencies
- */
-import { Button } from '@wordpress/components';
-import {
-	__experimentalGetBlockLabel as getBlockLabel,
-	getBlockType,
-} from '@wordpress/blocks';
-import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import BlockIcon from '../block-icon';
-import ButtonBlockAppender from '../button-block-appender';
+import BlockNavigationItem from './item';
 
 export default function BlockNavigationList( {
 	blocks,
@@ -40,30 +28,13 @@ export default function BlockNavigationList( {
 		/* eslint-disable jsx-a11y/no-redundant-roles */
 		<ul className="block-editor-block-navigation__list" role="list">
 			{ map( omitBy( blocks, isNil ), ( block ) => {
-				const blockType = getBlockType( block.name );
-				const isSelected = block.clientId === selectedBlockClientId;
-
 				return (
-					<li key={ block.clientId }>
-						<div className="block-editor-block-navigation__item">
-							<Button
-								className={ classnames(
-									'block-editor-block-navigation__item-button',
-									{
-										'is-selected': isSelected,
-									}
-								) }
-								onClick={ () => selectBlock( block.clientId ) }
-							>
-								<BlockIcon icon={ blockType.icon } showColors />
-								{ getBlockLabel( blockType, block.attributes ) }
-								{ isSelected && (
-									<span className="screen-reader-text">
-										{ __( '(selected block)' ) }
-									</span>
-								) }
-							</Button>
-						</div>
+					<BlockNavigationItem
+						key={ block.clientId }
+						block={ block }
+						onClick={ () => selectBlock( block.clientId ) }
+						isSelected={ block.clientId === selectedBlockClientId }
+					>
 						{ showNestedBlocks &&
 							!! block.innerBlocks &&
 							!! block.innerBlocks.length && (
@@ -78,18 +49,13 @@ export default function BlockNavigationList( {
 									showNestedBlocks
 								/>
 							) }
-					</li>
+					</BlockNavigationItem>
 				);
 			} ) }
 			{ shouldShowAppender && (
-				<li>
-					<div className="block-editor-block-navigation__item">
-						<ButtonBlockAppender
-							rootClientId={ parentBlockClientId }
-							__experimentalSelectBlockOnInsert={ false }
-						/>
-					</div>
-				</li>
+				<BlockNavigationItem.Appender
+					parentBlockClientId={ parentBlockClientId }
+				/>
 			) }
 		</ul>
 		/* eslint-enable jsx-a11y/no-redundant-roles */

--- a/packages/block-editor/src/components/block-navigation/style.scss
+++ b/packages/block-editor/src/components/block-navigation/style.scss
@@ -43,7 +43,8 @@ $tree-item-height: 36px;
 		margin-left: 1.5em;
 	}
 
-	.block-editor-block-navigation__item {
+	.block-editor-block-navigation-item__block,
+	.block-editor-block-navigation-item__appender {
 		position: relative;
 
 		&::before {
@@ -57,7 +58,7 @@ $tree-item-height: 36px;
 		}
 	}
 
-	.block-editor-block-navigation__item-button {
+	.block-editor-block-navigation-item__button {
 		margin-left: 0.8em;
 		width: calc(100% - 0.8em);
 	}
@@ -76,7 +77,7 @@ $tree-item-height: 36px;
 	}
 }
 
-.block-editor-block-navigation__item-button {
+.block-editor-block-navigation-item__button {
 	display: flex;
 	align-items: center;
 	width: 100%;

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -29,6 +29,8 @@ import {
 	parse,
 } from '@wordpress/blocks';
 import { SVG, Rect, G, Path } from '@wordpress/components';
+import { toPlainText } from '@wordpress/rich-text';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * A block selection object.
@@ -1622,4 +1624,129 @@ export function isNavigationMode( state ) {
  */
 export function didAutomaticChange( state ) {
 	return !! state.automaticChangeStatus;
+}
+
+/**
+ * Get the label for the block, usually this is either the block title,
+ * or the value of the attribute denoted by the block's `label` property.
+ *
+ * @param {Object} state    Store state.
+ * @param {string} clientId ClientId for the block.
+ *
+ * @return {string} The block label.
+ */
+export function getBlockLabel( state, clientId ) {
+	const blockName = getBlockName( state, clientId );
+
+	const { __experimentalLabel: labelAttribute, title } = getBlockType(
+		blockName
+	);
+
+	if ( ! labelAttribute ) {
+		return title;
+	}
+
+	const attributes = getBlockAttributes( state, clientId );
+	const label = attributes[ labelAttribute ];
+
+	if ( ! label ) {
+		return title;
+	}
+
+	// Strip any HTML (i.e. RichText formatting) before returning.
+	return toPlainText( label );
+}
+
+/**
+ * Get a label for the block for use by screenreaders, this can include the block title, the
+ * position of the block, and the value of the `getAccessibilityLabel` function if it's specified.
+ *
+ * @param {Object} state    Store state.
+ * @param {string} clientId ClientId for the block.
+ *
+ * @return {string} The accessibility label for the block.
+ */
+export function getAccessibleBlockLabel( state, clientId ) {
+	const blockName = getBlockName( state, clientId );
+
+	const {
+		__experimentalGetAccessibilityLabel: getAccessibilityLabel,
+		title,
+	} = getBlockType( blockName );
+
+	const rootClientId = getBlockRootClientId( state, clientId );
+	const attributes = getBlockAttributes( state, clientId );
+	const { __experimentalMoverDirection: direction = 'vertical' } =
+		getBlockListSettings( state, rootClientId ) || {};
+
+	// First, attempt to get the accessibility label if the block has one defined.
+	let label = getAccessibilityLabel
+		? toPlainText( getAccessibilityLabel( attributes ) )
+		: undefined;
+
+	// If there's no accessibility label, use the block label.
+	if ( ! label ) {
+		label = getBlockLabel( state, clientId );
+	}
+
+	const position = getBlockIndex( state, clientId, rootClientId ) + 1;
+
+	// getBlockLabel returns the block title as a fallback when there's no label,
+	// if it did return the title, this function needs to avoid adding the
+	// title twice within the accessible label. Use this `hasLabel` boolean to
+	// handle that.
+	const hasLabel = !! label && label !== title;
+
+	const hasPosition = position !== undefined;
+
+	if ( hasPosition && direction === 'vertical' ) {
+		if ( hasLabel ) {
+			return sprintf(
+				/* translators: accessibility text. %1: The block title, %2: The block row number, %3: The block label.. */
+				__( '%1$s Block. Row %2$d. %3$s' ),
+				title,
+				position,
+				label
+			);
+		}
+
+		return sprintf(
+			/* translators: accessibility text. %s: The block title, %d The block row number. */
+			__( '%s Block. Row %d' ),
+			title,
+			position
+		);
+	} else if ( hasPosition && direction === 'horizontal' ) {
+		if ( hasLabel ) {
+			return sprintf(
+				/* translators: accessibility text. %1: The block title, %2: The block column number, %3: The block label.. */
+				__( '%1$s Block. Column %2$d. %3$s' ),
+				title,
+				position,
+				label
+			);
+		}
+
+		return sprintf(
+			/* translators: accessibility text. %s: The block title, %d The block column number. */
+			__( '%s Block. Column %d' ),
+			title,
+			position
+		);
+	}
+
+	if ( hasLabel ) {
+		return sprintf(
+			/* translators: accessibility text. %1: The block title. %2: The block label. */
+			__( '%1$s Block. %2$s' ),
+			title,
+			label
+		);
+	}
+
+	return sprintf(
+		/* translators: accessibility text. %s: The block title. */
+		__( '%s Block' ),
+		title
+	);
 }

--- a/packages/block-library/src/heading/index.js
+++ b/packages/block-library/src/heading/index.js
@@ -40,23 +40,21 @@ export const settings = {
 			level: 2,
 		},
 	},
-	__experimentalLabel( attributes, { context } ) {
-		if ( context === 'accessibility' ) {
-			const { content, level } = attributes;
-
-			return isEmpty( content )
-				? sprintf(
-						/* translators: accessibility text. %s: heading level. */
-						__( 'Level %s. Empty.' ),
-						level
-				  )
-				: sprintf(
-						/* translators: accessibility text. 1: heading level. 2: heading content. */
-						__( 'Level %1$s. %2$s' ),
-						level,
-						content
-				  );
+	__experimentalGetAccessibilityLabel( { content, level } ) {
+		if ( isEmpty( content ) ) {
+			return sprintf(
+				/* translators: accessibility text. %s: heading level. */
+				__( 'Level %s. Empty.' ),
+				level
+			);
 		}
+
+		return sprintf(
+			/* translators: accessibility text. 1: heading level. 2: heading content. */
+			__( 'Level %1$s. %2$s' ),
+			level,
+			content
+		);
 	},
 	transforms,
 	deprecated,

--- a/packages/block-library/src/image/index.js
+++ b/packages/block-library/src/image/index.js
@@ -41,22 +41,18 @@ export const settings = {
 		},
 		{ name: 'rounded', label: _x( 'Rounded', 'block style' ) },
 	],
-	__experimentalLabel( attributes, { context } ) {
-		if ( context === 'accessibility' ) {
-			const { caption, alt, url } = attributes;
-
-			if ( ! url ) {
-				return __( 'Empty' );
-			}
-
-			if ( ! alt ) {
-				return caption || '';
-			}
-
-			// This is intended to be read by a screen reader.
-			// A period simply means a pause, no need to translate it.
-			return alt + ( caption ? '. ' + caption : '' );
+	__experimentalGetAccessibilityLabel( { caption, alt, url } ) {
+		if ( ! url ) {
+			return __( 'Empty' );
 		}
+
+		if ( ! alt ) {
+			return caption || '';
+		}
+
+		// This is intended to be read by a screen reader.
+		// A period simply means a pause, no need to translate it.
+		return alt + ( caption ? '. ' + caption : '' );
 	},
 	transforms,
 	getEditWrapperProps( attributes ) {

--- a/packages/block-library/src/missing/index.js
+++ b/packages/block-library/src/missing/index.js
@@ -26,20 +26,16 @@ export const settings = {
 		html: false,
 		reusable: false,
 	},
-	__experimentalLabel( attributes, { context } ) {
-		if ( context === 'accessibility' ) {
-			const { originalName } = attributes;
+	__experimentalGetAccessibilityLabel( { originalName } ) {
+		const originalBlockType = originalName
+			? getBlockType( originalName )
+			: undefined;
 
-			const originalBlockType = originalName
-				? getBlockType( originalName )
-				: undefined;
-
-			if ( originalBlockType ) {
-				return originalBlockType.settings.title || originalName;
-			}
-
-			return '';
+		if ( originalBlockType ) {
+			return originalBlockType.settings.title || originalName;
 		}
+
+		return '';
 	},
 	edit,
 	save,

--- a/packages/block-library/src/more/index.js
+++ b/packages/block-library/src/more/index.js
@@ -29,10 +29,8 @@ export const settings = {
 		multiple: false,
 	},
 	example: {},
-	__experimentalLabel( attributes, { context } ) {
-		if ( context === 'accessibility' ) {
-			return attributes.customText;
-		}
+	__experimentalGetAccessibilityLabel( { customText } ) {
+		return customText;
 	},
 	transforms,
 	edit,

--- a/packages/block-library/src/navigation-link/index.js
+++ b/packages/block-library/src/navigation-link/index.js
@@ -28,7 +28,11 @@ export const settings = {
 		html: false,
 	},
 
-	__experimentalLabel: ( { label } ) => label,
+	__experimentalLabel: 'label',
+
+	__experimentalGetAccessibilityLabel( { label } ) {
+		return label;
+	},
 
 	edit,
 	save,

--- a/packages/block-library/src/paragraph/index.js
+++ b/packages/block-library/src/paragraph/index.js
@@ -40,11 +40,8 @@ export const settings = {
 		className: false,
 		__unstablePasteTextInline: true,
 	},
-	__experimentalLabel( attributes, { context } ) {
-		if ( context === 'accessibility' ) {
-			const { content } = attributes;
-			return isEmpty( content ) ? __( 'Empty' ) : content;
-		}
+	__experimentalGetAccessibilityLabel( { content } ) {
+		return isEmpty( content ) ? __( 'Empty' ) : content;
 	},
 	transforms,
 	deprecated,

--- a/packages/blocks/src/api/index.js
+++ b/packages/blocks/src/api/index.js
@@ -57,8 +57,6 @@ export {
 	isUnmodifiedDefaultBlock,
 	normalizeIconObject,
 	isValidIcon,
-	getBlockLabel as __experimentalGetBlockLabel,
-	getAccessibleBlockLabel as __experimentalGetAccessibleBlockLabel,
 } from './utils';
 export {
 	doBlocksMatchTemplate,

--- a/packages/blocks/src/api/test/utils.js
+++ b/packages/blocks/src/api/test/utils.js
@@ -13,11 +13,7 @@ import {
 	registerBlockType,
 	setDefaultBlockName,
 } from '../registration';
-import {
-	isUnmodifiedDefaultBlock,
-	getAccessibleBlockLabel,
-	getBlockLabel,
-} from '../utils';
+import { isUnmodifiedDefaultBlock } from '../utils';
 
 describe( 'block helpers', () => {
 	beforeAll( () => {
@@ -105,110 +101,5 @@ describe( 'block helpers', () => {
 				isUnmodifiedDefaultBlock( createBlock( 'core/test-block2' ) )
 			).toBe( true );
 		} );
-	} );
-} );
-
-describe( 'getBlockLabel', () => {
-	it( 'returns only the block title when the block has no `getLabel` function', () => {
-		const blockType = { title: 'Recipe' };
-		const attributes = {};
-
-		expect( getBlockLabel( blockType, attributes ) ).toBe( 'Recipe' );
-	} );
-
-	it( 'returns only the block title when the block has a `getLabel` function, but it returns a falsey value', () => {
-		const blockType = { title: 'Recipe', __experimentalLabel: () => '' };
-		const attributes = {};
-
-		expect( getBlockLabel( blockType, attributes ) ).toBe( 'Recipe' );
-	} );
-
-	it( 'returns the block title with the label when the `getLabel` function returns a value', () => {
-		const blockType = {
-			title: 'Recipe',
-			__experimentalLabel: ( { heading } ) => heading,
-		};
-		const attributes = { heading: 'Cupcakes!' };
-
-		expect( getBlockLabel( blockType, attributes ) ).toBe( 'Cupcakes!' );
-	} );
-
-	it( 'removes any html elements from the output of the `getLabel` function', () => {
-		const blockType = {
-			title: 'Recipe',
-			__experimentalLabel: ( { heading } ) => heading,
-		};
-		const attributes = {
-			heading: '<b><span class="my-class">Cupcakes!</span></b>',
-		};
-
-		expect( getBlockLabel( blockType, attributes ) ).toBe( 'Cupcakes!' );
-	} );
-} );
-
-describe( 'getAccessibleBlockLabel', () => {
-	it( 'returns only the block title when the block has no `getLabel` function', () => {
-		const blockType = { title: 'Recipe' };
-		const attributes = {};
-
-		expect( getAccessibleBlockLabel( blockType, attributes ) ).toBe(
-			'Recipe Block'
-		);
-	} );
-
-	it( 'returns only the block title when the block has a `getLabel` function, but it returns a falsey value', () => {
-		const blockType = { title: 'Recipe', __experimentalLabel: () => '' };
-		const attributes = {};
-
-		expect( getAccessibleBlockLabel( blockType, attributes ) ).toBe(
-			'Recipe Block'
-		);
-	} );
-
-	it( 'returns the block title with the label when the `getLabel` function returns a value', () => {
-		const blockType = {
-			title: 'Recipe',
-			__experimentalLabel: ( { heading } ) => heading,
-		};
-		const attributes = { heading: 'Cupcakes!' };
-
-		expect( getAccessibleBlockLabel( blockType, attributes ) ).toBe(
-			'Recipe Block. Cupcakes!'
-		);
-	} );
-
-	it( 'removes any html elements from the output of the `getLabel` function', () => {
-		const blockType = {
-			title: 'Recipe',
-			__experimentalLabel: ( { heading } ) => heading,
-		};
-		const attributes = {
-			heading: '<b><span class="my-class">Cupcakes!</span></b>',
-		};
-
-		expect( getAccessibleBlockLabel( blockType, attributes ) ).toBe(
-			'Recipe Block. Cupcakes!'
-		);
-	} );
-
-	it( 'outputs the block title and label with a row number indicating the position of the block, when the optional third parameter is provided', () => {
-		const blockType = {
-			title: 'Recipe',
-			__experimentalLabel: ( { heading } ) => heading,
-		};
-		const attributes = { heading: 'Cupcakes!' };
-
-		expect( getAccessibleBlockLabel( blockType, attributes, 3 ) ).toBe(
-			'Recipe Block. Row 3. Cupcakes!'
-		);
-	} );
-
-	it( 'outputs just the block title and row number when there no label is available for the block', () => {
-		const blockType = { title: 'Recipe' };
-		const attributes = {};
-
-		expect( getAccessibleBlockLabel( blockType, attributes, 3 ) ).toBe(
-			'Recipe Block. Row 3'
-		);
 	} );
 } );

--- a/packages/blocks/src/api/utils.js
+++ b/packages/blocks/src/api/utils.js
@@ -8,8 +8,6 @@ import { default as tinycolor, mostReadable } from 'tinycolor2';
  * WordPress dependencies
  */
 import { Component, isValidElement } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
-import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
 
 /**
  * Internal dependencies
@@ -127,108 +125,4 @@ export function normalizeBlockType( blockTypeOrName ) {
 	}
 
 	return blockTypeOrName;
-}
-
-/**
- * Get the label for the block, usually this is either the block title,
- * or the value of the block's `label` function when that's specified.
- *
- * @param {Object} blockType  The block type.
- * @param {Object} attributes The values of the block's attributes.
- * @param {Object} context    The intended use for the label.
- *
- * @return {string} The block label.
- */
-export function getBlockLabel( blockType, attributes, context = 'visual' ) {
-	const { __experimentalLabel: getLabel, title } = blockType;
-
-	const label = getLabel && getLabel( attributes, { context } );
-
-	if ( ! label ) {
-		return title;
-	}
-
-	// Strip any HTML (i.e. RichText formatting) before returning.
-	return stripHTML( label );
-}
-
-/**
- * Get a label for the block for use by screenreaders, this is more descriptive
- * than the visual label and includes the block title and the value of the
- * `getLabel` function if it's specified.
- *
- * @param {Object}  blockType              The block type.
- * @param {Object}  attributes             The values of the block's attributes.
- * @param {?number} position               The position of the block in the block list.
- * @param {string}  [direction='vertical'] The direction of the block layout.
- *
- * @return {string} The block label.
- */
-export function getAccessibleBlockLabel(
-	blockType,
-	attributes,
-	position,
-	direction = 'vertical'
-) {
-	// `title` is already localized, `label` is a user-supplied value.
-	const { title } = blockType;
-	const label = getBlockLabel( blockType, attributes, 'accessibility' );
-	const hasPosition = position !== undefined;
-
-	// getBlockLabel returns the block title as a fallback when there's no label,
-	// if it did return the title, this function needs to avoid adding the
-	// title twice within the accessible label. Use this `hasLabel` boolean to
-	// handle that.
-	const hasLabel = label && label !== title;
-
-	if ( hasPosition && direction === 'vertical' ) {
-		if ( hasLabel ) {
-			return sprintf(
-				/* translators: accessibility text. %1: The block title, %2: The block row number, %3: The block label.. */
-				__( '%1$s Block. Row %2$d. %3$s' ),
-				title,
-				position,
-				label
-			);
-		}
-
-		return sprintf(
-			/* translators: accessibility text. %s: The block title, %d The block row number. */
-			__( '%s Block. Row %d' ),
-			title,
-			position
-		);
-	} else if ( hasPosition && direction === 'horizontal' ) {
-		if ( hasLabel ) {
-			return sprintf(
-				/* translators: accessibility text. %1: The block title, %2: The block column number, %3: The block label.. */
-				__( '%1$s Block. Column %2$d. %3$s' ),
-				title,
-				position,
-				label
-			);
-		}
-
-		return sprintf(
-			/* translators: accessibility text. %s: The block title, %d The block column number. */
-			__( '%s Block. Column %d' ),
-			title,
-			position
-		);
-	}
-
-	if ( hasLabel ) {
-		return sprintf(
-			/* translators: accessibility text. %1: The block title. %2: The block label. */
-			__( '%1$s Block. %2$s' ),
-			title,
-			label
-		);
-	}
-
-	return sprintf(
-		/* translators: accessibility text. %s: The block title. */
-		__( '%s Block' ),
-		title
-	);
 }

--- a/packages/dom/src/dom.js
+++ b/packages/dom/src/dom.js
@@ -7,7 +7,7 @@ import { includes } from 'lodash';
  * Browser dependencies
  */
 
-const { DOMParser, getComputedStyle } = window;
+const { getComputedStyle } = window;
 const {
 	TEXT_NODE,
 	ELEMENT_NODE,
@@ -677,16 +677,4 @@ export function replaceTag( node, tagName ) {
 export function wrap( newNode, referenceNode ) {
 	referenceNode.parentNode.insertBefore( newNode, referenceNode );
 	newNode.appendChild( referenceNode );
-}
-
-/**
- * Removes any HTML tags from the provided string.
- *
- * @param {string} html The string containing html.
- *
- * @return {string} The text content with any html removed.
- */
-export function __unstableStripHTML( html ) {
-	const document = new DOMParser().parseFromString( html, 'text/html' );
-	return document.body.textContent || '';
 }

--- a/packages/dom/src/test/dom.js
+++ b/packages/dom/src/test/dom.js
@@ -5,7 +5,6 @@ import {
 	isHorizontalEdge,
 	placeCaretAtHorizontalEdge,
 	isTextField,
-	__unstableStripHTML as stripHTML,
 } from '../dom';
 
 describe( 'DOM', () => {
@@ -155,20 +154,6 @@ describe( 'DOM', () => {
 			expect( isTextField( document.createElement( 'div' ) ) ).toBe(
 				false
 			);
-		} );
-	} );
-
-	describe( 'stripHTML', () => {
-		it( 'removes any HTML from a text string', () => {
-			expect( stripHTML( 'This is <em>emphasized</em>' ) ).toBe(
-				'This is emphasized'
-			);
-		} );
-
-		it( 'removes script tags, but does not execute them', () => {
-			const html = 'This will not <script>throw "Error"</script>';
-			expect( stripHTML( html ) ).toBe( 'This will not throw "Error"' );
-			expect( () => stripHTML( html ) ).not.toThrow();
 		} );
 	} );
 } );

--- a/packages/e2e-tests/specs/editor/blocks/columns.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/columns.test.js
@@ -20,7 +20,7 @@ describe( 'Columns', () => {
 		await page.click( '[aria-label="Block navigation"]' );
 		const columnBlockMenuItem = (
 			await page.$x(
-				'//button[contains(concat(" ", @class, " "), " block-editor-block-navigation__item-button ")][text()="Column"]'
+				'//button[contains(concat(" ", @class, " "), " block-editor-block-navigation-item__button ")][text()="Column"]'
 			)
 		 )[ 0 ];
 		await columnBlockMenuItem.click();

--- a/packages/e2e-tests/specs/editor/plugins/block-icons.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/block-icons.test.js
@@ -39,7 +39,7 @@ async function getFirstInserterIcon() {
 async function selectFirstBlock() {
 	await pressKeyWithModifier( 'access', 'o' );
 	const navButtons = await page.$$(
-		'.block-editor-block-navigation__item-button'
+		'.block-editor-block-navigation-item__button'
 	);
 	await navButtons[ 0 ].click();
 }

--- a/packages/e2e-tests/specs/editor/various/block-hierarchy-navigation.test.js
+++ b/packages/e2e-tests/specs/editor/various/block-hierarchy-navigation.test.js
@@ -12,7 +12,7 @@ import {
 async function openBlockNavigator() {
 	await pressKeyWithModifier( 'access', 'o' );
 	await page.waitForSelector(
-		'.block-editor-block-navigation__item-button.is-selected'
+		'.block-editor-block-navigation-item__button.is-selected'
 	);
 }
 
@@ -37,7 +37,7 @@ describe( 'Navigating the block hierarchy', () => {
 		await page.click( '[aria-label="Block navigation"]' );
 		const columnsBlockMenuItem = (
 			await page.$x(
-				"//button[contains(@class,'block-editor-block-navigation__item') and contains(text(), 'Columns')]"
+				"//button[contains(@class,'block-editor-block-navigation-item__button') and contains(text(), 'Columns')]"
 			)
 		 )[ 0 ];
 		await columnsBlockMenuItem.click();
@@ -55,7 +55,7 @@ describe( 'Navigating the block hierarchy', () => {
 		await page.click( '[aria-label="Block navigation"]' );
 		const lastColumnsBlockMenuItem = (
 			await page.$x(
-				"//button[contains(@class,'block-editor-block-navigation__item') and contains(text(), 'Column')]"
+				"//button[contains(@class,'block-editor-block-navigation-item__button') and contains(text(), 'Column')]"
 			)
 		 )[ 3 ];
 		await lastColumnsBlockMenuItem.click();

--- a/packages/rich-text/README.md
+++ b/packages/rich-text/README.md
@@ -335,6 +335,18 @@ _Returns_
 
 -   `string`: HTML string.
 
+<a name="toPlainText" href="#toPlainText">#</a> **toPlainText**
+
+Removes any HTML tags from the provided string.
+
+_Parameters_
+
+-   _html_ `string`: The string containing html.
+
+_Returns_
+
+-   `string`: The text content with any html removed.
+
 <a name="unregisterFormatType" href="#unregisterFormatType">#</a> **unregisterFormatType**
 
 Unregisters a format.

--- a/packages/rich-text/src/index.js
+++ b/packages/rich-text/src/index.js
@@ -26,6 +26,7 @@ export { slice } from './slice';
 export { split } from './split';
 export { toDom as __unstableToDom } from './to-dom';
 export { toHTMLString } from './to-html-string';
+export { toPlainText } from './to-plain-text';
 export { toggleFormat } from './toggle-format';
 export { LINE_SEPARATOR as __UNSTABLE_LINE_SEPARATOR } from './special-characters';
 export { unregisterFormatType } from './unregister-format-type';

--- a/packages/rich-text/src/test/to-plain-text.js
+++ b/packages/rich-text/src/test/to-plain-text.js
@@ -1,0 +1,27 @@
+/**
+ * Internal dependencies
+ */
+import { toPlainText } from '../to-plain-text';
+
+describe( 'toPlainText', () => {
+	beforeAll( () => {
+		// Initialize the rich-text store.
+		require( '../store' );
+	} );
+
+	it( 'removes any HTML from a text string', () => {
+		expect( toPlainText( 'This is <em>emphasized</em>' ) ).toBe( 'This is emphasized' );
+	} );
+
+	it( 'removes script tags, but does not execute them', () => {
+		const html = 'This will not <script>throw "Error"</script>';
+		expect( toPlainText( html ) ).toBe( 'This will not throw "Error"' );
+		expect( () => toPlainText( html ) ).not.toThrow();
+	} );
+
+	it( 'expects strings and an empty string for falsey values', () => {
+		expect( toPlainText( '' ) ).toBe( '' );
+		expect( toPlainText( undefined ) ).toBe( '' );
+		expect( toPlainText( null ) ).toBe( '' );
+	} );
+} );

--- a/packages/rich-text/src/to-plain-text.js
+++ b/packages/rich-text/src/to-plain-text.js
@@ -1,0 +1,19 @@
+/**
+ * Internal dependencies
+ */
+import { create } from './create';
+
+/**
+ * Removes any HTML tags from the provided string.
+ *
+ * @param {string} html The string containing html.
+ *
+ * @return {string} The text content with any html removed.
+ */
+export function toPlainText( html ) {
+	if ( ! html ) {
+		return '';
+	}
+
+	return create( { html } ).text;
+}


### PR DESCRIPTION
## Description
PR #18132 was merged accidentally prior to any code review, but rather than revert I'll attempt to tackle review feedback in follow-ups. #19597 also tackles much of the feedback (thanks @ellatrix!)

This PR:

- Moves the experimental functions `getAccessibleBlockLabel` and `getBlockLabel` to the `block-editor` package as selectors.
- Moves `stripHTML` from the dom package to rich-text and renames to `toPlainText`.
- Instead of one experimental `getLabel` function that can be declared on blocks there's now separate properties:
  - `label`, which can be declared as a string, the name of an attribute that should appear in the block navigator.
  - `getAccessibilityLabel( attributes )` a function that takes attributes for tailoring an accessibility label for the block. #19597 exposes this in navigation mode. It falls back to using the above `label` when unspecified


## How has this been tested?
1. Add a Navigation Block (make sure it's enabled as an experimental feature).
2. Ensure the navigation block has menu items.
3. View the Block navigator.
4. Observe the block labels for menu items
5. Inspect the block mover for a menu item using dev tools
6. Observe the screen reader text includes the new block label
7. Inspect the menu item's block wrapper
8. Observe the aria label includes the new block label

Other blocks worth testing for the aria-label - Paragraph, Heading, More, Image.


## Types of changes
Task
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
