### PR TITLE
Multi selection: fix intermittent e2e failure

### DIFF
--- a/packages/block-editor/src/components/block-list/block-popover.js
+++ b/packages/block-editor/src/components/block-list/block-popover.js
@@ -115,9 +115,17 @@ function BlockPopover( {
 	let anchorRef = node;
 
 	if ( hasMultiSelection ) {
+		const bottomNode = blockNodes[ lastClientId ];
+
+		// Wait to render the popover until the bottom reference is available
+		// as well.
+		if ( ! bottomNode ) {
+			return null;
+		}
+
 		anchorRef = {
-			top: blockNodes[ clientId ],
-			bottom: blockNodes[ lastClientId ],
+			top: node,
+			bottom: bottomNode,
 		};
 	}
 


### PR DESCRIPTION
## Description

This PR fixes an error with multi selection when the bottom reference is not available yet. In that case, we shouldn't render it and wait for the bottom node to become available.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
