### PR TITLE
Block styles: only add auto margin to root blocks

### DIFF
--- a/packages/block-editor/src/components/block-list/root-container.js
+++ b/packages/block-editor/src/components/block-list/root-container.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { createContext, forwardRef, useState } from '@wordpress/element';
@@ -73,6 +78,8 @@ function RootContainer( { children, className, hasPopover = true }, ref ) {
 			selectBlock( clientId );
 		}
 	}
+
+	className = classnames( className, 'block-editor-block-list__layout-root' );
 
 	return (
 		<InsertionPoint

--- a/packages/block-library/src/columns/editor.scss
+++ b/packages/block-library/src/columns/editor.scss
@@ -12,21 +12,6 @@
 	margin-bottom: 0;
 }
 
-// To do: remove horizontal margin override by the editor.
-@include break-small() {
-	.editor-styles-wrapper
-	.block-editor-block-list__block.wp-block-column:nth-child(even) {
-		margin-left: $grid-unit-20 * 2;
-	}
-}
-
-@include break-medium() {
-	.editor-styles-wrapper
-	.block-editor-block-list__block.wp-block-column:not(:first-child) {
-		margin-left: $grid-unit-20 * 2;
-	}
-}
-
 // This is the style used on the front-end, which ideally should be loaded in
 // the editor too.
 .wp-block-column > *:first-child {

--- a/packages/block-library/src/cover/editor.scss
+++ b/packages/block-library/src/cover/editor.scss
@@ -19,11 +19,6 @@
 		text-align: left;
 	}
 
-	.wp-block-cover__inner-container > .block-editor-inner-blocks > .block-editor-block-list__layout {
-		margin-left: 0;
-		margin-right: 0;
-	}
-
 	.wp-block-cover__placeholder-background-options {
 		width: 100%;
 	}

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -10,12 +10,6 @@ $navigation-item-height: 46px;
 		flex: 1; // expand to fill available space required for justification
 	}
 
-	// 1. Reset margins on immediate innerblocks container.
-	.wp-block-navigation .block-editor-inner-blocks > .block-editor-block-list__layout {
-		margin-left: 0;
-		margin-right: 0;
-	}
-
 	.wp-block-navigation.items-justification-left .block-editor-inner-blocks > .block-editor-block-list__layout {
 		justify-content: flex-start;
 	}

--- a/packages/block-library/src/social-links/editor.scss
+++ b/packages/block-library/src/social-links/editor.scss
@@ -15,24 +15,16 @@
 // @todo: eventually we may add a feature that lets a parent container absorb the block UI of a child block.
 // When that happens, leverage that instead of the following overrides.
 [data-type="core/social-links"] {
-	// 1. Reset margins on immediate innerblocks container.
-	.wp-block-social-links > .block-editor-inner-blocks > .block-editor-block-list__layout {
-		margin-left: 0;
-		margin-right: 0;
-	}
-
-	// 2. Remove paddings on subsequent immediate children.
+	// 1. Remove paddings on subsequent immediate children.
 	.wp-block-social-links > .block-editor-inner-blocks > .block-editor-block-list__layout > .wp-block {
 		width: auto;
 		padding-left: 0;
 		padding-right: 0;
-		margin-left: 0;
-		margin-right: 0;
 		margin-top: 0;
 		margin-bottom: 0;
 	}
 
-	// 3. Minimize the block outlines.
+	// 2. Minimize the block outlines.
 	.wp-block-social-links > .block-editor-inner-blocks > .block-editor-block-list__layout > .wp-block::before {
 		border-right: none;
 		border-top: none;

--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -37,7 +37,7 @@
 }
 
 // The base width of blocks
-.edit-post-visual-editor .block-editor-block-list__block {
+.edit-post-visual-editor .block-editor-block-list__layout-root > .block-editor-block-list__block {
 	margin-left: auto;
 	margin-right: auto;
 }


### PR DESCRIPTION
## Description

Currently block margins on the left and right is set to `auto` for _every_ block including nested blocks. This seems unintended to me. I think it should only be applied to blocks at the root level, so they are centred within the editor canvas. It shouldn't be added for nested blocks.

## How has this been tested?

Test nested blocks.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
