### PR TITLE
Block Editor: Typewriter: Skip entire component for IE

### DIFF
--- a/packages/block-editor/src/components/typewriter/index.js
+++ b/packages/block-editor/src/components/typewriter/index.js
@@ -236,12 +236,6 @@ class Typewriter extends Component {
 	}
 
 	render() {
-		// There are some issues with Internet Explorer, which are probably not
-		// worth spending time on. Let's disable it.
-		if ( isIE ) {
-			return this.props.children;
-		}
-
 		// Disable reason: Wrapper itself is non-interactive, but must capture
 		// bubbling events from children to determine focus transition intents.
 		/* eslint-disable jsx-a11y/no-static-element-interactions */
@@ -262,11 +256,22 @@ class Typewriter extends Component {
 }
 
 /**
+ * The exported component. The implementation of Typewriter faced technical
+ * challenges in Internet Explorer, and is simply skipped, rendering the given
+ * props children instead.
+ *
+ * @type {WPComponent}
+ */
+const TypewriterOrIEBypass = isIE
+	? ( props ) => props.children
+	: withSelect( ( select ) => {
+			const { getSelectedBlockClientId } = select( 'core/block-editor' );
+			return { selectedBlockClientId: getSelectedBlockClientId() };
+	  } )( Typewriter );
+
+/**
  * Ensures that the text selection keeps the same vertical distance from the
  * viewport during keyboard events within this component. The vertical distance
  * can vary. It is the last clicked or scrolled to position.
  */
-export default withSelect( ( select ) => {
-	const { getSelectedBlockClientId } = select( 'core/block-editor' );
-	return { selectedBlockClientId: getSelectedBlockClientId() };
-} )( Typewriter );
+export default TypewriterOrIEBypass;


### PR DESCRIPTION
Fixes [Trac#49516](https://core.trac.wordpress.org/ticket/49516)
Related: #16460

This pull request seeks to resolve an error that occurs in the Typewriter component when used in Internet Explorer. Notably, the Typewriter component was written to intentionally bypass itself in Internet Explorer:

https://github.com/WordPress/gutenberg/blob/d026d5b5c189e85bf1bb83321a74494c664e0159/packages/block-editor/src/components/typewriter/index.js#L238-L243

However, event handlers for scroll and resize were still added when the component mounted:

https://github.com/WordPress/gutenberg/blob/d026d5b5c189e85bf1bb83321a74494c664e0159/packages/block-editor/src/components/typewriter/index.js#L35-L40

These event handlers eventually try to reference the `ref` of the `div` that is only rendered in non-IE environments:

https://github.com/WordPress/gutenberg/blob/d026d5b5c189e85bf1bb83321a74494c664e0159/packages/block-editor/src/components/typewriter/index.js#L100

Thus, an error occurs.

With these changes, the _entire component_ is bypassed in Internet Explorer, preventing any event handlers from being attached.

**Testing Instructions:**

Repeat steps to reproduce from [Trac#49516](https://core.trac.wordpress.org/ticket/49516).

Notably, I was able to reproduce this when scrolling in the editor in Internet Explorer.

<!-- typescriptisnice -->