### PR TITLE
[Latest Posts] Add filtering by author

### DIFF
--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -74,6 +74,7 @@ class LatestPostsEdit extends Component {
 			attributes,
 			setAttributes,
 			imageSizeOptions,
+			authorsList,
 			latestPosts,
 			defaultImageWidth,
 			defaultImageHeight,
@@ -89,6 +90,7 @@ class LatestPostsEdit extends Component {
 			order,
 			orderBy,
 			categories,
+			author,
 			postsToShow,
 			excerptLength,
 			featuredImageAlign,
@@ -210,7 +212,9 @@ class LatestPostsEdit extends Component {
 						{ ...{ order, orderBy } }
 						numberOfItems={ postsToShow }
 						categoriesList={ categoriesList }
+						authorsList={ authorsList }
 						selectedCategoryId={ categories }
+						selectedAuthorId={ author }
 						onOrderChange={ ( value ) =>
 							setAttributes( { order: value } )
 						}
@@ -220,6 +224,11 @@ class LatestPostsEdit extends Component {
 						onCategoryChange={ ( value ) =>
 							setAttributes( {
 								categories: '' !== value ? value : undefined,
+							} )
+						}
+						onAuthorChange={ ( value ) =>
+							setAttributes( {
+								author: '' !== value ? value : undefined,
 							} )
 						}
 						onNumberOfItemsChange={ ( value ) =>
@@ -420,7 +429,7 @@ export default withSelect( ( select, props ) => {
 		orderBy,
 		categories,
 	} = props.attributes;
-	const { getEntityRecords, getMedia } = select( 'core' );
+	const { getEntityRecords, getMedia, getAuthors } = select( 'core' );
 	const { getSettings } = select( 'core/block-editor' );
 	const { imageSizes, imageDimensions } = getSettings();
 	const latestPostsQuery = pickBy(
@@ -464,5 +473,11 @@ export default withSelect( ( select, props ) => {
 					}
 					return post;
 			  } ),
+		authorsList: getAuthors().map( ( author ) => {
+			return {
+				value: author.id,
+				label: author.name,
+			};
+		} ),
 	};
 } )( LatestPostsEdit );

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -428,6 +428,7 @@ export default withSelect( ( select, props ) => {
 		order,
 		orderBy,
 		categories,
+		author,
 	} = props.attributes;
 	const { getEntityRecords, getMedia, getAuthors } = select( 'core' );
 	const { getSettings } = select( 'core/block-editor' );
@@ -438,6 +439,7 @@ export default withSelect( ( select, props ) => {
 			order,
 			orderby: orderBy,
 			per_page: postsToShow,
+			author,
 		},
 		( value ) => ! isUndefined( value )
 	);
@@ -473,10 +475,10 @@ export default withSelect( ( select, props ) => {
 					}
 					return post;
 			  } ),
-		authorsList: getAuthors().map( ( author ) => {
+		authorsList: getAuthors().map( ( currentAuthor ) => {
 			return {
-				value: author.id,
-				label: author.name,
+				value: currentAuthor.id,
+				label: currentAuthor.name,
 			};
 		} ),
 	};

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -157,6 +157,9 @@ function register_block_core_latest_posts() {
 				'categories'              => array(
 					'type' => 'string',
 				),
+				'author'                  => array(
+					'type' => 'string',
+				),
 				'postsToShow'             => array(
 					'type'    => 'number',
 					'default' => 5,

--- a/packages/components/src/query-controls/index.js
+++ b/packages/components/src/query-controls/index.js
@@ -78,10 +78,10 @@ export default function QueryControls( {
 		onAuthorChange && (
 			<SelectControl
 				key="query-controls-author-select"
-				options={ authorsList }
 				label={ __( 'Author' ) }
 				noOptionLabel={ __( 'All' ) }
 				value={ selectedAuthorId }
+				options={ authorsList }
 				onChange={ onAuthorChange }
 			/>
 		),

--- a/packages/components/src/query-controls/index.js
+++ b/packages/components/src/query-controls/index.js
@@ -1,4 +1,10 @@
 /**
+ * External dependencies
+ */
+
+import { union } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -79,9 +85,11 @@ export default function QueryControls( {
 			<SelectControl
 				key="query-controls-author-select"
 				label={ __( 'Author' ) }
-				noOptionLabel={ __( 'All' ) }
 				value={ selectedAuthorId }
-				options={ authorsList }
+				options={ union(
+					[ { value: '', label: __( 'All' ) } ],
+					authorsList
+				) }
 				onChange={ onAuthorChange }
 			/>
 		),

--- a/packages/components/src/query-controls/index.js
+++ b/packages/components/src/query-controls/index.js
@@ -14,13 +14,16 @@ const DEFAULT_MAX_ITEMS = 100;
 
 export default function QueryControls( {
 	categoriesList,
+	authorsList,
 	selectedCategoryId,
+	selectedAuthorId,
 	numberOfItems,
 	order,
 	orderBy,
 	maxItems = DEFAULT_MAX_ITEMS,
 	minItems = DEFAULT_MIN_ITEMS,
 	onCategoryChange,
+	onAuthorChange,
 	onNumberOfItemsChange,
 	onOrderChange,
 	onOrderByChange,
@@ -70,6 +73,16 @@ export default function QueryControls( {
 				noOptionLabel={ __( 'All' ) }
 				selectedCategoryId={ selectedCategoryId }
 				onChange={ onCategoryChange }
+			/>
+		),
+		onAuthorChange && (
+			<SelectControl
+				key="query-controls-author-select"
+				options={ authorsList }
+				label={ __( 'Author' ) }
+				noOptionLabel={ __( 'All' ) }
+				value={ selectedAuthorId }
+				onChange={ onAuthorChange }
 			/>
 		),
 		onNumberOfItemsChange && (


### PR DESCRIPTION
## Description
Adds an Author filter to the `LatestPosts` block.

## How has this been tested?
Tested locally by:

0. Making sure I have posts by multiple authors
1. Creating a post
2. Adding a `LatestPosts` block
3. Setting the Author to some author

## Screenshots 

![latest-posts-author](https://user-images.githubusercontent.com/107534/75243274-3d373b80-57d2-11ea-9e0d-78a3a2ddbee1.gif)


## Types of changes
Non breaking filter addition to `QueryControls` component and `LatestPosts` block.