### PR TITLE
Revert/top toolbar tab order

### DIFF
--- a/packages/e2e-tests/specs/editor/various/a11y.test.js
+++ b/packages/e2e-tests/specs/editor/various/a11y.test.js
@@ -23,7 +23,7 @@ describe( 'a11y', () => {
 			':focus',
 			( focusedElement ) => {
 				return focusedElement.classList.contains(
-					'editor-post-publish-button__button'
+					'block-editor-inserter__toggle'
 				);
 			}
 		);

--- a/packages/edit-post/src/components/header/index.js
+++ b/packages/edit-post/src/components/header/index.js
@@ -58,6 +58,10 @@ function Header() {
 
 	return (
 		<div className="edit-post-header">
+			<div className="edit-post-header__toolbar">
+				<FullscreenModeClose />
+				<HeaderToolbar />
+			</div>
 			<div className="edit-post-header__settings">
 				{ ! isPublishSidebarOpened && (
 					// This button isn't completely hidden by the publish sidebar.
@@ -92,10 +96,6 @@ function Header() {
 				/>
 				<PinnedPlugins.Slot />
 				<MoreMenu />
-			</div>
-			<div className="edit-post-header__toolbar">
-				<FullscreenModeClose />
-				<HeaderToolbar />
 			</div>
 		</div>
 	);

--- a/packages/edit-post/src/components/header/style.scss
+++ b/packages/edit-post/src/components/header/style.scss
@@ -3,7 +3,6 @@
 	background: $white;
 	display: flex;
 	flex-wrap: wrap;
-	flex-direction: row-reverse;
 	justify-content: space-between;
 	align-items: center;
 	// The header should never be wider than the viewport, or buttons might be hidden. Especially relevant at high zoom levels. Related to https://core.trac.wordpress.org/ticket/47603#ticket.


### PR DESCRIPTION
## Description

Reverts #19623, so horizontal reading order matches DOM order.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
