### PR TITLE
[RNMobile] Fix BlockCaption padding visibility

### DIFF
--- a/packages/block-editor/src/components/block-caption/index.native.js
+++ b/packages/block-editor/src/components/block-caption/index.native.js
@@ -20,7 +20,7 @@ const BlockCaption = ( {
 	shouldDisplay,
 	text,
 } ) => (
-	<View style={ { flex: 1, padding: 12 } }>
+	<View style={ { flex: 1, padding: shouldDisplay ? 12 : 0 } }>
 		<Caption
 			accessibilityLabelCreator={ accessibilityLabelCreator }
 			accessible={ accessible }

--- a/packages/block-editor/src/components/block-caption/index.native.js
+++ b/packages/block-editor/src/components/block-caption/index.native.js
@@ -10,6 +10,11 @@ import { Caption, RichText } from '@wordpress/block-editor';
 import { compose } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
 
+/**
+ * Internal dependencies
+ */
+import styles from './styles.scss';
+
 const BlockCaption = ( {
 	accessible,
 	accessibilityLabelCreator,
@@ -20,7 +25,7 @@ const BlockCaption = ( {
 	shouldDisplay,
 	text,
 } ) => (
-	<View style={ { flex: 1, padding: shouldDisplay ? 12 : 0 } }>
+	<View style={ [ styles.container, shouldDisplay && styles.padding ] }>
 		<Caption
 			accessibilityLabelCreator={ accessibilityLabelCreator }
 			accessible={ accessible }

--- a/packages/block-editor/src/components/block-caption/styles.native.scss
+++ b/packages/block-editor/src/components/block-caption/styles.native.scss
@@ -1,0 +1,7 @@
+.container {
+	flex: 1;
+}
+
+.padding {
+	padding: $block-selected-to-content;
+}


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
According to [this issue](https://github.com/wordpress-mobile/gutenberg-mobile/issues/1919) this PR fixes extra spaces added below Image.

The issue is connected with the `BlockCaption`. See [this comment](https://github.com/wordpress-mobile/gutenberg-mobile/issues/1919#issuecomment-592535355) for more details and [this PR](https://github.com/WordPress/gutenberg/pull/19118/files) which bring this component.

I have noticed that it also affect `Gallery` and `Video` blocks because under the media it also uses `BlockCaption` component.

Please also refer to:
[Related gutenberg-mobile PR](https://github.com/wordpress-mobile/gutenberg-mobile/pull/1971)
[Related gutenberg-mobile issue](https://github.com/wordpress-mobile/gutenberg-mobile/issues/1919)

[comment with investigation](https://github.com/wordpress-mobile/gutenberg-mobile/issues/1919#issuecomment-592535355)
[PR on Caption refactor](https://github.com/WordPress/gutenberg/pull/19118)


Presented solution is the simplest one. However we might also consider the one I posted in the comment with investigation which is:

>move that padding value to styles and connect with $block-selected-to-content variable which ensure to always align the padding with rest of the content

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

1. Start with below code in `initial-html`

<details>

```
/**
 * @format
 * @flow
 */

export default `
<!-- wp:group -->
<div class="wp-block-group"><div class="wp-block-group__inner-container"><!-- wp:image {"id":1,"sizeSlug":"large"} -->
<figure class="wp-block-image size-large"><img src="https://cldup.com/cXyG__fTLN.jpg" alt="" class="wp-image-1"/></figure>
<!-- /wp:image -->

<!-- wp:media-text -->
<div class="wp-block-media-text is-stacked-on-mobile"><figure class="wp-block-media-text__media"></figure><div class="wp-block-media-text__content"><!-- wp:paragraph -->
<p></p>
<!-- /wp:paragraph --></div></div>
<!-- /wp:media-text -->

<!-- wp:group -->
<div class="wp-block-group"><div class="wp-block-group__inner-container"><!-- wp:image -->
<figure class="wp-block-image"><img alt=""/></figure>
<!-- /wp:image --></div></div>
<!-- /wp:group -->

<!-- wp:video {"id":2} -->
<figure class="wp-block-video"><video controls src="https://i.cloudup.com/YtZFJbuQCE.mov"></video></figure>
<!-- /wp:video -->

<!-- wp:gallery {"ids":[1,3]} -->
<figure class="wp-block-gallery columns-2 is-cropped"><ul class="blocks-gallery-grid"><li class="blocks-gallery-item"><figure><img src="https://cldup.com/cXyG__fTLN.jpg" data-id="1" class="wp-image-1"/></figure></li><li class="blocks-gallery-item"><figure><img src="https://cldup.com/cXyG__fTLN.jpg" data-id="3" class="wp-image-3"/></figure></li></ul></figure>
<!-- /wp:gallery --></div></div>
<!-- /wp:group -->


`;
```

</details>

2. Change selection between blocks
3. Observe that the extra space is not visible anymore under the mentioned blocks (it is easier to observe when the Goup block which holds the block is selected - then the children got the dashed border style)

To replicate the previous behaviour fix the padding value to 12 in `BlockCaption` component. Then after proceeding with above you will notice extra space below mentioned blocks.

## Screenshots <!-- if applicable -->

**Before:**
<image src="https://user-images.githubusercontent.com/21242757/75561593-90fe8a80-5a47-11ea-80a5-2cecfccf8f98.png" width="300" />


**After:**
<image src="https://user-images.githubusercontent.com/21242757/75561648-a83d7800-5a47-11ea-979d-51ab3b7ecb0c.png" width="300" />


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix: Remove extra padding below media in Video, Image and Gallery block.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
