### PR TITLE
Navigation: rename background color CSS class

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -211,7 +211,7 @@ function NavigationLinkEdit( {
 					'has-child': hasDescendants,
 					'has-text-color': rgbTextColor,
 					[ `has-${ textColor }-color` ]: !! textColor,
-					'has-background-color': rgbBackgroundColor,
+					'has-background': rgbBackgroundColor,
 					[ `has-${ backgroundColor }-background-color` ]: !! backgroundColor,
 				} ) }
 				style={ {

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -68,7 +68,7 @@ function Navigation( {
 	} = __experimentalUseColors(
 		[
 			{ name: 'textColor', property: 'color' },
-			{ name: 'backgroundColor', className: 'has-background-color' },
+			{ name: 'backgroundColor', className: 'has-background' },
 		],
 		{
 			contrastCheckers: [

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -42,8 +42,8 @@ function build_css_colors( $attributes ) {
 
 	// If has background color.
 	if ( $has_custom_background_color || $has_named_background_color ) {
-		// Add has-background-color class.
-		$colors['css_classes'][] = 'has-background-color';
+		// Add has-background class.
+		$colors['css_classes'][] = 'has-background';
 	}
 
 	if ( $has_named_background_color ) {

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -208,8 +208,8 @@ $navigation-sub-menu-width: $grid-size * 25;
 		}
 
 		// No background color
-		&:not(.has-background-color) > .block-editor-inner-blocks,
-		&:not(.has-background-color) > .wp-block-navigation__container {
+		&:not(.has-background) > .block-editor-inner-blocks,
+		&:not(.has-background) > .wp-block-navigation__container {
 			background-color: $light-style-sub-menu-background-color;
 		}
 	}
@@ -223,8 +223,8 @@ $navigation-sub-menu-width: $grid-size * 25;
 		}
 
 		// No background color
-		&:not(.has-background-color) > .block-editor-inner-blocks,
-		&:not(.has-background-color) > .wp-block-navigation__container {
+		&:not(.has-background) > .block-editor-inner-blocks,
+		&:not(.has-background) > .wp-block-navigation__container {
 			background-color: $dark-style-sub-menu-background-color;
 		}
 	}


### PR DESCRIPTION
## Description

This PR renames the CSS class from `has-background-color` to `has-background` when it defines a background color of the Navigation menu since, in general and by convention, `has-background-color` makes a reference to a color named `background`, in the same way that `has-foreground-light-background-color`, `has-primary-background-color`, ... does.
So the correct CSS class name to apply is `has-background`.


<!-- Please describe what you have changed or added -->

## How has this been tested?

It has been tested with `Maywood` theme.

1) Install/Activate Maywood theme in your site
2) Create a Navigation menu.
3) Add links to the menu
4) Set the text and background color of the menu.

**before**
Confirm that the text color is not visualized either in the editor-canvas as well as in the front-end.

**after**
Confirm that the text color is rightly applied on both sides.

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

<img width="990" alt="Screen Shot 2020-02-03 at 3 41 03 PM" src="https://user-images.githubusercontent.com/77539/73700561-b3e18d00-469b-11ea-9f20-c1c68de70632.png">


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->