### PR TITLE
Preload the edited template to avoid the white page effect before the screen loads

### DIFF
--- a/lib/edit-site-page.php
+++ b/lib/edit-site-page.php
@@ -216,7 +216,6 @@ function gutenberg_edit_site_init( $hook ) {
 		'/wp/v2/taxonomies?per_page=-1&context=edit',
 		'/wp/v2/themes?status=active',
 		sprintf( '/wp/v2/templates/%s?context=edit', $_wp_current_template_id ),
-		'/wp/v2/users/me?post_type=templates&context=edit',
 		array( '/wp/v2/media', 'OPTIONS' ),
 	);
 	$preload_data  = array_reduce(

--- a/lib/edit-site-page.php
+++ b/lib/edit-site-page.php
@@ -208,6 +208,28 @@ function gutenberg_edit_site_init( $hook ) {
 	global $post;
 	$settings = apply_filters( 'block_editor_settings', $settings, $post );
 
+	// Preload block editor paths.
+	// most of these are copied from edit-forms-blocks.php.
+	$preload_paths = array(
+		'/',
+		'/wp/v2/types?context=edit',
+		'/wp/v2/taxonomies?per_page=-1&context=edit',
+		'/wp/v2/themes?status=active',
+		sprintf( '/wp/v2/templates/%s?context=edit', $_wp_current_template_id ),
+		'/wp/v2/users/me?post_type=templates&context=edit',
+		array( '/wp/v2/media', 'OPTIONS' ),
+	);
+	$preload_data  = array_reduce(
+		$preload_paths,
+		'rest_preload_api_request',
+		array()
+	);
+	wp_add_inline_script(
+		'wp-api-fetch',
+		sprintf( 'wp.apiFetch.use( wp.apiFetch.createPreloadingMiddleware( %s ) );', wp_json_encode( $preload_data ) ),
+		'after'
+	);
+
 	// Initialize editor.
 	wp_add_inline_script(
 		'wp-edit-site',

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -139,6 +139,9 @@ const ColorPanel = ( { colorSettings, clientId } ) => {
 
 	useEffect( () => {
 		const colorsDetectionElement = getBlockDOMNode( clientId );
+		if ( ! colorsDetectionElement ) {
+			return;
+		}
 		setDetectedColor( getComputedStyle( colorsDetectionElement ).color );
 
 		let backgroundColorNode = colorsDetectionElement;


### PR DESCRIPTION
Right now the screen loads as a white page before the API fetching the template finishes. This PR fixes that by preloading the template.