### PR TITLE
Docs: Prescribe latest NPM for development environment

### DIFF
--- a/docs/contributors/getting-started.md
+++ b/docs/contributors/getting-started.md
@@ -2,7 +2,7 @@
 
 Gutenberg is a Node.js-based project, built primarily in JavaScript.
 
-The first step is to install the [latest active LTS release](https://github.com/nodejs/Release#release-schedule) of Node. The easiest way (on macOS, Linux, or Windows 10 with the Linux Subsystem) is by installing and running [nvm]. Once `nvm` is installed, you can install the correct version of Node by running `nvm install` in the Gutenberg directory.
+The first step is to install the [latest active LTS release](https://github.com/nodejs/Release#release-schedule) of Node, along with the latest version of [NPM](https://www.npmjs.com/). The easiest way (on macOS, Linux, or Windows 10 with the Linux Subsystem) is by installing and running [nvm]. Once `nvm` is installed, you can install the correct version of Node by running `nvm install --latest-npm` in the Gutenberg directory.
 
 Once you have Node installed, run these scripts from within your local Gutenberg repository:
 


### PR DESCRIPTION
Related: #14201, #18923

This pull request seeks to prescribe that the latest version of NPM should be used in developing Gutenberg, not merely the version which ships with the latest active LTS release of Node.js

**Rationale:**

Historically, there have been a number of issues which surface in relation to inconsistent versions of NPM being used by contributors, typically attributable to various bugs (and subsequent fixes of bugs) in NPM itself.

Example: https://github.com/WordPress/gutenberg/issues/16157#issuecomment-599589261

At one time, we did have a mention in documentation that the latest NPM should be used ([source](https://github.com/WordPress/gutenberg/blob/9e6054b3314f5e2184da3a73aced53c90bc384da/docs/contributors/getting-started.md#getting-started)). This was removed as part of the changes in #17004. In #18923, we reintroduced the _Node LTS_ support commitment, but did not reintroduce the intention to use the latest NPM.

Finally, our build environment is configured to use the latest NPM release ([source](https://github.com/WordPress/gutenberg/blob/70eef3a076787043e8d960d70cae81724e69adcf/.travis.yml#L42)). As such, without encouraging developers to follow suit, there is a higher likelihood that the behavior of NPM in the build environment may be different than in the developer's own environment. This could result in unexpected build failures, for example.

Ideally we'd have some easier way to enforce that a developer is always running the latest NPM version. There are a few challenges to this, both technically (#14201) and in terms of developer experience (NPM releases tend to be more frequent than Node LTS maintenance releases).

**Testing Instructions:**

As this pull request affects only documentation, it is not expected to have any impact on the application runtime.