### PR TITLE
Data: Add useSelector hook

### DIFF
--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -657,6 +657,10 @@ _Returns_
 
 -   `Function`: A custom react hook.
 
+<a name="useSelector" href="#useSelector">#</a> **useSelector**
+
+Undocumented declaration.
+
 <a name="withDispatch" href="#withDispatch">#</a> **withDispatch**
 
 Higher-order component used to add dispatch props using registered action

--- a/packages/data/src/components/use-selector/index.js
+++ b/packages/data/src/components/use-selector/index.js
@@ -1,0 +1,56 @@
+/**
+ * External dependencies
+ */
+import { useMemoOne } from 'use-memo-one';
+
+/**
+ * WordPress dependencies
+ */
+import { createQueue } from '@wordpress/priority-queue';
+import { useLayoutEffect, useReducer } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import useRegistry from '../registry-provider/use-registry';
+import useAsyncMode from '../async-mode-provider/use-async-mode';
+
+const renderQueue = createQueue();
+
+function useSelector( storeKey ) {
+	const [ , forceRender ] = useReducer( () => ( {} ) );
+	const registry = useRegistry();
+	const isAsync = useAsyncMode();
+	// React can sometimes clear the `useMemo` cache. Use the cache-stable
+	// `useMemoOne` to avoid losing queues.
+	const queueContext = useMemoOne( () => ( { queue: true } ), [ registry ] );
+
+	useLayoutEffect( () => {
+		renderQueue.flush( queueContext );
+	}, [ isAsync ] );
+
+	useLayoutEffect( () => {
+		function onStoreChange() {
+			if ( isAsync ) {
+				renderQueue.add( queueContext, forceRender );
+			} else {
+				forceRender();
+			}
+		}
+
+		// Catch any possible state changes during mount before the subscription
+		// could be set.
+		onStoreChange();
+
+		const unsubscribe = registry.subscribe( onStoreChange );
+
+		return () => {
+			unsubscribe();
+			renderQueue.flush( queueContext );
+		};
+	}, [ registry ] );
+
+	return registry.select( storeKey );
+}
+
+export default useSelector;

--- a/packages/data/src/index.js
+++ b/packages/data/src/index.js
@@ -18,6 +18,7 @@ export {
 	useRegistry,
 } from './components/registry-provider';
 export { default as useSelect } from './components/use-select';
