### PR TITLE
Core-data: do not publish outdated state to subscribers during updates

### DIFF
--- a/docs/designers-developers/developers/data/data-core.md
+++ b/docs/designers-developers/developers/data/data-core.md
@@ -202,6 +202,21 @@ _Returns_
 
 -   `?Object`: The entity record's non transient edits.
 
+<a name="getEntityRecordNoResolver" href="#getEntityRecordNoResolver">#</a> **getEntityRecordNoResolver**
+
+Returns the Entity's record object by key. Doesn't trigger a resolver nor requests the entity from the API if the entity record isn't available in the local state.
+
+_Parameters_
+
+-   _state_ `Object`: State tree
+-   _kind_ `string`: Entity kind.
+-   _name_ `string`: Entity name.
+-   _key_ `number`: Record's key
+
+_Returns_
+
+-   `?Object`: Record.
+
 <a name="getEntityRecords" href="#getEntityRecords">#</a> **getEntityRecords**
 
 Returns the Entity's records.

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -415,6 +415,21 @@ _Returns_
 
 -   `?Object`: The entity record's non transient edits.
 
+<a name="getEntityRecordNoResolver" href="#getEntityRecordNoResolver">#</a> **getEntityRecordNoResolver**
+
+Returns the Entity's record object by key. Doesn't trigger a resolver nor requests the entity from the API if the entity record isn't available in the local state.
+
+_Parameters_
+
+-   _state_ `Object`: State tree
+-   _kind_ `string`: Entity kind.
+-   _name_ `string`: Entity name.
+-   _key_ `number`: Record's key
+
+_Returns_
+
+-   `?Object`: Record.
+
 <a name="getEntityRecords" href="#getEntityRecords">#</a> **getEntityRecords**
 
 Returns the Entity's records.

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -357,28 +357,34 @@ export function* saveEntityRecord(
 				}
 			}
 
-			// We perform an optimistic update here to clear all the edits that
-			// will be persisted so that if the server filters them, the new
-			// filtered values are always accepted.
-			persistedEntity = yield select(
-				'getEntityRecord',
-				kind,
-				name,
-				recordId
-			);
-			currentEdits = yield select(
-				'getEntityRecordEdits',
-				kind,
-				name,
-				recordId
-			);
-			yield receiveEntityRecords( kind, name, { ...persistedEntity, ...data }, undefined, true );
+			/*
+				// the code below issues an API fetch action against the server and gets the outdates pre-modification state of the record
+				// and since getEntityRecord calls receiveEntityRecords, this outdated state is rendered to the user, causing an unstable (flickering)
+				// intermediate UI state
+
+				//////// disabled //////////
+					// We perform an optimistic update here to clear all the edits that
+					// will be persisted so that if the server filters them, the new
+					// filtered values are always accepted.
+					persistedEntity = yield select(
+						'getEntityRecord',
+						kind,
+						name,
+						recordId
+					);
+				//////// disabled //////////
+			*/
+
+			// optimistic update subscribers (eg trigger re-renders) with the modifications applied to the record
+			// and on their way to be persisted on the server
+			yield receiveEntityRecords( kind, name, { ...data }, undefined, true );
 
 			updatedRecord = yield apiFetch( {
 				path,
 				method: recordId ? 'PUT' : 'POST',
 				data,
 			} );
+
 			yield receiveEntityRecords( kind, name, updatedRecord, undefined, true );
 		}
 	} catch ( _error ) {

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -357,7 +357,7 @@ export function* saveEntityRecord(
 				}
 			}
 
-			// get the full local version of the record before the update,
+			// Get the full local version of the record before the update,
 			// to merge it with the edits and then propagate it to subscribers
 			persistedEntity = yield select(
 				'getEntityRecordNoResolver',
@@ -378,7 +378,6 @@ export function* saveEntityRecord(
 				method: recordId ? 'PUT' : 'POST',
 				data,
 			} );
