### PR TITLE
Packages: Add and check types 

### DIFF
--- a/packages/autop/CHANGELOG.md
+++ b/packages/autop/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Master
+
+### New feature
+
+- Include TypeScript type declarations ([#20669](https://github.com/WordPress/gutenberg/pull/20669))
+
 ## 2.3.0 (2019-05-21)
 
 ### Bug Fix

--- a/packages/autop/package.json
+++ b/packages/autop/package.json
@@ -20,6 +20,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"react-native": "src/index",
+	"types": "build-types",
 	"sideEffects": false,
 	"dependencies": {
 		"@babel/runtime": "^7.8.3"

--- a/packages/autop/tsconfig.json
+++ b/packages/autop/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"rootDir": "src",
+		"declarationDir": "build-types"
+	},
+	"references": [ { "path": "../dom-ready" } ],
+	"include": [ "src/**/*" ]
+}

--- a/packages/escape-html/CHANGELOG.md
+++ b/packages/escape-html/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Master
+
+### New feature
+
+- Include TypeScript type declarations ([#20669](https://github.com/WordPress/gutenberg/pull/20669))
+
 ## 1.2.0 (2019-03-20)
 
 - Add fix for WordPress wptexturize greater-than tokenize bug (see https://core.trac.wordpress.org/ticket/45387)

--- a/packages/escape-html/package.json
+++ b/packages/escape-html/package.json
@@ -19,6 +19,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"react-native": "src/index",
+	"types": "build-types",
 	"sideEffects": false,
 	"dependencies": {
 		"@babel/runtime": "^7.8.3"

--- a/packages/escape-html/tsconfig.json
+++ b/packages/escape-html/tsconfig.json
@@ -1,0 +1,8 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"rootDir": "src",
+		"declarationDir": "build-types"
+	},
+	"include": [ "src/**/*" ]
+}

--- a/packages/html-entities/CHANGELOG.md
+++ b/packages/html-entities/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Master
+
+### New feature
+
+- Include TypeScript type declarations ([#20669](https://github.com/WordPress/gutenberg/pull/20669))
+
 ## 2.0.2 (2018-12-12)
 
 ## 2.0.1 (2018-11-21)

--- a/packages/html-entities/package.json
+++ b/packages/html-entities/package.json
@@ -21,6 +21,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"react-native": "src/index",
+	"types": "build-types",
 	"dependencies": {
 		"@babel/runtime": "^7.8.3"
 	},

--- a/packages/html-entities/src/index.js
+++ b/packages/html-entities/src/index.js
@@ -1,3 +1,4 @@
+/** @type {HTMLTextAreaElement} */
 let _decodeTextArea;
 
 /**
@@ -36,5 +37,6 @@ export function decodeEntities( html ) {
 	_decodeTextArea.innerHTML = html;
 	const decoded = _decodeTextArea.textContent;
 	_decodeTextArea.innerHTML = '';
-	return decoded;
+	// Cast to string, HTMLTextElement should always have `string` textContent
+	return /** @type {string} */ ( decoded );
 }

--- a/packages/html-entities/src/index.js
+++ b/packages/html-entities/src/index.js
@@ -37,6 +37,23 @@ export function decodeEntities( html ) {
 	_decodeTextArea.innerHTML = html;
 	const decoded = _decodeTextArea.textContent;
 	_decodeTextArea.innerHTML = '';
-	// Cast to string, HTMLTextElement should always have `string` textContent
+
+	/**
+	 * Cast to string, HTMLTextAreaElement should always have `string` textContent.
+	 *
+	 * > The `textContent` property of the `Node` interface represents the text content of the
+	 * > node and its descendants.
+	 * >
+	 * > Value: A string or `null`
+	 * >
+	 * > * If the node is a `document` or a Doctype, `textContent` returns `null`.
+	 * > * If the node is a CDATA section, comment, processing instruction, or text node,
+	 * >   textContent returns the text inside the node, i.e., the `Node.nodeValue`.
+	 * > * For other node types, `textContent returns the concatenation of the textContent of
+	 * >   every child node, excluding comments and processing instructions. (This is an empty
+	 * >   string if the node has no children.)
+	 *
+	 * @see https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent
+	 */
 	return /** @type {string} */ ( decoded );
 }

--- a/packages/html-entities/tsconfig.json
+++ b/packages/html-entities/tsconfig.json
@@ -1,0 +1,8 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"rootDir": "src",
+		"declarationDir": "build-types"
+	},
+	"include": [ "src/**/*" ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
 		{ "path": "packages/autop" },
 		{ "path": "packages/blob" },
 		{ "path": "packages/dom-ready" },
+		{ "path": "packages/escape-html" },
 		{ "path": "packages/i18n" },
 		{ "path": "packages/is-shallow-equal" },
 		{ "path": "packages/priority-queue" },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
 		{ "path": "packages/blob" },
 		{ "path": "packages/dom-ready" },
 		{ "path": "packages/escape-html" },
+		{ "path": "packages/html-entities" },
 		{ "path": "packages/i18n" },
 		{ "path": "packages/is-shallow-equal" },
 		{ "path": "packages/priority-queue" },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
 	"references": [
 		{ "path": "bin" },
 		{ "path": "packages/a11y" },
+		{ "path": "packages/autop" },
 		{ "path": "packages/blob" },
 		{ "path": "packages/dom-ready" },
 		{ "path": "packages/i18n" },


### PR DESCRIPTION
## Description
Type:
- `@wordpress/autop`
- `@wordpress/escape-html`
- `@wordpress/html-entities`

✅ ~Depends on https://github.com/WordPress/gutenberg/pull/18942 (set as merge base)~

Part of https://github.com/WordPress/gutenberg/issues/18838

## How has this been tested?

The following runs without errors:

```
npm run build:package-types
```

Declaration files are output to each packages' `build-types` directory.

## Types of changes
New feature: Publish TypeScript type declarations.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
