### PR TITLE
Media & Text Block: Fix frontend styles when "Crop image to fill" is selected

### DIFF
--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -161,7 +161,7 @@ class MediaTextEdit extends Component {
 		} = attributes;
 		return (
 			<MediaContainer
-				className="wp-block-media-text__media-container"
+				className="wp-block-media-text__media"
 				onSelectMedia={ this.onSelectMedia }
 				onWidthChange={ this.onWidthChange }
 				commitWidthChange={ this.commitWidthChange }

--- a/packages/block-library/src/media-text/editor.scss
+++ b/packages/block-library/src/media-text/editor.scss
@@ -59,18 +59,6 @@
 	max-width: unset;
 }
 
-figure.wp-block-media-text__media-container {
-	margin: 0;
-	height: 100%;
-	width: 100%;
-}
-
-.wp-block-media-text .wp-block-media-text__media-container img,
-.wp-block-media-text .wp-block-media-text__media-container video {
-	vertical-align: middle;
-	width: 100%;
-}
-
 .editor-media-container__resizer .components-resizable-box__handle {
 	display: none;
 }

--- a/packages/block-library/src/media-text/style.scss
+++ b/packages/block-library/src/media-text/style.scss
@@ -72,13 +72,13 @@
 	vertical-align: middle;
 }
 
-.wp-block-media-text.is-image-fill figure.wp-block-media-text__media-container {
+.wp-block-media-text.is-image-fill figure.wp-block-media-text__media {
 	height: 100%;
 	min-height: 250px;
 	background-size: cover;
 }
 
-.wp-block-media-text.is-image-fill figure.wp-block-media-text__media-container > img {
+.wp-block-media-text.is-image-fill figure.wp-block-media-text__media > img {
 	// The image is visually hidden but accessible to assistive technologies.
 	position: absolute;
 	width: 1px;


### PR DESCRIPTION
**Description**
#20439 introduced a bug that broke the "Crop image to fill entire column" styles on the front end. 

This PR reverts the names of those selectors for the front-end styles, while leaving the fixes for the editor styles in place. 