### PR TITLE
Flip "style-loader"/"css-loader" order in @wordpress/scripts webpack example

### DIFF
--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -489,7 +489,7 @@ module.exports = {
       ...defaultConfig.module.rules,
       {
         test: /\.css$/,
-        use: ["style-loader", "css-loader"],
+        use: [ 'style-loader', 'css-loader' ],
       }
     ]
   }

--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -489,7 +489,7 @@ module.exports = {
       ...defaultConfig.module.rules,
       {
         test: /\.css$/,
-        use: ["css-loader", "style-loader"],
+        use: ["style-loader", "css-loader"],
       }
     ]
   }


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

The "Extending the webpack config" section in [the `@wordpress/scripts` README](https://github.com/WordPress/gutenberg/tree/master/packages/scripts) had exactly the snippet I needed, except `css-loader` and `style-loader` needed to switched. When `css-loader` comes first, I get this error when running `wp-scripts build`: 

```
ERROR in ./node_modules/react-character-map/dist/component/style.css
Module build failed (from ./node_modules/css-loader/dist/cjs.js):
CssSyntaxError

(1:1) Unknown word
```

When `style-loader` is placed first, it works as expected. 

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Verified in my local environment.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Small README-only change.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
