### PR TITLE
URL: Conform to URL Living Standard definition of valid URL

### DIFF
--- a/lib/compat.php
+++ b/lib/compat.php
@@ -38,9 +38,9 @@ add_filter( 'safe_style_css', 'gutenberg_safe_style_css_column_flex_basis' );
  *
  * This can be removed when plugin support requires WordPress 5.4.0+.
  *
+ * @see https://core.trac.wordpress.org/ticket/49360
  * @see https://developer.mozilla.org/en-US/docs/Web/API/URL/URL
  * @see https://developer.wordpress.org/reference/functions/wp_default_packages_vendor/
- * @see (TODO: Trac Ticket TBD)
  *
  * @since 7.3.0
  *

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -45,6 +45,14 @@ add_filter( 'safe_style_css', 'gutenberg_safe_style_css_column_flex_basis' );
  * @param WP_Scripts $scripts WP_Scripts object.
  */
 function gutenberg_add_url_polyfill( $scripts ) {
+	// Only register polyfill if not already registered. This prevents handling
+	// in an environment where core has updated to manage the polyfill. This
+	// depends on the action being handled after default script registration.
+	$is_polyfill_script_registered = (bool) $scripts->query( 'wp-polyfill-url', 'registered' );
+	if ( $is_polyfill_script_registered ) {
+		return;
+	}
+
 	gutenberg_register_vendor_script(
 		$scripts,
 		'wp-polyfill-url',
@@ -63,7 +71,7 @@ function gutenberg_add_url_polyfill( $scripts ) {
 		)
 	);
 }
-add_action( 'wp_default_scripts', 'gutenberg_add_url_polyfill' );
+add_action( 'wp_default_scripts', 'gutenberg_add_url_polyfill', 20 );
 
 /**
  * Sets the current post for usage in template blocks.

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -31,6 +31,41 @@ function gutenberg_safe_style_css_column_flex_basis( $attr ) {
 add_filter( 'safe_style_css', 'gutenberg_safe_style_css_column_flex_basis' );
 
 /**
+ * Adds a polyfill for the WHATWG URL in environments which do not support it.
+ * The intention in how this action is handled is under the assumption that this
+ * code would eventually be placed at `wp_default_packages_vendor`, which is
+ * called as a result of `wp_default_packages` via the `wp_default_scripts`.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/URL/URL
+ * @see https://developer.wordpress.org/reference/functions/wp_default_packages_vendor/
+ * @see (TODO: Trac Ticket TBD)
+ *
+ * @since 7.3.0
+ *
+ * @param WP_Scripts $scripts WP_Scripts object.
+ */
+function gutenberg_add_url_polyfill( $scripts ) {
+	gutenberg_register_vendor_script(
+		$scripts,
+		'wp-polyfill-url',
+		'https://unpkg.com/polyfill-library@3.26.0-0/polyfills/URL/polyfill.js',
+		array(),
+		'3.26.0-0'
+	);
+
+	did_action( 'init' ) && $scripts->add_inline_script(
+		'wp-polyfill',
+		wp_get_script_polyfill(
+			$scripts,
+			array(
+				'\'URL\' in window' => 'wp-polyfill-url',
+			)
+		)
+	);
+}
+add_action( 'wp_default_scripts', 'gutenberg_add_url_polyfill' );
+
+/**
  * Sets the current post for usage in template blocks.
  *
  * @return WP_Post|null The post if any, or null otherwise.

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -36,6 +36,8 @@ add_filter( 'safe_style_css', 'gutenberg_safe_style_css_column_flex_basis' );
  * code would eventually be placed at `wp_default_packages_vendor`, which is
  * called as a result of `wp_default_packages` via the `wp_default_scripts`.
  *
+ * This can be removed when plugin support requires WordPress 5.4.0+.
+ *
  * @see https://developer.mozilla.org/en-US/docs/Web/API/URL/URL
  * @see https://developer.wordpress.org/reference/functions/wp_default_packages_vendor/
  * @see (TODO: Trac Ticket TBD)

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -214,17 +214,10 @@ function LinkControl( {
 	// Effects
 	const getSearchHandler = useCallback(
 		( val, args ) => {
-			const protocol = getProtocol( val ) || '';
-			const isMailto = protocol.includes( 'mailto' );
 			const isInternal = startsWith( val, '#' );
-			const isTel = protocol.includes( 'tel' );
 
 			const handleManualEntry =
-				isInternal ||
-				isMailto ||
-				isTel ||
-				isURL( val ) ||
-				( val && val.includes( 'www.' ) );
+				isInternal || isURL( val ) || ( val && val.includes( 'www.' ) );
 
 			return handleManualEntry
 				? handleDirectEntry( val, args )

--- a/packages/url/CHANGELOG.md
+++ b/packages/url/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Master
+
+### Bug Fixes
+
+- `isURL` now correctly returns `true` for many other forms of a valid URL, as it now conforms to the [URL Living Standard](https://url.spec.whatwg.org/) definition of a [valid URL string](https://url.spec.whatwg.org/#valid-url-string).
+
 ## 2.3.3 (2019-01-03)
 
 ### Bug Fixes

--- a/packages/url/README.md
+++ b/packages/url/README.md
@@ -231,6 +231,11 @@ _Returns_
 
 Determines whether the given string looks like a URL.
 
+_Related_
+
+-   <https://url.spec.whatwg.org/>
+-   <https://url.spec.whatwg.org/#valid-url-string>
+
 _Usage_
 
 ```js

--- a/packages/url/src/is-url.js
+++ b/packages/url/src/is-url.js
@@ -1,5 +1,3 @@
-const URL_REGEXP = /^(?:https?:)?\/\/\S+$/i;
-
 /**
  * Determines whether the given string looks like a URL.
  *
@@ -10,8 +8,18 @@ const URL_REGEXP = /^(?:https?:)?\/\/\S+$/i;
  * const isURL = isURL( 'https://wordpress.org' ); // true
  * ```
  *
+ * @see https://url.spec.whatwg.org/
+ * @see https://url.spec.whatwg.org/#valid-url-string
+ *
  * @return {boolean} Whether or not it looks like a URL.
  */
 export function isURL( url ) {
-	return URL_REGEXP.test( url );
+	// A URL can be considered value if the `URL` constructor is able to parse
+	// it. The constructor throws an error for an invalid URL.
+	try {
+		new URL( url );
+		return true;
+	} catch ( error ) {
+		return false;
+	}
 }

