### PR TITLE
Add container class for ClipboardButton component

### DIFF
--- a/packages/components/src/clipboard-button/index.js
+++ b/packages/components/src/clipboard-button/index.js
@@ -81,6 +81,7 @@ class ClipboardButton extends Component {
 			onFinishCopy,
 			// eslint-disable-next-line no-unused-vars
 			text,
+			containerClassName,
 			...buttonProps
 		} = this.props;
 		const classes = classnames( 'components-clipboard-button', className );
@@ -95,7 +96,11 @@ class ClipboardButton extends Component {
 		};
 
 		return (
-			<span ref={ this.containerRef } onCopy={ focusOnCopyEventTarget }>
+			<span
+				ref={ this.containerRef }
+				onCopy={ focusOnCopyEventTarget }
+				className={ containerClassName }
+			>
 				<Button { ...buttonProps } className={ classes }>
 					{ children }
 				</Button>


### PR DESCRIPTION
## Description
This PR add an ability to give class names to the span element that wraps the Button component in ClipboardButton component.

## How has this been tested?
Tested in Storybook.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
