### PR TITLE
ColorPalette: Make selected color more obvious

### DIFF
--- a/packages/block-editor/src/components/color-palette/test/__snapshots__/control.js.snap
+++ b/packages/block-editor/src/components/color-palette/test/__snapshots__/control.js.snap
@@ -54,7 +54,7 @@ exports[`ColorPaletteControl matches the snapshot 1`] = `
           />
           <svg
             aria-hidden="true"
-            fill="#111111"
+            fill="#000000"
             focusable="false"
             height={24}
             role="img"

--- a/packages/block-editor/src/components/color-palette/test/__snapshots__/control.js.snap
+++ b/packages/block-editor/src/components/color-palette/test/__snapshots__/control.js.snap
@@ -46,6 +46,7 @@ exports[`ColorPaletteControl matches the snapshot 1`] = `
             onMouseLeave={[Function]}
             style={
               Object {
+                "backgroundColor": "#f00",
                 "color": "#f00",
               }
             }

--- a/packages/block-editor/src/components/color-palette/test/__snapshots__/control.js.snap
+++ b/packages/block-editor/src/components/color-palette/test/__snapshots__/control.js.snap
@@ -58,11 +58,6 @@ exports[`ColorPaletteControl matches the snapshot 1`] = `
             focusable="false"
             height={24}
             role="img"
-            style={
-              Object {
-                "backgroundColor": "#f00",
-              }
-            }
             viewBox="-2 -2 24 24"
             width={24}
             xmlns="http://www.w3.org/2000/svg"

--- a/packages/block-editor/src/components/color-palette/test/__snapshots__/control.js.snap
+++ b/packages/block-editor/src/components/color-palette/test/__snapshots__/control.js.snap
@@ -53,9 +53,15 @@ exports[`ColorPaletteControl matches the snapshot 1`] = `
           />
           <svg
             aria-hidden="true"
+            fill="#111111"
             focusable="false"
             height={24}
             role="img"
+            style={
+              Object {
+                "backgroundColor": "#f00",
+              }
+            }
             viewBox="-2 -2 24 24"
             width={24}
             xmlns="http://www.w3.org/2000/svg"

--- a/packages/components/src/circular-option-picker/index.js
+++ b/packages/components/src/circular-option-picker/index.js
@@ -15,7 +15,13 @@ import Button from '../button';
 import Dropdown from '../dropdown';
 import Tooltip from '../tooltip';
 
-function Option( { className, isSelected, tooltipText, ...additionalProps } ) {
+function Option( {
+	className,
+	isSelected,
+	selectedIconProps = {},
+	tooltipText,
+	...additionalProps
+} ) {
 	const optionButton = (
 		<Button
 			isPressed={ isSelected }
@@ -33,7 +39,7 @@ function Option( { className, isSelected, tooltipText, ...additionalProps } ) {
 			) : (
 				optionButton
 			) }
-			{ isSelected && <Icon icon={ check } /> }
+			{ isSelected && <Icon icon={ check } { ...selectedIconProps } /> }
 		</div>
 	);
 }

--- a/packages/components/src/circular-option-picker/index.js
+++ b/packages/components/src/circular-option-picker/index.js
@@ -18,7 +18,7 @@ import Tooltip from '../tooltip';
 function Option( {
 	className,
 	isSelected,
-	selectedIconProps = {},
+	selectedIconProps,
 	tooltipText,
 	...additionalProps
 } ) {
@@ -39,7 +39,12 @@ function Option( {
 			) : (
 				optionButton
 			) }
-			{ isSelected && <Icon icon={ check } { ...selectedIconProps } /> }
+			{ isSelected && (
+				<Icon
+					icon={ check }
+					{ ...( selectedIconProps ? selectedIconProps : {} ) }
+				/>
+			) }
 		</div>
 	);
 }

--- a/packages/components/src/circular-option-picker/style.scss
+++ b/packages/components/src/circular-option-picker/style.scss
@@ -79,7 +79,6 @@ $color-palette-circle-spacing: 12px;
 			top: 2px;
 			border-radius: 50%;
 			z-index: z-index(".components-circular-option-picker__option.is-pressed + svg");
