### PR TITLE
Fix sidebar jumpiness.

### DIFF
--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -57,6 +57,10 @@
 	}
 }
 
+.block-editor-editor-skeleton__sidebar > div {
+	height: 100%;
+}
+
 .edit-post-layout .editor-post-publish-panel__header-publish-button {
 	justify-content: center;
 }

--- a/packages/edit-post/src/components/sidebar/style.scss
+++ b/packages/edit-post/src/components/sidebar/style.scss
@@ -6,7 +6,7 @@
 	@include break-small() {
 		z-index: auto;
 		height: 100%;
-		overflow: visible;
+		overflow: auto;
 		-webkit-overflow-scrolling: touch;
 	}
 


### PR DESCRIPTION
The sidebar grows wider when the scrollbar appears. This is a regression compared to WordPress 5.4, where the scrollbar instead indented the content. This PR fixes that.

Before:

![before](https://user-images.githubusercontent.com/1204802/75021146-3b007480-5494-11ea-9bb9-31e5de26afbb.gif)

After:

![after](https://user-images.githubusercontent.com/1204802/75021148-3d62ce80-5494-11ea-935e-cd2da582ae66.gif)

Just to be clear, this only restores the behavior that has shipped with WordPress for a while already. You can verify this by testing WordPress 5.4 without the plugin.