### PR TITLE
Create a new document section for "Gutenberg as a Platform"

### DIFF
--- a/docs/designers-developers/developers/platform/README.md
+++ b/docs/designers-developers/developers/platform/README.md
@@ -29,7 +29,7 @@ function MyApp() {
 
 ## Development Scripts
 
-The wp-scripts package is a collection of reusable scripts for JavaScript development — includes scripts for building, linting, and testing — all with no additional configuration files.
+The [wp-scripts package](https://developer.wordpress.org/block-editor/packages/packages-scripts/) is a collection of reusable scripts for JavaScript development — includes scripts for building, linting, and testing — all with no additional configuration files.
 
 Here is a quick example, on how to use wp-scripts in your project.
 

--- a/docs/designers-developers/developers/platform/README.md
+++ b/docs/designers-developers/developers/platform/README.md
@@ -1,7 +1,7 @@
 
 # Gutenberg as a Development Platform
 
-The Gutenberg Project is not only building a better editor for WordPress, but while doing creating a platform to build upon. This platform consists of a set of JavaScript packages and tools that you can use in your web application. [View the list packages available on npm](https://www.npmjs.com/org/wordpress).
+The Gutenberg Project is not only building a better editor for WordPress, but also creating a platform to build upon. This platform consists of a set of JavaScript packages and tools that you can use in your web application. [View the list packages available on npm](https://www.npmjs.com/org/wordpress).
 
 ## UI Components
 

--- a/docs/designers-developers/developers/platform/README.md
+++ b/docs/designers-developers/developers/platform/README.md
@@ -1,0 +1,15 @@
+
+# Gutenberg as a Development Platform
+
+The Gutenberg Project is not only building a better editor for WordPress, but while doing creating a platform to build upon. This platform consists of numerous JavaScript packages and tools that you can use in your web application.
+
+## UI Components
+
+The [WordPress Components package](/docs/components/) contains a set of UI components you can use in your project. See the [WordPress Storybook site](https://wordpress.github.io/gutenberg/) for an interactive guide to the available components and settings.
+
+## Development Scripts
+
+The wp-scripts package is a collection of reusable scripts for JavaScript development, includes scripts for building, linting, and testing, all with no additional configuration files.
+
+See [Gutenberg Example #03](https://github.com/WordPress/gutenberg-examples/tree/master/03-editable-esnext) for the package is setup and defined in the `package.json` file in the example.
+

--- a/docs/designers-developers/developers/platform/README.md
+++ b/docs/designers-developers/developers/platform/README.md
@@ -1,15 +1,55 @@
 
 # Gutenberg as a Development Platform
 
-The Gutenberg Project is not only building a better editor for WordPress, but while doing creating a platform to build upon. This platform consists of numerous JavaScript packages and tools that you can use in your web application.
+The Gutenberg Project is not only building a better editor for WordPress, but while doing creating a platform to build upon. This platform consists of a set of JavaScript packages and tools that you can use in your web application. [View the list packages available on npm](https://www.npmjs.com/org/wordpress).
 
 ## UI Components
 
 The [WordPress Components package](/docs/components/) contains a set of UI components you can use in your project. See the [WordPress Storybook site](https://wordpress.github.io/gutenberg/) for an interactive guide to the available components and settings.
 
+Here is a quick example, how to use components in your project.
+
+Install the dependency:
+
+```bash
+npm install --save @wordpress/components
+```
+
+Usage in React:
+
+```jsx
+import { Button } from '@wordpress/components';
+
+function MyApp() {
+   return (
+      <Button>Hello Button</Button>
+   );
+}
+```
+
 ## Development Scripts
 
-The wp-scripts package is a collection of reusable scripts for JavaScript development, includes scripts for building, linting, and testing, all with no additional configuration files.
+The wp-scripts package is a collection of reusable scripts for JavaScript development — includes scripts for building, linting, and testing — all with no additional configuration files.
 
-See [Gutenberg Example #03](https://github.com/WordPress/gutenberg-examples/tree/master/03-editable-esnext) for the package is setup and defined in the `package.json` file in the example.
+Here is a quick example, on how to use wp-scripts in your project.
 
+Install the depenency:
+
+```bash
+npm install --save-dev @wordpress/scripts
+```
+
+You can then add a scripts section to your package.json file, for example:
+
+```json
+	"scripts": {
+		"build": "wp-scripts build",
+		"format:js": "wp-scripts format-js",
+		"lint:js": "wp-scripts lint-js",
+		"start": "wp-scripts start"
+	}
+```
+
+You can then use `npm run build` to build your project with all the default webpack settings already configured, likewise for formating and linting. The `start` command is used for development mode. See [the scripts package](https://www.npmjs.com/package/@wordpress/scripts) for full documentation.
+
+You can also play with the [Gutenberg Example #03](https://github.com/WordPress/gutenberg-examples/tree/master/03-editable-esnext) for a complete setup using the wp-scripts package.

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -234,6 +234,12 @@
 		"parent": "backward-compatibility"
 	},
 	{
+		"title": "Gutenberg as a Development Platform",
+		"slug": "platform",
+		"markdown_source": "../docs/designers-developers/developers/platform/README.md",
+		"parent": "developers"
+	},
+	{
 		"title": "Designer Documentation",
 		"slug": "designers",
 		"markdown_source": "../docs/designers-developers/designers/README.md",

--- a/docs/toc.json
+++ b/docs/toc.json
@@ -44,7 +44,8 @@
 		{ "docs/designers-developers/developers/backward-compatibility/README.md": [
 			{ "docs/designers-developers/developers/backward-compatibility/deprecations.md": [] },
 			{ "docs/designers-developers/developers/backward-compatibility/meta-box.md": [] }
-		] }
+		] },
+		{ "docs/designers-developers/developers/platform/README.md": [] }
 	] },
 	{ "docs/designers-developers/designers/README.md": [
 		{ "docs/designers-developers/designers/block-design.md": [] },


### PR DESCRIPTION
## Description

Adds a new document section under developer docs for Gutenberg as a Platform.

It initially links to Components and Script, but will be a good place for additional documentation especially around using packages.

## How has this been tested?

[Viewable on the branch here](https://github.com/WordPress/gutenberg/tree/add/docs-guten-platform/docs/designers-developers/developers/platform).


## Types of changes

Documentation.
