### PR TITLE
Fix more block styles #8750

### DIFF
--- a/packages/block-library/src/more/edit.js
+++ b/packages/block-library/src/more/edit.js
@@ -53,7 +53,8 @@ export default class MoreEdit extends Component {
 		const toggleHideExcerpt = () => setAttributes( { noTeaser: ! noTeaser } );
 		const { defaultText } = this.state;
 		const value = customText !== undefined ? customText : defaultText;
-		const inputLength = value.length + 1;
+		const inputLength = value.length + 1.2;
+		const currentWidth = { width: inputLength + 'em' };
 
 		return (
 			<>
@@ -71,9 +72,9 @@ export default class MoreEdit extends Component {
 					<input
 						type="text"
 						value={ value }
-						size={ inputLength }
 						onChange={ this.onChangeInput }
 						onKeyDown={ this.onKeyDown }
+						style={ currentWidth }
 					/>
 				</div>
 			</>

--- a/packages/block-library/src/more/editor.scss
+++ b/packages/block-library/src/more/editor.scss
@@ -27,6 +27,7 @@
 		background: $white;
 		padding: 6px 8px;
 		height: $icon-button-size-small;
+		max-width: 100%;
 
 		&:focus {
 			box-shadow: none;

--- a/packages/block-library/src/more/test/__snapshots__/edit.js.snap
+++ b/packages/block-library/src/more/test/__snapshots__/edit.js.snap
@@ -18,7 +18,11 @@ exports[`core/more/edit should match snapshot when noTeaser is false 1`] = `
     <input
       onChange={[Function]}
       onKeyDown={[Function]}
-      size={1}
+      style={
+        Object {
+          "width": "1.2em",
+        }
+      }
       type="text"
       value=""
     />
@@ -44,7 +48,11 @@ exports[`core/more/edit should match snapshot when noTeaser is true 1`] = `
     <input
       onChange={[Function]}
       onKeyDown={[Function]}
-      size={1}
+      style={
+        Object {
+          "width": "1.2em",
+        }
+      }
       type="text"
       value=""
     />


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
This PR will fix #8750 ( Redo #18966 ).

## Screenshots <!-- if applicable -->
![pr_for_8750_ss01](https://user-images.githubusercontent.com/487207/72658616-be8ef780-39f6-11ea-95ef-fa27b4973955.jpg)
![pr_for_8750_ss02](https://user-images.githubusercontent.com/487207/72658617-c189e800-39f6-11ea-8f97-be4fb0c7f4aa.jpg)
![pr_for_8750_ss03](https://user-images.githubusercontent.com/487207/72658618-c51d6f00-39f6-11ea-85fc-eb0f793c1d75.jpg)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
