### PR TITLE
Navigation Block: Move the Link Settings panel

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -105,18 +105,6 @@ function NavigationLinkEdit( {
 			</BlockControls>
 			<InspectorControls>
 				<PanelBody
-					title={ __( 'Link settings' ) }
-				>
-					<TextareaControl
-						value={ description || '' }
-						onChange={ ( descriptionValue ) => {
-							setAttributes( { description: descriptionValue } );
-						} }
-						label={ __( 'Description' ) }
-						help={ __( 'The description will be displayed in the menu if the current theme supports it.' ) }
-					/>
-				</PanelBody>
-				<PanelBody
 					title={ __( 'SEO settings' ) }
 				>
 					<TextControl
@@ -144,6 +132,18 @@ function NavigationLinkEdit( {
 								</ExternalLink>
 							</Fragment>
 						) }
+					/>
+				</PanelBody>
+				<PanelBody
+					title={ __( 'Link settings' ) }
+				>
+					<TextareaControl
+						value={ description || '' }
+						onChange={ ( descriptionValue ) => {
+							setAttributes( { description: descriptionValue } );
+						} }
+						label={ __( 'Description' ) }
+						help={ __( 'The description will be displayed in the menu if the current theme supports it.' ) }
 					/>
 				</PanelBody>
 			</InspectorControls>


### PR DESCRIPTION
## Description
Move the "Link Settings" panel in the sidebar below the "SEO" panel because link settings is subject to theme support and I believe will be significantly less used than the SEO panel.

**Before:**

<img width="961" alt="before" src="https://user-images.githubusercontent.com/1464705/73203236-8328b300-40f1-11ea-9fcb-b3e77d78ea0e.png">

**After:**

<img width="958" alt="after" src="https://user-images.githubusercontent.com/1464705/73203245-891e9400-40f1-11ea-808b-6363a511517f.png">

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
