### PR TITLE
Sibling inserter click redirect: add e2e tests

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -386,8 +386,9 @@
 	cursor: text;
 
 	// Hide the inserter above the selected block.
-	&.is-inserter-hidden {
+	&.is-inserter-hidden .block-editor-inserter__toggle {
 		opacity: 0;
+		pointer-events: none;
 	}
 }
 

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/writing-flow.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/writing-flow.test.js.snap
@@ -232,6 +232,26 @@ exports[`Writing Flow should not delete surrounding space when deleting a word w
 <!-- /wp:paragraph -->"
 `;
 
+exports[`Writing Flow should not have a dead zone between blocks (lower) 1`] = `
+"<!-- wp:paragraph -->
+<p>1</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>23</p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`Writing Flow should not have a dead zone between blocks (upper) 1`] = `
+"<!-- wp:paragraph -->
+<p>13</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>2</p>
+<!-- /wp:paragraph -->"
+`;
+
 exports[`Writing Flow should not prematurely multi-select 1`] = `
 "<!-- wp:paragraph -->
 <p>1</p>

--- a/packages/e2e-tests/specs/editor/various/writing-flow.test.js
+++ b/packages/e2e-tests/specs/editor/various/writing-flow.test.js
@@ -457,4 +457,53 @@ describe( 'Writing Flow', () => {
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
+
+	it( 'should not have a dead zone between blocks (lower)', async () => {
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '1' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '2' );
+		await page.keyboard.press( 'ArrowUp' );
+
+		const paragraph = await page.$( '[data-type="core/paragraph"]' );
+		const paragraphRect = await paragraph.boundingBox();
+		const x = paragraphRect.x + ( 2 * paragraphRect.width / 3 );
+		const y = paragraphRect.y + paragraphRect.height + 10;
+
+		await page.mouse.move( x, y, { steps: 10 } );
+		await page.waitForSelector( '.block-editor-block-list__insertion-point-inserter' );
+
+		const inserter = await page.$( '.block-editor-block-list__insertion-point-inserter' );
+		const inserterRect = await inserter.boundingBox();
+		const lowerInserterY = inserterRect.y + ( 2 * inserterRect.height / 3 );
+
+		await page.mouse.click( x, lowerInserterY );
+		await page.keyboard.type( '3' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'should not have a dead zone between blocks (upper)', async () => {
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '1' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '2' );
+
+		const paragraph = await page.$( '[data-type="core/paragraph"]' );
+		const paragraphRect = await paragraph.boundingBox();
+		const x = paragraphRect.x + ( 2 * paragraphRect.width / 3 );
+		const y = paragraphRect.y + paragraphRect.height + 10;
+
+		await page.mouse.move( x, y, { steps: 10 } );
+		await page.waitForSelector( '.block-editor-block-list__insertion-point-inserter' );
+
+		const inserter = await page.$( '.block-editor-block-list__insertion-point-inserter' );
+		const inserterRect = await inserter.boundingBox();
+		const upperInserterY = inserterRect.y + ( inserterRect.height / 3 );
+
+		await page.mouse.click( x, upperInserterY );
+		await page.keyboard.type( '3' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
 } );

--- a/packages/e2e-tests/specs/editor/various/writing-flow.test.js
+++ b/packages/e2e-tests/specs/editor/various/writing-flow.test.js
@@ -465,12 +465,14 @@ describe( 'Writing Flow', () => {
 		await page.keyboard.type( '2' );
 		await page.keyboard.press( 'ArrowUp' );
 
+		// Find a point outside the paragraph between the blocks where it's
+		// expected that the sibling inserter would be placed.
 		const paragraph = await page.$( '[data-type="core/paragraph"]' );
 		const paragraphRect = await paragraph.boundingBox();
 		const x = paragraphRect.x + ( 2 * paragraphRect.width / 3 );
-		const y = paragraphRect.y + paragraphRect.height + 10;
+		const y = paragraphRect.y + paragraphRect.height + 1;
 
-		await page.mouse.move( x, y, { steps: 10 } );
+		await page.mouse.move( x, y );
 		await page.waitForSelector( '.block-editor-block-list__insertion-point-inserter' );
 
 		const inserter = await page.$( '.block-editor-block-list__insertion-point-inserter' );
@@ -489,12 +491,14 @@ describe( 'Writing Flow', () => {
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( '2' );
 
+		// Find a point outside the paragraph between the blocks where it's
+		// expected that the sibling inserter would be placed.
 		const paragraph = await page.$( '[data-type="core/paragraph"]' );
 		const paragraphRect = await paragraph.boundingBox();
 		const x = paragraphRect.x + ( 2 * paragraphRect.width / 3 );
-		const y = paragraphRect.y + paragraphRect.height + 10;
+		const y = paragraphRect.y + paragraphRect.height + 1;
 
-		await page.mouse.move( x, y, { steps: 10 } );
+		await page.mouse.move( x, y );
 		await page.waitForSelector( '.block-editor-block-list__insertion-point-inserter' );
 
 		const inserter = await page.$( '.block-editor-block-list__insertion-point-inserter' );


### PR DESCRIPTION
## Description

See #19719. This PR fixes the visible inserter tooltip from the inserter above a selected block. It also adds e2e tests for the whole feature.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
