### PR TITLE
RNMobile: Only fetch image data if image url is not a local file

### DIFF
--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -78,6 +78,8 @@ const getUrlForSlug = ( image, { sizeSlug } ) => {
 	return get( image, [ 'media_details', 'sizes', sizeSlug, 'source_url' ] );
 };
 
+const isFileUrl = ( url ) => url && url.startsWith( 'file:' );
+
 export class ImageEdit extends React.Component {
 	constructor( props ) {
 		super( props );
@@ -123,7 +125,7 @@ export class ImageEdit extends React.Component {
 		if (
 			! attributes.id &&
 			attributes.url &&
-			attributes.url.indexOf( 'file:' ) === 0
+			isFileUrl( attributes.url )
 		) {
 			requestMediaImport( attributes.url, ( id, url ) => {
 				if ( url ) {
@@ -658,13 +660,14 @@ export default compose( [
 		const { getMedia } = select( 'core' );
 		const { getSettings } = select( 'core/block-editor' );
 		const {
-			attributes: { id },
+			attributes: { id, url },
 			isSelected,
 		} = props;
 		const { imageSizes } = getSettings();
 
+		const shouldGetMedia = id && isSelected && ! isFileUrl( url );
 		return {
-			image: id && isSelected ? getMedia( id ) : null,
+			image: shouldGetMedia ? getMedia( id ) : null,
 			imageSizes,
 		};
 	} ),


### PR DESCRIPTION
[Related gutenberg-mobile PR](https://github.com/wordpress-mobile/gutenberg-mobile/pull/1895)

## Description
Addresses https://github.com/wordpress-mobile/gutenberg-mobile/issues/1853 by not attempting to fetch an image that has a local file path url. This avoids accidentally fetching the wrong image when the local image id conflicts with a different remote id.

## How has this been tested?
1. On Android, add photos from the device to image blocks until the incrementing local id of the newly-added photo conflicts with the remote id of a photo for the site. Using an emulator and taking a snapshot of the device immediately before you add the photo that will have the conflicting id is handy for testing.
2. Observe that when the photo is uploading the placeholder only displays the correct newly added photo and does not ever display the photo with the conflicting remote id. 

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [X] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
