### PR TITLE
Add storybook story for Notice component

### DIFF
--- a/packages/components/src/notice/stories/index.js
+++ b/packages/components/src/notice/stories/index.js
@@ -1,0 +1,71 @@
+/**
+ * External dependencies
+ */
+import { boolean, select, text } from '@storybook/addon-knobs';
+
+/**
+ * Internal dependencies
+ */
+import Notice from '../';
+
+export default {
+	title: 'Components/Notice',
+	component: Notice,
+};
+
+export const _default = () => {
+	const status = select(
+		'Status',
+		{
+			Warning: 'warning',
+			Success: 'success',
+			Error: 'error',
+			Info: 'info',
+		},
+		'info'
+	);
+	const isDismissible = boolean( 'Is Dismissible', true );
+
+	return (
+		<Notice status={ status } isDismissible={ isDismissible }>
+			<p>This is a notice.</p>
+		</Notice>
+	);
+};
+
+export const withCustomSpokenMessage = () => {
+	const status = select(
+		'Status',
+		{
+			Warning: 'warning',
+			Success: 'success',
+			Error: 'error',
+			Info: 'info',
+		},
+		'info'
+	);
+	const isDismissible = boolean( 'Is Dismissible', true );
+	const politeness = select(
+		'Politeness',
+		{
+			Assertive: 'assertive',
+			Polite: 'polite',
+		},
+		'assertive'
+	);
+	const spokenMessage = text(
+		'Spoken Message',
+		'This is a notice with a custom spoken message'
+	);
+
+	return (
+		<Notice
+			status={ status }
+			isDismissible={ isDismissible }
+			politeness={ politeness }
+			spokenMessage={ spokenMessage }
+		>
+			<p>This is a notice.</p>
+		</Notice>
+	);
+};


### PR DESCRIPTION
## Description
Adds a storybook story for the Notice component as part of #17973

## How has this been tested?
* run `npm run storybook:dev`
* See the new Notice story under components

## Screenshots
![Components___Notice_-_Default_⋅_Storybook](https://user-images.githubusercontent.com/6653970/75583603-f187ca80-5a3b-11ea-8433-de6e84b1b26c.png)

## Types of changes
New feature (non-breaking change which adds functionality)
