### PR TITLE
Scripts: Ensure the default Prettier config is used with `lint-js` when needed

### DIFF
--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Master
 
+### Bug Fixes
+
+- Ensure the default Prettier config is used in the `lint-js` script when no Prettier config found in the project ([#20071](https://github.com/WordPress/gutenberg/pull/20071)).
+
 ## 7.0.0 (2020-02-04)
 
 ### Breaking Changes

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Bug Fixes
 
-- Ensure the default Prettier config is used in the `lint-js` script when no Prettier config found in the project ([#20071](https://github.com/WordPress/gutenberg/pull/20071)).
+- Ensure the default Prettier config is used in the `lint-js` script when no Prettier config is found in the project ([#20071](https://github.com/WordPress/gutenberg/pull/20071)).
 
 ## 7.0.0 (2020-02-04)
 

--- a/packages/scripts/config/.eslintrc.js
+++ b/packages/scripts/config/.eslintrc.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-const defaultPrettierConfig = require( '../config/.prettierrc' );
+const defaultPrettierConfig = require( './.prettierrc' );
 const { hasPrettierConfig } = require( '../utils' );
 
 const eslintConfig = {

--- a/packages/scripts/config/.eslintrc.js
+++ b/packages/scripts/config/.eslintrc.js
@@ -1,4 +1,10 @@
-module.exports = {
+/**
+ * Internal dependencies
+ */
+const defaultPrettierConfig = require( '../config/.prettierrc' );
+const { hasPrettierConfig } = require( '../utils' );
+
+const eslintConfig = {
 	root: true,
 	extends: [
 		'plugin:@wordpress/eslint-plugin/recommended',
@@ -10,3 +16,17 @@ module.exports = {
 		'plugin:@wordpress/eslint-plugin/test-unit',
 	],
 };
+
+if ( ! hasPrettierConfig() ) {
+	eslintConfig.rules = {
+		'prettier/prettier': [
+			'error',
+			defaultPrettierConfig,
+			{
+				usePrettierrc: false,
+			},
+		],
+	};
+}
+
+module.exports = eslintConfig;

--- a/packages/scripts/scripts/format-js.js
+++ b/packages/scripts/scripts/format-js.js
@@ -21,7 +21,7 @@ const {
 	getArgFromCLI,
 	getFileArgsFromCLI,
 	hasArgInCLI,
-	hasPackageProp,
+	hasPrettierConfig,
 	hasProjectFile,
 } = require( '../utils' );
 
@@ -72,18 +72,8 @@ if ( ! checkResult.success ) {
 // needed for config, otherwise pass in args to default config in packages
 // See: https://prettier.io/docs/en/configuration.html
 let configArgs = [];
-const hasProjectPrettierConfig =
-	hasProjectFile( '.prettierrc.js' ) ||
-	hasProjectFile( '.prettierrc.json' ) ||
-	hasProjectFile( '.prettierrc.toml' ) ||
-	hasProjectFile( '.prettierrc.yaml' ) ||
-	hasProjectFile( '.prettierrc.yml' ) ||
-	hasProjectFile( 'prettier.config.js' ) ||
-	hasProjectFile( '.prettierrc' ) ||
-	hasPackageProp( 'prettier' );
-
 // TODO: once setup, use @wordpress/prettier-config
-if ( ! hasProjectPrettierConfig ) {
+if ( ! hasPrettierConfig() ) {
 	configArgs = [ '--config', fromConfigRoot( '.prettierrc.js' ) ];
 }
 

--- a/packages/scripts/utils/config.js
+++ b/packages/scripts/utils/config.js
@@ -31,6 +31,16 @@ const hasJestConfig = () =>
 	hasProjectFile( 'jest.config.json' ) ||
 	hasPackageProp( 'jest' );
 
+const hasPrettierConfig = () =>
+	hasProjectFile( '.prettierrc.js' ) ||
+	hasProjectFile( '.prettierrc.json' ) ||
+	hasProjectFile( '.prettierrc.toml' ) ||
+	hasProjectFile( '.prettierrc.yaml' ) ||
+	hasProjectFile( '.prettierrc.yml' ) ||
+	hasProjectFile( 'prettier.config.js' ) ||
+	hasProjectFile( '.prettierrc' ) ||
+	hasPackageProp( 'prettier' );
+
 const hasWebpackConfig = () =>
 	hasArgInCLI( '--config' ) ||
 	hasProjectFile( 'webpack.config.js' ) ||
@@ -98,4 +108,5 @@ module.exports = {
 	getWebpackArgs,
 	hasBabelConfig,
 	hasJestConfig,
+	hasPrettierConfig,
 };

--- a/packages/scripts/utils/index.js
+++ b/packages/scripts/utils/index.js
@@ -9,7 +9,12 @@ const {
 	hasFileArgInCLI,
 	spawnScript,
 } = require( './cli' );
-const { getWebpackArgs, hasBabelConfig, hasJestConfig } = require( './config' );
+const {
+	getWebpackArgs,
+	hasBabelConfig,
+	hasJestConfig,
+	hasPrettierConfig,
+} = require( './config' );
 const {
 	buildWordPress,
 	downloadWordPressZip,
@@ -33,6 +38,7 @@ module.exports = {
 	hasFileArgInCLI,
 	hasJestConfig,
 	hasPackageProp,
+	hasPrettierConfig,
 	hasProjectFile,
 	downloadWordPressZip,
 	mergeYAMLConfigs,


### PR DESCRIPTION
## Description
Follow-up for #20036.

`wp-scripts lint-js` uses the default Prettier settings if no config is provided in the root of the project. It wasn't the case for Gutenberg because it has Prettier config for IDE integration.

This patch adds a fallback for projects who opt-out from defining their own Prettier config and reuses the default one used with `wp-scripts format-js`

## How has this been tested?
I removed ESLint config and Prettier config from the root level of Gutenberg and executed:
`npm run lint-js`

There were 24 errors reported but they are silenced with the existing ESLint plugin. That confirms that this patch works as intended.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
