### PR TITLE
Block Editor: LinkControl: Avoid lingering value properties from previous value

### DIFF
--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -84,6 +84,18 @@ import LinkControlSearchInput from './search-input';
  */
 
 /**
+ * Default settings configuration.
+ *
+ * @type {WPLinkControlSetting[]}
+ */
+const DEFAULT_SETTINGS = [
+	{
+		id: 'opensInNewTab',
+		title: __( 'Open in New Tab' ),
+	},
+];
+
+/**
  * Renders a link control. A link control is a controlled input which maintains
  * a value associated with a link (HTML anchor element) and relevant settings
  * for how that link is expected to behave.
@@ -92,7 +104,7 @@ import LinkControlSearchInput from './search-input';
  */
 function LinkControl( {
 	value,
-	settings,
+	settings = DEFAULT_SETTINGS,
 	onChange = noop,
 	showInitialSuggestions,
 } ) {

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { noop, startsWith } from 'lodash';
+import { noop, startsWith, pick, map } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -223,6 +223,19 @@ function LinkControl( {
 		setIsEditingLink( false );
 	}
 
+	/**
+	 * Given a selected suggestion, returns the merged next value. The merged
+	 * value inherits only settings properties from the previous value.
+	 *
+	 * @param {WPLinkControlValue} suggestion Next value suggestion.
+	 *
+	 * @return {WPLinkControlValue} Merged next value.
+	 */
+	const getNextValue = ( suggestion ) => ( {
+		...pick( value, map( settings, 'id' ) ),
+		...suggestion,
+	} );
+
 	// Effects
 	const getSearchHandler = useCallback(
 		( val, args ) => {
@@ -297,7 +310,7 @@ function LinkControl( {
 							) }
 							suggestion={ suggestion }
 							onClick={ () => {
-								onChange( { ...value, ...suggestion } );
+								onChange( getNextValue( suggestion ) );
 								stopEditing();
 							} }
 							isSelected={ index === selectedSuggestion }
@@ -323,7 +336,7 @@ function LinkControl( {
 					value={ inputValue }
 					onChange={ onInputChange }
 					onSelect={ ( suggestion ) => {
-						onChange( { ...value, ...suggestion } );
+						onChange( getNextValue( suggestion ) );
 						stopEditing();
 					} }
 					renderSuggestions={ renderSearchResults }

--- a/packages/block-editor/src/components/link-control/settings-drawer.js
+++ b/packages/block-editor/src/components/link-control/settings-drawer.js
@@ -9,18 +9,7 @@ import { noop } from 'lodash';
 import { __ } from '@wordpress/i18n';
 import { ToggleControl } from '@wordpress/components';
 
-const defaultSettings = [
-	{
-		id: 'opensInNewTab',
-		title: __( 'Open in New Tab' ),
-	},
-];
-
-const LinkControlSettingsDrawer = ( {
-	value,
-	onChange = noop,
-	settings = defaultSettings,
-} ) => {
+const LinkControlSettingsDrawer = ( { value, onChange = noop, settings } ) => {
 	if ( ! settings || ! settings.length ) {
 		return null;
 	}

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -816,6 +816,54 @@ describe( 'Selecting links', () => {
 		);
 		expect( isExpectedFocusTarget ).toBe( true );
 	} );
+
+	it( 'should update a selected link value', ( done ) => {
+		// Regression: Previously, the behavior of updating a value was to merge
+		// the previous value with the newly selected suggestion. If the keys
+		// between the two objects were not the same, it could wrongly leave
+		// lingering values from the previous value.
+
+		const LinkControlConsumer = () => (
+			<LinkControl
+				value={ { url: 'https://wordpress.org', title: 'WordPress' } }
+				onChange={ ( nextValue ) => {
+					expect( nextValue ).toEqual( {
+						url: 'https://example.com',
+					} );
+
+					done();
+				} }
+			/>
+		);
+
+		act( () => {
+			render( <LinkControlConsumer />, container );
+		} );
+
+		// Toggle edit.
+		document
+			.querySelector( '.block-editor-link-control__search-item-action' )
+			.click();
+
+		// Change value.
+		const form = container.querySelector( 'form' );
+		const searchInput = container.querySelector(
+			'input[aria-label="URL"]'
+		);
+
+		// Simulate searching for a term
+		act( () => {
+			Simulate.change( searchInput, {
+				target: { value: 'https://example.com' },
+			} );
+		} );
+		act( () => {
+			Simulate.keyDown( searchInput, { keyCode: ENTER } );
+		} );
+		act( () => {
+			Simulate.submit( form );
+		} );
+	} );
 } );
 
 describe( 'Addition Settings UI', () => {


### PR DESCRIPTION
Related: #19827

This pull request seeks to resolve an issue introduced by #19651, where if a link is assigned a value with an associated `title` (or any other [supported `value` properties](https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/link-control/README.md#value)), they will be inherited into the next value when the user manually enters a URL. This ties in to related work at #19827, where ideally the suggestion value shapes are made to be consistent. As of #19651, the form submit handler will only assign the `url` property of the next value.

Even with separate improvements to make the suggestion value consistent, the changes here may still be valuable as an expression of intent of the next value to only derive settings properties from the previous values, and no other properties.

**Testing Instructions:**

Verify that a title does not transfer to a newly manually-entered value:

1. Navigate to Posts > Add New
2. Insert a Navigation block
3. Click "Create empty"
4. When prompted with the link input, search for a post within the current site, and select its suggestion entry
5. Click "Link" in the block toolbar to edit the link
6. Click "Edit" to edit the URL
7. Now manually enter a URL, e.g. `http://example.com`
8. Press Enter
9. Note the "Title Attribute" field in the block inspector's SEO Settings is empty, and not the title from the link selected at step 4