### PR TITLE
[RNMobile] Latest-Posts: Resolve issue with Query Controls, and fix API Fetch strategy

### DIFF
--- a/packages/block-library/src/latest-posts/edit.native.js
+++ b/packages/block-library/src/latest-posts/edit.native.js
@@ -14,7 +14,7 @@ import { coreBlocks } from '@wordpress/block-library';
 import { __ } from '@wordpress/i18n';
 import { postList as icon } from '@wordpress/icons';
 import { InspectorControls } from '@wordpress/block-editor';
-import { fetchRequest } from 'react-native-gutenberg-bridge';
+import apiFetch from '@wordpress/api-fetch';
 import {
 	Icon,
 	PanelBody,
@@ -52,23 +52,13 @@ class LatestPostsEdit extends Component {
 
 	componentDidMount() {
 		this.isStillMounted = true;
-		this.fetchRequest = fetchRequest( '/wp/v2/categories' )
+		this.fetchRequest = apiFetch( { path: '/wp/v2/categories' } )
 			.then( ( categoriesList ) => {
 				if ( this.isStillMounted ) {
-					let parsedCategoriesList = categoriesList;
-
-					// TODO: remove this check after `fetchRequest` types are made consist across platforms
-					// (see: https://github.com/wordpress-mobile/gutenberg-mobile/issues/1961)
-					if ( typeof categoriesList === 'string' ) {
-						parsedCategoriesList = JSON.parse( categoriesList );
-					}
-
-					if ( isEmpty( parsedCategoriesList ) ) {
-						parsedCategoriesList = [];
-					}
-
 					this.setState( {
-						categoriesList: parsedCategoriesList,
+						categoriesList: isEmpty( categoriesList )
+							? []
+							: categoriesList,
 					} );
 				}
 			} )

--- a/packages/block-library/src/latest-posts/style.native.scss
+++ b/packages/block-library/src/latest-posts/style.native.scss
@@ -31,7 +31,7 @@
 	text-align: center;
 	margin-top: 8;
 	font-size: 14;
-	color: #2e4453;
+	color: $gray-dark;
 }
 
 .latestPostBlockMessageDark {

--- a/packages/components/src/query-controls/index.js
+++ b/packages/components/src/query-controls/index.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Platform } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -12,17 +11,6 @@ import { RangeControl, SelectControl, FormTokenField } from '../';
 const DEFAULT_MIN_ITEMS = 1;
 const DEFAULT_MAX_ITEMS = 100;
 const MAX_CATEGORIES_SUGGESTIONS = 20;
-
-// currently this is needed for consistent controls UI on mobile
-// this can be removed after control components settle on consistent defaults
-const MOBILE_CONTROL_PROPS = Platform.select( {
-	web: {},
-	native: { separatorType: 'fullWidth' },
-} );
-const MOBILE_CONTROL_PROPS_SEPARATOR_NONE = Platform.select( {
-	web: {},
-	native: { separatorType: 'none' },
-} );
 
 export default function QueryControls( {
 	categorySuggestions,
@@ -72,7 +60,6 @@ export default function QueryControls( {
 						onOrderByChange( newOrderBy );
 					}
 				} }
-				{ ...MOBILE_CONTROL_PROPS }
 			/>
 		),
 		onCategoryChange && (
@@ -100,7 +87,6 @@ export default function QueryControls( {
 				min={ minItems }
 				max={ maxItems }
 				required
-				{ ...MOBILE_CONTROL_PROPS_SEPARATOR_NONE }
 			/>
 		),
 	];

--- a/packages/components/src/query-controls/index.native.js
+++ b/packages/components/src/query-controls/index.native.js
@@ -1,0 +1,87 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { RangeControl, SelectControl } from '../';
+import CategorySelect from './category-select';
+
+const DEFAULT_MIN_ITEMS = 1;
+const DEFAULT_MAX_ITEMS = 100;
+
+export default function QueryControls( {
+	categoriesList,
+	selectedCategoryId,
+	numberOfItems,
+	order,
+	orderBy,
+	maxItems = DEFAULT_MAX_ITEMS,
+	minItems = DEFAULT_MIN_ITEMS,
+	onCategoryChange,
+	onNumberOfItemsChange,
+	onOrderChange,
+	onOrderByChange,
+} ) {
+	return [
+		onOrderChange && onOrderByChange && (
+			<SelectControl
+				label={ __( 'Order by' ) }
+				value={ `${ orderBy }/${ order }` }
+				options={ [
+					{
+						label: __( 'Newest to oldest' ),
+						value: 'date/desc',
+					},
+					{
+						label: __( 'Oldest to newest' ),
+						value: 'date/asc',
+					},
+					{
+						/* translators: label for ordering posts by title in ascending order */
+						label: __( 'A → Z' ),
+						value: 'title/asc',
+					},
+					{
+						/* translators: label for ordering posts by title in descending order */
+						label: __( 'Z → A' ),
+						value: 'title/desc',
+					},
+				] }
+				onChange={ ( value ) => {
+					const [ newOrderBy, newOrder ] = value.split( '/' );
+					if ( newOrder !== order ) {
+						onOrderChange( newOrder );
+					}
+					if ( newOrderBy !== orderBy ) {
+						onOrderByChange( newOrderBy );
+					}
+				} }
+				{ ...{ separatorType: 'fullWidth' } }
+			/>
+		),
+		onCategoryChange && (
+			<CategorySelect
+				categoriesList={ categoriesList }
+				label={ __( 'Category' ) }
+				noOptionLabel={ __( 'All' ) }
+				selectedCategoryId={ selectedCategoryId }
+				onChange={ onCategoryChange }
+				{ ...{ separatorType: 'fullWidth' } }
+			/>
+		),
+		onNumberOfItemsChange && (
+			<RangeControl
+				label={ __( 'Number of items' ) }
+				value={ numberOfItems }
+				onChange={ onNumberOfItemsChange }
+				min={ minItems }
+				max={ maxItems }
+				required
+				{ ...{ separatorType: 'none' } }
+			/>
+		),
+	];
+}


### PR DESCRIPTION
**Fixes:** https://github.com/wordpress-mobile/gutenberg-mobile/issues/2038

`gutenberg-mobile:` https://github.com/wordpress-mobile/gutenberg-mobile/pull/2039

## Description
<!-- Please describe what you have changed or added -->
### API 
Adjusts the fetching of categories from using `fetchRequest` to use `apiFetch` which also removed the need for casting the platform response and converting it to JSON for Android

### QueryControls
https://github.com/WordPress/gutenberg/pull/20832 Introduced an issue with Query Controls in order to maintain the stable state of these controls I cloned that file to `index.native.js` and removed the mobile-specific code in the old file. There seem to be a lot of planned changes there so we can probably reassess combining them later.

### Style change 
Resolved the issue mentioned here https://github.com/WordPress/gutenberg/pull/20301#discussion_r392873584

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Tested following the steps here: https://github.com/WordPress/gutenberg/pull/20301

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
- Regression Bug Fix
- Updates from code review

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
