### PR TITLE
Nav Block: Fix toolbar overlap on navigation links

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -41,7 +41,6 @@ $navigation-sub-menu-width: $grid-unit-10 * 25;
 		&:hover,
 		&:focus-within {
 			cursor: pointer;
-			z-index: 99999;
 		}
 
 		// Submenu Display


### PR DESCRIPTION
## Description
Fixes #20852

This is a somewhat brute-force attempt to resolve this issue by removed a z-index rule.

In testing, I couldn't see that removing this causes any issues. My suggestion would be that we try to live without z-index rules for as long as possible, unless we absolutely need it. 

It might be that some themes require z-index rules, but then those should ideally be applied by the theme, because there's no way the core styles can get it right for everyone.

## How has this been tested?
1. Add a nav block
2. Add a nav link and add multiple sub-links
3. Observe that when various links are selected, the toolbar is never overlapped.

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->
*Before*
![2020-03-12 21 57 46](https://user-images.githubusercontent.com/253067/76570289-ece7fb00-64ac-11ea-83da-57e85d2bde29.gif)

*After*
<img width="259" alt="Screenshot 2020-03-20 at 12 22 19 pm" src="https://user-images.githubusercontent.com/677833/77135225-7e56fe80-6aa5-11ea-959c-e122b5a0e063.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
