### PR TITLE
Block Library: Handle Popover onClose for LinkControl

### DIFF
--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -97,7 +97,10 @@ function URLPicker( { isSelected, url, title, setAttributes, opensInNewTab, onTo
 		setIsURLPickerOpen( true );
 	};
 	const linkControl = isURLPickerOpen && (
-		<Popover position="bottom center">
+		<Popover
+			position="bottom center"
+			onClose={ () => setIsURLPickerOpen( false ) }
+		>
 			<LinkControl
 				className="wp-block-navigation-link__inline-link-input"
 				value={ { url, title, opensInNewTab } }
@@ -110,9 +113,6 @@ function URLPicker( { isSelected, url, title, setAttributes, opensInNewTab, onTo
 					if ( opensInNewTab !== newOpensInNewTab ) {
 						onToggleOpenInNewTab( newOpensInNewTab );
 					}
-				} }
-				onClose={ () => {
-					setIsURLPickerOpen( false );
 				} }
 			/>
 		</Popover>

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -175,7 +175,10 @@ function NavigationLinkEdit( {
 						</span>
 					}
 					{ isLinkOpen && (
-						<Popover position="bottom center">
+						<Popover
+							position="bottom center"
+							onClose={ () => setIsLinkOpen( false ) }
+						>
 							<LinkControl
 								className="wp-block-navigation-link__inline-link-input"
 								value={ link }
@@ -202,7 +205,6 @@ function NavigationLinkEdit( {
 									opensInNewTab: newOpensInNewTab,
 									id,
 								} ) }
-								onClose={ () => setIsLinkOpen( false ) }
 							/>
 						</Popover>
 					) }

--- a/packages/e2e-tests/specs/editor/blocks/__snapshots__/buttons.test.js.snap
+++ b/packages/e2e-tests/specs/editor/blocks/__snapshots__/buttons.test.js.snap
@@ -8,6 +8,14 @@ exports[`Buttons can jump to the link editor using the keyboard shortcut 1`] = `
 <!-- /wp:buttons -->"
 `;
 
+exports[`Buttons dismisses link editor when escape is pressed 1`] = `
+"<!-- wp:buttons -->
+<div class=\\"wp-block-buttons\\"><!-- wp:button -->
+<div class=\\"wp-block-button\\"><a class=\\"wp-block-button__link\\">WordPress</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons -->"
+`;
+
 exports[`Buttons has focus on button content 1`] = `
 "<!-- wp:buttons -->
 <div class=\\"wp-block-buttons\\"><!-- wp:button -->

--- a/packages/e2e-tests/specs/editor/blocks/buttons.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/buttons.test.js
@@ -20,6 +20,16 @@ describe( 'Buttons', () => {
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 
+	it( 'dismisses link editor when escape is pressed', async () => {
+		// Regression: https://github.com/WordPress/gutenberg/pull/19885
+		await insertBlock( 'Buttons' );
+		await pressKeyWithModifier( 'primary', 'k' );
+		await page.keyboard.press( 'Escape' );
+		await page.keyboard.type( 'WordPress' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
 	it( 'can jump to the link editor using the keyboard shortcut', async () => {
 		await insertBlock( 'Buttons' );
 		await page.keyboard.type( 'WordPress' );

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -9,6 +9,7 @@ import {
 	insertBlock,
 	pressKeyWithModifier,
 	setUpResponseMocking,
+	clickBlockToolbarButton,
 } from '@wordpress/e2e-test-utils';
 
 async function mockPagesResponse( pages ) {
@@ -131,6 +132,23 @@ describe( 'Navigation', () => {
 		// Using 'click' here checks for regressions of https://github.com/WordPress/gutenberg/issues/18329,
 		// an issue where the block appender requires two clicks.
 		await page.click( '.wp-block-navigation .block-list-appender' );
+
+		// After adding a new block, search input should be shown immediately.
+		// Verify that Escape would close the popover.
+		// Regression: https://github.com/WordPress/gutenberg/pull/19885
+		const isInURLInput = await page.evaluate( () => (
+			!! document.activeElement.closest( '.block-editor-url-input' )
+		) );
+		expect( isInURLInput ).toBe( true );
+		await page.keyboard.press( 'Escape' );
+		const isInLinkRichText = await page.evaluate( () => (
+			document.activeElement.classList.contains( 'rich-text' ) &&
+			!! document.activeElement.closest( '.block-editor-block-list__block' )
+		) );
+		expect( isInLinkRichText ).toBe( true );
+
+		// Now, trigger the link dialog once more.
+		await clickBlockToolbarButton( 'Link' );
 
 		// For the second nav link block use an existing internal page.
 		// Mock the api response so that it's consistent.


### PR DESCRIPTION
Previously: #19638

This pull request seeks to resolve an issue where popovers rendered by the Buttons and Navigation Link blocks are not correctly handling close intentions. As part of #19638, LinkControl was refactored to remove its built-in `Popover` rendering. It no longer handles `onClose`, and thus the prop should have been moved to the rendered `Popover` component.

**Testing Instructions:**

1. Navigate to Posts > Add New
2. Insert a Buttons block
3. Press the Add Link button in the toolbar of the Button block
4. Press <kbd>Escape</kbd>
5. Note that the Popover is closed