### PR TITLE
[RNMobile] Disable Category selection in release

### DIFF
--- a/packages/block-library/src/latest-posts/edit.native.js
+++ b/packages/block-library/src/latest-posts/edit.native.js
@@ -185,7 +185,10 @@ class LatestPostsEdit extends Component {
 						}
 						onOrderChange={ this.onSetOrder }
 						onOrderByChange={ this.onSetOrderBy }
-						onCategoryChange={ this.onSetCategories }
+						onCategoryChange={
+							// eslint-disable-next-line no-undef
+							__DEV__ ? this.onSetCategories : undefined
+						}
 						onNumberOfItemsChange={ this.onSetPostsToShow }
 					/>
 				</PanelBody>


### PR DESCRIPTION
**Fixes:** https://github.com/wordpress-mobile/gutenberg-mobile/issues/2073
`gutenberg-mobile` https://github.com/WordPress/gutenberg/pull/21203

## Description
<!-- Please describe what you have changed or added -->
WordPress 5.4 adds support for Multi-Select on Categories in the Latest-Posts Block. This places this setting behind a development flag until support is added on Mobile.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
This can be tested from the builds:
`iOS:` https://github.com/wordpress-mobile/WordPress-iOS/pull/13760
`Android:` https://github.com/wordpress-mobile/WordPress-Android/pull/11548

Launching a Latest-Post block should hide the Categories option in the block settings.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Removes setting feature.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
