### PR TITLE
Prettier: Update format-js to use default config, and update editor docs usage

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,3 @@
+// Import the default config file and expose it in the project root.
+// Useful for editor integrations.
+module.exports = require( '@wordpress/scripts/config/.prettierrc.js' );

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,3 +1,0 @@
-// Import the default config file and expose it in the project root.
-// Useful for editor integrations.
-module.exports = require( '@wordpress/scripts/config/.prettierrc.js' );

--- a/docs/contributors/getting-started.md
+++ b/docs/contributors/getting-started.md
@@ -130,17 +130,20 @@ With the extension installed, ESLint will use the [.eslintrc.js](https://github.
 
 [Prettier](https://prettier.io/) is a tool that allows you to define an opinionated format, and automate fixing the code to match that format. Prettier and ESlint are similar, Prettier is more about formatting and style, while ESlint is for detecting coding errors.
 
-To use Prettier, you should install the [Prettier - Code formatter extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) in Visual Studio Code. You can then configure it to be the default formatter and to automatically fix issues on save, by adding the following to your settings.
+To use Prettier with Visual Studio Code, you should install the [Prettier - Code formatter extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode). You can then configure it to be the default formatter and to automatically fix issues on save, by adding the following to your settings.
 
 ```json
 "[javascript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.formatOnSave": true
 },
-"prettier.configPath": "packages/scripts/config/.prettierrc.js"
 ```
 
-This will use the `.prettierrc.js` file included in the scripts package of the Gutenberg repository.
+This will use the `.prettierrc.js` file included in the root of the Gutenberg repository.
+
+If you only want to use this configuration with the Gutenberg project, create a directory called .vscode at the top-level of Gutenberg, and place your settings in a settings.json there. Visual Studio Code refers to this as Workplace Settings, and only apply to the project.
+
+For other editors, see [Prettier's Editor Integration docs](https://prettier.io/docs/en/editors.html)
 
 ### TypeScript
 

--- a/docs/contributors/getting-started.md
+++ b/docs/contributors/getting-started.md
@@ -8,7 +8,7 @@ Once you have Node installed, run these scripts from within your local Gutenberg
 
 Note: The install scripts require [Python](https://www.python.org/) to be installed and in the path of the local system.
 
-```
+```bash
 npm install
 npm run build
 ```
@@ -20,6 +20,7 @@ If you don't have a local WordPress environment to load Gutenberg in, we can hel
 ## Local Environment
 
 ### Step 1: Installing a Local Environment
+
 #### Quickest Method: Using Docker
 
 The quickest way to get up and running is to use the provided Docker setup. If you don't already have it, you'll need to install Docker and Docker Compose.
@@ -30,16 +31,17 @@ To install Docker Compose, [follow their instructions here](https://docs.docker.
 
 Once Docker is installed and running, run this script to install WordPress, and build your local environment:
 
-```
+```bash
 npm run env install
 ```
 
 #### Alternative Method: Using an Existing Local WordPress Install
+
 WordPress will be installed in the `wordpress` directory, if you need to access WordPress core files directly, you can find them there.
 
 If you already have WordPress checked out in a different directory, you can use that installation, instead, by running these commands:
 
-```
+```bash
 export WP_DEVELOP_DIR=/path/to/wordpress-develop
 npm run env connect
 ```
@@ -48,10 +50,11 @@ This will use WordPress' own local environment, and mount your Gutenberg directo
 
 In Windows, you can set the `WP_DEVELOP_DIR` environment variable using the appropriate method for your shell:
 
-    CMD: set WP_DEVELOP_DIR=/path/to/wordpress-develop
-    PowerShell: $env:WP_DEVELOP_DIR = "/path/to/wordpress-develop"
+- CMD: `set WP_DEVELOP_DIR=/path/to/wordpress-develop`
+- PowerShell: `$env:WP_DEVELOP_DIR = "/path/to/wordpress-develop"`
 
 ### Step 2: Accessing and Configuring the Local WordPress Install
+
 #### Accessing the Local WordPress Install
 
 Whether you decided to use Docker or an existing local WordPress install, the WordPress installation should now be available at `http://localhost:8889` (**Username**: `admin`, **Password**: `password`).
@@ -71,9 +74,11 @@ To shut down this local WordPress instance run `npm run env stop`. To start it b
 WordPress comes with specific [debug systems](https://wordpress.org/support/article/debugging-in-wordpress/) designed to simplify the process as well as standardize code across core, plugins and themes. It is possible to use environment variables (`LOCAL_WP_DEBUG` and `LOCAL_SCRIPT_DEBUG`) to update a site's configuration constants located in `wp-config.php` file. Both flags can be disabled at any time by running the following command:
 
 Example on Linux/MacOS:
-```
+
+```bash
 LOCAL_SCRIPT_DEBUG=false LOCAL_WP_DEBUG=false npm run env install
 ```
+
 By default, both flags will be set to `true`.
 
 #### Troubleshooting

--- a/docs/contributors/getting-started.md
+++ b/docs/contributors/getting-started.md
@@ -50,7 +50,7 @@ In Windows, you can set the `WP_DEVELOP_DIR` environment variable using the appr
 
     CMD: set WP_DEVELOP_DIR=/path/to/wordpress-develop
     PowerShell: $env:WP_DEVELOP_DIR = "/path/to/wordpress-develop"
-	
+
 ### Step 2: Accessing and Configuring the Local WordPress Install
 #### Accessing the Local WordPress Install
 
@@ -132,13 +132,10 @@ To use Prettier, you should install the [Prettier - Code formatter extension](ht
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.formatOnSave": true
 },
+"prettier.configPath": "packages/scripts/config/.prettierrc.js"
 ```
 
-This will use the `.prettierrc.js` file in the root folder of the Gutenberg repository and the version of Prettier that is installed in the root `node_modules` folder. To test it out prior to PR #18048 being merged, you should:
-
-1. git switch add/prettier
-2. npm ci
-3. Edit a JavaScript file and on save it will format it as defined
+This will use the `.prettierrc.js` file included in the scripts package of the Gutenberg repository.
 
 ### TypeScript
 

--- a/packages/scripts/scripts/format-js.js
+++ b/packages/scripts/scripts/format-js.js
@@ -59,29 +59,6 @@ function checkPrettier() {
 		};
 	}
 
-	// See: https://prettier.io/docs/en/configuration.html
-	const hasProjectPrettierConfig =
-		hasProjectFile( '.prettierrc.js' ) ||
-		hasProjectFile( '.prettierrc.json' ) ||
-		hasProjectFile( '.prettierrc.toml' ) ||
-		hasProjectFile( '.prettierrc.yaml' ) ||
-		hasProjectFile( '.prettierrc.yml' ) ||
-		hasProjectFile( 'prettier.config.js' ) ||
-		hasProjectFile( '.prettierrc' ) ||
-		hasPackageProp( 'prettier' );
-
-	if ( ! hasProjectPrettierConfig ) {
-		return {
-			success: false,
-			message:
-				chalk.red(
-					'The Prettier config file was not found in your project\n'
-				) +
-				'You need to create a top-level Prettier config file in your project to get ' +
-				'automatic code formatting that works with IDE and editor integrations.\n\n',
-		};
-	}
-
 	return { success: true };
 }
 
@@ -89,6 +66,25 @@ const checkResult = checkPrettier();
 if ( ! checkResult.success ) {
 	stdout.write( checkResult.message );
 	exit( 1 );
+}
+
+// Check for existing config in project, if it exists no command-line args are
+// needed for config, otherwise pass in args to default config in packages
+// See: https://prettier.io/docs/en/configuration.html
+let configArgs = [];
+const hasProjectPrettierConfig =
+	hasProjectFile( '.prettierrc.js' ) ||
+	hasProjectFile( '.prettierrc.json' ) ||
+	hasProjectFile( '.prettierrc.toml' ) ||
+	hasProjectFile( '.prettierrc.yaml' ) ||
+	hasProjectFile( '.prettierrc.yml' ) ||
+	hasProjectFile( 'prettier.config.js' ) ||
+	hasProjectFile( '.prettierrc' ) ||
+	hasPackageProp( 'prettier' );
+
+// TODO: once setup, use @wordpress/prettier-config
+if ( ! hasProjectPrettierConfig ) {
+	configArgs = [ '--config', fromConfigRoot( '.prettierrc.js' ) ];
 }
 
 // If `--ignore-path` is not explicitly specified, use the project's or global .eslintignore
@@ -119,7 +115,7 @@ const globArgs = dirGlob( fileArgs, { extensions: [ 'js' ] } );
 
 const result = spawn(
 	resolveBin( 'prettier' ),
-	[ '--write', ...ignoreArgs, ...pragmaArgs, ...globArgs ],
+	[ '--write', ...configArgs, ...ignoreArgs, ...pragmaArgs, ...globArgs ],
 	{ stdio: 'inherit' }
 );
 

--- a/packages/scripts/scripts/format-js.js
+++ b/packages/scripts/scripts/format-js.js
@@ -72,8 +72,7 @@ if ( ! checkResult.success ) {
 // needed for config, otherwise pass in args to default config in packages
 // See: https://prettier.io/docs/en/configuration.html
 let configArgs = [];
-const hasProjectPrettierConfig =
-	hasProjectFile( '.prettierrc.js' ) ||
+const hasProjectPrettierConfig = hasProjectFile( '.prettierrc.js' ) ||
 	hasProjectFile( '.prettierrc.json' ) ||
 	hasProjectFile( '.prettierrc.toml' ) ||
 	hasProjectFile( '.prettierrc.yaml' ) ||

--- a/packages/scripts/scripts/format-js.js
+++ b/packages/scripts/scripts/format-js.js
@@ -72,7 +72,8 @@ if ( ! checkResult.success ) {
 // needed for config, otherwise pass in args to default config in packages
 // See: https://prettier.io/docs/en/configuration.html
 let configArgs = [];
-const hasProjectPrettierConfig = hasProjectFile( '.prettierrc.js' ) ||
+const hasProjectPrettierConfig =
+	hasProjectFile( '.prettierrc.js' ) ||
 	hasProjectFile( '.prettierrc.json' ) ||
 	hasProjectFile( '.prettierrc.toml' ) ||
 	hasProjectFile( '.prettierrc.yaml' ) ||


### PR DESCRIPTION
## Description

Updates format-js instead of failing if it does not find a default config, to use the default in the packages/scripts config. This supports using the script outside of the Gutenberg project  where a default config might not already exist, for example developing a block plugin.

Updates documentation, clarifying editor usage, including part about workpsace settings in Visual Studio Code and adds link to other editor integrations.

## How has this been tested?

- Confirm prettier still runs as expected in Visual Studio Code.
- Confirm `npm run format-js` works as expected
- Use `format-js` script without a prettier config, and should still work

## Types of changes

Updates format-js script moving the check to configure the default config and not fail.
Minor update to getting started docs.
