### PR TITLE
Fix the z-index on the sub-nav

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -134,7 +134,7 @@ $navigation-sub-menu-width: $grid-size * 25;
 
 			// Position (first level)
 			position: absolute;
-			z-index: 1;
+			z-index: 2;
 			top: 100%;
 			left: 0; // just under the main menu item.
 


### PR DESCRIPTION
## Description
A sub-nav with a z-index of 1 can sit below other blocks when open. Specifically the cover block overlay (See #20203).

In this change, I've bumped the z-index to a value of 2 which seems to solve this issue.

## How has this been tested?
This has been tested manually using a fork of the Gutenberg repository, up to date with `master`

## Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/968731/74549880-57f2f000-4f48-11ea-8fa7-0d34b109c303.png)


## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
