### PR TITLE
Block library: Use block.json consistently for FSE blocks

### DIFF
--- a/packages/block-library/src/post-author/index.php
+++ b/packages/block-library/src/post-author/index.php
@@ -23,10 +23,16 @@ function render_block_core_post_author() {
  * Registers the `core/post-author` block on the server.
  */
 function register_block_core_post_author() {
+	$path     = __DIR__ . '/post-author/block.json';
+	$metadata = json_decode( file_get_contents( $path ), true );
+
 	register_block_type(
-		'core/post-author',
-		array(
-			'render_callback' => 'render_block_core_post_author',
+		$metadata['name'],
+		array_merge(
+			$metadata,
+			array(
+				'render_callback' => 'render_block_core_post_author',
+			)
 		)
 	);
 }

--- a/packages/block-library/src/post-comments-count/index.php
+++ b/packages/block-library/src/post-comments-count/index.php
@@ -32,15 +32,21 @@ function render_block_core_post_comments_count( $attributes ) {
  * Registers the `core/post-comments-count` block on the server.
  */
 function register_block_core_post_comments_count() {
+	$path     = __DIR__ . '/post-comments-count/block.json';
+	$metadata = json_decode( file_get_contents( $path ), true );
+
 	register_block_type(
-		'core/post-comments-count',
-		array(
-			'attributes'      => array(
-				'className' => array(
-					'type' => 'string',
+		$metadata['name'],
+		array_merge(
+			$metadata,
+			array(
+				'attributes'      => array(
+					'className' => array(
+						'type' => 'string',
+					),
 				),
-			),
-			'render_callback' => 'render_block_core_post_comments_count',
+				'render_callback' => 'render_block_core_post_comments_count',
+			)
 		)
 	);
 }

--- a/packages/block-library/src/post-comments-form/index.php
+++ b/packages/block-library/src/post-comments-form/index.php
@@ -26,10 +26,16 @@ function render_block_core_post_comments_form() {
  * Registers the `core/post-comments-form` block on the server.
  */
 function register_block_core_post_comments_form() {
+	$path     = __DIR__ . '/post-comments-form/block.json';
+	$metadata = json_decode( file_get_contents( $path ), true );
+
 	register_block_type(
-		'core/post-comments-form',
-		array(
-			'render_callback' => 'render_block_core_post_comments_form',
+		$metadata['name'],
+		array_merge(
+			$metadata,
+			array(
+				'render_callback' => 'render_block_core_post_comments_form',
+			)
 		)
 	);
 }

--- a/packages/block-library/src/post-content/index.php
+++ b/packages/block-library/src/post-content/index.php
@@ -26,10 +26,16 @@ function render_block_core_post_content() {
  * Registers the `core/post-content` block on the server.
  */
 function register_block_core_post_content() {
+	$path     = __DIR__ . '/post-content/block.json';
+	$metadata = json_decode( file_get_contents( $path ), true );
+
 	register_block_type(
-		'core/post-content',
-		array(
-			'render_callback' => 'render_block_core_post_content',
+		$metadata['name'],
+		array_merge(
+			$metadata,
+			array(
+				'render_callback' => 'render_block_core_post_content',
+			)
 		)
 	);
 }

--- a/packages/block-library/src/post-date/index.php
+++ b/packages/block-library/src/post-date/index.php
@@ -27,15 +27,16 @@ function render_block_core_post_date( $attributes ) {
  * Registers the `core/post-date` block on the server.
  */
 function register_block_core_post_date() {
+	$path     = __DIR__ . '/post-date/block.json';
+	$metadata = json_decode( file_get_contents( $path ), true );
+
 	register_block_type(
-		'core/post-date',
-		array(
-			'attributes'      => array(
-				'format' => array(
-					'type' => 'string',
-				),
-			),
-			'render_callback' => 'render_block_core_post_date',
+		$metadata['name'],
+		array_merge(
+			$metadata,
+			array(
+				'render_callback' => 'render_block_core_post_date',
+			)
 		)
 	);
 }

--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -47,23 +47,16 @@ function render_block_core_post_excerpt( $attributes ) {
  * Registers the `core/post-excerpt` block on the server.
  */
 function register_block_core_post_excerpt() {
+	$path     = __DIR__ . '/post-excerpt/block.json';
+	$metadata = json_decode( file_get_contents( $path ), true );
+
 	register_block_type(
-		'core/post-excerpt',
-		array(
-			'attributes'      => array(
-				'wordCount'         => array(
-					'type'    => 'number',
-					'default' => 55,
-				),
-				'moreText'          => array(
-					'type' => 'string',
-				),
-				'showMoreOnNewLine' => array(
-					'type'    => 'boolean',
-					'default' => true,
-				),
-			),
-			'render_callback' => 'render_block_core_post_excerpt',
+		$metadata['name'],
+		array_merge(
+			$metadata,
+			array(
+				'render_callback' => 'render_block_core_post_excerpt',
+			)
 		)
 	);
 }

--- a/packages/block-library/src/post-featured-image/index.php
+++ b/packages/block-library/src/post-featured-image/index.php
@@ -22,10 +22,16 @@ function render_block_core_post_featured_image() {
  * Registers the `core/post-featured-image` block on the server.
  */
 function register_block_core_post_featured_image() {
+	$path     = __DIR__ . '/post-featured-image/block.json';
+	$metadata = json_decode( file_get_contents( $path ), true );
+
 	register_block_type(
-		'core/post-featured-image',
-		array(
-			'render_callback' => 'render_block_core_post_featured_image',
+		$metadata['name'],
+		array_merge(
+			$metadata,
+			array(
+				'render_callback' => 'render_block_core_post_featured_image',
+			)
 		)
 	);
 }

--- a/packages/block-library/src/post-tags/index.php
+++ b/packages/block-library/src/post-tags/index.php
@@ -29,10 +29,16 @@ function render_block_core_post_tags() {
  * Registers the `core/post-tags` block on the server.
  */
 function register_block_core_post_tags() {
+	$path     = __DIR__ . '/post-tags/block.json';
+	$metadata = json_decode( file_get_contents( $path ), true );
+
 	register_block_type(
-		'core/post-tags',
-		array(
-			'render_callback' => 'render_block_core_post_tags',
+		$metadata['name'],
+		array_merge(
+			$metadata,
+			array(
+				'render_callback' => 'render_block_core_post_tags',
+			)
 		)
 	);
 }

--- a/packages/block-library/src/post-title/index.php
+++ b/packages/block-library/src/post-title/index.php
@@ -22,10 +22,16 @@ function render_block_core_post_title() {
  * Registers the `core/post-title` block on the server.
  */
 function register_block_core_post_title() {
+	$path     = __DIR__ . '/post-title/block.json';
+	$metadata = json_decode( file_get_contents( $path ), true );
+
 	register_block_type(
-		'core/post-title',
-		array(
-			'render_callback' => 'render_block_core_post_title',
+		$metadata['name'],
+		array_merge(
+			$metadata,
+			array(
+				'render_callback' => 'render_block_core_post_title',
+			)
 		)
 	);
 }

--- a/packages/block-library/src/site-title/index.php
+++ b/packages/block-library/src/site-title/index.php
@@ -24,10 +24,16 @@ function render_block_core_site_title( $attributes ) {
  * Registers the `core/site-title` block on the server.
  */
 function register_block_core_site_title() {
+	$path     = __DIR__ . '/site-title/block.json';
+	$metadata = json_decode( file_get_contents( $path ), true );
+
 	register_block_type(
-		'core/site-title',
-		array(
-			'render_callback' => 'render_block_core_site_title',
+		$metadata['name'],
+		array_merge(
+			$metadata,
+			array(
+				'render_callback' => 'render_block_core_site_title',
+			)
 		)
 	);
 }


### PR DESCRIPTION
Previously: #19786

This pull request seeks to update block registration for a number of full-site editing blocks to match that of other server-registered blocks leveraging `block.json`. As noted in #19786, when a block registers settings both in PHP and via `block.json`, it should be implemented as a merge of the PHP implementation of the JSON metadata. This also has the benefit of eliminating some duplication that currently exists between PHP implementation and `block.json` ("Post Date" and "Post Excerpt" block attributes definition). An exception was made for "Post Comments Count" block `className` attribute, which is registered only in PHP, as it's expected this would eventually be handled as part of the implementation of block "supports" server-side (e.g. #18414, specifically c7cded60c73e8e5c784743bc3474a0914c55928e). 


**Testing Instructions:**
There should be no regressions in the display or behavior of full-site editing blocks.

Check the source and ensure that `wp.blocks.unstable__bootstrapServerSideBlockDefinitions` call properly propagates all updated blocks and their definitions. 