### PR TITLE
wp-env: Add custom port numbers to .wp-env.json

### DIFF
--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Master
 
+### New Feature
+
+- The `.wp-env.json` coniguration file now accepts `port` and `testsPort` options which can be used to set the ports on which the docker instance is mounted.
+
 ## 1.0.0 (2020-02-10)
 
 ### Breaking Changes

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -259,7 +259,7 @@ This is useful for integration testing: that is, testing how old versions of Wor
 
 #### Custom Port Numbers
 
-A custom port number so that your installation ports do not conflict with other wp-env instances.
+You can tell `wp-env` to use a custom port number so that your instance does not conflict with other `wp-env` instances.
 
 ```json
 {

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -79,6 +79,8 @@ $ WP_ENV_PORT=3333 wp-env start
 
 Running `docker ps` and inspecting the `PORTS` column allows you to determine which port `wp-env` is currently using.
 
+You may also specify the port numbers in your `.wp-env.json` file.
+
 ### 3. Restart `wp-env`
 
 Restarting `wp-env` will restart the underlying Docker containers which can fix many issues.
@@ -175,15 +177,17 @@ Positionals:
 
 You can customize the WordPress installation, plugins and themes that the development environment will use by specifying a `.wp-env.json` file in the directory that you run `wp-env` from.
 
-`.wp-env.json` supports three fields:
+`.wp-env.json` supports five fields:
 
 | Field | Type | Default | Description |
 | -- | -- | -- | -- |
 | `"core"` | `string|null` | `null` | The WordPress installation to use. If `null` is specified, `wp-env` will use the latest production release of WordPress. |
 | `"plugins"` | `string[]` | `[]` | A list of plugins to install and activate in the environment. |
 | `"themes"` | `string[]` | `[]` | A list of themes to install in the environment. The first theme in the list will be activated. |
+| `"portNumber"` | `string` | `"8888"` | The primary port number to use for the insallation. You'll access the instance through the port: 'http://localhost:8888'. |
+| `"testsPortNumber"` | `string` | `"8889"` | The port number to use for the tests instance. |
 
-Several types of strings can be passed into these fields:
+Several types of strings can be passed into the `core`, `plugins`, and `themes` fields:
 
 | Type | Format | Example(s) |
 | -- | -- | -- |
@@ -248,6 +252,20 @@ This is useful for integration testing: that is, testing how old versions of Wor
   "themes": [
     "WordPress/theme-experiments"
   ]
+}
+```
+
+#### Custom Port Numbers
+
+A custom port number so that your installation ports do not conflict with other wp-env instances.
+
+```json
+{
+  "plugins": [
+    ".",
+  ],
+  "portNumber": 4013,
+  "testsPortNumber": 4012
 }
 ```
 

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -79,7 +79,7 @@ $ WP_ENV_PORT=3333 wp-env start
 
 Running `docker ps` and inspecting the `PORTS` column allows you to determine which port `wp-env` is currently using.
 
-You may also specify the port numbers in your `.wp-env.json` file.
+You may also specify the port numbers in your `.wp-env.json` file, but the environment variables take precedent.
 
 ### 3. Restart `wp-env`
 
@@ -186,6 +186,8 @@ You can customize the WordPress installation, plugins and themes that the develo
 | `"themes"` | `string[]` | `[]` | A list of themes to install in the environment. The first theme in the list will be activated. |
 | `"portNumber"` | `string` | `"8888"` | The primary port number to use for the insallation. You'll access the instance through the port: 'http://localhost:8888'. |
 | `"testsPortNumber"` | `string` | `"8889"` | The port number to use for the tests instance. |
+
+_Note: the port number environment variables (`WP_ENV_PORT` and `WP_ENV_TESTS_PORT`) take precedent over the .wp-env.json values._
 
 Several types of strings can be passed into the `core`, `plugins`, and `themes` fields:
 

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -184,8 +184,8 @@ You can customize the WordPress installation, plugins and themes that the develo
 | `"core"` | `string|null` | `null` | The WordPress installation to use. If `null` is specified, `wp-env` will use the latest production release of WordPress. |
 | `"plugins"` | `string[]` | `[]` | A list of plugins to install and activate in the environment. |
 | `"themes"` | `string[]` | `[]` | A list of themes to install in the environment. The first theme in the list will be activated. |
