### PR TITLE
Rich text: remove is-selected class

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -386,7 +386,7 @@ class RichTextWrapper extends Component {
 				onSelectionChange={ onSelectionChange }
 				tagName={ tagName }
 				className={ classnames( classes, className, {
-					'is-selected': originalIsSelected,
+					'is-rich-text-selected': originalIsSelected,
 					'keep-placeholder-on-focus': keepPlaceholderOnFocus,
 				} ) }
 				placeholder={ placeholder }

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -386,7 +386,6 @@ class RichTextWrapper extends Component {
 				onSelectionChange={ onSelectionChange }
 				tagName={ tagName }
 				className={ classnames( classes, className, {
-					'is-rich-text-selected': originalIsSelected,
 					'keep-placeholder-on-focus': keepPlaceholderOnFocus,
 				} ) }
 				placeholder={ placeholder }

--- a/packages/block-editor/src/components/rich-text/style.scss
+++ b/packages/block-editor/src/components/rich-text/style.scss
@@ -37,7 +37,7 @@
 	}
 
 	// Could be unset for individual rich text instances.
-	&.is-selected:not(.keep-placeholder-on-focus) [data-rich-text-placeholder]::after {
+	&.is-rich-text-selected:not(.keep-placeholder-on-focus) [data-rich-text-placeholder]::after {
 		display: none;
 	}
 }

--- a/packages/block-editor/src/components/rich-text/style.scss
+++ b/packages/block-editor/src/components/rich-text/style.scss
@@ -16,15 +16,6 @@
 		font-size: inherit; // This is necessary to override upstream CSS.
 	}
 
-	&:focus {
-		// Removes outline added by the browser.
-		outline: none;
-
-		*[data-rich-text-format-boundary] {
-			border-radius: 2px;
-		}
-	}
-
 	[data-rich-text-placeholder] {
 		pointer-events: none;
 	}
@@ -36,9 +27,17 @@
 		opacity: 0.62;
 	}
 
-	// Could be unset for individual rich text instances.
-	&.is-rich-text-selected:not(.keep-placeholder-on-focus) [data-rich-text-placeholder]::after {
-		display: none;
+	&:focus {
+		// Removes outline added by the browser.
+		outline: none;
+
+		[data-rich-text-format-boundary] {
+			border-radius: 2px;
+		}
+
+		&:not(.keep-placeholder-on-focus) [data-rich-text-placeholder]::after {
+			display: none;
+		}
 	}
 }
 

--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -51,7 +51,7 @@
 		margin-left: 4px;
 	}
 
-	.block-editor-rich-text__editable.is-selected:not(.keep-placeholder-on-focus):not(:focus) [data-rich-text-placeholder]::after {
+	.block-editor-rich-text__editable.is-rich-text-selected:not(.keep-placeholder-on-focus):not(:focus) [data-rich-text-placeholder]::after {
 		display: inline-block;
 	}
 }

--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -50,10 +50,6 @@
 	.wp-block-navigation-link__submenu-icon {
 		margin-left: 4px;
 	}
-
-	.block-editor-rich-text__editable.is-rich-text-selected:not(.keep-placeholder-on-focus):not(:focus) [data-rich-text-placeholder]::after {
-		display: inline-block;
-	}
 }
 
 [data-type="core/navigation-link"] {

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -59,7 +59,7 @@ async function updateActiveNavigationLink( { url, label } ) {
 	}
 
 	if ( label ) {
-		await page.click( '.wp-block-navigation-link__label.is-selected' );
+		await page.click( '.wp-block-navigation-link__label.is-rich-text-selected' );
 
 		// Ideally this would be `await pressKeyWithModifier( 'primary', 'a' )`
 		// to select all text like other tests do.

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -59,7 +59,7 @@ async function updateActiveNavigationLink( { url, label } ) {
 	}
 
 	if ( label ) {
-		await page.click( '.wp-block-navigation-link__label.is-rich-text-selected' );
+		await page.click( '.is-selected .wp-block-navigation-link__label' );
 
 		// Ideally this would be `await pressKeyWithModifier( 'primary', 'a' )`
 		// to select all text like other tests do.


### PR DESCRIPTION
## Description

Alternative to #19568.

This PR removes rich text's `is-selected` class to avoid conflicts with use of that class by block. This is a safer changes since the class is only used to hide the placeholder on select. Instead we can simply use `:focus`.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
