### PR TITLE
Refactor the inserter menu component and split into multiple smaller components

### DIFF
--- a/packages/block-editor/src/components/inserter/block-list.js
+++ b/packages/block-editor/src/components/inserter/block-list.js
@@ -1,0 +1,462 @@
+/**
+ * External dependencies
+ */
+import {
+	map,
+	pick,
+	includes,
+	filter,
+	findIndex,
+	flow,
+	sortBy,
+	groupBy,
+	isEmpty,
+	without,
+} from 'lodash';
+import scrollIntoView from 'dom-scroll-into-view';
+
+/**
+ * WordPress dependencies
+ */
+import { __, _x, _n, sprintf } from '@wordpress/i18n';
+import { PanelBody, withSpokenMessages } from '@wordpress/components';
+import { addQueryArgs } from '@wordpress/url';
+import { controlsRepeat } from '@wordpress/icons';
+import { speak } from '@wordpress/a11y';
+import { createBlock, isUnmodifiedDefaultBlock } from '@wordpress/blocks';
+import { useMemo, useEffect, useState, useRef } from '@wordpress/element';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { compose, withSafeTimeout } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import BlockTypesList from '../block-types-list';
+import ChildBlocks from './child-blocks';
+import __experimentalInserterMenuExtension from '../inserter-menu-extension';
+import { searchItems } from './search-items';
+
+// Copied over from the Columns block. It seems like it should become part of public API.
+const createBlocksFromInnerBlocksTemplate = ( innerBlocksTemplate ) => {
+	return map(
+		innerBlocksTemplate,
+		( [ name, attributes, innerBlocks = [] ] ) =>
+			createBlock(
+				name,
+				attributes,
+				createBlocksFromInnerBlocksTemplate( innerBlocks )
+			)
+	);
+};
+
+const getBlockNamespace = ( item ) => item.name.split( '/' )[ 0 ];
+
+const MAX_SUGGESTED_ITEMS = 9;
+
+function InserterBlockList( {
+	clientId,
+	isAppender,
+	rootClientId,
+	onSelect,
+	onHover,
+	__experimentalSelectBlockOnInsert: selectBlockOnInsert,
+	filterValue,
+	debouncedSpeak,
+	setTimeout: safeSetTimeout,
+} ) {
+	const {
+		categories,
+		collections,
+		items,
+		rootChildBlocks,
+		getSelectedBlock,
+		destinationRootClientId,
+		getBlockIndex,
+		getBlockSelectionEnd,
+		getBlockOrder,
+		fetchReusableBlocks,
+	} = useSelect(
+		( select ) => {
+			const {
+				getInserterItems,
+				getBlockName,
+				getBlockRootClientId,
+				getBlockSelectionEnd: _getBlockSelectionEnd,
+				getSettings,
+			} = select( 'core/block-editor' );
+			const {
+				getCategories,
+				getCollections,
+				getChildBlockNames,
+			} = select( 'core/blocks' );
+
+			let destRootClientId = rootClientId;
+			if ( ! destRootClientId && ! clientId && ! isAppender ) {
+				const end = _getBlockSelectionEnd();
+				if ( end ) {
+					destRootClientId = getBlockRootClientId( end ) || undefined;
+				}
+			}
+			const destinationRootBlockName = getBlockName(
+				destinationRootClientId
+			);
+
+			const { __experimentalFetchReusableBlocks } = getSettings();
+
+			return {
+				categories: getCategories(),
+				collections: getCollections(),
+				rootChildBlocks: getChildBlockNames( destinationRootBlockName ),
+				items: getInserterItems( destinationRootClientId ),
+				destinationRootClientId: destRootClientId,
+				fetchReusableBlocks: __experimentalFetchReusableBlocks,
+				...pick( select( 'core/block-editor' ), [
+					'getSelectedBlock',
+					'getBlockIndex',
+					'getBlockSelectionEnd',
+					'getBlockOrder',
+				] ),
+			};
+		},
+		[ clientId, isAppender, rootClientId ]
+	);
+	const {
+		replaceBlocks,
+		insertBlock,
+		showInsertionPoint,
+		hideInsertionPoint,
+	} = useDispatch( 'core/block-editor' );
+
+	// Fetch resuable blocks on mount
+	useEffect( () => {
+		fetchReusableBlocks();
+	}, [] );
+
+	// To avoid duplication, getInsertionIndex is extracted and used in two event handlers
+	// This breaks the withDispatch not containing any logic rule.
+	// Since it's a function only called when the event handlers are called,
+	// it's fine to extract it.
+	// eslint-disable-next-line no-restricted-syntax
+	function getInsertionIndex() {
+		// If the clientId is defined, we insert at the position of the block.
+		if ( clientId ) {
+			return getBlockIndex( clientId, destinationRootClientId );
+		}
+
+		// If there a selected block, we insert after the selected block.
+		const end = getBlockSelectionEnd();
+		if ( ! isAppender && end ) {
+			return getBlockIndex( end, destinationRootClientId ) + 1;
+		}
+
+		// Otherwise, we insert at the end of the current rootClientId
+		return getBlockOrder( destinationRootClientId ).length;
+	}
+
+	const onHoverItem = ( item ) => {
+		onHover();
+		if ( item ) {
+			const index = getInsertionIndex();
+			showInsertionPoint( destinationRootClientId, index );
+		} else {
+			hideInsertionPoint();
+		}
+	};
+
+	const onSelectItem = ( item ) => {
+		const { name, title, initialAttributes, innerBlocks } = item;
+		const selectedBlock = getSelectedBlock();
+		const insertedBlock = createBlock(
+			name,
+			initialAttributes,
+			createBlocksFromInnerBlocksTemplate( innerBlocks )
+		);
+		if (
+			! isAppender &&
+			selectedBlock &&
+			isUnmodifiedDefaultBlock( selectedBlock )
+		) {
+			replaceBlocks( selectedBlock.clientId, insertedBlock );
+		} else {
+			insertBlock(
+				insertedBlock,
+				getInsertionIndex(),
+				destinationRootClientId,
+				selectBlockOnInsert
+			);
+
+			if ( ! selectBlockOnInsert ) {
+				// translators: %s: the name of the block that has been added
+				const message = sprintf( __( '%s block added' ), title );
+				speak( message );
+			}
+		}
+
+		onSelect();
+		return insertedBlock;
+	};
+
+	const filteredItems = useMemo( () => {
+		return searchItems( items, categories, collections, filterValue );
+	}, [ filterValue, items, categories, collections ] );
+
+	const childItems = useMemo( () => {
+		return filter( filteredItems, ( { name } ) =>
+			includes( rootChildBlocks, name )
+		);
+	}, [ filteredItems, rootChildBlocks ] );
+
+	const suggestedItems = useMemo( () => {
+		return filter( items, ( item ) => item.utility > 0 ).slice(
+			0,
+			MAX_SUGGESTED_ITEMS
+		);
+	}, [ items ] );
+
+	const reusableItems = useMemo( () => {
+		return filter( filteredItems, { category: 'reusable' } );
+	}, [ filteredItems ] );
+
+	const itemsPerCategory = useMemo( () => {
+		const getCategoryIndex = ( item ) => {
+			return findIndex(
+				categories,
+				( category ) => category.slug === item.category
+			);
+		};
+
+		return flow(
+			( itemList ) =>
+				filter( itemList, ( item ) => item.category !== 'reusable' ),
+			( itemList ) => sortBy( itemList, getCategoryIndex ),
+			( itemList ) => groupBy( itemList, 'category' )
+		)( filteredItems );
+	}, [ filteredItems, categories ] );
+
+	const itemsPerCollection = useMemo( () => {
+		// Create a new Object to avoid mutating collection
+		const result = { ...collections };
+		Object.keys( collections ).forEach( ( namespace ) => {
+			result[ namespace ] = filteredItems.filter(
+				( item ) => getBlockNamespace( item ) === namespace
+			);
+			if ( result[ namespace ].length === 0 ) {
+				delete result[ namespace ];
+			}
+		} );
+
+		return result;
+	}, [ filteredItems, collections ] );
+
+	const inserterResults = useRef();
+	const panels = useRef( [] );
+	const bindPanel = ( name ) => ( ref ) => {
+		panels.current[ name ] = ref;
+	};
+	const [ openPanels, setOpenPanels ] = useState( [ 'suggested' ] );
+
+	const onTogglePanel = ( panel ) => {
+		return () => {
+			const isOpened = openPanels.indexOf( panel ) !== -1;
+			if ( isOpened ) {
+				setOpenPanels( without( openPanels, panel ) );
+			} else {
+				setOpenPanels( [ ...openPanels, panel ] );
+
+				safeSetTimeout( () => {
+					// We need a generic way to access the panel's container
+					scrollIntoView(
+						panels.current[ panel ],
+						inserterResults.current,
+						{
+							alignWithTop: true,
+						}
+					);
+				} );
+			}
+		};
+	};
+
+	// Update the open panels on search
+	useEffect( () => {
+		if ( ! filterValue ) {
+			setOpenPanels( [ 'suggested' ] );
+		}
+		let newOpenPanels = [];
+		if ( reusableItems.length > 0 ) {
+			newOpenPanels.push( 'reusable' );
+		}
+		if ( filteredItems.length > 0 ) {
+			newOpenPanels = newOpenPanels.concat(
+				Object.keys( itemsPerCategory ),
+				Object.keys( itemsPerCollection )
+			);
+		}
+
+		setOpenPanels( newOpenPanels );
+	}, [
+		filterValue,
+		filteredItems,
+		reusableItems,
+		itemsPerCategory,
+		itemsPerCollection,
+	] );
+
+	// Announce search results on change
+	useEffect( () => {
+		const resultCount = Object.keys( itemsPerCategory ).reduce(
+			( accumulator, currentCategorySlug ) => {
+				return (
+					accumulator + itemsPerCategory[ currentCategorySlug ].length
+				);
+			},
+			0
+		);
+
+		const resultsFoundMessage = sprintf(
+			_n( '%d result found.', '%d results found.', resultCount ),
+			resultCount
+		);
+		debouncedSpeak( resultsFoundMessage );
+	}, [ itemsPerCategory, debouncedSpeak ] );
+
+	const isPanelOpen = ( panel ) => openPanels.indexOf( panel ) !== -1;
+
+	const hasItems =
+		! isEmpty( suggestedItems ) ||
+		! isEmpty( reusableItems ) ||
+		! isEmpty( itemsPerCategory ) ||
+		! isEmpty( itemsPerCollection );
+
+	return (
+		<div
+			className="block-editor-inserter__results"
+			ref={ inserterResults }
+			tabIndex="0"
+			role="region"
+			aria-label={ __( 'Available block types' ) }
+		>
+			<ChildBlocks
+				rootClientId={ rootClientId }
+				items={ childItems }
+				onSelect={ onSelectItem }
+				onHover={ onHoverItem }
+			/>
+
+			{ !! suggestedItems.length && (
+				<PanelBody
+					title={ _x( 'Most used', 'blocks' ) }
+					opened={ isPanelOpen( 'suggested' ) }
+					onToggle={ onTogglePanel( 'suggested' ) }
+					ref={ bindPanel( 'suggested' ) }
+				>
+					<BlockTypesList
+						items={ suggestedItems }
+						onSelect={ onSelectItem }
+						onHover={ onHoverItem }
+					/>
+				</PanelBody>
+			) }
+
+			{ map( categories, ( category ) => {
+				const categoryItems = itemsPerCategory[ category.slug ];
+				if ( ! categoryItems || ! categoryItems.length ) {
+					return null;
+				}
+				return (
+					<PanelBody
+						key={ category.slug }
+						title={ category.title }
+						icon={ category.icon }
+						opened={ isPanelOpen( category.slug ) }
+						onToggle={ onTogglePanel( category.slug ) }
+						ref={ bindPanel( category.slug ) }
+					>
+						<BlockTypesList
+							items={ categoryItems }
+							onSelect={ onSelectItem }
+							onHover={ onHoverItem }
+						/>
+					</PanelBody>
+				);
+			} ) }
+
+			{ map( collections, ( collection, namespace ) => {
+				const collectionItems = itemsPerCollection[ namespace ];
+				if ( ! collectionItems || ! collectionItems.length ) {
+					return null;
+				}
+
+				return (
+					<PanelBody
+						key={ namespace }
+						title={ collection.title }
+						icon={ collection.icon }
+						opened={ isPanelOpen( namespace ) }
+						onToggle={ onTogglePanel( namespace ) }
+						ref={ bindPanel( namespace ) }
+					>
+						<BlockTypesList
+							items={ collectionItems }
+							onSelect={ onSelectItem }
+							onHover={ onHoverItem }
+						/>
+					</PanelBody>
+				);
+			} ) }
+
+			{ !! reusableItems.length && (
+				<PanelBody
+					className="block-editor-inserter__reusable-blocks-panel"
+					title={ __( 'Reusable' ) }
+					opened={ isPanelOpen( 'reusable' ) }
+					onToggle={ onTogglePanel( 'reusable' ) }
+					icon={ controlsRepeat }
+					ref={ bindPanel( 'reusable' ) }
+				>
+					<BlockTypesList
+						items={ reusableItems }
+						onSelect={ onSelectItem }
+						onHover={ onHoverItem }
+					/>
+					<a
+						className="block-editor-inserter__manage-reusable-blocks"
+						href={ addQueryArgs( 'edit.php', {
+							post_type: 'wp_block',
+						} ) }
+					>
+						{ __( 'Manage all reusable blocks' ) }
+					</a>
+				</PanelBody>
+			) }
+
+			<__experimentalInserterMenuExtension.Slot
+				fillProps={ {
+					onSelect: onSelectItem,
+					onHover: onHoverItem,
+					filterValue,
+					hasItems,
+				} }
+			>
+				{ ( fills ) => {
+					if ( fills.length ) {
+						return fills;
+					}
+					if ( ! hasItems ) {
+						return (
+							<p className="block-editor-inserter__no-results">
+								{ __( 'No blocks found.' ) }
+							</p>
+						);
+					}
+					return null;
+				} }
+			</__experimentalInserterMenuExtension.Slot>
+		</div>
+	);
+}
+
+export default compose(
+	withSpokenMessages,
+	withSafeTimeout
+)( InserterBlockList );

