### PR TITLE
Update page template picker after design review

### DIFF
--- a/packages/block-editor/src/components/block-list/index.native.js
+++ b/packages/block-editor/src/components/block-list/index.native.js
@@ -130,7 +130,7 @@ export class BlockList extends Component {
 						this.shouldFlatListPreventAutomaticScroll
 					}
 					title={ title }
-					ListHeaderComponent={ ! isReadOnly && header }
+					ListHeaderComponent={ header }
 					ListEmptyComponent={
 						! isReadOnly && this.renderDefaultBlockAppender
 					}

--- a/packages/block-editor/src/components/page-template-picker/preview.native.js
+++ b/packages/block-editor/src/components/page-template-picker/preview.native.js
@@ -32,16 +32,12 @@ const BlockPreview = ( { blocks } ) => {
 		readOnly: true,
 	};
 
-	const spaceView = () => {
-		return (
-			<View style={ { flex: 0, height: 12}} />
-		);
-	}
+	const header = <View style={ styles.previewHeader } />;
 
 	return (
 		<BlockEditorProvider value={ blocks } settings={ settings }>
 			<View style={ { flex: 1 } }>
-				<BlockList header={ spaceView() }/>
+				<BlockList header={ header } />
 			</View>
 		</BlockEditorProvider>
 	);

--- a/packages/block-editor/src/components/page-template-picker/preview.native.js
+++ b/packages/block-editor/src/components/page-template-picker/preview.native.js
@@ -3,7 +3,7 @@
  */
 import { BlockEditorProvider, BlockList } from '@wordpress/block-editor';
 import { ModalHeaderBar } from '@wordpress/components';
-import { usePreferredColorScheme } from '@wordpress/compose';
+import { usePreferredColorSchemeStyle } from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
@@ -11,6 +11,11 @@ import { __ } from '@wordpress/i18n';
  * External dependencies
  */
 import { Modal, View, SafeAreaView } from 'react-native';
+
+/**
+ * Internal dependencies
+ */
+import styles from './styles.scss';
 
 // We are replicating this here because the one in @wordpress/block-editor always
 // tries to scale the preview and we would need a lot of cross platform code to handle
