### PR TITLE
Make navigation button expand to fit longer nav link text

### DIFF
--- a/packages/block-editor/src/components/block-navigation/style.scss
+++ b/packages/block-editor/src/components/block-navigation/style.scss
@@ -60,7 +60,7 @@ $tree-item-height: 36px;
 	.block-editor-block-navigation__item-button {
 		margin-left: 0.8em;
 		width: calc(100% - 0.8em);
-		height: fit-content;
+		height: auto;
 	}
 
 	& > li:last-child {

--- a/packages/block-editor/src/components/block-navigation/style.scss
+++ b/packages/block-editor/src/components/block-navigation/style.scss
@@ -60,6 +60,7 @@ $tree-item-height: 36px;
 	.block-editor-block-navigation__item-button {
 		margin-left: 0.8em;
 		width: calc(100% - 0.8em);
+		height: fit-content;
 	}
 
 	& > li:last-child {


### PR DESCRIPTION
## Description
Fixes #20156 by making button grow to fit long navigation link text.

## How has this been tested?
Tested manually by adding long navigation labels to navigation block links

## Screenshots

Before:
<img width="263" alt="Screen Shot 2020-02-14 at 4 10 34 PM" src="https://user-images.githubusercontent.com/3629020/74498422-83c0a680-4f45-11ea-816e-ff9bfc7d37ae.png">

After: 
<img width="259" alt="Screen Shot 2020-02-14 at 4 11 09 PM" src="https://user-images.githubusercontent.com/3629020/74498456-989d3a00-4f45-11ea-8607-368c5aa0c69c.png">

## Types of changes
minor css change

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->

