### PR TITLE
Nav Block: Avoid hiding submenu when adding a link

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -296,7 +296,12 @@ function NavigationLinkEdit( {
 					__experimentalTagName="ul"
 					__experimentalAppenderTagName="li"
 					__experimentalPassedProps={ {
-						className: 'wp-block-navigation__container',
+						className: classnames(
+							'wp-block-navigation__container',
+							{
+								'is-parent-of-selected-block': isParentOfSelectedBlock,
+							}
+						),
 					} }
 				/>
 			</Block.li>

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -23,6 +23,12 @@ $navigation-item-height: 46px;
 	padding: $grid-unit-20;
 }
 
+// Ensure sub-menus stay open and visible when a nested block is selected.
+.wp-block-navigation__container.is-parent-of-selected-block {
+	visibility: visible;
+	opacity: 1;
+}
+
 /**
  * Colors Selector component
  */


### PR DESCRIPTION
## Description
Related #20852, #21033

Nav Block submenus are only visible when hover or focus is within the submenu. This causes an issue in the editor where a Navigation Link in a nested submenu can be selected, but because focus is in a Toolbar or LinkControl (which are popovers), the submenu hides, and the user can no longer see what they're editing.

This PR adds editor only styles to solve that issue—when any Navigation Link block in a submenu is selected the list now receives the `.is-parent-of-selected-block` class name which is used to ensure the submenu stays visible.

## How has this been tested?
Manual Testing
1. Add a navigation block
2. Attempt to add navigation link in a submenu
3. Observe the submenu now stays visible when focus is in the link control.

## Screenshots <!-- if applicable -->
*Before*
![2020-03-12 21 57 46](https://user-images.githubusercontent.com/253067/76570289-ece7fb00-64ac-11ea-83da-57e85d2bde29.gif)

*After*
<img width="431" alt="Screenshot 2020-03-20 at 1 12 50 pm" src="https://user-images.githubusercontent.com/677833/77138306-86666c80-6aac-11ea-97a3-92b62434d7f0.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
