### PR TITLE
Update the heading block to use the colors hook

### DIFF
--- a/packages/block-library/src/columns/deprecated.js
+++ b/packages/block-library/src/columns/deprecated.js
@@ -50,7 +50,7 @@ const migrateCustomColors = ( attributes ) => {
 		style.color.background = attributes.customBackgroundColor;
 	}
 	return {
-		...attributes,
+		...omit( attributes, [ 'customTextColor', 'customBackgroundColor' ] ),
 		style,
 	};
 };

--- a/packages/block-library/src/group/deprecated.js
+++ b/packages/block-library/src/group/deprecated.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
+import { omit } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -20,7 +21,7 @@ const migrateCustomColors = ( attributes ) => {
 		style.color.background = attributes.customBackgroundColor;
 	}
 	return {
-		...attributes,
+		...omit( attributes, [ 'customTextColor', 'customBackgroundColor' ] ),
 		style,
 	};
 };

--- a/packages/block-library/src/heading/block.json
+++ b/packages/block-library/src/heading/block.json
@@ -17,12 +17,6 @@
 		},
 		"placeholder": {
 			"type": "string"
-		},
-		"textColor": {
-			"type": "string"
-		},
-		"customTextColor": {
-			"type": "string"
 		}
 	}
 }

--- a/packages/block-library/src/heading/deprecated.js
+++ b/packages/block-library/src/heading/deprecated.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
+import { omit } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -42,7 +43,7 @@ const migrateCustomColors = ( attributes ) => {
 		},
 	};
 	return {
-		...attributes,
+		...omit( attributes, [ 'customTextColor' ] ),
 		style,
 	};
 };

