### PR TITLE
Project Management Automation: Call core setFailed with error message

### DIFF
--- a/packages/project-management-automation/lib/index.js
+++ b/packages/project-management-automation/lib/index.js
@@ -48,8 +48,14 @@ const automations = [
 			event === context.eventName &&
 			action === context.payload.action
 		) {
-			debug( `main: Starting task ${ task.name }` );
-			await task( context.payload, octokit );
+			try {
+				debug( `main: Starting task ${ task.name }` );
+				await task( context.payload, octokit );
+			} catch ( error ) {
+				setFailed(
+					`main: Task ${ task.name } failed with error: ${ error }`
+				);
+			}
 		}
 	}
 


### PR DESCRIPTION
Previously: #20009

This pull request seeks to reintroduce error handling removed as part of #20009. This time, it seeks to report the error using `setFailed` from the `@actions/core` package. This is also consistent with other usage a few lines above where a failure of a missing token is reported using this means.

https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-a-javascript-action#write-the-action-code

https://github.com/WordPress/gutenberg/blob/2e00995f97911dd69b0dd5d8d11c8e6335ab0cc8/packages/project-management-automation/lib/index.js#L34-L38

