### PR TITLE
Add alwaysOpen prop to PanelBody

### DIFF
--- a/packages/block-editor/src/components/block-switcher/index.js
+++ b/packages/block-editor/src/components/block-switcher/index.js
@@ -177,9 +177,7 @@ export class BlockSwitcher extends Component {
 								{ possibleBlockTransformations.length !== 0 && (
 									<PanelBody
 										title={ __( 'Transform To:' ) }
-										{ ...( hasBlockStyles
-											? { initialOpen: true }
-											: { opened: true } ) }
+										alwaysOpen={ ! hasBlockStyles }
 									>
 										<BlockTypesList
 											items={ possibleBlockTransformations.map(

--- a/packages/block-editor/src/components/block-switcher/index.js
+++ b/packages/block-editor/src/components/block-switcher/index.js
@@ -177,7 +177,9 @@ export class BlockSwitcher extends Component {
 								{ possibleBlockTransformations.length !== 0 && (
 									<PanelBody
 										title={ __( 'Transform To:' ) }
-										initialOpen
+										{ ...( hasBlockStyles
+											? { initialOpen: true }
+											: { opened: true } ) }
 									>
 										<BlockTypesList
 											items={ possibleBlockTransformations.map(

--- a/packages/block-editor/src/components/inserter/test/menu.js
+++ b/packages/block-editor/src/components/inserter/test/menu.js
@@ -208,7 +208,7 @@ describe( 'InserterMenu', () => {
 		assertOpenedPanels( element, 3 );
 
 		const matchingCategories = element.querySelectorAll(
-			'.components-panel__body-toggle'
+			'.components-panel__body-toggle, .components-panel__body-text-title'
 		);
 
 		expect( matchingCategories ).toHaveLength( 3 );
@@ -234,7 +234,7 @@ describe( 'InserterMenu', () => {
 		assertOpenedPanels( element, 3 );
 
 		const matchingCategories = element.querySelectorAll(
-			'.components-panel__body-toggle'
+			'.components-panel__body-toggle, .components-panel__body-text-title'
 		);
 
 		expect( matchingCategories ).toHaveLength( 3 );

--- a/packages/components/src/panel/README.md
+++ b/packages/components/src/panel/README.md
@@ -108,7 +108,7 @@ Title of the `PanelBody`. This shows even when it is closed.
 
 ###### opened
 
-If opened is true then the `Panel` will remain open regardless of the `initialOpen` prop and the panel will be prevented from being closed.
+Passing `opened` turns `PanelBody` into a controlled component, overriding its internal state.
 
 -   Type: `Boolean`
 -   Required: No
@@ -141,6 +141,13 @@ Whether or not the panel will start open.
 -   Type: `Boolean`
 -   Required: No
 -   Default: true
+
+###### alwaysOpen
+
+If `alwaysOpen` is set to true, the `PanelBody` can't be closed by the user.
+
+-   Type: `Boolean`
+-   Required: No
 
 ---
 

--- a/packages/components/src/panel/body.js
+++ b/packages/components/src/panel/body.js
@@ -47,38 +47,48 @@ export class PanelBody extends Component {
 			forwardedRef,
 		} = this.props;
 		const isOpened = opened === undefined ? this.state.opened : opened;
+		const isAlwaysOpened = true === this.props.opened;
 		const classes = classnames( 'components-panel__body', className, {
 			'is-opened': isOpened,
+			'is-always-opened': isAlwaysOpened,
 		} );
 
 		return (
 			<div className={ classes } ref={ forwardedRef }>
 				{ !! title && (
 					<h2 className="components-panel__body-title">
-						<Button
-							className="components-panel__body-toggle"
-							onClick={ this.toggle }
-							aria-expanded={ isOpened }
-						>
-							{ /*
-								Firefox + NVDA don't announce aria-expanded because the browser
-								repaints the whole element, so this wrapping span hides that.
-							*/ }
-							<span aria-hidden="true">
-								<Icon
-									className="components-panel__arrow"
-									icon={ isOpened ? chevronUp : chevronDown }
-								/>
+						{ isAlwaysOpened ? (
+							<span className="components-panel__body-text-title">
+								{ title }
 							</span>
-							{ title }
-							{ icon && (
-								<Icon
-									icon={ icon }
-									className="components-panel__icon"
-									size={ 20 }
-								/>
-							) }
-						</Button>
+						) : (
+							<Button
+								className="components-panel__body-toggle"
+								onClick={ this.toggle }
+								aria-expanded={ isOpened }
+							>
+								{ /*
+									Firefox + NVDA don't announce aria-expanded because the browser
+									repaints the whole element, so this wrapping span hides that.
+									*/ }
+								<span aria-hidden="true">
+									<Icon
+										className="components-panel__arrow"
+										icon={
+											isOpened ? chevronUp : chevronDown
+										}
+									/>
+								</span>
+								{ title }
+								{ icon && (
+									<Icon
+										icon={ icon }
+										className="components-panel__icon"
+										size={ 20 }
+									/>
+								) }
+							</Button>
+						) }
 					</h2>
 				) }
 				{ isOpened && children }

--- a/packages/components/src/panel/body.js
+++ b/packages/components/src/panel/body.js
@@ -39,6 +39,7 @@ export class PanelBody extends Component {
 
 	render() {
 		const {
+			alwaysOpen,
 			title,
 			children,
 			opened,
@@ -47,17 +48,16 @@ export class PanelBody extends Component {
 			forwardedRef,
 		} = this.props;
 		const isOpened = opened === undefined ? this.state.opened : opened;
-		const canUserToggle = undefined === opened; // Opened state is controlled externally.
 		const classes = classnames( 'components-panel__body', className, {
 			'is-opened': isOpened,
-			'has-toggle': canUserToggle,
+			'is-always-open': alwaysOpen,
 		} );
 
 		return (
 			<div className={ classes } ref={ forwardedRef }>
 				{ !! title && (
 					<h2 className="components-panel__body-title">
-						{ canUserToggle ? (
+						{ ! alwaysOpen ? (
 							<Button
 								className="components-panel__body-toggle"
 								onClick={ this.toggle }

--- a/packages/components/src/panel/body.js
+++ b/packages/components/src/panel/body.js
@@ -47,21 +47,17 @@ export class PanelBody extends Component {
 			forwardedRef,
 		} = this.props;
 		const isOpened = opened === undefined ? this.state.opened : opened;
-		const isAlwaysOpened = true === this.props.opened;
+		const canUserToggle = undefined === opened; // Opened state is controlled externally.
 		const classes = classnames( 'components-panel__body', className, {
 			'is-opened': isOpened,
-			'is-always-opened': isAlwaysOpened,
+			'has-toggle': canUserToggle,
 		} );
 
 		return (
 			<div className={ classes } ref={ forwardedRef }>
 				{ !! title && (
 					<h2 className="components-panel__body-title">
-						{ isAlwaysOpened ? (
-							<span className="components-panel__body-text-title">
-								{ title }
-							</span>
-						) : (
+						{ canUserToggle ? (
 							<Button
 								className="components-panel__body-toggle"
 								onClick={ this.toggle }
@@ -88,6 +84,10 @@ export class PanelBody extends Component {
 									/>
 								) }
 							</Button>
+						) : (
+							<span className="components-panel__body-text-title">
+								{ title }
+							</span>
 						) }
 					</h2>
 				) }

--- a/packages/components/src/panel/style.scss
+++ b/packages/components/src/panel/style.scss
@@ -68,10 +68,16 @@
 }
 
 // Hover States
-.components-panel__body > .components-panel__body-title:hover {
+.components-panel__body:not(.is-always-opened) > .components-panel__body-title:hover {
 	// Override the default button hover style
 	background: $light-gray-200 !important;
 	border: none !important;
+}
+
+.components-panel__body-text-title {
+	display: block;
+	padding: 15px;
+	font-weight: 600;
 }
 
 .components-panel__body-toggle.components-button {

--- a/packages/components/src/panel/style.scss
+++ b/packages/components/src/panel/style.scss
@@ -68,7 +68,7 @@
 }
 
 // Hover States
-.components-panel__body:not(.has-toggle) > .components-panel__body-title:hover {
+.components-panel__body:not(.is-always-open) > .components-panel__body-title:hover {
 	// Override the default button hover style
 	background: $light-gray-200 !important;
 	border: none !important;

--- a/packages/components/src/panel/style.scss
+++ b/packages/components/src/panel/style.scss
@@ -68,7 +68,7 @@
 }
 
 // Hover States
-.components-panel__body:not(.is-always-opened) > .components-panel__body-title:hover {
+.components-panel__body:not(.has-toggle) > .components-panel__body-title:hover {
 	// Override the default button hover style
 	background: $light-gray-200 !important;
 	border: none !important;

--- a/packages/components/src/panel/test/body.js
+++ b/packages/components/src/panel/test/body.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { shallow, mount } from 'enzyme';
+import TestUtils from 'react-dom/test-utils';
 
 /**
  * Internal dependencies
@@ -103,19 +104,38 @@ describe( 'PanelBody', () => {
 	describe( 'button inclusion', () => {
 		const buttonSelector = '.components-panel__body-toggle';
 
-		it( 'should have a button if opened prop does not exist', () => {
-			const panelBody = mount( <PanelBody /> );
-			expect( panelBody.find( buttonSelector ).exists() ).toBe( true );
-		} );
-
-		it( 'should have a button if opened prop is not true', () => {
-			const panelBody = mount( <PanelBody opened={ false } /> );
-			expect( panelBody.find( buttonSelector ).exists() ).toBe( true );
+		it( 'should have a button if opened prop is not set', () => {
+			const wrapper = TestUtils.renderIntoDocument( <PanelBody /> );
+			expect(
+				TestUtils.scryRenderedDOMComponentsWithClass(
+					wrapper,
+					buttonSelector
+				)
+			).toHaveLength( 0 );
 		} );
 
 		it( 'should not have a button if opened prop is true', () => {
-			const panelBody = mount( <PanelBody opened={ true } /> );
-			expect( panelBody.find( buttonSelector ).exists() ).toBe( false );
+			const wrapper = TestUtils.renderIntoDocument(
+				<PanelBody alwaysOpen={ true } />
+			);
+			expect(
+				TestUtils.scryRenderedDOMComponentsWithClass(
+					wrapper,
+					buttonSelector
+				)
+			).toHaveLength( 0 );
+		} );
+
+		it( 'should have a button if alwaysOpen is false', () => {
+			const wrapper = TestUtils.renderIntoDocument(
+				<PanelBody alwaysOpen={ false } />
+			);
+			expect(
+				TestUtils.scryRenderedDOMComponentsWithClass(
+					wrapper,
+					buttonSelector
+				)
+			).toHaveLength( 0 );
 		} );
 	} );
 } );

--- a/packages/components/src/panel/test/body.js
+++ b/packages/components/src/panel/test/body.js
@@ -99,4 +99,23 @@ describe( 'PanelBody', () => {
 			expect( panelBody.state( 'opened' ) ).toBe( true );
 		} );
 	} );
+
+	describe( 'button inclusion', () => {
+		const buttonSelector = '.components-panel__body-toggle';
+
+		it( 'should have a button if opened prop does not exist', () => {
+			const panelBody = mount( <PanelBody /> );
+			expect( panelBody.find( buttonSelector ).exists() ).toBe( true );
+		} );
+
+		it( 'should have a button if opened prop is not true', () => {
+			const panelBody = mount( <PanelBody opened={ false } /> );
+			expect( panelBody.find( buttonSelector ).exists() ).toBe( true );
+		} );
+
+		it( 'should not have a button if opened prop is true', () => {
+			const panelBody = mount( <PanelBody opened={ true } /> );
+			expect( panelBody.find( buttonSelector ).exists() ).toBe( false );
+		} );
+	} );
 } );


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

This was initially meant to resolve #9522:

![44936544-1fa32600-ad43-11e8-946b-0437e497b6c0](https://user-images.githubusercontent.com/9020968/74595472-3d338080-5007-11ea-9b05-24d1f8841b6f.jpg)

In working on it I also reviewed the discussion in #9886 and #9889 and ended up addressing the `PanelBody` changes discussed there.

The README for the Panel component currently says about the `opened` prop: 

```
If opened is true then the `Panel` will remain open regardless of the `initialOpen` prop and the panel will be prevented from being closed.
```

But it's more accurate to say that the `opened` prop makes `PanelBody` a controlled component and overrides its internal state. It's used this way in the Inserter and in a few other places, including in some slot fills. So instead of messing with the `opened` component and potentially breaking backward-compatibility, I added a new `alwaysOpen` prop to `PanelBody`. This overrides internal state and `opened`, making the panel body truly always open.

When the `alwaysOpen` prop is true, the PanelBody heading is no longer a button; it no longer has the hover state or the down arrow icon. I applied this prop to the block switcher component, which now looks like this when there are no block styles:

<img width="332" alt="Screen Shot 2020-02-15 at 3 33 22 PM" src="https://user-images.githubusercontent.com/9020968/74595555-8932f500-5008-11ea-84ea-def63bb9398e.png">

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Tests added to cover the new behavior in the PanelBody component. Verified in the editor in my local environment.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Backward-compatible improvement to the `PanelBody` component.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
