### PR TITLE
[RNMobile] Fix crash pasting HTML with wrapped images.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19762,7 +19762,7 @@
 				},
 				"node-pre-gyp": {
 					"version": "0.12.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz",
 					"integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
 					"dev": true,
 					"optional": true,
@@ -19781,7 +19781,7 @@
 				},
 				"nopt": {
 					"version": "4.0.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
 					"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
 					"dev": true,
 					"optional": true,

--- a/packages/blocks/src/api/raw-handling/figure-content-reducer.js
+++ b/packages/blocks/src/api/raw-handling/figure-content-reducer.js
@@ -88,7 +88,11 @@ export default function( node, doc, schema ) {
 	// there is no text content.
 	// Otherwise, if directly at the root, wrap in a figure element.
 	if ( wrapper ) {
-		if (
+		// In jsdom-jscore, 'node.classList' can be undefined.
+		// In this case, default to extract as it offers a better UI experience on mobile.
+		if ( ! node.classList ) {
+			wrapFigureContent( nodeToInsert, wrapper );
+		} else if (
 			node.classList.contains( 'alignright' ) ||
 			node.classList.contains( 'alignleft' ) ||
 			node.classList.contains( 'aligncenter' ) ||


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/1950
`gutenberg-mobile` PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1964

## Description
<!-- Please describe what you have changed or added -->

Adding a check for `node.classList` to avoid a crash pasting HTML containing wrapped image figures.

The PR that broke this behaviour on Mobile is https://github.com/WordPress/gutenberg/pull/19064

> The reason for this was that aligned images are often nested in a paragraph but appear to be a block (as we want it in Gutenberg). The solution is to only extract aligned images and leave the rest alone.

On mobile, since `classList` is undefined, we won't be able to have this choice, so we can only inline all figures or extract them all. I opted for the later, since the inline image experience on Paragraph block is rather poor on mobile. The Image block will offer a much richer experience.

cc @ellatrix @iamthomasbishop

**To test:**
- Go to https://automattic.com/work-with-us/
- Copy the first part of the page (from Work With Us until the end of the Coming on board paragraph).
- Paste on Gutenberg Mobile (on an empty post).
- Check that all blocks are created.

