### PR TITLE
Create block: Fix buggy check for minimum system requirements

### DIFF
--- a/packages/create-block/CHANGELOG.md
+++ b/packages/create-block/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Master
 
+## 0.8.2 (2020-02-26)
+
+- Fixed buggy check for minimum system requirements when run with `npx` and `npm init`.
+
+## 0.8.1 (2020-02-25)
+
 ### Bug Fixes
 
 - Added error message when minimum system requirements not met ([#20398](https://github.com/WordPress/gutenberg/pull/20398/)).

--- a/packages/create-block/CHANGELOG.md
+++ b/packages/create-block/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.8.2 (2020-02-26)
 
-- Fixed buggy check for minimum system requirements when run with `npx` and `npm init`.
+- Fixed buggy check for minimum system requirements when run with `npx` and `npm init` ([#20456](https://github.com/WordPress/gutenberg/pull/20456)).
 
 ## 0.8.1 (2020-02-25)
 

--- a/packages/create-block/lib/index.js
+++ b/packages/create-block/lib/index.js
@@ -1,26 +1,28 @@
 /**
  * External dependencies
  */
-const { command } = require( 'execa' );
+const execa = require( 'execa' );
 const program = require( 'commander' );
 const inquirer = require( 'inquirer' );
 const { startCase } = require( 'lodash' );
-const { join } = require( 'path' );
 
 /**
  * Internal dependencies
  */
 const CLIError = require( './cli-error' );
 const log = require( './log' );
-const { version } = require( '../package.json' );
+const { engines, version } = require( '../package.json' );
 const scaffold = require( './scaffold' );
 const { getDefaultValues, getPrompts } = require( './templates' );
 
 async function checkSystemRequirements() {
 	try {
-		await command( 'check-node-version --package', {
-			cwd: join( __dirname, '..' ),
-		} );
+		await execa( 'check-node-version', [
+			'--node',
+			engines.node,
+			'--npm',
+			engines.npm,
+		] );
 	} catch ( error ) {
 		log.error( 'Minimum system requirements not met!' );
 		log.error( error.stderr );


### PR DESCRIPTION
## Description

Fixes #20450.

> With version 0.8.1 of the @wordpress/create-block script, I always get the error "Minimum system requirements not met!"
> 
> Node version: v13.8.0
> npm version: 6.14.0

## How has this been tested?
It can't be really tested until it's published to npm.

`npx wp-create-block` works as expected locally.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
