### PR TITLE
Introduce the_template_part filter

### DIFF
--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -32,7 +32,7 @@ function render_block_core_template_part( $attributes ) {
 	if ( is_null( $content ) ) {
 		return 'Template Part Not Found';
 	}
-	return apply_filters( 'the_content', str_replace( ']]>', ']]&gt;', $content ) );
+	return apply_filters( 'the_template_part', str_replace( ']]>', ']]&gt;', $content ) );
 }
 
 /**
@@ -58,3 +58,13 @@ function register_block_core_template_part() {
 	);
 }
 add_action( 'init', 'register_block_core_template_part' );
+
+// Add the filters that process the_template_part for template_parts.
+add_filter( 'the_template_part', 'do_blocks', 9 );
+add_filter( 'the_template_part', 'wptexturize' );
+add_filter( 'the_template_part', 'convert_smilies', 20 );
+add_filter( 'the_template_part', 'wpautop' );
+add_filter( 'the_template_part', 'shortcode_unautop' );
+add_filter( 'the_template_part', 'prepend_attachment' );
+add_filter( 'the_template_part', 'wp_make_content_images_responsive' );
+add_filter( 'the_template_part', 'do_shortcode', 11 ); // AFTER wpautop().


### PR DESCRIPTION
## Description
This PR fixes #20342, where content filtered to the_content appears after every block template part is output. It is a replacement for this PR, which only removed the filter's usage, which would cause dynamic blocks and shortcode to break inside the header.html file (and other template parts). 

A new filter is added to replace the usage of `the_content` in block template parts. This prevents duplicate output from plugins who've hooked output to the_content.

## How has this been tested?
1. Create a block-based theme, with the header.html and footer.html in the block-template-parts directory, and the index.html file pulling those in.
2. Add this code to a custom plugin:
```
function my_content_after_the_content( $the_content ) {
	return $the_content .
	'<div class="sharing_icons">I am hooked to the_content, to appear after every output of the_content</div>';
}
 add_filter( 'the_content', 'my_content_after_the_content' );
```
3. View a post.
4. Notice you see the hooked output after each template_part is shown.
5. Switch to this branch, notice you now only see the custom-hooked output after the post's content. 
6. Now, add a shortcode to your header.html file, and make sure it works in the header. 

## Screenshots <!-- if applicable -->
### Before the new filter is used:
<img width="976" alt="Screen Shot 2020-02-20 at 2 36 18 PM" src="https://user-images.githubusercontent.com/7538525/74979819-5c625180-53fd-11ea-8e2e-96f01010a5c2.png">

### After the new filter is used:
<img width="555" alt="Screen Shot 2020-02-20 at 2 58 38 PM" src="https://user-images.githubusercontent.com/7538525/74979854-6be19a80-53fd-11ea-98c4-5c8b6b6e9b8f.png">


## Types of changes
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [☑️] My code is tested.
- [☑️] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [☑️] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [☑️] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [☑️] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [☑️] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
