### PR TITLE
Update the edit site save modal UI

### DIFF
--- a/docs/designers-developers/developers/data/data-core.md
+++ b/docs/designers-developers/developers/data/data-core.md
@@ -153,21 +153,6 @@ _Returns_
 
 -   `?Object`: Record.
 
-<a name="getEntityRecordChangesByRecord" href="#getEntityRecordChangesByRecord">#</a> **getEntityRecordChangesByRecord**
-
-Returns a map of objects with each edited
-raw entity record and its corresponding edits.
-
-The map is keyed by entity `kind => name => key => { rawRecord, edits }`.
-
-_Parameters_
-
--   _state_ `Object`: State tree.
-
-_Returns_
-
--   (unknown type): The map of edited records with their edits.
-
 <a name="getEntityRecordEdits" href="#getEntityRecordEdits">#</a> **getEntityRecordEdits**
 
 Returns the specified entity record's edits.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10240,6 +10240,7 @@
 				"@wordpress/data": "file:packages/data",
 				"@wordpress/deprecated": "file:packages/deprecated",
 				"@wordpress/element": "file:packages/element",
+				"@wordpress/i18n": "file:packages/i18n",
 				"@wordpress/is-shallow-equal": "file:packages/is-shallow-equal",
 				"@wordpress/url": "file:packages/url",
 				"equivalent-key-map": "^0.2.2",
@@ -10422,7 +10423,8 @@
 				"@wordpress/notices": "file:packages/notices",
 				"@wordpress/url": "file:packages/url",
 				"file-saver": "^2.0.2",
-				"jszip": "^3.2.2"
+				"jszip": "^3.2.2",
+				"lodash": "^4.17.15"
 			}
 		},
 		"@wordpress/edit-widgets": {
@@ -19762,7 +19764,7 @@
 				},
 				"node-pre-gyp": {
 					"version": "0.12.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz",
 					"integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
 					"dev": true,
 					"optional": true,
@@ -19781,7 +19783,7 @@
 				},
 				"nopt": {
 					"version": "4.0.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
 					"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
 					"dev": true,
 					"optional": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -10480,7 +10480,6 @@
 				"@wordpress/viewport": "file:packages/viewport",
 				"@wordpress/wordcount": "file:packages/wordcount",
 				"classnames": "^2.2.5",
-				"equivalent-key-map": "^0.2.2",
 				"lodash": "^4.17.15",
 				"memize": "^1.0.5",
 				"react-autosize-textarea": "^3.0.2",

--- a/packages/components/src/base-control/style.scss
+++ b/packages/components/src/base-control/style.scss
@@ -22,5 +22,5 @@
 }
 
 .components-base-control + .components-base-control {
-	margin-bottom: $grid-unit-20;
+	margin-top: $grid-unit-20;
 }

