### PR TITLE
Fix missing i18n in custom gradient picker

### DIFF
--- a/packages/components/src/custom-gradient-picker/index.js
+++ b/packages/components/src/custom-gradient-picker/index.js
@@ -79,13 +79,13 @@ const GradientTypePicker = ( { gradientAST, hasGradient, onChange } ) => {
 				controls={ [
 					{
 						icon: <LinearGradientIcon />,
-						title: 'Linear Gradient',
+						title: __( 'Linear Gradient' ),
 						isActive: hasGradient && type === 'linear-gradient',
 						onClick: onSetLinearGradient,
 					},
 					{
 						icon: <RadialGradientIcon />,
-						title: 'Radial Gradient',
+						title: __( 'Radial Gradient' ),
 						isActive: hasGradient && type === 'radial-gradient',
 						onClick: onSetRadialGradient,
 					},


### PR DESCRIPTION
Fixes #20183
## Description
Add missing i18n to Gradient type in the block "Buttons".

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
