### PR TITLE
Introduce a support key for support global style colors in blocks

### DIFF
--- a/packages/block-editor/src/components/block-list/block-wrapper.js
+++ b/packages/block-editor/src/components/block-list/block-wrapper.js
@@ -202,7 +202,7 @@ const BlockComponent = forwardRef(
 				className={ classnames(
 					className,
 					props.className,
-					wrapperProps?.className
+					wrapperProps && wrapperProps.className
 				) }
 				data-block={ clientId }
 				data-type={ name }
@@ -213,7 +213,7 @@ const BlockComponent = forwardRef(
 				onMouseLeave={ isSelected ? onMouseLeave : undefined }
 				tabIndex="0"
 				style={ {
-					...wrapperProps?.style,
+					...( wrapperProps ? wrapperProps.style : {} ),
 					...( props.style || {} ),
 					...animationStyle,
 				} }

--- a/packages/block-editor/src/components/block-list/block-wrapper.js
+++ b/packages/block-editor/src/components/block-list/block-wrapper.js
@@ -199,7 +199,11 @@ const BlockComponent = forwardRef(
 				{ ...props }
 				id={ blockElementId }
 				ref={ wrapper }
-				className={ classnames( className, props.className ) }
+				className={ classnames(
+					className,
+					props.className,
+					wrapperProps?.className
+				) }
 				data-block={ clientId }
 				data-type={ name }
 				data-title={ blockTitle }
@@ -209,6 +213,7 @@ const BlockComponent = forwardRef(
 				onMouseLeave={ isSelected ? onMouseLeave : undefined }
 				tabIndex="0"
 				style={ {
+					...wrapperProps?.style,
 					...( props.style || {} ),
 					...animationStyle,
 				} }

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -88,7 +88,7 @@ function BlockListBlock( {
 		isDraggingBlocks && ( isSelected || isPartOfMultiSelection );
 
 	// Determine whether the block has props to apply to the wrapper.
-	if ( ! lightBlockWrapper && blockType.getEditWrapperProps ) {
+	if ( blockType.getEditWrapperProps ) {
 		wrapperProps = {
 			...wrapperProps,
 			...blockType.getEditWrapperProps( attributes ),

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -185,7 +185,7 @@ export const withBlockControls = createHigherOrderComponent(
 				},
 			};
 			const newNamedColor =
-				colorObject && colorObject.slug ? colorObject.slug : undefined;
+				colorObject?.slug ? colorObject.slug : undefined;
 			props.setAttributes( {
 				style: newStyle,
 				[ attributeName ]: newNamedColor,

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -1,0 +1,247 @@
+/**
+ * External dependencies
+ */
+import { assign, has } from 'lodash';
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { addFilter } from '@wordpress/hooks';
+import { hasBlockSupport } from '@wordpress/blocks';
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { __ } from '@wordpress/i18n';
+import { useState, useEffect } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+// This should be moved out of the components folder
+import {
+	getColorClassName,
+	getColorObjectByColorValue,
+	getColorObjectByAttributeValues,
+} from '../components/colors';
+import PanelColorSettings from '../components/panel-color-settings';
+import ContrastChecker from '../components/contrast-checker';
+import InspectorControls from '../components/inspector-controls';
+import { getBlockDOMNode } from '../utils/dom';
+
+export const COLOR_SUPPORT_KEY = '__experimentalColor';
+
+/**
+ * Filters registered block settings, extending attributes to include
+ * `backgroundColor` and `textColor` attribute.
+ *
+ * @param  {Object} settings Original block settings
+ * @return {Object}          Filtered block settings
+ */
+function addAttributes( settings ) {
+	if ( ! hasBlockSupport( settings, COLOR_SUPPORT_KEY ) ) {
+		return settings;
+	}
+
+	// allow blocks to specify their own attribute definition with default values if needed.
+	if ( ! has( settings.attributes, [ 'backgroundColor', 'type' ] ) ) {
+		settings.attributes = assign( settings.attributes, {
+			backgroundColor: {
+				type: 'object',
+			},
+		} );
+	}
+	if ( ! has( settings.attributes, [ 'textColor', 'type' ] ) ) {
+		settings.attributes = assign( settings.attributes, {
+			textColor: {
+				type: 'object',
+			},
+		} );
+	}
+
+	return settings;
+}
+
+/**
+ * Override props assigned to save component to inject colors classnames.
+ *
+ * @param  {Object} props      Additional props applied to save element
+ * @param  {Object} blockType  Block type
+ * @param  {Object} attributes Block attributes
+ * @return {Object}            Filtered props applied to save element
+ */
+export function addSaveProps( props, blockType, attributes ) {
+	if ( ! hasBlockSupport( blockType, COLOR_SUPPORT_KEY ) ) {
+		return props;
+	}
+
+	// I'd have prefered to avoid the "style" attribute usage here
+	const { backgroundColor, textColor, style } = attributes;
+
+	const backgroundClass = getColorClassName(
+		'background-color',
+		backgroundColor
+	);
+	const textClass = getColorClassName( 'color', textColor );
+	props.className = classnames( props.className, backgroundClass, textClass, {
+		'has-text-color': textColor || style?.textColor,
+		'has-background': backgroundColor || style?.backgroundColor,
+	} );
+
+	return props;
+}
+
+/**
+ * Filters registered block settings to extand the block edit wrapper
+ * to apply the desired styles and classnames properly.
+ *
+ * @param  {Object} settings Original block settings
+ * @return {Object}          Filtered block settings
+ */
+export function addEditProps( settings ) {
+	if ( ! hasBlockSupport( settings, COLOR_SUPPORT_KEY ) ) {
+		return settings;
+	}
+	const existingGetEditWrapperProps = settings.getEditWrapperProps;
+	settings.getEditWrapperProps = ( attributes ) => {
+		let props = {};
+		if ( existingGetEditWrapperProps ) {
+			props = existingGetEditWrapperProps( attributes );
+		}
+		return addSaveProps( props, settings, attributes );
+	};
+
+	return settings;
+}
+
+const ColorPanel = ( { colorSettings, clientId } ) => {
+	const { getComputedStyle, Node } = window;
+
+	const [ detectedBackgroundColor, setDetectedBackgroundColor ] = useState();
+	const [ detectedColor, setDetectedColor ] = useState();
+
+	// TODO: check performance impact of running this on each render
+	useEffect( () => {
+		const colorsDetectionElement = getBlockDOMNode( clientId );
+		setDetectedColor( getComputedStyle( colorsDetectionElement ).color );
+
+		let backgroundColorNode = colorsDetectionElement;
+		let backgroundColor = getComputedStyle( backgroundColorNode )
+			.backgroundColor;
+		while (
+			backgroundColor === 'rgba(0, 0, 0, 0)' &&
+			backgroundColorNode.parentNode &&
+			backgroundColorNode.parentNode.nodeType === Node.ELEMENT_NODE
+		) {
+			backgroundColorNode = backgroundColorNode.parentNode;
+			backgroundColor = getComputedStyle( backgroundColorNode )
+				.backgroundColor;
+		}
+
+		setDetectedBackgroundColor( backgroundColor );
+	} );
+
+	return (
+		<InspectorControls>
+			<PanelColorSettings
+				title={ __( 'Color settings' ) }
+				initialOpen={ false }
+				colorSettings={ colorSettings }
+			>
+				<ContrastChecker
+					backgroundColor={ detectedBackgroundColor }
+					textColor={ detectedColor }
+				/>
+			</PanelColorSettings>
+		</InspectorControls>
+	);
+};
+
+/**
+ * Override the default edit UI to include new inspector controls for block
+ * color, if block defines support.
+ *
+ * @param  {Function} BlockEdit Original component
+ * @return {Function}           Wrapped component
+ */
+export const withBlockControls = createHigherOrderComponent(
+	( BlockEdit ) => ( props ) => {
+		const { name: blockName } = props;
+		const colors = useSelect( ( select ) => {
+			return select( 'core/block-editor' ).getSettings().colors;
+		}, [] );
+
+		if ( ! hasBlockSupport( blockName, COLOR_SUPPORT_KEY ) ) {
+			return <BlockEdit key="edit" { ...props } />;
+		}
+		const { style, textColor, backgroundColor } = props.attributes;
+
+		const onChangeColor = ( name ) => ( value ) => {
+			const colorObject = getColorObjectByColorValue( colors, value );
+			const newStyle = {
+				...style,
+				[ name ]: colorObject && colorObject.slug ? undefined : value,
+			};
+			const newNamedColor =
+				colorObject && colorObject.slug ? colorObject.slug : undefined;
+			props.setAttributes( {
+				style: newStyle,
+				[ name ]: newNamedColor,
+			} );
+		};
+
+		return [
+			<ColorPanel
+				key="colors"
+				clientId={ props.clientId }
+				colorSettings={ [
+					{
+						label: __( 'Text Color' ),
+						onChange: onChangeColor( 'textColor' ),
+						colors,
+						value: getColorObjectByAttributeValues(
+							colors,
+							textColor,
+							style?.textColor
+						).color,
+					},
+					{
+						label: __( 'Background Color' ),
+						onChange: onChangeColor( 'backgroundColor' ),
+						colors,
+						value: getColorObjectByAttributeValues(
+							colors,
+							backgroundColor,
+							style?.backgroundColor
+						).color,
+					},
+				] }
+			/>,
+			<BlockEdit key="edit" { ...props } />,
+		];
+	},
+	'withToolbarControls'
+);
+
+addFilter(
+	'blocks.registerBlockType',
+	'core/color/addAttribute',
+	addAttributes
+);
+
+addFilter(
+	'blocks.getSaveContent.extraProps',
+	'core/color/addSaveProps',
+	addSaveProps
+);
+
+addFilter(
+	'blocks.registerBlockType',
+	'core/color/addEditProps',
+	addEditProps
+);
+
+addFilter(
+	'editor.BlockEdit',
+	'core/color/with-block-controls',
+	withBlockControls
+);

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -82,8 +82,8 @@ export function addSaveProps( props, blockType, attributes ) {
 	);
 	const textClass = getColorClassName( 'color', textColor );
 	props.className = classnames( props.className, backgroundClass, textClass, {
-		'has-text-color': textColor || style?.textColor,
-		'has-background': backgroundColor || style?.backgroundColor,
+		'has-text-color': textColor || style?.color?.text,
+		'has-background': backgroundColor || style?.color?.background,
 	} );
 
 	return props;
@@ -176,15 +176,20 @@ export const withBlockControls = createHigherOrderComponent(
 
 		const onChangeColor = ( name ) => ( value ) => {
 			const colorObject = getColorObjectByColorValue( colors, value );
+			const attributeName = name + 'Color';
 			const newStyle = {
 				...style,
-				[ name ]: colorObject && colorObject.slug ? undefined : value,
+				color: {
+					...style?.color,
+					[ name ]:
+						colorObject && colorObject.slug ? undefined : value,
+				},
 			};
 			const newNamedColor =
 				colorObject && colorObject.slug ? colorObject.slug : undefined;
 			props.setAttributes( {
 				style: newStyle,
-				[ name ]: newNamedColor,
+				[ attributeName ]: newNamedColor,
 			} );
 		};
 
@@ -195,22 +200,22 @@ export const withBlockControls = createHigherOrderComponent(
 				colorSettings={ [
 					{
 						label: __( 'Text Color' ),
-						onChange: onChangeColor( 'textColor' ),
+						onChange: onChangeColor( 'text' ),
 						colors,
 						value: getColorObjectByAttributeValues(
 							colors,
 							textColor,
-							style?.textColor
+							style?.color?.text
 						).color,
 					},
 					{
 						label: __( 'Background Color' ),
-						onChange: onChangeColor( 'backgroundColor' ),
+						onChange: onChangeColor( 'background' ),
 						colors,
 						value: getColorObjectByAttributeValues(
 							colors,
 							backgroundColor,
-							style?.backgroundColor
+							style?.color?.background
 						).color,
 					},
 				] }

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -45,14 +45,14 @@ function addAttributes( settings ) {
 	if ( ! settings.attributes?.backgroundColor ) {
 		settings.attributes = Object.assign( settings.attributes, {
 			backgroundColor: {
-				type: 'object',
+				type: 'string',
 			},
 		} );
 	}
 	if ( ! settings.attributes?.textColor ) {
 		settings.attributes = Object.assign( settings.attributes, {
 			textColor: {
-				type: 'object',
+				type: 'string',
 			},
 		} );
 	}

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -16,7 +16,6 @@ import { useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-// This should be moved out of the components folder
 import {
 	getColorClassName,
 	getColorObjectByColorValue,

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -181,7 +181,7 @@ export const withBlockControls = createHigherOrderComponent(
 				color: {
 					...style?.color,
 					[ name ]:
-						colorObject && colorObject.slug ? undefined : value,
+						colorObject?.slug ? undefined : value,
 				},
 			};
 			const newNamedColor =

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -42,7 +42,7 @@ function addAttributes( settings ) {
 
 	// allow blocks to specify their own attribute definition with default values if needed.
 	if ( ! settings.attributes?.backgroundColor ) {
-		settings.attributes = Object.assign( settings.attributes, {
+		Object.assign( settings.attributes, {
 			backgroundColor: {
 				type: 'string',
 			},

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -117,7 +117,6 @@ const ColorPanel = ( { colorSettings, clientId } ) => {
 	const [ detectedBackgroundColor, setDetectedBackgroundColor ] = useState();
 	const [ detectedColor, setDetectedColor ] = useState();
 
-	// TODO: check performance impact of running this on each render
 	useEffect( () => {
 		const colorsDetectionElement = getBlockDOMNode( clientId );
 		setDetectedColor( getComputedStyle( colorsDetectionElement ).color );
@@ -180,12 +179,12 @@ export const withBlockControls = createHigherOrderComponent(
 				...style,
 				color: {
 					...style?.color,
-					[ name ]:
-						colorObject?.slug ? undefined : value,
+					[ name ]: colorObject?.slug ? undefined : value,
 				},
 			};
-			const newNamedColor =
-				colorObject?.slug ? colorObject.slug : undefined;
+			const newNamedColor = colorObject?.slug
+				? colorObject.slug
+				: undefined;
 			props.setAttributes( {
 				style: newStyle,
 				[ attributeName ]: newNamedColor,

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { assign, has } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -43,15 +42,15 @@ function addAttributes( settings ) {
 	}
 
 	// allow blocks to specify their own attribute definition with default values if needed.
-	if ( ! has( settings.attributes, [ 'backgroundColor', 'type' ] ) ) {
-		settings.attributes = assign( settings.attributes, {
+	if ( ! settings.attributes?.backgroundColor ) {
+		settings.attributes = Object.assign( settings.attributes, {
 			backgroundColor: {
 				type: 'object',
 			},
 		} );
 	}
-	if ( ! has( settings.attributes, [ 'textColor', 'type' ] ) ) {
-		settings.attributes = assign( settings.attributes, {
+	if ( ! settings.attributes?.textColor ) {
+		settings.attributes = Object.assign( settings.attributes, {
 			textColor: {
 				type: 'object',
 			},

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
+import { pickBy, isEqual, isObject, identity, mapValues } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -27,6 +28,19 @@ import InspectorControls from '../components/inspector-controls';
 import { getBlockDOMNode } from '../utils/dom';
 
 export const COLOR_SUPPORT_KEY = '__experimentalColor';
+
+export const cleanEmptyObject = ( object ) => {
+	if ( ! isObject( object ) ) {
+		return object;
+	}
+	const cleanedNestedObjects = pickBy(
+		mapValues( object, cleanEmptyObject ),
+		identity
+	);
+	return isEqual( cleanedNestedObjects, {} )
+		? undefined
+		: cleanedNestedObjects;
+};
 
 /**
  * Filters registered block settings, extending attributes to include
@@ -186,7 +200,7 @@ export const withBlockControls = createHigherOrderComponent(
 				? colorObject.slug
 				: undefined;
 			props.setAttributes( {
-				style: newStyle,
+				style: cleanEmptyObject( newStyle ),
 				[ attributeName ]: newNamedColor,
 			} );
 		};

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -41,14 +41,14 @@ function addAttributes( settings ) {
 	}
 
 	// allow blocks to specify their own attribute definition with default values if needed.
-	if ( ! settings.attributes?.backgroundColor ) {
+	if ( ! settings.attributes.backgroundColor ) {
 		Object.assign( settings.attributes, {
 			backgroundColor: {
 				type: 'string',
 			},
 		} );
 	}
-	if ( ! settings.attributes?.textColor ) {
+	if ( ! settings.attributes.textColor ) {
 		Object.assign( settings.attributes, {
 			textColor: {
 				type: 'string',

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -49,7 +49,7 @@ function addAttributes( settings ) {
 		} );
 	}
 	if ( ! settings.attributes?.textColor ) {
-		settings.attributes = Object.assign( settings.attributes, {
+		Object.assign( settings.attributes, {
 			textColor: {
 				type: 'string',
 			},

--- a/packages/block-editor/src/hooks/index.js
+++ b/packages/block-editor/src/hooks/index.js
@@ -5,5 +5,7 @@ import { AlignmentHookSettingsProvider } from './align';
 import './anchor';
 import './custom-class-name';
 import './generated-class-name';
+import './style';
+import './color';
 
 export { AlignmentHookSettingsProvider };

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -67,7 +67,7 @@ function addAttribute( settings ) {
 	}
 
 	// allow blocks to specify their own attribute definition with default values if needed.
-	if ( ! settings.attributes?.style ) {
+	if ( ! settings.attributes.style ) {
 		Object.assign( settings.attributes, {
 			style: {
 				type: 'object',

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -1,0 +1,120 @@
+/**
+ * External dependencies
+ */
+import { assign, has, mapKeys, kebabCase } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { addFilter } from '@wordpress/hooks';
+import { hasBlockSupport } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import { COLOR_SUPPORT_KEY } from './color';
+
+const styleSupportKeys = [ COLOR_SUPPORT_KEY ];
+
+const hasStyleSupport = ( blockType ) =>
+	styleSupportKeys.some( ( key ) => hasBlockSupport( blockType, key ) );
+
+// This is a global styles utility that should probably be shared with code elsewhere.
+function getCSSVariables( styles = {} ) {
+	const prefix = '--wp';
+	const token = '--';
+
+	return mapKeys(
+		styles,
+		( value, key ) => prefix + token + kebabCase( key )
+	);
+}
+
+/**
+ * Filters registered block settings, extending attributes to include `style` attribute.
+ *
+ * @param  {Object} settings Original block settings
+ * @return {Object}          Filtered block settings
+ */
+function addAttribute( settings ) {
+	if ( ! hasStyleSupport( settings ) ) {
+		return settings;
+	}
+
+	// allow blocks to specify their own attribute definition with default values if needed.
+	if ( ! has( settings.attributes, [ 'style', 'type' ] ) ) {
+		settings.attributes = assign( settings.attributes, {
+			style: {
+				type: 'object',
+			},
+		} );
+	}
+
+	return settings;
+}
+
+/**
+ * Override props assigned to save component to inject colors classnames and styles.
+ *
+ * @param  {Object} props      Additional props applied to save element
+ * @param  {Object} blockType  Block type
+ * @param  {Object} attributes Block attributes
+ * @return {Object}            Filtered props applied to save element
+ */
+export function addSaveProps( props, blockType, attributes ) {
+	if ( ! hasStyleSupport( blockType ) ) {
+		return props;
+	}
+
+	const { style } = attributes;
+
+	props.style = {
+		...getCSSVariables( style ),
+		...props.style,
+	};
+
+	return props;
+}
+
+/**
+ * Filters registered block settings to extand the block edit wrapper
+ * to apply the desired styles and classnames properly.
+ *
+ * @param  {Object} settings Original block settings
+ * @return {Object}          Filtered block settings
+ */
+export function addEditProps( settings ) {
+	if ( ! hasStyleSupport( settings ) ) {
+		return settings;
+	}
+
+	const existingGetEditWrapperProps = settings.getEditWrapperProps;
+	settings.getEditWrapperProps = ( attributes ) => {
+		let props = {};
+		if ( existingGetEditWrapperProps ) {
+			props = existingGetEditWrapperProps( attributes );
+		}
+
+		return addSaveProps( props, settings, attributes );
+	};
+
+	return settings;
+}
+
+addFilter(
+	'blocks.registerBlockType',
+	'core/style/addAttribute',
+	addAttribute
+);
+
+addFilter(
+	'blocks.getSaveContent.extraProps',
+	'core/style/addSaveProps',
+	addSaveProps
+);
+
+addFilter(
+	'blocks.registerBlockType',
+	'core/style/addEditProps',
+	addEditProps
+);

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -19,7 +19,13 @@ const styleSupportKeys = [ COLOR_SUPPORT_KEY ];
 const hasStyleSupport = ( blockType ) =>
 	styleSupportKeys.some( ( key ) => hasBlockSupport( blockType, key ) );
 
-// This is a global styles utility that should probably be shared with code elsewhere.
+/**
+ * Flatten a nested Global styles config and generates the corresponding
+ * flattened CSS variables.
+ *
+ * @param  {Object} styles Styles configuration
+ * @return {Object}        Flattened CSS variables declaration
+ */
 function getCSSVariables( styles = {} ) {
 	const prefix = '--wp';
 	const token = '--';

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -26,14 +26,14 @@ const hasStyleSupport = ( blockType ) =>
  * @param  {Object} styles Styles configuration
  * @return {Object}        Flattened CSS variables declaration
  */
-function getCSSVariables( styles = {} ) {
+export function getCSSVariables( styles = {} ) {
 	const prefix = '--wp';
 	const token = '--';
 	const getNestedCSSVariables = ( config ) => {
 		let result = {};
 		entries( config ).forEach( ( [ key, value ] ) => {
 			if ( ! isObject( value ) ) {
-				result[ key ] = value;
+				result[ kebabCase( key ) ] = value;
 				return;
 			}
 

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -79,7 +79,7 @@ function addAttribute( settings ) {
 }
 
 /**
- * Override props assigned to save component to inject colors classnames and styles.
+ * Override props assigned to save component to inject the CSS variables definition.
  *
  * @param  {Object} props      Additional props applied to save element
  * @param  {Object} blockType  Block type

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { assign, has, mapKeys, kebabCase } from 'lodash';
+import { mapKeys, kebabCase } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -42,8 +42,8 @@ function addAttribute( settings ) {
 	}
 
 	// allow blocks to specify their own attribute definition with default values if needed.
-	if ( ! has( settings.attributes, [ 'style', 'type' ] ) ) {
-		settings.attributes = assign( settings.attributes, {
+	if ( ! settings.attributes?.style ) {
+		settings.attributes = Object.assign( settings.attributes, {
 			style: {
 				type: 'object',
 			},

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -68,7 +68,7 @@ function addAttribute( settings ) {
 
 	// allow blocks to specify their own attribute definition with default values if needed.
 	if ( ! settings.attributes?.style ) {
-		settings.attributes = Object.assign( settings.attributes, {
+		Object.assign( settings.attributes, {
 			style: {
 				type: 'object',
 			},

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { mapKeys, kebabCase } from 'lodash';
+import { mapKeys, kebabCase, isObject, entries } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -23,10 +23,29 @@ const hasStyleSupport = ( blockType ) =>
 function getCSSVariables( styles = {} ) {
 	const prefix = '--wp';
 	const token = '--';
+	const getNestedCSSVariables = ( config ) => {
+		let result = {};
+		entries( config ).forEach( ( [ key, value ] ) => {
+			if ( ! isObject( value ) ) {
+				result[ key ] = value;
+				return;
+			}
+
+			result = {
+				...result,
+				...mapKeys(
+					getNestedCSSVariables( value ),
+					( _, subkey ) => kebabCase( key ) + token + subkey
+				),
+			};
+		} );
+
+		return result;
+	};
 
 	return mapKeys(
-		styles,
-		( value, key ) => prefix + token + kebabCase( key )
+		getNestedCSSVariables( styles ),
+		( _, key ) => prefix + token + key
 	);
 }
 

--- a/packages/block-editor/src/hooks/test/color.js
+++ b/packages/block-editor/src/hooks/test/color.js
@@ -1,0 +1,12 @@
+/**
+ * Internal dependencies
+ */
+import { cleanEmptyObject } from '../color';
+
+describe( 'cleanEmptyObject', () => {
+	it( 'should remove nested keys', () => {
+		expect( cleanEmptyObject( { color: { text: undefined } } ) ).toEqual(
+			undefined
+		);
+	} );
+} );

--- a/packages/block-editor/src/hooks/test/style.js
+++ b/packages/block-editor/src/hooks/test/style.js
@@ -1,0 +1,28 @@
+/**
+ * Internal dependencies
+ */
+import { getCSSVariables } from '../style';
+
+describe( 'getCSSVariables', () => {
+	it( 'should return an empty object when called with undefined', () => {
+		expect( getCSSVariables() ).toEqual( {} );
+	} );
+
+	it( 'should return the correct simple CSS variables', () => {
+		expect( getCSSVariables( { color: 'red' } ) ).toEqual( {
+			'--wp--color': 'red',
+		} );
+	} );
+
+	it( 'should flatten nested style config', () => {
+		expect(
+			getCSSVariables( {
+				color: { text: 'red' },
+				typography: { lineHeight: 1.5 },
+			} )
+		).toEqual( {
+			'--wp--color--text': 'red',
+			'--wp--typography--line-height': 1.5,
+		} );
+	} );
+} );

--- a/packages/block-editor/src/hooks/test/style.js
+++ b/packages/block-editor/src/hooks/test/style.js
@@ -14,6 +14,10 @@ describe( 'getCSSVariables', () => {
 		} );
 	} );
 
+	it( 'should omit CSS variables when the provided value is falsy', () => {
+		expect( getCSSVariables( { color: undefined } ) ).toEqual( {} );
+	} );
+
 	it( 'should flatten nested style config', () => {
 		expect(
 			getCSSVariables( {

--- a/packages/block-library/src/group/block.json
+++ b/packages/block-library/src/group/block.json
@@ -1,18 +1,5 @@
 {
 	"name": "core/group",
 	"category": "layout",
-	"attributes": {
-		"backgroundColor": {
-			"type": "string"
-		},
-		"customBackgroundColor": {
-			"type": "string"
-		},
-		"textColor": {
-			"type": "string"
-		},
-		"customTextColor": {
-			"type": "string"
-		}
-	}
+	"attributes": {}
 }

--- a/packages/block-library/src/group/block.json
+++ b/packages/block-library/src/group/block.json
@@ -1,5 +1,4 @@
 {
 	"name": "core/group",
-	"category": "layout",
-	"attributes": {}
+	"category": "layout"
 }

--- a/packages/block-library/src/group/deprecated.js
+++ b/packages/block-library/src/group/deprecated.js
@@ -8,7 +8,80 @@ import classnames from 'classnames';
  */
 import { InnerBlocks, getColorClassName } from '@wordpress/block-editor';
 
+const migrateCustomColors = ( attributes ) => {
+	if ( ! attributes.customTextColor && ! attributes.customBackgroundColor ) {
+		return attributes;
+	}
+	const style = { color: {} };
+	if ( attributes.customTextColor ) {
+		style.color.text = attributes.customTextColor;
+	}
+	if ( attributes.customBackgroundColor ) {
+		style.color.background = attributes.customBackgroundColor;
+	}
+	return {
+		...attributes,
+		style,
+	};
+};
+
 const deprecated = [
+	// Version of the block without global styles support
+	{
+		attributes: {
+			backgroundColor: {
+				type: 'string',
+			},
+			customBackgroundColor: {
+				type: 'string',
+			},
+			textColor: {
+				type: 'string',
+			},
+			customTextColor: {
+				type: 'string',
+			},
+		},
+		supports: {
+			align: [ 'wide', 'full' ],
+			anchor: true,
+			html: false,
+		},
+		migrate: migrateCustomColors,
+		save( { attributes } ) {
+			const {
+				backgroundColor,
+				customBackgroundColor,
+				textColor,
+				customTextColor,
+			} = attributes;
+
+			const backgroundClass = getColorClassName(
+				'background-color',
+				backgroundColor
+			);
+			const textClass = getColorClassName( 'color', textColor );
+			const className = classnames( backgroundClass, textClass, {
+				'has-text-color': textColor || customTextColor,
+				'has-background': backgroundColor || customBackgroundColor,
+			} );
+
+			const styles = {
+				backgroundColor: backgroundClass
+					? undefined
+					: customBackgroundColor,
+				color: textClass ? undefined : customTextColor,
+			};
+
+			return (
+				<div className={ className } style={ styles }>
+					<div className="wp-block-group__inner-container">
+						<InnerBlocks.Content />
+					</div>
+				</div>
+			);
+		},
+	},
 	// Version of the group block with a bug that made text color class not applied.
 	{
 		attributes: {
@@ -25,6 +98,7 @@ const deprecated = [
 				type: 'string',
 			},
 		},
+		migrate: migrateCustomColors,
 		supports: {
 			align: [ 'wide', 'full' ],
 			anchor: true,
@@ -79,6 +153,7 @@ const deprecated = [
 			anchor: true,
 			html: false,
 		},
+		migrate: migrateCustomColors,
 		save( { attributes } ) {
 			const { backgroundColor, customBackgroundColor } = attributes;
 

--- a/packages/block-library/src/group/edit.js
+++ b/packages/block-library/src/group/edit.js
@@ -1,61 +1,33 @@
 /**
  * WordPress dependencies
  */
-import { withSelect } from '@wordpress/data';
-import { compose } from '@wordpress/compose';
+import { useSelect } from '@wordpress/data';
 import {
 	InnerBlocks,
-	__experimentalUseColors,
 	__experimentalBlock as Block,
 } from '@wordpress/block-editor';
-import { useRef } from '@wordpress/element';
 
-function GroupEdit( { hasInnerBlocks, className } ) {
-	const ref = useRef();
-	const {
-		TextColor,
-		BackgroundColor,
-		InspectorControlsColorPanel,
-	} = __experimentalUseColors(
-		[
-			{ name: 'textColor', property: 'color' },
-			{ name: 'backgroundColor', className: 'has-background' },
-		],
-		{
-			contrastCheckers: [ { backgroundColor: true, textColor: true } ],
-			colorDetector: { targetRef: ref },
-		}
+function GroupEdit( { className, clientId } ) {
+	const hasInnerBlocks = useSelect(
+		( select ) => {
+			const { getBlock } = select( 'core/block-editor' );
+			const block = getBlock( clientId );
+			return !! ( block && block.innerBlocks.length );
+		},
+		[ clientId ]
 	);
 
 	return (
-		<>
-			{ InspectorControlsColorPanel }
-			<BackgroundColor>
-				<TextColor>
-					<Block.div className={ className } ref={ ref }>
-						<div className="wp-block-group__inner-container">
-							<InnerBlocks
-								renderAppender={
-									! hasInnerBlocks &&
-									InnerBlocks.ButtonBlockAppender
-								}
-							/>
-						</div>
-					</Block.div>
-				</TextColor>
-			</BackgroundColor>
-		</>
+		<Block.div className={ className }>
+			<div className="wp-block-group__inner-container">
+				<InnerBlocks
+					renderAppender={
+						! hasInnerBlocks && InnerBlocks.ButtonBlockAppender
+					}
+				/>
+			</div>
+		</Block.div>
 	);
 }
 
-export default compose( [
-	withSelect( ( select, { clientId } ) => {
-		const { getBlock } = select( 'core/block-editor' );
-
-		const block = getBlock( clientId );
-
-		return {
-			hasInnerBlocks: !! ( block && block.innerBlocks.length ),
-		};
-	} ),
-] )( GroupEdit );
+export default GroupEdit;

--- a/packages/block-library/src/group/index.js
+++ b/packages/block-library/src/group/index.js
@@ -30,8 +30,10 @@ export const settings = {
 	example: {
 		attributes: {
 			style: {
-				textColor: '#000000',
-				backgroundColor: '#ffffff',
+				color: {
+					text: '#000000',
+					background: '#ffffff',
+				},
 			},
 		},
 		innerBlocks: [

--- a/packages/block-library/src/group/index.js
+++ b/packages/block-library/src/group/index.js
@@ -91,7 +91,6 @@ export const settings = {
 		html: false,
 		lightBlockWrapper: true,
 		__experimentalColor: true,
-		customClassName: false,
 	},
 	transforms: {
 		from: [

--- a/packages/block-library/src/group/index.js
+++ b/packages/block-library/src/group/index.js
@@ -29,8 +29,10 @@ export const settings = {
 	],
 	example: {
 		attributes: {
-			customBackgroundColor: '#ffffff',
-			customTextColor: '#000000',
+			style: {
+				textColor: '#000000',
+				backgroundColor: '#ffffff',
+			},
 		},
 		innerBlocks: [
 			{
@@ -88,6 +90,8 @@ export const settings = {
 		anchor: true,
 		html: false,
 		lightBlockWrapper: true,
+		__experimentalColor: true,
+		customClassName: false,
 	},
 	transforms: {
 		from: [

--- a/packages/block-library/src/group/save.js
+++ b/packages/block-library/src/group/save.js
@@ -1,38 +1,11 @@
 /**
- * External dependencies
- */
-import classnames from 'classnames';
-
-/**
  * WordPress dependencies
  */
-import { InnerBlocks, getColorClassName } from '@wordpress/block-editor';
+import { InnerBlocks } from '@wordpress/block-editor';
 
-export default function save( { attributes } ) {
-	const {
-		backgroundColor,
-		customBackgroundColor,
-		textColor,
-		customTextColor,
-	} = attributes;
-
-	const backgroundClass = getColorClassName(
-		'background-color',
-		backgroundColor
-	);
-	const textClass = getColorClassName( 'color', textColor );
-	const className = classnames( backgroundClass, textClass, {
-		'has-text-color': textColor || customTextColor,
-		'has-background': backgroundColor || customBackgroundColor,
-	} );
-
-	const styles = {
-		backgroundColor: backgroundClass ? undefined : customBackgroundColor,
-		color: textClass ? undefined : customTextColor,
-	};
-
+export default function save() {
 	return (
-		<div className={ className } style={ styles }>
+		<div>
 			<div className="wp-block-group__inner-container">
 				<InnerBlocks.Content />
 			</div>

--- a/packages/block-library/src/group/style.scss
+++ b/packages/block-library/src/group/style.scss
@@ -1,4 +1,4 @@
 .wp-block-group {
-	background-color: var(--wp--background-color);
-	color: var(--wp--text-color);
+	background-color: var(--wp--color--background);
+	color: var(--wp--color--text);
 }

--- a/packages/block-library/src/group/style.scss
+++ b/packages/block-library/src/group/style.scss
@@ -1,0 +1,4 @@
+.wp-block-group {
+	background-color: var(--wp--background-color);
+	color: var(--wp--text-color);
+}

--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -13,6 +13,7 @@
 @import "./embed/style.scss";
 @import "./file/style.scss";
 @import "./gallery/style.scss";
+@import "./group/style.scss";
 @import "./image/style.scss";
 @import "./latest-comments/style.scss";
 @import "./latest-posts/style.scss";

--- a/packages/e2e-tests/fixtures/blocks/core__group.html
+++ b/packages/e2e-tests/fixtures/blocks/core__group.html
@@ -1,4 +1,4 @@
-<!-- wp:group {"backgroundColor":"secondary","align":"full"} -->
+<!-- wp:group {"align":"full","backgroundColor":"secondary"} -->
 <div class="wp-block-group alignfull has-secondary-background-color has-background">
 	<div class="wp-block-group__inner-container">
 		<!-- wp:paragraph -->

--- a/packages/e2e-tests/fixtures/blocks/core__group.serialized.html
+++ b/packages/e2e-tests/fixtures/blocks/core__group.serialized.html
@@ -1,4 +1,4 @@
-<!-- wp:group {"backgroundColor":"secondary","align":"full"} -->
+<!-- wp:group {"align":"full","backgroundColor":"secondary"} -->
 <div class="wp-block-group alignfull has-secondary-background-color has-background"><div class="wp-block-group__inner-container"><!-- wp:paragraph -->
 <p>This is a group block.</p>
 <!-- /wp:paragraph -->

--- a/packages/e2e-tests/fixtures/blocks/core__group__deprecated.html
+++ b/packages/e2e-tests/fixtures/blocks/core__group__deprecated.html
@@ -1,4 +1,4 @@
-<!-- wp:group {"backgroundColor":"lighter-blue","align":"full"} -->
+<!-- wp:group {"align":"full","backgroundColor":"lighter-blue"} -->
 <div class="wp-block-group alignfull has-lighter-blue-background-color has-background" id="test-id">
 	<!-- wp:paragraph -->
 	<p>test</p>

--- a/packages/e2e-tests/fixtures/blocks/core__group__deprecated.serialized.html
+++ b/packages/e2e-tests/fixtures/blocks/core__group__deprecated.serialized.html
@@ -1,4 +1,4 @@
-<!-- wp:group {"backgroundColor":"lighter-blue","align":"full"} -->
+<!-- wp:group {"align":"full","backgroundColor":"lighter-blue"} -->
 <div class="wp-block-group alignfull has-lighter-blue-background-color has-background" id="test-id"><div class="wp-block-group__inner-container"><!-- wp:paragraph -->
 <p>test</p>
 <!-- /wp:paragraph --></div></div>


### PR DESCRIPTION
Yes I know I know, I've been an opponent of "support" keys for blocks for a long time but we can change our minds right? The simplicity they allow for block authors is IMO good, especially for generic features that should be consistent across blocks. 

One of these consistent features could be "colors" and it would include things like:

 1- Applying a background color (custom or palette)
 2- Applying a text color (custom or palette)
 3- Contrast checking
 4- Applying gradients (custom or palette) as backgrounds

Some very small changes could be possible between blocks, like enabling/disabling gradients, backgrounds, choosing whether to put the controls in the inspector or toolbar, but ultimately these could be provided by the support key too.

In addition to the factorization benefits, this PR is also based on some ideas:

 5- Adding support for colors also means adding support for global styles colors (configurable from theme.json files)
 6- Support custom colors is not different from supporting say lineHeight, customFontSize... All these options could be considered global styles support and persisted similarly in a unique `style` attribute.

The current PR solves 1, 2, 3, 5, 6 and applies a refactor to the Group block to make use of this new support flag.

I also know this makes `useColors` kind of redundant but since it's experimental, that's fine and if we find value in this approach we can decide to go with one or the other.