### PR TITLE
Try smaller space between toolbar and block.

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -648,7 +648,7 @@
 		// Position the block toolbar.
 		.block-editor-block-list__breadcrumb,
 		.block-editor-block-contextual-toolbar {
-			margin-bottom: $grid-unit-20;
+			margin-bottom: $grid-unit-15;
 
 			// @todo It should position the block transform dialog as the left margin of a block. It currently
 			// positions instead, the mover control.


### PR DESCRIPTION
This needs design feedback. The current space between the blocks footprint and the toolbar is 16px. This PR makes it 12px, to align with the grid. But visually I lean towards the 16px one.

What are your thoughts?

Before:

<img width="635" alt="before" src="https://user-images.githubusercontent.com/1204802/77622745-1db14100-6f3f-11ea-9979-c9de7d467c44.png">

After:

<img width="632" alt="after" src="https://user-images.githubusercontent.com/1204802/77622753-21dd5e80-6f3f-11ea-86ad-981683b76f51.png">

Perhaps more visible in select mode, after:

<img width="726" alt="Screenshot 2020-03-26 at 08 50 30" src="https://user-images.githubusercontent.com/1204802/77622764-26097c00-6f3f-11ea-9574-22e8a7cfd7e0.png">
