### PR TITLE
E2E Test Utils: Improve durability of embedding matcher

### DIFF
--- a/packages/e2e-test-utils/src/mocks/create-embedding-matcher.js
+++ b/packages/e2e-test-utils/src/mocks/create-embedding-matcher.js
@@ -1,7 +1,7 @@
 /**
- * Internal dependencies
+ * External dependencies
  */
-import { createURLMatcher } from './create-url-matcher';
+import { join } from 'path';
 
 /**
  * Creates a function to determine if a request has a parameter with a certain value.
@@ -11,16 +11,25 @@ import { createURLMatcher } from './create-url-matcher';
  * @return {Function} Function that determines if a request's query parameter is the specified value.
  */
 function parameterEquals( parameterName, value ) {
-	return ( request ) => {
-		const url = request.url();
-		const match = new RegExp( `.*${ parameterName }=([^&]+).*` ).exec(
-			url
-		);
-		if ( ! match ) {
-			return false;
-		}
-		return value === decodeURIComponent( match[ 1 ] );
-	};
+	return ( request ) =>
+		new URL( request.url() ).searchParams.get( parameterName ) === value;
+}
+/**
+ * Creates a function to determine if a request is a REST request of a given
+ * path, accounting for variance in site permalink configuration.
+ *
+ * @param {string} path REST path to test.
+ *
+ * @return {Function} Function that determines if a request is a REST request of
+ *                    a given path, accounting for variance in site permalink
+ *                    configuration.
+ */
+function isRESTRoute( path ) {
+	return ( request ) =>
+		parameterEquals( 'rest_route', path )( request ) ||
+		new URL( request.url() ).pathname
+			.replace( /\/$/, '' )
+			.endsWith( join( '/wp-json', path ).replace( /\/$/, '' ) );
 }
 
 /**
@@ -31,6 +40,6 @@ function parameterEquals( parameterName, value ) {
  */
 export function createEmbeddingMatcher( url ) {
 	return ( request ) =>
-		createURLMatcher( 'oembed%2F1.0%2Fproxy' )( request ) &&
+		isRESTRoute( '/oembed/1.0/proxy' )( request ) &&
 		parameterEquals( 'url', url )( request );
 }

--- a/packages/e2e-test-utils/src/mocks/create-embedding-matcher.js
+++ b/packages/e2e-test-utils/src/mocks/create-embedding-matcher.js
@@ -14,6 +14,7 @@ function parameterEquals( parameterName, value ) {
 	return ( request ) =>
 		new URL( request.url() ).searchParams.get( parameterName ) === value;
 }
+
 /**
  * Creates a function to determine if a request is a REST request of a given
  * path, accounting for variance in site permalink configuration.

--- a/packages/e2e-test-utils/src/mocks/create-embedding-matcher.js
+++ b/packages/e2e-test-utils/src/mocks/create-embedding-matcher.js
@@ -28,9 +28,7 @@ function parameterEquals( parameterName, value ) {
 function isRESTRoute( path ) {
 	return ( request ) =>
 		parameterEquals( 'rest_route', path )( request ) ||
-		new URL( request.url() ).pathname
-			.replace( /\/$/, '' )
-			.endsWith( join( '/wp-json', path ).replace( /\/$/, '' ) );
+		new URL( request.url() ).pathname.endsWith( join( '/wp-json', path ) );
 }
 
 /**


### PR DESCRIPTION
This pull request seeks to improve the implementation of `createEmbeddingMatcher` to be more durable to inputs. Specifically:

- Account for varying site permalink configuration, where the current implementation assumes the default permalink configuration (`?rest_route=`), and would fail with "pretty permalinks"
- Use `URL.searchParams` for the implementation of `parameterEquals`, to avoid edge cases like:
   - `https://url=why` (doesn't verify that it's part of the query string)
   - `https://example.com/?noturl=why` (doesn't verify the full parameter name)

This was implemented in testing #20481, though it didn't appear related to the issues being debugged there. So this is purely meant as a refactoring.

**Testing Instructions:**

End-to-end tests should pass:

```
npm run test-e2e
```