### PR TITLE
RichText: make window/document agnostic

### DIFF
--- a/packages/rich-text/src/component/boundary-style.js
+++ b/packages/rich-text/src/component/boundary-style.js
@@ -4,15 +4,6 @@
 import { useEffect } from '@wordpress/element';
 
 /**
- * Global stylesheet shared by all RichText instances.
- */
-const globalStyle = document.createElement( 'style' );
-
-const boundarySelector = '*[data-rich-text-format-boundary]';
-
-document.head.appendChild( globalStyle );
-
-/**
  * Calculates and renders the format boundary style when the active formats
  * change.
  */
@@ -24,19 +15,31 @@ export function BoundaryStyle( { activeFormats, forwardedRef } ) {
 			return;
 		}
 
+		const boundarySelector = '*[data-rich-text-format-boundary]';
 		const element = forwardedRef.current.querySelector( boundarySelector );
 
 		if ( ! element ) {
 			return;
 		}
 
-		const computedStyle = window.getComputedStyle( element );
+		const { ownerDocument } = element;
+		const { defaultView } = ownerDocument;
+		const computedStyle = defaultView.getComputedStyle( element );
 		const newColor = computedStyle.color
 			.replace( ')', ', 0.2)' )
 			.replace( 'rgb', 'rgba' );
 		const selector = `.rich-text:focus ${ boundarySelector }`;
 		const rule = `background-color: ${ newColor }`;
 		const style = `${ selector } {${ rule }}`;
