### PR TITLE
Components: RangeControl: Fix zero value handling with number input

### DIFF
--- a/packages/components/src/range-control/index.js
+++ b/packages/components/src/range-control/index.js
@@ -64,7 +64,7 @@ const BaseRangeControl = forwardRef(
 			renderTooltipContent = ( v ) => v,
 			showTooltip: showTooltipProp,
 			step = 1,
-			value: valueProp = 0,
+			value: valueProp,
 			withInputField = true,
 			...props
 		},
@@ -72,7 +72,8 @@ const BaseRangeControl = forwardRef(
 	) => {
 		const isRTL = useRtl();
 
-		const sliderValue = valueProp || initialPosition;
+		const sliderValue =
+			valueProp !== undefined ? valueProp : initialPosition;
 		const [ value, setValue ] = useControlledRangeValue( {
 			min,
 			max,
@@ -95,8 +96,10 @@ const BaseRangeControl = forwardRef(
 		const isThumbFocused = ! disabled && isFocused;
 
 		const isValueReset = value === null;
-		const inputSliderValue = isValueReset ? '' : value;
-		const currentInputValue = isValueReset ? '' : value || currentInput;
+		const currentValue = value !== undefined ? value : currentInput;
+
+		const inputSliderValue = isValueReset ? '' : currentValue;
+		const currentInputValue = isValueReset ? '' : currentValue;
 
 		const rangeFillValue = isValueReset
 			? floatClamp( max / 2, min, max )
@@ -119,11 +122,19 @@ const BaseRangeControl = forwardRef(
 		const enableTooltip = showTooltipProp !== false && isFinite( value );
 
 		const handleOnChange = ( event ) => {
-			if ( ! event.target.checkValidity() ) {
+			if (
+				event.target.checkValidity &&
+				! event.target.checkValidity()
+			) {
 				return;
 			}
 
 			const nextValue = parseFloat( event.target.value );
+
+			if ( isNaN( nextValue ) ) {
+				handleOnReset();
+				return;
+			}
 
 			setValue( nextValue );
 			onChange( nextValue );

--- a/packages/components/src/range-control/index.js
+++ b/packages/components/src/range-control/index.js
@@ -74,6 +74,7 @@ const BaseRangeControl = forwardRef(
 
 		const sliderValue =
 			valueProp !== undefined ? valueProp : initialPosition;
+
 		const [ value, setValue ] = useControlledRangeValue( {
 			min,
 			max,
@@ -99,7 +100,6 @@ const BaseRangeControl = forwardRef(
 		const currentValue = value !== undefined ? value : currentInput;
 
 		const inputSliderValue = isValueReset ? '' : currentValue;
-		const currentInputValue = isValueReset ? '' : currentValue;
 
 		const rangeFillValue = isValueReset
 			? floatClamp( max / 2, min, max )
@@ -260,7 +260,7 @@ const BaseRangeControl = forwardRef(
 							onChange={ handleOnChange }
 							step={ step }
 							type="number"
-							value={ currentInputValue }
+							value={ inputSliderValue }
 						/>
 					) }
 					{ allowReset && (

--- a/packages/components/src/range-control/rail.js
+++ b/packages/components/src/range-control/rail.js
@@ -1,8 +1,4 @@
 /**
- * External dependencies
- */
-import { isUndefined } from 'lodash';
-/**
  * Internal dependencies
  */
 import RangeMark from './mark';
@@ -78,7 +74,7 @@ function useMarks( { marks, min = 0, max = 100, step = 1, value = 0 } ) {
 		  } ) );
 
 	const enhancedMarks = marksArray.map( ( mark, index ) => {
-		const markValue = ! isUndefined( mark.value ) ? mark.value : value;
+		const markValue = mark.value !== undefined ? mark.value : value;
 
 		const key = `mark-${ index }`;
 		const isFilled = markValue * step <= value;

--- a/packages/components/src/range-control/test/index.js
+++ b/packages/components/src/range-control/test/index.js
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import TestUtils, { act } from 'react-dom/test-utils';
+import { render, unmountComponentAtNode } from 'react-dom';
+import TestUtils, { act, Simulate } from 'react-dom/test-utils';
 
 /**
  * Internal dependencies
@@ -13,6 +14,19 @@ import RangeControl from '../';
  */
 import { Component } from '@wordpress/element';
 import { Dashicon } from '@wordpress/components';
+
+let container = null;
+
+beforeEach( () => {
+	container = document.createElement( 'div' );
+	document.body.appendChild( container );
+} );
+
+afterEach( () => {
+	unmountComponentAtNode( container );
+	container.remove();
+	container = null;
+} );
 
 describe( 'RangeControl', () => {
 	class TestWrapper extends Component {
@@ -323,6 +337,79 @@ describe( 'RangeControl', () => {
 			const inputElement = getInputElement( wrapper );
 
 			expect( inputElement.value ).toBe( '10' );
+		} );
+	} );
+
+	describe( 'input field', () => {
+		it( 'should render an input field by default', () => {
+			act( () => {
+				render( <RangeControl />, container );
+			} );
+			const field = container.querySelector( 'input[type="number"]' );
+
+			expect( field ).toBeTruthy();
+		} );
+
+		it( 'should not render an input field, if disabled', () => {
+			act( () => {
+				render( <RangeControl withInputField={ false } />, container );
+			} );
+			const field = container.querySelector( 'input[type="number"]' );
+
+			expect( field ).toBeFalsy();
+		} );
+
+		it( 'should render a zero value into input range and field', () => {
+			act( () => {
+				render( <RangeControl value={ 0 } />, container );
+			} );
+			const range = container.querySelector( 'input[type="range"]' );
+			const field = container.querySelector( 'input[type="number"]' );
+
+			expect( range.value ).toBe( '0' );
+			expect( field.value ).toBe( '0' );
+		} );
+
+		it( 'should update both field and range on change', () => {
+			act( () => {
+				render( <RangeControl value={ 0 } />, container );
+			} );
+			const range = container.querySelector( 'input[type="range"]' );
+			const field = container.querySelector( 'input[type="number"]' );
+
+			act( () => {
+				Simulate.change( range, { target: { value: 13 } } );
+			} );
+
+			expect( range.value ).toBe( '13' );
+			expect( field.value ).toBe( '13' );
+
+			act( () => {
+				Simulate.change( field, { target: { value: 7 } } );
+			} );
+
+			expect( range.value ).toBe( '7' );
+			expect( field.value ).toBe( '7' );
+		} );
+
+		it( 'should reset input values if next value is removed', () => {
+			act( () => {
+				render( <RangeControl value={ 13 } />, container );
+			} );
+			const range = container.querySelector( 'input[type="range"]' );
+			const field = container.querySelector( 'input[type="number"]' );
+
+			expect( range.value ).toBe( '13' );
+			expect( field.value ).toBe( '13' );
+
+			act( () => {
+				Simulate.change( field, { target: { value: undefined } } );
+			} );
+
+			// Reset to 50. Median value of min: 0, max: 100
+			expect( range.value ).toBe( '50' );
+			// Input field should be blank
+			expect( field.value ).toBe( '' );
 		} );
 	} );
 

--- a/packages/components/src/range-control/utils.js
+++ b/packages/components/src/range-control/utils.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { clamp, isFinite, noop } from 'lodash';
+import { clamp, noop } from 'lodash';
 
 /**
  * WordPress dependencies

--- a/storybook/test/__snapshots__/index.js.snap
+++ b/storybook/test/__snapshots__/index.js.snap
@@ -5421,6 +5421,7 @@ input[type='number'].emotion-14 {
         onChange={[Function]}
         step={1}
         type="number"
+        value={0}
       />
     </span>
   </div>


### PR DESCRIPTION
## Description
This update fixes the `RangeControl` issue where a `0` (zero) value would result in the `input[type="number"]` not updating.

## How has this been tested?
This was tested locally in Storybook and Gutenberg.
Jest tests were also added and run.

## Screenshots

<img width="381" alt="Screen Shot 2020-03-26 at 7 04 18 PM" src="https://user-images.githubusercontent.com/2322354/77705323-ba063280-6f95-11ea-9dd9-7bac58520d74.png">

Sliding the Range slider to zero will render `0` in the number input.


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->

Resolves: https://github.com/WordPress/gutenberg/issues/21186