### PR TITLE
@wordpress/env: Set owner of wp-content to www-data

### DIFF
--- a/packages/env/lib/env.js
+++ b/packages/env/lib/env.js
@@ -50,6 +50,7 @@ module.exports = {
 		await module.exports.stop( { spinner, debug } );
 
 		await checkForLegacyInstall( spinner );
+
 		const config = await initConfig( { spinner, debug } );
 
 		spinner.text = 'Downloading WordPress.';
@@ -113,6 +114,14 @@ module.exports = {
 			config: config.dockerComposeConfigPath,
 			log: config.debug,
 		} );
+
+		if ( config.coreSource === null ) {
+			// Don't chown wp-content when it exists on the user's local filesystem.
+			await Promise.all( [
+				makeContentDirectoriesWritable( 'development', config ),
+				makeContentDirectoriesWritable( 'tests', config ),
+			] );
+		}
 
 		try {
 			await checkDatabaseConnection( config );
@@ -353,6 +362,35 @@ async function copyCoreFiles( fromPath, toPath ) {
 			return true;
 		},
 	} );
+}
+
+/**
+ * Makes the WordPress content directories (wp-content, wp-content/plugins,
+ * wp-content/themes) owned by the www-data user. This ensures that WordPress
+ * can write to these directories.
+ *
+ * This is necessary when running wp-env with `"core": null` because Docker
+ * will automatically create these directories as the root user when binding
+ * volumes during `docker-compose up`, and `docker-compose up` doesn't support
+ * the `-u` option.
+ *
+ * See https://github.com/docker-library/wordpress/issues/436.
+ *
+ * @param {string} environment The environment to check. Either 'development' or 'tests'.
+ * @param {Config} config The wp-env config object.
+ */
+async function makeContentDirectoriesWritable(
+	environment,
+	{ dockerComposeConfigPath, debug }
+) {
+	await dockerCompose.exec(
+		environment === 'development' ? 'wordpress' : 'tests-wordpress',
+		'chown www-data:www-data wp-content wp-content/plugins wp-content/themes',
+		{
+			config: dockerComposeConfigPath,
+			log: debug,
+		}
+	);
 }
 
 /**


### PR DESCRIPTION
Fixes bug I noticed in https://github.com/WordPress/gutenberg/pull/20403#issuecomment-590154382.

Makes the WordPress content directories (`wp-content`, `wp-content/plugins`, `wp-content/themes`) owned by the `www-data` user. This ensures that WordPress can write to these directories.

This is necessary when running wp-env with `"core": null` because Docker will automatically create these directories as the root user when binding volumes during `docker-compose up`, and `docker-compose up` doesn't support a `--user` option.

See https://github.com/docker-library/wordpress/issues/436.

**To test:**

1. Set `"core": null` in your `.wp-env.json` or `.wp-env.override.json`
2. Run `packages/env/bin/wp-env start`
3. Check that you can upload images, install themes, and install plugins 