### PR TITLE
Use default cursor in CustomSelectControl items

### DIFF
--- a/packages/components/src/custom-select-control/style.scss
+++ b/packages/components/src/custom-select-control/style.scss
@@ -43,6 +43,7 @@
 
 .components-custom-select-control__item {
 	align-items: center;
+	cursor: default;
 	display: flex;
 	list-style-type: none;
 	padding: 10px 5px 10px 25px;


### PR DESCRIPTION
## Description
While reviewing https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/1727, @mikejolley noticed the cursor changes from `default` to `text` when hovering the text of `CustomSelectControl` items. This PR makes the cursor consistent so the default cursor is used in the entire item.

This way we match the native `<select>` element.

## How has this been tested?
* Testing the `CustomSelectControl` in the story board.
* Verifying there were no regressions in the editor font size select.

## Screenshots
| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/3616980/74450465-6379e480-4e7e-11ea-8e55-d85d46a806cc.png" alt="Screenshoft from before" width="142" /> | <img src="https://user-images.githubusercontent.com/3616980/74450343-388f9080-4e7e-11ea-9394-d030c4e1ad63.png" alt="Screenshoft from before" width="141" /> |

## Types of changes
CSS enhancement.
