### PR TITLE
Merge changes from mobile v1.23.0 to master

### DIFF
--- a/packages/block-editor/src/components/block-list/block.native.js
+++ b/packages/block-editor/src/components/block-list/block.native.js
@@ -198,27 +198,27 @@ class BlockListBlock extends Component {
 		);
 
 		return (
-			<>
-				{ isSelected && (
-					<FloatingToolbar>
-						<Toolbar passedStyle={ styles.toolbar }>
-							<ToolbarButton
-								title={ __( 'Navigate Up' ) }
-								onClick={ () =>
-									this.props.onSelect( parentId )
-								}
-								icon={ NavigateUpSVG }
-							/>
-							<View style={ styles.pipe } />
-						</Toolbar>
-						<Breadcrumbs clientId={ clientId } />
-					</FloatingToolbar>
-				) }
-				<TouchableWithoutFeedback
-					onPress={ this.onFocus }
-					accessible={ ! isSelected }
-					accessibilityRole={ 'button' }
-				>
+			<TouchableWithoutFeedback
+				onPress={ this.onFocus }
+				accessible={ ! isSelected }
+				accessibilityRole={ 'button' }
+			>
+				<View accessibilityLabel={ accessibilityLabel }>
+					{ isSelected && (
+						<FloatingToolbar>
+							<Toolbar passedStyle={ styles.toolbar }>
+								<ToolbarButton
+									title={ __( 'Navigate Up' ) }
+									onClick={ () =>
+										this.props.onSelect( parentId )
+									}
+									icon={ NavigateUpSVG }
+								/>
+								<View style={ styles.pipe } />
+							</Toolbar>
+							<Breadcrumbs clientId={ clientId } />
+						</FloatingToolbar>
+					) }
 					<View
 						pointerEvents={ isTouchable ? 'auto' : 'box-only' }
 						accessibilityLabel={ accessibilityLabel }
@@ -238,8 +238,8 @@ class BlockListBlock extends Component {
 							) }
 						</View>
 					</View>
-				</TouchableWithoutFeedback>
-			</>
+				</View>
+			</TouchableWithoutFeedback>
 		);
 	}
 }

--- a/packages/block-editor/src/components/block-list/index.native.js
+++ b/packages/block-editor/src/components/block-list/index.native.js
@@ -97,7 +97,12 @@ export class BlockList extends Component {
 			withFooter = true,
 			isReadOnly,
 			isRootList,
+			shouldShowInsertionPointBefore,
+			shouldShowInsertionPointAfter,
 		} = this.props;
+
+		const forceRefresh =
+			shouldShowInsertionPointBefore || shouldShowInsertionPointAfter;
 
 		return (
 			<View
@@ -116,6 +121,7 @@ export class BlockList extends Component {
 					scrollViewStyle={ { flex: isRootList ? 1 : 0 } }
 					data={ blockClientIds }
 					keyExtractor={ identity }
+					extraData={ forceRefresh }
 					renderItem={ this.renderItem }
 					shouldPreventAutomaticScroll={
 						this.shouldFlatListPreventAutomaticScroll

--- a/packages/block-editor/src/components/default-block-appender/index.native.js
+++ b/packages/block-editor/src/components/default-block-appender/index.native.js
@@ -16,6 +16,7 @@ import { getDefaultBlockName } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
+import BlockInsertionPoint from '../block-list/insertion-point';
 import styles from './style.scss';
 
 export function DefaultBlockAppender( {
@@ -24,6 +25,7 @@ export function DefaultBlockAppender( {
 	onAppend,
 	placeholder,
 	containerStyle,
+	showSeparator,
 } ) {
 	if ( isLocked || ! isVisible ) {
 		return null;
@@ -40,7 +42,11 @@ export function DefaultBlockAppender( {
 				style={ [ styles.blockHolder, containerStyle ] }
 				pointerEvents="box-only"
 			>
-				<RichText placeholder={ value } onChange={ () => {} } />
+				{ showSeparator ? (
+					<BlockInsertionPoint />
+				) : (
+					<RichText placeholder={ value } onChange={ () => {} } />
+				) }
 			</View>
 		</TouchableWithoutFeedback>
 	);

--- a/packages/editor/src/components/post-title/index.native.js
+++ b/packages/editor/src/components/post-title/index.native.js
@@ -101,7 +101,7 @@ class PostTitle extends Component {
 			>
 				<RichText
 					tagName={ 'p' }
-					rootTagsToEliminate={ [ 'strong' ] }
+					tagsToEliminate={ [ 'strong' ] }
 					unstableOnFocus={ this.props.onSelect }
 					onBlur={ this.props.onBlur } // always assign onBlur as a props
 					multiline={ false }


### PR DESCRIPTION
Related [gutenberg-mobile PR](https://github.com/wordpress-mobile/gutenberg-mobile/pull/1947)

## Description
Update with changes from Mobile 1.23 release

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [X] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
