### PR TITLE
Fix movers in full-wide.

### DIFF
--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -202,8 +202,17 @@
 			top: -1px;
 			transform: translateX(-48px);
 			user-select: none;
-			z-index: -1; // This makes it slide out from underneath the toolbar.
 		}
+	}
+
+	// Explicitly color the background of the switcher to "cover" the mover control as it animates out.
+	.block-editor-block-toolbar__block-switcher-wrapper {
+		background: $white;
+		border-left: $border-width solid;
+		border-radius: 0 0 $radius-block-ui $radius-block-ui;
+		position: relative;
+		z-index: 1;
+		margin-left: -$border-width;
 	}
 
 	.block-editor-block-toolbar__mover-trigger-wrapper:not(:empty) {


### PR DESCRIPTION
Fixes #20451. Props @lgersman for advice.

The mover control did not work for full-wide images. I'm honestly surprised it worked in wide and normal settings, because the z-index was -1 meaning it shouldn't be. I suspect it's because the layout canvas has padding left and right that somehow interferes with things here, but couldn't verify.

However the negative z index wasn't a good fix in the first place. The reason it was there, was to make sure that when the mover control animates out, it appears to be coming from "beneath" the block toolbar. The z-index put it below the entire block toolbar, which is the container that has a background color.

This PR changes things so the mover control does not have a z-index, but the switcher button has been elevated, and been given a white background color to cover it.

![movers](https://user-images.githubusercontent.com/1204802/77406203-92a43f80-6db4-11ea-8f24-40c9279d2eee.gif)
