### PR TITLE
Block Library: Button: Remove title attribute handling

### DIFF
--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { escape } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -86,7 +85,6 @@ function BorderPanel( { borderRadius = '', setAttributes } ) {
 function URLPicker( {
 	isSelected,
 	url,
-	title,
 	setAttributes,
 	opensInNewTab,
 	onToggleOpenInNewTab,
@@ -102,16 +100,12 @@ function URLPicker( {
 		>
 			<LinkControl
 				className="wp-block-navigation-link__inline-link-input"
-				value={ { url, title, opensInNewTab } }
+				value={ { url, opensInNewTab } }
 				onChange={ ( {
-					title: newTitle = '',
 					url: newURL = '',
 					opensInNewTab: newOpensInNewTab,
 				} ) => {
-					setAttributes( {
-						title: escape( newTitle ),
-						url: newURL,
-					} );
+					setAttributes( { url: newURL } );
 
 					if ( opensInNewTab !== newOpensInNewTab ) {
 						onToggleOpenInNewTab( newOpensInNewTab );
@@ -164,7 +158,6 @@ function ButtonEdit( {
 		placeholder,
 		rel,
 		text,
-		title,
 		url,
 	} = attributes;
 	const onSetLinkRel = useCallback(
@@ -199,7 +192,7 @@ function ButtonEdit( {
 	} = __experimentalUseGradient();
 
 	return (
-		<div className={ className } title={ title }>
+		<div className={ className }>
 			<RichText
 				placeholder={ placeholder || __( 'Add text…' ) }
 				value={ text }
@@ -225,7 +218,6 @@ function ButtonEdit( {
 				} }
 			/>
 			<URLPicker
-				title={ title }
 				url={ url }
 				setAttributes={ setAttributes }
 				isSelected={ isSelected }

--- a/packages/block-library/src/button/save.js
+++ b/packages/block-library/src/button/save.js
@@ -57,6 +57,10 @@ export default function save( { attributes } ) {
 		borderRadius: borderRadius ? borderRadius + 'px' : undefined,
 	};
 
+	// The use of a `title` attribute here is soft-deprecated, but still applied
+	// if it had already been assigned, for the sake of backward-compatibility.
+	// A title will no longer be assigned for new or updated button block links.
+
 	return (
 		<div>
 			<RichText.Content

--- a/packages/e2e-tests/specs/editor/blocks/__snapshots__/buttons.test.js.snap
+++ b/packages/e2e-tests/specs/editor/blocks/__snapshots__/buttons.test.js.snap
@@ -3,7 +3,7 @@
 exports[`Buttons can jump to the link editor using the keyboard shortcut 1`] = `
 "<!-- wp:buttons -->
 <div class=\\"wp-block-buttons\\"><!-- wp:button -->
-<div class=\\"wp-block-button\\"><a class=\\"wp-block-button__link\\" href=\\"https://www.wordpress.org/\\" title=\\"\\">WordPress</a></div>
+<div class=\\"wp-block-button\\"><a class=\\"wp-block-button__link\\" href=\\"https://www.wordpress.org/\\">WordPress</a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons -->"
 `;


### PR DESCRIPTION
Previously: #17352, https://github.com/WordPress/gutenberg/pull/19462#discussion_r366566720, https://github.com/WordPress/gutenberg/pull/19490#discussion_r366558464, #616

This pull request seeks to remove UI controls which assign a `title` attribute for a block. 

This is based on advisory resources and related core efforts which recommend that `title` attributes be avoided for links:

- https://html.spec.whatwg.org/multipage/dom.html#the-title-attribute
- https://silktide.com/blog/2013/i-thought-title-text-improved-accessibility-i-was-wrong
- https://developer.paciellogroup.com/blog/2012/01/html5-accessibility-chops-title-attribute-use-and-abuse/
- https://www.24a11y.com/2017/the-trials-and-tribulations-of-the-title-attribute/
- https://a11yproject.com/posts/title-attributes/
- https://core.trac.wordpress.org/ticket/24766

The proposed changes _do not_ currently remove the attribute from the block definition, nor do they prevent the attribute from being applied when rendering the generating the block's saved markup. This is to avoid invalidations of existing blocks. We could potentially choose to implement a deprecation to remove the attribute altogether, but the implementation as proposed seemed simplest in that it merely prevents the addition of new titles.

**Current Status:** I'm considering this as blocked by the issue described in https://github.com/WordPress/gutenberg/pull/19651#discussion_r367660325, where an empty title would introduce a confusing user experience for editing links.

**Testing Instructions:**

Verify that when selecting a link for a Button block, the resulting post markup does not contain a `title` attribute:

1. Navigate to Posts > Add New
2. Insert a Buttons block
3. Assign a link to the button (either to an external URL, or a search result for a post within the site)
4. Change to Code Editor using the editor's top-right "More Options" menu
5. Verify that the resulting markup does not contain a `title` attribute

**Follow-up Tasks:** If these changes are considered acceptable, a similar effort should be undertaken to remove the assignment of `title` attribute for the navigation link block:

https://github.com/WordPress/gutenberg/blob/c8a1eef8e9837494dbf98aeb69d7c183d80aaf68/packages/block-library/src/navigation/index.php#L187-L189

The "Image" block also includes `title` assignment, but my understanding is that it is not _quite_ as problematic for use in images (see also #11054).