### PR TITLE
Lighter block DOM: Group

### DIFF
--- a/packages/block-library/src/group/edit.js
+++ b/packages/block-library/src/group/edit.js
@@ -3,7 +3,11 @@
  */
 import { withSelect } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
-import { InnerBlocks, __experimentalUseColors } from '@wordpress/block-editor';
+import {
+	InnerBlocks,
+	__experimentalUseColors,
+	__experimentalBlock as Block,
+} from '@wordpress/block-editor';
 import { useRef } from '@wordpress/element';
 
 function GroupEdit( { hasInnerBlocks, className } ) {
@@ -28,7 +32,7 @@ function GroupEdit( { hasInnerBlocks, className } ) {
 			{ InspectorControlsColorPanel }
 			<BackgroundColor>
 				<TextColor>
-					<div className={ className } ref={ ref }>
+					<Block.div className={ className } ref={ ref }>
 						<div className="wp-block-group__inner-container">
 							<InnerBlocks
 								renderAppender={
@@ -37,7 +41,7 @@ function GroupEdit( { hasInnerBlocks, className } ) {
 								}
 							/>
 						</div>
-					</div>
+					</Block.div>
 				</TextColor>
 			</BackgroundColor>
 		</>

--- a/packages/block-library/src/group/index.js
+++ b/packages/block-library/src/group/index.js
@@ -87,6 +87,7 @@ export const settings = {
 		align: [ 'wide', 'full' ],
 		anchor: true,
 		html: false,
+		lightBlockWrapper: true,
 	},
 	transforms: {
 		from: [


### PR DESCRIPTION
## Description

Makes the group block a light block.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
