### PR TITLE
Add storybook story for text-control component

### DIFF
--- a/packages/components/src/text-control/stories/index.js
+++ b/packages/components/src/text-control/stories/index.js
@@ -1,0 +1,43 @@
+/**
+ * External dependencies
+ */
+import { boolean, text } from '@storybook/addon-knobs';
+
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import TextControl from '../';
+
+export default {
+	title: 'Components/TextControl',
+	component: TextControl,
+};
+
+const TextControlWithState = ( props ) => {
+	const [ value, setValue ] = useState();
+
+	return <TextControl { ...props } value={ value } onChange={ setValue } />;
+};
+
+export const _default = () => {
+	const label = text( 'Label', 'Label Text' );
+	const hideLabelFromVision = boolean( 'Hide Label From Vision', false );
+	const help = text( 'Help Text', 'Help text to explain the input.' );
+	const type = text( 'Input Type', 'text' );
+	const className = text( 'Class Name', '' );
+
+	return (
+		<TextControlWithState
+			label={ label }
+			hideLabelFromVision={ hideLabelFromVision }
+			help={ help }
+			type={ type }
+			className={ className }
+		/>
+	);
+};

--- a/storybook/test/__snapshots__/index.js.snap
+++ b/storybook/test/__snapshots__/index.js.snap
@@ -7983,6 +7983,36 @@ exports[`Storyshots Components/TabPanel Default 1`] = `
 </div>
 `;
 
+exports[`Storyshots Components/TextControl Default 1`] = `
+<div
+  className="components-base-control"
+>
+  <div
+    className="components-base-control__field"
+  >
+    <label
+      className="components-base-control__label"
+      htmlFor="inspector-text-control-3"
+    >
+      Label Text
+    </label>
+    <input
+      aria-describedby="inspector-text-control-3__help"
+      className="components-text-control__input"
+      id="inspector-text-control-3"
+      onChange={[Function]}
+      type="text"
+    />
+  </div>
+  <p
+    className="components-base-control__help"
+    id="inspector-text-control-3__help"
+  >
+    Help text to explain the input.
+  </p>
+</div>
+`;
+
 exports[`Storyshots Components/TextHighlight Default 1`] = `
 Array [
   "We call the new editor ",


### PR DESCRIPTION
## Description
Adds a storybook story for the text-control component as part of #17973

## How has this been tested?
* run `npm run storybook:dev`
* See the new TextControl story under components

## Screenshots
![Components___TextControl_-_Default_⋅_Storybook](https://user-images.githubusercontent.com/6653970/75352571-f56aef80-5877-11ea-921c-427f8c1c66b9.png)

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
