### PR TITLE
Accessibility: Show open button when the sidebar is closed and tabbingg out of the content

### DIFF
--- a/packages/edit-post/src/components/editor-regions/style.scss
+++ b/packages/edit-post/src/components/editor-regions/style.scss
@@ -74,6 +74,27 @@ html {
 }
 
 .edit-post-editor-regions__sidebar {
+	display: none;
+
+	@include break-medium() {
+		display: block;
+		z-index: z-index(".edit-post-editor-regions__sidebar");
+		position: fixed !important; // Need to override the default relative positionning
+		top: -9999em;
+		bottom: auto;
+		left: auto;
+		right: 0;
+		width: $sidebar-width;
+
+		&:focus {
+			top: auto;
+			bottom: 0;
+		}
+	}
+}
+
+.is-sidebar-opened .edit-post-editor-regions__sidebar {
+	display: block;
 	width: auto; // Keep the sidebar width flexible.
 	flex-shrink: 0;
 	position: absolute;
@@ -83,10 +104,6 @@ html {
 	bottom: 0;
 	left: 0;
 	background: $white;
-
-	&:empty {
-		display: none;
-	}
 
 	// On Mobile the header is fixed to keep HTML as scrollable.
 	@include break-medium() {

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -52,9 +52,11 @@ import WelcomeGuide from '../welcome-guide';
 
 function Layout() {
 	const isMobileViewport = useViewportMatch( 'small', '<' );
-	const { closePublishSidebar, togglePublishSidebar } = useDispatch(
-		'core/edit-post'
-	);
+	const {
+		closePublishSidebar,
+		openGeneralSidebar,
+		togglePublishSidebar,
+	} = useDispatch( 'core/edit-post' );
 	const {
 		mode,
 		isRichEditingEnabled,
@@ -66,6 +68,7 @@ function Layout() {
 		hasFixedToolbar,
 		previousShortcut,
 		nextShortcut,
+		hasBlockSelected,
 	} = useSelect( ( select ) => {
 		return {
 			hasFixedToolbar: select( 'core/edit-post' ).isFeatureActive(
@@ -93,6 +96,9 @@ function Layout() {
 			nextShortcut: select(
 				'core/keyboard-shortcuts'
 			).getAllShortcutRawKeyCombinations( 'core/edit-post/next-region' ),
+			hasBlockSelected: select(
+				'core/block-editor'
+			).getBlockSelectionStart(),
 		};
 	}, [] );
 	const showPageTemplatePicker = __experimentalUsePageTemplatePickerVisible();
@@ -103,6 +109,10 @@ function Layout() {
 		'has-fixed-toolbar': hasFixedToolbar,
 		'has-metaboxes': hasActiveMetaboxes,
 	} );
+	const openSidebarPanel = () =>
+		openGeneralSidebar(
+			hasBlockSelected ? 'edit-post/block' : 'edit-post/document'
+		);
 
 	return (
 		<>
@@ -120,6 +130,22 @@ function Layout() {
 					sidebar={
 						! publishSidebarOpened && (
 							<>
+								{ ! sidebarIsOpened && (
+									<div className="edit-post-layout__toogle-sidebar-panel">
+										<Button
+											isSecondary
+											className="edit-post-layout__toogle-sidebar-panel-button"
+											onClick={ openSidebarPanel }
+											aria-expanded={ false }
+										>
+											{ hasBlockSelected
+												? __( 'Open block settings' )
+												: __(
+														'Open document settings'
+												  ) }
+										</Button>
+									</div>
+								) }
 								<SettingsSidebar />
 								<Sidebar.Slot />
 							</>
@@ -165,10 +191,10 @@ function Layout() {
 								}
 							/>
 						) : (
-							<div className="edit-post-toggle-publish-panel">
+							<div className="edit-post-layout__toogle-publish-panel">
 								<Button
 									isSecondary
-									className="edit-post-toggle-publish-panel__button"
+									className="edit-post-layout__toogle-publish-panel-button"
 									onClick={ togglePublishSidebar }
 									aria-expanded={ false }
 								>

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -61,31 +61,33 @@
 	justify-content: center;
 }
 
-.edit-post-toggle-publish-panel {
+.edit-post-layout__toogle-publish-panel,
+.edit-post-layout__toogle-sidebar-panel {
 	background-color: $white;
 	padding: 10px 10px 10px 0;
+}
 
-	.edit-post-toggle-publish-panel__button {
-		width: auto;
-		height: auto;
-		display: block;
-		font-size: 14px;
-		font-weight: 600;
-		margin: 0 0 0 auto;
-		padding: 15px 23px 14px;
-		line-height: normal;
-		text-decoration: none;
-		outline: none;
-		background: #f1f1f1;
-		color: theme(secondary);
+.edit-post-layout__toogle-publish-panel-button,
+.edit-post-layout__toogle-sidebar-panel-button {
+	width: auto;
+	height: auto;
+	display: block;
+	font-size: 14px;
+	font-weight: 600;
+	margin: 0 0 0 auto;
+	padding: 15px 23px 14px;
+	line-height: normal;
+	text-decoration: none;
+	outline: none;
+	background: #f1f1f1;
+	color: theme(secondary);
 
-		&:focus {
-			position: fixed;
-			top: auto;
-			right: 10px;
-			bottom: 10px;
-			left: auto;
-		}
+	&:focus {
+		position: fixed;
+		top: auto;
+		right: 10px;
+		bottom: 10px;
+		left: auto;
 	}
 }
 


### PR DESCRIPTION
## Description

When the Document/Block sidebar is closed then there is this empty Sidebar region rendered which causes issues when navigating between landmarks. `ctrl` + `backtick` gets stuck when it reaches the empty sidebar.

I see 4 possible options:
1. The simplest approach would be to remove `display: none` applied which will result in rendering the blue line on the left side (for LTR languages).
2. Another approach would be to not render the region at all in such case  - it also fixes the issue.
3. I tried an alternative which is similar to what we do for the Publish panel. It renders a button which allows opening the sidebar. It fits perfectly fine with the Edit mode flow where user tabs out of the content. I would need some help from designers if we opt for this one – I tried really hard but I couldn't sort it out fully myself.
4. It's a mix of (2) and (3) but the button is rendered after the content but inside the region.

This issue was also discussed on the WordPress Slack in #accessibility channel (link requires registration):
https://wordpress.slack.com/archives/C02RP4X03/p1579012942211300

## Screenshots <!-- if applicable -->

### Before

![landmarks](https://user-images.githubusercontent.com/699132/72624454-4ae1e180-3947-11ea-9c8a-5c342b9774fc.gif)

### After

![landmarks](https://user-images.githubusercontent.com/699132/73646188-2db44f00-4679-11ea-9849-bc1e4757abfd.gif)

In the case of mobile viewports, this button is not supported. Instead of the sidebar landmark is not displayed if it doesn't have content inside.

![landmarks-mobile](https://user-images.githubusercontent.com/699132/73646473-cea30a00-4679-11ea-855b-c798c6adcb06.gif)


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
