### PR TITLE
Expand create block options and add readme.txt template

### DIFF
--- a/packages/create-block/lib/prompts.js
+++ b/packages/create-block/lib/prompts.js
@@ -96,9 +96,6 @@ const version = {
 	type: 'input',
 	name: 'author',
 	message: 'The plugin version:',
-	filter( input ) {
-		return input || '0.1.0';
-	},
 };
 
 module.exports = {

--- a/packages/create-block/lib/prompts.js
+++ b/packages/create-block/lib/prompts.js
@@ -84,9 +84,12 @@ const license = {
 	type: 'input',
 	name: 'license',
 	message: 'The plugin license:',
-	filter( input ) {
-		return input || 'GPLv2 or later';
-	},
+};
+
+const licenseURI = {
+	type: 'input',
+	name: 'licenseURI',
+	message: 'The plugin license URI:',
 };
 
 const version = {
@@ -107,5 +110,6 @@ module.exports = {
 	category,
 	author,
 	license,
+	licenseURI,
 	version,
 };

--- a/packages/create-block/lib/prompts.js
+++ b/packages/create-block/lib/prompts.js
@@ -73,6 +73,31 @@ const category = {
 	choices: [ 'common', 'embed', 'formatting', 'layout', 'widgets' ],
 };
 
+const author = {
+	type: 'input',
+	name: 'author',
+	message:
+		"The author name — this should be a list of wordpress.org userid's:",
+};
+
+const license = {
+	type: 'input',
+	name: 'license',
+	message: 'The plugin license:',
+	filter( input ) {
+		return input || 'GPLv2 or later';
+	},
+};
+
+const version = {
+	type: 'input',
+	name: 'author',
+	message: 'The plugin version:',
+	filter( input ) {
+		return input || '0.1.0';
+	},
+};
+
 module.exports = {
 	slug,
 	namespace,
@@ -80,4 +105,7 @@ module.exports = {
 	description,
 	dashicon,
 	category,
+	author,
+	license,
+	version,
 };

--- a/packages/create-block/lib/prompts.js
+++ b/packages/create-block/lib/prompts.js
@@ -94,7 +94,7 @@ const licenseURI = {
 
 const version = {
 	type: 'input',
-	name: 'author',
+	name: 'version',
 	message: 'The plugin version:',
 };
 

--- a/packages/create-block/lib/prompts.js
+++ b/packages/create-block/lib/prompts.js
@@ -77,7 +77,7 @@ const author = {
 	type: 'input',
 	name: 'author',
 	message:
-		"The author name — this should be a list of wordpress.org userid's:",
+		"The author name — this should be a list of wordpress.org user id's:",
 };
 
 const license = {

--- a/packages/create-block/lib/prompts.js
+++ b/packages/create-block/lib/prompts.js
@@ -77,25 +77,25 @@ const author = {
 	type: 'input',
 	name: 'author',
 	message:
-		"The author name — this should be a list of wordpress.org user id's:",
+		'The list of contributors containing only WordPress.org usernames (optional):',
 };
 
 const license = {
 	type: 'input',
 	name: 'license',
-	message: 'The plugin license:',
+	message: 'The plugin license (optional):',
 };
 
 const licenseURI = {
 	type: 'input',
 	name: 'licenseURI',
-	message: 'The plugin license URI:',
+	message: 'The plugin license URI (optional):',
 };
 
 const version = {
 	type: 'input',
 	name: 'version',
-	message: 'The plugin version:',
+	message: 'The plugin version (optional):',
 };
 
 module.exports = {

--- a/packages/create-block/lib/scaffold.js
+++ b/packages/create-block/lib/scaffold.js
@@ -25,6 +25,7 @@ module.exports = async function(
 		category,
 		author,
 		license,
+		licenseURI,
 		version,
 	}
 ) {
@@ -46,6 +47,7 @@ module.exports = async function(
 		version,
 		author,
 		license,
+		licenseURI,
 		textdomain: namespace,
 	};
 	await Promise.all(

--- a/packages/create-block/lib/templates.js
+++ b/packages/create-block/lib/templates.js
@@ -19,7 +19,7 @@ const templates = {
 			slug: 'es5-example',
 			title: 'ES5 Example',
 			description:
-				'Example block written with ES5 standard and no JSX – no build step required.',
+				'Example block written with ES5 standard and no JSX – no build step required. This should be no more than 150 characters. No markup here.',
 			dashicon,
 			category,
 			author,
@@ -42,7 +42,7 @@ const templates = {
 			slug: 'esnext-example',
 			title: 'ESNext Example',
 			description:
-				'Example block written with ESNext standard and JSX support – build step required.',
+				'Example block written with ESNext standard and JSX support – build step required. This should be no more than 150 characters. No markup here.',
 			dashicon,
 			category,
 			author,

--- a/packages/create-block/lib/templates.js
+++ b/packages/create-block/lib/templates.js
@@ -9,6 +9,7 @@ const dashicon = 'smiley';
 const category = 'widgets';
 const author = 'The WordPress Contributors';
 const license = 'GPL-2.0-or-later';
+const licenseURI = 'https://www.gnu.org/licenses/gpl-2.0.html';
 const version = '0.1.0';
 
 const templates = {
@@ -23,6 +24,7 @@ const templates = {
 			category,
 			author,
 			license,
+			licenseURI,
 			version,
 		},
 		outputFiles: [
@@ -45,6 +47,7 @@ const templates = {
 			category,
 			author,
 			license,
+			licenseURI,
 			version,
 		},
 		outputFiles: [

--- a/packages/create-block/lib/templates.js
+++ b/packages/create-block/lib/templates.js
@@ -19,7 +19,7 @@ const templates = {
 			slug: 'es5-example',
 			title: 'ES5 Example',
 			description:
-				'Example block written with ES5 standard and no JSX – no build step required. This should be no more than 150 characters. No markup here.',
+				'Example block written with ES5 standard and no JSX – no build step required.',
 			dashicon,
 			category,
 			author,
@@ -42,7 +42,7 @@ const templates = {
 			slug: 'esnext-example',
 			title: 'ESNext Example',
 			description:
-				'Example block written with ESNext standard and JSX support – build step required. This should be no more than 150 characters. No markup here.',
+				'Example block written with ESNext standard and JSX support – build step required.',
 			dashicon,
 			category,
 			author,

--- a/packages/create-block/lib/templates.js
+++ b/packages/create-block/lib/templates.js
@@ -31,6 +31,7 @@ const templates = {
 			'index.js',
 			'$slug.php',
 			'style.css',
+			'readme.txt',
 		],
 	},
 	esnext: {
@@ -53,6 +54,7 @@ const templates = {
 			'src/index.js',
 			'$slug.php',
 			'style.css',
+			'readme.txt',
 		],
 		wpScriptsEnabled: true,
 	},

--- a/packages/create-block/lib/templates/es5/readme.txt.mustache
+++ b/packages/create-block/lib/templates/es5/readme.txt.mustache
@@ -6,7 +6,7 @@ Tested up to:      5.3.2
 Stable tag:        {{version}}
 Requires PHP:      7.0.0
 License:           {{license}}
-License URI:       License URL
+License URI:       {{{licenseURI}}}
 
 Here is a short description of the plugin. This should be no more than 150 characters. No markup here.
 

--- a/packages/create-block/lib/templates/es5/readme.txt.mustache
+++ b/packages/create-block/lib/templates/es5/readme.txt.mustache
@@ -8,11 +8,14 @@ Requires PHP:      7.0.0
 License:           {{license}}
 License URI:       {{{licenseURI}}}
 
-Here is a short description of the plugin. This should be no more than 150 characters. No markup here.
+{{description}}
 
 == Description ==
 
-{{description}}
+This is the long description. No limit, and you can use Markdown (as well as in the following sections).
+
+For backwards compatibility, if this section is missing, the full length of the short description will be used, and
+Markdown parsed.
 
 == Installation ==
 

--- a/packages/create-block/lib/templates/es5/readme.txt.mustache
+++ b/packages/create-block/lib/templates/es5/readme.txt.mustache
@@ -1,0 +1,54 @@
+=== {{title}} ===
+Contributors:      {{author}}
+Tags:              comments, spam
+Requires at least: 5.0
+Tested up to:      5.3.2
+Stable tag:        {{version}}
+Requires PHP:      7.0.0
+License:           {{license}}
+License URI:       License URL
+
+Here is a short description of the plugin. This should be no more than 150 characters. No markup here.
+
+== Description ==
+
+{{description}}
+
+== Installation ==
+
+This section describes how to install the plugin and get it working.
+
+e.g.
+
+1. Upload the plugin files to the `/wp-content/plugins/{{slug}}` directory, or install the plugin through the WordPress plugins screen directly.
+1. Activate the plugin through the 'Plugins' screen in WordPress
+
+
+== Frequently Asked Questions ==
+
+= A question that someone might have =
+
+An answer to that question.
+
+= What about foo bar? =
+
+Answer to foo bar dilemma.
+
+== Screenshots ==
+
+1. This screen shot description corresponds to screenshot-1.(png|jpg|jpeg|gif). Note that the screenshot is taken from
+the /assets directory or the directory that contains the stable readme.txt (tags or trunk). Screenshots in the /assets
+directory take precedence. For example, `/assets/screenshot-1.png` would win over `/tags/4.3/screenshot-1.png`
+(or jpg, jpeg, gif).
+2. This is the second screen shot
+
+== Changelog ==
+
+= 0.1.0 =
+* Release
+
+== Arbitrary section ==
+
+You may provide arbitrary sections, in the same format as the ones above.  This may be of use for extremely complicated
+plugins where more information needs to be conveyed that doesn't fit into the categories of "description" or
+"installation."  Arbitrary sections will be shown below the built-in sections outlined above.

--- a/packages/create-block/lib/templates/es5/readme.txt.mustache
+++ b/packages/create-block/lib/templates/es5/readme.txt.mustache
@@ -52,6 +52,6 @@ directory take precedence. For example, `/assets/screenshot-1.png` would win ove
 
 == Arbitrary section ==
 
-You may provide arbitrary sections, in the same format as the ones above.  This may be of use for extremely complicated
+You may provide arbitrary sections, in the same format as the ones above. This may be of use for extremely complicated
 plugins where more information needs to be conveyed that doesn't fit into the categories of "description" or
-"installation."  Arbitrary sections will be shown below the built-in sections outlined above.
+"installation." Arbitrary sections will be shown below the built-in sections outlined above.

--- a/packages/create-block/lib/templates/es5/readme.txt.mustache
+++ b/packages/create-block/lib/templates/es5/readme.txt.mustache
@@ -44,7 +44,7 @@ directory take precedence. For example, `/assets/screenshot-1.png` would win ove
 
 == Changelog ==
 
-= 0.1.0 =
+= {{version}} =
 * Release
 
 == Arbitrary section ==

--- a/packages/create-block/lib/templates/es5/readme.txt.mustache
+++ b/packages/create-block/lib/templates/es5/readme.txt.mustache
@@ -1,7 +1,7 @@
 === {{title}} ===
 Contributors:      {{author}}
-Tags:              comments, spam
-Requires at least: 5.0
+Tags:              block
+Requires at least: 5.3.2
 Tested up to:      5.3.2
 Stable tag:        {{version}}
 Requires PHP:      7.0.0

--- a/packages/create-block/lib/templates/esnext/readme.txt.mustache
+++ b/packages/create-block/lib/templates/esnext/readme.txt.mustache
@@ -6,7 +6,7 @@ Tested up to:      5.3.2
 Stable tag:        {{version}}
 Requires PHP:      7.0.0
 License:           {{license}}
-License URI:       License URL
+License URI:       {{{licenseURI}}}
 
 Here is a short description of the plugin. This should be no more than 150 characters. No markup here.
 

--- a/packages/create-block/lib/templates/esnext/readme.txt.mustache
+++ b/packages/create-block/lib/templates/esnext/readme.txt.mustache
@@ -8,11 +8,14 @@ Requires PHP:      7.0.0
 License:           {{license}}
 License URI:       {{{licenseURI}}}
 
-Here is a short description of the plugin. This should be no more than 150 characters. No markup here.
+{{description}}
 
 == Description ==
 
-{{description}}
+This is the long description. No limit, and you can use Markdown (as well as in the following sections).
+
+For backwards compatibility, if this section is missing, the full length of the short description will be used, and
+Markdown parsed.
 
 == Installation ==
 

--- a/packages/create-block/lib/templates/esnext/readme.txt.mustache
+++ b/packages/create-block/lib/templates/esnext/readme.txt.mustache
@@ -1,0 +1,54 @@
+=== {{title}} ===
+Contributors:      {{author}}
+Tags:              comments, spam
+Requires at least: 5.0
+Tested up to:      5.3.2
+Stable tag:        {{version}}
+Requires PHP:      7.0.0
+License:           {{license}}
+License URI:       License URL
+
+Here is a short description of the plugin. This should be no more than 150 characters. No markup here.
+
+== Description ==
+
+{{description}}
+
+== Installation ==
+
+This section describes how to install the plugin and get it working.
+
+e.g.
+
+1. Upload the plugin files to the `/wp-content/plugins/{{slug}}` directory, or install the plugin through the WordPress plugins screen directly.
+1. Activate the plugin through the 'Plugins' screen in WordPress
+
+
+== Frequently Asked Questions ==
+
+= A question that someone might have =
+
+An answer to that question.
+
+= What about foo bar? =
+
+Answer to foo bar dilemma.
+
+== Screenshots ==
+
+1. This screen shot description corresponds to screenshot-1.(png|jpg|jpeg|gif). Note that the screenshot is taken from
+the /assets directory or the directory that contains the stable readme.txt (tags or trunk). Screenshots in the /assets
+directory take precedence. For example, `/assets/screenshot-1.png` would win over `/tags/4.3/screenshot-1.png`
+(or jpg, jpeg, gif).
+2. This is the second screen shot
+
+== Changelog ==
+
+= 0.1.0 =
+* Release
+
+== Arbitrary section ==
+
+You may provide arbitrary sections, in the same format as the ones above.  This may be of use for extremely complicated
+plugins where more information needs to be conveyed that doesn't fit into the categories of "description" or
+"installation."  Arbitrary sections will be shown below the built-in sections outlined above.

--- a/packages/create-block/lib/templates/esnext/readme.txt.mustache
+++ b/packages/create-block/lib/templates/esnext/readme.txt.mustache
@@ -52,6 +52,6 @@ directory take precedence. For example, `/assets/screenshot-1.png` would win ove
 
 == Arbitrary section ==
 
-You may provide arbitrary sections, in the same format as the ones above.  This may be of use for extremely complicated
+You may provide arbitrary sections, in the same format as the ones above. This may be of use for extremely complicated
 plugins where more information needs to be conveyed that doesn't fit into the categories of "description" or
-"installation."  Arbitrary sections will be shown below the built-in sections outlined above.
+"installation." Arbitrary sections will be shown below the built-in sections outlined above.

--- a/packages/create-block/lib/templates/esnext/readme.txt.mustache
+++ b/packages/create-block/lib/templates/esnext/readme.txt.mustache
@@ -44,7 +44,7 @@ directory take precedence. For example, `/assets/screenshot-1.png` would win ove
 
 == Changelog ==
 
-= 0.1.0 =
+= {{version}} =
 * Release
 
 == Arbitrary section ==

--- a/packages/create-block/lib/templates/esnext/readme.txt.mustache
+++ b/packages/create-block/lib/templates/esnext/readme.txt.mustache
@@ -1,7 +1,7 @@
 === {{title}} ===
 Contributors:      {{author}}
-Tags:              comments, spam
-Requires at least: 5.0
+Tags:              block
+Requires at least: 5.3.2
 Tested up to:      5.3.2
 Stable tag:        {{version}}
 Requires PHP:      7.0.0


### PR DESCRIPTION
## Description
This PR closes https://github.com/WordPress/gutenberg/issues/20263

## How has this been tested?
@gziolo I could use your guidance to test this, as I wasn't able to do it yet.

## Types of changes
The PR introduces `Author`, `Version` and `License` and prompt options when creating a new block.
The PR also adds `readme.txt` to both templates.

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
