### PR TITLE
Pass original event to file and html drop-zone callbacks (#18885)

### DIFF
--- a/packages/components/src/drop-zone/README.md
+++ b/packages/components/src/drop-zone/README.md
@@ -44,7 +44,7 @@ A string to be shown within the drop zone area.
 
 ### onFilesDrop
 
-The function is called when dropping a file into the `DropZone`. It receives an array of dropped files as an argument.
+The function is called when dropping a file into the `DropZone`. It receives three arguments: an array of dropped files, a position object which the following shape: `{ x: 'left|right', y: 'top|bottom' }`, and the original drop `event` object. The position object indicates whether the drop event happened closer to the top or bottom edges and left or right ones.
 
 - Type: `Function`
 - Required: No
@@ -52,7 +52,7 @@ The function is called when dropping a file into the `DropZone`. It receives an 
 
 ### onHTMLDrop
 
-The function is called when dropping a file into the `DropZone`. It receives the HTML being dropped as an argument.
+The function is called when dropping a file into the `DropZone`. It receives three arguments: the HTML being dropped, a position object, and the original drop `event` object.
 
 - Type: `Function`
 - Required: No

--- a/packages/components/src/drop-zone/provider.js
+++ b/packages/components/src/drop-zone/provider.js
@@ -236,13 +236,15 @@ class DropZoneProvider extends Component {
 				case 'file':
 					dropZone.onFilesDrop(
 						[ ...event.dataTransfer.files ],
-						position
+						position,
+						event
 					);
 					break;
 				case 'html':
 					dropZone.onHTMLDrop(
 						event.dataTransfer.getData( 'text/html' ),
-						position
+						position,
+						event
 					);
 					break;
 				case 'default':


### PR DESCRIPTION
Closes #18885

## Description
This is an enhancement of the dropzone provider's `onFilesDrop` and `onHTMLDrop` callbacks. It adds the passing of original drop event as the third parameter to those callbacks. It should help with the use case described in https://github.com/WordPress/gutenberg/issues/18885.

## How has this been tested?
There is no test for dropzone provider component. I tested it manually using console.log.

## Types of changes
It adds the ability to access the original drop event within `onFilesDrop` and `onHTMLDrop` callbacks.

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