-
 			yield receiveEntityRecords( kind, name, updatedRecord, undefined, true );
 		}
 	} catch ( _error ) {

--- a/packages/core-data/src/selectors.js
+++ b/packages/core-data/src/selectors.js
@@ -118,7 +118,7 @@ export function getEntityRecord( state, kind, name, key ) {
  * @return {Object?} Record.
  */
 export function getEntityRecordNoResolver( state, kind, name, key ) {
-	return get( state.entities.data, [ kind, name, 'queriedData', 'items', key ] );
+	return getEntityRecord( state, kind, name, key );
 }
 
 /**

--- a/packages/core-data/src/selectors.js
+++ b/packages/core-data/src/selectors.js
@@ -108,6 +108,20 @@ export function getEntityRecord( state, kind, name, key ) {
 }
 
 /**
+ * Returns the Entity's record object by key. Doesn't trigger a resolver nor requests the entity from the API if the entity record isn't available in the local state.
+ *
+ * @param {Object} state  State tree
+ * @param {string} kind   Entity kind.
+ * @param {string} name   Entity name.
+ * @param {number} key    Record's key
+ *
+ * @return {Object?} Record.
+ */
+export function getEntityRecordNoResolver( state, kind, name, key ) {
+	return get( state.entities.data, [ kind, name, 'queriedData', 'items', key ] );
+}
+
+/**
  * Returns the entity's record object by key,
  * with its attributes mapped to their raw values.
  *

--- a/packages/core-data/src/test/actions.js
+++ b/packages/core-data/src/test/actions.js
@@ -42,13 +42,11 @@ describe( 'saveEntityRecord', () => {
 			'SAVE_ENTITY_RECORD_START'
 		);
 
-		// should select getEntityRecordNoResolver selector (as opposed to getEntityRecord)
-		// see https://github.com/WordPress/gutenberg/pull/19752#discussion_r368498318
+		// Should select getEntityRecordNoResolver selector (as opposed to getEntityRecord)
+		// see https://github.com/WordPress/gutenberg/pull/19752#discussion_r368498318.
 		expect( fulfillment.next().value.type ).toBe( 'SELECT' );
 		expect( fulfillment.next().value.selectorName ).toBe( 'getEntityRecordNoResolver' );
-
 		expect( fulfillment.next().value.type ).toBe( 'SELECT' );
-
 		expect( fulfillment.next().value.type ).toBe( 'RECEIVE_ITEMS' );
 		const { value: apiFetchAction } = fulfillment.next( {} );
 		expect( apiFetchAction.request ).toEqual( {

--- a/packages/core-data/src/test/actions.js
+++ b/packages/core-data/src/test/actions.js
@@ -41,7 +41,14 @@ describe( 'saveEntityRecord', () => {
 		expect( fulfillment.next( entities ).value.type ).toBe(
 			'SAVE_ENTITY_RECORD_START'
 		);
+
+		// should select getEntityRecordNoResolver selector (as opposed to getEntityRecord)
+		// see https://github.com/WordPress/gutenberg/pull/19752#discussion_r368498318
 		expect( fulfillment.next().value.type ).toBe( 'SELECT' );
+		expect( fulfillment.next().value.selectorName ).toBe( 'getEntityRecordNoResolver' );
+
+		expect( fulfillment.next().value.type ).toBe( 'SELECT' );
+
 		expect( fulfillment.next().value.type ).toBe( 'RECEIVE_ITEMS' );
 		const { value: apiFetchAction } = fulfillment.next( {} );
 		expect( apiFetchAction.request ).toEqual( {
@@ -76,6 +83,8 @@ describe( 'saveEntityRecord', () => {
 			'SAVE_ENTITY_RECORD_START'
 		);
 		expect( fulfillment.next().value.type ).toBe( 'SELECT' );
+		expect( fulfillment.next().value.type ).toBe( 'SELECT' );
+		expect( fulfillment.next().value.type ).toBe( 'SELECT' );
 		expect( fulfillment.next().value.type ).toBe( 'RECEIVE_ITEMS' );
 		const { value: apiFetchAction } = fulfillment.next( {} );
 		expect( apiFetchAction.request ).toEqual( {
@@ -99,6 +108,8 @@ describe( 'saveEntityRecord', () => {
 		expect( fulfillment.next( entities ).value.type ).toBe(
 			'SAVE_ENTITY_RECORD_START'
 		);
+		expect( fulfillment.next().value.type ).toBe( 'SELECT' );
+		expect( fulfillment.next().value.type ).toBe( 'SELECT' );
 		expect( fulfillment.next().value.type ).toBe( 'SELECT' );
 		expect( fulfillment.next().value.type ).toBe( 'RECEIVE_ITEMS' );
 		const { value: apiFetchAction } = fulfillment.next( {} );

--- a/packages/core-data/src/test/actions.js
+++ b/packages/core-data/src/test/actions.js
@@ -42,8 +42,6 @@ describe( 'saveEntityRecord', () => {
 			'SAVE_ENTITY_RECORD_START'
 		);
 		expect( fulfillment.next().value.type ).toBe( 'SELECT' );
-		expect( fulfillment.next().value.type ).toBe( 'SELECT' );
-		expect( fulfillment.next().value.type ).toBe( 'SELECT' );
 		expect( fulfillment.next().value.type ).toBe( 'RECEIVE_ITEMS' );
 		const { value: apiFetchAction } = fulfillment.next( {} );
 		expect( apiFetchAction.request ).toEqual( {
@@ -78,8 +76,6 @@ describe( 'saveEntityRecord', () => {
 			'SAVE_ENTITY_RECORD_START'
 		);
 		expect( fulfillment.next().value.type ).toBe( 'SELECT' );
-		expect( fulfillment.next().value.type ).toBe( 'SELECT' );
-		expect( fulfillment.next().value.type ).toBe( 'SELECT' );
 		expect( fulfillment.next().value.type ).toBe( 'RECEIVE_ITEMS' );
 		const { value: apiFetchAction } = fulfillment.next( {} );
 		expect( apiFetchAction.request ).toEqual( {
@@ -103,8 +99,6 @@ describe( 'saveEntityRecord', () => {
 		expect( fulfillment.next( entities ).value.type ).toBe(
 			'SAVE_ENTITY_RECORD_START'
 		);
-		expect( fulfillment.next().value.type ).toBe( 'SELECT' );
-		expect( fulfillment.next().value.type ).toBe( 'SELECT' );
 		expect( fulfillment.next().value.type ).toBe( 'SELECT' );
 		expect( fulfillment.next().value.type ).toBe( 'RECEIVE_ITEMS' );
 		const { value: apiFetchAction } = fulfillment.next( {} );

--- a/packages/core-data/src/test/selectors.js
+++ b/packages/core-data/src/test/selectors.js
@@ -8,6 +8,7 @@ import deepFreeze from 'deep-freeze';
  */
 import {
 	getEntityRecord,
+	getEntityRecordNoResolver,
 	getEntityRecords,
 	getEntityRecordChangesByRecord,
 	getEntityRecordNonTransientEdits,
@@ -20,43 +21,47 @@ import {
 	getReferenceByDistinctEdits,
 } from '../selectors';
 
-describe( 'getEntityRecord', () => {
-	it( 'should return undefined for unknown record’s key', () => {
-		const state = deepFreeze( {
-			entities: {
-				data: {
-					root: {
-						postType: {
-							queriedData: {
-								items: {},
-								queries: {},
-							},
-						},
-					},
-				},
-			},
-		} );
-		expect( getEntityRecord( state, 'root', 'postType', 'post' ) ).toBe( undefined );
-	} );
-
-	it( 'should return a record by key', () => {
-		const state = deepFreeze( {
-			entities: {
-				data: {
-					root: {
-						postType: {
-							queriedData: {
-								items: {
-									post: { slug: 'post' },
+// getEntityRecord and getEntityRecordNoResolver selectors share the same tests
+Object.entries( { getEntityRecord, getEntityRecordNoResolver } ).forEach( ( [ name, func ] ) => {
+	// the interpolation is needed due to https://github.com/jest-community/eslint-plugin-jest/issues/203
+	describe( `${ name }`, () => {
+		it( 'should return undefined for unknown record’s key', () => {
+			const state = deepFreeze( {
+				entities: {
+					data: {
+						root: {
+							postType: {
+								queriedData: {
+									items: {},
+									queries: {},
 								},
-								queries: {},
 							},
 						},
 					},
 				},
-			},
+			} );
+			expect( func( state, 'root', 'postType', 'post' ) ).toBe( undefined );
 		} );
-		expect( getEntityRecord( state, 'root', 'postType', 'post' ) ).toEqual( { slug: 'post' } );
+
+		it( 'should return a record by key', () => {
+			const state = deepFreeze( {
+				entities: {
+					data: {
+						root: {
+							postType: {
+								queriedData: {
+									items: {
+										post: { slug: 'post' },
+									},
+									queries: {},
+								},
+							},
+						},
+					},
+				},
+			} );
+			expect( func( state, 'root', 'postType', 'post' ) ).toEqual( { slug: 'post' } );
+		} );
 	} );
 } );
 

--- a/packages/core-data/src/test/selectors.js
+++ b/packages/core-data/src/test/selectors.js
@@ -22,45 +22,47 @@ import {
 } from '../selectors';
 
 // getEntityRecord and getEntityRecordNoResolver selectors share the same tests
-Object.entries( { getEntityRecord, getEntityRecordNoResolver } ).forEach( ( [ name, func ] ) => {
-	// the interpolation is needed due to https://github.com/jest-community/eslint-plugin-jest/issues/203
-	describe( `${ name }`, () => {
-		it( 'should return undefined for unknown record’s key', () => {
-			const state = deepFreeze( {
-				entities: {
-					data: {
-						root: {
-							postType: {
-								queriedData: {
-									items: {},
-									queries: {},
-								},
+describe.each( [
+	[ getEntityRecord ],
+	[ getEntityRecordNoResolver ],
+] )( '%p', ( selector ) => {
+	it( 'should return undefined for unknown record’s key', () => {
+		const state = deepFreeze( {
+			entities: {
+				data: {
+					root: {
+						postType: {
+							queriedData: {
+								items: {},
+								queries: {},
 							},
 						},
 					},
 				},
-			} );
-			expect( func( state, 'root', 'postType', 'post' ) ).toBe( undefined );
+			},
 		} );
+		expect( selector( state, 'root', 'postType', 'post' ) ).toBe( undefined );
+	} );
 
-		it( 'should return a record by key', () => {
-			const state = deepFreeze( {
-				entities: {
-					data: {
-						root: {
-							postType: {
-								queriedData: {
-									items: {
-										post: { slug: 'post' },
-									},
-									queries: {},
+	it( 'should return a record by key', () => {
+		const state = deepFreeze( {
+			entities: {
+				data: {
+					root: {
+						postType: {
+							queriedData: {
+								items: {
+									post: { slug: 'post' },
 								},
+								queries: {},
 							},
 						},
 					},
 				},
-			} );
-			expect( func( state, 'root', 'postType', 'post' ) ).toEqual( { slug: 'post' } );
+			},
+		} );
+		expect( selector( state, 'root', 'postType', 'post' ) ).toEqual( {
+			slug: 'post',
 		} );
 	} );
 } );


### PR DESCRIPTION
Hello,

Absolutely loving Gutenberg. Thank you so much! 

Currently, if you use `select('core').getEntityRecords(...)` to get records, and you issue an update against these records using `saveEntityRecord` (I suspect any update effect will surface this bug), you'll get unstable intermediate states until the final state settles. 

See GIF (all data here is mocked):
![Pistachio  WordPress](https://user-images.githubusercontent.com/17054134/72684600-49005580-3ae2-11ea-9054-ec7a9a3be767.gif)

This is because calling `saveEntityRecord` with an update does the following:

1. Calls `getEntityRecord` to fetch the current persisted state of the entity record
2. Calls `receiveEntityRecords` with the new up-to-date state to render the updates
3. Sends an API fetch with the update patch to persist the update
4. Calls `receiveEntityRecords` again with the new up-to-date *persisted*
state

The issue here is that point 1 (Calling `getEntityRecord`) not only fetches the persisted state but it also internally calls `receiveEntityRecords` itself. This results in the persisted outdated server state to be propagated and thus momentarily rendered on the UI, causing a flickering effect, that jumps pack when pointing 2 takes its turn.

This PR proposes removing the call to `getEntityRecord`, and instead, to optimistically call `receiveEntityRecords` with the local up-to-date state of the entity record. This fixes the flickering issue.

## Changes to tests
`saveEntityRecord` used to `select` and use `getEntityRecord`. `getEntityRecord` is itself a selector. `saveEntityRecord` no longer selects nor uses `getEntityRecord`. This implies that `saveEntityRecord` yields two SELECT actions short from its previous implementation. This PR proposes removing the expectation of these two SELECTs in the tests.

## How has this been tested?
I tested this manually and by running the Gutenberg's tests. By manually I mean I built the `core-data` package after this change and used it with a local instance of Wordpress, the issue disappeared.

## Types of changes
Bugfix, but potentially a breaking change, since `saveEntityRecord` now yields a different sequence of actions. However, all indirectly concerned JS tests are passing except the affected ones, which I updated according to the new yields. 

**Edit** :bulb: : Some E2E tests are failing, I'm looking into it. I would really appreciate some input on this one. It seems way deeper than my current understanding of the flow.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. I couldn't find an `*.native.js` files that are related to this change.

Thanks.
