### PR TITLE
Fixing selector for media on the right

### DIFF
--- a/packages/block-library/src/media-text/style.scss
+++ b/packages/block-library/src/media-text/style.scss
@@ -7,7 +7,7 @@
 	grid-template-columns: 50% 1fr;
 	grid-template-rows: auto;
 
-	.has-media-on-the-right {
+	&.has-media-on-the-right {
 		grid-template-columns: 1fr 50%;
 	}
 }


### PR DESCRIPTION
## Description
The `.has-media-on-the-right` should be altering the `.wp-block-media-text`, not nested within.

## How has this been tested?
Haven't tested this myself though. Could anybody compile and test to make sure it does not cause any issue?

## Types of changes
Bug fix (non-breaking change which fixes an issue)