### PR TITLE
Add TreeSelect component to Storybook

### DIFF
--- a/packages/components/src/tree-select/stories/index.js
+++ b/packages/components/src/tree-select/stories/index.js
@@ -1,0 +1,53 @@
+/**
+ * WordPress dependencies
+ */
+import { withState } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import TreeSelect from '../';
+
+export default { title: 'Components/TreeSelect', component: TreeSelect };
+
+const TreeSelectStory = withState( {
+	page: 'p21',
+} )( ( { page, setState } ) => (
+	<TreeSelect
+		label="Parent page"
+		noOptionLabel="No parent page"
+		onChange={ ( pageId ) => setState( { page: pageId } ) }
+		selectedId={ page }
+		tree={ [
+			{
+				name: 'Page 1',
+				id: 'p1',
+				children: [
+					{ name: 'Descend 1 of page 1', id: 'p11' },
+					{ name: 'Descend 2 of page 1', id: 'p12' },
+				],
+			},
+			{
+				name: 'Page 2',
+				id: 'p2',
+				children: [
+					{
+						name: 'Descend 1 of page 2',
+						id: 'p21',
+						children: [
+							{
+								name: 'Descend 1 of Descend 1 of page 2',
+								id: 'p211',
+							},
+						],
+					},
+				],
+			},
+		] }
+		style={ { width: '400px' } }
+	/>
+) );
+
+export const _default = () => {
+	return <TreeSelectStory />;
+};

--- a/packages/components/src/tree-select/stories/index.js
+++ b/packages/components/src/tree-select/stories/index.js
@@ -1,53 +1,77 @@
 /**
+ * External dependencies
+ */
+import { boolean, object, text } from '@storybook/addon-knobs';
+
+/**
  * WordPress dependencies
  */
-import { withState } from '@wordpress/compose';
+import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import TreeSelect from '../';
 
-export default { title: 'Components/TreeSelect', component: TreeSelect };
+export default {
+	title: 'Components/TreeSelect',
+	component: TreeSelect,
+};
 
-const TreeSelectStory = withState( {
-	page: 'p21',
-} )( ( { page, setState } ) => (
-	<TreeSelect
-		label="Parent page"
-		noOptionLabel="No parent page"
-		onChange={ ( pageId ) => setState( { page: pageId } ) }
-		selectedId={ page }
-		tree={ [
-			{
-				name: 'Page 1',
-				id: 'p1',
-				children: [
-					{ name: 'Descend 1 of page 1', id: 'p11' },
-					{ name: 'Descend 2 of page 1', id: 'p12' },
-				],
-			},
-			{
-				name: 'Page 2',
-				id: 'p2',
-				children: [
-					{
-						name: 'Descend 1 of page 2',
-						id: 'p21',
-						children: [
-							{
-								name: 'Descend 1 of Descend 1 of page 2',
-								id: 'p211',
-							},
-						],
-					},
-				],
-			},
-		] }
-		style={ { width: '400px' } }
-	/>
-) );
+const TreeSelectWithState = ( props ) => {
+	const [ selection, setSelection ] = useState();
+
+	return (
+		<TreeSelect
+			{ ...props }
+			onChange={ setSelection }
+			selectedId={ selection }
+		/>
+	);
+};
 
 export const _default = () => {
-	return <TreeSelectStory />;
+	const label = text( 'Label', 'Label Text' );
+	const noOptionLabel = text( 'No Option Label', 'No parent page' );
+	const hideLabelFromVision = boolean( 'Hide Label From Vision', false );
+	const help = text(
+		'Help Text',
+		'Help text to explain the select control.'
+	);
+	const tree = object( 'Tree', [
+		{
+			name: 'Page 1',
+			id: 'p1',
+			children: [
+				{ name: 'Descend 1 of page 1', id: 'p11' },
+				{ name: 'Descend 2 of page 1', id: 'p12' },
+			],
+		},
+		{
+			name: 'Page 2',
+			id: 'p2',
+			children: [
+				{
+					name: 'Descend 1 of page 2',
+					id: 'p21',
+					children: [
+						{
+							name: 'Descend 1 of Descend 1 of page 2',
+							id: 'p211',
+						},
+					],
+				},
+			],
+		},
+	] );
+
+	return (
+		<TreeSelectWithState
+			label={ label }
+			noOptionLabel={ noOptionLabel }
+			hideLabelFromVision={ hideLabelFromVision }
+			help={ help }
+			tree={ tree }
+		/>
+	);
 };

--- a/storybook/test/__snapshots__/index.js.snap
+++ b/storybook/test/__snapshots__/index.js.snap
@@ -8665,6 +8665,72 @@ exports[`Storyshots Components/ToolbarGroup With Controls Prop 1`] = `
 </div>
 `;
 
+exports[`Storyshots Components/TreeSelect Default 1`] = `
+<div
+  className="components-base-control"
+>
+  <div
+    className="components-base-control__field"
+  >
+    <label
+      className="components-base-control__label"
+      htmlFor="inspector-select-control-0"
+    >
+      Label Text
+    </label>
+    <select
+      aria-describedby="inspector-select-control-0__help"
+      className="components-select-control__input"
+      id="inspector-select-control-0"
+      multiple={false}
+      onChange={[Function]}
+    >
+      <option
+        value=""
+      >
+        No parent page
+      </option>
+      <option
+        value="p1"
+      >
+        Page 1
+      </option>
+      <option
+        value="p11"
+      >
+           Descend 1 of page 1
+      </option>
+      <option
+        value="p12"
+      >
+           Descend 2 of page 1
+      </option>
+      <option
+        value="p2"
+      >
+        Page 2
+      </option>
+      <option
+        value="p21"
+      >
+           Descend 1 of page 2
+      </option>
+      <option
+        value="p211"
+      >
+              Descend 1 of Descend 1 of page 2
+      </option>
+    </select>
+  </div>
+  <p
+    className="components-base-control__help"
+    id="inspector-select-control-0__help"
+  >
+    Help text to explain the select control.
+  </p>
+</div>
+`;
+
 exports[`Storyshots Components/VisuallyHidden Default 1`] = `
 Array [
   <div

--- a/storybook/test/__snapshots__/index.js.snap
+++ b/storybook/test/__snapshots__/index.js.snap
@@ -8674,14 +8674,14 @@ exports[`Storyshots Components/TreeSelect Default 1`] = `
   >
     <label
       className="components-base-control__label"
-      htmlFor="inspector-select-control-0"
+      htmlFor="inspector-select-control-1"
     >
       Label Text
     </label>
     <select
-      aria-describedby="inspector-select-control-0__help"
+      aria-describedby="inspector-select-control-1__help"
       className="components-select-control__input"
-      id="inspector-select-control-0"
+      id="inspector-select-control-1"
       multiple={false}
       onChange={[Function]}
     >
@@ -8724,7 +8724,7 @@ exports[`Storyshots Components/TreeSelect Default 1`] = `
   </div>
   <p
     className="components-base-control__help"
-    id="inspector-select-control-0__help"
+    id="inspector-select-control-1__help"
   >
     Help text to explain the select control.
   </p>


### PR DESCRIPTION
## Description
This PR add TreeSelect component to Storybook.

## How has this been tested?
I've tested in my localhost running `npm run storybook:dev`.

## Screenshots <!-- if applicable -->
<img width="554" alt="Screenshot 2020-02-27 at 3 37 51 PM" src="https://user-images.githubusercontent.com/1541774/75431842-a86e4280-5977-11ea-935c-6dffc9edc5a2.png">

## Types of changes
- Added new Storybook item

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
