### PR TITLE
Add prettier dependency to @wordpress/eslint-plugin 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10521,6 +10521,7 @@
 				"eslint-plugin-react": "^7.14.3",
 				"eslint-plugin-react-hooks": "^1.6.1",
 				"globals": "^12.0.0",
+				"prettier": "npm:wp-prettier@1.19.1",
 				"requireindex": "^1.2.0"
 			}
 		},

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -33,6 +33,7 @@
 		"eslint-plugin-react": "^7.14.3",
 		"eslint-plugin-react-hooks": "^1.6.1",
 		"globals": "^12.0.0",
+		"prettier": "npm:wp-prettier@1.19.1",
 		"requireindex": "^1.2.0"
 	},
 	"peerDependencies": {


### PR DESCRIPTION
## Description

Fixes #20027.

In #19963 we added `eslint-plugin-prettier` as a dependency to `@wordpress/eslint-plugin` in f5c44ea36ca1928604e43c1145845ded5b6993d3 which [requires `prettier` as a peer dependency](https://github.com/prettier/eslint-plugin-prettier/blob/9a47a6feab691cf228d184c103d4cab99b464d0b/package.json#L35).

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->.
