### PR TITLE
Try: Block Library polish

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -19,12 +19,12 @@ import {
 	BlockEditorProvider,
 	BlockList,
 	WritingFlow,
-	ObserveTyping
+	ObserveTyping,
 } from '@wordpress/block-editor';
 import { Popover } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 
-function MyEditorComponent () {
+function MyEditorComponent() {
 	const [ blocks, updateBlocks ] = useState( [] );
 
 	return (
@@ -413,7 +413,6 @@ _Properties_
 -   _bodyPlaceholder_ `string`: Empty post placeholder
 -   _titlePlaceholder_ `string`: Empty title placeholder
 -   _codeEditingEnabled_ `boolean`: Whether or not the user can switch to the code editor
--   _showInserterHelpPanel_ `boolean`: Whether or not the inserter help panel is shown
 -   _\_\_experimentalCanUserUseUnfilteredHTML_ `boolean`: Whether the user should be able to use unfiltered HTML or the HTML should be filtered e.g., to remove elements considered insecure like iframes.
 -   _\_\_experimentalEnableLegacyWidgetBlock_ `boolean`: Whether the user has enabled the Legacy Widget Block
 -   _\_\_experimentalBlockDirectory_ `boolean`: Whether the user has enabled the Block Directory

--- a/packages/block-editor/src/components/block-preview/index.js
+++ b/packages/block-editor/src/components/block-preview/index.js
@@ -95,7 +95,8 @@ function ScaledBlockPreview( { blocks, viewportWidth, padding = 0 } ) {
 		};
 	}, [] );
 
-	if ( ! blocks || blocks.length === 0 ) {
+	// previewScale sometimes returns -Infinity when rendered hidden.
+	if ( ! blocks || blocks.length === 0 || previewScale < 0 ) {
 		return null;
 	}
 

--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -111,7 +111,6 @@ class Inserter extends Component {
 			rootClientId,
 			clientId,
 			isAppender,
-			showInserterHelpPanel,
 			__experimentalSelectBlockOnInsert: selectBlockOnInsert,
 		} = this.props;
 
@@ -121,7 +120,6 @@ class Inserter extends Component {
 				rootClientId={ rootClientId }
 				clientId={ clientId }
 				isAppender={ isAppender }
-				showInserterHelpPanel={ showInserterHelpPanel }
 				__experimentalSelectBlockOnInsert={ selectBlockOnInsert }
 			/>
 		);

--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -144,7 +144,7 @@ class Inserter extends Component {
 				className="block-editor-inserter"
 				contentClassName={ classnames(
 					'block-editor-inserter__popover',
-					{ 'is-from-toolbar': !isAppender }
+					{ 'is-top-toolbar-inserter': ! isAppender }
 				) }
 				position={ position }
 				onToggle={ this.onToggle }

--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -2,6 +2,8 @@
  * External dependencies
  */
 import { size } from 'lodash';
+import classnames from 'classnames';
+
 /**
  * WordPress dependencies
  */
@@ -127,6 +129,7 @@ class Inserter extends Component {
 
 	render() {
 		const {
+			isAppender,
 			position,
 			hasSingleBlockType,
 			insertOnlyAllowedBlock,
@@ -139,7 +142,10 @@ class Inserter extends Component {
 		return (
 			<Dropdown
 				className="block-editor-inserter"
-				contentClassName="block-editor-inserter__popover"
+				contentClassName={ classnames(
+					'block-editor-inserter__popover',
+					{ 'is-from-toolbar': !isAppender }
+				) }
 				position={ position }
 				onToggle={ this.onToggle }
 				expandOnMobile

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -510,7 +510,7 @@ export class InserterMenu extends Component {
 								</div>
 							) : (
 								<div className="block-editor-inserter__preview-content-missing">
-									{ __( 'No Preview Available.' ) }
+									{ __( 'No preview available.' ) }
 								</div>
 							) }
 						</div>

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -282,7 +282,6 @@ export class InserterMenu extends Component {
 			instanceId,
 			onSelect,
 			rootClientId,
-			showInserterHelpPanel,
 		} = this.props;
 		const {
 			childItems,
@@ -303,7 +302,6 @@ export class InserterMenu extends Component {
 		const hoveredItemBlockType = hoveredItem
 			? getBlockType( hoveredItem.name )
 			: null;
-		const hasHelpPanel = hasItems && showInserterHelpPanel;
 
 		// Disable reason (no-autofocus): The inserter menu is a modal display, not one which
 		// is always visible, and one which already incurs this behavior of autoFocus via
@@ -467,7 +465,9 @@ export class InserterMenu extends Component {
 
 					<Tip>
 						{ __experimentalCreateInterpolateElement(
-							__( 'While writing, you can press <kbd>/</kbd> to quickly insert new blocks.' ),
+							__(
+								'While writing, you can press <kbd>/</kbd> to quickly insert new blocks.'
+							),
 							{ kbd: <kbd /> }
 						) }
 					</Tip>
@@ -479,7 +479,8 @@ export class InserterMenu extends Component {
 							<BlockCard blockType={ hoveredItemBlockType } />
 						) }
 						<div className="block-editor-inserter__preview">
-							{ ( isReusableBlock( hoveredItem ) || hoveredItemBlockType.example ) ? (
+							{ isReusableBlock( hoveredItem ) ||
+							hoveredItemBlockType.example ? (
 								<div className="block-editor-inserter__preview-content">
 									<BlockPreview
 										padding={ 10 }
@@ -500,11 +501,11 @@ export class InserterMenu extends Component {
 																	.example
 																	.innerBlocks,
 														}
-													)
+												  )
 												: createBlock(
 														hoveredItem.name,
 														hoveredItem.initialAttributes
-													)
+												  )
 										}
 									/>
 								</div>
@@ -523,53 +524,43 @@ export class InserterMenu extends Component {
 }
 
 export default compose(
-	withSelect(
-		(
-			select,
-			{ clientId, isAppender, rootClientId, showInserterHelpPanel }
-		) => {
-			const {
-				getInserterItems,
-				getBlockName,
-				getBlockRootClientId,
-				getBlockSelectionEnd,
-				getSettings,
-			} = select( 'core/block-editor' );
-			const {
-				getCategories,
-				getCollections,
-				getChildBlockNames,
-			} = select( 'core/blocks' );
+	withSelect( ( select, { clientId, isAppender, rootClientId } ) => {
+		const {
+			getInserterItems,
+			getBlockName,
+			getBlockRootClientId,
+			getBlockSelectionEnd,
+			getSettings,
+		} = select( 'core/block-editor' );
+		const { getCategories, getCollections, getChildBlockNames } = select(
+			'core/blocks'
+		);
 
-			let destinationRootClientId = rootClientId;
-			if ( ! destinationRootClientId && ! clientId && ! isAppender ) {
-				const end = getBlockSelectionEnd();
-				if ( end ) {
-					destinationRootClientId =
-						getBlockRootClientId( end ) || undefined;
-				}
+		let destinationRootClientId = rootClientId;
+		if ( ! destinationRootClientId && ! clientId && ! isAppender ) {
+			const end = getBlockSelectionEnd();
+			if ( end ) {
+				destinationRootClientId =
+					getBlockRootClientId( end ) || undefined;
 			}
-			const destinationRootBlockName = getBlockName(
-				destinationRootClientId
-			);
-
-			const {
-				showInserterHelpPanel: showInserterHelpPanelSetting,
-				__experimentalFetchReusableBlocks: fetchReusableBlocks,
-			} = getSettings();
-
-			return {
-				categories: getCategories(),
-				collections: getCollections(),
-				rootChildBlocks: getChildBlockNames( destinationRootBlockName ),
-				items: getInserterItems( destinationRootClientId ),
-				showInserterHelpPanel:
-					showInserterHelpPanel && showInserterHelpPanelSetting,
-				destinationRootClientId,
-				fetchReusableBlocks,
-			};
 		}
-	),
+		const destinationRootBlockName = getBlockName(
+			destinationRootClientId
+		);
+
+		const {
+			__experimentalFetchReusableBlocks: fetchReusableBlocks,
+		} = getSettings();
+
+		return {
+			categories: getCategories(),
+			collections: getCollections(),
+			rootChildBlocks: getChildBlockNames( destinationRootBlockName ),
+			items: getInserterItems( destinationRootClientId ),
+			destinationRootClientId,
+			fetchReusableBlocks,
+		};
+	} ),
 	withDispatch( ( dispatch, ownProps, { select } ) => {
 		const { showInsertionPoint, hideInsertionPoint } = dispatch(
 			'core/block-editor'

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -13,7 +13,6 @@ import {
 	includes,
 } from 'lodash';
 import scrollIntoView from 'dom-scroll-into-view';
-import classnames from 'classnames';
 
 /**
  * WordPress dependencies
@@ -314,9 +313,7 @@ export class InserterMenu extends Component {
 		/* eslint-disable jsx-a11y/no-autofocus, jsx-a11y/no-static-element-interactions */
 		return (
 			<div
-				className={ classnames( 'block-editor-inserter__menu', {
-					'has-help-panel': hasHelpPanel,
-				} ) }
+				className="block-editor-inserter__menu"
 				onKeyPress={ stopKeyPropagation }
 				onKeyDown={ this.onKeyDown }
 			>
@@ -467,86 +464,56 @@ export class InserterMenu extends Component {
 							} }
 						</__experimentalInserterMenuExtension.Slot>
 					</div>
+
+					<Tip>
+						{ __experimentalCreateInterpolateElement(
+							__( 'While writing, you can press <kbd>/</kbd> to quickly insert new blocks.' ),
+							{ kbd: <kbd /> }
+						) }
+					</Tip>
 				</div>
 
-				{ hasHelpPanel && (
-					<div className="block-editor-inserter__menu-help-panel">
-						{ hoveredItem && (
-							<>
-								{ ! isReusableBlock( hoveredItem ) && (
-									<BlockCard blockType={ hoveredItem } />
-								) }
-								<div className="block-editor-inserter__preview">
-									{ isReusableBlock( hoveredItem ) ||
-									hoveredItemBlockType.example ? (
-										<div className="block-editor-inserter__preview-content">
-											<BlockPreview
-												padding={ 10 }
-												viewportWidth={ 500 }
-												blocks={
-													hoveredItemBlockType.example
-														? getBlockFromExample(
-																hoveredItem.name,
-																{
-																	attributes: {
-																		...hoveredItemBlockType
-																			.example
-																			.attributes,
-																		...hoveredItem.initialAttributes,
-																	},
-																	innerBlocks:
-																		hoveredItemBlockType
-																			.example
-																			.innerBlocks,
-																}
-														  )
-														: createBlock(
-																hoveredItem.name,
-																hoveredItem.initialAttributes
-														  )
-												}
-											/>
-										</div>
-									) : (
-										<div className="block-editor-inserter__preview-content-missing">
-											{ __( 'No Preview Available.' ) }
-										</div>
-									) }
-								</div>
-							</>
+				{ hoveredItem && (
+					<div className="block-editor-inserter__preview-panel">
+						{ ! isReusableBlock( hoveredItem ) && (
+							<BlockCard blockType={ hoveredItemBlockType } />
 						) }
-						{ ! hoveredItem && (
-							<div className="block-editor-inserter__menu-help-panel-no-block">
-								<div className="block-editor-inserter__menu-help-panel-no-block-text">
-									<div className="block-editor-inserter__menu-help-panel-title">
-										{ __( 'Content blocks' ) }
-									</div>
-									<p>
-										{ __(
-											'Welcome to the wonderful world of blocks! Blocks are the basis of all content within the editor.'
-										) }
-									</p>
-									<p>
-										{ __(
-											'There are blocks available for all kinds of content: insert text, headings, images, lists, videos, tables, and lots more.'
-										) }
-									</p>
-									<p>
-										{ __(
-											'Browse through the library to learn more about what each block does.'
-										) }
-									</p>
+						<div className="block-editor-inserter__preview">
+							{ ( isReusableBlock( hoveredItem ) || hoveredItemBlockType.example ) ? (
+								<div className="block-editor-inserter__preview-content">
+									<BlockPreview
+										padding={ 10 }
+										viewportWidth={ 500 }
+										blocks={
+											hoveredItemBlockType.example
+												? getBlockFromExample(
+														hoveredItem.name,
+														{
+															attributes: {
+																...hoveredItemBlockType
+																	.example
+																	.attributes,
+																...hoveredItem.initialAttributes,
+															},
+															innerBlocks:
+																hoveredItemBlockType
+																	.example
+																	.innerBlocks,
+														}
+													)
+												: createBlock(
+														hoveredItem.name,
+														hoveredItem.initialAttributes
+													)
+										}
+									/>
 								</div>
-								<Tip>
-									{ __experimentalCreateInterpolateElement(
-										__(
-											'While writing, you can press <kbd>/</kbd> to quickly insert new blocks.'
-										),
-										{ kbd: <kbd /> }
-									) }
-								</Tip>
-							</div>
-						) }
+							) : (
+								<div className="block-editor-inserter__preview-content-missing">
+									{ __( 'No Preview Available.' ) }
+								</div>
+							) }
+						</div>
 					</div>
 				) }
 			</div>

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -30,48 +30,66 @@
 }
 
 // Popover container.
-.block-editor-inserter__popover > .components-popover__content {
-	@include break-medium {
-		overflow-y: visible;
-		height: 92vh; // This is limited by a max-height from the popover component itself.
-		width: 82vw; // This is limited by a max-width.
+.block-editor-inserter__popover {
 
-		.is-fullscreen-mode & {
-			width: 86vw;
-		}
-
-		// We take up the whole space horizontally, so as to afford a preview panel appearing.
-		// The layer is only for layout, and should not block clicks through it.
-		pointer-events: none;
+	// The in-canvas appender library.
+	> .components-popover__content {
+		height: 440px;
 	}
 
-	// Remove the popover styling and apply it instead to each sub panel.
-	box-shadow: none;
-	border: none;
-	background: none;
+	// The toolbar library.
+	&.is-from-toolbar > .components-popover__content {
+		@include break-medium {
+			overflow-y: visible;
+			height: 92vh; // This is limited by a max-height from the popover component itself.
+			width: 82vw; // This is limited by a max-width.
+
+			.is-fullscreen-mode & {
+				width: 86vw;
+			}
+
+			// We take up the whole space horizontally, so as to afford a preview panel appearing.
+			// The layer is only for layout, and should not block clicks through it.
+			pointer-events: none;
+		}
+
+		// Remove the popover styling and apply it instead to each sub panel.
+		box-shadow: none;
+		border: none;
+		background: none;
+	}
 }
 
 // Container for all inserter content.
 .block-editor-inserter__menu {
 	height: 100%;
 	display: flex;
-	width: 100%;
+	width: auto;
 
 	@include break-medium {
-		min-width: 480px;
-		position: relative;
+		width: 400px;
+
+		.is-from-toolbar & {
+			width: 100%;
+			min-width: 480px;
+			position: relative;
+		}
 	}
 
 	.components-tip {
-		padding: $grid-size-large;
-		display: flex;
-		align-items: center;
+		display: none;
+
+		.is-from-toolbar & {
+			padding: $grid-size-large;
+			display: flex;
+			align-items: center;
+		}
 	}
 }
 
-// Show popover background behind main menu and preview both.
-.block-editor-inserter__main-area,
-.block-editor-inserter__preview-panel {
+// When opened from toolbar, show popover background behind main menu and preview.
+.is-from-toolbar .block-editor-inserter__main-area,
+.is-from-toolbar .block-editor-inserter__preview-panel {
 	background: $white;
 
 	@include break-medium() {
@@ -88,13 +106,16 @@
 	display: flex;
 	flex-direction: column;
 	height: 100%;
+	width: 100%;
 
 	@include break-medium {
-		position: relative;
-		margin-right: $grid-size-large;
+		.is-from-toolbar & {
+			position: relative;
+			margin-right: $grid-size-large;
 
-		// Re-enable clicks on this layer.
-		pointer-events: all;
+			// Re-enable clicks on this layer.
+			pointer-events: all;
+		}
 	}
 }
 
@@ -187,34 +208,36 @@
 .block-editor-inserter__preview-panel {
 	display: none;
 
-	// Show preview panel when inserter is not modal.
+	// Show preview panel when inserter is not modal, and opened from inserter.
 	@include break-medium () {
-		display: block;
-		position: relative;
-		min-height: 480px;
-		height: 50%;
-		max-height: 640px;
-		overflow: hidden;
-		padding: $grid-size-large;
-		@include edit-post__fade-in-animation();
-
-		.block-editor-block-card {
-			min-height: 6em;
-			padding-bottom: $grid-size-large;
-			margin-bottom: $grid-size-large;
-			border-bottom: $border-width solid $light-gray-500;
-		}
-
-		// Create a white overlay at the bottom of the preview to soft-crop the preview.
-		&::after {
-			content: "";
+		.is-from-toolbar & {
 			display: block;
-			position: absolute;
-			right: 0;
-			bottom: 0;
-			left: 0;
-			height: $grid-size-large;
-			background: $white;
+			position: relative;
+			min-height: 480px;
+			height: 50%;
+			max-height: 640px;
+			overflow: hidden;
+			padding: $grid-size-large;
+			@include edit-post__fade-in-animation();
+
+			.block-editor-block-card {
+				min-height: 6em;
+				padding-bottom: $grid-size-large;
+				margin-bottom: $grid-size-large;
+				border-bottom: $border-width solid $light-gray-500;
+			}
+
+			// Create a white overlay at the bottom of the preview to soft-crop the preview.
+			&::after {
+				content: "";
+				display: block;
+				position: absolute;
+				right: 0;
+				bottom: 0;
+				left: 0;
+				height: $grid-size-large;
+				background: $white;
+			}
 		}
 	}
 }

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -33,7 +33,12 @@
 .block-editor-inserter__popover > .components-popover__content {
 	@include break-medium {
 		overflow-y: visible;
-		height: 92vh; // This is further limited by a max-height from the popover component itself.
+		width: 86vw; // This is limited by a max-width.
+		height: 92vh; // This is limited by a max-height from the popover component itself.
+
+		// We take up the whole space horizontally, so as to afford a preview panel appearing.
+		// The layer is only for layout, and should not block clicks through it.
+		pointer-events: none;
 	}
 
 	// Remove the popover styling and apply it instead to each sub panel.
@@ -55,17 +60,23 @@
 
 	.components-tip {
 		padding: 0 $grid-size-large $grid-size-large $grid-size-large;
+		display: flex;
+		align-items: center;
 	}
 }
 
 // Show popover background behind main menu and preview both.
 .block-editor-inserter__main-area,
 .block-editor-inserter__preview-panel {
-	box-shadow: $shadow-popover;
-	border: $border-width solid $light-gray-500;
 	background: $white;
+	width: 49%;
+	width: calc(50% - #{$grid-size-large});
 
-	width: 480px;
+	@include break-medium() {
+		box-shadow: $shadow-popover;
+		border: $border-width solid $light-gray-500;
+		max-width: 480px;
+	}
 }
 
 // Container for just the block library.
@@ -73,11 +84,13 @@
 	display: flex;
 	flex-direction: column;
 	height: 100%;
-
 	margin-right: $grid-size-large;
 
 	@include break-medium {
 		position: relative;
+
+		// Re-enable clicks on this layer.
+		pointer-events: all;
 	}
 }
 
@@ -95,6 +108,7 @@
 
 .components-popover input[type="search"].block-editor-inserter__search {
 	display: block;
+	flex-shrink: 0;
 	margin: $grid-size-large;
 	padding: 11px $grid-size-large;
 	position: relative;
@@ -167,13 +181,33 @@
 
 // Container for the preview.
 .block-editor-inserter__preview-panel {
-	height: 480px;
-	padding: $grid-size-large;
-	@include edit-post__fade-in-animation();
+	display: none;
 
-	.block-editor-block-card {
-		padding-bottom: $grid-size-large;
-		margin-bottom: $grid-size;
-		border-bottom: $border-width solid $light-gray-500;
+	// Show preview panel when inserter is not modal.
+	@include break-medium () {
+		display: block;
+		position: relative;
+		height: 480px;
+		padding: $grid-size-large;
+		@include edit-post__fade-in-animation();
+
+		.block-editor-block-card {
+			min-height: 6em;
+			padding-bottom: $grid-size-large;
+			margin-bottom: $grid-size-large;
+			border-bottom: $border-width solid $light-gray-500;
+		}
+
+		// Create a white overlay at the bottom of the preview to soft-crop the preview.
+		&::after {
+			content: "";
+			display: block;
+			position: absolute;
+			right: 0;
+			bottom: 0;
+			left: 0;
+			height: $grid-size-large;
+			background: $white;
+		}
 	}
 }

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -1,7 +1,8 @@
-$block-inserter-content-height: 350px;
-$block-inserter-tabs-height: 44px;
-$block-inserter-search-height: 38px;
+/**
+ * Block Library
+ */
 
+// Plus button.
 .block-editor-inserter {
 	display: inline-block;
 	background: none;
@@ -14,42 +15,68 @@ $block-inserter-search-height: 38px;
 	@include break-medium {
 		position: relative;
 	}
+
+	.block-editor-inserter__toggle {
+		display: inline-flex;
+		align-items: center;
+		color: $dark-gray-500;
+		background: none;
+		cursor: pointer;
+		border: none;
+		outline: none;
+		transition: color 0.2s ease;
+		@include reduce-motion("transition");
+	}
 }
 
+// Popover container.
 .block-editor-inserter__popover > .components-popover__content {
 	@include break-medium {
 		overflow-y: visible;
-		height: $block-inserter-content-height + $block-inserter-tabs-height + $block-inserter-search-height;
+		height: 92vh; // This is further limited by a max-height from the popover component itself.
 	}
+
+	// Remove the popover styling and apply it instead to each sub panel.
+	box-shadow: none;
+	border: none;
+	background: none;
 }
 
-.block-editor-inserter__toggle {
-	transition: color 0.2s ease;
-	@include reduce-motion("transition");
-}
-
+// Container for all inserter content.
 .block-editor-inserter__menu {
 	height: 100%;
 	display: flex;
-	width: auto;
+	width: 100%;
 
 	@include break-medium {
-		width: 400px;
+		min-width: 480px;
 		position: relative;
+	}
 
-		&.has-help-panel {
-			width: 700px;
-		}
+	.components-tip {
+		padding: 0 $grid-size-large $grid-size-large $grid-size-large;
 	}
 }
 
+// Show popover background behind main menu and preview both.
+.block-editor-inserter__main-area,
+.block-editor-inserter__preview-panel {
+	box-shadow: $shadow-popover;
+	border: $border-width solid $light-gray-500;
+	background: $white;
+
+	width: 480px;
+}
+
+// Container for just the block library.
 .block-editor-inserter__main-area {
-	width: auto;
 	display: flex;
 	flex-direction: column;
 	height: 100%;
+
+	margin-right: $grid-size-large;
+
 	@include break-medium {
-		width: 400px;
 		position: relative;
 	}
 }
@@ -96,10 +123,6 @@ $block-inserter-search-height: 38px;
 		outline: $border-width dotted $dark-gray-500;
 	}
 
-	@include break-medium {
-		height: $block-inserter-content-height + $block-inserter-tabs-height;
-	}
-
 	// Don't show the top border on the first panel, let the Search border be the border.
 	[role="presentation"] + .components-panel__body {
 		border-top: none;
@@ -142,91 +165,15 @@ $block-inserter-search-height: 38px;
 	}
 }
 
-.block-editor-inserter__menu-help-panel {
-	display: none;
-	border-left: $border-width solid $light-gray-500;
-	width: 300px;
-	height: 100%;
-	padding: 20px;
-	overflow-y: auto;
-
-	@include break-medium {
-		display: flex;
-		flex-direction: column;
-	}
-
-	.block-editor-block-card {
-		padding-bottom: 20px;
-		margin-bottom: 20px;
-		border-bottom: $border-width solid $light-gray-500;
-		@include edit-post__fade-in-animation();
-	}
-
-	.block-editor-inserter__preview {
-		display: flex;
-		flex-grow: 2;
-	}
-}
-
-.block-editor-inserter__menu-help-panel-no-block {
-	display: flex;
-	height: 100%;
-	flex-direction: column;
+// Container for the preview.
+.block-editor-inserter__preview-panel {
+	height: 480px;
+	padding: $grid-size-large;
 	@include edit-post__fade-in-animation();
 
-	.block-editor-inserter__menu-help-panel-no-block-text {
-		flex-grow: 1;
-
-		h4 {
-			font-size: $big-font-size;
-		}
+	.block-editor-block-card {
+		padding-bottom: $grid-size-large;
+		margin-bottom: $grid-size;
+		border-bottom: $border-width solid $light-gray-500;
 	}
-
-	.components-notice {
-		margin: 0;
-	}
-
-	h4 {
-		margin-top: 0;
-	}
-}
-
-.block-editor-inserter__menu-help-panel-hover-area {
-	flex-grow: 1;
-	margin-top: 20px;
-	padding: 20px;
-	border: 1px dotted $light-gray-500;
-	display: flex;
-	align-items: center;
-	text-align: center;
-}
-
-.block-editor-inserter__menu-help-panel-title {
-	font-size: $big-font-size;
-	font-weight: 600;
-	margin-bottom: 20px;
-}
-
-.block-editor-inserter__preview-content {
-	border: $border-width solid $light-gray-500;
-	border-radius: $radius-round-rectangle;
-	min-height: 150px;
-	display: grid;
-	flex-grow: 2;
-
-	.block-editor-block-preview__container {
-		margin-right: 0;
-		margin-left: 0;
-		padding: 10px;
-	}
-}
-
-.block-editor-inserter__preview-content-missing {
-	flex: 1;
-	display: flex;
-	justify-content: center;
-	color: $dark-gray-400;
-	border: $border-width solid $light-gray-500;
-	border-radius: $radius-round-rectangle;
-	align-items: center;
 }

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -33,8 +33,12 @@
 .block-editor-inserter__popover > .components-popover__content {
 	@include break-medium {
 		overflow-y: visible;
-		width: 86vw; // This is limited by a max-width.
 		height: 92vh; // This is limited by a max-height from the popover component itself.
+		width: 82vw; // This is limited by a max-width.
+
+		.is-fullscreen-mode & {
+			width: 86vw;
+		}
 
 		// We take up the whole space horizontally, so as to afford a preview panel appearing.
 		// The layer is only for layout, and should not block clicks through it.
@@ -59,7 +63,7 @@
 	}
 
 	.components-tip {
-		padding: 0 $grid-size-large $grid-size-large $grid-size-large;
+		padding: $grid-size-large;
 		display: flex;
 		align-items: center;
 	}
@@ -69,10 +73,10 @@
 .block-editor-inserter__main-area,
 .block-editor-inserter__preview-panel {
 	background: $white;
-	width: 49%;
-	width: calc(50% - #{$grid-size-large});
 
 	@include break-medium() {
+		width: 49%;
+		width: calc(50% - #{$grid-size-large});
 		box-shadow: $shadow-popover;
 		border: $border-width solid $light-gray-500;
 		max-width: 480px;
@@ -84,10 +88,10 @@
 	display: flex;
 	flex-direction: column;
 	height: 100%;
-	margin-right: $grid-size-large;
 
 	@include break-medium {
 		position: relative;
+		margin-right: $grid-size-large;
 
 		// Re-enable clicks on this layer.
 		pointer-events: all;
@@ -187,7 +191,10 @@
 	@include break-medium () {
 		display: block;
 		position: relative;
-		height: 480px;
+		min-height: 480px;
+		height: 50%;
+		max-height: 640px;
+		overflow: hidden;
 		padding: $grid-size-large;
 		@include edit-post__fade-in-animation();
 

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -38,7 +38,7 @@
 	}
 
 	// The toolbar library.
-	&.is-from-toolbar > .components-popover__content {
+	&.is-top-toolbar-inserter > .components-popover__content {
 		@include break-medium {
 			overflow-y: visible;
 			height: 92vh; // This is limited by a max-height from the popover component itself.
@@ -69,7 +69,7 @@
 	@include break-medium {
 		width: 400px;
 
-		.is-from-toolbar & {
+		.is-top-toolbar-inserter & {
 			width: 100%;
 			min-width: 480px;
 			position: relative;
@@ -79,7 +79,7 @@
 	.components-tip {
 		display: none;
 
-		.is-from-toolbar & {
+		.is-top-toolbar-inserter & {
 			padding: $grid-size-large;
 			display: flex;
 			align-items: center;
@@ -88,8 +88,8 @@
 }
 
 // When opened from toolbar, show popover background behind main menu and preview.
-.is-from-toolbar .block-editor-inserter__main-area,
-.is-from-toolbar .block-editor-inserter__preview-panel {
+.is-top-toolbar-inserter .block-editor-inserter__main-area,
+.is-top-toolbar-inserter .block-editor-inserter__preview-panel {
 	background: $white;
 
 	@include break-medium() {
@@ -109,7 +109,7 @@
 	width: 100%;
 
 	@include break-medium {
-		.is-from-toolbar & {
+		.is-top-toolbar-inserter & {
 			position: relative;
 			margin-right: $grid-size-large;
 
@@ -210,7 +210,7 @@
 
 	// Show preview panel when inserter is not modal, and opened from inserter.
 	@include break-medium () {
-		.is-from-toolbar & {
+		.is-top-toolbar-inserter & {
 			display: block;
 			position: relative;
 			min-height: 480px;

--- a/packages/block-editor/src/store/defaults.js
+++ b/packages/block-editor/src/store/defaults.js
@@ -28,7 +28,6 @@ export const PREFERENCES_DEFAULTS = {
  * @property {string} bodyPlaceholder Empty post placeholder
  * @property {string} titlePlaceholder Empty title placeholder
  * @property {boolean} codeEditingEnabled Whether or not the user can switch to the code editor
- * @property {boolean} showInserterHelpPanel Whether or not the inserter help panel is shown
  * @property {boolean} __experimentalCanUserUseUnfilteredHTML Whether the user should be able to use unfiltered HTML or the HTML should be filtered e.g., to remove elements considered insecure like iframes.
  * @property {boolean} __experimentalEnableLegacyWidgetBlock Whether the user has enabled the Legacy Widget Block
  * @property {boolean} __experimentalBlockDirectory Whether the user has enabled the Block Directory
@@ -147,7 +146,6 @@ export const SETTINGS_DEFAULTS = {
 
 	availableLegacyWidgets: {},
 	hasPermissionsToManageWidgets: false,
-	showInserterHelpPanel: true,
 	__experimentalCanUserUseUnfilteredHTML: false,
 	__experimentalEnableLegacyWidgetBlock: false,
 	__experimentalBlockDirectory: false,

--- a/packages/components/src/tip/style.scss
+++ b/packages/components/src/tip/style.scss
@@ -4,7 +4,7 @@
 
 	svg {
 		align-self: center;
-		fill: $alert-yellow;
+		fill: $blue-medium-focus;
 		flex-shrink: 0;
 		margin-right: $grid-size-large;
 	}

--- a/packages/edit-post/src/components/header/header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.js
@@ -45,11 +45,7 @@ function HeaderToolbar() {
 			className="edit-post-header-toolbar"
 			aria-label={ toolbarAriaLabel }
 		>
-			<Inserter
-				disabled={ ! showInserter }
-				position="bottom right"
-				showInserterHelpPanel
-			/>
+			<Inserter disabled={ ! showInserter } position="bottom right" />
 			<EditorHistoryUndo />
 			<EditorHistoryRedo />
 			<TableOfContents hasOutlineItemsDisabled={ isTextModeEnabled } />

--- a/packages/edit-post/src/components/options-modal/index.js
+++ b/packages/edit-post/src/components/options-modal/index.js
@@ -26,7 +26,6 @@ import {
 	EnablePluginDocumentSettingPanelOption,
 	EnablePublishSidebarOption,
 	EnablePanelOption,
-	EnableFeature,
 } from './options';
 import MetaBoxesSection from './meta-boxes-section';
 
@@ -47,10 +46,6 @@ export function OptionsModal( { isModalActive, isViewable, closeModal } ) {
 			<Section title={ __( 'General' ) }>
 				<EnablePublishSidebarOption
 					label={ __( 'Pre-publish checks' ) }
-				/>
-				<EnableFeature
-					feature="showInserterHelpPanel"
-					label={ __( 'Inserter help panel' ) }
 				/>
 			</Section>
 			<Section title={ __( 'Document panels' ) }>

--- a/packages/edit-post/src/components/options-modal/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/options-modal/test/__snapshots__/index.js.snap
@@ -12,10 +12,6 @@ exports[`OptionsModal should match snapshot when the modal is active 1`] = `
     <WithSelect(WithDispatch(IfViewportMatches(BaseOption)))
       label="Pre-publish checks"
     />
-    <WithSelect(WithDispatch(BaseOption))
-      feature="showInserterHelpPanel"
-      label="Inserter help panel"
-    />
   </Section>
   <Section
     title="Document panels"

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -41,7 +41,6 @@ class Editor extends Component {
 	getEditorSettings(
 		settings,
 		hasFixedToolbar,
-		showInserterHelpPanel,
 		focusMode,
 		hiddenBlockTypes,
 		blockTypes,
@@ -57,7 +56,6 @@ class Editor extends Component {
 			},
 			hasFixedToolbar,
 			focusMode,
-			showInserterHelpPanel,
 			__experimentalLocalAutosaveInterval,
 		};
 
@@ -93,7 +91,6 @@ class Editor extends Component {
 			blockTypes,
 			preferredStyleVariations,
 			__experimentalLocalAutosaveInterval,
-			showInserterHelpPanel,
 			updatePreferredStyleVariations,
 			...props
 		} = this.props;
@@ -105,7 +102,6 @@ class Editor extends Component {
 		const editorSettings = this.getEditorSettings(
 			settings,
 			hasFixedToolbar,
-			showInserterHelpPanel,
 			focusMode,
 			hiddenBlockTypes,
 			blockTypes,
@@ -150,7 +146,6 @@ export default compose( [
 		const { getBlockTypes } = select( 'core/blocks' );
 
 		return {
-			showInserterHelpPanel: isFeatureActive( 'showInserterHelpPanel' ),
 			hasFixedToolbar: isFeatureActive( 'fixedToolbar' ),
 			focusMode: isFeatureActive( 'focusMode' ),
 			post: getEntityRecord( 'postType', postType, postId ),

--- a/packages/edit-post/src/store/defaults.js
+++ b/packages/edit-post/src/store/defaults.js
@@ -8,7 +8,6 @@ export const PREFERENCES_DEFAULTS = {
 	},
 	features: {
 		fixedToolbar: false,
-		showInserterHelpPanel: true,
 		welcomeGuide: true,
 	},
 	pinnedPluginItems: {},

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -118,7 +118,6 @@ class EditorProvider extends Component {
 				'__experimentalEnableFullSiteEditing',
 				'__experimentalEnableFullSiteEditingDemo',
 				'__experimentalEnablePageTemplates',
-				'showInserterHelpPanel',
 				'gradients',
 			] ),
 			mediaUpload: hasUploadPermissions ? mediaUpload : undefined,


### PR DESCRIPTION
This starts work on https://github.com/WordPress/gutenberg/issues/17335#issuecomment-562049752.

Desktop:

![desktop](https://user-images.githubusercontent.com/1204802/73068705-26888680-3eac-11ea-9a86-e9b8bf23a302.gif)

Medium sized desktop:

<img width="981" alt="Screenshot 2020-01-24 at 13 09 39" src="https://user-images.githubusercontent.com/1204802/73068714-2daf9480-3eac-11ea-806c-344c2b688bcc.png">

Smaller screens and mobile:

<img width="806" alt="Screenshot 2020-01-24 at 13 10 02" src="https://user-images.githubusercontent.com/1204802/73068737-3902c000-3eac-11ea-85fc-83325be0e9a1.png">

For starters, it redesigns the block library:

- It is full-height to give lots more space.
- It drops the help panel, as we now have a welcome screen.
- It moves the tip to the footer.
- It detaches the preview and shows it only on hover.

<strike>Still to do here, is to polish the responsive behavior, possibly apply the new category names, and massage the pixels a bit further.</strike>

What should also be done is to explore the UI from #18667, as well as add a tab for block patterns, and finally the ability for the block library to open as a modal dialog defaulting to the block patterns tab when opened from the sibling inserter. However these are probably best explored separately.

<strike>For now and serving as a prototype, </strike> I appreciate how much space there is, including whitespace. The detached preview also feels lighter, even if it actually covers a bit more content. The amount of red in the code is also encouraging. 