### PR TITLE
Don't show protocol on suggestions in navigation

### DIFF
--- a/packages/block-editor/src/components/link-control/search-item.js
+++ b/packages/block-editor/src/components/link-control/search-item.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { safeDecodeURI } from '@wordpress/url';
+import { safeDecodeURI, filterURLForDisplay } from '@wordpress/url';
 import { __ } from '@wordpress/i18n';
 import { Button, TextHighlight } from '@wordpress/components';
 import { Icon, globe } from '@wordpress/icons';
@@ -46,7 +46,11 @@ export const LinkControlSearchItem = ( {
 					aria-hidden={ ! isURL }
 					className="block-editor-link-control__search-item-info"
 				>
-					{ ! isURL && ( safeDecodeURI( suggestion.url ) || '' ) }
+					{ ! isURL &&
+						( filterURLForDisplay(
+							safeDecodeURI( suggestion.url )
+						) ||
+							'' ) }
 					{ isURL && __( 'Press ENTER to add this link' ) }
 				</span>
 			</span>


### PR DESCRIPTION
Closes #19670

## Description

On suggestions of navigation, protocols won't be shown.

## How has this been tested?

* I added test case in `LinkControl` test. 
* Test Env: Ubuntu 18.04 Node 12.14.1
* It's a simple change in `LinkControl`. It doesn't affect others. 

## Screenshots 

### Before:

![Screenshot from 2020-02-21 12-03-23](https://user-images.githubusercontent.com/8130013/75001071-b4ec2a00-54a3-11ea-8246-385917877a4e.png)

### After:

![Screenshot from 2020-02-21 12-09-30](https://user-images.githubusercontent.com/8130013/75001077-b9184780-54a3-11ea-9ddd-f4c0433a52f3.png)

## Types of changes

Simple fix. (I don't think it's either a bug or a new feature) It doesn't break anything.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [N/A] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [N/A] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [N/A] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
