### PR TITLE
Fix: Media & Text: "Crop image to fill entire column" resets on image change

### DIFF
--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -102,7 +102,6 @@ class MediaTextEdit extends Component {
 			mediaUrl: src || media.url,
 			mediaLink: media.link || undefined,
 			href: newHref,
-			imageFill: undefined,
 			focalPoint: undefined,
 		} );
 	}


### PR DESCRIPTION
Fix: #18684

This issue was fixed in https://github.com/WordPress/gutenberg/pull/18729 but PR https://github.com/WordPress/gutenberg/pull/18139 reverted the change. I think the change was reverted during a merge. cc: @draganescu could you confirm if this PR is ok and that the reverting of the change was not intentional?

Props to @dianeco for reporting this issue.

How has this been tested?
I added a media and text block.
I enabled "Crop image to fill entire column".
I changed the image.
I verified "Crop image to fill entire column" option was still enabled.