### PR TITLE
[RNMobile] Fix isURL 

### DIFF
--- a/packages/url/src/is-url.native.js
+++ b/packages/url/src/is-url.native.js
@@ -1,4 +1,4 @@
-const URL_REGEXP = /((([A-Za-z]{3,9}:(?:\/\/)?)(?:[\-;:&=\+\$,\w]+@)?[A-Za-z0-9\.\-]+|(?:www\.|[\-;:&=\+\$,\w]+@)[A-Za-z0-9\.\-]+)(?::\d{2,5})?((?:\/[\+~%\/\.\w\-_]*)?\??(?:[\-\+=&;%@\.\w_]*)#?(?:[\.\!\/\\\w]*))?)/i
+const URL_REGEXP = /((([A-Za-z]{3,9}:(?:\/\/)?)(?:[\-;:&=\+\$,\w]+@)?[A-Za-z0-9\.\-]+|(?:www\.|[\-;:&=\+\$,\w]+@)[A-Za-z0-9\.\-]+)(?::\d{2,5})?((?:\/[\+~%\/\.\w\-_]*)?\??(?:[\-\+=&;%@\.\w_]*)#?(?:[\.\!\/\\\w]*))?)/i;
 
 /**
  * Determines whether the given string looks like a URL.
@@ -13,6 +13,6 @@ const URL_REGEXP = /((([A-Za-z]{3,9}:(?:\/\/)?)(?:[\-;:&=\+\$,\w]+@)?[A-Za-z0-9\
  * @return {boolean} Whether or not it looks like a URL.
  */
 export function isURL( url ) {
-		const match = url.match(URL_REGEXP);// URL_REGEXP.match
-		return match !== null && match.length >= 1 && match[0] === url;
+	const match = url.match( URL_REGEXP ); // URL_REGEXP.match
+	return match !== null && match.length >= 1 && match[ 0 ] === url;
 }

--- a/packages/url/src/is-url.native.js
+++ b/packages/url/src/is-url.native.js
@@ -1,0 +1,17 @@
+const URL_REGEXP = /^(?:(?:(?:https?|ftp):)?\/\/)(?:(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)(?:\.(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)*(?:\.(?:[a-z\u00a1-\uffff]{2,})))(?::\d{2,5})?(?:[/?#]\S*)?$/i;
+
+/**
+ * Determines whether the given string looks like a URL.
+ *
+ * @param {string} url The string to scrutinise.
+ *
+ * @example
+ * ```js
+ * const isURL = isURL( 'https://wordpress.org' ); // true
+ * ```
+ *
+ * @return {boolean} Whether or not it looks like a URL.
+ */
+export function isURL( url ) {
+	return URL_REGEXP.test( url );
+}

--- a/packages/url/src/is-url.native.js
+++ b/packages/url/src/is-url.native.js
@@ -1,4 +1,4 @@
-const URL_REGEXP = /^(?:(?:(?:https?|ftp):)?\/\/)(?:(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)(?:\.(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)*(?:\.(?:[a-z\u00a1-\uffff]{2,})))(?::\d{2,5})?(?:[/?#]\S*)?$/i;
+const URL_REGEXP = /((([A-Za-z]{3,9}:(?:\/\/)?)(?:[\-;:&=\+\$,\w]+@)?[A-Za-z0-9\.\-]+|(?:www\.|[\-;:&=\+\$,\w]+@)[A-Za-z0-9\.\-]+)(?::\d{2,5})?((?:\/[\+~%\/\.\w\-_]*)?\??(?:[\-\+=&;%@\.\w_]*)#?(?:[\.\!\/\\\w]*))?)/i
 
 /**
  * Determines whether the given string looks like a URL.
@@ -13,5 +13,6 @@ const URL_REGEXP = /^(?:(?:(?:https?|ftp):)?\/\/)(?:(?:[1-9]\d?|1\d\d|2[01]\d|22
  * @return {boolean} Whether or not it looks like a URL.
  */
 export function isURL( url ) {
-	return URL_REGEXP.test( url );
+		const match = url.match(URL_REGEXP);// URL_REGEXP.match
+		return match !== null && match.length >= 1 && match[0] === url;
 }

--- a/packages/url/src/is-url.native.js
+++ b/packages/url/src/is-url.native.js
@@ -14,5 +14,9 @@ const URL_REGEXP = /((([A-Za-z]{3,9}:(?:\/\/)?)(?:[\-;:&=\+\$,\w]+@)?[A-Za-z0-9\
  */
 export function isURL( url ) {
 	const match = url.match( URL_REGEXP );
+	// The current REGEX pattern will match strings where a valid url is part of it,
+	// so things like 'this is https://wordpress.com' will return true using `URL_REGEXP.test( url );`.
+	// This check will ensure that the matched url (the url found) is the same as the original string,
+	// so the given example will return false.
 	return match !== null && match.length >= 1 && match[ 0 ] === url;
 }

--- a/packages/url/src/is-url.native.js
+++ b/packages/url/src/is-url.native.js
@@ -13,6 +13,6 @@ const URL_REGEXP = /((([A-Za-z]{3,9}:(?:\/\/)?)(?:[\-;:&=\+\$,\w]+@)?[A-Za-z0-9\
  * @return {boolean} Whether or not it looks like a URL.
  */
 export function isURL( url ) {
-	const match = url.match( URL_REGEXP ); // URL_REGEXP.match
+	const match = url.match( URL_REGEXP );
 	return match !== null && match.length >= 1 && match[ 0 ] === url;
 }

--- a/packages/url/src/test/index.native.js
+++ b/packages/url/src/test/index.native.js
@@ -1,14 +1,7 @@
 /**
- * External dependencies
- */
-import { every } from 'lodash';
-
-/**
  * Internal dependencies
  */
-import {
-	isURL,
-} from '../';
+import { isURL } from '../';
 
 describe( 'isURL', () => {
 	it.each( [

--- a/packages/url/src/test/index.native.js
+++ b/packages/url/src/test/index.native.js
@@ -1,0 +1,40 @@
+/**
+ * External dependencies
+ */
+import { every } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import {
+	isURL,
+} from '../';
+
+describe( 'isURL', () => {
+	it.each( [
+		[ 'http://wordpress.org' ],
+		[ 'https://wordpress.org' ],
+		[ 'HTTPS://WORDPRESS.ORG' ],
+		[ 'https://wordpress.org/./foo' ],
+		[ 'https://wordpress.org/path?query#fragment' ],
+		[ 'https://localhost/foo#bar' ],
+		[ 'mailto:example@example.com' ],
+		[ 'ssh://user:password@127.0.0.1:8080' ],
+	] )( 'valid (true): %s', ( url ) => {
+		expect( isURL( url ) ).toBe( true );
+	} );
+
+	it.each( [
+		[ 'http://word press.org' ],
+		[ 'http://wordpress.org:port' ],
+		[ 'http://[wordpress.org]/' ],
+		[ 'HTTP: HyperText Transfer Protocol' ],
+		[ 'URLs begin with a http:// prefix' ],
+		[ 'Go here: http://wordpress.org' ],
+		[ 'http://' ],
+		[ 'hello' ],
+		[ '' ],
+	] )( 'invalid (false): %s', ( url ) => {
+		expect( isURL( url ) ).toBe( false );
+	} );
+} );

--- a/packages/url/src/test/index.native.js
+++ b/packages/url/src/test/index.native.js
@@ -1,33 +1,4 @@
 /**
  * Internal dependencies
  */
-import { isURL } from '../';
-
-describe( 'isURL', () => {
-	it.each( [
-		[ 'http://wordpress.org' ],
-		[ 'https://wordpress.org' ],
-		[ 'HTTPS://WORDPRESS.ORG' ],
-		[ 'https://wordpress.org/./foo' ],
-		[ 'https://wordpress.org/path?query#fragment' ],
-		[ 'https://localhost/foo#bar' ],
-		[ 'mailto:example@example.com' ],
-		[ 'ssh://user:password@127.0.0.1:8080' ],
-	] )( 'valid (true): %s', ( url ) => {
-		expect( isURL( url ) ).toBe( true );
-	} );
-
-	it.each( [
-		[ 'http://word press.org' ],
-		[ 'http://wordpress.org:port' ],
-		[ 'http://[wordpress.org]/' ],
-		[ 'HTTP: HyperText Transfer Protocol' ],
-		[ 'URLs begin with a http:// prefix' ],
-		[ 'Go here: http://wordpress.org' ],
-		[ 'http://' ],
-		[ 'hello' ],
-		[ '' ],
-	] )( 'invalid (false): %s', ( url ) => {
-		expect( isURL( url ) ).toBe( false );
-	} );
-} );
+import './index.test';


### PR DESCRIPTION
`gutenberg-mobile` PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1879

## Description
<!-- Please describe what you have changed or added -->
The changes on the PR #19871 to `isURL` assume that the constructor of `URL` "throws an error for an invalid URL", which is not the case for the [mobile implementation.](https://github.com/facebook/react-native/blob/6ba2aeefa8dfe031bf1dc46dbea29235aec31d61/Libraries/Blob/URL.js#L133-L137)

This PR brings back the previous implementation of `isURL` just for native, with a few improvements to make it behave as the new web version (tested running the same set of tests).

@SergioEstevao - I remember you having some opinions about the `isURL` check, could you please take a look at this?

Also @aduth - since you authored the original PR, it would be great if we could have a shared implementation on this, but from what I see, we can not trust that the URL constructor will throw.

Any improvement to the given solution is welcome!
The implemented Regex was taken from [here](https://urlregex.com), adding a group to match for ports.

## How has this been tested?
- The new native Unit Tests should pass.
- Test on the related [gutenberg-mobile](https://github.com/wordpress-mobile/gutenberg-mobile/pull/1879) PR following the given test steps.
