### PR TITLE
Multi select: remove inserter between selected blocks

### DIFF
--- a/packages/block-editor/src/components/block-list/insertion-point.js
+++ b/packages/block-editor/src/components/block-list/insertion-point.js
@@ -51,6 +51,7 @@ function Indicator( { clientId } ) {
 export default function InsertionPoint( {
 	className,
 	isMultiSelecting,
+	hasMultiSelection,
 	selectedBlockClientId,
 	children,
 	containerRef,
@@ -60,6 +61,15 @@ export default function InsertionPoint( {
 	const [ inserterElement, setInserterElement ] = useState( null );
 	const [ inserterClientId, setInserterClientId ] = useState( null );
 	const ref = useRef();
+	const { multiSelectedBlockClientIds } = useSelect( ( select ) => {
+		const { getMultiSelectedBlockClientIds } = select(
+			'core/block-editor'
+		);
+
+		return {
+			multiSelectedBlockClientIds: getMultiSelectedBlockClientIds(),
+		};
+	} );
 
 	function onMouseMove( event ) {
 		if ( event.target.className !== className ) {
@@ -125,6 +135,11 @@ export default function InsertionPoint( {
 		}
 	}
 
+	// Hide the inserter above the selected block and during multi-selection.
+	const isInserterHidden = hasMultiSelection
+		? multiSelectedBlockClientIds.includes( inserterClientId )
+		: inserterClientId === selectedBlockClientId;
+
 	return (
 		<>
 			{ ! isMultiSelecting && ( isInserterShown || isInserterForced ) && (
@@ -159,10 +174,7 @@ export default function InsertionPoint( {
 							className={ classnames(
 								'block-editor-block-list__insertion-point-inserter',
 								{
-									// Hide the inserter above the selected block.
-									'is-inserter-hidden':
-										inserterClientId ===
-										selectedBlockClientId,
+									'is-inserter-hidden': isInserterHidden,
 								}
 							) }
 						>

--- a/packages/block-editor/src/components/block-list/root-container.js
+++ b/packages/block-editor/src/components/block-list/root-container.js
@@ -78,6 +78,7 @@ function RootContainer( { children, className, hasPopover = true }, ref ) {
 		<InsertionPoint
 			className={ className }
 			isMultiSelecting={ isMultiSelecting }
+			hasMultiSelection={ hasMultiSelection }
 			selectedBlockClientId={ selectedBlockClientId }
 			containerRef={ ref }
 		>


### PR DESCRIPTION
## Description

Fixes #20092.

## How has this been tested?

When multi selecting, there should be no sibling inserter within the selection.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
