### PR TITLE
Blocks: Promote block variations to stable API

### DIFF
--- a/docs/designers-developers/developers/data/data-core-blocks.md
+++ b/docs/designers-developers/developers/data/data-core-blocks.md
@@ -59,6 +59,20 @@ _Returns_
 
 -   `Array`: Block Types.
 
+<a name="getBlockVariations" href="#getBlockVariations">#</a> **getBlockVariations**
+
+Returns block variations by block name.
+
+_Parameters_
+
+-   _state_ `Object`: Data state.
+-   _blockName_ `string`: Block type name.
+-   _scope_ `[WPBlockVariationScope]`: Block variation scope name.
+
+_Returns_
+
+-   `(Array<WPBlockVariation>|void)`: Block variations.
+
 <a name="getCategories" href="#getCategories">#</a> **getCategories**
 
 Returns all the available categories.
@@ -107,6 +121,23 @@ _Parameters_
 _Returns_
 
 -   `?string`: Default block name.
+
+<a name="getDefaultBlockVariation" href="#getDefaultBlockVariation">#</a> **getDefaultBlockVariation**
+
+Returns the default block variation for the given block type.
+When there are multiple variations annotated as the default one,
+the last added item is picked. This simplifies registering overrides.
+When there is no default variation set, it returns the first item.
+
+_Parameters_
+
+-   _state_ `Object`: Data state.
+-   _blockName_ `string`: Block type name.
+-   _scope_ `[WPBlockVariationScope]`: Block variation scope name.
+
+_Returns_
+
+-   `?WPBlockVariation`: The default block variation.
 
 <a name="getFreeformFallbackBlockName" href="#getFreeformFallbackBlockName">#</a> **getFreeformFallbackBlockName**
 
@@ -246,6 +277,19 @@ _Returns_
 
 -   `Object`: Action object.
 
+<a name="addBlockVariations" href="#addBlockVariations">#</a> **addBlockVariations**
+
+Returns an action object used in signalling that new block variations have been added.
+
+_Parameters_
+
+-   _blockName_ `string`: Block name.
+-   _variations_ `(WPBlockVariation|Array<WPBlockVariation>)`: Block variations.
+
+_Returns_
+
+-   `Object`: Action object.
+
 <a name="removeBlockCollection" href="#removeBlockCollection">#</a> **removeBlockCollection**
 
 Returns an action object used to remove block collections
@@ -278,6 +322,19 @@ Returns an action object used to remove a registered block type.
 _Parameters_
 
 -   _names_ `(string|Array)`: Block name.
+
+_Returns_
+
+-   `Object`: Action object.
+
+<a name="removeBlockVariations" href="#removeBlockVariations">#</a> **removeBlockVariations**
+
+Returns an action object used in signalling that block variations have been removed.
+
+_Parameters_
+
+-   _blockName_ `string`: Block name.
+-   _variationNames_ `(string|Array<string>)`: Block variation names.
 
 _Returns_
 

