### PR TITLE
Select Parent Navigation Block after clicking "Create from all top-level pages"

### DIFF
--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -22,7 +22,7 @@ import {
 } from '@wordpress/block-editor';
 
 import { createBlock } from '@wordpress/blocks';
-import { withSelect, withDispatch } from '@wordpress/data';
+import { useDispatch, withSelect, withDispatch } from '@wordpress/data';
 import {
 	Button,
 	PanelBody,
@@ -61,6 +61,7 @@ function Navigation( {
 	//
 	/* eslint-disable @wordpress/no-unused-vars-before-return */
 	const ref = useRef();
+	const { selectBlock } = useDispatch( 'core/block-editor' );
 
 	const {
 		TextColor,
@@ -127,6 +128,7 @@ function Navigation( {
 
 	function handleCreateFromExistingPages() {
 		updateNavItemBlocks( defaultPagesNavigationItems );
+		selectBlock( clientId );
 	}
 
 	const hasPages = hasResolvedPages && pages && pages.length;


### PR DESCRIPTION
Closes https://github.com/WordPress/gutenberg/issues/19645

## Description
When you select "Create from all top-level pages,"  it would select the first navigation-link item, rather than the parent block navigation options.

## How has this been tested?
Manually.
1. Add a new navigation block
2. Click "Create from all top-level pages" button
3. See the navigation block focused, rather than the first navigation item

## Screenshots 
![Focus parent navigation on create from pages](https://user-images.githubusercontent.com/967608/72913121-4714dd00-3d02-11ea-9fc6-4452c5665125.gif)


## Types of changes
Bug fix/UX Improvement (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
