### PR TITLE
Device Preview: Reduce contrast and add a shadow

### DIFF
--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -123,7 +123,8 @@
 	}
 }
 
+// Creates the background "surface" when changing the viewport
+// size (Desktop, Tablet, Mobile) using the preview-options button.
 .edit-post-layout .block-editor-editor-skeleton__content {
-	background-color: $light-gray-700;
+	background-color: $light-gray-500;
 }
-

--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -4,6 +4,10 @@
 	// Default background color so that grey .edit-post-editor-regions__content color doesn't show through.
 	background-color: $white;
 
+	// This helps to create the canvas "surface" when changing the viewport
+	// size (Desktop, Tablet, Mobile) using the preview-options button.
+	box-shadow: 0 2px 4px $light-gray-900;
+
 	& .components-button {
 		font-family: $default-font;
 	}


### PR DESCRIPTION
This one might be personal preference, so I'd love your feedback.

Right now the device preview (Tablet and Mobile) uses a slightly dark background to show how the current document would look at estimated viewport sizes.

Current:
<img width="631" alt="image" src="https://user-images.githubusercontent.com/191598/76101349-48415700-5f9c-11ea-9686-ad21726410d7.png">

The current background colors feels a little _too_ dark, so this PR lightens it up a bit. Along with that, the white canvas feels a little _lifeless_? (Maybe that the wrong word, but it feels _off_.) Adding a subtle box-shadow helps me understand its relationship to the editor surface behind it.

This PR:
<img width="749" alt="Screen Shot 2020-03-06 at 11 10 15 AM" src="https://user-images.githubusercontent.com/191598/76101843-0e248500-5f9d-11ea-9e2b-56aadaa98277.png">
