### PR TITLE
Minor change to switch Help link target to _blank, add rels

### DIFF
--- a/packages/edit-post/src/plugins/index.js
+++ b/packages/edit-post/src/plugins/index.js
@@ -43,7 +43,8 @@ registerPlugin( 'edit-post', {
 								href={ __(
 									'https://wordpress.org/support/article/wordpress-editor/'
 								) }
-								target="_new"
+								target="_blank"
+								rel="noopener noreferer"
 							>
 								{ __( 'Help' ) }
 							</MenuItem>

--- a/packages/edit-post/src/plugins/index.js
+++ b/packages/edit-post/src/plugins/index.js
@@ -44,7 +44,7 @@ registerPlugin( 'edit-post', {
 									'https://wordpress.org/support/article/wordpress-editor/'
 								) }
 								target="_blank"
-								rel="noopener noreferer"
+								rel="noopener noreferrer"
 							>
 								{ __( 'Help' ) }
 							</MenuItem>


### PR DESCRIPTION
## Description

This is a minor change that updates the Help link from `target="_new"` to `target="_blank"`

Technically `target="_new"` is not a valid keyword target, all browsers treat it as such because the name could be anything, `_blank` is the proper keyword to use.

Also, <a href="https://www.jitbit.com/alexblog/256-targetblank---the-most-underestimated-vulnerability-ever/">per this security advisory</a> it is advised to include `rel="noopener noreferrer"` to avoid reverse-tab hijacking. The link was to WP.org so very low risk.

## How has this been tested?

1. Apply Patch
2. Confirm Help link in sidebar has `target="_blank"` and proper rels