--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -158,9 +158,7 @@ export default compose( [
 			hasInserterItems,
 			__experimentalGetAllowedBlocks,
 		} = select( 'core/block-editor' );
-		const { __experimentalGetBlockVariations: getBlockVariations } = select(
-			'core/blocks'
-		);
+		const { getBlockVariations } = select( 'core/blocks' );
 
 		rootClientId =
 			rootClientId || getBlockRootClientId( clientId ) || undefined;

--- a/packages/block-library/src/columns/edit.js
+++ b/packages/block-library/src/columns/edit.js
@@ -218,21 +218,18 @@ const ColumnsEdit = ( props ) => {
 	} = useSelect(
 		( select ) => {
 			const {
-				__experimentalGetBlockVariations,
+				getBlockVariations,
 				getBlockType,
-				__experimentalGetDefaultBlockVariation,
+				getDefaultBlockVariation,
 			} = select( 'core/blocks' );
 
 			return {
 				blockType: getBlockType( name ),
-				defaultVariation: __experimentalGetDefaultBlockVariation(
-					name,
-					'block'
-				),
+				defaultVariation: getDefaultBlockVariation( name, 'block' ),
 				hasInnerBlocks:
 					select( 'core/block-editor' ).getBlocks( clientId ).length >
 					0,
-				variations: __experimentalGetBlockVariations( name, 'block' ),
+				variations: getBlockVariations( name, 'block' ),
 			};
 		},
 		[ clientId, name ]

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -660,6 +660,15 @@ _Returns_
 
 -   `?WPBlock`: The block, if it has been successfully registered; otherwise `undefined`.
 
+<a name="registerBlockVariation" href="#registerBlockVariation">#</a> **registerBlockVariation**
+
+Registers a new block variation for the given block type.
+
+_Parameters_
+
+-   _blockName_ `string`: Name of the block (example: “core/columns”).
+-   _variation_ `WPBlockVariation`: Object describing a block variation.
+
 <a name="serialize" href="#serialize">#</a> **serialize**
 
 Takes a block or set of blocks and returns the serialized post content.
@@ -764,6 +773,15 @@ _Parameters_
 _Returns_
 
 -   `?WPBlock`: The previous block value, if it has been successfully unregistered; otherwise `undefined`.
+
+<a name="unregisterBlockVariation" href="#unregisterBlockVariation">#</a> **unregisterBlockVariation**
+
+Unregisters a block variation defined for the given block type.
+
+_Parameters_
+
+-   _blockName_ `string`: Name of the block (example: “core/columns”).
+-   _variationName_ `string`: Name of the variation defined for the block.
 
 <a name="updateCategory" href="#updateCategory">#</a> **updateCategory**
 

--- a/packages/blocks/src/api/index.js
+++ b/packages/blocks/src/api/index.js
@@ -50,8 +50,8 @@ export {
 	unstable__bootstrapServerSideBlockDefinitions, // eslint-disable-line camelcase
 	registerBlockStyle,
 	unregisterBlockStyle,
-	__experimentalRegisterBlockVariation,
-	__experimentalUnregisterBlockVariation,
+	registerBlockVariation,
+	unregisterBlockVariation,
 } from './registration';
 export {
 	isUnmodifiedDefaultBlock,

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -491,33 +491,21 @@ export const unregisterBlockStyle = ( blockName, styleVariationName ) => {
 };
 
 /**
- * Registers a new block variation for the given block.
+ * Registers a new block variation for the given block type.
  *
  * @param {string}           blockName Name of the block (example: “core/columns”).
  * @param {WPBlockVariation} variation Object describing a block variation.
  */
-export const __experimentalRegisterBlockVariation = (
-	blockName,
-	variation
-) => {
-	dispatch( 'core/blocks' ).__experimentalAddBlockVariations(
-		blockName,
-		variation
-	);
+export const registerBlockVariation = ( blockName, variation ) => {
+	dispatch( 'core/blocks' ).addBlockVariations( blockName, variation );
 };
 
 /**
- * Unregisters a block variation defined for the given block.
+ * Unregisters a block variation defined for the given block type.
  *
  * @param {string} blockName     Name of the block (example: “core/columns”).
  * @param {string} variationName Name of the variation defined for the block.
  */
-export const __experimentalUnregisterBlockVariation = (
-	blockName,
-	variationName
-) => {
-	dispatch( 'core/blocks' ).__experimentalRemoveBlockVariations(
-		blockName,
-		variationName
-	);
+export const unregisterBlockVariation = ( blockName, variationName ) => {
+	dispatch( 'core/blocks' ).removeBlockVariations( blockName, variationName );
 };

--- a/packages/blocks/src/store/actions.js
+++ b/packages/blocks/src/store/actions.js
@@ -73,7 +73,7 @@ export function removeBlockStyles( blockName, styleNames ) {
  *
  * @return {Object} Action object.
  */
-export function __experimentalAddBlockVariations( blockName, variations ) {
+export function addBlockVariations( blockName, variations ) {
 	return {
 		type: 'ADD_BLOCK_VARIATIONS',
 		variations: castArray( variations ),
@@ -89,10 +89,7 @@ export function __experimentalAddBlockVariations( blockName, variations ) {
  *
  * @return {Object} Action object.
  */
-export function __experimentalRemoveBlockVariations(
-	blockName,
-	variationNames
-) {
+export function removeBlockVariations( blockName, variationNames ) {
 	return {
 		type: 'REMOVE_BLOCK_VARIATIONS',
 		variationNames: castArray( variationNames ),

--- a/packages/blocks/src/store/selectors.js
+++ b/packages/blocks/src/store/selectors.js
@@ -44,10 +44,7 @@ export const getBlockTypes = createSelector(
 		return Object.values( state.blockTypes ).map( ( blockType ) => {
 			return {
 				...blockType,
-				variations: __experimentalGetBlockVariations(
-					state,
-					blockType.name
-				),
+				variations: getBlockVariations( state, blockType.name ),
 			};
 		} );
 	},
@@ -87,7 +84,7 @@ export function getBlockStyles( state, name ) {
  *
  * @return {(WPBlockVariation[]|void)} Block variations.
  */
-export function __experimentalGetBlockVariations( state, blockName, scope ) {
+export function getBlockVariations( state, blockName, scope ) {
 	const variations = state.blockVariations[ blockName ];
 	if ( ! variations || ! scope ) {
 		return variations;
@@ -109,16 +106,8 @@ export function __experimentalGetBlockVariations( state, blockName, scope ) {
  *
  * @return {?WPBlockVariation} The default block variation.
  */
-export function __experimentalGetDefaultBlockVariation(
-	state,
-	blockName,
-	scope
-) {
-	const variations = __experimentalGetBlockVariations(
-		state,
-		blockName,
-		scope
-	);
+export function getDefaultBlockVariation( state, blockName, scope ) {
+	const variations = getBlockVariations( state, blockName, scope );
 
 	return findLast( variations, 'isDefault' ) || first( variations );
 }

--- a/packages/blocks/src/store/test/actions.js
+++ b/packages/blocks/src/store/test/actions.js
@@ -1,10 +1,7 @@
 /**
  * Internal dependencies
  */
-import {
-	__experimentalAddBlockVariations,
-	__experimentalRemoveBlockVariations,
-} from '../actions';
+import { addBlockVariations, removeBlockVariations } from '../actions';
 
 describe( 'actions', () => {
 	describe( 'addBlockVariations', () => {
@@ -19,10 +16,7 @@ describe( 'actions', () => {
 					example: 'foo',
 				},
 			};
-			const result = __experimentalAddBlockVariations(
-				blockName,
-				variation
-			);
+			const result = addBlockVariations( blockName, variation );
 			expect( result ).toEqual( {
 				type: 'ADD_BLOCK_VARIATIONS',
 				variations: [ variation ],
@@ -31,10 +25,7 @@ describe( 'actions', () => {
 		} );
 
 		it( 'should return the REMOVE_BLOCK_VARIATIONS action', () => {
-			const result = __experimentalRemoveBlockVariations(
-				blockName,
-				variationName
-			);
+			const result = removeBlockVariations( blockName, variationName );
 			expect( result ).toEqual( {
 				type: 'REMOVE_BLOCK_VARIATIONS',
 				variationNames: [ variationName ],

--- a/packages/blocks/src/store/test/reducer.js
+++ b/packages/blocks/src/store/test/reducer.js
@@ -7,9 +7,9 @@ import deepFreeze from 'deep-freeze';
  * Internal dependencies
  */
 import {
-	__experimentalAddBlockVariations,
+	addBlockVariations,
 	addBlockTypes,
-	__experimentalRemoveBlockVariations,
+	removeBlockVariations,
 } from '../actions';
 import {
 	blockVariations,
@@ -153,7 +153,7 @@ describe( 'blockVariations', () => {
 
 		const state = blockVariations(
 			initialState,
-			__experimentalAddBlockVariations( blockName, blockVariation )
+			addBlockVariations( blockName, blockVariation )
 		);
 
 		expect( state ).toEqual( {
@@ -168,7 +168,7 @@ describe( 'blockVariations', () => {
 
 		const state = blockVariations(
 			initialState,
-			__experimentalAddBlockVariations( blockName, secondBlockVariation )
+			addBlockVariations( blockName, secondBlockVariation )
 		);
 
 		expect( state ).toEqual( {
@@ -201,7 +201,7 @@ describe( 'blockVariations', () => {
 
 		const state = blockVariations(
 			initialState,
-			__experimentalRemoveBlockVariations( blockName, blockVariationName )
+			removeBlockVariations( blockName, blockVariationName )
 		);
 
 		expect( state ).toEqual( {

--- a/packages/blocks/src/store/test/selectors.js
+++ b/packages/blocks/src/store/test/selectors.js
@@ -8,7 +8,7 @@ import deepFreeze from 'deep-freeze';
  */
 import {
 	getChildBlockNames,
-	__experimentalGetDefaultBlockVariation,
+	getDefaultBlockVariation,
 	getGroupingBlockName,
 	isMatchingSearchTerm,
 } from '../selectors';
@@ -156,7 +156,7 @@ describe( 'selectors', () => {
 		} );
 	} );
 
-	describe( '__experimentalGetDefaultBlockVariation', () => {
+	describe( 'getDefaultBlockVariation', () => {
 		const blockName = 'block/name';
 		const createBlockVariationsState = ( variations ) => {
 			return deepFreeze( {
@@ -186,10 +186,7 @@ describe( 'selectors', () => {
 				thirdBlockVariation,
 			] );
 
-			const result = __experimentalGetDefaultBlockVariation(
-				state,
-				blockName
-			);
+			const result = getDefaultBlockVariation( state, blockName );
 
 			expect( result ).toEqual( defaultBlockVariation );
 		} );
@@ -211,10 +208,7 @@ describe( 'selectors', () => {
 				defaultBlockVariation,
 			] );
 
-			const result = __experimentalGetDefaultBlockVariation(
-				state,
-				blockName
-			);
+			const result = getDefaultBlockVariation( state, blockName );
 
 			expect( result ).toEqual( defaultBlockVariation );
 		} );
@@ -226,10 +220,7 @@ describe( 'selectors', () => {
 				thirdBlockVariation,
 			] );
 
-			const result = __experimentalGetDefaultBlockVariation(
-				state,
-				blockName
-			);
+			const result = getDefaultBlockVariation( state, blockName );
 
 			expect( result ).toEqual( firstBlockVariation );
 		} );


### PR DESCRIPTION
## Description
Part of #16283.

Now that #19887 is close to merging, I opened #20068 to mark the API for the inserter as stable. It also will work with the Columns block.

`__experimentalBlockVariationPicker` remains experimental.

## New APIs

### New type definitions

```js
/**
 * Named block variation scopes.
 *
 * @typedef {'block'|'inserter'} WPBlockVariationScope
 */
```

```js
/**
 * An object describing a variation defined for the block type.
 *
 * @typedef {Object} WPBlockVariation
 *
 * @property {string}   name                   The unique and machine-readable name.
 * @property {string}   title                  A human-readable variation title.
 * @property {string}   description            A detailed variation description.
 * @property {WPIcon}   [icon]                 An icon helping to visualize the variation.
 * @property {boolean}  [isDefault]            Indicates whether the current variation is
 *                                             the default one. Defaults to `false`.
 * @property {Object}   [attributes]           Values which override block attributes.
 * @property {Array[]}  [innerBlocks]          Initial configuration of nested blocks.
 * @property {Object}   [example]              Example provides structured data for
 *                                             the block preview. You can set to
 *                                             `undefined` to disable the preview shown
 *                                             for the block type.
 * @property {WPBlockVariationScope[]} [scope] The list of scopes where the variation
 *                                             is applicable. When not provided, it
 *                                             assumes all available scopes.
 */
```

### `@wordpress/blocks`

```js
/**
 * Registers a new block variation for the given block.
 *
 * @param {string}           blockName Name of the block (example: “core/columns”).
 * @param {WPBlockVariation} variation Object describing a block variation.
 */
function registerBlockVariation( blockName, variation );
```

```js
/**
 * Unregisters a block variation defined for the given block.
 *
 * @param {string} blockName     Name of the block (example: “core/columns”).
 * @param {string} variationName Name of the variation defined for the block.
 */
function unregisterBlockVariation( blockName, variationName );
```

### `core/blocks` store

```js
/**
 * Returns an action object used in signalling that new block variations have been added.
 *
 * @param {string}                              blockName  Block name.
 * @param {WPBlockVariation|WPBlockVariation[]} variations Block variations.
 *
 * @return {Object} Action object.
 */
function addBlockVariations( blockName, variations );
```

```js
/**
 * Returns an action object used in signalling that block variations have been removed.
 *
 * @param {string}          blockName      Block name.
 * @param {string|string[]} variationNames Block variation names.
 *
 * @return {Object} Action object.
 */
function removeBlockVariations( blockName, variationNames );
````

```js
/**
 * Returns block variations by block name.
 *
 * @param {Object}                state     Data state.
 * @param {string}                blockName Block type name.
 * @param {WPBlockVariationScope} [scope]   Block variation scope name.
 *
 * @return {(WPBlockVariation[]|void)} Block variations.
 */
function getBlockVariations( state, blockName, scope );
```

```js
/**
 * Returns the default block variation for the given block type.
 * When there are multiple variations annotated as the default one,
 * the last added item is picked. This simplifies registering overrides.
 * When there is no default variation set, it returns the first item.
 *
 * @param {Object}                state     Data state.
 * @param {string}                blockName Block type name.
 * @param {WPBlockVariationScope} [scope]   Block variation scope name.
 *
 * @return {?WPBlockVariation} The default block variation.
 */
function getDefaultBlockVariation( state, blockName, scope );
```

## Testing scenarios:

_Recorded screencasts contain unstable API but included code examples are up to date._

1. Registers the variation with the inner blocks to apply from the block variation picker using `scope` limited to the block: 

```js
wp.blocks.registerBlockVariation( 'core/columns', { name: 'custom', title: 'Smiley', isDefault: true, innerBlocks: [ [ 'core/column' ], [ 'core/column' ], [ 'core/column' ], [ 'core/column' ] ], icon: 'smiley', scope: [ 'block' ] } );
```
![patterns-api-inserter-1](https://user-images.githubusercontent.com/699132/72546493-245e7080-388b-11ea-9962-c870b6e69046.gif)

2. Registers the variation with the inner blocks to apply from the inserter using `scope` limited to the inserter: 
```js
wp.blocks.registerBlockVariation( 'core/columns', { name: 'custom', title: 'Smiley', isDefault: true, innerBlocks: [ [ 'core/column' ], [ 'core/column' ], [ 'core/column' ], [ 'core/column' ] ], icon: 'smiley', scope: [ 'inserter' ] } );
```

![patterns-api-inserter-2](https://user-images.githubusercontent.com/699132/72546494-245e7080-388b-11ea-8ee1-d2a309991fcd.gif)

2. Registers two variations with initial attributes to apply from the inserter directly:
```js
wp.blocks.registerBlockVariation( 'core/heading', { name: 'green-text', title: 'Green Text', description: 'This block has green text. It overrides the default description.',  attributes: { content: 'Green Text', textColor: 'vivid-green-cyan' }, icon: 'palmtree', scope: [ 'inserter' ] } );
wp.blocks.registerBlockVariation( 'core/heading', { name: 'red-text', title: 'Red Text', attributes: { content: 'Red Text', level: 3, textColor: 'vivid-red' }, icon: 'smiley', scope: [ 'inserter' ] } );
```

![patterns-api-inserter-3](https://user-images.githubusercontent.com/699132/72546975-080f0380-388c-11ea-8955-5eef87d997be.gif)

3. Registers a variation which allows changing the default style variation:
```js
wp.blocks.registerBlockVariation( 'core/quote', { name: 'large', title: 'Large Quote', isDefault: true, attributes: { className: 'is-style-large' }, icon: 'palmtree', scope: [ 'inserter' ] } );
```
## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
