### PR TITLE
Fix auto-hiding appender regression.

### DIFF
--- a/packages/block-editor/src/components/block-list-appender/style.scss
+++ b/packages/block-editor/src/components/block-list-appender/style.scss
@@ -10,10 +10,12 @@
 	}
 
 	// Animate appearance.
-	opacity: 1;
-	transform: scale(1);
-	transition: all 0.1s ease;
-	@include reduce-motion("transition");
+	.block-list-appender__toggle {
+		opacity: 1;
+		transform: scale(1);
+		transition: all 0.1s ease;
+		@include reduce-motion("transition");
+	}
 }
 
 .block-list-appender.is-drop-target > div::before {
@@ -35,7 +37,7 @@
 // Hide the nested appender unless parent or child is selected.
 // This selector targets unselected blocks that have only a single nesting level.
 .block-editor-block-list__block:not(.is-selected):not(.has-child-selected):not(.block-editor-block-list__layout) {
-	.block-editor-block-list__layout > .block-list-appender {
+	.block-editor-block-list__layout > .block-list-appender .block-list-appender__toggle {
 		opacity: 0;
 		transform: scale(0);
 	}


### PR DESCRIPTION
In #20753 I caused a regression that collapsed the big square appender that exists in an empty columns block, or an empty group block.

The only thing that should collapse, until selected, is the black appender button inside blocks like Social Links, Buttons, or Navigation Menu.

This PR fixes that regression by scoping the animation to said button.

![appender](https://user-images.githubusercontent.com/1204802/76399530-09861500-637f-11ea-8ad5-22ef69edce9f.gif)
