### PR TITLE
Block Examples: Skip and warn if block type is missing

### DIFF
--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -276,6 +276,7 @@ _Returns_
 <a name="getBlockFromExample" href="#getBlockFromExample">#</a> **getBlockFromExample**
 
 Create a block object from the example API.
+Can return `undefined` if the block can't be created.
 
 _Parameters_
 
@@ -284,7 +285,7 @@ _Parameters_
 
 _Returns_
 
--   `Object`: block.
+-   `?Object`: block object or undefined.
 
 <a name="getBlockMenuDefaultClassName" href="#getBlockMenuDefaultClassName">#</a> **getBlockMenuDefaultClassName**
 

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -34,6 +34,7 @@
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
 		"@wordpress/shortcode": "file:../shortcode",
+		"@wordpress/warning": "file:../warning",
 		"hpq": "^1.3.0",
 		"lodash": "^4.17.15",
 		"rememo": "^3.0.0",

--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -537,7 +537,7 @@ export function switchToBlockType( blocks, name ) {
  * @param {string} name
  * @param {Object} example
  *
- * @return {?Object} block object or undefined.
+ * @return {Object|undefined} block object or undefined.
  */
 export const getBlockFromExample = ( name, example ) => {
 	if ( ! getBlockType( name ) ) {

--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -3,6 +3,7 @@
  */
 import uuid from 'uuid/v4';
 import {
+	compact,
 	every,
 	reduce,
 	castArray,
@@ -545,7 +546,7 @@ export const getBlockFromExample = ( name, example ) => {
 	return createBlock(
 		name,
 		example.attributes,
-		filter(
+		compact(
 			map( example.innerBlocks, ( innerBlock ) =>
 				getBlockFromExample( innerBlock.name, innerBlock )
 			)

--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -22,6 +22,7 @@ import {
  * WordPress dependencies
  */
 import { createHooks, applyFilters } from '@wordpress/hooks';
+import warning from '@wordpress/warning';
 
 /**
  * Internal dependencies
@@ -537,11 +538,17 @@ export function switchToBlockType( blocks, name ) {
  * @return {Object} block.
  */
 export const getBlockFromExample = ( name, example ) => {
+	if ( ! getBlockType( name ) ) {
+		warning( 'Block example used an unknown block type: ' + name );
+		return false;
+	}
 	return createBlock(
 		name,
 		example.attributes,
-		map( example.innerBlocks, ( innerBlock ) =>
-			getBlockFromExample( innerBlock.name, innerBlock )
+		filter(
+			map( example.innerBlocks, ( innerBlock ) =>
+				getBlockFromExample( innerBlock.name, innerBlock )
+			)
 		)
 	);
 };

--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -532,16 +532,17 @@ export function switchToBlockType( blocks, name ) {
 
 /**
  * Create a block object from the example API.
+ * Can return `undefined` if the block can't be created.
  *
  * @param {string} name
  * @param {Object} example
  *
- * @return {Object} block.
+ * @return {?Object} block object or undefined.
  */
 export const getBlockFromExample = ( name, example ) => {
 	if ( ! getBlockType( name ) ) {
 		warning( 'Block example used an unknown block type: ' + name );
-		return false;
+		return;
 	}
 	return createBlock(
 		name,


### PR DESCRIPTION
## Description
As reported in #19815, block previews could cause editor fatals if some blocks used for the preview are missing.

Easy way to trigger this is to unregister the Image block `wp.blocks.unregisterBlockType( 'core/image' )` and navigate to the block inserter where you hover Columns. Columns internally use Image for the example.

What I've tried in this PR is to check if block type exists before using it in Preview. If the block type is missing, a dev warning is shown and the block is skipped from the preview. This only applies to the example preview, nothing has been changed about missing block types in the post content and other places.

Since Examples are a visual enhancement, I thought it might be ok to just skip unknown blocks without any visual error or fatal. Also, the most common usage of Examples would only use the block itself (which would always be registered) so this situation is quite limited to blocks that use some other blocks as their example children.

## How has this been tested?
1. Open Editor
2. Run `wp.blocks.unregisterBlockType( 'core/image' )`
3. Open Inserter
4. Hover Columns block
5. On master, you should see Fatal Error. On this branch, you should see the example sans Images and a warning in console

## Screenshots <!-- if applicable -->

| Columns Example | Columns with Image unregistered | 
| - | - |
| <img width="698" alt="Screenshot 2020-02-06 at 14 30 46" src="https://user-images.githubusercontent.com/156676/73984396-65c3c800-48ed-11ea-9929-17de228bd6e4.png"> | <img width="701" alt="Screenshot 2020-02-06 at 14 30 55" src="https://user-images.githubusercontent.com/156676/73984409-6bb9a900-48ed-11ea-8493-52916e3eaa75.png">



## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
