### PR TITLE
Fix: `$black` background-color remains visible when there is no backg…

### DIFF
--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -1,7 +1,6 @@
 .wp-block-cover-image,
 .wp-block-cover {
 	position: relative;
-	background-color: $black;
 	background-size: cover;
 	background-position: center center;
 	min-height: 430px;
@@ -11,7 +10,6 @@
 	justify-content: center;
 	align-items: center;
 	overflow: hidden;
-
 	&.has-parallax {
 		background-attachment: fixed;
 
@@ -28,9 +26,13 @@
 		}
 	}
 
-	&.has-background-dim::before {
-		content: "";
-		background-color: inherit;
+	&.has-background-dim {
+		background-color: $black;
+
+		&::before {
+			content: "";
+			background-color: inherit;
+		}
 	}
 
 	&.has-background-dim:not(.has-background-gradient)::before,


### PR DESCRIPTION
…round dim with transparent images.

## Description

When setting the background opacity to 0 with a PNG transparent image the background remains black.

## Screenshots <!-- if applicable -->

**Current**

![bug](https://user-images.githubusercontent.com/6705443/76677845-52cea280-65d3-11ea-86db-e10dadee99d9.gif)

**Fix**

![fix](https://user-images.githubusercontent.com/6705443/76677850-67129f80-65d3-11ea-8ab2-057082d15a74.gif)

## Types of changes

Bug fix

## Checklist:
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines:
