### PR TITLE
Block Library: Navigation: Remove title attribute from navigation link

### DIFF
--- a/packages/block-library/src/navigation-link/block.json
+++ b/packages/block-library/src/navigation-link/block.json
@@ -9,9 +9,6 @@
 			"type": "boolean",
 			"default": false
 		},
-		"title": {
-			"type": "string"
-		},
 		"type": {
 			"type": "string"
 		},

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { escape, unescape, head } from 'lodash';
+import { escape, head } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -16,7 +16,6 @@ import {
 	PanelBody,
 	Popover,
 	TextareaControl,
-	TextControl,
 	ToggleControl,
 	ToolbarButton,
 	ToolbarGroup,
@@ -48,14 +47,7 @@ function NavigationLinkEdit( {
 	insertLinkBlock,
 	navigationBlockAttributes,
 } ) {
-	const {
-		label,
-		opensInNewTab,
-		title,
-		url,
-		nofollow,
-		description,
-	} = attributes;
+	const { label, opensInNewTab, url, nofollow, description } = attributes;
 
 	/*
 	 * Navigation Block attributes.
@@ -68,7 +60,6 @@ function NavigationLinkEdit( {
 	} = navigationBlockAttributes;
 
 	const link = {
-		title: title ? unescape( title ) : '',
 		url,
 		opensInNewTab,
 	};
@@ -157,16 +148,6 @@ function NavigationLinkEdit( {
 			</BlockControls>
 			<InspectorControls>
 				<PanelBody title={ __( 'SEO settings' ) }>
-					<TextControl
-						value={ title || '' }
-						onChange={ ( titleValue ) => {
-							setAttributes( { title: titleValue } );
-						} }
-						label={ __( 'Title Attribute' ) }
-						help={ __(
-							'Provide more context about where the link goes.'
-						) }
-					/>
 					<ToggleControl
 						checked={ nofollow }
 						onChange={ ( nofollowValue ) => {
@@ -258,7 +239,6 @@ function NavigationLinkEdit( {
 									id,
 								} = {} ) =>
 									setAttributes( {
-										title: escape( newTitle ),
 										url: encodeURI( newURL ),
 										label: ( () => {
 											const normalizedTitle = newTitle.replace(

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -113,7 +113,6 @@ function Navigation( {
 				label: ! title.rendered
 					? __( '(no title)' )
 					: escape( title.rendered ),
-				title: ! title.raw ? __( '(no title)' ) : escape( title.raw ),
 				opensInNewTab: false,
 			} )
 		);

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -195,9 +195,6 @@ function core_block_navigation_build_html( $attributes, $block, $colors, $font_s
 		if ( isset( $block['attrs']['url'] ) ) {
 			$html .= ' href="' . esc_url( $block['attrs']['url'] ) . '"';
 		}
-		if ( isset( $block['attrs']['title'] ) ) {
-			$html .= ' title="' . esc_attr( $block['attrs']['title'] ) . '"';
-		}
 
 		if ( isset( $block['attrs']['opensInNewTab'] ) && true === $block['attrs']['opensInNewTab'] ) {
 			$html .= ' target="_blank"  ';

--- a/packages/e2e-tests/specs/editor/blocks/__snapshots__/navigation.test.js.snap
+++ b/packages/e2e-tests/specs/editor/blocks/__snapshots__/navigation.test.js.snap
@@ -2,18 +2,18 @@
 
 exports[`Navigation allows a navigation menu to be created from an empty menu using a mixture of internal and external links 1`] = `
 "<!-- wp:navigation -->
-<!-- wp:navigation-link {\\"label\\":\\"WP\\",\\"title\\":\\"https://wordpress.org\\",\\"id\\":\\"-1\\",\\"url\\":\\"https://wordpress.org\\"} /-->
+<!-- wp:navigation-link {\\"label\\":\\"WP\\",\\"id\\":\\"-1\\",\\"url\\":\\"https://wordpress.org\\"} /-->
 
-<!-- wp:navigation-link {\\"label\\":\\"Get in touch\\",\\"title\\":\\"Contact Us\\",\\"id\\":1,\\"url\\":\\"https://this/is/a/test/url/contact-us\\"} /-->
+<!-- wp:navigation-link {\\"label\\":\\"Get in touch\\",\\"id\\":1,\\"url\\":\\"https://this/is/a/test/url/contact-us\\"} /-->
 <!-- /wp:navigation -->"
 `;
 
 exports[`Navigation allows a navigation menu to be created using existing pages 1`] = `
 "<!-- wp:navigation -->
-<!-- wp:navigation-link {\\"label\\":\\"Home\\",\\"title\\":\\"Home\\",\\"type\\":\\"page\\",\\"id\\":1,\\"url\\":\\"https://this/is/a/test/url/home\\"} /-->
+<!-- wp:navigation-link {\\"label\\":\\"Home\\",\\"type\\":\\"page\\",\\"id\\":1,\\"url\\":\\"https://this/is/a/test/url/home\\"} /-->
 
-<!-- wp:navigation-link {\\"label\\":\\"About\\",\\"title\\":\\"About\\",\\"type\\":\\"page\\",\\"id\\":2,\\"url\\":\\"https://this/is/a/test/url/about\\"} /-->
+<!-- wp:navigation-link {\\"label\\":\\"About\\",\\"type\\":\\"page\\",\\"id\\":2,\\"url\\":\\"https://this/is/a/test/url/about\\"} /-->
 
-<!-- wp:navigation-link {\\"label\\":\\"Contact Us\\",\\"title\\":\\"Contact Us\\",\\"type\\":\\"page\\",\\"id\\":3,\\"url\\":\\"https://this/is/a/test/url/contact\\"} /-->
+<!-- wp:navigation-link {\\"label\\":\\"Contact Us\\",\\"type\\":\\"page\\",\\"id\\":3,\\"url\\":\\"https://this/is/a/test/url/contact\\"} /-->
 <!-- /wp:navigation -->"
 `;


### PR DESCRIPTION
Previously: #19735, #17352, #19462 (comment), #19490 (comment), #616

This pull request seeks to remove the `title` attribute from the Navigation Link block.

For more context, refer to #19735, which includes additional resources for why we should be avoiding the `title` attribute for links.

Note: To disambiguate, the Navigation Link block will still handle a `title` from a suggestion in the `LinkControl` input that it renders. From what I can tell, this is used to assign a default text label of the link. I expect that `LinkControl` will still continue to offer a `title` value when the selected link changes. This is consistent from what is reported by the [search results endpoint](https://developer.wordpress.org/rest-api/reference/search-results/) and can be useful for these sorts of scenarios in using e.g. a post title. This is not to be confused with the [`title` HTML attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/title), which we should seek to avoid for `a` anchor tags.

There is not expected to need to be a deprecation here, since the title was used in the dynamic server-side rendering and not in the saved static markup of the block.

**Testing Instructions:**

Verify that there are no regressions in creating, saving, and previewing a post containing a Navigation and Navigation Link block:

1. Navigate to Posts > Add New
2. Insert a Navigation block
3. Click the "Create empty" button
4. Add a link
5. Save and preview the post
6. Verify that the navigation and navigation link are shown correctly