### PR TITLE
Fix applying backgrounds and colors to the columns block in the editor

### DIFF
--- a/packages/block-library/src/columns/edit.js
+++ b/packages/block-library/src/columns/edit.js
@@ -102,17 +102,29 @@ function ColumnsEditContainer( {
 			</InspectorControls>
 			{ InspectorControlsColorPanel }
 			<BackgroundColor>
-				<TextColor>
-					<InnerBlocks
-						allowedBlocks={ ALLOWED_BLOCKS }
-						__experimentalMoverDirection="horizontal"
-						ref={ ref }
-						__experimentalTagName={ Block.div }
-						__experimentalPassedProps={ {
-							className: classes,
-						} }
-					/>
-				</TextColor>
+				{ ( backgroundProps ) => (
+					<TextColor>
+						{ ( textColorProps ) => (
+							<InnerBlocks
+								allowedBlocks={ ALLOWED_BLOCKS }
+								__experimentalMoverDirection="horizontal"
+								ref={ ref }
+								__experimentalTagName={ Block.div }
+								__experimentalPassedProps={ {
+									className: classnames(
+										classes,
+										backgroundProps.className,
+										textColorProps.className
+									),
+									style: {
+										...backgroundProps.style,
+										...textColorProps.style,
+									},
+								} }
+							/>
+						) }
+					</TextColor>
+				) }
 			</BackgroundColor>
 		</>
 	);


### PR DESCRIPTION
closes #20804 

The problem was that the components returned by the useColors hook try to magically apply props to their children. This works in most case but doesn't here since InnerBlocks doesn't accept extra props.

**Solution**

I updated the useColors components to support children as function pattern and just pass the props to add to that function leaving the merge responsibiity to the caller.