### PR TITLE
Embeds: Improve find-ability for social/video embeds

### DIFF
--- a/packages/block-library/src/embed/core-embeds.js
+++ b/packages/block-library/src/embed/core-embeds.js
@@ -31,7 +31,7 @@ export const common = [
 		settings: {
 			title: 'Twitter',
 			icon: embedTwitterIcon,
-			keywords: [ 'tweet' ],
+			keywords: [ 'tweet', __( 'social' ) ],
 			description: __( 'Embed a tweet.' ),
 		},
 		patterns: [ /^https?:\/\/(www\.)?twitter\.com\/.+/i ],
@@ -54,6 +54,7 @@ export const common = [
 		settings: {
 			title: 'Facebook',
 			icon: embedFacebookIcon,
+			keywords: [ __( 'social' ) ],
 			description: __( 'Embed a Facebook post.' ),
 		},
 		patterns: [ /^https?:\/\/www\.facebook.com\/.+/i ],
@@ -63,7 +64,7 @@ export const common = [
 		settings: {
 			title: 'Instagram',
 			icon: embedInstagramIcon,
-			keywords: [ __( 'image' ) ],
+			keywords: [ __( 'image' ), __( 'social' ) ],
 			description: __( 'Embed an Instagram post.' ),
 		},
 		patterns: [ /^https?:\/\/(www\.)?instagr(\.am|am\.com)\/.+/i ],
@@ -160,7 +161,7 @@ export const others = [
 		settings: {
 			title: 'Crowdsignal',
 			icon: embedContentIcon,
-			keywords: [ 'polldaddy' ],
+			keywords: [ 'polldaddy', __( 'survey' ) ],
 			transform: [
 				{
 					type: 'block',
@@ -185,6 +186,7 @@ export const others = [
 		settings: {
 			title: 'Dailymotion',
 			icon: embedVideoIcon,
+			keywords: [ __( 'video' ) ],
 			description: __( 'Embed a Dailymotion video.' ),
 		},
 		patterns: [ /^https?:\/\/(www\.)?dailymotion\.com\/.+/i ],
@@ -194,6 +196,7 @@ export const others = [
 		settings: {
 			title: 'Hulu',
 			icon: embedVideoIcon,
+			keywords: [ __( 'video' ) ],
 			description: __( 'Embed Hulu content.' ),
 		},
 		patterns: [ /^https?:\/\/(www\.)?hulu\.com\/.+/i ],
@@ -351,6 +354,7 @@ export const others = [
 		settings: {
 			title: 'TikTok',
 			icon: embedVideoIcon,
+			keywords: [ __( 'video' ) ],
 			description: __( 'Embed a TikTok video.' ),
 		},
 		patterns: [ /^https?:\/\/(www\.)?tiktok\.com\/.+/i ],
@@ -369,6 +373,7 @@ export const others = [
 		settings: {
 			title: 'Tumblr',
 			icon: embedTumblrIcon,
+			keywords: [ __( 'social' ) ],
 			description: __( 'Embed a Tumblr post.' ),
 		},
 		patterns: [ /^https?:\/\/(www\.)?tumblr\.com\/.+/i ],


### PR DESCRIPTION
## Description
Adds popular keywords to embed blocks to make it easier for them to be found in the block selector. Currently `social` and `survey` return an empty result, and `video` doesn't contain all video options.

## How has this been tested?
Locally, searching with these keywords in the block picker, verifying that the added blocks show up.

## Types of changes
Bug fix (non-breaking change which fixes an issue) 
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
