### PR TITLE
Improve hierarchical term list sorting

### DIFF
--- a/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
@@ -297,14 +297,12 @@ export class HierarchicalTermSelector extends Component {
 			}
 			return false;
 		};
-		const termOrChildIsSelected = ( termA, termB ) => {
+
+		const sortTerms = ( termA, termB ) => {
 			const termASelected = treeHasSelection( termA );
 			const termBSelected = treeHasSelection( termB );
 
-			if ( termASelected === termBSelected ) {
-				return 0;
-			}
-
+			// Selected terms come first.
 			if ( termASelected && ! termBSelected ) {
 				return -1;
 			}
@@ -313,11 +311,30 @@ export class HierarchicalTermSelector extends Component {
 				return 1;
 			}
 
-			return 0;
-		};
-		termsTree.sort( termOrChildIsSelected );
+			// Neither is selected. Now sort by name.
+			if ( termA.name === termB.name ) {
+				return 0;
+			}
 
-		return termsTree;
+			return termA.name < termB.name ? -1 : 1;
+		};
+
+		termsTree.sort( sortTerms );
+
+		// Apply sorting recursively to all children.
+		return termsTree.map( ( termTree ) => {
+			if (
+				undefined === termTree.children ||
+				termTree.children.length === 0
+			) {
+				return termTree;
+			}
+
+			return {
+				...termTree,
+				children: this.sortBySelected( termTree.children ),
+			};
+		} );
 	}
 
 	setFilterValue( event ) {

--- a/packages/editor/src/components/post-taxonomies/style.scss
+++ b/packages/editor/src/components/post-taxonomies/style.scss
@@ -10,6 +10,10 @@
 	margin-bottom: 8px;
 }
 
