### PR TITLE
Block Library: Add a Post Navigation block.

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -59,6 +59,7 @@ function gutenberg_reregister_core_block_types() {
 		'post-author.php'     => 'core/post-author',
 		'post-date.php'       => 'core/post-date',
 		'post-excerpt.php'    => 'core/post-excerpt',
+		'post-navigation.php' => 'core/post-navigation',
 	);
 
 	$registry = WP_Block_Type_Registry::get_instance();

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -70,6 +70,7 @@ import * as postContent from './post-content';
 import * as postAuthor from './post-author';
 import * as postDate from './post-date';
 import * as postExcerpt from './post-excerpt';
+import * as postNavigation from './post-navigation';
 
 /**
  * Function to register an individual block.
@@ -197,6 +198,7 @@ export const __experimentalRegisterExperimentalCoreBlocks =
 						postAuthor,
 						postDate,
 						postExcerpt,
+						postNavigation,
 					] :
 					[] ),
 			].forEach( registerBlock );

--- a/packages/block-library/src/post-navigation/block.json
+++ b/packages/block-library/src/post-navigation/block.json
@@ -1,0 +1,4 @@
+{
+	"name": "core/post-navigation",
+	"category": "layout"
+}

--- a/packages/block-library/src/post-navigation/edit.js
+++ b/packages/block-library/src/post-navigation/edit.js
@@ -1,0 +1,3 @@
+export default function PostNavigationEdit() {
+	return 'Post Navigation Placeholder';
+}

--- a/packages/block-library/src/post-navigation/index.js
+++ b/packages/block-library/src/post-navigation/index.js
@@ -1,0 +1,21 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+import edit from './edit';
+
+const { name } = metadata;
+export { metadata, name };
+
+export const settings = {
+	title: __( 'Post Navigation' ),
+	supports: {
+		html: false,
+	},
+	edit,
+};

--- a/packages/block-library/src/post-navigation/index.php
+++ b/packages/block-library/src/post-navigation/index.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Server-side rendering of the `core/post-navigation` block.
+ *
+ * @package WordPress
+ */
+
+/**
+ * Renders the `core/post-navigation` block on the server.
+ *
+ * @return string Returns the post navigation UI for the current post.
+ */
+function render_block_core_post_navigation() {
+	global $wp_query;
+	$wp_query->query_vars['posts_per_page'] = 1;
+	$wp_query->max_num_pages                = $wp_query->found_posts;
+	return get_the_posts_pagination();
+}
+
+/**
+ * Registers the `core/post-navigation` block on the server.
+ */
+function register_block_core_post_navigation() {
+	register_block_type(
+		'core/post-navigation',
+		array(
+			'render_callback' => 'render_block_core_post_navigation',
+		)
+	);
+}
+add_action( 'init', 'register_block_core_post_navigation' );

--- a/packages/e2e-tests/fixtures/blocks/core__post-navigation.html
+++ b/packages/e2e-tests/fixtures/blocks/core__post-navigation.html
@@ -1,0 +1,1 @@
+<!-- wp:post-navigation /-->

--- a/packages/e2e-tests/fixtures/blocks/core__post-navigation.json
+++ b/packages/e2e-tests/fixtures/blocks/core__post-navigation.json
@@ -1,0 +1,10 @@
+[
+    {
+        "clientId": "_clientId_0",
+        "name": "core/post-navigation",
+        "isValid": true,
+        "attributes": {},
+        "innerBlocks": [],
+        "originalContent": ""
+    }
+]

--- a/packages/e2e-tests/fixtures/blocks/core__post-navigation.parsed.json
+++ b/packages/e2e-tests/fixtures/blocks/core__post-navigation.parsed.json
@@ -1,0 +1,18 @@
+[
+    {
+        "blockName": "core/post-navigation",
+        "attrs": {},
+        "innerBlocks": [],
+        "innerHTML": "",
+        "innerContent": []
+    },
+    {
+        "blockName": null,
+        "attrs": {},
+        "innerBlocks": [],
+        "innerHTML": "\n",
+        "innerContent": [
+            "\n"
+        ]
+    }
+]

--- a/packages/e2e-tests/fixtures/blocks/core__post-navigation.serialized.html
+++ b/packages/e2e-tests/fixtures/blocks/core__post-navigation.serialized.html
@@ -1,0 +1,1 @@
+<!-- wp:post-navigation /-->


### PR DESCRIPTION
## Description

This PR adds a new Post Navigation block akin to the Post Title and Post Content blocks.

## How has this been tested?

- Inserted Post Navigation block in a post.
- Confirmed post navigation rendered in the editor and front end on a page with a multi-post query.

## Types of Changes

*New Feature:* There is a new Post Navigation block for template building.

## Checklist:

- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
