### PR TITLE
Eriktdesign add/tags in latest posts block

### DIFF
--- a/packages/block-library/src/latest-posts/block.json
+++ b/packages/block-library/src/latest-posts/block.json
@@ -12,6 +12,9 @@
 		"categories": {
 			"type": "array"
 		},
+		"tags": {
+			"type": "array"
+		},
 		"postsToShow": {
 			"type": "number",
 			"default": 5

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -156,14 +156,9 @@ class LatestPostsEdit extends Component {
 		} );
 		request.then( unescapeTerms ).then( ( terms ) => {
 			this.setState( ( state ) => ( {
-				suggestedTags: state.tagsList.concat(
-					terms.filter(
-						( term ) =>
-							! find(
-								state.tagsList,
-								( tag ) => tag.id === term.id
-							)
-					)
+				suggestedTags: terms.filter(
+					( term ) =>
+						! find( state.tagsList, ( tag ) => tag.id === term.id )
 				),
 			} ) );
 		} );

--- a/packages/components/src/query-controls/index.js
+++ b/packages/components/src/query-controls/index.js
@@ -11,16 +11,22 @@ import { RangeControl, SelectControl, FormTokenField } from '../';
 const DEFAULT_MIN_ITEMS = 1;
 const DEFAULT_MAX_ITEMS = 100;
 const MAX_CATEGORIES_SUGGESTIONS = 20;
+const MAX_TERMS_SUGGESTIONS = 20;
 
 export default function QueryControls( {
 	categorySuggestions,
 	selectedCategories,
+	onCategoryChange,
+	selectedTags,
+	suggestedTags,
+	onTagInputChage,
+	tagsLoading,
+	onTagsChange,
 	numberOfItems,
 	order,
 	orderBy,
 	maxItems = DEFAULT_MAX_ITEMS,
 	minItems = DEFAULT_MIN_ITEMS,
-	onCategoryChange,
 	onNumberOfItemsChange,
 	onOrderChange,
 	onOrderByChange,
@@ -77,7 +83,17 @@ export default function QueryControls( {
 				maxSuggestions={ MAX_CATEGORIES_SUGGESTIONS }
 			/>
 		),
-
+		onTagsChange && (
+			<FormTokenField
+				value={ selectedTags }
+				suggestions={ suggestedTags }
+				onChange={ onTagsChange }
+				onInputChange={ onTagInputChage }
+				maxSuggestions={ MAX_TERMS_SUGGESTIONS }
+				disabled={ tagsLoading }
+				label={ __( 'Filter by tags' ) }
+			/>
+		),
 		onNumberOfItemsChange && (
 			<RangeControl
 				key="query-controls-range-control"


### PR DESCRIPTION
WORK IN PROGRESS!

## Description
Props @eriktdesign, this is a refresh of #19755 
Moves #13027 forward by adding filtering by tags.

## How has this been tested?
Tested locally.

1. Make sure you have some posts with tags
2. Make a new post/page
3. Add a `LatestPosts` block 
4. Use the tag filter in the inspector

## Screenshots <!-- if applicable -->

<img width="1150" alt="Screenshot 2020-03-11 at 12 19 31" src="https://user-images.githubusercontent.com/107534/76406580-a1d9c500-6392-11ea-8b97-0d0f9b38fbf5.png">


## Types of changes
Non breaking addition to `LatestPosts` and `QuerySelector`

## Checklist:
- [ ] Make the tag list a multiple selection