### PR TITLE
FSE: Use slug for template part display label

### DIFF
--- a/packages/block-library/src/template-part/index.js
+++ b/packages/block-library/src/template-part/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { startCase } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -17,5 +22,6 @@ export const settings = {
 	supports: {
 		html: false,
 	},
+	__experimentalLabel: ( { slug } ) => startCase( slug ),
 	edit,
 };


### PR DESCRIPTION
## Description
Use the slug attribute for template part block display label.

Thoughts:
1. Do we need to add a "displayName" attribute for template parts? Currently the closest we have is the "slug", which is more of a unique identifier than a display name.
2. Should we convert the slug to title case here?

## Screenshots <!-- if applicable -->
<img width="730" alt="Screen Shot 2020-03-25 at 8 16 21 PM" src="https://user-images.githubusercontent.com/6265975/77606709-87950080-6ed5-11ea-8393-8fa101c1b0aa.png">

## Types of changes
Resolves #21104 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
