### PR TITLE
Block Library: Stop gallery images from creating undo levels as they load.

### DIFF
--- a/packages/block-library/src/gallery/gallery-image.js
+++ b/packages/block-library/src/gallery/gallery-image.js
@@ -10,9 +10,10 @@ import { Component } from '@wordpress/element';
 import { Button, Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { BACKSPACE, DELETE } from '@wordpress/keycodes';
-import { withSelect } from '@wordpress/data';
+import { withSelect, withDispatch } from '@wordpress/data';
 import { RichText } from '@wordpress/block-editor';
 import { isBlobURL } from '@wordpress/blob';
+import { compose } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -74,8 +75,9 @@ class GalleryImage extends Component {
 	}
 
 	componentDidUpdate( prevProps ) {
-		const { isSelected, image, url } = this.props;
+		const { isSelected, image, url, __unstableMarkNextChangeAsNotPersistent } = this.props;
 		if ( image && ! url ) {
+			__unstableMarkNextChangeAsNotPersistent();
 			this.props.setAttributes( {
 				url: image.source_url,
 				alt: image.alt_text,
@@ -200,11 +202,21 @@ class GalleryImage extends Component {
 	}
 }
 
-export default withSelect( ( select, ownProps ) => {
-	const { getMedia } = select( 'core' );
-	const { id } = ownProps;
+export default compose( [
+	withSelect( ( select, ownProps ) => {
+		const { getMedia } = select( 'core' );
+		const { id } = ownProps;
 
-	return {
-		image: id ? getMedia( id ) : null,
-	};
-} )( GalleryImage );
+		return {
+			image: id ? getMedia( id ) : null,
+		};
+	} ),
+	withDispatch( ( dispatch ) => {
+		const { __unstableMarkNextChangeAsNotPersistent } = dispatch(
+			'core/block-editor'
+		);
+		return {
+			__unstableMarkNextChangeAsNotPersistent,
+		};
+	} ),
+] )( GalleryImage );

--- a/packages/block-library/src/gallery/gallery-image.js
+++ b/packages/block-library/src/gallery/gallery-image.js
@@ -75,7 +75,12 @@ class GalleryImage extends Component {
 	}
 
 	componentDidUpdate( prevProps ) {
-		const { isSelected, image, url, __unstableMarkNextChangeAsNotPersistent } = this.props;
+		const {
+			isSelected,
+			image,
+			url,
+			__unstableMarkNextChangeAsNotPersistent,
+		} = this.props;
 		if ( image && ! url ) {
 			__unstableMarkNextChangeAsNotPersistent();
 			this.props.setAttributes( {

--- a/packages/e2e-tests/specs/editor/blocks/classic.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/classic.test.js
@@ -14,6 +14,8 @@ import {
 	createNewPost,
 	insertBlock,
 	pressKeyWithModifier,
+	clickBlockToolbarButton,
+	clickButton,
 } from '@wordpress/e2e-test-utils';
 
 describe( 'Classic', () => {
@@ -34,7 +36,7 @@ describe( 'Classic', () => {
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 
-	it( 'should insert media', async () => {
+	it( 'should insert media, convert to blocks, and undo in one step', async () => {
 		await insertBlock( 'Classic' );
 		// Wait for TinyMCE to initialise.
 		await page.waitForSelector( '.mce-content-body' );
@@ -45,6 +47,7 @@ describe( 'Classic', () => {
 		// Click the image button.
 		await page.waitForSelector( 'div[aria-label^="Add Media"]' );
 		await page.click( 'div[aria-label^="Add Media"]' );
+		await page.click( '.media-menu-item#menu-item-gallery' );
 
 		// Wait for media modal to appear and upload image.
 		await page.waitForSelector( '.media-modal input[type=file]' );
@@ -68,17 +71,34 @@ describe( 'Classic', () => {
 		);
 
 		// Insert the uploaded image.
+		await page.click( '.media-modal button.media-button-gallery' );
 		await page.click( '.media-modal button.media-button-insert' );
 
 		// Wait for image to be inserted.
 		await page.waitForSelector( '.mce-content-body img' );
 
-		// Move focus away.
+		// Move focus away and verify gallery was inserted.
 		await pressKeyWithModifier( 'shift', 'Tab' );
-
-		const regExp = new RegExp(
-			`test<img class="alignnone size-full wp-image-\\d+" src="[^"]+\\/${ filename }\\.png" alt="" width="10" height="10" \\/>`
+		expect( await getEditedPostContent() ).toMatch(
+			/\[gallery ids=\"\d+\"\]/
 		);
-		expect( await getEditedPostContent() ).toMatch( regExp );
+
+		// Convert to blocks and verify it worked correctly.
+		await clickBlockToolbarButton( 'More options' );
+		await clickButton( 'Convert to Blocks' );
+		await page.waitForSelector( '.wp-block[data-type="core/gallery"]' );
+		expect( await getEditedPostContent() ).toMatch( /<!-- wp:gallery/ );
+
+		// Check that you can undo back to a Classic block gallery in one step.
+		await pressKeyWithModifier( 'primary', 'z' );
+		expect( await getEditedPostContent() ).toMatch(
+			/\[gallery ids=\"\d+\"\]/
+		);
+
+		// Convert to blocks again and verify it worked correctly.
+		await clickBlockToolbarButton( 'More options' );
+		await clickButton( 'Convert to Blocks' );
+		await page.waitForSelector( '.wp-block[data-type="core/gallery"]' );
+		expect( await getEditedPostContent() ).toMatch( /<!-- wp:gallery/ );
 	} );
 } );


### PR DESCRIPTION
Fixes #19923

## Description

Gallery images in the Gallery block trigger a change of undo-level creating edits as they load image URLs from data provided through attributes. This was causing issues when converting to the Gallery block and trying to undo. An undo would send you back to the block's immediately previous loading state in which it would proceed to trigger the undone edit again and leave you stuck in an infinite loop of undoing.

The pattern should be refactored at some point, but for now, I managed to fix it with the `__unstableMarkNextChangeAsNotPersistent` escape hatch.

I also added tests to guard against regressions.

## How has this been tested?

#19923 was verified to be fixed manually and through E2E testing.

## Types of Changes

*Bug Fix*: Converting a gallery to blocks can now be undone in one step.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
