### PR TITLE
wp-env: override generated file directory with environment variable

### DIFF
--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### New Feature
 
 - The `.wp-env.json` coniguration file now accepts `port` and `testsPort` options which can be used to set the ports on which the docker instance is mounted.
+- You may now override the directory in which wp-env creates generated files with the `WP_ENV_SOURCE` environment variable. (The default directory is `~/.wp-env/`.)
 
 ## 1.0.0 (2020-02-10)
 

--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### New Feature
 
-- You may now override the directory in which `wp-env` creates generated files with the `WP_ENV_SOURCE` environment variable. (The default directory is `~/.wp-env/`.)
+- You may now override the directory in which `wp-env` creates generated files with the `WP_ENV_HOME` environment variable. The default directory is `~/.wp-env/` (or `~/wp-env/` on Linux).
 - The `.wp-env.json` coniguration file now accepts `port` and `testsPort` options which can be used to set the ports on which the docker instance is mounted.
 
 ## 1.0.0 (2020-02-10)

--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ### New Feature
 
+- You may now override the directory in which `wp-env` creates generated files with the `WP_ENV_SOURCE` environment variable. (The default directory is `~/.wp-env/`.)
 - The `.wp-env.json` coniguration file now accepts `port` and `testsPort` options which can be used to set the ports on which the docker instance is mounted.
-- You may now override the directory in which wp-env creates generated files with the `WP_ENV_SOURCE` environment variable. (The default directory is `~/.wp-env/`.)
 
 ## 1.0.0 (2020-02-10)
 

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -137,6 +137,8 @@ $ wp-env start
 
 ## Command reference
 
