### PR TITLE
[RNMobile] - test break tags removal

### DIFF
--- a/packages/rich-text/src/component/test/index.native.js
+++ b/packages/rich-text/src/component/test/index.native.js
@@ -30,4 +30,41 @@ describe( 'RichText Native', () => {
 			expect( richText.willTrimSpaces( html ) ).toBe( false );
 		} );
 	} );
+
+	describe( 'countBreaksBeforeParagraphTag', () => {
+		it( 'exists', () => {
+			expect( richText ).toHaveProperty( 'countBreaksBeforeParagraphTag' );
+		} );
+
+		it( 'is a function', () => {
+			expect( richText.countBreaksBeforeParagraphTag ).toBeInstanceOf( Function );
+		} );
+
+		it( 'Counts zero breaks when no breaks are in the text', () => {
+			const html = '<p><b>Hello</b> <strong>Hello</strong> WorldWorld! </p>';
+			expect( richText.countBreaksBeforeParagraphTag( html ) ).toBe( 0 );
+		} );
+
+		it( 'Counts zero breaks when breaks precede a non paragraph tag', () => {
+			const html = '<pre><b>Hello</b> <strong>Hello</strong> WorldWorld!<br></pre>';
+			expect( richText.countBreaksBeforeParagraphTag( html ) ).toBe( 0 );
+		} );
+
+		it( 'Counts zero breaks when no break is not directly in front of ending paragraph tag', () => {
+			const html = '<p><b>Hello</b> <br><strong>Hello</strong> WorldWorld!<br><br> </p>';
+			expect( richText.countBreaksBeforeParagraphTag( html ) ).toBe( 0 );
+		} );
+
+		it( 'Counts one break tag preceding the ending paragraph tag', () => {
+			const html = '<p><b>Hello</b> <strong>Hello</strong> WorldWorld!<br></p>';
+			expect( richText.countBreaksBeforeParagraphTag( html ) ).toBe( 1 );
+		} );
+
+		it( 'Counts multiple break tags preceding the ending paragraph tag', () => {
+			const html = '<p><b>Hello</b> <strong>Hello</strong> WorldWorld!<br><br><br></p>';
+			expect( richText.countBreaksBeforeParagraphTag( html ) ).toBe( 3 );
+		} );
+
+	} );
+
 } );


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
Fixes part of https://github.com/wordpress-mobile/gutenberg-mobile/issues/1543 addressing some comments from here: https://github.com/WordPress/gutenberg/pull/18138#pullrequestreview-308836159

This changes adds more visibility into selection adjustments that we are making in gutenberg mobile code to ensure compatibility with react-native-aztec.

The code tested in this change is related to addressing a crash that was surfaced by the WordPressAndroid app which is using this code: https://github.com/wordpress-mobile/WordPress-Android/issues/9832

## How has this been tested?
Tested using steps from the [PR](https://github.com/wordpress-mobile/gutenberg-mobile/pull/1507) that originally added this code:

1. Create a post on Gutenberg web with a para block that ends with one or more empty line(s) (Shift+Enter)
2. Open this new post in GB mobile
3. Tap on the Plus symbol to add a new block below the para
4. Put the focus into this new block and taps on Backspace to merge this new block with the one above.
5. It should not crash, and the 2 blocks merged, with the caret at the end of the block

Also you can run the new tests using the following:
`yarn test gutenberg/packages/rich-text/src/component/test/index.native.js`

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
This change is only introducing some new unit tests and a small refactor to accommodate those tests. 


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
