### PR TITLE
Edit-site Package: Make public, set version to 1.3.0-alpha.0

### DIFF
--- a/packages/edit-site/package.json
+++ b/packages/edit-site/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@wordpress/edit-site",
 	"version": "1.2.0",
-	"private": true,
 	"description": "Edit Site Page module for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/edit-site/package.json
+++ b/packages/edit-site/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/edit-site",
-	"version": "1.2.0",
+	"version": "1.3.0-alpha.0",
 	"description": "Edit Site Page module for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
## Description
Edit-site Package: Make public, set version to 1.3.0-alpha.0

This hasn't been published to npm yet. We're interested in using it to explore Full Site Editing outside of a 'regular' Gutenberg context, so we'd like to publish it.

Note that even though the package hasn't been published yet, the version number has been regularly bumped by the publish script, and it's now at 1.2.0. I'd like to set it to an alpha version (to make clear that it's still in its early stages and not yet ready for production). I've thus chosen 1.3.0-alpha.0 -- I hope that choice is okay.

## How has this been tested?
N/A

## Types of changes
N/A

## Checklist:
N/A

/cc @vindl @noahtallen 