### PR TITLE
Fix input rules

### DIFF
--- a/packages/e2e-tests/specs/editor/blocks/__snapshots__/heading.test.js.snap
+++ b/packages/e2e-tests/specs/editor/blocks/__snapshots__/heading.test.js.snap
@@ -43,3 +43,15 @@ exports[`Heading should create a paragraph block below when pressing enter at th
 <p></p>
 <!-- /wp:paragraph -->"
 `;
+
+exports[`Heading should not work with the list input rule 1`] = `
+"<!-- wp:heading -->
+<h2>1. H</h2>
+<!-- /wp:heading -->"
+`;
+
+exports[`Heading should work with the format input rules 1`] = `
+"<!-- wp:heading -->
+<h2><code>code</code></h2>
+<!-- /wp:heading -->"
+`;

--- a/packages/e2e-tests/specs/editor/blocks/heading.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/heading.test.js
@@ -36,6 +36,20 @@ describe( 'Heading', () => {
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 
+	it( 'should not work with the list input rule', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( '## 1. H' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'should work with the format input rules', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( '## `code`' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
 	it( 'should create a paragraph block above when pressing enter at the start', async () => {
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( '## a' );

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -482,16 +482,12 @@ class RichText extends Component {
 		clearTimeout( this.onInput.timeout );
 		this.onInput.timeout = setTimeout( this.onCreateUndoLevel, 1000 );
 
-		if ( ! allowPrefixTransformations ) {
-			return;
-		}
-
 		// Only run input rules when inserting text.
 		if ( inputType !== 'insertText' ) {
 			return;
 		}
 
-		if ( inputRule ) {
+		if ( allowPrefixTransformations && inputRule ) {
 			inputRule( change, this.valueToFormat );
 		}
 


### PR DESCRIPTION
## Description

Adjusts #19727 so some input rules continue to work in all rich text fields. Only rules that transform the block should be limited to the paragraph.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
