### PR TITLE
Use require.resolve() instead of <rootDir> in @wordpress/jest-preset-default

### DIFF
--- a/packages/jest-preset-default/jest-preset.js
+++ b/packages/jest-preset-default/jest-preset.js
@@ -1,31 +1,26 @@
 module.exports = {
 	moduleNameMapper: {
-		'\\.(scss|css)$':
-			require.resolve('@wordpress/jest-preset-default/scripts/style-mock.js'),
+		'\\.(scss|css)$': require.resolve( '@wordpress/jest-preset-default/scripts/style-mock.js' ),
 	},
 	modulePaths: [ '<rootDir>' ],
-	setupFiles: [
-		require.resolve('@wordpress/jest-preset-default/scripts/setup-globals.js'),
-	],
+	setupFiles: [ require.resolve( '@wordpress/jest-preset-default/scripts/setup-globals.js' ) ],
 	setupFilesAfterEnv: [
-		require.resolve('@wordpress/jest-preset-default/scripts/setup-test-framework.js'),
+		require.resolve( '@wordpress/jest-preset-default/scripts/setup-test-framework.js' ),
 	],
-	snapshotSerializers: [ require.resolve('enzyme-to-json/serializer.js') ],
-	testMatch: [
-		'**/__tests__/**/*.[jt]s',
-		'**/test/*.[jt]s',
-		'**/?(*.)test.[jt]s',
-	],
+	snapshotSerializers: [ require.resolve( 'enzyme-to-json/serializer.js' ) ],
+	testMatch: [ '**/__tests__/**/*.[jt]s', '**/test/*.[jt]s', '**/?(*.)test.[jt]s' ],
 	testPathIgnorePatterns: [ '/node_modules/', '/wordpress/' ],
 	timers: 'fake',
 	transform: {
-		'^.+\\.[jt]sx?$': require.resolve('babel-jest'),
+		'^.+\\.[jt]sx?$': require.resolve( 'babel-jest' ),
 	},
 	verbose: true,
 	reporters:
-		'TRAVIS' in process.env && 'CI' in process.env ?
-			[
-				require.resolve('@wordpress/jest-preset-default/scripts/travis-fold-passes-reporter.js'),
-			] :
-			undefined,
+		'TRAVIS' in process.env && 'CI' in process.env
+			? [
+					require.resolve(
+						'@wordpress/jest-preset-default/scripts/travis-fold-passes-reporter.js'
+					),
+			  ]
+			: undefined,
 };

--- a/packages/jest-preset-default/jest-preset.js
+++ b/packages/jest-preset-default/jest-preset.js
@@ -1,16 +1,16 @@
 module.exports = {
 	moduleNameMapper: {
 		'\\.(scss|css)$':
-			'<rootDir>/node_modules/@wordpress/jest-preset-default/scripts/style-mock.js',
+			require.resolve('@wordpress/jest-preset-default/scripts/style-mock.js'),
 	},
 	modulePaths: [ '<rootDir>' ],
 	setupFiles: [
-		'<rootDir>/node_modules/@wordpress/jest-preset-default/scripts/setup-globals.js',
+		require.resolve('@wordpress/jest-preset-default/scripts/setup-globals.js'),
 	],
 	setupFilesAfterEnv: [
-		'<rootDir>/node_modules/@wordpress/jest-preset-default/scripts/setup-test-framework.js',
+		require.resolve('@wordpress/jest-preset-default/scripts/setup-test-framework.js'),
 	],
-	snapshotSerializers: [ '<rootDir>/node_modules/enzyme-to-json/serializer.js' ],
+	snapshotSerializers: [ require.resolve('enzyme-to-json/serializer.js') ],
 	testMatch: [
 		'**/__tests__/**/*.[jt]s',
 		'**/test/*.[jt]s',
@@ -19,13 +19,13 @@ module.exports = {
 	testPathIgnorePatterns: [ '/node_modules/', '/wordpress/' ],
 	timers: 'fake',
 	transform: {
-		'^.+\\.[jt]sx?$': '<rootDir>/node_modules/babel-jest',
+		'^.+\\.[jt]sx?$': require.resolve('babel-jest'),
 	},
 	verbose: true,
 	reporters:
 		'TRAVIS' in process.env && 'CI' in process.env ?
 			[
-				'../../../@wordpress/jest-preset-default/scripts/travis-fold-passes-reporter.js',
+				require.resolve('@wordpress/jest-preset-default/scripts/travis-fold-passes-reporter.js'),
 			] :
 			undefined,
 };


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

The `@wordpress/jest-preset-default` package currently assumes a single `node_modules` directory at the `rootDir`. This isn't always the case and results in Jest failing to run any tests.

This PR switches use of `<rootDir>` for `require.resolve()` which means the configuration files are resolved according to the standard NodeJS algorithm, allowing the package to be used more widely.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Ran all tests in the monorepo. The tests depend on the package which is linked using the `file:` protocol.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
