### PR TITLE
Make sure that all strong tags are removed from title.

### DIFF
--- a/packages/block-editor/src/components/block-list/block.native.js
+++ b/packages/block-editor/src/components/block-list/block.native.js
@@ -198,27 +198,27 @@ class BlockListBlock extends Component {
 		);
 
 		return (
-			<>
-				{ isSelected && (
-					<FloatingToolbar>
-						<Toolbar passedStyle={ styles.toolbar }>
-							<ToolbarButton
-								title={ __( 'Navigate Up' ) }
-								onClick={ () =>
-									this.props.onSelect( parentId )
-								}
-								icon={ NavigateUpSVG }
-							/>
-							<View style={ styles.pipe } />
-						</Toolbar>
-						<Breadcrumbs clientId={ clientId } />
-					</FloatingToolbar>
-				) }
-				<TouchableWithoutFeedback
-					onPress={ this.onFocus }
-					accessible={ ! isSelected }
-					accessibilityRole={ 'button' }
-				>
+			<TouchableWithoutFeedback
+				onPress={ this.onFocus }
+				accessible={ ! isSelected }
+				accessibilityRole={ 'button' }
+			>
+				<View accessibilityLabel={ accessibilityLabel }>
+					{ isSelected && (
+						<FloatingToolbar>
+							<Toolbar passedStyle={ styles.toolbar }>
+								<ToolbarButton
+									title={ __( 'Navigate Up' ) }
+									onClick={ () =>
+										this.props.onSelect( parentId )
+									}
+									icon={ NavigateUpSVG }
+								/>
+								<View style={ styles.pipe } />
+							</Toolbar>
+							<Breadcrumbs clientId={ clientId } />
+						</FloatingToolbar>
+					) }
 					<View
 						pointerEvents={ isTouchable ? 'auto' : 'box-only' }
 						accessibilityLabel={ accessibilityLabel }
@@ -238,8 +238,8 @@ class BlockListBlock extends Component {
 							) }
 						</View>
 					</View>
-				</TouchableWithoutFeedback>
-			</>
+				</View>
+			</TouchableWithoutFeedback>
 		);
 	}
 }

--- a/packages/editor/src/components/post-title/index.native.js
+++ b/packages/editor/src/components/post-title/index.native.js
@@ -101,7 +101,7 @@ class PostTitle extends Component {
 			>
 				<RichText
 					tagName={ 'p' }
-					rootTagsToEliminate={ [ 'strong' ] }
+					tagsToEliminate={ [ 'strong' ] }
 					unstableOnFocus={ this.props.onSelect }
 					onBlur={ this.props.onBlur } // always assign onBlur as a props
 					multiline={ false }


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

This change makes sure that any extra `strong` element tags added on the post-title are removed correctly. This could have happened because of the presence of emoji characters on the title that made the RichText native element to add extra `strong` elements around the emojis.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

This can be tested with this GB-mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1930

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
