### PR TITLE
Block Editor: Fix block placeholder notices alignment.

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -62,7 +62,7 @@
 	 */
 
 	.components-placeholder .components-with-notices-ui {
-		margin: -10px 20px 12px 20px;
+		margin: -10px 0 12px 0;
 		width: calc(100% - 40px);
 	}
 


### PR DESCRIPTION
Fixes #19671

## Description

This PR fixes the block placeholder notices alignment issues introduced by #18745.

## How to test this?

- Add `this.onUploadError( 'Error message.' );` to the File block edit component's `componentDidMount`. (`packages/block-library/src/file/edit.js`)
- Build and refresh.
- Insert a File block.
- Verify the error notice is aligned correctly.

## Screenshots

#### Before

<img width="694" alt="Screen Shot 2020-02-04 at 7 53 10 AM" src="https://user-images.githubusercontent.com/19157096/73747230-03b86680-4725-11ea-87e6-b2c2cbd93469.png">

#### After

<img width="680" alt="Screen Shot 2020-02-04 at 7 52 48 AM" src="https://user-images.githubusercontent.com/19157096/73747233-05822a00-4725-11ea-9968-0e0031821d14.png">

## Types of Changes

*Bug Fix:* The block placeholder notices are aligned correctly again.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
