### PR TITLE
Project Management Automation: Tolerate duplicate milestone

### DIFF
--- a/packages/project-management-automation/lib/add-milestone.js
+++ b/packages/project-management-automation/lib/add-milestone.js
@@ -85,12 +85,24 @@ async function addMilestone( payload, octokit ) {
 		`add-milestone: Creating 'Gutenberg ${ major }.${ minor }' milestone, due on ${ dueDate.toISOString() }`
 	);
 
-	await octokit.issues.createMilestone( {
-		owner: payload.repository.owner.login,
-		repo: payload.repository.name,
-		title: `Gutenberg ${ major }.${ minor }`,
-		due_on: dueDate.toISOString(),
-	} );
+	try {
+		await octokit.issues.createMilestone( {
+			owner: payload.repository.owner.login,
+			repo: payload.repository.name,
+			title: `Gutenberg ${ major }.${ minor }`,
+			due_on: dueDate.toISOString(),
+		} );
+
+		debug( 'add-milestone: Milestone created' );
+	} catch ( error ) {
+		if ( error.code !== 'already_exists' ) {
+			throw error;
+		}
+
+		debug(
+			'add-milestone: Milestone already exists, proceeding with assignment'
+		);
+	}
 
 	debug( 'add-milestone: Fetching all milestones' );
 


### PR DESCRIPTION
Related (possibly blocks): #20009

This pull request seeks to resolve an issue where the milestone assignment automation will fail to assign the milestone to a pull request when attempting to create the milestone would result in a duplicate milestone error. Prior to #17080, a duplicate milestone was considered tolerable. If the milestone already exists, it simply proceeds to assign the milestone. However, since this milestone creation would throw an error in the new JavaScript implementation, there was no chance for the task to recover to proceed to assigning the milestone.

With these changes, a thrown error is tolerated within the task, as long as it represents an error from a duplicate milestone.

**Note:** A possible future refactoring to this task could try to fetch the milestone first, and only if determined to not exist, proceed to create the milestone.

**Testing Instructions:**

This can only be tested once merged, confirming that a milestone is assigned.