### PR TITLE
wp-env: no longer show error message twice

### DIFF
--- a/packages/env/test/cli.js
+++ b/packages/env/test/cli.js
@@ -84,8 +84,6 @@ describe( 'env cli', () => {
 		/* eslint-disable no-console */
 		env.start.mockRejectedValueOnce( {
 			message: 'failure message',
-			out: 'failure message',
-			exitCode: 2,
 		} );
 		const consoleError = console.error;
 		console.error = jest.fn();
@@ -98,28 +96,37 @@ describe( 'env cli', () => {
 
 		expect( spinner.fail ).toHaveBeenCalledWith( 'failure message' );
 		expect( console.error ).toHaveBeenCalled();
-		expect( process.exit ).toHaveBeenCalledWith( 2 );
+		expect( process.exit ).toHaveBeenCalledWith( 1 );
 		console.error = consoleError;
 		process.exit = processExit;
 		/* eslint-enable no-console */
 	} );
-	it( 'handles failed commands with errors.', async () => {
+	it( 'handles failed docker commands with errors.', async () => {
 		/* eslint-disable no-console */
-		env.start.mockRejectedValueOnce( { err: 'failure error' } );
+		env.start.mockRejectedValueOnce( {
+			err: 'failure error',
+			out: 'message',
+			exitCode: 1,
+		} );
 		const consoleError = console.error;
 		console.error = jest.fn();
 		const processExit = process.exit;
 		process.exit = jest.fn();
+		const stderr = process.stderr.write;
+		process.stderr.write = jest.fn();
 
 		cli().parse( [ 'start' ] );
 		const { spinner } = env.start.mock.calls[ 0 ][ 0 ];
 		await env.start.mock.results[ 0 ].value.catch( () => {} );
 
-		expect( spinner.fail ).toHaveBeenCalledWith( 'failure error' );
-		expect( console.error ).toHaveBeenCalled();
+		expect( spinner.fail ).toHaveBeenCalledWith(
+			'Error while running docker-compose command.'
+		);
+		expect( process.stderr.write ).toHaveBeenCalledWith( 'failure error' );
 		expect( process.exit ).toHaveBeenCalledWith( 1 );
 		console.error = consoleError;
 		process.exit = processExit;
+		process.stderr.write = stderr;
 		/* eslint-enable no-console */
 	} );
 } );


### PR DESCRIPTION
I noticed during some testing today that wp-env would show error messages twice. This PR attempts to only display the error message once. @noisysocks / @epiqueras I may be missing the context for why we needed to check for `error instanceof env.ValidationError` and then display the error twice, so if you have thoughts I'm all ears. :) Perhaps there are some cases where multiline error output wouldn't be shown by `spinner.fail`?

## Screenshots <!-- if applicable -->
<img width="998" alt="Screen Shot 2020-02-10 at 2 21 57 PM" src="https://user-images.githubusercontent.com/6265975/74196439-1560a900-4c12-11ea-9cbe-2d22f20def46.png">

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
