### PR TITLE
Try, fix inserter being hidden.

### DIFF
--- a/packages/block-editor/src/components/default-block-appender/style.scss
+++ b/packages/block-editor/src/components/default-block-appender/style.scss
@@ -67,10 +67,11 @@
 }
 
 // Empty / default block side inserter.
-.block-editor-block-list__empty-block-inserter, // Empty paragraph
-.block-editor-default-block-appender .block-editor-inserter { // Empty appender
+.components-popover__content > .block-editor-block-list__empty-block-inserter, // Empty paragraph, needs specificity.
+.block-editor-default-block-appender .block-editor-inserter { // Empty appender.
 	position: absolute;
 	top: 2px; // Centers it in the default paragraph height.
+	height: $button-size-small + $grid-unit-10;
 
 	.block-editor-inserter__toggle {
 		margin-right: 0;

--- a/packages/block-editor/src/components/default-block-appender/style.scss
+++ b/packages/block-editor/src/components/default-block-appender/style.scss
@@ -67,7 +67,7 @@
 }
 
 // Empty / default block side inserter.
-.components-popover__content > .block-editor-block-list__empty-block-inserter, // Empty paragraph, needs specificity.
+.block-editor-block-list__empty-block-inserter.block-editor-block-list__empty-block-inserter, // Empty paragraph, needs specificity to override inherited popover styles.
 .block-editor-default-block-appender .block-editor-inserter { // Empty appender.
 	position: absolute;
 	top: 2px; // Centers it in the default paragraph height.


### PR DESCRIPTION
Fixes #20615.

The inserter in an empty paragraph gets hidden behind the library because it's abs-positioned, which means the popover "collapses" and puts the block librarys coordinate accordingly.

This adds an explicit height, with specificity, solving that.

<img width="694" alt="Screenshot 2020-03-05 at 17 29 35" src="https://user-images.githubusercontent.com/1204802/76002574-1df18a00-5f07-11ea-95cb-914ad8431bdc.png">
