### PR TITLE
Annotations: Merge assigned block className with incoming prop

### DIFF
--- a/packages/annotations/src/block/index.js
+++ b/packages/annotations/src/block/index.js
@@ -11,7 +11,7 @@ import { withSelect } from '@wordpress/data';
  * @return {Object} The enhanced component.
  */
 const addAnnotationClassName = ( OriginalComponent ) => {
-	return withSelect( ( select, { clientId } ) => {
+	return withSelect( ( select, { clientId, className } ) => {
 		const annotations = select(
 			'core/annotations'
 		).__experimentalGetAnnotationsForBlock( clientId );
@@ -21,6 +21,8 @@ const addAnnotationClassName = ( OriginalComponent ) => {
 				.map( ( annotation ) => {
 					return 'is-annotated-by-' + annotation.source;
 				} )
+				.concat( className )
+				.filter( Boolean )
 				.join( ' ' ),
 		};
 	} )( OriginalComponent );


### PR DESCRIPTION
Fixes #21172 
Related: #19514

This pull request seeks to resolve an issue in the implementation of annotations whereby it would _replace_ the `className` assigned to the original component. This interfered with the changes introduced as of #19514 in that the `.is-drop-target` class name was no longer being assigned.

The changes here resolve this by _merging_ any incoming `className` value to the assigned `className`.

**Testing Instructions:**

Repeat Steps to Reproduce from #21172, verifying the drop target appears when dragging a block.

As noted in https://github.com/WordPress/gutenberg/issues/21172#issuecomment-604638789, this is most easily accomplished by enabling the "Gutenberg Test Plugin, Plugins API" plugin, assuming the [default development environment](https://developer.wordpress.org/block-editor/contributors/develop/getting-started/#step-1-installing-a-local-environment) is used.

**Future Tasks:**

There should be automated testing for this behavior. However, the implementation of annotations using `withSelect` is not easily tested without significant refactoring of the implementation itself (migrating to use `useSelect` hook and/or extracting common function for class name assignment). Since this may or may not need to be cherry-picked for WordPress 5.4, it would be best to save refactoring for future effort.

cc @herregroen