### PR TITLE
Improve performance testing

### DIFF
--- a/packages/e2e-tests/config/performance-reporter.js
+++ b/packages/e2e-tests/config/performance-reporter.js
@@ -4,6 +4,11 @@ function average( array ) {
 	return array.reduce( ( a, b ) => a + b ) / array.length;
 }
 
+function round( number, decimalPlaces = 2 ) {
+	const factor = Math.pow( 10, decimalPlaces );
+	return Math.round( number * factor ) / factor;
+}
+
 class PerformanceReporter {
 	onRunComplete() {
 		const path = __dirname + '/../specs/performance/results.json';
@@ -17,11 +22,11 @@ class PerformanceReporter {
 
 		// eslint-disable-next-line no-console
 		console.log( `
-Average time to load: ${ average( load ) }ms
-Average time to DOM content load: ${ average( domcontentloaded ) }ms
-Average time to type character: ${ average( type ) }ms
-Slowest time to type character: ${ Math.max( ...type ) }ms
-Fastest time to type character: ${ Math.min( ...type ) }ms
+Average time to load: ${ round( average( load ) ) }ms
+Average time to DOM content load: ${ round( average( domcontentloaded ) ) }ms
+Average time to type character: ${ round( average( type ) ) }ms
+Slowest time to type character: ${ round( Math.max( ...type ) ) }ms
+Fastest time to type character: ${ round( Math.min( ...type ) ) }ms
 		` );
 	}
 }

--- a/packages/e2e-tests/specs/performance/performance.test.js
+++ b/packages/e2e-tests/specs/performance/performance.test.js
@@ -51,16 +51,22 @@ describe( 'Performance', () => {
 		let i = 1;
 		let startTime;
 
-		await page.on( 'load', () =>
-			results.load.push( new Date() - startTime )
-		);
-		await page.on( 'domcontentloaded', () =>
-			results.domcontentloaded.push( new Date() - startTime )
-		);
-
 		while ( i-- ) {
-			startTime = new Date();
 			await page.reload( { waitUntil: [ 'domcontentloaded', 'load' ] } );
+			const timings = JSON.parse(
+				await page.evaluate( () =>
+					JSON.stringify( window.performance.timing )
+				)
+			);
+			const {
+				navigationStart,
+				domContentLoadedEventEnd,
+				loadEventEnd,
+			} = timings;
+			results.load.push( loadEventEnd - navigationStart );
+			results.domcontentloaded.push(
+				domContentLoadedEventEnd - navigationStart
+			);
 		}
 
 		await insertBlock( 'Paragraph' );


### PR DESCRIPTION
## Description

Performance testing for Gutenberg was being done using puppeteer, by instrumenting a browser instance, loading a page, and performing some typing. However, these times were being measured across the instrumented browser / host context switch; this meant that the numbers were potentially unreliable, since they were subject to unpredictable factors such as OS scheduling.

This PR performs the measurements within the instrumented browser instance, by relying on browser performance timings for the `load` / `DOMContentLoaded` numbers, and by using in-browser tracing for the typing event duration numbers.

The results won't be directly comparable to the previous way of testing, but they should be comparable between each other henceforth, assuming equivalent testing conditions (same machine, similar system load, etc.).

## How has this been tested?

The intermediate trace files were loaded in Chrome's performance tab, and it was experimentally verified that the numbers in the generated `results.json` matched the duration of the events visible in the DevTools timeline.

## Types of changes

Test-only bugfixes.
