### PR TITLE
e2e test for reusable block after refresh.

### DIFF
--- a/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
@@ -164,6 +164,56 @@ describe( 'Reusable blocks', () => {
 		expect( text ).toMatch( 'Oh! Hello there!' );
 	} );
 
+	it( 'can be inserted after refresh', async () => {
+		// Step 1. Insert a paragraph block
+
+		await insertBlock( 'Paragraph' );
+		await page.keyboard.type( 'Awesome Paragraph' );
+
+		await clickBlockToolbarButton( 'More options' );
+
+		const convertButton = await page.waitForXPath(
+			'//button[text()="Add to Reusable blocks"]'
+		);
+		await convertButton.click();
+
+		// Wait for creation to finish
+		await page.waitForXPath(
+			'//*[contains(@class, "components-snackbar")]/*[text()="Block created."]'
+		);
+
+		// Select all of the text in the title field.
+		await pressKeyWithModifier( 'primary', 'a' );
+
+		// Give the reusable block a title
+		await page.keyboard.type( 'Awesome block' );
+
+		// Save the reusable block
+		const [ saveButton ] = await page.$x( '//button[text()="Save"]' );
+		await saveButton.click();
+
+		// Step 2. Create new post.
+
+		await createNewPost();
+
+		// Step 3. Insert the block created in Step 1.
+
+		await insertBlock( 'Awesome block' );
+
+		// Check that we have a reusable block on the page
+		const block = await page.$(
+			'.block-editor-block-list__block[data-type="core/block"]'
+		);
+		expect( block ).not.toBeNull();
+
+		// Check that its title is displayed
+		const title = await page.$eval(
+			'.reusable-block-edit-panel__info',
+			( element ) => element.innerText
+		);
+		expect( title ).toBe( 'Awesome block' );
+	} );
+
 	it( 'can be converted to a regular block', async () => {
 		// Insert the reusable block we edited above
 		await insertBlock( 'Surprised greeting block' );


### PR DESCRIPTION
* Closes #9962

## Description

Add an e2e test to test reusable block is added correctly after refresh.

## How has this been tested?

Written code to test the scenario below:

1. Add a new reusable block
2. Create new post.
3. Add the reusable block created in Step 1.
4. Check if it is added correctly.

## Screenshots 

N/A

## Types of changes

Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [N/A] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [N/A] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [N/A] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
