### PR TITLE
Use fork of the bundle size action to fix the base branch used

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@v2-beta
       with:
         fetch-depth: 1
-    - uses: preactjs/compressed-size-action@v1
+    - uses: youknowriad/compressed-size-action@master
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         pattern: "{build/**/*.js,build/**/*.css}"


### PR DESCRIPTION
See https://github.com/preactjs/compressed-size-action/issues/10 and  https://github.com/preactjs/compressed-size-action/pull/11

I intentionally created this from an old commit in the master branch.
Since this PR doesn't affect the build output, ideally the bundle size bot should always result in a "0" diff