### PR TITLE
Build: Include entire `lib/` folder in plugin bundle

### DIFF
--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -115,8 +115,7 @@ build_files=$(ls build/*/*.{js,css,asset.php} build/block-library/blocks/*.php b
 status "Creating archive... 🎁"
 zip -r gutenberg.zip \
 	gutenberg.php \
-	lib/*.php \
-	lib/demo-block-templates/*.html \
+	lib \
 	packages/block-serialization-default-parser/*.php \
 	post-content.php \
 	$vendor_scripts \


### PR DESCRIPTION
This pull request seeks to resolve an issue where warnings are logged in the [Gutenberg 7.7.0 RC1 release](https://github.com/WordPress/gutenberg/releases/tag/v7.7.0-rc.1).

```
<br />
<b>Warning</b>:  file_get_contents(/var/www/src/wp-content/plugins/gutenberg-1/lib/patterns/text-two-columns.json): failed to open stream: No such file or directory in <b>/var/www/src/wp-content/plugins/gutenberg-1/lib/client-assets.php</b> on line <b>639</b>
...
```

The underlying cause is due to the fact that these files are not whitelisted for inclusion in the built plugin ZIP file. This has been a common source of issues in the past (see #20225, #19072, f09bb3eaeaea5b10acd0e43ebdd70c7435cf52d1, #9799).

The proposed changes opt to include the entire `lib` folder, rather than add additional patterns to match these files. It's not clear by the initial introduction of this pattern in #985 whether there were any files intended to be _omitted_ from this directory, since [at the time all files would have been matched anyways](https://github.com/WordPress/gutenberg/tree/e94961092358a61f83d014f482bddb97a9a4dad7/lib).

In the future, we should consider options for being more proactive in accounting for these errors. Specifically, we should try to incorporate the built plugin as part of the Travis build, perhaps as part of the end-to-end tasks (see https://github.com/WordPress/gutenberg/pull/14289#issuecomment-472464952 and “Pregenerate the plugin build to use across tasks” task of #15159).

**Testing Instructions:**

Run `npm run bundle-plugin`.

Verify that all expected files in `lib` are included:

```
...
  adding: lib/ (stored 0%)
  adding: lib/blocks.php (deflated 70%)
  adding: lib/widgets.php (deflated 73%)
  adding: lib/load.php (deflated 68%)
  adding: lib/block-directory.php (deflated 57%)
  adding: lib/global-styles.php (deflated 75%)
  adding: lib/edit-site-page.php (deflated 68%)
  adding: lib/templates.php (deflated 72%)
  adding: lib/experiments-page.php (deflated 71%)
  adding: lib/patterns/ (stored 0%)
  adding: lib/patterns/text-two-columns.json (deflated 50%)
  adding: lib/patterns/cover-abc.json (deflated 44%)
  adding: lib/patterns/two-buttons.json (deflated 62%)
  adding: lib/rest-api.php (deflated 61%)
  adding: lib/demo-block-templates/ (stored 0%)
  adding: lib/demo-block-templates/front-page.html (deflated 69%)
  adding: lib/template-parts.php (deflated 70%)
  adding: lib/class-wp-rest-widget-forms.php (deflated 67%)
  adding: lib/client-assets.php (deflated 73%)
  adding: lib/demo.php (deflated 64%)
  adding: lib/class-experimental-wp-widget-blocks-manager.php (deflated 76%)
  adding: lib/customizer.php (deflated 63%)
  adding: lib/template-canvas.php (deflated 40%)
  adding: lib/class-wp-block-styles-registry.php (deflated 76%)
  adding: lib/template-loader.php (deflated 70%)
  adding: lib/class-wp-customize-widget-blocks-control.php (deflated 54%)
  adding: lib/class-wp-rest-block-directory-controller.php (deflated 73%)
  adding: lib/widgets-page.php (deflated 63%)
  adding: lib/compat.php (deflated 67%)
  adding: lib/class-wp-rest-widget-areas-controller.php (deflated 75%)
  adding: lib/demo-block-template-parts/ (stored 0%)
  adding: lib/demo-block-template-parts/header.html (deflated 21%)
...
```