### PR TITLE
[RNMobile] Remove left border of the toolbar

### DIFF
--- a/packages/edit-post/src/components/header/header-toolbar/index.native.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.native.js
@@ -56,28 +56,26 @@ function HeaderToolbar( {
 				alwaysBounceHorizontal={ false }
 				contentContainerStyle={ styles.scrollableContent }
 			>
-				<Toolbar accessible={ false }>
-					<Inserter disabled={ ! showInserter } />
-					{ /* TODO: replace with EditorHistoryRedo and EditorHistoryUndo */ }
-					<ToolbarButton
-						title={ __( 'Undo' ) }
-						icon={ undoIcon }
-						isDisabled={ ! hasUndo }
-						onClick={ undo }
-						extraProps={ {
-							hint: __( 'Double tap to undo last change' ),
-						} }
-					/>
-					<ToolbarButton
-						title={ __( 'Redo' ) }
-						icon={ redoIcon }
-						isDisabled={ ! hasRedo }
-						onClick={ redo }
-						extraProps={ {
-							hint: __( 'Double tap to redo last change' ),
-						} }
-					/>
-				</Toolbar>
+				<Inserter disabled={ ! showInserter } />
+				{ /* TODO: replace with EditorHistoryRedo and EditorHistoryUndo */ }
+				<ToolbarButton
+					title={ __( 'Undo' ) }
+					icon={ undoIcon }
+					isDisabled={ ! hasUndo }
+					onClick={ undo }
+					extraProps={ {
+						hint: __( 'Double tap to undo last change' ),
+					} }
+				/>
+				<ToolbarButton
+					title={ __( 'Redo' ) }
+					icon={ redoIcon }
+					isDisabled={ ! hasRedo }
+					onClick={ redo }
+					extraProps={ {
+						hint: __( 'Double tap to redo last change' ),
+					} }
+				/>
 				{ hasFixedToolbar && <BlockToolbar /> }
 			</ScrollView>
 			{ showKeyboardHideButton && (


### PR DESCRIPTION
## Description
This PR removes the left border for the toolbar on mobile.
It does so by removing the `<Toolbar>` element that wrapped the inserter and the undo/redo buttons. This also brings us closer to the web code that doesn't have it.

Gutenberg Mobile related PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/2004

![image](https://user-images.githubusercontent.com/230230/76526286-960f0100-646d-11ea-9ae3-6868d4cbf6c5.png)

## How has this been tested?
Visual test (check GB Mobile PR)

## Screenshots <!-- if applicable -->
New look:
| iPhone landscade  | iPad  |
|---|---|
| ![iphone-landscape](https://user-images.githubusercontent.com/230230/76525763-ba1e1280-646c-11ea-82fa-34b9f5dbd0b8.png) | ![ipad](https://user-images.githubusercontent.com/230230/76525765-bb4f3f80-646c-11ea-9787-4c8d870c9edf.png) |


## Types of changes
Visual change

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
