### PR TITLE
Avoid using DOMRect constructor for Edge and IE

### DIFF
--- a/packages/block-editor/src/components/block-list/insertion-point.js
+++ b/packages/block-editor/src/components/block-list/insertion-point.js
@@ -118,7 +118,14 @@ export default function InsertionPoint( {
 		const blockNode = getBlockDOMNode( inserterClientId );
 		const container = isReverse ? containerRef.current : blockNode;
 		const closest = getClosestTabbable( blockNode, true, container );
-		const rect = new window.DOMRect( clientX, clientY, 0, 16 );
+		const rect = {
+			left: clientX,
+			right: clientX,
+			top: clientY,
+			bottom: clientY + 16,
+			width: 0,
+			height: 16,
+		};
 
 		if ( closest ) {
 			placeCaretAtVerticalEdge( closest, isReverse, rect, false );

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -78,12 +78,14 @@ function computeAnchorRect(
 		const { top, bottom } = anchorRef;
 		const topRect = top.getBoundingClientRect();
 		const bottomRect = bottom.getBoundingClientRect();
-		const rect = new window.DOMRect(
-			topRect.left,
-			topRect.top,
-			topRect.width,
-			bottomRect.bottom - topRect.top
-		);
+		const rect = {
+			left: topRect.left,
+			right: topRect.right,
+			top: topRect.top,
+			bottom: bottomRect.bottom,
+			width: topRect.width,
+			height: bottomRect.bottom - topRect.top,
+		};
 
 		if ( shouldAnchorIncludePadding ) {
 			return rect;
@@ -313,12 +315,14 @@ const Popover = ( {
 				const offsetParentRect = offsetParent.getBoundingClientRect();
 
 				relativeOffsetTop = offsetParentRect.top;
-				anchor = new window.DOMRect(
-					anchor.left - offsetParentRect.left,
-					anchor.top - offsetParentRect.top,
-					anchor.width,
-					anchor.height
-				);
+				anchor = {
+					left: anchor.left - offsetParentRect.left,
+					right: anchor.left - offsetParentRect.left + anchor.width,
+					top: anchor.top - offsetParentRect.top,
+					bottom: anchor.top - offsetParentRect.top + anchor.height,
+					width: anchor.width,
+					height: anchor.height,
+				};
 			} else {
 				setStyle( containerRef.current, 'position' );
 			}


### PR DESCRIPTION
## Description

Fixes #19979. Not sure if this is the solution we want, but it does get rid of calling DOMRect.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
