### PR TITLE
Fix MediaReplaceFlow to select media in media library on replace

### DIFF
--- a/packages/block-editor/src/components/media-replace-flow/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/index.js
@@ -28,6 +28,7 @@ import LinkViewer from '../url-popover/link-viewer';
 
 const MediaReplaceFlow = ( {
 	mediaURL,
+	mediaId,
 	allowedTypes,
 	accept,
 	onSelect,
@@ -141,6 +142,7 @@ const MediaReplaceFlow = ( {
 				<>
 					<NavigableMenu>
 						<MediaUpload
+							value={ mediaId }
 							onSelect={ ( media ) => selectMedia( media ) }
 							allowedTypes={ allowedTypes }
 							render={ ( { open } ) => (

--- a/packages/block-library/src/audio/edit.js
+++ b/packages/block-library/src/audio/edit.js
@@ -106,7 +106,14 @@ class AudioEdit extends Component {
 	}
 
 	render() {
-		const { autoplay, caption, loop, preload, src } = this.props.attributes;
+		const {
+			id,
+			autoplay,
+			caption,
+			loop,
+			preload,
+			src,
+		} = this.props.attributes;
 		const { setAttributes, isSelected, className, noticeUI } = this.props;
 		const onSelectAudio = ( media ) => {
 			if ( ! media || ! media.url ) {
@@ -139,6 +146,7 @@ class AudioEdit extends Component {
 			<>
 				<BlockControls>
 					<MediaReplaceFlow
+						mediaId={ id }
 						mediaURL={ src }
 						allowedTypes={ ALLOWED_MEDIA_TYPES }
 						accept="audio/*"

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -258,6 +258,7 @@ function CoverEdit( {
 	noticeOperations,
 } ) {
 	const {
+		id,
 		backgroundType,
 		dimRatio,
 		focalPoint,
@@ -315,6 +316,7 @@ function CoverEdit( {
 			<BlockControls>
 				{ hasBackground && (
 					<MediaReplaceFlow
+						mediaId={ id }
 						mediaURL={ url }
 						allowedTypes={ ALLOWED_MEDIA_TYPES }
 						accept="image/*,video/*"

--- a/packages/block-library/src/file/edit.js
+++ b/packages/block-library/src/file/edit.js
@@ -138,6 +138,7 @@ class FileEdit extends Component {
 			media,
 		} = this.props;
 		const {
+			id,
 			fileName,
 			href,
 			textLinkHref,
@@ -185,6 +186,7 @@ class FileEdit extends Component {
 				/>
 				<BlockControls>
 					<MediaReplaceFlow
+						mediaId={ id }
 						mediaURL={ href }
 						accept="*"
 						onSelect={ this.onSelectFile }

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -360,6 +360,7 @@ export class ImageEdit extends Component {
 				/>
 				{ url && (
 					<MediaReplaceFlow
+						mediaId={ id }
 						mediaURL={ url }
 						allowedTypes={ ALLOWED_MEDIA_TYPES }
 						accept="image/*"

--- a/packages/block-library/src/media-text/media-container.js
+++ b/packages/block-library/src/media-text/media-container.js
@@ -47,10 +47,11 @@ class MediaContainer extends Component {
 	}
 
 	renderToolbarEditButton() {
-		const { onSelectMedia, mediaUrl } = this.props;
+		const { onSelectMedia, mediaUrl, mediaId } = this.props;
 		return (
 			<BlockControls>
 				<MediaReplaceFlow
+					mediaId={ mediaId }
 					mediaURL={ mediaUrl }
 					allowedTypes={ ALLOWED_MEDIA_TYPES }
 					accept="image/*,video/*"

--- a/packages/block-library/src/video/edit.js
+++ b/packages/block-library/src/video/edit.js
@@ -113,7 +113,7 @@ class VideoEdit extends Component {
 	}
 
 	render() {
-		const { caption, controls, poster, src } = this.props.attributes;
+		const { id, caption, controls, poster, src } = this.props.attributes;
 		const {
 			className,
 			instanceId,
@@ -156,6 +156,7 @@ class VideoEdit extends Component {
 			<>
 				<BlockControls>
 					<MediaReplaceFlow
+						mediaId={ id }
 						mediaURL={ src }
 						allowedTypes={ ALLOWED_MEDIA_TYPES }
 						accept="video/*"


### PR DESCRIPTION
## Description
Closes #20040

Props: @Ringish Thank you for the quick fix.

## How has this been tested?
Tested locally.

To test:

- add any media block
- select media from library
- try to replace from library
- the current media should be selected

## Types of changes
I have fixed all the media blocks which implement `MediaReplaceControl` to have this behavior. 


