### PR TITLE
Switch Social Links to use LinkControl component

### DIFF
--- a/packages/block-library/src/social-link/block.json
+++ b/packages/block-library/src/social-link/block.json
@@ -9,6 +9,10 @@
 		"service": {
 			"type": "string"
 		},
+		"opensInNewTab": {
+			"type": "boolean",
+			"default": false
+		},
 		"label": {
 			"type": "string"
 		}

--- a/packages/block-library/src/social-link/edit.js
+++ b/packages/block-library/src/social-link/edit.js
@@ -7,9 +7,9 @@ import classNames from 'classnames';
  * WordPress dependencies
  */
 import {
+	__experimentalLinkControl as LinkControl,
 	InspectorControls,
 	URLPopover,
-	URLInput,
 } from '@wordpress/block-editor';
 import { Fragment, useState } from '@wordpress/element';
 import {
@@ -27,11 +27,16 @@ import { keyboardReturn } from '@wordpress/icons';
 import { getIconBySite, getNameBySite } from './social-list';
 
 const SocialLinkEdit = ( { attributes, setAttributes, isSelected } ) => {
-	const { url, service, label } = attributes;
+	const { url, label, opensInNewTab, service } = attributes;
 	const [ showURLPopover, setPopover ] = useState( false );
 	const classes = classNames( 'wp-social-link', 'wp-social-link-' + service, {
 		'wp-social-link__is-incomplete': ! url,
 	} );
+
+	const link = {
+		url,
+		opensInNewTab,
+	};
 
 	// Import icon.
 	const IconComponent = getIconBySite( service );
@@ -70,13 +75,18 @@ const SocialLinkEdit = ( { attributes, setAttributes, isSelected } ) => {
 							} }
 						>
 							<div className="block-editor-url-input">
-								<URLInput
-									value={ url }
-									onChange={ ( nextURL ) =>
-										setAttributes( { url: nextURL } )
+								<LinkControl
+									value={ link }
+									onChange={ ( {
+										url: newURL = '',
+										opensInNewTab: newOpensInNewTab,
+									} = {} ) =>
+										setAttributes( {
+											url: encodeURI( newURL ),
+											opensInNewTab: newOpensInNewTab,
+										} )
 									}
-									placeholder={ __( 'Enter address' ) }
-									disableSuggestions={ true }
+									showInitialSuggestions={ false }
 								/>
 							</div>
 							<Button

--- a/packages/block-library/src/social-link/index.php
+++ b/packages/block-library/src/social-link/index.php
@@ -13,11 +13,10 @@
  * @return string Rendered HTML of the referenced block.
  */
 function render_block_core_social_link( $attributes ) {
-	$service = ( isset( $attributes['service'] ) ) ? $attributes['service'] : 'Icon';
-	$url     = ( isset( $attributes['url'] ) ) ? $attributes['url'] : false;
-	$opensInNewTab = ( isset( $attributes['opensInNewTab'] ) ) ? $attributes['opensInNewTab'] : false;
-
-	$label   = ( isset( $attributes['label'] ) ) ?
+	$service          = ( isset( $attributes['service'] ) ) ? $attributes['service'] : 'Icon';
+	$url              = ( isset( $attributes['url'] ) ) ? $attributes['url'] : false;
+	$opens_in_new_tab = ( isset( $attributes['opensInNewTab'] ) ) ? $attributes['opensInNewTab'] : false;
+	$label            = ( isset( $attributes['label'] ) ) ?
 		$attributes['label'] :
 		/* translators: %s: Social Link service name */
 		sprintf( __( 'Link to %s' ), block_core_social_link_get_name( $service ) );
@@ -26,8 +25,8 @@ function render_block_core_social_link( $attributes ) {
 	if ( ! $url ) {
 		return '';
 	}
-	$target = ( $opensInNewTab ) ? 'target="_new"' : '';
-	$icon = block_core_social_link_get_icon( $service );
+	$target = ( $opens_in_new_tab ) ? 'target="_new"' : '';
+	$icon   = block_core_social_link_get_icon( $service );
 	return '<li class="wp-social-link wp-social-link-' . esc_attr( $service ) . '"><a href="' . esc_url( $url ) . '" ' . $target . ' aria-label="' . esc_attr( $label ) . '"> ' . $icon . '</a></li>';
 }
 

--- a/packages/block-library/src/social-link/index.php
+++ b/packages/block-library/src/social-link/index.php
@@ -15,6 +15,8 @@
 function render_block_core_social_link( $attributes ) {
 	$service = ( isset( $attributes['service'] ) ) ? $attributes['service'] : 'Icon';
 	$url     = ( isset( $attributes['url'] ) ) ? $attributes['url'] : false;
+	$opensInNewTab = ( isset( $attributes['opensInNewTab'] ) ) ? $attributes['opensInNewTab'] : false;
+
 	$label   = ( isset( $attributes['label'] ) ) ?
 		$attributes['label'] :
 		/* translators: %s: Social Link service name */
@@ -24,9 +26,9 @@ function render_block_core_social_link( $attributes ) {
 	if ( ! $url ) {
 		return '';
 	}
-
+	$target = ( $opensInNewTab ) ? 'target="_new"' : '';
 	$icon = block_core_social_link_get_icon( $service );
-	return '<li class="wp-social-link wp-social-link-' . esc_attr( $service ) . '"><a href="' . esc_url( $url ) . '" aria-label="' . esc_attr( $label ) . '"> ' . $icon . '</a></li>';
+	return '<li class="wp-social-link wp-social-link-' . esc_attr( $service ) . '"><a href="' . esc_url( $url ) . '" ' . $target . ' aria-label="' . esc_attr( $label ) . '"> ' . $icon . '</a></li>';
 }
 
 /**

--- a/packages/e2e-tests/fixtures/blocks/core__social-link-amazon.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-link-amazon.json
@@ -4,7 +4,7 @@
         "name": "core/social-link",
         "isValid": true,
         "attributes": {
-			"opensInNewTab": false,
+            "opensInNewTab": false,
             "url": "https://example.com/",
             "service": "amazon"
         },

--- a/packages/e2e-tests/fixtures/blocks/core__social-link-amazon.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-link-amazon.json
@@ -4,6 +4,7 @@
         "name": "core/social-link",
         "isValid": true,
         "attributes": {
+			"opensInNewTab": false,
             "url": "https://example.com/",
             "service": "amazon"
         },

--- a/packages/e2e-tests/fixtures/blocks/core__social-link-bandcamp.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-link-bandcamp.json
@@ -4,6 +4,7 @@
         "name": "core/social-link",
         "isValid": true,
         "attributes": {
+			"opensInNewTab": false,
             "url": "https://example.com/",
             "service": "bandcamp"
         },

--- a/packages/e2e-tests/fixtures/blocks/core__social-link-behance.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-link-behance.json
@@ -4,6 +4,7 @@
         "name": "core/social-link",
         "isValid": true,
         "attributes": {
+			"opensInNewTab": false,
             "url": "https://example.com/",
             "service": "behance"
         },

--- a/packages/e2e-tests/fixtures/blocks/core__social-link-chain.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-link-chain.json
@@ -4,6 +4,7 @@
         "name": "core/social-link",
         "isValid": true,
         "attributes": {
+			"opensInNewTab": false,
             "url": "https://example.com/",
             "service": "chain"
         },

--- a/packages/e2e-tests/fixtures/blocks/core__social-link-codepen.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-link-codepen.json
@@ -4,6 +4,7 @@
         "name": "core/social-link",
         "isValid": true,
         "attributes": {
+			"opensInNewTab": false,
             "url": "https://example.com/",
             "service": "codepen"
         },

--- a/packages/e2e-tests/fixtures/blocks/core__social-link-deviantart.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-link-deviantart.json
@@ -4,6 +4,7 @@
         "name": "core/social-link",
         "isValid": true,
         "attributes": {
+			"opensInNewTab": false,
             "url": "https://example.com/",
             "service": "deviantart"
         },

--- a/packages/e2e-tests/fixtures/blocks/core__social-link-dribbble.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-link-dribbble.json
@@ -4,6 +4,7 @@
         "name": "core/social-link",
         "isValid": true,
         "attributes": {
+			"opensInNewTab": false,
             "url": "https://example.com/",
             "service": "dribbble"
         },

--- a/packages/e2e-tests/fixtures/blocks/core__social-link-dropbox.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-link-dropbox.json
@@ -4,6 +4,7 @@
         "name": "core/social-link",
         "isValid": true,
         "attributes": {
+			"opensInNewTab": false,
             "url": "https://example.com/",
             "service": "dropbox"
         },

--- a/packages/e2e-tests/fixtures/blocks/core__social-link-etsy.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-link-etsy.json
@@ -4,6 +4,7 @@
         "name": "core/social-link",
         "isValid": true,
         "attributes": {
+			"opensInNewTab": false,
             "url": "https://example.com/",
             "service": "etsy"
         },

--- a/packages/e2e-tests/fixtures/blocks/core__social-link-facebook.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-link-facebook.json
@@ -4,6 +4,7 @@
         "name": "core/social-link",
         "isValid": true,
         "attributes": {
+			"opensInNewTab": false,
             "url": "https://example.com/",
             "service": "facebook"
         },

--- a/packages/e2e-tests/fixtures/blocks/core__social-link-feed.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-link-feed.json
@@ -4,7 +4,7 @@
         "name": "core/social-link",
         "isValid": true,
         "attributes": {
-			"opensInNewTab": false,
+            "opensInNewTab": false,
             "url": "https://example.com/",
             "service": "feed"
         },

--- a/packages/e2e-tests/fixtures/blocks/core__social-link-feed.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-link-feed.json
@@ -4,6 +4,7 @@
         "name": "core/social-link",
         "isValid": true,
         "attributes": {
+			"opensInNewTab": false,
             "url": "https://example.com/",
             "service": "feed"
         },

--- a/packages/e2e-tests/fixtures/blocks/core__social-link-fivehundredpx.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-link-fivehundredpx.json
@@ -4,7 +4,7 @@
         "name": "core/social-link",
         "isValid": true,
         "attributes": {
-			"opensInNewTab": false,
+            "opensInNewTab": false,
             "url": "https://example.com/",
             "service": "fivehundredpx"
         },

--- a/packages/e2e-tests/fixtures/blocks/core__social-link-fivehundredpx.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-link-fivehundredpx.json
@@ -4,6 +4,7 @@
         "name": "core/social-link",
         "isValid": true,
         "attributes": {
+			"opensInNewTab": false,
             "url": "https://example.com/",
             "service": "fivehundredpx"
         },

--- a/packages/e2e-tests/fixtures/blocks/core__social-link-flickr.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-link-flickr.json
@@ -4,6 +4,7 @@
         "name": "core/social-link",
         "isValid": true,
         "attributes": {
+			"opensInNewTab": false,
             "url": "https://example.com/",
             "service": "flickr"
         },

--- a/packages/e2e-tests/fixtures/blocks/core__social-link-flickr.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-link-flickr.json
@@ -4,7 +4,7 @@
         "name": "core/social-link",
         "isValid": true,
         "attributes": {
-			"opensInNewTab": false,
+            "opensInNewTab": false,
             "url": "https://example.com/",
             "service": "flickr"
         },

--- a/packages/e2e-tests/fixtures/blocks/core__social-link-foursquare.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-link-foursquare.json
@@ -4,7 +4,7 @@
         "name": "core/social-link",
         "isValid": true,
         "attributes": {
-			"opensInNewTab": false,
+            "opensInNewTab": false,
             "url": "https://example.com/",
             "service": "foursquare"
         },

--- a/packages/e2e-tests/fixtures/blocks/core__social-link-foursquare.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-link-foursquare.json
@@ -4,6 +4,7 @@
         "name": "core/social-link",
         "isValid": true,
         "attributes": {
+			"opensInNewTab": false,
             "url": "https://example.com/",
             "service": "foursquare"
         },

--- a/packages/e2e-tests/fixtures/blocks/core__social-link-github.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-link-github.json
@@ -4,7 +4,7 @@
         "name": "core/social-link",
         "isValid": true,
         "attributes": {
-			"opensInNewTab": false,
+            "opensInNewTab": false,
             "url": "https://example.com/",
             "service": "github"
         },

--- a/packages/e2e-tests/fixtures/blocks/core__social-link-github.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-link-github.json
@@ -4,6 +4,7 @@
         "name": "core/social-link",
         "isValid": true,
         "attributes": {
+			"opensInNewTab": false,
             "url": "https://example.com/",
             "service": "github"
         },

--- a/packages/e2e-tests/fixtures/blocks/core__social-link-goodreads.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-link-goodreads.json
@@ -4,7 +4,7 @@
         "name": "core/social-link",
         "isValid": true,
         "attributes": {
-			"opensInNewTab": false,
+            "opensInNewTab": false,
             "url": "https://example.com/",
             "service": "goodreads"
         },

--- a/packages/e2e-tests/fixtures/blocks/core__social-link-goodreads.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-link-goodreads.json
@@ -4,6 +4,7 @@
         "name": "core/social-link",
         "isValid": true,
         "attributes": {
+			"opensInNewTab": false,
             "url": "https://example.com/",
             "service": "goodreads"
         },

--- a/packages/e2e-tests/fixtures/blocks/core__social-link-google.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-link-google.json
@@ -4,6 +4,7 @@
         "name": "core/social-link",
         "isValid": true,
         "attributes": {
+			"opensInNewTab": false,
             "url": "https://example.com/",
             "service": "google"
         },

--- a/packages/e2e-tests/fixtures/blocks/core__social-link-google.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-link-google.json
@@ -4,7 +4,7 @@
         "name": "core/social-link",
         "isValid": true,
         "attributes": {
-			"opensInNewTab": false,
+            "opensInNewTab": false,
             "url": "https://example.com/",
             "service": "google"
         },

--- a/packages/e2e-tests/fixtures/blocks/core__social-link-instagram.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-link-instagram.json
@@ -4,7 +4,7 @@
         "name": "core/social-link",
         "isValid": true,
         "attributes": {
-			"opensInNewTab": false,
+            "opensInNewTab": false,
             "url": "https://example.com/",
             "service": "instagram"
         },

--- a/packages/e2e-tests/fixtures/blocks/core__social-link-instagram.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-link-instagram.json
@@ -4,6 +4,7 @@
         "name": "core/social-link",
         "isValid": true,
         "attributes": {
+			"opensInNewTab": false,
             "url": "https://example.com/",
             "service": "instagram"
         },

--- a/packages/e2e-tests/fixtures/blocks/core__social-link-lastfm.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-link-lastfm.json
@@ -4,7 +4,7 @@
         "name": "core/social-link",
         "isValid": true,
         "attributes": {
-			"opensInNewTab": false,
+            "opensInNewTab": false,
             "url": "https://example.com/",
             "service": "lastfm"
         },

--- a/packages/e2e-tests/fixtures/blocks/core__social-link-lastfm.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-link-lastfm.json
@@ -4,6 +4,7 @@
         "name": "core/social-link",
         "isValid": true,
         "attributes": {
+			"opensInNewTab": false,
             "url": "https://example.com/",
             "service": "lastfm"
         },

--- a/packages/e2e-tests/fixtures/blocks/core__social-link-linkedin.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-link-linkedin.json
@@ -4,6 +4,7 @@
         "name": "core/social-link",
         "isValid": true,
         "attributes": {
+			"opensInNewTab": false,
             "url": "https://example.com/",
             "service": "linkedin"
         },

--- a/packages/e2e-tests/fixtures/blocks/core__social-link-linkedin.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-link-linkedin.json
@@ -4,7 +4,7 @@
         "name": "core/social-link",
         "isValid": true,
         "attributes": {
-			"opensInNewTab": false,
+            "opensInNewTab": false,
             "url": "https://example.com/",
             "service": "linkedin"
         },

--- a/packages/e2e-tests/fixtures/blocks/core__social-link-mail.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-link-mail.json
@@ -4,6 +4,7 @@
         "name": "core/social-link",
         "isValid": true,
         "attributes": {
+			"opensInNewTab": false,
             "url": "https://example.com/",
             "service": "mail"
         },

--- a/packages/e2e-tests/fixtures/blocks/core__social-link-mail.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-link-mail.json
@@ -4,7 +4,7 @@
         "name": "core/social-link",
         "isValid": true,
         "attributes": {
-			"opensInNewTab": false,
+            "opensInNewTab": false,
             "url": "https://example.com/",
             "service": "mail"
         },

--- a/packages/e2e-tests/fixtures/blocks/core__social-link-mastodon.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-link-mastodon.json
@@ -4,7 +4,7 @@
         "name": "core/social-link",
         "isValid": true,
         "attributes": {
-			"opensInNewTab": false,
+            "opensInNewTab": false,
             "url": "https://example.com/",
             "service": "mastodon"
         },

--- a/packages/e2e-tests/fixtures/blocks/core__social-link-mastodon.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-link-mastodon.json
@@ -4,6 +4,7 @@
         "name": "core/social-link",
         "isValid": true,
         "attributes": {
+			"opensInNewTab": false,
             "url": "https://example.com/",
             "service": "mastodon"
         },

--- a/packages/e2e-tests/fixtures/blocks/core__social-link-medium.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-link-medium.json
@@ -4,6 +4,7 @@
         "name": "core/social-link",
         "isValid": true,
         "attributes": {
+			"opensInNewTab": false,
             "url": "https://example.com/",
             "service": "medium"
         },

--- a/packages/e2e-tests/fixtures/blocks/core__social-link-medium.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-link-medium.json
@@ -4,7 +4,7 @@
         "name": "core/social-link",
         "isValid": true,
         "attributes": {
-			"opensInNewTab": false,
+            "opensInNewTab": false,
             "url": "https://example.com/",
             "service": "medium"
         },

--- a/packages/e2e-tests/fixtures/blocks/core__social-link-meetup.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-link-meetup.json
@@ -4,7 +4,7 @@
         "name": "core/social-link",
         "isValid": true,
         "attributes": {
-			"opensInNewTab": false,
+            "opensInNewTab": false,
             "url": "https://example.com/",
             "service": "meetup"
         },

--- a/packages/e2e-tests/fixtures/blocks/core__social-link-meetup.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-link-meetup.json
@@ -4,6 +4,7 @@
         "name": "core/social-link",
         "isValid": true,
         "attributes": {
+			"opensInNewTab": false,
             "url": "https://example.com/",
             "service": "meetup"
         },

--- a/packages/e2e-tests/fixtures/blocks/core__social-link-pinterest.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-link-pinterest.json
@@ -4,6 +4,7 @@
         "name": "core/social-link",
         "isValid": true,
         "attributes": {
+			"opensInNewTab": false,
             "url": "https://example.com/",
             "service": "pinterest"
         },

--- a/packages/e2e-tests/fixtures/blocks/core__social-link-pinterest.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-link-pinterest.json
@@ -4,7 +4,7 @@
         "name": "core/social-link",
         "isValid": true,
         "attributes": {
-			"opensInNewTab": false,
+            "opensInNewTab": false,
             "url": "https://example.com/",
             "service": "pinterest"
         },

--- a/packages/e2e-tests/fixtures/blocks/core__social-link-pocket.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-link-pocket.json
@@ -4,7 +4,7 @@
         "name": "core/social-link",
         "isValid": true,
         "attributes": {
-			"opensInNewTab": false,
+            "opensInNewTab": false,
             "url": "https://example.com/",
             "service": "pocket"
         },

--- a/packages/e2e-tests/fixtures/blocks/core__social-link-pocket.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-link-pocket.json
@@ -4,6 +4,7 @@
         "name": "core/social-link",
         "isValid": true,
         "attributes": {
+			"opensInNewTab": false,
             "url": "https://example.com/",
             "service": "pocket"
         },

--- a/packages/e2e-tests/fixtures/blocks/core__social-link-reddit.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-link-reddit.json
@@ -4,6 +4,7 @@
         "name": "core/social-link",
         "isValid": true,
         "attributes": {
+			"opensInNewTab": false,
             "url": "https://example.com/",
             "service": "reddit"
         },

--- a/packages/e2e-tests/fixtures/blocks/core__social-link-reddit.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-link-reddit.json
@@ -4,7 +4,7 @@
         "name": "core/social-link",
         "isValid": true,
         "attributes": {
-			"opensInNewTab": false,
+            "opensInNewTab": false,
             "url": "https://example.com/",
             "service": "reddit"
         },

--- a/packages/e2e-tests/fixtures/blocks/core__social-link-skype.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-link-skype.json
@@ -4,7 +4,7 @@
         "name": "core/social-link",
         "isValid": true,
         "attributes": {
-			"opensInNewTab": false,
+            "opensInNewTab": false,
             "url": "https://example.com/",
             "service": "skype"
         },

--- a/packages/e2e-tests/fixtures/blocks/core__social-link-skype.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-link-skype.json
@@ -4,6 +4,7 @@
         "name": "core/social-link",
         "isValid": true,
         "attributes": {
+			"opensInNewTab": false,
             "url": "https://example.com/",
             "service": "skype"
         },

--- a/packages/e2e-tests/fixtures/blocks/core__social-link-snapchat.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-link-snapchat.json
@@ -4,6 +4,7 @@
         "name": "core/social-link",
         "isValid": true,
         "attributes": {
+			"opensInNewTab": false,
             "url": "https://example.com/",
             "service": "snapchat"
         },

--- a/packages/e2e-tests/fixtures/blocks/core__social-link-snapchat.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-link-snapchat.json
@@ -4,7 +4,7 @@
         "name": "core/social-link",
         "isValid": true,
         "attributes": {
-			"opensInNewTab": false,
+            "opensInNewTab": false,
             "url": "https://example.com/",
             "service": "snapchat"
         },

--- a/packages/e2e-tests/fixtures/blocks/core__social-link-soundcloud.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-link-soundcloud.json
@@ -4,6 +4,7 @@
         "name": "core/social-link",
         "isValid": true,
         "attributes": {
+			"opensInNewTab": false,
             "url": "https://example.com/",
             "service": "soundcloud"
         },

--- a/packages/e2e-tests/fixtures/blocks/core__social-link-soundcloud.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-link-soundcloud.json
@@ -4,7 +4,7 @@
         "name": "core/social-link",
         "isValid": true,
         "attributes": {
-			"opensInNewTab": false,
+            "opensInNewTab": false,
             "url": "https://example.com/",
             "service": "soundcloud"
         },

--- a/packages/e2e-tests/fixtures/blocks/core__social-link-spotify.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-link-spotify.json
@@ -4,7 +4,7 @@
         "name": "core/social-link",
         "isValid": true,
         "attributes": {
-			"opensInNewTab": false,
+            "opensInNewTab": false,
             "url": "https://example.com/",
             "service": "spotify"
         },

--- a/packages/e2e-tests/fixtures/blocks/core__social-link-spotify.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-link-spotify.json
@@ -4,6 +4,7 @@
         "name": "core/social-link",
         "isValid": true,
         "attributes": {
+			"opensInNewTab": false,
             "url": "https://example.com/",
             "service": "spotify"
         },

--- a/packages/e2e-tests/fixtures/blocks/core__social-link-tumblr.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-link-tumblr.json
@@ -4,7 +4,7 @@
         "name": "core/social-link",
         "isValid": true,
         "attributes": {
-			"opensInNewTab": false,
+            "opensInNewTab": false,
             "url": "https://example.com/",
             "service": "tumblr"
         },

--- a/packages/e2e-tests/fixtures/blocks/core__social-link-tumblr.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-link-tumblr.json
@@ -4,6 +4,7 @@
         "name": "core/social-link",
         "isValid": true,
         "attributes": {
+			"opensInNewTab": false,
             "url": "https://example.com/",
             "service": "tumblr"
         },

--- a/packages/e2e-tests/fixtures/blocks/core__social-link-twitch.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-link-twitch.json
@@ -4,6 +4,7 @@
         "name": "core/social-link",
         "isValid": true,
         "attributes": {
+			"opensInNewTab": false,
             "url": "https://example.com/",
             "service": "twitch"
         },

--- a/packages/e2e-tests/fixtures/blocks/core__social-link-twitch.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-link-twitch.json
@@ -4,7 +4,7 @@
         "name": "core/social-link",
         "isValid": true,
         "attributes": {
-			"opensInNewTab": false,
+            "opensInNewTab": false,
             "url": "https://example.com/",
             "service": "twitch"
         },

--- a/packages/e2e-tests/fixtures/blocks/core__social-link-twitter.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-link-twitter.json
@@ -4,6 +4,7 @@
         "name": "core/social-link",
         "isValid": true,
         "attributes": {
+			"opensInNewTab": false,
             "url": "https://example.com/",
             "service": "twitter"
         },

--- a/packages/e2e-tests/fixtures/blocks/core__social-link-twitter.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-link-twitter.json
@@ -4,7 +4,7 @@
         "name": "core/social-link",
         "isValid": true,
         "attributes": {
-			"opensInNewTab": false,
+            "opensInNewTab": false,
             "url": "https://example.com/",
             "service": "twitter"
         },

--- a/packages/e2e-tests/fixtures/blocks/core__social-link-vimeo.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-link-vimeo.json
@@ -4,7 +4,7 @@
         "name": "core/social-link",
         "isValid": true,
         "attributes": {
-			"opensInNewTab": false,
+            "opensInNewTab": false,
             "url": "https://example.com/",
             "service": "vimeo"
         },

--- a/packages/e2e-tests/fixtures/blocks/core__social-link-vimeo.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-link-vimeo.json
@@ -4,6 +4,7 @@
         "name": "core/social-link",
         "isValid": true,
         "attributes": {
+			"opensInNewTab": false,
             "url": "https://example.com/",
             "service": "vimeo"
         },

--- a/packages/e2e-tests/fixtures/blocks/core__social-link-vk.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-link-vk.json
@@ -4,6 +4,7 @@
         "name": "core/social-link",
         "isValid": true,
         "attributes": {
+			"opensInNewTab": false,
             "url": "https://example.com/",
             "service": "vk"
         },

--- a/packages/e2e-tests/fixtures/blocks/core__social-link-vk.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-link-vk.json
@@ -4,7 +4,7 @@
         "name": "core/social-link",
         "isValid": true,
         "attributes": {
-			"opensInNewTab": false,
+            "opensInNewTab": false,
             "url": "https://example.com/",
             "service": "vk"
         },

--- a/packages/e2e-tests/fixtures/blocks/core__social-link-wordpress.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-link-wordpress.json
@@ -4,6 +4,7 @@
         "name": "core/social-link",
         "isValid": true,
         "attributes": {
+			"opensInNewTab": false,
             "url": "https://example.com/",
             "service": "wordpress"
         },

--- a/packages/e2e-tests/fixtures/blocks/core__social-link-wordpress.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-link-wordpress.json
@@ -4,7 +4,7 @@
         "name": "core/social-link",
         "isValid": true,
         "attributes": {
-			"opensInNewTab": false,
+            "opensInNewTab": false,
             "url": "https://example.com/",
             "service": "wordpress"
         },

--- a/packages/e2e-tests/fixtures/blocks/core__social-link-yelp.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-link-yelp.json
@@ -4,7 +4,7 @@
         "name": "core/social-link",
         "isValid": true,
         "attributes": {
-			"opensInNewTab": false,
+            "opensInNewTab": false,
             "url": "https://example.com/",
             "service": "yelp"
         },

--- a/packages/e2e-tests/fixtures/blocks/core__social-link-yelp.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-link-yelp.json
@@ -4,6 +4,7 @@
         "name": "core/social-link",
         "isValid": true,
         "attributes": {
+			"opensInNewTab": false,
             "url": "https://example.com/",
             "service": "yelp"
         },

--- a/packages/e2e-tests/fixtures/blocks/core__social-link-youtube.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-link-youtube.json
@@ -4,6 +4,7 @@
         "name": "core/social-link",
         "isValid": true,
         "attributes": {
+			"opensInNewTab": false,
             "url": "https://example.com/",
             "service": "youtube"
         },

--- a/packages/e2e-tests/fixtures/blocks/core__social-link-youtube.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-link-youtube.json
@@ -4,7 +4,7 @@
         "name": "core/social-link",
         "isValid": true,
         "attributes": {
-			"opensInNewTab": false,
+            "opensInNewTab": false,
             "url": "https://example.com/",
             "service": "youtube"
         },

--- a/packages/e2e-tests/fixtures/blocks/core__social-link.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-link.json
@@ -4,7 +4,7 @@
         "name": "core/social-link",
         "isValid": true,
         "attributes": {
-			"opensInNewTab": false,
+            "opensInNewTab": false,
             "url": "https://example.com/",
             "service": "spotify"
         },

--- a/packages/e2e-tests/fixtures/blocks/core__social-link.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-link.json
@@ -4,6 +4,7 @@
         "name": "core/social-link",
         "isValid": true,
         "attributes": {
+			"opensInNewTab": false,
             "url": "https://example.com/",
             "service": "spotify"
         },

--- a/packages/e2e-tests/fixtures/blocks/core__social-links.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-links.json
@@ -12,7 +12,7 @@
                 "attributes": {
                     "url": "https://mastodon.social/@marcuskaz",
                     "service": "mastodon",
-					"opensInNewTab": false
+                    "opensInNewTab": false
                 },
                 "innerBlocks": [],
                 "originalContent": ""

--- a/packages/e2e-tests/fixtures/blocks/core__social-links.json
+++ b/packages/e2e-tests/fixtures/blocks/core__social-links.json
@@ -11,7 +11,8 @@
                 "isValid": true,
                 "attributes": {
                     "url": "https://mastodon.social/@marcuskaz",
-                    "service": "mastodon"
+                    "service": "mastodon",
+					"opensInNewTab": false
                 },
                 "innerBlocks": [],
                 "originalContent": ""


### PR DESCRIPTION
## Description

This updates the Social Links to use the LinkControl component instead of URLInput, this allows for setting the "opens in external tab" property.

Fixes #20707 

## How has this been tested?

- Create social link, make sure you can add URL
- Toggle opens in new tab, confirm when saved it does what is expected
- Confirm previous social links created prior to patch do not break

## Screenshots 

![Screenshot from 2020-03-09 12-36-15](https://user-images.githubusercontent.com/45363/76252950-f51f0c80-6206-11ea-8566-ea60308759f9.png)


## Types of changes

- Switch `URLInput` to `LinkControl`
- Adds new attribute `opensInNewTab` 
- Update fixtures

