### PR TITLE
Remove: Gradient Picker from cover block placeholder

### DIFF
--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -35,7 +35,6 @@ import {
 	withColors,
 	ColorPalette,
 	__experimentalUseGradient,
-	__experimentalGradientPicker,
 	__experimentalPanelColorGradientSettings as PanelColorGradientSettings,
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
@@ -425,19 +424,6 @@ function CoverEdit( {
 							disableCustomColors={ true }
 							value={ overlayColor.color }
 							onChange={ setOverlayColor }
-							clearable={ false }
-						/>
-						<__experimentalGradientPicker
-							disableCustomGradients
-							onChange={
-								( newGradient ) => {
-									setGradient( newGradient );
-									setAttributes( {
-										overlayColor: undefined,
-									} );
-								}
-							}
-							value={ gradientValue }
 							clearable={ false }
 						/>
 					</div>


### PR DESCRIPTION
## Description
This PR follows a suggestion by @mtias and removes the gradient picking functionality from the cover block placeholder.
It is still possible to use gradients on the placeholder block by using the block inspector.

## How has this been tested?
I added a cover block.
I verified the block placeholder did not render gradients as it does on master.
