### PR TITLE
Block Library: Add caption alignment to the image block.

### DIFF
--- a/packages/block-library/src/image/block.json
+++ b/packages/block-library/src/image/block.json
@@ -5,6 +5,9 @@
 		"align": {
 			"type": "string"
 		},
+		"captionAlign": {
+			"type": "string"
+		},
 		"url": {
 			"type": "string",
 			"source": "attribute",

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -22,6 +22,7 @@ import { compose } from '@wordpress/compose';
 import { withSelect, withDispatch } from '@wordpress/data';
 import {
 	BlockAlignmentToolbar,
+	AlignmentToolbar,
 	BlockControls,
 	BlockIcon,
 	InspectorControls,
@@ -90,6 +91,7 @@ export class ImageEdit extends Component {
 		super( ...arguments );
 		this.updateAlt = this.updateAlt.bind( this );
 		this.updateAlignment = this.updateAlignment.bind( this );
+		this.updateCaptionAlignment = this.updateCaptionAlignment.bind( this );
 		this.onFocusCaption = this.onFocusCaption.bind( this );
 		this.onImageClick = this.onImageClick.bind( this );
 		this.onSelectImage = this.onSelectImage.bind( this );
@@ -280,6 +282,12 @@ export class ImageEdit extends Component {
 		} );
 	}
 
+	updateCaptionAlignment( nextAlign ) {
+		this.props.setAttributes( {
+			captionAlign: nextAlign,
+		} );
+	}
+
 	updateImage( sizeSlug ) {
 		const { image } = this.props;
 
@@ -336,6 +344,7 @@ export class ImageEdit extends Component {
 			alt,
 			caption,
 			align,
+			captionAlign,
 			id,
 			href,
 			rel,
@@ -354,6 +363,10 @@ export class ImageEdit extends Component {
 				<BlockAlignmentToolbar
 					value={ align }
 					onChange={ this.updateAlignment }
+				/>
+				<AlignmentToolbar
+					value={ align }
+					onChange={ this.updateCaptionAlignment }
 				/>
 				{ url && (
 					<MediaReplaceFlow
@@ -671,6 +684,11 @@ export class ImageEdit extends Component {
 							}
 							isSelected={ this.state.captionFocused }
 							inlineToolbar
+							style={
+								captionAlign
+									? { textAlign: captionAlign }
+									: undefined
+							}
 						/>
 					) }
 				</figure>

--- a/packages/block-library/src/image/save.js
+++ b/packages/block-library/src/image/save.js
@@ -15,6 +15,7 @@ export default function save( { attributes } ) {
 		alt,
 		caption,
 		align,
+		captionAlign,
 		href,
 		rel,
 		linkClass,
@@ -60,7 +61,13 @@ export default function save( { attributes } ) {
 				image
 			) }
 			{ ! RichText.isEmpty( caption ) && (
-				<RichText.Content tagName="figcaption" value={ caption } />
+				<RichText.Content
+					tagName="figcaption"
+					value={ caption }
+					className={ classnames( {
+						[ `has-text-align-${ captionAlign }` ]: captionAlign,
+					} ) }
+				/>
 			) }
 		</>
 	);


### PR DESCRIPTION
Closes #19975

## Description

This PR adds text alignment to the Image block's caption.

## How has this been tested?

It was verified that setting the text alignment on the Image block's caption works as expected.

## Screenshots

#### Editor

<img width="700" alt="Screen Shot 2020-02-03 at 4 03 42 PM" src="https://user-images.githubusercontent.com/19157096/73690923-61a26b00-469f-11ea-9f32-de70b3802e65.png">

#### Front End

<img width="676" alt="Screen Shot 2020-02-03 at 4 03 55 PM" src="https://user-images.githubusercontent.com/19157096/73690926-636c2e80-469f-11ea-9faf-0b1d7b5bf79f.png">

## Types of Changes

*New Feature:* You can now align the captions in Image blocks.

## Checklist:

- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
