### PR TITLE
Pull Request Automation: Avoid automation tasks for forked repository

### DIFF
--- a/packages/project-management-automation/lib/if-not-fork.js
+++ b/packages/project-management-automation/lib/if-not-fork.js
@@ -1,5 +1,5 @@
 /**
- * Higher-order function which executes and returns the resutl of the given
+ * Higher-order function which executes and returns the result of the given
  * handler only if the enhanced function is called with a payload indicating a
  * pull request event which did not originate from a forked repository.
  *

--- a/packages/project-management-automation/lib/if-not-fork.js
+++ b/packages/project-management-automation/lib/if-not-fork.js
@@ -1,0 +1,21 @@
+/**
+ * Higher-order function which executes and returns the resutl of the given
+ * handler only if the enhanced function is called with a payload indicating a
+ * pull request event which did not originate from a forked repository.
+ *
+ * @param {Function} handler Original task.
+ *
+ * @return {Function} Enhanced task.
+ */
+function ifNotFork( handler ) {
+	return ( payload, ...args ) => {
+		if (
+			payload.pull_request.head.repo.full_name ===
+			payload.pull_request.base.repo.full_name
+		) {
+			return handler( payload, ...args );
+		}
+	};
+}
+
+module.exports = ifNotFork;

--- a/packages/project-management-automation/lib/index.js
+++ b/packages/project-management-automation/lib/index.js
@@ -11,17 +11,18 @@ const assignFixedIssues = require( './assign-fixed-issues' );
 const addFirstTimeContributorLabel = require( './add-first-time-contributor-label' );
 const addMilestone = require( './add-milestone' );
 const debug = require( './debug' );
+const ifNotFork = require( './if-not-fork' );
 
 const automations = [
 	{
 		event: 'pull_request',
 		action: 'opened',
-		task: assignFixedIssues,
+		task: ifNotFork( assignFixedIssues ),
 	},
 	{
 		event: 'pull_request',
 		action: 'opened',
-		task: addFirstTimeContributorLabel,
+		task: ifNotFork( addFirstTimeContributorLabel ),
 	},
 	{
 		event: 'pull_request',


### PR DESCRIPTION
Related: #17324

This pull request seeks to avoid running automation tasks for pull request events when the event was triggered by a pull request originated from a forked repository. Based on the comment at https://github.com/WordPress/gutenberg/issues/17324#issuecomment-548637488, events which trigger from forked repositories are run with read-only permissions, and as such are not allowed to add labels, resulting in errors for tasks which perform these actions.

**Testing Instructions:**

The actions associated with this pull request should be expected to run fully and successfully, since it does not originate from a fork repository.