### PR TITLE
Create block: Add support for `format:js` to ESNext template

### DIFF
--- a/packages/create-block/CHANGELOG.md
+++ b/packages/create-block/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Master
 
+### New Features
+
+- Added support for `format:js` script to the block scaffolded with ESNext template ([#20335](https://github.com/WordPress/gutenberg/pull/20335)).
+
 ## 0.6.0 (2020-02-04)
 
 ### Enhancements

--- a/packages/create-block/README.md
+++ b/packages/create-block/README.md
@@ -74,6 +74,11 @@ $ npm run build
 Builds the code for production. [Learn more](/packages/scripts#build).
 
 ```bash
+$ npm run format:js
+```
+Formats JavaScript files. [Learn more](/packages/scripts#format-js).
+
+```bash
 $ npm run lint:css
 ```
 Lints CSS files. [Learn more](/packages/scripts#lint-style).

--- a/packages/create-block/lib/init-wp-scripts.js
+++ b/packages/create-block/lib/init-wp-scripts.js
@@ -30,6 +30,7 @@ module.exports = async function( {
 		main: 'build/index.js',
 		scripts: {
 			build: 'wp-scripts build',
+			'format:js': 'wp-scripts format-js',
 			'lint:css': 'wp-scripts lint-style',
 			'lint:js': 'wp-scripts lint-js',
 			start: 'wp-scripts start',
@@ -40,6 +41,12 @@ module.exports = async function( {
 	info( '' );
 	info( 'Installing packages. It might take a couple of minutes.' );
 	await command( 'npm install @wordpress/scripts --save-dev', {
+		cwd,
+	} );
+
+	info( '' );
+	info( 'Formatting JavaScript files.' );
+	await command( 'npm run format:js', {
 		cwd,
 	} );
 

--- a/packages/create-block/lib/scaffold.js
+++ b/packages/create-block/lib/scaffold.js
@@ -85,6 +85,9 @@ module.exports = async function(
 		code( '  $ npm run build' );
 		info( '    Builds the code for production.' );
 		info( '' );
+		code( '  $ npm run format:js' );
+		info( '    Formats JavaScript files.' );
+		info( '' );
 		code( '  $ npm run lint:css' );
 		info( '    Lints CSS files.' );
 		info( '' );


### PR DESCRIPTION
## Description

This PR adds support for `format:js` script to the block scaffolded when using the default ESNext template.

It also runs this command during the scaffolding process. The reason for that is that we can't predict the length of inputs provided by users so we can't really format JavaScript file correctly for all cases. That's why the idea to format those files popped up. It ensures that users won't see any errors when running `npm run lint:js` in the scaffolded project. At the moment, when I run `npm ini @wordpress/block`, use default values and run `npm run lint:js` in the scaffolded folder, I see:

```bash
/Users/gziolo/Projects/gutenberg/esnext-example/src/index.js
  25:12  error  Replace `⏎↹↹'ESNext·Example',⏎↹↹'create-block'⏎↹` with `·'ESNext·Example',·'create-block'·`                                                                           prettier/prettier
  72:10  error  Replace `·'ESNext·Example·–·hello·from·the·editor!',·'create-block'·` with `⏎↹↹↹↹↹'ESNext·Example·–·hello·from·the·editor!',⏎↹↹↹↹↹'create-block'⏎↹↹↹↹`                prettier/prettier
  88:10  error  Replace `·'ESNext·Example·–·hello·from·the·saved·content!',·'create-block'·` with `⏎↹↹↹↹↹'ESNext·Example·–·hello·from·the·saved·content!',⏎↹↹↹↹↹'create-block'⏎↹↹↹↹`  prettier/prettier

✖ 3 problems (3 errors, 0 warnings)
  3 errors and 0 warnings potentially fixable with the `--fix` option.
```

## How has this been tested?

```bash
$ npx wp-create-block
$ cd esnext-example
$ npm run lint:js
$ npm run format:js
```

## Types of changes
Enhancement

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
