### PR TITLE
Block: consistent focus behaviour on mount

### DIFF
--- a/packages/block-editor/src/components/block-list/block-wrapper.js
+++ b/packages/block-editor/src/components/block-list/block-wrapper.js
@@ -131,7 +131,7 @@ const BlockComponent = forwardRef(
 
 		useEffect( () => {
 			if ( ! isMultiSelecting && ! isNavigationMode && isSelected ) {
-				focusTabbable( ! isMounting.current );
+				focusTabbable( true );
 			}
 
 			isMounting.current = false;

--- a/packages/block-editor/src/components/block-list/block-wrapper.js
+++ b/packages/block-editor/src/components/block-list/block-wrapper.js
@@ -94,10 +94,8 @@ const BlockComponent = forwardRef(
 
 		/**
 		 * When a block becomes selected, transition focus to an inner tabbable.
-		 *
-		 * @param {boolean} ignoreInnerBlocks Should not focus inner blocks.
 		 */
-		const focusTabbable = ( ignoreInnerBlocks ) => {
+		const focusTabbable = () => {
 			// Focus is captured by the wrapper node, so while focus transition
 			// should only consider tabbables within editable display, since it
 			// may be the wrapper itself or a side control which triggered the
@@ -111,10 +109,8 @@ const BlockComponent = forwardRef(
 				.find( wrapper.current )
 				.filter( isTextField )
 				// Exclude inner blocks
-				.filter(
-					( node ) =>
-						! ignoreInnerBlocks ||
-						isInsideRootBlock( wrapper.current, node )
+				.filter( ( node ) =>
+					isInsideRootBlock( wrapper.current, node )
 				);
 
 			// If reversed (e.g. merge via backspace), use the last in the set of
@@ -126,15 +122,10 @@ const BlockComponent = forwardRef(
 			placeCaretAtHorizontalEdge( target, isReverse );
 		};
 
-		// Focus the selected block's wrapper or inner input on mount and update
-		const isMounting = useRef( true );
-
 		useEffect( () => {
 			if ( ! isMultiSelecting && ! isNavigationMode && isSelected ) {
-				focusTabbable( true );
+				focusTabbable();
 			}
-
-			isMounting.current = false;
 		}, [ isSelected, isMultiSelecting, isNavigationMode ] );
 
 		// Block Reordering animation


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
