### PR TITLE
Add Rich image editing capabilities to Gutenberg

### DIFF
--- a/lib/class-wp-rest-image-editor.php
+++ b/lib/class-wp-rest-image-editor.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * Registers the Image Editing API endpoints
+ *
+ * @since 7.x ?
+ */
+
+include_once __DIR__ . '/image-editor/image-editor.php';
+
+class WP_REST_Image_Editor_API extends WP_REST_Controller {
+	private static $instance = null;
+
+	const API_NAMESPACE = '__experimental';
+	const API_BASE = '/richimage/(?P<mediaID>[\d]+)';
+
+	public static function init() {
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new WP_REST_Image_Editor_API();
+		}
+
+		return self::$instance;
+	}
+
+	private function get_rest_params( $callback, $args ) {
+		return [
+			[
+				'methods' => WP_REST_Server::EDITABLE,
+				'callback' => $callback,
+				'permission_callback' => [ $this, 'permission_callback' ],
+				'args' => $args,
+			],
+		];
+	}
+
+	public function __construct() {
+		register_rest_route(
+			self::API_NAMESPACE,
+			self::API_BASE . '/rotate',
+			$this->get_rest_params(
+				[ $this, 'rotate_image' ],
+				[
+					'angle' => [
+						'type' => 'integer',
+						'required' => true,
+					],
+				]
+			)
+		);
+
+		register_rest_route(
+			self::API_NAMESPACE,
+			self::API_BASE . '/flip',
+			$this->get_rest_params(
+				[ $this, 'flip_image' ],
+				[
+					'direction' => [
+						'type' => 'enum',
+						'enum' => [ 'vertical', 'horizontal' ],
+						'required' => true,
+					],
+				]
+			)
+		);
+
+		register_rest_route(
+			self::API_NAMESPACE,
+			self::API_BASE . '/crop',
+			$this->get_rest_params(
+				[ $this, 'crop_image' ],
+				[
+					'cropX' => [
+						'type' => 'integer',
+						'minimum' => 0,
+						'required' => true,
+					],
+					'cropY' => [
+						'type' => 'integer',
+						'minimum' => 0,
+						'required' => true,
+					],
+					'cropWidth' => [
+						'type' => 'integer',
+						'minimum' => 1,
+						'required' => true,
+					],
+					'cropHeight' => [
+						'type' => 'integer',
+						'minimum' => 1,
+						'required' => true,
+					],
+				]
+			)
+		);
+	}
+
+	public function permission_callback( WP_REST_Request $request ) {
+		$params = $request->get_params();
+
+		return current_user_can( 'edit_post', $params['mediaID'] );
+	}
+
+	public function rotate_image( WP_REST_Request $request ) {
+		$params = $request->get_params();
+
+		$editor = new Image_Editor();
+		$modifier = new Image_Editor_Rotate( $params['angle'] );
+
+		return $editor->modify_image( $params['mediaID'], $modifier );
+	}
+
+	public function flip_image( WP_REST_Request $request ) {
+		$params = $request->get_params();
+
+		$editor = new Image_Editor();
+		$modifier = new Image_Editor_Flip( $params['direction'] );
+
+		return $editor->modify_image( $params['mediaID'], $modifier );
+	}
+
+	public function crop_image( WP_REST_Request $request ) {
+		$params = $request->get_params();
+
+		$editor = new Image_Editor();
+		$modifier = new Image_Editor_Crop( $params['cropX'], $params['cropY'], $params['cropWidth'], $params['cropHeight'] );
+
+		return $editor->modify_image( $params['mediaID'], $modifier );
+	}
+}

--- a/lib/image-editor/image-crop.php
+++ b/lib/image-editor/image-crop.php
@@ -1,0 +1,52 @@
+<?php
+
+class Image_Editor_Crop extends Image_Editor_Modifier {
+	private $crop_x = 0;
+	private $crop_y = 0;
+	private $width = 0;
+	private $height = 0;
+
+	public function __construct( $crop_x, $crop_y, $width, $height ) {
+		$this->crop_x = floatval( $crop_x );
+		$this->crop_y = floatval( $crop_y );
+		$this->width = floatval( $width );
+		$this->height = floatval( $height );
+	}
+
+	public function apply_to_meta( array $meta ) {
+		$meta['cropX'] = $this->crop_x;
+		$meta['cropY'] = $this->crop_y;
+		$meta['cropWidth'] = $this->width;
+		$meta['cropHeight'] = $this->height;
+
+		return $meta;
+	}
+
+	public function apply_to_image( $image, array $info, $target_file ) {
+		$size = $image->get_size();
+
+		$crop_x = round( ( $size['width'] * $this->crop_x ) / 100.0 );
+		$crop_y = round( ( $size['height'] * $this->crop_y ) / 100.0 );
+		$width = round( ( $size['width'] * $this->width ) / 100.0 );
+		$height = round( ( $size['height'] * $this->height ) / 100.0 );
+
+		$image->crop( $crop_x, $crop_y, $width, $height );
+
+		// We need to change the original name to include the crop. This way if it's cropped again we won't clash
+		$info['meta']['original_name'] = $target_file;
+
+		return $info;
+	}
+
+	public static function get_filename( array $meta ) {
+		if ( isset( $meta['cropWidth'] ) && $meta['cropWidth'] > 0 ) {
+			return sprintf( 'crop-%d-%d-%d-%d', round( $meta['cropX'], 2 ), round( $meta['cropY'], 2 ), round( $meta['cropWidth'], 2 ), round( $meta['cropHeight'], 2 ) );
+		}
+
+		return false;
+	}
+
+	public static function get_default_meta() {
+		return [];
+	}
+}

