### PR TITLE
[RNMobile] Removing DEV flag for Image block size options

### DIFF
--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -402,8 +402,7 @@ export class ImageEdit extends React.Component {
 						checked={ linkTarget === '_blank' }
 						onChange={ this.onSetNewTab }
 					/>
-					{ // eslint-disable-next-line no-undef
-					image && sizeOptionsValid && __DEV__ && (
+					{ image && sizeOptionsValid && (
 						<CycleSelectControl
 							icon={ 'editor-expand' }
 							label={ __( 'Size' ) }


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
We recently finished resolving behavioral issues related to updating images sizes on mobile, and are therefore removing the DEV flag blocking the feature in non-development builds.
See - https://github.com/wordpress-mobile/gutenberg-mobile/issues/1593


## Related PRs
Gutenberg-Mobile: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1904

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Individual changes have all already been tested as seen in the PRs linked in this issue https://github.com/wordpress-mobile/gutenberg-mobile/issues/1593

## Screenshots <!-- if applicable -->
![size-changes](https://user-images.githubusercontent.com/1103838/71146730-5e891380-21f4-11ea-9eaf-6d66be5a7a34.gif)


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
We are removing DEV flag blocking a feature now that all known issues are resolved. 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
