### PR TITLE
Block editor: use vanilla JS Array.prototype.includes instead of Lodash

### DIFF
--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { includes } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { useState } from '@wordpress/element';
@@ -60,8 +55,7 @@ function InserterMenu( {
 	const showPatterns = ! destinationRootClientId && hasPatterns;
 	const onKeyDown = ( event ) => {
 		if (
-			includes(
-				[ LEFT, DOWN, RIGHT, UP, BACKSPACE, ENTER ],
+			[ LEFT, DOWN, RIGHT, UP, BACKSPACE, ENTER ].includes(
 				event.keyCode
 			)
 		) {

--- a/packages/block-editor/src/components/observe-typing/index.js
+++ b/packages/block-editor/src/components/observe-typing/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { over, includes } from 'lodash';
+import { over } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -39,7 +39,7 @@ const KEY_DOWN_ELIGIBLE_KEY_CODES = [ UP, RIGHT, DOWN, LEFT, ENTER, BACKSPACE ];
  */
 function isKeyDownEligibleForStartTyping( event ) {
 	const { keyCode, shiftKey } = event;
-	return ! shiftKey && includes( KEY_DOWN_ELIGIBLE_KEY_CODES, keyCode );
+	return ! shiftKey && KEY_DOWN_ELIGIBLE_KEY_CODES.includes( keyCode );
 }
 
 function ObserveTyping( { children, setTimeout: setSafeTimeout } ) {

--- a/packages/block-editor/src/hooks/align.js
+++ b/packages/block-editor/src/hooks/align.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { get, has, includes, without } from 'lodash';
+import { get, has, without } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -189,7 +189,7 @@ export const withDataAlign = createHigherOrderComponent(
 		);
 
 		let wrapperProps = props.wrapperProps;
-		if ( includes( validAlignments, align ) ) {
+		if ( validAlignments.includes( align ) ) {
 			wrapperProps = { ...wrapperProps, 'data-align': align };
 		}
 
@@ -210,13 +210,14 @@ export function addAssignedAlign( props, blockType, attributes ) {
 	const { align } = attributes;
 	const blockAlign = getBlockSupport( blockType, 'align' );
 	const hasWideBlockSupport = hasBlockSupport( blockType, 'alignWide', true );
-	const isAlignValid = includes(
-		// Compute valid alignments without taking into account,
-		// if the theme supports wide alignments or not.
-		// This way changing themes does not impacts the block save.
-		getValidAlignments( blockAlign, hasWideBlockSupport ),
-		align
-	);
+
+	// Compute valid alignments without taking into account if
+	// the theme supports wide alignments or not.
+	// This way changing themes does not impact the block save.
+	const isAlignValid = getValidAlignments(
+		blockAlign,
+		hasWideBlockSupport
+	).includes( align );
 	if ( isAlignValid ) {
 		props.className = classnames( `align${ align }`, props.className );
 	}

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import { castArray, first, get, includes, last, some } from 'lodash';
+import { castArray, first, get, last, some } from 'lodash';
+
 /**
  * WordPress dependencies
  */
@@ -265,7 +266,7 @@ function getBlocksWithDefaultStylesApplied( blocks, blockEditorSettings ) {
 			return block;
 		}
 		const className = get( block, [ 'attributes', 'className' ] );
-		if ( includes( className, 'is-style-' ) ) {
+		if ( className?.includes( 'is-style-' ) ) {
 			return block;
 		}
 		const { attributes = {} } = block;

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -6,7 +6,6 @@ import {
 	flatMap,
 	first,
 	get,
-	includes,
 	isArray,
 	isBoolean,
 	last,
@@ -1126,11 +1125,11 @@ const canInsertBlockTypeUnmemoized = (
 		if ( isArray( list ) ) {
 			// TODO: when there is a canonical way to detect that we are editing a post
 			// the following check should be changed to something like:
-			// if ( includes( list, 'core/post-content' ) && getEditorMode() === 'post-content' && item === null )
-			if ( includes( list, 'core/post-content' ) && item === null ) {
+			// if ( list.includes( 'core/post-content' ) && getEditorMode() === 'post-content' && item === null )
+			if ( list.includes( 'core/post-content' ) && item === null ) {
 				return true;
 			}
-			return includes( list, item );
+			return list.includes( item );
 		}
 		return defaultResult;
 	};

--- a/packages/block-editor/src/utils/transform-styles/transforms/wrap.js
+++ b/packages/block-editor/src/utils/transform-styles/transforms/wrap.js
@@ -1,16 +1,11 @@
 /**
- * External dependencies
- */
-import { includes } from 'lodash';
-
-/**
  * @constant string IS_ROOT_TAG Regex to check if the selector is a root tag selector.
  */
 const IS_ROOT_TAG = /^(body|html|:root).*$/;
 
 const wrap = ( namespace, ignore = [] ) => ( node ) => {
 	const updateSelector = ( selector ) => {
-		if ( includes( ignore, selector.trim() ) ) {
+		if ( ignore.includes( selector.trim() ) ) {
 			return selector;
 		}
 


### PR DESCRIPTION
## Description
See title. In my testing, the vanilla method is slightly faster, and I find it easier to comprehend when reading the code. It also has stronger typing, making it better for pushing the codebase closer to complete type checking.

As it turns out, `lodash.includes` is used a lot in the code, so to make reviewing and catching mistakes easier, I'm doing one package at a time.

The long-term goal is to reduce `lodash` usage in cases where a standard JS function works just as well or better, which should reduce our packages' bundle sizes for 3rd parties using them. This will also increase clarity by making nullish value handling more explicit, and avoiding the use of external libraries when simple equivalents exist in standard JS.