### PR TITLE
Block Library: Add features to the Post Tags block.

### DIFF
--- a/packages/block-library/src/post-tags/block.json
+++ b/packages/block-library/src/post-tags/block.json
@@ -1,4 +1,16 @@
 {
 	"name": "core/post-tags",
-	"category": "layout"
+	"category": "layout",
+	"attributes": {
+		"beforeText": {
+			"type": "string"
+		},
+		"separator": {
+			"type": "string",
+			"default": " | "
+		},
+		"afterText": {
+			"type": "string"
+		}
+	}
 }

--- a/packages/block-library/src/post-tags/edit.js
+++ b/packages/block-library/src/post-tags/edit.js
@@ -4,8 +4,12 @@
 import { useEntityProp, useEntityId } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
+import { RichText } from '@wordpress/block-editor';
 
-function PostTagsDisplay() {
+function PostTagsDisplay( {
+	attributes: { beforeText, separator, afterText },
+	setAttributes,
+} ) {
 	const [ tags ] = useEntityProp( 'postType', 'post', 'tags' );
 	const tagLinks = useSelect(
 		( select ) => {
@@ -28,15 +32,55 @@ function PostTagsDisplay() {
 	);
 	return (
 		tagLinks &&
-		( tagLinks.length === 0
-			? __( 'No tags.' )
-			: tagLinks.reduce( ( prev, curr ) => [ prev, ' | ', curr ] ) )
+		( tagLinks.length === 0 ? (
+			__( 'No tags.' )
+		) : (
+			<>
+				<RichText
+					tagName="span"
+					placeholder={ __( 'Before text.' ) }
+					keepPlaceholderOnFocus
+					value={ beforeText }
+					onChange={ ( newBeforeText ) =>
+						setAttributes( { beforeText: newBeforeText } )
+					}
+				/>{ ' ' }
+				{ tagLinks.reduce( ( prev, curr ) => [
+					prev,
+					<RichText
+						key={ prev + curr }
+						tagName="span"
+						placeholder={ __( ' | ' ) }
+						keepPlaceholderOnFocus
+						value={ separator }
+						onChange={ ( newSeparator ) =>
+							setAttributes( { separator: newSeparator } )
+						}
+					/>,
+					curr,
+				] ) }{ ' ' }
+				<RichText
+					tagName="span"
+					placeholder={ __( 'After text.' ) }
+					keepPlaceholderOnFocus
+					value={ afterText }
+					onChange={ ( newAfterText ) =>
+						setAttributes( { afterText: newAfterText } )
+					}
+				/>
+			</>
+		) )
 	);
 }
 
-export default function PostTagsEdit() {
+export default function PostTagsEdit( { attributes, setAttributes } ) {
 	if ( ! useEntityId( 'postType', 'post' ) ) {
 		return 'Post Tags Placeholder';
 	}
-	return <PostTagsDisplay />;
+	return (
+		<PostTagsDisplay
+			attributes={ attributes }
+			setAttributes={ setAttributes }
+		/>
+	);
 }

--- a/packages/block-library/src/post-tags/index.php
+++ b/packages/block-library/src/post-tags/index.php
@@ -8,20 +8,40 @@
 /**
  * Renders the `core/post-tags` block on the server.
  *
+ * @param array $attributes The block attributes.
+ *
  * @return string Returns the filtered post tags for the current post wrapped inside "a" tags.
  */
-function render_block_core_post_tags() {
+function render_block_core_post_tags( $attributes ) {
 	$post = gutenberg_get_post_from_context();
 	if ( ! $post ) {
 		return '';
 	}
 	$post_tags = get_the_tags();
 	if ( ! empty( $post_tags ) ) {
-		$output = '';
-		foreach ( $post_tags as $tag ) {
-			$output .= '<a href="' . get_tag_link( $tag->term_id ) . '">' . $tag->name . '</a>' . ' | ';
-		}
-		return trim( $output, ' | ' );
+		$output = array_map(
+			function ( $tag ) {
+				return '<a href="' .
+				get_tag_link( $tag->term_id ) .
+				'">' .
+				$tag->name .
+				'</a>';
+			},
+			$post_tags
+		);
+		$output = join(
+			$attributes['separator'],
+			$output
+		);
+		return ( isset( $attributes['beforeText'] )
+			? ( $attributes['beforeText'] . ' ' )
+			: ''
+		) .
+		$output .
+		( isset( $attributes['afterText'] )
+			? ( ' ' . $attributes['afterText'] )
+			: ''
+		);
 	}
 }
 
@@ -32,6 +52,18 @@ function register_block_core_post_tags() {
 	register_block_type(
 		'core/post-tags',
 		array(
+			'attributes'      => array(
+				'beforeText' => array(
+					'type' => 'string',
+				),
+				'separator'  => array(
+					'type'    => 'string',
+					'default' => ' | ',
+				),
+				'afterText'  => array(
+					'type' => 'string',
+				),
+			),
 			'render_callback' => 'render_block_core_post_tags',
 		)
 	);


### PR DESCRIPTION
## Description

This PR adds all the features of the tags theme function, https://codex.wordpress.org/Function_Reference/the_tags, to the Post Tags block as @mtias suggested in https://github.com/WordPress/gutenberg/pull/19580#discussion_r383318141.

## How has this been tested?

It was verified that changing the before and after texts, and the separator, works as expected.

## Screenshots

![gif](https://user-images.githubusercontent.com/19157096/75177701-8b254400-56eb-11ea-935f-10c457ac6c1a.gif)

## Types of Changes

*New Feature:* The Post Tags block now allows you to edit the before and after texts, and the separator.

## Checklist:

- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->