### PR TITLE
IE11: fix focus on backspace

### DIFF
--- a/packages/rich-text/src/to-dom.js
+++ b/packages/rich-text/src/to-dom.js
@@ -305,21 +305,15 @@ export function applySelection( { startPath, endPath }, current ) {
 
 	// This function is not intended to cause a shift in focus. Since the above
 	// selection manipulations may shift focus, ensure that focus is restored to
-	// its previous state. `activeElement` can be `null` or the body element if
-	// there is no focus, which is accounted for here in the explicit `blur` to
-	// restore to a state of non-focus.
+	// its previous state.
 	if ( activeElement !== document.activeElement ) {
 		// The `instanceof` checks protect against edge cases where the focused
 		// element is not of the interface HTMLElement (does not have a `focus`
 		// or `blur` property).
 		//
 		// See: https://github.com/Microsoft/TypeScript/issues/5901#issuecomment-431649653
-		if ( activeElement ) {
-			if ( activeElement instanceof window.HTMLElement ) {
-				activeElement.focus();
-			}
-		} else if ( document.activeElement instanceof window.HTMLElement ) {
-			document.activeElement.blur();
+		if ( activeElement instanceof window.HTMLElement ) {
+			activeElement.focus();
 		}
 	}
 }


### PR DESCRIPTION
## Description

Fixes #20598. Introduced in #20594.

## How has this been tested?

See #20598. Needs testing in IE11.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
