### PR TITLE
Generates excerpt using core get_the_excerpt

### DIFF
--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -192,7 +192,7 @@ class LatestPostsEdit extends Component {
 					{ displayPosts.map( ( post, i ) => {
 						const titleTrimmed = post.title.rendered.trim();
 						let excerpt = post.excerpt.rendered;
-						if ( post.excerpt.raw === '' ) {
+						if ( excerpt === '' ) {
 							excerpt = post.content.raw;
 						}
 						const excerptElement = document.createElement( 'div' );

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -192,9 +192,7 @@ class LatestPostsEdit extends Component {
 					{ displayPosts.map( ( post, i ) => {
 						const titleTrimmed = post.title.rendered.trim();
 						let excerpt = post.excerpt.rendered;
-						if ( excerpt === '' ) {
-							excerpt = post.content.raw;
-						}
+
 						const excerptElement = document.createElement( 'div' );
 						excerptElement.innerHTML = excerpt;
 						excerpt = excerptElement.textContent || excerptElement.innerText || '';

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -29,8 +29,6 @@ function render_block_core_latest_posts( $attributes ) {
 
 	$list_items_markup = '';
 
-	$excerpt_length = $attributes['excerptLength'];
-
 	foreach ( $recent_posts as $post ) {
 		$title = get_the_title( $post );
 		if ( ! $title ) {

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -52,11 +52,8 @@ function render_block_core_latest_posts( $attributes ) {
 
 		if ( isset( $attributes['displayPostContent'] ) && $attributes['displayPostContent']
 			&& isset( $attributes['displayPostContentRadio'] ) && 'excerpt' === $attributes['displayPostContentRadio'] ) {
-			$post_excerpt = $post->post_excerpt;
-			if ( ! ( $post_excerpt ) ) {
-				$post_excerpt = $post->post_content;
-			}
-			$trimmed_excerpt = esc_html( wp_trim_words( $post_excerpt, $excerpt_length, ' &hellip; ' ) );
+
+			$trimmed_excerpt = get_the_excerpt( $post );
 
 			$list_items_markup .= sprintf(
 				'<div class="wp-block-latest-posts__post-excerpt">%1$s',


### PR DESCRIPTION
## Description
Closes #19418 

## How has this been tested?
Tested locally in browser by making some posts with embedded tweets and then another using the latest posts block.

The way to test:
- make a post or more with some tweet embeds and some text.
- mare sure the embed is close to the start of the post.
- make a post and use the latest posts block
- set the block to show excerpt
- there should be no tweet links in the excerpt

## Types of changes
The latest posts block does, I believe, two wrong things about the excerpt:

- in the server side renderer it uses a custom way to get the excerpt which bypasses the core function that among other things renders only allowed blocks, strips shortcodes and a lot more.
- in the client side renderer it gets the rendered excerpt and then wrongfully checks for the raw excerpt, which may be empty if post has no manual excerpt, resetting the rendered excerpt with the raw post content.

This is what this PR fixes.