### PR TITLE
Change hasItems to look at filteredItems in block editor inserter

### DIFF
--- a/packages/block-editor/src/components/inserter/block-list.js
+++ b/packages/block-editor/src/components/inserter/block-list.js
@@ -206,12 +206,12 @@ function InserterBlockList( {
 		);
 	}, [ filteredItems, rootChildBlocks ] );
 
-	const suggestedItems = () => {
+	const suggestedItems = useMemo( () => {
 		return filter( items, ( item ) => item.utility > 0 ).slice(
 			0,
 			MAX_SUGGESTED_ITEMS
 		);
-	};
+	}, [ items ] );
 
 	const reusableItems = useMemo( () => {
 		return filter( filteredItems, { category: 'reusable' } );
@@ -323,11 +323,7 @@ function InserterBlockList( {
 
 	const isPanelOpen = ( panel ) => openPanels.indexOf( panel ) !== -1;
 
-	const hasItems =
-		! isEmpty( suggestedItems ) ||
-		! isEmpty( reusableItems ) ||
-		! isEmpty( itemsPerCategory ) ||
-		! isEmpty( itemsPerCollection );
+	const hasItems = ! isEmpty( filteredItems );
 
 	return (
 		<div

--- a/packages/block-editor/src/components/inserter/block-list.js
+++ b/packages/block-editor/src/components/inserter/block-list.js
@@ -206,12 +206,12 @@ function InserterBlockList( {
 		);
 	}, [ filteredItems, rootChildBlocks ] );
 
-	const suggestedItems = useMemo( () => {
+	const suggestedItems = () => {
 		return filter( items, ( item ) => item.utility > 0 ).slice(
 			0,
 			MAX_SUGGESTED_ITEMS
 		);
-	}, [ items ] );
+	};
 
 	const reusableItems = useMemo( () => {
 		return filter( filteredItems, { category: 'reusable' } );


### PR DESCRIPTION
## Description
This PR removes the use of `useMemo` on the suggestion list and addresses issue: https://github.com/WordPress/gutenberg/issues/21069.

We most likely want to revisit the logic here but for now, this will restore functionality.

## How has this been tested?
1. Using the steps to reproduced contained in the issue linked above.


## Types of changes
Removing `useMemo` on the suggestion list. This will result in a slight degrade in performance for users that have a large number of blocks... Should be negligible. 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
