### PR TITLE
Apply sentence case formatting to Setting Sidebar controls

### DIFF
--- a/packages/block-editor/src/components/color-palette/test/__snapshots__/control.js.snap
+++ b/packages/block-editor/src/components/color-palette/test/__snapshots__/control.js.snap
@@ -80,7 +80,7 @@ exports[`ColorPaletteControl matches the snapshot 1`] = `
               onClick={[Function]}
               type="button"
             >
-              Custom Color
+              Custom color
             </button>
           </div>
           <button

--- a/packages/block-editor/src/components/colors-gradients/test/control.js
+++ b/packages/block-editor/src/components/colors-gradients/test/control.js
@@ -86,7 +86,7 @@ describe( 'ColorPaletteControl', () => {
 
 		// Is showing the custom color picker.
 		expect(
-			wrapper.root.findAll( getButtonWithTestPredicate( 'Custom Color' ) )
+			wrapper.root.findAll( getButtonWithTestPredicate( 'Custom color' ) )
 		).toHaveLength( 1 );
 	} );
 
@@ -128,7 +128,7 @@ describe( 'ColorPaletteControl', () => {
 
 		// Is showing the custom color picker.
 		expect(
-			wrapper.root.findAll( getButtonWithTestPredicate( 'Custom Color' ) )
+			wrapper.root.findAll( getButtonWithTestPredicate( 'Custom color' ) )
 		).toHaveLength( 1 );
 	} );
 

--- a/packages/block-editor/src/components/colors/use-colors.js
+++ b/packages/block-editor/src/components/colors/use-colors.js
@@ -304,7 +304,7 @@ export default function __experimentalUseColors(
 
 				panelLabel = colorConfig.label ||
 					COMMON_COLOR_LABELS[ name ] ||
-					startCase( name ), // E.g. 'Background Color'.
+					startCase( name ), // E.g. 'Background color'.
 				componentName = startCase( name ).replace( /\s/g, '' ), // E.g. 'BackgroundColor'.
 
 				color = colorConfig.color,

--- a/packages/block-editor/src/components/image-size-control/index.js
+++ b/packages/block-editor/src/components/image-size-control/index.js
@@ -50,7 +50,7 @@ class ImageSizeControl extends Component {
 			<>
 				{ ! isEmpty( imageSizeOptions ) && (
 					<SelectControl
-						label={ __( 'Image Size' ) }
+						label={ __( 'Image size' ) }
 						value={ slug }
 						options={ imageSizeOptions }
 						onChange={ onChangeImage }
@@ -59,7 +59,7 @@ class ImageSizeControl extends Component {
 				{ isResizable && (
 					<div className="block-editor-image-size-control">
 						<p className="block-editor-image-size-control__row">
-							{ __( 'Image Dimensions' ) }
+							{ __( 'Image dimensions' ) }
 						</p>
 						<div className="block-editor-image-size-control__row">
 							<TextControl

--- a/packages/block-editor/src/hooks/anchor.js
+++ b/packages/block-editor/src/hooks/anchor.js
@@ -72,11 +72,11 @@ export const withInspectorControl = createHigherOrderComponent(
 						<InspectorAdvancedControls>
 							<TextControl
 								className="html-anchor-control"
-								label={ __( 'HTML Anchor' ) }
+								label={ __( 'HTML anchor' ) }
 								help={
 									<>
 										{ __(
-											'Enter a word or two — without spaces — to make a unique web address just for this heading, called an “anchor.” Then, you’ll be able to link directly to this section of your page.'
+											'Enter a word or two — without spaces — to make a unique web address just for this heading, called an “anchor.” Then, you’ll be able to link directly to this section of your page.'
 										) }
 
 										<ExternalLink

--- a/packages/block-editor/src/hooks/custom-class-name.js
+++ b/packages/block-editor/src/hooks/custom-class-name.js
@@ -65,7 +65,7 @@ export const withInspectorControl = createHigherOrderComponent(
 						<BlockEdit { ...props } />
 						<InspectorAdvancedControls>
 							<TextControl
-								label={ __( 'Additional CSS Class(es)' ) }
+								label={ __( 'Additional CSS class(es)' ) }
 								value={ props.attributes.className || '' }
 								onChange={ ( nextValue ) => {
 									props.setAttributes( {

--- a/packages/block-library/src/archives/edit.js
+++ b/packages/block-library/src/archives/edit.js
@@ -14,7 +14,7 @@ export default function ArchivesEdit( { attributes, setAttributes } ) {
 			<InspectorControls>
 				<PanelBody title={ __( 'Archives settings' ) }>
 					<ToggleControl
-						label={ __( 'Display as Dropdown' ) }
+						label={ __( 'Display as dropdown' ) }
 						checked={ displayAsDropdown }
 						onChange={ () =>
 							setAttributes( {
@@ -23,7 +23,7 @@ export default function ArchivesEdit( { attributes, setAttributes } ) {
 						}
 					/>
 					<ToggleControl
-						label={ __( 'Show Post Counts' ) }
+						label={ __( 'Show post counts' ) }
 						checked={ showPostCounts }
 						onChange={ () =>
 							setAttributes( {

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -72,7 +72,7 @@ function BorderPanel( { borderRadius = '', setAttributes } ) {
 		<PanelBody title={ __( 'Border settings' ) }>
 			<RangeControl
 				value={ borderRadius }
-				label={ __( 'Border Radius' ) }
+				label={ __( 'Border radius' ) }
 				min={ MIN_BORDER_RADIUS_VALUE }
 				max={ MAX_BORDER_RADIUS_VALUE }
 				initialPosition={ INITIAL_BORDER_RADIUS_POSITION }
@@ -232,7 +232,7 @@ function ButtonEdit( {
 						{
 							colorValue: textColor.color,
 							onColorChange: setTextColor,
-							label: __( 'Text Color' ),
+							label: __( 'Text color' ),
 						},
 						{
 							colorValue: backgroundColor.color,

--- a/packages/block-library/src/categories/edit.js
+++ b/packages/block-library/src/categories/edit.js
@@ -177,17 +177,17 @@ class CategoriesEdit extends Component {
 			<InspectorControls>
 				<PanelBody title={ __( 'Categories settings' ) }>
 					<ToggleControl
-						label={ __( 'Display as Dropdown' ) }
+						label={ __( 'Display as dropdown' ) }
 						checked={ displayAsDropdown }
 						onChange={ this.toggleDisplayAsDropdown }
 					/>
 					<ToggleControl
-						label={ __( 'Show Hierarchy' ) }
+						label={ __( 'Show hierarchy' ) }
 						checked={ showHierarchy }
 						onChange={ this.toggleShowHierarchy }
 					/>
 					<ToggleControl
-						label={ __( 'Show Post Counts' ) }
+						label={ __( 'Show post counts' ) }
 						checked={ showPostCounts }
 						onChange={ this.toggleShowPostCounts }
 					/>

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -329,7 +329,7 @@ function CoverEdit( {
 					<PanelBody title={ __( 'Media settings' ) }>
 						{ IMAGE_BACKGROUND_TYPE === backgroundType && (
 							<ToggleControl
-								label={ __( 'Fixed Background' ) }
+								label={ __( 'Fixed background' ) }
 								checked={ hasParallax }
 								onChange={ toggleParallax }
 							/>
@@ -337,7 +337,7 @@ function CoverEdit( {
 						{ IMAGE_BACKGROUND_TYPE === backgroundType &&
 							! hasParallax && (
 								<FocalPointPicker
-									label={ __( 'Focal Point Picker' ) }
+									label={ __( 'Focal point picker' ) }
 									url={ url }
 									value={ focalPoint }
 									onChange={ ( newFocalPoint ) =>
@@ -396,7 +396,7 @@ function CoverEdit( {
 						>
 							{ !! url && (
 								<RangeControl
-									label={ __( 'Background Opacity' ) }
+									label={ __( 'Background opacity' ) }
 									value={ dimRatio }
 									onChange={ ( newDimRation ) =>
 										setAttributes( {

--- a/packages/block-library/src/file/inspector.js
+++ b/packages/block-library/src/file/inspector.js
@@ -18,7 +18,7 @@ export default function FileBlockInspector( {
 	let linkDestinationOptions = [ { value: href, label: __( 'URL' ) } ];
 	if ( attachmentPage ) {
 		linkDestinationOptions = [
-			{ value: href, label: __( 'Media File' ) },
+			{ value: href, label: __( 'Media file' ) },
 			{ value: attachmentPage, label: __( 'Attachment page' ) },
 		];
 	}
@@ -28,7 +28,7 @@ export default function FileBlockInspector( {
 			<InspectorControls>
 				<PanelBody title={ __( 'Text link settings' ) }>
 					<SelectControl
-						label={ __( 'Link To' ) }
+						label={ __( 'Link to' ) }
 						value={ textLinkHref }
 						options={ linkDestinationOptions }
 						onChange={ changeLinkDestinationOption }

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -394,14 +394,14 @@ class GalleryEdit extends Component {
 						) }
 
 						<ToggleControl
-							label={ __( 'Crop Images' ) }
+							label={ __( 'Crop images' ) }
 							{ ...MOBILE_CONTROL_PROPS }
 							checked={ !! imageCrop }
 							onChange={ this.toggleImageCrop }
 							help={ this.getImageCropHelp }
 						/>
 						<SelectControl
-							label={ __( 'Link To' ) }
+							label={ __( 'Link to' ) }
 							{ ...mobileLinkToProps }
 							value={ linkTo }
 							onChange={ this.setLinkTo }
@@ -409,7 +409,7 @@ class GalleryEdit extends Component {
 						/>
 						{ shouldShowSizeOptions && (
 							<SelectControl
-								label={ __( 'Images Size' ) }
+								label={ __( 'Images size' ) }
 								{ ...MOBILE_CONTROL_PROPS_SEPARATOR_NONE }
 								value={ sizeSlug }
 								options={ imageSizeOptions }

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -446,7 +446,7 @@ export class ImageEdit extends Component {
 				<InspectorControls>
 					<PanelBody title={ __( 'Image settings' ) }>
 						<TextareaControl
-							label={ __( 'Alt Text (Alternative Text)' ) }
+							label={ __( 'Alt text (alternative text)' ) }
 							value={ alt }
 							onChange={ this.updateAlt }
 							help={
@@ -477,7 +477,7 @@ export class ImageEdit extends Component {
 				</InspectorControls>
 				<InspectorAdvancedControls>
 					<TextControl
-						label={ __( 'Title Attribute' ) }
+						label={ __( 'Title attribute' ) }
 						value={ title || '' }
 						onChange={ this.onSetTitle }
 						help={

--- a/packages/block-library/src/latest-comments/edit.js
+++ b/packages/block-library/src/latest-comments/edit.js
@@ -69,22 +69,22 @@ class LatestComments extends Component {
 				<InspectorControls>
 					<PanelBody title={ __( 'Latest comments settings' ) }>
 						<ToggleControl
-							label={ __( 'Display Avatar' ) }
+							label={ __( 'Display avatar' ) }
 							checked={ displayAvatar }
 							onChange={ this.toggleDisplayAvatar }
 						/>
 						<ToggleControl
-							label={ __( 'Display Date' ) }
+							label={ __( 'Display date' ) }
 							checked={ displayDate }
 							onChange={ this.toggleDisplayDate }
 						/>
 						<ToggleControl
-							label={ __( 'Display Excerpt' ) }
+							label={ __( 'Display excerpt' ) }
 							checked={ displayExcerpt }
 							onChange={ this.toggleDisplayExcerpt }
 						/>
 						<RangeControl
-							label={ __( 'Number of Comments' ) }
+							label={ __( 'Number of comments' ) }
 							value={ commentsToShow }
 							onChange={ this.setCommentsToShow }
 							min={ MIN_COMMENTS }

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -101,7 +101,7 @@ class LatestPostsEdit extends Component {
 			<InspectorControls>
 				<PanelBody title={ __( 'Post content settings' ) }>
 					<ToggleControl
-						label={ __( 'Post Content' ) }
+						label={ __( 'Post content' ) }
 						checked={ displayPostContent }
 						onChange={ ( value ) =>
 							setAttributes( { displayPostContent: value } )
@@ -114,7 +114,7 @@ class LatestPostsEdit extends Component {
 							options={ [
 								{ label: __( 'Excerpt' ), value: 'excerpt' },
 								{
-									label: __( 'Full Post' ),
+									label: __( 'Full post' ),
 									value: 'full_post',
 								},
 							] }
@@ -149,7 +149,7 @@ class LatestPostsEdit extends Component {
 					/>
 				</PanelBody>
 
-				<PanelBody title={ __( 'Featured Image Settings' ) }>
+				<PanelBody title={ __( 'Featured image settings' ) }>
 					<ToggleControl
 						label={ __( 'Display featured image' ) }
 						checked={ displayFeaturedImage }
@@ -188,7 +188,7 @@ class LatestPostsEdit extends Component {
 							/>
 							<BaseControl>
 								<BaseControl.VisualLabel>
-									{ __( 'Image Alignment' ) }
+									{ __( 'Image alignment' ) }
 								</BaseControl.VisualLabel>
 								<BlockAlignmentToolbar
 									value={ featuredImageAlign }

--- a/packages/block-library/src/list/ordered-list-settings.js
+++ b/packages/block-library/src/list/ordered-list-settings.js
@@ -9,7 +9,7 @@ const OrderedListSettings = ( { setAttributes, reversed, start } ) => (
 	<InspectorControls>
 		<PanelBody title={ __( 'Ordered list settings' ) }>
 			<TextControl
-				label={ __( 'Start Value' ) }
+				label={ __( 'Start value' ) }
 				type="number"
 				onChange={ ( value ) => {
 					const int = parseInt( value, 10 );
@@ -24,7 +24,7 @@ const OrderedListSettings = ( { setAttributes, reversed, start } ) => (
 				step="1"
 			/>
 			<ToggleControl
-				label={ __( 'Reverse List Numbering' ) }
+				label={ __( 'Reverse list numbering' ) }
 				checked={ reversed || false }
 				onChange={ ( value ) => {
 					setAttributes( {

--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -230,7 +230,7 @@ class MediaTextEdit extends Component {
 			{
 				value: backgroundColor.color,
 				onChange: setBackgroundColor,
-				label: __( 'Background Color' ),
+				label: __( 'Background color' ),
 			},
 		];
 		const toolbarControls = [
@@ -277,7 +277,7 @@ class MediaTextEdit extends Component {
 				) }
 				{ imageFill && (
 					<FocalPointPicker
-						label={ __( 'Focal Point Picker' ) }
+						label={ __( 'Focal point picker' ) }
 						url={ mediaUrl }
 						value={ focalPoint }
 						onChange={ ( value ) =>
@@ -287,7 +287,7 @@ class MediaTextEdit extends Component {
 				) }
 				{ mediaType === 'image' && (
 					<TextareaControl
-						label={ __( 'Alt Text (Alternative Text)' ) }
+						label={ __( 'Alt text (alternative text)' ) }
 						value={ mediaAlt }
 						onChange={ onMediaAltChange }
 						help={

--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -132,7 +132,7 @@ function ParagraphBlock( {
 						onChange={ setFontSize }
 					/>
 					<ToggleControl
-						label={ __( 'Drop Cap' ) }
+						label={ __( 'Drop cap' ) }
 						checked={ !! dropCap }
 						onChange={ () =>
 							setAttributes( { dropCap: ! dropCap } )

--- a/packages/block-library/src/pullquote/edit.js
+++ b/packages/block-library/src/pullquote/edit.js
@@ -166,12 +166,12 @@ class PullQuoteEdit extends Component {
 							{
 								value: mainColor.color,
 								onChange: this.pullQuoteMainColorSetter,
-								label: __( 'Main Color' ),
+								label: __( 'Main color' ),
 							},
 							{
 								value: textColor.color,
 								onChange: this.pullQuoteTextColorSetter,
-								label: __( 'Text Color' ),
+								label: __( 'Text color' ),
 							},
 						] }
 					>

--- a/packages/block-library/src/pullquote/index.js
+++ b/packages/block-library/src/pullquote/index.js
@@ -41,7 +41,7 @@ export const settings = {
 			label: _x( 'Default', 'block style' ),
 			isDefault: true,
 		},
-		{ name: SOLID_COLOR_STYLE_NAME, label: __( 'Solid Color' ) },
+		{ name: SOLID_COLOR_STYLE_NAME, label: __( 'Solid color' ) },
 	],
 	supports: {
 		align: [ 'left', 'right', 'wide', 'full' ],

--- a/packages/block-library/src/social-link/edit.js
+++ b/packages/block-library/src/social-link/edit.js
@@ -46,7 +46,7 @@ const SocialLinkEdit = ( { attributes, setAttributes, isSelected } ) => {
 				>
 					<PanelRow>
 						<TextControl
-							label={ __( 'Link Label' ) }
+							label={ __( 'Link label' ) }
 							help={ __(
 								'Briefly describe the link to help screen reader users.'
 							) }
@@ -75,7 +75,7 @@ const SocialLinkEdit = ( { attributes, setAttributes, isSelected } ) => {
 									onChange={ ( nextURL ) =>
 										setAttributes( { url: nextURL } )
 									}
-									placeholder={ __( 'Enter Address' ) }
+									placeholder={ __( 'Enter address' ) }
 									disableSuggestions={ true }
 								/>
 							</div>

--- a/packages/block-library/src/table/edit.js
+++ b/packages/block-library/src/table/edit.js
@@ -640,7 +640,7 @@ export class TableEdit extends Component {
 							{
 								value: backgroundColor.color,
 								onChange: setBackgroundColor,
-								label: __( 'Background Color' ),
+								label: __( 'Background color' ),
 								disableCustomColors: true,
 								colors: BACKGROUND_COLORS,
 							},

--- a/packages/block-library/src/video/edit-common-settings.js
+++ b/packages/block-library/src/video/edit-common-settings.js
@@ -47,7 +47,7 @@ const VideoSettings = ( { setAttributes, attributes } ) => {
 				checked={ muted }
 			/>
 			<ToggleControl
-				label={ __( 'Playback Controls' ) }
+				label={ __( 'Playback controls' ) }
 				onChange={ toggleAttribute( 'controls' ) }
 				checked={ controls }
 			/>

--- a/packages/block-library/src/video/edit.js
+++ b/packages/block-library/src/video/edit.js
@@ -174,10 +174,10 @@ class VideoEdit extends Component {
 						<MediaUploadCheck>
 							<BaseControl className="editor-video-poster-control">
 								<BaseControl.VisualLabel>
-									{ __( 'Poster Image' ) }
+									{ __( 'Poster image' ) }
 								</BaseControl.VisualLabel>
 								<MediaUpload
-									title={ __( 'Select Poster Image' ) }
+									title={ __( 'Select poster image' ) }
 									onSelect={ this.onSelectPoster }
 									allowedTypes={
 										VIDEO_POSTER_ALLOWED_MEDIA_TYPES

--- a/packages/components/src/color-palette/index.js
+++ b/packages/components/src/color-palette/index.js
@@ -85,7 +85,7 @@ export default function ColorPalette( {
 							buttonProps={ {
 								'aria-label': __( 'Custom color picker' ),
 							} }
-							linkText={ __( 'Custom Color' ) }
+							linkText={ __( 'Custom color' ) }
 						/>
 					) }
 					{ !! clearable && (

--- a/packages/components/src/color-palette/test/__snapshots__/index.js.snap
+++ b/packages/components/src/color-palette/test/__snapshots__/index.js.snap
@@ -94,7 +94,7 @@ exports[`ColorPalette Dropdown .renderToggle should render dropdown content 1`] 
   onClick={[MockFunction]}
   type="button"
 >
-  Custom Color
+  Custom color
 </button>
 `;
 
