### PR TITLE
Framework: Guard WP_Patterns_Registry call by class_exists

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -651,7 +651,7 @@ add_filter( 'block_editor_settings', 'gutenberg_extend_settings_block_patterns',
 /*
  * Register default patterns if not registered in Core already.
  */
-if ( ! WP_Patterns_Registry::get_instance()->is_registered( 'text-two-columns' ) ) {
+if ( class_exists( 'WP_Patterns_Registry' ) && ! WP_Patterns_Registry::get_instance()->is_registered( 'text-two-columns' ) ) {
 	register_pattern( 'core/text-two-columns', gutenberg_load_block_pattern( 'text-two-columns' ) );
 	register_pattern( 'core/two-buttons', gutenberg_load_block_pattern( 'two-buttons' ) );
 	register_pattern( 'core/cover-abc', gutenberg_load_block_pattern( 'cover-abc' ) );


### PR DESCRIPTION
Fixes #21185

This pull request seeks to resolve an issue preventing the vendor scripts download of the plugin build to be executed correctly. See https://github.com/WordPress/gutenberg/issues/21185#issuecomment-604733794 for full debugging details. Currently, a fatal error occurs when running `php bin/get-vendor-scripts.php` because there is code in `client-assets.php` which assumes the `WP_Patterns_Registry` to be defined. Since the vendor download script loads `client-assets.php` in isolation, it is not defined. The changes here propose to add a guard such that [short-circuit evaluation](https://en.wikipedia.org/wiki/Short-circuit_evaluation) will prevent the fatal error from occurring, while still retaining the existing behavior in environments where the class is defined (the regular plugin loading procedure).

**Testing Instructions:**

Build the plugin:

```
npm run package-plugin
```

Confirm in the logging of the script that the vendor dependencies are downloaded:

```
Downloading remote vendor scripts... 🛵

https://unpkg.com/core-js-url-browser@3.6.4/url.min.js
 > vendor/wp-polyfill-url.min.7490158b.js ... done!
https://unpkg.com/polyfill-library@3.42.0/polyfills/DOMRect/polyfill.js
 > vendor/wp-polyfill-dom-rect.7e21c103.js ... done!
https://unpkg.com/core-js-url-browser@3.6.4/url.js
 > vendor/wp-polyfill-url.db0b5454.js ... done!
https://unpkg.com/polyfill-library@3.42.0/polyfills/DOMRect/polyfill.js
 > vendor/wp-polyfill-dom-rect.7e21c103.js ... done!
```

Ideally, test to ensure the built `gutenberg.zip` file, once installed to a site, will allow the editor to be loaded once again in Internet Explorer.