### PR TITLE
Add mobile code owners for gallery block

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,6 +11,7 @@
 
 # Blocks
 /packages/block-library                         @Soean @ajitbohra @jorgefilipecosta @talldan
+/packages/block-library/src/gallery             @mkevins @pinarol
 /packages/block-library/src/social-links        @mkaz
 /packages/block-library/src/social-link         @mkaz
 


### PR DESCRIPTION
## Description
This PR adds @mkevins and @pinarol as codeowners for the Gallery block. Since we are sharing the `edit.js` w/ web, it's important to be notified of incoming changes that may affect mobile.