-			background: $white;
 			pointer-events: none;
 		}
 	}

--- a/packages/components/src/circular-option-picker/style.scss
+++ b/packages/components/src/circular-option-picker/style.scss
@@ -58,7 +58,7 @@ $color-palette-circle-spacing: 12px;
 	border-radius: 50%;
 	background: transparent;
 	box-shadow: inset 0 0 0 ($color-palette-circle-size / 2);
-	transition: none;
+	transition: 100ms box-shadow ease;
 	@include reduce-motion("transition");
 	cursor: pointer;
 
@@ -69,6 +69,9 @@ $color-palette-circle-spacing: 12px;
 
 	&.is-pressed {
 		box-shadow: inset 0 0 0 4px;
+		position: relative;
+		z-index: z-index(".components-circular-option-picker__option.is-pressed");
+		overflow: visible;
 
 		& + svg {
 			position: absolute;

--- a/packages/components/src/circular-option-picker/style.scss
+++ b/packages/components/src/circular-option-picker/style.scss
@@ -58,7 +58,7 @@ $color-palette-circle-spacing: 12px;
 	border-radius: 50%;
 	background: transparent;
 	box-shadow: inset 0 0 0 ($color-palette-circle-size / 2);
-	transition: 100ms box-shadow ease;
+	transition: none;
 	@include reduce-motion("transition");
 	cursor: pointer;
 
@@ -69,8 +69,6 @@ $color-palette-circle-spacing: 12px;
 
 	&.is-pressed {
 		box-shadow: inset 0 0 0 4px;
-		position: relative;
-		z-index: z-index(".components-circular-option-picker__option.is-pressed");
 
 		& + svg {
 			position: absolute;

--- a/packages/components/src/color-palette/index.js
+++ b/packages/components/src/color-palette/index.js
@@ -34,7 +34,7 @@ export default function ColorPalette( {
 					value === color
 						? {
 								fill: tinycolor
-									.mostReadable( color, [ '#111', '#fff' ] )
+									.mostReadable( color, [ '#000', '#fff' ] )
 									.toHexString(),
 						  }
 						: {}

--- a/packages/components/src/color-palette/index.js
+++ b/packages/components/src/color-palette/index.js
@@ -36,9 +36,6 @@ export default function ColorPalette( {
 								fill: tinycolor
 									.mostReadable( color, [ '#111', '#fff' ] )
 									.toHexString(),
-								style: {
-									backgroundColor: color,
-								},
 						  }
 						: {}
 				}

--- a/packages/components/src/color-palette/index.js
+++ b/packages/components/src/color-palette/index.js
@@ -47,7 +47,7 @@ export default function ColorPalette( {
 					// translators: %s: color hex code e.g: "#f00".
 					sprintf( __( 'Color code: %s' ), color )
 				}
-				style={ { color } }
+				style={ { backgroundColor: color, color } }
 				onClick={
 					value === color ? clearColor : () => onChange( color )
 				}

--- a/packages/components/src/color-palette/index.js
+++ b/packages/components/src/color-palette/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { map } from 'lodash';
+import tinycolor from 'tinycolor2';
 
 /**
  * WordPress dependencies
@@ -29,6 +30,18 @@ export default function ColorPalette( {
 			<CircularOptionPicker.Option
 				key={ color }
 				isSelected={ value === color }
+				selectedIconProps={
+					value === color
+						? {
+								fill: tinycolor
+									.mostReadable( color, [ '#111', '#fff' ] )
+									.toHexString(),
+								style: {
+									backgroundColor: color,
+								},
+						  }
+						: {}
+				}
 				tooltipText={
 					name ||
 					// translators: %s: color hex code e.g: "#f00".

--- a/packages/components/src/color-palette/test/__snapshots__/index.js.snap
+++ b/packages/components/src/color-palette/test/__snapshots__/index.js.snap
@@ -145,6 +145,14 @@ exports[`ColorPalette should allow disabling custom color picker 1`] = `
         aria-label="Color: red"
         isSelected={true}
         onClick={[Function]}
+        selectedIconProps={
+          Object {
+            "fill": "#111111",
+            "style": Object {
+              "backgroundColor": "#f00",
+            },
+          }
+        }
         style={
           Object {
             "color": "#f00",
@@ -156,6 +164,7 @@ exports[`ColorPalette should allow disabling custom color picker 1`] = `
         aria-label="Color: white"
         isSelected={false}
         onClick={[Function]}
+        selectedIconProps={Object {}}
         style={
           Object {
             "color": "#fff",
@@ -167,6 +176,7 @@ exports[`ColorPalette should allow disabling custom color picker 1`] = `
         aria-label="Color: blue"
         isSelected={false}
         onClick={[Function]}
+        selectedIconProps={Object {}}
         style={
           Object {
             "color": "#00f",
@@ -230,6 +240,14 @@ exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
           aria-label="Color: red"
           isSelected={true}
           onClick={[Function]}
+          selectedIconProps={
+            Object {
+              "fill": "#111111",
+              "style": Object {
+                "backgroundColor": "#f00",
+              },
+            }
+          }
           style={
             Object {
               "color": "#f00",
@@ -241,6 +259,7 @@ exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
           aria-label="Color: white"
           isSelected={false}
           onClick={[Function]}
+          selectedIconProps={Object {}}
           style={
             Object {
               "color": "#fff",
@@ -252,6 +271,7 @@ exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
           aria-label="Color: blue"
           isSelected={false}
           onClick={[Function]}
+          selectedIconProps={Object {}}
           style={
             Object {
               "color": "#00f",
@@ -270,6 +290,14 @@ exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
         isSelected={true}
         key="#f00"
         onClick={[Function]}
+        selectedIconProps={
+          Object {
+            "fill": "#111111",
+            "style": Object {
+              "backgroundColor": "#f00",
+            },
+          }
+        }
         style={
           Object {
             "color": "#f00",
@@ -319,6 +347,7 @@ exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
             </ForwardRef(Button)>
           </Tooltip>
           <Icon
+            fill="#111111"
             icon={
               <SVG
                 viewBox="-2 -2 24 24"
@@ -329,18 +358,35 @@ exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
                 />
               </SVG>
             }
+            style={
+              Object {
+                "backgroundColor": "#f00",
+              }
+            }
           >
             <SVG
+              fill="#111111"
               height={24}
+              style={
+                Object {
+                  "backgroundColor": "#f00",
+                }
+              }
               viewBox="-2 -2 24 24"
               width={24}
               xmlns="http://www.w3.org/2000/svg"
             >
               <svg
                 aria-hidden="true"
+                fill="#111111"
                 focusable="false"
                 height={24}
                 role="img"
+                style={
+                  Object {
+                    "backgroundColor": "#f00",
+                  }
+                }
                 viewBox="-2 -2 24 24"
                 width={24}
                 xmlns="http://www.w3.org/2000/svg"
@@ -362,6 +408,7 @@ exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
         isSelected={false}
         key="#fff"
         onClick={[Function]}
+        selectedIconProps={Object {}}
         style={
           Object {
             "color": "#fff",
@@ -417,6 +464,7 @@ exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
         isSelected={false}
         key="#00f"
         onClick={[Function]}
+        selectedIconProps={Object {}}
         style={
           Object {
             "color": "#00f",

--- a/packages/components/src/color-palette/test/__snapshots__/index.js.snap
+++ b/packages/components/src/color-palette/test/__snapshots__/index.js.snap
@@ -147,7 +147,7 @@ exports[`ColorPalette should allow disabling custom color picker 1`] = `
         onClick={[Function]}
         selectedIconProps={
           Object {
-            "fill": "#111111",
+            "fill": "#000000",
           }
         }
         style={
@@ -242,7 +242,7 @@ exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
           onClick={[Function]}
           selectedIconProps={
             Object {
-              "fill": "#111111",
+              "fill": "#000000",
             }
           }
           style={
@@ -292,7 +292,7 @@ exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
         onClick={[Function]}
         selectedIconProps={
           Object {
-            "fill": "#111111",
+            "fill": "#000000",
           }
         }
         style={
@@ -347,7 +347,7 @@ exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
             </ForwardRef(Button)>
           </Tooltip>
           <Icon
-            fill="#111111"
+            fill="#000000"
             icon={
               <SVG
                 viewBox="-2 -2 24 24"
@@ -360,7 +360,7 @@ exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
             }
           >
             <SVG
-              fill="#111111"
+              fill="#000000"
               height={24}
               viewBox="-2 -2 24 24"
               width={24}
@@ -368,7 +368,7 @@ exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
             >
               <svg
                 aria-hidden="true"
-                fill="#111111"
+                fill="#000000"
                 focusable="false"
                 height={24}
                 role="img"

--- a/packages/components/src/color-palette/test/__snapshots__/index.js.snap
+++ b/packages/components/src/color-palette/test/__snapshots__/index.js.snap
@@ -155,6 +155,7 @@ exports[`ColorPalette should allow disabling custom color picker 1`] = `
         }
         style={
           Object {
+            "backgroundColor": "#f00",
             "color": "#f00",
           }
         }
@@ -167,6 +168,7 @@ exports[`ColorPalette should allow disabling custom color picker 1`] = `
         selectedIconProps={Object {}}
         style={
           Object {
+            "backgroundColor": "#fff",
             "color": "#fff",
           }
         }
@@ -179,6 +181,7 @@ exports[`ColorPalette should allow disabling custom color picker 1`] = `
         selectedIconProps={Object {}}
         style={
           Object {
+            "backgroundColor": "#00f",
             "color": "#00f",
           }
         }
@@ -250,6 +253,7 @@ exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
           }
           style={
             Object {
+              "backgroundColor": "#f00",
               "color": "#f00",
             }
           }
@@ -262,6 +266,7 @@ exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
           selectedIconProps={Object {}}
           style={
             Object {
+              "backgroundColor": "#fff",
               "color": "#fff",
             }
           }
@@ -274,6 +279,7 @@ exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
           selectedIconProps={Object {}}
           style={
             Object {
+              "backgroundColor": "#00f",
               "color": "#00f",
             }
           }
@@ -300,6 +306,7 @@ exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
         }
         style={
           Object {
+            "backgroundColor": "#f00",
             "color": "#f00",
           }
         }
@@ -323,6 +330,7 @@ exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
               onMouseLeave={[Function]}
               style={
                 Object {
+                  "backgroundColor": "#f00",
                   "color": "#f00",
                 }
               }
@@ -339,6 +347,7 @@ exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
                 onMouseLeave={[Function]}
                 style={
                   Object {
+                    "backgroundColor": "#f00",
                     "color": "#f00",
                   }
                 }
@@ -411,6 +420,7 @@ exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
         selectedIconProps={Object {}}
         style={
           Object {
+            "backgroundColor": "#fff",
             "color": "#fff",
           }
         }
@@ -434,6 +444,7 @@ exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
               onMouseLeave={[Function]}
               style={
                 Object {
+                  "backgroundColor": "#fff",
                   "color": "#fff",
                 }
               }
@@ -450,6 +461,7 @@ exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
                 onMouseLeave={[Function]}
                 style={
                   Object {
+                    "backgroundColor": "#fff",
                     "color": "#fff",
                   }
                 }
@@ -467,6 +479,7 @@ exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
         selectedIconProps={Object {}}
         style={
           Object {
+            "backgroundColor": "#00f",
             "color": "#00f",
           }
         }
@@ -490,6 +503,7 @@ exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
               onMouseLeave={[Function]}
               style={
                 Object {
+                  "backgroundColor": "#00f",
                   "color": "#00f",
                 }
               }
@@ -506,6 +520,7 @@ exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
                 onMouseLeave={[Function]}
                 style={
                   Object {
+                    "backgroundColor": "#00f",
                     "color": "#00f",
                   }
                 }

--- a/packages/components/src/color-palette/test/__snapshots__/index.js.snap
+++ b/packages/components/src/color-palette/test/__snapshots__/index.js.snap
@@ -148,9 +148,6 @@ exports[`ColorPalette should allow disabling custom color picker 1`] = `
         selectedIconProps={
           Object {
             "fill": "#111111",
-            "style": Object {
-              "backgroundColor": "#f00",
-            },
           }
         }
         style={
@@ -246,9 +243,6 @@ exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
           selectedIconProps={
             Object {
               "fill": "#111111",
-              "style": Object {
-                "backgroundColor": "#f00",
-              },
             }
           }
           style={
@@ -299,9 +293,6 @@ exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
         selectedIconProps={
           Object {
             "fill": "#111111",
-            "style": Object {
-              "backgroundColor": "#f00",
-            },
           }
         }
         style={
@@ -367,20 +358,10 @@ exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
                 />
               </SVG>
             }
-            style={
-              Object {
-                "backgroundColor": "#f00",
-              }
-            }
           >
             <SVG
               fill="#111111"
               height={24}
-              style={
-                Object {
-                  "backgroundColor": "#f00",
-                }
-              }
               viewBox="-2 -2 24 24"
               width={24}
               xmlns="http://www.w3.org/2000/svg"
@@ -391,11 +372,6 @@ exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
                 focusable="false"
                 height={24}
                 role="img"
-                style={
-                  Object {
-                    "backgroundColor": "#f00",
-                  }
-                }
                 viewBox="-2 -2 24 24"
                 width={24}
                 xmlns="http://www.w3.org/2000/svg"

--- a/storybook/test/__snapshots__/index.js.snap
+++ b/storybook/test/__snapshots__/index.js.snap
@@ -1963,6 +1963,7 @@ exports[`Storyshots Components/ColorPalette Default 1`] = `
       onMouseLeave={[Function]}
       style={
         Object {
+          "backgroundColor": "#f00",
           "color": "#f00",
         }
       }
@@ -1984,6 +1985,7 @@ exports[`Storyshots Components/ColorPalette Default 1`] = `
       onMouseLeave={[Function]}
       style={
         Object {
+          "backgroundColor": "#fff",
           "color": "#fff",
         }
       }
@@ -2005,6 +2007,7 @@ exports[`Storyshots Components/ColorPalette Default 1`] = `
       onMouseLeave={[Function]}
       style={
         Object {
+          "backgroundColor": "#00f",
           "color": "#00f",
         }
       }
@@ -2057,6 +2060,7 @@ exports[`Storyshots Components/ColorPalette With Knobs 1`] = `
       onMouseLeave={[Function]}
       style={
         Object {
+          "backgroundColor": "#f00",
           "color": "#f00",
         }
       }
@@ -2078,6 +2082,7 @@ exports[`Storyshots Components/ColorPalette With Knobs 1`] = `
       onMouseLeave={[Function]}
       style={
         Object {
+          "backgroundColor": "#fff",
           "color": "#fff",
         }
       }
@@ -2099,6 +2104,7 @@ exports[`Storyshots Components/ColorPalette With Knobs 1`] = `
       onMouseLeave={[Function]}
       style={
         Object {
+          "backgroundColor": "#00f",
           "color": "#00f",
         }
       }


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

This would resolve #17332. Currently when selecting a color from the ColorPalette it can be hard to tell which color you have selected:

<img width="264" alt="64284216-11c04c00-cf27-11e9-8aaa-2dbbd4e3e398" src="https://user-images.githubusercontent.com/9020968/74609796-221e4a80-50b3-11ea-9030-a57ec2666e62.png">

This is especially true working with the Text Color format, which doesn't have the "Background Color" indicator that appears other places. 

This update adds a new `selectedIconProps` prop to the CircularOptionPicker. This allows extra props to be passed to the check icon that shows over the selected color. We then use this prop to pass down style overrides from the ColorPalette component. The style override uses the tinycolor `mostReadable` function to determine whether the icon should be white or dark gray.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Ran Jest tests, which passed when snapshots were updated. Tested locally in the browser using several components that use the ColorPalette, including the table block and pull quote block.

## Screenshots <!-- if applicable -->

After:

![color-picker](https://user-images.githubusercontent.com/9020968/74609894-33b42200-50b4-11ea-93b1-06de940a5676.gif)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

This is a backward-compatible improvement to the display of the color picker. 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
