### PR TITLE
Edit Site: Update template navigation to use new link control.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10418,6 +10418,7 @@
 				"@wordpress/i18n": "file:packages/i18n",
 				"@wordpress/media-utils": "file:packages/media-utils",
 				"@wordpress/notices": "file:packages/notices",
+				"@wordpress/url": "file:packages/url",
 				"file-saver": "^2.0.2",
 				"jszip": "^3.2.2"
 			}
@@ -19703,7 +19704,7 @@
 				},
 				"node-pre-gyp": {
 					"version": "0.12.0",
-					"resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz",
+					"resolved": false,
 					"integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
 					"dev": true,
 					"optional": true,
@@ -19722,7 +19723,7 @@
 				},
 				"nopt": {
 					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
 					"dev": true,
 					"optional": true,

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -12,6 +12,7 @@ import {
 	ExternalLink,
 	Spinner,
 	VisuallyHidden,
+	createSlotFill,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import {
@@ -21,6 +22,7 @@ import {
 	Fragment,
 	useEffect,
 	createElement,
+	useMemo,
 } from '@wordpress/element';
 import {
 	safeDecodeURI,
@@ -40,6 +42,10 @@ import LinkControlSettingsDrawer from './settings-drawer';
 import LinkControlSearchItem from './search-item';
 import LinkControlSearchInput from './search-input';
 import LinkControlSearchCreate from './search-create-button';
+
+const { Slot: ViewerSlot, Fill: ViewerFill } = createSlotFill(
+	'BlockEditorLinkControlViewer'
+);
 
 // Used as a unique identifier for the "Create" option within search results.
 // Used to help distinguish the "Create" suggestion within the search results in
@@ -510,6 +516,9 @@ function LinkControl( {
 		);
 	};
 
+	const viewerSlotFillProps = useMemo( () => ( { url: value.url } ), [
+		value.url,
+	] );
 	return (
 		<div
 			tabIndex={ -1 }
@@ -574,6 +583,7 @@ function LinkControl( {
 						>
 							{ __( 'Edit' ) }
 						</Button>
+						<ViewerSlot fillProps={ viewerSlotFillProps } />
 					</div>
 				</Fragment>
 			) }
@@ -585,5 +595,7 @@ function LinkControl( {
 		</div>
 	);
 }
+
+LinkControl.ViewerFill = ViewerFill;
 
 export default LinkControl;

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -516,9 +516,10 @@ function LinkControl( {
 		);
 	};
 
-	const viewerSlotFillProps = useMemo( () => ( { url: value.url } ), [
-		value.url,
-	] );
+	const viewerSlotFillProps = useMemo(
+		() => ( { url: value && value.url } ),
+		[ value && value.url ]
+	);
 	return (
 		<div
 			tabIndex={ -1 }

--- a/packages/block-editor/src/components/url-popover/link-viewer.js
+++ b/packages/block-editor/src/components/url-popover/link-viewer.js
@@ -7,12 +7,9 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { pencil } from '@wordpress/icons';
-import { createSlotFill, ExternalLink, Button } from '@wordpress/components';
+import { ExternalLink, Button } from '@wordpress/components';
 import { safeDecodeURI, filterURLForDisplay } from '@wordpress/url';
-import { useMemo } from '@wordpress/element';
-
-const { Slot, Fill } = createSlotFill( 'BlockEditorURLPopoverLinkViewer' );
+import { pencil } from '@wordpress/icons';
 
 function LinkViewerUrl( { url, urlLabel, className } ) {
 	const linkClassName = classnames(
@@ -31,7 +28,7 @@ function LinkViewerUrl( { url, urlLabel, className } ) {
 	);
 }
 
-function LinkViewer( {
+export default function LinkViewer( {
 	className,
 	linkClassName,
 	onEditLinkClick,
@@ -59,11 +56,6 @@ function LinkViewer( {
 					onClick={ onEditLinkClick }
 				/>
 			) }
-			<Slot fillProps={ useMemo( () => ( { url } ), [ url ] ) } />
 		</div>
 	);
 }
-
-LinkViewer.Fill = Fill;
-
-export default LinkViewer;

--- a/packages/edit-site/package.json
+++ b/packages/edit-site/package.json
@@ -33,6 +33,7 @@
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/media-utils": "file:../media-utils",
 		"@wordpress/notices": "file:../notices",
+		"@wordpress/url": "file:../url",
 		"file-saver": "^2.0.2",
 		"jszip": "^3.2.2"
 	},

--- a/packages/edit-site/src/components/block-editor/index.js
+++ b/packages/edit-site/src/components/block-editor/index.js
@@ -8,7 +8,7 @@ import { useEntityBlockEditor } from '@wordpress/core-data';
 import {
 	BlockEditorProvider,
 	BlockEditorKeyboardShortcuts,
-	URLPopover,
+	__experimentalLinkControl,
 	BlockInspector,
 	WritingFlow,
 	ObserveTyping,
@@ -69,7 +69,7 @@ export default function BlockEditor() {
 			useSubRegistry={ false }
 		>
 			<BlockEditorKeyboardShortcuts />
-			<URLPopover.LinkViewer.Fill>
+			<__experimentalLinkControl.ViewerFill>
 				{ useCallback(
 					( fillProps ) => (
 						<NavigateToLink
@@ -85,7 +85,7 @@ export default function BlockEditor() {
 						setActiveTemplateId,
 					]
 				) }
-			</URLPopover.LinkViewer.Fill>
+			</__experimentalLinkControl.ViewerFill>
 			<Sidebar.InspectorFill>
 				<BlockInspector />
 			</Sidebar.InspectorFill>

--- a/packages/edit-site/src/components/navigate-to-link/index.js
+++ b/packages/edit-site/src/components/navigate-to-link/index.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { useState, useEffect, useMemo } from '@wordpress/element';
+import { addQueryArgs } from '@wordpress/url';
 import { select } from '@wordpress/data';
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -22,7 +23,7 @@ export default function NavigateToLink( {
 		const effect = async () => {
 			try {
 				const { success, data } = await fetch(
-					`${ url }?_wp-find-template`
+					addQueryArgs( url, { '_wp-find-template': true } )
 				).then( ( res ) => res.json() );
 				if ( success ) {
 					let newTemplateId = data.ID;


### PR DESCRIPTION
## Description

#19141 was merged with a feature to navigate to the template that an internal link will use to render its front end, using the `URLPopover`.

The `URLPopover` has since been replaced with the `LinkControl`. This PR moves the slot/fill extension introduced by #19141 to the new `LinkControl` component.

## How has this been tested?

It was verified that the feature works as expected with the new `LinkControl`.

## Screenshots

![image](https://user-images.githubusercontent.com/19157096/75062198-34273100-5497-11ea-8d1f-0f98dd8c89f9.png)

## Checklist:

- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->