### PR TITLE
Docs: Improve spelling

### DIFF
--- a/docs/contributors/design.md
+++ b/docs/contributors/design.md
@@ -28,7 +28,7 @@ Gutenberg's all-encompassing goal is a post- and page-building experience that m
 
 From the [kickoff post](https://make.wordpress.org/core/2017/01/04/focus-tech-and-design-leads/):
 
-> The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.
+> The editor will endeavor to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.
 
 We can extract a few key principles from this:
 


### PR DESCRIPTION
The spelling of <b>endeavour</b> is a non-American variant. For consistency, consider replacing it with the American English spelling.