### PR TITLE
Block Library: Flatten width calculation of gallery columns

### DIFF
--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -102,7 +102,7 @@
 		@for $i from 3 through 8 {
 			&.columns-#{ $i } .blocks-gallery-image,
 			&.columns-#{ $i } .blocks-gallery-item {
-				width: calc(#{ 100% / $i } - #{ $grid-unit-20 * ( $i - 1 ) });
+				width: calc(#{ 100% / $i } - #{ $grid-unit-20 * ( $i - 1 ) / $i });
 				margin-right: $grid-unit-20;
 			}
 		}

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -84,7 +84,7 @@
 	// On mobile and responsive viewports, we allow only 1 or 2 columns at the most.
 	& .blocks-gallery-image,
 	& .blocks-gallery-item {
-		width: calc((100% - #{ $grid-unit-20 }) / 2);
+		width: calc(50% - #{ $grid-unit-20 });
 
 		&:nth-of-type(even) {
 			margin-right: 0;
@@ -102,15 +102,8 @@
 		@for $i from 3 through 8 {
 			&.columns-#{ $i } .blocks-gallery-image,
 			&.columns-#{ $i } .blocks-gallery-item {
-				width: calc((100% - #{ $grid-unit-20 } * #{ $i - 1 }) / #{ $i });
-				margin-right: 16px;
-
-				// Rules inside this query are only run by Microsoft Edge.
-				// Edge miscalculates `calc`, so we have to add some buffer.
-				// See also https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/15637241/
-				@supports (-ms-ime-align:auto) {
-					width: calc((100% - #{ $grid-unit-20 } * #{ $i - 1 }) / #{ $i } - 1px);
-				}
+				width: calc(#{ 100% / $i } - #{ $grid-unit-20 * ( $i - 1 ) });
+				margin-right: $grid-unit-20;
 			}
 		}
 


### PR DESCRIPTION
Fixes #20652 

This pull request seeks to update the width calculation applied to the gallery block columns. These changes are intended both as a simplification/unification of the width calculation, and as a resolution to a crash which occurs in Microsoft Edge.

As observed at https://github.com/WordPress/gutenberg/issues/20652#issuecomment-595439037, the crash appears to occur as a result of the Edge-specific `@supports (-ms-ime-align:auto) {` block implemented in the gallery block styles.

As noted in #13326, the original issue #13270 is a result of how Edge interprets the `width` style. Compare how the style `width: calc((100% - 16px * 2) / 3);` is interpreted between Edge and Chrome:

Edge|Chrome
---|---
![Screen_Shot_2020-03-06_at_1_15_46_PM](https://user-images.githubusercontent.com/1779930/76111143-bd695800-5fad-11ea-94be-267eb61abb10.png)|![Screen_Shot_2020-03-06_at_1_16_03_PM](https://user-images.githubusercontent.com/1779930/76111144-bd695800-5fad-11ea-94a4-cb8b8bb0929c.png)

The proposed changes should apply effectively the same width, but simplify the calculation at compile time, resulting in the style `calc(33.33333% - 10.66667px)`. It appears that this is handled better in Edge, avoiding the early wrapping, rounding down to `10.66px` per column.

![image](https://user-images.githubusercontent.com/1779930/76112097-8d22b900-5faf-11ea-80e5-6e346b45378c.png)

Aside: There is overflow which occurs in Edge for the gallery block, with or without these changes. This should probably be investigated separately.
 
**Testing Instructions:**

Repeat steps to reproduce from #20652, verifying that no crash occurs.

Repeat steps to reproduce from #13270 / testing instructions from #13326, verifying that gallery columns wrap as expected both in Edge and in your preferred browser.

**Follow-up tasks:**

There is another style which uses the problematic `@supports(-ms-ime-align:auto)` block:

https://github.com/WordPress/gutenberg/blob/3ab37270ac91bec58ac6e137fd1d7d26b7f1b15d/packages/components/src/modal/style.scss#L80-L86

However, there is no immediate crash which occurs as a result of this style. The problem may only manifest as a combination of `@supports` within a `@media` media query. In any case, over time we should consider removing these Edge-specific styles, which are no longer valid in recent Chromium-based versions of Edge.