### PR TITLE
[Mobile] Fix blank image size labels on mobile - 1.22.0

### DIFF
--- a/packages/block-editor/src/store/defaults.js
+++ b/packages/block-editor/src/store/defaults.js
@@ -126,10 +126,10 @@ export const SETTINGS_DEFAULTS = {
 	],
 
 	imageSizes: [
-		{ slug: 'thumbnail', label: __( 'Thumbnail' ) },
-		{ slug: 'medium', label: __( 'Medium' ) },
-		{ slug: 'large', label: __( 'Large' ) },
-		{ slug: 'full', label: __( 'Full Size' ) },
+		{ slug: 'thumbnail', name: __( 'Thumbnail' ) },
+		{ slug: 'medium', name: __( 'Medium' ) },
+		{ slug: 'large', name: __( 'Large' ) },
+		{ slug: 'full', name: __( 'Full Size' ) },
 	],
 
 	// This is current max width of the block inner area


### PR DESCRIPTION
#### Related PR:

`gutenberg-mobile`: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1856
`WordPress-Android`: https://github.com/wordpress-mobile/WordPress-Android/pull/11236
`WordPress-iOS`: https://github.com/wordpress-mobile/WordPress-iOS/pull/13375


## Description
This brings the fix from https://github.com/WordPress/gutenberg/pull/19800 to the release branch for `1.22.0`.

## How has this been tested?
Tested via steps here: https://github.com/WordPress/gutenberg/pull/19800#issue-365661691

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
