### PR TITLE
[RNMobile] Fix replacing empty paragraph in inner block

### DIFF
--- a/packages/block-editor/src/components/inserter/menu.native.js
+++ b/packages/block-editor/src/components/inserter/menu.native.js
@@ -241,7 +241,8 @@ export default compose(
 					);
 
 					const count = getBlockCount();
-					if ( count === 1 ) {
+					// Check if there is a rootClientId because that means it is a nested replacable block and we don't want to clear/reset block.
+					if ( count === 1 && ! ownProps.rootClientId ) {
 						// removing the last block is not possible with `removeBlock` action
 						// it always inserts a default block if the last of the blocks have been removed
 						clearSelectedBlock();

--- a/packages/block-editor/src/components/inserter/menu.native.js
+++ b/packages/block-editor/src/components/inserter/menu.native.js
@@ -241,7 +241,7 @@ export default compose(
 					);
 
 					const count = getBlockCount();
-					// Check if there is a rootClientId because that means it is a nested replacable block and we don't want to clear/reset block.
+					// Check if there is a rootClientId because that means it is a nested replacable block and we don't want to clear/reset all blocks.
 					if ( count === 1 && ! ownProps.rootClientId ) {
 						// removing the last block is not possible with `removeBlock` action
 						// it always inserts a default block if the last of the blocks have been removed


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/1974

Gutenberg-mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1984

In this PR i fixed the issue when trying to replace a paragraph that is nested in the inner block that is the only block on the root level. I added a check if the `rootClientId` is passed in props because that means the selected and replaceable paragraph is a nested one.

## How has this been tested?
**Test case 1**
- Open an empty editor w/o any block in it.
- Add Cover/Group block
- Add empty paragraph inside the created block
- Make sure that the created paragraph is empty and selected
- Click on the "Add block" button and select some block
- The paragraph should be replaced by selected block

**Test case 2**
- Open empty editor w/o any block in it
- Select the already existing paragraph (placeholder)
- Click on "Add block" button and select some block
- The paragraph should be replaced by selected block


## Screenshots <!-- if applicable -->
Before | After
---|---
![cover-issue](https://user-images.githubusercontent.com/16336501/75979182-40bc7800-5ee0-11ea-9ac0-12373a94ee40.gif) |  ![cover-issue-after](https://user-images.githubusercontent.com/16336501/75979395-b45e8500-5ee0-11ea-9173-74bc36bed27f.gif)


## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
