### PR TITLE
Multi block selection: fix tabbing

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -103,8 +103,10 @@ function BlockListBlock( {
 	const onBlockError = () => setErrorState( true );
 
 	const blockType = getBlockType( name );
-	// translators: %s: Type of block (i.e. Text, Image etc)
-	const blockLabel = sprintf( __( 'Block: %s' ), blockType.title );
+	const blockLabel = isFirstMultiSelected ?
+		__( 'Multiple selected blocks' ) :
+		// translators: %s: Type of block (i.e. Text, Image etc)
+		sprintf( __( 'Block: %s' ), blockType.title );
 
 	// Handing the focus of the block on creation and update
 

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -286,9 +286,9 @@ function BlockListBlock( {
 			onKeyDown={ isSelected && ! isLocked ? onKeyDown : undefined }
 			// Only allow selection to be started from a selected block.
 			onMouseLeave={ isSelected ? onMouseLeave : undefined }
-			tabIndex={ ( isSelected || isFirstMultiSelected ) ? '0' : undefined }
-			aria-label={ ( isSelected || isFirstMultiSelected ) ? blockLabel : undefined }
-			role={ ( isSelected || isFirstMultiSelected ) ? 'group' : undefined }
+			tabIndex="0"
+			aria-label={ blockLabel }
+			role="group"
 			{ ...wrapperProps }
 			style={
 				wrapperProps && wrapperProps.style ?

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -284,9 +284,9 @@ function BlockListBlock( {
 			onKeyDown={ isSelected && ! isLocked ? onKeyDown : undefined }
 			// Only allow selection to be started from a selected block.
 			onMouseLeave={ isSelected ? onMouseLeave : undefined }
-			tabIndex="0"
-			aria-label={ blockLabel }
-			role="group"
+			tabIndex={ ( isSelected || isFirstMultiSelected ) ? '0' : undefined }
+			aria-label={ ( isSelected || isFirstMultiSelected ) ? blockLabel : undefined }
+			role={ ( isSelected || isFirstMultiSelected ) ? 'group' : undefined }
 			{ ...wrapperProps }
 			style={
 				wrapperProps && wrapperProps.style ?

--- a/packages/block-editor/src/components/writing-flow/focus-capture.js
+++ b/packages/block-editor/src/components/writing-flow/focus-capture.js
@@ -73,7 +73,8 @@ const FocusCapture = forwardRef( ( {
 
 		if ( isReverse ) {
 			const tabbables = focus.tabbable.find( wrapper );
-			last( tabbables ).focus();
+			const lastTabbable = last( tabbables ) || wrapper;
+			lastTabbable.focus();
 		} else {
 			wrapper.focus();
 		}

--- a/packages/block-editor/src/components/writing-flow/index.js
+++ b/packages/block-editor/src/components/writing-flow/index.js
@@ -369,15 +369,14 @@ export default function WritingFlow( { children } ) {
 						focusCaptureBeforeRef.current.focus();
 						return;
 					}
-				} else {
-					const tabbables = focus.tabbable.find( wrapper );
-
-					if ( target === last( tabbables ) ) {
-						// See comment above.
-						noCapture.current = true;
-						focusCaptureAfterRef.current.focus();
-						return;
-					}
+				} else if (
+					target === wrapper ||
+					target === last( focus.tabbable.find( wrapper ) )
+				) {
+					// See comment above.
+					noCapture.current = true;
+					focusCaptureAfterRef.current.focus();
+					return;
 				}
 			} else if ( isEscape ) {
 				setNavigationMode( true );

--- a/packages/block-editor/src/components/writing-flow/index.js
+++ b/packages/block-editor/src/components/writing-flow/index.js
@@ -348,7 +348,7 @@ export default function WritingFlow( { children } ) {
 			return;
 		}
 
-		const clientId = selectedBlockClientId || selectionStartClientId;
+		const clientId = selectedBlockClientId || selectedFirstClientId;
 
 		// In Edit mode, Tab should focus the first tabbable element after the
 		// content, which is normally the sidebar (with block controls) and
@@ -369,14 +369,16 @@ export default function WritingFlow( { children } ) {
 						focusCaptureBeforeRef.current.focus();
 						return;
 					}
-				} else if (
-					target === wrapper ||
-					target === last( focus.tabbable.find( wrapper ) )
-				) {
-					// See comment above.
-					noCapture.current = true;
-					focusCaptureAfterRef.current.focus();
-					return;
+				} else {
+					const tabbables = focus.tabbable.find( wrapper );
+					const lastTabbable = last( tabbables ) || wrapper;
+
+					if ( target === lastTabbable ) {
+						// See comment above.
+						noCapture.current = true;
+						focusCaptureAfterRef.current.focus();
+						return;
+					}
 				}
 			} else if ( isEscape ) {
 				setNavigationMode( true );
@@ -484,7 +486,7 @@ export default function WritingFlow( { children } ) {
 		}
 	}
 
-	const selectedClientId = selectedBlockClientId || selectionStartClientId;
+	const selectedClientId = selectedBlockClientId || selectedFirstClientId;
 
 	// Disable reason: Wrapper itself is non-interactive, but must capture
 	// bubbling events from children to determine focus transition intents.

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/keyboard-navigable-blocks.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/keyboard-navigable-blocks.test.js.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Order of block keyboard navigation should navigate correctly with multi selection 1`] = `
+"<!-- wp:paragraph -->
+<p>1</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>2</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>3</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>4</p>
+<!-- /wp:paragraph -->"
+`;

--- a/packages/e2e-tests/specs/editor/various/keyboard-navigable-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/keyboard-navigable-blocks.test.js
@@ -5,6 +5,8 @@ import {
 	createNewPost,
 	insertBlock,
 	pressKeyWithModifier,
+	clickBlockAppender,
+	getEditedPostContent,
 } from '@wordpress/e2e-test-utils';
 
 async function getActiveLabel() {
@@ -156,5 +158,31 @@ describe( 'Order of block keyboard navigation', () => {
 		await expect( await page.evaluate( () => {
 			return document.activeElement.placeholder;
 		} ) ).toBe( 'Add title' );
+	} );
+
+	it( 'should navigate correctly with multi selection', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( '1' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '2' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '3' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '4' );
+		await page.keyboard.press( 'ArrowUp' );
+		await pressKeyWithModifier( 'shift', 'ArrowUp' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+
+		expect( await getActiveLabel() ).toBe( 'Multiple selected blocks' );
+
+		await page.keyboard.press( 'Tab' );
+		await expect( await getActiveLabel() ).toBe( 'Document' );
+
+		await pressKeyWithModifier( 'shift', 'Tab' );
+		await expect( await getActiveLabel() ).toBe( 'Multiple selected blocks' );
+
+		await pressKeyWithModifier( 'shift', 'Tab' );
+		await expect( await getActiveLabel() ).toBe( 'More options' );
 	} );
 } );


### PR DESCRIPTION
## Description

This PR fixes tabbing when multiple blocks are selected. It should work just the same as normal blocks in Edit mode. Currently tabbing forward is broken: instead of going to the sidebar focus moves to the next block.

Adds an e2e test.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
