### PR TITLE
Build: Include JSON files in zip archive

### DIFF
--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -109,7 +109,7 @@ npm run build
 php bin/generate-gutenberg-php.php > gutenberg.tmp.php
 mv gutenberg.tmp.php gutenberg.php
 
-build_files=$(ls build/*/*.{js,css,asset.php} build/block-library/blocks/*.php)
+build_files=$(ls build/*/*.{js,json,css,asset.php} build/block-library/blocks/*.php)
 
 # Generate the plugin zip file.
 status "Creating archive... 🎁"

--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -109,7 +109,7 @@ npm run build
 php bin/generate-gutenberg-php.php > gutenberg.tmp.php
 mv gutenberg.tmp.php gutenberg.php
 
-build_files=$(ls build/*/*.{js,json,css,asset.php} build/block-library/blocks/*.php)
+build_files=$(ls build/*/*.{js,css,asset.php} build/block-library/blocks/*.{php,json})
 
 # Generate the plugin zip file.
 status "Creating archive... 🎁"


### PR DESCRIPTION
## Description

Tentative fix for #19770.

In the zip archive built by `bin/build-plugin-zip.sh`, include JSON files found in the `build/` directory.

Question: Is this casting too wide a net, i.e. including JSON files that we don't want/need to include?

## How has this been tested?
Hasn't yet :grimacing: 

## Screenshots <!-- if applicable -->

## Types of changes

See above.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
