### PR TITLE
Remove prepend_attachment from filters run on content for post template parts

### DIFF
--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -39,7 +39,6 @@ function render_block_core_template_part( $attributes ) {
 	$content = convert_smilies( $content );
 	$content = wpautop( $content );
 	$content = shortcode_unautop( $content );
-	$content = prepend_attachment( $content );
 	$content = wp_make_content_images_responsive( $content );
 	$content = do_shortcode( $content );
 


### PR DESCRIPTION
This PR is a follow-up to PR #20343 for issue #20342

## Description
The need for all of the filters which run on `the_content` was discussed in #20343, and after testing each one, I discovered that only `prepend_attachment` appears to be unneeded in the post_template_part context. Since prepend_attachment [only runs on post_type(s) set to be `attachment`](https://github.com/WordPress/wordpress-develop/blob/130751cda30fd9a53a7378120ff51d4abea0cf5d/src/wp-includes/post-template.php#L1657), it is unnecessary in the this context. Because of that, I am removing it here. 

However, all other filters applied have been tested and I found them to be necessary. See my discoveries in this comment:
https://github.com/WordPress/gutenberg/pull/20343#issuecomment-589674433

## How has this been tested?
1. I created a block based theme using a header.html template part, placed blocks, shortcodes, multi-line breaks, and more inside the header.html file. 
2. I viewed a page and confirmed that all of those things continued to work as expected. 

## Types of changes
Bug fix.

## Checklist:
- [✅] My code is tested.
- [✅] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [✅] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [✅] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [✅] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [✅] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
