### PR TITLE
Media & Text Block: Fix the "Crop image to fill entire column" option

### DIFF
--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -161,7 +161,7 @@ class MediaTextEdit extends Component {
 		} = attributes;
 		return (
 			<MediaContainer
-				className="block-library-media-text__media-container"
+				className="wp-block-media-text__media-container"
 				onSelectMedia={ this.onSelectMedia }
 				onWidthChange={ this.onWidthChange }
 				commitWidthChange={ this.commitWidthChange }

--- a/packages/block-library/src/media-text/editor.scss
+++ b/packages/block-library/src/media-text/editor.scss
@@ -59,14 +59,14 @@
 	max-width: unset;
 }
 
-figure.block-library-media-text__media-container {
+figure.wp-block-media-text__media-container {
 	margin: 0;
 	height: 100%;
 	width: 100%;
 }
 
-.wp-block-media-text .block-library-media-text__media-container img,
-.wp-block-media-text .block-library-media-text__media-container video {
+.wp-block-media-text .wp-block-media-text__media-container img,
+.wp-block-media-text .wp-block-media-text__media-container video {
 	vertical-align: middle;
 	width: 100%;
 }

--- a/packages/block-library/src/media-text/style.scss
+++ b/packages/block-library/src/media-text/style.scss
@@ -72,13 +72,13 @@
 	vertical-align: middle;
 }
 
-.wp-block-media-text.is-image-fill figure.wp-block-media-text__media {
+.wp-block-media-text.is-image-fill figure.block-library-media-text__media-container {
 	height: 100%;
 	min-height: 250px;
 	background-size: cover;
 }
 
-.wp-block-media-text.is-image-fill figure.wp-block-media-text__media > img {
+.wp-block-media-text.is-image-fill figure.block-library-media-text__media-container > img {
 	// The image is visually hidden but accessible to assistive technologies.
 	position: absolute;
 	width: 1px;

--- a/packages/block-library/src/media-text/style.scss
+++ b/packages/block-library/src/media-text/style.scss
@@ -72,13 +72,13 @@
 	vertical-align: middle;
 }
 
-.wp-block-media-text.is-image-fill figure.block-library-media-text__media-container {
+.wp-block-media-text.is-image-fill figure.wp-block-media-text__media-container {
 	height: 100%;
 	min-height: 250px;
 	background-size: cover;
 }
 
-.wp-block-media-text.is-image-fill figure.block-library-media-text__media-container > img {
+.wp-block-media-text.is-image-fill figure.wp-block-media-text__media-container > img {
 	// The image is visually hidden but accessible to assistive technologies.
 	position: absolute;
 	width: 1px;


### PR DESCRIPTION
## Description
Closes: #20434 

## How has this been tested?
1. Check-out this branch,
1. Add `Media & Text` block to any page,
2. Add an image (left block column),
3. Add enough text to exceed the image height (right block column),
4. Turn on the `Crop image to fill entire column` option in the block settings panel on the right,
5. The image should crop & fill the whole column,
6. `Focal Point Picker` option should work as expected.

## Screenshots <!-- if applicable -->

Before the fix:

<img width="1615" alt="Screenshot 2020-02-25 16 08 16" src="https://user-images.githubusercontent.com/1451471/75260024-3d8f0100-57e9-11ea-9a3b-0ffcba890453.png">

After the fix, image fills the column:

<img width="1595" alt="Screenshot 2020-02-25 16 08 53" src="https://user-images.githubusercontent.com/1451471/75260050-454ea580-57e9-11ea-8013-21624b9c1cea.png">

After the fix, `Focal Point Picker` works as expected:

<img width="1608" alt="Screenshot 2020-02-25 16 09 19" src="https://user-images.githubusercontent.com/1451471/75260054-47186900-57e9-11ea-9f29-a5a9c2bbfb55.png">

After the fix, page view:

![image](https://user-images.githubusercontent.com/1451471/75262546-facf2800-57ec-11ea-9cd2-ae3df19c2935.png)


## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->