### PR TITLE
Editor: PostTitle: Decode entities for display

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -696,6 +696,12 @@
 		"parent": "components"
 	},
 	{
+		"title": "DetectFocusOutside",
+		"slug": "detect-focus-outside",
+		"markdown_source": "../packages/components/src/detect-focus-outside/README.md",
+		"parent": "components"
+	},
+	{
 		"title": "DimensionControl",
 		"slug": "dimension-control",
 		"markdown_source": "../packages/components/src/dimension-control/README.md",

--- a/packages/components/src/detect-focus-outside/README.md
+++ b/packages/components/src/detect-focus-outside/README.md
@@ -1,8 +1,8 @@
 # DetectFocusOutside
 
-`DetectFocusOutside` is a component used to help detect when focus leaves an element.
+`DetectFocusOutside` is a component used to help detect when focus leaves a component tree.
 
-This can be useful to disambiguate focus transitions within the same element. A React `blur` event will fire even when focus transitions to another element in the same context. `DetectFocusOutside` will only invoke its callback prop when focus has truly left the element.
+This is useful to detect whether focus has transitioned to another element outside a particular component tree, in which case DetectFocusOutside will invoke the onFocusOutside callback. This is unlike React's `onBlur`, which will be invoked even when focus transitions to another element in the same component tree.
 
 ## Usage
 

--- a/packages/components/src/detect-focus-outside/README.md
+++ b/packages/components/src/detect-focus-outside/README.md
@@ -1,0 +1,36 @@
+# DetectFocusOutside
+
+`DetectFocusOutside` is a component used to help detect when focus leaves an element.
+
+This can be useful to disambiguate focus transitions within the same element. A React `blur` event will fire even when focus transitions to another element in the same context. `DetectFocusOutside` will only invoke its callback prop when focus has truly left the element.
+
+## Usage
+
+Wrap your rendered children with `DetectFocusOutside`, defining an `onFocusOutside` callback prop.
+
+```jsx
+import { DetectFocusOutside, TextControl } from '@wordpress/components';
+
+function MyComponent() {
+	function onFocusOutside() {
+		console.log( 'Focus has left the rendered element.' );
+	}
+
+	return (
+		<DetectFocusOutside onFocusOutside={ onFocusOutside }>
+			<TextControl />
+			<TextControl />
+		</DetectFocusOutside>
+	);
+);
+```
+
+In the above example, the `onFocusOutside` function is only called if focus leaves the element, and not if transitioning focus between the two inputs.
+
+## Props
+
+### `onFocusOutside`
+* **Type:** `Function`
+* **Required:** Yes
+
+A callback function to invoke when focus has left the rendered element. The callback will receive the original blur event.

--- a/packages/components/src/detect-focus-outside/index.js
+++ b/packages/components/src/detect-focus-outside/index.js
@@ -1,0 +1,161 @@
+/**
+ * WordPress dependencies
+ */
+import { useRef, useEffect } from '@wordpress/element';
+
+/** @typedef {import('react').MouseEvent} ReactMouseEvent */
+/** @typedef {import('react').TouchEvent} ReactTouchEvent */
+/** @typedef {import('react').SyntheticEvent} ReactSyntheticEvent */
+/** @typedef {import('react').ReactNode} ReactNode */
+
+/**
+ * @typedef {(event:ReactSyntheticEvent)=>void} OnFocusOutsideProp
+ */
+
+/**
+ * Input types which are classified as button types, for use in considering
+ * whether element is a (focus-normalized) button.
+ *
+ * @type {Set<string>}
+ */
+const INPUT_BUTTON_TYPES = new Set( [ 'button', 'submit' ] );
+
+/**
+ * Event types which are classified as ends of interaction considered for focus
+ * event normalization.
+ *
+ * @type {Set<string>}
+ */
+const INTERACTION_END_TYPES = new Set( [ 'mouseup', 'touchend' ] );
+
+/**
+ * Returns true if the given element is a button element subject to focus
+ * normalization, or false otherwise.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Clicking_and_focus
+ *
+ * @param {Element} element Element to test.
+ *
+ * @return {boolean} Whether element is a button.
+ */
+function isFocusNormalizedButton( element ) {
+	switch ( element.nodeName ) {
+		case 'A':
+		case 'BUTTON':
+			return true;
+
+		case 'INPUT':
+			const { type } = /** @type {HTMLInputElement} */ ( element );
+			return INPUT_BUTTON_TYPES.has( type );
+	}
+
+	return false;
+}
+
+/**
+ * Component used to help detect when focus leaves an element.
+ *
+ * This can be useful to disambiguate focus transitions within the same element.
+ * A React `blur` event will fire even when focus transitions to another element
+ * in the same context. `DetectFocusOutside` will only invoke its callback prop
+ * when focus has truly left the element
+ *
+ * @type {import('react').FC}
+ *
+ * @param {Object}             props                Component props.
+ * @param {OnFocusOutsideProp} props.onFocusOutside Callback function to invoke
+ *                                                  when focus has left the
+ *                                                  rendered element. The
+ *                                                  callback will receive the
+ *                                                  original blur event.
+ * @param {ReactNode}          props.children       Element children.
+ */
+function DetectFocusOutside( { children, onFocusOutside } ) {
+	const blurCheckTimeout = /** @type {import('react').MutableRefObject<number>} */ ( useRef() );
+	const preventBlurCheck = useRef( false );
+	useEffect( () => cancelBlurCheck );
+
+	/**
+	 * Cancels the scheduled blur check, if one is scheduled.
+	 */
+	function cancelBlurCheck() {
+		clearTimeout( blurCheckTimeout.current );
+	}
+
+	/**
+	 * Schedules a blur check to occur after the current call stack ends, during
+	 * which time it may be expected that the check is nullified based on other
+	 * interactions.
+	 *
+	 * @see normalizeButtonFocus
+	 *
+	 * @param {ReactSyntheticEvent} event Focus event.
+	 */
+	function queueBlurCheck( event ) {
+		// Skip blur check if clicking button. See `normalizeButtonFocus`.
+		if ( preventBlurCheck.current ) {
+			return;
+		}
+
+		// React does not allow using an event reference asynchronously due to
+		// recycling behavior, except when explicitly persisted.
+		event.persist();
+
+		blurCheckTimeout.current = setTimeout( () => {
+			// If document is not focused then focus should remain inside the
+			// wrapped component and therefore we cancel this blur event thereby
+			// leaving focus in place.
+			//
+			// See: https://developer.mozilla.org/en-US/docs/Web/API/Document/hasFocus
+			if ( document.hasFocus() ) {
+				onFocusOutside( event );
+			}
+		}, 0 );
+	}
+
+	/**
+	 * Handles a mousedown or mouseup event to respectively assign and unassign
+	 * a flag for preventing blur check on button elements. Some browsers,
+	 * namely Firefox and Safari, do not emit a focus event on button elements
+	 * when clicked, while others do. The logic here intends to normalize this
+	 * as treating click on buttons as focus.
+	 *
+	 * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Clicking_and_focus
+	 *
+	 * @param {ReactMouseEvent|ReactTouchEvent} event Event on which to base
+	 *                                                normalize.
+	 */
+	function normalizeButtonFocus( event ) {
+		const { type, target } = event;
+		if ( ! ( target instanceof window.Element ) ) {
+			return;
+		}
+
+		const isInteractionEnd = INTERACTION_END_TYPES.has( type );
+		if ( isInteractionEnd ) {
+			preventBlurCheck.current = false;
+		} else if ( isFocusNormalizedButton( target ) ) {
+			preventBlurCheck.current = true;
+		}
+	}
+
+	// Disable reason: See `normalizeButtonFocus` for browser-specific focus
+	// event normalization.
+
+	/* eslint-disable jsx-a11y/no-static-element-interactions */
+	return (
+		<div
+			onFocus={ cancelBlurCheck }
+			onMouseDown={ normalizeButtonFocus }
+			onMouseUp={ normalizeButtonFocus }
+			onTouchStart={ normalizeButtonFocus }
+			onTouchEnd={ normalizeButtonFocus }
+			onBlur={ queueBlurCheck }
+		>
+			{ children }
+		</div>
+	);
+	/* eslint-enable jsx-a11y/no-static-element-interactions */
+}
+
+export default DetectFocusOutside;

--- a/packages/components/src/detect-focus-outside/test/index.js
+++ b/packages/components/src/detect-focus-outside/test/index.js
@@ -1,0 +1,119 @@
+/**
+ * External dependencies
+ */
+import TestUtils from 'react-dom/test-utils';
+
+/**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import ReactDOM from 'react-dom';
+import DetectFocusOutside from '../';
+
+let wrapper, onFocusOutside;
+
+describe( 'DetectFocusOutside', () => {
+	let origHasFocus;
+
+	class TestComponent extends Component {
+		render() {
+			return (
+				<DetectFocusOutside
+					onFocusOutside={ this.props.onFocusOutside }
+				>
+					<input />
+					<input type="button" />
+				</DetectFocusOutside>
+			);
+		}
+	}
+
+	const simulateEvent = ( event, index = 0 ) => {
+		const element = TestUtils.scryRenderedDOMComponentsWithTag(
+			wrapper,
+			'input'
+		);
+		TestUtils.Simulate[ event ]( element[ index ] );
+	};
+
+	beforeEach( () => {
+		// Mock document.hasFocus() to always be true for testing
+		// note: we overide this for some tests.
+		origHasFocus = document.hasFocus;
+		document.hasFocus = () => true;
+
+		onFocusOutside = jest.fn();
+		wrapper = TestUtils.renderIntoDocument(
+			<TestComponent onFocusOutside={ onFocusOutside } />
+		);
+	} );
+
+	afterEach( () => {
+		document.hasFocus = origHasFocus;
+	} );
+
+	it( 'should not call handler if focus shifts to element within component', () => {
+		simulateEvent( 'focus' );
+		simulateEvent( 'blur' );
+		simulateEvent( 'focus', 1 );
+
+		jest.runAllTimers();
+
+		expect( onFocusOutside ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should not call handler if focus transitions via click to button', () => {
+		simulateEvent( 'focus' );
+		simulateEvent( 'mouseDown', 1 );
+		simulateEvent( 'blur' );
+
+		// In most browsers, the input at index 1 would receive a focus event
+		// at this point, but this is not guaranteed, which is the intention of
+		// the normalization behavior tested here.
+		simulateEvent( 'mouseUp', 1 );
+
+		jest.runAllTimers();
+
+		expect( onFocusOutside ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should call handler if focus doesn’t shift to element within component', () => {
+		simulateEvent( 'focus' );
+		simulateEvent( 'blur' );
+
+		jest.runAllTimers();
+
+		expect( onFocusOutside ).toHaveBeenCalled();
+	} );
+
+	it( 'should not call handler if focus shifts outside the component when the document does not have focus', () => {
+		// Force document.hasFocus() to return false to simulate the window/document losing focus
+		// See https://developer.mozilla.org/en-US/docs/Web/API/Document/hasFocus.
+		document.hasFocus = () => false;
+
+		simulateEvent( 'focus' );
+		simulateEvent( 'blur' );
+
+		jest.runAllTimers();
+
+		expect( onFocusOutside ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should cancel check when unmounting while queued', () => {
+		simulateEvent( 'focus' );
+		simulateEvent( 'input' );
+
+		ReactDOM.unmountComponentAtNode(
+			// eslint-disable-next-line react/no-find-dom-node
+			ReactDOM.findDOMNode( wrapper ).parentNode
+		);
+
+		jest.runAllTimers();
+
+		expect( onFocusOutside ).not.toHaveBeenCalled();
+	} );
+} );

--- a/packages/components/src/higher-order/with-focus-outside/README.md
+++ b/packages/components/src/higher-order/with-focus-outside/README.md
@@ -1,3 +1,5 @@
+>⚠️ **Note:** While this higher-order component is not officially deprecated, you should consider using the [`DetectFocusOutside` component](../../detect-focus-outside) instead. This higher-order component _does not_ and will never support being used by function components.
+
 # withFocusOutside
 
 `withFocusOutside` is a React [higher-order component](https://facebook.github.io/react/docs/higher-order-components.html) to enable behavior to occur when focus leaves an element. Since a `blur` event will fire in React even when focus transitions to another element in the same context, this higher-order component encapsulates the logic necessary to determine if focus has truly left the element.

--- a/packages/components/src/higher-order/with-focus-outside/index.js
+++ b/packages/components/src/higher-order/with-focus-outside/index.js
@@ -1,44 +1,13 @@
 /**
- * External dependencies
- */
-import { includes } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
 import { createHigherOrderComponent } from '@wordpress/compose';
 
 /**
- * Input types which are classified as button types, for use in considering
- * whether element is a (focus-normalized) button.
- *
- * @type {string[]}
+ * Internal dependencies
  */
-const INPUT_BUTTON_TYPES = [ 'button', 'submit' ];
-
-/**
- * Returns true if the given element is a button element subject to focus
- * normalization, or false otherwise.
- *
- * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Clicking_and_focus
- *
- * @param {Element} element Element to test.
- *
- * @return {boolean} Whether element is a button.
- */
-function isFocusNormalizedButton( element ) {
-	switch ( element.nodeName ) {
-		case 'A':
-		case 'BUTTON':
-			return true;
-
-		case 'INPUT':
-			return includes( INPUT_BUTTON_TYPES, element.type );
-	}
-
-	return false;
-}
+import DetectFocusOutside from '../../detect-focus-outside';
 
 export default createHigherOrderComponent( ( WrappedComponent ) => {
 	return class extends Component {
@@ -46,97 +15,28 @@ export default createHigherOrderComponent( ( WrappedComponent ) => {
 			super( ...arguments );
 
 			this.bindNode = this.bindNode.bind( this );
-			this.cancelBlurCheck = this.cancelBlurCheck.bind( this );
-			this.queueBlurCheck = this.queueBlurCheck.bind( this );
-			this.normalizeButtonFocus = this.normalizeButtonFocus.bind( this );
-		}
-
-		componentWillUnmount() {
-			this.cancelBlurCheck();
+			this.onFocusOutside = this.onFocusOutside.bind( this );
 		}
 
 		bindNode( node ) {
-			if ( node ) {
-				this.node = node;
-			} else {
-				delete this.node;
-				this.cancelBlurCheck();
-			}
+			this.node = node;
 		}
 
-		queueBlurCheck( event ) {
-			// React does not allow using an event reference asynchronously
-			// due to recycling behavior, except when explicitly persisted.
-			event.persist();
-
-			// Skip blur check if clicking button. See `normalizeButtonFocus`.
-			if ( this.preventBlurCheck ) {
-				return;
-			}
-
-			this.blurCheckTimeout = setTimeout( () => {
-				// If document is not focused then focus should remain
-				// inside the wrapped component and therefore we cancel
-				// this blur event thereby leaving focus in place.
-				// https://developer.mozilla.org/en-US/docs/Web/API/Document/hasFocus.
-				if ( ! document.hasFocus() ) {
-					event.preventDefault();
-					return;
-				}
-				if ( 'function' === typeof this.node.handleFocusOutside ) {
-					this.node.handleFocusOutside( event );
-				}
-			}, 0 );
-		}
-
-		cancelBlurCheck() {
-			clearTimeout( this.blurCheckTimeout );
-		}
-
-		/**
-		 * Handles a mousedown or mouseup event to respectively assign and
-		 * unassign a flag for preventing blur check on button elements. Some
-		 * browsers, namely Firefox and Safari, do not emit a focus event on
-		 * button elements when clicked, while others do. The logic here
-		 * intends to normalize this as treating click on buttons as focus.
-		 *
-		 * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Clicking_and_focus
-		 *
-		 * @param {MouseEvent} event Event for mousedown or mouseup.
-		 */
-		normalizeButtonFocus( event ) {
-			const { type, target } = event;
-
-			const isInteractionEnd = includes(
-				[ 'mouseup', 'touchend' ],
-				type
-			);
-
-			if ( isInteractionEnd ) {
-				this.preventBlurCheck = false;
-			} else if ( isFocusNormalizedButton( target ) ) {
-				this.preventBlurCheck = true;
+		onFocusOutside( event ) {
+			if (
+				this.node &&
+				'function' === typeof this.node.handleFocusOutside
+			) {
+				this.node.handleFocusOutside( event );
 			}
 		}
 
 		render() {
-			// Disable reason: See `normalizeButtonFocus` for browser-specific
-			// focus event normalization.
-
-			/* eslint-disable jsx-a11y/no-static-element-interactions */
 			return (
-				<div
-					onFocus={ this.cancelBlurCheck }
-					onMouseDown={ this.normalizeButtonFocus }
-					onMouseUp={ this.normalizeButtonFocus }
-					onTouchStart={ this.normalizeButtonFocus }
-					onTouchEnd={ this.normalizeButtonFocus }
-					onBlur={ this.queueBlurCheck }
-				>
+				<DetectFocusOutside onFocusOutside={ this.onFocusOutside }>
 					<WrappedComponent ref={ this.bindNode } { ...this.props } />
-				</div>
+				</DetectFocusOutside>
 			);
-			/* eslint-enable jsx-a11y/no-static-element-interactions */
 		}
 	};
 }, 'withFocusOutside' );

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -33,6 +33,7 @@ export { default as Dashicon } from './dashicon';
 export { DateTimePicker, DatePicker, TimePicker } from './date-time';
 export { default as __experimentalDimensionControl } from './dimension-control';
 export { default as Disabled } from './disabled';
+export { default as DetectFocusOutside } from './detect-focus-outside';
 export { default as Draggable } from './draggable';
 export {
 	default as DropZone,

--- a/packages/e2e-tests/specs/editor/various/capabilities.test.js
+++ b/packages/e2e-tests/specs/editor/various/capabilities.test.js
@@ -1,0 +1,47 @@
+/**
+ * WordPress dependencies
+ */
+import { createNewPost, saveDraft } from '@wordpress/e2e-test-utils';
+
+describe( 'capabilities', () => {
+	// Purpose: These tests verify sufficient accommodations for users based on
+	// their user role and corresponding capabilities. For example, if a user
+	// does not have permission to upload files, any UI interactions where an
+	// upload would take place should make affordances for that user. The tests
+	// verify the existence of such affordances.
+	//
+	// See: https://wordpress.org/support/article/roles-and-capabilities/
+	//
+	// Note: There is only value in these tests if they are run under users of
+	// different roles and capabiliities. As an example, refer to the `E2E_ROLE`
+	// environment variable in Gutenberg's Travis configuration.
+	//
+	// See: https://github.com/WordPress/gutenberg/blob/42d2b36/.travis.yml#L97-L100
+
+	beforeEach( async () => {
+		await createNewPost();
+	} );
+
+	it( 'should retain title escaping exactly as the user entered', async () => {
+		// See: https://github.com/WordPress/gutenberg/issues/20490
+
+		await page.type( '.editor-post-title__input', 'A & B &amp; C' );
+
+		const getTitleValue = () =>
+			page.$eval(
+				'.editor-post-title__input',
+				( input ) => input.textContent
+			);
+
+		// Verify that no unescaping occurred.
+		expect( await getTitleValue() ).toBe( 'A & B &amp; C' );
+
+		// Save draft, and verify that no escaping or unescaping occurred.
+		await saveDraft();
+		expect( await getTitleValue() ).toBe( 'A & B &amp; C' );
+
+		// Reload the page, and verify that no escaping or unescaping occurred.
+		await page.reload();
+		expect( await getTitleValue() ).toBe( 'A & B &amp; C' );
+	} );
+} );

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -63,15 +63,11 @@ function Layout() {
 		publishSidebarOpened,
 		hasActiveMetaboxes,
 		isSaving,
-		hasFixedToolbar,
 		previousShortcut,
 		nextShortcut,
 		hasBlockSelected,
 	} = useSelect( ( select ) => {
 		return {
-			hasFixedToolbar: select( 'core/edit-post' ).isFeatureActive(
-				'fixedToolbar'
-			),
 			editorSidebarOpened: select(
 				'core/edit-post'
 			).isEditorSidebarOpened(),
@@ -100,7 +96,6 @@ function Layout() {
 		editorSidebarOpened || pluginSidebarOpened || publishSidebarOpened;
 	const className = classnames( 'edit-post-layout', 'is-mode-' + mode, {
 		'is-sidebar-opened': sidebarIsOpened,
-		'has-fixed-toolbar': hasFixedToolbar,
 		'has-metaboxes': hasActiveMetaboxes,
 	} );
 	const openSidebarPanel = () =>

--- a/packages/editor/src/components/post-title/index.js
+++ b/packages/editor/src/components/post-title/index.js
@@ -34,7 +34,6 @@ function PostTitle() {
 		isPostTypeViewable,
 		placeholder,
 		isFocusMode,
-		hasFixedToolbar,
 	} = useSelect( ( select ) => {
 		const {
 			getEditedPostAttribute,
@@ -43,11 +42,7 @@ function PostTitle() {
 		const { getSettings } = select( 'core/block-editor' );
 		const { getPostType } = select( 'core' );
 		const postType = getPostType( getEditedPostAttribute( 'type' ) );
-		const {
-			titlePlaceholder,
-			focusMode,
-			hasFixedToolbar: _hasFixedToolbar,
-		} = getSettings();
+		const { titlePlaceholder, focusMode } = getSettings();
 
 		return {
 			isCleanNewPost: getIsCleanNewPost(),
@@ -55,7 +50,6 @@ function PostTitle() {
 			isPostTypeViewable: get( postType, [ 'viewable' ], false ),
 			placeholder: titlePlaceholder,
 			isFocusMode: focusMode,
-			hasFixedToolbar: _hasFixedToolbar,
 		};
 	} );
 	const { insertDefaultBlock, clearSelectedBlock } = useDispatch(
@@ -90,7 +84,6 @@ function PostTitle() {
 	const className = classnames( 'wp-block editor-post-title__block', {
 		'is-selected': isSelected,
 		'is-focus-mode': isFocusMode,
-		'has-fixed-toolbar': hasFixedToolbar,
 	} );
 	const decodedPlaceholder = decodeEntities( placeholder );
 

--- a/packages/editor/src/components/post-title/index.js
+++ b/packages/editor/src/components/post-title/index.js
@@ -13,7 +13,7 @@ import { __ } from '@wordpress/i18n';
 import { decodeEntities } from '@wordpress/html-entities';
 import { ENTER } from '@wordpress/keycodes';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { DetectFocusOutside } from '@wordpress/components';
+import { DetectFocusOutside, VisuallyHidden } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
 
 /**
@@ -92,12 +92,12 @@ function PostTitle() {
 				<div className="editor-post-title">
 					<div className={ className }>
 						<div>
-							<label
+							<VisuallyHidden
+								as="label"
 								htmlFor={ `post-title-${ instanceId }` }
-								className="screen-reader-text"
 							>
 								{ decodedPlaceholder || __( 'Add title' ) }
-							</label>
+							</VisuallyHidden>
 							<Textarea
 								id={ `post-title-${ instanceId }` }
 								className="editor-post-title__input"

--- a/packages/editor/src/components/post-title/index.js
+++ b/packages/editor/src/components/post-title/index.js
@@ -82,7 +82,6 @@ function PostTitle() {
 
 	// The wp-block className is important for editor styles.
 	const className = classnames( 'wp-block editor-post-title__block', {
-		'is-selected': isSelected,
 		'is-focus-mode': isFocusMode,
 	} );
 	const decodedPlaceholder = decodeEntities( placeholder );


### PR DESCRIPTION
Closes #20490 
Related: #18616, #19955, https://core.trac.wordpress.org/ticket/11311

This pull request seeks to improve the behavior for title character encoding for users who do not have `unfiltered_html` capability. Without these changes, a contributing user to the site would see escape sequences for characters in the title after they have saved a post (i.e. `&` becomes `&amp;`, shown _literally_ in the editor's title field).

Before|After
---|---
![Before](https://user-images.githubusercontent.com/1779930/76654350-279b7300-6541-11ea-9393-7a058b5f79cd.png)|![After](https://user-images.githubusercontent.com/1779930/76654333-223e2880-6541-11ea-8506-6915628510b6.png)

Notably, this implementation must make quite a few accommodations:

- **It must not save the title as escaped.** The previous implementation of #18616 did escape titles, thus breaking ["texturize"](https://developer.wordpress.org/reference/functions/wptexturize/) behavior that is expected to apply for titles, content, etc.
   - We depend on the server to escape input based on the user capabilities. In fact, this server-side escaping is what causes the issue in the first place, and why it only affects users of particular capabilities.
- **It should leave the underlying data intact.** The post entities (`core/data`) should still report a raw title value including entities, if applicable. The implementation here _could_ have transformed the values at the editor level. However, since this is largely a concern of display, it was decided to implement this at the level of the title component.
- **It shouldn't interfere with user input.** If a user starts typing `&`, `&a`, `&am`, etc., the title should not suddenly update to decode that input. This is accounted for by preemptively _encoding_ an ampersand input.
- **A user should still be able to insert HTML in the title according to their own capabilities.**

**Current Status:**

This is largely complete. However, as may be evidenced by the size of the changes, a fair bit of unrelated refactoring was included. This could be included as part of review of these changes, or separated out to separate pull requests and rebased on this branch to make this smaller.

These include:

- [ ] Components: Implement new component DetectFocusOutside (e14f981)
- [ ] Components: Refactor withFocusOutside to use DetectFocusOutside (bece56c)
- [ ] Editor: Refactor PostTitle as function component (9fc08cb)
- [ ] Editor: PostTitle: Remove unused className has-fixed-toolbar (bec7518)
- [ ] Edit Post: Layout: Remove unused className has-fixed-toolbar (df174b9)
- [ ] Editor: PostTitle: Remove unused className is-selected (9eadc8e)
- [ ] Editor: PostTitle: Refactor PostTitle label screen-reader-text as Vis… … (d80332d)

**Testing Instructions:**

Repeat Steps to Reproduce from #20490, both as a user with and without `unfiltered_html` capability (i.e. adminstrators and contributors). Note that it's not necessary to use a multisite installation. This can be tested in single-site as well.

Verify also all of the above accommodations.

Specifically, be on the lookout for edge cases concerning:

- User input of HTML or escape sequences.
- Title field updates at load, and after save.