--- a/lib/image-editor/image-editor.php
+++ b/lib/image-editor/image-editor.php
@@ -1,0 +1,177 @@
+<?php
+
+require_once __DIR__ . '/image-flip.php';
+require_once __DIR__ . '/image-rotate.php';
+require_once __DIR__ . '/image-crop.php';
+
+abstract class Image_Editor_Modifier {
+	abstract public function apply_to_meta( array $meta );
+	abstract public function apply_to_image( $image, array $meta, $target_file );
+	abstract public static function get_filename( array $meta );
+	abstract public static function get_default_meta();
+}
+
+class Image_Editor {
+	const META_KEY = 'richimage';
+
+	public function modify_image( $media_id, Image_Editor_Modifier $modifier ) {
+		// Get image information
+		$info = $this->load_image_info( $media_id );
+		if ( is_wp_error( $info ) ) {
+			return $info;
+		}
+
+		// Update it with our modifier
+		$info['meta'] = $modifier->apply_to_meta( $info['meta'] );
+
+		// Generate filename based on current attributes
+		$target_file = $this->get_filename( $info['meta'] );
+
+		// Does the image already exist?
+		$image = $this->get_existing_image( $info, $target_file );
+		if ( $image ) {
+			// Return the existing image
+			return $image;
+		}
+
+		// Try and load the image itself
+		$image = $this->load_image( $media_id, $info );
+		if ( is_wp_error( $image ) ) {
+			return $image;
+		}
+
+		// Finally apply the modification
+		$info = $modifier->apply_to_image( $image['editor'], $info, $target_file );
+
+		// And save
+		return $this->save_image( $image, $target_file, $info );
+	}
+
+	private function load_image( $media_id ) {
+		require_once ABSPATH . 'wp-admin/includes/image.php';
+
+		$attachment_meta = wp_get_attachment_metadata( $media_id );
+		$image_path = get_attached_file( $media_id );
+
+		if ( empty( $image_path ) ) {
+			return new WP_Error( 'fileunknown', 'Unable to find original media file' );
+		}
+
+		$image_editor = wp_get_image_editor( $image_path );
+		if ( ! $image_editor->load() ) {
+			return new WP_Error( 'fileload', 'Unable to load original media file' );
+		}
+
+		return [
+			'editor' => $image_editor,
+			'path' => $image_path,
+		];
+	}
+
+	private function get_image_as_json( $id ) {
+		return [
+			'mediaID' => $id,
+			'url' => wp_get_attachment_image_url( $id, 'original' ),
+		];
+	}
+
+	private function get_existing_image( $attachment, $target_file ) {
+		$url = str_replace( basename( $attachment['url'] ), $target_file, $attachment['url'] );
+
+		$new_id = attachment_url_to_postid( $url );
+		if ( $new_id > 0 ) {
+			return $this->get_image_as_json( $new_id );
+		}
+
+		return false;
+	}
+
+	private function save_image( $image, $target_name, $attachment ) {
+		$filename = rtrim( dirname( $image['path'] ), '/' ) . '/' . $target_name;
+
+		// Save to disk
+		$saved = $image['editor']->save( $filename );
+
+		if ( is_wp_error( $saved ) ) {
+			return $saved;
+		}
+
+		// Update attachment details
+		$attachment_post = [
+			'guid'           => $saved['path'],
+			'post_mime_type' => $saved['mime-type'],
+			'post_title'     => pathinfo( $target_name, PATHINFO_FILENAME ),
+			'post_content'   => '',
+			'post_status'    => 'inherit',
+		];
+
+		// Add this as an attachment
+		$attachment_id = wp_insert_attachment( $attachment_post, $saved['path'], 0 );
+		if ( $attachment_id === 0 ) {
+			return new WP_Error( 'attachment', 'Unable to add image as attachment' );
+		}
+
+		// Generate thumbnails
+		$metadata = wp_generate_attachment_metadata( $attachment_id, $saved['path'] );
+
+		// Store out meta data
+		$metadata[ self::META_KEY ] = $attachment['meta'];
+
+		wp_update_attachment_metadata( $attachment_id, $metadata );
+
+		return $this->get_image_as_json( $attachment_id );
+	}
+
+	private function get_all_modifiers() {
+		return [
+			'Image_Editor_Crop',
+			'Image_Editor_Flip',
+			'Image_Editor_Rotate',
+		];
+	}
+
+	private function get_filename( $meta ) {
+		$parts = [];
+
+		foreach ( $this->get_all_modifiers() as $modifier ) {
+			$parts[] = $modifier::get_filename( $meta );
+		}
+
+		$parts = array_filter( $parts );
+
+		if ( count( $parts ) > 0 ) {
+			return sprintf( '%s-%s', implode( '-', $parts ), $meta['original_name'] );
+		}
+
+		return $meta['original_name'];
+	}
+
+	private function load_image_info( $media_id ) {
+		$attachment_info = wp_get_attachment_metadata( $media_id );
+		$media_url = wp_get_attachment_image_url( $media_id, 'original' );
+
+		if ( ! $attachment_info || ! $media_url ) {
+			return new WP_Error( 'unknown', 'Unable to get meta information for file' );
+		}
+
+		$default_meta = [];
+		foreach ( $this->get_all_modifiers() as $modifier ) {
+			$default_meta = array_merge( $default_meta, $modifier::get_default_meta() );
+		}
+
+		$info = [
+			'url' => $media_url,
+			'media_id' => $media_id,
+			'meta' => array_merge(
+				$default_meta,
+				[ 'original_name' => basename( $media_url ) ]
+			),
+		];
+
+		if ( isset( $attachment_info[ self::META_KEY ] ) ) {
+			$info['meta'] = array_merge( $info['meta'], $attachment_info[ self::META_KEY ] );
+		}
+
+		return $info;
+	}
+}

--- a/lib/image-editor/image-flip.php
+++ b/lib/image-editor/image-flip.php
@@ -1,0 +1,62 @@
+<?php
+
+class Image_Editor_Flip extends Image_Editor_Modifier {
+	private $direction = 'vertical';
+
+	public function __construct( $direction ) {
+		$this->direction = 'vertical';
+
+		if ( $direction === 'horizontal' ) {
+			$this->direction = $direction;
+		}
+	}
+
+	public function apply_to_meta( $meta ) {
+		if ( $this->is_vertical() ) {
+			$meta['flipv'] = ! $meta['flipv'];
+		} elseif ( $this->is_horizontal() ) {
+			$meta['flipH'] = ! $meta['flipH'];
+		}
+
+		return $meta;
+	}
+
+	public function apply_to_image( $image, array $info, $target_file ) {
+		$image->flip( $this->is_vertical(), $this->is_horizontal() );
+
+		return $info;
+	}
+
+	private function is_vertical() {
+		return $this->direction === 'vertical';
+	}
+
+	private function is_horizontal() {
+		return $this->direction === 'horizontal';
+	}
+
+	public static function get_filename( array $meta ) {
+		$parts = [];
+
+		if ( $meta['flipH'] ) {
+			$parts[] = 'fliph';
+		}
+
+		if ( $meta['flipv'] ) {
+			$parts[] = 'flipv';
+		}
+
+		if ( count( $parts ) > 0 ) {
+			return implode( '-', $parts );
+		}
+
+		return false;
+	}
+
+	public static function get_default_meta() {
+		return [
+			'flipH' => false,
+			'flipv' => false,
+		];
+	}
+}

--- a/lib/image-editor/image-rotate.php
+++ b/lib/image-editor/image-rotate.php
@@ -1,0 +1,44 @@
+<?php
+
+class Image_Editor_Rotate extends Image_Editor_Modifier {
+	private $angle = 0;
+
+	public function __construct( $angle ) {
+		$this->angle = $this->restrict_angle( intval( $angle, 10 ) );
+	}
+
+	public function apply_to_meta( $meta ) {
+		$meta['rotate'] += $this->angle;
+		$meta['rotate'] = $this->restrict_angle( $meta['rotate'] );
+
+		return $meta;
+	}
+
+	public function apply_to_image( $image, array $info, $target_file ) {
+		$image->rotate( 0 - $this->angle );
+
+		return $info;
+	}
+
+	private function restrict_angle( $angle ) {
+		if ( $angle >= 360 ) {
+			$angle = $angle % 360;
+		} elseif ( $angle < 0 ) {
+			$angle = 360 - ( abs( $angle ) % 360 );
+		}
+
+		return $angle;
+	}
+
+	public static function get_filename( array $meta ) {
+		if ( $meta['rotate'] > 0 ) {
+			return 'rotate-' . intval( $meta['rotate'], 10 );
+		}
+
+		return false;
+	}
+
+	public static function get_default_meta() {
+		return [ 'rotate' => 0 ];
+	}
+}

