### PR TITLE
Fix: Featured image appears cropped

### DIFF
--- a/packages/editor/src/components/post-featured-image/style.scss
+++ b/packages/editor/src/components/post-featured-image/style.scss
@@ -38,6 +38,10 @@
 	box-shadow: 0 0 0 0 $blue-medium-500;
 }
 
+.editor-post-featured-image__preview {
+	height: auto;
+}
+
 .editor-post-featured-image__preview:not(:disabled):not([aria-disabled="true"]):focus {
 	box-shadow: 0 0 0 4px $blue-medium-500;
 }


### PR DESCRIPTION
## Description
Currently, the featured images appear cropped instead of the featured image expanding to show a complete image preview.


## How has this been tested?
I added a big featured image with a height bigger than width.
I verified the image appears complete and is not cropped.
