### PR TITLE
Compat: Add DOMRect polyfill

### DIFF
--- a/lib/compat.php
+++ b/lib/compat.php
@@ -58,9 +58,9 @@ function gutenberg_add_url_polyfill( $scripts ) {
 	gutenberg_register_vendor_script(
 		$scripts,
 		'wp-polyfill-url',
-		'https://unpkg.com/polyfill-library@3.26.0-0/polyfills/URL/polyfill.js',
+		'https://unpkg.com/polyfill-library@3.42.0/polyfills/URL/polyfill.js',
 		array(),
-		'3.26.0-0'
+		'3.42.0'
 	);
 
 	did_action( 'init' ) && $scripts->add_inline_script(

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -76,6 +76,49 @@ function gutenberg_add_url_polyfill( $scripts ) {
 add_action( 'wp_default_scripts', 'gutenberg_add_url_polyfill', 20 );
 
 /**
+ * Adds a polyfill for DOMRect in environments which do not support it.
+ *
+ * This can be removed when plugin support requires WordPress 5.4.0+.
+ *
+ * @see gutenberg_add_url_polyfill
+ * @see https://core.trac.wordpress.org/ticket/49360
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMRect
+ * @see https://developer.wordpress.org/reference/functions/wp_default_packages_vendor/
+ *
+ * @since 7.5.0
+ *
+ * @param WP_Scripts $scripts WP_Scripts object.
+ */
+function gutenberg_add_dom_rect_polyfill( $scripts ) {
+	// Only register polyfill if not already registered. This prevents handling
+	// in an environment where core has updated to manage the polyfill. This
+	// depends on the action being handled after default script registration.
+	$is_polyfill_script_registered = (bool) $scripts->query( 'wp-polyfill-dom-rect', 'registered' );
+	if ( $is_polyfill_script_registered ) {
+		return;
+	}
+
+	gutenberg_register_vendor_script(
+		$scripts,
+		'wp-polyfill-dom-rect',
+		'https://unpkg.com/polyfill-library@3.42.0/polyfills/DOMRect/polyfill.js',
+		array(),
+		'3.42.0'
+	);
+
+	did_action( 'init' ) && $scripts->add_inline_script(
+		'wp-polyfill',
+		wp_get_script_polyfill(
+			$scripts,
+			array(
+				'window.DOMRect' => 'wp-polyfill-dom-rect',
+			)
+		)
+	);
+}
+add_action( 'wp_default_scripts', 'gutenberg_add_dom_rect_polyfill', 20 );
+
+/**
  * Sets the current post for usage in template blocks.
  *
  * @return WP_Post|null The post if any, or null otherwise.


### PR DESCRIPTION
Fixes #19979
Alternative to #20103
Related: #19823, https://core.trac.wordpress.org/ticket/49360

This pull request seeks to add a polyfill for [DOMRect](https://developer.mozilla.org/en-US/docs/Web/API/DOMRect#Browser_compatibility) to resolve errors which can occur when using browsers which do not support this feature (Internet Explorer, Edge). It is modeled after the changes in #19823, and uses the same `polyfill-library` library. The library version at the version inherited from core (`3.26.0`) did not include this at the time, and it was only made available later. The changes are pinned to the current version as of the time of writing (`3.42.0`). An upgrade to this dependency would be required for an equivalent core patch.

**Testing Instructions:**

Repeat steps to reproduce from #19979, verifying no error.