### PR TITLE
[Navigation] Makes URL dynamic for pages and posts

### DIFF
--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -273,7 +273,6 @@ function LinkControl( {
 
 				return Promise.resolve( [
 					{
-						id: val,
 						title: val,
 						url: type === 'URL' ? prependHTTP( val ) : val,
 						type,

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -158,6 +158,7 @@ const makeCancelable = ( promise ) => {
 function LinkControl( {
 	searchInputPlaceholder,
 	value,
+	id,
 	settings,
 	onChange = noop,
 	noDirectEntry = false,
@@ -177,7 +178,7 @@ function LinkControl( {
 	const [ isEditingLink, setIsEditingLink ] = useState(
 		forceIsEditingLink !== undefined
 			? forceIsEditingLink
-			: ! value || ! value.url
+			: ! value || ( ! value.url && ! id )
 	);
 	const [ isResolvingLink, setIsResolvingLink ] = useState( false );
 	const [ errorMessage, setErrorMessage ] = useState( null );
@@ -591,19 +592,31 @@ function LinkControl( {
 							}
 						) }
 					>
-						<span className="block-editor-link-control__search-item-header">
-							<ExternalLink
-								className="block-editor-link-control__search-item-title"
-								href={ value.url }
-							>
-								{ ( value && value.title ) || displayURL }
-							</ExternalLink>
-							{ value && value.title && (
-								<span className="block-editor-link-control__search-item-info">
-									{ displayURL }
-								</span>
-							) }
-						</span>
+						{ typeof value.url !== 'undefined' && (
+							<span className="block-editor-link-control__search-item-header">
+								<ExternalLink
+									className="block-editor-link-control__search-item-title"
+									href={ value.url }
+								>
+									{ ( value && value.title ) || displayURL }
+								</ExternalLink>
+								{ value && value.title && (
+									<span className="block-editor-link-control__search-item-info">
+										{ displayURL }
+									</span>
+								) }
+							</span>
+						) }
+
+						{ typeof value.url === 'undefined' && (
+							<span className="block-editor-link-control__search-item-header">
+								{ value && value.title && (
+									<span className="block-editor-link-control__search-item-info">
+										{ value.title }
+									</span>
+								) }
+							</span>
+						) }
 
 						<Button
 							isSecondary

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -158,7 +158,6 @@ const makeCancelable = ( promise ) => {
 function LinkControl( {
 	searchInputPlaceholder,
 	value,
-	id,
 	settings,
 	onChange = noop,
 	noDirectEntry = false,
@@ -178,7 +177,7 @@ function LinkControl( {
 	const [ isEditingLink, setIsEditingLink ] = useState(
 		forceIsEditingLink !== undefined
 			? forceIsEditingLink
-			: ! value || ( ! value.url && ! id )
+			: ! value || ( ! value.url && ! value.id )
 	);
 	const [ isResolvingLink, setIsResolvingLink ] = useState( false );
 	const [ errorMessage, setErrorMessage ] = useState( null );
@@ -608,7 +607,7 @@ function LinkControl( {
 							</span>
 						) }
 
-						{ typeof value.url === 'undefined' && (
+						{ typeof value.id !== 'undefined' && (
 							<span className="block-editor-link-control__search-item-header">
 								{ value && value.title && (
 									<span className="block-editor-link-control__search-item-info">

--- a/packages/block-library/src/navigation-link/block.json
+++ b/packages/block-library/src/navigation-link/block.json
@@ -12,9 +12,6 @@
 			"type": "boolean",
 			"default": false
 		},
-		"type": {
-			"type": "string"
-		},
 		"description": {
 			"type": "string"
 		},

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -261,7 +261,12 @@ function NavigationLinkEdit( {
 									id,
 								} = {} ) =>
 									setAttributes( {
-										url: encodeURI( newURL ),
+										url: ( () => {
+											if ( id ) {
+												return undefined;
+											}
+											return encodeURI( newURL );
+										} )(),
 										label: ( () => {
 											const normalizedTitle = newTitle.replace(
 												/http(s?):\/\//gi,

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -262,9 +262,6 @@ function NavigationLinkEdit( {
 								} = {} ) =>
 									setAttributes( {
 										url: ( () => {
-											if ( id ) {
-												return undefined;
-											}
 											return encodeURI( newURL );
 										} )(),
 										label: ( () => {

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -258,7 +258,6 @@ function NavigationLinkEdit( {
 									title: newTitle = '',
 									url: newURL = '',
 									opensInNewTab: newOpensInNewTab,
-									type,
 									id,
 								} = {} ) =>
 									setAttributes( {
@@ -286,8 +285,7 @@ function NavigationLinkEdit( {
 											return escape( normalizedURL );
 										} )(),
 										opensInNewTab: newOpensInNewTab,
-										type,
-										id,
+										id: id ? Number( id ) : undefined,
 									} )
 								}
 							/>

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -258,6 +258,7 @@ function NavigationLinkEdit( {
 									title: newTitle = '',
 									url: newURL = '',
 									opensInNewTab: newOpensInNewTab,
+									type,
 									id,
 								} = {} ) =>
 									setAttributes( {
@@ -285,6 +286,7 @@ function NavigationLinkEdit( {
 											return escape( normalizedURL );
 										} )(),
 										opensInNewTab: newOpensInNewTab,
+										type,
 										id,
 									} )
 								}

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -63,6 +63,7 @@ function NavigationLinkEdit( {
 	const { label, opensInNewTab, url, id, nofollow, description } = attributes;
 	const link = {
 		url,
+		id,
 		opensInNewTab,
 		title: label,
 	};
@@ -249,7 +250,6 @@ function NavigationLinkEdit( {
 							<LinkControl
 								className="wp-block-navigation-link__inline-link-input"
 								value={ link }
-								id={ id }
 								showInitialSuggestions={ true }
 								createSuggestion={
 									userCanCreatePages

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -263,11 +263,7 @@ function NavigationLinkEdit( {
 									id: newId,
 								} = {} ) =>
 									setAttributes( {
-										url: newId
-											? undefined
-											: ( () => {
-													return encodeURI( newURL );
-											  } )(),
+										url: newId ? undefined : newURL,
 										label: ( () => {
 											const normalizedTitle = newTitle.replace(
 												/http(s?):\/\//gi,

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -60,10 +60,11 @@ function NavigationLinkEdit( {
 	mergeBlocks,
 	onReplace,
 } ) {
-	const { label, opensInNewTab, url, nofollow, description } = attributes;
+	const { label, opensInNewTab, url, id, nofollow, description } = attributes;
 	const link = {
 		url,
 		opensInNewTab,
+		title: label,
 	};
 	const [ isLinkOpen, setIsLinkOpen ] = useState( false );
 	const itemLabelPlaceholder = __( 'Add link…' );
@@ -248,6 +249,7 @@ function NavigationLinkEdit( {
 							<LinkControl
 								className="wp-block-navigation-link__inline-link-input"
 								value={ link }
+								id={ id }
 								showInitialSuggestions={ true }
 								createSuggestion={
 									userCanCreatePages
@@ -258,12 +260,14 @@ function NavigationLinkEdit( {
 									title: newTitle = '',
 									url: newURL = '',
 									opensInNewTab: newOpensInNewTab,
-									id,
+									id: newId,
 								} = {} ) =>
 									setAttributes( {
-										url: ( () => {
-											return encodeURI( newURL );
-										} )(),
+										url: newId
+											? undefined
+											: ( () => {
+													return encodeURI( newURL );
+											  } )(),
 										label: ( () => {
 											const normalizedTitle = newTitle.replace(
 												/http(s?):\/\//gi,
@@ -287,7 +291,7 @@ function NavigationLinkEdit( {
 											return escape( normalizedURL );
 										} )(),
 										opensInNewTab: newOpensInNewTab,
-										id: id ? Number( id ) : undefined,
+										id: newId ? Number( newId ) : undefined,
 									} )
 								}
 							/>

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -95,6 +95,22 @@ function block_core_navigation_link_render_submenu_icon() {
 }
 
 /**
+ * Returns the link for the one nav iteem or false
+ *
+ * @param array $attrs    The Navigation Link block attributes.
+ *
+ * @return string|bool Returns the determined link or false.
+ */
+function block_core_navigation_link_get_url( $attrs ) {
+	if ( isset( $attrs['id'] ) ) {
+		return esc_url( get_permalink( $attrs['id'] ) );
+	} elseif ( isset( $attrs['url'] ) ) {
+		return esc_url( $attrs['url'] );
+	}
+	return false;
+}
+
+/**
  * Renders the `core/navigation-link` block.
  *
  * @param array $attributes The block attributes.
@@ -128,16 +144,23 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 		$css_classes .= ' ' . $class_name;
 	};
 
+	$item_url = get_navigation_link_url( $attributes );
+	$item_tag = $item_url ? 'a' : 'span';
+
 	$html = '<li class="' . esc_attr( $css_classes . ( $has_submenu ? ' has-child' : '' ) ) .
 		( $is_active ? ' current-menu-item' : '' ) . '"' . $style_attribute . '>' .
-		'<a class="wp-block-navigation-link__content"';
+		'<' . $item_tag . ' class="wp-block-navigation-link__content"';
 
 	// Start appending HTML attributes to anchor tag.
-	if ( isset( $attributes['url'] ) ) {
+	if ( $item_url ) {
 		$html .= ' href="' . esc_url( $attributes['url'] ) . '"';
 	}
 
-	if ( isset( $attributes['opensInNewTab'] ) && true === $attributes['opensInNewTab'] ) {
+	if (
+		$item_url &&
+		isset( $attributes['opensInNewTab'] ) &&
+		true === $attributes['opensInNewTab']
+	) {
 		$html .= ' target="_blank"  ';
 	}
 	// End appending HTML attributes to anchor tag.
@@ -171,7 +194,7 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 
 	$html .= '</span>';
 
-	$html .= '</a>';
+	$html .= '</' . $item_tag . '>';
 	// End anchor tag content.
 
 	if ( $block->context['showSubmenuIcon'] && $has_submenu ) {

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -197,7 +197,7 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 	$html .= '</' . $item_tag . '>';
 	// End anchor tag content.
 
-	if ( $block->context['showSubmenuIcon'] && $has_submenu ) {
+	if ( isset( $block->context['showSubmenuIcon'] ) && $block->context['showSubmenuIcon'] && $has_submenu ) {
 		// The submenu icon can be hidden by a CSS rule on the Navigation Block.
 		$html .= '<span class="wp-block-navigation-link__submenu-icon">' . block_core_navigation_link_render_submenu_icon() . '</span>';
 	}

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -144,7 +144,7 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 		$css_classes .= ' ' . $class_name;
 	};
 
-	$item_url = get_navigation_link_url( $attributes );
+	$item_url = block_core_navigation_link_get_url( $attributes );
 	$item_tag = $item_url ? 'a' : 'span';
 
 	$html = '<li class="' . esc_attr( $css_classes . ( $has_submenu ? ' has-child' : '' ) ) .
@@ -153,7 +153,7 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 
 	// Start appending HTML attributes to anchor tag.
 	if ( $item_url ) {
-		$html .= ' href="' . esc_url( $attributes['url'] ) . '"';
+		$html .= ' href="' . esc_url( $item_url ) . '"';
 	}
 
 	if (

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -154,6 +154,15 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 	);
 }
 
+function get_navigation_link_url( $attrs ) {
+	if ( isset( $attrs['id'] ) ) {
+		return esc_url( get_permalink( $attrs['id'] ) );
+	} else if ( isset( $attrs['url'] ) ) {
+		return esc_url( $attrs['url'] );
+	}
+	return false;
+}
+
 /**
  * Register the navigation block.
  *

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -157,7 +157,7 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 /**
  * Returns the link for the one nav iteem or false
  *
- * @param array $attributes    The Navigation Link block attributes.
+ * @param array $attrs    The Navigation Link block attributes.
  *
  * @return string|bool Returns the determined link or false.
  */

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -154,10 +154,17 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 	);
 }
 
+/**
+ * Returns the link for the one nav iteem or false
+ *
+ * @param array $attributes    The Navigation Link block attributes.
+ *
+ * @return string|bool Returns the determined link or false.
+ */
 function get_navigation_link_url( $attrs ) {
 	if ( isset( $attrs['id'] ) ) {
 		return esc_url( get_permalink( $attrs['id'] ) );
-	} else if ( isset( $attrs['url'] ) ) {
+	} elseif ( isset( $attrs['url'] ) ) {
 		return esc_url( $attrs['url'] );
 	}
 	return false;

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -155,22 +155,6 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 }
 
 /**
- * Returns the link for the one nav iteem or false
- *
- * @param array $attrs    The Navigation Link block attributes.
- *
- * @return string|bool Returns the determined link or false.
- */
-function get_navigation_link_url( $attrs ) {
-	if ( isset( $attrs['id'] ) ) {
-		return esc_url( get_permalink( $attrs['id'] ) );
-	} elseif ( isset( $attrs['url'] ) ) {
-		return esc_url( $attrs['url'] );
-	}
-	return false;
-}
-
-/**
  * Register the navigation block.
  *
  * @uses render_block_core_navigation()

--- a/packages/block-library/src/navigation/placeholder.js
+++ b/packages/block-library/src/navigation/placeholder.js
@@ -83,7 +83,7 @@ function getSelectedMenu( selectedCreateOption ) {
  * @return {WPBlock[]} An array of blocks.
  */
 function mapMenuItemsToBlocks( nodes ) {
-	return nodes.map( ( { title, type, link: url, id, children } ) => {
+	return nodes.map( ( { title, type, children, object_id: id } ) => {
 		const innerBlocks =
 			children && children.length ? mapMenuItemsToBlocks( children ) : [];
 
@@ -92,7 +92,6 @@ function mapMenuItemsToBlocks( nodes ) {
 			{
 				type,
 				id,
-				url,
 				label: ! title.rendered
 					? __( '(no title)' )
 					: escape( title.rendered ),
@@ -131,11 +130,10 @@ function convertPagesToBlocks( pages ) {
 		return null;
 	}
 
-	return pages.map( ( { title, type, link: url, id } ) =>
+	return pages.map( ( { title, type, id } ) =>
 		createBlock( 'core/navigation-link', {
 			type,
 			id,
-			url,
 			label: ! title.rendered
 				? __( '(no title)' )
 				: escape( title.rendered ),

--- a/packages/e2e-tests/specs/experiments/__snapshots__/navigation.test.js.snap
+++ b/packages/e2e-tests/specs/experiments/__snapshots__/navigation.test.js.snap
@@ -59,7 +59,7 @@ exports[`Navigation allows an empty navigation block to be created and manually 
 "<!-- wp:navigation {\\"orientation\\":\\"horizontal\\"} -->
 <!-- wp:navigation-link {\\"label\\":\\"WP\\",\\"url\\":\\"https://wordpress.org\\"} /-->
 
-<!-- wp:navigation-link {\\"label\\":\\"Contact\\",\\"id\\":1,\\"url\\":\\"https://this/is/a/test/search/get-in-touch\\" /-->
+<!-- wp:navigation-link {\\"label\\":\\"Contact\\",\\"id\\":1,\\"url\\":\\"https://this/is/a/test/search/get-in-touch\\"} /-->
 <!-- /wp:navigation -->"
 `;
 

--- a/packages/e2e-tests/specs/experiments/__snapshots__/navigation.test.js.snap
+++ b/packages/e2e-tests/specs/experiments/__snapshots__/navigation.test.js.snap
@@ -3,6 +3,7 @@
 exports[`Navigation Creating from existing Menus allows a navigation block to be created from existing menus 1`] = `
 "<!-- wp:navigation {\\"orientation\\":\\"horizontal\\"} -->
 <!-- wp:navigation-link {\\"label\\":\\"Home\\",\\"id\\":94} /-->
+
 <!-- wp:navigation-link {\\"label\\":"Accusamus quo repellat illum magnam quas\\",\\"id\\":41} -->
 <!-- wp:navigation-link {\\"label\\":"Debitis cum consequatur sit doloremque\\",\\"id\\":51} /-->
 <!-- /wp:navigation-link -->

--- a/packages/e2e-tests/specs/experiments/__snapshots__/navigation.test.js.snap
+++ b/packages/e2e-tests/specs/experiments/__snapshots__/navigation.test.js.snap
@@ -65,6 +65,6 @@ exports[`Navigation allows an empty navigation block to be created and manually 
 
 exports[`Navigation allows pages to be created from the navigation block and their links added to menu 1`] = `
 "<!-- wp:navigation {\\"orientation\\":\\"horizontal\\"} -->
-<!-- wp:navigation-link {\\"label\\":\\"A really long page name that will not exist\\",\\"id\\":1} /-->
+<!-- wp:navigation-link {\\"label\\":\\"A really long page name that will not exist\\",\\"id\\":1,\\"url\\":\\"https://this/is/a/test/create/page/my-new-page\\"} /-->
 <!-- /wp:navigation -->"
 `;

--- a/packages/e2e-tests/specs/experiments/__snapshots__/navigation.test.js.snap
+++ b/packages/e2e-tests/specs/experiments/__snapshots__/navigation.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`Navigation Creating from existing Menus allows a navigation block to be created from existing menus 1`] = `
 "<!-- wp:navigation {\\"orientation\\":\\"horizontal\\"} -->
+<<<<<<< HEAD
 <!-- wp:navigation-link {\\"label\\":\\"Home\\",\\"type\\":\\"custom\\",\\"id\\":94} /-->
 
 <!-- wp:navigation-link {\\"label\\":\\"Accusamus quo repellat illum magnam quas\\",\\"type\\":\\"post_type\\",\\"id\\":95} -->
@@ -59,7 +60,6 @@ exports[`Navigation Creating from existing Pages does not display option to crea
 exports[`Navigation allows an empty navigation block to be created and manually populated using a mixture of internal and external links 1`] = `
 "<!-- wp:navigation {\\"orientation\\":\\"horizontal\\"} -->
 <!-- wp:navigation-link {\\"label\\":\\"WP\\",\\"id\\":\\"https://wordpress.org\\",\\"url\\":\\"https://wordpress.org\\"} /-->
-
 <!-- wp:navigation-link {\\"label\\":\\"Contact\\",\\"id\\":1,\\"url\\":\\"https://this/is/a/test/search/get-in-touch\\"} /-->
 <!-- /wp:navigation -->"
 `;

--- a/packages/e2e-tests/specs/experiments/__snapshots__/navigation.test.js.snap
+++ b/packages/e2e-tests/specs/experiments/__snapshots__/navigation.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`Navigation Creating from existing Menus allows a navigation block to be created from existing menus 1`] = `
 "<!-- wp:navigation {\\"orientation\\":\\"horizontal\\"} -->
-<<<<<<< HEAD
 <!-- wp:navigation-link {\\"label\\":\\"Home\\",\\"type\\":\\"custom\\",\\"id\\":94} /-->
 
 <!-- wp:navigation-link {\\"label\\":\\"Accusamus quo repellat illum magnam quas\\",\\"type\\":\\"post_type\\",\\"id\\":95} -->
@@ -59,7 +58,7 @@ exports[`Navigation Creating from existing Pages does not display option to crea
 
 exports[`Navigation allows an empty navigation block to be created and manually populated using a mixture of internal and external links 1`] = `
 "<!-- wp:navigation {\\"orientation\\":\\"horizontal\\"} -->
-<!-- wp:navigation-link {\\"label\\":\\"WP\\",\\"id\\":\\"https://wordpress.org\\",\\"url\\":\\"https://wordpress.org\\"} /-->
+<!-- wp:navigation-link {\\"label\\":\\"WP\\",\\"url\\":\\"https://wordpress.org\\"} /-->
 <!-- wp:navigation-link {\\"label\\":\\"Contact\\",\\"id\\":1,\\"url\\":\\"https://this/is/a/test/search/get-in-touch\\"} /-->
 <!-- /wp:navigation -->"
 `;

--- a/packages/e2e-tests/specs/experiments/__snapshots__/navigation.test.js.snap
+++ b/packages/e2e-tests/specs/experiments/__snapshots__/navigation.test.js.snap
@@ -66,6 +66,6 @@ exports[`Navigation allows an empty navigation block to be created and manually 
 
 exports[`Navigation allows pages to be created from the navigation block and their links added to menu 1`] = `
 "<!-- wp:navigation {\\"orientation\\":\\"horizontal\\"} -->
-<!-- wp:navigation-link {\\"label\\":\\"A really long page name that will not exist\\",\\"id\\":1,\\"url\\":\\"https://this/is/a/test/create/page/my-new-page\\"} /-->
+<!-- wp:navigation-link {\\"label\\":\\"A really long page name that will not exist\\",\\"type\\":\\"page\\",\\"id\\":1,\\"url\\":\\"https://this/is/a/test/create/page/my-new-page\\"} /-->
 <!-- /wp:navigation -->"
 `;

--- a/packages/e2e-tests/specs/experiments/__snapshots__/navigation.test.js.snap
+++ b/packages/e2e-tests/specs/experiments/__snapshots__/navigation.test.js.snap
@@ -3,7 +3,6 @@
 exports[`Navigation Creating from existing Menus allows a navigation block to be created from existing menus 1`] = `
 "<!-- wp:navigation {\\"orientation\\":\\"horizontal\\"} -->
 <!-- wp:navigation-link {\\"label\\":\\"Home\\",\\"type\\":\\"custom\\",\\"id\\":94} /-->
-
 <!-- wp:navigation-link {\\"label\\":\\"Accusamus quo repellat illum magnam quas\\",\\"type\\":\\"post_type\\",\\"id\\":95} -->
 <!-- wp:navigation-link {\\"label\\":\\"Debitis cum consequatur sit doloremque\\",\\"type\\":\\"post_type\\",\\"id\\":96} /-->
 <!-- /wp:navigation-link -->
@@ -46,11 +45,11 @@ exports[`Navigation Creating from existing Menus does not display option to crea
 
 exports[`Navigation Creating from existing Pages allows a navigation block to be created using existing pages 1`] = `
 "<!-- wp:navigation {\\"orientation\\":\\"horizontal\\"} -->
-<!-- wp:navigation-link {\\"label\\":\\"Home\\",\\"id\\":1,\\"url\\":\\"https://this/is/a/test/page/home\\"} /-->
+<!-- wp:navigation-link {\\"label\\":\\"Home\\",\\"id\\":1} /-->
 
-<!-- wp:navigation-link {\\"label\\":\\"About\\",\\"id\\":2,\\"url\\":\\"https://this/is/a/test/page/about\\"} /-->
+<!-- wp:navigation-link {\\"label\\":\\"About\\",\\"id\\":2} /-->
 
-<!-- wp:navigation-link {\\"label\\":\\"Contact Us\\",\\"id\\":3,\\"url\\":\\"https://this/is/a/test/page/contact\\"} /-->
+<!-- wp:navigation-link {\\"label\\":\\"Contact Us\\",\\"id\\":3} /-->
 <!-- /wp:navigation -->"
 `;
 
@@ -60,12 +59,12 @@ exports[`Navigation allows an empty navigation block to be created and manually 
 "<!-- wp:navigation {\\"orientation\\":\\"horizontal\\"} -->
 <!-- wp:navigation-link {\\"label\\":\\"WP\\",\\"url\\":\\"https://wordpress.org\\"} /-->
 
-<!-- wp:navigation-link {\\"label\\":\\"Contact\\",\\"id\\":1,\\"url\\":\\"https://this/is/a/test/search/get-in-touch\\"} /-->
+<!-- wp:navigation-link {\\"label\\":\\"Contact\\",\\"id\\":1 /-->
 <!-- /wp:navigation -->"
 `;
 
 exports[`Navigation allows pages to be created from the navigation block and their links added to menu 1`] = `
 "<!-- wp:navigation {\\"orientation\\":\\"horizontal\\"} -->
-<!-- wp:navigation-link {\\"label\\":\\"A really long page name that will not exist\\",\\"id\\":1,\\"url\\":\\"https://this/is/a/test/create/page/my-new-page\\"} /-->
+<!-- wp:navigation-link {\\"label\\":\\"A really long page name that will not exist\\",\\"id\\":1} /-->
 <!-- /wp:navigation -->"
 `;

--- a/packages/e2e-tests/specs/experiments/__snapshots__/navigation.test.js.snap
+++ b/packages/e2e-tests/specs/experiments/__snapshots__/navigation.test.js.snap
@@ -2,35 +2,35 @@
 
 exports[`Navigation Creating from existing Menus allows a navigation block to be created from existing menus 1`] = `
 "<!-- wp:navigation {\\"orientation\\":\\"horizontal\\"} -->
-<!-- wp:navigation-link {\\"label\\":\\"Home\\",\\"type\\":\\"custom\\",\\"id\\":94} /-->
-<!-- wp:navigation-link {\\"label\\":\\"Accusamus quo repellat illum magnam quas\\",\\"type\\":\\"post_type\\",\\"id\\":95} -->
-<!-- wp:navigation-link {\\"label\\":\\"Debitis cum consequatur sit doloremque\\",\\"type\\":\\"post_type\\",\\"id\\":96} /-->
+<!-- wp:navigation-link {\\"label\\":\\"Home\\",\\"id\\":94} /-->
+<!-- wp:navigation-link {\\"label\\":"Accusamus quo repellat illum magnam quas\\",\\"id\\":41} -->
+<!-- wp:navigation-link {\\"label\\":"Debitis cum consequatur sit doloremque\\",\\"id\\":51} /-->
 <!-- /wp:navigation-link -->
 
-<!-- wp:navigation-link {\\"label\\":\\"Est ea vero non nihil officiis in\\",\\"type\\":\\"post_type\\",\\"id\\":97} -->
-<!-- wp:navigation-link {\\"label\\":\\"Fuga odio quis tempora\\",\\"type\\":\\"post_type\\",\\"id\\":98} -->
-<!-- wp:navigation-link {\\"label\\":\\"In consectetur repellendus eveniet maiores aperiam\\",\\"type\\":\\"post_type\\",\\"id\\":99} -->
-<!-- wp:navigation-link {\\"label\\":\\"Mollitia maiores consequatur ea dolorem blanditiis\\",\\"type\\":\\"post_type\\",\\"id\\":100} -->
-<!-- wp:navigation-link {\\"label\\":\\"Necessitatibus nisi qui qui necessitatibus quaerat possimus\\",\\"type\\":\\"post_type\\",\\"id\\":101} /-->
+<!-- wp:navigation-link {\\"label\\":"Est ea vero non nihil officiis in\\",\\"id\\":53} -->
+<!-- wp:navigation-link {\\"label\\":"Fuga odio quis tempora\\",\\"id\\":56} -->
+<!-- wp:navigation-link {\\"label\\":"In consectetur repellendus eveniet maiores aperiam\\",\\"id\\":15} -->
+<!-- wp:navigation-link {\\"label\\":"Mollitia maiores consequatur ea dolorem blanditiis\\",\\"id\\":45} -->
+<!-- wp:navigation-link {\\"label\\":"Necessitatibus nisi qui qui necessitatibus quaerat possimus\\",\\"id\\":27} /-->
 <!-- /wp:navigation-link -->
-<!-- /wp:navigation-link -->
-<!-- /wp:navigation-link -->
-<!-- /wp:navigation-link -->
-
-<!-- wp:navigation-link {\\"label\\":\\"Nulla omnis autem dolores eligendi\\",\\"type\\":\\"post_type\\",\\"id\\":102} /-->
-
-<!-- wp:navigation-link {\\"label\\":\\"Sample Page\\",\\"type\\":\\"post_type\\",\\"id\\":103} /-->
-
-<!-- wp:navigation-link {\\"label\\":\\"Beatae qui labore voluptas eveniet officia quia voluptas qui porro sequi et aut est\\",\\"type\\":\\"taxonomy\\",\\"id\\":104} -->
-<!-- wp:navigation-link {\\"label\\":\\"Et minus itaque velit tempore hic quisquam saepe quas asperiores\\",\\"type\\":\\"taxonomy\\",\\"id\\":105} -->
-<!-- wp:navigation-link {\\"label\\":\\"Et quas a et mollitia et voluptas optio voluptate quia quo unde aut in nostrum iste impedit quisquam id aut\\",\\"type\\":\\"taxonomy\\",\\"id\\":106} -->
-<!-- wp:navigation-link {\\"label\\":\\"Illo quis sit impedit itaque expedita earum deserunt magni doloremque velit eum id error\\",\\"type\\":\\"taxonomy\\",\\"id\\":107} /-->
 <!-- /wp:navigation-link -->
 <!-- /wp:navigation-link -->
 <!-- /wp:navigation-link -->
 
-<!-- wp:navigation-link {\\"label\\":\\"WordPress.org\\",\\"type\\":\\"custom\\",\\"id\\":108} -->
-<!-- wp:navigation-link {\\"label\\":\\"Google\\",\\"type\\":\\"custom\\",\\"id\\":109} /-->
+<!-- wp:navigation-link {\\"label\\":"Nulla omnis autem dolores eligendi\\",\\"id\\":43} /-->
+
+<!-- wp:navigation-link {\\"label\\":"Sample Page\\",\\"id\\":2} /-->
+
+<!-- wp:navigation-link {\\"label\\":"Beatae qui labore voluptas eveniet officia quia voluptas qui porro sequi et aut est\\",\\"id\\":7} -->
+<!-- wp:navigation-link {\\"label\\":"Et minus itaque velit tempore hic quisquam saepe quas asperiores\\",\\"id\\":19} -->
+<!-- wp:navigation-link {\\"label\\":"Et quas a et mollitia et voluptas optio voluptate quia quo unde aut in nostrum iste impedit quisquam id aut\\",\\"id\\":6} -->
+<!-- wp:navigation-link {\\"label\\":"Illo quis sit impedit itaque expedita earum deserunt magni doloremque velit eum id error\\",\\"id\\":16} /-->
+<!-- /wp:navigation-link -->
+<!-- /wp:navigation-link -->
+<!-- /wp:navigation-link -->
+
+<!-- wp:navigation-link {\\"label\\":"WordPress.org\\",\\"id\\":108} -->
+<!-- wp:navigation-link {\\"label\\":"Google\\",\\"id\\":109} /-->
 <!-- /wp:navigation-link -->
 <!-- /wp:navigation -->"
 `;
@@ -45,11 +45,11 @@ exports[`Navigation Creating from existing Menus does not display option to crea
 
 exports[`Navigation Creating from existing Pages allows a navigation block to be created using existing pages 1`] = `
 "<!-- wp:navigation {\\"orientation\\":\\"horizontal\\"} -->
-<!-- wp:navigation-link {\\"label\\":\\"Home\\",\\"id\\":1,\\"url\\":\\"https://this/is/a/test/page/home\\"} /-->
+<!-- wp:navigation-link {\\"label\\":\\"Home\\",\\"id\\":1} /-->
 
-<!-- wp:navigation-link {\\"label\\":\\"About\\",\\"id\\":2,\\"url\\":\\"https://this/is/a/test/page/about\\"} /-->
+<!-- wp:navigation-link {\\"label\\":\\"About\\",\\"id\\":2} /-->
 
-<!-- wp:navigation-link {\\"label\\":\\"Contact Us\\",\\"id\\":3,\\"url\\":\\"https://this/is/a/test/page/contact\\"} /-->
+<!-- wp:navigation-link {\\"label\\":\\"Contact Us\\",\\"id\\":3} /-->
 <!-- /wp:navigation -->"
 `;
 

--- a/packages/e2e-tests/specs/experiments/__snapshots__/navigation.test.js.snap
+++ b/packages/e2e-tests/specs/experiments/__snapshots__/navigation.test.js.snap
@@ -4,34 +4,34 @@ exports[`Navigation Creating from existing Menus allows a navigation block to be
 "<!-- wp:navigation {\\"orientation\\":\\"horizontal\\"} -->
 <!-- wp:navigation-link {\\"label\\":\\"Home\\",\\"id\\":94} /-->
 
-<!-- wp:navigation-link {\\"label\\":"Accusamus quo repellat illum magnam quas\\",\\"id\\":41} -->
-<!-- wp:navigation-link {\\"label\\":"Debitis cum consequatur sit doloremque\\",\\"id\\":51} /-->
+<!-- wp:navigation-link {\\"label\\":\\"Accusamus quo repellat illum magnam quas\\",\\"id\\":41} -->
+<!-- wp:navigation-link {\\"label\\":\\"Debitis cum consequatur sit doloremque\\",\\"id\\":51} /-->
 <!-- /wp:navigation-link -->
 
-<!-- wp:navigation-link {\\"label\\":"Est ea vero non nihil officiis in\\",\\"id\\":53} -->
-<!-- wp:navigation-link {\\"label\\":"Fuga odio quis tempora\\",\\"id\\":56} -->
-<!-- wp:navigation-link {\\"label\\":"In consectetur repellendus eveniet maiores aperiam\\",\\"id\\":15} -->
-<!-- wp:navigation-link {\\"label\\":"Mollitia maiores consequatur ea dolorem blanditiis\\",\\"id\\":45} -->
-<!-- wp:navigation-link {\\"label\\":"Necessitatibus nisi qui qui necessitatibus quaerat possimus\\",\\"id\\":27} /-->
+<!-- wp:navigation-link {\\"label\\":\\"Est ea vero non nihil officiis in\\",\\"id\\":53} -->
+<!-- wp:navigation-link {\\"label\\":\\"Fuga odio quis tempora\\",\\"id\\":56} -->
+<!-- wp:navigation-link {\\"label\\":\\"In consectetur repellendus eveniet maiores aperiam\\",\\"id\\":15} -->
+<!-- wp:navigation-link {\\"label\\":\\"Mollitia maiores consequatur ea dolorem blanditiis\\",\\"id\\":45} -->
+<!-- wp:navigation-link {\\"label\\":\\"Necessitatibus nisi qui qui necessitatibus quaerat possimus\\",\\"id\\":27} /-->
 <!-- /wp:navigation-link -->
-<!-- /wp:navigation-link -->
-<!-- /wp:navigation-link -->
-<!-- /wp:navigation-link -->
-
-<!-- wp:navigation-link {\\"label\\":"Nulla omnis autem dolores eligendi\\",\\"id\\":43} /-->
-
-<!-- wp:navigation-link {\\"label\\":"Sample Page\\",\\"id\\":2} /-->
-
-<!-- wp:navigation-link {\\"label\\":"Beatae qui labore voluptas eveniet officia quia voluptas qui porro sequi et aut est\\",\\"id\\":7} -->
-<!-- wp:navigation-link {\\"label\\":"Et minus itaque velit tempore hic quisquam saepe quas asperiores\\",\\"id\\":19} -->
-<!-- wp:navigation-link {\\"label\\":"Et quas a et mollitia et voluptas optio voluptate quia quo unde aut in nostrum iste impedit quisquam id aut\\",\\"id\\":6} -->
-<!-- wp:navigation-link {\\"label\\":"Illo quis sit impedit itaque expedita earum deserunt magni doloremque velit eum id error\\",\\"id\\":16} /-->
 <!-- /wp:navigation-link -->
 <!-- /wp:navigation-link -->
 <!-- /wp:navigation-link -->
 
-<!-- wp:navigation-link {\\"label\\":"WordPress.org\\",\\"id\\":108} -->
-<!-- wp:navigation-link {\\"label\\":"Google\\",\\"id\\":109} /-->
+<!-- wp:navigation-link {\\"label\\":\\"Nulla omnis autem dolores eligendi\\",\\"id\\":43} /-->
+
+<!-- wp:navigation-link {\\"label\\":\\"Sample Page\\",\\"id\\":2} /-->
+
+<!-- wp:navigation-link {\\"label\\":\\"Beatae qui labore voluptas eveniet officia quia voluptas qui porro sequi et aut est\\",\\"id\\":7} -->
+<!-- wp:navigation-link {\\"label\\":\\"Et minus itaque velit tempore hic quisquam saepe quas asperiores\\",\\"id\\":19} -->
+<!-- wp:navigation-link {\\"label\\":\\"Et quas a et mollitia et voluptas optio voluptate quia quo unde aut in nostrum iste impedit quisquam id aut\\",\\"id\\":6} -->
+<!-- wp:navigation-link {\\"label\\":\\"Illo quis sit impedit itaque expedita earum deserunt magni doloremque velit eum id error\\",\\"id\\":16} /-->
+<!-- /wp:navigation-link -->
+<!-- /wp:navigation-link -->
+<!-- /wp:navigation-link -->
+
+<!-- wp:navigation-link {\\"label\\":\\"WordPress.org\\",\\"id\\":108} -->
+<!-- wp:navigation-link {\\"label\\":\\"Google\\",\\"id\\":109} /-->
 <!-- /wp:navigation-link -->
 <!-- /wp:navigation -->"
 `;

--- a/packages/e2e-tests/specs/experiments/__snapshots__/navigation.test.js.snap
+++ b/packages/e2e-tests/specs/experiments/__snapshots__/navigation.test.js.snap
@@ -45,11 +45,11 @@ exports[`Navigation Creating from existing Menus does not display option to crea
 
 exports[`Navigation Creating from existing Pages allows a navigation block to be created using existing pages 1`] = `
 "<!-- wp:navigation {\\"orientation\\":\\"horizontal\\"} -->
-<!-- wp:navigation-link {\\"label\\":\\"Home\\",\\"id\\":1} /-->
+<!-- wp:navigation-link {\\"label\\":\\"Home\\",\\"id\\":1,\\"url\\":\\"https://this/is/a/test/page/home\\"} /-->
 
-<!-- wp:navigation-link {\\"label\\":\\"About\\",\\"id\\":2} /-->
+<!-- wp:navigation-link {\\"label\\":\\"About\\",\\"id\\":2,\\"url\\":\\"https://this/is/a/test/page/about\\"} /-->
 
-<!-- wp:navigation-link {\\"label\\":\\"Contact Us\\",\\"id\\":3} /-->
+<!-- wp:navigation-link {\\"label\\":\\"Contact Us\\",\\"id\\":3,\\"url\\":\\"https://this/is/a/test/page/contact\\"} /-->
 <!-- /wp:navigation -->"
 `;
 
@@ -59,7 +59,7 @@ exports[`Navigation allows an empty navigation block to be created and manually 
 "<!-- wp:navigation {\\"orientation\\":\\"horizontal\\"} -->
 <!-- wp:navigation-link {\\"label\\":\\"WP\\",\\"url\\":\\"https://wordpress.org\\"} /-->
 
-<!-- wp:navigation-link {\\"label\\":\\"Contact\\",\\"id\\":1 /-->
+<!-- wp:navigation-link {\\"label\\":\\"Contact\\",\\"id\\":1,\\"url\\":\\"https://this/is/a/test/search/get-in-touch\\" /-->
 <!-- /wp:navigation -->"
 `;
 

--- a/packages/e2e-tests/specs/experiments/__snapshots__/navigation.test.js.snap
+++ b/packages/e2e-tests/specs/experiments/__snapshots__/navigation.test.js.snap
@@ -46,11 +46,11 @@ exports[`Navigation Creating from existing Menus does not display option to crea
 
 exports[`Navigation Creating from existing Pages allows a navigation block to be created using existing pages 1`] = `
 "<!-- wp:navigation {\\"orientation\\":\\"horizontal\\"} -->
-<!-- wp:navigation-link {\\"label\\":\\"Home\\",\\"type\\":\\"page\\",\\"id\\":1,\\"url\\":\\"https://this/is/a/test/page/home\\"} /-->
+<!-- wp:navigation-link {\\"label\\":\\"Home\\",\\"id\\":1,\\"url\\":\\"https://this/is/a/test/page/home\\"} /-->
 
-<!-- wp:navigation-link {\\"label\\":\\"About\\",\\"type\\":\\"page\\",\\"id\\":2,\\"url\\":\\"https://this/is/a/test/page/about\\"} /-->
+<!-- wp:navigation-link {\\"label\\":\\"About\\",\\"id\\":2,\\"url\\":\\"https://this/is/a/test/page/about\\"} /-->
 
-<!-- wp:navigation-link {\\"label\\":\\"Contact Us\\",\\"type\\":\\"page\\",\\"id\\":3,\\"url\\":\\"https://this/is/a/test/page/contact\\"} /-->
+<!-- wp:navigation-link {\\"label\\":\\"Contact Us\\",\\"id\\":3,\\"url\\":\\"https://this/is/a/test/page/contact\\"} /-->
 <!-- /wp:navigation -->"
 `;
 
@@ -66,6 +66,6 @@ exports[`Navigation allows an empty navigation block to be created and manually 
 
 exports[`Navigation allows pages to be created from the navigation block and their links added to menu 1`] = `
 "<!-- wp:navigation {\\"orientation\\":\\"horizontal\\"} -->
-<!-- wp:navigation-link {\\"label\\":\\"A really long page name that will not exist\\",\\"type\\":\\"page\\",\\"id\\":1,\\"url\\":\\"https://this/is/a/test/create/page/my-new-page\\"} /-->
+<!-- wp:navigation-link {\\"label\\":\\"A really long page name that will not exist\\",\\"id\\":1,\\"url\\":\\"https://this/is/a/test/create/page/my-new-page\\"} /-->
 <!-- /wp:navigation -->"
 `;

--- a/packages/e2e-tests/specs/experiments/__snapshots__/navigation.test.js.snap
+++ b/packages/e2e-tests/specs/experiments/__snapshots__/navigation.test.js.snap
@@ -59,6 +59,7 @@ exports[`Navigation Creating from existing Pages does not display option to crea
 exports[`Navigation allows an empty navigation block to be created and manually populated using a mixture of internal and external links 1`] = `
 "<!-- wp:navigation {\\"orientation\\":\\"horizontal\\"} -->
 <!-- wp:navigation-link {\\"label\\":\\"WP\\",\\"url\\":\\"https://wordpress.org\\"} /-->
+
 <!-- wp:navigation-link {\\"label\\":\\"Contact\\",\\"id\\":1,\\"url\\":\\"https://this/is/a/test/search/get-in-touch\\"} /-->
 <!-- /wp:navigation -->"
 `;


### PR DESCRIPTION
## Description
Closes #18345

## How has this been tested?
Tested locally by:
1. Make sure you have some posts and pages
2. Add a new page
3. Add a Navigation block
4. Create empty
5. Add a link to a page, a link to a post and an external link
6. Save and view post
7. Links should be working

## Types of changes
Small change to `NavigationLinkEdit` to also save the `type` which `LinkControl` offers to the `onChange` handler.

Then on the render function (PHP) added a call to `get_permalink` for anything which is not an external URL.
