### PR TITLE
E2E Tests: Improve stability of image block test

### DIFF
--- a/packages/e2e-tests/specs/editor/blocks/image.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/image.test.js
@@ -31,7 +31,9 @@ async function upload( selector ) {
 	const tmpFileName = path.join( os.tmpdir(), filename + '.png' );
 	fs.copyFileSync( testImagePath, tmpFileName );
 	await inputElement.uploadFile( tmpFileName );
-	await page.waitForSelector( '.wp-block-image img[src^="http"]' );
+	await page.waitForSelector(
+		`.wp-block-image img[src$="${ filename }.png"]`
+	);
 	return filename;
 }
 


### PR DESCRIPTION
Fixes #21051

This pull request seeks to resolve an intermittent failure in the end-to-end test suite affecting the image block. The reason for the failure is that in the course of uploading a new image in the test, the upload process awaits completion using the following line of code:

https://github.com/WordPress/gutenberg/blob/d37ed1f63df1cd9f2101d9353f908221170538c9/packages/e2e-tests/specs/editor/blocks/image.test.js#L34

The intention here is to differentiate the previewed image ([`blob:`](https://developer.mozilla.org/en-US/docs/Web/API/Blob)) from the completed uploaded file (`http:`). The problem is that this selector matches multiple images which have nothing to do with the upload in question: Notably, the "Default" and "Rounded" style variation block previews.

![image](https://user-images.githubusercontent.com/1779930/77668052-4f370600-6f59-11ea-809b-530ea15542a0.png)

You can confirm this in the editor:

1. Navigate to Posts > Add New
2. Insert an image block
3. Execute the following in your DevTools console:
   - `[ ...document.querySelectorAll( '.wp-block-image img' ) ].map( ( img ) => img.src )`

You should see there is two results. The problem as it affects this test is that it's effectively no different than if the `await` did not exist at all, since it will be resolved immediately by the presence of these two images. Thus, the reason the test fails intermittently is that it becomes a race condition between when the upload can complete vs. the continuation of assertions in the remainder of the test.

It can be reproduced locally by [throttling network speed](https://github.com/WordPress/gutenberg/blob/master/docs/contributors/testing-overview.md#end-to-end-testing):

The proposed changes resolve this by testing for a `src` matching the specific file we're expecting. It is still able to differentiate from the blob URL because the blob URL would not include the file extension.

```
DOWNLOAD_THROUGHPUT=125000 npm run test-e2e packages/e2e-tests/specs/editor/blocks/image.test.js
```

**Testing Instructions:**

End-to-end tests should pass.

```
npm run test-e2e
```