### PR TITLE
First pass at Navigation screen

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1302,6 +1302,12 @@
 		"parent": "packages"
 	},
 	{
+		"title": "@wordpress/edit-navigation",
+		"slug": "packages-edit-navigation",
+		"markdown_source": "../packages/edit-navigation/README.md",
+		"parent": "packages"
+	},
+	{
 		"title": "@wordpress/edit-post",
 		"slug": "packages-edit-post",
 		"markdown_source": "../packages/edit-post/README.md",

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -54,6 +54,16 @@ function gutenberg_menu() {
 				'the_gutenberg_widgets'
 			);
 		}
+		if ( array_key_exists( 'gutenberg-navigation', get_option( 'gutenberg-experiments' ) ) ) {
+			add_submenu_page(
+				'gutenberg',
+				__( 'Navigation (beta)', 'gutenberg' ),
+				__( 'Navigation (beta)', 'gutenberg' ),
+				'edit_theme_options',
+				'gutenberg-navigation',
+				'gutenberg_navigation_page'
+			);
+		}
 		if ( array_key_exists( 'gutenberg-full-site-editing', get_option( 'gutenberg-experiments' ) ) ) {
 			add_submenu_page(
 				'gutenberg',

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -398,6 +398,15 @@ function gutenberg_register_packages_styles( &$styles ) {
 
 	gutenberg_override_style(
 		$styles,
+		'wp-edit-navigation',
+		gutenberg_url( 'build/edit-navigation/style.css' ),
+		array( 'wp-components', 'wp-block-editor', 'wp-edit-blocks' ),
+		filemtime( gutenberg_dir_path() . 'build/edit-navigation/style.css' )
+	);
+	$styles->add_data( 'wp-edit-navigation', 'rtl', 'replace' );
+
+	gutenberg_override_style(
+		$styles,
 		'wp-edit-site',
 		gutenberg_url( 'build/edit-site/style.css' ),
 		array( 'wp-components', 'wp-block-editor', 'wp-edit-blocks' ),

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -52,6 +52,17 @@ function gutenberg_initialize_experiments_settings() {
 		)
 	);
 	add_settings_field(
+		'gutenberg-navigation',
+		__( 'Navigation', 'gutenberg' ),
+		'gutenberg_display_experiment_field',
+		'gutenberg-experiments',
+		'gutenberg_experiments_section',
+		array(
+			'label' => __( 'Enable Navigation screen', 'gutenberg' ),
+			'id'    => 'gutenberg-navigation',
+		)
+	);
+	add_settings_field(
 		'gutenberg-block-directory',
 		__( 'Block Directory', 'gutenberg' ),
 		'gutenberg_display_experiment_field',

--- a/lib/load.php
+++ b/lib/load.php
@@ -74,6 +74,7 @@ require dirname( __FILE__ ) . '/block-directory.php';
 require dirname( __FILE__ ) . '/demo.php';
 require dirname( __FILE__ ) . '/widgets.php';
 require dirname( __FILE__ ) . '/widgets-page.php';
+require dirname( __FILE__ ) . '/navigation-page.php';
 require dirname( __FILE__ ) . '/experiments-page.php';
 require dirname( __FILE__ ) . '/customizer.php';
 require dirname( __FILE__ ) . '/edit-site-page.php';

--- a/lib/navigation-page.php
+++ b/lib/navigation-page.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Bootstraping the Gutenberg Navigation page.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * The main entry point for the Gutenberg Navigation page.
+ *
+ * @since 7.8.0
+ */
+function gutenberg_navigation_page() {
+	?>
+	<div
+		id="navigation-editor"
+		class="edit-navigation"
+	>
+	</div>
+	<?php
+}
+
+/**
+ * Initialize the Gutenberg Navigation page.
+ *
+ * @since 7.8.0
+ *
+ * @param string $hook Page.
+ */
+function gutenberg_navigation_init( $hook ) {
+	if ( 'gutenberg_page_gutenberg-navigation' !== $hook ) {
+			return;
+	}
+
+	// Media settings.
+	$max_upload_size = wp_max_upload_size();
+	if ( ! $max_upload_size ) {
+		$max_upload_size = 0;
+	}
+
+	/** This filter is documented in wp-admin/includes/media.php */
+	$image_size_names = apply_filters(
+		'image_size_names_choose',
+		array(
+			'thumbnail' => __( 'Thumbnail', 'gutenberg' ),
+			'medium'    => __( 'Medium', 'gutenberg' ),
+			'large'     => __( 'Large', 'gutenberg' ),
+			'full'      => __( 'Full Size', 'gutenberg' ),
+		)
+	);
+
+	$available_image_sizes = array();
+	foreach ( $image_size_names as $image_size_slug => $image_size_name ) {
+		$available_image_sizes[] = array(
+			'slug' => $image_size_slug,
+			'name' => $image_size_name,
+		);
+	}
+
+	$settings = array(
+		'disableCustomColors'    => get_theme_support( 'disable-custom-colors' ),
+		'disableCustomFontSizes' => get_theme_support( 'disable-custom-font-sizes' ),
+		'imageSizes'             => $available_image_sizes,
+		'isRTL'                  => is_rtl(),
+		'maxUploadFileSize'      => $max_upload_size,
+	);
+
+	list( $color_palette, ) = (array) get_theme_support( 'editor-color-palette' );
+	list( $font_sizes, )    = (array) get_theme_support( 'editor-font-sizes' );
+
+	if ( false !== $color_palette ) {
+		$settings['colors'] = $color_palette;
+	}
+
+	if ( false !== $font_sizes ) {
+		$settings['fontSizes'] = $font_sizes;
+	}
+
+	wp_add_inline_script(
+		'wp-edit-navigation',
+		sprintf(
+			'wp.domReady( function() {
+				wp.editNavigation.initialize( "navigation-editor", %s );
+			} );',
+			wp_json_encode( gutenberg_experiments_editor_settings( $settings ) )
+		)
+	);
+
+	// Preload server-registered block schemas.
+	wp_add_inline_script(
+		'wp-blocks',
+		'wp.blocks.unstable__bootstrapServerSideBlockDefinitions(' . wp_json_encode( get_block_editor_server_block_settings() ) . ');'
+	);
+
+	wp_enqueue_script( 'wp-edit-navigation' );
+	wp_enqueue_style( 'wp-edit-navigation' );
+	wp_enqueue_style( 'wp-block-library' );
+	wp_enqueue_script( 'wp-format-library' );
+	wp_enqueue_style( 'wp-format-library' );
+}
+add_action( 'admin_enqueue_scripts', 'gutenberg_navigation_init' );

--- a/package-lock.json
+++ b/package-lock.json
@@ -10932,6 +10932,27 @@
 				"uuid": "^3.3.2"
 			}
 		},
