### PR TITLE
Preview Button: Remove the separator and border, and reduce the size of the icon.

### DIFF
--- a/packages/block-library/src/embed/test/__snapshots__/index.js.snap
+++ b/packages/block-library/src/embed/test/__snapshots__/index.js.snap
@@ -79,12 +79,12 @@ exports[`core/embed block edit matches snapshot 1`] = `
           focusable="false"
           height="24"
           role="img"
-          viewBox="-2 -2 24 24"
+          viewBox="0 0 24 24"
           width="24"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path
-            d="M9 3h8v8l-2-1V6.92l-5.6 5.59-1.41-1.41L14.08 5H10zm3 12v-3l2-2v7H3V6h8L9 8H5v7h7z"
+            d="M18.2 17c0 .7-.6 1.2-1.2 1.2H7c-.7 0-1.2-.6-1.2-1.2V7c0-.7.6-1.2 1.2-1.2h3.2V4.2H7C5.5 4.2 4.2 5.5 4.2 7v10c0 1.5 1.2 2.8 2.8 2.8h10c1.5 0 2.8-1.2 2.8-2.8v-3.6h-1.5V17zM14.9 3v1.5h3.7l-6.4 6.4 1.1 1.1 6.4-6.4v3.7h1.5V3h-6.3z"
           />
         </svg>
       </a>

--- a/packages/edit-post/src/components/header/style.scss
+++ b/packages/edit-post/src/components/header/style.scss
@@ -29,6 +29,11 @@
 			order: initial;
 		}
 	}
+
+	// Adjust icon sizes for dropdowns
+	.components-dropdown svg {
+		height: 16px;
+	}
 }
 
 .edit-post-header__toolbar {

--- a/packages/edit-post/src/components/header/style.scss
+++ b/packages/edit-post/src/components/header/style.scss
@@ -29,11 +29,6 @@
 			order: initial;
 		}
 	}
-
-	// Adjust icon sizes for dropdowns
-	.components-dropdown svg {
-		height: 16px;
-	}
 }
 
 .edit-post-header__toolbar {

--- a/packages/edit-post/src/components/preview-options/index.js
+++ b/packages/edit-post/src/components/preview-options/index.js
@@ -17,7 +17,7 @@ import {
 } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { PostPreviewButton } from '@wordpress/editor';
-import { __, _x } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { external, check } from '@wordpress/icons';
 
 const downArrow = (
@@ -72,7 +72,7 @@ export default function PreviewOptions( {
 			) }
 			renderContent={ () => (
 				<>
-					<MenuGroup label={ _x( 'View', 'noun' ) }>
+					<MenuGroup>
 						<MenuItem
 							className="editor-post-preview__button-resize"
 							onClick={ () => setPreviewDeviceType( 'Desktop' ) }
@@ -106,8 +106,8 @@ export default function PreviewOptions( {
 									forcePreviewLink={ forcePreviewLink }
 									textContent={
 										<>
-											{ __( 'Preview externally' ) }
 											<Icon icon={ external } />
+											{ __( 'Preview in new tab' ) }
 										</>
 									}
 								/>

--- a/packages/edit-post/src/components/preview-options/index.js
+++ b/packages/edit-post/src/components/preview-options/index.js
@@ -22,7 +22,6 @@ import { external, check } from '@wordpress/icons';
 
 const downArrow = (
 	<SVG
-		className="editor-post-preview__button-icon"
 		width="24"
 		height="24"
 		xmlns="http://www.w3.org/2000/svg"
@@ -43,17 +42,6 @@ export default function PreviewOptions( {
 	const deviceType = useSelect( ( select ) => {
 		return select( 'core/edit-post' ).__experimentalGetPreviewDeviceType();
 	}, [] );
-
-	const translateDropdownButtonText = () => {
-		switch ( deviceType ) {
-			case 'Tablet':
-				return __( 'Tablet' );
-			case 'Mobile':
-				return __( 'Mobile' );
-			default:
-				return __( 'Desktop' );
-		}
-	};
 
 	const isSaveable = useSelect( ( select ) => {
 		return select( 'core/editor' ).isEditedPostSaveable();
@@ -78,7 +66,7 @@ export default function PreviewOptions( {
 					aria-expanded={ isOpen }
 					disabled={ ! isSaveable }
 				>
-					{ translateDropdownButtonText() }
+					{ __( 'Preview' ) }
 					{ downArrow }
 				</Button>
 			) }

--- a/packages/edit-post/src/components/preview-options/index.js
+++ b/packages/edit-post/src/components/preview-options/index.js
@@ -22,6 +22,7 @@ import { external, check } from '@wordpress/icons';
 
 const downArrow = (
 	<SVG
+		className="editor-post-preview__button-icon"
 		width="24"
 		height="24"
 		xmlns="http://www.w3.org/2000/svg"
@@ -78,9 +79,7 @@ export default function PreviewOptions( {
 					disabled={ ! isSaveable }
 				>
 					{ translateDropdownButtonText() }
-					<div className="editor-post-preview__button-separator">
-						{ downArrow }
-					</div>
+					{ downArrow }
 				</Button>
 			) }
 			renderContent={ () => (

--- a/packages/edit-post/src/components/preview-options/style.scss
+++ b/packages/edit-post/src/components/preview-options/style.scss
@@ -1,19 +1,23 @@
 .editor-post-preview__dropdown {
 	display: none;
 	margin-right: $grid-unit-15;
-	box-shadow: inset 0 0 0 $border-width $light-gray-secondary;
-	border-radius: $radius-block-ui;
+	//box-shadow: inset 0 0 0 $border-width $light-gray-secondary;
+	//border-radius: $radius-block-ui;
 	padding: 0;
 }
 
 .editor-post-preview__button-toggle {
 	display: flex;
 	justify-content: space-between;
-	padding: 0 0 0 $grid-unit-15;
+	padding: 0 $grid-unit-15;
 
 	&:focus:not(:disabled) {
 		box-shadow: inset 0 0 0 1px $white, 0 0 0 2px color($theme-color);
 	}
+}
+
+.editor-post-preview__button-icon {
+	height: 16px;
 }
 
 .editor-post-preview__button-resize.editor-post-preview__button-resize {
@@ -22,15 +26,6 @@
 	&.has-icon {
 		padding-left: $grid-unit-10;
 	}
-}
-
-.editor-post-preview__button-separator {
-	border-left: $border-width solid $light-gray-secondary;
-	padding: 6px;
-	margin-left: $grid-unit-15;
-	display: flex;
-	align-items: center;
-	justify-content: center;
 }
 
 .editor-post-preview__dropdown-content {

--- a/packages/edit-post/src/components/preview-options/style.scss
+++ b/packages/edit-post/src/components/preview-options/style.scss
@@ -14,10 +14,6 @@
 	&:focus:not(:disabled) {
 		box-shadow: inset 0 0 0 1px $white, 0 0 0 2px color($theme-color);
 	}
-
-	svg {
-		height: 16px;
-	}
 }
 
 .editor-post-preview__button-resize.editor-post-preview__button-resize {
@@ -48,11 +44,16 @@
 }
 
 .editor-post-preview__button-external {
-	padding-left: $button-size-small + $grid-unit-10 + $grid-unit-10;
+	padding-left: 8px;
 	margin-right: auto;
 	width: 100%;
 	display: flex;
-	justify-content: space-between;
+	justify-content: flex-start;
+
+	svg {
+		margin-right: 8px;
+		height: 20px;
+	}
 }
 
 @include break-small() {

--- a/packages/edit-post/src/components/preview-options/style.scss
+++ b/packages/edit-post/src/components/preview-options/style.scss
@@ -14,10 +14,10 @@
 	&:focus:not(:disabled) {
 		box-shadow: inset 0 0 0 1px $white, 0 0 0 2px color($theme-color);
 	}
-}
 
-.editor-post-preview__button-icon {
-	height: 16px;
+	svg {
+		height: 16px;
+	}
 }
 
 .editor-post-preview__button-resize.editor-post-preview__button-resize {

--- a/packages/edit-post/src/components/preview-options/style.scss
+++ b/packages/edit-post/src/components/preview-options/style.scss
@@ -1,18 +1,20 @@
 .editor-post-preview__dropdown {
 	display: none;
 	margin-right: $grid-unit-15;
-	//box-shadow: inset 0 0 0 $border-width $light-gray-secondary;
-	//border-radius: $radius-block-ui;
 	padding: 0;
 }
 
 .editor-post-preview__button-toggle {
 	display: flex;
 	justify-content: space-between;
-	padding: 0 $grid-unit-15;
+	padding: 0 $grid-unit-10 0 $grid-unit-15;
 
 	&:focus:not(:disabled) {
 		box-shadow: inset 0 0 0 1px $white, 0 0 0 2px color($theme-color);
+	}
+
+	svg {
+		margin-left: $grid-unit-05;
 	}
 }
 
@@ -44,15 +46,14 @@
 }
 
 .editor-post-preview__button-external {
-	padding-left: 8px;
+	padding-left: $grid-unit-10;
 	margin-right: auto;
 	width: 100%;
 	display: flex;
 	justify-content: flex-start;
 
 	svg {
-		margin-right: 8px;
-		height: 20px;
+		margin-right: $grid-unit-10;
 	}
 }
 

--- a/packages/icons/src/library/external.js
+++ b/packages/icons/src/library/external.js
@@ -4,8 +4,8 @@
 import { Path, SVG } from '@wordpress/primitives';
 
 const external = (
-	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="-2 -2 24 24">
-		<Path d="M9 3h8v8l-2-1V6.92l-5.6 5.59-1.41-1.41L14.08 5H10zm3 12v-3l2-2v7H3V6h8L9 8H5v7h7z" />
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+		<Path d="M18.2 17c0 .7-.6 1.2-1.2 1.2H7c-.7 0-1.2-.6-1.2-1.2V7c0-.7.6-1.2 1.2-1.2h3.2V4.2H7C5.5 4.2 4.2 5.5 4.2 7v10c0 1.5 1.2 2.8 2.8 2.8h10c1.5 0 2.8-1.2 2.8-2.8v-3.6h-1.5V17zM14.9 3v1.5h3.7l-6.4 6.4 1.1 1.1 6.4-6.4v3.7h1.5V3h-6.3z" />
 	</SVG>
 );
 

--- a/storybook/test/__snapshots__/index.js.snap
+++ b/storybook/test/__snapshots__/index.js.snap
@@ -3036,12 +3036,12 @@ exports[`Storyshots Components/ExternalLink Default 1`] = `
     focusable="false"
     height={24}
     role="img"
