### PR TITLE
Improve README for `<LinkControl />` with historical context and props docs.

### DIFF
--- a/packages/block-editor/src/components/link-control/README.md
+++ b/packages/block-editor/src/components/link-control/README.md
@@ -24,7 +24,7 @@ an experimental component which would consume `URLInput` internally. The API of
 facilitate the implementation of the new UI with the goal of eventually phasing
 out the use of `URLInput` entirely.
 
-Indeed, over time, is is expected that `URLInput` will be depracted in favour of
+Indeed, over time, is is expected that `URLInput` will be deprecated in favour of
 lower-level presentation components (eg: `<Combobox>`) which will not be tightly
 coupled to the concept of URL entry. This will allow `LinkControl` to become the
 canonical UI component for the creation of hyperlinks and will enable the
@@ -110,4 +110,3 @@ The function callback will receive the selected item, or Null.
 	}
 />
 ```
-

--- a/packages/block-editor/src/components/link-control/README.md
+++ b/packages/block-editor/src/components/link-control/README.md
@@ -76,7 +76,7 @@ Default properties include:
 ];
 ```
 
-An array of settings objects associated with a link (for example: a setting to determine whether or not the link opens in a new tab). Each object will used to render a `ToggleControl` for that setting.
+An array of settings objects associated with a link (for example: a setting to determine whether or not the link opens in a new tab). Each object will be used to render a `ToggleControl` for that setting.
 
 ### onClose
 

--- a/packages/block-editor/src/components/link-control/README.md
+++ b/packages/block-editor/src/components/link-control/README.md
@@ -117,7 +117,7 @@ If passed as either `true` or `false`, controls the internal editing state of th
 
 - Type: `function`
 - Required: No
-- Returns: when called may return either a new `suggestion` directly or a `Promise` which resolves to a
+- Returns: When called may return either a new `suggestion` directly or a `Promise` which resolves to a
 new `suggestion`.
 
 Used to handle the dynamic creation of a new `suggestion` (and ultimately new link `value`) within the Link UI.

--- a/packages/block-editor/src/components/link-control/README.md
+++ b/packages/block-editor/src/components/link-control/README.md
@@ -1,7 +1,11 @@
 # Link Control
 
-`<LinkControl>` is a component designed to provide a standardized UI for the
-creation of hyperlinks within the Editor.
+Renders a link control. A link control is a controlled input which maintains a
+value associated with a link (HTML anchor element) and relevant settings for how
+that link is expected to behave.
+
+It is designed to provide a standardized UI for the
+creation of link throughout the Editor.
 
 
 ## History
@@ -81,17 +85,20 @@ It is however, possible to provide your own entity search handler via the `fetch
 
 ## Props
 
-`<LinkControl>` supports the following `props`:
-
-### className
-
-- Type: `String`
-- Required: Yes
-
 ### value
 
 - Type: `Object`
-- Required: Yes
+- Required: No
+
+Current link value.
+
+A link value contains is composed as a union of the default properties and any custom settings values.
+
+Default properties include:
+
+- `url` (`string`): Link URL.
+- `title` (`string`, optional): Link title.
+- `opensInNewTab` (`boolean`, optional): Whether link should open in a new browser tab.This value is only assigned if not providing a custom `settings` prop.
 
 ### settings
 
@@ -102,18 +109,14 @@ It is however, possible to provide your own entity search handler via the `fetch
 [
 	{
 		id: 'opensInNewTab',
-		title: 'Open in New Tab',
+		title: 'Open in new tab',
 	},
 ];
 ```
 
-An array of settings objects. Each object will used to render a `ToggleControl`
-for that setting.
+An array of settings objects. Each object will used to render a `ToggleControl` for that setting.
 
-You may choose to provide additional settings by providing an alternative array
-of setting objects.
-
-### fetchSearchSuggestions
+### onClose
 
 - Type: `Function`
 - Required: No
@@ -123,15 +126,84 @@ of setting objects.
 - Type: `Function`
 - Required: No
 
-Use this callback to take an action after a user set or updated a link.
-The function callback will receive the selected item, or Null.
+Value change handler, called with the updated value if the user selects a new link or updates settings.
 
-```es6
+```jsx
 <LinkControl
-	onLinkChange={ ( item ) => {
-		item
-			? console.log( `The item selected has the ${ item.id } id.` )
-			: console.warn( 'No Item selected.' );
+	onChange={ ( nextValue ) => {
+		console.log( `The selected item URL: ${ nextValue.url }.` );
 	}
+/>
+```
+
+### showInitialSuggestions
+
+- Type: `boolean`
+- Required: No
+- Default: `false`
+
+Whether to present initial suggestions immediately.
+
+### forceIsEditingLink
+
+- Type: `boolean`
+- Required: No
+
+If passed as either `true` or `false`, controls the internal editing state of the component to respective show or not show the URL input field.
+
+
+### createSuggestion
+
+- Type: `function`
+- Required: No
+
+Used to handle the dynamic creation of new suggestions within the Link UI. When
+the prop is provided, an option is added to the end of all search
+results requests which when clicked will call `createSuggestion` callback
+(passing the current value of the search `<input>`) in
+order to afford the parent component the opportunity to dynamically create a new
+link `value` (see above).
+
+This is often used to allow on-the-fly creation of new entities (eg: `Posts`,
+`Pages`) based on the text the user has entered into the link search UI. For
+example, the Navigation Block uses this to create Pages on demand.
+
+When called, `createSuggestion` may return either a new suggestion directly or a `Promise` which resolves to a
+new suggestion. Suggestions have the following shape:
+
+```js
+{
+	id: // unique identifier
+	type: // "url", "page", "post"...etc
+	title: // "My new suggestion"
+	url: // any string representing the URL value
+}
+```
+
+#### Example
+```jsx
+// Promise example
+<LinkControl
+	createSuggestion={ async (inputText) => {
+        // Hard coded values. These could be dynamically created by calling out to an API which creates an entity (eg: https://developer.wordpress.org/rest-api/reference/pages/#create-a-page).
+		return {
+			id: 1234,
+			type: 'page',
+			title: inputText,
+			url: '/some-url-here'
+		}
+	}}
+/>
+
+// Non-Promise example
+<LinkControl
+	createSuggestion={ (inputText) => (
+		{
+			id: 1234,
+			type: 'page',
+			title: inputText,
+			url: '/some-url-here'
+		}
+	)}
 />
 ```

