### PR TITLE
Fix: Custom color formatter may end up "bouncing"

### DIFF
--- a/packages/format-library/src/text-color/inline.js
+++ b/packages/format-library/src/text-color/inline.js
@@ -39,7 +39,10 @@ export function getActiveColor( formatName, formatValue, colors ) {
 	}
 }
 
-const ColorPopoverAtLink = ( { isActive, addingColor, value, ...props } ) => {
+const ColorPopoverAtLink = ( { addingColor, ...props } ) => {
+	// There is no way to open a text formatter popover when another one is mounted.
+	// The first popover will always be dismounted when a click outside happens, so we can store the
+	// anchor Rect during the lifetime of the component.
 	const anchorRect = useMemo( () => {
 		const selection = window.getSelection();
 		const range =
@@ -65,7 +68,7 @@ const ColorPopoverAtLink = ( { isActive, addingColor, value, ...props } ) => {
 		if ( closest ) {
 			return closest.getBoundingClientRect();
 		}
-	}, [ isActive, addingColor, value.start, value.end ] );
+	}, [] );
 
 	if ( ! anchorRect ) {
 		return null;


### PR DESCRIPTION
Fixes: https://core.trac.wordpress.org/ticket/49568


## How has this been tested?
I added a paragraph with some text.
I opened the formater menu and applied a custom text color to the paragraph using the mouse.
I manually applied the "red" color (I verified that the popover did not start moving randomly around the screen).
I selected another part of the text in the paragraph I applied a custom color and verified the popovers positions for both parts of the paragraph with colors are correct close to the part of text they refer to.

