### PR TITLE
Navigation: Implement new design for sub-menus

### DIFF
--- a/packages/base-styles/_colors.scss
+++ b/packages/base-styles/_colors.scss
@@ -92,7 +92,7 @@ $alert-green: #4ab866;
 
 // Navigation.
 $light-style-sub-menu-background-color: #fff;
-$light-style-sub-menu-border-color: #e2e4e7;
+$light-style-sub-menu-border-color: #111;
 $light-style-sub-menu-text-color: #111;
 $light-style-sub-menu-text-color-hover: #333;
 

--- a/packages/base-styles/_colors.scss
+++ b/packages/base-styles/_colors.scss
@@ -89,3 +89,14 @@ $blue-medium-focus-dark: #fff;
 $alert-yellow: #f0b849;
 $alert-red: #d94f4f;
 $alert-green: #4ab866;
+
+// Navigation.
+$light-style-sub-menu-background-color: #fff;
+$light-style-sub-menu-border-color: #e2e4e7;
+$light-style-sub-menu-text-color: #111;
+$light-style-sub-menu-text-color-hover: #333;
+
+$dark-style-sub-menu-background-color: #333;
+$dark-style-sub-menu-border-color: #111;
+$dark-style-sub-menu-text-color: #fff;
+$dark-style-sub-menu-text-color-hover: #eee;

--- a/packages/base-styles/_colors.scss
+++ b/packages/base-styles/_colors.scss
@@ -92,7 +92,7 @@ $alert-green: #4ab866;
 
 // Navigation.
 $light-style-sub-menu-background-color: #fff;
-$light-style-sub-menu-border-color: #111;
+$light-style-sub-menu-border-color: #ddd;
 $light-style-sub-menu-text-color: #111;
 $light-style-sub-menu-text-color-hover: #333;
 

--- a/packages/block-editor/src/components/colors/use-colors.js
+++ b/packages/block-editor/src/components/colors/use-colors.js
@@ -220,7 +220,6 @@ export default function __experimentalUseColors(
 							: camelCase( `custom ${ name }` ) ]: color
 							? color.slug
 							: newColor,
