### PR TITLE
Add tag selector to latest posts widget, add tag selector to queries

### DIFF
--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -34,6 +34,9 @@ import { withSelect } from '@wordpress/data';
 const CATEGORIES_LIST_QUERY = {
 	per_page: -1,
 };
+const TAGS_LIST_QUERY = {
+	per_page: -1,
+};
 const MAX_POSTS_COLUMNS = 6;
 
 class LatestPostsEdit extends Component {
@@ -41,6 +44,7 @@ class LatestPostsEdit extends Component {
 		super( ...arguments );
 		this.state = {
 			categoriesList: [],
+			tagsList: [],
 		};
 	}
 
@@ -61,6 +65,21 @@ class LatestPostsEdit extends Component {
 				}
 			}
 		);
+		this.fetchRequest = apiFetch( {
+			path: addQueryArgs( `/wp/v2/tags`, TAGS_LIST_QUERY ),
+		} ).then(
+			( tagsList ) => {
+				if ( this.isStillMounted ) {
+					this.setState( { tagsList } );
+				}
+			}
+		).catch(
+			() => {
+				if ( this.isStillMounted ) {
+					this.setState( { tagsList: [] } );
+				}
+			}
+		);
 	}
 
 	componentWillUnmount() {
@@ -70,7 +89,8 @@ class LatestPostsEdit extends Component {
 	render() {
 		const { attributes, setAttributes, latestPosts } = this.props;
 		const { categoriesList } = this.state;
-		const { displayPostContentRadio, displayPostContent, displayPostDate, postLayout, columns, order, orderBy, categories, postsToShow, excerptLength } = attributes;
+		const { tagsList } = this.state;
+		const { displayPostContentRadio, displayPostContent, displayPostDate, postLayout, columns, order, orderBy, categories, tags, postsToShow, excerptLength } = attributes;
 
 		const inspectorControls = (
 			<InspectorControls>
@@ -116,9 +136,12 @@ class LatestPostsEdit extends Component {
 						numberOfItems={ postsToShow }
 						categoriesList={ categoriesList }
 						selectedCategoryId={ categories }
+						tagsList={ tagsList }
+						selectedTagId={ tags }
 						onOrderChange={ ( value ) => setAttributes( { order: value } ) }
 						onOrderByChange={ ( value ) => setAttributes( { orderBy: value } ) }
 						onCategoryChange={ ( value ) => setAttributes( { categories: '' !== value ? value : undefined } ) }
+						onTagChange={ ( value ) => setAttributes( { tags: '' !== value ? value : undefined } ) }
 						onNumberOfItemsChange={ ( value ) => setAttributes( { postsToShow: value } ) }
 					/>
 					{ postLayout === 'grid' &&
@@ -244,10 +267,11 @@ class LatestPostsEdit extends Component {
 }
 
 export default withSelect( ( select, props ) => {
-	const { postsToShow, order, orderBy, categories } = props.attributes;
+	const { postsToShow, order, orderBy, categories, tags } = props.attributes;
 	const { getEntityRecords } = select( 'core' );
 	const latestPostsQuery = pickBy( {
 		categories,
+		tags,
 		order,
 		orderby: orderBy,
 		per_page: postsToShow,

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -25,6 +25,10 @@ function render_block_core_latest_posts( $attributes ) {
 		$args['category'] = $attributes['categories'];
 	}
 
+	if ( isset( $attributes['tags'] ) ) {
+		$args['tag'] = $attributes['tags'];
+	}
+
 	$recent_posts = get_posts( $args );
 
 	$list_items_markup = '';
@@ -131,6 +135,9 @@ function register_block_core_latest_posts() {
 					'type' => 'string',
 				),
 				'categories'              => array(
+					'type' => 'string',
+				),
+				'tags'                    => array(
 					'type' => 'string',
 				),
 				'postsToShow'             => array(

--- a/packages/components/src/query-controls/index.js
+++ b/packages/components/src/query-controls/index.js
@@ -8,6 +8,7 @@ import { __ } from '@wordpress/i18n';
  */
 import { RangeControl, SelectControl } from '../';
 import CategorySelect from './category-select';
+import TagSelect from './tag-select';
 
 const DEFAULT_MIN_ITEMS = 1;
 const DEFAULT_MAX_ITEMS = 100;
@@ -15,12 +16,15 @@ const DEFAULT_MAX_ITEMS = 100;
 export default function QueryControls( {
 	categoriesList,
 	selectedCategoryId,
+	tagsList,
+	selectedTagId,
 	numberOfItems,
 	order,
 	orderBy,
 	maxItems = DEFAULT_MAX_ITEMS,
 	minItems = DEFAULT_MIN_ITEMS,
 	onCategoryChange,
+	onTagChange,
 	onNumberOfItemsChange,
 	onOrderChange,
 	onOrderByChange,
@@ -70,6 +74,15 @@ export default function QueryControls( {
 				noOptionLabel={ __( 'All' ) }
 				selectedCategoryId={ selectedCategoryId }
 				onChange={ onCategoryChange }
+			/> ),
+		onTagChange && (
+			<TagSelect
+				key="query-controls-tag-select"
+				tagsList={ tagsList }
+				label={ __( 'Tag' ) }
+				noOptionLabel={ __( 'All' ) }
+				selectedTagId={ selectedTagId }
+				onChange={ onTagChange }
 			/> ),
 		onNumberOfItemsChange && (
 			<RangeControl

--- a/packages/components/src/query-controls/tag-select.js
+++ b/packages/components/src/query-controls/tag-select.js
@@ -1,0 +1,16 @@
+/**
+ * Internal dependencies
+ */
+import { buildTermsTree } from './terms';
+import TreeSelect from '../tree-select';
+
+export default function TagSelect( { label, noOptionLabel, tagsList, selectedTagId, onChange } ) {
+	const termsTree = buildTermsTree( tagsList );
+	return (
+		<TreeSelect
+			{ ...{ label, noOptionLabel, onChange } }
+			tree={ termsTree }
+			selectedId={ selectedTagId }
+		/>
+	);
+}


### PR DESCRIPTION
## Description
Add a selector to filter by tags to the Latest Posts block. Modeled on the Categories filter, works the same way.

## How has this been tested?
Tested in WP 5.3.2 on TwentyTwenty using Local running PHP 7.3.2. Passes the test suite. Added a file in the QueryControls module called tag-select.js -- it is a nearly exact copy of category-select.js, just changes variable names to use tags.

## Screenshots 
![image](https://user-images.githubusercontent.com/730032/72686932-42b0b000-3ac7-11ea-97e2-a41bf1e35701.png)

## Types of changes
New feature: Adds a Tag selection dropdown to the "Latest Posts" block
New feature: Add tag selection to QueryControl

## Checklist:
- [X ] My code is tested.
- [X ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [X ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [X ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
