### PR TITLE
Refactor ReusableBlockEditPanel to use hooks (and add type info)

### DIFF
--- a/packages/block-library/src/block/edit-panel/index.js
+++ b/packages/block-library/src/block/edit-panel/index.js
@@ -2,123 +2,138 @@
  * WordPress dependencies
  */
 import { Button } from '@wordpress/components';
-import { Component, createRef } from '@wordpress/element';
+import { useInstanceId, usePrevious } from '@wordpress/compose';
+import { useEffect, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { ESCAPE } from '@wordpress/keycodes';
-import { withInstanceId } from '@wordpress/compose';
 
-class ReusableBlockEditPanel extends Component {
-	constructor() {
-		super( ...arguments );
+/** @typedef {import('@wordpress/element').WPComponent} WPComponent */
 
-		this.titleField = createRef();
-		this.editButton = createRef();
-		this.handleFormSubmit = this.handleFormSubmit.bind( this );
-		this.handleTitleChange = this.handleTitleChange.bind( this );
-		this.handleTitleKeyDown = this.handleTitleKeyDown.bind( this );
-	}
+/**
+ * ReusableBlockEditPanel props.
+ *
+ * @typedef WPReusableBlockEditPanelProps
+ *
+ * @property {boolean}                 isEditDisabled Is editing the reusable
+ *                                                    block disabled.
+ * @property {boolean}                 isEditing      Is the reusable block
+ *                                                    being edited.
+ * @property {boolean}                 isSaving       Is the reusable block
+ *                                                    being saved.
+ * @property {()=>void}                onCancel       Callback to run when
+ *                                                    editing is canceled.
+ * @property {(newTitle:string)=>void} onChangeTitle  Callback to run when the
+ *                                                    title input value is
+ *                                                    changed.
+ * @property {()=>void}                onEdit         Callback to run when
+ *                                                    editing begins.
+ * @property {()=>void}                onSave         Callback to run when
+ *                                                    saving.
+ * @property {string}                  title          Title of the reusable
+ *                                                    block.
+ */
 
-	componentDidMount() {
-		// Select the input text when the form opens.
-		if ( this.props.isEditing && this.titleField.current ) {
-			this.titleField.current.select();
+/**
+ * Panel for enabling the editing and saving of a reusable block.
+ *
+ * @param {WPReusableBlockEditPanelProps} props Component props.
+ *
+ * @return {WPComponent} The panel.
+ */
+export default function ReusableBlockEditPanel( {
+	isEditDisabled,
+	isEditing,
+	isSaving,
+	onCancel,
+	onChangeTitle,
+	onEdit,
+	onSave,
+	title,
+} ) {
+	const instanceId = useInstanceId( ReusableBlockEditPanel );
+	const titleField = useRef();
+	const editButton = useRef();
+	const wasEditing = usePrevious( isEditing );
+	const wasSaving = usePrevious( isSaving );
+
+	// Select the title input when the form opens.
+	useEffect( () => {
+		if ( ! wasEditing && isEditing ) {
+			titleField.current.select();
 		}
-	}
+	}, [ isEditing ] );
 
-	componentDidUpdate( prevProps ) {
-		// Select the input text only once when the form opens.
-		if ( ! prevProps.isEditing && this.props.isEditing ) {
-			this.titleField.current.select();
+	// Move focus back to the Edit button after pressing the Escape key or Save.
+	useEffect( () => {
+		if ( ( wasEditing || wasSaving ) && ! isEditing && ! isSaving ) {
+			editButton.current.focus();
 		}
-		// Move focus back to the Edit button after pressing the Escape key or Save.
-		if (
-			( prevProps.isEditing || prevProps.isSaving ) &&
-			! this.props.isEditing &&
-			! this.props.isSaving
-		) {
-			this.editButton.current.focus();
-		}
-	}
+	}, [ isEditing, isSaving ] );
 
-	handleFormSubmit( event ) {
+	function handleFormSubmit( event ) {
 		event.preventDefault();
-		this.props.onSave();
+		onSave();
 	}
 
-	handleTitleChange( event ) {
-		this.props.onChangeTitle( event.target.value );
+	function handleTitleChange( event ) {
+		onChangeTitle( event.target.value );
 	}
 
-	handleTitleKeyDown( event ) {
+	function handleTitleKeyDown( event ) {
 		if ( event.keyCode === ESCAPE ) {
 			event.stopPropagation();
-			this.props.onCancel();
+			onCancel();
 		}
 	}
 
-	render() {
-		const {
-			isEditing,
-			title,
-			isSaving,
-			isEditDisabled,
-			onEdit,
-			instanceId,
-		} = this.props;
-
-		return (
-			<>
-				{ ! isEditing && ! isSaving && (
-					<div className="reusable-block-edit-panel">
-						<b className="reusable-block-edit-panel__info">
-							{ title }
-						</b>
-						<Button
-							ref={ this.editButton }
-							isSecondary
-							className="reusable-block-edit-panel__button"
-							disabled={ isEditDisabled }
-							onClick={ onEdit }
-						>
-							{ __( 'Edit' ) }
-						</Button>
-					</div>
-				) }
-				{ ( isEditing || isSaving ) && (
-					<form
-						className="reusable-block-edit-panel"
-						onSubmit={ this.handleFormSubmit }
+	return (
+		<>
+			{ ! isEditing && ! isSaving && (
+				<div className="reusable-block-edit-panel">
+					<b className="reusable-block-edit-panel__info">{ title }</b>
+					<Button
+						ref={ editButton }
+						isSecondary
+						className="reusable-block-edit-panel__button"
+						disabled={ isEditDisabled }
+						onClick={ onEdit }
 					>
-						<label
-							htmlFor={ `reusable-block-edit-panel__title-${ instanceId }` }
-							className="reusable-block-edit-panel__label"
-						>
-							{ __( 'Name:' ) }
-						</label>
-						<input
-							ref={ this.titleField }
-							type="text"
-							disabled={ isSaving }
-							className="reusable-block-edit-panel__title"
-							value={ title }
-							onChange={ this.handleTitleChange }
-							onKeyDown={ this.handleTitleKeyDown }
-							id={ `reusable-block-edit-panel__title-${ instanceId }` }
-						/>
-						<Button
-							type="submit"
-							isSecondary
-							isBusy={ isSaving }
-							disabled={ ! title || isSaving }
-							className="reusable-block-edit-panel__button"
-						>
-							{ __( 'Save' ) }
-						</Button>
-					</form>
-				) }
-			</>
-		);
-	}
+						{ __( 'Edit' ) }
+					</Button>
+				</div>
+			) }
+			{ ( isEditing || isSaving ) && (
+				<form
+					className="reusable-block-edit-panel"
+					onSubmit={ handleFormSubmit }
+				>
+					<label
+						htmlFor={ `reusable-block-edit-panel__title-${ instanceId }` }
+						className="reusable-block-edit-panel__label"
+					>
+						{ __( 'Name:' ) }
+					</label>
+					<input
+						ref={ titleField }
+						type="text"
+						disabled={ isSaving }
+						className="reusable-block-edit-panel__title"
+						value={ title }
+						onChange={ handleTitleChange }
+						onKeyDown={ handleTitleKeyDown }
+						id={ `reusable-block-edit-panel__title-${ instanceId }` }
+					/>
+					<Button
+						type="submit"
+						isSecondary
+						isBusy={ isSaving }
+						disabled={ ! title || isSaving }
+						className="reusable-block-edit-panel__button"
+					>
+						{ __( 'Save' ) }
+					</Button>
+				</form>
+			) }
+		</>
+	);
 }
-
-export default withInstanceId( ReusableBlockEditPanel );


### PR DESCRIPTION
## Description
This PR refactors the `ReusableBlockEditPanel` to use React hooks. It also adds JSDoc type information.

I've tested to make sure that creating, saving, and editing reusable blocks still works, and the focus behavior when editing/saving remains the same.