+		const globalStyleId = 'rich-text-boundary-style';
+
+		let globalStyle = ownerDocument.getElementById( globalStyleId );
+
+		if ( ! globalStyle ) {
+			globalStyle = ownerDocument.createElement( 'style' );
+			globalStyle.id = globalStyleId;
+			ownerDocument.head.appendChild( globalStyle );
+		}
 
 		if ( globalStyle.innerHTML !== style ) {
 			globalStyle.innerHTML = style;

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -41,12 +41,6 @@ import withFormatTypes from './with-format-types';
 import { BoundaryStyle } from './boundary-style';
 import { InlineWarning } from './inline-warning';
 
-/**
- * Browser dependencies
- */
-
-const { getComputedStyle } = window;
-
 /** @typedef {import('@wordpress/element').WPSyntheticEvent} WPSyntheticEvent */
 
 /**
@@ -850,7 +844,7 @@ class RichText extends Component {
 		const { text, formats, start, end, activeFormats = [] } = value;
 		const collapsed = isCollapsed( value );
 		// To do: ideally, we should look at visual position instead.
-		const { direction } = getComputedStyle(
+		const { direction } = this.getWindow().getComputedStyle(
 			this.props.forwardedRef.current
 		);
 		const reverseKey = direction === 'rtl' ? RIGHT : LEFT;

--- a/packages/rich-text/src/component/inline-warning.js
+++ b/packages/rich-text/src/component/inline-warning.js
@@ -6,9 +6,9 @@ import { useEffect } from '@wordpress/element';
 export function InlineWarning( { forwardedRef } ) {
 	useEffect( () => {
 		if ( process.env.NODE_ENV === 'development' ) {
-			const computedStyle = window.getComputedStyle(
-				forwardedRef.current
-			);
+			const target = forwardedRef.current;
+			const { defaultView } = target.ownerDocument;
+			const computedStyle = defaultView.getComputedStyle( target );
 
 			if ( computedStyle.display === 'inline' ) {
 				// eslint-disable-next-line no-console

--- a/packages/rich-text/src/create.js
+++ b/packages/rich-text/src/create.js
@@ -16,12 +16,6 @@ import {
 	ZWNBSP,
 } from './special-characters';
 
-/**
- * Browser dependencies
- */
-
-const { TEXT_NODE, ELEMENT_NODE } = window.Node;
-
 function createEmptyValue() {
 	return {
 		formats: [],
@@ -160,6 +154,8 @@ export function create( {
 	}
 
 	if ( typeof html === 'string' && html.length > 0 ) {
+		// It does not matter which document this is, we're just using it to
+		// parse.
 		element = createElement( document, html );
 	}
 
@@ -208,7 +204,7 @@ function accumulateSelection( accumulator, node, range, value ) {
 	if ( value.start !== undefined ) {
 		accumulator.start = currentLength + value.start;
 		// Range indicates that the current node has selection.
-	} else if ( node === startContainer && node.nodeType === TEXT_NODE ) {
+	} else if ( node === startContainer && node.nodeType === node.TEXT_NODE ) {
 		accumulator.start = currentLength + startOffset;
 		// Range indicates that the current node is selected.
 	} else if (
@@ -231,7 +227,7 @@ function accumulateSelection( accumulator, node, range, value ) {
 	if ( value.end !== undefined ) {
 		accumulator.end = currentLength + value.end;
 		// Range indicates that the current node has selection.
-	} else if ( node === endContainer && node.nodeType === TEXT_NODE ) {
+	} else if ( node === endContainer && node.nodeType === node.TEXT_NODE ) {
 		accumulator.end = currentLength + endOffset;
 		// Range indicates that the current node is selected.
 	} else if (
@@ -342,7 +338,7 @@ function createFromElement( {
 		const node = element.childNodes[ index ];
 		const type = node.nodeName.toLowerCase();
 
-		if ( node.nodeType === TEXT_NODE ) {
+		if ( node.nodeType === node.TEXT_NODE ) {
 			let filter = removePadding;
 
 			if ( ! preserveWhiteSpace ) {
@@ -361,7 +357,7 @@ function createFromElement( {
 			continue;
 		}
 
-		if ( node.nodeType !== ELEMENT_NODE ) {
+		if ( node.nodeType !== node.ELEMENT_NODE ) {
 			continue;
 		}
 

--- a/packages/rich-text/src/to-dom.js
+++ b/packages/rich-text/src/to-dom.js
@@ -6,12 +6,6 @@ import { toTree } from './to-tree';
 import { createElement } from './create-element';
 
 /**
- * Browser dependencies
- */
-
-const { TEXT_NODE } = window.Node;
-
-/**
  * Creates a path as an array of indices from the given root node to the given
  * node.
  *
@@ -59,18 +53,6 @@ function getNodeByPath( node, path ) {
 	};
 }
 
-/**
- * Returns a new instance of a DOM tree upon which RichText operations can be
- * applied.
- *
- * Note: The current implementation will return a shared reference, reset on
- * each call to `createEmpty`. Therefore, you should not hold a reference to
- * the value to operate upon asynchronously, as it may have unexpected results.
- *
- * @return {Object} RichText tree.
- */
-const createEmpty = () => createElement( document, '' );
-
 function append( element, child ) {
 	if ( typeof child === 'string' ) {
 		child = element.ownerDocument.createTextNode( child );
@@ -101,8 +83,8 @@ function getParent( { parentNode } ) {
 	return parentNode;
 }
 
-function isText( { nodeType } ) {
-	return nodeType === TEXT_NODE;
+function isText( node ) {
+	return node.nodeType === node.TEXT_NODE;
 }
 
 function getText( { nodeValue } ) {
@@ -119,6 +101,7 @@ export function toDom( {
 	prepareEditableTree,
 	isEditableTree = true,
 	placeholder,
+	doc,
 } ) {
 	let startPath = [];
 	let endPath = [];
@@ -129,6 +112,18 @@ export function toDom( {
 			formats: prepareEditableTree( value ),
 		};
 	}
+
+	/**
+	 * Returns a new instance of a DOM tree upon which RichText operations can be
+	 * applied.
+	 *
+	 * Note: The current implementation will return a shared reference, reset on
+	 * each call to `createEmpty`. Therefore, you should not hold a reference to
+	 * the value to operate upon asynchronously, as it may have unexpected results.
+	 *
+	 * @return {Object} RichText tree.
+	 */
+	const createEmpty = () => createElement( doc, '' );
 
 	const tree = toTree( {
 		value,
@@ -186,6 +181,7 @@ export function apply( {
 		multilineTag,
 		prepareEditableTree,
 		placeholder,
+		doc: current.ownerDocument,
 	} );
 
 	applyValue( body, current );
@@ -207,7 +203,7 @@ export function applyValue( future, current ) {
 		} else if ( ! currentChild.isEqualNode( futureChild ) ) {
 			if (
 				currentChild.nodeName !== futureChild.nodeName ||
-				( currentChild.nodeType === TEXT_NODE &&
+				( currentChild.nodeType === currentChild.TEXT_NODE &&
 					currentChild.data !== futureChild.data )
 			) {
 				current.replaceChild( futureChild, currentChild );
@@ -282,8 +278,9 @@ export function applySelection( { startPath, endPath }, current ) {
 		current,
 		endPath
 	);
-	const selection = window.getSelection();
 	const { ownerDocument } = current;
+	const { defaultView } = ownerDocument;
+	const selection = defaultView.getSelection();
 	const range = ownerDocument.createRange();
 
 	range.setStart( startContainer, startOffset );
@@ -306,13 +303,13 @@ export function applySelection( { startPath, endPath }, current ) {
 	// This function is not intended to cause a shift in focus. Since the above
 	// selection manipulations may shift focus, ensure that focus is restored to
 	// its previous state.
-	if ( activeElement !== document.activeElement ) {
+	if ( activeElement !== ownerDocument.activeElement ) {
 		// The `instanceof` checks protect against edge cases where the focused
 		// element is not of the interface HTMLElement (does not have a `focus`
 		// or `blur` property).
 		//
 		// See: https://github.com/Microsoft/TypeScript/issues/5901#issuecomment-431649653
-		if ( activeElement instanceof window.HTMLElement ) {
+		if ( activeElement instanceof defaultView.HTMLElement ) {
 			activeElement.focus();
 		}
 	}

--- a/packages/rich-text/src/to-dom.js
+++ b/packages/rich-text/src/to-dom.js
@@ -101,7 +101,7 @@ export function toDom( {
 	prepareEditableTree,
 	isEditableTree = true,
 	placeholder,
-	doc,
+	doc = document,
 } ) {
 	let startPath = [];
 	let endPath = [];


### PR DESCRIPTION
## Description

I'm splitting this out from #21102. This PR will be needed to allow rich text to work inside an iframe. To be honest, this is something that should be done anyway, as it's good practice not to depend on globals. This PR uses the rich text element's window/document rather than the global window/document.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
