### PR TITLE
Data: Migrate post editor persistence with fullscreenMode false

### DIFF
--- a/packages/data/src/plugins/persistence/index.js
+++ b/packages/data/src/plugins/persistence/index.js
@@ -246,6 +246,26 @@ persistencePlugin.__unstableMigrate = ( pluginOptions ) => {
 		} );
 	}
 
+	let editPostState = state[ 'core/edit-post' ];
+
+	// Default `fullscreenMode` to `false` if any persisted state had existed
+	// and the user hadn't made an explicit choice about fullscreen mode. This
+	// is needed since `fullscreenMode` previously did not have a default value
+	// and was implicitly false by its absence. It is now `true` by default, but
+	// this change is not intended to affect upgrades from earlier versions.
+	const hadPersistedState = Object.keys( state ).length > 0;
+	const hadFullscreenModePreference = has( state, [
+		'core/edit-post',
+		'preferences',
+		'features',
+		'fullscreenMode',
+	] );
+	if ( hadPersistedState && ! hadFullscreenModePreference ) {
+		editPostState = merge( {}, editPostState, {
+			preferences: { features: { fullscreenMode: false } },
+		} );
+	}
+
 	// Migrate 'areTipsEnabled' from 'core/nux' to 'showWelcomeGuide' in 'core/edit-post'
 	const areTipsEnabled = get( state, [
 		'core/nux',
@@ -259,16 +279,17 @@ persistencePlugin.__unstableMigrate = ( pluginOptions ) => {
 		'welcomeGuide',
 	] );
 	if ( areTipsEnabled !== undefined && ! hasWelcomeGuide ) {
-		persistence.set(
-			'core/edit-post',
-			merge( state[ 'core/edit-post' ], {
-				preferences: {
-					features: {
-						welcomeGuide: areTipsEnabled,
-					},
+		editPostState = merge( {}, editPostState, {
+			preferences: {
+				features: {
+					welcomeGuide: areTipsEnabled,
 				},
-			} )
-		);
+			},
+		} );
+	}
+
+	if ( editPostState !== state[ 'core/edit-post' ] ) {
+		persistence.set( 'core/edit-post', editPostState );
 	}
 };
 


### PR DESCRIPTION
Fixes #20956

This pull request seeks to resolve an issue where the fullscreen mode would not default to `false` for a user who had previously interacted with the editor, but who had not made an explicit choice to enable or disable the fullscreen mode setting.

This issue stems in-part from the fact that prior to #20611, there was no default value assigned for the `fullscreenMode` preference, and it was implicitly treated as `false`. Thus, as of #20611, even if there was persisted state for the editor, the absence of this default value would cause the _new_ default (`true`) to take effect.

This is compounded with the fact that state is only persisted at the point that any of the preferences within a given store have been changed. Thus, if a user did not change any of the [post editor default preferences](https://github.com/WordPress/gutenberg/blob/master/packages/edit-post/src/store/defaults.js), the full set of new defaults would be used.

The proposed changes seek to resolve this by considering at first load whether any persisted state had existed previously (for all stores) to use as an indication that the user had previously interacted with the editor. If state had existed, but the user did not have a default value assigned for `fullscreenMode`, then a value of `false` is assigned.

This works in large part due to the fact that the "New User Experience" tips are a preference value. At the point a user dismisses these tips (even if by navigating elsewhere in the admin), this preferenece is persisted and leveraged as a marker for prior interaction.

Before|After
---|---
If the user had interacted with the editor previously but had not made a choice of full screen preference: **Use `true`**.|If the user had interacted with the editor previously but had not made a choice of full screen preference: **Use `false`**.
If the user had interacted with the editor previously and had made a choice of full screen preference: **Use their chosen preference**.|If the user had interacted with the editor previously and had made a choice of full screen preference: **Use their chosen preference**.
If the user had never interacted with the editor previously. **Use `true`**.|If the user had never interacted with the editor previously. **Use `true`**.

**Implementation Notes:**

For the purposes of setting a default persistence value, the implementation is based in part on prior art from [NUX to welcome guide](https://github.com/WordPress/gutenberg/blob/9f0471e36aaf4a7172cc567494a8b9e4561861db/packages/data/src/plugins/persistence/index.js#L249-L272) migration.

While this function [was originally marked for removal](https://github.com/WordPress/gutenberg/blob/9f0471e36aaf4a7172cc567494a8b9e4561861db/packages/data/src/plugins/persistence/index.js#L225-L228), given the recent additions of Welcome Mode migration, this is not likely for the near future.

In initial implementations, I had observed some sporadic behavior in whether the default would take effect. I believe this was caused by conflicts with the two separate migrations attempting to merge to the same state. Even [changing this mutation](https://github.com/WordPress/gutenberg/blob/9f0471e36aaf4a7172cc567494a8b9e4561861db/packages/data/src/plugins/persistence/index.js#L264) was not enough. It may be that since persistence operates with localStorage, there was a race condition causing only one of the two migrations to "take hold". The proposed implementation seeks to try to make this more durable by calling `persistence.set` at most one time for both of these migrations.

**Testing Instructions:**

Run through each of the scenarios above, confirming the expected outcomes.

In testing, you will likely want to be running a site on WordPress 5.3.2. For each scenario, start fresh with localStorage by either running `localStorage.clear()` in your browser console prior (ideally on a screen other than the editor). For simulating the case of a user having made some prior interaction with the editor, you should perform this action while the Gutenberg plugin is disabled.