### PR TITLE
Update/modal component

### DIFF
--- a/packages/components/src/modal/README.md
+++ b/packages/components/src/modal/README.md
@@ -195,11 +195,13 @@ If this property is added, it will be added to the modal content `div` as `aria-
 
 #### focusOnMount
 
-If this property is true, it will focus the first tabbable element rendered in the modal.
+By default, the *first tabblable element* in the modal will receive focus when it mounts. This is the same as setting `focusOnMount` to `"firstElement"`. If you want to focus the container instead, you can set `focusOnMount` to `"container"` or true.
 
--   Type: `boolean`
--   Required: No
--   Default: true
+Set this prop to `false` to not focus on mount.
+
+- Type: `String` or `Boolean`
+- Required: No
+- Default: `firstElement`
 
 #### shouldCloseOnEsc
 

--- a/packages/components/src/modal/frame.js
+++ b/packages/components/src/modal/frame.js
@@ -78,6 +78,46 @@ class ModalFrame extends Component {
 	constructor() {
 		super( ...arguments );
 		this.handleFocusOutside = this.handleFocusOutside.bind( this );
+<<<<<<< HEAD
+=======
+		this.focusFirstTabbable = this.focusFirstTabbable.bind( this );
+		this.focusOnMount = this.focusOnMount.bind( this );
+	}
+
+	/**
+	 * Focuses the container or first tabbable element based on props.focusOnMount.
+	 */
+	componentDidMount() {
+		// Focus on mount
+		if ( this.props.focusOnMount ) {
+			this.focusOnMount();
+		}
+	}
+
+	/**
+	 * Handle focus on mount.
+	 */
+
+	focusOnMount() {
+		if ( this.props.focusOnMount === 'firstElement' ) {
+			this.focusFirstTabbable();
+		} else {
+			this.containerRef.current.focus();
+		}			
+	}
+
+	/**
+	 * Focuses the first tabbable element.
+	 */
+	focusFirstTabbable() {
+		const tabbables = focus.tabbable.find( this.containerRef.current );
+		if ( tabbables.length ) {
+			tabbables[ 0 ].focus();
+		} else {
+			this.containerRef.current.focus();
+		}
+		return true;
+>>>>>>> 93e0cff0be (Allow the focusOnMount prop to be either boolean or string)
 	}
 
 	/**

--- a/packages/components/src/modal/frame.js
+++ b/packages/components/src/modal/frame.js
@@ -100,7 +100,8 @@ class ModalFrame extends Component {
 	focusOnMount() {
 		if ( this.props.focusOnMount === 'firstElement' ) {
 			this.focusFirstTabbable();
-		} else {
+		}
+		if ( this.props.focusOnMount === 'container' || this.props.focusOnMount === true ) {
 			this.containerRef.current.focus();
 		}
 	}

--- a/packages/components/src/modal/frame.js
+++ b/packages/components/src/modal/frame.js
@@ -97,7 +97,6 @@ class ModalFrame extends Component {
 	/**
 	 * Handle focus on mount.
 	 */
-
 	focusOnMount() {
 		if ( this.props.focusOnMount === 'firstElement' ) {
 			this.focusFirstTabbable();

--- a/packages/components/src/modal/frame.js
+++ b/packages/components/src/modal/frame.js
@@ -103,7 +103,7 @@ class ModalFrame extends Component {
 			this.focusFirstTabbable();
 		} else {
 			this.containerRef.current.focus();
-		}			
+		}
 	}
 
 	/**
@@ -116,8 +116,11 @@ class ModalFrame extends Component {
 		} else {
 			this.containerRef.current.focus();
 		}
+<<<<<<< HEAD
 		return true;
 >>>>>>> 93e0cff0be (Allow the focusOnMount prop to be either boolean or string)
+=======
+>>>>>>> d44204c5c8 (Remove added return from focusFirstTabbable)
 	}
 
 	/**

--- a/packages/components/src/modal/frame.js
+++ b/packages/components/src/modal/frame.js
@@ -101,7 +101,10 @@ class ModalFrame extends Component {
 		if ( this.props.focusOnMount === 'firstElement' ) {
 			this.focusFirstTabbable();
 		}
-		if ( this.props.focusOnMount === 'container' || this.props.focusOnMount === true ) {
+		if (
+			this.props.focusOnMount === 'container' ||
+			this.props.focusOnMount === true
+		) {
 			this.containerRef.current.focus();
 		}
 	}

--- a/packages/components/src/modal/index.js
+++ b/packages/components/src/modal/index.js
@@ -159,7 +159,7 @@ Modal.defaultProps = {
 	bodyOpenClassName: 'modal-open',
 	role: 'dialog',
 	title: null,
-	focusOnMount: true,
+	focusOnMount: 'firstElement',
 	shouldCloseOnEsc: true,
 	shouldCloseOnClickOutside: true,
 	isDismissible: true,

--- a/packages/components/src/modal/stories/index.js
+++ b/packages/components/src/modal/stories/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { boolean, text } from '@storybook/addon-knobs';
+import { boolean, text, select } from '@storybook/addon-knobs';
 
 /**
  * Internal dependencies
@@ -42,7 +42,12 @@ export const _default = () => {
 	const title = text( 'title', 'Title' );
 	const icon = text( 'icon', '' );
 	const isDismissible = boolean( 'isDismissible', true );
-	const focusOnMount = boolean( 'focusOnMount', true );
+	const focusOnMount = select( 'focusOnMount', {
+		firstElement: 'firstElement',
+		container: 'container',
+		true: true,
+		false: false,
+	} );
 	const shouldCloseOnEsc = boolean( 'shouldCloseOnEsc', true );
 	const shouldCloseOnClickOutside = boolean(
 		'shouldCloseOnClickOutside',


### PR DESCRIPTION
## Description
This pull request is related to #7698. 
Updated focusOnMount prop so it can be defined as string or boolean. If "firstElement"  is set as value, the first tabbable element will be focused. If any other truthy value is set, then the container will be focused.

## How has this been tested?
I will create another pull request with changes to the component stories. It covers possible values to the prop. 

## Checklist:
- [:x:  ] My code is tested.
- [ :x: ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ :x: ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ :x: ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->