### PR TITLE
LinkControl - adds search results label for initial suggestions

### DIFF
--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -137,10 +137,14 @@ export function LinkControl( {
 		} );
 
 		const manualLinkEntryTypes = [ 'url', 'mailto', 'tel', 'internal' ];
-		const searchResultsLabelId = `block-editor-link-control-search-results-label-${ instanceId }`;
+		const searchResultsLabelId = isInitialSuggestions && `block-editor-link-control-search-results-label-${ instanceId }`;
 		const labelText = isInitialSuggestions ? __( 'Recently updated' ) : sprintf( __( 'Search results for %s' ), inputValue );
+		// According to guidelines aria-label should be added if the label
+		// itself is not visible.
+		// See: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/listbox_role
+		const ariaLabel = isInitialSuggestions ? undefined : labelText;
 		const SearchResultsLabel = (
-			<span className="block-editor-link-control__search-results-label" id={ searchResultsLabelId }>
+			<span className="block-editor-link-control__search-results-label" id={ searchResultsLabelId } aria-label={ ariaLabel } >
 				{ labelText }
 			</span>
 		);

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -7,7 +7,7 @@ import { noop, startsWith } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { Button, ExternalLink } from '@wordpress/components';
+import { Button, ExternalLink, VisuallyHidden } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { useCallback, useState, Fragment } from '@wordpress/element';
 
