### PR TITLE
Enable prettier for JSX files

### DIFF
--- a/packages/scripts/scripts/format-js.js
+++ b/packages/scripts/scripts/format-js.js
@@ -101,7 +101,7 @@ if ( fileArgs.length === 0 ) {
 }
 
 // Converts `foo/bar` directory to `foo/bar/**/*.js`
-const globArgs = dirGlob( fileArgs, { extensions: [ 'js' ] } );
+const globArgs = dirGlob( fileArgs, { extensions: [ 'js', 'jsx' ] } );
 
 const result = spawn(
 	resolveBin( 'prettier' ),


### PR DESCRIPTION
## Description

Enables `npm run format:js` to apply prettier formatting to both `.js` and `.jsx` files.

## How has this been tested?

I have tested this locally with my own Gutenberg project which uses JSX file extension.

## Screenshots <!-- if applicable -->

## Types of changes

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