+export { default as useSelector } from './components/use-selector';
 export {
 	useDispatch,
 	useDispatchWithMap as __unstableUseDispatchWithMap,


### PR DESCRIPTION
Related Slack discussion ([link requires registration](https://make.wordpress.org/chat/)): https://wordpress.slack.com/archives/C5UNMSU4R/p1584734770269400

This pull request seeks to try an alternative function signature to `useSelect`.

Where what was previously expressed as...

```js
function MyPlugin() {
    const currentPostType = useSelect( ( select ) => select( 'core/editor' ).getCurrentPostType() );
    // ...
}
```

...could instead be expressed as:

```js
function MyPlugin() {
    const currentPostType = useSelector( 'core/editor' ).getCurrentPostType();
    // ...
}
```

In its current state, it's intended to be explored as a prototype. Some observations:

- The refactored component is a `+26 -72` revision.
   - Observation: Often less code to write (can be seen also by the snippets above)
- Externalized `selector` functions are removed.
   - Observation: This can serve as a solution to the issues concerning [variable shadowing](https://eslint.org/docs/rules/no-shadow) of assignment of variables in a `useSelect` callback using same names as that of their parent scope.
   - Observation: However, these now return the selector function, not the result of that function
      - Bad: In current usage, some component implementations may need to either call the selector multiple times, or assign its result to a variable, where the latter would likely reintroduce the challenges around [no-shadow](https://eslint.org/docs/rules/no-shadow).
      - Good: Calling the function inline in conditions can often be an optimization, and avoids calling the selector altogether in many cases:
         - [Short-circuit evaluation](https://en.wikipedia.org/wiki/Short-circuit_evaluation) can skip selector calls in right-hand of `&&` and `||` conditions [[1]](https://github.com/WordPress/gutenberg/blob/899fb2fc7708dc5fcc192d924a023e124ef2a598/packages/block-editor/src/components/block-list/block-popover.js#L57) [[2]](https://github.com/WordPress/gutenberg/blob/899fb2fc7708dc5fcc192d924a023e124ef2a598/packages/block-editor/src/components/block-list/block-popover.js#L58) [[3]](https://github.com/WordPress/gutenberg/blob/899fb2fc7708dc5fcc192d924a023e124ef2a598/packages/block-editor/src/components/block-list/block-popover.js#L58) [[4]](https://github.com/WordPress/gutenberg/blob/899fb2fc7708dc5fcc192d924a023e124ef2a598/packages/block-editor/src/components/block-list/block-popover.js#L221) [[5]](https://github.com/WordPress/gutenberg/blob/899fb2fc7708dc5fcc192d924a023e124ef2a598/packages/block-editor/src/components/block-list/block-popover.js#L262)
         - Early render returns and conditions can skip selector calls when unreached [[1]](https://github.com/WordPress/gutenberg/blob/899fb2fc7708dc5fcc192d924a023e124ef2a598/packages/block-editor/src/components/block-list/block-popover.js#L101) [[2]](https://github.com/WordPress/gutenberg/blob/899fb2fc7708dc5fcc192d924a023e124ef2a598/packages/block-editor/src/components/block-list/block-popover.js#L102) [[3]](https://github.com/WordPress/gutenberg/blob/899fb2fc7708dc5fcc192d924a023e124ef2a598/packages/block-editor/src/components/block-list/block-popover.js#L234) [[4]](https://github.com/WordPress/gutenberg/blob/899fb2fc7708dc5fcc192d924a023e124ef2a598/packages/block-editor/src/components/block-list/block-popover.js#L235) [[5]](https://github.com/WordPress/gutenberg/blob/899fb2fc7708dc5fcc192d924a023e124ef2a598/packages/block-editor/src/components/block-list/block-popover.js#L237) [[6]](https://github.com/WordPress/gutenberg/blob/899fb2fc7708dc5fcc192d924a023e124ef2a598/packages/block-editor/src/components/block-list/block-popover.js#L240) [[7]](https://github.com/WordPress/gutenberg/blob/899fb2fc7708dc5fcc192d924a023e124ef2a598/packages/block-editor/src/components/block-list/block-popover.js#L262)
- Observation: [A component will always render on any store change](https://wordpress.slack.com/archives/C5UNMSU4R/p1584738589283000)
   - Neutral: The selectors would be called regardless of whether their results are the same or not
   - Bad: We're not avoiding unneeded renders if selector results would be the same
   - Good: A future optimization for store specific subscriptions (previously #15483, #12877) would be made trivial by this API. With this, renders could at least be limited to changes within the specific stores for which the component is concerned.
   - Good: We're at least benefitting from possibly not calling selectors at all (see above points about short-circuit evaluation and early returns)
   - Good: [Unlike `useSelect`](https://github.com/WordPress/gutenberg/blob/bee1bf91958c71c733be4514b42cfa136243b3eb/packages/data/src/components/use-select/index.js#L148), we're never performing a shallow comparison.
    - Bad (**Blocker?**): If the render is allowed to cascade to its children, a top-level component using `useSelector` would not only needlessly re-render itself, but also all of its descendents... every time state changes.

Note: Strictly speaking, this could be implemented as an overloaded form of `useSelect`. I don't hold strong feelings about this, but implemented it as a separate `useSelector` for the proposal due to:

- Easier to analyze the implementation in isolation (for purposes of prototyping and review)
- Overloaded functions are hard to document, harder to implement, harder to type (as in "type-checking")
- Possible performance overhead if each call to `useSelect` must make up-front decision on how to handle logic of its hook
- Said "up-front decision" is a condition, and thus violates the first of the [Rules of Hooks](https://reactjs.org/docs/hooks-rules.html#only-call-hooks-at-the-top-level).
- Semantically, it can make sense as two separate implementations: `useSelect`, as indicated by its name, provides a callback with the `select` function. By contrast, `useSelector` implies some intention to gain access to selectors specifically. More accurately, it could be `useSelectors`, since it returns an object of a store's selectors. To me, it feels more readable in the singular form.