### PR TITLE
Prettier Config: Add type-checking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10086,6 +10086,12 @@
 			"resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
 			"integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
 		},
+		"@types/prettier": {
+			"version": "1.19.0",
+			"resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-1.19.0.tgz",
+			"integrity": "sha512-gDE8JJEygpay7IjA/u3JiIURvwZW08f0cZSZLAzFoX/ZmeqvS0Sqv+97aKuHpNsalAMMhwPe+iAS6fQbfmbt7A==",
+			"dev": true
+		},
 		"@types/prop-types": {
 			"version": "15.7.3",
 			"resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
 		"@storybook/react": "5.3.2",
 		"@types/jest": "24.0.25",
 		"@types/lodash": "4.14.149",
+		"@types/prettier": "1.19.0",
 		"@types/qs": "6.9.1",
 		"@types/requestidlecallback": "0.3.1",
 		"@types/sprintf-js": "1.1.2",

--- a/packages/prettier-config/lib/index.js
+++ b/packages/prettier-config/lib/index.js
@@ -1,4 +1,13 @@
-module.exports = {
+/** @typedef {import('prettier').Options} PrettierOptions */
+
+/**
+ * @typedef WPPrettierOptions
+ *
+ * @property {boolean} [parenSpacing=true] Insert spaces inside parentheses.
+ */
+
+/** @type {PrettierOptions & WPPrettierOptions} */
+const config = {
 	useTabs: true,
 	tabWidth: 4,
 	printWidth: 80,
@@ -10,3 +19,5 @@ module.exports = {
 	semi: true,
 	arrowParens: 'always',
 };
+
+module.exports = config;

--- a/packages/prettier-config/lib/index.js
+++ b/packages/prettier-config/lib/index.js
@@ -6,7 +6,12 @@
  * @property {boolean} [parenSpacing=true] Insert spaces inside parentheses.
  */
 
+// Disable reason: The current JSDoc tooling does not yet understand TypeScript
+// union types.
+
+/* eslint-disable jsdoc/valid-types */
 /** @type {PrettierOptions & WPPrettierOptions} */
+/* eslint-enable jsdoc/valid-types */
 const config = {
 	useTabs: true,
 	tabWidth: 4,

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -25,6 +25,7 @@
 		"lib/index.js"
 	],
 	"main": "lib/index.js",
+	"types": "build-types",
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/prettier-config/tsconfig.json
+++ b/packages/prettier-config/tsconfig.json
@@ -1,0 +1,8 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"rootDir": "lib",
+		"declarationDir": "build-types"
+	},
+	"include": [ "lib/**/*" ]
+}


### PR DESCRIPTION
Blocked by (current base): #18942
Related: #18838

This pull request seeks to add type-checking for the `@wordpress/prettier-config` package.

By virtue of #18942, it also implies that types will be output as part of package distribution, though this may or may not be a very useful package to reference.

The primary benefit of these changes is largely in verifying configuration keys and values.

It also benefits from the same sorts of thing [I wrote about recently](https://andrewduthie.com/2020/03/15/typescript-types-for-productivity/), wherein the addition of the type detail trivializes future configuration maintenance:

<img src="https://user-images.githubusercontent.com/1779930/77196310-72753780-6ab9-11ea-8ac7-b34cedd882c6.png" alt="Prettier config" width="484">

Finally, this pull request serves as a possible reference for the revised approach to opting in to TypeScript type-checking for a package as of #18942.

**Testing Instructions:**

Ensure type-checking passes:

```
npm run build:package-types
```
