### PR TITLE
Move the device preview state to the edit-post store

### DIFF
--- a/docs/designers-developers/developers/data/data-core-block-editor.md
+++ b/docs/designers-developers/developers/data/data-core-block-editor.md
@@ -500,18 +500,6 @@ _Returns_
 
 -   `?string`: Adjacent block's client ID, or null if none exists.
 
-<a name="getPreviewDeviceType" href="#getPreviewDeviceType">#</a> **getPreviewDeviceType**
-
-Returns the current editing canvas device type.
-
-_Parameters_
-
--   _state_ `Object`: Global application state.
-
-_Returns_
-
--   `string`: Device type.
-
 <a name="getPreviousBlockClientId" href="#getPreviousBlockClientId">#</a> **getPreviousBlockClientId**
 
 Returns the previous block's client ID from the given reference start ID.
@@ -1225,18 +1213,6 @@ Generators that triggers an action used to enable or disable the navigation mode
 _Parameters_
 
 -   _isNavigationMode_ `string`: Enable/Disable navigation mode.
-
-<a name="setPreviewDeviceType" href="#setPreviewDeviceType">#</a> **setPreviewDeviceType**
-
-Returns an action object used to toggle the width of the editing canvas
-
-_Parameters_
-
--   _deviceType_ `string`: 
-
-_Returns_
-
--   `Object`: Action object.
 
 <a name="setTemplateValidity" href="#setTemplateValidity">#</a> **setTemplateValidity**
 

--- a/docs/designers-developers/developers/data/data-core-edit-post.md
+++ b/docs/designers-developers/developers/data/data-core-edit-post.md
@@ -98,6 +98,18 @@ _Returns_
 
 -   `Object`: Preferences Object.
 
+<a name="getPreviewDeviceType" href="#getPreviewDeviceType">#</a> **getPreviewDeviceType**
+
+Returns the current editing canvas device type.
+
+_Parameters_
+
+-   _state_ `Object`: Global application state.
+
+_Returns_
+
+-   `string`: Device type.
+
 <a name="hasMetaBoxes" href="#hasMetaBoxes">#</a> **hasMetaBoxes**
 
 Returns true if the post is using Meta Boxes
@@ -381,6 +393,18 @@ what Meta boxes are available in which location.
 _Parameters_
 
 -   _metaBoxesPerLocation_ `Object`: Meta boxes per location.
+
+_Returns_
+
+-   `Object`: Action object.
+
+<a name="setPreviewDeviceType" href="#setPreviewDeviceType">#</a> **setPreviewDeviceType**
+
+Returns an action object used to toggle the width of the editing canvas
+
+_Parameters_
+
+-   _deviceType_ `string`: 
 
 _Returns_
 

--- a/docs/designers-developers/developers/data/data-core-edit-post.md
+++ b/docs/designers-developers/developers/data/data-core-edit-post.md
@@ -98,18 +98,6 @@ _Returns_
 
 -   `Object`: Preferences Object.
 
-<a name="getPreviewDeviceType" href="#getPreviewDeviceType">#</a> **getPreviewDeviceType**
-
-Returns the current editing canvas device type.
-
-_Parameters_
-
--   _state_ `Object`: Global application state.
-
-_Returns_
-
--   `string`: Device type.
-
 <a name="hasMetaBoxes" href="#hasMetaBoxes">#</a> **hasMetaBoxes**
 
 Returns true if the post is using Meta Boxes
@@ -393,18 +381,6 @@ what Meta boxes are available in which location.
 _Parameters_
 
 -   _metaBoxesPerLocation_ `Object`: Meta boxes per location.
