### PR TITLE
Add storybook story for the ToolbarButton component

### DIFF
--- a/packages/components/src/toolbar-button/stories/index.js
+++ b/packages/components/src/toolbar-button/stories/index.js
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ */
+import { text } from '@storybook/addon-knobs';
+
+/**
+ * Internal dependencies
+ */
+import { Toolbar } from '../../';
+import ToolbarButton from '../';
+
+export default { title: 'Components/ToolbarButton', component: ToolbarButton };
+
+export const _default = () => {
+	const label = text( 'Label', 'This is an example label.' );
+	const icon = text( 'Icon', 'wordpress' );
+
+	return (
+		<Toolbar __experimentalAccessibilityLabel="Example Toolbar">
+			<ToolbarButton icon={ icon } label={ label } />
+		</Toolbar>
+	);
+};


### PR DESCRIPTION
## Description
Adds a storybook story for the ToolbarButton component as part of #17973

## How has this been tested?
* run `npm run storybook:dev`
* See the new ToolbarButton story under components

## Screenshots
![Components___ToolbarButton_-_Default_⋅_Storybook](https://user-images.githubusercontent.com/6653970/76912838-a834d900-688b-11ea-9bce-87cf9053b7c8.png)

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
