### PR TITLE
Add basic nav block example for inserter and styles previews

### DIFF
--- a/packages/block-library/src/navigation/index.js
+++ b/packages/block-library/src/navigation/index.js
@@ -32,6 +32,35 @@ export const settings = {
 		lightBlockWrapper: true,
 	},
 
+	example: {
+		innerBlocks: [
+			{
+				name: 'core/navigation-link',
+				attributes: {
+					// translators: 'Home' as in a website's home page.
+					label: __( 'Home' ),
+					url: 'https://make.wordpress.org/',
+				},
+			},
+			{
+				name: 'core/navigation-link',
+				attributes: {
+					// translators: 'About' as in a website's about page.
+					label: __( 'About' ),
+					url: 'https://make.wordpress.org/',
+				},
+			},
+			{
+				name: 'core/navigation-link',
+				attributes: {
+					// translators: 'Contact' as in a website's contact page.
+					label: __( 'Contact' ),
+					url: 'https://make.wordpress.org/',
+				},
+			},
+		],
+	},
+
 	styles: [
 		{ name: 'light', label: __( 'Light' ), isDefault: true },
 		{ name: 'dark', label: __( 'Dark' ) },


### PR DESCRIPTION
## Description
Fixes #19872.

Adds an example for the nav block, which ensures the placeholder for the block doesn't show up in the styles preview.

## How has this been tested?
Manual testing:
1. Add a navigation block
2. Observe the sidebar styles panel shows an appropriate preview

## Screenshots <!-- if applicable -->
*Before*
<img width="707" alt="image" src="https://user-images.githubusercontent.com/191598/73079549-6c385580-3e92-11ea-8ed3-b3838faf4211.png">

*After*
<img width="646" alt="Screenshot 2020-03-19 at 5 42 31 pm" src="https://user-images.githubusercontent.com/677833/77053259-0a671880-6a09-11ea-9a7d-0bad8c893810.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