--- a/packages/block-editor/src/components/inserter/block-list.js
+++ b/packages/block-editor/src/components/inserter/block-list.js
@@ -105,7 +105,7 @@ function InserterBlockList( {
 				categories: getCategories(),
 				collections: getCollections(),
 				rootChildBlocks: getChildBlockNames( destinationRootBlockName ),
-				items: getInserterItems( destinationRootClientId ),
+				items: getInserterItems( destRootClientId ),
 				destinationRootClientId: destRootClientId,
 				fetchReusableBlocks: __experimentalFetchReusableBlocks,
 				...pick( select( 'core/block-editor' ), [

--- a/packages/block-editor/src/components/inserter/block-list.js
+++ b/packages/block-editor/src/components/inserter/block-list.js
@@ -97,9 +97,7 @@ function InserterBlockList( {
 					destRootClientId = getBlockRootClientId( end ) || undefined;
 				}
 			}
-			const destinationRootBlockName = getBlockName(
-				destinationRootClientId
-			);
+			const destinationRootBlockName = getBlockName( destRootClientId );
 
 			const { __experimentalFetchReusableBlocks } = getSettings();
 
@@ -281,6 +279,7 @@ function InserterBlockList( {
 	useEffect( () => {
 		if ( ! filterValue ) {
 			setOpenPanels( [ 'suggested' ] );
+			return;
 		}
 		let newOpenPanels = [];
 		if ( reusableItems.length > 0 ) {

--- a/packages/block-editor/src/components/inserter/block-list.js
+++ b/packages/block-editor/src/components/inserter/block-list.js
@@ -127,7 +127,9 @@ function InserterBlockList( {
 
 	// Fetch resuable blocks on mount
 	useEffect( () => {
-		fetchReusableBlocks();
+		if ( fetchReusableBlocks ) {
+			fetchReusableBlocks();
+		}
 	}, [] );
 
 	// To avoid duplication, getInsertionIndex is extracted and used in two event handlers
@@ -342,7 +344,7 @@ function InserterBlockList( {
 				onHover={ onHoverItem }
 			/>
 
-			{ !! suggestedItems.length && (
+			{ !! suggestedItems.length && ! filterValue && (
 				<PanelBody
 					title={ _x( 'Most used', 'blocks' ) }
 					opened={ isPanelOpen( 'suggested' ) }

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -19,7 +19,7 @@ import InserterBlockList from './block-list';
 
 const stopKeyPropagation = ( event ) => event.stopPropagation();
 
-export function InserterMenu( {
+function InserterMenu( {
 	rootClientId,
 	clientId,
 	isAppender,

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -1,271 +1,35 @@
 /**
  * External dependencies
  */
-import {
-	filter,
-	findIndex,
-	flow,
-	groupBy,
-	isEmpty,
-	map,
-	sortBy,
-	without,
-	includes,
-} from 'lodash';
-import scrollIntoView from 'dom-scroll-into-view';
+import { includes } from 'lodash';
 
 /**
  * WordPress dependencies
  */
-import { speak } from '@wordpress/a11y';
-import { __, _n, _x, sprintf } from '@wordpress/i18n';
-import { Component, createRef } from '@wordpress/element';
-import {
-	PanelBody,
-	withSpokenMessages,
-	VisuallyHidden,
-} from '@wordpress/components';
-import {
-	isReusableBlock,
-	createBlock,
-	isUnmodifiedDefaultBlock,
-	getBlockType,
-	getBlockFromExample,
-} from '@wordpress/blocks';
-import { withDispatch, withSelect } from '@wordpress/data';
-import { withInstanceId, compose, withSafeTimeout } from '@wordpress/compose';
+import { useState } from '@wordpress/element';
 import { LEFT, RIGHT, UP, DOWN, BACKSPACE, ENTER } from '@wordpress/keycodes';
-import { addQueryArgs } from '@wordpress/url';
-import { controlsRepeat } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
-import BlockPreview from '../block-preview';
-import BlockTypesList from '../block-types-list';
-import BlockCard from '../block-card';
-import ChildBlocks from './child-blocks';
 import Tips from './tips';
-import __experimentalInserterMenuExtension from '../inserter-menu-extension';
-import { searchItems } from './search-items';
-
-const MAX_SUGGESTED_ITEMS = 9;
+import InserterSearchForm from './search-form';
+import InserterPreviewPanel from './preview-panel';
+import InserterBlockList from './block-list';
 
 const stopKeyPropagation = ( event ) => event.stopPropagation();
 
-const getBlockNamespace = ( item ) => item.name.split( '/' )[ 0 ];
-
-// Copied over from the Columns block. It seems like it should become part of public API.
-const createBlocksFromInnerBlocksTemplate = ( innerBlocksTemplate ) => {
-	return map(
-		innerBlocksTemplate,
-		( [ name, attributes, innerBlocks = [] ] ) =>
-			createBlock(
-				name,
-				attributes,
-				createBlocksFromInnerBlocksTemplate( innerBlocks )
-			)
-	);
-};
-
-export class InserterMenu extends Component {
-	constructor() {
-		super( ...arguments );
-		this.state = {
-			childItems: [],
-			filterValue: '',
-			hoveredItem: null,
-			suggestedItems: [],
-			reusableItems: [],
-			itemsPerCategory: {},
-			itemsPerCollection: {},
-			openPanels: [ 'suggested' ],
-		};
-		this.onChangeSearchInput = this.onChangeSearchInput.bind( this );
-		this.onHover = this.onHover.bind( this );
-		this.panels = {};
-		this.inserterResults = createRef();
-	}
-
-	componentDidMount() {
-		if ( this.props.fetchReusableBlocks ) {
-			this.props.fetchReusableBlocks();
-		}
-		this.filter();
-	}
-
-	componentDidUpdate( prevProps ) {
-		if ( prevProps.items !== this.props.items ) {
-			this.filter( this.state.filterValue );
-		}
-	}
-
-	onChangeSearchInput( event ) {
-		this.filter( event.target.value );
-	}
-
-	onHover( item ) {
-		this.setState( {
-			hoveredItem: item,
-		} );
-
-		const { showInsertionPoint, hideInsertionPoint } = this.props;
-		if ( item ) {
-			showInsertionPoint();
-		} else {
-			hideInsertionPoint();
-		}
-	}
-
-	bindPanel( name ) {
-		return ( ref ) => {
-			this.panels[ name ] = ref;
-		};
-	}
-
-	onTogglePanel( panel ) {
-		return () => {
-			const isOpened = this.state.openPanels.indexOf( panel ) !== -1;
-			if ( isOpened ) {
-				this.setState( {
-					openPanels: without( this.state.openPanels, panel ),
-				} );
-			} else {
-				this.setState( {
-					openPanels: [ ...this.state.openPanels, panel ],
-				} );
-
-				this.props.setTimeout( () => {
-					// We need a generic way to access the panel's container
-					scrollIntoView(
-						this.panels[ panel ],
-						this.inserterResults.current,
-						{
-							alignWithTop: true,
-						}
-					);
-				} );
-			}
-		};
-	}
-
-	filterOpenPanels(
-		filterValue,
-		itemsPerCategory,
-		itemsPerCollection,
-		filteredItems,
-		reusableItems
-	) {
-		if ( filterValue === this.state.filterValue ) {
-			return this.state.openPanels;
-		}
-		if ( ! filterValue ) {
-			return [ 'suggested' ];
-		}
-		let openPanels = [];
-		if ( reusableItems.length > 0 ) {
-			openPanels.push( 'reusable' );
-		}
-		if ( filteredItems.length > 0 ) {
-			openPanels = openPanels.concat(
-				Object.keys( itemsPerCategory ),
-				Object.keys( itemsPerCollection )
-			);
-		}
-
-		return openPanels;
-	}
-
-	filter( filterValue = '' ) {
-		const {
-			categories,
-			collections,
-			debouncedSpeak,
-			items,
-			rootChildBlocks,
-		} = this.props;
-
-		const filteredItems = searchItems(
-			items,
-			categories,
-			collections,
-			filterValue
-		);
-
-		const childItems = filter( filteredItems, ( { name } ) =>
-			includes( rootChildBlocks, name )
-		);
-
-		let suggestedItems = [];
-		if ( ! filterValue ) {
-			const maxSuggestedItems =
-				this.props.maxSuggestedItems || MAX_SUGGESTED_ITEMS;
-			suggestedItems = filter(
-				items,
-				( item ) => item.utility > 0
-			).slice( 0, maxSuggestedItems );
-		}
-
-		const reusableItems = filter( filteredItems, { category: 'reusable' } );
-
-		const getCategoryIndex = ( item ) => {
-			return findIndex(
-				categories,
-				( category ) => category.slug === item.category
-			);
-		};
-		const itemsPerCategory = flow(
-			( itemList ) =>
-				filter( itemList, ( item ) => item.category !== 'reusable' ),
-			( itemList ) => sortBy( itemList, getCategoryIndex ),
-			( itemList ) => groupBy( itemList, 'category' )
-		)( filteredItems );
-
-		// Create a new Object to avoid mutating this.props.collection
-		const itemsPerCollection = { ...collections };
-		Object.keys( collections ).forEach( ( namespace ) => {
-			itemsPerCollection[ namespace ] = filteredItems.filter(
-				( item ) => getBlockNamespace( item ) === namespace
-			);
-			if ( itemsPerCollection[ namespace ].length === 0 ) {
-				delete itemsPerCollection[ namespace ];
-			}
-		} );
-
-		this.setState( {
-			hoveredItem: null,
-			childItems,
-			filterValue,
-			suggestedItems,
-			reusableItems,
-			itemsPerCategory,
-			itemsPerCollection,
-			openPanels: this.filterOpenPanels(
-				filterValue,
-				itemsPerCategory,
-				itemsPerCollection,
-				filteredItems,
-				reusableItems
-			),
-		} );
-
-		const resultCount = Object.keys( itemsPerCategory ).reduce(
-			( accumulator, currentCategorySlug ) => {
-				return (
-					accumulator + itemsPerCategory[ currentCategorySlug ].length
-				);
-			},
-			0
-		);
-
-		const resultsFoundMessage = sprintf(
-			_n( '%d result found.', '%d results found.', resultCount ),
-			resultCount
-		);
-		debouncedSpeak( resultsFoundMessage );
-	}
-
-	onKeyDown( event ) {
+export function InserterMenu( {
+	rootClientId,
+	clientId,
+	isAppender,
+	__experimentalSelectBlockOnInsert,
+	onSelect,
+	showInserterHelpPanel,
+} ) {
+	const [ filterValue, setFilterValue ] = useState( '' );
+	const [ hoveredItem, setHoveredItem ] = useState( null );
+	const onKeyDown = ( event ) => {
 		if (
 			includes(
 				[ LEFT, DOWN, RIGHT, UP, BACKSPACE, ENTER ],
@@ -275,379 +39,45 @@ export class InserterMenu extends Component {
 			// Stop the key event from propagating up to ObserveTyping.startTypingInTextField.
 			event.stopPropagation();
 		}
-	}
+	};
 
-	render() {
-		const {
-			categories,
-			collections,
-			instanceId,
-			onSelect,
-			rootClientId,
-			showInserterHelpPanel,
-		} = this.props;
-		const {
-			childItems,
-			hoveredItem,
-			itemsPerCategory,
-			itemsPerCollection,
-			openPanels,
-			reusableItems,
-			suggestedItems,
-			filterValue,
-		} = this.state;
-		const isPanelOpen = ( panel ) => openPanels.indexOf( panel ) !== -1;
-		const hasItems =
-			! isEmpty( suggestedItems ) ||
-			! isEmpty( reusableItems ) ||
-			! isEmpty( itemsPerCategory ) ||
-			! isEmpty( itemsPerCollection );
-		const hoveredItemBlockType = hoveredItem
-			? getBlockType( hoveredItem.name )
-			: null;
-		const hasHelpPanel = hasItems && showInserterHelpPanel;
-
-		// Disable reason (no-autofocus): The inserter menu is a modal display, not one which
-		// is always visible, and one which already incurs this behavior of autoFocus via
-		// Popover's focusOnMount.
-		// Disable reason (no-static-element-interactions): Navigational key-presses within
-		// the menu are prevented from triggering WritingFlow and ObserveTyping interactions.
-		/* eslint-disable jsx-a11y/no-autofocus, jsx-a11y/no-static-element-interactions */
-		return (
-			<div
-				className="block-editor-inserter__menu"
-				onKeyPress={ stopKeyPropagation }
-				onKeyDown={ this.onKeyDown }
-			>
-				<div className="block-editor-inserter__main-area">
-					<VisuallyHidden
-						as="label"
-						htmlFor={ `block-editor-inserter__search-${ instanceId }` }
-					>
-						{ __( 'Search for a block' ) }
-					</VisuallyHidden>
-					<input
-						id={ `block-editor-inserter__search-${ instanceId }` }
-						type="search"
-						placeholder={ __( 'Search for a block' ) }
-						className="block-editor-inserter__search"
-						autoFocus
-						onChange={ this.onChangeSearchInput }
-					/>
-
-					<div
-						className="block-editor-inserter__results"
-						ref={ this.inserterResults }
-						tabIndex="0"
-						role="region"
-						aria-label={ __( 'Available block types' ) }
-					>
-						<ChildBlocks
-							rootClientId={ rootClientId }
-							items={ childItems }
-							onSelect={ onSelect }
-							onHover={ this.onHover }
-						/>
-
-						{ !! suggestedItems.length && (
-							<PanelBody
-								title={ _x( 'Most used', 'blocks' ) }
-								opened={ isPanelOpen( 'suggested' ) }
-								onToggle={ this.onTogglePanel( 'suggested' ) }
-								ref={ this.bindPanel( 'suggested' ) }
-							>
-								<BlockTypesList
-									items={ suggestedItems }
-									onSelect={ onSelect }
-									onHover={ this.onHover }
-								/>
-							</PanelBody>
-						) }
-
-						{ map( categories, ( category ) => {
-							const categoryItems =
-								itemsPerCategory[ category.slug ];
-							if ( ! categoryItems || ! categoryItems.length ) {
-								return null;
-							}
-							return (
-								<PanelBody
-									key={ category.slug }
-									title={ category.title }
-									icon={ category.icon }
-									opened={ isPanelOpen( category.slug ) }
-									onToggle={ this.onTogglePanel(
-										category.slug
-									) }
-									ref={ this.bindPanel( category.slug ) }
-								>
-									<BlockTypesList
-										items={ categoryItems }
-										onSelect={ onSelect }
-										onHover={ this.onHover }
-									/>
-								</PanelBody>
-							);
-						} ) }
-
-						{ map( collections, ( collection, namespace ) => {
-							const collectionItems =
-								itemsPerCollection[ namespace ];
-							if (
-								! collectionItems ||
-								! collectionItems.length
-							) {
-								return null;
-							}
-
-							return (
-								<PanelBody
-									key={ namespace }
-									title={ collection.title }
-									icon={ collection.icon }
-									opened={ isPanelOpen( namespace ) }
-									onToggle={ this.onTogglePanel( namespace ) }
-									ref={ this.bindPanel( namespace ) }
-								>
-									<BlockTypesList
-										items={ collectionItems }
-										onSelect={ onSelect }
-										onHover={ this.onHover }
-									/>
-								</PanelBody>
-							);
-						} ) }
-
-						{ !! reusableItems.length && (
-							<PanelBody
-								className="block-editor-inserter__reusable-blocks-panel"
-								title={ __( 'Reusable' ) }
-								opened={ isPanelOpen( 'reusable' ) }
-								onToggle={ this.onTogglePanel( 'reusable' ) }
-								icon={ controlsRepeat }
-								ref={ this.bindPanel( 'reusable' ) }
-							>
-								<BlockTypesList
-									items={ reusableItems }
-									onSelect={ onSelect }
-									onHover={ this.onHover }
-								/>
-								<a
-									className="block-editor-inserter__manage-reusable-blocks"
-									href={ addQueryArgs( 'edit.php', {
-										post_type: 'wp_block',
-									} ) }
-								>
-									{ __( 'Manage all reusable blocks' ) }
-								</a>
-							</PanelBody>
-						) }
-
-						<__experimentalInserterMenuExtension.Slot
-							fillProps={ {
-								onSelect,
-								onHover: this.onHover,
-								filterValue,
-								hasItems,
-							} }
-						>
-							{ ( fills ) => {
-								if ( fills.length ) {
-									return fills;
-								}
-								if ( ! hasItems ) {
-									return (
-										<p className="block-editor-inserter__no-results">
-											{ __( 'No blocks found.' ) }
-										</p>
-									);
-								}
-								return null;
-							} }
-						</__experimentalInserterMenuExtension.Slot>
-					</div>
-					{ showInserterHelpPanel && (
-						<div className="block-editor-inserter__tips">
-							<Tips />
-						</div>
-					) }
-				</div>
-				{ hasHelpPanel && hoveredItem && (
-					<div className="block-editor-inserter__menu-help-panel">
-						{ ! isReusableBlock( hoveredItem ) && (
-							<BlockCard blockType={ hoveredItem } />
-						) }
-						<div className="block-editor-inserter__preview">
-							{ isReusableBlock( hoveredItem ) ||
-							hoveredItemBlockType.example ? (
-								<div className="block-editor-inserter__preview-content">
-									<BlockPreview
-										padding={ 10 }
-										viewportWidth={ 500 }
-										blocks={
-											hoveredItemBlockType.example
-												? getBlockFromExample(
-														hoveredItem.name,
-														{
-															attributes: {
-																...hoveredItemBlockType
-																	.example
-																	.attributes,
-																...hoveredItem.initialAttributes,
-															},
-															innerBlocks:
-																hoveredItemBlockType
-																	.example
-																	.innerBlocks,
-														}
-												  )
-												: createBlock(
-														hoveredItem.name,
-														hoveredItem.initialAttributes
-												  )
-										}
-										autoHeight
-									/>
-								</div>
-							) : (
-								<div className="block-editor-inserter__preview-content-missing">
-									{ __( 'No Preview Available.' ) }
-								</div>
-							) }
-						</div>
+	// Disable reason (no-autofocus): The inserter menu is a modal display, not one which
+	// is always visible, and one which already incurs this behavior of autoFocus via
+	// Popover's focusOnMount.
+	// Disable reason (no-static-element-interactions): Navigational key-presses within
+	// the menu are prevented from triggering WritingFlow and ObserveTyping interactions.
+	/* eslint-disable jsx-a11y/no-autofocus, jsx-a11y/no-static-element-interactions */
+	return (
+		<div
+			className="block-editor-inserter__menu"
+			onKeyPress={ stopKeyPropagation }
+			onKeyDown={ onKeyDown }
+		>
+			<div className="block-editor-inserter__main-area">
+				<InserterSearchForm onChange={ setFilterValue } />
+				<InserterBlockList
+					rootClientId={ rootClientId }
+					clientId={ clientId }
+					isAppender={ isAppender }
+					onSelect={ onSelect }
+					onHover={ setHoveredItem }
+					__experimentalSelectBlockOnInsert={
+						__experimentalSelectBlockOnInsert
+					}
+					filterValue={ filterValue }
+				/>
+				{ showInserterHelpPanel && (
+					<div className="block-editor-inserter__tips">
+						<Tips />
 					</div>
 				) }
 			</div>
-		);
-		/* eslint-enable jsx-a11y/no-autofocus, jsx-a11y/no-static-element-interactions */
-	}
+			{ showInserterHelpPanel && hoveredItem && (
+				<InserterPreviewPanel item={ hoveredItem } />
+			) }
+		</div>
+	);
+	/* eslint-enable jsx-a11y/no-autofocus, jsx-a11y/no-static-element-interactions */
 }
 
-export default compose(
-	withSelect( ( select, { clientId, isAppender, rootClientId } ) => {
-		const {
-			getInserterItems,
-			getBlockName,
-			getBlockRootClientId,
-			getBlockSelectionEnd,
-			getSettings,
-		} = select( 'core/block-editor' );
-		const { getCategories, getCollections, getChildBlockNames } = select(
-			'core/blocks'
-		);
-
-		let destinationRootClientId = rootClientId;
-		if ( ! destinationRootClientId && ! clientId && ! isAppender ) {
-			const end = getBlockSelectionEnd();
-			if ( end ) {
-				destinationRootClientId =
-					getBlockRootClientId( end ) || undefined;
-			}
-		}
-		const destinationRootBlockName = getBlockName(
-			destinationRootClientId
-		);
-
-		const {
-			__experimentalFetchReusableBlocks: fetchReusableBlocks,
-		} = getSettings();
-
-		return {
-			categories: getCategories(),
-			collections: getCollections(),
-			rootChildBlocks: getChildBlockNames( destinationRootBlockName ),
-			items: getInserterItems( destinationRootClientId ),
-			destinationRootClientId,
-			fetchReusableBlocks,
-		};
-	} ),
-	withDispatch( ( dispatch, ownProps, { select } ) => {
-		const { showInsertionPoint, hideInsertionPoint } = dispatch(
-			'core/block-editor'
-		);
-
-		// To avoid duplication, getInsertionIndex is extracted and used in two event handlers
-		// This breaks the withDispatch not containing any logic rule.
-		// Since it's a function only called when the event handlers are called,
-		// it's fine to extract it.
-		// eslint-disable-next-line no-restricted-syntax
-		function getInsertionIndex() {
-			const {
-				getBlockIndex,
-				getBlockSelectionEnd,
-				getBlockOrder,
-			} = select( 'core/block-editor' );
-			const { clientId, destinationRootClientId, isAppender } = ownProps;
-
-			// If the clientId is defined, we insert at the position of the block.
-			if ( clientId ) {
-				return getBlockIndex( clientId, destinationRootClientId );
-			}
-
-			// If there a selected block, we insert after the selected block.
-			const end = getBlockSelectionEnd();
-			if ( ! isAppender && end ) {
-				return getBlockIndex( end, destinationRootClientId ) + 1;
-			}
-
-			// Otherwise, we insert at the end of the current rootClientId
-			return getBlockOrder( destinationRootClientId ).length;
-		}
-
-		return {
-			showInsertionPoint() {
-				const index = getInsertionIndex();
-				showInsertionPoint( ownProps.destinationRootClientId, index );
-			},
-			hideInsertionPoint,
-			onSelect( item ) {
-				const { replaceBlocks, insertBlock } = dispatch(
-					'core/block-editor'
-				);
-				const { getSelectedBlock } = select( 'core/block-editor' );
-				const {
-					isAppender,
-					onSelect,
-					__experimentalSelectBlockOnInsert: selectBlockOnInsert,
-				} = ownProps;
-				const { name, title, initialAttributes, innerBlocks } = item;
-				const selectedBlock = getSelectedBlock();
-				const insertedBlock = createBlock(
-					name,
-					initialAttributes,
-					createBlocksFromInnerBlocksTemplate( innerBlocks )
-				);
-
-				if (
-					! isAppender &&
-					selectedBlock &&
-					isUnmodifiedDefaultBlock( selectedBlock )
-				) {
-					replaceBlocks( selectedBlock.clientId, insertedBlock );
-				} else {
-					insertBlock(
-						insertedBlock,
-						getInsertionIndex(),
-						ownProps.destinationRootClientId,
-						selectBlockOnInsert
-					);
-
-					if ( ! selectBlockOnInsert ) {
-						// translators: %s: the name of the block that has been added
-						const message = sprintf(
-							__( '%s block added' ),
-							title
-						);
-						speak( message );
-					}
-				}
-
-				onSelect();
-				return insertedBlock;
-			},
-		};
-	} ),
-	withSpokenMessages,
-	withInstanceId,
-	withSafeTimeout
-)( InserterMenu );
+export default InserterMenu;

--- a/packages/block-editor/src/components/inserter/preview-panel.js
+++ b/packages/block-editor/src/components/inserter/preview-panel.js
@@ -1,0 +1,59 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	isReusableBlock,
+	createBlock,
+	getBlockFromExample,
+	getBlockType,
+} from '@wordpress/blocks';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import BlockCard from '../block-card';
+import BlockPreview from '../block-preview';
+
+function InserterPreviewPanel( { item } ) {
+	const hoveredItemBlockType = getBlockType( item.name );
+	return (
+		<div className="block-editor-inserter__menu-help-panel">
+			{ ! isReusableBlock( item ) && <BlockCard blockType={ item } /> }
+			<div className="block-editor-inserter__preview">
+				{ isReusableBlock( item ) || hoveredItemBlockType.example ? (
+					<div className="block-editor-inserter__preview-content">
+						<BlockPreview
+							padding={ 10 }
+							viewportWidth={ 500 }
+							blocks={
+								hoveredItemBlockType.example
+									? getBlockFromExample( item.name, {
+											attributes: {
+												...hoveredItemBlockType.example
+													.attributes,
+												...item.initialAttributes,
+											},
+											innerBlocks:
+												hoveredItemBlockType.example
+													.innerBlocks,
+									  } )
+									: createBlock(
+											item.name,
+											item.initialAttributes
+									  )
+							}
+							autoHeight
+						/>
+					</div>
+				) : (
+					<div className="block-editor-inserter__preview-content-missing">
+						{ __( 'No Preview Available.' ) }
+					</div>
+				) }
+			</div>
+		</div>
+	);
+}
+
+export default InserterPreviewPanel;

--- a/packages/block-editor/src/components/inserter/search-form.js
+++ b/packages/block-editor/src/components/inserter/search-form.js
@@ -1,0 +1,36 @@
+/**
+ * WordPress dependencies
+ */
+import { useInstanceId } from '@wordpress/compose';
+import { __ } from '@wordpress/i18n';
+import { VisuallyHidden } from '@wordpress/components';
+
+function InserterSearchForm( { onChange } ) {
+	const instanceId = useInstanceId( InserterSearchForm );
+
+	// Disable reason (no-autofocus): The inserter menu is a modal display, not one which
+	// is always visible, and one which already incurs this behavior of autoFocus via
+	// Popover's focusOnMount.
+	/* eslint-disable jsx-a11y/no-autofocus */
+	return (
+		<>
+			<VisuallyHidden
+				as="label"
+				htmlFor={ `block-editor-inserter__search-${ instanceId }` }
+			>
+				{ __( 'Search for a block' ) }
+			</VisuallyHidden>
+			<input
+				id={ `block-editor-inserter__search-${ instanceId }` }
+				type="search"
+				placeholder={ __( 'Search for a block' ) }
+				className="block-editor-inserter__search"
+				autoFocus
+				onChange={ ( event ) => onChange( event.target.value ) }
+			/>
+		</>
+	);
+	/* eslint-enable jsx-a11y/no-autofocus */
+}
+
+export default InserterSearchForm;


### PR DESCRIPTION
To prepare the addition of the block patterns into the Main Block Inserter, this PR refactors the code base of the InserterMenu component and split it into separate smaller components.
It rewrites some of it with React hooks at the same time.

**Testing instructions**

 - Try using the inserter, it should work as usual. No behavior change.