### PR TITLE
[RNMobile] Extend current Button settings with automatically pasting link

### DIFF
--- a/packages/block-library/src/button/edit.native.js
+++ b/packages/block-library/src/button/edit.native.js
@@ -92,11 +92,11 @@ class ButtonEdit extends Component {
 		}
 
 		// Blur `RichText` on Android when link settings sheet or button settings sheet is opened,
-		// to avoid flashing caret after closing one of them	
+		// to avoid flashing caret after closing one of them
 		if (
 			( ! prevProps.editorSidebarOpened && editorSidebarOpened ) ||
 			( ! prevState.isLinkSheetVisible && isLinkSheetVisible )
-		) {		
+		) {
 			if ( Platform.OS === 'android' && this.richTextRef ) {
 				this.richTextRef.blur();
 				this.onToggleButtonFocus( false );

--- a/packages/block-library/src/button/edit.native.js
+++ b/packages/block-library/src/button/edit.native.js
@@ -104,7 +104,11 @@ class ButtonEdit extends Component {
 		}
 
 		// Paste a URL from clipboard
-		if ( (isLinkSheetVisible || editorSidebarOpened) && ! url && ! this.isEditingURL ) {
+		if (
+			( isLinkSheetVisible || editorSidebarOpened ) &&
+			! url &&
+			! this.isEditingURL
+		) {
 			this.getURLFromClipboard();
 		}
 
@@ -235,7 +239,10 @@ class ButtonEdit extends Component {
 					onChange={ this.onChangeURL }
 					autoCapitalize="none"
 					autoCorrect={ false }
-					autoFocus={ !isCompatibleWithSettings && Platform.OS === 'ios' }
+					// eslint-disable-next-line jsx-a11y/no-autofocus
+					autoFocus={
+						! isCompatibleWithSettings && Platform.OS === 'ios'
+					}
 					separatorType={
 						isCompatibleWithSettings ? 'fullWidth' : 'leftMargin'
 					}

--- a/packages/block-library/src/button/edit.native.js
+++ b/packages/block-library/src/button/edit.native.js
@@ -81,20 +81,22 @@ class ButtonEdit extends Component {
 		} = this.props;
 		const { isLinkSheetVisible, isButtonFocused } = this.state;
 
-		// Get initial value for `isEditingURL` when closing link settings sheet or button settings sheet
 		if (
 			( prevProps.editorSidebarOpened && ! editorSidebarOpened ) ||
 			( prevState.isLinkSheetVisible && ! isLinkSheetVisible )
 		) {
+			// Prepends "http://" to an url when closing link settings sheet and button settings sheet
+			setAttributes( { url: prependHTTP( url ) } );
+			// Get initial value for `isEditingURL` when closing link settings sheet or button settings sheet
 			this.isEditingURL = false;
 		}
 
 		// Blur `RichText` on Android when link settings sheet or button settings sheet is opened,
-		// to avoid flashing caret after closing one of them
+		// to avoid flashing caret after closing one of them	
 		if (
 			( ! prevProps.editorSidebarOpened && editorSidebarOpened ) ||
 			( ! prevState.isLinkSheetVisible && isLinkSheetVisible )
-		) {
+		) {		
 			if ( Platform.OS === 'android' && this.richTextRef ) {
 				this.richTextRef.blur();
 				this.onToggleButtonFocus( false );
@@ -102,13 +104,8 @@ class ButtonEdit extends Component {
 		}
 
 		// Paste a URL from clipboard
-		if ( isLinkSheetVisible && ! url && ! this.isEditingURL ) {
+		if ( (isLinkSheetVisible || editorSidebarOpened) && ! url && ! this.isEditingURL ) {
 			this.getURLFromClipboard();
-		}
-
-		// Prepends "http://" to a url when closing link settings sheet and button settings sheet
-		if ( ! isLinkSheetVisible && ! editorSidebarOpened ) {
-			setAttributes( { url: prependHTTP( url ) } );
 		}
 
 		if ( this.richTextRef ) {
@@ -238,6 +235,7 @@ class ButtonEdit extends Component {
 					onChange={ this.onChangeURL }
 					autoCapitalize="none"
 					autoCorrect={ false }
+					autoFocus={ !isCompatibleWithSettings && Platform.OS === 'ios' }
 					separatorType={
 						isCompatibleWithSettings ? 'fullWidth' : 'leftMargin'
 					}


### PR DESCRIPTION
## Description

Fixes: https://github.com/wordpress-mobile/gutenberg-mobile/issues/1957#event-3072715893
Ref to gutenberg-mobile: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1958
 
* Extend current Button setting to get automatically link pasting into button settings.
* Add autofocus on Button Link URL field like in other examples

## How has this been tested?

1. Copy link into clipboard, e.g: `http://apple.com`
2. Open mobile app
3. Add Button block
4. Open Button settings
5. Notice if link is automatically pasted into Button Link URL field

## Screenshots <!-- if applicable -->
<img src="https://user-images.githubusercontent.com/22746080/75343254-56a2bb00-5898-11ea-8118-15644e51e1c3.gif" width="300" />


## Types of changes

Enhancements:
* Extend current Button setting to get automatically link pasting into button settings.
* Add autofocus on Button Link URL field like in other examples

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
