### PR TITLE
Block: move focus mode classes to edit-post

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -29,7 +29,6 @@ import {
 	withSelect,
 	useSelect,
 } from '@wordpress/data';
-import { withViewportMatch } from '@wordpress/viewport';
 import { compose, pure, ifCondition } from '@wordpress/compose';
 
 /**
@@ -46,7 +45,6 @@ import { Context, BlockNodes } from './root-container';
 
 function BlockListBlock( {
 	mode,
-	isFocusMode,
 	isLocked,
 	clientId,
 	isSelected,
@@ -216,7 +214,6 @@ function BlockListBlock( {
 	// Empty paragraph blocks should always show up as unselected.
 	const showEmptyBlockSideInserter = ! isNavigationMode && isSelected && isEmptyDefaultBlock && isValid;
 	const shouldAppearSelected =
-		! isFocusMode &&
 		! showEmptyBlockSideInserter &&
 		isSelected &&
 		! isTypingWithinBlock;
@@ -245,8 +242,6 @@ function BlockListBlock( {
 			'is-reusable': isReusableBlock( blockType ),
 			'is-dragging': isDragging,
 			'is-typing': isTypingWithinBlock,
-			'is-focused': isFocusMode && ( isSelected || isAncestorOfSelectedBlock ),
-			'is-focus-mode': isFocusMode,
 			'has-child-selected': isAncestorOfSelectedBlock,
 			'is-block-collapsed': isAligned,
 		},
@@ -330,7 +325,7 @@ function BlockListBlock( {
 }
 
 const applyWithSelect = withSelect(
-	( select, { clientId, rootClientId, isLargeViewport } ) => {
+	( select, { clientId, rootClientId } ) => {
 		const {
 			isBlockSelected,
 			isAncestorMultiSelected,
@@ -341,7 +336,6 @@ const applyWithSelect = withSelect(
 			getBlockMode,
 			isSelectionEnabled,
 			getSelectedBlocksInitialCaretPosition,
-			getSettings,
 			hasSelectedInnerBlock,
 			getTemplateLock,
 			__unstableGetBlockWithoutInnerBlocks,
@@ -350,7 +344,6 @@ const applyWithSelect = withSelect(
 
 		const block = __unstableGetBlockWithoutInnerBlocks( clientId );
 		const isSelected = isBlockSelected( clientId );
-		const { focusMode, isRTL } = getSettings();
 		const templateLock = getTemplateLock( rootClientId );
 		const checkDeep = true;
 
@@ -380,9 +373,7 @@ const applyWithSelect = withSelect(
 			isEmptyDefaultBlock:
 				name && isUnmodifiedDefaultBlock( { name, attributes } ),
 			isLocked: !! templateLock,
-			isFocusMode: focusMode && isLargeViewport,
 			isNavigationMode: isNavigationMode(),
-			isRTL,
 
 			// Users of the editor.BlockListBlock filter used to be able to access the block prop
 			// Ideally these blocks would rely on the clientId prop only.
@@ -474,7 +465,6 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps, { select } ) => {
 
 export default compose(
 	pure,
-	withViewportMatch( { isLargeViewport: 'medium' } ),
 	applyWithSelect,
 	applyWithDispatch,
 	// block is sometimes not mounted at the right time, causing it be undefined

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -145,6 +145,7 @@
 
 		&:not(.is-selected) .block-editor-block-list__block,
 		&.has-child-selected,
+		&.is-typing,
 		&.is-selected {
 			opacity: 1;
 		}

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -138,13 +138,14 @@
 	}
 
 	// Spotlight mode.
-	&.is-focus-mode:not(.is-multi-selected) {
+	.is-focus-mode &:not(.is-multi-selected) {
 		opacity: 0.5;
 		transition: opacity 0.1s linear;
 		@include reduce-motion("transition");
 
-		&:not(.is-focused) .block-editor-block-list__block,
-		&.is-focused {
+		&:not(.is-selected) .block-editor-block-list__block,
+		&.has-child-selected,
+		&.is-selected {
 			opacity: 1;
 		}
 	}

--- a/packages/edit-post/src/components/text-editor/style.scss
+++ b/packages/edit-post/src/components/text-editor/style.scss
@@ -15,8 +15,8 @@
 		}
 
 		// Hide the thick left border in the code editor.
-		:not(.is-focus-mode) &:not(.has-fixed-toolbar):not(.is-selected) .editor-post-title__input:hover,
-		:not(.is-focus-mode) &:not(.has-fixed-toolbar).is-selected .editor-post-title__input {
+		&:not(.has-fixed-toolbar):not(.is-selected) .editor-post-title__input:hover,
+		&:not(.has-fixed-toolbar).is-selected .editor-post-title__input {
 			box-shadow: none;
 			border-left-width: $border-width;
 		}

--- a/packages/edit-post/src/components/text-editor/style.scss
+++ b/packages/edit-post/src/components/text-editor/style.scss
@@ -15,8 +15,8 @@
 		}
 
 		// Hide the thick left border in the code editor.
-		&:not(.is-focus-mode):not(.has-fixed-toolbar):not(.is-selected) .editor-post-title__input:hover,
-		&:not(.is-focus-mode):not(.has-fixed-toolbar).is-selected .editor-post-title__input {
+		:not(.is-focus-mode) &:not(.has-fixed-toolbar):not(.is-selected) .editor-post-title__input:hover,
+		:not(.is-focus-mode) &:not(.has-fixed-toolbar).is-selected .editor-post-title__input {
 			box-shadow: none;
 			border-left-width: $border-width;
 		}

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import {
@@ -17,6 +22,8 @@ import {
 	__experimentalBlockSettingsMenuPluginsExtension,
 } from '@wordpress/block-editor';
 import { Popover } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { useViewportMatch } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -25,8 +32,16 @@ import BlockInspectorButton from './block-inspector-button';
 import PluginBlockSettingsMenuGroup from '../block-settings-menu/plugin-block-settings-menu-group';
 
 function VisualEditor() {
+	const isLargeViewport = useViewportMatch( 'medium' );
+	const isFocusMode = useSelect( ( select ) =>
+		select( 'core/edit-post' ).isFeatureActive( 'focusMode' )
+	);
+	const className = classnames( 'edit-post-visual-editor editor-styles-wrapper', {
+		'is-focus-mode': isLargeViewport && isFocusMode,
+	} );
+
 	return (
-		<BlockSelectionClearer className="edit-post-visual-editor editor-styles-wrapper">
+		<BlockSelectionClearer className={ className }>
 			<VisualEditorGlobalKeyboardShortcuts />
 			<MultiSelectScrollIntoView />
 			<Popover.Slot name="block-toolbar" />

--- a/packages/editor/src/components/post-title/index.js
+++ b/packages/editor/src/components/post-title/index.js
@@ -70,7 +70,6 @@ class PostTitle extends Component {
 		const {
 			hasFixedToolbar,
 			isCleanNewPost,
-			isFocusMode,
 			isPostTypeViewable,
 			instanceId,
 			placeholder,
@@ -81,7 +80,6 @@ class PostTitle extends Component {
 		// The wp-block className is important for editor styles.
 		const className = classnames( 'wp-block editor-post-title__block', {
 			'is-selected': isSelected,
-			'is-focus-mode': isFocusMode,
 			'has-fixed-toolbar': hasFixedToolbar,
 		} );
 		const decodedPlaceholder = decodeEntities( placeholder );
@@ -127,14 +125,13 @@ const applyWithSelect = withSelect( ( select ) => {
 	const { getSettings } = select( 'core/block-editor' );
 	const { getPostType } = select( 'core' );
 	const postType = getPostType( getEditedPostAttribute( 'type' ) );
-	const { titlePlaceholder, focusMode, hasFixedToolbar } = getSettings();
+	const { titlePlaceholder, hasFixedToolbar } = getSettings();
 
 	return {
 		isCleanNewPost: isCleanNewPost(),
 		title: getEditedPostAttribute( 'title' ),
 		isPostTypeViewable: get( postType, [ 'viewable' ], false ),
 		placeholder: titlePlaceholder,
-		isFocusMode: focusMode,
 		hasFixedToolbar,
 	};
 } );

--- a/packages/editor/src/components/post-title/style.scss
+++ b/packages/editor/src/components/post-title/style.scss
@@ -60,29 +60,27 @@
 		}
 	}
 
-	&:not(.is-focus-mode) {
-		&.is-selected .editor-post-title__input {
-			// use opacity to work in various editor styles.
-			border-color: $dark-opacity-light-800;
-			box-shadow: inset $block-left-border-width 0 0 0 $dark-gray-500;
+	:not(.is-focus-mode) &.is-selected .editor-post-title__input {
+		// use opacity to work in various editor styles.
+		border-color: $dark-opacity-light-800;
+		box-shadow: inset $block-left-border-width 0 0 0 $dark-gray-500;
+
+		.is-dark-theme & {
+			border-color: $light-opacity-light-800;
+			box-shadow: inset $block-left-border-width 0 0 0 $light-gray-600;
+		}
+
+		// Switch to outset borders on larger screens.
+		@include break-small() {
+			box-shadow: -$block-left-border-width 0 0 0 $dark-gray-500;
 
 			.is-dark-theme & {
-				border-color: $light-opacity-light-800;
-				box-shadow: inset $block-left-border-width 0 0 0 $light-gray-600;
-			}
-
-			// Switch to outset borders on larger screens.
-			@include break-small() {
-				box-shadow: -$block-left-border-width 0 0 0 $dark-gray-500;
-
-				.is-dark-theme & {
-					box-shadow: -$block-left-border-width 0 0 0 $light-gray-600;
-				}
+				box-shadow: -$block-left-border-width 0 0 0 $light-gray-600;
 			}
 		}
 	}
 
-	&.is-focus-mode .editor-post-title__input {
+	.is-focus-mode & .editor-post-title__input {
 		opacity: 0.5;
 		transition: opacity 0.1s linear;
 		@include reduce-motion("transition");


### PR DESCRIPTION
## Description

This PR moves the focus mode classes the `edit-post` package. These classes are dependent on the focus mode feature, which is added by the `edit-post` package, so they make more sense there.

With that, it also removes the block's dependency on `getSettings` and viewport matching.

It's also a slight performance improvement: it doesn't make sense for every block to add the `is-focus-mode` class, and when toggling the mode, every single block doesn't need to re-render.

## How has this been tested?

Test focus mode:

* All blocks should be faded out, but only when the viewport is bigger than the medium breakpoint.
* A selected block should fade in.
* A block with a child selected should fade in.
* The title should fade in.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
