### PR TITLE
Fix/block toolbars with preview

### DIFF
--- a/packages/block-editor/src/components/block-list/block-popover.js
+++ b/packages/block-editor/src/components/block-list/block-popover.js
@@ -31,7 +31,6 @@ function selector( select ) {
 		isCaretWithinFormattedText,
 		getSettings,
 		getLastMultiSelectedBlockClientId,
-		getPreviewDeviceType,
 	} = select( 'core/block-editor' );
 	return {
 		isNavigationMode: isNavigationMode(),
@@ -41,7 +40,6 @@ function selector( select ) {
 		hasMultiSelection: hasMultiSelection(),
 		hasFixedToolbar: getSettings().hasFixedToolbar,
 		lastClientId: getLastMultiSelectedBlockClientId(),
-		previewDeviceType: getPreviewDeviceType(),
 	};
 }
 
@@ -63,7 +61,6 @@ function BlockPopover( {
 		hasMultiSelection,
 		hasFixedToolbar,
 		lastClientId,
-		previewDeviceType,
 	} = useSelect( selector, [] );
 	const isLargeViewport = useViewportMatch( 'medium' );
 	const [ isToolbarForced, setIsToolbarForced ] = useState( false );
@@ -77,7 +74,6 @@ function BlockPopover( {
 		! isNavigationMode &&
 		! hasFixedToolbar &&
 		isLargeViewport &&
-		previewDeviceType === 'Desktop' &&
 		! showEmptyBlockSideInserter &&
 		! isMultiSelecting &&
 		( ! isTyping || isCaretWithinFormattedText );

--- a/packages/block-editor/src/components/block-list/block-popover.js
+++ b/packages/block-editor/src/components/block-list/block-popover.js
@@ -31,6 +31,7 @@ function selector( select ) {
 		isCaretWithinFormattedText,
 		getSettings,
 		getLastMultiSelectedBlockClientId,
+		getPreviewDeviceType,
 	} = select( 'core/block-editor' );
 	return {
 		isNavigationMode: isNavigationMode(),
@@ -40,6 +41,7 @@ function selector( select ) {
 		hasMultiSelection: hasMultiSelection(),
 		hasFixedToolbar: getSettings().hasFixedToolbar,
 		lastClientId: getLastMultiSelectedBlockClientId(),
+		previewDeviceType: getPreviewDeviceType(),
 	};
 }
 
@@ -61,6 +63,7 @@ function BlockPopover( {
 		hasMultiSelection,
 		hasFixedToolbar,
 		lastClientId,
+		previewDeviceType,
 	} = useSelect( selector, [] );
 	const isLargeViewport = useViewportMatch( 'medium' );
 	const [ isToolbarForced, setIsToolbarForced ] = useState( false );
@@ -74,6 +77,7 @@ function BlockPopover( {
 		! isNavigationMode &&
 		! hasFixedToolbar &&
 		isLargeViewport &&
+		previewDeviceType === 'Desktop' &&
 		! showEmptyBlockSideInserter &&
 		! isMultiSelecting &&
 		( ! isTyping || isCaretWithinFormattedText );

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -447,6 +447,10 @@
 	border: $border-width solid $dark-gray-primary;
 	border-radius: $radius-block-ui;
 	background-color: $white;
+
+	.block-editor-block-toolbar .components-toolbar {
+		border-right-color: $dark-gray-primary;
+	}
 }
 
 

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -26,6 +26,7 @@ export default function BlockToolbar( { hideDragHandle } ) {
 		mode,
 		moverDirection,
 		hasMovers = true,
+		previewDeviceType,
 	} = useSelect( ( select ) => {
 		const {
 			getBlockMode,
@@ -33,6 +34,7 @@ export default function BlockToolbar( { hideDragHandle } ) {
 			isBlockValid,
 			getBlockRootClientId,
 			getBlockListSettings,
+			getPreviewDeviceType,
 		} = select( 'core/block-editor' );
 		const selectedBlockClientIds = getSelectedBlockClientIds();
 		const blockRootClientId = getBlockRootClientId(
@@ -58,6 +60,7 @@ export default function BlockToolbar( { hideDragHandle } ) {
 					: null,
 			moverDirection: __experimentalMoverDirection,
 			hasMovers: __experimentalUIParts.hasMovers,
+			previewDeviceType: getPreviewDeviceType(),
 		};
 	}, [] );
 
@@ -71,6 +74,7 @@ export default function BlockToolbar( { hideDragHandle } ) {
 	const shouldShowMovers =
 		useViewportMatch( 'medium', '<' ) ||
 		hasFixedToolbar ||
+		previewDeviceType !== 'Desktop' ||
 		( showMovers && hasMovers );
 
 	if ( blockClientIds.length === 0 ) {

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -71,10 +71,13 @@ export default function BlockToolbar( { hideDragHandle } ) {
 		gestures: showMoversGestures,
 	} = useShowMoversGestures( { ref: nodeRef } );
 
-	const shouldShowMovers =
+	const displayHeaderToolbar =
 		useViewportMatch( 'medium', '<' ) ||
 		hasFixedToolbar ||
-		previewDeviceType !== 'Desktop' ||
+		previewDeviceType !== 'Desktop'
+	
+	const shouldShowMovers =
+		displayHeaderToolbar ||
 		( showMovers && hasMovers );
 
 	if ( blockClientIds.length === 0 ) {
@@ -91,7 +94,7 @@ export default function BlockToolbar( { hideDragHandle } ) {
 
 	const classes = classnames(
 		'block-editor-block-toolbar',
-		! hasFixedToolbar && 'has-responsive-movers'
+		! displayHeaderToolbar && 'has-responsive-movers'
 	);
 
 	return (

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -33,6 +33,7 @@ export default function BlockToolbar( { hideDragHandle } ) {
 			isBlockValid,
 			getBlockRootClientId,
 			getBlockListSettings,
+			getSettings,
 		} = select( 'core/block-editor' );
 		const selectedBlockClientIds = getSelectedBlockClientIds();
 		const blockRootClientId = getBlockRootClientId(
@@ -44,9 +45,7 @@ export default function BlockToolbar( { hideDragHandle } ) {
 
 		return {
 			blockClientIds: selectedBlockClientIds,
-			hasFixedToolbar: select( 'core/edit-post' ).isFeatureActive(
-				'fixedToolbar'
-			),
+			hasFixedToolbar: getSettings().hasFixedToolbar,
 			rootClientId: blockRootClientId,
 			isValid:
 				selectedBlockClientIds.length === 1

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -74,11 +74,10 @@ export default function BlockToolbar( { hideDragHandle } ) {
 	const displayHeaderToolbar =
 		useViewportMatch( 'medium', '<' ) ||
 		hasFixedToolbar ||
-		previewDeviceType !== 'Desktop'
-	
+		previewDeviceType !== 'Desktop';
+
 	const shouldShowMovers =
-		displayHeaderToolbar ||
-		( showMovers && hasMovers );
+		displayHeaderToolbar || ( showMovers && hasMovers );
 
 	if ( blockClientIds.length === 0 ) {
 		return null;

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -26,7 +26,6 @@ export default function BlockToolbar( { hideDragHandle } ) {
 		mode,
 		moverDirection,
 		hasMovers = true,
-		previewDeviceType,
 	} = useSelect( ( select ) => {
 		const {
 			getBlockMode,
@@ -34,7 +33,6 @@ export default function BlockToolbar( { hideDragHandle } ) {
 			isBlockValid,
 			getBlockRootClientId,
 			getBlockListSettings,
-			getPreviewDeviceType,
 		} = select( 'core/block-editor' );
 		const selectedBlockClientIds = getSelectedBlockClientIds();
 		const blockRootClientId = getBlockRootClientId(
@@ -60,7 +58,6 @@ export default function BlockToolbar( { hideDragHandle } ) {
 					: null,
 			moverDirection: __experimentalMoverDirection,
 			hasMovers: __experimentalUIParts.hasMovers,
-			previewDeviceType: getPreviewDeviceType(),
 		};
 	}, [] );
 
@@ -72,9 +69,7 @@ export default function BlockToolbar( { hideDragHandle } ) {
 	} = useShowMoversGestures( { ref: nodeRef } );
 
 	const displayHeaderToolbar =
-		useViewportMatch( 'medium', '<' ) ||
-		hasFixedToolbar ||
-		previewDeviceType !== 'Desktop';
+		useViewportMatch( 'medium', '<' ) || hasFixedToolbar;
 
 	const shouldShowMovers =
 		displayHeaderToolbar || ( showMovers && hasMovers );

--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -33,26 +33,12 @@
 		border: 0;
 
 		// Add a border after item groups to show as separator in the block toolbar.
-		// Also, on Mobile the toolbar is docked to the top of the screen.
 		border-right: $border-width solid $light-gray-500;
-		@include break-medium() {
-			border-right: $border-width solid $dark-gray-primary;
-		}
 	}
 
 	> :last-child,
 	> :last-child .components-toolbar {
 		border-right: none;
-	}
-
-	// Add a border and adjust the color for Top Toolbar mode.
-	.has-fixed-toolbar & {
-		.block-editor-block-mover .components-toolbar {
-			border-left: $border-width solid $light-gray-500;
-		}
-		.components-toolbar {
-			border-color: $light-gray-500;
-		}
 	}
 }
 

--- a/packages/block-editor/src/style.scss
+++ b/packages/block-editor/src/style.scss
@@ -19,7 +19,6 @@
 @import "./components/block-settings-menu/style.scss";
 @import "./components/block-styles/style.scss";
 @import "./components/block-switcher/style.scss";
-@import "./components/block-toolbar/style.scss";
 @import "./components/block-types-list/style.scss";
 @import "./components/block-variation-picker/style.scss";
 @import "./components/button-block-appender/style.scss";
@@ -52,5 +51,7 @@
 
 // Styles for components that are used outside of the editing canvas go here:
 
+@import "./components/block-toolbar/style.scss";
 @import "./components/editor-skeleton/style.scss";
 @import "./components/inserter/style.scss";
+

--- a/packages/edit-post/src/components/header/header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.js
@@ -16,7 +16,7 @@ import { EditorHistoryRedo, EditorHistoryUndo } from '@wordpress/editor';
 const inserterToggleProps = { isPrimary: true };
 
 function HeaderToolbar() {
-	const { hasFixedToolbar, showInserter, isTextModeEnabled } = useSelect(
+	const { hasFixedToolbar, showInserter, isTextModeEnabled, previewDeviceType } = useSelect(
 		( select ) => ( {
 			hasFixedToolbar: select( 'core/edit-post' ).isFeatureActive(
 				'fixedToolbar'
@@ -27,12 +27,18 @@ function HeaderToolbar() {
 				select( 'core/editor' ).getEditorSettings().richEditingEnabled,
 			isTextModeEnabled:
 				select( 'core/edit-post' ).getEditorMode() === 'text',
+			previewDeviceType: select('core/block-editor').getPreviewDeviceType(),
 		} ),
 		[]
 	);
 	const isLargeViewport = useViewportMatch( 'medium' );
 
-	const toolbarAriaLabel = hasFixedToolbar
+	const displayBlockToolbar = 
+		! isLargeViewport || 
+		previewDeviceType !== 'Desktop' ||
+		hasFixedToolbar;
+
+	const toolbarAriaLabel = displayBlockToolbar
 		? /* translators: accessibility text for the editor toolbar when Top Toolbar is on */
 		  __( 'Document and block tools' )
 		: /* translators: accessibility text for the editor toolbar when Top Toolbar is off */
@@ -53,7 +59,7 @@ function HeaderToolbar() {
 			<EditorHistoryUndo />
 			<EditorHistoryRedo />
 			<BlockNavigationDropdown isDisabled={ isTextModeEnabled } />
-			{ ( hasFixedToolbar || ! isLargeViewport ) && (
+			{ displayBlockToolbar && (
 				<div className="edit-post-header-toolbar__block-toolbar">
 					<BlockToolbar hideDragHandle />
 				</div>

--- a/packages/edit-post/src/components/header/header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.js
@@ -16,7 +16,12 @@ import { EditorHistoryRedo, EditorHistoryUndo } from '@wordpress/editor';
 const inserterToggleProps = { isPrimary: true };
 
 function HeaderToolbar() {
-	const { hasFixedToolbar, showInserter, isTextModeEnabled, previewDeviceType } = useSelect(
+	const {
+		hasFixedToolbar,
+		showInserter,
+		isTextModeEnabled,
+		previewDeviceType,
+	} = useSelect(
 		( select ) => ( {
 			hasFixedToolbar: select( 'core/edit-post' ).isFeatureActive(
 				'fixedToolbar'
@@ -27,16 +32,16 @@ function HeaderToolbar() {
 				select( 'core/editor' ).getEditorSettings().richEditingEnabled,
 			isTextModeEnabled:
 				select( 'core/edit-post' ).getEditorMode() === 'text',
-			previewDeviceType: select('core/block-editor').getPreviewDeviceType(),
+			previewDeviceType: select(
+				'core/block-editor'
+			).getPreviewDeviceType(),
 		} ),
 		[]
 	);
 	const isLargeViewport = useViewportMatch( 'medium' );
 
-	const displayBlockToolbar = 
-		! isLargeViewport || 
-		previewDeviceType !== 'Desktop' ||
-		hasFixedToolbar;
+	const displayBlockToolbar =
+		! isLargeViewport || previewDeviceType !== 'Desktop' || hasFixedToolbar;
 
 	const toolbarAriaLabel = displayBlockToolbar
 		? /* translators: accessibility text for the editor toolbar when Top Toolbar is on */

--- a/packages/edit-post/src/components/header/header-toolbar/style.scss
+++ b/packages/edit-post/src/components/header/header-toolbar/style.scss
@@ -64,6 +64,10 @@
 			right: auto;
 		}
 
+		.block-editor-block-toolbar {
+			border-left: $border-width solid $light-gray-500;
+		}
+
 		.block-editor-block-toolbar .components-toolbar {
 			$top-toolbar-padding: ($header-height - $grid-unit-60) / 2;
 			height: $header-height;

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -148,10 +148,13 @@ export default compose( [
 		const { isFeatureActive, getPreference } = select( 'core/edit-post' );
 		const { getEntityRecord } = select( 'core' );
 		const { getBlockTypes } = select( 'core/blocks' );
+		const { getPreviewDeviceType } = select( 'core/block-editor' );
 
 		return {
 			showInserterHelpPanel: isFeatureActive( 'showInserterHelpPanel' ),
-			hasFixedToolbar: isFeatureActive( 'fixedToolbar' ),
+			hasFixedToolbar:
+				isFeatureActive( 'fixedToolbar' ) ||
+				getPreviewDeviceType() !== 'Desktop',
 			focusMode: isFeatureActive( 'focusMode' ),
 			post: getEntityRecord( 'postType', postType, postId ),
 			preferredStyleVariations: getPreference(

--- a/packages/edit-post/src/editor.native.js
+++ b/packages/edit-post/src/editor.native.js
@@ -147,9 +147,12 @@ export default compose( [
 			'core/edit-post'
 		);
 		const { getBlockTypes } = select( 'core/blocks' );
+		const { getPreviewDeviceType } = select( 'core/block-editor' );
 
 		return {
-			hasFixedToolbar: isFeatureActive( 'fixedToolbar' ),
+			hasFixedToolbar:
+				isFeatureActive( 'fixedToolbar' ) ||
+				getPreviewDeviceType() !== 'Desktop',
 			focusMode: isFeatureActive( 'focusMode' ),
 			mode: getEditorMode(),
 			hiddenBlockTypes: getPreference( 'hiddenBlockTypes' ),


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

Fix rendering of block toolbars with responsive preview by always fixing them to top on Tablet and Mobile previews.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Browser tested only.

## Screenshots <!-- if applicable -->

<img width="1287" alt="Screen Shot 2020-02-21 at 2 34 41 pm" src="https://user-images.githubusercontent.com/8096000/75002049-53ce5180-54b7-11ea-8896-3ad6c709de98.png">

<img width="1283" alt="Screen Shot 2020-02-21 at 2 44 55 pm" src="https://user-images.githubusercontent.com/8096000/75002513-c986ed00-54b8-11ea-9009-0a5c427a052a.png">


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
