### PR TITLE
@wordpress/env: Fix accidental quotes in Site Title

### DIFF
--- a/packages/env/lib/env.js
+++ b/packages/env/lib/env.js
@@ -411,13 +411,17 @@ async function configureWordPress( environment, config ) {
 	// Install WordPress.
 	await dockerCompose.run(
 		environment === 'development' ? 'cli' : 'tests-cli',
-		`wp core install
-			--url=localhost:${ port }
-			--title='${ config.name }'
-			--admin_user=admin
-			--admin_password=password
-			--admin_email=wordpress@example.com
-			--skip-email`,
+		[
+			'wp',
+			'core',
+			'install',
+			`--url=localhost:${ port }`,
+			`--title=${ config.name }`,
+			'--admin_user=admin',
+			'--admin_password=password',
+			'--admin_email=wordpress@example.com',
+			'--skip-email',
+		],
 		options
 	);
 


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/pull/20002#discussion_r384544374.

Removes the `'`s from `wp core install` as these were being interpreted literally meaning that the Site Title would be set to `'gutenberg'` instead of `gutenberg`.

![](https://user-images.githubusercontent.com/1779930/75356432-f737b180-587d-11ea-8fbb-1a50d126ab42.png)

The fix still accounts for titles which contain spaces by passing an explicit array of arguments to `dockerCompose.run()`.