### PR TITLE
Block Editor: LinkControl: Resolve error when undefined value, "view" state

### DIFF
--- a/packages/block-editor/src/components/link-control/README.md
+++ b/packages/block-editor/src/components/link-control/README.md
@@ -17,11 +17,9 @@ A link value contains is composed as a union of the default properties and any c
 
 Default properties include:
 
-- id (`string|number`): Unique identifier of link.
-- url (`string`): Link URL.
-- title (`string`): Link title.
-- type (`string`): Type of link entity.
-- subtype (`string`): Subtype of link entity.
+- `url` (`string`): Link URL.
+- `title` (`string`, optional): Link title.
+- `opensInNewTab` (`boolean`, optional): Whether link should open in a new browser tab.This value is only assigned if not providing a custom `settings` prop.
 
 ### settings
 

--- a/packages/block-editor/src/components/link-control/README.md
+++ b/packages/block-editor/src/components/link-control/README.md
@@ -52,7 +52,7 @@ Value change handler, called with the updated value if the user selects a new li
 ```jsx
 <LinkControl
 	onChange={ ( nextValue ) => {
-		console.log( `The item selected has the ${ nextValue.id } id.` );
+		console.log( `The selected item URL: ${ nextValue.url }.` );
 	}
 /> 
 ```

--- a/packages/block-editor/src/components/link-control/README.md
+++ b/packages/block-editor/src/components/link-control/README.md
@@ -1,11 +1,27 @@
 # Link Control
 
+Renders a link control. A link control is a controlled input which maintains
+a value associated with a link (HTML anchor element) and relevant settings
+for how that link is expected to behave.
+
 ## Props
 
 ### value
 
 - Type: `Object`
 - Required: No
+
+Current link value.
+
+A link value contains is composed as a union of the default properties and any custom settings values.
+
+Default properties include:
+
+- id (`string|number`): Unique identifier of link.
+- url (`string`): Link URL.
+- title (`string`): Link title.
+- type (`string`): Type of link entity.
+- subtype (`string`): Subtype of link entity.
 
 ### settings
 
@@ -33,14 +49,20 @@ An array of settings objects. Each object will used to render a `ToggleControl` 
 - Type: `Function`
 - Required: No
 
-Use this callback to take an action after a user set or updated a link.
-The function callback will receive the selected item.
+Value change handler, called with the updated value if the user selects a new link or updates settings.
 
 ```jsx
 <LinkControl
-	onChange={ ( item ) => {
-		console.log( `The item selected has the ${ item.id } id.` );
+	onChange={ ( nextValue ) => {
+		console.log( `The item selected has the ${ nextValue.id } id.` );
 	}
 /> 
 ```
 
+### showInitialSuggestions
+
+- Type: `boolean`
+- Required: No
+- Default: `false`
+
+Whether to present initial suggestions immediately.

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -27,6 +27,66 @@ import LinkControlSettingsDrawer from './settings-drawer';
 import LinkControlSearchItem from './search-item';
 import LinkControlSearchInput from './search-input';
 
