### PR TITLE
Array type attribute source query comma missing

### DIFF
--- a/docs/designers-developers/developers/block-api/block-attributes.md
+++ b/docs/designers-developers/developers/block-api/block-attributes.md
@@ -114,7 +114,7 @@ _Example_: Extract `src` and `alt` from each image element in the block's markup
 {
 	images: {
 		type: 'array',
-		source: 'query'
+		source: 'query',
 		selector: 'img',
 		query: {
 			url: {


### PR DESCRIPTION
Array type attribute source query comma missing

## Description
Missing comma in object

