### PR TITLE
Heading: Add line height support

### DIFF
--- a/packages/block-library/src/heading/index.js
+++ b/packages/block-library/src/heading/index.js
@@ -35,6 +35,7 @@ export const settings = {
 		__unstablePasteTextInline: true,
 		lightBlockWrapper: true,
 		__experimentalColor: true,
+		__experimentalLineHeight: true,
 	},
 	example: {
 		attributes: {

--- a/packages/block-library/src/heading/style.scss
+++ b/packages/block-library/src/heading/style.scss
@@ -1,17 +1,3 @@
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
-	background-color: var(--wp--color--background);
-	color: var(--wp--color--text);
-
-	&.has-background {
-		padding: $block-bg-padding--v $block-bg-padding--h;
-	}
-}
-
 :root {
 	h1,
 	h2,
@@ -19,6 +5,19 @@ h6 {
 	h4,
 	h5,
 	h6 {
+		background-color: var(--wp--color--background);
+		color: var(--wp--color--text);
 		line-height: var(--wp--typography--line-height);
+	}
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+	&.has-background {
+		padding: $block-bg-padding--v $block-bg-padding--h;
 	}
 }

--- a/packages/block-library/src/heading/style.scss
+++ b/packages/block-library/src/heading/style.scss
@@ -11,3 +11,14 @@ h6 {
 		padding: $block-bg-padding--v $block-bg-padding--h;
 	}
 }
+
+:root {
+	h1,
+	h2,
+	h3,
+	h4,
+	h5,
+	h6 {
+		line-height: var(--wp--typography--line-height);
+	}
+}


### PR DESCRIPTION
## Description

<img width="725" alt="Screen Shot 2020-03-27 at 1 54 37 PM" src="https://user-images.githubusercontent.com/2322354/77785836-2420e500-7033-11ea-9552-4734b71c018d.png">

This update adds `line-height` style support to the Heading block!


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Types of changes

### `supports: __experimentalLineHeight`

This update adds `__experimentalLineHeight` to the `Heading` block settings. This new `supports` attribute was defined when introduced [line height to the Paragraph block](https://github.com/WordPress/gutenberg/pull/20775).

By adding this flag, the `LineHeightControl` and attribute is automatically added to the Editor, and the styles (CSS variables) are automatically rendered with the new internal hook.

### CSS

In order to render this change, we need to add CSS for the Heading block. We're leveraging the `:root` technique (renders:`:root h1, h2, h3, etc...` ) that bumps the specificity in a relatively hands-off manner. There's discussion around this technique here: https://github.com/WordPress/gutenberg/pull/21037

Note: Depending on how a theme's CSS is coded, these new line-height styles may not render correctly (due to specificity)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->

Along with https://github.com/WordPress/gutenberg/pull/20775, this PR resolves:
#20339