### PR TITLE
Do not unmount the sidebar when opening the publish pane

### DIFF
--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -128,28 +128,24 @@ function Layout() {
 					className={ className }
 					header={ <Header /> }
 					sidebar={
-						! publishSidebarOpened && (
-							<>
-								{ ! sidebarIsOpened && (
-									<div className="edit-post-layout__toogle-sidebar-panel">
-										<Button
-											isSecondary
-											className="edit-post-layout__toogle-sidebar-panel-button"
-											onClick={ openSidebarPanel }
-											aria-expanded={ false }
-										>
-											{ hasBlockSelected
-												? __( 'Open block settings' )
-												: __(
-														'Open document settings'
-												  ) }
-										</Button>
-									</div>
-								) }
-								<SettingsSidebar />
-								<Sidebar.Slot />
-							</>
-						)
+						<>
+							{ ! sidebarIsOpened && (
+								<div className="edit-post-layout__toogle-sidebar-panel">
+									<Button
+										isSecondary
+										className="edit-post-layout__toogle-sidebar-panel-button"
+										onClick={ openSidebarPanel }
+										aria-expanded={ false }
+									>
+										{ hasBlockSelected
+											? __( 'Open block settings' )
+											: __( 'Open document settings' ) }
+									</Button>
+								</div>
+							) }
+							<SettingsSidebar />
+							<Sidebar.Slot />
+						</>
 					}
 					content={
 						<>


### PR DESCRIPTION
## Description
Closes #19840
Leaves the sidebar open and in page below the publish panel. In doing so it avoids the content jumping to the right because of new found viewport width.

## How has this been tested?
- Create a new post
- Open the publish panel
- The content region has the same width


