### PR TITLE
Code quality: Enable import/no-unresolved ESLint rule for Gutenberg

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -131,6 +131,7 @@ module.exports = {
 			],
 			rules: {
 				'import/no-extraneous-dependencies': 'error',
+				'import/no-unresolved': 'error',
 			},
 		},
 		{


### PR DESCRIPTION
## Description
Related to #15876.

I want to test this new rule against the Gutenberg repository before it gets enabled for the ESLint plugin.


## How has this been tested?
npm run lint-js

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
