### PR TITLE
Apply sentence case formatting to PanelBody titles

### DIFF
--- a/packages/block-editor/src/components/colors/use-colors.js
+++ b/packages/block-editor/src/components/colors/use-colors.js
@@ -116,7 +116,7 @@ const InspectorControlsColorPanel = ( props ) => (
 export default function __experimentalUseColors(
 	colorConfigs,
 	{
-		panelTitle = __( 'Color Settings' ),
+		panelTitle = __( 'Color settings' ),
 		colorPanelProps,
 		contrastCheckers,
 		panelChildren,
@@ -126,7 +126,7 @@ export default function __experimentalUseColors(
 			textColorTargetRef = targetRef,
 		} = {},
 	} = {
-		panelTitle: __( 'Color Settings' ),
+		panelTitle: __( 'Color settings' ),
 	},
 	deps = []
 ) {

--- a/packages/block-library/src/archives/edit.js
+++ b/packages/block-library/src/archives/edit.js
@@ -16,7 +16,7 @@ export default function ArchivesEdit( { attributes, setAttributes } ) {
 	return (
 		<>
 			<InspectorControls>
-				<PanelBody title={ __( 'Archives Settings' ) }>
+				<PanelBody title={ __( 'Archives settings' ) }>
 					<ToggleControl
 						label={ __( 'Display as Dropdown' ) }
 						checked={ displayAsDropdown }

--- a/packages/block-library/src/audio/edit.js
+++ b/packages/block-library/src/audio/edit.js
@@ -144,7 +144,7 @@ class AudioEdit extends Component {
 					/>
 				</BlockControls>
 				<InspectorControls>
-					<PanelBody title={ __( 'Audio Settings' ) }>
+					<PanelBody title={ __( 'Audio settings' ) }>
 						<ToggleControl
 							label={ __( 'Autoplay' ) }
 							onChange={ this.toggleAttribute( 'autoplay' ) }

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -69,7 +69,7 @@ function BorderPanel( { borderRadius = '', setAttributes } ) {
 		[ setAttributes ]
 	);
 	return (
-		<PanelBody title={ __( 'Border Settings' ) }>
+		<PanelBody title={ __( 'Border settings' ) }>
 			<RangeControl
 				value={ borderRadius }
 				label={ __( 'Border Radius' ) }

--- a/packages/block-library/src/categories/edit.js
+++ b/packages/block-library/src/categories/edit.js
@@ -150,7 +150,7 @@ class CategoriesEdit extends Component {
 
 		const inspectorControls = (
 			<InspectorControls>
-				<PanelBody title={ __( 'Categories Settings' ) }>
+				<PanelBody title={ __( 'Categories settings' ) }>
 					<ToggleControl
 						label={ __( 'Display as Dropdown' ) }
 						checked={ displayAsDropdown }

--- a/packages/block-library/src/column/edit.js
+++ b/packages/block-library/src/column/edit.js
@@ -55,7 +55,7 @@ function ColumnEdit( {
 				/>
 			</BlockControls>
 			<InspectorControls>
-				<PanelBody title={ __( 'Column Settings' ) }>
+				<PanelBody title={ __( 'Column settings' ) }>
 					<RangeControl
 						label={ __( 'Percentage width' ) }
 						value={ width || '' }

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -314,7 +314,7 @@ function CoverEdit( {
 			</BlockControls>
 			<InspectorControls>
 				{ !! url && (
-					<PanelBody title={ __( 'Media Settings' ) }>
+					<PanelBody title={ __( 'Media settings' ) }>
 						{ IMAGE_BACKGROUND_TYPE === backgroundType && (
 							<ToggleControl
 								label={ __( 'Fixed Background' ) }

--- a/packages/block-library/src/embed/embed-controls.js
+++ b/packages/block-library/src/embed/embed-controls.js
@@ -36,7 +36,7 @@ const EmbedControls = ( props ) => {
 			</BlockControls>
 			{ themeSupportsResponsive && blockSupportsResponsive && (
 				<InspectorControls>
-					<PanelBody title={ __( 'Media Settings' ) } className="blocks-responsive">
+					<PanelBody title={ __( 'Media settings' ) } className="blocks-responsive">
 						<ToggleControl
 							label={ __( 'Resize for smaller devices' ) }
 							checked={ allowResponsive }

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -353,7 +353,7 @@ class GalleryEdit extends Component {
 		return (
 			<>
 				<InspectorControls>
-					<PanelBody title={ __( 'Gallery Settings' ) }>
+					<PanelBody title={ __( 'Gallery settings' ) }>
 						{ images.length > 1 && <RangeControl
 							label={ __( 'Columns' ) }
 							{ ...MOBILE_CONTROL_PROPS }

--- a/packages/block-library/src/heading/edit.js
+++ b/packages/block-library/src/heading/edit.js
@@ -52,7 +52,7 @@ function HeadingEdit( {
 				} } />
 			</BlockControls>
 			<InspectorControls>
-				<PanelBody title={ __( 'Heading Settings' ) }>
+				<PanelBody title={ __( 'Heading settings' ) }>
 					<p>{ __( 'Level' ) }</p>
 					<HeadingToolbar isCollapsed={ false } minLevel={ 1 } maxLevel={ 7 } selectedLevel={ level } onChange={ ( newLevel ) => setAttributes( { level: newLevel } ) } />
 				</PanelBody>

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -417,7 +417,7 @@ export class ImageEdit extends Component {
 		const getInspectorControls = ( imageWidth, imageHeight ) => (
 			<>
 				<InspectorControls>
-					<PanelBody title={ __( 'Image Settings' ) }>
+					<PanelBody title={ __( 'Image settings' ) }>
 						<TextareaControl
 							label={ __( 'Alt Text (Alternative Text)' ) }
 							value={ alt }

--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -331,7 +331,7 @@ export class ImageEdit extends React.Component {
 
 		const getInspectorControls = () => (
 			<InspectorControls>
-				<PanelBody title={ __( 'Image Settings' ) } >
+				<PanelBody title={ __( 'Image settings' ) } >
 					<TextControl
 						icon={ 'admin-links' }
 						label={ __( 'Link To' ) }

--- a/packages/block-library/src/latest-comments/edit.js
+++ b/packages/block-library/src/latest-comments/edit.js
@@ -63,7 +63,7 @@ class LatestComments extends Component {
 		return (
 			<>
 				<InspectorControls>
-					<PanelBody title={ __( 'Latest Comments Settings' ) }>
+					<PanelBody title={ __( 'Latest comments settings' ) }>
 						<ToggleControl
 							label={ __( 'Display Avatar' ) }
 							checked={ displayAvatar }

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -74,7 +74,7 @@ class LatestPostsEdit extends Component {
 
 		const inspectorControls = (
 			<InspectorControls>
-				<PanelBody title={ __( 'Post Content Settings' ) }>
+				<PanelBody title={ __( 'Post content settings' ) }>
 					<ToggleControl
 						label={ __( 'Post Content' ) }
 						checked={ displayPostContent }
@@ -102,7 +102,7 @@ class LatestPostsEdit extends Component {
 					}
 				</PanelBody>
 
-				<PanelBody title={ __( 'Post Meta Settings' ) }>
+				<PanelBody title={ __( 'Post meta settings' ) }>
 					<ToggleControl
 						label={ __( 'Display post date' ) }
 						checked={ displayPostDate }
@@ -110,7 +110,7 @@ class LatestPostsEdit extends Component {
 					/>
 				</PanelBody>
 
-				<PanelBody title={ __( 'Sorting and Filtering' ) }>
+				<PanelBody title={ __( 'Sorting and filtering' ) }>
 					<QueryControls
 						{ ...{ order, orderBy } }
 						numberOfItems={ postsToShow }

--- a/packages/block-library/src/list/ordered-list-settings.js
+++ b/packages/block-library/src/list/ordered-list-settings.js
@@ -11,7 +11,7 @@ import {
 
 const OrderedListSettings = ( { setAttributes, reversed, start } ) => (
 	<InspectorControls>
-		<PanelBody title={ __( 'Ordered List Settings' ) }>
+		<PanelBody title={ __( 'Ordered list settings' ) }>
 			<TextControl
 				label={ __( 'Start Value' ) }
 				type="number"

--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -250,7 +250,7 @@ class MediaTextEdit extends Component {
 				<InspectorControls>
 					{ mediaTextGeneralSettings }
 					<PanelColorSettings
-						title={ __( 'Color Settings' ) }
+						title={ __( 'Color settings' ) }
 						initialOpen={ false }
 						colorSettings={ colorSettings }
 					/>

--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -208,7 +208,7 @@ class MediaTextEdit extends Component {
 			setAttributes( { verticalAlignment: alignment } );
 		};
 		const mediaTextGeneralSettings = (
-			<PanelBody title={ __( 'Media & Text Settings' ) }>
+			<PanelBody title={ __( 'Media & Text settings' ) }>
 				<ToggleControl
 					label={ __( 'Stack on mobile' ) }
 					checked={ isStackedOnMobile }

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -105,7 +105,7 @@ function NavigationLinkEdit( {
 			</BlockControls>
 			<InspectorControls>
 				<PanelBody
-					title={ __( 'Link Settings' ) }
+					title={ __( 'Link settings' ) }
 				>
 					<TextareaControl
 						value={ description || '' }
@@ -117,7 +117,7 @@ function NavigationLinkEdit( {
 					/>
 				</PanelBody>
 				<PanelBody
-					title={ __( 'SEO Settings' ) }
+					title={ __( 'SEO settings' ) }
 				>
 					<TextControl
 						value={ title || '' }

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -211,7 +211,7 @@ function Navigation( {
 				>
 					<BlockNavigationList clientId={ clientId } />
 				</PanelBody>
-				<PanelBody title={ __( 'Text Settings' ) }>
+				<PanelBody title={ __( 'Text settings' ) }>
 					<FontSizePicker
 						value={ fontSize.size }
 						onChange={ setFontSize }
@@ -221,7 +221,7 @@ function Navigation( {
 			{ InspectorControlsColorPanel }
 			<InspectorControls>
 				<PanelBody
-					title={ __( 'Display Settings' ) }
+					title={ __( 'Display settings' ) }
 				>
 					<ToggleControl
 						checked={ attributes.showSubmenuIcon }

--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -125,7 +125,7 @@ function ParagraphBlock( {
 				/>
 			</BlockControls>
 			<InspectorControls>
-				<PanelBody title={ __( 'Text Settings' ) }>
+				<PanelBody title={ __( 'Text settings' ) }>
 					<FontSizePicker
 						value={ fontSize.size }
 						onChange={ setFontSize }

--- a/packages/block-library/src/pullquote/edit.js
+++ b/packages/block-library/src/pullquote/edit.js
@@ -142,7 +142,7 @@ class PullQuoteEdit extends Component {
 				</figure>
 				<InspectorControls>
 					<PanelColorSettings
-						title={ __( 'Color Settings' ) }
+						title={ __( 'Color settings' ) }
 						colorSettings={ [
 							{
 								value: mainColor.color,

--- a/packages/block-library/src/rss/edit.js
+++ b/packages/block-library/src/rss/edit.js
@@ -112,7 +112,7 @@ class RSSEdit extends Component {
 					<ToolbarGroup controls={ toolbarControls } />
 				</BlockControls>
 				<InspectorControls>
-					<PanelBody title={ __( 'RSS Settings' ) }>
+					<PanelBody title={ __( 'RSS settings' ) }>
 						<RangeControl
 							label={ __( 'Number of items' ) }
 							value={ itemsToShow }

--- a/packages/block-library/src/separator/separator-settings.js
+++ b/packages/block-library/src/separator/separator-settings.js
@@ -10,7 +10,7 @@ import {
 const SeparatorSettings = ( { color, setColor } ) => (
 	<InspectorControls>
 		<PanelColorSettings
-			title={ __( 'Color Settings' ) }
+			title={ __( 'Color settings' ) }
 			colorSettings={ [
 				{
 					value: color.color,

--- a/packages/block-library/src/social-link/edit.js
+++ b/packages/block-library/src/social-link/edit.js
@@ -37,7 +37,7 @@ const SocialLinkEdit = ( { attributes, setAttributes, isSelected } ) => {
 	return (
 		<Fragment>
 			<InspectorControls>
-				<PanelBody title={ sprintf( __( '%s Label' ), socialLinkName ) } initialOpen={ false }>
+				<PanelBody title={ sprintf( __( '%s label' ), socialLinkName ) } initialOpen={ false }>
 					<PanelRow>
 						<TextControl
 							label={ __( 'Link Label' ) }

--- a/packages/block-library/src/spacer/edit.js
+++ b/packages/block-library/src/spacer/edit.js
@@ -50,7 +50,7 @@ const SpacerEdit = ( { attributes, isSelected, setAttributes, instanceId, onResi
 				} }
 			/>
 			<InspectorControls>
-				<PanelBody title={ __( 'Spacer Settings' ) }>
+				<PanelBody title={ __( 'Spacer settings' ) }>
 					<BaseControl label={ __( 'Height in pixels' ) } id={ id }>
 						<input
 							type="number"

--- a/packages/block-library/src/spacer/edit.native.js
+++ b/packages/block-library/src/spacer/edit.native.js
@@ -47,7 +47,7 @@ const SpacerEdit = ( { isSelected, attributes, setAttributes, getStylesFromColor
 	return (
 		<View style={ [ defaultStyle, isSelected && styles.selectedSpacer, { height } ] }>
 			<InspectorControls>
-				<PanelBody title={ __( 'Spacer Settings' ) } >
+				<PanelBody title={ __( 'Spacer settings' ) } >
 					<RangeControl
 						label={ __( 'Height in pixels' ) }
 						minimumValue={ minSpacerHeight }

--- a/packages/block-library/src/table/edit.js
+++ b/packages/block-library/src/table/edit.js
@@ -577,7 +577,7 @@ export class TableEdit extends Component {
 						/>
 					</PanelBody>
 					<PanelColorSettings
-						title={ __( 'Color Settings' ) }
+						title={ __( 'Color settings' ) }
 						initialOpen={ false }
 						colorSettings={ [
 							{

--- a/packages/block-library/src/table/edit.js
+++ b/packages/block-library/src/table/edit.js
@@ -559,7 +559,7 @@ export class TableEdit extends Component {
 					/>
 				</BlockControls>
 				<InspectorControls>
-					<PanelBody title={ __( 'Table Settings' ) } className="blocks-table-settings">
+					<PanelBody title={ __( 'Table settings' ) } className="blocks-table-settings">
 						<ToggleControl
 							label={ __( 'Fixed width table cells' ) }
 							checked={ !! hasFixedLayout }

--- a/packages/block-library/src/tag-cloud/edit.js
+++ b/packages/block-library/src/tag-cloud/edit.js
@@ -66,7 +66,7 @@ class TagCloudEdit extends Component {
 
 		const inspectorControls = (
 			<InspectorControls>
-				<PanelBody title={ __( 'Tag Cloud Settings' ) }>
+				<PanelBody title={ __( 'Tag Cloud settings' ) }>
 					<SelectControl
 						label={ __( 'Taxonomy' ) }
 						options={ taxonomyOptions }

--- a/packages/block-library/src/video/edit.js
+++ b/packages/block-library/src/video/edit.js
@@ -178,7 +178,7 @@ class VideoEdit extends Component {
 					/>
 				</BlockControls>
 				<InspectorControls>
-					<PanelBody title={ __( 'Video Settings' ) }>
+					<PanelBody title={ __( 'Video settings' ) }>
 						<VideoCommonSettings
 							setAttributes={ setAttributes }
 							attributes={ attributes }

--- a/packages/block-library/src/video/edit.native.js
+++ b/packages/block-library/src/video/edit.native.js
@@ -222,7 +222,7 @@ class VideoEdit extends React.Component {
 							{ toolbarEditButton }
 						</BlockControls> }
 					<InspectorControls>
-						<PanelBody title={ __( 'Video Settings' ) }>
+						<PanelBody title={ __( 'Video settings' ) }>
 							<VideoCommonSettings
 								setAttributes={ setAttributes }
 								attributes={ attributes }

--- a/packages/e2e-tests/specs/editor/blocks/heading.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/heading.test.js
@@ -12,7 +12,7 @@ describe( 'Heading', () => {
 	const CUSTOM_COLOR_TEXT = 'Custom Color';
 	const CUSTOM_COLOR_BUTTON_X_SELECTOR = `//button[contains(text(),'${ CUSTOM_COLOR_TEXT }')]`;
 	const COLOR_INPUT_FIELD_SELECTOR = '.components-color-palette__picker .components-text-control__input';
-	const COLOR_PANEL_TOGGLE_X_SELECTOR = '//button[./span[contains(text(),\'Color Settings\')]]';
+	const COLOR_PANEL_TOGGLE_X_SELECTOR = '//button[./span[contains(text(),\'Color settings\')]]';
 
 	beforeEach( async () => {
 		await createNewPost();


### PR DESCRIPTION
## Description
This PR closes #19900 by changing existing PanelBody titles to utilize sentence case formatting. Related to #18758 and #16764

## Screenshots <!-- if applicable -->
Changes were made like this, but for all blocks (`Text Settings` -> `Text settings`, etc):

<img width="334" alt="Screen Shot 2020-01-26 at 4 22 28 PM" src="https://user-images.githubusercontent.com/1813435/73142037-31801a00-4058-11ea-87f7-7d40360dc4ce.png">

## Types of changes
Text string changes.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
