### PR TITLE
Snackbar: Replace incorrect 'label' attribute with 'aria-label'

### DIFF
--- a/packages/components/src/snackbar/index.js
+++ b/packages/components/src/snackbar/index.js
@@ -77,7 +77,7 @@ function Snackbar(
 			tabIndex="0"
 			role="button"
 			onKeyPress={ onRemove }
-			label={ __( 'Dismiss this notice' ) }
+			aria-label={ __( 'Dismiss this notice' ) }
 		>
 			<div className="components-snackbar__content">
 				{ children }

--- a/storybook/test/__snapshots__/index.js.snap
+++ b/storybook/test/__snapshots__/index.js.snap
@@ -7941,8 +7941,8 @@ exports[`Storyshots Components/SelectControl Default 1`] = `
 
 exports[`Storyshots Components/Snackbar Default 1`] = `
 <div
+  aria-label="Dismiss this notice"
   className="components-snackbar"
-  label="Dismiss this notice"
   onClick={[Function]}
   onKeyPress={[Function]}
   role="button"
@@ -7958,8 +7958,8 @@ exports[`Storyshots Components/Snackbar Default 1`] = `
 
 exports[`Storyshots Components/Snackbar With Actions 1`] = `
 <div
+  aria-label="Dismiss this notice"
   className="components-snackbar"
-  label="Dismiss this notice"
   onClick={[Function]}
   onKeyPress={[Function]}
   role="button"


### PR DESCRIPTION
## Description
`label` isn't valid on `div`, should have been `aria-label`.


## Types of changes
Bug fix