### PR TITLE
Chore: Use useResizeObserver from compose instead of useResizeAware

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10093,7 +10093,6 @@
 				"lodash": "^4.17.15",
 				"memize": "^1.0.5",
 				"react-autosize-textarea": "^3.0.2",
-				"react-resize-aware": "^3.0.0",
 				"react-spring": "^8.0.19",
 				"redux-multi": "^0.1.12",
 				"refx": "^3.0.0",

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -52,7 +52,6 @@
 		"lodash": "^4.17.15",
 		"memize": "^1.0.5",
 		"react-autosize-textarea": "^3.0.2",
-		"react-resize-aware": "^3.0.0",
 		"react-spring": "^8.0.19",
 		"redux-multi": "^0.1.12",
 		"refx": "^3.0.0",

--- a/packages/block-editor/src/components/block-preview/auto.js
+++ b/packages/block-editor/src/components/block-preview/auto.js
@@ -1,12 +1,8 @@
 /**
- * External dependencies
- */
-import useResizeAware from 'react-resize-aware';
-
-/**
  * WordPress dependencies
  */
 import { Disabled } from '@wordpress/components';
+import { useResizeObserver } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -17,11 +13,11 @@ function AutoBlockPreview( { viewportWidth } ) {
 	const [
 		containerResizeListener,
 		{ width: containerWidth },
-	] = useResizeAware();
+	] = useResizeObserver();
 	const [
 		containtResizeListener,
 		{ height: contentHeight },
-	] = useResizeAware();
+	] = useResizeObserver();
 
 	return (
 		<div


### PR DESCRIPTION
## Description
This PR uses useResizeObserver instead of useResizeAware directly on the web both hooks reference the same code but on mobile, we have a compatibility layer at useResizeObserver so I guess we should use it.
