### PR TITLE
[Mobile] Make Image.getSize cancellable in ImageSize component

### DIFF
--- a/packages/block-editor/src/components/media-upload-progress/image-size.native.js
+++ b/packages/block-editor/src/components/media-upload-progress/image-size.native.js
@@ -6,7 +6,7 @@ import { Component } from '@wordpress/element';
 /**
  * External dependencies
  */
-import { View, Image } from 'react-native';
+import { View, Image as RNImage } from 'react-native';
 
 /**
  * Internal dependencies
@@ -20,6 +20,17 @@ function calculatePreferedImageSize( image, container ) {
 	const height = exceedMaxWidth ? maxWidth * ratio : image.height;
 	return { width, height };
 }
+
+const Image = ( () => {
+	let cancelled = false;
+
+	return {
+		cancelAllGetSize: () => cancelled = true,
+		getSize: ( src, callback ) => RNImage.getSize( src, ( ...args ) => (
+			cancelled ? undefined : callback( ...args )
+		) ),
+	};
+} )();
 
 class ImageSize extends Component {
 	constructor() {
@@ -73,6 +84,10 @@ class ImageSize extends Component {
 			clientHeight: height,
 		};
 		this.calculateSize();
+	}
+
+	componentWillUnmount() {
+		Image.cancelAllGetSize();
 	}
 
 	render() {


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/1831

#### Related PR:
`gutenberg-mobile`: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1832

## Description
This PR adds a wrapper to `Image.getSize` with a cancelled flag, and a method to make all callback invocations a noop.

## How has this been tested?
Tested via steps described here: https://github.com/wordpress-mobile/gutenberg-mobile/issues/1831

## Types of changes
This PR makes `getSize` cancellable in the `ImageSize` component, and cancels invocations on unmount.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
