### PR TITLE
Project Management Automation: Avoid milestone task for forks

### DIFF
--- a/packages/project-management-automation/lib/index.js
+++ b/packages/project-management-automation/lib/index.js
@@ -27,7 +27,7 @@ const automations = [
 	{
 		event: 'pull_request',
 		action: 'closed',
-		task: addMilestone,
+		task: ifNotFork( addMilestone ),
 	},
 ];
 


### PR DESCRIPTION
Previously: #20021
Related: #17324

The milestone Action currently generate errors for merged pull requests originating from a fork repository:

https://github.com/WordPress/gutenberg/commit/084f38a21662a27d00bb3d32f350e9141f9caf38/checks?check_suite_id=439313372#step:4:12

The milestone task was originally omitted from the conditional runs implemented in #20021 based on the incorrect assumption the merge event would be considered with higher permissions, even if the pull request being merged originated from a fork. This is clearly not the case, and it seems all `pull_request` events will be subject to these restrictions.

https://help.github.com/en/actions/automating-your-workflow-with-github-actions/authenticating-with-the-github_token#permissions-for-the-github_token

Understandably, this diminishes the value of this automation, as we can't rely that the milestone will have been applied.

Separately, there might be alternatives to explore here, where the event is handled in response to the commit as it ends up being pushed to master. In other words, some combination of:

- The [`push` event](https://developer.github.com/v3/activity/events/types/#pushevent)
- Conditioning on commits that occur in the `master` branch
- Deriving a pull request associated with the commit
   - Related: https://developer.github.com/v3/repos/commits/#list-pull-requests-associated-with-commit (still experimental as of the writing of this pull request)
- Applying milestone to the pull request