### PR TITLE
RNMobile - FloatingToolbar - Make children accessible

### DIFF
--- a/packages/block-editor/src/components/block-list/block-mobile-floating-toolbar.native.js
+++ b/packages/block-editor/src/components/block-list/block-mobile-floating-toolbar.native.js
@@ -10,7 +10,7 @@ import styles from './block-mobile-floating-toolbar.scss';
 
 const FloatingToolbar = ( { children } ) => {
 	return (
-		<TouchableWithoutFeedback>
+		<TouchableWithoutFeedback accessible={ false }>
 			<View style={ styles.floatingToolbar }>{ children }</View>
 		</TouchableWithoutFeedback>
 	);


### PR DESCRIPTION
`Gutenberg Mobile PR` -> https://github.com/wordpress-mobile/gutenberg-mobile/pull/1997

## Description
The `FloatingToolbar` wasn't working correctly when using VoiceOver, the children within the component weren't reachable. 

By making the `TouchableWithoutFeedback` accessible prop to `false` allows them to be reached by VoiceOver / TalkBack.

| iOS | Android |
|     :---:      |     :---:      |
| <img src="https://user-images.githubusercontent.com/4885740/76418191-7e1c7c00-639e-11ea-9c0d-5c08129452ee.gif" width=250 /> | <img src="https://user-images.githubusercontent.com/4885740/76418195-7fe63f80-639e-11ea-8c31-5a71c1e2133e.gif" width=250 />  |

## How has this been tested?

### iOS

- Run the app with metro running
- Enable VoiceOver (easy to do it with Siri)
- Focus on a `Paragraph` block
- Navigate down and **expect** the elements within the `FloatingToolbar` to be reachable and the arrow button action to work

### Android

- Run the app with metro running
- Enable TalkBack
- Focus on a `Paragraph` block
- Navigate down and **expect** the elements within the `FloatingToolbar` to be reachable and the arrow button action to work

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
