### PR TITLE
Avoid triggering WritingFlow when the containing element is aria-hidden

### DIFF
--- a/packages/block-editor/src/components/writing-flow/index.js
+++ b/packages/block-editor/src/components/writing-flow/index.js
@@ -306,6 +306,16 @@ export default function WritingFlow( { children } ) {
 	}
 
 	function onKeyDown( event ) {
+		// If the writing flow component is inside a parent that is hidden to
+		// assistive technologies, ignore the event. This typically happens
+		// when a modal is opened and `aria-hidden` is applied to an element
+		// wrapping this one. When that happens, keyboard input events (like
+		// those handled here) that change the focus can cause a modal to close
+		// unexpectedly. Returning early avoids that.
+		if ( container.current && container.current.closest( '[aria-hidden]' ) ) {
+			return;
+		}
+
 		const { keyCode, target } = event;
 		const isUp = keyCode === UP;
 		const isDown = keyCode === DOWN;


### PR DESCRIPTION
## Description
Extracted from PR #18014

There's an issue that occurs in live/master with the Block Navigator in the Navigation Block. When this modal is open, if you use arrow-keys, the modal closes instantly.

What's happening is that the `WritingFlow` component's `onKeyDown` event is being triggered. It thinks the user is navigating around or between blocks and causes a change of focus. That change of focus closes the modal.

One solution would be for the modal to `preventDefault` on arrow key navigation. But this is a very specific problem that only occurs when a modal is launched from a block. It'd mean sprinkling this kind of code on every modal implemented as part of a block.

Instead, I think this is really a bug with WritingFlow—it shouldn't be handling key events when it's in the background/aria-hidden. This PR adds an `if` statement that returns early from the `onKeyDown` event if one of `WritingFlow`'s parents is `aria-hidden`, which is what happens when a modal is opened.

## How has this been tested?
Test this using PR #18014

1. Add a navigation block
2. Open the Block Navigator from the navigation block's toolbar
3. Press an arrow key
4. Observe that the Block Navigator modal should stay open
5. Close the modal
6. Add a few more blocks
7. Navigate between them using arrow keys
8. Observe that navigation continues to work as before
9. Press escape to enter navigation mode
10. Use arrow keys to navigate up and down between blocks
11. Observe that this continues to work.

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue) 
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
