### PR TITLE
Block Editor: Flatten LinkControl components by mocking useSelect for tests

### DIFF
--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -31,16 +31,21 @@ import LinkControlSearchInput from './search-input';
 
 const MODE_EDIT = 'edit';
 
-export function LinkControl( {
+function LinkControl( {
 	value,
 	settings,
 	onChange = noop,
 	showInitialSuggestions,
-	fetchSearchSuggestions,
 } ) {
 	const instanceId = useInstanceId( LinkControl );
 	const [ inputValue, setInputValue ] = useState( '' );
 	const [ isEditingLink, setIsEditingLink ] = useState( ! value || ! value.url );
+	const { fetchSearchSuggestions } = useSelect( ( select ) => {
+		const { getSettings } = select( 'core/block-editor' );
+		return {
+			fetchSearchSuggestions: getSettings().__experimentalFetchLinkSuggestions,
+		};
+	}, [] );
 
 	// Handlers
 
@@ -226,15 +231,4 @@ export function LinkControl( {
 	);
 }
 
-function ConnectedLinkControl( props ) {
-	const { fetchSearchSuggestions } = useSelect( ( select ) => {
-		const { getSettings } = select( 'core/block-editor' );
-		return {
-			fetchSearchSuggestions: getSettings().__experimentalFetchLinkSuggestions,
-		};
-	}, [] );
-
-	return <LinkControl fetchSearchSuggestions={ fetchSearchSuggestions } { ...props } />;
-}
-
-export default ConnectedLinkControl;
+export default LinkControl;

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -17,16 +17,9 @@ import { fauxEntitySuggestions, fetchFauxEntitySuggestions } from './fixtures';
 
 const mockFetchSearchSuggestions = jest.fn();
 
-jest.mock( '@wordpress/data', () => {
-	return {
-		...require.requireActual( '../../../../../data' ),
-		useSelect() {
-			return {
-				fetchSearchSuggestions: mockFetchSearchSuggestions,
-			};
-		},
-	};
-} );
+jest.mock( '@wordpress/data/src/components/use-select', () => () => ( {
+	fetchSearchSuggestions: mockFetchSearchSuggestions,
+} ) );
 
 /**
  * Wait for next tick of event loop. This is required

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -12,8 +12,21 @@ import { UP, DOWN, ENTER } from '@wordpress/keycodes';
 /**
  * Internal dependencies
  */
-import { LinkControl } from '../index';
+import LinkControl from '../';
 import { fauxEntitySuggestions, fetchFauxEntitySuggestions } from './fixtures';
+
+const mockFetchSearchSuggestions = jest.fn();
+
+jest.mock( '@wordpress/data', () => {
+	return {
+		...require.requireActual( '../../../../../data' ),
+		useSelect() {
+			return {
+				fetchSearchSuggestions: mockFetchSearchSuggestions,
+			};
+		},
+	};
+} );
 
 /**
  * Wait for next tick of event loop. This is required
@@ -33,6 +46,7 @@ beforeEach( () => {
 	// setup a DOM element as a render target
 	container = document.createElement( 'div' );
 	document.body.appendChild( container );
+	mockFetchSearchSuggestions.mockImplementation( fetchFauxEntitySuggestions );
 } );
 
 afterEach( () => {
@@ -40,6 +54,7 @@ afterEach( () => {
 	unmountComponentAtNode( container );
 	container.remove();
 	container = null;
+	mockFetchSearchSuggestions.mockReset();
 } );
 
 describe( 'Basic rendering', () => {
@@ -71,11 +86,11 @@ describe( 'Searching for a link', () => {
 			resolver = resolve;
 		} );
 
+		mockFetchSearchSuggestions.mockImplementation( fauxRequest );
+
 		act( () => {
 			render(
-				<LinkControl
-					fetchSearchSuggestions={ fauxRequest }
-				/>, container
+				<LinkControl />, container
 			);
 		} );
 
@@ -116,9 +131,7 @@ describe( 'Searching for a link', () => {
 
 		act( () => {
 			render(
-				<LinkControl
-					fetchSearchSuggestions={ fetchFauxEntitySuggestions }
-				/>, container
+				<LinkControl />, container
 			);
 		} );
 
@@ -154,9 +167,7 @@ describe( 'Searching for a link', () => {
 	] )( 'should display a URL suggestion as a default fallback for the search term "%s" which could potentially be a valid url.', async ( searchTerm ) => {
 		act( () => {
 			render(
-				<LinkControl
-					fetchSearchSuggestions={ fetchFauxEntitySuggestions }
-				/>, container
+				<LinkControl />, container
 			);
 		} );
 
@@ -191,9 +202,7 @@ describe( 'Searching for a link', () => {
 
 		act( () => {
 			render(
-				<LinkControl
-					fetchSearchSuggestions={ fetchFauxEntitySuggestions }
-				/>, container
+				<LinkControl />, container
 			);
 		} );
 
@@ -243,9 +252,7 @@ describe( 'Manual link entry', () => {
 	] )( 'should display a single suggestion result when the current input value is URL-like (eg: %s)', async ( searchTerm ) => {
 		act( () => {
 			render(
-				<LinkControl
-					fetchSearchSuggestions={ fetchFauxEntitySuggestions }
-				/>, container
+				<LinkControl />, container
 			);
 		} );
 
@@ -279,9 +286,7 @@ describe( 'Manual link entry', () => {
 		] )( 'should recognise "%s" as a %s link and handle as manual entry by displaying a single suggestion', async ( searchTerm, searchType ) => {
 			act( () => {
 				render(
-					<LinkControl
-						fetchSearchSuggestions={ fetchFauxEntitySuggestions }
-					/>, container
+					<LinkControl />, container
 				);
 			} );
 
@@ -311,15 +316,11 @@ describe( 'Manual link entry', () => {
 
 describe( 'Default search suggestions', () => {
 	it( 'should display a list of initial search suggestions when there is no search value or suggestions', async () => {
-		const searchSuggestionsSpy = jest.fn( fetchFauxEntitySuggestions );
 		const expectedResultsLength = 3; // set within `LinkControl`
 
 		act( () => {
 			render(
-				<LinkControl
-					fetchSearchSuggestions={ searchSuggestionsSpy }
-					showInitialSuggestions={ true }
-				/>, container
+				<LinkControl showInitialSuggestions />, container
 			);
 		} );
 
@@ -341,7 +342,7 @@ describe( 'Default search suggestions', () => {
 		// Ensure only called once as a guard against potential infinite
 		// re-render loop within `componentDidUpdate` calling `updateSuggestions`
 		// which has calls to `setState` within it.
-		expect( searchSuggestionsSpy ).toHaveBeenCalledTimes( 1 );
+		expect( mockFetchSearchSuggestions ).toHaveBeenCalledTimes( 1 );
 
 		// Verify the search results already display the initial suggestions
 		expect( initialSearchResultElements ).toHaveLength( expectedResultsLength );
@@ -350,7 +351,6 @@ describe( 'Default search suggestions', () => {
 	} );
 
 	it( 'should not display initial suggestions when input value is present', async () => {
-		const searchSuggestionsSpy = jest.fn( fetchFauxEntitySuggestions );
 		let searchResultElements;
 		//
 		// Render with an initial value an ensure that no initial suggestions
@@ -359,8 +359,7 @@ describe( 'Default search suggestions', () => {
 		act( () => {
 			render(
 				<LinkControl
-					fetchSearchSuggestions={ searchSuggestionsSpy }
-					showInitialSuggestions={ true }
+					showInitialSuggestions
 					value={ fauxEntitySuggestions[ 0 ] }
 				/>, container
 			);
@@ -368,7 +367,7 @@ describe( 'Default search suggestions', () => {
 
 		await eventLoopTick();
 
-		expect( searchSuggestionsSpy ).not.toHaveBeenCalled();
+		expect( mockFetchSearchSuggestions ).not.toHaveBeenCalled();
 
 		//
 		// Click the "Edit/Change" button and check initial suggestions are not
@@ -387,7 +386,7 @@ describe( 'Default search suggestions', () => {
 
 		expect( searchResultElements ).toHaveLength( 0 );
 
-		expect( searchSuggestionsSpy ).not.toHaveBeenCalled();
+		expect( mockFetchSearchSuggestions ).not.toHaveBeenCalled();
 
 		//
 		// Reset the search to empty and check the initial suggestions are now shown.
@@ -407,7 +406,7 @@ describe( 'Default search suggestions', () => {
 		// Ensure only called once as a guard against potential infinite
 		// re-render loop within `componentDidUpdate` calling `updateSuggestions`
 		// which has calls to `setState` within it.
-		expect( searchSuggestionsSpy ).toHaveBeenCalledTimes( 1 );
+		expect( mockFetchSearchSuggestions ).toHaveBeenCalledTimes( 1 );
 	} );
 } );
 
@@ -418,18 +417,11 @@ describe( 'Selecting links', () => {
 		const LinkControlConsumer = () => {
 			const [ link ] = useState( selectedLink );
 
-			return (
-				<LinkControl
-					value={ link }
-					fetchSearchSuggestions={ fetchFauxEntitySuggestions }
-				/>
-			);
+			return <LinkControl value={ link } />;
 		};
 
 		act( () => {
-			render(
-				<LinkControlConsumer />, container
-			);
+			render( <LinkControlConsumer />, container );
 		} );
 
 		// TODO: select by aria role or visible text
@@ -453,15 +445,12 @@ describe( 'Selecting links', () => {
 				<LinkControl
 					value={ link }
 					onChange={ ( suggestion ) => setLink( suggestion ) }
-					fetchSearchSuggestions={ fetchFauxEntitySuggestions }
 				/>
 			);
 		};
 
 		act( () => {
-			render(
-				<LinkControlConsumer />, container
-			);
+			render( <LinkControlConsumer />, container );
 		} );
 
 		// Required in order to select the button below
@@ -499,7 +488,6 @@ describe( 'Selecting links', () => {
 					<LinkControl
 						value={ link }
 						onChange={ ( suggestion ) => setLink( suggestion ) }
-						fetchSearchSuggestions={ fetchFauxEntitySuggestions }
 					/>
 				);
 			};
@@ -559,7 +547,6 @@ describe( 'Selecting links', () => {
 					<LinkControl
 						value={ link }
 						onChange={ ( suggestion ) => setLink( suggestion ) }
-						fetchSearchSuggestions={ fetchFauxEntitySuggestions }
 					/>
 				);
 			};
@@ -644,18 +631,11 @@ describe( 'Addition Settings UI', () => {
 		const LinkControlConsumer = () => {
 			const [ link ] = useState( selectedLink );
 
-			return (
-				<LinkControl
-					value={ link }
-					fetchSearchSuggestions={ fetchFauxEntitySuggestions }
-				/>
-			);
+			return <LinkControl value={ link } />;
 		};
 
 		act( () => {
-			render(
-				<LinkControlConsumer />, container
-			);
+			render( <LinkControlConsumer />, container );
 		} );
 
 		const newTabSettingLabel = Array.from( container.querySelectorAll( 'label' ) ).find( ( label ) => label.innerHTML && label.innerHTML.includes( expectedSettingText ) );
@@ -689,16 +669,13 @@ describe( 'Addition Settings UI', () => {
 			return (
 				<LinkControl
 					value={ { ...link, newTab: false, noFollow: true } }
-					fetchSearchSuggestions={ fetchFauxEntitySuggestions }
 					settings={ customSettings }
 				/>
 			);
 		};
 
 		act( () => {
-			render(
-				<LinkControlConsumer />, container
-			);
+			render( <LinkControlConsumer />, container );
 		} );
 
 		// Grab the elements using user perceivable DOM queries

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -89,9 +89,7 @@ describe( 'Searching for a link', () => {
 		mockFetchSearchSuggestions.mockImplementation( fauxRequest );
 
 		act( () => {
-			render(
-				<LinkControl />, container
-			);
+			render( <LinkControl />, container );
 		} );
 
 		// Search Input UI
@@ -130,9 +128,7 @@ describe( 'Searching for a link', () => {
 		const firstFauxSuggestion = first( fauxEntitySuggestions );
 
 		act( () => {
-			render(
-				<LinkControl />, container
-			);
+			render( <LinkControl />, container );
 		} );
 
 		// Search Input UI
@@ -166,9 +162,7 @@ describe( 'Searching for a link', () => {
 		[ 'ThisCouldAlsoBeAValidURL' ],
 	] )( 'should display a URL suggestion as a default fallback for the search term "%s" which could potentially be a valid url.', async ( searchTerm ) => {
 		act( () => {
-			render(
-				<LinkControl />, container
-			);
+			render( <LinkControl />, container );
 		} );
 
 		// Search Input UI
@@ -201,9 +195,7 @@ describe( 'Searching for a link', () => {
 		const searchTerm = 'Hello world';
 
 		act( () => {
-			render(
-				<LinkControl />, container
-			);
+			render( <LinkControl />, container );
 		} );
 
 		let searchResultElements;
@@ -251,9 +243,7 @@ describe( 'Manual link entry', () => {
 		[ 'www.wordpress.org' ], // usage of "www"
 	] )( 'should display a single suggestion result when the current input value is URL-like (eg: %s)', async ( searchTerm ) => {
 		act( () => {
-			render(
-				<LinkControl />, container
-			);
+			render( <LinkControl />, container );
 		} );
 
 		// Search Input UI


### PR DESCRIPTION
Previously: https://github.com/WordPress/gutenberg/pull/19638/files#r366440796

This pull request seeks to flatten the `LinkControl` component to remove the wrapper component added in #19638 which had been used for the purpose of preserving test behavior. The changes here resolve this by providing a mock for the `useSelect` function in the tests.

**Testing Instructions:**

Ensure unit tests pass:

```
npm run test-unit packages/block-editor/src/components/link-control/index.js
```