### PR TITLE
Nav Block: Fix submenus being overlapped by wrapping top-level nav links.

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -36,8 +36,6 @@ $navigation-sub-menu-width: $grid-unit-10 * 25;
 
 .wp-block-navigation > ul {
 	li {
-		z-index: 1;
-
 		&:hover,
 		&:focus-within {
 			cursor: pointer;


### PR DESCRIPTION
## Description
My previous PR removed a z-index rule from the nav block - https://github.com/WordPress/gutenberg/pull/21033.

Some further testing shows that this resulted in top level navigation link overlapping links in submenus when a nav menu wraps (see screenshots).

This PR fixes the issue by removing another z-index rule.

## How has this been tested?
1. Add a navigation block
2. Add a couple of navigation links.
3. Make the text of the first navigation link very long so that it wraps onto a second line
4. Add a submenu to the first nav link
5. Observe that the submenu overlaps the wrapped top level link

## Screenshots <!-- if applicable -->
*Before*
<img width="508" alt="Screenshot 2020-03-25 at 5 09 25 pm" src="https://user-images.githubusercontent.com/677833/77520377-1b59d300-6ebc-11ea-9caa-e12a7f6551c8.png">

*After*
<img width="433" alt="Screenshot 2020-03-25 at 5 09 04 pm" src="https://user-images.githubusercontent.com/677833/77520390-1e54c380-6ebc-11ea-885f-b4d843503ae5.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
