### PR TITLE
Remove: Alignment options from button nested inside buttons

### DIFF
--- a/packages/block-editor/src/hooks/align.js
+++ b/packages/block-editor/src/hooks/align.js
@@ -7,6 +7,7 @@ import { assign, get, has, includes, without } from 'lodash';
 /**
  * WordPress dependencies
  */
+import { createContext, useContext } from '@wordpress/element';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { addFilter } from '@wordpress/hooks';
 import {
@@ -99,6 +100,13 @@ export function addAttribute( settings ) {
 	return settings;
 }
 
+const AlignmentHookSettings = createContext( {} );
+
+/**
+ * Allows to pass additional settings to the alignment hook.
+ */
+export const AlignmentHookSettingsProvider = AlignmentHookSettings.Provider;
+
 /**
  * Override the default edit UI to include new toolbar controls for block
  * alignment, if block defines support.
@@ -108,14 +116,17 @@ export function addAttribute( settings ) {
  */
 export const withToolbarControls = createHigherOrderComponent(
 	( BlockEdit ) => ( props ) => {
+		const { isEmbedButton } = useContext( AlignmentHookSettings );
 		const { name: blockName } = props;
 		// Compute valid alignments without taking into account,
 		// if the theme supports wide alignments or not.
 		// BlockAlignmentToolbar takes into account the theme support.
-		const validAlignments = getValidAlignments(
-			getBlockSupport( blockName, 'align' ),
-			hasBlockSupport( blockName, 'alignWide', true )
-		);
+		const validAlignments = isEmbedButton
+			? []
+			: getValidAlignments(
+					getBlockSupport( blockName, 'align' ),
+					hasBlockSupport( blockName, 'alignWide', true )
+			  );
 
 		const updateAlignment = ( nextAlign ) => {
 			if ( ! nextAlign ) {

--- a/packages/block-editor/src/hooks/index.js
+++ b/packages/block-editor/src/hooks/index.js
@@ -1,7 +1,9 @@
 /**
  * Internal dependencies
  */
-import './align';
+import { AlignmentHookSettingsProvider } from './align';
 import './anchor';
 import './custom-class-name';
 import './generated-class-name';
+
+export { AlignmentHookSettingsProvider };

--- a/packages/block-editor/src/index.js
+++ b/packages/block-editor/src/index.js
@@ -9,7 +9,8 @@ import '@wordpress/keyboard-shortcuts';
 /**
  * Internal dependencies
  */
-import './hooks';
+import { AlignmentHookSettingsProvider as __experimentalAlignmentHookSettingsProvider } from './hooks';
+export { __experimentalAlignmentHookSettingsProvider };
 export * from './components';
 export * from './utils';
 export { storeConfig } from './store';

--- a/packages/block-library/src/buttons/edit.js
+++ b/packages/block-library/src/buttons/edit.js
@@ -1,7 +1,10 @@
 /**
  * WordPress dependencies
  */
-import { InnerBlocks } from '@wordpress/block-editor';
+import {
+	__experimentalAlignmentHookSettingsProvider as AlignmentHookSettingsProvider,
+	InnerBlocks,
+} from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -14,15 +17,22 @@ const UI_PARTS = {
 	hasSelectedUI: false,
 };
 
+// Inside buttons block alignment options are not supported.
+const alignmentHooksSetting = {
+	isEmbedButton: true,
+};
+
 function ButtonsEdit( { className } ) {
 	return (
 		<div className={ className }>
-			<InnerBlocks
-				allowedBlocks={ ALLOWED_BLOCKS }
-				template={ BUTTONS_TEMPLATE }
-				__experimentalUIParts={ UI_PARTS }
-				__experimentalMoverDirection="horizontal"
-			/>
+			<AlignmentHookSettingsProvider value={ alignmentHooksSetting }>
+				<InnerBlocks
+					allowedBlocks={ ALLOWED_BLOCKS }
+					template={ BUTTONS_TEMPLATE }
+					__experimentalUIParts={ UI_PARTS }
+					__experimentalMoverDirection="horizontal"
+				/>
+			</AlignmentHookSettingsProvider>
 		</div>
 	);
 }


### PR DESCRIPTION
Fix: https://github.com/WordPress/gutenberg/issues/19616

When a button block is inside a buttons block, we should not render alignment options for the button block. The alignment is controlled globally for all blocks on the buttons block.

This change is complex because we can not simply remove the alignment from the button block, as for existing "button" blocks outside buttons the alignment on the block should still be supported.

If the alignment toolbar was not being rendered in a popover hiding it with CSS would be an option but given the change to popover that is not an option.
I thought of adding another filter `addFilter( 'editor.BlockEdit', 'core/editor/align/with-toolbar-controls', withButtonBlockAlignRemover );`. The filter would remove the added alignment toolbar for button blocks whose parent is a buttons block. But, doing that would mean we would add a dependency on WordPress hooks in our block library.

So it seems with the current API's it was not possible to hide the alignment toolbar of a button block when nested inside buttons block.
I exposed an API component AlignmentHookSettingsProvider in block editor that allows parent blocks to provide settings for the alignment hook. The current setting we support is getContextualValidAlignments that allows changing what alignments are supported based on the expected valid alignments for a given block and the props a block receives.

I prefer a change that does not involve additions to the public API, but it seems it is something not possible. I'm open to other ideas.


## How has this been tested?
I added a buttons block and some "button" blocks inside.
I verified it was not possible to change the alignment of a "button" block.
I verified I could change the alignment of a button block.
I pasted this code in the block editor to create a top-level button:
```
<!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link">Top Level Button</a></div>
<!-- /wp:button -->
```
I verified I could change the aligment of that button block.
