### PR TITLE
API: Stabilize localAutosave() as autosave( { local: true } )

### DIFF
--- a/docs/designers-developers/developers/data/data-core-editor.md
+++ b/docs/designers-developers/developers/data/data-core-editor.md
@@ -1153,6 +1153,11 @@ _Related_
 
 -   insertDefaultBlock in core/block-editor store.
 
+<a name="localAutosave" href="#localAutosave">#</a> **localAutosave**
+
+Action generator used in signalling that the post should be locally
+autosaved (e.g. on the Web, it might be committed to Session Storage).
+
 <a name="lockPostAutosaving" href="#lockPostAutosaving">#</a> **lockPostAutosaving**
 
 Returns an action object used to signal that post autosaving is locked.

--- a/docs/designers-developers/developers/data/data-core-editor.md
+++ b/docs/designers-developers/developers/data/data-core-editor.md
@@ -1068,7 +1068,10 @@ _Related_
 
 <a name="autosave" href="#autosave">#</a> **autosave**
 
-Action generator used in signalling that the post should autosave.
+Action generator used in signalling that the post should autosave.  This
+includes server-side autosaving (default) and client-side (a.k.a. local)
+autosaving (e.g. on the Web, the post might be committed to Session
+Storage).
 
 _Parameters_
 
@@ -1152,11 +1155,6 @@ _Related_
 _Related_
 
 -   insertDefaultBlock in core/block-editor store.
-
-<a name="localAutosave" href="#localAutosave">#</a> **localAutosave**
-
-Action generator used in signalling that the post should be locally
-autosaved (e.g. on the Web, it might be committed to Session Storage).
 
 <a name="lockPostAutosaving" href="#lockPostAutosaving">#</a> **lockPostAutosaving**
 