--- a/packages/components/src/color-picker/style.scss
+++ b/packages/components/src/color-picker/style.scss
@@ -244,7 +244,7 @@
 	margin-right: 4px;
 
 	.components-base-control + .components-base-control {
-		margin-bottom: 0;
+		margin-top: 0;
 	}
 
 	.components-base-control__field {

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -366,21 +366,6 @@ _Returns_
 
 -   `?Object`: Record.
 
-<a name="getEntityRecordChangesByRecord" href="#getEntityRecordChangesByRecord">#</a> **getEntityRecordChangesByRecord**
-
-Returns a map of objects with each edited
-raw entity record and its corresponding edits.
-
-The map is keyed by entity `kind => name => key => { rawRecord, edits }`.
-
-_Parameters_
-
--   _state_ `Object`: State tree.
-
-_Returns_
-
--   (unknown type): The map of edited records with their edits.
-
 <a name="getEntityRecordEdits" href="#getEntityRecordEdits">#</a> **getEntityRecordEdits**
 
 Returns the specified entity record's edits.

--- a/packages/core-data/package.json
+++ b/packages/core-data/package.json
@@ -28,6 +28,7 @@
 		"@wordpress/data": "file:../data",
 		"@wordpress/deprecated": "file:../deprecated",
 		"@wordpress/element": "file:../element",
+		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
 		"@wordpress/url": "file:../url",
 		"equivalent-key-map": "^0.2.2",

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -1,7 +1,12 @@
 /**
  * External dependencies
  */
-import { upperFirst, camelCase, map, find } from 'lodash';
+import { upperFirst, camelCase, map, find, get, startCase } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -12,13 +17,25 @@ import { apiFetch, select } from './controls';
 export const DEFAULT_ENTITY_KEY = 'id';
 
 export const defaultEntities = [
-	{ name: 'site', kind: 'root', baseURL: '/wp/v2/settings' },
-	{ name: 'postType', kind: 'root', key: 'slug', baseURL: '/wp/v2/types' },
+	{
+		label: __( 'Site' ),
+		name: 'site',
+		kind: 'root',
+		baseURL: '/wp/v2/settings',
+	},
+	{
+		label: __( 'Post Type' ),
+		name: 'postType',
+		kind: 'root',
+		key: 'slug',
+		baseURL: '/wp/v2/types',
+	},
 	{
 		name: 'media',
 		kind: 'root',
 		baseURL: '/wp/v2/media',
 		plural: 'mediaItems',
+		label: __( 'Media' ),
 	},
 	{
 		name: 'taxonomy',
@@ -26,6 +43,7 @@ export const defaultEntities = [
 		key: 'slug',
 		baseURL: '/wp/v2/taxonomies',
 		plural: 'taxonomies',
+		label: __( 'Taxonomy' ),
 	},
 	{
 		name: 'widgetArea',
@@ -33,8 +51,15 @@ export const defaultEntities = [
 		baseURL: '/__experimental/widget-areas',
 		plural: 'widgetAreas',
 		transientEdits: { blocks: true },
+		label: __( 'Widget area' ),
 	},
-	{ name: 'user', kind: 'root', baseURL: '/wp/v2/users', plural: 'users' },
+	{
+		label: __( 'User' ),
+		name: 'user',
+		kind: 'root',
+		baseURL: '/wp/v2/users',
+		plural: 'users',
+	},
 ];
 
 export const kinds = [
@@ -54,12 +79,19 @@ function* loadPostTypeEntities() {
 			kind: 'postType',
 			baseURL: '/wp/v2/' + postType.rest_base,
 			name,
+			label: postType.labels.singular_name,
 			transientEdits: {
 				blocks: true,
 				selectionStart: true,
 				selectionEnd: true,
 			},
 			mergedEdits: { meta: true },
+			getTitle( record ) {
+				if ( name === 'wp_template_part' || name === 'wp_template' ) {
+					return startCase( record.slug );
+				}
+				return get( record, [ 'title', 'rendered' ], record.id );
+			},
 		};
 	} );
 }
@@ -78,6 +110,7 @@ function* loadTaxonomyEntities() {
 			kind: 'taxonomy',
 			baseURL: '/wp/v2/' + taxonomy.rest_base,
 			name,
+			label: taxonomy.labels.singular_name,
 		};
 	} );
 }

--- a/packages/core-data/src/selectors.js
+++ b/packages/core-data/src/selectors.js
@@ -235,7 +235,6 @@ export const __experimentalGetDirtyEntityRecords = createSelector(
 								: entity.getTitle( entityRecord ),
 							name,
 							kind,
-							entity,
 						} );
 					} );
 				}

--- a/packages/core-data/src/selectors.js
+++ b/packages/core-data/src/selectors.js
@@ -15,6 +15,7 @@ import deprecated from '@wordpress/deprecated';
  */
 import { REDUCER_KEY } from './name';
 import { getQueriedItems } from './queried-data';
