### PR TITLE
Fix group block editor block class name

### DIFF
--- a/packages/block-library/src/group/edit.js
+++ b/packages/block-library/src/group/edit.js
@@ -6,7 +6,7 @@ import { compose } from '@wordpress/compose';
 import { InnerBlocks, __experimentalUseColors } from '@wordpress/block-editor';
 import { useRef } from '@wordpress/element';
 
-function GroupEdit( { hasInnerBlocks } ) {
+function GroupEdit( { hasInnerBlocks, className } ) {
 	const ref = useRef();
 	const {
 		TextColor,
@@ -28,7 +28,7 @@ function GroupEdit( { hasInnerBlocks } ) {
 			{ InspectorControlsColorPanel }
 			<BackgroundColor>
 				<TextColor>
-					<div className="wp-block-group" ref={ ref }>
+					<div className={ className } ref={ ref }>
 						<div className="wp-block-group__inner-container">
 							<InnerBlocks
 								renderAppender={


### PR DESCRIPTION
## Description
Fixes #20140.

#19181 seems to have accidentally removed the use of the className prop in the group block's edit function. This was causing custom block styles and the Additional CSS Classes option not to function in the editor. This PR restores use of the `className` prop.

## How has this been tested?
1. Add a class name (e.g. 'my-class') to a group block using the Advanced > Additional CSS Class(es) option
2. Inspect the group block using dev tools. The block should have the classname matching the one added above (e.g. 'wp-block-group my-class')

----
1. Register a block style by adding something like the following 
```php
register_block_style( 'core/group', [ 'name' => 'golden-border', 'label' => 'Golden Border', 'style_handle' => 'block-styles-stylesheet', ] );
```
2. Reload the editor and toggle the style on a group block
3. Inspect the group block using the dev tools. The block should have the class name 'wp-block-group is-style-golden-border'.
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
