### PR TITLE
Navigation: Manage navigation link appender visibility

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -209,7 +209,7 @@ function NavigationLinkEdit( {
 				</div>
 				<InnerBlocks
 					allowedBlocks={ [ 'core/navigation-link' ] }
-					renderAppender={ ( hasDescendants && isSelected ) ? InnerBlocks.DefaultAppender : false }
+					renderAppender={ ( ( hasDescendants && isSelected ) || isParentOfSelectedBlock ) ? InnerBlocks.DefaultAppender : false }
 				/>
 			</div>
 		</Fragment>


### PR DESCRIPTION
Closes https://github.com/WordPress/gutenberg/issues/19788

## Description
Currently the navigation link appender for a submenu is only shown when the parent block is selected. This changes it so the appender is shown when the parent block item or a submenu item is selected. 

## How has this been tested?
Manually

## Screenshots
**With this PR's Changes** (This gif is taken with code from https://github.com/WordPress/gutenberg/pull/19686/ included as well)
![submenu appender when relevant](https://user-images.githubusercontent.com/967608/72999051-64aa7b00-3dc4-11ea-81b5-22c8482f14ae.gif)


## Types of changes
Bug fix (non-breaking change which fixes an issue)


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->