### PR TITLE
Lighter block DOM: Code

### DIFF
--- a/packages/block-editor/src/components/block-list/block-wrapper.js
+++ b/packages/block-editor/src/components/block-list/block-wrapper.js
@@ -238,6 +238,7 @@ const elements = [
 	'li',
 	'figure',
 	'nav',
+	'pre',
 ];
 
 const ExtendedBlockComponent = elements.reduce( ( acc, element ) => {

--- a/packages/block-editor/src/components/editable-text/index.js
+++ b/packages/block-editor/src/components/editable-text/index.js
@@ -9,7 +9,14 @@ import { forwardRef } from '@wordpress/element';
 import RichText from '../rich-text';
 
 const EditableText = forwardRef( ( props, ref ) => {
-	return <RichText ref={ ref } { ...props } __unstableDisableFormats />;
+	return (
+		<RichText
+			ref={ ref }
+			{ ...props }
+			__unstableDisableFormats
+			preserveWhiteSpace
+		/>
+	);
 } );
 
 EditableText.Content = ( { value = '', tagName: Tag = 'div', ...props } ) => {

--- a/packages/block-library/src/code/edit.js
+++ b/packages/block-library/src/code/edit.js
@@ -6,17 +6,22 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { PlainText } from '@wordpress/block-editor';
+import {
+	PlainText,
+	__experimentalBlock as Block,
+} from '@wordpress/block-editor';
 
-export default function CodeEdit( { attributes, setAttributes, className } ) {
+export default function CodeEdit( { attributes, setAttributes } ) {
 	return (
-		<div className={ className }>
+		<Block.pre>
 			<PlainText
+				__experimentalVersion={ 2 }
+				tagName="code"
 				value={ attributes.content }
 				onChange={ ( content ) => setAttributes( { content } ) }
 				placeholder={ __( 'Write code…' ) }
 				aria-label={ __( 'Code' ) }
 			/>
-		</div>
+		</Block.pre>
 	);
 }

--- a/packages/block-library/src/code/editor.scss
+++ b/packages/block-library/src/code/editor.scss
@@ -1,14 +1,4 @@
-.wp-block-code .block-editor-plain-text {
-	font-family: $editor-html-font;
-	color: $dark-gray-800;
-
-	/* Fonts smaller than 16px causes mobile safari to zoom. */
-	font-size: $mobile-text-min-font-size;
-	@include break-small {
-		font-size: $default-font-size;
-	}
-
-	&:focus {
-		box-shadow: none;
-	}
+.wp-block-code > code {
+	// PlainText cannot be an inline element yet.
+	display: block;
 }

--- a/packages/block-library/src/code/index.js
+++ b/packages/block-library/src/code/index.js
@@ -32,6 +32,7 @@ export const settings = {
 	},
 	supports: {
 		html: false,
+		lightBlockWrapper: true,
 	},
 	transforms,
 	edit,

--- a/packages/e2e-tests/specs/editor/various/convert-block-type.test.js
+++ b/packages/e2e-tests/specs/editor/various/convert-block-type.test.js
@@ -17,8 +17,7 @@ describe( 'Code block', () => {
 		const code = 'print "Hello Dolly!"';
 
 		await insertBlock( 'Code' );
-
-		await page.type( '.block-editor-block-list__block textarea', code );
+		await page.keyboard.type( code );
 
 		// Verify the content starts out as a Code block.
 		const originalPostContent = await getEditedPostContent();

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -40,6 +40,7 @@ import { isEmptyLine } from '../is-empty';
 import withFormatTypes from './with-format-types';
 import { BoundaryStyle } from './boundary-style';
 import { InlineWarning } from './inline-warning';
+import { insert } from '../insert';
 
 /** @typedef {import('@wordpress/element').WPSyntheticEvent} WPSyntheticEvent */
 
@@ -257,6 +258,7 @@ class RichText extends Component {
 			formatTypes,
 			onPaste,
 			__unstableIsSelected: isSelected,
+			__unstableDisableFormats,
 		} = this.props;
 		const { activeFormats = [] } = this.state;
 
@@ -298,6 +300,11 @@ class RichText extends Component {
 		// Allows us to ask for this information when we get a report.
 		window.console.log( 'Received HTML:\n\n', html );
 		window.console.log( 'Received plain text:\n\n', plainText );
+
+		if ( __unstableDisableFormats ) {
+			this.onChange( insert( this.record, plainText ) );
+			return;
+		}
 
 		const record = this.record;
 		const transformed = formatTypes.reduce(


### PR DESCRIPTION
## Description

Makes the Code block a light block and uses PlainText v2.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
