### PR TITLE
CLASSIC EDITOR < added fix to border around the content

### DIFF
--- a/packages/block-library/src/classic/editor.scss
+++ b/packages/block-library/src/classic/editor.scss
@@ -249,20 +249,31 @@ div[data-type="core/freeform"] {
 		outline: $border-width solid transparent;
 	}
 
-	&.is-selected::before {
-		border-color: $dark-gray-primary;
+	&.is-selected{
+		&::before {
+			border-color: $dark-gray-primary;
+		}
+
+		// Ensure aligned blocks at end are within the selected block.
+		.block-library-rich-text__tinymce{
+
+			&.mce-edit-focus{
+				padding: 10px;
+				border: $border-width solid $light-gray-500;
+				border-top: none;
+			}
+
+			&::after {
+				content: "";
+				display: table;
+				clear: both;
+			}
+		}
 	}
 
 	.block-editor-block-contextual-toolbar + div {
 		margin-top: 0;
 		padding-top: 0;
-	}
-
-	// Ensure aligned blocks at end are within the selected block.
-	&.is-selected .block-library-rich-text__tinymce::after {
-		content: "";
-		display: table;
-		clear: both;
 	}
 }
 
@@ -313,6 +324,7 @@ div[data-type="core/freeform"] {
 	div[data-type="core/freeform"].is-typing & {
 		display: block;
 		border-color: $dark-gray-primary;
+		margin-bottom: 0;
 	}
 
 	// Remove the box shadow to mimic other Gutenberg UI.

--- a/packages/block-library/src/classic/editor.scss
+++ b/packages/block-library/src/classic/editor.scss
@@ -249,15 +249,15 @@ div[data-type="core/freeform"] {
 		outline: $border-width solid transparent;
 	}
 
-	&.is-selected{
+	&.is-selected {
 		&::before {
 			border-color: $dark-gray-primary;
 		}
 
 		// Ensure aligned blocks at end are within the selected block.
-		.block-library-rich-text__tinymce{
+		.block-library-rich-text__tinymce {
 
-			&.mce-edit-focus{
+			&.mce-edit-focus {
 				padding: 10px;
 				border: $border-width solid $light-gray-500;
 				border-top: none;


### PR DESCRIPTION
## Description
More people use the "Classic Block Editor". In my option I think the border is very important.
I think its better way to give users a better user experience. 

## Screenshots <!-- if applicable -->

 #### Without FIX
![Bildschirmfoto 2020-03-18 um 14 52 58](https://user-images.githubusercontent.com/15845265/76977344-78daa680-6935-11ea-9a4d-2b9622e31a8a.png)

 #### With FIX
![Bildschirmfoto 2020-03-18 um 16 03 30](https://user-images.githubusercontent.com/15845265/76977360-7f691e00-6935-11ea-9cae-70f64807d682.png)


## Types of changes
- Clean Up and better readable code in SASS (SCSS) 
- Added Border around the content 
## Checklist:
- [x] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
