### PR TITLE
E2E Tests: Use waitForSelector to wait for sidebar presence

### DIFF
--- a/packages/e2e-tests/specs/editor/various/sidebar.test.js
+++ b/packages/e2e-tests/specs/editor/various/sidebar.test.js
@@ -87,8 +87,7 @@ describe( 'Sidebar', () => {
 
 		await setBrowserViewport( 'large' );
 
-		const sidebarsDesktop = await page.$$( SIDEBAR_SELECTOR );
-		expect( sidebarsDesktop ).toHaveLength( 1 );
+		await page.waitForSelector( SIDEBAR_SELECTOR );
 	} );
 
 	it( 'should preserve tab order while changing active tab', async () => {


### PR DESCRIPTION
Fixes #21177

This pull request seeks to resolve an intermittent end-to-end test failure in the Sidebar tests. See #21177 for the full message and initial debugging information. The changes here seek to resolve this by leveraging `waitForSelector` to allow for a delay in the presence of the sidebar which is expected to be shown. It's assumed this will resolve the issue because, as observed by notes in #21177, there appears to be a CPU-bound race condition between the browser resizing and the sidebar showing. While these sorts of delays are not ideal, the use of `waitForSelector` will prove to be more durable in any case.

**Testing Instructions:**

Ensure end-to-end tests pass:

```
THROTTLE_CPU=4 npm run test-e2e packages/e2e-tests/specs/editor/various/sidebar.test.js
```