### PR TITLE
Block API: Add new utility to register block types from metadata in PHP

### DIFF
--- a/lib/compat.php
+++ b/lib/compat.php
@@ -8,6 +8,45 @@
  * @package gutenberg
  */
 
+ if ( ! function_exists( 'register_block_type_from_metadata' ) ) {
+	/**
+	 * Registers a block type from metadata stored in the `block.json` file.
+	 *
+	 * @since 7.8.0
+	 *
+	 * @param string $path Path to the folder where the `block.json` file is located.
+	 *                     Alternatively it's possible to provide only the name of the
+	 *                     last folder for blocks located in the WordPress core.
+	 * @param array  $args {
+	 *     Optional. Array of block type arguments. Any arguments may be defined, however the
+	 *     ones described below are supported by default. Default empty array.
+	 *
+	 *     @type callable $render_callback Callback used to render blocks of this block type.
+	 * }
+	 * @return WP_Block_Type|false The registered block type on success, or false on failure.
+	 */
+	function register_block_type_from_metadata( $path, $args = array() ) {
+		$path = is_dir( $path ) ? $path : ABSPATH . WPINC . '/blocks/' . $path;
+		$file = trailingslashit( $path ) . 'block.json';
+		if ( ! file_exists( $file ) ) {
+			return false;
+		}
+
+		$metadata = json_decode( file_get_contents( $path ), true );
+		if ( ! is_array( $metadata ) ) {
+			return false;
+		}
+
+		return register_block_type(
+			$metadata['name'],
+			array_merge(
+				$metadata,
+				$args
+			)
+		);
+	}
+ }
+
 /**
  * Adds a polyfill for the WHATWG URL in environments which do not support it.
  * The intention in how this action is handled is under the assumption that this

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -8,15 +8,13 @@
  * @package gutenberg
  */
 
- if ( ! function_exists( 'register_block_type_from_metadata' ) ) {
+if ( ! function_exists( 'register_block_type_from_metadata' ) ) {
 	/**
 	 * Registers a block type from metadata stored in the `block.json` file.
 	 *
 	 * @since 7.8.0
 	 *
 	 * @param string $path Path to the folder where the `block.json` file is located.
-	 *                     Alternatively it's possible to provide only the name of the
-	 *                     last folder for blocks located in the WordPress core.
 	 * @param array  $args {
 	 *     Optional. Array of block type arguments. Any arguments may be defined, however the
 	 *     ones described below are supported by default. Default empty array.
@@ -26,13 +24,12 @@
 	 * @return WP_Block_Type|false The registered block type on success, or false on failure.
 	 */
 	function register_block_type_from_metadata( $path, $args = array() ) {
-		$path = is_dir( $path ) ? $path : ABSPATH . WPINC . '/blocks/' . $path;
 		$file = trailingslashit( $path ) . 'block.json';
 		if ( ! file_exists( $file ) ) {
 			return false;
 		}
 
-		$metadata = json_decode( file_get_contents( $path ), true );
+		$metadata = json_decode( file_get_contents( $file ), true );
 		if ( ! is_array( $metadata ) ) {
 			return false;
 		}
@@ -45,7 +42,7 @@
 			)
 		);
 	}
