### PR TITLE
Adds current menu class to navigation block

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -196,6 +196,7 @@ function block_core_navigation_build_html( $attributes, $block, $colors, $font_s
 		$colors['css_classes'],
 		$font_sizes['css_classes']
 	);
+
 	$classes[]       = 'wp-block-navigation-link';
 	$css_classes     = trim( implode( ' ', $classes ) );
 	$style_attribute = ( $colors['inline_styles'] || $font_sizes['inline_styles'] )
@@ -204,8 +205,16 @@ function block_core_navigation_build_html( $attributes, $block, $colors, $font_s
 
 	foreach ( (array) $block['innerBlocks'] as $key => $block ) {
 		$has_submenu = count( (array) $block['innerBlocks'] ) > 0;
+		$is_active = ! empty( $block['attrs']['id'] ) && ( get_the_ID() === $block['attrs']['id'] );
 
-		$html .= '<li class="' . esc_attr( $css_classes . ( $has_submenu ? ' has-child' : '' ) ) . '"' . $style_attribute . '>' .
+		$class_name = ! empty( $block['attrs']['className'] ) ? implode( ' ', (array) $block['attrs']['className'] ) : false;
+
+		if ( false !== $class_name ) {
+			$css_classes .= ' ' . $class_name;
+		};
+
+		$html .= '<li class="' . esc_attr( $css_classes . ( $has_submenu ? ' has-child' : '' ) ) .
+			( $is_active ? ' current-menu-item' : '' ) . '"' . $style_attribute . '>' .
 			'<a class="wp-block-navigation-link__content"';
 
 		// Start appending HTML attributes to anchor tag.
@@ -264,7 +273,7 @@ function block_core_navigation_build_html( $attributes, $block, $colors, $font_s
 		// End anchor tag content.
 
 		if ( $has_submenu ) {
-			$html .= block_core_navigation_build_html( $attributes, $block, $colors, $font_sizes, false );
+			$html .= core_block_navigation_build_html( $attributes, $block, $colors, $font_sizes );
 		}
 
 		$html .= '</li>';

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -198,12 +198,12 @@ function block_core_navigation_build_html( $attributes, $block, $colors, $font_s
 	);
 
 	$classes[]       = 'wp-block-navigation-link';
-	$css_classes     = trim( implode( ' ', $classes ) );
 	$style_attribute = ( $colors['inline_styles'] || $font_sizes['inline_styles'] )
 		? sprintf( ' style="%s"', esc_attr( $colors['inline_styles'] ) . esc_attr( $font_sizes['inline_styles'] ) )
 		: '';
 
 	foreach ( (array) $block['innerBlocks'] as $key => $block ) {
+		$css_classes     = trim( implode( ' ', $classes ) );
 		$has_submenu = count( (array) $block['innerBlocks'] ) > 0;
 		$is_active   = ! empty( $block['attrs']['id'] ) && ( get_the_ID() === $block['attrs']['id'] );
 

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -196,14 +196,13 @@ function block_core_navigation_build_html( $attributes, $block, $colors, $font_s
 		$colors['css_classes'],
 		$font_sizes['css_classes']
 	);
-
 	$classes[]       = 'wp-block-navigation-link';
 	$style_attribute = ( $colors['inline_styles'] || $font_sizes['inline_styles'] )
 		? sprintf( ' style="%s"', esc_attr( $colors['inline_styles'] ) . esc_attr( $font_sizes['inline_styles'] ) )
 		: '';
 
 	foreach ( (array) $block['innerBlocks'] as $key => $block ) {
-		$css_classes     = trim( implode( ' ', $classes ) );
+		$css_classes = trim( implode( ' ', $classes ) );
 		$has_submenu = count( (array) $block['innerBlocks'] ) > 0;
 		$is_active   = ! empty( $block['attrs']['id'] ) && ( get_the_ID() === $block['attrs']['id'] );
 

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -205,7 +205,7 @@ function block_core_navigation_build_html( $attributes, $block, $colors, $font_s
 
 	foreach ( (array) $block['innerBlocks'] as $key => $block ) {
 		$has_submenu = count( (array) $block['innerBlocks'] ) > 0;
-		$is_active = ! empty( $block['attrs']['id'] ) && ( get_the_ID() === $block['attrs']['id'] );
+		$is_active   = ! empty( $block['attrs']['id'] ) && ( get_the_ID() === $block['attrs']['id'] );
 
 		$class_name = ! empty( $block['attrs']['className'] ) ? implode( ' ', (array) $block['attrs']['className'] ) : false;
 


### PR DESCRIPTION
## Description
Closes #19993 
Closes #19858

This PR adds two new updates to the server side rendering of the `Navigation` block:

- it renders on each navigation link the custom CSS class saved from the block editor
- it renders on navigation links a class named 'current-menu-item'

## How has this been tested?
1. In a post add a new navigation block
2. Add three links to the post you are editing and two other posts and/or pages
 2.1 Add a custom CSS class to one of the links
3. Save the block as a reusable block
4. Edit the pages/posts that you linked to and add the reusable block
5. Visit the pages and notice the class being added to the current menu item and the custom CSS class being rendered

## Types of changes
Updated the server side rendering of the `Navigation` block to output the custom CSS class of each `NavigationLink` and to check for the current post ID.