### PR TITLE
[RNMobile] fix show appender and separator in Group block

### DIFF
--- a/packages/block-editor/src/components/block-list/index.native.js
+++ b/packages/block-editor/src/components/block-list/index.native.js
@@ -73,7 +73,7 @@ export class BlockList extends Component {
 			blockClientIds,
 			renderAppender,
 		} = this.props;
-		return ( renderAppender && blockClientIds.length > 0 )
+		return ( renderAppender && blockClientIds.length > 0 );
 	}
 
 	render() {
@@ -84,7 +84,6 @@ export class BlockList extends Component {
 			title,
 			header,
 			withFooter = true,
-			renderAppender,
 			isReadOnly,
 			isRootList,
 		} = this.props;

--- a/packages/block-editor/src/components/block-list/index.native.js
+++ b/packages/block-editor/src/components/block-list/index.native.js
@@ -35,7 +35,7 @@ export class BlockList extends Component {
 		this.scrollViewInnerRef = this.scrollViewInnerRef.bind( this );
 		this.addBlockToEndOfPost = this.addBlockToEndOfPost.bind( this );
 		this.shouldFlatListPreventAutomaticScroll = this.shouldFlatListPreventAutomaticScroll.bind( this );
-		this.showGroupAppender = this.showGroupAppender.bind( this );
+		this.shouldShowInnerBlockAppender = this.shouldShowInnerBlockAppender.bind( this );
 	}
 
 	addBlockToEndOfPost( newBlock ) {
@@ -68,7 +68,7 @@ export class BlockList extends Component {
 		);
 	}
 
-	showGroupAppender() {
+	shouldShowInnerBlockAppender() {
 		const {
 			blockClientIds,
 			renderAppender,
@@ -112,7 +112,7 @@ export class BlockList extends Component {
 					ListFooterComponent={ ! isReadOnly && withFooter && this.renderBlockListFooter }
 				/>
 
-				{ this.showGroupAppender() && (
+				{ this.shouldShowInnerBlockAppender() && (
 					<View style={ styles.paddingToContent }>
 						<BlockListAppender
 							rootClientId={ this.props.rootClientId }
@@ -155,7 +155,7 @@ export class BlockList extends Component {
 							onCaretVerticalPositionChange={ this.onCaretVerticalPositionChange }
 							isSmallScreen={ ! this.props.isFullyBordered }
 						/> ) }
-					{ ! this.showGroupAppender() && shouldShowInsertionPointAfter( clientId ) && <BlockInsertionPoint /> }
+					{ ! this.shouldShowInnerBlockAppender() && shouldShowInsertionPointAfter( clientId ) && <BlockInsertionPoint /> }
 				</View>
 			</ReadableContentView>
 		);

--- a/packages/block-editor/src/components/block-list/index.native.js
+++ b/packages/block-editor/src/components/block-list/index.native.js
@@ -109,6 +109,7 @@ export class BlockList extends Component {
 						<BlockListAppender
 							rootClientId={ this.props.rootClientId }
 							renderAppender={ this.props.renderAppender }
+							showSeparator
 						/>
 					</View>
 				)
@@ -131,6 +132,8 @@ export class BlockList extends Component {
 			shouldShowBlockAtIndex,
 			shouldShowInsertionPointBefore,
 			shouldShowInsertionPointAfter,
+			renderAppender,
+			blockClientIds,
 		} = this.props;
 
 		return (
@@ -146,7 +149,7 @@ export class BlockList extends Component {
 							onCaretVerticalPositionChange={ this.onCaretVerticalPositionChange }
 							isSmallScreen={ ! this.props.isFullyBordered }
 						/> ) }
-					{ shouldShowInsertionPointAfter( clientId ) && <BlockInsertionPoint /> }
+					{ ! ( renderAppender && blockClientIds.length > 0 ) && shouldShowInsertionPointAfter( clientId ) && <BlockInsertionPoint /> }
 				</View>
 			</ReadableContentView>
 		);

--- a/packages/block-editor/src/components/block-list/index.native.js
+++ b/packages/block-editor/src/components/block-list/index.native.js
@@ -35,6 +35,7 @@ export class BlockList extends Component {
 		this.scrollViewInnerRef = this.scrollViewInnerRef.bind( this );
 		this.addBlockToEndOfPost = this.addBlockToEndOfPost.bind( this );
 		this.shouldFlatListPreventAutomaticScroll = this.shouldFlatListPreventAutomaticScroll.bind( this );
+		this.showGroupAppender = this.showGroupAppender.bind( this );
 	}
 
 	addBlockToEndOfPost( newBlock ) {
@@ -65,6 +66,14 @@ export class BlockList extends Component {
 				/>
 			</ReadableContentView>
 		);
+	}
+
+	showGroupAppender() {
+		const {
+			blockClientIds,
+			renderAppender,
+		} = this.props;
+		return ( renderAppender && blockClientIds.length > 0 )
 	}
 
 	render() {
@@ -104,7 +113,7 @@ export class BlockList extends Component {
 					ListFooterComponent={ ! isReadOnly && withFooter && this.renderBlockListFooter }
 				/>
 
-				{ renderAppender && blockClientIds.length > 0 && (
+				{ this.showGroupAppender() && (
 					<View style={ styles.paddingToContent }>
 						<BlockListAppender
 							rootClientId={ this.props.rootClientId }
@@ -132,8 +141,6 @@ export class BlockList extends Component {
 			shouldShowBlockAtIndex,
 			shouldShowInsertionPointBefore,
 			shouldShowInsertionPointAfter,
-			renderAppender,
-			blockClientIds,
 		} = this.props;
 
 		return (
@@ -149,7 +156,7 @@ export class BlockList extends Component {
 							onCaretVerticalPositionChange={ this.onCaretVerticalPositionChange }
 							isSmallScreen={ ! this.props.isFullyBordered }
 						/> ) }
-					{ ! ( renderAppender && blockClientIds.length > 0 ) && shouldShowInsertionPointAfter( clientId ) && <BlockInsertionPoint /> }
+					{ ! this.showGroupAppender() && shouldShowInsertionPointAfter( clientId ) && <BlockInsertionPoint /> }
 				</View>
 			</ReadableContentView>
 		);


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
With [this PR](https://github.com/WordPress/gutenberg/pull/18564) we moved condition to render separator when adding Blocks into `AppenderButton`.

When working on Column Block feature I have noticed that when adding new Block into `Group` we see both component (`Separator` and `AppenderButton`). I suppose only `Separator` should be visible. We didn't noticed that before because `BotomSheet` covers the content. Please see GIFs posted below

Please also refer to:
[Related gutenberg-mobile PR]()

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

1. Start with blank `initial/html` file
2. Add Group block
3 Add any Block into Group
4. Press `AppenderButton` to add another Block (see that `Separator` and `AppenderButton` are visible)

After presented fix in point 4 you should see only the `Separator`.

## Screenshots <!-- if applicable -->
**Current behaviour**
<image src="https://user-images.githubusercontent.com/21242757/73166172-9d649000-40f5-11ea-96e6-b6b133189b45.gif" width="300" />

**Fixed version**
<image src="https://user-images.githubusercontent.com/21242757/73166197-aead9c80-40f5-11ea-9f29-663320dfb7d6.gif" width="300" />

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Bug-fix
## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
