### PR TITLE
Create block: Reimplement check for system requirements using Node API

### DIFF
--- a/packages/create-block/CHANGELOG.md
+++ b/packages/create-block/CHANGELOG.md
@@ -1,8 +1,10 @@
 ## Master
 
-## 0.8.2 (2020-02-26)
+## 0.8.3 (2020-02-26)
 
-- Fixed buggy check for minimum system requirements when run with `npx` and `npm init` ([#20456](https://github.com/WordPress/gutenberg/pull/20456)).
+### Bug Fixes
+
+- Fixed buggy check for minimum system requirements when run with `npx` and `npm init` ([#20461](https://github.com/WordPress/gutenberg/pull/20461)).
 
 ## 0.8.1 (2020-02-25)
 

--- a/packages/create-block/lib/check-system-requirements.js
+++ b/packages/create-block/lib/check-system-requirements.js
@@ -1,0 +1,34 @@
+/**
+ * External dependencies
+ */
+const checkSync = require( 'check-node-version' );
+const { forEach } = require( 'lodash' );
+const { promisify } = require( 'util' );
+
+/**
+ * Internal dependencies
+ */
+const log = require( './log' );
+
+const check = promisify( checkSync );
+
+async function checkSystemRequirements( engines ) {
+	const result = await check( engines );
+	if ( ! result.isSatisfied ) {
+		log.error( 'Minimum system requirements not met!' );
+		log.info( '' );
+		forEach( result.versions, ( { isSatisfied, wanted }, name ) => {
+			if ( ! isSatisfied ) {
+				log.error(
+					`Error: Wanted ${ name } version ${ wanted.raw } (${ wanted.range })`
+				);
+				log.info(
+					check.PROGRAMS[ name ].getInstallInstructions( wanted.raw )
+				);
+			}
+		} );
+		process.exit( 1 );
+	}
+}
+
+module.exports = checkSystemRequirements;

--- a/packages/create-block/lib/index.js
+++ b/packages/create-block/lib/index.js
@@ -1,35 +1,19 @@
 /**
  * External dependencies
  */
-const execa = require( 'execa' );
-const program = require( 'commander' );
 const inquirer = require( 'inquirer' );
+const program = require( 'commander' );
 const { startCase } = require( 'lodash' );
 
 /**
  * Internal dependencies
  */
+const checkSystemRequirements = require( './check-system-requirements' );
 const CLIError = require( './cli-error' );
 const log = require( './log' );
 const { engines, version } = require( '../package.json' );
 const scaffold = require( './scaffold' );
 const { getDefaultValues, getPrompts } = require( './templates' );
-
-async function checkSystemRequirements() {
-	try {
-		await execa( 'check-node-version', [
-			'--node',
-			engines.node,
-			'--npm',
-			engines.npm,
-		] );
-	} catch ( error ) {
-		log.error( 'Minimum system requirements not met!' );
-		log.error( error.stderr );
-		log.info( error.stdout );
-		process.exit( error.exitCode );
-	}
-}
 
 const commandName = `wp-create-block`;
 program
@@ -48,7 +32,7 @@ program
 		'esnext'
 	)
 	.action( async ( slug, { template } ) => {
-		await checkSystemRequirements();
+		await checkSystemRequirements( engines );
 		try {
 			const defaultValues = getDefaultValues( template );
 			if ( slug ) {


### PR DESCRIPTION
## Description

2nd attempt to fix #20450.

Follow-up for #20456 which doesn't work on npm.

> With version 0.8.1 of the @wordpress/create-block script, I always get the error "Minimum system requirements not met!"
> 
> Node version: v13.8.0
> npm version: 6.14.0

## How has this been tested?
It can't be really tested until it's published to npm.

`npx wp-create-block` works as expected locally.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
