### PR TITLE
Dependencies webpack plugin: Let the output file be specified when output is combined

### DIFF
--- a/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
+++ b/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
@@ -1,10 +1,14 @@
 ## Master
 
+### New Features
+
+- The plugin now supports an optional `combinedOutputFile` option that is useful only when another `combineAssets` option is enabled. It allows providing a custom output file for the generated single assets file ([#20844](https://github.com/WordPress/gutenberg/pull/20844)).
+
 ## 2.3.0 (2020-02-21)
 
 ### New Features
 
-- The plugin now supports optional `combineAssets` options. When this flag is set to `true`, all information about assets is combined into a single `assets.(json|php)` file generated in the output directory ([#20330](https://github.com/WordPress/gutenberg/pull/20330)).
+- The plugin now supports optional `combineAssets` option. When this flag is set to `true`, all information about assets is combined into a single `assets.(json|php)` file generated in the output directory ([#20330](https://github.com/WordPress/gutenberg/pull/20330)).
 
 ## 2.0.0 (2019-09-16)
 

--- a/packages/dependency-extraction-webpack-plugin/README.md
+++ b/packages/dependency-extraction-webpack-plugin/README.md
@@ -123,6 +123,13 @@ The output format for the generated asset file. There are two options available:
 
 By default, one asset file is created for each entry point. When this flag is set to `true`, all information about assets is combined into a single `assets.(json|php)` file generated in the output directory.
 
+##### `combinedOutputFile`
+
+- Type: string
+- Default: `null`
+
+This option is useful only when the `combineAssets` option is enabled. It allows providing a custom output file for the generated single assets file. It's possible to provide a path that is relative to the output directory.
+
 ##### `useDefaults`
 
 - Type: boolean

--- a/packages/dependency-extraction-webpack-plugin/index.js
+++ b/packages/dependency-extraction-webpack-plugin/index.js
@@ -20,6 +20,7 @@ class DependencyExtractionWebpackPlugin {
 		this.options = Object.assign(
 			{
 				combineAssets: false,
+				combinedOutputFile: null,
 				injectPolyfill: false,
 				outputFormat: 'php',
 				useDefaults: true,
@@ -106,6 +107,7 @@ class DependencyExtractionWebpackPlugin {
 		compiler.hooks.emit.tap( this.constructor.name, ( compilation ) => {
 			const {
 				combineAssets,
+				combinedOutputFile,
 				injectPolyfill,
 				outputFormat,
 			} = this.options;
@@ -180,7 +182,8 @@ class DependencyExtractionWebpackPlugin {
 				const outputFolder = compiler.options.output.path;
 				const assetsFilePath = path.resolve(
 					outputFolder,
-					'assets.' + ( outputFormat === 'php' ? 'php' : 'json' )
+					combinedOutputFile ||
+						'assets.' + ( outputFormat === 'php' ? 'php' : 'json' )
 				);
 				const assetsFilename = path.relative(
 					outputFolder,


### PR DESCRIPTION
## Description

Closes #20562.

> After https://github.com/WordPress/gutenberg/pull/20330 it seems to make sense to be able to specify the (single) output file name and path.
> 
> Use case: currently in core the `assets.php` file has to be moved with Grunt after the Webpack build is done. Seems pretty simple to "tell" Webpack where to output the file instead of having this additional step.

The plugin now supports an optional `combinedOutputFile` option that is useful only when another `combineAssets` option is enabled. It allows providing a custom output file for the generated single assets file.

## How has this been tested?

I used the following diff to ensure that the new option is respected:

```diff
diff --git a/webpack.config.js b/webpack.config.js
index 2251ffe33..4d0199ac0 100644
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -186,7 +186,11 @@ module.exports = {
                                to: 'build/block-library/blocks/[1]/block.json',
                        },
                ] ),
-               new DependencyExtractionWebpackPlugin( { injectPolyfill: true } ),
+               new DependencyExtractionWebpackPlugin( {
+                       combineAssets: true,
+                       combinedOutputFile: 'assets.test.php',
+                       injectPolyfill: true,
+               } ),
        ],
        devtool,
 };
```

## Types of changes
New feature (non-breaking change which adds functionality).

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
