### PR TITLE
Add new option to dependency-group ESLint rule

### DIFF
--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Master
 
+### Enhancements
+
+- Added new `isInternalDependencyPatterns` option to `@wordpress/dependency-group` that allows marking aliased dependencies as internal ones.
+
 ## 4.0.0 (2020-02-10)
 
 ### Breaking Changes

--- a/packages/eslint-plugin/docs/rules/dependency-group.md
+++ b/packages/eslint-plugin/docs/rules/dependency-group.md
@@ -34,3 +34,9 @@ import { Component } from '@wordpress/element';
  */
 import edit from './edit';
 ```
+
+## Options
+
+This rule accepts a single option:
+
+- Set `isInternalDependencyPatterns` to specify a list of regular expressions that can be used to mark a specific dependency as internal.

--- a/packages/eslint-plugin/rules/__tests__/dependency-group.js
+++ b/packages/eslint-plugin/rules/__tests__/dependency-group.js
@@ -48,16 +48,13 @@ import { Component } from '@wordpress/element';
 import edit from './edit';`,
 			errors: [
 				{
-					message:
-						'Expected preceding "External dependencies" comment block',
+					messageId: 'expectExternal',
 				},
 				{
-					message:
-						'Expected preceding "WordPress dependencies" comment block',
+					messageId: 'expectWordPress',
 				},
 				{
-					message:
-						'Expected preceding "Internal dependencies" comment block',
+					messageId: 'expectInternal',
 				},
 			],
 			output: `

--- a/packages/eslint-plugin/rules/__tests__/dependency-group.js
+++ b/packages/eslint-plugin/rules/__tests__/dependency-group.js
@@ -35,6 +35,28 @@ import { Component } from '@wordpress/element';
  */
 import edit from './edit';`,
 		},
+		{
+			code: `
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import CoolComponent from 'my-awesome-alias';
+import edit from './edit';`,
+			options: [
+				{ isInternalDependencyPatterns: [ '^my-awesome-alias$' ] },
+			],
+		},
 	],
 	invalid: [
 		{

--- a/packages/eslint-plugin/rules/dependency-group.js
+++ b/packages/eslint-plugin/rules/dependency-group.js
@@ -8,6 +8,14 @@ module.exports = {
 		},
 		schema: [],
 		fixable: true,
+		messages: {
+			expectExternal:
+				'Expected preceding "External dependencies" comment block',
+			expectWordPress:
+				'Expected preceding "WordPress dependencies" comment block',
+			expectInternal:
+				'Expected preceding "Internal dependencies" comment block',
+		},
 	},
 	create( context ) {
 		const comments = context.getSourceCode().getAllComments();
@@ -204,7 +212,7 @@ module.exports = {
 
 					context.report( {
 						node: child,
-						message: `Expected preceding "${ locality } dependencies" comment block`,
+						messageId: `expect${ locality }`,
 						fix( fixer ) {
 							const { comment, value } = correction;
 							const text = `/*${ value }*/`;

--- a/packages/eslint-plugin/rules/dependency-group.js
+++ b/packages/eslint-plugin/rules/dependency-group.js
@@ -6,7 +6,21 @@ module.exports = {
 			url:
 				'https://github.com/WordPress/gutenberg/blob/master/packages/eslint-plugin/docs/rules/dependency-group.md',
 		},
-		schema: [],
+		schema: [
+			{
+				type: 'object',
+				properties: {
+					isInternalDependencyPatterns: {
+						type: 'array',
+						items: {
+							type: 'string',
+						},
+						uniqueItems: true,
+					},
+				},
+				additionalProperties: false,
+			},
+		],
 		fixable: true,
 		messages: {
 			expectExternal:
@@ -155,6 +169,9 @@ module.exports = {
 
 		return {
 			Program( node ) {
+				const options = context.options[ 0 ] || {};
+				const { isInternalDependencyPatterns = [] } = options;
+
 				/**
 				 * The set of package localities which have been reported for
 				 * the current program. Each locality is reported at most one
@@ -192,7 +209,16 @@ module.exports = {
 						return;
 					}
 
-					const locality = getPackageLocality( source );
+					let locality = getPackageLocality( source );
+
+					const isInternalDependency = isInternalDependencyPatterns.some(
+						( pattern ) => source.match( pattern )
+					);
+
+					if ( isInternalDependency ) {
+						locality = 'Internal';
+					}
+
 					if ( verified.has( locality ) ) {
 						return;
 					}


### PR DESCRIPTION
## Description

Allows passing regex to mark specific dependencies as internal ones. Example:

```
{ isInternalDependencyPatterns: [ '^my-project' ] }
```

Fixes #16789.

## How has this been tested?

Added new tests

## Screenshots <!-- if applicable -->

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
