### PR TITLE
Duplicate blocks: Make it possible to disable duplicating blocks

### DIFF
--- a/packages/block-editor/src/components/block-actions/index.js
+++ b/packages/block-editor/src/components/block-actions/index.js
@@ -51,7 +51,8 @@ export default compose( [
 			return (
 				!! block &&
 				hasBlockSupport( block.name, 'multiple', true ) &&
-				canInsertBlockType( block.name, rootClientId )
+				canInsertBlockType( block.name, rootClientId ) &&
+				hasBlockSupport( block.name, 'duplicate', true )
 			);
 		} );
 


### PR DESCRIPTION
We came across a situation in Jetpack recently where it would have been really useful to turn off the duplicate block feature: https://github.com/Automattic/jetpack/pull/14558

We found a fix in the end, but it was messy. It would be really useful if we could just disable this for some blocks. The default should be true.

## Description
This adds a `duplicate` option to `supports` which hides the "Duplicate" option in the Block Toolbar.

## How has this been tested?
I added `duplicate: false` to the block settings for a block and checked the option was hidden. The option is still there for other blocks.

## Screenshots <!-- if applicable -->
<img width="287" alt="Screenshot 2020-02-14 at 12 28 40" src="https://user-images.githubusercontent.com/275961/74531799-8e6b4380-4f25-11ea-9f24-368114c74575.png">

## Types of changes
New feature (non-breaking change which adds functionality) 

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->

If this is accepted I will need to add documentation for it.
