### PR TITLE
Fix/18841 classic editor block fix inconsistent banner behavior

### DIFF
--- a/packages/block-library/src/classic/edit.js
+++ b/packages/block-library/src/classic/edit.js
@@ -55,9 +55,22 @@ export default class ClassicEdit extends Component {
 		const {
 			clientId,
 			attributes: { content },
+			isSelected,
+			setAttributes,
 		} = this.props;
 
 		const editor = window.tinymce.get( `editor-${ clientId }` );
+		if ( ! isSelected && editor && editor.getContent().length === 0 ) {
+			// Reset the content.
+			setAttributes( {
+				content: '',
+			} );
+			wp.oldEditor.remove( `editor-${ clientId }` );
+			return;
+		} else if ( ! editor ) {
+			this.initialize();
+			return;
+		}
 
 		if ( prevProps.attributes.content !== content ) {
 			editor.setContent( content || '' );

--- a/packages/block-library/src/classic/edit.js
+++ b/packages/block-library/src/classic/edit.js
@@ -201,7 +201,11 @@ export default class ClassicEdit extends Component {
 	}
 
 	render() {
-		const { clientId } = this.props;
+		const {
+			clientId,
+			attributes: { content },
+			isSelected,
+		} = this.props;
 
 		// Disable reasons:
 		//
@@ -219,7 +223,13 @@ export default class ClassicEdit extends Component {
 				onClick={ this.focus }
 				data-placeholder={ __( 'Classic' ) }
 				onKeyDown={ this.onToolbarKeyDown }
-			/>,
+			>
+				{ ! isSelected &&
+					! this.editor &&
+					content &&
+					content.length > 0 &&
+					' ' }
+			</div>,
 			<div
 				key="editor"
 				id={ `editor-${ clientId }` }

--- a/packages/block-library/src/classic/edit.js
+++ b/packages/block-library/src/classic/edit.js
@@ -60,6 +60,12 @@ export default class ClassicEdit extends Component {
 		} = this.props;
 
 		const editor = window.tinymce.get( `editor-${ clientId }` );
+
+		/**
+		 * Removes the `editor` if there's no content.
+		 * Doing so will make the <div key="toolbar"/> empty which will result
+		 * to showing the 'Classic' banner.
+		 */
 		if ( ! isSelected && editor && editor.getContent().length === 0 ) {
 			// Reset the content.
 			setAttributes( {
@@ -68,6 +74,7 @@ export default class ClassicEdit extends Component {
 			wp.oldEditor.remove( `editor-${ clientId }` );
 			return;
 		} else if ( ! editor ) {
+			// Reinitialize the `editor`.
 			this.initialize();
 			return;
 		}


### PR DESCRIPTION
Closes #18841

## Description
Show "Classic" banner in Classic Editor Block when the Classic Editor is empty and prevent it from showing on first page / editor load.

## Screenshots
![Kapture 2020-02-28 at 23 51 17](https://user-images.githubusercontent.com/5747475/75563801-e9ed1380-5a85-11ea-899f-759c839fbe5f.gif)

## Types of changes
Bug fix. In a high-level view, what the PR does is it removes the Classic editor if it's empty (this will result to showing the "Classic" banner) then re-instantiate the Classic editor when needed. This happens in `componentDidUpdate()`.

As for the block
```
{ ! isSelected &&
    ! this.editor &&
    content &&
    content.length > 0 &&
    ' ' }
```
this is to prevent the "Classic" banner from showing up on first page load.

## Checklist:
- [ X ] My code is tested.
- [ X ] My code follows the WordPress code style.