### PR TITLE
Remove unnecessary import from playground

### DIFF
--- a/storybook/stories/playground/index.js
+++ b/storybook/stories/playground/index.js
@@ -1,8 +1,6 @@
 /**
  * WordPress dependencies
  */
-import '@wordpress/editor'; // This shouldn't be necessary
-
 import { useEffect, useState } from '@wordpress/element';
 import {
 	BlockEditorKeyboardShortcuts,


### PR DESCRIPTION
## Description
I removed unnecessary import of @wordpress/editor package. Dependency on @wordpress/editor package had been fixed by this commit https://github.com/WordPress/gutenberg/commit/c97ccf0bea983cc1042cea7a1171a5a7c0ff5770

## How has this been tested?
I ran storybook build and tested manually.

## Screenshots <!-- if applicable -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
