### PR TITLE
Popovers: Update border colors to follow the G2 block UI

### DIFF
--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -137,7 +137,7 @@ $block-inserter-search-height: 38px;
 
 .block-editor-inserter__menu-help-panel {
 	display: none;
-	border: $border-width solid $light-gray-secondary;
+	border: $border-width solid $dark-gray-primary;
 	width: 300px;
 	margin-right: 20px;
 	padding: 20px;

--- a/packages/block-editor/src/components/tool-selector/style.scss
+++ b/packages/block-editor/src/components/tool-selector/style.scss
@@ -4,6 +4,6 @@
 	margin-right: -$grid-unit-15;
 	margin-bottom: -$grid-unit-15;
 	padding: $grid-unit-15 ($grid-unit-15 + $grid-unit-10);
-	border-top: 1px solid $light-gray-500;
+	border-top: 1px solid $dark-gray-primary;
 	color: $dark-gray-300;
 }

--- a/packages/components/src/dropdown-menu/style.scss
+++ b/packages/components/src/dropdown-menu/style.scss
@@ -26,7 +26,7 @@
 			display: block;
 			content: "";
 			box-sizing: content-box;
-			background-color: $light-gray-500;
+			background-color: $dark-gray-primary;
 			position: absolute;
 			top: -3px;
 			left: 0;
@@ -81,7 +81,7 @@
 
 	.components-menu-group + .components-menu-group {
 		margin-top: 0;
-		border-top: $border-width solid $light-gray-secondary;
+		border-top: $border-width solid $dark-gray-primary;
 		padding: $grid-unit-15;
 	}
 }

--- a/packages/components/src/popover/style.scss
+++ b/packages/components/src/popover/style.scss
@@ -143,9 +143,10 @@ $arrow-size: 8px;
 }
 
 .components-popover__content {
+	margin: 6px;
 	height: 100%;
 	background: $white;
-	border: $border-width solid $light-gray-secondary;
+	border: $border-width solid $dark-gray-primary;
 	box-shadow: $shadow-popover;
 	border-radius: $radius-block-ui;
 

--- a/packages/edit-post/src/components/preview-options/style.scss
+++ b/packages/edit-post/src/components/preview-options/style.scss
@@ -33,7 +33,6 @@
 	}
 
 	.components-menu-group + .components-menu-group {
-		border-top: $border-width solid $light-gray-secondary;
 		padding: $grid-unit-10 $grid-unit-15;
 		margin-left: -$grid-unit-15;
 		margin-right: -$grid-unit-15;


### PR DESCRIPTION
This PR updates the border color for the `Popover` and `Menu` components to fit in better with the new G2 block UI. Here's how the borders look in `master`:

<img width="699" alt="image" src="https://user-images.githubusercontent.com/191598/77179631-1b626900-6a9f-11ea-9d83-2b4550269914.png">

And here's how they look in this PR:

<img width="696" alt="image" src="https://user-images.githubusercontent.com/191598/77179756-46e55380-6a9f-11ea-8505-5f0a989ff256.png">
