### PR TITLE
Fix link control search results spacing.

### DIFF
--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -41,6 +41,10 @@ $block-editor-link-control-number-of-actions: 1;
 			@include input-style__focus();
 		}
 	}
+
+	.components-base-control__field {
+		margin-bottom: 0;
+	}
 }
 
 .block-editor-link-control__search-error {

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -103,7 +103,7 @@ $block-editor-link-control-number-of-actions: 1;
 
 .block-editor-link-control__search-results {
 	margin: 0;
-	padding: $grid-unit-20/2 $grid-unit-20 $grid-unit-20;
+	padding: $grid-unit-20/2 $grid-unit-20 $grid-unit-20/2;
 	max-height: 200px;
 	overflow-y: auto; // allow results list to scroll
 


### PR DESCRIPTION
## Description
Fixes #20999

Issue was added in https://github.com/WordPress/gutenberg/commit/ef73ed07bd59bdcbbe77cc1c537299d8e39167b1#diff-e902225dcc254c593dfa1a8344d640e6L106

**Before** (Menu)
<img width="375" alt="before2" src="https://user-images.githubusercontent.com/695201/77008190-f9b19680-6965-11ea-8f73-fc5494e2dd84.png">

**After** (Menu)
<img width="374" alt="after" src="https://user-images.githubusercontent.com/695201/77009990-37fc8500-6969-11ea-9526-ee4cd2443212.png">

