### PR TITLE
Block toolbar: fix error

### DIFF
--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -64,6 +64,7 @@ function Editor( { settings: _settings } ) {
 									content={
 										<>
 											<Notices />
+											<Popover.Slot name="block-toolbar" />
 											<BlockEditor />
 										</>
 									}

--- a/packages/edit-widgets/src/components/layout/index.js
+++ b/packages/edit-widgets/src/components/layout/index.js
@@ -38,6 +38,7 @@ function Layout( { blockEditorSettings } ) {
 							content={
 								<>
 									<Notices />
+									<Popover.Slot name="block-toolbar" />
 									<div
 										className="edit-widgets-layout__content"
 										tabIndex="-1"

--- a/storybook/stories/playground/index.js
+++ b/storybook/stories/playground/index.js
@@ -43,6 +43,7 @@ function App() {
 							<BlockInspector />
 						</div>
 						<div className="editor-styles-wrapper">
+							<Popover.Slot name="block-toolbar" />
 							<BlockEditorKeyboardShortcuts />
 							<WritingFlow>
 								<ObserveTyping>


### PR DESCRIPTION
## Description

Fixes #20429.

This is a potential solution, but I'm not sure if it's the best.

The problem is that a popover slot may not always be provided, so the popover may not have a parent element with the `popover-slot` class.

Either we:

* Add the `popover-slot` class to the root container. Not a very clean solution, but it work when the popover is rendered in place (not in a slot). We could change the class to something else if necessary.
* Require the toolbar to render in the slot. (I don't think we should require this.)
* Not use the popover slot div at all, but use a reference or class provided to `Popover` to determine what the boundary container is.

Perhaps the last solution is the best?

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
