### PR TITLE
Remove !important from social links preview.

### DIFF
--- a/packages/block-library/src/social-links/editor.scss
+++ b/packages/block-library/src/social-links/editor.scss
@@ -68,19 +68,10 @@
 	justify-content: center;
 }
 
-// Improve the preview.
+// Improve the preview, ensure buttons are fully opaque despite being disabled.
 // @todo: Look at improving the preview component to make this unnecessary.
-.block-editor-block-preview__content {
-
-	// This ensures buttons in preview are fully opaque despite being disabled.
-	.wp-social-link:disabled {
-		opacity: 1;
-	}
-
-	// This ensures the preview is of a good size.
-	[data-type="core/social-links"] {
-		display: inline-block;
-	}
+.block-editor-block-preview__content .wp-social-link:disabled {
+	opacity: 1;
 }
 
 // Selected/unselected states.

--- a/packages/block-library/src/social-links/editor.scss
+++ b/packages/block-library/src/social-links/editor.scss
@@ -79,7 +79,6 @@
 
 	// This ensures the preview is of a good size.
 	[data-type="core/social-links"] {
-		width: auto;
 		display: inline-block;
 	}
 }

--- a/packages/block-library/src/social-links/editor.scss
+++ b/packages/block-library/src/social-links/editor.scss
@@ -79,7 +79,7 @@
 
 	// This ensures the preview is of a good size.
 	[data-type="core/social-links"] {
-		width: auto !important;
+		width: auto;
 		display: inline-block;
 	}
 }


### PR DESCRIPTION
This removes an !important width rule, which does not appear to be necessary.

This screenshot shows both the before and after, indicating the !important wasn't necessary:

![Screenshot 2020-02-11 at 13 34 18](https://user-images.githubusercontent.com/1204802/74237276-73a19080-4cd3-11ea-82b9-144873b90b08.png)

What happens if the inline block property is removed too? Well, you get this:

![Screenshot 2020-02-11 at 13 37 00](https://user-images.githubusercontent.com/1204802/74237394-c2e7c100-4cd3-11ea-9874-f65c46a60153.png)

That's technically more accurate, since it is block level block with three social icons filled out, and a lot of empty space to fill up the rest. I can do that too, if that's preferred?