### PR TITLE
Fix: Use array form for contrast checkers.

### DIFF
--- a/packages/block-library/src/columns/edit.js
+++ b/packages/block-library/src/columns/edit.js
@@ -72,7 +72,7 @@ function ColumnsEditContainer( {
 			{ name: 'backgroundColor', className: 'has-background' },
 		],
 		{
-			contrastCheckers: { backgroundColor: true, textColor: true },
+			contrastCheckers: [ { backgroundColor: true, textColor: true } ],
 			colorDetector: { targetRef: ref },
 		}
 	);

--- a/packages/block-library/src/group/edit.js
+++ b/packages/block-library/src/group/edit.js
@@ -18,7 +18,7 @@ function GroupEdit( { hasInnerBlocks } ) {
 			{ name: 'backgroundColor', className: 'has-background' },
 		],
 		{
-			contrastCheckers: { backgroundColor: true, textColor: true },
+			contrastCheckers: [ { backgroundColor: true, textColor: true } ],
 			colorDetector: { targetRef: ref },
 		}
 	);


### PR DESCRIPTION
## Description
Fix use array form of contrast checker to avoid contrast message appearing multiple times.

Applies changes suggested by @epiqueras in https://github.com/WordPress/gutenberg/pull/20016#pullrequestreview-355902764 to fix an issue with contrast checkers.

The change is being applied to heading, columns and group block.

