### PR TITLE
Avoid page templates overwriting page title

### DIFF
--- a/packages/block-editor/src/components/page-template-picker/picker.js
+++ b/packages/block-editor/src/components/page-template-picker/picker.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useState } from '@wordpress/element';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 
 /**
  * External dependencies
@@ -21,11 +21,19 @@ const __experimentalPageTemplatePicker = ( {
 	templates = getDefaultTemplates(),
 } ) => {
 	const { editPost } = useDispatch( 'core/editor' );
+	const { title } = useSelect( ( select ) => {
+		const { getEditedPostAttribute } = select( 'core/editor' );
+
+		return {
+			title: getEditedPostAttribute( 'title' ),
+		};
+	} );
+
 	const [ templatePreview, setTemplatePreview ] = useState();
 
 	const onApply = () => {
 		editPost( {
-			title: templatePreview.name,
+			title: title ? title : templatePreview.name,
 			blocks: templatePreview.blocks,
 		} );
 		logUserEvent( userEvents.editorSessionTemplateApply, {

--- a/packages/block-editor/src/components/page-template-picker/picker.js
+++ b/packages/block-editor/src/components/page-template-picker/picker.js
@@ -33,7 +33,7 @@ const __experimentalPageTemplatePicker = ( {
 
 	const onApply = () => {
 		editPost( {
-			title: title ? title : templatePreview.name,
+			title: title || templatePreview.name,
 			blocks: templatePreview.blocks,
 		} );
 		logUserEvent( userEvents.editorSessionTemplateApply, {


### PR DESCRIPTION
## Description

Fixes: https://github.com/wordpress-mobile/gutenberg-mobile/issues/2013

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

- Create a new page, pick and apply a template: the page should have the template title
- Create a new page, type a title, pick and apply a template: the page should have the typed title and the template contents

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
