### PR TITLE
Fix sandbox refresh bug

### DIFF
--- a/packages/components/src/sandbox/index.js
+++ b/packages/components/src/sandbox/index.js
@@ -30,7 +30,10 @@ class Sandbox extends Component {
 
 	componentDidUpdate( prevProps ) {
 		let refreshOnChange = false;
-		if ( prevProps.html !== this.props.html && this.props.refreshOnHtmlChange ) {
+		if (
+			prevProps.html !== this.props.html &&
+			this.props.refreshOnHtmlChange
+		) {
 			refreshOnChange = true;
 		}
 		this.trySandbox( refreshOnChange );
@@ -79,7 +82,10 @@ class Sandbox extends Component {
 		}
 
 		const body = this.iframe.current.contentDocument.body;
-		if ( null !== body.getAttribute( 'data-resizable-iframe-connected' ) && ! refreshOnChange ) {
+		if (
+			null !== body.getAttribute( 'data-resizable-iframe-connected' ) &&
+			! refreshOnChange
+		) {
 			return;
 		}
 

--- a/packages/components/src/sandbox/index.js
+++ b/packages/components/src/sandbox/index.js
@@ -28,8 +28,12 @@ class Sandbox extends Component {
 		this.trySandbox();
 	}
 
-	componentDidUpdate() {
-		this.trySandbox();
+	componentDidUpdate( prevProps ) {
+		let refreshOnChange = false;
+		if ( prevProps.html !== this.props.html && this.props.refreshOnHtmlChange ) {
+			refreshOnChange = true;
+		}
+		this.trySandbox( refreshOnChange );
 	}
 
 	isFrameAccessible() {
@@ -69,13 +73,13 @@ class Sandbox extends Component {
 		}
 	}
 
-	trySandbox() {
+	trySandbox( refreshOnChange ) {
 		if ( ! this.isFrameAccessible() ) {
 			return;
 		}
 
 		const body = this.iframe.current.contentDocument.body;
-		if ( null !== body.getAttribute( 'data-resizable-iframe-connected' ) ) {
+		if ( null !== body.getAttribute( 'data-resizable-iframe-connected' ) && ! refreshOnChange ) {
 			return;
 		}
 

--- a/packages/components/src/sandbox/index.js
+++ b/packages/components/src/sandbox/index.js
@@ -29,14 +29,9 @@ class Sandbox extends Component {
 	}
 
 	componentDidUpdate( prevProps ) {
-		let refreshOnChange = false;
-		if (
-			prevProps.html !== this.props.html &&
-			this.props.refreshOnHtmlChange
-		) {
-			refreshOnChange = true;
-		}
-		this.trySandbox( refreshOnChange );
+		const forceRerender = prevProps.html !== this.props.html;
+
+		this.trySandbox( forceRerender );
 	}
 
 	isFrameAccessible() {
@@ -76,15 +71,15 @@ class Sandbox extends Component {
 		}
 	}
 
-	trySandbox( refreshOnChange ) {
+	trySandbox( forceRerender = false ) {
 		if ( ! this.isFrameAccessible() ) {
 			return;
 		}
 
 		const body = this.iframe.current.contentDocument.body;
 		if (
-			null !== body.getAttribute( 'data-resizable-iframe-connected' ) &&
-			! refreshOnChange
+			! forceRerender &&
+			null !== body.getAttribute( 'data-resizable-iframe-connected' )
 		) {
 			return;
 		}

--- a/packages/components/src/sandbox/test/index.js
+++ b/packages/components/src/sandbox/test/index.js
@@ -1,0 +1,73 @@
+/**
+ * External dependencies
+ */
+import ReactDOM from 'react-dom';
+import { act } from 'react-dom/test-utils';
+
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import Sandbox from '../';
+
+let container;
+
+const TestWrapper = () => {
+	const [ html, setHtml ] = useState(
+		'<iframe class="mock-iframe" src="https://super.embed"></iframe>'
+	);
+
+	const updateHtml = () => {
+		setHtml(
+			'<iframe class="mock-iframe" src="https://another.super.embed"></iframe>'
+		);
+	};
+
+	return (
+		<div>
+			<button onClick={ updateHtml } className="mock-button">
+				Mock Button
+			</button>
+			<Sandbox html={ html } />
+		</div>
+	);
+};
+
+beforeEach( () => {
+	container = document.createElement( 'div' );
+	document.body.appendChild( container );
+} );
+
+afterEach( () => {
+	document.body.removeChild( container );
+	container = null;
+} );
+
+it( 'should rerender with new emdeded content if html prop changes', () => {
+	act( () => {
+		ReactDOM.render( <TestWrapper />, container );
+	} );
+
+	const button = container.querySelector( '.mock-button' );
+	const iframe = container.querySelector( '.components-sandbox' );
+
+	let sandboxedIframe = iframe.contentWindow.document.body.querySelector(
+		'.mock-iframe'
+	);
+
+	expect( sandboxedIframe.src ).toEqual( 'https://super.embed/' );
+
+	act( () => {
+		button.dispatchEvent( new window.MouseEvent( 'click', { bubbles: true } ) );
+	} );
+
+	sandboxedIframe = iframe.contentWindow.document.body.querySelector(
+		'.mock-iframe'
+	);
+
+	expect( sandboxedIframe.src ).toEqual( 'https://another.super.embed/' );
+} );

--- a/packages/components/src/sandbox/test/index.js
+++ b/packages/components/src/sandbox/test/index.js
@@ -62,7 +62,9 @@ it( 'should rerender with new emdeded content if html prop changes', () => {
 	expect( sandboxedIframe.src ).toEqual( 'https://super.embed/' );
 
 	act( () => {
-		button.dispatchEvent( new window.MouseEvent( 'click', { bubbles: true } ) );
+		button.dispatchEvent(
+			new window.MouseEvent( 'click', { bubbles: true } )
+		);
 	} );
 
 	sandboxedIframe = iframe.contentWindow.document.body.querySelector(


### PR DESCRIPTION
## Description
Fixes #16831 - currently passing in new iframe html to the sandbox does not cause the component to rerender. This forces a rerender if the html prop has changed.

## How has this been tested?
Tested manually using new google calendar block at https://github.com/Automattic/jetpack/pull/13999  - without this patch, and with [the temporary key prop to fix this issue removed](https://github.com/Automattic/jetpack/pull/13999/files#diff-79dff83b7f1000a7b0f61a8752aa35cfR181) updating the calendar embed url does not affect the iframe preview, with this patch the iframe preview is reloaded when embed url is changed

## Types of changes
Sets the forceRerender value to false by default and sets to true if component updates and html prop has changed 