### PR TITLE
Block Editor: Link Control: Initialize inputValue state from value

### DIFF
--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -29,8 +29,6 @@ import LinkControlSettingsDrawer from './settings-drawer';
 import LinkControlSearchItem from './search-item';
 import LinkControlSearchInput from './search-input';
 
-const MODE_EDIT = 'edit';
-
 function LinkControl( {
 	value,
 	settings,
@@ -38,7 +36,7 @@ function LinkControl( {
 	showInitialSuggestions,
 } ) {
 	const instanceId = useInstanceId( LinkControl );
-	const [ inputValue, setInputValue ] = useState( '' );
+	const [ inputValue, setInputValue ] = useState( ( value && value.url ) || '' );
 	const [ isEditingLink, setIsEditingLink ] = useState( ! value || ! value.url );
 	const { fetchSearchSuggestions } = useSelect( ( select ) => {
 		const { getSettings } = select( 'core/block-editor' );
@@ -47,8 +45,6 @@ function LinkControl( {
 		};
 	}, [] );
 
-	// Handlers
-
 	/**
 	 * onChange LinkControlSearchInput event handler
 	 *
@@ -56,24 +52,6 @@ function LinkControl( {
 	 */
 	const onInputChange = ( val = '' ) => {
 		setInputValue( val );
-	};
-
-	// Utils
-
-	/**
-	 * Handler function which switches the mode of the component,
-	 * between `edit` and `show` mode.
-	 *
-	 * @param {string} mode Component mode: `show` or `edit`.
-	 */
-	const setMode = ( mode = 'show' ) => () => {
-		setIsEditingLink( MODE_EDIT === mode );
-
-		// Populate input searcher whether
-		// the current link has a title.
-		if ( value && value.title && MODE_EDIT === mode ) {
-			setInputValue( value.title );
-		}
 	};
 
 	const resetInput = () => {
@@ -202,7 +180,11 @@ function LinkControl( {
 							<span className="block-editor-link-control__search-item-info">{ filterURLForDisplay( safeDecodeURI( value.url ) ) || '' }</span>
 						</span>
 
-						<Button isSecondary onClick={ setMode( MODE_EDIT ) } className="block-editor-link-control__search-item-action block-editor-link-control__search-item-action--edit">
+						<Button
+							isSecondary
+							onClick={ () => setIsEditingLink( true ) }
+							className="block-editor-link-control__search-item-action block-editor-link-control__search-item-action--edit"
+						>
 							{ __( 'Edit' ) }
 						</Button>
 					</div>

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -450,7 +450,7 @@ describe( 'Selecting links', () => {
 
 		// We should be back to showing the search input
 		expect( searchInput ).not.toBeNull();
-		expect( searchInput.value ).toBe( selectedLink.title ); // prepopulated with previous link's title
+		expect( searchInput.value ).toBe( selectedLink.url ); // prepopulated with previous link's URL
 		expect( currentLinkUI ).toBeNull();
 	} );
 


### PR DESCRIPTION
Previously: https://github.com/WordPress/gutenberg/pull/18225#discussion_r368122858, https://github.com/WordPress/gutenberg/pull/19396/files#r368127421

This pull request seeks to change the behavior of the LinkControl component to initialize its `inputValue` state as being derived from the `value` prop.

This...

- ...Avoids the need for a `setMode` utility function altogether
- ...Ensures better syncing of the relationship between `inputValue` state and the `value` prop
- ...Resolves inconsistency where not all mode changing would occur through `setMode` [[1]](https://github.com/WordPress/gutenberg/blob/cf9742c0ce56c2b10f282b2a0d35a852ada75aa2/packages/block-editor/src/components/link-control/index.js#L168) [[2]](https://github.com/WordPress/gutenberg/blob/cf9742c0ce56c2b10f282b2a0d35a852ada75aa2/packages/block-editor/src/components/link-control/index.js#L217)

There is also one change in behavior, inherited from #19462:

- The edit field is prepopulated with the link _URL_, rather than with the link _title_ ([see discussion](https://github.com/WordPress/gutenberg/pull/19462/files#r363731432)).

**Testing Instructions:**

Ensure unit tests pass:

```
npm run test-unit
```

Verify there are no regressions in the behavior of link control.

Notably:

- Adding a new link should show an empty link field
- Editing an existing link should prepopulate the link field with its URL
- Editing _and then re-editing_ while the link dialog is still shown should still reflect the updated value