### PR TITLE
Buttons: Align appender vertically

### DIFF
--- a/packages/block-library/src/buttons/editor.scss
+++ b/packages/block-library/src/buttons/editor.scss
@@ -19,6 +19,7 @@
 	.block-list-appender {
 		display: inline-block;
 		margin: 0;
+		vertical-align: middle;
 	}
 
 	.block-editor-block-list__layout > div:last-child {


### PR DESCRIPTION
## Description
This adds a vertical alignment style to the appender inside the Buttons block to make them align nicer with Button blocks.

Fix #20513 

## How has this been tested?
Manual testing with Twenty Twenty (bigger buttons than appender):

<img width="654" alt="Screenshot 2020-03-02 at 14 50 08" src="https://user-images.githubusercontent.com/156676/75682328-889b8f00-5c95-11ea-9b5e-2cedc6544102.png">

Maywood (smaller buttons than appender): 

<img width="557" alt="Screenshot 2020-03-02 at 14 44 30" src="https://user-images.githubusercontent.com/156676/75682383-a23cd680-5c95-11ea-98dd-1f4605a61f8d.png">

Both seem to be aligned as expected.

A bit of an edge case is when buttons are in a narrow container and have to wrap. Tested here: 

<img width="493" alt="Screenshot 2020-03-02 at 14 50 43" src="https://user-images.githubusercontent.com/156676/75682521-d6b09280-5c95-11ea-88f9-a4f6fbf36169.png">

The gap between lines of buttons seems too big to me but that's definitely a separate issue. I wanted to test this case to check the appender still aligns well and that seems to be the case.

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
