### PR TITLE
Expose @wordpress/icons to react-native

### DIFF
--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -21,6 +21,7 @@
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",
+	"react-native": "src/index",
 	"dependencies": {
 		"@wordpress/element": "../element",
 		"@wordpress/primitives": "../primitives"


### PR DESCRIPTION
This is required for the react-native project to be able to load `@wordpress/icons`