+		"@wordpress/edit-navigation": {
+			"version": "file:packages/edit-navigation",
+			"requires": {
+				"@babel/runtime": "^7.8.3",
+				"@wordpress/block-editor": "file:packages/block-editor",
+				"@wordpress/block-library": "file:packages/block-library",
+				"@wordpress/blocks": "file:packages/blocks",
+				"@wordpress/components": "file:packages/components",
+				"@wordpress/compose": "file:packages/compose",
+				"@wordpress/data": "file:packages/data",
+				"@wordpress/data-controls": "file:packages/data-controls",
+				"@wordpress/dom-ready": "file:packages/dom-ready",
+				"@wordpress/element": "file:packages/element",
+				"@wordpress/hooks": "file:packages/hooks",
+				"@wordpress/i18n": "file:packages/i18n",
+				"@wordpress/media-utils": "file:packages/media-utils",
+				"@wordpress/notices": "file:packages/notices",
+				"lodash": "^4.17.15",
+				"rememo": "^3.0.0"
+			}
+		},
 		"@wordpress/edit-post": {
 			"version": "file:packages/edit-post",
 			"requires": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
 		"@wordpress/deprecated": "file:packages/deprecated",
 		"@wordpress/dom": "file:packages/dom",
 		"@wordpress/dom-ready": "file:packages/dom-ready",
+		"@wordpress/edit-navigation": "file:packages/edit-navigation",
 		"@wordpress/edit-post": "file:packages/edit-post",
 		"@wordpress/edit-site": "file:packages/edit-site",
 		"@wordpress/edit-widgets": "file:packages/edit-widgets",

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -277,6 +277,9 @@ function Navigation( {
 								className: 'wp-block-navigation__container',
 							} }
 							__experimentalCaptureToolbars={ true }
+							// Template lock set to false here so that the Nav
+							// Block on the experimental menus screen does not
+							// inherit templateLock={ 'all' }.
 							templateLock={ false }
 						/>
 					</Block.nav>

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -277,6 +277,7 @@ function Navigation( {
 								className: 'wp-block-navigation__container',
 							} }
 							__experimentalCaptureToolbars={ true }
+							templateLock={ false }
 						/>
 					</Block.nav>
 				</BackgroundColor>

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -67,6 +67,27 @@ export const defaultEntities = [
 		plural: 'comments',
 		label: __( 'Comment' ),
 	},
+	{
+		name: 'menu',
+		kind: 'root',
+		baseURL: '/__experimental/menus',
+		plural: 'menus',
+		label: __( 'Menu' ),
+	},
+	{
+		name: 'menuItem',
+		kind: 'root',
+		baseURL: '/__experimental/menu-items',
+		plural: 'menuItems',
+		label: __( 'Menu Item' ),
+	},
+	{
+		name: 'menuLocation',
+		kind: 'root',
+		baseURL: '/__experimental/menu-locations',
+		plural: 'menuLocations',
+		label: __( 'Menu Location' ),
+	},
 ];
 
 export const kinds = [

--- a/packages/edit-navigation/.npmrc
+++ b/packages/edit-navigation/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/packages/edit-navigation/README.md
+++ b/packages/edit-navigation/README.md
@@ -1,0 +1,5 @@
+- Package name
+- Package description
+- Installation details
+- Usage example
+- `Code is Poetry` logo (`<br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>`)

--- a/packages/edit-navigation/package.json
+++ b/packages/edit-navigation/package.json
@@ -1,0 +1,44 @@
+{
+	"name": "@wordpress/edit-navigation",
+	"version": "1.0.0-beta.0",
+	"private": true,
+	"description": "Module for the Navigation page in WordPress.",
+	"author": "The WordPress Contributors",
+	"license": "GPL-2.0-or-later",
+	"keywords": [
+		"wordpress"
+	],
+	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/edit-navigation/README.md",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/WordPress/gutenberg.git",
+		"directory": "packages/edit-navigation"
+	},
+	"bugs": {
+		"url": "https://github.com/WordPress/gutenberg/issues"
+	},
+	"main": "build/index.js",
+	"module": "build-module/index.js",
+	"react-native": "src/index",
+	"dependencies": {
+		"@babel/runtime": "^7.8.3",
+		"@wordpress/block-editor": "file:../block-editor",
+		"@wordpress/block-library": "file:../block-library",
+		"@wordpress/blocks": "file:../blocks",
+		"@wordpress/components": "file:../components",
+		"@wordpress/compose": "file:../compose",
+		"@wordpress/data": "file:../data",
+		"@wordpress/data-controls": "file:../data-controls",
+		"@wordpress/dom-ready": "file:../dom-ready",
+		"@wordpress/element": "file:../element",
+		"@wordpress/hooks": "file:../hooks",
+		"@wordpress/i18n": "file:../i18n",
+		"@wordpress/media-utils": "file:../media-utils",
+		"@wordpress/notices": "file:../notices",
+		"lodash": "^4.17.15",
+		"rememo": "^3.0.0"
+	},
+	"publishConfig": {
+		"access": "public"
+	}
+}

