### PR TITLE
Remove experimentalUIParts API

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -61,7 +61,6 @@ function BlockListBlock( {
 	enableAnimation,
 	isNavigationMode,
 	isMultiSelecting,
-	hasSelectedUI = true,
 } ) {
 	// In addition to withSelect, we should favor using useSelect in this
 	// component going forward to avoid leaking new props to the public API
@@ -109,7 +108,6 @@ function BlockListBlock( {
 		customClassName,
 		'wp-block block-editor-block-list__block',
 		{
-			'has-selected-ui': hasSelectedUI,
 			'has-warning': ! isValid || !! hasError || isUnregisteredBlock,
 			'is-selected': isSelected,
 			'is-multi-selected': isMultiSelected,

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -29,7 +29,6 @@ function BlockList(
 		rootClientId,
 		isDraggable,
 		renderAppender,
-		__experimentalUIParts = {},
 		__experimentalTagName = 'div',
 		__experimentalAppenderTagName,
 		__experimentalPassedProps = {},
@@ -73,9 +72,6 @@ function BlockList(
 		element: ref,
 		rootClientId,
 	} );
-	const __experimentalContainerProps = rootClientId
-		? {}
-		: { hasPopover: __experimentalUIParts.hasPopover };
 
 	return (
 		<Container
@@ -86,7 +82,6 @@ function BlockList(
 				className,
 				__experimentalPassedProps.className
 			) }
-			{ ...__experimentalContainerProps }
 		>
 			{ blockClientIds.map( ( clientId, index ) => {
 				const isBlockInSelection = hasMultiSelection
@@ -108,9 +103,6 @@ function BlockList(
 							// otherwise there might be a small delay to trigger the animation.
 							index={ index }
 							enableAnimation={ enableAnimation }
-							hasSelectedUI={
-								__experimentalUIParts.hasSelectedUI
-							}
 							className={
 								clientId === targetClientId
 									? 'is-drop-target'

--- a/packages/block-editor/src/components/block-list/root-container.js
+++ b/packages/block-editor/src/components/block-list/root-container.js
@@ -46,7 +46,7 @@ function onDragStart( event ) {
 	}
 }
 
-function RootContainer( { children, className, hasPopover = true }, ref ) {
+function RootContainer( { children, className }, ref ) {
 	const {
 		selectedBlockClientId,
 		hasMultiSelection,
@@ -83,7 +83,7 @@ function RootContainer( { children, className, hasPopover = true }, ref ) {
 			containerRef={ ref }
 		>
 			<BlockNodes.Provider value={ useState( {} ) }>
-				{ hasPopover ? <BlockPopover /> : null }
+				<BlockPopover />
 				<div
 					ref={ ref }
 					className={ className }

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -25,7 +25,6 @@ export default function BlockToolbar( { hideDragHandle } ) {
 		isValid,
 		mode,
 		moverDirection,
-		hasMovers = true,
 	} = useSelect( ( select ) => {
 		const {
 			getBlockMode,
@@ -40,7 +39,7 @@ export default function BlockToolbar( { hideDragHandle } ) {
 			selectedBlockClientIds[ 0 ]
 		);
 
-		const { __experimentalMoverDirection, __experimentalUIParts = {} } =
+		const { __experimentalMoverDirection } =
 			getBlockListSettings( blockRootClientId ) || {};
 
 		return {
@@ -56,7 +55,6 @@ export default function BlockToolbar( { hideDragHandle } ) {
 					? getBlockMode( selectedBlockClientIds[ 0 ] )
 					: null,
 			moverDirection: __experimentalMoverDirection,
-			hasMovers: __experimentalUIParts.hasMovers,
 		};
 	}, [] );
 
@@ -70,8 +68,7 @@ export default function BlockToolbar( { hideDragHandle } ) {
 	const displayHeaderToolbar =
 		useViewportMatch( 'medium', '<' ) || hasFixedToolbar;
 
-	const shouldShowMovers =
-		displayHeaderToolbar || ( showMovers && hasMovers );
+	const shouldShowMovers = displayHeaderToolbar || showMovers;
 
 	if ( blockClientIds.length === 0 ) {
 		return null;

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -125,7 +125,6 @@ class InnerBlocks extends Component {
 			parentLock,
 			__experimentalCaptureToolbars,
 			__experimentalMoverDirection,
-			__experimentalUIParts,
 		} = this.props;
 
 		const newSettings = {
@@ -135,7 +134,6 @@ class InnerBlocks extends Component {
 			__experimentalCaptureToolbars:
 				__experimentalCaptureToolbars || false,
 			__experimentalMoverDirection,
-			__experimentalUIParts,
 		};
 
 		if ( ! isShallowEqual( blockListSettings, newSettings ) ) {

--- a/packages/block-library/src/buttons/edit.js
+++ b/packages/block-library/src/buttons/edit.js
@@ -13,9 +13,6 @@ import { name as buttonBlockName } from '../button/';
 
 const ALLOWED_BLOCKS = [ buttonBlockName ];
 const BUTTONS_TEMPLATE = [ [ 'core/button' ] ];
-const UI_PARTS = {
-	hasSelectedUI: false,
-};
 
 // Inside buttons block alignment options are not supported.
 const alignmentHooksSetting = {
@@ -29,7 +26,6 @@ function ButtonsEdit( { className } ) {
 				<InnerBlocks
 					allowedBlocks={ ALLOWED_BLOCKS }
 					template={ BUTTONS_TEMPLATE }
-					__experimentalUIParts={ UI_PARTS }
 					__experimentalMoverDirection="horizontal"
 				/>
 			</AlignmentHookSettingsProvider>


### PR DESCRIPTION
This PR removes the experimentalUIParts API as this became useless with the G2 refactoring.

cc @ockham 