### PR TITLE
BlockEditor: refactoring getBlockParentsByBlockName() selector

### DIFF
--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -470,24 +470,22 @@ export const getBlockParents = createSelector(
  *
  * @return {Array} ClientIDs of the parent blocks.
  */
-export const getBlockParentsByBlockName = (
-	state,
-	clientId,
-	blockName,
-	ascending = false
-) => {
-	const parents = getBlockParents( state, clientId, ascending );
-	return map(
-		filter(
-			map( parents, ( id ) => ( {
-				id,
-				name: getBlockName( state, id ),
-			} ) ),
-			{ name: blockName }
-		),
-		( { id } ) => id
-	);
-};
+export const getBlockParentsByBlockName = createSelector(
+	( state, clientId, blockName, ascending = false ) => {
+		const parents = getBlockParents( state, clientId, ascending );
+		return map(
+			filter(
+				map( parents, ( id ) => ( {
+					id,
+					name: getBlockName( state, id ),
+				} ) ),
+				{ name: blockName }
+			),
+			( { id } ) => id
+		);
+	},
+	( state ) => [ state.blocks.parents ]
+);
 
 /**
  * Given a block client ID, returns the root of the hierarchy from which the block is nested, return the block itself for root level blocks.

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -22,6 +22,7 @@ const {
 	getBlockName,
 	getBlock,
 	getBlocks,
+	getBlockParents,
 	getBlockCount,
 	getClientIdsWithDescendants,
 	getClientIdsOfDescendants,
@@ -326,6 +327,53 @@ describe( 'selectors', () => {
 					innerBlocks: [],
 				},
 			] );
+		} );
+	} );
+
+	describe( 'getBlockParents', () => {
+		it( 'should return parent blocks', () => {
+			const state = {
+				blocks: {
+					parents: {
+						'client-id-01': '',
+						'client-id-02': 'client-id-01',
+						'client-id-03': 'client-id-02',
+						'client-id-04': 'client-id-03',
+					},
+					byClientId: {
+						'client-id-01': {
+							clientId: 'client-id-01',
+							name: 'core/columns',
+						},
+						'client-id-02': {
+							clientId: 'client-id-02',
+							name: 'core/navigation',
+						},
+						'client-id-03': {
+							clientId: 'client-id-03',
+							name: 'core/navigation-link',
+						},
+						'client-id-04': {
+							clientId: 'client-id-04',
+							name: 'core/paragraph',
+						},
+					},
+					cache: {
+						'client-id-01': {},
+						'client-id-02': {},
+						'client-id-03': {},
+						'client-id-04': {},
+					},
+				},
+			};
+
+			expect( getBlockParents( state, 'client-id-04' ) ).toEqual( [
+				'client-id-01',
+				'client-id-02',
+				'client-id-03',
+			] );
+
+			expect( getBlockParents( state, 'client-id-0' ) ).toEqual( [] );
 		} );
 	} );
 

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -23,6 +23,7 @@ const {
 	getBlock,
 	getBlocks,
 	getBlockParents,
+	getBlockParentsByBlockName,
 	getBlockCount,
 	getClientIdsWithDescendants,
 	getClientIdsOfDescendants,
@@ -374,6 +375,75 @@ describe( 'selectors', () => {
 			] );
 
 			expect( getBlockParents( state, 'client-id-0' ) ).toEqual( [] );
+		} );
+	} );
+
+	describe( 'getBlockParentsByBlockName', () => {
+		it( 'should return parent blocks', () => {
+			const state = {
+				blocks: {
+					parents: {
+						'client-id-01': '',
+						'client-id-02': 'client-id-01',
+						'client-id-03': 'client-id-02',
+						'client-id-04': 'client-id-03',
+						'client-id-05': 'client-id-04',
+					},
+					byClientId: {
+						'client-id-01': {
+							clientId: 'client-id-01',
+							name: 'core/navigation',
+						},
+						'client-id-02': {
+							clientId: 'client-id-02',
+							name: 'core/columns',
+						},
+						'client-id-03': {
+							clientId: 'client-id-03',
+							name: 'core/navigation',
+						},
+						'client-id-04': {
+							clientId: 'client-id-04',
+							name: 'core/navigation-link',
+						},
+						'client-id-05': {
+							clientId: 'client-id-05',
+							name: 'core/navigation-link',
+						},
+					},
+					cache: {
+						'client-id-01': {},
+						'client-id-02': {},
+						'client-id-03': {},
+						'client-id-04': {},
+						'client-id-05': {},
+					},
+				},
+			};
+
+			expect(
+				getBlockParentsByBlockName(
+					state,
+					'client-id-05',
+					'core/navigation'
+				)
+			).toEqual( [ 'client-id-01', 'client-id-03' ] );
+
+			expect(
+				getBlockParentsByBlockName(
+					state,
+					'client-id-05',
+					'core/columns'
+				)
+			).toEqual( [ 'client-id-02' ] );
+
+			expect(
+				getBlockParentsByBlockName(
+					state,
+					'client-id-5',
+					'core/unknown-block'
+				)
+			).toEqual( [] );
 		} );
 	} );
 


### PR DESCRIPTION
## Description
It re implements the getBlockParentsByBlockName() selector using the createSelector() function to memoize what t returns in order to avoid performance issues.

## How has this been tested?

### Manually

Create the following block structure

1) Create a column block (two columns)
2) Add a Navigation block inside
3) Add submenus
4) Set customs colors for text and background

Visually, something like this:
-------------
![image](https://user-images.githubusercontent.com/77539/73882997-f5974280-4817-11ea-8ff6-bda29309a2b7.png)

or paste the following code in the Code Editor mode
```
<!-- wp:columns -->
<div class="wp-block-columns"><!-- wp:column -->
<div class="wp-block-column"><!-- wp:navigation {"rgbTextColor":"#6ab2d1","rgbBackgroundColor":"#051922","itemsJustification":"left"} -->
<!-- wp:navigation-link {"label":"\u003cstrong\u003eAbout\u003c/strong\u003e","title":"Sample Page","type":"page","id":2,"url":"http://localhost:8889/?page_id=2"} -->
<!-- wp:navigation-link {"label":"Contact"} -->
<!-- wp:navigation-link {"label":"Work with Us!"} -->
<!-- wp:navigation-link {"label":"Contact!"} /-->

<!-- wp:navigation-link {"label":"Twenty-Twenty"} /-->

<!-- wp:navigation-link {"label":"Maywood"} /-->

<!-- wp:navigation-link /-->
<!-- /wp:navigation-link -->
<!-- /wp:navigation-link -->

<!-- wp:navigation-link {"label":"Call Us!"} /-->

<!-- wp:navigation-link {"label":"Me"} /-->

<!-- wp:navigation-link {"label":"You!"} /-->
<!-- /wp:navigation-link -->

<!-- wp:navigation-link {"label":"Contact"} -->
<!-- wp:navigation-link {"label":"Regie Miller"} /-->

<!-- wp:navigation-link {"label":"John Stockton"} /-->

<!-- wp:navigation-link {"label":"Penny Hardaway "} /-->

<!-- wp:navigation-link /-->
<!-- /wp:navigation-link -->
<!-- /wp:navigation --></div>
<!-- /wp:column -->

<!-- wp:column -->
<div class="wp-block-column"></div>
<!-- /wp:column --></div>
<!-- /wp:columns -->

<!-- wp:paragraph -->
<p></p>
<!-- /wp:paragraph -->
```

When you inspect the nested Navigation Items, the colors should be propagated to all of them.

Also, you can check the behavior following the steps [of this comment](https://github.com/WordPress/gutenberg/pull/20032#issuecomment-582078664).

### Unit tests

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->