### PR TITLE
Polish date-picker component

### DIFF
--- a/packages/components/src/button-group/style.scss
+++ b/packages/components/src/button-group/style.scss
@@ -1,15 +1,22 @@
 .components-button-group {
 	display: inline-block;
-	border-radius: $radius-block-ui;
-	border: $border-width solid $theme-color;
 
 	.components-button {
 		border-radius: 0;
 		display: inline-flex;
 		color: $theme-color;
+		box-shadow: inset 0 0 0 $border-width $theme-color;
 
 		& + .components-button {
 			margin-left: -1px;
+		}
+
+		&:first-child {
+			border-radius: $radius-block-ui 0 0 $radius-block-ui;
+		}
+
+		&:last-child {
+			border-radius: 0 $radius-block-ui $radius-block-ui 0;
 		}
 
 		// The focused button should be elevated so the focus ring isn't cropped,
@@ -22,7 +29,7 @@
 
 		// The active button should look pressed.
 		&.is-primary {
-			box-shadow: none;
+			box-shadow: inset 0 0 0 $border-width $theme-color;
 		}
 	}
 }

--- a/packages/components/src/date-time/style.scss
+++ b/packages/components/src/date-time/style.scss
@@ -7,6 +7,10 @@
 .components-datetime {
 	padding: $grid-unit-20;
 
+	.components-popover__content & {
+		padding: 0;
+	}
+
 	.components-datetime__calendar-help {
 		padding: $grid-unit-20;
 
@@ -126,7 +130,7 @@
 			}
 
 			select {
-				margin-right: 4px;
+				margin-right: $grid-unit-05;
 
 				&:focus {
 					position: relative;
@@ -136,7 +140,7 @@
 
 			input[type="number"] {
 				padding: 2px;
-				margin-right: 4px;
+				margin-right: $grid-unit-05;
 				text-align: center;
 				-moz-appearance: textfield;
 
@@ -157,7 +161,7 @@
 	// We are assuming MM-DD-YYY correlates with AM/PM
 	&.is-12-hour {
 		.components-datetime__time-field-day input {
-			margin: 0 -4px 0 0 !important;
+			margin: 0 -$grid-unit-05 0 0 !important;
 			border-radius: $radius-round-rectangle 0 0 $radius-round-rectangle !important;
 		}
 		.components-datetime__time-field-year input {
@@ -194,5 +198,5 @@
 // Hack to center the datepicker component within the popover.
 // It sets its own styles so centering is tricky.
 .components-popover .components-datetime__date {
-	padding-left: 4px;
+	padding-left: $grid-unit-05;
 }

--- a/packages/components/src/date-time/style.scss
+++ b/packages/components/src/date-time/style.scss
@@ -118,47 +118,11 @@
 			color: $dark-gray-500;
 		}
 
-		.components-datetime__time-am-button {
-			margin-left: 8px;
-			margin-right: -1px;
-			border-radius: 3px 0 0 3px;
-		}
-
-		.components-datetime__time-pm-button {
-			margin-left: -1px;
-			border-radius: 0 3px 3px 0;
-		}
-
-		.components-datetime__time-am-button:focus,
-		.components-datetime__time-pm-button:focus {
-			position: relative;
-			z-index: 1;
-		}
-
-		.components-datetime__time-am-button.is-pressed,
-		.components-datetime__time-pm-button.is-pressed {
-			background: $light-gray-300;
-			border-color: $dark-gray-100;
-			box-shadow: inset 0 2px 5px -3px $dark-gray-500;
-			&:focus {
-				box-shadow:
-					inset 0 2px 5px -3px $dark-gray-500,
-					0 0 0 1px $white,
-					0 0 0 3px $blue-medium-focus;
-			}
-		}
-
 		.components-datetime__time-field {
 
 			&-time {
 				/*rtl:ignore*/
 				direction: ltr;
-			}
-
-
-			&.am-pm button {
-				font-size: 11px;
-				font-weight: 600;
 			}
 
 			select {

--- a/packages/components/src/date-time/style.scss
+++ b/packages/components/src/date-time/style.scss
@@ -5,11 +5,7 @@
 /*rtl:end:ignore*/
 
 .components-datetime {
-	padding: $grid-unit-20;
-
-	.components-popover__content & {
-		padding: 0;
-	}
+	padding: 0;
 
 	.components-datetime__calendar-help {
 		padding: $grid-unit-20;

--- a/packages/components/src/date-time/test/__snapshots__/time.js.snap
+++ b/packages/components/src/date-time/test/__snapshots__/time.js.snap
@@ -317,12 +317,12 @@ exports[`TimePicker matches the snapshot when the is12hour prop is specified 1`]
           value="00"
         />
       </div>
-      <div
+      <ButtonGroup
         className="components-datetime__time-field components-datetime__time-field-am-pm"
       >
         <ForwardRef(Button)
           className="components-datetime__time-am-button"
-          isPressed={false}
+          isPrimary={false}
           isSecondary={true}
           onClick={[Function]}
         >
@@ -330,13 +330,13 @@ exports[`TimePicker matches the snapshot when the is12hour prop is specified 1`]
         </ForwardRef(Button)>
         <ForwardRef(Button)
           className="components-datetime__time-pm-button"
-          isPressed={true}
-          isSecondary={true}
+          isPrimary={true}
+          isSecondary={false}
           onClick={[Function]}
         >
           PM
         </ForwardRef(Button)>
-      </div>
+      </ButtonGroup>
     </div>
   </fieldset>
 </div>
@@ -498,12 +498,12 @@ exports[`TimePicker matches the snapshot when the is12hour prop is true 1`] = `
           value="00"
         />
       </div>
-      <div
+      <ButtonGroup
         className="components-datetime__time-field components-datetime__time-field-am-pm"
       >
         <ForwardRef(Button)
           className="components-datetime__time-am-button"
-          isPressed={false}
+          isPrimary={false}
           isSecondary={true}
           onClick={[Function]}
         >
@@ -511,13 +511,13 @@ exports[`TimePicker matches the snapshot when the is12hour prop is true 1`] = `
         </ForwardRef(Button)>
         <ForwardRef(Button)
           className="components-datetime__time-pm-button"
-          isPressed={true}
-          isSecondary={true}
+          isPrimary={true}
+          isSecondary={false}
           onClick={[Function]}
         >
           PM
         </ForwardRef(Button)>
-      </div>
+      </ButtonGroup>
     </div>
   </fieldset>
 </div>

--- a/packages/components/src/date-time/time.js
+++ b/packages/components/src/date-time/time.js
@@ -15,6 +15,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import Button from '../button';
+import ButtonGroup from '../button-group';
 
 /**
  * Module Constants
@@ -318,24 +319,22 @@ class TimePicker extends Component {
 							/>
 						</div>
 						{ is12Hour && (
-							<div className="components-datetime__time-field components-datetime__time-field-am-pm">
+							<ButtonGroup className="components-datetime__time-field components-datetime__time-field-am-pm">
 								<Button
-									isSecondary
-									className="components-datetime__time-am-button"
-									isPressed={ am === 'AM' }
+									isPrimary={ am === 'AM' }
+									isSecondary={ am !== 'AM' }
 									onClick={ this.updateAmPm( 'AM' ) }
 								>
 									{ __( 'AM' ) }
 								</Button>
 								<Button
-									isSecondary
-									className="components-datetime__time-pm-button"
-									isPressed={ am === 'PM' }
+									isPrimary={ am === 'PM' }
+									isSecondary={ am !== 'PM' }
 									onClick={ this.updateAmPm( 'PM' ) }
 								>
 									{ __( 'PM' ) }
 								</Button>
-							</div>
+							</ButtonGroup>
 						) }
 					</div>
 				</fieldset>

--- a/packages/components/src/date-time/time.js
+++ b/packages/components/src/date-time/time.js
@@ -324,6 +324,7 @@ class TimePicker extends Component {
 									isPrimary={ am === 'AM' }
 									isSecondary={ am !== 'AM' }
 									onClick={ this.updateAmPm( 'AM' ) }
+									className="components-datetime__time-am-button"
 								>
 									{ __( 'AM' ) }
 								</Button>
@@ -331,6 +332,7 @@ class TimePicker extends Component {
 									isPrimary={ am === 'PM' }
 									isSecondary={ am !== 'PM' }
 									onClick={ this.updateAmPm( 'PM' ) }
+									className="components-datetime__time-pm-button"
 								>
 									{ __( 'PM' ) }
 								</Button>

--- a/packages/editor/src/components/post-publish-panel/style.scss
+++ b/packages/editor/src/components/post-publish-panel/style.scss
@@ -78,12 +78,6 @@
 	.editor-post-visibility__dialog-legend {
 		display: none;
 	}
-
-	// The DateTime component has an intrinsic padding in order for the horizontal scrolling to function inside a popover.
-	// We unset that here when used inline.
-	.components-datetime {
-		padding: 0;
-	}
 }
 
 .post-publish-panel__postpublish .components-panel__body {


### PR DESCRIPTION
This PR does a few things:

1. It refines the buttongroup component slightly. There was a small issue with the button group used for gradient type picking, that this addresses.
2. It refactors the am/pm selector in the date component to use a ButtonGroup.
3. It polishes the padding of the datetime picker, closing #20774.

Screens:

<img width="379" alt="Screenshot 2020-03-12 at 11 27 54" src="https://user-images.githubusercontent.com/1204802/76512889-bd59d400-6455-11ea-9c95-dde5b50f0fc1.png">

<img width="289" alt="Screenshot 2020-03-12 at 11 27 59" src="https://user-images.githubusercontent.com/1204802/76512892-bfbc2e00-6455-11ea-8480-bc26fed35f38.png">

<img width="239" alt="Screenshot 2020-03-12 at 11 28 03" src="https://user-images.githubusercontent.com/1204802/76512898-c185f180-6455-11ea-824f-311a9ff47df3.png">

<img width="376" alt="Screenshot 2020-03-12 at 11 28 13" src="https://user-images.githubusercontent.com/1204802/76512902-c3e84b80-6455-11ea-9c78-a1cd52b1cdf2.png">
