### PR TITLE
Dismiss bottom sheet on return key submit

### DIFF
--- a/packages/block-library/src/button/edit.native.js
+++ b/packages/block-library/src/button/edit.native.js
@@ -24,7 +24,7 @@ import {
 	BottomSheet,
 } from '@wordpress/components';
 import { Component } from '@wordpress/element';
-import { withSelect } from '@wordpress/data';
+import { withSelect, withDispatch } from '@wordpress/data';
 import { isURL, prependHTTP } from '@wordpress/url';
 import { link, external } from '@wordpress/icons';
 
@@ -52,6 +52,7 @@ class ButtonEdit extends Component {
 		this.onChangeURL = this.onChangeURL.bind( this );
 		this.onClearSettings = this.onClearSettings.bind( this );
 		this.onLayout = this.onLayout.bind( this );
+		this.dismissSheet = this.dismissSheet.bind( this );
 		this.getURLFromClipboard = this.getURLFromClipboard.bind( this );
 		this.onToggleLinkSettings = this.onToggleLinkSettings.bind( this );
 		this.onToggleButtonFocus = this.onToggleButtonFocus.bind( this );
@@ -228,6 +229,13 @@ class ButtonEdit extends Component {
 		this.setState( { maxWidth: width - buttonSpacing } );
 	}
 
+	dismissSheet() {
+		this.setState( {
+			isLinkSheetVisible: false,
+		} );
+		this.props.closeSettingsBottomSheet();
+	}
+
 	getLinkSettings( url, rel, linkTarget, isCompatibleWithSettings ) {
 		return (
 			<>
@@ -237,6 +245,7 @@ class ButtonEdit extends Component {
 					value={ url || '' }
 					valuePlaceholder={ __( 'Add URL' ) }
 					onChange={ this.onChangeURL }
+					onSubmit={ this.dismissSheet }
 					autoCapitalize="none"
 					autoCorrect={ false }
 					// eslint-disable-next-line jsx-a11y/no-autofocus
@@ -263,6 +272,7 @@ class ButtonEdit extends Component {
 					value={ rel || '' }
 					valuePlaceholder={ __( 'None' ) }
 					onChange={ this.onChangeLinkRel }
+					onSubmit={ this.dismissSheet }
 					autoCapitalize="none"
 					autoCorrect={ false }
 					separatorType={
@@ -445,6 +455,13 @@ export default compose( [
 			selectedId,
 			editorSidebarOpened: isEditorSidebarOpened(),
 			hasParents,
+		};
+	} ),
+	withDispatch( ( dispatch ) => {
+		return {
+			closeSettingsBottomSheet() {
+				dispatch( 'core/edit-post' ).closeGeneralSidebar();
+			},
 		};
 	} ),
 ] )( ButtonEdit );

--- a/packages/components/src/mobile/bottom-sheet/cell.native.js
+++ b/packages/components/src/mobile/bottom-sheet/cell.native.js
@@ -98,6 +98,7 @@ class BottomSheetCell extends Component {
 			cellContainerStyle = {},
 			cellRowContainerStyle = {},
 			onChangeValue,
+			onSubmit,
 			children,
 			editable = true,
 			separatorType,
@@ -226,6 +227,7 @@ class BottomSheetCell extends Component {
 					}
 					onFocus={ startEditing }
 					onBlur={ finishEditing }
+					onSubmitEditing={ onSubmit }
 					keyboardType={ this.typeToKeyboardType( type, step ) }
 					{ ...valueProps }
 				/>

--- a/packages/format-library/src/link/modal.native.js
+++ b/packages/format-library/src/link/modal.native.js
@@ -169,6 +169,7 @@ class ModalLinkUI extends Component {
 						autoCorrect={ false }
 						keyboardType="url"
 						onChangeValue={ this.onChangeInputValue }
+						onSubmit={ this.onDismiss }
 						autoFocus={ Platform.OS === 'ios' }
 					/>
 					/* eslint-enable jsx-a11y/no-autofocus */
@@ -179,6 +180,7 @@ class ModalLinkUI extends Component {
 					value={ text }
 					placeholder={ __( 'Add link text' ) }
 					onChangeValue={ this.onChangeText }
+					onSubmit={ this.onDismiss }
 				/>
 				<BottomSheet.SwitchCell
 					icon={ external }


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/1164

## Description
Bottom sheets may contain text inputs. When a text input has focus and the keyboard is displayed, tapping the Return button on the keyboard should dismiss the bottom sheet.

## How has this been tested?

There are two types of bottom sheets: 
- The link sheet
- The Button block settings sheet 
(The sheet that the Latest Posts block uses does not include text inputs which use the return key on their keyboard, so its not affected by this change.) 

The link sheet appears in any block that includes a rich text area such as Paragraph, Heading, Button, Image (caption), Video (caption), Cover, List, Gallery, Media & Text, etc.
The Button block settings sheet is present only on the Button block.

### Paragraph Block
1. Create a Paragraph Block and add text
2. Tap the link button in the toolbar to reveal a sheet containing link options
3. Fill in the first text input
4. Tap the keyboard Return button and observe that the sheet is dismissed
5. Repeat steps 3 and 4 for any other text inputs on the sheet

### Button Block

1. Create a Button Block and add text
2. Tap the link button in the toolbar to reveal a sheet containing link options
3. Fill in the first text input
4. Tap the keyboard Return button and observe that the sheet is dismissed
5. Repeat steps 3 and 4 for any other text inputs on the sheet
6. Repeat steps 2-5 using the settings button instead of the link button

<img width="300" alt="How to identify link and settings buttons" src="https://user-images.githubusercontent.com/1898325/76561962-20159480-6483-11ea-9e73-344556ab54f3.png">

## Screenshots <!-- if applicable -->

Paragraph Block | Button Block
-- | --
<img width="250" src="https://user-images.githubusercontent.com/1898325/76563575-76380700-6486-11ea-9c6b-6a875d48f6a2.gif"> | <img width="250" src="https://user-images.githubusercontent.com/1898325/76563583-7a642480-6486-11ea-8a50-427c18f96e85.gif">



## Types of changes
- Bug fix
- New feature
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
