### PR TITLE
Fix Broken Link in Glossary Page

### DIFF
--- a/docs/designers-developers/glossary.md
+++ b/docs/designers-developers/glossary.md
@@ -56,6 +56,6 @@
 <dd>A set of button controls. In the context of a block, usually referring to the toolbar of block controls shown above the selected block.</dd>
 
 <dt>Template</dt>
-<dd> A template is a pre-defined arrangement of blocks, possibly with predefined attributes or placeholder content. You can provide a template for a post type, to give users a starting point when creating a new piece of content, or inside a custom block with the <code>InnerBlocks</code> component. See the templates documentation for more information. See <a href="../../developers/block-api/block-templates.md">templates documentation</a> for more information.</dd>
+<dd> A template is a pre-defined arrangement of blocks, possibly with predefined attributes or placeholder content. You can provide a template for a post type, to give users a starting point when creating a new piece of content, or inside a custom block with the <code>InnerBlocks</code> component. See the templates documentation for more information. See <a href="../../developers/block-api/block-templates/">templates documentation</a> for more information.</dd>
 
 </dl>


### PR DESCRIPTION

## Description
Fix Broken Link in [Glossary Page](https://developer.wordpress.org/block-editor/principles/glossary/) 

## Types of changes
Bug fix - A non-breaking change which fixes an issue in the documentation page.
