### PR TITLE
E2E Tests: Mock Embed response for InnerBlocks locking test

### DIFF
--- a/packages/e2e-tests/specs/editor/plugins/innerblocks-locking-all-embed.js
+++ b/packages/e2e-tests/specs/editor/plugins/innerblocks-locking-all-embed.js
@@ -6,7 +6,24 @@ import {
 	createNewPost,
 	deactivatePlugin,
 	insertBlock,
+	createEmbeddingMatcher,
+	createJSONResponse,
+	setUpResponseMocking,
 } from '@wordpress/e2e-test-utils';
+
+const MOCK_RESPONSES = [
+	{
+		match: createEmbeddingMatcher( 'https://twitter.com/wordpress' ),
+		onRequestMatch: createJSONResponse( {
+			url: 'https://twitter.com/wordpress',
+			html: '<p>Mock success response.</p>',
+			type: 'rich',
+			provider_name: 'Twitter',
+			provider_url: 'https://twitter.com',
+			version: '1.0',
+		} ),
+	},
+];
 
 describe( 'Embed block inside a locked all parent', () => {
 	beforeAll( async () => {
@@ -14,6 +31,7 @@ describe( 'Embed block inside a locked all parent', () => {
 	} );
 
 	beforeEach( async () => {
+		await setUpResponseMocking( MOCK_RESPONSES );
 		await createNewPost();
 	} );
 
@@ -30,7 +48,7 @@ describe( 'Embed block inside a locked all parent', () => {
 		await page.waitForSelector( embedInputSelector );
 		await page.click( embedInputSelector );
 		// This URL should not have a trailing slash.
-		await page.keyboard.type( 'https://twitter.com/WordPress' );
+		await page.keyboard.type( 'https://twitter.com/wordpress' );
 		await page.keyboard.press( 'Enter' );
 		// The twitter block should appear correctly.
 		await page.waitForSelector( 'figure.wp-block-embed' );


### PR DESCRIPTION
This pull request seeks to improve end-to-end test stability for the `editor/plugins/innerblocks-locking-all-embed.js` tests. These test cases have been observed to fail intermittently.

Example: https://travis-ci.com/WordPress/gutenberg/jobs/291310078

It is suspected that these are caused by unreliability of third-party network requests. This has been a problem in the past for other tests which include embeds, which led to the implementation of mocking for the core embedding tests (#10467, #11250).

**Testing Instructions:**

Verify that the affected tests still pass:

```
npm run test-e2e packages/e2e-tests/specs/editor/plugins/innerblocks-locking-all-embed.js
```