### PR TITLE
Lowercase block editor in the Welcome Guide to match core standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The block editor first became available in December 2018, and we're still hard a
 
 ## Getting Started
 
-Get hands on: check out the [Block Editor live demo](https://wordpress.org/gutenberg/) to play with a test instance of the editor.
+Get hands on: check out the [block editor live demo](https://wordpress.org/gutenberg/) to play with a test instance of the editor.
 
 ### Using Gutenberg
 

--- a/docs/designers-developers/designers/block-design.md
+++ b/docs/designers-developers/designers/block-design.md
@@ -54,7 +54,7 @@ In most cases, a block’s setup state is only shown once and then further custo
 
 ### Block Identification
 
-A block should have a straightforward, short name so users can easily find it in the Block Library. A block named "YouTube" is easy to find and understand. The same block, named "Embedded Video (YouTube)", would be less clear and harder to find in the Block Library.
+A block should have a straightforward, short name so users can easily find it in the block library. A block named "YouTube" is easy to find and understand. The same block, named "Embedded Video (YouTube)", would be less clear and harder to find in the block library.
 
 When referring to a block in documentation or UI, use title case for the block title and lowercase for the "block" descriptor. For example:
 
@@ -64,11 +64,11 @@ When referring to a block in documentation or UI, use title case for the block t
 
 Blocks should have an identifying icon, ideally using a single color. Try to avoid using the same icon used by an existing block. The core block icons are based on [Material Design Icons](https://material.io/tools/icons/). Look to that icon set, or to [Dashicons](https://developer.wordpress.org/resource/dashicons/) for style inspiration.
 
-![A screenshot of the Block Library with concise block names](https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/designers/assets/blocks-do.png)
+![A screenshot of the block library with concise block names](https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/designers/assets/blocks-do.png)
 **Do:**
 Use concise block names.
 
-![A screenshot of the Block Library with long, multi-line block names](https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/designers/assets/blocks-dont.png)
+![A screenshot of the block library with long, multi-line block names](https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/designers/assets/blocks-dont.png)
 **Don't:**
 Avoid long, multi-line block names.
 

--- a/packages/e2e-tests/specs/editor/various/nux.test.js
+++ b/packages/e2e-tests/specs/editor/various/nux.test.js
@@ -55,7 +55,7 @@ describe( 'New User Experience (NUX)', () => {
 		// Press the right arrow key for Page 3
 		await page.keyboard.press( 'ArrowRight' );
 		await page.waitForXPath(
-			'//h1[contains(text(), "Get to know the Block Library")]'
+			'//h1[contains(text(), "Get to know the block library")]'
 		);
 
 		// Press the right arrow key for Page 4

--- a/packages/e2e-tests/specs/editor/various/nux.test.js
+++ b/packages/e2e-tests/specs/editor/various/nux.test.js
@@ -15,7 +15,7 @@ describe( 'New User Experience (NUX)', () => {
 			'.edit-post-welcome-guide',
 			( element ) => element.innerText
 		);
-		expect( welcomeGuideText ).toContain( 'Welcome to the Block Editor' );
+		expect( welcomeGuideText ).toContain( 'Welcome to the block editor' );
 
 		// Click on the 'Next' button
 		const [ nextButton ] = await page.$x(
@@ -41,7 +41,7 @@ describe( 'New User Experience (NUX)', () => {
 			'.edit-post-welcome-guide',
 			( element ) => element.innerText
 		);
-		expect( welcomeGuideText ).toContain( 'Welcome to the Block Editor' );
+		expect( welcomeGuideText ).toContain( 'Welcome to the block editor' );
 
 		// Press the button for Page 2
 		await page.click( 'button[aria-label="Page 2 of 4"]' );
@@ -61,7 +61,7 @@ describe( 'New User Experience (NUX)', () => {
 		// Press the right arrow key for Page 4
 		await page.keyboard.press( 'ArrowRight' );
 		await page.waitForXPath(
-			'//h1[contains(text(), "Learn how to use the Block Editor")]'
+			'//h1[contains(text(), "Learn how to use the block editor")]'
 		);
 
 		// Click on the *visible* 'Get started' button. There are two in the DOM

--- a/packages/edit-post/src/components/welcome-guide/index.js
+++ b/packages/edit-post/src/components/welcome-guide/index.js
@@ -63,13 +63,13 @@ export default function WelcomeGuide() {
 
 			<GuidePage className="edit-post-welcome-guide__page">
 				<h1 className="edit-post-welcome-guide__heading">
-					{ __( 'Get to know the Block Library' ) }
+					{ __( 'Get to know the block library' ) }
 				</h1>
 				<BlockLibraryImage className="edit-post-welcome-guide__image" />
 				<p className="edit-post-welcome-guide__text">
 					{ __experimentalCreateInterpolateElement(
 						__(
-							'All of the blocks available to you live in the Block Library. You’ll find it wherever you see the <InserterIconImage /> icon.'
+							'All of the blocks available to you live in the block library. You’ll find it wherever you see the <InserterIconImage /> icon.'
 						),
 						{
 							InserterIconImage: (

--- a/packages/edit-post/src/components/welcome-guide/index.js
+++ b/packages/edit-post/src/components/welcome-guide/index.js
@@ -33,13 +33,13 @@ export default function WelcomeGuide() {
 	return (
 		<Guide
 			className="edit-post-welcome-guide"
-			contentLabel={ __( 'Welcome to the Block Editor' ) }
+			contentLabel={ __( 'Welcome to the block editor' ) }
 			finishButtonText={ __( 'Get started' ) }
 			onFinish={ () => toggleFeature( 'welcomeGuide' ) }
 		>
 			<GuidePage className="edit-post-welcome-guide__page">
 				<h1 className="edit-post-welcome-guide__heading">
-					{ __( 'Welcome to the Block Editor' ) }
+					{ __( 'Welcome to the block editor' ) }
 				</h1>
 				<CanvasImage className="edit-post-welcome-guide__image" />
 				<p className="edit-post-welcome-guide__text">
@@ -82,12 +82,12 @@ export default function WelcomeGuide() {
 
 			<GuidePage className="edit-post-welcome-guide__page">
 				<h1 className="edit-post-welcome-guide__heading">
-					{ __( 'Learn how to use the Block Editor' ) }
+					{ __( 'Learn how to use the block editor' ) }
 				</h1>
 				<DocumentationImage className="edit-post-welcome-guide__image" />
 				<p className="edit-post-welcome-guide__text">
 					{ __(
-						'New to the Block Editor? Want to learn more about using it? '
+						'New to the block editor? Want to learn more about using it? '
 					) }
 					<ExternalLink
 						href={ __(


### PR DESCRIPTION
## Description
Following #14205 and the core spelling Best Practice I've lowercased 'Block Editor' within the Welcome Guide.

## How has this been tested?
Manually checked this didn't break anything and updated the nux tests.

## Types of changes
Non-breaking text change.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
