### PR TITLE
Bundle the icons package instead of using it as an external

### DIFF
--- a/packages/components/src/circular-option-picker/index.js
+++ b/packages/components/src/circular-option-picker/index.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { __experimentalIcon as Icon, check } from '@wordpress/icons';
+import { Icon, check } from '@wordpress/icons';
 
 /**
  * Internal dependencies

--- a/packages/components/src/color-palette/test/__snapshots__/index.js.snap
+++ b/packages/components/src/color-palette/test/__snapshots__/index.js.snap
@@ -321,9 +321,6 @@ exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
           <Icon
             icon={
               <SVG
-                aria-hidden={true}
-                focusable="false"
-                role="img"
                 viewBox="-2 -2 24 24"
                 xmlns="http://www.w3.org/2000/svg"
               >
@@ -334,10 +331,7 @@ exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
             }
           >
             <SVG
-              aria-hidden={true}
-              focusable="false"
               height={24}
-              role="img"
               viewBox="-2 -2 24 24"
               width={24}
               xmlns="http://www.w3.org/2000/svg"

--- a/packages/components/src/custom-select-control/index.js
+++ b/packages/components/src/custom-select-control/index.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { __experimentalIcon as Icon, check } from '@wordpress/icons';
+import { Icon, check } from '@wordpress/icons';
 /**
  * Internal dependencies
  */

--- a/packages/dependency-extraction-webpack-plugin/util.js
+++ b/packages/dependency-extraction-webpack-plugin/util.js
@@ -1,4 +1,5 @@
 const WORDPRESS_NAMESPACE = '@wordpress/';
+const BUNDLED_PACKAGES = '@wordpress/icons';
 
 /**
  * Default request to global transformation
@@ -32,6 +33,10 @@ function defaultRequestToExternal( request ) {
 
 		case 'react-dom':
 			return 'ReactDOM';
+	}
+
+	if ( BUNDLED_PACKAGES.includes( request ) ) {
+		return undefined;
 	}
 
 	if ( request.startsWith( WORDPRESS_NAMESPACE ) ) {

--- a/packages/dependency-extraction-webpack-plugin/util.js
+++ b/packages/dependency-extraction-webpack-plugin/util.js
@@ -1,5 +1,5 @@
 const WORDPRESS_NAMESPACE = '@wordpress/';
-const BUNDLED_PACKAGES = '@wordpress/icons';
+const BUNDLED_PACKAGES = [ '@wordpress/icons' ];
 
 /**
  * Default request to global transformation

--- a/packages/editor/src/components/post-saved-state/index.js
+++ b/packages/editor/src/components/post-saved-state/index.js
@@ -14,7 +14,7 @@ import { withSelect, withDispatch } from '@wordpress/data';
 import { displayShortcut } from '@wordpress/keycodes';
 import { withSafeTimeout, compose } from '@wordpress/compose';
 import { withViewportMatch } from '@wordpress/viewport';
-import { __experimentalIcon as Icon, check } from '@wordpress/icons';
+import { Icon, check } from '@wordpress/icons';
 
 /**
  * Internal dependencies

--- a/packages/icons/CHANGELOG.md
+++ b/packages/icons/CHANGELOG.md
@@ -1,3 +1,3 @@
-## 1.0.0 (2019-08-15)
+## Master
 
 - Initial release

--- a/packages/icons/README.md
+++ b/packages/icons/README.md
@@ -15,7 +15,7 @@ _This package assumes that your code will run in an **ES2015+** environment. If 
 ## Usage
 
 ```js
-import { __experimentalIcon as Icon, check } from '@wordpress/icons';
+import { Icon, check } from '@wordpress/icons';
 
 <Icon icon={ check } />
 ```

--- a/packages/icons/src/index.js
+++ b/packages/icons/src/index.js
@@ -1,4 +1,4 @@
-export { default as __experimentalIcon } from './icon';
+export { default as Icon } from './icon';
 
 export { default as check } from './library/check';
 export { default as paragraph } from './library/paragraph';

--- a/packages/icons/src/library/check.js
+++ b/packages/icons/src/library/check.js
@@ -4,13 +4,7 @@
 import { SVG, Path } from '@wordpress/primitives';
 
 const saved = (
-	<SVG
-		aria-hidden
-		role="img"
-		focusable="false"
-		xmlns="http://www.w3.org/2000/svg"
-		viewBox="-2 -2 24 24"
-	>
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="-2 -2 24 24">
 		<Path d="M15.3 5.3l-6.8 6.8-2.8-2.8-1.4 1.4 4.2 4.2 8.2-8.2" />
 	</SVG>
 );

--- a/packages/primitives/CHANGELOG.md
+++ b/packages/primitives/CHANGELOG.md
@@ -1,3 +1,3 @@
-### Master
+## Master
 
 Initial release.

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -26,9 +26,13 @@ const {
 } = process.env;
 
 const WORDPRESS_NAMESPACE = '@wordpress/';
+const BUNDLED_PACKAGES = [ '@wordpress/icons' ];
 
 const gutenbergPackages = Object.keys( dependencies )
-	.filter( ( packageName ) => packageName.startsWith( WORDPRESS_NAMESPACE ) )
+	.filter( ( packageName ) =>
+		! BUNDLED_PACKAGES.includes( packageName ) &&
+		packageName.startsWith( WORDPRESS_NAMESPACE )
+	)
 	.map( ( packageName ) => packageName.replace( WORDPRESS_NAMESPACE, '' ) );
 
 module.exports = {


### PR DESCRIPTION
The design team plan to add hundreds/thousands of icons to this package for third-party users. That makes it impossible to load it as its own script (bundle size). Instead we should encourage its usage via npm and tree-shaking. 

This PR avoid creating a WordPress script entirely for this package and bundle it when used. The advantage also is that we can iterate on the package without making it a public API (so all breaking changes allowed) until we're certain of the result.