### PR TITLE
[Navigation block] Lift the limit of 10 pages max when creating navigation from top level pages

### DIFF
--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -293,6 +293,7 @@ export default compose( [
 			parent: 0,
 			order: 'asc',
 			orderby: 'id',
+			per_page: -1,
 		};
 
 		const pagesSelect = [


### PR DESCRIPTION
## Description

As reported in #19266:

> In the Navigation block, if there are more than 10 top level pages and you choose Create from all top level pages then you only get the first 10, ordered by post ID.

This PR lifts this restriction by setting `per_page: -1`. It's actually also a good opportunity to discuss - should we still have a fixed limit of e.g. 50 pages? I don't see how navigation consisting of 200 top level pages would be any useful.

## How has this been tested?
Tested locally

## Screenshots <!-- if applicable -->

![2020-03-19 15-19-22 2020-03-19 15_21_11](https://user-images.githubusercontent.com/205419/77077313-527c4000-69f5-11ea-94e9-c9ff19d1f05a.gif)

## Types of changes
Non-breaking changes

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
