### PR TITLE
Block Directory: Add error messages inline.

### DIFF
--- a/packages/block-directory/src/components/downloadable-block-header/index.js
+++ b/packages/block-directory/src/components/downloadable-block-header/index.js
@@ -15,6 +15,7 @@ function DownloadableBlockHeader( {
 	title,
 	rating,
 	ratingCount,
+	isLoading,
 	onClick,
 } ) {
 	return (
@@ -45,12 +46,15 @@ function DownloadableBlockHeader( {
 			</div>
 			<Button
 				isSecondary
+				isBusy={ isLoading }
 				onClick={ ( event ) => {
 					event.preventDefault();
-					onClick();
+					if ( ! isLoading ) {
+						onClick();
+					}
 				} }
 			>
-				{ __( 'Add block' ) }
+				{ isLoading ? __( 'Adding…' ) : __( 'Add block' ) }
 			</Button>
 		</div>
 	);

--- a/packages/block-directory/src/components/downloadable-block-header/index.js
+++ b/packages/block-directory/src/components/downloadable-block-header/index.js
@@ -1,8 +1,9 @@
 /**
  * WordPress dependencies
  */
-import { Button } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
+import { Button } from '@wordpress/components';
+import { withSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -10,7 +11,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { BlockIcon } from '@wordpress/block-editor';
 import BlockRatings from '../block-ratings';
 
-function DownloadableBlockHeader( {
+export function DownloadableBlockHeader( {
 	icon,
 	title,
 	rating,
@@ -60,4 +61,8 @@ function DownloadableBlockHeader( {
 	);
 }
 
-export default DownloadableBlockHeader;
+export default withSelect( ( select ) => {
+	return {
+		isLoading: select( 'core/block-directory' ).isInstalling(),
+	};
+} )( DownloadableBlockHeader );

--- a/packages/block-directory/src/components/downloadable-block-header/index.js
+++ b/packages/block-directory/src/components/downloadable-block-header/index.js
@@ -48,6 +48,7 @@ export function DownloadableBlockHeader( {
 			<Button
 				isSecondary
 				isBusy={ isLoading }
+				disabled={ isLoading }
 				onClick={ ( event ) => {
 					event.preventDefault();
 					if ( ! isLoading ) {

--- a/packages/block-directory/src/components/downloadable-block-header/test/index.js
+++ b/packages/block-directory/src/components/downloadable-block-header/test/index.js
@@ -7,6 +7,7 @@ import { shallow } from 'enzyme';
  * WordPress dependencies
  */
 import { BlockIcon } from '@wordpress/block-editor';
+import { Button } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -14,14 +15,15 @@ import { BlockIcon } from '@wordpress/block-editor';
 import DownloadableBlockHeader from '../index';
 import { pluginWithImg, pluginWithIcon } from './fixtures';
 
-const getContainer = ( { icon, title, rating, ratingCount } ) => {
+const getContainer = ( { icon, title, rating, ratingCount }, onClick = jest.fn(), isLoading = false ) => {
 	return shallow(
 		<DownloadableBlockHeader
 			icon={ icon }
-			onClick={ () => {} }
+			onClick={ onClick }
 			title={ title }
 			rating={ rating }
 			ratingCount={ ratingCount }
+			isLoading={ isLoading }
 		/>
 	);
 };
@@ -48,6 +50,30 @@ describe( 'DownloadableBlockHeader', () => {
 		test( 'should render a <BlockIcon/> component', () => {
 			const wrapper = getContainer( pluginWithIcon );
 			expect( wrapper.find( BlockIcon ) ).toHaveLength( 1 );
+		} );
+	} );
+
+	describe( 'user interaction', () => {
+		test( 'should trigger the onClick function', () => {
+			const onClickMock = jest.fn();
+			const wrapper = getContainer( pluginWithIcon, onClickMock );
+			const event = {
+				preventDefault: jest.fn(),
+			};
+			wrapper.find( Button ).simulate( 'click', event );
+			expect( onClickMock ).toHaveBeenCalledTimes( 1 );
+			expect( event.preventDefault ).toHaveBeenCalled();
+		} );
+
+		test( 'should not trigger the onClick function if loading', () => {
+			const onClickMock = jest.fn();
+			const wrapper = getContainer( pluginWithIcon, onClickMock, true );
+			const event = {
+				preventDefault: jest.fn(),
+			};
+			wrapper.find( Button ).simulate( 'click', event );
+			expect( event.preventDefault ).toHaveBeenCalled();
+			expect( onClickMock ).toHaveBeenCalledTimes( 0 );
 		} );
 	} );
 } );

--- a/packages/block-directory/src/components/downloadable-block-header/test/index.js
+++ b/packages/block-directory/src/components/downloadable-block-header/test/index.js
@@ -12,7 +12,7 @@ import { Button } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-import DownloadableBlockHeader from '../index';
+import { DownloadableBlockHeader } from '../index';
 import { pluginWithImg, pluginWithIcon } from './fixtures';
 
 const getContainer = (

--- a/packages/block-directory/src/components/downloadable-block-header/test/index.js
+++ b/packages/block-directory/src/components/downloadable-block-header/test/index.js
@@ -15,7 +15,11 @@ import { Button } from '@wordpress/components';
 import DownloadableBlockHeader from '../index';
 import { pluginWithImg, pluginWithIcon } from './fixtures';
 
-const getContainer = ( { icon, title, rating, ratingCount }, onClick = jest.fn(), isLoading = false ) => {
+const getContainer = (
+	{ icon, title, rating, ratingCount },
+	onClick = jest.fn(),
+	isLoading = false
+) => {
 	return shallow(
 		<DownloadableBlockHeader
 			icon={ icon }

--- a/packages/block-directory/src/components/downloadable-block-list-item/index.js
+++ b/packages/block-directory/src/components/downloadable-block-list-item/index.js
@@ -5,7 +5,7 @@ import DownloadableBlockHeader from '../downloadable-block-header';
 import DownloadableBlockAuthorInfo from '../downloadable-block-author-info';
 import DownloadableBlockInfo from '../downloadable-block-info';
 
-function DownloadableBlockListItem( { item, onClick } ) {
+function DownloadableBlockListItem( { item, onClick, isLoading, children } ) {
 	const {
 		icon,
 		title,
@@ -29,9 +29,11 @@ function DownloadableBlockListItem( { item, onClick } ) {
 						title={ title }
 						rating={ rating }
 						ratingCount={ ratingCount }
+						isLoading={ isLoading }
 					/>
 				</header>
 				<section className="block-directory-downloadable-block-list-item__body">
+					{ children }
 					<DownloadableBlockInfo
 						activeInstalls={ activeInstalls }
 						description={ description }

--- a/packages/block-directory/src/components/downloadable-block-list-item/index.js
+++ b/packages/block-directory/src/components/downloadable-block-list-item/index.js
@@ -1,11 +1,12 @@
 /**
  * Internal dependencies
  */
-import DownloadableBlockHeader from '../downloadable-block-header';
 import DownloadableBlockAuthorInfo from '../downloadable-block-author-info';
+import DownloadableBlockHeader from '../downloadable-block-header';
 import DownloadableBlockInfo from '../downloadable-block-info';
+import DownloadableBlockNotice from '../downloadable-block-notice';
 
-function DownloadableBlockListItem( { item, onClick, children } ) {
+function DownloadableBlockListItem( { item, onClick } ) {
 	const {
 		icon,
 		title,
@@ -32,7 +33,10 @@ function DownloadableBlockListItem( { item, onClick, children } ) {
 					/>
 				</header>
 				<section className="block-directory-downloadable-block-list-item__body">
-					{ children }
+					<DownloadableBlockNotice
+						onClick={ onClick }
+						block={ item }
+					/>
 					<DownloadableBlockInfo
 						activeInstalls={ activeInstalls }
 						description={ description }

--- a/packages/block-directory/src/components/downloadable-block-list-item/index.js
+++ b/packages/block-directory/src/components/downloadable-block-list-item/index.js
@@ -5,7 +5,7 @@ import DownloadableBlockHeader from '../downloadable-block-header';
 import DownloadableBlockAuthorInfo from '../downloadable-block-author-info';
 import DownloadableBlockInfo from '../downloadable-block-info';
 
-function DownloadableBlockListItem( { item, onClick, isLoading, children } ) {
+function DownloadableBlockListItem( { item, onClick, children } ) {
 	const {
 		icon,
 		title,
@@ -29,7 +29,6 @@ function DownloadableBlockListItem( { item, onClick, isLoading, children } ) {
 						title={ title }
 						rating={ rating }
 						ratingCount={ ratingCount }
-						isLoading={ isLoading }
 					/>
 				</header>
 				<section className="block-directory-downloadable-block-list-item__body">

--- a/packages/block-directory/src/components/downloadable-block-notice/index.js
+++ b/packages/block-directory/src/components/downloadable-block-notice/index.js
@@ -27,9 +27,9 @@ const DownloadableBlockNotice = ( { block, errorNotices, onClick } ) => {
 		<Notice
 			status="error"
 			isDismissible={ false }
-			className="block-directory-downloadable-blocks-notice"
+			className="block-directory-downloadable-blocks__notice"
 		>
-			<div className="block-directory-downloadable-blocks-notice-content">
+			<div className="block-directory-downloadable-blocks__notice-content">
 				{ copy }
 			</div>
 			<Button

--- a/packages/block-directory/src/components/downloadable-block-notice/index.js
+++ b/packages/block-directory/src/components/downloadable-block-notice/index.js
@@ -29,9 +29,9 @@ const DownloadableBlockNotice = ( { block, errorNotices, onClick } ) => {
 			isDismissible={ false }
 			className="block-directory-downloadable-blocks-notice"
 		>
-			<span className="block-directory-downloadable-blocks-notice-content">
+			<div className="block-directory-downloadable-blocks-notice-content">
 				{ copy }
-			</span>
+			</div>
 			<Button
 				isSmall
 				isPrimary

--- a/packages/block-directory/src/components/downloadable-block-notice/index.js
+++ b/packages/block-directory/src/components/downloadable-block-notice/index.js
@@ -18,17 +18,27 @@ const DownloadableBlockNotice = ( { block, errorNotices, onClick } ) => {
 	let copy = __( 'Block could not be added.' );
 
 	if ( errorNotices[ block.id ] === DOWNLOAD_ERROR_NOTICE_ID ) {
-		copy = __( 'Block could not be added. There is a problem with the block.' );
+		copy = __(
+			'Block could not be added. There is a problem with the block.'
+		);
 	}
 
 	return (
-		<Notice status="error" isDismissible={ false } className="block-directory-downloadable-blocks-notice">
+		<Notice
+			status="error"
+			isDismissible={ false }
+			className="block-directory-downloadable-blocks-notice"
+		>
 			<span className="block-directory-downloadable-blocks-notice-content">
 				{ copy }
 			</span>
-			<Button isSmall isPrimary onClick={ () => {
-				onClick( block );
-			} }>
+			<Button
+				isSmall
+				isPrimary
+				onClick={ () => {
+					onClick( block );
+				} }
+			>
 				{ __( 'Retry' ) }
 			</Button>
 		</Notice>

--- a/packages/block-directory/src/components/downloadable-block-notice/index.js
+++ b/packages/block-directory/src/components/downloadable-block-notice/index.js
@@ -1,15 +1,16 @@
 /**
  * WordPress dependencies
  */
-import { Notice, Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { Button, Notice } from '@wordpress/components';
+import { withSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import { DOWNLOAD_ERROR_NOTICE_ID } from '../../store/constants';
 
-const DownloadableBlockNotice = ( { block, errorNotices, onClick } ) => {
+export const DownloadableBlockNotice = ( { block, errorNotices, onClick } ) => {
 	if ( ! errorNotices[ block.id ] ) {
 		return null;
 	}
@@ -45,4 +46,8 @@ const DownloadableBlockNotice = ( { block, errorNotices, onClick } ) => {
 	);
 };
 
-export default DownloadableBlockNotice;
+export default withSelect( ( select ) => {
+	return {
+		errorNotices: select( 'core/block-directory' ).getErrorNotices(),
+	};
+} )( DownloadableBlockNotice );

--- a/packages/block-directory/src/components/downloadable-block-notice/index.js
+++ b/packages/block-directory/src/components/downloadable-block-notice/index.js
@@ -1,0 +1,38 @@
+/**
+ * WordPress dependencies
+ */
+import { Notice, Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { DOWNLOAD_ERROR_NOTICE_ID } from '../../store/constants';
+
+const DownloadableBlockNotice = ( { block, errorNotices, onClick } ) => {
+	if ( ! errorNotices[ block.id ] ) {
+		return null;
+	}
+
+	// A Failed install is the default error as its the first step
+	let copy = __( 'Block could not be added.' );
+
+	if ( errorNotices[ block.id ] === DOWNLOAD_ERROR_NOTICE_ID ) {
+		copy = __( 'Block could not be added. There is a problem with the block.' );
+	}
+
+	return (
+		<Notice status="error" isDismissible={ false } className="block-directory-downloadable-blocks-notice">
+			<span className="block-directory-downloadable-blocks-notice-content">
+				{ copy }
+			</span>
+			<Button isSmall isPrimary onClick={ () => {
+				onClick( block );
+			} }>
+				{ __( 'Retry' ) }
+			</Button>
+		</Notice>
+	);
+};
+
+export default DownloadableBlockNotice;

--- a/packages/block-directory/src/components/downloadable-block-notice/style.scss
+++ b/packages/block-directory/src/components/downloadable-block-notice/style.scss
@@ -4,4 +4,5 @@
 
 .block-directory-downloadable-blocks-notice-content {
 	padding-right: 12px;
+	margin-bottom: 8px;
 }

--- a/packages/block-directory/src/components/downloadable-block-notice/style.scss
+++ b/packages/block-directory/src/components/downloadable-block-notice/style.scss
@@ -1,5 +1,5 @@
 .block-directory-downloadable-blocks__notice {
-	margin: 0;
+	margin: 0 0 16px;
 }
 
 .block-directory-downloadable-blocks__notice-content {

--- a/packages/block-directory/src/components/downloadable-block-notice/style.scss
+++ b/packages/block-directory/src/components/downloadable-block-notice/style.scss
@@ -1,0 +1,7 @@
+.block-directory-downloadable-blocks-notice {
+	margin: 0;
+}
+
+.block-directory-downloadable-blocks-notice-content {
+	padding-right: 12px;
+}

--- a/packages/block-directory/src/components/downloadable-block-notice/style.scss
+++ b/packages/block-directory/src/components/downloadable-block-notice/style.scss
@@ -1,8 +1,8 @@
-.block-directory-downloadable-blocks-notice {
+.block-directory-downloadable-blocks__notice {
 	margin: 0;
 }
 
-.block-directory-downloadable-blocks-notice-content {
+.block-directory-downloadable-blocks__notice-content {
 	padding-right: 12px;
 	margin-bottom: 8px;
 }

--- a/packages/block-directory/src/components/downloadable-block-notice/test/fixtures/index.js
+++ b/packages/block-directory/src/components/downloadable-block-notice/test/fixtures/index.js
@@ -1,0 +1,3 @@
+export const plugin = {
+	id: 'boxer-block',
+};

--- a/packages/block-directory/src/components/downloadable-block-notice/test/index.js
+++ b/packages/block-directory/src/components/downloadable-block-notice/test/index.js
@@ -49,7 +49,11 @@ describe( 'DownloadableBlockNotice', () => {
 			};
 
 			const onClick = jest.fn();
-			const wrapper = getContainer( { block: plugin, onClick, errorNotices } );
+			const wrapper = getContainer( {
+				block: plugin,
+				onClick,
+				errorNotices,
+			} );
 
 			wrapper.find( Button ).simulate( 'click', { event: {} } );
 

--- a/packages/block-directory/src/components/downloadable-block-notice/test/index.js
+++ b/packages/block-directory/src/components/downloadable-block-notice/test/index.js
@@ -1,0 +1,59 @@
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+
+/**
+ * WordPress dependencies
+ */
+import { Button } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import DownloadableBlockNotice from '../index';
+import { plugin } from './fixtures';
+
+import { INSTALL_ERROR_NOTICE_ID } from '../../../store/constants';
+
+const getContainer = ( { block, onClick = jest.fn(), errorNotices = {} } ) => {
+	return shallow(
+		<DownloadableBlockNotice
+			block={ block }
+			onClick={ onClick }
+			errorNotices={ errorNotices }
+		/>
+	);
+};
+
+describe( 'DownloadableBlockNotice', () => {
+	describe( 'Rendering', () => {
+		it( 'should return null when there are no error notices', () => {
+			const wrapper = getContainer( { block: plugin } );
+			expect( wrapper.isEmptyRender() ).toBe( true );
+		} );
+
+		it( 'should return something when there are error notices', () => {
+			const errorNotices = {
+				[ plugin.id ]: INSTALL_ERROR_NOTICE_ID,
+			};
+			const wrapper = getContainer( { block: plugin, errorNotices } );
+			expect( wrapper.length ).toBeGreaterThan( 0 );
+		} );
+	} );
+
+	describe( 'Behavior', () => {
+		it( 'should trigger the callback on button click', () => {
+			const errorNotices = {
+				[ plugin.id ]: INSTALL_ERROR_NOTICE_ID,
+			};
+
+			const onClick = jest.fn();
+			const wrapper = getContainer( { block: plugin, onClick, errorNotices } );
+
+			wrapper.find( Button ).simulate( 'click', { event: {} } );
+
+			expect( onClick ).toHaveBeenCalledTimes( 1 );
+		} );
+	} );
+} );

--- a/packages/block-directory/src/components/downloadable-block-notice/test/index.js
+++ b/packages/block-directory/src/components/downloadable-block-notice/test/index.js
@@ -11,7 +11,7 @@ import { Button } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-import DownloadableBlockNotice from '../index';
+import { DownloadableBlockNotice } from '../index';
 import { plugin } from './fixtures';
 
 import { INSTALL_ERROR_NOTICE_ID } from '../../../store/constants';

--- a/packages/block-directory/src/components/downloadable-blocks-list/index.js
+++ b/packages/block-directory/src/components/downloadable-blocks-list/index.js
@@ -93,7 +93,6 @@ export function DownloadableBlocksList( {
 					>
 						<DownloadableBlockNotice
 							onClick={ callBack }
-							errorNotices={ errorNotices }
 							block={ item }
 						/>
 					</DownloadableBlockListItem>

--- a/packages/block-directory/src/components/downloadable-blocks-list/index.js
+++ b/packages/block-directory/src/components/downloadable-blocks-list/index.js
@@ -14,7 +14,6 @@ import { compose } from '@wordpress/compose';
  * Internal dependencies
  */
 import DownloadableBlockListItem from '../downloadable-block-list-item';
-import DownloadableBlockNotice from '../downloadable-block-notice';
 import {
 	DOWNLOAD_ERROR_NOTICE_ID,
 	INSTALL_ERROR_NOTICE_ID,
@@ -90,12 +89,7 @@ export function DownloadableBlocksList( {
 						onBlur={ () => onHover( null ) }
 						item={ item }
 						isLoading={ isLoading }
-					>
-						<DownloadableBlockNotice
-							onClick={ callBack }
-							block={ item }
-						/>
-					</DownloadableBlockListItem>
+					/>
 				);
 			} ) }
 			{ children }

--- a/packages/block-directory/src/components/downloadable-blocks-list/test/fixtures/index.js
+++ b/packages/block-directory/src/components/downloadable-blocks-list/test/fixtures/index.js
@@ -1,0 +1,23 @@
+export const plugin = {
+	name: 'boxer/boxer',
+	title: 'Boxer',
+	description: 'Boxer is a Block that puts your WordPress posts into boxes on a page.',
+	id: 'boxer-block',
+	icon: 'block-default',
+	rating: 5,
+	rating_count: 1,
+	active_installs: 0,
+	author_block_rating: 5,
+	author_block_count: '1',
+	author: 'CK Lee',
+	assets: [
+		'http://plugins.svn.wordpress.org/boxer-block/trunk/build/index.js',
+		'http://plugins.svn.wordpress.org/boxer-block/trunk/build/view.js',
+	],
+	humanized_updated: '3 months ago',
+};
+
+export const items = [
+	plugin,
+	{ ...plugin, name: 'my-block/test', id: 'my-block' },
+];

--- a/packages/block-directory/src/components/downloadable-blocks-list/test/fixtures/index.js
+++ b/packages/block-directory/src/components/downloadable-blocks-list/test/fixtures/index.js
@@ -1,7 +1,8 @@
 export const plugin = {
 	name: 'boxer/boxer',
 	title: 'Boxer',
-	description: 'Boxer is a Block that puts your WordPress posts into boxes on a page.',
+	description:
+		'Boxer is a Block that puts your WordPress posts into boxes on a page.',
 	id: 'boxer-block',
 	icon: 'block-default',
 	rating: 5,

--- a/packages/block-directory/src/components/downloadable-blocks-list/test/index.js
+++ b/packages/block-directory/src/components/downloadable-blocks-list/test/index.js
@@ -10,16 +10,13 @@ import { DownloadableBlocksList } from '../index';
 import DownloadableBlockListItem from '../../downloadable-block-list-item';
 import { items, plugin } from './fixtures';
 
-import { DOWNLOAD_ERROR_NOTICE_ID } from '../../../store/constants';
-
 const getContainer = ( {
 	blocks,
 	selectMock = jest.fn(),
 	hoverMock = jest.fn(),
 	isLoading = false,
 	errorNotices = {},
-	installAndDownload = jest.fn(),
-	download = jest.fn(),
+	install = jest.fn(),
 } ) => {
 	return shallow(
 		<DownloadableBlocksList
@@ -28,8 +25,7 @@ const getContainer = ( {
 			onHover={ hoverMock }
 			errorNotices={ errorNotices }
 			isLoading={ isLoading }
-			installAndDownload={ installAndDownload }
-			download={ download }
+			install={ install }
 		/>
 	);
 };
@@ -50,43 +46,20 @@ describe( 'DownloadableBlocksList', () => {
 		} );
 	} );
 	describe( 'Behaviour', () => {
-		it( 'should try to install and download the block plugin', () => {
-			const installAndDownload = jest.fn();
-			const download = jest.fn();
+		it( 'should try to install the block plugin', () => {
+			const install = jest.fn();
 			const errorNotices = {};
 
 			const wrapper = getContainer( {
 				blocks: [ plugin ],
-				installAndDownload,
-				download,
+				install,
 				errorNotices,
 			} );
 			const listItems = wrapper.find( DownloadableBlockListItem );
 
 			listItems.get( 0 ).props.onClick();
 
-			expect( installAndDownload ).toHaveBeenCalledTimes( 1 );
-			expect( download ).toHaveBeenCalledTimes( 0 );
-		} );
-		it( 'should try to only download the block plugin to the page', () => {
-			const installAndDownload = jest.fn();
-			const download = jest.fn();
-			const errorNotices = {
-				[ plugin.id ]: DOWNLOAD_ERROR_NOTICE_ID,
-			};
-
-			const wrapper = getContainer( {
-				blocks: [ plugin ],
-				installAndDownload,
-				download,
-				errorNotices,
-			} );
-			const listItems = wrapper.find( DownloadableBlockListItem );
-
-			listItems.get( 0 ).props.onClick();
-
-			expect( installAndDownload ).toHaveBeenCalledTimes( 0 );
-			expect( download ).toHaveBeenCalledTimes( 1 );
+			expect( install ).toHaveBeenCalledTimes( 1 );
 		} );
 	} );
 } );

--- a/packages/block-directory/src/components/downloadable-blocks-list/test/index.js
+++ b/packages/block-directory/src/components/downloadable-blocks-list/test/index.js
@@ -44,7 +44,9 @@ describe( 'DownloadableBlocksList', () => {
 		it( 'should render plugins items into the list', () => {
 			const wrapper = getContainer( { blocks: items } );
 
-			expect( wrapper.find( DownloadableBlockListItem ).length ).toBe( items.length );
+			expect( wrapper.find( DownloadableBlockListItem ).length ).toBe(
+				items.length
+			);
 		} );
 	} );
 	describe( 'Behaviour', () => {
@@ -53,7 +55,12 @@ describe( 'DownloadableBlocksList', () => {
 			const download = jest.fn();
 			const errorNotices = {};
 
-			const wrapper = getContainer( { blocks: [ plugin ], installAndDownload, download, errorNotices } );
+			const wrapper = getContainer( {
+				blocks: [ plugin ],
+				installAndDownload,
+				download,
+				errorNotices,
+			} );
 			const listItems = wrapper.find( DownloadableBlockListItem );
 
 			listItems.get( 0 ).props.onClick();
@@ -68,7 +75,12 @@ describe( 'DownloadableBlocksList', () => {
 				[ plugin.id ]: DOWNLOAD_ERROR_NOTICE_ID,
 			};
 
-			const wrapper = getContainer( { blocks: [ plugin ], installAndDownload, download, errorNotices } );
+			const wrapper = getContainer( {
+				blocks: [ plugin ],
+				installAndDownload,
+				download,
+				errorNotices,
+			} );
 			const listItems = wrapper.find( DownloadableBlockListItem );
 
 			listItems.get( 0 ).props.onClick();

--- a/packages/block-directory/src/components/downloadable-blocks-list/test/index.js
+++ b/packages/block-directory/src/components/downloadable-blocks-list/test/index.js
@@ -1,0 +1,80 @@
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import { DownloadableBlocksList } from '../index';
+import DownloadableBlockListItem from '../../downloadable-block-list-item';
+import { items, plugin } from './fixtures';
+
+import { DOWNLOAD_ERROR_NOTICE_ID } from '../../../store/constants';
+
+const getContainer = ( {
+	blocks,
+	selectMock = jest.fn(),
+	hoverMock = jest.fn(),
+	isLoading = false,
+	errorNotices = {},
+	installAndDownload = jest.fn(),
+	download = jest.fn(),
+} ) => {
+	return shallow(
+		<DownloadableBlocksList
+			items={ blocks }
+			onSelect={ selectMock }
+			onHover={ hoverMock }
+			errorNotices={ errorNotices }
+			isLoading={ isLoading }
+			installAndDownload={ installAndDownload }
+			download={ download }
+		/>
+	);
+};
+
+describe( 'DownloadableBlocksList', () => {
+	describe( 'List rendering', () => {
+		it( 'should render and empty list', () => {
+			const wrapper = getContainer( { blocks: [] } );
+			expect( wrapper.isEmptyRender() ).toBe( true );
+		} );
+
+		it( 'should render plugins items into the list', () => {
+			const wrapper = getContainer( { blocks: items } );
+
+			expect( wrapper.find( DownloadableBlockListItem ).length ).toBe( items.length );
+		} );
+	} );
+	describe( 'Behaviour', () => {
+		it( 'should try to install and download the block plugin', () => {
+			const installAndDownload = jest.fn();
+			const download = jest.fn();
+			const errorNotices = {};
+
+			const wrapper = getContainer( { blocks: [ plugin ], installAndDownload, download, errorNotices } );
+			const listItems = wrapper.find( DownloadableBlockListItem );
+
+			listItems.get( 0 ).props.onClick();
+
+			expect( installAndDownload ).toHaveBeenCalledTimes( 1 );
+			expect( download ).toHaveBeenCalledTimes( 0 );
+		} );
+		it( 'should try to only download the block plugin to the page', () => {
+			const installAndDownload = jest.fn();
+			const download = jest.fn();
+			const errorNotices = {
+				[ plugin.id ]: DOWNLOAD_ERROR_NOTICE_ID,
+			};
+
+			const wrapper = getContainer( { blocks: [ plugin ], installAndDownload, download, errorNotices } );
+			const listItems = wrapper.find( DownloadableBlockListItem );
+
+			listItems.get( 0 ).props.onClick();
+
+			expect( installAndDownload ).toHaveBeenCalledTimes( 0 );
+			expect( download ).toHaveBeenCalledTimes( 1 );
+		} );
+	} );
+} );

--- a/packages/block-directory/src/store/actions.js
+++ b/packages/block-directory/src/store/actions.js
@@ -150,3 +150,45 @@ export function removeInstalledBlockType( item ) {
 		item,
 	};
 }
+
+/**
+ * Returns an action object used to indicate install in progress
+ *
+ * @param {boolean} isInstalling Boolean value that tells state whether installation is occurring
+ *
+ */
+export function setIsInstalling( isInstalling ) {
+	return {
+		type: 'SET_INSTALLING_BLOCK',
+		isInstalling,
+	};
+}
+
+/**
+ * Sets an error notice string to be displayed to the user
+ *
+ * @param {string} blockId The ID of the block plugin. eg: my-block
+ * @param {string} noticeId The ID of the message used to determine which notice to show.
+ *
+ */
+export function setErrorNotice( blockId, noticeId ) {
+	return {
+		type: 'SET_ERROR_NOTICE_ID',
+		blockId,
+		noticeId,
+	};
+}
+
+/**
+ * Sets the error noticeId to empty for specific block
+ *
+ * @param {string} blockId The ID of the block plugin. eg: my-block
+ *
+ */
+export function clearErrorNotice( blockId ) {
+	return {
+		type: 'SET_ERROR_NOTICE_ID',
+		blockId,
+		noticeId: '',
+	};
+}

--- a/packages/block-directory/src/store/constants.js
+++ b/packages/block-directory/src/store/constants.js
@@ -1,0 +1,13 @@
+/**
+ * ID of error when downloading block fails
+ *
+ * @type {string}
+ */
+export const DOWNLOAD_ERROR_NOTICE_ID = 'block-download-error';
+
+/**
+ * ID of error when installing block fails
+ *
+ * @type {string}
+ */
+export const INSTALL_ERROR_NOTICE_ID = 'block-install-error';

--- a/packages/block-directory/src/store/reducer.js
+++ b/packages/block-directory/src/store/reducer.js
@@ -28,9 +28,10 @@ export const downloadableBlocks = (
 		case 'RECEIVE_DOWNLOADABLE_BLOCKS':
 			return {
 				...state,
-				results: Object.assign( {}, state.results, {
+				results: {
+					...state.results,
 					[ action.filterValue ]: action.downloadableBlocks,
-				} ),
+				},
 				isRequestingDownloadableBlocks: false,
 			};
 	}
@@ -48,6 +49,7 @@ export const downloadableBlocks = (
 export const blockManagement = (
 	state = {
 		installedBlockTypes: [],
+		isInstalling: false,
 	},
 	action
 ) => {
@@ -67,12 +69,17 @@ export const blockManagement = (
 					( blockType ) => blockType.name !== action.item.name
 				),
 			};
+		case 'SET_INSTALLING_BLOCK':
+			return {
+				...state,
+				isInstalling: action.isInstalling,
+			};
 	}
 	return state;
 };
 
 /**
- * Reducer returns whether the user can install blocks.
+ * Reducer returning an array of downloadable blocks.
  *
  * @param {Object} state  Current state.
  * @param {Object} action Dispatched action.
@@ -87,8 +94,36 @@ export function hasPermission( state = true, action ) {
 	return state;
 }
 
+/**
+ * Reducer returning an object of error notices.
+ *
+ * @param {Object} state  Current state.
+ * @param {Object} action Dispatched action.
+ *
+ * @return {Object} Updated state.
+ */
+export const errorNotices = (
+	state = {
+		notices: {},
+	},
+	action
+) => {
+	switch ( action.type ) {
+		case 'SET_ERROR_NOTICE_ID':
+			return {
+				...state,
+				notices: {
+					...state.notices,
+					[ action.blockId ]: action.noticeId,
+				},
+			};
+	}
+	return state;
+};
+
 export default combineReducers( {
 	downloadableBlocks,
 	blockManagement,
 	hasPermission,
+	errorNotices,
 } );

--- a/packages/block-directory/src/store/selectors.js
+++ b/packages/block-directory/src/store/selectors.js
@@ -45,3 +45,25 @@ export function hasInstallBlocksPermission( state ) {
 export function getInstalledBlockTypes( state ) {
 	return state.blockManagement.installedBlockTypes;
 }
+
+/**
+ * Returns true if application is calling install endpoint.
+ *
+ * @param {Object} state Global application state.
+ *
+ * @return {boolean} Whether its currently installing
+ */
+export function isInstalling( state ) {
+	return state.blockManagement.isInstalling;
+}
+
+/**
+ * Returns the error notices
+ *
+ * @param {Object} state Global application state.
+ *
+ * @return {Object} Object with error notices.
+ */
+export function getErrorNotices( state ) {
+	return state.errorNotices.notices;
+}

--- a/packages/block-directory/src/store/test/actions.js
+++ b/packages/block-directory/src/store/test/actions.js
@@ -6,10 +6,7 @@ import * as blockFunctions from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
-import {
-	downloadBlock,
-	installBlock,
-} from '../actions';
+import { downloadBlock, installBlock } from '../actions';
 import * as controls from '../controls';
 
 const ACTIONS = {
@@ -38,9 +35,9 @@ describe( 'actions', () => {
 	} );
 
 	const callsTheApi = ( generator ) => {
-		return expect(
-			generator.next( { success: true } ).value.type,
-		).toEqual( ACTIONS.apiFetch );
+		return expect( generator.next( { success: true } ).value.type ).toEqual(
+			ACTIONS.apiFetch
+		);
 	};
 
 	const expectTest = ( hasCall, noCall ) => {
@@ -61,9 +58,13 @@ describe( 'actions', () => {
 			const onSuccess = jest.fn();
 			const onError = jest.fn();
 
-			const generator = downloadBlock( {
-				assets: [],
-			}, onSuccess, onError );
+			const generator = downloadBlock(
+				{
+					assets: [],
+				},
+				onSuccess,
+				onError
+			);
 
 			// Move onto the onError callback
 			generator.next();
@@ -119,9 +120,9 @@ describe( 'actions', () => {
 			callsTheApi( generator );
 
 			// It triggers ADD_INSTALLED_BLOCK_TYPE
-			expect(
-				generator.next( { success: true } ).value.type,
-			).toEqual( ACTIONS.addInstalledBlockType );
+			expect( generator.next( { success: true } ).value.type ).toEqual(
+				ACTIONS.addInstalledBlockType
+			);
 
 			// Move on to success
 			generator.next();

--- a/packages/block-directory/src/store/test/actions.js
+++ b/packages/block-directory/src/store/test/actions.js
@@ -1,0 +1,147 @@
+/**
+ * WordPress dependencies
+ */
+import * as blockFunctions from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import {
+	downloadBlock,
+	installBlock,
+} from '../actions';
+import * as controls from '../controls';
+
+const ACTIONS = {
+	apiFetch: 'API_FETCH',
+	addInstalledBlockType: 'ADD_INSTALLED_BLOCK_TYPE',
+	removeInstalledBlockType: 'REMOVE_INSTALLED_BLOCK_TYPE',
+};
+
+jest.mock( '@wordpress/blocks' );
+
+describe( 'actions', () => {
+	const item = { id: 'block/block', name: 'Test Block' };
+	const blockPlugin = {
+		assets: [ 'http://www.wordpress.org/plugins/fakeasset.js' ],
+	};
+	const getBlockTypeMock = jest.spyOn( blockFunctions, 'getBlockTypes' );
+	jest.spyOn( controls, 'apiFetch' );
+	jest.spyOn( controls, 'loadAssets' );
+
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	afterAll( () => {
+		jest.resetAllMocks();
+	} );
+
+	const callsTheApi = ( generator ) => {
+		return expect(
+			generator.next( { success: true } ).value.type,
+		).toEqual( ACTIONS.apiFetch );
+	};
+
+	const expectTest = ( hasCall, noCall ) => {
+		expect( hasCall ).toHaveBeenCalledTimes( 1 );
+		expect( noCall ).toHaveBeenCalledTimes( 0 );
+	};
+
+	const expectSuccess = ( onSuccess, onError ) => {
+		expectTest( onSuccess, onError );
+	};
+
+	const expectError = ( onSuccess, onError ) => {
+		expectTest( onError, onSuccess );
+	};
+
+	describe( 'downloadBlock', () => {
+		it( 'should throw error if the plugin has no assets', () => {
+			const onSuccess = jest.fn();
+			const onError = jest.fn();
+
+			const generator = downloadBlock( {
+				assets: [],
+			}, onSuccess, onError );
+
+			// Move onto the onError callback
+			generator.next();
+
+			expectError( onSuccess, onError );
+		} );
+
+		it( 'should call on success function', () => {
+			const onSuccess = jest.fn();
+			const onError = jest.fn();
+
+			// The block is registered
+			getBlockTypeMock.mockReturnValue( [ item ] );
+
+			const generator = downloadBlock( blockPlugin, onSuccess, onError );
+
+			// Trigger the loading of assets
+			generator.next();
+
+			// Trigger the block check via getBlockTypes
+			generator.next();
+
+			expectSuccess( onSuccess, onError );
+		} );
+
+		it( 'should call on error when no blocks are returned', () => {
+			const onSuccess = jest.fn();
+			const onError = jest.fn();
+
+			// The block is not registered
+			getBlockTypeMock.mockReturnValue( [] );
+
+			const generator = downloadBlock( blockPlugin, onSuccess, onError );
+
+			// Trigger the loading of assets
+			generator.next();
+
+			//Complete
+			generator.next();
+
+			expectError( onSuccess, onError );
+		} );
+	} );
+
+	describe( 'installBlock', () => {
+		it( 'should install a block successfully', () => {
+			const onSuccess = jest.fn();
+			const onError = jest.fn();
+
+			const generator = installBlock( item, onSuccess, onError );
+
+			// It triggers API_FETCH that wraps @wordpress/api-fetch
+			callsTheApi( generator );
+
+			// It triggers ADD_INSTALLED_BLOCK_TYPE
+			expect(
+				generator.next( { success: true } ).value.type,
+			).toEqual( ACTIONS.addInstalledBlockType );
+
+			// Move on to success
+			generator.next();
+
+			expectSuccess( onSuccess, onError );
+		} );
+
+		it( 'should trigger error state when error is thrown', () => {
+			const onSuccess = jest.fn();
+			const onError = jest.fn();
+
+			const generator = installBlock( item, onSuccess, onError );
+
+			// It triggers API_FETCH that wraps @wordpress/api-fetch
+			callsTheApi( generator );
+
+			// Move on to error
+			generator.next();
+
+			expectError( onSuccess, onError );
+		} );
+	} );
+} );

--- a/packages/block-directory/src/style.scss
+++ b/packages/block-directory/src/style.scss
@@ -5,3 +5,4 @@
 @import "./components/downloadable-blocks-list/style.scss";
 @import "./components/downloadable-blocks-panel/style.scss";
 @import "./components/block-ratings/style.scss";
+@import "./components/downloadable-block-notice/style.scss";


### PR DESCRIPTION

This PR was originally here: https://github.com/WordPress/gutenberg/pull/19589

I opened the changes here after foolishly rebasing + merging and mangling history.

Applicable comments were made here:
https://github.com/WordPress/gutenberg/pull/19589/files/2da9406051d66e0bea2fe8590d305db924da6002


---

## Description
This PR is an experiment to add inline error messages to the block directory. This PR also introduces a change in execution that needs discussion.

### Background Info
- We currently, `download` the assets (which means we inject scripts into the DOM)
- Then we `install` the assets by calling an API rest endpoint (.... the plugin ends up in their plugins folder)
- We currently execute `download` then `install` as a callback.
- During the `download` sequence, the block is registered which closes the menu (because the way the inserter works) and then the `install` is executed with the menu closed. Should any issues arise, the error message will appear with a bit of a delay.
- If the block fails at `install` we offer them a button and allow them to remove the block.
  - If they don't remove and reload the page, the block is broken. There is no way to fix it.

## Types of changes
### Changes:
Along with the obvious changes to add errors inline, this PR changes the order of execution. Instead of immediate injecting the assets in the `download` sequence and then installing. This PR first `installs` and then `downloads`.

### Why?
- Before this PR, the inserter disappears as soon as the block gets registered in the `download` phase (the block registers and update the state). This means that if an error is throw on install, the context has already changed. We can't show anything inline, it's gone.
- If a block fails at `install` there isn't much recourse to fix it. Now, or potentially in the future. This means we have a broken plugin in the document. We therefore would need to have a robust "removal" experience. By flipping it, nothing is added until everything is :100 with the server. 
- We could maintain a thinner front end package since the error logic and validation stays on the server and does creep to the front end.

### Cons
- There is a delay as we `install` (subject to the network speed)
  - Added a loading state to the button to mitigate.
- ... probably more

### Known Issues
- We should consider a better way to close the inserter. There is a callback that is passed in from the inserter slot `onSelect`,  but it has a lower priority and depending on the state of the app, you could see a bit of a flicker. I have seen it sporadically.

## Screenshots
|  |  Before | After   |  
|---|---|---|
| Success | ![Before Success](https://d.pr/i/EtXCeH.gif)    |  ![After Success](https://d.pr/i/SmltOl.gif)  |
| Install Error |   ![Before Install Error](https://d.pr/i/UfAfRE.gif) <sub><sup>Disregard that the component actually was loaded below.</sup></sub>  | ![After Install Error ](https://d.pr/i/J8Shcy.gif)   |
| Download Error |   ![Before Download Error](https://d.pr/i/yhjFTK.gif)  |  ![After Download Error](https://d.pr/i/0UgUzH.gif)   <sub><sup>Mimicking this issue was tough and therefore I couldn't resolve the "Retry" work... but it is retrying :).</sup></sub> |   

## How has this been tested?
- Unit tests were added to cover the changes

### Manual Testing
Manual test were done by doing the following: ( using these block: Card, Boxer, Listicle)
#### Case Success
1. Search/Add Block
a. Notice that the block is added to the document without error
b. Notice that the plugin is not in the regular WordPress plugin folder

#### Case Install Error:
1. Search/Add a block
a. Make the `/install` endpoint return an error on first call
b. Notice the error message is showing with the proper copy..
2. Click Retry
a. Notice the error message is removed
b. Notice the plugin is in WordPress plugin folder

#### Case Download Error:
1. Search/Add a block
a. Add a throw statement in the download function in `action.js` to mimick and issue with adding assets to the DOM
b. Notice the error message is showing with the proper copy.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
