### PR TITLE
Site Editor - extension point filter list for Site Editor init hook.

### DIFF
--- a/lib/edit-site-page.php
+++ b/lib/edit-site-page.php
@@ -34,7 +34,7 @@ function gutenberg_edit_site_init( $hook ) {
 		$_wp_current_template_content,
 		$_wp_current_template_hierarchy,
 		$_wp_current_template_part_ids;
-	if ( apply_filters('is-ineligible-site-editor-hook', $hook) ) {
+	if ( apply_filters( 'is-ineligible-site-editor-hook', $hook ) ) {
 		return;
 	}
 
@@ -165,8 +165,8 @@ add_action( 'admin_enqueue_scripts', 'gutenberg_edit_site_init' );
  * the init function itself.  This will filter through all hooks added by the outer filter and
  * return 'false' if there is any match.  It will return the original hook if no match is found.
  */
-add_filter( 'add-site-editor-hook-path', function( $new_hook ){
-	add_filter('is-ineligible-site-editor-hook', function( $hook ) use ( $new_hook ){
+add_filter( 'add-site-editor-hook-path', function( $new_hook ) {
+	add_filter( 'is-ineligible-site-editor-hook', function( $hook ) use ( $new_hook ) {
 		if ( $hook === false || $new_hook === $hook ){
 			return false;
 		}
@@ -175,4 +175,4 @@ add_filter( 'add-site-editor-hook-path', function( $new_hook ){
 });
 
 // Define our default allowed hook for gutenberg_edit_site_init function.
-apply_filters( 'add-site-editor-hook-path', 'gutenberg_page_gutenberg-edit-site');
+apply_filters( 'add-site-editor-hook-path', 'gutenberg_page_gutenberg-edit-site' );

--- a/lib/edit-site-page.php
+++ b/lib/edit-site-page.php
@@ -34,9 +34,7 @@ function gutenberg_edit_site_init( $hook ) {
 		$_wp_current_template_content,
 		$_wp_current_template_hierarchy,
 		$_wp_current_template_part_ids;
-	if ( 'gutenberg_page_gutenberg-edit-site' !== $hook
-		&& 'toplevel_page_gutenberg-edit-site' !== $hook
-	) {
+	if ( apply_filters('is-ineligable-site-editor-hook', $hook) ) {
 		return;
 	}
 
@@ -157,3 +155,14 @@ function gutenberg_edit_site_init( $hook ) {
 	wp_enqueue_style( 'wp-format-library' );
 }
 add_action( 'admin_enqueue_scripts', 'gutenberg_edit_site_init' );
+
+add_filter( 'add-site-editor-hook-path', function( $slug ){
+	add_filter('is-ineligable-site-editor-hook', function( $hook ){
+		if ( $hook === false || $slug === $hook ){
+			return false;
+		}
+		return $hook;
+	});
+});
+
+applyFilter( 'add-site-editor-hook-path', 'gutenberg_page_gutenberg-edit-site');

--- a/lib/edit-site-page.php
+++ b/lib/edit-site-page.php
@@ -34,7 +34,11 @@ function gutenberg_edit_site_init( $hook ) {
 		$_wp_current_template_content,
 		$_wp_current_template_hierarchy,
 		$_wp_current_template_part_ids;
-	if ( apply_filters( 'is-ineligible-site-editor-hook', $hook ) ) {
+
+	$allowed_hooks = [ 'gutenberg_page_gutenberg-edit-site', 'toplevel_page_gutenberg-edit-site' ];
+	$allowed_hooks = apply_filters( 'site-editor-hook-paths', $allowed_hooks );
+
+	if ( ! in_array( $hook, $allowed_hooks, true ) ) {
 		return;
 	}
 
@@ -156,23 +160,3 @@ function gutenberg_edit_site_init( $hook ) {
 }
 add_action( 'admin_enqueue_scripts', 'gutenberg_edit_site_init' );
 
-/**
- * Adds a filter to allow defining more hooks to be accepted by gutenberg_edit_site_init function.
- * 
- * Usage: apply_filters( 'add-site-editor-hook-path', $new_hook_string )
- * 
- * The inner filter for 'is-ineligible-site-editor-hook' is only intended to be applied within
- * the init function itself.  This will filter through all hooks added by the outer filter and
- * return 'false' if there is any match.  It will return the original hook if no match is found.
- */
-add_filter( 'add-site-editor-hook-path', function( $new_hook ) {
-	add_filter( 'is-ineligible-site-editor-hook', function( $hook ) use ( $new_hook ) {
-		if ( $hook === false || $new_hook === $hook ){
-			return false;
-		}
-		return $hook;
-	});
-});
-
-// Define our default allowed hook for gutenberg_edit_site_init function.
-apply_filters( 'add-site-editor-hook-path', 'gutenberg_page_gutenberg-edit-site' );

--- a/lib/edit-site-page.php
+++ b/lib/edit-site-page.php
@@ -156,13 +156,13 @@ function gutenberg_edit_site_init( $hook ) {
 }
 add_action( 'admin_enqueue_scripts', 'gutenberg_edit_site_init' );
 
-add_filter( 'add-site-editor-hook-path', function( $slug ){
-	add_filter('is-ineligable-site-editor-hook', function( $hook ){
-		if ( $hook === false || $slug === $hook ){
+add_filter( 'add-site-editor-hook-path', function( $new_hook ){
+	add_filter('is-ineligable-site-editor-hook', function( $hook ) use ( $new_hook ){
+		if ( $hook === false || $new_hook === $hook ){
 			return false;
 		}
 		return $hook;
 	});
 });
 
-applyFilter( 'add-site-editor-hook-path', 'gutenberg_page_gutenberg-edit-site');
+apply_filters( 'add-site-editor-hook-path', 'gutenberg_page_gutenberg-edit-site');

--- a/lib/edit-site-page.php
+++ b/lib/edit-site-page.php
@@ -35,7 +35,7 @@ function gutenberg_edit_site_init( $hook ) {
 		$_wp_current_template_hierarchy,
 		$_wp_current_template_part_ids;
 
-	$allowed_hooks = [ 'gutenberg_page_gutenberg-edit-site', 'toplevel_page_gutenberg-edit-site' ];
+	$allowed_hooks = array( 'gutenberg_page_gutenberg-edit-site' );
 	$allowed_hooks = apply_filters( 'site-editor-hook-paths', $allowed_hooks );
 
 	if ( ! in_array( $hook, $allowed_hooks, true ) ) {
@@ -159,4 +159,3 @@ function gutenberg_edit_site_init( $hook ) {
 	wp_enqueue_style( 'wp-format-library' );
 }
 add_action( 'admin_enqueue_scripts', 'gutenberg_edit_site_init' );
-

--- a/lib/edit-site-page.php
+++ b/lib/edit-site-page.php
@@ -34,7 +34,9 @@ function gutenberg_edit_site_init( $hook ) {
 		$_wp_current_template_content,
 		$_wp_current_template_hierarchy,
 		$_wp_current_template_part_ids;
-	if ( 'gutenberg_page_gutenberg-edit-site' !== $hook ) {
+	if ( 'gutenberg_page_gutenberg-edit-site' !== $hook
+		&& 'toplevel_page_gutenberg-edit-site' !== $hook
+	) {
 		return;
 	}
 

--- a/lib/edit-site-page.php
+++ b/lib/edit-site-page.php
@@ -36,7 +36,7 @@ function gutenberg_edit_site_init( $hook ) {
 		$_wp_current_template_part_ids;
 
 	$allowed_hooks = array( 'gutenberg_page_gutenberg-edit-site' );
-	$allowed_hooks = apply_filters( 'site-editor-hook-paths', $allowed_hooks );
+	$allowed_hooks = apply_filters( 'site_editor_allowed_hooks', $allowed_hooks );
 
 	if ( ! in_array( $hook, $allowed_hooks, true ) ) {
 		return;

--- a/lib/edit-site-page.php
+++ b/lib/edit-site-page.php
@@ -156,6 +156,15 @@ function gutenberg_edit_site_init( $hook ) {
 }
 add_action( 'admin_enqueue_scripts', 'gutenberg_edit_site_init' );
 
+/**
+ * Adds a filter to allow defining more hooks to be accepted by gutenberg_edit_site_init function.
+ * 
+ * Usage: apply_filters( 'add-site-editor-hook-path', $new_hook_string )
+ * 
+ * The inner filter for 'is-ineligable-site-editor-hook' is only intended to be applied within
+ * the init function itself.  This will filter through all hooks added by the outer filter and
+ * return 'false' if there is any match.  It will return the original hook if no match is found.
+ */
 add_filter( 'add-site-editor-hook-path', function( $new_hook ){
 	add_filter('is-ineligable-site-editor-hook', function( $hook ) use ( $new_hook ){
 		if ( $hook === false || $new_hook === $hook ){
@@ -165,4 +174,5 @@ add_filter( 'add-site-editor-hook-path', function( $new_hook ){
 	});
 });
 
+// Define our default allowed hook for gutenberg_edit_site_init function.
 apply_filters( 'add-site-editor-hook-path', 'gutenberg_page_gutenberg-edit-site');

--- a/lib/edit-site-page.php
+++ b/lib/edit-site-page.php
@@ -34,7 +34,7 @@ function gutenberg_edit_site_init( $hook ) {
 		$_wp_current_template_content,
 		$_wp_current_template_hierarchy,
 		$_wp_current_template_part_ids;
-	if ( apply_filters('is-ineligable-site-editor-hook', $hook) ) {
+	if ( apply_filters('is-ineligible-site-editor-hook', $hook) ) {
 		return;
 	}
 
@@ -161,12 +161,12 @@ add_action( 'admin_enqueue_scripts', 'gutenberg_edit_site_init' );
  * 
  * Usage: apply_filters( 'add-site-editor-hook-path', $new_hook_string )
  * 
- * The inner filter for 'is-ineligable-site-editor-hook' is only intended to be applied within
+ * The inner filter for 'is-ineligible-site-editor-hook' is only intended to be applied within
  * the init function itself.  This will filter through all hooks added by the outer filter and
  * return 'false' if there is any match.  It will return the original hook if no match is found.
  */
 add_filter( 'add-site-editor-hook-path', function( $new_hook ){
-	add_filter('is-ineligable-site-editor-hook', function( $hook ) use ( $new_hook ){
+	add_filter('is-ineligible-site-editor-hook', function( $hook ) use ( $new_hook ){
 		if ( $hook === false || $new_hook === $hook ){
 			return false;
 		}


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

Refactored the early return statement of the `gutenberg_site_editor_init` function to instead check a list that is filterable.  This will allow extra allowable hooks to be added by plugin developers.

Background:
We would like to enable the site editor experiment via a plugin and would like to add the 'Site Editor' button to the top-level of the sidebar.  Without updating the allowed hooks in the early return condition, this would be required to be a submenu page of the Gutenberg plugin page which we do not want shown in this context for various reasons.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Locally as well as with other plugin usage.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
