### PR TITLE
Block Editor: Simulated Media Query: Skip CSS rule if not style rule

### DIFF
--- a/packages/block-editor/src/components/simulate-media-query/index.js
+++ b/packages/block-editor/src/components/simulate-media-query/index.js
@@ -74,6 +74,10 @@ export default function useSimulatedMediaQuery( marker, width ) {
 				++ruleIndex
 			) {
 				const rule = styleSheet.cssRules[ ruleIndex ];
+				if ( rule.type !== window.CSSRule.STYLE_RULE ) {
+					continue;
+				}
+
 				if (
 					! relevantSection &&
 					!! rule.cssText.match( new RegExp( `#start-${ marker }` ) )

--- a/packages/block-editor/src/components/simulate-media-query/index.js
+++ b/packages/block-editor/src/components/simulate-media-query/index.js
@@ -75,7 +75,10 @@ export default function useSimulatedMediaQuery( marker, width ) {
 				++ruleIndex
 			) {
 				const rule = styleSheet.cssRules[ ruleIndex ];
-				if ( rule.type !== window.CSSRule.STYLE_RULE ) {
+				if (
+					rule.type !== window.CSSRule.STYLE_RULE &&
+					rule.type !== window.CSSRule.MEDIA_RULE
+				) {
 					continue;
 				}
 

--- a/packages/block-editor/src/components/simulate-media-query/index.js
+++ b/packages/block-editor/src/components/simulate-media-query/index.js
@@ -16,6 +16,7 @@ const VALID_MEDIA_QUERY_REGEX = /\((min|max)-width:[^\(]*?\)/g;
 
 function getStyleSheetsThatMatchHostname() {
 	if ( typeof window === 'undefined' ) {
+		return [];
 	}
 
 	return filter(

--- a/packages/block-editor/src/components/simulate-media-query/index.js
+++ b/packages/block-editor/src/components/simulate-media-query/index.js
@@ -15,9 +15,9 @@ const DISABLED_MEDIA_QUERY = '(min-width:999999px)';
 const VALID_MEDIA_QUERY_REGEX = /\((min|max)-width:[^\(]*?\)/g;
 
 function getStyleSheetsThatMatchHostname() {
-	if ( ! window ) {
-		return;
+	if ( typeof window === 'undefined' ) {
 	}
+
 	return filter(
 		get( window, [ 'document', 'styleSheets' ], [] ),
 		( styleSheet ) => {


### PR DESCRIPTION
Related: #19082

This pull request seeks to resolve an error preventing the editor from loading in Internet Explorer.

![Screen Shot 2020-02-13 at 8 20 12 PM](https://user-images.githubusercontent.com/1779930/74492852-40f7c380-4e9e-11ea-956c-b5b6ba1995a3.png)

See TBD for more context:

>Specifically, it seems that Internet Explorer chokes when trying to access `rule.cssText` if the rule is not a style rule.
>
>https://github.com/WordPress/gutenberg/blob/5a5564b4d5cd6fe271ccb02e3f85f4141d7f21b5/packages/block-editor/src/components/simulate-media-query/index.js#L79
>
>```
>Error: Member not found.
>
>   at Anonymous function (http://192.168.1.162:8888/wp-content/plugins/gutenberg/build/block-editor/index.js?ver=4b589b399cd6b646f1ffb628aaece1e3:26000:9)
>   at Anonymous function (http://192.168.1.162:8888/wp-content/plugins/gutenberg/build/block-editor/index.js?ver=4b589b399cd6b646f1ffb628aaece1e3:25994:5)
>   at Vb (http://192.168.1.162:8888/wp-content/plugins/gutenberg/vendor/react-dom.min.b694e242.js?ver=16.9.0:104:421)
>   at Xi (http://192.168.1.162:8888/wp-content/plugins/gutenberg/vendor/react-dom.min.b694e242.js?ver=16.9.0:151:136)
>   at Scheduler.unstable_runWithPriority (http://192.168.1.162:8888/wp-content/plugins/gutenberg/vendor/react.min.0212dc62.js?ver=16.9.0:26:333)
>   at Ma (http://192.168.1.162:8888/wp-content/plugins/gutenberg/vendor/react-dom.min.b694e242.js?ver=16.9.0:52:273)
>   at Yb (http://192.168.1.162:8888/wp-content/plugins/gutenberg/vendor/react-dom.min.b694e242.js?ver=16.9.0:150:413)
>   at O (http://192.168.1.162:8888/wp-content/plugins/gutenberg/vendor/react-dom.min.b694e242.js?ver=16.9.0:120:254)
>   at ze (http://192.168.1.162:8888/wp-content/plugins/gutenberg/vendor/react-dom.min.b694e242.js?ver=16.9.0:118:5)
>   at Anonymous function (http://192.168.1.162:8888/wp-content/plugins/gutenberg/vendor/react-dom.min.b694e242.js?ver=16.9.0:53:47)
>```
>
>On some debugging, this seems to be caused by `mejs-loading-spinner`, of type `CSSRule.KEYFRAMES_RULE`. It's unclear, but given this is ["experimental"](https://developer.mozilla.org/en-US/docs/Web/API/CSSKeyframesRule), I imagine that may be connected to why it errors.
>
>In any case, I imagine that we're only concerned with replacing CSS style rules? In which case, we can skip anything which is not a style rule. For me, this resolves the error. I imagine it could also marginally improve the performance of this implementation.

**Testing Instructions:**

Repeat testing instructions from #19082.

Verify that the editor loads in Internet Explorer.