@@ -139,14 +139,15 @@ export function LinkControl( {
 		const manualLinkEntryTypes = [ 'url', 'mailto', 'tel', 'internal' ];
 		const searchResultsLabelId = `block-editor-link-control-search-results-label-${ instanceId }`;
 		const labelText = isInitialSuggestions ? __( 'Recently modified' ) : sprintf( __( 'Search results for %s' ), inputValue );
+		const SearchResultsLabel = (
+			<span className="block-editor-link-control__search-results-label" id={ searchResultsLabelId }>
+				{ labelText }
+			</span>
+		);
 
 		return (
 			<div className="block-editor-link-control__search-results-wrapper">
-				{ isInitialSuggestions && (
-					<span className="block-editor-link-control__search-results-label" id={ searchResultsLabelId }>
-						{ labelText }
-					</span>
-				) }
+				{ ! isInitialSuggestions ? <VisuallyHidden>{ SearchResultsLabel }</VisuallyHidden> : SearchResultsLabel }
 
 				<div { ...suggestionsListProps } className={ resultsListClasses } aria-labelledby={ searchResultsLabelId }>
 					{ suggestions.map( ( suggestion, index ) => (

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -8,7 +8,7 @@ import { noop, startsWith } from 'lodash';
  * WordPress dependencies
  */
 import { Button, ExternalLink } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useCallback, useState, Fragment } from '@wordpress/element';
 
 import {
@@ -131,16 +131,24 @@ export function LinkControl( {
 	}, [ handleDirectEntry, fetchSearchSuggestions ] );
 
 	// Render Components
-	const renderSearchResults = ( { suggestionsListProps, buildSuggestionItemProps, suggestions, selectedSuggestion, isLoading } ) => {
+	const renderSearchResults = ( { suggestionsListProps, buildSuggestionItemProps, suggestions, selectedSuggestion, isLoading, isInitialSuggestions } ) => {
 		const resultsListClasses = classnames( 'block-editor-link-control__search-results', {
 			'is-loading': isLoading,
 		} );
 
 		const manualLinkEntryTypes = [ 'url', 'mailto', 'tel', 'internal' ];
+		const searchResultsLabelId = `block-editor-link-control-search-results-label-${ instanceId }`;
+		const labelText = isInitialSuggestions ? __( 'Recently modified' ) : sprintf( __( 'Search results for %s' ), inputValue );
 
 		return (
 			<div className="block-editor-link-control__search-results-wrapper">
-				<div { ...suggestionsListProps } className={ resultsListClasses }>
+				{ isInitialSuggestions && (
+					<span className="block-editor-link-control__search-results-label" id={ searchResultsLabelId }>
+						{ labelText }
+					</span>
+				) }
+
+				<div { ...suggestionsListProps } className={ resultsListClasses } aria-labelledby={ searchResultsLabelId }>
 					{ suggestions.map( ( suggestion, index ) => (
 						<LinkControlSearchItem
 							key={ `${ suggestion.id }-${ suggestion.type }` }

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -138,7 +138,7 @@ export function LinkControl( {
 
 		const manualLinkEntryTypes = [ 'url', 'mailto', 'tel', 'internal' ];
 		const searchResultsLabelId = `block-editor-link-control-search-results-label-${ instanceId }`;
-		const labelText = isInitialSuggestions ? __( 'Recently modified' ) : sprintf( __( 'Search results for %s' ), inputValue );
+		const labelText = isInitialSuggestions ? __( 'Recently updated' ) : sprintf( __( 'Search results for %s' ), inputValue );
 		const SearchResultsLabel = (
 			<span className="block-editor-link-control__search-results-label" id={ searchResultsLabelId }>
 				{ labelText }

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -147,7 +147,7 @@ export function LinkControl( {
 
 		return (
 			<div className="block-editor-link-control__search-results-wrapper">
-				{ ! isInitialSuggestions ? <VisuallyHidden>{ SearchResultsLabel }</VisuallyHidden> : SearchResultsLabel }
+				{ isInitialSuggestions ? SearchResultsLabel : <VisuallyHidden>{ SearchResultsLabel }</VisuallyHidden> }
 
 				<div { ...suggestionsListProps } className={ resultsListClasses } aria-labelledby={ searchResultsLabelId }>
 					{ suggestions.map( ( suggestion, index ) => (

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -137,7 +137,7 @@ export function LinkControl( {
 		} );
 
 		const manualLinkEntryTypes = [ 'url', 'mailto', 'tel', 'internal' ];
-		const searchResultsLabelId = isInitialSuggestions && `block-editor-link-control-search-results-label-${ instanceId }`;
+		const searchResultsLabelId = isInitialSuggestions ? `block-editor-link-control-search-results-label-${ instanceId }` : undefined;
 		const labelText = isInitialSuggestions ? __( 'Recently updated' ) : sprintf( __( 'Search results for %s' ), inputValue );
 		// According to guidelines aria-label should be added if the label
 		// itself is not visible.

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -67,6 +67,12 @@
 	}
 }
 
+.block-editor-link-control__search-results-label {
+	padding: 15px 30px 0 30px;
+	display: block;
+	font-size: 1.1em;
+}
+
 .block-editor-link-control__search-results {
 	margin: 0;
 	padding: $grid-size-large/2 $grid-size-large $grid-size-large;

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -329,7 +329,10 @@ describe( 'Default search suggestions', () => {
 		const searchInput = container.querySelector( 'input[aria-label="URL"]' );
 
 		// TODO: select these by aria relationship to autocomplete rather than arbitary selector.
-		const initialSearchResultElements = container.querySelectorAll( '[role="listbox"] [role="option"]' );
+		const searchResultsWrapper = container.querySelector( '[role="listbox"]' );
+		const initialSearchResultElements = searchResultsWrapper.querySelectorAll( '[role="option"]' );
+
+		const searchResultsLabel = container.querySelector( `#${ searchResultsWrapper.getAttribute( 'aria-labelledby' ) }` );
 
 		// Verify input has no value has default suggestions should only show
 		// when this does not have a value
@@ -342,6 +345,8 @@ describe( 'Default search suggestions', () => {
 
 		// Verify the search results already display the initial suggestions
 		expect( initialSearchResultElements ).toHaveLength( expectedResultsLength );
+
+		expect( searchResultsLabel.innerHTML ).toEqual( 'Recently modified' );
 	} );
 
 	it( 'should not display initial suggestions when input value is present', async () => {

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -346,7 +346,7 @@ describe( 'Default search suggestions', () => {
 		// Verify the search results already display the initial suggestions
 		expect( initialSearchResultElements ).toHaveLength( expectedResultsLength );
 
-		expect( searchResultsLabel.innerHTML ).toEqual( 'Recently modified' );
+		expect( searchResultsLabel.innerHTML ).toEqual( 'Recently updated' );
 	} );
 
 	it( 'should not display initial suggestions when input value is present', async () => {

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -298,6 +298,7 @@ class URLInput extends Component {
 			placeholder = __( 'Paste URL or type to search' ),
 			value = '',
 			autoFocus = true,
+			__experimentalShowInitialSuggestions = false,
 		} = this.props;
 
 		const {
@@ -365,6 +366,7 @@ class URLInput extends Component {
 					buildSuggestionItemProps,
 					isLoading: loading,
 					handleSuggestionClick: this.handleOnClick,
+					isInitialSuggestions: __experimentalShowInitialSuggestions && ! ( value && value.length ),
 				} ) }
 
 				{ ! isFunction( renderSuggestions ) && showSuggestions && !! suggestions.length &&

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -169,7 +169,7 @@ function NavigationLinkEdit( {
 							<LinkControl
 								className="wp-block-navigation-link__inline-link-input"
 								value={ link }
-								initialSuggestions={ true }
+								showInitialSuggestions={ true }
 								onChange={ ( {
 									title: newTitle = '',
 									url: newURL = '',


### PR DESCRIPTION
As per https://github.com/WordPress/gutenberg/issues/19513, this PR adds a label to the search results for initial suggestions.

**Note**: this does not attempt to address [this feedback](https://github.com/WordPress/gutenberg/issues/19513#issuecomment-573070658).

> Could the URL protocol be dropped?

This will be handled in another PR.

## How has this been tested?
* Unit tests
* Manual testing:

To test:

* Add Nav Block
* See initial search suggestions
* See "Recently modified" above search results.



## Screenshots <!-- if applicable -->

<img width="623" alt="Screenshot 2020-01-15 at 11 54 39" src="https://user-images.githubusercontent.com/444434/72431938-d57ee100-378d-11ea-9198-87b46180e7ed.png">

## Types of changes
New feature (non-breaking change which adds functionality)
## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
