### PR TITLE
Fix gallery to image transform and inconsistent types used in gallery block

### DIFF
--- a/packages/block-library/src/gallery/block.json
+++ b/packages/block-library/src/gallery/block.json
@@ -9,27 +9,32 @@
 			"selector": ".blocks-gallery-item",
 			"query": {
 				"url": {
+					"type": "string",
 					"source": "attribute",
 					"selector": "img",
 					"attribute": "src"
 				},
 				"fullUrl": {
+					"type": "string",
 					"source": "attribute",
 					"selector": "img",
 					"attribute": "data-full-url"
 				},
 				"link": {
+					"type": "string",
 					"source": "attribute",
 					"selector": "img",
 					"attribute": "data-link"
 				},
 				"alt": {
+					"type": "string",
 					"source": "attribute",
 					"selector": "img",
 					"attribute": "alt",
 					"default": ""
 				},
 				"id": {
+					"type": "string",
 					"source": "attribute",
 					"selector": "img",
 					"attribute": "data-id"

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -11,6 +11,7 @@ import {
 	map,
 	reduce,
 	some,
+	toString,
 } from 'lodash';
 
 /**
@@ -100,7 +101,9 @@ class GalleryEdit extends Component {
 		if ( attributes.images ) {
 			attributes = {
 				...attributes,
-				ids: map( attributes.images, 'id' ),
+				// Unlike images[ n ].id which is a string, always ensure the
+				// ids array contains numbers as per its attribute type.
+				ids: map( attributes.images, ( { id } ) => parseInt( id, 10 ) ),
 			};
 		}
 
@@ -159,7 +162,11 @@ class GalleryEdit extends Component {
 	}
 
 	selectCaption( newImage, images, attachmentCaptions ) {
-		const currentImage = find( images, { id: newImage.id } );
+		// The image id in both the images and attachmentCaptions arrays is a
+		// string, so ensure comparison works correctly by converting the
+		// newImage.id to a string.
+		const newImageId = toString( newImage.id );
+		const currentImage = find( images, { id: newImageId } );
 
 		const currentImageCaption = currentImage
 			? currentImage.caption
@@ -169,7 +176,9 @@ class GalleryEdit extends Component {
 			return currentImageCaption;
 		}
 
-		const attachment = find( attachmentCaptions, { id: newImage.id } );
+		const attachment = find( attachmentCaptions, {
+			id: newImageId,
+		} );
 
 		// if the attachment caption is updated
 		if ( attachment && attachment.caption !== newImage.caption ) {
@@ -184,7 +193,9 @@ class GalleryEdit extends Component {
 		const { attachmentCaptions } = this.state;
 		this.setState( {
 			attachmentCaptions: newImages.map( ( newImage ) => ( {
-				id: newImage.id,
+				// Store the attachmentCaption id as a string for consistency
+				// with the type of the id in the images attribute.
+				id: toString( newImage.id ),
 				caption: newImage.caption,
 			} ) ),
 		} );
@@ -196,6 +207,10 @@ class GalleryEdit extends Component {
 					images,
 					attachmentCaptions
 				),
+				// The id value is stored in a data attribute, so when the
+				// block is parsed it's converted to a string. Converting
+				// to a string here ensures it's type is consistent.
+				id: toString( newImage.id ),
 			} ) ),
 			columns: columns ? Math.min( newImages.length, columns ) : columns,
 		} );

--- a/packages/block-library/src/gallery/gallery-image.js
+++ b/packages/block-library/src/gallery/gallery-image.js
@@ -214,7 +214,7 @@ export default compose( [
 		const { id } = ownProps;
 
 		return {
-			image: id ? getMedia( id ) : null,
+			image: id ? getMedia( parseInt( id, 10 ) ) : null,
 		};
 	} ),
 	withDispatch( ( dispatch ) => {

--- a/packages/block-library/src/gallery/transforms.js
+++ b/packages/block-library/src/gallery/transforms.js
@@ -116,11 +116,11 @@ const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'core/image' ],
-			transform: ( { images, align, sizeSlug } ) => {
+			transform: ( { images, align, sizeSlug, ids } ) => {
 				if ( images.length > 0 ) {
-					return images.map( ( { id, url, alt, caption } ) =>
+					return images.map( ( { url, alt, caption }, index ) =>
 						createBlock( 'core/image', {
-							id,
+							id: ids[ index ],
 							url,
 							alt,
 							caption,

--- a/packages/block-library/src/gallery/transforms.js
+++ b/packages/block-library/src/gallery/transforms.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { filter, every } from 'lodash';
+import { filter, every, toString } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -44,13 +44,13 @@ const transforms = {
 				return createBlock( 'core/gallery', {
 					images: validImages.map(
 						( { id, url, alt, caption } ) => ( {
-							id,
+							id: toString( id ),
 							url,
 							alt,
 							caption,
 						} )
 					),
-					ids: validImages.map( ( { id } ) => id ),
+					ids: validImages.map( ( { id } ) => parseInt( id, 10 ) ),
 					align,
 					sizeSlug,
 				} );
@@ -64,7 +64,7 @@ const transforms = {
 					type: 'array',
 					shortcode: ( { named: { ids } } ) => {
 						return parseShortcodeIds( ids ).map( ( id ) => ( {
-							id,
+							id: toString( id ),
 						} ) );
 					},
 				},


### PR DESCRIPTION
## Description
Fixes #20041

Fixes gallery to image transforms that were broken because the gallery block inconsistently stores image ids sometimes as numbers, but other times as strings. They're set as numbers initially when a gallery is created, but then as strings when loading a post and an existing gallery block is parsed. 

The image block expects them to be numbers, so transforming an existing gallery block to images caused invalid image blocks.

This PR tidies up the inconsistencies:
- Set `type` on gallery block attributes so that types are enforced.
- Ensure `attributes.images[ index ].id` is always stored as a string by parsing the initial value.
- Ensure the `attributes.ids` array is always updated as numbers by explicitly parsing the values.
- Use `attributes.ids` when transforming galleries to images, as the attribute types are both numbers. 
- When looking up captions, always use the string value.
- Always pass a number to the `getMedia` selector. It seems like if you try `getMedia( 71 )` and `getMedia( '71' )` the cache lookup doesn't resolve both ids as the same, resulting in a new HTTP request being made. This might be something to fix in a separate PR—entities could either (a) accept strings or numbers, but consistently convert them to the same type or (b) throw an error if the wrong type is used.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

1. Add a gallery with some images
2. Save the post and reload
3. Transform the gallery to images.
4. Save and reload
5. Expect that none of the image blocks should be invalid.

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)

My feeling is this is non-breaking and doesn't require a block deprecation. Any existing galleries saved into posts will have their ids stored as strings in the data-id attribute. Every deprecation also stores ids this way. So setting the id `type` as string shouldn't cause an issue for existing blocks.
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
