### PR TITLE
Edit Post: Register block patterns as separate plugin

### DIFF
--- a/packages/edit-post/src/plugins/index.js
+++ b/packages/edit-post/src/plugins/index.js
@@ -16,11 +16,16 @@ import ToolsMoreMenuGroup from '../components/header/tools-more-menu-group';
 import WelcomeGuideMenuItem from './welcome-guide-menu-item';
 import BlockPatterns from './block-patterns';
 
+registerPlugin( 'edit-post-block-patterns', {
+	render() {
+		return <BlockPatterns />;
+	},
+} );
+
 registerPlugin( 'edit-post', {
 	render() {
 		return (
 			<>
-				<BlockPatterns />
 				<ToolsMoreMenuGroup>
 					{ ( { onClose } ) => (
 						<>


### PR DESCRIPTION
## Description

Alternative to #20867.

Block Patterns are at an early stage of development and have so far been built as a sidebar plugin (#20354). This PR seeks to keep Patterns true to this design decision by ensuring they are registered as an independent plugin.

This, in turn, allows Block Patterns to be trivially disabled on any installation via the Plugins API:

```js
wp.plugins.unregisterPlugin( 'edit-post-block-patterns' )
```

This change should not condition planned improvements to Block Patterns that seek to make them an integral part of the editor (e.g. their inclusion in the Inserter).

## How has this been tested?
1. There should be no noticeable changes in the UI or behaviour of the editor or block patterns.
2. It should be possible to disable the block patterns sidebar as described above.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
