### PR TITLE
Add things required to load custom blocks to Site Editor page

### DIFF
--- a/lib/edit-site-page.php
+++ b/lib/edit-site-page.php
@@ -49,11 +49,20 @@ function gutenberg_edit_site_init( $hook ) {
 		$_wp_current_template_name,
 		$_wp_current_template_content,
 		$_wp_current_template_hierarchy,
-		$_wp_current_template_part_ids;
+		$_wp_current_template_part_ids,
+		$current_screen;
 
 	if ( ! gutenberg_is_edit_site_page( $hook ) ) {
 		return;
 	}
+
+	/**
+	 * Make the WP Screen object aware that this is a block editor page.
+	 * Since custom blocks check whether the screen is_block_editor,
+	 * this is required for custom blocks to be loaded.
+	 * See wp_enqueue_registered_block_scripts_and_styles in wp-includes/script-loader.php
+	 */
+	$current_screen->is_block_editor( true );
 
 	// Get editor settings.
 	$max_upload_size = wp_max_upload_size();
@@ -160,11 +169,31 @@ function gutenberg_edit_site_init( $hook ) {
 		)
 	);
 
-	// Preload server-registered block schemas.
 	wp_add_inline_script(
 		'wp-blocks',
-		'wp.blocks.unstable__bootstrapServerSideBlockDefinitions(' . wp_json_encode( get_block_editor_server_block_settings() ) . ');'
+		sprintf( 'wp.blocks.setCategories( %s );', wp_json_encode( get_block_categories( $post ) ) ),
+		'after'
 	);
+
+	/**
+	 * Scripts
+	 */
+	wp_enqueue_media();
+	wp_tinymce_inline_scripts();
+	wp_enqueue_editor();
+
+	/**
+	 * Fires after block assets have been enqueued for the editing interface.
+	 *
+	 * Call `add_action` on any hook before 'admin_enqueue_scripts'.
+	 *
+	 * In the function call you supply, simply use `wp_enqueue_script` and
+	 * `wp_enqueue_style` to add your functionality to the block editor.
+	 *
+	 * @since 5.0.0
+	 */
+
+	do_action( 'enqueue_block_editor_assets' );
 
 	wp_enqueue_script( 'wp-edit-site' );
 	wp_enqueue_script( 'wp-format-library' );

--- a/lib/edit-site-page.php
+++ b/lib/edit-site-page.php
@@ -171,6 +171,12 @@ function gutenberg_edit_site_init( $hook ) {
 
 	wp_add_inline_script(
 		'wp-blocks',
+		sprintf( 'wp.blocks.unstable__bootstrapServerSideBlockDefinitions( %s );', wp_json_encode( array_merge( get_block_categories( $post ), get_block_editor_server_block_settings() ) ) ),
+		'after'
+	);
+
+	wp_add_inline_script(
+		'wp-blocks',
 		sprintf( 'wp.blocks.setCategories( %s );', wp_json_encode( get_block_categories( $post ) ) ),
 		'after'
 	);

--- a/lib/edit-site-page.php
+++ b/lib/edit-site-page.php
@@ -171,7 +171,7 @@ function gutenberg_edit_site_init( $hook ) {
 
 	wp_add_inline_script(
 		'wp-blocks',
-		sprintf( 'wp.blocks.unstable__bootstrapServerSideBlockDefinitions( %s );', wp_json_encode( array_merge( get_block_categories( $post ), get_block_editor_server_block_settings() ) ) ),
+		sprintf( 'wp.blocks.unstable__bootstrapServerSideBlockDefinitions( %s );', wp_json_encode( get_block_editor_server_block_settings() ) ),
 		'after'
 	);
 

--- a/lib/edit-site-page.php
+++ b/lib/edit-site-page.php
@@ -176,13 +176,6 @@ function gutenberg_edit_site_init( $hook ) {
 	);
 
 	/**
-	 * Scripts
-	 */
-	wp_enqueue_media();
-	wp_tinymce_inline_scripts();
-	wp_enqueue_editor();
-
-	/**
 	 * Fires after block assets have been enqueued for the editing interface.
 	 *
 	 * Call `add_action` on any hook before 'admin_enqueue_scripts'.

--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -304,8 +304,9 @@ function gutenberg_strip_php_suffix( $template_file ) {
  * @return array Filtered editor settings.
  */
 function gutenberg_template_loader_filter_block_editor_settings( $settings ) {
-	global $_wp_current_template_id;
-	if ( ! post_type_exists( 'wp_template' ) || ! post_type_exists( 'wp_template_part' ) ) {
+	global $post, $_wp_current_template_id;
+
+	if ( ! $post || ! post_type_exists( 'wp_template' ) || ! post_type_exists( 'wp_template_part' ) ) {
 		return $settings;
 	}
 


### PR DESCRIPTION
## Description
I wanted to play with using custom blocks in the "Edit Site" mode. This PR makes custom blocks work there, though there is still some discrepancies with FullScreen mode, which WP core [assumes](https://github.com/WordPress/wordpress-develop/blob/master/src/wp-admin/admin-header.php#L196) is `on` if you're in Block Editor mode. I would imagine that the Site Editor mode will require some changes [there](https://github.com/WordPress/wordpress-develop/blob/master/src/wp-admin/admin-header.php#L196), because the [edit-post](https://github.com/WordPress/gutenberg/blob/a356318c7177deefc890fbdba47e069996433cb3/packages/edit-post/src/components/fullscreen-mode/index.js) package doesn't apply in Site Edit mode to remove the `is-fullscreen-mode` class from the  body.

## How has this been tested?
1. Install [Atomic Blocks](https://wordpress.org/plugins/atomic-blocks/) as a plugin.
2. Go to "Gutenberg" > "Edit Site".
3. Search for `atomic` and notice none of the blocks come up. 
4. Switch to this PR's branch, and those blocks should now appear. 

## Screenshots <!-- if applicable -->
<img width="1492" alt="Screen Shot 2020-02-28 at 6 36 23 PM" src="https://user-images.githubusercontent.com/7538525/75595188-556cbc00-5a59-11ea-922a-d2b233e162c9.png">


## Types of changes
Bug fix

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
