### PR TITLE
Add storybook story for DropZone component

### DIFF
--- a/packages/components/src/drop-zone/stories/index.js
+++ b/packages/components/src/drop-zone/stories/index.js
@@ -1,0 +1,52 @@
+/**
+ * External dependencies
+ */
+import { text } from '@storybook/addon-knobs';
+
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import DropZone from '../';
+import DropZoneProvider from '../provider.js';
+
+export default {
+	title: 'Components/DropZone',
+	component: DropZone,
+};
+
+const DropZoneWithState = ( props ) => {
+	const [ hasDropped, setDropped ] = useState();
+
+	return (
+		<DropZoneProvider>
+			<div
+				style={ {
+					margin: '50px auto',
+					width: '200px',
+					padding: '20px',
+					textAlign: 'center',
+					border: '1px solid #ccc',
+				} }
+			>
+				{ hasDropped ? 'Dropped!' : 'Drop something here' }
+				<DropZone
+					{ ...props }
+					onFilesDrop={ setDropped }
+					onHTMLDrop={ setDropped }
+					onDrop={ setDropped }
+				/>
+			</div>
+		</DropZoneProvider>
+	);
+};
+
+export const _default = () => {
+	const label = text( 'Label', 'Label Text' );
+
+	return <DropZoneWithState label={ label } />;
+};


### PR DESCRIPTION
Current a Draft PR because it looks like the DropZone component is being updated and I wanted to get some feedback on if the README example is still correct? It appears the "label" prop isn't working either.

## Description
Adds a storybook story for the DropZone component as part of #17973.

## How has this been tested?
* run `npm run storybook:dev`
* See the new DropZone story under components

## Screenshots
![Components___DropZone_-_Default_⋅_Storybook_and_Activity_Monitor__All_Processes_](https://user-images.githubusercontent.com/6653970/75707655-42dac880-5c8d-11ea-9913-bc751ed58144.png)

## Types of changes
New feature (non-breaking change which adds functionality)
