### PR TITLE
Block Library: Social Link: Escape generated class name

### DIFF
--- a/packages/block-library/src/social-link/index.php
+++ b/packages/block-library/src/social-link/index.php
@@ -23,7 +23,7 @@ function render_block_core_social_link( $attributes ) {
 	}
 
 	$icon = block_core_social_link_get_icon( $service );
-	return '<li class="wp-social-link wp-social-link-' . $service . '"><a href="' . esc_url( $url ) . '" aria-label="' . esc_attr( $label ) . '"> ' . $icon . '</a></li>';
+	return '<li class="wp-social-link wp-social-link-' . esc_attr( $service ) . '"><a href="' . esc_url( $url ) . '" aria-label="' . esc_attr( $label ) . '"> ' . $icon . '</a></li>';
 }
 
 /**


### PR DESCRIPTION
This pull request seeks to update the Social Link block to correctly escape the output of the service in the generated class name.

Note that this is not a security issue. Block comment attribute values are sanitized based on user capabilities at save time. Rather, this change is intended to preserve HTML integrity, since otherwise a user could potentially "break out" of the `class` attribute and mangle the generated markup.

**Testing Instructions:**

Verify there are no regressions in the class name assigned to a Social Icon block.

1. Navigate to Posts > Add New
2. Insert a Social Icons block
3. Preview the post on the front of the site
4. Verify that the assigned `class` of the WordPress icon element contains `wp-social-link-wordpress`.