### PR TITLE
Polish a few broken things in the sidebar.

### DIFF
--- a/packages/block-editor/src/components/block-styles/style.scss
+++ b/packages/block-editor/src/components/block-styles/style.scss
@@ -27,7 +27,13 @@
 	}
 
 	&.is-active {
-		@include block-style__is-active();
+		.block-editor-block-styles__item-label {
+			font-weight: bold;
+		}
+
+		.block-editor-block-styles__item-preview {
+			border: 2px solid $dark-gray-primary;
+		}
 	}
 }
 

--- a/packages/block-library/src/table/editor.scss
+++ b/packages/block-library/src/table/editor.scss
@@ -68,10 +68,6 @@
 			margin-bottom: 0;
 		}
 	}
-
-	.components-base-control + .components-base-control {
-		margin-top: 0;
-	}
 }
 
 .blocks-table__placeholder-input {

--- a/packages/components/src/base-control/style.scss
+++ b/packages/components/src/base-control/style.scss
@@ -20,7 +20,3 @@
 		font-style: italic;
 	}
 }
-
-.components-base-control + .components-base-control {
-	margin-top: $grid-unit-20;
-}

--- a/packages/components/src/button-group/style.scss
+++ b/packages/components/src/button-group/style.scss
@@ -1,20 +1,15 @@
 .components-button-group {
 	display: inline-block;
+	border-radius: $radius-block-ui;
+	border: $border-width solid $theme-color;
 
 	.components-button {
 		border-radius: 0;
 		display: inline-flex;
+		color: $theme-color;
 
 		& + .components-button {
 			margin-left: -1px;
-		}
-
-		&:first-child {
-			border-radius: 3px 0 0 3px;
-		}
-
-		&:last-child {
-			border-radius: 0 3px 3px 0;
 		}
 
 		// The focused button should be elevated so the focus ring isn't cropped,


### PR DESCRIPTION
There were some issues with the block sidebar:

- The active style looked a bit overwhelming.
- The button-group control lacked a little style.
- The Width/Height controls for an image were offset.

This PR addresses those.

Before:

<img width="251" alt="Screenshot 2020-03-11 at 10 10 02" src="https://user-images.githubusercontent.com/1204802/76403614-73092200-6385-11ea-9035-42de49261e95.png">

After:

<img width="255" alt="Screenshot 2020-03-11 at 10 16 03" src="https://user-images.githubusercontent.com/1204802/76403620-76041280-6385-11ea-8ae0-c17b4556336b.png">

The button-group after:

<img width="230" alt="Screenshot 2020-03-11 at 10 24 23" src="https://user-images.githubusercontent.com/1204802/76403639-7c928a00-6385-11ea-9bc4-d7015ee14b02.png">

Before:

<img width="273" alt="Screenshot 2020-03-11 at 10 30 55" src="https://user-images.githubusercontent.com/1204802/76403649-80261100-6385-11ea-8a00-801b243a5dd0.png">

After:

<img width="270" alt="Screenshot 2020-03-11 at 10 41 46" src="https://user-images.githubusercontent.com/1204802/76403658-83210180-6385-11ea-89a5-d897c37dd0a5.png">

**Note that I expect all of the above to receive additional polish**. #18667 offers additional avenues to refining how each of these controls look, behave, and are positioned well in the sidebar. I consider this PR a _minimal_ first step towards making it less broken, but not the endgame step. 