### PR TITLE
Block: fix alignments

### DIFF
--- a/packages/block-editor/src/components/block-edit/edit.js
+++ b/packages/block-editor/src/components/block-edit/edit.js
@@ -30,7 +30,7 @@ export const Edit = ( props ) => {
 	const component = <Component { ...props } className={ className } />;
 
 	if ( attributes.align ) {
-		return <div data-block-content>{ component }</div>;
+		return <div className="is-block-content">{ component }</div>;
 	}
 
 	return component;

--- a/packages/block-editor/src/components/block-edit/edit.js
+++ b/packages/block-editor/src/components/block-edit/edit.js
@@ -27,8 +27,13 @@ export const Edit = ( props ) => {
 	// with which a block is displayed. If `blockType` is valid, assign
 	// them preferentially as the render value for the block.
 	const Component = blockType.edit || blockType.save;
+	const component = <Component { ...props } className={ className } />;
 
-	return <Component { ...props } className={ className } />;
+	if ( attributes.align ) {
+		return <div data-block-content>{ component }</div>;
+	}
+
+	return component;
 };
 
 export default withFilters( 'editor.BlockEdit' )( Edit );

--- a/packages/block-editor/src/components/block-edit/edit.js
+++ b/packages/block-editor/src/components/block-edit/edit.js
@@ -27,13 +27,7 @@ export const Edit = ( props ) => {
 	// with which a block is displayed. If `blockType` is valid, assign
 	// them preferentially as the render value for the block.
 	const Component = blockType.edit || blockType.save;
-	const component = <Component { ...props } className={ className } />;
-
-	if ( attributes.align ) {
-		return <div className="is-block-content">{ component }</div>;
-	}
-
-	return component;
+	return <Component { ...props } className={ className } />;
 };
 
 export default withFilters( 'editor.BlockEdit' )( Edit );

--- a/packages/block-editor/src/components/block-list/block-popover.js
+++ b/packages/block-editor/src/components/block-list/block-popover.js
@@ -98,11 +98,9 @@ function BlockPopover( {
 		return null;
 	}
 
-	const contentElement = node.querySelector( '[data-block-content]' );
-
 	// A block may speciy a different target element for the toolbar.
-	if ( contentElement ) {
-		node = contentElement;
+	if ( node.classList.contains( 'is-block-collapsed' ) ) {
+		node = node.querySelector( '.is-block-content' ) || node;
 	}
 
 	function onFocus() {

--- a/packages/block-editor/src/components/block-list/block-popover.js
+++ b/packages/block-editor/src/components/block-list/block-popover.js
@@ -92,10 +92,17 @@ function BlockPopover( {
 		return null;
 	}
 
-	const node = document.getElementById( 'block-' + capturingClientId );
+	let node = document.getElementById( 'block-' + capturingClientId );
 
 	if ( ! node ) {
 		return null;
+	}
+
+	const contentElement = node.querySelector( '[data-block-content]' );
+
+	// A block may speciy a different target element for the toolbar.
+	if ( contentElement ) {
+		node = contentElement;
 	}
 
 	function onFocus() {

--- a/packages/block-editor/src/components/block-list/block-popover.js
+++ b/packages/block-editor/src/components/block-list/block-popover.js
@@ -98,7 +98,7 @@ function BlockPopover( {
 		return null;
 	}
 
-	// A block may speciy a different target element for the toolbar.
+	// A block may specify a different target element for the toolbar.
 	if ( node.classList.contains( 'is-block-collapsed' ) ) {
 		node = node.querySelector( '.is-block-content' ) || node;
 	}

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -238,6 +238,7 @@ function BlockListBlock( {
 			'is-focused': isFocusMode && ( isSelected || isAncestorOfSelectedBlock ),
 			'is-focus-mode': isFocusMode,
 			'has-child-selected': isAncestorOfSelectedBlock,
+			'is-block-collapsed': !! attributes.align,
 		},
 		className
 	);

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -275,7 +275,8 @@ function BlockListBlock( {
 	);
 
 	// For aligned blocks, provide a wrapper element so the block can be
-	// positioned relative to the block column.
+	// positioned relative to the block column. This is enabled with the
+	// .is-block-content className.
 	if ( isAligned ) {
 		blockEdit = <div className="is-block-content">{ blockEdit }</div>;
 	}

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -222,6 +222,16 @@ function BlockListBlock( {
 
 	const isDragging = isDraggingBlocks && ( isSelected || isPartOfMultiSelection );
 
+	// Determine whether the block has props to apply to the wrapper.
+	if ( blockType.getEditWrapperProps ) {
+		wrapperProps = {
+			...wrapperProps,
+			...blockType.getEditWrapperProps( attributes ),
+		};
+	}
+
+	const isAligned = wrapperProps && wrapperProps[ 'data-align' ];
+
 	// The wp-block className is important for editor styles.
 	// Generate the wrapper class names handling the different states of the block.
 	const wrapperClassName = classnames(
@@ -238,18 +248,11 @@ function BlockListBlock( {
 			'is-focused': isFocusMode && ( isSelected || isAncestorOfSelectedBlock ),
 			'is-focus-mode': isFocusMode,
 			'has-child-selected': isAncestorOfSelectedBlock,
-			'is-block-collapsed': !! attributes.align,
+			'is-block-collapsed': isAligned,
 		},
 		className
 	);
 
-	// Determine whether the block has props to apply to the wrapper.
-	if ( blockType.getEditWrapperProps ) {
-		wrapperProps = {
-			...wrapperProps,
-			...blockType.getEditWrapperProps( attributes ),
-		};
-	}
 	const blockElementId = `block-${ clientId }`;
 
 	// We wrap the BlockEdit component in a div that hides it when editing in
@@ -273,7 +276,7 @@ function BlockListBlock( {
 
 	// For aligned blocks, provide a wrapper element so the block can be
 	// positioned relative to the block column.
-	if ( attributes.align ) {
+	if ( isAligned ) {
 		blockEdit = <div className="is-block-content">{ blockEdit }</div>;
 	}
 

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -270,6 +270,13 @@ function BlockListBlock( {
 			toggleSelection={ toggleSelection }
 		/>
 	);
+
+	// For aligned blocks, provide a wrapper element so the block can be
+	// positioned relative to the block column.
+	if ( attributes.align ) {
+		blockEdit = <div className="is-block-content">{ blockEdit }</div>;
+	}
+
 	if ( mode !== 'visual' ) {
 		blockEdit = <div style={ { display: 'none' } }>{ blockEdit }</div>;
 	}

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -57,10 +57,6 @@
 	// Break long strings of text without spaces so they don't overflow the block.
 	overflow-wrap: break-word;
 
-	[data-block-target] {
-		position: relative;
-	}
-
 	/**
 	 * Notices
 	 */
@@ -169,15 +165,18 @@
 	// When selecting multiple blocks, we provide an additional selection indicator.
 	.block-editor-block-list__block.is-multi-selected {
 		// Show selection borders around every non-nested block's actual footprint.
-		box-shadow: 0 0 0 2px $blue-medium-focus;
-		border-radius: 1px;
+		&:not(.is-block-collapsed),
+		.is-block-content {
+			box-shadow: 0 0 0 2px $blue-medium-focus;
+			border-radius: 1px;
 
-		// Windows High Contrast mode will show this outline.
-		outline: 2px solid transparent;
+			// Windows High Contrast mode will show this outline.
+			outline: 2px solid transparent;
 
-		// Show a lighter blue for dark themes.
-		.is-dark-theme & {
-			box-shadow: 0 0 0 2px $blue-medium-focus-dark;
+			// Show a lighter blue for dark themes.
+			.is-dark-theme & {
+				box-shadow: 0 0 0 2px $blue-medium-focus-dark;
+			}
 		}
 
 		// Provide exceptions for placeholders.
@@ -298,7 +297,7 @@
 	}
 
 	// Left.
-	&[data-align="left"] > [data-block-content] {
+	&[data-align="left"] > .is-block-content {
 		// This is in the editor only; the image should be floated on the frontend.
 		/*!rtl:begin:ignore*/
 		float: left;
@@ -307,7 +306,7 @@
 	}
 
 	// Right.
-	&[data-align="right"] > [data-block-content] {
+	&[data-align="right"] > .is-block-content {
 		// Right: This is in the editor only; the image should be floated on the frontend.
 		/*!rtl:begin:ignore*/
 		float: right;

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -57,6 +57,10 @@
 	// Break long strings of text without spaces so they don't overflow the block.
 	overflow-wrap: break-word;
 
+	[data-block-target] {
+		position: relative;
+	}
+
 	/**
 	 * Notices
 	 */
@@ -283,6 +287,10 @@
 	&[data-align="right"] {
 		// Without z-index, won't be clickable as "above" adjacent content.
 		z-index: z-index(".block-editor-block-list__block {core/image aligned left or right}");
+		width: 100%;
+
+		// When images are floated, the block itself should collapse to zero height.
+		height: 0;
 
 		&::before {
 			content: none;
@@ -290,7 +298,7 @@
 	}
 
 	// Left.
-	&[data-align="left"] {
+	&[data-align="left"] > [data-block-content] {
 		// This is in the editor only; the image should be floated on the frontend.
 		/*!rtl:begin:ignore*/
 		float: left;
@@ -299,7 +307,7 @@
 	}
 
 	// Right.
-	&[data-align="right"] {
+	&[data-align="right"] > [data-block-content] {
 		// Right: This is in the editor only; the image should be floated on the frontend.
 		/*!rtl:begin:ignore*/
 		float: right;


### PR DESCRIPTION
## Description

After #19593, this PR reintroduces a `div` wrapper element for blocks that support alignment. This wrapper `div` is necessary to contain the aligned block within the main block column. Maybe in the future, the block itself can add this wrapper `div`, but for now we have to provide it.

Note that the wrapper div has the `is-block-content` class. Regardless of how we rewrite alignments, an attribute like this will be necessary so a block can decide where the toolbar should be attached to.

## How has this been tested?

Test alignments on blocks.

## Screenshots <!-- if applicable -->

<img width="666" alt="Screenshot 2020-01-16 at 16 02 09" src="https://user-images.githubusercontent.com/4710635/72535867-8f9f4700-3879-11ea-8ad6-cca032329eb6.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