+/**
+ * Default properties associated with a link control value.
+ *
+ * @typedef WPLinkControlDefaultValue
+ *
+ * @property {string|number} id              Unique identifier of link.
+ * @property {string}        url             Link URL.
+ * @property {string}        title           Link title.
+ * @property {string}        type            Type of link entity.
+ * @property {string}        subtype         Subtype of link entity.
+ * @property {boolean}       [opensInNewTab] Whether link should open in a new
+ *                                           browser tab. This value is only
+ *                                           assigned if not providing a custom
+ *                                           settings array.
+ */
+
+/**
+ * Custom settings values associated with a link.
+ *
+ * @typedef {{[setting:string]:any}} WPLinkControlSettingsValue
+ */
+
+/**
+ * Custom settings values associated with a link.
+ *
+ * @typedef WPLinkControlSetting
+ *
+ * @property {string} id    Identifier to use as property for setting value.
+ * @property {string} title Human-readable label to show in user interface.
+ */
+
+/**
+ * Properties associated with a link control value, composed as a union of the
+ * default properties and any custom settings values.
+ *
+ * @typedef {WPLinkControlDefaultValue&WPLinkControlSettingsValue} WPLinkControlValue
+ */
+
+/** @typedef {(nextValue:WPLinkControlValue)=>void} WPLinkControlOnChangeProp */
+
+/**
+ * @typedef WPLinkControlProps
+ *
+ * @property {(WPLinkControlSetting[])=}  settings               An array of settings objects. Each object will used to
+ *                                                               render a `ToggleControl` for that setting.
+ * @property {(search:string)=>Promise=}  fetchSearchSuggestions Fetches suggestions for a given search term,
+ *                                                               returning a promise resolving once fetch is complete.
+ * @property {WPLinkControlValue=}        value                  Current link value.
+ * @property {WPLinkControlOnChangeProp=} onChange               Value change handler, called with the updated value if
+ *                                                               the user selects a new link or updates settings.
+ * @property {boolean=}                   showInitialSuggestions Whether to present initial suggestions immediately.
+ */
+
+/**
+ * Renders a link control. A link control is a controlled input which maintains
+ * a value associated with a link (HTML anchor element) and relevant settings
+ * for how that link is expected to behave.
+ *
+ * @param {WPLinkControlProps} props Component props.
+ */
 function LinkControl( {
 	value,
 	settings,
@@ -157,7 +217,19 @@ function LinkControl( {
 
 	return (
 		<div className="block-editor-link-control">
-			{ ( ! isEditingLink ) && (
+			{ isEditingLink || ! value ?
+				<LinkControlSearchInput
+					value={ inputValue }
+					onChange={ onInputChange }
+					onSelect={ ( suggestion ) => {
+						setIsEditingLink( false );
+						onChange( { ...value, ...suggestion } );
+					} }
+					renderSuggestions={ renderSearchResults }
+					fetchSuggestions={ getSearchHandler }
+					onReset={ resetInput }
+					showInitialSuggestions={ showInitialSuggestions }
+				/> :
 				<Fragment>
 					<p className="screen-reader-text" id={ `current-link-label-${ instanceId }` }>
 						{ __( 'Currently selected' ) }:
@@ -191,27 +263,13 @@ function LinkControl( {
 							{ __( 'Edit' ) }
 						</Button>
 					</div>
+					<LinkControlSettingsDrawer
+						value={ value }
+						settings={ settings }
+						onChange={ onChange }
+					/>
 				</Fragment>
-			) }
-
-			{ isEditingLink && (
-				<LinkControlSearchInput
-					value={ inputValue }
-					onChange={ onInputChange }
-					onSelect={ ( suggestion ) => {
-						setIsEditingLink( false );
-						onChange( { ...value, ...suggestion } );
-					} }
-					renderSuggestions={ renderSearchResults }
-					fetchSuggestions={ getSearchHandler }
-					onReset={ resetInput }
-					showInitialSuggestions={ showInitialSuggestions }
-				/>
-			) }
-
-			{ ! isEditingLink && (
-				<LinkControlSettingsDrawer value={ value } settings={ settings } onChange={ onChange } />
-			) }
+			}
 		</div>
 	);
 }

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -32,15 +32,11 @@ import LinkControlSearchInput from './search-input';
  *
  * @typedef WPLinkControlDefaultValue
  *
- * @property {string|number} id              Unique identifier of link.
- * @property {string}        url             Link URL.
- * @property {string}        title           Link title.
- * @property {string}        type            Type of link entity.
- * @property {string}        subtype         Subtype of link entity.
- * @property {boolean}       [opensInNewTab] Whether link should open in a new
- *                                           browser tab. This value is only
- *                                           assigned if not providing a custom
- *                                           settings array.
+ * @property {string}   url           Link URL.
+ * @property {string=}  title         Link title.
+ * @property {boolean=} opensInNewTab Whether link should open in a new browser
+ *                                    tab. This value is only assigned if not
+ *                                    providing a custom `settings` prop.
  */
 
 /**


### PR DESCRIPTION
This pull request seeks to resolve an error that can occur when `LinkControl` is rendered with an `undefined` value, if the user inputs text into the field and then presses <kbd>Enter</kbd>. The component toggles the editing state (to the "view" state) but assumes that the rendering parent would provide a non-`undefined` value, which is otherwise not guaranteed or documented as being a requirement.

Included are full typings of the component props, at which point the error is surfaced by TypeScript tooling:

```
.../link-control/index.js:247:16 - error TS2532: Object is possibly 'undefined'.

247    href={ value.url }
```

I first observed this in creating the first of the examples in https://github.com/WordPress/gutenberg/issues/18061#issuecomment-577334493, where a `value` is not provided. We should be able to handle this usage in a way which doesn't throw an error.

**Implementation Notes:**

As implemented, the field is forced to remain in an editing mode if a `value` is not present. This could be potential confusing to maintain, considering that the `isEditingLink` state can be `false` despite the editing input still being shown. However, it was done this way because it can't be known until the next render whether the `value` will actually be provided. There might be some alternative way to express this using various lifecycle hooks (`useEffect`).

This also slightly simplifies the rendering of the component, avoiding the separate logic consideration in the rendering of `LinkControlSettingsDrawer` and instead moving it into the same render path as the rest of the `! isEditingLink` condition.

The included types also serve the purpose of:

- Clarifying the intended object shape of `value`
- Expanding on existing documentation by reusing the types descriptions (at some point in the future, it would be nice to be able to automate this as part of the `@wordpress/docgen` documentation extraction)

**Testing Instructions:**

Verify that in a usage example like the first of https://github.com/WordPress/gutenberg/issues/18061#issuecomment-577334493 (where no `value` is provided), no error occurs when inserting a link into the field.

```
curl https://gist.githubusercontent.com/aduth/e33bd00dc7a4c9bf022e989babd8ece6/raw/a38b66983e215989dc84fff5fd52795582757126/link-control-form.diff | patch -p1
```

