### PR TITLE
Fix: Snackbar container block portion of UI while present.

### DIFF
--- a/packages/editor/src/components/editor-notices/style.scss
+++ b/packages/editor/src/components/editor-notices/style.scss
@@ -35,4 +35,8 @@
 
 .components-editor-notices__snackbar {
 	width: 100%;
+	@include break-medium() {
+		width: fit-content;
+		width: -moz-fit-content;
+	}
 }


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/20654

## How has this been tested?
Followed steps referred in https://github.com/WordPress/gutenberg/issues/20654 and verified the issue was not happening anymore.