### PR TITLE
wp-env: fix syntax error where spread operator could fail

### DIFF
--- a/packages/env/lib/build-docker-compose-config.js
+++ b/packages/env/lib/build-docker-compose-config.js
@@ -22,10 +22,12 @@ module.exports = function buildDockerComposeConfig( config ) {
 
 		// If this is is the Gutenberg plugin, then mount its E2E test plugins.
 		// TODO: Implement an API that lets Gutenberg mount test plugins without this workaround.
-		...( fs.existsSync( path.resolve( source.path, 'gutenberg.php' ) ) && [
-			`${ source.path }/packages/e2e-tests/plugins:/var/www/html/wp-content/plugins/gutenberg-test-plugins`,
-			`${ source.path }/packages/e2e-tests/mu-plugins:/var/www/html/wp-content/mu-plugins`,
-		] ),
+		...( fs.existsSync( path.resolve( source.path, 'gutenberg.php' ) )
+			? [
+					`${ source.path }/packages/e2e-tests/plugins:/var/www/html/wp-content/plugins/gutenberg-test-plugins`,
+					`${ source.path }/packages/e2e-tests/mu-plugins:/var/www/html/wp-content/mu-plugins`,
+			  ]
+			: [] ),
 	] );
 
 	const themeMounts = config.themeSources.map(


### PR DESCRIPTION
Fixes a case in the @wordpress/env logic which could try to spread `false` rather than an array. This was causing [the error I mentioned here](https://github.com/WordPress/gutenberg/pull/20002#discussion_r376199804) (albeit with a misleading error message). 

In a node repl, you can see that the old syntax doesn't quite work:

```node
$ node
$ const foo = [ ...( false && [ 1, 2, 3 ] ), 4 ];
// Thrown:
// TypeError: boolean false is not iterable (cannot read property Symbol(Symbol.iterator))
```

### Description
The logic now always spreads an array, rather than sometimes trying to spread `false`.

### How has this been tested?
I ran the the wp-env start script from my own plugin. Before this patch I got `undefined is not a function` every time I ran the script. After this patch, the command successfully completes every time I run it, and the plugins are all mounted successfully (including the Gutenberg test plugins, since Gutenberg is a dependency.)

### Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
