### PR TITLE
NavigationLink: improve colors handling 

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -310,29 +310,29 @@ export default compose( [
 		const rootBlock = head(
 			getBlockParentsByBlockName( clientId, 'core/navigation' )
 		);
-		const navBlockAttrs = getBlockAttributes( rootBlock );
+		const navigationBlockAttributes = getBlockAttributes( rootBlock );
 		const colors = get( getSettings(), 'colors', [] );
 		const hasDescendants = !! getClientIdsOfDescendants( [ clientId ] )
 			.length;
 		const showSubmenuIcon =
-			!! navBlockAttrs.showSubmenuIcon && hasDescendants;
+			!! navigationBlockAttributes.showSubmenuIcon && hasDescendants;
 		const isParentOfSelectedBlock = hasSelectedInnerBlock( clientId, true );
 
 		return {
 			isParentOfSelectedBlock,
 			hasDescendants,
 			showSubmenuIcon,
-			textColor: navBlockAttrs.textColor,
-			backgroundColor: navBlockAttrs.backgroundColor,
+			textColor: navigationBlockAttributes.textColor,
+			backgroundColor: navigationBlockAttributes.backgroundColor,
 			rgbTextColor: getColorObjectByColorSlug(
 				colors,
-				navBlockAttrs.textColor,
-				navBlockAttrs.customTextColor
+				navigationBlockAttributes.textColor,
+				navigationBlockAttributes.customTextColor
 			),
 			rgbBackgroundColor: getColorObjectByColorSlug(
 				colors,
-				navBlockAttrs.backgroundColor,
-				navBlockAttrs.customBackgroundColor
+				navigationBlockAttributes.backgroundColor,
+				navigationBlockAttributes.customBackgroundColor
 			),
 		};
 	} ),

