### PR TITLE
[RNMobile] Revert "enable FloatingToolbar for all blocks"

### DIFF
--- a/packages/block-editor/src/components/block-list/block.native.js
+++ b/packages/block-editor/src/components/block-list/block.native.js
@@ -189,6 +189,7 @@ class BlockListBlock extends Component {
 			title,
 			parentId,
 			isTouchable,
+			showFloatingToolbar,
 		} = this.props;
 
 		const accessibilityLabel = getAccessibleBlockLabel(
@@ -204,7 +205,7 @@ class BlockListBlock extends Component {
 				accessibilityRole={ 'button' }
 			>
 				<View accessibilityLabel={ accessibilityLabel }>
-					{ isSelected && (
+					{ showFloatingToolbar && (
 						<FloatingToolbar>
 							<Toolbar passedStyle={ styles.toolbar }>
 								<ToolbarButton
@@ -252,6 +253,7 @@ export default compose( [
 			__unstableGetBlockWithoutInnerBlocks,
 			getBlockHierarchyRootClientId,
 			getSelectedBlockClientId,
+			getBlock,
 			getBlockRootClientId,
 			getLowestCommonAncestorWithSelectedBlock,
 			getBlockParents,
@@ -273,6 +275,10 @@ export default compose( [
 		const parentId = parents[ 0 ] || '';
 
 		const rootBlockId = getBlockHierarchyRootClientId( clientId );
+		const rootBlock = getBlock( rootBlockId );
+		const hasRootInnerBlocks = rootBlock.innerBlocks.length !== 0;
+
+		const showFloatingToolbar = isSelected && hasRootInnerBlocks;
 
 		const selectedBlockClientId = getSelectedBlockClientId();
 
@@ -333,6 +339,7 @@ export default compose( [
 			isTouchable,
 			isDimmed,
 			isUnregisteredBlock,
+			showFloatingToolbar,
 		};
 	} ),
 	withDispatch( ( dispatch, ownProps, { select } ) => {


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
According to [this issue](https://github.com/wordpress-mobile/gutenberg-mobile/issues/1960) this PR reverts one of the changes made by [this PR](https://github.com/WordPress/gutenberg/pull/20064) and **block** showing `FloatingToolbar` for root list blocks which is not InnerBlock holder.

Please also refer to:
[Related gutenberg-mobile PR](https://github.com/wordpress-mobile/gutenberg-mobile/pull/1968)
[Related gutenberg-mobile issue](https://github.com/wordpress-mobile/gutenberg-mobile/issues/1960)

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

1. Start with below code in `initial-html`

<details>

```
/**
 * @format
 * @flow
 */

export default `
<!-- wp:group -->
<div class="wp-block-group"><div class="wp-block-group__inner-container"><!-- wp:heading -->
<h2>Group</h2>
<!-- /wp:heading -->

<!-- wp:image -->
<figure class="wp-block-image"><img alt=""/></figure>
<!-- /wp:image --></div></div>
<!-- /wp:group -->

<!-- wp:image -->
<figure class="wp-block-image"><img alt=""/></figure>
<!-- /wp:image -->

<!-- wp:image -->
<figure class="wp-block-image"><img alt=""/></figure>
<!-- /wp:image -->

<!-- wp:image -->
<figure class="wp-block-image"><img alt=""/></figure>
<!-- /wp:image -->

<!-- wp:image -->
<figure class="wp-block-image"><img alt=""/></figure>
<!-- /wp:image -->

<!-- wp:image -->
<figure class="wp-block-image"><img alt=""/></figure>
<!-- /wp:image -->

<!-- wp:image -->
<figure class="wp-block-image"><img alt=""/></figure>
<!-- /wp:image -->


`;
```

</details>

2. Change selection between blocks
3. Check if FloatingToolbar is not visible for root blocks


## Screenshots <!-- if applicable -->

**Before:**
<image src="https://user-images.githubusercontent.com/21242757/75540664-b924c400-5a1c-11ea-9c5e-57531884bae6.png" width="300" />

**After:**
<image src="https://user-images.githubusercontent.com/21242757/75540522-7c58cd00-5a1c-11ea-9ce6-f5c192bf707c.png" width="300"/>

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Fix which reverts unwanted changes

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
