### PR TITLE
Site Editor: style resets for top level page

### DIFF
--- a/lib/edit-site-page.php
+++ b/lib/edit-site-page.php
@@ -21,6 +21,22 @@ function gutenberg_edit_site_page() {
 }
 
 /**
+ * Checks whether the provided page is one of allowed Site Editor pages.
+ *
+ * @param string $page Page to check.
+ *
+ * @return bool True for Site Editor pages, false otherwise.
+ */
+function gutenberg_is_edit_site_page( $page ) {
+	$allowed_pages = array(
+		'gutenberg_page_gutenberg-edit-site',
+		'toplevel_page_gutenberg-edit-site',
+	);
+
+	return in_array( $page, $allowed_pages, true );
+}
+
+/**
  * Initialize the Gutenberg Edit Site Page.
  *
  * @since 7.2.0
@@ -35,10 +51,7 @@ function gutenberg_edit_site_init( $hook ) {
 		$_wp_current_template_hierarchy,
 		$_wp_current_template_part_ids;
 
-	$allowed_hooks = array( 'gutenberg_page_gutenberg-edit-site' );
-	$allowed_hooks = apply_filters( 'site_editor_allowed_hooks', $allowed_hooks );
-
-	if ( ! in_array( $hook, $allowed_hooks, true ) ) {
+	if ( ! gutenberg_is_edit_site_page( $hook ) ) {
 		return;
 	}
 

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -266,8 +266,7 @@ function gutenberg_experimental_global_styles_is_site_editor() {
 	}
 
 	$screen = get_current_screen();
-	return ! empty( $screen ) &&
-		( 'gutenberg_page_gutenberg-edit-site' === $screen->id );
+	return ! empty( $screen ) && gutenberg_is_edit_site_page( $screen->id );
 }
 
 /**

--- a/lib/widgets.php
+++ b/lib/widgets.php
@@ -21,7 +21,7 @@ function gutenberg_is_block_editor() {
 		(
 			$screen->is_block_editor() ||
 			'gutenberg_page_gutenberg-widgets' === $screen->id ||
-			'gutenberg_page_gutenberg-edit-site' === $screen->id
+			gutenberg_is_edit_site_page( $screen->id )
 		);
 }
 

--- a/packages/edit-site/src/style.scss
+++ b/packages/edit-site/src/style.scss
@@ -10,7 +10,8 @@ html.wp-toolbar {
 	background: $white;
 }
 
-body.gutenberg_page_gutenberg-edit-site {
+body.gutenberg_page_gutenberg-edit-site,
+body.toplevel_page_gutenberg-edit-site {
 	@include wp-admin-reset(".edit-site");
 }
 


### PR DESCRIPTION
## Description

Allow Site Editor to be loaded as a top level page. So far the style resets only worked when this page has been added as submenu item of Gutenberg menu.

## How has this been tested?

There are no functional or visual changes. Smoke tested the affected experimental sections to make sure they still work as before.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
