### PR TITLE
[RNMobile] Fix alignement issues on long bottom-sheet cells

### DIFF
--- a/packages/components/src/mobile/bottom-sheet/styles.native.scss
+++ b/packages/components/src/mobile/bottom-sheet/styles.native.scss
@@ -112,7 +112,7 @@
 .cellRowContainer {
 	flex-direction: row;
 	align-items: center;
-	flex-shrink: 1;
+	flex-shrink: 0;
 }
 
 .cellIcon {


### PR DESCRIPTION
## Description

Fixed the `flexShrink` parameter on bottom sheet cell style.

## How has this been tested?

Tested in the `gutenberg-mobile` repo in the demo app and using wpandroid.

## Screenshots <!-- if applicable -->

Notice the left position is shifted to the left on multiline text

Before/After in the demo app:
![before-after1](https://user-images.githubusercontent.com/40213/76315423-ef91f700-62d8-11ea-98da-7b00113ac5a9.png)

Before/After in wpandroid:
![before-after2](https://user-images.githubusercontent.com/40213/76315417-ebfe7000-62d8-11ea-860f-fa971ce27dd5.png)



## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

UI update

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
