### PR TITLE
[LatestPosts] Don't trim manual excerpts

### DIFF
--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -309,9 +309,6 @@ class LatestPostsEdit extends Component {
 							'trim',
 						] );
 						let excerpt = post.excerpt.rendered;
-						if ( post.excerpt.raw !== '' ) {
-							excerpt = post.excerpt.raw;
-						}
 
 						const excerptElement = document.createElement( 'div' );
 						excerptElement.innerHTML = excerpt;

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -309,6 +309,9 @@ class LatestPostsEdit extends Component {
 							'trim',
 						] );
 						let excerpt = post.excerpt.rendered;
+						if ( post.excerpt.raw !== '' ) {
+							excerpt = post.excerpt.raw;
+						}
 
 						const excerptElement = document.createElement( 'div' );
 						excerptElement.innerHTML = excerpt;
@@ -324,6 +327,21 @@ class LatestPostsEdit extends Component {
 							'wp-block-latest-posts__featured-image': true,
 							[ `align${ featuredImageAlign }` ]: !! featuredImageAlign,
 						} );
+
+						const postExcerpt =
+							excerptLength <
+								excerpt.trim().split( ' ' ).length &&
+							post.excerpt.raw === ''
+								? excerpt
+										.trim()
+										.split( ' ', excerptLength )
+										.join( ' ' ) +
+								  ' ... <a href=' +
+								  post.link +
+								  'target="_blank" rel="noopener noreferrer">' +
+								  __( 'Read more' ) +
+								  '</a>'
+								: excerpt;
 
 						return (
 							<li key={ i }>
@@ -370,28 +388,7 @@ class LatestPostsEdit extends Component {
 									displayPostContentRadio === 'excerpt' && (
 										<div className="wp-block-latest-posts__post-excerpt">
 											<RawHTML key="html">
-												{ excerptLength <
-												excerpt.trim().split( ' ' )
-													.length
-													? excerpt
-															.trim()
-															.split(
-																' ',
-																excerptLength
-															)
-															.join( ' ' ) +
-													  ' ... <a href=' +
-													  post.link +
-													  'target="_blank" rel="noopener noreferrer">' +
-													  __( 'Read more' ) +
-													  '</a>'
-													: excerpt
-															.trim()
-															.split(
-																' ',
-																excerptLength
-															)
-															.join( ' ' ) }
+												{ postExcerpt }
 											</RawHTML>
 										</div>
 									) }


### PR DESCRIPTION
## Description
Closes #20327 Based on input from #20313 

This PR makes the `LatestPosts` block respect manual excerpts by showing `post.excerpt.raw` if it exists - without trimming it.

## How has this been tested?
Tested locally by:

1. Making sure you have a bunch of posts that have manual excerpts and some which don't
2. Creating a new post
3. Adding a LatestPosts block
4. Set the block to `Show post content` -> `Excerpt` and `Excerpt length` to 10 words/
5. Observe that manual excerpts are not trimmed.
## Screenshots <!-- if applicable -->

## Types of changes
Non breaking changes to the `LatestPosts` block edit function.