### PR TITLE
Chore: Fix lint issue in list-reusable-blocks/import-dropdown

### DIFF
--- a/packages/list-reusable-blocks/src/components/import-dropdown/index.js
+++ b/packages/list-reusable-blocks/src/components/import-dropdown/index.js
@@ -20,11 +20,7 @@ function ImportDropdown( { onUpload } ) {
 			position="bottom right"
 			contentClassName="list-reusable-blocks-import-dropdown__content"
 			renderToggle={ ( { isOpen, onToggle } ) => (
-				<Button
-					aria-expanded={ isOpen }
-					onClick={ onToggle }
-					isPrimary
-				>
+				<Button aria-expanded={ isOpen } onClick={ onToggle } isPrimary>
 					{ __( 'Import from JSON' ) }
 				</Button>
 			) }


### PR DESCRIPTION
Chore fixes a linting issue merged by mistake in https://github.com/WordPress/gutenberg/pull/20416.
