### PR TITLE
Build: Include block.json files in the build output

### DIFF
--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -109,7 +109,7 @@ npm run build
 php bin/generate-gutenberg-php.php > gutenberg.tmp.php
 mv gutenberg.tmp.php gutenberg.php
 
-build_files=$(ls build/*/*.{js,css,asset.php} build/block-library/blocks/*.{php,json})
+build_files=$(ls build/*/*.{js,css,asset.php} build/block-library/blocks/*.php build/block-library/blocks/*/block.json)
 
 # Generate the plugin zip file.
 status "Creating archive... 🎁"

--- a/packages/block-library/src/shortcode/index.php
+++ b/packages/block-library/src/shortcode/index.php
@@ -21,13 +21,15 @@ function render_block_core_shortcode( $attributes, $content ) {
  * Registers the `core/shortcode` block on server.
  */
 function register_block_core_shortcode() {
-	$path     = __DIR__ . '/shortcode.json';
+	$path     = __DIR__ . '/shortcode/block.json';
 	$metadata = json_decode( file_get_contents( $path ), true );
 	register_block_type(
-		'core/shortcode',
-		array(
-			'attributes'      => $metadata['attributes'],
-			'render_callback' => 'render_block_core_shortcode',
+		$metadata['name'],
+		array_merge(
+			$metadata,
+			array(
+				'render_callback' => 'render_block_core_shortcode',
+			)
 		)
 	);
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -153,12 +153,10 @@ module.exports = {
 						.replace( /(add_action\(\s*'init',\s*'gutenberg_register_block_[^']+'(?!,))/, '$1, 20' );
 				},
 			},
-		] ),
-		new CopyWebpackPlugin( [
 			{
-				from: './packages/block-library/src/+(shortcode)/block.json',
+				from: './packages/block-library/src/*/block.json',
 				test: new RegExp( `([\\w-]+)${ escapeRegExp( sep ) }block\\.json$` ),
-				to: 'build/block-library/blocks/[1].json',
+				to: 'build/block-library/blocks/[1]/block.json',
 			},
 		] ),
 		new DependencyExtractionWebpackPlugin( { injectPolyfill: true } ),


### PR DESCRIPTION
## Description
The comment from @chipsnyder from WordPress Track (https://core.trac.wordpress.org/ticket/49196#comment:9):

> @gziolo I like the approach here better. I think it makes the references more clear by moving the blocks to their respective folders.
> 
> If we go with this approach, we'll need to make a few changes back in Gutenberg as well. 
> 
> 1) Update the copy of the PHP files to be in nested folders https://github.com/WordPress/gutenberg/blob/master/webpack.config.js#L120-L122
> 
> 2) Update the copy of the JSON files to be in nested folders https://github.com/WordPress/gutenberg/blob/master/webpack.config.js#L155-L157 (Or consolidate with step 1)
> 
> 3) Update the JSON reference in shortcode https://github.com/WordPress/gutenberg/blob/master/packages/block-library/src/shortcode/index.php#L24
> 
> 4) Update the references to the PHP files. This is the step I wasn't sure about before and what had me hesitant about taking in on as part of the shortcode PR. I think that this is the only place we would need to make that update though https://github.com/WordPress/gutenberg/blob/eeb13f45a4f890179cfc9b0203f4019eb4d19f41/lib/blocks.php#L41-L62 
> 
> 5) Update the build script for zipping plugins https://github.com/WordPress/gutenberg/blob/master/bin/build-plugin-zip.sh#L112
> 
> These are probably pretty straight forward changes now that I'm learning more about how the project organized. There might be another step in there that I'm not aware of yet. I'm happy to work with you to get those done.

## How has this been tested?
Dynamic blocks should work as before in the block editor. In particular, the Shortcode block should still work properly.

## Types of changes
Refactoring - everything should work as before but `block.json` files should be exposed in the plugin package.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
