### PR TITLE
Edit Post: Hide block drag handle in top toolbar.

### DIFF
--- a/packages/block-editor/src/components/block-mover/index.js
+++ b/packages/block-editor/src/components/block-mover/index.js
@@ -59,6 +59,7 @@ export class BlockMover extends Component {
 			instanceId,
 			isHidden,
 			rootClientId,
+			hideDragHandle,
 		} = this.props;
 		const { isFocused } = this.state;
 		const blocksCount = castArray( clientIds ).length;
@@ -122,21 +123,23 @@ export class BlockMover extends Component {
 					onBlur={ this.onBlur }
 				/>
 
-				<BlockDraggable clientIds={ clientIds }>
-					{ ( { onDraggableStart, onDraggableEnd } ) => (
-						<Button
-							icon={ dragHandle }
-							className="block-editor-block-mover__control-drag-handle block-editor-block-mover__control"
-							aria-hidden="true"
-							// Should not be able to tab to drag handle as this
-							// button can only be used with a pointer device.
-							tabIndex="-1"
-							onDragStart={ onDraggableStart }
-							onDragEnd={ onDraggableEnd }
-							draggable
-						/>
-					) }
-				</BlockDraggable>
+				{ ! hideDragHandle && (
+					<BlockDraggable clientIds={ clientIds }>
+						{ ( { onDraggableStart, onDraggableEnd } ) => (
+							<Button
+								icon={ dragHandle }
+								className="block-editor-block-mover__control-drag-handle block-editor-block-mover__control"
+								aria-hidden="true"
+								// Should not be able to tab to drag handle as this
+								// button can only be used with a pointer device.
+								tabIndex="-1"
+								onDragStart={ onDraggableStart }
+								onDragEnd={ onDraggableEnd }
+								draggable
+							/>
+						) }
+					</BlockDraggable>
+				) }
 
 				<Button
 					className="block-editor-block-mover__control"

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -14,7 +14,7 @@ import BlockSwitcher from '../block-switcher';
 import MultiBlocksSwitcher from '../block-switcher/multi-blocks-switcher';
 import BlockMover from '../block-mover';
 
-export default function BlockToolbar() {
+export default function BlockToolbar( { hideDragHandle } ) {
 	const {
 		blockClientIds,
 		isValid,
@@ -64,6 +64,7 @@ export default function BlockToolbar() {
 					<BlockMover
 						clientIds={ blockClientIds }
 						__experimentalOrientation={ moverDirection }
+						hideDragHandle={ hideDragHandle }
 					/>
 				) }
 				<MultiBlocksSwitcher />
@@ -78,6 +79,7 @@ export default function BlockToolbar() {
 				<BlockMover
 					clientIds={ blockClientIds }
 					__experimentalOrientation={ moverDirection }
+					hideDragHandle={ hideDragHandle }
 				/>
 			) }
 			{ mode === 'visual' && isValid && (

--- a/packages/edit-post/src/components/header/header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.js
@@ -57,7 +57,7 @@ function HeaderToolbar() {
 			<ToolSelector />
 			{ ( hasFixedToolbar || ! isLargeViewport ) && (
 				<div className="edit-post-header-toolbar__block-toolbar">
-					<BlockToolbar />
+					<BlockToolbar hideDragHandle />
 				</div>
 			) }
 		</NavigableToolbar>


### PR DESCRIPTION
Closes #19602

## Description

This PR adds an option to the block toolbar for disabling the block drag handle and uses it to hide it in the top toolbar mode. Starting a block drag from up there doesn't really make for a nice experience.

## How has this been tested?

It was verified that the top toolbar no longer has a block drag handle.

## Screenshots

#### Before

<img width="504" alt="Screen Shot 2020-02-03 at 2 18 09 PM" src="https://user-images.githubusercontent.com/19157096/73684139-94ddfd80-4691-11ea-9c60-1f6938b89e4d.png">

#### After

<img width="555" alt="Screen Shot 2020-02-03 at 2 21 34 PM" src="https://user-images.githubusercontent.com/19157096/73684143-960f2a80-4691-11ea-9c8e-40ff22fa67ca.png">


## Types of Changes

*Bug Fix:* The top toolbar no longer has a drag handle.

## Checklist:

- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