-| `"portNumber"` | `string` | `"8888"` | The primary port number to use for the insallation. You'll access the instance through the port: 'http://localhost:8888'. |
-| `"testsPortNumber"` | `string` | `"8889"` | The port number to use for the tests instance. |
+| `"port"` | `string` | `"8888"` | The primary port number to use for the insallation. You'll access the instance through the port: 'http://localhost:8888'. |
+| `"testsPort"` | `string` | `"8889"` | The port number to use for the tests instance. |
 
 _Note: the port number environment variables (`WP_ENV_PORT` and `WP_ENV_TESTS_PORT`) take precedent over the .wp-env.json values._
 
@@ -266,8 +266,8 @@ A custom port number so that your installation ports do not conflict with other 
   "plugins": [
     ".",
   ],
-  "portNumber": 4013,
-  "testsPortNumber": 4012
+  "port": 4013,
+  "testsPort": 4012
 }
 ```
 

--- a/packages/env/lib/build-docker-compose-config.js
+++ b/packages/env/lib/build-docker-compose-config.js
@@ -52,8 +52,8 @@ module.exports = function buildDockerComposeConfig( config ) {
 	];
 
 	// Set the default ports based on the config values.
-	const mainPort = `\${WP_ENV_PORT:-${ config.portNumber }}:80`;
-	const testsPort = `\${WP_ENV_TESTS_PORT:-${ config.testsPortNumber }}:80`;
+	const mainPort = `\${WP_ENV_PORT:-${ config.port }}:80`;
+	const testsPort = `\${WP_ENV_TESTS_PORT:-${ config.testsPort }}:80`;
 
 	return {
 		version: '3.7',

--- a/packages/env/lib/build-docker-compose-config.js
+++ b/packages/env/lib/build-docker-compose-config.js
@@ -53,7 +53,7 @@ module.exports = function buildDockerComposeConfig( config ) {
 
 	// Set the default ports based on the config values.
 	const mainPort = `\${WP_ENV_PORT:-${ config.portNumber }}:80`;
-	const testsPort = `\${WP_ENV_PORT:-${ config.testsPortNumber }}:80`;
+	const testsPort = `\${WP_ENV_TESTS_PORT:-${ config.testsPortNumber }}:80`;
 
 	return {
 		version: '3.7',

--- a/packages/env/lib/build-docker-compose-config.js
+++ b/packages/env/lib/build-docker-compose-config.js
@@ -52,8 +52,8 @@ module.exports = function buildDockerComposeConfig( config ) {
 	];
 
 	// Set the default ports based on the config values.
-	const mainPort = `\${WP_ENV_PORT:-${ config.port }}:80`;
-	const testsPort = `\${WP_ENV_TESTS_PORT:-${ config.testsPort }}:80`;
+	const developmentPorts = `\${WP_ENV_PORT:-${ config.port }}:80`;
+	const testsPorts = `\${WP_ENV_TESTS_PORT:-${ config.testsPort }}:80`;
 
 	return {
 		version: '3.7',
@@ -67,7 +67,7 @@ module.exports = function buildDockerComposeConfig( config ) {
 			wordpress: {
 				depends_on: [ 'mysql' ],
 				image: 'wordpress',
-				ports: [ mainPort ],
+				ports: [ developmentPorts ],
 				environment: {
 					WORDPRESS_DEBUG: '1',
 					WORDPRESS_DB_NAME: 'wordpress',
@@ -77,7 +77,7 @@ module.exports = function buildDockerComposeConfig( config ) {
 			'tests-wordpress': {
 				depends_on: [ 'mysql' ],
 				image: 'wordpress',
-				ports: [ testsPort ],
+				ports: [ testsPorts ],
 				environment: {
 					WORDPRESS_DEBUG: '1',
 					WORDPRESS_DB_NAME: 'tests-wordpress',

--- a/packages/env/lib/build-docker-compose-config.js
+++ b/packages/env/lib/build-docker-compose-config.js
@@ -51,6 +51,10 @@ module.exports = function buildDockerComposeConfig( config ) {
 		...themeMounts,
 	];
 
+	// Set the default ports based on the config values.
+	const mainPort = `\${WP_ENV_PORT:-${ config.portNumber }}:80`;
+	const testsPort = `\${WP_ENV_PORT:-${ config.testsPortNumber }}:80`;
+
 	return {
 		version: '3.7',
 		services: {
@@ -63,7 +67,7 @@ module.exports = function buildDockerComposeConfig( config ) {
 			wordpress: {
 				depends_on: [ 'mysql' ],
 				image: 'wordpress',
-				ports: [ '${WP_ENV_PORT:-8888}:80' ],
+				ports: [ mainPort ],
 				environment: {
 					WORDPRESS_DEBUG: '1',
 					WORDPRESS_DB_NAME: 'wordpress',
@@ -73,7 +77,7 @@ module.exports = function buildDockerComposeConfig( config ) {
 			'tests-wordpress': {
 				depends_on: [ 'mysql' ],
 				image: 'wordpress',
-				ports: [ '${WP_ENV_TESTS_PORT:-8889}:80' ],
+				ports: [ testsPort ],
 				environment: {
 					WORDPRESS_DEBUG: '1',
 					WORDPRESS_DB_NAME: 'tests-wordpress',

--- a/packages/env/lib/config.js
+++ b/packages/env/lib/config.js
@@ -35,8 +35,8 @@ const HOME_PATH_PREFIX = `~${ path.sep }`;
  * @property {Source|null} coreSource The WordPress installation to load in the environment.
  * @property {Source[]} pluginSources Plugins to load in the environment.
  * @property {Source[]} themeSources Themes to load in the environment.
- * @property {number} portNumber The port on which to start the main WordPress environment.
- * @property {number} testsPortNumber The port on which to start the tests WordPress environment.
+ * @property {number} port The port on which to start the main WordPress environment.
+ * @property {number} testsPort The port on which to start the tests WordPress environment.
  */
 
 /**
@@ -98,8 +98,8 @@ module.exports = {
 				core: null,
 				plugins: [],
 				themes: [],
-				portNumber: 8888,
-				testsPortNumber: 8889,
+				port: 8888,
+				testsPort: 8889,
 			},
 			config
 		);
@@ -128,21 +128,21 @@ module.exports = {
 			);
 		}
 
-		if ( ! Number.isInteger( config.portNumber ) ) {
+		if ( ! Number.isInteger( config.port ) ) {
 			throw new ValidationError(
-				'Invalid .wp-env.json: "portNumber" must be an integer.'
+				'Invalid .wp-env.json: "port" must be an integer.'
 			);
 		}
 
-		if ( ! Number.isInteger( config.testsPortNumber ) ) {
+		if ( ! Number.isInteger( config.testsPort ) ) {
 			throw new ValidationError(
-				'Invalid .wp-env.json: "testsPortNumber" must be an integer.'
+				'Invalid .wp-env.json: "testsPort" must be an integer.'
 			);
 		}
 
-		if ( config.testsPortNumber === config.portNumber ) {
+		if ( config.port === config.testsPort ) {
 			throw new ValidationError(
-				'Invalid .wp-env.json: "testsPortNumber" and "portNumber" must be different.'
+				'Invalid .wp-env.json: "testsPort" and "port" must be different.'
 			);
 		}
 
@@ -156,8 +156,8 @@ module.exports = {
 			name: path.basename( configDirectoryPath ),
 			configDirectoryPath,
 			workDirectoryPath,
-			portNumber: config.portNumber,
-			testsPortNumber: config.testsPortNumber,
+			port: config.port,
+			testsPort: config.testsPort,
 			dockerComposeConfigPath: path.resolve(
 				workDirectoryPath,
 				'docker-compose.yml'

--- a/packages/env/lib/config.js
+++ b/packages/env/lib/config.js
@@ -35,8 +35,8 @@ const HOME_PATH_PREFIX = `~${ path.sep }`;
  * @property {Source|null} coreSource The WordPress installation to load in the environment.
  * @property {Source[]} pluginSources Plugins to load in the environment.
  * @property {Source[]} themeSources Themes to load in the environment.
- * @property {number} port The port on which to start the main WordPress environment.
- * @property {number} testsPort The port on which to start the tests WordPress environment.
+ * @property {number} port The port on which to start the development WordPress environment.
+ * @property {number} testsPort The port on which to start the testing WordPress environment.
  */
 
 /**

--- a/packages/env/lib/config.js
+++ b/packages/env/lib/config.js
@@ -35,6 +35,8 @@ const HOME_PATH_PREFIX = `~${ path.sep }`;
  * @property {Source|null} coreSource The WordPress installation to load in the environment.
  * @property {Source[]} pluginSources Plugins to load in the environment.
  * @property {Source[]} themeSources Themes to load in the environment.
+ * @property {number} portNumber The port on which to start the main WordPress environment.
+ * @property {number} testsPortNumber The port on which to start the tests WordPress environment.
  */
 
 /**
@@ -96,6 +98,8 @@ module.exports = {
 				core: null,
 				plugins: [],
 				themes: [],
+				portNumber: 8888,
+				testsPortNumber: 8889,
 			},
 			config
 		);
@@ -124,6 +128,24 @@ module.exports = {
 			);
 		}
 
+		if ( ! Number.isInteger( config.portNumber ) ) {
+			throw new ValidationError(
+				'Invalid .wp-env.json: "portNumber" must be an integer.'
+			);
+		}
+
+		if ( ! Number.isInteger( config.testsPortNumber ) ) {
+			throw new ValidationError(
+				'Invalid .wp-env.json: "testsPortNumber" must be an integer.'
+			);
+		}
+
+		if ( config.testsPortNumber === config.portNumber ) {
+			throw new ValidationError(
+				'Invalid .wp-env.json: "testsPortNumber" and "portNumber" must be different.'
+			);
+		}
+
 		const workDirectoryPath = path.resolve(
 			os.homedir(),
 			'.wp-env',
@@ -134,6 +156,8 @@ module.exports = {
 			name: path.basename( configDirectoryPath ),
 			configDirectoryPath,
 			workDirectoryPath,
+			portNumber: config.portNumber,
+			testsPortNumber: config.testsPortNumber,
 			dockerComposeConfigPath: path.resolve(
 				workDirectoryPath,
 				'docker-compose.yml'

--- a/packages/env/test/config.js
+++ b/packages/env/test/config.js
@@ -217,4 +217,49 @@ describe( 'readConfig', () => {
 			);
 		}
 	} );
+
+	it( 'should throw a validaton error if the ports are not numbers', async () => {
+		expect.assertions( 10 );
+		testPortNumberValidation( 'port', 'string' );
+		testPortNumberValidation( 'testsPort', [] );
+		testPortNumberValidation( 'port', {} );
+		testPortNumberValidation( 'testsPort', false );
+		testPortNumberValidation( 'port', null );
+	} );
+
+	it( 'should throw a validaton error if the ports are the same', async () => {
+		expect.assertions( 2 );
+		readFile.mockImplementation( () =>
+			Promise.resolve( JSON.stringify( { port: 8888, testsPort: 8888 } ) )
+		);
+		try {
+			await readConfig( '.wp-env.json' );
+		} catch ( error ) {
+			expect( error ).toBeInstanceOf( ValidationError );
+			expect( error.message ).toContain(
+				'Invalid .wp-env.json: "testsPort" and "port" must be different.'
+			);
+		}
+	} );
 } );
+
+/**
+ * Tests that readConfig will throw errors when invalid port numbers are passed.
+ *
+ * @param {string} portName The name of the port to test ('port' or 'testsPort')
+ * @param {any} value A value which should throw an error.
+ */
+async function testPortNumberValidation( portName, value ) {
+	readFile.mockImplementation( () =>
+		Promise.resolve( JSON.stringify( { [ portName ]: value } ) )
+	);
+	try {
+		await readConfig( '.wp-env.json' );
+	} catch ( error ) {
+		expect( error ).toBeInstanceOf( ValidationError );
+		expect( error.message ).toContain(
+			`Invalid .wp-env.json: "${ portName }" must be an integer.`
+		);
+	}
+	jest.clearAllMocks();
+}

--- a/packages/env/test/config.js
+++ b/packages/env/test/config.js
@@ -241,6 +241,22 @@ describe( 'readConfig', () => {
 			);
 		}
 	} );
+
+	it( 'should parse custom ports', async () => {
+		readFile.mockImplementation( () =>
+			Promise.resolve(
+				JSON.stringify( {
+					port: 1000,
+				} )
+			)
+		);
+		const config = await readConfig( '.wp-env.json' );
+		// Custom port is overriden while testsPort gets the deault value.
+		expect( config ).toMatchObject( {
+			port: 1000,
+			testsPort: 8889,
+		} );
+	} );
 } );
 
 /**


### PR DESCRIPTION
## Description
This PR adds support for custom port numbers in the .wp-env.json file.

Here's why I like having this option:
- It can make sense for a team to use the same base URL for development
- In the case of e2e tests, when you specify the URL, the port numbers would always be consistent
- It's sort of clunky to start every call to `wp-env start` with the port numbers if you need them to be different every time
- There are some oddities in browsers/docker when you change the port number all the time. If you forget to include the different port number, the browser can start redirecting you to the default port number.

This does not change the behavior of the environment variables; they still take precedent over values in .wp-env.json. The default port numbers also stay the same.

## How has this been tested?
I ran this code on my local plugin and verified that:
- Invalid port numbers were not accepted
- Having the same port number was discarded
- The default values are the same as before if not specified
- Custom values are added to the docker-compose file

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
