### PR TITLE
Rnmobile/fix spacer max

### DIFF
--- a/packages/block-library/src/spacer/edit.js
+++ b/packages/block-library/src/spacer/edit.js
@@ -68,7 +68,7 @@ const SpacerEdit = ( {
 					<RangeControl
 						label={ __( 'Height in pixels' ) }
 						min={ MIN_SPACER_HEIGHT }
-						max={ MAX_SPACER_HEIGHT }
+						max={ Math.max( MAX_SPACER_HEIGHT, height ) }
 						separatorType={ 'none' }
 						value={ height }
 						onChange={ updateHeight }


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
Fix scenarios where the spacer height is larger than the current max and we want to allow users to edit the value inside the range.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

This can be tested on GB mobile here: https://github.com/wordpress-mobile/gutenberg-mobile/pull/2030

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
