### PR TITLE
Use user-specified defaults for image block, not constants

### DIFF
--- a/packages/block-library/src/image/constants.js
+++ b/packages/block-library/src/image/constants.js
@@ -5,4 +5,5 @@ export const LINK_DESTINATION_ATTACHMENT = 'attachment';
 export const LINK_DESTINATION_CUSTOM = 'custom';
 export const NEW_TAB_REL = [ 'noreferrer', 'noopener' ];
 export const ALLOWED_MEDIA_TYPES = [ 'image' ];
-export const DEFAULT_SIZE_SLUG = 'large';
+export const DEFAULT_SIZE_SLUG = 'large'; // use image_default_size from options
+export const DEFAULT_ALIGN_SLUG = 'center'; // use image_default_align from options


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

Asking you guys to use the user-specified defaults already in the database instead of constants

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Not tested at all - above my head.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

You guys broke the features we rely on to set the default align + image size

This is unbreaking it.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->

Nope.