### PR TITLE
Fix incorrectly displayed preview option for private post types

### DIFF
--- a/packages/e2e-tests/plugins/custom-post-types.php
+++ b/packages/e2e-tests/plugins/custom-post-types.php
@@ -16,12 +16,12 @@ function public_queryable_false_public_false_cpt() {
 	register_post_type(
 		$public_queryable_false_public_false,
 		array(
-			'label'              => 'NotPublicQNotPublic',
-			'show_in_rest'       => true,
-			'public'             => false,
-			'supports'           => array( 'title', 'editor', 'revisions' ),
-			'show_ui'            => true,
-			'show_in_menu'       => true,
+			'label'        => 'NotPublicQNotPublic',
+			'show_in_rest' => true,
+			'public'       => false,
+			'supports'     => array( 'title', 'editor', 'revisions' ),
+			'show_ui'      => true,
+			'show_in_menu' => true,
 		)
 	);
 }

--- a/packages/e2e-tests/plugins/custom-post-types.php
+++ b/packages/e2e-tests/plugins/custom-post-types.php
@@ -8,6 +8,26 @@
  */
 
 /**
+ * Registers a custom post type that is not public_queryable and not public.
+ */
+function public_queryable_false_public_false_cpt() {
+	// post type name has to be less than 20 chars.
+	$public_queryable_false_public_false = 'not_public';
+	register_post_type(
+		$public_queryable_false_public_false,
+		array(
+			'label'              => 'NotPublicQNotPublic',
+			'show_in_rest'       => true,
+			'public'             => false,
+			'supports'           => array( 'title', 'editor', 'revisions' ),
+			'show_ui'            => true,
+			'show_in_menu'       => true,
+		)
+	);
+}
+add_action( 'init', 'public_queryable_false_public_false_cpt' );
+
+/**
  * Registers a custom post type that is public_queryable but not public.
  */
 function public_queryable_true_public_false_cpt() {

--- a/packages/e2e-tests/specs/editor/various/preview.test.js
+++ b/packages/e2e-tests/specs/editor/various/preview.test.js
@@ -345,6 +345,12 @@ describe( 'Preview with private custom post type', () => {
 		// Open the preview menu.
 		await page.click( '.editor-post-preview__button-toggle' );
 
+		// Expect there to be a single menu group in the dropdown.
+		const menuGroups = await page.$$(
+			'.editor-post-preview__dropdown-content .components-menu-group'
+		);
+		expect( menuGroups.length ).toBe( 1 );
+
 		// Expect there to be three preview buttons.
 		const previewButtons = await page.$$(
 			'.editor-post-preview__button-resize'

--- a/packages/e2e-tests/specs/editor/various/preview.test.js
+++ b/packages/e2e-tests/specs/editor/various/preview.test.js
@@ -335,7 +335,7 @@ describe( 'Preview with private custom post type', () => {
 		await deactivatePlugin( 'gutenberg-test-custom-post-types' );
 	} );
 
-	it( 'should not show the Preview Externally button', async () => {
+	it( 'should not show the Preview Externally link', async () => {
 		await createNewPost( { postType: 'not_public' } );
 
 		// Type in the title filed.
@@ -349,10 +349,10 @@ describe( 'Preview with private custom post type', () => {
 			'.editor-post-preview__dropdown-content'
 		);
 
-		// Expect the Preview Externally button not to be present.
-		const previewExternallyButton = await previewDropdownContents.$x(
+		// Expect the Preview Externally link not to be present.
+		const previewExternallyLink = await previewDropdownContents.$x(
 			'//a[contains(text(), "Preview externally")]'
 		);
-		expect( previewExternallyButton.length ).toBe( 0 );
+		expect( previewExternallyLink.length ).toBe( 0 );
 	} );
 } );

--- a/packages/e2e-tests/specs/editor/various/preview.test.js
+++ b/packages/e2e-tests/specs/editor/various/preview.test.js
@@ -345,18 +345,6 @@ describe( 'Preview with private custom post type', () => {
 		// Open the preview menu.
 		await page.click( '.editor-post-preview__button-toggle' );
 
-		// Expect there to be a single menu group in the dropdown.
-		const menuGroups = await page.$$(
-			'.editor-post-preview__dropdown-content .components-menu-group'
-		);
-		expect( menuGroups.length ).toBe( 1 );
-
-		// Expect there to be three preview buttons.
-		const previewButtons = await page.$$(
-			'.editor-post-preview__button-resize'
-		);
-		expect( previewButtons.length ).toBe( 3 );
-
 		// Expect the Preview Externally button not to be present.
 		const previewExternallyButton = await page.$x(
 			'//a[contains(text(), "Preview externally")]'

--- a/packages/e2e-tests/specs/editor/various/preview.test.js
+++ b/packages/e2e-tests/specs/editor/various/preview.test.js
@@ -345,8 +345,12 @@ describe( 'Preview with private custom post type', () => {
 		// Open the preview menu.
 		await page.click( '.editor-post-preview__button-toggle' );
 
+		const previewDropdownContents = await page.$(
+			'.editor-post-preview__dropdown-content'
+		);
+
 		// Expect the Preview Externally button not to be present.
-		const previewExternallyButton = await page.$x(
+		const previewExternallyButton = await previewDropdownContents.$x(
 			'//a[contains(text(), "Preview externally")]'
 		);
 		expect( previewExternallyButton.length ).toBe( 0 );

--- a/packages/edit-post/src/components/preview-options/index.js
+++ b/packages/edit-post/src/components/preview-options/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import {
@@ -53,6 +58,13 @@ export default function PreviewOptions( {
 		return select( 'core/editor' ).isEditedPostSaveable();
 	}, [] );
 
+	const isViewable = useSelect( ( select ) => {
+		const { getEditedPostAttribute } = select( 'core/editor' );
+		const { getPostType } = select( 'core' );
+		const postType = getPostType( getEditedPostAttribute( 'type' ) );
+		return get( postType, [ 'viewable' ], false );
+	}, [] );
+
 	return (
 		<Dropdown
 			className="editor-post-preview__dropdown"
@@ -96,22 +108,28 @@ export default function PreviewOptions( {
 							{ __( 'Mobile' ) }
 						</MenuItem>
 					</MenuGroup>
-					<MenuGroup>
-						<div className="editor-post-preview__grouping-external">
-							<PostPreviewButton
-								className={
-									'editor-post-preview__button-external'
-								}
-								forceIsAutosaveable={ forceIsAutosaveable }
-								forcePreviewLink={ forcePreviewLink }
-								textContent={ __( 'Preview externally' ) }
-							/>
-							<Icon
-								icon={ external }
-								className="editor-post-preview__icon-external"
-							/>
-						</div>
-					</MenuGroup>
+					{ isViewable && (
+						<MenuGroup>
+							<div className="editor-post-preview__grouping-external">
+								<PostPreviewButton
+									className={
+										'editor-post-preview__button-external'
+									}
+									forceIsAutosaveable={ forceIsAutosaveable }
+									forcePreviewLink={ forcePreviewLink }
+									textContent={
+										<>
+											{ __( 'Preview externally' ) }
+											<Icon
+												icon={ external }
+												className="editor-post-preview__icon-external"
+											/>
+										</>
+									}
+								/>
+							</div>
+						</MenuGroup>
+					) }
 				</>
 			) }
 		/>

--- a/packages/edit-post/src/components/preview-options/index.js
+++ b/packages/edit-post/src/components/preview-options/index.js
@@ -120,10 +120,7 @@ export default function PreviewOptions( {
 									textContent={
 										<>
 											{ __( 'Preview externally' ) }
-											<Icon
-												icon={ external }
-												className="editor-post-preview__icon-external"
-											/>
+											<Icon icon={ external } />
 										</>
 									}
 								/>

--- a/packages/edit-post/src/components/preview-options/style.scss
+++ b/packages/edit-post/src/components/preview-options/style.scss
@@ -57,13 +57,7 @@
 	margin-right: auto;
 	width: 100%;
 	display: flex;
-}
-
-.editor-post-preview__icon-external {
-	position: absolute;
-	right: $grid-unit-10;
-	top: 6px;
-	z-index: 1;
+	justify-content: space-between;
 }
 
 @include break-small() {

--- a/packages/edit-post/src/components/preview-options/style.scss
+++ b/packages/edit-post/src/components/preview-options/style.scss
@@ -56,6 +56,7 @@
 	padding-left: $button-size-small + $grid-unit-10 + $grid-unit-10;
 	margin-right: auto;
 	width: 100%;
+	display: flex;
 }
 
 .editor-post-preview__icon-external {


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
For private post types, the preview link is not normally displayed. The new preview menu isn't displaying this correctly though—while the Preview Externally link is (correctly) not displayed, the Open In New Tab icon is still being shown along with the surrounding menu group.

This PR fixes that to hide the menu group that contained the Preview externally link completely for non-viewable posts.

It also moves the Open In New Tab icon so that it's within the anchor element, whereas before it wasn't clickable.

## How has this been tested?
Added e2e tests.

Manual Testing steps:
1. Register a new private custom post type by adding the following php code:
```
function public_queryable_false_public_false_cpt() {
	$public_queryable_false_public_false = 'not_public';
	register_post_type(
		$public_queryable_false_public_false,
		array(
			'label'              => 'NotPublicQNotPublic',
			'show_in_rest'       => true,
			'public'             => false,
			'supports'           => array( 'title', 'editor', 'revisions' ),
			'show_ui'            => true,
			'show_in_menu'       => true,
		)
	);
}
add_action( 'init', 'public_queryable_false_public_false_cpt' );
```
2. Add a new post of that type
3. Type a post title
4. View the preview dropdown menu
5. Observe that the preview externally link isn't present
6. Try adding a normal post and view the preview dropdown menu.
7. Observe that the preview externally link is present
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->
*Before:*
<img width="275" alt="Screenshot 2020-03-03 at 5 23 46 pm" src="https://user-images.githubusercontent.com/677833/75761357-e6060d80-5d73-11ea-816f-71275f16e4d1.png">

*After:*
<img width="283" alt="Screenshot 2020-03-03 at 5 23 25 pm" src="https://user-images.githubusercontent.com/677833/75761371-edc5b200-5d73-11ea-832a-65cb65f29418.png">


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
