### PR TITLE
ESLint Plugin: Relax `prefer-const` for destructuring assignment

### DIFF
--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Master
 
+### New Features
+
+- The `prefer-const` rule included in the `recommended` and `esnext` rulesets has been relaxed to allow a `let` assignment if any of a [destructuring assignment](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment) are reassigned.
+
 ## 4.0.0 (2020-02-10)
 
 ### Breaking Changes

--- a/packages/eslint-plugin/configs/esnext.js
+++ b/packages/eslint-plugin/configs/esnext.js
@@ -22,7 +22,12 @@ module.exports = {
 		'no-useless-constructor': 'error',
 		'no-var': 'error',
 		'object-shorthand': 'error',
-		'prefer-const': 'error',
+		'prefer-const': [
+			'error',
+			{
+				destructuring: 'all',
+			},
+		],
 		quotes: [
 			'error',
 			'single',


### PR DESCRIPTION
Extracted from: #20693

This pull request seeks to update the default ESLint configuration of [`prefer-const`](https://eslint.org/docs/rules/prefer-const) to allow a `let` assignment if any of a [destructuring assignment](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment) are reassigned. The intention with this change is to avoid scenarios where the developer must resort to cumbersome workarounds (like multiple destructuring assignments of `let` and `const`) when there is mixed reassignment of destructured variables. The potential downside of this change is that we lose "signalling" of intent to reassign when working with destructuring.

**Before:**

```js
let { a, b } = obj; // Error: error 'b' is never reassigned, use 'const' instead.
a++;
console.log( a, b );
```

**After:**

```js
let { a, b } = obj; // (no error, since at least one of the destructured props 'a' is reassigned)
a++;
console.log( a, b );
```

See rule configuration for more detail:

https://eslint.org/docs/rules/prefer-const#destructuring

I marked this as a "New Feature" instead of "Breaking Change". While technically the behavior is now different, it should not result in the _introduction_ of any errors.

For a real-world example, see #20693 (specifically [this assignment](https://github.com/WordPress/gutenberg/pull/20693/commits/3121d796becccff59b66e18096f1dbce8da39f63#diff-c73ff988241158c8fc44ba4613bb9d60R13)).

**Testing Instructions:**

Try incorporating a code snippet like those above somewhere in code, and observe the expected result.