### PR TITLE
[RNMobile] Revert change to fix Action Sheet

### DIFF
--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -397,7 +397,7 @@ export class ImageEdit extends React.Component {
 
 		const imageContainerHeight = Dimensions.get( 'window' ).width / IMAGE_ASPECT_RATIO;
 
-		const editImageComponent = ( { openMediaOptions, mediaOptions } ) => (
+		const editImageComponent = ( openMediaOptions, mediaOptions ) => (
 			<TouchableWithoutFeedback
 				onPress={ openMediaOptions }>
 				<View style={ styles.edit }>
@@ -476,7 +476,9 @@ export class ImageEdit extends React.Component {
 												onSelect={ this.onSelectMediaUploadOption }
 												source={ { uri: url } }
 												openReplaceMediaOptions={ openMediaOptions }
-												render={ editImageComponent }
+												render={ ( { open, mediaOptions } ) => {
+													return editImageComponent( open, mediaOptions );
+												} }
 											/>
 										}
 									</ImageBackground>

--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -397,9 +397,9 @@ export class ImageEdit extends React.Component {
 
 		const imageContainerHeight = Dimensions.get( 'window' ).width / IMAGE_ASPECT_RATIO;
 
-		const editImageComponent = ( openMediaOptions, mediaOptions ) => (
+		const editImageComponent = ( { open, mediaOptions } ) => (
 			<TouchableWithoutFeedback
-				onPress={ openMediaOptions }>
+				onPress={ open }>
 				<View style={ styles.edit }>
 					{ mediaOptions() }
 					<Icon icon={ SvgIconCustomize } { ...styles.iconCustomise } />
@@ -476,9 +476,7 @@ export class ImageEdit extends React.Component {
 												onSelect={ this.onSelectMediaUploadOption }
 												source={ { uri: url } }
 												openReplaceMediaOptions={ openMediaOptions }
-												render={ ( { open, mediaOptions } ) => {
-													return editImageComponent( open, mediaOptions );
-												} }
+												render={ editImageComponent }
 											/>
 										}
 									</ImageBackground>


### PR DESCRIPTION
This reverts commit e1133106d76ca04b9710b5f6d4a3aaf59c2a1a73 in order to fix the Action Sheet.

## Description
The Action Sheet was not being displayed anymore, this PR fixes it.

## How has this been tested?
Tap the icon that appears over the Image and check if it shows an Action Sheet in iOS.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
