### PR TITLE
@wordpress/env: Use user with UID=33 to run WP CLI commands

### DIFF
--- a/packages/env/lib/build-docker-compose-config.js
+++ b/packages/env/lib/build-docker-compose-config.js
@@ -55,6 +55,12 @@ module.exports = function buildDockerComposeConfig( config ) {
 	const developmentPorts = `\${WP_ENV_PORT:-${ config.port }}:80`;
 	const testsPorts = `\${WP_ENV_TESTS_PORT:-${ config.testsPort }}:80`;
 
+	// The www-data user in wordpress:cli has a different UID (82) to the
+	// www-data user in wordpress (33). Ensure we use the wordpress www-data
+	// user for CLI commands.
+	// https://github.com/docker-library/wordpress/issues/256
+	const cliUser = '33:33';
+
 	return {
 		version: '3.7',
 		services: {
@@ -86,11 +92,13 @@ module.exports = function buildDockerComposeConfig( config ) {
 				depends_on: [ 'wordpress' ],
 				image: 'wordpress:cli',
 				volumes: developmentMounts,
+				user: cliUser,
 			},
 			'tests-cli': {
 				depends_on: [ 'wordpress' ],
 				image: 'wordpress:cli',
 				volumes: testsMounts,
+				user: cliUser,
 			},
 			composer: {
 				image: 'composer',


### PR DESCRIPTION
Follows https://github.com/WordPress/gutenberg/pull/20352. Fixes the issue described in https://github.com/WordPress/gutenberg/issues/20180#issuecomment-590131178.

The `www-data` user in `wordpress:cli` has a different UID (82) to the `www-data` user in `wordpress` (33). This change ensures we use the `wordpress` `www-data` user for CLI commands.

This only is an issue when `"core"` in `.wp-env.json` is set to `null`, because this means that we're using a volume mount instead of a bind mount. Files in a bind mount have the same permissions as they do on the host system.

See https://github.com/docker-library/wordpress/issues/256 for more discussion on this.

cc. @noahtallen @epiqueras 