@@ -121,7 +121,7 @@ exports[`ColorPalette Dropdown should render it correctly 1`] = `
         onClick={[Function]}
         type="button"
       >
-        Custom Color
+        Custom color
       </button>
     </ForwardRef(Button)>
   </div>
@@ -225,7 +225,7 @@ exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
               "renderContent": [Function],
             }
           }
-          linkText="Custom Color"
+          linkText="Custom color"
         />
         <ButtonAction
           onClick={[Function]}
@@ -521,7 +521,7 @@ exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
               "renderContent": [Function],
             }
           }
-          linkText="Custom Color"
+          linkText="Custom color"
         >
           <Dropdown
             className="components-circular-option-picker__dropdown-link-action"
@@ -545,7 +545,7 @@ exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
                   onClick={[Function]}
                   type="button"
                 >
-                  Custom Color
+                  Custom color
                 </button>
               </ForwardRef(Button)>
             </div>

--- a/packages/components/src/custom-select-control/stories/index.js
+++ b/packages/components/src/custom-select-control/stories/index.js
@@ -31,5 +31,5 @@ const options = [
 	},
 ];
 export const _default = () => (
-	<CustomSelectControl label="Font Size" options={ options } />
+	<CustomSelectControl label="Font size" options={ options } />
 );

--- a/packages/components/src/focal-point-picker/index.js
+++ b/packages/components/src/focal-point-picker/index.js
@@ -243,7 +243,7 @@ export class FocalPointPicker extends Component {
 				</div>
 				<div className="components-focal-point-picker_position-display-container">
 					<BaseControl
-						label={ __( 'Horizontal Pos.' ) }
+						label={ __( 'Horizontal pos.' ) }
 						id={ horizontalPositionId }
 					>
 						<input
@@ -258,7 +258,7 @@ export class FocalPointPicker extends Component {
 						<span>%</span>
 					</BaseControl>
 					<BaseControl
-						label={ __( 'Vertical Pos.' ) }
+						label={ __( 'Vertical pos.' ) }
 						id={ verticalPositionId }
 					>
 						<input

--- a/packages/components/src/font-size-picker/index.js
+++ b/packages/components/src/font-size-picker/index.js
@@ -100,13 +100,13 @@ export default function FontSizePicker( {
 	return (
 		<fieldset className="components-font-size-picker">
 			<legend className="screen-reader-text">
-				{ __( 'Font Size' ) }
+				{ __( 'Font size' ) }
 			</legend>
 			<div className="components-font-size-picker__controls">
 				{ fontSizes.length > 0 && (
 					<CustomSelectControl
 						className={ 'components-font-size-picker__select' }
-						label={ __( 'Preset Size' ) }
+						label={ __( 'Preset size' ) }
 						options={ options }
 						value={
 							options.find(

--- a/packages/components/src/query-controls/index.js
+++ b/packages/components/src/query-controls/index.js
@@ -33,11 +33,11 @@ export default function QueryControls( {
 				value={ `${ orderBy }/${ order }` }
 				options={ [
 					{
-						label: __( 'Newest to Oldest' ),
+						label: __( 'Newest to oldest' ),
 						value: 'date/desc',
 					},
 					{
-						label: __( 'Oldest to Newest' ),
+						label: __( 'Oldest to newest' ),
 						value: 'date/asc',
 					},
 					{

--- a/packages/e2e-tests/specs/editor/blocks/heading.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/heading.test.js
@@ -9,7 +9,7 @@ import {
 } from '@wordpress/e2e-test-utils';
 
 describe( 'Heading', () => {
-	const CUSTOM_COLOR_TEXT = 'Custom Color';
+	const CUSTOM_COLOR_TEXT = 'Custom color';
 	const CUSTOM_COLOR_BUTTON_X_SELECTOR = `//button[contains(text(),'${ CUSTOM_COLOR_TEXT }')]`;
 	const COLOR_INPUT_FIELD_SELECTOR =
 		'.components-color-palette__picker .components-text-control__input';

