### PR TITLE
wp-env: Fix issue where docker & wp had different URLs

### DIFF
--- a/packages/env/lib/config.js
+++ b/packages/env/lib/config.js
@@ -104,6 +104,10 @@ module.exports = {
 			config
 		);
 
+		config.port = getNumberFromEnvVariable( 'WP_ENV_PORT' ) || config.port;
+		config.testsPort =
+			getNumberFromEnvVariable( 'WP_ENV_TESTS_PORT' ) || config.testsPort;
+
 		if ( config.core !== null && typeof config.core !== 'string' ) {
 			throw new ValidationError(
 				'Invalid .wp-env.json: "core" must be null or a string.'
@@ -253,6 +257,33 @@ function includeTestsPath( source ) {
 			'tests-' + path.basename( source.path )
 		),
 	};
+}
+
+/**
+ * Parses an environment variable which should be a number.
+ *
+ * Throws an error if the variable cannot be parsed to a number.
+ * Returns null if the environment variable has not been specified.
+ *
+ * @param {string} varName The environment variable to check (e.g. WP_ENV_PORT).
+ * @return {null|number} The number. Null if it does not exist.
+ */
+function getNumberFromEnvVariable( varName ) {
+	// Allow use of the default if it does not exist.
+	if ( ! process.env[ varName ] ) {
+		return null;
+	}
+
+	const maybeNumber = parseInt( process.env[ varName ] );
+
+	// Throw an error if it is not parseable as a number.
+	if ( isNaN( maybeNumber ) ) {
+		throw new ValidationError(
+			`Invalid environment variable: ${ varName } must be a number.`
+		);
+	}
+
+	return maybeNumber;
 }
 
 /**

--- a/packages/env/lib/env.js
+++ b/packages/env/lib/env.js
@@ -302,15 +302,13 @@ async function configureWordPress( environment, config ) {
 		commandOptions: [ '--rm' ],
 	};
 
+	const port = environment === 'development' ? config.port : config.testsPort;
+
 	// Install WordPress.
 	await dockerCompose.run(
 		environment === 'development' ? 'cli' : 'tests-cli',
 		`wp core install
-			--url=localhost:${
-				environment === 'development'
-					? process.env.WP_ENV_PORT || '8888'
-					: process.env.WP_ENV_TESTS_PORT || '8889'
-			}
+			--url=localhost:${ port }
 			--title='${ config.name }'
 			--admin_user=admin
 			--admin_password=password

--- a/packages/env/test/config.js
+++ b/packages/env/test/config.js
@@ -257,6 +257,76 @@ describe( 'readConfig', () => {
 			testsPort: 8889,
 		} );
 	} );
+
+	it( 'should throw an error if the port number environment variable is invalid', async () => {
+		readFile.mockImplementation( () =>
+			Promise.resolve( JSON.stringify( {} ) )
+		);
+		const oldPort = process.env.WP_ENV_PORT;
+		process.env.WP_ENV_PORT = 'hello';
+		try {
+			await readConfig( '.wp-env.json' );
+		} catch ( error ) {
+			expect( error ).toBeInstanceOf( ValidationError );
+			expect( error.message ).toContain(
+				'Invalid environment variable: WP_ENV_PORT must be a number.'
+			);
+		}
+		process.env.WP_ENV_PORT = oldPort;
+	} );
+
+	it( 'should throw an error if the tests port number environment variable is invalid', async () => {
+		readFile.mockImplementation( () =>
+			Promise.resolve( JSON.stringify( {} ) )
+		);
+		const oldPort = process.env.WP_ENV_TESTS_PORT;
+		process.env.WP_ENV_TESTS_PORT = 'hello';
+		try {
+			await readConfig( '.wp-env.json' );
+		} catch ( error ) {
+			expect( error ).toBeInstanceOf( ValidationError );
+			expect( error.message ).toContain(
+				'Invalid environment variable: WP_ENV_TESTS_PORT must be a number.'
+			);
+		}
+		process.env.WP_ENV_TESTS_PORT = oldPort;
+	} );
+
+	it( 'should use port environment values rather than config values if both are defined', async () => {
+		readFile.mockImplementation( () =>
+			Promise.resolve(
+				JSON.stringify( {
+					port: 1000,
+					testsPort: 2000,
+				} )
+			)
+		);
+		const oldPort = process.env.WP_ENV_PORT;
+		const oldTestsPort = process.env.WP_ENV_TESTS_PORT;
+		process.env.WP_ENV_PORT = 4000;
+		process.env.WP_ENV_TESTS_PORT = 3000;
+
+		const config = await readConfig( '.wp-env.json' );
+		expect( config ).toMatchObject( {
+			port: 4000,
+			testsPort: 3000,
+		} );
+
+		process.env.WP_ENV_PORT = oldPort;
+		process.env.WP_ENV_TESTS_PORT = oldTestsPort;
+	} );
+
+	it( 'should use 8888 and 8889 as the default port and testsPort values if nothing else is specified', async () => {
+		readFile.mockImplementation( () =>
+			Promise.resolve( JSON.stringify( {} ) )
+		);
+
+		const config = await readConfig( '.wp-env.json' );
+		expect( config ).toMatchObject( {
+			port: 8888,
+			testsPort: 8889,
+		} );
+	} );
 } );
 
 /**


### PR DESCRIPTION
## Description
Fixes an issue where a custom port in .wp-env.json would not change the URL used to install WordPress. This resulted in the WordPress redirecting you to the default port. So if you would access docker at localhost:4013, it would send the request to WordPress, which thought the URL was localhost:8888, and you'd then be redirected to localhost:8888 which had nothing running on it.

## How has this been tested?
I made sure that accessing the custom port in .wp-env.json correctly loaded WordPress on that port. I also added unit tests to verify that environment variables are validated and take precedent over config values.

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
