### PR TITLE
[RNMobile] Enable Dismiss on PlainText in Android

### DIFF
--- a/packages/block-editor/src/components/plain-text/index.native.js
+++ b/packages/block-editor/src/components/plain-text/index.native.js
@@ -17,6 +17,7 @@ export default class PlainText extends Component {
 	constructor() {
 		super( ...arguments );
 		this.isIOS = Platform.OS === 'ios';
+		this.isAndroid = Platform.OS === 'android';
 	}
 
 	componentDidMount() {

--- a/packages/block-editor/src/components/plain-text/index.native.js
+++ b/packages/block-editor/src/components/plain-text/index.native.js
@@ -45,7 +45,7 @@ export default class PlainText extends Component {
 
 	componentWillUnmount() {
 		if ( this.isAndroid ) {
-			clearTimeout(this.timeoutID);
+			clearTimeout( this.timeoutID );
 		}
 	}
 

--- a/packages/block-editor/src/components/plain-text/index.native.js
+++ b/packages/block-editor/src/components/plain-text/index.native.js
@@ -16,23 +16,36 @@ import styles from './style.scss';
 export default class PlainText extends Component {
 	constructor() {
 		super( ...arguments );
-		this.isIOS = Platform.OS === 'ios';
 		this.isAndroid = Platform.OS === 'android';
 	}
 
 	componentDidMount() {
 		// if isSelected is true, we should request the focus on this TextInput
-		if (
-			this._input.isFocused() === false &&
-			this._input.props.isSelected === true
-		) {
-			this.focus();
+		if ( this._input.isFocused() === false && this.props.isSelected ) {
+			if ( this.isAndroid ) {
+				/*
+				 * There seems to be an issue in React Native where the keyboard doesn't show if called shortly after rendering.
+				 * As a common work around this delay is used.
+				 * https://github.com/facebook/react-native/issues/19366#issuecomment-400603928
+				 */
+				this.timeoutID = setTimeout( () => {
+					this._input.focus();
+				}, 100 );
+			} else {
+				this._input.focus();
+			}
 		}
 	}
 
 	componentDidUpdate( prevProps ) {
-		if ( ! this.props.isSelected && prevProps.isSelected && this.isIOS ) {
+		if ( ! this.props.isSelected && prevProps.isSelected ) {
 			this._input.blur();
+		}
+	}
+
+	componentWillUnmount() {
+		if ( this.isAndroid ) {
+			clearTimeout(this.timeoutID);
 		}
 	}
 


### PR DESCRIPTION
## Description
Fixes: https://github.com/wordpress-mobile/gutenberg-mobile/issues/1864

Selecting the dismiss keyboard button on a PlainText component should hide the keyboard. Also focusing on a field with PlainText should show the keyboard.

`gutenberg-mobile`: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1871

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Blocks with PlainText:
- code
- shortcode

**Existing Field**
1. Open a page or post with a block that uses the PlainText component.
2. Click on the field
3. Edit or leave unchanged
4. Click the keyboard dismiss button
_**Expect the keyboard to dismiss**_

**New Field**
1. Select to add a new component with the PlainText component
_**Expect the keyboard to dismiss**_
2. Add text or leave blank
3. Click the keyboard dismiss button
_**Expect the keyboard to dismiss**_

## Screenshots <!-- if applicable -->
![Screen Recording 2020-02-07 at 8 53 25 AM 2020-02-07 08_58_12](https://user-images.githubusercontent.com/3384451/74035959-52663a80-4989-11ea-920c-690548d37666.gif)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Fixes: https://github.com/wordpress-mobile/gutenberg-mobile/issues/1864

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->

## Additional info:
There is a known issue with Shortcode where the text is being cut off on multiline: https://github.com/wordpress-mobile/gutenberg-mobile/issues/1868 