### PR TITLE
Prefer primary buttons in block placeholders

### DIFF
--- a/packages/block-library/src/embed/embed-placeholder.js
+++ b/packages/block-library/src/embed/embed-placeholder.js
@@ -34,7 +34,7 @@ const EmbedPlaceholder = ( props ) => {
 					placeholder={ __( 'Enter URL to embed here…' ) }
 					onChange={ onChange }
 				/>
-				<Button isSecondary type="submit">
+				<Button isPrimary type="submit">
 					{ _x( 'Embed', 'button label' ) }
 				</Button>
 			</form>

--- a/packages/block-library/src/embed/test/__snapshots__/index.js.snap
+++ b/packages/block-library/src/embed/test/__snapshots__/index.js.snap
@@ -52,7 +52,7 @@ exports[`core/embed block edit matches snapshot 1`] = `
         value=""
       />
       <button
-        class="components-button is-secondary"
+        class="components-button is-primary"
         type="submit"
       >
         Embed

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -162,7 +162,7 @@ function Navigation( {
 						className="wp-block-navigation-placeholder__buttons"
 					>
 						<Button
-							isSecondary
+							isPrimary
 							className="wp-block-navigation-placeholder__button"
 							onClick={ handleCreateFromExistingPages }
 							disabled={ ! hasPages }

--- a/packages/block-library/src/rss/edit.js
+++ b/packages/block-library/src/rss/edit.js
@@ -75,7 +75,7 @@ class RSSEdit extends Component {
 							}
 							className={ 'components-placeholder__input' }
 						/>
-						<Button isSecondary type="submit">
+						<Button isPrimary type="submit">
 							{ __( 'Use URL' ) }
 						</Button>
 					</form>

--- a/packages/block-library/src/table/edit.js
+++ b/packages/block-library/src/table/edit.js
@@ -576,7 +576,7 @@ export class TableEdit extends Component {
 						/>
 						<Button
 							className="wp-block-table__placeholder-button"
-							isSecondary
+							isPrimary
 							type="submit"
 						>
 							{ __( 'Create Table' ) }


### PR DESCRIPTION
Refs #18667 

Similarly to the MediaPlaceholder, this PR updates the block placeholders to use primary buttons.

## Before

<img width="635" alt="Capture d’écran 2020-02-25 à 4 39 43 PM" src="https://user-images.githubusercontent.com/272444/75263078-c60fa080-57ed-11ea-9b0f-e59312631426.png">

<img width="629" alt="Capture d’écran 2020-02-25 à 4 39 49 PM" src="https://user-images.githubusercontent.com/272444/75263082-c871fa80-57ed-11ea-9435-3a0efc77b2d7.png">

## After

<img width="736" alt="Capture d’écran 2020-02-25 à 4 39 13 PM" src="https://user-images.githubusercontent.com/272444/75263105-cf990880-57ed-11ea-8f46-6fad6bf6d2b1.png">
<img width="738" alt="Capture d’écran 2020-02-25 à 4 39 21 PM" src="https://user-images.githubusercontent.com/272444/75263115-d1fb6280-57ed-11ea-9ee0-5eafcb4f7819.png">

**Notes**

Seems like there's a small visual glitch on the RSS block placeholder.