### PR TITLE
 Trim input value in navigation search input field

### DIFF
--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -501,7 +501,7 @@ function LinkControl( {
 								isURL={ directLinkEntryTypes.includes(
 									suggestion.type.toLowerCase()
 								) }
-								searchTerm={ inputValue.trim() }
+								searchTerm={ inputValue }
 							/>
 						);
 					} ) }

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -501,7 +501,7 @@ function LinkControl( {
 								isURL={ directLinkEntryTypes.includes(
 									suggestion.type.toLowerCase()
 								) }
-								searchTerm={ inputValue }
+								searchTerm={ inputValue.trim() }
 							/>
 						);
 					} ) }

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -214,7 +214,7 @@ class URLInput extends Component {
 
 		this.props.onChange( inputValue );
 		if ( ! this.props.disableSuggestions ) {
-			this.updateSuggestions( inputValue );
+			this.updateSuggestions( inputValue.trim() );
 		}
 	}
 

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -231,7 +231,7 @@ class URLInput extends Component {
 			! ( suggestions && suggestions.length )
 		) {
 			// Ensure the suggestions are updated with the current input value
-			this.updateSuggestions( value );
+			this.updateSuggestions( value.trim() );
 		}
 	}
 

--- a/packages/components/src/text-highlight/index.js
+++ b/packages/components/src/text-highlight/index.js
@@ -9,11 +9,16 @@ import { escapeRegExp } from 'lodash';
 import { __experimentalCreateInterpolateElement } from '@wordpress/element';
 
 const TextHighlight = ( { text = '', highlight = '' } ) => {
-	if ( ! highlight.trim() ) {
+	const trimmedHighlightText = highlight.trim();
+
+	if ( ! trimmedHighlightText ) {
 		return text;
 	}
 
-	const regex = new RegExp( `(${ escapeRegExp( highlight ) })`, 'gi' );
+	const regex = new RegExp(
+		`(${ escapeRegExp( trimmedHighlightText ) })`,
+		'gi'
+	);
 
 	return __experimentalCreateInterpolateElement(
 		text.replace( regex, '<mark>$&</mark>' ),


### PR DESCRIPTION
- Closes #19631

## Description

Trim input values in navigation search input field. 

## How has this been tested?

Added related e2e code. 

## Screenshots <!-- if applicable -->

**Before:**

![Screenshot from 2020-01-23 17-36-30](https://user-images.githubusercontent.com/8130013/72968554-17033200-3e07-11ea-9e03-d68e612d6f2c.png)

**After:**

![Screenshot from 2020-01-23 17-35-55](https://user-images.githubusercontent.com/8130013/72968584-22565d80-3e07-11ea-9646-e5eed7de9e10.png)

**NOTE:** It doesn't show url item at the bottom because `    page     ` is not a valid url.

## Types of changes

Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [NA] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [NA] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.

I'm sorry @WunderBart. I realized that I intercepted your issue after finished implementing it.