### PR TITLE
Core Data: Mark the `getEntityRecordNoResolver` selector as experimental.

### DIFF
--- a/docs/designers-developers/developers/data/data-core.md
+++ b/docs/designers-developers/developers/data/data-core.md
@@ -202,21 +202,6 @@ _Returns_
 
 -   `?Object`: The entity record's non transient edits.
 
-<a name="getEntityRecordNoResolver" href="#getEntityRecordNoResolver">#</a> **getEntityRecordNoResolver**
-
-Returns the Entity's record object by key. Doesn't trigger a resolver nor requests the entity from the API if the entity record isn't available in the local state.
-
-_Parameters_
-
--   _state_ `Object`: State tree
--   _kind_ `string`: Entity kind.
--   _name_ `string`: Entity name.
--   _key_ `number`: Record's key
-
-_Returns_
-
--   `?Object`: Record.
-
 <a name="getEntityRecords" href="#getEntityRecords">#</a> **getEntityRecords**
 
 Returns the Entity's records.

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -415,21 +415,6 @@ _Returns_
 
 -   `?Object`: The entity record's non transient edits.
 
-<a name="getEntityRecordNoResolver" href="#getEntityRecordNoResolver">#</a> **getEntityRecordNoResolver**
-
-Returns the Entity's record object by key. Doesn't trigger a resolver nor requests the entity from the API if the entity record isn't available in the local state.
-
-_Parameters_
-
--   _state_ `Object`: State tree
--   _kind_ `string`: Entity kind.
--   _name_ `string`: Entity name.
--   _key_ `number`: Record's key
-
-_Returns_
-
--   `?Object`: Record.
-
 <a name="getEntityRecords" href="#getEntityRecords">#</a> **getEntityRecords**
 
 Returns the Entity's records.

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -393,7 +393,7 @@ export function* saveEntityRecord(
 			// Get the full local version of the record before the update,
 			// to merge it with the edits and then propagate it to subscribers
 			persistedEntity = yield select(
-				'getEntityRecordNoResolver',
+				'__experimentalGetEntityRecordNoResolver',
 				kind,
 				name,
 				recordId

--- a/packages/core-data/src/selectors.js
+++ b/packages/core-data/src/selectors.js
@@ -129,7 +129,12 @@ export function getEntityRecord( state, kind, name, key ) {
  *
  * @return {Object?} Record.
  */
-export function getEntityRecordNoResolver( state, kind, name, key ) {
+export function __experimentalGetEntityRecordNoResolver(
+	state,
+	kind,
+	name,
+	key
+) {
 	return getEntityRecord( state, kind, name, key );
 }
 

--- a/packages/core-data/src/test/actions.js
+++ b/packages/core-data/src/test/actions.js
@@ -44,11 +44,11 @@ describe( 'saveEntityRecord', () => {
 			'SAVE_ENTITY_RECORD_START'
 		);
 
-		// Should select getEntityRecordNoResolver selector (as opposed to getEntityRecord)
+		// Should select __experimentalGetEntityRecordNoResolver selector (as opposed to getEntityRecord)
 		// see https://github.com/WordPress/gutenberg/pull/19752#discussion_r368498318.
 		expect( fulfillment.next().value.type ).toBe( 'SELECT' );
 		expect( fulfillment.next().value.selectorName ).toBe(
-			'getEntityRecordNoResolver'
+			'__experimentalGetEntityRecordNoResolver'
 		);
 		expect( fulfillment.next().value.type ).toBe( 'SELECT' );
 		expect( fulfillment.next().value.type ).toBe( 'RECEIVE_ITEMS' );

--- a/packages/core-data/src/test/selectors.js
+++ b/packages/core-data/src/test/selectors.js
@@ -8,7 +8,7 @@ import deepFreeze from 'deep-freeze';
  */
 import {
 	getEntityRecord,
-	getEntityRecordNoResolver,
+	__experimentalGetEntityRecordNoResolver,
 	getEntityRecords,
 	getEntityRecordChangesByRecord,
 	getEntityRecordNonTransientEdits,
@@ -21,53 +21,53 @@ import {
 	getReferenceByDistinctEdits,
 } from '../selectors';
 
-// getEntityRecord and getEntityRecordNoResolver selectors share the same tests
-describe.each( [ [ getEntityRecord ], [ getEntityRecordNoResolver ] ] )(
-	'%p',
-	( selector ) => {
-		it( 'should return undefined for unknown record’s key', () => {
-			const state = deepFreeze( {
-				entities: {
-					data: {
-						root: {
-							postType: {
-								queriedData: {
-									items: {},
-									queries: {},
-								},
+// getEntityRecord and __experimentalGetEntityRecordNoResolver selectors share the same tests
+describe.each( [
+	[ getEntityRecord ],
+	[ __experimentalGetEntityRecordNoResolver ],
+] )( '%p', ( selector ) => {
+	it( 'should return undefined for unknown record’s key', () => {
+		const state = deepFreeze( {
+			entities: {
+				data: {
+					root: {
+						postType: {
+							queriedData: {
+								items: {},
+								queries: {},
 							},
 						},
 					},
 				},
-			} );
-			expect( selector( state, 'root', 'postType', 'post' ) ).toBe(
-				undefined
-			);
+			},
 		} );
+		expect( selector( state, 'root', 'postType', 'post' ) ).toBe(
+			undefined
+		);
+	} );
 
-		it( 'should return a record by key', () => {
-			const state = deepFreeze( {
-				entities: {
-					data: {
-						root: {
-							postType: {
-								queriedData: {
-									items: {
-										post: { slug: 'post' },
-									},
-									queries: {},
+	it( 'should return a record by key', () => {
+		const state = deepFreeze( {
+			entities: {
+				data: {
+					root: {
+						postType: {
+							queriedData: {
+								items: {
+									post: { slug: 'post' },
 								},
+								queries: {},
 							},
 						},
 					},
 				},
-			} );
-			expect( selector( state, 'root', 'postType', 'post' ) ).toEqual( {
-				slug: 'post',
-			} );
+			},
 		} );
-	}
-);
+		expect( selector( state, 'root', 'postType', 'post' ) ).toEqual( {
+			slug: 'post',
+		} );
+	} );
+} );
 
 describe( 'getEntityRecords', () => {
 	it( 'should return an null by default', () => {


### PR DESCRIPTION
See https://github.com/WordPress/gutenberg/pull/19752#discussion_r375378545.