### PR TITLE
Fixes docblock for useViewportMatch

### DIFF
--- a/packages/compose/src/hooks/use-viewport-match/index.js
+++ b/packages/compose/src/hooks/use-viewport-match/index.js
@@ -63,7 +63,7 @@ const ViewportMatchWidthContext = createContext( null );
  * @example
  *
  * ```js
- * useViewportMatch( 'huge', <' );
+ * useViewportMatch( 'huge', '<' );
  * useViewportMatch( 'medium' );
  * ```
  *


### PR DESCRIPTION
#20911 only changed the README and not the docblock it should be generated from, causing build failures since then. This simply updates the docblock.