### PR TITLE
Env: Bind "core" files to tests environment

### DIFF
--- a/packages/env/lib/build-docker-compose-config.js
+++ b/packages/env/lib/build-docker-compose-config.js
@@ -46,6 +46,8 @@ module.exports = function buildDockerComposeConfig( config ) {
 	let testsMounts;
 	if ( config.coreSource ) {
 		testsMounts = [
+			`${ config.coreSource.testsPath }:/var/www/html`,
+
 			// When using a local source for "core" we want to ensure two things:
 			//
 			// 1. That changes the user makes within the "core" directory are
@@ -63,22 +65,24 @@ module.exports = function buildDockerComposeConfig( config ) {
 			// - *                    <- $wordpress/*
 			//
 			// https://github.com/WordPress/gutenberg/issues/21164
-			`${ config.coreSource.testsPath }:/var/www/html`,
-			...fs
-				.readdirSync( config.coreSource.path )
-				.filter(
-					( file ) =>
-						file !== 'wp-config.php' &&
-						file !== 'wp-config-sample.php' &&
-						file !== 'wp-content'
-				)
-				.map(
-					( file ) =>
-						`${ path.join(
-							config.coreSource.path,
-							file
-						) }:/var/www/html/${ file }`
-				),
+			...( config.coreSource.type === 'local'
+				? fs
+						.readdirSync( config.coreSource.path )
+						.filter(
+							( filename ) =>
+								filename !== 'wp-config.php' &&
+								filename !== 'wp-config-sample.php' &&
+								filename !== 'wp-content'
+						)
+						.map(
+							( filename ) =>
+								`${ path.join(
+									config.coreSource.path,
+									filename
+								) }:/var/www/html/${ filename }`
+						)
+				: [] ),
+
 			...pluginMounts,
 			...themeMounts,
 		];


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/21164.

When using a local source for "core" we want to ensure two things:

1. That changes the user makes within the "core" directory are served in both the development and tests environments.
2. That the development and tests environment use separate databases and `wp-content/uploads`.

Only (2) was working because the tests environment served everything from a totally separate copy of WordPress.

The fix is to bind every file **except** `wp-config.php` and `wp-content` from the local "core" directory to the tests environment.

**To test:**

1. Create a `.wp-env.json` that has its `"core"` set to a local path:

   ```json
   { "core": "/path/to/wordpress-develop/build" }
   ```
2. Run `wp-env start`.

3. Make changes to something in `wordpress-develop/build`.

The changes should appear in both `localhost:8888` and `localhost:8889`.

We should also verify that this does not break existing flows, e.g. running `wp-env start` with `"core": null` and `"core: "WordPress/WordPress"`.