### PR TITLE
Data: Log first-pass `mapSelect` errors.

### DIFF
--- a/packages/data/src/components/use-select/index.js
+++ b/packages/data/src/components/use-select/index.js
@@ -114,6 +114,9 @@ export default function useSelect( _mapSelect, deps ) {
 			errorMessage += 'Original stack trace:';
 
 			throw new Error( errorMessage );
+		} else {
+			// eslint-disable-next-line no-console
+			console.error( errorMessage );
 		}
 	}
 


### PR DESCRIPTION
Closes #20117

This PR makes `useSelect` log the first error thrown in `mapSelect` instead of just swallowing it and waiting for a second one. This doesn't decrease the durability of the hook against zombie child updates. Still, it allows for easier debugging of errors like the one in #20117 where a first-pass render exception was causing the hook to return `undefined`, and that triggered an obscure error elsewhere.