### PR TITLE
Dependencies webpack plugin: Add new option to combine assets files into one file

### DIFF
--- a/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
+++ b/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Master
+
+### New Features
+
+- The plugin now supports optional `combineAssets` options. When this flag is set to `true`, all information about assets is combined into a single `assets.(json|php)` file generated in the output directory ([#20330](https://github.com/WordPress/gutenberg/pull/20330)).
+
 ## 2.0.0 (2019-09-16)
 
 ### Breaking Changes

--- a/packages/dependency-extraction-webpack-plugin/README.md
+++ b/packages/dependency-extraction-webpack-plugin/README.md
@@ -116,6 +116,13 @@ module.exports = {
 
 The output format for the generated asset file. There are two options available: 'php' or 'json'.
 
+##### `combineAssets`
+
+- Type: boolean
+- Default: `false`
+
+By default, one asset file is created for each entry point. When this flag is set to `true`, all information about assets is combined into a single `assets.(json|php)` file generated in the output directory.
+
 ##### `useDefaults`
 
 - Type: boolean
@@ -217,7 +224,7 @@ Enqueue your script as usual and read the script dependencies dynamically:
 $script_path       = 'path/to/script.js';
 $script_asset_path = 'path/to/script.asset.php';
 $script_asset      = file_exists( $script_asset_path )
-	? require( $script_asset_path ) 
+	? require( $script_asset_path )
 	: array( 'dependencies' => array(), 'version' => filemtime( $script_path ) );
 $script_url = plugins_url( $script_path, __FILE__ );
 wp_enqueue_script( 'script', $script_url, $script_asset['dependencies'], $script_asset['version'] );

--- a/packages/dependency-extraction-webpack-plugin/index.js
+++ b/packages/dependency-extraction-webpack-plugin/index.js
@@ -3,6 +3,7 @@
  */
 const { createHash } = require( 'crypto' );
 const json2php = require( 'json2php' );
+const path = require( 'path' );
 const { ExternalsPlugin } = require( 'webpack' );
 const { RawSource } = require( 'webpack-sources' );
 
@@ -18,6 +19,7 @@ class DependencyExtractionWebpackPlugin {
 	constructor( options ) {
 		this.options = Object.assign(
 			{
+				combineAssets: false,
 				injectPolyfill: false,
 				outputFormat: 'php',
 				useDefaults: true,
@@ -102,7 +104,12 @@ class DependencyExtractionWebpackPlugin {
 		const { filename: outputFilename } = output;
 
 		compiler.hooks.emit.tap( this.constructor.name, ( compilation ) => {
-			const { injectPolyfill, outputFormat } = this.options;
+			const {
+				combineAssets,
+				injectPolyfill,
+				outputFormat,
+			} = this.options;
+			const combinedAssetsData = {};
 
 			// Process each entry point independently.
 			for ( const [
@@ -130,36 +137,60 @@ class DependencyExtractionWebpackPlugin {
 
 				const runtimeChunk = entrypoint.getRuntimeChunk();
 
-				// Get a stable, stringified representation of the WordPress script asset.
-				const assetString = this.stringify( {
+				const assetData = {
 					dependencies: Array.from(
 						entrypointExternalizedWpDeps
 					).sort(),
 					version: runtimeChunk.hash,
-				} );
+				};
+
+				// Get a stable, stringified representation of the WordPress script asset.
+				const assetString = this.stringify( assetData );
 
 				// Determine a filename for the asset file.
 				const [ filename, query ] = entrypointName.split( '?', 2 );
-				const assetFilename = compilation
-					.getPath( outputFilename, {
-						chunk: runtimeChunk,
-						filename,
-						query,
-						basename: basename( filename ),
-						contentHash: createHash( 'md4' )
-							.update( assetString )
-							.digest( 'hex' ),
-					} )
-					.replace(
-						/\.js$/i,
-						'.asset.' + ( outputFormat === 'php' ? 'php' : 'json' )
-					);
+				const buildFilename = compilation.getPath( outputFilename, {
+					chunk: runtimeChunk,
+					filename,
+					query,
+					basename: basename( filename ),
+					contentHash: createHash( 'md4' )
+						.update( assetString )
+						.digest( 'hex' ),
+				} );
+
+				if ( combineAssets ) {
+					combinedAssetsData[ buildFilename ] = assetData;
+					continue;
+				}
+
+				const assetFilename = buildFilename.replace(
+					/\.js$/i,
+					'.asset.' + ( outputFormat === 'php' ? 'php' : 'json' )
+				);
 
 				// Add source and file into compilation for webpack to output.
 				compilation.assets[ assetFilename ] = new RawSource(
 					assetString
 				);
 				runtimeChunk.files.push( assetFilename );
+			}
+
+			if ( combineAssets ) {
+				const outputFolder = compiler.options.output.path;
+				const assetsFilePath = path.resolve(
+					outputFolder,
+					'assets.' + ( outputFormat === 'php' ? 'php' : 'json' )
+				);
+				const assetsFilename = path.relative(
+					outputFolder,
+					assetsFilePath
+				);
+
+				// Add source into compilation for webpack to output.
+				compilation.assets[ assetsFilename ] = new RawSource(
+					this.stringify( combinedAssetsData )
+				);
 			}
 		} );
 	}

--- a/packages/dependency-extraction-webpack-plugin/index.js
+++ b/packages/dependency-extraction-webpack-plugin/index.js
@@ -138,13 +138,13 @@ class DependencyExtractionWebpackPlugin {
 				const runtimeChunk = entrypoint.getRuntimeChunk();
 
 				const assetData = {
+					// Get a sorted array so we can produce a stable, stringified representation.
 					dependencies: Array.from(
 						entrypointExternalizedWpDeps
 					).sort(),
 					version: runtimeChunk.hash,
 				};
 
-				// Get a stable, stringified representation of the WordPress script asset.
 				const assetString = this.stringify( assetData );
 
 				// Determine a filename for the asset file.

--- a/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
+++ b/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
@@ -1,5 +1,39 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Webpack \`combine-assets\` should produce expected output: Asset file should match snapshot 1`] = `"<?php return array('fileA.js' => array('dependencies' => array('lodash', 'wp-blob'), 'version' => '2ac177723ec97b400d9b7c46f5270974'), 'fileB.js' => array('dependencies' => array('wp-token-list'), 'version' => 'bddb08fb8608759738528b9de111454d'));"`;
+
+exports[`Webpack \`combine-assets\` should produce expected output: External modules should match snapshot 1`] = `
+Array [
+  Object {
+    "externalType": "this",
+    "request": Object {
+      "this": Array [
+        "wp",
+        "blob",
+      ],
+    },
+    "userRequest": "@wordpress/blob",
+  },
+  Object {
+    "externalType": "this",
+    "request": Object {
+      "this": Array [
+        "wp",
+        "tokenList",
+      ],
+    },
+    "userRequest": "@wordpress/token-list",
+  },
+  Object {
+    "externalType": "this",
+    "request": Object {
+      "this": "lodash",
+    },
+    "userRequest": "lodash",
+  },
+]
+`;
+
 exports[`Webpack \`dynamic-import\` should produce expected output: Asset file should match snapshot 1`] = `"<?php return array('dependencies' => array('lodash', 'wp-blob'), 'version' => '5d8e58fe98bc4c6277a76ece11fcb8b7');"`;
 
 exports[`Webpack \`dynamic-import\` should produce expected output: External modules should match snapshot 1`] = `

--- a/packages/dependency-extraction-webpack-plugin/test/build.js
+++ b/packages/dependency-extraction-webpack-plugin/test/build.js
@@ -46,14 +46,21 @@ describe.each( configFixtures )( 'Webpack `%s`', ( configCase ) => {
 			webpack( options, ( err, stats ) => {
 				expect( err ).toBeNull();
 
-				const assetFiles = glob(
-					`${ outputDirectory }/*.asset.@(json|php)`
+				let assetFiles = glob(
+					`${ outputDirectory }/assets.@(json|php)`
 				);
-				const expectedLength =
-					typeof options.entry === 'object'
-						? Object.keys( options.entry ).length
-						: 1;
-				expect( assetFiles ).toHaveLength( expectedLength );
+				if ( assetFiles.length > 0 ) {
+					expect( assetFiles ).toHaveLength( 1 );
+				} else {
+					assetFiles = glob(
+						`${ outputDirectory }/*.asset.@(json|php)`
+					);
+					const expectedLength =
+						typeof options.entry === 'object'
+							? Object.keys( options.entry ).length
+							: 1;
+					expect( assetFiles ).toHaveLength( expectedLength );
+				}
 
 				// Asset files should match.
 				assetFiles.forEach( ( assetFile ) => {

--- a/packages/dependency-extraction-webpack-plugin/test/build.js
+++ b/packages/dependency-extraction-webpack-plugin/test/build.js
@@ -46,21 +46,18 @@ describe.each( configFixtures )( 'Webpack `%s`', ( configCase ) => {
 			webpack( options, ( err, stats ) => {
 				expect( err ).toBeNull();
 
-				let assetFiles = glob(
-					`${ outputDirectory }/assets.@(json|php)`
+				const assetFiles = glob(
+					`${ outputDirectory }/+(*.asset|assets).@(json|php)`
 				);
-				if ( assetFiles.length > 0 ) {
-					expect( assetFiles ).toHaveLength( 1 );
-				} else {
-					assetFiles = glob(
-						`${ outputDirectory }/*.asset.@(json|php)`
-					);
-					const expectedLength =
-						typeof options.entry === 'object'
-							? Object.keys( options.entry ).length
-							: 1;
-					expect( assetFiles ).toHaveLength( expectedLength );
-				}
+				const hasCombinedAssets = ( options.plugins || [] ).some(
+					( plugin ) => !! ( plugin.options || {} ).combineAssets
+				);
+				const entrypointCount =
+					typeof options.entry === 'object'
+						? Object.keys( options.entry ).length
+						: 1;
+				const expectedLength = hasCombinedAssets ? 1 : entrypointCount;
+				expect( assetFiles ).toHaveLength( expectedLength );
 
 				// Asset files should match.
 				assetFiles.forEach( ( assetFile ) => {

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/combine-assets/file-a.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/combine-assets/file-a.js
@@ -1,0 +1,11 @@
+/**
+ * External dependencies
+ */
+import { isEmpty } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { isBlobURL } from '@wordpress/blob';
+
+isEmpty( isBlobURL( '' ) );

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/combine-assets/file-b.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/combine-assets/file-b.js
@@ -1,0 +1,9 @@
+/**
+ * WordPress dependencies
+ */
+import TokenList from '@wordpress/token-list';
+
+const tokens = new TokenList( 'abc def' );
+tokens.add( 'ghi' );
+tokens.remove( 'def' );
+tokens.replace( 'abc', 'xyz' );

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/combine-assets/webpack.config.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/combine-assets/webpack.config.js
@@ -1,0 +1,13 @@
+const DependencyExtractionWebpackPlugin = require( '../../..' );
+
+module.exports = {
+	entry: {
+		fileA: './file-a.js',
+		fileB: './file-b.js',
+	},
+	plugins: [
+		new DependencyExtractionWebpackPlugin( {
+			combineAssets: true,
+		} ),
+	],
+};


### PR DESCRIPTION
## Description

By default, one asset file is created for each entry point. When the new `combineAssets` flag is set to `true`, all information about assets is combined into a single `assets.(json|php)` file generated in the output directory.

The single `assets.php` file generated with the new flag enabled for Gutenberg looks like follow:

```php
<?php return array('./build/a11y/index.js' => array('dependencies' => array('wp-dom-ready', 'wp-polyfill'), 'version' => 'd0323101e5a462180d070032eaeae6e6'), './build/annotations/index.js' => array('dependencies' => array('lodash', 'wp-data', 'wp-hooks', 'wp-i18n', 'wp-polyfill', 'wp-rich-text'), 'version' => '2aa0c8e06a8cd11915aaa983fb78817e'), './build/api-fetch/index.js' => array('dependencies' => array('wp-i18n', 'wp-polyfill', 'wp-url'), 'version' => 'c0be210b78663d966e22e12a356cb130'), './build/autop/index.js' => array('dependencies' => array('wp-polyfill'), 'version' => '8e0a87c15a4422a90e3a0e2be573ce92'), './build/blob/index.js' => array('dependencies' => array('wp-polyfill'), 'version' => 'e38a5045702b58d3c22eab8bad2f0478'), './build/block-directory/index.js' => array('dependencies' => array('lodash', 'wp-api-fetch', 'wp-block-editor', 'wp-blocks', 'wp-components', 'wp-compose', 'wp-data', 'wp-element', 'wp-i18n', 'wp-plugins', 'wp-polyfill', 'wp-primitives'), 'version' => '11dc8d19406305fb1eb9ed685e04c857'), './build/block-editor/index.js' => array('dependencies' => array('lodash', 'react', 'wp-a11y', 'wp-blob', 'wp-blocks', 'wp-components', 'wp-compose', 'wp-data', 'wp-deprecated', 'wp-dom', 'wp-element', 'wp-hooks', 'wp-html-entities', 'wp-i18n', 'wp-is-shallow-equal', 'wp-keyboard-shortcuts', 'wp-keycodes', 'wp-polyfill', 'wp-primitives', 'wp-rich-text', 'wp-token-list', 'wp-url', 'wp-viewport', 'wp-wordcount'), 'version' => 'bffbf21043e0e25e4935e0ecc8ffc4c0'), './build/block-library/index.js' => array('dependencies' => array('lodash', 'moment', 'wp-api-fetch', 'wp-autop', 'wp-blob', 'wp-block-editor', 'wp-blocks', 'wp-components', 'wp-compose', 'wp-core-data', 'wp-data', 'wp-date', 'wp-deprecated', 'wp-dom', 'wp-element', 'wp-escape-html', 'wp-i18n', 'wp-is-shallow-equal', 'wp-keycodes', 'wp-polyfill', 'wp-primitives', 'wp-rich-text', 'wp-server-side-render', 'wp-url', 'wp-viewport'), 'version' => 'b7dc52f6fe359aad86656e3470a4c44c'), './build/block-serialization-default-parser/index.js' => array('dependencies' => array('wp-polyfill'), 'version' => '868c078b26e0c39916665352df033753'), './build/block-serialization-spec-parser/index.js' => array('dependencies' => array('wp-polyfill'), 'version' => '5c36638eeae619b50e48fd3d0d883a38'), './build/blocks/index.js' => array('dependencies' => array('lodash', 'wp-autop', 'wp-blob', 'wp-block-serialization-default-parser', 'wp-compose', 'wp-data', 'wp-dom', 'wp-element', 'wp-hooks', 'wp-html-entities', 'wp-i18n', 'wp-is-shallow-equal', 'wp-polyfill', 'wp-primitives', 'wp-shortcode'), 'version' => '0cdcdcbbd2f8f3f505f0a5bd886ea83d'), './build/components/index.js' => array('dependencies' => array('lodash', 'moment', 'react', 'react-dom', 'wp-a11y', 'wp-compose', 'wp-deprecated', 'wp-dom', 'wp-element', 'wp-hooks', 'wp-i18n', 'wp-is-shallow-equal', 'wp-keycodes', 'wp-polyfill', 'wp-primitives', 'wp-rich-text', 'wp-warning'), 'version' => '09eb282b761b014393dd203a56aea0c0'), './build/compose/index.js' => array('dependencies' => array('lodash', 'wp-element', 'wp-is-shallow-equal', 'wp-polyfill'), 'version' => '1ca131c2eac02a4d93863b08cd7f9eea'), './build/core-data/index.js' => array('dependencies' => array('lodash', 'wp-api-fetch', 'wp-blocks', 'wp-data', 'wp-deprecated', 'wp-element', 'wp-is-shallow-equal', 'wp-polyfill', 'wp-url'), 'version' => 'ff4956463a1bafb76de0387398abcdc2'), './build/data/index.js' => array('dependencies' => array('lodash', 'react', 'wp-compose', 'wp-deprecated', 'wp-element', 'wp-is-shallow-equal', 'wp-polyfill', 'wp-priority-queue', 'wp-redux-routine'), 'version' => '0e10f1a62f8ee1889d17f86bf433c2a6'), './build/data-controls/index.js' => array('dependencies' => array('wp-api-fetch', 'wp-data', 'wp-polyfill'), 'version' => '381d35f4eacf4ec2e9d2840dbbef5246'), './build/date/index.js' => array('dependencies' => array('moment', 'wp-polyfill'), 'version' => 'f43cbe4e88d48f22e4801096670f4579'), './build/deprecated/index.js' => array('dependencies' => array('wp-hooks', 'wp-polyfill'), 'version' => '27f43911e0f66b31558fec65d3c1e08a'), './build/dom/index.js' => array('dependencies' => array('lodash', 'wp-polyfill'), 'version' => '3addb01a9d90f4d518e556088295d563'), './build/dom-ready/index.js' => array('dependencies' => array('wp-polyfill'), 'version' => '418294fc6d5c7d6787c5f31c655f5a73'), './build/edit-post/index.js' => array('dependencies' => array('lodash', 'wp-a11y', 'wp-api-fetch', 'wp-block-editor', 'wp-block-library', 'wp-blocks', 'wp-components', 'wp-compose', 'wp-core-data', 'wp-data', 'wp-editor', 'wp-element', 'wp-hooks', 'wp-i18n', 'wp-keyboard-shortcuts', 'wp-keycodes', 'wp-media-utils', 'wp-notices', 'wp-plugins', 'wp-polyfill', 'wp-primitives', 'wp-url', 'wp-viewport'), 'version' => 'e1562ad8999da283331087f1eadc9a4e'), './build/edit-site/index.js' => array('dependencies' => array('wp-block-editor', 'wp-block-library', 'wp-blocks', 'wp-components', 'wp-core-data', 'wp-data', 'wp-editor', 'wp-element', 'wp-hooks', 'wp-i18n', 'wp-media-utils', 'wp-notices', 'wp-polyfill'), 'version' => 'ce91a3af8fa80847138fab8554d019f7'), './build/edit-widgets/index.js' => array('dependencies' => array('lodash', 'wp-block-editor', 'wp-block-library', 'wp-blocks', 'wp-components', 'wp-compose', 'wp-data', 'wp-element', 'wp-hooks', 'wp-i18n', 'wp-media-utils', 'wp-notices', 'wp-polyfill'), 'version' => '39e40c7c2ccf048ae8f6f7771505ad25'), './build/editor/index.js' => array('dependencies' => array('lodash', 'react', 'wp-api-fetch', 'wp-autop', 'wp-block-editor', 'wp-blocks', 'wp-components', 'wp-compose', 'wp-core-data', 'wp-data', 'wp-data-controls', 'wp-date', 'wp-deprecated', 'wp-element', 'wp-hooks', 'wp-html-entities', 'wp-i18n', 'wp-keyboard-shortcuts', 'wp-keycodes', 'wp-media-utils', 'wp-notices', 'wp-polyfill', 'wp-primitives', 'wp-rich-text', 'wp-server-side-render', 'wp-url', 'wp-viewport', 'wp-wordcount'), 'version' => 'b47bf57bdf6771d5a53e98d606eff301'), './build/element/index.js' => array('dependencies' => array('lodash', 'react', 'react-dom', 'wp-escape-html', 'wp-polyfill'), 'version' => '9ff0c85cae03d2267595bd6b2ab5e526'), './build/escape-html/index.js' => array('dependencies' => array('wp-polyfill'), 'version' => '8d03dd15a895a7cab2ed33977ffaf5e5'), './build/format-library/index.js' => array('dependencies' => array('lodash', 'wp-block-editor', 'wp-components', 'wp-data', 'wp-dom', 'wp-element', 'wp-html-entities', 'wp-i18n', 'wp-keycodes', 'wp-polyfill', 'wp-primitives', 'wp-rich-text', 'wp-url'), 'version' => 'c15f9df76cb04a6f8cfd0288d0527ed2'), './build/hooks/index.js' => array('dependencies' => array('wp-polyfill'), 'version' => '917516ad17edfc948cd8fa111bdeb744'), './build/html-entities/index.js' => array('dependencies' => array('wp-polyfill'), 'version' => '627aee6897f133acc6d604c1a840d0d9'), './build/i18n/index.js' => array('dependencies' => array('wp-polyfill'), 'version' => '2d6418794683a9ac38e4512faac706bf'), './build/is-shallow-equal/index.js' => array('dependencies' => array('wp-polyfill'), 'version' => '65fd2ab2c0480085bddca52c3f61ad7f'), './build/keyboard-shortcuts/index.js' => array('dependencies' => array('lodash', 'wp-compose', 'wp-data', 'wp-keycodes', 'wp-polyfill'), 'version' => '8fac404fcae9f86ac9e87c95057d71b6'), './build/keycodes/index.js' => array('dependencies' => array('lodash', 'wp-i18n', 'wp-polyfill'), 'version' => '4f20ffa46535e02a872f35e3877ff75f'), './build/list-reusable-blocks/index.js' => array('dependencies' => array('lodash', 'wp-api-fetch', 'wp-components', 'wp-compose', 'wp-element', 'wp-i18n', 'wp-polyfill'), 'version' => '98daec5da5e217040d9a13f80c84e4c1'), './build/media-utils/index.js' => array('dependencies' => array('lodash', 'wp-api-fetch', 'wp-blob', 'wp-element', 'wp-i18n', 'wp-polyfill'), 'version' => 'd4d9ee2d5c33e058041bde4f044a0815'), './build/notices/index.js' => array('dependencies' => array('lodash', 'wp-data', 'wp-polyfill'), 'version' => 'acb5dcbca47b7db9a48d4e244f21dabf'), './build/nux/index.js' => array('dependencies' => array('lodash', 'wp-components', 'wp-compose', 'wp-data', 'wp-deprecated', 'wp-element', 'wp-i18n', 'wp-polyfill', 'wp-primitives'), 'version' => 'ccdfd1c5306ae423e684ebc4c13ab12e'), './build/plugins/index.js' => array('dependencies' => array('lodash', 'wp-compose', 'wp-element', 'wp-hooks', 'wp-polyfill'), 'version' => '36aa9fd0a74c0071031d539a9b18e332'), './build/primitives/index.js' => array('dependencies' => array('wp-element', 'wp-polyfill'), 'version' => 'f35d6c72bdbf05a65dae6f687925a688'), './build/priority-queue/index.js' => array('dependencies' => array('wp-polyfill'), 'version' => '17c0213e442ae6981e763c39cabb4922'), './build/redux-routine/index.js' => array('dependencies' => array('lodash', 'wp-polyfill'), 'version' => '82e5f157a143f0561abc16d1e86afecc'), './build/rich-text/index.js' => array('dependencies' => array('lodash', 'wp-compose', 'wp-data', 'wp-deprecated', 'wp-element', 'wp-escape-html', 'wp-is-shallow-equal', 'wp-keycodes', 'wp-polyfill'), 'version' => 'e895bc609591f830d9643ae0d1ba2e2a'), './build/server-side-render/index.js' => array('dependencies' => array('lodash', 'wp-api-fetch', 'wp-components', 'wp-data', 'wp-deprecated', 'wp-element', 'wp-i18n', 'wp-polyfill', 'wp-url'), 'version' => '01c539e09a0ac679fd2b7cdacaf18e65'), './build/shortcode/index.js' => array('dependencies' => array('lodash', 'wp-polyfill'), 'version' => 'e518e71e49a2ef0028b2b6876e15a9de'), './build/token-list/index.js' => array('dependencies' => array('lodash', 'wp-polyfill'), 'version' => 'abf481874a93d9084f14510f06dde341'), './build/url/index.js' => array('dependencies' => array('lodash', 'wp-polyfill'), 'version' => '59bb094cc70ae6916bab4597d9565087'), './build/viewport/index.js' => array('dependencies' => array('lodash', 'wp-compose', 'wp-data', 'wp-element', 'wp-polyfill'), 'version' => 'd8497420eb74159cd56697ea074a5ffa'), './build/warning/index.js' => array('dependencies' => array('wp-polyfill'), 'version' => 'e95338a7d95f3f629f3c7a8cc749c7ac'), './build/wordcount/index.js' => array('dependencies' => array('lodash', 'wp-polyfill'), 'version' => 'c744791db0a5d3db3c8031b3df1532e3'));
```

I decided to use the build file paths for entry points as keys in the output object. This way, it should be quite easy to get the asset data for individual entry points when registering in the WordPress core. 

## How has this been tested?
`npm run test-unit`

I also played with the webpack config inside Gutenberg. Please note that the block editor won't work out of the box when `combineAssets` is enabled because PHP logic depends on individual asset files.

## Types of changes
Enhancement.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
