### PR TITLE
NavigationLink: fix getting Navigation parent block

### DIFF
--- a/docs/designers-developers/developers/data/data-core-block-editor.md
+++ b/docs/designers-developers/developers/data/data-core-block-editor.md
@@ -203,6 +203,23 @@ _Returns_
 
 -   `Array`: ClientIDs of the parent blocks.
 
+<a name="getBlockParentsByBlockName" href="#getBlockParentsByBlockName">#</a> **getBlockParentsByBlockName**
+
+Given a block client ID and a block name,
+returns the list of all its parents from top to bottom,
+filtered by the given name.
+
+_Parameters_
+
+-   _state_ `Object`: Editor state.
+-   _clientId_ `string`: Block from which to find root client ID.
+-   _blockName_ `string`: Block name to filter.
+-   _ascending_ `boolean`: Order results from bottom to top (true) or top to bottom (false).
+
+_Returns_
+
+-   `Array`: ClientIDs of the parent blocks.
+
 <a name="getBlockRootClientId" href="#getBlockRootClientId">#</a> **getBlockRootClientId**
 
 Given a block client ID, returns the root block from which the block is

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -459,6 +459,37 @@ export const getBlockParents = createSelector(
 );
 
 /**
+ * Given a block client ID and a block name,
+ * returns the list of all its parents from top to bottom,
+ * filtered by the given name.
+ *
+ * @param {Object} state     Editor state.
+ * @param {string} clientId  Block from which to find root client ID.
+ * @param {string} blockName Block name to filter.
+ * @param {boolean} ascending Order results from bottom to top (true) or top to bottom (false).
+ *
+ * @return {Array} ClientIDs of the parent blocks.
+ */
+export const getBlockParentsByBlockName = (
+	state,
+	clientId,
+	blockName,
+	ascending = false
+) => {
+	const parents = getBlockParents( state, clientId, ascending );
+	return map(
+		filter(
+			map( parents, ( id ) => ( {
+				id,
+				name: getBlockName( state, id ),
+			} ) ),
+			{ name: blockName }
+		),
+		( { id } ) => id
+	);
+};
+
+/**
  * Given a block client ID, returns the root of the hierarchy from which the block is nested, return the block itself for root level blocks.
  *
  * @param {Object} state    Editor state.

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { escape, unescape } from 'lodash';
+import { escape, unescape, head } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -308,12 +308,14 @@ export default compose( [
 	withSelect( ( select, ownProps ) => {
 		const {
 			getBlockAttributes,
-			getBlockParents,
 			getClientIdsOfDescendants,
 			hasSelectedInnerBlock,
+			getBlockParentsByBlockName,
 		} = select( 'core/block-editor' );
 		const { clientId } = ownProps;
-		const rootBlock = getBlockParents( clientId )[ 0 ];
+		const rootBlock = head(
+			getBlockParentsByBlockName( clientId, 'core/navigation' )
+		);
 		const navigationBlockAttributes = getBlockAttributes( rootBlock );
 		const hasDescendants = !! getClientIdsOfDescendants( [ clientId ] )
 			.length;


### PR DESCRIPTION
## Description
This PR fixes an issue which was found by @getdave reviewing this [PR](https://github.com/WordPress/gutenberg/pull/20022)):

----------
...However, I noticed a potential coding issue where we're expecting the rootBlock to always be the Nav Block:

```
const rootBlock = getBlockParents( clientId )[ 0 ];
```

...when in actual fact I think it could actually be _any_ parent Block that uses `InnerBlocks` (eg: Columms) as it will return the topmost Block in the hierarchy. Therefore if the Block is nested then this logic is problematic.

I tested this theory by:

* Adding a Column Block
* Add Nav Block within the first Column
* Setting Custom Colors
* Looking for `style` attribute set on the DOM on the Nav Link.

It appears in the above scenario it doesn't work as the style wasn't applied to the Navigation _**Link**_ Block, only to the _parent_ Navigation Block.

![Screen Shot 2020-02-04 at 13 41 11](https://user-images.githubusercontent.com/444434/73750056-712fbb80-4754-11ea-99fb-acff8c07f85c.png)

------

So, in order to fix this issue what we do is adding a new `getBlockParentsByBlockName()` selector, which returns an array of parent client IDs, but also filtered by block name. So in this way, will ensure to get the proper attributes of the parent block:

```es6
const parentNavigationIds = getBlockParentsByBlockName(
	clientId,
	'core/navigation'
);
```

Then it's a matter of getting the first item of the array and pick up the block attributes.

## How has this been tested?

1) Adding a Column Block
2) Add Nav Block within the first Column
3) Setting Custom Colors
4) Looking for `style` attribute set on the DOM on the Nav Link.

**before**
5) The colors attributes of the Navigation block are not propagated to the NavigationLink and the colors are not applied to the sub-menus:

<img width="639" alt="Screen Shot 2020-02-04 at 10 52 25 AM" src="https://user-images.githubusercontent.com/77539/73776421-8b5d9f80-473c-11ea-9242-673c3b7e69e3.png">



**after**
6) The colors are righty applied to the NavigationLink blocks

<img width="639" alt="Screen Shot 2020-02-04 at 10 49 48 AM" src="https://user-images.githubusercontent.com/77539/73776285-55202000-473c-11ea-9ec6-754441096c9d.png">


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->