-    viewBox="-2 -2 24 24"
+    viewBox="0 0 24 24"
     width={24}
     xmlns="http://www.w3.org/2000/svg"
   >
     <path
-      d="M9 3h8v8l-2-1V6.92l-5.6 5.59-1.41-1.41L14.08 5H10zm3 12v-3l2-2v7H3V6h8L9 8H5v7h7z"
+      d="M18.2 17c0 .7-.6 1.2-1.2 1.2H7c-.7 0-1.2-.6-1.2-1.2V7c0-.7.6-1.2 1.2-1.2h3.2V4.2H7C5.5 4.2 4.2 5.5 4.2 7v10c0 1.5 1.2 2.8 2.8 2.8h10c1.5 0 2.8-1.2 2.8-2.8v-3.6h-1.5V17zM14.9 3v1.5h3.7l-6.4 6.4 1.1 1.1 6.4-6.4v3.7h1.5V3h-6.3z"
     />
   </svg>
 </a>
@@ -11021,12 +11021,12 @@ exports[`Storyshots Icons/Icon Library 1`] = `
       focusable="false"
       height={24}
       role="img"
-      viewBox="-2 -2 24 24"
+      viewBox="0 0 24 24"
       width={24}
       xmlns="http://www.w3.org/2000/svg"
     >
       <path
-        d="M9 3h8v8l-2-1V6.92l-5.6 5.59-1.41-1.41L14.08 5H10zm3 12v-3l2-2v7H3V6h8L9 8H5v7h7z"
+        d="M18.2 17c0 .7-.6 1.2-1.2 1.2H7c-.7 0-1.2-.6-1.2-1.2V7c0-.7.6-1.2 1.2-1.2h3.2V4.2H7C5.5 4.2 4.2 5.5 4.2 7v10c0 1.5 1.2 2.8 2.8 2.8h10c1.5 0 2.8-1.2 2.8-2.8v-3.6h-1.5V17zM14.9 3v1.5h3.7l-6.4 6.4 1.1 1.1 6.4-6.4v3.7h1.5V3h-6.3z"
       />
     </svg>
     <svg
@@ -11034,12 +11034,12 @@ exports[`Storyshots Icons/Icon Library 1`] = `
       focusable="false"
       height={36}
       role="img"
