### PR TITLE
[LatestPosts] Fixes the excerpt length

### DIFF
--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -5,8 +5,21 @@
  * @package WordPress
  */
 
+/**
+ * The excerpt length set by the Latest Posts core block
+ * set at render time and used by the block itself.
+ *
+ * @var int
+ */
 $block_core_latest_posts_excerpt = 0;
 
+/**
+ * Callback for the excerpt_length filter used by
+ * the Latest Posts block at render time.
+ *
+ * @return int Returns the global $block_core_latest_posts_excerpt variable
+ *             to allow the excerpt_length filter respect the Latest Block setting.
+ */
 function get_block_core_latest_posts_excerpt() {
 	global $block_core_latest_posts_excerpt;
 	return $block_core_latest_posts_excerpt;

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -44,7 +44,7 @@ function render_block_core_latest_posts( $attributes ) {
 	);
 
 	$block_core_latest_posts_excerpt_length = $attributes['excerptLength'];
-	add_filter( 'excerpt_length', 'block_core_latest_posts_get_excerpt_length', 999 );
+	add_filter( 'excerpt_length', 'block_core_latest_posts_get_excerpt_length', 20 );
 
 	if ( isset( $attributes['categories'] ) ) {
 		$args['category'] = $attributes['categories'];
@@ -136,7 +136,7 @@ function render_block_core_latest_posts( $attributes ) {
 		$list_items_markup .= "</li>\n";
 	}
 
-	remove_filter( 'excerpt_length', 'block_core_latest_posts_get_excerpt_length', 999 );
+	remove_filter( 'excerpt_length', 'block_core_latest_posts_get_excerpt_length', 20 );
 
 	$class = 'wp-block-latest-posts wp-block-latest-posts__list';
 	if ( isset( $attributes['align'] ) ) {

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -5,6 +5,13 @@
  * @package WordPress
  */
 
+$block_core_latest_posts_excerpt = 0;
+
+function get_block_core_latest_posts_excerpt() {
+	global $block_core_latest_posts_excerpt;
+	return $block_core_latest_posts_excerpt;
+}
+
 /**
  * Renders the `core/latest-posts` block on server.
  *
@@ -13,6 +20,8 @@
  * @return string Returns the post content with latest posts added.
  */
 function render_block_core_latest_posts( $attributes ) {
+	global $block_core_latest_posts_excerpt;
+
 	$args = array(
 		'posts_per_page'   => $attributes['postsToShow'],
 		'post_status'      => 'publish',
@@ -21,11 +30,8 @@ function render_block_core_latest_posts( $attributes ) {
 		'suppress_filters' => false,
 	);
 
-	$excerpt_length        = $attributes['excerptLength'];
-	$excerpt_length_filter = function ( $length ) use ( $excerpt_length ) {
-		return $excerpt_length;
-	};
-	add_filter( 'excerpt_length', $excerpt_length_filter, 999 );
+	$block_core_latest_posts_excerpt = $attributes['excerptLength'];
+	add_filter( 'excerpt_length', 'get_block_core_latest_posts_excerpt', 999 );
 
 	if ( isset( $attributes['categories'] ) ) {
 		$args['category'] = $attributes['categories'];
@@ -116,6 +122,8 @@ function render_block_core_latest_posts( $attributes ) {
 
 		$list_items_markup .= "</li>\n";
 	}
+
+	remove_filter( 'excerpt_length', 'get_block_core_latest_posts_excerpt', 999 );
 
 	$class = 'wp-block-latest-posts wp-block-latest-posts__list';
 	if ( isset( $attributes['align'] ) ) {

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -11,18 +11,18 @@
  *
  * @var int
  */
-$block_core_latest_posts_excerpt = 0;
+$block_core_latest_posts_excerpt_length = 0;
 
 /**
  * Callback for the excerpt_length filter used by
  * the Latest Posts block at render time.
  *
- * @return int Returns the global $block_core_latest_posts_excerpt variable
+ * @return int Returns the global $block_core_latest_posts_excerpt_length variable
  *             to allow the excerpt_length filter respect the Latest Block setting.
  */
-function get_block_core_latest_posts_excerpt() {
-	global $block_core_latest_posts_excerpt;
-	return $block_core_latest_posts_excerpt;
+function block_core_latest_posts_get_excerpt_length() {
+	global $block_core_latest_posts_excerpt_length;
+	return $block_core_latest_posts_excerpt_length;
 }
 
 /**
@@ -33,7 +33,7 @@ function get_block_core_latest_posts_excerpt() {
  * @return string Returns the post content with latest posts added.
  */
 function render_block_core_latest_posts( $attributes ) {
-	global $block_core_latest_posts_excerpt;
+	global $block_core_latest_posts_excerpt_length;
 
 	$args = array(
 		'posts_per_page'   => $attributes['postsToShow'],
@@ -43,8 +43,8 @@ function render_block_core_latest_posts( $attributes ) {
 		'suppress_filters' => false,
 	);
 
-	$block_core_latest_posts_excerpt = $attributes['excerptLength'];
-	add_filter( 'excerpt_length', 'get_block_core_latest_posts_excerpt', 999 );
+	$block_core_latest_posts_excerpt_length = $attributes['excerptLength'];
+	add_filter( 'excerpt_length', 'block_core_latest_posts_get_excerpt_length', 999 );
 
 	if ( isset( $attributes['categories'] ) ) {
 		$args['category'] = $attributes['categories'];
@@ -136,7 +136,7 @@ function render_block_core_latest_posts( $attributes ) {
 		$list_items_markup .= "</li>\n";
 	}
 
-	remove_filter( 'excerpt_length', 'get_block_core_latest_posts_excerpt', 999 );
+	remove_filter( 'excerpt_length', 'block_core_latest_posts_get_excerpt_length', 999 );
 
 	$class = 'wp-block-latest-posts wp-block-latest-posts__list';
 	if ( isset( $attributes['align'] ) ) {

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -5,6 +5,25 @@
  * @package WordPress
  */
 
+/**
+ * The excerpt length set by the Latest Posts core block
+ * set at render time and used by the block itself.
+ *
+ * @var int
+ */
+$block_core_latest_posts_excerpt = 0;
+
+/**
+ * Callback for the excerpt_length filter used by
+ * the Latest Posts block at render time.
+ *
+ * @return int Returns the global $block_core_latest_posts_excerpt variable
+ *             to allow the excerpt_length filter respect the Latest Block setting.
+ */
+function get_block_core_latest_posts_excerpt() {
+	global $block_core_latest_posts_excerpt;
+	return $block_core_latest_posts_excerpt;
+}
 
 /**
  * Renders the `core/latest-posts` block on server.
@@ -14,6 +33,7 @@
  * @return string Returns the post content with latest posts added.
  */
 function render_block_core_latest_posts( $attributes ) {
+	global $block_core_latest_posts_excerpt;
 
 	$args = array(
 		'posts_per_page'   => $attributes['postsToShow'],
@@ -23,21 +43,8 @@ function render_block_core_latest_posts( $attributes ) {
 		'suppress_filters' => false,
 	);
 
-	/**
-	* Callback for the excerpt_length filter used by
-	* the Latest Posts block at render time.
-	*
-	* @return int Returns the $length variable
-	*             to allow the excerpt_length filter respect the Latest Block setting.
-	*/
-	$block_core_latest_posts_excerpt_length = function( $length ) use ( $attributes ) {
-		if ( ! empty( $attributes['excerptLength'] ) ) {
-			return $attributes['excerptLength'];
-		}
-		return $length;
-	};
-
-	add_filter( 'excerpt_length', $block_core_latest_posts_excerpt_length, 999 );
+	$block_core_latest_posts_excerpt = $attributes['excerptLength'];
+	add_filter( 'excerpt_length', 'get_block_core_latest_posts_excerpt', 999 );
 
 	if ( isset( $attributes['categories'] ) ) {
 		$args['category'] = $attributes['categories'];
@@ -129,7 +136,7 @@ function render_block_core_latest_posts( $attributes ) {
 		$list_items_markup .= "</li>\n";
 	}
 
-	remove_filter( 'excerpt_length', $block_core_latest_posts_excerpt_length );
+	remove_filter( 'excerpt_length', 'get_block_core_latest_posts_excerpt', 999 );
 
 	$class = 'wp-block-latest-posts wp-block-latest-posts__list';
 	if ( isset( $attributes['align'] ) ) {

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -21,6 +21,12 @@ function render_block_core_latest_posts( $attributes ) {
 		'suppress_filters' => false,
 	);
 
+	$excerpt_length        = $attributes['excerptLength'];
+	$excerpt_length_filter = function ( $length ) use ( $excerpt_length ) {
+		return $excerpt_length;
+	};
+	add_filter( 'excerpt_length', $excerpt_length_filter, 999 );
+
 	if ( isset( $attributes['categories'] ) ) {
 		$args['category'] = $attributes['categories'];
 	}


### PR DESCRIPTION
## Description
Closes #20311

It is a bug introduced by #19669

## How has this been tested?
Tested locally by:

- add a post
- add a latest posts block
- set the block to show excerpt
- set the limit of excerpt words to be 10
- save the post
- check that the rendering does not exceed 10 words in the excerpt

## Types of changes
Introduces an excerpt_length filter in the `LatestPosts` block.
