### PR TITLE
Try: Nicer block footprint for social links.

### DIFF
--- a/packages/block-library/src/social-links/editor.scss
+++ b/packages/block-library/src/social-links/editor.scss
@@ -15,40 +15,9 @@
 // @todo: eventually we may add a feature that lets a parent container absorb the block UI of a child block.
 // When that happens, leverage that instead of the following overrides.
 [data-type="core/social-links"] {
-	// 1. Reset margins on immediate innerblocks container.
-	.wp-block-social-links > .block-editor-inner-blocks > .block-editor-block-list__layout {
-		margin-left: 0;
-		margin-right: 0;
-	}
-
-	// 2. Remove paddings on subsequent immediate children.
 	.wp-block-social-links > .block-editor-inner-blocks > .block-editor-block-list__layout > .wp-block {
-		width: auto;
-		padding-left: 0;
-		padding-right: 0;
-		margin-left: 0;
-		margin-right: 0;
 		margin-top: 0;
 		margin-bottom: 0;
-	}
-
-	// 3. Minimize the block outlines.
-	.wp-block-social-links > .block-editor-inner-blocks > .block-editor-block-list__layout > .wp-block::before {
-		border-right: none;
-		border-top: none;
-		border-bottom: none;
-	}
-
-	// 4. Remove the dashed outlines for child blocks.
-	&.is-selected .wp-block-social-links .block-editor-block-list__block::before,
-	&.has-child-selected .wp-block-social-links .block-editor-block-list__block::before {
-		border-color: transparent !important; // !important used to keep the selector from growing any more complex.
-	}
-
-	// Hide the mover.
-	// Hide the sibling inserter.
-	.wp-block-social-links .block-editor-block-list__insertion-point { // Needs specificity.
-		display: none;
 	}
 }
 
@@ -113,4 +82,10 @@
 
 	// Windows High Contrast mode will show this outline, but not the box-shadow.
 	outline: 2px solid transparent;
+}
+
+// To ensure a better selection footprint when editing, attach the margin to the block container.
+// @todo: This can very probably be removed entirely when this block receives a lighter DOM.
+.block-editor-block-list__layout .block-editor-block-list__block[data-type="core/social-link"]:not([contenteditable]):focus::after {
+	right: 8px;
 }

--- a/packages/block-library/src/social-links/editor.scss
+++ b/packages/block-library/src/social-links/editor.scss
@@ -86,6 +86,7 @@
 
 // To ensure a better selection footprint when editing, attach the margin to the block container.
 // @todo: This can very probably be removed entirely when this block receives a lighter DOM.
+.is-navigate-mode .block-editor-block-list__layout .block-editor-block-list__block[data-type="core/social-link"].is-selected::after,
 .block-editor-block-list__layout .block-editor-block-list__block[data-type="core/social-link"]:not([contenteditable]):focus::after {
 	right: 8px;
 }


### PR DESCRIPTION
Let the images speak. Before:

<img width="694" alt="Screenshot 2020-03-18 at 10 04 29" src="https://user-images.githubusercontent.com/1204802/76945205-7f9bf600-6902-11ea-98e4-bb2dd2ef17b2.png">

After:

<img width="692" alt="Screenshot 2020-03-18 at 10 22 38" src="https://user-images.githubusercontent.com/1204802/76945221-81fe5000-6902-11ea-835a-192956588148.png">
