### PR TITLE
Fix Full width movers

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -611,11 +611,6 @@
 			// positions instead, the mover control.
 			margin-left: - $block-toolbar-height - $border-width;
 		}
-
-		.block-editor-block-contextual-toolbar[data-align="full"],
-		.block-editor-block-list__breadcrumb[data-align="full"] {
-			margin-left: 0;
-		}
 	}
 
 	.is-dragging-components-draggable & {


### PR DESCRIPTION
closes #20451 

On full width blocks, the block movers was not accessible. You can see it but not click it.

**Testing instructions**

Repeat instructions from #20451 and notice that you can move the full width blocks.