### PR TITLE
Fix className attributes rendering for navigation/navigation link block

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -194,7 +194,14 @@ function NavigationLinkEdit( {
 					backgroundColor: rgbBackgroundColor,
 				} }
 			>
-				<div className="wp-block-navigation-link__content">
+				<div
+					className={ classnames(
+						'wp-block-navigation-link__content',
+						{
+							[ attributes.className ]: attributes.className,
+						}
+					) }
+				>
 					<RichText
 						ref={ ref }
 						tagName="span"

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -138,6 +138,7 @@ function Navigation( {
 	const blockClassNames = classnames( className, {
 		[ `items-justification-${ attributes.itemsJustification }` ]: attributes.itemsJustification,
 		[ fontSize.class ]: fontSize.class,
+		[ attributes.className ]: attributes.className,
 	} );
 	const blockInlineStyles = {
 		fontSize: fontSize.size ? fontSize.size + 'px' : undefined,

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -194,7 +194,8 @@ function core_block_navigation_build_html( $attributes, $block, $colors, $font_s
 	$html            = '';
 	$classes         = array_merge(
 		$colors['css_classes'],
-		$font_sizes['css_classes']
+		$font_sizes['css_classes'],
+		isset( $block['attrs']['className'] ) ? array( $block['attrs']['className'] ) : array()
 	);
 	$classes[]       = 'wp-block-navigation-link';
 	$css_classes     = trim( implode( ' ', $classes ) );


### PR DESCRIPTION
## Description
This PR addresses an issue described in https://github.com/WordPress/gutenberg/issues/19858
Both blocks support setting additional class in block settings, but the className is not applied as it should be.

I've added rendering of `attributes.className` for navigation block in editor environment and I've added rendering of those attributes for navigation link in both editor and front end.

## How has this been tested?
Manually. I added classes: `navi-class`, `first-level-class`, `second-level-class` in navigation and navigation link blocks. See the results in screenshots.

### Rendering in the editor
<img width="910" alt="Screenshot 2020-02-02 at 09 30 13" src="https://user-images.githubusercontent.com/1082140/73605485-36385700-459f-11ea-8419-27af222d3aac.png">

### Rendering in page
<img width="784" alt="Screenshot 2020-02-02 at 09 31 55" src="https://user-images.githubusercontent.com/1082140/73605497-4d774480-459f-11ea-8039-fb53773e65be.png">

## Types of changes
This PR contains only additions to rendered outputs.

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
