### PR TITLE
GradientPicker: Fix control point UI and drag interaction

### DIFF
--- a/packages/components/src/angle-picker-control/index.js
+++ b/packages/components/src/angle-picker-control/index.js
@@ -39,7 +39,10 @@ const AngleCircle = ( { value, onChange, ...props } ) => {
 
 	const changeAngleToPosition = ( event ) => {
 		const { x: centerX, y: centerY } = angleCircleCenter.current;
+		// Prevent (drag) mouse events from selecting and accidentally
+		// triggering actions from other elements.
 		event.preventDefault();
+
 		onChange( getAngle( centerX, centerY, event.clientX, event.clientY ) );
 	};
 

--- a/packages/components/src/angle-picker-control/index.js
+++ b/packages/components/src/angle-picker-control/index.js
@@ -39,6 +39,7 @@ const AngleCircle = ( { value, onChange, ...props } ) => {
 
 	const changeAngleToPosition = ( event ) => {
 		const { x: centerX, y: centerY } = angleCircleCenter.current;
+		event.preventDefault();
 		onChange( getAngle( centerX, centerY, event.clientX, event.clientY ) );
 	};
 

--- a/packages/components/src/custom-gradient-picker/style.scss
+++ b/packages/components/src/custom-gradient-picker/style.scss
@@ -24,15 +24,22 @@ $components-custom-gradient-picker__padding: 3px; // 24px container, 18px handle
 		border-radius: 50%;
 		background: $white;
 		padding: 2px;
+		min-width: $button-size-small;
 		width: $button-size-small;
 		height: $button-size-small;
 		position: relative;
+
+		svg {
+			height: 100%;
+			width: 100%;
+		}
 	}
 
 	.components-custom-gradient-picker__control-point-button {
 		border: 2px solid $white;
 		border-radius: 50%;
 		height: 18px;
+		padding: 0;
 		position: absolute;
 		width: 18px;
 		top: $components-custom-gradient-picker__padding;
@@ -42,7 +49,6 @@ $components-custom-gradient-picker__padding: 3px; // 24px container, 18px handle
 			color: #23282d;
 			border-color: #999;
 			box-shadow:
-				inset 0 -1px 0 #999,
 				0 0 0 1px $white,
 				0 0 0 3px $blue-medium-focus;
 		}


### PR DESCRIPTION
## Description
<img width="272" alt="Screen Shot 2020-03-05 at 4 37 44 PM" src="https://user-images.githubusercontent.com/2322354/76033242-627a2700-5f01-11ea-9a08-e1849a6492e1.png">

This update fixes the control point circular UI rendered in the (custom) GradientPicker.
It also improves the drag interaction for the angular picker - removing content selection and accidental drag side effects on other UI elements.

## How has this been tested?
Tested locally on Gutenberg.

## Screenshots

Before:
![before](https://user-images.githubusercontent.com/2322354/76033092-02838080-5f01-11ea-9555-cd2acef7e570.gif)

(Note: GIF goes white because dragging at a certain point causes the block to deselect) 

After:
![after](https://user-images.githubusercontent.com/2322354/76033095-06170780-5f01-11ea-8857-4657fc41d6d1.gif)


## Types of changes
* Adjusted CSS
* Add `event.preventDefault` for drag event

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->

Addresses the GradientPicker issue mentioned in
https://github.com/WordPress/gutenberg/issues/20575