### PR TITLE
Try: Show inserter only when block selected for nesting contexts.

### DIFF
--- a/packages/block-editor/src/components/block-list-appender/style.scss
+++ b/packages/block-editor/src/components/block-list-appender/style.scss
@@ -8,6 +8,12 @@
 	.has-background & {
 		margin: ($grid-unit-20 + $block-spacing) $grid-unit-10;
 	}
+
+	// Animate appearance.
+	opacity: 1;
+	transform: scale(1);
+	transition: all 0.1s ease;
+	@include reduce-motion("transition");
 }
 
 .block-list-appender.is-drop-target > div::before {
@@ -23,4 +29,11 @@
 
 .block-list-appender > .block-editor-inserter {
 	display: block;
+}
+
+
+// Hide the nested appender unless parent or child is selected.
+.block-editor-block-list__block:not(.is-selected):not(.has-child-selected) .block-editor-inner-blocks > .block-editor-block-list__layout > .block-list-appender {
+	opacity: 0;
+	transform: scale(0);
 }

--- a/packages/block-editor/src/components/block-list-appender/style.scss
+++ b/packages/block-editor/src/components/block-list-appender/style.scss
@@ -33,7 +33,10 @@
 
 
 // Hide the nested appender unless parent or child is selected.
-.block-editor-block-list__block:not(.is-selected):not(.has-child-selected) .block-editor-inner-blocks > .block-editor-block-list__layout > .block-list-appender {
-	opacity: 0;
-	transform: scale(0);
+// This selector targets unselected blocks that have only a single nesting level.
+.block-editor-block-list__block:not(.is-selected):not(.has-child-selected):not(.block-editor-block-list__layout) {
+	.block-editor-block-list__layout > .block-list-appender {
+		opacity: 0;
+		transform: scale(0);
+	}
 }


### PR DESCRIPTION
Starts work on #20728. It doesn't completely fix it though.

What it does is create a generic rule to hide the appender in nesting contexts, until the parent or a child of the same block, is selected.

![inserter](https://user-images.githubusercontent.com/1204802/76303649-5b1c9a00-62c2-11ea-9ea2-cf381c757256.gif)

Not yet addressed is the addition of a label. A behavior of the columns block that used to show the plus in arbitrary situations has not been touched, as that issue does not appear to be present in master anymore. 