### PR TITLE
Sibling inserter: fix dead zone between blocks

### DIFF
--- a/packages/block-editor/src/components/block-list/insertion-point.js
+++ b/packages/block-editor/src/components/block-list/insertion-point.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { useState } from '@wordpress/element';
+import { useState, useRef } from '@wordpress/element';
 import { Popover } from '@wordpress/components';
 import { placeCaretAtVerticalEdge } from '@wordpress/dom';
 
@@ -49,6 +49,7 @@ export default function InsertionPoint( {
 	const [ isInserterForced, setIsInserterForced ] = useState( false );
 	const [ inserterElement, setInserterElement ] = useState( null );
 	const [ inserterClientId, setInserterClientId ] = useState( null );
+	const ref = useRef();
 
 	function onMouseMove( event ) {
 		if ( event.target.className !== className ) {
@@ -89,8 +90,13 @@ export default function InsertionPoint( {
 	}
 
 	function onClick( event ) {
-		const { clientX, clientY } = event;
-		const targetRect = event.target.getBoundingClientRect();
+		const { clientX, clientY, target } = event;
+
+		if ( target !== ref.current ) {
+			return;
+		}
+
+		const targetRect = target.getBoundingClientRect();
 		const isReverse = clientY < targetRect.top + ( targetRect.height / 2 );
 		const blockNode = getBlockDOMNode( inserterClientId );
 		const container = isReverse ? containerRef.current : blockNode;
@@ -116,6 +122,7 @@ export default function InsertionPoint( {
 				<Indicator clientId={ inserterClientId } />
 				{ /* eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */ }
 				<div
+					ref={ ref }
 					onFocus={ () => setIsInserterForced( true ) }
 					onBlur={ () => setIsInserterForced( false ) }
 					onClick={ onClick }

--- a/packages/block-editor/src/components/block-list/insertion-point.js
+++ b/packages/block-editor/src/components/block-list/insertion-point.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
@@ -71,7 +76,7 @@ export default function InsertionPoint( {
 
 		const clientId = element.id.slice( 'block-'.length );
 
-		if ( ! clientId || clientId === selectedBlockClientId ) {
+		if ( ! clientId ) {
 			return;
 		}
 
@@ -89,7 +94,7 @@ export default function InsertionPoint( {
 		setInserterClientId( clientId );
 	}
 
-	function onClick( event ) {
+	function focusClosestTabbable( event ) {
 		const { clientX, clientY, target } = event;
 
 		// Only handle click on the wrapper specifically, and not an event
@@ -127,7 +132,7 @@ export default function InsertionPoint( {
 					ref={ ref }
 					onFocus={ () => setIsInserterForced( true ) }
 					onBlur={ () => setIsInserterForced( false ) }
-					onClick={ onClick }
+					onClick={ focusClosestTabbable }
 					// While ideally it would be enough to capture the
 					// bubbling focus event from the Inserter, due to the
 					// characteristics of click focusing of `button`s in
@@ -135,7 +140,13 @@ export default function InsertionPoint( {
 					//
 					// See: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Clicking_and_focus
 					tabIndex={ -1 }
-					className="block-editor-block-list__insertion-point-inserter"
+					className={ classnames(
+						'block-editor-block-list__insertion-point-inserter',
+						{
+							// Hide the inserter above the selected block.
+							'is-inserter-hidden': inserterClientId === selectedBlockClientId,
+						}
+					) }
 				>
 					<Inserter clientId={ inserterClientId } />
 				</div>

--- a/packages/block-editor/src/components/block-list/insertion-point.js
+++ b/packages/block-editor/src/components/block-list/insertion-point.js
@@ -92,6 +92,8 @@ export default function InsertionPoint( {
 	function onClick( event ) {
 		const { clientX, clientY, target } = event;
 
+		// Only handle click on the wrapper specifically, and not an event
+		// bubbled from the inserter itself.
 		if ( target !== ref.current ) {
 			return;
 		}

--- a/packages/block-editor/src/components/block-list/root-container.js
+++ b/packages/block-editor/src/components/block-list/root-container.js
@@ -78,6 +78,7 @@ function RootContainer( { children, className }, ref ) {
 			className={ className }
 			isMultiSelecting={ isMultiSelecting }
 			selectedBlockClientId={ selectedBlockClientId }
+			containerRef={ ref }
 		>
 			<BlockPopover />
 			<div

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -381,6 +381,14 @@
 	}
 
 	justify-content: center;
+
+	// Clicks on the inserter are redirected to the nearest tabbable element.
+	cursor: text;
+
+	// Hide the inserter above the selected block.
+	&.is-inserter-hidden {
+		opacity: 0;
+	}
 }
 
 .block-editor-block-list__block-popover-inserter {
@@ -531,6 +539,13 @@
 		border: none;
 		box-shadow: none;
 		overflow-y: visible;
+
+		// Allow clicking through the toolbar holder.
+		pointer-events: none;
+
+		> * {
+			pointer-events: all;
+		}
 
 		.block-editor-block-contextual-toolbar,
 		.block-editor-block-list__breadcrumb {

--- a/packages/block-editor/src/components/writing-flow/index.js
+++ b/packages/block-editor/src/components/writing-flow/index.js
@@ -86,7 +86,7 @@ export function isNavigationCandidate( element, keyCode, hasModifier ) {
  *
  * @return {?Element} Optimal tab target, if one exists.
  */
-function getClosestTabbable( target, isReverse, containerElement ) {
+export function getClosestTabbable( target, isReverse, containerElement ) {
 	// Since the current focus target is not guaranteed to be a text field,
 	// find all focusables. Tabbability is considered later.
 	let focusableNodes = focus.focusable.find( containerElement );


### PR DESCRIPTION
## Description

Fixes #18733.
Fixes #10648.

This PR removes the "dead zone" between blocks by handling clicks on the inserter to focus the closest element.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
