### PR TITLE
CustomGradientPicker / Cover: Update UI

### DIFF
--- a/packages/block-editor/src/components/color-palette/test/__snapshots__/control.js.snap
+++ b/packages/block-editor/src/components/color-palette/test/__snapshots__/control.js.snap
@@ -9,20 +9,24 @@ exports[`ColorPaletteControl matches the snapshot 1`] = `
   >
     <fieldset>
       <legend>
-        <span
-          className="components-base-control__label"
+        <div
+          className="block-editor-color-gradient-control__color-indicator"
         >
-          Test Color
           <span
-            aria-label="(Color: #f00)"
-            className="component-color-indicator"
-            style={
-              Object {
-                "background": "#f00",
+            className="components-base-control__label"
+          >
+            Test Color
+            <span
+              aria-label="(Color: #f00)"
+              className="component-color-indicator"
+              style={
+                Object {
+                  "background": "#f00",
+                }
               }
-            }
-          />
-        </span>
+            />
+          </span>
+        </div>
       </legend>
       <div
         className="components-circular-option-picker"

--- a/packages/block-editor/src/components/colors-gradients/control.js
+++ b/packages/block-editor/src/components/colors-gradients/control.js
@@ -110,27 +110,29 @@ function ColorGradientControlInner( {
 		>
 			<fieldset>
 				<legend>
-					<BaseControl.VisualLabel>
-						<VisualLabel
-							currentTab={ currentTab }
-							label={ label }
-							colorValue={ colorValue }
-							gradientValue={ gradientValue }
-						/>
-					</BaseControl.VisualLabel>
+					<div className="block-editor-color-gradient-control__color-indicator">
+						<BaseControl.VisualLabel>
+							<VisualLabel
+								currentTab={ currentTab }
+								label={ label }
+								colorValue={ colorValue }
+								gradientValue={ gradientValue }
+							/>
+						</BaseControl.VisualLabel>
+					</div>
 				</legend>
 				{ canChooseAColor && canChooseAGradient && (
 					<ButtonGroup className="block-editor-color-gradient-control__button-tabs">
 						<Button
-							isLarge
+							isSmall
 							isPrimary={ currentTab === 'color' }
 							isSecondary={ currentTab !== 'color' }
 							onClick={ () => setCurrentTab( 'color' ) }
 						>
-							{ __( 'Solid Color' ) }
+							{ __( 'Solid' ) }
 						</Button>
 						<Button
-							isLarge
+							isSmall
 							isPrimary={ currentTab === 'gradient' }
 							isSecondary={ currentTab !== 'gradient' }
 							onClick={ () => setCurrentTab( 'gradient' ) }

--- a/packages/block-editor/src/components/colors-gradients/style.scss
+++ b/packages/block-editor/src/components/colors-gradients/style.scss
@@ -1,5 +1,12 @@
-.block-editor-color-gradient-control__button-tabs {
-	display: block;
+.block-editor-color-gradient-control {
+	&__color-indicator {
+		margin-bottom: $grid-size;
+	}
+
+	&__button-tabs {
+		display: block;
+		margin-bottom: $grid-size;
+	}
 }
 
 .block-editor-panel-color-gradient-settings {
@@ -7,8 +14,10 @@
 		vertical-align: text-bottom;
 	}
 
-	&__panel-title .component-color-indicator {
-		display: inline-block;
+	&__panel-title {
+		.component-color-indicator {
+			display: inline-block;
+		}
 	}
 
 	&.is-opened &__panel-title .component-color-indicator {

--- a/packages/block-editor/src/components/colors-gradients/test/control.js
+++ b/packages/block-editor/src/components/colors-gradients/test/control.js
@@ -27,7 +27,7 @@ const getButtonWithAriaLabelStartPredicate = ( ariaLabelStart ) => (
 	);
 };
 
-const colorTabButtonPredicate = getButtonWithTestPredicate( 'Solid Color' );
+const colorTabButtonPredicate = getButtonWithTestPredicate( 'Solid' );
 const gradientTabButtonPredicate = getButtonWithTestPredicate( 'Gradient' );
 
 describe( 'ColorPaletteControl', () => {

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -388,7 +388,7 @@ function CoverEdit( {
 									gradientValue,
 									onColorChange: setOverlayColor,
 									onGradientChange: setGradient,
-									label: __( 'Overlay' ),
+									label: __( 'Color' ),
 								},
 							] }
 						>

--- a/packages/components/src/custom-gradient-picker/icons.js
+++ b/packages/components/src/custom-gradient-picker/icons.js
@@ -3,13 +3,12 @@
  */
 import { withInstanceId } from '@wordpress/compose';
 import {
-	SVG,
-	G,
-	Rect,
-	Defs,
-	RadialGradient,
+	Circle,
 	LinearGradient,
+	Path,
+	RadialGradient,
 	Stop,
+	SVG,
 } from '@wordpress/primitives';
 
 /**
@@ -18,28 +17,25 @@ import {
 export const LinearGradientIcon = withInstanceId( ( { instanceId } ) => {
 	const linerGradientId = `linear-gradient-${ instanceId }`;
 	return (
-		<SVG width="20" height="20" xmlns="http://www.w3.org/2000/svg">
-			<Defs>
-				<LinearGradient
-					y2="0"
-					x2="0.5"
-					y1="1"
-					x1="0.5"
-					id={ linerGradientId }
-				>
-					<Stop offset="0" stopColor="#000000" />
-					<Stop offset="1" stopColor="#fff" />
-				</LinearGradient>
-			</Defs>
-			<G>
-				<Rect
-					fill={ `url(#${ linerGradientId })` }
-					height="20"
-					width="20"
-					y="-1"
-					x="-1"
-				/>
-			</G>
+		<SVG
+			fill="none"
+			height="20"
+			viewBox="0 0 20 20"
+			width="20"
+			xmlns="http://www.w3.org/2000/svg"
+		>
+			<LinearGradient
+				id={ linerGradientId }
+				gradientUnits="userSpaceOnUse"
+				x1="10"
+				x2="10"
+				y1="1"
+				y2="19"
+			>
+				<Stop offset="0" stopColor="#000000" />
+				<Stop offset="1" stopColor="#ffffff" />
+			</LinearGradient>
+			<Path d="m1 1h18v18h-18z" fill={ `url(#${ linerGradientId })` } />
 		</SVG>
 	);
 } );
