### PR TITLE
Wp-env: Add phpunit support 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -159,11 +159,12 @@ jobs:
         - npm run test-unit:native -- --ci --maxWorkers=2 --cacheDirectory="$HOME/.jest-cache"
 
     - name: PHP unit tests
+      env: WP_ENV_TESTS_PORT=8887 # TODO: Remove tests port when scripts/env is replaced with wp-env.
       script:
         - npm run test-php && npm run test-unit-php-multisite
 
     - name: PHP unit tests (PHP 5.6)
-      env: LOCAL_PHP=5.6-fpm
+      env: LOCAL_PHP=5.6-fpm WP_ENV_TESTS_PORT=8887 # TODO: Remove tests port when scripts/env is replaced with wp-env.
       script:
         - npm run test-php && npm run test-unit-php-multisite
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -159,13 +159,15 @@ jobs:
         - npm run test-unit:native -- --ci --maxWorkers=2 --cacheDirectory="$HOME/.jest-cache"
 
     - name: PHP unit tests
-      env: WP_ENV_TESTS_PORT=8887 # TODO: Remove tests port when scripts/env is replaced with wp-env.
+      env: WP_ENV_TESTS_PORT=8887 WP_ENV_PORT=8886 # TODO: Remove tests port when scripts/env is replaced with wp-env.
       script:
+        - npm run wp-env start
         - npm run test-php && npm run test-unit-php-multisite
 
     - name: PHP unit tests (PHP 5.6)
-      env: LOCAL_PHP=5.6-fpm WP_ENV_TESTS_PORT=8887 # TODO: Remove tests port when scripts/env is replaced with wp-env.
+      env: LOCAL_PHP=5.6-fpm WP_ENV_TESTS_PORT=8887 WP_ENV_PORT=8886 # TODO: Remove tests port when scripts/env is replaced with wp-env.
       script:
+        - npm run wp-env start
         - npm run test-php && npm run test-unit-php-multisite
 
     - name: E2E tests (Admin) (1/4)

--- a/.travis.yml
+++ b/.travis.yml
@@ -161,12 +161,14 @@ jobs:
     - name: PHP unit tests
       env: WP_ENV_TESTS_PORT=8887 WP_ENV_PORT=8886 # TODO: Remove tests port when scripts/env is replaced with wp-env.
       script:
+        - chmod -R 767 ./build
         - npm run wp-env start
         - npm run test-php && npm run test-unit-php-multisite
 
     - name: PHP unit tests (PHP 5.6)
       env: LOCAL_PHP=5.6-fpm WP_ENV_TESTS_PORT=8887 WP_ENV_PORT=8886 # TODO: Remove tests port when scripts/env is replaced with wp-env.
       script:
+        - chmod -R 767 ./build
         - npm run wp-env start
         - npm run test-php && npm run test-unit-php-multisite
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
 		"squizlabs/php_codesniffer": "^3.5",
 		"phpcompatibility/php-compatibility": "^9.3",
 		"wp-coding-standards/wpcs": "^2.2",
-		"sirbrillig/phpcs-variable-analysis": "^2.8"
+		"sirbrillig/phpcs-variable-analysis": "^2.8",
+		"wp-phpunit/wp-phpunit": "^5.4"
 	},
 	"require": {
 		"composer/installers": "~1.0"

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "9745a2b1c8d1005bf9f7617061e4fc7d",
+    "content-hash": "bcdce838e8354d08b1ed65eb1ebf3636",
     "packages": [
         {
             "name": "composer/installers",
@@ -402,6 +402,49 @@
                 "wordpress"
             ],
             "time": "2020-02-04T02:52:06+00:00"
+        },
+        {
+            "name": "wp-phpunit/wp-phpunit",
+            "version": "5.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/wp-phpunit/wp-phpunit.git",
+                "reference": "15925e03c8594c08cf2822e24e511af8dc6f779e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/wp-phpunit/wp-phpunit/zipball/15925e03c8594c08cf2822e24e511af8dc6f779e",
+                "reference": "15925e03c8594c08cf2822e24e511af8dc6f779e",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "__loaded.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Evan Mattson",
+                    "email": "me@aaemnnost.tv"
+                },
+                {
+                    "name": "WordPress Community",
+                    "homepage": "https://wordpress.org/about/"
+                }
+            ],
+            "description": "WordPress core PHPUnit library",
+            "homepage": "https://github.com/wp-phpunit",
+            "keywords": [
+                "phpunit",
+                "test",
+                "wordpress"
+            ],
+            "time": "2020-04-01T14:35:27+00:00"
         }
     ],
     "aliases": [],

