### PR TITLE
[ Latest Posts ] Testing larger margins

### DIFF
--- a/packages/block-library/src/latest-posts/style.scss
+++ b/packages/block-library/src/latest-posts/style.scss
@@ -20,7 +20,7 @@
 		padding: 0;
 
 		li {
-			margin: 0 16px 16px 0;
+			margin: 0 20px 20px 0;
 			width: 100%;
 		}
 	}
@@ -28,7 +28,7 @@
 	@include break-small {
 		@for $i from 2 through 6 {
 			&.columns-#{ $i } li {
-				width: calc((100% / #{ $i }) - 16px);
+				width: calc((100% / #{ $i }) - 20px);
 			}
 		}
 	}
@@ -62,4 +62,8 @@
 		margin-bottom: 1em;
 		text-align: center;
 	}
+}
+
+.edit-post-visual-editor .wp-block-latest-posts.is-grid li {
+	margin-bottom: 20px;
 }


### PR DESCRIPTION
## Description
Closes #19421

## How has this been tested?
Tested locally.

## Screenshots <!-- if applicable -->

## Types of changes
Modified the margin of posts in `LatesPosts` grid view to 20 px.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
