### PR TITLE
Add outline transition to navigate / edit mode switching

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -163,6 +163,7 @@
 			// 2px outside.
 			box-shadow: 0 0 0 2px $blue-medium-focus;
 			border-radius: $radius-block-ui;
+			transition: box-shadow 0.2s ease-out;
 
 			// Windows High Contrast mode will show this outline.
 			outline: 2px solid transparent;
@@ -196,6 +197,18 @@
 .block-editor-block-list__layout .block-editor-block-list__block {
 	&.has-warning {
 		min-height: ( $block-padding + $block-spacing ) * 2;
+	}
+
+	&::after {
+		content: "";
+		position: absolute;
+		top: 0;
+		right: 0;
+		bottom: 0;
+		left: 0;
+		border-radius: $radius-block-ui;
+		transition: box-shadow 0.1s ease-in;
+		box-shadow: 0 0 0 2px transparent;
 	}
 
 	// Warnings

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -164,6 +164,7 @@
 			box-shadow: 0 0 0 2px $blue-medium-focus;
 			border-radius: $radius-block-ui;
 			transition: box-shadow 0.2s ease-out;
+			@include reduce-motion("transition");
 
 			// Windows High Contrast mode will show this outline.
 			outline: 2px solid transparent;
@@ -207,8 +208,9 @@
 		bottom: 0;
 		left: 0;
 		border-radius: $radius-block-ui;
-		transition: box-shadow 0.1s ease-in;
 		box-shadow: 0 0 0 2px transparent;
+		transition: box-shadow 0.1s ease-in;
+		@include reduce-motion("transition");
 	}
 
 	// Warnings

--- a/packages/block-library/src/paragraph/editor.scss
+++ b/packages/block-library/src/paragraph/editor.scss
@@ -29,6 +29,7 @@
 			background: rgba($white, 0.1);
 		}
 
+		// Disable the flashing on navigation mode.
 		.is-navigate-mode & {
 			background: transparent;
 		}

--- a/packages/block-library/src/paragraph/editor.scss
+++ b/packages/block-library/src/paragraph/editor.scss
@@ -28,6 +28,10 @@
 		.is-dark-theme & {
 			background: rgba($white, 0.1);
 		}
+
+		.is-navigate-mode & {
+			background: transparent;
+		}
 	}
 }
 


### PR DESCRIPTION
This attempts to make switching between "Edit" and "Navigate" perceptually more fluid. It also removes the background fade on paragraph blocks when navigate mode is engaged.

cc @jasmussen 