### PR TITLE
[FIX] inserter point in mobile app

### DIFF
--- a/packages/block-editor/src/components/block-list/index.native.js
+++ b/packages/block-editor/src/components/block-list/index.native.js
@@ -101,6 +101,9 @@ export class BlockList extends Component {
 			shouldShowInsertionPointAfter,
 		} = this.props;
 
+		const forceRefresh =
+			shouldShowInsertionPointBefore || shouldShowInsertionPointAfter;
+
 		return (
 			<View
 				style={ { flex: isRootList ? 1 : 0 } }
@@ -118,10 +121,7 @@ export class BlockList extends Component {
 					scrollViewStyle={ { flex: isRootList ? 1 : 0 } }
 					data={ blockClientIds }
 					keyExtractor={ identity }
-					extraData={
-						shouldShowInsertionPointBefore ||
-						shouldShowInsertionPointAfter
-					}
+					extraData={ forceRefresh }
 					renderItem={ this.renderItem }
 					shouldPreventAutomaticScroll={
 						this.shouldFlatListPreventAutomaticScroll

--- a/packages/block-editor/src/components/block-list/index.native.js
+++ b/packages/block-editor/src/components/block-list/index.native.js
@@ -97,6 +97,8 @@ export class BlockList extends Component {
 			withFooter = true,
 			isReadOnly,
 			isRootList,
+			shouldShowInsertionPointBefore,
+			shouldShowInsertionPointAfter,
 		} = this.props;
 
 		return (
@@ -116,8 +118,10 @@ export class BlockList extends Component {
 					scrollViewStyle={ { flex: isRootList ? 1 : 0 } }
 					data={ blockClientIds }
 					keyExtractor={ identity }
-					// We need that prop because we want to call 'renderItem' even if the data prop is the same
-					extraData={ [ true ] }
+					extraData={
+						shouldShowInsertionPointBefore ||
+						shouldShowInsertionPointAfter
+					}
 					renderItem={ this.renderItem }
 					shouldPreventAutomaticScroll={
 						this.shouldFlatListPreventAutomaticScroll

--- a/packages/block-editor/src/components/block-list/index.native.js
+++ b/packages/block-editor/src/components/block-list/index.native.js
@@ -116,6 +116,8 @@ export class BlockList extends Component {
 					scrollViewStyle={ { flex: isRootList ? 1 : 0 } }
 					data={ blockClientIds }
 					keyExtractor={ identity }
+					// We need that prop because we want to call 'renderItem' even if the data prop is the same
+					extraData={ [ true ] }
 					renderItem={ this.renderItem }
 					shouldPreventAutomaticScroll={
 						this.shouldFlatListPreventAutomaticScroll

--- a/packages/block-editor/src/components/default-block-appender/index.native.js
+++ b/packages/block-editor/src/components/default-block-appender/index.native.js
@@ -16,6 +16,7 @@ import { getDefaultBlockName } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
+import BlockInsertionPoint from '../block-list/insertion-point';
 import styles from './style.scss';
 
 export function DefaultBlockAppender( {
@@ -24,6 +25,7 @@ export function DefaultBlockAppender( {
 	onAppend,
 	placeholder,
 	containerStyle,
+	showSeparator,
 } ) {
 	if ( isLocked || ! isVisible ) {
 		return null;
@@ -40,7 +42,11 @@ export function DefaultBlockAppender( {
 				style={ [ styles.blockHolder, containerStyle ] }
 				pointerEvents="box-only"
 			>
-				<RichText placeholder={ value } onChange={ () => {} } />
+				{ showSeparator ? (
+					<BlockInsertionPoint />
+				) : (
+					<RichText placeholder={ value } onChange={ () => {} } />
+				) }
 			</View>
 		</TouchableWithoutFeedback>
 	);


### PR DESCRIPTION
## Description
Gutenberg-mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1894
I found an issue with the inserter point in the mobile app. The inserter was rendered even if the Add block bottom sheet was hidden. Look at the screen:
![Simulator Screen Shot - iPhone X - 2020-02-12 at 12 28 47](https://user-images.githubusercontent.com/16336501/74358339-97430480-4dc1-11ea-96bb-c48429cf075f.png)

It happens because we removed the `extraData` prop from FlatList. Because of that if the `data` is the same (it is the same in the case when we open bottom sheet and hide it- we don't change anything ) the `renderItem` is not called and we end with the wrong state of list items (they are not re-rendered after change of props).
I also fixed the inserter for the first block in an empty post. The Inserter should be rendered instead of a paragraph placeholder.

## How has this been tested?
- Remove all from initial html
- Click Add Block button
- The inserter should be shown instead of paragraph placeholder - below the title
- Add group block
- add a block in that group
- the inserter shouldn't be visible after that action and should be in the right place when the bottom sheet is open (please swipe bottom sheet a bit to see if inserter is in the right place)
- Click and hold on the Add Button (long press) and chose `add before` or `add after` and check if inserter is in the right place

## Screenshots <!-- if applicable -->

## Types of changes
Fix for inserter

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
