### PR TITLE
Block Previews: dynamic preview size

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19502,7 +19502,7 @@
 				},
 				"node-pre-gyp": {
 					"version": "0.12.0",
-					"resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz",
+					"resolved": false,
 					"integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
 					"dev": true,
 					"optional": true,
@@ -19521,7 +19521,7 @@
 				},
 				"nopt": {
 					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
 					"dev": true,
 					"optional": true,
@@ -27294,7 +27294,7 @@
 			"dependencies": {
 				"clone-deep": {
 					"version": "0.2.4",
-					"resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
+					"resolved": "http://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
 					"integrity": "sha1-TnPdCen7lxzDhnDF3O2cGJZIHMY=",
 					"dev": true,
 					"requires": {
@@ -27328,7 +27328,7 @@
 					"dependencies": {
 						"kind-of": {
 							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+							"resolved": "http://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
 							"integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
 							"dev": true,
 							"requires": {

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -251,6 +251,7 @@ export class InserterMenu extends Component {
 			! isEmpty( itemsPerCollection );
 		const hoveredItemBlockType = hoveredItem ? getBlockType( hoveredItem.name ) : null;
 		const hasHelpPanel = hasItems && showInserterHelpPanel;
+		const viewportWidth = ( hoveredItemBlockType && hoveredItemBlockType.example && hoveredItemBlockType.example.viewportWidth ) ? hoveredItemBlockType.example.viewportWidth : 500;
 
 		// Disable reason (no-autofocus): The inserter menu is a modal display, not one which
 		// is always visible, and one which already incurs this behavior of autoFocus via
@@ -416,7 +417,7 @@ export class InserterMenu extends Component {
 										<div className="block-editor-inserter__preview-content">
 											<BlockPreview
 												padding={ 10 }
-												viewportWidth={ 500 }
+												viewportWidth={ viewportWidth }
 												blocks={
 													hoveredItemBlockType.example
 														? getBlockFromExample( hoveredItem.name, {

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -1,7 +1,18 @@
 /**
  * External dependencies
  */
-import { filter, findIndex, flow, get, groupBy, isEmpty, map, sortBy, without, includes } from 'lodash';
+import {
+	filter,
+	findIndex,
+	flow,
+	get,
+	groupBy,
+	isEmpty,
+	map,
+	sortBy,
+	without,
+	includes,
+} from 'lodash';
 import scrollIntoView from 'dom-scroll-into-view';
 import classnames from 'classnames';
 
@@ -251,7 +262,7 @@ export class InserterMenu extends Component {
 			! isEmpty( itemsPerCollection );
 		const hoveredItemBlockType = hoveredItem ? getBlockType( hoveredItem.name ) : null;
 		const hasHelpPanel = hasItems && showInserterHelpPanel;
-		const viewportWidth = get( hoveredItemBlockType, 'example.viewportWidth', 500);
+		const viewportWidth = get( hoveredItemBlockType, 'example.viewportWidth', 500 );
 
 		// Disable reason (no-autofocus): The inserter menu is a modal display, not one which
 		// is always visible, and one which already incurs this behavior of autoFocus via

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -251,7 +251,12 @@ export class InserterMenu extends Component {
 			! isEmpty( itemsPerCollection );
 		const hoveredItemBlockType = hoveredItem ? getBlockType( hoveredItem.name ) : null;
 		const hasHelpPanel = hasItems && showInserterHelpPanel;
-		const viewportWidth = ( hoveredItemBlockType && hoveredItemBlockType.example && hoveredItemBlockType.example.viewportWidth ) ? hoveredItemBlockType.example.viewportWidth : 500;
+		const viewportWidth =
+			hoveredItemBlockType &&
+			hoveredItemBlockType.example &&
+			hoveredItemBlockType.example.viewportWidth
+				? hoveredItemBlockType.example.viewportWidth
+				: 500;
 
 		// Disable reason (no-autofocus): The inserter menu is a modal display, not one which
 		// is always visible, and one which already incurs this behavior of autoFocus via

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { filter, findIndex, flow, groupBy, isEmpty, map, sortBy, without, includes } from 'lodash';
+import { filter, findIndex, flow, get, groupBy, isEmpty, map, sortBy, without, includes } from 'lodash';
 import scrollIntoView from 'dom-scroll-into-view';
 import classnames from 'classnames';
 
@@ -251,12 +251,7 @@ export class InserterMenu extends Component {
 			! isEmpty( itemsPerCollection );
 		const hoveredItemBlockType = hoveredItem ? getBlockType( hoveredItem.name ) : null;
 		const hasHelpPanel = hasItems && showInserterHelpPanel;
-		const viewportWidth =
-			hoveredItemBlockType &&
-			hoveredItemBlockType.example &&
-			hoveredItemBlockType.example.viewportWidth
-				? hoveredItemBlockType.example.viewportWidth
-				: 500;
+		const viewportWidth = get( hoveredItemBlockType, 'example.viewportWidth', 500);
 
 		// Disable reason (no-autofocus): The inserter menu is a modal display, not one which
 		// is always visible, and one which already incurs this behavior of autoFocus via


### PR DESCRIPTION
## Description
This allows block to specify the viewport width for their example. This is useful because some block previews look better at smaller viewport sizes.

## How has this been tested?
In chrome.

## Screenshots <!-- if applicable -->
Before:
<img width="292" alt="Screenshot 2020-01-31 at 17 06 52" src="https://user-images.githubusercontent.com/275961/73558967-19d7d580-444c-11ea-8bfc-11b4569ac102.png">

After:
<img width="302" alt="Screenshot 2020-01-31 at 17 03 44" src="https://user-images.githubusercontent.com/275961/73558978-1fcdb680-444c-11ea-87ec-30e91db1ff46.png">


## Types of changes
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
