### PR TITLE
Lighter Block: allow block types to render their own wrapper

### DIFF
--- a/packages/block-editor/src/components/block-list/block-wrapper.js
+++ b/packages/block-editor/src/components/block-list/block-wrapper.js
@@ -1,0 +1,238 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+import { first, last, omit } from 'lodash';
+import { animated } from 'react-spring/web.cjs';
+
+/**
+ * WordPress dependencies
+ */
+import {
+	useRef,
+	useEffect,
+	useLayoutEffect,
+	useContext,
+	forwardRef,
+} from '@wordpress/element';
+import { focus, isTextField, placeCaretAtHorizontalEdge } from '@wordpress/dom';
+import { BACKSPACE, DELETE, ENTER } from '@wordpress/keycodes';
+import { __, sprintf } from '@wordpress/i18n';
+import { useSelect, useDispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { isInsideRootBlock } from '../../utils/dom';
+import useMovingAnimation from './moving-animation';
+import { Context, BlockNodes } from './root-container';
+import { BlockContext } from './block';
+
+const BlockComponent = forwardRef(
+	( { children, tagName = 'div', __unstableIsHtml, ...props }, wrapper ) => {
+		const onSelectionStart = useContext( Context );
+		const [ , setBlockNodes ] = useContext( BlockNodes );
+		const {
+			clientId,
+			rootClientId,
+			isSelected,
+			isFirstMultiSelected,
+			isLastMultiSelected,
+			isMultiSelecting,
+			isNavigationMode,
+			isPartOfMultiSelection,
+			enableAnimation,
+			index,
+			className,
+			isLocked,
+			name,
+			mode,
+			blockTitle,
+		} = useContext( BlockContext );
+		const { initialPosition } = useSelect(
+			( select ) => {
+				if ( ! isSelected ) {
+					return {};
+				}
+
+				return {
+					initialPosition: select(
+						'core/block-editor'
+					).getSelectedBlocksInitialCaretPosition(),
+				};
+			},
+			[ isSelected ]
+		);
+		const { removeBlock, insertDefaultBlock } = useDispatch(
+			'core/block-editor'
+		);
+		const fallbackRef = useRef();
+
+		wrapper = wrapper || fallbackRef;
+
+		// Provide the selected node, or the first and last nodes of a multi-
+		// selection, so it can be used to position the contextual block toolbar.
+		// We only provide what is necessary, and remove the nodes again when they
+		// are no longer selected.
+		useLayoutEffect( () => {
+			if ( isSelected || isFirstMultiSelected || isLastMultiSelected ) {
+				const node = wrapper.current;
+				setBlockNodes( ( nodes ) => ( {
+					...nodes,
+					[ clientId ]: node,
+				} ) );
+				return () => {
+					setBlockNodes( ( nodes ) => omit( nodes, clientId ) );
+				};
+			}
+		}, [ isSelected, isFirstMultiSelected, isLastMultiSelected ] );
+
+		// translators: %s: Type of block (i.e. Text, Image etc)
+		const blockLabel = sprintf( __( 'Block: %s' ), blockTitle );
+
+		// Handing the focus of the block on creation and update
+
+		/**
+		 * When a block becomes selected, transition focus to an inner tabbable.
+		 *
+		 * @param {boolean} ignoreInnerBlocks Should not focus inner blocks.
+		 */
+		const focusTabbable = ( ignoreInnerBlocks ) => {
+			// Focus is captured by the wrapper node, so while focus transition
+			// should only consider tabbables within editable display, since it
+			// may be the wrapper itself or a side control which triggered the
+			// focus event, don't unnecessary transition to an inner tabbable.
+			if ( wrapper.current.contains( document.activeElement ) ) {
+				return;
+			}
+
+			// Find all tabbables within node.
+			const textInputs = focus.tabbable
+				.find( wrapper.current )
+				.filter( isTextField )
+				// Exclude inner blocks
+				.filter(
+					( node ) =>
+						! ignoreInnerBlocks ||
+						isInsideRootBlock( wrapper.current, node )
+				);
+
+			// If reversed (e.g. merge via backspace), use the last in the set of
+			// tabbables.
+			const isReverse = -1 === initialPosition;
+			const target =
+				( isReverse ? last : first )( textInputs ) || wrapper.current;
+
+			placeCaretAtHorizontalEdge( target, isReverse );
+		};
+
+		// Focus the selected block's wrapper or inner input on mount and update
+		const isMounting = useRef( true );
+
+		useEffect( () => {
+			if ( ! isMultiSelecting && ! isNavigationMode && isSelected ) {
+				focusTabbable( ! isMounting.current );
+			}
+
+			isMounting.current = false;
+		}, [ isSelected, isMultiSelecting, isNavigationMode ] );
+
+		// Block Reordering animation
+		const animationStyle = useMovingAnimation(
+			wrapper,
+			isSelected || isPartOfMultiSelection,
+			isSelected || isFirstMultiSelected,
+			enableAnimation,
+			index
+		);
+
+		/**
+		 * Interprets keydown event intent to remove or insert after block if key
+		 * event occurs on wrapper node. This can occur when the block has no text
+		 * fields of its own, particularly after initial insertion, to allow for
+		 * easy deletion and continuous writing flow to add additional content.
+		 *
+		 * @param {KeyboardEvent} event Keydown event.
+		 */
+		const onKeyDown = ( event ) => {
+			const { keyCode, target } = event;
+
+			if ( props.onKeyDown ) {
+				props.onKeyDown( event );
+			}
+
+			if (
+				keyCode !== ENTER &&
+				keyCode !== BACKSPACE &&
+				keyCode !== DELETE
+			) {
+				return;
+			}
+
+			if ( target !== wrapper.current || isTextField( target ) ) {
+				return;
+			}
+
+			event.preventDefault();
+
+			if ( keyCode === ENTER ) {
+				insertDefaultBlock( {}, rootClientId, index + 1 );
+			} else {
+				removeBlock( clientId );
+			}
+		};
+
+		const onMouseLeave = ( { which, buttons } ) => {
+			// The primary button must be pressed to initiate selection. Fall back
+			// to `which` if the standard `buttons` property is falsy. There are
+			// cases where Firefox might always set `buttons` to `0`.
+			// See https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/buttons
+			// See https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/which
+			if ( ( buttons || which ) === 1 ) {
+				onSelectionStart( clientId );
+			}
+		};
+
+		const htmlSuffix =
+			mode === 'html' && ! __unstableIsHtml ? '-visual' : '';
+		const blockElementId = `block-${ clientId }${ htmlSuffix }`;
+		const Animated = animated[ tagName ];
+
+		return (
+			<Animated
+				// Overrideable props.
+				aria-label={ blockLabel }
+				role="group"
+				{ ...props }
+				id={ blockElementId }
+				ref={ wrapper }
+				className={ classnames( className, props.className ) }
+				data-block={ clientId }
+				data-type={ name }
+				data-title={ blockTitle }
+				// Only allow shortcuts when a blocks is selected and not locked.
+				onKeyDown={ isSelected && ! isLocked ? onKeyDown : undefined }
+				// Only allow selection to be started from a selected block.
+				onMouseLeave={ isSelected ? onMouseLeave : undefined }
+				tabIndex="0"
+				style={ {
+					...( props.style || {} ),
+					...animationStyle,
+				} }
+			>
+				{ children }
+			</Animated>
+		);
+	}
+);
+
+const elements = [ 'p', 'div' ];
+
+const ExtendedBlockComponent = elements.reduce( ( acc, element ) => {
+	acc[ element ] = forwardRef( ( props, ref ) => {
+		return <BlockComponent { ...props } ref={ ref } tagName={ element } />;
+	} );
+	return acc;
+}, BlockComponent );
+
+export const Block = ExtendedBlockComponent;

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -2,30 +2,20 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { first, last, omit } from 'lodash';
-import { animated } from 'react-spring/web.cjs';
 
 /**
  * WordPress dependencies
  */
-import {
-	useRef,
-	useEffect,
-	useLayoutEffect,
-	useState,
-	useContext,
-} from '@wordpress/element';
-import { focus, isTextField, placeCaretAtHorizontalEdge } from '@wordpress/dom';
-import { BACKSPACE, DELETE, ENTER } from '@wordpress/keycodes';
+import { useState, createContext, useMemo } from '@wordpress/element';
 import {
 	getBlockType,
 	getSaveElement,
 	isReusableBlock,
 	isUnmodifiedDefaultBlock,
 	getUnregisteredTypeHandlerName,
+	hasBlockSupport,
 } from '@wordpress/blocks';
 import { withFilters } from '@wordpress/components';
-import { __, sprintf } from '@wordpress/i18n';
 import { withDispatch, withSelect, useSelect } from '@wordpress/data';
 import { withViewportMatch } from '@wordpress/viewport';
 import { compose, pure, ifCondition } from '@wordpress/compose';
@@ -38,15 +28,16 @@ import BlockInvalidWarning from './block-invalid-warning';
 import BlockCrashWarning from './block-crash-warning';
 import BlockCrashBoundary from './block-crash-boundary';
 import BlockHtml from './block-html';
-import { isInsideRootBlock } from '../../utils/dom';
-import useMovingAnimation from './moving-animation';
-import { Context, BlockNodes } from './root-container';
+import { Block } from './block-wrapper';
+
+export const BlockContext = createContext();
 
 function BlockListBlock( {
 	mode,
 	isFocusMode,
 	isLocked,
 	clientId,
+	rootClientId,
 	isSelected,
 	isMultiSelected,
 	isPartOfMultiSelection,
@@ -59,166 +50,43 @@ function BlockListBlock( {
 	name,
 	isValid,
 	attributes,
-	initialPosition,
 	wrapperProps,
 	setAttributes,
 	onReplace,
 	onInsertBlocksAfter,
 	onMerge,
-	onRemove,
-	onInsertDefaultBlockAfter,
 	toggleSelection,
-	animateOnChange,
+	index,
 	enableAnimation,
 	isNavigationMode,
 	isMultiSelecting,
 	hasSelectedUI = true,
 } ) {
-	const onSelectionStart = useContext( Context );
-	const [ , setBlockNodes ] = useContext( BlockNodes );
-	// In addition to withSelect, we should favor using useSelect in this component going forward
-	// to avoid leaking new props to the public API (editor.BlockListBlock filter)
+	// In addition to withSelect, we should favor using useSelect in this
+	// component going forward to avoid leaking new props to the public API
+	// (editor.BlockListBlock filter)
 	const { isDraggingBlocks } = useSelect( ( select ) => {
 		return {
 			isDraggingBlocks: select( 'core/block-editor' ).isDraggingBlocks(),
 		};
 	}, [] );
 
-	// Reference of the wrapper
-	const wrapper = useRef( null );
-
-	// Provide the selected node, or the first and last nodes of a multi-
-	// selection, so it can be used to position the contextual block toolbar.
-	// We only provide what is necessary, and remove the nodes again when they
-	// are no longer selected.
-	useLayoutEffect( () => {
-		if ( isSelected || isFirstMultiSelected || isLastMultiSelected ) {
-			const node = wrapper.current;
-			setBlockNodes( ( nodes ) => ( { ...nodes, [ clientId ]: node } ) );
-			return () => {
-				setBlockNodes( ( nodes ) => omit( nodes, clientId ) );
-			};
-		}
-	}, [ isSelected, isFirstMultiSelected, isLastMultiSelected ] );
-
 	// Handling the error state
 	const [ hasError, setErrorState ] = useState( false );
 	const onBlockError = () => setErrorState( true );
 
 	const blockType = getBlockType( name );
-	// translators: %s: Type of block (i.e. Text, Image etc)
-	const blockLabel = sprintf( __( 'Block: %s' ), blockType.title );
-
-	// Handing the focus of the block on creation and update
-
-	/**
-	 * When a block becomes selected, transition focus to an inner tabbable.
-	 *
-	 * @param {boolean} ignoreInnerBlocks Should not focus inner blocks.
-	 */
-	const focusTabbable = ( ignoreInnerBlocks ) => {
-		// Focus is captured by the wrapper node, so while focus transition
-		// should only consider tabbables within editable display, since it
-		// may be the wrapper itself or a side control which triggered the
-		// focus event, don't unnecessary transition to an inner tabbable.
-		if ( wrapper.current.contains( document.activeElement ) ) {
-			return;
-		}
-
-		// Find all tabbables within node.
-		const textInputs = focus.tabbable
-			.find( wrapper.current )
-			.filter( isTextField )
-			// Exclude inner blocks
-			.filter(
-				( node ) =>
-					! ignoreInnerBlocks ||
-					isInsideRootBlock( wrapper.current, node )
-			);
-
-		// If reversed (e.g. merge via backspace), use the last in the set of
-		// tabbables.
-		const isReverse = -1 === initialPosition;
-		const target = ( isReverse ? last : first )( textInputs );
-
-		if ( ! target ) {
-			wrapper.current.focus();
-			return;
-		}
-
-		placeCaretAtHorizontalEdge( target, isReverse );
-	};
-
-	// Focus the selected block's wrapper or inner input on mount and update
-	const isMounting = useRef( true );
-
-	useEffect( () => {
-		if ( ! isMultiSelecting && ! isNavigationMode && isSelected ) {
-			focusTabbable( ! isMounting.current );
-		}
-
-		isMounting.current = false;
-	}, [ isSelected, isMultiSelecting, isNavigationMode ] );
-
-	// Block Reordering animation
-	const animationStyle = useMovingAnimation(
-		wrapper,
-		isSelected || isPartOfMultiSelection,
-		isSelected || isFirstMultiSelected,
-		enableAnimation,
-		animateOnChange
+	const lightBlockWrapper = hasBlockSupport(
+		blockType,
+		'lightBlockWrapper',
+		false
 	);
-
-	// Other event handlers
-
-	/**
-	 * Interprets keydown event intent to remove or insert after block if key
-	 * event occurs on wrapper node. This can occur when the block has no text
-	 * fields of its own, particularly after initial insertion, to allow for
-	 * easy deletion and continuous writing flow to add additional content.
-	 *
-	 * @param {KeyboardEvent} event Keydown event.
-	 */
-	const onKeyDown = ( event ) => {
-		const { keyCode, target } = event;
-
-		switch ( keyCode ) {
-			case ENTER:
-				if ( target === wrapper.current ) {
-					// Insert default block after current block if enter and event
-					// not already handled by descendant.
-					onInsertDefaultBlockAfter();
-					event.preventDefault();
-				}
-				break;
-			case BACKSPACE:
-			case DELETE:
-				if ( target === wrapper.current ) {
-					// Remove block on backspace.
-					onRemove( clientId );
-					event.preventDefault();
-				}
-				break;
-		}
-	};
-
-	const onMouseLeave = ( { which, buttons } ) => {
-		// The primary button must be pressed to initiate selection. Fall back
-		// to `which` if the standard `buttons` property is falsy. There are
-		// cases where Firefox might always set `buttons` to `0`.
-		// See https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/buttons
-		// See https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/which
-		if ( ( buttons || which ) === 1 ) {
-			onSelectionStart( clientId );
-		}
-	};
-
 	const isUnregisteredBlock = name === getUnregisteredTypeHandlerName();
 	const isDragging =
 		isDraggingBlocks && ( isSelected || isPartOfMultiSelection );
 
 	// Determine whether the block has props to apply to the wrapper.
-	if ( blockType.getEditWrapperProps ) {
+	if ( ! lightBlockWrapper && blockType.getEditWrapperProps ) {
 		wrapperProps = {
 			...wrapperProps,
 			...blockType.getEditWrapperProps( attributes ),
@@ -228,7 +96,8 @@ function BlockListBlock( {
 	const isAligned = wrapperProps && wrapperProps[ 'data-align' ];
 
 	// The wp-block className is important for editor styles.
-	// Generate the wrapper class names handling the different states of the block.
+	// Generate the wrapper class names handling the different states of the
+	// block.
 	const wrapperClassName = classnames(
 		'wp-block block-editor-block-list__block',
 		{
@@ -247,8 +116,6 @@ function BlockListBlock( {
 		},
 		className
 	);
-
-	const blockElementId = `block-${ clientId }`;
 
 	// We wrap the BlockEdit component in a div that hides it when editing in
 	// HTML mode. This allows us to render all of the ancillary pieces
@@ -280,47 +147,59 @@ function BlockListBlock( {
 		blockEdit = <div style={ { display: 'none' } }>{ blockEdit }</div>;
 	}
 
+	const value = {
+		clientId,
+		rootClientId,
+		isSelected,
+		isFirstMultiSelected,
+		isLastMultiSelected,
+		isMultiSelecting,
+		isNavigationMode,
+		isPartOfMultiSelection,
+		enableAnimation,
+		index,
+		className: wrapperClassName,
+		isLocked,
+		name,
+		mode,
+		blockTitle: blockType.title,
+	};
+	const memoizedValue = useMemo( () => value, Object.values( value ) );
+
 	return (
-		<animated.div
-			id={ blockElementId }
-			ref={ wrapper }
-			className={ wrapperClassName }
-			data-block={ clientId }
-			data-type={ name }
-			// Only allow shortcuts when a blocks is selected and not locked.
-			onKeyDown={ isSelected && ! isLocked ? onKeyDown : undefined }
-			// Only allow selection to be started from a selected block.
-			onMouseLeave={ isSelected ? onMouseLeave : undefined }
-			tabIndex="0"
-			aria-label={ blockLabel }
-			role="group"
-			{ ...wrapperProps }
-			style={
-				wrapperProps && wrapperProps.style
-					? {
-							...wrapperProps.style,
-							...animationStyle,
-					  }
-					: animationStyle
-			}
-		>
+		<BlockContext.Provider value={ memoizedValue }>
 			<BlockCrashBoundary onError={ onBlockError }>
-				{ isValid && blockEdit }
-				{ isValid && mode === 'html' && (
-					<BlockHtml clientId={ clientId } />
+				{ isValid && lightBlockWrapper && (
+					<>
+						{ blockEdit }
+						{ mode === 'html' && (
+							<Block.div __unstableIsHtml>
+								<BlockHtml clientId={ clientId } />
+							</Block.div>
+						) }
+					</>
 				) }
-				{ ! isValid && [
-					<BlockInvalidWarning
-						key="invalid-warning"
-						clientId={ clientId }
-					/>,
-					<div key="invalid-preview">
-						{ getSaveElement( blockType, attributes ) }
-					</div>,
-				] }
+				{ isValid && ! lightBlockWrapper && (
+					<Block.div { ...wrapperProps }>
+						{ blockEdit }
+						{ mode === 'html' && (
+							<BlockHtml clientId={ clientId } />
+						) }
+					</Block.div>
+				) }
+				{ ! isValid && (
+					<Block.div>
+						<BlockInvalidWarning clientId={ clientId } />
+						<div>{ getSaveElement( blockType, attributes ) }</div>
+					</Block.div>
+				) }
 			</BlockCrashBoundary>
-			{ !! hasError && <BlockCrashWarning /> }
-		</animated.div>
+			{ !! hasError && (
+				<Block.div>
+					<BlockCrashWarning />
+				</Block.div>
+			) }
+		</BlockContext.Provider>
 	);
 }
 
@@ -335,7 +214,6 @@ const applyWithSelect = withSelect(
 			isTyping,
 			getBlockMode,
 			isSelectionEnabled,
-			getSelectedBlocksInitialCaretPosition,
 			getSettings,
 			hasSelectedInnerBlock,
 			getTemplateLock,
@@ -355,8 +233,9 @@ const applyWithSelect = withSelect(
 		);
 
 		// The fallback to `{}` is a temporary fix.
-		// This function should never be called when a block is not present in the state.
-		// It happens now because the order in withSelect rendering is not correct.
+		// This function should never be called when a block is not present in
+		// the state. It happens now because the order in withSelect rendering
+		// is not correct.
 		const { name, attributes, isValid } = block || {};
 
 		return {
@@ -369,21 +248,20 @@ const applyWithSelect = withSelect(
 				getLastMultiSelectedBlockClientId() === clientId,
 
 			// We only care about this prop when the block is selected
-			// Thus to avoid unnecessary rerenders we avoid updating the prop if the block is not selected.
+			// Thus to avoid unnecessary rerenders we avoid updating the prop if
+			// the block is not selected.
 			isTypingWithinBlock:
 				( isSelected || isAncestorOfSelectedBlock ) && isTyping(),
 
 			mode: getBlockMode( clientId ),
 			isSelectionEnabled: isSelectionEnabled(),
-			initialPosition: isSelected
-				? getSelectedBlocksInitialCaretPosition()
-				: null,
 			isLocked: !! templateLock,
 			isFocusMode: focusMode && isLargeViewport,
 			isNavigationMode: isNavigationMode(),
 			isRTL,
 
-			// Users of the editor.BlockListBlock filter used to be able to access the block prop
+			// Users of the editor.BlockListBlock filter used to be able to
+			// access the block prop.
 			// Ideally these blocks would rely on the clientId prop only.
 			// This is kept for backward compatibility reasons.
 			block,
@@ -401,8 +279,6 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps, { select } ) => {
 	const {
 		updateBlockAttributes,
 		insertBlocks,
-		insertDefaultBlock,
-		removeBlock,
 		mergeBlocks,
 		replaceBlocks,
 		toggleSelection,
@@ -418,20 +294,11 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps, { select } ) => {
 			const { rootClientId } = ownProps;
 			insertBlocks( blocks, index, rootClientId );
 		},
-		onInsertDefaultBlockAfter() {
-			const { clientId, rootClientId } = ownProps;
-			const { getBlockIndex } = select( 'core/block-editor' );
-			const index = getBlockIndex( clientId, rootClientId );
-			insertDefaultBlock( {}, rootClientId, index + 1 );
-		},
 		onInsertBlocksAfter( blocks ) {
 			const { clientId, rootClientId } = ownProps;
 			const { getBlockIndex } = select( 'core/block-editor' );
 			const index = getBlockIndex( clientId, rootClientId );
 			insertBlocks( blocks, index + 1, rootClientId );
-		},
-		onRemove( clientId ) {
-			removeBlock( clientId );
 		},
 		onMerge( forward ) {
 			const { clientId } = ownProps;
@@ -474,7 +341,8 @@ export default compose(
 	applyWithSelect,
 	applyWithDispatch,
 	// block is sometimes not mounted at the right time, causing it be undefined
-	// see issue for more info https://github.com/WordPress/gutenberg/issues/17013
+	// see issue for more info
+	// https://github.com/WordPress/gutenberg/issues/17013
 	ifCondition( ( { block } ) => !! block ),
 	withFilters( 'editor.BlockListBlock' )
 )( BlockListBlock );

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -107,7 +107,7 @@ function BlockList( {
 							// This prop is explicitely computed and passed down
 							// to avoid being impacted by the async mode
 							// otherwise there might be a small delay to trigger the animation.
-							animateOnChange={ index }
+							index={ index }
 							enableAnimation={ enableAnimation }
 							hasSelectedUI={
 								__experimentalUIParts.hasSelectedUI

--- a/packages/block-editor/src/components/block-list/insertion-point.js
+++ b/packages/block-editor/src/components/block-list/insertion-point.js
@@ -127,12 +127,11 @@ export default function InsertionPoint( {
 		const isReverse = clientY < targetRect.top + targetRect.height / 2;
 		const blockNode = getBlockDOMNode( inserterClientId );
 		const container = isReverse ? containerRef.current : blockNode;
-		const closest = getClosestTabbable( blockNode, true, container );
+		const closest =
+			getClosestTabbable( blockNode, true, container ) || blockNode;
 		const rect = new window.DOMRect( clientX, clientY, 0, 16 );
 
-		if ( closest ) {
-			placeCaretAtVerticalEdge( closest, isReverse, rect, false );
-		}
+		placeCaretAtVerticalEdge( closest, isReverse, rect, false );
 	}
 
 	// Hide the inserter above the selected block and during multi-selection.

--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -60,6 +60,7 @@ export { default as __experimentalBlockSettingsMenuFirstItem } from './block-set
 export { default as __experimentalInserterMenuExtension } from './inserter-menu-extension';
 export { default as BlockInspector } from './block-inspector';
 export { default as BlockList } from './block-list';
+export { Block as __experimentalBlock } from './block-list/block-wrapper';
 export { default as BlockMover } from './block-mover';
 export { default as BlockPreview } from './block-preview';
 export { default as BlockSelectionClearer } from './block-selection-clearer';

--- a/packages/block-editor/src/components/observe-typing/index.js
+++ b/packages/block-editor/src/components/observe-typing/index.js
@@ -17,6 +17,7 @@ import {
 	ENTER,
 	BACKSPACE,
 	ESCAPE,
+	TAB,
 } from '@wordpress/keycodes';
 import { withSafeTimeout } from '@wordpress/compose';
 
@@ -111,7 +112,10 @@ function ObserveTyping( { children, setTimeout: setSafeTimeout } ) {
 	 * @param {KeyboardEvent} event Keypress or keydown event to interpret.
 	 */
 	function stopTypingOnEscapeKey( event ) {
-		if ( isTyping && event.keyCode === ESCAPE ) {
+		if (
+			isTyping &&
+			( event.keyCode === ESCAPE || event.keyCode === TAB )
+		) {
 			stopTyping();
 		}
 	}

--- a/packages/block-editor/src/utils/dom.js
+++ b/packages/block-editor/src/utils/dom.js
@@ -91,7 +91,7 @@ export function getBlockClientId( node ) {
 		node = node.parentElement;
 	}
 
-	const blockNode = node.closest( '.wp-block' );
+	const blockNode = node.closest( '.block-editor-block-list__block' );
 
 	if ( ! blockNode ) {
 		return;

--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -16,6 +16,7 @@ import {
 	RichText,
 	withFontSizes,
 	__experimentalUseColors,
+	__experimentalBlock as Block,
 } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
 import { compose } from '@wordpress/compose';
@@ -151,7 +152,7 @@ function ParagraphBlock( {
 					<RichText
 						ref={ ref }
 						identifier="content"
-						tagName="p"
+						tagName={ Block.p }
 						className={ classnames(
 							'wp-block-paragraph',
 							className,

--- a/packages/block-library/src/paragraph/editor.scss
+++ b/packages/block-library/src/paragraph/editor.scss
@@ -1,5 +1,5 @@
 // Overwrite the inline style to make the height collapse when the paragraph editable gets focus.
-.block-editor-block-list__block[data-type="core/paragraph"] .has-drop-cap:focus {
+.block-editor-block-list__block[data-type="core/paragraph"].has-drop-cap:focus {
 	min-height: auto !important;
 }
 

--- a/packages/block-library/src/paragraph/index.js
+++ b/packages/block-library/src/paragraph/index.js
@@ -39,6 +39,7 @@ export const settings = {
 	supports: {
 		className: false,
 		__unstablePasteTextInline: true,
+		lightBlockWrapper: true,
 	},
 	__experimentalLabel( attributes, { context } ) {
 		if ( context === 'accessibility' ) {

--- a/packages/e2e-test-utils/src/transform-block-to.js
+++ b/packages/e2e-test-utils/src/transform-block-to.js
@@ -23,6 +23,6 @@ export async function transformBlockTo( name ) {
 
 	// Wait for the transformed block to appear.
 	const BLOCK_SELECTOR = '.block-editor-block-list__block';
-	const BLOCK_NAME_SELECTOR = `[aria-label="Block: ${ name }"]`;
+	const BLOCK_NAME_SELECTOR = `[data-title="${ name }"]`;
 	await page.waitForSelector( `${ BLOCK_SELECTOR }${ BLOCK_NAME_SELECTOR }` );
 }

--- a/packages/e2e-tests/specs/editor/plugins/block-icons.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/block-icons.test.js
@@ -82,7 +82,7 @@ describe( 'Correctly Renders Block Icons on Inserter and Inspector', () => {
 			await insertBlock( blockTitle );
 			expect(
 				await getInnerHTML(
-					`[data-type="${ blockName }"] [data-type="core/paragraph"] p`
+					`[data-type="${ blockName }"] [data-type="core/paragraph"]`
 				)
 			).toEqual( blockTitle );
 		} );

--- a/packages/e2e-tests/specs/editor/plugins/block-variations.js
+++ b/packages/e2e-tests/specs/editor/plugins/block-variations.js
@@ -74,10 +74,7 @@ describe( 'Block variations', () => {
 		);
 		expect( successMessageBlock ).toBeDefined();
 		expect(
-			await successMessageBlock.$eval(
-				'p.has-vivid-green-cyan-background-color',
-				( node ) => node.innerText
-			)
+			await successMessageBlock.evaluate( ( node ) => node.innerText )
 		).toBe( 'This is a success message!' );
 	} );
 	test( 'Pick the additional variation in the inserted Columns block', async () => {

--- a/packages/e2e-tests/specs/editor/plugins/cpt-locking.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/cpt-locking.test.js
@@ -76,7 +76,7 @@ describe( 'cpt locking', () => {
 
 		it( 'should not error when deleting the cotents of a paragraph', async () => {
 			await page.click(
-				'.block-editor-block-list__block[data-type="core/paragraph"] p'
+				'.block-editor-block-list__block[data-type="core/paragraph"]'
 			);
 			const textToType = 'Paragraph';
 			await page.keyboard.type( 'Paragraph' );

--- a/packages/e2e-tests/specs/editor/plugins/hooks-api.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/hooks-api.test.js
@@ -34,7 +34,7 @@ describe( 'Using Hooks API', () => {
 		await clickBlockAppender();
 		await page.keyboard.type( 'First paragraph' );
 		const paragraphContent = await page.$eval(
-			'div[data-type="core/paragraph"] p',
+			'p[data-type="core/paragraph"]',
 			( element ) => element.textContent
 		);
 		expect( paragraphContent ).toEqual( 'First paragraph' );

--- a/packages/e2e-tests/specs/editor/various/block-mover.test.js
+++ b/packages/e2e-tests/specs/editor/various/block-mover.test.js
@@ -18,6 +18,10 @@ describe( 'block mover', () => {
 		// Select a block so the block mover is rendered.
 		await page.focus( '.block-editor-block-list__block' );
 
+		// Move the mouse to show the block toolbar
+		await page.mouse.move( 0, 0 );
+		await page.mouse.move( 10, 10 );
+
 		const blockMover = await page.$$( '.block-editor-block-mover' );
 		// There should be a block mover.
 		expect( blockMover ).toHaveLength( 1 );
@@ -30,6 +34,10 @@ describe( 'block mover', () => {
 
 		// Select a block so the block mover has the possibility of being rendered.
 		await page.focus( '.block-editor-block-list__block' );
+
+		// Move the mouse to show the block toolbar
+		await page.mouse.move( 0, 0 );
+		await page.mouse.move( 10, 10 );
 
 		// Ensure no block mover exists when only one block exists on the page.
 		const blockMover = await page.$$( '.block-editor-block-mover' );

--- a/packages/e2e-tests/specs/editor/various/editor-modes.test.js
+++ b/packages/e2e-tests/specs/editor/various/editor-modes.test.js
@@ -18,7 +18,7 @@ describe( 'Editing modes (visual/HTML)', () => {
 	it( 'should switch between visual and HTML modes', async () => {
 		// This block should be in "visual" mode by default.
 		let visualBlock = await page.$$(
-			'.block-editor-block-list__layout .block-editor-block-list__block .rich-text'
+			'.block-editor-block-list__layout .block-editor-block-list__block.rich-text'
 		);
 		expect( visualBlock ).toHaveLength( 1 );
 
@@ -52,7 +52,7 @@ describe( 'Editing modes (visual/HTML)', () => {
 
 		// This block should be in "visual" mode by default.
 		visualBlock = await page.$$(
-			'.block-editor-block-list__layout .block-editor-block-list__block .rich-text'
+			'.block-editor-block-list__layout .block-editor-block-list__block.rich-text'
 		);
 		expect( visualBlock ).toHaveLength( 1 );
 	} );

--- a/packages/e2e-tests/specs/editor/various/keyboard-navigable-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/keyboard-navigable-blocks.test.js
@@ -32,9 +32,6 @@ const tabThroughParagraphBlock = async ( paragraphText ) => {
 	await tabThroughBlockToolbar();
 
 	await page.keyboard.press( 'Tab' );
-	await expect( await getActiveLabel() ).toBe( 'Block: Paragraph' );
-
-	await page.keyboard.press( 'Tab' );
 	await expect( await getActiveLabel() ).toBe( 'Paragraph block' );
 	await expect(
 		await page.evaluate( () => document.activeElement.innerHTML )

--- a/packages/e2e-tests/specs/editor/various/preview.test.js
+++ b/packages/e2e-tests/specs/editor/various/preview.test.js
@@ -14,7 +14,6 @@ import {
 	publishPost,
 	saveDraft,
 	clickOnMoreMenuItem,
-	pressKeyWithModifier,
 } from '@wordpress/e2e-test-utils';
 
 /** @typedef {import('puppeteer').Page} Page */
@@ -278,13 +277,13 @@ describe( 'Preview with Custom Fields enabled', () => {
 		// Return to editor and modify the title and content.
 		await editorPage.bringToFront();
 		await editorPage.click( '.editor-post-title__input' );
-		await pressKeyWithModifier( 'primary', 'a' );
-		await editorPage.keyboard.press( 'Delete' );
-		await editorPage.keyboard.type( 'title 2' );
+		await editorPage.keyboard.press( 'End' );
+		await editorPage.keyboard.press( 'Backspace' );
+		await editorPage.keyboard.type( '2' );
 		await editorPage.keyboard.press( 'Tab' );
-		await pressKeyWithModifier( 'primary', 'a' );
-		await editorPage.keyboard.press( 'Delete' );
-		await editorPage.keyboard.type( 'content 2' );
+		await editorPage.keyboard.press( 'End' );
+		await editorPage.keyboard.press( 'Backspace' );
+		await editorPage.keyboard.type( '2' );
 
 		// Open the preview page.
 		await waitForPreviewNavigation( previewPage );

--- a/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
@@ -181,7 +181,7 @@ describe( 'Reusable blocks', () => {
 
 		// Check that its content is up to date
 		const text = await page.$eval(
-			'.block-editor-block-list__block[data-type="core/paragraph"] p',
+			'.block-editor-block-list__block[data-type="core/paragraph"]',
 			( element ) => element.innerText
 		);
 		expect( text ).toMatch( 'Oh! Hello there!' );

--- a/packages/e2e-tests/specs/editor/various/undo.test.js
+++ b/packages/e2e-tests/specs/editor/various/undo.test.js
@@ -22,9 +22,16 @@ const getSelection = async () => {
 			return {};
 		}
 
-		const editables = Array.from(
-			selectedBlock.querySelectorAll( '[contenteditable]' )
-		);
+		let editables;
+
+		if ( selectedBlock.getAttribute( 'contenteditable' ) ) {
+			editables = [ selectedBlock ];
+		} else {
+			editables = Array.from(
+				selectedBlock.querySelectorAll( '[contenteditable]' )
+			);
+		}
+
 		const editableIndex = editables.indexOf( document.activeElement );
 		const selection = window.getSelection();
 

--- a/packages/e2e-tests/specs/experiments/navigation.test.js
+++ b/packages/e2e-tests/specs/experiments/navigation.test.js
@@ -76,6 +76,7 @@ async function mockCreatePageResponse( title, slug ) {
 
 /**
  * Interacts with the LinkControl to perform a search and select a returned suggestion
+ *
  * @param {string} url What will be typed in the search input
  * @param {string} label What the resulting label will be in the creating Navigation Link Block after the block is created.
  * @param {string} type What kind of suggestion should be clicked, ie. 'url', 'create', or 'entity'


### PR DESCRIPTION
## Description

This is still a work in progress as there are some final details to be figured out.

This is the final step in lightening the block DOM. This PR allows block types to opt in to rendering their own wrapper.

```js
supports: {
   lightBlockWrapper: true,
}
```

**Why?**

* If a block type opts in, there is no longer a need for the `getEditWrapperProps` setting. Blocks can now apply the props themselves. The could be useful for e.g. alignment. A block can now set proper classes instead of `data-align` attributes, which will make it easier for themes to style the editor. Currently, for many themes, even the latest core theme, alignment in the editor doesn't reflect the alignment on the front-end.
* As we lighten the `InnerBlocks` DOM, it will be possible to build more complex block that need a semantic relationship with its child blocks. E.g. for a table and list block, the table cells and list items need to be direct children of the parent block, so these blocks need to render their own wrapper.
* This also means that complex nested blocks become much easier to style by themes as the element tree in the editor matches that of the front-end.

```html
<div class="wp-block-columns">
  <div class="wp-block-column">
    <p>one</p>
  </div>
  <div class="wp-block-column">
    <p>two</p>
  </div>
</div>
```

The above is much nicer to handle than many layers of nested `div` elements.

I believe that allowing simple block markup in the editor will be essential for full site editing and theming.

* For blocks that opt in, it will get rid of the useless focusable wrapper element. For example, a paragraph block has currently two focusable elements: the wrapper and the paragraph. The focusable wrapper is useless here, and adds an extra tab stop. There's no reason for the paragraph not to be the wrapper.

<img width="725" alt="Screenshot 2020-01-16 at 13 52 17" src="https://user-images.githubusercontent.com/4710635/72526749-6bd30580-3867-11ea-97b2-d3cde2773c67.png">

**Implementation notes**

The way I'm approaching this is a bit inspired by `react-spring`. I created a base block component that is provided with the context it needs to render and the props that the block `Edit` component may pass. For every element that can act as a block wrapper, I created a wrapped component as properties of the base component, so you can have `Block.p`, `Block.div`, `Block.figure` etc.

This works well together with `RichText` too. You can pass the component through the `tagName` props, and `RichText` will render the wrapper.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
