### PR TITLE
Components: Fix focus loss for Guide Finish button in IE

### DIFF
--- a/packages/components/src/guide/finish-button.js
+++ b/packages/components/src/guide/finish-button.js
@@ -14,7 +14,10 @@ export default function FinishButton( { className, onClick, children } ) {
 	// Focus the button on mount if nothing else is focused. This prevents a
 	// focus loss when the 'Next' button is swapped out.
 	useLayoutEffect( () => {
-		if ( document.activeElement === document.body ) {
+		if (
+			! document.activeElement ||
+			document.activeElement === document.body
+		) {
 			button.current.focus();
 		}
 	}, [ button ] );

--- a/packages/editor/src/components/post-title/index.js
+++ b/packages/editor/src/components/post-title/index.js
@@ -109,7 +109,8 @@ class PostTitle extends Component {
 						*/
 						/* eslint-disable jsx-a11y/no-autofocus */
 						autoFocus={
-							document.body === document.activeElement &&
+							( document.body === document.activeElement ||
+								! document.activeElement ) &&
 							isCleanNewPost
 						}
 						/* eslint-enable jsx-a11y/no-autofocus */


### PR DESCRIPTION
Previously: https://github.com/WordPress/gutenberg/pull/18041#discussion_r386581264

This pull request seeks to resolve two conditions which detect the absence of focus, but only consider one of the two possible values for there being no focus:

>When there is no selection, the active element is the page's `<body>` or `null`.

https://developer.mozilla.org/en-US/docs/Web/API/DocumentOrShadowRoot/activeElement

Notably, in Internet Explorer, `document.activeElement` will often report as being `null` when there is no focus. This is in contrast to other browsers, where it will commonly report as being the `body` element. The affected code had previously only been accounting for the latter of these two.

**Testing Instructions:**

Verify that there is no focus loss when using the keyboard to navigate between steps of the Welcoem Modal in Internet Explorer.

1. Navigate to Posts > Add New
2. If you have already dismissed the Welcome Guide in a previous session, you can manually have it shown by clicking Welcome Guide under the "More Tools & Options" menu in the top-right of the page.
3. Use the keyboard to navigate to the final step of the guide
4. Observe at the final step of the guide that the "Finish" button is focused