### PR TITLE
[RNMobile]: Update 'Add Block Here' indicator style

### DIFF
--- a/packages/block-editor/src/components/block-list/style.native.scss
+++ b/packages/block-editor/src/components/block-list/style.native.scss
@@ -30,8 +30,9 @@
 	flex: 1;
 	text-align: center;
 	font-family: $default-monospace-font;
-	font-size: 12px;
-	font-weight: bold;
+	font-size: 14px;
+	color: $gray;
+	margin: 0 8px;
 }
 
 .labelStyleAddHereDark {


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

Fixes: https://github.com/wordpress-mobile/gutenberg-mobile/issues/1166

Gutenberg Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/2014

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

1. Tap (+) to insert a new block
1. Check "ADD BLOCK HERE" design

## Screenshots <!-- if applicable -->

### Current

<img width="584" alt="current" src="https://user-images.githubusercontent.com/1845482/76550116-e304ce80-6491-11ea-85f1-e9c94e5cbaa6.png">


### Proposed

Light
<img width="584" alt="14-gray-margin-no-bold" src="https://user-images.githubusercontent.com/1845482/76550115-e26c3800-6491-11ea-8cde-def87907f9b2.png">
Dark
<img width="584" alt="14-gray-margin-no-bold-dark-mode" src="https://user-images.githubusercontent.com/1845482/76550112-e0a27480-6491-11ea-9190-0f7962f5c671.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
