### PR TITLE
[ Latest Posts ] Fix link for read more markup

### DIFF
--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -360,9 +360,9 @@ class LatestPostsEdit extends Component {
 										.trim()
 										.split( ' ', excerptLength )
 										.join( ' ' ) +
-								  ' ... <a href=' +
+								  ' ... <a href="' +
 								  post.link +
-								  'target="_blank" rel="noopener noreferrer">' +
+								  '" target="_blank" rel="noopener noreferrer">' +
 								  __( 'Read more' ) +
 								  '</a>'
 								: excerpt;


### PR DESCRIPTION
## Description
Fixes #20783

## How has this been tested?
1. Make sure you have some posts
2. Add a page or post
3. Add a LatestPosts block
4. Set the block to show post content > excerpt
5. Check that the URL of the read more link is correct

## Screenshots <!-- if applicable -->

<img width="1075" alt="Screenshot 2020-03-16 at 10 48 45" src="https://user-images.githubusercontent.com/107534/76738683-c4dded80-6773-11ea-97a9-b96bff855a1b.png">

