### PR TITLE
Improve the Back to WP button in Fullscreen Mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10394,6 +10394,7 @@
 				"@wordpress/media-utils": "file:packages/media-utils",
 				"@wordpress/notices": "file:packages/notices",
 				"@wordpress/plugins": "file:packages/plugins",
+				"@wordpress/primitives": "file:packages/primitives",
 				"@wordpress/url": "file:packages/url",
 				"@wordpress/viewport": "file:packages/viewport",
 				"classnames": "^2.2.5",
@@ -19762,7 +19763,7 @@
 				},
 				"node-pre-gyp": {
 					"version": "0.12.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz",
 					"integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
 					"dev": true,
 					"optional": true,
@@ -19781,7 +19782,7 @@
 				},
 				"nopt": {
 					"version": "4.0.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
 					"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
 					"dev": true,
 					"optional": true,

--- a/packages/e2e-tests/specs/editor/various/fullscreen-mode.test.js
+++ b/packages/e2e-tests/specs/editor/various/fullscreen-mode.test.js
@@ -22,10 +22,10 @@ describe( 'Fullscreen Mode', () => {
 
 		expect( isFullscreenEnabled ).toBe( true );
 
-		const fullscreenToolbar = await page.$(
-			'.edit-post-fullscreen-mode-close__toolbar'
+		const fullscreenCloseButton = await page.$(
+			'.edit-post-fullscreen-mode-close'
 		);
 
-		expect( fullscreenToolbar ).not.toBeNull();
+		expect( fullscreenCloseButton ).not.toBeNull();
 	} );
 } );

--- a/packages/edit-post/package.json
+++ b/packages/edit-post/package.json
@@ -41,6 +41,7 @@
 		"@wordpress/media-utils": "file:../media-utils",
 		"@wordpress/notices": "file:../notices",
 		"@wordpress/plugins": "file:../plugins",
+		"@wordpress/primitives": "file:../primitives",
 		"@wordpress/url": "file:../url",
 		"@wordpress/viewport": "file:../viewport",
 		"classnames": "^2.2.5",

--- a/packages/edit-post/src/components/header/fullscreen-mode-close/index.js
+++ b/packages/edit-post/src/components/header/fullscreen-mode-close/index.js
@@ -7,10 +7,15 @@ import { get } from 'lodash';
  * WordPress dependencies
  */
 import { withSelect } from '@wordpress/data';
