### PR TITLE
Navigation block: show color controls in toolbar only.

### DIFF
--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -57,14 +57,7 @@ function Navigation( {
 	//
 	const ref = useRef();
 	const { selectBlock } = useDispatch( 'core/block-editor' );
-
-	/* eslint-disable @wordpress/no-unused-vars-before-return */
-	const {
-		TextColor,
-		BackgroundColor,
-		InspectorControlsColorPanel,
-		ColorPanel,
-	} = __experimentalUseColors(
+	const { TextColor, BackgroundColor, ColorPanel } = __experimentalUseColors(
 		[
 			{ name: 'textColor', property: 'color' },
 			{ name: 'backgroundColor', className: 'has-background' },
@@ -84,7 +77,6 @@ function Navigation( {
 		},
 		[ fontSize.size ]
 	);
-	/* eslint-enable @wordpress/no-unused-vars-before-return */
 
 	const { navigatorToolbarButton, navigatorModal } = useBlockNavigator(
 		clientId
@@ -261,7 +253,6 @@ function Navigation( {
 					/>
 				</PanelBody>
 			</InspectorControls>
-			{ InspectorControlsColorPanel }
 			<InspectorControls>
 				<PanelBody title={ __( 'Display settings' ) }>
 					<ToggleControl


### PR DESCRIPTION
## Description
Closes #20845. Removes the color controls from the inspector, while keeping the ones in the toolbar.

![image](https://user-images.githubusercontent.com/19592990/76638960-556dc100-651b-11ea-868a-74625f5215ab.png)