### PR TITLE
Block Library: Columns: Fix equal column growth for unassigned-width columns

### DIFF
--- a/packages/block-library/src/columns/editor.scss
+++ b/packages/block-library/src/columns/editor.scss
@@ -66,14 +66,21 @@
 			// Responsiveness: Show at most one columns on mobile.
 			flex-basis: 100%;
 
+			// Beyond mobile, allow columns.
 			@include break-small() {
+				// Available space should be divided equally amongst columns
+				// without an assigned width. This is achieved by assigning a
+				// flex basis that is consistent (equal), would not cause the
+				// sum total of column widths to exceed 100%, and which would
+				// cede to a column with an assigned width. The `flex-grow`
+				// allows columns to maximally and equally occupy space
+				// remaining after subtracting the space occupied by columns
+				// with explicit widths (if any exist).
 				flex-grow: 1;
-				flex-basis: auto;
+				flex-basis: 0;
 
-				// Beyond mobile, allow columns. Columns with an explicitly-
-				// assigned width should maintain their `flex-basis` width and
-				// not grow. All other blocks should automatically inherit the
-				// `flex-grow` to occupy the available space.
+				// Columns with an explicitly-assigned width should maintain
+				// their `flex-basis` width and not grow.
 				&[data-has-explicit-width] {
 					flex-grow: 0;
 				}

--- a/packages/block-library/src/columns/editor.scss
+++ b/packages/block-library/src/columns/editor.scss
@@ -70,6 +70,8 @@
 			@include break-small() {
 				flex-basis: calc(50% - (#{$grid-size-large}));
 				flex-grow: 0;
+				margin-left: 0;
+				margin-right: 0;
 			}
 
 			// At large viewports, show all columns horizontally.
@@ -90,9 +92,6 @@
 				&[data-has-explicit-width] {
 					flex-grow: 0;
 				}
-
-				margin-left: 0;
-				margin-right: 0;
 			}
 
 			// Add space between columns. Themes can customize this if they wish to work differently.

--- a/packages/block-library/src/columns/editor.scss
+++ b/packages/block-library/src/columns/editor.scss
@@ -66,8 +66,14 @@
 			// Responsiveness: Show at most one columns on mobile.
 			flex-basis: 100%;
 
-			// Beyond mobile, allow columns.
+			// Between mobile and large viewports, allow 2 columns.
 			@include break-small() {
+				flex-basis: calc(50% - (#{$grid-size-large}));
+				flex-grow: 0;
+			}
+
+			// At large viewports, show all columns horizontally.
+			@include break-medium() {
 				// Available space should be divided equally amongst columns
 				// without an assigned width. This is achieved by assigning a
 				// flex basis that is consistent (equal), would not cause the
@@ -76,8 +82,8 @@
 				// allows columns to maximally and equally occupy space
 				// remaining after subtracting the space occupied by columns
 				// with explicit widths (if any exist).
-				flex-grow: 1;
 				flex-basis: 0;
+				flex-grow: 1;
 
 				// Columns with an explicitly-assigned width should maintain
 				// their `flex-basis` width and not grow.

--- a/packages/block-library/src/columns/style.scss
+++ b/packages/block-library/src/columns/style.scss
@@ -30,7 +30,7 @@
 	word-break: break-word; // For back-compat.
 	overflow-wrap: break-word; // New standard.
 
-	// Beyond mobile, allow columns.
+	// Between mobile and large viewports, allow 2 columns.
 	@include break-small() {
 		flex-basis: calc(50% - #{$grid-size-large});
 		flex-grow: 0;

--- a/packages/block-library/src/columns/style.scss
+++ b/packages/block-library/src/columns/style.scss
@@ -30,12 +30,19 @@
 	word-break: break-word; // For back-compat.
 	overflow-wrap: break-word; // New standard.
 
+	// Beyond mobile, allow columns.
 	@include break-small() {
+		// Available space should be divided equally amongst columns without an
+		// assigned width. This is achieved by assigning a flex basis that is
+		// consistent (equal), would not cause the sum total of column widths to
+		// exceed 100%, and which would cede to a column with an assigned width.
+		// The inherited `flex-grow` allows columns to maximally and equally
+		// occupy space remaining after subtracting the space occupied by
+		// columns with explicit widths (if any exist).
+		flex-basis: 0;
 
-		// Beyond mobile, allow columns. Columns with an explicitly-assigned
-		// width should maintain their `flex-basis` width and not grow. All
-		// other blocks should automatically inherit the `flex-grow` to occupy
-		// the available space.
+		// Columns with an explicitly-assigned width should maintain their
+		// `flex-basis` width and not grow.
 		&[style] {
 			flex-grow: 0;
 		}

--- a/packages/block-library/src/columns/style.scss
+++ b/packages/block-library/src/columns/style.scss
@@ -32,20 +32,8 @@
 
 	// Beyond mobile, allow columns.
 	@include break-small() {
-		// Available space should be divided equally amongst columns without an
-		// assigned width. This is achieved by assigning a flex basis that is
-		// consistent (equal), would not cause the sum total of column widths to
-		// exceed 100%, and which would cede to a column with an assigned width.
-		// The inherited `flex-grow` allows columns to maximally and equally
-		// occupy space remaining after subtracting the space occupied by
-		// columns with explicit widths (if any exist).
-		flex-basis: 0;
-
-		// Columns with an explicitly-assigned width should maintain their
-		// `flex-basis` width and not grow.
-		&[style] {
-			flex-grow: 0;
-		}
+		flex-basis: calc(50% - #{$grid-size-large});
+		flex-grow: 0;
 
 		// Add space between the multiple columns. Themes can customize this if they wish to work differently.
 		// Only apply this beyond the mobile breakpoint, as there's only a single column on mobile.
@@ -54,7 +42,23 @@
 		}
 	}
 
+	// At large viewports, show all columns horizontally.
 	@include break-medium() {
+		// Available space should be divided equally amongst columns without an
+		// assigned width. This is achieved by assigning a flex basis that is
+		// consistent (equal), would not cause the sum total of column widths to
+		// exceed 100%, and which would cede to a column with an assigned width.
+		// The `flex-grow` allows columns to maximally and equally occupy space
+		// remaining after subtracting the space occupied by columns with
+		// explicit widths (if any exist).
+		flex-basis: 0;
+		flex-grow: 1;
+
+		// Columns with an explicitly-assigned width should maintain their
+		// `flex-basis` width and not grow.
+		&[style] {
+			flex-grow: 0;
+		}
 
 		// When columns are in a single row, add space before all except the first.
 		&:not(:first-child) {


### PR DESCRIPTION
Introduced in: #19515

This pull request seeks to resolve a styling issue introduced in the changes of #19515 (5d9dff2) where columns which do not have an explicitly-assigned width will be allowed unrestrained growth disproportionately to other columns in the set.

Before|After
---|---
![Before](https://user-images.githubusercontent.com/1779930/74247175-ac317200-4cb3-11ea-81c6-1e0f328bcb0f.png)|![After](https://user-images.githubusercontent.com/1779930/74247179-ad629f00-4cb3-11ea-86fd-74e3392f0302.png)


The intended behavior of columns without assigned width is that they should occupy the available space equally with other columns without assigned width. For example, a newly inserted three-column block should behave such that each of the three columns occupy a third of the available space. The changes in 5d9dff2ef9bfcd903925627f35d9108200809fd6 allowed for growth, but also allowed for one column to grow more than the others.

The changes here seek to address this by reintroducing a `flex-basis` as a default style for columns without one of its own. In order for available space to be divided equally amongst columns without an assigned width, this value must be consistent (equal), not cause the sum total of column widths to exceed 100%, and cede to a column with an assigned width. Thus, a `flex-basis: 0` is chosen which, in combination with the existing `flex-grow: 1`, should allow columns to maximally and equally occupy space remaining after subtracting the space occupied by columns with explicit widths (if any exist).

**Testing Instructions:**

Verify that a default columns block of three equal columns should result in columns which each occupy a third of the available space.

1. Navigate to Posts > Add New
2. Insert a Columns block
3. Choose the "Three columns; equal split" variation when prompted
4. Insert a paragraph block in one of the columns
5. Add enough text that wrapping occurs.
6. Note (both in the editor and in the preview) that each column occupies a third of the available space.

Try with different variations of unassigned and assigned width columns:

- `25% | auto | 25%`
- `20% | auto | 20% | auto`
- `auto | auto | 33%`
- etc.

Note that the widths between two columns arrangements `25% | 50% | 25%` and `25% | auto | 25%` are similar but not identical. This is impacted by the "gutter" margins between each column. My understanding is that the behavior is correct, where the implication of "auto" to "occupy available space" is affected by the fact that "available space" will be _after margins are deducted_, whereas with each of the fixed-value widths (`25% | 50% | 25%`), the widths are calculated _before margins are considered_, and thus each of the three must be adjusted to offset the margins. You can see that by eliminating margin styles (either in code or by [element inspector](https://developers.google.com/web/tools/chrome-devtools/dom/)), the widths of columns in these two arrangements are the same. Note that I don't expect this to be a common consideration for end-users, but including for exhaustiveness' sake in case the disparity is noticed.