### PR TITLE
Adapt the height of the block preview container to its content

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10093,6 +10093,7 @@
 				"lodash": "^4.17.15",
 				"memize": "^1.0.5",
 				"react-autosize-textarea": "^3.0.2",
+				"react-resize-aware": "^3.0.0",
 				"react-spring": "^8.0.19",
 				"redux-multi": "^0.1.12",
 				"refx": "^3.0.0",
@@ -19770,7 +19771,7 @@
 				},
 				"node-pre-gyp": {
 					"version": "0.12.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz",
 					"integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
 					"dev": true,
 					"optional": true,
@@ -19789,7 +19790,7 @@
 				},
 				"nopt": {
 					"version": "4.0.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
 					"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
 					"dev": true,
 					"optional": true,

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -52,6 +52,7 @@
 		"lodash": "^4.17.15",
 		"memize": "^1.0.5",
 		"react-autosize-textarea": "^3.0.2",
+		"react-resize-aware": "^3.0.0",
 		"react-spring": "^8.0.19",
 		"redux-multi": "^0.1.12",
 		"refx": "^3.0.0",

--- a/packages/block-editor/src/components/block-patterns/index.js
+++ b/packages/block-editor/src/components/block-patterns/index.js
@@ -34,7 +34,7 @@ function BlockPattern( { pattern, onClick } ) {
 			tabIndex={ 0 }
 		>
 			<div className="block-editor-patterns__item-preview">
-				<BlockPreview blocks={ blocks } />
+				<BlockPreview blocks={ blocks } autoHeight />
 			</div>
 			<div className="block-editor-patterns__item-title">{ title }</div>
 		</div>

--- a/packages/block-editor/src/components/block-patterns/style.scss
+++ b/packages/block-editor/src/components/block-patterns/style.scss
@@ -21,17 +21,7 @@
 }
 
 .block-editor-patterns__item-preview {
-	overflow: hidden;
-	height: 200px;
-
-	.block-editor-block-preview__container {
-		height: 100%;
-	}
-
-	.block-editor-block-preview__content {
-		display: flex;
-		justify-content: center;
-	}
+	padding: $grid-unit-20;
 }
 
 .block-editor-patterns__item-title {

--- a/packages/block-editor/src/components/block-preview/auto.js
+++ b/packages/block-editor/src/components/block-preview/auto.js
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+import useResizeAware from 'react-resize-aware';
+
+/**
+ * WordPress dependencies
+ */
+import { Disabled } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import BlockList from '../block-list';
+
+function AutoBlockPreview( { viewportWidth } ) {
+	const [
+		containerResizeListener,
+		{ width: containerWidth },
+	] = useResizeAware();
+	const [
+		containtResizeListener,
+		{ height: contentHeight },
+	] = useResizeAware();
+
+	return (
+		<div
+			className="block-editor-block-preview__container editor-styles-wrapper is-auto-height"
+			aria-hidden
+			style={ {
+				height: ( contentHeight * containerWidth ) / viewportWidth,
+			} }
+		>
+			{ containerResizeListener }
+			<Disabled
+				style={ {
+					transform: `scale(${ containerWidth / viewportWidth })`,
+					width: viewportWidth,
+				} }
+				className="block-editor-block-preview__content"
+			>
+				{ containtResizeListener }
+				<BlockList />
+			</Disabled>
+		</div>
+	);
+}
+
+export default AutoBlockPreview;

--- a/packages/block-editor/src/components/block-preview/index.js
+++ b/packages/block-editor/src/components/block-preview/index.js
@@ -2,197 +2,19 @@
  * External dependencies
  */
 import { castArray, noop } from 'lodash';
-import classnames from 'classnames';
 
 /**
  * WordPress dependencies
  */
-import { Disabled } from '@wordpress/components';
-import { withSelect } from '@wordpress/data';
-import {
-	useLayoutEffect,
-	useState,
-	useRef,
-	useReducer,
-	useMemo,
-} from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+import { useLayoutEffect, useReducer, useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import BlockEditorProvider from '../provider';
-import BlockList from '../block-list';
-import { getBlockPreviewContainerDOMNode } from '../../utils/dom';
-
-const getInlineStyles = ( scale, x, y, isReady, width ) => ( {
-	transform: `scale(${ scale })`,
-	visibility: isReady ? 'visible' : 'hidden',
-	left: x,
-	top: y,
-	width,
-} );
-
-function ScaledBlockPreview( {
-	blocks,
-	viewportWidth,
-	padding = 0,
-	onReady,
-	scalingDelay,
-} ) {
-	const previewRef = useRef( null );
-
-	const [ isReady, setIsReady ] = useState( false );
-	const [ previewScale, setPreviewScale ] = useState( 1 );
-	const [ { x, y }, setPosition ] = useState( { x: 0, y: 0 } );
-
-	// Dynamically calculate the scale factor
-	useLayoutEffect( () => {
-		// Timer - required to account for async render of `BlockEditorProvider`
-		const timerId = setTimeout( () => {
-			const containerElement = previewRef.current;
-			if ( ! containerElement ) {
-				return;
-			}
-
-			// Auxiliary vars used for onReady() callback.
-			let scale,
-				offsetX = 0,
-				offsetY = 0;
-
-			// If we're previewing a single block, scale the preview to fit it.
-			if ( blocks.length === 1 ) {
-				const block = blocks[ 0 ];
-				const previewElement = getBlockPreviewContainerDOMNode(
-					block.clientId
-				);
-				if ( ! previewElement ) {
-					return;
-				}
-
-				let containerElementRect = containerElement.getBoundingClientRect();
-				containerElementRect = {
-					width: containerElementRect.width - padding * 2,
-					height: containerElementRect.height - padding * 2,
-					left: containerElementRect.left,
-					top: containerElementRect.top,
-				};
-				const scaledElementRect = previewElement.getBoundingClientRect();
-
-				scale =
-					containerElementRect.width / scaledElementRect.width || 1;
-				offsetX =
-					-( scaledElementRect.left - containerElementRect.left ) *
-						scale +
-					padding;
-				offsetY =
-					containerElementRect.height >
-					scaledElementRect.height * scale
-						? ( containerElementRect.height -
-								scaledElementRect.height * scale ) /
-								2 +
-						  padding
-						: 0;
-
-				setPreviewScale( scale );
-				setPosition( { x: offsetX, y: offsetY } );
-
-				// Hack: we need  to reset the scaled elements margins
-				previewElement.style.marginTop = '0';
-			} else {
-				const containerElementRect = containerElement.getBoundingClientRect();
-				scale = containerElementRect.width / viewportWidth;
-				setPreviewScale( scale );
-			}
-
-			setIsReady( true );
-			onReady( {
-				scale,
-				position: { x: offsetX, y: offsetY },
-				previewContainerRef: previewRef,
-
-				inlineStyles: getInlineStyles(
-					scale,
-					offsetX,
-					offsetY,
-					true,
-					viewportWidth
-				),
-			} );
-		}, scalingDelay );
-
-		// Cleanup
-		return () => {
-			if ( timerId ) {
-				window.clearTimeout( timerId );
-			}
-		};
-	}, [] );
-
-	if ( ! blocks || blocks.length === 0 ) {
-		return null;
-	}
-
-	const previewStyles = getInlineStyles(
-		previewScale,
-		x,
-		y,
-		isReady,
-		viewportWidth
-	);
-
-	return (
-		<div
-			ref={ previewRef }
-			className={ classnames(
-				'block-editor-block-preview__container editor-styles-wrapper',
-				{
-					'is-ready': isReady,
-				}
-			) }
-			aria-hidden
-		>
-			<Disabled
-				style={ previewStyles }
-				className="block-editor-block-preview__content"
-			>
-				<BlockList />
-			</Disabled>
-		</div>
-	);
-}
-
-export function BlockPreview( {
-	blocks,
-	viewportWidth = 700,
-	padding,
-	settings,
-	__experimentalOnReady = noop,
-	__experimentalScalingDelay = 100,
-} ) {
-	const renderedBlocks = useMemo( () => castArray( blocks ), [ blocks ] );
-	const [ recompute, triggerRecompute ] = useReducer(
-		( state ) => state + 1,
-		0
-	);
-	useLayoutEffect( triggerRecompute, [ blocks ] );
-	return (
-		<BlockEditorProvider value={ renderedBlocks } settings={ settings }>
-			{ /*
-			 * The key prop is used to force recomputing the preview
-			 * by remounting the component, ScaledBlockPreview is not meant to
-			 * be rerendered.
-			 */ }
-			<ScaledBlockPreview
-				key={ recompute }
-				blocks={ renderedBlocks }
-				viewportWidth={ viewportWidth }
-				padding={ padding }
-				onReady={ __experimentalOnReady }
-				scalingDelay={ __experimentalScalingDelay }
-			/>
-		</BlockEditorProvider>
-	);
-}
+import ScaledBlockPreview from './scaled';
+import AutoHeightBlockPreview from './auto';
 
 /**
  * BlockPreview renders a preview of a block or array of blocks.
@@ -203,8 +25,47 @@ export function BlockPreview( {
  * @param {number} viewportWidth Width of the preview container in pixels. Controls at what size the blocks will be rendered inside the preview. Default: 700.
  * @return {WPComponent} The component to be rendered.
  */
-export default withSelect( ( select ) => {
-	return {
-		settings: select( 'core/block-editor' ).getSettings(),
-	};
-} )( BlockPreview );
+export function BlockPreview( {
+	blocks,
+	viewportWidth = 700,
+	padding,
+	autoHeight = false,
+	__experimentalOnReady = noop,
+	__experimentalScalingDelay = 100,
+} ) {
+	const settings = useSelect( ( select ) =>
+		select( 'core/block-editor' ).getSettings()
+	);
+	const renderedBlocks = useMemo( () => castArray( blocks ), [ blocks ] );
+	const [ recompute, triggerRecompute ] = useReducer(
+		( state ) => state + 1,
+		0
+	);
+	useLayoutEffect( triggerRecompute, [ blocks ] );
+	if ( ! blocks || blocks.length === 0 ) {
+		return null;
+	}
+	return (
+		<BlockEditorProvider value={ renderedBlocks } settings={ settings }>
+			{ /*
+			 * The key prop is used to force recomputing the preview
+			 * by remounting the component, ScaledBlockPreview is not meant to
+			 * be rerendered.
+			 */ }
+			{ autoHeight ? (
+				<AutoHeightBlockPreview viewportWidth={ viewportWidth } />
+			) : (
+				<ScaledBlockPreview
+					key={ recompute }
+					blocks={ renderedBlocks }
+					viewportWidth={ viewportWidth }
+					padding={ padding }
+					onReady={ __experimentalOnReady }
+					scalingDelay={ __experimentalScalingDelay }
+				/>
+			) }
+		</BlockEditorProvider>
+	);
+}
+
+export default BlockPreview;

--- a/packages/block-editor/src/components/block-preview/index.js
+++ b/packages/block-editor/src/components/block-preview/index.js
@@ -53,7 +53,10 @@ export function BlockPreview( {
 			 * be rerendered.
 			 */ }
 			{ autoHeight ? (
-				<AutoHeightBlockPreview viewportWidth={ viewportWidth } />
+				<AutoHeightBlockPreview
+					key={ recompute }
+					viewportWidth={ viewportWidth }
+				/>
 			) : (
 				<ScaledBlockPreview
 					key={ recompute }

--- a/packages/block-editor/src/components/block-preview/scaled.js
+++ b/packages/block-editor/src/components/block-preview/scaled.js
@@ -1,0 +1,155 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { Disabled } from '@wordpress/components';
+import { useLayoutEffect, useState, useRef } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import BlockList from '../block-list';
+import { getBlockPreviewContainerDOMNode } from '../../utils/dom';
+
+const getInlineStyles = ( scale, x, y, isReady, width ) => ( {
+	transform: `scale(${ scale })`,
+	visibility: isReady ? 'visible' : 'hidden',
+	left: x,
+	top: y,
+	width,
+} );
+
+function ScaledBlockPreview( {
+	blocks,
+	viewportWidth,
+	padding = 0,
+	onReady,
+	scalingDelay,
+} ) {
+	const previewRef = useRef( null );
+
+	const [ isReady, setIsReady ] = useState( false );
+	const [ previewScale, setPreviewScale ] = useState( 1 );
+	const [ { x, y }, setPosition ] = useState( { x: 0, y: 0 } );
+
+	// Dynamically calculate the scale factor
+	useLayoutEffect( () => {
+		// Timer - required to account for async render of `BlockEditorProvider`
+		const timerId = setTimeout( () => {
+			const containerElement = previewRef.current;
+			if ( ! containerElement ) {
+				return;
+			}
+
+			// Auxiliary vars used for onReady() callback.
+			let scale,
+				offsetX = 0,
+				offsetY = 0;
+
+			// If we're previewing a single block, scale the preview to fit it.
+			if ( blocks.length === 1 ) {
+				const block = blocks[ 0 ];
+				const previewElement = getBlockPreviewContainerDOMNode(
+					block.clientId
+				);
+				if ( ! previewElement ) {
+					return;
+				}
+
+				let containerElementRect = containerElement.getBoundingClientRect();
+				containerElementRect = {
+					width: containerElementRect.width - padding * 2,
+					height: containerElementRect.height - padding * 2,
+					left: containerElementRect.left,
+					top: containerElementRect.top,
+				};
+				const scaledElementRect = previewElement.getBoundingClientRect();
+
+				scale =
+					containerElementRect.width / scaledElementRect.width || 1;
+				offsetX =
+					-( scaledElementRect.left - containerElementRect.left ) *
+						scale +
+					padding;
+				offsetY =
+					containerElementRect.height >
+					scaledElementRect.height * scale
+						? ( containerElementRect.height -
+								scaledElementRect.height * scale ) /
+								2 +
+						  padding
+						: 0;
+
+				setPreviewScale( scale );
+				setPosition( { x: offsetX, y: offsetY } );
+
+				// Hack: we need  to reset the scaled elements margins
+				previewElement.style.marginTop = '0';
+			} else {
+				const containerElementRect = containerElement.getBoundingClientRect();
+				scale = containerElementRect.width / viewportWidth;
+				setPreviewScale( scale );
+			}
+
+			setIsReady( true );
+			onReady( {
+				scale,
+				position: { x: offsetX, y: offsetY },
+				previewContainerRef: previewRef,
+
+				inlineStyles: getInlineStyles(
+					scale,
+					offsetX,
+					offsetY,
+					true,
+					viewportWidth
+				),
+			} );
+		}, scalingDelay );
+
+		// Cleanup
+		return () => {
+			if ( timerId ) {
+				window.clearTimeout( timerId );
+			}
+		};
+	}, [] );
+
+	if ( ! blocks || blocks.length === 0 ) {
+		return null;
+	}
+
+	const previewStyles = getInlineStyles(
+		previewScale,
+		x,
+		y,
+		isReady,
+		viewportWidth
+	);
+
+	return (
+		<div
+			ref={ previewRef }
+			className={ classnames(
+				'block-editor-block-preview__container editor-styles-wrapper is-centered',
+				{
+					'is-ready': isReady,
+				}
+			) }
+			aria-hidden
+		>
+			<Disabled
+				style={ previewStyles }
+				className="block-editor-block-preview__content"
+			>
+				<BlockList />
+			</Disabled>
+		</div>
+	);
+}
+
+export default ScaledBlockPreview;

--- a/packages/block-editor/src/components/block-preview/style.scss
+++ b/packages/block-editor/src/components/block-preview/style.scss
@@ -29,18 +29,17 @@
 	transform-origin: top left;
 
 	// Resetting paddings, margins, and other.
+
 	text-align: initial;
 	margin: 0;
 	overflow: visible;
 	min-height: auto;
 
-	.block-editor-block-list__layout,
-	.block-editor-block-list__block {
-		padding: 0;
-	}
-
-	> div section {
-		height: auto;
+	.block-editor-block-preview__container &.is-centered {
+		.block-editor-block-list__layout,
+		.block-editor-block-list__block {
+			padding: 0;
+		}
 	}
 
 	.block-editor-block-list__insertion-point,


### PR DESCRIPTION
closes #20692

This PR adds a new mode to the BlockPreview component called "auto-height" where instead of relying on a fixed height, the height is computed based on the content of the preview.

This preview mode is used in the patterns preview and I'll explore using for the inserter separately.

<img width="266" alt="Capture d’écran 2020-03-09 à 11 09 50 AM" src="https://user-images.githubusercontent.com/272444/76203199-8934a800-61f6-11ea-993a-2007b8721338.png">
