### PR TITLE
Automatically render category keyboard shortcuts

### DIFF
--- a/docs/designers-developers/developers/data/data-core-keyboard-shortcuts.md
+++ b/docs/designers-developers/developers/data/data-core-keyboard-shortcuts.md
@@ -19,6 +19,19 @@ _Returns_
 
 -   `Array<string>`: Shortcuts.
 
+<a name="getCategoryShortcuts" href="#getCategoryShortcuts">#</a> **getCategoryShortcuts**
+
+Returns the shortcut names list for a give category name.
+
+_Parameters_
+
+-   _state_ `Object`: Global state.
+-   _name_ `string`: Category name.
+
+_Returns_
+
+-   `Array<string>`: Shortcut names.
+
 <a name="getShortcutAliases" href="#getShortcutAliases">#</a> **getShortcutAliases**
 
 Returns the aliases for a given shortcut name.

--- a/docs/designers-developers/developers/data/data-core-keyboard-shortcuts.md
+++ b/docs/designers-developers/developers/data/data-core-keyboard-shortcuts.md
@@ -21,7 +21,7 @@ _Returns_
 
 <a name="getCategoryShortcuts" href="#getCategoryShortcuts">#</a> **getCategoryShortcuts**
 
-Returns the shortcut names list for a give category name.
+Returns the shortcut names list for a given category name.
 
 _Parameters_
 

