### PR TITLE
Docs: Add missing the article

### DIFF
--- a/docs/contributors/document.md
+++ b/docs/contributors/document.md
@@ -12,7 +12,7 @@ The Gutenberg project uses GitHub for managing code and tracking issues. The mai
 
 ## Documentation Types
 
-There are two major sets of documentation for Gutenberg project:
+There are two major sets of documentation for the Gutenberg project:
 
 1. [User documentation](https://wordpress.org/support/article/wordpress-editor/) is information on how to use the Editor as an author publishing posts. For contributing to user docs, follow the docs blog, or ask in the #docs Slack channel, to understand the current priorities.
 2. [Block Editor Handbook](https://developer.wordpress.org/block-editor/) is everything related to the Gutenberg project including: developing, extending, and—what you are reading right now—contributing specific to Gutenberg.


### PR DESCRIPTION
It appears that an article is missing before the word <b>Gutenberg</b>. Consider adding the article.