-
-_Returns_
-
--   `Object`: Action object.
-
-<a name="setPreviewDeviceType" href="#setPreviewDeviceType">#</a> **setPreviewDeviceType**
-
-Returns an action object used to toggle the width of the editing canvas
-
-_Parameters_
-
--   _deviceType_ `string`: 
 
 _Returns_
 

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -800,20 +800,6 @@ export function updateSettings( settings ) {
 }
 
 /**
- * Returns an action object used to toggle the width of the editing canvas
- *
- * @param {string} deviceType
- *
- * @return {Object} Action object.
- */
-export function setPreviewDeviceType( deviceType ) {
-	return {
-		type: 'SET_PREVIEW_DEVICE_TYPE',
-		deviceType,
-	};
-}
-
-/**
  * Returns an action object used in signalling that a temporary reusable blocks have been saved
  * in order to switch its temporary id with the real id.
  *

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1448,23 +1448,6 @@ export function automaticChangeStatus( state, action ) {
 	// Reset the state by default (for any action not handled).
 }
 
-/**
- * Reducer returning the editing canvas device type.
- *
- * @param {Object} state  Current state.
- * @param {Object} action Dispatched action.
- *
- * @return {Object} Updated state.
- */
-export function deviceType( state = 'Desktop', action ) {
-	switch ( action.type ) {
-		case 'SET_PREVIEW_DEVICE_TYPE':
-			return action.deviceType;
-	}
-
-	return state;
-}
-
 export default combineReducers( {
 	blocks,
 	isTyping,
@@ -1484,5 +1467,4 @@ export default combineReducers( {
 	lastBlockAttributesChange,
 	isNavigationMode,
 	automaticChangeStatus,
-	deviceType,
 } );

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1621,14 +1621,3 @@ export function isNavigationMode( state ) {
 export function didAutomaticChange( state ) {
 	return !! state.automaticChangeStatus;
 }
-
-/**
- * Returns the current editing canvas device type.
- *
- * @param {Object} state Global application state.
- *
- * @return {string} Device type.
- */
-export function getPreviewDeviceType( state ) {
-	return state.deviceType;
-}

--- a/packages/edit-post/src/components/preview-options/index.js
+++ b/packages/edit-post/src/components/preview-options/index.js
@@ -30,10 +30,12 @@ export default function PreviewOptions( {
 	forceIsAutosaveable,
 	forcePreviewLink,
 } ) {
-	const { setPreviewDeviceType } = useDispatch( 'core/edit-post' );
+	const {
+		__experimentalSetPreviewDeviceType: setPreviewDeviceType,
+	} = useDispatch( 'core/edit-post' );
 
 	const deviceType = useSelect( ( select ) => {
-		return select( 'core/edit-post' ).getPreviewDeviceType();
+		return select( 'core/edit-post' ).__experimentalGetPreviewDeviceType();
 	}, [] );
 
 	const translateDropdownButtonText = () => {

--- a/packages/edit-post/src/components/preview-options/index.js
+++ b/packages/edit-post/src/components/preview-options/index.js
@@ -30,10 +30,10 @@ export default function PreviewOptions( {
 	forceIsAutosaveable,
 	forcePreviewLink,
 } ) {
-	const { setPreviewDeviceType } = useDispatch( 'core/block-editor' );
+	const { setPreviewDeviceType } = useDispatch( 'core/edit-post' );
 
 	const deviceType = useSelect( ( select ) => {
-		return select( 'core/block-editor' ).getPreviewDeviceType();
+		return select( 'core/edit-post' ).getPreviewDeviceType();
 	}, [] );
 
 	const translateDropdownButtonText = () => {

--- a/packages/edit-post/src/components/resize-canvas/index.js
+++ b/packages/edit-post/src/components/resize-canvas/index.js
@@ -12,7 +12,7 @@ import { useEffect, useState } from '@wordpress/element';
  */
 export function useResizeCanvas() {
 	const deviceType = useSelect( ( select ) => {
-		return select( 'core/block-editor' ).getPreviewDeviceType();
+		return select( 'core/edit-post' ).getPreviewDeviceType();
 	}, [] );
 
 	const [ actualWidth, updateActualWidth ] = useState( window.innerWidth );

--- a/packages/edit-post/src/components/resize-canvas/index.js
+++ b/packages/edit-post/src/components/resize-canvas/index.js
@@ -12,7 +12,7 @@ import { useEffect, useState } from '@wordpress/element';
  */
 export function useResizeCanvas() {
 	const deviceType = useSelect( ( select ) => {
-		return select( 'core/edit-post' ).getPreviewDeviceType();
+		return select( 'core/edit-post' ).__experimentalGetPreviewDeviceType();
 	}, [] );
 
 	const [ actualWidth, updateActualWidth ] = useState( window.innerWidth );

--- a/packages/edit-post/src/store/actions.js
+++ b/packages/edit-post/src/store/actions.js
@@ -269,7 +269,7 @@ export function metaBoxUpdatesSuccess() {
  *
  * @return {Object} Action object.
  */
-export function setPreviewDeviceType( deviceType ) {
+export function __experimentalSetPreviewDeviceType( deviceType ) {
 	return {
 		type: 'SET_PREVIEW_DEVICE_TYPE',
 		deviceType,

--- a/packages/edit-post/src/store/actions.js
+++ b/packages/edit-post/src/store/actions.js
@@ -261,3 +261,17 @@ export function metaBoxUpdatesSuccess() {
 		type: 'META_BOX_UPDATES_SUCCESS',
 	};
 }
+
+/**
+ * Returns an action object used to toggle the width of the editing canvas
+ *
+ * @param {string} deviceType
+ *
+ * @return {Object} Action object.
+ */
+export function setPreviewDeviceType( deviceType ) {
+	return {
+		type: 'SET_PREVIEW_DEVICE_TYPE',
+		deviceType,
+	};
+}

--- a/packages/edit-post/src/store/actions.js
+++ b/packages/edit-post/src/store/actions.js
@@ -263,7 +263,9 @@ export function metaBoxUpdatesSuccess() {
 }
 
 /**
- * Returns an action object used to toggle the width of the editing canvas
+ * Returns an action object used to toggle the width of the editing canvas.
+ * It's marked as experimental because, potentially, we'll need this
+ * in several pages including edit-site.
  *
  * @param {string} deviceType
  *

--- a/packages/edit-post/src/store/reducer.js
+++ b/packages/edit-post/src/store/reducer.js
@@ -271,6 +271,23 @@ export function metaBoxLocations( state = {}, action ) {
 	return state;
 }
 
+/**
+ * Reducer returning the editing canvas device type.
+ *
+ * @param {Object} state  Current state.
+ * @param {Object} action Dispatched action.
+ *
+ * @return {Object} Updated state.
+ */
+export function deviceType( state = 'Desktop', action ) {
+	switch ( action.type ) {
+		case 'SET_PREVIEW_DEVICE_TYPE':
+			return action.deviceType;
+	}
+
+	return state;
+}
+
 const metaBoxes = combineReducers( {
 	isSaving: isSavingMetaBoxes,
 	locations: metaBoxLocations,
@@ -283,4 +300,5 @@ export default combineReducers( {
 	preferences,
 	publishSidebarActive,
 	removedPanels,
+	deviceType,
 } );

--- a/packages/edit-post/src/store/selectors.js
+++ b/packages/edit-post/src/store/selectors.js
@@ -295,6 +295,6 @@ export function isSavingMetaBoxes( state ) {
  *
  * @return {string} Device type.
  */
-export function getPreviewDeviceType( state ) {
+export function __experimentalGetPreviewDeviceType( state ) {
 	return state.deviceType;
 }

--- a/packages/edit-post/src/store/selectors.js
+++ b/packages/edit-post/src/store/selectors.js
@@ -287,3 +287,14 @@ export function hasMetaBoxes( state ) {
 export function isSavingMetaBoxes( state ) {
 	return state.metaBoxes.isSaving;
 }
+
+/**
+ * Returns the current editing canvas device type.
+ *
+ * @param {Object} state Global application state.
+ *
+ * @return {string} Device type.
+ */
+export function getPreviewDeviceType( state ) {
+	return state.deviceType;
+}

--- a/packages/edit-post/src/store/selectors.js
+++ b/packages/edit-post/src/store/selectors.js
@@ -290,6 +290,8 @@ export function isSavingMetaBoxes( state ) {
 
 /**
  * Returns the current editing canvas device type.
+ * It's marked as experimental because, potentially, we'll need this
+ * in several pages including edit-site.
  *
  * @param {Object} state Global application state.
  *


### PR DESCRIPTION
The block-editor module doesn't have to know about the preview device at all, it's more a UI thing, so I moved everything to the edit-post package.