### PR TITLE
Block editor: Alt+F10 shouldn't scroll to top

### DIFF
--- a/packages/block-editor/src/components/block-list/insertion-point.js
+++ b/packages/block-editor/src/components/block-list/insertion-point.js
@@ -124,6 +124,7 @@ export default function InsertionPoint( {
 			focusOnMount={ false }
 			className="block-editor-block-list__insertion-point-popover"
 			__unstableSlotName="block-toolbar"
+			__unstableFixedPosition={ false }
 		>
 			<div className="block-editor-block-list__insertion-point" style={ { width: inserterElement.offsetWidth } }>
 				<Indicator clientId={ inserterClientId } />

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -539,7 +539,6 @@
 
 .block-editor-block-list__insertion-point-popover {
 	z-index: z-index(".block-editor-block-list__insertion-point-popover");
-	position: absolute;
 
 	.components-popover__content {
 		background: none;
@@ -551,7 +550,6 @@
 
 .components-popover.block-editor-block-list__block-popover {
 	z-index: z-index(".block-editor-block-list__block-popover");
-	position: absolute;
 
 	.components-popover__content {
 		margin: 0 !important;

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -246,6 +246,7 @@ const Popover = ( {
 	__unstableSlotName = SLOT_NAME,
 	__unstableAllowVerticalSubpixelPosition,
 	__unstableAllowHorizontalSubpixelPosition,
+	__unstableFixedPosition = true,
 	/* eslint-enable no-unused-vars */
 	...contentProps
 } ) => {
@@ -268,6 +269,7 @@ const Popover = ( {
 			setStyle( containerRef.current, 'left' );
 			setStyle( contentRef.current, 'maxHeight' );
 			setStyle( contentRef.current, 'maxWidth' );
+			setStyle( containerRef.current, 'position' );
 			return;
 		}
 
@@ -292,7 +294,6 @@ const Popover = ( {
 				contentRect.current = contentRef.current.getBoundingClientRect();
 			}
 
-			const { offsetParent, ownerDocument } = containerRef.current;
 			let relativeOffsetTop = 0;
 
 			// If there is a positioned ancestor element that is not the body,
@@ -300,7 +301,10 @@ const Popover = ( {
 			// the popover is fixed, the offset parent is null or the body
 			// element, in which case the position is relative to the viewport.
 			// See https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetParent
-			if ( offsetParent && offsetParent !== ownerDocument.body ) {
+			if ( ! __unstableFixedPosition ) {
+				setStyle( containerRef.current, 'position', 'absolute' );
+
+				const { offsetParent } = containerRef.current;
 				const offsetParentRect = offsetParent.getBoundingClientRect();
 
 				relativeOffsetTop = offsetParentRect.top;
@@ -310,6 +314,8 @@ const Popover = ( {
 					anchor.width,
 					anchor.height
 				);
+			} else {
+				setStyle( containerRef.current, 'position' );
 			}
 
 			const {

--- a/packages/e2e-tests/specs/editor/various/navigable-toolbar.test.js
+++ b/packages/e2e-tests/specs/editor/various/navigable-toolbar.test.js
@@ -40,6 +40,30 @@ describe.each( [ [ 'unified', true ], [ 'contextual', false ] ] )(
 			await pressKeyWithModifier( 'alt', 'F10' );
 			expect( await isInBlockToolbar() ).toBe( true );
 		} );
+
+		if ( ! isUnifiedToolbar ) {
+			it( 'should not scroll page', async () => {
+				while ( await page.evaluate( () =>
+					wp.dom.getScrollContainer( document.activeElement ).scrollTop === 0
+				) ) {
+					await page.keyboard.press( 'Enter' );
+				}
+
+				await page.keyboard.type( 'a' );
+
+				const scrollTopBefore = await page.evaluate( () =>
+					wp.dom.getScrollContainer( document.activeElement ).scrollTop
+				);
+
+				await pressKeyWithModifier( 'alt', 'F10' );
+				expect( await isInBlockToolbar() ).toBe( true );
+
+				const scrollTopAfter = await page.evaluate( () =>
+					wp.dom.getScrollContainer( document.activeElement ).scrollTop
+				);
+
+				expect( scrollTopBefore ).toBe( scrollTopAfter );
+			} );
+		}
 	}
 );
-


### PR DESCRIPTION
## Description

#19769 has caused a small regression: if you press Alt+F10 to focus the block toolbar, the page scroll to the top. This is because the toolbar now has an absolute position instead of a fixed position. At the time that the toolbar receives focus, the position of the toolbar is not set yet, and it will be invisible at the top of the page. When the browser places the focus, it also scroll the page within view, but shortly after that we position the popover, so it ends up being out of view.

One solution could be to set the position earlier, but this is tricky because for some popovers, we need the height, which is not available early enough.

I went for leaving the position to be fixed until we can set the popover position. Since it's initially fixed, the page won't scroll since the element is within the viewport.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
