### PR TITLE
Remove inaccurate message from image block

### DIFF
--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -391,12 +391,6 @@ export class ImageEdit extends Component {
 			</BlockControls>
 		);
 		const src = isExternal ? url : undefined;
-		const labels = {
-			title: ! url ? __( 'Image' ) : __( 'Edit image' ),
-			instructions: __(
-				'Upload an image file, pick one from your media library, or add one with a URL.'
-			),
-		};
 		const mediaPreview = !! url && (
 			<img
 				alt={ __( 'Edit image' ) }
@@ -412,7 +406,6 @@ export class ImageEdit extends Component {
 		const mediaPlaceholder = (
 			<MediaPlaceholder
 				icon={ <BlockIcon icon={ icon } /> }
-				labels={ labels }
 				onSelect={ this.onSelectImage }
 				onSelectURL={ this.onSelectURL }
 				notices={ noticeUI }


### PR DESCRIPTION
## Description
Remove an inaccurate message from the image block, to make it the
same as the other media files: audio and video. Fixes #20682


## How has this been tested?
npm run test


## Screenshots 
before:
![before](https://user-images.githubusercontent.com/26669835/76703231-79bece80-66d0-11ea-86c8-39282046c910.png)

after:
![after](https://user-images.githubusercontent.com/26669835/76703244-9b1fba80-66d0-11ea-85fe-15995cb06990.png)


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
