### PR TITLE
Fix widgets screen inserter

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -395,7 +395,13 @@
 		&:hover {
 			color: $white;
 		}
+	}
+}
 
+
+.block-editor-block-list__insertion-point-inserter,
+.block-editor-block-list__block-popover-inserter {
+	.block-editor-inserter__toggle.components-button {
 		// Fade it in after a delay.
 		animation: block-editor-inserter__toggle__fade-in-animation-delayed 1.2s ease;
 		animation-fill-mode: forwards;

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -378,10 +378,25 @@
 }
 
 // Sibling inserter / "inbetweenserter".
-// Fade it in after a delay.
+.block-editor-block-list__empty-block-inserter,
+.block-editor-default-block-appender,
 .block-editor-block-list__insertion-point-inserter,
 .block-editor-block-list__block-popover-inserter {
 	.block-editor-inserter__toggle.components-button {
+		// Basic look
+		background: $dark-gray-primary;
+		border-radius: $radius-block-ui;
+		color: $white;
+
+		// Special dimensions for this button.
+		min-width: 24px;
+		height: 24px;
+
+		&:hover {
+			color: $white;
+		}
+
+		// Fade it in after a delay.
 		animation: block-editor-inserter__toggle__fade-in-animation-delayed 1.2s ease;
 		animation-fill-mode: forwards;
 		@include reduce-motion("animation");

--- a/packages/block-editor/src/components/default-block-appender/style.scss
+++ b/packages/block-editor/src/components/default-block-appender/style.scss
@@ -51,21 +51,6 @@
 	line-height: $editor-line-height;
 }
 
-// Basic look for sibling inserter, and side-inserter.
-.block-editor-inserter__toggle.components-button {
-	background: $dark-gray-primary;
-	border-radius: $radius-block-ui;
-	color: $white;
-
-	// Special dimensions for this button.
-	min-width: 24px;
-	height: 24px;
-
-	&:hover {
-		color: $white;
-	}
-}
-
 // Empty / default block side inserter.
 .block-editor-block-list__empty-block-inserter.block-editor-block-list__empty-block-inserter, // Empty paragraph, needs specificity to override inherited popover styles.
 .block-editor-default-block-appender .block-editor-inserter { // Empty appender.

--- a/packages/edit-post/src/components/header/style.scss
+++ b/packages/edit-post/src/components/header/style.scss
@@ -51,9 +51,6 @@
 
 .edit-post-header__toolbar {
 	.block-editor-inserter__toggle {
-		background: $theme-color;
-		margin-right: $grid-unit-10;
-
 		// Special dimensions for this button.
 		min-width: 32px;
 		height: 32px;

--- a/packages/edit-widgets/src/components/header/style.scss
+++ b/packages/edit-widgets/src/components/header/style.scss
@@ -3,14 +3,11 @@
 	align-items: center;
 	justify-content: space-between;
 	height: $header-height;
+	padding: 0 $grid-unit-20;
 }
 
 .edit-widgets-header__title {
 	font-size: 16px;
 	padding: 0 20px;
 	margin: 0;
-}
-
-.edit-widgets-header__actions {
-	padding: 0 20px;
 }

--- a/packages/edit-widgets/src/components/widget-area/index.js
+++ b/packages/edit-widgets/src/components/widget-area/index.js
@@ -29,6 +29,8 @@ import Sidebar from '../sidebar';
 import SelectionObserver from './selection-observer';
 import Inserter from '../inserter';
 
+const inserterToggleProps = { isPrimary: true };
+
 function getBlockEditorSettings( blockEditorSettings, hasUploadPermissions ) {
 	if ( ! hasUploadPermissions ) {
 		return blockEditorSettings;
@@ -128,7 +130,9 @@ function WidgetArea( {
 						{ isSelectedArea && (
 							<>
 								<Inserter>
-									<BlockInserter />
+									<BlockInserter
+										toggleProps={ inserterToggleProps }
+									/>
 								</Inserter>
 								<BlockEditorKeyboardShortcuts />
 							</>


### PR DESCRIPTION
This fixes the widgets screen inserter but also refactors the inserter style to avoid the global override of button styles.

<img width="1291" alt="Capture d’écran 2020-03-06 à 10 41 37 AM" src="https://user-images.githubusercontent.com/272444/76071867-43c66f80-5f97-11ea-8614-71adce9316b3.png">
