### PR TITLE
Mark the SocialLinks block as a stable block

### DIFF
--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -142,6 +142,8 @@ export const registerCoreBlocks = () => {
 		search,
 		separator,
 		reusableBlock,
+		socialLinks,
+		socialLink,
 		spacer,
 		subhead,
 		table,
@@ -184,8 +186,6 @@ export const __experimentalRegisterExperimentalCoreBlocks =
 
 				[
 					__experimentalEnableLegacyWidgetBlock ? legacyWidget : null,
-					socialLinks,
-					socialLink,
 
 					// Register Full Site Editing Blocks.
 					...( __experimentalEnableFullSiteEditing


### PR DESCRIPTION
Now that #19887 is merged, we can mark the block as stable to include in Core.