### PR TITLE
Fix image not using its intrisinsic size by default

### DIFF
--- a/packages/block-library/src/image/block.json
+++ b/packages/block-library/src/image/block.json
@@ -56,6 +56,12 @@
 		"height": {
 			"type": "number"
 		},
+		"imageWidth": {
+			"type": "number"
+		},
+		"imageHeight": {
+			"type": "number"
+		},
 		"sizeSlug": {
 			"type": "string"
 		},

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -64,7 +64,7 @@ import {
 } from './constants';
 
 export const pickRelevantMediaFiles = ( image ) => {
-	const imageProps = pick( image, [ 'alt', 'id', 'link', 'caption' ] );
+	const imageProps = pick( image, [ 'alt', 'id', 'link', 'caption', 'width', 'height' ] );
 	imageProps.url = get( image, [ 'sizes', 'large', 'url' ] ) || get( image, [ 'media_details', 'sizes', 'large', 'source_url' ] ) || image.url;
 	return imageProps;
 };
@@ -192,6 +192,8 @@ export class ImageEdit extends Component {
 			additionalAttributes = {
 				width: undefined,
 				height: undefined,
+				imageWidth: mediaAttributes.width,
+				imageHeight: mediaAttributes.height,
 				sizeSlug: DEFAULT_SIZE_SLUG,
 			};
 		} else {

--- a/packages/block-library/src/image/save.js
+++ b/packages/block-library/src/image/save.js
@@ -20,6 +20,8 @@ export default function save( { attributes } ) {
 		linkClass,
 		width,
 		height,
+		imageWidth,
+		imageHeight,
 		id,
 		linkTarget,
 		sizeSlug,
@@ -39,8 +41,8 @@ export default function save( { attributes } ) {
 			src={ url }
 			alt={ alt }
 			className={ id ? `wp-image-${ id }` : null }
-			width={ width }
-			height={ height }
+			width={ width || imageWidth }
+			height={ height || imageHeight }
 			title={ title }
 		/>
 	);


### PR DESCRIPTION
## Description
This PR adds a couple new attributes to the image block where it saves the instrinsic size of the image. In case the user hasn't set an explicit width/height, those will be used, preventing the content from jumping around as images get loaded (https://youtu.be/4-d_SoCHeWE).

Closes #6652.

## How has this been tested?
Not much. Only tried adding images from the library and it seems to work fine. I'm not super familiar with everything in core so take this as a PoC that'll need to be improved to meet the standards.

## Screenshots <!-- if applicable -->

## Types of changes
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
