### PR TITLE
Block Editor: Add local change detection.

### DIFF
--- a/docs/designers-developers/developers/data/data-core-block-editor.md
+++ b/docs/designers-developers/developers/data/data-core-block-editor.md
@@ -1120,11 +1120,17 @@ _Returns_
 Returns an action object signalling that a blocks should be replaced with
 one or more replacement blocks.
 
+You may set `isLocalChange` to true to scope change detection to a section of
+the block tree. I.e. so the edit doesn't dirty the entire block tree. This
+is used for edits made to blocks that are saved somewhere other than the main
+post by their root.
+
 _Parameters_
 
 -   _clientIds_ `(string|Array<string>)`: Block client ID(s) to replace.
 -   _blocks_ `(Object|Array<Object>)`: Replacement block(s).
 -   _indexToSelect_ `number`: Index of replacement block to select.
+-   _isLocalChange_ `[string]`: Whether to scope change detection.
 
 <a name="replaceInnerBlocks" href="#replaceInnerBlocks">#</a> **replaceInnerBlocks**
 

--- a/docs/designers-developers/developers/data/data-core-block-editor.md
+++ b/docs/designers-developers/developers/data/data-core-block-editor.md
@@ -828,13 +828,14 @@ _Returns_
 
 <a name="isLastBlockChangePersistent" href="#isLastBlockChangePersistent">#</a> **isLastBlockChangePersistent**
 
-Returns true if the most recent block change is be considered persistent, or
-false otherwise. A persistent change is one committed by BlockEditorProvider
-via its `onChange` callback, in addition to `onInput`.
+Returns true if the most recent block change is to be considered persistent with
+regards to the provided root client ID, or false otherwise. A persistent
+change is one committed by `BlockEditorProvider` via its `onChange` callback, in addition to `onInput`.
 
 _Parameters_
 
 -   _state_ `Object`: Block editor state.
+-   _rootClientId_ `[string]`: Block root client ID.
 
 _Returns_
 
@@ -1364,10 +1365,16 @@ _Returns_
 Returns an action object used in signalling that the block attributes with
 the specified client ID has been updated.
 
+You may specify a root client ID to scope change detection to a section of
+the block tree. I.e. so the edit doesn't dirty the entire block tree. This
+is used for edits made to blocks that are saved somewhere other than the main
+post by their root.
+
 _Parameters_
 
 -   _clientId_ `string`: Block client ID.
 -   _attributes_ `Object`: Block attributes to be merged.
+-   _rootClientId_ `[string]`: Block root client ID.
 
 _Returns_
 

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -23,6 +23,7 @@ import {
 	isReusableBlock,
 	isUnmodifiedDefaultBlock,
 	getUnregisteredTypeHandlerName,
+	DEFAULT_BLOCK_TYPE_SETTINGS,
 } from '@wordpress/blocks';
 import { withFilters } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
