### PR TITLE
[Mobile] Disable gallery size options on mobile in v1.21.0

### DIFF
--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -343,7 +343,11 @@ class GalleryEdit extends Component {
 			return mediaPlaceholder;
 		}
 
-		const imageSizeOptions = this.getImagesSizeOptions();
+		// disable image size options on mobile for now
+		const imageSizeOptions = Platform.select( {
+			web: this.getImagesSizeOptions(),
+			native: [],
+		} );
 		const shouldShowSizeOptions = hasImages && ! isEmpty( imageSizeOptions );
 		// This is needed to fix a separator fence-post issue on mobile.
 		const mobileLinkToProps = shouldShowSizeOptions ?


### PR DESCRIPTION
**Note:**

This PR does not need to be merged back into develop. Its purpose is for the v1.21.0 release branch only. For `develop`, simply omitting this PR will leave the options enabled, but a [small fix](https://github.com/WordPress/gutenberg/pull/19800) is needed to show labels correctly, and this should be tested and get some design approval (the reason for not including the size options in the `v1.21.0` release).

### Related PRs:

`gutenberg-mobile`: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1804

## Description
This PR disables the gallery image size options on mobile. We can re-enable them after we've verified / implemented the desired behavior for mobile.

## How has this been tested?

Tested via WordPress-Android and WordPress-iOS (via `gutenberg/integrate_release_1.21.0` branches).

## Screenshots:

Android|iOS
---|---
![gallery-image-size-options-disabled-v1 21 0-android](https://user-images.githubusercontent.com/8507675/72953187-fd9abf80-3ddf-11ea-8047-767d39ed0fd9.png)|![gallery-image-size-options-disabled-v1 21 0-ios](https://user-images.githubusercontent.com/8507675/72953189-fffd1980-3ddf-11ea-826e-04837c11153d.png)


Steps:

* Create a gallery block with some images
* Tap the gallery
* Tap the gallery settings icon (the gear)

Expected result:

The image size option should not be visible in the menu.

## Types of changes
This uses the `Platform.select` function to provide an empty array of image size options on mobile, leaving web implementation unchanged. There is already logic in place to hide the option when the array is empty, so this is sufficient to hide the option on mobile.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
