### PR TITLE
fixes #21018 : block preview throws error / fails

### DIFF
--- a/packages/block-editor/src/utils/dom.js
+++ b/packages/block-editor/src/utils/dom.js
@@ -19,7 +19,9 @@ export function getBlockPreviewContainerDOMNode( clientId ) {
 		return;
 	}
 
-	return domNode.firstChild || domNode;
+	return [ domNode.firstChild, domNode ].find(
+		( node ) => node && node.getBoundingClientRect
+	);
 }
 
 /**


### PR DESCRIPTION
This PR fixes #21018 - Block preview fails in Gutenberg for all block types containing just text like 

* core/paragraph
* core/heading  

For the same reason block styles for core/paragraph and core/heading will not get rendered in the Sidebar inspector panel.

The main reason is that in function `ScaledBlockPreview` (`packages/block-editor/src/components/block-preview/scaled.js`) previewElement is expected to be a Element (having method `getBoundingClientRect`) but the called method `getBlockPreviewContainerDOMNode(block.clientId)` will return a Text Node instead of an Element for 'core/paragraph' and 'core/heading'.  And Text Node does'nt provide method 'getBoundingClientRect'.

**Screenshots**

![bug](https://user-images.githubusercontent.com/81591/77074592-56a65e80-69f1-11ea-83f0-2accbc5cfb2b.jpg)

## How has this been tested?

The change ensures that the returned node is a DOM element node (not a DOM text node or anything else ...) having method getBoundingClientRect.

Since the changed function `getBlockPreviewContainerDOMNode` is only used once within a single source file (ScaledBlockPreview.js) its a side effect free change

