### PR TITLE
Compat: Use core-js-url-browser for URL polyfill

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -205,17 +205,36 @@ function gutenberg_override_style( &$styles, $handle, $src, $deps = array(), $ve
  *
  * @param WP_Scripts $scripts WP_Scripts instance (passed by reference).
  */
-function gutenberg_register_vendor_scripts( &$scripts ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-	// This function is intentionally left empty.
-	//
-	// Scripts such as react and react-dom are expected to be overridden soon,
-	// and it is preferred to keep this function in place so as not to disturb
-	// tooling related to the plugin build process.
-	//
-	// TODO: Remove phpcs exception in function signature once this function
-	// regains its use.
-	//
-	// See https://github.com/WordPress/gutenberg/pull/20628.
+function gutenberg_register_vendor_scripts( &$scripts ) {
+	$suffix = SCRIPT_DEBUG ? '' : '.min';
+
+	/*
+	 * This script registration and the corresponding function should be removed
+	 * once the plugin is updated to support WordPress 5.4.0 and newer.
+	 *
+	 * See: `gutenberg_add_url_polyfill`
+	 */
+	gutenberg_register_vendor_script(
+		$scripts,
+		'wp-polyfill-url',
+		'https://unpkg.com/core-js-url-browser@3.6.4/url' . $suffix . '.js',
+		array(),
+		'3.6.4'
+	);
+
+	/*
+	 * This script registration and the corresponding function should be removed
+	 * removed once the plugin is updated to support WordPress 5.4.0 and newer.
+	 *
+	 * See: `gutenberg_add_dom_rect_polyfill`
+	 */
+	gutenberg_register_vendor_script(
+		$scripts,
+		'wp-polyfill-dom-rect',
+		'https://unpkg.com/polyfill-library@3.42.0/polyfills/DOMRect/polyfill.js',
+		array(),
+		'3.42.0'
+	);
 }
 add_action( 'wp_default_scripts', 'gutenberg_register_vendor_scripts' );
 

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -33,10 +33,12 @@ function gutenberg_add_url_polyfill( $scripts ) {
 		return;
 	}
 
+	$suffix = SCRIPT_DEBUG ? '' : '.min';
+
 	gutenberg_register_vendor_script(
 		$scripts,
 		'wp-polyfill-url',
-		'https://unpkg.com/core-js-url-browser@3.6.4/url.min.js',
+		'https://unpkg.com/core-js-url-browser@3.6.4/url' . $suffix . '.js',
 		array(),
 		'3.6.4'
 	);

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -36,9 +36,9 @@ function gutenberg_add_url_polyfill( $scripts ) {
 	gutenberg_register_vendor_script(
 		$scripts,
 		'wp-polyfill-url',
-		'https://unpkg.com/polyfill-library@3.42.0/polyfills/URL/polyfill.js',
+		'https://unpkg.com/core-js-url-browser@3.6.4/url.min.js',
 		array(),
-		'3.42.0'
+		'3.6.4'
 	);
 
 	did_action( 'init' ) && $scripts->add_inline_script(

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -16,6 +16,10 @@
  *
  * This can be removed when plugin support requires WordPress 5.4.0+.
  *
+ * The script registration occurs in `gutenberg_register_vendor_scripts`, which
+ * should be removed in coordination with this function.
+ *
+ * @see gutenberg_register_vendor_scripts
  * @see https://core.trac.wordpress.org/ticket/49360
  * @see https://developer.mozilla.org/en-US/docs/Web/API/URL/URL
  * @see https://developer.wordpress.org/reference/functions/wp_default_packages_vendor/
@@ -25,24 +29,6 @@
  * @param WP_Scripts $scripts WP_Scripts object.
  */
 function gutenberg_add_url_polyfill( $scripts ) {
-	// Only register polyfill if not already registered. This prevents handling
-	// in an environment where core has updated to manage the polyfill. This
-	// depends on the action being handled after default script registration.
-	$is_polyfill_script_registered = (bool) $scripts->query( 'wp-polyfill-url', 'registered' );
-	if ( $is_polyfill_script_registered ) {
-		return;
-	}
-
-	$suffix = SCRIPT_DEBUG ? '' : '.min';
-
-	gutenberg_register_vendor_script(
-		$scripts,
-		'wp-polyfill-url',
-		'https://unpkg.com/core-js-url-browser@3.6.4/url' . $suffix . '.js',
-		array(),
-		'3.6.4'
-	);
-
 	did_action( 'init' ) && $scripts->add_inline_script(
 		'wp-polyfill',
 		wp_get_script_polyfill(
@@ -60,6 +46,10 @@ add_action( 'wp_default_scripts', 'gutenberg_add_url_polyfill', 20 );
  *
  * This can be removed when plugin support requires WordPress 5.4.0+.
  *
+ * The script registration occurs in `gutenberg_register_vendor_scripts`, which
+ * should be removed in coordination with this function.
+ *
+ * @see gutenberg_register_vendor_scripts
  * @see gutenberg_add_url_polyfill
  * @see https://core.trac.wordpress.org/ticket/49360
  * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMRect
@@ -70,22 +60,6 @@ add_action( 'wp_default_scripts', 'gutenberg_add_url_polyfill', 20 );
  * @param WP_Scripts $scripts WP_Scripts object.
  */
 function gutenberg_add_dom_rect_polyfill( $scripts ) {
-	// Only register polyfill if not already registered. This prevents handling
-	// in an environment where core has updated to manage the polyfill. This
-	// depends on the action being handled after default script registration.
-	$is_polyfill_script_registered = (bool) $scripts->query( 'wp-polyfill-dom-rect', 'registered' );
-	if ( $is_polyfill_script_registered ) {
-		return;
-	}
-
-	gutenberg_register_vendor_script(
-		$scripts,
-		'wp-polyfill-dom-rect',
-		'https://unpkg.com/polyfill-library@3.42.0/polyfills/DOMRect/polyfill.js',
-		array(),
-		'3.42.0'
-	);
-
 	did_action( 'init' ) && $scripts->add_inline_script(
 		'wp-polyfill',
 		wp_get_script_polyfill(

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -46,7 +46,7 @@ function gutenberg_add_url_polyfill( $scripts ) {
 		wp_get_script_polyfill(
 			$scripts,
 			array(
-				'\'URL\' in window' => 'wp-polyfill-url',
+				'window.URL && window.URL.prototype && window.URLSearchParams' => 'wp-polyfill-url',
 			)
 		)
 	);


### PR DESCRIPTION
Previously: #19871
Related: https://github.com/Financial-Times/polyfill-library/issues/462, https://github.com/WordPress/gutenberg/pull/20172#issuecomment-584781181, [Trac#49360](https://core.trac.wordpress.org/ticket/49360#comment:6)

This pull request seeks to resolve issues where the current polyfill for `URL` introduced in #19871 is ineffective:

- The condition will never be satisfied, since `window.URL` _does exist_ in IE11. It's specifically the constructor which is not supported ([see related comment](https://core.trac.wordpress.org/ticket/49360#comment:9)).
- The chosen polyfill is non-spec-conformant in a way that we need it to be (https://github.com/Financial-Times/polyfill-library/issues/462, #19871)

The proposed changes improve the condition, and use [`core-js-url-polyfill`](https://www.npmjs.com/package/core-js-url-browser) in place of `polyfill-library` for the URL polyfill. This is a package I've published to NPM, and is a simple wrapper of [`core-js`](https://github.com/zloirock/core-js)'s URL polyfills. See [Trac#49360 comment](https://core.trac.wordpress.org/ticket/49360#comment:6) for more context on why a wrapper module is needed.

**Testing Instructions:**

_NOTE:_ The following can't yet be tested, because there is an unrelated error in IE11 preventing the page from being loaded. (TBD PR)

Prerequisites:

- Use Internet Explorer
- Either run WordPress 5.3.x (or any version **earlier than 5.4-beta / trunk**), or comment this line in the local copy of your branch:
   - https://github.com/WordPress/gutenberg/blob/5a5564b4d5cd6fe271ccb02e3f85f4141d7f21b5/lib/compat.php#L55
   - This is needed because Gutenberg's polyfill script is not registered if there is already one registered for `wp-polyfill-url`. Since this was already patched to core in 5.4-beta, the changes would not otherwise take effect.

Test:

1. Navigate to Posts > Add New
2. Open F12 Developer Tools Console
3. Observe success: `new URL( 'http://example.com' );`
4. Observe thrown error: `new URL( 'invalid' );`

![Screen Shot 2020-02-13 at 7 47 02 PM](https://user-images.githubusercontent.com/1779930/74491770-95993f80-4e9a-11ea-91fc-8c46bd2396c5.png)

