### PR TITLE
Documentation: added documentation for onSelectURL property.

### DIFF
--- a/packages/block-editor/src/components/media-placeholder/README.md
+++ b/packages/block-editor/src/components/media-placeholder/README.md
@@ -161,6 +161,14 @@ An object or an array of objects that contain media ID (`id` property) to be sel
 - Required: No
 - Platform: Web
 
+### onSelectURL
+
+Callback called when urls can be configured. No media insertion from url will be available if not set.
+
+- Type: `Function`
+- Required: No
+- Platform: Web
+
 
 ## Extend
 


### PR DESCRIPTION
## Description
I added description in the README.md of media-placeholder of the property 'onSelectURL'.

I have the requirement to modify the media-placeholder and to disable the button 'upload from URL'. Therefore I used the media-placeholder filter to modify the output of the component.

In the filter I override the property 'onSelectURL' (setting to null) although it is not documented. Doing so the 'upload from URL' button is not rendered.

This pull request is also a question: Is this a way to go and if so, should the property be documentated and 'officially' be available for modification?

## How has this been tested?
I am not sure how to test a change in README.md. Linting succeeded.

## Types of changes
Extend README.md documentation of media-placeholder for property 'onSelectURL'.

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
