### PR TITLE
PostTitle: be able to set post title via own prop

### DIFF
--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -39,7 +39,7 @@ function VisualEditor() {
 					<WritingFlow>
 						<ObserveTyping>
 							<CopyHandler>
-								<PostTitle />
+								<PostTitle title="Static Title Value!" />
 								<BlockList />
 							</CopyHandler>
 						</ObserveTyping>

--- a/packages/editor/src/components/post-title/index.js
+++ b/packages/editor/src/components/post-title/index.js
@@ -132,7 +132,7 @@ class PostTitle extends Component {
 	}
 }
 
-const applyWithSelect = withSelect( ( select, { title: ownTitle } ) => {
+const applyWithSelect = withSelect( ( select, { fallbackTitle: ownTitle } ) => {
 	const { getEditedPostAttribute, isCleanNewPost } = select( 'core/editor' );
 	const { getSettings } = select( 'core/block-editor' );
 	const { getPostType } = select( 'core' );

--- a/packages/editor/src/components/post-title/index.js
+++ b/packages/editor/src/components/post-title/index.js
@@ -132,7 +132,7 @@ class PostTitle extends Component {
 	}
 }
 
-const applyWithSelect = withSelect( ( select, { fallbackTitle: ownTitle } ) => {
+const applyWithSelect = withSelect( ( select, { fallbackTitle } ) => {
 	const { getEditedPostAttribute, isCleanNewPost } = select( 'core/editor' );
 	const { getSettings } = select( 'core/block-editor' );
 	const { getPostType } = select( 'core' );
@@ -141,7 +141,9 @@ const applyWithSelect = withSelect( ( select, { fallbackTitle: ownTitle } ) => {
 
 	return {
 		isCleanNewPost: isCleanNewPost(),
-		title: getEditedPostAttribute( 'title' ) || ownTitle,
+		title: fallbackTitle
+			? fallbackTitle
+			: getEditedPostAttribute( 'title' ),
 		isPostTypeViewable: get( postType, [ 'viewable' ], false ),
 		placeholder: titlePlaceholder,
 		isFocusMode: focusMode,

--- a/packages/editor/src/components/post-title/index.js
+++ b/packages/editor/src/components/post-title/index.js
@@ -132,7 +132,7 @@ class PostTitle extends Component {
 	}
 }
 
-const applyWithSelect = withSelect( ( select ) => {
+const applyWithSelect = withSelect( ( select, { title: ownTitle } ) => {
 	const { getEditedPostAttribute, isCleanNewPost } = select( 'core/editor' );
 	const { getSettings } = select( 'core/block-editor' );
 	const { getPostType } = select( 'core' );
@@ -141,7 +141,7 @@ const applyWithSelect = withSelect( ( select ) => {
 
 	return {
 		isCleanNewPost: isCleanNewPost(),
-		title: getEditedPostAttribute( 'title' ),
+		title: getEditedPostAttribute( 'title' ) || ownTitle,
 		isPostTypeViewable: get( postType, [ 'viewable' ], false ),
 		placeholder: titlePlaceholder,
 		isFocusMode: focusMode,


### PR DESCRIPTION
## Description
This PR proposes to be able to set the title prop of the `<PostTitle />` explicitly.~, giving priority to the post title attribute, trying to guarantee it won't affect the current and natural behavior of the component.~

Particularly, we are working on some stuff related to the page preview, and we'd like to use `<PostTitle />` component on this context, where among many particularities, the site post doesn't exist. With the current implementation, is not possible to set arbitrarily the title.

## How has this been tested?

* Start to create a new post. It should the placeholder text, as usual.

![image](https://user-images.githubusercontent.com/77539/75778345-5d1cb100-5d36-11ea-8772-258b47417390.png)

* Edit a post. You should see the post title, as usual.

![image](https://user-images.githubusercontent.com/77539/75778428-88070500-5d36-11ea-8720-bba87c78b2a2.png)

* Try to play with this component passing the `<PostTitle />` as property. Just for testing purposes, I've edited the [<VisualEditor /> component](https://github.com/WordPress/gutenberg/blob/742dbf2ef0e37481a3c14c29f3688aa0cd3cf887/packages/edit-post/src/components/visual-editor/index.js#L42) with something like this:

```es6
//....
<ObserveTyping>
	<CopyHandler>
		<PostTitle fallbackTitle="Static Title Value!" />
		<BlockList />
	</CopyHandler>
</ObserveTyping>
//....
```

![image](https://user-images.githubusercontent.com/77539/75778742-22ffdf00-5d37-11ea-972d-8483c98af84c.png)

~The static title value should be shown only if the post doesn't have defined a title. Once the post gets its title value, it should be shown properly.~

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->