+.editor-post-taxonomies__hierarchical-terms-choice .components-checkbox-control__input-container {
+	margin-right: 10px;
+}
+
 .editor-post-taxonomies__hierarchical-terms-subchoices {
 	margin-top: 8px;
 	margin-left: $panel-padding;

--- a/packages/editor/src/components/post-taxonomies/test/index.js
+++ b/packages/editor/src/components/post-taxonomies/test/index.js
@@ -129,9 +129,29 @@ describe( 'HierarchicalTermSelector', () => {
 
 	const getStateWrapperAndWrapperWithDefaultTerms = (
 		defaultTerms = [
-			{ id: 1, name: 'Atlanta' },
-			{ id: 2, name: 'Miami' },
-			{ id: 3, name: 'Zurich' },
+			{ id: 3, name: 'Zurich', children: [] },
+			{ id: 1, name: 'Atlanta', children: [] },
+			{
+				id: 2,
+				name: 'Chicago',
+				children: [
+					{
+						id: 6,
+						name: 'Skokie',
+						children: [],
+					},
+					{
+						id: 5,
+						name: 'Naperville',
+						children: [],
+					},
+					{
+						id: 4,
+						name: 'Aurora',
+						children: [],
+					},
+				],
+			},
 		]
 	) => {
 		const app = TestUtils.renderIntoDocument( <App /> );
@@ -158,7 +178,7 @@ describe( 'HierarchicalTermSelector', () => {
 				wrapper,
 				'components-checkbox-control__input'
 			)
-		).toHaveLength( 3 );
+		).toHaveLength( 6 );
 	} );
 
 	it( 'handles changes to selected terms', () => {
@@ -180,7 +200,7 @@ describe( 'HierarchicalTermSelector', () => {
 			)
 		).toHaveLength( 1 );
 
-		app.setState( { selectedTerms: [ 1, 2 ] } );
+		app.setState( { selectedTerms: [ 1, 5 ] } );
 
 		expect(
 			TestUtils.scryRenderedDOMComponentsWithClass(
@@ -251,7 +271,7 @@ describe( 'HierarchicalTermSelector', () => {
 				wrapper,
 				'components-checkbox-control__input'
 			)
-		).toHaveLength( 2 );
+		).toHaveLength( 4 );
 	} );
 
 	it( 'shows selected matching search terms first', () => {
@@ -265,7 +285,7 @@ describe( 'HierarchicalTermSelector', () => {
 				wrapper,
 				'components-checkbox-control__label'
 			)[ 0 ].innerHTML
-		).toEqual( expect.stringContaining( 'Miami' ) );
+		).toEqual( expect.stringContaining( 'Chicago' ) );
 
 		// Select Zurich.
 		app.setState( { selectedTerms: [ 3 ] } );
@@ -278,7 +298,26 @@ describe( 'HierarchicalTermSelector', () => {
 			)[ 0 ].innerHTML
 		).toEqual( expect.stringContaining( 'Zurich' ) );
 
-		// Unselect Zurich.
+		// Add a child of Chicago.
+		app.setState( { selectedTerms: [ 3, 6 ] } );
+
+		// Chicago will now be first even though it's not selected.
+		expect(
+			TestUtils.scryRenderedDOMComponentsWithClass(
+				wrapper,
+				'components-checkbox-control__label'
+			)[ 0 ].innerHTML
+		).toEqual( expect.stringContaining( 'Chicago' ) );
+
+		// And the child will be next.
+		expect(
+			TestUtils.scryRenderedDOMComponentsWithClass(
+				wrapper,
+				'components-checkbox-control__label'
+			)[ 1 ].innerHTML
+		).toEqual( expect.stringContaining( 'Skokie' ) );
+
+		// Unselect all.
 		app.setState( { selectedTerms: [] } );
 
 		expect(
@@ -286,7 +325,7 @@ describe( 'HierarchicalTermSelector', () => {
 				wrapper,
 				'components-checkbox-control__label'
 			)[ 0 ].innerHTML
-		).toEqual( expect.stringContaining( 'Miami' ) );
+		).toEqual( expect.stringContaining( 'Chicago' ) );
 
 		wrapper.setFilterValue( { target: { value: '' } } );
 

--- a/packages/editor/src/components/post-taxonomies/test/index.js
+++ b/packages/editor/src/components/post-taxonomies/test/index.js
@@ -2,11 +2,18 @@
  * External dependencies
  */
 import { shallow } from 'enzyme';
+import TestUtils from 'react-dom/test-utils';
+/**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import { PostTaxonomies } from '../';
+import { HierarchicalTermSelector } from '../hierarchical-term-selector';
+import { buildTermsTree } from '../../../utils/terms';
 
 describe( 'PostTaxonomies', () => {
 	it( 'should render no children if taxonomy data not available', () => {
@@ -98,5 +105,196 @@ describe( 'PostTaxonomies', () => {
 		);
 
 		expect( wrapperTwo.at( 0 ) ).toHaveLength( 0 );
+	} );
+} );
+
+describe( 'HierarchicalTermSelector', () => {
+	// Simulates the state passed in from the store.
+	class App extends Component {
+		constructor( props ) {
+			super( props );
+			this.state = { selectedTerms: [] };
+		}
+
+		render() {
+			return (
+				<HierarchicalTermSelector
+					terms={ this.state.selectedTerms }
+					hasAssignAction={ true }
+					debouncedSpeak={ () => null }
+				/>
+			);
+		}
+	}
+
+	const getStateWrapperAndWrapperWithDefaultTerms = (
+		defaultTerms = [
+			{ id: 1, name: 'Atlanta' },
+			{ id: 2, name: 'Miami' },
+			{ id: 3, name: 'Zurich' },
+		]
+	) => {
+		const app = TestUtils.renderIntoDocument( <App /> );
+		const wrapper = TestUtils.findRenderedComponentWithType(
+			app,
+			HierarchicalTermSelector
+		);
+
+		wrapper.setState( {
+			availableTerms: defaultTerms,
+			availableTermsTree: wrapper.sortBySelected(
+				buildTermsTree( defaultTerms )
+			),
+		} );
+
+		return { wrapper, app };
+	};
+
+	it( 'rerenders tree with no terms selected', () => {
+		const { wrapper } = getStateWrapperAndWrapperWithDefaultTerms();
+
+		expect(
+			TestUtils.scryRenderedDOMComponentsWithClass(
+				wrapper,
+				'components-checkbox-control__input'
+			)
+		).toHaveLength( 3 );
+	} );
+
+	it( 'handles changes to selected terms', () => {
+		const { app, wrapper } = getStateWrapperAndWrapperWithDefaultTerms();
+
+		expect(
+			TestUtils.scryRenderedDOMComponentsWithClass(
+				wrapper,
+				'components-checkbox-control__checked'
+			)
+		).toHaveLength( 0 );
+
+		app.setState( { selectedTerms: [ 1 ] } );
+
+		expect(
+			TestUtils.scryRenderedDOMComponentsWithClass(
+				wrapper,
+				'components-checkbox-control__checked'
+			)
+		).toHaveLength( 1 );
+
+		app.setState( { selectedTerms: [ 1, 2 ] } );
+
+		expect(
+			TestUtils.scryRenderedDOMComponentsWithClass(
+				wrapper,
+				'components-checkbox-control__checked'
+			)
+		).toHaveLength( 2 );
+
+		app.setState( { selectedTerms: [] } );
+
+		expect(
+			TestUtils.scryRenderedDOMComponentsWithClass(
+				wrapper,
+				'components-checkbox-control__checked'
+			)
+		).toHaveLength( 0 );
+	} );
+
+	it( 'brings selected terms to the top', () => {
+		const { app, wrapper } = getStateWrapperAndWrapperWithDefaultTerms();
+
+		// No selected terms; Atlanta should be first.
+		expect(
+			TestUtils.scryRenderedDOMComponentsWithClass(
+				wrapper,
+				'components-checkbox-control__label'
+			)[ 0 ].innerHTML
+		).toEqual( expect.stringContaining( 'Atlanta' ) );
+
+		// Select Zurich.
+		app.setState( { selectedTerms: [ 3 ] } );
+
+		// Zurich should be first.
+		expect(
+			TestUtils.scryRenderedDOMComponentsWithClass(
+				wrapper,
+				'components-checkbox-control__label'
+			)[ 0 ].innerHTML
+		).toEqual( expect.stringContaining( 'Zurich' ) );
+
+		// Unset selection. Items should be alphabetical again.
+		app.setState( { selectedTerms: [] } );
+
+		expect(
+			TestUtils.scryRenderedDOMComponentsWithClass(
+				wrapper,
+				'components-checkbox-control__label'
+			)[ 0 ].innerHTML
+		).toEqual( expect.stringContaining( 'Atlanta' ) );
+	} );
+
+	it( 'shows matching search terms', () => {
+		const { wrapper } = getStateWrapperAndWrapperWithDefaultTerms();
+
+		wrapper.setFilterValue( { target: { value: 'zur' } } );
+
+		expect(
+			TestUtils.scryRenderedDOMComponentsWithClass(
+				wrapper,
+				'components-checkbox-control__input'
+			)
+		).toHaveLength( 1 );
+
+		wrapper.setFilterValue( { target: { value: 'i' } } );
+
+		expect(
+			TestUtils.scryRenderedDOMComponentsWithClass(
+				wrapper,
+				'components-checkbox-control__input'
+			)
+		).toHaveLength( 2 );
+	} );
+
+	it( 'shows selected matching search terms first', () => {
+		const { app, wrapper } = getStateWrapperAndWrapperWithDefaultTerms();
+
+		wrapper.setFilterValue( { target: { value: 'i' } } );
+
+		// No terms selected. The search terms display alphabetically.
+		expect(
+			TestUtils.scryRenderedDOMComponentsWithClass(
+				wrapper,
+				'components-checkbox-control__label'
+			)[ 0 ].innerHTML
+		).toEqual( expect.stringContaining( 'Miami' ) );
+
+		// Select Zurich.
+		app.setState( { selectedTerms: [ 3 ] } );
+
+		// Expect Zurich to come first.
+		expect(
+			TestUtils.scryRenderedDOMComponentsWithClass(
+				wrapper,
+				'components-checkbox-control__label'
+			)[ 0 ].innerHTML
+		).toEqual( expect.stringContaining( 'Zurich' ) );
+
+		// Unselect Zurich.
+		app.setState( { selectedTerms: [] } );
+
+		expect(
+			TestUtils.scryRenderedDOMComponentsWithClass(
+				wrapper,
+				'components-checkbox-control__label'
+			)[ 0 ].innerHTML
+		).toEqual( expect.stringContaining( 'Miami' ) );
+
+		wrapper.setFilterValue( { target: { value: '' } } );
+
+		expect(
+			TestUtils.scryRenderedDOMComponentsWithClass(
+				wrapper,
+				'components-checkbox-control__label'
+			)[ 0 ].innerHTML
+		).toEqual( expect.stringContaining( 'Atlanta' ) );
 	} );
 } );


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

This resolves #12171 by implementing the solution outlined in @mapk's comment here: https://github.com/WordPress/gutenberg/issues/12171#issuecomment-513031610

The first requirement, "Selected categories automatically appear at the top of the list," was already the case when the `HierarchicalTermSelector` first loads. But no further sorting would happen as the user interacted with the feature. 

This update rebuilds the tree when the selected terms change. When there's a filter term, it also rebuilds the separate filtered tree according to the requirements.

Terms are now alphabetized when not selected, and sorting is applied recursively through the tree.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Added Jest tests that cover not just these changes but the filtering and ordering of the term list generally.

Tested locally in the browser.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Non-breaking change to the internal functionality of an existing component. Also made one small CSS change that I'll note in an inline comment.

Side note: I feel the HierarchicalTermSelector component is due for a refactor. The dependency on app state and the creation of side effects within internal methods make testing the component complicated, and I think the current implementation can begin to have performance issues with long category lists. Breaking it down into three or four functional components with hooks would solve these problems. That could be done as part of this issue: https://github.com/WordPress/gutenberg/issues/17476

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
