### PR TITLE
@wordpress/env: Adds a `wp-env wp` command

### DIFF
--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### New Feature
 
+-   You can now use `wp-env wp` as a convenient shortcut for running WP-CLI commands.
 -   URLs for ZIP files are now supported as core, plugin, and theme sources.
 -   The `.wp-env.json` coniguration file now accepts a `config` object for setting `wp-config.php` values.
 -   A `.wp-env.override.json` configuration file can now be used to override fields from `.wp-env.json`.

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -175,6 +175,33 @@ Positionals:
             [string] [choices: "all", "development", "tests"] [default: "tests"]
 ```
 
+### `wp-env run <container> [command..]`
+
+```sh
+wp-env run <container> [command..]
+
+Runs a shell command in one of the underlying Docker containers.
+
+Positionals:
+  container  The container to run the command on.            [string] [required]
+  command    The command to run.                           [array] [default: []]
+```
+
+### `wp-env wp [command..]`
+
+```sh
+wp-env wp [command..]
+
+Runs a WP-CLI command (https://wp-cli.org) against one of the environments.
+
+Positionals:
+  command  The command to run.                             [array] [default: []]
+
+Options:
+  --environment  Which environment to run the WP-CLI command against.
+             [string] [choices: "development", "tests"] [default: "development"]
+```
+
 ## .wp-env.json
 
 You can customize the WordPress installation, plugins and themes that the development environment will use by specifying a `.wp-env.json` file in the directory that you run `wp-env` from.

--- a/packages/env/lib/cli.js
+++ b/packages/env/lib/cli.js
@@ -111,7 +111,7 @@ module.exports = function cli() {
 	);
 	yargs.command(
 		'run <container> [command..]',
-		'Runs an arbitrary command in one of the underlying Docker containers.',
+		'Runs a shell command in one of the underlying Docker containers.',
 		( args ) => {
 			args.positional( 'container', {
 				type: 'string',
@@ -123,6 +123,24 @@ module.exports = function cli() {
 			} );
 		},
 		withSpinner( env.run )
+	);
+	yargs.command(
+		'wp [command..]',
+		'Runs a WP-CLI command (https://wp-cli.org) against one of the environments.',
+		( args ) => {
+			args.option( 'environment', {
+				type: 'string',
+				describe:
+					'Which environment to run the WP-CLI command against.',
+				choices: [ 'development', 'tests' ],
+				default: 'development',
+			} );
+			args.positional( 'command', {
+				type: 'string',
+				describe: 'The command to run.',
+			} );
+		},
+		withSpinner( env.wpCLI )
 	);
 
 	return yargs;

--- a/packages/env/lib/env.js
+++ b/packages/env/lib/env.js
@@ -203,18 +203,18 @@ module.exports = {
 	/**
 	 * Runs an arbitrary command on the given Docker container.
 	 *
-	 * @param {Object}  options
-	 * @param {Object}  options.container The Docker container to run the command on.
-	 * @param {Object}  options.command   The command to run.
-	 * @param {Object}  options.spinner   A CLI spinner which indicates progress.
-	 * @param {boolean} options.debug     True if debug mode is enabled.
+	 * @param {Object}   options
+	 * @param {string}   options.container The Docker container to run the command on.
+	 * @param {string[]} options.command   The command to run.
+	 * @param {Object}   options.spinner   A CLI spinner which indicates progress.
+	 * @param {boolean}  options.debug     True if debug mode is enabled.
 	 */
 	async run( { container, command, spinner, debug } ) {
 		const config = await initConfig( { spinner, debug } );
 
-		command = command.join( ' ' );
+		const commandDescription = command.join( ' ' );
 
-		spinner.text = `Running \`${ command }\` in '${ container }'.`;
+		spinner.text = `Running \`${ commandDescription }\` in '${ container }'.`;
 
 		const result = await dockerCompose.run( container, command, {
 			config: config.dockerComposeConfigPath,
@@ -235,7 +235,24 @@ module.exports = {
 			throw result.err;
 		}
 
-		spinner.text = `Ran \`${ command }\` in '${ container }'.`;
+		spinner.text = `Ran \`${ commandDescription }\` in '${ container }'.`;
+	},
+
+	/**
+	 * Runs an WP-CLI against the specified environment.
+	 *
+	 * @param {Object}   options
+	 * @param {string}   options.environment The environment to run against. Either 'development' or 'tests'.
+	 * @param {string[]} options.command     The command to run.
+	 * @param {Object}   options.spinner     A CLI spinner which indicates progress.
+	 * @param {boolean}  options.debug       True if debug mode is enabled.
+	 */
+	async wpCLI( { environment, command, ...options } ) {
+		await module.exports.run( {
+			container: environment === 'development' ? 'cli' : 'tests-cli',
+			command: [ 'wp', ...command ],
+			...options,
+		} );
 	},
 
 	ValidationError,


### PR DESCRIPTION
Adds a `wp-env wp` so that WP-CLI commands can easily be run against an underlying environment.

Props to @draganescu for the suggestion.

**Example usage:**

```
$ wp-env wp option get siteurl        
⠧ Running `wp option get siteurl` in 'cli'.

http://localhost:8888



✔ Ran `wp option get siteurl` in 'cli'. (in 2s 257ms)
```

**Issues:**

- `--option`s are parsed by `yargs` and therefore not passed to WP-CLI. For example, `wp-env wp option list --format=json` does not return its output in a JSON format.

  I'm not sure how to fix this. I had a look at setting [halt-at-not-option](https://github.com/yargs/yargs-parser#halt-at-non-option) using `yargs.parserConfiguration()` but seemingly that did nothing. Any ideas, @epiqueras?

- Because we use the spinner in `wp-env run` and therefore `wp-env wp`, we can't pipe output like you would expect to be able to do. For example, `wp-env wp option list --format=json > options.json` will result in `options.json` having syntax errors.

  I think we should not use the spinner in these two commands.