### PR TITLE
Autocomplete: Add support for results with long titles

### DIFF
--- a/packages/components/src/autocomplete/style.scss
+++ b/packages/components/src/autocomplete/style.scss
@@ -4,6 +4,9 @@
 
 .components-autocomplete__result.components-button {
 	display: flex;
+	height: auto;
+	min-height: $button-size;
+	text-align: left;
 	width: 100%;
 
 	&.is-selected {


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
The `Autocomplete` component displays a `Popover` consisting of a list of `Button`s, one for each autocomplete results.
If the result title is multiple lines long, the `Button` label gets centered.
If the title is 3 or more lines long, the label gets cut off, as the `Button` forces a `36px` (`$button-size`) height.

This PR makes sure that the `Button`s inside `Autocomplete` have automatic height, and their labels are left-aligned.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Tested on Chrome 80 on Mac, running Gutenberg on the Jetpack Docker environment, at any possible screen size.

## Screenshots <!-- if applicable -->

| Before | After |
| - | - |
| <img width="510" alt="Screenshot 2020-03-17 at 15 37 52" src="https://user-images.githubusercontent.com/2070010/76873620-e4554300-6865-11ea-9247-b59c9f3ea419.png"> | <img width="516" alt="Screenshot 2020-03-17 at 15 37 18" src="https://user-images.githubusercontent.com/2070010/76873629-e6b79d00-6865-11ea-891f-b54fc0a1c035.png"> |

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
