### PR TITLE
Add useDebounce hook

### DIFF
--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -119,6 +119,33 @@ _Returns_
 
 -   `WPComponent`: Component class with generated display name assigned.
 
+<a name="useDebounce" href="#useDebounce">#</a> **useDebounce**
+
+Use to debounce a value that is changing too frequently.
+
+Example usage:
+
+// An example using the useDebounce hook with useResizeObserver()
+ // to debounce a rapidly changing width value
+
+const [ resizeListener, sizes ] = useResizeObserver();
+const debouncedSize = useDebounce(sizes.width, 100);
+
+useEffect( () => {
+
+    // ... do your thing here ...
+
+}, [debouncedSize] );
+
+_Parameters_
+
+-   _value_ `Object`: The value changing you want to debounce.
+-   _delay_ `number`: The amount to delay time in ms.
+
+_Returns_
+
+-   `Object`: Debounced value
+
 <a name="useInstanceId" href="#useInstanceId">#</a> **useInstanceId**
 
 Provides a unique instance ID.

--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -130,23 +130,25 @@ Example usage:
  // to debounce a rapidly changing width value
 
 const [ resizeListener, sizes ] = useResizeObserver();
-const debouncedSize = useDebounce(sizes.width, 100);
 
-useEffect( () => {
+useDebounce( ( sz ) => {
 
 	// ... do your thing here ...
 
-}, [debouncedSize] );
+}, 200, sizes.width );
+
+return (
+	<div>
+		{resizeListener}
+	</div>
+);
 ```
 
 _Parameters_
 
--   _value_ `Object`: The value changing you want to debounce.
+-   _callback_ `Function`: The function to call with the debounced value.
 -   _delay_ `number`: The amount to delay time in ms.
-
-_Returns_
-
--   `Object`: Debounced value
+-   _deps_ `*`: The dependent value changing you want to debounce.
 
 <a name="useInstanceId" href="#useInstanceId">#</a> **useInstanceId**
 

--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -148,7 +148,7 @@ _Parameters_
 
 -   _callback_ `Function`: The function to call with the debounced value.
 -   _delay_ `number`: The amount to delay time in ms.
--   _deps_ `*`: The dependent value changing you want to debounce.
+-   _deps_ `Array`: The dependent value changing you want to debounce.
 
 <a name="useInstanceId" href="#useInstanceId">#</a> **useInstanceId**
 

--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -125,6 +125,7 @@ Use to debounce a value that is changing too frequently.
 
 Example usage:
 
+```js
 // An example using the useDebounce hook with useResizeObserver()
  // to debounce a rapidly changing width value
 
@@ -133,9 +134,10 @@ const debouncedSize = useDebounce(sizes.width, 100);
 
 useEffect( () => {
 
-    // ... do your thing here ...
+	// ... do your thing here ...
 
 }, [debouncedSize] );
+```
 
 _Parameters_
 

--- a/packages/compose/src/hooks/use-debounce/index.js
+++ b/packages/compose/src/hooks/use-debounce/index.js
@@ -1,0 +1,44 @@
+/**
+ * useDebounce hook
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { useState, useEffect } from '@wordpress/element';
+
+/**
+ * Use to debounce a value that is changing too frequently.
+ *
+ * Example usage:
+ *
+ *	// An example using the useDebounce hook with useResizeObserver()
+ *  // to debounce a rapidly changing width value
+ *
+ *	const [ resizeListener, sizes ] = useResizeObserver();
+ *	const debouncedSize = useDebounce(sizes.width, 100);
+ *
+ *	useEffect( () => {
+ *
+ *		// ... do your thing here ...
+ *
+ *	}, [debouncedSize] );
+ *
+ * @param {Object}        value  The value changing you want to debounce.
+ * @param {number}        delay  The amount to delay time in ms.
+ * @return {Object}				 Debounced value
+ *
+ */
+
+const useDebounce = ( value, delay ) => {
+	const [ debouncedValue, setDebouncedValue ] = useState( value );
+
+	useEffect( () => {
+		const handler = setTimeout( () => setDebouncedValue( value ), delay );
+		return () => clearTimeout( handler );
+	}, [ value ] );
+
+	return debouncedValue;
+};
+
+export default useDebounce;

--- a/packages/compose/src/hooks/use-debounce/index.js
+++ b/packages/compose/src/hooks/use-debounce/index.js
@@ -5,7 +5,7 @@
 /**
  * WordPress dependencies
  */
-import { useState, useEffect } from '@wordpress/element';
+import { useEffect } from '@wordpress/element';
 
 /**
  * Use to debounce a value that is changing too frequently.
@@ -17,30 +17,30 @@ import { useState, useEffect } from '@wordpress/element';
  *  // to debounce a rapidly changing width value
  *
  *	const [ resizeListener, sizes ] = useResizeObserver();
- *	const debouncedSize = useDebounce( sizes.width, 100 );
  *
- *	useEffect( () => {
+ *	useDebounce( ( sz ) => {
  *
  *		// ... do your thing here ...
  *
- *	}, [debouncedSize] );
+ *	}, 200, sizes.width );
+ *
+ *	return (
+ *		<div>
+ *			{resizeListener}
+ *		</div>
+ *	);
  *	```
  *
