### PR TITLE
Fix the PluginBlockSettingsMenuItem

### DIFF
--- a/packages/block-editor/src/components/block-settings-menu-controls/README.md
+++ b/packages/block-editor/src/components/block-settings-menu-controls/README.md
@@ -5,7 +5,7 @@ Block Settings Menu Controls appear in the block settings dropdown menu when the
 ## Usage
 
 ```jsx
-import { BlockSettingsMenuControls } from '@wordress/components';
+import { BlockSettingsMenuControls } from '@wordress/block-editor';
 import MyButton from './my-toggle-button';
 
 function ReusableBlocksButtons() {

--- a/packages/edit-post/src/components/block-settings-menu/plugin-block-settings-menu-item.js
+++ b/packages/edit-post/src/components/block-settings-menu/plugin-block-settings-menu-item.js
@@ -6,7 +6,8 @@ import { difference } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { BlockSettingsMenuControls, MenuItem } from '@wordpress/components';
+import { BlockSettingsMenuControls } from '@wordpress/block-editor';
+import { MenuItem } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import { plugins } from '@wordpress/icons';
 


### PR DESCRIPTION
When merging https://github.com/WordPress/gutenberg/pull/20233 there was kind of error and parts of the PR didn't go through with the merge, resulting in a break of the `wp.editPost.PluginBlockSettingsMenuItem` SlotFill, which this PR fixes.