### PR TITLE
Added conditions and new translation strings for BlockMover

### DIFF
--- a/packages/block-editor/src/components/block-mover/mover-description.js
+++ b/packages/block-editor/src/components/block-mover/mover-description.js
@@ -84,11 +84,11 @@ export function getBlockMoverDescription( selectedCount, type, firstIndex, isFir
 
 	if ( dir > 0 && isLast ) {
 		// moving down, and is the last item
-		// translators: 1: Type of block (i.e. Text, Image etc)
 		const movementDirection = getMovementDirection( 'down' );
 
 		if ( movementDirection === 'down' ) {
 			return sprintf(
+				// translators: 1: Type of block (i.e. Text, Image etc)
 				__( 'Block %1$s is at the end of the content and can’t be moved down' ),
 				type,
 			);
@@ -96,6 +96,7 @@ export function getBlockMoverDescription( selectedCount, type, firstIndex, isFir
 
 		if ( movementDirection === 'left' ) {
 			return sprintf(
+				// translators: 1: Type of block (i.e. Text, Image etc)
 				__( 'Block %1$s is at the end of the content and can’t be moved left' ),
 				type,
 			);
@@ -103,6 +104,7 @@ export function getBlockMoverDescription( selectedCount, type, firstIndex, isFir
 
 		if ( movementDirection === 'right' ) {
 			return sprintf(
+				// translators: 1: Type of block (i.e. Text, Image etc)
 				__( 'Block %1$s is at the end of the content and can’t be moved right' ),
 				type,
 			);
@@ -149,24 +151,24 @@ export function getBlockMoverDescription( selectedCount, type, firstIndex, isFir
 		const movementDirection = getMovementDirection( 'up' );
 
 		if ( movementDirection === 'up' ) {
-			// translators: 1: Type of block (i.e. Text, Image etc)
 			return sprintf(
+				// translators: 1: Type of block (i.e. Text, Image etc)
 				__( 'Block %1$s is at the beginning of the content and can’t be moved up' ),
 				type,
 			);
 		}
 
 		if ( movementDirection === 'left' ) {
-			// translators: 1: Type of block (i.e. Text, Image etc)
 			return sprintf(
+				// translators: 1: Type of block (i.e. Text, Image etc)
 				__( 'Block %1$s is at the beginning of the content and can’t be moved left' ),
 				type,
 			);
 		}
 
 		if ( movementDirection === 'right' ) {
-			// translators: 1: Type of block (i.e. Text, Image etc)
 			return sprintf(
+				// translators: 1: Type of block (i.e. Text, Image etc)
 				__( 'Block %1$s is at the beginning of the content and can’t be moved right' ),
 				type,
 			);

--- a/packages/block-editor/src/components/block-mover/mover-description.js
+++ b/packages/block-editor/src/components/block-mover/mover-description.js
@@ -49,47 +49,128 @@ export function getBlockMoverDescription( selectedCount, type, firstIndex, isFir
 
 	if ( dir > 0 && ! isLast ) {
 		// moving down
-		return sprintf(
-			// translators: 1: Type of block (i.e. Text, Image etc), 2: Position of selected block, 3: Direction of movement ( up, down, left, right ), 4: New position
-			__( 'Move %1$s block from position %2$d %3$s to position %4$d' ),
-			type,
-			position,
-			getMovementDirection( 'down' ),
-			( position + 1 ),
-		);
+		const movementDirection = getMovementDirection( 'down' );
+
+		if ( movementDirection === 'down' ) {
+			return sprintf(
+				// translators: 1: Type of block (i.e. Text, Image etc), 2: Position of selected block, 3: New position
+				__( 'Move %1$s block from position %2$d down to position %3$d' ),
+				type,
+				position,
+				( position + 1 ),
+			);
+		}
+
+		if ( movementDirection === 'left' ) {
+			return sprintf(
+				// translators: 1: Type of block (i.e. Text, Image etc), 2: Position of selected block, 3: New position
+				__( 'Move %1$s block from position %2$d left to position %3$d' ),
+				type,
+				position,
+				( position + 1 ),
+			);
+		}
+
+		if ( movementDirection === 'right' ) {
+			return sprintf(
+				// translators: 1: Type of block (i.e. Text, Image etc), 2: Position of selected block, 3: New position
+				__( 'Move %1$s block from position %2$d right to position %3$d' ),
+				type,
+				position,
+				( position + 1 ),
+			);
+		}
 	}
 
 	if ( dir > 0 && isLast ) {
 		// moving down, and is the last item
-		// translators: 1: Type of block (i.e. Text, Image etc), 2: Direction of movement ( up, down, left, right )
-		return sprintf(
-			__( 'Block %1$s is at the end of the content and can’t be moved %2$s' ),
-			type,
-			getMovementDirection( 'down' ),
+		// translators: 1: Type of block (i.e. Text, Image etc)
+		const movementDirection = getMovementDirection( 'down' );
 
-		);
+		if ( movementDirection === 'down' ) {
+			return sprintf(
+				__( 'Block %1$s is at the end of the content and can’t be moved down' ),
+				type,
+			);
+		}
+
+		if ( movementDirection === 'left' ) {
+			return sprintf(
+				__( 'Block %1$s is at the end of the content and can’t be moved left' ),
+				type,
+			);
+		}
+
+		if ( movementDirection === 'right' ) {
+			return sprintf(
+				__( 'Block %1$s is at the end of the content and can’t be moved right' ),
+				type,
+			);
+		}
 	}
 
 	if ( dir < 0 && ! isFirst ) {
 		// moving up
-		return sprintf(
-			// translators: 1: Type of block (i.e. Text, Image etc), 2: Position of selected block, 3: Direction of movement ( up, down, left, right ), 4: New position
-			__( 'Move %1$s block from position %2$d %3$s to position %4$d' ),
-			type,
-			position,
-			getMovementDirection( 'up' ),
-			( position - 1 ),
-		);
+		const movementDirection = getMovementDirection( 'up' );
+
+		if ( movementDirection === 'up' ) {
+			return sprintf(
+				// translators: 1: Type of block (i.e. Text, Image etc), 2: Position of selected block, 3: New position
+				__( 'Move %1$s block from position %2$d up to position %3$d' ),
+				type,
+				position,
+				( position - 1 ),
+			);
+		}
+
+		if ( movementDirection === 'left' ) {
+			return sprintf(
+				// translators: 1: Type of block (i.e. Text, Image etc), 2: Position of selected block, 3: New position
+				__( 'Move %1$s block from position %2$d left to position %3$d' ),
+				type,
+				position,
+				( position - 1 ),
+			);
+		}
+
+		if ( movementDirection === 'right' ) {
+			return sprintf(
+				// translators: 1: Type of block (i.e. Text, Image etc), 2: Position of selected block, 3: New position
+				__( 'Move %1$s block from position %2$d right to position %3$d' ),
+				type,
+				position,
+				( position - 1 ),
+			);
+		}
 	}
 
 	if ( dir < 0 && isFirst ) {
 		// moving up, and is the first item
-		// translators: 1: Type of block (i.e. Text, Image etc), 2: Direction of movement ( up, down, left, right )
-		return sprintf(
-			__( 'Block %1$s is at the beginning of the content and can’t be moved %2$s' ),
-			type,
-			getMovementDirection( 'up' ),
-		);
+		const movementDirection = getMovementDirection( 'up' );
+
+		if ( movementDirection === 'up' ) {
+			// translators: 1: Type of block (i.e. Text, Image etc)
+			return sprintf(
+				__( 'Block %1$s is at the beginning of the content and can’t be moved up' ),
+				type,
+			);
+		}
+
+		if ( movementDirection === 'left' ) {
+			// translators: 1: Type of block (i.e. Text, Image etc)
+			return sprintf(
+				__( 'Block %1$s is at the beginning of the content and can’t be moved left' ),
+				type,
+			);
+		}
+
+		if ( movementDirection === 'right' ) {
+			// translators: 1: Type of block (i.e. Text, Image etc)
+			return sprintf(
+				__( 'Block %1$s is at the beginning of the content and can’t be moved right' ),
+				type,
+			);
+		}
 	}
 }
 


### PR DESCRIPTION
## Description
Added conditions and translation strings for the directional words in screen reader labels. This addresses issue #19550 

## How has this been tested?
`npm run test` passed with zero failures. Unit tests check if the `getBlockMoverDescription` function returns the correct string when tested against various arguments.

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