--- a/packages/edit-navigation/src/components/layout/index.js
+++ b/packages/edit-navigation/src/components/layout/index.js
@@ -1,0 +1,60 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	DropZoneProvider,
+	FocusReturnProvider,
+	Popover,
+	SlotFillProvider,
+	TabPanel,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import MenusEditor from '../menus-editor';
+import MenuLocationsEditor from '../menu-locations-editor';
+
+export default function Layout( { blockEditorSettings } ) {
+	return (
+		<>
+			<SlotFillProvider>
+				<DropZoneProvider>
+					<FocusReturnProvider>
+						{ /* <Notices /> */ }
+						<Popover.Slot name="block-toolbar" />
+						<TabPanel
+							tabs={ [
+								{
+									name: 'menus',
+									title: __( 'Edit Navigation' ),
+								},
+								{
+									name: 'menu-locations',
+									title: __( 'Manage Locations' ),
+								},
+							] }
+						>
+							{ ( tab ) => (
+								<>
+									{ tab.name === 'menus' && (
+										<MenusEditor
+											blockEditorSettings={
+												blockEditorSettings
+											}
+										/>
+									) }
+									{ tab.name === 'menu-locations' && (
+										<MenuLocationsEditor />
+									) }
+								</>
+							) }
+						</TabPanel>
+						<Popover.Slot />
+					</FocusReturnProvider>
+				</DropZoneProvider>
+			</SlotFillProvider>
+		</>
+	);
+}