+By default, the files wp-env generates are located at `~/.wp-env/$md5_of_project_path`. To change this location, set the `WP_ENV_SOURCE` environment variable. This changes the `~/.wp-env/` part of the path to wherever you wish. For example, running `WP_ENV_SOURCE="something" wp-env start` will download the project files to the directory `./something/$md5_of_project_path` (relative to the current directory.)
+
 ### `wp-env start [ref]`
 
 ```sh

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -137,7 +137,7 @@ $ wp-env start
 
 ## Command reference
 
-By default, the files `wp-env` generates are located at `~/.wp-env/$md5_of_project_path`. To change this location, set the `WP_ENV_SOURCE` environment variable. This changes the `~/.wp-env/` part of the path to wherever you wish. For example, running `WP_ENV_SOURCE="something" wp-env start` will download the project files to the directory `./something/$md5_of_project_path` (relative to the current directory).
+`wp-env` creates generated files in the wp-env home directory. By default, this is `~/.wp-env`. The exception is Linux, where files are placed at `~/wp-env` [for compatibility with Snap Packages](https://github.com/WordPress/gutenberg/issues/20180#issuecomment-587046325). The wp-env home directory contains a subdirectory for each project named `/$md5_of_project_path`. To change the wp-env home directory, set the `WP_ENV_HOME` environment variable. For example, running `WP_ENV_HOME="something" wp-env start` will download the project files to the directory `./something/$md5_of_project_path` (relative to the current directory).
 
 ### `wp-env start [ref]`
 

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -137,7 +137,7 @@ $ wp-env start
 
 ## Command reference
 
-By default, the files wp-env generates are located at `~/.wp-env/$md5_of_project_path`. To change this location, set the `WP_ENV_SOURCE` environment variable. This changes the `~/.wp-env/` part of the path to wherever you wish. For example, running `WP_ENV_SOURCE="something" wp-env start` will download the project files to the directory `./something/$md5_of_project_path` (relative to the current directory.)
+By default, the files `wp-env` generates are located at `~/.wp-env/$md5_of_project_path`. To change this location, set the `WP_ENV_SOURCE` environment variable. This changes the `~/.wp-env/` part of the path to wherever you wish. For example, running `WP_ENV_SOURCE="something" wp-env start` will download the project files to the directory `./something/$md5_of_project_path` (relative to the current directory).
 
 ### `wp-env start [ref]`
 

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -137,7 +137,7 @@ $ wp-env start
 
 ## Command reference
 
-`wp-env` creates generated files in the wp-env home directory. By default, this is `~/.wp-env`. The exception is Linux, where files are placed at `~/wp-env` [for compatibility with Snap Packages](https://github.com/WordPress/gutenberg/issues/20180#issuecomment-587046325). The wp-env home directory contains a subdirectory for each project named `/$md5_of_project_path`. To change the wp-env home directory, set the `WP_ENV_HOME` environment variable. For example, running `WP_ENV_HOME="something" wp-env start` will download the project files to the directory `./something/$md5_of_project_path` (relative to the current directory).
+`wp-env` creates generated files in the `wp-env` home directory. By default, this is `~/.wp-env`. The exception is Linux, where files are placed at `~/wp-env` [for compatibility with Snap Packages](https://github.com/WordPress/gutenberg/issues/20180#issuecomment-587046325). The `wp-env` home directory contains a subdirectory for each project named `/$md5_of_project_path`. To change the `wp-env` home directory, set the `WP_ENV_HOME` environment variable. For example, running `WP_ENV_HOME="something" wp-env start` will download the project files to the directory `./something/$md5_of_project_path` (relative to the current directory).
 
 ### `wp-env start [ref]`
 

--- a/packages/env/lib/config.js
+++ b/packages/env/lib/config.js
@@ -150,11 +150,10 @@ module.exports = {
 			);
 		}
 
-		const workDirectoryPath = path.resolve(
-			os.homedir(),
-			'.wp-env',
-			md5( configPath )
-		);
+		const wpEnvHome =
+			process.env.WP_ENV_SOURCE || `${ os.homedir() }/.wp-env`;
+
+		const workDirectoryPath = path.resolve( wpEnvHome, md5( configPath ) );
 
 		return {
 			name: path.basename( configDirectoryPath ),

--- a/packages/env/lib/config.js
+++ b/packages/env/lib/config.js
@@ -286,12 +286,12 @@ function getNumberFromEnvVariable( varName ) {
 }
 
 /**
- * Gets the wp-env home directory in which generated files are created.
+ * Gets the `wp-env` home directory in which generated files are created.
  *
  * By default, '~/.wp-env/'. On Linux, '~/wp-env/'. Can be overriden with the
  * WP_ENV_HOME environment variable.
  *
- * @return {string} The absolute path to the wp-env home directory.
+ * @return {string} The absolute path to the `wp-env` home directory.
  */
 function getWpEnvHomeDir() {
 	// Allow user to override download location.

--- a/packages/env/lib/config.js
+++ b/packages/env/lib/config.js
@@ -150,10 +150,10 @@ module.exports = {
 			);
 		}
 
-		const wpEnvHome =
-			process.env.WP_ENV_SOURCE || `${ os.homedir() }/.wp-env`;
-
-		const workDirectoryPath = path.resolve( wpEnvHome, md5( configPath ) );
+		const workDirectoryPath = path.resolve(
+			getWpEnvHomeDir(),
+			md5( configPath )
+		);
 
 		return {
 			name: path.basename( configDirectoryPath ),
@@ -283,6 +283,32 @@ function getNumberFromEnvVariable( varName ) {
 	}
 
 	return maybeNumber;
+}
+
+/**
+ * Gets the wp-env home directory in which generated files are created.
+ *
+ * By default, '~/.wp-env/'. On Linux, '~/wp-env/'. Can be overriden with the
+ * WP_ENV_HOME environment variable.
+ *
+ * @return {string} The absolute path to the wp-env home directory.
+ */
+function getWpEnvHomeDir() {
+	// Allow user to override download location.
+	if ( process.env.WP_ENV_HOME ) {
+		return path.resolve( process.env.WP_ENV_HOME );
+	}
+
+	/**
+	 * Installing docker with Snap Packages on Linux is common, but does not
+	 * support hidden directories. Therefore we use a public directory on Linux.
+	 *
+	 * @see https://github.com/WordPress/gutenberg/issues/20180#issuecomment-587046325
+	 */
+	return path.resolve(
+		os.homedir(),
+		os.platform() === 'linux' ? 'wp-env' : '.wp-env'
+	);
 }
 
 /**

--- a/packages/env/lib/config.js
+++ b/packages/env/lib/config.js
@@ -151,7 +151,7 @@ module.exports = {
 		}
 
 		const workDirectoryPath = path.resolve(
-			getWpEnvHomeDir(),
+			getHomeDirectory(),
 			md5( configPath )
 		);
 
@@ -293,7 +293,7 @@ function getNumberFromEnvVariable( varName ) {
  *
  * @return {string} The absolute path to the `wp-env` home directory.
  */
-function getWpEnvHomeDir() {
+function getHomeDirectory() {
 	// Allow user to override download location.
 	if ( process.env.WP_ENV_HOME ) {
 		return path.resolve( process.env.WP_ENV_HOME );

--- a/packages/env/lib/env.js
+++ b/packages/env/lib/env.js
@@ -373,7 +373,7 @@ async function resetDatabase( environment, { dockerComposeConfigPath } ) {
 }
 
 /**
- * Sets the correct user and permissions on the wp-conf.php file.
+ * Sets the correct user and permissions on the wp-config.php file.
  *
  * @param {string} coreSourcePath The path to the WordPress source code.
  */

--- a/packages/env/lib/env.js
+++ b/packages/env/lib/env.js
@@ -375,6 +375,11 @@ async function resetDatabase( environment, { dockerComposeConfigPath } ) {
 /**
  * Sets the correct user and permissions on the wp-config.php file.
  *
+ * This is needed because the file can be generated under the wrong user and
+ * group, which means we may not have permission to access it at runtime.
+ *
+ * @see https://github.com/WordPress/gutenberg/pull/20253#issuecomment-586871441
+ *
  * @param {string} coreSourcePath The path to the WordPress source code.
  */
 async function setCoreConfigPermissions( coreSourcePath ) {

--- a/packages/env/lib/env.js
+++ b/packages/env/lib/env.js
@@ -33,6 +33,19 @@ module.exports = {
 	 * @param {Object} options.spinner A CLI spinner which indicates progress.
 	 */
 	async start( { spinner } ) {
+		/**
+		 * If the Docker image is already running and the wp-env files have been
+		 * deleted, the start command will not complete successfully. Stopping
+		 * the container before continuing allows the docker entrypoint script
+		 * to run again when we start the containers.
+		 *
+		 * Additionally, this serves as a way to restart the container entirely
+		 * should the need arise.
+		 *
+		 * @see https://github.com/WordPress/gutenberg/pull/20253#issuecomment-587228440
+		 */
+		await module.exports.stop( { spinner } );
+
 		const config = await initConfig();
 
 		spinner.text = 'Downloading WordPress.';
@@ -387,6 +400,7 @@ async function setCoreConfigPermissions( coreSourcePath ) {
 	if ( process.platform !== 'linux' ) {
 		return;
 	}
+
 	// Get the UID and GID of an existing file that works correctly.
 	const indexFile = path.resolve( coreSourcePath, 'index.php' );
 	const { uid, gid } = await fs.stat( indexFile );


### PR DESCRIPTION
## Description
- Adds a non-hidden default directory for Linux (`~/wp-env`) 
- Allows a user to override the directory in which wp-env creates generated files with the `WP_ENV_HOME` environment variable.

Work towards #20180, but will need to continue solving it in a follow-up.

## How has this been tested?
I used the environment variable locally and verified generated files were placed there. I also checked that the default location is still used if the environment variable is not specified.

I also tested that, if the container is running, the start command works successfully after deleting the wp-env home directory.

## Types of changes
New Feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