-						[ camelCase( `value ${ name }` ) ]: newColor,
 					} );
 				},
 				{

--- a/packages/block-editor/src/components/colors/use-colors.js
+++ b/packages/block-editor/src/components/colors/use-colors.js
@@ -220,6 +220,7 @@ export default function __experimentalUseColors(
 							: camelCase( `custom ${ name }` ) ]: color
 							? color.slug
 							: newColor,
+						[ camelCase( `value ${ name }` ) ]: newColor,
 					} );
 				},
 				{

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -205,8 +205,8 @@ function NavigationLinkEdit( {
 						[ `has-${ navigationBlockAttributes.backgroundColor }-background-color` ]: !! navigationBlockAttributes.backgroundColor,
 					} ) }
 				style={ {
-					borderColor: navigationBlockAttributes.valueTextColor,
-					color: navigationBlockAttributes.valueTextColor,
+					// borderColor: navigationBlockAttributes.valueTextColor,
+					color: navigationBlockAttributes.detectedTextColor,
 					backgroundColor: navigationBlockAttributes.valueBackgroundColor,
 				} }
 			>

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -296,20 +296,17 @@ export default compose( [
 		const { clientId } = ownProps;
 		const rootBlock = getBlockParents( clientId )[ 0 ];
 		const parentBlock = getBlockParents( clientId, true )[ 0 ];
-		const rootBlockAttributes = getBlockAttributes( rootBlock );
-		const hasDescendants = !! getClientIdsOfDescendants( [ clientId ] )
-			.length;
+		const navigationBlockAttributes = getBlockAttributes( rootBlock );
+		const hasDescendants = !! getClientIdsOfDescendants( [ clientId ] ).length;
 		const isLevelZero = getBlockName( parentBlock ) === 'core/navigation';
-		const showSubmenuIcon =
-			rootBlockAttributes.showSubmenuIcon &&
-			isLevelZero &&
-			hasDescendants;
+		const showSubmenuIcon = navigationBlockAttributes.showSubmenuIcon && isLevelZero && hasDescendants;
 		const isParentOfSelectedBlock = hasSelectedInnerBlock( clientId, true );
 
 		return {
 			isParentOfSelectedBlock,
 			hasDescendants,
 			showSubmenuIcon,
+			navigationBlockAttributes,
 		};
 	} ),
 	withDispatch( ( dispatch, ownProps, registry ) => {

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -40,7 +40,6 @@ import { toolbarSubmenuIcon, itemSubmenuIcon } from './icons';
 
 function NavigationLinkEdit( {
 	attributes,
-	hasChild,
 	hasDescendants,
 	isSelected,
 	isParentOfSelectedBlock,

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -40,6 +40,7 @@ import { toolbarSubmenuIcon, itemSubmenuIcon } from './icons';
 
 function NavigationLinkEdit( {
 	attributes,
+	hasChild,
 	hasDescendants,
 	isSelected,
 	isParentOfSelectedBlock,
@@ -196,6 +197,7 @@ function NavigationLinkEdit( {
 					'is-editing': isSelected || isParentOfSelectedBlock,
 					'is-selected': isSelected,
 					'has-link': !! url,
+					'has-child': hasChild,
 				} ) }
 			>
 				<div className="wp-block-navigation-link__content">
@@ -291,8 +293,10 @@ export default compose( [
 			getBlockParents,
 			getClientIdsOfDescendants,
 			hasSelectedInnerBlock,
+			getBlocks,
 		} = select( 'core/block-editor' );
 		const { clientId } = ownProps;
+		const innerBlocks = getBlocks( clientId );
 		const rootBlock = getBlockParents( clientId )[ 0 ];
 		const parentBlock = getBlockParents( clientId, true )[ 0 ];
 		const rootBlockAttributes = getBlockAttributes( rootBlock );
@@ -309,6 +313,7 @@ export default compose( [
 			isParentOfSelectedBlock,
 			hasDescendants,
 			showSubmenuIcon,
+			hasChild: !! innerBlocks.length,
 		};
 	} ),
 	withDispatch( ( dispatch, ownProps, registry ) => {

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -36,7 +36,7 @@ import { placeCaretAtHorizontalEdge } from '@wordpress/dom';
 /**
  * Internal dependencies
  */
-import { toolbarSubmenuIcon, itemSubmenuIcon } from './icons';
+import { ToolbarSubmenuIcon, ItemSubmenuIcon } from './icons';
 
 function NavigationLinkEdit( {
 	attributes,
@@ -138,7 +138,7 @@ function NavigationLinkEdit( {
 					/>
 					<ToolbarButton
 						name="submenu"
-						icon={ toolbarSubmenuIcon }
+						icon={ <ToolbarSubmenuIcon /> }
 						title={ __( 'Add submenu' ) }
 						onClick={ insertLinkBlock }
 					/>
@@ -230,7 +230,7 @@ function NavigationLinkEdit( {
 					/>
 					{ showSubmenuIcon && (
 						<span className="wp-block-navigation-link__submenu-icon">
-							{ itemSubmenuIcon }
+							<ItemSubmenuIcon />
 						</span>
 					) }
 					{ isLinkOpen && (

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -46,6 +46,7 @@ function NavigationLinkEdit( {
 	setAttributes,
 	showSubmenuIcon,
 	insertLinkBlock,
+	navigationAttributes,
 } ) {
 	const {
 		label,
@@ -192,12 +193,14 @@ function NavigationLinkEdit( {
 				</PanelBody>
 			</InspectorControls>
 			<div
-				className={ classnames( 'wp-block-navigation-link', {
-					'is-editing': isSelected || isParentOfSelectedBlock,
-					'is-selected': isSelected,
-					'has-link': !! url,
-					'has-child': hasDescendants,
-				} ) }
+				className={ classnames(
+					'wp-block-navigation-link', {
+						'is-editing': isSelected || isParentOfSelectedBlock,
+						'is-selected': isSelected,
+						'has-link': !! url,
+						'has-child': hasDescendants,
+					} ) }
+				style={ navigationAttributes.customTextColor ? { borderColor: navigationAttributes.customTextColor } : null }
 			>
 				<div className="wp-block-navigation-link__content">
 					<RichText

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -298,7 +298,6 @@ function NavigationLinkEdit( {
 export default compose( [
 	withSelect( ( select, ownProps ) => {
 		const {
-			getBlockName,
 			getBlockAttributes,
 			getBlockParents,
 			getClientIdsOfDescendants,
@@ -306,11 +305,9 @@ export default compose( [
 		} = select( 'core/block-editor' );
 		const { clientId } = ownProps;
 		const rootBlock = getBlockParents( clientId )[ 0 ];
-		const parentBlock = getBlockParents( clientId, true )[ 0 ];
 		const navigationBlockAttributes = getBlockAttributes( rootBlock );
 		const hasDescendants = !! getClientIdsOfDescendants( [ clientId ] ).length;
-		const isLevelZero = getBlockName( parentBlock ) === 'core/navigation';
-		const showSubmenuIcon = navigationBlockAttributes.showSubmenuIcon && isLevelZero && hasDescendants;
+		const showSubmenuIcon = navigationBlockAttributes.showSubmenuIcon && hasDescendants;
 		const isParentOfSelectedBlock = hasSelectedInnerBlock( clientId, true );
 
 		return {

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -199,9 +199,9 @@ function NavigationLinkEdit( {
 						'is-selected': isSelected,
 						'has-link': !! url,
 						'has-child': hasDescendants,
-						'has-text-color': navigationBlockAttributes.textColor,
+						'has-text-color': navigationBlockAttributes.valueTextColor,
 						[ `has-${ navigationBlockAttributes.textColor }-color` ]: !! navigationBlockAttributes.textColor,
-						'has-background-color': navigationBlockAttributes.backgroundColor,
+						'has-background-color': navigationBlockAttributes.valueBackgroundColor,
 						[ `has-${ navigationBlockAttributes.backgroundColor }-background-color` ]: !! navigationBlockAttributes.backgroundColor,
 					} ) }
 				style={ {

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -230,7 +230,7 @@ function NavigationLinkEdit( {
 					/>
 					{ showSubmenuIcon && (
 						<span className="wp-block-navigation-link__submenu-icon">
-							<ItemSubmenuIcon borderColor={ navigationBlockAttributes.detectedTextColor } />
+							<ItemSubmenuIcon />
 						</span>
 					) }
 					{ isLinkOpen && (

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -56,6 +56,14 @@ function NavigationLinkEdit( {
 		nofollow,
 		description,
 	} = attributes;
+
+	const {
+		textColor,
+		valueTextColor,
+		backgroundColor,
+		valueBackgroundColor,
+	} = navigationBlockAttributes;
+
 	const link = {
 		title: title ? unescape( title ) : '',
 		url,
@@ -199,14 +207,14 @@ function NavigationLinkEdit( {
 						'is-selected': isSelected,
 						'has-link': !! url,
 						'has-child': hasDescendants,
-						'has-text-color': navigationBlockAttributes.valueTextColor,
-						[ `has-${ navigationBlockAttributes.textColor }-color` ]: !! navigationBlockAttributes.textColor,
-						'has-background-color': navigationBlockAttributes.valueBackgroundColor,
-						[ `has-${ navigationBlockAttributes.backgroundColor }-background-color` ]: !! navigationBlockAttributes.backgroundColor,
+						'has-text-color': valueTextColor,
+						[ `has-${ textColor }-color` ]: !! textColor,
+						'has-background-color': valueBackgroundColor,
+						[ `has-${ backgroundColor }-background-color` ]: !! backgroundColor,
 					} ) }
 				style={ {
-					color: navigationBlockAttributes.valueTextColor,
-					backgroundColor: navigationBlockAttributes.valueBackgroundColor,
+					color: valueTextColor,
+					backgroundColor: valueBackgroundColor,
 				} }
 			>
 				<div className="wp-block-navigation-link__content">

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -204,6 +204,11 @@ function NavigationLinkEdit( {
 						'has-background-color': navigationAttributes.backgroundColor,
 						[ `has-${ navigationAttributes.backgroundColor }-background-color` ]: !! navigationAttributes.backgroundColor,
 					} ) }
+				style={ {
+					borderColor: navigationAttributes.valueTextColor,
+					color: navigationAttributes.valueTextColor,
+					backgroundColor: navigationAttributes.valueBackgroundColor,
+				} }
 			>
 				<div className="wp-block-navigation-link__content">
 					<RichText

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -57,11 +57,14 @@ function NavigationLinkEdit( {
 		description,
 	} = attributes;
 
+	/*
+	 * Navigation Block attributes.
+	 */
 	const {
 		textColor,
-		valueTextColor,
+		rgbTextColor,
 		backgroundColor,
-		valueBackgroundColor,
+		rgbBackgroundColor,
 	} = navigationBlockAttributes;
 
 	const link = {
@@ -207,14 +210,14 @@ function NavigationLinkEdit( {
 						'is-selected': isSelected,
 						'has-link': !! url,
 						'has-child': hasDescendants,
-						'has-text-color': valueTextColor,
+						'has-text-color': rgbTextColor,
 						[ `has-${ textColor }-color` ]: !! textColor,
-						'has-background-color': valueBackgroundColor,
+						'has-background-color': rgbBackgroundColor,
 						[ `has-${ backgroundColor }-background-color` ]: !! backgroundColor,
 					} ) }
 				style={ {
-					color: valueTextColor,
-					backgroundColor: valueBackgroundColor,
+					color: rgbTextColor,
+					backgroundColor: rgbBackgroundColor,
 				} }
 			>
 				<div className="wp-block-navigation-link__content">

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -230,7 +230,7 @@ function NavigationLinkEdit( {
 					/>
 					{ showSubmenuIcon && (
 						<span className="wp-block-navigation-link__submenu-icon">
-							<ItemSubmenuIcon />
+							<ItemSubmenuIcon borderColor={ navigationBlockAttributes.detectedTextColor } />
 						</span>
 					) }
 					{ isLinkOpen && (

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -46,7 +46,7 @@ function NavigationLinkEdit( {
 	setAttributes,
 	showSubmenuIcon,
 	insertLinkBlock,
-	navigationAttributes,
+	navigationBlockAttributes,
 } ) {
 	const {
 		label,
@@ -199,15 +199,15 @@ function NavigationLinkEdit( {
 						'is-selected': isSelected,
 						'has-link': !! url,
 						'has-child': hasDescendants,
-						'has-text-color': navigationAttributes.textColor,
-						[ `has-${ navigationAttributes.textColor }-color` ]: !! navigationAttributes.textColor,
-						'has-background-color': navigationAttributes.backgroundColor,
-						[ `has-${ navigationAttributes.backgroundColor }-background-color` ]: !! navigationAttributes.backgroundColor,
+						'has-text-color': navigationBlockAttributes.textColor,
+						[ `has-${ navigationBlockAttributes.textColor }-color` ]: !! navigationBlockAttributes.textColor,
+						'has-background-color': navigationBlockAttributes.backgroundColor,
+						[ `has-${ navigationBlockAttributes.backgroundColor }-background-color` ]: !! navigationBlockAttributes.backgroundColor,
 					} ) }
 				style={ {
-					borderColor: navigationAttributes.valueTextColor,
-					color: navigationAttributes.valueTextColor,
-					backgroundColor: navigationAttributes.valueBackgroundColor,
+					borderColor: navigationBlockAttributes.valueTextColor,
+					color: navigationBlockAttributes.valueTextColor,
+					backgroundColor: navigationBlockAttributes.valueBackgroundColor,
 				} }
 			>
 				<div className="wp-block-navigation-link__content">

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -199,8 +199,11 @@ function NavigationLinkEdit( {
 						'is-selected': isSelected,
 						'has-link': !! url,
 						'has-child': hasDescendants,
+						'has-text-color': navigationAttributes.textColor,
+						[ `has-${ navigationAttributes.textColor }-color` ]: !! navigationAttributes.textColor,
+						'has-background-color': navigationAttributes.backgroundColor,
+						[ `has-${ navigationAttributes.backgroundColor }-background-color` ]: !! navigationAttributes.backgroundColor,
 					} ) }
-				style={ navigationAttributes.customTextColor ? { borderColor: navigationAttributes.customTextColor } : null }
 			>
 				<div className="wp-block-navigation-link__content">
 					<RichText

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -204,17 +204,16 @@ function NavigationLinkEdit( {
 				</PanelBody>
 			</InspectorControls>
 			<div
-				className={ classnames(
-					'wp-block-navigation-link', {
-						'is-editing': isSelected || isParentOfSelectedBlock,
-						'is-selected': isSelected,
-						'has-link': !! url,
-						'has-child': hasDescendants,
-						'has-text-color': rgbTextColor,
-						[ `has-${ textColor }-color` ]: !! textColor,
-						'has-background-color': rgbBackgroundColor,
-						[ `has-${ backgroundColor }-background-color` ]: !! backgroundColor,
-					} ) }
+				className={ classnames( 'wp-block-navigation-link', {
+					'is-editing': isSelected || isParentOfSelectedBlock,
+					'is-selected': isSelected,
+					'has-link': !! url,
+					'has-child': hasDescendants,
+					'has-text-color': rgbTextColor,
+					[ `has-${ textColor }-color` ]: !! textColor,
+					'has-background-color': rgbBackgroundColor,
+					[ `has-${ backgroundColor }-background-color` ]: !! backgroundColor,
+				} ) }
 				style={ {
 					color: rgbTextColor,
 					backgroundColor: rgbBackgroundColor,
@@ -316,8 +315,10 @@ export default compose( [
 		const { clientId } = ownProps;
 		const rootBlock = getBlockParents( clientId )[ 0 ];
 		const navigationBlockAttributes = getBlockAttributes( rootBlock );
-		const hasDescendants = !! getClientIdsOfDescendants( [ clientId ] ).length;
-		const showSubmenuIcon = navigationBlockAttributes.showSubmenuIcon && hasDescendants;
+		const hasDescendants = !! getClientIdsOfDescendants( [ clientId ] )
+			.length;
+		const showSubmenuIcon =
+			!! navigationBlockAttributes.showSubmenuIcon && hasDescendants;
 		const isParentOfSelectedBlock = hasSelectedInnerBlock( clientId, true );
 
 		return {

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -205,7 +205,6 @@ function NavigationLinkEdit( {
 						[ `has-${ navigationBlockAttributes.backgroundColor }-background-color` ]: !! navigationBlockAttributes.backgroundColor,
 					} ) }
 				style={ {
-					borderColor: navigationBlockAttributes.valueTextColor,
 					color: navigationBlockAttributes.valueTextColor,
 					backgroundColor: navigationBlockAttributes.valueBackgroundColor,
 				} }

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -197,7 +197,7 @@ function NavigationLinkEdit( {
 					'is-editing': isSelected || isParentOfSelectedBlock,
 					'is-selected': isSelected,
 					'has-link': !! url,
-					'has-child': hasChild,
+					'has-child': hasDescendants,
 				} ) }
 			>
 				<div className="wp-block-navigation-link__content">
@@ -293,10 +293,8 @@ export default compose( [
 			getBlockParents,
 			getClientIdsOfDescendants,
 			hasSelectedInnerBlock,
-			getBlocks,
 		} = select( 'core/block-editor' );
 		const { clientId } = ownProps;
-		const innerBlocks = getBlocks( clientId );
 		const rootBlock = getBlockParents( clientId )[ 0 ];
 		const parentBlock = getBlockParents( clientId, true )[ 0 ];
 		const rootBlockAttributes = getBlockAttributes( rootBlock );
@@ -313,7 +311,6 @@ export default compose( [
 			isParentOfSelectedBlock,
 			hasDescendants,
 			showSubmenuIcon,
-			hasChild: !! innerBlocks.length,
 		};
 	} ),
 	withDispatch( ( dispatch, ownProps, registry ) => {

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -205,8 +205,8 @@ function NavigationLinkEdit( {
 						[ `has-${ navigationBlockAttributes.backgroundColor }-background-color` ]: !! navigationBlockAttributes.backgroundColor,
 					} ) }
 				style={ {
-					// borderColor: navigationBlockAttributes.valueTextColor,
-					color: navigationBlockAttributes.detectedTextColor,
+					borderColor: navigationBlockAttributes.valueTextColor,
+					color: navigationBlockAttributes.valueTextColor,
 					backgroundColor: navigationBlockAttributes.valueBackgroundColor,
 				} }
 			>

--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -41,6 +41,10 @@
 
 	.wp-block-navigation-link__submenu-icon {
 		margin-left: 4px;
+
+		svg {
+			fill: currentColor;
+		}
 	}
 
 	.block-editor-rich-text__editable.is-selected:not(.keep-placeholder-on-focus):not(:focus) [data-rich-text-placeholder]::after {

--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -22,12 +22,6 @@
 		min-width: 20px;
 	}
 
-	.wp-block-navigation-link__content {
-		display: flex;
-		align-items: center;
-		width: max-content;
-	}
-
 	&.has-link .wp-block-navigation-link__label {
 		text-decoration: underline;
 	}

--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -24,11 +24,6 @@
 		margin: $grid-size;
 	}
 
-	// Only display inner blocks when the block is being edited.
-	.block-editor-inner-blocks {
-		display: none;
-	}
-
 	&.is-editing,
 	&.is-selected {
 		min-width: 20px;

--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -40,6 +40,7 @@
 
 	&.has-link .wp-block-navigation-link__label {
 		text-decoration: underline;
+		white-space: nowrap !important; // TODO: solve differently to prevent use of !important
 	}
 
 	.wp-block-navigation-link__submenu-icon {

--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -43,35 +43,35 @@
 		margin-left: 4px;
 	}
 
-	// Arrow indicator to show presence of children.
-	&.has-child {
-		position: relative;
-		padding-right: 15px;
-
-		&::after {
-			content: "";
-			position: absolute;
-			right: 0;
-			top: 50%;
-			border-left: 4px solid transparent;
-			border-right: 4px solid transparent;
-
-			border-top-width: 6px;
-			border-top-style: solid;
-			border-top-color: inherit;
-		}
-	}
-
-	.wp-block-navigation-link.has-child::after {
-		top: calc(50% - 3px);
-		border-right: 0;
-		border-top: 4px solid transparent;
-		border-bottom: 4px solid transparent;
-
-		border-left-width: 6px;
-		border-left-style: solid;
-		border-left-color: inherit;
-	}
+	//// Arrow indicator to show presence of children.
+	//&.has-child {
+	//	position: relative;
+	//	padding-right: 15px;
+	//
+	//	&::after {
+	//		content: "";
+	//		position: absolute;
+	//		right: 0;
+	//		top: 50%;
+	//		border-left: 4px solid transparent;
+	//		border-right: 4px solid transparent;
+	//
+	//		border-top-width: 6px;
+	//		border-top-style: solid;
+	//		border-top-color: inherit;
+	//	}
+	//}
+	//
+	//.wp-block-navigation-link.has-child::after {
+	//	top: calc(50% - 3px);
+	//	border-right: 0;
+	//	border-top: 4px solid transparent;
+	//	border-bottom: 4px solid transparent;
+	//
+	//	border-left-width: 6px;
+	//	border-left-style: solid;
+	//	border-left-color: inherit;
+	//}
 
 	.block-editor-rich-text__editable.is-selected:not(.keep-placeholder-on-focus):not(:focus) [data-rich-text-placeholder]::after {
 		display: inline-block;

--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -14,7 +14,6 @@
 
 	.block-editor-block-list__layout {
 		display: block;
-		margin: $grid-size;
 	}
 
 	&.is-editing,

--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -43,36 +43,6 @@
 		margin-left: 4px;
 	}
 
-	//// Arrow indicator to show presence of children.
-	//&.has-child {
-	//	position: relative;
-	//	padding-right: 15px;
-	//
-	//	&::after {
-	//		content: "";
-	//		position: absolute;
-	//		right: 0;
-	//		top: 50%;
-	//		border-left: 4px solid transparent;
-	//		border-right: 4px solid transparent;
-	//
-	//		border-top-width: 6px;
-	//		border-top-style: solid;
-	//		border-top-color: inherit;
-	//	}
-	//}
-	//
-	//.wp-block-navigation-link.has-child::after {
-	//	top: calc(50% - 3px);
-	//	border-right: 0;
-	//	border-top: 4px solid transparent;
-	//	border-bottom: 4px solid transparent;
-	//
-	//	border-left-width: 6px;
-	//	border-left-style: solid;
-	//	border-left-color: inherit;
-	//}
-
 	.block-editor-rich-text__editable.is-selected:not(.keep-placeholder-on-focus):not(:focus) [data-rich-text-placeholder]::after {
 		display: inline-block;
 	}

--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -42,9 +42,37 @@
 		text-decoration: underline;
 		white-space: nowrap !important; // TODO: solve differently to prevent use of !important
 	}
-
+	
 	.wp-block-navigation-link__submenu-icon {
 		margin-left: 4px;
+	}
+
+	// Arrow indicator to show presence of children.
+	&.has-child {
+		position: relative;
+		padding-right: 15px;
+
+		&::after {
+			content: "";
+			position: absolute;
+			right: 0;
+			top: 50%;
+			border-left: 4px solid transparent;
+			border-right: 4px solid transparent;
+			border-top: 6px solid #111; //TODO: change to var
+		}
+	}
+
+	.wp-block-navigation-link.has-child::after {
+		top: calc(50% - 3px);
+		border-right: 0;
+		border-top: 4px solid transparent;
+		border-bottom: 4px solid transparent;
+		border-left: 6px solid #111; //TODO: change to var
+	}
+
+	.block-editor-rich-text__editable.is-selected:not(.keep-placeholder-on-focus):not(:focus) [data-rich-text-placeholder]::after {
+		display: inline-block;
 	}
 }
 

--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -11,13 +11,6 @@
  * Adjust Navigation Item.
  */
 .wp-block-navigation-link {
-	margin-left: $grid-size;
-	margin-right: $grid-size;
-	// Provide a base menu item margin.
-	// This should be the same inside the field,
-	// and the edit container should compensate.
-	// This is to make sure the edit and view are the same.
-	padding: 0 $grid-size;
 
 	.block-editor-block-list__layout {
 		display: block;

--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -38,7 +38,7 @@
 		text-decoration: underline;
 		white-space: nowrap !important; // TODO: solve differently to prevent use of !important
 	}
-	
+
 	.wp-block-navigation-link__submenu-icon {
 		margin-left: 4px;
 	}

--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -29,10 +29,6 @@
 		min-width: 20px;
 	}
 
-	&.is-editing .block-editor-inner-blocks {
-		display: block;
-	}
-
 	.wp-block-navigation-link__content {
 		display: flex;
 		align-items: center;

--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -59,7 +59,10 @@
 			top: 50%;
 			border-left: 4px solid transparent;
 			border-right: 4px solid transparent;
-			border-top: 6px solid #111; //TODO: change to var
+
+			border-top-width: 6px;
+			border-top-style: solid;
+			border-top-color: inherit;
 		}
 	}
 
@@ -68,7 +71,10 @@
 		border-right: 0;
 		border-top: 4px solid transparent;
 		border-bottom: 4px solid transparent;
-		border-left: 6px solid #111; //TODO: change to var
+
+		border-left-width: 6px;
+		border-left-style: solid;
+		border-left-color: inherit;
 	}
 
 	.block-editor-rich-text__editable.is-selected:not(.keep-placeholder-on-focus):not(:focus) [data-rich-text-placeholder]::after {

--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -32,11 +32,11 @@
 	.wp-block-navigation-link__content {
 		display: flex;
 		align-items: center;
+		width: max-content;
 	}
 
 	&.has-link .wp-block-navigation-link__label {
 		text-decoration: underline;
-		white-space: nowrap !important; // TODO: solve differently to prevent use of !important
 	}
 
 	.wp-block-navigation-link__submenu-icon {

--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -26,14 +26,6 @@
 		text-decoration: underline;
 	}
 
-	.wp-block-navigation-link__submenu-icon {
-		margin-left: 4px;
-
-		svg {
-			fill: currentColor;
-		}
-	}
-
 	.block-editor-rich-text__editable.is-selected:not(.keep-placeholder-on-focus):not(:focus) [data-rich-text-placeholder]::after {
 		display: inline-block;
 	}

--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -11,7 +11,6 @@
  * Adjust Navigation Item.
  */
 .wp-block-navigation-link {
-
 	.block-editor-block-list__layout {
 		display: block;
 	}
@@ -27,6 +26,12 @@
 
 	.block-editor-rich-text__editable.is-selected:not(.keep-placeholder-on-focus):not(:focus) [data-rich-text-placeholder]::after {
 		display: inline-block;
+	}
+
+	.block-list-appender {
+		margin: $grid-size * 2;
+		margin-left: $grid-size * 1.25;
+		margin-top: $grid-size * 1.25;
 	}
 }
 

--- a/packages/block-library/src/navigation-link/icons.js
+++ b/packages/block-library/src/navigation-link/icons.js
@@ -11,7 +11,13 @@ export const ToolbarSubmenuIcon = () => (
 );
 
 export const ItemSubmenuIcon = () => (
-	<SVG xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" transform="rotate(90)" >
+	<SVG
+		xmlns="http://www.w3.org/2000/svg"
+		width="12"
+		height="12"
+		viewBox="0 0 24 24"
+		transform="rotate(90)"
+	>
 		<Path d="M8 5v14l11-7z" />
 		<Path d="M0 0h24v24H0z" fill="none" />
 	</SVG>

--- a/packages/block-library/src/navigation-link/icons.js
+++ b/packages/block-library/src/navigation-link/icons.js
@@ -10,8 +10,8 @@ export const ToolbarSubmenuIcon = () => (
 	</SVG>
 );
 
-export const ItemSubmenuIcon = ( { borderColor = 'black' } ) => (
-	<SVG  width="18"  height="18"  xmlns="http://www.w3.org/2000/svg"  viewBox="0 0 18 18"  fill={ borderColor }>
+export const ItemSubmenuIcon = () => (
+	<SVG xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" transform="rotate(90)" >
 		<Path d="M8 5v14l11-7z" />
 		<Path d="M0 0h24v24H0z" fill="none" />
 	</SVG>

--- a/packages/block-library/src/navigation-link/icons.js
+++ b/packages/block-library/src/navigation-link/icons.js
@@ -1,22 +1,18 @@
 /**
  * WordPress dependencies
  */
-import { Polygon, Path, SVG } from '@wordpress/components';
+import { Path, SVG } from '@wordpress/components';
 
-export const toolbarSubmenuIcon = (
+export const ToolbarSubmenuIcon = () => (
 	<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24">
 		<Path d="M14 5h8v2h-8zm0 5.5h8v2h-8zm0 5.5h8v2h-8zM2 11.5C2 15.08 4.92 18 8.5 18H9v2l3-3-3-3v2h-.5C6.02 16 4 13.98 4 11.5S6.02 7 8.5 7H12V5H8.5C4.92 5 2 7.92 2 11.5z" />
 		<Path fill="none" d="M0 0h24v24H0z" />
 	</SVG>
 );
 
-export const itemSubmenuIcon = (
-	<SVG
-		width="18"
-		height="18"
-		xmlns="http://www.w3.org/2000/svg"
-		viewBox="0 0 18 18"
-	>
-		<Polygon points="9,13.5 14.7,7.9 13.2,6.5 9,10.7 4.8,6.5 3.3,7.9 " />
+export const ItemSubmenuIcon = ( { borderColor = 'black' } ) => (
+	<SVG  width="18"  height="18"  xmlns="http://www.w3.org/2000/svg"  viewBox="0 0 18 18"  fill={ borderColor }>
+		<Path d="M8 5v14l11-7z" />
+		<Path d="M0 0h24v24H0z" fill="none" />
 	</SVG>
 );

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -283,7 +283,7 @@ function Navigation( {
 						onChange={ ( value ) => {
 							setAttributes( { showSubmenuIcon: value } );
 						} }
-						label={ __( 'Show submenu icon for top-level items' ) }
+						label={ __( 'Show submenu indicator icons' ) }
 					/>
 				</PanelBody>
 			</InspectorControls>

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -7,7 +7,12 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { useMemo, Fragment, useRef } from '@wordpress/element';
+import {
+	useMemo,
+	Fragment,
+	useRef,
+	useEffect,
+} from '@wordpress/element';
 import {
 	InnerBlocks,
 	InspectorControls,
@@ -85,6 +90,29 @@ function Navigation( {
 		},
 		[ fontSize.size ]
 	);
+
+	/**
+	 * The following hook will get the current text color of the menu,
+	 * getting it from the valueTextColor if it's already defined.
+	 * If not, it will try to compute it from the DOM tree.
+	 * This value will be stored as a new detectedTextColor attribute.
+	 */
+	useEffect( () => {
+		if ( attributes.valueTextColor ) {
+			return setAttributes( { detectedTextColor: attributes.valueTextColor } )
+		}
+
+		if ( ! ref || ! ref.current ) {
+			return;
+		}
+
+		const navigationStyles  = getComputedStyle( ref.current );
+		if ( ! navigationStyles || ! navigationStyles.color ) {
+			return;
+		}
+
+		setAttributes( { detectedTextColor: navigationStyles.color } );
+	}, [ attributes.valueTextColor, attributes.valueBackgroundColor ] );
 
 	/* eslint-enable @wordpress/no-unused-vars-before-return */
 	const { navigatorToolbarButton, navigatorModal } = useBlockNavigator(

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -51,6 +51,7 @@ function Navigation( {
 	setAttributes,
 	setFontSize,
 	updateNavItemBlocks,
+	className,
 } ) {
 	//
 	// HOOKS
@@ -135,10 +136,12 @@ function Navigation( {
 
 	const hasPages = hasResolvedPages && pages && pages.length;
 
-	const blockClassNames = classnames( 'wp-block-navigation', {
-		[ `items-justification-${ attributes.itemsJustification }` ]: attributes.itemsJustification,
-		[ fontSize.class ]: fontSize.class,
-	} );
+	const blockClassNames = classnames(
+		className, {
+			[ `items-justification-${ attributes.itemsJustification }` ]: attributes.itemsJustification,
+			[ fontSize.class ]: fontSize.class,
+		}
+	);
 	const blockInlineStyles = {
 		fontSize: fontSize.size ? fontSize.size + 'px' : undefined,
 	};

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -11,7 +11,6 @@ import {
 	useMemo,
 	Fragment,
 	useRef,
-	useEffect,
 } from '@wordpress/element';
 import {
 	InnerBlocks,
@@ -44,8 +43,6 @@ import useBlockNavigator from './use-block-navigator';
 import BlockNavigationList from './block-navigation-list';
 import BlockColorsStyleSelector from './block-colors-selector';
 import * as navIcons from './icons';
-
-const { getComputedStyle } = window;
 
 function Navigation( {
 	attributes,
@@ -92,29 +89,6 @@ function Navigation( {
 		},
 		[ fontSize.size ]
 	);
-
-	/**
-	 * The following hook will get the current text color of the menu,
-	 * getting it from the valueTextColor if it's already defined.
-	 * If not, it will try to compute it from the DOM tree.
-	 * This value will be stored as a new detectedTextColor attribute.
-	 */
-	useEffect( () => {
-		if ( attributes.valueTextColor ) {
-			return setAttributes( { detectedTextColor: attributes.valueTextColor } );
-		}
-
-		if ( ! ref || ! ref.current ) {
-			return;
-		}
-
-		const navigationStyles = getComputedStyle( ref.current );
-		if ( ! navigationStyles || ! navigationStyles.color ) {
-			return;
-		}
-
-		setAttributes( { detectedTextColor: navigationStyles.color } );
-	}, [ attributes.valueTextColor, attributes.valueBackgroundColor ] );
 
 	/* eslint-enable @wordpress/no-unused-vars-before-return */
 	const { navigatorToolbarButton, navigatorModal } = useBlockNavigator(

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -68,7 +68,7 @@ function Navigation( {
 	} = __experimentalUseColors(
 		[
 			{ name: 'textColor', property: 'color' },
-			{ name: 'backgroundColor', className: 'background-color' },
+			{ name: 'backgroundColor', className: 'has-background-color' },
 		],
 		{
 			contrastCheckers: [

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -45,6 +45,8 @@ import BlockNavigationList from './block-navigation-list';
 import BlockColorsStyleSelector from './block-colors-selector';
 import * as navIcons from './icons';
 
+const { getComputedStyle } = window;
+
 function Navigation( {
 	attributes,
 	clientId,
@@ -99,14 +101,14 @@ function Navigation( {
 	 */
 	useEffect( () => {
 		if ( attributes.valueTextColor ) {
-			return setAttributes( { detectedTextColor: attributes.valueTextColor } )
+			return setAttributes( { detectedTextColor: attributes.valueTextColor } );
 		}
 
 		if ( ! ref || ! ref.current ) {
 			return;
 		}
 
-		const navigationStyles  = getComputedStyle( ref.current );
+		const navigationStyles = getComputedStyle( ref.current );
 		if ( ! navigationStyles || ! navigationStyles.color ) {
 			return;
 		}

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -7,12 +7,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import {
-	useMemo,
-	Fragment,
-	useRef,
-	useEffect,
-} from '@wordpress/element';
+import { useMemo, Fragment, useRef, useEffect } from '@wordpress/element';
 import {
 	InnerBlocks,
 	InspectorControls,
@@ -149,12 +144,10 @@ function Navigation( {
 
 	const hasPages = hasResolvedPages && pages && pages.length;
 
-	const blockClassNames = classnames(
-		className, {
-			[ `items-justification-${ attributes.itemsJustification }` ]: attributes.itemsJustification,
-			[ fontSize.class ]: fontSize.class,
-		}
-	);
+	const blockClassNames = classnames( className, {
+		[ `items-justification-${ attributes.itemsJustification }` ]: attributes.itemsJustification,
+		[ fontSize.class ]: fontSize.class,
+	} );
 	const blockInlineStyles = {
 		fontSize: fontSize.size ? fontSize.size + 'px' : undefined,
 	};

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -11,6 +11,7 @@ import {
 	useMemo,
 	Fragment,
 	useRef,
+	useEffect,
 } from '@wordpress/element';
 import {
 	InnerBlocks,
@@ -89,6 +90,14 @@ function Navigation( {
 		},
 		[ fontSize.size ]
 	);
+
+	// Pickup and store text and background colors in grb format into attrs object.
+	useEffect( () => {
+		setAttributes( {
+			rgbTextColor: TextColor.color,
+			rgbBackgroundColor: BackgroundColor.color,
+		} );
+	}, [ TextColor.color, BackgroundColor.color ] );
 
 	/* eslint-enable @wordpress/no-unused-vars-before-return */
 	const { navigatorToolbarButton, navigatorModal } = useBlockNavigator(

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -28,20 +28,6 @@ $navigation-item-height: 46px;
 		justify-content: flex-end;
 	}
 
-	// 2. Remove paddings on subsequent immediate children.
-	.wp-block-navigation .block-editor-inner-blocks > .block-editor-block-list__layout > .wp-block {
-		width: auto;
-		padding-left: 0;
-		padding-right: 0;
-		margin: 0;
-	}
-
-	// 3. Set a min height for nav items.
-	// It's needed in order to hide the sub-items when the navigation is not selected.
-	.wp-block-navigation .block-editor-inner-blocks > .block-editor-block-list__layout .wp-block > [data-block] {
-		min-height: $navigation-item-height;
-	}
-
 	.wp-block-navigation .block-editor-block-list__block::before {
 		left: 0;
 		right: 0;

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -123,19 +123,31 @@ $navigation-item-height: 46px;
 		}
 	}
 
-	// Default / Light styles
-	.wp-block-navigation-link > .block-editor-inner-blocks {
-		color: $light-style-sub-menu-text-color;
-		border-color: $light-style-sub-menu-border-color;
-		background-color: $light-style-sub-menu-background-color;
+	// Inherit colors from menu.
+	// Some of these selectors shoule be replaced/removed
+	// once sub-menus support custom colors.
+	.block-editor-inner-blocks,
+	.block-editor-block-list__layout,
+	.wp-block,
+	.wp-block-navigation-link {
+		background-color: inherit;
+		color: inherit;
 	}
 
-	// Dark styles
-	&.is-style-dark .wp-block-navigation-link > .block-editor-inner-blocks {
-		color: $dark-style-sub-menu-text-color;
-		border-color: $dark-style-sub-menu-border-color;
-		background-color: $dark-style-sub-menu-background-color;
-	}
+	// Commenting styles for the moment.
+	//// Default / Light styles
+	//.wp-block-navigation-link > .block-editor-inner-blocks {
+	//	color: $light-style-sub-menu-text-color;
+	//	border-color: $light-style-sub-menu-border-color;
+	//	background-color: $light-style-sub-menu-background-color;
+	//}
+	//
+	//// Dark styles
+	//&.is-style-dark .wp-block-navigation-link > .block-editor-inner-blocks {
+	//	color: $dark-style-sub-menu-text-color;
+	//	border-color: $dark-style-sub-menu-border-color;
+	//	background-color: $dark-style-sub-menu-background-color;
+	//}
 }
 
 .wp-block-navigation__inserter-content {

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -124,7 +124,7 @@ $navigation-item-height: 46px;
 	}
 
 	// Inherit colors from menu.
-	// Some of these selectors shoule be replaced/removed
+	// Some of these selectors should be replaced/removed
 	// once sub-menus support custom colors.
 	.block-editor-inner-blocks,
 	.block-editor-block-list__layout,
@@ -134,20 +134,22 @@ $navigation-item-height: 46px;
 		color: inherit;
 	}
 
-	// Commenting styles for the moment.
-	//// Default / Light styles
-	//.wp-block-navigation-link > .block-editor-inner-blocks {
-	//	color: $light-style-sub-menu-text-color;
-	//	border-color: $light-style-sub-menu-border-color;
-	//	background-color: $light-style-sub-menu-background-color;
-	//}
-	//
-	//// Dark styles
-	//&.is-style-dark .wp-block-navigation-link > .block-editor-inner-blocks {
-	//	color: $dark-style-sub-menu-text-color;
-	//	border-color: $dark-style-sub-menu-border-color;
-	//	background-color: $dark-style-sub-menu-background-color;
-	//}
+	// Default / Light styles
+	.wp-block-navigation-link > .block-editor-inner-blocks {
+		border-color: $light-style-sub-menu-border-color;
+	}
+
+	// No background color - Default / Light styles
+	&:not(.has-background-color) .wp-block-navigation-link > .block-editor-inner-blocks {
+		background-color: $light-style-sub-menu-background-color;
+	}
+
+	// No background color - Dark styles
+	&:not(.has-background-color).is-style-dark .wp-block-navigation-link > .block-editor-inner-blocks {
+		border-color: $dark-style-sub-menu-border-color;
+		color: $dark-style-sub-menu-text-color;
+		background-color: $dark-style-sub-menu-background-color;
+	}
 }
 
 .wp-block-navigation__inserter-content {

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -76,20 +76,6 @@ $navigation-item-height: 46px;
 	}
 }
 
-.wp-block-navigation .block-editor-block-list__layout,
-.wp-block-navigation {
-	display: flex;
-	flex-wrap: wrap;
-}
-
-// Vertical alignment.
-.wp-block-navigation {
-	min-height: $navigation-height;
-	padding-top: 7px;
-	padding-bottom: 7px;
-	align-items: center;
-}
-
 // Sub menus.
 .wp-block-navigation {
 	.wp-block-navigation-link {

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -105,16 +105,22 @@ $navigation-item-height: 46px;
 		}
 
 		&.is-editing.has-child > .block-editor-inner-blocks {
+			// Box model.
 			display: block;
-			position: absolute;
 			width: 100%;
-			z-index: 1;
-			white-space: nowrap;
+			border-width: 1px;
+			border-style: solid;
+			border-color: $light-style-sub-menu-border-color;
 
-			border: 1px solid $light-style-sub-menu-border-color;
+			// Light / Dark styles.
 			background-color: $light-style-sub-menu-background-color;
 			color: $light-style-sub-menu-text-color;
 
+			// Position (level 1)
+			position: absolute;
+			z-index: 1;
+
+			// Position (deep levels).
 			.block-editor-inner-blocks {
 				left: 100%;
 				top: 0;

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -76,37 +76,6 @@ $navigation-item-height: 46px;
 	}
 }
 
-// Sub menus.
-.wp-block-navigation {
-
-	// Only display inner blocks when the block is being edited.
-	.wp-block-navigation-link > .block-editor-inner-blocks {
-		display: none;
-	}
-
-	// No text color - Default / Light styles
-	&:not(.has-text-color) .wp-block-navigation-link > .block-editor-inner-blocks {
-		color: $light-style-sub-menu-background-color;
-		border-color: $light-style-sub-menu-background-color;
-	}
-
-	// No background color - Default / Light styles
-	&:not(.has-background-color) .wp-block-navigation-link > .block-editor-inner-blocks {
-		background-color: $light-style-sub-menu-background-color;
-	}
-
-	// No text color - Dark styles
-	&:not(.has-text-color).is-style-dark .wp-block-navigation-link > .block-editor-inner-blocks {
-		color: $dark-style-sub-menu-text-color;
-		border-color: $dark-style-sub-menu-border-color;
-	}
-
-	// No background color - Dark styles
-	&:not(.has-background-color).is-style-dark .wp-block-navigation-link > .block-editor-inner-blocks {
-		background-color: $dark-style-sub-menu-background-color;
-	}
-}
-
 .wp-block-navigation__inserter-content {
 	padding: $grid-size-large;
 }

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -78,31 +78,10 @@ $navigation-item-height: 46px;
 
 // Sub menus.
 .wp-block-navigation {
-	.wp-block-navigation-link {
-		position: relative;
 
-		// Only display inner blocks when the block is being edited.
-		> .block-editor-inner-blocks {
-			display: none;
-		}
-
-		&.is-editing.has-child > .block-editor-inner-blocks {
-			// Box model.
-			display: flex;
-			border-width: 1px;
-			border-style: solid;
-			border-radius: 2px;
-
-			// Position (level 1)
-			position: absolute;
-			z-index: 1;
-
-			// Position (deep levels).
-			.block-editor-inner-blocks {
-				left: calc(100% + 8px); // TODO: use correct variable
-				top: 0;
-			}
-		}
+	// Only display inner blocks when the block is being edited.
+	.wp-block-navigation-link > .block-editor-inner-blocks {
+		display: none;
 	}
 
 	// Inherit colors from menu.

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -84,13 +84,6 @@ $navigation-item-height: 46px;
 		display: none;
 	}
 
-	// Inherit colors from menu.
-	.wp-block-navigation-link .block-editor-inner-blocks {
-		background-color: inherit;
-		color: inherit;
-		border-color: inherit;
-	}
-
 	// No text color - Default / Light styles
 	&:not(.has-text-color) .wp-block-navigation-link > .block-editor-inner-blocks {
 		color: $light-style-sub-menu-background-color;

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -82,12 +82,45 @@ $navigation-item-height: 46px;
 	flex-wrap: wrap;
 }
 
-// Vertical aligment.
+// Vertical alignment.
 .wp-block-navigation {
 	min-height: $navigation-height;
 	padding-top: 7px;
 	padding-bottom: 7px;
 	align-items: center;
+}
+
+// Sub menus.
+
+
+// Only display inner blocks when the block is being edited.
+
+.wp-block-navigation {
+	.wp-block-navigation-link {
+		position: relative;
+
+		// Only display inner blocks when the block is being edited.
+		> .block-editor-inner-blocks {
+			display: none;
+		}
+
+		&.is-editing.has-child > .block-editor-inner-blocks {
+			display: block;
+			position: absolute;
+			width: 100%;
+			z-index: 1;
+			white-space: nowrap;
+
+			border: 1px solid $light-style-sub-menu-border-color;
+			background-color: $light-style-sub-menu-background-color;
+			color: $light-style-sub-menu-text-color;
+
+			.block-editor-inner-blocks {
+				left: 100%;
+				top: 0;
+			}
+		}
+	}
 }
 
 .wp-block-navigation__inserter-content {

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -91,10 +91,6 @@ $navigation-item-height: 46px;
 }
 
 // Sub menus.
-
-
-// Only display inner blocks when the block is being edited.
-
 .wp-block-navigation {
 	.wp-block-navigation-link {
 		position: relative;
@@ -124,19 +120,16 @@ $navigation-item-height: 46px;
 	}
 
 	// Inherit colors from menu.
-	// Some of these selectors should be replaced/removed
-	// once sub-menus support custom colors.
-	.block-editor-inner-blocks,
-	.block-editor-block-list__layout,
-	.wp-block,
-	.wp-block-navigation-link {
+	.wp-block-navigation-link .block-editor-inner-blocks {
 		background-color: inherit;
 		color: inherit;
+		border-color: inherit;
 	}
 
-	// Default / Light styles
-	.wp-block-navigation-link > .block-editor-inner-blocks {
-		border-color: $light-style-sub-menu-border-color;
+	// No text color - Default / Light styles
+	&:not(.has-text-color) .wp-block-navigation-link > .block-editor-inner-blocks {
+		color: $light-style-sub-menu-background-color;
+		border-color: $light-style-sub-menu-background-color;
 	}
 
 	// No background color - Default / Light styles
@@ -144,10 +137,14 @@ $navigation-item-height: 46px;
 		background-color: $light-style-sub-menu-background-color;
 	}
 
+	// No text color - Dark styles
+	&:not(.has-text-color).is-style-dark .wp-block-navigation-link > .block-editor-inner-blocks {
+		color: $dark-style-sub-menu-text-color;
+		border-color: $dark-style-sub-menu-border-color;
+	}
+
 	// No background color - Dark styles
 	&:not(.has-background-color).is-style-dark .wp-block-navigation-link > .block-editor-inner-blocks {
-		border-color: $dark-style-sub-menu-border-color;
-		color: $dark-style-sub-menu-text-color;
 		background-color: $dark-style-sub-menu-background-color;
 	}
 }

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -46,11 +46,8 @@ $navigation-item-height: 46px;
 
 	// Polish the Appender.
 	.wp-block-navigation .block-list-appender {
-		margin: 0;
 		width: 28px;
 		height: 28px;
-		margin-top: $grid-size-small;
-		margin-left: $grid-size + $block-side-ui-clearance;
 
 		.block-editor-button-block-appender {
 			padding: $grid-size;

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -106,10 +106,10 @@ $navigation-item-height: 46px;
 
 		&.is-editing.has-child > .block-editor-inner-blocks {
 			// Box model.
-			display: block;
-			width: 100%;
+			display: flex;
 			border-width: 1px;
 			border-style: solid;
+			border-radius: 2px;
 
 			// Position (level 1)
 			position: absolute;
@@ -117,20 +117,20 @@ $navigation-item-height: 46px;
 
 			// Position (deep levels).
 			.block-editor-inner-blocks {
-				left: 100%;
+				left: calc(100% + 8px); // TODO: use correct variable
 				top: 0;
 			}
 		}
 	}
 
-	// Light styles.
-	&.is-style-light .wp-block-navigation-link > .block-editor-inner-blocks {
+	// Default / Light styles
+	.wp-block-navigation-link > .block-editor-inner-blocks {
 		color: $light-style-sub-menu-text-color;
 		border-color: $light-style-sub-menu-border-color;
 		background-color: $light-style-sub-menu-background-color;
 	}
 
-	// Light / Dark styles.
+	// Dark styles
 	&.is-style-dark .wp-block-navigation-link > .block-editor-inner-blocks {
 		color: $dark-style-sub-menu-text-color;
 		border-color: $dark-style-sub-menu-border-color;

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -110,11 +110,6 @@ $navigation-item-height: 46px;
 			width: 100%;
 			border-width: 1px;
 			border-style: solid;
-			border-color: $light-style-sub-menu-border-color;
-
-			// Light / Dark styles.
-			background-color: $light-style-sub-menu-background-color;
-			color: $light-style-sub-menu-text-color;
 
 			// Position (level 1)
 			position: absolute;
@@ -126,6 +121,20 @@ $navigation-item-height: 46px;
 				top: 0;
 			}
 		}
+	}
+
+	// Light styles.
+	&.is-style-light .wp-block-navigation-link > .block-editor-inner-blocks {
+		color: $light-style-sub-menu-text-color;
+		border-color: $light-style-sub-menu-border-color;
+		background-color: $light-style-sub-menu-background-color;
+	}
+
+	// Light / Dark styles.
+	&.is-style-dark .wp-block-navigation-link > .block-editor-inner-blocks {
+		color: $dark-style-sub-menu-text-color;
+		border-color: $dark-style-sub-menu-border-color;
+		background-color: $dark-style-sub-menu-background-color;
 	}
 }
 

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -116,7 +116,7 @@ function gutenberg_remove_empty_navigation_links_recursive( $blocks ) {
  * @return string
  */
 function render_submenu_icon() {
-	return '<svg width="18" height="18" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" role="img" aria-hidden="true" focusable="false"><polygon points="9,13.5 14.7,7.9 13.2,6.5 9,10.7 4.8,6.5 3.3,7.9 "></polygon></svg>';
+	return '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" transform="rotate(90)"><path d="M8 5v14l11-7z"/><path d="M0 0h24v24H0z" fill="none"/></svg>';
 }
 
 /**

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -180,8 +180,8 @@ function build_navigation_html( $attributes, $block, $colors, $font_sizes, $is_l
 		$colors['css_classes'],
 		$font_sizes['css_classes']
 	);
-	$css_classes     = implode( ' ', $classes );
-	$class_attribute = sprintf( ' class="wp-block-navigation-link %s', esc_attr( trim( $css_classes ) ) );
+	$classes[]       = 'wp-block-navigation-link';
+	$css_classes     = trim( implode( ' ', $classes ) );
 	$style_attribute = ( $colors['inline_styles'] || $font_sizes['inline_styles'] )
 		? sprintf( ' style="%s"', esc_attr( $colors['inline_styles'] ) . esc_attr( $font_sizes['inline_styles'] ) )
 		: '';
@@ -189,7 +189,7 @@ function build_navigation_html( $attributes, $block, $colors, $font_sizes, $is_l
 	foreach ( (array) $block['innerBlocks'] as $key => $block ) {
 		$has_submenu = count( (array) $block['innerBlocks'] ) > 0;
 
-		$html .= '<li' . $class_attribute . ( $has_submenu ? ' has-child' : '' ) . '"' . $style_attribute . '>' .
+		$html .= '<li class="' . esc_attr( $css_classes . ( $has_submenu ? ' has-child' : '' ) ) . '"' . $style_attribute . '>' .
 			'<a class="wp-block-navigation-link__content"';
 
 		// Start appending HTML attributes to anchor tag.

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -20,7 +20,7 @@ function build_css_colors( $attributes ) {
 
 	// Text color.
 	$has_named_text_color  = array_key_exists( 'textColor', $attributes );
-	$has_custom_text_color = array_key_exists( 'customTextColor', $attributes );
+	$has_custom_text_color = array_key_exists( 'rgbTextColor', $attributes );
 
 	// If has text color.
 	if ( $has_custom_text_color || $has_named_text_color ) {
@@ -33,12 +33,12 @@ function build_css_colors( $attributes ) {
 		$colors['css_classes'][] = sprintf( 'has-%s-color', $attributes['textColor'] );
 	} elseif ( $has_custom_text_color ) {
 		// Add the custom color inline style.
-		$colors['inline_styles'] .= sprintf( 'color: %s;', $attributes['customTextColor'] );
+		$colors['inline_styles'] .= sprintf( 'color: %s;', $attributes['rgbTextColor'] );
 	}
 
 	// Background color.
 	$has_named_background_color  = array_key_exists( 'backgroundColor', $attributes );
-	$has_custom_background_color = array_key_exists( 'customBackgroundColor', $attributes );
+	$has_custom_background_color = array_key_exists( 'rgbBackgroundColor', $attributes );
 
 	// If has background color.
 	if ( $has_custom_background_color || $has_named_background_color ) {
@@ -51,7 +51,7 @@ function build_css_colors( $attributes ) {
 		$colors['css_classes'][] = sprintf( 'has-%s-background-color', $attributes['backgroundColor'] );
 	} elseif ( $has_custom_background_color ) {
 		// Add the custom background-color inline style.
-		$colors['inline_styles'] .= sprintf( 'background-color: %s;', $attributes['customBackgroundColor'] );
+		$colors['inline_styles'] .= sprintf( 'background-color: %s;', $attributes['rgbBackgroundColor'] );
 	}
 
 	return $colors;
@@ -269,19 +269,13 @@ function register_block_core_navigation() {
 				'textColor'             => array(
 					'type' => 'string',
 				),
-				'customTextColor'       => array(
-					'type' => 'string',
-				),
-				'valueTextColor'        => array(
+				'rgbTextColor'        => array(
 					'type' => 'string',
 				),
 				'backgroundColor'       => array(
 					'type' => 'string',
 				),
-				'customBackgroundColor' => array(
-					'type' => 'string',
-				),
-				'valueBackgroundColor'  => array(
+				'rgbBackgroundColor' => array(
 					'type' => 'string',
 				),
 				'fontSize'              => array(

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -276,10 +276,16 @@ function register_block_core_navigation() {
 				'customTextColor'       => array(
 					'type' => 'string',
 				),
+				'valueTextColor'            => array(
+					'type' => 'string',
+				),
 				'backgroundColor'       => array(
 					'type' => 'string',
 				),
 				'customBackgroundColor' => array(
+					'type' => 'string',
+				),
+				'valueBackgroundColor'  => array(
 					'type' => 'string',
 				),
 				'fontSize'              => array(

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -302,7 +302,7 @@ function register_block_core_navigation() {
 				),
 				'showSubmenuIcon'       => array(
 					'type'    => 'boolean',
-					'default' => false,
+					'default' => true,
 				),
 			),
 		)

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -276,7 +276,7 @@ function register_block_core_navigation() {
 				'customTextColor'       => array(
 					'type' => 'string',
 				),
-				'valueTextColor'            => array(
+				'valueTextColor'        => array(
 					'type' => 'string',
 				),
 				'backgroundColor'       => array(

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -234,7 +234,7 @@ function build_navigation_html( $attributes, $block, $colors, $font_sizes ) {
 		$html .= '</span>';
 
 		// Append submenu icon to top-level item.
-		if ( $attributes['showSubmenuIcon'] && $has_submenu ) {
+		if ( isset( $attributes['showSubmenuIcon'] ) && $attributes['showSubmenuIcon'] !== false && $has_submenu ) {
 			$html .= '<span class="wp-block-navigation-link__submenu-icon">' . render_submenu_icon() . '</span>';
 		}
 
@@ -287,7 +287,7 @@ function register_block_core_navigation() {
 					'type' => 'string',
 				),
 				'showSubmenuIcon'    => array(
-					'type'    => 'boolean',
+					'type' => 'boolean',
 					'default' => true,
 				),
 			),

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -189,7 +189,7 @@ function build_navigation_html( $attributes, $block, $colors, $font_sizes, $is_l
 	foreach ( (array) $block['innerBlocks'] as $key => $block ) {
 		$has_submenu = count( (array) $block['innerBlocks'] ) > 0;
 
-		$html .= '<li class="wp-block-navigation-link' . ( $has_submenu ? ' has-submenu' : '' ) . '">' .
+		$html .= '<li class="wp-block-navigation-link' . ( $has_submenu ? ' has-child' : '' ) . '">' .
 			'<a';
 
 		if ( $is_level_zero ) {

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -181,7 +181,7 @@ function build_navigation_html( $attributes, $block, $colors, $font_sizes, $is_l
 		$font_sizes['css_classes']
 	);
 	$css_classes     = implode( ' ', $classes );
-	$class_attribute = sprintf( ' class="wp-block-navigation-link__content %s"', esc_attr( trim( $css_classes ) ) );
+	$class_attribute = sprintf( ' class="wp-block-navigation-link %s', esc_attr( trim( $css_classes ) ) );
 	$style_attribute = ( $colors['inline_styles'] || $font_sizes['inline_styles'] )
 		? sprintf( ' style="%s"', esc_attr( $colors['inline_styles'] ) . esc_attr( $font_sizes['inline_styles'] ) )
 		: '';
@@ -189,10 +189,8 @@ function build_navigation_html( $attributes, $block, $colors, $font_sizes, $is_l
 	foreach ( (array) $block['innerBlocks'] as $key => $block ) {
 		$has_submenu = count( (array) $block['innerBlocks'] ) > 0;
 
-		$html .= '<li class="wp-block-navigation-link' . ( $has_submenu ? ' has-child' : '' ) . '">' .
-			'<a';
-
-		$html .= $class_attribute . $style_attribute;
+		$html .= '<li' . $class_attribute . ( $has_submenu ? ' has-child' : '' ) . '"' . $style_attribute . '>' .
+			'<a class="wp-block-navigation-link__content"';
 
 		// Start appending HTML attributes to anchor tag.
 		if ( isset( $block['attrs']['url'] ) ) {

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -262,32 +262,32 @@ function register_block_core_navigation() {
 	register_block_type(
 		'core/navigation',
 		array(
-			'attributes' => array(
-				'className'             => array(
+			'attributes'      => array(
+				'className'          => array(
 					'type' => 'string',
 				),
-				'textColor'             => array(
+				'textColor'          => array(
 					'type' => 'string',
 				),
-				'rgbTextColor'        => array(
+				'rgbTextColor'       => array(
 					'type' => 'string',
 				),
-				'backgroundColor'       => array(
+				'backgroundColor'    => array(
 					'type' => 'string',
 				),
 				'rgbBackgroundColor' => array(
 					'type' => 'string',
 				),
-				'fontSize'              => array(
+				'fontSize'           => array(
 					'type' => 'string',
 				),
-				'customFontSize'        => array(
+				'customFontSize'     => array(
 					'type' => 'number',
 				),
-				'itemsJustification'    => array(
+				'itemsJustification' => array(
 					'type' => 'string',
 				),
-				'showSubmenuIcon'       => array(
+				'showSubmenuIcon'    => array(
 					'type'    => 'boolean',
 					'default' => true,
 				),

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -170,11 +170,10 @@ function render_block_navigation( $content, $block ) {
  * @param array $block         The NavigationItem block.
  * @param array $colors        Contains inline styles and CSS classes to apply to navigation item.
  * @param array $font_sizes    Contains inline styles and CSS classes to apply to navigation item.
- * @param bool  $is_level_zero True whether is main menu (level zero). Otherwise, False.
  *
  * @return string Returns  an HTML list from innerBlocks.
  */
-function build_navigation_html( $attributes, $block, $colors, $font_sizes, $is_level_zero = true ) {
+function build_navigation_html( $attributes, $block, $colors, $font_sizes ) {
 	$html            = '';
 	$classes         = array_merge(
 		$colors['css_classes'],

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -288,6 +288,9 @@ function register_block_core_navigation() {
 				'valueBackgroundColor'  => array(
 					'type' => 'string',
 				),
+				'detectedTextColor'  => array(
+					'type' => 'string',
+				),
 				'fontSize'              => array(
 					'type' => 'string',
 				),

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -252,7 +252,7 @@ function build_navigation_html( $attributes, $block, $colors, $font_sizes, $is_l
 
 		$html .= '</li>';
 	}
-	return '<ul>' . $html . '</ul>';
+	return '<ul class="wp-block-navigation__container">' . $html . '</ul>';
 }
 
 /**

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -190,11 +190,9 @@ function build_navigation_html( $attributes, $block, $colors, $font_sizes, $is_l
 		$has_submenu = count( (array) $block['innerBlocks'] ) > 0;
 
 		$html .= '<li class="wp-block-navigation-link' . ( $has_submenu ? ' has-child' : '' ) . '">' .
-			'<a class="wp-block-navigation-link__content"';
+			'<a';
 
-		if ( $is_level_zero ) {
-			$html .= $class_attribute . $style_attribute;
-		}
+		$html .= $class_attribute . $style_attribute;
 
 		// Start appending HTML attributes to anchor tag.
 		if ( isset( $block['attrs']['url'] ) ) {

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -190,7 +190,7 @@ function build_navigation_html( $attributes, $block, $colors, $font_sizes, $is_l
 		$has_submenu = count( (array) $block['innerBlocks'] ) > 0;
 
 		$html .= '<li class="wp-block-navigation-link' . ( $has_submenu ? ' has-child' : '' ) . '">' .
-			'<a';
+			'<a class="wp-block-navigation-link__content"';
 
 		if ( $is_level_zero ) {
 			$html .= $class_attribute . $style_attribute;
@@ -239,7 +239,7 @@ function build_navigation_html( $attributes, $block, $colors, $font_sizes, $is_l
 		$html .= '</span>';
 
 		// Append submenu icon to top-level item.
-		if ( ! empty( $attributes['showSubmenuIcon'] ) && $is_level_zero && $has_submenu ) {
+		if ( $attributes['showSubmenuIcon'] && $has_submenu ) {
 			$html .= '<span class="wp-block-navigation-link__submenu-icon">' . render_submenu_icon() . '</span>';
 		}
 

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -234,7 +234,15 @@ function build_navigation_html( $attributes, $block, $colors, $font_sizes ) {
 		$html .= '</span>';
 
 		// Append submenu icon to top-level item.
-		if ( isset( $attributes['showSubmenuIcon'] ) && $attributes['showSubmenuIcon'] !== false && $has_submenu ) {
+		// it shows the icon as default, when 'showSubmenuIcon' is not set,
+		// or when it's set and also not False.
+		if (
+			(
+				isset( $attributes['showSubmenuIcon'] ) && false !== $attributes['showSubmenuIcon'] ||
+				! isset( $attributes['showSubmenuIcon'] )
+			) &&
+			$has_submenu
+		) {
 			$html .= '<span class="wp-block-navigation-link__submenu-icon">' . render_submenu_icon() . '</span>';
 		}
 
@@ -261,7 +269,7 @@ function register_block_core_navigation() {
 	register_block_type(
 		'core/navigation',
 		array(
-			'attributes'      => array(
+			'attributes' => array(
 				'className'          => array(
 					'type' => 'string',
 				),
@@ -287,7 +295,7 @@ function register_block_core_navigation() {
 					'type' => 'string',
 				),
 				'showSubmenuIcon'    => array(
-					'type' => 'boolean',
+					'type'    => 'boolean',
 					'default' => true,
 				),
 			),

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -284,9 +284,6 @@ function register_block_core_navigation() {
 				'valueBackgroundColor'  => array(
 					'type' => 'string',
 				),
-				'detectedTextColor'  => array(
-					'type' => 'string',
-				),
 				'fontSize'              => array(
 					'type' => 'string',
 				),

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -105,7 +105,6 @@ $navigation-sub-menu-width: $grid-size * 25;
 	.wp-block-navigation-link {
 		position: relative;
 		margin: 0;
-		padding: 0 $grid-size * 2;
 		min-height: $navigation-menu-height;
 		display: flex;
 		line-height: 1.4;
@@ -158,14 +157,11 @@ $navigation-sub-menu-width: $grid-size * 25;
 			display: flex;
 			align-items: center;
 			width: max-content;
+			padding: $grid-size * 0.75 $grid-size * 2;
 		}
 
 		// Submenu links only
 		.wp-block-navigation-link {
-
-			.wp-block-navigation-link__content {
-				padding: $grid-size * 0.75 $grid-size * 2;
-			}
 
 			&:first-child .wp-block-navigation-link__content {
 				padding-top: $grid-size;

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -1,21 +1,31 @@
 .wp-block-navigation {
+
+	// Frontend: list style reset
 	& > ul {
 		display: block;
 		list-style: none;
 		margin: 0;
-		max-width: none;
 		padding-left: 0;
-		position: relative;
 
 		@include break-small {
 			display: flex;
 			flex-wrap: wrap;
 		}
 
+		// Sub-menu
 		ul {
+			list-style: none;
 			padding-left: 0;
-		}
+			margin-left: 0;
 
+			li {
+				margin: 0;
+			}
+		}
+	}
+
+	// Frontend: submenu flyout
+	& > ul {
 		li {
 			position: relative;
 			z-index: 1;
@@ -37,9 +47,21 @@
 			}
 		}
 
-		// ToDo: move navigation-link styles to navigation-link/style.scss
-		& > li {
+		& > li > ul {
+			position: absolute;
+			left: 0;
+			top: 80%;
+			min-width: max-content;
+			opacity: 0;
+			transition: opacity 0.15s linear, transform 0.15s linear, right 0s 0.15s;
+			transform: translateY(0.6rem);
+			visibility: hidden;
+		}
+	}
 
+	// TODO: these styles should be shared between editor & Frontend
+	& > ul {
+		& > li {
 			& > a {
 				display: flex;
 				align-items: center;
@@ -66,52 +88,12 @@
 				}
 			}
 		}
-
-		// Sub-menus Flyout
-		& > li > ul {
-			margin: 0;
-			padding: 0 30px 0 10px;
-			position: absolute;
-			left: 0;
-			top: 80%;
-			min-width: max-content;
-			opacity: 0;
-			transition: opacity 0.15s linear, transform 0.15s linear, right 0s 0.15s;
-			transform: translateY(0.6rem);
-			visibility: hidden;
-
-			li {
-				margin: 0;
-
-				& > ul {
-					padding-left: 10px;
-				}
-			}
-
-			a {
-				text-decoration: none;
-
-				&:hover {
-					text-decoration: underline;
-				}
-			}
-
-			ul {
-				width: 100%;
-			}
-		}
 	}
 
 	// Navigation Link
 	a {
 		display: block;
 		padding: 16px;
-	}
-
-	// Sub-menu
-	ul ul {
-		list-style: none;
-		margin-left: 0;
 	}
 
 	&.items-justified-left > ul {

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -188,7 +188,7 @@ $navigation-min-height: 60px;
 		//  No text color
 		&:not(.has-text-color) > .block-editor-inner-blocks,
 		&:not(.has-text-color) > .wp-block-navigation__container {
-			color: $light-style-sub-menu-background-color;
+			color: $light-style-sub-menu-text-color;
 			border-color: $light-style-sub-menu-border-color;
 		}
 
@@ -196,15 +196,6 @@ $navigation-min-height: 60px;
 		&:not(.has-background-color) > .block-editor-inner-blocks,
 		&:not(.has-background-color) > .wp-block-navigation__container {
 			background-color: $light-style-sub-menu-background-color;
-
-			.wp-block-navigation-link__submenu-icon,
-			.wp-block-navigation-link__content {
-				color: $light-style-sub-menu-text-color;
-			}
-
-			.wp-block-navigation-link__content:hover {
-				color: $light-style-sub-menu-text-color-hover;
-			}
 		}
 	}
 
@@ -213,7 +204,7 @@ $navigation-min-height: 60px;
 		// No text color
 		&:not(.has-text-color) > .block-editor-inner-blocks,
 		&:not(.has-text-color) > .wp-block-navigation__container {
-			color: $dark-style-sub-menu-background-color;
+			color: $dark-style-sub-menu-text-color;
 			border-color: $dark-style-sub-menu-border-color;
 		}
 
@@ -221,15 +212,6 @@ $navigation-min-height: 60px;
 		&:not(.has-background-color) > .block-editor-inner-blocks,
 		&:not(.has-background-color) > .wp-block-navigation__container {
 			background-color: $dark-style-sub-menu-background-color;
-
-			.wp-block-navigation-link__submenu-icon,
-			.wp-block-navigation-link__content {
-				color: $dark-style-sub-menu-text-color;
-			}
-
-			.wp-block-navigation-link__content:hover {
-				color: $dark-style-sub-menu-text-color-hover;
-			}
 		}
 	}
 }

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -180,7 +180,7 @@ $navigation-sub-menu-width: $grid-size * 25;
 
 		.wp-block-navigation-link__submenu-icon {
 			position: absolute;
-			right: $grid-size;
+			right: $grid-size * 2;
 
 			svg {
 				fill: currentColor;

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -126,13 +126,14 @@ $navigation-height: 60px;
 				fill: currentColor;
 			}
 		}
+
+		// reset rotation of submenu indicator icons on nested levels
+		.wp-block-navigation-link svg {
+			transform: rotate(0);
+		}
 	}
 }
 
-// reset rotation of submenu indicator icons on nested levels
-.wp-block-navigation-link .wp-block-navigation-link svg {
-	transform: rotate(0);
-}
 
 /*
 * Frontend: non-shared styles & overrides

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -112,6 +112,12 @@ $navigation-height: 60px;
 				top: 0;
 			}
 		}
+
+		.wp-block-navigation-link__content {
+			display: flex;
+			align-items: center;
+			width: max-content;
+		}
 	}
 }
 
@@ -125,10 +131,6 @@ $navigation-height: 60px;
 */
 
 .wp-block-navigation {
-
-	.wp-block-navigation__container {
-		width: max-content;
-	}
 
 	.wp-block-navigation-link.has-child > .wp-block-navigation__container {
 		display: block;

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -19,6 +19,7 @@ $navigation-height: 60px;
 	ul {
 		list-style: none;
 		padding-left: 0;
+		margin-top: 0;
 		margin-left: 0;
 
 		li {
@@ -107,7 +108,7 @@ $navigation-height: 60px;
 			// Position (nested levels)
 			.block-editor-inner-blocks,
 			.wp-block-navigation__container {
-				left: calc(100% + 8px); // TODO: use correct variable
+				left: calc(100% + #{$grid-size});
 				top: 0;
 			}
 		}
@@ -132,6 +133,10 @@ $navigation-height: 60px;
 	.wp-block-navigation-link.has-child > .wp-block-navigation__container {
 		display: block;
 		padding: $grid-size;
+
+		.wp-block-navigation__container {
+			left: calc(100% + #{$grid-size} * 2);
+		}
 	}
 }
 

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -49,7 +49,8 @@ $navigation-height: 60px;
 		& ul:focus {
 			visibility: visible;
 			opacity: 1;
-			display: block;
+			display: flex;
+			flex-direction: column;
 		}
 	}
 
@@ -76,9 +77,12 @@ $navigation-height: 60px;
 
 .wp-block-navigation {
 
-	// Vertical alignment
-	min-height: $navigation-height;
-	align-items: center;
+	// Min height and vertical alignment.
+	&,
+	> .wp-block-navigation__container {
+		min-height: $navigation-height;
+		align-items: center;
+	}
 
 	// Submenus
 	.wp-block-navigation-link {
@@ -214,7 +218,8 @@ $navigation-height: 60px;
 .wp-block-navigation {
 
 	.wp-block-navigation-link.has-child > .wp-block-navigation__container {
-		display: block;
+		display: flex;
+		flex-direction: column;
 		padding: $grid-size;
 
 		.wp-block-navigation__container {

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -160,6 +160,18 @@
 		}
 	}
 
+	// Top-level sub-menu indicators.
+	& .has-sub-menu > a {
+
+		&::after {
+			content: "\00a0\25BC";
+			display: inline-block;
+			font-size: 0.6rem;
+			height: inherit;
+			width: inherit;
+		}
+	}
+
 	&.items-justified-left > ul {
 		justify-content: flex-start;
 	}
@@ -172,18 +184,7 @@
 		justify-content: flex-end;
 	}
 
-	// Colors.
-	$light-style-sub-menu-background-color: #fff;
-	$light-style-sub-menu-border-color: #e2e4e7;
-	$light-style-sub-menu-text-color: #111;
-	$light-style-sub-menu-text-color-hover: #333;
-
-	$dark-style-sub-menu-background-color: #333;
-	$dark-style-sub-menu-border-color: #111;
-	$dark-style-sub-menu-text-color: #fff;
-	$dark-style-sub-menu-text-color-hover: #eee;
-
-	// Default Style / Ligth style.
+	// Default Style / Light styles.
 	& > ul > li > ul,
 	&.is-light-style > ul > li > ul {
 		background-color: $light-style-sub-menu-background-color;
@@ -210,7 +211,7 @@
 		}
 	}
 
-	// Dark Style.
+	// Dark Styles.
 	&.is-style-dark > ul > li > ul {
 		background-color: $dark-style-sub-menu-background-color;
 		border-color: $dark-style-sub-menu-border-color;

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -33,7 +33,6 @@ $navigation-height: 60px;
 
 .wp-block-navigation > ul {
 	li {
-		position: relative;
 		z-index: 1;
 
 		&:hover,
@@ -66,7 +65,7 @@ $navigation-height: 60px;
 }
 
 /*
-* Shared styles between editor and frontend
+* Styles shared between editor and frontend
 */
 .wp-block-navigation,
 .wp-block-navigation .block-editor-block-list__layout {
@@ -81,11 +80,59 @@ $navigation-height: 60px;
 	padding-top: 7px;
 	padding-bottom: 7px;
 	align-items: center;
+
+	// Submenus
+	.wp-block-navigation-link {
+		position: relative;
+		// Provide a base menu item margin.
+		// This should be the same inside the field,
+		// and the edit container should compensate.
+		// This is to make sure the edit and view are the same.
+		margin-left: $grid-size;
+		margin-right: $grid-size;
+		padding: 0 $grid-size;
+
+		&.has-child > .wp-block-navigation__container,
+		&.is-editing.has-child > .block-editor-inner-blocks {
+			// Box model
+			display: flex;
+			border-width: 1px;
+			border-style: solid;
+			border-radius: 2px;
+
+			// Position (first level)
+			position: absolute;
+			z-index: 1;
+
+			// Position (nested levels)
+			.block-editor-inner-blocks,
+			.wp-block-navigation__container {
+				left: calc(100% + 8px); // TODO: use correct variable
+				top: 0;
+			}
+		}
+	}
 }
 
 // reset rotation of submenu indicator icons on nested levels
 .wp-block-navigation-link .wp-block-navigation-link svg {
 	transform: rotate(0);
+}
+
+/*
+* Frontend: non-shared styles & overrides
+*/
+
+.wp-block-navigation {
+
+	.wp-block-navigation__container {
+		width: max-content;
+	}
+
+	.wp-block-navigation-link.has-child > .wp-block-navigation__container {
+		display: block;
+		padding: $grid-size;
+	}
 }
 
 /*

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -139,7 +139,7 @@ $navigation-sub-menu-height: $grid-size * 5;
 			// Position (first level)
 			position: absolute;
 			z-index: 1;
-			top: $navigation-menu-height;
+			top: $navigation-menu-height - $grid-size;
 			left: $grid-size * 2; // just under the main menu item.
 
 			// Position (nested levels)

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -69,12 +69,6 @@
 
 		// Sub-menus Flyout
 		& > li > ul {
-			-webkit-box-shadow: 0 3px 30px rgba(25, 30, 35, 0.1);
-			-moz-box-shadow: 0 3px 30px rgba(25, 30, 35, 0.1);
-			border-radius: 3px;
-			box-shadow: 0 3px 30px rgba(25, 30, 35, 0.1);
-			border-width: 1px;
-			border-style: solid;
 			margin: 0;
 			padding: 0 30px 0 10px;
 			position: absolute;
@@ -102,33 +96,6 @@
 				}
 			}
 
-			// Sub menu arrow.
-			$light-style-sub-menu-arrow-width: 20px;
-			&::after,
-			&::before {
-				bottom: 100%;
-				left: 22px;
-				border: solid transparent;
-				content: " ";
-				height: 0;
-				width: 0;
-				position: absolute;
-				pointer-events: none;
-			}
-
-			// Sub menu arrow. Background.
-			&::after {
-				border-width: $light-style-sub-menu-arrow-width / 2;
-				margin-left: -($light-style-sub-menu-arrow-width / 2);
-				bottom: calc(100% - 1px);
-			}
-
-			// Sub menu arrow. Border.
-			&::before {
-				border-width: $light-style-sub-menu-arrow-width / 2 + 1px;
-				margin-left: -($light-style-sub-menu-arrow-width / 2 + 1px);
-			}
-
 			ul {
 				width: 100%;
 			}
@@ -141,35 +108,10 @@
 		padding: 16px;
 	}
 
-	// Sub-menu depth indicators
+	// Sub-menu
 	ul ul {
 		list-style: none;
 		margin-left: 0;
-
-		li a {
-			padding-top: 8px;
-			padding-bottom: 8px;
-
-			&:first-child {
-				padding-top: 13px;
-			}
-
-			&:last-child {
-				padding-bottom: 13px;
-			}
-		}
-	}
-
-	// Top-level sub-menu indicators.
-	& .has-sub-menu > a {
-
-		&::after {
-			content: "\00a0\25BC";
-			display: inline-block;
-			font-size: 0.6rem;
-			height: inherit;
-			width: inherit;
-		}
 	}
 
 	&.items-justified-left > ul {

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -1,3 +1,5 @@
+$navigation-height: 60px;
+
 /*
 * Frontend: reset the default list styles
 */
@@ -66,13 +68,19 @@
 /*
 * Shared styles between editor and frontend
 */
+.wp-block-navigation,
+.wp-block-navigation .block-editor-block-list__layout {
+	display: flex;
+	flex-wrap: wrap;
+}
 
 .wp-block-navigation {
 
-	// reset rotation of submenu indicator icons on nested levels
-	.wp-block-navigation-link .wp-block-navigation-link svg {
-		transform: rotate(0);
-	}
+	// Vertical alignment
+	min-height: $navigation-height;
+	padding-top: 7px;
+	padding-bottom: 7px;
+	align-items: center;
 }
 
 

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -91,6 +91,10 @@ $navigation-height: 60px;
 		margin-right: $grid-size;
 		padding: 0 $grid-size;
 
+		> .block-editor-inner-blocks {
+			display: none;
+		}
+
 		&.has-child > .wp-block-navigation__container,
 		&.is-editing.has-child > .block-editor-inner-blocks {
 			// Box model
@@ -148,6 +152,60 @@ $navigation-height: 60px;
 	}
 }
 
+// Styles
+.wp-block-navigation {
+
+	// Default / Light styles - No text color
+	.wp-block-navigation-link,
+	&.is-style-light .wp-block-navigation-link {
+		//  No text color
+		&:not(.has-text-color) > .block-editor-inner-blocks,
+		&:not(.has-text-color) > .wp-block-navigation__container {
+			color: $light-style-sub-menu-background-color;
+			border-color: $light-style-sub-menu-border-color;
+		}
+
+		// No background color
+		&:not(.has-background-color) > .block-editor-inner-blocks,
+		&:not(.has-background-color) > .wp-block-navigation__container {
+			background-color: $light-style-sub-menu-background-color;
+
+			.wp-block-navigation-link__submenu-icon,
+			.wp-block-navigation-link__content {
+				color: $light-style-sub-menu-text-color;
+			}
+
+			.wp-block-navigation-link__content:hover {
+				color: $light-style-sub-menu-text-color-hover;
+			}
+		}
+	}
+
+	// Dark styles.
+	&.is-style-dark .wp-block-navigation-link {
+		// No text color
+		&:not(.has-text-color) > .block-editor-inner-blocks,
+		&:not(.has-text-color) > .wp-block-navigation__container {
+			color: $dark-style-sub-menu-background-color;
+			border-color: $dark-style-sub-menu-border-color;
+		}
+
+		// No background color
+		&:not(.has-background-color) > .block-editor-inner-blocks,
+		&:not(.has-background-color) > .wp-block-navigation__container {
+			background-color: $dark-style-sub-menu-background-color;
+
+			.wp-block-navigation-link__submenu-icon,
+			.wp-block-navigation-link__content {
+				color: $dark-style-sub-menu-text-color;
+			}
+
+			.wp-block-navigation-link__content:hover {
+				color: $dark-style-sub-menu-text-color-hover;
+			}
+		}
+	}
+}
 
 /*
 * Frontend: non-shared styles & overrides
@@ -203,34 +261,5 @@ $navigation-height: 60px;
 
 	&.items-justified-right > ul {
 		justify-content: flex-end;
-	}
-
-	// Default Style / Light styles.
-	& > ul > li > ul,
-	&.is-light-style > ul > li > ul {
-		background-color: $light-style-sub-menu-background-color;
-		border-color: $light-style-sub-menu-border-color;
-
-		a {
-			color: $light-style-sub-menu-text-color;
-
-			&:hover {
-				color: $light-style-sub-menu-text-color-hover;
-			}
-		}
-	}
-
-	// Dark Styles.
-	&.is-style-dark > ul > li > ul {
-		background-color: $dark-style-sub-menu-background-color;
-		border-color: $dark-style-sub-menu-border-color;
-
-		a {
-			color: $dark-style-sub-menu-text-color;
-
-			&:hover {
-				color: $dark-style-sub-menu-text-color-hover;
-			}
-		}
 	}
 }

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -105,14 +105,8 @@ $navigation-sub-menu-height: $grid-size * 5;
 		// Sub menus
 		.wp-block,
 		.wp-block-navigation-link {
-			min-height: $navigation-sub-menu-height;
-			&:first-child {
-				margin-top: $grid-size;
-			}
-
-			&:last-child {
-				margin-bottom: $grid-size;
-			}
+			min-height: auto; // reset the min-height and rely on padding
+			padding: 0;
 		}
 
 		// Sub menus (editor canvas)
@@ -140,7 +134,7 @@ $navigation-sub-menu-height: $grid-size * 5;
 			.block-editor-inner-blocks,
 			.wp-block-navigation__container {
 				left: 100%;
-				top: - $grid-size - $border-width;
+				top: - $border-width;
 			}
 		}
 
@@ -151,22 +145,38 @@ $navigation-sub-menu-height: $grid-size * 5;
 			color: inherit;
 		}
 
+		// All links
 		.wp-block-navigation-link__content {
 			display: flex;
 			align-items: center;
 			width: max-content;
 		}
 
+		// Submenu links only
+		.wp-block-navigation-link {
+
+			.wp-block-navigation-link__content {
+				padding: $grid-size / 2 $grid-size * 2;
+			}
+
+			&:first-child .wp-block-navigation-link__content {
+				padding-top: $grid-size;
+			}
+
+			&:last-child .wp-block-navigation-link__content {
+				padding-bottom: $grid-size;
+			}
+		}
+
 		&.has-child .wp-block-navigation-link__content {
 			min-width: 100%;
-			padding-right: 16px;
+			padding-right: $grid-size * 4;
 			position: relative;
 		}
 
 		.wp-block-navigation-link__submenu-icon {
-			margin-left: 4px;
 			position: absolute;
-			right: 0;
+			right: $grid-size;
 
 			svg {
 				fill: currentColor;

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -132,11 +132,12 @@ $navigation-sub-menu-height: $grid-size * 5;
 		&.is-editing.has-child > .block-editor-inner-blocks {
 			// Box model
 			display: flex;
+			border: $border-width solid rgba(0, 0, 0, 0.15);
 
 			// Position (first level)
 			position: absolute;
 			z-index: 1;
-			top: $navigation-menu-height;
+			top: $navigation-menu-height - ( $block-padding / 2 );
 			left: $grid-size * 2; // just under the main menu item.
 
 			// Position (nested levels)
@@ -152,7 +153,6 @@ $navigation-sub-menu-height: $grid-size * 5;
 		.wp-block-navigation__container {
 			background-color: inherit;
 			color: inherit;
-			border-color: currentColor;
 		}
 
 		.wp-block-navigation-link__content {
@@ -194,7 +194,6 @@ $navigation-sub-menu-height: $grid-size * 5;
 		&:not(.has-text-color) > .block-editor-inner-blocks,
 		&:not(.has-text-color) > .wp-block-navigation__container {
 			color: $light-style-sub-menu-text-color;
-			border-color: $light-style-sub-menu-border-color;
 		}
 
 		// No background color
@@ -210,7 +209,6 @@ $navigation-sub-menu-height: $grid-size * 5;
 		&:not(.has-text-color) > .block-editor-inner-blocks,
 		&:not(.has-text-color) > .wp-block-navigation__container {
 			color: $dark-style-sub-menu-text-color;
-			border-color: $dark-style-sub-menu-border-color;
 		}
 
 		// No background color

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -113,6 +113,14 @@ $navigation-height: 60px;
 			}
 		}
 
+		// Inherit colors from menu
+		.block-editor-inner-blocks,
+		.wp-block-navigation__container {
+			background-color: inherit;
+			color: inherit;
+			border-color: inherit;
+		}
+
 		.wp-block-navigation-link__content {
 			display: flex;
 			align-items: center;

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -1,4 +1,5 @@
-$navigation-min-height: 60px;
+$navigation-menu-height: $grid-size * 7;
+$navigation-sub-menu-height: $grid-size * 5;
 
 /*
 * Frontend: reset the default list styles
@@ -61,8 +62,11 @@ $navigation-min-height: 60px;
 		min-width: max-content;
 		opacity: 0;
 		transition: opacity 0.15s linear, transform 0.15s linear, right 0s 0.15s;
-		transform: translateY(0.6rem);
 		visibility: hidden;
+
+		> li ul {
+			transform: translateY(0.6rem);
+		}
 	}
 }
 
@@ -77,16 +81,18 @@ $navigation-min-height: 60px;
 
 .wp-block-navigation {
 
-	// Min height and vertical alignment (main menu - level 0)
+	// Remove paddings on subsequent immediate children.
+	.block-editor-inner-blocks > .block-editor-block-list__layout > .wp-block {
+		margin: 0;
+	}
+
 	&,
 	> .wp-block-navigation__container {
-		min-height: $navigation-min-height;
 		align-items: center;
 		width: 100%;
 
 		> .wp-block-navigation-link {
 			display: flex;
-			min-height: $navigation-min-height;
 			margin-top: 0;
 			margin-bottom: 0;
 		}
@@ -96,25 +102,26 @@ $navigation-min-height: 60px;
 	.wp-block-navigation-link {
 		position: relative;
 		margin: 0;
-		padding-left: $grid-size * 2;
-		padding-right: $grid-size * 2;
+		padding: 0 $grid-size * 2;
+		min-height: $navigation-menu-height;
+		display: flex;
 
+		// Sub menus
+		.wp-block,
 		.wp-block-navigation-link {
-			padding-top: $grid-size / 4;
-			padding-bottom: $grid-size / 4;
+			min-height: $navigation-sub-menu-height;
 			&:first-child {
-				padding-top: $grid-size;
+				margin-top: $grid-size;
 			}
 
 			&:last-child {
-				padding-bottom: $grid-size;
+				margin-bottom: $grid-size;
 			}
 		}
 
 		// Sub menus (editor canvas)
-		[data-type="core/navigation-link"] .wp-block-navigation-link {
-			padding-top: 0;
-			padding-bottom: 0;
+		.wp-block .wp-block-navigation-link {
+			margin: 0;
 		}
 
 		> .block-editor-inner-blocks {
@@ -132,6 +139,7 @@ $navigation-min-height: 60px;
 			// Position (first level)
 			position: absolute;
 			z-index: 1;
+			top: $navigation-menu-height;
 			left: $grid-size * 2; // just under the main menu item.
 
 			// Position (nested levels)
@@ -240,9 +248,6 @@ $navigation-min-height: 60px;
 			& > a {
 				display: flex;
 				align-items: center;
-				@include break-small {
-					padding-left: 16px;
-				}
 			}
 
 			&:first-of-type > a {

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -140,7 +140,7 @@ $navigation-sub-menu-height: $grid-size * 5;
 			.block-editor-inner-blocks,
 			.wp-block-navigation__container {
 				left: 100%;
-				top: - $grid-size - 1px; // -1px to account for border width
+				top: - $grid-size - $border-width;
 			}
 		}
 

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -78,8 +78,6 @@ $navigation-height: 60px;
 
 	// Vertical alignment
 	min-height: $navigation-height;
-	padding-top: 7px;
-	padding-bottom: 7px;
 	align-items: center;
 
 	// Submenus

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -127,8 +127,16 @@ $navigation-height: 60px;
 			width: max-content;
 		}
 
+		&.has-child .wp-block-navigation-link__content {
+			min-width: 100%;
+			padding-right: 16px;
+			position: relative;
+		}
+
 		.wp-block-navigation-link__submenu-icon {
 			margin-left: 4px;
+			position: absolute;
+			right: 0;
 
 			svg {
 				fill: currentColor;

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -53,7 +53,7 @@ $navigation-height: 60px;
 		}
 	}
 
-	& > li > ul {
+	& > li ul {
 		position: absolute;
 		left: 0;
 		top: 80%;

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -126,6 +126,11 @@
 		justify-content: flex-end;
 	}
 
+	// reset rotation of submenu indicator icons on nested levels
+	.wp-block-navigation-link .wp-block-navigation-link svg {
+		transform: rotate(0);
+	}
+
 	// Default Style / Light styles.
 	& > ul > li > ul,
 	&.is-light-style > ul > li > ul {

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -1,4 +1,4 @@
-$navigation-height: 60px;
+$navigation-min-height: 60px;
 
 /*
 * Frontend: reset the default list styles
@@ -77,11 +77,18 @@ $navigation-height: 60px;
 
 .wp-block-navigation {
 
-	// Min height and vertical alignment.
+	// Min height and vertical alignment (main menu - level 0)
 	&,
 	> .wp-block-navigation__container {
-		min-height: $navigation-height;
+		min-height: $navigation-min-height;
 		align-items: center;
+
+		> .wp-block-navigation-link {
+			display: flex;
+			min-height: $navigation-min-height;
+			margin-top: 0;
+			margin-bottom: 0;
+		}
 	}
 
 	// Submenus
@@ -159,7 +166,7 @@ $navigation-height: 60px;
 // Styles
 .wp-block-navigation {
 
-	// Default / Light styles - No text color
+	// Default / Light styles
 	.wp-block-navigation-link,
 	&.is-style-light .wp-block-navigation-link {
 		//  No text color

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -91,16 +91,30 @@ $navigation-min-height: 60px;
 		}
 	}
 
-	// Submenus
+	// Main menu
 	.wp-block-navigation-link {
 		position: relative;
-		// Provide a base menu item margin.
-		// This should be the same inside the field,
-		// and the edit container should compensate.
-		// This is to make sure the edit and view are the same.
-		margin-left: $grid-size;
-		margin-right: $grid-size;
-		padding: 0 $grid-size;
+		margin: 0;
+		padding-left: $grid-size * 2;
+		padding-right: $grid-size * 2;
+
+		.wp-block-navigation-link {
+			padding-top: $grid-size / 4;
+			padding-bottom: $grid-size / 4;
+			&:first-child {
+				padding-top: $grid-size;
+			}
+
+			&:last-child {
+				padding-bottom: $grid-size;
+			}
+		}
+
+		// Sub menus (editor canvas)
+		[data-type="core/navigation-link"] .wp-block-navigation-link {
+			padding-top: 0;
+			padding-bottom: 0;
+		}
 
 		> .block-editor-inner-blocks {
 			display: none;
@@ -117,11 +131,12 @@ $navigation-min-height: 60px;
 			// Position (first level)
 			position: absolute;
 			z-index: 1;
+			left: $grid-size * 2; // just under the main menu item.
 
 			// Position (nested levels)
 			.block-editor-inner-blocks,
 			.wp-block-navigation__container {
-				left: calc(100% + #{$grid-size});
+				left: 100%;
 				top: 0;
 			}
 		}
@@ -227,11 +242,7 @@ $navigation-min-height: 60px;
 	.wp-block-navigation-link.has-child > .wp-block-navigation__container {
 		display: flex;
 		flex-direction: column;
-		padding: $grid-size;
-
-		.wp-block-navigation__container {
-			left: calc(100% + #{$grid-size} * 2);
-		}
+		padding: 0;
 	}
 }
 
@@ -246,8 +257,6 @@ $navigation-min-height: 60px;
 			& > a {
 				display: flex;
 				align-items: center;
-				padding-left: 0;
-
 				@include break-small {
 					padding-left: 16px;
 				}

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -82,6 +82,7 @@ $navigation-min-height: 60px;
 	> .wp-block-navigation__container {
 		min-height: $navigation-min-height;
 		align-items: center;
+		width: 100%;
 
 		> .wp-block-navigation-link {
 			display: flex;

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -163,7 +163,7 @@ $navigation-sub-menu-width: $grid-size * 25;
 		// Submenu links only
 		.wp-block-navigation-link {
 
-			&:first-child .wp-block-navigation-link__content {
+			&:first-child:not(:only-child) .wp-block-navigation-link__content {
 				padding-top: $grid-size;
 			}
 

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -218,18 +218,6 @@ $navigation-height: 60px;
 				color: $light-style-sub-menu-text-color-hover;
 			}
 		}
-
-		// Sub menu arrow - background color.
-		&::after {
-			border-color: transparent;
-			border-bottom-color: $light-style-sub-menu-background-color;
-		}
-
-		// Sub menu arrow - border color.
-		&::before {
-			border-color: transparent;
-			border-bottom-color: $light-style-sub-menu-border-color;
-		}
 	}
 
 	// Dark Styles.
@@ -243,16 +231,6 @@ $navigation-height: 60px;
 			&:hover {
 				color: $dark-style-sub-menu-text-color-hover;
 			}
-		}
-
-		// Sub menu arrow - background color.
-		&::after {
-			border-bottom-color: $dark-style-sub-menu-background-color;
-		}
-
-		// Sub menu arrow - border color.
-		&::before {
-			border-bottom-color: $dark-style-sub-menu-border-color;
 		}
 	}
 }

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -118,6 +118,14 @@ $navigation-height: 60px;
 			align-items: center;
 			width: max-content;
 		}
+
+		.wp-block-navigation-link__submenu-icon {
+			margin-left: 4px;
+
+			svg {
+				fill: currentColor;
+			}
+		}
 	}
 }
 
@@ -166,14 +174,6 @@ $navigation-height: 60px;
 
 			&:last-of-type > a {
 				padding-right: 0;
-			}
-
-			.wp-block-navigation-link__submenu-icon {
-				margin-left: 4px;
-
-				svg {
-					fill: currentColor;
-				}
 			}
 		}
 	}

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -83,6 +83,10 @@ $navigation-height: 60px;
 	align-items: center;
 }
 
+// reset rotation of submenu indicator icons on nested levels
+.wp-block-navigation-link .wp-block-navigation-link svg {
+	transform: rotate(0);
+}
 
 /*
 * TODO: organize/untangle styles below this line

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -1,65 +1,87 @@
+/*
+* Frontend: reset the default list styles
+*/
+
+.wp-block-navigation > ul {
+	display: block;
+	list-style: none;
+	margin: 0;
+	padding-left: 0;
+
+	@include break-small {
+		display: flex;
+		flex-wrap: wrap;
+	}
+
+	// Submenu
+	ul {
+		list-style: none;
+		padding-left: 0;
+		margin-left: 0;
+
+		li {
+			margin: 0;
+		}
+	}
+}
+
+/*
+* Frontend: styles for submenu flyout
+*/
+
+.wp-block-navigation > ul {
+	li {
+		position: relative;
+		z-index: 1;
+
+		&:hover,
+		&:focus-within {
+			cursor: pointer;
+			z-index: 99999;
+		}
+
+		// Submenu Display
+		&:hover > ul,
+		&:focus-within > ul,
+		& ul:hover,
+		& ul:focus {
+			visibility: visible;
+			opacity: 1;
+			display: block;
+		}
+	}
+
+	& > li > ul {
+		position: absolute;
+		left: 0;
+		top: 80%;
+		min-width: max-content;
+		opacity: 0;
+		transition: opacity 0.15s linear, transform 0.15s linear, right 0s 0.15s;
+		transform: translateY(0.6rem);
+		visibility: hidden;
+	}
+}
+
+/*
+* Shared styles between editor and frontend
+*/
+
 .wp-block-navigation {
 
-	// Frontend: list style reset
-	& > ul {
-		display: block;
-		list-style: none;
-		margin: 0;
-		padding-left: 0;
-
-		@include break-small {
-			display: flex;
-			flex-wrap: wrap;
-		}
-
-		// Sub-menu
-		ul {
-			list-style: none;
-			padding-left: 0;
-			margin-left: 0;
-
-			li {
-				margin: 0;
-			}
-		}
+	// reset rotation of submenu indicator icons on nested levels
+	.wp-block-navigation-link .wp-block-navigation-link svg {
+		transform: rotate(0);
 	}
+}
 
-	// Frontend: submenu flyout
-	& > ul {
-		li {
-			position: relative;
-			z-index: 1;
 
-			&:hover,
-			&:focus-within {
-				cursor: pointer;
-				z-index: 99999;
-			}
+/*
+* TODO: organize/untangle styles below this line
+*/
 
-			// Submenu Display
-			&:hover > ul,
-			&:focus-within > ul,
-			& ul:hover,
-			& ul:focus {
-				visibility: visible;
-				opacity: 1;
-				display: block;
-			}
-		}
+.wp-block-navigation {
 
-		& > li > ul {
-			position: absolute;
-			left: 0;
-			top: 80%;
-			min-width: max-content;
-			opacity: 0;
-			transition: opacity 0.15s linear, transform 0.15s linear, right 0s 0.15s;
-			transform: translateY(0.6rem);
-			visibility: hidden;
-		}
-	}
-
-	// TODO: these styles should be shared between editor & Frontend
 	& > ul {
 		& > li {
 			& > a {
@@ -90,12 +112,6 @@
 		}
 	}
 
-	// Navigation Link
-	a {
-		display: block;
-		padding: 16px;
-	}
-
 	&.items-justified-left > ul {
 		justify-content: flex-start;
 	}
@@ -106,11 +122,6 @@
 
 	&.items-justified-right > ul {
 		justify-content: flex-end;
-	}
-
-	// reset rotation of submenu indicator icons on nested levels
-	.wp-block-navigation-link .wp-block-navigation-link svg {
-		transform: rotate(0);
 	}
 
 	// Default Style / Light styles.

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -147,7 +147,7 @@ $navigation-min-height: 60px;
 		.wp-block-navigation__container {
 			background-color: inherit;
 			color: inherit;
-			border-color: inherit;
+			border-color: currentColor;
 		}
 
 		.wp-block-navigation-link__content {

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -63,10 +63,6 @@ $navigation-sub-menu-height: $grid-size * 5;
 		opacity: 0;
 		transition: opacity 0.1s linear;
 		visibility: hidden;
-
-		> li ul {
-			transform: translateY(0.6rem);
-		}
 	}
 }
 
@@ -144,7 +140,7 @@ $navigation-sub-menu-height: $grid-size * 5;
 			.block-editor-inner-blocks,
 			.wp-block-navigation__container {
 				left: 100%;
-				top: 0;
+				top: - $grid-size - 1px; // -1px to account for border width
 			}
 		}
 

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -58,10 +58,10 @@ $navigation-sub-menu-height: $grid-size * 5;
 	& > li ul {
 		position: absolute;
 		left: 0;
-		top: 80%;
+		top: 100%;
 		min-width: max-content;
 		opacity: 0;
-		transition: opacity 0.15s linear, transform 0.15s linear, right 0s 0.15s;
+		transition: opacity 0.1s linear;
 		visibility: hidden;
 
 		> li ul {
@@ -132,14 +132,11 @@ $navigation-sub-menu-height: $grid-size * 5;
 		&.is-editing.has-child > .block-editor-inner-blocks {
 			// Box model
 			display: flex;
-			border-width: 1px;
-			border-style: solid;
-			border-radius: 2px;
 
 			// Position (first level)
 			position: absolute;
 			z-index: 1;
-			top: $navigation-menu-height - $grid-size;
+			top: $navigation-menu-height;
 			left: $grid-size * 2; // just under the main menu item.
 
 			// Position (nested levels)

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -1,5 +1,6 @@
 $navigation-menu-height: $grid-size * 7;
 $navigation-sub-menu-height: $grid-size * 5;
+$navigation-sub-menu-width: $grid-size * 25;
 
 /*
 * Frontend: reset the default list styles
@@ -59,7 +60,8 @@ $navigation-sub-menu-height: $grid-size * 5;
 		position: absolute;
 		left: 0;
 		top: 100%;
-		min-width: max-content;
+		min-width: $navigation-sub-menu-width;
+		max-width: $navigation-sub-menu-width;
 		opacity: 0;
 		transition: opacity 0.1s linear;
 		visibility: hidden;
@@ -76,6 +78,11 @@ $navigation-sub-menu-height: $grid-size * 5;
 }
 
 .wp-block-navigation {
+
+	// set a width on the editor submenus
+	.block-editor-block-list__layout .block-editor-block-list__layout {
+		width: $navigation-sub-menu-width;
+	}
 
 	// Remove paddings on subsequent immediate children.
 	.block-editor-inner-blocks > .block-editor-block-list__layout > .wp-block {
@@ -101,6 +108,7 @@ $navigation-sub-menu-height: $grid-size * 5;
 		padding: 0 $grid-size * 2;
 		min-height: $navigation-menu-height;
 		display: flex;
+		line-height: 1.4;
 
 		// Sub menus
 		.wp-block,
@@ -156,7 +164,7 @@ $navigation-sub-menu-height: $grid-size * 5;
 		.wp-block-navigation-link {
 
 			.wp-block-navigation-link__content {
-				padding: $grid-size / 2 $grid-size * 2;
+				padding: $grid-size * 0.75 $grid-size * 2;
 			}
 
 			&:first-child .wp-block-navigation-link__content {

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -133,7 +133,7 @@ $navigation-sub-menu-width: $grid-size * 25;
 			// Position (first level)
 			position: absolute;
 			z-index: 1;
-			top: $navigation-menu-height - ( $block-padding / 2 );
+			top: 100%;
 			left: $grid-size * 2; // just under the main menu item.
 
 			// Position (nested levels)

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -74,6 +74,7 @@ $navigation-sub-menu-width: $grid-size * 25;
 .wp-block-navigation,
 .wp-block-navigation .block-editor-block-list__layout {
 	display: flex;
+	flex-wrap: wrap;
 }
 
 .wp-block-navigation {
@@ -86,6 +87,7 @@ $navigation-sub-menu-width: $grid-size * 25;
 	// Remove paddings on subsequent immediate children.
 	.block-editor-inner-blocks > .block-editor-block-list__layout > .wp-block {
 		margin: 0;
+		width: auto;
 	}
 
 	&,

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -134,7 +134,7 @@ $navigation-sub-menu-width: $grid-size * 25;
 			position: absolute;
 			z-index: 1;
 			top: 100%;
-			left: $grid-size * 2; // just under the main menu item.
+			left: 0; // just under the main menu item.
 
 			// Position (nested levels)
 			.block-editor-inner-blocks,

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -74,7 +74,6 @@ $navigation-sub-menu-width: $grid-size * 25;
 .wp-block-navigation,
 .wp-block-navigation .block-editor-block-list__layout {
 	display: flex;
-	flex-wrap: wrap;
 }
 
 .wp-block-navigation {


### PR DESCRIPTION
## Description
This PR improves the sub-menus for the Navigation block. Significant changes:

* Apply position absolute to sub-menus, removing the block movements when a sub-menu is opened/closed, making the UX less stressful for the user.
* Propagate text and background colors to the sub-menus.
* Apply Light/Dark styles only when it doesn't have a custom background color.
* ~Apply the border-color getting its value from text color ([to be defined/under discussion](https://github.com/WordPress/gutenberg/issues/18310#issuecomment-576441985))~

Fixes https://github.com/WordPress/gutenberg/issues/18310

### Design

The [final design to implement on this PR was defined](https://github.com/WordPress/gutenberg/issues/18310#issuecomment-574737902) in #18310:

<img src="https://user-images.githubusercontent.com/191598/72371352-377a1080-36d2-11ea-9703-ddaff11d9663.gif" width="600px" />

### About technical implementation

We need to keep in mind that this PR propagates the color values from the Navigation block to each Navigation Item. It simplifies applying the styles via CSS, and get ready the code to apply custom colors to sub-menus/sub-items.

Tasks on this PR:

- [x] Propagate the color changes for background and text through to all submenus


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/77539/73002353-a9dda580-3de2-11ea-83e0-c64b2c75cb37.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->