### PR TITLE
FSE: Get current template part correctly for auto drafts

### DIFF
--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -304,12 +304,16 @@ function gutenberg_strip_php_suffix( $template_file ) {
  * @return array Filtered editor settings.
  */
 function gutenberg_template_loader_filter_block_editor_settings( $settings ) {
+	global $_wp_current_template_id;
 	if ( ! post_type_exists( 'wp_template' ) || ! post_type_exists( 'wp_template_part' ) ) {
 		return $settings;
 	}
 
 	// Create template part auto-drafts for the edited post.
-	foreach ( parse_blocks( get_post()->post_content ) as $block ) {
+	$post = isset( $_wp_current_template_id )
+		? get_post( $_wp_current_template_id ) // It's a template.
+		: get_post(); // It's a post.
+	foreach ( parse_blocks( $post->post_content ) as $block ) {
 		create_auto_draft_for_template_part_block( $block );
 	}
 


### PR DESCRIPTION
## Description

This PR fixes the PHP notice that was being shown when the site editor loads by correctly getting the current post for auto-drafting template parts depending on whether a template or post is currently being edited.

## How to test this?

Verify there are no regressions or PHP notices in the site editor.

## Checklist:

- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->