### PR TITLE
Use the EditorSkeleton component in the edit-site page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10411,6 +10411,7 @@
 				"@wordpress/block-library": "file:packages/block-library",
 				"@wordpress/blocks": "file:packages/blocks",
 				"@wordpress/components": "file:packages/components",
+				"@wordpress/compose": "file:packages/compose",
 				"@wordpress/core-data": "file:packages/core-data",
 				"@wordpress/data": "file:packages/data",
 				"@wordpress/editor": "file:packages/editor",

--- a/packages/edit-site/package.json
+++ b/packages/edit-site/package.json
@@ -25,6 +25,7 @@
 		"@wordpress/block-library": "file:../block-library",
 		"@wordpress/blocks": "file:../blocks",
 		"@wordpress/components": "file:../components",
+		"@wordpress/compose": "file:../compose",
 		"@wordpress/core-data": "file:../core-data",
 		"@wordpress/data": "file:../data",
 		"@wordpress/editor": "file:../editor",

--- a/packages/edit-site/src/components/block-editor/style.scss
+++ b/packages/edit-site/src/components/block-editor/style.scss
@@ -1,18 +1,3 @@
-.edit-site-block-editor__editor-styles-wrapper {
-	-webkit-overflow-scrolling: touch;
-	background: $white;
-	height: calc(100% - #{$header-height});
-	left: 0;
-	overflow: auto;
-	position: absolute;
-	top: $header-height;
-	width: 100%;
-
-	@include break-small {
-		width: calc(100% - #{$sidebar-width});
-	}
-}
-
 .edit-site-block-editor__block-list {
 	padding-bottom: $grid-unit-30;
 	padding-top: $grid-unit-30 + 5;

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -12,9 +12,11 @@ import {
 	SlotFillProvider,
 	DropZoneProvider,
 	Popover,
-	navigateRegions,
+	FocusReturnProvider,
 } from '@wordpress/components';
 import { EntityProvider } from '@wordpress/core-data';
+import { __experimentalEditorSkeleton as EditorSkeleton } from '@wordpress/block-editor';
+import { useViewportMatch } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -30,6 +32,7 @@ export function useEditorContext() {
 }
 
 function Editor( { settings: _settings } ) {
+	const isMobile = useViewportMatch( 'medium', '<' );
 	const [ settings, setSettings ] = useState( _settings );
 	const template = useSelect(
 		( select ) =>
@@ -54,11 +57,19 @@ function Editor( { settings: _settings } ) {
 						id={ settings.templateId }
 					>
 						<Context.Provider value={ context }>
-							<Notices />
-							<Header />
-							<Sidebar />
-							<BlockEditor />
-							<Popover.Slot />
+							<FocusReturnProvider>
+								<EditorSkeleton
+									sidebar={ ! isMobile && <Sidebar /> }
+									header={ <Header /> }
+									content={
+										<>
+											<Notices />
+											<BlockEditor />
+										</>
+									}
+								/>
+								<Popover.Slot />
+							</FocusReturnProvider>
 						</Context.Provider>
 					</EntityProvider>
 				</EntityProvider>
@@ -66,4 +77,4 @@ function Editor( { settings: _settings } ) {
 		</SlotFillProvider>
 	) : null;
 }
-export default navigateRegions( Editor );
+export default Editor;

--- a/packages/edit-site/src/components/header/index.js
+++ b/packages/edit-site/src/components/header/index.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { useCallback } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
 import { BlockNavigationDropdown, ToolSelector } from '@wordpress/block-editor';
 
 /**
@@ -42,12 +41,7 @@ export default function Header() {
 		[]
 	);
 	return (
-		<div
-			className="edit-site-header"
-			role="region"
-			aria-label={ __( 'Site editor top bar.' ) }
-			tabIndex="-1"
-		>
+		<div className="edit-site-header">
 			<div className="edit-site-header__toolbar">
 				<TemplateSwitcher
 					ids={ settings.templateIds }

--- a/packages/edit-site/src/components/header/style.scss
+++ b/packages/edit-site/src/components/header/style.scss
@@ -1,30 +1,11 @@
 .edit-site-header {
 	align-items: center;
-	background: $white;
-	border-bottom: 1px solid $light-gray-500;
 	display: flex;
 	height: $header-height;
 	justify-content: space-between;
-	left: 0;
-	// Stick the toolbar to the top, because the admin bar is not fixed on mobile.
-	position: sticky;
-	right: 0;
-	top: 0;
-	z-index: z-index(".edit-site-header");
-
-	// On mobile, the main content area has to scroll,
-	// otherwise you can invoke the over-scroll bounce on the non-scrolling container.
-	@include break-small {
-		padding: $grid-unit-10;
-		position: fixed;
-		top: $admin-bar-height-big;
-	}
-
-	@include break-medium() {
-		top: $admin-bar-height;
-	}
+	padding: $grid-unit-10;
+	box-sizing: border-box;
 }
-@include editor-left(".edit-site-header");
 
 .edit-site-header__toolbar,
 .edit-site-header__actions {

--- a/packages/edit-site/src/components/sidebar/index.js
+++ b/packages/edit-site/src/components/sidebar/index.js
@@ -10,12 +10,7 @@ const { Slot: InspectorSlot, Fill: InspectorFill } = createSlotFill(
 
 function Sidebar() {
 	return (
-		<div
-			className="edit-site-sidebar"
-			role="region"
-			aria-label={ __( 'Site editor advanced settings.' ) }
-			tabIndex="-1"
-		>
+		<div className="edit-site-sidebar">
 			<Panel header={ __( 'Inspector' ) }>
 				<InspectorSlot bubblesVirtually />
 			</Panel>

--- a/packages/edit-site/src/components/sidebar/style.scss
+++ b/packages/edit-site/src/components/sidebar/style.scss
@@ -1,33 +1,5 @@
 .edit-site-sidebar {
-	background: $white;
-	border-left: $border-width solid $light-gray-500;
-	bottom: 0;
-	color: $dark-gray-500;
-	height: 100vh;
-	overflow: hidden;
-	position: fixed;
-	right: 0;
-	top: 0;
 	width: $sidebar-width;
-	z-index: z-index(".edit-site-sidebar");
-
-	@include break-small() {
-		-webkit-overflow-scrolling: touch;
-		height: auto;
-		overflow: auto;
-		top: $admin-bar-height-big + $header-height;
-		z-index: z-index(".edit-site-sidebar {greater than small}");
-	}
-
-	@include break-medium() {
-		top: $admin-bar-height + $header-height;
-	}
-
-	// Temporarily disable the sidebar on mobile.
-	display: none;
-	@include break-small() {
-		display: block;
-	}
 
 	> .components-panel {
 		border-left: 0;

--- a/packages/edit-widgets/src/components/header/index.js
+++ b/packages/edit-widgets/src/components/header/index.js
@@ -12,12 +12,7 @@ import SaveButton from '../save-button';
 
 function Header() {
 	return (
-		<div
-			className="edit-widgets-header"
-			role="region"
-			aria-label={ __( 'Widgets screen top bar' ) }
-			tabIndex="-1"
-		>
+		<div className="edit-widgets-header">
 			<NavigableMenu>
 				<Inserter.Slot />
 			</NavigableMenu>

--- a/packages/edit-widgets/src/components/layout/index.js
+++ b/packages/edit-widgets/src/components/layout/index.js
@@ -1,9 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import {
-	navigateRegions,
 	DropZoneProvider,
 	Popover,
 	SlotFillProvider,
@@ -14,6 +12,7 @@ import {
 	BlockEditorKeyboardShortcuts,
 	__experimentalEditorSkeleton as EditorSkeleton,
 } from '@wordpress/block-editor';
+import { useViewportMatch } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -25,6 +24,8 @@ import Notices from '../notices';
 
 function Layout( { blockEditorSettings } ) {
 	const [ selectedArea, setSelectedArea ] = useState( null );
+	const isMobile = useViewportMatch( 'medium', '<' );
+
 	return (
 		<>
 			<BlockEditorKeyboardShortcuts.Register />
@@ -33,16 +34,12 @@ function Layout( { blockEditorSettings } ) {
 					<FocusReturnProvider>
 						<EditorSkeleton
 							header={ <Header /> }
-							sidebar={ <Sidebar /> }
+							sidebar={ ! isMobile && <Sidebar /> }
 							content={
 								<>
 									<Notices />
 									<div
 										className="edit-widgets-layout__content"
-										role="region"
-										aria-label={ __(
-											'Widgets screen content'
-										) }
 										tabIndex="-1"
 										onFocus={ () => {
 											setSelectedArea( null );
@@ -68,4 +65,4 @@ function Layout( { blockEditorSettings } ) {
 	);
 }
 
-export default navigateRegions( Layout );
+export default Layout;

--- a/packages/edit-widgets/src/components/sidebar/index.js
+++ b/packages/edit-widgets/src/components/sidebar/index.js
@@ -3,7 +3,6 @@
  */
 import { createSlotFill, Panel } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useViewportMatch } from '@wordpress/compose';
 
 export const {
 	Fill: BlockSidebarFill,
@@ -11,20 +10,8 @@ export const {
 } = createSlotFill( 'EditWidgetsBlockSidebar' );
 
 function Sidebar() {
-	const isMobile = useViewportMatch( 'medium', '<' );
-
-	// Disable on mobile temporarily
-	if ( isMobile ) {
-		return null;
-	}
-
 	return (
-		<div
-			className="edit-widgets-sidebar"
-			role="region"
-			aria-label={ __( 'Widgets advanced settings' ) }
-			tabIndex="-1"
-		>
+		<div className="edit-widgets-sidebar">
 			<Panel header={ __( 'Block Areas' ) }>
 				<BlockSidebarSlot bubblesVirtually />
 			</Panel>


### PR DESCRIPTION
To avoid duplicating the same CSS over and over, this PR reuses the EditorSkeleton in the edit-site package. It also removes some leftovers from the edit-widgets package.