### PR TITLE
Cherry Pick PR's for WordPress 5.4 RC 3

### DIFF
--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -8,7 +8,7 @@ import {
 } from '@wordpress/blocks';
 import {
 	PanelBody,
-	__experimentalSlotFillConsumer,
+	__experimentalUseSlot as useSlot,
 } from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
 
@@ -30,6 +30,9 @@ const BlockInspector = ( {
 	selectedBlockName,
 	showNoBlockSelectedMessage = true,
 } ) => {
+	const slot = useSlot( InspectorAdvancedControls.slotName );
+	const hasFills = Boolean( slot.fills && slot.fills.length );
+
 	if ( count > 1 ) {
 		return <MultiSelectionInspector />;
 	}
@@ -69,21 +72,15 @@ const BlockInspector = ( {
 			) }
 			<InspectorControls.Slot bubblesVirtually />
 			<div>
-				<__experimentalSlotFillConsumer>
-					{ ( { hasFills } ) =>
-						hasFills( InspectorAdvancedControls.slotName ) && (
-							<PanelBody
-								className="block-editor-block-inspector__advanced"
-								title={ __( 'Advanced' ) }
-								initialOpen={ false }
-							>
-								<InspectorAdvancedControls.Slot
-									bubblesVirtually
-								/>
-							</PanelBody>
-						)
-					}
-				</__experimentalSlotFillConsumer>
+				{ hasFills && (
+					<PanelBody
+						className="block-editor-block-inspector__advanced"
+						title={ __( 'Advanced' ) }
+						initialOpen={ false }
+					>
+						<InspectorAdvancedControls.Slot bubblesVirtually />
+					</PanelBody>
+				) }
 			</div>
 			<SkipToSelectedBlock key="back" />
 		</div>

--- a/packages/block-library/src/cover/deprecated.js
+++ b/packages/block-library/src/cover/deprecated.js
@@ -106,6 +106,109 @@ const deprecated = [
 				style.backgroundColor = customOverlayColor;
 			}
 			if ( focalPoint && ! hasParallax ) {
+				style.backgroundPosition = `${ Math.round(
+					focalPoint.x * 100
+				) }% ${ Math.round( focalPoint.y * 100 ) }%`;
+			}
+			if ( customGradient && ! url ) {
+				style.background = customGradient;
+			}
+			style.minHeight = minHeight || undefined;
+
+			const classes = classnames(
+				dimRatioToClass( dimRatio ),
+				overlayColorClass,
+				{
+					'has-background-dim': dimRatio !== 0,
+					'has-parallax': hasParallax,
+					'has-background-gradient': customGradient,
+					[ gradientClass ]: ! url && gradientClass,
+				}
+			);
+
+			return (
+				<div className={ classes } style={ style }>
+					{ url &&
+						( gradient || customGradient ) &&
+						dimRatio !== 0 && (
+							<span
+								aria-hidden="true"
+								className={ classnames(
+									'wp-block-cover__gradient-background',
+									gradientClass
+								) }
+								style={
+									customGradient
+										? { background: customGradient }
+										: undefined
+								}
+							/>
+						) }
+					{ VIDEO_BACKGROUND_TYPE === backgroundType && url && (
+						<video
+							className="wp-block-cover__video-background"
+							autoPlay
+							muted
+							loop
+							src={ url }
+						/>
+					) }
+					<div className="wp-block-cover__inner-container">
+						<InnerBlocks.Content />
+					</div>
+				</div>
+			);
+		},
+	},
+	{
+		attributes: {
+			...blockAttributes,
+			title: {
+				type: 'string',
+				source: 'html',
+				selector: 'p',
+			},
+			contentAlign: {
+				type: 'string',
+				default: 'center',
+			},
+			minHeight: {
+				type: 'number',
+			},
+			gradient: {
+				type: 'string',
+			},
+			customGradient: {
+				type: 'string',
+			},
+		},
+		save( { attributes } ) {
+			const {
+				backgroundType,
+				gradient,
+				customGradient,
+				customOverlayColor,
+				dimRatio,
+				focalPoint,
+				hasParallax,
+				overlayColor,
+				url,
+				minHeight,
+			} = attributes;
+			const overlayColorClass = getColorClassName(
+				'background-color',
+				overlayColor
+			);
+			const gradientClass = __experimentalGetGradientClass( gradient );
+
+			const style =
+				backgroundType === IMAGE_BACKGROUND_TYPE
+					? backgroundImageStyles( url )
+					: {};
+			if ( ! overlayColorClass ) {
+				style.backgroundColor = customOverlayColor;
+			}
+			if ( focalPoint && ! hasParallax ) {
 				style.backgroundPosition = `${ focalPoint.x *
 					100 }% ${ focalPoint.y * 100 }%`;
 			}

--- a/packages/block-library/src/cover/save.js
+++ b/packages/block-library/src/cover/save.js
@@ -64,7 +64,7 @@ export default function save( { attributes } ) {
 		{
 			'has-background-dim': dimRatio !== 0,
 			'has-parallax': hasParallax,
-			'has-background-gradient': customGradient,
+			'has-background-gradient': gradient || customGradient,
 			[ gradientClass ]: ! url && gradientClass,
 		}
 	);

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -98,7 +98,7 @@ export {
 	Slot,
 	Fill,
 	Provider as SlotFillProvider,
-	Consumer as __experimentalSlotFillConsumer,
+	useSlot as __experimentalUseSlot,
 } from './slot-fill';
 
 // Higher-Order Components

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -23,7 +23,7 @@ import PopoverDetectOutside from './detect-outside';
 import Button from '../button';
 import ScrollLock from '../scroll-lock';
 import IsolatedEventContainer from '../isolated-event-container';
-import { Slot, Fill, Consumer } from '../slot-fill';
+import { Slot, Fill, useSlot } from '../slot-fill';
 import Animate from '../animate';
 
 const FocusManaged = withConstrainedTabbing(
@@ -261,6 +261,7 @@ const Popover = ( {
 	const contentRect = useRef();
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
 	const [ animateOrigin, setAnimateOrigin ] = useState();
+	const slot = useSlot( __unstableSlotName );
 	const isExpanded = expandOnMobile && isMobileViewport;
 
 	noArrow = isExpanded || noArrow;
@@ -602,25 +603,15 @@ const Popover = ( {
 		content = <FocusManaged>{ content }</FocusManaged>;
 	}
 
-	return (
-		<Consumer>
-			{ ( { getSlot } ) => {
-				// In case there is no slot context in which to render,
-				// default to an in-place rendering.
-				if ( getSlot && getSlot( __unstableSlotName ) ) {
-					content = (
-						<Fill name={ __unstableSlotName }>{ content }</Fill>
-					);
-				}
+	if ( slot.ref ) {
+		content = <Fill name={ __unstableSlotName }>{ content }</Fill>;
+	}
 
-				if ( anchorRef || anchorRect ) {
-					return content;
-				}
+	if ( anchorRef || anchorRect ) {
+		return content;
+	}
 
-				return <span ref={ anchorRefFallback }>{ content }</span>;
-			} }
-		</Consumer>
-	);
+	return <span ref={ anchorRefFallback }>{ content }</span>;
 };
 
 const PopoverContainer = Popover;

--- a/packages/components/src/responsive-wrapper/index.js
+++ b/packages/components/src/responsive-wrapper/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
+import useResizeAware from 'react-resize-aware';
 
 /**
  * WordPress dependencies
@@ -14,15 +15,23 @@ function ResponsiveWrapper( {
 	children,
 	isInline = false,
 } ) {
+	const [
+		containerResizeListener,
+		{ width: containerWidth },
+	] = useResizeAware();
 	if ( Children.count( children ) !== 1 ) {
 		return null;
 	}
 	const imageStyle = {
-		paddingBottom: ( naturalHeight / naturalWidth ) * 100 + '%',
+		paddingBottom:
+			naturalWidth < containerWidth
+				? naturalHeight
+				: ( naturalHeight / naturalWidth ) * 100 + '%',
 	};
 	const TagName = isInline ? 'span' : 'div';
 	return (
 		<TagName className="components-responsive-wrapper">
+			{ containerResizeListener }
 			<TagName style={ imageStyle } />
 			{ cloneElement( children, {
 				className: classnames(

--- a/packages/components/src/responsive-wrapper/style.scss
+++ b/packages/components/src/responsive-wrapper/style.scss
@@ -15,4 +15,5 @@
 	left: 0;
 	width: 100%;
 	height: 100%;
+	margin: auto;
 }

--- a/packages/components/src/slot-fill/bubbles-virtually/fill.js
+++ b/packages/components/src/slot-fill/bubbles-virtually/fill.js
@@ -1,0 +1,34 @@
+/**
+ * WordPress dependencies
+ */
+import { useRef, useEffect, createPortal } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import useSlot from './use-slot';
+
+export default function Fill( { name, children } ) {
+	const slot = useSlot( name );
+	const ref = useRef();
+
+	useEffect( () => {
+		// We register fills so we can keep track of their existance.
+		// Some Slot implementations need to know if there're already fills
+		// registered so they can choose to render themselves or not.
+		slot.registerFill( ref );
+		return () => {
+			slot.unregisterFill( ref );
+		};
+	}, [ slot.registerFill, slot.unregisterFill ] );
+
+	if ( ! slot.ref || ! slot.ref.current ) {
+		return null;
+	}
+
+	if ( typeof children === 'function' ) {
+		children = children( slot.fillProps );
+	}
+
+	return createPortal( children, slot.ref.current );
+}

--- a/packages/components/src/slot-fill/bubbles-virtually/slot-fill-context.js
+++ b/packages/components/src/slot-fill/bubbles-virtually/slot-fill-context.js
@@ -1,0 +1,15 @@
+/**
+ * WordPress dependencies
+ */
+import { createContext } from '@wordpress/element';
+
+const SlotFillContext = createContext( {
+	slots: {},
+	fills: {},
+	registerSlot: () => {},
+	unregisterSlot: () => {},
+	registerFill: () => {},
+	unregisterFill: () => {},
+} );
+
+export default SlotFillContext;

--- a/packages/components/src/slot-fill/bubbles-virtually/slot-fill-provider.js
+++ b/packages/components/src/slot-fill/bubbles-virtually/slot-fill-provider.js
@@ -1,0 +1,92 @@
+/**
+ * WordPress dependencies
+ */
+import { useMemo, useCallback, useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import SlotFillContext from './slot-fill-context';
+
+function useSlotRegistry() {
+	const [ slots, setSlots ] = useState( {} );
+	const [ fills, setFills ] = useState( {} );
+
+	const registerSlot = useCallback( ( name, ref, fillProps ) => {
+		setSlots( ( prevSlots ) => ( {
+			...prevSlots,
+			[ name ]: {
+				...prevSlots[ name ],
+				ref: ref || prevSlots[ name ].ref,
+				fillProps: fillProps || prevSlots[ name ].fillProps || {},
+			},
+		} ) );
+	}, [] );
+
+	const unregisterSlot = useCallback( ( name, ref ) => {
+		setSlots( ( prevSlots ) => {
+			// eslint-disable-next-line no-unused-vars
+			const { [ name ]: slot, ...nextSlots } = prevSlots;
+			// Make sure we're not unregistering a slot registered by another element
+			// See https://github.com/WordPress/gutenberg/pull/19242#issuecomment-590295412
+			if ( slot.ref === ref ) {
+				return nextSlots;
+			}
+			return prevSlots;
+		} );
+	}, [] );
+
+	const registerFill = useCallback( ( name, ref ) => {
+		setFills( ( prevFills ) => ( {
+			...prevFills,
+			[ name ]: [ ...( prevFills[ name ] || [] ), ref ],
+		} ) );
+	}, [] );
+
+	const unregisterFill = useCallback( ( name, ref ) => {
+		setFills( ( prevFills ) => {
+			if ( prevFills[ name ] ) {
+				return {
+					...prevFills,
+					[ name ]: prevFills[ name ].filter(
+						( fillRef ) => fillRef !== ref
+					),
+				};
+			}
+			return prevFills;
+		} );
+	}, [] );
+
+	// Memoizing the return value so it can be directly passed to Provider value
+	const registry = useMemo(
+		() => ( {
+			slots,
+			fills,
+			registerSlot,
+			// Just for readability
+			updateSlot: registerSlot,
+			unregisterSlot,
+			registerFill,
+			unregisterFill,
+		} ),
+		[
+			slots,
+			fills,
+			registerSlot,
+			unregisterSlot,
+			registerFill,
+			unregisterFill,
+		]
+	);
+
+	return registry;
+}
+
+export default function SlotFillProvider( { children } ) {
+	const registry = useSlotRegistry();
+	return (
+		<SlotFillContext.Provider value={ registry }>
+			{ children }
+		</SlotFillContext.Provider>
+	);
+}

--- a/packages/components/src/slot-fill/bubbles-virtually/slot.js
+++ b/packages/components/src/slot-fill/bubbles-virtually/slot.js
@@ -1,0 +1,48 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	useEffect,
+	useRef,
+	useLayoutEffect,
+	useContext,
+} from '@wordpress/element';
+import isShallowEqual from '@wordpress/is-shallow-equal';
+
+/**
+ * Internal dependencies
+ */
+import SlotFillContext from './slot-fill-context';
+import useSlot from './use-slot';
+
+export default function Slot( {
+	name,
+	fillProps = {},
+	as: Component = 'div',
+	...props
+} ) {
+	const registry = useContext( SlotFillContext );
+	const ref = useRef();
+	const slot = useSlot( name );
+
+	useEffect( () => {
+		registry.registerSlot( name, ref, fillProps );
+		return () => {
+			registry.unregisterSlot( name, ref );
+		};
+		// We are not including fillProps in the deps because we don't want to
+		// unregister and register the slot whenever fillProps change, which would
+		// cause the fill to be re-mounted. We are only considering the initial value
+		// of fillProps.
+	}, [ registry.registerSlot, registry.unregisterSlot, name ] );
+
+	// fillProps may be an update that interact with the layout, so
+	// we useLayoutEffect
+	useLayoutEffect( () => {
+		if ( slot.fillProps && ! isShallowEqual( slot.fillProps, fillProps ) ) {
+			registry.updateSlot( name, ref, fillProps );
+		}
+	} );
+
+	return <Component ref={ ref } { ...props } />;
+}

--- a/packages/components/src/slot-fill/bubbles-virtually/slot.js
+++ b/packages/components/src/slot-fill/bubbles-virtually/slot.js
@@ -1,12 +1,7 @@
 /**
  * WordPress dependencies
  */
-import {
-	useEffect,
-	useRef,
-	useLayoutEffect,
-	useContext,
-} from '@wordpress/element';
+import { useRef, useLayoutEffect, useContext } from '@wordpress/element';
 import isShallowEqual from '@wordpress/is-shallow-equal';
 
 /**
@@ -25,7 +20,7 @@ export default function Slot( {
 	const ref = useRef();
 	const slot = useSlot( name );
 
-	useEffect( () => {
+	useLayoutEffect( () => {
 		registry.registerSlot( name, ref, fillProps );
 		return () => {
 			registry.unregisterSlot( name, ref );

--- a/packages/components/src/slot-fill/bubbles-virtually/use-slot.js
+++ b/packages/components/src/slot-fill/bubbles-virtually/use-slot.js
@@ -1,0 +1,54 @@
+/**
+ * WordPress dependencies
+ */
+import { useCallback, useContext, useMemo } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import SlotFillContext from './slot-fill-context';
+
+export default function useSlot( name ) {
+	const registry = useContext( SlotFillContext );
+
+	const slot = registry.slots[ name ] || {};
+	const slotFills = registry.fills[ name ];
+	const fills = useMemo( () => slotFills || [], [ slotFills ] );
+
+	const updateSlot = useCallback(
+		( slotRef, slotFillProps ) => {
+			registry.updateSlot( name, slotRef, slotFillProps );
+		},
+		[ name, registry.updateSlot ]
+	);
+
+	const unregisterSlot = useCallback(
+		( slotRef ) => {
+			registry.unregisterSlot( name, slotRef );
+		},
+		[ name, registry.unregisterSlot ]
+	);
+
+	const registerFill = useCallback(
+		( fillRef ) => {
+			registry.registerFill( name, fillRef );
+		},
+		[ name, registry.registerFill ]
+	);
+
+	const unregisterFill = useCallback(
+		( fillRef ) => {
+			registry.unregisterFill( name, fillRef );
+		},
+		[ name, registry.unregisterFill ]
+	);
+
+	return {
+		...slot,
+		updateSlot,
+		unregisterSlot,
+		fills,
+		registerFill,
+		unregisterFill,
+	};
+}

--- a/packages/components/src/slot-fill/context.js
+++ b/packages/components/src/slot-fill/context.js
@@ -14,6 +14,11 @@ import {
 	useEffect,
 } from '@wordpress/element';
 
+/**
+ * Internal dependencies
+ */
+import SlotFillBubblesVirtuallyProvider from './bubbles-virtually/slot-fill-provider';
+
 const SlotFillContext = createContext( {
 	registerSlot: () => {},
 	unregisterSlot: () => {},
@@ -140,7 +145,9 @@ class SlotFillProvider extends Component {
 	render() {
 		return (
 			<Provider value={ this.contextValue }>
-				{ this.props.children }
+				<SlotFillBubblesVirtuallyProvider>
+					{ this.props.children }
+				</SlotFillBubblesVirtuallyProvider>
 			</Provider>
 		);
 	}

--- a/packages/components/src/slot-fill/fill.js
+++ b/packages/components/src/slot-fill/fill.js
@@ -34,7 +34,7 @@ function FillComponent( { name, children, registerFill, unregisterFill } ) {
 
 	useLayoutEffect( () => {
 		ref.current.children = children;
-		if ( slot && ! slot.props.bubblesVirtually ) {
+		if ( slot ) {
 			slot.forceUpdate();
 		}
 	}, [ children ] );
@@ -49,7 +49,7 @@ function FillComponent( { name, children, registerFill, unregisterFill } ) {
 		registerFill( name, ref.current );
 	}, [ name ] );
 
-	if ( ! slot || ! slot.node || ! slot.props.bubblesVirtually ) {
+	if ( ! slot || ! slot.node ) {
 		return null;
 	}
 

--- a/packages/components/src/slot-fill/index.js
+++ b/packages/components/src/slot-fill/index.js
@@ -1,13 +1,31 @@
 /**
  * Internal dependencies
  */
-import Slot from './slot';
-import Fill from './fill';
-import Provider, { Consumer } from './context';
+import BaseSlot from './slot';
+import BaseFill from './fill';
+import Provider from './context';
+import BubblesVirtuallySlot from './bubbles-virtually/slot';
+import BubblesVirtuallyFill from './bubbles-virtually/fill';
+import useSlot from './bubbles-virtually/use-slot';
 
-export { Slot };
-export { Fill };
-export { Provider, Consumer };
+export function Slot( { bubblesVirtually, ...props } ) {
+	if ( bubblesVirtually ) {
+		return <BubblesVirtuallySlot { ...props } />;
+	}
+	return <BaseSlot { ...props } />;
+}
+
+export function Fill( props ) {
+	// We're adding both Fills here so they can register themselves before
+	// their respective slot has been registered. Only the Fill that has a slot
+	// will render. The other one will return null.
+	return (
+		<>
+			<BaseFill { ...props } />
+			<BubblesVirtuallyFill { ...props } />
+		</>
+	);
+}
 
 export function createSlotFill( name ) {
 	const FillComponent = ( props ) => <Fill name={ name } { ...props } />;
@@ -21,3 +39,5 @@ export function createSlotFill( name ) {
 		Slot: SlotComponent,
 	};
 }
+
+export { useSlot, Provider };

--- a/packages/components/src/slot-fill/slot.js
+++ b/packages/components/src/slot-fill/slot.js
@@ -51,18 +51,7 @@ class SlotComponent extends Component {
 	}
 
 	render() {
-		const {
-			children,
-			name,
-			bubblesVirtually = false,
-			fillProps = {},
-			getFills,
-			className,
-		} = this.props;
-
-		if ( bubblesVirtually ) {
-			return <div ref={ this.bindNode } className={ className } />;
-		}
+		const { children, name, fillProps = {}, getFills } = this.props;
 
 		const fills = map( getFills( name, this ), ( fill ) => {
 			const fillKey = fill.occurrence;

--- a/packages/components/src/slot-fill/stories/index.js
+++ b/packages/components/src/slot-fill/stories/index.js
@@ -13,7 +13,13 @@ import { createContext, useContext } from '@wordpress/element';
  */
 import { Slot, Fill, Provider } from '../';
 
-export default { title: 'Components/SlotFill', component: Slot };
+export default {
+	title: 'Components/SlotFill',
+	component: Slot,
+	parameters: {
+		storyshots: { disable: true },
+	},
+};
 
 export const _default = () => {
 	return (

--- a/packages/components/src/slot-fill/stories/index.js
+++ b/packages/components/src/slot-fill/stories/index.js
@@ -1,0 +1,87 @@
+/**
+ * External dependencies
+ */
+import { text, number } from '@storybook/addon-knobs';
+
+/**
+ * WordPress dependencies
+ */
+import { createContext, useContext } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { Slot, Fill, Provider } from '../';
+
+export default { title: 'Components/SlotFill', component: Slot };
+
+export const _default = () => {
+	return (
+		<Provider>
+			<h2>Profile</h2>
+			<p>
+				Name: <Slot bubblesVirtually as="span" name="name" />
+			</p>
+			<p>
+				Age: <Slot bubblesVirtually as="span" name="age" />
+			</p>
+			<Fill name="name">Grace</Fill>
+			<Fill name="age">33</Fill>
+		</Provider>
+	);
+};
+
+export const withFillProps = () => {
+	const name = text( 'name', 'Grace' );
+	const age = number( 'age', 33 );
+	return (
+		<Provider>
+			<h2>Profile</h2>
+			<p>
+				Name:{ ' ' }
+				<Slot
+					bubblesVirtually
+					as="span"
+					name="name"
+					fillProps={ { name } }
+				/>
+			</p>
+			<p>
+				Age:{ ' ' }
+				<Slot
+					bubblesVirtually
+					as="span"
+					name="age"
+					fillProps={ { age } }
+				/>
+			</p>
+			<Fill name="name">{ ( fillProps ) => fillProps.name }</Fill>
+			<Fill name="age">{ ( fillProps ) => fillProps.age }</Fill>
+		</Provider>
+	);
+};
+
+export const withContext = () => {
+	const Context = createContext();
+	const ContextFill = ( { name } ) => {
+		const value = useContext( Context );
+		return <Fill name={ name }>{ value }</Fill>;
+	};
+	return (
+		<Provider>
+			<h2>Profile</h2>
+			<p>
+				Name: <Slot bubblesVirtually as="span" name="name" />
+			</p>
+			<p>
+				Age: <Slot bubblesVirtually as="span" name="age" />
+			</p>
+			<Context.Provider value="Grace">
+				<ContextFill name="name" />
+			</Context.Provider>
+			<Context.Provider value={ 33 }>
+				<ContextFill name="age" />
+			</Context.Provider>
+		</Provider>
+	);
+};

--- a/packages/components/src/slot-fill/test/slot.js
+++ b/packages/components/src/slot-fill/test/slot.js
@@ -7,9 +7,7 @@ import ReactTestRenderer from 'react-test-renderer';
 /**
  * Internal dependencies
  */
-import Slot from '../slot';
-import Fill from '../fill';
-import Provider from '../context';
+import { Slot, Fill, Provider } from '../';
 
 /**
  * WordPress dependencies
@@ -261,10 +259,6 @@ describe( 'Slot', () => {
 				);
 
 				expect( testRenderer.toJSON() ).toMatchSnapshot();
-
-				expect( testRenderer.getInstance().slots ).toHaveProperty(
-					'egg'
-				);
 			} );
 		}
 	);

--- a/packages/e2e-tests/fixtures/blocks/core__cover__deprecated-5.html
+++ b/packages/e2e-tests/fixtures/blocks/core__cover__deprecated-5.html
@@ -1,0 +1,11 @@
+<!-- wp:cover {"url":"data:image/jpeg;base64,/9j/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8QEBEQCgwSExIQEw8QEBD/yQALCAABAAEBAREA/8wABgAQEAX/2gAIAQEAAD8A0s8g/9k=","gradient":"midnight"} -->
+<div class="wp-block-cover has-background-dim"
+	style="background-image:url(data:image/jpeg;base64,/9j/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8QEBEQCgwSExIQEw8QEBD/yQALCAABAAEBAREA/8wABgAQEAX/2gAIAQEAAD8A0s8g/9k=)">
+	<span aria-hidden="true" class="wp-block-cover__gradient-background has-midnight-gradient-background"></span>
+	<div class="wp-block-cover__inner-container">
+		<!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
+		<p class="has-text-align-center has-large-font-size">Cover</p>
+		<!-- /wp:paragraph -->
+	</div>
+</div>
+<!-- /wp:cover -->

--- a/packages/e2e-tests/fixtures/blocks/core__cover__deprecated-5.json
+++ b/packages/e2e-tests/fixtures/blocks/core__cover__deprecated-5.json
@@ -1,0 +1,33 @@
+[
+    {
+        "clientId": "_clientId_0",
+        "name": "core/cover",
+        "isValid": true,
+        "attributes": {
+            "url": "data:image/jpeg;base64,/9j/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8QEBEQCgwSExIQEw8QEBD/yQALCAABAAEBAREA/8wABgAQEAX/2gAIAQEAAD8A0s8g/9k=",
+            "hasParallax": false,
+            "dimRatio": 50,
+            "backgroundType": "image",
+            "title": "",
+            "contentAlign": "center",
+            "gradient": "midnight"
+        },
+        "innerBlocks": [
+            {
+                "clientId": "_clientId_0",
+                "name": "core/paragraph",
+                "isValid": true,
+                "attributes": {
+                    "align": "center",
+                    "content": "Cover",
+                    "dropCap": false,
+                    "placeholder": "Write title…",
+                    "fontSize": "large"
+                },
+                "innerBlocks": [],
+                "originalContent": "<p class=\"has-text-align-center has-large-font-size\">Cover</p>"
+            }
+        ],
+        "originalContent": "<div class=\"wp-block-cover has-background-dim\"\n\tstyle=\"background-image:url(data:image/jpeg;base64,/9j/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8QEBEQCgwSExIQEw8QEBD/yQALCAABAAEBAREA/8wABgAQEAX/2gAIAQEAAD8A0s8g/9k=)\">\n\t<span aria-hidden=\"true\" class=\"wp-block-cover__gradient-background has-midnight-gradient-background\"></span>\n\t<div class=\"wp-block-cover__inner-container\">\n\t\t\n\t</div>\n</div>"
+    }
+]

--- a/packages/e2e-tests/fixtures/blocks/core__cover__deprecated-5.parsed.json
+++ b/packages/e2e-tests/fixtures/blocks/core__cover__deprecated-5.parsed.json
@@ -1,0 +1,39 @@
+[
+    {
+        "blockName": "core/cover",
+        "attrs": {
+            "url": "data:image/jpeg;base64,/9j/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8QEBEQCgwSExIQEw8QEBD/yQALCAABAAEBAREA/8wABgAQEAX/2gAIAQEAAD8A0s8g/9k=",
+            "gradient": "midnight"
+        },
+        "innerBlocks": [
+            {
+                "blockName": "core/paragraph",
+                "attrs": {
+                    "align": "center",
+                    "placeholder": "Write title…",
+                    "fontSize": "large"
+                },
+                "innerBlocks": [],
+                "innerHTML": "\n\t\t<p class=\"has-text-align-center has-large-font-size\">Cover</p>\n\t\t",
+                "innerContent": [
+                    "\n\t\t<p class=\"has-text-align-center has-large-font-size\">Cover</p>\n\t\t"
+                ]
+            }
+        ],
+        "innerHTML": "\n<div class=\"wp-block-cover has-background-dim\"\n\tstyle=\"background-image:url(data:image/jpeg;base64,/9j/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8QEBEQCgwSExIQEw8QEBD/yQALCAABAAEBAREA/8wABgAQEAX/2gAIAQEAAD8A0s8g/9k=)\">\n\t<span aria-hidden=\"true\" class=\"wp-block-cover__gradient-background has-midnight-gradient-background\"></span>\n\t<div class=\"wp-block-cover__inner-container\">\n\t\t\n\t</div>\n</div>\n",
+        "innerContent": [
+            "\n<div class=\"wp-block-cover has-background-dim\"\n\tstyle=\"background-image:url(data:image/jpeg;base64,/9j/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8QEBEQCgwSExIQEw8QEBD/yQALCAABAAEBAREA/8wABgAQEAX/2gAIAQEAAD8A0s8g/9k=)\">\n\t<span aria-hidden=\"true\" class=\"wp-block-cover__gradient-background has-midnight-gradient-background\"></span>\n\t<div class=\"wp-block-cover__inner-container\">\n\t\t",
+            null,
+            "\n\t</div>\n</div>\n"
+        ]
+    },
+    {
+        "blockName": null,
+        "attrs": {},
+        "innerBlocks": [],
+        "innerHTML": "\n",
+        "innerContent": [
+            "\n"
+        ]
+    }
+]

--- a/packages/e2e-tests/fixtures/blocks/core__cover__deprecated-5.serialized.html
+++ b/packages/e2e-tests/fixtures/blocks/core__cover__deprecated-5.serialized.html
@@ -1,0 +1,5 @@
+<!-- wp:cover {"url":"data:image/jpeg;base64,/9j/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8QEBEQCgwSExIQEw8QEBD/yQALCAABAAEBAREA/8wABgAQEAX/2gAIAQEAAD8A0s8g/9k=","gradient":"midnight"} -->
+<div class="wp-block-cover has-background-dim has-background-gradient" style="background-image:url(data:image/jpeg;base64,/9j/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8QEBEQCgwSExIQEw8QEBD/yQALCAABAAEBAREA/8wABgAQEAX/2gAIAQEAAD8A0s8g/9k=)"><span aria-hidden="true" class="wp-block-cover__gradient-background has-midnight-gradient-background"></span><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
+<p class="has-text-align-center has-large-font-size">Cover</p>
+<!-- /wp:paragraph --></div></div>
+<!-- /wp:cover -->

--- a/storybook/test/__snapshots__/index.js.snap
+++ b/storybook/test/__snapshots__/index.js.snap
@@ -4851,56 +4851,6 @@ exports[`Storyshots Components/ScrollLock Default 1`] = `
 </div>
 `;
 
-exports[`Storyshots Components/SlotFill Default 1`] = `
-Array [
-  <h2>
-    Profile
-  </h2>,
-  <p>
-    Name: 
-    <span />
-  </p>,
-  <p>
-    Age: 
-    <span />
-  </p>,
-]
-`;
-
-exports[`Storyshots Components/SlotFill With Context 1`] = `
-Array [
-  <h2>
-    Profile
-  </h2>,
-  <p>
-    Name: 
-    <span />
-  </p>,
-  <p>
-    Age: 
-    <span />
-  </p>,
-]
-`;
-
-exports[`Storyshots Components/SlotFill With Fill Props 1`] = `
-Array [
-  <h2>
-    Profile
-  </h2>,
-  <p>
-    Name:
-     
-    <span />
-  </p>,
-  <p>
-    Age:
-     
-    <span />
-  </p>,
-]
-`;
-
 exports[`Storyshots Components/Snackbar Default 1`] = `
 <div
   className="components-snackbar"

--- a/storybook/test/__snapshots__/index.js.snap
+++ b/storybook/test/__snapshots__/index.js.snap
@@ -4851,6 +4851,56 @@ exports[`Storyshots Components/ScrollLock Default 1`] = `
 </div>
 `;
 
+exports[`Storyshots Components/SlotFill Default 1`] = `
+Array [
+  <h2>
+    Profile
+  </h2>,
+  <p>
+    Name: 
+    <span />
+  </p>,
+  <p>
+    Age: 
+    <span />
+  </p>,
+]
+`;
+
+exports[`Storyshots Components/SlotFill With Context 1`] = `
+Array [
+  <h2>
+    Profile
+  </h2>,
+  <p>
+    Name: 
+    <span />
+  </p>,
+  <p>
+    Age: 
+    <span />
+  </p>,
+]
+`;
+
+exports[`Storyshots Components/SlotFill With Fill Props 1`] = `
+Array [
+  <h2>
+    Profile
+  </h2>,
+  <p>
+    Name:
+     
+    <span />
+  </p>,
+  <p>
+    Age:
+     
+    <span />
+  </p>,
+]
+`;
+
 exports[`Storyshots Components/Snackbar Default 1`] = `
 <div
   className="components-snackbar"


### PR DESCRIPTION
## Description
This PR cherry picks the following PR's into wp/trunk:
<table>
<tr><td><b>PR title</b></td><td><b>Author</b></td><td><b>Change required for cherry-picking</b></td></tr>



<tr><td><a href="https://github.com/WordPress/gutenberg/pull/19242">Components: Refactor SlotFill</a></td><td>@diegohaz</td><td>Update snapshots</td></tr>

<tr><td><a href="https://github.com/WordPress/gutenberg/pull/20457">Fix intermittent RichText e2e test failure</a></td><td>@youknowriad</td><td>Update snapshots</td></tr>
<tr><td><a href="https://github.com/WordPress/gutenberg/pull/20892">Fix: ResponsiveWrapper can not handle cases with small dimensions</a></td><td>@jorgefilipecosta</td><td>Use useResizeAware directly from react-resize-aware (package was already in use by the components package) instead of useResizeObserver from wordpress/compose (in trunk the hook is not available).</td></tr>
<tr><td><a href="https://github.com/WordPress/gutenberg/pull/20921">Fix: Cover block does not contain a class for predefined gradients</a></td><td>@jorgefilipecosta</td><td>-</td></tr>




</table>

cc: @youknowriad, @aduth, @gziolo

These PR's will be part of WordPress 5.4 RC 3.

## How has this been tested?
I did some smoke tests and verified the branch, in fact, contained the expected fixes.