### PR TITLE
[RNMobile] Update cellRowStyles to add flex-shrink back and fix a disapearing stepper in bottom sheets

### DIFF
--- a/packages/components/src/mobile/bottom-sheet/stepper-cell/style.native.scss
+++ b/packages/components/src/mobile/bottom-sheet/stepper-cell/style.native.scss
@@ -12,6 +12,7 @@
 }
 
 .cellRowStyles {
+	flex-shrink: 1;
 	min-height: 48px;
 	align-items: center;
 	justify-content: space-between;


### PR DESCRIPTION
## Description

This previous fix https://github.com/WordPress/gutenberg/pull/20768 actually broke the bottom-sheet stepper component. This PR fixes the problem.

## How has this been tested?

Tested in the demo app on Android and iOS via gutenberg-mobile

## Screenshots <!-- if applicable -->
![stepper-fix](https://user-images.githubusercontent.com/40213/76628680-67f8f200-653d-11ea-9e10-8991d8873dfc.png)

## Types of changes

Style change

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->

