### PR TITLE
Add storybook story for the TextAreaControl component

### DIFF
--- a/packages/components/src/textarea-control/stories/index.js
+++ b/packages/components/src/textarea-control/stories/index.js
@@ -1,0 +1,45 @@
+/**
+ * External dependencies
+ */
+import { boolean, number, text } from '@storybook/addon-knobs';
+
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import TextareaControl from '../';
+
+export default {
+	title: 'Components/TextareaControl',
+	component: TextareaControl,
+};
+
+const TextareaControlWithState = ( props ) => {
+	const [ value, setValue ] = useState();
+
+	return (
+		<TextareaControl { ...props } value={ value } onChange={ setValue } />
+	);
+};
+
+export const _default = () => {
+	const label = text( 'Label', 'Label Text' );
+	const hideLabelFromVision = boolean( 'Hide Label From Vision', false );
+	const help = text( 'Help Text', 'Help text to explain the textarea.' );
+	const rows = number( 'Rows', 4 );
+	const className = text( 'Class Name', '' );
+
+	return (
+		<TextareaControlWithState
+			label={ label }
+			hideLabelFromVision={ hideLabelFromVision }
+			help={ help }
+			rows={ rows }
+			className={ className }
+		/>
+	);
+};

--- a/storybook/test/__snapshots__/index.js.snap
+++ b/storybook/test/__snapshots__/index.js.snap
@@ -7993,6 +7993,36 @@ Array [
 ]
 `;
 
+exports[`Storyshots Components/TextareaControl Default 1`] = `
+<div
+  className="components-base-control"
+>
+  <div
+    className="components-base-control__field"
+  >
+    <label
+      className="components-base-control__label"
+      htmlFor="inspector-textarea-control-0"
+    >
+      Label Text
+    </label>
+    <textarea
+      aria-describedby="inspector-textarea-control-0__help"
+      className="components-textarea-control__input"
+      id="inspector-textarea-control-0"
+      onChange={[Function]}
+      rows={4}
+    />
+  </div>
+  <p
+    className="components-base-control__help"
+    id="inspector-textarea-control-0__help"
+  >
+    Help text to explain the textarea.
+  </p>
+</div>
+`;
+
 exports[`Storyshots Components/Tip Default 1`] = `
 <div
   className="components-tip"


### PR DESCRIPTION
## Description
Adds a storybook story for the textarea-control component as part of #17973

## How has this been tested?
* run `npm run storybook:dev`
* See the new TextAreaControl story under components

## Screenshots
![Components___TextareaControl_-_Default_⋅_Storybook](https://user-images.githubusercontent.com/6653970/75367156-d8411b80-588d-11ea-92d9-2653359146b1.png)

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
