### PR TITLE
Update Documentation on how to update post meta values from a block.

### DIFF
--- a/docs/designers-developers/developers/tutorials/metabox/meta-block-3-add.md
+++ b/docs/designers-developers/developers/tutorials/metabox/meta-block-3-add.md
@@ -4,9 +4,7 @@ With the meta field registered in the previous step, next you will create a new 
 
 For this block, you will use the TextControl component, which is similar to an HTML input text field. For additional components, check out the [components](/packages/components/src) and [editor](/packages/editor/src/components) packages repositories.
 
-Attributes are the information displayed in blocks. As shown in the block tutorial, the source of attributes come from the text or HTML a user writes in the editor. For your meta block, the attribute will come from the post meta field.
-
-By specifying the source of the attributes as `meta`, the block editor automatically handles the loading and storing of the data; no REST API or data functions are needed.
+The hook `useEntityProp` can be used by the blocks to change meta values.
 
 Add this code to your JavaScript file (this tutorial will call the file `myguten.js`):
 
@@ -17,26 +15,42 @@ Add this code to your JavaScript file (this tutorial will call the file `myguten
 	var el = wp.element.createElement;
 	var registerBlockType = wp.blocks.registerBlockType;
 	var TextControl = wp.components.TextControl;
+	var useSelect = wp.data.useSelect;
+	var useEntityProp = wp.coreData.useEntityProp;
 
 	registerBlockType( 'myguten/meta-block', {
 		title: 'Meta Block',
 		icon: 'smiley',
 		category: 'common',
 
-		attributes: {
-			blockValue: {
-				type: 'string',
-				source: 'meta',
-				meta: 'myguten_meta_block_field',
-			},
-		},
-
 		edit: function( props ) {
 			var className = props.className;
-			var setAttributes = props.setAttributes;
 
-			function updateBlockValue( blockValue ) {
-				setAttributes( { blockValue } );
+			var postType = useSelect(
+				function( select ) {
+					return select( 'core/editor' ).getCurrentPostType();
+				},
+				[]
+			);
+			var entityProp = useEntityProp(
+				'postType',
+				postType,
+				'meta'
+			);
+			var meta = entityProp[ 0 ];
+			var setMeta = entityProp[ 1 ];
+
+			var metaFieldValue = meta['myguten_meta_block_field'];
+			function updateMetaValue( newValue ) {
+				setMeta(
+					Object.assign(
+						{},
+						meta,
+						{
+							'myguten_meta_block_field': newValue,
+						}
+					)
+				);
 			}
 
 			return el(
@@ -44,8 +58,8 @@ Add this code to your JavaScript file (this tutorial will call the file `myguten
 				{ className: className },
 				el( TextControl, {
 					label: 'Meta Block Field',
-					value: props.attributes.blockValue,
-					onChange: updateBlockValue,
+					value: metaFieldValue,
+					onChange: updateMetaValue,
 				} )
 			);
 		},
@@ -62,38 +76,42 @@ Add this code to your JavaScript file (this tutorial will call the file `myguten
 ```js
 import { registerBlockType } from '@wordpress/blocks';
 import { TextControl } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { useEntityProp } from '@wordpress/core-data';
 
 registerBlockType( 'myguten/meta-block', {
 	title: 'Meta Block',
 	icon: 'smiley',
 	category: 'common',
 
-	attributes: {
-		blockValue: {
-			type: 'string',
-			source: 'meta',
-			meta: 'myguten_meta_block_field',
-		},
-	},
-
 	edit( { className, setAttributes, attributes } ) {
-		function updateBlockValue( blockValue ) {
-			setAttributes( { blockValue } );
+		const postType = useSelect(
+			( select ) => select( 'core/editor' ).getCurrentPostType(),
+			[]
+		);
+		const [ meta, setMeta ] = useEntityProp(
+			'postType',
+			postType,
+			'meta'
+		);
+		const metaFieldValue = meta['myguten_meta_block_field'];
+		function updateMetaValue( newValue ) {
+			setMeta( { ...meta, 'myguten_meta_block_field': newValue } );
 		}
 
 		return (
 			<div className={ className }>
 				<TextControl
 					label="Meta Block Field"
-					value={ attributes.blockValue }
-					onChange={ updateBlockValue }
+					value={ metaFieldValue }
+					onChange={ updateMetaValue }
 				/>
 			</div>
 		);
 	},
 
 	// No information saved to the block
-	// Data is saved to post meta via attributes
+	// Data is saved to post meta via the hook
 	save() {
 		return null;
 	},
@@ -101,14 +119,14 @@ registerBlockType( 'myguten/meta-block', {
 ```
 {% end %}
 
-**Important:** Before you test, you need to enqueue your JavaScript file and its dependencies. Note the WordPress packages used above are `wp.element`, `wp.blocks`, and `wp.components`. Each of these need to be included in the array of dependencies. Update the `myguten-meta-block.php` file adding the enqueue function:
+**Important:** Before you test, you need to enqueue your JavaScript file and its dependencies. Note the WordPress packages used above are `wp.element`, `wp.blocks`, `wp.components`, `wp.data`, and `wp.coreData`. Each of these need to be included in the array of dependencies. Update the `myguten-meta-block.php` file adding the enqueue function:
 
 ```php
 function myguten_enqueue() {
 	wp_enqueue_script(
 		'myguten-script',
 		plugins_url( 'myguten.js', __FILE__ ),
-		array( 'wp-blocks', 'wp-element', 'wp-components' )
+		array( 'wp-blocks', 'wp-element', 'wp-components', 'wp-data', 'wp-core-data' )
 	);
 }
 add_action( 'enqueue_block_editor_assets', 'myguten_enqueue' );

--- a/docs/designers-developers/developers/tutorials/metabox/meta-block-3-add.md
+++ b/docs/designers-developers/developers/tutorials/metabox/meta-block-3-add.md
@@ -4,7 +4,7 @@ With the meta field registered in the previous step, next you will create a new 
 
 For this block, you will use the TextControl component, which is similar to an HTML input text field. For additional components, check out the [components](/packages/components/src) and [editor](/packages/editor/src/components) packages repositories.
 
-The hook `useEntityProp` can be used by the blocks to change meta values.
+The hook `useEntityProp` can be used by the blocks to get or change meta values.
 
 Add this code to your JavaScript file (this tutorial will call the file `myguten.js`):
 
@@ -137,4 +137,3 @@ You can now edit a draft post and add a Meta Block to the post. You will see you
 ![Meta Block](https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/metabox/meta-block.png)
 
 You can now use the post meta data in a template, or another block. See next section for [using post meta data](/docs/designers-developers/developers/tutorials/metabox/meta-block-4-use-data.md). You could also confirm the data is saved by checking the database table `wp_postmeta` and confirm the new post id contains the new field data.
-


### PR DESCRIPTION
## Description
The meta attributes were deprecated, but our docs were not updated.
This PR updates the tutorial on how to create a meta block to use the new mechanisms.
