### PR TITLE
Try adding bundle size github action

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -1,0 +1,17 @@
+name: Compressed Size
+
+on: [pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2-beta
+      with:
+        fetch-depth: 1
+    - uses: preactjs/compressed-size-action@v1
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        pattern: "build/**/*.js"


### PR DESCRIPTION
Adds a Github action to compare the bundle size of the different packages between the PR branch and master.

Seems to work pretty well (see the comment here)