### PR TITLE
Save database on wp-env.

### DIFF
--- a/packages/env/lib/build-docker-compose-config.js
+++ b/packages/env/lib/build-docker-compose-config.js
@@ -69,6 +69,7 @@ module.exports = function buildDockerComposeConfig( config ) {
 				environment: {
 					MYSQL_ALLOW_EMPTY_PASSWORD: 'yes',
 				},
+				volumes: [ 'mysql:/var/lib/mysql' ],
 			},
 			wordpress: {
 				depends_on: [ 'mysql' ],
@@ -108,6 +109,7 @@ module.exports = function buildDockerComposeConfig( config ) {
 		volumes: {
 			...( ! config.coreSource && { wordpress: {} } ),
 			...( ! config.coreSource && { 'tests-wordpress': {} } ),
+			mysql: {},
 		},
 	};
 };


### PR DESCRIPTION
closes #20657

## Description
<!-- Please describe what you have changed or added -->
wp-env does not save the database now. 
Each time run `wp-env start`  , the database is emptied and WordPress is newly installed.
should reset the database only when run `wp-env clean`  .

## How has this been tested?

1. `$ ./packages/env/bin/wp-env start`
2. add post.
3. `$./packages/env/bin/wp-env stop`
4. `$ ./packages/env/bin/wp-env start` and check your WordPress.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
