### PR TITLE
Components: Storybook: Update AnglePickerControl title

### DIFF
--- a/packages/components/src/angle-picker-control/stories/index.js
+++ b/packages/components/src/angle-picker-control/stories/index.js
@@ -9,7 +9,7 @@ import { useState } from '@wordpress/element';
 import AnglePickerControl from '../';
 
 export default {
-	title: 'Components|AnglePickerControl',
+	title: 'Components/AnglePickerControl',
 	component: AnglePickerControl,
 };
 

--- a/storybook/test/__snapshots__/index.js.snap
+++ b/storybook/test/__snapshots__/index.js.snap
@@ -1,5 +1,44 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Storyshots Components/AnglePickerControl Default 1`] = `
+<div
+  className="components-base-control components-angle-picker-control"
+>
+  <div
+    className="components-base-control__field"
+  >
+    <label
+      className="components-base-control__label"
+      htmlFor="components-angle-picker-control__input-0"
+    >
+      Angle
+    </label>
+    <div
+      aria-hidden="true"
+      className="components-angle-picker-control__angle-circle"
+      onMouseDown={[Function]}
+    >
+      <div
+        className="components-angle-picker-control__angle-circle-indicator-wrapper"
+      >
+        <span
+          className="components-angle-picker-control__angle-circle-indicator"
+        />
+      </div>
+    </div>
+    <input
+      className="components-angle-picker-control__input-field"
+      id="components-angle-picker-control__input-0"
+      max={360}
+      min={0}
+      onChange={[Function]}
+      step="1"
+      type="number"
+    />
+  </div>
+</div>
+`;
+
 exports[`Storyshots Components/Animate Appear Bottom Left 1`] = `
 <div
   className="components-animate__appear is-from-left is-from-bottom components-notice is-success is-dismissible"
@@ -8911,45 +8950,6 @@ Array [
   </span>,
   "Inspect the HTML to see!",
 ]
-`;
-
-exports[`Storyshots Components|AnglePickerControl Default 1`] = `
-<div
-  className="components-base-control components-angle-picker-control"
->
-  <div
-    className="components-base-control__field"
-  >
-    <label
-      className="components-base-control__label"
-      htmlFor="components-angle-picker-control__input-0"
-    >
-      Angle
-    </label>
-    <div
-      aria-hidden="true"
-      className="components-angle-picker-control__angle-circle"
-      onMouseDown={[Function]}
-    >
-      <div
-        className="components-angle-picker-control__angle-circle-indicator-wrapper"
-      >
-        <span
-          className="components-angle-picker-control__angle-circle-indicator"
-        />
-      </div>
-    </div>
-    <input
-      className="components-angle-picker-control__input-field"
-      id="components-angle-picker-control__input-0"
-      max={360}
-      min={0}
-      onChange={[Function]}
-      step="1"
-      type="number"
-    />
-  </div>
-</div>
 `;
 
 exports[`Storyshots Icons/Icon Default 1`] = `


### PR DESCRIPTION
## Description

This update modifies the `AnglePickerControl` storybook title to use `/` instead of `|`.

Storybook is deprecating custom separators, opting for `/` only.
We've updated the other titles. This one was missed!

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->


Resolves: https://github.com/WordPress/gutenberg/issues/21085