### PR TITLE
RichText API: Limit "prefix" transformations to Paragraph blocks

### DIFF
--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -176,6 +176,7 @@ function ParagraphBlock( {
 						aria-label={ content ? __( 'Paragraph block' ) : __( 'Empty block; start writing or type forward slash to choose a block' ) }
 						placeholder={ placeholder || __( 'Start writing or type / to choose a block' ) }
 						__unstableEmbedURLOnPaste
+						__unstableAllowPrefixTransformations
 					/>
 				</TextColor>
 			</BackgroundColor>

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -445,6 +445,7 @@ class RichText extends Component {
 		const {
 			__unstableInputRule: inputRule,
 			__unstableMarkAutomaticChange: markAutomaticChange,
+			__unstableAllowPrefixTransformations: allowPrefixTransformations,
 			formatTypes,
 			setTimeout,
 			clearTimeout,
@@ -453,6 +454,10 @@ class RichText extends Component {
 		// Create an undo level when input stops for over a second.
 		clearTimeout( this.onInput.timeout );
 		this.onInput.timeout = setTimeout( this.onCreateUndoLevel, 1000 );
+
+		if ( ! allowPrefixTransformations ) {
+			return;
+		}
 
 		// Only run input rules when inserting text.
 		if ( inputType !== 'insertText' ) {


### PR DESCRIPTION
## Description

Partly fixes #19566. ~_For now, this PR is only a proof of concept._~

Limit "prefix" transformations to Paragraph blocks, as well as any block that passes the experimental flag `__unstableAllowPrefixTransformations` to `RichText`.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
