### PR TITLE
Project Management Automation: Bump due date for 7.5 special release cycle

### DIFF
--- a/packages/project-management-automation/lib/add-milestone.js
+++ b/packages/project-management-automation/lib/add-milestone.js
@@ -4,10 +4,10 @@
 const debug = require( './debug' );
 
 // Milestone due dates are calculated from a known due date:
-// 6.3, which was due on August 12 2019.
-const REFERENCE_MAJOR = 6;
-const REFERENCE_MINOR = 3;
-const REFERENCE_DATE = '2019-08-12';
+// 7.5, which was due on February 10 2020.
+const REFERENCE_MAJOR = 7;
+const REFERENCE_MINOR = 5;
+const REFERENCE_DATE = '2020-02-10';
 
 // Releases are every 14 days.
 const DAYS_PER_RELEASE = 14;

--- a/packages/project-management-automation/lib/test/add-milestone.js
+++ b/packages/project-management-automation/lib/test/add-milestone.js
@@ -45,7 +45,7 @@ describe( 'addMilestone', () => {
 				get: jest.fn( () =>
 					Promise.resolve( {
 						data: {
-							milestone: 'Gutenberg 6.4',
+							milestone: 'Gutenberg 7.5',
 						},
 					} )
 				),
@@ -95,9 +95,9 @@ describe( 'addMilestone', () => {
 				listMilestonesForRepo: jest.fn( () =>
 					Promise.resolve( {
 						data: [
-							{ title: 'Gutenberg 6.2', number: 10 },
-							{ title: 'Gutenberg 6.3', number: 11 },
-							{ title: 'Gutenberg 6.4', number: 12 },
+							{ title: 'Gutenberg 7.4', number: 10 },
+							{ title: 'Gutenberg 7.5', number: 11 },
+							{ title: 'Gutenberg 7.6', number: 12 },
 						],
 					} )
 				),
@@ -109,7 +109,7 @@ describe( 'addMilestone', () => {
 						data: {
 							content: Buffer.from(
 								JSON.stringify( {
-									version: '6.3.0',
+									version: '7.5.0',
 								} )
 							).toString( 'base64' ),
 							encoding: 'base64',
@@ -134,8 +134,8 @@ describe( 'addMilestone', () => {
 		expect( octokit.issues.createMilestone ).toHaveBeenCalledWith( {
 			owner: 'WordPress',
 			repo: 'gutenberg',
-			title: 'Gutenberg 6.4',
-			due_on: '2019-08-26T00:00:00.000Z',
+			title: 'Gutenberg 7.6',
+			due_on: '2020-02-24T00:00:00.000Z',
 		} );
 		expect( octokit.issues.listMilestonesForRepo ).toHaveBeenCalledWith( {
 			owner: 'WordPress',
@@ -173,9 +173,9 @@ describe( 'addMilestone', () => {
 				listMilestonesForRepo: jest.fn( () =>
 					Promise.resolve( {
 						data: [
-							{ title: 'Gutenberg 6.8', number: 10 },
-							{ title: 'Gutenberg 6.9', number: 11 },
-							{ title: 'Gutenberg 7.0', number: 12 },
+							{ title: 'Gutenberg 7.8', number: 10 },
+							{ title: 'Gutenberg 7.9', number: 11 },
+							{ title: 'Gutenberg 8.0', number: 12 },
 						],
 					} )
 				),
@@ -187,7 +187,7 @@ describe( 'addMilestone', () => {
 						data: {
 							content: Buffer.from(
 								JSON.stringify( {
-									version: '6.9.0',
+									version: '7.9.0',
 								} )
 							).toString( 'base64' ),
 							encoding: 'base64',
@@ -212,8 +212,8 @@ describe( 'addMilestone', () => {
 		expect( octokit.issues.createMilestone ).toHaveBeenCalledWith( {
 			owner: 'WordPress',
 			repo: 'gutenberg',
-			title: 'Gutenberg 7.0',
-			due_on: '2019-11-18T00:00:00.000Z',
+			title: 'Gutenberg 8.0',
+			due_on: '2020-04-20T00:00:00.000Z',
 		} );
 		expect( octokit.issues.listMilestonesForRepo ).toHaveBeenCalledWith( {
 			owner: 'WordPress',


### PR DESCRIPTION
This pull request seeks to update the reference version / date used in the milestone task to that of Gutenberg 7.5. The milestone task uses a hard-coded reference release date to compute the due date of the next milestone. Since Gutenberg 7.5 was an exception to the 2-week release cycle (it was released one week after Gutenberg 7.4), this reference date must be updated, as otherwise milestones would not be assigned correctly.