### PR TITLE
Add a label property to the __experimentalUseColors component

### DIFF
--- a/packages/block-editor/src/components/colors/use-colors.js
+++ b/packages/block-editor/src/components/colors/use-colors.js
@@ -296,9 +296,8 @@ export default function __experimentalUseColors(
 				name, // E.g. 'backgroundColor'.
 				property = name, // E.g. 'backgroundColor'.
 				className,
-
-				panelLabel = startCase( name ), // E.g. 'Background Color'.
-				componentName = panelLabel.replace( /\s/g, '' ), // E.g. 'BackgroundColor'.
+				label,
+				componentName = startCase( name ).replace( /\s/g, '' ), // E.g. 'BackgroundColor'.
 
 				color = colorConfig.color,
 				colors = settingsColors,
@@ -333,7 +332,7 @@ export default function __experimentalUseColors(
 					? _color.color
 					: attributes[ camelCase( `custom ${ name }` ) ],
 				onChange: acc[ componentName ].setColor,
-				label: panelLabel,
+				label,
 				colors,
 			};
 			// These settings will be spread over the `colors` in

--- a/packages/block-library/src/columns/edit.js
+++ b/packages/block-library/src/columns/edit.js
@@ -63,7 +63,11 @@ function ColumnsEditContainer( {
 		BackgroundColor,
 		InspectorControlsColorPanel,
 	} = __experimentalUseColors( [
-		{ name: 'backgroundColor', className: 'has-background' },
+		{
+			name: 'backgroundColor',
+			className: 'has-background',
+			label: __( 'Background Color' ),
+		},
 	] );
 
 	const classes = classnames( className, {

--- a/packages/block-library/src/group/edit.js
+++ b/packages/block-library/src/group/edit.js
@@ -5,6 +5,7 @@ import { withSelect } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 import { InnerBlocks, __experimentalUseColors } from '@wordpress/block-editor';
 import { useRef } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 
 function GroupEdit( { hasInnerBlocks } ) {
 	const ref = useRef();
@@ -14,8 +15,16 @@ function GroupEdit( { hasInnerBlocks } ) {
 		InspectorControlsColorPanel,
 	} = __experimentalUseColors(
 		[
-			{ name: 'textColor', property: 'color' },
-			{ name: 'backgroundColor', className: 'has-background' },
+			{
+				name: 'textColor',
+				property: 'color',
+				label: __( 'Text Color' ),
+			},
+			{
+				name: 'backgroundColor',
+				className: 'has-background',
+				label: __( 'Background Color' ),
+			},
 		],
 		{
 			contrastCheckers: { backgroundColor: true, textColor: true },

--- a/packages/block-library/src/heading/edit.js
+++ b/packages/block-library/src/heading/edit.js
@@ -32,7 +32,7 @@ function HeadingEdit( {
 } ) {
 	const ref = useRef();
 	const { TextColor, InspectorControlsColorPanel } = __experimentalUseColors(
-		[ { name: 'textColor', property: 'color' } ],
+		[ { name: 'textColor', property: 'color', label: __( 'Text Color' ) } ],
 		{
 			contrastCheckers: { backgroundColor: true, textColor: true },
 			colorDetector: { targetRef: ref },

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -67,8 +67,12 @@ function Navigation( {
 		ColorPanel,
 	} = __experimentalUseColors(
 		[
-			{ name: 'textColor', property: 'color' },
-			{ name: 'backgroundColor', className: 'has-background' },
+			{ name: 'textColor', property: 'color', label: __( 'Text Color' ) },
+			{
+				name: 'backgroundColor',
+				className: 'has-background',
+				label: __( 'Background Color' ),
+			},
 		],
 		{
 			contrastCheckers: [

--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -92,8 +92,12 @@ function ParagraphBlock( {
 		InspectorControlsColorPanel,
 	} = __experimentalUseColors(
 		[
-			{ name: 'textColor', property: 'color' },
-			{ name: 'backgroundColor', className: 'has-background' },
+			{ name: 'textColor', property: 'color', label: __( 'Text Color' ) },
+			{
+				name: 'backgroundColor',
+				className: 'has-background',
+				label: __( 'Background Color' ),
+			},
 		],
 		{
 			contrastCheckers: [


### PR DESCRIPTION
## Description
Fixes #19890 by adding a label to the colorConfig object passed into the __experimentalUseColors component. I also updated all instances of the object I could find to include a translatable label.

@jorgefilipecosta hopefully this is helpful and not getting in your way, just trying to help push 5.4 forward. 

## How has this been tested?
Add components that use __experimentalUseColors and verify they are displaying the correct labels.

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
