### PR TITLE
Fix the latest-posts block when `imageDimensions` is empty

### DIFF
--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -483,8 +483,16 @@ export default withSelect( ( select, props ) => {
 		.map( ( { name, slug } ) => ( { value: slug, label: name } ) );
 
 	return {
-		defaultImageWidth: imageDimensions[ featuredImageSizeSlug ].width,
-		defaultImageHeight: imageDimensions[ featuredImageSizeSlug ].height,
+		defaultImageWidth: get(
+			imageDimensions,
+			[ featuredImageSizeSlug, 'width' ],
+			0
+		),
+		defaultImageHeight: get(
+			imageDimensions,
+			[ featuredImageSizeSlug, 'height' ],
+			0
+		),
 		imageSizeOptions,
 		latestPosts: ! Array.isArray( posts )
 			? posts


### PR DESCRIPTION
## Description
We found a bug when testing the Latest Posts block on WordPress.com that caused the block to fail to load: https://github.com/Automattic/wp-calypso/issues/40127

There was a javascript crash caused by ` imageDimensions` array having missing values for certain sizes that we try to access without a null check via  `imageDimensions[featuredImageSizeSlug].height`

This PR adds a null check and defaults the image size to 0 if not values are found in the `imageDimensions` array.

## How has this been tested?
I tested this by modifying `imageDimensions` to be empty. The Latest Posts block was then able to load, save, preview, etc.

After applying this fix, I did notice that if you select the named percentage sizes: "25%, 50%, 75%, 100%" then the image's max-width is set to 0px. I'm not sure if that is related but it could be fixed in addition to this null check.

I also noticed that the Width and Height values that the user enters set `max-width` and `max-height` css properties. This means that only the lowest value of Width and Height is used, If this is deliberate, I think it should be communicated better to the user :)