--- a/storybook/test/__snapshots__/index.js.snap
+++ b/storybook/test/__snapshots__/index.js.snap
@@ -2027,7 +2027,7 @@ exports[`Storyshots Components/ColorPalette Default 1`] = `
         onClick={[Function]}
         type="button"
       >
-        Custom Color
+        Custom color
       </button>
     </div>
     <button
@@ -2124,7 +2124,7 @@ exports[`Storyshots Components/ColorPalette With Knobs 1`] = `
         onClick={[Function]}
         type="button"
       >
-        Custom Color
+        Custom color
       </button>
     </div>
     <button
@@ -2532,12 +2532,12 @@ exports[`Storyshots Components/CustomSelectControl Default 1`] = `
     htmlFor="downshift-null-toggle-button"
     id="downshift-null-label"
   >
-    Font Size
+    Font size
   </label>
   <button
     aria-expanded={false}
     aria-haspopup="listbox"
-    aria-label="Font Size"
+    aria-label="Font size"
     className="components-button components-custom-select-control__button is-small"
     id="downshift-null-toggle-button"
     onClick={[Function]}
@@ -3054,7 +3054,7 @@ exports[`Storyshots Components/FontSizePicker Default 1`] = `
   <legend
     className="screen-reader-text"
   >
-    Font Size
+    Font size
   </legend>
   <div
     className="components-font-size-picker__controls"
