### PR TITLE
Paragraph block: remove min-height

### DIFF
--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -66,7 +66,7 @@ function useDropCapMinimumHeight( isDropCap, deps ) {
 					getComputedStyle(
 						element,
 						'first-letter'
-					).height
+					).lineHeight
 				);
 			} else if ( minimumHeight ) {
 				setMinimumHeight( undefined );

--- a/packages/block-library/src/paragraph/editor.scss
+++ b/packages/block-library/src/paragraph/editor.scss
@@ -1,9 +1,4 @@
-.block-editor-block-list__block[data-type="core/paragraph"] p {
-	min-height: $empty-paragraph-height / 2;
-	line-height: $editor-line-height;
-}
-
 // Overwrite the inline style to make the height collapse when the paragraph editable gets focus.
 .block-editor-block-list__block[data-type="core/paragraph"] .has-drop-cap:focus {
-	min-height: $empty-paragraph-height / 2 !important;
+	min-height: auto !important;
 }


### PR DESCRIPTION
## Description

This PR removes the min-height and line height for paragraphs. I believe this is a remnant from the TinyMCE instances days where a paragraph could be empty and collapse. This rule was added to ensure empty paragraphs don't collapse. It's no longer necessary because `RichText` always pads empty paragraphs:

<img width="221" alt="Screenshot 2020-01-23 at 09 58 05" src="https://user-images.githubusercontent.com/4710635/72969974-dedbff00-3dc6-11ea-90da-f5f0d3e3485e.png">

This ensures that no block ever has to have special styles to pad a rich text field.

This styles may actually do damage right now if a theme is reducing the font size of paragraphs.

## How has this been tested?

Test empty paragraphs.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
