### PR TITLE
Fix sidebar scroll issue on small viewports.

### DIFF
--- a/packages/edit-post/src/components/sidebar/style.scss
+++ b/packages/edit-post/src/components/sidebar/style.scss
@@ -20,7 +20,7 @@
 		overflow: auto;
 		-webkit-overflow-scrolling: touch;
 		height: auto;
-		max-height: calc(100vh - #{ $admin-bar-height-big + $panel-header-height });
+		max-height: calc(100vh - #{ $admin-bar-height-big + $panel-header-height + $panel-header-height });
 		margin-top: -1px;
 		margin-bottom: -1px;
 		position: relative;


### PR DESCRIPTION
Fixes feedback from https://github.com/WordPress/gutenberg/pull/20355#issuecomment-591838313.

The vh math was off, it counted 1 panel height and 1 adminbar height, but there are two panels headers to account for:

<img width="583" alt="Screenshot 2020-02-27 at 09 19 26" src="https://user-images.githubusercontent.com/1204802/75425153-6d9de780-5942-11ea-8519-5c16e48d3c26.png">

I wonder how long it's been like this.