### PR TITLE
Correct link to list of WP's supported browsers

### DIFF
--- a/packages/dom-ready/README.md
+++ b/packages/dom-ready/README.md
@@ -43,6 +43,6 @@ _Returns_
 
 ## Browser support
 
-See <https://make.wordpress.org/design/handbook/design-guide/browser-support/>
+See <https://make.wordpress.org/core/handbook/best-practices/browser-support/>
 
 <br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>


### PR DESCRIPTION
## Description

I assume this is where it should be pointing.