### PR TITLE
Fix missing label on heading toolbar.

### DIFF
--- a/packages/block-library/src/heading/heading-toolbar.js
+++ b/packages/block-library/src/heading/heading-toolbar.js
@@ -48,6 +48,7 @@ class HeadingToolbar extends Component {
 				controls={ range( minLevel, maxLevel ).map( ( index ) =>
 					this.createLevelControl( index, selectedLevel, onChange )
 				) }
+				label={ __( 'Change heading level' ) }
 			/>
 		);
 	}


### PR DESCRIPTION
## Description
The heading level toolbar lacked an `aria-label`. This PR adds one.
![image](https://user-images.githubusercontent.com/19592990/74561718-bc08ba80-4f2e-11ea-8631-d497e265b254.png)