--- a/packages/block-editor/src/components/keyboard-shortcuts/index.js
+++ b/packages/block-editor/src/components/keyboard-shortcuts/index.js
@@ -204,7 +204,7 @@ function KeyboardShortcutsRegister() {
 
 		registerShortcut( {
 			name: 'core/block-editor/unselect',
-			category: 'selections',
+			category: 'selection',
 			description: __( 'Clear selection.' ),
 			keyCombination: {
 				character: 'escape',

--- a/packages/edit-post/src/components/keyboard-shortcut-help-modal/index.js
+++ b/packages/edit-post/src/components/keyboard-shortcut-help-modal/index.js
@@ -10,7 +10,7 @@ import { isString } from 'lodash';
 import { Modal } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useShortcut } from '@wordpress/keyboard-shortcuts';
-import { withSelect, withDispatch } from '@wordpress/data';
+import { withSelect, withDispatch, useSelect } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 
 /**
@@ -64,6 +64,28 @@ const ShortcutSection = ( { title, shortcuts, className } ) => (
 	</section>
 );
 
+const ShortcutCategorySection = ( {
+	title,
+	categoryName,
+	additionalShortcuts = [],
+} ) => {
+	const categoryShortcuts = useSelect(
+		( select ) => {
+			return select( 'core/keyboard-shortcuts' ).getCategoryShortcuts(
+				categoryName
+			);
+		},
+		[ categoryName ]
+	);
+
+	return (
+		<ShortcutSection
+			title={ title }
+			shortcuts={ categoryShortcuts.concat( additionalShortcuts ) }
+		/>
+	);
+};
+
 export function KeyboardShortcutHelpModal( { isModalActive, toggleModal } ) {
 	useShortcut( 'core/edit-post/keyboard-shortcuts', toggleModal, {
 		bindGlobal: true,
@@ -84,34 +106,20 @@ export function KeyboardShortcutHelpModal( { isModalActive, toggleModal } ) {
 				className="edit-post-keyboard-shortcut-help-modal__main-shortcuts"
 				shortcuts={ [ 'core/edit-post/keyboard-shortcuts' ] }
 			/>
-			<ShortcutSection
+			<ShortcutCategorySection
 				title={ __( 'Global shortcuts' ) }
-				shortcuts={ [
-					'core/editor/save',
-					'core/editor/undo',
-					'core/editor/redo',
-					'core/edit-post/toggle-sidebar',
-					'core/edit-post/toggle-block-navigation',
-					'core/edit-post/next-region',
-					'core/edit-post/previous-region',
-					'core/block-editor/focus-toolbar',
-					'core/edit-post/toggle-mode',
-				] }
+				categoryName="global"
 			/>
-			<ShortcutSection
+
+			<ShortcutCategorySection
 				title={ __( 'Selection shortcuts' ) }
-				shortcuts={ [
-					'core/block-editor/select-all',
-					'core/block-editor/unselect',
-				] }
+				categoryName="selection"
 			/>
-			<ShortcutSection
+
+			<ShortcutCategorySection
 				title={ __( 'Block shortcuts' ) }
-				shortcuts={ [
-					'core/block-editor/duplicate',
-					'core/block-editor/remove',
-					'core/block-editor/insert-before',
-					'core/block-editor/insert-after',
+				categoryName="block"
+				additionalShortcuts={ [
 					{
 						keyCombination: { character: '/' },
 						description: __(

--- a/packages/edit-post/src/components/keyboard-shortcut-help-modal/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/keyboard-shortcut-help-modal/test/__snapshots__/index.js.snap
@@ -15,38 +15,17 @@ exports[`KeyboardShortcutHelpModal should match snapshot when the modal is activ
       ]
     }
   />
-  <ShortcutSection
-    shortcuts={
-      Array [
-        "core/editor/save",
-        "core/editor/undo",
-        "core/editor/redo",
-        "core/edit-post/toggle-sidebar",
-        "core/edit-post/toggle-block-navigation",
-        "core/edit-post/next-region",
-        "core/edit-post/previous-region",
-        "core/block-editor/focus-toolbar",
-        "core/edit-post/toggle-mode",
-      ]
-    }
+  <ShortcutCategorySection
+    categoryName="global"
     title="Global shortcuts"
   />
-  <ShortcutSection
-    shortcuts={
-      Array [
-        "core/block-editor/select-all",
-        "core/block-editor/unselect",
-      ]
-    }
+  <ShortcutCategorySection
+    categoryName="selection"
     title="Selection shortcuts"
   />
-  <ShortcutSection
-    shortcuts={
+  <ShortcutCategorySection
+    additionalShortcuts={
       Array [
-        "core/block-editor/duplicate",
-        "core/block-editor/remove",
-        "core/block-editor/insert-before",
-        "core/block-editor/insert-after",
         Object {
           "ariaLabel": "Forward-slash",
           "description": "Change the block type after adding a new paragraph.",
@@ -56,6 +35,7 @@ exports[`KeyboardShortcutHelpModal should match snapshot when the modal is activ
         },
       ]
     }
+    categoryName="block"
     title="Block shortcuts"
   />
   <ShortcutSection

--- a/packages/keyboard-shortcuts/src/store/selectors.js
+++ b/packages/keyboard-shortcuts/src/store/selectors.js
@@ -138,3 +138,20 @@ export const getAllShortcutRawKeyCombinations = createSelector(
 	},
 	( state, name ) => [ state[ name ] ]
 );
+
+/**
+ * Returns the shortcut names list for a give category name.
+ *
+ * @param {Object} state Global state.
+ * @param {string} name  Category name.
+ *
+ * @return {string[]} Shortcut names.
+ */
+export const getCategoryShortcuts = createSelector(
+	( state, categoryName ) => {
+		return Object.entries( state )
+			.filter( ( [ , shortcut ] ) => shortcut.category === categoryName )
+			.map( ( [ name ] ) => name );
+	},
+	( state ) => [ state ]
+);

--- a/packages/keyboard-shortcuts/src/store/selectors.js
+++ b/packages/keyboard-shortcuts/src/store/selectors.js
@@ -140,7 +140,7 @@ export const getAllShortcutRawKeyCombinations = createSelector(
 );
 
 /**
- * Returns the shortcut names list for a give category name.
+ * Returns the shortcut names list for a given category name.
  *
  * @param {Object} state Global state.
  * @param {string} name  Category name.


### PR DESCRIPTION
closes #15205

In This PR, instead of listing the shortcuts to be shown in each category of the help modal, I'm update the code to automatically show the registered shortcuts of that category.

The good news is that this allows third-party plugins to register their shortcuts and they'll show up magically on that help modal. The only requirement is to choose one of these categories (block, selection, global). 

Down the road, we can probably open to random categories but this is a good start I think.

The downside of this PR is that we don't control the order of the shortcuts. We could add an alphabetical order or a priority property per shortcut. But we can iterate on that.

**Testing instructions**

- Register a custom shortcut like so (paste into the console):

```
wp.data.dispatch('core/keyboard-shortcuts').registerShortcut( {
			name: 'mynamespace/myshortcut',
			category: 'global',
			description: 'Awesome shortcut that sends spaceships to another Galaxy',
			keyCombination: {
				character: 's',
			},
		} );
```

- Open the keyboard shortcuts modal, you should see the shortcut added to the right category.