### PR TITLE
Element: Fix serializer handling of multiple distinct contexts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11037,9 +11037,17 @@
 			"requires": {
 				"@babel/runtime": "^7.8.3",
 				"@wordpress/escape-html": "file:packages/escape-html",
+				"core-js-pure": "^3.6.4",
 				"lodash": "^4.17.15",
 				"react": "^16.9.0",
 				"react-dom": "^16.9.0"
+			},
+			"dependencies": {
+				"core-js-pure": {
+					"version": "3.6.4",
+					"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.6.4.tgz",
+					"integrity": "sha512-epIhRLkXdgv32xIUFaaAry2wdxZYBi6bgM7cB136dzzXXa+dFyRLTZeLUJxnd8ShrmyVXBub63n2NHo2JAt8Cw=="
+				}
 			}
 		},
 		"@wordpress/env": {

--- a/packages/element/README.md
+++ b/packages/element/README.md
@@ -313,7 +313,7 @@ Serializes a React element to string.
 _Parameters_
 
 -   _element_ `WPElement`: Element to serialize.
--   _context_ `?Object`: Context object.
+-   _context_ `[Map]`: Context object.
 -   _legacyContext_ `?Object`: Legacy context object.
 
 _Returns_

--- a/packages/element/package.json
+++ b/packages/element/package.json
@@ -25,6 +25,7 @@
 	"dependencies": {
 		"@babel/runtime": "^7.8.3",
 		"@wordpress/escape-html": "file:../escape-html",
+		"core-js-pure": "^3.6.4",
 		"lodash": "^4.17.15",
 		"react": "^16.9.0",
 		"react-dom": "^16.9.0"

--- a/packages/element/src/serialize.js
+++ b/packages/element/src/serialize.js
@@ -347,7 +347,7 @@ function getNormalStylePropertyValue( property, value ) {
  * Serializes a React element to string.
  *
  * @param {WPElement} element       Element to serialize.
- * @param {?Object}   context       Context object.
+ * @param {Map=}      context       Context object.
  * @param {?Object}   legacyContext Legacy context object.
  *
  * @return {string} Serialized element.
@@ -411,11 +411,16 @@ export function renderElement( element, context, legacyContext = {} ) {
 
 	switch ( type && type.$$typeof ) {
 		case Provider.$$typeof:
-			return renderChildren( props.children, props.value, legacyContext );
+			context = new Map( context );
+			context.set( type, props.value );
+			return renderChildren( props.children, context, legacyContext );
 
 		case Consumer.$$typeof:
 			return renderElement(
-				props.children( context || type._currentValue ),
+				props.children(
+					( context && context.get( type._context.Provider ) ) ||
+						type._currentValue
+				),
 				context,
 				legacyContext
 			);

--- a/packages/element/src/serialize.js
+++ b/packages/element/src/serialize.js
@@ -412,7 +412,7 @@ export function renderElement( element, context, legacyContext = {} ) {
 
 	switch ( type && type.$$typeof ) {
 		case Provider.$$typeof:
-			context = new CoreJSMap( context );
+			context = context ? new CoreJSMap( context ) : new CoreJSMap();
 			context.set( type, props.value );
 			return renderChildren( props.children, context, legacyContext );
 

--- a/packages/element/src/serialize.js
+++ b/packages/element/src/serialize.js
@@ -418,7 +418,9 @@ export function renderElement( element, context, legacyContext = {} ) {
 		case Consumer.$$typeof:
 			return renderElement(
 				props.children(
-					( context && context.get( type._context.Provider ) ) ||
+					( context &&
+						type._context &&
+						context.get( type._context.Provider ) ) ||
 						type._currentValue
 				),
 				context,

--- a/packages/element/src/serialize.js
+++ b/packages/element/src/serialize.js
@@ -36,6 +36,7 @@ import {
 	kebabCase,
 	isPlainObject,
 } from 'lodash';
+import CoreJSMap from 'core-js-pure/features/map';
 
 /**
  * WordPress dependencies
@@ -411,7 +412,7 @@ export function renderElement( element, context, legacyContext = {} ) {
 
 	switch ( type && type.$$typeof ) {
 		case Provider.$$typeof:
-			context = new Map( context );
+			context = new CoreJSMap( context );
 			context.set( type, props.value );
 			return renderChildren( props.children, context, legacyContext );
 

--- a/packages/element/src/test/serialize.js
+++ b/packages/element/src/test/serialize.js
@@ -317,6 +317,36 @@ describe( 'renderElement()', () => {
 		expect( result ).toBe( 'inner provided|outer provided' );
 	} );
 
+	it( 'renders proper value through Context API when nested, distinct providers present', () => {
+		const {
+			Consumer: FirstConsumer,
+			Provider: FirstProvider,
+		} = createContext();
+		const {
+			Consumer: SecondConsumer,
+			Provider: SecondProvider,
+		} = createContext();
+
+		const result = renderElement(
+			<FirstProvider value="First">
+				<SecondProvider value="Second">
+					<FirstConsumer>
+						{ ( first ) => (
+							<>
+								First: { first }, Second:{ ' ' }
+								<SecondConsumer>
+									{ ( second ) => second }
+								</SecondConsumer>
+							</>
+						) }
+					</FirstConsumer>
+				</SecondProvider>
+			</FirstProvider>
+		);
+
+		expect( result ).toBe( 'First: First, Second: Second' );
+	} );
+
 	it( 'renders RawHTML as its unescaped children', () => {
 		const result = renderElement( <RawHTML>{ '<img/>' }</RawHTML> );
 

--- a/packages/element/src/test/serialize.js
+++ b/packages/element/src/test/serialize.js
@@ -317,6 +317,16 @@ describe( 'renderElement()', () => {
 		expect( result ).toBe( 'inner provided|outer provided' );
 	} );
 
+	it( 'renders Context gracefully', () => {
+		const Context = createContext( 'Default' );
+
+		const result = renderElement(
+			<Context>{ ( value ) => value }</Context>
+		);
+
+		expect( result ).toBe( 'Default' );
+	} );
+
 	it( 'renders proper value through Context API when nested, distinct providers present', () => {
 		const {
 			Consumer: FirstConsumer,

--- a/packages/element/src/test/serialize.js
+++ b/packages/element/src/test/serialize.js
@@ -329,6 +329,35 @@ describe( 'renderElement()', () => {
 
 		const result = renderElement(
 			<FirstProvider value="First">
+				<FirstConsumer>
+					{ ( first ) => (
+						<SecondProvider value="Second">
+							<SecondConsumer>
+								{ ( second ) =>
+									`First: ${ first }, Second: ${ second }`
+								}
+							</SecondConsumer>
+						</SecondProvider>
+					) }
+				</FirstConsumer>
+			</FirstProvider>
+		);
+
+		expect( result ).toBe( 'First: First, Second: Second' );
+	} );
+
+	it( 'renders proper value through Context API when nested, distinct providers present (mixed order)', () => {
+		const {
+			Consumer: FirstConsumer,
+			Provider: FirstProvider,
+		} = createContext();
+		const {
+			Consumer: SecondConsumer,
+			Provider: SecondProvider,
+		} = createContext();
+
+		const result = renderElement(
+			<FirstProvider value="First">
 				<SecondProvider value="Second">
 					<FirstConsumer>
 						{ ( first ) => (


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/pull/20721#discussion_r397072949
Previously: #8189, #5897

This pull request seeks to resolve an issue with the implementation of the custom `@wordpress/element` serializer where the a context consumer is only able to consume the value of the closest context provider, even if it is not of the same context type. As can be observed in the included test case, the result was that two distinct context providers would not interoperate.

**Implementation Notes:**

As described at https://github.com/WordPress/gutenberg/pull/20721#discussion_r398075725, the underlying problem is that when a provider renders its children, it _replaces_ the current context recursion argument, which prevents multiple provider values from coexisting in the same element tree.

The proposed changes seek to resolve this by changing the context argument to a `Map` object, where a provider extends the map with its value. At the time the consumer is rendered, it performs a lookup of the provider's value using the components internal `type._context.Provider` value.

**Testing Instructions:**

Ensure unit tests pass:

```
npm run test-unit
```