### PR TITLE
Remove the_content filter for block_template_parts

### DIFF
--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -32,6 +32,17 @@ function render_block_core_template_part( $attributes ) {
 	if ( is_null( $content ) ) {
 		return 'Template Part Not Found';
 	}
+
+	// Run through the actions that are typically taken on the_content.
+	$content = do_blocks( $content );
+	$content = wptexturize( $content );
+	$content = convert_smilies( $content );
+	$content = wpautop( $content );
+	$content = shortcode_unautop( $content );
+	$content = prepend_attachment( $content );
+	$content = wp_make_content_images_responsive( $content );
+	$content = do_shortcode( $content );
+
 	return str_replace( ']]>', ']]&gt;', $content );
 }
 

--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -32,7 +32,7 @@ function render_block_core_template_part( $attributes ) {
 	if ( is_null( $content ) ) {
 		return 'Template Part Not Found';
 	}
-	return apply_filters( 'the_content', str_replace( ']]>', ']]&gt;', $content ) );
+	return str_replace( ']]>', ']]&gt;', $content );
 }
 
 /**


### PR DESCRIPTION
## Description
This PR fixes https://github.com/WordPress/gutenberg/issues/20342, where content filtered to the_content appears after every block template part is output. 

## How has this been tested?
1. Create a block-based theme, with the header.html and footer.html in the block-template-parts directory, and the index.html file pulling those in. 
2. Add this code to a custom plugin:
```
function my_content_after_the_content( $the_content ) {
	return $the_content .
	'<div class="sharing_icons">I am hooked to the_content, to appear after every output of the_content</div>';
}
 add_filter( 'the_content', 'my_content_after_the_content' );
```
3. View a post. 
4. Notice you see the hooked output after each template_part is shown. 

## Types of changes
Bug fix.

## Screenshots:

### Before:
<img width="976" alt="Screen Shot 2020-02-20 at 2 36 18 PM" src="https://user-images.githubusercontent.com/7538525/74973542-975e8800-53f1-11ea-9bdf-73a0cabdbea0.png">

### After:
<img width="555" alt="Screen Shot 2020-02-20 at 2 58 38 PM" src="https://user-images.githubusercontent.com/7538525/74973536-94639780-53f1-11ea-94c0-cdcfeb5ed702.png">


## Checklist:
- [✔] My code is tested.
- [✔] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [✔] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [✔] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [✔] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [✔] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
