### PR TITLE
Update social links block to output a custom class on each individual link

### DIFF
--- a/packages/block-library/src/social-link/index.php
+++ b/packages/block-library/src/social-link/index.php
@@ -19,6 +19,7 @@ function render_block_core_social_link( $attributes ) {
 		$attributes['label'] :
 		/* translators: %s: Social Link service name */
 		sprintf( __( 'Link to %s' ), block_core_social_link_get_name( $service ) );
+	$class_name = isset( $attributes['className'] ) ? ' ' . $attributes['className'] : false;
 
 	// Don't render a link if there is no URL set.
 	if ( ! $url ) {
@@ -26,7 +27,7 @@ function render_block_core_social_link( $attributes ) {
 	}
 
 	$icon = block_core_social_link_get_icon( $service );
-	return '<li class="wp-social-link wp-social-link-' . esc_attr( $service ) . '"><a href="' . esc_url( $url ) . '" aria-label="' . esc_attr( $label ) . '"> ' . $icon . '</a></li>';
+	return '<li class="wp-social-link wp-social-link-' . esc_attr( $service ) . esc_attr( $class_name ) . '"><a href="' . esc_url( $url ) . '" aria-label="' . esc_attr( $label ) . '"> ' . $icon . '</a></li>';
 }
 
 /**


### PR DESCRIPTION
## Description
Fixed #19335 by updating `render_block_core_social_link()` to append a custom class to each `<li>` if one is present.

## How has this been tested?
* Create a post with a social links block.
* Click to select an individual link (not the whole block).
* Add a custom css class to "Additional CSS class(es)" under the "Advanced" panel.
* Publish the post and see that the `<li>` has your custom class appended.
* Also, add a custom class to the entire block and see that it still works as well.

## Screenshots
![Edit_Post_‹_gutenberg_—_WordPress](https://user-images.githubusercontent.com/6653970/76993959-1331ee80-6924-11ea-8696-264cd8a00aa1.png)
Add a custom class 'CUSTOM' to the individual link
 
![Edit_Post_‹_gutenberg_—_WordPress 2](https://user-images.githubusercontent.com/6653970/76993991-1b8a2980-6924-11ea-8169-bf33b82930b3.png)
Add a custom class 'Banana' to the entire block

![DevTools_-_localhost_8888__p_7_preview_id_7_preview_nonce_65857c213d_preview_true_and_gutenberg](https://user-images.githubusercontent.com/6653970/76994000-1dec8380-6924-11ea-9069-c5ea2a87b450.png)
See that they both render correctly on the public side

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