--- a/lib/load.php
+++ b/lib/load.php
@@ -39,6 +39,11 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	if ( ! class_exists( 'WP_REST_Block_Directory_Controller' ) ) {
 		require dirname( __FILE__ ) . '/class-wp-rest-block-directory-controller.php';
 	}
+
+	if ( ! class_exists( 'WP_REST_Image_Editor_API' ) ) {
+		error_log("YO!!!");
+		require dirname( __FILE__ ) . '/class-wp-rest-image-editor.php';
+	}
 	/**
 	* End: Include for phase 2
 	*/

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -93,3 +93,13 @@ function gutenberg_register_rest_block_directory() {
 	$block_directory_controller->register_routes();
 }
 add_filter( 'rest_api_init', 'gutenberg_register_rest_block_directory' );
+
+/**
+ * Registers the image editor.
+ *
+ * @since 7.x.0
+ */
+function gutenberg_register_image_editor_api() {
+	WP_REST_Image_Editor_API::init();
+}
+add_filter( 'rest_api_init', 'gutenberg_register_image_editor_api' );

--- a/package-lock.json
+++ b/package-lock.json
@@ -10135,6 +10135,7 @@
 				"lodash": "^4.17.15",
 				"memize": "^1.0.5",
 				"moment": "^2.22.1",
+				"react-image-crop": "^8.5.0",
 				"tinycolor2": "^1.4.1",
 				"url": "^0.11.0"
 			}
@@ -14703,6 +14704,11 @@
 				"is-regexp": "^1.0.0",
 				"is-supported-regexp-flag": "^1.0.0"
 			}
+		},
+		"clsx": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.0.tgz",
+			"integrity": "sha512-3avwM37fSK5oP6M5rQ9CNe99lwxhXDOeSWVPAOYF6OazUTgZCMb0yWlJpmdD74REy1gkEaFiub2ULv4fq9GUhA=="
 		},
 		"co": {
 			"version": "4.6.0",
@@ -33347,6 +33353,23 @@
 			"dev": true,
 			"requires": {
 				"prop-types": "^15.6.1"
+			}
+		},
+		"react-image-crop": {
+			"version": "8.5.0",
+			"resolved": "https://registry.npmjs.org/react-image-crop/-/react-image-crop-8.5.0.tgz",
+			"integrity": "sha512-7wTg2AfMI1S6wYJxpEXxoO1MBKPoYB692AK3yb39bNnODdVcn8/eWDY/ucJ/JXeOGI2D6xbiViDsm4Jm/KQW0A==",
+			"requires": {
+				"clsx": "^1.0.4",
+				"core-js": "^3.4.2",
+				"prop-types": "^15.7.2"
+			},
+			"dependencies": {
+				"core-js": {
+					"version": "3.6.4",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.4.tgz",
+					"integrity": "sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw=="
+				}
 			}
 		},
 		"react-input-autosize": {

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -41,6 +41,7 @@
 		"@wordpress/editor": "file:../editor",
 		"@wordpress/element": "file:../element",
 		"@wordpress/escape-html": "file:../escape-html",
+		"@wordpress/hooks": "file:../hooks",
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/icons": "file:../icons",
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
@@ -55,6 +56,7 @@
 		"lodash": "^4.17.15",
 		"memize": "^1.0.5",
 		"moment": "^2.22.1",
+		"react-image-crop": "^8.5.0",
 		"tinycolor2": "^1.4.1",
 		"url": "^0.11.0"
 	},

--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -31,6 +31,7 @@
 @import "./post-excerpt/editor.scss";
 @import "./pullquote/editor.scss";
 @import "./quote/editor.scss";
+@import "./rich-image/editor.scss";
 @import "./rss/editor.scss";
 @import "./search/editor.scss";
 @import "./separator/editor.scss";

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -46,6 +46,7 @@ import * as nextpage from './nextpage';
 import * as preformatted from './preformatted';
 import * as pullquote from './pullquote';
 import * as reusableBlock from './block';
+import * as richImage from './rich-image';
 import * as rss from './rss';
 import * as search from './search';
 import * as group from './group';
@@ -164,6 +165,9 @@ export const registerCoreBlocks = () => {
 	if ( group ) {
 		setGroupingBlockName( group.name );
 	}
+	// attach richImage filters
+	// where should this live?
+	richImage.registerBlock();
 };
 
 /**

--- a/packages/block-library/src/rich-image/constants.js
+++ b/packages/block-library/src/rich-image/constants.js
@@ -1,0 +1,62 @@
+/**
+ * WordPress dependencies
+ */
+
+import { __ } from '@wordpress/i18n';
+
+export const isSupportedBlock = ( blockName ) =>
+	[ 'core/image', 'core/cover' ].includes( blockName );
+
+export const supportedFilters = [
+	{
+		title: __( 'Technicolor' ),
+		value: 'technicolor',
+	},
+	{
+		title: __( 'Black & White' ),
+		value: 'black-and-white',
+	},
+	{
+		title: __( 'Sunshine' ),
+		value: 'sunshine',
+	},
+	{
+		title: __( 'Aviator' ),
+		value: 'aviator',
+	},
+	{
+		title: __( 'Polar Vortex' ),
+		value: 'polar-vortex',
+	},
+	{
+		title: __( 'Rocketeer' ),
+		value: 'rocketeer',
+	},
+	{
+		title: __( 'Black Hole' ),
+		value: 'black-hole',
+	},
+];
+
+export const richImageAttributes = {
+	imageCropWidth: {
+		type: 'number',
+		default: 200,
+	},
+	imageCropHeight: {
+		type: 'number',
+		default: 200,
+	},
+	imageCropX: {
+		type: 'number',
+		default: 0,
+	},
+	imageCropY: {
+		type: 'number',
+		default: 0,
+	},
+	imageFilter: {
+		type: 'string',
+		default: '',
+	},
+};

