### PR TITLE
Fix columns block selection

### DIFF
--- a/packages/block-editor/src/utils/dom.js
+++ b/packages/block-editor/src/utils/dom.js
@@ -58,13 +58,8 @@ export function isInSameBlock( a, b ) {
  * @return {boolean} Whether element is in the block Element but not its children.
  */
 export function isInsideRootBlock( blockElement, element ) {
-	const innerBlocksContainer = blockElement.querySelector(
-		'.block-editor-block-list__layout'
-	);
-	return (
-		blockElement.contains( element ) &&
-		( ! innerBlocksContainer || ! innerBlocksContainer.contains( element ) )
-	);
+	const parentBlock = element.closest( '.block-editor-block-list__block' );
+	return parentBlock === blockElement;
 }
 
 /**


### PR DESCRIPTION
closes #20803

Now that the InnerBlocks component can serve as the Block wrapper at the same time (after the columns block refactor), the `isInsideRootBlock` utility was broken causing the paragraph block inside columns to be selected when you try to select its parents.

**Testing instructions**

 - Ensure you're able to select column blocks that contain paragraphs using the breadcrumb.