### PR TITLE
Block Library: Social Link: Fix label attribute type as string

### DIFF
--- a/packages/block-library/src/social-link/block.json
+++ b/packages/block-library/src/social-link/block.json
@@ -10,7 +10,7 @@
 			"type": "string"
 		},
 		"label": {
-			"type": "number"
+			"type": "string"
 		}
 	}
 }


### PR DESCRIPTION
Reported by @afercia at https://github.com/WordPress/gutenberg/pull/18651#issuecomment-591444335
Regression of #19887 

This pull request seeks to resolve an issue where custom `aria-label` assigned to a Social Link block will otherwise not be represented on the front of a site.

**Testing Instructions:**

1. Navigate to Posts > Add New
2. Insert a Social Links block
3. For one of the Social Link block items in the set, assign a label
4. Publish or preview the post on the front of the site
5. Note that the `aria-label` is correctly assigned to the rendered link element

