### PR TITLE
Update the inserter's block preview to use the AutoHeightPreview

### DIFF
--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -502,6 +502,7 @@ export class InserterMenu extends Component {
 														hoveredItem.initialAttributes
 												  )
 										}
+										autoHeight
 									/>
 								</div>
 							) : (

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -139,7 +139,6 @@ $block-inserter-search-height: 38px;
 	display: none;
 	border: $border-width solid $light-gray-secondary;
 	width: 300px;
-	min-height: $block-inserter-preview-height;
 	margin-right: 20px;
 	padding: 20px;
 	background: $white;
@@ -150,8 +149,7 @@ $block-inserter-search-height: 38px;
 		position: absolute;
 		top: -$border-width;
 		left: calc(100% + #{$grid-unit-15});
-		display: flex;
-		flex-direction: column;
+		display: block;
 	}
 
 	.block-editor-block-card {
@@ -159,12 +157,6 @@ $block-inserter-search-height: 38px;
 		margin-bottom: 20px;
 		border-bottom: $border-width solid $light-gray-500;
 		@include edit-post__fade-in-animation();
-	}
-
-	.block-editor-inserter__preview {
-		display: flex;
-		flex-grow: 1;
-		overflow-y: auto;
 	}
 }
 
@@ -213,10 +205,9 @@ $block-inserter-search-height: 38px;
 	min-height: 150px;
 	display: grid;
 	flex-grow: 1;
+	align-items: center;
 
 	.block-editor-block-preview__container {
-		margin-right: 0;
-		margin-left: 0;
 		padding: 10px;
 	}
 }
@@ -229,6 +220,7 @@ $block-inserter-search-height: 38px;
 	border: $border-width solid $light-gray-500;
 	border-radius: $radius-round-rectangle;
 	align-items: center;
+	min-height: 150px;
 }
 
 .block-editor-inserter__tips {

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -202,7 +202,7 @@ $block-inserter-search-height: 38px;
 .block-editor-inserter__preview-content {
 	border: $border-width solid $light-gray-500;
 	border-radius: $radius-round-rectangle;
-	min-height: 150px;
+	min-height: $grid-unit-60 * 3;
 	display: grid;
 	flex-grow: 1;
 	align-items: center;
@@ -220,7 +220,7 @@ $block-inserter-search-height: 38px;
 	border: $border-width solid $light-gray-500;
 	border-radius: $radius-round-rectangle;
 	align-items: center;
-	min-height: 150px;
+	min-height: $grid-unit-60 * 3;
 }
 
 .block-editor-inserter__tips {


### PR DESCRIPTION
closes #20713

Fixes the trimmed previews by using au automatic computed height for block previews.

<img width="738" alt="Capture d’écran 2020-03-12 à 8 13 02 AM" src="https://user-images.githubusercontent.com/272444/76496413-50384580-6439-11ea-93f8-530e9edd5fd9.png">