--- a/packages/block-library/src/rich-image/editor.scss
+++ b/packages/block-library/src/rich-image/editor.scss
@@ -1,0 +1,404 @@
+// SASS variables for normal drag handle and bar size.
+// Override in your scss file by setting these variables FIRST, then including this file.
+$drag-handle-width: 10px !default;
+$drag-handle-height: 10px !default;
+$drag-bar-size: 6px !default;
+
+// Query to kick us into "mobile" mode with larger drag handles/bars.
+// See: https://developer.mozilla.org/en-US/docs/Web/CSS/@media/pointer
+$mobile-media-query: "(pointer: coarse)" !default;
+
+// Mobile handle/bar sizes.  Override as above.
+$drag-handle-mobile-width: 34px !default;
+$drag-handle-mobile-height: 34px !default;
+
+// Handle color/border.
+$drag-handle-background-colour: rgba(0, 0, 0, 0.2) !default;
+$drag-handle-border: 1px solid rgba(255, 255, 255, 0.7) !default;
+
+.ReactCrop {
+	position: relative;
+	display: inline-block;
+	cursor: crosshair;
+	overflow: hidden;
+	max-width: 100%;
+	background-color: #000;
+
+	&:focus {
+		outline: none;
+	}
+
+	&--disabled,
+	&--locked {
+		cursor: inherit;
+	}
+
+	&__image {
+		display: block;
+		max-width: 100%;
+		touch-action: manipulation;
+	}
+
+	&--crop-invisible &__image {
+		opacity: 0.5;
+	}
+
+	&__crop-selection {
+		position: absolute;
+		top: 0;
+		left: 0;
+		transform: translate3d(0, 0, 0);
+		box-sizing: border-box;
+		cursor: move;
+		box-shadow: 0 0 0 9999em rgba(0, 0, 0, 0.5);
+		touch-action: manipulation;
+
+		.ReactCrop--disabled & {
+			cursor: inherit;
+		}
+
+		.ReactCrop--circular-crop & {
+			border-radius: 50%;
+			box-shadow: 0 0 1px 1px #fff, 0 0 0 9999em rgba(0, 0, 0, 0.5);
+		}
+
+		border: 1px solid;
+		border-image-source: url(data:image/gif;base64,R0lGODlhCgAKAJECAAAAAP///////wAAACH/C05FVFNDQVBFMi4wAwEAAAAh/wtYTVAgRGF0YVhNUDw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuMy1jMDExIDY2LjE0NTY2MSwgMjAxMi8wMi8wNi0xNDo1NjoyNyAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wTU09Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9tbS8iIHhtbG5zOnN0UmVmPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvc1R5cGUvUmVzb3VyY2VSZWYjIiB4bWxuczp4bXA9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC8iIHhtcE1NOkRvY3VtZW50SUQ9InhtcC5kaWQ6OEI5RDc5MTFDNkE2MTFFM0JCMDZEODI2QTI4MzJBOTIiIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6OEI5RDc5MTBDNkE2MTFFM0JCMDZEODI2QTI4MzJBOTIiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENTNiAoTWFjaW50b3NoKSI+IDx4bXBNTTpEZXJpdmVkRnJvbSBzdFJlZjppbnN0YW5jZUlEPSJ4bXAuZGlkOjAyODAxMTc0MDcyMDY4MTE4MDgzQzNDMjA5MzREQ0ZDIiBzdFJlZjpkb2N1bWVudElEPSJ4bXAuZGlkOjAyODAxMTc0MDcyMDY4MTE4MDgzQzNDMjA5MzREQ0ZDIi8+IDwvcmRmOkRlc2NyaXB0aW9uPiA8L3JkZjpSREY+IDwveDp4bXBtZXRhPiA8P3hwYWNrZXQgZW5kPSJyIj8+Af/+/fz7+vn49/b19PPy8fDv7u3s6+rp6Ofm5eTj4uHg397d3Nva2djX1tXU09LR0M/OzczLysnIx8bFxMPCwcC/vr28u7q5uLe2tbSzsrGwr66trKuqqainpqWko6KhoJ+enZybmpmYl5aVlJOSkZCPjo2Mi4qJiIeGhYSDgoGAf359fHt6eXh3dnV0c3JxcG9ubWxramloZ2ZlZGNiYWBfXl1cW1pZWFdWVVRTUlFQT05NTEtKSUhHRkVEQ0JBQD8+PTw7Ojk4NzY1NDMyMTAvLi0sKyopKCcmJSQjIiEgHx4dHBsaGRgXFhUUExIREA8ODQwLCgkIBwYFBAMCAQAAIfkEBQoAAgAsAAAAAAoACgAAAhWEERkn7W3ei7KlagMWF/dKgYeyGAUAIfkEBQoAAgAsAAAAAAoACgAAAg+UYwLJ7RnQm7QmsCyVKhUAIfkEBQoAAgAsAAAAAAoACgAAAhCUYgLJHdiinNSAVfOEKoUCACH5BAUKAAIALAAAAAAKAAoAAAIRVISAdusPo3RAzYtjaMIaUQAAIfkEBQoAAgAsAAAAAAoACgAAAg+MDiem7Q8bSLFaG5il6xQAIfkEBQoAAgAsAAAAAAoACgAAAg+UYRLJ7QnQm7SmsCyVKhUAIfkEBQoAAgAsAAAAAAoACgAAAhCUYBLJDdiinNSEVfOEKoECACH5BAUKAAIALAAAAAAKAAoAAAIRFISBdusPo3RBzYsjaMIaUQAAOw==);
+		border-image-slice: 1;
+		border-image-repeat: repeat;
+	}
+
+	&__rule-of-thirds-vt::before,
+	&__rule-of-thirds-vt::after,
+	&__rule-of-thirds-hz::before,
+	&__rule-of-thirds-hz::after {
+		content: "";
+		display: block;
+		position: absolute;
+		background-color: rgba(255, 255, 255, 0.4);
+	}
+
+	&__rule-of-thirds-vt {
+		&::before,
+		&::after {
+			width: 1px;
+			height: 100%;
+		}
+
+		&::before {
+			left: 33.3333%;
+			left: calc(100% / 3);
+		}
+
+		&::after {
+			left: 66.6666%;
+			left: calc(100% / 3 * 2);
+		}
+	}
+
+	&__rule-of-thirds-hz {
+		&::before,
+		&::after {
+			width: 100%;
+			height: 1px;
+		}
+
+		&::before {
+			top: 33.3333%;
+			top: calc(100% / 3);
+		}
+
+		&::after {
+			top: 66.6666%;
+			top: calc(100% / 3 * 2);
+		}
+	}
+
+	&__drag-handle {
+		position: absolute;
+		width: $drag-handle-width;
+		height: $drag-handle-height;
+		background-color: $drag-handle-background-colour;
+		border: $drag-handle-border;
+		box-sizing: border-box;
+
+		// This stops the borders disappearing when keyboard
+		// nudging.
+		outline: 1px solid transparent;
+	}
+
+	.ord-nw {
+		top: 0;
+		left: 0;
+		margin-top: -(ceil($drag-handle-height / 2));
+		margin-left: -(ceil($drag-handle-width / 2));
+		cursor: nw-resize;
+	}
+	.ord-n {
+		top: 0;
+		left: 50%;
+		margin-top: -(ceil($drag-handle-height / 2));
+		margin-left: -(ceil($drag-handle-width / 2));
+		cursor: n-resize;
+	}
+	.ord-ne {
+		top: 0;
+		right: 0;
+		margin-top: -(ceil($drag-handle-height / 2));
+		margin-right: -(ceil($drag-handle-width / 2));
+		cursor: ne-resize;
+	}
+	.ord-e {
+		top: 50%;
+		right: 0;
+		margin-top: -(ceil($drag-handle-height / 2));
+		margin-right: -(ceil($drag-handle-width / 2));
+		cursor: e-resize;
+	}
+	.ord-se {
+		bottom: 0;
+		right: 0;
+		margin-bottom: -(ceil($drag-handle-height / 2));
+		margin-right: -(ceil($drag-handle-width / 2));
+		cursor: se-resize;
+	}
+	.ord-s {
+		bottom: 0;
+		left: 50%;
+		margin-bottom: -(ceil($drag-handle-height / 2));
+		margin-left: -(ceil($drag-handle-width / 2));
+		cursor: s-resize;
+	}
+	.ord-sw {
+		bottom: 0;
+		left: 0;
+		margin-bottom: -(ceil($drag-handle-height / 2));
+		margin-left: -(ceil($drag-handle-width / 2));
+		cursor: sw-resize;
+	}
+	.ord-w {
+		top: 50%;
+		left: 0;
+		margin-top: -(ceil($drag-handle-height / 2));
+		margin-left: -(ceil($drag-handle-width / 2));
+		cursor: w-resize;
+	}
+
+	// Use the same specificity as the ords above but just
+	// come after.
+	&__disabled &__drag-handle {
+		cursor: inherit;
+	}
+
+	&__drag-bar {
+		position: absolute;
+
+		&.ord-n {
+			top: 0;
+			left: 0;
+			width: 100%;
+			height: $drag-bar-size;
+			margin-top: -($drag-bar-size / 2);
+		}
+		&.ord-e {
+			right: 0;
+			top: 0;
+			width: $drag-bar-size;
+			height: 100%;
+			margin-right: -($drag-bar-size / 2);
+		}
+		&.ord-s {
+			bottom: 0;
+			left: 0;
+			width: 100%;
+			height: $drag-bar-size;
+			margin-bottom: -($drag-bar-size / 2);
+		}
+		&.ord-w {
+			top: 0;
+			left: 0;
+			width: $drag-bar-size;
+			height: 100%;
+			margin-left: -($drag-bar-size / 2);
+		}
+	}
+
+	&--new-crop &__drag-bar,
+	&--new-crop &__drag-handle,
+	&--fixed-aspect &__drag-bar {
+		display: none;
+	}
+
+	&--fixed-aspect &__drag-handle.ord-n,
+	&--fixed-aspect &__drag-handle.ord-e,
+	&--fixed-aspect &__drag-handle.ord-s,
+	&--fixed-aspect &__drag-handle.ord-w {
+		display: none;
+	}
+
+	@media #{$mobile-media-query} {
+		&__drag-handle {
+			width: $drag-handle-mobile-width;
+			height: $drag-handle-mobile-height;
+		}
+
+		&__drag-bar {
+			display: none;
+		}
+
+		.ord-nw,
+		.ord-n,
+		.ord-ne,
+		.ord-e,
+		.ord-s,
+		.ord-sw,
+		.ord-w {
+			display: none;
+		}
+
+		.ord-se {
+			margin-bottom: -1px;
+			margin-right: -1px;
+		}
+	}
+}
+
+// Working State.
+.richimage__working {
+	position: relative;
+
+	.richimage__working-notice {
+		position: absolute;
+		z-index: 1;
+		margin-top: 0;
+		top: 18px;
+		left: 18px;
+		font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+		color: #fff;
+		font-size: 13px;
+		background: rgba(0, 0, 0, 0.8);
+		padding: 0 1em;
+		border-radius: 36px; // Pill shaped.
+	}
+
+	img {
+		opacity: 0.6;
+		transition: all 0.4s ease; // Make flips smooth.
+	}
+
+	&.richimage__working__flipv img {
+		transform: scale(1, -1);
+	}
+
+	&.richimage__working__fliph img {
+		transform: scale(-1, 1);
+	}
+}
+
+// Without this the toolbar buttons gain padding, making them too tall and breaking the toolbar
+// This only happens during the processing state as we change the dropdowns into buttons to disable the dropdowns
+.richimage-toolbar__working {
+	padding: 0 6px;
+}
+
+.richimage-crop {
+	.components-resizable-box__handle {
+		display: block;
+	}
+}
+
+.richimage__working .ReactCrop {
+	background-color: #ddd;
+}
+
+.richimage__crop-icon {
+	padding: 6px;
+	color: #555d66; // Be sure to update this as the UI changes.
+
+	svg {
+		fill: currentColor;
+	}
+}
+
+.richimage-filters__images {
+	display: flex;
+	align-items: flex-start;
+	justify-content: space-between;
+	flex-wrap: wrap;
+	width: 100%;
+
+	.richimage-filterimage {
+		text-align: center;
+		margin-bottom: 1em;
+		width: 25%;
+		padding: 4px;
+		cursor: pointer;
+
+		border-radius: 4px;
+		border: 2px solid transparent;
+
+		&:focus {
+			border-color: #057cba;
+		}
+
+		img {
+			display: block;
+			width: 100%;
+			height: auto;
+		}
+
+		div {
+			border: 4px solid transparent;
+		}
+	}
+
+	.richimage-filterimage__selected {
+		div {
+			border-color: #057cba;
+		}
+
+		p {
+			font-weight: bold;
+		}
+	}
+
+	p {
+		margin: 1em 0 0 0;
+	}
+}
+
+.richimage-filters__button-group {
+	text-align: right;
+
+	.components-button {
+		margin-left: 16px;
+	}
+}
+
+// Make the toolbar dropdowns blend in.
+.components-toolbar.richimage-toolbar__dropdown { // Needs specificity.
+	padding: 0;
+	border-left: none;
+	border-right: none;
+
+	.components-icon-button.has-text svg {
+		margin-right: 0;
+	}
+
+	.components-dropdown-menu__indicator {
+		display: none;
+	}
+}
+
+// Make icons 24x24 unscaled.
+.richimage-toolbar__dropdown > .components-button,
+.richimage-toolbar__dropdown,
+.richimage-toolbar__control {
+	padding: 6px;
+}
+
+// Make the filter dialog bigger.
+.richimage__filter-modal {
+	width: 100%;
+	max-width: calc(100% - 32px - 32px);
+}

