### PR TITLE
Block Editor: Remove non-public fetchSearchSuggestions from LinkControl documentation

### DIFF
--- a/packages/block-editor/src/components/link-control/README.md
+++ b/packages/block-editor/src/components/link-control/README.md
@@ -28,11 +28,6 @@
 
 An array of settings objects. Each object will used to render a `ToggleControl` for that setting.
 
-### fetchSearchSuggestions
-
-- Type: `Function`
-- Required: No
-
 ## Event handlers
 
 ### onClose


### PR DESCRIPTION
Previously: https://github.com/WordPress/gutenberg/pull/19705#issuecomment-575294824

This pull request seeks to resolve an issue where the `LinkControl` component is documented to support a `fetchSearchSuggestions` prop. However, this prop was removed as of #19705 under the assumption it was not expected to be needed (after #19638).

That said, there's two approaches this could take:

- Reintroduce the prop to the component
- Remove the documented prop

The current pull request changes implement the second option.

It is not clear to me whether this prop is actually needed, or if it's sufficient to rely on the `__experimentalFetchLinkSuggestions` block settings value which is `select`-ed in the internal implementation of the component. It may have been useful previously for the purpose of the unit tests to verify the expected behavior of a stubbed fetch function.

**Testing Instructions:**

Currently, the only changes are to the documentation, so there are no expected changes to the application runtime.