### PR TITLE
Enable verse block for mobile debug builds

### DIFF
--- a/packages/block-library/src/index.native.js
+++ b/packages/block-library/src/index.native.js
@@ -152,6 +152,7 @@ export const registerCoreBlocks = () => {
 		button,
 		spacer,
 		shortcode,
+		devOnly( verse ),
 	].forEach( registerBlock );
 
 	setDefaultBlockName( paragraph.name );


### PR DESCRIPTION
## Description
On mobile, this block will be only available on debug builds. There are [known issues being tracked](https://github.com/wordpress-mobile/gutenberg-mobile/issues/1886) with this block on mobile, including lack of proper styling and incorrect whitespace handling with rich text.

## How has this been tested?

- ✅ Create a verse block on web and verify it is displayed in the mobile Gutenberg editor
- ✅ Create a verse block on mobile and verify it is displayed in the web Gutenberg editor
- ✅ Add a verse block on mobile and verify key features of the verse block work as expected, e.g. soft line-breaks are allowed, arbitrary whitespace is saved as-is


## Screenshots <!-- if applicable -->

Here are some screenshots of the verse block running on the WordPress for iOS and Android apps.

| | Block Selection | Editor | Reader |
|--|--|--|--|
| iOS | <img width="150" src="https://user-images.githubusercontent.com/1898325/74868672-5dc84700-5335-11ea-8ea4-141da9547061.png"> | <img width="150" src="https://user-images.githubusercontent.com/1898325/74868685-61f46480-5335-11ea-9dec-cc40170d5acd.png"> | <img width="150" src="https://user-images.githubusercontent.com/1898325/74868700-6751af00-5335-11ea-97c1-0f8417fe0835.png"> |
| Android | <img width="150" src="https://user-images.githubusercontent.com/1898325/74868798-9831e400-5335-11ea-969b-e19180eef8e6.png"> | <img width="150" src="https://user-images.githubusercontent.com/1898325/74878098-645eba80-5345-11ea-88b1-acf637896b64.png"> | <img width="150" src="https://user-images.githubusercontent.com/1898325/74868804-9a943e00-5335-11ea-9f13-c4906a1e7954.png"> |


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
