### PR TITLE
Enable verse block text alignment

### DIFF
--- a/packages/block-library/src/verse/edit.js
+++ b/packages/block-library/src/verse/edit.js
@@ -12,6 +12,7 @@ import {
 	BlockControls,
 	AlignmentToolbar,
 } from '@wordpress/block-editor';
+import { Platform } from '@wordpress/element';
 
 export default function VerseEdit( {
 	attributes,
@@ -20,12 +21,16 @@ export default function VerseEdit( {
 	mergeBlocks,
 } ) {
 	const { textAlign, content } = attributes;
+	const isAlignmentToolbarCollapsed = Platform.select( {
+		web: true,
+		native: false,
+	} );
 
 	return (
 		<>
 			<BlockControls>
 				<AlignmentToolbar
-					isCollapsed={ false }
+					isCollapsed={ isAlignmentToolbarCollapsed }
 					value={ textAlign }
 					onChange={ ( nextAlign ) => {
 						setAttributes( { textAlign: nextAlign } );

--- a/packages/block-library/src/verse/edit.js
+++ b/packages/block-library/src/verse/edit.js
@@ -25,6 +25,7 @@ export default function VerseEdit( {
 		<>
 			<BlockControls>
 				<AlignmentToolbar
+					isCollapsed={ false }
 					value={ textAlign }
 					onChange={ ( nextAlign ) => {
 						setAttributes( { textAlign: nextAlign } );
@@ -45,6 +46,7 @@ export default function VerseEdit( {
 					[ `has-text-align-${ textAlign }` ]: textAlign,
 				} ) }
 				onMerge={ mergeBlocks }
+				textAlign={ textAlign }
 			/>
 		</>
 	);


### PR DESCRIPTION
## Description

Enable UI for verse block text alignment on mobile. This is achieved in two steps:
    
- On mobile-only, make the alignment toolbar expanded by default (setting `isCollapsed` to `false` on `<AlignmentToolbar>`)
- Pass the text alignment property to the rich text area (pass `textAlign` prop to `<RichText>`)


## How has this been tested?



### Gutenberg Mobile
1. Run the changes inside the WordPress for iOS app, create a new post, open the block editor, add a verse block, and observe that the UI for text alignment now appears (the three alignment options)
2. After setting custom alignment, observe that the change is persisted upon previewing or publishing the post
3. Open the post on WordPress.com and verify that the change is still present
4. Repeat steps 1 to 3 for the **WordPress for Android** app

### Gutenberg Plugin

This change should not affect the Gutenberg WordPress plugin. The following tests checked for regressions:

1. Run the changes inside a local Gutenberg environment, create a new post, open the block editor, add a verse block, and observe the UI for text alignment has no changes (i.e. the alignment options are collapsed by default and are only shown when the text alignment button is clicked)
2. After setting custom alignment, observe that the alignment is persisted upon previewing or publishing the post
3. Open the post on **WordPress for iOS** and verify that the alignment is still present
4. Open the post on **WordPress for Android** and verify that the alignment is still present
