### PR TITLE
Components: SlotFill: Guard property access to possibly-undefined slot

### DIFF
--- a/packages/components/src/slot-fill/bubbles-virtually/slot-fill-provider.js
+++ b/packages/components/src/slot-fill/bubbles-virtually/slot-fill-provider.js
@@ -29,7 +29,7 @@ function useSlotRegistry() {
 			const { [ name ]: slot, ...nextSlots } = prevSlots;
 			// Make sure we're not unregistering a slot registered by another element
 			// See https://github.com/WordPress/gutenberg/pull/19242#issuecomment-590295412
-			if ( slot.ref === ref ) {
+			if ( slot?.ref === ref ) {
 				return nextSlots;
 			}
 			return prevSlots;


### PR DESCRIPTION
Fixes crash mentioned at https://github.com/WordPress/gutenberg/issues/18560#issuecomment-604920204
Related: #19242

This pull request seeks to update the implementation of the new SlotFill `unregisterSlot` added in #19242 to guard property access on its condition for testing an equal `ref` value. While based on my comment at https://github.com/WordPress/gutenberg/pull/19242#discussion_r399298774 it is not entirely clear the reason for which a duplicate call is made to `unregisterSlot` when the slot is already unregistered, this avoids a situation where the absence of the slot would throw an error. The updated logic is such that if the `slot` is not defined, it will fall back to to returning the previous slots value `prevSlots`, since if the slot was not defined in `prevSlots` already, then `prevSlots` will continue to be the valid next state.

**Testing Instructions:**

1. Make a reusable block with two or more blocks
2. Edit the reusable block
3. Select one of the inner blocks
4. Select the reusable block by clicking on it in the navigator or on the bar of the reusable panel
5. Try to select another one of the inner blocks (not the same as before)

Verify no error occurs.

I will need some advice on implementing automated tests here. There are tests for the Slot / Fill components, but two issues:

- We need an isolated reproduceable case which triggers the initial error
- The tests use the [old `Provider` implementation](https://github.com/WordPress/gutenberg/blob/712dbfd1868446cc8f5e51be070df916346852be/packages/components/src/slot-fill/context.js#L33-L154). I'm not sure if this was intended to have been removed as part of #19242. In any case, I am not sure there is complete test coverage for the new implementations added in #19242.