### PR TITLE
Reduce gap between block library and preview

### DIFF
--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -143,6 +143,8 @@ $block-inserter-search-height: 38px;
 	margin-right: 20px;
 	padding: 20px;
 	background: $white;
+	box-shadow: $shadow-popover;
+	border-radius: $radius-block-ui;
 
 	@include break-medium {
 		position: absolute;

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -146,8 +146,8 @@ $block-inserter-search-height: 38px;
 
 	@include break-medium {
 		position: absolute;
-		top: 0;
-		left: calc(100% + 20px);
+		top: -1px;
+		left: calc(100% + 12px);
 		display: flex;
 		flex-direction: column;
 	}

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -148,8 +148,8 @@ $block-inserter-search-height: 38px;
 
 	@include break-medium {
 		position: absolute;
-		top: -1px;
-		left: calc(100% + 12px);
+		top: -$border-width;
+		left: calc(100% + #{$grid-unit-15});
 		display: flex;
 		flex-direction: column;
 	}


### PR DESCRIPTION
## Description
Closes #20747. These are minor CSS changes that reduce the gap between the block library and the preview popover.

It also adds border radius and box shadow to the preview popover.

## Screenshots
**Before:**
<img width="763" alt="Screen Shot 2020-03-10 at 16 03 02" src="https://user-images.githubusercontent.com/3276087/76363483-be212780-62e8-11ea-9531-0ab3d7c270c7.png">

**After:**
<img width="752" alt="Screen Shot 2020-03-10 at 16 03 25" src="https://user-images.githubusercontent.com/3276087/76363523-d133f780-62e8-11ea-92e3-fa5ba697e49f.png">


## Types of changes
CSS changes.
