### PR TITLE
Automated Testing: Try composer non-interactive flag for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,7 +91,7 @@ install:
     fi
   - |
     if [[ "$INSTALL_COMPOSER" = "true" ]]; then
-      npm run env docker-run -- php composer install
+      npm run env docker-run -- php composer install --no-interaction
     fi
   - |
     if [[ "$E2E_ROLE" = "author" ]]; then
@@ -152,12 +152,12 @@ jobs:
         - npm run test-unit:native -- --ci --maxWorkers=2 --cacheDirectory="$HOME/.jest-cache"
 
     - name: PHP unit tests
-      env: INSTALL_COMPOSER=true COMPOSER_NO_INTERACTION=1
+      env: INSTALL_COMPOSER=true
       script:
         - npm run test-php && npm run test-unit-php-multisite
 
     - name: PHP unit tests (PHP 5.6)
-      env: INSTALL_COMPOSER=true LOCAL_PHP=5.6-fpm COMPOSER_NO_INTERACTION=1
+      env: INSTALL_COMPOSER=true LOCAL_PHP=5.6-fpm
       script:
         - npm run test-php && npm run test-unit-php-multisite
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -152,12 +152,12 @@ jobs:
         - npm run test-unit:native -- --ci --maxWorkers=2 --cacheDirectory="$HOME/.jest-cache"
 
     - name: PHP unit tests
-      env: INSTALL_COMPOSER=true
+      env: INSTALL_COMPOSER=true COMPOSER_NO_INTERACTION=1
       script:
         - npm run test-php && npm run test-unit-php-multisite
 
     - name: PHP unit tests (PHP 5.6)
-      env: INSTALL_COMPOSER=true LOCAL_PHP=5.6-fpm
+      env: INSTALL_COMPOSER=true LOCAL_PHP=5.6-fpm COMPOSER_NO_INTERACTION=1
       script:
         - npm run test-php && npm run test-unit-php-multisite
 


### PR DESCRIPTION
This pull request seeks to attempt to resolve rate-limit errors which have become increasingly common in Travis builds lately:

- https://travis-ci.com/github/WordPress/gutenberg/jobs/301962702
- https://travis-ci.com/github/WordPress/gutenberg/jobs/301931757
- https://travis-ci.com/github/WordPress/gutenberg/jobs/301903064
- https://travis-ci.com/github/WordPress/gutenberg/jobs/301838013
- https://travis-ci.com/github/WordPress/gutenberg/jobs/301837884

>GitHub API limit (0 calls/hr) is exhausted, could not fetch https://api.github.com/repos/composer/installers/zipball/cfcca6b1b60bc4974324efb5783c13dca6932b5b. Create a GitHub OAuth token to go over the API rate limit. You can also wait until ? for the rate limit to reset.

It's unclear what is causing this to suddenly become an issue. There are related discussions which seem to imply that there should be no rate limit ([example](https://github.com/composer/composer/issues/4884#issuecomment-195229989)). The messaging in the error itself is also rather nonsensical ("0 calls/hr" limit, "wait until ? for the rate limit to reset"). It may in-fact be an issue of either Travis and/or GitHub.

The proposed changes are based upon the advice at https://github.com/composer/composer/issues/1314#issuecomment-10266196 . Notably, this changes the behavior to fall back on a clone fallback if unable to fetch the composer dependencies ([source](https://github.com/composer/composer/blob/7e679656a4a847f49b06a5ca3117e67223591063/src/Composer/Repository/Vcs/GitHubDriver.php#L429-L431)). As implemented here, this can also be provided as an environment variable `COMPOSER_NO_INTERACTION` (https://github.com/composer/composer/commit/83ea90296e001c3df6f1eb9933db65c1d45a1b37). Generally speaking, it is sensible that we would configure Travis builds to run commands in a non-interactive mode when available.

**Testing Instructions:**

If build history is any indication, the changes here can be assumed to be effective if the build merely passes.