@@ -3067,12 +3067,12 @@ exports[`Storyshots Components/FontSizePicker Default 1`] = `
         htmlFor="downshift-null-toggle-button"
         id="downshift-null-label"
       >
-        Preset Size
+        Preset size
       </label>
       <button
         aria-expanded={false}
         aria-haspopup="listbox"
-        aria-label="Preset Size"
+        aria-label="Preset size"
         className="components-button components-custom-select-control__button is-small"
         id="downshift-null-toggle-button"
         onClick={[Function]}
@@ -3344,7 +3344,7 @@ input[type='number'].emotion-18 {
   <legend
     className="screen-reader-text"
   >
-    Font Size
+    Font size
   </legend>
   <div
     className="components-font-size-picker__controls"
@@ -3357,12 +3357,12 @@ input[type='number'].emotion-18 {
         htmlFor="downshift-null-toggle-button"
         id="downshift-null-label"
       >
-        Preset Size
+        Preset size
       </label>
       <button
         aria-expanded={false}
         aria-haspopup="listbox"
-        aria-label="Preset Size"
+        aria-label="Preset size"
         className="components-button components-custom-select-control__button is-small"
         id="downshift-null-toggle-button"
         onClick={[Function]}
@@ -3542,7 +3542,7 @@ exports[`Storyshots Components/FontSizePicker Without Custom Sizes 1`] = `
   <legend
     className="screen-reader-text"
   >
