### PR TITLE
Innerblock Templates Docs Link Typo Issue Fixed

### DIFF
--- a/packages/block-editor/src/components/inner-blocks/README.md
+++ b/packages/block-editor/src/components/inner-blocks/README.md
@@ -71,7 +71,7 @@ The previous code block restricts all blocks, so only child blocks explicitly re
 * **Type:** `Array<Array<Object>>`
 
 The template is defined as a list of block items. Such blocks can have predefined attributes, placeholder, content, etc. Block templates allow specifying a default initial state for an InnerBlocks area.
-More information about templates can be found in [template docs](/docs/developers/block-api/block-templates.md).
+More information about templates can be found in [template docs](/docs/designers-developers/developers/block-api/block-templates.md).
 
 ```jsx
 const TEMPLATE = [ [ 'core/columns', {}, [

--- a/packages/block-editor/src/components/inner-blocks/README.md
+++ b/packages/block-editor/src/components/inner-blocks/README.md
@@ -100,7 +100,7 @@ If false the selection should not be updated when child blocks specified in the 
 ### `templateLock`
 * **Type:** `String|Boolean`
 
-Template locking of `InnerBlocks` is similar to [Custom Post Type templates locking](/docs/developers/block-api/block-templates.md#locking).
+Template locking of `InnerBlocks` is similar to [Custom Post Type templates locking](/docs/designers-developers/developers/block-api/block-templates.md#locking).
 
 Template locking allows locking the `InnerBlocks` area for the current template.
 *Options:*


### PR DESCRIPTION
## Description

Previous Inner Block doc link was broken.

Previous Link: [https://github.com/WordPress/gutenberg/blob/master/docs/developers/block-api/block-templates.md#locking](https://github.com/WordPress/gutenberg/blob/master/docs/developers/block-api/block-templates.md#locking)

New Link: [https://github.com/WordPress/gutenberg/blob/master/docs/designers-developers/developers/block-api/block-templates.md#locking](https://github.com/WordPress/gutenberg/blob/master/docs/designers-developers/developers/block-api/block-templates.md#locking)