### PR TITLE
@wordpress/env: Fix testsPath on local sources

### DIFF
--- a/packages/env/lib/config.js
+++ b/packages/env/lib/config.js
@@ -195,7 +195,8 @@ module.exports = {
 			coreSource: includeTestsPath(
 				parseSourceString( config.core, {
 					workDirectoryPath,
-				} )
+				} ),
+				{ workDirectoryPath }
 			),
 			pluginSources: config.plugins.map( ( sourceString ) =>
 				parseSourceString( sourceString, {
@@ -268,9 +269,11 @@ function parseSourceString( sourceString, { workDirectoryPath } ) {
  * property set correctly. Only the 'core' source requires a testsPath.
  *
  * @param {Source|null} source A source object.
+ * @param {Object} options
+ * @param {string} options.workDirectoryPath Path to the work directory located in ~/.wp-env.
  * @return {Source|null} A source object.
  */
-function includeTestsPath( source ) {
+function includeTestsPath( source, { workDirectoryPath } ) {
 	if ( source === null ) {
 		return null;
 	}
@@ -278,8 +281,7 @@ function includeTestsPath( source ) {
 	return {
 		...source,
 		testsPath: path.resolve(
-			source.path,
-			'..',
+			workDirectoryPath,
 			'tests-' + path.basename( source.path )
 		),
 	};

--- a/packages/env/lib/env.js
+++ b/packages/env/lib/env.js
@@ -47,7 +47,7 @@ module.exports = {
 		 *
 		 * @see https://github.com/WordPress/gutenberg/pull/20253#issuecomment-587228440
 		 */
-		await module.exports.stop( { spinner } );
+		await module.exports.stop( { spinner, debug } );
 
 		await checkForLegacyInstall( spinner );
 		const config = await initConfig( { spinner, debug } );


### PR DESCRIPTION
When using a local source (e.g. `"core": "~/path/to/wordpress"`), the tests WordPress directory should be at `~/.wp-env/$hash/tests-wordpress` instead of `~/path/to/tests-wordpress`.