### PR TITLE
Blocks: Support implicit attributes and test them for `useColors`.

### DIFF
--- a/packages/block-editor/src/components/colors/use-colors.js
+++ b/packages/block-editor/src/components/colors/use-colors.js
@@ -17,6 +17,7 @@ import {
 	Children,
 	cloneElement,
 	useState,
+	INTERNALS,
 } from '@wordpress/element';
 
 /**
@@ -137,6 +138,16 @@ export default function __experimentalUseColors(
 	},
 	deps = []
 ) {
+	if ( INTERNALS.useImplicitAttributes ) {
+		INTERNALS.useImplicitAttributes(
+			colorConfigs.reduce( ( acc, { name } ) => {
+				acc[ name ] = { type: 'string' };
+				acc[ camelCase( `custom ${ name }` ) ] = { type: 'string' };
+				return acc;
+			}, {} )
+		);
+	}
+
 	const { clientId } = useBlockEditContext();
 	const { attributes, settingsColors } = useSelect(
 		( select ) => {

--- a/packages/block-library/src/paragraph/block.json
+++ b/packages/block-library/src/paragraph/block.json
@@ -18,18 +18,6 @@
 		"placeholder": {
 			"type": "string"
 		},
-		"textColor": {
-			"type": "string"
-		},
-		"customTextColor": {
-			"type": "string"
-		},
-		"backgroundColor": {
-			"type": "string"
-		},
-		"customBackgroundColor": {
-			"type": "string"
-		},
 		"fontSize": {
 			"type": "string"
 		},

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -15,7 +15,11 @@ import { blockDefault } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import { isValidIcon, normalizeIconObject } from './utils';
+import {
+	isValidIcon,
+	normalizeIconObject,
+	addImplicitAttributes,
+} from './utils';
 import { DEPRECATED_ENTRY_KEYS } from './constants';
 
 /**
@@ -244,6 +248,11 @@ export function registerBlockType( name, settings ) {
 		);
 		return;
 	}
+
+	settings.attributes = addImplicitAttributes(
+		settings.edit,
+		settings.attributes
+	);
 
 	dispatch( 'core/blocks' ).addBlockTypes( settings );
 

--- a/packages/element/README.md
+++ b/packages/element/README.md
@@ -188,6 +188,12 @@ _Returns_
 
 A component which renders its children without any wrapping element.
 
+<a name="INTERNALS" href="#INTERNALS">#</a> **INTERNALS**
+
+_Related_
+
+-   <https://github.com/facebook/react/blob/master/packages/react/src/ReactSharedInternals.js>
+
 <a name="isEmptyElement" href="#isEmptyElement">#</a> **isEmptyElement**
 
 Checks if the provided WP element is empty.

--- a/packages/element/src/react.js
+++ b/packages/element/src/react.js
@@ -25,6 +25,7 @@ import {
 	useDebugValue,
 	lazy,
 	Suspense,
+	__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED as INTERNALS,
 } from 'react';
 import { isString } from 'lodash';
 
@@ -194,6 +195,11 @@ export { lazy };
  * @see https://reactjs.org/docs/react-api.html#reactsuspense
  */
 export { Suspense };
+
+/**
+ * @see https://github.com/facebook/react/blob/master/packages/react/src/ReactSharedInternals.js
+ */
+export { INTERNALS };
 
 /**
  * Concatenate two or more React children objects.


### PR DESCRIPTION
## Description

Gutenberg provides tools for block authors to quickly implement [Common Block Functionality](https://github.com/WordPress/gutenberg/pull/15450).

An example of this is `useColors` for arbitrary color picking and application.

Most of these tools persist data in the form of new block attributes, which forces developers to add to their block definitions manually.

This PR explores the idea of implicit attributes and leverages them inside `useColors` to dynamically resolve the new block attribute definitions during block registration.

It does this by monkey patching the React dispatcher to be able to render functional components with hooks to strings (this might also be useful for our block serialization implementation, which currently does not support hooks in block `save` functions). It then injects an internal hook, `useImplicitAttributes`, for common block tools or third party custom hooks to register additional attributes during a block's registration. Then it sets everything back to normal before continuing as usual.

It's worth noting that errors are swallowed to avoid potential breakage with blocks that do strange things or depend on context. We can continue to refine the approach as we see run into these edge cases, but blocks can always register attributes explicitly to be safe.

## How has this been tested?

It was verified that the paragraph block is still being registered with all color attributes even though they are no longer in its `block.json` file.

## Types of Changes

*New Feature:* A new API for implicit attributes allows for custom hooks to automatically add attributes to a block's type.

## Checklist:

- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->