-import { Button } from '@wordpress/components';
+import { Button, Path, SVG } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
-import { wordpress } from '@wordpress/icons';
+
+const WordPressLogo = () => (
+	<SVG width="28" height="28" viewBox="0 0 128 128" version="1.1">
+		<Path d="M100 61.3c0-6.6-2.4-11.2-4.4-14.7-2.7-4.4-5.2-8.1-5.2-12.5 0-4.9 3.7-9.5 9-9.5h.7c-9.5-8.7-22.1-14-36-14-18.6 0-35 9.6-44.6 24 1.3 0 2.4.1 3.4.1 5.6 0 14.2-.7 14.2-.7 2.9-.2 3.2 4.1.3 4.4 0 0-2.9.3-6.1.5l19.4 57.8 11.7-35L54.1 39c-2.9-.2-5.6-.5-5.6-.5-2.9-.2-2.5-4.6.3-4.4 0 0 8.8.7 14 .7 5.6 0 14.2-.7 14.2-.7 2.9-.2 3.2 4.1.3 4.4 0 0-2.9.3-6.1.5l19.3 57.3L96 78.9c2.6-7.6 4-13 4-17.6zM10.7 64c0 21.1 12.3 39.4 30.1 48L15.3 42.3c-3 6.6-4.6 14-4.6 21.7zm54.2 4.7l-16 46.5c4.8 1.4 9.8 2.2 15.1 2.2 6.2 0 12.2-1.1 17.7-3-.1-.2-.3-.5-.4-.7l-16.4-45zM64 0C28.7 0 0 28.7 0 64s28.7 64 64 64 64-28.7 64-64S99.3 0 64 0zm49.9 97.6c-2.2 3.2-4.6 6.2-7.3 8.9s-5.7 5.2-8.9 7.3c-3.2 2.2-6.7 4-10.2 5.5-7.4 3.1-15.3 4.7-23.4 4.7s-16-1.6-23.4-4.7c-3.6-1.5-7-3.4-10.2-5.5-3.2-2.2-6.2-4.6-8.9-7.3s-5.2-5.7-7.3-8.9c-2.2-3.2-4-6.7-5.5-10.2-3.4-7.4-5-15.3-5-23.4s1.6-16 4.7-23.4c1.5-3.6 3.4-7 5.5-10.2 2.2-3.2 4.6-6.2 7.3-8.9s5.7-5.2 8.9-7.3c3.2-2.2 6.7-4 10.2-5.5C48 5.4 55.9 3.8 64 3.8s16 1.6 23.4 4.7c3.6 1.5 7 3.4 10.2 5.5 3.2 2.2 6.2 4.6 8.9 7.3s5.2 5.7 7.3 8.9c2.2 3.2 4 6.7 5.5 10.2 3.1 7.4 4.7 15.3 4.7 23.4s-1.6 16-4.7 23.4c-1.4 3.8-3.2 7.2-5.4 10.4zm-2.7-53.7c0 5.4-1 11.5-4.1 19.1l-16.3 47.1c15.9-9.2 26.5-26.4 26.5-46.1 0-9.3-2.4-18-6.5-25.6.2 1.7.4 3.5.4 5.5z" />
+	</SVG>
+);
 
 function FullscreenModeClose( { isActive, postType } ) {
 	if ( ! isActive || ! postType ) {
@@ -20,7 +25,7 @@ function FullscreenModeClose( { isActive, postType } ) {
 	return (
 		<Button
 			className="edit-post-fullscreen-mode-close"
-			icon={ wordpress }
+			icon={ WordPressLogo }
 			iconSize={ 36 }
 			href={ addQueryArgs( 'edit.php', {
 				post_type: postType.slug,

--- a/packages/edit-post/src/components/header/fullscreen-mode-close/index.js
+++ b/packages/edit-post/src/components/header/fullscreen-mode-close/index.js
@@ -6,18 +6,29 @@ import { get } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { withSelect } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import { Button, Path, SVG } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 
-const WordPressLogo = () => (
+const wordPressLogo = (
 	<SVG width="28" height="28" viewBox="0 0 128 128" version="1.1">
 		<Path d="M100 61.3c0-6.6-2.4-11.2-4.4-14.7-2.7-4.4-5.2-8.1-5.2-12.5 0-4.9 3.7-9.5 9-9.5h.7c-9.5-8.7-22.1-14-36-14-18.6 0-35 9.6-44.6 24 1.3 0 2.4.1 3.4.1 5.6 0 14.2-.7 14.2-.7 2.9-.2 3.2 4.1.3 4.4 0 0-2.9.3-6.1.5l19.4 57.8 11.7-35L54.1 39c-2.9-.2-5.6-.5-5.6-.5-2.9-.2-2.5-4.6.3-4.4 0 0 8.8.7 14 .7 5.6 0 14.2-.7 14.2-.7 2.9-.2 3.2 4.1.3 4.4 0 0-2.9.3-6.1.5l19.3 57.3L96 78.9c2.6-7.6 4-13 4-17.6zM10.7 64c0 21.1 12.3 39.4 30.1 48L15.3 42.3c-3 6.6-4.6 14-4.6 21.7zm54.2 4.7l-16 46.5c4.8 1.4 9.8 2.2 15.1 2.2 6.2 0 12.2-1.1 17.7-3-.1-.2-.3-.5-.4-.7l-16.4-45zM64 0C28.7 0 0 28.7 0 64s28.7 64 64 64 64-28.7 64-64S99.3 0 64 0zm49.9 97.6c-2.2 3.2-4.6 6.2-7.3 8.9s-5.7 5.2-8.9 7.3c-3.2 2.2-6.7 4-10.2 5.5-7.4 3.1-15.3 4.7-23.4 4.7s-16-1.6-23.4-4.7c-3.6-1.5-7-3.4-10.2-5.5-3.2-2.2-6.2-4.6-8.9-7.3s-5.2-5.7-7.3-8.9c-2.2-3.2-4-6.7-5.5-10.2-3.4-7.4-5-15.3-5-23.4s1.6-16 4.7-23.4c1.5-3.6 3.4-7 5.5-10.2 2.2-3.2 4.6-6.2 7.3-8.9s5.7-5.2 8.9-7.3c3.2-2.2 6.7-4 10.2-5.5C48 5.4 55.9 3.8 64 3.8s16 1.6 23.4 4.7c3.6 1.5 7 3.4 10.2 5.5 3.2 2.2 6.2 4.6 8.9 7.3s5.2 5.7 7.3 8.9c2.2 3.2 4 6.7 5.5 10.2 3.1 7.4 4.7 15.3 4.7 23.4s-1.6 16-4.7 23.4c-1.4 3.8-3.2 7.2-5.4 10.4zm-2.7-53.7c0 5.4-1 11.5-4.1 19.1l-16.3 47.1c15.9-9.2 26.5-26.4 26.5-46.1 0-9.3-2.4-18-6.5-25.6.2 1.7.4 3.5.4 5.5z" />
 	</SVG>
 );
 
-function FullscreenModeClose( { isActive, postType } ) {
+function FullscreenModeClose() {
+	const { isActive, postType } = useSelect( ( select ) => {
+		const { getCurrentPostType } = select( 'core/editor' );
+		const { isFeatureActive } = select( 'core/edit-post' );
+		const { getPostType } = select( 'core' );
+
+		return {
+			isActive: isFeatureActive( 'fullscreenMode' ),
+			postType: getPostType( getCurrentPostType() ),
+		};
+	}, [] );
+
 	if ( ! isActive || ! postType ) {
 		return null;
 	}
@@ -25,7 +36,7 @@ function FullscreenModeClose( { isActive, postType } ) {
 	return (
 		<Button
 			className="edit-post-fullscreen-mode-close"
-			icon={ WordPressLogo }
+			icon={ wordPressLogo }
 			iconSize={ 36 }
 			href={ addQueryArgs( 'edit.php', {
 				post_type: postType.slug,
@@ -35,13 +46,4 @@ function FullscreenModeClose( { isActive, postType } ) {
 	);
 }
 
-export default withSelect( ( select ) => {
-	const { getCurrentPostType } = select( 'core/editor' );
-	const { isFeatureActive } = select( 'core/edit-post' );
-	const { getPostType } = select( 'core' );
-
-	return {
-		isActive: isFeatureActive( 'fullscreenMode' ),
-		postType: getPostType( getCurrentPostType() ),
-	};
-} )( FullscreenModeClose );
+export default FullscreenModeClose;

--- a/packages/edit-post/src/components/header/fullscreen-mode-close/index.js
+++ b/packages/edit-post/src/components/header/fullscreen-mode-close/index.js
@@ -7,7 +7,8 @@ import { get } from 'lodash';
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { Button, Path, SVG } from '@wordpress/components';
+import { Button } from '@wordpress/components';
+import { Path, SVG } from '@wordpress/primitives';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 

--- a/packages/edit-post/src/components/header/fullscreen-mode-close/index.js
+++ b/packages/edit-post/src/components/header/fullscreen-mode-close/index.js
@@ -7,10 +7,10 @@ import { get } from 'lodash';
  * WordPress dependencies
  */
 import { withSelect } from '@wordpress/data';
-import { Button, Toolbar } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
-import { chevronLeft } from '@wordpress/icons';
+import { wordpress } from '@wordpress/icons';
 
 function FullscreenModeClose( { isActive, postType } ) {
 	if ( ! isActive || ! postType ) {
@@ -18,19 +18,15 @@ function FullscreenModeClose( { isActive, postType } ) {
 	}
 
 	return (
-		<Toolbar className="edit-post-fullscreen-mode-close__toolbar">
-			<Button
-				icon={ chevronLeft }
-				href={ addQueryArgs( 'edit.php', {
-					post_type: postType.slug,
-				} ) }
-				label={ get(
-					postType,
-					[ 'labels', 'view_items' ],
-					__( 'Back' )
-				) }
-			/>
-		</Toolbar>
+		<Button
+			className="edit-post-fullscreen-mode-close"
+			icon={ wordpress }
+			iconSize={ 36 }
+			href={ addQueryArgs( 'edit.php', {
+				post_type: postType.slug,
+			} ) }
+			label={ get( postType, [ 'labels', 'view_items' ], __( 'Back' ) ) }
+		/>
 	);
 }
 

--- a/packages/edit-post/src/components/header/fullscreen-mode-close/style.scss
+++ b/packages/edit-post/src/components/header/fullscreen-mode-close/style.scss
@@ -1,4 +1,4 @@
-.edit-post-fullscreen-mode-close__toolbar {
+.edit-post-fullscreen-mode-close.has-icon {
 	// Do not show the toolbar icon on small screens,
 	// when Fullscreen Mode is not an option in the "More" menu.
 	display: none;
@@ -6,7 +6,12 @@
 	@include break-medium() {
 		display: flex;
 		align-items: center;
+		align-self: stretch;
 		border: none;
-		margin-right: $grid-unit-10;
+		background: $black;
+		color: $white;
+		border-radius: 0;
+		height: auto;
+		width: $header-height;
 	}
 }

--- a/packages/edit-post/src/components/header/fullscreen-mode-close/style.scss
+++ b/packages/edit-post/src/components/header/fullscreen-mode-close/style.scss
@@ -8,7 +8,7 @@
 		align-items: center;
 		align-self: stretch;
 		border: none;
-		background: $black;
+		background: #23282e; // WP-admin gray.
 		color: $white;
 		border-radius: 0;
 		height: auto;

--- a/packages/edit-post/src/components/header/fullscreen-mode-close/style.scss
+++ b/packages/edit-post/src/components/header/fullscreen-mode-close/style.scss
@@ -13,5 +13,17 @@
 		border-radius: 0;
 		height: auto;
 		width: $header-height;
+
+		&:hover {
+			background: #32373d; // WP-admin light-gray.
+		}
+
+		&:active {
+			color: $white;
+		}
+
+		&:focus {
+			box-shadow: inset 0 0 0 2px color($theme-color), inset 0 0 0 3px $white;
+		}
 	}
 }

--- a/packages/edit-post/src/components/header/index.js
+++ b/packages/edit-post/src/components/header/index.js
@@ -58,8 +58,8 @@ function Header() {
 
 	return (
 		<div className="edit-post-header">
+			<FullscreenModeClose />
 			<div className="edit-post-header__toolbar">
-				<FullscreenModeClose />
 				<HeaderToolbar />
 			</div>
 			<div className="edit-post-header__settings">

--- a/packages/edit-post/src/components/header/style.scss
+++ b/packages/edit-post/src/components/header/style.scss
@@ -3,16 +3,9 @@
 	background: $white;
 	display: flex;
 	flex-wrap: wrap;
-	justify-content: space-between;
 	align-items: center;
 	// The header should never be wider than the viewport, or buttons might be hidden. Especially relevant at high zoom levels. Related to https://core.trac.wordpress.org/ticket/47603#ticket.
 	max-width: 100vw;
-
-	// Padding.
-	padding: $grid-unit-15;
-	@include break-small() {
-		padding: $grid-unit-15 ($grid-unit-15 + 6px);
-	}
 
 	// Make toolbar sticky on larger breakpoints
 	@include break-zoomed-in {
@@ -40,12 +33,15 @@
 
 .edit-post-header__toolbar {
 	display: flex;
+	flex-grow: 1;
+	padding-left: $grid-unit-20;
 }
 
 .edit-post-header__settings {
 	display: inline-flex;
 	align-items: center;
 	flex-wrap: wrap;
+	padding-right: $grid-unit-20;
 }
 
 


### PR DESCRIPTION
closes #20579 

This PR tries to implement the proposal in 120579. It doesn't change the button label because it's CPT specific and we only have the view_items label here https://developer.wordpress.org/reference/functions/get_post_type_labels/ (potentially we could change to a more generic label like "Back to WP Admin"

<img width="347" alt="Capture d’écran 2020-03-03 à 9 42 23 AM" src="https://user-images.githubusercontent.com/272444/75758199-fd250b00-5d33-11ea-8454-0a2c50c90a4e.png">

The button does feel a bit prominent but maybe that's fine.