### PR TITLE
Add react-hooks/exhaustive-deps lint rule

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10764,7 +10764,7 @@
 				"eslint-plugin-jsx-a11y": "^6.2.3",
 				"eslint-plugin-prettier": "^3.1.2",
 				"eslint-plugin-react": "^7.14.3",
-				"eslint-plugin-react-hooks": "^1.6.1",
+				"eslint-plugin-react-hooks": "^2.4.0",
 				"globals": "^12.0.0",
 				"prettier": "npm:wp-prettier@1.19.1",
 				"requireindex": "^1.2.0"

--- a/packages/eslint-plugin/configs/react.js
+++ b/packages/eslint-plugin/configs/react.js
@@ -30,5 +30,6 @@ module.exports = {
 		'react/prop-types': 'off',
 		'react/react-in-jsx-scope': 'off',
 		'react-hooks/rules-of-hooks': 'error',
+		'react-hooks/exhaustive-deps': 'warn',
 	},
 };

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -31,7 +31,7 @@
 		"eslint-plugin-jsx-a11y": "^6.2.3",
 		"eslint-plugin-prettier": "^3.1.2",
 		"eslint-plugin-react": "^7.14.3",
-		"eslint-plugin-react-hooks": "^1.6.1",
+		"eslint-plugin-react-hooks": "^2.4.0",
 		"globals": "^12.0.0",
 		"prettier": "npm:wp-prettier@1.19.1",
 		"requireindex": "^1.2.0"


### PR DESCRIPTION
## Description

As mentioned in the docs, when using hooks it's worth checking if deps array is exhaustive. This is done by [react-hooks/exhaustive-dep](https://reactjs.org/docs/hooks-rules.html#eslint-plugin) eslint rule. This PR adds that rule. It immediately detected numerous violations, most of the time with a pretty good explanation:

>   62:2  warning  The 'toggleEventBindings' function makes the dependencies of useEffect Hook (at line 54) change on every render. Move it inside the useEffect callback. Alternatively, wrap the 'toggleEventBindings' definition into its own useCallback() Hook  react-hooks/exhaustive-deps

```js
function ObserveTyping( { children, setTimeout: setSafeTimeout } ) {
	// ...
	useEffect( () => {
		toggleEventBindings( isTyping );
		return () => toggleEventBindings( false );
	}, [ isTyping ] );
	// ...
	function toggleEventBindings( isBound ) {
```

Let's use this PR as a place to discuss whether or not we should be using that rule.

## How has this been tested?
Tested locally.

## Types of changes
Non-breaking changes

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
