### PR TITLE
[RNMobile] Correct add icon appearance

### DIFF
--- a/packages/block-editor/src/components/inserter/style.native.scss
+++ b/packages/block-editor/src/components/inserter/style.native.scss
@@ -73,7 +73,6 @@
 
 .addBlockButtonDark {
 	color: $blue-30;
-	border-color: $blue-30;
 }
 
 .columnPadding {

--- a/packages/block-editor/src/components/inserter/style.native.scss
+++ b/packages/block-editor/src/components/inserter/style.native.scss
@@ -69,9 +69,6 @@
 
 .addBlockButton {
 	color: $blue-wordpress;
-	border: 2px;
-	border-radius: 10px;
-	border-color: $blue-wordpress;
 }
 
 .addBlockButtonDark {


### PR DESCRIPTION
## Description

Like in the title I've corrected inserter icon appearance

Ref to gb-mobile: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1918

## How has this been tested?

1. Open the app
2. Observe add icon

## Screenshots <!-- if applicable -->

before | after
--- | ---
<img width="463" alt="Screenshot 2020-02-14 at 17 22 32" src="https://user-images.githubusercontent.com/22746080/74548681-9ab7c680-4f4e-11ea-9b6a-fff8cc6484a7.png"> | <img width="507" alt="Screenshot 2020-02-14 at 17 19 16" src="https://user-images.githubusercontent.com/22746080/74548621-7cea6180-4f4e-11ea-930d-d4cb3df1fb38.png">


## Types of changes

Remove redundant styles related to old dashicon.



## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
