### PR TITLE
Block Library: Columns: Force 50% column width at mid-range viewport

### DIFF
--- a/packages/block-library/src/columns/style.scss
+++ b/packages/block-library/src/columns/style.scss
@@ -31,8 +31,11 @@
 	overflow-wrap: break-word; // New standard.
 
 	// Between mobile and large viewports, allow 2 columns.
-	@include break-small() {
-		flex-basis: calc(50% - #{$grid-unit-20});
+	@media (min-width: #{ ($break-small) }) and (max-width: #{ ($break-medium - 1) }) {
+		// As with mobile styles, this must be important since the Column
+		// assigns its own width as an inline style, which should take effect
+		// starting at `break-medium`.
+		flex-basis: calc(50% - #{$grid-unit-20}) !important;
 		flex-grow: 0;
 
 		// Add space between the multiple columns. Themes can customize this if they wish to work differently.


### PR DESCRIPTION
Fixes #18416

This pull request seeks to resolve an issue where columns do not always size correctly at mid-range viewports. Specifically, columns with explicit widths assigned will assign those widths using an inline style attribute which, prior to these changes, would take precedent over the `50%` intended width at this viewport range.

These changes resolve this by assigning the `flex-basis` using `!important`. While `!important` is typically discouraged, it is the only means by which the inline style can be overridden, which is the intent of these styles (to override the explicit assigned width). An alternative would require that the flex-basis be assigned by some other means, e.g. a combination of `data-` attribute and CSS `attr()`, which [has no browser support](https://caniuse.com/#feat=css3-attr) and would not be backwards-compatible with existing columns content.

Note that there is already prior art for this behavior. The styles which force `100%` width in mobile viewports is applied in the exact same fashion:

https://github.com/WordPress/gutenberg/blob/e01b562f6e87a5a3ed73282cc71f28dee0712ae0/packages/block-library/src/columns/style.scss#L20-L24

The important caveat is that unless this is used with `max-width` media query, then the `!important` styles would override the intended explicit widths at larger viewports. That is the reason for changing from using the mixin to a manually-crafted `@media` query (same as with the mobile styles).

**Note about WordPress 5.4 cherry-picking:** It was my hope to try to have this fixed in time for WordPress 5.4, despite being a bug which has existed for some time. While it could still be included, it is complicated by the facts that (a) RC1 is scheduled for tomorrow, and since this is not a regression of WordPress 5.4, it may not qualify for cherry-picking during RC, and (b) the patch would not apply cleanly because of refactoring which has occurred in this stylesheet since 5.4-beta1 (#20529).

**Testing Instructions:**

Make a post including Columns with varying combinations of explicit and flexible-width columns. Specifically, you should observe that when assigning an explicit width to a column, the width is overridden when previewed at viewport sizes between ~600-800px.

Repeat steps to reproduce from #18416