### PR TITLE
Add CPT selector to Latest Posts

### DIFF
--- a/packages/block-library/src/latest-posts/block.json
+++ b/packages/block-library/src/latest-posts/block.json
@@ -1,72 +1,75 @@
 {
-	"name": "core/latest-posts",
-	"category": "widgets",
-	"attributes": {
-		"align": {
-			"type": "string",
-			"enum":  ["left", "center", "right", "wide", "full"]
-		},
-		"className": {
-			"type": "string"
-		},
-		"categories": {
-			"type": "array"
-		},
-		"postsToShow": {
-			"type": "number",
-			"default": 5
-		},
-		"displayPostContent": {
-			"type": "boolean",
-			"default": false
-		},
-		"displayPostContentRadio": {
-			"type": "string",
-			"default": "excerpt"
-		},
-		"excerptLength": {
-			"type": "number",
-			"default": 55
-		},
-		"displayPostDate": {
-			"type": "boolean",
-			"default": false
-		},
-		"postLayout": {
-			"type": "string",
-			"default": "list"
-		},
-		"columns": {
-			"type": "number",
-			"default": 3
-		},
-		"order": {
-			"type": "string",
-			"default": "desc"
-		},
-		"orderBy": {
-			"type": "string",
-			"default": "date"
-		},
-		"displayFeaturedImage": {
-			"type": "boolean",
-			"default": false
-		},
-		"featuredImageAlign": {
-			"type": "string",
-			"enum": ["left", "center", "right"]
-		},
-		"featuredImageSizeSlug": {
-			"type": "string",
-			"default":"thumbnail"
-		},
-		"featuredImageSizeWidth": {
-			"type": "number",
-			"default":null
-		},
-		"featuredImageSizeHeight": {
-			"type": "number",
-			"default":null
-		}
-	}
+    "name": "core/latest-posts",
+    "category": "widgets",
+    "attributes": {
+        "align": {
+            "type": "string",
+            "enum": ["left", "center", "right", "wide", "full"]
+        },
+        "className": {
+            "type": "string"
+        },
+        "categories": {
+            "type": "array"
+        },
+        "postType": {
+            "type": "string"
+        },
+        "postsToShow": {
+            "type": "number",
+            "default": 5
+        },
+        "displayPostContent": {
+            "type": "boolean",
+            "default": false
+        },
+        "displayPostContentRadio": {
+            "type": "string",
+            "default": "excerpt"
+        },
+        "excerptLength": {
+            "type": "number",
+            "default": 55
+        },
+        "displayPostDate": {
+            "type": "boolean",
+            "default": false
+        },
+        "postLayout": {
+            "type": "string",
+            "default": "list"
+        },
+        "columns": {
+            "type": "number",
+            "default": 3
+        },
+        "order": {
+            "type": "string",
+            "default": "desc"
+        },
+        "orderBy": {
+            "type": "string",
+            "default": "date"
+        },
+        "displayFeaturedImage": {
+            "type": "boolean",
+            "default": false
+        },
+        "featuredImageAlign": {
+            "type": "string",
+            "enum": ["left", "center", "right"]
+        },
+        "featuredImageSizeSlug": {
+            "type": "string",
+            "default": "thumbnail"
+        },
+        "featuredImageSizeWidth": {
+            "type": "number",
+            "default": null
+        },
+        "featuredImageSizeHeight": {
+            "type": "number",
+            "default": null
+        }
+    }
 }

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -19,7 +19,6 @@ import {
 	ToggleControl,
 	ToolbarGroup,
 	FormTokenField,
-	SelectControl,
 } from '@wordpress/components';
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
@@ -128,7 +127,6 @@ class LatestPostsEdit extends Component {
 			} ),
 			{}
 		);
-		const postTypeSuggestions = postTypeList;
 
 		const selectCategories = ( tokens ) => {
 			// Categories that are already will be objects, while new additions will be strings (the name).
@@ -137,10 +135,6 @@ class LatestPostsEdit extends Component {
 				typeof token === 'string' ? categorySuggestions[ token ] : token
 			);
 			setAttributes( { categories: allCategories } );
-		};
-
-		const selectPostTypes = ( val ) => {
-			setAttributes( { postType: val } );
 		};
 
 		const inspectorControls = (
@@ -264,6 +258,11 @@ class LatestPostsEdit extends Component {
 						onNumberOfItemsChange={ ( value ) =>
 							setAttributes( { postsToShow: value } )
 						}
+						onPostTypeChange={ ( value ) =>
+							setAttributes( { postType: value } )
+						}
+						postTypeList={ postTypeList }
+						selectedPostType={ postType }
 					/>
 					{ categoriesList.length > 0 && (
 						<FormTokenField
@@ -279,21 +278,7 @@ class LatestPostsEdit extends Component {
 							onChange={ selectCategories }
 						/>
 					) }
-					{ postTypeList && (
-						<SelectControl
-							label={ __( 'Post types' ) }
-							value={ postType }
-							onChange={ selectPostTypes }
-							options={ Object.values( postTypeList ).map(
-								( item ) => {
-									return {
-										label: item.name,
-										value: item.slug,
-									};
-								}
-							) }
-						/>
-					) }
+
 					{ postLayout === 'grid' && (
 						<RangeControl
 							label={ __( 'Columns' ) }

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -53,8 +53,6 @@ function render_block_core_latest_posts( $attributes ) {
 		$args['post_type'] = $attributes['postType'];
 	}
 
-
-
 	$recent_posts = get_posts( $args );
 
 	$list_items_markup = '';

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -49,6 +49,11 @@ function render_block_core_latest_posts( $attributes ) {
 	if ( isset( $attributes['categories'] ) ) {
 		$args['category__in'] = array_column( $attributes['categories'], 'id' );
 	}
+	if ( isset( $attributes['postType'] ) ) {
+		$args['post_type'] = $attributes['postType'];
+	}
+
+
 
 	$recent_posts = get_posts( $args );
 

--- a/packages/components/src/query-controls/index.js
+++ b/packages/components/src/query-controls/index.js
@@ -36,6 +36,9 @@ export default function QueryControls( {
 	onNumberOfItemsChange,
 	onOrderChange,
 	onOrderByChange,
+	onPostTypeChange,
+	postTypeList,
+	selectedPostType,
 } ) {
 	return [
 		onOrderChange && onOrderByChange && (
@@ -83,6 +86,18 @@ export default function QueryControls( {
 				noOptionLabel={ __( 'All' ) }
 				selectedCategoryId={ selectedCategoryId }
 				onChange={ onCategoryChange }
+				{ ...MOBILE_CONTROL_PROPS }
+			/>
+		),
+		onPostTypeChange && (
+			<SelectControl
+				label={ __( 'Post types' ) }
+				value={ selectedPostType }
+				options={ Object.values( postTypeList ).map( ( item ) => ( {
+					label: item.name,
+					value: item.slug,
+				} ) ) }
+				onChange={ onPostTypeChange }
 				{ ...MOBILE_CONTROL_PROPS }
 			/>
 		),


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
Adds a post type selector to the `LatestPosts` (in the `QueryControls`) block as described at #9013 and mentioned in #20046. 

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
I've tested a few different scenarios where you would choose specific post types in the `LatestPosts` block.
## Screenshots <!-- if applicable -->
![Skärminspelning-2020-03-12-kl -14 23 38](https://user-images.githubusercontent.com/3396172/76526052-3d3f6880-646d-11ea-8269-a2714720773c.gif)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
New feature 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
