### PR TITLE
Update browserslist to fix out-of-date caniuse-lite messages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14006,29 +14006,35 @@
 			}
 		},
 		"browserslist": {
-			"version": "4.7.0",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.7.0.tgz",
-			"integrity": "sha512-9rGNDtnj+HaahxiVV38Gn8n8Lr8REKsel68v1sPFfIGEK6uSXTY3h9acgiT1dZVtOOUtifo/Dn8daDQ5dUgVsA==",
+			"version": "4.9.1",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.9.1.tgz",
+			"integrity": "sha512-Q0DnKq20End3raFulq6Vfp1ecB9fh8yUNV55s8sekaDDeqBaCtWlRHCUdaWyUeSSBJM7IbM6HcsyaeYqgeDhnw==",
 			"dev": true,
 			"requires": {
-				"caniuse-lite": "^1.0.30000989",
-				"electron-to-chromium": "^1.3.247",
-				"node-releases": "^1.1.29"
+				"caniuse-lite": "^1.0.30001030",
+				"electron-to-chromium": "^1.3.363",
+				"node-releases": "^1.1.50"
 			},
 			"dependencies": {
+				"caniuse-lite": {
+					"version": "1.0.30001032",
+					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001032.tgz",
+					"integrity": "sha512-8joOm7BwcpEN4BfVHtfh0hBXSAPVYk+eUIcNntGtMkUWy/6AKRCDZINCLe3kB1vHhT2vBxBF85Hh9VlPXi/qjA==",
+					"dev": true
+				},
 				"node-releases": {
-					"version": "1.1.33",
-					"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.33.tgz",
-					"integrity": "sha512-I0V30bWQEoHb+10W8oedVoUrdjW5wIkYm0w7vvcrPO95pZY738m1k77GF5sO0vKg5eXYg9oGtrMAETbgZGm11A==",
+					"version": "1.1.51",
+					"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.51.tgz",
+					"integrity": "sha512-1eQEs6HFYY1kMXQPOLzCf7HdjReErmvn85tZESMczdCNVWP3Y7URYLBAyYynuI7yef1zj4HN5q+oB2x67QU0lw==",
 					"dev": true,
 					"requires": {
-						"semver": "^5.3.0"
+						"semver": "^6.3.0"
 					}
 				},
 				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
 					"dev": true
 				}
 			}
@@ -17122,9 +17128,9 @@
 			"dev": true
 		},
 		"electron-to-chromium": {
-			"version": "1.3.269",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.269.tgz",
-			"integrity": "sha512-t2ZTfo07HxkxTOUbIwMmqHBSnJsC9heqJUm7LwQu2iSk0wNhG4H5cMREtb8XxeCrQABDZ6IqQKY3yZq+NfAqwg==",
+			"version": "1.3.372",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.372.tgz",
+			"integrity": "sha512-77a4jYC52OdisHM+Tne7dgWEvQT1FoNu/jYl279pP88ZtG4ZRIPyhQwAKxj6C2rzsyC1OwsOds9JlZtNncSz6g==",
 			"dev": true
 		},
 		"elegant-spinner": {
@@ -19764,7 +19770,7 @@
 				},
 				"node-pre-gyp": {
 					"version": "0.12.0",
-					"resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz",
+					"resolved": false,
 					"integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
 					"dev": true,
 					"optional": true,
@@ -19783,7 +19789,7 @@
 				},
 				"nopt": {
 					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
 					"dev": true,
 					"optional": true,
@@ -32793,6 +32799,17 @@
 					"resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
 					"integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
 					"dev": true
+				},
+				"browserslist": {
+					"version": "4.7.0",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.7.0.tgz",
+					"integrity": "sha512-9rGNDtnj+HaahxiVV38Gn8n8Lr8REKsel68v1sPFfIGEK6uSXTY3h9acgiT1dZVtOOUtifo/Dn8daDQ5dUgVsA==",
+					"dev": true,
+					"requires": {
+						"caniuse-lite": "^1.0.30000989",
+						"electron-to-chromium": "^1.3.247",
+						"node-releases": "^1.1.29"
+					}
 				},
 				"cross-spawn": {
 					"version": "6.0.5",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
 		"babel-plugin-react-native-platform-specific-extensions": "1.1.1",
 		"babel-plugin-require-context-hook": "1.0.0",
 		"benchmark": "2.1.4",
-		"browserslist": "4.7.0",
+		"browserslist": "4.9.1",
 		"chalk": "2.4.2",
 		"commander": "4.1.0",
 		"concurrently": "3.5.0",


### PR DESCRIPTION
## Description

Running `npm run test-unit` on master was returning this error for the `packages/browserslist-config/test/index.test.js` test:

```
 ["Browserslist: caniuse-lite is outdated. Please run next command `npm update`"]
```

In this pull I updated the npm `browserslist` package which seems to fix the error.

## How has this been tested?

Unit test execution should result in no errors (I ran locally after the package update and all green for me).