### PR TITLE
Paragraph block: remove unnecessary CSS after shortcuts removal

### DIFF
--- a/packages/block-library/src/paragraph/editor.scss
+++ b/packages/block-library/src/paragraph/editor.scss
@@ -1,16 +1,3 @@
-// Specific to the empty paragraph placeholder:
-// when shown on mobile and in nested contexts, one or more icons show up on the right.
-// This padding makes sure it doesn't overlap text.
-.block-editor-rich-text__editable.wp-block-paragraph:not(.is-selected) [data-rich-text-placeholder]::after {
-	display: inline-block;
-	padding-right: $icon-button-size * 3;
-
-	// In nested contexts only one icon shows up.
-	.wp-block .wp-block & {
-		padding-right: $icon-button-size;
-	}
-}
-
 .block-editor-block-list__block[data-type="core/paragraph"] p {
 	min-height: $empty-paragraph-height / 2;
 	line-height: $editor-line-height;


### PR DESCRIPTION
## Description

This PR removes the extra padding added to a paragraph's placeholder for the recently removed inserter shortcuts (#19045). It also removes padding for the empty default block inserter since the placeholder and the inserter now never appear together. The inserter is shown on selection, and the placeholder is shown when the paragraph is not selected.

## How has this been tested?

Selecting and deselecting an empty paragraph (all screen sizes).

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