@@ -427,7 +428,23 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps, { select } ) => {
 	return {
 		setAttributes( newAttributes ) {
 			const { clientId } = ownProps;
-			updateBlockAttributes( clientId, newAttributes );
+			const { getBlockRootClientId, getBlockName } = select(
+				'core/block-editor'
+			);
+			let isLocalChange = false;
+			const rootClientId = getBlockRootClientId( clientId );
+			if ( rootClientId ) {
+				// The default save outputs null.
+				// We can have more nuanced heuristics in the future.
+				isLocalChange =
+					select( 'core/blocks' ).getBlockType( getBlockName( rootClientId ) )
+						.save === DEFAULT_BLOCK_TYPE_SETTINGS.save;
+			}
+			updateBlockAttributes(
+				clientId,
+				newAttributes,
+				isLocalChange ? rootClientId : undefined
+			);
 		},
 		onInsertBlocks( blocks, index ) {
 			const { rootClientId } = ownProps;

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -437,8 +437,9 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps, { select } ) => {
 				// The default save outputs null.
 				// We can have more nuanced heuristics in the future.
 				isLocalChange =
-					select( 'core/blocks' ).getBlockType( getBlockName( rootClientId ) )
-						.save === DEFAULT_BLOCK_TYPE_SETTINGS.save;
+					select( 'core/blocks' ).getBlockType(
+						getBlockName( rootClientId )
+					).save === DEFAULT_BLOCK_TYPE_SETTINGS.save;
 			}
 			updateBlockAttributes(
 				clientId,
@@ -492,7 +493,22 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps, { select } ) => {
 			) {
 				__unstableMarkLastChangeAsPersistent();
 			}
-			replaceBlocks( [ ownProps.clientId ], blocks, indexToSelect );
+
+			const { clientId } = ownProps;
+			const { getBlockRootClientId, getBlockName } = select(
+				'core/block-editor'
+			);
+			let isLocalChange = false;
+			const rootClientId = getBlockRootClientId( clientId );
+			if ( rootClientId ) {
+				// The default save outputs null.
+				// We can have more nuanced heuristics in the future.
+				isLocalChange =
+					select( 'core/blocks' ).getBlockType(
+						getBlockName( rootClientId )
+					).save === DEFAULT_BLOCK_TYPE_SETTINGS.save;
+			}
+			replaceBlocks( [ clientId ], blocks, indexToSelect, isLocalChange );
 		},
 		toggleSelection( selectionEnabled ) {
 			toggleSelection( selectionEnabled );

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -432,14 +432,17 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps, { select } ) => {
 				'core/block-editor'
 			);
 			let isLocalChange = false;
-			const rootClientId = getBlockRootClientId( clientId );
-			if ( rootClientId ) {
+			let rootClientId = clientId;
+			while ( ( rootClientId = getBlockRootClientId( rootClientId ) ) ) {
 				// The default save outputs null.
 				// We can have more nuanced heuristics in the future.
 				isLocalChange =
 					select( 'core/blocks' ).getBlockType(
 						getBlockName( rootClientId )
 					).save === DEFAULT_BLOCK_TYPE_SETTINGS.save;
+				if ( isLocalChange ) {
+					break;
+				}
 			}
 			updateBlockAttributes(
 				clientId,
@@ -499,14 +502,17 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps, { select } ) => {
 				'core/block-editor'
 			);
 			let isLocalChange = false;
-			const rootClientId = getBlockRootClientId( clientId );
-			if ( rootClientId ) {
+			let rootClientId = clientId;
+			while ( ( rootClientId = getBlockRootClientId( rootClientId ) ) ) {
 				// The default save outputs null.
 				// We can have more nuanced heuristics in the future.
 				isLocalChange =
 					select( 'core/blocks' ).getBlockType(
 						getBlockName( rootClientId )
 					).save === DEFAULT_BLOCK_TYPE_SETTINGS.save;
+				if ( isLocalChange ) {
+					break;
+				}
 			}
 			replaceBlocks( [ clientId ], blocks, indexToSelect, isLocalChange );
 		},

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -195,7 +195,7 @@ InnerBlocks = compose( [
 				! hasSelectedInnerBlock( clientId, true ),
 			parentLock: getTemplateLock( rootClientId ),
 			enableClickThrough: isNavigationMode() || isSmallScreen,
-			isLastBlockChangePersistent: isLastBlockChangePersistent(),
+			isLastBlockChangePersistent: isLastBlockChangePersistent( clientId ),
 		};
 	} ),
 	withDispatch( ( dispatch, ownProps ) => {

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -289,14 +289,25 @@ function getBlocksWithDefaultStylesApplied( blocks, blockEditorSettings ) {
  * Returns an action object signalling that a blocks should be replaced with
  * one or more replacement blocks.
  *
- * @param {(string|string[])} clientIds     Block client ID(s) to replace.
- * @param {(Object|Object[])} blocks        Replacement block(s).
- * @param {number}            indexToSelect Index of replacement block to
- *                                          select.
+ * You may set `isLocalChange` to true to scope change detection to a section of
+ * the block tree. I.e. so the edit doesn't dirty the entire block tree. This
+ * is used for edits made to blocks that are saved somewhere other than the main
+ * post by their root.
+ *
+ * @param {(string|string[])} clientIds       Block client ID(s) to replace.
+ * @param {(Object|Object[])} blocks          Replacement block(s).
+ * @param {number}            indexToSelect   Index of replacement block to
+ *                                            select.
+ * @param {string}            [isLocalChange] Whether to scope change detection.
  *
  * @yield {Object} Action object.
  */
-export function* replaceBlocks( clientIds, blocks, indexToSelect ) {
+export function* replaceBlocks(
+	clientIds,
+	blocks,
+	indexToSelect,
+	isLocalChange
+) {
 	clientIds = castArray( clientIds );
 	blocks = getBlocksWithDefaultStylesApplied(
 		castArray( blocks ),
@@ -326,6 +337,7 @@ export function* replaceBlocks( clientIds, blocks, indexToSelect ) {
 		blocks,
 		time: Date.now(),
 		indexToSelect,
+		rootClientId: isLocalChange ? rootClientId : undefined,
 	};
 	yield* ensureDefaultBlock();
 }

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -100,16 +100,23 @@ export function receiveBlocks( blocks ) {
  * Returns an action object used in signalling that the block attributes with
  * the specified client ID has been updated.
  *
- * @param {string} clientId   Block client ID.
- * @param {Object} attributes Block attributes to be merged.
+ * You may specify a root client ID to scope change detection to a section of
+ * the block tree. I.e. so the edit doesn't dirty the entire block tree. This
+ * is used for edits made to blocks that are saved somewhere other than the main
+ * post by their root.
+ *
+ * @param {string} clientId       Block client ID.
+ * @param {Object} attributes     Block attributes to be merged.
+ * @param {string} [rootClientId] Block root client ID.
  *
  * @return {Object} Action object.
  */
-export function updateBlockAttributes( clientId, attributes ) {
+export function updateBlockAttributes( clientId, attributes, rootClientId ) {
 	return {
 		type: 'UPDATE_BLOCK_ATTRIBUTES',
 		clientId,
 		attributes,
+		rootClientId,
 	};
 }
 

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -16,7 +16,7 @@ import {
 	identity,
 	difference,
 	omitBy,
-	filter,
+	pickBy,
 } from 'lodash';
 
 /**
@@ -409,6 +409,12 @@ function withPersistentBlockChange( reducer ) {
 				? ! markNextChangeAsNotPersistent
 				: ! isUpdatingSameBlockAttribute( action, lastAction ),
 		};
+		if (
+			action.type === 'UPDATE_BLOCK_ATTRIBUTES' &&
+			action.rootClientId
+		) {
+			nextState.persistentChangeRootClientId = action.rootClientId;
+		}
 
 		// In comparing against the previous action, consider only those which
 		// would have qualified as one which would have been ignored or not
@@ -531,7 +537,7 @@ const withBlockReset = ( reducer ) => ( state, action ) => {
 			cache: {
 				...state.cache,
 				...mapValues(
-					filter(
+					pickBy(
 						flattenBlocks( action.blocks ),
 						( block ) =>
 							! isShallowEqual( block, {

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -375,8 +375,7 @@ function withPersistentBlockChange( reducer ) {
 
 	return ( state, action ) => {
 		let nextState = reducer( state, action );
-		nextState.persistentChangeRootClientId =
-			action.type === 'UPDATE_BLOCK_ATTRIBUTES' && action.rootClientId;
+		nextState.persistentChangeRootClientId = action.rootClientId;
 
 		const isExplicitPersistentChange =
 			action.type === 'MARK_LAST_CHANGE_AS_PERSISTENT' ||
@@ -409,10 +408,7 @@ function withPersistentBlockChange( reducer ) {
 				? ! markNextChangeAsNotPersistent
 				: ! isUpdatingSameBlockAttribute( action, lastAction ),
 		};
-		if (
-			action.type === 'UPDATE_BLOCK_ATTRIBUTES' &&
-			action.rootClientId
-		) {
+		if ( action.rootClientId ) {
 			nextState.persistentChangeRootClientId = action.rootClientId;
 		}
 

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1502,16 +1502,21 @@ export function getSettings( state ) {
 }
 
 /**
- * Returns true if the most recent block change is be considered persistent, or
- * false otherwise. A persistent change is one committed by BlockEditorProvider
- * via its `onChange` callback, in addition to `onInput`.
+ * Returns true if the most recent block change is to be considered persistent with
+ * regards to the provided root client ID, or false otherwise. A persistent
+ * change is one committed by `BlockEditorProvider` via its `onChange` callback, in addition to `onInput`.
  *
- * @param {Object} state Block editor state.
+ * @param {Object} state          Block editor state.
+ * @param {string} [rootClientId] Block root client ID.
  *
  * @return {boolean} Whether the most recent block change was persistent.
  */
-export function isLastBlockChangePersistent( state ) {
-	return state.blocks.isPersistentChange;
+export function isLastBlockChangePersistent( state, rootClientId ) {
+	return (
+		state.blocks.isPersistentChange &&
+		( ! state.blocks.persistentChangeRootClientId ||
+			state.blocks.persistentChangeRootClientId === rootClientId )
+	);
 }
 
 /**

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -205,6 +205,14 @@ _Returns_
 
 -   `Object`: Block object.
 
+<a name="DEFAULT_BLOCK_TYPE_SETTINGS" href="#DEFAULT_BLOCK_TYPE_SETTINGS">#</a> **DEFAULT_BLOCK_TYPE_SETTINGS**
+
+Default values to assign for omitted optional block type settings.
+
+_Type_
+
+-   `Object` 
+
 <a name="doBlocksMatchTemplate" href="#doBlocksMatchTemplate">#</a> **doBlocksMatchTemplate**
 
 Checks whether a list of blocks matches a template by comparing the block names.

--- a/packages/blocks/src/api/index.js
+++ b/packages/blocks/src/api/index.js
@@ -28,6 +28,7 @@ export {
 export { isValidBlockContent } from './validation';
 export { getCategories, setCategories, updateCategory } from './categories';
 export {
+	DEFAULT_BLOCK_TYPE_SETTINGS,
 	registerBlockType,
 	registerBlockCollection,
 	unregisterBlockType,


### PR DESCRIPTION
## Description

This PR enhances change detection mechanisms so that an edit's dirtiness can scope to a specific block and its children, solving issue number 2 found by @jorgefilipecosta in https://github.com/WordPress/gutenberg/pull/19521#pullrequestreview-344631415. The approach taken is to have attribute updates optionally provide a root client ID and have the persistent change selector optionally take a root client ID. This way, changing a block's inner blocks that don't save to the top-level won't dirty the top-level.

This PR also solves issue number 1 found by @jorgefilipecosta in https://github.com/WordPress/gutenberg/pull/19521#pullrequestreview-344631415 by reusing block editor store caches for the blocks that haven't changed by referential equality after a reset. This way, undoing or redoing won't dirty nested blocks that save to other entities unless they have changed.

## How to test this?

Follow the steps for the two issues from https://github.com/WordPress/gutenberg/pull/19521#pullrequestreview-344631415.

## Types of Changes

*New Feature*: Change detection/dirtiness can now scope to specific blocks. E.g., template parts.

## Checklist:

- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
