### PR TITLE
Project Management: Run pull request automation on closed

### DIFF
--- a/.github/workflows/pull-request-automation.yml
+++ b/.github/workflows/pull-request-automation.yml
@@ -1,4 +1,6 @@
-on: pull_request
+on:
+  pull_request:
+    types: [opened, closed]
 name: Pull request automation
 
 jobs:


### PR DESCRIPTION
Previously: #17080

This pull request seeks to resolve an issue where the project management automation task responsible for assigning merged pull requests to milestone has not been run.

The underlying issue is that the default behavior of the the `pull_request` event is such that it will not be triggered for close events, unless opted into.

>Note: By default, a workflow only runs when a pull_request's activity type is opened, synchronize, or reopened. To trigger workflows for more activity types, use the types keyword.

https://help.github.com/en/actions/automating-your-workflow-with-github-actions/events-that-trigger-workflows#pull-request-event-pull_request

See also: https://github.community/t5/GitHub-Actions/pull-request-action-does-not-run-on-merge/td-p/29284

The changes as proposed will include the `types` corresponding to the distinct actions currently in use by the `project-management-automation` script:

https://github.com/WordPress/gutenberg/blob/cf9742c0ce56c2b10f282b2a0d35a852ada75aa2/packages/project-management-automation/lib/index.js#L15-L31

**Testing Instructions:**

I'm not sure this is something we'll be able to test without merging. However, the automation associated with the "opened" action should be expected to run attached to this pull request.