### PR TITLE
Build: Add TypeScript version validation

### DIFF
--- a/bin/packages/lint-staged-typecheck.js
+++ b/bin/packages/lint-staged-typecheck.js
@@ -6,6 +6,11 @@ const path = require( 'path' );
 const fs = require( 'fs' );
 const execa = require( 'execa' );
 
+/**
+ * Internal dependencies
+ */
+require( './validate-typescript-version' );
+
 /* eslint-disable no-console */
 
 const repoRoot = path.join( __dirname, '..', '..' );

--- a/bin/packages/validate-typescript-version.js
+++ b/bin/packages/validate-typescript-version.js
@@ -2,6 +2,10 @@
  * External dependencies
  */
 const tscDetectedVersion = require( 'typescript' ).version;
+
+/**
+ * Internal dependencies
+ */
 const tscDependencyVersion = require( '../../package.json' ).devDependencies
 	.typescript;
 

--- a/bin/packages/validate-typescript-version.js
+++ b/bin/packages/validate-typescript-version.js
@@ -1,0 +1,24 @@
+/**
+ * External dependencies
+ */
+const tscDetectedVersion = require( 'typescript' ).version;
+const tscDependencyVersion = require( '../../package.json' ).devDependencies
+	.typescript;
+
+/* eslint-disable no-console */
+
+if ( tscDependencyVersion !== tscDetectedVersion ) {
+	console.error(
+		[
+			'TypeScript dependency out of date.',
+			'\tDetected: %o',
+			'\tRequired: %o',
+			'Please ensure dependencies are up to date.',
+		].join( require( 'os' ).EOL ),
+		tscDetectedVersion,
+		tscDependencyVersion
+	);
+	process.exit( 1 );
+}
+
+/* eslint-enable no-console */

--- a/package.json
+++ b/package.json
@@ -181,7 +181,7 @@
 		"clean:package-types": "tsc --build --clean",
 		"prebuild:packages": "npm run clean:packages && lerna run build",
 		"build:packages": "npm run build:package-types && node ./bin/packages/build.js",
-		"build:package-types": "tsc --build",
+		"build:package-types": "node ./bin/packages/validate-typescript-version.js && tsc --build",
 		"build": "npm run build:packages && wp-scripts build",
 		"check-engines": "wp-scripts check-engines",
 		"check-licenses": "concurrently \"wp-scripts check-licenses --prod --gpl2\" \"wp-scripts check-licenses --dev\"",


### PR DESCRIPTION
## Description
Provide clear errors due to mismated TypeScript versions. This should help make the transition period from https://github.com/WordPress/gutenberg/pull/18942 smoother.

Add `validate-typescript-version` bin that will be used by `lint-staged` typechecker and in `build:package-types` script.

This helps to prevent cryptic errors when an older TypeScript module is present in `node_modules` and requires updating.

Without this change, lint-staged and `npm run build:package-types` would print this error:

```none
# npm run build:pacakge-types
> tsc --build

error TS5053: Option 'allowJs' cannot be specified with option 'declaration'.
error TS5053: Option 'declaration' cannot be specified with option 'isolatedModules'.
```

This is due to an incompatible TypeScript package. With this change, these script will print this error:

```none
$ npm run build:package-types
> node ./bin/packages/validate-typescript-version.js && tsc --build

TypeScript dependency out of date.
        Detected: '3.5.3'
        Required: '3.8.3'
Please ensure dependencies are up to date.
```

## How has this been tested?

```sh
git checkout HEAD~3 # `master` branch before TypeScript update
npm ci # install stale TypeScript package
git checkout - # return to branch HEAD
npm run build:package-types # Fails and prints error
npm ci # Get up to date version
npm run build:package-types # Works!
```

## Screenshots <!-- if applicable -->

<img width="724" alt="Screen Shot 2020-03-27 at 17 46 15" src="https://user-images.githubusercontent.com/841763/77779517-f186e480-7052-11ea-8b16-c61f3a51877c.png">

## Types of changes

Developer experience improvement. No changelog entry necessary.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
