### PR TITLE
Block Library: Social Link: Use placeholder for default label

### DIFF
--- a/packages/block-library/src/social-link/index.php
+++ b/packages/block-library/src/social-link/index.php
@@ -15,7 +15,10 @@
 function render_block_core_social_link( $attributes ) {
 	$service = ( isset( $attributes['service'] ) ) ? $attributes['service'] : 'Icon';
 	$url     = ( isset( $attributes['url'] ) ) ? $attributes['url'] : false;
-	$label   = ( isset( $attributes['label'] ) ) ? $attributes['label'] : __( 'Link to ' ) . block_core_social_link_get_name( $service );
+	$label   = ( isset( $attributes['label'] ) ) ?
+		$attributes['label'] :
+		/* translators: %s: Social Link service name */
+		sprintf( __( 'Link to %s' ), block_core_social_link_get_name( $service ) );
 
 	// Don't render a link if there is no URL set.
 	if ( ! $url ) {


### PR DESCRIPTION
Fixes #20152 

This pull request seeks to update the implementation of Social Block to use a placeholder for its default label. Previously, it used string concatenation of "Link to " + the service name. This sort of concatenation can be problematic for translations, especially when a translation would require a reordering of the service name relative to other words in the phrase.

References:

- https://codex.wordpress.org/I18n_for_WordPress_Developers#Placeholders
- https://developer.wordpress.org/apis/handbook/internationalization/internationalization-guidelines/#variables

Note: I have assigned this to the "WordPress 5.4 Must Have" project, since this block is newly introduced in WordPress 5.4 and this string may otherwise be problematic to translate. However, it is worth noting that the upcoming 5.4 RC constitutes a string freeze. This change should be considered a string change and would not qualify to be changed after the RC release.

**Testing Instructions:**

Verify that there are no regressions in the rendering of a Social Link block using the default label.

1. Navigate to Posts > Add New
2. Insert a Social Icons block
3. Preview the post on the front of the site
4. Verify that the assigned `aria-label` of the WordPress icon is "Link to WordPress"