### PR TITLE
Cherry pick: fullscreen by default into wp-trunk

### DIFF
--- a/packages/e2e-test-utils/src/create-new-post.js
+++ b/packages/e2e-test-utils/src/create-new-post.js
@@ -32,6 +32,9 @@ export async function createNewPost( {
 	const isWelcomeGuideActive = await page.evaluate( () =>
 		wp.data.select( 'core/edit-post' ).isFeatureActive( 'welcomeGuide' )
 	);
+	const isFullscreenMode = await page.evaluate( () =>
+		wp.data.select( 'core/edit-post' ).isFeatureActive( 'fullscreenMode' )
+	);
 
 	if ( showWelcomeGuide !== isWelcomeGuideActive ) {
 		await page.evaluate( () =>
@@ -39,5 +42,13 @@ export async function createNewPost( {
 		);
 
 		await page.reload();
+	}
+
+	if ( isFullscreenMode ) {
+		await page.evaluate( () =>
+			wp.data
+				.dispatch( 'core/edit-post' )
+				.toggleFeature( 'fullscreenMode' )
+		);
 	}
 }

--- a/packages/edit-post/src/store/defaults.js
+++ b/packages/edit-post/src/store/defaults.js
@@ -10,6 +10,7 @@ export const PREFERENCES_DEFAULTS = {
 		fixedToolbar: false,
 		showInserterHelpPanel: true,
 		welcomeGuide: true,
+		fullscreenMode: true,
 	},
 	pinnedPluginItems: {},
 	hiddenBlockTypes: [],


### PR DESCRIPTION
This PR cherry picks https://github.com/WordPress/gutenberg/pull/20611 by @youknowriad into the trunk branch.