### PR TITLE
Rich text: move default styles to editor normalisation stylesheet

### DIFF
--- a/packages/block-editor/src/components/rich-text/style.scss
+++ b/packages/block-editor/src/components/rich-text/style.scss
@@ -3,19 +3,6 @@
 		margin-top: 0;
 	}
 
-	a {
-		color: $blue-medium-700;
-	}
-
-	code {
-		padding: 2px;
-		border-radius: 2px;
-		color: $dark-gray-800;
-		background: $light-gray-200;
-		font-family: $editor-html-font;
-		font-size: inherit; // This is necessary to override upstream CSS.
-	}
-
 	[data-rich-text-placeholder] {
 		pointer-events: none;
 	}

--- a/packages/editor/src/editor-styles.scss
+++ b/packages/editor/src/editor-styles.scss
@@ -144,3 +144,16 @@ ol ul {
 		max-width: 1100px;
 	}
 }
+
+a {
+	color: $blue-medium-700;
+}
+
+code {
+	padding: 2px;
+	border-radius: 2px;
+	color: $dark-gray-800;
+	background: $light-gray-200;
+	font-family: $editor-html-font;
+	font-size: inherit; // This is necessary to override upstream CSS.
+}

--- a/packages/editor/src/editor-styles.scss
+++ b/packages/editor/src/editor-styles.scss
@@ -146,14 +146,15 @@ ol ul {
 }
 
 a {
-	color: $blue-medium-700;
+	color: inherit;
+	transition: none;
 }
 
-code {
-	padding: 2px;
-	border-radius: 2px;
-	color: $dark-gray-800;
-	background: $light-gray-200;
-	font-family: $editor-html-font;
-	font-size: inherit; // This is necessary to override upstream CSS.
+code,
+kbd {
+	padding: 0;
+	margin: 0;
+	background: inherit;
+	font-size: inherit;
+	font-family: monospace;
 }


### PR DESCRIPTION
## Description

Blocks #21079.

This PR moves default styles for the `a` and `code` elements from rich text to the editor normalisation stylesheet. These styles do not belong at all in rich text. Themes are supposed to be able to override these styles without needing rich text selectors.

Admin styles that need to be reset:

```css
code, kbd {
    padding: 3px 5px 2px 5px;
    margin: 0 1px;
    background: #eaeaea;
    background: rgba(0,0,0,.07);
    font-size: 13px;
}
```

```css
.code, code {
    font-family: Consolas,Monaco,monospace;
    direction: ltr;
    unicode-bidi: embed;
}
```

```css
a {
    color: #0073aa;
    transition-property: border,background,color;
    transition-duration: .05s;
    transition-timing-function: ease-in-out;
}
```

## How has this been tested?

Test the `a` and `code` elements in e.g. a paragraph.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
