### PR TITLE
Block Styles: Remove the block margin in the style selector

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -19,6 +19,9 @@
 	}
 }
 
+.block-editor-block-styles .editor-styles-wrapper .block-editor-block-list__block {
+	margin: 0;
+}
 
 /**
  * General Post Content Layout

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -19,6 +19,8 @@
 	}
 }
 
+// This remove the margins set here: https://github.com/WordPress/gutenberg/blob/17e5c2d870d84fb6de48dcd5bc3c38cd0c0fb0d0/packages/block-library/src/editor.scss#L56
+// It removes the margins around blocks when a BlockPreview is rendered in the block style selector
 .block-editor-block-styles .editor-styles-wrapper .block-editor-block-list__block {
 	margin: 0;
 }


### PR DESCRIPTION
## Description
This removes margins on the block preview when used in the styles selector.

This is being added here: https://github.com/WordPress/gutenberg/blob/17e5c2d870d84fb6de48dcd5bc3c38cd0c0fb0d0/packages/block-library/src/editor.scss#L56

but it doesn't make much sense for previews in the block style selector.

## How has this been tested?
In chrome

## Screenshots <!-- if applicable -->
Before:
<img width="297" alt="Screenshot 2020-01-31 at 15 29 40" src="https://user-images.githubusercontent.com/275961/73553383-c5c7f380-4441-11ea-8206-069f712a9866.png">

After:
<img width="288" alt="Screenshot 2020-01-31 at 15 38 29" src="https://user-images.githubusercontent.com/275961/73553388-cbbdd480-4441-11ea-9e59-9ab3741feb98.png">


## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
