### PR TITLE
Nav Block: Remove 'frontend' from style comments

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -3,7 +3,7 @@ $navigation-sub-menu-height: $grid-unit-10 * 5;
 $navigation-sub-menu-width: $grid-unit-10 * 25;
 
 /*
-* Frontend: reset the default list styles
+* Reset the default list styles
 */
 
 .wp-block-navigation > ul {
@@ -31,7 +31,7 @@ $navigation-sub-menu-width: $grid-unit-10 * 25;
 }
 
 /*
-* Frontend: styles for submenu flyout
+* Styles for submenu flyout
 */
 
 .wp-block-navigation > ul {
@@ -219,7 +219,7 @@ $navigation-sub-menu-width: $grid-unit-10 * 25;
 }
 
 /*
-* Frontend: non-shared styles & overrides
+* Non-shared styles & overrides
 */
 
 .wp-block-navigation {


### PR DESCRIPTION
## Description
Tiny code-quality PR. The nav block's stylesheet has comments that refer to 'Frontend'. This is potentially confusing as this stylesheet applies to both editor and frontend styles. This PR removes the word 'Frontend'.

## Types of changes
Code Quality
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
