### PR TITLE
Navigation: set inherit color to anchor elements

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -192,6 +192,10 @@ $navigation-sub-menu-width: $grid-size * 25;
 		.wp-block-navigation-link svg {
 			transform: rotate(0);
 		}
+
+		&.has-text-color .wp-block-navigation-link__content {
+			color: inherit;
+		}
 	}
 }
 


### PR DESCRIPTION
## Description
It sets the color of the anchor elements when the Navigation menu has defined a text color. It fixes coloring issues for some themes.

## How has this been tested?
Tested with `Maywood`, `Twenty-Seventeen` themes:

1) Create a Navigation menu
2) Set (only) text color

<img src="https://user-images.githubusercontent.com/77539/73790867-1303d800-4756-11ea-8a46-f65d014ee0b1.png" width="300px" />

3) Save

**before**
4) In the front-end, confirm that the color is not applied on the menu.
![image](https://user-images.githubusercontent.com/77539/73791023-67a75300-4756-11ea-8ca7-d680a9677737.png)

**after**
5) Confirm that the color is rightly applied ob the menu, in the front-end.
<img width="1502" alt="Screen Shot 2020-02-04 at 1 56 25 PM" src="https://user-images.githubusercontent.com/77539/73790940-3cbcff00-4756-11ea-90b9-fe4d315e475e.png">


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->