### PR TITLE
Docs: Improve typo of the doc

### DIFF
--- a/docs/contributors/develop.md
+++ b/docs/contributors/develop.md
@@ -21,5 +21,5 @@ Browse [the issues list](https://github.com/wordpress/gutenberg/issues) to find 
 * [Coding Guidelines](/docs/contributors/coding-guidelines.md) outline additional patterns and conventions used in the Gutenberg project.
 * [Testing Overview](/docs/contributors/testing-overview.md) for PHP and JavaScript development in Gutenberg.
 * [Managing Packages](/docs/contributors/managing-packages.md) documents the process for managing the npm packages.
-* [Gutenberg Release Process](/docs/contributors/release.md) - a checklist for the different type of releases for Gutenberg project.
+* [Gutenberg Release Process](/docs/contributors/release.md) - a checklist for the different type of releases for the Gutenberg project.
 * [React Native mobile Gutenberg](/docs/contributors/native-mobile.md) - a guide on the React Native based mobile Gutenberg editor.


### PR DESCRIPTION
It appears that an article is missing before the word <b>Gutenberg</b>. Consider adding the article.