### PR TITLE
[Mobile] Disable gallery size options on mobile

### DIFF
--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -339,7 +339,11 @@ class GalleryEdit extends Component {
 			return mediaPlaceholder;
 		}
 
-		const imageSizeOptions = this.getImagesSizeOptions();
+		// disable image size options on mobile for now
+		const imageSizeOptions = Platform.select( {
+			web: this.getImagesSizeOptions(),
+			native: [],
+		} );
 
 		return (
 			<>


### PR DESCRIPTION
**Note:**

This PR _can_ be merged into the `v1.20.1` branch. The `v1.20.1` branch does not need to be merged. Its purpose is for the v1.20.1 hotfix only, and that branch can be deleted. The release tag should be created from this branch, since this repository does not allow merge commits (so we will not get a clean fast-forward). For `v1.21.0`, simply omitting this PR will leave the options enabled, but a small fix is needed to show labels correctly, and this should be tested and get some design approval (the reason for not including this in the hotfix).

### Related PRs:

`gutenberg-mobile` (hotfix): https://github.com/wordpress-mobile/gutenberg-mobile/pull/1794
`WordPress-Android`: https://github.com/wordpress-mobile/WordPress-Android/pull/11120
`WordPress-iOS`: https://github.com/wordpress-mobile/WordPress-iOS/pull/13252

## Description
This PR disables the gallery image size options on mobile. We can re-enable them after we've verified / implemented the desired behavior for mobile.

## How has this been tested?

Tested on iOS via WordPress-iOS.

Steps:

* Create a gallery block with some images
* Tap the gallery
* Tap the gallery settings icon (the gear)

Expected result:

The image size option should not be visible in the menu.

## Screenshots <!-- if applicable -->

## Types of changes
This uses the `Platform.select` function to provide an empty array of image size options on mobile, leaving web implementation unchanged. There is already logic in place to hide the option when the array is empty, so this is sufficient to hide the option on mobile.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
