### PR TITLE
Site Editor: add more menu and fullscreen toggle

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -102,6 +102,7 @@ $z-layers: (
 	".components-popover.table-of-contents__popover": 99998,
 	".components-popover.block-editor-block-navigation__popover": 99998,
 	".components-popover.edit-post-more-menu__content": 99998,
+	".components-popover.edit-site-more-menu__content": 99998,
 	".components-popover.block-editor-rich-text__inline-format-toolbar": 99998,
 
 	".components-autocomplete__results": 1000000,

--- a/packages/edit-site/src/components/header/feature-toggle/index.js
+++ b/packages/edit-site/src/components/header/feature-toggle/index.js
@@ -1,0 +1,55 @@
+/**
+ * External dependencies
+ */
+import { flow } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { withSelect, withDispatch } from '@wordpress/data';
+import { compose } from '@wordpress/compose';
+import { MenuItem, withSpokenMessages } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { check } from '@wordpress/icons';
+
+function FeatureToggle( {
+	onToggle,
+	isActive,
+	label,
+	info,
+	messageActivated,
+	messageDeactivated,
+	speak,
+} ) {
+	const speakMessage = () => {
+		if ( isActive ) {
+			speak( messageDeactivated || __( 'Feature deactivated' ) );
+		} else {
+			speak( messageActivated || __( 'Feature activated' ) );
+		}
+	};
+
+	return (
+		<MenuItem
+			icon={ isActive && check }
+			isSelected={ isActive }
+			onClick={ flow( onToggle, speakMessage ) }
+			role="menuitemcheckbox"
+			info={ info }
+		>
+			{ label }
+		</MenuItem>
+	);
+}
+
+export default compose( [
+	withSelect( ( select, { feature } ) => ( {
+		isActive: select( 'core/edit-site' ).isFeatureActive( feature ),
+	} ) ),
+	withDispatch( ( dispatch, ownProps ) => ( {
+		onToggle() {
+			dispatch( 'core/edit-site' ).toggleFeature( ownProps.feature );
+		},
+	} ) ),
+	withSpokenMessages,
+] )( FeatureToggle );

--- a/packages/edit-site/src/components/header/feature-toggle/index.js
+++ b/packages/edit-site/src/components/header/feature-toggle/index.js
@@ -6,15 +6,13 @@ import { flow } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { withSelect, withDispatch } from '@wordpress/data';
-import { compose } from '@wordpress/compose';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { MenuItem, withSpokenMessages } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { check } from '@wordpress/icons';
 
 function FeatureToggle( {
-	onToggle,
-	isActive,
+	feature,
 	label,
 	info,
 	messageActivated,
@@ -29,11 +27,17 @@ function FeatureToggle( {
 		}
 	};
 
+	const isActive = useSelect( ( select ) => {
+		return select( 'core/edit-site' ).isFeatureActive( feature );
+	}, [] );
+
+	const { toggleFeature } = useDispatch( 'core/edit-site' );
+
 	return (
 		<MenuItem
 			icon={ isActive && check }
 			isSelected={ isActive }
-			onClick={ flow( onToggle, speakMessage ) }
+			onClick={ flow( toggleFeature.bind( null, feature ), speakMessage ) }
 			role="menuitemcheckbox"
 			info={ info }
 		>
@@ -42,14 +46,4 @@ function FeatureToggle( {
 	);
 }
 
-export default compose( [
-	withSelect( ( select, { feature } ) => ( {
-		isActive: select( 'core/edit-site' ).isFeatureActive( feature ),
-	} ) ),
-	withDispatch( ( dispatch, ownProps ) => ( {
-		onToggle() {
-			dispatch( 'core/edit-site' ).toggleFeature( ownProps.feature );
-		},
-	} ) ),
-	withSpokenMessages,
-] )( FeatureToggle );
+export default withSpokenMessages( FeatureToggle );

--- a/packages/edit-site/src/components/header/feature-toggle/index.js
+++ b/packages/edit-site/src/components/header/feature-toggle/index.js
@@ -37,7 +37,10 @@ function FeatureToggle( {
 		<MenuItem
 			icon={ isActive && check }
 			isSelected={ isActive }
-			onClick={ flow( toggleFeature.bind( null, feature ), speakMessage ) }
+			onClick={ flow(
+				toggleFeature.bind( null, feature ),
+				speakMessage
+			) }
 			role="menuitemcheckbox"
 			info={ info }
 		>

--- a/packages/edit-site/src/components/header/index.js
+++ b/packages/edit-site/src/components/header/index.js
@@ -8,6 +8,7 @@ import { BlockNavigationDropdown, ToolSelector } from '@wordpress/block-editor';
  * Internal dependencies
  */
 import { useEditorContext } from '../editor';
+import MoreMenu from './more-menu';
 import TemplateSwitcher from '../template-switcher';
 import SaveButton from '../save-button';
 
@@ -59,6 +60,7 @@ export default function Header() {
 			</div>
 			<div className="edit-site-header__actions">
 				<SaveButton />
+				<MoreMenu />
 			</div>
 		</div>
 	);

--- a/packages/edit-site/src/components/header/more-menu/index.js
+++ b/packages/edit-site/src/components/header/more-menu/index.js
@@ -1,0 +1,43 @@
+/**
+ * WordPress dependencies
+ */
+import { __, _x } from '@wordpress/i18n';
+import { DropdownMenu, MenuGroup } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import FeatureToggle from '../feature-toggle';
+import { moreVertical } from '@wordpress/icons';
+
+const POPOVER_PROPS = {
+	className: 'edit-site-more-menu__content',
+	position: 'bottom left',
+};
+const TOGGLE_PROPS = {
+	tooltipPosition: 'bottom',
+};
+
+const MoreMenu = () => (
+	<DropdownMenu
+		className="edit-site-more-menu"
+		icon={ moreVertical }
+		label={ __( 'More tools & options' ) }
+		popoverProps={ POPOVER_PROPS }
+		toggleProps={ TOGGLE_PROPS }
+	>
+		{ () => (
+			<MenuGroup label={ _x( 'View', 'noun' ) }>
+				<FeatureToggle
+					feature="fullscreenMode"
+					label={ __( 'Fullscreen mode' ) }
+					info={ __( 'Work without distraction' ) }
+					messageActivated={ __( 'Fullscreen mode activated' ) }
+					messageDeactivated={ __( 'Fullscreen mode deactivated' ) }
+				/>
+			</MenuGroup>
+		) }
+	</DropdownMenu>
+);
+
+export default MoreMenu;

--- a/packages/edit-site/src/components/header/more-menu/style.scss
+++ b/packages/edit-site/src/components/header/more-menu/style.scss
@@ -19,12 +19,6 @@
 .edit-site-more-menu__content .components-popover__content {
 	min-width: 260px;
 
-	// Let the menu scale to fit items.
-	@include break-mobile() {
-		width: auto;
-		max-width: $break-mobile;
-	}
-
 	.components-dropdown-menu__menu {
 		padding: 0;
 	}

--- a/packages/edit-site/src/components/header/more-menu/style.scss
+++ b/packages/edit-site/src/components/header/more-menu/style.scss
@@ -8,7 +8,7 @@
 	}
 
 	@include break-small() {
-		margin-left: 0;
+		margin-left: 4px;
 
 		.components-button {
 			padding: 0 4px;

--- a/packages/edit-site/src/components/header/more-menu/style.scss
+++ b/packages/edit-site/src/components/header/more-menu/style.scss
@@ -1,0 +1,35 @@
+.edit-site-more-menu {
+	margin-left: -4px;
+
+	// the padding and margin of the more menu is intentionally non-standard
+	.components-button {
+		width: auto;
+		padding: 0 2px;
+	}
+
+	@include break-small() {
+		margin-left: 0;
+
+		.components-button {
+			padding: 0 4px;
+		}
+	}
+}
+
+.edit-site-more-menu__content .components-popover__content {
+	min-width: 260px;
+
+	// Let the menu scale to fit items.
+	@include break-mobile() {
+		width: auto;
+		max-width: $break-mobile;
+	}
+
+	.components-dropdown-menu__menu {
+		padding: 0;
+	}
+}
+
+.components-popover.edit-site-more-menu__content {
+	z-index: z-index(".components-popover.edit-site-more-menu__content");
+}

--- a/packages/edit-site/src/components/header/style.scss
+++ b/packages/edit-site/src/components/header/style.scss
@@ -1,3 +1,5 @@
+@import "./more-menu/style.scss";
+
 .edit-site-header {
 	align-items: center;
 	display: flex;

--- a/packages/edit-site/src/components/header/style.scss
+++ b/packages/edit-site/src/components/header/style.scss
@@ -1,5 +1,3 @@
-@import "./more-menu/style.scss";
-
 .edit-site-header {
 	align-items: center;
 	display: flex;

--- a/packages/edit-site/src/style.scss
+++ b/packages/edit-site/src/style.scss
@@ -1,5 +1,6 @@
 @import "./components/block-editor/style.scss";
 @import "./components/header/style.scss";
+@import "./components/header/more-menu/style.scss";
 @import "./components/notices/style.scss";
 @import "./components/sidebar/style.scss";
 @import "./components/template-switcher/style.scss";


### PR DESCRIPTION
## Description

Adds more menu to the Site Editor's header which contains the Fullscreen mode toggle option.

Follow up of https://github.com/WordPress/gutenberg/pull/20691

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Navigate to site editor and verify that Fullscreen toggle works as expected. Reload the page and make sure that the preference is saved properly.

## Screenshots <!-- if applicable -->

<img width="292" alt="Screenshot 2020-03-19 at 01 21 27" src="https://user-images.githubusercontent.com/1182160/77019801-fa582600-6981-11ea-8832-bde4d9113ed1.png">


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
