### PR TITLE
Remove template locking from the columns block

### DIFF
--- a/packages/block-library/src/columns/edit.js
+++ b/packages/block-library/src/columns/edit.js
@@ -105,8 +105,8 @@ function ColumnsEditContainer( {
 				<TextColor>
 					<div className={ classes } ref={ ref }>
 						<InnerBlocks
-							templateLock="all"
 							allowedBlocks={ ALLOWED_BLOCKS }
+							__experimentalMoverDirection="horizontal"
 						/>
 					</div>
 				</TextColor>

--- a/packages/block-library/src/columns/editor.scss
+++ b/packages/block-library/src/columns/editor.scss
@@ -9,13 +9,6 @@
 	}
 }
 
-// Ideally all block toolbars should be positioned the same.
-.components-popover.block-editor-block-list__block-popover
-.components-popover__content
-.block-editor-block-contextual-toolbar[data-type="core/column"] {
-	margin-left: 0;
-}
-
 .wp-block-columns {
 	display: block;
 


### PR DESCRIPTION
With all the new UI updates, I don't think there's a valid reason to keep the template locking in the Columns block. What this means concretely is that the columns block becomes just a list of "column" block, you can remove/add any columns you want and also use the block movers (horizontal) from the toolbar to move columns.