### PR TITLE
E2E tests: Block variations

### DIFF
--- a/packages/e2e-tests/plugins/block-variations.php
+++ b/packages/e2e-tests/plugins/block-variations.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Plugin Name: Gutenberg Test Block Variations
+ * Plugin URI: https://github.com/WordPress/gutenberg
+ * Author: Gutenberg Team
+ *
+ * @package gutenberg-test-block-variations
+ */
+
+/**
+ * Registers a custom script for the plugin.
+ */
+function enqueue_block_variations_plugin_script() {
+	wp_enqueue_script(
+		'gutenberg-test-block-variations',
+		plugins_url( 'block-variations/index.js', __FILE__ ),
+		array(
+			'wp-blocks',
+			'wp-element',
+			'wp-i18n',
+			'wp-primitives',
+		),
+		filemtime( plugin_dir_path( __FILE__ ) . 'block-variations/index.js' ),
+		true
+	);
+}
+
+add_action( 'init', 'enqueue_block_variations_plugin_script' );

--- a/packages/e2e-tests/plugins/block-variations/index.js
+++ b/packages/e2e-tests/plugins/block-variations/index.js
@@ -1,0 +1,69 @@
+( function() {
+	var el = wp.element.createElement;
+	var registerBlockVariation = wp.blocks.registerBlockVariation;
+	var __ = wp.i18n.__;
+	var Circle = wp.primitives.Circle;
+	var SVG = wp.primitives.SVG;
+
+	var redCircle = el( Circle, {
+		cx: 24,
+		cy: 24,
+		r: 15,
+		fill: 'red',
+		stroke: 'blue',
+		strokeWidth: '10',
+	} );
+	var redCircleIcon = el(
+		SVG,
+		{ width: 48, height: 48, viewBox: '0 0 48 48' },
+		redCircle
+	);
+
+	registerBlockVariation( 'core/quote', {
+		name: 'large',
+		title: 'Large Quote',
+		isDefault: true,
+		attributes: { className: 'is-style-large' },
+		icon: 'format-quote',
+		scope: [ 'inserter' ],
+	} );
+
+	registerBlockVariation( 'core/paragraph', {
+		name: 'success',
+		title: __( 'Success Message' ),
+		description:
+			'This block displays a success message. This description overrides the default one provided for the Paragraph block.',
+		attributes: {
+			content: 'This is a success message!',
+			backgroundColor: 'vivid-green-cyan',
+			dropCap: false,
+		},
+		icon: 'yes-alt',
+		scope: [ 'inserter' ],
+	} );
+
+	registerBlockVariation( 'core/paragraph', {
+		name: 'warning',
+		title: __( 'Warning Message' ),
+		attributes: {
+			content: 'This is a warning message!',
+			backgroundColor: 'luminous-vivid-amber',
+			dropCap: false,
+		},
+		icon: 'warning',
+		scope: [ 'inserter' ],
+	} );
+
+	registerBlockVariation( 'core/columns', {
+		name: 'four-columns',
+		title: 'Four columns',
+		innerBlocks: [
+			[ 'core/column' ],
+			[ 'core/column' ],
+			[ 'core/column' ],
+			[ 'core/column' ],
+		],
+		icon: redCircleIcon,
+		scope: [ 'block' ],
+	} );
+} )();

--- a/packages/e2e-tests/specs/editor/plugins/block-variations.js
+++ b/packages/e2e-tests/specs/editor/plugins/block-variations.js
@@ -1,0 +1,36 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	activatePlugin,
+	createNewPost,
+	deactivatePlugin,
+	insertBlock,
+	searchForBlock,
+} from '@wordpress/e2e-test-utils';
+
+describe( 'Block variations', () => {
+	beforeAll( async () => {
+		await activatePlugin( 'gutenberg-test-block-variations' );
+	} );
+
+	beforeEach( async () => {
+		await createNewPost();
+	} );
+
+	afterAll( async () => {
+		await deactivatePlugin( 'gutenberg-test-block-variations' );
+	} );
+
+	test( 'Search for the overriden default Quote block', () => {
+		searchForBlock( 'Quote' );
+	} );
+
+	test( 'Search for the Paragraph block with 2 additioanl variations', () => {
+		searchForBlock( 'Paragraph' );
+	} );
+
+	test( 'Insert the Columns block with additional variation in the picker', () => {
+		insertBlock( 'Columns' );
+	} );
+} );


### PR DESCRIPTION
## Description
Part of #16283.

This PR adds 5 new E2E tests that cover new block variations API. It includes a custom WordPress plugin that registers 3 sets of block variations:
1. Adds a variation that overrides the default Quote block type with a non-default style variation.
2. Adds two additional variations to the Paragraph block type with some custom initial attributes.
3. Adds additional variation to the Columns block that is rendered in the variation picker after the block is inserted in the editor. It means it's scoped to the block only.

## How has this been tested?
```bash
npm run test-e2e packages/e2e-tests/specs/editor/plugins/block-variations.js
```

## Types of changes
New e2e tests, no production changes.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