+import { DEFAULT_ENTITY_KEY } from './entities';
 
 /**
  * Returns true if a request is in progress for embed preview data, or false
@@ -209,8 +210,8 @@ export const __experimentalGetDirtyEntityRecords = createSelector(
 			Object.keys( data[ kind ] ).forEach( ( name ) => {
 				const primaryKeys = Object.keys(
 					data[ kind ][ name ].edits
-				).filter( ( pks ) =>
-					hasEditsForEntityRecord( state, kind, name, pks )
+				).filter( ( primaryKey ) =>
+					hasEditsForEntityRecord( state, kind, name, primaryKey )
 				);
 
 				if ( primaryKeys.length ) {
@@ -223,9 +224,12 @@ export const __experimentalGetDirtyEntityRecords = createSelector(
 							primaryKey
 						);
 						dirtyRecords.push( {
-							// We avoid using primrayKey because it's transformed to a string
+							// We avoid using primaryKey because it's transformed into a string
 							// when it's used as an object key.
-							key: entityRecord[ entity.key || 'id' ],
+							key:
+								entityRecord[
+									entity.key || DEFAULT_ENTITY_KEY
+								],
 							title: ! entity.getTitle
 								? ''
 								: entity.getTitle( entityRecord ),

--- a/packages/core-data/src/test/selectors.js
+++ b/packages/core-data/src/test/selectors.js
@@ -10,7 +10,7 @@ import {
 	getEntityRecord,
 	__experimentalGetEntityRecordNoResolver,
 	getEntityRecords,
-	getEntityRecordChangesByRecord,
+	__experimentalGetDirtyEntityRecords,
 	getEntityRecordNonTransientEdits,
 	getEmbedPreview,
 	isPreviewEmbedFallback,
@@ -115,7 +115,7 @@ describe( 'getEntityRecords', () => {
 	} );
 } );
 
-describe( 'getEntityRecordChangesByRecord', () => {
+describe( '__experimentalGetDirtyEntityRecords', () => {
 	it( 'should return a map of objects with each raw edited entity record and its corresponding edits', () => {
 		const state = deepFreeze( {
 			entities: {
@@ -136,6 +136,7 @@ describe( 'getEntityRecordChangesByRecord', () => {
 										someRawProperty: {
 											raw: 'somePersistedRawValue',
 										},
+										id: 'someKey',
 									},
 								},
 							},
@@ -152,22 +153,9 @@ describe( 'getEntityRecordChangesByRecord', () => {
 				},
 			},
 		} );
-		expect( getEntityRecordChangesByRecord( state ) ).toEqual( {
-			someKind: {
-				someName: {
-					someKey: {
-						rawRecord: {
-							someProperty: 'somePersistedValue',
-							someRawProperty: 'somePersistedRawValue',
-						},
-						edits: {
-							someProperty: 'someEditedValue',
-							someRawProperty: 'someEditedRawValue',
-						},
-					},
-				},
-			},
-		} );
+		expect( __experimentalGetDirtyEntityRecords( state ) ).toEqual( [
+			{ kind: 'someKind', name: 'someName', key: 'someKey', title: '' },
+		] );
 	} );
 } );
 

--- a/packages/edit-site/package.json
+++ b/packages/edit-site/package.json
@@ -36,7 +36,8 @@
 		"@wordpress/notices": "file:../notices",
 		"@wordpress/url": "file:../url",
 		"file-saver": "^2.0.2",
-		"jszip": "^3.2.2"
+		"jszip": "^3.2.2",
+		"lodash": "^4.17.15"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/edit-site/src/components/save-button/index.js
+++ b/packages/edit-site/src/components/save-button/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { some } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { useEntityProp } from '@wordpress/core-data';
@@ -33,29 +38,15 @@ export default function SaveButton() {
 	}, [ slug ] );
 
 	const { isDirty, isSaving } = useSelect( ( select ) => {
-		const { getEntityRecordChangesByRecord, isSavingEntityRecord } = select(
-			'core'
-		);
-		const entityRecordChangesByRecord = getEntityRecordChangesByRecord();
-		const changedKinds = Object.keys( entityRecordChangesByRecord );
+		const {
+			__experimentalGetDirtyEntityRecords,
+			isSavingEntityRecord,
+		} = select( 'core' );
+		const dirtyEntityRecords = __experimentalGetDirtyEntityRecords();
 		return {
-			isDirty: changedKinds.length > 0,
-			isSaving: changedKinds.some( ( changedKind ) =>
-				Object.keys(
-					entityRecordChangesByRecord[ changedKind ]
-				).some( ( changedName ) =>
-					Object.keys(
-						entityRecordChangesByRecord[ changedKind ][
-							changedName
-						]
-					).some( ( changedKey ) =>
-						isSavingEntityRecord(
-							changedKind,
-							changedName,
-							changedKey
-						)
-					)
-				)
+			isDirty: dirtyEntityRecords.length > 0,
+			isSaving: some( dirtyEntityRecords, ( record ) =>
+				isSavingEntityRecord( record.kind, record.name, record.key )
 			),
 		};
 	} );

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -51,7 +51,6 @@
 		"@wordpress/viewport": "file:../viewport",
 		"@wordpress/wordcount": "file:../wordcount",
 		"classnames": "^2.2.5",
-		"equivalent-key-map": "^0.2.2",
 		"lodash": "^4.17.15",
 		"memize": "^1.0.5",
 		"react-autosize-textarea": "^3.0.2",

--- a/packages/editor/src/components/entities-saved-states/index.js
+++ b/packages/editor/src/components/entities-saved-states/index.js
@@ -11,6 +11,33 @@ import { __ } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useState } from '@wordpress/element';
 
+function EntityRecordState( { record, checked, onChange } ) {
+	const entity = useSelect(
+		( select ) => select( 'core' ).getEntity( record.kind, record.name ),
+		[ record.kind, record.name ]
+	);
+
+	return (
+		<CheckboxControl
+			label={
+				<>
+					{ entity.label }
+					{ !! record.title && (
+						<>
+							{ ': ' }
+							<strong>
+								{ record.title || __( 'Untitled' ) }
+							</strong>
+						</>
+					) }
+				</>
+			}
+			checked={ ! checked }
+			onChange={ onChange }
+		/>
+	);
+}
+
 export default function EntitiesSavedStates( {
 	isOpen,
 	onRequestClose,
@@ -68,22 +95,9 @@ export default function EntitiesSavedStates( {
 			>
 				{ dirtyEntityRecords.map( ( record ) => {
 					return (
-						<CheckboxControl
+						<EntityRecordState
 							key={ record.key }
-							label={
-								<>
-									{ record.entity.label }
-									{ !! record.title && (
-										<>
-											{ ': ' }
-											<strong>
-												{ record.title ||
-													__( 'Untitled' ) }
-											</strong>
-										</>
-									) }
-								</>
-							}
+							record={ record }
 							checked={
 								! some(
 									unsavedEntityRecords,

--- a/packages/editor/src/components/entities-saved-states/index.js
+++ b/packages/editor/src/components/entities-saved-states/index.js
@@ -42,7 +42,7 @@ export default function EntitiesSavedStates( {
 	};
 	const saveCheckedEntities = () => {
 		const entitiesToSave = dirtyEntityRecords.filter(
-			( { key, kind, name } ) => {
+			( { kind, name, key } ) => {
 				return ! some(
 					ignoredForSave.concat( unsavedEntityRecords ),
 					( elt ) =>
@@ -53,7 +53,7 @@ export default function EntitiesSavedStates( {
 			}
 		);
 
-		entitiesToSave.forEach( ( { key, kind, name } ) => {
+		entitiesToSave.forEach( ( { kind, name, key } ) => {
 			saveEditedEntityRecord( kind, name, key );
 		} );
 

--- a/packages/editor/src/components/entities-saved-states/index.js
+++ b/packages/editor/src/components/entities-saved-states/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import EquivalentKeyMap from 'equivalent-key-map';
+import { some } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -11,57 +11,53 @@ import { __ } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useState } from '@wordpress/element';
 
-const EntitiesSavedStatesCheckbox = ( {
-	id,
-	name,
-	changes: { rawRecord },
-	checked,
-	setCheckedById,
-} ) => (
-	<CheckboxControl
-		label={ `${ name }: "${ rawRecord.name ||
-			rawRecord.slug ||
-			rawRecord.title ||
-			__( 'Untitled' ) }"` }
-		checked={ checked }
-		onChange={ ( nextChecked ) => setCheckedById( id, nextChecked ) }
-	/>
-);
-
 export default function EntitiesSavedStates( {
 	isOpen,
 	onRequestClose,
-	ignoredForSave = new EquivalentKeyMap(),
+	ignoredForSave = [],
 } ) {
-	const entityRecordChangesByRecord = useSelect( ( select ) =>
-		select( 'core' ).getEntityRecordChangesByRecord()
+	const dirtyEntityRecords = useSelect(
+		( select ) => select( 'core' ).__experimentalGetDirtyEntityRecords(),
+		[]
 	);
 	const { saveEditedEntityRecord } = useDispatch( 'core' );
 
-	const [ checkedById, _setCheckedById ] = useState(
-		() => new EquivalentKeyMap()
-	);
-	const setCheckedById = ( id, checked ) =>
-		_setCheckedById( ( prevCheckedById ) => {
-			const nextCheckedById = new EquivalentKeyMap( prevCheckedById );
-			if ( checked ) {
-				nextCheckedById.set( id, true );
-			} else {
-				nextCheckedById.delete( id );
-			}
-			return nextCheckedById;
-		} );
+	const [ unsavedEntityRecords, _setUnsavedEntityRecords ] = useState( [] );
+	const setUnsavedEntityRecords = ( { kind, name, key }, checked ) => {
+		if ( checked ) {
+			_setUnsavedEntityRecords(
+				unsavedEntityRecords.filter(
+					( elt ) =>
+						elt.kind !== kind ||
+						elt.name !== name ||
+						elt.key !== key
+				)
+			);
+		} else {
+			_setUnsavedEntityRecords( [
+				...unsavedEntityRecords,
+				{ kind, name, key },
+			] );
+		}
+	};
 	const saveCheckedEntities = () => {
-		checkedById.forEach( ( _checked, id ) => {
-			if ( ! ignoredForSave.has( id ) ) {
-				saveEditedEntityRecord(
-					...id.filter(
-						( s, i ) => i !== id.length - 1 || s !== 'undefined'
-					)
+		const entitiesToSave = dirtyEntityRecords.filter(
+			( { key, kind, name } ) => {
+				return ! some(
+					ignoredForSave.concat( unsavedEntityRecords ),
+					( elt ) =>
+						elt.kind === kind &&
+						elt.name === name &&
+						elt.key === key
 				);
 			}
+		);
+
+		entitiesToSave.forEach( ( { key, kind, name } ) => {
+			saveEditedEntityRecord( kind, name, key );
 		} );
-		onRequestClose( checkedById );
+
+		onRequestClose( entitiesToSave );
 	};
 	return (
 		isOpen && (
@@ -70,41 +66,47 @@ export default function EntitiesSavedStates( {
 				onRequestClose={ () => onRequestClose() }
 				contentLabel={ __( 'Select items to save.' ) }
 			>
-				{ Object.keys( entityRecordChangesByRecord ).map(
-					( changedKind ) =>
-						Object.keys(
-							entityRecordChangesByRecord[ changedKind ]
-						).map( ( changedName ) =>
-							Object.keys(
-								entityRecordChangesByRecord[ changedKind ][
-									changedName
-								]
-							).map( ( changedKey ) => {
-								const id = [
-									changedKind,
-									changedName,
-									changedKey,
-								];
-								return (
-									<EntitiesSavedStatesCheckbox
-										key={ id.join( ' | ' ) }
-										id={ id }
-										name={ changedName }
-										changes={
-											entityRecordChangesByRecord[
-												changedKind
-											][ changedName ][ changedKey ]
-										}
-										checked={ checkedById.get( id ) }
-										setCheckedById={ setCheckedById }
-									/>
-								);
-							} )
-						)
-				) }
+				{ dirtyEntityRecords.map( ( record ) => {
+					return (
+						<CheckboxControl
+							key={ record.key }
+							label={
+								<>
+									{ record.entity.label }
+									{ !! record.title && (
+										<>
+											{ ': ' }
+											<strong>
+												{ record.title ||
+													__( 'Untitled' ) }
+											</strong>
+										</>
+									) }
+								</>
+							}
+							checked={
+								! some(
+									unsavedEntityRecords,
+									( elt ) =>
+										elt.kind === record.kind &&
+										elt.name === record.name &&
+										elt.key === record.key
+								)
+							}
+							onChange={ ( value ) =>
+								setUnsavedEntityRecords( record, value )
+							}
+						/>
+					);
+				} ) }
+
 				<Button
 					isPrimary
-					disabled={ checkedById.size === 0 }
+					disabled={
+						dirtyEntityRecords.length -
+							unsavedEntityRecords.length ===
+						0
+					}
 					onClick={ saveCheckedEntities }
 					className="editor-entities-saved-states__save-button"
 				>

--- a/packages/editor/src/components/post-publish-button/index.js
+++ b/packages/editor/src/components/post-publish-button/index.js
@@ -1,10 +1,9 @@
 /**
  * External dependencies
  */
