### PR TITLE
Cherry Pick PR's for WordPress 5.4 RC 5

### DIFF
--- a/packages/annotations/src/block/index.js
+++ b/packages/annotations/src/block/index.js
@@ -11,7 +11,7 @@ import { withSelect } from '@wordpress/data';
  * @return {Object} The enhanced component.
  */
 const addAnnotationClassName = ( OriginalComponent ) => {
-	return withSelect( ( select, { clientId } ) => {
+	return withSelect( ( select, { clientId, className } ) => {
 		const annotations = select(
 			'core/annotations'
 		).__experimentalGetAnnotationsForBlock( clientId );
@@ -21,6 +21,8 @@ const addAnnotationClassName = ( OriginalComponent ) => {
 				.map( ( annotation ) => {
 					return 'is-annotated-by-' + annotation.source;
 				} )
+				.concat( className )
+				.filter( Boolean )
 				.join( ' ' ),
 		};
 	} )( OriginalComponent );

--- a/packages/blocks/src/api/raw-handling/phrasing-content.js
+++ b/packages/blocks/src/api/raw-handling/phrasing-content.js
@@ -74,17 +74,6 @@ const embeddedContentSchema = {
 	},
 	canvas: { attributes: [ 'width', 'height' ] },
 	embed: { attributes: [ 'src', 'type', 'width', 'height' ] },
-	iframe: {
-		attributes: [
-			'src',
-			'srcdoc',
-			'name',
-			'sandbox',
-			'seamless',
-			'width',
-			'height',
-		],
-	},
 	img: {
 		attributes: [
 			'alt',

--- a/packages/components/src/slot-fill/bubbles-virtually/slot-fill-provider.js
+++ b/packages/components/src/slot-fill/bubbles-virtually/slot-fill-provider.js
@@ -29,7 +29,7 @@ function useSlotRegistry() {
 			const { [ name ]: slot, ...nextSlots } = prevSlots;
 			// Make sure we're not unregistering a slot registered by another element
 			// See https://github.com/WordPress/gutenberg/pull/19242#issuecomment-590295412
-			if ( slot.ref === ref ) {
+			if ( slot?.ref === ref ) {
 				return nextSlots;
 			}
 			return prevSlots;


### PR DESCRIPTION
## Description
This PR cherry-picks the following PR's into wp/trunk:
<table>

<tr><td><b>PR title</b></td><td><b>Author</b></td><td><b>Change required for cherry-picking</b></td></tr>


<tr><td><a href="https://github.com/WordPress/gutenberg/pull/20976">Remove iframe from content elements</a></td><td>@talldan</td><td>-</td></tr>
<tr><td><a href="https://github.com/WordPress/gutenberg/pull/21184">Annotations: Merge assigned block className with incoming prop</a></td><td>@aduth</td><td>-</td></tr>
<tr><td><a href="https://github.com/WordPress/gutenberg/pull/21205">Components: SlotFill: Guard property access to possibly-undefined slot</a></td><td>@aduth</td><td>-</td></tr>





</table>


These PR's will be part of WordPress 5.4 RC 5.

## How has this been tested?
I did some smoke tests and verified the branch, in fact, contained the expected fixes.