### PR TITLE
Block: Outline when interacting with Toolbar Block Type/Movers

### DIFF
--- a/docs/designers-developers/developers/data/data-core-block-editor.md
+++ b/docs/designers-developers/developers/data/data-core-block-editor.md
@@ -1311,7 +1311,7 @@ _Returns_
 
 <a name="toggleBlockHighlight" href="#toggleBlockHighlight">#</a> **toggleBlockHighlight**
 
-Generator that toggles the highlighted block state.
+Returns an action object that toggles the highlighted block state.
 
 _Parameters_
 

--- a/docs/designers-developers/developers/data/data-core-block-editor.md
+++ b/docs/designers-developers/developers/data/data-core-block-editor.md
@@ -395,19 +395,6 @@ _Properties_
 -   _utility_ `number`: How useful we think this item is, between 0 and 3.
 -   _frecency_ `number`: Hueristic that combines frequency and recency.
 
-<a name="getIsBlockHighlighted" href="#getIsBlockHighlighted">#</a> **getIsBlockHighlighted**
-
-Returns true if the current highlighted block matches the block clientId.
-
-_Parameters_
-
--   _state_ `Object`: Global application state.
--   _clientId_ `string`: The block to check.
-
-_Returns_
-
--   `boolean`: Whether the block is currently highlighted.
-
 <a name="getLastMultiSelectedBlockClientId" href="#getLastMultiSelectedBlockClientId">#</a> **getLastMultiSelectedBlockClientId**
 
 Returns the client ID of the last block in the multi-selection set, or null
@@ -718,6 +705,19 @@ _Parameters_
 _Returns_
 
 -   `boolean`: Whether an ancestor of the block is in multi-selection set.
+
+<a name="isBlockHighlighted" href="#isBlockHighlighted">#</a> **isBlockHighlighted**
+
+Returns true if the current highlighted block matches the block clientId.
+
+_Parameters_
+
+-   _state_ `Object`: Global application state.
+-   _clientId_ `string`: The block to check.
+
+_Returns_
+
+-   `boolean`: Whether the block is currently highlighted.
 
 <a name="isBlockInsertionPointVisible" href="#isBlockInsertionPointVisible">#</a> **isBlockInsertionPointVisible**
 

--- a/docs/designers-developers/developers/data/data-core-block-editor.md
+++ b/docs/designers-developers/developers/data/data-core-block-editor.md
@@ -395,6 +395,19 @@ _Properties_
 -   _utility_ `number`: How useful we think this item is, between 0 and 3.
 -   _frecency_ `number`: Hueristic that combines frequency and recency.
 
+<a name="getIsBlockHighlighted" href="#getIsBlockHighlighted">#</a> **getIsBlockHighlighted**
+
+Returns true if the current highlighted block matches the block clientId.
+
+_Parameters_
+
+-   _state_ `Object`: Global application state.
+-   _clientId_ `string`: The block to check.
+
+_Returns_
+
+-   `boolean`: Whether the block is currently highlighted.
+
 <a name="getLastMultiSelectedBlockClientId" href="#getLastMultiSelectedBlockClientId">#</a> **getLastMultiSelectedBlockClientId**
 
 Returns the client ID of the last block in the multi-selection set, or null
@@ -1295,6 +1308,15 @@ Returns an action object synchronize the template with the list of blocks
 _Returns_
 
 -   `Object`: Action object.
