### PR TITLE
Update all block previews to use the auto-height behavior

### DIFF
--- a/packages/block-editor/src/components/block-styles/index.js
+++ b/packages/block-editor/src/components/block-styles/index.js
@@ -141,6 +141,7 @@ function BlockStyles( {
 					>
 						<div className="block-editor-block-styles__item-preview">
 							<BlockPreview
+								autoHeight
 								viewportWidth={ 500 }
 								blocks={
 									type.example

--- a/packages/block-editor/src/components/block-styles/style.scss
+++ b/packages/block-editor/src/components/block-styles/style.scss
@@ -12,7 +12,8 @@
 	overflow: hidden;
 	border-radius: $radius-round-rectangle;
 	padding: $grid-unit-05 * 1.5;
-	padding-top: calc(50% * 0.75 - #{ $grid-unit-05 } * 1.5);
+	display: flex;
+	flex-direction: column;
 
 	&:focus {
 		@include block-style__focus();
@@ -46,14 +47,9 @@
 	display: flex;
 	overflow: hidden;
 	background: $white;
-	padding-top: 75%;
-	margin-top: -75%;
-
-	.block-editor-block-preview__container {
-		padding-top: 0;
-		margin: 0;
-		margin-top: -75%;
-	}
+	align-items: center;
+	flex-grow: 1;
+	min-height: 80px;
 }
 
 .block-editor-block-styles__item-label {

--- a/packages/block-editor/src/components/block-switcher/index.js
+++ b/packages/block-editor/src/components/block-switcher/index.js
@@ -187,6 +187,7 @@ export class BlockSwitcher extends Component {
 									{ __( 'Preview' ) }
 								</div>
 								<BlockPreview
+									autoHeight
 									viewportWidth={ 500 }
 									blocks={
 										hoveredBlockType.example

--- a/packages/block-library/src/template-part/edit/placeholder.js
+++ b/packages/block-library/src/template-part/edit/placeholder.js
@@ -22,7 +22,7 @@ function TemplatePartPreview() {
 			<div className="wp-block-template-part__placeholder-preview-title">
 				{ __( 'Preview' ) }
 			</div>
-			<BlockPreview blocks={ blocks } />
+			<BlockPreview blocks={ blocks } autoHeight />
 		</div>
 	);
 }


### PR DESCRIPTION
This PR updates all BlockPreview usage to use the auto-height preview. 
You can see that the previews for the styles variations look a bit different between this PR and master.
The differences are:

 - On small blocks like buttons, the preview is not centered horizontally anymore. While this can be seen as a regression, I believe the auto-height behavior is less fragile and that the horizontal centering is not needed for most blocks. That same change can be seen as good for the separator block for instance, since now the difference between small and large separators is more obvious.

My goal ultimately is to make the autoHeight behavior the default behavior for BlockPreview and just remove the old behavior.