### PR TITLE
Add codeowners for env package

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -86,6 +86,9 @@
 /packages/rich-text                             @ellatrix @jorgefilipecosta @daniloercoli @sergioestevao @etoledom
 /packages/block-editor/src/components/rich-text @ellatrix @jorgefilipecosta @daniloercoli @sergioestevao @etoledom
 
+# wp-env
+/packages/env                                   @epiqueras @noahtallen @noisysocks
+
 # PHP
 /lib                                            @timothybjacobs
 


### PR DESCRIPTION
## Description
Adds myself, @epiqueras, and @noisysocks as codeowners of `/packages/env` for easier review of wp-env PRs. :) Let me know if I should modify this list at all.
