### PR TITLE
Add an overlay to the html block preview to fix block selection in Firefox

### DIFF
--- a/packages/block-library/src/html/edit.js
+++ b/packages/block-library/src/html/edit.js
@@ -76,10 +76,13 @@ class HTMLEdit extends Component {
 				<Disabled.Consumer>
 					{ ( isDisabled ) =>
 						isPreview || isDisabled ? (
-							<SandBox
-								html={ attributes.content }
-								styles={ styles }
-							/>
+							<>
+								<SandBox
+									html={ attributes.content }
+									styles={ styles }
+								/>
+								<div className="wp-block-html__preview-overlay"></div>
+							</>
 						) : (
 							<PlainText
 								value={ attributes.content }

--- a/packages/block-library/src/html/edit.js
+++ b/packages/block-library/src/html/edit.js
@@ -81,6 +81,11 @@ class HTMLEdit extends Component {
 									html={ attributes.content }
 									styles={ styles }
 								/>
+								{/*	
+									An overlay is added when the block is not selected in order to register click events as 
+									some browsers do not bubble up the clicks from the sandboxed iframe, which makes it 
+									difficult to reselect the block. 
+								*/}
 								{ ! this.props.isSelected && (
 									<div className="block-library-html__preview-overlay"></div>
 								) }

--- a/packages/block-library/src/html/edit.js
+++ b/packages/block-library/src/html/edit.js
@@ -81,7 +81,9 @@ class HTMLEdit extends Component {
 									html={ attributes.content }
 									styles={ styles }
 								/>
-								{ ! this.props.isSelected && <div className="block-library-html__preview-overlay"></div> }
+								{ ! this.props.isSelected && (
+									<div className="block-library-html__preview-overlay"></div>
+								) }
 							</>
 						) : (
 							<PlainText

--- a/packages/block-library/src/html/edit.js
+++ b/packages/block-library/src/html/edit.js
@@ -81,7 +81,7 @@ class HTMLEdit extends Component {
 									html={ attributes.content }
 									styles={ styles }
 								/>
-								<div className="block-library-html__preview-overlay"></div>
+								{ ! this.props.isSelected && <div className="block-library-html__preview-overlay"></div> }
 							</>
 						) : (
 							<PlainText

--- a/packages/block-library/src/html/edit.js
+++ b/packages/block-library/src/html/edit.js
@@ -81,11 +81,11 @@ class HTMLEdit extends Component {
 									html={ attributes.content }
 									styles={ styles }
 								/>
-								{/*	
+								{ /*	
 									An overlay is added when the block is not selected in order to register click events as 
 									some browsers do not bubble up the clicks from the sandboxed iframe, which makes it 
 									difficult to reselect the block. 
-								*/}
+								*/ }
 								{ ! this.props.isSelected && (
 									<div className="block-library-html__preview-overlay"></div>
 								) }

--- a/packages/block-library/src/html/edit.js
+++ b/packages/block-library/src/html/edit.js
@@ -81,7 +81,7 @@ class HTMLEdit extends Component {
 									html={ attributes.content }
 									styles={ styles }
 								/>
-								<div className="wp-block-html__preview-overlay"></div>
+								<div className="block-library-html__preview-overlay"></div>
 							</>
 						) : (
 							<PlainText

--- a/packages/block-library/src/html/edit.js
+++ b/packages/block-library/src/html/edit.js
@@ -82,8 +82,8 @@ class HTMLEdit extends Component {
 									styles={ styles }
 								/>
 								{ /*	
-									An overlay is added when the block is not selected in order to register click events as 
-									some browsers do not bubble up the clicks from the sandboxed iframe, which makes it 
+									An overlay is added when the block is not selected in order to register click events. 
+									Some browsers do not bubble up the clicks from the sandboxed iframe, which makes it 
 									difficult to reselect the block. 
 								*/ }
 								{ ! this.props.isSelected && (

--- a/packages/block-library/src/html/editor.scss
+++ b/packages/block-library/src/html/editor.scss
@@ -1,6 +1,14 @@
 .wp-block-html {
 	margin-bottom: $default-block-margin;
 
+	&__preview-overlay {
+		position: absolute;
+		width: 100%;
+		height: 100%;
+		top: 0;
+		left: 0;
+	}
+
 	.block-editor-plain-text {
 		font-family: $editor-html-font;
 		color: $dark-gray-800;

--- a/packages/block-library/src/html/editor.scss
+++ b/packages/block-library/src/html/editor.scss
@@ -1,7 +1,7 @@
 .wp-block-html {
 	margin-bottom: $default-block-margin;
 
-	&__preview-overlay {
+	.block-library-html__preview-overlay {
 		position: absolute;
 		width: 100%;
 		height: 100%;


### PR DESCRIPTION
In Firefox, if an html block is left in preview mode, it is very difficult to reselect the block except by clicking on the very bottom edge of the block - https://share.getcloudapp.com/9ZuArmrd. 

It appears that the click events are not bubbling up from the sandboxed iframe, and the selection works on the bottom edge due to some padding/margin which is outside the extents of the iframe.

Fixes #12577

## Description
This PR adds an overlay which covers the html preview area in order to prevent clicks being trapped in the sandboxed iframe

Before:
![before](https://user-images.githubusercontent.com/3629020/75199803-f0029c00-57c8-11ea-8bac-62d010ffb0dc.gif)

After:
![after](https://user-images.githubusercontent.com/3629020/75199819-f7c24080-57c8-11ea-8eec-4bfaa496c8ae.gif)

## How has this been tested?
Tested manually in Firefox and Chrome.

## Types of changes
Adds additional HTML and CSS to html block

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.

