### PR TITLE
Create block: Add check for minimum system requirements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10252,6 +10252,7 @@
 			"dev": true,
 			"requires": {
 				"chalk": "^2.4.2",
+				"check-node-version": "^3.1.1",
 				"commander": "^4.1.0",
 				"execa": "^4.0.0",
 				"inquirer": "^7.0.3",

--- a/packages/create-block/CHANGELOG.md
+++ b/packages/create-block/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ### Bug Fixes
 
-- Added error message when minimum system requirements not met.
-- Corrected the minimum `npm` version required to align with `@wordpress/scripts` package used internally.
+- Added error message when minimum system requirements not met ([#20398](https://github.com/WordPress/gutenberg/pull/20398/)).
+- Corrected the minimum `npm` version required to align with `@wordpress/scripts` package used internally ([#20398](https://github.com/WordPress/gutenberg/pull/20398/)).
 
 ## 0.8.0 (2020-02-21)
 

--- a/packages/create-block/CHANGELOG.md
+++ b/packages/create-block/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Master
 
+### Bug Fixes
+
+- Added error message when minimum system requirements not met.
+- Corrected the minimum `npm` version required to align with `@wordpress/scripts` package used internally.
+
 ## 0.8.0 (2020-02-21)
 
 ### New Features

--- a/packages/create-block/README.md
+++ b/packages/create-block/README.md
@@ -19,7 +19,7 @@ You just need to provide the `slug` which is the target location for scaffolded 
   $ npm start
   ```
 
-  _(requires `node` version `10.0.0` or above, and `npm` version `6.1.0` or above)_
+  _(requires `node` version `10.0.0` or above, and `npm` version `6.9.0` or above)_
 
 You don’t need to install or configure tools like [webpack](https://webpack.js.org), [Babel](https://babeljs.io) or [ESLint](https://eslint.org) yourself. They are preconfigured and hidden so that you can focus on the code.
 

--- a/packages/create-block/lib/index.js
+++ b/packages/create-block/lib/index.js
@@ -1,9 +1,11 @@
 /**
  * External dependencies
  */
+const { command } = require( 'execa' );
 const program = require( 'commander' );
 const inquirer = require( 'inquirer' );
 const { startCase } = require( 'lodash' );
+const { join } = require( 'path' );
 
 /**
  * Internal dependencies
@@ -13,6 +15,19 @@ const log = require( './log' );
 const { version } = require( '../package.json' );
 const scaffold = require( './scaffold' );
 const { getDefaultValues, getPrompts } = require( './templates' );
+
+async function checkSystemRequirements() {
+	try {
+		await command( 'check-node-version --package', {
+			cwd: join( __dirname, '..' ),
+		} );
+	} catch ( error ) {
+		log.error( 'Minimum system requirements not met!' );
+		log.error( error.stderr );
+		log.info( error.stdout );
+		process.exit( error.exitCode );
+	}
+}
 
 const commandName = `wp-create-block`;
 program
@@ -31,6 +46,7 @@ program
 		'esnext'
 	)
 	.action( async ( slug, { template } ) => {
+		await checkSystemRequirements();
 		try {
 			const defaultValues = getDefaultValues( template );
 			if ( slug ) {
@@ -50,21 +66,18 @@ program
 			}
 		} catch ( error ) {
 			if ( error instanceof CLIError ) {
-				log.info( '' );
 				log.error( error.message );
 				process.exit( 1 );
 			} else {
 				throw error;
 			}
 		}
-	} );
-
-program.on( '--help', function() {
-	log.info( '' );
-	log.info( 'Examples:' );
-	log.info( `  $ ${ commandName }` );
-	log.info( `  $ ${ commandName } todo-list` );
-	log.info( `  $ ${ commandName } --template es5 todo-list` );
-} );
-
-program.parse( process.argv );
+	} )
+	.on( '--help', function() {
+		log.info( '' );
+		log.info( 'Examples:' );
+		log.info( `  $ ${ commandName }` );
+		log.info( `  $ ${ commandName } todo-list` );
+		log.info( `  $ ${ commandName } --template es5 todo-list` );
+	} )
+	.parse( process.argv );

--- a/packages/create-block/lib/templates.js
+++ b/packages/create-block/lib/templates.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-const CliError = require( './cli-error' );
+const CLIError = require( './cli-error' );
 const prompts = require( './prompts' );
 
 const namespace = 'create-block';
@@ -60,7 +60,7 @@ const templates = {
 
 const getTemplate = ( templateName ) => {
 	if ( ! templates[ templateName ] ) {
-		throw new CliError(
+		throw new CLIError(
 			`Invalid template type name. Allowed values: ${ Object.keys(
 				templates
 			).join( ', ' ) }.`

--- a/packages/create-block/package.json
+++ b/packages/create-block/package.json
@@ -19,8 +19,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=10.0",
-		"npm": ">=6.1"
+		"node": ">=10",
+		"npm": ">=6.9"
 	},
 	"files": [
 		"lib"
@@ -31,6 +31,7 @@
 	},
 	"dependencies": {
 		"chalk": "^2.4.2",
+		"check-node-version": "^3.1.1",
 		"commander": "^4.1.0",
 		"execa": "^4.0.0",
 		"inquirer": "^7.0.3",


### PR DESCRIPTION
## Description

Fixes #20142.

This PR adds error message when minimum system requirements not met. It also include the change that corrected the minimum `npm` version required to align with `@wordpress/scripts` package used internally.

<!-- Please describe what you have changed or added -->

## How has this been tested?
`npx wp-create-block` should still work as expected.

If the minimum required version for `node` or `npm` is not met, the following error is going to be printed on the console:

```
$ npx wp-create-block
Minimum system requirements not met!
Error: Wanted node version >=13 (>=13.0.0)
Error: Wanted npm version >=7.9 (>=7.9.0)
node: 12.16.0
To install node, run `nvm install >=13` or see https://nodejs.org/
npm: 6.13.7
To install npm, run `npm install -g npm@>=7.9`
```

I manually tweaked the version in `package.json` file of `@wordpress/create-block` package. It can be also tested by downgrading `node` or `npm`.

## Types of changes
Bug fix (non-breaking change which fixes an issue).

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