-import { noop, get } from 'lodash';
+import { noop, get, some } from 'lodash';
 import classnames from 'classnames';
 import memoize from 'memize';
-import EquivalentKeyMap from 'equivalent-key-map';
 
 /**
  * WordPress dependencies
@@ -35,10 +34,9 @@ export class PostPublishButton extends Component {
 			entitiesSavedStatesCallback: false,
 		};
 		this.createIgnoredForSave = memoize(
-			( postType, postId ) =>
-				new EquivalentKeyMap( [
-					[ [ 'postType', postType, String( postId ) ], true ],
-				] ),
+			( postType, postId ) => [
+				{ kind: 'postType', name: postType, key: postId },
+			],
 			{ maxSize: 1 }
 		);
 	}
@@ -65,13 +63,19 @@ export class PostPublishButton extends Component {
 		};
 	}
 
-	closeEntitiesSavedStates( savedById ) {
+	closeEntitiesSavedStates( savedEntities ) {
 		const { postType, postId } = this.props;
 		const { entitiesSavedStatesCallback } = this.state;
 		this.setState( { entitiesSavedStatesCallback: false }, () => {
 			if (
-				savedById &&
-				savedById.has( [ 'postType', postType, String( postId ) ] )
+				savedEntities &&
+				some(
+					savedEntities,
+					( elt ) =>
+						elt.kind === 'postType' &&
+						elt.name === postType &&
+						elt.key === postId
+				)
 			) {
 				// The post entity was checked, call the held callback from `createOnClick`.
 				entitiesSavedStatesCallback();

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { find, get, has, map, pick, mapValues, includes } from 'lodash';
+import { find, get, has, map, pick, mapValues, includes, some } from 'lodash';
 import createSelector from 'rememo';
 
 /**
@@ -149,51 +149,17 @@ export const hasNonPostEntityChanges = createRegistrySelector(
 			return false;
 		}
 
-		const entityRecordChangesByRecord = select(
+		const dirtyEntityRecords = select(
 			'core'
-		).getEntityRecordChangesByRecord();
-		const changedKinds = Object.keys( entityRecordChangesByRecord );
-		if (
-			changedKinds.length > 1 ||
-			( changedKinds.length === 1 &&
-				! entityRecordChangesByRecord.postType )
-		) {
-			// Return true if there is more than one edited entity kind
-			// or the edited entity kind is not the editor's post's kind.
-			return true;
-		} else if ( ! entityRecordChangesByRecord.postType ) {
-			// Don't continue if there are no edited entity kinds.
-			return false;
-		}
-
+		).__experimentalGetDirtyEntityRecords();
 		const { type, id } = getCurrentPost( state );
-		const changedPostTypes = Object.keys(
-			entityRecordChangesByRecord.postType
+		return some(
+			dirtyEntityRecords,
+			( entityRecord ) =>
+				entityRecord.kind !== 'postType' ||
+				entityRecord.name !== type ||
+				entityRecord.key !== id
 		);
-		if (
-			changedPostTypes.length > 1 ||
-			( changedPostTypes.length === 1 &&
-				! entityRecordChangesByRecord.postType[ type ] )
-		) {
-			// Return true if there is more than one edited post type
-			// or the edited entity's post type is not the editor's post's post type.
-			return true;
-		}
-
-		const changedPosts = Object.keys(
-			entityRecordChangesByRecord.postType[ type ]
-		);
-		if (
-			changedPosts.length > 1 ||
-			( changedPosts.length === 1 &&
-				! entityRecordChangesByRecord.postType[ type ][ id ] )
-		) {
-			// Return true if there is more than one edited post
-			// or the edited post is not the editor's post.
-			return true;
-		}
-
-		return false;
 	}
 );
 

--- a/packages/editor/src/store/test/selectors.js
+++ b/packages/editor/src/store/test/selectors.js
@@ -33,10 +33,10 @@ selectorNames.forEach( ( name ) => {
 				return state.currentPost;
 			},
 
-			getEntityRecordChangesByRecord() {
+			__experimentalGetDirtyEntityRecords() {
 				return (
-					state.getEntityRecordChangesByRecord &&
-					state.getEntityRecordChangesByRecord()
+					state.__experimentalGetDirtyEntityRecords &&
+					state.__experimentalGetDirtyEntityRecords()
 				);
 			},
 
@@ -461,8 +461,10 @@ describe( 'selectors', () => {
 				editorSettings: {
 					__experimentalEnableFullSiteEditing: false,
 				},
-				getEntityRecordChangesByRecord() {
-					return { someKind: { someName: { someKey: {} } } };
+				__experimentalGetDirtyEntityRecords() {
+					return [
+						{ kind: 'someKind', name: 'someName', key: 'someKey' },
+					];
 				},
 			};
 			expect( hasNonPostEntityChanges( state ) ).toBe( false );
@@ -473,8 +475,10 @@ describe( 'selectors', () => {
 				editorSettings: {
 					__experimentalEnableFullSiteEditing: true,
 				},
-				getEntityRecordChangesByRecord() {
-					return { someKind: { someName: { someKey: {} } } };
+				__experimentalGetDirtyEntityRecords() {
+					return [
+						{ kind: 'someKind', name: 'someName', key: 'someKey' },
+					];
 				},
 			};
 			expect( hasNonPostEntityChanges( state ) ).toBe( true );
@@ -485,8 +489,8 @@ describe( 'selectors', () => {
 				editorSettings: {
 					__experimentalEnableFullSiteEditing: true,
 				},
-				getEntityRecordChangesByRecord() {
-					return { postType: { post: { 1: {} } } };
+				__experimentalGetDirtyEntityRecords() {
+					return [ { kind: 'postType', name: 'post', key: 1 } ];
 				},
 			};
 			expect( hasNonPostEntityChanges( state ) ).toBe( false );
@@ -497,8 +501,11 @@ describe( 'selectors', () => {
 				editorSettings: {
 					__experimentalEnableFullSiteEditing: true,
 				},
-				getEntityRecordChangesByRecord() {
-					return { postType: { post: { 1: {}, 2: {} } } };
+				__experimentalGetDirtyEntityRecords() {
+					return [
+						{ kind: 'postType', name: 'post', key: 1 },
+						{ kind: 'postType', name: 'post', key: 2 },
+					];
 				},
 			};
 			expect( hasNonPostEntityChanges( state ) ).toBe( true );
@@ -509,10 +516,11 @@ describe( 'selectors', () => {
 				editorSettings: {
 					__experimentalEnableFullSiteEditing: true,
 				},
-				getEntityRecordChangesByRecord() {
-					return {
-						postType: { post: { 1: {} }, wp_template: { 1: {} } },
-					};
+				__experimentalGetDirtyEntityRecords() {
+					return [
+						{ kind: 'postType', name: 'post', key: 1 },
+						{ kind: 'postType', name: 'wp_template', key: 1 },
+					];
 				},
 			};
 			expect( hasNonPostEntityChanges( state ) ).toBe( true );


### PR DESCRIPTION
refs #20421 

This PR addresses the first step of #20421 and tries to have more user-friendly labels. It is though very hard to achieve in a generic way and this PR had to also introduce some changes to existing APIs.

<img width="431" alt="Capture d’écran 2020-03-03 à 1 47 34 PM" src="https://user-images.githubusercontent.com/272444/75777068-8dc01300-5d55-11ea-9a39-f0c27d426ff9.png">