--- a/packages/block-library/src/navigation/deprecated.js
+++ b/packages/block-library/src/navigation/deprecated.js
@@ -1,0 +1,66 @@
+/**
+ * External dependencies
+ */
+import { omit } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { InnerBlocks } from '@wordpress/block-editor';
+
+export default [
+	{
+		attributes: {
+			className: {
+				type: 'string',
+			},
+			textColor: {
+				type: 'string',
+			},
+			rgbTextColor: {
+				type: 'string',
+			},
+			backgroundColor: {
+				type: 'string',
+			},
+			rgbBackgroundColor: {
+				type: 'string',
+			},
+			fontSize: {
+				type: 'string',
+			},
+			customFontSize: {
+				type: 'number',
+			},
+			itemsJustification: {
+				type: 'string',
+			},
+			showSubmenuIcon: {
+				type: 'boolean',
+			},
+		},
+		isEligible( attribute ) {
+			return attribute.rgbTextColor || attribute.rgbBackgroundColor;
+		},
+		supports: {
+			align: [ 'wide', 'full' ],
+			anchor: true,
+			html: false,
+			inserter: true,
+		},
+		migrate( attributes ) {
+			return {
+				...omit( attributes, [ 'rgbTextColor', 'rgbBackgroundColor' ] ),
+				customTextColor: attributes.textColor
+					? undefined
+					: attributes.rgbTextColor,
+				customBackgroundColor: attributes.backgroundColor
+					? undefined
+					: attributes.rgbBackgroundColor,
+			};
+		},
+		save() {
+			return <InnerBlocks.Content />;
+		},
+	},
+];

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { useMemo, Fragment, useRef, useEffect } from '@wordpress/element';
+import { useMemo, Fragment, useRef } from '@wordpress/element';
 import {
 	InnerBlocks,
 	InspectorControls,
@@ -85,14 +85,6 @@ function Navigation( {
 		},
 		[ fontSize.size ]
 	);
-
-	// Pickup and store text and background colors in grb format into attrs object.
-	useEffect( () => {
-		setAttributes( {
-			rgbTextColor: TextColor.color,
-			rgbBackgroundColor: BackgroundColor.color,
-		} );
-	}, [ TextColor.color, BackgroundColor.color ] );
 
 	/* eslint-enable @wordpress/no-unused-vars-before-return */
 	const { navigatorToolbarButton, navigatorModal } = useBlockNavigator(

--- a/packages/block-library/src/navigation/index.js
+++ b/packages/block-library/src/navigation/index.js
@@ -9,6 +9,7 @@ import { menu as icon } from '@wordpress/icons';
  */
 import edit from './edit';
 import save from './save';
+import deprecated from './deprecated';
 
 export const name = 'core/navigation';
 
@@ -38,4 +39,6 @@ export const settings = {
 	edit,
 
 	save,
+
+	deprecated,
 };

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -20,7 +20,7 @@ function core_block_navigation_build_css_colors( $attributes ) {
 
 	// Text color.
 	$has_named_text_color  = array_key_exists( 'textColor', $attributes );
-	$has_custom_text_color = array_key_exists( 'rgbTextColor', $attributes );
+	$has_custom_text_color = array_key_exists( 'customTextColor', $attributes );
 
 	// If has text color.
 	if ( $has_custom_text_color || $has_named_text_color ) {
@@ -33,12 +33,12 @@ function core_block_navigation_build_css_colors( $attributes ) {
 		$colors['css_classes'][] = sprintf( 'has-%s-color', $attributes['textColor'] );
 	} elseif ( $has_custom_text_color ) {
 		// Add the custom color inline style.
-		$colors['inline_styles'] .= sprintf( 'color: %s;', $attributes['rgbTextColor'] );
+		$colors['inline_styles'] .= sprintf( 'color: %s;', $attributes['customTextColor'] );
 	}
 
 	// Background color.
 	$has_named_background_color  = array_key_exists( 'backgroundColor', $attributes );
-	$has_custom_background_color = array_key_exists( 'rgbBackgroundColor', $attributes );
+	$has_custom_background_color = array_key_exists( 'customBackgroundColor', $attributes );
 
 	// If has background color.
 	if ( $has_custom_background_color || $has_named_background_color ) {
@@ -51,7 +51,7 @@ function core_block_navigation_build_css_colors( $attributes ) {
 		$colors['css_classes'][] = sprintf( 'has-%s-background-color', $attributes['backgroundColor'] );
 	} elseif ( $has_custom_background_color ) {
 		// Add the custom background-color inline style.
-		$colors['inline_styles'] .= sprintf( 'background-color: %s;', $attributes['rgbBackgroundColor'] );
+		$colors['inline_styles'] .= sprintf( 'background-color: %s;', $attributes['customBackgroundColor'] );
 	}
 
 	return $colors;
@@ -133,8 +133,23 @@ function render_block_navigation( $content, $block ) {
 		return $content;
 	}
 
-	$attributes           = $block['attrs'];
 	$block['innerBlocks'] = core_block_navigation_empty_navigation_links_recursive( $block['innerBlocks'] );
+	$attributes           = $block['attrs'];
+
+	// Deprecated:
+	// The rgbTextColor and rgbBackgroundColor attributes
+	// have been deprecated in favor of
+	// customTextColor and customBackgroundColor ones.
+	// Move the values from old attrs to the new ones.
+	if ( isset( $attributes['rgbTextColor'] ) && empty( $attributes['textColor'] ) ) {
+		$attributes['customTextColor'] = $attributes['rgbTextColor'];
+	}
+
+	if ( isset( $attributes['rgbBackgroundColor'] ) && empty( $attributes['backgroundColor'] ) ) {
+		$attributes['customBackgroundColor'] = $attributes['rgbBackgroundColor'];
+	}
+
+	unset( $attributes['rgbTextColor'], $attributes['rgbBackgroundColor'] );
 
 	if ( empty( $block['innerBlocks'] ) ) {
 		return '';
@@ -267,31 +282,39 @@ function register_block_core_navigation() {
 		'core/navigation',
 		array(
 			'attributes' => array(
-				'className'          => array(
+				'className'             => array(
 					'type' => 'string',
 				),
-				'textColor'          => array(
+				'textColor'             => array(
 					'type' => 'string',
 				),
-				'rgbTextColor'       => array(
+				'customTextColor'       => array(
 					'type' => 'string',
 				),
-				'backgroundColor'    => array(
+				// deprecated.
+				'rgbTextColor'          => array(
 					'type' => 'string',
 				),
-				'rgbBackgroundColor' => array(
+				'backgroundColor'       => array(
 					'type' => 'string',
 				),
-				'fontSize'           => array(
+				'customBackgroundColor' => array(
 					'type' => 'string',
 				),
-				'customFontSize'     => array(
+				// deprecated.
+				'rgbBackgroundColor'    => array(
+					'type' => 'string',
+				),
+				'fontSize'              => array(
+					'type' => 'string',
+				),
+				'customFontSize'        => array(
 					'type' => 'number',
 				),
-				'itemsJustification' => array(
+				'itemsJustification'    => array(
 					'type' => 'string',
 				),
-				'showSubmenuIcon'    => array(
+				'showSubmenuIcon'       => array(
 					'type'    => 'boolean',
 					'default' => true,
 				),

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -136,11 +136,13 @@ function render_block_navigation( $content, $block ) {
 	$block['innerBlocks'] = core_block_navigation_empty_navigation_links_recursive( $block['innerBlocks'] );
 	$attributes           = $block['attrs'];
 
-	// Deprecated:
-	// The rgbTextColor and rgbBackgroundColor attributes
-	// have been deprecated in favor of
-	// customTextColor and customBackgroundColor ones.
-	// Move the values from old attrs to the new ones.
+	/**
+	 * Deprecated:
+	 * The rgbTextColor and rgbBackgroundColor attributes
+	 * have been deprecated in favor of
+	 * customTextColor and customBackgroundColor ones.
+	 * Move the values from old attrs to the new ones.
+	 */
 	if ( isset( $attributes['rgbTextColor'] ) && empty( $attributes['textColor'] ) ) {
 		$attributes['customTextColor'] = $attributes['rgbTextColor'];
 	}


### PR DESCRIPTION
## Description
This PR improves the way of handling colors between the Navigation Block and its children (NavigationLink).

#### Background
The tricky parts about this handling are mainly based on the following points:

* `<NavigationItem />` blocks are created by the `<InnerBlocks />` components.
* It difficulties propagating data between the parent and the children blocks.
* The way to share data is through the block attributes of the parent block.
* Navigation colors are handled by the useColors hook.
* The useColors hook provides colors in RGB format only if they are custom colors (when don't belong from colors palette).
* NavigationLink always needs the colors in RGB format.

The way to get the color always in RGB is (master branch) getting this value from the `color` property of the component returned by the hook and store it as a block attribute in order to be able to pick it up from the children block.
This is a big mistake because storing and pulling the color to/from the block attribute makes the functionality static.

What this PR proposes is removing these additional attributes from the parent/Navigation block (rgbTextColor and rgbBlackgroundColor), and pick the RGB color by the color Id (when it comes from the colors palette), or just simply from the custom value if it's defined.

It makes the implementation simpler and clearer, avoiding to store unnecessary data in the Navigation attributes object.

Also, it fixes a bug when the text and/or background color are set using custom colors. The color attributes are not being saved correctly. This new refactoring implies also adding a deprecating handler since the rgbTextColor and rgbBackgrounColor attributes won't be used anymore.

## How has this been tested?

1) Go to the editor canvas side
2) Create a Navigation Menu
3) Set a custom color for text and/or background
4) Save the post
5) Hard Refresh

**before**
6) Confirm that the colors are not applied
7) However, confirm that the colors are applied in the front-end

**after**
8) Confirm that the colors are applied in the canvas-editor after the hard-refresh

Props to @marekhrabe for the development of the idea. 👏 

## Testing deprecation 

1) Go to `master` branch
2) Create a Navigation Menu
3) Set custom colors
4) Switch to the code editor
<img src="https://user-images.githubusercontent.com/77539/73864009-c66fd980-47f5-11ea-84d4-73c6f30de0c9.png" width="300px" />

5) Confirm that they are applied using the RGB attributes 

```
<!-- wp:navigation {"rgbTextColor":"#4296ba","rgbBackgroundColor":"#18333f"} -->
<!-- wp:navigation-link {"label":"Test"} /-->
<!-- /wp:navigation -->
```

6) Check colors are applied in the front-end
7) Switch to this branch
8) Check the colors are applied (again) in the front-end
9) In editor-canvas do a hard refresh
10) Check that the RGB attributes were removed and the custom ones are now there

```
<!-- wp:navigation {"customTextColor":"#4296ba","customBackgroundColor":"#18333f"} -->
<!-- wp:navigation-link {"label":"Test"} /-->
<!-- /wp:navigation -->
```

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