--- a/packages/block-library/src/rich-image/index.js
+++ b/packages/block-library/src/rich-image/index.js
@@ -1,0 +1,44 @@
+/**
+ * WordPress dependencies
+ */
+
+import { addFilter } from '@wordpress/hooks';
+import { createHigherOrderComponent } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import { isSupportedBlock, richImageAttributes } from './constants';
+import RichImage from './rich-image';
+
+const addRichImageAttributes = ( settings, name ) => {
+	if ( ! isSupportedBlock( name ) ) {
+		return settings;
+	}
+
+	settings.attributes = Object.assign(
+		settings.attributes,
+		richImageAttributes
+	);
+
+	return settings;
+};
+
+const addRichImage = createHigherOrderComponent( ( OriginalBlock ) => {
+	return ( props ) => {
+		if ( ! isSupportedBlock( props.name ) ) {
+			return <OriginalBlock { ...props } />;
+		}
+
+		return <RichImage { ...props } originalBlock={ OriginalBlock } />;
+	};
+}, 'addRichImage' );
+
+export function registerBlock() {
+	addFilter( 'editor.BlockEdit', 'core/rich-image', addRichImage );
+	addFilter(
+		'blocks.registerBlockType',
+		'core/rich-image/attributes',
+		addRichImageAttributes
+	);
+}

