### PR TITLE
Fix mobile header.

### DIFF
--- a/packages/edit-post/src/components/header/style.scss
+++ b/packages/edit-post/src/components/header/style.scss
@@ -34,14 +34,30 @@
 .edit-post-header__toolbar {
 	display: flex;
 	flex-grow: 1;
-	padding-left: $grid-unit-30;
+	padding-left: $grid-unit-10;
+
+	@include break-small() {
+		padding-left: $grid-unit-30;
+	}
+
+	.table-of-contents {
+		display: none;
+
+		@include break-small() {
+			display: block;
+		}
+	}
 }
 
 .edit-post-header__settings {
 	display: inline-flex;
 	align-items: center;
 	flex-wrap: wrap;
-	padding-right: $grid-unit-20;
+	padding-right: $grid-unit-05;
+
+	@include break-small () {
+		padding-right: $grid-unit-20;
+	}
 }
 
 

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -104,23 +104,6 @@
 		font-size: $default-font-size;
 		padding: 0 ($grid-unit-15 + 6px);
 	}
-
-	.table-of-contents {
-		margin: auto 0 0 auto;
-	}
-
-	.table-of-contents .components-button {
-		height: $button-size-small;
-		padding: 0;
-
-		&:focus {
-			box-shadow: inset 0 0 0 2px color($theme-color);
-
-			// Windows High Contrast mode will show this outline, but not the box-shadow.
-			outline: 1px solid transparent;
-
-		}
-	}
 }
 
 .edit-post-layout .block-editor-editor-skeleton__content {

--- a/packages/editor/src/components/post-saved-state/style.scss
+++ b/packages/editor/src/components/post-saved-state/style.scss
@@ -19,7 +19,7 @@
 		padding: $grid-unit-10 #{ $grid-unit-05 * 3 };
 		text-indent: inherit;
 
-		.dashicon {
+		svg {
 			margin-right: $grid-unit-05;
 		}
 	}


### PR DESCRIPTION
The mobile header regressed in recent margin/padding tweaks:

<img width="498" alt="Screenshot 2020-03-17 at 09 42 52" src="https://user-images.githubusercontent.com/1204802/76838295-4f862180-6834-11ea-81fc-35e50a98d1e2.png">

This PR fixes that, restores some forgotten rules, removes some dead CSS, and makes it nice again:

<img width="543" alt="Screenshot 2020-03-17 at 09 46 33" src="https://user-images.githubusercontent.com/1204802/76838350-590f8980-6834-11ea-9d69-0e487f33e571.png">