--- a/packages/url/src/test/index.test.js
+++ b/packages/url/src/test/index.test.js
@@ -30,28 +30,30 @@ import {
 } from '../';
 
 describe( 'isURL', () => {
-	it( 'returns true when given things that look like a URL', () => {
-		const urls = [
-			'http://wordpress.org',
-			'https://wordpress.org',
-			'HTTPS://WORDPRESS.ORG',
-			'https://wordpress.org/foo#bar',
-			'https://localhost/foo#bar',
-		];
-
-		expect( every( urls, isURL ) ).toBe( true );
+	it.each( [
+		[ 'http://wordpress.org' ],
+		[ 'https://wordpress.org' ],
+		[ 'HTTPS://WORDPRESS.ORG' ],
+		[ 'https://wordpress.org/./foo' ],
+		[ 'https://wordpress.org/path?query#fragment' ],
+		[ 'https://localhost/foo#bar' ],
+		[ 'mailto:example@example.com' ],
+		[ 'ssh://user:password@127.0.0.1:8080' ],
+	] )( 'valid (true): %s', ( url ) => {
+		expect( isURL( url ) ).toBe( true );
 	} );
 
-	it( "returns false when given things that don't look like a URL", () => {
-		const urls = [
-			'HTTP: HyperText Transfer Protocol',
-			'URLs begin with a http:// prefix',
-			'Go here: http://wordpress.org',
-			'http://',
-			'',
-		];
-
-		expect( every( urls, isURL ) ).toBe( false );
+	it.each( [
+		[ 'http://word press.org' ],
+		[ 'http://wordpress.org:port' ],
+		[ 'http://[wordpress.org]/' ],
+		[ 'HTTP: HyperText Transfer Protocol' ],
+		[ 'URLs begin with a http:// prefix' ],
+		[ 'Go here: http://wordpress.org' ],
+		[ 'http://' ],
+		[ '' ],
+	] )( 'invalid (false): %s', ( url ) => {
+		expect( isURL( url ) ).toBe( false );
 	} );
 } );
 


### PR DESCRIPTION
Previously: #19816
Related: #9067
Cherry-picks e2c0f74b2251e989b181c7661942b3fb73e34216 from #19823 (would require core back-port)
Unblocks: #19775

This pull request seeks to revise the implementation of `@wordpress/url` `isURL` to accept more of what should be considered as valid URLs based on the [URL Living Standard](https://url.spec.whatwg.org/) definition of a [valid URL string](https://url.spec.whatwg.org/#valid-url-string).

This includes a number of newly-acceptable URLs:

- `mailto` strings
- Non-HTTP schemes (`ftp:`, `ssh:`, `git:`, etc)

The original implementation was introduced in #9067, and based on the discussion in that pull request, it seems it was largely intended as a refactoring to replace a simple (naive) regular expression, and wasn't explicitly concerned with dealing with HTTP URLs. In fact, the changes with this pull request should further improve upon the intended changes in #9067, where a link will automatically be applied to e.g. `mailto:hello@example.com` if the text is highlighted in a paragraph. 

**Testing Instructions:**

Ensure unit tests pass:

```
npm run test-unit packages/url/src/test/index.test.js
```

Verify there are no regressions in the intended handling of `mailto:` and `tel:` links in the Navigation Block link editor experience (#17846), nor in the behavior of URL paragraph text auto-linking (#9067).