### PR TITLE
Add template preview to the edit site template switcher

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10820,6 +10820,7 @@
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/hooks": "file:packages/hooks",
 				"@wordpress/i18n": "file:packages/i18n",
+				"@wordpress/icons": "file:packages/icons",
 				"@wordpress/media-utils": "file:packages/media-utils",
 				"@wordpress/notices": "file:packages/notices",
 				"@wordpress/url": "file:packages/url",

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -61,7 +61,7 @@ class InnerBlocks extends Component {
 		// Set controlled blocks value from parent, if any.
 		if ( __experimentalBlocks ) {
 			__unstableMarkNextChangeAsNotPersistent();
-			replaceInnerBlocks( __experimentalBlocks );
+			replaceInnerBlocks( __experimentalBlocks, false );
 		}
 	}
 
@@ -227,13 +227,15 @@ const ComposedInnerBlocks = compose( [
 		} = ownProps;
 
 		return {
-			replaceInnerBlocks( blocks ) {
+			replaceInnerBlocks( blocks, forceUpdateSelection ) {
 				replaceInnerBlocks(
 					clientId,
 					blocks,
-					block.innerBlocks.length === 0 &&
-						templateInsertUpdatesSelection &&
-						blocks.length !== 0
+					forceUpdateSelection !== undefined
+						? forceUpdateSelection
+						: block.innerBlocks.length === 0 &&
+								templateInsertUpdatesSelection &&
+								blocks.length !== 0
 				);
 			},
 			__unstableMarkNextChangeAsNotPersistent,

--- a/packages/block-editor/src/components/inserter/block-list.js
+++ b/packages/block-editor/src/components/inserter/block-list.js
@@ -154,7 +154,7 @@ function InserterBlockList( {
 	}
 
 	const onHoverItem = ( item ) => {
-		onHover();
+		onHover( item );
 		if ( item ) {
 			const index = getInsertionIndex();
 			showInsertionPoint( destinationRootClientId, index );

--- a/packages/components/src/menu-items-choice/index.js
+++ b/packages/components/src/menu-items-choice/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { noop } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { check } from '@wordpress/icons';
@@ -8,7 +13,12 @@ import { check } from '@wordpress/icons';
  */
 import MenuItem from '../menu-item';
 
-export default function MenuItemsChoice( { choices = [], onSelect, value } ) {
+export default function MenuItemsChoice( {
+	choices = [],
+	onHover = noop,
+	onSelect,
+	value,
+} ) {
 	return choices.map( ( item ) => {
 		const isSelected = value === item.value;
 		return (
@@ -24,6 +34,8 @@ export default function MenuItemsChoice( { choices = [], onSelect, value } ) {
 						onSelect( item.value );
 					}
 				} }
+				onMouseEnter={ () => onHover( item.value ) }
+				onMouseLeave={ () => onHover( null ) }
 			>
 				{ item.label }
 			</MenuItem>

--- a/packages/edit-site/package.json
+++ b/packages/edit-site/package.json
@@ -32,6 +32,7 @@
 		"@wordpress/element": "file:../element",
 		"@wordpress/hooks": "file:../hooks",
 		"@wordpress/i18n": "file:../i18n",
+		"@wordpress/icons": "file:../icons",
 		"@wordpress/media-utils": "file:../media-utils",
 		"@wordpress/notices": "file:../notices",
 		"@wordpress/url": "file:../url",

--- a/packages/edit-site/src/components/template-switcher/index.js
+++ b/packages/edit-site/src/components/template-switcher/index.js
@@ -12,7 +12,7 @@ import {
 	MenuItemsChoice,
 	MenuItem,
 } from '@wordpress/components';
-import { layout } from '@wordpress/icons';
+import { layout, plus } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -123,7 +123,7 @@ export default function TemplateSwitcher( {
 								onHover={ onHoverTemplate }
 							/>
 							<MenuItem
-								icon="plus"
+								icon={ plus }
 								onClick={ () => {
 									onClose();
 									setIsAddTemplateOpen( true );

--- a/packages/edit-site/src/components/template-switcher/index.js
+++ b/packages/edit-site/src/components/template-switcher/index.js
@@ -12,11 +12,13 @@ import {
 	MenuItemsChoice,
 	MenuItem,
 } from '@wordpress/components';
+import { layout } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
 import AddTemplate from '../add-template';
+import TemplatePreview from './preview';
 
 function TemplateLabel( { template } ) {
 	return (
@@ -45,6 +47,13 @@ export default function TemplateSwitcher( {
 	onActiveTemplatePartIdChange,
 	onAddTemplateId,
 } ) {
+	const [ hoveredTemplate, setHoveredTemplate ] = useState();
+	const onHoverTemplate = ( id ) => {
+		setHoveredTemplate( { id, type: 'template' } );
+	};
+	const onHoverTemplatePart = ( id ) => {
+		setHoveredTemplate( { id, type: 'template-part' } );
+	};
 	const { templates, templateParts } = useSelect(
 		( select ) => {
 			const { getEntityRecord } = select( 'core' );
@@ -89,7 +98,11 @@ export default function TemplateSwitcher( {
 	return (
 		<>
 			<DropdownMenu
-				icon="layout"
+				popoverProps={ {
+					className: 'edit-site-template-switcher__popover',
+					position: 'bottom right',
+				} }
+				icon={ layout }
 				label={ __( 'Switch Template' ) }
 				toggleProps={ {
 					children: ( isTemplatePart
@@ -107,6 +120,7 @@ export default function TemplateSwitcher( {
 									! isTemplatePart ? activeId : undefined
 								}
 								onSelect={ onActiveIdChange }
+								onHover={ onHoverTemplate }
 							/>
 							<MenuItem
 								icon="plus"
@@ -123,8 +137,12 @@ export default function TemplateSwitcher( {
 								choices={ templateParts }
 								value={ isTemplatePart ? activeId : undefined }
 								onSelect={ onActiveTemplatePartIdChange }
+								onHover={ onHoverTemplatePart }
 							/>
 						</MenuGroup>
+						{ !! hoveredTemplate && (
+							<TemplatePreview item={ hoveredTemplate } />
+						) }
 					</>
 				) }
 			</DropdownMenu>

--- a/packages/edit-site/src/components/template-switcher/index.js
+++ b/packages/edit-site/src/components/template-switcher/index.js
@@ -140,7 +140,7 @@ export default function TemplateSwitcher( {
 								onHover={ onHoverTemplatePart }
 							/>
 						</MenuGroup>
-						{ !! hoveredTemplate && (
+						{ !! hoveredTemplate?.id && (
 							<TemplatePreview item={ hoveredTemplate } />
 						) }
 					</>

--- a/packages/edit-site/src/components/template-switcher/preview.js
+++ b/packages/edit-site/src/components/template-switcher/preview.js
@@ -1,0 +1,31 @@
+/**
+ * WordPress dependencies
+ */
+import { parse } from '@wordpress/blocks';
+import { useSelect } from '@wordpress/data';
+import { BlockPreview } from '@wordpress/block-editor';
+import { useMemo } from '@wordpress/element';
+
+function TemplatePreview( { item } ) {
+	const template = useSelect(
+		( select ) => {
+			return select( 'core' ).getEntityRecord(
+				'postType',
+				item.type === 'template' ? 'wp_template' : 'wp_template_part',
+				item.id
+			);
+		},
+		[ item ]
+	);
+	const blocks = useMemo(
+		() => ( template ? parse( template?.content?.raw || '' ) : [] ),
+		[ template ]
+	);
+	return (
+		<div className="edit-site-template-switcher__preview">
+			{ !! blocks && <BlockPreview blocks={ blocks } autoHeight /> }
+		</div>
+	);
+}
+
+export default TemplatePreview;

--- a/packages/edit-site/src/components/template-switcher/style.scss
+++ b/packages/edit-site/src/components/template-switcher/style.scss
@@ -1,3 +1,7 @@
+.edit-site-template-switcher__popover .components-popover__content {
+	overflow: visible;
+}
+
 .edit-site-template-switcher__label {
 	position: relative;
 	width: 100%;
@@ -12,4 +16,22 @@
 
 .edit-site-template-switcher__label-customized-icon-icon {
 	width: 100%;
+}
+
+.edit-site-template-switcher__preview {
+	display: none;
+	border: $border-width solid $light-gray-secondary;
+	width: 300px;
+	padding: $grid-unit-20;
+	background: $white;
+	box-shadow: $shadow-popover;
+	border-radius: $radius-block-ui;
+	position: absolute;
+	top: -$border-width;
+	left: calc(100% + #{$grid-unit-15});
+
+
+	@include break-medium {
+		display: block;
+	}
 }


### PR DESCRIPTION
closes #20478

This PR adds a preview panel similar to the inserter one to the template switcher on the edit-site package.

<img width="594" alt="Capture d’écran 2020-03-17 à 2 34 32 PM" src="https://user-images.githubusercontent.com/272444/76861159-6fc9d680-685c-11ea-9eff-759fee38e2be.png">