### PR TITLE
Replace lodash.assign with vanilla JS.

### DIFF
--- a/packages/block-editor/src/hooks/align.js
+++ b/packages/block-editor/src/hooks/align.js
@@ -89,13 +89,21 @@ export function addAttribute( settings ) {
 		return settings;
 	}
 	if ( hasBlockSupport( settings, 'align' ) ) {
-		// Gracefully handle if attributes are undefined.
-		settings.attributes = {
-			...settings.attributes,
-			align: {
-				type: 'string',
-			},
+		const alignAttribute = {
+			type: 'string',
 		};
+
+		// Gracefully handle if settings.attributes is undefined.
+		if (
+			typeof settings.attributes === 'object' &&
+			settings.attributes !== null
+		) {
+			settings.attributes.align = alignAttribute;
+		} else {
+			settings.attributes = {
+				align: alignAttribute,
+			};
+		}
 	}
 
 	return settings;

--- a/packages/block-editor/src/hooks/align.js
+++ b/packages/block-editor/src/hooks/align.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { assign, get, has, includes, without } from 'lodash';
+import { get, has, includes, without } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -89,12 +89,13 @@ export function addAttribute( settings ) {
 		return settings;
 	}
 	if ( hasBlockSupport( settings, 'align' ) ) {
-		// Use Lodash's assign to gracefully handle if attributes are undefined
-		settings.attributes = assign( settings.attributes, {
+		// Gracefully handle if attributes are undefined.
+		settings.attributes = {
+			...settings.attributes,
 			align: {
 				type: 'string',
 			},
-		} );
+		};
 	}
 
 	return settings;

--- a/packages/block-editor/src/hooks/align.js
+++ b/packages/block-editor/src/hooks/align.js
@@ -89,21 +89,13 @@ export function addAttribute( settings ) {
 		return settings;
 	}
 	if ( hasBlockSupport( settings, 'align' ) ) {
-		const alignAttribute = {
-			type: 'string',
-		};
-
 		// Gracefully handle if settings.attributes is undefined.
-		if (
-			typeof settings.attributes === 'object' &&
-			settings.attributes !== null
-		) {
-			settings.attributes.align = alignAttribute;
-		} else {
-			settings.attributes = {
-				align: alignAttribute,
-			};
-		}
+		settings.attributes = {
+			...settings.attributes,
+			align: {
+				type: 'string',
+			},
+		};
 	}
 
 	return settings;

--- a/packages/block-editor/src/hooks/anchor.js
+++ b/packages/block-editor/src/hooks/anchor.js
@@ -38,24 +38,16 @@ export function addAttribute( settings ) {
 		return settings;
 	}
 	if ( hasBlockSupport( settings, 'anchor' ) ) {
-		const anchorAttribute = {
-			type: 'string',
-			source: 'attribute',
-			attribute: 'id',
-			selector: '*',
-		};
-
 		// Gracefully handle if settings.attributes is undefined.
-		if (
-			typeof settings.attributes === 'object' &&
-			settings.attributes !== null
-		) {
-			settings.attributes.anchor = anchorAttribute;
-		} else {
-			settings.attributes = {
-				anchor: anchorAttribute,
-			};
-		}
+		settings.attributes = {
+			...settings.attributes,
+			anchor: {
+				type: 'string',
+				source: 'attribute',
+				attribute: 'id',
+				selector: '*',
+			},
+		};
 	}
 
 	return settings;

--- a/packages/block-editor/src/hooks/anchor.js
+++ b/packages/block-editor/src/hooks/anchor.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { assign, has } from 'lodash';
+import { has } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -38,15 +38,16 @@ export function addAttribute( settings ) {
 		return settings;
 	}
 	if ( hasBlockSupport( settings, 'anchor' ) ) {
-		// Use Lodash's assign to gracefully handle if attributes are undefined
-		settings.attributes = assign( settings.attributes, {
+		// Gracefully handle if attributes are undefined.
+		settings.attributes = {
+			...settings.attributes,
 			anchor: {
 				type: 'string',
 				source: 'attribute',
 				attribute: 'id',
 				selector: '*',
 			},
-		} );
+		};
 	}
 
 	return settings;

--- a/packages/block-editor/src/hooks/anchor.js
+++ b/packages/block-editor/src/hooks/anchor.js
@@ -38,16 +38,24 @@ export function addAttribute( settings ) {
 		return settings;
 	}
 	if ( hasBlockSupport( settings, 'anchor' ) ) {
-		// Gracefully handle if attributes are undefined.
-		settings.attributes = {
-			...settings.attributes,
-			anchor: {
-				type: 'string',
-				source: 'attribute',
-				attribute: 'id',
-				selector: '*',
-			},
+		const anchorAttribute = {
+			type: 'string',
+			source: 'attribute',
+			attribute: 'id',
+			selector: '*',
 		};
+
+		// Gracefully handle if settings.attributes is undefined.
+		if (
+			typeof settings.attributes === 'object' &&
+			settings.attributes !== null
+		) {
+			settings.attributes.anchor = anchorAttribute;
+		} else {
+			settings.attributes = {
+				anchor: anchorAttribute,
+			};
+		}
 	}
 
 	return settings;

--- a/packages/block-editor/src/hooks/custom-class-name.js
+++ b/packages/block-editor/src/hooks/custom-class-name.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { assign, difference, omit } from 'lodash';
+import { difference, omit } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -32,12 +32,13 @@ import { InspectorAdvancedControls } from '../components';
  */
 export function addAttribute( settings ) {
 	if ( hasBlockSupport( settings, 'customClassName', true ) ) {
-		// Use Lodash's assign to gracefully handle if attributes are undefined
-		settings.attributes = assign( settings.attributes, {
+		// Gracefully handle if attributes are undefined.
+		settings.attributes = {
+			...settings.attributes,
 			className: {
 				type: 'string',
 			},
-		} );
+		};
 	}
 
 	return settings;

--- a/packages/block-editor/src/hooks/custom-class-name.js
+++ b/packages/block-editor/src/hooks/custom-class-name.js
@@ -32,13 +32,21 @@ import { InspectorAdvancedControls } from '../components';
  */
 export function addAttribute( settings ) {
 	if ( hasBlockSupport( settings, 'customClassName', true ) ) {
-		// Gracefully handle if attributes are undefined.
-		settings.attributes = {
-			...settings.attributes,
-			className: {
-				type: 'string',
-			},
+		const classNameAttribute = {
+			type: 'string',
 		};
+
+		// Gracefully handle if settings.attributes is undefined.
+		if (
+			typeof settings.attributes === 'object' &&
+			settings.attributes !== null
+		) {
+			settings.attributes.className = classNameAttribute;
+		} else {
+			settings.attributes = {
+				className: classNameAttribute,
+			};
+		}
 	}
 
 	return settings;

--- a/packages/block-editor/src/hooks/custom-class-name.js
+++ b/packages/block-editor/src/hooks/custom-class-name.js
@@ -32,21 +32,13 @@ import { InspectorAdvancedControls } from '../components';
  */
 export function addAttribute( settings ) {
 	if ( hasBlockSupport( settings, 'customClassName', true ) ) {
-		const classNameAttribute = {
-			type: 'string',
-		};
-
 		// Gracefully handle if settings.attributes is undefined.
-		if (
-			typeof settings.attributes === 'object' &&
-			settings.attributes !== null
-		) {
-			settings.attributes.className = classNameAttribute;
-		} else {
-			settings.attributes = {
-				className: classNameAttribute,
-			};
-		}
+		settings.attributes = {
+			...settings.attributes,
+			className: {
+				type: 'string',
+			},
+		};
 	}
 
 	return settings;

--- a/packages/block-editor/src/hooks/custom-class-name.native.js
+++ b/packages/block-editor/src/hooks/custom-class-name.native.js
@@ -24,21 +24,13 @@ import {
  */
 export function addAttribute( settings ) {
 	if ( hasBlockSupport( settings, 'customClassName', true ) ) {
-		const classNameAttribute = {
-			type: 'string',
-		};
-
 		// Gracefully handle if settings.attributes is undefined.
-		if (
-			typeof settings.attributes === 'object' &&
-			settings.attributes !== null
-		) {
-			settings.attributes.className = classNameAttribute;
-		} else {
-			settings.attributes = {
-				className: classNameAttribute,
-			};
-		}
+		settings.attributes = {
+			...settings.attributes,
+			className: {
+				type: 'string',
+			},
+		};
 	}
 
 	return settings;

--- a/packages/block-editor/src/hooks/custom-class-name.native.js
+++ b/packages/block-editor/src/hooks/custom-class-name.native.js
@@ -24,13 +24,21 @@ import {
  */
 export function addAttribute( settings ) {
 	if ( hasBlockSupport( settings, 'customClassName', true ) ) {
-		// Gracefully handle if attributes are undefined.
-		settings.attributes = {
-			...settings.attributes,
-			className: {
-				type: 'string',
-			},
+		const classNameAttribute = {
+			type: 'string',
 		};
+
+		// Gracefully handle if settings.attributes is undefined.
+		if (
+			typeof settings.attributes === 'object' &&
+			settings.attributes !== null
+		) {
+			settings.attributes.className = classNameAttribute;
+		} else {
+			settings.attributes = {
+				className: classNameAttribute,
+			};
+		}
 	}
 
 	return settings;

--- a/packages/block-editor/src/hooks/custom-class-name.native.js
+++ b/packages/block-editor/src/hooks/custom-class-name.native.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { assign, difference, compact } from 'lodash';
+import { difference, compact } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -24,12 +24,13 @@ import {
  */
 export function addAttribute( settings ) {
 	if ( hasBlockSupport( settings, 'customClassName', true ) ) {
-		// Use Lodash's assign to gracefully handle if attributes are undefined
-		settings.attributes = assign( settings.attributes, {
+		// Gracefully handle if attributes are undefined.
+		settings.attributes = {
+			...settings.attributes,
 			className: {
 				type: 'string',
 			},
-		} );
+		};
 	}
 
 	return settings;


### PR DESCRIPTION
## Description
This PR replaces all uses of lodash.assign in the codebase with the standard JS `Object.assign`. The only exception to this are some ES5 documentation examples which I left unchanged since `Object.assign` wasn't introduced until ES6.

This is the first of several PRs I plan to make in order to reduce our usage of `lodash` whenever there is a simple vanilla JS equivalent, in the hopes of removing it as a dependency from several WP packages.