### PR TITLE
Fix: Focus bug on text control inside the block settings sidebar (trunk)

### DIFF
--- a/packages/block-editor/src/components/block-list/use-multi-selection.js
+++ b/packages/block-editor/src/components/block-list/use-multi-selection.js
@@ -242,6 +242,17 @@ export default function useMultiSelection( ref ) {
 
 			startClientId.current = clientId;
 			anchorElement.current = document.activeElement;
+			if ( anchorElement.current ) {
+				const blockInspector = document.querySelector(
+					'.block-editor-block-inspector'
+				);
+				if (
+					blockInspector &&
+					blockInspector.contains( anchorElement.current )
+				) {
+					return;
+				}
+			}
 			startMultiSelect();
 
 			// `onSelectionStart` is called after `mousedown` and `mouseleave`


### PR DESCRIPTION
## Description
Fixes: https://github.com/WordPress/gutenberg/issues/20950
The base branch of this PR is trunk because the issue does not exist in master anymore.
But this issue is preset on WordPress 5.4 RC3 and is a regression when compared with 5.3.2.


The regression happened on: https://github.com/WordPress/gutenberg/pull/18915/
It was fixed on (not part of 5.4): https://github.com/WordPress/gutenberg/pull/19701/

Unfortunately, we can not add https://github.com/WordPress/gutenberg/pull/19701/ as part of 5.4 so this PR proposes a temporary solution we can use.

cc: @ellatrix in case you know another way to fix the issue.

## How has this been tested?
I added a paragraph.
I went to the advanced panel on block inspector
I typed a classname.
I selected the text on the classname field and I verified the text did not get unselected and the focus removed from the field as soon as I released the mouse.

I verified selection and multi-selection still works as expected.