### PR TITLE
Fix drag and drop into the Columns block

### DIFF
--- a/packages/components/src/drop-zone/index.js
+++ b/packages/components/src/drop-zone/index.js
@@ -22,6 +22,7 @@ export function useDropZone( {
 	onDrop,
 	isDisabled,
 	withPosition,
+	__unstableIsRelative = false,
 } ) {
 	const { addDropZone, removeDropZone } = useContext( Context );
 	const [ state, setState ] = useState( {
@@ -39,6 +40,7 @@ export function useDropZone( {
 				onHTMLDrop,
 				setState,
 				withPosition,
+				isRelative: __unstableIsRelative,
 			};
 			addDropZone( dropZone );
 			return () => {
@@ -76,6 +78,7 @@ function DropZoneComponent( {
 			onFilesDrop,
 			onHTMLDrop,
 			onDrop,
+			__unstableIsRelative: true,
 		}
 	);
 

--- a/packages/components/src/drop-zone/provider.js
+++ b/packages/components/src/drop-zone/provider.js
@@ -150,18 +150,18 @@ class DropZoneProvider extends Component {
 		);
 
 		// Find the leaf dropzone not containing another dropzone
-		const hoveredDropZone = find(
-			hoveredDropZones,
-			( zone ) =>
-				! some(
-					hoveredDropZones,
-					( subZone ) =>
-						subZone !== zone &&
-						zone.element.current.parentElement.contains(
-							subZone.element.current
-						)
-				)
-		);
+		const hoveredDropZone = find( hoveredDropZones, ( zone ) => {
+			const container = zone.isRelative
+				? zone.element.current.parentElement
+				: zone.element.current;
+
+			return ! some(
+				hoveredDropZones,
+				( subZone ) =>
+					subZone !== zone &&
+					container.contains( subZone.element.current )
+			);
+		} );
 
 		const hoveredDropZoneIndex = this.dropZones.indexOf( hoveredDropZone );
 


### PR DESCRIPTION
closes #20806

This was a hidden bug in the `useDropzone` hook that is surfaced by the columns block refactor.
To find the leaf hovered dropzone, the DropzoneProvider was trying to find the dropzone that doesn't contain any other dropzone but since originally the Dropzone component was rendered without children, we were considering its parent as the Dropzone container, it's not the case with the direct usage of the useDropzone hook. The columns block refactor removed extra wrappers making the bug visible.

**Testing instructions**

- Try drag and dropping blocks from/to columns.