### PR TITLE
Testing: Use deterministic selectors for incremented IDs

### DIFF
--- a/packages/e2e-tests/config/setup-test-framework.js
+++ b/packages/e2e-tests/config/setup-test-framework.js
@@ -83,8 +83,8 @@ async function trashExistingPosts() {
 	}
 
 	// Select all posts.
-	await page.waitForSelector( '#cb-select-all-1' );
-	await page.click( '#cb-select-all-1' );
+	await page.waitForSelector( '[id^=cb-select-all-]' );
+	await page.click( '[id^=cb-select-all-]' );
 	// Select the "bulk actions" > "trash" option.
 	await page.select( '#bulk-action-selector-top', 'trash' );
 	// Submit the form to send all draft/scheduled/published posts to the trash.

--- a/packages/e2e-tests/specs/editor/various/embedding.test.js
+++ b/packages/e2e-tests/specs/editor/various/embedding.test.js
@@ -251,7 +251,7 @@ describe( 'Embedding content', () => {
 		await insertBlock( 'Paragraph' );
 		await page.keyboard.type( 'Hello there!' );
 		await publishPost();
-		const postUrl = await page.$eval( '#inspector-text-control-0', ( el ) => el.value );
+		const postUrl = await page.$eval( '[id^=inspector-text-control-]', ( el ) => el.value );
 
 		// Start a new post, embed the previous post.
 		await createNewPost();


### PR DESCRIPTION
Previously: https://github.com/WordPress/gutenberg/pull/19825#issuecomment-577539425

This pull request seeks to improve test stability, where currently a handful of tests will select elements by a given ID, where the ID is not guaranteed to be deterministic.

There are two contributing factors here:

- Components using [`useInstanceId`](https://github.com/WordPress/gutenberg/tree/master/packages/compose/src/hooks/use-instance-id) where the ID is based on an internal incrementing count
- The post list "Select All" button similarly based on [an incrementing counter](https://github.com/WordPress/wordpress-develop/blob/67f246b9b0f245661a4b9b125096b4c3dfe55997/src/wp-admin/includes/class-wp-list-table.php#L1128-L1130)

The changes here propose to continue to select by the ID, but use the [value prefix selector syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Attribute_selectors#Syntax) to select ID values which begin with the segment of the ID preceding the non-deterministic counter value.

**Testing Instructions:**

End-to-end tests should pass:

```
npm run test-e2e
```