### PR TITLE
[ Navigation ] Fix dynamic rendering recursive function name typo

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -272,7 +272,7 @@ function block_core_navigation_build_html( $attributes, $block, $colors, $font_s
 		// End anchor tag content.
 
 		if ( $has_submenu ) {
-			$html .= core_block_navigation_build_html( $attributes, $block, $colors, $font_sizes );
+			$html .= block_core_navigation_build_html( $attributes, $block, $colors, $font_sizes );
 		}
 
 		$html .= '</li>';


### PR DESCRIPTION
## Description
Somehow I managed to botch master by merging #20076 which had the rendering function named wrong.

## How has this been tested?
Tested locally. Before the change attempting to view a page or post containing a navigation menu resulted in:

```PHP
Fatal error: Uncaught Error: Call to undefined function core_block_navigation_build_html()
```

## Types of changes
Bug fix.

