### PR TITLE
Block Library: Social Link: Consistently rename sites to services

### DIFF
--- a/packages/block-library/src/social-link/index.php
+++ b/packages/block-library/src/social-link/index.php
@@ -49,45 +49,45 @@ add_action( 'init', 'register_block_core_social_link' );
 /**
  * Returns the SVG for social link.
  *
- * @param string $site The site icon.
+ * @param string $service The service icon.
  *
- * @return string SVG Element for site icon.
+ * @return string SVG Element for service icon.
  */
-function block_core_social_link_get_icon( $site ) {
-	$sites = block_core_social_link_sites();
-	if ( isset( $sites[ $site ] ) && isset( $sites[ $site ]['icon'] ) ) {
-		return $sites[ $site ]['icon'];
+function block_core_social_link_get_icon( $service ) {
+	$services = block_core_social_link_services();
+	if ( isset( $services[ $service ] ) && isset( $services[ $service ]['icon'] ) ) {
+		return $services[ $service ]['icon'];
 	}
 
-	return $sites['share']['icon'];
+	return $services['share']['icon'];
 }
 
 /**
  * Returns the brand name for social link.
  *
- * @param string $site The site icon.
+ * @param string $service The service icon.
  *
  * @return string Brand label.
  */
-function block_core_social_link_get_name( $site ) {
-	$sites = block_core_social_link_sites();
-	if ( isset( $sites[ $site ] ) && isset( $sites[ $site ]['name'] ) ) {
-		return $sites[ $site ]['name'];
+function block_core_social_link_get_name( $service ) {
+	$services = block_core_social_link_services();
+	if ( isset( $services[ $service ] ) && isset( $services[ $service ]['name'] ) ) {
+		return $services[ $service ]['name'];
 	}
 
-	return $sites['share']['name'];
+	return $services['share']['name'];
 }
 
 /**
  * Returns the SVG for social link.
  *
- * @param string $site The site slug to extract data from.
- * @param string $field The field ('name', 'icon', etc) to extract for a site.
+ * @param string $service The service slug to extract data from.
+ * @param string $field The field ('name', 'icon', etc) to extract for a service.
  *
  * @return array|string
  */
-function block_core_social_link_sites( $site = '', $field = '' ) {
-	$sites_data = array(
+function block_core_social_link_services( $service = '', $field = '' ) {
+	$services_data = array(
 		'fivehundredpx' => array(
 			'name' => '500px',
 			'icon' => '<svg width="24" height="24" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg"><path d="M6.94026,15.1412c.00437.01213.108.29862.168.44064a6.55008,6.55008,0,1,0,6.03191-9.09557,6.68654,6.68654,0,0,0-2.58357.51467A8.53914,8.53914,0,0,0,8.21268,8.61344L8.209,8.61725V3.22948l9.0504-.00008c.32934-.0036.32934-.46353.32934-.61466s0-.61091-.33035-.61467L7.47248,2a.43.43,0,0,0-.43131.42692v7.58355c0,.24466.30476.42131.58793.4819.553.11812.68074-.05864.81617-.2457l.018-.02481A10.52673,10.52673,0,0,1,9.32258,9.258a5.35268,5.35268,0,1,1,7.58985,7.54976,5.417,5.417,0,0,1-3.80867,1.56365,5.17483,5.17483,0,0,1-2.69822-.74478l.00342-4.61111a2.79372,2.79372,0,0,1,.71372-1.78792,2.61611,2.61611,0,0,1,1.98282-.89477,2.75683,2.75683,0,0,1,1.95525.79477,2.66867,2.66867,0,0,1,.79656,1.909,2.724,2.724,0,0,1-2.75849,2.748,4.94651,4.94651,0,0,1-.86254-.13719c-.31234-.093-.44519.34058-.48892.48349-.16811.54966.08453.65862.13687.67489a3.75751,3.75751,0,0,0,1.25234.18375,3.94634,3.94634,0,1,0-2.82444-6.742,3.67478,3.67478,0,0,0-1.13028,2.584l-.00041.02323c-.0035.11667-.00579,2.881-.00644,3.78811l-.00407-.00451a6.18521,6.18521,0,0,1-1.0851-1.86092c-.10544-.27856-.34358-.22925-.66857-.12917-.14192.04372-.57386.17677-.47833.489Zm4.65165-1.08338a.51346.51346,0,0,0,.19513.31818l.02276.022a.52945.52945,0,0,0,.3517.18416.24242.24242,0,0,0,.16577-.0611c.05473-.05082.67382-.67812.73287-.738l.69041.68819a.28978.28978,0,0,0,.21437.11032.53239.53239,0,0,0,.35708-.19486c.29792-.30419.14885-.46821.07676-.54751l-.69954-.69975.72952-.73469c.16-.17311.01874-.35708-.12218-.498-.20461-.20461-.402-.25742-.52855-.14083l-.7254.72665-.73354-.73375a.20128.20128,0,0,0-.14179-.05695.54135.54135,0,0,0-.34379.19648c-.22561.22555-.274.38149-.15656.5059l.73374.7315-.72942.73072A.26589.26589,0,0,0,11.59191,14.05782Zm1.59866-9.915A8.86081,8.86081,0,0,0,9.854,4.776a.26169.26169,0,0,0-.16938.22759.92978.92978,0,0,0,.08619.42094c.05682.14524.20779.531.50006.41955a8.40969,8.40969,0,0,1,2.91968-.55484,7.87875,7.87875,0,0,1,3.086.62286,8.61817,8.61817,0,0,1,2.30562,1.49315.2781.2781,0,0,0,.18318.07586c.15529,0,.30425-.15253.43167-.29551.21268-.23861.35873-.4369.1492-.63538a8.50425,8.50425,0,0,0-2.62312-1.694A9.0177,9.0177,0,0,0,13.19058,4.14283ZM19.50945,18.6236h0a.93171.93171,0,0,0-.36642-.25406.26589.26589,0,0,0-.27613.06613l-.06943.06929A7.90606,7.90606,0,0,1,7.60639,18.505a7.57284,7.57284,0,0,1-1.696-2.51537,8.58715,8.58715,0,0,1-.5147-1.77754l-.00871-.04864c-.04939-.25873-.28755-.27684-.62981-.22448-.14234.02178-.5755.088-.53426.39969l.001.00712a9.08807,9.08807,0,0,0,15.406,4.99094c.00193-.00192.04753-.04718.0725-.07436C19.79425,19.16234,19.87422,18.98728,19.50945,18.6236Z"></path></svg>',
@@ -250,15 +250,15 @@ function block_core_social_link_sites( $site = '', $field = '' ) {
 		),
 	);
 
-	if ( ! empty( $site )
+	if ( ! empty( $service )
 		&& ! empty( $field )
-		&& isset( $sites_data[ $site ] )
+		&& isset( $services_data[ $service ] )
 		&& ( 'icon' === $field || 'name' === $field )
 	) {
-		return $sites_data[ $site ][ $field ];
-	} elseif ( ! empty( $site ) && isset( $sites_data[ $site ] ) ) {
-		return $sites_data[ $site ];
+		return $services_data[ $service ][ $field ];
+	} elseif ( ! empty( $service ) && isset( $services_data[ $service ] ) ) {
+		return $services_data[ $service ];
 	}
 
-	return $sites_data;
+	return $services_data;
 }


### PR DESCRIPTION
Previously: #19887 

This pull request seeks to update all functions and references within functions of the Social Link block to reference "services" instead of "sites". Pending confirmation, it appears this was an intended change from #19887, but not all references to the "sites" terminology was included.

**Testing Instructions:**

There should be no regressions in the insertion, operation, or preview of a Social Links block.

Confirm in code there are no lingering reference to "site".