### PR TITLE
Try: High-luminance default colors

### DIFF
--- a/packages/base-styles/_colors.scss
+++ b/packages/base-styles/_colors.scss
@@ -32,7 +32,7 @@ $light-gray-ui: #949494;		// Meets 3:1 UI contrast.
 $light-gray-secondary: #ccc;
 $light-gray-tertiary: #e7e8e9;
 $theme-color: theme(button);
-$blue-medium-focus: #007cba;	// @todo: Currently being used as "spot" color. Needs to be considered in context of themes.
+$blue-medium-focus: #3858e9;	// @todo: Currently being used as "spot" color. Needs to be considered in context of themes.
 $blue-medium-focus-dark: #fff;
 
 // Dark opacities, for use with light themes.

--- a/packages/base-styles/_colors.scss
+++ b/packages/base-styles/_colors.scss
@@ -32,7 +32,7 @@ $light-gray-ui: #949494;		// Meets 3:1 UI contrast.
 $light-gray-secondary: #ccc;
 $light-gray-tertiary: #e7e8e9;
 $theme-color: theme(button);
-$blue-medium-focus: #3858e9;	// @todo: Currently being used as "spot" color. Needs to be considered in context of themes.
+$blue-medium-focus: theme(button);
 $blue-medium-focus-dark: #fff;
 
 // Dark opacities, for use with light themes.

--- a/packages/base-styles/index.js
+++ b/packages/base-styles/index.js
@@ -1,18 +1,18 @@
 exports.adminColorSchemes = {
 	defaults: {
 		primary: '#0085ba',
-		secondary: '#11a0d2',
-		toggle: '#11a0d2',
-		button: '#007cba',
-		outlines: '#007cba',
+		secondary: '#3858e9',
+		toggle: '#3858e9',
+		button: '#3858e9',
+		outlines: '#3858e9',
 	},
 	themes: {
 		'admin-color-light': {
 			primary: '#0085ba',
 			secondary: '#c75726',
-			toggle: '#11a0d2',
+			toggle: '#3858e9',
 			button: '#0085ba',
-			outlines: '#007cba',
+			outlines: '#3858e9',
 		},
 		'admin-color-blue': {
 			primary: '#82b4cb',

--- a/packages/base-styles/index.js
+++ b/packages/base-styles/index.js
@@ -1,17 +1,17 @@
 exports.adminColorSchemes = {
 	defaults: {
-		primary: '#0085ba',
-		secondary: '#3858e9',
+		primary: '#3858e9',
+		secondary: '#1635bb',
 		toggle: '#3858e9',
 		button: '#3858e9',
 		outlines: '#3858e9',
 	},
 	themes: {
 		'admin-color-light': {
-			primary: '#0085ba',
-			secondary: '#c75726',
+			primary: '#3858e9',
+			secondary: '#1635bb',
 			toggle: '#3858e9',
-			button: '#0085ba',
+			button: '#3858e9',
 			outlines: '#3858e9',
 		},
 		'admin-color-blue': {

--- a/packages/components/src/utils/colors-values.js
+++ b/packages/components/src/utils/colors-values.js
@@ -123,7 +123,7 @@ export const BLUE = {
 		200: '#bfe7f3',
 		100: '#e5f5fa',
 		highlight: '#b3e7fe',
-		focus: '#007cba',
+		focus: '#3858e9',
 	},
 };
 


### PR DESCRIPTION
These are colors that are explored through the G2 visual refresh (see #18667).

<img width="1747" alt="Screenshot 2020-05-11 at 12 30 00" src="https://user-images.githubusercontent.com/1204802/81552138-348ee400-9383-11ea-99a9-731376132c2f.png">

The color change does a few things:

- It is chosen and balanced against the rest of the visual refresh.
- It reduces the overall color palette, removing secondary colors used for toggles or checkmarks, unifying on a single blue.
- It increases contrast against white, quite a bit, which is good for toggles, focus, form widgets and buttons.

The new blue has a contrast of 5.61:1 compared to 4.57:1 for the previously used WordPress blue (#007cba).

Before:

<img width="735" alt="Screenshot 2020-02-26 at 12 11 47" src="https://user-images.githubusercontent.com/1204802/75339790-784c7400-5891-11ea-8bcc-07c9c41e09ca.png">

After:

<img width="740" alt="Screenshot 2020-02-26 at 12 09 45" src="https://user-images.githubusercontent.com/1204802/75339802-7b476480-5891-11ea-88c0-720cba38eb1f.png">

