### PR TITLE
Docs: Fix JavaScript linting command

### DIFF
--- a/docs/contributors/testing-overview.md
+++ b/docs/contributors/testing-overview.md
@@ -27,7 +27,7 @@ Assuming you've followed the [instructions](/docs/contributors/getting-started.m
 npm test
 ```
 
-Linting is static code analysis used to enforce coding standards and to avoid potential errors. This project uses [ESLint](http://eslint.org/) and [TypeScript's JavaScript type-checking](https://www.typescriptlang.org/docs/handbook/type-checking-javascript-files.html) to capture these issues. While the above `npm test` will execute both unit tests and code linting, code linting can be verified independently by running `npm run lint`. Some issues can be fixed automatically by running `npm run lint:fix`.
+Linting is static code analysis used to enforce coding standards and to avoid potential errors. This project uses [ESLint](http://eslint.org/) and [TypeScript's JavaScript type-checking](https://www.typescriptlang.org/docs/handbook/type-checking-javascript-files.html) to capture these issues. While the above `npm test` will execute both unit tests and code linting, code linting can be verified independently by running `npm run lint`. Some JavaScript issues can be fixed automatically by running `npm run lint-js:fix`.
 
 To improve your developer workflow, you should setup an editor linting integration. See the [getting started documentation](/docs/contributors/getting-started.md) for additional information.
 


### PR DESCRIPTION
## Description
The docs say to use run `npm run lint:fix` to automatically fix some issues. That doesn't exist, it should be `npm run lint-js:fix`

## How has this been tested?
Review docs

## Types of changes
Documentation Update
