### PR TITLE
Fix: ResponsiveWrapper can not handle cases with small dimensions

### DIFF
--- a/packages/components/src/responsive-wrapper/index.js
+++ b/packages/components/src/responsive-wrapper/index.js
@@ -7,6 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { cloneElement, Children } from '@wordpress/element';
+import { useResizeObserver } from '@wordpress/compose';
 
 function ResponsiveWrapper( {
 	naturalWidth,
@@ -14,15 +15,23 @@ function ResponsiveWrapper( {
 	children,
 	isInline = false,
 } ) {
+	const [
+		containerResizeListener,
+		{ width: containerWidth },
+	] = useResizeObserver();
 	if ( Children.count( children ) !== 1 ) {
 		return null;
 	}
 	const imageStyle = {
-		paddingBottom: ( naturalHeight / naturalWidth ) * 100 + '%',
+		paddingBottom:
+			naturalWidth < containerWidth
+				? naturalHeight
+				: ( naturalHeight / naturalWidth ) * 100 + '%',
 	};
 	const TagName = isInline ? 'span' : 'div';
 	return (
 		<TagName className="components-responsive-wrapper">
+			{ containerResizeListener }
 			<TagName style={ imageStyle } />
 			{ cloneElement( children, {
 				className: classnames(

--- a/packages/components/src/responsive-wrapper/style.scss
+++ b/packages/components/src/responsive-wrapper/style.scss
@@ -15,4 +15,5 @@
 	left: 0;
 	width: 100%;
 	height: 100%;
+	margin: auto;
 }


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/20697

## Description
The ResponsiveWrapper component makes sure the elements (normally images) passed to it are resized to the available width and the proportions between width and height are kept.


The component has a bug and does not deal correctly with cases where the width of the children is smaller than the width available for the container.
It applied the following rule style "( naturalHeight / naturalWidth ) * 100 + '%'" this made the container, in a case where the height is 20 and the width is 10 it makes the height 2 times the width. This creates lots of unnecessary space:
![image](https://user-images.githubusercontent.com/11271197/76661079-6b5aa080-6572-11ea-94db-e75fe7b2bbc6.png)


We had this bug since the component was created but it was not very noticeable because we did not load thumbnails on the featured images, we loaded full-size images. In WordPress 5.4 we started loading thumbnails and this bug becomes very noticeable as noted in https://github.com/WordPress/gutenberg/issues/20697 as almost all the images passed to the component are small.


This PR fixes the issue for small images when the width is smaller than the width of the container we simply make the height equal to the image height.


## Screenshots
Before:
![image](https://user-images.githubusercontent.com/11271197/76661890-71518100-6574-11ea-99e5-930da242f726.png)



After:

![image](https://user-images.githubusercontent.com/11271197/76661745-1a4bac00-6574-11ea-8653-442cbfc1432e.png)

