### PR TITLE
Docs: Correctness: Grammar

### DIFF
--- a/docs/contributors/scripts.md
+++ b/docs/contributors/scripts.md
@@ -1,6 +1,6 @@
 # Scripts
 
-The editor provides several vendor and internal scripts to plugin developers. Script names, handles, and descriptions are documented in the table below.
+The editor provides several vendors and internal scripts to plugin developers. Script names, handles, and descriptions are documented in the table below.
 
 ## WP Scripts
 


### PR DESCRIPTION
The singular countable noun <b>vendor</b> follows the quantifier <b>several</b>, which requires a plural noun. Consider using a& plural noun or a different quantifier.