### PR TITLE
Add e2e test for block settings menu

### DIFF
--- a/packages/e2e-tests/plugins/plugins-api.php
+++ b/packages/e2e-tests/plugins/plugins-api.php
@@ -86,6 +86,18 @@ function enqueue_plugins_api_plugin_scripts() {
 		filemtime( plugin_dir_path( __FILE__ ) . 'plugins-api/document-setting.js' ),
 		true
 	);
+
+	wp_enqueue_script(
+		'gutenberg-test-plugins-api-block-settings',
+		plugins_url( 'plugins-api/block-settings.js', __FILE__ ),
+		array(
+			'wp-element',
+			'wp-edit-post',
+			'wp-plugins',
+		),
+		filemtime( plugin_dir_path( __FILE__ ) . 'plugins-api/block-settings.js' ),
+		true
+	);
 }
 
 add_action( 'init', 'enqueue_plugins_api_plugin_scripts' );

--- a/packages/e2e-tests/plugins/plugins-api/block-settings.js
+++ b/packages/e2e-tests/plugins/plugins-api/block-settings.js
@@ -1,0 +1,19 @@
+( function( element, editPost, plugins ) {
+	function fillBlockSettingsMenuSlot() {
+		return element.createElement(
+			editPost.PluginBlockSettingsMenuItem,
+			{
+				icon: 'screenoptions',
+				label: 'My new plugin',
+				allowedBlocks: [ 'core/paragraph' ],
+				onClick: function() {
+					console.log( 'Block clicked ' );
+				},
+			},
+			null
+		);
+	}
+	plugins.registerPlugin( 'block-settings-menu-plugin', {
+		render: fillBlockSettingsMenuSlot,
+	} );
+} )( window.wp.element, window.wp.editPost, window.wp.plugins );

--- a/packages/e2e-tests/plugins/plugins-api/block-settings.js
+++ b/packages/e2e-tests/plugins/plugins-api/block-settings.js
@@ -7,7 +7,7 @@
 				label: 'My new plugin',
 				allowedBlocks: [ 'core/paragraph' ],
 				onClick: function() {
-					console.log( 'Block clicked ' );
+					console.log( 'Block clicked' );
 				},
 			},
 			null

--- a/packages/e2e-tests/plugins/plugins-api/block-settings.js
+++ b/packages/e2e-tests/plugins/plugins-api/block-settings.js
@@ -5,8 +5,9 @@
 			{
 				icon: 'screenoptions',
 				label: 'My new plugin',
-				allowedBlocks: [ 'core/paragraph' ],
-				onClick: function() {
+				allowedBlocks: [ 'core/list' ],
+				onClick() {
+					// eslint-disable-next-line no-console
 					console.log( 'Block clicked' );
 				},
 			},

--- a/packages/e2e-tests/specs/editor/plugins/plugins-api.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/plugins-api.test.js
@@ -4,6 +4,7 @@
 import {
 	activatePlugin,
 	clickBlockAppender,
+	clickBlockToolbarButton,
 	clickOnMoreMenuItem,
 	createNewPost,
 	deactivatePlugin,
@@ -154,6 +155,14 @@ describe( 'Using Plugins API', () => {
 				( el ) => el.innerText
 			);
 			expect( pluginDocumentSettingsText ).toMatchSnapshot();
+		} );
+	} );
+
+	describe( 'Block Settings Menu Item', () => {
+		it( 'Should render a new item', async () => {
+			clickBlockToolbarButton( 'My new plugin' );
+
+			expect( console ).toHaveLoggedWith( 'Block clicked' );
 		} );
 	} );
 } );

--- a/packages/e2e-tests/specs/editor/plugins/plugins-api.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/plugins-api.test.js
@@ -160,7 +160,7 @@ describe( 'Using Plugins API', () => {
 
 	describe( 'Block Settings Menu Item', () => {
 		it( 'Should render a new item', async () => {
-			clickBlockToolbarButton( 'My new plugin' );
+			await clickBlockToolbarButton( 'My new plugin' );
 
 			expect( console ).toHaveLoggedWith( 'Block clicked' );
 		} );

--- a/packages/e2e-tests/specs/editor/plugins/plugins-api.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/plugins-api.test.js
@@ -9,6 +9,7 @@ import {
 	clickOnMoreMenuItem,
 	createNewPost,
 	deactivatePlugin,
+	insertBlock,
 	openDocumentSettingsSidebar,
 	openPublishPanel,
 	publishPost,
@@ -161,6 +162,9 @@ describe( 'Using Plugins API', () => {
 
 	describe( 'Block Settings Menu Item', () => {
 		it( 'Should render a new item', async () => {
+			await insertBlock( 'List' );
+			await page.keyboard.type( 'one' );
+			await page.keyboard.press( 'Enter' );
 			await clickBlockToolbarButton( 'More options' );
 			await clickButton( 'My new plugin' );
 

--- a/packages/e2e-tests/specs/editor/plugins/plugins-api.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/plugins-api.test.js
@@ -5,6 +5,7 @@ import {
 	activatePlugin,
 	clickBlockAppender,
 	clickBlockToolbarButton,
+	clickButton,
 	clickOnMoreMenuItem,
 	createNewPost,
 	deactivatePlugin,
@@ -160,7 +161,8 @@ describe( 'Using Plugins API', () => {
 
 	describe( 'Block Settings Menu Item', () => {
 		it( 'Should render a new item', async () => {
-			await clickBlockToolbarButton( 'My new plugin' );
+			await clickBlockToolbarButton( 'More options' );
+			await clickButton( 'My new plugin' );
 
 			expect( console ).toHaveLoggedWith( 'Block clicked' );
 		} );

--- a/packages/e2e-tests/specs/editor/plugins/plugins-api.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/plugins-api.test.js
@@ -5,7 +5,7 @@ import {
 	activatePlugin,
 	clickBlockAppender,
 	clickBlockToolbarButton,
-	clickButton,
+	clickMenuItem,
 	clickOnMoreMenuItem,
 	createNewPost,
 	deactivatePlugin,
@@ -166,7 +166,7 @@ describe( 'Using Plugins API', () => {
 			await page.keyboard.type( 'one' );
 			await page.keyboard.press( 'Enter' );
 			await clickBlockToolbarButton( 'Options' );
-			await clickButton( 'My new plugin' );
+			await clickMenuItem( 'My new plugin' );
 
 			expect( console ).toHaveLoggedWith( 'Block clicked' );
 		} );

--- a/packages/e2e-tests/specs/editor/plugins/plugins-api.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/plugins-api.test.js
@@ -165,7 +165,7 @@ describe( 'Using Plugins API', () => {
 			await insertBlock( 'List' );
 			await page.keyboard.type( 'one' );
 			await page.keyboard.press( 'Enter' );
-			await clickBlockToolbarButton( 'More options' );
+			await clickBlockToolbarButton( 'Options' );
 			await clickButton( 'My new plugin' );
 
 			expect( console ).toHaveLoggedWith( 'Block clicked' );


### PR DESCRIPTION
This PR adds a new e2e test for the plugins API: the `PluginBlockSettingsMenuItem` SlotFill.

The added plugin registers a new item in the block settings sidebar whose text is "My new plugin" and that, upon being clicked, outputs a "Block clicked" in the console.
