### PR TITLE
Add missing onFocus action for children invocation.

### DIFF
--- a/packages/rich-text/src/component/index.native.js
+++ b/packages/rich-text/src/component/index.native.js
@@ -726,6 +726,7 @@ export class RichText extends Component {
 					isSelected,
 					value: record,
 					onChange: this.onFormatChange,
+					onFocus: () => {},
 				} ) }
 				<RCTAztecView
 					ref={ ( ref ) => {


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
Updating code on RichText native for the changes made here: https://github.com/WordPress/gutenberg/pull/19668

This adds a missing use of onFocus that was causing a crash when switching the list block style (ordered to unordered) on native.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

This can be tested on GB-mobile using this PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1803

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
