### PR TITLE
Block popover: allow scrolling over

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -85,6 +85,9 @@ $z-layers: (
 	// Above the block list, under the header.
 	".block-editor-block-list__block-popover": 29,
 
+	// Under the block popover (block toolbar).
+	".block-editor-block-list__insertion-point-popover": 28,
+
 	// Show snackbars above everything (similar to popovers)
 	".components-snackbar-list": 100000,
 

--- a/packages/block-editor/src/components/block-list/insertion-point.js
+++ b/packages/block-editor/src/components/block-list/insertion-point.js
@@ -122,7 +122,7 @@ export default function InsertionPoint( {
 			anchorRef={ inserterElement }
 			position="top right left"
 			focusOnMount={ false }
-			className="block-editor-block-list__block-popover"
+			className="block-editor-block-list__insertion-point-popover"
 			__unstableSlotName="block-toolbar"
 		>
 			<div className="block-editor-block-list__insertion-point" style={ { width: inserterElement.offsetWidth } }>

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -537,6 +537,18 @@
 	}
 }
 
+.block-editor-block-list__insertion-point-popover {
+	z-index: z-index(".block-editor-block-list__insertion-point-popover");
+	position: absolute;
+
+	.components-popover__content {
+		background: none;
+		border: none;
+		box-shadow: none;
+		overflow-y: visible;
+	}
+}
+
 .components-popover.block-editor-block-list__block-popover {
 	z-index: z-index(".block-editor-block-list__block-popover");
 	position: absolute;

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -539,6 +539,7 @@
 
 .components-popover.block-editor-block-list__block-popover {
 	z-index: z-index(".block-editor-block-list__block-popover");
+	position: absolute;
 
 	.components-popover__content {
 		margin: 0 !important;

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -257,7 +257,8 @@ const Popover = ( {
 			if ( ! containerRef.current || ! contentRef.current ) {
 				return;
 			}
-			const anchor = computeAnchorRect(
+
+			let anchor = computeAnchorRect(
 				anchorRefFallback,
 				anchorRect,
 				getAnchorRect,
@@ -273,6 +274,18 @@ const Popover = ( {
 				contentRect.current = contentRef.current.getBoundingClientRect();
 			}
 
+			const { offsetParent } = containerRef.current;
+
+			if ( offsetParent ) {
+				const offsetParentRect = offsetParent.getBoundingClientRect();
+				anchor = new window.DOMRect(
+					anchor.left - offsetParentRect.left,
+					anchor.top - offsetParentRect.top,
+					anchor.width,
+					anchor.height
+				);
+			}
+
 			const {
 				popoverTop,
 				popoverLeft,
@@ -280,7 +293,7 @@ const Popover = ( {
 				yAxis,
 				contentHeight,
 				contentWidth,
-			} = computePopoverPosition( anchor, contentRect.current, position, __unstableSticky, anchorRef );
+			} = computePopoverPosition( anchor, contentRect.current, position, __unstableSticky, anchorRef, containerRef.current );
 
 			if ( typeof popoverTop === 'number' && typeof popoverLeft === 'number' ) {
 				if ( subpixels && __unstableAllowVerticalSubpixelPosition ) {

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -275,9 +275,12 @@ const Popover = ( {
 			}
 
 			const { offsetParent } = containerRef.current;
+			let relativeOffsetTop = 0;
 
 			if ( offsetParent ) {
 				const offsetParentRect = offsetParent.getBoundingClientRect();
+
+				relativeOffsetTop = offsetParentRect.top;
 				anchor = new window.DOMRect(
 					anchor.left - offsetParentRect.left,
 					anchor.top - offsetParentRect.top,
@@ -293,7 +296,7 @@ const Popover = ( {
 				yAxis,
 				contentHeight,
 				contentWidth,
-			} = computePopoverPosition( anchor, contentRect.current, position, __unstableSticky, anchorRef, containerRef.current );
+			} = computePopoverPosition( anchor, contentRect.current, position, __unstableSticky, anchorRef, relativeOffsetTop );
 
 			if ( typeof popoverTop === 'number' && typeof popoverLeft === 'number' ) {
 				if ( subpixels && __unstableAllowVerticalSubpixelPosition ) {

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -278,7 +278,9 @@ const Popover = ( {
 			let relativeOffsetTop = 0;
 
 			// If there is a positioned ancestor element that is not the body,
-			// subtract the position from the anchor rect.
+			// subtract the position from the anchor rect. If the position of
+			// the popover is fixed, the offset parent is null or the body
+			// element, in which case the position is relative to the viewport.
 			// See https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetParent
 			if ( offsetParent && offsetParent !== ownerDocument.body ) {
 				const offsetParentRect = offsetParent.getBoundingClientRect();

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -274,10 +274,13 @@ const Popover = ( {
 				contentRect.current = contentRef.current.getBoundingClientRect();
 			}
 
-			const { offsetParent } = containerRef.current;
+			const { offsetParent, ownerDocument } = containerRef.current;
 			let relativeOffsetTop = 0;
 
-			if ( offsetParent ) {
+			// If there is a positioned ancestor element that is not the body,
+			// subtract the position from the anchor rect.
+			// See https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetParent
+			if ( offsetParent && offsetParent !== ownerDocument.body ) {
 				const offsetParentRect = offsetParent.getBoundingClientRect();
 
 				relativeOffsetTop = offsetParentRect.top;

--- a/packages/components/src/popover/utils.js
+++ b/packages/components/src/popover/utils.js
@@ -111,19 +111,20 @@ export function computePopoverXAxisPosition( anchorRect, contentSize, xAxis, cor
 /**
  * Utility used to compute the popover position over the yAxis
  *
- * @param {Object}  anchorRect  Anchor Rect.
- * @param {Object}  contentSize Content Size.
- * @param {string}  yAxis       Desired yAxis.
- * @param {string}  corner      Desired corner.
- * @param {boolean} sticky      Whether or not to stick the popover to the
- *                              scroll container edge when part of the anchor
- *                              leaves view.
- * @param {Element} anchorRef   The anchor element.
- * @param {Element} containerRef
+ * @param {Object}  anchorRect        Anchor Rect.
+ * @param {Object}  contentSize       Content Size.
+ * @param {string}  yAxis             Desired yAxis.
+ * @param {string}  corner            Desired corner.
+ * @param {boolean} sticky            Whether or not to stick the popover to the
+ *                                    scroll container edge when part of the
+ *                                    anchor leaves view.
+ * @param {Element} anchorRef         The anchor element.
+ * @param {Element} relativeOffsetTop If applicable, top offset of the relative
+ *                                    positioned parent container.
  *
  * @return {Object} Popover xAxis position and constraints.
  */
-export function computePopoverYAxisPosition( anchorRect, contentSize, yAxis, corner, sticky, anchorRef, containerRef ) {
+export function computePopoverYAxisPosition( anchorRect, contentSize, yAxis, corner, sticky, anchorRef, relativeOffsetTop ) {
 	const { height } = contentSize;
 
 	if ( sticky ) {
@@ -140,34 +141,14 @@ export function computePopoverYAxisPosition( anchorRect, contentSize, yAxis, cor
 		}
 
 		const scrollContainerEl = getScrollContainer( topEl ) || document.body;
-		let scrollRect = scrollContainerEl.getBoundingClientRect();
+		const scrollRect = scrollContainerEl.getBoundingClientRect();
 		const topRect = topEl.getBoundingClientRect();
-		let bottomRect = bottomEl.getBoundingClientRect();
+		const bottomRect = bottomEl.getBoundingClientRect();
 
 		if ( topRect.top - height <= scrollRect.top ) {
-			const { offsetParent } = containerRef;
-
-			if ( offsetParent ) {
-				const offsetParentRect = offsetParent.getBoundingClientRect();
-
-				scrollRect = new window.DOMRect(
-					scrollRect.left - offsetParentRect.left,
-					scrollRect.top - offsetParentRect.top,
-					scrollRect.width,
-					scrollRect.height
-				);
-
-				bottomRect = new window.DOMRect(
-					bottomRect.left - offsetParentRect.left,
-					bottomRect.top - offsetParentRect.top,
-					bottomRect.width,
-					bottomRect.height
-				);
-			}
-
 			return {
 				yAxis,
-				popoverTop: Math.min( bottomRect.bottom, scrollRect.top + height ),
+				popoverTop: Math.min( bottomRect.bottom - relativeOffsetTop, scrollRect.top + height - relativeOffsetTop ),
 			};
 		}
 	}
@@ -233,24 +214,25 @@ export function computePopoverYAxisPosition( anchorRect, contentSize, yAxis, cor
 }
 
 /**
- * Utility used to compute the popover position and the content max width/height for a popover
- * given its anchor rect and its content size.
+ * Utility used to compute the popover position and the content max width/height
+ * for a popover given its anchor rect and its content size.
  *
- * @param {Object}  anchorRect  Anchor Rect.
- * @param {Object}  contentSize Content Size.
- * @param {string}  position    Position.
- * @param {boolean} sticky      Whether or not to stick the popover to the
- *                              scroll container edge when part of the anchor
- *                              leaves view.
- * @param {Element} anchorRef   The anchor element.
- * @param {Element} containerRef
+ * @param {Object}  anchorRect        Anchor Rect.
+ * @param {Object}  contentSize       Content Size.
+ * @param {string}  position          Position.
+ * @param {boolean} sticky            Whether or not to stick the popover to the
+ *                                    scroll container edge when part of the
+ *                                    anchor leaves view.
+ * @param {Element} anchorRef         The anchor element.
+ * @param {number}  relativeOffsetTop If applicable, top offset of the relative
+ *                                    positioned parent container.
  *
  * @return {Object} Popover position and constraints.
  */
-export function computePopoverPosition( anchorRect, contentSize, position = 'top', sticky, anchorRef, containerRef ) {
+export function computePopoverPosition( anchorRect, contentSize, position = 'top', sticky, anchorRef, relativeOffsetTop ) {
 	const [ yAxis, xAxis = 'center', corner ] = position.split( ' ' );
 
-	const yAxisPosition = computePopoverYAxisPosition( anchorRect, contentSize, yAxis, corner, sticky, anchorRef, containerRef );
+	const yAxisPosition = computePopoverYAxisPosition( anchorRect, contentSize, yAxis, corner, sticky, anchorRef, relativeOffsetTop );
 	const xAxisPosition = computePopoverXAxisPosition( anchorRect, contentSize, xAxis, corner, sticky, yAxisPosition.yAxis );
 
 	return {

--- a/packages/components/src/popover/utils.js
+++ b/packages/components/src/popover/utils.js
@@ -119,10 +119,11 @@ export function computePopoverXAxisPosition( anchorRect, contentSize, xAxis, cor
  *                              scroll container edge when part of the anchor
  *                              leaves view.
  * @param {Element} anchorRef   The anchor element.
+ * @param {Element} containerRef
  *
  * @return {Object} Popover xAxis position and constraints.
  */
-export function computePopoverYAxisPosition( anchorRect, contentSize, yAxis, corner, sticky, anchorRef ) {
+export function computePopoverYAxisPosition( anchorRect, contentSize, yAxis, corner, sticky, anchorRef, containerRef ) {
 	const { height } = contentSize;
 
 	if ( sticky ) {
@@ -139,11 +140,31 @@ export function computePopoverYAxisPosition( anchorRect, contentSize, yAxis, cor
 		}
 
 		const scrollContainerEl = getScrollContainer( topEl ) || document.body;
-		const scrollRect = scrollContainerEl.getBoundingClientRect();
+		let scrollRect = scrollContainerEl.getBoundingClientRect();
 		const topRect = topEl.getBoundingClientRect();
-		const bottomRect = bottomEl.getBoundingClientRect();
+		let bottomRect = bottomEl.getBoundingClientRect();
 
 		if ( topRect.top - height <= scrollRect.top ) {
+			const { offsetParent } = containerRef;
+
+			if ( offsetParent ) {
+				const offsetParentRect = offsetParent.getBoundingClientRect();
+
+				scrollRect = new window.DOMRect(
+					scrollRect.left - offsetParentRect.left,
+					scrollRect.top - offsetParentRect.top,
+					scrollRect.width,
+					scrollRect.height
+				);
+
+				bottomRect = new window.DOMRect(
+					bottomRect.left - offsetParentRect.left,
+					bottomRect.top - offsetParentRect.top,
+					bottomRect.width,
+					bottomRect.height
+				);
+			}
+
 			return {
 				yAxis,
 				popoverTop: Math.min( bottomRect.bottom, scrollRect.top + height ),
@@ -222,13 +243,14 @@ export function computePopoverYAxisPosition( anchorRect, contentSize, yAxis, cor
  *                              scroll container edge when part of the anchor
  *                              leaves view.
  * @param {Element} anchorRef   The anchor element.
+ * @param {Element} containerRef
  *
  * @return {Object} Popover position and constraints.
  */
-export function computePopoverPosition( anchorRect, contentSize, position = 'top', sticky, anchorRef ) {
+export function computePopoverPosition( anchorRect, contentSize, position = 'top', sticky, anchorRef, containerRef ) {
 	const [ yAxis, xAxis = 'center', corner ] = position.split( ' ' );
 
-	const yAxisPosition = computePopoverYAxisPosition( anchorRect, contentSize, yAxis, corner, sticky, anchorRef );
+	const yAxisPosition = computePopoverYAxisPosition( anchorRect, contentSize, yAxis, corner, sticky, anchorRef, containerRef );
 	const xAxisPosition = computePopoverXAxisPosition( anchorRect, contentSize, xAxis, corner, sticky, yAxisPosition.yAxis );
 
 	return {

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -108,7 +108,6 @@ function Layout() {
 					content={
 						<>
 							<EditorNotices />
-							<Popover.Slot name="block-toolbar" />
 							{ ( mode === 'text' || ! isRichEditingEnabled ) && <TextEditor /> }
 							{ isRichEditingEnabled && mode === 'visual' && <VisualEditor /> }
 							<div className="edit-post-layout__metaboxes">

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -16,6 +16,7 @@ import {
 	__experimentalBlockSettingsMenuFirstItem,
 	__experimentalBlockSettingsMenuPluginsExtension,
 } from '@wordpress/block-editor';
+import { Popover } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -28,6 +29,7 @@ function VisualEditor() {
 		<BlockSelectionClearer className="edit-post-visual-editor editor-styles-wrapper">
 			<VisualEditorGlobalKeyboardShortcuts />
 			<MultiSelectScrollIntoView />
+			<Popover.Slot name="block-toolbar" />
 			<Typewriter>
 				<WritingFlow>
 					<ObserveTyping>


### PR DESCRIPTION
## Description

This bug has been in 7.2 but has gotten worse since the sibling inserter is now also a popover. I believe it should be fixed for 7.3.

This is an attempt to fix scrolling over the block popovers. Currently, if you have the pointer above a block popover (e.g. the contextual toolbar), the page won't scroll. This is because the popover's position is fixed (which is always relative to the viewport) and it can be solved by setting the position to absolute. This has to be relative to an element positioned within the scroll container.

This needs to adjustment within popover so the popover positions properly relative to the the offset parent.

One advantage of the relative positioning is that no position updates are required on scroll:

![no-dom-updates](https://user-images.githubusercontent.com/4710635/72783982-05176880-3c28-11ea-9b05-8cf3dc7c641e.gif)

Previously this would continuously update on scroll.

Also moves the inserter under the block toolbar. It shouldn't overlap the block toolbar.

## How has this been tested?

Move the pointer over the block toolbar and try to scroll the page.

## Screenshots <!-- if applicable -->

## Types of changes

Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
