### PR TITLE
Defer removal of iFrames on paste until transform stage, and only rem…

### DIFF
--- a/packages/blocks/src/api/raw-handling/iframe-remover.js
+++ b/packages/blocks/src/api/raw-handling/iframe-remover.js
@@ -17,11 +17,15 @@ export default function( node ) {
 }
 
 export function checkForUntransformedIframe( rawTransform, node ) {
-	const frameRegex = /(?:<iframe[^>]*)(?:(?:\/>)|(?:>.*?<\/iframe>))/gi;
+	const iframeRegex = /(?:<iframe[^>]*)(?:(?:\/>)|(?:>.*?<\/iframe>))/gi;
+
 	return (
-		rawTransform &&
-		node.nodeName === 'FIGURE' &&
-		rawTransform.blockName === 'core/html' &&
-		frameRegex.exec( node.innerHTML )
+		( ! rawTransform &&
+			( node.nodeName === 'IFRAME' ||
+				iframeRegex.test( node.innerHTML ) ) ) ||
+		( rawTransform &&
+			node.nodeName === 'FIGURE' &&
+			rawTransform.blockName === 'core/html' &&
+			iframeRegex.test( node.innerHTML ) )
 	);
 }

--- a/packages/blocks/src/api/raw-handling/iframe-remover.js
+++ b/packages/blocks/src/api/raw-handling/iframe-remover.js
@@ -20,7 +20,8 @@ export function checkForUntransformedIframe( rawTransform, node ) {
 	const frameRegex = /(?:<iframe[^>]*)(?:(?:\/>)|(?:>.*?<\/iframe>))/gi;
 	return (
 		rawTransform &&
-		frameRegex.exec( node.innerHTML ) &&
-		rawTransform.blockName === 'core/html'
+		node.nodeName === 'FIGURE' &&
+		rawTransform.blockName === 'core/html' &&
+		frameRegex.exec( node.innerHTML )
 	);
 }

--- a/packages/blocks/src/api/raw-handling/iframe-remover.js
+++ b/packages/blocks/src/api/raw-handling/iframe-remover.js
@@ -16,16 +16,28 @@ export default function( node ) {
 	}
 }
 
-export function checkForUntransformedIframe( rawTransform, node ) {
+export function isUntransformedIframe( rawTransform, node ) {
 	const iframeRegex = /(?:<iframe[^>]*)(?:(?:\/>)|(?:>.*?<\/iframe>))/gi;
 
 	return (
-		( ! rawTransform &&
-			( node.nodeName === 'IFRAME' ||
-				iframeRegex.test( node.innerHTML ) ) ) ||
+		( ! rawTransform && containsIframe( node, iframeRegex ) ) ||
 		( rawTransform &&
-			node.nodeName === 'FIGURE' &&
-			rawTransform.blockName === 'core/html' &&
-			iframeRegex.test( node.innerHTML ) )
+			containsCoreHtmlIframeTransform(
+				node,
+				rawTransform.blockName,
+				iframeRegex
+			) )
+	);
+}
+
+function containsIframe( node, iframeRegex ) {
+	return node.nodeName === 'IFRAME' || iframeRegex.test( node.innerHTML );
+}
+
+function containsCoreHtmlIframeTransform( node, blockName, iframeRegex ) {
+	return (
+		node.nodeName === 'FIGURE' &&
+		blockName === 'core/html' &&
+		iframeRegex.test( node.innerHTML )
 	);
 }

--- a/packages/blocks/src/api/raw-handling/iframe-remover.js
+++ b/packages/blocks/src/api/raw-handling/iframe-remover.js
@@ -15,3 +15,12 @@ export default function( node ) {
 		remove( node );
 	}
 }
+
+export function checkForUntransformedIframe( rawTransform, node ) {
+	const frameRegex = /(?:<iframe[^>]*)(?:(?:\/>)|(?:>.*?<\/iframe>))/gi;
+	return (
+		rawTransform &&
+		frameRegex.exec( node.innerHTML ) &&
+		rawTransform.blockName === 'core/html'
+	);
+}

