### PR TITLE
Update jest configuration to only ignore tests from /wordpress/ as a subdirectory

### DIFF
--- a/packages/e2e-tests/jest.config.js
+++ b/packages/e2e-tests/jest.config.js
@@ -9,7 +9,7 @@ module.exports = {
 	],
 	testPathIgnorePatterns: [
 		'/node_modules/',
-		'/wordpress/',
+		'<rootDir>/wordpress/',
 		'e2e-tests/specs/performance/',
 	],
 };

--- a/packages/jest-preset-default/jest-preset.js
+++ b/packages/jest-preset-default/jest-preset.js
@@ -21,7 +21,7 @@ module.exports = {
 		'**/test/*.[jt]s',
 		'**/?(*.)test.[jt]s',
 	],
-	testPathIgnorePatterns: [ '/node_modules/', '/wordpress/' ],
+	testPathIgnorePatterns: [ '/node_modules/', '<rootDir>/wordpress/' ],
 	timers: 'fake',
 	transform: {
 		'^.+\\.[jt]sx?$': require.resolve( 'babel-jest' ),

--- a/test/native/jest.config.js
+++ b/test/native/jest.config.js
@@ -33,7 +33,7 @@ module.exports = {
 	testMatch: [ '**/test/*.native.[jt]s?(x)' ],
 	testPathIgnorePatterns: [
 		'/node_modules/',
-		'/wordpress/',
+		'<rootDir>/wordpress/',
 		'/__device-tests__/',
 	],
 	testURL: 'http://localhost/',

--- a/test/unit/jest.config.js
+++ b/test/unit/jest.config.js
@@ -26,7 +26,7 @@ module.exports = {
 		'/.git/',
 		'/node_modules/',
 		'/packages/e2e-tests',
-		'/wordpress/',
+		'<rootDir>/wordpress/',
 		'<rootDir>/.*/build/',
 		'<rootDir>/.*/build-module/',
 		'<rootDir>/.+.native.js$',


### PR DESCRIPTION
## Description
Fixes #20255 by updating all the jest config files to only ignore `<rootDir>/wordpress/` as opposed to just `/wordpress/`. This is also addressed in #20270 where it was determined `wp-scripts env` needed to be deprecated. This PR provides a less-obtrusive (if temporary) fix to get unit tests working while that process is taking place

## How has this been tested?
* Setup the Gutenberg repository in a folder called /wordpress/
* Try running `npm run test-unit`, see no tests are found
* Check out this branch
* Try running `npm run test-unit`, see tests are found
* Repeat for `npm run test-unit:native` and `npm run test-e2e` 

## Types of changes
Bugfix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