--- a/packages/e2e-tests/specs/editor/various/autosave.test.js
+++ b/packages/e2e-tests/specs/editor/various/autosave.test.js
@@ -103,7 +103,7 @@ describe( 'autosave', () => {
 
 		// Trigger local autosave
 		await page.evaluate( () =>
-			window.wp.data.dispatch( 'core/editor' ).localAutosave()
+			window.wp.data.dispatch( 'core/editor' ).autosave( { local: true } )
 		);
 		// Reload without saving on the server
 		await page.reload();
@@ -205,7 +205,7 @@ describe( 'autosave', () => {
 
 		// Trigger local autosave
 		await page.evaluate( () =>
-			window.wp.data.dispatch( 'core/editor' ).localAutosave()
+			window.wp.data.dispatch( 'core/editor' ).autosave( { local: true } )
 		);
 		expect(
 			await page.evaluate( () => window.sessionStorage.length )
@@ -229,7 +229,7 @@ describe( 'autosave', () => {
 
 		// Trigger local autosave
 		await page.evaluate( () =>
-			window.wp.data.dispatch( 'core/editor' ).localAutosave()
+			window.wp.data.dispatch( 'core/editor' ).autosave( { local: true } )
 		);
 		expect(
 			await page.evaluate( () => window.sessionStorage.length )
@@ -254,7 +254,7 @@ describe( 'autosave', () => {
 
 		// Trigger local autosave
 		await page.evaluate( () =>
-			window.wp.data.dispatch( 'core/editor' ).localAutosave()
+			window.wp.data.dispatch( 'core/editor' ).autosave( { local: true } )
 		);
 		expect(
 			await page.evaluate( () => window.sessionStorage.length )
@@ -275,7 +275,7 @@ describe( 'autosave', () => {
 
 		// Trigger local autosave
 		await page.evaluate( () =>
-			window.wp.data.dispatch( 'core/editor' ).localAutosave()
+			window.wp.data.dispatch( 'core/editor' ).autosave( { local: true } )
 		);
 		expect(
 			await page.evaluate( () => window.sessionStorage.length )
@@ -304,7 +304,7 @@ describe( 'autosave', () => {
 
 		// Force conflicting local autosave
 		await page.evaluate( () =>
-			window.wp.data.dispatch( 'core/editor' ).localAutosave()
+			window.wp.data.dispatch( 'core/editor' ).autosave( { local: true } )
 		);
 		expect(
 			await page.evaluate( () => window.sessionStorage.length )

--- a/packages/e2e-tests/specs/editor/various/autosave.test.js
+++ b/packages/e2e-tests/specs/editor/various/autosave.test.js
@@ -103,9 +103,7 @@ describe( 'autosave', () => {
 
 		// Trigger local autosave
 		await page.evaluate( () =>
-			window.wp.data
-				.dispatch( 'core/editor' )
-				.__experimentalLocalAutosave()
+			window.wp.data.dispatch( 'core/editor' ).localAutosave()
 		);
 		// Reload without saving on the server
 		await page.reload();
@@ -207,9 +205,7 @@ describe( 'autosave', () => {
 
 		// Trigger local autosave
 		await page.evaluate( () =>
-			window.wp.data
-				.dispatch( 'core/editor' )
-				.__experimentalLocalAutosave()
+			window.wp.data.dispatch( 'core/editor' ).localAutosave()
 		);
 		expect(
 			await page.evaluate( () => window.sessionStorage.length )
@@ -233,9 +229,7 @@ describe( 'autosave', () => {
 
 		// Trigger local autosave
 		await page.evaluate( () =>
-			window.wp.data
-				.dispatch( 'core/editor' )
-				.__experimentalLocalAutosave()
+			window.wp.data.dispatch( 'core/editor' ).localAutosave()
 		);
 		expect(
 			await page.evaluate( () => window.sessionStorage.length )
@@ -260,9 +254,7 @@ describe( 'autosave', () => {
 
 		// Trigger local autosave
 		await page.evaluate( () =>
-			window.wp.data
-				.dispatch( 'core/editor' )
-				.__experimentalLocalAutosave()
+			window.wp.data.dispatch( 'core/editor' ).localAutosave()
 		);
 		expect(
 			await page.evaluate( () => window.sessionStorage.length )
@@ -283,9 +275,7 @@ describe( 'autosave', () => {
 
 		// Trigger local autosave
 		await page.evaluate( () =>
-			window.wp.data
-				.dispatch( 'core/editor' )
-				.__experimentalLocalAutosave()
+			window.wp.data.dispatch( 'core/editor' ).localAutosave()
 		);
 		expect(
 			await page.evaluate( () => window.sessionStorage.length )
@@ -314,9 +304,7 @@ describe( 'autosave', () => {
 
 		// Force conflicting local autosave
 		await page.evaluate( () =>
-			window.wp.data
-				.dispatch( 'core/editor' )
-				.__experimentalLocalAutosave()
+			window.wp.data.dispatch( 'core/editor' ).localAutosave()
 		);
 		expect(
 			await page.evaluate( () => window.sessionStorage.length )

--- a/packages/editor/src/components/local-autosave-monitor/index.js
+++ b/packages/editor/src/components/local-autosave-monitor/index.js
@@ -169,9 +169,9 @@ function useAutosavePurge() {
 }
 
 function LocalAutosaveMonitor() {
-	const { localAutosave } = useDispatch( 'core/editor' );
-	const autosave = useCallback( () => {
-		requestIdleCallback( localAutosave );
+	const { autosave } = useDispatch( 'core/editor' );
+	const deferedAutosave = useCallback( () => {
+		requestIdleCallback( () => autosave( { local: true } ) );
 	}, [] );
 	useAutosaveNotice();
 	useAutosavePurge();
@@ -187,7 +187,7 @@ function LocalAutosaveMonitor() {
 	return (
 		<AutosaveMonitor
 			interval={ localAutosaveInterval }
-			autosave={ autosave }
+			autosave={ deferedAutosave }
 		/>
 	);
 }

--- a/packages/editor/src/components/local-autosave-monitor/index.js
+++ b/packages/editor/src/components/local-autosave-monitor/index.js
@@ -169,9 +169,9 @@ function useAutosavePurge() {
 }
 
 function LocalAutosaveMonitor() {
-	const { __experimentalLocalAutosave } = useDispatch( 'core/editor' );
+	const { localAutosave } = useDispatch( 'core/editor' );
 	const autosave = useCallback( () => {
-		requestIdleCallback( __experimentalLocalAutosave );
+		requestIdleCallback( localAutosave );
 	}, [] );
 	useAutosaveNotice();
 	useAutosavePurge();

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -350,7 +350,11 @@ export function* autosave( options ) {
 	yield dispatch( STORE_KEY, 'savePost', { isAutosave: true, ...options } );
 }
 
-export function* __experimentalLocalAutosave() {
+/**
+ * Action generator used in signalling that the post should be locally
+ * autosaved (e.g. on the Web, it might be committed to Session Storage).
+ */
+export function* localAutosave() {
 	const post = yield select( STORE_KEY, 'getCurrentPost' );
 	const isPostNew = yield select( STORE_KEY, 'isEditedPostNew' );
 	const title = yield select( STORE_KEY, 'getEditedPostAttribute', 'title' );

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -342,40 +342,46 @@ export function* trashPost() {
 }
 
 /**
- * Action generator used in signalling that the post should autosave.
+ * Action generator used in signalling that the post should autosave.  This
+ * includes server-side autosaving (default) and client-side (a.k.a. local)
+ * autosaving (e.g. on the Web, the post might be committed to Session
+ * Storage).
  *
  * @param {Object?} options Extra flags to identify the autosave.
  */
-export function* autosave( options ) {
-	yield dispatch( STORE_KEY, 'savePost', { isAutosave: true, ...options } );
-}
-
-/**
- * Action generator used in signalling that the post should be locally
- * autosaved (e.g. on the Web, it might be committed to Session Storage).
- */
-export function* localAutosave() {
-	const post = yield select( STORE_KEY, 'getCurrentPost' );
-	const isPostNew = yield select( STORE_KEY, 'isEditedPostNew' );
-	const title = yield select( STORE_KEY, 'getEditedPostAttribute', 'title' );
-	const content = yield select(
-		STORE_KEY,
-		'getEditedPostAttribute',
-		'content'
-	);
-	const excerpt = yield select(
-		STORE_KEY,
-		'getEditedPostAttribute',
-		'excerpt'
-	);
-	yield {
-		type: 'LOCAL_AUTOSAVE_SET',
-		postId: post.id,
-		isPostNew,
-		title,
-		content,
-		excerpt,
-	};
+export function* autosave( { local = false, ...options } = {} ) {
+	if ( local ) {
+		const post = yield select( STORE_KEY, 'getCurrentPost' );
+		const isPostNew = yield select( STORE_KEY, 'isEditedPostNew' );
+		const title = yield select(
+			STORE_KEY,
+			'getEditedPostAttribute',
+			'title'
+		);
+		const content = yield select(
+			STORE_KEY,
+			'getEditedPostAttribute',
+			'content'
+		);
+		const excerpt = yield select(
+			STORE_KEY,
+			'getEditedPostAttribute',
+			'excerpt'
+		);
+		yield {
+			type: 'LOCAL_AUTOSAVE_SET',
+			postId: post.id,
+			isPostNew,
+			title,
+			content,
+			excerpt,
+		};
+	} else {
+		yield dispatch( STORE_KEY, 'savePost', {
+			isAutosave: true,
+			...options,
+		} );
+	}
 }
 
 /**


### PR DESCRIPTION
## Description
Part of #20116. See https://github.com/WordPress/gutenberg/issues/20116#issuecomment-584244847.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
