### PR TITLE
Create block: Improve how prompts and values provided are handled

### DIFF
--- a/packages/create-block/CHANGELOG.md
+++ b/packages/create-block/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## Master
 
+### New Features
+
+- Added readme.txt file to the existing templates to make your entry in the plugin browser most useful ([#20694](https://github.com/WordPress/gutenberg/pull/20694)).
+- Added prompts for the `author`, `license` and `version` of the plugin ([#20694](https://github.com/WordPress/gutenberg/pull/20694)).
+
+### Bug Fixes
+
+- Make `version` prompt mandatory and provide validation against semantic versioning ([#20756](https://github.com/WordPress/gutenberg/pull/20756)).
+- Omit optional values in the scaffolded files when they aren't provided ([#20756](https://github.com/WordPress/gutenberg/pull/20756)).
+
 ## 0.8.3 (2020-02-26)
 
 ### Bug Fixes

--- a/packages/create-block/lib/init-wp-scripts.js
+++ b/packages/create-block/lib/init-wp-scripts.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 const { command } = require( 'execa' );
+const { isEmpty, omitBy } = require( 'lodash' );
 const { join } = require( 'path' );
 const writePkg = require( 'write-pkg' );
 
@@ -21,22 +22,28 @@ module.exports = async function( {
 
 	info( '' );
 	info( 'Creating a "package.json" file.' );
-	await writePkg( cwd, {
-		name: slug,
-		version,
-		description,
-		author,
-		license,
-		main: 'build/index.js',
-		scripts: {
-			build: 'wp-scripts build',
-			'format:js': 'wp-scripts format-js',
-			'lint:css': 'wp-scripts lint-style',
-			'lint:js': 'wp-scripts lint-js',
-			start: 'wp-scripts start',
-			'packages-update': 'wp-scripts packages-update',
-		},
-	} );
+	await writePkg(
+		cwd,
+		omitBy(
+			{
+				name: slug,
+				version,
+				description,
+				author,
+				license,
+				main: 'build/index.js',
+				scripts: {
+					build: 'wp-scripts build',
+					'format:js': 'wp-scripts format-js',
+					'lint:css': 'wp-scripts lint-style',
+					'lint:js': 'wp-scripts lint-js',
+					start: 'wp-scripts start',
+					'packages-update': 'wp-scripts packages-update',
+				},
+			},
+			isEmpty
+		)
+	);
 
 	info( '' );
 	info( 'Installing packages. It might take a couple of minutes.' );

--- a/packages/create-block/lib/prompts.js
+++ b/packages/create-block/lib/prompts.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-const { upperFirst } = require( 'lodash' );
+const { isEmpty, upperFirst } = require( 'lodash' );
 
 const slug = {
 	type: 'input',
@@ -55,7 +55,7 @@ const dashicon = {
 	message:
 		'The dashicon to make it easier to identify your block (optional):',
 	validate( input ) {
-		if ( ! /^[a-z][a-z0-9\-]*$/.test( input ) ) {
+		if ( ! isEmpty( input ) && ! /^[a-z][a-z0-9\-]*$/.test( input ) ) {
 			return 'Invalid dashicon name specified. Visit https://developer.wordpress.org/resource/dashicons/ to discover available names.';
 		}
 
@@ -77,25 +77,34 @@ const author = {
 	type: 'input',
 	name: 'author',
 	message:
-		'The list of contributors containing only WordPress.org usernames (optional):',
+		'The name of the plugin author (optional). Multiple authors may be listed using commas:',
 };
 
 const license = {
 	type: 'input',
 	name: 'license',
-	message: 'The plugin license (optional):',
+	message: 'The short name of the plugin’s license (optional):',
 };
 
 const licenseURI = {
 	type: 'input',
 	name: 'licenseURI',
-	message: 'The plugin license URI (optional):',
+	message: 'A link to the full text of the license (optional):',
 };
 
 const version = {
 	type: 'input',
 	name: 'version',
-	message: 'The plugin version (optional):',
+	message: 'The current version number of the plugin:',
+	validate( input ) {
+		// Regular expression was copied from https://semver.org.
+		const validSemVerPattern = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/;
+		if ( ! validSemVerPattern.test( input ) ) {
+			return 'Invalid Semantic Version provided. Visit https://regex101.com/r/vkijKf/1/ to discover all valid patterns.';
+		}
+
+		return true;
+	},
 };
 
 module.exports = {

--- a/packages/create-block/lib/templates/es5/$slug.php.mustache
+++ b/packages/create-block/lib/templates/es5/$slug.php.mustache
@@ -1,10 +1,19 @@
 <?php
 /**
  * Plugin Name:     {{title}}
+{{#description}}
  * Description:     {{description}}
+{{/description}}
  * Version:         {{version}}
+{{#author}}
  * Author:          {{author}}
+{{/author}}
+{{#license}}
  * License:         {{license}}
+{{/license}}
+{{#licenseURI}}
+ * License URI:     {{{licenseURI}}}
+{{/licenseURI}}
  * Text Domain:     {{textdomain}}
  *
  * @package         {{namespace}}

--- a/packages/create-block/lib/templates/es5/readme.txt.mustache
+++ b/packages/create-block/lib/templates/es5/readme.txt.mustache
@@ -1,12 +1,18 @@
 === {{title}} ===
+{{#author}}
 Contributors:      {{author}}
+{{/author}}
 Tags:              block
 Requires at least: 5.3.2
 Tested up to:      5.3.2
 Stable tag:        {{version}}
 Requires PHP:      7.0.0
+{{#license}}
 License:           {{license}}
+{{/license}}
+{{#licenseURI}}
 License URI:       {{{licenseURI}}}
+{{/licenseURI}}
 
 {{description}}
 

--- a/packages/create-block/lib/templates/esnext/$slug.php.mustache
+++ b/packages/create-block/lib/templates/esnext/$slug.php.mustache
@@ -1,10 +1,19 @@
 <?php
 /**
  * Plugin Name:     {{title}}
+{{#description}}
  * Description:     {{description}}
+{{/description}}
  * Version:         {{version}}
+{{#author}}
  * Author:          {{author}}
+{{/author}}
+{{#license}}
  * License:         {{license}}
+{{/license}}
+{{#licenseURI}}
+ * License URI:     {{{licenseURI}}}
+{{/licenseURI}}
  * Text Domain:     {{textdomain}}
  *
  * @package         {{namespace}}

--- a/packages/create-block/lib/templates/esnext/readme.txt.mustache
+++ b/packages/create-block/lib/templates/esnext/readme.txt.mustache
@@ -1,12 +1,18 @@
 === {{title}} ===
+{{#author}}
 Contributors:      {{author}}
+{{/author}}
 Tags:              block
 Requires at least: 5.3.2
 Tested up to:      5.3.2
 Stable tag:        {{version}}
 Requires PHP:      7.0.0
+{{#license}}
 License:           {{license}}
+{{/license}}
+{{#licenseURI}}
 License URI:       {{{licenseURI}}}
+{{/licenseURI}}
 
 {{description}}
 


### PR DESCRIPTION
## Description
Inspired by #20694 and work done by @pereirinha to add `readme.txt` file.

This PR ensures that optional values are reflected in the generated code and therefore they are wrapped with conditionals that ensure they are only printed when provided.

In addition:
- the icon becomes optional for real by relaxing the validation
- the version is marked as mandatory and validation logic is included

## How has this been tested?
Testing is a bit tricky for this package because it is usually executed from npm. However, there is a way to run this script from Gutenberg:

`npx wp-create-block` for ESNext
`npx wp-create-block --template es5` for ES5

The best way is to omit optional marked as such and observe the scaffolded block.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
