### PR TITLE
Block Editor: Use useResizeObserver in place of direct react-resize-aware dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10093,7 +10093,6 @@
 				"lodash": "^4.17.15",
 				"memize": "^1.0.5",
 				"react-autosize-textarea": "^3.0.2",
-				"react-resize-aware": "^3.0.0",
 				"react-spring": "^8.0.19",
 				"redux-multi": "^0.1.12",
 				"refx": "^3.0.0",
@@ -19775,7 +19774,7 @@
 				},
 				"node-pre-gyp": {
 					"version": "0.12.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz",
 					"integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
 					"dev": true,
 					"optional": true,
@@ -19794,7 +19793,7 @@
 				},
 				"nopt": {
 					"version": "4.0.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
 					"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
 					"dev": true,
 					"optional": true,

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -52,7 +52,6 @@
 		"lodash": "^4.17.15",
 		"memize": "^1.0.5",
 		"react-autosize-textarea": "^3.0.2",
-		"react-resize-aware": "^3.0.0",
 		"react-spring": "^8.0.19",
 		"redux-multi": "^0.1.12",
 		"refx": "^3.0.0",

--- a/packages/block-editor/src/components/block-preview/auto.js
+++ b/packages/block-editor/src/components/block-preview/auto.js
@@ -1,12 +1,8 @@
 /**
- * External dependencies
- */
-import useResizeAware from 'react-resize-aware';
-
-/**
  * WordPress dependencies
  */
 import { Disabled } from '@wordpress/components';
+import { useResizeObserver } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -17,11 +13,11 @@ function AutoBlockPreview( { viewportWidth } ) {
 	const [
 		containerResizeListener,
 		{ width: containerWidth },
-	] = useResizeAware();
+	] = useResizeObserver();
 	const [
 		containtResizeListener,
 		{ height: contentHeight },
-	] = useResizeAware();
+	] = useResizeObserver();
 
 	return (
 		<div


### PR DESCRIPTION
Related: #20715, #19918

This pull request seeks to update the block preview component to use the new `useResizeObserver` custom hook introduced in #20715. The hook is a drop-in replacement for `react-resize-aware`, but supports use in a native environment. It should be used in all places we would otherwise have a direct dependency on `react-resize-aware`.

**Testing Instructions:**

Repeat testing instructions from #20715