- }
+}
 
 /**
  * Adds a polyfill for the WHATWG URL in environments which do not support it.

--- a/packages/block-library/src/post-author/index.php
+++ b/packages/block-library/src/post-author/index.php
@@ -23,16 +23,10 @@ function render_block_core_post_author() {
  * Registers the `core/post-author` block on the server.
  */
 function register_block_core_post_author() {
-	$path     = __DIR__ . '/post-author/block.json';
-	$metadata = json_decode( file_get_contents( $path ), true );
-
-	register_block_type(
-		$metadata['name'],
-		array_merge(
-			$metadata,
-			array(
-				'render_callback' => 'render_block_core_post_author',
-			)
+	register_block_type_from_metadata(
+		__DIR__ . '/post-author',
+		array(
+			'render_callback' => 'render_block_core_post_author',
 		)
 	);
 }

--- a/packages/block-library/src/post-comments-count/index.php
+++ b/packages/block-library/src/post-comments-count/index.php
@@ -32,21 +32,15 @@ function render_block_core_post_comments_count( $attributes ) {
  * Registers the `core/post-comments-count` block on the server.
  */
 function register_block_core_post_comments_count() {
-	$path     = __DIR__ . '/post-comments-count/block.json';
-	$metadata = json_decode( file_get_contents( $path ), true );
-
-	register_block_type(
-		$metadata['name'],
-		array_merge(
-			$metadata,
-			array(
-				'attributes'      => array(
-					'className' => array(
-						'type' => 'string',
-					),
+	register_block_type_from_metadata(
+		__DIR__ . '/post-comments-count',
+		array(
+			'attributes'      => array(
+				'className' => array(
+					'type' => 'string',
 				),
-				'render_callback' => 'render_block_core_post_comments_count',
-			)
+			),
+			'render_callback' => 'render_block_core_post_comments_count',
 		)
 	);
 }

--- a/packages/block-library/src/post-comments-form/index.php
+++ b/packages/block-library/src/post-comments-form/index.php
@@ -26,16 +26,10 @@ function render_block_core_post_comments_form() {
  * Registers the `core/post-comments-form` block on the server.
  */
 function register_block_core_post_comments_form() {
-	$path     = __DIR__ . '/post-comments-form/block.json';
-	$metadata = json_decode( file_get_contents( $path ), true );
-
-	register_block_type(
-		$metadata['name'],
-		array_merge(
-			$metadata,
-			array(
-				'render_callback' => 'render_block_core_post_comments_form',
-			)
+	register_block_type_from_metadata(
+		__DIR__ . '/post-comments-form',
+		array(
+			'render_callback' => 'render_block_core_post_comments_form',
 		)
 	);
 }

--- a/packages/block-library/src/post-content/index.php
+++ b/packages/block-library/src/post-content/index.php
@@ -26,16 +26,10 @@ function render_block_core_post_content() {
  * Registers the `core/post-content` block on the server.
  */
 function register_block_core_post_content() {
-	$path     = __DIR__ . '/post-content/block.json';
-	$metadata = json_decode( file_get_contents( $path ), true );
-
-	register_block_type(
-		$metadata['name'],
-		array_merge(
-			$metadata,
-			array(
-				'render_callback' => 'render_block_core_post_content',
-			)
+	register_block_type_from_metadata(
+		__DIR__ . '/post-content',
+		array(
+			'render_callback' => 'render_block_core_post_content',
 		)
 	);
 }

--- a/packages/block-library/src/post-date/index.php
+++ b/packages/block-library/src/post-date/index.php
@@ -27,16 +27,10 @@ function render_block_core_post_date( $attributes ) {
  * Registers the `core/post-date` block on the server.
  */
 function register_block_core_post_date() {
-	$path     = __DIR__ . '/post-date/block.json';
-	$metadata = json_decode( file_get_contents( $path ), true );
-
-	register_block_type(
-		$metadata['name'],
-		array_merge(
-			$metadata,
-			array(
-				'render_callback' => 'render_block_core_post_date',
-			)
+	register_block_type_from_metadata(
+		__DIR__ . '/post-date',
+		array(
+			'render_callback' => 'render_block_core_post_date',
 		)
 	);
 }

--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -47,16 +47,10 @@ function render_block_core_post_excerpt( $attributes ) {
  * Registers the `core/post-excerpt` block on the server.
  */
 function register_block_core_post_excerpt() {
-	$path     = __DIR__ . '/post-excerpt/block.json';
-	$metadata = json_decode( file_get_contents( $path ), true );
-
-	register_block_type(
-		$metadata['name'],
-		array_merge(
-			$metadata,
-			array(
-				'render_callback' => 'render_block_core_post_excerpt',
-			)
+	register_block_type_from_metadata(
+		__DIR__ . '/post-excerpt',
+		array(
+			'render_callback' => 'render_block_core_post_excerpt',
 		)
 	);
 }

--- a/packages/block-library/src/post-featured-image/index.php
+++ b/packages/block-library/src/post-featured-image/index.php
@@ -22,16 +22,10 @@ function render_block_core_post_featured_image() {
  * Registers the `core/post-featured-image` block on the server.
  */
 function register_block_core_post_featured_image() {
-	$path     = __DIR__ . '/post-featured-image/block.json';
-	$metadata = json_decode( file_get_contents( $path ), true );
-
-	register_block_type(
-		$metadata['name'],
-		array_merge(
-			$metadata,
-			array(
-				'render_callback' => 'render_block_core_post_featured_image',
-			)
+	register_block_type_from_metadata(
+		__DIR__ . '/post-featured-image',
+		array(
+			'render_callback' => 'render_block_core_post_featured_image',
 		)
 	);
 }

--- a/packages/block-library/src/post-tags/index.php
+++ b/packages/block-library/src/post-tags/index.php
@@ -29,16 +29,10 @@ function render_block_core_post_tags() {
  * Registers the `core/post-tags` block on the server.
  */
 function register_block_core_post_tags() {
-	$path     = __DIR__ . '/post-tags/block.json';
-	$metadata = json_decode( file_get_contents( $path ), true );
-
-	register_block_type(
-		$metadata['name'],
-		array_merge(
-			$metadata,
-			array(
-				'render_callback' => 'render_block_core_post_tags',
-			)
+	register_block_type_from_metadata(
+		__DIR__ . '/post-tags',
+		array(
+			'render_callback' => 'render_block_core_post_tags',
 		)
 	);
 }

--- a/packages/block-library/src/post-title/index.php
+++ b/packages/block-library/src/post-title/index.php
@@ -22,16 +22,10 @@ function render_block_core_post_title() {
  * Registers the `core/post-title` block on the server.
  */
 function register_block_core_post_title() {
-	$path     = __DIR__ . '/post-title/block.json';
-	$metadata = json_decode( file_get_contents( $path ), true );
-
-	register_block_type(
-		$metadata['name'],
-		array_merge(
-			$metadata,
-			array(
-				'render_callback' => 'render_block_core_post_title',
-			)
+	register_block_type_from_metadata(
+		__DIR__ . '/post-title',
+		array(
+			'render_callback' => 'render_block_core_post_title',
 		)
 	);
 }

--- a/packages/block-library/src/shortcode/index.php
+++ b/packages/block-library/src/shortcode/index.php
@@ -21,15 +21,10 @@ function render_block_core_shortcode( $attributes, $content ) {
  * Registers the `core/shortcode` block on server.
  */
 function register_block_core_shortcode() {
-	$path     = __DIR__ . '/shortcode/block.json';
-	$metadata = json_decode( file_get_contents( $path ), true );
-	register_block_type(
-		$metadata['name'],
-		array_merge(
-			$metadata,
-			array(
-				'render_callback' => 'render_block_core_shortcode',
-			)
+	register_block_type_from_metadata(
+		__DIR__ . '/shortcode',
+		array(
+			'render_callback' => 'render_block_core_shortcode',
 		)
 	);
 }

--- a/packages/block-library/src/site-title/index.php
+++ b/packages/block-library/src/site-title/index.php
@@ -24,16 +24,10 @@ function render_block_core_site_title( $attributes ) {
  * Registers the `core/site-title` block on the server.
  */
 function register_block_core_site_title() {
-	$path     = __DIR__ . '/site-title/block.json';
-	$metadata = json_decode( file_get_contents( $path ), true );
-
-	register_block_type(
-		$metadata['name'],
-		array_merge(
-			$metadata,
-			array(
-				'render_callback' => 'render_block_core_site_title',
-			)
+	register_block_type_from_metadata(
+		__DIR__ . '/site-title',
+		array(
+			'render_callback' => 'render_block_core_site_title',
 		)
 	);
 }

--- a/packages/block-library/src/social-link/index.php
+++ b/packages/block-library/src/social-link/index.php
@@ -33,16 +33,10 @@ function render_block_core_social_link( $attributes ) {
  * Registers the `core/social-link` blocks.
  */
 function register_block_core_social_link() {
-	$path     = __DIR__ . '/social-link/block.json';
-	$metadata = json_decode( file_get_contents( $path ), true );
-
-	register_block_type(
-		$metadata['name'],
-		array_merge(
-			$metadata,
-			array(
-				'render_callback' => 'render_block_core_social_link',
-			)
+	register_block_type_from_metadata(
+		__DIR__ . '/social-link',
+		array(
+			'render_callback' => 'render_block_core_social_link',
 		)
 	);
 }

--- a/phpunit/class-register-block-type-from-metadata-test.php
+++ b/phpunit/class-register-block-type-from-metadata-test.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Test `register_block_type_from_metadata`.
+ *
+ * @package Gutenberg
+ */
+
+class Register_Block_Type_From_Metadata_Test extends WP_UnitTestCase {
+	/**
+	 * Tests that the function returns false when the `block.json` is not found
+	 * in the WordPress core.
+	 */
+	function test_metadata_not_found_in_wordpress_core() {
+		$result = register_block_type_from_metadata( 'unknown' );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Tests that the function returns false when the `block.json` is not found
+	 * in the current directory.
+	 */
+	function test_metadata_not_found_in_the_current_directory() {
+		$result = register_block_type_from_metadata( __DIR__ );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Tests that the function returns the registered block when the `block.json`
+	 * is found in the fixtures directory.
+	 */
+	function test_block_registers_with_metadata_fixture() {
+		$result = register_block_type_from_metadata(
+			__DIR__ . '/fixtures',
+			array(
+				'foo' => 'bar',
+			)
+		);
+
+		$this->assertInstanceOf( 'WP_Block_Type', $result );
+		$this->assertEquals( 'test/block-name', $result->name );
+		$this->assertEquals( 'bar', $result->foo );
+	}
+}

--- a/phpunit/fixtures/block.json
+++ b/phpunit/fixtures/block.json
@@ -1,0 +1,4 @@
+{
+	"name": "test/block-name",
+	"category": "widgets"
+}


### PR DESCRIPTION
## Description
Follow up for #19786 and #20717 where we started using `block.json` file in PHP to register block types.

This PR tries to simplify the process by removing code duplication for the same tasks that need happen for every block.

API is based on my previous discussion with @azaozz. I hightlighed the most important parts below:

> > > Perhaps the abstracted function can have `__file__ ` as optional param and "calculate" the proper path? Maybe something like:
> > > 
> > > ```php
> > > function wp_get_block_metadata( $file, $path = null ) {
> > >     if ( empty( $path ) ) {
> > >         $path = ABSPATH . WPINC . '/blocks';
> > >     }
> > > 
> > >     $file = trailingslashit( $path ) . $file;
> > > 
> > >     if ( file_exists( $file ) {
> > >         return json_decode( file_get_contents( $file ), true );
> > >     }
> > > 
> > >     return false;
> > > }
> > > ```
> > 
> > I followed your proposal for params. I don't know what patterns are used in other places, but an alternative approach could be prepending `ABSPATH . WPINC . '/blocks'` in the case where the `$file` is not absolute. You could also omit the name of the file and default to `block.json`:
> > ```php
> > $metadata = wp_get_block_metadata( 'shortcode' );
> > // becomes ABSPATH . WPINC . '/blocks/shortcode/block.json'
> > $metadata = wp_get_block_metadata( __DIR__ );
> > // becomes __DIR__ . '/block.json'
> > ```
>
> As the file name is known, in core it will only need the (last) dir name, i.e. the block name. Then it can do: `$file = ABSPATH . WPINC . "/blocks/{$file}";` to get the default location in core, and plugins will be able to use `__DIR__`.
> 
> Then perhaps it will look like `register_block_type_from_metadata( $path, $args = null ) { ...` where `$path` will be `__DIR__` when used from plugins and "block name" when used in core.

## API proposed

```php
/**
 * Registers a block type from metadata stored in the `block.json` file.
 *
 * @param string $path Path to the folder where the `block.json` file is located.
 *                     Alternatively it's possible to provide only the name of the
 *                     last folder for blocks located in the WordPress core.
 * @param array  $args {
 *     Optional. Array of block type arguments. Any arguments may be defined, however the
 *     ones described below are supported by default. Default empty array.
 *
 *     @type callable $render_callback Callback used to render blocks of this block type.
 * }
 * @return WP_Block_Type|false The registered block type on success, or false on failure.
 */
function register_block_type_from_metadata( $path, $args = array() );
```

## Example

```php
register_block_type_from_metadata(
	__DIR__ . '/shortcode',
	array(
		'render_callback' => 'render_block_core_shortcode',
	)
);
```

## How has this been tested?

- `npm run test-php && npm run test-unit-php-multisite`
- `npm run test-e2e`

I also manually tested that the experimental Edit Site still works and all blocks are registered on the server.

## Types of changes
New API method introduced and core blocks are refactored to use it.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
