### PR TITLE
@wordpress/env: Fix GitHub source pattern

### DIFF
--- a/packages/env/lib/config.js
+++ b/packages/env/lib/config.js
@@ -193,9 +193,7 @@ function parseSourceString( sourceString, { workDirectoryPath } ) {
 		};
 	}
 
-	const gitHubFields = sourceString.match(
-		/^([\w-]+)\/([\w-]+)(?:#([\w-]+))?$/
-	);
+	const gitHubFields = sourceString.match( /^([^\/]+)\/([^#]+)(?:#(.+))?$/ );
 	if ( gitHubFields ) {
 		return {
 			type: 'git',

--- a/packages/env/test/config.js
+++ b/packages/env/test/config.js
@@ -170,6 +170,7 @@ describe( 'readConfig', () => {
 					plugins: [
 						'WordPress/gutenberg',
 						'WordPress/gutenberg#master',
+						'WordPress/gutenberg#5.0',
 					],
 				} )
 			)
@@ -188,6 +189,13 @@ describe( 'readConfig', () => {
 					type: 'git',
 					url: 'https://github.com/WordPress/gutenberg.git',
 					ref: 'master',
+					path: expect.stringMatching( /^\/.*gutenberg$/ ),
+					basename: 'gutenberg',
+				},
+				{
+					type: 'git',
+					url: 'https://github.com/WordPress/gutenberg.git',
+					ref: '5.0',
 					path: expect.stringMatching( /^\/.*gutenberg$/ ),
 					basename: 'gutenberg',
 				},


### PR DESCRIPTION
Follows https://github.com/WordPress/gutenberg/pull/20002.

Updates the regular expression used to match GitHub sources so that it matches GitHub sources that have e.g. periods in the ref.

That is, the following `.wp-env.json` file should work:

```json
{
	"core": "WordPress/WordPress#5.0"
}
```

(Note the `.` in `5.0`.)

A regression unit test is included.