### PR TITLE
Docs: Correct 2nd param of useViewportMatch() usage

### DIFF
--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -188,7 +188,7 @@ Returns true if the viewport matches the given query, or false otherwise.
 _Usage_
 
 ```js
-useViewportMatch( 'huge', <' );
+useViewportMatch( 'huge', '<' );
 useViewportMatch( 'medium' );
 ```
 


### PR DESCRIPTION
## Description
add missing opening single quote
