### PR TITLE
Removed the textarea width restriction for the Shortcode block

### DIFF
--- a/packages/block-library/src/shortcode/editor.scss
+++ b/packages/block-library/src/shortcode/editor.scss
@@ -16,7 +16,6 @@
 	}
 
 	.block-editor-plain-text {
-		width: 80%;
 		max-height: 250px;
 	}
 


### PR DESCRIPTION
## Description
Fixes #11079. 
Removed the textarea width restriction in CSS so that the textarea is full width now.

## How has this been tested?
Tested locally.

## Screenshots <!-- if applicable -->

**BEFORE**

![before](https://user-images.githubusercontent.com/617986/75890103-c0641d00-5de2-11ea-8d86-94320850afdb.png)

**AFTER**

![after](https://user-images.githubusercontent.com/617986/75890115-c4903a80-5de2-11ea-8485-84be4268224a.png)


## Types of changes
Non-breaking CSS changes only.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
