### PR TITLE
Fix: experimentalUseColors: labels are not translatable

### DIFF
--- a/packages/block-editor/src/components/colors/use-colors.js
+++ b/packages/block-editor/src/components/colors/use-colors.js
@@ -34,6 +34,11 @@ const { getComputedStyle, Node } = window;
 
 const DEFAULT_COLORS = [];
 
+const COMMON_COLOR_LABELS = {
+	textColor: __( 'Text Color' ),
+	backgroundColor: __( 'Background Color' ),
+};
+
 const resolveContrastCheckerColor = ( color, colorSettings, detectedColor ) => {
 	if ( typeof color === 'function' ) {
 		return color( colorSettings );
@@ -297,8 +302,10 @@ export default function __experimentalUseColors(
 				property = name, // E.g. 'backgroundColor'.
 				className,
 
-				panelLabel = startCase( name ), // E.g. 'Background Color'.
-				componentName = panelLabel.replace( /\s/g, '' ), // E.g. 'BackgroundColor'.
+				panelLabel = colorConfig.label ||
+					COMMON_COLOR_LABELS[ name ] ||
+					startCase( name ), // E.g. 'Background Color'.
+				componentName = startCase( name ).replace( /\s/g, '' ), // E.g. 'BackgroundColor'.
 
 				color = colorConfig.color,
 				colors = settingsColors,


### PR DESCRIPTION
## Description
Fix: https://github.com/WordPress/gutenberg/issues/19890

The PR makes sure labels color labels of blocks using __experimentalUseColors are translatable.
The PR adds a label property that allows blocks to explicitly set a label.
It also has adds an object with the translatable labels for common color usages to allow blocks to have translatable color labels without the need to explicitly set them.
If no label is passed and no common label exists the old mechanism to generate labels is used.


## How has this been tested?
I changed the COMMON_COLOR_LABELS to have random labels and verified the changes were applied.
I explicitly passed a label on the heading block text color and verified the label was used.