-    Font Size
+    Font size
   </legend>
   <div
     className="components-font-size-picker__controls"
@@ -3555,12 +3555,12 @@ exports[`Storyshots Components/FontSizePicker Without Custom Sizes 1`] = `
         htmlFor="downshift-null-toggle-button"
         id="downshift-null-label"
       >
-        Preset Size
+        Preset size
       </label>
       <button
         aria-expanded={false}
         aria-haspopup="listbox"
-        aria-label="Preset Size"
+        aria-label="Preset size"
         className="components-button components-custom-select-control__button is-small"
         id="downshift-null-toggle-button"
         onClick={[Function]}


### PR DESCRIPTION
## Description
This PR closes #19902 by changing existing PanelBody titles to utilize sentence case formatting. Related to #18758, #16764, and #19902.

## Screenshots <!-- if applicable -->

<img width="272" alt="Screen Shot 2020-01-26 at 5 20 06 PM" src="https://user-images.githubusercontent.com/1813435/73142732-292bdd00-4060-11ea-9843-4f28e615ab6f.png">

<img width="259" alt="Screen Shot 2020-01-26 at 5 20 17 PM" src="https://user-images.githubusercontent.com/1813435/73142734-2cbf6400-4060-11ea-9356-04c91858fa60.png">

## Types of changes
Text string changes.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
