### PR TITLE
FormTokenField: Make it possible to add children

### DIFF
--- a/packages/components/src/form-token-field/index.js
+++ b/packages/components/src/form-token-field/index.js
@@ -599,6 +599,7 @@ class FormTokenField extends Component {
 						/>
 					) }
 				</div>
+				{ this.props.children }
 				<p id={ `components-form-token-suggestions-howto-${ instanceId }` } className="components-form-token-field__help">
 					{ this.props.tokenizeOnSpace ?
 						__( 'Separate with commas, spaces, or the Enter key.' ) :


### PR DESCRIPTION
## Description
This makes it possible to add children to FormTokenField. There are cases where we want to use this component within a form and we'd like to add a button, but it's hard to do so. This PR will make it simpler

## How has this been tested?
Try adding a child component to FormTokenField

## Screenshots <!-- if applicable -->
This adds a "test" paragraph
<img width="477" alt="Screenshot 2020-01-15 at 16 13 29" src="https://user-images.githubusercontent.com/275961/72450281-fbb67800-37b1-11ea-943b-90ec358f22a1.png">


## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
