### PR TITLE
[RNMobile] Fix Quote border-left not visible in Dark Mode

### DIFF
--- a/packages/primitives/src/block-quotation/index.native.js
+++ b/packages/primitives/src/block-quotation/index.native.js
@@ -6,12 +6,20 @@ import { View } from 'react-native';
  * WordPress dependencies
  */
 import { Children, cloneElement } from '@wordpress/element';
+import { withPreferredColorScheme } from '@wordpress/compose';
 /**
  * Internal dependencies
  */
 import styles from './style.scss';
 
-export const BlockQuotation = ( props ) => {
+export const BlockQuotation = withPreferredColorScheme( ( props ) => {
+	const { getStylesFromColorScheme } = props;
+
+	const blockQuoteStyle = getStylesFromColorScheme(
+		styles.wpBlockQuoteLight,
+		styles.wpBlockQuoteDark
+	);
+
 	const newChildren = Children.map( props.children, ( child ) => {
 		if ( child && child.props.identifier === 'citation' ) {
 			return cloneElement( child, {
@@ -19,9 +27,12 @@ export const BlockQuotation = ( props ) => {
 			} );
 		}
 		if ( child && child.props.identifier === 'value' ) {
-			return cloneElement( child, { tagsToEliminate: [ 'div' ] } );
+			return cloneElement( child, {
+				tagsToEliminate: [ 'div' ],
+				style: styles.wpBlockQuoteValue,
+			} );
 		}
 		return child;
 	} );
-	return <View style={ styles.wpBlockQuote }>{ newChildren }</View>;
-};
+	return <View style={ blockQuoteStyle }>{ newChildren }</View>;
+} );

--- a/packages/primitives/src/block-quotation/style.native.scss
+++ b/packages/primitives/src/block-quotation/style.native.scss
@@ -1,12 +1,26 @@
-.wpBlockQuote {
-	border-left-width: 4px;
-	border-left-color: $black;
+%wpBlockQuote-shared {
+	border-left-width: 3px;
 	border-left-style: solid;
-	padding-left: 8px;
+	padding-left: 13px;
 	margin-left: 0;
 }
 
+.wpBlockQuoteLight {
+	@extend %wpBlockQuote-shared;
+	border-left-color: $black;
+}
+
+.wpBlockQuoteDark {
+	@extend %wpBlockQuote-shared;
+	border-left-color: $white;
+}
+
 .wpBlockQuoteCitation {
-	margin-top: 16px;
+	margin-top: 12px;
 	font-size: 14px;
+}
+
+.wpBlockQuoteValue {
+	margin-top: 0; // FIXME: On iOS without margin-top (or any other additional style) the font-size is not applied
+	font-size: 18px;
 }


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/1673

Also addressed design feedback from here: https://github.com/WordPress/gutenberg/pull/20265#issuecomment-590533974

Gutenberg mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1953

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

1. Enable light mode
1. Add Quote block
1. Enable dark mode
1. Check left border

## Screenshots <!-- if applicable -->
iOS (light) | iOS (dark) | Android
-- | -- | --
<img width="548" alt="ios-light" src="https://user-images.githubusercontent.com/1845482/75178637-bd10c780-5738-11ea-884a-cb27a3519e27.png">|<img width="548" alt="ios-dark" src="https://user-images.githubusercontent.com/1845482/75178640-c0a44e80-5738-11ea-8274-3429d12fec68.png">|<img width="485" alt="android-light" src="https://user-images.githubusercontent.com/1845482/75178728-efbac000-5738-11ea-8db0-2de5d1e1aff9.png">



## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
