### PR TITLE
[RNMobile] Fix crash on list block controls

### DIFF
--- a/packages/rich-text/src/component/index.native.js
+++ b/packages/rich-text/src/component/index.native.js
@@ -726,6 +726,7 @@ export class RichText extends Component {
 					isSelected,
 					value: record,
 					onChange: this.onFormatChange,
+					onFocus: () => {},
 				} ) }
 				<RCTAztecView
 					ref={ ( ref ) => {


### PR DESCRIPTION
## Description

This fixes a crash originated on this PR: https://github.com/WordPress/gutenberg/pull/19536, where the editor would crash after pressing any control on the List Block.

Gutenberg-mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1801

**To test:**

- Add a List Block.
- Press any of the controls (i.e: Change the list type to ordered).
- Check that it doesn't crash.
- Check that it works properly.

