### PR TITLE
Embed: Fix failure placeholder alignment/sizing

### DIFF
--- a/packages/block-library/src/embed/embed-placeholder.js
+++ b/packages/block-library/src/embed/embed-placeholder.js
@@ -36,7 +36,9 @@ const EmbedPlaceholder = ( props ) => {
 			</div>
 			{ cannotEmbed &&
 				<div className="components-placeholder__error">
-					{ __( 'Sorry, this content could not be embedded.' ) }<br />
+					<div className="components-placeholder__instructions">
+						{ __( 'Sorry, this content could not be embedded.' ) }
+					</div>
 					<Button isSecondary onClick={ tryAgain }>{ _x( 'Try again', 'button label' ) }</Button> <Button isSecondary onClick={ fallback }>{ _x( 'Convert to link', 'button label' ) }</Button>
 				</div>
 			}

--- a/packages/block-library/src/embed/embed-placeholder.js
+++ b/packages/block-library/src/embed/embed-placeholder.js
@@ -28,18 +28,18 @@ const EmbedPlaceholder = ( props ) => {
 				>
 					{ _x( 'Embed', 'button label' ) }
 				</Button>
-				{ cannotEmbed &&
-					<p className="components-placeholder__error">
-						{ __( 'Sorry, this content could not be embedded.' ) }<br />
-						<Button isSecondary onClick={ tryAgain }>{ _x( 'Try again', 'button label' ) }</Button> <Button isSecondary onClick={ fallback }>{ _x( 'Convert to link', 'button label' ) }</Button>
-					</p>
-				}
 			</form>
 			<div className="components-placeholder__learn-more">
 				<ExternalLink href={ __( 'https://wordpress.org/support/article/embeds/' ) }>
 					{ __( 'Learn more about embeds' ) }
 				</ExternalLink>
 			</div>
+			{ cannotEmbed &&
+				<div className="components-placeholder__error">
+					{ __( 'Sorry, this content could not be embedded.' ) }<br />
+					<Button isSecondary onClick={ tryAgain }>{ _x( 'Try again', 'button label' ) }</Button> <Button isSecondary onClick={ fallback }>{ _x( 'Convert to link', 'button label' ) }</Button>
+				</div>
+			}
 		</Placeholder>
 	);
 };

--- a/packages/block-library/src/table/editor.scss
+++ b/packages/block-library/src/table/editor.scss
@@ -63,6 +63,10 @@
 		}
 	}
 
+	.components-base-control__field {
+		margin-bottom: 0;
+	}
+
 	.wp-block-table__placeholder-button {
 		margin-top: auto;
 		margin-right: auto;

--- a/packages/components/src/placeholder/style.scss
+++ b/packages/components/src/placeholder/style.scss
@@ -26,6 +26,7 @@
 	}
 }
 
+.components-placeholder__error,
 .components-placeholder__instructions,
 .components-placeholder__label,
 .components-placeholder__fieldset {
@@ -72,6 +73,11 @@
 
 .components-placeholder__instructions {
 	margin-bottom: 1em;
+}
+
+.components-placeholder__error {
+	margin-top: 1em;
+	width: 100%;
 }
 
 .components-placeholder__preview img {


### PR DESCRIPTION
## Description
This update fixes the positioning, alignment, and sizing of the error message that appears in the `Embed` block, specifically when there is an error.

## How has this been tested?
* Tested locally
* Deliberately caused an error in Embedding to cause the message to show
* Ensure the UI looks correct for Embed URL, as well as other Embed placeholders

## Screenshots

<img width="746" alt="Screen Shot 2020-01-15 at 10 06 25 AM" src="https://user-images.githubusercontent.com/2322354/72445563-e6c0f100-377f-11ea-8cfe-ee3b42642b53.png">

In the above screenshot, we can see that the placeholder sizing/alignment appear correctly for regular embeds, table embeds, and embeds with errors.

## Types of changes
* Adjusted HTML markup structure of the Embed placeholder in order to resolve issue caused by `display: flex` wrapper
* Adjusted CSS to ensure proper sizing/alignment
* Replaced the `p` tag with a `div` to avoid inheriting `p` styles from the editor. I felt like this was okay, considering the instructions HTML selector was also a `div`

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.

Resolves https://github.com/WordPress/gutenberg/issues/19662