### PR TITLE
Use RichText instead of plain text for the Code block editing.

### DIFF
--- a/packages/block-library/src/code/edit.native.js
+++ b/packages/block-library/src/code/edit.native.js
@@ -43,6 +43,7 @@ export function CodeEdit( props ) {
 				} }
 				placeholder={ __( 'Write code…' ) }
 				style={ codeStyle }
+				enableAutoCorrection={ false }
 			/>
 		</View>
 	);

--- a/packages/block-library/src/code/edit.native.js
+++ b/packages/block-library/src/code/edit.native.js
@@ -6,14 +6,12 @@ import { View } from 'react-native';
 /**
  * WordPress dependencies
  */
-import { PlainText } from '@wordpress/block-editor';
+import { RichText } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import { withPreferredColorScheme } from '@wordpress/compose';
-
 /**
  * Internal dependencies
  */
-
 /**
  * Block code style
  */
@@ -22,36 +20,29 @@ import styles from './theme.scss';
 // Note: styling is applied directly to the (nested) PlainText component. Web-side components
 // apply it to the container 'div' but we don't have a proper proposal for cascading styling yet.
 export function CodeEdit( props ) {
-	const {
-		attributes,
-		setAttributes,
-		onFocus,
-		onBlur,
-		getStylesFromColorScheme,
-	} = props;
+	const { attributes, setAttributes, getStylesFromColorScheme } = props;
 	const codeStyle = getStylesFromColorScheme(
 		styles.blockCode,
 		styles.blockCodeDark
 	);
-	const placeholderStyle = getStylesFromColorScheme(
-		styles.placeholder,
-		styles.placeholderDark
-	);
 
 	return (
-		<View>
-			<PlainText
+		<View style={ codeStyle }>
+			<RichText
+				tagName="pre"
+				preserveWhiteSpace
 				value={ attributes.content }
-				style={ codeStyle }
-				multiline={ true }
-				underlineColorAndroid="transparent"
-				onChange={ ( content ) => setAttributes( { content } ) }
+				onChange={ ( nextContent ) => {
+					const cleanContent = nextContent.replace(
+						RegExp( '<br>', 'gim' ),
+						'\n'
+					);
+					setAttributes( {
+						content: cleanContent,
+					} );
+				} }
 				placeholder={ __( 'Write code…' ) }
-				aria-label={ __( 'Code' ) }
-				isSelected={ props.isSelected }
-				onFocus={ onFocus }
-				onBlur={ onBlur }
-				placeholderTextColor={ placeholderStyle.color }
+				style={ codeStyle }
 			/>
 		</View>
 	);

--- a/packages/block-library/src/code/edit.native.js
+++ b/packages/block-library/src/code/edit.native.js
@@ -44,6 +44,8 @@ export function CodeEdit( props ) {
 				placeholder={ __( 'Write code…' ) }
 				style={ codeStyle }
 				enableAutoCorrection={ false }
+				disableEditingMenu={ true }
+				__unstableDisableFormats={ true }
 			/>
 		</View>
 	);

--- a/packages/rich-text/src/component/index.native.js
+++ b/packages/rich-text/src/component/index.native.js
@@ -700,6 +700,7 @@ export class RichText extends Component {
 			formatTypes,
 			parentBlockStyles,
 			withoutInteractiveFormatting,
+			enableAutoCorrection,
 		} = this.props;
 
 		const record = this.getRecord();
@@ -858,6 +859,7 @@ export class RichText extends Component {
 					minWidth={ minWidth }
 					id={ this.props.id }
 					selectionColor={ this.props.selectionColor }
+					enableAutoCorrection={ enableAutoCorrection }
 				/>
 				{ isSelected && (
 					<FormatEdit


### PR DESCRIPTION
Replacing the PlainText component with the RichText will allow the scrollto caret functionality to work on the block.

## Description
<!-- Please describe what you have changed or added -->

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

This can be tested using this GB mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/2047

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
