### PR TITLE
Use URL interface to validate URI

### DIFF
--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -16,7 +16,7 @@ import {
 	prependHTTP,
 	getProtocol,
 	isValidFragment,
-	isUri,
+	isURI,
 } from '@wordpress/url';
 import { useInstanceId } from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
@@ -95,7 +95,7 @@ function LinkControl( {
 		const isInternal = startsWith( val, '#' ) && isValidFragment( val );
 		const includesWWW = !! ( val && val.includes( 'www.' ) );
 
-		return isUri( val ) || includesWWW || isInternal;
+		return isURI( val ) || includesWWW || isInternal;
 	};
 
 	// Effects

--- a/packages/url/README.md
+++ b/packages/url/README.md
@@ -230,6 +230,7 @@ _Returns_
 <a name="isURI" href="#isURI">#</a> **isURI**
 
 Determines whether the given string looks like a URI (of any type).
+See <https://url.spec.whatwg.org/#url-representation> for more info.
 
 _Usage_
 

--- a/packages/url/package.json
+++ b/packages/url/package.json
@@ -25,7 +25,7 @@
 		"@babel/runtime": "^7.4.4",
 		"lodash": "^4.17.15",
 		"qs": "^6.5.2",
-		"valid-url": "^1.0.9"
+		"whatwg-url": "^8.0.0"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/url/src/is-uri.js
+++ b/packages/url/src/is-uri.js
@@ -1,10 +1,11 @@
 /**
  * External dependencies
  */
-import { isUri } from 'valid-url';
+import { URL } from 'whatwg-url';
 
 /**
  * Determines whether the given string looks like a URI (of any type).
+ * See https://url.spec.whatwg.org/#url-representation for more info.
  *
  * @param {string} uri The string to scrutinise.
  *
@@ -17,5 +18,10 @@ import { isUri } from 'valid-url';
  * @return {boolean} Whether or not it looks like a URI.
  */
 export function isURI( uri ) {
-	return isUri( uri );
+	try {
+		new URL( uri );
+		return true;
+	} catch ( _ ) {
+		return false;
+	}
 }


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

Replacing `valid-url` package with the `whatwg-url` (because IE11) for creating a URI validator. The polyfill is a better choice IMO, as it's much more versatile and later on (once we drop IE11 support) we could easily switch to the [native implementation](https://developer.mozilla.org/en-US/docs/Web/API/URL).

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
