### PR TITLE
Block Directory: Use canUser() to determine install user permissions.

### DIFF
--- a/packages/block-directory/src/components/downloadable-blocks-panel/index.js
+++ b/packages/block-directory/src/components/downloadable-blocks-panel/index.js
@@ -61,11 +61,11 @@ export default compose( [
 	withSelect( ( select, { filterValue } ) => {
 		const {
 			getDownloadableBlocks,
-			hasInstallBlocksPermission,
 			isRequestingDownloadableBlocks,
 		} = select( 'core/block-directory' );
+		const { canUser } = select( 'core' );
 
-		const hasPermission = hasInstallBlocksPermission();
+		const hasPermission = !! canUser( 'create', { endpoint: 'block-directory/install', isExperimental: true } );
 		const downloadableItems = hasPermission ? getDownloadableBlocks( filterValue ) : [];
 		const isLoading = isRequestingDownloadableBlocks();
 

--- a/packages/block-directory/src/store/actions.js
+++ b/packages/block-directory/src/store/actions.js
@@ -30,17 +30,6 @@ export function receiveDownloadableBlocks( downloadableBlocks, filterValue ) {
 }
 
 /**
- * Returns an action object used in signalling that the user does not have permission to install blocks.
- *
- @param {boolean} hasPermission User has permission to install blocks.
- *
- * @return {Object} Action object.
- */
-export function setInstallBlocksPermission( hasPermission ) {
-	return { type: 'SET_INSTALL_BLOCKS_PERMISSION', hasPermission };
-}
-
-/**
  * Action triggered to download block assets.
  *
  * @param {Object} item The selected block item

--- a/packages/block-directory/src/store/reducer.js
+++ b/packages/block-directory/src/store/reducer.js
@@ -13,7 +13,6 @@ import { combineReducers } from '@wordpress/data';
  */
 export const downloadableBlocks = ( state = {
 	results: {},
-	hasPermission: true,
 	filterValue: undefined,
 	isRequestingDownloadableBlocks: true,
 	installedBlockTypes: [],
@@ -30,14 +29,12 @@ export const downloadableBlocks = ( state = {
 				results: Object.assign( {}, state.results, {
 					[ action.filterValue ]: action.downloadableBlocks,
 				} ),
-				hasPermission: true,
 				isRequestingDownloadableBlocks: false,
 			};
 		case 'SET_INSTALL_BLOCKS_PERMISSION' :
 			return {
 				...state,
 				items: action.hasPermission ? state.items : [],
-				hasPermission: action.hasPermission,
 			};
 		case 'ADD_INSTALLED_BLOCK_TYPE' :
 			return {

--- a/packages/block-directory/src/store/resolvers.js
+++ b/packages/block-directory/src/store/resolvers.js
@@ -7,7 +7,7 @@ import { camelCase, mapKeys } from 'lodash';
  * Internal dependencies
  */
 import { apiFetch } from './controls';
-import { fetchDownloadableBlocks, receiveDownloadableBlocks, setInstallBlocksPermission } from './actions';
+import { fetchDownloadableBlocks, receiveDownloadableBlocks } from './actions';
 
 export default {
 	* getDownloadableBlocks( filterValue ) {
@@ -26,21 +26,7 @@ export default {
 
 			yield receiveDownloadableBlocks( blocks, filterValue );
 		} catch ( error ) {
-			if ( error.code === 'rest_user_cannot_view' ) {
-				yield setInstallBlocksPermission( false );
-			}
-		}
-	},
-	* hasInstallBlocksPermission() {
-		try {
-			yield apiFetch( {
-				path: `__experimental/block-directory/search?term=`,
-			} );
-			yield setInstallBlocksPermission( true );
-		} catch ( error ) {
-			if ( error.code === 'rest_user_cannot_view' ) {
-				yield setInstallBlocksPermission( false );
-			}
+			// TODO trigger error state
 		}
 	},
 };

--- a/packages/block-directory/src/store/selectors.js
+++ b/packages/block-directory/src/store/selectors.js
@@ -30,17 +30,6 @@ export function getDownloadableBlocks( state, filterValue ) {
 }
 
 /**
- * Returns true if user has permission to install blocks.
- *
- * @param {Object} state Global application state.
- *
- * @return {boolean} User has permission to install blocks.
- */
-export function hasInstallBlocksPermission( state ) {
-	return state.downloadableBlocks.hasPermission;
-}
-
-/**
  * Returns the block types that have been installed on the server.
  *
  * @param {Object} state Global application state.

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -129,7 +129,7 @@ export function* hasUploadPermissions() {
  *
  * @param {string}  action   Action to check. One of: 'create', 'read', 'update',
  *                           'delete'.
- * @param {string}  resource REST resource to check, e.g. 'media' or 'posts'.
+ * @param {string|Object}  resource REST resource to check, e.g. 'media' or 'posts' | { endpoint: 'media', isExperimental: true }
  * @param {?string} id       ID of the rest resource to check.
  */
 export function* canUser( action, resource, id ) {
@@ -145,7 +145,10 @@ export function* canUser( action, resource, id ) {
 		throw new Error( `'${ action }' is not a valid action.` );
 	}
 
-	const path = id ? `/wp/v2/${ resource }/${ id }` : `/wp/v2/${ resource }`;
+	const apiPrefix = resource && resource.isExperimental ? '/__experimental/' : '/wp/v2/';
+	const endpoint = ( resource && resource.endpoint ) || resource;
+	const resourcePart = apiPrefix + endpoint;
+	const path = id ? `${ resourcePart }/${ id }` : resourcePart;
 
 	let response;
 	try {
@@ -175,7 +178,7 @@ export function* canUser( action, resource, id ) {
 		allowHeader = get( response, [ 'headers', 'Allow' ], '' );
 	}
 
-	const key = compact( [ action, resource, id ] ).join( '/' );
+	const key = compact( [ action, endpoint, id ] ).join( '/' );
 	const isAllowed = includes( allowHeader, method );
 	yield receiveUserPermission( key, isAllowed );
 }

--- a/packages/core-data/src/selectors.js
+++ b/packages/core-data/src/selectors.js
@@ -496,7 +496,9 @@ export function hasUploadPermissions( state ) {
  *                             or `undefined` if the OPTIONS request is still being made.
  */
 export function canUser( state, action, resource, id ) {
-	const key = compact( [ action, resource, id ] ).join( '/' );
+	const endpoint = ( resource && resource.endpoint ) || resource;
+
+	const key = compact( [ action, endpoint, id ] ).join( '/' );
 	return get( state, [ 'userPermissions', key ] );
 }
 


### PR DESCRIPTION
## Description
The Block Directory package makes use of its own approach to check user permissions. This PR will align its approach to check permissions with the rest of the project by using `canUser` from `core-data`. 

This PR does include a change to the `canUser` function to be able to handle REST endpoints that are experimental.

This PR has been opened early to initiate discussion.

## To Do Before Merge
- Add unit tests

## How has this been tested?
There is currently no new test added. They need to be.

## Types of changes
Considering this makes changes to a well used, shared function, this refactor has an impact larger than this package.

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
