### PR TITLE
Components: Apply width-based modifier classes to Placeholder only when width is known

### DIFF
--- a/packages/block-library/src/embed/test/__snapshots__/index.js.snap
+++ b/packages/block-library/src/embed/test/__snapshots__/index.js.snap
@@ -2,7 +2,7 @@
 
 exports[`core/embed block edit matches snapshot 1`] = `
 <div
-  class="components-placeholder is-small wp-block-embed"
+  class="components-placeholder wp-block-embed"
 >
   <iframe
     aria-hidden="true"

--- a/packages/components/src/placeholder/index.js
+++ b/packages/components/src/placeholder/index.js
@@ -27,13 +27,19 @@ function Placeholder( {
 	...additionalProps
 } ) {
 	const [ resizeListener, { width } ] = useResizeAware();
-	const classes = classnames(
-		'components-placeholder',
-		width >= 320 ? 'is-large' : '',
-		width >= 160 && width < 320 ? 'is-medium' : '',
-		width < 160 ? 'is-small' : '',
-		className
-	);
+
+	// Since `useResizeAware` will report a width of `null` until after the
+	// first render, avoid applying any modifier classes until width is known.
+	let modifierClassNames;
+	if ( typeof width === 'number' ) {
+		modifierClassNames = {
+			'is-large': width >= 320,
+			'is-medium': width >= 160 && width < 320,
+			'is-small': width < 160,
+		};
+	}
+
+	const classes = classnames( 'components-placeholder', className, modifierClassNames );
 	const fieldsetClasses = classnames( 'components-placeholder__fieldset', {
 		'is-column-layout': isColumnLayout,
 	} );

--- a/packages/components/src/placeholder/test/index.js
+++ b/packages/components/src/placeholder/test/index.js
@@ -1,4 +1,3 @@
-jest.mock( 'react-resize-aware' );
 /**
  * External dependencies
  */
@@ -10,8 +9,12 @@ import useResizeAware from 'react-resize-aware';
  */
 import Placeholder from '../';
 
+jest.mock( 'react-resize-aware' );
+
 describe( 'Placeholder', () => {
-	useResizeAware.mockReturnValue( [ <div key="1" />, { width: 320 } ] );
+	beforeEach( () => {
+		useResizeAware.mockReturnValue( [ <div key="1" />, { width: 320 } ] );
+	} );
 
 	describe( 'basic rendering', () => {
 		it( 'should by default render label section and fieldset.', () => {
@@ -75,6 +78,28 @@ describe( 'Placeholder', () => {
 		it( 'should add additional props to the top level container', () => {
 			const placeholder = shallow( <Placeholder test="test" /> );
 			expect( placeholder.prop( 'test' ) ).toBe( 'test' );
+		} );
+	} );
+
+	describe( 'resize aware', () => {
+		it( 'should not assign modifier class in first-pass `null` width from `useResizeAware`', () => {
+			useResizeAware.mockReturnValue( [ <div key="1" />, { width: 320 } ] );
+
+			const placeholder = shallow( <Placeholder /> );
+
+			expect( placeholder.hasClass( 'is-large' ) ).toBe( true );
+			expect( placeholder.hasClass( 'is-medium' ) ).toBe( false );
+			expect( placeholder.hasClass( 'is-small' ) ).toBe( false );
+		} );
+
+		it( 'should assign modifier class', () => {
+			useResizeAware.mockReturnValue( [ <div key="1" />, { width: null } ] );
+
+			const placeholder = shallow( <Placeholder /> );
+
+			expect( placeholder.hasClass( 'is-large' ) ).toBe( false );
+			expect( placeholder.hasClass( 'is-medium' ) ).toBe( false );
+			expect( placeholder.hasClass( 'is-small' ) ).toBe( false );
 		} );
 	} );
 } );

--- a/packages/e2e-tests/specs/editor/various/embedding.test.js
+++ b/packages/e2e-tests/specs/editor/various/embedding.test.js
@@ -210,6 +210,9 @@ describe( 'Embedding content', () => {
 		await page.keyboard.type( 'https://twitter.com/wooyaygutenberg123454312' );
 		await page.keyboard.press( 'Enter' );
 
+		// Wait for the request to fail and present an error.
+		await page.waitForSelector( '.components-placeholder__error' );
+
 		await clickButton( 'Convert to link' );
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
@@ -232,6 +235,10 @@ describe( 'Embedding content', () => {
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( 'https://twitter.com/wooyaygutenberg123454312' );
 		await page.keyboard.press( 'Enter' );
+
+		// Wait for the request to fail and present an error.
+		await page.waitForSelector( '.components-placeholder__error' );
+
 		// Set up a different mock to make sure that try again actually does make the request again.
 		await setUpResponseMocking( [
 			{

--- a/storybook/test/__snapshots__/index.js.snap
+++ b/storybook/test/__snapshots__/index.js.snap
@@ -4062,7 +4062,7 @@ exports[`Storyshots Components/Panel With Icon 1`] = `
 
 exports[`Storyshots Components/Placeholder Default 1`] = `
 <div
-  className="components-placeholder is-small"
+  className="components-placeholder"
 >
   <iframe
     aria-hidden={true}


### PR DESCRIPTION
Previously: https://github.com/WordPress/gutenberg/pull/18745#discussion_r369792562

This pull request seeks to address change the behavior of the `Placeholder` component to avoid applying any of its width-specific modifier classes until after the first render when the width is known. This, combined with some reorientation of the placeholder layout in both #18745 and #19673 may have contributed to some intermittent end-to-end test failures, where the layout of the placeholder may change abruptly while the Embed tests are trying to click on one or the other of the "Convert to link" or "Try again" buttons.

```
 ● Embedding content › should allow the user to try embedding a failed URL again
    TimeoutError: waiting for selector "figure.wp-block-embed-twitter" failed: timeout 30000ms exceeded
```

With these changes, the width-based modifier classes of a `Placeholder` component (`is-small`, `is-medium`, `is-large`) will only be assigned after the first render, when the width is known.

**Testing Instructions:**

Repeat testing instructions from #18745.

Verify unit tests and end-to-end tests pass:

```
npm run test-unit packages/components/src/placeholder/test/index.js
npm run test-e2e packages/e2e-tests/specs/editor/various/embedding.test.js
```