### PR TITLE
DOM: Mark stripHTML as unstable

### DIFF
--- a/packages/blocks/src/api/utils.js
+++ b/packages/blocks/src/api/utils.js
@@ -9,7 +9,7 @@ import { default as tinycolor, mostReadable } from 'tinycolor2';
  */
 import { Component, isValidElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { stripHTML } from '@wordpress/dom';
+import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
 
 /**
  * Internal dependencies

--- a/packages/dom/README.md
+++ b/packages/dom/README.md
@@ -204,18 +204,6 @@ _Returns_
 
 -   `Element`: The new node.
 
-<a name="stripHTML" href="#stripHTML">#</a> **stripHTML**
-
-Removes any HTML tags from the provided string.
-
-_Parameters_
-
--   _html_ `string`: The string containing html.
-
-_Returns_
-
--   `string`: The text content with any html removed.
-
 <a name="unwrap" href="#unwrap">#</a> **unwrap**
 
 Unwrap the given node. This means any child nodes are moved to the parent.

--- a/packages/dom/src/dom.js
+++ b/packages/dom/src/dom.js
@@ -669,7 +669,7 @@ export function wrap( newNode, referenceNode ) {
  *
  * @return {string} The text content with any html removed.
  */
-export function stripHTML( html ) {
+export function __unstableStripHTML( html ) {
 	const document = new DOMParser().parseFromString( html, 'text/html' );
 	return document.body.textContent || '';
 }

--- a/packages/dom/src/test/dom.js
+++ b/packages/dom/src/test/dom.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { isHorizontalEdge, placeCaretAtHorizontalEdge, isTextField, stripHTML } from '../dom';
+import { isHorizontalEdge, placeCaretAtHorizontalEdge, isTextField, __unstableStripHTML as stripHTML } from '../dom';
 
 describe( 'DOM', () => {
 	let parent;


### PR DESCRIPTION
Previously: #18132
Related: #19664

This pull request seeks to mark the `stripHTML` function added to the `@wordpress/dom` package in #18132 as unstable, subject to future removal (#19664). It is made a separate task in order to avoid a backward-compatibility commitment associated with the upcoming Gutenberg 7.3 release.

**Testing Instructions:**

Repeat testing instructions from #18132