### PR TITLE
Render the post comments form properly

### DIFF
--- a/packages/block-library/src/post-comments-form/index.php
+++ b/packages/block-library/src/post-comments-form/index.php
@@ -15,7 +15,11 @@ function render_block_core_post_comments_form() {
 	if ( ! $post ) {
 		return '';
 	}
-	return comment_form( array(), $post->ID );
+	ob_start();
+	comment_form( array(), $post->ID );
+	$form = ob_get_clean();
+
+	return $form;
 }
 
 /**


### PR DESCRIPTION
The comment_form php function outpus the HTML inline which means it doesn't get rendered properly when used as a block. This PR fixes by catching the output and outputting it to the right position.

**Testing instructions**

 - Add a "Post comment" block to your post
 - Make sure the form shows up at the right position in the frontend.