### PR TITLE
Fix: Conditionaly apply Editor Skeleton html element styles

### DIFF
--- a/packages/block-editor/src/components/editor-skeleton/index.js
+++ b/packages/block-editor/src/components/editor-skeleton/index.js
@@ -6,8 +6,23 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
+import { useEffect } from '@wordpress/element';
 import { navigateRegions } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+
+function useHTMLClass( className ) {
+	useEffect( () => {
+		const element =
+			document && document.querySelector( `html:not(.${ className }` );
+		if ( ! element ) {
+			return;
+		}
+		element.classList.toggle( className );
+		return () => {
+			element.classList.toggle( className );
+		};
+	}, [ className ] );
+}
 
 function EditorSkeleton( {
 	footer,
@@ -17,6 +32,7 @@ function EditorSkeleton( {
 	publish,
 	className,
 } ) {
+	useHTMLClass( 'block-editor-editor-skeleton__html-container' );
 	return (
 		<div
 			className={ classnames(

--- a/packages/block-editor/src/components/editor-skeleton/style.scss
+++ b/packages/block-editor/src/components/editor-skeleton/style.scss
@@ -1,6 +1,6 @@
 // On Mobile devices, swiping the HTML element should not scroll.
 // By making it fixed, we prevent that.
-html {
+html.block-editor-editor-skeleton__html-container {
 	position: fixed;
 	width: 100%;
 


### PR DESCRIPTION
Previously editor skeleton applied styles to the HTML element unconditionally.
This PR makes sure the styles are only applied if the component is mounted.
Related: https://github.com/WordPress/gutenberg/issues/20214#issuecomment-586350750

It is important to get this in 5.4 because many blocks may have a bug where block editor styles are being enqueued without need and without this change we may be breaking the mobile experience for users with one of these blocks installed.

## How has this been tested?
I verified the editor still works as expected on mobile.
I verified the styles for the new class are being loaded.