### PR TITLE
Remove potentially useless style override for floats

### DIFF
--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -79,11 +79,3 @@
 		}
 	}
 }
-
-.edit-post-visual-editor {
-	// If the first block is floated, it needs top margin, unlike the rule in line 69.
-	.block-editor-block-list__layout > .block-editor-block-list__block[data-align="left"]:first-child,
-	.block-editor-block-list__layout > .block-editor-block-list__block[data-align="right"]:first-child {
-		margin-top: $block-padding + $block-spacing + $border-width + $border-width + $block-padding;
-	}
-}


### PR DESCRIPTION
closes #17196 

This style affects any floated block if it's the first block inside a container (or canvas).
I'm not really certain why this was added in the first place (introduced in #11357 ) but it seems useless for me and removing it solves #17196 

Any ideas @jasmussen do we still need this style?