### PR TITLE
Lighter block DOM: Navigation

### DIFF
--- a/packages/block-editor/src/components/block-list-appender/index.js
+++ b/packages/block-editor/src/components/block-list-appender/index.js
@@ -27,6 +27,7 @@ function BlockListAppender( {
 	isLocked,
 	renderAppender: CustomAppender,
 	className,
+	tagName: TagName = 'div',
 } ) {
 	if ( isLocked || CustomAppender === false ) {
 		return null;
@@ -57,7 +58,7 @@ function BlockListAppender( {
 	}
 
 	return (
-		<div
+		<TagName
 			// A `tabIndex` is used on the wrapping `div` element in order to
 			// force a focus event to occur when an appender `button` element
 			// is clicked. In some browsers (Firefox, Safari), button clicks do
@@ -73,7 +74,7 @@ function BlockListAppender( {
 			className={ classnames( 'block-list-appender', className ) }
 		>
 			{ appender }
-		</div>
+		</TagName>
 	);
 }
 

--- a/packages/block-editor/src/components/block-list/block-wrapper.js
+++ b/packages/block-editor/src/components/block-list/block-wrapper.js
@@ -230,7 +230,9 @@ const elements = [
 	'h6',
 	'ol',
 	'ul',
+	'li',
 	'figure',
+	'nav',
 ];
 
 const ExtendedBlockComponent = elements.reduce( ( acc, element ) => {

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -31,6 +31,7 @@ function BlockList(
 		renderAppender,
 		__experimentalUIParts = {},
 		__experimentalTagName = 'div',
+		__experimentalAppenderTagName,
 		__experimentalPassedProps = {},
 	},
 	ref
@@ -120,6 +121,7 @@ function BlockList(
 				);
 			} ) }
 			<BlockListAppender
+				tagName={ __experimentalAppenderTagName }
 				rootClientId={ rootClientId }
 				renderAppender={ renderAppender }
 				className={

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -28,6 +28,7 @@ import {
 	InspectorControls,
 	RichText,
 	__experimentalLinkControl as LinkControl,
+	__experimentalBlock as Block,
 } from '@wordpress/block-editor';
 import { isURL, prependHTTP } from '@wordpress/url';
 import { Fragment, useState, useEffect, useRef } from '@wordpress/element';
@@ -192,8 +193,8 @@ function NavigationLinkEdit( {
 					/>
 				</PanelBody>
 			</InspectorControls>
-			<div
-				className={ classnames( 'wp-block-navigation-link', {
+			<Block.li
+				className={ classnames( {
 					'is-editing': isSelected || isParentOfSelectedBlock,
 					'is-selected': isSelected,
 					'has-link': !! url,
@@ -292,7 +293,7 @@ function NavigationLinkEdit( {
 							: false
 					}
 				/>
-			</div>
+			</Block.li>
 		</Fragment>
 	);
 }

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -295,6 +295,7 @@ function NavigationLinkEdit( {
 							: false
 					}
 					__experimentalTagName="ul"
+					__experimentalAppenderTagName="li"
 					__experimentalPassedProps={ {
 						className: 'wp-block-navigation__container',
 					} }

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -209,7 +209,8 @@ function NavigationLinkEdit( {
 					backgroundColor: rgbBackgroundColor,
 				} }
 			>
-				<div className="wp-block-navigation-link__content">
+				{ /* eslint-disable-next-line jsx-a11y/anchor-is-valid */ }
+				<a className="wp-block-navigation-link__content">
 					<RichText
 						ref={ ref }
 						tagName="span"
@@ -219,6 +220,7 @@ function NavigationLinkEdit( {
 							setAttributes( { label: labelValue } )
 						}
 						placeholder={ itemLabelPlaceholder }
+						keepPlaceholderOnFocus
 						withoutInteractiveFormatting
 						allowedFormats={ [
 							'core/bold',
@@ -283,7 +285,7 @@ function NavigationLinkEdit( {
 							/>
 						</Popover>
 					) }
-				</div>
+				</a>
 				<InnerBlocks
 					allowedBlocks={ [ 'core/navigation-link' ] }
 					renderAppender={
@@ -292,6 +294,10 @@ function NavigationLinkEdit( {
 							? InnerBlocks.DefaultAppender
 							: false
 					}
+					__experimentalTagName="ul"
+					__experimentalPassedProps={ {
+						className: 'wp-block-navigation__container',
+					} }
 				/>
 			</Block.li>
 		</Fragment>

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -209,8 +209,7 @@ function NavigationLinkEdit( {
 					backgroundColor: rgbBackgroundColor,
 				} }
 			>
-				{ /* eslint-disable-next-line jsx-a11y/anchor-is-valid */ }
-				<a className="wp-block-navigation-link__content">
+				<div className="wp-block-navigation-link__content">
 					<RichText
 						ref={ ref }
 						tagName="span"
@@ -285,7 +284,7 @@ function NavigationLinkEdit( {
 							/>
 						</Popover>
 					) }
-				</a>
+				</div>
 				<InnerBlocks
 					allowedBlocks={ [ 'core/navigation-link' ] }
 					renderAppender={

--- a/packages/block-library/src/navigation-link/index.js
+++ b/packages/block-library/src/navigation-link/index.js
@@ -26,6 +26,7 @@ export const settings = {
 	supports: {
 		reusable: false,
 		html: false,
+		lightBlockWrapper: true,
 	},
 
 	__experimentalLabel: ( { label } ) => label,

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -15,6 +15,7 @@ import {
 	FontSizePicker,
 	withFontSizes,
 	__experimentalUseColors,
+	__experimentalBlock as Block,
 } from '@wordpress/block-editor';
 
 import { createBlock } from '@wordpress/blocks';
@@ -148,7 +149,7 @@ function Navigation( {
 	// then show the Placeholder
 	if ( ! hasExistingNavItems ) {
 		return (
-			<Fragment>
+			<Block.div>
 				<Placeholder
 					className="wp-block-navigation-placeholder"
 					icon={ menu }
@@ -179,7 +180,7 @@ function Navigation( {
 						</Button>
 					</div>
 				</Placeholder>
-			</Fragment>
+			</Block.div>
 		);
 	}
 
@@ -256,8 +257,7 @@ function Navigation( {
 			</InspectorControls>
 			<TextColor>
 				<BackgroundColor>
-					<div
-						ref={ ref }
+					<Block.nav
 						className={ blockClassNames }
 						style={ blockInlineStyles }
 					>
@@ -266,13 +266,17 @@ function Navigation( {
 								<Spinner /> { __( 'Loading Navigation…' ) }{ ' ' }
 							</>
 						) }
-
 						<InnerBlocks
+							ref={ ref }
 							allowedBlocks={ [ 'core/navigation-link' ] }
 							templateInsertUpdatesSelection={ false }
 							__experimentalMoverDirection={ 'horizontal' }
+							__experimentalTagName="ul"
+							__experimentalPassedProps={ {
+								className: 'wp-block-navigation__container',
+							} }
 						/>
-					</div>
+					</Block.nav>
 				</BackgroundColor>
 			</TextColor>
 		</Fragment>

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -137,7 +137,7 @@ function Navigation( {
 	const hasPages = hasResolvedPages && pages && pages.length;
 
 	const blockClassNames = classnames( className, {
-		[ `items-justification-${ attributes.itemsJustification }` ]: attributes.itemsJustification,
+		[ `items-justified-${ attributes.itemsJustification }` ]: attributes.itemsJustification,
 		[ fontSize.class ]: fontSize.class,
 	} );
 	const blockInlineStyles = {

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -272,6 +272,7 @@ function Navigation( {
 							templateInsertUpdatesSelection={ false }
 							__experimentalMoverDirection={ 'horizontal' }
 							__experimentalTagName="ul"
+							__experimentalAppenderTagName="li"
 							__experimentalPassedProps={ {
 								className: 'wp-block-navigation__container',
 							} }

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -12,18 +12,6 @@ $navigation-item-height: 46px;
 	margin: 0;
 }
 
-.wp-block-navigation.items-justification-left > ul {
-	justify-content: flex-start;
-}
-
-.wp-block-navigation.items-justification-center > ul {
-	justify-content: center;
-}
-
-.wp-block-navigation.items-justification-right > ul {
-	justify-content: flex-end;
-}
-
 // Polish the Appender.
 .wp-block-navigation .block-list-appender {
 	margin: 0;

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -1,53 +1,27 @@
 $navigation-height: 60px;
 $navigation-item-height: 46px;
 
-// Reduce the paddings, margins, and UI of inner-blocks.
-// @todo: eventually we may add a feature that lets a parent container absorb the block UI of a child block.
-// When that happens, leverage that instead of the following overrides.
-[data-type="core/navigation"] {
+// Undo default editor styles.
+.editor-styles-wrapper .wp-block-navigation ul,
+.editor-styles-wrapper .wp-block-navigation ol {
+	margin-bottom: 0;
+	margin-left: 0;
+}
 
-	.wp-block-navigation .block-editor-inner-blocks {
-		flex: 1; // expand to fill available space required for justification
-	}
+.editor-styles-wrapper .wp-block-navigation .block-editor-block-list__block {
+	margin: 0;
+}
 
-	// 1. Reset margins on immediate innerblocks container.
-	.wp-block-navigation .block-editor-inner-blocks > .block-editor-block-list__layout {
-		margin-left: 0;
-		margin-right: 0;
-	}
+.wp-block-navigation.items-justification-left > ul {
+	justify-content: flex-start;
+}
 
-	.wp-block-navigation.items-justification-left .block-editor-inner-blocks > .block-editor-block-list__layout {
-		justify-content: flex-start;
-	}
+.wp-block-navigation.items-justification-center > ul {
+	justify-content: center;
+}
 
-	.wp-block-navigation.items-justification-center .block-editor-inner-blocks > .block-editor-block-list__layout {
-		justify-content: center;
-	}
-
-	.wp-block-navigation.items-justification-right .block-editor-inner-blocks > .block-editor-block-list__layout {
-		justify-content: flex-end;
-	}
-
-	.wp-block-navigation .block-editor-block-list__block::before {
-		left: 0;
-		right: 0;
-	}
-
-	// Remove the dashed outlines for child blocks.
-	&.is-selected .wp-block-navigation .block-editor-block-list__block::before,
-	&.has-child-selected .wp-block-navigation .block-editor-block-list__block::before {
-		border-color: transparent !important; // !important used to keep the selector from growing any more complex.
-	}
-
-	// Hide the sibling inserter.
-	.wp-block-navigation .block-editor-block-list__insertion-point {
-		display: none;
-	}
-
-	// Set a min width when the item is focused and empty in order to show the caret.
-	.wp-block-navigation .wp-block-navigation-link.is-selected .block-editor-rich-text__editable:focus {
-		min-width: 20px;
-	}
+.wp-block-navigation.items-justification-right > ul {
+	justify-content: flex-end;
 }
 
 // Polish the Appender.

--- a/packages/block-library/src/navigation/index.js
+++ b/packages/block-library/src/navigation/index.js
@@ -29,6 +29,7 @@ export const settings = {
 		anchor: true,
 		html: false,
 		inserter: true,
+		lightBlockWrapper: true,
 	},
 
 	styles: [

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -84,12 +84,6 @@ $navigation-sub-menu-width: $grid-unit-10 * 25;
 		width: $navigation-sub-menu-width;
 	}
 
-	// Remove paddings on subsequent immediate children.
-	.block-editor-inner-blocks > .block-editor-block-list__layout > .wp-block {
-		margin: 0;
-		width: auto;
-	}
-
 	&,
 	> .wp-block-navigation__container {
 		align-items: center;
@@ -122,12 +116,7 @@ $navigation-sub-menu-width: $grid-unit-10 * 25;
 			margin: 0;
 		}
 
-		> .block-editor-inner-blocks {
-			display: none;
-		}
-
-		&.has-child > .wp-block-navigation__container,
-		&.is-editing.has-child > .block-editor-inner-blocks {
+		&.has-child > .wp-block-navigation__container {
 			// Box model
 			display: flex;
 			border: $border-width solid rgba(0, 0, 0, 0.15);
@@ -147,7 +136,6 @@ $navigation-sub-menu-width: $grid-unit-10 * 25;
 		}
 
 		// Inherit colors from menu
-		.block-editor-inner-blocks,
 		.wp-block-navigation__container {
 			background-color: inherit;
 			color: inherit;
@@ -206,13 +194,11 @@ $navigation-sub-menu-width: $grid-unit-10 * 25;
 	.wp-block-navigation-link,
 	&.is-style-light .wp-block-navigation-link {
 		//  No text color
-		&:not(.has-text-color) > .block-editor-inner-blocks,
 		&:not(.has-text-color) > .wp-block-navigation__container {
 			color: $light-style-sub-menu-text-color;
 		}
 
 		// No background color
-		&:not(.has-background) > .block-editor-inner-blocks,
 		&:not(.has-background) > .wp-block-navigation__container {
 			background-color: $light-style-sub-menu-background-color;
 		}
@@ -221,13 +207,11 @@ $navigation-sub-menu-width: $grid-unit-10 * 25;
 	// Dark styles.
 	&.is-style-dark .wp-block-navigation-link {
 		// No text color
-		&:not(.has-text-color) > .block-editor-inner-blocks,
 		&:not(.has-text-color) > .wp-block-navigation__container {
 			color: $dark-style-sub-menu-text-color;
 		}
 
 		// No background color
-		&:not(.has-background) > .block-editor-inner-blocks,
 		&:not(.has-background) > .wp-block-navigation__container {
 			background-color: $dark-style-sub-menu-background-color;
 		}


### PR DESCRIPTION
## Description

Makes the navigation block (and inner blocks) light blocks. The goal is to have the same structure as the front-end.

Especially worth noting is the fact that we can now use the `ul` and `li` tags. This is something that wasn't possible before because the list items couldn't be direct children of `ul`.

<img width="521" alt="Screenshot 2020-03-09 at 15 42 18" src="https://user-images.githubusercontent.com/4710635/76225296-96648d80-621c-11ea-94ad-fb14c116e9b5.png">

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
