### PR TITLE
Fix: Admin menu collapses for 960px width but editor doesn't

### DIFF
--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -279,7 +279,7 @@
 			left: $admin-sidebar-width-collapsed;
 		}
 
-		@include break-large() {
+		@media (min-width: #{ ($break-large + 1) }) {
 			left: $admin-sidebar-width;
 		}
 	}

--- a/packages/e2e-tests/specs/editor/plugins/container-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/container-blocks.test.js
@@ -8,6 +8,7 @@ import {
 	getEditedPostContent,
 	insertBlock,
 	switchEditorModeTo,
+	pressKeyWithModifier,
 } from '@wordpress/e2e-test-utils';
 
 describe( 'InnerBlocks Template Sync', () => {
@@ -37,6 +38,8 @@ describe( 'InnerBlocks Template Sync', () => {
 		}, paragraphToAdd, blockSlug );
 		// Press "Enter" inside the Code Editor to fire the `onChange` event for the new value.
 		await page.click( '.editor-post-text-editor' );
+		await pressKeyWithModifier( 'primary', 'A' );
+		await page.keyboard.press( 'ArrowRight' );
 		await page.keyboard.press( 'Enter' );
 		await switchEditorModeTo( 'Visual' );
 	};


### PR DESCRIPTION
## Description
Fixes: https://github.com/WordPress/gutenberg/issues/19732

There was a visual bug where the editor kept a side space even if the sidebar was collapsed. The bug only happened at windows whose side is exactly 960px.
This PR addresses this issue by summing one pixel to a problematic media query rule we had.

## How has this been tested?
I created a new post.
I made the window size exactly equal to 960px.
I verified there was no side space at the side of the screen.