### PR TITLE
Adds multi-select to categories on Latest Posts

### DIFF
--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -97,7 +97,7 @@ class LatestPostsEdit extends Component {
 			featuredImageSizeWidth,
 			featuredImageSizeHeight,
 		} = attributes;
-		var suggestions = categoriesList.reduce(
+		const suggestions = categoriesList.reduce(
 			( accumulator, category ) => ( {
 				...accumulator,
 				[ category.name ]: category,
@@ -236,18 +236,20 @@ class LatestPostsEdit extends Component {
 							setAttributes( { postsToShow: value } )
 						}
 					/>
-					<FormTokenField
-						label={ __( 'Categories' ) }
-						value={
-							categories &&
-							categories.map( ( item ) => ( {
-								id: item.id,
-								value: item.name || item.value,
-							} ) )
-						}
-						suggestions={ Object.keys( suggestions ) }
-						onChange={ selectCategories }
-					/>
+					{ categoriesList.length > 0 && (
+						<FormTokenField
+							label={ __( 'Categories' ) }
+							value={
+								categories &&
+								categories.map( ( item ) => ( {
+									id: item.id,
+									value: item.name || item.value,
+								} ) )
+							}
+							suggestions={ Object.keys( suggestions ) }
+							onChange={ selectCategories }
+						/>
+					) }
 					{ postLayout === 'grid' && (
 						<RangeControl
 							label={ __( 'Columns' ) }
@@ -439,7 +441,10 @@ export default withSelect( ( select, props ) => {
 	const { getEntityRecords, getMedia } = select( 'core' );
 	const { getSettings } = select( 'core/block-editor' );
 	const { imageSizes, imageDimensions } = getSettings();
-	const catIds = categories.map( ( cat ) => cat.id );
+	const catIds =
+		categories && categories.length > 0
+			? categories.map( ( cat ) => cat.id )
+			: [];
 	const latestPostsQuery = pickBy(
 		{
 			categories: catIds,

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -105,14 +105,13 @@ class LatestPostsEdit extends Component {
 			{}
 		);
 
-		const handleOnChange = ( tokens ) => {
+		const selectCategories = ( tokens ) => {
 			// Categories that are already will be objects, while new additions will be strings (the name).
-			// allValues nomalizes the array so that they are all objects.
-			const allValues = tokens.map( ( token ) =>
+			// allCategories nomalizes the array so that they are all objects.
+			const allCategories = tokens.map( ( token ) =>
 				typeof token === 'string' ? suggestions[ token ] : token
 			);
-
-			setAttributes( { categories: allValues } );
+			setAttributes( { categories: allCategories } );
 		};
 
 		const inspectorControls = (
@@ -227,33 +226,27 @@ class LatestPostsEdit extends Component {
 					<QueryControls
 						{ ...{ order, orderBy } }
 						numberOfItems={ postsToShow }
-						categoriesList={ categoriesList }
-						selectedCategoryId={ categories }
 						onOrderChange={ ( value ) =>
 							setAttributes( { order: value } )
 						}
 						onOrderByChange={ ( value ) =>
 							setAttributes( { orderBy: value } )
 						}
-						onCategoryChange={ ( value ) =>
-							setAttributes( {
-								categories: '' !== value ? value : undefined,
-							} )
-						}
 						onNumberOfItemsChange={ ( value ) =>
 							setAttributes( { postsToShow: value } )
 						}
 					/>
 					<FormTokenField
+						label={ __( 'Categories' ) }
 						value={
 							categories &&
 							categories.map( ( item ) => ( {
 								id: item.id,
-								value: item.name,
+								value: item.name || item.value,
 							} ) )
 						}
 						suggestions={ Object.keys( suggestions ) }
-						onChange={ handleOnChange }
+						onChange={ selectCategories }
 					/>
 					{ postLayout === 'grid' && (
 						<RangeControl
@@ -446,9 +439,10 @@ export default withSelect( ( select, props ) => {
 	const { getEntityRecords, getMedia } = select( 'core' );
 	const { getSettings } = select( 'core/block-editor' );
 	const { imageSizes, imageDimensions } = getSettings();
+	const catIds = categories.map( ( cat ) => cat.id );
 	const latestPostsQuery = pickBy(
 		{
-			categories,
+			categories: catIds,
 			order,
 			orderby: orderBy,
 			per_page: postsToShow,

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -18,6 +18,7 @@ import {
 	Spinner,
 	ToggleControl,
 	ToolbarGroup,
+	FormTokenField,
 } from '@wordpress/components';
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
@@ -96,6 +97,23 @@ class LatestPostsEdit extends Component {
 			featuredImageSizeWidth,
 			featuredImageSizeHeight,
 		} = attributes;
+		var suggestions = categoriesList.reduce(
+			( accumulator, category ) => ( {
+				...accumulator,
+				[ category.name ]: category,
+			} ),
+			{}
+		);
+
+		const handleOnChange = ( tokens ) => {
+			// Categories that are already will be objects, while new additions will be strings (the name).
+			// allValues nomalizes the array so that they are all objects.
+			const allValues = tokens.map( ( token ) =>
+				typeof token === 'string' ? suggestions[ token ] : token
+			);
+
+			setAttributes( { categories: allValues } );
+		};
 
 		const inspectorControls = (
 			<InspectorControls>
@@ -225,6 +243,17 @@ class LatestPostsEdit extends Component {
 						onNumberOfItemsChange={ ( value ) =>
 							setAttributes( { postsToShow: value } )
 						}
+					/>
+					<FormTokenField
+						value={
+							categories &&
+							categories.map( ( item ) => ( {
+								id: item.id,
+								value: item.name,
+							} ) )
+						}
+						suggestions={ Object.keys( suggestions ) }
+						onChange={ handleOnChange }
 					/>
 					{ postLayout === 'grid' && (
 						<RangeControl

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -182,7 +182,7 @@ function register_block_core_latest_posts() {
 					'type' => 'string',
 				),
 				'categories'              => array(
-					'type' => 'string',
+					'type' => 'array',
 				),
 				'postsToShow'             => array(
 					'type'    => 'number',

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -47,7 +47,7 @@ function render_block_core_latest_posts( $attributes ) {
 	add_filter( 'excerpt_length', 'block_core_latest_posts_get_excerpt_length', 20 );
 
 	if ( isset( $attributes['categories'] ) ) {
-		$args['category'] = $attributes['categories'];
+		$args['category__in'] = array_column($attributes['categories'], "id");
 	}
 
 	$recent_posts = get_posts( $args );

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -47,7 +47,7 @@ function render_block_core_latest_posts( $attributes ) {
 	add_filter( 'excerpt_length', 'block_core_latest_posts_get_excerpt_length', 20 );
 
 	if ( isset( $attributes['categories'] ) ) {
-		$args['category__in'] = array_column($attributes['categories'], "id");
+		$args['category__in'] = array_column($attributes['categories'], 'id');
 	}
 
 	$recent_posts = get_posts( $args );

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -47,7 +47,7 @@ function render_block_core_latest_posts( $attributes ) {
 	add_filter( 'excerpt_length', 'block_core_latest_posts_get_excerpt_length', 20 );
 
 	if ( isset( $attributes['categories'] ) ) {
-		$args['category__in'] = array_column($attributes['categories'], 'id');
+		$args['category__in'] = array_column( $attributes['categories'], 'id' );
 	}
 
 	$recent_posts = get_posts( $args );


### PR DESCRIPTION
## Description
Adds possibility to add & select posts in `LatestPosts` by multiple categories as described in #20046.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Added a couple of posts and categories, and used the new implementation to test, edit and save.

## Screenshots <!-- if applicable -->
![ezgif-3-7d71cf866e74](https://user-images.githubusercontent.com/3396172/76398763-c37c8180-637d-11ea-8748-967fa76dc80b.gif)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Adds ability to filter by multiple categories. May be breaking change? Probably this could break blocks with the old implementation.
## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
