### PR TITLE
Try fix image block

### DIFF
--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -33,7 +33,7 @@ import {
 	__experimentalImageSizeControl as ImageSizeControl,
 	__experimentalImageURLInputUI as ImageURLInputUI,
 } from '@wordpress/block-editor';
-import { Component, Fragment } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { getPath } from '@wordpress/url';
 import { withViewportMatch } from '@wordpress/viewport';
@@ -509,15 +509,18 @@ export class ImageEdit extends Component {
 			</>
 		);
 
-		const AlignmentWrapper = needsAlignmentWrapper
-			? ( { children } ) => <div className="wp-block block-editor-block-list__block">{ children }</div>
-			: Fragment;
 		// Disable reason: Each block can be selected by clicking on it
 		/* eslint-disable jsx-a11y/click-events-have-key-events */
 		return (
 			<>
 				{ controls }
-				<AlignmentWrapper>
+				<div
+					className={
+						needsAlignmentWrapper
+							? 'wp-block block-editor-block-list__block'
+							: undefined
+					}
+				>
 					<Block.figure className={ classes }>
 						<ImageSize src={ url } dirtynessTrigger={ align }>
 							{ ( sizes ) => {
@@ -697,7 +700,7 @@ export class ImageEdit extends Component {
 
 						{ mediaPlaceholder }
 					</Block.figure>
-				</AlignmentWrapper>
+				</div>
 			</>
 		);
 		/* eslint-enable jsx-a11y/click-events-have-key-events */

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -509,17 +509,16 @@ export class ImageEdit extends Component {
 			</>
 		);
 
-		const AlignmentWrapper = needsAlignmentWrapper ? Block.div : Fragment;
-		const BlockContentWrapper = needsAlignmentWrapper
-			? 'figure'
-			: Block.figure;
+		const AlignmentWrapper = needsAlignmentWrapper
+			? ( { children } ) => <div className="wp-block block-editor-block-list__block">{ children }</div>
+			: Fragment;
 		// Disable reason: Each block can be selected by clicking on it
 		/* eslint-disable jsx-a11y/click-events-have-key-events */
 		return (
 			<>
 				{ controls }
 				<AlignmentWrapper>
-					<BlockContentWrapper className={ classes }>
+					<Block.figure className={ classes }>
 						<ImageSize src={ url } dirtynessTrigger={ align }>
 							{ ( sizes ) => {
 								const {
@@ -697,7 +696,7 @@ export class ImageEdit extends Component {
 						) }
 
 						{ mediaPlaceholder }
-					</BlockContentWrapper>
+					</Block.figure>
 				</AlignmentWrapper>
 			</>
 		);

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -516,6 +516,10 @@ export class ImageEdit extends Component {
 				{ controls }
 				<div
 					className={
+						// Ideally these classes are not needed, and ideally, we
+						// provide an alignment wrapper component that the block
+						// can wrap around the block or we build it into
+						// Block.*.
 						needsAlignmentWrapper
 							? 'wp-block block-editor-block-list__block'
 							: undefined


### PR DESCRIPTION
## Description

Alternative to #21160. This is a more complete fix, I think.

Fixes clicking on the block when it's floated.
Fixes centre alignment.
Fixes toolbar position when floated.
Fixes block outline when floated.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
