### PR TITLE
[ Latest Posts ] Fixes the read more link added by themes in Latest Posts

### DIFF
--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -33,11 +33,7 @@ function block_core_latest_posts_get_excerpt_length() {
  * @return string Returns the post content with latest posts added.
  */
 function render_block_core_latest_posts( $attributes ) {
-<<<<<<< HEAD
-	global $block_core_latest_posts_excerpt_length;
-=======
-	global $post;
->>>>>>> fixes the read more added by themes in latest posts block rendering
+	global $post, $block_core_latest_posts_excerpt_length;
 
 	$args = array(
 		'posts_per_page'   => $attributes['postsToShow'],

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -33,7 +33,11 @@ function block_core_latest_posts_get_excerpt_length() {
  * @return string Returns the post content with latest posts added.
  */
 function render_block_core_latest_posts( $attributes ) {
+<<<<<<< HEAD
 	global $block_core_latest_posts_excerpt_length;
+=======
+	global $post;
+>>>>>>> fixes the read more added by themes in latest posts block rendering
 
 	$args = array(
 		'posts_per_page'   => $attributes['postsToShow'],
@@ -55,6 +59,7 @@ function render_block_core_latest_posts( $attributes ) {
 	$list_items_markup = '';
 
 	foreach ( $recent_posts as $post ) {
+
 		$list_items_markup .= '<li>';
 
 		if ( $attributes['displayFeaturedImage'] && has_post_thumbnail( $post ) ) {
@@ -108,21 +113,9 @@ function render_block_core_latest_posts( $attributes ) {
 			$trimmed_excerpt = get_the_excerpt( $post );
 
 			$list_items_markup .= sprintf(
-				'<div class="wp-block-latest-posts__post-excerpt">%1$s',
+				'<div class="wp-block-latest-posts__post-excerpt">%1$s</div>',
 				$trimmed_excerpt
 			);
-
-			if ( strpos( $trimmed_excerpt, ' &hellip; ' ) !== false ) {
-				$list_items_markup .= sprintf(
-					'<a href="%1$s">%2$s</a></div>',
-					esc_url( get_permalink( $post ) ),
-					__( 'Read more' )
-				);
-			} else {
-				$list_items_markup .= sprintf(
-					'</div>'
-				);
-			}
 		}
 
 		if ( isset( $attributes['displayPostContent'] ) && $attributes['displayPostContent']


### PR DESCRIPTION
## Description
Closes #20511

## How has this been tested?
1. Use the twenty sixteen theme
2. Create a post
3. Add a Latest Posts block
4. Set up the block to show excerpts and make sure the excerpt length is set so that read more links show up
5. On the front end you should see the read more link added by the theme.


## Screenshots <!-- if applicable -->

<img width="1051" alt="Screenshot 2020-02-28 at 20 18 40" src="https://user-images.githubusercontent.com/107534/75574800-9b308100-5a67-11ea-9e23-0d509f114244.png">


## Types of changes
Non breaking changes in `LatestPosts` front end rendering.