### PR TITLE
Fix: Styling problem on vertically aligned blocks

### DIFF
--- a/packages/block-library/src/columns/style.scss
+++ b/packages/block-library/src/columns/style.scss
@@ -99,4 +99,10 @@
 	&.is-vertically-aligned-bottom {
 		align-self: flex-end;
 	}
+
+	&.is-vertically-aligned-top,
+	&.is-vertically-aligned-center,
+	&.is-vertically-aligned-bottom {
+		width: 100%;
+	}
 }


### PR DESCRIPTION
## Description
Fixes: https://github.com/WordPress/gutenberg/issues/19962

Props to @mrleemon for suggesting this fix.

Some blocks did not work inside the columns block, this PR adds a CSS fix for the issue.
In my tests, the fix does not seem to have unexpected consequences.

cc: @aduth, @jasmussen, @getdave I would appreciate if you could double-check if this fix works as expected.

## How has this been tested?
I added a columns block with two columns.
I added the Image Slider Block from the "Ultimate Blocks" plugin inside with some images inside the first column.
I added sample text on the second column making the height of the second column higher than the one of the first column.
I vertically aligned the columns to the three possible values and verified for each alignment the result looked correct. (On master the slider is broken).