### PR TITLE
Fix block selection indicator.

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -83,7 +83,7 @@
 	// Navigate mode & Focused wrapper.
 	// We're using a pseudo element to overflow placeholder borders
 	// and any border inside the block itself.
-	&:focus::after {
+	&:not([contenteditable]):focus::after {
 		position: absolute;
 		z-index: 1;
 		pointer-events: none;


### PR DESCRIPTION
The behavior of manipulating blocks in the recent G2 refresh regressed slightly in #19701, this PR addresses that.

Specifically, the blue border is meant to indicate _block focus_, i.e. when it is present you can press Delete to remove the block. It is not meant to indicate the block boundaries when focus is inside text.