### PR TITLE
Docs: update tutorials link to point at new platform section

### DIFF
--- a/docs/designers-developers/developers/tutorials/readme.md
+++ b/docs/designers-developers/developers/tutorials/readme.md
@@ -12,4 +12,4 @@
 
 * Learn how to add customized buttons to the toolbar with the [Format API tutorial](/docs/designers-developers/developers/tutorials/format-api/).
 
-* Build your own [custom block editor instance](/docs/designers-developers/developers/tutorials/custom-block-editor/) - this will walk you through building a standalone instance of the block editor within WP Admin.
+* Build your own [custom block editor instance](/docs/designers-developers/developers/platform/custom-block-editor/) - this will walk you through building a standalone instance of the block editor within WP Admin.


### PR DESCRIPTION
## Description
@WunderBart noticed that the Custom Block Editor tutorial link at

https://github.com/WordPress/gutenberg/blob/master/docs/designers-developers/developers/tutorials/readme.md

...points to the wrong location.

Updates to point at the new Platform section.

## How has this been tested?

On branch, verify that the link on the text `custom block editor` on this page goes to the [Custom Block Editor tutorial](https://github.com/WordPress/gutenberg/tree/master/docs/designers-developers/developers/platform/custom-block-editor).

See https://github.com/WordPress/gutenberg/blob/5ceb2eb04c91cc4dd7e36883b172ea41aa452b3f/docs/designers-developers/developers/tutorials/readme.md

## Types of changes
Bug fix (non-breaking change which fixes an issue) 

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
