### PR TITLE
Project Management Automation: Avoid gracefully handling error

### DIFF
--- a/packages/project-management-automation/lib/index.js
+++ b/packages/project-management-automation/lib/index.js
@@ -48,14 +48,8 @@ const automations = [
 			event === context.eventName &&
 			action === context.payload.action
 		) {
-			try {
-				debug( `main: Starting task ${ task.name }` );
-				await task( context.payload, octokit );
-			} catch ( error ) {
-				debug(
-					`main: Task ${ task.name } failed with error: ${ error }`
-				);
-			}
+			debug( `main: Starting task ${ task.name }` );
+			await task( context.payload, octokit );
 		}
 	}
 


### PR DESCRIPTION
This pull request seeks to change the behavior of our GitHub automation tasks to ensure that they fail loudly, rather than be silently absorbed.

For example, the following action was considered a success, despite the fact that it failed to assign the milestone:

https://github.com/WordPress/gutenberg/runs/423269588?check_suite_focus=true

>main: Task addMilestone failed with error: HttpError: Validation Failed: {"resource":"Milestone","code":"already_exists","field":"title"}

We should want these tasks to fail loudly to ensure that they are working properly. This specific tasks has been dysfunctional for quite some time, but was only recently noticed to not be assigning the milestone.

If a task expects to possibly be throwing errors, it should do its own `try` / `catch` and deal with the error accordingly. In this case, a duplicate milestone may be "fine" ([it was previously anticipated](https://github.com/WordPress/gutenberg/pull/17080/files#diff-63ed34ba6bc2161fa8be995aa976947fL79-L80)), so the specific step of creating the milestone could be allowed to fail with the duplicate, as long as it still proceeds to add the milestone to the pull request. Currently, this last part was never reached, because it never recovers from the thrown error.

**Testing Instructions:**

It will likely not be possible to test this, assuming there are no errors in current automation.

That said, there _is_ an error with the milestone assignment automation, which occurs when the next milestone has already been created. This could either be used as verification that the failures are logged loudly, or could be considered a blocker to resolve first before this is merged.