+
+<a name="toggleBlockHighlight" href="#toggleBlockHighlight">#</a> **toggleBlockHighlight**
+
+Generator that toggles the highlighted block state.
+
+_Parameters_
+
+-   _clientId_ `string`: The block's clientId.
+-   _isHighlighted_ `boolean`: The highlight state.
 
 <a name="toggleBlockMode" href="#toggleBlockMode">#</a> **toggleBlockMode**
 

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -39,6 +39,7 @@ function BlockListBlock( {
 	isLocked,
 	clientId,
 	rootClientId,
+	isHighlighted,
 	isSelected,
 	isMultiSelected,
 	isPartOfMultiSelection,
@@ -112,6 +113,7 @@ function BlockListBlock( {
 			'has-selected-ui': hasSelectedUI,
 			'has-warning': ! isValid || !! hasError || isUnregisteredBlock,
 			'is-selected': isSelected,
+			'is-highlighted': isHighlighted,
 			'is-multi-selected': isMultiSelected,
 			'is-reusable': isReusableBlock( blockType ),
 			'is-dragging': isDragging,
@@ -228,6 +230,7 @@ const applyWithSelect = withSelect(
 			getTemplateLock,
 			__unstableGetBlockWithoutInnerBlocks,
 			isNavigationMode,
+			getIsBlockHighlighted,
 		} = select( 'core/block-editor' );
 		const block = __unstableGetBlockWithoutInnerBlocks( clientId );
 		const isSelected = isBlockSelected( clientId );
@@ -248,6 +251,7 @@ const applyWithSelect = withSelect(
 		const { name, attributes, isValid } = block || {};
 
 		return {
+			isHighlighted: getIsBlockHighlighted( clientId ),
 			isMultiSelected: isBlockMultiSelected( clientId ),
 			isPartOfMultiSelection:
 				isBlockMultiSelected( clientId ) ||

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -230,7 +230,7 @@ const applyWithSelect = withSelect(
 			getTemplateLock,
 			__unstableGetBlockWithoutInnerBlocks,
 			isNavigationMode,
-			getIsBlockHighlighted,
+			isBlockHighlighted,
 		} = select( 'core/block-editor' );
 		const block = __unstableGetBlockWithoutInnerBlocks( clientId );
 		const isSelected = isBlockSelected( clientId );
@@ -251,7 +251,7 @@ const applyWithSelect = withSelect(
 		const { name, attributes, isValid } = block || {};
 
 		return {
-			isHighlighted: getIsBlockHighlighted( clientId ),
+			isHighlighted: isBlockHighlighted( clientId ),
 			isMultiSelected: isBlockMultiSelected( clientId ),
 			isPartOfMultiSelection:
 				isBlockMultiSelected( clientId ) ||

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -149,6 +149,7 @@
 	// The primary indicator of selection in text is the native selection marker.
 	// When selecting multiple blocks, we provide an additional selection indicator.
 	.is-navigate-mode & .block-editor-block-list__block.is-selected,
+	.block-editor-block-list__block.is-highlighted,
 	.block-editor-block-list__block.is-multi-selected {
 
 		// Show selection borders around every non-nested block's actual footprint.

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -169,6 +169,8 @@
 			// 2px outside.
 			box-shadow: 0 0 0 2px $blue-medium-focus;
 			border-radius: $radius-block-ui;
+			transition: box-shadow 0.2s ease-out;
+			@include reduce-motion("transition");
 
 			// Windows High Contrast mode will show this outline.
 			outline: 2px solid transparent;
@@ -202,6 +204,19 @@
 .block-editor-block-list__layout .block-editor-block-list__block {
 	&.has-warning {
 		min-height: ( $block-padding + $block-spacing ) * 2;
+	}
+
+	&::after {
+		content: "";
+		position: absolute;
+		top: 0;
+		right: 0;
+		bottom: 0;
+		left: 0;
+		border-radius: $radius-block-ui;
+		box-shadow: 0 0 0 2px transparent;
+		transition: box-shadow 0.1s ease-in;
+		@include reduce-motion("transition");
 	}
 
 	// Warnings

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -208,6 +208,7 @@
 
 	&::after {
 		content: "";
+		pointer-events: none;
 		position: absolute;
 		top: 0;
 		right: 0;

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -5,7 +5,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { useRef } from '@wordpress/element';
 import { useViewportMatch } from '@wordpress/compose';
 /**
@@ -26,6 +26,7 @@ export default function BlockToolbar( { hideDragHandle } ) {
 		mode,
 		moverDirection,
 		hasMovers = true,
+		rootClientId,
 	} = useSelect( ( select ) => {
 		const {
 			getBlockMode,
@@ -60,12 +61,19 @@ export default function BlockToolbar( { hideDragHandle } ) {
 		};
 	}, [] );
 
+	const { toggleBlockFocus } = useDispatch( 'core/block-editor' );
 	const nodeRef = useRef();
 
-	const {
-		showMovers,
-		gestures: showMoversGestures,
-	} = useShowMoversGestures( { ref: nodeRef } );
+	const handleOnFocusChange = ( isFocused ) => {
+		toggleBlockFocus( rootClientId, isFocused );
+	};
+
+	const { showMovers, gestures: showMoversGestures } = useShowMoversGestures(
+		{
+			ref: nodeRef,
+			onChange: handleOnFocusChange,
+		}
+	);
 
 	const displayHeaderToolbar =
 		useViewportMatch( 'medium', '<' ) || hasFixedToolbar;

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -21,12 +21,12 @@ import { useShowMoversGestures } from './utils';
 export default function BlockToolbar( { hideDragHandle } ) {
 	const {
 		blockClientIds,
+		blockClientId,
 		hasFixedToolbar,
 		isValid,
 		mode,
 		moverDirection,
 		hasMovers = true,
-		rootClientId,
 	} = useSelect( ( select ) => {
 		const {
 			getBlockMode,
@@ -37,15 +37,15 @@ export default function BlockToolbar( { hideDragHandle } ) {
 			getSettings,
 		} = select( 'core/block-editor' );
 		const selectedBlockClientIds = getSelectedBlockClientIds();
-		const blockRootClientId = getBlockRootClientId(
-			selectedBlockClientIds[ 0 ]
-		);
+		const selectedBlockClientId = selectedBlockClientIds[ 0 ];
+		const blockRootClientId = getBlockRootClientId( selectedBlockClientId );
 
 		const { __experimentalMoverDirection, __experimentalUIParts = {} } =
 			getBlockListSettings( blockRootClientId ) || {};
 
 		return {
 			blockClientIds: selectedBlockClientIds,
+			blockClientId: selectedBlockClientId,
 			hasFixedToolbar: getSettings().hasFixedToolbar,
 			rootClientId: blockRootClientId,
 			isValid:
@@ -61,11 +61,11 @@ export default function BlockToolbar( { hideDragHandle } ) {
 		};
 	}, [] );
 
-	const { toggleBlockFocus } = useDispatch( 'core/block-editor' );
+	const { toggleBlockHighlight } = useDispatch( 'core/block-editor' );
 	const nodeRef = useRef();
 
 	const handleOnFocusChange = ( isFocused ) => {
-		toggleBlockFocus( rootClientId, isFocused );
+		toggleBlockHighlight( blockClientId, isFocused );
 	};
 
 	const { showMovers, gestures: showMoversGestures } = useShowMoversGestures(

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -5,7 +5,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import { useRef } from '@wordpress/element';
 import { useViewportMatch } from '@wordpress/compose';
 /**
@@ -16,7 +16,7 @@ import BlockSwitcher from '../block-switcher';
 import BlockControls from '../block-controls';
 import BlockFormatControls from '../block-format-controls';
 import BlockSettingsMenu from '../block-settings-menu';
-import { useShowMoversGestures } from './utils';
+import { useShowMoversGestures, useToggleBlockHighlight } from './utils';
 
 export default function BlockToolbar( { hideDragHandle } ) {
 	const {
@@ -61,7 +61,7 @@ export default function BlockToolbar( { hideDragHandle } ) {
 		};
 	}, [] );
 
-	const { toggleBlockHighlight } = useDispatch( 'core/block-editor' );
+	const toggleBlockHighlight = useToggleBlockHighlight( blockClientId );
 	const nodeRef = useRef();
 
 	const handleOnFocusChange = ( isFocused ) => {

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -64,14 +64,10 @@ export default function BlockToolbar( { hideDragHandle } ) {
 	const toggleBlockHighlight = useToggleBlockHighlight( blockClientId );
 	const nodeRef = useRef();
 
-	const handleOnFocusChange = ( isFocused ) => {
-		toggleBlockHighlight( blockClientId, isFocused );
-	};
-
 	const { showMovers, gestures: showMoversGestures } = useShowMoversGestures(
 		{
 			ref: nodeRef,
-			onChange: handleOnFocusChange,
+			onChange: toggleBlockHighlight,
 		}
 	);
 

--- a/packages/block-editor/src/components/block-toolbar/utils.js
+++ b/packages/block-editor/src/components/block-toolbar/utils.js
@@ -38,16 +38,21 @@ export function useDebouncedShowMovers( {
 		return ! isFocused && ! isHovered;
 	};
 
-	const debouncedShowMovers = ( event ) => {
-		if ( event ) {
-			event.stopPropagation();
-		}
-
+	const clearTimeoutRef = () => {
 		const timeout = timeoutRef.current;
 
 		if ( timeout && clearTimeout ) {
 			clearTimeout( timeout );
 		}
+	};
+
+	const debouncedShowMovers = ( event ) => {
+		if ( event ) {
+			event.stopPropagation();
+		}
+
+		clearTimeoutRef();
+
 		if ( ! showMovers ) {
 			handleOnChange( true );
 		}
@@ -58,6 +63,8 @@ export function useDebouncedShowMovers( {
 			event.stopPropagation();
 		}
 
+		clearTimeoutRef();
+
 		timeoutRef.current = setTimeout( () => {
 			if ( shouldHideMovers() ) {
 				handleOnChange( false );
@@ -65,7 +72,7 @@ export function useDebouncedShowMovers( {
 		}, debounceTimeout );
 	};
 
-	useEffect( () => () => clearTimeout( timeoutRef.current ), [] );
+	useEffect( () => () => clearTimeoutRef(), [] );
 
 	return {
 		showMovers,

--- a/packages/block-editor/src/components/block-toolbar/utils.js
+++ b/packages/block-editor/src/components/block-toolbar/utils.js
@@ -53,7 +53,7 @@ export function useDebouncedShowMovers( {
 				handleOnChange( true );
 			}
 		},
-		[ showMovers ]
+		[ handleOnChange, showMovers ]
 	);
 
 	const debouncedHideMovers = useCallback(
@@ -68,10 +68,16 @@ export function useDebouncedShowMovers( {
 				}
 			}, debounceTimeout );
 		},
-		[ isFocused ]
+		[ handleOnChange, isFocused ]
 	);
 
-	useEffect( () => () => clearTimeout( timeoutRef.current ), [] );
+	useEffect(
+		() => () => {
+			clearTimeout( timeoutRef.current );
+			handleOnChange( false );
+		},
+		[ handleOnChange ]
+	);
 
 	return {
 		showMovers,

--- a/packages/block-editor/src/components/block-toolbar/utils.js
+++ b/packages/block-editor/src/components/block-toolbar/utils.js
@@ -1,4 +1,8 @@
 /**
+ * External dependencies
+ */
+import { noop } from 'lodash';
+/**
  * WordPress dependencies
  */
 import { useState, useRef, useEffect, useCallback } from '@wordpress/element';
@@ -12,9 +16,17 @@ export function useDebouncedShowMovers( {
 	ref,
 	isFocused,
 	debounceTimeout = 500,
+	onChange = noop,
 } ) {
 	const [ showMovers, setShowMovers ] = useState( false );
 	const timeoutRef = useRef();
+
+	const handleOnChange = ( nextIsFocused ) => {
+		if ( nextIsFocused !== showMovers ) {
+			setShowMovers( nextIsFocused );
+			onChange( nextIsFocused );
+		}
+	};
 
 	const getIsHovered = () => {
 		return ref?.current && ref.current.matches( ':hover' );
@@ -38,7 +50,7 @@ export function useDebouncedShowMovers( {
 				clearTimeout( timeout );
 			}
 			if ( ! showMovers ) {
-				setShowMovers( true );
+				handleOnChange( true );
 			}
 		},
 		[ showMovers ]
@@ -52,7 +64,7 @@ export function useDebouncedShowMovers( {
 
 			timeoutRef.current = setTimeout( () => {
 				if ( shouldHideMovers() ) {
-					setShowMovers( false );
+					handleOnChange( false );
 				}
 			}, debounceTimeout );
 		},
@@ -72,13 +84,17 @@ export function useDebouncedShowMovers( {
  * Hook that provides a showMovers state and gesture events for DOM elements
  * that interact with the showMovers state.
  */
-export function useShowMoversGestures( { ref, debounceTimeout = 500 } ) {
+export function useShowMoversGestures( {
+	ref,
+	debounceTimeout = 500,
+	onChange = noop,
+} ) {
 	const [ isFocused, setIsFocused ] = useState( false );
 	const {
 		showMovers,
 		debouncedShowMovers,
 		debouncedHideMovers,
-	} = useDebouncedShowMovers( { ref, debounceTimeout, isFocused } );
+	} = useDebouncedShowMovers( { ref, debounceTimeout, isFocused, onChange } );
 
 	const registerRef = useRef( false );
 

--- a/packages/block-editor/src/components/block-toolbar/utils.js
+++ b/packages/block-editor/src/components/block-toolbar/utils.js
@@ -38,38 +38,32 @@ export function useDebouncedShowMovers( {
 		return ! isFocused && ! isHovered;
 	};
 
-	const debouncedShowMovers = useCallback(
-		( event ) => {
-			if ( event ) {
-				event.stopPropagation();
-			}
+	const debouncedShowMovers = ( event ) => {
+		if ( event ) {
+			event.stopPropagation();
+		}
 
-			const timeout = timeoutRef.current;
+		const timeout = timeoutRef.current;
 
-			if ( timeout && clearTimeout ) {
-				clearTimeout( timeout );
-			}
-			if ( ! showMovers ) {
-				handleOnChange( true );
-			}
-		},
-		[ handleOnChange, showMovers ]
-	);
+		if ( timeout && clearTimeout ) {
+			clearTimeout( timeout );
+		}
+		if ( ! showMovers ) {
+			handleOnChange( true );
+		}
+	};
 
-	const debouncedHideMovers = useCallback(
-		( event ) => {
-			if ( event ) {
-				event.stopPropagation();
-			}
+	const debouncedHideMovers = ( event ) => {
+		if ( event ) {
+			event.stopPropagation();
+		}
 
-			timeoutRef.current = setTimeout( () => {
-				if ( shouldHideMovers() ) {
-					handleOnChange( false );
-				}
-			}, debounceTimeout );
-		},
-		[ handleOnChange, isFocused ]
-	);
+		timeoutRef.current = setTimeout( () => {
+			if ( shouldHideMovers() ) {
+				handleOnChange( false );
+			}
+		}, debounceTimeout );
+	};
 
 	useEffect( () => () => clearTimeout( timeoutRef.current ), [] );
 

--- a/packages/block-editor/src/components/block-toolbar/utils.js
+++ b/packages/block-editor/src/components/block-toolbar/utils.js
@@ -8,7 +8,7 @@ import { noop } from 'lodash';
 import { useDispatch } from '@wordpress/data';
 import { useState, useRef, useEffect, useCallback } from '@wordpress/element';
 
-const { clearTimeout, setTimeout } = window;
+const { clearTimeout, requestAnimationFrame, setTimeout } = window;
 const DEBOUNCE_TIMEOUT = 250;
 
 /**
@@ -171,7 +171,11 @@ export function useToggleBlockHighlight( clientId ) {
 
 	useEffect( () => {
 		return () => {
-			updateBlockHighlight( false );
+			// Sequences state change to enable editor updates (e.g. cursor
+			// position) to render correctly.
+			requestAnimationFrame( () => {
+				updateBlockHighlight( false );
+			} );
 		};
 	}, [] );
 

--- a/packages/block-editor/src/components/block-toolbar/utils.js
+++ b/packages/block-editor/src/components/block-toolbar/utils.js
@@ -24,10 +24,8 @@ export function useDebouncedShowMovers( {
 	const timeoutRef = useRef();
 
 	const handleOnChange = ( nextIsFocused ) => {
-		if ( nextIsFocused !== showMovers ) {
-			setShowMovers( nextIsFocused );
-			onChange( nextIsFocused );
-		}
+		setShowMovers( nextIsFocused );
+		onChange( nextIsFocused );
 	};
 
 	const getIsHovered = () => {

--- a/packages/block-editor/src/components/block-toolbar/utils.js
+++ b/packages/block-editor/src/components/block-toolbar/utils.js
@@ -5,6 +5,7 @@ import { noop } from 'lodash';
 /**
  * WordPress dependencies
  */
+import { useDispatch } from '@wordpress/data';
 import { useState, useRef, useEffect, useCallback } from '@wordpress/element';
 
 const { clearTimeout, setTimeout } = window;
@@ -71,13 +72,7 @@ export function useDebouncedShowMovers( {
 		[ handleOnChange, isFocused ]
 	);
 
-	useEffect(
-		() => () => {
-			clearTimeout( timeoutRef.current );
-			handleOnChange( false );
-		},
-		[ handleOnChange ]
-	);
+	useEffect( () => () => clearTimeout( timeoutRef.current ), [] );
 
 	return {
 		showMovers,
@@ -156,4 +151,30 @@ export function useShowMoversGestures( {
 			onMouseLeave: debouncedHideMovers,
 		},
 	};
+}
+
+/**
+ * Hook that toggles the highlight (outline) state of a block
+ *
+ * @param {string} clientId The block's clientId
+ *
+ * @return {Function} Callback function to toggle highlight state.
+ */
+export function useToggleBlockHighlight( clientId ) {
+	const { toggleBlockHighlight } = useDispatch( 'core/block-editor' );
+
+	const updateBlockHighlight = useCallback(
+		( isFocused ) => {
+			toggleBlockHighlight( clientId, isFocused );
+		},
+		[ clientId ]
+	);
+
+	useEffect( () => {
+		return () => {
+			updateBlockHighlight( false );
+		};
+	}, [] );
+
+	return updateBlockHighlight;
 }

--- a/packages/block-editor/src/components/block-toolbar/utils.js
+++ b/packages/block-editor/src/components/block-toolbar/utils.js
@@ -9,6 +9,7 @@ import { useDispatch } from '@wordpress/data';
 import { useState, useRef, useEffect, useCallback } from '@wordpress/element';
 
 const { clearTimeout, setTimeout } = window;
+const DEBOUNCE_TIMEOUT = 250;
 
 /**
  * Hook that creates a showMover state, as well as debounced show/hide callbacks
@@ -16,7 +17,7 @@ const { clearTimeout, setTimeout } = window;
 export function useDebouncedShowMovers( {
 	ref,
 	isFocused,
-	debounceTimeout = 500,
+	debounceTimeout = DEBOUNCE_TIMEOUT,
 	onChange = noop,
 } ) {
 	const [ showMovers, setShowMovers ] = useState( false );
@@ -87,7 +88,7 @@ export function useDebouncedShowMovers( {
  */
 export function useShowMoversGestures( {
 	ref,
-	debounceTimeout = 500,
+	debounceTimeout = DEBOUNCE_TIMEOUT,
 	onChange = noop,
 } ) {
 	const [ isFocused, setIsFocused ] = useState( false );

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -991,14 +991,20 @@ export function* insertAfterBlock( clientId ) {
 	yield insertDefaultBlock( {}, rootClientId, firstSelectedIndex + 1 );
 }
 
-export function toggleBlockFocus( clientId, isFocused ) {
-	if ( isFocused ) {
+/**
+ * Generator that toggles the highlighted block state.
+ *
+ * @param {string} clientId The block's clientId.
+ * @param {boolean} isHighlighted The highlight state.
+ */
+export function toggleBlockHighlight( clientId, isHighlighted ) {
+	if ( isHighlighted ) {
 		return {
-			type: 'FOCUS_BLOCK',
+			type: 'HIGHLIGHT_BLOCK',
 			clientId,
 		};
 	}
 	return {
-		type: 'UNFOCUS_BLOCK',
+		type: 'UNHIGHLIGHT_BLOCK',
 	};
 }

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -990,3 +990,15 @@ export function* insertAfterBlock( clientId ) {
 	);
 	yield insertDefaultBlock( {}, rootClientId, firstSelectedIndex + 1 );
 }
+
+export function toggleBlockFocus( clientId, isFocused ) {
+	if ( isFocused ) {
+		return {
+			type: 'FOCUS_BLOCK',
+			clientId,
+		};
+	}
+	return {
+		type: 'UNFOCUS_BLOCK',
+	};
+}

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -992,7 +992,7 @@ export function* insertAfterBlock( clientId ) {
 }
 
 /**
- * Generator that toggles the highlighted block state.
+ * Returns an action object that toggles the highlighted block state.
  *
  * @param {string} clientId The block's clientId.
  * @param {boolean} isHighlighted The highlight state.

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -998,13 +998,9 @@ export function* insertAfterBlock( clientId ) {
  * @param {boolean} isHighlighted The highlight state.
  */
 export function toggleBlockHighlight( clientId, isHighlighted ) {
-	if ( isHighlighted ) {
-		return {
-			type: 'HIGHLIGHT_BLOCK',
-			clientId,
-		};
-	}
 	return {
-		type: 'UNHIGHLIGHT_BLOCK',
+		type: 'TOGGLE_BLOCK_HIGHLIGHT',
+		clientId,
+		isHighlighted,
 	};
 }

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1456,7 +1456,7 @@ export function automaticChangeStatus( state, action ) {
  *
  * @return {string} Updated state.
  */
-export function blockHighlighted( state = '', action ) {
+export function highlightedBlock( state = '', action ) {
 	switch ( action.type ) {
 		case 'HIGHLIGHT_BLOCK':
 			return action.clientId;
@@ -1487,5 +1487,5 @@ export default combineReducers( {
 	lastBlockAttributesChange,
 	isNavigationMode,
 	automaticChangeStatus,
-	blockHighlighted,
+	highlightedBlock,
 } );

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1448,13 +1448,21 @@ export function automaticChangeStatus( state, action ) {
 	// Reset the state by default (for any action not handled).
 }
 
-export function blockFocused( state = undefined, action ) {
+/**
+ * Reducer returning current highlighted block.
+ *
+ * @param {boolean} state  Current highlighted block.
+ * @param {Object}  action Dispatched action.
+ *
+ * @return {string} Updated state.
+ */
+export function blockHighlighted( state = '', action ) {
 	switch ( action.type ) {
-		case 'FOCUS_BLOCK':
+		case 'HIGHLIGHT_BLOCK':
 			return action.clientId;
 
-		case 'UNFOCUS_BLOCK':
-			return undefined;
+		case 'UNHIGHLIGHT_BLOCK':
+			return '';
 	}
 
 	return state;
@@ -1479,5 +1487,5 @@ export default combineReducers( {
 	lastBlockAttributesChange,
 	isNavigationMode,
 	automaticChangeStatus,
-	blockFocused,
+	blockHighlighted,
 } );

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1456,13 +1456,15 @@ export function automaticChangeStatus( state, action ) {
  *
  * @return {string} Updated state.
  */
-export function highlightedBlock( state = '', action ) {
-	switch ( action.type ) {
-		case 'HIGHLIGHT_BLOCK':
-			return action.clientId;
+export function highlightedBlock( state, action ) {
+	const { clientId, isHighlighted } = action;
 
-		case 'UNHIGHLIGHT_BLOCK':
-			return '';
+	if ( action.type === 'TOGGLE_BLOCK_HIGHLIGHT' ) {
+		if ( isHighlighted ) {
+			return clientId;
+		} else if ( state === clientId ) {
+			return null;
+		}
 	}
 
 	return state;

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1448,6 +1448,18 @@ export function automaticChangeStatus( state, action ) {
 	// Reset the state by default (for any action not handled).
 }
 
+export function blockFocused( state = undefined, action ) {
+	switch ( action.type ) {
+		case 'FOCUS_BLOCK':
+			return action.clientId;
+
+		case 'UNFOCUS_BLOCK':
+			return undefined;
+	}
+
+	return state;
+}
+
 export default combineReducers( {
 	blocks,
 	isTyping,
@@ -1467,4 +1479,5 @@ export default combineReducers( {
 	lastBlockAttributesChange,
 	isNavigationMode,
 	automaticChangeStatus,
+	blockFocused,
 } );

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1622,8 +1622,14 @@ export function didAutomaticChange( state ) {
 	return !! state.automaticChangeStatus;
 }
 
-export function getIsBlockFocused( state ) {
-	const clientId = getSelectedBlockClientId( state );
-
-	return state.blockFocused === clientId;
+/**
+ * Returns true if the current highlighted block matches the block clientId.
+ *
+ * @param {Object} state Global application state.
+ * @param {string} clientId The block to check.
+ *
+ * @return {boolean} Whether the block is currently highlighted.
+ */
+export function getIsBlockHighlighted( state, clientId ) {
+	return state.blockHighlighted === clientId;
 }

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1630,6 +1630,6 @@ export function didAutomaticChange( state ) {
  *
  * @return {boolean} Whether the block is currently highlighted.
  */
-export function getIsBlockHighlighted( state, clientId ) {
+export function isBlockHighlighted( state, clientId ) {
 	return state.highlightedBlock === clientId;
 }

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1631,5 +1631,5 @@ export function didAutomaticChange( state ) {
  * @return {boolean} Whether the block is currently highlighted.
  */
 export function getIsBlockHighlighted( state, clientId ) {
-	return state.blockHighlighted === clientId;
+	return state.highlightedBlock === clientId;
 }

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1621,3 +1621,9 @@ export function isNavigationMode( state ) {
 export function didAutomaticChange( state ) {
 	return !! state.automaticChangeStatus;
 }
+
+export function getIsBlockFocused( state ) {
+	const clientId = getSelectedBlockClientId( state );
+
+	return state.blockFocused === clientId;
+}


### PR DESCRIPTION
## Description

<img width="751" alt="Screen Shot 2020-03-16 at 3 58 55 PM" src="https://user-images.githubusercontent.com/2322354/76795369-60d11e80-679f-11ea-9c0f-f248a7e81401.png">

This update enhances the new G2-based Toolbar interactions to provide a highlighted outline for a block when interacting with the Block Type/Mover actions.

## How has this been tested?

* Tested locally in Gutenberg

## Screenshots

![Screen Capture on 2020-03-16 at 15-49-00](https://user-images.githubusercontent.com/2322354/76795441-8bbb7280-679f-11ea-8870-b3d91cd94d51.gif)

The GIF (above) demonstrates the outline when engaging with the Block Type/Mover actions.

### Interaction

The outline shows when:

* Block Type is focused or hovered
* Any mover is focused or hovered

The style of the highlight is the **same** as the block's navigation mode styles. This can be seen by **pressing ESC** when on a block.

### Top Toolbar

<img width="800" alt="Screen Shot 2020-03-16 at 4 13 44 PM" src="https://user-images.githubusercontent.com/2322354/76796125-24062700-67a1-11ea-9733-138b2f0d7603.png">


The highlight feature still works for Top Toolbar (as well as smaller viewports)


## Types of changes
* Adding new `blockHighlighted` state to track the highlighted block, responding to Block Toolbar interactions
* Added reducer, action, and selector to accompany the `blockHighlighted` state
* Hook up the action with `BlockToolbar`
* Hook up state to render with `block-list/block`

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->

Resolves: https://github.com/WordPress/gutenberg/issues/20875