### PR TITLE
Add <VisibilityHelper /> component

### DIFF
--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -91,7 +91,7 @@ export { default as ToolbarGroup } from './toolbar-group';
 export { default as __experimentalToolbarItem } from './toolbar-item';
 export { default as Tooltip } from './tooltip';
 export { default as TreeSelect } from './tree-select';
-export { default as VisuallyHidden } from './visually-hidden';
+export { default as VisuallyHidden, VisibilityHelper } from './visually-hidden';
 export { default as IsolatedEventContainer } from './isolated-event-container';
 export {
 	createSlotFill,

--- a/packages/components/src/visually-hidden/index.js
+++ b/packages/components/src/visually-hidden/index.js
@@ -19,4 +19,26 @@ function VisuallyHidden( { as = 'div', className, ...props } ) {
 		...props,
 	} );
 }
+
+/**
+ * VisibilityHelper component to simplify common use-case of
+ * conditionally hiding components.
+ */
+export function VisibilityHelper( {
+	className,
+	isHidden = false,
+	as,
+	...props
+} ) {
+	if ( isHidden ) {
+		return <VisuallyHidden as={ as } { ...props } />;
+	}
+
+	return renderAsRenderProps( {
+		as,
+		className,
+		...props,
+	} );
+}
+
 export default VisuallyHidden;

--- a/packages/components/src/visually-hidden/stories/index.js
+++ b/packages/components/src/visually-hidden/stories/index.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import VisuallyHidden from '../';
+import VisuallyHidden, { VisibilityHelper } from '../';
 
 export default {
 	title: 'Components/VisuallyHidden',
@@ -37,6 +37,22 @@ export const withAdditionalClassNames = () => (
 		<VisuallyHidden as="label" className="test-input">
 			Check out my class!{ ' ' }
 		</VisuallyHidden>
+		Inspect the HTML to see!
+	</>
+);
+
+export const withVisibilityHelper = () => (
+	<>
+		You can use { '<VisibilityHelper/>' } to conditionally apply
+		VisuallyHidden component.
+		<br />
+		<VisibilityHelper isHidden={ true } as="label">
+			I am hidden!{ ' ' }
+		</VisibilityHelper>
+		<VisibilityHelper isHidden={ false } as="label">
+			I am visible!{ ' ' }
+		</VisibilityHelper>
+		<br />
 		Inspect the HTML to see!
 	</>
 );

--- a/storybook/test/__snapshots__/index.js.snap
+++ b/storybook/test/__snapshots__/index.js.snap
@@ -8714,6 +8714,28 @@ Array [
 ]
 `;
 
+exports[`Storyshots Components/VisuallyHidden With Visibility Helper 1`] = `
+Array [
+  "You can use ",
+  "<VisibilityHelper/>",
+  " to conditionally apply VisuallyHidden component.",
+  <br />,
+  <label
+    className="components-visually-hidden"
+  >
+    I am hidden!
+     
+  </label>,
+  <label>
+    I am visible!
+     
+  </label>,
+  <br />,
+  "Inspect the HTML to see!",
+]
+`;
+
+
 exports[`Storyshots Components|AnglePickerControl Default 1`] = `
 <div
   className="components-base-control components-angle-picker-control"


### PR DESCRIPTION
## Description
While working on #20607, I noticed a use-case of applying `<VisuallyHidden />` conditionally. The cleanest way to do it is with a separate component that either creates `<VisuallyHidden />` if target should be hidden, or creates desired element otherwise. This adds `<VisibilityHelper />` component that does just that.

## How has this been tested?
Added snapshot tests.

For manual testing:

1. Open `packages/block-library/src/gallery/gallery.js`
1. Find `<RichText />` instance
1. Replace the declaration with `<VisibilityHelper as={ RichText } isHidden={ ! isSelected && RichText.isEmpty( caption ) } className="blocks-gallery-caption" /* ...other props */ />`
1. Observe that the `<VisuallyHidden />` is only applied when `isHidden` is true

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. 
- [x] My code follows the accessibility standards.
- [x] My code has proper inline documentation. 
- [x] I've included developer documentation if appropriate.
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR.