### PR TITLE
Editor: Deprecate ServerSideRender in favour of @wordpress/server-side-render

### DIFF
--- a/packages/editor/src/components/deprecated.js
+++ b/packages/editor/src/components/deprecated.js
@@ -61,12 +61,12 @@ import {
 	withFontSizes as rootWithFontSizes,
 } from '@wordpress/block-editor';
 
-export { default as ServerSideRender } from '@wordpress/server-side-render';
+import { default as RootServerSideRender } from '@wordpress/server-side-render';
 
-function deprecateComponent( name, Wrapped, staticsToHoist = [] ) {
+function deprecateComponent( name, Wrapped, staticsToHoist = [], alternative ) {
 	const Component = forwardRef( ( props, ref ) => {
 		deprecated( 'wp.editor.' + name, {
-			alternative: 'wp.blockEditor.' + name,
+			alternative: alternative || 'wp.blockEditor.' + name,
 		} );
 
 		return <Wrapped ref={ ref } { ...props } />;
@@ -228,6 +228,12 @@ export const ObserveTyping = deprecateComponent(
 export const PreserveScrollInReorder = deprecateComponent(
 	'PreserveScrollInReorder',
 	RootPreserveScrollInReorder
+);
+export const ServerSideRender = deprecateComponent(
+	'ServerSideRender',
+	RootServerSideRender,
+	[],
+	'wp.serverSideRender'
 );
 export const SkipToSelectedBlock = deprecateComponent(
 	'SkipToSelectedBlock',


### PR DESCRIPTION
## Description

Use of component `wp.editor.ServerSideRender` now raises a deprecation warning recommending `wp.serverSideRender` as an alternative.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
