### PR TITLE
Allow entities to be marked as experimental

### DIFF
--- a/packages/core-data/src/index.js
+++ b/packages/core-data/src/index.js
@@ -20,19 +20,24 @@ import { REDUCER_KEY } from './name';
 // The "kind" and the "name" of the entity are combined to generate these shortcuts.
 
 const entitySelectors = defaultEntities.reduce( ( result, entity ) => {
-	const { kind, name } = entity;
-	result[ getMethodName( kind, name ) ] = ( state, key ) =>
+	const { kind, name, isExperimental = false } = entity;
+	const prefix = isExperimental ? '__experimentalGet' : 'get';
+	const singularMethodName = getMethodName( kind, name, prefix );
+	const pluralMethodName = getMethodName( kind, name, prefix, true );
+	result[ singularMethodName ] = ( state, key ) =>
 		selectors.getEntityRecord( state, kind, name, key );
-	result[ getMethodName( kind, name, 'get', true ) ] = ( state, ...args ) =>
+	result[ pluralMethodName ] = ( state, ...args ) =>
 		selectors.getEntityRecords( state, kind, name, ...args );
 	return result;
 }, {} );
 
 const entityResolvers = defaultEntities.reduce( ( result, entity ) => {
-	const { kind, name } = entity;
-	result[ getMethodName( kind, name ) ] = ( key ) =>
+	const { kind, name, isExperimental = false } = entity;
+	const prefix = isExperimental ? '__experimentalGet' : 'get';
+	const singularMethodName = getMethodName( kind, name, prefix );
+	const pluralMethodName = getMethodName( kind, name, prefix, true );
+	result[ singularMethodName ] = ( key ) =>
 		resolvers.getEntityRecord( kind, name, key );
-	const pluralMethodName = getMethodName( kind, name, 'get', true );
 	result[ pluralMethodName ] = ( ...args ) =>
 		resolvers.getEntityRecords( kind, name, ...args );
 	result[ pluralMethodName ].shouldInvalidate = ( action, ...args ) =>
@@ -46,8 +51,9 @@ const entityResolvers = defaultEntities.reduce( ( result, entity ) => {
 }, {} );
 
 const entityActions = defaultEntities.reduce( ( result, entity ) => {
-	const { kind, name } = entity;
-	result[ getMethodName( kind, name, 'save' ) ] = ( key ) =>
+	const { kind, name, isExperimental = false } = entity;
+	const prefix = isExperimental ? '__experimentalSave' : 'save';
+	result[ getMethodName( kind, name, prefix ) ] = ( key ) =>
 		actions.saveEntityRecord( kind, name, key );
 	return result;
 }, {} );


### PR DESCRIPTION
## Description
#21036 adds some experimental REST endpoints as entities, but these effectively become a stable api for the core data package. This allows entities to be marked as experimental to match the REST API endpoint, so that changes to the endpoint can also be made to the entity without backwards compat concerns.

When applied, generated entity function names are prefixed with `__experimental`. e.g. `__experimentalGetMenu` or `__experimentalSaveMenu`.

## How has this been tested?
Somewhat manually as there's no current tests for any of this code. It might be a good idea to move some of this code to a function in the future.

1. With a dev environment setup, mark an entity as experimental by adding `isExperimental: true` to its configuration.
2. Load the editor, and in the console try typing `wp.data.select( 'core' )` and observe the function names are prefixed with `__experimental`.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
