### PR TITLE
Core-data: more granular cache invalidation when updating records

### DIFF
--- a/packages/core-data/src/queried-data/actions.js
+++ b/packages/core-data/src/queried-data/actions.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { castArray } from 'lodash';
-
-/**
  * Returns an action object used in signalling that items have been received.
  *
  * @param {Array} items Items received.
@@ -13,7 +8,20 @@ import { castArray } from 'lodash';
 export function receiveItems( items ) {
 	return {
 		type: 'RECEIVE_ITEMS',
-		items: castArray( items ),
+		items,
+	};
+}
+/**
+ * Returns an action object used in signalling that an item has been received.
+ *
+ * @param {Array} item Item received.
+ *
+ * @return {Object} Action object.
+ */
+export function receiveItem( item ) {
+	return {
+		type: 'RECEIVE_ITEM',
+		item,
 	};
 }
 
@@ -29,6 +37,22 @@ export function receiveItems( items ) {
 export function receiveQueriedItems( items, query = {} ) {
 	return {
 		...receiveItems( items ),
+		query,
+	};
+}
+
+/**
+ * Returns an action object used in signalling that queried data has been
+ * received.
+ *
+ * @param {Object}   item Queried item received.
+ * @param {?Object} query Optional query object.
+ *
+ * @return {Object} Action object.
+ */
+export function receiveQueriedItem( item, query = {} ) {
+	return {
+		...receiveItem( item ),
 		query,
 	};
 }

--- a/packages/core-data/src/queried-data/reducer.js
+++ b/packages/core-data/src/queried-data/reducer.js
@@ -69,9 +69,9 @@ export function getMergedItemIds( itemIds, nextItemIds, page, perPage ) {
  * @return {Object} Next state.
  */
 function items( state = {}, action ) {
+	const key = action.key || DEFAULT_ENTITY_KEY;
 	switch ( action.type ) {
 		case 'RECEIVE_ITEMS':
-			const key = action.key || DEFAULT_ENTITY_KEY;
 			return {
 				...state,
 				...action.items.reduce( ( accumulator, value ) => {
@@ -79,6 +79,13 @@ function items( state = {}, action ) {
 					accumulator[ itemId ] = conservativeMapItem( state[ itemId ], value );
 					return accumulator;
 				}, {} ),
+			};
+		case 'RECEIVE_ITEM':
+			const item = action.item;
+			const itemId = item[ key ];
+			return {
+				...state,
+				[ itemId ]: conservativeMapItem( state[ itemId ], item ),
 			};
 	}
 

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -57,6 +57,15 @@ export function* getEntityRecord( kind, name, key = '' ) {
 	yield receiveEntityRecords( kind, name, record );
 }
 
+getEntityRecord.shouldInvalidate = ( action, kind, name ) => {
+	return (
+		action.type === 'RECEIVE_ITEM' &&
+		action.invalidateCache &&
+		kind === action.kind &&
+		name === action.name
+	);
+};
+
 /**
  * Requests the entity's records from the REST API.
  *

--- a/packages/core-data/src/test/actions.js
+++ b/packages/core-data/src/test/actions.js
@@ -44,7 +44,7 @@ describe( 'saveEntityRecord', () => {
 		expect( fulfillment.next().value.type ).toBe( 'SELECT' );
 		expect( fulfillment.next().value.type ).toBe( 'SELECT' );
 		expect( fulfillment.next().value.type ).toBe( 'SELECT' );
-		expect( fulfillment.next().value.type ).toBe( 'RECEIVE_ITEMS' );
+		expect( fulfillment.next().value.type ).toBe( 'RECEIVE_ITEM' );
 		const { value: apiFetchAction } = fulfillment.next( {} );
 		expect( apiFetchAction.request ).toEqual( {
 			path: '/wp/v2/posts',
@@ -80,7 +80,7 @@ describe( 'saveEntityRecord', () => {
 		expect( fulfillment.next().value.type ).toBe( 'SELECT' );
 		expect( fulfillment.next().value.type ).toBe( 'SELECT' );
 		expect( fulfillment.next().value.type ).toBe( 'SELECT' );
-		expect( fulfillment.next().value.type ).toBe( 'RECEIVE_ITEMS' );
+		expect( fulfillment.next().value.type ).toBe( 'RECEIVE_ITEM' );
 		const { value: apiFetchAction } = fulfillment.next( {} );
 		expect( apiFetchAction.request ).toEqual( {
 			path: '/wp/v2/posts/10',
@@ -106,7 +106,7 @@ describe( 'saveEntityRecord', () => {
 		expect( fulfillment.next().value.type ).toBe( 'SELECT' );
 		expect( fulfillment.next().value.type ).toBe( 'SELECT' );
 		expect( fulfillment.next().value.type ).toBe( 'SELECT' );
-		expect( fulfillment.next().value.type ).toBe( 'RECEIVE_ITEMS' );
+		expect( fulfillment.next().value.type ).toBe( 'RECEIVE_ITEM' );
 		const { value: apiFetchAction } = fulfillment.next( {} );
 		expect( apiFetchAction.request ).toEqual( {
 			path: '/wp/v2/types/page',


### PR DESCRIPTION
Hello!

## Description
Currently, if you modify a single record, the cache is invalidated for all the records.

If the user is interested in a lot of entry records, this behavior can be expensive.  In my case, I have 300 candidate objects stored as Entity Records and they're worth 800KB in JSON. If you modify, say, a single candidate's gender data, the whole cache is invalidated and all the 300 candidates data is re-fetched from the server. This commit separates the two caches of (`getEntityRecords` vs `getEntityRecord`). And such, invalidating `getEntityRecord(X, Y, Z)`'s cache would only invalidate the cache for a single record `X, Y, Z`. And all the other records remain intact. Much more efficient, at least in my case.

## How has this been tested?
I tested this manually and by running the Gutenberg's tests. By manually I mean I built the core-data package after this change and used it with a local instance of Wordpress, the problem was fixed.

## Types of changes
Feature update (potentially a breaking change). Some features might rely on the current behavior of re-fetching all entries when any entry is updated.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] _I've updated all React Native files affected by any refactorings/renamings in this PR_. I couldn't find an `*.native.js` files that are related to this change.
