### PR TITLE
Fix embedded blocks when converted to reusable blocks

### DIFF
--- a/lib/compat.php
+++ b/lib/compat.php
@@ -133,11 +133,9 @@ function gutenberg_get_post_from_context() {
  */
 function gutenberg_reorder_content_filters() {
 	global $wp_embed;
-	remove_filter( 'the_content', array( $wp_embed, 'run_shortcode' ), 8 );
 	remove_filter( 'the_content', array( $wp_embed, 'autoembed' ), 8 );
 	remove_filter( 'the_content', 'do_blocks', 9 );
 	add_filter( 'the_content', 'do_blocks', 8 );
-	add_filter( 'the_content', array( $wp_embed, 'run_shortcode' ), 9 );
 	add_filter( 'the_content', array( $wp_embed, 'autoembed' ), 9 );
 }
 add_action( 'init', 'gutenberg_reorder_content_filters' );

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -125,3 +125,19 @@ function gutenberg_get_post_from_context() {
 	}
 	return get_post();
 }
+
+/**
+ * Reorders the priority on the_content filters for blocks and autoembeds
+ *
+ * See: https://core.trac.wordpress.org/ticket/46457
+ */
+function gutenberg_reorder_content_filters() {
+	global $wp_embed;
+	remove_filter( 'the_content', array( $wp_embed, 'run_shortcode' ), 8 );
+	remove_filter( 'the_content', array( $wp_embed, 'autoembed' ), 8 );
+	remove_filter( 'the_content', 'do_blocks', 9 );
+	add_filter( 'the_content', 'do_blocks', 8 );
+	add_filter( 'the_content', array( $wp_embed, 'run_shortcode' ), 9 );
+	add_filter( 'the_content', array( $wp_embed, 'autoembed' ), 9 );
+}
+add_action( 'init', 'gutenberg_reorder_content_filters' );

--- a/packages/e2e-tests/specs/editor/various/manage-reusable-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/manage-reusable-blocks.test.js
@@ -21,7 +21,8 @@ describe( 'Managing reusable blocks', () => {
 				document
 					.querySelector( '.all .count' )
 					.textContent.replace( '(', '' )
-					.replace( ')', '' )
+					.replace( ')', '' ),
+				10
 			)
 		);
 	}

