### PR TITLE
Resizeable box: Fix documentation example

### DIFF
--- a/packages/components/src/resizable-box/README.md
+++ b/packages/components/src/resizable-box/README.md
@@ -41,8 +41,8 @@ const Edit = ( props ) => {
 			} }
 			onResizeStop={ ( event, direction, elt, delta ) => {
 				setAttributes( {
-					height: parseInt( height + delta.height, 10 ),
-					width: parseInt( width + delta.width, 10 ),
+					height: parseInt( elt.style.height + delta.height, 10 ),
+					width: parseInt( elt.style.width + delta.width, 10 ),
 				} );
 				toggleSelection( true );
 			} }


### PR DESCRIPTION
## Description
The docs in this file were missing a detail, which this fixes.

## How has this been tested?
I copied this example and it didn't work. Then when I made these changes it did!

## Types of changes
Documentation change

## Checklist:
- [x] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
