### PR TITLE
Use the EditorSkeleton component to layout the widgets screen

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -63,6 +63,7 @@ $z-layers: (
 	// Show sidebar above wp-admin navigation bar for mobile viewports:
 	// #wpadminbar { z-index: 99999 }
 	".block-editor-editor-skeleton__sidebar": 100000,
+	".edit-post-layout__toogle-sidebar-panel": 100000,
 	".edit-site-sidebar": 100000,
 	".edit-widgets-sidebar": 100000,
 	".edit-post-layout .edit-post-post-publish-panel": 100001,

--- a/packages/block-editor/src/components/editor-skeleton/style.scss
+++ b/packages/block-editor/src/components/editor-skeleton/style.scss
@@ -86,10 +86,6 @@ html.block-editor-editor-skeleton__html-container {
 	background: $white;
 	color: $dark-gray-primary;
 
-	&:empty {
-		display: none;
-	}
-
 	// On Mobile the header is fixed to keep HTML as scrollable.
 	@include break-medium() {
 		overflow: auto;

--- a/packages/block-editor/src/components/editor-skeleton/style.scss
+++ b/packages/block-editor/src/components/editor-skeleton/style.scss
@@ -59,7 +59,6 @@ html.block-editor-editor-skeleton__html-container {
 
 .block-editor-editor-skeleton__content {
 	flex-grow: 1;
-	background-color: $light-gray-700;
 
 	// Treat as flex container to allow children to grow to occupy full
 	// available height of the content area.
@@ -75,26 +74,6 @@ html.block-editor-editor-skeleton__html-container {
 }
 
 .block-editor-editor-skeleton__sidebar {
-	display: none;
-
-	@include break-medium() {
-		display: block;
-		z-index: z-index(".block-editor-editor-skeleton__sidebar");
-		position: fixed !important; // Need to override the default relative positionning
-		top: -9999em;
-		bottom: auto;
-		left: auto;
-		right: 0;
-		width: $sidebar-width;
-
-		&:focus {
-			top: auto;
-			bottom: 0;
-		}
-	}
-}
-
-.is-sidebar-opened .block-editor-editor-skeleton__sidebar {
 	display: block;
 	width: auto; // Keep the sidebar width flexible.
 	flex-shrink: 0;
@@ -106,6 +85,10 @@ html.block-editor-editor-skeleton__html-container {
 	left: 0;
 	background: $white;
 	color: $dark-gray-primary;
+
+	&:empty {
+		display: none;
+	}
 
 	// On Mobile the header is fixed to keep HTML as scrollable.
 	@include break-medium() {

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -191,10 +191,10 @@ function Layout() {
 								}
 							/>
 						) : (
-							<div className="edit-post-toggle-publish-panel">
+							<div className="edit-post-layout__toggle-publish-panel">
 								<Button
 									isSecondary
-									className="edit-post-toggle-publish-panel__button"
+									className="edit-post-layout__toggle-publish-panel-button"
 									onClick={ togglePublishSidebar }
 									aria-expanded={ false }
 								>

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -50,7 +50,7 @@ import PluginPrePublishPanel from '../sidebar/plugin-pre-publish-panel';
 import WelcomeGuide from '../welcome-guide';
 
 function Layout() {
-	const isMobileViewport = useViewportMatch( 'small', '<' );
+	const isMobileViewport = useViewportMatch( 'medium', '<' );
 	const {
 		closePublishSidebar,
 		openGeneralSidebar,
@@ -126,24 +126,28 @@ function Layout() {
 					className={ className }
 					header={ <Header /> }
 					sidebar={
-						<>
-							{ ! sidebarIsOpened && (
-								<div className="edit-post-layout__toogle-sidebar-panel">
-									<Button
-										isSecondary
-										className="edit-post-layout__toogle-sidebar-panel-button"
-										onClick={ openSidebarPanel }
-										aria-expanded={ false }
-									>
-										{ hasBlockSelected
-											? __( 'Open block settings' )
-											: __( 'Open document settings' ) }
-									</Button>
-								</div>
-							) }
-							<SettingsSidebar />
-							<Sidebar.Slot />
-						</>
+						( ! isMobileViewport || sidebarIsOpened ) && (
+							<>
+								{ ! isMobileViewport && ! sidebarIsOpened && (
+									<div className="edit-post-layout__toogle-sidebar-panel">
+										<Button
+											isSecondary
+											className="edit-post-layout__toogle-sidebar-panel-button"
+											onClick={ openSidebarPanel }
+											aria-expanded={ false }
+										>
+											{ hasBlockSelected
+												? __( 'Open block settings' )
+												: __(
+														'Open document settings'
+												  ) }
+										</Button>
+									</div>
+								) }
+								<SettingsSidebar />
+								<Sidebar.Slot />
+							</>
+						)
 					}
 					content={
 						<>
@@ -164,6 +168,7 @@ function Layout() {
 						</>
 					}
 					footer={
+						! isMobileViewport &&
 						isRichEditingEnabled &&
 						mode === 'visual' && (
 							<div className="edit-post-layout__footer">

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -65,34 +65,29 @@
 	justify-content: center;
 }
 
-.edit-post-layout__toogle-publish-panel,
+
+.edit-post-layout__toggle-publish-panel,
 .edit-post-layout__toogle-sidebar-panel {
+	z-index: z-index(".edit-post-layout__toogle-sidebar-panel");
+	position: fixed !important; // Need to override the default relative positionning
+	top: -9999em;
+	bottom: auto;
+	left: auto;
+	right: 0;
+	width: $sidebar-width;
 	background-color: $white;
-	padding: 10px 10px 10px 0;
-}
+	border: 1px dotted $light-gray-500;
+	height: auto !important; // Need to override the default sidebar positionnings
+	padding: $grid-unit-30;
+	display: flex;
+	justify-content: center;
 
-.edit-post-layout__toogle-publish-panel-button.components-button,
-.edit-post-layout__toogle-sidebar-panel-button.components-button {
-	width: auto;
-	height: auto;
-	display: block;
-	font-size: 14px;
-	font-weight: 600;
-	margin: 0 0 0 auto;
-	padding: $grid-unit-20 $grid-unit-30;
-	line-height: normal;
-	text-decoration: none;
-	outline: none;
-	background: $white;
-	color: $theme-color;
-
-	&:focus {
-		position: fixed;
+	.block-editor-editor-skeleton__publish:focus &,
+	.block-editor-editor-skeleton__publish:focus-within &,
+	.block-editor-editor-skeleton__sidebar:focus &,
+	.block-editor-editor-skeleton__sidebar:focus-within & {
 		top: auto;
-		right: $grid-unit-60;
-		bottom: $grid-unit-60;
-		left: auto;
-		box-shadow: 0 0 0 2px $blue-medium-focus, $shadow-modal;
+		bottom: 0;
 	}
 }
 

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -127,3 +127,8 @@
 		}
 	}
 }
+
+.edit-post-layout .block-editor-editor-skeleton__content {
+	background-color: $light-gray-700;
+}
+

--- a/packages/edit-widgets/src/components/header/style.scss
+++ b/packages/edit-widgets/src/components/header/style.scss
@@ -2,29 +2,8 @@
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
-	border-bottom: 1px solid $light-gray-500;
 	height: $header-height;
-	background: $white;
-	z-index: z-index(".edit-widgets-header");
-
-	left: 0;
-	right: 0;
-	// Stick the toolbar to the top, because the admin bar is not fixed on mobile.
-	top: 0;
-	position: sticky;
-
-	// On mobile the main content area has to scroll, otherwise you can invoke the overscroll bounce on the non-scrolling container.
-	@include break-small {
-		position: fixed;
-		padding: $grid-unit-10;
-		top: $admin-bar-height-big;
-	}
-
-	@include break-medium() {
-		top: $admin-bar-height;
-	}
 }
-@include editor-left(".edit-widgets-header");
 
 .edit-widgets-header__title {
 	font-size: 16px;

--- a/packages/edit-widgets/src/components/layout/index.js
+++ b/packages/edit-widgets/src/components/layout/index.js
@@ -7,9 +7,13 @@ import {
 	DropZoneProvider,
 	Popover,
 	SlotFillProvider,
+	FocusReturnProvider,
 } from '@wordpress/components';
 import { useState } from '@wordpress/element';
-import { BlockEditorKeyboardShortcuts } from '@wordpress/block-editor';
+import {
+	BlockEditorKeyboardShortcuts,
+	__experimentalEditorSkeleton as EditorSkeleton,
+} from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -22,30 +26,45 @@ import Notices from '../notices';
 function Layout( { blockEditorSettings } ) {
 	const [ selectedArea, setSelectedArea ] = useState( null );
 	return (
-		<SlotFillProvider>
-			<DropZoneProvider>
-				<BlockEditorKeyboardShortcuts.Register />
-				<Header />
-				<Sidebar />
-				<Notices />
-				<div
-					className="edit-widgets-layout__content"
-					role="region"
-					aria-label={ __( 'Widgets screen content' ) }
-					tabIndex="-1"
-					onFocus={ () => {
-						setSelectedArea( null );
-					} }
-				>
-					<WidgetAreas
-						selectedArea={ selectedArea }
-						setSelectedArea={ setSelectedArea }
-						blockEditorSettings={ blockEditorSettings }
-					/>
-				</div>
-				<Popover.Slot />
-			</DropZoneProvider>
-		</SlotFillProvider>
+		<>
+			<BlockEditorKeyboardShortcuts.Register />
+			<SlotFillProvider>
+				<DropZoneProvider>
+					<FocusReturnProvider>
+						<EditorSkeleton
+							header={ <Header /> }
+							sidebar={ <Sidebar /> }
+							content={
+								<>
+									<Notices />
+									<div
+										className="edit-widgets-layout__content"
+										role="region"
+										aria-label={ __(
+											'Widgets screen content'
+										) }
+										tabIndex="-1"
+										onFocus={ () => {
+											setSelectedArea( null );
+										} }
+									>
+										<WidgetAreas
+											selectedArea={ selectedArea }
+											setSelectedArea={ setSelectedArea }
+											blockEditorSettings={
+												blockEditorSettings
+											}
+										/>
+									</div>
+								</>
+							}
+						/>
+
+						<Popover.Slot />
+					</FocusReturnProvider>
+				</DropZoneProvider>
+			</SlotFillProvider>
+		</>
 	);
 }
 

--- a/packages/edit-widgets/src/components/layout/style.scss
+++ b/packages/edit-widgets/src/components/layout/style.scss
@@ -1,11 +1,3 @@
 .edit-widgets-layout__content {
-	min-height: 100%;
-	background: #f1f1f1;
 	padding: 30px 0;
-
-	// Temporarily disable the sidebar on mobile
-	@include break-small() {
-		margin-right: $sidebar-width;
-		margin-top: $header-height;
-	}
 }

--- a/packages/edit-widgets/src/components/sidebar/index.js
+++ b/packages/edit-widgets/src/components/sidebar/index.js
@@ -3,6 +3,7 @@
  */
 import { createSlotFill, Panel } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { useViewportMatch } from '@wordpress/compose';
 
 export const {
 	Fill: BlockSidebarFill,
@@ -10,6 +11,13 @@ export const {
 } = createSlotFill( 'EditWidgetsBlockSidebar' );
 
 function Sidebar() {
+	const isMobile = useViewportMatch( 'medium', '<' );
+
+	// Disable on mobile temporarily
+	if ( isMobile ) {
+		return null;
+	}
+
 	return (
 		<div
 			className="edit-widgets-sidebar"

--- a/packages/edit-widgets/src/components/sidebar/style.scss
+++ b/packages/edit-widgets/src/components/sidebar/style.scss
@@ -1,33 +1,5 @@
 .edit-widgets-sidebar {
-	position: fixed;
-	z-index: z-index(".edit-widgets-sidebar");
-	top: 0;
-	right: 0;
-	bottom: 0;
 	width: $sidebar-width;
-	border-left: $border-width solid $light-gray-500;
-	background: $white;
-	color: $dark-gray-500;
-	height: 100vh;
-	overflow: hidden;
-
-	@include break-small() {
-		top: $admin-bar-height-big + $header-height;
-		z-index: z-index(".edit-widgets-sidebar {greater than small}");
-		height: auto;
-		overflow: auto;
-		-webkit-overflow-scrolling: touch;
-	}
-
-	@include break-medium() {
-		top: $admin-bar-height + $header-height;
-	}
-
-	// Temporarily disable the sidebar on mobile
-	display: none;
-	@include break-small() {
-		display: block;
-	}
 
 	> .components-panel {
 		margin-top: -1px;

--- a/packages/edit-widgets/src/style.scss
+++ b/packages/edit-widgets/src/style.scss
@@ -47,6 +47,11 @@ body.gutenberg_page_gutenberg-widgets {
 		min-height: initial;
 		position: initial;
 	}
+
+
+	.block-editor-editor-skeleton__content {
+		background-color: #f1f1f1;
+	}
 }
 
 /**


### PR DESCRIPTION
The only way to ensure this component is generic enough is to actually use it in multiple screens.
This PR does it for the edit-widgets, we need to follow-up on the edit-site as well.