### PR TITLE
Allow media library in gallery mode to be reset

### DIFF
--- a/packages/media-utils/src/components/media-upload/index.js
+++ b/packages/media-utils/src/components/media-upload/index.js
@@ -11,6 +11,8 @@ import { __ } from '@wordpress/i18n';
 
 const { wp } = window;
 
+const DEFAULT_EMPTY_GALLERY = [];
+
 /**
  * Prepares the Featured Image toolbars and frames.
  *
@@ -280,8 +282,9 @@ class MediaUpload extends Component {
 			addToGallery = false,
 			allowedTypes,
 			multiple = false,
-			value = null,
+			value = DEFAULT_EMPTY_GALLERY,
 		} = this.props;
+
 		// If the value did not changed there is no need to rebuild the frame,
 		// we can continue to use the existing one.
 		if ( value === this.lastGalleryValue ) {
@@ -298,7 +301,7 @@ class MediaUpload extends Component {
 		if ( addToGallery ) {
 			currentState = 'gallery-library';
 		} else {
-			currentState = value ? 'gallery-edit' : 'gallery';
+			currentState = value && value.length ? 'gallery-edit' : 'gallery';
 		}
 		if ( ! this.GalleryDetailsMediaFrame ) {
 			this.GalleryDetailsMediaFrame = getGalleryDetailsMediaFrame();
@@ -313,7 +316,7 @@ class MediaUpload extends Component {
 			state: currentState,
 			multiple,
 			selection,
-			editing: value ? true : false,
+			editing: value && value.length ? true : false,
 		} );
 		wp.media.frame = this.frame;
 		this.initializeListeners();
@@ -417,11 +420,7 @@ class MediaUpload extends Component {
 	}
 
 	openModal() {
-		if (
-			this.props.gallery &&
-			this.props.value &&
-			this.props.value.length > 0
-		) {
+		if ( this.props.gallery ) {
 			this.buildAndSetGalleryFrame();
 		}
 		this.frame.open();


### PR DESCRIPTION
## Description
Fixes #20627

#20627 describes a situation where passing a falsey value or empty array into the `MediaUpload` component still results in the media library showing the Edit Gallery view with the previous selection of gallery images still selected.

The expected behaviour is for the library to be reset to its original Create Gallery mode. This PR upates the MediaUpload component to have that behaviour.

This core problem was that `this.buildAndSetGalleryFrame();` wasn't being called when the` value` was falsey or an empty array, so the previous edit view was still being recycled:
https://github.com/WordPress/gutenberg/blob/8a94254b6adac030f5a6ffd8e718972e1f19f48e/packages/media-utils/src/components/media-upload/index.js#L420-L426

In addition to that, `buildAndSetGalleryFrame` had some checks for the `value` being falsey to determine whether the edit or create view should be displayed. Given a media library is most likely to be used with a gallery, and galleries supply an array of images, it seemed prudent to primarily check for an empty array. The function now does this, but also supports `undefined` as a value.

## How has this been tested?
A custom block with the following code needs to be registered as none of our core blocks have the ability to reset a gallery.:
```jsx
import { registerBlockType } from '@wordpress/blocks';
import { MediaUpload } from '@wordpress/block-editor';
import { Button } from '@wordpress/components';

registerBlockType( 'test/block', {
	title: 'Test Block',
	icon: 'test gallery',
	category: 'common',
	attributes: {
		imageIds: {
			type: 'Array',
			default: [],
		},
	},
	edit( { attributes, setAttributes } ) {
		const { imageIds } = attributes;
		return (
			<>
				<MediaUpload
					onSelect={ ( selection ) =>
						setAttributes( {
							imageIds: selection.map(
								( selectedImage ) => `${ selectedImage.id }`
							),
						} )
					}
					allowedTypes={ [ 'image' ] }
					value={ imageIds.length ? imageIds : undefined }
					gallery={ true }
					multiple={ true }
					render={ ( { open } ) => (
						<Button isDefault onClick={ open }>
							{ imageIds.length
								? 'Manage images'
								: 'Select images' }
						</Button>
					) }
				/>
				<Button
					isDefault
					isDestructive
					onClick={ () => setAttributes( { imageIds: [] } ) }
				>
					Reset
				</Button>
				{ imageIds && (
					<div>
						{ imageIds.map( ( id ) => {
							return !! id ? ` ${ id } ` : ` (??)`;
						} ) }
					</div>
				) }
			</>
		);
	},
	save() {},
} );
```

1. Add the custom 'Test Block' block
2. Select some initial images for the block using the 'Select Images' option
3. Click 'Manage Images' and click Update gallery
3. Click 'Reset'
4. Click 'Select Images'
5. Observe that the media library displays the 'Create Gallery' view.

Previous Behaviour: The media library displayed the 'Edit Gallery' view even though the gallery is now supposed to contain no images.

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
