### PR TITLE
E2E Tests: Improve Allowed Inner Blocks test stability

### DIFF
--- a/packages/e2e-tests/plugins/inner-blocks-allowed-blocks/index.js
+++ b/packages/e2e-tests/plugins/inner-blocks-allowed-blocks/index.js
@@ -4,19 +4,20 @@
 	const { createElement: el } = wp.element;
 	const { InnerBlocks } = wp.blockEditor;
 	const __ = wp.i18n.__;
-	const divProps = { className: 'product', style: { outline: '1px solid gray', padding: 5 } };
+	const divProps = {
+		className: 'product',
+		style: { outline: '1px solid gray', padding: 5 },
+	};
 	const template = [
 		[ 'core/image' ],
 		[ 'core/paragraph', { placeholder: __( 'Add a description' ) } ],
-		[ 'core/quote' ]
+		[ 'core/quote' ],
 	];
 	const allowedBlocksWhenSingleEmptyChild = [ 'core/image', 'core/list' ];
 	const allowedBlocksWhenMultipleChildren = [ 'core/gallery', 'core/video' ];
 
 	const save = function() {
-		return el( 'div', divProps,
-			el( InnerBlocks.Content )
-		);
+		return el( 'div', divProps, el( InnerBlocks.Content ) );
 	};
 	registerBlockType( 'test/allowed-blocks-unset', {
 		title: 'Allowed Blocks Unset',
@@ -24,9 +25,7 @@
 		category: 'common',
 
 		edit() {
-			return el( 'div', divProps,
-				el( InnerBlocks, { template } )
-			);
+			return el( 'div', divProps, el( InnerBlocks, { template } ) );
 		},
 
 		save,
@@ -38,20 +37,19 @@
 		category: 'common',
 
 		edit() {
-			return el( 'div', divProps,
-				el(
-					InnerBlocks,
-					{
-						template,
-						allowedBlocks: [
-							'core/button',
-							'core/gallery',
-							'core/list',
-							'core/media-text',
-							'core/quote',
-						],
-					}
-				)
+			return el(
+				'div',
+				divProps,
+				el( InnerBlocks, {
+					template,
+					allowedBlocks: [
+						'core/button',
+						'core/gallery',
+						'core/list',
+						'core/media-text',
+						'core/quote',
+					],
+				} )
 			);
 		},
 
@@ -69,19 +67,21 @@
 				numberOfChildren: getBlockOrder( ownProps.clientId ).length,
 			};
 		} )( function( props ) {
-			return el( 'div', divProps,
-				el(
-					InnerBlocks,
-					{
-						allowedBlocks: props.numberOfChildren < 2 ?
-							allowedBlocksWhenSingleEmptyChild :
-							allowedBlocksWhenMultipleChildren,
-					}
-				)
+			return el(
+				'div',
+				{
+					...divProps,
+					'data-number-of-children': props.numberOfChildren,
+				},
+				el( InnerBlocks, {
+					allowedBlocks:
+						props.numberOfChildren < 2
+							? allowedBlocksWhenSingleEmptyChild
+							: allowedBlocksWhenMultipleChildren,
+				} )
 			);
 		} ),
 
 		save,
 	} );
-
 } )();

--- a/packages/e2e-tests/specs/editor/plugins/inner-blocks-allowed-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/inner-blocks-allowed-blocks.test.js
@@ -73,6 +73,7 @@ describe( 'Allowed Blocks Setting on InnerBlocks ', () => {
 		 )[ 0 ];
 		await insertButton.click();
 		await insertBlock( 'Image' );
+		await page.waitForSelector( '.product[data-number-of-children="2"]' );
 		await page.click( appenderSelector );
 		await openAllBlockInserterCategories();
 		expect( await getAllBlockInserterItemTitles() ).toEqual( [


### PR DESCRIPTION
Fixes #21052

This pull request seeks to improve the stability of the "Allowed Blocks Setting on InnerBlocks" end-to-end test which has proven to be a source of common intermittent failures.

**Implementation Notes:**

As mentioned at https://github.com/WordPress/gutenberg/issues/21052#issuecomment-604462397, the suspected issue is that the test relies on an update of its child blocks to apply new settings to its own `InnerBlocks` rendering. As of #19343, the parent's rendering occurs asynchronously and may be delayed.

The proposed changes seek to resolve this by adding a new `data-` attribute to the parent block's rendering, which is used by the test to know the point at which the next render is completed.

**Testing Instructions:**

Ensure end-to-end tests pass:

```
npm run test-e2e packages/e2e-tests/specs/editor/plugins/inner-blocks-allowed-blocks.test.js
```