### PR TITLE
Remove aria-expanded from close button in Publish panel

### DIFF
--- a/packages/editor/src/components/post-publish-panel/index.js
+++ b/packages/editor/src/components/post-publish-panel/index.js
@@ -95,7 +95,6 @@ export class PostPublishPanel extends Component {
 						</div>
 					) }
 					<Button
-						aria-expanded={ true }
 						onClick={ onClose }
 						icon={ close }
 						label={ __( 'Close panel' ) }

--- a/packages/editor/src/components/post-publish-panel/style.scss
+++ b/packages/editor/src/components/post-publish-panel/style.scss
@@ -14,9 +14,9 @@
 
 .editor-post-publish-panel__header {
 	background: $white;
-	padding-left: 8px;
-	padding-right: 8px;
-	height: $header-height;
+	padding-left: $grid-unit-10;
+	padding-right: $grid-unit-10;
+	height: $header-height + $border-width;
 	border-bottom: $border-width solid $light-gray-500;
 	display: flex;
 	align-items: center;
@@ -24,7 +24,7 @@
 
 	.components-button.has-icon {
 		position: absolute;
-		right: 8px;
+		right: $grid-unit-10;
 	}
 }
 

--- a/packages/editor/src/components/post-publish-panel/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/post-publish-panel/test/__snapshots__/index.js.snap
@@ -13,7 +13,6 @@ exports[`PostPublishPanel should render the post-publish panel if the post is pu
       Published
     </div>
     <ForwardRef(Button)
-      aria-expanded={true}
       icon={
         <SVG
           viewBox="0 0 24 24"
@@ -57,7 +56,6 @@ exports[`PostPublishPanel should render the post-publish panel if the post is sc
       Scheduled
     </div>
     <ForwardRef(Button)
-      aria-expanded={true}
       icon={
         <SVG
           viewBox="0 0 24 24"
@@ -104,7 +102,6 @@ exports[`PostPublishPanel should render the pre-publish panel if post status is 
       />
     </div>
     <ForwardRef(Button)
-      aria-expanded={true}
       icon={
         <SVG
           viewBox="0 0 24 24"
@@ -149,7 +146,6 @@ exports[`PostPublishPanel should render the pre-publish panel if the post is not
       />
     </div>
     <ForwardRef(Button)
-      aria-expanded={true}
       icon={
         <SVG
           viewBox="0 0 24 24"
@@ -194,7 +190,6 @@ exports[`PostPublishPanel should render the spinner if the post is being saved 1
       />
     </div>
     <ForwardRef(Button)
-      aria-expanded={true}
       icon={
         <SVG
           viewBox="0 0 24 24"


### PR DESCRIPTION
Fixes #20278

This tiny PR removes the `aria-expanded` attribute from the Close (X) button in the Publish panel. The attribute is not necessary in this button (the close button hasn't opened a menu) and it was making the button to be displayed in the wrong color.

## How has this been tested?
Locally.

## Screenshots

**Before:**
<img width="279" alt="Screen Shot 2020-03-18 at 10 16 22" src="https://user-images.githubusercontent.com/3276087/76982521-a1e14400-6901-11ea-8306-56c914f72bb0.png">



**After:**
<img width="280" alt="Screen Shot 2020-03-17 at 18 53 47" src="https://user-images.githubusercontent.com/3276087/76982300-4ca53280-6901-11ea-803f-cc61355ecd70.png">


## Types of changes
HTML and visual.
