### PR TITLE
Media: Fix flow for gallery creation and editing

### DIFF
--- a/packages/media-utils/src/components/media-upload/index.js
+++ b/packages/media-utils/src/components/media-upload/index.js
@@ -76,7 +76,7 @@ const getFeaturedImageMediaFrame = () => {
 /**
  * Prepares the Gallery toolbars and frames.
  *
- * @return {wp.media.view.MediaFrame.Select} The default media workflow.
+ * @return {wp.media.view.MediaFrame.Post} The default media workflow.
  */
 const getGalleryDetailsMediaFrame = () => {
 	/**

--- a/packages/media-utils/src/components/media-upload/index.js
+++ b/packages/media-utils/src/components/media-upload/index.js
@@ -86,7 +86,7 @@ const getGalleryDetailsMediaFrame = () => {
 	 * @class GalleryDetailsMediaFrame
 	 * @class
 	 */
-	return wp.media.view.MediaFrame.Select.extend( {
+	return wp.media.view.MediaFrame.Post.extend( {
 		/**
 		 * Set up gallery toolbar.
 		 *


### PR DESCRIPTION
## Description

See bug report at https://github.com/WordPress/gutenberg/pull/17641#issuecomment-587417201. An issue raised that Gallery flows skipped the edit gallery state and also added every image in the image library to the gallery. 😅

This PR restores the Post flow to the gallery frames so that we 1) restore the sidebar that is important to the edit gallery state. 2) Fix the issue where all images are added to the gallery. 

This PR also restores the ability to "add to gallery"