### PR TITLE
Fix: Crash when updating a post with the latest post block

### DIFF
--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, isUndefined, pickBy } from 'lodash';
+import { get, invoke, isUndefined, pickBy } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -303,7 +303,11 @@ class LatestPostsEdit extends Component {
 					} ) }
 				>
 					{ displayPosts.map( ( post, i ) => {
-						const titleTrimmed = post.title.rendered.trim();
+						const titleTrimmed = invoke( post, [
+							'title',
+							'rendered',
+							'trim',
+						] );
 						let excerpt = post.excerpt.rendered;
 
 						const excerptElement = document.createElement( 'div' );


### PR DESCRIPTION
## Description
This PR fixes an issue where the latest post block crashed during a post update.


With this change we don't have a crash in the block.

## How has this been tested?
I created a new post with the title "Post title" and added the latest posts block to it.
I published the post and reloaded it in the editor.
I updated the post title and saved the post (I verified the latest post block did not crash, on master it crashes).