### PR TITLE
Scripts: Ensure packages-update works with missing dependencies

### DIFF
--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Master
 
+### Bug Fixes
+
+- Ensure `packages-update` work when `dependencies` or `devDependencies` are missing in the `package.json` file.
+
 ## 7.1.0 (2020-02-10)
 
 ### Bug Fixes

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Bug Fixes
 
-- Ensure `packages-update` work when `dependencies` or `devDependencies` are missing in the `package.json` file.
+- Ensure `packages-update` work when `dependencies` or `devDependencies` are missing in the `package.json` file ([#20408](https://github.com/WordPress/gutenberg/pull/20408)).
 
 ## 7.1.0 (2020-02-10)
 

--- a/packages/scripts/scripts/packages-update.js
+++ b/packages/scripts/scripts/packages-update.js
@@ -15,9 +15,9 @@ function readJSONFile( fileName ) {
 	return JSON.parse( data );
 }
 
-function getWordPressPackages( packageJSON ) {
-	return Object.keys( packageJSON.dependencies )
-		.concat( Object.keys( packageJSON.devDependencies ) )
+function getWordPressPackages( { dependencies = {}, devDependencies = {} } ) {
+	return Object.keys( dependencies )
+		.concat( Object.keys( devDependencies ) )
 		.filter( ( packageName ) =>
 			packageName.startsWith( WORDPRESS_PACKAGES_PREFIX )
 		);
@@ -26,19 +26,17 @@ function getWordPressPackages( packageJSON ) {
 function getPackageVersionDiff( initialPackageJSON, finalPackageJSON ) {
 	const diff = [ 'dependencies', 'devDependencies' ].reduce(
 		( result, keyPackageJSON ) => {
-			return Object.keys( finalPackageJSON[ keyPackageJSON ] ).reduce(
-				( _result, dependency ) => {
-					const initial =
-						initialPackageJSON[ keyPackageJSON ][ dependency ];
-					const final =
-						finalPackageJSON[ keyPackageJSON ][ dependency ];
-					if ( initial !== final ) {
-						_result.push( { dependency, initial, final } );
-					}
-					return _result;
-				},
-				result
-			);
+			return Object.keys(
+				finalPackageJSON[ keyPackageJSON ] || {}
+			).reduce( ( _result, dependency ) => {
+				const initial =
+					initialPackageJSON[ keyPackageJSON ][ dependency ];
+				const final = finalPackageJSON[ keyPackageJSON ][ dependency ];
+				if ( initial !== final ) {
+					_result.push( { dependency, initial, final } );
+				}
+				return _result;
+			}, result );
 		},
 		[]
 	);


### PR DESCRIPTION
## Description

I discovered thed following issue when testing `wp-scripts packages-update` with `gutenberg-examples` repository:

```bash
$ npx wp-scripts packages-update
/Users/gziolo/Projects/gutenberg-examples/node_modules/@wordpress/scripts/scripts/packages-update.js:19
        return Object.keys( packageJSON.dependencies )
                      ^
TypeError: Cannot convert undefined or null to object
```

`dependencies` key is missing in the `package.json` causing the script to error. The proposed fix mitigates the issue by providing the default value.

## How has this been tested?

I monkey-patched `node_modules` to use the updated version and tested it in the same repository. 

## Types of changes
Bug fix (non-breaking change which fixes an issue).

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
