### PR TITLE
Block: rename is-selected class

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -234,7 +234,7 @@ function BlockListBlock( {
 		{
 			'has-selected-ui': hasSelectedUI,
 			'has-warning': ! isValid || !! hasError || isUnregisteredBlock,
-			'is-selected': shouldAppearSelected && hasSelectedUI,
+			'is-appearing-selected': shouldAppearSelected && hasSelectedUI,
 			'is-navigate-mode': isNavigationMode,
 			'is-multi-selected': isMultiSelected,
 			'is-reusable': isReusableBlock( blockType ),

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -1,4 +1,4 @@
-.block-editor-block-list__layout .block-editor-block-list__block.is-selected { // Needs specificity to override inherited styles.
+.block-editor-block-list__layout .block-editor-block-list__block.is-appearing-selected { // Needs specificity to override inherited styles.
 	// While block is being dragged, dim the slot dragged from, and hide some UI.
 	&.is-dragging {
 		&::before {
@@ -106,7 +106,7 @@
 	}
 
 	// Selected style.
-	&.is-selected {
+	&.is-appearing-selected {
 		&::before {
 			// Use opacity to work in various editor styles.
 			border-color: $dark-opacity-light-800;
@@ -222,7 +222,7 @@
 		}
 	}
 
-	&.has-warning.is-selected::before {
+	&.has-warning.is-appearing-selected::before {
 		// Use opacity to work in various editor styles.
 		border-color: $dark-opacity-light-800;
 		border-left-color: transparent;
@@ -248,7 +248,7 @@
 		background-color: transparent;
 	}
 
-	&.has-warning.is-selected::after {
+	&.has-warning.is-appearing-selected::after {
 		bottom: ( $block-toolbar-height - $block-padding - $border-width );
 
 		@include break-small() {
@@ -257,7 +257,7 @@
 	}
 
 	// Reusable blocks.
-	&.is-reusable.is-selected::before {
+	&.is-reusable.is-appearing-selected::before {
 		border-left-color: transparent;
 		border-style: dashed;
 		border-width: $border-width;

--- a/packages/block-library/src/button/editor.scss
+++ b/packages/block-library/src/button/editor.scss
@@ -65,7 +65,7 @@
 
 	}
 
-	.is-selected &,
+	.is-appearing-selected &,
 	.is-typing & {
 		height: auto;
 		overflow: visible;

--- a/packages/block-library/src/classic/editor.scss
+++ b/packages/block-library/src/classic/editor.scss
@@ -249,7 +249,7 @@ div[data-type="core/freeform"] {
 		outline: $border-width solid transparent;
 	}
 
-	&.is-selected::before {
+	&.is-appearing-selected::before {
 		border-color: $light-gray-800;
 		border-left-color: transparent;
 	}
@@ -260,7 +260,7 @@ div[data-type="core/freeform"] {
 	}
 
 	// Ensure aligned blocks at end are within the selected block.
-	&.is-selected .block-library-rich-text__tinymce::after {
+	&.is-appearing-selected .block-library-rich-text__tinymce::after {
 		content: "";
 		display: table;
 		clear: both;
@@ -309,7 +309,7 @@ div[data-type="core/freeform"] {
 	// By using the `data-type` attribute in this selector it ensures these styles only appear
 	// when the block itself is selected, without it they would also show when a parent block
 	// is selected.
-	div[data-type="core/freeform"].is-selected &,
+	div[data-type="core/freeform"].is-appearing-selected &,
 	div[data-type="core/freeform"].is-typing & {
 		display: block;
 		border-color: $light-gray-800;

--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -7,7 +7,7 @@
 	}
 
 	// Override the bottom margin every block gets.
-	.is-selected & {
+	.is-appearing-selected & {
 		margin-bottom: 0;
 	}
 }

--- a/packages/block-library/src/group/editor.scss
+++ b/packages/block-library/src/group/editor.scss
@@ -81,7 +81,7 @@
 }
 
 // Place block list appender in the same place content will appear.
-[data-type="core/group"].is-selected {
+[data-type="core/group"].is-appearing-selected {
 
 	.block-list-appender {
 		margin-left: 0;

--- a/packages/block-library/src/media-text/editor.scss
+++ b/packages/block-library/src/media-text/editor.scss
@@ -75,14 +75,14 @@ figure.block-library-media-text__media-container {
 	display: none;
 }
 
-.wp-block-media-text.is-selected:not(.is-stacked-on-mobile) {
+.wp-block-media-text.is-appearing-selected:not(.is-stacked-on-mobile) {
 	.editor-media-container__resizer .components-resizable-box__handle {
 		display: block;
 	}
 }
 
 @include break-small {
-	.wp-block-media-text.is-selected.is-stacked-on-mobile {
+	.wp-block-media-text.is-appearing-selected.is-stacked-on-mobile {
 		.editor-media-container__resizer .components-resizable-box__handle {
 			display: block;
 		}
@@ -111,4 +111,3 @@ figure.block-library-media-text__media-container {
 		}
 	}
 }
-

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -49,7 +49,7 @@ $navigation-item-height: 46px;
 
 	// Remove the dashed outlines for child blocks.
 	&.is-hovered .wp-block-navigation .block-editor-block-list__block::before,
-	&.is-selected .wp-block-navigation .block-editor-block-list__block::before,
+	&.is-appearing-selected .wp-block-navigation .block-editor-block-list__block::before,
 	&.has-child-selected .wp-block-navigation .block-editor-block-list__block::before {
 		border-color: transparent !important; // !important used to keep the selector from growing any more complex.
 	}

--- a/packages/block-library/src/paragraph/editor.scss
+++ b/packages/block-library/src/paragraph/editor.scss
@@ -1,7 +1,7 @@
 // Specific to the empty paragraph placeholder:
 // when shown on mobile and in nested contexts, one or more icons show up on the right.
 // This padding makes sure it doesn't overlap text.
-.block-editor-rich-text__editable.wp-block-paragraph:not(.is-selected) [data-rich-text-placeholder]::after {
+.block-editor-rich-text__editable.wp-block-paragraph:not(.is-appearing-selected) [data-rich-text-placeholder]::after {
 	display: inline-block;
 	padding-right: $icon-button-size * 3;
 

--- a/packages/block-library/src/social-links/editor.scss
+++ b/packages/block-library/src/social-links/editor.scss
@@ -45,7 +45,7 @@
 
 	// 4. Remove the dashed outlines for child blocks.
 	&.is-hovered .wp-block-social-links .block-editor-block-list__block::before,
-	&.is-selected .wp-block-social-links .block-editor-block-list__block::before,
+	&.is-appearing-selected .wp-block-social-links .block-editor-block-list__block::before,
 	&.has-child-selected .wp-block-social-links .block-editor-block-list__block::before {
 		border-color: transparent !important; // !important used to keep the selector from growing any more complex.
 	}
@@ -91,7 +91,7 @@
 
 // Selected/unselected states.
 // Unselected block is preview, selected has additional options.
-[data-type="core/social-links"]:not(.is-selected):not(.has-child-selected) .wp-block-social-links {
+[data-type="core/social-links"]:not(.is-appearing-selected):not(.has-child-selected) .wp-block-social-links {
 	min-height: 36px; // This height matches the height of the buttons and ensures an empty block doesn't collapse.
 }
 
@@ -101,7 +101,7 @@
 	transform-origin: center center;
 }
 
-[data-type="core/social-links"]:not(.is-selected):not(.has-child-selected) {
+[data-type="core/social-links"]:not(.is-appearing-selected):not(.has-child-selected) {
 	.wp-social-link__is-incomplete {
 		opacity: 0;
 		transform: scale(0);

--- a/packages/e2e-tests/specs/editor/blocks/spacer.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/spacer.test.js
@@ -32,7 +32,7 @@ describe( 'Spacer', () => {
 		await dragAndResize( resizableHandle, { x: 0, y: 50 } );
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 
-		const selectedSpacer = await page.$( '[data-type="core/spacer"].is-selected' );
+		const selectedSpacer = await page.$( '[data-type="core/spacer"].is-appearing-selected' );
 		expect( selectedSpacer ).not.toBe( null );
 	} );
 } );

--- a/packages/e2e-tests/specs/editor/various/block-hierarchy-navigation.test.js
+++ b/packages/e2e-tests/specs/editor/various/block-hierarchy-navigation.test.js
@@ -90,7 +90,7 @@ describe( 'Navigating the block hierarchy', () => {
 		await openBlockNavigator();
 		await pressKeyTimes( 'Tab', 4 );
 		await page.keyboard.press( 'Enter' );
-		await page.waitForSelector( '.is-selected[data-type="core/column"]' );
+		await page.waitForSelector( '.is-appearing-selected[data-type="core/column"]' );
 
 		// Insert text in the last column block
 		await page.keyboard.press( 'Tab' ); // Tab to inserter.

--- a/packages/e2e-tests/specs/editor/various/multi-block-selection.test.js
+++ b/packages/e2e-tests/specs/editor/various/multi-block-selection.test.js
@@ -44,7 +44,7 @@ async function testNativeSelection() {
 		);
 
 		if ( ! elements.length ) {
-			const element = document.querySelector( '.is-selected' );
+			const element = document.querySelector( '.is-appearing-selected' );
 
 			if ( ! element || ! selection.rangeCount ) {
 				return;


### PR DESCRIPTION
## Description

Blocks #19701.

This PR renames the block's `is-selected` class to the more descriptive `is-appearing-selected` class. The current class is misleading, as it may not be added even though the block is selected. The class is omitted when a block does not appear selected (when typing).

This change is necessary for blocks to be able to render their own wrapper as `RichText` also has a `is-selected` class, which causes a block to continuously _look_ selected. The problem is not really the class duplication, but rather using `is-selected` to mean different things.

Some more complex block may have CSS rules using this class, but

1. The class is anyway going to change meaning with the new G2 design (blocks will not have the selection border). It may even be removed since it won't be needed anymore.
2. Classes are not an official API.
3. When it is used, blocks are diverging from a consistent block styling.
4. In some cases it seems to be combined with `is-typing`, which maybe indicates a need for a proper `is-selected` class. I consider adding a new class out of scope though.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