-      viewBox="-2 -2 24 24"
+      viewBox="0 0 24 24"
       width={36}
       xmlns="http://www.w3.org/2000/svg"
     >
       <path
-        d="M9 3h8v8l-2-1V6.92l-5.6 5.59-1.41-1.41L14.08 5H10zm3 12v-3l2-2v7H3V6h8L9 8H5v7h7z"
+        d="M18.2 17c0 .7-.6 1.2-1.2 1.2H7c-.7 0-1.2-.6-1.2-1.2V7c0-.7.6-1.2 1.2-1.2h3.2V4.2H7C5.5 4.2 4.2 5.5 4.2 7v10c0 1.5 1.2 2.8 2.8 2.8h10c1.5 0 2.8-1.2 2.8-2.8v-3.6h-1.5V17zM14.9 3v1.5h3.7l-6.4 6.4 1.1 1.1 6.4-6.4v3.7h1.5V3h-6.3z"
       />
     </svg>
     <svg
@@ -11047,12 +11047,12 @@ exports[`Storyshots Icons/Icon Library 1`] = `
       focusable="false"
       height={48}
       role="img"
-      viewBox="-2 -2 24 24"
+      viewBox="0 0 24 24"
       width={48}
       xmlns="http://www.w3.org/2000/svg"
     >
       <path
-        d="M9 3h8v8l-2-1V6.92l-5.6 5.59-1.41-1.41L14.08 5H10zm3 12v-3l2-2v7H3V6h8L9 8H5v7h7z"
+        d="M18.2 17c0 .7-.6 1.2-1.2 1.2H7c-.7 0-1.2-.6-1.2-1.2V7c0-.7.6-1.2 1.2-1.2h3.2V4.2H7C5.5 4.2 4.2 5.5 4.2 7v10c0 1.5 1.2 2.8 2.8 2.8h10c1.5 0 2.8-1.2 2.8-2.8v-3.6h-1.5V17zM14.9 3v1.5h3.7l-6.4 6.4 1.1 1.1 6.4-6.4v3.7h1.5V3h-6.3z"
       />
     </svg>
   </div>


### PR DESCRIPTION
There's a few visual things about the new device-preview button that have been bothering me. 

The first is the separator between the currently selected device, and the dropdown arrow. The line makes me thing that this button does two things; I'd expect different behavior when clicking the label and when clicking the icon. But both the label and the icon both trigger the same action. So, I don't see the need for the line at all. This PR removes it.

The border around button feels a little strange. Not all buttons in the toolbar have a border, in fact I don't see any other buttons in the top toolbar, or block toolbars that use a border. So, I removed the border and kind of like how it feels. What do you think?

The icon's current size feels too heavy. When compared to other dropdown in the editor and WordPress, the icon is larger than others. So, I reduces the size of the icon down to 16px and it feels nicer. What do you think?

Current:
<img width="417" alt="image" src="https://user-images.githubusercontent.com/191598/76098638-d1a25a80-5f97-11ea-8f0a-70c185128818.png">

This PR:
<img width="394" alt="image" src="https://user-images.githubusercontent.com/191598/76098388-593b9980-5f97-11ea-9efe-2595cef99064.png">
