### PR TITLE
Fix fullscreen mode device preview

### DIFF
--- a/packages/block-editor/src/style.scss
+++ b/packages/block-editor/src/style.scss
@@ -26,7 +26,6 @@
 @import "./components/colors-gradients/style.scss";
 @import "./components/contrast-checker/style.scss";
 @import "./components/default-block-appender/style.scss";
-@import "./components/fullscreen-mode/style.scss";
 @import "./components/link-control/style.scss";
 @import "./components/image-size-control/style.scss";
 @import "./components/inner-blocks/style.scss";
@@ -55,5 +54,6 @@
 
 @import "./components/block-toolbar/style.scss";
 @import "./components/editor-skeleton/style.scss";
+@import "./components/fullscreen-mode/style.scss";
 @import "./components/inserter/style.scss";
 


### PR DESCRIPTION
closes #20991

The fullscreen mode stylesheet was being manipulated by the simulated media queries behavior since it was wrongly placed in the block-editor stylesheet.

That's a regression from #20691 