### PR TITLE
Update cleanForSlug() to remove additional non-word characters

### DIFF
--- a/packages/editor/src/utils/test/url.js
+++ b/packages/editor/src/utils/test/url.js
@@ -5,7 +5,7 @@ import { cleanForSlug } from '../url';
 
 describe( 'cleanForSlug()', () => {
 	it( 'Should return string prepared for use as url slug', () => {
-		expect( cleanForSlug( ' /Déjà_vu. ' ) ).toBe( 'deja-vu' );
+		expect( cleanForSlug( '/Is th@t Déjà_vu? ' ) ).toBe( 'is-tht-deja_vu' );
 	} );
 
 	it( 'Should return an empty string for missing argument', () => {

--- a/packages/editor/src/utils/url.js
+++ b/packages/editor/src/utils/url.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { deburr, toLower, trim } from 'lodash';
+import { deburr, trim } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -28,11 +28,11 @@ export function getWPAdminURL( page, query ) {
  * This replicates some of what sanitize_title() does in WordPress core, but
  * is only designed to approximate what the slug will be.
  *
- * Converts whitespace, periods, forward slashes and underscores to hyphens.
  * Converts Latin-1 Supplement and Latin Extended-A letters to basic Latin
- * letters. Removes combining diacritical marks. Converts remaining string
- * to lowercase. It does not touch octets, HTML entities, or other encoded
- * characters.
+ * letters. Removes combining diacritical marks. Converts whitespace, periods,
+ * and forward slashes to hyphens. Removes any remaining non-word characters
+ * except hyphens. Converts remaining string to lowercase. It does not account
+ * for octets, HTML entities, or other encoded characters.
  *
  * @param {string} string Title or slug to be processed
  *
@@ -42,7 +42,11 @@ export function cleanForSlug( string ) {
 	if ( ! string ) {
 		return '';
 	}
-	return toLower(
-		deburr( trim( string.replace( /[\s\./_]+/g, '-' ), '-' ) )
+	return trim(
+		deburr( string )
+			.replace( /[\s\./]+/g, '-' )
+			.replace( /[^\w-]+/g, '' )
+			.toLowerCase(),
+		'-'
 	);
 }

--- a/packages/url/README.md
+++ b/packages/url/README.md
@@ -44,11 +44,11 @@ Performs some basic cleanup of a string for use as a post slug.
 This replicates some of what `sanitize_title()` does in WordPress core, but
 is only designed to approximate what the slug will be.
 
-Converts whitespace, periods, forward slashes and underscores to hyphens.
 Converts Latin-1 Supplement and Latin Extended-A letters to basic Latin
-letters. Removes combining diacritical marks. Converts remaining string
-to lowercase. It does not touch octets, HTML entities, or other encoded
-characters.
+letters. Removes combining diacritical marks. Converts whitespace, periods,
+and forward slashes to hyphens. Removes any remaining non-word characters
+except hyphens. Converts remaining string to lowercase. It does not account
+for octets, HTML entities, or other encoded characters.
 
 _Parameters_
 

--- a/packages/url/src/clean-for-slug.js
+++ b/packages/url/src/clean-for-slug.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { deburr, toLower, trim } from 'lodash';
+import { deburr, trim } from 'lodash';
 
 /**
  * Performs some basic cleanup of a string for use as a post slug.
@@ -9,11 +9,11 @@ import { deburr, toLower, trim } from 'lodash';
  * This replicates some of what `sanitize_title()` does in WordPress core, but
  * is only designed to approximate what the slug will be.
  *
- * Converts whitespace, periods, forward slashes and underscores to hyphens.
  * Converts Latin-1 Supplement and Latin Extended-A letters to basic Latin
- * letters. Removes combining diacritical marks. Converts remaining string
- * to lowercase. It does not touch octets, HTML entities, or other encoded
- * characters.
+ * letters. Removes combining diacritical marks. Converts whitespace, periods,
+ * and forward slashes to hyphens. Removes any remaining non-word characters
+ * except hyphens. Converts remaining string to lowercase. It does not account
+ * for octets, HTML entities, or other encoded characters.
  *
  * @param {string} string Title or slug to be processed.
  *
@@ -23,7 +23,11 @@ export function cleanForSlug( string ) {
 	if ( ! string ) {
 		return '';
 	}
-	return toLower(
-		deburr( trim( string.replace( /[\s\./_]+/g, '-' ), '-' ) )
+	return trim(
+		deburr( string )
+			.replace( /[\s\./]+/g, '-' )
+			.replace( /[^\w-]+/g, '' )
+			.toLowerCase(),
+		'-'
 	);
 }

--- a/packages/url/src/test/index.test.js
+++ b/packages/url/src/test/index.test.js
@@ -665,7 +665,7 @@ describe( 'filterURLForDisplay', () => {
 
 describe( 'cleanForSlug', () => {
 	it( 'should return string prepared for use as url slug', () => {
-		expect( cleanForSlug( ' /Déjà_vu. ' ) ).toBe( 'deja-vu' );
+		expect( cleanForSlug( '/Is th@t Déjà_vu? ' ) ).toBe( 'is-tht-deja_vu' );
 	} );
 
 	it( 'should return an empty string for missing argument', () => {


### PR DESCRIPTION
## Description
This updates the `cleanForSlug()` function to remove punctuation characters that would get removed by `sanitize_title()` upon publishing. 

This fixes the original issue from #12907 regarding punctuation in the slug. It doesn't resolve the related issues referenced there that were opened for characters in other languages (such as German and Danish) not being converted properly. If we merge this and close #12907, we may want to reopen one of those that was closed as a duplicate in order to keep a more accurate record. 

On investigating removing other punctuation, I realized `sanitize_title()` allows underscores in slugs, so I adjusted the function to allow those, but to remove any other non-hyphen punctuation. I also removed the `toLower` dependency and switched to `.toLowerCase()`

## How has this been tested?
Used identical strings with a variety of characters in the classic editor and in the current editor to test how they compared. Also updated the unit tests to reflect the new characters that should be removed. 

## Screenshots <!-- if applicable -->
Here is a sample string in the classic editor:
![Screen Shot 2020-03-18 at 1 14 05 PM](https://user-images.githubusercontent.com/4267290/77019808-1515a500-6958-11ea-8d80-7f4631c70068.png)

Vs the block editor after this change:
![Screen Shot 2020-03-18 at 1 15 26 PM](https://user-images.githubusercontent.com/4267290/77019822-21016700-6958-11ea-8ccf-c146e73fd8ec.png)


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
