### PR TITLE
Columns: fix appender

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -430,7 +430,7 @@
 		@include reduce-motion("animation");
 
 		&:hover {
-			animation: block-editor-inserter__toggle__fade-in-animation 0.2s ease;
+			animation: block-editor-inserter__toggle__fade-in-animation 0.1s ease;
 			animation-fill-mode: forwards;
 			@include reduce-motion("animation");
 		}
@@ -440,36 +440,44 @@
 @keyframes block-editor-inserter__toggle__fade-in-animation-delayed {
 	0% {
 		opacity: 0;
+		transform: scale(0);
 	}
 	80% {
 		opacity: 0;
+		transform: scale(0);
 	}
 	100% {
 		opacity: 1;
+		transform: scale(1);
 	}
 }
 
 @keyframes block-editor-inserter__toggle__fade-in-animation {
 	from {
 		opacity: 0;
+		transform: scale(0);
 	}
 	to {
 		opacity: 1;
+		transform: scale(1);
 	}
 }
 
 // Hide the appender that sits at the end of block lists, when inside a nested block,
 // unless the block itself, or a parent, is selected.
 .wp-block .block-list-appender .block-editor-inserter__toggle {
-	opacity: 1;
-	transform: scale(1);
-	transition: all 0.1s ease;
+	animation: block-editor-inserter__toggle__fade-in-animation 0.1s ease;
+	animation-fill-mode: forwards;
 	@include reduce-motion("animation");
 }
 
-.wp-block:not(.is-selected):not(.has-child-selected) .block-list-appender  .block-editor-inserter__toggle {
-	opacity: 0;
-	transform: scale(0);
+.wp-block:not(.is-selected):not(.has-child-selected) .block-list-appender {
+	display: none;
+
+	.block-editor-inserter__toggle {
+		opacity: 0;
+		transform: scale(0);
+	}
 }
 
 // This is the edge-to-edge hover area that contains the plus.

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -458,6 +458,19 @@
 	}
 }
 
+// Hide the appender that sits at the end of block lists, when inside a nested block,
+// unless the block itself, or a parent, is selected.
+.wp-block .block-list-appender .block-editor-inserter__toggle {
+	opacity: 1;
+	transform: scale(1);
+	transition: all 0.1s ease;
+	@include reduce-motion("animation");
+}
+
+.wp-block:not(.is-selected):not(.has-child-selected) .block-list-appender  .block-editor-inserter__toggle {
+	opacity: 0;
+	transform: scale(0);
+}
 
 // This is the edge-to-edge hover area that contains the plus.
 .block-editor-block-list__block {

--- a/packages/block-library/src/column/edit.js
+++ b/packages/block-library/src/column/edit.js
@@ -63,7 +63,7 @@ function ColumnEdit( {
 				templateLock={ false }
 				renderAppender={
 					hasChildBlocks
-						? false
+						? undefined
 						: () => <InnerBlocks.ButtonBlockAppender />
 				}
 				__experimentalTagName={ Block.div }

--- a/packages/block-library/src/group/edit.js
+++ b/packages/block-library/src/group/edit.js
@@ -22,7 +22,9 @@ function GroupEdit( { className, clientId } ) {
 			<div className="wp-block-group__inner-container">
 				<InnerBlocks
 					renderAppender={
-						! hasInnerBlocks && InnerBlocks.ButtonBlockAppender
+						hasInnerBlocks
+							? undefined
+							: () => <InnerBlocks.ButtonBlockAppender />
 					}
 				/>
 			</div>


### PR DESCRIPTION
## Description

Restores the appender in the columns block after a non paragraph.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
