### PR TITLE
Social Links: Consistently rebrand as Social Icons

### DIFF
--- a/packages/block-library/src/social-links/index.js
+++ b/packages/block-library/src/social-links/index.js
@@ -17,7 +17,7 @@ export { metadata, name };
 export const settings = {
 	title: __( 'Social Icons' ),
 	description: __(
-		'Create a block of links to your social media or external sites'
+		'Create a block of links to your social media or external services.'
 	),
 	keywords: [ _x( 'links', 'block keywords' ) ],
 	supports: {

--- a/packages/block-library/src/social-links/index.js
+++ b/packages/block-library/src/social-links/index.js
@@ -17,7 +17,7 @@ export { metadata, name };
 export const settings = {
 	title: __( 'Social Icons' ),
 	description: __(
-		'Create a block of links to your social media or external services.'
+		'Create a block of links to your social media or external sites.'
 	),
 	keywords: [ _x( 'links', 'block keywords' ) ],
 	supports: {

--- a/packages/block-library/src/social-links/index.js
+++ b/packages/block-library/src/social-links/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -15,10 +15,11 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	title: __( 'Social links' ),
+	title: __( 'Social Icons' ),
 	description: __(
 		'Create a block of links to your social media or external sites'
 	),
+	keywords: [ _x( 'links', 'block keywords' ) ],
 	supports: {
 		align: [ 'left', 'center', 'right' ],
 	},

--- a/packages/e2e-tests/fixtures/block-transforms.js
+++ b/packages/e2e-tests/fixtures/block-transforms.js
@@ -489,7 +489,7 @@ export const EXPECTED_TRANSFORMS = {
 		originalBlock: 'YouTube',
 	},
 	'core__social-links': {
-		originalBlock: 'Social links',
+		originalBlock: 'Social Icons',
 		availableTransforms: [ 'Group' ],
 	},
 	core__spacer: {


### PR DESCRIPTION
Since #19887, `core/social-link` was already titled "Social Icon". This PR does the same to parent `core/social-links`.

**Note:** This is not the same as renaming the block's `name`, something which would affect how content is saved. Internally renaming the block isn't off the table, but is a greater commitment that we don't need to make right away.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
