### PR TITLE
[RNMobile] Release v1.21.0 to master

### DIFF
--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -343,7 +343,11 @@ class GalleryEdit extends Component {
 			return mediaPlaceholder;
 		}
 
-		const imageSizeOptions = this.getImagesSizeOptions();
+		// disable image size options on mobile for now
+		const imageSizeOptions = Platform.select( {
+			web: this.getImagesSizeOptions(),
+			native: [],
+		} );
 		const shouldShowSizeOptions = hasImages && ! isEmpty( imageSizeOptions );
 		// This is needed to fix a separator fence-post issue on mobile.
 		const mobileLinkToProps = shouldShowSizeOptions ?

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -343,11 +343,7 @@ class GalleryEdit extends Component {
 			return mediaPlaceholder;
 		}
 
-		// disable image size options on mobile for now
-		const imageSizeOptions = Platform.select( {
-			web: this.getImagesSizeOptions(),
-			native: [],
-		} );
+		const imageSizeOptions = this.getImagesSizeOptions();
 		const shouldShowSizeOptions = hasImages && ! isEmpty( imageSizeOptions );
 		// This is needed to fix a separator fence-post issue on mobile.
 		const mobileLinkToProps = shouldShowSizeOptions ?

--- a/packages/rich-text/src/component/index.native.js
+++ b/packages/rich-text/src/component/index.native.js
@@ -726,6 +726,7 @@ export class RichText extends Component {
 					isSelected,
 					value: record,
 					onChange: this.onFormatChange,
+					onFocus: () => {},
 				} ) }
 				<RCTAztecView
 					ref={ ( ref ) => {


### PR DESCRIPTION
## Description

This PR merges the changes made for Mobile Gutenberg release v1.21.0 back to master branch.

Gutenberg Mobile side PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1812

@mkevins - if we don't want https://github.com/WordPress/gutenberg/pull/19828 to be on develop, we should probably revert it at this point before merging.