### PR TITLE
Patterns: Make adding patterns easier

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -668,13 +668,20 @@ function gutenberg_load_block_pattern( $name ) {
  * @return array Filtered editor settings.
  */
 function gutenberg_extend_settings_block_patterns( $settings ) {
-	$block_patterns                          = [
-		gutenberg_load_block_pattern( 'text-two-columns' ),
-		gutenberg_load_block_pattern( 'two-buttons' ),
-		gutenberg_load_block_pattern( 'cover-abc' ),
-		gutenberg_load_block_pattern( 'two-images' ),
-	];
-	$settings['__experimentalBlockPatterns'] = $block_patterns;
+	if ( empty( $settings['__experimentalBlockPatterns'] ) ) {
+		$settings['__experimentalBlockPatterns'] = [];
+	}
+
+	$settings['__experimentalBlockPatterns'] = array_merge(
+		[
+			gutenberg_load_block_pattern( 'text-two-columns' ),
+			gutenberg_load_block_pattern( 'two-buttons' ),
+			gutenberg_load_block_pattern( 'cover-abc' ),
+			gutenberg_load_block_pattern( 'two-images' ),
+		],
+		$settings['__experimentalBlockPatterns']
+	);
+
 	return $settings;
 }
-add_filter( 'block_editor_settings', 'gutenberg_extend_settings_block_patterns' );
+add_filter( 'block_editor_settings', 'gutenberg_extend_settings_block_patterns', 0 );


### PR DESCRIPTION
## Description
Let's make it easier for plugins to add their own patterns to the stack. Filtering `block_editor_settings` at the default priority means that plugins will have to define a later priority to avoid having their patterns be overwritten. Not something they should have to worry about.

* Creates `__experimentalBlockPatterns` at priority 0
* Adds default patterns to the list of patterns instead of overwriting it.


Alternatively we could make the list of core patterns filterable:
```php
function gutenberg_extend_settings_block_patterns( $settings ) {
	$block_patterns                          = [
		gutenberg_load_block_pattern( 'text-two-columns' ),
		gutenberg_load_block_pattern( 'two-buttons' ),
		gutenberg_load_block_pattern( 'cover-abc' ),
		gutenberg_load_block_pattern( 'two-images' ),
	];

	/**
	 * Filters the list of block patterns.
	 *
	 * @since X.X.X
	 *
	 * @param array $block_patterns The list of block patterns.
	 */
	$settings['__experimentalBlockPatterns'] = apply_filters( 'gutenberg_block_patterns', $block_patterns );
	
	return $settings;
}
add_filter( 'block_editor_settings', 'gutenberg_extend_settings_block_patterns' );
```

## How has this been tested?
Tested with a plugin that add its own patterns.


## Types of changes
Enhancement to an existing feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
