### PR TITLE
Docs: Include `npm run dev` guidance in "Getting Started"

### DIFF
--- a/docs/contributors/getting-started.md
+++ b/docs/contributors/getting-started.md
@@ -15,6 +15,8 @@ npm run build
 
 This will build Gutenberg, ready to be used as a WordPress plugin!
 
+`npm run build` is intended for one-off compilations of the project. If you're planning to do continued development in the source files, using `npm run dev` will most often be the better option. This will configure the build to avoid minifying the generated output, rebuild files automatically as they are changed in your working directory, and configure dependencies as running in a development environment so that useful warnings and errors are logged to your browser's developer console.
+
 If you don't have a local WordPress environment to load Gutenberg in, we can help get that up and running, too.
 
 ## Local Environment


### PR DESCRIPTION
Context ([link requires registration](https://make.wordpress.org/chat/)): https://wordpress.slack.com/archives/C02QB2JS7/p1584622721035100

Despite being the best option for builds when doing continued development in the project, the documentation currently includes no reference to `npm run dev`. This pull request seeks to add such a mention, immediately following the initial `npm run build` example. In relation to the `npm run build`, the given text intentionally provides some contextual contrast to differentiate `dev` from `build`.

**Testing Instructions:**

As this pull request affects only documentation, it is not expected to have any impact on the application runtime.