### PR TITLE
EditorSkeleton: Add Changelog entries, drop backwards-compat class names

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Master
 
+### New Features
+
 - Add new `__experimentalEditorSkeleton` component. This has been moved over from the `@wordpress/edit-post` package, where it was an internal component called `EditorRegions`. Its class names have thus been renamed from `edit-post-editor-regions` to `block-editor-editor-skeleton`.
 
 ## 3.3.0 (2019-11-14)

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Master
+
+- Add new `__experimentalEditorSkeleton` component. This has been moved over from the `@wordpress/edit-post` package, where it was an internal component called `EditorRegions`. Its class names have thus been renamed from `edit-post-editor-regions` to `block-editor-editor-skeleton`.
+
 ## 3.3.0 (2019-11-14)
 
 ### New Features

--- a/packages/block-editor/src/components/editor-skeleton/index.js
+++ b/packages/block-editor/src/components/editor-skeleton/index.js
@@ -21,13 +21,12 @@ function EditorSkeleton( {
 		<div
 			className={ classnames(
 				className,
-				'block-editor-editor-skeleton',
-				'edit-post-editor-regions'
+				'block-editor-editor-skeleton'
 			) }
 		>
 			{ !! header && (
 				<div
-					className="block-editor-editor-skeleton__header edit-post-editor-regions__header"
+					className="block-editor-editor-skeleton__header"
 					role="region"
 					/* translators: accessibility text for the top bar landmark region. */
 					aria-label={ __( 'Editor top bar' ) }
@@ -36,9 +35,9 @@ function EditorSkeleton( {
 					{ header }
 				</div>
 			) }
-			<div className="block-editor-editor-skeleton__body edit-post-editor-regions__body">
+			<div className="block-editor-editor-skeleton__body">
 				<div
-					className="block-editor-editor-skeleton__content edit-post-editor-regions__content"
+					className="block-editor-editor-skeleton__content"
 					role="region"
 					/* translators: accessibility text for the content landmark region. */
 					aria-label={ __( 'Editor content' ) }
@@ -48,7 +47,7 @@ function EditorSkeleton( {
 				</div>
 				{ !! sidebar && (
 					<div
-						className="block-editor-editor-skeleton__sidebar edit-post-editor-regions__sidebar"
+						className="block-editor-editor-skeleton__sidebar"
 						role="region"
 						/* translators: accessibility text for the settings landmark region. */
 						aria-label={ __( 'Editor settings' ) }
@@ -59,7 +58,7 @@ function EditorSkeleton( {
 				) }
 				{ !! publish && (
 					<div
-						className="block-editor-editor-skeleton__publish edit-post-editor-regions__publish"
+						className="block-editor-editor-skeleton__publish"
 						role="region"
 						/* translators: accessibility text for the publish landmark region. */
 						aria-label={ __( 'Editor publish' ) }
@@ -71,7 +70,7 @@ function EditorSkeleton( {
 			</div>
 			{ !! footer && (
 				<div
-					className="block-editor-editor-skeleton__footer edit-post-editor-regions__footer"
+					className="block-editor-editor-skeleton__footer"
 					role="region"
 					/* translators: accessibility text for the footer landmark region. */
 					aria-label={ __( 'Editor footer' ) }

--- a/packages/edit-post/CHANGELOG.md
+++ b/packages/edit-post/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Master
 
-- Moved the internal `EditorRegions` component to the `@wordpress/block-editor` package, an rename to `EditorSkeleton`. Its class names have thus been renamed from `edit-post-editor-regions` to `block-editor-editor-skeleton`.
+- Move the internal `EditorRegions` component to the `@wordpress/block-editor` package, an rename to `EditorSkeleton`. Its class names have thus been renamed from `edit-post-editor-regions` to `block-editor-editor-skeleton`.
 
 ## 3.8.2
 

--- a/packages/edit-post/CHANGELOG.md
+++ b/packages/edit-post/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Master
 
+### Internal
+
 - Move the internal `EditorRegions` component to the `@wordpress/block-editor` package, an rename to `EditorSkeleton`. Its class names have thus been renamed from `edit-post-editor-regions` to `block-editor-editor-skeleton`.
 
 ## 3.8.2

--- a/packages/edit-post/CHANGELOG.md
+++ b/packages/edit-post/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Master
+
+- Moved the internal `EditorRegions` component to the `@wordpress/block-editor` package, an rename to `EditorSkeleton`. Its class names have thus been renamed from `edit-post-editor-regions` to `block-editor-editor-skeleton`.
+
 ## 3.8.2
 
 ### Bug Fixes


### PR DESCRIPTION
## Description
Follow-up to #20050, where the component was moved and renamed.
Dropping backwards-compat classnames as discussed [here](https://github.com/WordPress/gutenberg/pull/20050#discussion_r375887591).

## How has this been tested?
Rebuild Gutenberg (`npm run build`), and start it (`npx wp-env start`). Verify that the editor styling isn't broken (specifically regions like header or sidebar).

## Types of changes
Add Changelog entries, drop backwards-compat class names.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->