### PR TITLE
Fix fullwide regression.

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -649,6 +649,9 @@
 
 .block-editor-block-list__layout.is-root-container {
 	// Full-wide. (to account for the padddings added above)
+	// The first two rules account for the alignment wrapper div for the image block.
+	> div > .block-editor-block-list__block[data-align="full"],
+	> div > .block-editor-block-list__block.alignfull,
 	> .block-editor-block-list__block[data-align="full"],
 	> .block-editor-block-list__block.alignfull {
 		margin-left: -$block-padding;

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -650,8 +650,8 @@
 .block-editor-block-list__layout.is-root-container {
 	// Full-wide. (to account for the padddings added above)
 	// The first two rules account for the alignment wrapper div for the image block.
-	> div > .block-editor-block-list__block[data-align="full"],
-	> div > .block-editor-block-list__block.alignfull,
+	> div:not(.block-editor-block-list__block) > .block-editor-block-list__block[data-align="full"],
+	> div:not(.block-editor-block-list__block) > .block-editor-block-list__block.alignfull,
 	> .block-editor-block-list__block[data-align="full"],
 	> .block-editor-block-list__block.alignfull {
 		margin-left: -$block-padding;


### PR DESCRIPTION
Full-wide blocks were no longer full-width. This PR fixes that.

This possibly regressed in #21099. 

Before:

<img width="710" alt="Screenshot 2020-03-27 at 15 11 36" src="https://user-images.githubusercontent.com/1204802/77765247-42401280-703e-11ea-8609-b26fcd897b8e.png">

After:

<img width="671" alt="Screenshot 2020-03-27 at 15 16 50" src="https://user-images.githubusercontent.com/1204802/77765254-4409d600-703e-11ea-8644-a002dc0954ad.png">
