### PR TITLE
Spacer block: fix background color for dark themes

### DIFF
--- a/packages/block-library/src/spacer/editor.scss
+++ b/packages/block-library/src/spacer/editor.scss
@@ -1,5 +1,9 @@
 .block-library-spacer__resize-container.is-selected {
 	background: $light-gray-200;
+
+	.is-dark-theme & {
+		background: $light-opacity-light-200;
+	}
 }
 
 .block-library-spacer__resize-container {


### PR DESCRIPTION
## Description
Fix spacer block background color in "selected" state:

#### Before
<img width="757" alt="Screenshot 2020-02-18 at 21 47 50" src="https://user-images.githubusercontent.com/87168/74772315-6880ce80-5298-11ea-9def-9a4ff90e6562.png">

#### After
<img width="600" alt="Screenshot 2020-02-18 at 21 47 15" src="https://user-images.githubusercontent.com/87168/74772306-661e7480-5298-11ea-83a7-b1b06acc3434.png">

Used the same background color as placeholder component has:

<img width="400" alt="image" src="https://user-images.githubusercontent.com/87168/74772525-d9c08180-5298-11ea-9aab-999c7b148e3b.png">


## How has this been tested?
- Install Gutenberg starter theme https://github.com/WordPress/gutenberg-starter-theme
- Switch to the dark mode from settings
- Add spacer, select it
- Observe eye-hurting white box be gone

## Screenshots <!-- if applicable -->

## Types of changes
Bugfix.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