--- a/package.json
+++ b/package.json
@@ -233,7 +233,7 @@
 		"test-unit:debug": "wp-scripts --inspect-brk test-unit-js --runInBand --no-cache --verbose --config test/unit/jest.config.js ",
 		"test-unit:update": "npm run test-unit -- --updateSnapshot",
 		"test-unit:watch": "npm run test-unit -- --watch",
-		"test-unit-php": "wp-scripts env test-php",
+		"test-unit-php": "wp-env run phpunit 'phpunit -c /var/www/html/wp-content/plugins/gutenberg/phpunit.xml.dist'",
 		"test-unit-php-multisite": "cross-env WP_MULTISITE=1 wp-scripts env test-php",
 		"test-unit:native": "cd test/native/ && cross-env NODE_ENV=test jest --config ./jest.config.js",
 		"test-unit:native:debug": "cd test/native/ && node --inspect-brk ../../node_modules/.bin/jest --runInBand --verbose --config ./jest.config.js",

--- a/package.json
+++ b/package.json
@@ -234,7 +234,7 @@
 		"test-unit:update": "npm run test-unit -- --updateSnapshot",
 		"test-unit:watch": "npm run test-unit -- --watch",
 		"test-unit-php": "wp-env run phpunit 'phpunit -c /var/www/html/wp-content/plugins/gutenberg/phpunit.xml.dist'",
-		"test-unit-php-multisite": "cross-env WP_MULTISITE=1 wp-scripts env test-php",
+		"test-unit-php-multisite": "wp-env run phpunit 'WP_MULTISITE=1 phpunit -c /var/www/html/wp-content/plugins/gutenberg/phpunit.xml.dist'",
 		"test-unit:native": "cd test/native/ && cross-env NODE_ENV=test jest --config ./jest.config.js",
 		"test-unit:native:debug": "cd test/native/ && node --inspect-brk ../../node_modules/.bin/jest --runInBand --verbose --config ./jest.config.js",
 		"prestorybook:build": "npm run build:packages",

--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New Feature
 
+-   Expose Docker service for running phpunit commands.
 -   You may now mount local directories to any location within the WordPress install. For example, you may specify `"wp-content/mu-plugins": "./path/to/mu-plugins"` to add mu-plugins.
 
 ## 1.1.0 (2020-04-01)

--- a/packages/env/lib/build-docker-compose-config.js
+++ b/packages/env/lib/build-docker-compose-config.js
@@ -142,11 +142,24 @@ module.exports = function buildDockerComposeConfig( config ) {
 				image: 'composer',
 				volumes: [ `${ config.configDirectoryPath }:/app` ],
 			},
+			phpunit: {
+				image: 'wordpressdevelop/phpunit',
+				depends_on: [ 'wordpress' ],
+				volumes: [
+					...testsMounts,
+					'phpunit-uploads:/var/www/html/wp-content/uploads',
+				],
+				environment: {
+					LOCAL_DIR: 'html',
+					WP_PHPUNIT__TESTS_CONFIG: '/var/www/html/wp-config.php',
+				},
+			},
 		},
 		volumes: {
 			...( ! config.coreSource && { wordpress: {} } ),
 			...( ! config.coreSource && { 'tests-wordpress': {} } ),
 			mysql: {},
+			'phpunit-uploads': {},
 		},
 	};
 };

