### PR TITLE
Try: Show metaboxes peeking in even on tiny screens.

### DIFF
--- a/packages/e2e-tests/specs/editor/various/navigable-toolbar.test.js
+++ b/packages/e2e-tests/specs/editor/various/navigable-toolbar.test.js
@@ -50,11 +50,12 @@ describe.each( [
 	if ( ! isUnifiedToolbar ) {
 		it( 'should not scroll page', async () => {
 			while (
-				await page.evaluate(
-					() =>
-						wp.dom.getScrollContainer( document.activeElement )
-							.scrollTop === 0
-				)
+				await page.evaluate( () => {
+					const scrollable = wp.dom.getScrollContainer(
+						document.activeElement
+					);
+					return ! scrollable || scrollable.scrollTop === 0;
+				} )
 			) {
 				await page.keyboard.press( 'Enter' );
 			}

--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -27,7 +27,7 @@
 
 .edit-post-visual-editor .block-editor-writing-flow__click-redirect {
 	// Allow the page to be scrolled with the last block in the middle.
-	min-height: 50vh;
+	min-height: 40vh;
 	width: 100%;
 }
 


### PR DESCRIPTION
Fixes #19709.

19709 reports that if metaboxes are present on the page, on a new page they might be out of sight below the fold and therefore hard to find. 

The CSS to enable the editor to scale as it does is rather complicated and could use a greater refactor. For example, the div that is dedicated to `editor-styles-wrapper` is currently born with a hard coded top padding, which seems like something the theme should provide. Combine that with various flex rules, and there's an opportunity to make strides here. 

But the canvas is currently in the midst of a great deal of open heart surgery with DOM nodes being removed left and right, and lots of other block paddings being revisited in #18667 it really doesn't feel like the right time to rearrange those bits. 

In that vein, this PR does the smallest possible thing it can to fix the issue, which is to simply reduce the min-height of the click redirect. 

![Screenshot 2020-02-17 at 08 13 40](https://user-images.githubusercontent.com/1204802/74631790-205d9100-515e-11ea-8a15-c5f4d2130024.png)

If you make the viewport less tall than this, the left navigation sidebar will start to scroll. 