### PR TITLE
Rich Text: Avoid activeElement focus call

### DIFF
--- a/packages/rich-text/src/to-dom.js
+++ b/packages/rich-text/src/to-dom.js
@@ -289,6 +289,8 @@ export function applySelection( { startPath, endPath }, current ) {
 	range.setStart( startContainer, startOffset );
 	range.setEnd( endContainer, endOffset );
 
+	const { activeElement } = ownerDocument;
+
 	if ( selection.rangeCount > 0 ) {
 		// If the to be added range and the live range are the same, there's no
 		// need to remove the live range and add the equivalent range.
@@ -300,4 +302,17 @@ export function applySelection( { startPath, endPath }, current ) {
 	}
 
 	selection.addRange( range );
+
+	// This function is not intended to cause a shift in focus. Since the above
+	// selection manipulations may shift focus, ensure that focus is restored to
+	// its previous state. `activeElement` can be `null` or the body element if
+	// there is no focus, which is accounted for here in the explicit `blur` to
+	// restore to a state of non-focus.
+	if ( activeElement !== document.activeElement ) {
+		if ( activeElement ) {
+			activeElement.focus();
+		} else {
+			document.activeElement.blur();
+		}
+	}
 }

--- a/packages/rich-text/src/to-dom.js
+++ b/packages/rich-text/src/to-dom.js
@@ -289,8 +289,6 @@ export function applySelection( { startPath, endPath }, current ) {
 	range.setStart( startContainer, startOffset );
 	range.setEnd( endContainer, endOffset );
 
-	const { activeElement } = ownerDocument;
-
 	if ( selection.rangeCount > 0 ) {
 		// If the to be added range and the live range are the same, there's no
 		// need to remove the live range and add the equivalent range.
@@ -302,5 +300,4 @@ export function applySelection( { startPath, endPath }, current ) {
 	}
 
 	selection.addRange( range );
-	activeElement.focus();
 }

--- a/packages/rich-text/src/to-dom.js
+++ b/packages/rich-text/src/to-dom.js
@@ -309,9 +309,16 @@ export function applySelection( { startPath, endPath }, current ) {
 	// there is no focus, which is accounted for here in the explicit `blur` to
 	// restore to a state of non-focus.
 	if ( activeElement !== document.activeElement ) {
+		// The `instanceof` checks protect against edge cases where the focused
+		// element is not of the interface HTMLElement (does not have a `focus`
+		// or `blur` property).
+		//
+		// See: https://github.com/Microsoft/TypeScript/issues/5901#issuecomment-431649653
 		if ( activeElement ) {
-			activeElement.focus();
-		} else {
+			if ( activeElement instanceof window.HTMLElement ) {
+				activeElement.focus();
+			}
+		} else if ( document.activeElement instanceof window.HTMLElement ) {
 			document.activeElement.blur();
 		}
 	}


### PR DESCRIPTION
Fixes: https://core.trac.wordpress.org/ticket/49519

This pull request attempts to fix [Trac#49519](https://core.trac.wordpress.org/ticket/49519), where an error occurs when deleting blocks in the editor in Internet Explorer.

The error manifests itself as:

```
Unable to get property 'focus' of undefined or null reference
```

It was traced back to this line of code in the `applySelection` function:

https://github.com/WordPress/gutenberg/blob/11963546b7921f26d6f21a7b74e27ddfb9b8e1f4/packages/rich-text/src/to-dom.js#L305

This was recently changed/introduced as part of #19536.

It's not immediately clear to me whether this explicit focus is required. It may be that the manipulation of selections on the lines preceeding the `focus()` call would cause focus to be lost, so an explicit focus is intended in restoring the focus which had existed before those selection manipulations occurred.

Ultimately, it seems that `activeElement` is unset in Internet Explorer, but not other browsers.

If removing the `focus` is not acceptable, the following alternatives may be considered:

- Perform a truthy test of `activeElement`, to at least verify existence before calling `focus`
   - Why would this be any different or allowable in Internet Explorer? Is it a specific difference in browser implementation of `activeElement`? Specifically, I have found that `activeElement` will tend to fall back to `document.body` in many other browsers ([see related example](https://github.com/WordPress/gutenberg/blob/11963546b7921f26d6f21a7b74e27ddfb9b8e1f4/packages/components/src/guide/finish-button.js#L17)).
- Focus an element relative to the new selection, e.g. `range.commonAncestorContainer`

**Testing Instructions:**

In Internet Explorer and your preferred browser, verify no errors when deleting block:

1. Navigate to Posts > Add New
2. Insert a paragraph block with some text
3. Press <kbd>Enter</kbd> to create a second paragraph
4. Delete the second paragraph by pressing <kbd>Backspace</kbd>

<!-- typescriptisnice: activeElement can be null, `focus` is invalid on null type -->