--- a/packages/block-library/src/heading/deprecated.js
+++ b/packages/block-library/src/heading/deprecated.js
@@ -30,17 +30,77 @@ const blockAttributes = {
 	placeholder: {
 		type: 'string',
 	},
-	textColor: {
-		type: 'string',
-	},
-	customTextColor: {
-		type: 'string',
-	},
+};
+
+const migrateCustomColors = ( attributes ) => {
+	if ( ! attributes.customTextColor ) {
+		return attributes;
+	}
+	const style = {
+		color: {
+			text: attributes.customTextColor,
+		},
+	};
+	return {
+		...attributes,
+		style,
+	};
 };
 
 const deprecated = [
 	{
-		attributes: blockAttributes,
+		supports: blockSupports,
+		attributes: {
+			...blockAttributes,
+			customTextColor: {
+				type: 'string',
+			},
+			textColor: {
+				type: 'string',
+			},
+		},
+		migrate: migrateCustomColors,
+		save( { attributes } ) {
+			const {
+				align,
+				content,
+				customTextColor,
+				level,
+				textColor,
+			} = attributes;
+			const tagName = 'h' + level;
+
+			const textClass = getColorClassName( 'color', textColor );
+
+			const className = classnames( {
+				[ textClass ]: textClass,
+				'has-text-color': textColor || customTextColor,
+				[ `has-text-align-${ align }` ]: align,
+			} );
+
+			return (
+				<RichText.Content
+					className={ className ? className : undefined }
+					tagName={ tagName }
+					style={ {
+						color: textClass ? undefined : customTextColor,
+					} }
+					value={ content }
+				/>
+			);
+		},
+	},
+	{
+		attributes: {
+			...blockAttributes,
+			customTextColor: {
+				type: 'string',
+			},
+			textColor: {
+				type: 'string',
+			},
+		},
+		migrate: migrateCustomColors,
 		save( { attributes } ) {
 			const {
 				align,
@@ -73,7 +133,16 @@ const deprecated = [
 	},
 	{
 		supports: blockSupports,
-		attributes: blockAttributes,
+		attributes: {
+			...blockAttributes,
+			customTextColor: {
+				type: 'string',
+			},
+			textColor: {
+				type: 'string',
+			},
+		},
+		migrate: migrateCustomColors,
 		save( { attributes } ) {
 			const {
 				align,

--- a/packages/block-library/src/heading/edit.js
+++ b/packages/block-library/src/heading/edit.js
@@ -19,22 +19,11 @@ import {
 	BlockControls,
 	InspectorControls,
 	RichText,
-	__experimentalUseColors,
 	__experimentalBlock as Block,
 } from '@wordpress/block-editor';
-import { useRef, Platform } from '@wordpress/element';
+import { Platform } from '@wordpress/element';
 
 function HeadingEdit( { attributes, setAttributes, mergeBlocks, onReplace } ) {
-	const ref = useRef();
-	const { TextColor, InspectorControlsColorPanel } = __experimentalUseColors(
-		[ { name: 'textColor', property: 'color' } ],
-		{
-			contrastCheckers: { backgroundColor: true, textColor: true },
-			colorDetector: { targetRef: ref },
-		},
-		[]
-	);
-
 	const { align, content, level, placeholder } = attributes;
 	const tagName = 'h' + level;
 
@@ -72,36 +61,30 @@ function HeadingEdit( { attributes, setAttributes, mergeBlocks, onReplace } ) {
 					</PanelBody>
 				</InspectorControls>
 			) }
-			{ InspectorControlsColorPanel }
-			<TextColor>
-				<RichText
-					ref={ ref }
-					identifier="content"
-					tagName={ Block[ tagName ] }
-					value={ content }
-					onChange={ ( value ) =>
-						setAttributes( { content: value } )
+			<RichText
+				identifier="content"
+				tagName={ Block[ tagName ] }
+				value={ content }
+				onChange={ ( value ) => setAttributes( { content: value } ) }
+				onMerge={ mergeBlocks }
+				onSplit={ ( value ) => {
+					if ( ! value ) {
+						return createBlock( 'core/paragraph' );
 					}
-					onMerge={ mergeBlocks }
-					onSplit={ ( value ) => {
-						if ( ! value ) {
-							return createBlock( 'core/paragraph' );
-						}
 
-						return createBlock( 'core/heading', {
-							...attributes,
-							content: value,
-						} );
-					} }
-					onReplace={ onReplace }
-					onRemove={ () => onReplace( [] ) }
-					className={ classnames( {
-						[ `has-text-align-${ align }` ]: align,
-					} ) }
-					placeholder={ placeholder || __( 'Write heading…' ) }
-					textAlign={ align }
-				/>
-			</TextColor>
+					return createBlock( 'core/heading', {
+						...attributes,
+						content: value,
+					} );
+				} }
+				onReplace={ onReplace }
+				onRemove={ () => onReplace( [] ) }
+				className={ classnames( {
+					[ `has-text-align-${ align }` ]: align,
+				} ) }
+				placeholder={ placeholder || __( 'Write heading…' ) }
+				textAlign={ align }
+			/>
 		</>
 	);
 }

--- a/packages/block-library/src/heading/index.js
+++ b/packages/block-library/src/heading/index.js
@@ -34,6 +34,7 @@ export const settings = {
 		anchor: true,
 		__unstablePasteTextInline: true,
 		lightBlockWrapper: true,
+		__experimentalColor: true,
 	},
 	example: {
 		attributes: {

--- a/packages/block-library/src/heading/save.js
+++ b/packages/block-library/src/heading/save.js
@@ -6,17 +6,13 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { getColorClassName, RichText } from '@wordpress/block-editor';
+import { RichText } from '@wordpress/block-editor';
 
 export default function save( { attributes } ) {
-	const { align, content, customTextColor, level, textColor } = attributes;
+	const { align, content, level } = attributes;
 	const tagName = 'h' + level;
 
-	const textClass = getColorClassName( 'color', textColor );
-
 	const className = classnames( {
-		[ textClass ]: textClass,
-		'has-text-color': textColor || customTextColor,
 		[ `has-text-align-${ align }` ]: align,
 	} );
 
@@ -24,9 +20,6 @@ export default function save( { attributes } ) {
 		<RichText.Content
 			className={ className ? className : undefined }
 			tagName={ tagName }
-			style={ {
-				color: textClass ? undefined : customTextColor,
-			} }
 			value={ content }
 		/>
 	);

--- a/packages/block-library/src/heading/style.scss
+++ b/packages/block-library/src/heading/style.scss
@@ -1,0 +1,13 @@
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+	background-color: var(--wp--color--background);
+	color: var(--wp--color--text);
+
+	&.has-background {
+		padding: $block-bg-padding--v $block-bg-padding--h;
+	}
+}

--- a/packages/block-library/src/paragraph/deprecated.js
+++ b/packages/block-library/src/paragraph/deprecated.js
@@ -68,7 +68,7 @@ const migrateCustomColors = ( attributes ) => {
 		style.color.background = attributes.customBackgroundColor;
 	}
 	return {
-		...attributes,
+		...omit( attributes, [ 'customTextColor', 'customBackgroundColor' ] ),
 		style,
 	};
 };

--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -14,6 +14,7 @@
 @import "./file/style.scss";
 @import "./gallery/style.scss";
 @import "./group/style.scss";
+@import "./heading/style.scss";
 @import "./image/style.scss";
 @import "./latest-comments/style.scss";
 @import "./latest-posts/style.scss";

--- a/packages/e2e-tests/fixtures/blocks/core__heading__deprecated-3.json
+++ b/packages/e2e-tests/fixtures/blocks/core__heading__deprecated-3.json
@@ -6,7 +6,11 @@
         "attributes": {
             "content": "Text",
             "level": 2,
-            "customTextColor": "#268ebb"
+            "style": {
+				"color": {
+					"text": "#268ebb"
+				}
+			}
         },
         "innerBlocks": [],
         "originalContent": "<h2 style=\"color:#268ebb\">Text</h2>"

--- a/packages/e2e-tests/fixtures/blocks/core__heading__deprecated-3.serialized.html
+++ b/packages/e2e-tests/fixtures/blocks/core__heading__deprecated-3.serialized.html
@@ -1,3 +1,3 @@
-<!-- wp:heading {"customTextColor":"#268ebb"} -->
-<h2 class="has-text-color" style="color:#268ebb">Text</h2>
+<!-- wp:heading {"style":{"color":{"text":"#268ebb"}}} -->
+<h2 class="has-text-color" style="--wp--color--text:#268ebb">Text</h2>
 <!-- /wp:heading -->

--- a/packages/e2e-tests/specs/editor/blocks/__snapshots__/heading.test.js.snap
+++ b/packages/e2e-tests/specs/editor/blocks/__snapshots__/heading.test.js.snap
@@ -13,8 +13,8 @@ exports[`Heading can be created by prefixing number sign and a space 1`] = `
 `;
 
 exports[`Heading it should correctly apply custom colors 1`] = `
-"<!-- wp:heading {\\"level\\":3,\\"customTextColor\\":\\"#7700ff\\"} -->
-<h3 class=\\"has-text-color\\" style=\\"color:#7700ff\\">Heading</h3>
+"<!-- wp:heading {\\"level\\":3,\\"style\\":{\\"color\\":{\\"text\\":\\"#7700ff\\"}}} -->
+<h3 class=\\"has-text-color\\" style=\\"--wp--color--text:#7700ff\\">Heading</h3>
 <!-- /wp:heading -->"
 `;
 


### PR DESCRIPTION
Based on #21021 to try test the API on different blocks (heading for this PR)

It also adds background color support to the heading block. At the moment there's no way to choose just text color, but it's easy to implement if needed. I just thought being consistent with other blocks is a good thing.