### PR TITLE
New Block: Description List

### DIFF
--- a/packages/block-editor/src/components/block-list/block-wrapper.js
+++ b/packages/block-editor/src/components/block-list/block-wrapper.js
@@ -231,6 +231,9 @@ const elements = [
 	'ol',
 	'ul',
 	'figure',
+	'dl',
+	'dt',
+	'dd',
 ];
 
 const ExtendedBlockComponent = elements.reduce( ( acc, element ) => {

--- a/packages/block-library/src/description-details/edit.js
+++ b/packages/block-library/src/description-details/edit.js
@@ -1,0 +1,17 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	RichText,
+	__experimentalBlock as Block,
+} from '@wordpress/block-editor';
+
+export default function Edit( { attributes, setAttributes } ) {
+	return (
+		<RichText
+			tagName={ Block.dd }
+			value={ attributes.content }
+			onChange={ ( content ) => setAttributes( { content } ) }
+		/>
+	);
+}

--- a/packages/block-library/src/description-details/index.js
+++ b/packages/block-library/src/description-details/index.js
@@ -1,0 +1,33 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import edit from './edit';
+import save from './save';
+
+export const name = 'core/description-details';
+
+export const settings = {
+	title: __( 'Description Details' ),
+	parent: [ 'core/description-details' ],
+	description: __( 'The details of a term.' ),
+	category: 'layout',
+	supports: {
+		className: false,
+		lightBlockWrapper: true,
+	},
+	edit,
+	save,
+	attributes: {
+		content: {
+			type: 'string',
+			source: 'html',
+			selector: 'dd',
+			default: '',
+		},
+	},
+};

--- a/packages/block-library/src/description-details/save.js
+++ b/packages/block-library/src/description-details/save.js
@@ -1,0 +1,8 @@
+/**
+ * WordPress dependencies
+ */
+import { RichText } from '@wordpress/block-editor';
+
+export default function Save( { attributes } ) {
+	return <RichText.Content tagName="dd" value={ attributes.content } />;
+}

--- a/packages/block-library/src/description-list/edit.js
+++ b/packages/block-library/src/description-list/edit.js
@@ -1,0 +1,23 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	InnerBlocks,
+	__experimentalBlock as Block,
+} from '@wordpress/block-editor';
+
+const ALLOWED_BLOCKS = [ 'core/description-term', 'core/description-details' ];
+const TEMPLATE = [
+	[ 'core/description-term' ],
+	[ 'core/description-details' ],
+];
+
+export default function Edit() {
+	return (
+		<InnerBlocks
+			allowedBlocks={ ALLOWED_BLOCKS }
+			template={ TEMPLATE }
+			__experimentalTagName={ Block.dl }
+		/>
+	);
+}

--- a/packages/block-library/src/description-list/editor.scss
+++ b/packages/block-library/src/description-list/editor.scss
@@ -1,0 +1,13 @@
+// Undo default editor styles.
+.editor-styles-wrapper .block-editor-block-list__block {
+	&[data-type="core/description-list"],
+	&[data-type="core/description-term"],
+	&[data-type="core/description-details"] {
+		margin-top: 0;
+		margin-bottom: 0;
+	}
+
+	&[data-type="core/description-details"] {
+		margin-inline-start: 40px;
+	}
+}

--- a/packages/block-library/src/description-list/index.js
+++ b/packages/block-library/src/description-list/index.js
@@ -1,0 +1,25 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import edit from './edit';
+import save from './save';
+
+export const name = 'core/description-list';
+
+export const settings = {
+	title: __( 'Description List' ),
+	description: __( 'List groups of terms and descriptions.' ),
+	keywords: [ __( 'list' ), __( 'definitions' ), __( 'terms' ) ],
+	category: 'layout',
+	supports: {
+		className: false,
+		lightBlockWrapper: true,
+	},
+	edit,
+	save,
+};

--- a/packages/block-library/src/description-list/save.js
+++ b/packages/block-library/src/description-list/save.js
@@ -1,0 +1,12 @@
+/**
+ * WordPress dependencies
+ */
+import { InnerBlocks } from '@wordpress/block-editor';
+
+export default function Save() {
+	return (
+		<dl>
+			<InnerBlocks.Content />
+		</dl>
+	);
+}

--- a/packages/block-library/src/description-term/edit.js
+++ b/packages/block-library/src/description-term/edit.js
@@ -1,0 +1,17 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	RichText,
+	__experimentalBlock as Block,
+} from '@wordpress/block-editor';
+
+export default function Edit( { attributes, setAttributes } ) {
+	return (
+		<RichText
+			tagName={ Block.dt }
+			value={ attributes.content }
+			onChange={ ( content ) => setAttributes( { content } ) }
+		/>
+	);
+}

--- a/packages/block-library/src/description-term/index.js
+++ b/packages/block-library/src/description-term/index.js
@@ -1,0 +1,33 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import edit from './edit';
+import save from './save';
+
+export const name = 'core/description-term';
+
+export const settings = {
+	title: __( 'Description Term' ),
+	parent: [ 'core/description-list' ],
+	description: __( 'A term in a description list.' ),
+	category: 'layout',
+	supports: {
+		className: false,
+		lightBlockWrapper: true,
+	},
+	edit,
+	save,
+	attributes: {
+		content: {
+			type: 'string',
+			source: 'html',
+			selector: 'dt',
+			default: '',
+		},
+	},
+};

--- a/packages/block-library/src/description-term/save.js
+++ b/packages/block-library/src/description-term/save.js
@@ -1,0 +1,8 @@
+/**
+ * WordPress dependencies
+ */
+import { RichText } from '@wordpress/block-editor';
+
+export default function Save( { attributes } ) {
+	return <RichText.Content tagName="dt" value={ attributes.content } />;
+}

--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -12,6 +12,7 @@
 @import "./code/editor.scss";
 @import "./columns/editor.scss";
 @import "./cover/editor.scss";
+@import "./description-list/editor.scss";
 @import "./embed/editor.scss";
 @import "./file/editor.scss";
 @import "./classic/editor.scss";

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -30,6 +30,9 @@ import * as code from './code';
 import * as columns from './columns';
 import * as column from './column';
 import * as cover from './cover';
+import * as descriptionList from './description-list';
+import * as descriptionTerm from './description-term';
+import * as descriptionDetails from './description-details';
 import * as embed from './embed';
 import * as file from './file';
 import * as html from './html';
@@ -125,6 +128,9 @@ export const registerCoreBlocks = () => {
 		columns,
 		column,
 		cover,
+		descriptionList,
+		descriptionTerm,
+		descriptionDetails,
 		embed,
 		...embed.common,
 		...embed.others,


### PR DESCRIPTION
## Description

Fixes #4880

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dl

This is a block that I think would have been more difficult to implement without the use of light blocks. With light blocks, we're able to use proper semantic tags in the editor, which also allow it to be styled more easily.

To do: it might be could to handle enter/delete from rich text.

<img width="423" alt="Screenshot 2020-03-10 at 12 24 37" src="https://user-images.githubusercontent.com/4710635/76308204-8efbbd80-62ca-11ea-9141-938442faffe1.png">

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
