### PR TITLE
Compat: Social Links: Remove legacy renderers from packages

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -78,7 +78,7 @@ add_action( 'init', 'gutenberg_reregister_core_block_types' );
  * @see https://github.com/WordPress/gutenberg/pull/19887
  */
 function gutenberg_register_legacy_social_link_blocks() {
-	$sites = array(
+	$services = array(
 		'amazon',
 		'bandcamp',
 		'behance',
@@ -120,9 +120,9 @@ function gutenberg_register_legacy_social_link_blocks() {
 		'youtube',
 	);
 
-	foreach ( $sites as $site ) {
+	foreach ( $services as $service ) {
 		register_block_type(
-			'core/social-link-' . $site,
+			'core/social-link-' . $service,
 			array(
 				'category'        => 'widgets',
 				'attributes'      => array(
@@ -131,7 +131,7 @@ function gutenberg_register_legacy_social_link_blocks() {
 					),
 					'service' => array(
 						'type'    => 'string',
-						'default' => $site,
+						'default' => $service,
 					),
 					'label'   => array(
 						'type' => 'string',

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -6,28 +6,6 @@
  */
 
 /**
- * Retrieves registered social link blocks
- *
- * @return array Array of strings containing the registered social link block names.
- */
-function gutenberg_get_registered_social_link_blocks() {
-	$social_link_prefix        = 'core/social-link';
-	$social_link_prefix_length = strlen( $social_link_prefix );
-
-	$registry    = WP_Block_Type_Registry::get_instance();
-	$block_types = $registry->get_all_registered();
-
-	$registered_social_link_blocks = array();
-	foreach ( $block_types as $block_type ) {
-		// Block type name starts with $social_link_prefix.
-		if ( strncmp( $block_type->name, $social_link_prefix, $social_link_prefix_length ) === 0 ) {
-			$registered_social_link_blocks[] = $block_type->name;
-		}
-	}
-	return $registered_social_link_blocks;
-}
-
-/**
  * Substitutes the implementation of a core-registered block type, if exists,
  * with the built result from the plugin.
  */
@@ -50,7 +28,7 @@ function gutenberg_reregister_core_block_types() {
 		'rss.php'             => 'core/rss',
 		'shortcode.php'       => 'core/shortcode',
 		'search.php'          => 'core/search',
-		'social-link.php'     => gutenberg_get_registered_social_link_blocks(),
+		'social-link.php'     => 'core/social-link',
 		'tag-cloud.php'       => 'core/tag-cloud',
 		'site-title.php'      => 'core/site-title',
 		'template-part.php'   => 'core/template-part',
@@ -84,6 +62,87 @@ function gutenberg_reregister_core_block_types() {
 	}
 }
 add_action( 'init', 'gutenberg_reregister_core_block_types' );
+
+/**
+ * Complements the implementation of block type `core/social-icon`, whether it
+ * be provided by core or the plugin, with derived block types for each
+ * "service" (WordPress, Twitter, etc.) supported by Social Links.
+ *
+ * This ensures backwards compatibility for any users running the Gutenberg
+ * plugin who have used Social Links prior to their conversion to block
+ * variations.
+ *
+ * This shim is INTENTIONALLY left out of core, as Social Links haven't yet
+ * landed there.
+ *
+ * @see https://github.com/WordPress/gutenberg/pull/19887
+ */
+function gutenberg_register_legacy_social_link_blocks() {
+	$sites = array(
+		'amazon',
+		'bandcamp',
+		'behance',
+		'chain',
+		'codepen',
+		'deviantart',
+		'dribbble',
+		'dropbox',
+		'etsy',
+		'facebook',
+		'feed',
+		'fivehundredpx',
+		'flickr',
+		'foursquare',
+		'goodreads',
+		'google',
+		'github',
+		'instagram',
+		'lastfm',
+		'linkedin',
+		'mail',
+		'mastodon',
+		'meetup',
+		'medium',
+		'pinterest',
+		'pocket',
+		'reddit',
+		'skype',
+		'snapchat',
+		'soundcloud',
+		'spotify',
+		'tumblr',
+		'twitch',
+		'twitter',
+		'vimeo',
+		'vk',
+		'wordpress',
+		'yelp',
+		'youtube',
+	);
+
+	foreach ( $sites as $site ) {
+		register_block_type(
+			'core/social-link-' . $site,
+			array(
+				'category'        => 'widgets',
+				'attributes'      => array(
+					'url'     => array(
+						'type' => 'string',
+					),
+					'service' => array(
+						'type'    => 'string',
+						'default' => $site,
+					),
+					'label'   => array(
+						'type' => 'string',
+					),
+				),
+				'render_callback' => 'gutenberg_render_core_social_link',
+			)
+		);
+	}
+}
+add_action( 'init', 'gutenberg_register_legacy_social_link_blocks' );
 
 if ( ! function_exists( 'register_block_style' ) ) {
 	/**

--- a/packages/block-library/src/social-link/index.php
+++ b/packages/block-library/src/social-link/index.php
@@ -30,74 +30,8 @@ function render_core_social_link( $attributes ) {
  * Registers the `core/social-link` blocks.
  */
 function register_block_core_social_link() {
-	$sites = array(
-		'amazon',
-		'bandcamp',
-		'behance',
-		'chain',
-		'codepen',
-		'deviantart',
-		'dribbble',
-		'dropbox',
-		'etsy',
-		'facebook',
-		'feed',
-		'fivehundredpx',
-		'flickr',
-		'foursquare',
-		'goodreads',
-		'google',
-		'github',
-		'instagram',
-		'lastfm',
-		'linkedin',
-		'mail',
-		'mastodon',
-		'meetup',
-		'medium',
-		'pinterest',
-		'pocket',
-		'reddit',
-		'skype',
-		'snapchat',
-		'soundcloud',
-		'spotify',
-		'tumblr',
-		'twitch',
-		'twitter',
-		'vimeo',
-		'vk',
-		'wordpress',
-		'yelp',
-		'youtube',
-	);
-
 	$path     = __DIR__ . '/social-link/block.json';
 	$metadata = json_decode( file_get_contents( $path ), true );
-
-	foreach ( $sites as $site ) {
-		register_block_type(
-			'core/social-link-' . $site,
-			array_merge(
-				$metadata,
-				array(
-					'attributes'      => array(
-						'url'     => array(
-							'type' => 'string',
-						),
-						'service' => array(
-							'type'    => 'string',
-							'default' => $site,
-						),
-						'label'   => array(
-							'type' => 'string',
-						),
-					),
-					'render_callback' => 'render_core_social_link',
-				)
-			)
-		);
-	}
 
 	register_block_type(
 		$metadata['name'],


### PR DESCRIPTION
## Description

As of #19887, Social Link is implemented as a single block type with multiple variations, whereas previously each supported service (e.g. WordPress, Twitter) was implemented as its own cloned block type:

Old format: `<!-- wp:social-link-wordpress {"url":"foo"} /-->`
New format: `<!-- wp:social-link {"service":"wordpress","url":"foo"} /-->`

However, Social Link is defined as a dynamic block. Thus, for backwards compatibility, #19887 preserved the server-side registration of all the "cloned" block types. However, this requirement only applies to the Gutenberg plugin, since Social Links haven't landed in core yet. Thus, this PR moves the server-side registration of cloned block types out of packages — specifically, `block-library` and into `lib/blocks.php`.

This will ensure that, the next time packages are published and pulled into WordPress core, no added work is needed to make sure that core installations do not register unneeded legacy block types.

## How has this been tested?
- Make sure that both new-format and old-format Social Link blocks are correctly rendered on the front-end.
- If the process were more ergonomic, it would be ideal to test that publishing packages and building core from them pulls in `core/social-link` but no `core/social-link-xyz` clones.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