@@ -47,27 +43,30 @@ export const LinearGradientIcon = withInstanceId( ( { instanceId } ) => {
 export const RadialGradientIcon = withInstanceId( ( { instanceId } ) => {
 	const radialGradientId = `radial-gradient-${ instanceId }`;
 	return (
-		<SVG width="20" height="20" xmlns="http://www.w3.org/2000/svg">
-			<Defs>
-				<RadialGradient
-					cy="0.5"
-					cx="0.5"
-					spreadMethod="pad"
-					id={ radialGradientId }
-				>
-					<Stop offset="0" stopColor="#fff" />
-					<Stop offset="1" stopColor="#000000" />
-				</RadialGradient>
-			</Defs>
-			<G>
-				<Rect
-					fill={ `url(#${ radialGradientId })` }
-					height="20"
-					width="20"
-					y="-1"
-					x="-1"
-				/>
-			</G>
+		<SVG
+			fill="none"
+			height="20"
+			viewBox="0 0 20 20"
+			width="20"
+			xmlns="http://www.w3.org/2000/svg"
+		>
+			<RadialGradient
+				id={ radialGradientId }
+				cx="0"
+				cy="0"
+				gradientTransform="matrix(0 9 -9 0 10 10)"
+				gradientUnits="userSpaceOnUse"
+				r="1"
+			>
+				<Stop offset="0" stopColor="#000000" />
+				<Stop offset="1" stopColor="#ffffff" />
+			</RadialGradient>
+			<Circle
+				cx="10"
+				cy="10"
+				fill={ `url(#${ radialGradientId })` }
+				r="9"
+			/>
 		</SVG>
 	);
 } );

--- a/packages/components/src/custom-gradient-picker/index.js
+++ b/packages/components/src/custom-gradient-picker/index.js
@@ -75,6 +75,7 @@ const GradientTypePicker = ( { gradientAST, hasGradient, onChange } ) => {
 		<BaseControl className="components-custom-gradient-picker__type-picker">
 			<BaseControl.VisualLabel>{ __( 'Type' ) }</BaseControl.VisualLabel>
 			<ToolbarGroup
+				className="components-custom-gradient-picker__toolbar"
 				controls={ [
 					{
 						icon: <LinearGradientIcon />,

--- a/packages/components/src/custom-gradient-picker/style.scss
+++ b/packages/components/src/custom-gradient-picker/style.scss
@@ -77,17 +77,8 @@ $components-custom-gradient-picker__padding: 3px; // 24px container, 18px handle
 }
 
 .components-custom-gradient-picker .components-custom-gradient-picker__ui-line {
-	.components-base-control.components-custom-gradient-picker__angle-picker,
+	.components-base-control.components-angle-picker,
 	.components-base-control.components-custom-gradient-picker__type-picker {
 		margin-bottom: 0;
 	}
-}
-
-.components-custom-gradient-picker__angle-picker-field {
-	display: block;
-	width: 100%;
-}
-
-.components-custom-gradient-picker__angle-picker {
-	width: 50%;
 }

--- a/packages/components/src/custom-gradient-picker/style.scss
+++ b/packages/components/src/custom-gradient-picker/style.scss
@@ -2,10 +2,6 @@ $components-custom-gradient-picker__padding: 3px; // 24px container, 18px handle
 
 .components-custom-gradient-picker {
 	margin-top: $grid-size;
-
-	.components-custom-gradient-picker__toolbar {
-		border: none;
-	}
 }
 
 .components-custom-gradient-picker__gradient-bar:not(.has-gradient) {
@@ -80,5 +76,18 @@ $components-custom-gradient-picker__padding: 3px; // 24px container, 18px handle
 	.components-base-control.components-angle-picker,
 	.components-base-control.components-custom-gradient-picker__type-picker {
 		margin-bottom: 0;
+	}
+}
+
+.components-custom-gradient-picker .components-custom-gradient-picker__toolbar {
+	border: none;
+
+	button {
+		&.is-pressed {
+			> svg {
+				background: $white;
+				border: 1px solid $dark-gray-200;
+			}
+		}
 	}
 }

--- a/packages/components/src/custom-gradient-picker/style.scss
+++ b/packages/components/src/custom-gradient-picker/style.scss
@@ -1,6 +1,8 @@
 $components-custom-gradient-picker__padding: 3px; // 24px container, 18px handles inside, that leaves 6px padding, half of which is 3.
 
 .components-custom-gradient-picker {
+	margin-top: $grid-size;
+
 	.components-custom-gradient-picker__toolbar {
 		border: none;
 	}
@@ -14,7 +16,7 @@ $components-custom-gradient-picker__padding: 3px; // 24px container, 18px handle
 	width: 100%;
 	height: $icon-button-size-small;
 	border-radius: $icon-button-size-small;
-	margin-bottom: $grid-size;
+	margin-bottom: $grid-size-large;
 	padding-left: $components-custom-gradient-picker__padding;
 	padding-right: $icon-button-size-small - $components-custom-gradient-picker__padding;
 

--- a/packages/components/src/custom-gradient-picker/style.scss
+++ b/packages/components/src/custom-gradient-picker/style.scss
@@ -82,7 +82,14 @@ $components-custom-gradient-picker__padding: 3px; // 24px container, 18px handle
 .components-custom-gradient-picker .components-custom-gradient-picker__toolbar {
 	border: none;
 
+	// Work-around to target the inner button containers rendered by <ToolbarGroup />
+	> div + div {
+		margin-left: 1px;
+	}
+
 	button {
+		border-radius: 4px;
+
 		&.is-pressed {
 			> svg {
 				background: $white;

--- a/packages/components/src/custom-gradient-picker/style.scss
+++ b/packages/components/src/custom-gradient-picker/style.scss
@@ -88,12 +88,11 @@ $components-custom-gradient-picker__padding: 3px; // 24px container, 18px handle
 	}
 
 	button {
-		border-radius: 4px;
-
 		&.is-pressed {
 			> svg {
 				background: $white;
 				border: 1px solid $dark-gray-200;
+				border-radius: 2px;
 			}
 		}
 	}

--- a/packages/components/src/custom-gradient-picker/style.scss
+++ b/packages/components/src/custom-gradient-picker/style.scss
@@ -1,5 +1,11 @@
 $components-custom-gradient-picker__padding: 3px; // 24px container, 18px handles inside, that leaves 6px padding, half of which is 3.
 
+.components-custom-gradient-picker {
+	.components-custom-gradient-picker__toolbar {
+		border: none;
+	}
+}
+
 .components-custom-gradient-picker__gradient-bar:not(.has-gradient) {
 	opacity: 0.4;
 }


### PR DESCRIPTION
## Description
This update adjusts the UI of the `CustomGradientPicker`, specifically as it appears in the `Cover` block.
This is a follow up to Design suggestions from https://github.com/WordPress/gutenberg/pull/19582#issuecomment-583085072

## How has this been tested?
Tested locally in Gutenberg

## Screenshots 
##### Solid Color
<img width="340" alt="Screen Shot 2020-02-07 at 11 16 51 AM" src="https://user-images.githubusercontent.com/2322354/74046282-459f1200-499c-11ea-97d3-b4bc7a109db7.png">

##### Gradient Color
<img width="300" alt="Screen Shot 2020-02-07 at 11 29 35 AM" src="https://user-images.githubusercontent.com/2322354/74046779-28b70e80-499d-11ea-8e62-9ce6cbd2aba0.png">

### Notes

These were the original design update suggestions:

* [x] Let’s minimize those tabs (Solid color | Gradient) as much as possible. They’re too big right now.
* [x] Change the word "Overlay" to "Color".
* [x] Remove the border around the gradient type icons.
* [x] Provide more vertical padding between all the parts. (24px or some other CSS variable close to that)
* [ ] Make sure the Angle number field and the "Clear" button align along the right side nicely.

I was able to make all of the updates with the exception of the `Clear` button. The reason is because of how the various UI pieces are composed together. The button actions area, which contains clear, is separate from the color/gradient controls:

<img width="348" alt="Screen Shot 2020-02-07 at 11 14 38 AM" src="https://user-images.githubusercontent.com/2322354/74046420-8b5bda80-499c-11ea-8fb2-14e498c71b79.png">

Making this update would require refactoring across multiple components. It's doable, but perhaps something to tackle after WP 5.4.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
