### PR TITLE
Multi select: keep selection after move

### DIFF
--- a/packages/block-editor/src/components/block-list/use-multi-selection.js
+++ b/packages/block-editor/src/components/block-list/use-multi-selection.js
@@ -147,7 +147,7 @@ export default function useMultiSelection( ref ) {
 		selectedBlockClientId,
 	] );
 
-	const onSelectionChange = useCallback( () => {
+	const onSelectionChange = useCallback( ( { isFinal } ) => {
 		const selection = window.getSelection();
 
 		// If no selection is found, end multi selection.
@@ -159,6 +159,20 @@ export default function useMultiSelection( ref ) {
 
 		if ( startClientId.current === clientId ) {
 			selectBlock( clientId );
+
+			if ( isFinal ) {
+				toggleRichText( ref.current, true );
+
+				// If the anchor element contains the selection, set focus back to
+				// the anchor element.
+				if ( selection.rangeCount ) {
+					const { commonAncestorContainer } = selection.getRangeAt( 0 );
+
+					if ( anchorElement.current.contains( commonAncestorContainer ) ) {
+						anchorElement.current.focus();
+					}
+				}
+			}
 		} else {
 			const startPath = [ ...getBlockParents( startClientId.current ), startClientId.current ];
 			const endPath = [ ...getBlockParents( clientId ), clientId ];
@@ -178,21 +192,8 @@ export default function useMultiSelection( ref ) {
 		// The browser selection won't have updated yet at this point, so wait
 		// until the next animation frame to get the browser selection.
 		rafId.current = window.requestAnimationFrame( () => {
-			onSelectionChange();
+			onSelectionChange( { isFinal: true } );
 			stopMultiSelect();
-			toggleRichText( ref.current, true );
-
-			const selection = window.getSelection();
-
-			// If the anchor element contains the selection, set focus back to
-			// the anchor element.
-			if ( selection.rangeCount ) {
-				const { commonAncestorContainer } = selection.getRangeAt( 0 );
-
-				if ( anchorElement.current.contains( commonAncestorContainer ) ) {
-					anchorElement.current.focus();
-				}
-			}
 		} );
 	}, [ onSelectionChange, stopMultiSelect ] );
 

--- a/packages/block-editor/src/components/block-list/use-multi-selection.js
+++ b/packages/block-editor/src/components/block-list/use-multi-selection.js
@@ -147,7 +147,7 @@ export default function useMultiSelection( ref ) {
 		selectedBlockClientId,
 	] );
 
-	const onSelectionChange = useCallback( ( { isFinal } ) => {
+	const onSelectionChange = useCallback( ( { isSelectionEnd } ) => {
 		const selection = window.getSelection();
 
 		// If no selection is found, end multi selection.
@@ -156,15 +156,19 @@ export default function useMultiSelection( ref ) {
 		}
 
 		const clientId = getBlockClientId( selection.focusNode );
+		const isSingularSelection = startClientId.current === clientId;
 
-		if ( startClientId.current === clientId ) {
+		if ( isSingularSelection ) {
 			selectBlock( clientId );
 
-			if ( isFinal ) {
+			// If the selection is complete (on mouse up), and no multiple
+			// blocks have been selected, set focus back to the anchor element
+			// if the anchor element contains the selection. Additionally, rich
+			// text elements that were previously disabled can now be enabled
+			// again.
+			if ( isSelectionEnd ) {
 				toggleRichText( ref.current, true );
 
-				// If the anchor element contains the selection, set focus back to
-				// the anchor element.
 				if ( selection.rangeCount ) {
 					const { commonAncestorContainer } = selection.getRangeAt( 0 );
 
@@ -192,7 +196,7 @@ export default function useMultiSelection( ref ) {
 		// The browser selection won't have updated yet at this point, so wait
 		// until the next animation frame to get the browser selection.
 		rafId.current = window.requestAnimationFrame( () => {
-			onSelectionChange( { isFinal: true } );
+			onSelectionChange( { isSelectionEnd: true } );
 			stopMultiSelect();
 		} );
 	}, [ onSelectionChange, stopMultiSelect ] );

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/multi-block-selection.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/multi-block-selection.test.js.snap
@@ -52,7 +52,7 @@ exports[`Multi-block selection should only trigger multi-selection when at the e
 <!-- /wp:paragraph -->"
 `;
 
-exports[`Multi-block selection should preserve selection on move 1`] = `
+exports[`Multi-block selection should preserve dragged selection on move 1`] = `
 "<!-- wp:paragraph -->
 <p>2</p>
 <!-- /wp:paragraph -->

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/multi-block-selection.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/multi-block-selection.test.js.snap
@@ -52,6 +52,20 @@ exports[`Multi-block selection should only trigger multi-selection when at the e
 <!-- /wp:paragraph -->"
 `;
 
+exports[`Multi-block selection should preserve selection on move 1`] = `
+"<!-- wp:paragraph -->
+<p>2</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>3</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>1</p>
+<!-- /wp:paragraph -->"
+`;
+
 exports[`Multi-block selection should return original focus after failed multi selection attempt 1`] = `
 "<!-- wp:paragraph -->
 <p>2</p>

--- a/packages/e2e-tests/specs/editor/various/multi-block-selection.test.js
+++ b/packages/e2e-tests/specs/editor/various/multi-block-selection.test.js
@@ -7,6 +7,7 @@ import {
 	pressKeyWithModifier,
 	pressKeyTimes,
 	getEditedPostContent,
+	clickBlockToolbarButton,
 } from '@wordpress/e2e-test-utils';
 
 async function getSelectedFlatIndices() {
@@ -405,6 +406,26 @@ describe( 'Multi-block selection', () => {
 
 		// Only "1" should be deleted.
 		await page.keyboard.press( 'Backspace' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'should preserve selection on move', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( '1' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '2' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '3' );
+		await pressKeyWithModifier( 'shift', 'ArrowUp' );
+
+		await testNativeSelection();
+		expect( await getSelectedFlatIndices() ).toEqual( [ 2, 3 ] );
+
+		await clickBlockToolbarButton( 'Move up' );
+
+		await testNativeSelection();
+		expect( await getSelectedFlatIndices() ).toEqual( [ 1, 2 ] );
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );

--- a/packages/e2e-tests/specs/editor/various/multi-block-selection.test.js
+++ b/packages/e2e-tests/specs/editor/various/multi-block-selection.test.js
@@ -410,14 +410,34 @@ describe( 'Multi-block selection', () => {
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 
-	it( 'should preserve selection on move', async () => {
+	it( 'should preserve dragged selection on move', async () => {
 		await clickBlockAppender();
 		await page.keyboard.type( '1' );
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( '2' );
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( '3' );
-		await pressKeyWithModifier( 'shift', 'ArrowUp' );
+
+		const [ coord1, coord2 ] = await page.evaluate( () => {
+			const elements = Array.from( document.querySelectorAll( '.wp-block-paragraph' ) );
+			const rect1 = elements[ 2 ].getBoundingClientRect();
+			const rect2 = elements[ 1 ].getBoundingClientRect();
+			return [
+				{
+					x: rect1.x + ( rect1.width / 2 ),
+					y: rect1.y + ( rect1.height / 2 ),
+				},
+				{
+					x: rect2.x + ( rect2.width / 2 ),
+					y: rect2.y + ( rect2.height / 2 ),
+				},
+			];
+		} );
+
+		await page.mouse.move( coord1.x, coord1.y );
+		await page.mouse.down();
+		await page.mouse.move( coord2.x, coord2.y );
+		await page.mouse.up();
 
 		await testNativeSelection();
 		expect( await getSelectedFlatIndices() ).toEqual( [ 2, 3 ] );


### PR DESCRIPTION
## Description

Fixes #19807.

Since #19720, selection is cleared after moving a multi block selection. Unfortunately, there was no e2e test to check the behaviour. I'll add an e2e test in this PR.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
