### PR TITLE
Fix Core Columns butting up against viewport on smaller screens

### DIFF
--- a/packages/block-library/src/columns/editor.scss
+++ b/packages/block-library/src/columns/editor.scss
@@ -175,3 +175,16 @@ div.block-core-columns.is-vertically-aligned-bottom {
 		padding-right: $block-container-side-padding;
 	}
 }
+
+// Stop Columns butting up against edge of viewport on smaller viewports. Remove
+// on larger viewports where width handles this. Specificity overide required to
+// overide generic `.entry-content *` rule
+.wp-block-columns > .block-editor-inner-blocks > .block-editor-block-list__layout {
+	padding-left: $block-padding;
+	padding-right: $block-padding;
+
+	@include break-small() {
+		padding-left: 0;
+		padding-right: 0;
+	}
+}

--- a/packages/block-library/src/columns/style.scss
+++ b/packages/block-library/src/columns/style.scss
@@ -14,6 +14,21 @@
 	}
 }
 
+// Stop Columns butting up against edge of viewport on smaller viewports. Remove
+// on larger viewports where width handles this. Specificity overide required to
+// overide generic `.entry-content *` rule
+.wp-block-columns {
+	&.wp-block-columns:not(.has-background) {
+		padding-left: $block-padding;
+		padding-right: $block-padding;
+
+		@include break-xlarge() {
+			padding-left: 0;
+			padding-right: 0;
+		}
+	}
+}
+
 .wp-block-column {
 	flex-grow: 1;
 


### PR DESCRIPTION
![Screen Shot 2020-03-02 at 15 44 15](https://user-images.githubusercontent.com/444434/75691939-b2a47f80-5c9c-11ea-97e5-8078e9e87dde.png)


On smaller screens, the Core Columns block butts up against the edges of the viewport (unless it has a background set) on both Editor and Frontend.

This PR aims to fix this by introducing left/right spacing around the Block on smaller viewports. This has to be handled differently between Editor and Frontend/Theme due to the way background padding is applied.

See [screenshots below](#screenshots).

My feeling is that without this fix Core Columns looks broken on Themes that don't have specific CSS to add space on left/right. I feel that Core should try to avoid things looking "broken" by default.

I would, however, welcome some guidance and direction from those more experienced with the wider Themes ecosystem.

Also relates to https://github.com/Automattic/wp-calypso/issues/39804.


## How has this been tested?

### Environment
This has been tested using the Gutenberg Starter Theme because it enqueues no Theme specific styles so we see the raw Block styles.

Note that on Twenty Twenty this fix is not needed because the `block-editor-block-list__layout` rules add space on left/right by default. However this is not the case for some Themes.



### Instructions

Switch to "Code View" and paste in the following test Block definitions:

```
<!-- wp:columns {"align":"wide"} -->
<div class="wp-block-columns alignwide"><!-- wp:column -->
<div class="wp-block-column"><!-- wp:paragraph -->
<p><strong>Align Wide<br></strong><em>Smoked salmon topped with crème fraîche, dill and capers<br></em>$15.00</p>
<!-- /wp:paragraph --></div>
<!-- /wp:column -->

<!-- wp:column -->
<div class="wp-block-column"><!-- wp:paragraph -->
<p><strong>Pork Rillettes<br></strong><em>With quick pickle of dried apricots and pistachio crumble<br></em>$14.00</p>
<!-- /wp:paragraph --></div>
<!-- /wp:column -->

<!-- wp:column -->
<div class="wp-block-column"><!-- wp:paragraph -->
<p><strong>Provençal Vegetable Tart<br></strong><em>With seasonal vegetables<br></em>$12.50</p>
<!-- /wp:paragraph --></div>
<!-- /wp:column --></div>
<!-- /wp:columns -->

<!-- wp:columns {"backgroundColor":"luminous-vivid-amber","textColor":"very-dark-gray","align":"wide"} -->
<div class="wp-block-columns alignwide has-background has-text-color has-luminous-vivid-amber-background-color has-very-dark-gray-color"><!-- wp:column -->
<div class="wp-block-column"><!-- wp:paragraph -->
<p><strong>Align Wide + Background<br></strong><em>Smoked salmon topped with crème fraîche, dill and capers<br></em>$15.00</p>
<!-- /wp:paragraph --></div>
<!-- /wp:column -->

<!-- wp:column -->
<div class="wp-block-column"><!-- wp:paragraph -->
<p><strong>Pork Rillettes<br></strong><em>With quick pickle of dried apricots and pistachio crumble<br></em>$14.00</p>
<!-- /wp:paragraph --></div>
<!-- /wp:column -->

<!-- wp:column -->
<div class="wp-block-column"><!-- wp:paragraph -->
<p><strong>Provençal Vegetable Tart<br></strong><em>With seasonal vegetables<br></em>$12.50</p>
<!-- /wp:paragraph --></div>
<!-- /wp:column --></div>
<!-- /wp:columns -->

<!-- wp:columns -->
<div class="wp-block-columns"><!-- wp:column -->
<div class="wp-block-column"><!-- wp:paragraph -->
<p><strong>Align Default<br></strong><em>Smoked salmon topped with crème fraîche, dill and capers<br></em>$15.00</p>
<!-- /wp:paragraph --></div>
<!-- /wp:column -->

<!-- wp:column -->
<div class="wp-block-column"><!-- wp:paragraph -->
<p><strong>Pork Rillettes<br></strong><em>With quick pickle of dried apricots and pistachio crumble<br></em>$14.00</p>
<!-- /wp:paragraph --></div>
<!-- /wp:column -->

<!-- wp:column -->
<div class="wp-block-column"><!-- wp:paragraph -->
<p><strong>Provençal Vegetable Tart<br></strong><em>With seasonal vegetables<br></em>$12.50</p>
<!-- /wp:paragraph --></div>
<!-- /wp:column --></div>
<!-- /wp:columns -->

<!-- wp:columns {"align":"full"} -->
<div class="wp-block-columns alignfull"><!-- wp:column -->
<div class="wp-block-column"><!-- wp:paragraph -->
<p><strong>Align Full<br></strong><em>Smoked salmon topped with crème fraîche, dill and capers<br></em>$15.00</p>
<!-- /wp:paragraph --></div>
<!-- /wp:column -->

<!-- wp:column -->
<div class="wp-block-column"><!-- wp:paragraph -->
<p><strong>Pork Rillettes<br></strong><em>With quick pickle of dried apricots and pistachio crumble<br></em>$14.00</p>
<!-- /wp:paragraph --></div>
<!-- /wp:column -->

<!-- wp:column -->
<div class="wp-block-column"><!-- wp:paragraph -->
<p><strong>Provençal Vegetable Tart<br></strong><em>With seasonal vegetables<br></em>$12.50</p>
<!-- /wp:paragraph --></div>
<!-- /wp:column --></div>
<!-- /wp:columns -->

<!-- wp:paragraph {"backgroundColor":"luminous-vivid-orange"} -->
<p class="has-background has-luminous-vivid-orange-background-color">Comparr to this please</p>
<!-- /wp:paragraph -->
```

* Install the [Gutenberg Starter Theme](https://github.com/WordPress/gutenberg-starter-theme). 
* On `master`- resize screen to a small viewport 
* Notice how the Columns Block edge butt up against viewport.
* Switch to this PR.
* Resize screen again.
* Notice how the Columns Block edges no longer butt up against viewport.

Do the same on both Editor and when viewing post on Frontend.


## Screenshots <!-- if applicable -->

### Before
<img width="501" alt="Screenshot 2020-03-02 at 15 34 35" src="https://user-images.githubusercontent.com/444434/75691010-a5d35c00-5c9b-11ea-80a3-2e0f3e2ac3e0.png">

---------------
---------------
---------------

### After
<img width="501" alt="Screenshot 2020-03-02 at 15 33 38" src="https://user-images.githubusercontent.com/444434/75691647-40339f80-5c9c-11ea-8d98-6dba71c65d38.png">

## Types of changes
Bug fix (non-breaking change which fixes an issue).

Could possibly break some Themes.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
