### PR TITLE
[RNMobile] Cover block -  Support adding video background from media library

### DIFF
--- a/packages/block-library/src/cover/edit.native.js
+++ b/packages/block-library/src/cover/edit.native.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { View, TouchableWithoutFeedback } from 'react-native';
+import { default as Video } from 'react-native-video';
 
 /**
  * WordPress dependencies
@@ -21,6 +22,7 @@ import {
 	InnerBlocks,
 	InspectorControls,
 	MEDIA_TYPE_IMAGE,
+	MEDIA_TYPE_VIDEO,
 	MediaPlaceholder,
 	MediaUpload,
 	withColors,
@@ -46,7 +48,7 @@ import { EditMediaIcon } from './edit-media-icon';
 /**
  * Constants
  */
-const ALLOWED_MEDIA_TYPES = [ MEDIA_TYPE_IMAGE ];
+const ALLOWED_MEDIA_TYPES = [ MEDIA_TYPE_IMAGE, MEDIA_TYPE_VIDEO ];
 const INNER_BLOCKS_TEMPLATE = [
 	[
 		'core/paragraph',
@@ -116,11 +118,7 @@ const Cover = ( {
 				overlayColor && overlayColor.color
 					? overlayColor.color
 					: styles.overlay.color,
-			// Set opacity to 1 while video / theme color support is not available
-			opacity:
-				url && VIDEO_BACKGROUND_TYPE !== backgroundType
-					? dimRatio / 100
-					: 1,
+			opacity: dimRatio / 100,
 		},
 		// While we don't support theme colors we add a default bg color
 		! overlayColor.color && ! url
@@ -207,6 +205,16 @@ const Cover = ( {
 							url={ url }
 						/>
 					) ) }
+				{ VIDEO_BACKGROUND_TYPE === backgroundType && (
+					<Video
+						muted
+						disableFocus
+						repeat
+						resizeMode={ 'cover' }
+						source={ { uri: url } }
+						style={ styles.background }
+					/>
+				) }
 			</View>
 		</TouchableWithoutFeedback>
 	);
@@ -249,7 +257,7 @@ const Cover = ( {
 
 				<MediaUpload
 					__experimentalOnlyMediaLibrary
-					allowedTypes={ [ MEDIA_TYPE_IMAGE ] }
+					allowedTypes={ [ MEDIA_TYPE_IMAGE, MEDIA_TYPE_VIDEO ] }
 					onSelect={ onSelectMedia }
 					render={ ( { open, getMediaOptions } ) => {
 						return background( open, getMediaOptions );

--- a/packages/block-library/src/cover/edit.native.js
+++ b/packages/block-library/src/cover/edit.native.js
@@ -257,7 +257,7 @@ const Cover = ( {
 
 				<MediaUpload
 					__experimentalOnlyMediaLibrary
-					allowedTypes={ [ MEDIA_TYPE_IMAGE, MEDIA_TYPE_VIDEO ] }
+					allowedTypes={ ALLOWED_MEDIA_TYPES }
 					onSelect={ onSelectMedia }
 					render={ ( { open, getMediaOptions } ) => {
 						return background( open, getMediaOptions );


### PR DESCRIPTION
Fixes - https://github.com/wordpress-mobile/gutenberg-mobile/issues/1738

Gutenberg-mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1959

In this PR I added the possibility to add video from the media library as a background in the cover block.

## How has this been tested?
Test cases:

**Test case 1 - render video background on the mobile that is set on the web**
- Open web version of gutenberg
- Add the cover bloc, set video as a background and save the post
- Open the mobile app and open saved post
- Video background should be rendered properly

**Test case 2 - Set video as a background in the mobile app**
- Open the mobile app (Wordpress-iOS or Wordpress Android) and add a cover block
- Click on the media upload placeholder to open the media library
- Select video from the media library
- The video should be set as a background

**Test case 3 - render video background on the web that is set on the mobile**
- Open the mobile version of the editor
- Add the cover block, set video as a background and save the post
- Open the saved post on the web
- Video background should be rendered properly

**Test case 4 - change the image background to the video background**
- Open the mobile app (Wordpress-iOS or Wordpress Android) and add a cover block with some image as a background
- Click on the button in the Block Toolbar to change the background that is already set <img width="184" alt="Screenshot 2020-03-03 at 14 08 32" src="https://user-images.githubusercontent.com/16336501/75778764-b3025080-5d58-11ea-96bc-5fdddcf33066.png">
- Select some video from the media library
- The image background should be changed to the video

**Test case 5 - change the video background to the image background**
- Open the mobile app (Wordpress-iOS or Wordpress Android) and add a cover block with some video as a background
- Click on the button in the Block Toolbar to change the background that is already set <img width="184" alt="Screenshot 2020-03-03 at 14 08 32" src="https://user-images.githubusercontent.com/16336501/75778764-b3025080-5d58-11ea-96bc-5fdddcf33066.png">
- Select some image from the media library
- The video background should be changed to the image

**Test case 6 - change the min-height of the block and the opacity of the overlay**
- Open the mobile app (Wordpress-iOS or Wordpress Android) and add a cover block with some video as a background
- Open settings of the block
- Change the opacity and min-height and look if they are applied to the block

## Screenshots <!-- if applicable -->

## iOS
**Set video as a background**
![cover-video-set](https://user-images.githubusercontent.com/16336501/75780635-0aee8680-5d5c-11ea-98f1-5cd7431747db.gif)
**Change settings of cover block**
![cover-height-opacity](https://user-images.githubusercontent.com/16336501/75780650-104bd100-5d5c-11ea-9ff1-3fe3ea0d3486.gif)
**Change image to the video and video to the image**
![cover-video-replace](https://user-images.githubusercontent.com/16336501/75781124-f19a0a00-5d5c-11ea-897a-7902530ebe12.gif)

## Android
**Set video as a background**
![androd-cover-set](https://user-images.githubusercontent.com/16336501/75793038-126b5b00-5d6f-11ea-9095-c42ce15bbbf7.gif)
**Change settings of cover block**
![androd-cover-set](https://user-images.githubusercontent.com/16336501/75793055-18613c00-5d6f-11ea-9e7f-964479eb051f.gif)
**Change image to the video and video to the image**
![android-cover-change](https://user-images.githubusercontent.com/16336501/75793068-1dbe8680-5d6f-11ea-999c-3c8d7cbfda15.gif)


## Types of changes
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