--- a/packages/edit-navigation/src/components/menu-editor/index.js
+++ b/packages/edit-navigation/src/components/menu-editor/index.js
@@ -21,7 +21,7 @@ export default function MenuEditor( { menuId, blockEditorSettings } ) {
 	const [ blocks, setBlocks, saveBlocks ] = useNavigationBlocks( menuId );
 
 	return (
-		<div style={ { border: '1px solid black', padding: 10 } }>
+		<div className="edit-navigation-menu-editor">
 			<BlockEditorKeyboardShortcuts.Register />
 			<Button isPrimary onClick={ saveBlocks }>
 				{ __( 'Save' ) }
@@ -35,7 +35,7 @@ export default function MenuEditor( { menuId, blockEditorSettings } ) {
 					templateLock: 'all',
 				} }
 			>
-				<div style={ { border: '1px solid black', padding: 10 } }>
+				<div className="edit-navigation-menu-editor__panel">
 					{ !! blocks.length && (
 						<__experimentalBlockNavigationList
 							blocks={ blocks }
@@ -46,7 +46,7 @@ export default function MenuEditor( { menuId, blockEditorSettings } ) {
 						/>
 					) }
 				</div>
-				<div style={ { border: '1px solid black', padding: 10 } }>
+				<div className="edit-navigation-menu-editor__panel">
 					<WritingFlow>
 						<ObserveTyping>
 							<BlockList />

--- a/packages/edit-navigation/src/components/menu-editor/index.js
+++ b/packages/edit-navigation/src/components/menu-editor/index.js
@@ -1,0 +1,59 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	BlockEditorKeyboardShortcuts,
+	BlockEditorProvider,
+	BlockList,
+	ObserveTyping,
+	WritingFlow,
+	__experimentalBlockNavigationList,
+} from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import useNavigationBlocks from './use-navigation-blocks';
+
+export default function MenuEditor( { menuId, blockEditorSettings } ) {
+	const [ blocks, setBlocks, saveBlocks ] = useNavigationBlocks( menuId );
+
+	return (
+		<div style={ { border: '1px solid black', padding: 10 } }>
+			<BlockEditorKeyboardShortcuts.Register />
+			<Button isPrimary onClick={ saveBlocks }>
+				{ __( 'Save' ) }
+			</Button>
+			<BlockEditorProvider
+				value={ blocks }
+				onInput={ ( updatedBlocks ) => setBlocks( updatedBlocks ) }
+				onChange={ ( updatedBlocks ) => setBlocks( updatedBlocks ) }
+				settings={ {
+					...blockEditorSettings,
+					templateLock: 'all',
+				} }
+			>
+				<div style={ { border: '1px solid black', padding: 10 } }>
+					{ !! blocks.length && (
+						<__experimentalBlockNavigationList
+							blocks={ blocks }
+							selectedBlockClientId={ blocks[ 0 ].clientId }
+							selectBlock={ () => {} }
+							showNestedBlocks
+							showAppender
+						/>
+					) }
+				</div>
+				<div style={ { border: '1px solid black', padding: 10 } }>
+					<WritingFlow>
+						<ObserveTyping>
+							<BlockList />
+						</ObserveTyping>
+					</WritingFlow>
+				</div>
+			</BlockEditorProvider>
+		</div>
+	);
+}

--- a/packages/edit-navigation/src/components/menu-editor/style.scss
+++ b/packages/edit-navigation/src/components/menu-editor/style.scss
@@ -1,0 +1,8 @@
+.edit-navigation-menu-editor {
+	border: 1px solid #000;
+}
+
+.edit-navigation-menu-editor__panel {
+	border: 1px solid #000;
+	padding: 10px;
+}

--- a/packages/edit-navigation/src/components/menu-editor/use-navigation-blocks.js
+++ b/packages/edit-navigation/src/components/menu-editor/use-navigation-blocks.js
@@ -61,7 +61,6 @@ export default function useNavigationBlocks( menuId ) {
 			const menuItem = menuItemsRef.current[ block.clientId ];
 
 			if ( ! menuItem ) {
-				console.log( 'CREATE MENU ITEM' );
 				saveMenuItem( {
 					...createMenuItemAttributesFromBlock( block ),
 					menus: menuId,
@@ -75,7 +74,6 @@ export default function useNavigationBlocks( menuId ) {
 					createBlockFromMenuItem( menuItem ).attributes
 				)
 			) {
-				console.log( 'UPDATE MENU ITEM', menuItem.id );
 				saveMenuItem( {
 					...menuItem,
 					...createMenuItemAttributesFromBlock( block ),
@@ -89,12 +87,10 @@ export default function useNavigationBlocks( menuId ) {
 			innerBlocks.map( ( block ) => block.clientId )
 		);
 
+		// Disable reason, this code will eventually be implemented.
+		// eslint-disable-next-line no-unused-vars
 		for ( const clientId of deletedClientIds ) {
-			console.log(
-				'DELETE MENU ITEM',
-				menuItemsRef.current[ clientId ].id
-			);
-			// Hm, don't think we have a deleteEntityRecord() action?
+			// TODO - delete menu items.
 		}
 	};
 

--- a/packages/edit-navigation/src/components/menu-editor/use-navigation-blocks.js
+++ b/packages/edit-navigation/src/components/menu-editor/use-navigation-blocks.js
@@ -1,0 +1,102 @@
+/**
+ * External dependencies
+ */
+import { isEqual, difference } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { createBlock } from '@wordpress/blocks';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { useState, useRef, useEffect } from '@wordpress/element';
+
+function createBlockFromMenuItem( menuItem ) {
+	return createBlock( 'core/navigation-link', {
+		label: menuItem.title.raw,
+		url: menuItem.url,
+	} );
+}
+
+function createMenuItemAttributesFromBlock( block ) {
+	return {
+		title: block.attributes.label,
+		url: block.attributes.url,
+	};
+}
+
+export default function useNavigationBlocks( menuId ) {
+	const menuItems = useSelect(
+		( select ) => select( 'core' ).getMenuItems( { menus: menuId } ),
+		[ menuId ]
+	);
+
+	const { saveMenuItem } = useDispatch( 'core' );
+
+	const [ blocks, setBlocks ] = useState( [] );
+
+	const menuItemsRef = useRef( {} );
+
+	useEffect( () => {
+		if ( ! menuItems ) {
+			return;
+		}
+
+		menuItemsRef.current = {};
+
+		const innerBlocks = [];
+
+		for ( const menuItem of menuItems ) {
+			const block = createBlockFromMenuItem( menuItem );
+			menuItemsRef.current[ block.clientId ] = menuItem;
+			innerBlocks.push( block );
+		}
+
+		setBlocks( [ createBlock( 'core/navigation', {}, innerBlocks ) ] );
+	}, [ menuItems ] );
+
+	const saveBlocks = () => {
+		const { innerBlocks } = blocks[ 0 ];
+
+		for ( const block of innerBlocks ) {
+			const menuItem = menuItemsRef.current[ block.clientId ];
+
+			if ( ! menuItem ) {
+				console.log( 'CREATE MENU ITEM' );
+				saveMenuItem( {
+					...createMenuItemAttributesFromBlock( block ),
+					menus: menuId,
+				} );
+				continue;
+			}
+
+			if (
+				! isEqual(
+					block.attributes,
+					createBlockFromMenuItem( menuItem ).attributes
+				)
+			) {
+				console.log( 'UPDATE MENU ITEM', menuItem.id );
+				saveMenuItem( {
+					...menuItem,
+					...createMenuItemAttributesFromBlock( block ),
+					menus: menuId, // Gotta do this because REST API doesn't like receiving an array here. Maybe a bug in the REST API?
+				} );
+			}
+		}
+
+		const deletedClientIds = difference(
+			Object.keys( menuItemsRef.current ),
+			innerBlocks.map( ( block ) => block.clientId )
+		);
+
+		for ( const clientId of deletedClientIds ) {
+			console.log(
+				'DELETE MENU ITEM',
+				menuItemsRef.current[ clientId ].id
+			);
+			// Hm, don't think we have a deleteEntityRecord() action?
+		}
+	};
+
+	return [ blocks, setBlocks, saveBlocks ];
+}

--- a/packages/edit-navigation/src/components/menu-locations-editor/index.js
+++ b/packages/edit-navigation/src/components/menu-locations-editor/index.js
@@ -1,0 +1,3 @@
+export default function MenuLocationsEditor() {
+	return <>Menu locations editor</>;
+}

--- a/packages/edit-navigation/src/components/menus-editor/index.js
+++ b/packages/edit-navigation/src/components/menus-editor/index.js
@@ -1,0 +1,47 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { useState, useEffect } from '@wordpress/element';
+import { Spinner, SelectControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import MenuEditor from '../menu-editor';
+
+export default function MenusEditor( { blockEditorSettings } ) {
+	const menus = useSelect( ( select ) => select( 'core' ).getMenus() );
+
+	const [ menuId, setMenuId ] = useState( 0 );
+
+	useEffect( () => {
+		if ( menus?.length ) {
+			setMenuId( menus[ 0 ].id );
+		}
+	}, [ menus ] );
+
+	if ( ! menus ) {
+		return <Spinner />;
+	}
+
+	return (
+		<>
+			<SelectControl
+				label={ __( 'Select navigation to edit:' ) }
+				options={ menus.map( ( menu ) => ( {
+					value: menu.id,
+					label: menu.name,
+				} ) ) }
+				onChange={ ( selectedMenuId ) => setMenuId( selectedMenuId ) }
+			/>
+			{ !! menuId && (
+				<MenuEditor
+					menuId={ menuId }
+					blockEditorSettings={ blockEditorSettings }
+				/>
+			) }
+		</>
+	);
+}

--- a/packages/edit-navigation/src/index.js
+++ b/packages/edit-navigation/src/index.js
@@ -1,0 +1,24 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	registerCoreBlocks,
+	__experimentalRegisterExperimentalCoreBlocks,
+} from '@wordpress/block-library';
+import { render } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import Layout from './components/layout';
+
+export function initialize( id, settings ) {
+	registerCoreBlocks();
+	if ( process.env.GUTENBERG_PHASE === 2 ) {
+		__experimentalRegisterExperimentalCoreBlocks( settings );
+	}
+	render(
+		<Layout blockEditorSettings={ settings } />,
+		document.getElementById( id )
+	);
+}

--- a/packages/edit-navigation/src/style.scss
+++ b/packages/edit-navigation/src/style.scss
@@ -1,0 +1,1 @@
+@import "./components/menu-editor/style.scss";


### PR DESCRIPTION
_Very_ rough first pass at implementing https://github.com/WordPress/gutenberg/issues/19170.

![navigation](https://user-images.githubusercontent.com/612155/77140133-bd4c7a80-6acc-11ea-882f-79cad080b8b1.gif)

Adds a new Navigation screen, a new edit-navigation package, and a very rough UI for editing menus using the Navigation block.

The key functionality is in `useNavigationBlocks` — this is a hook which turns menu items from the REST API into blocks, and blocks into CRUD requests. I haven't tested it very thoroughly but I think it's a pretty viable way of implementing this screen.

The Navigation block is displayed on the page by rendering a `@wordpress/block-editor` `BlockList` with `templateLock: 'all`'. This also works pretty well. I tried rendering just the `BlockEdit` component but couldn't get it working.

I decided to build an entirely new screen. I did think about a different approach where we swap out `#nav-menus-frame` in the existing `nav-menus.php` page with a React app, but there's a few drawbacks to doing this: 1) We can't have both screens at once in the plugin; 2) We can't implement an "opt out" plugin similar to the Classic Editor plugin; 3) We would have to add a hook to `nav-menus.php` in Core to do this; 4) We can't use `wp.data` and have to do a lot of painful syncing between jQuery and React.

**Tasks remaining:**

- [ ] Allow menus to be created and deleted.
- [ ] Allow menu items to be deleted.
- [ ] Implement Manage Locations tab.
- [ ] Make UI look like the mockup in https://github.com/WordPress/gutenberg/issues/19170.
- [ ] Add unit tests for `useNavigationBlocks`.
- [ ] Add a `README.md` to the package.

cc. @talldan @draganescu @tellthemachines @adamziel 