### PR TITLE
Project Management: Fix pull request merge automation errors

### DIFF
--- a/.github/workflows/pull-request-automation.yml
+++ b/.github/workflows/pull-request-automation.yml
@@ -7,7 +7,7 @@ jobs:
   pull-request-automation:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
       # Changing into the action's directory and running `npm install` is much
       # faster than a full project-wide `npm ci`.
       - run: cd packages/project-management-automation && npm install

--- a/.github/workflows/pull-request-automation.yml
+++ b/.github/workflows/pull-request-automation.yml
@@ -7,7 +7,11 @@ jobs:
   pull-request-automation:
     runs-on: ubuntu-latest
     steps:
+      # Checkout defaults to using the branch which triggered the event, which
+      # isn't necessarily `master` (e.g. in the case of a merge).
       - uses: actions/checkout@v2
+        with:
+          ref: master
       # Changing into the action's directory and running `npm install` is much
       # faster than a full project-wide `npm ci`.
       - run: cd packages/project-management-automation && npm install


### PR DESCRIPTION
Previously: #19742 (specifically https://github.com/WordPress/gutenberg/pull/19742#issuecomment-576416175)
Related: https://github.com/actions/checkout/issues/136

This pull request seeks to resolve an issue where the GitHub Actions triggered in the merging of a pull request will currently error. This is caused by the specific handling of the [`actions/checkout` action](https://github.com/actions/checkout), where the default configuration is not sufficient for guaranteeing that the checked-out repository is that of the master branch. Instead, it's assumed to be checking out the branch of the merged pull request, which is not correct (and is causing the error):

>The branch, tag or SHA to checkout. **When checking out the repository that
>triggered a workflow, this defaults to the reference or SHA for that event.
>Otherwise, defaults to `master`.**

https://github.com/actions/checkout#usage (emphasis mine)

Also included is a change to use a specific version of `actions/checkout`, so that we don't find ourselves in a situation where a future breaking change would cause disruption to our workflows. To a lesser extent, this also helps clarify that this tag refers to the _version of the action_, not the branch being checked out.

**Testing Instructions:**

Verify that pull request automation associated with the pushed commit does not error.

Merge behavior can only be verified once the pull request is merged.