### PR TITLE
Add storybook story for the SelectControl component

### DIFF
--- a/packages/components/src/select-control/stories/index.js
+++ b/packages/components/src/select-control/stories/index.js
@@ -1,0 +1,59 @@
+/**
+ * External dependencies
+ */
+import { boolean, object, text } from '@storybook/addon-knobs';
+
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import SelectControl from '../';
+
+export default {
+	title: 'Components/SelectControl',
+	component: SelectControl,
+};
+
+const SelectControlWithState = ( props ) => {
+	const [ selection, setSelection ] = useState();
+
+	return (
+		<SelectControl
+			{ ...props }
+			value={ selection }
+			onChange={ setSelection }
+		/>
+	);
+};
+
+export const _default = () => {
+	const label = text( 'Label', 'Label Text' );
+	const hideLabelFromVision = boolean( 'Hide Label From Vision', false );
+	const help = text(
+		'Help Text',
+		'Help text to explain the select control.'
+	);
+	const multiple = boolean( 'Allow Multiple Selection', false );
+	const options = object( 'Options', [
+		{ value: null, label: 'Select an Option', disabled: true },
+		{ value: 'a', label: 'Option A' },
+		{ value: 'b', label: 'Option B' },
+		{ value: 'c', label: 'Option C' },
+	] );
+	const className = text( 'Class Name', '' );
+
+	return (
+		<SelectControlWithState
+			label={ label }
+			hideLabelFromVision={ hideLabelFromVision }
+			help={ help }
+			multiple={ multiple }
+			options={ options }
+			className={ className }
+		/>
+	);
+};

--- a/storybook/test/__snapshots__/index.js.snap
+++ b/storybook/test/__snapshots__/index.js.snap
@@ -7887,6 +7887,58 @@ exports[`Storyshots Components/ScrollLock Default 1`] = `
 </div>
 `;
 
+exports[`Storyshots Components/SelectControl Default 1`] = `
+<div
+  className="components-base-control"
+>
+  <div
+    className="components-base-control__field"
+  >
+    <label
+      className="components-base-control__label"
+      htmlFor="inspector-select-control-0"
+    >
+      Label Text
+    </label>
+    <select
+      aria-describedby="inspector-select-control-0__help"
+      className="components-select-control__input"
+      id="inspector-select-control-0"
+      multiple={false}
+      onChange={[Function]}
+    >
+      <option
+        disabled={true}
+        value={null}
+      >
+        Select an Option
+      </option>
+      <option
+        value="a"
+      >
+        Option A
+      </option>
+      <option
+        value="b"
+      >
+        Option B
+      </option>
+      <option
+        value="c"
+      >
+        Option C
+      </option>
+    </select>
+  </div>
+  <p
+    className="components-base-control__help"
+    id="inspector-select-control-0__help"
+  >
+    Help text to explain the select control.
+  </p>
+</div>
+`;
+
 exports[`Storyshots Components/Snackbar Default 1`] = `
 <div
   className="components-snackbar"


### PR DESCRIPTION
## Description
Adds a storybook story for the SelectControl component as part of #17973

## How has this been tested?
* run `npm run storybook:dev`
* See the new SelectControl story under components

## Screenshots
![Components___SelectControl_-_Default_⋅_Storybook](https://user-images.githubusercontent.com/6653970/75375734-adaa8f00-589c-11ea-8f41-3732e0791dcf.png)

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
