### PR TITLE
[RNMobile] - Gallery Block: Columns Control

### DIFF
--- a/packages/block-library/src/gallery/columns-control/index.js
+++ b/packages/block-library/src/gallery/columns-control/index.js
@@ -1,0 +1,17 @@
+/**
+ * WordPress dependencies
+ */
+import { RangeControl } from '@wordpress/components';
+
+const ColumnsControl = ( { label, value, onChange, min, max } ) => (
+	<RangeControl
+		label={ label }
+		max={ max }
+		min={ min }
+		onChange={ onChange }
+		required
+		value={ value }
+	/>
+);
+
+export default ColumnsControl;

--- a/packages/block-library/src/gallery/columns-control/index.native.js
+++ b/packages/block-library/src/gallery/columns-control/index.native.js
@@ -1,0 +1,17 @@
+/**
+ * WordPress dependencies
+ */
+import { StepperControl } from '@wordpress/components';
+
+const ColumnsControl = ( { label, value, onChange, min, max } ) => (
+	<StepperControl
+		label={ label }
+		max={ max }
+		min={ min }
+		onChange={ onChange }
+		separatorType="fullWidth"
+		value={ value }
+	/>
+);
+
+export default ColumnsControl;

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -20,9 +20,7 @@ import {
 import { compose } from '@wordpress/compose';
 import {
 	PanelBody,
-	RangeControl,
 	SelectControl,
-	StepperControl,
 	ToggleControl,
 	withNotices,
 } from '@wordpress/components';
@@ -39,8 +37,8 @@ import { withViewportMatch } from '@wordpress/viewport';
 import { sharedIcon } from './shared-icon';
 import { defaultColumnsNumber, pickRelevantMediaFiles } from './shared';
 import Gallery from './gallery';
+import ColumnsControl from './columns-control';
 
-const ColumnsControl = Platform.OS === 'web' ? RangeControl : StepperControl;
 const MAX_COLUMNS = 8;
 const linkOptions = [
 	{ value: 'attachment', label: __( 'Attachment Page' ) },
@@ -384,7 +382,6 @@ class GalleryEdit extends Component {
 						{ images.length > 1 && (
 							<ColumnsControl
 								label={ __( 'Columns' ) }
-								{ ...MOBILE_CONTROL_PROPS }
 								value={ columns }
 								onChange={ this.setColumnsNumber }
 								min={ 1 }


### PR DESCRIPTION
`Gutenberg Mobile` PR -> https://github.com/wordpress-mobile/gutenberg-mobile/pull/1905

## Description

Due to this PR https://github.com/WordPress/gutenberg/pull/19947 a warning started to show up due to a missing import for web.

I'm proposing to add a `ColumnsControl` component with its own `Web` and `Mobile` variant.

The `Web` variant will have the `RangeControl` and the `Mobile` will have the `StepperControl`.

Having two different components (Slider / Stepper) [was a design decision](https://github.com/WordPress/gutenberg/pull/18864#issuecomment-565110060) to improve the UX on mobile.

Any other solution for this case is more than welcome =)

## How has this been tested?

**Web**:
- Start docker
- Open a new post
- Add a `Gallery` block
- Select images
- Open Settings
- Play with the slider in Columns section
- **Expect** the value to change and the Gallery to adjust.

**Mobile**:
- Open the demo app with metro running
- Add a `Gallery` block
- Select images
- Open Settings
- Change the value of the stepper
- **Expect** the value to change and the Gallery to adjust (Switch to landscape to see more columns)

## Types of changes
Bug fix (Import Warning)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
