### PR TITLE
Block Editor: Disable autocomplete for Custom Class name Input

### DIFF
--- a/packages/block-editor/src/hooks/custom-class-name.js
+++ b/packages/block-editor/src/hooks/custom-class-name.js
@@ -65,6 +65,7 @@ export const withInspectorControl = createHigherOrderComponent(
 						<BlockEdit { ...props } />
 						<InspectorAdvancedControls>
 							<TextControl
+								autoComplete="off"
 								label={ __( 'Additional CSS class(es)' ) }
 								value={ props.attributes.className || '' }
 								onChange={ ( nextValue ) => {


### PR DESCRIPTION
## Description

This update disables autocomplete for the CSS Class input that appears under "Advanced" within the Block Editor.

### Before
<img width="511" alt="Screen Shot 2020-03-24 at 11 36 55 AM" src="https://user-images.githubusercontent.com/2322354/77446076-48c35580-6dc4-11ea-8eb5-d40e48ddd21b.png">


### After
<img width="281" alt="Screen Shot 2020-03-24 at 11 37 35 AM" src="https://user-images.githubusercontent.com/2322354/77446097-4d880980-6dc4-11ea-865f-3ec750fb5eca.png">


## How has this been tested?
* Tested locally in Gutenberg


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->


Resolves: https://github.com/WordPress/gutenberg/issues/21093