### PR TITLE
Social Link: Fix server-side rendering for legacy format

### DIFF
--- a/packages/block-library/src/social-link/index.php
+++ b/packages/block-library/src/social-link/index.php
@@ -81,6 +81,18 @@ function register_block_core_social_link() {
 			array_merge(
 				$metadata,
 				array(
+					'attributes'      => array(
+						'url'     => array(
+							'type' => 'string',
+						),
+						'service' => array(
+							'type'    => 'string',
+							'default' => $site,
+						),
+						'label'   => array(
+							'type' => 'string',
+						),
+					),
 					'render_callback' => 'render_core_social_link',
 				)
 			)


### PR DESCRIPTION
Fixes a regression introduced in #19887.

While changing the logic in `register_block_core_social_link` to consume the block type's `block.json` and switch to the `$service` attribute name, I broke the handling of the legacy format for social links.

Old format: `<!-- wp:social-link-wordpress {"url":"foo"} /-->`
New format: `<!-- wp:social-link {"service":"wordpress","url":"foo"} /-->`

This fixes the handling of legacy social links by providing the adequate attribute default for each `$service`.

## How has this been tested?
Make sure both new and old formats of social links are correctly rendered in the front-end.

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
