### PR TITLE
SVG primitive: Support custom aria-hidden value

### DIFF
--- a/packages/primitives/src/svg/index.js
+++ b/packages/primitives/src/svg/index.js
@@ -26,7 +26,9 @@ export const SVG = ( { className, isPressed, ...props } ) => {
 		className:
 			classnames( className, { 'is-pressed': isPressed } ) || undefined,
 		role: 'img',
-		'aria-hidden': 'true',
+		'aria-hidden': props.hasOwnProperty( 'aria-hidden' )
+			? props[ 'aria-hidden' ]
+			: 'true',
 		focusable: 'false',
 	};
 


### PR DESCRIPTION
## Description

This PR introduces support for providing a custom `aria-hidden` attribute for the `SVG` primitive.

Currently, [the SVG component has the `aria-hidden` value fixed to `true`](https://github.com/WordPress/gutenberg/blob/4c472c3443513d070a50ba1e96f3a476861447b3/packages/primitives/src/svg/index.js#L29). This is fine for decorative icons that are used within a button or a link to other interactive controls. Unfortunately, this prevents us from using ARIA when we need to enhance SVG accessibility. E.g., if we wanted to add the `<title>` element inside SVG as suggested [here](https://developer.paciellogroup.com/blog/2013/12/using-aria-enhance-svg-accessibility/), it wouldn't take any effect because of the hardcoded `aria-hidden="true"` presence.

Related discussion: https://wordpress.slack.com/archives/C02RP4X03/p1585161710006700

## How has this been tested?

If explicitly specified, the `aria-hidden` prop value should be passed as is to the `aria-hidden` SVG attribute. This means that the `undefined` will also be accepted, resulting in the removal of that attribute.

⚠️ Note:
`undefined` should be the preferred way over `"false"` as it's [reported to behave inconsistently across browsers](https://www.w3.org/TR/wai-aria-1.1/#aria-hidden).

## Types of changes

New feature (non-breaking change which adds functionality)

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
