### PR TITLE
Lib: Show error when resolved block template is empty.

### DIFF
--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -199,7 +199,7 @@ function gutenberg_find_template( $template_file ) {
 			}
 		}
 		$_wp_current_template_id      = $current_template_post->ID;
-		$_wp_current_template_content = $current_template_post->post_content;
+		$_wp_current_template_content = empty( $current_template_post->post_content ) ? 'Empty template.' : $current_template_post->post_content;
 	}
 
 	// Add extra hooks for template canvas.


### PR DESCRIPTION
Closes #20201

## Description

When a resolved block template was empty, the "No matching template found." error message was displayed. This was confusing to users because a template was found; it was just empty.

This PR handles these cases with an "Empty template." error message instead.

## How to test this?

- Enable The Gutenberg FSE and Demo Templates Experiments.
- Visit your home page and verify the demo `front-page` template is rendering.
- Delete the contents of `lib/demo-block-templates/front-page.html`.
- Refresh your home page and verify that the "Empty template." message is displayed.

## Types of Changes

*New Feature:* There is now a more granular error message to differentiate between when a block template is not found and when a block template is found, but it is empty.

## Checklist:

- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->