### PR TITLE
Dry up `<LinkControl>` "unit" tests

### DIFF
--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -54,6 +54,10 @@ function getURLInput() {
 	return container.querySelector( 'input[aria-label="URL"]' );
 }
 
+function getSearchResults() {
+	return container.querySelectorAll( '[role="listbox"] [role="option"]' );
+}
+
 describe( 'Basic rendering', () => {
 	it( 'should render', () => {
 		act( () => {
@@ -159,9 +163,7 @@ describe( 'Searching for a link', () => {
 		await eventLoopTick();
 
 		// TODO: select these by aria relationship to autocomplete rather than arbitary selector.
-		const searchResultElements = container.querySelectorAll(
-			'[role="menu"] button[role="menuitem"]'
-		);
+		const searchResultElements = getSearchResults();
 
 		let loadingUI = container.querySelector( '.components-spinner' );
 
@@ -200,9 +202,8 @@ describe( 'Searching for a link', () => {
 		await eventLoopTick();
 
 		// TODO: select these by aria relationship to autocomplete rather than arbitary selector.
-		const searchResultElements = container.querySelectorAll(
-			'[role="listbox"] [role="option"]'
-		);
+		const searchResultElements = getSearchResults();
+
 		const firstSearchResultItemHTML = first( searchResultElements )
 			.innerHTML;
 		const lastSearchResultItemHTML = last( searchResultElements ).innerHTML;
@@ -249,9 +250,8 @@ describe( 'Searching for a link', () => {
 			await eventLoopTick();
 
 			// TODO: select these by aria relationship to autocomplete rather than arbitary selector.
-			const searchResultElements = container.querySelectorAll(
-				'[role="listbox"] [role="option"]'
-			);
+			const searchResultElements = getSearchResults();
+
 			const lastSearchResultItemHTML = last( searchResultElements )
 				.innerHTML;
 			const additionalDefaultFallbackURLSuggestionLength = 1;
@@ -303,9 +303,8 @@ describe( 'Manual link entry', () => {
 			await eventLoopTick();
 
 			// TODO: select these by aria relationship to autocomplete rather than arbitary selector.
-			const searchResultElements = container.querySelectorAll(
-				'[role="listbox"] [role="option"]'
-			);
+			const searchResultElements = getSearchResults();
+
 			const firstSearchResultItemHTML =
 				searchResultElements[ 0 ].innerHTML;
 			const expectedResultsLength = 1;
@@ -351,9 +350,8 @@ describe( 'Manual link entry', () => {
 				await eventLoopTick();
 
 				// TODO: select these by aria relationship to autocomplete rather than arbitary selector.
-				const searchResultElements = container.querySelectorAll(
-					'[role="listbox"] [role="option"]'
-				);
+				const searchResultElements = getSearchResults();
+
 				const firstSearchResultItemHTML =
 					searchResultElements[ 0 ].innerHTML;
 				const expectedResultsLength = 1;
@@ -450,9 +448,7 @@ describe( 'Default search suggestions', () => {
 
 		await eventLoopTick();
 
-		const searchResultElements = container.querySelectorAll(
-			'[role="listbox"] [role="option"]'
-		);
+		const searchResultElements = getSearchResults();
 
 		const searchInput = getURLInput();
 
@@ -489,9 +485,7 @@ describe( 'Default search suggestions', () => {
 		expect( searchInput.value ).toBe( searchTerm );
 
 		// TODO: select these by aria relationship to autocomplete rather than arbitary selector.
-		searchResultElements = container.querySelectorAll(
-			'[role="listbox"] [role="option"]'
-		);
+		searchResultElements = getSearchResults();
 
 		// delete the text
 		act( () => {
@@ -501,9 +495,8 @@ describe( 'Default search suggestions', () => {
 		await eventLoopTick();
 
 		// TODO: select these by aria relationship to autocomplete rather than arbitary selector.
-		searchResultElements = container.querySelectorAll(
-			'[role="listbox"] [role="option"]'
-		);
+		searchResultElements = getSearchResults();
+
 		searchInput = getURLInput();
 
 		// check the input is empty now
@@ -637,9 +630,7 @@ describe( 'Selecting links', () => {
 				await eventLoopTick();
 
 				// TODO: select these by aria relationship to autocomplete rather than arbitary selector.
-				const searchResultElements = container.querySelectorAll(
-					'[role="listbox"] [role="option"]'
-				);
+				const searchResultElements = getSearchResults();
 
 				const firstSearchSuggestion = first( searchResultElements );
 
@@ -719,9 +710,8 @@ describe( 'Selecting links', () => {
 				} );
 
 				// TODO: select these by aria relationship to autocomplete rather than arbitary selector.
-				const searchResultElements = container.querySelectorAll(
-					'[role="listbox"] [role="option"]'
-				);
+				const searchResultElements = getSearchResults();
+
 				const firstSearchSuggestion = first( searchResultElements );
 				const secondSearchSuggestion = nth( searchResultElements, 1 );
 
@@ -827,9 +817,8 @@ describe( 'Selecting links', () => {
 			await eventLoopTick();
 
 			// TODO: select these by aria relationship to autocomplete rather than arbitary selector.
-			const searchResultElements = container.querySelectorAll(
-				'[role="listbox"] [role="option"]'
-			);
+			const searchResultElements = getSearchResults();
+
 			const firstSearchSuggestion = first( searchResultElements );
 			const secondSearchSuggestion = nth( searchResultElements, 1 );
 

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -50,6 +50,10 @@ afterEach( () => {
 	mockFetchSearchSuggestions.mockReset();
 } );
 
+function getURLInput() {
+	return container.querySelector( 'input[aria-label="URL"]' );
+}
+
 describe( 'Basic rendering', () => {
 	it( 'should render', () => {
 		act( () => {
@@ -57,17 +61,14 @@ describe( 'Basic rendering', () => {
 		} );
 
 		// Search Input UI
-		const searchInput = container.querySelector(
-			'input[aria-label="URL"]'
-		);
+		const searchInput = getURLInput();
 
 		expect( searchInput ).not.toBeNull();
 		expect( container.innerHTML ).toMatchSnapshot();
 	} );
 
 	describe( 'forceIsEditingLink', () => {
-		const isEditing = () =>
-			!! container.querySelector( 'input[aria-label="URL"]' );
+		const isEditing = () => !! getURLInput();
 
 		it( 'undefined', () => {
 			act( () => {
@@ -147,9 +148,7 @@ describe( 'Searching for a link', () => {
 		} );
 
 		// Search Input UI
-		const searchInput = container.querySelector(
-			'input[aria-label="URL"]'
-		);
+		const searchInput = getURLInput();
 
 		// Simulate searching for a term
 		act( () => {
@@ -190,9 +189,7 @@ describe( 'Searching for a link', () => {
 		} );
 
 		// Search Input UI
-		const searchInput = container.querySelector(
-			'input[aria-label="URL"]'
-		);
+		const searchInput = getURLInput();
 
 		// Simulate searching for a term
 		act( () => {
@@ -239,9 +236,7 @@ describe( 'Searching for a link', () => {
 			} );
 
 			// Search Input UI
-			const searchInput = container.querySelector(
-				'input[aria-label="URL"]'
-			);
+			const searchInput = getURLInput();
 
 			// Simulate searching for a term
 			act( () => {
@@ -295,9 +290,7 @@ describe( 'Manual link entry', () => {
 			} );
 
 			// Search Input UI
-			const searchInput = container.querySelector(
-				'input[aria-label="URL"]'
-			);
+			const searchInput = getURLInput();
 
 			// Simulate searching for a term
 			act( () => {
@@ -345,9 +338,7 @@ describe( 'Manual link entry', () => {
 				} );
 
 				// Search Input UI
-				const searchInput = container.querySelector(
-					'input[aria-label="URL"]'
-				);
+				const searchInput = getURLInput();
 
 				// Simulate searching for a term
 				act( () => {
@@ -395,9 +386,7 @@ describe( 'Default search suggestions', () => {
 		await eventLoopTick();
 
 		// Search Input UI
-		const searchInput = container.querySelector(
-			'input[aria-label="URL"]'
-		);
+		const searchInput = getURLInput();
 
 		// TODO: select these by aria relationship to autocomplete rather than arbitary selector.
 		const searchResultsWrapper = container.querySelector(
@@ -465,9 +454,7 @@ describe( 'Default search suggestions', () => {
 			'[role="listbox"] [role="option"]'
 		);
 
-		const searchInput = container.querySelector(
-			'input[aria-label="URL"]'
-		);
+		const searchInput = getURLInput();
 
 		// search input is set to the URL value
 		expect( searchInput.value ).toEqual( fauxEntitySuggestions[ 0 ].url );
@@ -489,7 +476,7 @@ describe( 'Default search suggestions', () => {
 		let searchInput;
 
 		// Search Input UI
-		searchInput = container.querySelector( 'input[aria-label="URL"]' );
+		searchInput = getURLInput();
 
 		// Simulate searching for a term
 		act( () => {
@@ -517,7 +504,7 @@ describe( 'Default search suggestions', () => {
 		searchResultElements = container.querySelectorAll(
 			'[role="listbox"] [role="option"]'
 		);
-		searchInput = container.querySelector( 'input[aria-label="URL"]' );
+		searchInput = getURLInput();
 
 		// check the input is empty now
 		expect( searchInput.value ).toBe( '' );
@@ -594,9 +581,7 @@ describe( 'Selecting links', () => {
 			Simulate.click( currentLinkBtn );
 		} );
 
-		const searchInput = container.querySelector(
-			'input[aria-label="URL"]'
-		);
+		const searchInput = getURLInput();
 		currentLinkUI = container.querySelector(
 			'.block-editor-link-control__search-item.is-current'
 		);
@@ -639,9 +624,7 @@ describe( 'Selecting links', () => {
 				} );
 
 				// Search Input UI
-				const searchInput = container.querySelector(
-					'input[aria-label="URL"]'
-				);
+				const searchInput = getURLInput();
 
 				// Simulate searching for a term
 				act( () => {
@@ -717,9 +700,7 @@ describe( 'Selecting links', () => {
 				} );
 
 				// Search Input UI
-				const searchInput = container.querySelector(
-					'input[aria-label="URL"]'
-				);
+				const searchInput = getURLInput();
 				const form = container.querySelector( 'form' );
 
 				// Simulate searching for a term
@@ -836,9 +817,7 @@ describe( 'Selecting links', () => {
 			);
 
 			// Search Input UI
-			const searchInput = container.querySelector(
-				'input[aria-label="URL"]'
-			);
+			const searchInput = getURLInput();
 
 			// Step down into the search results, highlighting the first result item
 			act( () => {
@@ -922,9 +901,7 @@ describe( 'Selecting links', () => {
 
 		// Change value.
 		const form = container.querySelector( 'form' );
-		const searchInput = container.querySelector(
-			'input[aria-label="URL"]'
-		);
+		const searchInput = getURLInput();
 
 		// Simulate searching for a term
 		act( () => {

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -58,6 +58,12 @@ function getSearchResults() {
 	return container.querySelectorAll( '[role="listbox"] [role="option"]' );
 }
 
+function getCurrentLink() {
+	return container.querySelector(
+		'.block-editor-link-control__search-item.is-current'
+	);
+}
+
 describe( 'Basic rendering', () => {
 	it( 'should render', () => {
 		act( () => {
@@ -437,9 +443,7 @@ describe( 'Default search suggestions', () => {
 		// Click the "Edit/Change" button and check initial suggestions are not
 		// shown.
 		//
-		const currentLinkUI = container.querySelector(
-			'.block-editor-link-control__search-item.is-current'
-		);
+		const currentLinkUI = getCurrentLink();
 		const currentLinkBtn = currentLinkUI.querySelector( 'button' );
 
 		act( () => {
@@ -527,9 +531,7 @@ describe( 'Selecting links', () => {
 		} );
 
 		// TODO: select by aria role or visible text
-		const currentLink = container.querySelector(
-			'.block-editor-link-control__search-item.is-current'
-		);
+		const currentLink = getCurrentLink();
 		const currentLinkHTML = currentLink.innerHTML;
 		const currentLinkAnchor = currentLink.querySelector(
 			`[href="${ selectedLink.url }"]`
@@ -564,9 +566,7 @@ describe( 'Selecting links', () => {
 		} );
 
 		// Required in order to select the button below
-		let currentLinkUI = container.querySelector(
-			'.block-editor-link-control__search-item.is-current'
-		);
+		let currentLinkUI = getCurrentLink();
 		const currentLinkBtn = currentLinkUI.querySelector( 'button' );
 
 		// Simulate searching for a term
@@ -575,9 +575,7 @@ describe( 'Selecting links', () => {
 		} );
 
 		const searchInput = getURLInput();
-		currentLinkUI = container.querySelector(
-			'.block-editor-link-control__search-item.is-current'
-		);
+		currentLinkUI = getCurrentLink();
 
 		// We should be back to showing the search input
 		expect( searchInput ).not.toBeNull();

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -55,7 +55,15 @@ function getURLInput() {
 }
 
 function getSearchResults() {
-	return container.querySelectorAll( '[role="listbox"] [role="option"]' );
+	const input = getURLInput();
+	// The input has `aria-owns` to indicate that it owns (and is related to)
+	// the search results with `role="listbox"`.
+	const relatedSelector = input.getAttribute( 'aria-owns' );
+
+	// Select by relationship as well as role
+	return container.querySelectorAll(
+		`#${ relatedSelector }[role="listbox"] [role="option"]`
+	);
 }
 
 function getCurrentLink() {


### PR DESCRIPTION
A minor refactor of **"unit" tests** for `<LinkControl>` to DRY up the implementation. 

Currently, there is a lot of repetition in the test code. Whilst I"m not in favour of heavily abstracted test implementations (test should prefer clarity and verbosity for the sake of readability) it pays to slightly refactor the current implementation to remove the repeated CSS selectors.

Doing this whilst I'm waiting on builds for https://github.com/WordPress/gutenberg/pull/19775 to finish 😆 

Closes https://github.com/WordPress/gutenberg/issues/20166

## How has this been tested?
Checked the existing unit tests continue to pass.

## Screenshots <!-- if applicable -->
Nope!

## Types of changes
Bug fix (non-breaking change which fixes an issue).

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
