### PR TITLE
Block Editor: Add closing parenthesis on selector

### DIFF
--- a/packages/block-editor/src/components/editor-skeleton/index.js
+++ b/packages/block-editor/src/components/editor-skeleton/index.js
@@ -13,7 +13,7 @@ import { __ } from '@wordpress/i18n';
 function useHTMLClass( className ) {
 	useEffect( () => {
 		const element =
-			document && document.querySelector( `html:not(.${ className }` );
+			document && document.querySelector( `html:not(.${ className })` );
 		if ( ! element ) {
 			return;
 		}


### PR DESCRIPTION
Fixes #20504
Introduced in #20245 

This pull request seeks to resolve an error which occurs in Safari 12.x. The cause of the error is an invalid selector, as it omits the closing parenthesis of `:not()`.

**Testing Instructions:**

Repeat steps to reproduce from #20504, verifying no error occurs.