### PR TITLE
Intermitent test failures while running the tests on Core patch

### DIFF
--- a/packages/e2e-test-utils/src/open-publish-panel.js
+++ b/packages/e2e-test-utils/src/open-publish-panel.js
@@ -2,10 +2,9 @@
  * Opens the publish panel.
  */
 export async function openPublishPanel() {
+	await page.waitForSelector(
+		'.editor-post-publish-panel__toggle:not([aria-disabled="true"])'
+	);
 	await page.click( '.editor-post-publish-panel__toggle' );
-
-	// Disable reason: Wait for the animation to complete, since otherwise the
-	// click attempt may occur at the wrong point.
-	// eslint-disable-next-line no-restricted-syntax
-	await page.waitFor( 100 );
+	await page.waitForSelector( '.editor-post-publish-button' );
 }

--- a/packages/e2e-tests/specs/editor/various/editor-modes.test.js
+++ b/packages/e2e-tests/specs/editor/various/editor-modes.test.js
@@ -101,6 +101,9 @@ describe( 'Editing modes (visual/HTML)', () => {
 		await page.click(
 			'.components-custom-select-control__item:nth-child(5)'
 		);
+		await page.waitForXPath(
+			`//button[contains(@class, "components-custom-select-control__button") and contains(text(), 'Large')]`
+		);
 
 		// Make sure the HTML content updated.
 		htmlBlockContent = await page.$eval(

--- a/packages/e2e-tests/specs/editor/various/font-size-picker.test.js
+++ b/packages/e2e-tests/specs/editor/various/font-size-picker.test.js
@@ -21,6 +21,9 @@ describe( 'Font Size Picker', () => {
 		await page.click(
 			'.components-custom-select-control__item:nth-child(5)'
 		);
+		await page.waitForXPath(
+			`//button[contains(@class, "components-custom-select-control__button") and contains(text(), 'Large')]`
+		);
 
 		// Ensure content matches snapshot.
 		const content = await getEditedPostContent();


### PR DESCRIPTION
While running the tests for the Core patch for the 7.4 release locally, I noticed some failures. Most of them are intermittent e2e test failures. This fixes three of them.