### PR TITLE
Lowercase visual editor and code editor to match block editor and classic editor

### DIFF
--- a/docs/designers-developers/developers/filters/editor-filters.md
+++ b/docs/designers-developers/developers/filters/editor-filters.md
@@ -41,12 +41,12 @@ The filter will send any setting to the initialized Editor, which means any edit
 ### Available default editor settings
 
 #### `richEditingEnabled`
-If it is `true` the user can edit the content using the Visual Editor.
+If it is `true` the user can edit the content using the visual editor.
 
-It is set by default to the return value of the [`user_can_richedit`](https://developer.wordpress.org/reference/functions/user_can_richedit/) function. It checks if the user can access the Visual Editor and whether it’s supported by the user’s browser.
+It is set by default to the return value of the [`user_can_richedit`](https://developer.wordpress.org/reference/functions/user_can_richedit/) function. It checks if the user can access the visual editor and whether it’s supported by the user’s browser.
 
 
 #### `codeEditingEnabled`
-Default `true`. Indicates whether the user can access the Code Editor **in addition** to the Visual Editor.
+Default `true`. Indicates whether the user can access the code editor **in addition** to the visual editor.
 
-If set to false the user will not be able to switch between Visual and Code editor. The option in the settings menu will not be available and the keyboard shortcut for switching editor types will not fire.  
+If set to false the user will not be able to switch between visual and code editor. The option in the settings menu will not be available and the keyboard shortcut for switching editor types will not fire.  

--- a/docs/designers-developers/developers/themes/block-based-themes.md
+++ b/docs/designers-developers/developers/themes/block-based-themes.md
@@ -73,7 +73,7 @@ Ultimately, any WordPress user with the correct capabilities (example: `administ
 
 In the current iteration (at the time of writing this doc), you can navigate to the temporary "Templates" admin menu under "Appearance" `wp-admin/edit.php?post_type=wp_template` and use this as a playground to edit your templates.
 
-When ready, switch to the "Code editor" mode and grab the HTML of the template from there and put it in the right file in your theme directory.
+When ready, switch to the code editor mode and grab the HTML of the template from there and put it in the right file in your theme directory.
 
 ## Templates CPT
 

--- a/docs/designers-developers/faq.md
+++ b/docs/designers-developers/faq.md
@@ -116,7 +116,7 @@ This is the canonical list of keyboard shortcuts:
 			<td><kbd>⌥</kbd><kbd>F10</kbd></td>
 		</tr>
 		<tr>
-			<td>Switch between Visual editor and Code editor.</td>
+			<td>Switch between visual editor and code editor.</td>
 			<td><kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>Alt</kbd>+<kbd>M</kbd></td>
 			<td><kbd>⇧</kbd><kbd>⌥</kbd><kbd>⌘</kbd><kbd>M</kbd></td>
 		</tr>

--- a/packages/components/src/menu-items-choice/README.md
+++ b/packages/components/src/menu-items-choice/README.md
@@ -63,11 +63,11 @@ const MyMenuItemsChoice = withState( {
 	choices: [
 		{
 			value: 'visual',
-			label: 'Visual Editor',
+			label: 'Visual editor',
 		},
 		{
 			value: 'text',
-			label: 'Code Editor',
+			label: 'Code editor',
 		},
 	],
 } )( ( { mode, choices, setState } ) => (

--- a/packages/e2e-tests/specs/editor/plugins/container-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/container-blocks.test.js
@@ -44,7 +44,7 @@ describe( 'InnerBlocks Template Sync', () => {
 			paragraphToAdd,
 			blockSlug
 		);
-		// Press "Enter" inside the Code Editor to fire the `onChange` event for the new value.
+		// Press "Enter" inside the code editor to fire the `onChange` event for the new value.
 		await page.click( '.editor-post-text-editor' );
 		await pressKeyWithModifier( 'primary', 'A' );
 		await page.keyboard.press( 'ArrowRight' );

--- a/packages/edit-post/src/components/keyboard-shortcuts/index.js
+++ b/packages/edit-post/src/components/keyboard-shortcuts/index.js
@@ -37,7 +37,7 @@ function KeyboardShortcuts() {
 		registerShortcut( {
 			name: 'core/edit-post/toggle-mode',
 			category: 'global',
-			description: __( 'Switch between Visual editor and Code editor.' ),
+			description: __( 'Switch between visual editor and code editor.' ),
 			keyCombination: {
 				modifier: 'secondary',
 				character: 'm',

--- a/packages/edit-post/src/components/text-editor/index.js
+++ b/packages/edit-post/src/components/text-editor/index.js
@@ -24,7 +24,7 @@ function TextEditor( { onExit, isRichEditingEnabled } ) {
 						icon={ close }
 						shortcut={ displayShortcut.secondary( 'm' ) }
 					>
-						{ __( 'Exit Code Editor' ) }
+						{ __( 'Exit code editor' ) }
 					</Button>
 					<TextEditorGlobalKeyboardShortcuts />
 				</div>

--- a/packages/edit-post/src/components/text-editor/style.scss
+++ b/packages/edit-post/src/components/text-editor/style.scss
@@ -38,7 +38,7 @@
 	padding-top: $block-toolbar-height + $grid-unit-10;
 }
 
-// Exit Code Editor toolbar.
+// Exit code editor toolbar.
 .edit-post-text-editor__toolbar {
 	position: absolute;
 	top: $grid-unit-10;


### PR DESCRIPTION
## Description
This PR lowercases visual editor and code editor to follow the casing laid out for the block editor and classic editor as seen in #14203 / #14205 / #20293.

## How has this been tested?
Just confirmed I didn't break anything.

## Types of changes
Text changes to follow pre-existing convention.