- * @param {*}      value  The value changing you want to debounce.
- * @param {number} delay  The amount to delay time in ms.
- *
- * @return {*} Debounced value.
+ * @param {Function} callback The function to call with the debounced value.
+ * @param {number}   delay    The amount to delay time in ms.
+ * @param {*}        deps     The dependent value changing you want to debounce.
  *
  */
-const useDebounce = ( value, delay ) => {
-	const [ debouncedValue, setDebouncedValue ] = useState( value );
-
+const useDebounce = ( callback, delay, deps ) => {
 	useEffect( () => {
-		const handler = setTimeout( () => setDebouncedValue( value ), delay );
+		const handler = setTimeout( () => callback( deps ), delay );
 		return () => clearTimeout( handler );
-	}, [ value ] );
-
-	return debouncedValue;
+	}, [ deps ] );
 };
 
 export default useDebounce;

--- a/packages/compose/src/hooks/use-debounce/index.js
+++ b/packages/compose/src/hooks/use-debounce/index.js
@@ -12,8 +12,9 @@ import { useState, useEffect } from '@wordpress/element';
  *
  * Example usage:
  *
- * // An example using the useDebounce hook with useResizeObserver()
- * // to debounce a rapidly changing width value
+ * ```js
+ *	// An example using the useDebounce hook with useResizeObserver()
+ *  // to debounce a rapidly changing width value
  *
  *	const [ resizeListener, sizes ] = useResizeObserver();
  *	const debouncedSize = useDebounce( sizes.width, 100 );
@@ -22,7 +23,8 @@ import { useState, useEffect } from '@wordpress/element';
  *
  *		// ... do your thing here ...
  *
- *	}, [ debouncedSize ] );
+ *	}, [debouncedSize] );
+ *	```
  *
  * @param {*}      value  The value changing you want to debounce.
  * @param {number} delay  The amount to delay time in ms.

--- a/packages/compose/src/hooks/use-debounce/index.js
+++ b/packages/compose/src/hooks/use-debounce/index.js
@@ -33,14 +33,14 @@ import { useEffect } from '@wordpress/element';
  *
  * @param {Function} callback The function to call with the debounced value.
  * @param {number}   delay    The amount to delay time in ms.
- * @param {*}        deps     The dependent value changing you want to debounce.
+ * @param {Array}    deps     The dependent value changing you want to debounce.
  *
  */
 const useDebounce = ( callback, delay, deps ) => {
 	useEffect( () => {
 		const handler = setTimeout( () => callback( deps ), delay );
 		return () => clearTimeout( handler );
-	}, [ deps ] );
+	}, deps );
 };
 
 export default useDebounce;

--- a/packages/compose/src/hooks/use-debounce/index.js
+++ b/packages/compose/src/hooks/use-debounce/index.js
@@ -12,24 +12,24 @@ import { useState, useEffect } from '@wordpress/element';
  *
  * Example usage:
  *
- *	// An example using the useDebounce hook with useResizeObserver()
- *  // to debounce a rapidly changing width value
+ * // An example using the useDebounce hook with useResizeObserver()
+ * // to debounce a rapidly changing width value
  *
  *	const [ resizeListener, sizes ] = useResizeObserver();
- *	const debouncedSize = useDebounce(sizes.width, 100);
+ *	const debouncedSize = useDebounce( sizes.width, 100 );
  *
  *	useEffect( () => {
  *
  *		// ... do your thing here ...
  *
- *	}, [debouncedSize] );
+ *	}, [ debouncedSize ] );
  *
- * @param {Object}        value  The value changing you want to debounce.
- * @param {number}        delay  The amount to delay time in ms.
- * @return {Object}				 Debounced value
+ * @param {*}      value  The value changing you want to debounce.
+ * @param {number} delay  The amount to delay time in ms.
+ *
+ * @return {*} Debounced value.
  *
  */
-
 const useDebounce = ( value, delay ) => {
 	const [ debouncedValue, setDebouncedValue ] = useState( value );
 

--- a/packages/compose/src/index.js
+++ b/packages/compose/src/index.js
@@ -14,6 +14,7 @@ export { default as withState } from './higher-order/with-state';
 
 // Hooks
 export { default as __experimentalUseDragging } from './hooks/use-dragging';
+export { default as useDebounce } from './hooks/use-debounce';
 export { default as useInstanceId } from './hooks/use-instance-id';
 export { default as useKeyboardShortcut } from './hooks/use-keyboard-shortcut';
 export { default as useMediaQuery } from './hooks/use-media-query';


### PR DESCRIPTION
## Description

Adds a useDebounce hook to help debounce a rapidly changing value.

This was needed when developing a block using the useResizeObserver() hook. I wanted to debounce the value which triggered redrawing an image section.

## How has this been tested?

See instructions for usage. The testing I did was create a block attaching the useResizeObserver() to the main component. Then when watch the number of calls to the useEffect. Here is a basic edit.js that highlights the usage:

```
import { useResizeObserver } from '@wordpress/compose';
import { useEffect } from '@wordpress/element';
import useDebounce from './use-debounce';

const edit = ( ) => {
    const [ resizeListener, sizes ] = useResizeObserver();
    const debouncedSize = useDebounce(sizes.width, 100);
    useEffect( () => {
        console.log("Do it.");
    }, [debouncedSize] );

    return (
       <div>
            { resizeListener }
       </div>
    );
}
export default edit;
```

## Types of changes

Adds a hook to compose package.