--- a/packages/block-editor/src/components/link-control/README.md
+++ b/packages/block-editor/src/components/link-control/README.md
@@ -35,7 +35,7 @@ Currently LinkControl will handle two types of input to create hyperlinks:
 1. Entity searches - the user may input text-based search queries for entities retrieved from remove data sources (in the context of WordPress these are `Pages`). For example a user might search for a `Page` they have just created by name (eg: About) and the UI will return a matching result if found.
 2. Direct entry - the user may also enter any arbitrary URL-like text. This includes full URLs (https://), URL fragements (eg: `#myinternallink`), `tel` protocol links (eg: `tel: 0800 1234`) and `mailto` protocol links (eg: `mailto: hello@wordpress.org`).
 
-In addition, `<LinkControl>` also allows for on-the-fly creation of links based on the **current content of the `<input>` element**. When enabled, a default "Create new" search suggestion is appended to all non-URL-like search results.
+In addition, `<LinkControl>` also allows for on the fly creation of links based on the **current content of the `<input>` element**. When enabled, a default "Create new" search suggestion is appended to all non-URL-like search results.
 
 When this suggestion is selected it will call the `createSuggestion` prop affording the developer the ability to create new links on the fly (the [Navigation Block uses this to allow creation of Pages
 from within the Block](https://github.com/WordPress/gutenberg/pull/19775/files)). See below for more details.
@@ -126,7 +126,7 @@ When provided, an option is appended to all search results requests which when c
 
 This `suggestion` will then be _automatically_ passed to the `onChange` handler to create **the next link value**.
 
-As a result of the above, this prop is often used to allow on-the-fly creation of new entities (eg: `Posts`, `Pages`) based on the text the user has entered into the link search UI. As an example, the Navigation Block uses `createSuggestion` to create Pages on the fly from within the Block itself.
+As a result of the above, this prop is often used to allow on the fly creation of new entities (eg: `Posts`, `Pages`) based on the text the user has entered into the link search UI. As an example, the Navigation Block uses `createSuggestion` to create Pages on the fly from within the Block itself.
 
 
 

--- a/packages/block-editor/src/components/link-control/README.md
+++ b/packages/block-editor/src/components/link-control/README.md
@@ -81,8 +81,6 @@ By default LinkControl utilizes the `__experimentalFetchLinkSuggestions` API
 from `core/block-editor` in order to retrieve search suggestions for matching
 `Page` post-type entities.
 
-It is however, possible to provide your own entity search handler via the `fetchSearchSuggestions` prop.
-
 ## Props
 
 ### value

--- a/packages/block-editor/src/components/link-control/README.md
+++ b/packages/block-editor/src/components/link-control/README.md
@@ -30,7 +30,7 @@ The distinction between the two components is perhaps best represented as:
 
 ## Search Suggestions
 
-Currently LinkControl will handle two types of input to create hyperlinks:
+Currently `LinkControl` will handle two types of input to create hyperlinks:
 
 1. Entity searches - the user may input text-based search queries for entities retrieved from remove data sources (in the context of WordPress these are `Pages`). For example a user might search for a `Page` they have just created by name (eg: About) and the UI will return a matching result if found.
 2. Direct entry - the user may also enter any arbitrary URL-like text. This includes full URLs (https://), URL fragements (eg: `#myinternallink`), `tel` protocol links (eg: `tel: 0800 1234`) and `mailto` protocol links (eg: `mailto: hello@wordpress.org`).
@@ -42,7 +42,7 @@ from within the Block](https://github.com/WordPress/gutenberg/pull/19775/files))
 
 ### Data sources
 
-By default LinkControl utilizes the `__experimentalFetchLinkSuggestions` API from `core/block-editor` in order to retrieve search suggestions for matching `Page` post-type entities.
+By default `LinkControl` utilizes the `__experimentalFetchLinkSuggestions` API from `core/block-editor` in order to retrieve search suggestions for matching `Page` post-type entities.
 
 ## Props
 

--- a/packages/block-editor/src/components/link-control/README.md
+++ b/packages/block-editor/src/components/link-control/README.md
@@ -1,7 +1,12 @@
 # Link Control
 
 `<LinkControl>` is a component designed to provide a standardized UI for the
-creation of hyperlinks within the Editor. Much of the context for this component
+creation of hyperlinks within the Editor.
+
+
+## History
+
+Much of the context for this component
 can be found in [the original Issue](https://github.com/WordPress/gutenberg/issues/17557).
 
 Previously iterations of a hyperlink UI existed within the Gutenberg interface
@@ -24,13 +29,26 @@ an experimental component which would consume `URLInput` internally. The API of
 facilitate the implementation of the new UI with the goal of eventually phasing
 out the use of `URLInput` entirely.
 
-Indeed, over time, is is expected that `URLInput` will be deprecated in favour of
-lower-level presentation components (eg: `<Combobox>`) which will not be tightly
-coupled to the concept of URL entry. This will allow `LinkControl` to become the
-canonical UI component for the creation of hyperlinks and will enable the
-simplification of the more complex internal mechanics of `LinkControl` which are
-currently necessary to enable it to mesh well with the older APIs exposed by
-`URLInput`.
+
+## Relationship to `<URLInput>`
+
+As of Gutenberg 7.4, `<LinkControl> became the default link creation interface
+within the Block Editor, replacing previous disparate uses of `<URLInput>` and
+standardising the UI.
+
+Nonetheless, it should be remembered that `<LinkControl>` builds **on top of**
+`<URLInput>` and makes use of it under the hood.
+
+The distinction between the two components is perhaps best represented as:
+
+* `<URLInput>` - an input for presenting and managing selection behaviors
+  associated with choosing a URL, optionally from a pool of available
+  candidates.
+* `<LinkControl>` - includes the features of `<URLInput>` , plus additional
+  UI and behaviors to control how this URL applies to the concept of a "link". This includes link
+  "settings" (eg: "opens in new tab", etc) and dynamic, "on the fly" link
+  creation capabilities.
+
 
 ## Search Suggestions
 
@@ -45,6 +63,14 @@ Currently LinkControl will handle two types of input to create hyperlinks:
    protocol links (eg: `tel: 0800 1234`) and `mailto` protocol links (eg:
    `mailto: hello@wordpress.org).
 
+In addition, `<LinkControl>` also allows for on-the-fly creation of links based
+on the **current content of the `<input>` element**. When enabled, a default
+"Create new" search suggestion is appended to all non-URL-like search results.
+When this suggestion is
+selected it will call the `createSuggestion` prop affording the developer the ability to create
+new links on the fly (the [Navigation Block uses this to allow creation of Pages
+from within the Block](https://github.com/WordPress/gutenberg/pull/19775/files)). See below for more details.
+
 ### Data sources
 
 By default LinkControl utilizes the `__experimentalFetchLinkSuggestions` API
@@ -54,6 +80,8 @@ from `core/block-editor` in order to retrieve search suggestions for matching
 It is however, possible to provide your own entity search handler via the `fetchSearchSuggestions` prop.
 
 ## Props
+
+`<LinkControl>` supports the following `props`:
 
 ### className
 
@@ -79,16 +107,13 @@ It is however, possible to provide your own entity search handler via the `fetch
 ];
 ```
 
-An array of settings objects. Each object will used to render a `ToggleControl` for that setting.
+An array of settings objects. Each object will used to render a `ToggleControl`
+for that setting.
+
+You may choose to provide additional settings by providing an alternative array
+of setting objects.
 
 ### fetchSearchSuggestions
-
-- Type: `Function`
-- Required: No
-
-## Event handlers
-
-### onClose
 
 - Type: `Function`
 - Required: No

--- a/packages/block-editor/src/components/link-control/README.md
+++ b/packages/block-editor/src/components/link-control/README.md
@@ -90,13 +90,16 @@ from `core/block-editor` in order to retrieve search suggestions for matching
 
 Current link value.
 
-A link value contains is composed as a union of the default properties and any custom settings values.
+A link `value` is composed of a union between the values of default link properties and any
+custom link `settings`.
 
 Default properties include:
 
 - `url` (`string`): Link URL.
 - `title` (`string`, optional): Link title.
-- `opensInNewTab` (`boolean`, optional): Whether link should open in a new browser tab.This value is only assigned if not providing a custom `settings` prop.
+- `opensInNewTab` (`boolean`, optional): Whether link should open in a new
+  browser tab. This value is only assigned if not providing a custom `settings`
+  prop.
 
 ### settings
 
@@ -112,7 +115,9 @@ Default properties include:
 ];
 ```
 
-An array of settings objects. Each object will used to render a `ToggleControl` for that setting.
+An array of settings objects associated with a link (for example: a setting to
+determine whether or not the link
+opens in a new tab). Each object will used to render a `ToggleControl` for that setting.
 
 ### onClose
 
@@ -147,36 +152,49 @@ Whether to present initial suggestions immediately.
 - Type: `boolean`
 - Required: No
 
-If passed as either `true` or `false`, controls the internal editing state of the component to respective show or not show the URL input field.
+If passed as either `true` or `false`, controls the internal editing state of
+the component to respectively show or not to show the URL input field.
 
 
 ### createSuggestion
 
 - Type: `function`
 - Required: No
+- Returns: when called may return either a new `suggestion` directly or a `Promise` which resolves to a
+new `suggestion`.
 
-Used to handle the dynamic creation of new suggestions within the Link UI. When
-the prop is provided, an option is added to the end of all search
-results requests which when clicked will call `createSuggestion` callback
-(passing the current value of the search `<input>`) in
-order to afford the parent component the opportunity to dynamically create a new
-link `value` (see above).
+Used to handle the dynamic creation of a new `suggestion` (and ultimately new link
+`value`) within the Link UI.
 
-This is often used to allow on-the-fly creation of new entities (eg: `Posts`,
-`Pages`) based on the text the user has entered into the link search UI. For
-example, the Navigation Block uses this to create Pages on demand.
+When provided, an option is appended to all search
+results requests which when clicked will call the `createSuggestion` callback
+(passing the current value of the search `<input>`). This affords the parent component the opportunity to dynamically create a new
+link `suggestion` (see above).
 
-When called, `createSuggestion` may return either a new suggestion directly or a `Promise` which resolves to a
-new suggestion. Suggestions have the following shape:
+This `suggestion` will then be _automatically_ passed to the
+`onChange` handler to create **the next link value**.
+
+As a result of the above, this prop is often used to allow on-the-fly creation of new entities (eg: `Posts`,
+`Pages`) based on the text the user has entered into the link search UI. As an
+example, the Navigation Block uses `createSuggestion` to create Pages on fly
+from within the Block itself.
+
+
+
+#### Search `suggestion` values
+
+A `suggestion` should have the following shape:
 
 ```js
 {
-	id: // unique identifier
-	type: // "url", "page", "post"...etc
-	title: // "My new suggestion"
-	url: // any string representing the URL value
+	id: // uniquely identifies the suggestion.
+	type: // the type of the suggestion (eg: `post`).
+	title: // Human-readable label for the suggestion.
+	url: // any string representing a URL value
 }
 ```
+
+
 
 #### Example
 ```jsx

--- a/packages/block-editor/src/components/link-control/README.md
+++ b/packages/block-editor/src/components/link-control/README.md
@@ -37,8 +37,7 @@ Currently `LinkControl` will handle two types of input to create hyperlinks:
 
 In addition, `<LinkControl>` also allows for on the fly creation of links based on the **current content of the `<input>` element**. When enabled, a default "Create new" search suggestion is appended to all non-URL-like search results.
 
-When this suggestion is selected it will call the `createSuggestion` prop affording the developer the ability to create new links on the fly (the [Navigation Block uses this to allow creation of Pages
-from within the Block](https://github.com/WordPress/gutenberg/pull/19775/files)). See below for more details.
+When this suggestion is selected it will call the `createSuggestion` prop affording the developer the ability to create new links on the fly (the [Navigation Block uses this to allow creation of Pages from within the Block](https://github.com/WordPress/gutenberg/pull/19775/files)). See below for more details.
 
 ### Data sources
 

--- a/packages/block-editor/src/components/link-control/README.md
+++ b/packages/block-editor/src/components/link-control/README.md
@@ -13,8 +13,7 @@ Previously iterations of a hyperlink UI existed within the Gutenberg interface b
 
 These older UIs tended to make use of two existing components: `URLInput` and `URLPopover`. When a requirement was raised to implement a new UI for hyperlink creation, an assessment of these existing components was undertaken and it was determined that they were too opinionated as to be easily refactored to accommodate the new use cases required by the new UI. Attempting to do so would also have meant unavoidable breaking changes to the interface of `URLInput` which would have (most probably) caused breaking changes to ripple across not only the Core codebase, but also that of 3rd party Plugins.
 
-As a result, it was agreed that a new component `LinkControl` would be created to realise the new hyperlink creation interface. This new UI would begin life as an experimental component which would consume `URLInput` internally. The API of `URLInput` would be enhanced as required with "experimental" features to facilitate the implementation of the new UI with the goal of eventually phasing
-out the use of `URLInput` entirely.
+As a result, it was agreed that a new component `LinkControl` would be created to realise the new hyperlink creation interface. This new UI would begin life as an experimental component which would consume `URLInput` internally. The API of `URLInput` would be enhanced as required with "experimental" features to facilitate the implementation of the new UI with the goal of eventually phasing out the use of `URLInput` entirely.
 
 
 ## Relationship to `<URLInput>`

--- a/packages/block-editor/src/components/link-control/README.md
+++ b/packages/block-editor/src/components/link-control/README.md
@@ -1,85 +1,49 @@
 # Link Control
 
-Renders a link control. A link control is a controlled input which maintains a
-value associated with a link (HTML anchor element) and relevant settings for how
-that link is expected to behave.
+Renders a link control. A link control is a controlled input which maintains a value associated with a link (HTML anchor element) and relevant settings for how that link is expected to behave.
 
-It is designed to provide a standardized UI for the
-creation of link throughout the Editor.
+It is designed to provide a standardized UI for the creation of link throughout the Editor.
 
 
 ## History
 
-Much of the context for this component
-can be found in [the original Issue](https://github.com/WordPress/gutenberg/issues/17557).
+Much of the context for this component can be found in [the original Issue](https://github.com/WordPress/gutenberg/issues/17557).
 
-Previously iterations of a hyperlink UI existed within the Gutenberg interface
-but these tended to be highly tailored to their individual use cases and were
-not standardised, each having their own implementation.
+Previously iterations of a hyperlink UI existed within the Gutenberg interface but these tended to be highly tailored to their individual use cases and were not standardized, each having their own implementation.
 
-These older UIs tended to make use of two existing components: `URLInput` and
-`URLPopover`. When a requirement was raised to implement a new UI for hyperlink
-creation, an assessment of these existing components was undertaken and it was
-determined that they were too opinionated as to be easily refactored to
-accommodate the new use cases required by the new UI. Attempting to do so would
-also have meant unavoidable breaking changes to the interface of `URLInput`
-which would have (most probably) caused breaking changes to ripple across not
-only the Core codebase, but also that of 3rd party Plugins.
+These older UIs tended to make use of two existing components: `URLInput` and `URLPopover`. When a requirement was raised to implement a new UI for hyperlink creation, an assessment of these existing components was undertaken and it was determined that they were too opinionated as to be easily refactored to accommodate the new use cases required by the new UI. Attempting to do so would also have meant unavoidable breaking changes to the interface of `URLInput` which would have (most probably) caused breaking changes to ripple across not only the Core codebase, but also that of 3rd party Plugins.
 
-As a result, it was agreed that a new component `LinkControl` would be created
-to realise the new hyperlink creation interface. This new UI would begin life as
-an experimental component which would consume `URLInput` internally. The API of
-`URLInput` would be enhanced as required with "experimental" features to
-facilitate the implementation of the new UI with the goal of eventually phasing
+As a result, it was agreed that a new component `LinkControl` would be created to realise the new hyperlink creation interface. This new UI would begin life as an experimental component which would consume `URLInput` internally. The API of `URLInput` would be enhanced as required with "experimental" features to facilitate the implementation of the new UI with the goal of eventually phasing
 out the use of `URLInput` entirely.
 
 
 ## Relationship to `<URLInput>`
 
-As of Gutenberg 7.4, `<LinkControl>` became the default link creation interface
-within the Block Editor, replacing previous disparate uses of `<URLInput>` and
-standardizing the UI.
+As of Gutenberg 7.4, `<LinkControl>` became the default link creation interface within the Block Editor, replacing previous disparate uses of `<URLInput>` and standardizing the UI.
 
-Nonetheless, it should be remembered that `<LinkControl>` builds **on top of**
-`<URLInput>` and makes use of it under the hood.
+Nonetheless, it should be remembered that `<LinkControl>` builds **on top of** `<URLInput>` and makes use of it under the hood.
 
 The distinction between the two components is perhaps best represented as:
 
-* `<URLInput>` - an input for presenting and managing selection behaviors
-  associated with choosing a URL, optionally from a pool of available
-  candidates.
-* `<LinkControl>` - includes the features of `<URLInput>` , plus additional
-  UI and behaviors to control how this URL applies to the concept of a "link". This includes link
-  "settings" (eg: "opens in new tab", etc) and dynamic, "on the fly" link
-  creation capabilities.
+* `<URLInput>` - an input for presenting and managing selection behaviors associated with choosing a URL, optionally from a pool of available candidates.
+* `<LinkControl>` - includes the features of `<URLInput>`, plus additional UI and behaviors to control how this URL applies to the concept of a "link". This includes link "settings" (eg: "opens in new tab", etc) and dynamic, "on the fly" link creation capabilities.
 
 
 ## Search Suggestions
 
 Currently LinkControl will handle two types of input to create hyperlinks:
 
-1. Entity searches - the user may input text-based search queries for entities retrieved from
-   remove data sources (in the context of WordPress these are `Pages`). For
-   example a user might search for a `Page` they have just created by name (eg:
-   About) and the UI will return a matching result if found.
-2. Direct entry - the user may also enter any arbitrary URL-like text. This
-   includes full URLs (https://), URL fragements (eg: `#myinternallink`), `tel`
-   protocol links (eg: `tel: 0800 1234`) and `mailto` protocol links (eg:
-   `mailto: hello@wordpress.org).
+1. Entity searches - the user may input text-based search queries for entities retrieved from remove data sources (in the context of WordPress these are `Pages`). For example a user might search for a `Page` they have just created by name (eg: About) and the UI will return a matching result if found.
+2. Direct entry - the user may also enter any arbitrary URL-like text. This includes full URLs (https://), URL fragements (eg: `#myinternallink`), `tel` protocol links (eg: `tel: 0800 1234`) and `mailto` protocol links (eg: `mailto: hello@wordpress.org).
 
-In addition, `<LinkControl>` also allows for on-the-fly creation of links based
-on the **current content of the `<input>` element**. When enabled, a default
-"Create new" search suggestion is appended to all non-URL-like search results.
-When this suggestion is
-selected it will call the `createSuggestion` prop affording the developer the ability to create
-new links on the fly (the [Navigation Block uses this to allow creation of Pages
+In addition, `<LinkControl>` also allows for on-the-fly creation of links based on the **current content of the `<input>` element**. When enabled, a default "Create new" search suggestion is appended to all non-URL-like search results.
+
+When this suggestion is selected it will call the `createSuggestion` prop affording the developer the ability to create new links on the fly (the [Navigation Block uses this to allow creation of Pages
 from within the Block](https://github.com/WordPress/gutenberg/pull/19775/files)). See below for more details.
 
 ### Data sources
 
-By default LinkControl utilizes the `__experimentalFetchLinkSuggestions` API
-from `core/block-editor` in order to retrieve search suggestions for matching
-`Page` post-type entities.
+By default LinkControl utilizes the `__experimentalFetchLinkSuggestions` API from `core/block-editor` in order to retrieve search suggestions for matching `Page` post-type entities.
 
 ## Props
 
@@ -90,16 +54,13 @@ from `core/block-editor` in order to retrieve search suggestions for matching
 
 Current link value.
 
-A link `value` is composed of a union between the values of default link properties and any
-custom link `settings`.
+A link `value` is composed of a union between the values of default link properties and any custom link `settings`.
 
 Default properties include:
 
 - `url` (`string`): Link URL.
 - `title` (`string`, optional): Link title.
-- `opensInNewTab` (`boolean`, optional): Whether link should open in a new
-  browser tab. This value is only assigned if not providing a custom `settings`
-  prop.
+- `opensInNewTab` (`boolean`, optional): Whether link should open in a new browser tab. This value is only assigned if not providing a custom `settings` prop.
 
 ### settings
 
@@ -115,9 +76,7 @@ Default properties include:
 ];
 ```
 
-An array of settings objects associated with a link (for example: a setting to
-determine whether or not the link
-opens in a new tab). Each object will used to render a `ToggleControl` for that setting.
+An array of settings objects associated with a link (for example: a setting to determine whether or not the link opens in a new tab). Each object will used to render a `ToggleControl` for that setting.
 
 ### onClose
 
@@ -152,8 +111,7 @@ Whether to present initial suggestions immediately.
 - Type: `boolean`
 - Required: No
 
-If passed as either `true` or `false`, controls the internal editing state of
-the component to respectively show or not to show the URL input field.
+If passed as either `true` or `false`, controls the internal editing state of the component to respectively show or not to show the URL input field.
 
 
 ### createSuggestion
@@ -163,21 +121,13 @@ the component to respectively show or not to show the URL input field.
 - Returns: when called may return either a new `suggestion` directly or a `Promise` which resolves to a
 new `suggestion`.
 
-Used to handle the dynamic creation of a new `suggestion` (and ultimately new link
-`value`) within the Link UI.
+Used to handle the dynamic creation of a new `suggestion` (and ultimately new link `value`) within the Link UI.
 
-When provided, an option is appended to all search
-results requests which when clicked will call the `createSuggestion` callback
-(passing the current value of the search `<input>`). This affords the parent component the opportunity to dynamically create a new
-link `suggestion` (see above).
+When provided, an option is appended to all search results requests which when clicked will call the `createSuggestion` callback (passing the current value of the search `<input>`). This affords the parent component the opportunity to dynamically create a new link `suggestion` (see above).
 
-This `suggestion` will then be _automatically_ passed to the
-`onChange` handler to create **the next link value**.
+This `suggestion` will then be _automatically_ passed to the `onChange` handler to create **the next link value**.
 
-As a result of the above, this prop is often used to allow on-the-fly creation of new entities (eg: `Posts`,
-`Pages`) based on the text the user has entered into the link search UI. As an
-example, the Navigation Block uses `createSuggestion` to create Pages on fly
-from within the Block itself.
+As a result of the above, this prop is often used to allow on-the-fly creation of new entities (eg: `Posts`, `Pages`) based on the text the user has entered into the link search UI. As an example, the Navigation Block uses `createSuggestion` to create Pages on fly from within the Block itself.
 
 
 

--- a/packages/block-editor/src/components/link-control/README.md
+++ b/packages/block-editor/src/components/link-control/README.md
@@ -127,7 +127,7 @@ When provided, an option is appended to all search results requests which when c
 
 This `suggestion` will then be _automatically_ passed to the `onChange` handler to create **the next link value**.
 
-As a result of the above, this prop is often used to allow on-the-fly creation of new entities (eg: `Posts`, `Pages`) based on the text the user has entered into the link search UI. As an example, the Navigation Block uses `createSuggestion` to create Pages on fly from within the Block itself.
+As a result of the above, this prop is often used to allow on-the-fly creation of new entities (eg: `Posts`, `Pages`) based on the text the user has entered into the link search UI. As an example, the Navigation Block uses `createSuggestion` to create Pages on the fly from within the Block itself.
 
 
 

--- a/packages/block-editor/src/components/link-control/README.md
+++ b/packages/block-editor/src/components/link-control/README.md
@@ -43,6 +43,7 @@ When this suggestion is selected it will call the `createSuggestion` prop afford
 
 By default `LinkControl` utilizes the `__experimentalFetchLinkSuggestions` API from `core/block-editor` in order to retrieve search suggestions for matching `Page` post-type entities.
 
+
 ## Props
 
 ### value
@@ -111,7 +112,6 @@ Whether to present initial suggestions immediately.
 
 If passed as either `true` or `false`, controls the internal editing state of the component to respectively show or not to show the URL input field.
 
-
 ### createSuggestion
 
 - Type: `function`
@@ -127,8 +127,6 @@ This `suggestion` will then be _automatically_ passed to the `onChange` handler 
 
 As a result of the above, this prop is often used to allow on the fly creation of new entities (eg: `Posts`, `Pages`) based on the text the user has entered into the link search UI. As an example, the Navigation Block uses `createSuggestion` to create Pages on the fly from within the Block itself.
 
-
-
 #### Search `suggestion` values
 
 A `suggestion` should have the following shape:
@@ -141,8 +139,6 @@ A `suggestion` should have the following shape:
 	url: // any string representing a URL value
 }
 ```
-
-
 
 #### Example
 ```jsx

--- a/packages/block-editor/src/components/link-control/README.md
+++ b/packages/block-editor/src/components/link-control/README.md
@@ -36,9 +36,9 @@ out the use of `URLInput` entirely.
 
 ## Relationship to `<URLInput>`
 
-As of Gutenberg 7.4, `<LinkControl> became the default link creation interface
+As of Gutenberg 7.4, `<LinkControl>` became the default link creation interface
 within the Block Editor, replacing previous disparate uses of `<URLInput>` and
-standardising the UI.
+standardizing the UI.
 
 Nonetheless, it should be remembered that `<LinkControl>` builds **on top of**
 `<URLInput>` and makes use of it under the hood.

--- a/packages/block-editor/src/components/link-control/README.md
+++ b/packages/block-editor/src/components/link-control/README.md
@@ -33,7 +33,7 @@ The distinction between the two components is perhaps best represented as:
 Currently LinkControl will handle two types of input to create hyperlinks:
 
 1. Entity searches - the user may input text-based search queries for entities retrieved from remove data sources (in the context of WordPress these are `Pages`). For example a user might search for a `Page` they have just created by name (eg: About) and the UI will return a matching result if found.
-2. Direct entry - the user may also enter any arbitrary URL-like text. This includes full URLs (https://), URL fragements (eg: `#myinternallink`), `tel` protocol links (eg: `tel: 0800 1234`) and `mailto` protocol links (eg: `mailto: hello@wordpress.org).
+2. Direct entry - the user may also enter any arbitrary URL-like text. This includes full URLs (https://), URL fragements (eg: `#myinternallink`), `tel` protocol links (eg: `tel: 0800 1234`) and `mailto` protocol links (eg: `mailto: hello@wordpress.org`).
 
 In addition, `<LinkControl>` also allows for on-the-fly creation of links based on the **current content of the `<input>` element**. When enabled, a default "Create new" search suggestion is appended to all non-URL-like search results.
 

--- a/packages/block-editor/src/components/link-control/README.md
+++ b/packages/block-editor/src/components/link-control/README.md
@@ -77,11 +77,6 @@ Default properties include:
 
 An array of settings objects associated with a link (for example: a setting to determine whether or not the link opens in a new tab). Each object will be used to render a `ToggleControl` for that setting.
 
-### onClose
-
-- Type: `Function`
-- Required: No
-
 ### onChange
 
 - Type: `Function`

--- a/packages/block-editor/src/components/link-control/README.md
+++ b/packages/block-editor/src/components/link-control/README.md
@@ -55,7 +55,7 @@ Current link value.
 
 A link `value` is composed of a union between the values of default link properties and any custom link `settings`.
 
-Default properties include:
+The resulting default properties of `value` include:
 
 - `url` (`string`): Link URL.
 - `title` (`string`, optional): Link title.

--- a/packages/block-editor/src/components/link-control/README.md
+++ b/packages/block-editor/src/components/link-control/README.md
@@ -32,7 +32,7 @@ The distinction between the two components is perhaps best represented as:
 
 Currently `LinkControl` will handle two types of input to create hyperlinks:
 
-1. Entity searches - the user may input text-based search queries for entities retrieved from remove data sources (in the context of WordPress these are `Pages`). For example a user might search for a `Page` they have just created by name (eg: About) and the UI will return a matching result if found.
+1. Entity searches - the user may input free-text based search queries for entities retrieved from remove data sources (in the context of WordPress these are `Pages`). For example, a user might search for a `Page` they have just created by name (eg: About) and the UI will return a matching result if found.
 2. Direct entry - the user may also enter any arbitrary URL-like text. This includes full URLs (https://), URL fragements (eg: `#myinternallink`), `tel` protocol links (eg: `tel: 0800 1234`) and `mailto` protocol links (eg: `mailto: hello@wordpress.org`).
 
 In addition, `<LinkControl>` also allows for on the fly creation of links based on the **current content of the `<input>` element**. When enabled, a default "Create new" search suggestion is appended to all non-URL-like search results.

--- a/packages/block-editor/src/components/link-control/README.md
+++ b/packages/block-editor/src/components/link-control/README.md
@@ -13,7 +13,7 @@ Previously iterations of a hyperlink UI existed within the Gutenberg interface b
 
 These older UIs tended to make use of two existing components: `URLInput` and `URLPopover`. When a requirement was raised to implement a new UI for hyperlink creation, an assessment of these existing components was undertaken and it was determined that they were too opinionated as to be easily refactored to accommodate the new use cases required by the new UI. Attempting to do so would also have meant unavoidable breaking changes to the interface of `URLInput` which would have (most probably) caused breaking changes to ripple across not only the Core codebase, but also that of 3rd party Plugins.
 
-As a result, it was agreed that a new component `LinkControl` would be created to realise the new hyperlink creation interface. This new UI would begin life as an experimental component which would consume `URLInput` internally. The API of `URLInput` would be enhanced as required with "experimental" features to facilitate the implementation of the new UI with the goal of eventually phasing out the use of `URLInput` entirely.
+As a result, it was agreed that a new component `LinkControl` would be created to realise the new hyperlink creation interface. This new UI would begin life as an experimental component which would consume `URLInput` internally. The API of `URLInput` would be enhanced as required with "experimental" features to facilitate the implementation of the new UI.
 
 
 ## Relationship to `<URLInput>`

--- a/packages/block-editor/src/components/link-control/README.md
+++ b/packages/block-editor/src/components/link-control/README.md
@@ -32,7 +32,7 @@ The distinction between the two components is perhaps best summarized by the fol
 
 When creating links the `LinkControl` component will handle two kinds of input from users:
 
-1. Entity searches - the user may input free-text based search queries for entities retrieved from remove data sources (in the context of WordPress these are `Pages`). For example, a user might search for a `Page` they have just created by name (eg: About) and the UI will return a matching result if found.
+1. Entity searches - the user may input free-text based search queries for entities retrieved from remote data sources (in the context of WordPress these are `Pages`). For example, a user might search for a `Page` they have just created by name (eg: About) and the UI will return a matching result if found.
 2. Direct entry - the user may also enter any arbitrary URL-like text. This includes full URLs (https://), URL fragements (eg: `#myinternallink`), `tel` protocol links (eg: `tel: 0800 1234`) and `mailto` protocol links (eg: `mailto: hello@wordpress.org`).
 
 In addition, `<LinkControl>` also allows for on the fly creation of links based on the **current content of the `<input>` element**. When enabled, a default "Create new" search suggestion is appended to all non-URL-like search results.

--- a/packages/block-editor/src/components/link-control/README.md
+++ b/packages/block-editor/src/components/link-control/README.md
@@ -59,7 +59,7 @@ Default properties include:
 
 - `url` (`string`): Link URL.
 - `title` (`string`, optional): Link title.
-- `opensInNewTab` (`boolean`, optional): Whether link should open in a new browser tab. This value is only assigned if not providing a custom `settings` prop.
+- `opensInNewTab` (`boolean`, optional): Whether link should open in a new browser tab. This value is only assigned when not providing a custom `settings` prop.
 
 ### settings
 

--- a/packages/block-editor/src/components/link-control/README.md
+++ b/packages/block-editor/src/components/link-control/README.md
@@ -135,7 +135,7 @@ A `suggestion` should have the following shape:
 {
 	id: // uniquely identifies the suggestion.
 	type: // the type of the suggestion (eg: `post`).
-	title: // Human-readable label for the suggestion.
+	title: // human-readable label for the suggestion.
 	url: // any string representing a URL value
 }
 ```

--- a/packages/block-editor/src/components/link-control/README.md
+++ b/packages/block-editor/src/components/link-control/README.md
@@ -30,7 +30,7 @@ The distinction between the two components is perhaps best represented as:
 
 ## Search Suggestions
 
-Currently `LinkControl` will handle two types of input to create hyperlinks:
+When creating links the `LinkControl` component will handle two kinds of input from users:
 
 1. Entity searches - the user may input free-text based search queries for entities retrieved from remove data sources (in the context of WordPress these are `Pages`). For example, a user might search for a `Page` they have just created by name (eg: About) and the UI will return a matching result if found.
 2. Direct entry - the user may also enter any arbitrary URL-like text. This includes full URLs (https://), URL fragements (eg: `#myinternallink`), `tel` protocol links (eg: `tel: 0800 1234`) and `mailto` protocol links (eg: `mailto: hello@wordpress.org`).

--- a/packages/block-editor/src/components/link-control/README.md
+++ b/packages/block-editor/src/components/link-control/README.md
@@ -110,7 +110,7 @@ Whether to present initial suggestions immediately.
 - Type: `boolean`
 - Required: No
 
-If passed as either `true` or `false`, controls the internal editing state of the component to respectively show or not to show the URL input field.
+Controls the internal editing state of the component. If passed as either `true` or `false` will respectively show or hide the URL input field.
 
 ### createSuggestion
 

--- a/packages/block-editor/src/components/link-control/README.md
+++ b/packages/block-editor/src/components/link-control/README.md
@@ -22,7 +22,7 @@ As of Gutenberg 7.4, `<LinkControl>` became the default link creation interface 
 
 Nonetheless, it should be remembered that `<LinkControl>` builds **on top of** `<URLInput>` and makes use of it under the hood.
 
-The distinction between the two components is perhaps best represented as:
+The distinction between the two components is perhaps best summarized by the following definitions:
 
 * `<URLInput>` - an input for presenting and managing selection behaviors associated with choosing a URL, optionally from a pool of available candidates.
 * `<LinkControl>` - includes the features of `<URLInput>`, plus additional UI and behaviors to control how this URL applies to the concept of a "link". This includes link "settings" (eg: "opens in new tab", etc) and dynamic, "on the fly" link creation capabilities.

--- a/packages/block-editor/src/components/link-control/README.md
+++ b/packages/block-editor/src/components/link-control/README.md
@@ -2,7 +2,7 @@
 
 Renders a link control. A link control is a controlled input which maintains a value associated with a link (HTML anchor element) and relevant settings for how that link is expected to behave.
 
-It is designed to provide a standardized UI for the creation of link throughout the Editor.
+It is designed to provide a standardized UI for the creation of a link throughout the Editor.
 
 
 ## History


### PR DESCRIPTION
## Description
The current docs for `LinkControl` don't provide any context about how/why it was created. This PR aims to provide this plus generally improve the docs with more detail around `props` and expected value types.

## Todo

- [x] Document [all things suggested by @aduth](https://github.com/WordPress/gutenberg/pull/19462#issuecomment-574732569). 
- [x] Match Types against TS/JS docblocks
- [x] Double check `prop` documentation is accurate.

## How has this been tested?

You can test this by:

* Reading the `LinkControl` source code and comparing JSDoc and TSDoc blocks against README.
* Checking for grammar/spelling errors.
* Checking for areas which don't make sense or could be made clearer.
* Ensuring the historical context matches your understanding of how the component evolved.
* Ensuring nothing in the docs is misleading nor implies other components will be deprecated or superseded.
* Comparing against `master` to see if (subjectively) the docs feel like they are better thanks to the changes suggested here,


## Types of changes
Bug fix (non-breaking change which fixes an issue) 
## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
