### PR TITLE
Fix: Inconsistency on Import from JSON button look

### DIFF
--- a/packages/list-reusable-blocks/src/components/import-dropdown/index.js
+++ b/packages/list-reusable-blocks/src/components/import-dropdown/index.js
@@ -24,7 +24,6 @@ function ImportDropdown( { onUpload } ) {
 					aria-expanded={ isOpen }
 					onClick={ onToggle }
 					isPrimary
-					isSmall
 				>
 					{ __( 'Import from JSON' ) }
 				</Button>

--- a/packages/list-reusable-blocks/src/components/import-dropdown/index.js
+++ b/packages/list-reusable-blocks/src/components/import-dropdown/index.js
@@ -20,7 +20,12 @@ function ImportDropdown( { onUpload } ) {
 			position="bottom right"
 			contentClassName="list-reusable-blocks-import-dropdown__content"
 			renderToggle={ ( { isOpen, onToggle } ) => (
-				<Button aria-expanded={ isOpen } onClick={ onToggle } isPrimary>
+				<Button
+					aria-expanded={ isOpen }
+					onClick={ onToggle }
+					isPrimary
+					isSmall
+				>
 					{ __( 'Import from JSON' ) }
 				</Button>
 			) }

--- a/packages/list-reusable-blocks/src/style.scss
+++ b/packages/list-reusable-blocks/src/style.scss
@@ -3,7 +3,7 @@
 
 .list-reusable-blocks__container {
 	display: inline-flex;
-	padding: 9px 0 4px; // To match the H1
+	padding: 11px 0 4px; // To match the H1
 	align-items: center;
 	vertical-align: top;
 }

--- a/packages/list-reusable-blocks/src/style.scss
+++ b/packages/list-reusable-blocks/src/style.scss
@@ -3,7 +3,11 @@
 
 .list-reusable-blocks__container {
 	display: inline-flex;
-	padding: 11px 0 4px; // To match the H1
 	align-items: center;
-	vertical-align: top;
+	position: relative;
+	top: -3px;
+	// Todo: Make core button height and gutenberg button height equal.
+	.components-button {
+		height: 26px;
+	}
 }


### PR DESCRIPTION
## Description
Fixes: https://github.com/WordPress/gutenberg/issues/20302

This PR fixes the size and padding of the import from JSON button to make the button consistent with the Add New button.

## How has this been tested?
I verified the button still works (the UI can be accessed on .../wp-admin/edit.php?post_type=wp_block).

![image](https://user-images.githubusercontent.com/11271197/75176051-5638e180-572b-11ea-935e-7c03b1a7ee05.png)

