### PR TITLE
Try: G2 polish

### DIFF
--- a/packages/block-editor/src/components/alignment-toolbar/index.js
+++ b/packages/block-editor/src/components/alignment-toolbar/index.js
@@ -28,6 +28,10 @@ const DEFAULT_ALIGNMENT_CONTROLS = [
 	},
 ];
 
+const POPOVER_PROPS = {
+	position: 'bottom right',
+};
+
 export function AlignmentToolbar( props ) {
 	const {
 		value,
@@ -45,11 +49,6 @@ export function AlignmentToolbar( props ) {
 		alignmentControls,
 		( control ) => control.align === value
 	);
-
-	const POPOVER_PROPS = {
-		position: 'bottom right',
-		noArrow: true,
-	};
 
 	return (
 		<Toolbar

--- a/packages/block-editor/src/components/alignment-toolbar/index.js
+++ b/packages/block-editor/src/components/alignment-toolbar/index.js
@@ -46,11 +46,17 @@ export function AlignmentToolbar( props ) {
 		( control ) => control.align === value
 	);
 
+	const POPOVER_PROPS = {
+		position: 'bottom right',
+		noArrow: true,
+	};
+
 	return (
 		<Toolbar
 			isCollapsed={ isCollapsed }
 			icon={ activeAlignment ? activeAlignment.icon : 'editor-alignleft' }
 			label={ label }
+			popoverProps={ POPOVER_PROPS }
 			controls={ alignmentControls.map( ( control ) => {
 				const { align } = control;
 				const isActive = value === align;

--- a/packages/block-editor/src/components/alignment-toolbar/test/__snapshots__/index.js.snap
+++ b/packages/block-editor/src/components/alignment-toolbar/test/__snapshots__/index.js.snap
@@ -48,6 +48,11 @@ exports[`AlignmentToolbar should allow custom alignment controls to be specified
   }
   isCollapsed={true}
   label="Change text alignment"
+  popoverProps={
+    Object {
+      "position": "bottom right",
+    }
+  }
 />
 `;
 
@@ -114,5 +119,10 @@ exports[`AlignmentToolbar should match snapshot 1`] = `
   }
   isCollapsed={true}
   label="Change text alignment"
+  popoverProps={
+    Object {
+      "position": "bottom right",
+    }
+  }
 />
 `;

--- a/packages/block-editor/src/components/block-switcher/style.scss
+++ b/packages/block-editor/src/components/block-switcher/style.scss
@@ -17,12 +17,6 @@
 		border-width: 4px;
 		border-right-color: currentColor;
 		border-bottom-color: currentColor;
-		transition: border 0.2s cubic-bezier(0.25, 0.1, 0.25, 1);
-	}
-
-	// Grow the indicator a little bit on hover.
-	&:hover::after {
-		border-width: 5px;
 	}
 }
 

--- a/packages/block-editor/src/components/rich-text/format-toolbar/index.js
+++ b/packages/block-editor/src/components/rich-text/format-toolbar/index.js
@@ -12,7 +12,7 @@ import { __ } from '@wordpress/i18n';
 import { Toolbar, Slot, DropdownMenu } from '@wordpress/components';
 
 const POPOVER_PROPS = {
-	position: 'bottom left',
+	position: 'bottom right',
 };
 
 const FormatToolbar = () => {

--- a/packages/components/src/notice/style.scss
+++ b/packages/components/src/notice/style.scss
@@ -37,7 +37,7 @@
 .components-notice__action.components-button {
 	&,
 	&.is-link {
-		margin-left: 4px;
+		margin-left: $grid-unit-15;
 	}
 	&.is-secondary {
 		vertical-align: initial;
@@ -72,12 +72,19 @@
 	.components-notice__content {
 		margin-top: $grid-unit-15;
 		margin-bottom: $grid-unit-15;
-		line-height: 1.6;
+		line-height: 2;
 	}
 
-	// Reduce margins on inline buttons so that they don't add too much extra line-height.
 	.components-notice__action.components-button {
-		margin-top: -2px;
-		margin-bottom: -2px;
+		display: block;
+		margin-left: 0;
+		margin-top: $grid-unit-10;
+
+		// Beyond mobile, align the action button on the right to use the space, and reduce margins so they don't add too much extra line-height.
+		@include break-medium() {
+			float: right;
+			margin-top: -$grid-unit-05;
+			margin-bottom: -$grid-unit-05;
+		}
 	}
 }

--- a/packages/components/src/placeholder/index.js
+++ b/packages/components/src/placeholder/index.js
@@ -5,18 +5,12 @@ import classnames from 'classnames';
 import useResizeAware from 'react-resize-aware';
 
 /**
- * Internal dependencies
- */
-import Icon from '../icon';
-
-/**
  * Renders a placeholder. Normally used by blocks to render their empty state.
  *
  * @param  {Object} props The component props.
  * @return {Object}       The rendered placeholder.
  */
 function Placeholder( {
-	icon,
 	children,
 	label,
 	instructions,
@@ -56,10 +50,7 @@ function Placeholder( {
 					{ preview }
 				</div>
 			) }
-			<div className="components-placeholder__label">
-				<Icon icon={ icon } />
-				{ label }
-			</div>
+			<div className="components-placeholder__label">{ label }</div>
 			{ !! instructions && (
 				<div className="components-placeholder__instructions">
 					{ instructions }

--- a/packages/components/src/placeholder/index.js
+++ b/packages/components/src/placeholder/index.js
@@ -5,12 +5,18 @@ import classnames from 'classnames';
 import useResizeAware from 'react-resize-aware';
 
 /**
+ * Internal dependencies
+ */
+import Icon from '../icon';
+
+/**
  * Renders a placeholder. Normally used by blocks to render their empty state.
  *
  * @param  {Object} props The component props.
  * @return {Object}       The rendered placeholder.
  */
 function Placeholder( {
+	icon,
 	children,
 	label,
 	instructions,
@@ -50,7 +56,10 @@ function Placeholder( {
 					{ preview }
 				</div>
 			) }
-			<div className="components-placeholder__label">{ label }</div>
+			<div className="components-placeholder__label">
+				<Icon icon={ icon } />
+				{ label }
+			</div>
 			{ !! instructions && (
 				<div className="components-placeholder__instructions">
 					{ instructions }

--- a/packages/components/src/placeholder/style.scss
+++ b/packages/components/src/placeholder/style.scss
@@ -41,14 +41,7 @@
 .components-placeholder__label {
 	display: flex;
 	font-weight: 600;
-	margin-bottom: 1.5em;
-
-	> svg,
-	.dashicon,
-	.block-editor-block-icon {
-		fill: currentColor;
-		margin-right: 1ch;
-	}
+	margin-bottom: $grid-unit-20;
 }
 
 .components-placeholder__fieldset,
@@ -115,6 +108,14 @@
 // Element queries to show different layouts at various sizes.
 .components-placeholder {
 
+	// Medium and large sizes.
+	&.is-large {
+		.components-placeholder__label {
+			font-size: 18pt;
+			font-weight: normal;
+		}
+	}
+
 	// Medium and small sizes.
 	&.is-medium,
 	&.is-small {
@@ -134,10 +135,6 @@
 
 	// Small sizes.
 	&.is-small {
-		.block-editor-block-icon {
-			display: none;
-		}
-
 		.components-button {
 			padding: 0 $grid-unit-10 2px;
 		}

--- a/packages/components/src/placeholder/style.scss
+++ b/packages/components/src/placeholder/style.scss
@@ -42,6 +42,14 @@
 	display: flex;
 	font-weight: 600;
 	margin-bottom: $grid-unit-20;
+	align-items: center;
+
+	> svg,
+	.dashicon,
+	.block-editor-block-icon {
+		fill: currentColor;
+		margin-right: 1ch;
+	}
 }
 
 .components-placeholder__fieldset,

--- a/packages/editor/src/components/editor-notices/style.scss
+++ b/packages/editor/src/components/editor-notices/style.scss
@@ -1,13 +1,9 @@
 // Dismissible notices.
 .components-editor-notices__dismissible {
 	position: sticky;
-	top: $header-height;
+	top: 0;
 	right: 0;
 	color: $dark-gray-900;
-
-	@include break-small {
-		top: 0;
-	}
 }
 
 // Non-dismissible notices.
@@ -24,15 +20,15 @@
 	.components-notice {
 		box-sizing: border-box;
 		margin: 0;
-		border-bottom: 1px solid rgba(0, 0, 0, 0.2);
-		padding: 6px 12px;
+		border-bottom: $border-width solid rgba(0, 0, 0, 0.2);
+		padding: 0 $grid-unit-15;
 
 		// Min-height matches the height of a single-line notice with an action button.
-		min-height: $header-height + $grid-unit-05;
+		min-height: $header-height;
 
 		// Margins ensure that the dismiss button aligns to the center of the first line of text.
 		.components-notice__dismiss {
-			margin: 6px -5px 6px 5px;
+			margin-top: $grid-unit-15;
 		}
 	}
 }

--- a/packages/editor/src/components/post-publish-button/index.js
+++ b/packages/editor/src/components/post-publish-button/index.js
@@ -163,7 +163,7 @@ export class PostPublishButton extends Component {
 
 		const toggleChildren = isBeingScheduled
 			? __( 'Schedule…' )
-			: __( 'Publish…' );
+			: __( 'Publish' );
 		const buttonChildren = (
 			<PublishButtonLabel
 				forceIsSaving={ forceIsSaving }

--- a/packages/editor/src/components/post-publish-button/label.js
+++ b/packages/editor/src/components/post-publish-button/label.js
@@ -37,7 +37,7 @@ export function PublishButtonLabel( {
 		return hasNonPostEntityChanges ? __( 'Schedule…' ) : __( 'Schedule' );
 	}
 
-	return hasNonPostEntityChanges ? __( 'Publish…' ) : __( 'Publish' );
+	return hasNonPostEntityChanges ? __( 'Publish' ) : __( 'Publish' );
 }
 
 export default compose( [

--- a/packages/editor/src/components/post-publish-button/label.js
+++ b/packages/editor/src/components/post-publish-button/label.js
@@ -37,7 +37,7 @@ export function PublishButtonLabel( {
 		return hasNonPostEntityChanges ? __( 'Schedule…' ) : __( 'Schedule' );
 	}
 
-	return hasNonPostEntityChanges ? __( 'Publish' ) : __( 'Publish' );
+	return __( 'Publish' );
 }
 
 export default compose( [


### PR DESCRIPTION
This PR checks a couple of the boxes on the list in #20575, these:

- The direction that block toolbar menu items open in, seems arbitrary.
- Renaming the "Publish..." button to just "Publish", as the ellipsis does not add value.

Partially this one:

- Placeholders: consider simplifying further by merging the title with the description and removing the icon. This will scale better to very tiny states, necessary for patterns.

- Notices behave inconsistently towards the mobile breakpoint.

I also explored this one:

- Explore a directional "appear" animation to the block toolbar.

... but it did not feel right. It can potentially still work, but it's something to revisit. 
