### PR TITLE
Make Preview and Save Draft buttons use the same style

### DIFF
--- a/packages/block-editor/src/components/preview-options/index.js
+++ b/packages/block-editor/src/components/preview-options/index.js
@@ -8,7 +8,7 @@ import classnames from 'classnames';
  */
 import { Button, Dropdown, MenuGroup, MenuItem } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { Icon, check, chevronDown } from '@wordpress/icons';
+import { check } from '@wordpress/icons';
 
 export default function PreviewOptions( {
 	children,
@@ -28,13 +28,13 @@ export default function PreviewOptions( {
 			position="bottom left"
 			renderToggle={ ( { isOpen, onToggle } ) => (
 				<Button
+					isTertiary
 					onClick={ onToggle }
 					className="block-editor-post-preview__button-toggle"
 					aria-expanded={ isOpen }
 					disabled={ ! isEnabled }
 				>
 					{ __( 'Preview' ) }
-					<Icon icon={ chevronDown } />
 				</Button>
 			) }
 			renderContent={ () => (

--- a/packages/block-editor/src/components/preview-options/style.scss
+++ b/packages/block-editor/src/components/preview-options/style.scss
@@ -4,20 +4,6 @@
 	padding: 0;
 }
 
-.block-editor-post-preview__button-toggle {
-	display: flex;
-	justify-content: space-between;
-	padding: 0 $grid-unit-10 0 $grid-unit-15;
-
-	&:focus:not(:disabled) {
-		box-shadow: inset 0 0 0 1px $white, 0 0 0 $border-width-focus var(--wp-admin-theme-color);
-	}
-
-	svg {
-		margin-left: $grid-unit-05;
-	}
-}
-
 .block-editor-post-preview__button-resize.block-editor-post-preview__button-resize {
 	padding-left: $button-size-small + $grid-unit-10 + $grid-unit-10;
 

--- a/packages/edit-post/src/components/header/style.scss
+++ b/packages/edit-post/src/components/header/style.scss
@@ -70,14 +70,30 @@
 	.editor-post-saved-state,
 	.components-button.editor-post-switch-to-draft,
 	.components-button.editor-post-preview,
-	.components-button.block-editor-post-preview__dropdown,
-	.components-button.editor-post-publish-button,
-	.components-button.editor-post-publish-panel__toggle {
-		padding: 0 6px;
+	.components-button.block-editor-post-preview__dropdown {
+		padding: 0 #{ $grid-unit-15 / 2 };
 		margin-right: $grid-unit-05;
 
 		@include break-small() {
-			padding: 0 12px;
+			margin-right: $grid-unit-15;
+		}
+	}
+
+	.components-button.editor-post-save-draft,
+	.components-button.editor-post-switch-to-draft,
+	.components-button.editor-post-preview,
+	.components-button.block-editor-post-preview__button-toggle {
+		color: $dark-gray-primary;
+	}
+
+	.components-button.block-editor-post-preview__dropdown,
+	.components-button.editor-post-publish-button,
+	.components-button.editor-post-publish-panel__toggle {
+		padding: 0 #{ $grid-unit-15 / 2 };
+		margin-right: $grid-unit-05;
+
+		@include break-small() {
+			padding: 0 $grid-unit-15;
 			margin-right: $grid-unit-15;
 		}
 	}

--- a/packages/editor/src/components/post-saved-state/index.js
+++ b/packages/editor/src/components/post-saved-state/index.js
@@ -117,7 +117,7 @@ export class PostSavedState extends Component {
 			return null;
 		}
 
-		const label = isPending ? __( 'Save as Pending' ) : __( 'Save Draft' );
+		const label = isPending ? __( 'Save as pending' ) : __( 'Save draft' );
 		if ( ! isLargeViewport ) {
 			return (
 				<Button

--- a/packages/editor/src/components/post-saved-state/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/post-saved-state/test/__snapshots__/index.js.snap
@@ -9,6 +9,6 @@ exports[`PostSavedState should return Save button if edits to be saved 1`] = `
   onClick={[Function]}
   shortcut="Ctrl+S"
 >
-  Save Draft
+  Save draft
 </ForwardRef(Button)>
 `;


### PR DESCRIPTION
## Description
We were moving away from showing chevrons in buttons that open dropdown menus... so why does the Preview button still have one? This PR removes it.

One issue this raises to the surface is the inconsistency in design between the "Save Draft" and "Preview" buttons. I'm not really sure what an icon-less button _should_ look like. What exactly is the standard?

**UPDATE:** this PR now changes both buttons to look the same and adjusts their padding to optically balance the spacing between them.

## Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/19592990/77713343-25ef9780-6fa4-11ea-985a-c7d844e03102.png)
![image](https://user-images.githubusercontent.com/19592990/77713359-3273f000-6fa4-11ea-8608-05759287621d.png)

**UPDATE:** the buttons now look like this:
![image](https://user-images.githubusercontent.com/19592990/84062563-1c5fb400-a985-11ea-8b24-628bbdb472a5.png)
![image](https://user-images.githubusercontent.com/19592990/84062636-3dc0a000-a985-11ea-9908-de335d4565af.png)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
