### PR TITLE
Omit the onKeyDown prop from the NavigableContainer DOM element

### DIFF
--- a/packages/components/src/navigable-container/container.js
+++ b/packages/components/src/navigable-container/container.js
@@ -122,6 +122,7 @@ class NavigableContainer extends Component {
 					'stopNavigationEvents',
 					'eventToOffset',
 					'onNavigate',
+					'onKeyDown',
 					'cycle',
 					'onlyBrowserTabstops',
 					'forwardedRef',


### PR DESCRIPTION
## Description
Fixes #19694 by adding the `onKeyDown` prop to the list of omitted properties.

## How has this been tested?
Tested manually.

## Types of changes
Bug Fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
