### PR TITLE
Avoid coupling `LinkControl` test to css class

### DIFF
--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -177,7 +177,6 @@ describe( 'Searching for a link', () => {
 		// fetchFauxEntitySuggestions resolves on next "tick" of event loop
 		await eventLoopTick();
 
-		// TODO: select these by aria relationship to autocomplete rather than arbitary selector.
 		const searchResultElements = getSearchResults();
 
 		let loadingUI = container.querySelector( '.components-spinner' );
@@ -216,7 +215,6 @@ describe( 'Searching for a link', () => {
 		// fetchFauxEntitySuggestions resolves on next "tick" of event loop
 		await eventLoopTick();
 
-		// TODO: select these by aria relationship to autocomplete rather than arbitary selector.
 		const searchResultElements = getSearchResults();
 
 		const firstSearchResultItemHTML = first( searchResultElements )
@@ -264,7 +262,6 @@ describe( 'Searching for a link', () => {
 			// fetchFauxEntitySuggestions resolves on next "tick" of event loop
 			await eventLoopTick();
 
-			// TODO: select these by aria relationship to autocomplete rather than arbitary selector.
 			const searchResultElements = getSearchResults();
 
 			const lastSearchResultItemHTML = last( searchResultElements )
@@ -317,7 +314,6 @@ describe( 'Manual link entry', () => {
 			// fetchFauxEntitySuggestions resolves on next "tick" of event loop
 			await eventLoopTick();
 
-			// TODO: select these by aria relationship to autocomplete rather than arbitary selector.
 			const searchResultElements = getSearchResults();
 
 			const firstSearchResultItemHTML =
@@ -364,7 +360,6 @@ describe( 'Manual link entry', () => {
 				// fetchFauxEntitySuggestions resolves on next "tick" of event loop
 				await eventLoopTick();
 
-				// TODO: select these by aria relationship to autocomplete rather than arbitary selector.
 				const searchResultElements = getSearchResults();
 
 				const firstSearchResultItemHTML =
@@ -401,7 +396,6 @@ describe( 'Default search suggestions', () => {
 		// Search Input UI
 		const searchInput = getURLInput();
 
-		// TODO: select these by aria relationship to autocomplete rather than arbitary selector.
 		const searchResultsWrapper = container.querySelector(
 			'[role="listbox"]'
 		);
@@ -497,7 +491,6 @@ describe( 'Default search suggestions', () => {
 
 		expect( searchInput.value ).toBe( searchTerm );
 
-		// TODO: select these by aria relationship to autocomplete rather than arbitary selector.
 		searchResultElements = getSearchResults();
 
 		// delete the text
@@ -507,7 +500,6 @@ describe( 'Default search suggestions', () => {
 
 		await eventLoopTick();
 
-		// TODO: select these by aria relationship to autocomplete rather than arbitary selector.
 		searchResultElements = getSearchResults();
 
 		searchInput = getURLInput();
@@ -636,7 +628,6 @@ describe( 'Selecting links', () => {
 				// fetchFauxEntitySuggestions resolves on next "tick" of event loop
 				await eventLoopTick();
 
-				// TODO: select these by aria relationship to autocomplete rather than arbitary selector.
 				const searchResultElements = getSearchResults();
 
 				const firstSearchSuggestion = first( searchResultElements );
@@ -716,7 +707,6 @@ describe( 'Selecting links', () => {
 					Simulate.keyDown( searchInput, { keyCode: DOWN } );
 				} );
 
-				// TODO: select these by aria relationship to autocomplete rather than arbitary selector.
 				const searchResultElements = getSearchResults();
 
 				const firstSearchSuggestion = first( searchResultElements );
@@ -823,7 +813,6 @@ describe( 'Selecting links', () => {
 
 			await eventLoopTick();
 
-			// TODO: select these by aria relationship to autocomplete rather than arbitary selector.
 			const searchResultElements = getSearchResults();
 
 			const firstSearchSuggestion = first( searchResultElements );

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -122,9 +122,10 @@ describe( 'Basic rendering', () => {
 			} );
 
 			// Click the "Edit" button to trigger into the editing mode.
-			const editButton = container.querySelector(
-				'.block-editor-link-control__search-item-action'
-			);
+			const editButton = Array.from(
+				container.querySelectorAll( 'button' )
+			).find( ( button ) => button.innerHTML.includes( 'Edit' ) );
+
 			act( () => {
 				Simulate.click( editButton );
 			} );


### PR DESCRIPTION
As we saw [here](https://github.com/WordPress/gutenberg/commit/38f4914149bc6fecbeb45e86ed29b2c101ca65fc) coupling this test to a CSS selector makes it more prone to error.

In general, it's my opinion that we should try to test user perceivable UI rather than developer-centric implementation details. 

This PR updates the test to check for text content to identify the `Edit` button rather than rely on the CSS class implementation detail. It's a minor change but I feel it's worthwhile.

This should make the test more resilient to change, as changing text is a user perceivable change and will, therefore, be more easily identifiable as a cause of test regression.

PS: also sneaking in removal of legacy comments I sholuld have removed in https://github.com/WordPress/gutenberg/pull/20182

## How has this been tested?
Checking all existing unit tests pass both on Travis and on local

```
npm run test-unit:watch packages/block-editor/src/components/link-control/
```


## Types of changes
Bug fix (non-breaking change which fixes an issue)
## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
