### PR TITLE
Cover: Add custom unit support for height controls

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -894,6 +894,12 @@
 		"parent": "components"
 	},
 	{
+		"title": "NumberControl",
+		"slug": "number-control",
+		"markdown_source": "../packages/components/src/number-control/README.md",
+		"parent": "components"
+	},
+	{
 		"title": "Panel",
 		"slug": "panel",
 		"markdown_source": "../packages/components/src/panel/README.md",
@@ -1029,6 +1035,12 @@
 		"title": "TreeSelect",
 		"slug": "tree-select",
 		"markdown_source": "../packages/components/src/tree-select/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "UnitControl",
+		"slug": "unit-control",
+		"markdown_source": "../packages/components/src/unit-control/README.md",
 		"parent": "components"
 	},
 	{

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -665,7 +665,7 @@ add_filter( 'block_editor_settings', 'gutenberg_extend_settings_custom_line_heig
 * @return array Filtered editor settings.
 */
 function gutenberg_extend_settings_custom_units( $settings ) {
-	$settings['__experimentalDisableCustomUnits'] = get_theme_support( 'disable-custom-units' );
+	$settings['__experimentalDisableCustomUnits'] = get_theme_support( 'experimental-custom-units' );
 	return $settings;
 }
 add_filter( 'block_editor_settings', 'gutenberg_extend_settings_custom_units' );

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -649,17 +649,26 @@ add_filter( 'block_editor_settings', 'gutenberg_extend_settings_block_patterns',
 
 /**
  * Extends block editor settings to determine whether to use custom line height controls.
- * Currently experimental.
- *
- * @param array $settings Default editor settings.
- *
- * @return array Filtered editor settings.
  */
 function gutenberg_extend_settings_custom_line_height( $settings ) {
 	$settings['__experimentalDisableCustomLineHeight'] = get_theme_support( 'disable-custom-line-height' );
 	return $settings;
 }
 add_filter( 'block_editor_settings', 'gutenberg_extend_settings_custom_line_height' );
+
+/**
+* Extends block editor settings to determine whether to use custom unit controls.
+* Currently experimental.
+*
+* @param array $settings Default editor settings.
+*
+* @return array Filtered editor settings.
+*/
+function gutenberg_extend_settings_custom_units( $settings ) {
+	$settings['__experimentalDisableCustomUnits'] = get_theme_support( 'disable-custom-units' );
+	return $settings;
+}
+add_filter( 'block_editor_settings', 'gutenberg_extend_settings_custom_units' );
 
 /*
  * Register default patterns if not registered in Core already.

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -649,6 +649,10 @@ add_filter( 'block_editor_settings', 'gutenberg_extend_settings_block_patterns',
 
 /**
  * Extends block editor settings to determine whether to use custom line height controls.
+ *
+ * @param array $settings Default editor settings.
+ *
+ * @return array Updated editor settings.
  */
 function gutenberg_extend_settings_custom_line_height( $settings ) {
 	$settings['__experimentalDisableCustomLineHeight'] = get_theme_support( 'disable-custom-line-height' );
@@ -662,7 +666,7 @@ add_filter( 'block_editor_settings', 'gutenberg_extend_settings_custom_line_heig
 *
 * @param array $settings Default editor settings.
 *
-* @return array Filtered editor settings.
+* @return array Updated editor settings.
 */
 function gutenberg_extend_settings_custom_units( $settings ) {
 	$settings['__experimentalDisableCustomUnits'] = get_theme_support( 'experimental-custom-units' );

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -652,7 +652,7 @@ add_filter( 'block_editor_settings', 'gutenberg_extend_settings_block_patterns',
  *
  * @param array $settings Default editor settings.
  *
- * @return array Updated editor settings.
+ * @return array Filtered editor settings.
  */
 function gutenberg_extend_settings_custom_line_height( $settings ) {
 	$settings['__experimentalDisableCustomLineHeight'] = get_theme_support( 'disable-custom-line-height' );
@@ -661,13 +661,13 @@ function gutenberg_extend_settings_custom_line_height( $settings ) {
 add_filter( 'block_editor_settings', 'gutenberg_extend_settings_custom_line_height' );
 
 /**
-* Extends block editor settings to determine whether to use custom unit controls.
-* Currently experimental.
-*
-* @param array $settings Default editor settings.
-*
-* @return array Updated editor settings.
-*/
+ * Extends block editor settings to determine whether to use custom unit controls.
+ * Currently experimental.
+ *
+ * @param array $settings Default editor settings.
+ *
+ * @return array Filtered editor settings.
+ */
 function gutenberg_extend_settings_custom_units( $settings ) {
 	$settings['__experimentalDisableCustomUnits'] = get_theme_support( 'experimental-custom-units' );
 	return $settings;

--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -49,6 +49,7 @@ export {
 	__unstableRichTextInputEvent,
 } from './rich-text';
 export { default as ToolSelector } from './tool-selector';
+export { default as __experimentalUnitControl } from './unit-control';
 export { default as URLInput } from './url-input';
 export { default as URLInputButton } from './url-input/button';
 export { default as URLPopover } from './url-popover';

--- a/packages/block-editor/src/components/unit-control/index.js
+++ b/packages/block-editor/src/components/unit-control/index.js
@@ -52,7 +52,7 @@ function useCustomUnitsSettings() {
  * @param {Array} settings Collection of preferred units.
  * @param {Array} units Collection of available units.
  *
- * @return {Array}
+ * @return {Array} Filtered units based on settings.
  */
 function filterUnitsWithSettings( settings = [], units = [] ) {
 	return units.filter( ( unit ) => {

--- a/packages/block-editor/src/components/unit-control/index.js
+++ b/packages/block-editor/src/components/unit-control/index.js
@@ -13,8 +13,15 @@ export default function UnitControl( { units: unitsProp, ...props } ) {
 	// Adjust units based on add_theme_support( 'disable-custom-units' );
 	let units;
 
-	// Handle extra arguments for add_theme_support,
-	// Example: ( 'disable-custom-units', 'rem' );
+	/**
+	 * Handle extra arguments for add_theme_support
+	 *
+	 * Example: add_theme_support( 'disable-custom-units', 'rem' );
+	 * Or: add_theme_support( 'disable-custom-units', 'px, 'rem', 'em' );
+	 *
+	 * Note: If there are unit argument (e.g. 'em'), these units are enabled
+	 * within the control.
+	 */
 	if ( Array.isArray( settings ) ) {
 		units = filterUnitsWithSettings( settings, unitsProp );
 	} else {

--- a/packages/block-editor/src/components/unit-control/index.js
+++ b/packages/block-editor/src/components/unit-control/index.js
@@ -4,7 +4,7 @@
 import { __experimentalUnitControl as BaseUnitControl } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 
-const { __defaultUnits, __getComputedSize } = BaseUnitControl;
+const { __defaultUnits } = BaseUnitControl;
 
 export default function UnitControl( { units: unitsProp, ...props } ) {
 	const isCustomUnitsDisabled = useIsCustomUnitsDisabled();
@@ -17,9 +17,8 @@ export default function UnitControl( { units: unitsProp, ...props } ) {
 
 // Hoisting statics from the BaseUnitControl
 UnitControl.__defaultUnits = __defaultUnits;
-UnitControl.__getComputedSize = __getComputedSize;
 
-export function useIsCustomUnitsDisabled() {
+function useIsCustomUnitsDisabled() {
 	const isDisabled = useSelect( ( select ) => {
 		const { getSettings } = select( 'core/block-editor' );
 		return !! getSettings().__experimentalDisableCustomUnits;

--- a/packages/block-editor/src/components/unit-control/index.js
+++ b/packages/block-editor/src/components/unit-control/index.js
@@ -1,0 +1,29 @@
+/**
+ * WordPress dependencies
+ */
+import { __experimentalUnitControl as BaseUnitControl } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+
+const { __defaultUnits, __getComputedSize } = BaseUnitControl;
+
+export default function UnitControl( { units: unitsProp, ...props } ) {
+	const isCustomUnitsDisabled = useIsCustomUnitsDisabled();
+
+	// Disable units if specified by add_theme_support
+	const units = isCustomUnitsDisabled ? false : unitsProp;
+
+	return <BaseUnitControl units={ units } { ...props } />;
+}
+
+// Hoisting statics from the BaseUnitControl
+UnitControl.__defaultUnits = __defaultUnits;
+UnitControl.__getComputedSize = __getComputedSize;
+
+export function useIsCustomUnitsDisabled() {
+	const isDisabled = useSelect( ( select ) => {
+		const { getSettings } = select( 'core/block-editor' );
+		return !! getSettings().__experimentalDisableCustomUnits;
+	}, [] );
+
+	return isDisabled;
+}

--- a/packages/block-editor/src/components/unit-control/index.js
+++ b/packages/block-editor/src/components/unit-control/index.js
@@ -10,14 +10,14 @@ export default function UnitControl( { units: unitsProp, ...props } ) {
 	const settings = useCustomUnitsSettings();
 	const isDisabled = !! settings;
 
-	// Adjust units based on add_theme_support( 'disable-custom-units' );
+	// Adjust units based on add_theme_support( 'experimental-custom-units' );
 	let units;
 
 	/**
 	 * Handle extra arguments for add_theme_support
 	 *
-	 * Example: add_theme_support( 'disable-custom-units', 'rem' );
-	 * Or: add_theme_support( 'disable-custom-units', 'px, 'rem', 'em' );
+	 * Example: add_theme_support( 'experimental-custom-units', 'rem' );
+	 * Or: add_theme_support( 'experimental-custom-units', 'px, 'rem', 'em' );
 	 *
 	 * Note: If there are unit argument (e.g. 'em'), these units are enabled
 	 * within the control.
@@ -35,7 +35,7 @@ export default function UnitControl( { units: unitsProp, ...props } ) {
 UnitControl.__defaultUnits = __defaultUnits;
 
 /**
- * Hook that retrieves the 'disable-custom-units' setting from add_theme_support()
+ * Hook that retrieves the 'experimental-custom-units' setting from add_theme_support()
  */
 function useCustomUnitsSettings() {
 	const settings = useSelect( ( select ) => {

--- a/packages/block-library/src/cover/block.json
+++ b/packages/block-library/src/cover/block.json
@@ -33,8 +33,7 @@
 			"type": "number"
 		},
 		"minHeightUnit": {
-			"type": "string",
-			"default": "px"
+			"type": "string"
 		},
 		"gradient": {
 			"type": "string"

--- a/packages/block-library/src/cover/block.json
+++ b/packages/block-library/src/cover/block.json
@@ -32,6 +32,10 @@
 		"minHeight": {
 			"type": "number"
 		},
+		"minHeightUnit": {
+			"type": "string",
+			"default": "px"
+		},
 		"gradient": {
 			"type": "string"
 		},

--- a/packages/block-library/src/cover/block.json
+++ b/packages/block-library/src/cover/block.json
@@ -33,7 +33,8 @@
 			"type": "number"
 		},
 		"minHeightUnit": {
-			"type": "string"
+			"type": "string",
+			"default": "px"
 		},
 		"gradient": {
 			"type": "string"

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -279,7 +279,7 @@ function CoverEdit( {
 			? backgroundImageStyles( url )
 			: {} ),
 		backgroundColor: overlayColor.color,
-		minHeight: computedMinHeight,
+		minHeight: computedMinHeight || undefined,
 	};
 
 	if ( gradientValue && ! url ) {

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -75,7 +75,12 @@ function retrieveFastAverageColor() {
 
 const { __getComputedSize: getComputedUnitSize } = UnitControl;
 
-function CoverHeightInput( { onChange, onUnitChange, unit, value = '' } ) {
+function CoverHeightInput( {
+	onChange,
+	onUnitChange,
+	unit = 'px',
+	value = '',
+} ) {
 	const [ temporaryInput, setTemporaryInput ] = useState( null );
 	const instanceId = useInstanceId( UnitControl );
 	const inputId = `block-cover-height-input-${ instanceId }`;

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -35,7 +35,7 @@ import {
 	__experimentalPanelColorGradientSettings as PanelColorGradientSettings,
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
-import { withDispatch } from '@wordpress/data';
+import { useSelect, withDispatch } from '@wordpress/data';
 import { cover as icon } from '@wordpress/icons';
 
 /**
@@ -73,6 +73,15 @@ function retrieveFastAverageColor() {
 	return retrieveFastAverageColor.fastAverageColor;
 }
 
+export function useIsCustomUnitsDisabled() {
+	const isDisabled = useSelect( ( select ) => {
+		const { getSettings } = select( 'core/block-editor' );
+		return !! getSettings().__experimentalDisableCustomUnits;
+	}, [] );
+
+	return isDisabled;
+}
+
 const { __getComputedSize: getComputedUnitSize } = UnitControl;
 
 function CoverHeightInput( {
@@ -85,6 +94,7 @@ function CoverHeightInput( {
 	const instanceId = useInstanceId( UnitControl );
 	const inputId = `block-cover-height-input-${ instanceId }`;
 	const isPx = unit === 'px';
+	const isCustomUnitsDisabled = useIsCustomUnitsDisabled();
 
 	const handleOnChange = ( unprocessedValue ) => {
 		const inputValue =
@@ -108,6 +118,7 @@ function CoverHeightInput( {
 
 	const inputValue = temporaryInput !== null ? temporaryInput : value;
 	const min = isPx ? COVER_MIN_HEIGHT : 0;
+	const units = isCustomUnitsDisabled ? false : CSS_UNITS;
 
 	return (
 		<BaseControl label={ __( 'Minimum height in pixels' ) } id={ inputId }>
@@ -120,7 +131,7 @@ function CoverHeightInput( {
 				step="1"
 				style={ { maxWidth: 80 } }
 				unit={ unit }
-				units={ CSS_UNITS }
+				units={ units }
 				value={ inputValue }
 			/>
 		</BaseControl>

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -18,7 +18,6 @@ import {
 	RangeControl,
 	ResizableBox,
 	ToggleControl,
-	__experimentalUnitControl as UnitControl,
 	withNotices,
 } from '@wordpress/components';
 import { compose, withInstanceId, useInstanceId } from '@wordpress/compose';
@@ -33,9 +32,10 @@ import {
 	ColorPalette,
 	__experimentalUseGradient,
 	__experimentalPanelColorGradientSettings as PanelColorGradientSettings,
+	__experimentalUnitControl as UnitControl,
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
-import { useSelect, withDispatch } from '@wordpress/data';
+import { withDispatch } from '@wordpress/data';
 import { cover as icon } from '@wordpress/icons';
 
 /**
@@ -73,15 +73,6 @@ function retrieveFastAverageColor() {
 	return retrieveFastAverageColor.fastAverageColor;
 }
 
-export function useIsCustomUnitsDisabled() {
-	const isDisabled = useSelect( ( select ) => {
-		const { getSettings } = select( 'core/block-editor' );
-		return !! getSettings().__experimentalDisableCustomUnits;
-	}, [] );
-
-	return isDisabled;
-}
-
 const { __getComputedSize: getComputedUnitSize } = UnitControl;
 
 function CoverHeightInput( {
@@ -94,7 +85,6 @@ function CoverHeightInput( {
 	const instanceId = useInstanceId( UnitControl );
 	const inputId = `block-cover-height-input-${ instanceId }`;
 	const isPx = unit === 'px';
-	const isCustomUnitsDisabled = useIsCustomUnitsDisabled();
 
 	const handleOnChange = ( unprocessedValue ) => {
 		const inputValue =
@@ -118,7 +108,6 @@ function CoverHeightInput( {
 
 	const inputValue = temporaryInput !== null ? temporaryInput : value;
 	const min = isPx ? COVER_MIN_HEIGHT : 0;
-	const units = isCustomUnitsDisabled ? false : CSS_UNITS;
 
 	return (
 		<BaseControl label={ __( 'Minimum height in pixels' ) } id={ inputId }>
@@ -131,7 +120,7 @@ function CoverHeightInput( {
 				step="1"
 				style={ { maxWidth: 80 } }
 				unit={ unit }
-				units={ units }
+				units={ CSS_UNITS }
 				value={ inputValue }
 			/>
 		</BaseControl>

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -73,8 +73,6 @@ function retrieveFastAverageColor() {
 	return retrieveFastAverageColor.fastAverageColor;
 }
 
-const { __getComputedSize: getComputedUnitSize } = UnitControl;
-
 function CoverHeightInput( {
 	onChange,
 	onUnitChange,
@@ -267,19 +265,18 @@ function CoverEdit( {
 	);
 
 	const [ temporaryMinHeight, setTemporaryMinHeight ] = useState( null );
-
 	const { removeAllNotices, createErrorNotice } = noticeOperations;
 
-	const computedMinHeight =
-		temporaryMinHeight ||
-		getComputedUnitSize( { value: minHeight, unit: minHeightUnit } );
+	const minHeightWithUnit = minHeightUnit
+		? `${ minHeight }${ minHeightUnit }`
+		: minHeight;
 
 	const style = {
 		...( backgroundType === IMAGE_BACKGROUND_TYPE
 			? backgroundImageStyles( url )
 			: {} ),
 		backgroundColor: overlayColor.color,
-		minHeight: computedMinHeight || undefined,
+		minHeight: temporaryMinHeight || minHeightWithUnit || undefined,
 	};
 
 	if ( gradientValue && ! url ) {

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -108,7 +108,7 @@ function CoverHeightInput( {
 	const min = isPx ? COVER_MIN_HEIGHT : 0;
 
 	return (
-		<BaseControl label={ __( 'Minimum height in pixels' ) } id={ inputId }>
+		<BaseControl label={ __( 'Minimum height of cover' ) } id={ inputId }>
 			<UnitControl
 				id={ inputId }
 				min={ min }

--- a/packages/block-library/src/cover/save.js
+++ b/packages/block-library/src/cover/save.js
@@ -34,6 +34,7 @@ export default function save( { attributes } ) {
 		overlayColor,
 		url,
 		minHeight,
+		minHeightUnit,
 	} = attributes;
 	const overlayColorClass = getColorClassName(
 		'background-color',
@@ -56,7 +57,9 @@ export default function save( { attributes } ) {
 	if ( customGradient && ! url ) {
 		style.background = customGradient;
 	}
-	style.minHeight = minHeight || undefined;
+	style.minHeight = minHeightUnit
+		? `${ minHeight }${ minHeightUnit }`
+		: minHeight || undefined;
 
 	const classes = classnames(
 		dimRatioToClass( dimRatio ),

--- a/packages/block-library/src/cover/save.js
+++ b/packages/block-library/src/cover/save.js
@@ -33,7 +33,7 @@ export default function save( { attributes } ) {
 		hasParallax,
 		overlayColor,
 		url,
-		minHeight,
+		minHeight: minHeightProp,
 		minHeightUnit,
 	} = attributes;
 	const overlayColorClass = getColorClassName(
@@ -41,6 +41,9 @@ export default function save( { attributes } ) {
 		overlayColor
 	);
 	const gradientClass = __experimentalGetGradientClass( gradient );
+	const minHeight = minHeightUnit
+		? `${ minHeightProp }${ minHeightUnit }`
+		: minHeightProp;
 
 	const style =
 		backgroundType === IMAGE_BACKGROUND_TYPE
@@ -57,9 +60,7 @@ export default function save( { attributes } ) {
 	if ( customGradient && ! url ) {
 		style.background = customGradient;
 	}
-	style.minHeight = minHeightUnit
-		? `${ minHeight }${ minHeightUnit }`
-		: minHeight || undefined;
+	style.minHeight = minHeight || undefined;
 
 	const classes = classnames(
 		dimRatioToClass( dimRatio ),

--- a/packages/block-library/src/cover/shared.js
+++ b/packages/block-library/src/cover/shared.js
@@ -6,11 +6,11 @@ export function backgroundImageStyles( url ) {
 }
 
 export const CSS_UNITS = [
-	{ value: 'px', label: 'px', default: COVER_MIN_HEIGHT },
-	{ value: 'em', label: 'em', default: 10 },
-	{ value: 'rem', label: 'rem', default: 10 },
-	{ value: 'vw', label: 'vw', default: 10 },
-	{ value: 'vh', label: 'vh', default: 10 },
+	{ value: 'px', label: 'px', default: 430 },
+	{ value: 'em', label: 'em', default: 20 },
+	{ value: 'rem', label: 'rem', default: 20 },
+	{ value: 'vw', label: 'vw', default: 20 },
+	{ value: 'vh', label: 'vh', default: 50 },
 ];
 
 export function dimRatioToClass( ratio ) {

--- a/packages/block-library/src/cover/shared.js
+++ b/packages/block-library/src/cover/shared.js
@@ -5,6 +5,14 @@ export function backgroundImageStyles( url ) {
 	return url ? { backgroundImage: `url(${ url })` } : {};
 }
 
+export const CSS_UNITS = [
+	{ value: 'px', label: 'px', default: COVER_MIN_HEIGHT },
+	{ value: 'em', label: 'em', default: 10 },
+	{ value: 'rem', label: 'rem', default: 10 },
+	{ value: 'vw', label: 'vw', default: 10 },
+	{ value: 'vh', label: 'vh', default: 10 },
+];
+
 export function dimRatioToClass( ratio ) {
 	return ratio === 0 || ratio === 50 || ! ratio
 		? null

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -62,6 +62,7 @@ export { default as Modal } from './modal';
 export { default as ScrollLock } from './scroll-lock';
 export { NavigableMenu, TabbableContainer } from './navigable-container';
 export { default as Notice } from './notice';
+export { default as __experimentalNumberControl } from './number-control';
 export { default as NoticeList } from './notice/list';
 export { default as Panel } from './panel';
 export { default as PanelBody } from './panel/body';
@@ -92,6 +93,7 @@ export { default as ToolbarGroup } from './toolbar-group';
 export { default as __experimentalToolbarItem } from './toolbar-item';
 export { default as Tooltip } from './tooltip';
 export { default as TreeSelect } from './tree-select';
+export { default as __experimentalUnitControl } from './unit-control';
 export { default as VisuallyHidden } from './visually-hidden';
 export { default as IsolatedEventContainer } from './isolated-event-container';
 export {

--- a/packages/components/src/number-control/README.md
+++ b/packages/components/src/number-control/README.md
@@ -1,0 +1,29 @@
+# NumberControl
+
+NumberControl is an enhanced HTML [`input[type="number]`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/number) element.
+
+## Usage
+
+```jsx
+import { __experimentalNumberControl as NumberControl } from '@wordpress/components';
+
+const Example = () => {
+	const [value, setValue] = useState(10);
+
+	return (
+		<NumberControl
+			isShiftStepEnabled={ true }
+			onChange={ setValue }
+			shiftStep={ 10 }
+			value={ value }
+		/>
+	)
+};
+```
+
+## Props
+
+Name | Type | Default | Description
+--- | --- | --- | ---
+`isShiftStepEnabled` | `boolean` | `true` | Determines if the unit `<select>` is tabbable.
+`shiftStep` | `number` | `10` | Amount to increment by when the `shift` key is held down.

--- a/packages/components/src/number-control/index.js
+++ b/packages/components/src/number-control/index.js
@@ -1,0 +1,80 @@
+/**
+ * External dependencies
+ */
+import { clamp, noop } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { UP, DOWN } from '@wordpress/keycodes';
+
+export default function NumberControl( {
+	enableShiftIncrement = true,
+	max = Infinity,
+	min = -Infinity,
+	onChange = noop,
+	onKeyDown = noop,
+	shiftIncrement = 10,
+	step = 1,
+	...props
+} ) {
+	const baseValue = clamp( 0, min, max );
+
+	const handleOnKeyDown = ( event ) => {
+		onKeyDown( event );
+		const { value } = event.target;
+
+		const isEmpty = value === '';
+		const shiftAmount = step * shiftIncrement;
+
+		let nextValue = isEmpty ? baseValue : value;
+		// Convert to a number to use math
+		nextValue = parseFloat( nextValue );
+
+		switch ( event.keyCode ) {
+			case UP:
+				event.preventDefault();
+
+				if ( event.shiftKey && enableShiftIncrement ) {
+					nextValue = nextValue + shiftAmount;
+				} else {
+					nextValue = nextValue + step;
+				}
+
+				nextValue = clamp( nextValue, min, max );
+
+				onChange( nextValue.toString() );
+
+				break;
+
+			case DOWN:
+				event.preventDefault();
+
+				if ( event.shiftKey && enableShiftIncrement ) {
+					nextValue = nextValue - shiftAmount;
+				} else {
+					nextValue = nextValue - step;
+				}
+
+				nextValue = clamp( nextValue, min, max );
+
+				onChange( nextValue.toString() );
+
+				break;
+		}
+	};
+
+	const handleOnChange = ( event ) => {
+		onChange( event.target.value );
+	};
+
+	return (
+		<input
+			{ ...props }
+			inputMode="numeric"
+			type="number"
+			onChange={ handleOnChange }
+			onKeyDown={ handleOnKeyDown }
+		/>
+	);
+}

--- a/packages/components/src/number-control/index.js
+++ b/packages/components/src/number-control/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { clamp, noop } from 'lodash';
+import classNames from 'classnames';
 
 /**
  * WordPress dependencies
@@ -9,6 +10,7 @@ import { clamp, noop } from 'lodash';
 import { UP, DOWN } from '@wordpress/keycodes';
 
 export default function NumberControl( {
+	className,
 	isShiftStepEnabled = true,
 	max = Infinity,
 	min = -Infinity,
@@ -27,7 +29,9 @@ export default function NumberControl( {
 		const isEmpty = value === '';
 		const enableShift = event.shiftKey && isShiftStepEnabled;
 
-		const incrementalValue = enableShift ? shiftStep : step;
+		const incrementalValue = enableShift
+			? parseFloat( shiftStep )
+			: parseFloat( step );
 		let nextValue = isEmpty ? baseValue : value;
 
 		// Convert to a number to use math
@@ -40,7 +44,7 @@ export default function NumberControl( {
 				nextValue = nextValue + incrementalValue;
 				nextValue = clamp( nextValue, min, max );
 
-				onChange( nextValue.toString() );
+				onChange( nextValue.toString(), { event } );
 
 				break;
 
@@ -50,20 +54,23 @@ export default function NumberControl( {
 				nextValue = nextValue - incrementalValue;
 				nextValue = clamp( nextValue, min, max );
 
-				onChange( nextValue.toString() );
+				onChange( nextValue.toString(), { event } );
 
 				break;
 		}
 	};
 
 	const handleOnChange = ( event ) => {
-		onChange( event.target.value );
+		onChange( event.target.value, { event } );
 	};
+
+	const classes = classNames( 'component-number-control', className );
 
 	return (
 		<input
 			inputMode="numeric"
 			{ ...props }
+			className={ classes }
 			type="number"
 			onChange={ handleOnChange }
 			onKeyDown={ handleOnKeyDown }

--- a/packages/components/src/number-control/index.js
+++ b/packages/components/src/number-control/index.js
@@ -9,12 +9,12 @@ import { clamp, noop } from 'lodash';
 import { UP, DOWN } from '@wordpress/keycodes';
 
 export default function NumberControl( {
-	enableShiftIncrement = true,
+	isShiftStepEnabled = true,
 	max = Infinity,
 	min = -Infinity,
 	onChange = noop,
 	onKeyDown = noop,
-	shiftIncrement = 10,
+	shiftStep = 10,
 	step = 1,
 	...props
 } ) {
@@ -25,9 +25,11 @@ export default function NumberControl( {
 		const { value } = event.target;
 
 		const isEmpty = value === '';
-		const shiftAmount = step * shiftIncrement;
+		const enableShift = event.shiftKey && isShiftStepEnabled;
 
+		const incrementalValue = enableShift ? shiftStep : step;
 		let nextValue = isEmpty ? baseValue : value;
+
 		// Convert to a number to use math
 		nextValue = parseFloat( nextValue );
 
@@ -35,12 +37,7 @@ export default function NumberControl( {
 			case UP:
 				event.preventDefault();
 
-				if ( event.shiftKey && enableShiftIncrement ) {
-					nextValue = nextValue + shiftAmount;
-				} else {
-					nextValue = nextValue + step;
-				}
-
+				nextValue = nextValue + incrementalValue;
 				nextValue = clamp( nextValue, min, max );
 
 				onChange( nextValue.toString() );
@@ -50,12 +47,7 @@ export default function NumberControl( {
 			case DOWN:
 				event.preventDefault();
 
-				if ( event.shiftKey && enableShiftIncrement ) {
-					nextValue = nextValue - shiftAmount;
-				} else {
-					nextValue = nextValue - step;
-				}
-
+				nextValue = nextValue - incrementalValue;
 				nextValue = clamp( nextValue, min, max );
 
 				onChange( nextValue.toString() );
@@ -70,8 +62,8 @@ export default function NumberControl( {
 
 	return (
 		<input
-			{ ...props }
 			inputMode="numeric"
+			{ ...props }
 			type="number"
 			onChange={ handleOnChange }
 			onKeyDown={ handleOnKeyDown }

--- a/packages/components/src/number-control/stories/index.js
+++ b/packages/components/src/number-control/stories/index.js
@@ -1,0 +1,35 @@
+/**
+ * External dependencies
+ */
+import { boolean, number } from '@storybook/addon-knobs';
+
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import NumberControl from '../';
+
+export default {
+	title: 'Components/NumberControl',
+	component: NumberControl,
+};
+
+function Example() {
+	const [ value, setValue ] = useState( '' );
+
+	const props = {
+		isShiftStepEnabled: boolean( 'isShiftStepEnabled', true ),
+		shiftStep: number( 'shiftStep', 10 ),
+		step: number( 'step', 1 ),
+	};
+
+	return <NumberControl { ...props } value={ value } onChange={ setValue } />;
+}
+
+export const _default = () => {
+	return <Example />;
+};

--- a/packages/components/src/number-control/test/index.js
+++ b/packages/components/src/number-control/test/index.js
@@ -1,0 +1,305 @@
+/**
+ * External dependencies
+ */
+import { render, unmountComponentAtNode } from 'react-dom';
+import { act, Simulate } from 'react-dom/test-utils';
+
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+import { UP, DOWN } from '@wordpress/keycodes';
+
+/**
+ * Internal dependencies
+ */
+import NumberControl from '../';
+
+let container = null;
+
+function getInput() {
+	return container.querySelector( 'input' );
+}
+
+beforeEach( () => {
+	// setup a DOM element as a render target
+	container = document.createElement( 'div' );
+	document.body.appendChild( container );
+} );
+
+afterEach( () => {
+	// cleanup on exiting
+	unmountComponentAtNode( container );
+	container.remove();
+	container = null;
+} );
+
+function StatefulNumberControl( props ) {
+	const [ value, setValue ] = useState( props.value );
+	const handleOnChange = ( v ) => setValue( v );
+
+	return (
+		<NumberControl
+			{ ...props }
+			value={ value }
+			onChange={ handleOnChange }
+		/>
+	);
+}
+
+describe( 'NumberControl', () => {
+	describe( 'Basic rendering', () => {
+		it( 'should render', () => {
+			act( () => {
+				render( <NumberControl />, container );
+			} );
+
+			const input = getInput();
+
+			expect( input ).not.toBeNull();
+		} );
+
+		it( 'should render custom className', () => {
+			act( () => {
+				render( <NumberControl className="hello" />, container );
+			} );
+
+			const input = getInput();
+
+			expect( input.classList.contains( 'hello' ) ).toBe( true );
+		} );
+	} );
+
+	describe( 'onChange handling', () => {
+		it( 'should provide onChange callback with string value', () => {
+			const spy = jest.fn();
+			act( () => {
+				render(
+					<NumberControl value={ 5 } onChange={ spy } />,
+					container
+				);
+			} );
+
+			const input = getInput();
+
+			input.value = 10;
+			Simulate.change( input );
+
+			expect( spy.mock.calls[ 0 ][ 0 ] ).toBe( '10' );
+		} );
+	} );
+
+	describe( 'Key UP interactions', () => {
+		it( 'should fire onKeyDown callback', () => {
+			const spy = jest.fn();
+			act( () => {
+				render(
+					<StatefulNumberControl value={ 5 } onKeyDown={ spy } />,
+					container
+				);
+			} );
+
+			const input = getInput();
+
+			Simulate.keyDown( input, { keyCode: UP } );
+
+			expect( spy ).toHaveBeenCalled();
+		} );
+
+		it( 'should increment by step on key UP press', () => {
+			act( () => {
+				render( <StatefulNumberControl value={ 5 } />, container );
+			} );
+
+			const input = getInput();
+
+			Simulate.keyDown( input, { keyCode: UP } );
+
+			expect( input.value ).toBe( '6' );
+		} );
+
+		it( 'should increment from a negative value', () => {
+			act( () => {
+				render( <StatefulNumberControl value={ -5 } />, container );
+			} );
+
+			const input = getInput();
+
+			Simulate.keyDown( input, { keyCode: UP } );
+
+			expect( input.value ).toBe( '-4' );
+		} );
+
+		it( 'should increment by shiftStep on key UP + shift press', () => {
+			act( () => {
+				render( <StatefulNumberControl value={ 5 } />, container );
+			} );
+
+			const input = getInput();
+
+			Simulate.keyDown( input, { keyCode: UP, shiftKey: true } );
+
+			expect( input.value ).toBe( '15' );
+		} );
+
+		it( 'should increment by custom shiftStep on key UP + shift press', () => {
+			act( () => {
+				render(
+					<StatefulNumberControl value={ 5 } shiftStep={ 100 } />,
+					container
+				);
+			} );
+
+			const input = getInput();
+
+			Simulate.keyDown( input, { keyCode: UP, shiftKey: true } );
+
+			expect( input.value ).toBe( '105' );
+		} );
+
+		it( 'should increment but be limited by max on shiftStep', () => {
+			act( () => {
+				render(
+					<StatefulNumberControl
+						value={ 5 }
+						shiftStep={ 100 }
+						max={ 99 }
+					/>,
+					container
+				);
+			} );
+
+			const input = getInput();
+
+			Simulate.keyDown( input, { keyCode: UP, shiftKey: true } );
+
+			expect( input.value ).toBe( '99' );
+		} );
+
+		it( 'should not increment by shiftStep if disabled', () => {
+			act( () => {
+				render(
+					<StatefulNumberControl
+						value={ 5 }
+						shiftStep={ 100 }
+						isShiftStepEnabled={ false }
+					/>,
+					container
+				);
+			} );
+
+			const input = getInput();
+
+			Simulate.keyDown( input, { keyCode: UP, shiftKey: true } );
+
+			expect( input.value ).toBe( '6' );
+		} );
+	} );
+
+	describe( 'Key DOWN interactions', () => {
+		it( 'should fire onKeyDown callback', () => {
+			const spy = jest.fn();
+			act( () => {
+				render(
+					<StatefulNumberControl value={ 5 } onKeyDown={ spy } />,
+					container
+				);
+			} );
+
+			const input = getInput();
+
+			Simulate.keyDown( input, { keyCode: DOWN } );
+
+			expect( spy ).toHaveBeenCalled();
+		} );
+
+		it( 'should decrement by step on key DOWN press', () => {
+			act( () => {
+				render( <StatefulNumberControl value={ 5 } />, container );
+			} );
+
+			const input = getInput();
+
+			Simulate.keyDown( input, { keyCode: DOWN } );
+
+			expect( input.value ).toBe( '4' );
+		} );
+
+		it( 'should decrement from a negative value', () => {
+			act( () => {
+				render( <StatefulNumberControl value={ -5 } />, container );
+			} );
+
+			const input = getInput();
+
+			Simulate.keyDown( input, { keyCode: DOWN } );
+
+			expect( input.value ).toBe( '-6' );
+		} );
+
+		it( 'should decrement by shiftStep on key DOWN + shift press', () => {
+			act( () => {
+				render( <StatefulNumberControl value={ 5 } />, container );
+			} );
+
+			const input = getInput();
+
+			Simulate.keyDown( input, { keyCode: DOWN, shiftKey: true } );
+
+			expect( input.value ).toBe( '-5' );
+		} );
+
+		it( 'should decrement by custom shiftStep on key DOWN + shift press', () => {
+			act( () => {
+				render(
+					<StatefulNumberControl value={ 5 } shiftStep={ 100 } />,
+					container
+				);
+			} );
+
+			const input = getInput();
+
+			Simulate.keyDown( input, { keyCode: DOWN, shiftKey: true } );
+
+			expect( input.value ).toBe( '-95' );
+		} );
+
+		it( 'should decrement but be limited by min on shiftStep', () => {
+			act( () => {
+				render(
+					<StatefulNumberControl
+						value={ 5 }
+						shiftStep={ 100 }
+						min={ 4 }
+					/>,
+					container
+				);
+			} );
+
+			const input = getInput();
+
+			Simulate.keyDown( input, { keyCode: DOWN, shiftKey: true } );
+
+			expect( input.value ).toBe( '4' );
+		} );
+
+		it( 'should not decrement by shiftStep if disabled', () => {
+			act( () => {
+				render(
+					<StatefulNumberControl
+						value={ 5 }
+						shiftStep={ 100 }
+						isShiftStepEnabled={ false }
+					/>,
+					container
+				);
+			} );
+
+			const input = getInput();
+
+			Simulate.keyDown( input, { keyCode: DOWN, shiftKey: true } );
+
+			expect( input.value ).toBe( '4' );
+		} );
+	} );
+} );

--- a/packages/components/src/number-control/test/index.js
+++ b/packages/components/src/number-control/test/index.js
@@ -22,13 +22,11 @@ function getInput() {
 }
 
 beforeEach( () => {
-	// setup a DOM element as a render target
 	container = document.createElement( 'div' );
 	document.body.appendChild( container );
 } );
 
 afterEach( () => {
-	// cleanup on exiting
 	unmountComponentAtNode( container );
 	container.remove();
 	container = null;

--- a/packages/components/src/unit-control/README.md
+++ b/packages/components/src/unit-control/README.md
@@ -1,0 +1,37 @@
+# UnitControl
+
+UnitControl allows the user to set a value as well as a unit (e.g. `px`).
+
+## Usage
+
+```jsx
+import { __experimentalUnitControl as UnitControl } from '@wordpress/components';
+import { useState } from '@wordpress/element';
+
+const Example = () => {
+	const [value, setValue] = useState(10);
+	const [unit, setUnit] = useState('px');
+
+	return (
+		<UnitControl
+			onChange={ setValue }
+			onUnitChange={ setUnit }
+			unit={ unit }
+			value={ value}
+		/>
+	)
+};
+```
+
+## Props
+
+Name | Type | Default | Description
+--- | --- | --- | ---
+`isUnitSelectTabbable` | `boolean` | `true` | Determines if the unit `<select>` is tabbable.
+`label` | `string` | | Aria label for the control.
+`onChange` | `Function` | `noop` | Callback when the `value` changes.
+`onUnitChange` | `Function` | `noop` | Callback when the `unit` changes.
+`size` | `string` | `default` | Determines the height of the control.
+`unit` | `string` | `px` | Current unit value.
+`units` | `Array<string>` | | Collection of available units.
+`value` | `number` |  | Current number value.

--- a/packages/components/src/unit-control/index.js
+++ b/packages/components/src/unit-control/index.js
@@ -1,0 +1,89 @@
+/**
+ * External dependencies
+ */
+import { noop, isEmpty } from 'lodash';
+/**
+ * Internal dependencies
+ */
+import {
+	Root,
+	UnitSelect,
+	UnitLabel,
+	ValueInput,
+} from './styles/unit-control-styles';
+
+const CSS_UNITS = [
+	{ value: 'px', label: 'px' },
+	{ value: '%', label: '%' },
+	{ value: 'em', label: 'em' },
+	{ value: 'rem', label: 'rem' },
+	{ value: 'vw', label: 'vw' },
+	{ value: 'vh', label: 'vh' },
+];
+
+export default function UnitControl( {
+	isUnitSelectTabbable = true,
+	label,
+	onChange = noop,
+	onUnitChange = noop,
+	size = 'default',
+	unit,
+	units = CSS_UNITS,
+	value,
+	...props
+} ) {
+	const handleOnChange = ( event ) => {
+		onChange( event.target.value );
+	};
+
+	return (
+		<Root>
+			<ValueInput
+				aria-label={ label }
+				{ ...props }
+				value={ value }
+				onChange={ handleOnChange }
+				size={ size }
+				type="number"
+			/>
+			<UnitSelectControl
+				isTabbable={ isUnitSelectTabbable }
+				options={ units }
+				onChange={ onUnitChange }
+				size={ size }
+				value={ unit }
+			/>
+		</Root>
+	);
+}
+
+function UnitSelectControl( {
+	isTabbable = true,
+	options = CSS_UNITS,
+	onChange = noop,
+	size = 'default',
+	value = 'px',
+} ) {
+	if ( isEmpty( options ) ) {
+		return <UnitLabel size={ size }>{ value }</UnitLabel>;
+	}
+
+	const handleOnChange = ( event ) => {
+		onChange( event.target.value );
+	};
+
+	return (
+		<UnitSelect
+			value={ value }
+			onChange={ handleOnChange }
+			size={ size }
+			tabIndex={ isTabbable ? null : '-1' }
+		>
+			{ options.map( ( option ) => (
+				<option value={ option.value } key={ option.value }>
+					{ option.label }
+				</option>
+			) ) }
+		</UnitSelect>
+	);
+}

--- a/packages/components/src/unit-control/index.js
+++ b/packages/components/src/unit-control/index.js
@@ -8,7 +8,7 @@ import classNames from 'classnames';
  */
 import { Root, ValueInput } from './styles/unit-control-styles';
 import UnitSelectControl from './unit-select-control';
-import { CSS_UNITS, getComputedSize } from './utils';
+import { CSS_UNITS } from './utils';
 
 export default function UnitControl( {
 	className,
@@ -59,4 +59,3 @@ export default function UnitControl( {
 }
 
 UnitControl.__defaultUnits = CSS_UNITS;
-UnitControl.__getComputedSize = getComputedSize;

--- a/packages/components/src/unit-control/index.js
+++ b/packages/components/src/unit-control/index.js
@@ -1,25 +1,13 @@
 /**
  * External dependencies
  */
-import { noop, isEmpty } from 'lodash';
+import { noop } from 'lodash';
 /**
  * Internal dependencies
  */
-import {
-	Root,
-	UnitSelect,
-	UnitLabel,
-	ValueInput,
-} from './styles/unit-control-styles';
-
-const CSS_UNITS = [
-	{ value: 'px', label: 'px' },
-	{ value: '%', label: '%' },
-	{ value: 'em', label: 'em' },
-	{ value: 'rem', label: 'rem' },
-	{ value: 'vw', label: 'vw' },
-	{ value: 'vh', label: 'vh' },
-];
+import { Root, ValueInput } from './styles/unit-control-styles';
+import UnitSelectControl from './unit-select-control';
+import { CSS_UNITS } from './utils';
 
 export default function UnitControl( {
 	isUnitSelectTabbable = true,
@@ -27,7 +15,7 @@ export default function UnitControl( {
 	onChange = noop,
 	onUnitChange = noop,
 	size = 'default',
-	unit,
+	unit = 'px',
 	units = CSS_UNITS,
 	value,
 	...props
@@ -50,36 +38,5 @@ export default function UnitControl( {
 				value={ unit }
 			/>
 		</Root>
-	);
-}
-
-function UnitSelectControl( {
-	isTabbable = true,
-	options = CSS_UNITS,
-	onChange = noop,
-	size = 'default',
-	value = 'px',
-} ) {
-	if ( isEmpty( options ) ) {
-		return <UnitLabel size={ size }>{ value }</UnitLabel>;
-	}
-
-	const handleOnChange = ( event ) => {
-		onChange( event.target.value );
-	};
-
-	return (
-		<UnitSelect
-			value={ value }
-			onChange={ handleOnChange }
-			size={ size }
-			tabIndex={ isTabbable ? null : '-1' }
-		>
-			{ options.map( ( option ) => (
-				<option value={ option.value } key={ option.value }>
-					{ option.label }
-				</option>
-			) ) }
-		</UnitSelect>
 	);
 }

--- a/packages/components/src/unit-control/index.js
+++ b/packages/components/src/unit-control/index.js
@@ -36,6 +36,8 @@ export default function UnitControl( {
 		onChange( event.target.value );
 	};
 
+	// TODO: Create NumberControl primitive
+
 	return (
 		<Root>
 			<ValueInput

--- a/packages/components/src/unit-control/index.js
+++ b/packages/components/src/unit-control/index.js
@@ -1,42 +1,62 @@
 /**
  * External dependencies
  */
-import { noop } from 'lodash';
+import { isUndefined, noop } from 'lodash';
+import classNames from 'classnames';
 /**
  * Internal dependencies
  */
 import { Root, ValueInput } from './styles/unit-control-styles';
 import UnitSelectControl from './unit-select-control';
-import { CSS_UNITS } from './utils';
+import { CSS_UNITS, getComputedSize } from './utils';
 
 export default function UnitControl( {
+	className,
 	isUnitSelectTabbable = true,
+	isResetValueOnUnitChange = true,
 	label,
 	onChange = noop,
 	onUnitChange = noop,
 	size = 'default',
+	style,
 	unit = 'px',
 	units = CSS_UNITS,
 	value,
 	...props
 } ) {
+	const handleOnUnitChange = ( unitValue, changeProps ) => {
+		const { data } = changeProps;
+		onUnitChange( unitValue, changeProps );
+
+		if ( isResetValueOnUnitChange && ! isUndefined( data.default ) ) {
+			onChange( data.default, changeProps );
+		}
+	};
+
+	const classes = classNames( 'component-unit-control', className );
+
 	return (
-		<Root>
+		<Root className={ classes } style={ style }>
 			<ValueInput
 				aria-label={ label }
 				{ ...props }
+				className="component-unit-control__input"
 				value={ value }
 				onChange={ onChange }
 				size={ size }
 				type="number"
 			/>
 			<UnitSelectControl
+				className="component-unit-control__select"
 				isTabbable={ isUnitSelectTabbable }
 				options={ units }
-				onChange={ onUnitChange }
+				onChange={ handleOnUnitChange }
 				size={ size }
 				value={ unit }
 			/>
 		</Root>
 	);
 }
+
+UnitControl.__defaultUnits = CSS_UNITS;
+UnitControl.__getComputedSize = getComputedSize;

--- a/packages/components/src/unit-control/index.js
+++ b/packages/components/src/unit-control/index.js
@@ -32,20 +32,13 @@ export default function UnitControl( {
 	value,
 	...props
 } ) {
-	const handleOnChange = ( event ) => {
-		onChange( event.target.value );
-	};
-
-	// TODO: Create NumberControl primitive
-
 	return (
 		<Root>
 			<ValueInput
 				aria-label={ label }
-				inputmode="numeric"
 				{ ...props }
 				value={ value }
-				onChange={ handleOnChange }
+				onChange={ onChange }
 				size={ size }
 				type="number"
 			/>

--- a/packages/components/src/unit-control/index.js
+++ b/packages/components/src/unit-control/index.js
@@ -40,6 +40,7 @@ export default function UnitControl( {
 		<Root>
 			<ValueInput
 				aria-label={ label }
+				inputmode="numeric"
 				{ ...props }
 				value={ value }
 				onChange={ handleOnChange }

--- a/packages/components/src/unit-control/index.js
+++ b/packages/components/src/unit-control/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { isUndefined, noop } from 'lodash';
-import classNames from 'classnames';
+import classnames from 'classnames';
 /**
  * Internal dependencies
  */
@@ -33,7 +33,7 @@ export default function UnitControl( {
 		}
 	};
 
-	const classes = classNames( 'component-unit-control', className );
+	const classes = classnames( 'component-unit-control', className );
 
 	return (
 		<Root className={ classes } style={ style }>

--- a/packages/components/src/unit-control/stories/index.js
+++ b/packages/components/src/unit-control/stories/index.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { boolean, number, select } from '@storybook/addon-knobs';
 import styled from '@emotion/styled';
 
 /**
@@ -22,9 +23,25 @@ function Example() {
 	const [ value, setValue ] = useState( '' );
 	const [ unit, setUnit ] = useState( 'px' );
 
+	const props = {
+		isShiftStepEnabled: boolean( 'isShiftStepEnabled', true ),
+		isUnitSelectTabbable: boolean( 'isUnitSelectTabbable', true ),
+		shiftStep: number( 'shiftStep', 10 ),
+		size: select(
+			'size',
+			{
+				default: 'default',
+				small: 'small',
+			},
+			'default'
+		),
+		step: number( 'step', 1 ),
+	};
+
 	return (
 		<ControlWrapperView>
 			<UnitControl
+				{ ...props }
 				value={ value }
 				onChange={ setValue }
 				unit={ unit }
@@ -35,16 +52,8 @@ function Example() {
 }
 
 export const _default = () => {
-	return (
-		<Wrapper>
-			<Example />
-		</Wrapper>
-	);
+	return <Example />;
 };
-
-const Wrapper = styled.div`
-	padding: 40px;
-`;
 
 const ControlWrapperView = styled.div`
 	max-width: 80px;

--- a/packages/components/src/unit-control/stories/index.js
+++ b/packages/components/src/unit-control/stories/index.js
@@ -1,0 +1,43 @@
+/**
+ * External dependencies
+ */
+import styled from '@emotion/styled';
+
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import UnitControl from '../';
+
+export default {
+	title: 'Components/UnitControl',
+	component: UnitControl,
+};
+
+function Example() {
+	const [ value, setValue ] = useState( 0 );
+	const [ unit, setUnit ] = useState( 'px' );
+
+	return (
+		<ControlWrapperView>
+			<UnitControl
+				value={ value }
+				onChange={ setValue }
+				unit={ unit }
+				onUnitChange={ setUnit }
+			/>
+		</ControlWrapperView>
+	);
+}
+
+export const _default = () => {
+	return <Example />;
+};
+
+const ControlWrapperView = styled.div`
+	max-width: 80px;
+`;

--- a/packages/components/src/unit-control/stories/index.js
+++ b/packages/components/src/unit-control/stories/index.js
@@ -19,7 +19,7 @@ export default {
 };
 
 function Example() {
-	const [ value, setValue ] = useState( 0 );
+	const [ value, setValue ] = useState( '' );
 	const [ unit, setUnit ] = useState( 'px' );
 
 	return (
@@ -35,8 +35,16 @@ function Example() {
 }
 
 export const _default = () => {
-	return <Example />;
+	return (
+		<Wrapper>
+			<Example />
+		</Wrapper>
+	);
 };
+
+const Wrapper = styled.div`
+	padding: 40px;
+`;
 
 const ControlWrapperView = styled.div`
 	max-width: 80px;

--- a/packages/components/src/unit-control/styles/unit-control-styles.js
+++ b/packages/components/src/unit-control/styles/unit-control-styles.js
@@ -74,10 +74,12 @@ const unitSizeStyles = ( { size } ) => {
 		default: {
 			top: 5,
 			height: 20,
+			minHeight: 20,
 		},
 		small: {
 			top: 4,
 			height: 16,
+			minHeight: 16,
 		},
 	};
 
@@ -94,7 +96,7 @@ const unitLabelStyles = ( props ) => {
 		color: ${color( 'darkGray.500' )};
 		display: block;
 		font-size: 8px;
-		height: 20px;
+		line-height: 1;
 		letter-spacing: -0.5px;
 		outline: none;
 		padding: 2px 2px;

--- a/packages/components/src/unit-control/styles/unit-control-styles.js
+++ b/packages/components/src/unit-control/styles/unit-control-styles.js
@@ -17,12 +17,16 @@ export const Root = styled.div`
 const fontSizeStyles = ( { size } ) => {
 	const sizes = {
 		default: null,
-		small: 11,
+		small: '11px',
 	};
+
+	const fontSize = sizes[ size ];
+
+	if ( ! fontSize ) return '';
 
 	return css`
 		@media ( min-width: 600px ) {
-			font-size: ${sizes[ size ]};
+			font-size: ${fontSize};
 		}
 	`;
 };
@@ -32,10 +36,12 @@ const sizeStyles = ( { size } ) => {
 		default: {
 			height: 30,
 			lineHeight: 30,
+			minHeight: 30,
 		},
 		small: {
 			height: 24,
 			lineHeight: 24,
+			minHeight: 24,
 		},
 	};
 
@@ -86,7 +92,7 @@ const unitSizeStyles = ( { size } ) => {
 	return css( sizes[ size ] );
 };
 
-const unitLabelStyles = ( props ) => {
+const baseUnitLabelStyles = ( props ) => {
 	return css`
 		appearance: none;
 		background: ${color( 'ui.background' )};
@@ -111,16 +117,25 @@ const unitLabelStyles = ( props ) => {
 	`;
 };
 
+const unitLabelPaddingStyles = ( { size } ) => {
+	const sizes = {
+		default: '6px 2px',
+		small: '4px 2px',
+	};
+
+	return css( { padding: sizes[ size ] } );
+};
+
 export const UnitLabel = styled.div`
 	&&& {
-		${unitLabelStyles};
-		padding: 5px 2px;
+		${baseUnitLabelStyles};
+		${unitLabelPaddingStyles};
 	}
 `;
 
 export const UnitSelect = styled.select`
 	&&& {
-		${unitLabelStyles};
+		${baseUnitLabelStyles};
 		cursor: pointer;
 		border: 1px solid transparent;
 

--- a/packages/components/src/unit-control/styles/unit-control-styles.js
+++ b/packages/components/src/unit-control/styles/unit-control-styles.js
@@ -6,7 +6,7 @@ import styled from '@emotion/styled';
 /**
  * Internal dependencies
  */
-import { rtl } from '../../utils/style-mixins';
+import { color, rtl } from '../../utils/style-mixins';
 
 export const Root = styled.div`
 	box-sizing: border-box;
@@ -36,7 +36,7 @@ export const ValueInput = styled.input`
 	&&& {
 		appearance: none;
 		box-sizing: border-box;
-		border: 1px solid black;
+		border: 1px solid ${color( 'ui.border' )};
 		border-radius: 2px;
 		padding: 3px 8px;
 		display: block;
@@ -65,11 +65,11 @@ const unitHeightStyles = ( { size } ) => {
 const unitLabelStyles = ( props ) => {
 	return css`
 		appearance: none;
-		background: white;
+		background: ${color( 'ui.background' )};
 		border-radius: 2px;
 		border: none;
 		box-sizing: border-box;
-		color: #333;
+		color: ${color( 'darkGray.500' )};
 		display: block;
 		font-size: 8px;
 		height: 20px;
@@ -82,7 +82,7 @@ const unitLabelStyles = ( props ) => {
 		width: 22px;
 		z-index: 1;
 
-		${rtl( { right: 4 } )}
+		${rtl( { right: 4 } )()}
 		${unitHeightStyles( props )}
 	`;
 };
@@ -101,7 +101,7 @@ export const UnitSelect = styled.select`
 
 		&:hover,
 		&:focus {
-			box-shadow: 0 0 0 1px black inset;
+			box-shadow: 0 0 0 1px ${color( 'ui.border' )} inset;
 		}
 	}
 `;

--- a/packages/components/src/unit-control/styles/unit-control-styles.js
+++ b/packages/components/src/unit-control/styles/unit-control-styles.js
@@ -7,6 +7,7 @@ import styled from '@emotion/styled';
  * Internal dependencies
  */
 import { color, rtl } from '../../utils/style-mixins';
+import NumberControl from '../../number-control';
 
 export const Root = styled.div`
 	box-sizing: border-box;
@@ -32,7 +33,7 @@ const sizeStyles = ( { size } ) => {
 	return css( style );
 };
 
-export const ValueInput = styled.input`
+export const ValueInput = styled( NumberControl )`
 	&&& {
 		appearance: none;
 		box-sizing: border-box;
@@ -48,7 +49,7 @@ export const ValueInput = styled.input`
 			margin: 0;
 		}
 
-		${rtl( { paddingRight: 18 } )}
+		${rtl( { paddingRight: 20 } )}
 		${sizeStyles};
 	}
 `;

--- a/packages/components/src/unit-control/styles/unit-control-styles.js
+++ b/packages/components/src/unit-control/styles/unit-control-styles.js
@@ -1,0 +1,107 @@
+/**
+ * External dependencies
+ */
+import { css } from '@emotion/core';
+import styled from '@emotion/styled';
+/**
+ * Internal dependencies
+ */
+import { rtl } from '../../utils/style-mixins';
+
+export const Root = styled.div`
+	box-sizing: border-box;
+	position: relative;
+`;
+
+const sizeStyles = ( { size } ) => {
+	const sizes = {
+		default: {
+			fontSize: null,
+			height: 30,
+			lineHeight: 30,
+		},
+		small: {
+			fontSize: 11,
+			height: 24,
+			lineHeight: 24,
+		},
+	};
+
+	const style = sizes[ size ] || sizes.default;
+
+	return css( style );
+};
+
+export const ValueInput = styled.input`
+	&&& {
+		appearance: none;
+		box-sizing: border-box;
+		border: 1px solid black;
+		border-radius: 2px;
+		padding: 3px 8px;
+		display: block;
+		width: 100%;
+
+		&::-webkit-outer-spin-button,
+		&::-webkit-inner-spin-button {
+			-webkit-appearance: none;
+			margin: 0;
+		}
+
+		${rtl( { paddingRight: 18 } )}
+		${sizeStyles};
+	}
+`;
+
+const unitHeightStyles = ( { size } ) => {
+	const tops = {
+		default: 5,
+		small: 2,
+	};
+
+	return css( { top: tops[ size ] } );
+};
+
+const unitLabelStyles = ( props ) => {
+	return css`
+		appearance: none;
+		background: white;
+		border-radius: 2px;
+		border: none;
+		box-sizing: border-box;
+		color: #333;
+		display: block;
+		font-size: 8px;
+		height: 20px;
+		letter-spacing: -0.5px;
+		outline: none;
+		padding: 2px 2px;
+		position: absolute;
+		text-align-last: center;
+		text-transform: uppercase;
+		width: 22px;
+		z-index: 1;
+
+		${rtl( { right: 4 } )}
+		${unitHeightStyles( props )}
+	`;
+};
+
+export const UnitLabel = styled.div`
+	&&& {
+		${unitLabelStyles};
+		padding: 5px 2px;
+	}
+`;
+
+export const UnitSelect = styled.select`
+	&&& {
+		${unitLabelStyles};
+		cursor: pointer;
+
+		&:hover,
+		&:focus {
+			box-shadow: 0 0 0 1px black inset;
+		}
+	}
+`;

--- a/packages/components/src/unit-control/styles/unit-control-styles.js
+++ b/packages/components/src/unit-control/styles/unit-control-styles.js
@@ -14,15 +14,26 @@ export const Root = styled.div`
 	position: relative;
 `;
 
+const fontSizeStyles = ( { size } ) => {
+	const sizes = {
+		default: null,
+		small: 11,
+	};
+
+	return css`
+		@media ( min-width: 600px ) {
+			font-size: ${sizes[ size ]};
+		}
+	`;
+};
+
 const sizeStyles = ( { size } ) => {
 	const sizes = {
 		default: {
-			fontSize: null,
 			height: 30,
 			lineHeight: 30,
 		},
 		small: {
-			fontSize: 11,
 			height: 24,
 			lineHeight: 24,
 		},
@@ -32,6 +43,9 @@ const sizeStyles = ( { size } ) => {
 
 	return css( style );
 };
+
+// TODO: Resolve need to use &&& to increase specificity
+// https://github.com/WordPress/gutenberg/issues/18483
 
 export const ValueInput = styled( NumberControl )`
 	&&& {
@@ -50,17 +64,24 @@ export const ValueInput = styled( NumberControl )`
 		}
 
 		${rtl( { paddingRight: 20 } )}
+		${fontSizeStyles};
 		${sizeStyles};
 	}
 `;
 
-const unitHeightStyles = ( { size } ) => {
-	const tops = {
-		default: 5,
-		small: 2,
+const unitSizeStyles = ( { size } ) => {
+	const sizes = {
+		default: {
+			top: 5,
+			height: 20,
+		},
+		small: {
+			top: 4,
+			height: 16,
+		},
 	};
 
-	return css( { top: tops[ size ] } );
+	return css( sizes[ size ] );
 };
 
 const unitLabelStyles = ( props ) => {
@@ -84,7 +105,7 @@ const unitLabelStyles = ( props ) => {
 		z-index: 1;
 
 		${rtl( { right: 4 } )()}
-		${unitHeightStyles( props )}
+		${unitSizeStyles( props )}
 	`;
 };
 
@@ -99,10 +120,16 @@ export const UnitSelect = styled.select`
 	&&& {
 		${unitLabelStyles};
 		cursor: pointer;
+		border: 1px solid transparent;
 
-		&:hover,
+		&:hover {
+			background-color: ${color( 'lightGray.300' )};
+		}
+
 		&:focus {
-			box-shadow: 0 0 0 1px ${color( 'ui.border' )} inset;
+			border-color: ${color( 'ui.borderFocus' )};
+			outline: 2px solid transparent;
+			outline-offset: 0;
 		}
 	}
 `;

--- a/packages/components/src/unit-control/test/index.js
+++ b/packages/components/src/unit-control/test/index.js
@@ -1,0 +1,283 @@
+/**
+ * External dependencies
+ */
+import { render, unmountComponentAtNode } from 'react-dom';
+import { act, Simulate } from 'react-dom/test-utils';
+
+/**
+ * WordPress dependencies
+ */
+import { UP, DOWN } from '@wordpress/keycodes';
+
+/**
+ * Internal dependencies
+ */
+import UnitControl from '../';
+
+let container = null;
+
+beforeEach( () => {
+	container = document.createElement( 'div' );
+	document.body.appendChild( container );
+} );
+
+afterEach( () => {
+	unmountComponentAtNode( container );
+	container.remove();
+	container = null;
+} );
+
+const getComponent = () => container.querySelector( '.component-unit-control' );
+const getInput = () =>
+	container.querySelector( '.component-unit-control__input' );
+const getSelect = () =>
+	container.querySelector( '.component-unit-control__select' );
+
+describe( 'UnitControl', () => {
+	describe( 'Basic rendering', () => {
+		it( 'should render', () => {
+			act( () => {
+				render( <UnitControl />, container );
+			} );
+			const input = getInput();
+			const select = getSelect();
+
+			expect( input ).toBeTruthy();
+			expect( select ).toBeTruthy();
+		} );
+
+		it( 'should render custom className', () => {
+			act( () => {
+				render( <UnitControl className="hello" />, container );
+			} );
+
+			const el = getComponent();
+
+			expect( el.classList.contains( 'hello' ) ).toBe( true );
+		} );
+
+		it( 'should not render select, if units are disabled', () => {
+			act( () => {
+				render( <UnitControl unit="em" units={ false } />, container );
+			} );
+			const input = getInput();
+			const select = getSelect();
+
+			expect( input ).toBeTruthy();
+			expect( select ).toBeFalsy();
+		} );
+	} );
+
+	describe( 'Value', () => {
+		it( 'should update value on change', () => {
+			let state = 50;
+			const setState = ( nextState ) => ( state = nextState );
+
+			act( () => {
+				render(
+					<UnitControl value={ state } onChange={ setState } />,
+					container
+				);
+			} );
+
+			const input = getInput();
+
+			act( () => {
+				Simulate.change( input, { target: { value: 62 } } );
+			} );
+
+			expect( state ).toBe( 62 );
+		} );
+
+		it( 'should increment value on UP press', () => {
+			let state = 50;
+			const setState = ( nextState ) => ( state = nextState );
+
+			act( () => {
+				render(
+					<UnitControl value={ state } onChange={ setState } />,
+					container
+				);
+			} );
+
+			const input = getInput();
+
+			act( () => {
+				Simulate.keyDown( input, { keyCode: UP } );
+			} );
+
+			expect( state ).toBe( '51' );
+		} );
+
+		it( 'should increment value on UP + SHIFT press, with step', () => {
+			let state = 50;
+			const setState = ( nextState ) => ( state = nextState );
+
+			act( () => {
+				render(
+					<UnitControl value={ state } onChange={ setState } />,
+					container
+				);
+			} );
+
+			const input = getInput();
+
+			act( () => {
+				Simulate.keyDown( input, { keyCode: UP, shiftKey: true } );
+			} );
+
+			expect( state ).toBe( '60' );
+		} );
+
+		it( 'should decrement value on DOWN press', () => {
+			let state = 50;
+			const setState = ( nextState ) => ( state = nextState );
+
+			act( () => {
+				render(
+					<UnitControl value={ state } onChange={ setState } />,
+					container
+				);
+			} );
+
+			const input = getInput();
+
+			act( () => {
+				Simulate.keyDown( input, { keyCode: DOWN } );
+			} );
+
+			expect( state ).toBe( '49' );
+		} );
+
+		it( 'should decrement value on DOWN + SHIFT press, with step', () => {
+			let state = 50;
+			const setState = ( nextState ) => ( state = nextState );
+
+			act( () => {
+				render(
+					<UnitControl value={ state } onChange={ setState } />,
+					container
+				);
+			} );
+
+			const input = getInput();
+
+			act( () => {
+				Simulate.keyDown( input, { keyCode: DOWN, shiftKey: true } );
+			} );
+
+			expect( state ).toBe( '40' );
+		} );
+	} );
+
+	describe( 'Unit', () => {
+		it( 'should update unit value on change', () => {
+			let state = 'px';
+			const setState = ( nextState ) => ( state = nextState );
+
+			act( () => {
+				render(
+					<UnitControl unit={ state } onUnitChange={ setState } />,
+					container
+				);
+			} );
+
+			const select = getSelect();
+
+			act( () => {
+				Simulate.change( select, { target: { value: 'em' } } );
+			} );
+
+			expect( state ).toBe( 'em' );
+		} );
+
+		it( 'should render customized units, if defined', () => {
+			const units = [
+				{ value: 'pt', label: 'pt', default: 0 },
+				{ value: 'vmax', label: 'vmax', default: 10 },
+			];
+			act( () => {
+				render( <UnitControl units={ units } />, container );
+			} );
+
+			const select = getSelect();
+			const options = select.querySelectorAll( 'option' );
+
+			expect( options.length ).toBe( 2 );
+
+			const [ pt, vmax ] = options;
+
+			expect( pt.value ).toBe( 'pt' );
+			expect( vmax.value ).toBe( 'vmax' );
+		} );
+
+		it( 'should reset value on unit change, if unit has default value', () => {
+			let state = 50;
+			const setState = ( nextState ) => ( state = nextState );
+
+			const units = [
+				{ value: 'pt', label: 'pt', default: 25 },
+				{ value: 'vmax', label: 'vmax', default: 75 },
+			];
+			act( () => {
+				render(
+					<UnitControl
+						units={ units }
+						onChange={ setState }
+						value={ state }
+					/>,
+					container
+				);
+			} );
+
+			const select = getSelect();
+
+			act( () => {
+				Simulate.change( select, { target: { value: 'vmax' } } );
+			} );
+
+			expect( state ).toBe( 75 );
+
+			act( () => {
+				Simulate.change( select, { target: { value: 'pt' } } );
+			} );
+
+			expect( state ).toBe( 25 );
+		} );
+
+		it( 'should not reset value on unit change, if disabled', () => {
+			let state = 50;
+			const setState = ( nextState ) => ( state = nextState );
+
+			const units = [
+				{ value: 'pt', label: 'pt', default: 25 },
+				{ value: 'vmax', label: 'vmax', default: 75 },
+			];
+			act( () => {
+				render(
+					<UnitControl
+						isResetValueOnUnitChange={ false }
+						value={ state }
+						units={ units }
+						onChange={ setState }
+					/>,
+					container
+				);
+			} );
+
+			const select = getSelect();
+
+			act( () => {
+				Simulate.change( select, { target: { value: 'vmax' } } );
+			} );
+
+			expect( state ).toBe( 50 );
+
+			act( () => {
+				Simulate.change( select, { target: { value: 'pt' } } );
+			} );
+
+			expect( state ).toBe( 50 );
+		} );
+	} );
+} );

--- a/packages/components/src/unit-control/unit-select-control.js
+++ b/packages/components/src/unit-control/unit-select-control.js
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import { noop, isEmpty } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { UnitSelect, UnitLabel } from './styles/unit-control-styles';
+import { CSS_UNITS } from './utils';
+
+export default function UnitSelectControl( {
+	isTabbable = true,
+	options = CSS_UNITS,
+	onChange = noop,
+	size = 'default',
+	value = 'px',
+} ) {
+	if ( isEmpty( options ) ) {
+		return <UnitLabel size={ size }>{ value }</UnitLabel>;
+	}
+
+	const handleOnChange = ( event ) => {
+		onChange( event.target.value );
+	};
+
+	return (
+		<UnitSelect
+			value={ value }
+			onChange={ handleOnChange }
+			size={ size }
+			tabIndex={ isTabbable ? null : '-1' }
+		>
+			{ options.map( ( option ) => (
+				<option value={ option.value } key={ option.value }>
+					{ option.label }
+				</option>
+			) ) }
+		</UnitSelect>
+	);
+}

--- a/packages/components/src/unit-control/unit-select-control.js
+++ b/packages/components/src/unit-control/unit-select-control.js
@@ -20,7 +20,7 @@ export default function UnitSelectControl( {
 	size = 'default',
 	value = 'px',
 } ) {
-	if ( isEmpty( options ) || options.length === 1 ) {
+	if ( isEmpty( options ) || options.length === 1 || options === false ) {
 		return <UnitLabel size={ size }>{ value }</UnitLabel>;
 	}
 

--- a/packages/components/src/unit-control/unit-select-control.js
+++ b/packages/components/src/unit-control/unit-select-control.js
@@ -9,6 +9,10 @@ import { noop, isEmpty } from 'lodash';
 import { UnitSelect, UnitLabel } from './styles/unit-control-styles';
 import { CSS_UNITS } from './utils';
 
+/**
+ * Renders a `select` if there are multiple units.
+ * Otherwise, renders a non-selectable label.
+ */
 export default function UnitSelectControl( {
 	isTabbable = true,
 	options = CSS_UNITS,
@@ -16,7 +20,7 @@ export default function UnitSelectControl( {
 	size = 'default',
 	value = 'px',
 } ) {
-	if ( isEmpty( options ) ) {
+	if ( isEmpty( options ) || options.length === 1 ) {
 		return <UnitLabel size={ size }>{ value }</UnitLabel>;
 	}
 

--- a/packages/components/src/unit-control/unit-select-control.js
+++ b/packages/components/src/unit-control/unit-select-control.js
@@ -25,7 +25,10 @@ export default function UnitSelectControl( {
 	}
 
 	const handleOnChange = ( event ) => {
-		onChange( event.target.value );
+		const { value: unitValue } = event.target;
+		const data = options.find( ( option ) => option.value === unitValue );
+
+		onChange( unitValue, { event, data } );
 	};
 
 	return (

--- a/packages/components/src/unit-control/unit-select-control.js
+++ b/packages/components/src/unit-control/unit-select-control.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { noop, isEmpty } from 'lodash';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -14,11 +15,13 @@ import { CSS_UNITS } from './utils';
  * Otherwise, renders a non-selectable label.
  */
 export default function UnitSelectControl( {
+	className,
 	isTabbable = true,
 	options = CSS_UNITS,
 	onChange = noop,
 	size = 'default',
 	value = 'px',
+	...props
 } ) {
 	if ( isEmpty( options ) || options.length === 1 || options === false ) {
 		return <UnitLabel size={ size }>{ value }</UnitLabel>;
@@ -31,12 +34,16 @@ export default function UnitSelectControl( {
 		onChange( unitValue, { event, data } );
 	};
 
+	const classes = classnames( 'component-unit-control__select', className );
+
 	return (
 		<UnitSelect
-			value={ value }
+			className={ classes }
 			onChange={ handleOnChange }
 			size={ size }
 			tabIndex={ isTabbable ? null : '-1' }
+			value={ value }
+			{ ...props }
 		>
 			{ options.map( ( option ) => (
 				<option value={ option.value } key={ option.value }>

--- a/packages/components/src/unit-control/utils.js
+++ b/packages/components/src/unit-control/utils.js
@@ -6,20 +6,3 @@ export const CSS_UNITS = [
 	{ value: 'vw', label: 'vw', default: 10 },
 	{ value: 'vh', label: 'vh', default: 10 },
 ];
-
-export function getComputedSize( { value = 0, unit = 'px' } ) {
-	if ( unit === 'px' ) {
-		return value;
-	}
-
-	if ( unit === 'em' || unit === 'rem' ) {
-		const { fontSize } = window.getComputedStyle(
-			document.documentElement
-		);
-		return parseFloat( fontSize ) * value;
-	}
-
-	const windowValue = unit === 'vw' ? window.innerWidth : window.innerHeight;
-
-	return Math.round( windowValue * ( value / 100 ) );
-}

--- a/packages/components/src/unit-control/utils.js
+++ b/packages/components/src/unit-control/utils.js
@@ -1,8 +1,25 @@
 export const CSS_UNITS = [
-	{ value: 'px', label: 'px' },
-	{ value: '%', label: '%' },
-	{ value: 'em', label: 'em' },
-	{ value: 'rem', label: 'rem' },
-	{ value: 'vw', label: 'vw' },
-	{ value: 'vh', label: 'vh' },
+	{ value: 'px', label: 'px', default: 0 },
+	{ value: '%', label: '%', default: 10 },
+	{ value: 'em', label: 'em', default: 0 },
+	{ value: 'rem', label: 'rem', default: 0 },
+	{ value: 'vw', label: 'vw', default: 10 },
+	{ value: 'vh', label: 'vh', default: 10 },
 ];
+
+export function getComputedSize( { value = 0, unit = 'px' } ) {
+	if ( unit === 'px' ) {
+		return value;
+	}
+
+	if ( unit === 'em' || unit === 'rem' ) {
+		const { fontSize } = window.getComputedStyle(
+			document.documentElement
+		);
+		return parseFloat( fontSize ) * value;
+	}
+
+	const windowValue = unit === 'vw' ? window.innerWidth : window.innerHeight;
+
+	return Math.round( windowValue * ( value / 100 ) );
+}

--- a/packages/components/src/unit-control/utils.js
+++ b/packages/components/src/unit-control/utils.js
@@ -1,0 +1,8 @@
+export const CSS_UNITS = [
+	{ value: 'px', label: 'px' },
+	{ value: '%', label: '%' },
+	{ value: 'em', label: 'em' },
+	{ value: 'rem', label: 'rem' },
+	{ value: 'vw', label: 'vw' },
+	{ value: 'vh', label: 'vh' },
+];

--- a/packages/components/src/utils/colors-values.js
+++ b/packages/components/src/utils/colors-values.js
@@ -1,10 +1,36 @@
 /**
+ * External dependencies
+ */
+import { merge } from 'lodash';
+
+/**
  * Internal dependencies
  */
 import { rgba } from './colors';
+
 export const BASE = {
 	black: '#000',
 	white: '#fff',
+};
+
+export const G2 = {
+	blue: {
+		medium: {
+			focus: '#007cba',
+			focusDark: '#fff',
+		},
+	},
+	darkGray: {
+		primary: '#1e1e1e',
+	},
+	mediumGray: {
+		text: '#757575',
+	},
+	lightGray: {
+		ui: '#949494',
+		secondary: '#ccc',
+		tertiary: '#e7e8e9',
+	},
 };
 
 export const DARK_GRAY = {
@@ -101,15 +127,23 @@ export const ALERT = {
 	green: '#4ab866',
 };
 
+// Namespaced values for raw colors hex codes
+export const UI = {
+	background: BASE.white,
+	border: BASE.black,
+};
+
 export const COLORS = {
 	...BASE,
-	darkGray: DARK_GRAY,
+	darkGray: merge( DARK_GRAY, G2.darkGray ),
 	darkOpacity: DARK_OPACITY,
 	darkOpacityLight: DARK_OPACITY_LIGHT,
-	lightGray: LIGHT_GRAY,
+	mediumGray: G2.mediumGray,
+	lightGray: merge( LIGHT_GRAY, G2.lightGray ),
 	lightGrayLight: LIGHT_OPACITY_LIGHT,
-	blue: BLUE,
+	blue: merge( BLUE, G2.blue ),
 	alert: ALERT,
+	ui: UI,
 };
 
 export default COLORS;

--- a/packages/components/src/utils/colors-values.js
+++ b/packages/components/src/utils/colors-values.js
@@ -131,6 +131,7 @@ export const ALERT = {
 export const UI = {
 	background: BASE.white,
 	border: BASE.black,
+	borderFocus: BLUE.medium.focus,
 };
 
 export const COLORS = {

--- a/packages/components/src/utils/colors-values.js
+++ b/packages/components/src/utils/colors-values.js
@@ -18,7 +18,6 @@ export const BASE = {
  *
  * "G2" refers to the movement to advance the interface of the block editor.
  * https://github.com/WordPress/gutenberg/issues/18667
-
  */
 export const G2 = {
 	blue: {
@@ -143,13 +142,13 @@ export const UI = {
 
 export const COLORS = {
 	...BASE,
-	darkGray: merge( DARK_GRAY, G2.darkGray ),
+	darkGray: merge( {}, DARK_GRAY, G2.darkGray ),
 	darkOpacity: DARK_OPACITY,
 	darkOpacityLight: DARK_OPACITY_LIGHT,
 	mediumGray: G2.mediumGray,
-	lightGray: merge( LIGHT_GRAY, G2.lightGray ),
+	lightGray: merge( {}, LIGHT_GRAY, G2.lightGray ),
 	lightGrayLight: LIGHT_OPACITY_LIGHT,
-	blue: merge( BLUE, G2.blue ),
+	blue: merge( {}, BLUE, G2.blue ),
 	alert: ALERT,
 	ui: UI,
 };

--- a/packages/components/src/utils/colors-values.js
+++ b/packages/components/src/utils/colors-values.js
@@ -13,6 +13,13 @@ export const BASE = {
 	white: '#fff',
 };
 
+/**
+ * TODO: Continue to update values as "G2" design evolves.
+ *
+ * "G2" refers to the movement to advance the interface of the block editor.
+ * https://github.com/WordPress/gutenberg/issues/18667
+
+ */
 export const G2 = {
 	blue: {
 		medium: {

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -117,6 +117,7 @@ class EditorProvider extends Component {
 				'templateLock',
 				'titlePlaceholder',
 				'onUpdateDefaultBlockStyles',
+				'__experimentalDisableCustomUnits',
 				'__experimentalEnableLegacyWidgetBlock',
 				'__experimentalBlockDirectory',
 				'__experimentalEnableFullSiteEditing',

--- a/storybook/test/__snapshots__/index.js.snap
+++ b/storybook/test/__snapshots__/index.js.snap
@@ -3929,6 +3929,17 @@ exports[`Storyshots Components/Modal Default 1`] = `
 </button>
 `;
 
+exports[`Storyshots Components/NumberControl Default 1`] = `
+<input
+  className="component-number-control"
+  inputMode="numeric"
+  onChange={[Function]}
+  onKeyDown={[Function]}
+  type="number"
+  value=""
+/>
+`;
+
 exports[`Storyshots Components/Panel Default 1`] = `
 <div
   className="components-panel"
@@ -8745,6 +8756,135 @@ exports[`Storyshots Components/TreeSelect Default 1`] = `
   >
     Help text to explain the select control.
   </p>
+</div>
+`;
+
+exports[`Storyshots Components/UnitControl Default 1`] = `
+.emotion-6 {
+  max-width: 80px;
+}
+
+.emotion-4 {
+  box-sizing: border-box;
+  position: relative;
+}
+
+.emotion-0.emotion-0.emotion-0 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  box-sizing: border-box;
+  border: 1px solid #000;
+  border-radius: 2px;
+  padding: 3px 8px;
+  display: block;
+  width: 100%;
+  padding-right: 20px;
+  height: 30px;
+  line-height: 30;
+}
+
+.emotion-0.emotion-0.emotion-0::-webkit-outer-spin-button,
+.emotion-0.emotion-0.emotion-0::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.emotion-2.emotion-2.emotion-2 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background: #fff;
+  border-radius: 2px;
+  border: none;
+  box-sizing: border-box;
+  color: #555d66;
+  display: block;
+  font-size: 8px;
+  line-height: 1;
+  -webkit-letter-spacing: -0.5px;
+  -moz-letter-spacing: -0.5px;
+  -ms-letter-spacing: -0.5px;
+  letter-spacing: -0.5px;
+  outline: none;
+  padding: 2px 2px;
+  position: absolute;
+  text-align-last: center;
+  text-transform: uppercase;
+  width: 22px;
+  z-index: 1;
+  right: 4px;
+  top: 5px;
+  height: 20px;
+  min-height: 20px;
+  cursor: pointer;
+  border: 1px solid transparent;
+}
+
+.emotion-2.emotion-2.emotion-2:hover {
+  background-color: #edeff0;
+}
+
+.emotion-2.emotion-2.emotion-2:focus {
+  border-color: #007cba;
+  outline: 2px solid transparent;
+  outline-offset: 0;
+}
+
+<div
+  className="emotion-6 emotion-7"
+>
+  <div
+    className="component-unit-control emotion-4 emotion-5"
+  >
+    <input
+      className="component-number-control component-unit-control__input emotion-0 emotion-1"
+      inputMode="numeric"
+      onChange={[Function]}
+      onKeyDown={[Function]}
+      size="default"
+      type="number"
+      value=""
+    />
+    <select
+      className="emotion-2 emotion-3"
+      onChange={[Function]}
+      size="default"
+      tabIndex={null}
+      value="px"
+    >
+      <option
+        value="px"
+      >
+        px
+      </option>
+      <option
+        value="%"
+      >
+        %
+      </option>
+      <option
+        value="em"
+      >
+        em
+      </option>
+      <option
+        value="rem"
+      >
+        rem
+      </option>
+      <option
+        value="vw"
+      >
+        vw
+      </option>
+      <option
+        value="vh"
+      >
+        vh
+      </option>
+    </select>
+  </div>
 </div>
 `;
 

--- a/storybook/test/__snapshots__/index.js.snap
+++ b/storybook/test/__snapshots__/index.js.snap
@@ -8848,7 +8848,7 @@ exports[`Storyshots Components/UnitControl Default 1`] = `
       value=""
     />
     <select
-      className="emotion-2 emotion-3"
+      className="component-unit-control__select component-unit-control__select emotion-2 emotion-3"
       onChange={[Function]}
       size="default"
       tabIndex={null}

--- a/storybook/test/__snapshots__/index.js.snap
+++ b/storybook/test/__snapshots__/index.js.snap
@@ -8782,6 +8782,7 @@ exports[`Storyshots Components/UnitControl Default 1`] = `
   padding-right: 20px;
   height: 30px;
   line-height: 30;
+  min-height: 30px;
 }
 
 .emotion-0.emotion-0.emotion-0::-webkit-outer-spin-button,


### PR DESCRIPTION
## Description

<img width="816" alt="Screen Shot 2020-03-13 at 4 05 01 PM" src="https://user-images.githubusercontent.com/2322354/76655786-7a2a5e80-6544-11ea-9c20-6747244a619a.png">

This update adds a new (experimental) `UnitControl` that enables values beyond pixels! For Cover block, this control unlocks the ability to set `px`, `em`, `rem`, `vw` and `vh` values.

(Note: Although `%` is supported, it's omitted from the Cover block control as `%` height does not render predictably).


## How has this been tested?

* New (experimental) `UnitControl` and `NumberControl` were tested in Storybook and Gutenberg
* `UnitControl` x Cover block integration was developed and tested in local Gutenberg

## Screenshots

![Screen Capture on 2020-03-13 at 15-35-36](https://user-images.githubusercontent.com/2322354/76655967-ee650200-6544-11ea-8435-e091f7b0fe62.gif)

The GIF above showcases the flow for changing values and unit values for the Cover block.

## Types of changes

### UnitControl (and NumberControl)

<img width="225" alt="Screen Shot 2020-03-13 at 3 58 26 PM" src="https://user-images.githubusercontent.com/2322354/76656061-2cfabc80-6545-11ea-9724-326680f899d0.png">

These new experimental components have been added to `@wordpress/components`. The `UnitControl` is the component that powers the input for setting the height for the Cover block.

#### Shift Increment

One of the features with this new control is to jump values when holding down `shift` while pressing `up` or `down` (default is by `10`). This interaction is common for other Design applications like Figma, Sketch, Photoshop, etc...

Note: This feature can be customized and even disabled in the base component.

### Switching Units

<img width="816" alt="Screen Shot 2020-03-13 at 4 05 01 PM" src="https://user-images.githubusercontent.com/2322354/76656242-8f53bd00-6545-11ea-9125-1661a575950d.png">

The original behaviour defaults to a min-height of `50px`, but only if the user makes a change. **This interaction is preserved in this update**.

To improve the canvas rendering of Cover, switching units would "reset" the Cover to predetermined values for each unit. This is to prevent the Cover block's height from unexpectedly jumping to `3000px` if they switch to a `vh` or `vw` unit.

#### Drag Resize Handling

Dragging to resize will "reset" the unit **back to px**. This interaction decision was made as it is very difficult to accurately translate pixel by pixel drag values to their respective `vh` or `em` values.

### Simulated Height Rendering

Cover's canvas rendering is simulated as best as possible given the value and unit type. For example, `vh` and `vw` can be accurately rendered. Whereas we have to take the best guess for units like `em` or `rem`.

### Tests

These updates have been tested locally in Gutenberg. Unit tests need to be written for the new `UnitControl` and `NumberControl` components.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->

Resolves:
https://github.com/WordPress/gutenberg/issues/20567#issuecomment-598240345