### PR TITLE
[RNMobile] Fix item width inside Inserter

### DIFF
--- a/packages/block-editor/src/components/inserter/menu.native.js
+++ b/packages/block-editor/src/components/inserter/menu.native.js
@@ -70,23 +70,22 @@ export class InserterMenu extends Component {
 
 	calculateColumnsProperties() {
 		const bottomSheetWidth = BottomSheet.getWidth();
-		const {
-			paddingLeft: containerPaddingLeft,
-			paddingRight: containerPaddingRight,
-		} = styles.content;
+		const { paddingLeft, paddingRight } = styles.columnPadding;
 		const itemTotalWidth = this.calculateItemWidth();
 		const containerTotalWidth =
-			bottomSheetWidth - ( containerPaddingLeft + containerPaddingRight );
+			bottomSheetWidth - ( paddingLeft + paddingRight );
 		const numofColumns = Math.floor( containerTotalWidth / itemTotalWidth );
 
 		if ( numofColumns < MIN_COL_NUM ) {
 			return {
 				numOfColumns: MIN_COL_NUM,
 				itemWidth: this.calculateMinItemWidth( bottomSheetWidth ),
+				maxWidth: containerTotalWidth / MIN_COL_NUM,
 			};
 		}
 		return {
 			numOfColumns: numofColumns,
+			maxWidth: containerTotalWidth / numofColumns,
 		};
 	}
 
@@ -153,7 +152,12 @@ export class InserterMenu extends Component {
 								accessibilityLabel={ item.title }
 								onPress={ () => onSelect( item ) }
 							>
-								<View style={ styles.modalItem }>
+								<View
+									style={ [
+										styles.modalItem,
+										{ width: columnProperties.maxWidth },
+									] }
+								>
 									<View
 										style={ [
 											modalIconWrapperStyle,

--- a/packages/components/src/mobile/bottom-sheet/index.native.js
+++ b/packages/components/src/mobile/bottom-sheet/index.native.js
@@ -9,6 +9,7 @@ import {
 	Dimensions,
 	ScrollView,
 	Keyboard,
+	StatusBar,
 } from 'react-native';
 import Modal from 'react-native-modal';
 import SafeArea from 'react-native-safe-area';
@@ -111,10 +112,15 @@ class BottomSheet extends Component {
 	onSetMaxHeight() {
 		const { height, width } = Dimensions.get( 'window' );
 		const { safeAreaBottomInset, keyboardHeight } = this.state;
+		const statusBarHeight =
+			Platform.OS === 'android' ? StatusBar.currentHeight : 0;
 
 		// `maxHeight` when modal is opened alon with a keyboard
 		const maxHeightWithOpenKeyboard =
-			0.95 * ( Dimensions.get( 'window' ).height - keyboardHeight );
+			0.95 *
+			( Dimensions.get( 'window' ).height -
+				keyboardHeight -
+				statusBarHeight );
 
 		// On horizontal mode `maxHeight` has to be set on 90% of width
 		if ( width > height ) {

--- a/packages/components/src/mobile/bottom-sheet/styles.native.scss
+++ b/packages/components/src/mobile/bottom-sheet/styles.native.scss
@@ -123,6 +123,7 @@
 	font-size: 17px;
 	color: #2e4453;
 	margin-right: 12px;
+	flex-shrink: 1;
 }
 
 .cellLabelCentered {


### PR DESCRIPTION
## Description

Fixes:

* https://github.com/wordpress-mobile/gutenberg-mobile/issues/1906
* https://github.com/wordpress-mobile/gutenberg-mobile/issues/1907

Ref to gutenberg-mobile: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1914

## How has this been tested?

1. Change device font size to the largest
2. Change display zoom to max (if available)
3. Open the app
4. Press the inserter
5. Observe if all the items are displayed properly within a grid

## Screenshots <!-- if applicable -->

* IOS - observe the long block name as well

default font size | the largest font size
--- | ---
![Screenshot 2020-02-14 at 14 48 41](https://user-images.githubusercontent.com/22746080/74536851-32aab580-4f39-11ea-9649-0f083d851cd7.png) | ![Screenshot 2020-02-14 at 14 49 43](https://user-images.githubusercontent.com/22746080/74536904-52da7480-4f39-11ea-9f87-1d180d29c361.png)


default font size | the largest font size
--- | ---
![Screenshot 2020-02-14 at 14 51 03](https://user-images.githubusercontent.com/22746080/74536977-756c8d80-4f39-11ea-8238-c2ec12d61e11.png) | ![Screenshot 2020-02-14 at 14 50 35](https://user-images.githubusercontent.com/22746080/74536985-78677e00-4f39-11ea-9e34-729c02bdd09e.png)

* Android

default font size | the largest font size + zoom
--- | ---
![Screenshot 2020-02-14 at 14 54 28](https://user-images.githubusercontent.com/22746080/74537413-54586c80-4f3a-11ea-8387-4d9c2c8fea0d.png) | <img width="449" alt="Screenshot 2020-02-14 at 14 53 23" src="https://user-images.githubusercontent.com/22746080/74537428-5ae6e400-4f3a-11ea-9c98-624c5636e492.png">

default font size | the largest font size + zoom
--- | ---
![Screenshot 2020-02-14 at 14 59 15](https://user-images.githubusercontent.com/22746080/74537539-95508100-4f3a-11ea-8604-be248d23c14a.png) | <img width="828" alt="Screenshot 2020-02-14 at 14 52 55" src="https://user-images.githubusercontent.com/22746080/74537450-69cd9680-4f3a-11ea-90f7-90062a3d9175.png">


## Types of changes
Set the width on modal item.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
