### PR TITLE
Make the inner button block not allowed as a reusable block or editable as HTML

### DIFF
--- a/packages/block-library/src/button/index.js
+++ b/packages/block-library/src/button/index.js
@@ -33,6 +33,7 @@ export const settings = {
 	supports: {
 		align: true,
 		alignWide: false,
+		reusable: false,
 	},
 	parent: [ 'core/buttons' ],
 	styles: [

--- a/packages/block-library/src/button/index.js
+++ b/packages/block-library/src/button/index.js
@@ -34,7 +34,6 @@ export const settings = {
 		align: true,
 		alignWide: false,
 		reusable: false,
-		html: false,
 	},
 	parent: [ 'core/buttons' ],
 	styles: [

--- a/packages/block-library/src/button/index.js
+++ b/packages/block-library/src/button/index.js
@@ -34,6 +34,7 @@ export const settings = {
 		align: true,
 		alignWide: false,
 		reusable: false,
+		html: false,
 	},
 	parent: [ 'core/buttons' ],
 	styles: [


### PR DESCRIPTION
## Description
Fixes #20942, which identifies that the button block can be made reusable, but then attempting to convert that reusable button block to a regular block outside of its parent context fails.

This PR makes the Button block consistent with other inner blocks (navigation link, social icons, column) with a distinct parent. Those blocks generally can't be made reusable, because of the above issue. They also generally can't be edited as HMTL. The general idea is that the parent has those options but the child doesn't.

With the Button block, there is a the possibility that this block is already in use in some reusable blocks and those still can't be converted to regular blocks, that's something this PR doesn't solve.

## How has this been tested?
1. Add a Buttons block
2. Try to make the Inner Button block reusable
3. Observe that there is now no menu option to achieve this.

## Screenshots <!-- if applicable -->
<img width="494" alt="Screenshot 2020-03-17 at 5 02 32 pm" src="https://user-images.githubusercontent.com/677833/76839801-1fa93f00-6871-11ea-9136-4b852f4ca755.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
