### PR TITLE
Fix heading block sidebar level is-pressed styling

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -482,6 +482,7 @@
 /**
  * Block Toolbar, top and contextual.
  */
+
 .block-editor-block-contextual-toolbar-wrapper {
 	padding-left: $block-toolbar-height; // Provide space for the mover control on full-wide items.
 }

--- a/packages/block-editor/src/components/block-mover/style.scss
+++ b/packages/block-editor/src/components/block-mover/style.scss
@@ -12,7 +12,7 @@
 }
 
 // Show the mover in a single button under the contextual toolbar.
-.block-editor-block-mover {
+.block-editor-block-toolbar .block-editor-block-mover {
 	.components-toolbar {
 		flex-direction: column;
 	}

--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -46,7 +46,7 @@
 .block-editor-block-toolbar,
 .block-editor-format-toolbar {
 	// Toolbar buttons.
-	.components-button {
+	.components-toolbar .components-button {
 		position: relative;
 
 		// Give all buttons extra padding to fit text.

--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -42,6 +42,7 @@
 	}
 }
 
+.edit-post-sidebar,
 .block-editor-block-toolbar,
 .block-editor-format-toolbar {
 	// Toolbar buttons.

--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -42,7 +42,6 @@
 	}
 }
 
-.edit-post-sidebar,
 .block-editor-block-toolbar,
 .block-editor-format-toolbar {
 	// Toolbar buttons.

--- a/packages/components/src/toolbar-button/style.scss
+++ b/packages/components/src/toolbar-button/style.scss
@@ -1,6 +1,5 @@
 .components-toolbar__control.components-button {
 	position: relative;
-	border-radius: 0;
 
 	// Subscript for numbered icon buttons, like headings
 	&[data-subscript] svg {
@@ -25,10 +24,5 @@
 
 	&:not(:disabled).is-pressed[data-subscript]::after {
 		color: $white;
-	}
-
-	&.is-pressed {
-		color: $white;
-		background: $dark-gray-primary;
 	}
 }

--- a/packages/components/src/toolbar-button/style.scss
+++ b/packages/components/src/toolbar-button/style.scss
@@ -1,5 +1,6 @@
 .components-toolbar__control.components-button {
 	position: relative;
+	border-radius: 0;
 
 	// Subscript for numbered icon buttons, like headings
 	&[data-subscript] svg {
@@ -24,5 +25,10 @@
 
 	&:not(:disabled).is-pressed[data-subscript]::after {
 		color: $white;
+	}
+
+	&.is-pressed {
+		color: $white;
+		background: $dark-gray-primary;
 	}
 }

--- a/packages/edit-post/src/components/sidebar/style.scss
+++ b/packages/edit-post/src/components/sidebar/style.scss
@@ -65,15 +65,20 @@
 		margin: 1.5em 0;
 	}
 
-	div.components-toolbar {
-		box-shadow: none;
-		margin-bottom: 1.5em;
-		&:last-child {
-			margin-bottom: 0;
+	.components-toolbar {
+		height: $block-toolbar-height;
+		background: none;
+		border-radius: $radius-block-ui;
+		border-color: $dark-gray-primary;
+
+		.components-button {
+			margin-top: -$border-width;
+			height: $block-toolbar-height;
 		}
 	}
 
 	p + div.components-toolbar {
+		display: inline-flex;
 		margin-top: -1em;
 	}
 

--- a/packages/edit-post/src/components/sidebar/style.scss
+++ b/packages/edit-post/src/components/sidebar/style.scss
@@ -65,6 +65,9 @@
 		margin: 1.5em 0;
 	}
 
+	// This section of code duplicates many of the styles of the block toolbar.
+	// It would be good to refactor the block toolbar/components-toolbar to
+	// include those styles so we don't have to duplicate these styles here.
 	.components-toolbar {
 		height: $block-toolbar-height;
 		background: none;

--- a/packages/edit-post/src/components/sidebar/style.scss
+++ b/packages/edit-post/src/components/sidebar/style.scss
@@ -74,7 +74,48 @@
 		.components-button {
 			margin-top: -$border-width;
 			height: $block-toolbar-height;
+
+			svg {
+				position: relative;
+
+				// Center the icon inside.
+				margin-left: auto;
+				margin-right: auto;
+			}
+
+			&:focus {
+				box-shadow: none;
+			}
 		}
+
+		// Focus and toggle pseudo elements.
+		.components-button::before {
+			content: "";
+			position: absolute;
+			display: block;
+			border-radius: $radius-block-ui;
+			height: 32px;
+			min-width: 32px;
+
+			// Position the focus rectangle.
+			left: 2px;
+			right: 2px;
+		}
+
+		// Toggled style.
+		.components-button.is-pressed {
+			color: $white;
+
+			&::before {
+				background: $dark-gray-primary;
+			}
+		}
+
+		// Focus style.
+		.components-button:focus::before {
+			@include block-toolbar-button-style__focus();
+		}
+
 	}
 
 	p + div.components-toolbar {


### PR DESCRIPTION
## Description
In the G2 commit we lost the `is-pressed` styling for the heading block sidebar level select. This is a quick fix to get that back.

I also got rid of the border radius so it matched the is-pressed design of similar icons in the block toolbar. It also just looked odd with rounded corners inside a row with squared corners. 

Fixes: #21022

## Screenshots
Before:
![image](https://user-images.githubusercontent.com/4267290/77239579-a97b4400-6bb2-11ea-9951-02e369039f63.png)

After:
![image](https://user-images.githubusercontent.com/4267290/77239565-99fbfb00-6bb2-11ea-8883-75fd6d46155d.png)
