### PR TITLE
Save State: Removing the icons from the `post-saved-state` component

### DIFF
--- a/packages/editor/src/components/post-saved-state/index.js
+++ b/packages/editor/src/components/post-saved-state/index.js
@@ -14,7 +14,6 @@ import { withSelect, withDispatch } from '@wordpress/data';
 import { displayShortcut } from '@wordpress/keycodes';
 import { withSafeTimeout, compose } from '@wordpress/compose';
 import { withViewportMatch } from '@wordpress/viewport';
-import { Icon, check, cloud, cloudUpload } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -79,7 +78,6 @@ export class PostSavedState extends Component {
 								animateClassName
 							) }
 						>
-							<Icon icon={ cloud } />
 							{ isAutosaving
 								? __( 'Autosaving' )
 								: __( 'Saving' ) }
@@ -100,7 +98,6 @@ export class PostSavedState extends Component {
 		if ( forceSavedMessage || ( ! isNew && ! isDirty ) ) {
 			return (
 				<span className="editor-post-saved-state is-saved">
-					<Icon icon={ check } />
 					{ __( 'Saved' ) }
 				</span>
 			);
@@ -125,7 +122,6 @@ export class PostSavedState extends Component {
 					label={ label }
 					onClick={ () => onSave() }
 					shortcut={ displayShortcut.primary( 's' ) }
-					icon={ cloudUpload }
 				/>
 			);
 		}


### PR DESCRIPTION
Currently, the saved status in the editor's top bar shows an icon to indicate saving and saved states:

<img width="212" alt="image" src="https://user-images.githubusercontent.com/191598/77670659-e2be0600-6f5c-11ea-9405-11ce4fe704ca.png">

<img width="218" alt="image" src="https://user-images.githubusercontent.com/191598/77670687-e9e51400-6f5c-11ea-87bc-5589c2890bcb.png">

Considering the abundance of icons (and the valuable horizontal space in the top bar) I'm not sure these icons are necessary. This PR removes them.