### PR TITLE
Block Editor: Consider events only from DOM descendents (WritingFlow, ObserveTyping)

### DIFF
--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -39,7 +39,6 @@ import {
 } from '@wordpress/blocks';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { withInstanceId, compose, withSafeTimeout } from '@wordpress/compose';
-import { LEFT, RIGHT, UP, DOWN, BACKSPACE, ENTER } from '@wordpress/keycodes';
 import { addQueryArgs } from '@wordpress/url';
 
 /**
@@ -53,8 +52,6 @@ import __experimentalInserterMenuExtension from '../inserter-menu-extension';
 import { searchItems } from './search-items';
 
 const MAX_SUGGESTED_ITEMS = 9;
-
-const stopKeyPropagation = ( event ) => event.stopPropagation();
 
 const getBlockNamespace = ( item ) => item.name.split( '/' )[ 0 ];
 
@@ -220,13 +217,6 @@ export class InserterMenu extends Component {
 		debouncedSpeak( resultsFoundMessage );
 	}
 
-	onKeyDown( event ) {
-		if ( includes( [ LEFT, DOWN, RIGHT, UP, BACKSPACE, ENTER ], event.keyCode ) ) {
-			// Stop the key event from propagating up to ObserveTyping.startTypingInTextField.
-			event.stopPropagation();
-		}
-	}
-
 	render() {
 		const { categories, collections, instanceId, onSelect, rootClientId, showInserterHelpPanel } = this.props;
 		const {
@@ -247,16 +237,12 @@ export class InserterMenu extends Component {
 		// Disable reason (no-autofocus): The inserter menu is a modal display, not one which
 		// is always visible, and one which already incurs this behavior of autoFocus via
 		// Popover's focusOnMount.
-		// Disable reason (no-static-element-interactions): Navigational key-presses within
-		// the menu are prevented from triggering WritingFlow and ObserveTyping interactions.
-		/* eslint-disable jsx-a11y/no-autofocus, jsx-a11y/no-static-element-interactions */
+		/* eslint-disable jsx-a11y/no-autofocus */
 		return (
 			<div
 				className={ classnames( 'block-editor-inserter__menu', {
 					'has-help-panel': hasHelpPanel,
 				} ) }
-				onKeyPress={ stopKeyPropagation }
-				onKeyDown={ this.onKeyDown }
 			>
 				<div className="block-editor-inserter__main-area">
 					<label htmlFor={ `block-editor-inserter__search-${ instanceId }` } className="screen-reader-text">
@@ -438,7 +424,7 @@ export class InserterMenu extends Component {
 				) }
 			</div>
 		);
-		/* eslint-enable jsx-a11y/no-autofocus, jsx-a11y/no-static-element-interactions */
+		/* eslint-enable jsx-a11y/no-autofocus */
 	}
 }
 

--- a/packages/block-editor/src/components/link-control/search-input.js
+++ b/packages/block-editor/src/components/link-control/search-input.js
@@ -4,37 +4,11 @@
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
-import { LEFT,
-	RIGHT,
-	UP,
-	DOWN,
-	BACKSPACE,
-	ENTER,
-} from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
  */
 import { URLInput } from '../';
