### PR TITLE
Lighter InnerBlocks: allow blocks to render own wrappers

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -51,7 +51,7 @@ $z-layers: (
 
 	// Small screen inner blocks overlay must be displayed above drop zone,
 	// settings menu, and movers.
-	".block-editor-inner-blocks.has-overlay::after": 60,
+	".block-editor-block-list__layout.has-overlay::after": 60,
 
 	// The toolbar, when contextual, should be above any adjacent nested block click overlays.
 	".block-editor-block-contextual-toolbar": 61,

--- a/packages/block-editor/src/components/block-list/block-wrapper.js
+++ b/packages/block-editor/src/components/block-list/block-wrapper.js
@@ -48,6 +48,7 @@ const BlockComponent = forwardRef(
 			name,
 			mode,
 			blockTitle,
+			wrapperProps,
 		} = useContext( BlockContext );
 		const { initialPosition } = useSelect(
 			( select ) => {
@@ -203,6 +204,7 @@ const BlockComponent = forwardRef(
 				// Overrideable props.
 				aria-label={ blockLabel }
 				role="group"
+				{ ...wrapperProps }
 				{ ...props }
 				id={ blockElementId }
 				ref={ wrapper }

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -139,7 +139,7 @@ function BlockListBlock( {
 	// For aligned blocks, provide a wrapper element so the block can be
 	// positioned relative to the block column. This is enabled with the
 	// .is-block-content className.
-	if ( isAligned ) {
+	if ( ! lightBlockWrapper && isAligned ) {
 		blockEdit = <div className="is-block-content">{ blockEdit }</div>;
 	}
 
@@ -163,6 +163,7 @@ function BlockListBlock( {
 		name,
 		mode,
 		blockTitle: blockType.title,
+		wrapperProps,
 	};
 	const memoizedValue = useMemo( () => value, Object.values( value ) );
 

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -39,6 +39,7 @@ function BlockList( {
 	__experimentalUIParts = {},
 	tagName = 'div',
 	forwardedRef,
+	style,
 } ) {
 	function selector( select ) {
 		const {
@@ -90,6 +91,7 @@ function BlockList( {
 				className
 			) }
 			{ ...__experimentalContainerProps }
+			style={ style }
 		>
 			{ blockClientIds.map( ( clientId, index ) => {
 				const isBlockInSelection = hasMultiSelection

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -39,7 +39,7 @@ function BlockList( {
 	__experimentalUIParts = {},
 	tagName = 'div',
 	forwardedRef,
-	style,
+	...props
 } ) {
 	function selector( select ) {
 		const {
@@ -91,7 +91,7 @@ function BlockList( {
 				className
 			) }
 			{ ...__experimentalContainerProps }
-			style={ style }
+			{ ...props }
 		>
 			{ blockClientIds.map( ( clientId, index ) => {
 				const isBlockInSelection = hasMultiSelection

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -37,6 +37,8 @@ function BlockList( {
 	isDraggable,
 	renderAppender,
 	__experimentalUIParts = {},
+	tagName = 'div',
+	forwardedRef,
 } ) {
 	function selector( select ) {
 		const {
@@ -70,7 +72,7 @@ function BlockList( {
 		enableAnimation,
 	} = useSelect( selector, [ rootClientId ] );
 
-	const Container = rootClientId ? 'div' : RootContainer;
+	const Container = rootClientId ? tagName : RootContainer;
 	const ref = useRef();
 	const targetClientId = useBlockDropZone( {
 		element: ref,
@@ -82,7 +84,7 @@ function BlockList( {
 
 	return (
 		<Container
-			ref={ ref }
+			ref={ forwardedRef || ref }
 			className={ classnames(
 				'block-editor-block-list__layout',
 				className

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -30,8 +30,8 @@ function BlockList(
 		isDraggable,
 		renderAppender,
 		__experimentalUIParts = {},
-		tagName = 'div',
-		...props
+		__experimentalTagName = 'div',
+		__experimentalPassedProps = {},
 	},
 	ref
 ) {
@@ -67,7 +67,7 @@ function BlockList(
 		enableAnimation,
 	} = useSelect( selector, [ rootClientId ] );
 
-	const Container = rootClientId ? tagName : RootContainer;
+	const Container = rootClientId ? __experimentalTagName : RootContainer;
 	const targetClientId = useBlockDropZone( {
 		element: ref,
 		rootClientId,
@@ -84,7 +84,7 @@ function BlockList(
 				className
 			) }
 			{ ...__experimentalContainerProps }
-			{ ...props }
+			{ ...__experimentalPassedProps }
 		>
 			{ blockClientIds.map( ( clientId, index ) => {
 				const isBlockInSelection = hasMultiSelection

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -78,13 +78,14 @@ function BlockList(
 
 	return (
 		<Container
+			{ ...__experimentalPassedProps }
 			ref={ ref }
 			className={ classnames(
 				'block-editor-block-list__layout',
-				className
+				className,
+				__experimentalPassedProps.className
 			) }
 			{ ...__experimentalContainerProps }
-			{ ...__experimentalPassedProps }
 		>
 			{ blockClientIds.map( ( clientId, index ) => {
 				const isBlockInSelection = hasMultiSelection

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -226,14 +226,14 @@
 	}
 
 	// Reusable blocks clickthrough overlays.
-	&.is-reusable > .block-editor-inner-blocks.has-overlay {
+	&.is-reusable > .block-editor-inner-blocks > .block-editor-block-list__layout.has-overlay {
 		// Remove only the top click overlay.
 		&::after {
 			display: none;
 		}
 
 		// Restore it for subsequent.
-		.block-editor-inner-blocks.has-overlay::after {
+		.block-editor-block-list__layout.has-overlay::after {
 			display: block;
 		}
 	}

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -150,6 +150,7 @@ class InnerBlocks extends Component {
 			hasOverlay,
 			__experimentalCaptureToolbars: captureToolbars,
 			forwardedRef,
+			className,
 			...props
 		} = this.props;
 		const { templateInProcess } = this.state;
@@ -158,10 +159,16 @@ class InnerBlocks extends Component {
 			return null;
 		}
 
+		const classes = classnames( className, {
+			'has-overlay': enableClickThrough && hasOverlay,
+			'is-capturing-toolbar': captureToolbars,
+		} );
+
 		const blockList = (
 			<BlockList
 				ref={ forwardedRef }
 				rootClientId={ clientId }
+				className={ classes }
 				{ ...omit( props, [
 					'templateLock',
 					'isSmallScreen',
@@ -178,17 +185,13 @@ class InnerBlocks extends Component {
 				] ) }
 			/>
 		);
+
 		if ( props.tagName ) {
 			return blockList;
 		}
 
-		const classes = classnames( 'block-editor-inner-blocks', {
-			'has-overlay': enableClickThrough && hasOverlay,
-			'is-capturing-toolbar': captureToolbars,
-		} );
-
 		return (
-			<div className={ classes } ref={ forwardedRef }>
+			<div className="block-editor-inner-blocks" ref={ forwardedRef }>
 				{ blockList }
 			</div>
 		);

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -160,8 +160,8 @@ class InnerBlocks extends Component {
 
 		const blockList = (
 			<BlockList
+				ref={ forwardedRef }
 				rootClientId={ clientId }
-				forwardedRef={ forwardedRef }
 				{ ...omit( props, [
 					'templateLock',
 					'isSmallScreen',

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { pick, isEqual } from 'lodash';
+import { pick, isEqual, omit } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -162,7 +162,20 @@ class InnerBlocks extends Component {
 			<BlockList
 				rootClientId={ clientId }
 				forwardedRef={ forwardedRef }
-				{ ...props }
+				{ ...omit( props, [
+					'templateLock',
+					'isSmallScreen',
+					'block',
+					'blockListSettings',
+					'parentLock',
+					'isLastBlockChangePersistent',
+					'replaceInnerBlocks',
+					'__unstableMarkNextChangeAsNotPersistent',
+					'updateNestedSettings',
+					'__experimentalMoverDirection',
+					'allowedBlocks',
+					'template',
+				] ) }
 			/>
 		);
 		if ( props.tagName ) {

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { pick, isEqual, omit } from 'lodash';
+import { pick, isEqual } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -150,7 +150,6 @@ class InnerBlocks extends Component {
 			hasOverlay,
 			__experimentalCaptureToolbars: captureToolbars,
 			forwardedRef,
-			className,
 			...props
 		} = this.props;
 		const { templateInProcess } = this.state;
@@ -159,34 +158,21 @@ class InnerBlocks extends Component {
 			return null;
 		}
 
-		const classes = classnames( className, {
+		const classes = classnames( {
 			'has-overlay': enableClickThrough && hasOverlay,
 			'is-capturing-toolbar': captureToolbars,
 		} );
 
 		const blockList = (
 			<BlockList
+				{ ...props }
 				ref={ forwardedRef }
 				rootClientId={ clientId }
 				className={ classes }
-				{ ...omit( props, [
-					'templateLock',
-					'isSmallScreen',
-					'block',
-					'blockListSettings',
-					'parentLock',
-					'isLastBlockChangePersistent',
-					'replaceInnerBlocks',
-					'__unstableMarkNextChangeAsNotPersistent',
-					'updateNestedSettings',
-					'__experimentalMoverDirection',
-					'allowedBlocks',
-					'template',
-				] ) }
 			/>
 		);
 
-		if ( props.tagName ) {
+		if ( props.__experimentalTagName ) {
 			return blockList;
 		}
 

--- a/packages/block-editor/src/components/inner-blocks/style.scss
+++ b/packages/block-editor/src/components/inner-blocks/style.scss
@@ -1,6 +1,6 @@
 // Add clickable overlay to blocks with nesting.
 // This makes it easy to select all layers of the block.
-.block-editor-inner-blocks.has-overlay {
+.block-editor-block-list__layout.has-overlay {
 	&::after {
 		content: "";
 		position: absolute;
@@ -8,7 +8,7 @@
 		right: -$block-padding;
 		bottom: -$block-padding;
 		left: -$block-padding;
-		z-index: z-index(".block-editor-inner-blocks.has-overlay::after");
+		z-index: z-index(".block-editor-block-list__layout.has-overlay::after");
 	}
 }
 

--- a/packages/block-editor/src/utils/dom.js
+++ b/packages/block-editor/src/utils/dom.js
@@ -76,7 +76,10 @@ export function isInsideRootBlock( blockElement, element ) {
  * @return {boolean} Whether element contains inner blocks.
  */
 export function hasInnerBlocksContext( element ) {
-	return !! element.querySelector( '.block-editor-block-list__layout' );
+	return (
+		element.classList.contains( 'block-editor-block-list__layout' ) ||
+		!! element.querySelector( '.block-editor-block-list__layout' )
+	);
 }
 
 /**

--- a/packages/block-library/src/column/edit.js
+++ b/packages/block-library/src/column/edit.js
@@ -11,6 +11,7 @@ import {
 	BlockControls,
 	BlockVerticalAlignmentToolbar,
 	InspectorControls,
+	__experimentalBlock as Block,
 } from '@wordpress/block-editor';
 import { PanelBody, RangeControl } from '@wordpress/components';
 import { withDispatch, withSelect } from '@wordpress/data';
@@ -31,7 +32,7 @@ function ColumnEdit( {
 	} );
 
 	return (
-		<div className={ classes }>
+		<>
 			<BlockControls>
 				<BlockVerticalAlignmentToolbar
 					onChange={ updateAlignment }
@@ -61,11 +62,13 @@ function ColumnEdit( {
 				templateLock={ false }
 				renderAppender={
 					hasChildBlocks
-						? undefined
+						? false
 						: () => <InnerBlocks.ButtonBlockAppender />
 				}
+				tagName={ Block.div }
+				className={ classes }
 			/>
-		</div>
+		</>
 	);
 }
 

--- a/packages/block-library/src/column/edit.js
+++ b/packages/block-library/src/column/edit.js
@@ -31,6 +31,8 @@ function ColumnEdit( {
 		[ `is-vertically-aligned-${ verticalAlignment }` ]: verticalAlignment,
 	} );
 
+	const hasWidth = Number.isFinite( width );
+
 	return (
 		<>
 			<BlockControls>
@@ -67,6 +69,8 @@ function ColumnEdit( {
 				}
 				tagName={ Block.div }
 				className={ classes }
+				style={ hasWidth ? { flexBasis: width + '%' } : undefined }
+				data-has-explicit-width={ hasWidth }
 			/>
 		</>
 	);

--- a/packages/block-library/src/column/edit.js
+++ b/packages/block-library/src/column/edit.js
@@ -70,7 +70,6 @@ function ColumnEdit( {
 				tagName={ Block.div }
 				className={ classes }
 				style={ hasWidth ? { flexBasis: width + '%' } : undefined }
-				data-has-explicit-width={ hasWidth }
 			/>
 		</>
 	);

--- a/packages/block-library/src/column/edit.js
+++ b/packages/block-library/src/column/edit.js
@@ -67,9 +67,11 @@ function ColumnEdit( {
 						? false
 						: () => <InnerBlocks.ButtonBlockAppender />
 				}
-				tagName={ Block.div }
-				className={ classes }
-				style={ hasWidth ? { flexBasis: width + '%' } : undefined }
+				__experimentalTagName={ Block.div }
+				__experimentalPassedProps={ {
+					className: classes,
+					style: hasWidth ? { flexBasis: width + '%' } : undefined,
+				} }
 			/>
 		</>
 	);

--- a/packages/block-library/src/column/index.js
+++ b/packages/block-library/src/column/index.js
@@ -24,6 +24,7 @@ export const settings = {
 		inserter: false,
 		reusable: false,
 		html: false,
+		lightBlockWrapper: true,
 	},
 	getEditWrapperProps( attributes ) {
 		const { width } = attributes;

--- a/packages/block-library/src/column/index.js
+++ b/packages/block-library/src/column/index.js
@@ -26,17 +26,6 @@ export const settings = {
 		html: false,
 		lightBlockWrapper: true,
 	},
-	getEditWrapperProps( attributes ) {
-		const { width } = attributes;
-		if ( Number.isFinite( width ) ) {
-			return {
-				style: {
-					flexBasis: width + '%',
-				},
-				'data-has-explicit-width': true,
-			};
-		}
-	},
 	edit,
 	save,
 };

--- a/packages/block-library/src/columns/edit.js
+++ b/packages/block-library/src/columns/edit.js
@@ -18,6 +18,7 @@ import {
 	BlockVerticalAlignmentToolbar,
 	__experimentalBlockVariationPicker,
 	__experimentalUseColors,
+	__experimentalBlock as Block,
 } from '@wordpress/block-editor';
 import { withDispatch, useDispatch, useSelect } from '@wordpress/data';
 import { createBlock } from '@wordpress/blocks';
@@ -103,12 +104,13 @@ function ColumnsEditContainer( {
 			{ InspectorControlsColorPanel }
 			<BackgroundColor>
 				<TextColor>
-					<div className={ classes } ref={ ref }>
-						<InnerBlocks
-							allowedBlocks={ ALLOWED_BLOCKS }
-							__experimentalMoverDirection="horizontal"
-						/>
-					</div>
+					<InnerBlocks
+						allowedBlocks={ ALLOWED_BLOCKS }
+						__experimentalMoverDirection="horizontal"
+						tagName={ Block.div }
+						className={ classes }
+						ref={ ref }
+					/>
 				</TextColor>
 			</BackgroundColor>
 		</>
@@ -255,25 +257,27 @@ const ColumnsEdit = ( props ) => {
 	}
 
 	return (
-		<__experimentalBlockVariationPicker
-			icon={ get( blockType, [ 'icon', 'src' ] ) }
-			label={ get( blockType, [ 'title' ] ) }
-			variations={ variations }
-			onSelect={ ( nextVariation = defaultVariation ) => {
-				if ( nextVariation.attributes ) {
-					props.setAttributes( nextVariation.attributes );
-				}
-				if ( nextVariation.innerBlocks ) {
-					replaceInnerBlocks(
-						props.clientId,
-						createBlocksFromInnerBlocksTemplate(
-							nextVariation.innerBlocks
-						)
-					);
-				}
-			} }
-			allowSkip
-		/>
+		<Block.div>
+			<__experimentalBlockVariationPicker
+				icon={ get( blockType, [ 'icon', 'src' ] ) }
+				label={ get( blockType, [ 'title' ] ) }
+				variations={ variations }
+				onSelect={ ( nextVariation = defaultVariation ) => {
+					if ( nextVariation.attributes ) {
+						props.setAttributes( nextVariation.attributes );
+					}
+					if ( nextVariation.innerBlocks ) {
+						replaceInnerBlocks(
+							props.clientId,
+							createBlocksFromInnerBlocksTemplate(
+								nextVariation.innerBlocks
+							)
+						);
+					}
+				} }
+				allowSkip
+			/>
+		</Block.div>
 	);
 };
 

--- a/packages/block-library/src/columns/edit.js
+++ b/packages/block-library/src/columns/edit.js
@@ -107,9 +107,11 @@ function ColumnsEditContainer( {
 					<InnerBlocks
 						allowedBlocks={ ALLOWED_BLOCKS }
 						__experimentalMoverDirection="horizontal"
-						tagName={ Block.div }
-						className={ classes }
 						ref={ ref }
+						__experimentalTagName={ Block.div }
+						__experimentalPassedProps={ {
+							className: classes,
+						} }
 					/>
 				</TextColor>
 			</BackgroundColor>

--- a/packages/block-library/src/columns/editor.scss
+++ b/packages/block-library/src/columns/editor.scss
@@ -4,11 +4,6 @@
 	max-width: none;
 }
 
-// It needs to be investigated which of these removed styles remain applicable
-// in the editor, but the removal of all the wrapper containers should
-// significantly reduce the amount of corrections needed. The front-end styles
-// should ideally be enough.
-
 // Ideally this shouldn't be necessary. There should be no default margins in
 // the editor.
 .editor-styles-wrapper .block-editor-block-list__block.wp-block-column,

--- a/packages/block-library/src/columns/editor.scss
+++ b/packages/block-library/src/columns/editor.scss
@@ -1,3 +1,9 @@
+// This max-width is used to constrain the main editor column, it should not
+// cascade into columns.
+.wp-block-columns .wp-block {
+	max-width: none;
+}
+
 // It needs to be investigated which of these removed styles remain applicable
 // in the editor, but the removal of all the wrapper containers should
 // significantly reduce the amount of corrections needed. The front-end styles

--- a/packages/block-library/src/columns/editor.scss
+++ b/packages/block-library/src/columns/editor.scss
@@ -1,177 +1,22 @@
-// These margins make sure that nested blocks stack/overlay with the parent block chrome
-// This is sort of an experiment at making sure the editor looks as much like the end result as possible
-// Potentially the rules here can apply to all nested blocks and enable stacking, in which case it should be moved elsewhere
-// When using CSS grid, margins do not collapse on the container.
-.wp-block-columns .block-editor-block-list__layout {
-	// This max-width is used to constrain the main editor column, it should not cascade into columns
-	.block-editor-block-list__block {
-		max-width: none;
-	}
+// It needs to be investigated which of these removed styles remain applicable
+// in the editor, but the removal of all the wrapper containers should
+// significantly reduce the amount of corrections needed. The front-end styles
+// should ideally be enough.
+
+// Ideally this shouldn't be necessary. There should be no default margins in
+// the editor.
+.editor-styles-wrapper .block-editor-block-list__block.wp-block-column,
+.editor-styles-wrapper .block-editor-block-list__block.wp-block-columns {
+	margin-top: 0;
+	margin-bottom: 0;
 }
 
-.wp-block-columns {
-	display: block;
-
-	> .block-editor-inner-blocks > .block-editor-block-list__layout {
-		display: flex;
-
-		// Responsiveness: Allow wrapping on mobile.
-		flex-wrap: wrap;
-
-		@include break-medium() {
-			flex-wrap: nowrap;
-		}
-		// Set full heights on Columns to enable vertical alignment preview
-		> [data-type="core/column"],
-		> [data-type="core/column"] .block-core-columns {
-			display: flex;
-			flex-direction: column;
-
-			// This flex rule fixes an issue in IE11.
-			flex: 1 1 auto;
-
-			// IE11 does not support `position: sticky`, so we use it here to serve correct Flex rules to modern browsers.
-			@supports (position: sticky) {
-				flex: 1;
-			}
-		}
-
-		// Adjust the individual column block.
-		> [data-type="core/column"] {
-
-			// On mobile, only a single column is shown, so match adjacent block paddings.
-			padding-left: 0;
-			padding-right: 0;
-			margin-left: -$block-padding;
-			margin-right: -$block-padding;
-
-			// Zero out margins.
-			margin-top: 0;
-			margin-bottom: 0;
-
-			// Prevent the columns from growing wider than their distributed sizes.
-			min-width: 0;
-
-			// Prevent long unbroken words from overflowing.
-			word-break: break-word; // For back-compat.
-			overflow-wrap: break-word; // New standard.
-
-			// Responsiveness: Show at most one columns on mobile.
-			flex-basis: 100%;
-
-			// Between mobile and large viewports, allow 2 columns.
-			@include break-small() {
-				flex-basis: calc(50% - (#{$grid-unit-20}));
-				flex-grow: 0;
-				margin-left: 0;
-				margin-right: 0;
-			}
-
-			// At large viewports, show all columns horizontally.
-			@include break-medium() {
-				// Available space should be divided equally amongst columns
-				// without an assigned width. This is achieved by assigning a
-				// flex basis that is consistent (equal), would not cause the
-				// sum total of column widths to exceed 100%, and which would
-				// cede to a column with an assigned width. The `flex-grow`
-				// allows columns to maximally and equally occupy space
-				// remaining after subtracting the space occupied by columns
-				// with explicit widths (if any exist).
-				flex-basis: 0;
-				flex-grow: 1;
-
-				// Columns with an explicitly-assigned width should maintain
-				// their `flex-basis` width and not grow.
-				&[data-has-explicit-width] {
-					flex-grow: 0;
-				}
-			}
-
-			// Add space between columns. Themes can customize this if they wish to work differently.
-			// This has to match the same padding applied in style.scss.
-			// Only apply this beyond the mobile breakpoint, as there's only a single column on mobile.
-			@include break-small() {
-				&:nth-child(even) {
-					margin-left: calc(#{$grid-unit-20 * 2});
-				}
-			}
-
-			// When columns are in a single row, add space before all except the first.
-			@include break-medium() {
-				&:not(:first-child) {
-					margin-left: calc(#{$grid-unit-20 * 2});
-				}
-			}
-
-			// Remove Block "padding" so individual Column is flush with parent Columns
-			&::before {
-				left: 0;
-				right: 0;
-			}
-
-			// The Columns block is a flex-container, therefore it nullifies margin collapsing.
-			// Therefore, blocks inside this will appear to create a double margin.
-			// We compensate for this using negative margins.
-			> .block-core-columns > .block-editor-inner-blocks {
-				margin-top: -$default-block-margin;
-				margin-bottom: -$default-block-margin;
-			}
-		}
-	}
+// This is the style used on the front-end, which ideally should be loaded in
+// the editor too.
+.wp-block-column > *:first-child {
+	margin-top: 0 !important;
 }
 
-/**
- * Columns act as as a "passthrough container"
- * and therefore has its vertical margins/padding removed via negative margins
- * therefore we need to compensate for this here by doubling the spacing on the
- * vertical to ensure there is equal visual spacing around the inserter. Note there
- * is no formal API for a "passthrough" Block so this is an edge case overide
- */
-[data-type="core/columns"] {
-
-	.block-list-appender {
-		margin-top: $block-padding*2;
-		margin-bottom: $block-padding*2;
-	}
-}
-
-/**
- * Vertical Alignment Preview
- * note: specificity is important here to ensure individual
- * * columns alignment is prioritised over parent column alignment
- *
- */
-.are-vertically-aligned-top .block-core-columns,
-div.block-core-columns.is-vertically-aligned-top {
-	justify-content: flex-start;
-}
-
-.are-vertically-aligned-center .block-core-columns,
-div.block-core-columns.is-vertically-aligned-center {
-	justify-content: center;
-}
-
-.are-vertically-aligned-bottom .block-core-columns,
-div.block-core-columns.is-vertically-aligned-bottom {
-	justify-content: flex-end;
-}
-
-/**
- * Make single Column overlay not extend past boundaries of parent
- */
-.block-core-columns > .block-editor-inner-blocks.has-overlay::after {
-	left: 0;
-	right: 0;
-}
-
-// Fullwide: show margin left/right to ensure there's room for the side UI.
-// This is not a 1:1 preview with the front-end where these margins would presumably be zero.
-[data-type="core/columns"][data-align="full"] .wp-block-columns {
-	padding-left: $block-padding;
-	padding-right: $block-padding;
-
-	@include break-small() {
-		padding-left: $block-container-side-padding;
-		padding-right: $block-container-side-padding;
-	}
+.wp-block-column > *:last-child {
+	margin-bottom: 0 !important;
 }

--- a/packages/block-library/src/columns/editor.scss
+++ b/packages/block-library/src/columns/editor.scss
@@ -12,6 +12,21 @@
 	margin-bottom: 0;
 }
 
+// To do: remove horizontal margin override by the editor.
+@include break-small() {
+	.editor-styles-wrapper
+	.block-editor-block-list__block.wp-block-column:nth-child(even) {
+		margin-left: $grid-unit-20 * 2;
+	}
+}
+
+@include break-medium() {
+	.editor-styles-wrapper
+	.block-editor-block-list__block.wp-block-column:not(:first-child) {
+		margin-left: $grid-unit-20 * 2;
+	}
+}
+
 // This is the style used on the front-end, which ideally should be loaded in
 // the editor too.
 .wp-block-column > *:first-child {

--- a/packages/block-library/src/columns/index.js
+++ b/packages/block-library/src/columns/index.js
@@ -26,6 +26,7 @@ export const settings = {
 	supports: {
 		align: [ 'wide', 'full' ],
 		html: false,
+		lightBlockWrapper: true,
 	},
 	variations,
 	example: {

--- a/packages/block-library/src/columns/style.scss
+++ b/packages/block-library/src/columns/style.scss
@@ -56,7 +56,7 @@
 
 		// Columns with an explicitly-assigned width should maintain their
 		// `flex-basis` width and not grow.
-		&[style] {
+		&[style*="flex-basis"] {
 			flex-grow: 0;
 		}
 


### PR DESCRIPTION
## Description

closes #7770

Removes 6 wrapper `div` elements from the columns and column together.

I created this PR before the merge of #19701 to illustrate with the columns block how it all comes together. This PR really shows the power that blocks will have when they can entirely render themselves.

With this PR, the DOM tree of the columns block is exactly the same as the DOM tree on the front end. This removes the need add any styling for the editor. There's still a few things that ideally should be adjusted (we shouldn't be adding a margin to blocks by default because some blocks need to reset this). But you get the idea and the direction.

I believe this direction will be really important for full site editing themes and performance as well (which is built on `InnerBlocks`).

It will also allow us to build complex block with inner blocks that need a semantic relationship with the ancestors. Think about a list, table, or definition list built entirely with `InnerBlocks`.

Please note that I haven't polished the styling of the columns block yet.

Before:

<img width="801" alt="Screenshot 2020-01-27 at 13 49 01" src="https://user-images.githubusercontent.com/4710635/73172746-03f0aa80-4104-11ea-99b1-2186f90a05da.png">

After:

<img width="784" alt="Screenshot 2020-01-27 at 13 45 24" src="https://user-images.githubusercontent.com/4710635/73172768-0fdc6c80-4104-11ea-9501-0a9bf2a7e3e0.png">

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
