### PR TITLE
Update hover and focus selectors for Move to Trash to ensure the link is always red

### DIFF
--- a/packages/editor/src/components/post-trash/style.scss
+++ b/packages/editor/src/components/post-trash/style.scss
@@ -3,8 +3,8 @@
 	border-color: darken($alert-red, 15%);
 	justify-content: center;
 
-	&:hover,
-	&:focus {
+	&:not(:disabled):not([aria-disabled="true"]):hover,
+	&:not([aria-disabled="true"]):focus {
 		color: darken($alert-red, 20%);
 		border-color: darken($alert-red, 20%);
 	}


### PR DESCRIPTION
Fixes: #19841

## Description
Due to the specificity of the `:hover` and `:focus` selectors [in the button component](https://github.com/wordpress/gutenberg/blob/06f02c96efcf27c4d2c348ca3abe08d08ca5f51d/packages/components/src/button/style.scss#L151), the post trash button was displaying as blue instead of red when hovered over or tabbed to via keyboard. This change updates the selectors in `.editor-post-trash` to use similar specificity as `.components-button.is-link` for the hover and focus states to ensure that they are always red.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Manually test by:

* Go to an existing post and from the Document tab in the sidebar hover over the `Move to Trash` button. It should be red (slightly darker than the default color).
* Tab through elements using the keyboard <kbd>tab</kbd> button. When the `Move to Trash` button is active, it also should be red.

## Screenshots <!-- if applicable -->

![image](https://user-images.githubusercontent.com/14988353/73498900-b160f980-4362-11ea-8c0a-71d4a2c69558.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] ~My code is tested.~
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] ~My code has proper inline documentation.~ <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] ~I've included developer documentation if appropriate.~ <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] ~I've updated all React Native files affected by any refactorings/renamings in this PR.~ <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
