### PR TITLE
Allow the column block in the inserter

### DIFF
--- a/packages/block-library/src/column/index.js
+++ b/packages/block-library/src/column/index.js
@@ -21,7 +21,6 @@ export const settings = {
 	icon,
 	description: __( 'A single column within a columns block.' ),
 	supports: {
-		inserter: false,
 		reusable: false,
 		html: false,
 		lightBlockWrapper: true,

--- a/packages/block-library/src/columns/edit.js
+++ b/packages/block-library/src/columns/edit.js
@@ -83,7 +83,7 @@ function ColumnsEditContainer( {
 					{ count > 6 && (
 						<Notice status="warning" isDismissible={ false }>
 							{ __(
-								'This number of columns used is too big. It may cause visual breakage.'
+								'This column count exceeds the recommended amount and may cause visual breakage.'
 							) }
 						</Notice>
 					) }

--- a/packages/block-library/src/columns/edit.js
+++ b/packages/block-library/src/columns/edit.js
@@ -8,7 +8,7 @@ import { dropRight, get, map, times } from 'lodash';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { PanelBody, RangeControl } from '@wordpress/components';
+import { PanelBody, RangeControl, Notice } from '@wordpress/components';
 
 import {
 	InspectorControls,
@@ -78,8 +78,15 @@ function ColumnsEditContainer( {
 						value={ count }
 						onChange={ ( value ) => updateColumns( count, value ) }
 						min={ 2 }
-						max={ 6 }
+						max={ Math.max( 6, count ) }
 					/>
+					{ count > 6 && (
+						<Notice status="warning" isDismissible={ false }>
+							{ __(
+								'This number of columns used is too big. It may cause visual breakage.'
+							) }
+						</Notice>
+					) }
 				</PanelBody>
 			</InspectorControls>
 			<InnerBlocks

--- a/packages/block-library/src/columns/edit.js
+++ b/packages/block-library/src/columns/edit.js
@@ -89,6 +89,7 @@ function ColumnsEditContainer( {
 				__experimentalPassedProps={ {
 					className: classes,
 				} }
+				renderAppender={ false }
 			/>
 		</>
 	);

--- a/packages/e2e-tests/specs/editor/blocks/columns.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/columns.test.js
@@ -26,6 +26,6 @@ describe( 'Columns', () => {
 		 )[ 0 ];
 		await columnBlockMenuItem.click();
 		await openGlobalBlockInserter();
-		expect( await getAllBlockInserterItemTitles() ).toHaveLength( 0 );
+		expect( await getAllBlockInserterItemTitles() ).toHaveLength( 1 );
 	} );
 } );


### PR DESCRIPTION
closes #19354 

Since the "column" block already has a "parent" property defined, we should just let it appear in the inserter if a sibling is selected, allowing you to insert another column to the columns block without using the "columns count" range.

Thoughts?