### PR TITLE
Improve URLInput onFocus method implementation

### DIFF
--- a/packages/block-editor/src/components/link-control/search-input.js
+++ b/packages/block-editor/src/components/link-control/search-input.js
@@ -59,7 +59,6 @@ const LinkControlSearchInput = ( {
 				className="block-editor-link-control__search-input"
 				value={ value }
 				onChange={ selectItemHandler }
-				onFocus={ selectItemHandler }
 				onKeyDown={ ( event ) => {
 					if ( event.keyCode === ENTER ) {
 						return;

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -218,23 +218,19 @@ class URLInput extends Component {
 		}
 	}
 
-	onFocus( event ) {
+	onFocus() {
 		const { suggestions } = this.state;
-		const { disableSuggestions, onFocus } = this.props;
-
-		const inputValue = event.target.value;
-
-		onFocus( inputValue );
+		const { disableSuggestions, value } = this.props;
 
 		// When opening the link editor, if there's a value present, we want to load the suggestions pane with the results for this input search value
 		// Don't re-run the suggestions on focus if there are already suggestions present (prevents searching again when tabbing between the input and buttons)
 		if (
-			inputValue &&
+			value &&
 			! disableSuggestions &&
 			! ( suggestions && suggestions.length )
 		) {
 			// Ensure the suggestions are updated with the current input value
-			this.updateSuggestions( inputValue );
+			this.updateSuggestions( value );
 		}
 	}
 

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -227,6 +227,7 @@ class URLInput extends Component {
 		if (
 			value &&
 			! disableSuggestions &&
+			! this.isUpdatingSuggestions &&
 			! ( suggestions && suggestions.length )
 		) {
 			// Ensure the suggestions are updated with the current input value


### PR DESCRIPTION
The `onFocus` implementation in `URLInput` had a few small fixes for improving it brought up by @aduth in his review of the merged PR https://github.com/WordPress/gutenberg/pull/19850.

## Description
- Previously, `onFocus` got the input value from the focus event, when this value should be the same as the `this.props.value`. I removed the event argument and am getting the input value from `this.props.value`
- The `onFocus` method allowed an `onFocus` method to be passed in via the `props`. This isn't necessary, so it has been removed.

## How has this been tested?
- Manually
- Existing Unit Tests still pass

## Types of changes
- Refactor. 
- Remove undocumented `onFocus` prop from being used with `URLInput`.

This PR should not change or break any implementations, unless someone did pass a method into the undocumented `URLInput` `onFocus` handler. This seems highly unlikely, as it was undocumented and only got merged on 2/11/2020.

## Testing Instructions
- Confirm manually by opening the `LinkControl` on an existing navigation link. Click the `Edit` button. A URL search result for the current input should be present.
- Run unit tests and make sure they all pass.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