--- a/packages/block-library/src/rich-image/rich-image/api.js
+++ b/packages/block-library/src/rich-image/rich-image/api.js
@@ -1,0 +1,17 @@
+/**
+ * WordPress dependencies
+ */
+
+import apiFetch from '@wordpress/api-fetch';
+
+// Note this always happens with the original media ID. This way the rotation is consistent (otherwise we rotate an already rotated image)
+export default function richImageRequest( id, action, attrs ) {
+	return apiFetch( {
+		path: `__experimental/richimage/${ id }/${ action }`,
+		headers: {
+			'Content-type': 'application/json',
+		},
+		method: 'POST',
+		body: JSON.stringify( attrs ),
+	} );
+}

--- a/packages/block-library/src/rich-image/rich-image/cropped-image.js
+++ b/packages/block-library/src/rich-image/rich-image/cropped-image.js
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+
+import ReactCrop from 'react-image-crop';
+
+const CroppedImage = ( {
+	url,
+	currentCrop,
+	setCrop,
+	children,
+	inProgress,
+} ) => {
+	if ( currentCrop === null ) {
+		return children;
+	}
+
+	return (
+		<ReactCrop
+			src={ url }
+			crop={ currentCrop }
+			ruleOfThirds
+			disabled={ inProgress }
+			onChange={ ( newCrop, newCropPercent ) =>
+				setCrop( newCropPercent )
+			}
+		/>
+	);
+};
+
+export default CroppedImage;

--- a/packages/block-library/src/rich-image/rich-image/filter-class.js
+++ b/packages/block-library/src/rich-image/rich-image/filter-class.js
@@ -1,0 +1,34 @@
+/**
+ * Internal dependencies
+ */
+
+import { supportedFilters } from '../constants';
+
+export const filterCssName = ( filter ) => `richimage-filter__${ filter }`;
+const addClass = ( existing, toAdd ) =>
+	existing !== undefined ? existing + ' ' + toAdd : toAdd;
+const removeClass = ( existing, toRemove ) =>
+	existing
+		.replace( toRemove, '' )
+		.replace( /  /, '' )
+		.trim();
+
+export const getFilterClass = ( imageFilter, existingClass ) => {
+	let className =
+		existingClass === 'undefined' || existingClass === undefined
+			? ''
+			: existingClass;
+
+	// Remove all filters
+	supportedFilters.forEach( ( filter ) => {
+		className = removeClass( className, filterCssName( filter.value ) );
+	} );
+
+	if ( imageFilter !== '' ) {
+		className = addClass( className, filterCssName( imageFilter ) );
+	}
+
+	return {
+		className,
+	};
+};

--- a/packages/block-library/src/rich-image/rich-image/filter-menu.js
+++ b/packages/block-library/src/rich-image/rich-image/filter-menu.js
@@ -1,0 +1,88 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/components';
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { supportedFilters } from '../constants';
+import { filterCssName } from './filter-class';
+
+const FilteredImage = ( { title, url, filterName, selected, onSelect } ) => {
+	const selectImage = ( ev ) => {
+		ev.preventDefault();
+		onSelect( filterName );
+	};
+	const classes = classnames( 'richimage-filterimage', {
+		'richimage-filterimage__selected': selected,
+		[ filterCssName( filterName ) ]: true,
+	} );
+
+	/**
+	 * TODO: Fix a11y rules for clickable div
+	 */
+	return (
+		<div tabIndex="0" className={ classes } onClick={ selectImage }>
+			<div>
+				<img src={ url } alt={ title } />
+			</div>
+			<p>{ title }</p>
+		</div>
+	);
+};
+
+const FilterMenu = ( { url, currentFilter, onSelect } ) => {
+	const [ selected, setSelected ] = useState( currentFilter );
+	const filters = [
+		{
+			title: __( 'No Filter' ),
+			value: '',
+		},
+		...supportedFilters,
+	];
+
+	return (
+		<div className="richimage-filters">
+			<div className="richimage-filters__images">
+				{ filters.map( ( filter ) => (
+					<FilteredImage
+						key={ filter.value }
+						title={ filter.title }
+						url={ url }
+						filterName={ filter.value }
+						selected={ selected === filter.value }
+						onSelect={ setSelected }
+					/>
+				) ) }
+			</div>
+
+			<div className="richimage-filters__button-group">
+				<Button
+					isLarge
+					isDefault
+					onClick={ () => onSelect( currentFilter ) }
+				>
+					Cancel
+				</Button>
+				<Button
+					isLarge
+					isDefault
+					isPrimary
+					onClick={ () => onSelect( selected ) }
+				>
+					Apply
+				</Button>
+			</div>
+		</div>
+	);
+};
+
+export default FilterMenu;

