### PR TITLE
Add storybook story to the Tooltip component

### DIFF
--- a/packages/components/src/tooltip/README.md
+++ b/packages/components/src/tooltip/README.md
@@ -9,13 +9,13 @@ Accessibility note: the tooltip text is hidden from screen readers and assistive
 Render a Tooltip, passing as a child the element to which it should anchor:
 
 ```jsx
-import { Tooltip, Button } from '@wordpress/components';
+import { Tooltip } from '@wordpress/components';
 
 const MyTooltip = () => (
 	<Tooltip text="More information">
-		<Button isSecondary>
+		<div>
 			Hover for more information
-		</Button>
+		</div>
 	</Tooltip>
 );
 ```

--- a/packages/components/src/tooltip/stories/index.js
+++ b/packages/components/src/tooltip/stories/index.js
@@ -1,0 +1,24 @@
+/**
+ * External dependencies
+ */
+import { text } from '@storybook/addon-knobs';
+
+/**
+ * Internal dependencies
+ */
+import Tooltip from '../';
+import Button from '../../button';
+
+export default {
+	title: 'Components/ToolTip',
+	component: Tooltip,
+};
+
+export const _default = () => {
+	const tooltipText = text( 'Text', 'More information' );
+	return (
+		<Tooltip text={ tooltipText }>
+			<Button isSecondary>Hover for more information</Button>
+		</Tooltip>
+	);
+};

--- a/packages/components/src/tooltip/stories/index.js
+++ b/packages/components/src/tooltip/stories/index.js
@@ -1,13 +1,12 @@
 /**
  * External dependencies
  */
-import { text } from '@storybook/addon-knobs';
+import { text, select } from '@storybook/addon-knobs';
 
 /**
  * Internal dependencies
  */
 import Tooltip from '../';
-import Button from '../../button';
 
 export default {
 	title: 'Components/ToolTip',
@@ -18,7 +17,40 @@ export const _default = () => {
 	const tooltipText = text( 'Text', 'More information' );
 	return (
 		<Tooltip text={ tooltipText }>
-			<Button isSecondary>Hover for more information</Button>
+			<div
+				style={ {
+					margin: '100px',
+					textAlign: 'center',
+					border: '1px solid #ccc',
+				} }
+			>
+				Hover for more information
+			</div>
+		</Tooltip>
+	);
+};
+export const withPosition = () => {
+	const positionOptions = {
+		'top left': 'top left',
+		'top center ': 'top center',
+		'top right': 'top right',
+		'bottom left': 'bottom left',
+		'bottom center ': 'bottom center',
+		'bottom right': 'bottom right',
+	};
+	const tooltipText = text( 'Text', 'More information' );
+	const position = select( 'Position', positionOptions, 'top center' );
+	return (
+		<Tooltip text={ tooltipText } position={ position }>
+			<div
+				style={ {
+					margin: '100px',
+					textAlign: 'center',
+					border: '1px solid #ccc',
+				} }
+			>
+				Hover for more information
+			</div>
 		</Tooltip>
 	);
 };

--- a/packages/components/src/tooltip/stories/index.js
+++ b/packages/components/src/tooltip/stories/index.js
@@ -14,22 +14,6 @@ export default {
 };
 
 export const _default = () => {
-	const tooltipText = text( 'Text', 'More information' );
-	return (
-		<Tooltip text={ tooltipText }>
-			<div
-				style={ {
-					margin: '100px',
-					textAlign: 'center',
-					border: '1px solid #ccc',
-				} }
-			>
-				Hover for more information
-			</div>
-		</Tooltip>
-	);
-};
-export const withPosition = () => {
 	const positionOptions = {
 		'top left': 'top left',
 		'top center ': 'top center',
@@ -44,7 +28,9 @@ export const withPosition = () => {
 		<Tooltip text={ tooltipText } position={ position }>
 			<div
 				style={ {
-					margin: '100px',
+					margin: '50px auto',
+					width: '200px',
+					padding: '20px',
 					textAlign: 'center',
 					border: '1px solid #ccc',
 				} }

--- a/storybook/test/__snapshots__/index.js.snap
+++ b/storybook/test/__snapshots__/index.js.snap
@@ -8120,6 +8120,28 @@ exports[`Storyshots Components/ToggleControl With Help Text 1`] = `
 </div>
 `;
 
+exports[`Storyshots Components/ToolTip Default 1`] = `
+<div
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onMouseDown={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+  style={
+    Object {
+      "border": "1px solid #ccc",
+      "margin": "50px auto",
+      "padding": "20px",
+      "textAlign": "center",
+      "width": "200px",
+    }
+  }
+>
+  Hover for more information
+</div>
+`;
+
 exports[`Storyshots Components/Toolbar Default 1`] = `
 <div
   aria-label="Options"


### PR DESCRIPTION
## Description
Add a story for the tooltip component

## How has this been tested?
Run storybook and see the new tooltip option under the Components section

## Screenshots
![Fullscreen_2_19_20__8_23_PM](https://user-images.githubusercontent.com/6653970/74891918-3c2b8780-5356-11ea-8535-95ec954aa69c.png)

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
