### PR TITLE
Fix: Predefined group text colors don't work on the frontend

### DIFF
--- a/packages/block-library/src/group/deprecated.js
+++ b/packages/block-library/src/group/deprecated.js
@@ -9,6 +9,61 @@ import classnames from 'classnames';
 import { InnerBlocks, getColorClassName } from '@wordpress/block-editor';
 
 const deprecated = [
+	// Version of the group block with a bug that made text color class not applied.
+	{
+		attributes: {
+			backgroundColor: {
+				type: 'string',
+			},
+			customBackgroundColor: {
+				type: 'string',
+			},
+			textColor: {
+				type: 'string',
+			},
+			customTextColor: {
+				type: 'string',
+			},
+		},
+		supports: {
+			align: [ 'wide', 'full' ],
+			anchor: true,
+			html: false,
+		},
+		save( { attributes } ) {
+			const {
+				backgroundColor,
+				customBackgroundColor,
+				textColor,
+				customTextColor,
+			} = attributes;
+
+			const backgroundClass = getColorClassName(
+				'background-color',
+				backgroundColor
+			);
+			const textClass = getColorClassName( 'color', textColor );
+			const className = classnames( backgroundClass, {
+				'has-text-color': textColor || customTextColor,
+				'has-background': backgroundColor || customBackgroundColor,
+			} );
+
+			const styles = {
+				backgroundColor: backgroundClass
+					? undefined
+					: customBackgroundColor,
+				color: textClass ? undefined : customTextColor,
+			};
+
+			return (
+				<div className={ className } style={ styles }>
+					<div className="wp-block-group__inner-container">
+						<InnerBlocks.Content />
+					</div>
+				</div>
+			);
+		},
+	},
 	// v1 of group block. Deprecated to add an inner-container div around `InnerBlocks.Content`.
 	{
 		attributes: {

--- a/packages/block-library/src/group/save.js
+++ b/packages/block-library/src/group/save.js
@@ -21,7 +21,7 @@ export default function save( { attributes } ) {
 		backgroundColor
 	);
 	const textClass = getColorClassName( 'color', textColor );
-	const className = classnames( backgroundClass, {
+	const className = classnames( backgroundClass, textClass, {
 		'has-text-color': textColor || customTextColor,
 		'has-background': backgroundColor || customBackgroundColor,
 	} );

--- a/packages/e2e-tests/fixtures/blocks/core__group__deprecated-2.html
+++ b/packages/e2e-tests/fixtures/blocks/core__group__deprecated-2.html
@@ -1,0 +1,9 @@
+<!-- wp:group {"textColor":"accent"} -->
+<div class="wp-block-group has-text-color">
+	<div class="wp-block-group__inner-container">
+		<!-- wp:paragraph -->
+		<p>My paragraph</p>
+		<!-- /wp:paragraph -->
+	</div>
+</div>
+<!-- /wp:group -->

--- a/packages/e2e-tests/fixtures/blocks/core__group__deprecated-2.json
+++ b/packages/e2e-tests/fixtures/blocks/core__group__deprecated-2.json
@@ -1,0 +1,24 @@
+[
+    {
+        "clientId": "_clientId_0",
+        "name": "core/group",
+        "isValid": true,
+        "attributes": {
+            "textColor": "accent"
+        },
+        "innerBlocks": [
+            {
+                "clientId": "_clientId_0",
+                "name": "core/paragraph",
+                "isValid": true,
+                "attributes": {
+                    "content": "My paragraph",
+                    "dropCap": false
+                },
+                "innerBlocks": [],
+                "originalContent": "<p>My paragraph</p>"
+            }
+        ],
+        "originalContent": "<div class=\"wp-block-group has-text-color\">\n\t<div class=\"wp-block-group__inner-container\">\n\t\t\n\t</div>\n</div>"
+    }
+]

--- a/packages/e2e-tests/fixtures/blocks/core__group__deprecated-2.parsed.json
+++ b/packages/e2e-tests/fixtures/blocks/core__group__deprecated-2.parsed.json
@@ -1,0 +1,34 @@
+[
+    {
+        "blockName": "core/group",
+        "attrs": {
+            "textColor": "accent"
+        },
+        "innerBlocks": [
+            {
+                "blockName": "core/paragraph",
+                "attrs": {},
+                "innerBlocks": [],
+                "innerHTML": "\n\t\t<p>My paragraph</p>\n\t\t",
+                "innerContent": [
+                    "\n\t\t<p>My paragraph</p>\n\t\t"
+                ]
+            }
+        ],
+        "innerHTML": "\n<div class=\"wp-block-group has-text-color\">\n\t<div class=\"wp-block-group__inner-container\">\n\t\t\n\t</div>\n</div>\n",
+        "innerContent": [
+            "\n<div class=\"wp-block-group has-text-color\">\n\t<div class=\"wp-block-group__inner-container\">\n\t\t",
+            null,
+            "\n\t</div>\n</div>\n"
+        ]
+    },
+    {
+        "blockName": null,
+        "attrs": {},
+        "innerBlocks": [],
+        "innerHTML": "\n",
+        "innerContent": [
+            "\n"
+        ]
+    }
+]

--- a/packages/e2e-tests/fixtures/blocks/core__group__deprecated-2.serialized.html
+++ b/packages/e2e-tests/fixtures/blocks/core__group__deprecated-2.serialized.html
@@ -1,0 +1,5 @@
+<!-- wp:group {"textColor":"accent"} -->
+<div class="wp-block-group has-accent-color has-text-color"><div class="wp-block-group__inner-container"><!-- wp:paragraph -->
+<p>My paragraph</p>
+<!-- /wp:paragraph --></div></div>
+<!-- /wp:group -->


### PR DESCRIPTION
## Description
Fixes: https://github.com/WordPress/gutenberg/issues/20109

The group block did not add the text class for predefined colors so colors did not work as expected on the front end.


## How has this been tested?
I added a group block and set a predefined text color.
I added a paragraph inside.
I saved the post. I the paragraph inside the group appeared as expected.
