### PR TITLE
Keycodes: Test modifiers for keyboard event as exclusive set

### DIFF
--- a/packages/keycodes/CHANGELOG.md
+++ b/packages/keycodes/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Master
+
+### Bug Fixes
+
+- `isKeyboardEvent` now tests expected modifiers as an exclusive set, fixing an issue where additional modifiers would wrongly report as satisfying a test for a subset of those modifiers [#20733](https://github.com/WordPress/gutenberg/pull/20733).
+
 ## 2.0.5 (2018-11-21)
 
 ## 2.0.4 (2018-11-20)

--- a/packages/keycodes/src/index.js
+++ b/packages/keycodes/src/index.js
@@ -12,7 +12,7 @@
 /**
  * External dependencies
  */
-import { get, mapValues, includes, capitalize } from 'lodash';
+import { get, mapValues, includes, capitalize, xor } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -224,6 +224,20 @@ export const shortcutAriaLabel = mapValues( modifiers, ( modifier ) => {
 } );
 
 /**
+ * From a given KeyboardEvent, returns an array of active modifier constants for
+ * the event.
+ *
+ * @param {KeyboardEvent} event Keyboard event.
+ *
+ * @return {Array<ALT|CTRL|COMMAND|SHIFT>} Active modifier constants.
+ */
+function getEventModifiers( event ) {
+	return [ ALT, CTRL, COMMAND, SHIFT ].filter(
+		( key ) => event[ `${ key }Key` ]
+	);
+}
+
+/**
  * An object that contains functions to check if a keyboard event matches a
  * predefined shortcut combination.
  * E.g. isKeyboardEvent.primary( event, 'm' ) will return true if the event
@@ -234,8 +248,9 @@ export const shortcutAriaLabel = mapValues( modifiers, ( modifier ) => {
 export const isKeyboardEvent = mapValues( modifiers, ( getModifiers ) => {
 	return ( event, character, _isApple = isAppleOS ) => {
 		const mods = getModifiers( _isApple );
+		const eventMods = getEventModifiers( event );
 
-		if ( ! mods.every( ( key ) => event[ `${ key }Key` ] ) ) {
+		if ( xor( mods, eventMods ).length ) {
 			return false;
 		}
 

--- a/packages/keycodes/src/test/index.js
+++ b/packages/keycodes/src/test/index.js
@@ -296,6 +296,21 @@ describe( 'isKeyboardEvent', () => {
 		return attachNode;
 	}
 
+	it( 'returns false for a superset of modifiers', () => {
+		expect.assertions( 3 );
+		const attachNode = attachEventListeners( ( event ) => {
+			expect(
+				isKeyboardEvent.primary( event, 'm', isAppleOSFalse )
+			).toBe( false );
+		} );
+
+		keyPress( attachNode, {
+			ctrlKey: true,
+			shiftKey: true,
+			key: 'm',
+		} );
+	} );
+
 	describe( 'primary', () => {
 		it( 'should identify modifier key when Ctrl is pressed', () => {
 			expect.assertions( 3 );

--- a/packages/keycodes/src/test/index.js
+++ b/packages/keycodes/src/test/index.js
@@ -359,7 +359,11 @@ describe( 'isKeyboardEvent', () => {
 			expect.assertions( 3 );
 			const attachNode = attachEventListeners( ( event ) => {
 				expect(
-					isKeyboardEvent.primary( event, undefined, isAppleOSFalse )
+					isKeyboardEvent.primaryShift(
+						event,
+						undefined,
+						isAppleOSFalse
+					)
 				).toBe( true );
 			} );
 
@@ -374,7 +378,11 @@ describe( 'isKeyboardEvent', () => {
 			expect.assertions( 3 );
 			const attachNode = attachEventListeners( ( event ) => {
 				expect(
-					isKeyboardEvent.primary( event, undefined, isAppleOSTrue )
+					isKeyboardEvent.primaryShift(
+						event,
+						undefined,
+						isAppleOSTrue
+					)
 				).toBe( true );
 			} );
 
@@ -389,7 +397,7 @@ describe( 'isKeyboardEvent', () => {
 			expect.assertions( 3 );
 			const attachNode = attachEventListeners( ( event ) => {
 				expect(
-					isKeyboardEvent.primary( event, 'm', isAppleOSFalse )
+					isKeyboardEvent.primaryShift( event, 'm', isAppleOSFalse )
 				).toBe( true );
 			} );
 
@@ -404,7 +412,7 @@ describe( 'isKeyboardEvent', () => {
 			expect.assertions( 3 );
 			const attachNode = attachEventListeners( ( event ) => {
 				expect(
-					isKeyboardEvent.primary( event, 'm', isAppleOSTrue )
+					isKeyboardEvent.primaryShift( event, 'm', isAppleOSTrue )
 				).toBe( true );
 			} );
 
@@ -421,7 +429,11 @@ describe( 'isKeyboardEvent', () => {
 			expect.assertions( 3 );
 			const attachNode = attachEventListeners( ( event ) => {
 				expect(
-					isKeyboardEvent.primary( event, undefined, isAppleOSFalse )
+					isKeyboardEvent.secondary(
+						event,
+						undefined,
+						isAppleOSFalse
+					)
 				).toBe( true );
 			} );
 
@@ -437,7 +449,7 @@ describe( 'isKeyboardEvent', () => {
 			expect.assertions( 3 );
 			const attachNode = attachEventListeners( ( event ) => {
 				expect(
-					isKeyboardEvent.primary( event, undefined, isAppleOSTrue )
+					isKeyboardEvent.secondary( event, undefined, isAppleOSTrue )
 				).toBe( true );
 			} );
 
@@ -453,7 +465,7 @@ describe( 'isKeyboardEvent', () => {
 			expect.assertions( 3 );
 			const attachNode = attachEventListeners( ( event ) => {
 				expect(
-					isKeyboardEvent.primary( event, 'm', isAppleOSFalse )
+					isKeyboardEvent.secondary( event, 'm', isAppleOSFalse )
 				).toBe( true );
 			} );
 
@@ -469,7 +481,7 @@ describe( 'isKeyboardEvent', () => {
 			expect.assertions( 3 );
 			const attachNode = attachEventListeners( ( event ) => {
 				expect(
-					isKeyboardEvent.primary( event, 'm', isAppleOSTrue )
+					isKeyboardEvent.secondary( event, 'm', isAppleOSTrue )
 				).toBe( true );
 			} );
 
@@ -483,61 +495,61 @@ describe( 'isKeyboardEvent', () => {
 	} );
 
 	describe( 'access', () => {
-		it( 'should identify modifier key when Alt + Ctrl is pressed', () => {
+		it( 'should identify modifier key when Shift + Alt is pressed', () => {
 			expect.assertions( 3 );
 			const attachNode = attachEventListeners( ( event ) => {
 				expect(
-					isKeyboardEvent.primary( event, undefined, isAppleOSFalse )
+					isKeyboardEvent.access( event, undefined, isAppleOSFalse )
+				).toBe( true );
+			} );
+
+			keyPress( attachNode, {
+				shiftKey: true,
+				altKey: true,
+				key: 'Alt',
+			} );
+		} );
+
+		it( 'should identify modifier key when Ctrl + ⌥ is pressed', () => {
+			expect.assertions( 3 );
+			const attachNode = attachEventListeners( ( event ) => {
+				expect(
+					isKeyboardEvent.access( event, undefined, isAppleOSTrue )
 				).toBe( true );
 			} );
 
 			keyPress( attachNode, {
 				ctrlKey: true,
 				altKey: true,
-				key: 'Ctrl',
+				key: 'Alt',
 			} );
 		} );
 
-		it( 'should identify modifier key when ⌥⌘ is pressed', () => {
+		it( 'should identify modifier key when Shift + Alt + M is pressed', () => {
 			expect.assertions( 3 );
 			const attachNode = attachEventListeners( ( event ) => {
 				expect(
-					isKeyboardEvent.primary( event, undefined, isAppleOSTrue )
+					isKeyboardEvent.access( event, 'm', isAppleOSFalse )
 				).toBe( true );
 			} );
 
 			keyPress( attachNode, {
-				metaKey: true,
-				altKey: true,
-				key: 'Meta',
-			} );
-		} );
-
-		it( 'should identify modifier key when Ctrl + ALt + M is pressed', () => {
-			expect.assertions( 3 );
-			const attachNode = attachEventListeners( ( event ) => {
-				expect(
-					isKeyboardEvent.primary( event, 'm', isAppleOSFalse )
-				).toBe( true );
-			} );
-
-			keyPress( attachNode, {
-				ctrlKey: true,
+				shiftKey: true,
 				altKey: true,
 				key: 'm',
 			} );
 		} );
 
-		it( 'should identify modifier key when ⌥⌘M is pressed', () => {
+		it( 'should identify modifier key when Ctrl + ⌥M is pressed', () => {
 			expect.assertions( 3 );
 			const attachNode = attachEventListeners( ( event ) => {
 				expect(
-					isKeyboardEvent.primary( event, 'm', isAppleOSTrue )
+					isKeyboardEvent.access( event, 'm', isAppleOSTrue )
 				).toBe( true );
 			} );
 
 			keyPress( attachNode, {
-				metaKey: true,
+				ctrlKey: true,
 				altKey: true,
 				key: 'm',
 			} );


### PR DESCRIPTION
Fixes #17870 

This pull request seeks to improve the logic for `@wordpress/keycodes` `isKeyboardEvent` to test expected modifiers as exclusively the same as those reported by the given event. See the test case added in 3f88808b3 as an example of a result which would previously have returned `true` for `isKeyboardEvent.primary` with a key event for <kbd>Ctrl</kbd><kbd>Shift</kbd><kbd>m</kbd>.

Also included are updates to test cases of non-`primary` modifiers, where previously the tests were always asserting against the result of `isKeyboardEvent.primary`. See 05bd72165 for specific changes. Notably, the tests for `access` expected modifiers were inconsistent with the actual implementation and needed to be updated. I deferred to the current implementation as the "expected" result, though I am not entirely clear what an "access" modifier is, so I'd appreciate a second set of eyes.

**Testing Instructions:**

Ensure unit tests pass:

```
npm run test-unit packages/keycodes/src/test/index.js
```

Repeat Steps to Reproduce from #17870, ensuring that the Ctrl+A "Select All" behavior is not triggered in response to a <kbd>AltGr</kbd><kbd>A</kbd> key combination.