### PR TITLE
Remove toolbar left separator for the Inserter/undo/redo toolbar on mobile

### DIFF
--- a/packages/components/src/toolbar-group/style.native.scss
+++ b/packages/components/src/toolbar-group/style.native.scss
@@ -1,11 +1,14 @@
 .container {
 	flex-direction: row;
-	border-left-width: 1px;
-	border-color: #e9eff3;
 	padding-left: 5px;
 	padding-right: 5px;
 }
 
 .containerDark {
 	border-color: #525354;
+}
+
+.leftSeparator {
+	border-left-width: 1px;
+	border-color: #e9eff3;
 }

--- a/packages/components/src/toolbar-group/toolbar-group-container.native.js
+++ b/packages/components/src/toolbar-group/toolbar-group-container.native.js
@@ -17,11 +17,13 @@ const ToolbarGroupContainer = ( {
 	getStylesFromColorScheme,
 	passedStyle,
 	children,
+	...props
 } ) => (
 	<View
 		style={ [
 			getStylesFromColorScheme( styles.container, styles.containerDark ),
 			passedStyle,
+			! props.noLeftSeparator && styles.leftSeparator,
 		] }
 	>
 		{ children }

--- a/packages/edit-post/src/components/header/header-toolbar/index.native.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.native.js
@@ -56,7 +56,7 @@ function HeaderToolbar( {
 				alwaysBounceHorizontal={ false }
 				contentContainerStyle={ styles.scrollableContent }
 			>
-				<Toolbar accessible={ false }>
+				<Toolbar accessible={ false } noLeftSeparator >
 					<Inserter disabled={ ! showInserter } />
 					{ /* TODO: replace with EditorHistoryRedo and EditorHistoryUndo */ }
 					<ToolbarButton


### PR DESCRIPTION
## Description
Introduces a `noLeftSeparator` prop to the native mobile version of the `ToolbarGroup` component and uses it in the native mobile "Header Toolbar" to remove the excess left border. Essentially fixing issue https://github.com/wordpress-mobile/gutenberg-mobile/issues/639.

## How has this been tested?
Using the gutenberg-mobile PR: TBD

## Types of changes
1. Introduces a `noLeftSeparator` prop to the native mobile version of the `ToolbarGroup` component
2. Breaks out the border-left width and color styles from the `.container` style into a dedicated `.leftSeparator` style to be used only if `noLeftSeparator` is falsy.
3. Uses the `noLeftSeparator` prop in the mobile header-toolbar component to remove the left border from the toolbar that hosts the Inserter button

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
