### PR TITLE
[Latest posts] Fixes the categories selector crash when category does not exist

### DIFF
--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, invoke, isUndefined, pickBy } from 'lodash';
+import { get, includes, invoke, isUndefined, pickBy } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -121,9 +121,19 @@ class LatestPostsEdit extends Component {
 		const selectCategories = ( tokens ) => {
 			// Categories that are already will be objects, while new additions will be strings (the name).
 			// allCategories nomalizes the array so that they are all objects.
-			const allCategories = tokens.map( ( token ) =>
-				typeof token === 'string' ? suggestions[ token ] : token
-			);
+			const allCategories = tokens.map( ( token ) => {
+				if ( typeof suggestions[ token ] !== 'undefined' ) {
+					return typeof token === 'string'
+						? suggestions[ token ]
+						: token;
+				}
+				return null;
+			} );
+			// we do nothing if the category is not selected
+			// from suggestions
+			if ( includes( allCategories, null ) ) {
+				return [];
+			}
 			setAttributes( { categories: allCategories } );
 		};
 

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -122,12 +122,11 @@ class LatestPostsEdit extends Component {
 			// Categories that are already will be objects, while new additions will be strings (the name).
 			// allCategories nomalizes the array so that they are all objects.
 			const allCategories = tokens.map( ( token ) => {
-				if ( typeof suggestions[ token ] !== 'undefined' ) {
-					return typeof token === 'string'
+				const newToken =
+					typeof suggestions[ token ] !== 'undefined'
 						? suggestions[ token ]
-						: token;
-				}
-				return null;
+						: null;
+				return typeof token === 'string' ? newToken : token;
 			} );
 			// we do nothing if the category is not selected
 			// from suggestions

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -128,8 +128,8 @@ class LatestPostsEdit extends Component {
 						: null;
 				return typeof token === 'string' ? newToken : token;
 			} );
-			// we do nothing if the category is not selected
-			// from suggestions
+			// We do nothing if the category is not selected
+			// from suggestions.
 			if ( includes( allCategories, null ) ) {
 				return false;
 			}

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -131,7 +131,7 @@ class LatestPostsEdit extends Component {
 			// we do nothing if the category is not selected
 			// from suggestions
 			if ( includes( allCategories, null ) ) {
-				return [];
+				return false;
 			}
 			setAttributes( { categories: allCategories } );
 		};

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -119,14 +119,16 @@ class LatestPostsEdit extends Component {
 			{}
 		);
 		const selectCategories = ( tokens ) => {
+			const hasNoSuggestion = tokens.some(
+				( token ) => typeof token === 'string' && ! suggestions[ token ]
+			);
+			if ( hasNoSuggestion ) {
+				return;
+			}
 			// Categories that are already will be objects, while new additions will be strings (the name).
 			// allCategories nomalizes the array so that they are all objects.
 			const allCategories = tokens.map( ( token ) => {
-				const newToken =
-					typeof suggestions[ token ] !== 'undefined'
-						? suggestions[ token ]
-						: null;
-				return typeof token === 'string' ? newToken : token;
+				return typeof token === 'string' ? suggestions[ token ] : token;
 			} );
 			// We do nothing if the category is not selected
 			// from suggestions.


### PR DESCRIPTION
## Description
Closes  #20915

## How has this been tested?
Tested locally by:

- make sure you have posts in categories
- add a page or post
- insert a LatestPosts block
- try to filter by a category that does not exist
- nothing should happen

## Types of changes
Non breaking changes to the LatestPosts edit component.

cc @Ringish 
