### PR TITLE
Fix panel header styles

### DIFF
--- a/packages/components/src/panel/style.scss
+++ b/packages/components/src/panel/style.scss
@@ -28,11 +28,6 @@
 	&.is-opened {
 		padding: $panel-padding;
 	}
-
-	// panel section header
-	&-title > .components-button {
-		color: $dark-gray-900;
-	}
 }
 
 .components-panel__header {

--- a/packages/components/src/panel/style.scss
+++ b/packages/components/src/panel/style.scss
@@ -29,7 +29,7 @@
 		padding: $panel-padding;
 	}
 
-	// panel section header 	
+	// panel section header
 	&-title > .components-button {
 		color: $dark-gray-900;
 	}

--- a/packages/components/src/panel/style.scss
+++ b/packages/components/src/panel/style.scss
@@ -29,7 +29,8 @@
 		padding: $panel-padding;
 	}
 
-	> .components-button {
+	// panel section header 	
+	&-title > .components-button {
 		color: $dark-gray-900;
 	}
 }


### PR DESCRIPTION
## Description

af3153afe99f9c4be614c2943a6ad1559c846534 & 3ca05a7d0ef966df724ebe744b04efd4330e7c20 have effectively updated the color of any `.components-button` button placed in the side panel. 
This selector should however affect only the button in the panel title. Otherwise, it also affects any `.components-button` placed in the side panel.

## How has this been tested?

by changing the selector in Chrome devtools

## Screenshots <!-- if applicable -->

before: 

![image](https://user-images.githubusercontent.com/7383192/72982951-8c0f4100-3de0-11ea-98ec-2b23917b002b.png)

after:

![image](https://user-images.githubusercontent.com/7383192/72982995-a47f5b80-3de0-11ea-9aab-09665abb6288.png)
## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
