### PR TITLE
Lib: Limit `pre_render_block` extension.

### DIFF
--- a/lib/compat.php
+++ b/lib/compat.php
@@ -45,7 +45,7 @@ add_filter( 'safe_style_css', 'gutenberg_safe_style_css_column_flex_basis' );
 function gutenberg_provide_render_callback_with_block_object( $pre_render, $block ) {
 	global $post;
 	if ( 'core/navigation' !== $block['blockName'] ) {
-		return null;
+		return $pre_render;
 	}
 
 	$source_block = $block;

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -44,6 +44,9 @@ add_filter( 'safe_style_css', 'gutenberg_safe_style_css_column_flex_basis' );
  */
 function gutenberg_provide_render_callback_with_block_object( $pre_render, $block ) {
 	global $post;
+	if ( 'core/navigation' !== $block['blockName'] ) {
+		return null;
+	}
 
 	$source_block = $block;
 


### PR DESCRIPTION
This PR limits the extension made for the Navigation block to blocks' `render_callback`s to the navigation block only. This is done by bailing out of hijacking `render_block` in `pre_render_block` if any block name other than `core/navigation` is used.

The extension needed for the current Navigation block is not something we want to have in Core now that 5.4 is approaching, and the overall approach needs to be refactored to align with #19685 due to the issues outlined there.