--- a/packages/blocks/src/api/raw-handling/paste-handler.js
+++ b/packages/blocks/src/api/raw-handling/paste-handler.js
@@ -111,7 +111,7 @@ function htmlToBlocks( { html, rawTransforms, canUserUseUnfilteredHTML } ) {
 		}
 
 		if (
-			canUserUseUnfilteredHTML &&
+			! canUserUseUnfilteredHTML &&
 			checkForUntransformedIframe( rawTransform, node )
 		) {
 			return [];

--- a/packages/blocks/src/api/raw-handling/paste-handler.js
+++ b/packages/blocks/src/api/raw-handling/paste-handler.js
@@ -23,7 +23,7 @@ import blockquoteNormaliser from './blockquote-normaliser';
 import figureContentReducer from './figure-content-reducer';
 import shortcodeConverter from './shortcode-converter';
 import markdownConverter from './markdown-converter';
-import { checkForUntransformedIframe } from './iframe-remover';
+import { isUntransformedIframe } from './iframe-remover';
 import googleDocsUIDRemover from './google-docs-uid-remover';
 import htmlFormattingRemover from './html-formatting-remover';
 import brRemover from './br-remover';
@@ -110,7 +110,7 @@ export function htmlToBlocks( {
 
 			if (
 				! canUserUseUnfilteredHTML &&
-				checkForUntransformedIframe( rawTransform, node )
+				isUntransformedIframe( rawTransform, node )
 			) {
 				return undefined;
 			}

--- a/packages/blocks/src/api/raw-handling/test/figure-content-reducer.js
+++ b/packages/blocks/src/api/raw-handling/test/figure-content-reducer.js
@@ -9,6 +9,7 @@ describe( 'figureContentReducer', () => {
 		figure: {
 			children: {
 				img: {},
+				iframe: {},
 				a: {
 					children: {
 						img: {},
@@ -21,6 +22,15 @@ describe( 'figureContentReducer', () => {
 	it( 'should wrap image in figure', () => {
 		const input = '<img>';
 		const output = '<figure><img></figure>';
+
+		expect(
+			deepFilterHTML( input, [ figureContentReducer ], schema )
+		).toEqual( output );
+	} );
+
+	it( 'should wrap iframe in figure', () => {
+		const input = '<iframe></iframe>';
+		const output = '<figure><iframe></iframe></figure>';
 
 		expect(
 			deepFilterHTML( input, [ figureContentReducer ], schema )

--- a/packages/blocks/src/api/raw-handling/test/paste-handler.js
+++ b/packages/blocks/src/api/raw-handling/test/paste-handler.js
@@ -1,0 +1,101 @@
+/**
+ * Internal dependencies
+ */
+
+import { htmlToBlocks } from '../paste-handler';
+import * as factory from '../../factory';
+import * as parser from '../../parser';
+
+let rawTransforms;
+
+describe( 'htmlToBlocks', () => {
+	beforeEach( () => {
+		factory.createBlock = jest.fn( () => ( { name: 'core/html-block' } ) );
+		parser.getBlockAttributes = jest.fn( () => ( {} ) );
+		const iframeRegex = /<iframe>Custom Embed Block<\/iframe>/gi;
+		rawTransforms = [
+			{
+				type: 'raw',
+				isMatch: ( node ) =>
+					node.nodeName === 'FIGURE' &&
+					iframeRegex.test( node.innerHTML ),
+				blockName: 'custom/block',
+				transform: () => ( { name: 'custom/embed-block' } ),
+			},
+			{
+				type: 'raw',
+				priority: 15,
+				blockName: 'core/html',
+				isMatch: ( node ) =>
+					node.nodeName === 'FIGURE' &&
+					!! node.querySelector( 'iframe' ),
+				transform: () => ( { name: 'core/html-transform' } ),
+			},
+		];
+	} );
+
+	it( 'should remove iframe if user cannot use unfiltered html and no transform found', () => {
+		const result = htmlToBlocks( {
+			html: '<div><iframe>Unknown Embed</iframe></div>',
+			rawTransforms,
+			canUserUseUnfilteredHTML: false,
+		} );
+		expect( result ).toEqual( [] );
+	} );
+
+	it( 'should remove iframe if user cannot use unfiltered html and no transform found and iframe is root node', () => {
+		const result = htmlToBlocks( {
+			html: '<iframe>Unknown Embed</iframe>',
+			rawTransforms,
+			canUserUseUnfilteredHTML: false,
+		} );
+		expect( result ).toEqual( [] );
+	} );
+
+	it( 'should transform iframe to core/html if user can use unfiltered html and no transform found', () => {
+		const result = htmlToBlocks( {
+			html: '<div><iframe>Unknown Embed</iframe></div>',
+			rawTransforms,
+			canUserUseUnfilteredHTML: true,
+		} );
+		expect( factory.createBlock ).toHaveBeenCalledWith( 'core/html', {} );
+		expect( result ).toEqual( [ { name: 'core/html-block' } ] );
+	} );
+
+	it( 'should remove iframe if user cannot use unfiltered html and only core/html transform found', () => {
+		const result = htmlToBlocks( {
+			html: '<figure><iframe>Unknown Embed</iframe></figure>',
+			rawTransforms,
+			canUserUseUnfilteredHTML: false,
+		} );
+		expect( result ).toEqual( [] );
+	} );
+
+	it( 'should transform iframe if user cannot use unfiltered html but transform found', () => {
+		const result = htmlToBlocks( {
+			html: '<figure><iframe>Custom Embed Block</iframe></figure>',
+			rawTransforms,
+			canUserUseUnfilteredHTML: false,
+		} );
+		expect( result ).toEqual( [ { name: 'custom/embed-block' } ] );
+	} );
+
+	it( 'should transform iframe if user can use unfiltered html and transform found', () => {
+		const result = htmlToBlocks( {
+			html: '<figure><iframe>Custom Embed Block</iframe></figure>',
+			rawTransforms,
+			canUserUseUnfilteredHTML: true,
+		} );
+		expect( result ).toEqual( [ { name: 'custom/embed-block' } ] );
+	} );
+
+	it( 'should use core/html transform if user can use unfiltered html and no custom transform found', () => {
+		const result = htmlToBlocks( {
+			html: '<figure><iframe>Unknown Iframe</iframe></figure>',
+			rawTransforms,
+			canUserUseUnfilteredHTML: true,
+		} );
+		expect( factory.createBlock ).not.toHaveBeenCalled();
+		expect( result ).toEqual( [ { name: 'core/html-transform' } ] );
+	} );
+} );


### PR DESCRIPTION
A potential fix for #18389. Defers the removal of iFrames on paste until transform stage, and only removes if no custom transform

## Description

Moves the deletion of iframes in in the paste handler to the htmlToBlocks method. This allows for users without unfilteredHTML permissions to still paste iframe code that is going to be transformed to blocks anyway.

## How has this been tested?

Tested manually by pasting known and unknown iframe code into a paragraph block, and also added unit tests for the htmlToBlocks method.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.

