### PR TITLE
Docs: Fixes links in platform and custom block editor tutorial

### DIFF
--- a/docs/designers-developers/developers/platform/README.md
+++ b/docs/designers-developers/developers/platform/README.md
@@ -58,5 +58,5 @@ You can also play with the [Gutenberg Example #03](https://github.com/WordPress/
 
 The [`@wordpress/block-editor` package](https://developer.wordpress.org/block-editor/packages/packages-block-editor/) allows you to create and use standalone block editors.
 
-You can learn more by reading the [tutorial "Building a custom block editor"](./custom-block-editor/README.md).
+You can learn more by reading the [tutorial "Building a custom block editor"](/docs/designers-developers/developers/platform/custom-block-editor/README.md).
 

--- a/docs/designers-developers/developers/platform/custom-block-editor/README.md
+++ b/docs/designers-developers/developers/platform/custom-block-editor/README.md
@@ -15,4 +15,4 @@ Code snippets are provided in "ESNext". ESNext refers to the next versions of th
 
 Note that it is not required to use ESNext to create blocks or extend the editor, you can use classic JavaScript. However, once familiar with ESNext, developers find it is easier to read and write, thus most code examples you'll find use the ESNext syntax.
 
-* [Start custom block editor tutorial](/docs/designers-developers/developers/platform/tutorial.md)
+* [Start custom block editor tutorial](/docs/designers-developers/developers/platform/custom-block-editor/tutorial.md)

--- a/docs/designers-developers/developers/platform/custom-block-editor/README.md
+++ b/docs/designers-developers/developers/platform/custom-block-editor/README.md
@@ -1,16 +1,18 @@
 # Building a custom block editor
 
-The purpose of [this tutorial](tutorial.md) is to step through the fundamentals of creating a custom instance of a "block editor".
+The purpose of [this tutorial](/docs/designers-developers/developers/platform/tutorial.md) is to step through the fundamentals of creating a custom instance of a "block editor".
 
 ![alt text](https://wordpress.org/gutenberg/files/2020/03/editor.png "The Standalone Editor instance populated with example Blocks within a custom WP Admin page.")
 
-The editor you will see in this tutorial (as above) is **__not__ be the same Block Editor you are familiar with when creating Posts** in with WordPress. Rather it is an entirely **custom block editor instance** built using the lower-level [`@wordpress/block-editor`](https://developer.wordpress.org/block-editor/packages/packages-block-editor/) package (and friends).
+The editor you will see in this tutorial (as above) is **__not__ the same Block Editor you are familiar with when creating Posts** in with WordPress. Rather it is an entirely **custom block editor instance** built using the lower-level [`@wordpress/block-editor`](https://developer.wordpress.org/block-editor/packages/packages-block-editor/) package (and friends).
 
 ## Following this tutorial
-To follow along with this tutorial, you can [download the accompanying WordPress plugin](https://github.com/getdave/standalone-block-editor) which includes all of the examples for you to try on your own site.
 
+To follow along with this tutorial, you can [download the accompanying WordPress plugin](https://github.com/getdave/standalone-block-editor) which includes all of the examples for you to try on your own site.
 
 ## Code Syntax
 Code snippets are provided in "ESNext". ESNext refers to the next versions of the language standard, plus JSX syntax.
 
 Note that it is not required to use ESNext to create blocks or extend the editor, you can use classic JavaScript. However, once familiar with ESNext, developers find it is easier to read and write, thus most code examples you'll find use the ESNext syntax.
+
+* [Start custom block editor tutorial](/docs/designers-developers/developers/platform/tutorial.md)

--- a/docs/designers-developers/developers/platform/custom-block-editor/README.md
+++ b/docs/designers-developers/developers/platform/custom-block-editor/README.md
@@ -1,6 +1,6 @@
 # Building a custom block editor
 
-The purpose of [this tutorial](/docs/designers-developers/developers/platform/tutorial.md) is to step through the fundamentals of creating a custom instance of a "block editor".
+The purpose of [this tutorial](/docs/designers-developers/developers/platform/custom-block-editor/tutorial.md) is to step through the fundamentals of creating a custom instance of a "block editor".
 
 ![alt text](https://wordpress.org/gutenberg/files/2020/03/editor.png "The Standalone Editor instance populated with example Blocks within a custom WP Admin page.")
 


### PR DESCRIPTION
## Description

Fixes doc links for platform page and custom block editor.

I missed this on first review, all links in documentation need to use links starting at the top-level docs `/docs/...` this is needed for the scripts that publish to https://developer.wordpress.org/block-editor/

## How has this been tested?

[Confirm links on branch here](https://github.com/WordPress/gutenberg/tree/fix/docs-platform-links/docs/designers-developers/developers/platform)

## Types of changes

Documentation.
