### PR TITLE
Add width: 100% to vertically-aligned columns

### DIFF
--- a/packages/block-library/src/columns/style.scss
+++ b/packages/block-library/src/columns/style.scss
@@ -90,13 +90,16 @@
 .wp-block-column {
 	&.is-vertically-aligned-top {
 		align-self: flex-start;
+		width: 100%;
 	}
 
 	&.is-vertically-aligned-center {
 		align-self: center;
+		width: 100%;
 	}
 
 	&.is-vertically-aligned-bottom {
 		align-self: flex-end;
+		width: 100%;
 	}
 }


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
This is a pull request to fix the following issue:
https://github.com/WordPress/gutenberg/issues/19962

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
