### PR TITLE
Fix SelectControl example code synax highlight

### DIFF
--- a/packages/components/src/select-control/README.md
+++ b/packages/components/src/select-control/README.md
@@ -81,38 +81,42 @@ Use sentences in your menu.
 
 Render a user interface to select the size of an image.
 
-    import { SelectControl } from '@wordpress/components';
-    import { withState } from '@wordpress/compose';
+```jsx
+import { SelectControl } from '@wordpress/components';
+import { withState } from '@wordpress/compose';
 
-    const MySelectControl = withState( {
-        size: '50%',
-    } )( ( { size, setState } ) => (
-        <SelectControl
-            label="Size"
-            value={ size }
-            options={ [
-                { label: 'Big', value: '100%' },
-                { label: 'Medium', value: '50%' },
-                { label: 'Small', value: '25%' },
-            ] }
-            onChange={ ( size ) => { setState( { size } ) } }
-        />
-    ) );
+const MySelectControl = withState( {
+    size: '50%',
+} )( ( { size, setState } ) => (
+    <SelectControl
+        label="Size"
+        value={ size }
+        options={ [
+            { label: 'Big', value: '100%' },
+            { label: 'Medium', value: '50%' },
+            { label: 'Small', value: '25%' },
+        ] }
+        onChange={ ( size ) => { setState( { size } ) } }
+    />
+) );
+```
 
 Render a user interface to select multiple users from a list.
 
-        <SelectControl
-            multiple
-            label={ __( 'Select some users:' ) }
-            value={ this.state.users } // e.g: value = [ 'a', 'c' ]
-            onChange={ ( users ) => { this.setState( { users } ) } }
-            options={ [
-                { value: null, label: 'Select a User', disabled: true },
-                { value: 'a', label: 'User A' },
-                { value: 'b', label: 'User B' },
-                { value: 'c', label: 'User c' },
-            ] }
-        />
+```jsx
+<SelectControl
+    multiple
+    label={ __( 'Select some users:' ) }
+    value={ this.state.users } // e.g: value = [ 'a', 'c' ]
+    onChange={ ( users ) => { this.setState( { users } ) } }
+    options={ [
+        { value: null, label: 'Select a User', disabled: true },
+        { value: 'a', label: 'User A' },
+        { value: 'b', label: 'User B' },
+        { value: 'c', label: 'User c' },
+    ] }
+/>
+```
 
 ### Props
 


### PR DESCRIPTION
## Description
This PR add missing language identifier to SelectControl component's example usage code.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
