### PR TITLE
Add storybook story for DropdownMenu component

### DIFF
--- a/packages/components/src/dropdown-menu/stories/index.js
+++ b/packages/components/src/dropdown-menu/stories/index.js
@@ -1,0 +1,27 @@
+/**
+ * External dependencies
+ */
+import { text, object } from '@storybook/addon-knobs';
+
+/**
+ * Internal dependencies
+ */
+import DropdownMenu from '../';
+
+export default { title: 'Components/DropdownMenu', component: DropdownMenu };
+
+export const _default = () => {
+	const label = text( 'Label', 'Select a direction.' );
+	const icon = text( 'Icon', 'ellipsis' );
+	const controls = object( 'Controls', [
+		{
+			title: 'Up',
+			icon: 'arrow-up',
+		},
+		{
+			title: 'Down',
+			icon: 'arrow-down',
+		},
+	] );
+	return <DropdownMenu icon={ icon } label={ label } controls={ controls } />;
+};


### PR DESCRIPTION
## Description
Adds a storybook story for the DropdownMenu component as part of #17973

## How has this been tested?
* run `npm run storybook:dev`
* See the new DropdownMenu story under components

## Screenshots
![Components___DropdownMenu_-_Default_⋅_Storybook](https://user-images.githubusercontent.com/6653970/77476038-2c3d1280-6df0-11ea-8186-b998f3776f0d.png)

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
