### PR TITLE
Block registration: Fix shared defaults between different blocks

### DIFF
--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -3,7 +3,15 @@
 /**
  * External dependencies
  */
-import { get, omit, pick, isFunction, isPlainObject, some } from 'lodash';
+import {
+	cloneDeep,
+	get,
+	isFunction,
+	isPlainObject,
+	omit,
+	pick,
+	some,
+} from 'lodash';
 
 /**
  * WordPress dependencies
@@ -154,7 +162,7 @@ export function unstable__bootstrapServerSideBlockDefinitions( definitions ) {
 export function registerBlockType( name, settings ) {
 	settings = {
 		name,
-		...DEFAULT_BLOCK_TYPE_SETTINGS,
+		...cloneDeep( DEFAULT_BLOCK_TYPE_SETTINGS ),
 		...get( serverSideBlockDefinitions, name ),
 		...settings,
 	};

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -3,15 +3,7 @@
 /**
  * External dependencies
  */
-import {
-	cloneDeep,
-	get,
-	isFunction,
-	isPlainObject,
-	omit,
-	pick,
-	some,
-} from 'lodash';
+import { get, isFunction, isPlainObject, omit, pick, some } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -121,18 +113,6 @@ import { DEPRECATED_ENTRY_KEYS } from './constants';
  *                                             then no preview is shown.
  */
 
-/**
- * Default values to assign for omitted optional block type settings.
- *
- * @type {Object}
- */
-export const DEFAULT_BLOCK_TYPE_SETTINGS = {
-	icon: blockDefault,
-	attributes: {},
-	keywords: [],
-	save: () => null,
-};
-
 export let serverSideBlockDefinitions = {};
 
 /**
@@ -162,7 +142,10 @@ export function unstable__bootstrapServerSideBlockDefinitions( definitions ) {
 export function registerBlockType( name, settings ) {
 	settings = {
 		name,
-		...cloneDeep( DEFAULT_BLOCK_TYPE_SETTINGS ),
+		icon: blockDefault,
+		attributes: {},
+		keywords: [],
+		save: () => null,
 		...get( serverSideBlockDefinitions, name ),
 		...settings,
 	};

--- a/packages/blocks/src/api/test/registration.js
+++ b/packages/blocks/src/api/test/registration.js
@@ -632,6 +632,31 @@ describe( 'blocks', () => {
 					);
 				} );
 			} );
+
+			it( 'should update block attributes separately for each block when they use a default set', () => {
+				addFilter(
+					'blocks.registerBlockType',
+					'core/blocks/shared-defaults',
+					( settings, name ) => {
+						if ( name === 'my-plugin/test-block-1' ) {
+							settings.attributes.newlyAddedAttribute = {
+								type: String,
+							};
+						}
+						return settings;
+					}
+				);
+				const block1 = registerBlockType(
+					'my-plugin/test-block-1',
+					defaultBlockSettings
+				);
+				const block2 = registerBlockType(
+					'my-plugin/test-block-2',
+					defaultBlockSettings
+				);
+				// Only attributes of block1 are supposed to be edited by the filter thus it must differ from block2.
+				expect( block1.attributes ).not.toEqual( block2.attributes );
+			} );
 		} );
 	} );
 

--- a/packages/blocks/src/api/test/registration.js
+++ b/packages/blocks/src/api/test/registration.js
@@ -35,7 +35,6 @@ import {
 	isReusableBlock,
 	serverSideBlockDefinitions,
 	unstable__bootstrapServerSideBlockDefinitions, // eslint-disable-line camelcase
-	DEFAULT_BLOCK_TYPE_SETTINGS,
 } from '../registration';
 import { DEPRECATED_ENTRY_KEYS } from '../constants';
 
@@ -588,7 +587,10 @@ describe( 'blocks', () => {
 								...omit(
 									{
 										name,
-										...DEFAULT_BLOCK_TYPE_SETTINGS,
+										icon: blockIcon,
+										attributes: {},
+										keywords: [],
+										save: () => null,
 										...get(
 											serverSideBlockDefinitions,
 											name


### PR DESCRIPTION
## Description

I've added a failing test for the issue described. The severity of this bug shows as it also breaks 4 other unrelated tests, despite the filter being auto-removed and limited to a specific block. 

I have addressed it by calling `cloneDeep` on the object `DEFAULT_BLOCK_TYPE_SETTINGS` before it is applied as a default in `registerBlockType`. 

Tests are all green now, including the new one testing mutations of default attributes.

Fixes #20524

## How has this been tested?
- added a new unit test `npm run test-unit -- packages/blocks/src/api/test/registration.js`

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
