### PR TITLE
Fix alignment of notice lists in block placeholders

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -62,8 +62,7 @@
 	 */
 
 	.components-placeholder .components-with-notices-ui {
-		margin: -10px 20px 12px 20px;
-		width: calc(100% - 40px);
+		margin: -10px 0 12px 0;
 	}
 
 	.components-with-notices-ui {


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
This change updates the margins of the notice UI added to block placeholders using the `withNotices` mixin. The update was necessary after #18745 which made the content of block placeholders left-aligned.

Fixes #19671

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
- Get the File block into error state by uploading an invalid file and then look at the rendered output to observe any layout issues.
- Tested with File block in column layout
- Tested mobile width
- Safari, FF and Chrome on Mac
- Viewed the fix in [a testing block](https://gist.github.com/p-jackson/fe601434d0ab5202387f9799ebae184e) with no other content but the placeholder. This was to check that the fix worked in general, not just for the File block.

## Screenshots <!-- if applicable -->

**Before #18745**
Block placeholder content is centred.
<img width="661" alt="before" src="https://user-images.githubusercontent.com/1500769/73725919-50d32180-4793-11ea-9fc2-306258d00339.png">

**After #18745**
With alignment bug as reported by #19671
<img width="661" alt="image" src="https://user-images.githubusercontent.com/1500769/73726251-fa1a1780-4793-11ea-963b-c09ca82023ba.png">

**After this fix**
Vertical margins the same as before #18745, but notice is now full width
<img width="661" alt="image" src="https://user-images.githubusercontent.com/1500769/73726165-c7701f00-4793-11ea-81a2-ee681e99f06f.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
