### PR TITLE
Block Editor: Use full labels for directional block movers

### DIFF
--- a/packages/block-editor/src/components/block-mover/index.js
+++ b/packages/block-editor/src/components/block-mover/index.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { Button, ToolbarGroup } from '@wordpress/components';
 import { getBlockType } from '@wordpress/blocks';
 import { Component } from '@wordpress/element';
@@ -82,17 +82,17 @@ export class BlockMover extends Component {
 			return null;
 		};
 
-		const getMovementDirection = ( moveDirection ) => {
+		const getMovementDirectionLabel = ( moveDirection ) => {
 			if ( moveDirection === 'up' ) {
 				if ( orientation === 'horizontal' ) {
-					return isRTL ? 'right' : 'left';
+					return isRTL ? __( 'Move right' ) : __( 'Move left' );
 				}
-				return 'up';
+				return __( 'Move up' );
 			} else if ( moveDirection === 'down' ) {
 				if ( orientation === 'horizontal' ) {
-					return isRTL ? 'left' : 'right';
+					return isRTL ? __( 'Move left' ) : __( 'Move right' );
 				}
-				return 'down';
+				return __( 'Move down' );
 			}
 			return null;
 		};
@@ -118,11 +118,7 @@ export class BlockMover extends Component {
 								className="block-editor-block-mover__control block-editor-block-mover__control-up"
 								onClick={ isFirst ? null : onMoveUp }
 								icon={ getArrowIcon( 'up' ) }
-								// translators: %s: Horizontal direction of block movement ( left, right )
-								label={ sprintf(
-									__( 'Move %s' ),
-									getMovementDirection( 'up' )
-								) }
+								label={ getMovementDirectionLabel( 'up' ) }
 								aria-describedby={ `block-editor-block-mover__up-description-${ instanceId }` }
 								aria-disabled={ isFirst }
 								onFocus={ this.onFocus }
@@ -133,11 +129,7 @@ export class BlockMover extends Component {
 								className="block-editor-block-mover__control block-editor-block-mover__control-down"
 								onClick={ isLast ? null : onMoveDown }
 								icon={ getArrowIcon( 'down' ) }
-								// translators: %s: Horizontal direction of block movement ( left, right )
-								label={ sprintf(
-									__( 'Move %s' ),
-									getMovementDirection( 'down' )
-								) }
+								label={ getMovementDirectionLabel( 'down' ) }
 								aria-describedby={ `block-editor-block-mover__down-description-${ instanceId }` }
 								aria-disabled={ isLast }
 								onFocus={ this.onFocus }


### PR DESCRIPTION
Fixes #20655
Regressed in #16615

This pull request seeks to resolve an issue where block mover labels cannot be fully translated, due to concatenation (`sprintf`) of the translated label with non-translated directional strings ("up", "down", "right", "left").

The changes in this pull request reintroduce labels which had existed prior to #16615 (plus horizontal additions), in their fully expanded form. Per discussion in #20655, this is considered to be preferable to placeholder substitution, where the short directional strings are more difficult to translate than the full labels.

**Note about cherry-picking for WordPress 5.4:** ~It's unclear to me whether this is allowable to be cherry-picked for 5.4, given that the WordPress 5.4 RC was already released this Tuesday, and which is considered ([by its announcement post](https://wordpress.org/news/2020/03/wordpress-5-4-release-candidate/)) as a [hard string freeze](https://make.wordpress.org/polyglots/handbook/glossary/#hard-freeze). Without these new strings, however, it is impossible to correctly translate the block mover labels.~ Based on @ocean90's comment at https://github.com/WordPress/gutenberg/issues/20655#issuecomment-595406806, it should be fine to cherry-pick these changes for WordPress 5.4.

**Testing Instructions:**

Repeat Testing Instructions from #16615, verifying no regressions in expected behavior.

For complete testing of strings, you could run `wp i18n make-pot` on the built output of the file to confirm the strings "Move left", "Move up", "Move right', and "Move down" are correctly available for translation.