### PR TITLE
Try G2: Mover interactions

### DIFF
--- a/packages/block-editor/src/components/block-list/block-contextual-toolbar.js
+++ b/packages/block-editor/src/components/block-list/block-contextual-toolbar.js
@@ -11,15 +11,17 @@ import { BlockToolbar } from '../';
 
 function BlockContextualToolbar( { focusOnMount, ...props } ) {
 	return (
-		<NavigableToolbar
-			focusOnMount={ focusOnMount }
-			className="block-editor-block-contextual-toolbar"
-			/* translators: accessibility text for the block toolbar */
-			aria-label={ __( 'Block tools' ) }
-			{ ...props }
-		>
-			<BlockToolbar />
-		</NavigableToolbar>
+		<div className="block-editor-block-contextual-toolbar-wrapper">
+			<NavigableToolbar
+				focusOnMount={ focusOnMount }
+				className="block-editor-block-contextual-toolbar"
+				/* translators: accessibility text for the block toolbar */
+				aria-label={ __( 'Block tools' ) }
+				{ ...props }
+			>
+				<BlockToolbar />
+			</NavigableToolbar>
+		</div>
 	);
 }
 

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -424,6 +424,9 @@
 /**
  * Block Toolbar when contextual.
  */
+.block-editor-block-contextual-toolbar-wrapper {
+	padding-left: 48px;
+}
 
 .block-editor-block-contextual-toolbar {
 	// Adapt the height of the toolbar items.

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -425,7 +425,7 @@
  * Block Toolbar when contextual.
  */
 .block-editor-block-contextual-toolbar-wrapper {
-	padding-left: 48px;
+	padding-left: $grid-unit-60; // Provide space for the mover control on full-wide items.
 }
 
 .block-editor-block-contextual-toolbar {
@@ -543,7 +543,7 @@
 
 			// @todo It should position the block transform dialog as the left margin of a block. It currently
 			// positions instead, the mover control.
-			margin-left: -$grid-unit-60;
+			margin-left: -$grid-unit-60 - $grid-unit-60 - $border-width;
 		}
 
 		.block-editor-block-contextual-toolbar[data-align="full"],

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -425,7 +425,7 @@
  * Block Toolbar when contextual.
  */
 .block-editor-block-contextual-toolbar-wrapper {
-	padding-left: $grid-unit-60; // Provide space for the mover control on full-wide items.
+	padding-left: $block-toolbar-height; // Provide space for the mover control on full-wide items.
 }
 
 .block-editor-block-contextual-toolbar {
@@ -463,7 +463,7 @@
 		// The button here has a special style to appear as a toolbar.
 		.components-button {
 			font-size: $default-font-size;
-			height: $grid-unit-60;
+			height: $block-toolbar-height;
 			padding: $grid-unit-15 $grid-unit-20;
 
 			// Block UI appearance.
@@ -543,7 +543,7 @@
 
 			// @todo It should position the block transform dialog as the left margin of a block. It currently
 			// positions instead, the mover control.
-			margin-left: -$grid-unit-60 - $grid-unit-60 - $border-width;
+			margin-left: - $block-toolbar-height - $border-width;
 		}
 
 		.block-editor-block-contextual-toolbar[data-align="full"],

--- a/packages/block-editor/src/components/block-switcher/style.scss
+++ b/packages/block-editor/src/components/block-switcher/style.scss
@@ -33,7 +33,7 @@
 }
 
 .components-button.block-editor-block-switcher__no-switcher-icon {
-	width: $grid-unit-60;
+	width: $block-toolbar-height;
 
 	.block-editor-blocks-icon {
 		margin-right: auto;

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -53,7 +53,6 @@ export default function BlockToolbar( { hideDragHandle } ) {
 		};
 	}, [] );
 
-	const containerNodeRef = useRef();
 	const nodeRef = useRef();
 
 	const {
@@ -77,7 +76,7 @@ export default function BlockToolbar( { hideDragHandle } ) {
 	};
 
 	return (
-		<div className="block-editor-block-toolbar" ref={ containerNodeRef }>
+		<div className="block-editor-block-toolbar">
 			<div
 				className="block-editor-block-toolbar__mover-switcher-container"
 				ref={ nodeRef }

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -2,7 +2,8 @@
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-
+import { useRef } from '@wordpress/element';
+import { useViewportMatch } from '@wordpress/compose';
 /**
  * Internal dependencies
  */
@@ -11,6 +12,7 @@ import BlockSwitcher from '../block-switcher';
 import BlockControls from '../block-controls';
 import BlockFormatControls from '../block-format-controls';
 import BlockSettingsMenu from '../block-settings-menu';
+import { useShowMoversGestures } from './utils';
 
 export default function BlockToolbar( { hideDragHandle } ) {
 	const {
@@ -51,6 +53,17 @@ export default function BlockToolbar( { hideDragHandle } ) {
 		};
 	}, [] );
 
+	const containerNodeRef = useRef();
+	const nodeRef = useRef();
+
+	const {
+		showMovers,
+		gestures: showMoversGestures,
+	} = useShowMoversGestures( { ref: nodeRef } );
+
+	const shouldShowMovers =
+		useViewportMatch( 'medium', '<' ) || ( showMovers && hasMovers );
+
 	if ( blockClientIds.length === 0 ) {
 		return null;
 	}
@@ -58,18 +71,41 @@ export default function BlockToolbar( { hideDragHandle } ) {
 	const shouldShowVisualToolbar = isValid && mode === 'visual';
 	const isMultiToolbar = blockClientIds.length > 1;
 
+	const animatedMoverStyles = {
+		opacity: shouldShowMovers ? 1 : 0,
+		transform: shouldShowMovers ? 'translateX(0px)' : 'translateX(100%)',
+	};
+
 	return (
-		<div className="block-editor-block-toolbar">
-			{ hasMovers && (
-				<BlockMover
-					clientIds={ blockClientIds }
-					__experimentalOrientation={ moverDirection }
-					hideDragHandle={ hideDragHandle }
-				/>
-			) }
-			{ ( shouldShowVisualToolbar || isMultiToolbar ) && (
-				<BlockSwitcher clientIds={ blockClientIds } />
-			) }
+		<div className="block-editor-block-toolbar" ref={ containerNodeRef }>
+			<div
+				className="block-editor-block-toolbar__mover-switcher-container"
+				ref={ nodeRef }
+			>
+				<div
+					className="block-editor-block-toolbar__mover-trigger-container"
+					{ ...showMoversGestures }
+				>
+					<div
+						className="block-editor-block-toolbar__mover-trigger-wrapper"
+						style={ animatedMoverStyles }
+					>
+						<BlockMover
+							clientIds={ blockClientIds }
+							__experimentalOrientation={ moverDirection }
+							hideDragHandle={ hideDragHandle }
+						/>
+					</div>
+				</div>
+				{ ( shouldShowVisualToolbar || isMultiToolbar ) && (
+					<div
+						{ ...showMoversGestures }
+						className="block-editor-block-toolbar__block-switcher-wrapper"
+					>
+						<BlockSwitcher clientIds={ blockClientIds } />
+					</div>
+				) }
+			</div>
 			{ shouldShowVisualToolbar && ! isMultiToolbar && (
 				<>
 					<BlockControls.Slot

--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -209,6 +209,7 @@
 		top: -1px;
 		transform: translateX(-48px);
 		user-select: none;
+		z-index: -1; // This makes it slide out from underneath the toolbar.
 	}
 }
 

--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -225,3 +225,9 @@
 
 	@include reduce-motion("transition");
 }
+
+.block-editor-block-toolbar__block-switcher-wrapper {
+	.block-editor-block-switcher {
+		display: block;
+	}
+}

--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -203,6 +203,7 @@
 
 .block-editor-block-toolbar__mover-trigger-container {
 	@include break-medium() {
+		bottom: -1px;
 		left: -1px;
 		position: absolute;
 		top: -1px;
@@ -218,6 +219,7 @@
 		border-bottom-left-radius: 2px;
 		border-top-left-radius: 2px;
 		border-right: none;
+		height: 100%;
 		transition: all 60ms linear;
 	}
 

--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -196,3 +196,30 @@
 		display: inline-flex;
 	}
 }
+
+.block-editor-block-toolbar__mover-switcher-container {
+	display: flex;
+}
+
+.block-editor-block-toolbar__mover-trigger-container {
+	@include break-medium() {
+		left: -1px;
+		position: absolute;
+		top: -1px;
+		transform: translateX(-48px);
+		user-select: none;
+	}
+}
+
+.block-editor-block-toolbar__mover-trigger-wrapper {
+	@include break-medium() {
+		background-color: $white;
+		border: 1px solid $black;
+		border-bottom-left-radius: 2px;
+		border-top-left-radius: 2px;
+		border-right: none;
+		transition: all 60ms linear;
+	}
+
+	@include reduce-motion("transition");
+}

--- a/packages/block-editor/src/components/block-toolbar/utils.js
+++ b/packages/block-editor/src/components/block-toolbar/utils.js
@@ -17,7 +17,7 @@ export function useDebouncedShowMovers( {
 	const timeoutRef = useRef();
 
 	const getIsHovered = () => {
-		return ref && ref.current.matches( ':hover' );
+		return ref?.current && ref.current.matches( ':hover' );
 	};
 
 	const shouldHideMovers = () => {

--- a/packages/block-editor/src/components/block-toolbar/utils.js
+++ b/packages/block-editor/src/components/block-toolbar/utils.js
@@ -1,0 +1,260 @@
+/**
+ * WordPress dependencies
+ */
+import { useViewportMatch } from '@wordpress/compose';
+import { useState, useRef, useEffect, useCallback } from '@wordpress/element';
+
+const {
+	cancelAnimationFrame,
+	clearTimeout,
+	setTimeout,
+	requestAnimationFrame,
+} = window;
+
+/**
+ * Hook that creates a showMover state, as well as debounced show/hide callbacks
+ */
+export function useDebouncedShowMovers( {
+	ref,
+	isFocused,
+	debounceTimeout = 500,
+} ) {
+	const [ showMovers, setShowMovers ] = useState( false );
+	const timeoutRef = useRef();
+
+	const getIsHovered = () => {
+		return ref && ref.current.matches( ':hover' );
+	};
+
+	const shouldHideMovers = () => {
+		const isHovered = getIsHovered();
+
+		return ! isFocused && ! isHovered;
+	};
+
+	const debouncedShowMovers = useCallback(
+		( event ) => {
+			if ( event ) {
+				event.stopPropagation();
+			}
+
+			const timeout = timeoutRef.current;
+
+			if ( timeout && clearTimeout ) {
+				clearTimeout( timeout );
+			}
+			if ( ! showMovers ) {
+				setShowMovers( true );
+			}
+		},
+		[ showMovers ]
+	);
+
+	const debouncedHideMovers = useCallback(
+		( event ) => {
+			if ( event ) {
+				event.stopPropagation();
+			}
+
+			timeoutRef.current = setTimeout( () => {
+				if ( shouldHideMovers() ) {
+					setShowMovers( false );
+				}
+			}, debounceTimeout );
+		},
+		[ isFocused ]
+	);
+
+	return {
+		showMovers,
+		debouncedShowMovers,
+		debouncedHideMovers,
+	};
+}
+
+/**
+ * Hook that provides a showMovers state and gesture events for DOM elements
+ * that interact with the showMovers state.
+ */
+export function useShowMoversGestures( { ref, debounceTimeout = 500 } ) {
+	const [ isFocused, setIsFocused ] = useState( false );
+	const {
+		showMovers,
+		debouncedShowMovers,
+		debouncedHideMovers,
+	} = useDebouncedShowMovers( { ref, debounceTimeout, isFocused } );
+
+	const registerRef = useRef( false );
+
+	const isFocusedWithin = () => {
+		return ref && ref.current.contains( document.activeElement );
+	};
+
+	useEffect( () => {
+		const node = ref.current;
+
+		const handleOnFocus = () => {
+			if ( isFocusedWithin() ) {
+				setIsFocused( true );
+				debouncedShowMovers();
+			}
+		};
+
+		const handleOnBlur = () => {
+			if ( ! isFocusedWithin() ) {
+				setIsFocused( false );
+				debouncedHideMovers();
+			}
+		};
+
+		/**
+		 * Events are added via DOM events (vs. React synthetic events),
+		 * as the child React components swallow mouse events.
+		 */
+		if ( node && ! registerRef.current ) {
+			node.addEventListener( 'focus', handleOnFocus, true );
+			node.addEventListener( 'blur', handleOnBlur, true );
+			registerRef.current = true;
+		}
+
+		return () => {
+			if ( node ) {
+				node.removeEventListener( 'focus', handleOnFocus );
+				node.removeEventListener( 'blur', handleOnBlur );
+			}
+		};
+	}, [
+		ref,
+		registerRef,
+		setIsFocused,
+		debouncedShowMovers,
+		debouncedHideMovers,
+	] );
+
+	return {
+		showMovers,
+		gestures: {
+			onMouseMove: debouncedShowMovers,
+			onMouseLeave: debouncedHideMovers,
+		},
+	};
+}
+
+const EDITOR_SELECTOR = '.editor-styles-wrapper';
+
+/**
+ * This is experimental.
+ */
+export function useExperimentalToolbarPositioning( { ref } ) {
+	const containerNode = document.querySelector( EDITOR_SELECTOR );
+	const translateXRef = useRef( 0 );
+	const isViewportSmall = useViewportMatch( 'medium', '<' );
+
+	// MATH values
+	const moverWidth = 48;
+	const buffer = 8;
+	const offsetLeft = moverWidth + buffer;
+
+	const updatePosition = useCallback( () => {
+		const node = ref.current;
+		if ( ! node ) return;
+
+		const targetNode = node.parentElement;
+		if ( ! targetNode ) return;
+
+		const { x: containerX, right: containerRight } = getCoords(
+			containerNode
+		);
+		const { x: nodeX, left: nodeLeft, right: nodeRight } = getCoords(
+			targetNode
+		);
+
+		if ( nodeLeft < 0 ) return;
+
+		const currentTranslateX = translateXRef.current;
+		let nextTranslateX;
+
+		// Computed values
+		const totalOffsetLeft = nodeX - offsetLeft;
+		const totalOffsetRight = nodeRight + buffer;
+
+		const isOverflowLeft = totalOffsetLeft < containerX;
+		const isOverflowRight = totalOffsetRight > containerRight;
+
+		if ( isOverflowLeft ) {
+			nextTranslateX = containerX - totalOffsetLeft + currentTranslateX;
+			translateXRef.current = nextTranslateX;
+		} else if ( isOverflowRight ) {
+			nextTranslateX =
+				containerRight - totalOffsetRight + currentTranslateX;
+			translateXRef.current = nextTranslateX;
+		} else {
+			// TODO: Improve reset rendering
+			translateXRef.current = 0;
+		}
+
+		if ( isViewportSmall ) {
+			nextTranslateX = 0;
+		}
+
+		if ( nextTranslateX ) {
+			const translateX = Math.round( nextTranslateX );
+			targetNode.style.transform = `translateX(${ translateX }px)`;
+		}
+
+		targetNode.style.opacity = 1;
+	}, [] );
+
+	useHideOnInitialRender( { ref } );
+	useRequestAnimationFrameLoop( updatePosition );
+}
+
+function useHideOnInitialRender( { ref } ) {
+	useEffect( () => {
+		const node = ref.current;
+		if ( ! node ) return;
+
+		const targetNode = node.parentElement;
+		targetNode.style.opacity = 0;
+	}, [ ref ] );
+}
+
+function useRequestAnimationFrameLoop( callback ) {
+	const rafLoopRef = useRef();
+
+	const rafCallback = ( ...args ) => {
+		if ( callback ) {
+			callback( ...args );
+		}
+		rafLoopRef.current = requestAnimationFrame( rafCallback );
+	};
+
+	useEffect( () => {
+		const cancelAnimationLoop = () => {
+			if ( rafLoopRef.current ) {
+				cancelAnimationFrame( rafLoopRef.current );
+			}
+		};
+
+		rafLoopRef.current = requestAnimationFrame( rafCallback );
+
+		return () => {
+			cancelAnimationLoop();
+		};
+	}, [ rafLoopRef ] );
+}
+
+function getCoords( node ) {
+	if ( ! node ) {
+		return new window.DOMRect( 0, 0, 0, 0 );
+	}
+
+	const { x, left, width } = node.getBoundingClientRect();
+
+	return {
+		x,
+		left,
+		width,
+		right: x + width,
+	};
+}

--- a/packages/block-editor/src/components/rich-text/style.scss
+++ b/packages/block-editor/src/components/rich-text/style.scss
@@ -71,8 +71,8 @@ figcaption.block-editor-rich-text__editable [data-rich-text-placeholder]::before
 
 	.components-toolbar__control,
 	.components-dropdown-menu__toggle {
-		min-width: $grid-unit-60;
-		min-height: $grid-unit-60;
+		min-width: $block-toolbar-height;
+		min-height: $block-toolbar-height;
 		padding-left: $grid-unit-15;
 		padding-right: $grid-unit-15;
 	}


### PR DESCRIPTION
This (draft) PR aims to improve the interactions of the Mover for the G2 redesigned Toolbar.

### Demo of initial attempt:
https://d.pr/v/gqcVs7

(Note: This update does not change how the drag/reorder UX works. It only focuses on the Toolbar Mover bit)

## Interactions
The current implementation works like the following:

### Show mover when:

* Mouse enters/moves **anywhere** within the Toolbar
* Focus is on **any** element within the Toolbar

### Hide mover when:

* Mouse leaves the Toolbar, after a specified debounced time (currently `300ms`)
* Focus jumps outside the Toolbar, and your mouse is not within the Toolbar

### (Current) Gotchas:

* Border radius of Toolbar container needs to be adjusted to work with independent Mover UI
* Show/Hide logic is unaware of Dropdown item interactions (since the elements are Portal, and are technically not child elements of Toolbar)

## Feedback

@youknowriad / @jasmussen Let me know how this feels! The code is definitely not final. I coded enough to test out this interaction, with as little mess as possible.