### PR TITLE
Add max-height to CustomSelectControl menu

### DIFF
--- a/packages/components/src/custom-select-control/style.scss
+++ b/packages/components/src/custom-select-control/style.scss
@@ -33,7 +33,9 @@
 
 .components-custom-select-control__menu {
 	background: $white;
+	max-height: 400px;
 	min-width: 100%;
+	overflow: auto;
 	padding: 0;
 	position: absolute;
 	z-index: z-index(".components-popover");


### PR DESCRIPTION
Fixes #19751.

## Description
In WooCommerce Blocks we used the `CustomSelectControl` component to create a Country selector (see https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/1585).

It had the issue that when all countries were displayed, the dropdown was taking the height of the entire screen. It could be easily fixed adding a `max-height` property to the menu, but we considered that it could be interesting to upstream this change so all consumers of `CustomSelectControl` get this default `max-height`.

## How has this been tested?
* Using the `CustomSelectControl` component to create a select with many options and verifying they took a maximum height of 400px.
* Verifying there were no regressions in the editor font size select.

## Screenshots
| Before | After |
| --- | --- |
| ![imatge](https://user-images.githubusercontent.com/3616980/72685252-a8f9fa80-3ae8-11ea-83d0-34e08e0fe649.png) | ![imatge](https://user-images.githubusercontent.com/3616980/72685266-b3b48f80-3ae8-11ea-922b-48729b419ebc.png) |

## Types of changes
CSS enhancement: makes the dropdown of the `CustomSelectControl` component to have a `max-height` to avoid very long lists.