### PR TITLE
Use the default post comments template for the post comments listing

### DIFF
--- a/packages/block-library/src/post-comments/index.php
+++ b/packages/block-library/src/post-comments/index.php
@@ -15,17 +15,18 @@ function render_block_core_post_comments() {
 	if ( ! $post ) {
 		return '';
 	}
-	$comments = get_comments(
-		array(
-			'post_id' => $post->ID,
-		)
-	);
-	$output   = '';
-	// TODO: Handle nested comments.
-	foreach ( $comments as $comment ) {
-		$output .= '<p>' . $comment->comment_author . '<br />' . $comment->comment_content . '</p>';
-	}
-	return $output;
+
+	ob_start();
+	// This generates a deprecate message.
+	// Ideally this deprecation is removed.
+	comments_template();
+	ob_get_clean();
+
+	ob_start();
+	wp_list_comments( array( 'page' => $post->ID ) );
+	$comments = ob_get_clean();
+
+	return $comments;
 }
 
 /**


### PR DESCRIPTION
Related #20791 

The Post comments block was using an adhoc template for the comments list. This PR updates the block to rely on the default one that ships with WordPress.

Apparently, this template is deprecated though but it's handy for the FSE block so we might consider removing the deprecation.

<img width="783" alt="Capture d’écran 2020-03-19 à 10 56 37 AM" src="https://user-images.githubusercontent.com/272444/77054662-547fd800-69d0-11ea-8816-3b5bd990becf.png">

**Notes**

While working on this, I actually wondered whether we'd need to build comments blocks suite (comment author block, comment content, comment avatar...) and use them in a comment query block (similar to what we're doing with the post blocks. 

My thinking is that it's too soon for these, and the use-cases are smaller than the post ones. cc @mtias 