--- a/packages/env/lib/build-docker-compose-config.js
+++ b/packages/env/lib/build-docker-compose-config.js
@@ -143,7 +143,7 @@ module.exports = function buildDockerComposeConfig( config ) {
 				volumes: [ `${ config.configDirectoryPath }:/app` ],
 			},
 			phpunit: {
-				image: 'wordpressdevelop/phpunit',
+				image: 'wordpressdevelop/phpunit:${LOCAL_PHP-latest}',
 				depends_on: [ 'tests-wordpress' ],
 				volumes: [
 					...testsMounts,

--- a/packages/env/lib/build-docker-compose-config.js
+++ b/packages/env/lib/build-docker-compose-config.js
@@ -133,7 +133,7 @@ module.exports = function buildDockerComposeConfig( config ) {
 				user: cliUser,
 			},
 			'tests-cli': {
-				depends_on: [ 'wordpress' ],
+				depends_on: [ 'tests-wordpress' ],
 				image: 'wordpress:cli',
 				volumes: testsMounts,
 				user: cliUser,
@@ -144,7 +144,7 @@ module.exports = function buildDockerComposeConfig( config ) {
 			},
 			phpunit: {
 				image: 'wordpressdevelop/phpunit',
-				depends_on: [ 'wordpress' ],
+				depends_on: [ 'tests-wordpress' ],
 				volumes: [
 					...testsMounts,
 					'phpunit-uploads:/var/www/html/wp-content/uploads',

--- a/packages/env/lib/config.js
+++ b/packages/env/lib/config.js
@@ -128,7 +128,11 @@ module.exports = {
 				themes: [],
 				port: 8888,
 				testsPort: 8889,
-				config: { WP_DEBUG: true, SCRIPT_DEBUG: true },
+				config: {
+					WP_DEBUG: true,
+					SCRIPT_DEBUG: true,
+					WP_TESTS_DOMAIN: 'example.org',
+				},
 				mappings: {},
 			},
 			config,

--- a/packages/env/lib/config.js
+++ b/packages/env/lib/config.js
@@ -132,6 +132,7 @@ module.exports = {
 					WP_DEBUG: true,
 					SCRIPT_DEBUG: true,
 					WP_TESTS_DOMAIN: 'example.org',
+					WP_PHP_BINARY: 'php',
 				},
 				mappings: {},
 			},

--- a/phpunit/bootstrap.php
+++ b/phpunit/bootstrap.php
@@ -5,6 +5,9 @@
  * @package Gutenberg
  */
 
+// Require composer dependencies.
+require_once dirname( dirname( __FILE__ ) ) . '/vendor/autoload.php';
+
 // If we're running in WP's build directory, ensure that WP knows that, too.
 if ( 'build' === getenv( 'LOCAL_DIR' ) ) {
 	define( 'WP_RUN_CORE_TESTS', true );
@@ -13,6 +16,11 @@ if ( 'build' === getenv( 'LOCAL_DIR' ) ) {
 // Determine the tests directory (from a WP dev checkout).
 // Try the WP_TESTS_DIR environment variable first.
 $_tests_dir = getenv( 'WP_TESTS_DIR' );
+
+// Next, try the WP_PHPUNIT composer package.
+if ( ! $_tests_dir ) {
+	$_tests_dir = getenv( 'WP_PHPUNIT__DIR' );
+}
 
 // See if we're installed inside an existing WP dev instance.
 if ( ! $_tests_dir ) {


### PR DESCRIPTION
This PR allows the phpunit script to work with @wordpress/env.

## Changes:
- Add phpunit service to wp-env docker
- Add wp_phpunit composer dependency so we don't have to use wordpress-develop
- switch package.json to use wp-env for phpunit tests.

To test, run:

```sh
# Get the new composer changes.
./packages/env/bin/wp-env run composer 'composer install'  

# Run phpunit via package.json:
npm run test-unit-php

# With multisite setup:
npm run test-unit-php-multisite

# Alternatively, directly run phpunit command (the package commands are aliases for this)
./packages/env/bin/wp-env run phpunit 'phpunit -c /var/www/html/wp-content/plugins/gutenberg/phpunit.xml.dist'   
```

## External API

This works pretty well for us internally, but I think it will be difficult to use from a 3rd party perspective for a few reasons:

1. Currently, you are required to know the absolute path to the phpunit config file inside Docker. That will be different for every source.
2. You have to install the correct wp-phpunit dependency yourself.
3. You have to know how to setup the bootstrap and config files correctly. 

See #22365 for explorations on how to improve the external API.
 
### To do:
- [x] Should we export functions from @wordpress/env to handle things like `getDockerComposeDir`? (or even for reading the config file if needed.)
- [x] Provide a phpunit service in the default docker config. ([Similar to the WordPress one we used before](https://github.com/WordPress/wordpress-develop/blob/112649ea924e2aed6c18bfcbf8ab7306d3c53b78/docker-compose.yml#L95-L121).)
- [x] verify multisite tests also work
- [x] verify exit code is 1 if tests fail
- [x] use different tests port in travis to avoid conflicting with scripts/env
- [x] verify php version from `LOCAL_PHP` is used in phpunit environment
- [x] make sure wordpress is installed before continuing
- [ ] make sure we have permissions to rename files in travis 