### PR TITLE
Document default login credentials and `wp-env run` command

### DIFF
--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -192,7 +192,7 @@ Positionals:
 For example:
 
 ```sh
-;  wp-env run cli wp user list
+wp-env run cli wp user list
 ⠏ Running `wp user list` in 'cli'.
 
 ID      user_login      display_name    user_email      user_registered roles

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -180,7 +180,9 @@ Positionals:
 ```sh
 wp-env run <container> [command..]
 
-Runs an arbitrary command in one of the underlying Docker containers.
+Runs an arbitrary command in one of the underlying Docker containers, for
+example it's useful for running wp cli commands.
+
 
 Positionals:
   container  The container to run the command on.            [string] [required]

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -43,7 +43,7 @@ Then, start the local environment:
 $ wp-env start
 ```
 
-Finally, navigate to http://localhost:8888 in your web browser to see WordPress running with the local WordPress plugin or theme running and activated.
+Finally, navigate to http://localhost:8888 in your web browser to see WordPress running with the local WordPress plugin or theme running and activated. Default login credentials are username: `admin` password: `password`.
 
 ### Stopping the environment
 
@@ -173,6 +173,30 @@ Cleans the WordPress databases.
 Positionals:
   environment  Which environments' databases to clean.
             [string] [choices: "all", "development", "tests"] [default: "tests"]
+```
+
+### `wp-env run [container] [command]` 
+
+```sh
+wp-env run <container> [command..]
+
+Runs an arbitrary command in one of the underlying Docker containers.
+
+Positionals:
+  container  The container to run the command on.            [string] [required]
+  command    The command to run.                           [array] [default: []]
+```
+
+For example:
+
+```sh
+;  wp-env run cli wp user list
+⠏ Running `wp user list` in 'cli'.
+
+ID      user_login      display_name    user_email      user_registered roles
+1       admin   admin   wordpress@example.com   2020-03-05 10:45:14     administrator
+
+✔ Ran `wp user list` in 'cli'. (in 2s 374ms)
 ```
 
 ## .wp-env.json

--- a/packages/env/lib/cli.js
+++ b/packages/env/lib/cli.js
@@ -111,7 +111,7 @@ module.exports = function cli() {
 	);
 	yargs.command(
 		'run <container> [command..]',
-		'Runs an arbitrary command in one of the underlying Docker containers, for example it\'s useful for running wp cli commands.',
+		"Runs an arbitrary command in one of the underlying Docker containers, for example it's useful for running wp cli commands.",
 		( args ) => {
 			args.positional( 'container', {
 				type: 'string',

--- a/packages/env/lib/cli.js
+++ b/packages/env/lib/cli.js
@@ -111,7 +111,7 @@ module.exports = function cli() {
 	);
 	yargs.command(
 		'run <container> [command..]',
-		'Runs an arbitrary command in one of the underlying Docker containers.',
+		'Runs an arbitrary command in one of the underlying Docker containers, for example running wp cli commands.',
 		( args ) => {
 			args.positional( 'container', {
 				type: 'string',
@@ -124,6 +124,7 @@ module.exports = function cli() {
 		},
 		withSpinner( env.run )
 	);
+	yargs.example('$0 run cli wp users list', 'Runs `wp users list` wp-cli command which lists WordPress users.');
 
 	return yargs;
 };

--- a/packages/env/lib/cli.js
+++ b/packages/env/lib/cli.js
@@ -124,7 +124,10 @@ module.exports = function cli() {
 		},
 		withSpinner( env.run )
 	);
-	yargs.example('$0 run cli wp user list', 'Runs `wp user list` wp-cli command which lists WordPress users.');
+	yargs.example(
+		'$0 run cli wp user list',
+		'Runs `wp user list` wp-cli command which lists WordPress users.'
+	);
 
 	return yargs;
 };

--- a/packages/env/lib/cli.js
+++ b/packages/env/lib/cli.js
@@ -124,7 +124,7 @@ module.exports = function cli() {
 		},
 		withSpinner( env.run )
 	);
-	yargs.example('$0 run cli wp users list', 'Runs `wp users list` wp-cli command which lists WordPress users.');
+	yargs.example('$0 run cli wp user list', 'Runs `wp user list` wp-cli command which lists WordPress users.');
 
 	return yargs;
 };

--- a/packages/env/lib/cli.js
+++ b/packages/env/lib/cli.js
@@ -111,7 +111,7 @@ module.exports = function cli() {
 	);
 	yargs.command(
 		'run <container> [command..]',
-		'Runs an arbitrary command in one of the underlying Docker containers, for example running wp cli commands.',
+		'Runs an arbitrary command in one of the underlying Docker containers, for example it\'s useful for running wp cli commands.',
 		( args ) => {
 			args.positional( 'container', {
 				type: 'string',


### PR DESCRIPTION
## Description

When I've been getting up to speed with wp-env, I've been struggling with:

* Logging in to my new WordPress
* Running WP CLI commands

This PR documents both of these in README.

## Types of changes

non-breaking changes