### PR TITLE
Fix color picker saturation overlay offset

### DIFF
--- a/packages/components/src/color-picker/saturation.js
+++ b/packages/components/src/color-picker/saturation.js
@@ -62,6 +62,17 @@ export class Saturation extends Component {
 		this.handleMouseUp = this.handleMouseUp.bind( this );
 	}
 
+	componentDidMount() {
+		// Ensure container is scrolled to the left.
+		// When pointer starts at right edge, scroll position is offset by a few pixels (issue #19610).
+		const findContainer = setInterval( () => {
+			if ( this.container.current ) {
+				this.container.current.scroll( 0, 0 );
+				clearInterval( findContainer );
+			}
+		}, 10 );
+	}
+
 	componentWillUnmount() {
 		this.throttle.cancel();
 		this.unbindEventListeners();

--- a/packages/components/src/color-picker/style.scss
+++ b/packages/components/src/color-picker/style.scss
@@ -126,7 +126,7 @@
 		0 0 1px 2px rgba(0, 0, 0, 0.4);
 	border-radius: 50%;
 	background-color: transparent;
-	transform: translate(-7px, -7px);
+	transform: translate(-50%, -50%);
 }
 
 /* HUE & ALPHA BARS */

--- a/packages/components/src/color-picker/style.scss
+++ b/packages/components/src/color-picker/style.scss
@@ -126,7 +126,7 @@
 		0 0 1px 2px rgba(0, 0, 0, 0.4);
 	border-radius: 50%;
 	background-color: transparent;
-	transform: translate(-4px, -4px);
+	transform: translate(-7px, -7px);
 }
 
 /* HUE & ALPHA BARS */


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
Fixes issue #19610 . 

* Forces a scroll on mounting of the saturation component.
* Updates the translate offset for the picker to appropriately match its size.

Previously, when the saturation component loaded with the picker on the right side it would cause the `scrollLeft` value to be several pixels, causing the issue noted in #19610  .  
 
**Before this PR**
![Screen Shot 2020-01-15 at 7 13 11 PM](https://user-images.githubusercontent.com/28742426/72482263-1c3efc00-37cb-11ea-9e7a-b2c24df15aec.png)

In absence of finding a CSS rule to fix this behavior, forcing a `scroll(0,0)` in the parent element on mounting of the component will fix the issue.

**After scroll on mount**
![Screen Shot 2020-01-15 at 7 04 35 PM](https://user-images.githubusercontent.com/28742426/72482343-60ca9780-37cb-11ea-8ef3-e8f08bff7797.png)

But as you may notice, the pointer is now almost all the way off the screen.  It turns out the `transform: translate(x,y)` property in the CSS was set for a picker of 8px width/height.  Since the picker is now 14px wide/tall it was necessary to update this translate value as well.  (Update, set the translate to use % based values so this will be less of an issue in the future)

**After this PR**
![Screen Shot 2020-01-15 at 7 02 56 PM](https://user-images.githubusercontent.com/28742426/72482322-485a7d00-37cb-11ea-8c34-fcb730f6a367.png)


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Tested on local docker environment.

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [n/a] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [n/a] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
