### PR TITLE
Ability to disable block popover through __experimentalUIParts.hasPopover option.

### DIFF
--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -37,7 +37,7 @@ function BlockList( {
 	rootClientId,
 	isDraggable,
 	renderAppender,
-	__experimentalUIParts = { hasPopover: true },
+	__experimentalUIParts = { },
 } ) {
 	function selector( select ) {
 		const {
@@ -86,7 +86,7 @@ function BlockList( {
 				'block-editor-block-list__layout',
 				className
 			) }
-			__experimentalUIParts={ __experimentalUIParts }
+			hasPopover={ __experimentalUIParts.hasPopover }
 		>
 			{ blockClientIds.map( ( clientId, index ) => {
 				const isBlockInSelection = hasMultiSelection ?

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -37,7 +37,7 @@ function BlockList( {
 	rootClientId,
 	isDraggable,
 	renderAppender,
-	__experimentalUIParts = {},
+	__experimentalUIParts = { hasPopover: true },
 } ) {
 	function selector( select ) {
 		const {
@@ -86,6 +86,7 @@ function BlockList( {
 				'block-editor-block-list__layout',
 				className
 			) }
+			__experimentalUIParts={ __experimentalUIParts }
 		>
 			{ blockClientIds.map( ( clientId, index ) => {
 				const isBlockInSelection = hasMultiSelection ?

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -37,7 +37,7 @@ function BlockList( {
 	rootClientId,
 	isDraggable,
 	renderAppender,
-	__experimentalUIParts = { },
+	__experimentalUIParts = {},
 } ) {
 	function selector( select ) {
 		const {

--- a/packages/block-editor/src/components/block-list/root-container.js
+++ b/packages/block-editor/src/components/block-list/root-container.js
@@ -46,7 +46,7 @@ function onDragStart( event ) {
 	}
 }
 
-function RootContainer( { children, className }, ref ) {
+function RootContainer( { children, className, __experimentalUIParts = { hasPopover: true } }, ref ) {
 	const {
 		selectedBlockClientId,
 		hasMultiSelection,
@@ -82,7 +82,7 @@ function RootContainer( { children, className }, ref ) {
 			containerRef={ ref }
 		>
 			<BlockNodes.Provider value={ useState( {} ) }>
-				<BlockPopover />
+				{ __experimentalUIParts.hasPopover ? <BlockPopover /> : null }
 				<div
 					ref={ ref }
 					className={ className }

--- a/packages/block-editor/src/components/block-list/root-container.js
+++ b/packages/block-editor/src/components/block-list/root-container.js
@@ -46,7 +46,7 @@ function onDragStart( event ) {
 	}
 }
 
-function RootContainer( { children, className, __experimentalUIParts = { hasPopover: true } }, ref ) {
+function RootContainer( { children, className, hasPopover = true }, ref ) {
 	const {
 		selectedBlockClientId,
 		hasMultiSelection,
@@ -82,7 +82,7 @@ function RootContainer( { children, className, __experimentalUIParts = { hasPopo
 			containerRef={ ref }
 		>
 			<BlockNodes.Provider value={ useState( {} ) }>
-				{ __experimentalUIParts.hasPopover ? <BlockPopover /> : null }
+				{ hasPopover ? <BlockPopover /> : null }
 				<div
 					ref={ ref }
 					className={ className }

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -21,6 +21,7 @@ export default function BlockToolbar() {
 		mode,
 		moverDirection,
 		hasMovers = true,
+		hasToolbar = true,
 	} = useSelect( ( select ) => {
 		const {
 			getBlockMode,
@@ -48,8 +49,13 @@ export default function BlockToolbar() {
 				null,
 			moverDirection: __experimentalMoverDirection,
 			hasMovers: __experimentalUIParts.hasMovers,
+			hasToolbar: __experimentalUIParts.hasToolbar,
 		};
 	}, [] );
+
+	if ( ! hasToolbar ) {
+		return null;
+	}
 
 	if ( blockClientIds.length === 0 ) {
 		return null;

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -21,7 +21,6 @@ export default function BlockToolbar() {
 		mode,
 		moverDirection,
 		hasMovers = true,
-		hasToolbar = true,
 	} = useSelect( ( select ) => {
 		const {
 			getBlockMode,
@@ -49,13 +48,8 @@ export default function BlockToolbar() {
 				null,
 			moverDirection: __experimentalMoverDirection,
 			hasMovers: __experimentalUIParts.hasMovers,
-			hasToolbar: __experimentalUIParts.hasToolbar,
 		};
 	}, [] );
-
-	if ( ! hasToolbar ) {
-		return null;
-	}
 
 	if ( blockClientIds.length === 0 ) {
 		return null;


### PR DESCRIPTION
## Description
This PR adds ability to disable block popover through the `__experimentalUIParts.hasPopover` option. 

## Why do we need this?
We are using blocks without the need for the block popover, block toolbar and everything around it. The implementation as seen in https://github.com/WordPress/gutenberg/pull/18173 only hides them using CSS. While they are not visible visually, the components are still rendered, this causes accessibility issues. When user tabs through the interface, the buttons from the block toolbar is still being focused, even though it is not visible on the screen.

## Example Usage:
```jsx
<BlockList
	__experimentalUIParts={ {
		hasPopover: false,
	} }
/>
```

## Test Instructions
We will use storybook to test if the block popover component isn't rendered when the `hasPopover` attribute is set to `false`. Here are the steps:

1. Inside the file `storybook/stories/playground/index.js`, modify the element `<BlockList />` at line 49 to:  
    ```jsx
    <BlockList __experimentalUIParts={ { hasPopover: false } } />
    ```
2. Run `npm run storybook:dev`.
3. Go to **Playground > Block Editor > Default**.
4. Click on the first block (and type something if you like) in the editor.
5. There should be no block popover displayed.

## Screenshot

**Without `hasPopover: false`**

![image](https://user-images.githubusercontent.com/1287077/73760945-6550f300-476e-11ea-96df-9e229910f6e3.png)

**With `hasPopover: false`**

![image](https://user-images.githubusercontent.com/1287077/73760923-59fdc780-476e-11ea-8011-ba252ddbd7bc.png)

