### PR TITLE
Add: Plugin Sidebar management functionality to plugins package. 

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -409,6 +409,15 @@ function gutenberg_register_packages_styles( &$styles ) {
 
 	gutenberg_override_style(
 		$styles,
+		'wp-plugins',
+		gutenberg_url( 'build/plugins/style.css' ),
+		array( 'wp-components' ),
+		filemtime( gutenberg_dir_path() . 'build/plugins/style.css' )
+	);
+	$styles->add_data( 'wp-plugins', 'rtl', 'replace' );
+
+	gutenberg_override_style(
+		$styles,
 		'wp-edit-widgets',
 		gutenberg_url( 'build/edit-widgets/style.css' ),
 		array( 'wp-components', 'wp-block-editor', 'wp-edit-blocks' ),

--- a/lib/edit-site-page.php
+++ b/lib/edit-site-page.php
@@ -106,5 +106,6 @@ function gutenberg_edit_site_init( $hook ) {
 	wp_enqueue_script( 'wp-format-library' );
 	wp_enqueue_style( 'wp-edit-site' );
 	wp_enqueue_style( 'wp-format-library' );
+	wp_enqueue_style( 'wp-plugins' );
 }
 add_action( 'admin_enqueue_scripts', 'gutenberg_edit_site_init' );

--- a/package-lock.json
+++ b/package-lock.json
@@ -10416,8 +10416,10 @@
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/hooks": "file:packages/hooks",
 				"@wordpress/i18n": "file:packages/i18n",
+				"@wordpress/icons": "file:packages/icons",
 				"@wordpress/media-utils": "file:packages/media-utils",
-				"@wordpress/notices": "file:packages/notices"
+				"@wordpress/notices": "file:packages/notices",
+				"@wordpress/plugins": "file:packages/plugins"
 			}
 		},
 		"@wordpress/edit-widgets": {
@@ -10696,10 +10698,14 @@
 			"version": "file:packages/plugins",
 			"requires": {
 				"@babel/runtime": "^7.8.3",
+				"@wordpress/components": "file:packages/components",
 				"@wordpress/compose": "file:packages/compose",
+				"@wordpress/data": "file:packages/data",
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/hooks": "file:packages/hooks",
+				"@wordpress/i18n": "file:packages/i18n",
 				"@wordpress/icons": "file:packages/icons",
+				"classnames": "^2.2.5",
 				"lodash": "^4.17.15"
 			}
 		},
