### PR TITLE
Add e2e test for image block

### DIFF
--- a/packages/e2e-tests/specs/editor/blocks/image.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/image.test.js
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+import path from 'path';
+import fs from 'fs';
+import os from 'os';
+import uuid from 'uuid/v4';
+
+/**
+ * WordPress dependencies
+ */
+import {
+	insertBlock,
+	getEditedPostContent,
+	createNewPost,
+} from '@wordpress/e2e-test-utils';
+
+describe( 'Image', () => {
+	beforeEach( async () => {
+		await createNewPost();
+	} );
+
+	it( 'can be inserted', async () => {
+		await insertBlock( 'Image' );
+		await page.waitForSelector( '.wp-block-image input[type="file"]' );
+		const inputElement = await page.$(
+			'.wp-block-image input[type="file"]'
+		);
+		const testImagePath = path.join(
+			__dirname,
+			'..',
+			'..',
+			'..',
+			'assets',
+			'10x10_e2e_test_image_z9T8jK.png'
+		);
+		const filename = uuid();
+		const tmpFileName = path.join( os.tmpdir(), filename + '.png' );
+		fs.copyFileSync( testImagePath, tmpFileName );
+		await inputElement.uploadFile( tmpFileName );
+		await page.waitForSelector( '.wp-block-image img[src^="http"]' );
+
+		// Check the content.
+		const regex = new RegExp(
+			`<!-- wp:image {"id":\\d+,"sizeSlug":"large"} -->\\s*<figure class="wp-block-image size-large"><img src="[^"]+\\/${ filename }\\.png" alt="" class="wp-image-\\d+"/></figure>\\s*<!-- \\/wp:image -->`
+		);
+		expect( await getEditedPostContent() ).toMatch( regex );
+	} );
+} );


### PR DESCRIPTION
## Description

I saw we don't have any e2e tests for the image block yet. This adds a basic one uploading an image.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