-
-const handleLinkControlOnKeyDown = ( event ) => {
-	const { keyCode } = event;
-
-	if ( [ LEFT, DOWN, RIGHT, UP, BACKSPACE, ENTER ].indexOf( keyCode ) > -1 ) {
-		// Stop the key event from propagating up to ObserveTyping.startTypingInTextField.
-		event.stopPropagation();
-	}
-};
-
-const handleLinkControlOnKeyPress = ( event ) => {
-	const { keyCode } = event;
-
-	event.stopPropagation();
-
-	if ( keyCode === ENTER ) {
-
-	}
-};
 
 const LinkControlSearchInput = ( {
 	value,
@@ -67,13 +41,6 @@ const LinkControlSearchInput = ( {
 				className="block-editor-link-control__search-input"
 				value={ value }
 				onChange={ selectItemHandler }
-				onKeyDown={ ( event ) => {
-					if ( event.keyCode === ENTER ) {
-						return;
-					}
-					handleLinkControlOnKeyDown( event );
-				} }
-				onKeyPress={ handleLinkControlOnKeyPress }
 				placeholder={ __( 'Search or type url' ) }
 				__experimentalRenderSuggestions={ renderSuggestions }
 				__experimentalFetchLinkSuggestions={ fetchSuggestions }

--- a/packages/block-editor/src/components/media-replace-flow/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/index.js
@@ -13,14 +13,7 @@ import {
 	Dropdown,
 	withNotices,
 } from '@wordpress/components';
-import {
-	LEFT,
-	RIGHT,
-	UP,
-	DOWN,
-	BACKSPACE,
-	ENTER,
-} from '@wordpress/keycodes';
+import { DOWN } from '@wordpress/keycodes';
 import { useSelect } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 
@@ -50,17 +43,6 @@ const MediaReplaceFlow = (
 		return select( 'core/block-editor' ).getSettings().mediaUpload;
 	}, [] );
 	const editMediaButtonRef = createRef();
-
-	const stopPropagation = ( event ) => {
-		event.stopPropagation();
-	};
-
-	const stopPropagationRelevantKeys = ( event ) => {
-		if ( [ LEFT, DOWN, RIGHT, UP, BACKSPACE, ENTER ].indexOf( event.keyCode ) > -1 ) {
-			// Stop the key event from propagating up to ObserveTyping.startTypingInTextField.
-			event.stopPropagation();
-		}
-	};
 
 	const selectMedia = ( media ) => {
 		onSelect( media );
@@ -99,8 +81,6 @@ const MediaReplaceFlow = (
 	if ( showEditURLInput ) {
 		urlInputUIContent = (
 			<LinkEditor
-				onKeyDown={ stopPropagationRelevantKeys }
-				onKeyPress={ stopPropagation }
 				value={ mediaURLValue }
 				isFullWidthInput={ true }
 				hasInputBorder={ true }

--- a/packages/block-editor/src/components/observe-typing/index.js
+++ b/packages/block-editor/src/components/observe-typing/index.js
@@ -47,7 +47,6 @@ function ObserveTyping( {
 	children,
 	setTimeout: setSafeTimeout,
 } ) {
-	const node = useRef();
 	const lastMouseMove = useRef();
 	const isTyping = useSelect( ( select ) => select( 'core/block-editor' ).isTyping() );
 	const { startTyping, stopTyping } = useDispatch( 'core/block-editor' );
@@ -72,7 +71,7 @@ function ObserveTyping( {
 	 * @return {(event:WPSyntheticEvent)=>void} Enhanced event handler.
 	 */
 	const ifDOMDescendentEventTarget = ( handler ) => ( event ) => {
-		if ( node.current.contains( event.target ) ) {
+		if ( event.currentTarget.contains( event.target ) ) {
 			handler( event );
 		}
 	};
@@ -186,7 +185,6 @@ function ObserveTyping( {
 	/* eslint-disable jsx-a11y/no-static-element-interactions */
 	return (
 		<div
-			ref={ node }
 			onFocus={ stopTypingOnNonTextField }
 			onKeyPress={ startTypingInTextField }
 			onKeyDown={ over( [ startTypingInTextField, stopTypingOnEscapeKey ] ) }

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -15,12 +15,6 @@ import { BaseControl, Button, Spinner, withSpokenMessages, Popover } from '@word
 import { withInstanceId, withSafeTimeout, compose } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
 import { isURL } from '@wordpress/url';
-
-// Since URLInput is rendered in the context of other inputs, but should be
-// considered a separate modal node, prevent keyboard events from propagating
-// as being considered from the input.
-const stopEventPropagation = ( event ) => event.stopPropagation();
-
 class URLInput extends Component {
 	constructor( props ) {
 		super( props );
@@ -346,7 +340,6 @@ class URLInput extends Component {
 					required
 					value={ value }
 					onChange={ this.onChange }
-					onInput={ stopEventPropagation }
 					placeholder={ placeholder }
 					onKeyDown={ this.onKeyDown }
 					role="combobox"

--- a/packages/block-editor/src/components/url-popover/image-url-input-ui.js
+++ b/packages/block-editor/src/components/url-popover/image-url-input-ui.js
@@ -17,14 +17,6 @@ import {
 	SVG,
 	Path,
 } from '@wordpress/components';
-import {
-	LEFT,
-	RIGHT,
-	UP,
-	DOWN,
-	BACKSPACE,
-	ENTER,
-} from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
@@ -59,17 +51,6 @@ const ImageURLInputUI = ( {
 	const [ urlInput, setUrlInput ] = useState( null );
 
 	const autocompleteRef = useRef( null );
-
-	const stopPropagation = ( event ) => {
-		event.stopPropagation();
-	};
-
-	const stopPropagationRelevantKeys = ( event ) => {
-		if ( [ LEFT, DOWN, RIGHT, UP, BACKSPACE, ENTER ].indexOf( event.keyCode ) > -1 ) {
-			// Stop the key event from propagating up to ObserveTyping.startTypingInTextField.
-			event.stopPropagation();
-		}
-	};
 
 	const startEditLink = useCallback( () => {
 		if ( linkDestination === LINK_DESTINATION_MEDIA ||
@@ -223,14 +204,10 @@ const ImageURLInputUI = ( {
 				label={ __( 'Link Rel' ) }
 				value={ removeNewTabRel( rel ) || '' }
 				onChange={ onSetLinkRel }
-				onKeyPress={ stopPropagation }
-				onKeyDown={ stopPropagationRelevantKeys }
 			/>
 			<TextControl
 				label={ __( 'Link CSS Class' ) }
 				value={ linkClass || '' }
-				onKeyPress={ stopPropagation }
-				onKeyDown={ stopPropagationRelevantKeys }
 				onChange={ onSetLinkClass }
 			/>
 		</>
@@ -279,8 +256,6 @@ const ImageURLInputUI = ( {
 							className="block-editor-format-toolbar__link-container-content"
 							value={ linkEditorValue }
 							onChangeInputValue={ setUrlInput }
-							onKeyDown={ stopPropagationRelevantKeys }
-							onKeyPress={ stopPropagation }
 							onSubmit={ onSubmitLinkChange() }
 							autocompleteRef={ autocompleteRef }
 						/>
@@ -289,7 +264,6 @@ const ImageURLInputUI = ( {
 						<>
 							<URLPopover.LinkViewer
 								className="block-editor-format-toolbar__link-container-content"
-								onKeyPress={ stopPropagation }
 								url={ url }
 								onEditLinkClick={ startEditLink }
 								urlLabel={ urlLabel }

--- a/packages/block-editor/src/components/writing-flow/index.js
+++ b/packages/block-editor/src/components/writing-flow/index.js
@@ -308,6 +308,19 @@ export default function WritingFlow( { children } ) {
 
 	function onKeyDown( event ) {
 		const { keyCode, target } = event;
+
+		// Handle only if the event occurred within the same DOM hierarchy as
+		// the rendered container. This is used to distinguish between events
+		// which bubble through React's virtual event system from those which
+		// strictly occur in the DOM created by the component.
+		//
+		// The implication here is: If it's not desirable for a bubbled event to
+		// be considered by WritingFlow, it can be avoided by rendering to a
+		// distinct place in the DOM (e.g. using Slot/Fill).
+		if ( ! container.current.contains( target ) ) {
+			return;
+		}
+
 		const isUp = keyCode === UP;
 		const isDown = keyCode === DOWN;
 		const isLeft = keyCode === LEFT;

--- a/packages/format-library/src/image/index.js
+++ b/packages/format-library/src/image/index.js
@@ -6,14 +6,11 @@ import { __ } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
 import { insertObject } from '@wordpress/rich-text';
 import { MediaUpload, RichTextToolbarButton, MediaUploadCheck } from '@wordpress/block-editor';
-import { LEFT, RIGHT, UP, DOWN, BACKSPACE, ENTER } from '@wordpress/keycodes';
 
 const ALLOWED_MEDIA_TYPES = [ 'image' ];
 
 const name = 'core/image';
 const title = __( 'Inline image' );
-
-const stopKeyPropagation = ( event ) => event.stopPropagation();
 
 function getRange() {
 	const selection = window.getSelection();
@@ -37,7 +34,6 @@ export const image = {
 		constructor() {
 			super( ...arguments );
 			this.onChange = this.onChange.bind( this );
-			this.onKeyDown = this.onKeyDown.bind( this );
 			this.openModal = this.openModal.bind( this );
 			this.closeModal = this.closeModal.bind( this );
 			this.state = {
@@ -67,13 +63,6 @@ export const image = {
 
 		onChange( width ) {
 			this.setState( { width } );
-		}
-
-		onKeyDown( event ) {
-			if ( [ LEFT, DOWN, RIGHT, UP, BACKSPACE, ENTER ].indexOf( event.keyCode ) > -1 ) {
-				// Stop the key event from propagating up to ObserveTyping.startTypingInTextField.
-				event.stopPropagation();
-			}
 		}
 
 		openModal() {
@@ -126,8 +115,6 @@ export const image = {
 							/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */ }
 							<form
 								className="block-editor-format-toolbar__image-container-content"
-								onKeyPress={ stopKeyPropagation }
-								onKeyDown={ this.onKeyDown }
 								onSubmit={ ( event ) => {
 									const newReplacements = value.replacements.slice();
 

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -7,7 +7,6 @@ import {
 	ToggleControl,
 	withSpokenMessages,
 } from '@wordpress/components';
-import { LEFT, RIGHT, UP, DOWN, BACKSPACE, ENTER } from '@wordpress/keycodes';
 import { prependHTTP } from '@wordpress/url';
 import {
 	create,
@@ -23,8 +22,6 @@ import { URLPopover } from '@wordpress/block-editor';
  * Internal dependencies
  */
 import { createLinkFormat, isValidHref } from './utils';
-
-const stopKeyPropagation = ( event ) => event.stopPropagation();
 
 function isShowingInput( props, state ) {
 	return props.addingLink || state.editLink;
@@ -69,7 +66,6 @@ class InlineLinkUI extends Component {
 
 		this.editLink = this.editLink.bind( this );
 		this.submitLink = this.submitLink.bind( this );
-		this.onKeyDown = this.onKeyDown.bind( this );
 		this.onChangeInputValue = this.onChangeInputValue.bind( this );
 		this.setLinkTarget = this.setLinkTarget.bind( this );
 		this.onFocusOutside = this.onFocusOutside.bind( this );
@@ -99,13 +95,6 @@ class InlineLinkUI extends Component {
 		}
 
 		return null;
-	}
-
-	onKeyDown( event ) {
-		if ( [ LEFT, DOWN, RIGHT, UP, BACKSPACE, ENTER ].indexOf( event.keyCode ) > -1 ) {
-			// Stop the key event from propagating up to ObserveTyping.startTypingInTextField.
-			event.stopPropagation();
-		}
 	}
 
 	onChangeInputValue( inputValue ) {
@@ -216,15 +205,12 @@ class InlineLinkUI extends Component {
 						className="block-editor-format-toolbar__link-container-content"
 						value={ inputValue }
 						onChangeInputValue={ this.onChangeInputValue }
-						onKeyDown={ this.onKeyDown }
-						onKeyPress={ stopKeyPropagation }
 						onSubmit={ this.submitLink }
 						autocompleteRef={ this.autocompleteRef }
 					/>
 				) : (
 					<URLPopover.LinkViewer
 						className="block-editor-format-toolbar__link-container-content"
-						onKeyPress={ stopKeyPropagation }
 						url={ url }
 						onEditLinkClick={ this.editLink }
 						linkClassName={ isValidHref( prependHTTP( url ) ) ? undefined : 'has-invalid-link' }


### PR DESCRIPTION
Alternative to: #19804

This pull request seeks to improve upon how events are interpreted by WritingFlow and ObserveTyping. Historically, we have often resorted to `Event#stopPropagation` within many components for the sole purpose of avoiding this top-level event handling, but this is problematic for a number of reasons:

- It is not obvious to implement this, and is usually added later only once the undesirable behavior has been identified.
   - Example: #11088
- `Event#stopPropagation` is an extreme solution and often introduces a lot of unintended incompatibilities and interoperability issues. It should be avoided whenever possible.
  - Related reading: https://css-tricks.com/dangers-stopping-event-propagation/
- It introduces an undesirable implicit dependency between the component and its ancestors
  - Example: In stopping propagation, `URLInput` (`@wordpress/components`) establishes a dependency on both its editor ancestry (`@wordpress/block-editor` `WritingFlow`, `ObserveTyping`) and an assumption that it is shown in [`Popover`](https://github.com/WordPress/gutenberg/tree/master/packages/components/src/popover), despite the fact it is intended to be a general-purpose component.

In some of the discussion from https://github.com/WordPress/gutenberg/pull/19804#discussion_r369891119 , it is considered that it might be possible to consider the various dialog components (`Popover`, `Modal`) as entirely separate contexts and to not allow events to bubble through to its ancestor components. In some ways, this aligns with its implementation using Slot/Fill, where the intention of rendering the dialogs elsewhere in the DOM is largely to treat it as being positioned independently from its ancestors (in practical terms, to avoid CSS cascading styles).

The implementation here achieves this by considering whether the events handled by ObserveTyping and WritingFlow originate from within its own DOM hierarchy. This is meant to be distinguished from event bubbling which occurs through the React hierarchy, and provides an opportunity for any components which do not want to be subject to this handling to avoid detection by rendering elsewhere in the DOM. In the case of popovers, this happens by virtue of the fact that they are rendered using [`Slot` and `Fill` components](https://github.com/WordPress/gutenberg/tree/master/packages/components/src/slot-fill).

**Testing Instructions:**

Verify that affected components continue to work as expected, notably that:

- When typing in a paragraph, the block contextual toolbar is dismissed until the mouse is moved, Escape is pressed, or a non-collapsed selection is made (ObserveTyping behaviors)
- Arrow keys traverse across blocks (WritingFlow behaviors)
- These same interactions are not affected when typing occurs within a popover
   - Example: When adding a link to a paragraph, the block contextual toolbar should remain visible while typing within the link editor.