### PR TITLE
Remove iframe from content elements

### DIFF
--- a/packages/blocks/src/api/raw-handling/phrasing-content.js
+++ b/packages/blocks/src/api/raw-handling/phrasing-content.js
@@ -74,17 +74,6 @@ const embeddedContentSchema = {
 	},
 	canvas: { attributes: [ 'width', 'height' ] },
 	embed: { attributes: [ 'src', 'type', 'width', 'height' ] },
-	iframe: {
-		attributes: [
-			'src',
-			'srcdoc',
-			'name',
-			'sandbox',
-			'seamless',
-			'width',
-			'height',
-		],
-	},
 	img: {
 		attributes: [
 			'alt',


### PR DESCRIPTION
## Description
Removes `iframe` from the list of elements.

## Types of changes
Non-breaking task
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
