### PR TITLE
NavigationLink: set width in order to show caret

### DIFF
--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -57,6 +57,11 @@ $navigation-item-height: 46px;
 			background: none;
 		}
 	}
+
+	// Set a min width when the item is focused and empty in order to show the caret.
+	.wp-block-navigation .wp-block-navigation-link.is-selected .block-editor-rich-text__editable:focus {
+		min-width: 20px;
+	}
 }
 
 .wp-block-navigation__inserter-content {


### PR DESCRIPTION
## Description
This PR adds a min-width to the label of the Navigation Link when it's empty, and also focused, in order to show the carte. 

Fixes the https://github.com/WordPress/gutenberg/issues/20073

## How has this been tested?
1) Go to post edit.
2) Create a Navigation menu.
3) Add a Navigation Link.
4) Do not select a link. Just close the popover.
5) Focus the label in order to start to edit it.

**before**
6) The caret is hidden

**after**
7) The caret should be shown.

## Screenshots <!-- if applicable -->

![caret](https://user-images.githubusercontent.com/77539/73965971-fab4ca00-48c9-11ea-85df-70e30cecdf1f.gif)


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->