### PR TITLE
Top Bar Inserter: Add more space between the inserter button and the tools button.

### DIFF
--- a/packages/edit-post/src/components/header/style.scss
+++ b/packages/edit-post/src/components/header/style.scss
@@ -54,6 +54,7 @@
 		// Special dimensions for this button.
 		min-width: 32px;
 		height: 32px;
+		margin-right: 8px;
 	}
 }
 


### PR DESCRIPTION
Right now, the Tools button is right up against the Inserter button in the top toolbar:

<img width="226" alt="image" src="https://user-images.githubusercontent.com/191598/76102515-1d580280-5f9e-11ea-9554-9f2bd95d43c4.png">

Its feeling a little cramped. This PR adds 8px of margin to the right of the Inserter button:

<img width="201" alt="Screen Shot 2020-03-06 at 11 30 14 AM" src="https://user-images.githubusercontent.com/191598/76102544-28ab2e00-5f9e-11ea-8c88-32f415f8748a.png">