@@ -19519,7 +19525,7 @@
 				},
 				"node-pre-gyp": {
 					"version": "0.12.0",
-					"resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz",
+					"resolved": false,
 					"integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
 					"dev": true,
 					"optional": true,
@@ -19538,7 +19544,7 @@
 				},
 				"nopt": {
 					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
 					"dev": true,
 					"optional": true,

--- a/packages/edit-site/package.json
+++ b/packages/edit-site/package.json
@@ -31,8 +31,10 @@
 		"@wordpress/element": "file:../element",
 		"@wordpress/hooks": "file:../hooks",
 		"@wordpress/i18n": "file:../i18n",
+		"@wordpress/icons": "file:../icons",
 		"@wordpress/media-utils": "file:../media-utils",
-		"@wordpress/notices": "file:../notices"
+		"@wordpress/notices": "file:../notices",
+		"@wordpress/plugins": "file:../plugins"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/edit-site/src/components/header/index.js
+++ b/packages/edit-site/src/components/header/index.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { PluginSidebar } from '@wordpress/plugins';
 
 /**
  * Internal dependencies
@@ -21,6 +22,7 @@ export default function Header() {
 			</h1>
 			<div className="edit-site-header__actions">
 				<SaveButton />
+				<PluginSidebar.PinnedItemsSlot scope="edit-site/sidebar" />
 			</div>
 		</div>
 	);

--- a/packages/edit-site/src/components/header/style.scss
+++ b/packages/edit-site/src/components/header/style.scss
@@ -33,5 +33,10 @@
 }
 
 .edit-site-header__actions {
+	display: flex;
 	padding: 0 20px;
+	button {
+		margin-right: $grid-size-small;
+		margin-left: $grid-size-small;
+	}
 }

--- a/packages/edit-site/src/components/sidebar/index.js
+++ b/packages/edit-site/src/components/sidebar/index.js
@@ -1,25 +1,52 @@
 /**
  * WordPress dependencies
  */
-import { createSlotFill, Panel } from '@wordpress/components';
+import { createSlotFill } from '@wordpress/components';
+import { PluginSidebar } from '@wordpress/plugins';
 import { __ } from '@wordpress/i18n';
+import { cog, pencil } from '@wordpress/icons';
 
 const { Slot: InspectorSlot, Fill: InspectorFill } = createSlotFill(
 	'EditSiteSidebarInspector'
 );
-
 function Sidebar() {
 	return (
-		<div
-			className="edit-site-sidebar"
-			role="region"
-			aria-label={ __( 'Site editor advanced settings.' ) }
-			tabIndex="-1"
-		>
-			<Panel header={ __( 'Inspector' ) }>
+		<>
+			<PluginSidebar.Slot scope="edit-site/sidebar">
+				{ ( fills ) => {
+					return (
+						fills.length > 0 && (
+							<div
+								className="edit-site-sidebar"
+								role="region"
+								aria-label={ __(
+									'Site editor advanced settings.'
+								) }
+								tabIndex="-1"
+							>
+								{ fills }
+							</div>
+						)
+					);
+				} }
+			</PluginSidebar.Slot>
+			<PluginSidebar
+				scope="edit-site/sidebar"
+				sidebarName="block-inspector"
+				title={ __( 'Block Inspector' ) }
+				icon={ cog }
+			>
 				<InspectorSlot bubblesVirtually />
-			</Panel>
-		</div>
+			</PluginSidebar>
+			<PluginSidebar
+				scope="edit-site/sidebar"
+				sidebarName="global-styles"
+				title={ __( 'Global Styles' ) }
+				icon={ pencil }
+			>
+				<p>Global Styles area</p>
+			</PluginSidebar>
+		</>
 	);
 }
 

--- a/packages/plugins/README.md
+++ b/packages/plugins/README.md
@@ -73,6 +73,10 @@ _Returns_
 
 -   `WPComponent`: The component to be rendered.
 
+<a name="PluginSidebar" href="#PluginSidebar">#</a> **PluginSidebar**
+
+Undocumented declaration.
+
 <a name="registerPlugin" href="#registerPlugin">#</a> **registerPlugin**
 
 Registers a plugin to the editor.

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -22,10 +22,14 @@
 	"react-native": "src/index",
 	"dependencies": {
 		"@babel/runtime": "^7.8.3",
+		"@wordpress/components": "file:../components",
 		"@wordpress/compose": "file:../compose",
+		"@wordpress/data": "file:../data",
 		"@wordpress/element": "file:../element",
 		"@wordpress/hooks": "file:../hooks",
+		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/icons": "file:../icons",
+		"classnames": "^2.2.5",
 		"lodash": "^4.17.15"
 	},
 	"publishConfig": {

--- a/packages/plugins/src/components/index.js
+++ b/packages/plugins/src/components/index.js
@@ -1,2 +1,3 @@
 export { default as PluginArea } from './plugin-area';
 export { withPluginContext } from './plugin-context';
+export { default as PluginSidebar } from './plugin-sidebar';

--- a/packages/plugins/src/components/plugin-sidebar/index.js
+++ b/packages/plugins/src/components/plugin-sidebar/index.js
@@ -1,0 +1,110 @@
+/**
+ * External dependencies
+ */
+import { isEmpty } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { Button, Panel, Slot, Fill } from '@wordpress/components';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+//import PinnedPlugins from '../../header/pinned-plugins';
+import { withPluginContext } from '../plugin-context';
+import SidebarHeader from './sidebar-header';
+
+function PluginSidebarPinnedItems( { scope, ...props } ) {
+	return <Fill name={ `PluginPinnedAreas/${ scope }` } { ...props } />;
+}
+
+function PluginSidebarPinnedItemsSlot( { scope, className, ...props } ) {
+	return (
+		<Slot name={ `PluginPinnedAreas/${ scope }` } { ...props }>
+			{ ( fills ) =>
+				! isEmpty( fills ) && (
+					<div className={ className }>{ fills }</div>
+				)
+			}
+		</Slot>
+	);
+}
+
+function PluginSidebarSlot( { scope, ...props } ) {
+	return <Slot name={ `PluginSidebar/${ scope }` } { ...props } />;
+}
+
+function PluginSidebarFill( { scope, ...props } ) {
+	return <Fill name={ `PluginSidebar/${ scope }` } { ...props } />;
+}
+
+function PluginSidebar( {
+	sidebarName,
+	children,
+	className,
+	icon,
+	title,
+	scope,
+	...props
+} ) {
+	const { isActive, isPinned } = useSelect(
+		( select ) => {
+			const { getSingleActiveArea, isMultipleActiveAreaActive } = select(
+				'core/plugins'
+			);
+			return {
+				isActive: getSingleActiveArea( scope ) === sidebarName,
+				isPinned: isMultipleActiveAreaActive( scope, sidebarName ),
+			};
+		},
+		[ sidebarName, scope ]
+	);
+
+	const { setSingleActiveArea } = useDispatch( 'core/plugins' );
+	return (
+		<>
+			{ isPinned && (
+				<PluginSidebarPinnedItems scope={ scope }>
+					<Button
+						icon={ icon }
+						label={ title }
+						onClick={ () =>
+							isActive
+								? setSingleActiveArea( scope )
+								: setSingleActiveArea( scope, sidebarName )
+						}
+						isPressed={ isActive }
+						aria-expanded={ isActive }
+					/>
+				</PluginSidebarPinnedItems>
+			) }
+			{ isActive && (
+				<PluginSidebarFill scope={ scope } { ...props }>
+					<SidebarHeader
+						closeLabel={ __( 'Close plugin' ) }
+						closeSidebar={ () => setSingleActiveArea( scope ) }
+					>
+						<strong>{ title }</strong>
+					</SidebarHeader>
+					<Panel className={ className }>{ children }</Panel>
+				</PluginSidebarFill>
+			) }
+		</>
+	);
+}
+
+const PluginSidebarWrapped = withPluginContext( ( context, ownProps ) => {
+	return {
+		icon: ownProps.icon || context.icon,
+		sidebarName:
+			ownProps.sidebarName || `${ context.name }/${ ownProps.name }`,
+	};
+} )( PluginSidebar );
+
+PluginSidebarWrapped.Slot = PluginSidebarSlot;
+PluginSidebarWrapped.PinnedItemsSlot = PluginSidebarPinnedItemsSlot;
+
+export default PluginSidebarWrapped;

--- a/packages/plugins/src/components/plugin-sidebar/sidebar-header.js
+++ b/packages/plugins/src/components/plugin-sidebar/sidebar-header.js
@@ -1,0 +1,51 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/components';
+import { close } from '@wordpress/icons';
+
+const SidebarHeader = ( {
+	smallSidebarTitle,
+	closeSidebarShortcut,
+	closeSidebar,
+	children,
+	className,
+	closeLabel,
+} ) => {
+	return (
+		<>
+			<div className="components-panel__header plugins-sidebar-header__small">
+				<span className="plugins-sidebar-header__title">
+					{ smallSidebarTitle || __( '(no title)' ) }
+				</span>
+				<Button
+					onClick={ closeSidebar }
+					icon={ close }
+					label={ closeLabel }
+				/>
+			</div>
+			<div
+				className={ classnames(
+					'components-panel__header plugins-sidebar-header',
+					className
+				) }
+			>
+				{ children }
+				<Button
+					onClick={ closeSidebar }
+					icon={ close }
+					label={ closeLabel }
+					shortcut={ closeSidebarShortcut }
+				/>
+			</div>
+		</>
+	);
+};
+
+export default SidebarHeader;

--- a/packages/plugins/src/components/plugin-sidebar/style.scss
+++ b/packages/plugins/src/components/plugin-sidebar/style.scss
@@ -1,0 +1,5 @@
+.plugins-sidebar-header__small {
+	@include break-medium() {
+		display: none;
+	}
+}

--- a/packages/plugins/src/index.js
+++ b/packages/plugins/src/index.js
@@ -1,2 +1,6 @@
 export * from './components';
 export * from './api';
+/**
+ * Internal dependencies
+ */
+import './store';

--- a/packages/plugins/src/store/actions.js
+++ b/packages/plugins/src/store/actions.js
@@ -1,0 +1,33 @@
+/**
+ * Returns an action object used in signalling that an active area should be changed.
+ *
+ * @param {string} scope      Area scope.
+ * @param {string} activeArea Area identifier.
+ *
+ * @return {Object} Action object.
+ */
+export function setSingleActiveArea( scope, activeArea ) {
+	return {
+		type: 'SET_SINGLE_ACTIVE_AREA',
+		scope,
+		activeArea,
+	};
+}
+
+/**
+ * Returns an action object to make an area enabled/disabled.
+ *
+ * @param {string}  scope    Area scope.
+ * @param {string}  area     Area identifier.
+ * @param {boolean} isEnable Boolean indicating if an area should be pinned or not.
+ *
+ * @return {Object} Action object.
+ */
+export function setMultipleActiveAreaEnableState( scope, area, isEnable ) {
+	return {
+		type: 'SET_MULTIPLE_ACTIVE_AREA_ENABLE_STATE',
+		scope,
+		area,
+		isEnable,
+	};
+}

--- a/packages/plugins/src/store/constants.js
+++ b/packages/plugins/src/store/constants.js
@@ -1,0 +1,6 @@
+/**
+ * The identifier for the data store.
+ *
+ * @type {string}
+ */
+export const STORE_KEY = 'core/plugins';

--- a/packages/plugins/src/store/defaults.js
+++ b/packages/plugins/src/store/defaults.js
@@ -1,0 +1,13 @@
+export const DEFAULTS = {
+	areaControl: {
+		singleActiveAreas: {
+			'edit-site/sidebar': 'block-inspector',
+		},
+		multipleActiveAreas: {
+			'edit-site/sidebar': {
+				'block-inspector': true,
+				'global-styles': true,
+			},
+		},
+	},
+};

--- a/packages/plugins/src/store/index.js
+++ b/packages/plugins/src/store/index.js
@@ -1,0 +1,20 @@
+/**
+ * WordPress dependencies
+ */
+import { registerStore } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import reducer from './reducer';
+import * as actions from './actions';
+import * as selectors from './selectors';
+import { STORE_KEY } from './constants';
+
+const store = registerStore( STORE_KEY, {
+	reducer,
+	actions,
+	selectors,
+} );
+
+export default store;

--- a/packages/plugins/src/store/reducer.js
+++ b/packages/plugins/src/store/reducer.js
@@ -1,0 +1,90 @@
+/**
+ * External dependencies
+ */
+import { flow, get, omit } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { combineReducers } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { DEFAULTS } from './defaults';
+
+/**
+ * Higher-order reducer creator which provides the given initial state for the
+ * original reducer.
+ *
+ * @param {*} initialState Initial state to provide to reducer.
+ *
+ * @return {Function} Higher-order reducer.
+ */
+const createWithInitialState = ( initialState ) => ( reducer ) => {
+	return ( state = initialState, action ) => reducer( state, action );
+};
+
+/**
+ * Reducer to keep tract of the active area per scope.
+ *
+ * @param {boolean}  state   Previous state.
+ * @param {Object}   action  Action Object.
+ *
+ * @return {Object} Updated state.
+ */
+export function singleActiveAreas( state = {}, action ) {
+	if ( action.type !== 'SET_SINGLE_ACTIVE_AREA' || ! action.scope ) {
+		return state;
+	}
+	if ( ! action.activeArea ) {
+		return omit( state, [ action.scope ] );
+	}
+	return {
+		...state,
+		[ action.scope ]: action.activeArea,
+	};
+}
+
+/**
+ * Reducer keeping track of the "pinned" items per scope
+ *
+ * @param {boolean}  state   Previous state.
+ * @param {Object}   action  Action Object.
+ *
+ * @return {Object} Updated state.
+ */
+export function multipleActiveAreas( state = {}, action ) {
+	if (
+		action.type !== 'SET_MULTIPLE_ACTIVE_AREA_ENABLE_STATE' ||
+		! action.scope ||
+		! action.area ||
+		get( state, [ action.scope, action.area ] ) === action.isEnable
+	) {
+		return state;
+	}
+	if ( action.isEnable ) {
+		return {
+			...state,
+			[ action.scope ]: {
+				...( state[ action.scope ] || {} ),
+				[ action.area ]: true,
+			},
+		};
+	}
+	return {
+		...state,
+		[ action.scope ]: omit( state[ action.scope ] || {}, [ action.area ] ),
+	};
+}
+
+const areaControl = combineReducers( {
+	singleActiveAreas,
+	multipleActiveAreas,
+} );
+
+export default flow( [ combineReducers, createWithInitialState( DEFAULTS ) ] )(
+	{
+		areaControl,
+	}
+);

--- a/packages/plugins/src/store/selectors.js
+++ b/packages/plugins/src/store/selectors.js
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Returns the single active area.
+ *
+ * @param {Object} state Global application state.
+ * @param {string} scope Area scope.
+ *
+ * @return {string} Editing mode.
+ */
+export function getSingleActiveArea( state, scope ) {
+	return state.areaControl.singleActiveAreas[ scope ];
+}
+
+/**
+ * Returns if an area is pinned or not.
+ *
+ * @param {Object} state Global application state.
+ * @param {string} scope Scope.
+ * @param {string} area  Area to check.
+ *
+ * @return {boolean} True if an area is pinned and false otherwise.
+ */
+export function isMultipleActiveAreaActive( state, scope, area ) {
+	return (
+		get( state.areaControl.multipleActiveAreas, [ scope, area ] ) === true
+	);
+}

--- a/packages/plugins/src/style.scss
+++ b/packages/plugins/src/style.scss
@@ -1,0 +1,1 @@
+@import "./components/plugin-sidebar/style.scss";


### PR DESCRIPTION
This PR adds Plugin Sidebar management functionality to plugins package similar to what we had in edit post.

That functionality is used to implement sidebars in edit-site uses the functionality on edit-site.


In order to make this PR reviewable for now, just PluginSidebar is added to plugins.

If we agree with this approach the following follow-ups are required:
- We will also need to expose functionality to render menu items to open the sidebar when it is not pinned.
- We need to add the UI to pin and unpin sidebar items.
- We need to refactor edit-post to use this functionality instead of using its own.

The plugins API is used in edit-site to register a sidebar for the block inspector and for the global styles.

cc: @ItsJonQ, @gziolo 



## How has this been tested?
I went to edit site and I verified I could toggle the block inspector and the "global styles sidebar" for now just a paragraph of text.
