### PR TITLE
[RNMobile] Adding global toolbar height to auto-scroll calculations

### DIFF
--- a/packages/base-styles/_variables.scss
+++ b/packages/base-styles/_variables.scss
@@ -48,6 +48,7 @@ $admin-sidebar-width-big: 190px;
 $admin-sidebar-width-collapsed: 36px;
 $modal-min-width: 360px;
 $spinner-size: 18px;
+$mobile-header-toolbar-height: 44px;
 
 
 /**
@@ -71,6 +72,7 @@ $widget-area-width: 700px;
  */
 
 $block-toolbar-height: $grid-unit-60;
+$mobile-block-toolbar-height: 44px;
 $block-padding: 14px; // Space between block footprint and focus boundaries. These are drawn outside the block footprint, and do not affect the size.
 $block-spacing: 4px; // Vertical space between blocks.
 $block-side-ui-width: 28px; // Width of the movers/drag handle UI.

--- a/packages/block-editor/src/components/block-list/index.native.js
+++ b/packages/block-editor/src/components/block-list/index.native.js
@@ -25,6 +25,7 @@ import BlockListAppender from '../block-list-appender';
 import BlockInsertionPoint from './insertion-point';
 
 const innerToolbarHeight = 44;
+const globalToolBarHeight = 44;
 
 export class BlockList extends Component {
 	constructor() {
@@ -116,7 +117,7 @@ export class BlockList extends Component {
 					accessibilityLabel="block-list"
 					autoScroll={ this.props.autoScroll }
 					innerRef={ this.scrollViewInnerRef }
-					extraScrollHeight={ innerToolbarHeight + 10 }
+					extraScrollHeight={ innerToolbarHeight + globalToolBarHeight + 4 } // + 4 to show the block's bottom border line.
 					keyboardShouldPersistTaps="always"
 					scrollViewStyle={ { flex: isRootList ? 1 : 0 } }
 					data={ blockClientIds }

--- a/packages/block-editor/src/components/block-list/index.native.js
+++ b/packages/block-editor/src/components/block-list/index.native.js
@@ -25,8 +25,8 @@ import BlockListAppender from '../block-list-appender';
 import BlockInsertionPoint from './insertion-point';
 
 const innerToolbarHeight = 44;
-const globalToolBarHeight = 44;
-const extraBlockBorderMargin = 4;
+const headerToolBarHeight = 44;
+const blockBorderWidth = 1;
 
 export class BlockList extends Component {
 	constructor() {
@@ -120,9 +120,9 @@ export class BlockList extends Component {
 					innerRef={ this.scrollViewInnerRef }
 					extraScrollHeight={
 						innerToolbarHeight +
-						globalToolBarHeight +
-						extraBlockBorderMargin
+						blockBorderWidth
 					}
+					inputAccessoryViewHeight={ headerToolBarHeight }
 					keyboardShouldPersistTaps="always"
 					scrollViewStyle={ { flex: isRootList ? 1 : 0 } }
 					data={ blockClientIds }

--- a/packages/block-editor/src/components/block-list/index.native.js
+++ b/packages/block-editor/src/components/block-list/index.native.js
@@ -118,10 +118,7 @@ export class BlockList extends Component {
 					accessibilityLabel="block-list"
 					autoScroll={ this.props.autoScroll }
 					innerRef={ this.scrollViewInnerRef }
-					extraScrollHeight={
-						innerToolbarHeight +
-						blockBorderWidth
-					}
+					extraScrollHeight={ innerToolbarHeight + blockBorderWidth }
 					inputAccessoryViewHeight={ headerToolBarHeight }
 					keyboardShouldPersistTaps="always"
 					scrollViewStyle={ { flex: isRootList ? 1 : 0 } }

--- a/packages/block-editor/src/components/block-list/index.native.js
+++ b/packages/block-editor/src/components/block-list/index.native.js
@@ -24,10 +24,6 @@ import BlockListBlock from './block';
 import BlockListAppender from '../block-list-appender';
 import BlockInsertionPoint from './insertion-point';
 
-const innerToolbarHeight = 44;
-const headerToolBarHeight = 44;
-const blockBorderWidth = 1;
-
 export class BlockList extends Component {
 	constructor() {
 		super( ...arguments );
@@ -103,6 +99,8 @@ export class BlockList extends Component {
 			shouldShowInsertionPointAfter,
 		} = this.props;
 
+		const { blockToolbar, blockBorder, headerToolbar } = styles;
+
 		const forceRefresh =
 			shouldShowInsertionPointBefore || shouldShowInsertionPointAfter;
 
@@ -118,8 +116,8 @@ export class BlockList extends Component {
 					accessibilityLabel="block-list"
 					autoScroll={ this.props.autoScroll }
 					innerRef={ this.scrollViewInnerRef }
-					extraScrollHeight={ innerToolbarHeight + blockBorderWidth }
-					inputAccessoryViewHeight={ headerToolBarHeight }
+					extraScrollHeight={ blockToolbar.height + blockBorder.width }
+					inputAccessoryViewHeight={ headerToolbar.height }
 					keyboardShouldPersistTaps="always"
 					scrollViewStyle={ { flex: isRootList ? 1 : 0 } }
 					data={ blockClientIds }

--- a/packages/block-editor/src/components/block-list/index.native.js
+++ b/packages/block-editor/src/components/block-list/index.native.js
@@ -116,7 +116,9 @@ export class BlockList extends Component {
 					accessibilityLabel="block-list"
 					autoScroll={ this.props.autoScroll }
 					innerRef={ this.scrollViewInnerRef }
-					extraScrollHeight={ blockToolbar.height + blockBorder.width }
+					extraScrollHeight={
+						blockToolbar.height + blockBorder.width
+					}
 					inputAccessoryViewHeight={ headerToolbar.height }
 					keyboardShouldPersistTaps="always"
 					scrollViewStyle={ { flex: isRootList ? 1 : 0 } }

--- a/packages/block-editor/src/components/block-list/index.native.js
+++ b/packages/block-editor/src/components/block-list/index.native.js
@@ -26,6 +26,7 @@ import BlockInsertionPoint from './insertion-point';
 
 const innerToolbarHeight = 44;
 const globalToolBarHeight = 44;
+const extraBlockBorderMargin = 4;
 
 export class BlockList extends Component {
 	constructor() {
@@ -117,7 +118,11 @@ export class BlockList extends Component {
 					accessibilityLabel="block-list"
 					autoScroll={ this.props.autoScroll }
 					innerRef={ this.scrollViewInnerRef }
-					extraScrollHeight={ innerToolbarHeight + globalToolBarHeight + 4 } // + 4 to show the block's bottom border line.
+					extraScrollHeight={
+						innerToolbarHeight +
+						globalToolBarHeight +
+						extraBlockBorderMargin
+					}
 					keyboardShouldPersistTaps="always"
 					scrollViewStyle={ { flex: isRootList ? 1 : 0 } }
 					data={ blockClientIds }

--- a/packages/block-editor/src/components/block-list/style.native.scss
+++ b/packages/block-editor/src/components/block-list/style.native.scss
@@ -51,3 +51,15 @@
 	padding-left: $block-custom-appender-to-content;
 	padding-right: $block-custom-appender-to-content;
 }
+
+.blockBorder {
+	width: $block-selected-border-width;
+}
+
+.headerToolbar {
+	height: $mobile-header-toolbar-height;
+}
+
+.blockToolbar {
+	height: $mobile-block-toolbar-height;
+}

--- a/packages/block-editor/src/components/block-mobile-toolbar/style.native.scss
+++ b/packages/block-editor/src/components/block-mobile-toolbar/style.native.scss
@@ -1,6 +1,6 @@
 .toolbar {
 	flex-direction: row;
-	height: 44px;
+	height: $mobile-block-toolbar-height;
 	align-items: flex-start;
 	margin-left: 2px;
 	margin-right: 2px;

--- a/packages/components/src/mobile/keyboard-aware-flat-list/index.ios.js
+++ b/packages/components/src/mobile/keyboard-aware-flat-list/index.ios.js
@@ -10,6 +10,7 @@ export const KeyboardAwareFlatList = ( {
 	innerRef,
 	autoScroll,
 	scrollViewStyle,
+	inputAccessoryViewHeight,
 	...listProps
 } ) => (
 	<KeyboardAwareScrollView
@@ -19,6 +20,7 @@ export const KeyboardAwareFlatList = ( {
 		keyboardShouldPersistTaps="handled"
 		extraScrollHeight={ extraScrollHeight }
 		extraHeight={ 0 }
+		inputAccessoryViewHeight={ inputAccessoryViewHeight }
 		enableAutomaticScroll={ autoScroll === undefined ? false : autoScroll }
 		innerRef={ ( ref ) => {
 			this.scrollViewRef = ref;

--- a/packages/edit-post/src/components/header/header-toolbar/style.native.scss
+++ b/packages/edit-post/src/components/header/header-toolbar/style.native.scss
@@ -1,6 +1,6 @@
 
 .container {
-	height: 44px;
+	height: $mobile-header-toolbar-height;
 	flex-direction: row;
 	background-color: #fff;
 	border-top-color: #e9eff3;

--- a/test/native/__mocks__/styleMock.js
+++ b/test/native/__mocks__/styleMock.js
@@ -81,4 +81,13 @@ module.exports = {
 	infoSheetIcon: {
 		color: 'gray',
 	},
+	blockToolbar: {
+		height: 44,
+	},
+	headerToolbar: {
+		height: 44,
+	},
+	blockBorder: {
+		width: 1,
+	},
 };


### PR DESCRIPTION
By considering the global toolbar on the autoscroll calculation, the final result is more precise in both iPhones and iPads.

More info on `gutenberg-mobile` PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1939

![autoscroll-iphone](https://user-images.githubusercontent.com/9772967/74945432-07700c80-53f8-11ea-8176-aaa9051dd8f8.gif)
![autoscroll-ipad](https://user-images.githubusercontent.com/9772967/74945440-0a6afd00-53f8-11ea-9a28-3ce4ef657925.gif)
