### PR TITLE
Build Tooling: Clone shallow for publish tool

### DIFF
--- a/bin/commander.js
+++ b/bin/commander.js
@@ -130,7 +130,9 @@ async function runGitRepositoryCloneStep( abortMessage ) {
 	await runStep( 'Cloning the Git repository', abortMessage, async () => {
 		console.log( '>> Cloning the Git repository' );
 		const simpleGit = SimpleGit();
-		await simpleGit.clone( gitRepoURL, gitWorkingDirectoryPath );
+		await simpleGit.clone( gitRepoURL, gitWorkingDirectoryPath, [
+			'--depth 1',
+		] );
 		console.log(
 			'>> The Gutenberg Git repository has been successfully cloned in the following temporary folder: ' +
 				success( gitWorkingDirectoryPath )


### PR DESCRIPTION
This pull request seeks to update the publish tool to perform a shallow clone of the repository for publishing. This improves the usability of the script, where currently it can be time-consuming since the full repository is quite large to clone in its entirety (300mb+). 

References:

- [Shallow clone via `--depth`](https://git-scm.com/docs/git-clone#Documentation/git-clone.txt---depthltdepthgt)
- [`simple-git` options argument](https://github.com/steveukx/git-js#usage) and [implementation](https://github.com/steveukx/git-js/blob/master/src/git.js#L205)