### PR TITLE
Block Library: Add pagination to the Latest Posts block.

### DIFF
--- a/packages/block-library/src/latest-posts/style.scss
+++ b/packages/block-library/src/latest-posts/style.scss
@@ -40,3 +40,11 @@
 	margin-top: $grid-size;
 	margin-bottom: $grid-size-large;
 }
+
+.wp-block-latest-posts__navigation-link {
+	color: $dark-gray-300;
+	cursor: pointer;
+	font-size: $default-font-size;
+	font-weight: 700;
+	margin: $grid-size;
+}


### PR DESCRIPTION
## Description

This PR adds basic single stepped pagination to the Latest Posts block posts list. In the future, we might want to look at adding more customization options.

## How to test this?

Verify toggling pagination on enables pagination for the post list both in the editor and front end and that things work as expected. E.g. The previous link only renders if there is a previous page, and the next link only renders if there is a next page.

## Screenshots

<img width="908" alt="Screen Shot 2020-01-30 at 12 30 50 PM" src="https://user-images.githubusercontent.com/19157096/73474693-df433f80-435c-11ea-9bef-aa601adf8962.png">

<img width="184" alt="Screen Shot 2020-01-30 at 12 30 38 PM" src="https://user-images.githubusercontent.com/19157096/73474702-e36f5d00-435c-11ea-8677-6219ff6d8910.png">

## Types of Changes

*New Feature*: The Latest Posts block now supports pagination.

## Checklist:

- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
