### PR TITLE
Add fix to make inputs of type email return true from isTextField

### DIFF
--- a/packages/dom/src/dom.js
+++ b/packages/dom/src/dom.js
@@ -453,6 +453,7 @@ export function isTextField( element ) {
 
 		return (
 			( nodeName === 'INPUT' && selectionStart !== null ) ||
+			element.getAttribute( 'type' ) === 'email' ||
 			nodeName === 'TEXTAREA' ||
 			contentEditable === 'true'
 		);

--- a/packages/dom/src/dom.js
+++ b/packages/dom/src/dom.js
@@ -453,7 +453,7 @@ export function isTextField( element ) {
 
 		return (
 			( nodeName === 'INPUT' && selectionStart !== null ) ||
-			element.getAttribute( 'type' ) === 'email' ||
+			( nodeName === 'INPUT' && element.getAttribute( 'type' ) === 'email' ) ||
 			nodeName === 'TEXTAREA' ||
 			contentEditable === 'true'
 		);

--- a/packages/dom/src/dom.js
+++ b/packages/dom/src/dom.js
@@ -449,18 +449,20 @@ export function placeCaretAtVerticalEdge(
  */
 export function isTextField( element ) {
 	const { nodeName, contentEditable } = element;
-	const textInputs = [
-		'text',
-		'email',
-		'number',
-		'password',
-		'search',
-		'url',
-		'tel',
+	const nonTextInputs = [
+		'button',
+		'checkbox',
+		'hidden',
+		'file',
+		'radio',
+		'image',
+		'range',
+		'reset',
+		'submit',
 	];
 	return (
 		( nodeName === 'INPUT' &&
-			textInputs.includes( element.getAttribute( 'type' ) ) ) ||
+			! nonTextInputs.includes( element.getAttribute( 'type' ) ) ) ||
 		nodeName === 'TEXTAREA' ||
 		contentEditable === 'true'
 	);

--- a/packages/dom/src/dom.js
+++ b/packages/dom/src/dom.js
@@ -461,8 +461,7 @@ export function isTextField( element ) {
 		'submit',
 	];
 	return (
-		( nodeName === 'INPUT' &&
-			! nonTextInputs.includes( element.type ) ) ||
+		( nodeName === 'INPUT' && ! nonTextInputs.includes( element.type ) ) ||
 		nodeName === 'TEXTAREA' ||
 		contentEditable === 'true'
 	);

--- a/packages/dom/src/dom.js
+++ b/packages/dom/src/dom.js
@@ -462,7 +462,7 @@ export function isTextField( element ) {
 	];
 	return (
 		( nodeName === 'INPUT' &&
-			! nonTextInputs.includes( element.getAttribute( 'type' ) ) ) ||
+			! nonTextInputs.includes( element.type ) ) ||
 		nodeName === 'TEXTAREA' ||
 		contentEditable === 'true'
 	);

--- a/packages/dom/src/dom.js
+++ b/packages/dom/src/dom.js
@@ -459,6 +459,7 @@ export function isTextField( element ) {
 		'range',
 		'reset',
 		'submit',
+		'number',
 	];
 	return (
 		( nodeName === 'INPUT' && ! nonTextInputs.includes( element.type ) ) ||

--- a/packages/dom/src/dom.js
+++ b/packages/dom/src/dom.js
@@ -448,26 +448,22 @@ export function placeCaretAtVerticalEdge(
  * @return {boolean} True if the element is an text field, false if not.
  */
 export function isTextField( element ) {
-	try {
-		const { nodeName, selectionStart, contentEditable } = element;
-
-		return (
-			( nodeName === 'INPUT' && selectionStart !== null ) ||
-			( nodeName === 'INPUT' && element.getAttribute( 'type' ) === 'email' ) ||
-			nodeName === 'TEXTAREA' ||
-			contentEditable === 'true'
-		);
-	} catch ( error ) {
-		// Safari throws an exception when trying to get `selectionStart`
-		// on non-text <input> elements (which, understandably, don't
-		// have the text selection API). We catch this via a try/catch
-		// block, as opposed to a more explicit check of the element's
-		// input types, because of Safari's non-standard behavior. This
-		// also means we don't have to worry about the list of input
-		// types that support `selectionStart` changing as the HTML spec
-		// evolves over time.
-		return false;
-	}
+	const { nodeName, contentEditable } = element;
+	const textInputs = [
+		'text',
+		'email',
+		'number',
+		'password',
+		'search',
+		'url',
+		'tel',
+	];
+	return (
+		( nodeName === 'INPUT' &&
+			textInputs.includes( element.getAttribute( 'type' ) ) ) ||
+		nodeName === 'TEXTAREA' ||
+		contentEditable === 'true'
+	);
 }
 
 /**

--- a/packages/dom/src/test/dom.js
+++ b/packages/dom/src/test/dom.js
@@ -107,9 +107,12 @@ describe( 'DOM', () => {
 		const NON_TEXT_INPUT_TYPES = [
 			'button',
 			'checkbox',
-			'image',
 			'hidden',
+			'file',
 			'radio',
+			'image',
+			'range',
+			'reset',
 			'submit',
 		];
 
@@ -118,7 +121,13 @@ describe( 'DOM', () => {
 		 *
 		 * @type {string[]}
 		 */
-		const TEXT_INPUT_TYPES = [ 'text', 'password', 'search', 'url' ];
+		const TEXT_INPUT_TYPES = [
+			'text',
+			'password',
+			'search',
+			'url',
+			'email',
+		];
 
 		it( 'should return false for non-text input elements', () => {
 			NON_TEXT_INPUT_TYPES.forEach( ( type ) => {


### PR DESCRIPTION
## Description
Currently `input` fields of type `email` return false from `isTextField` which causes the Gutenberg past handler to take over when pasting into an email input. 

Fixes https://github.com/Automattic/jetpack/issues/15121
Fixes https://github.com/WordPress/gutenberg/issues/12780

## How has this been tested?
Only tested manually at this staging using the email field in the Jetpack Simple Payments block.

## Screenshots 
**before:**

![before](https://user-images.githubusercontent.com/3629020/77715814-79fc8980-7041-11ea-80da-b6ec173b7c65.gif)

after:

![after](https://user-images.githubusercontent.com/3629020/77715816-7f59d400-7041-11ea-8606-f555bb37d5e6.gif)

## Types of changes
Adds an additional check in order flag an input of type email as a text input to prevent Gutenberg's paste handler from hijacking the native input field copy/cut/paste events.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
