### PR TITLE
Update main project README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Build Status](https://img.shields.io/travis/com/WordPress/gutenberg/master.svg)](https://travis-ci.com/WordPress/gutenberg)
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg)](https://lerna.js.org)
 
-![Screenshot of the Gutenberg Editor, editing a post in WordPress](https://cldup.com/R84R5fNgrI.png)
+![Screenshot of the Gutenberg Editor, editing a post in WordPress](https://user-images.githubusercontent.com/1204802/73433964-2540d900-4346-11ea-94f3-5df2e9d876bc.png)
 
 Welcome to the development hub for the WordPress Gutenberg project!
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Welcome to the development hub for the WordPress Gutenberg project!
 
-"Gutenberg" is a codename for a whole new paradigm in WordPress site building and publishing, one that will revolutionize the entire publishing experience as much as Gutenberg did the printed word. Right now, the project is in the first phase of a four-phase process that will touch every piece of WordPress -- Editing, Customization, Collaboration, and Multilingual -- and is focused on a new editing experience, the block editor.
+"Gutenberg" is a codename for a whole new paradigm in WordPress site building and publishing, that aims to revolutionize the entire publishing experience as much as Gutenberg did the printed word. Right now, the project is in the first phase of a four-phase process that will touch every piece of WordPress -- Editing, Customization, Collaboration, and Multilingual -- and is focused on a new editing experience, the block editor.
 
 The block editor introduces a modular approach to pages and posts: each piece of content in the editor, from a paragraph to an image gallery to a headline, is its own block. And just like physical blocks, WordPress blocks can added, arranged, and rearranged, allowing WordPress users to create media-rich pages in a visually intuitive way -- and without work-arounds like shortcodes or custom HTML.
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Get hands on: check out the [Block Editor live demo](https://wordpress.org/guten
 
 Extending and customizing is at the heart of the WordPress platform, this is no different for the Gutenberg project. The editor and future products can be extended by third-party developers using plugins.
 
-See the [Developer Documentation](https://developer.wordpress.org/block-editor/developers/) for extensive tutorials, documentation, and API references on how to extend the editor.
+The <a href="/docs/contributors/getting-started.md">Getting Started guide</a> will help you run Gutenberg locally to tinker with. See the [Developer Documentation](https://developer.wordpress.org/block-editor/developers/) for extensive tutorials, documentation, and API references on how to extend the editor.
 
 ### Contribute to Gutenberg
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Gutenberg development precedes what is shipped in a WordPress releases, usually 
 
 ## Getting started
 
-Get hands on with the block editor, check out the [Block Editor live demo](https://wordpress.org/gutenberg/) that allows you to play with a test instance of the editor.
+Get hands on, check out the [Block Editor live demo](https://wordpress.org/gutenberg/) to play with a test instance of the editor.
 
 ### Using Gutenberg
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The block editor first became available in December 2018, and we're still hard a
 
 ## Getting Started
 
-Get hands on, check out the [Block Editor live demo](https://wordpress.org/gutenberg/) to play with a test instance of the editor.
+Get hands on: check out the [Block Editor live demo](https://wordpress.org/gutenberg/) to play with a test instance of the editor.
 
 ### Using Gutenberg
 
@@ -28,7 +28,7 @@ Get hands on, check out the [Block Editor live demo](https://wordpress.org/guten
 
 Extending and customizing is at the heart of the WordPress platform, this is no different for the Gutenberg project. The editor and future products can be extended by third-party developers using plugins.
 
-See the [Developer Documentation](https://developer.wordpress.org/block-editor/developers/) for extensive tutorials, documentation, and API reference on how to extend the editor.
+See the [Developer Documentation](https://developer.wordpress.org/block-editor/developers/) for extensive tutorials, documentation, and API references on how to extend the editor.
 
 ### Contribute to Gutenberg
 
@@ -40,7 +40,7 @@ As with all WordPress projects, we want to ensure a welcoming environment for ev
 
 ## Get Involved
 
-You can join us in the `#core-editor` channel in Slack, see [WordPress Slack page](https://make.wordpress.org/chat/) for signup information, it is free to join.
+You can join us in the `#core-editor` channel in Slack, see the [WordPress Slack page](https://make.wordpress.org/chat/) for signup information; it is free to join.
 
 **Weekly meetings** The Editor Team meets weekly on Wednesdays at 14:00 UTC in Slack. If you can not join the meeting, agenda and notes are posted to the [Make WordPress Blog](https://make.wordpress.org/core/).
 

--- a/README.md
+++ b/README.md
@@ -43,3 +43,5 @@ You can join us in the `#core-editor` channel in Slack, see [WordPress Slack pag
 ## License
 
 WordPress is free software, and is released under the terms of the GNU General Public License version 2 or (at your option) any later version. See [LICENSE.md](LICENSE.md) for complete license.
+
+<br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Welcome to the development hub for the WordPress Gutenberg Project!
 
 Gutenberg development precedes what is shipped in a WordPress releases, usually by numerous weeks. The latest development version of Gutenberg is available as a plugin for testing and trying out the latest features.
 
-## Getting started
+## Getting Started
 
 Get hands on, check out the [Block Editor live demo](https://wordpress.org/gutenberg/) to play with a test instance of the editor.
 
@@ -34,7 +34,7 @@ See the [Contributors Handbook](https://developer.wordpress.org/block-editor/con
 
 As with all WordPress projects, we want to ensure a welcoming environment for everyone. With that in mind, all contributors are expected to follow our [Code of Conduct](https://github.com/WordPress/gutenberg/blob/master/CODE_OF_CONDUCT.md).
 
-## Get involved
+## Get Involved
 
 You can join us in the `#core-editor` channel in Slack, see [WordPress Slack page](https://make.wordpress.org/chat/) for signup information, it is free to join.
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,13 @@
 
 ![Screenshot of the Gutenberg Editor, editing a post in WordPress](https://cldup.com/R84R5fNgrI.png)
 
-Welcome to the development hub for the WordPress Gutenberg Project!
+Welcome to the development hub for the WordPress Gutenberg project!
 
-Gutenberg development precedes what is shipped in a WordPress releases, usually by numerous weeks. The latest development version of Gutenberg is available as a plugin for testing and trying out the latest features.
+"Gutenberg" is a codename for a whole new paradigm in WordPress site building and publishing, one that will revolutionize the entire publishing experience as much as Gutenberg did the printed word. Right now, the project is in the first phase of a four-phase process that will touch every piece of WordPress -- Editing, Customization, Collaboration, and Multilingual -- and is focused on a new editing experience, the block editor.
+
+The block editor introduces a modular approach to pages and posts: each piece of content in the editor, from a paragraph to an image gallery to a headline, is its own block. And just like physical blocks, WordPress blocks can added, arranged, and rearranged, allowing WordPress users to create media-rich pages in a visually intuitive way -- and without work-arounds like shortcodes or custom HTML.
+
+The block editor first became available in December 2018, and we're still hard at work refining the experience, creating more and better blocks, and laying the groundwork for the next three phases of work. The Gutenberg plugin gives you the latest version of the block editor so you can join us in testing bleeding-edge features, start playing with blocks, and maybe get inspired to build your own.
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -4,76 +4,42 @@
 
 ![Screenshot of the Gutenberg Editor, editing a post in WordPress](https://cldup.com/R84R5fNgrI.png)
 
-This repo is the development hub for the <a href="https://make.wordpress.org/core/2017/01/04/focus-tech-and-design-leads/">editor focus in WordPress Core</a>. `Gutenberg` is the project name.
+Welcome to the development hub for the WordPress Gutenberg Project!
+
+Gutenberg development precedes what is shipped in a WordPress releases, usually by numerous weeks. The latest development version of Gutenberg is available as a plugin for testing and trying out the latest features.
 
 ## Getting started
-- **Download:** If you want to use the latest release with your WordPress site, <a href="https://wordpress.org/plugins/gutenberg/">download the latest release from the WordPress.org plugins repository</a>.
-- **Discuss:** Conversations and discussions take place in <a href="https://wordpress.slack.com/messages/C02QB2JS7">`#core-editor` channel on the Making WordPress Slack</a>.
-- **Contribute:** Development of Gutenberg happens in this GitHub repo. Get started by <a href="https://github.com/WordPress/gutenberg/blob/master/CONTRIBUTING.md">reading the contributing guidelines</a>.
-- **Develop:** Just want to run Gutenberg locally to tinker with it? See <a href="https://github.com/WordPress/gutenberg/blob/master/docs/contributors/getting-started.md">Getting Started</a>.
-- **Learn:** <a href="https://wordpress.org/gutenberg/">Discover more about the project on WordPress.org</a>.
 
-**Gutenberg is more than an editor.** While the project is currently focused on building the new editor for WordPress, it doesn't end there. This lays the groundwork for a new model for WordPress Core that will ultimately impact the entire publishing experience of the platform.
+Get hands on with the block editor, check out the [Block Editor live demo](https://wordpress.org/gutenberg/) that allows you to play with a test instance of the editor.
 
-## Editing focus
+### Using Gutenberg
 
-> *The editor will create a new page- and post-building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.*
->
-> — Matt Mullenweg
+- **Download:** To use the latest release of the Gutenberg plugin on your WordPress site: install from the plugins page in wp-admin, or [download from the WordPress.org plugins repository](https://wordpress.org/plugins/gutenberg/).
 
-One thing that sets WordPress apart is that it allows you to create a post layout that's as rich as you can imagine—but only if you can build your own custom theme with HTML and CSS. By thinking of the editor as a tool that allows you to write rich posts **and** create beautiful layouts, we can transform WordPress into something users _love_, as opposed to something they choose because it happens to be what everyone else uses.
+- **User Documentation:** See the [WordPress Editor documentation](https://wordpress.org/support/article/wordpress-editor/) for detailed docs on using the editor as an author creating posts and pages.
 
-**Gutenberg is a new way forward.** It looks at the editor as more than a content field, revisiting a layout that has been largely unchanged for almost a decade. This project allows The WordPress Project to holistically design a modern editing experience and build a foundation for things to come.
+- **User Support:** If you have run into an issue, you should check the [Support Forums first](https://wordpress.org/support/forums/). The forums are a great place to get help. If you have a bug to report, please [submit it to the Gutenberg repository](https://github.com/wordpress/gutenberg/issues). Please search prior to creating a new bug to confirm its not a duplicate.
 
-Here's why we're looking at the whole editing screen, as opposed to just the content field:
+### Developing for Gutenberg
 
-1. **The block unifies multiple interfaces.** If Gutenberg added blocks on top of the existing interface, it would _add_ complexity, as opposed to removing it.
-2. **Simplified (and enhanced) editing.** By revisiting the interface, Gutenberg can modernize the writing, editing, and publishing experience, with usability and simplicity in mind, benefitting both new and casual users.
-3. **Better interface usability.** When singular block interface takes center stage, it demonstrates a clear path forward for developers to create premium blocks, superior to both shortcodes and widgets.
-4. **A fresh look at content creation.** Considering the whole interface lays a solid foundation for the next focus: full site customization.
-5. **Modern tooling.** Looking at the full editor screen also gives WordPress the opportunity to drastically modernize the foundation, and take steps towards a more fluid and JavaScript-powered future that fully leverages the WordPress REST API.
+Extending and customizing is at the heart of the WordPress platform, this is no different for the Gutenberg project. The editor and future products can be extended by third-party developers using plugins.
 
+See the [Developer Documentation](https://developer.wordpress.org/block-editor/developers/) for extensive tutorials, documentation, and API reference on how to extend the editor.
 
-## Blocks
+### Contribute to Gutenberg
 
-Blocks are the unifying evolution of what is now covered, in different ways, by shortcodes, embeds, widgets, post formats, custom post types, theme options, meta-boxes, and other formatting elements. They embrace the breadth of functionality WordPress is capable of, with the clarity of a consistent user experience.
+Gutenberg is an open-source project and welcomes all contributors from code to design, from documentation to triage. The project is built by many [contributors and volunteers](https://github.com/WordPress/gutenberg/blob/master/CONTRIBUTORS.md) and we'd love your help building it.
 
-Imagine a custom `employee` block that a client can drag onto an `About` page to automatically display a picture, name, and bio of all the employees. Imagine a whole universe of plugins just as flexible, all extending WordPress in the same way. Imagine simplified menus and widgets. Users who can instantly understand and use WordPress—and 90% of plugins. This will allow you to easily compose beautiful posts like <a href="http://moc.co/sandbox/example-post/">this example</a>.
+See the [Contributors Handbook](https://developer.wordpress.org/block-editor/contributors/) for all the details on how you can contribute. See [CONTRIBUTING.md](https://github.com/WordPress/gutenberg/blob/master/CONTRIBUTING.md) for the contributing guidelines.
 
-Check out the <a href="https://developer.wordpress.org/block-editor/contributors/faq/">FAQ</a> for answers to the most common questions about the project.
-
-## Compatibility
-
-Posts are backward compatible, and shortcodes will still work. We are continuously exploring how highly-tailored meta boxes can be accommodated, and are looking at solutions ranging from a plugin to disable Gutenberg to automatically detecting whether to load Gutenberg or not. While we want to make sure the new editing experience from writing to publishing is user-friendly, we’re committed to finding a good solution for highly-tailored existing sites.
-
-## The stages of Gutenberg
-
-Gutenberg has three planned stages.
-1) **The first, aimed for inclusion in WordPress 5.0, focuses on the post editing experience** and the implementation of blocks. This initial phase focuses on a content-first approach. The use of blocks, as detailed above, allows you to focus on how your content will look without the distraction of other configuration options. This ultimately will help all users present their content in a way that is engaging, direct, and visual. These foundational elements will pave the way forward.
-2) Planned for 2019, **The second stage focuses on overhauling The Customizer** and page templates.
-3) Ultimately, **full site customization** will be possible.
-
-**Gutenberg is a big change.** There will be ways to ensure that existing functionality (like shortcodes and meta-boxes) continue to work while allowing developers the time and paths to transition effectively. Ultimately, it will open new opportunities for plugin and theme developers to better serve users through a more engaging and visual experience that takes advantage of a toolset supported by core.
+As with all WordPress projects, we want to ensure a welcoming environment for everyone. With that in mind, all contributors are expected to follow our [Code of Conduct](https://github.com/WordPress/gutenberg/blob/master/CODE_OF_CONDUCT.md).
 
 ## Get involved
 
-We’re calling this editor project "Gutenberg" because it's a big undertaking. We are working on it every day in GitHub, and we'd love your help building it. You’re also welcome to give feedback, the easiest is to join us in <a href="https://make.wordpress.org/chat/">our Slack channel</a>, `#core-editor`. A weekly meeting is held in the Slack channel on Wednesdays at 13:00 UTC.
+You can join us in the `#core-editor` channel in Slack, see [WordPress Slack page](https://make.wordpress.org/chat/) for signup information, it is free to join.
 
-## Contributors
+**Weekly meetings** The Editor Team meets weekly on Wednesdays at 14:00 UTC in Slack. If you can not join the meeting, agenda and notes are posted to the [Make WordPress Blog](https://make.wordpress.org/core/).
 
-Gutenberg is built by many contributors and volunteers. Please see the full list in <a href="https://github.com/WordPress/gutenberg/blob/master/CONTRIBUTORS.md">CONTRIBUTORS.md</a>.
+## License
 
-## How You Can Contribute
-
-Please see <a href="https://github.com/WordPress/gutenberg/blob/master/CONTRIBUTING.md">CONTRIBUTING.md</a>.
-
-## Further Reading
-
-- <a href="http://matiasventura.com/post/gutenberg-or-the-ship-of-theseus/">Gutenberg, or the Ship of Theseus</a>, with examples of what Gutenberg might do in the future
-- <a href="https://make.wordpress.org/core/2017/01/17/editor-technical-overview/">Editor Technical Overview</a>
-- <a href="https://developer.wordpress.org/block-editor/contributors/design/">Design Principles and block design best practices</a>
-- <a href="https://github.com/Automattic/wp-post-grammar">WP Post Grammar Parser</a>
-- <a href="https://make.wordpress.org/core/tag/gutenberg/">Development updates on make.wordpress.org</a>
-- <a href="https://developer.wordpress.org/block-editor/">Documentation: Creating Blocks, Reference, and Guidelines</a>
-
-<br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>
+WordPress is free software, and is released under the terms of the GNU General Public License version 2 or (at your option) any later version. See [LICENSE.md](LICENSE.md) for complete license.

--- a/readme.txt
+++ b/readme.txt
@@ -10,7 +10,11 @@ The Gutenberg plugin provides editing, customization, and site building features
 
 == Description ==
 
-Gutenberg is more than an editor. It is the foundation that will revolutionize customization, site building and the entire publishing experience of the platform. The four phases of the project are Editing, Customization, Collaboration, and Multilingual.
+"Gutenberg" is a codename for a whole new paradigm in WordPress site building and publishing, one that will revolutionize the entire publishing experience as much as Gutenberg did the printed word. Right now, the project is in the first phase of a four-phase process that will touch every piece of WordPress -- Editing, Customization, Collaboration, and Multilingual -- and is focused on a new editing experience, the block editor.
+
+The block editor introduces a modular approach to pages and posts: each piece of content in the editor, from a paragraph to an image gallery to a headline, is its own block. And just like physical blocks, WordPress blocks can added, arranged, and rearranged, allowing WordPress users to create media-rich pages in a visually intuitive way -- and without work-arounds like shortcodes or custom HTML.
+
+The block editor first became available in December 2018, and we're still hard at work refining the experience, creating more and better blocks, and laying the groundwork for the next three phases of work. The Gutenberg plugin gives you the latest version of the block editor so you can join us in testing bleeding-edge features, start playing with blocks, and maybe get inspired to build your own.
 
 ### Discover More
 

--- a/readme.txt
+++ b/readme.txt
@@ -10,7 +10,7 @@ The Gutenberg plugin provides editing, customization, and site building features
 
 == Description ==
 
-"Gutenberg" is a codename for a whole new paradigm in WordPress site building and publishing, one that will revolutionize the entire publishing experience as much as Gutenberg did the printed word. Right now, the project is in the first phase of a four-phase process that will touch every piece of WordPress -- Editing, Customization, Collaboration, and Multilingual -- and is focused on a new editing experience, the block editor.
+"Gutenberg" is a codename for a whole new paradigm in WordPress site building and publishing, that aims to revolutionize the entire publishing experience as much as Gutenberg did the printed word. Right now, the project is in the first phase of a four-phase process that will touch every piece of WordPress -- Editing, Customization, Collaboration, and Multilingual -- and is focused on a new editing experience, the block editor.
 
 The block editor introduces a modular approach to pages and posts: each piece of content in the editor, from a paragraph to an image gallery to a headline, is its own block. And just like physical blocks, WordPress blocks can added, arranged, and rearranged, allowing WordPress users to create media-rich pages in a visually intuitive way -- and without work-arounds like shortcodes or custom HTML.
 

--- a/readme.txt
+++ b/readme.txt
@@ -30,12 +30,12 @@ Discussion for the project is on <a href="https://make.wordpress.com/core/">Make
 
 We'd love to hear your bug reports, feature suggestions and any other feedback! Please head over to <a href="https://github.com/WordPress/gutenberg/issues">the GitHub issues page</a> to search for existing issues or open a new one. While we'll try to triage issues reported here on the plugin forum, you'll get a faster response (and reduce duplication of effort) by keeping everything centralized in the GitHub repository.
 
-= What are the next phases for the project? =
+= What's Next for the Project? =
 
 The four phases of the project are Editing, Customization, Collaboration, and Multilingual. You can hear more about the project and phases from Matt in his State of the Word talks for <a href="https://ma.tt/2019/11/state-of-the-word-2019/">2019</a> and <a href="https://ma.tt/2018/12/state-of-the-word-2018/">2018</a>. Additionally you can follow updates in the <a href="https://make.wordpress.org/core/?s=gutenberg">Make WordPress Core blog</a>.
 
 
-= Where can I read more about Gutenberg? =
+= Where Can I Read More About Gutenberg? =
 
 - <a href="http://matiasventura.com/post/gutenberg-or-the-ship-of-theseus/">Gutenberg, or the Ship of Theseus</a>, with examples of what Gutenberg might do in the future
 - <a href="https://make.wordpress.org/core/2017/01/17/editor-technical-overview/">Editor Technical Overview</a>

--- a/readme.txt
+++ b/readme.txt
@@ -6,53 +6,23 @@ Stable tag: V.V.V
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
-The block editor was introduced in core WordPress with version 5.0. This beta plugin allows you to test bleeding-edge features around editing and customization projects before they land in future WordPress releases.
+The Gutenberg plugin provides editing, customization, and site building features to WordPress. This beta plugin allows you to test bleeding-edge features before they land in future WordPress releases.
 
 == Description ==
 
-The block editor was introduced in core WordPress with version 5.0 but the Gutenberg project will ultimately impact the entire publishing experience including customization (the next focus area). This beta plugin allows you to test bleeding-edge features around editing and customization projects before they land in future WordPress releases.
+Gutenberg is more than an editor. It is the foundation that will revolutionize customization, site building and the entire publishing experience of the platform. The four phases of the project are Editing, Customization, Collaboration, and Multilingual.
 
-<a href="https://wordpress.org/gutenberg">Discover more about the project</a>.
+### Discover More
 
-= Editing focus =
+- **User Documentation:** See the <a href="https://wordpress.org/support/article/wordpress-editor/">WordPress Editor documentation</a> for detailed docs on using the editor as an author creating posts and pages.
 
-> The editor will create a new page- and post-building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery. — Matt Mullenweg
+- **Developer Documentation:** Extending and customizing is at the heart of the WordPress platform, see the <a href="https://developer.wordpress.org/block-editor/developers/">Developer Documentation</a> for extensive tutorials, documentation, and API reference on how to extend the editor.
 
-One thing that sets WordPress apart from other systems is that it allows you to create as rich a post layout as you can imagine -- but only if you know HTML and CSS and build your own custom theme. By thinking of the editor as a tool to let you write rich posts and create beautiful layouts, we can transform WordPress into something users _love_ WordPress, as opposed something they pick it because it's what everyone else uses.
+- **Contributors:** Gutenberg is an open-source project and welcomes all contributors from code to design, from documentation to triage. See the <a href="https://developer.wordpress.org/block-editor/contributors/">Contributor's Handbook</a> for all the details on how you can help.
 
-Gutenberg looks at the editor as more than a content field, revisiting a layout that has been largely unchanged for almost a decade.This allows us to holistically design a modern editing experience and build a foundation for things to come.
+The development hub for the Gutenberg project is on Github at: <a href="https://github.com/wordpress/gutenberg/"> https://github.com/wordpress/gutenberg</a>
 
-Here's why we're looking at the whole editing screen, as opposed to just the content field:
-
-1. The block unifies multiple interfaces. If we add that on top of the existing interface, it would _add_ complexity, as opposed to remove it.
-2. By revisiting the interface, we can modernize the writing, editing, and publishing experience, with usability and simplicity in mind, benefitting both new and casual users.
-3. When singular block interface takes center stage, it demonstrates a clear path forward for developers to create premium blocks, superior to both shortcodes and widgets.
-4. Considering the whole interface lays a solid foundation for the next focus, full site customization.
-5. Looking at the full editor screen also gives us the opportunity to drastically modernize the foundation, and take steps towards a more fluid and JavaScript powered future that fully leverages the WordPress REST API.
-
-= Blocks =
-
-Blocks are the unifying evolution of what is now covered, in different ways, by shortcodes, embeds, widgets, post formats, custom post types, theme options, meta-boxes, and other formatting elements. They embrace the breadth of functionality WordPress is capable of, with the clarity of a consistent user experience.
-
-Imagine a custom “employee” block that a client can drag to an About page to automatically display a picture, name, and bio. A whole universe of plugins that all extend WordPress in the same way. Simplified menus and widgets. Users who can instantly understand and use WordPress  -- and 90% of plugins. This will allow you to easily compose beautiful posts like <a href="http://moc.co/sandbox/example-post/">this example</a>.
-
-Check out the <a href="https://wordpress.org/gutenberg/handbook/reference/faq/">FAQ</a> for answers to the most common questions about the project.
-
-= Compatibility =
-
-Posts are backwards compatible, and shortcodes will still work. We are continuously exploring how highly-tailored metaboxes can be accommodated, and are looking at solutions ranging from a plugin to disable Gutenberg to automatically detecting whether to load Gutenberg or not. While we want to make sure the new editing experience from writing to publishing is user-friendly, we’re committed to finding  a good solution for highly-tailored existing sites.
-
-= The stages of Gutenberg =
-
-Gutenberg has three planned stages. The first, aimed for inclusion in WordPress 5.0, focuses on the post editing experience and the implementation of blocks. This initial phase focuses on a content-first approach. The use of blocks, as detailed above, allows you to focus on how your content will look without the distraction of other configuration options. This ultimately will help all users present their content in a way that is engaging, direct, and visual.
-
-These foundational elements will pave the way for stages two and three, planned for the next year, to go beyond the post into page templates and ultimately, full site customization.
-
-Gutenberg is a big change, and there will be ways to ensure that existing functionality (like shortcodes and meta-boxes) continue to work while allowing developers the time and paths to transition effectively. Ultimately, it will open new opportunities for plugin and theme developers to better serve users through a more engaging and visual experience that takes advantage of a toolset supported by core.
-
-= Contributors =
-
-Gutenberg is built by many contributors and volunteers. Please see the full list in <a href="https://github.com/WordPress/gutenberg/blob/master/CONTRIBUTORS.md">CONTRIBUTORS.md</a>.
+Discussion for the project is on <a href="https://make.wordpress.com/core/">Make Blog</a> and the `#core-editor` channel in Slack, <a href="https://make.wordpress.org/chat/">signup information</a>.
 
 == Frequently Asked Questions ==
 
@@ -60,11 +30,10 @@ Gutenberg is built by many contributors and volunteers. Please see the full list
 
 We'd love to hear your bug reports, feature suggestions and any other feedback! Please head over to <a href="https://github.com/WordPress/gutenberg/issues">the GitHub issues page</a> to search for existing issues or open a new one. While we'll try to triage issues reported here on the plugin forum, you'll get a faster response (and reduce duplication of effort) by keeping everything centralized in the GitHub repository.
 
-= How can I contribute? =
+= What are the next phases for the project? =
 
-We’re calling this editor project "Gutenberg" because it's a big undertaking. We are working on it every day in GitHub, and we'd love your help building it.You’re also welcome to give feedback, the easiest is to join us in <a href="https://make.wordpress.org/chat/">our Slack channel</a>, `#core-editor`.
+The four phases of the project are Editing, Customization, Collaboration, and Multilingual. You can hear more about the project and phases from Matt in his State of the Word talks for <a href="https://ma.tt/2019/11/state-of-the-word-2019/">2019</a> and <a href="https://ma.tt/2018/12/state-of-the-word-2018/">2018</a>. Additionally you can follow updates in the <a href="https://make.wordpress.org/core/?s=gutenberg">Make WordPress Core blog</a>.
 
-See also <a href="https://github.com/WordPress/gutenberg/blob/master/CONTRIBUTING.md">CONTRIBUTING.md</a>.
 
 = Where can I read more about Gutenberg? =
 


### PR DESCRIPTION
This is the first part of updating the Gutenberg docs to match the current state, I'm going to submit as separate PRs so it focuses discussion for each piece. The Contributors Handbook is the second part for updates.

## Description

Update the main project repository readme with various updates that bring it current for now and down the line.

First organized it into a more general getting started recognizing the three levels that people might be coming to the project: as a User, as a Developer, and as a Contributor

For User - added links to the user documentation, support forums, and how to report an issue

For Developer - added links to the developer documentation

For Contributor - simplified the contributor sections and links to the contributors' guide

I removed the links at the bottom since those are mostly dated from when the project was starting out and justifying itself. These links can be included elsewhere for background and context, and not necessarily on the welcoming page.

## Types of changes

Documentation.

You can view the [rendered version on the branch here](https://github.com/WordPress/gutenberg/blob/update/main-readme/README.md)
