### PR TITLE
Switch social link icons to import svg parts from primitives

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10123,6 +10123,7 @@
 				"@wordpress/icons": "file:packages/icons",
 				"@wordpress/is-shallow-equal": "file:packages/is-shallow-equal",
 				"@wordpress/keycodes": "file:packages/keycodes",
+				"@wordpress/primitives": "file:packages/primitives",
 				"@wordpress/rich-text": "file:packages/rich-text",
 				"@wordpress/server-side-render": "file:packages/server-side-render",
 				"@wordpress/url": "file:packages/url",

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -45,6 +45,7 @@
 		"@wordpress/icons": "file:../icons",
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
 		"@wordpress/keycodes": "file:../keycodes",
+		"@wordpress/primitives": "file:../primitives",
 		"@wordpress/rich-text": "file:../rich-text",
 		"@wordpress/server-side-render": "file:../server-side-render",
 		"@wordpress/url": "file:../url",

--- a/packages/block-library/src/social-link/icons/amazon.js
+++ b/packages/block-library/src/social-link/icons/amazon.js
@@ -1,8 +1,7 @@
 /**
  * WordPress dependencies
  */
-
-import { Path, SVG } from '@wordpress/components';
+import { Path, SVG } from '@wordpress/primitives';
 
 export const AmazonIcon = () => (
 	<SVG width="24" height="24" viewBox="0 0 24 24" version="1.1">

--- a/packages/block-library/src/social-link/icons/bandcamp.js
+++ b/packages/block-library/src/social-link/icons/bandcamp.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 
-import { Path, SVG } from '@wordpress/components';
+import { Path, SVG } from '@wordpress/primitives';
 
 export const BandcampIcon = () => (
 	<SVG width="24" height="24" viewBox="0 0 24 24" version="1.1">

--- a/packages/block-library/src/social-link/icons/behance.js
+++ b/packages/block-library/src/social-link/icons/behance.js
@@ -1,8 +1,7 @@
 /**
  * WordPress dependencies
  */
-
-import { Path, SVG } from '@wordpress/components';
+import { Path, SVG } from '@wordpress/primitives';
 
 export const BehanceIcon = () => (
 	<SVG width="24" height="24" viewBox="0 0 24 24" version="1.1">

--- a/packages/block-library/src/social-link/icons/chain.js
+++ b/packages/block-library/src/social-link/icons/chain.js
@@ -1,8 +1,7 @@
 /**
  * WordPress dependencies
  */
-
-import { Path, SVG } from '@wordpress/components';
+import { Path, SVG } from '@wordpress/primitives';
 
 export const ChainIcon = () => (
 	<SVG width="24" height="24" viewBox="0 0 24 24" version="1.1">

--- a/packages/block-library/src/social-link/icons/codepen.js
+++ b/packages/block-library/src/social-link/icons/codepen.js
@@ -1,8 +1,7 @@
 /**
  * WordPress dependencies
  */
-
-import { Path, SVG } from '@wordpress/components';
+import { Path, SVG } from '@wordpress/primitives';
 
 export const CodepenIcon = () => (
 	<SVG width="24" height="24" viewBox="0 0 24 24" version="1.1">

--- a/packages/block-library/src/social-link/icons/deviantart.js
+++ b/packages/block-library/src/social-link/icons/deviantart.js
@@ -1,8 +1,7 @@
 /**
  * WordPress dependencies
  */
-
-import { Path, SVG } from '@wordpress/components';
+import { Path, SVG } from '@wordpress/primitives';
 
 export const DeviantArtIcon = () => (
 	<SVG width="24" height="24" viewBox="0 0 24 24" version="1.1">

--- a/packages/block-library/src/social-link/icons/dribbble.js
+++ b/packages/block-library/src/social-link/icons/dribbble.js
@@ -1,8 +1,7 @@
 /**
  * WordPress dependencies
  */
-
-import { Path, SVG } from '@wordpress/components';
+import { Path, SVG } from '@wordpress/primitives';
 
 export const DribbbleIcon = () => (
 	<SVG width="24" height="24" viewBox="0 0 24 24" version="1.1">

--- a/packages/block-library/src/social-link/icons/dropbox.js
+++ b/packages/block-library/src/social-link/icons/dropbox.js
@@ -1,8 +1,7 @@
 /**
  * WordPress dependencies
  */
-
-import { Path, SVG } from '@wordpress/components';
+import { Path, SVG } from '@wordpress/primitives';
 
 export const DropboxIcon = () => (
 	<SVG width="24" height="24" viewBox="0 0 24 24" version="1.1">

--- a/packages/block-library/src/social-link/icons/etsy.js
+++ b/packages/block-library/src/social-link/icons/etsy.js
@@ -1,8 +1,7 @@
 /**
  * WordPress dependencies
  */
-
-import { Path, SVG } from '@wordpress/components';
+import { Path, SVG } from '@wordpress/primitives';
 
 export const EtsyIcon = () => (
 	<SVG width="24" height="24" viewBox="0 0 24 24" version="1.1">

--- a/packages/block-library/src/social-link/icons/facebook.js
+++ b/packages/block-library/src/social-link/icons/facebook.js
@@ -1,8 +1,7 @@
 /**
  * WordPress dependencies
  */
-
-import { Path, SVG } from '@wordpress/components';
+import { Path, SVG } from '@wordpress/primitives';
 
 export const FacebookIcon = () => (
 	<SVG width="24" height="24" viewBox="0 0 24 24" version="1.1">

--- a/packages/block-library/src/social-link/icons/feed.js
+++ b/packages/block-library/src/social-link/icons/feed.js
@@ -1,8 +1,7 @@
 /**
  * WordPress dependencies
  */
-
-import { Path, SVG } from '@wordpress/components';
+import { Path, SVG } from '@wordpress/primitives';
 
 export const FeedIcon = () => (
 	<SVG width="24" height="24" viewBox="0 0 24 24" version="1.1">

--- a/packages/block-library/src/social-link/icons/fivehundredpx.js
+++ b/packages/block-library/src/social-link/icons/fivehundredpx.js
@@ -1,8 +1,7 @@
 /**
  * WordPress dependencies
  */
-
-import { Path, SVG } from '@wordpress/components';
+import { Path, SVG } from '@wordpress/primitives';
 
 export const FivehundredpxIcon = () => (
 	<SVG width="24" height="24" viewBox="0 0 24 24" version="1.1">

--- a/packages/block-library/src/social-link/icons/flickr.js
+++ b/packages/block-library/src/social-link/icons/flickr.js
@@ -1,8 +1,7 @@
 /**
  * WordPress dependencies
  */
-
-import { Path, SVG } from '@wordpress/components';
+import { Path, SVG } from '@wordpress/primitives';
 
 export const FlickrIcon = () => (
 	<SVG width="24" height="24" viewBox="0 0 24 24" version="1.1">

--- a/packages/block-library/src/social-link/icons/foursquare.js
+++ b/packages/block-library/src/social-link/icons/foursquare.js
@@ -1,8 +1,7 @@
 /**
  * WordPress dependencies
  */
-
-import { Path, SVG } from '@wordpress/components';
+import { Path, SVG } from '@wordpress/primitives';
 
 export const FoursquareIcon = () => (
 	<SVG width="24" height="24" viewBox="0 0 24 24" version="1.1">

--- a/packages/block-library/src/social-link/icons/github.js
+++ b/packages/block-library/src/social-link/icons/github.js
@@ -1,8 +1,7 @@
 /**
  * WordPress dependencies
  */
-
-import { Path, SVG } from '@wordpress/components';
+import { Path, SVG } from '@wordpress/primitives';
 
 export const GitHubIcon = () => (
 	<SVG width="24" height="24" viewBox="0 0 24 24" version="1.1">

--- a/packages/block-library/src/social-link/icons/goodreads.js
+++ b/packages/block-library/src/social-link/icons/goodreads.js
@@ -1,8 +1,7 @@
 /**
  * WordPress dependencies
  */
-
-import { Path, SVG } from '@wordpress/components';
+import { Path, SVG } from '@wordpress/primitives';
 
 export const GoodreadsIcon = () => (
 	<SVG width="24" height="24" viewBox="0 0 24 24" version="1.1">

--- a/packages/block-library/src/social-link/icons/google.js
+++ b/packages/block-library/src/social-link/icons/google.js
@@ -1,8 +1,7 @@
 /**
  * WordPress dependencies
  */
-
-import { Path, SVG } from '@wordpress/components';
+import { Path, SVG } from '@wordpress/primitives';
 
 export const GoogleIcon = () => (
 	<SVG width="24" height="24" viewBox="0 0 24 24" version="1.1">

--- a/packages/block-library/src/social-link/icons/instagram.js
+++ b/packages/block-library/src/social-link/icons/instagram.js
@@ -1,8 +1,7 @@
 /**
  * WordPress dependencies
  */
-
-import { Path, SVG } from '@wordpress/components';
+import { Path, SVG } from '@wordpress/primitives';
 
 export const InstagramIcon = () => (
 	<SVG width="24" height="24" viewBox="0 0 24 24" version="1.1">

--- a/packages/block-library/src/social-link/icons/lastfm.js
+++ b/packages/block-library/src/social-link/icons/lastfm.js
@@ -1,8 +1,7 @@
 /**
  * WordPress dependencies
  */
-
-import { Path, SVG } from '@wordpress/components';
+import { Path, SVG } from '@wordpress/primitives';
 
 export const LastfmIcon = () => (
 	<SVG width="24" height="24" viewBox="0 0 24 24" version="1.1">

--- a/packages/block-library/src/social-link/icons/linkedin.js
+++ b/packages/block-library/src/social-link/icons/linkedin.js
@@ -1,8 +1,7 @@
 /**
  * WordPress dependencies
  */
-
-import { Path, SVG } from '@wordpress/components';
+import { Path, SVG } from '@wordpress/primitives';
 
 export const LinkedInIcon = () => (
 	<SVG width="24" height="24" viewBox="0 0 24 24" version="1.1">

--- a/packages/block-library/src/social-link/icons/mail.js
+++ b/packages/block-library/src/social-link/icons/mail.js
@@ -1,8 +1,7 @@
 /**
  * WordPress dependencies
  */
-
-import { Path, SVG } from '@wordpress/components';
+import { Path, SVG } from '@wordpress/primitives';
 
 export const MailIcon = () => (
 	<SVG width="24" height="24" viewBox="0 0 24 24" version="1.1">

--- a/packages/block-library/src/social-link/icons/mastodon.js
+++ b/packages/block-library/src/social-link/icons/mastodon.js
@@ -1,8 +1,7 @@
 /**
  * WordPress dependencies
  */
-
-import { Path, SVG } from '@wordpress/components';
+import { Path, SVG } from '@wordpress/primitives';
 
 export const MastodonIcon = () => (
 	<SVG width="24" height="24" viewBox="0 0 24 24" version="1.1">

--- a/packages/block-library/src/social-link/icons/medium.js
+++ b/packages/block-library/src/social-link/icons/medium.js
@@ -1,8 +1,7 @@
 /**
  * WordPress dependencies
  */
-
-import { Path, SVG } from '@wordpress/components';
+import { Path, SVG } from '@wordpress/primitives';
 
 export const MediumIcon = () => (
 	<SVG width="24" height="24" viewBox="0 0 24 24" version="1.1">

--- a/packages/block-library/src/social-link/icons/meetup.js
+++ b/packages/block-library/src/social-link/icons/meetup.js
@@ -1,8 +1,7 @@
 /**
  * WordPress dependencies
  */
-
-import { Path, SVG } from '@wordpress/components';
+import { Path, SVG } from '@wordpress/primitives';
 
 export const MeetupIcon = () => (
 	<SVG width="24" height="24" viewBox="0 0 24 24" version="1.1">

--- a/packages/block-library/src/social-link/icons/pinterest.js
+++ b/packages/block-library/src/social-link/icons/pinterest.js
@@ -1,8 +1,7 @@
 /**
  * WordPress dependencies
  */
-
-import { Path, SVG } from '@wordpress/components';
+import { Path, SVG } from '@wordpress/primitives';
 
 export const PinterestIcon = () => (
 	<SVG width="24" height="24" viewBox="0 0 24 24" version="1.1">

--- a/packages/block-library/src/social-link/icons/pocket.js
+++ b/packages/block-library/src/social-link/icons/pocket.js
@@ -1,8 +1,7 @@
 /**
  * WordPress dependencies
  */
-
-import { Path, SVG } from '@wordpress/components';
+import { Path, SVG } from '@wordpress/primitives';
 
 export const PocketIcon = () => (
 	<SVG width="24" height="24" viewBox="0 0 24 24" version="1.1">

--- a/packages/block-library/src/social-link/icons/reddit.js
+++ b/packages/block-library/src/social-link/icons/reddit.js
@@ -1,8 +1,7 @@
 /**
  * WordPress dependencies
  */
-
-import { Path, SVG } from '@wordpress/components';
+import { Path, SVG } from '@wordpress/primitives';
 
 export const RedditIcon = () => (
 	<SVG width="24" height="24" viewBox="0 0 24 24" version="1.1">

--- a/packages/block-library/src/social-link/icons/skype.js
+++ b/packages/block-library/src/social-link/icons/skype.js
@@ -1,8 +1,7 @@
 /**
  * WordPress dependencies
  */
-
-import { Path, SVG } from '@wordpress/components';
+import { Path, SVG } from '@wordpress/primitives';
 
 export const SkypeIcon = () => (
 	<SVG width="24" height="24" viewBox="0 0 24 24" version="1.1">

--- a/packages/block-library/src/social-link/icons/snapchat.js
+++ b/packages/block-library/src/social-link/icons/snapchat.js
@@ -1,8 +1,7 @@
 /**
  * WordPress dependencies
  */
-
-import { Path, SVG } from '@wordpress/components';
+import { Path, SVG } from '@wordpress/primitives';
 
 export const SnapchatIcon = () => (
 	<SVG width="24" height="24" viewBox="0 0 24 24" version="1.1">

--- a/packages/block-library/src/social-link/icons/soundcloud.js
+++ b/packages/block-library/src/social-link/icons/soundcloud.js
@@ -1,8 +1,7 @@
 /**
  * WordPress dependencies
  */
-
-import { Path, SVG } from '@wordpress/components';
+import { Path, SVG } from '@wordpress/primitives';
 
 export const SoundCloudIcon = () => (
 	<SVG width="24" height="24" viewBox="0 0 24 24" version="1.1">

--- a/packages/block-library/src/social-link/icons/spotify.js
+++ b/packages/block-library/src/social-link/icons/spotify.js
@@ -1,8 +1,7 @@
 /**
  * WordPress dependencies
  */
-
-import { Path, SVG } from '@wordpress/components';
+import { Path, SVG } from '@wordpress/primitives';
 
 export const SpotifyIcon = () => (
 	<SVG width="24" height="24" viewBox="0 0 24 24" version="1.1">

--- a/packages/block-library/src/social-link/icons/tumblr.js
+++ b/packages/block-library/src/social-link/icons/tumblr.js
@@ -1,8 +1,7 @@
 /**
  * WordPress dependencies
  */
-
-import { Path, SVG } from '@wordpress/components';
+import { Path, SVG } from '@wordpress/primitives';
 
 export const TumblrIcon = () => (
 	<SVG width="24" height="24" viewBox="0 0 24 24" version="1.1">

--- a/packages/block-library/src/social-link/icons/twitch.js
+++ b/packages/block-library/src/social-link/icons/twitch.js
@@ -1,8 +1,7 @@
 /**
  * WordPress dependencies
  */
-
-import { Path, SVG } from '@wordpress/components';
+import { Path, SVG } from '@wordpress/primitives';
 
 export const TwitchIcon = () => (
 	<SVG width="24" height="24" viewBox="0 0 24 24" version="1.1">

--- a/packages/block-library/src/social-link/icons/twitter.js
+++ b/packages/block-library/src/social-link/icons/twitter.js
@@ -1,8 +1,7 @@
 /**
  * WordPress dependencies
  */
-
-import { Path, SVG } from '@wordpress/components';
+import { Path, SVG } from '@wordpress/primitives';
 
 export const TwitterIcon = () => (
 	<SVG width="24" height="24" viewBox="0 0 24 24" version="1.1">

--- a/packages/block-library/src/social-link/icons/vimeo.js
+++ b/packages/block-library/src/social-link/icons/vimeo.js
@@ -1,8 +1,7 @@
 /**
  * WordPress dependencies
  */
-
-import { Path, SVG } from '@wordpress/components';
+import { Path, SVG } from '@wordpress/primitives';
 
 export const VimeoIcon = () => (
 	<SVG width="24" height="24" viewBox="0 0 24 24" version="1.1">

--- a/packages/block-library/src/social-link/icons/vk.js
+++ b/packages/block-library/src/social-link/icons/vk.js
@@ -1,8 +1,7 @@
 /**
  * WordPress dependencies
  */
-
-import { Path, SVG } from '@wordpress/components';
+import { Path, SVG } from '@wordpress/primitives';
 
 export const VkIcon = () => (
 	<SVG width="24" height="24" viewBox="0 0 24 24" version="1.1">

--- a/packages/block-library/src/social-link/icons/wordpress.js
+++ b/packages/block-library/src/social-link/icons/wordpress.js
@@ -1,8 +1,7 @@
 /**
  * WordPress dependencies
  */
-
-import { Path, SVG } from '@wordpress/components';
+import { Path, SVG } from '@wordpress/primitives';
 
 export const WordPressIcon = () => (
 	<SVG

--- a/packages/block-library/src/social-link/icons/yelp.js
+++ b/packages/block-library/src/social-link/icons/yelp.js
@@ -1,8 +1,7 @@
 /**
  * WordPress dependencies
  */
-
-import { Path, SVG } from '@wordpress/components';
+import { Path, SVG } from '@wordpress/primitives';
 
 export const YelpIcon = () => (
 	<SVG width="24" height="24" viewBox="0 0 24 24" version="1.1">

--- a/packages/block-library/src/social-link/icons/youtube.js
+++ b/packages/block-library/src/social-link/icons/youtube.js
@@ -1,8 +1,7 @@
 /**
  * WordPress dependencies
  */
-
-import { Path, SVG } from '@wordpress/components';
+import { Path, SVG } from '@wordpress/primitives';
 
 export const YouTubeIcon = () => (
 	<SVG width="24" height="24" viewBox="0 0 24 24" version="1.1">


### PR DESCRIPTION
## Description

Switches Social Link icon imports to use `@wordpress/primitives`

## How has this been tested?

Built, confirmed icons still show in inspector as expected.

## Types of changes

Minor change switching import to use new primitives package introduced in #19781 

