### PR TITLE
Block Editor: Link Control: Use URL as link when title empty

### DIFF
--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -10,7 +10,6 @@ import { noop, startsWith } from 'lodash';
 import { Button, ExternalLink, VisuallyHidden } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { useCallback, useState, Fragment } from '@wordpress/element';
-
 import {
 	safeDecodeURI,
 	filterURLForDisplay,
@@ -18,7 +17,6 @@ import {
 	prependHTTP,
 	getProtocol,
 } from '@wordpress/url';
-
 import { useInstanceId } from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
 
@@ -46,6 +44,7 @@ function LinkControl( {
 			fetchSearchSuggestions: getSettings().__experimentalFetchLinkSuggestions,
 		};
 	}, [] );
+	const displayURL = ( value && filterURLForDisplay( safeDecodeURI( value.url ) ) ) || '';
 
 	// Handlers
 
@@ -197,9 +196,13 @@ function LinkControl( {
 								className="block-editor-link-control__search-item-title"
 								href={ value.url }
 							>
-								{ value.title }
+								{ ( value && value.title ) || displayURL }
 							</ExternalLink>
-							<span className="block-editor-link-control__search-item-info">{ filterURLForDisplay( safeDecodeURI( value.url ) ) || '' }</span>
+							{ value && value.title && (
+								<span className="block-editor-link-control__search-item-info">
+									{ displayURL }
+								</span>
+							) }
 						</span>
 
 						<Button isSecondary onClick={ setMode( MODE_EDIT ) } className="block-editor-link-control__search-item-action block-editor-link-control__search-item-action--edit">


### PR DESCRIPTION
Unblocks #19735
Unblocks #19651 (https://github.com/WordPress/gutenberg/pull/19651#discussion_r367660325)
Cherry-picks from #19462 ([see remarks](https://github.com/WordPress/gutenberg/pull/19462/files#r363731260))

This pull request seeks to improve the display of `<LinkControl />` when a title is not set for the value by using the URL as the rendered external link when the title is unset.

Before|After
---|---
![Before](https://user-images.githubusercontent.com/1779930/72650009-212bb900-394d-11ea-8e95-f8cd37c749b0.png)|![After](https://user-images.githubusercontent.com/1779930/72649978-0f4a1600-394d-11ea-891a-1dd408ce3b4f.png)

**Testing Instructions:**

In the Buttons and/or Navigation Link blocks, verify that when editing a link, the rendered result shows the title, if assigned, or otherwise the display-formatted URL:

1. Navigate to Posts > Add New
2. Insert a Navigation block
3. Click "Create empty" to start blank
4. Add a Navigation Link with URL
5. Verify that the link or title is shown as the external link
   - Note: Even when using a manually-entered URL, the raw URL will be used as a title. This is not an ideal implementation and should be changed in the future.
6. In "SEO Settings" in the sidebar, clear the "Title attribute" value
7. Note that the external link shown now reflects the URL