### PR TITLE
Fix issue #20069: Block Editor: Warning when rendering InnerBlocks

### DIFF
--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -77,6 +77,9 @@ function BlockList( {
 		element: ref,
 		rootClientId,
 	} );
+	const __experimentalContainerProps = rootClientId
+		? {}
+		: { hasPopover: __experimentalUIParts.hasPopover };
 
 	return (
 		<Container
@@ -85,7 +88,7 @@ function BlockList( {
 				'block-editor-block-list__layout',
 				className
 			) }
-			hasPopover={ __experimentalUIParts.hasPopover }
+			{ ...__experimentalContainerProps }
 		>
 			{ blockClientIds.map( ( clientId, index ) => {
 				const isBlockInSelection = hasMultiSelection


### PR DESCRIPTION
Fixes #20069


## Description
Implement conditional rendering for Block Editor's `BlockList` component to stop adding `hasPopover` prop to `Container` when `Container` is `'div'`.


## How has this been tested?
1. Navigate to Posts > Add New
2. Insert a Columns block
3. Open Developer Tools Console and observe warning


## Screenshots 

### Before:
![image](https://user-images.githubusercontent.com/33646954/74003526-e4962080-4940-11ea-856c-09dae81fcb85.png)
![image](https://user-images.githubusercontent.com/33646954/74003548-f7105a00-4940-11ea-81d6-51cba8ff248d.png)

### After:
![image](https://user-images.githubusercontent.com/33646954/74003013-21f9ae80-493f-11ea-899f-ef3c1d7b0d37.png)
![image](https://user-images.githubusercontent.com/33646954/74003037-3473e800-493f-11ea-8b3d-b0c71ee64c8c.png)


## Types of changes
Bug fix, fixes a warning that was being fired from the developer console.


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
