### PR TITLE
Compat: Conditionally filter editor settings for image dimensions

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -626,27 +626,6 @@ function gutenberg_extend_block_editor_styles( $settings ) {
 add_filter( 'block_editor_settings', 'gutenberg_extend_block_editor_styles' );
 
 /**
- * Extends block editor settings to include a list of image dimensions per size.
- *
- * @param array $settings Default editor settings.
- *
- * @return array Filtered editor settings.
- */
-function gutenberg_extend_settings_image_dimensions( $settings ) {
-	$image_dimensions = array();
-	$all_sizes        = wp_get_registered_image_subsizes();
-	foreach ( $settings['imageSizes'] as $size ) {
-		$key = $size['slug'];
-		if ( isset( $all_sizes[ $key ] ) ) {
-			$image_dimensions[ $key ] = $all_sizes[ $key ];
-		}
-	}
-	$settings['imageDimensions'] = $image_dimensions;
-	return $settings;
-}
-add_filter( 'block_editor_settings', 'gutenberg_extend_settings_image_dimensions' );
-
-/**
  * Load a block pattern by name.
  *
  * @param string $name Block Pattern File name.

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -21,11 +21,13 @@
  * @return array Filtered editor settings.
  */
 function gutenberg_extend_settings_image_dimensions( $settings ) {
-	// Only filter settings if:
-	// 1. `imageDimensions` is not already assigned, in which case it can be
-	//    assumed to have been set from WordPress 5.4.0+ default settings.
-	// 2. `imageSizes` is an array. Plugins may run `block_editor_settings`
-	//    directly and not provide all properties of the settings array.
+	/*
+	 * Only filter settings if:
+	 * 1. `imageDimensions` is not already assigned, in which case it can be
+	 *    assumed to have been set from WordPress 5.4.0+ default settings.
+	 * 2. `imageSizes` is an array. Plugins may run `block_editor_settings`
+	 *    directly and not provide all properties of the settings array.
+	 */
 	if ( ! isset( $settings['imageDimensions'] ) && ! empty( $settings['imageSizes'] ) ) {
 		$image_dimensions = array();
 		$all_sizes        = wp_get_registered_image_subsizes();

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -26,7 +26,7 @@ function gutenberg_extend_settings_image_dimensions( $settings ) {
 	//    assumed to have been set from WordPress 5.4.0+ default settings.
 	// 2. `imageSizes` is an array. Plugins may run `block_editor_settings`
 	//    directly and not provide all properties of the settings array.
-	if ( ! isset( $settings['imageDimensions'] ) && is_array( $settings['imageSizes'] ) ) {
+	if ( ! isset( $settings['imageDimensions'] ) && ! empty( $settings['imageSizes'] ) ) {
 		$image_dimensions = array();
 		$all_sizes        = wp_get_registered_image_subsizes();
 		foreach ( $settings['imageSizes'] as $size ) {

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -9,6 +9,40 @@
  */
 
 /**
+ * Extends block editor settings to include a list of image dimensions per size.
+ *
+ * This can be removed when plugin support requires WordPress 5.4.0+.
+ *
+ * @see https://core.trac.wordpress.org/ticket/49389
+ * @see https://core.trac.wordpress.org/changeset/47240
+ *
+ * @param array $settings Default editor settings.
+ *
+ * @return array Filtered editor settings.
+ */
+function gutenberg_extend_settings_image_dimensions( $settings ) {
+	// Only filter settings if:
+	// 1. `imageDimensions` is not already assigned, in which case it can be
+	//    assumed to have been set from WordPress 5.4.0+ default settings.
+	// 2. `imageSizes` is an array. Plugins may run `block_editor_settings`
+	//    directly and not provide all properties of the settings array.
+	if ( ! isset( $settings['imageDimensions'] ) && is_array( $settings['imageSizes'] ) ) {
+		$image_dimensions = array();
+		$all_sizes        = wp_get_registered_image_subsizes();
+		foreach ( $settings['imageSizes'] as $size ) {
+			$key = $size['slug'];
+			if ( isset( $all_sizes[ $key ] ) ) {
+				$image_dimensions[ $key ] = $all_sizes[ $key ];
+			}
+		}
+		$settings['imageDimensions'] = $image_dimensions;
+	}
+
+	return $settings;
+}
+add_filter( 'block_editor_settings', 'gutenberg_extend_settings_image_dimensions' );
+
+/**
  * Adds a polyfill for the WHATWG URL in environments which do not support it.
  * The intention in how this action is handled is under the assumption that this
  * code would eventually be placed at `wp_default_packages_vendor`, which is


### PR DESCRIPTION
Fixes #20907
Previously: #17151

This pull request seeks to move `gutenberg_extend_settings_image_dimensions` to `compat.php`, considering it as a temporary backporting of behavior otherwise assumed to be handled by WordPress 5.4.0+ (i.e. to support WordPress 5.3.x). In doing so, it makes the implementation more durable by only extending the settings if (a) `imageDimensions` is not already assigned and (b) the given settings `imageSizes` is an array.

**Testing Instructions:**

Repeat Steps to Reproduce from #20907, verifying that no warnings occur.

Repeat Testing Instructions from #17151, ideally both in WordPress 5.3.2 (where the extension will apply) and WordPress 5.4.0 RC2 (where it is not needed).