### PR TITLE
Scripts: Upgrade puppeteer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9625,6 +9625,12 @@
 			"integrity": "sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==",
 			"dev": true
 		},
+		"@types/mime-types": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.0.tgz",
+			"integrity": "sha1-nKUs2jY/aZxpRmwqbM2q2RPqenM=",
+			"dev": true
+		},
 		"@types/minimatch": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -11022,7 +11028,7 @@
 				"minimist": "^1.2.0",
 				"npm-package-json-lint": "^4.0.3",
 				"prettier": "npm:wp-prettier@1.19.1",
-				"puppeteer": "^2.0.0",
+				"puppeteer": "^2.1.1",
 				"read-pkg-up": "^1.0.1",
 				"request": "^2.88.0",
 				"resolve-bin": "^0.4.0",
@@ -32445,21 +32451,29 @@
 			"dev": true
 		},
 		"puppeteer": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-2.0.0.tgz",
-			"integrity": "sha512-t3MmTWzQxPRP71teU6l0jX47PHXlc4Z52sQv4LJQSZLq1ttkKS2yGM3gaI57uQwZkNaoGd0+HPPMELZkcyhlqA==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-2.1.1.tgz",
+			"integrity": "sha512-LWzaDVQkk1EPiuYeTOj+CZRIjda4k2s5w4MK4xoH2+kgWV/SDlkYHmxatDdtYrciHUKSXTsGgPgPP8ILVdBsxg==",
 			"dev": true,
 			"requires": {
+				"@types/mime-types": "^2.1.0",
 				"debug": "^4.1.0",
 				"extract-zip": "^1.6.6",
-				"https-proxy-agent": "^3.0.0",
+				"https-proxy-agent": "^4.0.0",
 				"mime": "^2.0.3",
+				"mime-types": "^2.1.25",
 				"progress": "^2.0.1",
 				"proxy-from-env": "^1.0.0",
 				"rimraf": "^2.6.1",
 				"ws": "^6.1.0"
 			},
 			"dependencies": {
+				"agent-base": {
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-5.1.1.tgz",
+					"integrity": "sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==",
+					"dev": true
+				},
 				"debug": {
 					"version": "4.1.1",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -32470,24 +32484,28 @@
 					}
 				},
 				"https-proxy-agent": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-3.0.1.tgz",
-					"integrity": "sha512-+ML2Rbh6DAuee7d07tYGEKOEi2voWPUGan+ExdPbPW6Z3svq+JCqr0v8WmKPOkz1vOVykPCBSuobe7G8GJUtVg==",
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz",
+					"integrity": "sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==",
 					"dev": true,
 					"requires": {
-						"agent-base": "^4.3.0",
-						"debug": "^3.1.0"
-					},
-					"dependencies": {
-						"debug": {
-							"version": "3.2.6",
-							"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-							"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-							"dev": true,
-							"requires": {
-								"ms": "^2.1.1"
-							}
-						}
+						"agent-base": "5",
+						"debug": "4"
+					}
+				},
+				"mime-db": {
+					"version": "1.43.0",
+					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
+					"integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ==",
+					"dev": true
+				},
+				"mime-types": {
+					"version": "2.1.26",
+					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
+					"integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
+					"dev": true,
+					"requires": {
+						"mime-db": "1.43.0"
 					}
 				},
 				"ms": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"config": {
-		"GUTENBERG_PHASE": 2
+		"GUTENBERG_PHASE": 2,
+		"puppeteer_chromium_revision": 706915
 	},
 	"dependencies": {
 		"@wordpress/a11y": "file:packages/a11y",

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Master
 
+### New Features
+
+- The bundled `puppeteer` dependency has been updated from requiring `^2.0.0` to requiring `^2.1.1` ([#20268](https://github.com/WordPress/gutenberg/pull/20268)). It still uses Chromium v79. See the [full list of changes](https://github.com/GoogleChrome/puppeteer/releases/tag/v2.1.0).
+
 ## 7.1.2 (2020-02-25)
 
 ### Bug Fixes

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -58,7 +58,7 @@
 		"minimist": "^1.2.0",
 		"npm-package-json-lint": "^4.0.3",
 		"prettier": "npm:wp-prettier@1.19.1",
-		"puppeteer": "^2.0.0",
+		"puppeteer": "^2.1.1",
 		"read-pkg-up": "^1.0.1",
 		"request": "^2.88.0",
 		"resolve-bin": "^0.4.0",


### PR DESCRIPTION
## Description
I have some trouble with upgrading Puppeteer in #20215 so I want to do it in smaller steps.

The bundled `puppeteer` dependency has been updated from requiring `^2.0.0` to requiring `^2.1.1`. It uses Chromium v80 instead of Chromium v79. See the [full list of changes](https://github.com/GoogleChrome/puppeteer/releases/tag/v2.1.0).
