### PR TITLE
Styles Panel: Don't force it to be closed by default.

### DIFF
--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -64,7 +64,7 @@ const BlockInspector = ( {
 			<BlockCard blockType={ blockType } />
 			{ hasBlockStyles && (
 				<div>
-					<PanelBody title={ __( 'Styles' ) } initialOpen={ false }>
+					<PanelBody title={ __( 'Styles' ) }>
 						<BlockStyles clientId={ selectedBlockClientId } />
 						<DefaultStylePicker blockName={ blockType.name } />
 					</PanelBody>


### PR DESCRIPTION
## Description

#6038 originally hid the Advanced panel by default, which I agree is the correct behaviour. In #10543, which turned the Advanced panel into the Styles panel, this behaviour was retained.

Whilst working on Automattic/jetpack#14852, I found the inability to set the `initialOpen` value of the Styles panel to be a little frustrating, but on further investigation, I'm inclined to think that #10543 incorrectly retained this behaviour from the Advanced panel, and it should be changed.

## How has this been tested?

Tested against Automattic/jetpack#14852.

It can also be tested against Core blocks that provide styles: for example, the Quote block.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows the accessibility standards.
- [x] My code has proper inline documentation.
- [x] I've included developer documentation if appropriate.
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR.
