### PR TITLE
Editor: Remove post title escaping

### DIFF
--- a/packages/editor/src/components/post-title/index.js
+++ b/packages/editor/src/components/post-title/index.js
@@ -3,7 +3,7 @@
  */
 import Textarea from 'react-autosize-textarea';
 import classnames from 'classnames';
-import { get, escape } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -97,7 +97,7 @@ class PostTitle extends Component {
 							<Textarea
 								id={ `post-title-${ instanceId }` }
 								className="editor-post-title__input"
-								value={ decodeEntities( title ) }
+								value={ title }
 								onChange={ this.onChange }
 								placeholder={ decodedPlaceholder || __( 'Add title' ) }
 								onFocus={ this.onSelect }
@@ -151,7 +151,7 @@ const applyWithDispatch = withDispatch( ( dispatch ) => {
 			insertDefaultBlock( undefined, undefined, 0 );
 		},
 		onUpdate( title ) {
-			editPost( { title: escape( title ) } );
+			editPost( { title } );
 		},
 		clearSelectedBlock,
 	};


### PR DESCRIPTION
Fixes #19898 
Reverts #18616, #19187

This pull request seeks to remove the escaping behavior applied to post titles starting in #18616. 

Additional context is available at https://github.com/WordPress/gutenberg/issues/19898#issuecomment-579798734 :

>- It will cause default title ["texturize"](https://developer.wordpress.org/reference/functions/wptexturize/) behavior to skipped, because these characters are only replaced if left unescaped ([source](https://github.com/WordPress/wordpress-develop/blob/b30baca3ca2feb7f44b3615262ca55fcd87ae232/src/wp-includes/default-filters.php#L168)).
>- It is intended that titles can include HTML, which this behavior would prevent.
>- Evidenced by this issue, it may be more prone to interoperability issues with other plugins and services.

**Note:** There is a small backwards-compatibility concern here, in that: Posts published using the Gutenberg plugin between versions 7.0 and 7.2 may now appear in the editor with escaped character sequences, if those titles contain characters which would have previously been escaped (apostrophes, `<` and `>`, etc). This could be okay considering that the behavior was never present in a stable release of WordPress, though users of the plugin (and services like WordPress.com, and sites running WordPress trunk) may start to see these escape sequences. The alternative I could imagine here is to always _decode_ the title value, but this could be problematic as well, considering that (a) it is anticipating a behavior that the editor itself does not apply and (b) it could decode _intentional_ character escaping, e.g. if a post was titled to include the _text representation_ of HTML markup, that markup may suddenly be changed to real HTML.

**Testing Instructions:**

Verify that post titles are [texturized](https://developer.wordpress.org/reference/functions/wptexturize/):

1. Navigate to Posts > Add New
2. Enter the title `Charlotte's Web`
3. Preview the post
4. Ensure the title markup shown is with a "pretty" apostrophe: `Charlotte’s Web`

Verify that, if you so choose, you can include markup in a title:

1. Navigate to Posts > Add New
2. Enter the title `Hello <em>world</em>!`
3. Preview the post
4. Ensure the title is shown with italicized "world"