--- a/packages/block-library/src/rich-image/rich-image/icon.js
+++ b/packages/block-library/src/rich-image/rich-image/icon.js
@@ -1,0 +1,82 @@
+/**
+ * WordPress dependencies
+ */
+import { Path, SVG } from '@wordpress/components';
+
+export const RotateLeftIcon = () => {
+	return (
+		<SVG
+			xmlns="http://www.w3.org/2000/svg"
+			width="24"
+			height="24"
+			viewBox="0 0 24 24"
+		>
+			<Path d="M7.11 8.53L5.7 7.11C4.8 8.27 4.24 9.61 4.07 11h2.02c.14-.87.49-1.72 1.02-2.47zM6.09 13H4.07c.17 1.39.72 2.73 1.62 3.89l1.41-1.42c-.52-.75-.87-1.59-1.01-2.47zm1.01 5.32c1.16.9 2.51 1.44 3.9 1.61V17.9c-.87-.15-1.71-.49-2.46-1.03L7.1 18.32zM13 4.07V1L8.45 5.55 13 10V6.09c2.84.48 5 2.94 5 5.91s-2.16 5.43-5 5.91v2.02c3.95-.49 7-3.85 7-7.93s-3.05-7.44-7-7.93z" />
+		</SVG>
+	);
+};
+
+export const RotateRightIcon = () => {
+	return (
+		<SVG
+			xmlns="http://www.w3.org/2000/svg"
+			width="24"
+			height="24"
+			viewBox="0 0 24 24"
+		>
+			<Path d="M15.55 5.55L11 1v3.07C7.06 4.56 4 7.92 4 12s3.05 7.44 7 7.93v-2.02c-2.84-.48-5-2.94-5-5.91s2.16-5.43 5-5.91V10l4.55-4.45zM19.93 11a7.906 7.906 0 00-1.62-3.89l-1.42 1.42c.54.75.88 1.6 1.02 2.47h2.02zM13 17.9v2.02c1.39-.17 2.74-.71 3.9-1.61l-1.44-1.44c-.75.54-1.59.89-2.46 1.03zm3.89-2.42l1.42 1.41c.9-1.16 1.45-2.5 1.62-3.89h-2.02c-.14.87-.48 1.72-1.02 2.48z" />
+		</SVG>
+	);
+};
+
+export const FlipHorizontalIcon = () => {
+	return (
+		<SVG
+			xmlns="http://www.w3.org/2000/svg"
+			width="24"
+			height="24"
+			viewBox="0 0 24 24"
+		>
+			<Path d="M15 21h2v-2h-2v2zm4-12h2V7h-2v2zM3 5v14c0 1.1.9 2 2 2h4v-2H5V5h4V3H5c-1.1 0-2 .9-2 2zm16-2v2h2c0-1.1-.9-2-2-2zm-8 20h2V1h-2v22zm8-6h2v-2h-2v2zM15 5h2V3h-2v2zm4 8h2v-2h-2v2zm0 8c1.1 0 2-.9 2-2h-2v2z" />
+		</SVG>
+	);
+};
+
+export const FlipVerticalIcon = () => {
+	return (
+		<SVG
+			xmlns="http://www.w3.org/2000/svg"
+			width="24"
+			height="24"
+			viewBox="0 0 24 24"
+		>
+			<Path d="M3 15v2h2v-2H3zm12 4v2h2v-2h-2zm4-16H5c-1.1 0-2 .9-2 2v4h2V5h14v4h2V5c0-1.1-.9-2-2-2zm2 16h-2v2c1.1 0 2-.9 2-2zM1 11v2h22v-2H1zm6 8v2h2v-2H7zm12-4v2h2v-2h-2zm-8 4v2h2v-2h-2zm-8 0c0 1.1.9 2 2 2v-2H3z" />
+		</SVG>
+	);
+};
+
+export const CropIcon = () => {
+	return (
+		<SVG
+			xmlns="http://www.w3.org/2000/svg"
+			width="24"
+			height="24"
+			viewBox="0 0 24 24"
+		>
+			<Path d="M17 15h2V7c0-1.1-.9-2-2-2H9v2h8v8zM7 17V1H5v4H1v2h4v10c0 1.1.9 2 2 2h10v4h2v-4h4v-2H7z" />
+		</SVG>
+	);
+};
+
+export const FilterIcon = () => {
+	return (
+		<SVG
+			xmlns="http://www.w3.org/2000/svg"
+			width="24"
+			height="24"
+			viewBox="0 0 24 24"
+		>
+			<Path d="M19.02 10v9H5V5h9V3H5.02c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2v-9h-2zM17 10l.94-2.06L20 7l-2.06-.94L17 4l-.94 2.06L14 7l2.06.94zm-3.75.75L12 8l-1.25 2.75L8 12l2.75 1.25L12 16l1.25-2.75L16 12z" />
+		</SVG>
+	);
+};

--- a/packages/block-library/src/rich-image/rich-image/image-css.js
+++ b/packages/block-library/src/rich-image/rich-image/image-css.js
@@ -1,0 +1,39 @@
+/**
+ * Internal dependencies
+ */
+
+import { supportedFilters } from '../constants';
+
+const filterCssName = ( filter ) => `richimage-filter__${ filter }`;
+const addClass = ( existing, toAdd ) =>
+	existing !== undefined ? existing + ' ' + toAdd : toAdd;
+const removeClass = ( existing, toRemove ) =>
+	existing
+		.replace( toRemove, '' )
+		.replace( /  /, '' )
+		.trim();
+
+export const getImageClass = ( attrs, existingClass ) => {
+	let className =
+		existingClass === 'undefined' || existingClass === undefined
+			? ''
+			: existingClass;
+
+	if ( attrs.imageFilter !== undefined ) {
+		// Remove all filters
+		supportedFilters.forEach( ( filter ) => {
+			className = removeClass( className, filterCssName( filter.value ) );
+		} );
+
+		if ( attrs.imageFilter !== '' ) {
+			className = addClass(
+				className,
+				filterCssName( attrs.imageFilter )
+			);
+		}
+	}
+
+	return {
+		className,
+	};
+};

