### PR TITLE
Classic editor block: Remove old back-compat code

### DIFF
--- a/packages/block-library/src/classic/edit.js
+++ b/packages/block-library/src/classic/edit.js
@@ -170,7 +170,6 @@ export default class ClassicEdit extends Component {
 			<div
 				key="toolbar"
 				id={ `toolbar-${ clientId }` }
-				ref={ ( ref ) => ( this.ref = ref ) }
 				className="block-library-classic__toolbar"
 				onClick={ this.focus }
 				data-placeholder={ __( 'Classic' ) }

--- a/packages/block-library/src/classic/edit.js
+++ b/packages/block-library/src/classic/edit.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
-import { __, _x } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { BACKSPACE, DELETE, F10 } from '@wordpress/keycodes';
 
 const { wp } = window;
@@ -83,7 +83,6 @@ export default class ClassicEdit extends Component {
 			attributes: { content },
 			setAttributes,
 		} = this.props;
-		const { ref } = this;
 		let bookmark;
 
 		this.editor = editor;
@@ -132,36 +131,6 @@ export default class ClassicEdit extends Component {
 				event.stopPropagation();
 			}
 		} );
-
-		// TODO: the following is for back-compat with WP 4.9, not needed in WP 5.0. Remove it after the release.
-		editor.addButton( 'kitchensink', {
-			tooltip: _x( 'More', 'button to expand options' ),
-			icon: 'dashicon dashicons-editor-kitchensink',
-			onClick() {
-				const button = this;
-				const active = ! button.active();
-
-				button.active( active );
-				editor.dom.toggleClass( ref, 'has-advanced-toolbar', active );
-			},
-		} );
-
-		// Show the second, third, etc. toolbars when the `kitchensink` button is removed by a plugin.
-		editor.on( 'init', function() {
-			if (
-				editor.settings.toolbar1 &&
-				editor.settings.toolbar1.indexOf( 'kitchensink' ) === -1
-			) {
-				editor.dom.addClass( ref, 'has-advanced-toolbar' );
-			}
-		} );
-
-		editor.addButton( 'wp_add_media', {
-			tooltip: __( 'Insert Media' ),
-			icon: 'dashicon dashicons-admin-media',
-			cmd: 'WP_Medialib',
-		} );
-		// End TODO.
 
 		editor.on( 'init', () => {
 			const rootNode = this.editor.getBody();


### PR DESCRIPTION
## Description
This PR removes old back-compat code for WP 4.9 from the classic block.
Added in #10964

@azaozz Can you confirm, we can remove it?