### PR TITLE
Framework: Use WHATWG URL in place of legacy url module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10136,8 +10136,7 @@
 				"lodash": "^4.17.15",
 				"memize": "^1.0.5",
 				"moment": "^2.22.1",
-				"tinycolor2": "^1.4.1",
-				"url": "^0.11.0"
+				"tinycolor2": "^1.4.1"
 			}
 		},
 		"@wordpress/block-serialization-default-parser": {
@@ -32532,7 +32531,8 @@
 		"querystring": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-			"integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+			"integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+			"dev": true
 		},
 		"querystring-es3": {
 			"version": "0.2.1",
@@ -39363,6 +39363,7 @@
 			"version": "0.11.0",
 			"resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
 			"integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+			"dev": true,
 			"requires": {
 				"punycode": "1.3.2",
 				"querystring": "0.2.0"
@@ -39371,7 +39372,8 @@
 				"punycode": {
 					"version": "1.3.2",
 					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-					"integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+					"integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+					"dev": true
 				}
 			}
 		},

--- a/packages/block-editor/src/utils/transform-styles/transforms/url-rewrite.js
+++ b/packages/block-editor/src/utils/transform-styles/transforms/url-rewrite.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { parse, resolve } from 'url';
-
-/**
  * Return `true` if the given path is http/https.
  *
  * @param  {string}  filePath path
@@ -62,10 +57,7 @@ function isValidURL( meta ) {
  * @return {string}              the full path to the file
  */
 function getResourcePath( str, baseURL ) {
-	const pathname = parse( str ).pathname;
-	const filePath = resolve( baseURL, pathname );
-
-	return filePath;
+	return new URL( str, baseURL ).toString();
 }
 
 /**

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -55,8 +55,7 @@
 		"lodash": "^4.17.15",
 		"memize": "^1.0.5",
 		"moment": "^2.22.1",
-		"tinycolor2": "^1.4.1",
-		"url": "^0.11.0"
+		"tinycolor2": "^1.4.1"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/block-library/src/embed/embed-preview.js
+++ b/packages/block-library/src/embed/embed-preview.js
@@ -7,7 +7,6 @@ import { getPhotoHtml } from './util';
 /**
  * External dependencies
  */
-import { parse } from 'url';
 import { includes } from 'lodash';
 import classnames from 'classnames/dedupe';
 
@@ -69,7 +68,7 @@ class EmbedPreview extends Component {
 		const { interactive } = this.state;
 
 		const html = 'photo' === type ? getPhotoHtml( preview ) : preview.html;
-		const parsedHost = parse( url ).host.split( '.' );
+		const parsedHost = new URL( url ).host.split( '.' );
 		const parsedHostBaseUrl = parsedHost
 			.splice( parsedHost.length - 2, parsedHost.length - 1 )
 			.join( '.' );

--- a/packages/e2e-test-utils/src/create-url.js
+++ b/packages/e2e-test-utils/src/create-url.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { join } from 'path';
-import { URL } from 'url';
 
 /**
  * Internal dependencies

--- a/packages/e2e-test-utils/src/is-current-url.js
+++ b/packages/e2e-test-utils/src/is-current-url.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { URL } from 'url';
-
-/**
  * Internal dependencies
  */
 import { createURL } from './create-url';

--- a/packages/e2e-tests/specs/editor/various/preview.test.js
+++ b/packages/e2e-tests/specs/editor/various/preview.test.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { last } from 'lodash';
-import { parse } from 'url';
 
 /**
  * WordPress dependencies
@@ -187,9 +186,9 @@ describe( 'Preview', () => {
 		expect( previewTitle ).toBe( 'Hello World! And more.' );
 
 		// Published preview URL should include ID and nonce parameters.
-		const { query } = parse( previewPage.url(), true );
-		expect( query ).toHaveProperty( 'preview_id' );
-		expect( query ).toHaveProperty( 'preview_nonce' );
+		const { searchParams } = new URL( previewPage.url() );
+		expect( searchParams.has( 'preview_id' ) ).toBe( true );
+		expect( searchParams.has( 'preview_nonce' ) ).toBe( true );
 
 		// Return to editor. Previewing already-autosaved preview tab should
 		// reuse the opened tab, skipping interstitial. This resolves an edge


### PR DESCRIPTION
Partially addresses: #13386
Unblocks (maybe): #19816
Closes #19629

This pull request seeks to remove usage of the [Node legacy `url` module](https://nodejs.org/docs/latest-v12.x/api/url.html#url_legacy_url_api) in favor of the [WHATWG `URL` constructor](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL) which is native to both Node.js and modern browsers. A polyfill has been included for unsupported browsers.

The proposed advantages here are:

- Improved future compatibility with Webpack Node.js shims
- Reduced bundle sizes

The following bundle size changes have been observed:

&nbsp;|`block-editor`|`block-library`
---|---|--
Before|346kb|387kb
After|333kb|375kb
Change|-13kb (-3.7%)|-12kb (-3.1%)

**Testing Instructions:**

Verify tests pass:

```
npm test
```

For good measure, verify affected behaviors:

- Embed previews
- [Editor style transforms](https://developer.wordpress.org/block-editor/developers/themes/theme-support/#editor-styles)