### PR TITLE
Focus preview button after opening preview.

### DIFF
--- a/packages/e2e-tests/specs/editor/various/preview.test.js
+++ b/packages/e2e-tests/specs/editor/various/preview.test.js
@@ -40,6 +40,21 @@ async function openPreviewPage( editorPage ) {
 }
 
 /**
+ * Given the Page instance for the editor, opens preview drodpdown, and
+ * awaits the presence of the external preview selector.
+ *
+ * @param {Page} editorPage current editor page.
+ *
+ * @return {Promise} Promise resolving once selector is visible on page.
+ */
+async function waitForPreviewDropdownOpen( editorPage ) {
+	await editorPage.click( '.editor-post-preview__button-toggle' );
+	return editorPage.waitForSelector(
+		'.editor-post-preview__button-external'
+	);
+}
+
+/**
  * Given a Puppeteer Page instance for a preview window, clicks Preview, and
  * awaits the window navigation.
  *
@@ -48,8 +63,6 @@ async function openPreviewPage( editorPage ) {
  * @return {Promise} Promise resolving once navigation completes.
  */
 async function waitForPreviewNavigation( previewPage ) {
-	await page.click( '.editor-post-preview__button-toggle' );
-	await page.waitForSelector( '.editor-post-preview__button-external' );
 	await page.click( '.editor-post-preview__button-external' );
 	return previewPage.waitForNavigation();
 }
@@ -134,6 +147,7 @@ describe( 'Preview', () => {
 		// Return to editor to change title.
 		await editorPage.bringToFront();
 		await editorPage.type( '.editor-post-title__input', '!' );
+		await waitForPreviewDropdownOpen( editorPage );
 		await waitForPreviewNavigation( previewPage );
 
 		// Title in preview should match updated input.
@@ -146,7 +160,6 @@ describe( 'Preview', () => {
 		// Pressing preview without changes should bring same preview window to
 		// front and reload, but should not show interstitial.
 		await editorPage.bringToFront();
-		await editorPage.click( '.editor-post-preview__button-toggle' );
 		await waitForPreviewNavigation( previewPage );
 		previewTitle = await previewPage.$eval(
 			'.entry-title',
@@ -161,6 +174,7 @@ describe( 'Preview', () => {
 		// Return to editor to change title.
 		await editorPage.bringToFront();
 		await editorPage.type( '.editor-post-title__input', ' And more.' );
+		await waitForPreviewDropdownOpen( editorPage );
 		await waitForPreviewNavigation( previewPage );
 
 		// Title in preview should match updated input.
@@ -182,7 +196,6 @@ describe( 'Preview', () => {
 		//
 		// See: https://github.com/WordPress/gutenberg/issues/7561
 		await editorPage.bringToFront();
-		await editorPage.click( '.editor-post-preview__button-toggle' );
 		await waitForPreviewNavigation( previewPage );
 
 		// Title in preview should match updated input.
@@ -226,6 +239,7 @@ describe( 'Preview', () => {
 		// Save draft and open the preview page right after.
 		await editorPage.waitForSelector( '.editor-post-save-draft' );
 		await saveDraft();
+		await waitForPreviewDropdownOpen( editorPage );
 		await waitForPreviewNavigation( previewPage );
 
 		// Title in preview should match updated input.
@@ -290,6 +304,7 @@ describe( 'Preview with Custom Fields enabled', () => {
 		await editorPage.keyboard.type( '2' );
 
 		// Open the preview page.
+		await waitForPreviewDropdownOpen( editorPage );
 		await waitForPreviewNavigation( previewPage );
 
 		// Title in preview should match input.

--- a/packages/e2e-tests/specs/editor/various/preview.test.js
+++ b/packages/e2e-tests/specs/editor/various/preview.test.js
@@ -48,6 +48,8 @@ async function openPreviewPage( editorPage ) {
  * @return {Promise} Promise resolving once navigation completes.
  */
 async function waitForPreviewNavigation( previewPage ) {
+	await page.click( '.editor-post-preview__button-toggle' );
+	await page.waitForSelector( '.editor-post-preview__button-external' );
 	await page.click( '.editor-post-preview__button-external' );
 	return previewPage.waitForNavigation();
 }
@@ -144,6 +146,7 @@ describe( 'Preview', () => {
 		// Pressing preview without changes should bring same preview window to
 		// front and reload, but should not show interstitial.
 		await editorPage.bringToFront();
+		await editorPage.click( '.editor-post-preview__button-toggle' );
 		await waitForPreviewNavigation( previewPage );
 		previewTitle = await previewPage.$eval(
 			'.entry-title',
@@ -179,6 +182,7 @@ describe( 'Preview', () => {
 		//
 		// See: https://github.com/WordPress/gutenberg/issues/7561
 		await editorPage.bringToFront();
+		await editorPage.click( '.editor-post-preview__button-toggle' );
 		await waitForPreviewNavigation( previewPage );
 
 		// Title in preview should match updated input.

--- a/packages/editor/src/components/post-preview-button/index.js
+++ b/packages/editor/src/components/post-preview-button/index.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { Component, renderToString } from '@wordpress/element';
+import { Component, createRef, renderToString } from '@wordpress/element';
 import { Button, Path, SVG } from '@wordpress/components';
 import { __, _x } from '@wordpress/i18n';
 import { withSelect, withDispatch } from '@wordpress/data';
@@ -104,12 +104,13 @@ export class PostPreviewButton extends Component {
 	constructor() {
 		super( ...arguments );
 
+		this.buttonRef = createRef();
+
 		this.openPreviewWindow = this.openPreviewWindow.bind( this );
 	}
 
 	componentDidUpdate( prevProps ) {
 		const { previewLink } = this.props;
-
 		// This relies on the window being responsible to unset itself when
 		// navigation occurs or a new preview window is opened, to avoid
 		// unintentional forceful redirects.
@@ -129,6 +130,7 @@ export class PostPreviewButton extends Component {
 
 		if ( previewWindow && ! previewWindow.closed ) {
 			previewWindow.location = url;
+			this.buttonRef.current.focus();
 		}
 	}
 
@@ -198,6 +200,7 @@ export class PostPreviewButton extends Component {
 				target={ this.getWindowTarget() }
 				disabled={ ! isSaveable }
 				onClick={ this.openPreviewWindow }
+				ref={ this.buttonRef }
 			>
 				{ this.props.textContent
 					? this.props.textContent

--- a/packages/editor/src/components/post-preview-button/index.js
+++ b/packages/editor/src/components/post-preview-button/index.js
@@ -130,7 +130,9 @@ export class PostPreviewButton extends Component {
 
 		if ( previewWindow && ! previewWindow.closed ) {
 			previewWindow.location = url;
-			this.buttonRef.current.focus();
+			if ( this.buttonRef.current ) {
+				this.buttonRef.current.focus();
+			}
 		}
 	}
 


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

Fixes #20404 .

When opening preview externally and returning to the editor tab, the dropdown loses focus, so it doesn't close when clicked outside. This change sets focus back on the preview button after opening the external preview.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Tested in browser; ran unit tests and updated selectors for e2e tests. 

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
