### PR TITLE
Project Management Automation: Add TypeScript type-checking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6537,12 +6537,38 @@
 			}
 		},
 		"@octokit/types": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.1.1.tgz",
-			"integrity": "sha512-89LOYH+d/vsbDX785NOfLxTW88GjNd0lWRz1DVPVsZgg9Yett5O+3MOvwo7iHgvUwbFz0mf/yPIjBkUbs4kxoQ==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.5.0.tgz",
+			"integrity": "sha512-KEnLwOfdXzxPNL34fj508bhi9Z9cStyN7qY1kOfVahmqtAfrWw6Oq3P4R+dtsg0lYtZdWBpUrS/Ixmd5YILSww==",
 			"dev": true,
 			"requires": {
 				"@types/node": ">= 8"
+			}
+		},
+		"@octokit/webhooks": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-7.1.0.tgz",
+			"integrity": "sha512-kHyYkJkqY/wiP/hp0IT9FhkY5PhnV01co16V2YMRP/Zgnk3Vsy3U5iLAaP6U/0eRIlz5T4LSvkrcfNlfSb3cVQ==",
+			"dev": true,
+			"requires": {
+				"debug": "^4.0.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
+				}
 			}
 		},
 		"@reach/router": {

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
 		"@babel/runtime-corejs3": "7.8.3",
 		"@babel/traverse": "7.8.3",
 		"@octokit/rest": "16.26.0",
+		"@octokit/webhooks": "7.1.0",
 		"@storybook/addon-a11y": "5.3.2",
 		"@storybook/addon-docs": "5.3.2",
 		"@storybook/addon-knobs": "5.3.2",

--- a/packages/project-management-automation/lib/add-first-time-contributor-label.js
+++ b/packages/project-management-automation/lib/add-first-time-contributor-label.js
@@ -3,12 +3,15 @@
  */
 const debug = require( './debug' );
 
+/** @typedef {import('@actions/github').GitHub} GitHub */
+/** @typedef {import('@octokit/webhooks').WebhookPayloadPullRequest} WebhookPayloadPullRequest */
+
 /**
  * Adds the 'First Time Contributor' label to PRs opened by contributors that
  * have not yet made a commit.
  *
- * @param {Object} payload Pull request event payload, see https://developer.github.com/v3/activity/events/types/#pullrequestevent.
- * @param {Object} octokit Initialized Octokit REST client, see https://octokit.github.io/rest.js/.
+ * @param {WebhookPayloadPullRequest} payload Pull request event payload.
+ * @param {GitHub}                    octokit Initialized Octokit REST client.
  */
 async function addFirstTimeContributorLabel( payload, octokit ) {
 	const owner = payload.repository.owner.login;

--- a/packages/project-management-automation/lib/add-milestone.js
+++ b/packages/project-management-automation/lib/add-milestone.js
@@ -6,8 +6,6 @@ const debug = require( './debug' );
 /** @typedef {import('@octokit/rest').HookError} HookError */
 /** @typedef {import('@actions/github').GitHub} GitHub */
 /** @typedef {import('@octokit/webhooks').WebhookPayloadPush} WebhookPayloadPush */
-/** @typedef {import('@octokit/rest').Response} OctokitResponse */
-/** @typedef {import('@octokit/rest').IssuesListMilestonesForRepoResponse} OctokitIssuesListMilestonesForRepoResponse */
 
 // Milestone due dates are calculated from a known due date:
 // 6.3, which was due on August 12 2019.

--- a/packages/project-management-automation/lib/add-milestone.js
+++ b/packages/project-management-automation/lib/add-milestone.js
@@ -3,6 +3,12 @@
  */
 const debug = require( './debug' );
 
+/** @typedef {import('@octokit/rest').HookError} HookError */
+/** @typedef {import('@actions/github').GitHub} GitHub */
+/** @typedef {import('@octokit/webhooks').WebhookPayloadPush} WebhookPayloadPush */
+/** @typedef {import('@octokit/rest').Response} OctokitResponse */
+/** @typedef {import('@octokit/rest').IssuesListMilestonesForRepoResponse} OctokitIssuesListMilestonesForRepoResponse */
+
 // Milestone due dates are calculated from a known due date:
 // 6.3, which was due on August 12 2019.
 const REFERENCE_MAJOR = 6;
@@ -21,7 +27,7 @@ const DAYS_PER_RELEASE = 14;
  * @see https://developer.github.com/v3/#client-errors
  * @see https://github.com/octokit/request.js/blob/2a1d768/src/fetch-wrapper.ts#L79-L80
  *
- * @param {Error} error Error to test.
+ * @param {HookError} error Error to test.
  *
  * @return {boolean} Whether error is a duplicate validation request error.
  */
@@ -32,8 +38,8 @@ const isDuplicateValidationError = ( error ) =>
 /**
  * Assigns the correct milestone to PRs once merged.
  *
- * @param {Object} payload Push event payload, see https://developer.github.com/v3/activity/events/types/#pushevent.
- * @param {Object} octokit Initialized Octokit REST client, see https://octokit.github.io/rest.js/.
+ * @param {WebhookPayloadPush} payload Push event payload.
+ * @param {GitHub}             octokit Initialized Octokit REST client.
  */
 async function addMilestone( payload, octokit ) {
 	if ( payload.ref !== 'refs/heads/master' ) {

--- a/packages/project-management-automation/lib/assign-fixed-issues.js
+++ b/packages/project-management-automation/lib/assign-fixed-issues.js
@@ -3,11 +3,14 @@
  */
 const debug = require( './debug' );
 
+/** @typedef {import('@actions/github').GitHub} GitHub */
+/** @typedef {import('@octokit/webhooks').WebhookPayloadPullRequest} WebhookPayloadPullRequest */
+
 /**
  * Assigns any issues 'fixed' by a newly opened PR to the author of that PR.
  *
- * @param {Object} payload Pull request event payload, see https://developer.github.com/v3/activity/events/types/#pullrequestevent.
- * @param {Object} octokit Initialized Octokit REST client, see https://octokit.github.io/rest.js/.
+ * @param {WebhookPayloadPullRequest} payload Pull request event payload.
+ * @param {GitHub}                    octokit Initialized Octokit REST client.
  */
 async function assignFixedIssues( payload, octokit ) {
 	const regex = /(?:close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved):? +(?:\#?|https?:\/\/github\.com\/WordPress\/gutenberg\/issues\/)(\d+)/gi;

--- a/packages/project-management-automation/lib/if-not-fork.js
+++ b/packages/project-management-automation/lib/if-not-fork.js
@@ -3,22 +3,24 @@
  */
 const debug = require( './debug' );
 
+/** @typedef {import('.').WPAutomationTask} WPAutomationTask */
+
 /**
  * Higher-order function which executes and returns the result of the given
  * handler only if the enhanced function is called with a payload indicating a
  * pull request event which did not originate from a forked repository.
  *
- * @param {Function} handler Original task.
+ * @param {WPAutomationTask} handler Original task.
  *
- * @return {Function} Enhanced task.
+ * @return {WPAutomationTask} Enhanced task.
  */
 function ifNotFork( handler ) {
-	const newHandler = ( payload, ...args ) => {
+	const newHandler = ( payload, octokit ) => {
 		if (
 			payload.pull_request.head.repo.full_name ===
 			payload.pull_request.base.repo.full_name
 		) {
-			return handler( payload, ...args );
+			return handler( payload, octokit );
 		}
 		debug( `main: Skipping ${ handler.name } because we are in a fork.` );
 	};

--- a/packages/project-management-automation/lib/index.js
+++ b/packages/project-management-automation/lib/index.js
@@ -13,6 +13,28 @@ const addMilestone = require( './add-milestone' );
 const debug = require( './debug' );
 const ifNotFork = require( './if-not-fork' );
 
+/** @typedef {import('@actions/github').GitHub} GitHub */
+
+/**
+ * Automation task function.
+ *
+ * @typedef {(payload:any,octokit:GitHub)=>void} WPAutomationTask
+ */
+
+/**
+ * Full list of automations, matched by given properties against the incoming
+ * payload object.
+ *
+ * @typedef WPAutomation
+ *
+ * @property {string}           event    Webhook event name to match.
+ * @property {string}           [action] Action to match, if applicable.
+ * @property {WPAutomationTask} task     Task to run.
+ */
+
+/**
+ * @type {WPAutomation[]}
+ */
 const automations = [
 	{
 		event: 'pull_request',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -37,6 +37,7 @@
 		"./packages/i18n/**/*.js",
 		"./packages/is-shallow-equal/**/*.js",
 		"./packages/priority-queue/**/*.js",
+		"./packages/project-management-automation/**/*.js",
 		"./packages/token-list/**/*.js",
 		"./packages/url/src/**/*.js",
 		"./packages/warning/**/*.js",


### PR DESCRIPTION
Part of: #18838

This pull request seeks to enable type-checking for the Project Management Automation package, and improves existing types. GitHub's core modules provide types by default, which we can use to verify types of the implementation of our automation tasks.

**Testing Instructions:**

Ensure type-checking passes:

```
npm run lint-types
```

cc @sirreal 