### PR TITLE
E2E Tests: Await embed error placeholder size class

### DIFF
--- a/packages/e2e-tests/specs/editor/various/embedding.test.js
+++ b/packages/e2e-tests/specs/editor/various/embedding.test.js
@@ -241,8 +241,13 @@ describe( 'Embedding content', () => {
 		);
 		await page.keyboard.press( 'Enter' );
 
-		// Wait for the request to fail and present an error.
-		await page.waitForSelector( '.components-placeholder__error' );
+		// Wait for the request to fail and present an error. Since placeholder
+		// has styles applied which depend on resize observer, wait for the
+		// expected size class to settle before clicking, since otherwise a race
+		// condition could occur on the placeholder layout vs. click intent.
+		await page.waitForSelector(
+			'.components-placeholder.is-large .components-placeholder__error'
+		);
 
 		await clickButton( 'Convert to link' );
 		expect( await getEditedPostContent() ).toMatchSnapshot();
@@ -269,8 +274,13 @@ describe( 'Embedding content', () => {
 		);
 		await page.keyboard.press( 'Enter' );
 
-		// Wait for the request to fail and present an error.
-		await page.waitForSelector( '.components-placeholder__error' );
+		// Wait for the request to fail and present an error. Since placeholder
+		// has styles applied which depend on resize observer, wait for the
+		// expected size class to settle before clicking, since otherwise a race
+		// condition could occur on the placeholder layout vs. click intent.
+		await page.waitForSelector(
+			'.components-placeholder.is-large .components-placeholder__error'
+		);
 
 		// Set up a different mock to make sure that try again actually does make the request again.
 		await setUpResponseMocking( [


### PR DESCRIPTION
Related: #19825, #20578, #18745
Relevant Slack conversation ([link requires registration](https://make.wordpress.org/chat/)): https://wordpress.slack.com/archives/C02QB2JS7/p1583415961458700

This pull request seeks to attempt to improve the stability of the embeds end-to-end tests. Based on the above Slack conversation, the assumed instability is caused by a race condition between layout changes from styles and a click action by the end-to-end test code. Specifically, the `Placeholder` component uses [a resize listener](https://github.com/WordPress/gutenberg/blob/8a94254b6adac030f5a6ffd8e718972e1f19f48e/packages/components/src/placeholder/index.js#L29-L40) to apply an "element-query"-like responsive class (see #18745). Since the class is only applied after an initial render whereupon the DOM element is measured, there is a chance that a misclick may occur if those styles would result in a layout change of the Placeholder. Specifically, #20578 introduced style changes where font-size may be adjusted for the "large" variant of the placeholder, thus pushing down the "Convert to link" button that the E2E tests attempt to click.

Without `is-large`|With `is-large`
---|---
![image](https://user-images.githubusercontent.com/1779930/76027046-f518c700-5efd-11ea-8663-037911a6d518.png)|![image](https://user-images.githubusercontent.com/1779930/76027062-fba73e80-5efd-11ea-9051-0aa84fa35647.png)

The changes included here wait for the assumed responsive class name to be applied to the Placeholder container before proceeding with the click.

**Testing Instructions:**

Ensure end-to-end tests pass:

```
npm run test-e2e packages/e2e-tests/specs/editor/various/embedding.test.js
```