### PR TITLE
Block: only focus wrapper on select

### DIFF
--- a/packages/block-editor/src/components/block-list/block-wrapper.js
+++ b/packages/block-editor/src/components/block-list/block-wrapper.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { first, last, omit } from 'lodash';
+import { omit } from 'lodash';
 import { animated } from 'react-spring/web.cjs';
 
 /**
@@ -15,7 +15,7 @@ import {
 	useContext,
 	forwardRef,
 } from '@wordpress/element';
-import { focus, isTextField, placeCaretAtHorizontalEdge } from '@wordpress/dom';
+import { isTextField, placeCaretAtHorizontalEdge } from '@wordpress/dom';
 import { BACKSPACE, DELETE, ENTER } from '@wordpress/keycodes';
 import { __, sprintf } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -23,7 +23,6 @@ import { useSelect, useDispatch } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { isInsideRootBlock } from '../../utils/dom';
 import useMovingAnimation from './moving-animation';
 import { Context, BlockNodes } from './root-container';
 import { BlockContext } from './block';
@@ -105,22 +104,9 @@ const BlockComponent = forwardRef(
 				return;
 			}
 
-			// Find all tabbables within node.
-			const textInputs = focus.tabbable
-				.find( wrapper.current )
-				.filter( isTextField )
-				// Exclude inner blocks
-				.filter( ( node ) =>
-					isInsideRootBlock( wrapper.current, node )
-				);
-
-			// If reversed (e.g. merge via backspace), use the last in the set of
-			// tabbables.
 			const isReverse = -1 === initialPosition;
-			const target =
-				( isReverse ? last : first )( textInputs ) || wrapper.current;
 
-			placeCaretAtHorizontalEdge( target, isReverse );
+			placeCaretAtHorizontalEdge( wrapper.current, isReverse );
 		};
 
 		useEffect( () => {


### PR DESCRIPTION
## Description

This PR simplifies block focus logic (after block selection) to only ever focus the block wrapper (and set the caret if needed and the wrapper is content editable). This is possible since the base blocks are light and content editable elements are no longer nested.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
