### PR TITLE
Polish poster image button arrangement.

### DIFF
--- a/packages/block-library/src/video/edit.js
+++ b/packages/block-library/src/video/edit.js
@@ -184,7 +184,7 @@ class VideoEdit extends Component {
 									}
 									render={ ( { open } ) => (
 										<Button
-											isSecondary
+											isPrimary
 											onClick={ open }
 											ref={ this.posterImageButton }
 											aria-describedby={
@@ -192,8 +192,8 @@ class VideoEdit extends Component {
 											}
 										>
 											{ ! this.props.attributes.poster
-												? __( 'Select Poster Image' )
-												: __( 'Replace image' ) }
+												? __( 'Select' )
+												: __( 'Replace' ) }
 										</Button>
 									) }
 								/>
@@ -212,10 +212,9 @@ class VideoEdit extends Component {
 								{ !! this.props.attributes.poster && (
 									<Button
 										onClick={ this.onRemovePoster }
-										isLink
-										isDestructive
+										isTertiary
 									>
-										{ __( 'Remove Poster Image' ) }
+										{ __( 'Remove' ) }
 									</Button>
 								) }
 							</BaseControl>

--- a/packages/block-library/src/video/editor.scss
+++ b/packages/block-library/src/video/editor.scss
@@ -2,11 +2,12 @@
 	text-align: center;
 }
 
-.editor-video-poster-control .components-button {
-	display: block;
-	margin-right: 8px;
-}
+.editor-video-poster-control {
+	.components-base-control__label {
+		display: block;
+	}
 
-.editor-video-poster-control .components-button + .components-button {
-	margin-top: 1em;
+	.components-button {
+		margin-right: $grid-unit-10;
+	}
 }

--- a/packages/components/src/base-control/style.scss
+++ b/packages/components/src/base-control/style.scss
@@ -12,7 +12,7 @@
 
 	.components-base-control__label {
 		display: inline-block;
-		margin-bottom: $grid-unit-05;
+		margin-bottom: $grid-unit-10;
 	}
 
 	.components-base-control__help {


### PR DESCRIPTION
Fixes #20704.

This changes the phrasing, the button types, and the arrangement of the video poster buttons.

Before:

<img width="219" alt="Screenshot 2020-03-10 at 11 40 42" src="https://user-images.githubusercontent.com/1204802/76305960-5f4ab680-62c6-11ea-9892-7cb5d0293644.png">

After:

<img width="236" alt="Screenshot 2020-03-10 at 11 52 27" src="https://user-images.githubusercontent.com/1204802/76305966-61ad1080-62c6-11ea-8848-bb68126e175a.png">

<img width="251" alt="Screenshot 2020-03-10 at 11 56 23" src="https://user-images.githubusercontent.com/1204802/76305969-62de3d80-62c6-11ea-8cde-805c57c1725b.png">

This also changes the "Remove" button from being a destructive link button, to simply being a tertiary button. It's not a destructive action as it doesn't delete anything, and you can just undo if you did something by accident. 