--- a/packages/block-library/src/rich-image/rich-image/index.js
+++ b/packages/block-library/src/rich-image/rich-image/index.js
@@ -1,0 +1,319 @@
+/**
+ * External dependencies
+ */
+
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+
+import { BlockControls } from '@wordpress/block-editor';
+import { Fragment, Component } from '@wordpress/element';
+import {
+	Toolbar,
+	IconButton,
+	Icon,
+	Button,
+	Modal,
+	withNotices,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { compose } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import { getFilterClass } from './filter-class';
+import FilterMenu from './filter-menu';
+import CroppedImage from './cropped-image';
+import richImageRequest from './api';
+import {
+	RotateLeftIcon,
+	RotateRightIcon,
+	FlipHorizontalIcon,
+	FlipVerticalIcon,
+	CropIcon,
+	FilterIcon,
+} from './icon';
+
+const ROTATE_STEP = 90;
+const DEFAULT_CROP = {
+	unit: '%',
+	x: 25,
+	y: 25,
+	width: 50,
+	height: 50,
+};
+
+class RichImage extends Component {
+	constructor( props ) {
+		super( props );
+
+		this.state = {
+			isCrop: false,
+			inProgress: null,
+			crop: DEFAULT_CROP,
+			isFilter: false,
+		};
+
+		this.adjustImage = this.adjustImage.bind( this );
+		this.applyFilter = this.applyFilter.bind( this );
+		this.cropImage = this.cropImage.bind( this );
+	}
+
+	adjustImage( action, attrs ) {
+		const { setAttributes, attributes, noticeOperations } = this.props;
+		const { id } = attributes;
+
+		this.setState( { inProgress: action } );
+		noticeOperations.removeAllNotices();
+
+		richImageRequest( id, action, attrs )
+			.then( ( response ) => {
+				this.setState( { inProgress: null, isCrop: false } );
+
+				if ( response.mediaID && response.mediaID !== id ) {
+					setAttributes( {
+						id: response.mediaID,
+						url: response.url,
+					} );
+				}
+			} )
+			.catch( () => {
+				noticeOperations.createErrorNotice(
+					__(
+						'Unable to perform the image modification. Please check your media storage.'
+					)
+				);
+				this.setState( { inProgress: null, isCrop: false } );
+			} );
+	}
+
+	applyFilter( imageFilter ) {
+		const { setAttributes, className } = this.props;
+		const adjustedAttrs = {
+			imageFilter,
+			...getFilterClass( imageFilter, className ),
+		};
+
+		setAttributes( adjustedAttrs );
+		this.setState( { isFilter: false } );
+	}
+
+	cropImage() {
+		const { crop } = this.state;
+
+		this.adjustImage( 'crop', {
+			cropX: crop.x,
+			cropY: crop.y,
+			cropWidth: crop.width,
+			cropHeight: crop.height,
+		} );
+	}
+
+	render() {
+		const {
+			isSelected,
+			attributes,
+			originalBlock: OriginalBlock,
+			noticeUI,
+		} = this.props;
+		const { isCrop, inProgress, crop, isFilter } = this.state;
+		const { url, imageFilter } = attributes;
+		const isEditing = ! isCrop && isSelected && url;
+
+		if ( ! isSelected ) {
+			return <OriginalBlock { ...this.props } />;
+		}
+
+		const classes = classnames( {
+			richimage__working: inProgress !== null,
+			[ 'richimage__working__' + inProgress ]: inProgress !== null,
+		} );
+
+		return (
+			<Fragment>
+				{ noticeUI }
+
+				<div className={ classes }>
+					{ inProgress && (
+						<Fragment>
+							<div className="richimage__working-notice">
+								{ __( 'Processing…' ) }
+							</div>
+						</Fragment>
+					) }
+
+					<CroppedImage
+						url={ url }
+						currentCrop={ isCrop ? crop : null }
+						setCrop={ ( newCrop ) =>
+							this.setState( { crop: newCrop } )
+						}
+						inProgress={ inProgress }
+					>
+						<OriginalBlock { ...this.props } />
+					</CroppedImage>
+				</div>
+
+				{ isEditing && (
+					<BlockControls>
+						{ ! inProgress && (
+							<Fragment>
+								<Toolbar
+									className="richimage-toolbar__dropdown"
+									isCollapsed={ true }
+									icon={ <RotateLeftIcon /> }
+									label={ __( 'Rotate' ) }
+									disabled={ inProgress }
+									controls={ [
+										{
+											icon: <RotateLeftIcon />,
+											title: __( 'Rotate left' ),
+											onClick: () =>
+												this.adjustImage( 'rotate', {
+													angle: -ROTATE_STEP,
+												} ),
+										},
+										{
+											icon: <RotateRightIcon />,
+											title: __( 'Rotate right' ),
+											onClick: () =>
+												this.adjustImage( 'rotate', {
+													angle: ROTATE_STEP,
+												} ),
+										},
+									] }
+								/>
+								<Toolbar
+									className="richimage-toolbar__dropdown"
+									isCollapsed={ true }
+									icon={ <FlipVerticalIcon /> }
+									label={ __( 'Flip' ) }
+									disabled={ inProgress }
+									controls={
+										inProgress
+											? []
+											: [
+													{
+														icon: (
+															<FlipVerticalIcon />
+														),
+														title: __(
+															'Flip vertical'
+														),
+														onClick: () =>
+															this.adjustImage(
+																'flip',
+																{
+																	direction:
+																		'vertical',
+																}
+															),
+													},
+													{
+														icon: (
+															<FlipHorizontalIcon />
+														),
+														title: __(
+															'Flip horizontal'
+														),
+														onClick: () =>
+															this.adjustImage(
+																'flip',
+																{
+																	direction:
+																		'horizontal',
+																}
+															),
+													},
+											  ]
+									}
+								/>
+							</Fragment>
+						) }
+
+						<Toolbar>
+							{ inProgress && (
+								<Fragment>
+									<IconButton
+										disabled
+										className="richimage-toolbar__working"
+										icon={ <RotateLeftIcon /> }
+										label={ __( 'Rotate' ) }
+									/>
+									<IconButton
+										disabled
+										className="richimage-toolbar__working"
+										icon={ <FlipVerticalIcon /> }
+										label={ __( 'Flip' ) }
+									/>
+								</Fragment>
+							) }
+							<IconButton
+								className="components-toolbar__control richimage-toolbar__dropdown"
+								disabled={ inProgress }
+								icon={ <CropIcon /> }
+								label={ __( 'Crop' ) }
+								onClick={ () =>
+									this.setState( {
+										isCrop: ! isCrop,
+										crop: DEFAULT_CROP,
+									} )
+								}
+							/>
+							<IconButton
+								className="components-toolbar__control richimage-toolbar__control"
+								disabled={ inProgress }
+								icon={ <FilterIcon /> }
+								label={ __( 'Filter' ) }
+								onClick={ () =>
+									this.setState( { isFilter: true } )
+								}
+							/>
+						</Toolbar>
+					</BlockControls>
+				) }
+
+				{ isCrop && (
+					<BlockControls>
+						<Toolbar>
+							<div className="richimage__crop-icon">
+								<Icon icon={ CropIcon } />
+							</div>
+							<Button onClick={ this.cropImage }>
+								{ __( 'Apply' ) }
+							</Button>
+							<Button
+								onClick={ () =>
+									this.setState( { isCrop: false } )
+								}
+							>
+								{ __( 'Cancel' ) }
+							</Button>
+						</Toolbar>
+					</BlockControls>
+				) }
+
+				{ isFilter && (
+					<Modal
+						className="richimage__filter-modal"
+						title={ __( 'Photo Filters' ) }
+						onRequestClose={ () =>
+							this.setState( { isFilter: false } )
+						}
+					>
+						<FilterMenu
+							onSelect={ this.applyFilter }
+							url={ url }
+							currentFilter={ imageFilter }
+						/>
+					</Modal>
+				) }
+			</Fragment>
+		);
+	}
+}
+
+export default compose( [ withNotices ] )( RichImage );

--- a/packages/block-library/src/rich-image/style.scss
+++ b/packages/block-library/src/rich-image/style.scss
@@ -1,0 +1,27 @@
+.richimage-filter__black-and-white img {
+	filter: grayscale(100%) contrast(1.5);
+}
+
+.richimage-filter__technicolor img {
+	filter: contrast(1.4) brightness(1.3) saturate(0.8) hue-rotate(-15deg) sepia(0.3);
+}
+
+.richimage-filter__sunshine img {
+	filter: sepia(0.45) contrast(1.25) brightness(1.75) saturate(1.3) hue-rotate(-5deg);
+}
+
+.richimage-filter__aviator img {
+	filter: sepia(0.2) contrast(1.2) brightness(1.4) hue-rotate(25deg) saturate(0.7);
+}
+
+.richimage-filter__polar-vortex img {
+	filter: sepia(1) contrast(1.2) brightness(1.05) saturate(1.3) hue-rotate(145deg);
+}
+
+.richimage-filter__rocketeer img {
+	filter: sepia(0.5) contrast(1.15) saturate(2);
+}
+
+.richimage-filter__black-hole img {
+	filter: contrast(1.7) brightness(0.9) saturate(0.8) hue-rotate(-15deg);
+}

--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -21,6 +21,7 @@
 @import "./paragraph/style.scss";
 @import "./pullquote/style.scss";
 @import "./quote/style.scss";
+@import "./rich-image/style.scss";
 @import "./rss/style.scss";
 @import "./search/style.scss";
 @import "./separator/style.scss";


### PR DESCRIPTION
## Description

Features:  Adds crop, filter, flip, rotate capabilities to images.

Fixes #13748

## How has this been tested?

- Add image
- Click on image and try different editing tools

## Screenshots 

![image-tools](https://user-images.githubusercontent.com/45363/75931143-1cea2b00-5e29-11ea-9c6b-20a7400f13a2.gif)


## Types of changes

- Adds new image-editor end points in `lib/`
- Adds new "block" that extends image capabilities,
?? Is block library the best location for extending other blocks?

- How should we enable and limit for testing as experimental? 

Props to @johngodley and @jasmussen for the heavy lifting.


## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