@@ -39,9 +44,10 @@ BlockPreview.displayName = 'BlockPreview';
 
 const Preview = ( props ) => {
 	const { template, onDismiss, onApply } = props;
-	const preferredColorScheme = usePreferredColorScheme();
-	const containerBackgroundColor =
-		preferredColorScheme === 'dark' ? 'black' : 'white';
+	const previewContainerStyle = usePreferredColorSchemeStyle(
+		styles.previewContainer,
+		styles.previewContainerDark
+	);
 
 	if ( template === undefined ) {
 		return null;
@@ -64,9 +70,7 @@ const Preview = ( props ) => {
 			onRequestClose={ onDismiss }
 			supportedOrientations={ [ 'portrait', 'landscape' ] }
 		>
-			<SafeAreaView
-				style={ { flex: 1, backgroundColor: containerBackgroundColor } }
-			>
+			<SafeAreaView style={ previewContainerStyle }>
 				<ModalHeaderBar
 					leftButton={ leftButton }
 					rightButton={ rightButton }

--- a/packages/block-editor/src/components/page-template-picker/preview.native.js
+++ b/packages/block-editor/src/components/page-template-picker/preview.native.js
@@ -32,10 +32,16 @@ const BlockPreview = ( { blocks } ) => {
 		readOnly: true,
 	};
 
+	const spaceView = () => {
+		return (
+			<View style={ { flex: 0, height: 12}} />
+		);
+	}
+
 	return (
 		<BlockEditorProvider value={ blocks } settings={ settings }>
 			<View style={ { flex: 1 } }>
-				<BlockList />
+				<BlockList header={ spaceView() }/>
 			</View>
 		</BlockEditorProvider>
 	);

--- a/packages/block-editor/src/components/page-template-picker/styles.native.scss
+++ b/packages/block-editor/src/components/page-template-picker/styles.native.scss
@@ -34,3 +34,12 @@
 .buttonTextDark {
 	color: $light-opacity-700;
 }
+
+.previewContainer {
+	flex: 1;
+	background-color: $white;
+}
+
+.previewContainerDark {
+	background-color: $black;
+}

--- a/packages/block-editor/src/components/page-template-picker/styles.native.scss
+++ b/packages/block-editor/src/components/page-template-picker/styles.native.scss
@@ -43,3 +43,8 @@
 .previewContainerDark {
 	background-color: $black;
 }
+
+.previewHeader {
+	flex: 0;
+	height: 15px;
+}

--- a/packages/components/src/mobile/modal-header-bar/styles.native.scss
+++ b/packages/components/src/mobile/modal-header-bar/styles.native.scss
@@ -8,7 +8,7 @@
 }
 
 .subtitleBar {
-	height: 64px;
+	height: 56px;
 }
 
 .leftContainer {

--- a/packages/compose/src/hooks/use-preferred-color-scheme-style/index.native.js
+++ b/packages/compose/src/hooks/use-preferred-color-scheme-style/index.native.js
@@ -1,0 +1,33 @@
+/**
+ * Internal dependencies
+ */
+import usePreferredColorScheme from '../use-preferred-color-scheme';
+
+/**
+ * Selects which of the passed style objects should be applied depending on the
+ * user's preferred color scheme.
+ *
+ * The "light" color schemed is assumed to be the default, and its styles are
+ * always applied. The "dark" styles will always extend those defined for the
+ * light case.
+ *
+ * @example
+ * const light = { padding: 10, backgroundColor: 'white' };
+ * const dark = { backgroundColor: 'black' };
+ * usePreferredColorSchemeStyle( light, dark);
+ * // On light mode:
+ * // => { padding: 10, backgroundColor: 'white' }
+ * // On dark mode:
+ * // => { padding: 10, backgroundColor: 'black' }
+ * @param {Object} lightStyle
+ * @param {Object} darkStyle
+ * @return {Object} the combined styles depending on the current color scheme
+ */
+const usePreferredColorSchemeStyle = ( lightStyle, darkStyle ) => {
+	const colorScheme = usePreferredColorScheme();
+	const isDarkMode = colorScheme === 'dark';
+
+	return isDarkMode ? { ...lightStyle, ...darkStyle } : lightStyle;
+};
+
+export default usePreferredColorSchemeStyle;

--- a/packages/compose/src/hooks/use-viewport-match/index.js
+++ b/packages/compose/src/hooks/use-viewport-match/index.js
@@ -63,7 +63,7 @@ const ViewportMatchWidthContext = createContext( null );
  * @example
  *
  * ```js
- * useViewportMatch( 'huge', <' );
+ * useViewportMatch( 'huge', '<' );
  * useViewportMatch( 'medium' );
  * ```
  *

--- a/packages/compose/src/index.native.js
+++ b/packages/compose/src/index.native.js
@@ -6,4 +6,5 @@ export { default as withPreferredColorScheme } from './higher-order/with-preferr
 
 // Hooks
 export { default as usePreferredColorScheme } from './hooks/use-preferred-color-scheme';
+export { default as usePreferredColorSchemeStyle } from './hooks/use-preferred-color-scheme-style';
 export { default as useResizeObserver } from './hooks/use-resize-observer';


### PR DESCRIPTION
## Description

Fixes some of the items in https://github.com/wordpress-mobile/gutenberg-mobile/issues/2012
Gutenberg Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/2020
<!-- Please describe what you have changed or added -->

This PR adjusts the modal header bar and adds some padding to the template preview so it aligns with where the editor content would start if it had a title:

![Screen Shot 2020-03-13 at 16 07 26](https://user-images.githubusercontent.com/8739/76737258-bf2eda80-6768-11ea-9631-d370e67e3862.png)

It also introduces a new `usePreferredColorSchemeStyle` hook to make dark mode support a bit nicer in functional components.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
