### PR TITLE
Aligments: explore idea on image block

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -247,12 +247,6 @@
 		cursor: default;
 	}
 
-	.alignleft,
-	.alignright {
-		// Without z-index, won't be clickable as "above" adjacent content.
-		z-index: z-index(".block-editor-block-list__block {core/image aligned left or right}");
-	}
-
 	// Alignments.
 	&[data-align="left"],
 	&[data-align="right"] {
@@ -288,15 +282,12 @@
 
 	// Wide and full-wide.
 	&[data-align="full"],
-	&[data-align="wide"],
-	&.alignfull,
-	&.alignwide {
+	&[data-align="wide"] {
 		clear: both;
 	}
 
 	// Full-wide.
-	&[data-align="full"],
-	&.alignfull {
+	&[data-align="full"] {
 		margin-left: -$block-padding;
 		margin-right: -$block-padding;
 

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -426,16 +426,16 @@ export class ImageEdit extends Component {
 			return (
 				<>
 					{ controls }
-					<Block.div
-						className={ classnames( className, `align${ align }` ) }
-					>
-						{ mediaPlaceholder }
-					</Block.div>
+					<div className={ `wp-align-wrapper wp-align-${ align }` }>
+						<Block.div className={ className }>
+							{ mediaPlaceholder }
+						</Block.div>
+					</div>
 				</>
 			);
 		}
 
-		const classes = classnames( className, `align${ align }`, {
+		const classes = classnames( className, {
 			'is-transient': isBlobURL( url ),
 			'is-resized': !! width || !! height,
 			'is-focused': isSelected,
@@ -508,7 +508,7 @@ export class ImageEdit extends Component {
 		return (
 			<>
 				{ controls }
-				<div className="wp-align-wrapper">
+				<div className={ `wp-align-wrapper wp-align-${ align }` }>
 					<Block.figure className={ classes }>
 						<ImageSize src={ url } dirtynessTrigger={ align }>
 							{ ( sizes ) => {

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -33,7 +33,7 @@ import {
 	__experimentalImageSizeControl as ImageSizeControl,
 	__experimentalImageURLInputUI as ImageURLInputUI,
 } from '@wordpress/block-editor';
-import { Component, Fragment } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { getPath } from '@wordpress/url';
 import { withViewportMatch } from '@wordpress/viewport';
@@ -405,9 +405,6 @@ export class ImageEdit extends Component {
 				src={ url }
 			/>
 		);
-		const needsAlignmentWrapper = [ 'center', 'left', 'right' ].includes(
-			align
-		);
 
 		const mediaPlaceholder = (
 			<MediaPlaceholder
@@ -430,29 +427,19 @@ export class ImageEdit extends Component {
 				<>
 					{ controls }
 					<Block.div
-						className={ classnames( className, {
-							[ `align${ align }` ]:
-								! needsAlignmentWrapper && align,
-						} ) }
+						className={ classnames( className, `align${ align }` ) }
 					>
-						{ needsAlignmentWrapper ? (
-							<div className={ `align${ align }` }>
-								{ mediaPlaceholder }
-							</div>
-						) : (
-							mediaPlaceholder
-						) }
+						{ mediaPlaceholder }
 					</Block.div>
 				</>
 			);
 		}
 
-		const classes = classnames( className, {
+		const classes = classnames( className, `align${ align }`, {
 			'is-transient': isBlobURL( url ),
 			'is-resized': !! width || !! height,
 			'is-focused': isSelected,
 			[ `size-${ sizeSlug }` ]: sizeSlug,
-			[ `align${ align }` ]: align,
 		} );
 
 		const isResizable =
@@ -516,17 +503,13 @@ export class ImageEdit extends Component {
 			</>
 		);
 
-		const AlignmentWrapper = needsAlignmentWrapper ? Block.div : Fragment;
-		const BlockContentWrapper = needsAlignmentWrapper
-			? 'figure'
-			: Block.figure;
 		// Disable reason: Each block can be selected by clicking on it
 		/* eslint-disable jsx-a11y/click-events-have-key-events */
 		return (
 			<>
 				{ controls }
-				<AlignmentWrapper>
-					<BlockContentWrapper className={ classes }>
+				<div className="wp-align-wrapper">
+					<Block.figure className={ classes }>
 						<ImageSize src={ url } dirtynessTrigger={ align }>
 							{ ( sizes ) => {
 								const {
@@ -702,10 +685,9 @@ export class ImageEdit extends Component {
 								inlineToolbar
 							/>
 						) }
-
 						{ mediaPlaceholder }
-					</BlockContentWrapper>
-				</AlignmentWrapper>
+					</Block.figure>
+				</div>
 			</>
 		);
 		/* eslint-enable jsx-a11y/click-events-have-key-events */

--- a/packages/edit-post/src/style.scss
+++ b/packages/edit-post/src/style.scss
@@ -104,13 +104,56 @@ body.block-editor-page {
 .wp-block {
 	max-width: $content-width;
 
-	&[data-align="wide"],
-	&.alignwide {
+	&[data-align="wide"] {
 		max-width: 1100px;
 	}
 
-	&[data-align="full"],
-	&.alignfull {
+	&[data-align="full"] {
 		max-width: none;
+	}
+}
+
+.wp-align-wrapper {
+	max-width: $content-width;
+	margin-left: auto;
+	margin-right: auto;
+
+	> .wp-block,
+	&.wp-align-full {
+		max-width: none;
+	}
+
+	&.wp-align-full {
+		margin-left: -$block-padding;
+		margin-right: -$block-padding;
+
+		@include break-small() {
+			margin-left: -$block-padding - $block-padding - $block-side-ui-width - $border-width - $border-width;
+			margin-right: -$block-padding - $block-padding - $block-side-ui-width - $border-width - $border-width;
+		}
+	}
+
+	&.wp-align-wide {
+		max-width: 1100px;
+	}
+
+	&.wp-align-left > * {
+		float: left;
+		margin-right: 2em;
+	}
+
+	&.wp-align-right > * {
+		float: right;
+		margin-left: 2em;
+	}
+
+	&.wp-align-left > *,
+	&.wp-align-right > * {
+		// Without z-index, won't be clickable as "above" adjacent content.
+		z-index: z-index(".block-editor-block-list__block {core/image aligned left or right}");
+	}
+
+	&.wp-align-center {
+		// Same as no alignment?
 	}
 }


### PR DESCRIPTION
## Description

Explores ideas in #20650.

<img width="881" alt="Screenshot 2020-03-05 at 14 35 56" src="https://user-images.githubusercontent.com/4710635/75986911-38b80480-5eef-11ea-919e-49b4b55f8f77.png">

(As you can see in the screenshot above, the block outline and toolbar are positioned correctly without an exception to the rule.)

The idea:

Add an "alignment wrapper" around the block instead of inside the block content. This alignment wrapper can similarly be used to position floated images relative to the main column.

Here's what the editor DOM looks like:

<img width="541" alt="Screenshot 2020-03-05 at 14 44 00" src="https://user-images.githubusercontent.com/4710635/75987174-c398ff00-5eef-11ea-95f0-b49f52f08b14.png">

As you can see it wraps around the block.

There are two ways to implement this:

* Either we automatically add this wrapper to both the `edit` and `save` output when we detect block support for it.
* Or the block add the wrapper by itself. A slight challenge here is that we automatically add `wp-block-*` classes to the top level element returned by `save`, which shouldn't be added to the wrapper.

Benefits:

* Much more straightforward to implement by blocks, especially if the wrapper would be added internally to both `edit` and `save` output.
* There's no exceptions needed to handle toolbar position and block selection styles.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
