### PR TITLE
Docs: Add tutorial link to Table of Contents for Custom Block Editor

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -246,6 +246,12 @@
 		"parent": "platform"
 	},
 	{
+		"title": "Tutorial: building a custom block editor",
+		"slug": "tutorial",
+		"markdown_source": "../docs/designers-developers/developers/platform/custom-block-editor/tutorial.md",
+		"parent": "custom-block-editor"
+	},
+	{
 		"title": "Designer Documentation",
 		"slug": "designers",
 		"markdown_source": "../docs/designers-developers/designers/README.md",

--- a/docs/toc.json
+++ b/docs/toc.json
@@ -46,7 +46,9 @@
 			{ "docs/designers-developers/developers/backward-compatibility/meta-box.md": [] }
 		] },
 		{ "docs/designers-developers/developers/platform/README.md": [
-			{ "docs/designers-developers/developers/platform/custom-block-editor/README.md": [] }
+			{ "docs/designers-developers/developers/platform/custom-block-editor/README.md": [
+				{ "docs/designers-developers/developers/platform/custom-block-editor/tutorial.md": [] }
+			] }
 		] }
 	] },
 	{ "docs/designers-developers/designers/README.md": [


### PR DESCRIPTION
## Description

One more link to the Table of Contents for the Custom Block Editor tutorial

## How has this been tested?

Published docs, the testing is wait 15 minutes :crossed_fingers: 

## Types of changes

Docs table of contents
