### PR TITLE
[RNMobile] Remove devOnly flag from Group block

### DIFF
--- a/packages/block-library/src/index.native.js
+++ b/packages/block-library/src/index.native.js
@@ -148,7 +148,7 @@ export const registerCoreBlocks = () => {
 		mediaText,
 		preformatted,
 		gallery,
-		devOnly( group ),
+		group,
 		spacer,
 		shortcode,
 	].forEach( registerBlock );


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
Open Group Block for production by removing `devOnly` flag according to [this ticket](https://github.com/wordpress-mobile/gutenberg-mobile/issues/1824)

Please also refer to:
[Related gutenberg-mobile PR](https://github.com/wordpress-mobile/gutenberg-mobile/pull/1850)

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

`WordPress iOS` -> https://github.com/wordpress-mobile/WordPress-iOS/pull/13367
`WordPress Android` -> https://github.com/wordpress-mobile/WordPress-Android/pull/11231


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

New feature (Group block)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