--- a/packages/e2e-tests/specs/editor/various/manage-reusable-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/manage-reusable-blocks.test.js
@@ -16,8 +16,13 @@ describe( 'Managing reusable blocks', () => {
 	 * @return {Promise} Promise resolving to number of post list entries.
 	 */
 	async function getNumberOfEntries() {
-		return page.evaluate(
-			() => document.querySelectorAll( '.hentry' ).length
+		return page.evaluate( () =>
+			parseInt(
+				document
+					.querySelector( '.all .count' )
+					.textContent.replace( '(', '' )
+					.replace( ')', '' )
+			)
 		);
 	}
 

--- a/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
@@ -295,7 +295,10 @@ describe( 'Reusable blocks', () => {
 		await page.keyboard.type( 'Hello there!' );
 		await publishPost();
 		await page.waitForSelector( '#inspector-text-control-0' );
-		const postUrl = await page.$eval( '#inspector-text-control-0', ( el ) => el.value );
+		const postUrl = await page.$eval(
+			'#inspector-text-control-0',
+			( el ) => el.value
+		);
 		await createNewPost();
 		await clickBlockAppender();
 		await page.keyboard.type( '/WordPress' );
@@ -303,19 +306,17 @@ describe( 'Reusable blocks', () => {
 		await page.keyboard.type( postUrl );
 		await page.keyboard.press( 'Enter' );
 
-		// Navigate to the WordPress block.
-		await page.click( '[aria-label="Block Navigation"]' );
-		const blockMenuItem = ( await page.$x( "//button[contains(@class,'block-editor-block-navigation__item') and contains(text(), 'WordPress')]" ) )[ 0 ];
-		await blockMenuItem.click();
 		await clickBlockToolbarButton( 'More options' );
 
 		// Convert it to a reusable block.
-		const convertButton = await page.waitForXPath( '//button[text()="Add to Reusable Blocks"]' );
+		const convertButton = await page.waitForXPath(
+			'//button[text()="Add to Reusable blocks"]'
+		);
 		await convertButton.click();
 
 		// Wait for creation to finish.
 		await page.waitForXPath(
-			'//*[contains(@class, "components-notice") and contains(@class, "is-success")]/*[text()="Block created."]'
+			'//*[contains(@class, "components-snackbar")]/*[text()="Block created."]'
 		);
 
 		// Save the reusable block
@@ -326,11 +327,17 @@ describe( 'Reusable blocks', () => {
 		await page.waitForXPath( '//button[text()="Edit"]' );
 
 		// Check that we have a reusable block on the page.
-		const block = await page.$( '.block-editor-block-list__block[data-type="core/block"]' );
+		const block = await page.$(
+			'.block-editor-block-list__block[data-type="core/block"]'
+		);
 		expect( block ).not.toBeNull();
+
 		await publishPost();
 		await page.waitForSelector( '#inspector-text-control-0' );
-		const postWithEmbedUrl = await page.$eval( '#inspector-text-control-0', ( el ) => el.value );
+		const postWithEmbedUrl = await page.$eval(
+			'#inspector-text-control-0',
+			( el ) => el.value
+		);
 
 		// Check the embed shows up on the front end of the site.
 		await page.goto( postWithEmbedUrl );

--- a/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
@@ -8,6 +8,8 @@ import {
 	pressKeyWithModifier,
 	searchForBlock,
 	getEditedPostContent,
+	publishPost,
+	clickBlockAppender,
 } from '@wordpress/e2e-test-utils';
 
 function waitForAndAcceptDialog() {
@@ -283,5 +285,55 @@ describe( 'Reusable blocks', () => {
 
 		// Check that we have two paragraph blocks on the page
 		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'can save and render embed blocks as reusable blocks', async () => {
+		await createNewPost();
+
+		// Create a post we can use to test embedding.
+		await insertBlock( 'Paragraph' );
+		await page.keyboard.type( 'Hello there!' );
+		await publishPost();
+		await page.waitForSelector( '#inspector-text-control-0' );
+		const postUrl = await page.$eval( '#inspector-text-control-0', ( el ) => el.value );
+		await createNewPost();
+		await clickBlockAppender();
+		await page.keyboard.type( '/WordPress' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( postUrl );
+		await page.keyboard.press( 'Enter' );
+
+		// Navigate to the WordPress block.
+		await page.click( '[aria-label="Block Navigation"]' );
+		const blockMenuItem = ( await page.$x( "//button[contains(@class,'block-editor-block-navigation__item') and contains(text(), 'WordPress')]" ) )[ 0 ];
+		await blockMenuItem.click();
+		await clickBlockToolbarButton( 'More options' );
+
+		// Convert it to a reusable block.
+		const convertButton = await page.waitForXPath( '//button[text()="Add to Reusable Blocks"]' );
+		await convertButton.click();
+
+		// Wait for creation to finish.
+		await page.waitForXPath(
+			'//*[contains(@class, "components-notice") and contains(@class, "is-success")]/*[text()="Block created."]'
+		);
+
+		// Save the reusable block
+		const [ saveButton ] = await page.$x( '//button[text()="Save"]' );
+		await saveButton.click();
+
+		// Wait for saving to finish
+		await page.waitForXPath( '//button[text()="Edit"]' );
+
+		// Check that we have a reusable block on the page.
+		const block = await page.$( '.block-editor-block-list__block[data-type="core/block"]' );
+		expect( block ).not.toBeNull();
+		await publishPost();
+		await page.waitForSelector( '#inspector-text-control-0' );
+		const postWithEmbedUrl = await page.$eval( '#inspector-text-control-0', ( el ) => el.value );
+
+		// Check the embed shows up on the front end of the site.
+		await page.goto( postWithEmbedUrl );
+		await page.waitForSelector( '.wp-embedded-content' );
 	} );
 } );


### PR DESCRIPTION
This PR fixes the issue of embed blocks not displaying on the front-end after being converted to reusable blocks. 

#14663 added a test for this, but that PR had become stale. This PR updates that new test to support the UI changes that have occurred since it was written. It also reorders `the_content` filters, which fixes the issue and gets that new test to pass. This would fix #18098, and close #14608. 

It feels _**very**_ risky to mess with the filter order because it is so brittle. I've run all the tests for this on core and in Gutenberg, as well as done some manual testing and it appears to work and resolve the issue. 

We'd probably want to commit the core change early in release cycle to try to catch any issues. 

Related Trac ticket: https://core.trac.wordpress.org/ticket/46457

Pull request that shows core tests passing: https://github.com/WordPress/wordpress-develop/pull/192
