### PR TITLE
Docs: Contributor Guide update subpages

### DIFF
--- a/docs/contributors/design.md
+++ b/docs/contributors/design.md
@@ -8,7 +8,7 @@ The [Make WordPress Design blog](https://make.wordpress.org/design/) is the prim
 
 Real-time discussions for design take place in the `#design` channel in [Slack](https://make.wordpress.org/chat). Weekly meetings for Design are on Weds at 19:00UTC.
 
-## How Can Designers Contribute?
+## How Can Designers Contribute
 
 The Gutenberg project uses Github for managing code and tracking issues. The main repository is at: [https://github.com/WordPress/gutenberg](https://github.com/WordPress/gutenberg).
 

--- a/docs/contributors/design.md
+++ b/docs/contributors/design.md
@@ -1,14 +1,24 @@
-# Design Principles & Vision
+# Design Contributions
 
-This is a living document that outlines the design principles and patterns of the editor interface. Its aim is to explain the background of the design, inform future improvements, and help people design great blocks.
+A guide on how to get started contributing design to the Gutenberg project.
+
+## Discussions
+
+The [Make WordPress Design blog](https://make.wordpress.org/design/) is the primary spot for the latest information around WordPress Design Team: including announcements, product goals, meeting notes, meeting agendas, and more.
+
+Real-time discussions for design take place in the `#design` channel in [Slack](https://make.wordpress.org/chat). Weekly meetings for Design are on Weds at 19:00UTC.
 
 ## How Can Designers Contribute?
 
-If you'd like to contribute to the design or front-end, feel free to contribute to tickets labelled [Needs Design](https://github.com/WordPress/gutenberg/issues?q=is%3Aissue+is%3Aopen+label%3A%22Needs+Design%22) or [Needs Design Feedback](https://github.com/WordPress/gutenberg/issues?q=is%3Aissue+is%3Aopen+label%3A"Needs+Design+Feedback%22). We could use your thoughtful replies, mockups, animatics, sketches, doodles. Proposed changes are best done as minimal and specific iterations on the work that precedes it so we can compare.
+The Gutenberg project uses Github for managing code and tracking issues. The main repository is at: [https://github.com/WordPress/gutenberg](https://github.com/WordPress/gutenberg).
+
+If you'd like to contribute to the design or front-end, feel free to contribute to tickets labeled [Needs Design](https://github.com/WordPress/gutenberg/issues?q=is%3Aissue+is%3Aopen+label%3A%22Needs+Design%22) or [Needs Design Feedback](https://github.com/WordPress/gutenberg/issues?q=is%3Aissue+is%3Aopen+label%3A"Needs+Design+Feedback%22). We could use your thoughtful replies, mockups, animatics, sketches, doodles. Proposed changes are best done as minimal and specific iterations on the work that precedes it so we can compare.
 
 The [WordPress Design team](http://make.wordpress.org/design/) uses [Figma](https://www.figma.com/) to collaborate and share work. If you'd like to contribute, join the [#design channel](http://wordpress.slack.com/messages/design/) in [Slack](https://make.wordpress.org/chat/) and ask the team to set you up with a free Figma account. This will give you access to a helpful [library of components](https://www.figma.com/file/ZtN5xslEVYgzU7Dd5CxgGZwq/WordPress-Components?node-id=0%3A1) used in WordPress.
 
 ## Principles
+
+This section outlines the design principles and patterns of the editor interface--to explain the background of the design, inform future improvements, and help people design great blocks.
 
 ![Gutenberg Logo](https://cldup.com/J2MgjuShPv-3000x3000.png)
 

--- a/docs/contributors/design.md
+++ b/docs/contributors/design.md
@@ -6,11 +6,11 @@ A guide on how to get started contributing design to the Gutenberg project.
 
 The [Make WordPress Design blog](https://make.wordpress.org/design/) is the primary spot for the latest information around WordPress Design Team: including announcements, product goals, meeting notes, meeting agendas, and more.
 
-Real-time discussions for design take place in the `#design` channel in [Slack](https://make.wordpress.org/chat). Weekly meetings for Design are on Weds at 19:00UTC.
+Real-time discussions for design take place in the `#design` channel in [Make WordPress Slack](https://make.wordpress.org/chat) (registration required). Weekly meetings for the Design team are on Wednesdays at 19:00UTC.
 
-## How Can Designers Contribute
+## How Can Designers Contribute?
 
-The Gutenberg project uses Github for managing code and tracking issues. The main repository is at: [https://github.com/WordPress/gutenberg](https://github.com/WordPress/gutenberg).
+The Gutenberg project uses GitHub for managing code and tracking issues. The main repository is at: [https://github.com/WordPress/gutenberg](https://github.com/WordPress/gutenberg).
 
 If you'd like to contribute to the design or front-end, feel free to contribute to tickets labeled [Needs Design](https://github.com/WordPress/gutenberg/issues?q=is%3Aissue+is%3Aopen+label%3A%22Needs+Design%22) or [Needs Design Feedback](https://github.com/WordPress/gutenberg/issues?q=is%3Aissue+is%3Aopen+label%3A"Needs+Design+Feedback%22). We could use your thoughtful replies, mockups, animatics, sketches, doodles. Proposed changes are best done as minimal and specific iterations on the work that precedes it so we can compare.
 
@@ -18,7 +18,7 @@ The [WordPress Design team](http://make.wordpress.org/design/) uses [Figma](http
 
 ## Principles
 
-This section outlines the design principles and patterns of the editor interface--to explain the background of the design, inform future improvements, and help people design great blocks.
+This section outlines the design principles and patterns of the editor interface—to explain the background of the design, inform future improvements, and help people design great blocks.
 
 ![Gutenberg Logo](https://cldup.com/J2MgjuShPv-3000x3000.png)
 

--- a/docs/contributors/develop.md
+++ b/docs/contributors/develop.md
@@ -1,16 +1,25 @@
-# Developer Contributions
+# Code Contributions
 
-Please also see [CONTRIBUTING.md](https://github.com/WordPress/gutenberg/blob/master/CONTRIBUTING.md) for general information about contributions to the Gutenberg repository.
+A guide on how to get started contributing code to the Gutenberg project.
 
-The following resources offer additional information for developers who wish to contribute to Gutenberg:
+## Discussions
 
-* [Getting Started](/docs/contributors/getting-started.md).
-* [Git Workflow](/docs/contributors/git-workflow.md).
+The [Make WordPress Core blog](https://make.wordpress.org/core/) is the primary spot for the latest information around WordPress development: including announcements, product goals, meeting notes, meeting agendas, and more.
+
+Real-time discussions for development take place in `#core-editor` and `#core-js` channels in [Slack](https://make.wordpress.org/chat). Weekly meetings for Editor are on Weds at 14:00UTC, and for JavaScript on Tuesday at 14:00UTC, in their respective slack channels.
+
+## Development Hub
+
+The Gutenberg project uses Github for managing code and tracking issues. The main repository is at: [https://github.com/WordPress/gutenberg](https://github.com/WordPress/gutenberg).
+
+Browse [the issues list](https://github.com/wordpress/gutenberg/issues) to find issues to work on. The [good first issue](https://github.com/wordpress/gutenberg/issues?q=is%3Aopen+is%3Aissue+label%3A%22Good+First+Issue%22) and [good first review](https://github.com/wordpress/gutenberg/issues?q=is%3Aopen+is%3Aissue+label%3A%22Good+First+Issue%22) labels are good starting points.
+
+## Contributor Resources
+
+* [Getting Started](/docs/contributors/getting-started.md) documents getting your development environment setup, this includes your test site and developer tools suggestions.
+* [Git Workflow](/docs/contributors/git-workflow.md) documents the git process for deploying changes using pull requests.
 * [Coding Guidelines](/docs/contributors/coding-guidelines.md) outline additional patterns and conventions used in the Gutenberg project.
 * [Testing Overview](/docs/contributors/testing-overview.md) for PHP and JavaScript development in Gutenberg.
-* [Gutenberg Block Grammar](/docs/contributors/grammar.md).
-* [Scripts](/docs/contributors/scripts.md) - a list of vendor and internal scripts available to plugin developers.
-* [Managing Packages](/docs/contributors/managing-packages.md).
+* [Managing Packages](/docs/contributors/managing-packages.md) documents the process for managing the npm packages.
 * [Gutenberg Release Process](/docs/contributors/release.md) - a checklist for the different type of releases for Gutenberg project.
-* [Localizing Gutenberg Plugin](/docs/contributors/localizing.md) - a guide on how to translate Gutenberg in your locale or language.
 * [React Native mobile Gutenberg](/docs/contributors/native-mobile.md) - a guide on the React Native based mobile Gutenberg editor.

--- a/docs/contributors/develop.md
+++ b/docs/contributors/develop.md
@@ -6,11 +6,11 @@ A guide on how to get started contributing code to the Gutenberg project.
 
 The [Make WordPress Core blog](https://make.wordpress.org/core/) is the primary spot for the latest information around WordPress development: including announcements, product goals, meeting notes, meeting agendas, and more.
 
-Real-time discussions for development take place in `#core-editor` and `#core-js` channels in [Slack](https://make.wordpress.org/chat). Weekly meetings for Editor are on Weds at 14:00UTC, and for JavaScript on Tuesday at 14:00UTC, in their respective slack channels.
+Real-time discussions for development take place in `#core-editor` and `#core-js` channels in [Make WordPress Slack](https://make.wordpress.org/chat) (registration required). Weekly meetings for the editor component are on Wednesdays at 14:00UTC, and for the JavaScript component on Tuesday at 14:00UTC, in their respective Slack channels.
 
 ## Development Hub
 
-The Gutenberg project uses Github for managing code and tracking issues. The main repository is at: [https://github.com/WordPress/gutenberg](https://github.com/WordPress/gutenberg).
+The Gutenberg project uses GitHub for managing code and tracking issues. The main repository is at: [https://github.com/WordPress/gutenberg](https://github.com/WordPress/gutenberg).
 
 Browse [the issues list](https://github.com/wordpress/gutenberg/issues) to find issues to work on. The [good first issue](https://github.com/wordpress/gutenberg/issues?q=is%3Aopen+is%3Aissue+label%3A%22Good+First+Issue%22) and [good first review](https://github.com/wordpress/gutenberg/issues?q=is%3Aopen+is%3Aissue+label%3A%22Good+First+Issue%22) labels are good starting points.
 

--- a/docs/contributors/document.md
+++ b/docs/contributors/document.md
@@ -66,6 +66,6 @@ This way they will be properly handled in all three aforementioned contexts.
 
 ## Resources
 
-* [Copy Guidelines](/docs/contributors/copy-guide.md) for writing instructions, documentations, or other contributions to Gutenberg project.
+- [Copy Guidelines](/docs/contributors/copy-guide.md) for writing instructions, documentations, or other contributions to Gutenberg project.
 
-* [Tone and Voice Guide](https://make.wordpress.org/docs/handbook/documentation-team-handbook/tone-and-voice-guide/) from WordPress Documentation.
+- [Tone and Voice Guide](https://make.wordpress.org/docs/handbook/documentation-team-handbook/tone-and-voice-guide/) from WordPress Documentation.

--- a/docs/contributors/document.md
+++ b/docs/contributors/document.md
@@ -1,19 +1,56 @@
 # Documentation Contributions
 
-Documentation for Gutenberg is maintained in the `/docs/` directory in the same Gutenberg Github repository. The docs are published every 15 minutes to the [Block Editor Handbook site](https://developer.wordpress.org/block-editor/).
+A guide on how to get started contributing documentation to the Gutenberg project.
 
-## New Document
+## Discussions
+
+The [Make WordPress Docs blog](https://make.wordpress.org/docs/) is the primary spot for the latest information around WordPress documentation: including announcements, product goals, meeting notes, meeting agendas, and more.
+
+Real-time discussions for documentation take place in the `#docs` channel in [Slack](https://make.wordpress.org/chat). Weekly meetings for Documentation are on Mon at 54:00UTC.
+
+The Gutenberg project uses Github for managing code and tracking issues. The main repository is at: [https://github.com/WordPress/gutenberg](https://github.com/WordPress/gutenberg).  To find documentation issues to work on, browse [issues with documentation label](https://github.com/WordPress/gutenberg/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3A%22%5BType%5D+Documentation%22+).
+
+## Documentation Types
+
+There are two major sets of documentation for Gutenberg project:
+
+1. [User documentation](https://wordpress.org/support/article/wordpress-editor/) is information on how to use the Editor as an author publishing posts. For contributing to user docs, follow docs blog above to see priorities. Ask in #docs channel for latest list of priorities for user docs.
+
+2. [Block Editor Handbook](https://developer.wordpress.org/block-editor/) is everything related to the Gutenberg project including: developing, extending, and--what you are reading right now--contributing specific to Gutenberg.
+
+The rest of this document covers contributing to the Block Editor Handbook.
+
+
+## Block Editor Handbook Process
+
+The Block Editor Handbook is a mix of markdown files in the `/docs/` directory of the [Gutenberg project repository](https://github.com/WordPress/gutenberg/) and generated documentation from the packages.
+
+An automated job publishes the docs every 15 minutes to the [Block Editor Handbook site](https://developer.wordpress.org/block-editor/).
+
+See [the Git Workflow](/docs/contributors/git-workflow.md) documentation for how to use git to deploy changes using pull requests.
+
+### Update a Document
+
+To update an existing page:
+
+1. Check out the gutenberg repository.
+2. Create a branch to work, for example `docs/update-contrib-guide`.
+3. Make the necessary changes to the existing document.
+4. Commit change
+5. Create a pull-request with "Documentation" label.
+
+### Create a New Document
 
 To add a new documentation page:
 
-1. Create a Markdown file in the [docs](https://github.com/WordPress/gutenberg/tree/master/docs) folder
-2. Add item to the [toc.json](https://github.com/WordPress/gutenberg/blob/master/docs/toc.json) hierarchy
-3. Update `manifest-devhub.json` by running `npm run docs:build`
-4. Commit `manifest-devhub.json` with other files updated
+1. Create a Markdown file in the [docs](https://github.com/WordPress/gutenberg/tree/master/docs) folder.
+2. Add item to the [toc.json](https://github.com/WordPress/gutenberg/blob/master/docs/toc.json) hierarchy.
+3. Update `manifest-devhub.json` by running `npm run docs:build`.
+4. Commit `manifest-devhub.json` with other files updated.
 
-## Using Links
+### Using Links
 
-It's very likely that at some point you will want to link to other documentation pages. It's worth emphasizing that all documents can be browsed in different contexts:
+It's likely that at some point you will want to link to other documentation pages. It's worth emphasizing that all documents can be browsed in different contexts:
 
 - Block Editor Handbook
 - GitHub website

--- a/docs/contributors/document.md
+++ b/docs/contributors/document.md
@@ -6,17 +6,16 @@ A guide on how to get started contributing documentation to the Gutenberg projec
 
 The [Make WordPress Docs blog](https://make.wordpress.org/docs/) is the primary spot for the latest information around WordPress documentation: including announcements, product goals, meeting notes, meeting agendas, and more.
 
-Real-time discussions for documentation take place in the `#docs` channel in [Slack](https://make.wordpress.org/chat). Weekly meetings for Documentation are on Mon at 54:00UTC.
+Real-time discussions for documentation take place in the `#docs` channel in [Make WordPress Slack](https://make.wordpress.org/chat) (registration required). Weekly meetings for the Documentation team are on Mondays at 14:00UTC.
 
-The Gutenberg project uses Github for managing code and tracking issues. The main repository is at: [https://github.com/WordPress/gutenberg](https://github.com/WordPress/gutenberg).  To find documentation issues to work on, browse [issues with documentation label](https://github.com/WordPress/gutenberg/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3A%22%5BType%5D+Documentation%22+).
+The Gutenberg project uses GitHub for managing code and tracking issues. The main repository is at: [https://github.com/WordPress/gutenberg](https://github.com/WordPress/gutenberg).  To find documentation issues to work on, browse [issues with documentation label](https://github.com/WordPress/gutenberg/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3A%22%5BType%5D+Documentation%22+).
 
 ## Documentation Types
 
 There are two major sets of documentation for Gutenberg project:
 
-1. [User documentation](https://wordpress.org/support/article/wordpress-editor/) is information on how to use the Editor as an author publishing posts. For contributing to user docs, follow docs blog above to see priorities. Ask in #docs channel for latest list of priorities for user docs.
-
-2. [Block Editor Handbook](https://developer.wordpress.org/block-editor/) is everything related to the Gutenberg project including: developing, extending, and--what you are reading right now--contributing specific to Gutenberg.
+1. [User documentation](https://wordpress.org/support/article/wordpress-editor/) is information on how to use the Editor as an author publishing posts. For contributing to user docs, follow the docs blog, or ask in the #docs Slack channel, to understand the current priorities.
+2. [Block Editor Handbook](https://developer.wordpress.org/block-editor/) is everything related to the Gutenberg project including: developing, extending, and—what you are reading right now—contributing specific to Gutenberg.
 
 The rest of this document covers contributing to the Block Editor Handbook.
 
@@ -36,8 +35,8 @@ To update an existing page:
 1. Check out the gutenberg repository.
 2. Create a branch to work, for example `docs/update-contrib-guide`.
 3. Make the necessary changes to the existing document.
-4. Commit change
-5. Create a pull-request with "Documentation" label.
+4. Commit your changes.
+5. Create a pull request with "Documentation" label.
 
 ### Create a New Document
 

--- a/docs/contributors/readme.md
+++ b/docs/contributors/readme.md
@@ -8,15 +8,15 @@ Gutenberg is a sub-project of Core WordPress. Please see the [Core Contributor H
 
 Find the section below based on what you are looking to contribute:
 
-- Code? See the [developer section](/docs/contributors/develop.md).
+- **Code?** See the [developer section](/docs/contributors/develop.md).
 
-- Design? See the [design section](/docs/contributors/design.md).
+- **Design?** See the [design section](/docs/contributors/design.md).
 
-- Documentation? See the [documentation section](/docs/contributors/document.md)
+- **Documentation?** See the [documentation section](/docs/contributors/document.md)
 
-- Triage Support? See the [triaging issues section](/docs/contributors/repository-management/#triaging-issues)
+- **Triage Support?** See the [triaging issues section](/docs/contributors/repository-management/#triaging-issues)
 
-- Internationalization? See the [localizing and translating section](/docs/contributors/localizing.md)
+- **Internationalization?** See the [localizing and translating section](/docs/contributors/localizing.md)
 
 ### Repository Management
 

--- a/docs/manifest-devhub.json
+++ b/docs/manifest-devhub.json
@@ -270,7 +270,7 @@
 		"parent": null
 	},
 	{
-		"title": "Developer Contributions",
+		"title": "Code Contributions",
 		"slug": "develop",
 		"markdown_source": "../docs/contributors/develop.md",
 		"parent": "contributors"
@@ -330,7 +330,7 @@
 		"parent": "develop"
 	},
 	{
-		"title": "Design Principles & Vision",
+		"title": "Design Contributions",
 		"slug": "design",
 		"markdown_source": "../docs/contributors/design.md",
 		"parent": "contributors"

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -270,7 +270,7 @@
 		"parent": null
 	},
 	{
-		"title": "Developer Contributions",
+		"title": "Code Contributions",
 		"slug": "develop",
 		"markdown_source": "../docs/contributors/develop.md",
 		"parent": "contributors"
@@ -330,7 +330,7 @@
 		"parent": "develop"
 	},
 	{
-		"title": "Design Principles & Vision",
+		"title": "Design Contributions",
 		"slug": "design",
 		"markdown_source": "../docs/contributors/design.md",
 		"parent": "contributors"


### PR DESCRIPTION
## Description

Continues updates to Contributor Guide, see previous work in #19853 
These changes update the main sub-pages of the guide, providing consistent info at the top for each section.

* [Main Contributor Guide page](https://github.com/WordPress/gutenberg/tree/update/docs-contrib-dev/docs/contributors) minor change for formatting, adding bold to start of bullet list

* [Code Contribution](https://github.com/WordPress/gutenberg/blob/update/docs-contrib-dev/docs/contributors/develop.md) changes rename page to the type of contribution, not the person, this is inline with Design and Documentation. Add Discussion, Development Hub sections. Remove Grammar and Scripts links from resources since not related to Contributing, will surface elsewhere. Remove Localizing since i18n is now linked to from top section and translating is different than contributing code.

* [Design Contrubtion](https://github.com/WordPress/gutenberg/blob/update/docs-contrib-dev/docs/contributors/design.md) update top section with discussion area.

* [Documentation Contribution](https://github.com/WordPress/gutenberg/blob/update/docs-contrib-dev/docs/contributors/document.md) update top section with discussion area. Add section for two types of documentation User vs Developer. Add link to Git workflow and additional explanation with an update example. 

@bph If you can take a look at the short explanation on how to contribute to Gutenberg User docs, I'm not real happy with what I have now, which basically says ask in Slack. Is there an existing page or link for better info? I think tasks are tracked in Trello or Google Docs, hence the "ask in Slack" which they can get access and links.

## How has this been tested?

Documentation. Browse live on branch see links above to each page.

