### PR TITLE
Project Management: Prompt user to link GitHub account to WordPress.org profile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11532,6 +11532,15 @@
 				"@babel/runtime": "^7.8.3"
 			}
 		},
+		"@wordpress/project-management-automation": {
+			"version": "file:packages/project-management-automation",
+			"dev": true,
+			"requires": {
+				"@actions/core": "^1.0.0",
+				"@actions/github": "^1.0.0",
+				"@babel/runtime": "^7.8.3"
+			}
+		},
 		"@wordpress/redux-routine": {
 			"version": "file:packages/redux-routine",
 			"requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6716,6 +6716,12 @@
 				"any-observable": "^0.3.0"
 			}
 		},
+		"@sindresorhus/is": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-2.1.0.tgz",
+			"integrity": "sha512-lXKXfypKo644k4Da4yXkPCrwcvn6SlUW2X2zFbuflKHNjf0w9htru01bo26uMhleMXsDmnZ12eJLdrAZa9MANg==",
+			"dev": true
+		},
 		"@storybook/addon-a11y": {
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-5.3.2.tgz",
@@ -9885,6 +9891,15 @@
 				}
 			}
 		},
+		"@szmarczak/http-timer": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.5.tgz",
+			"integrity": "sha512-PyRA9sm1Yayuj5OIoJ1hGt2YISX45w9WcFbh6ddT0Z/0yaFxOtGLInr4jUfU1EAFVs0Yfyfev4RNwBlUaHdlDQ==",
+			"dev": true,
+			"requires": {
+				"defer-to-connect": "^2.0.0"
+			}
+		},
 		"@tannin/compile": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/@tannin/compile/-/compile-1.0.3.tgz",
@@ -9968,6 +9983,18 @@
 				"@types/babel-types": "*"
 			}
 		},
+		"@types/cacheable-request": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.1.tgz",
+			"integrity": "sha512-ykFq2zmBGOCbpIXtoVbz4SKY5QriWPh3AjyU4G74RYbtt5yOc5OfaY75ftjg7mikMOla1CTGpX3lLbuJh8DTrQ==",
+			"dev": true,
+			"requires": {
+				"@types/http-cache-semantics": "*",
+				"@types/keyv": "*",
+				"@types/node": "*",
+				"@types/responselike": "*"
+			}
+		},
 		"@types/color-name": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
@@ -9995,6 +10022,12 @@
 			"version": "4.7.4",
 			"resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.4.tgz",
 			"integrity": "sha512-+o2igcuZA3xtOoFH56s+MCZVidwlJNcJID57DSCyawS2i910yG9vkwehCjJNZ6ImhCR5S9DbvIJKyYHcMyOfMw==",
+			"dev": true
+		},
+		"@types/http-cache-semantics": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.0.tgz",
+			"integrity": "sha512-c3Xy026kOF7QOTn00hbIllV1dLR9hG9NkSrLQgCVs8NF6sBU+VGWjD3wLPhmh1TYAc7ugCFsvHYMN4VcBN1U1A==",
 			"dev": true
 		},
 		"@types/is-function": {
@@ -10051,6 +10084,15 @@
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.3.tgz",
 			"integrity": "sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==",
 			"dev": true
+		},
+		"@types/keyv": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.1.tgz",
+			"integrity": "sha512-MPtoySlAZQ37VoLaPcTHCu1RWJ4llDkULYZIzOYxlhxBqYPB0RsRlmMU0R6tahtFe27mIdkHV+551ZWV4PLmVw==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*"
+			}
 		},
 		"@types/lodash": {
 			"version": "4.14.149",
@@ -10151,6 +10193,15 @@
 			"resolved": "https://registry.npmjs.org/@types/requestidlecallback/-/requestidlecallback-0.3.1.tgz",
 			"integrity": "sha512-BnnRkgWYijCIndUn+LgoqKHX/hNpJC5G03B9y7mZya/C2gUQTSn75fEj3ZP1/Rl2E6EYeXh2/7/8UNEZ4X7HuQ==",
 			"dev": true
+		},
+		"@types/responselike": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
+			"integrity": "sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*"
+			}
 		},
 		"@types/sprintf-js": {
 			"version": "1.1.2",
@@ -11538,7 +11589,8 @@
 			"requires": {
 				"@actions/core": "^1.0.0",
 				"@actions/github": "^1.0.0",
-				"@babel/runtime": "^7.8.3"
+				"@babel/runtime": "^7.8.3",
+				"got": "^10.7.0"
 			}
 		},
 		"@wordpress/redux-routine": {
@@ -14791,6 +14843,64 @@
 				"unset-value": "^1.0.0"
 			}
 		},
+		"cacheable-lookup": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-2.0.1.tgz",
+			"integrity": "sha512-EMMbsiOTcdngM/K6gV/OxF2x0t07+vMOWxZNSCRQMjO2MY2nhZQ6OYhOOpyQrbhqsgtvKGI7hcq6xjnA92USjg==",
+			"dev": true,
+			"requires": {
+				"@types/keyv": "^3.1.1",
+				"keyv": "^4.0.0"
+			}
+		},
+		"cacheable-request": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.1.tgz",
+			"integrity": "sha512-lt0mJ6YAnsrBErpTMWeu5kl/tg9xMAWjavYTN6VQXM1A/teBITuNcccXsCxF0tDQQJf9DfAaX5O4e0zp0KlfZw==",
+			"dev": true,
+			"requires": {
+				"clone-response": "^1.0.2",
+				"get-stream": "^5.1.0",
+				"http-cache-semantics": "^4.0.0",
+				"keyv": "^4.0.0",
+				"lowercase-keys": "^2.0.0",
+				"normalize-url": "^4.1.0",
+				"responselike": "^2.0.0"
+			},
+			"dependencies": {
+				"get-stream": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+					"integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+					"dev": true,
+					"requires": {
+						"pump": "^3.0.0"
+					}
+				},
+				"http-cache-semantics": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
+					"integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
+					"dev": true
+				},
+				"normalize-url": {
+					"version": "4.5.0",
+					"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
+					"integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==",
+					"dev": true
+				},
+				"pump": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+					"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+					"dev": true,
+					"requires": {
+						"end-of-stream": "^1.1.0",
+						"once": "^1.3.1"
+					}
+				}
+			}
+		},
 		"call-me-maybe": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
@@ -15308,6 +15418,23 @@
 			"requires": {
 				"is-regexp": "^1.0.0",
 				"is-supported-regexp-flag": "^1.0.0"
+			}
+		},
+		"clone-response": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
+			"integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
+			"dev": true,
+			"requires": {
+				"mimic-response": "^1.0.0"
+			},
+			"dependencies": {
+				"mimic-response": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+					"integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+					"dev": true
+				}
 			}
 		},
 		"co": {
@@ -17004,6 +17131,15 @@
 			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
 			"dev": true
 		},
+		"decompress-response": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-5.0.0.tgz",
+			"integrity": "sha512-TLZWWybuxWgoW7Lykv+gq9xvzOsUjQ9tF09Tj6NSTYGMTCHNXzrPnD6Hi+TgZq19PyTAGH4Ll/NIM/eTGglnMw==",
+			"dev": true,
+			"requires": {
+				"mimic-response": "^2.0.0"
+			}
+		},
 		"decompress-zip": {
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.2.2.tgz",
@@ -17110,6 +17246,12 @@
 			"requires": {
 				"clone": "^1.0.2"
 			}
+		},
+		"defer-to-connect": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.0.tgz",
+			"integrity": "sha512-bYL2d05vOSf1JEZNx5vSAtPuBMkX8K9EUutg7zlKvTqKXHt7RhWJFbmd7qakVuf13i+IkGmp6FwSsONOf6VYIg==",
+			"dev": true
 		},
 		"define-properties": {
 			"version": "1.1.2",
@@ -17683,6 +17825,12 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
 			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
+			"dev": true
+		},
+		"duplexer3": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+			"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
 			"dev": true
 		},
 		"duplexify": {
@@ -21383,6 +21531,56 @@
 			"integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
 			"requires": {
 				"delegate": "^3.1.2"
+			}
+		},
+		"got": {
+			"version": "10.7.0",
+			"resolved": "https://registry.npmjs.org/got/-/got-10.7.0.tgz",
+			"integrity": "sha512-aWTDeNw9g+XqEZNcTjMMZSy7B7yE9toWOFYip7ofFTLleJhvZwUxxTxkTpKvF+p1SAA4VHmuEy7PiHTHyq8tJg==",
+			"dev": true,
+			"requires": {
+				"@sindresorhus/is": "^2.0.0",
+				"@szmarczak/http-timer": "^4.0.0",
+				"@types/cacheable-request": "^6.0.1",
+				"cacheable-lookup": "^2.0.0",
+				"cacheable-request": "^7.0.1",
+				"decompress-response": "^5.0.0",
+				"duplexer3": "^0.1.4",
+				"get-stream": "^5.0.0",
+				"lowercase-keys": "^2.0.0",
+				"mimic-response": "^2.1.0",
+				"p-cancelable": "^2.0.0",
+				"p-event": "^4.0.0",
+				"responselike": "^2.0.0",
+				"to-readable-stream": "^2.0.0",
+				"type-fest": "^0.10.0"
+			},
+			"dependencies": {
+				"get-stream": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+					"integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+					"dev": true,
+					"requires": {
+						"pump": "^3.0.0"
+					}
+				},
+				"pump": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+					"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+					"dev": true,
+					"requires": {
+						"end-of-stream": "^1.1.0",
+						"once": "^1.3.1"
+					}
+				},
+				"type-fest": {
+					"version": "0.10.0",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.10.0.tgz",
+					"integrity": "sha512-EUV9jo4sffrwlg8s0zDhP0T2WD3pru5Xi0+HTE3zTUmBaZNhfkite9PdSJwdXLwPVW0jnAHT56pZHIOYckPEiw==",
+					"dev": true
+				}
 			}
 		},
 		"graceful-fs": {
@@ -26668,6 +26866,12 @@
 			"integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
 			"dev": true
 		},
+		"json-buffer": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+			"integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+			"dev": true
+		},
 		"json-parse-better-errors": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -26792,6 +26996,15 @@
 				"pako": "~1.0.2",
 				"readable-stream": "~2.3.6",
 				"set-immediate-shim": "~1.0.1"
+			}
+		},
+		"keyv": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.0.0.tgz",
+			"integrity": "sha512-U7ioE8AimvRVLfw4LffyOIRhL2xVgmE8T22L6i0BucSnBUyv4w+I7VN/zVZwRKHOI6ZRUcdMdWHQ8KSUvGpEog==",
+			"dev": true,
+			"requires": {
+				"json-buffer": "3.0.1"
 			}
 		},
 		"kind-of": {
@@ -27785,6 +27998,12 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
 			"integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
+			"dev": true
+		},
+		"lowercase-keys": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+			"integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
 			"dev": true
 		},
 		"lowlight": {
@@ -29335,6 +29554,12 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
 			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+		},
+		"mimic-response": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
+			"integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
+			"dev": true
 		},
 		"min-document": {
 			"version": "2.19.0",
@@ -31332,6 +31557,12 @@
 				"os-tmpdir": "^1.0.0"
 			}
 		},
+		"p-cancelable": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.0.0.tgz",
+			"integrity": "sha512-wvPXDmbMmu2ksjkB4Z3nZWTSkJEb9lqVdMaCKpZUGJG9TMiNp9XcbG3fn9fPKjem04fJMJnXoyFPk2FmgiaiNg==",
+			"dev": true
+		},
 		"p-defer": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
@@ -31345,6 +31576,15 @@
 			"dev": true,
 			"requires": {
 				"p-reduce": "^1.0.0"
+			}
+		},
+		"p-event": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/p-event/-/p-event-4.1.0.tgz",
+			"integrity": "sha512-4vAd06GCsgflX4wHN1JqrMzBh/8QZ4j+rzp0cd2scXRwuBEv+QR3wrVA5aLhWDLw4y2WgDKvzWF3CCLmVM1UgA==",
+			"dev": true,
+			"requires": {
+				"p-timeout": "^2.0.1"
 			}
 		},
 		"p-finally": {
@@ -31412,6 +31652,15 @@
 			"resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-1.0.0.tgz",
 			"integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo=",
 			"dev": true
+		},
+		"p-timeout": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
+			"integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
+			"dev": true,
+			"requires": {
+				"p-finally": "^1.0.0"
+			}
 		},
 		"p-try": {
 			"version": "1.0.0",
@@ -36112,6 +36361,15 @@
 			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
 			"dev": true
 		},
+		"responselike": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.0.tgz",
+			"integrity": "sha512-xH48u3FTB9VsZw7R+vvgaKeLKzT6jOogbQhEe/jewwnZgzPcnyWui2Av6JpoYZF/91uueC+lqhWqeURw5/qhCw==",
+			"dev": true,
+			"requires": {
+				"lowercase-keys": "^2.0.0"
+			}
+		},
 		"restore-cursor": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
@@ -39604,6 +39862,12 @@
 					}
 				}
 			}
+		},
+		"to-readable-stream": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-2.1.0.tgz",
+			"integrity": "sha512-o3Qa6DGg1CEXshSdvWNX2sN4QHqg03SPq7U6jPXRahlQdl5dK8oXjkU/2/sGrnOZKeGV1zLSO8qPwyKklPPE7w==",
+			"dev": true
 		},
 		"to-regex": {
 			"version": "3.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29833,6 +29833,35 @@
 				"lower-case": "^1.1.1"
 			}
 		},
+		"nock": {
+			"version": "12.0.3",
+			"resolved": "https://registry.npmjs.org/nock/-/nock-12.0.3.tgz",
+			"integrity": "sha512-QNb/j8kbFnKCiyqi9C5DD0jH/FubFGj5rt9NQFONXwQm3IPB0CULECg/eS3AU1KgZb/6SwUa4/DTRKhVxkGABw==",
+			"dev": true,
+			"requires": {
+				"debug": "^4.1.0",
+				"json-stringify-safe": "^5.0.1",
+				"lodash": "^4.17.13",
+				"propagate": "^2.0.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
+				}
+			}
+		},
 		"node-dir": {
 			"version": "0.1.17",
 			"resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.17.tgz",
@@ -33019,6 +33048,12 @@
 				"object.assign": "^4.1.0",
 				"reflect.ownkeys": "^0.2.0"
 			}
+		},
+		"propagate": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+			"integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+			"dev": true
 		},
 		"property-information": {
 			"version": "5.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6716,12 +6716,6 @@
 				"any-observable": "^0.3.0"
 			}
 		},
-		"@sindresorhus/is": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-2.1.0.tgz",
-			"integrity": "sha512-lXKXfypKo644k4Da4yXkPCrwcvn6SlUW2X2zFbuflKHNjf0w9htru01bo26uMhleMXsDmnZ12eJLdrAZa9MANg==",
-			"dev": true
-		},
 		"@storybook/addon-a11y": {
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-5.3.2.tgz",
@@ -9891,15 +9885,6 @@
 				}
 			}
 		},
-		"@szmarczak/http-timer": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.5.tgz",
-			"integrity": "sha512-PyRA9sm1Yayuj5OIoJ1hGt2YISX45w9WcFbh6ddT0Z/0yaFxOtGLInr4jUfU1EAFVs0Yfyfev4RNwBlUaHdlDQ==",
-			"dev": true,
-			"requires": {
-				"defer-to-connect": "^2.0.0"
-			}
-		},
 		"@tannin/compile": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/@tannin/compile/-/compile-1.0.3.tgz",
@@ -9983,18 +9968,6 @@
 				"@types/babel-types": "*"
 			}
 		},
-		"@types/cacheable-request": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.1.tgz",
-			"integrity": "sha512-ykFq2zmBGOCbpIXtoVbz4SKY5QriWPh3AjyU4G74RYbtt5yOc5OfaY75ftjg7mikMOla1CTGpX3lLbuJh8DTrQ==",
-			"dev": true,
-			"requires": {
-				"@types/http-cache-semantics": "*",
-				"@types/keyv": "*",
-				"@types/node": "*",
-				"@types/responselike": "*"
-			}
-		},
 		"@types/color-name": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
@@ -10022,12 +9995,6 @@
 			"version": "4.7.4",
 			"resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.4.tgz",
 			"integrity": "sha512-+o2igcuZA3xtOoFH56s+MCZVidwlJNcJID57DSCyawS2i910yG9vkwehCjJNZ6ImhCR5S9DbvIJKyYHcMyOfMw==",
-			"dev": true
-		},
-		"@types/http-cache-semantics": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.0.tgz",
-			"integrity": "sha512-c3Xy026kOF7QOTn00hbIllV1dLR9hG9NkSrLQgCVs8NF6sBU+VGWjD3wLPhmh1TYAc7ugCFsvHYMN4VcBN1U1A==",
 			"dev": true
 		},
 		"@types/is-function": {
@@ -10084,15 +10051,6 @@
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.3.tgz",
 			"integrity": "sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==",
 			"dev": true
-		},
-		"@types/keyv": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.1.tgz",
-			"integrity": "sha512-MPtoySlAZQ37VoLaPcTHCu1RWJ4llDkULYZIzOYxlhxBqYPB0RsRlmMU0R6tahtFe27mIdkHV+551ZWV4PLmVw==",
-			"dev": true,
-			"requires": {
-				"@types/node": "*"
-			}
 		},
 		"@types/lodash": {
 			"version": "4.14.149",
@@ -10193,15 +10151,6 @@
 			"resolved": "https://registry.npmjs.org/@types/requestidlecallback/-/requestidlecallback-0.3.1.tgz",
 			"integrity": "sha512-BnnRkgWYijCIndUn+LgoqKHX/hNpJC5G03B9y7mZya/C2gUQTSn75fEj3ZP1/Rl2E6EYeXh2/7/8UNEZ4X7HuQ==",
 			"dev": true
-		},
-		"@types/responselike": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
-			"integrity": "sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==",
-			"dev": true,
-			"requires": {
-				"@types/node": "*"
-			}
 		},
 		"@types/sprintf-js": {
 			"version": "1.1.2",
@@ -11589,8 +11538,7 @@
 			"requires": {
 				"@actions/core": "^1.0.0",
 				"@actions/github": "^1.0.0",
-				"@babel/runtime": "^7.8.3",
-				"got": "^10.7.0"
+				"@babel/runtime": "^7.8.3"
 			}
 		},
 		"@wordpress/redux-routine": {
@@ -14843,64 +14791,6 @@
 				"unset-value": "^1.0.0"
 			}
 		},
-		"cacheable-lookup": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-2.0.1.tgz",
-			"integrity": "sha512-EMMbsiOTcdngM/K6gV/OxF2x0t07+vMOWxZNSCRQMjO2MY2nhZQ6OYhOOpyQrbhqsgtvKGI7hcq6xjnA92USjg==",
-			"dev": true,
-			"requires": {
-				"@types/keyv": "^3.1.1",
-				"keyv": "^4.0.0"
-			}
-		},
-		"cacheable-request": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.1.tgz",
-			"integrity": "sha512-lt0mJ6YAnsrBErpTMWeu5kl/tg9xMAWjavYTN6VQXM1A/teBITuNcccXsCxF0tDQQJf9DfAaX5O4e0zp0KlfZw==",
-			"dev": true,
-			"requires": {
-				"clone-response": "^1.0.2",
-				"get-stream": "^5.1.0",
-				"http-cache-semantics": "^4.0.0",
-				"keyv": "^4.0.0",
-				"lowercase-keys": "^2.0.0",
-				"normalize-url": "^4.1.0",
-				"responselike": "^2.0.0"
-			},
-			"dependencies": {
-				"get-stream": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
-					"integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
-					"dev": true,
-					"requires": {
-						"pump": "^3.0.0"
-					}
-				},
-				"http-cache-semantics": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-					"integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
-					"dev": true
-				},
-				"normalize-url": {
-					"version": "4.5.0",
-					"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
-					"integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==",
-					"dev": true
-				},
-				"pump": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-					"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-					"dev": true,
-					"requires": {
-						"end-of-stream": "^1.1.0",
-						"once": "^1.3.1"
-					}
-				}
-			}
-		},
 		"call-me-maybe": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
@@ -15418,23 +15308,6 @@
 			"requires": {
 				"is-regexp": "^1.0.0",
 				"is-supported-regexp-flag": "^1.0.0"
-			}
-		},
-		"clone-response": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
-			"integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
-			"dev": true,
-			"requires": {
-				"mimic-response": "^1.0.0"
-			},
-			"dependencies": {
-				"mimic-response": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-					"integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
-					"dev": true
-				}
 			}
 		},
 		"co": {
@@ -17131,15 +17004,6 @@
 			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
 			"dev": true
 		},
-		"decompress-response": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-5.0.0.tgz",
-			"integrity": "sha512-TLZWWybuxWgoW7Lykv+gq9xvzOsUjQ9tF09Tj6NSTYGMTCHNXzrPnD6Hi+TgZq19PyTAGH4Ll/NIM/eTGglnMw==",
-			"dev": true,
-			"requires": {
-				"mimic-response": "^2.0.0"
-			}
-		},
 		"decompress-zip": {
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.2.2.tgz",
@@ -17246,12 +17110,6 @@
 			"requires": {
 				"clone": "^1.0.2"
 			}
-		},
-		"defer-to-connect": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.0.tgz",
-			"integrity": "sha512-bYL2d05vOSf1JEZNx5vSAtPuBMkX8K9EUutg7zlKvTqKXHt7RhWJFbmd7qakVuf13i+IkGmp6FwSsONOf6VYIg==",
-			"dev": true
 		},
 		"define-properties": {
 			"version": "1.1.2",
@@ -17825,12 +17683,6 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
 			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
-			"dev": true
-		},
-		"duplexer3": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-			"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
 			"dev": true
 		},
 		"duplexify": {
@@ -21531,56 +21383,6 @@
 			"integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
 			"requires": {
 				"delegate": "^3.1.2"
-			}
-		},
-		"got": {
-			"version": "10.7.0",
-			"resolved": "https://registry.npmjs.org/got/-/got-10.7.0.tgz",
-			"integrity": "sha512-aWTDeNw9g+XqEZNcTjMMZSy7B7yE9toWOFYip7ofFTLleJhvZwUxxTxkTpKvF+p1SAA4VHmuEy7PiHTHyq8tJg==",
-			"dev": true,
-			"requires": {
-				"@sindresorhus/is": "^2.0.0",
-				"@szmarczak/http-timer": "^4.0.0",
-				"@types/cacheable-request": "^6.0.1",
-				"cacheable-lookup": "^2.0.0",
-				"cacheable-request": "^7.0.1",
-				"decompress-response": "^5.0.0",
-				"duplexer3": "^0.1.4",
-				"get-stream": "^5.0.0",
-				"lowercase-keys": "^2.0.0",
-				"mimic-response": "^2.1.0",
-				"p-cancelable": "^2.0.0",
-				"p-event": "^4.0.0",
-				"responselike": "^2.0.0",
-				"to-readable-stream": "^2.0.0",
-				"type-fest": "^0.10.0"
-			},
-			"dependencies": {
-				"get-stream": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
-					"integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
-					"dev": true,
-					"requires": {
-						"pump": "^3.0.0"
-					}
-				},
-				"pump": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-					"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-					"dev": true,
-					"requires": {
-						"end-of-stream": "^1.1.0",
-						"once": "^1.3.1"
-					}
-				},
-				"type-fest": {
-					"version": "0.10.0",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.10.0.tgz",
-					"integrity": "sha512-EUV9jo4sffrwlg8s0zDhP0T2WD3pru5Xi0+HTE3zTUmBaZNhfkite9PdSJwdXLwPVW0jnAHT56pZHIOYckPEiw==",
-					"dev": true
-				}
 			}
 		},
 		"graceful-fs": {
@@ -26866,12 +26668,6 @@
 			"integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
 			"dev": true
 		},
-		"json-buffer": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-			"integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-			"dev": true
-		},
 		"json-parse-better-errors": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -26996,15 +26792,6 @@
 				"pako": "~1.0.2",
 				"readable-stream": "~2.3.6",
 				"set-immediate-shim": "~1.0.1"
-			}
-		},
-		"keyv": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.0.0.tgz",
-			"integrity": "sha512-U7ioE8AimvRVLfw4LffyOIRhL2xVgmE8T22L6i0BucSnBUyv4w+I7VN/zVZwRKHOI6ZRUcdMdWHQ8KSUvGpEog==",
-			"dev": true,
-			"requires": {
-				"json-buffer": "3.0.1"
 			}
 		},
 		"kind-of": {
@@ -27998,12 +27785,6 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
 			"integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
-			"dev": true
-		},
-		"lowercase-keys": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
-			"integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
 			"dev": true
 		},
 		"lowlight": {
@@ -29554,12 +29335,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
 			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
-		},
-		"mimic-response": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
-			"integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
-			"dev": true
 		},
 		"min-document": {
 			"version": "2.19.0",
@@ -31557,12 +31332,6 @@
 				"os-tmpdir": "^1.0.0"
 			}
 		},
-		"p-cancelable": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.0.0.tgz",
-			"integrity": "sha512-wvPXDmbMmu2ksjkB4Z3nZWTSkJEb9lqVdMaCKpZUGJG9TMiNp9XcbG3fn9fPKjem04fJMJnXoyFPk2FmgiaiNg==",
-			"dev": true
-		},
 		"p-defer": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
@@ -31576,15 +31345,6 @@
 			"dev": true,
 			"requires": {
 				"p-reduce": "^1.0.0"
-			}
-		},
-		"p-event": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/p-event/-/p-event-4.1.0.tgz",
-			"integrity": "sha512-4vAd06GCsgflX4wHN1JqrMzBh/8QZ4j+rzp0cd2scXRwuBEv+QR3wrVA5aLhWDLw4y2WgDKvzWF3CCLmVM1UgA==",
-			"dev": true,
-			"requires": {
-				"p-timeout": "^2.0.1"
 			}
 		},
 		"p-finally": {
@@ -31652,15 +31412,6 @@
 			"resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-1.0.0.tgz",
 			"integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo=",
 			"dev": true
-		},
-		"p-timeout": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
-			"integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
-			"dev": true,
-			"requires": {
-				"p-finally": "^1.0.0"
-			}
 		},
 		"p-try": {
 			"version": "1.0.0",
@@ -36361,15 +36112,6 @@
 			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
 			"dev": true
 		},
-		"responselike": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.0.tgz",
-			"integrity": "sha512-xH48u3FTB9VsZw7R+vvgaKeLKzT6jOogbQhEe/jewwnZgzPcnyWui2Av6JpoYZF/91uueC+lqhWqeURw5/qhCw==",
-			"dev": true,
-			"requires": {
-				"lowercase-keys": "^2.0.0"
-			}
-		},
 		"restore-cursor": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
@@ -39862,12 +39604,6 @@
 					}
 				}
 			}
-		},
-		"to-readable-stream": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-2.1.0.tgz",
-			"integrity": "sha512-o3Qa6DGg1CEXshSdvWNX2sN4QHqg03SPq7U6jPXRahlQdl5dK8oXjkU/2/sGrnOZKeGV1zLSO8qPwyKklPPE7w==",
-			"dev": true
 		},
 		"to-regex": {
 			"version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
 		"@wordpress/npm-package-json-lint-config": "file:packages/npm-package-json-lint-config",
 		"@wordpress/postcss-themes": "file:packages/postcss-themes",
 		"@wordpress/prettier-config": "file:packages/prettier-config",
+		"@wordpress/project-management-automation": "file:packages/project-management-automation",
 		"@wordpress/scripts": "file:packages/scripts",
 		"babel-loader": "8.0.6",
 		"babel-plugin-emotion": "10.0.27",

--- a/package.json
+++ b/package.json
@@ -149,6 +149,7 @@
 		"metro-react-native-babel-preset": "0.55.0",
 		"metro-react-native-babel-transformer": "0.55.0",
 		"mkdirp": "0.5.1",
+		"nock": "12.0.3",
 		"node-sass": "4.12.0",
 		"node-watch": "0.6.0",
 		"postcss": "7.0.13",

--- a/packages/project-management-automation/CHANGELOG.md
+++ b/packages/project-management-automation/CHANGELOG.md
@@ -3,6 +3,11 @@
 ### New feature
 
 - Include TypeScript type declarations ([#18942](https://github.com/WordPress/gutenberg/pull/18942))
+- The "Add First Time Contributor Label" task now prompts the user to link their GitHub account to their WordPress.org profile if neccessary for props credit.
+
+### Improvements
+
+- The "Add First Time Contributor Label" task now runs retroactively on pushes to master, due to [permission constraints](https://help.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token#permissions-for-the-github_token) of GitHub Actions.
 
 ## 1.0.0 (2019-08-29)
 

--- a/packages/project-management-automation/CHANGELOG.md
+++ b/packages/project-management-automation/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### New feature
 
 - Include TypeScript type declarations ([#18942](https://github.com/WordPress/gutenberg/pull/18942))
-- The "Add First Time Contributor Label" task now prompts the user to link their GitHub account to their WordPress.org profile if neccessary for props credit.
+- The "Add First Time Contributor Label" task now prompts the user to link their GitHub account to their WordPress.org profile if neccessary for props credit. The task has been renamed "First Time Contributor".
 
 ### Improvements
 

--- a/packages/project-management-automation/README.md
+++ b/packages/project-management-automation/README.md
@@ -2,7 +2,7 @@
 
 This is a [GitHub Action](https://help.github.com/en/categories/automating-your-workflow-with-github-actions) which contains various automation to assist with managing the Gutenberg GitHub repository:
 
-- `add-first-time-contributor-label`: Adds the 'First Time Contributor' label to PRs merged on behalf of contributors that have not previously made a contribution, and prompts the user to link their GitHub account to their WordPress.org profile if neccessary for props credit.
+- `first-time-contributor`: Adds the 'First Time Contributor' label to PRs merged on behalf of contributors that have not previously made a contribution, and prompts the user to link their GitHub account to their WordPress.org profile if neccessary for props credit.
 - `add-milestone`: Assigns the correct milestone to PRs once merged.
 - `assign-fixed-issues`: Assigns any issues 'fixed' by a newly opened PR to the author of that PR.
 

--- a/packages/project-management-automation/README.md
+++ b/packages/project-management-automation/README.md
@@ -2,7 +2,7 @@
 
 This is a [GitHub Action](https://help.github.com/en/categories/automating-your-workflow-with-github-actions) which contains various automation to assist with managing the Gutenberg GitHub repository:
 
-- `add-first-time-contributor-label`: Adds the 'First Time Contributor' label to PRs opened by contributors that have not yet made a commit.
+- `add-first-time-contributor-label`: Adds the 'First Time Contributor' label to PRs merged on behalf of contributors that have not previously made a contribution, and prompts the user to link their GitHub account to their WordPress.org profile if neccessary for props credit.
 - `add-milestone`: Assigns the correct milestone to PRs once merged.
 - `assign-fixed-issues`: Assigns any issues 'fixed' by a newly opened PR to the author of that PR.
 

--- a/packages/project-management-automation/lib/add-first-time-contributor-label.js
+++ b/packages/project-management-automation/lib/add-first-time-contributor-label.js
@@ -16,14 +16,14 @@ const hasWordPressProfile = require( './has-wordpress-profile' );
  * @type {string}
  */
 const ACCOUNT_LINK_PROMPT =
-	'Congratulations on your first merged pull request! We would like to ' +
-	'give you credit for your contribution in the next WordPress release, but ' +
-	'we were unable to find a WordPress.org profile associated with your ' +
-	'GitHub account. At your convenience, please visit the following URL and ' +
-	'click "link your GitHub account" under "GitHub Username" to initiate ' +
-	'the process to link your accounts:\n\nhttps://profiles.wordpress.org/me/profile/edit/\n\n' +
-	'If you do not have a WordPress.org account, you can create one at the ' +
-	'following page:\n\nhttps://login.wordpress.org/register';
+	"Congratulations on your first merged pull request! We'd like to credit " +
+	'you for your contribution in the post announcing the next WordPress ' +
+	"release, but we can't find a WordPress.org profile associated with your " +
+	'GitHub account. When you have a moment, visit the following URL and ' +
+	'click "link your GitHub account" under "GitHub Username" to link your ' +
+	'accounts:\n\nhttps://profiles.wordpress.org/me/profile/edit/\n\nAnd if ' +
+	"you don't have a WordPress.org account, you can create one on this page:" +
+	'\n\nhttps://login.wordpress.org/register\n\nKudos!';
 
 /**
  * Adds the 'First Time Contributor' label to PRs merged on behalf of

--- a/packages/project-management-automation/lib/add-first-time-contributor-label.js
+++ b/packages/project-management-automation/lib/add-first-time-contributor-label.js
@@ -69,15 +69,15 @@ async function addFirstTimeContributorLabel( payload, octokit ) {
 		`add-first-time-contributor-label: Searching for commits in ${ owner }/${ repo } by @${ author }`
 	);
 
-	const {
-		data: { total_count: totalCount },
-	} = await octokit.search.commits( {
-		q: `repo:${ owner }/${ repo }+author:${ author }`,
+	const { data: commits } = await octokit.repos.listCommits( {
+		owner,
+		repo,
+		author,
 	} );
 
-	if ( totalCount !== 0 ) {
+	if ( commits.length > 1 ) {
 		debug(
-			`add-first-time-contributor-label: ${ totalCount } commits found. Aborting`
+			`add-first-time-contributor-label: Not the first commit for author. Aborting`
 		);
 		return;
 	}

--- a/packages/project-management-automation/lib/add-first-time-contributor-label.js
+++ b/packages/project-management-automation/lib/add-first-time-contributor-label.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+const got = /** @type {*} */ ( require( 'got' ) ); // See: https://github.com/sindresorhus/got/issues/1137
+
+/**
  * Internal dependencies
  */
 const debug = require( './debug' );
@@ -7,6 +12,30 @@ const getAssociatedPullRequest = require( './get-associated-pull-request' );
 /** @typedef {import('@actions/github').GitHub} GitHub */
 /** @typedef {import('@octokit/webhooks').WebhookPayloadPush} WebhookPayloadPush */
 /** @typedef {import('./get-associated-pull-request').WebhookPayloadPushCommit} WebhookPayloadPushCommit */
+
+/**
+ * Base endpoint URL for WordPress.org profile lookup by GitHub username.
+ *
+ * @type {string}
+ */
+const BASE_PROFILE_LOOKUP_API_URL =
+	'https://profiles.wordpress.org/wp-json/wporg-github/v1/lookup/';
+
+/**
+ * Message of comment prompting contributor to link their GitHub account from
+ * their WordPress.org profile for props credit.
+ *
+ * @type {string}
+ */
+const ACCOUNT_LINK_PROMPT =
+	'Congratulations on your first merged pull request! We would like to ' +
+	'give you credit for your contribution in the next WordPress release, but ' +
+	'we were unable to find a WordPress.org profile associated with your ' +
+	'GitHub account. At your convenience, please visit the following URL and ' +
+	'click "link your GitHub account" under "GitHub Username" to initiate ' +
+	'the process to link your accounts:\n\nhttps://profiles.wordpress.org/me/profile/edit/\n\n' +
+	'If you do not have a WordPress.org account, you can create one at the ' +
+	'following page:\n\nhttps://login.wordpress.org/register';
 
 /**
  * Adds the 'First Time Contributor' label to PRs merged on behalf of
@@ -62,6 +91,40 @@ async function addFirstTimeContributorLabel( payload, octokit ) {
 		repo,
 		issue_number: pullRequest,
 		labels: [ 'First-time Contributor' ],
+	} );
+
+	debug(
+		`add-first-time-contributor-label: Checking for WordPress username associated with @${ author }`
+	);
+
+	let dotOrgUsername;
+	try {
+		const response = await got(
+			BASE_PROFILE_LOOKUP_API_URL + author,
+			/** @type {import('got').Options} */ ( {
+				responseType: 'json',
+			} )
+		);
+		dotOrgUsername = response.body.slug;
+	} catch ( error ) {
+		debug(
+			`add-first-time-contributor-label: Error retrieving from profile API:\n\n${ error.toString() }`
+		);
+		return;
+	}
+
+	if ( dotOrgUsername ) {
+		debug(
+			`add-first-time-contributor-label: User already known as ${ dotOrgUsername }. No need to prompt for account link!`
+		);
+		return;
+	}
+
+	await octokit.issues.createComment( {
+		owner,
+		repo,
+		issue_number: pullRequest,
+		body: ACCOUNT_LINK_PROMPT,
 	} );
 }
 

--- a/packages/project-management-automation/lib/add-milestone.js
+++ b/packages/project-management-automation/lib/add-milestone.js
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 const debug = require( './debug' );
+const getAssociatedPullRequest = require( './get-associated-pull-request' );
 
 /** @typedef {import('@octokit/rest').HookError} HookError */
 /** @typedef {import('@actions/github').GitHub} GitHub */
@@ -45,8 +46,7 @@ async function addMilestone( payload, octokit ) {
 		return;
 	}
 
-	const match = payload.commits[ 0 ].message.match( /\(#(\d+)\)$/m );
-	const prNumber = match && match[ 1 ];
+	const prNumber = getAssociatedPullRequest( payload.commits[ 0 ] );
 	if ( ! prNumber ) {
 		debug( 'add-milestone: Commit is not a squashed PR. Aborting' );
 		return;

--- a/packages/project-management-automation/lib/first-time-contributor.js
+++ b/packages/project-management-automation/lib/first-time-contributor.js
@@ -32,11 +32,9 @@ const ACCOUNT_LINK_PROMPT =
  * @param {WebhookPayloadPush} payload Push event payload.
  * @param {GitHub}             octokit Initialized Octokit REST client.
  */
-async function addFirstTimeContributorLabel( payload, octokit ) {
+async function firstTimeContributor( payload, octokit ) {
 	if ( payload.ref !== 'refs/heads/master' ) {
-		debug(
-			'add-first-time-contributor-label: Commit is not to `master`. Aborting'
-		);
+		debug( 'first-time-contributor: Commit is not to `master`. Aborting' );
 		return;
 	}
 
@@ -45,7 +43,7 @@ async function addFirstTimeContributorLabel( payload, octokit ) {
 	const pullRequest = getAssociatedPullRequest( commit );
 	if ( ! pullRequest ) {
 		debug(
-			'add-first-time-contributor-label: Cannot determine pull request associated with commit. Aborting'
+			'first-time-contributor: Cannot determine pull request associated with commit. Aborting'
 		);
 		return;
 	}
@@ -54,7 +52,7 @@ async function addFirstTimeContributorLabel( payload, octokit ) {
 	const owner = payload.repository.owner.login;
 	const author = commit.author.username;
 	debug(
-		`add-first-time-contributor-label: Searching for commits in ${ owner }/${ repo } by @${ author }`
+		`first-time-contributor: Searching for commits in ${ owner }/${ repo } by @${ author }`
 	);
 
 	const { data: commits } = await octokit.repos.listCommits( {
@@ -65,13 +63,13 @@ async function addFirstTimeContributorLabel( payload, octokit ) {
 
 	if ( commits.length > 1 ) {
 		debug(
-			`add-first-time-contributor-label: Not the first commit for author. Aborting`
+			`first-time-contributor: Not the first commit for author. Aborting`
 		);
 		return;
 	}
 
 	debug(
-		`add-first-time-contributor-label: Adding 'First Time Contributor' label to issue #${ pullRequest }`
+		`first-time-contributor: Adding 'First Time Contributor' label to issue #${ pullRequest }`
 	);
 
 	await octokit.issues.addLabels( {
@@ -82,7 +80,7 @@ async function addFirstTimeContributorLabel( payload, octokit ) {
 	} );
 
 	debug(
-		`add-first-time-contributor-label: Checking for WordPress username associated with @${ author }`
+		`first-time-contributor: Checking for WordPress username associated with @${ author }`
 	);
 
 	let hasProfile;
@@ -90,14 +88,14 @@ async function addFirstTimeContributorLabel( payload, octokit ) {
 		hasProfile = await hasWordPressProfile( author );
 	} catch ( error ) {
 		debug(
-			`add-first-time-contributor-label: Error retrieving from profile API:\n\n${ error.toString() }`
+			`first-time-contributor: Error retrieving from profile API:\n\n${ error.toString() }`
 		);
 		return;
 	}
 
 	if ( hasProfile ) {
 		debug(
-			`add-first-time-contributor-label: User already known. No need to prompt for account link!`
+			`first-time-contributor: User already known. No need to prompt for account link!`
 		);
 		return;
 	}
@@ -110,4 +108,4 @@ async function addFirstTimeContributorLabel( payload, octokit ) {
 	} );
 }
 
-module.exports = addFirstTimeContributorLabel;
+module.exports = firstTimeContributor;

--- a/packages/project-management-automation/lib/first-time-contributor.js
+++ b/packages/project-management-automation/lib/first-time-contributor.js
@@ -27,7 +27,9 @@ const ACCOUNT_LINK_PROMPT =
 
 /**
  * Adds the 'First Time Contributor' label to PRs merged on behalf of
- * contributors that have not yet made a commit.
+ * contributors that have not yet made a commit, and prompts the user to link
+ * their GitHub account to their WordPress.org profile if neccessary for props
+ * credit.
  *
  * @param {WebhookPayloadPush} payload Push event payload.
  * @param {GitHub}             octokit Initialized Octokit REST client.

--- a/packages/project-management-automation/lib/get-associated-pull-request.js
+++ b/packages/project-management-automation/lib/get-associated-pull-request.js
@@ -1,10 +1,22 @@
 /**
+ * @typedef WebhookPayloadPushCommitAuthor
+ *
+ * @property {string} name     Author name.
+ * @property {string} email    Author email.
+ * @property {string} username Author username.
+ */
+
+/**
  * Minimal type detail of GitHub Push webhook event payload, for lack of their
  * own.
  *
+ * TODO: If GitHub improves this on their own webhook payload types, this type
+ * should no longer be necessary.
+ *
  * @typedef {Record<string,*>} WebhookPayloadPushCommit
  *
- * @property {string} message Commit message.
+ * @property {string}                         message Commit message.
+ * @property {WebhookPayloadPushCommitAuthor} author  Commit author.
  *
  * @see https://developer.github.com/v3/activity/events/types/#pushevent
  */

--- a/packages/project-management-automation/lib/get-associated-pull-request.js
+++ b/packages/project-management-automation/lib/get-associated-pull-request.js
@@ -1,0 +1,27 @@
+/**
+ * Minimal type detail of GitHub Push webhook event payload, for lack of their
+ * own.
+ *
+ * @typedef {Record<string,*>} WebhookPayloadPushCommit
+ *
+ * @property {string} message Commit message.
+ *
+ * @see https://developer.github.com/v3/activity/events/types/#pushevent
+ */
+
+/**
+ * Given a commit object, returns a promise resolving with the pull request
+ * number associated with the commit, or null if an associated pull request
+ * cannot be determined.
+ *
+ * @param {WebhookPayloadPushCommit} commit Commit object.
+ *
+ * @return {number?} Pull request number, or null if it cannot be
+ *                            determined.
+ */
+function getAssociatedPullRequest( commit ) {
+	const match = commit.message.match( /\(#(\d+)\)$/m );
+	return match && Number( match[ 1 ] );
+}
+
+module.exports = getAssociatedPullRequest;

--- a/packages/project-management-automation/lib/has-wordpress-profile.js
+++ b/packages/project-management-automation/lib/has-wordpress-profile.js
@@ -1,0 +1,43 @@
+/**
+ * External dependencies
+ */
+const { request } = require( 'https' );
+
+/**
+ * Endpoint hostname for WordPress.org profile lookup by GitHub username.
+ *
+ * @type {string}
+ */
+const BASE_PROFILE_LOOKUP_API_HOSTNAME = 'https://profiles.wordpress.org';
+
+/**
+ * Base path for WordPress.org profile lookup by GitHub username.
+ *
+ * @type {string}
+ */
+const BASE_PROFILE_LOOKUP_API_BASE_PATH = '/wp-json/wporg-github/v1/lookup/';
+
+/**
+ * Returns a promise resolving to a boolean indicating if the given GitHub
+ * username can be associated with a WordPress.org profile.
+ *
+ * @param {string} githubUsername GitHub username.
+ *
+ * @return {Promise<boolean>} Promise resolving to whether WordPress profile is
+ *                            known.
+ */
+async function hasWordPressProfile( githubUsername ) {
+	return new Promise( ( resolve, reject ) => {
+		const options = {
+			hostname: BASE_PROFILE_LOOKUP_API_HOSTNAME,
+			path: BASE_PROFILE_LOOKUP_API_BASE_PATH + githubUsername,
+			method: 'HEAD',
+		};
+
+		request( options, ( res ) => resolve( res.statusCode === 200 ) )
+			.on( 'error', ( error ) => reject( error ) )
+			.end();
+	} );
+}
+
+module.exports = hasWordPressProfile;

--- a/packages/project-management-automation/lib/has-wordpress-profile.js
+++ b/packages/project-management-automation/lib/has-wordpress-profile.js
@@ -32,6 +32,9 @@ async function hasWordPressProfile( githubUsername ) {
 			hostname: BASE_PROFILE_LOOKUP_API_HOSTNAME,
 			path: BASE_PROFILE_LOOKUP_API_BASE_PATH + githubUsername,
 			method: 'HEAD',
+			headers: {
+				'User-Agent': 'Gutenberg/project-management-automation',
+			},
 		};
 
 		request( options, ( res ) => resolve( res.statusCode === 200 ) )

--- a/packages/project-management-automation/lib/has-wordpress-profile.js
+++ b/packages/project-management-automation/lib/has-wordpress-profile.js
@@ -8,7 +8,7 @@ const { request } = require( 'https' );
  *
  * @type {string}
  */
-const BASE_PROFILE_LOOKUP_API_HOSTNAME = 'https://profiles.wordpress.org';
+const BASE_PROFILE_LOOKUP_API_HOSTNAME = 'profiles.wordpress.org';
 
 /**
  * Base path for WordPress.org profile lookup by GitHub username.

--- a/packages/project-management-automation/lib/index.js
+++ b/packages/project-management-automation/lib/index.js
@@ -42,9 +42,8 @@ const automations = [
 		task: ifNotFork( assignFixedIssues ),
 	},
 	{
-		event: 'pull_request',
-		action: 'opened',
-		task: ifNotFork( addFirstTimeContributorLabel ),
+		event: 'push',
+		task: addFirstTimeContributorLabel,
 	},
 	{
 		event: 'push',

--- a/packages/project-management-automation/lib/index.js
+++ b/packages/project-management-automation/lib/index.js
@@ -8,7 +8,7 @@ const { context, GitHub } = require( '@actions/github' );
  * Internal dependencies
  */
 const assignFixedIssues = require( './assign-fixed-issues' );
-const addFirstTimeContributorLabel = require( './add-first-time-contributor-label' );
+const firstTimeContributor = require( './first-time-contributor' );
 const addMilestone = require( './add-milestone' );
 const debug = require( './debug' );
 const ifNotFork = require( './if-not-fork' );
@@ -43,7 +43,7 @@ const automations = [
 	},
 	{
 		event: 'push',
-		task: addFirstTimeContributorLabel,
+		task: firstTimeContributor,
 	},
 	{
 		event: 'push',

--- a/packages/project-management-automation/lib/test/add-first-time-contributor-label.js
+++ b/packages/project-management-automation/lib/test/add-first-time-contributor-label.js
@@ -1,18 +1,14 @@
 /**
- * External dependencies
- */
-import got from 'got';
-
-/**
  * Internal dependencies
  */
 import addFirstTimeContributorLabel from '../add-first-time-contributor-label';
+import hasWordPressProfile from '../has-wordpress-profile';
 
-jest.mock( 'got', () => jest.fn() );
+jest.mock( '../has-wordpress-profile', () => jest.fn() );
 
 describe( 'addFirstTimeContributorLabel', () => {
 	beforeEach( () => {
-		got.mockReset();
+		hasWordPressProfile.mockReset();
 	} );
 
 	const payload = {
@@ -123,7 +119,7 @@ describe( 'addFirstTimeContributorLabel', () => {
 			},
 		};
 
-		got.mockReturnValue( Promise.resolve( { body: { slug: 'ghostwp' } } ) );
+		hasWordPressProfile.mockReturnValue( Promise.resolve( true ) );
 
 		await addFirstTimeContributorLabel( payload, octokit );
 
@@ -158,8 +154,8 @@ describe( 'addFirstTimeContributorLabel', () => {
 			},
 		};
 
-		got.mockImplementation( () => {
-			throw new Error( 'Whoops!' );
+		hasWordPressProfile.mockImplementation( () => {
+			return Promise.reject( new Error( 'Whoops!' ) );
 		} );
 
 		await addFirstTimeContributorLabel( payload, octokit );
@@ -195,17 +191,7 @@ describe( 'addFirstTimeContributorLabel', () => {
 			},
 		};
 
-		got.mockReturnValue(
-			Promise.resolve( {
-				body: {
-					code: 'user_not_linked',
-					message: 'Github Account not linked.',
-					data: {
-						status: 404,
-					},
-				},
-			} )
-		);
+		hasWordPressProfile.mockReturnValue( Promise.resolve( false ) );
 
 		await addFirstTimeContributorLabel( payload, octokit );
 

--- a/packages/project-management-automation/lib/test/add-first-time-contributor-label.js
+++ b/packages/project-management-automation/lib/test/add-first-time-contributor-label.js
@@ -1,9 +1,20 @@
 /**
+ * External dependencies
+ */
+import got from 'got';
+
+/**
  * Internal dependencies
  */
 import addFirstTimeContributorLabel from '../add-first-time-contributor-label';
 
+jest.mock( 'got', () => jest.fn() );
+
 describe( 'addFirstTimeContributorLabel', () => {
+	beforeEach( () => {
+		got.mockReset();
+	} );
+
 	const payload = {
 		ref: 'refs/heads/master',
 		commits: [
@@ -104,8 +115,11 @@ describe( 'addFirstTimeContributorLabel', () => {
 			},
 			issues: {
 				addLabels: jest.fn(),
+				createComment: jest.fn(),
 			},
 		};
+
+		got.mockReturnValue( Promise.resolve( { body: { slug: 'ghostwp' } } ) );
 
 		await addFirstTimeContributorLabel( payload, octokit );
 
@@ -117,6 +131,90 @@ describe( 'addFirstTimeContributorLabel', () => {
 			repo: 'gutenberg',
 			issue_number: 123,
 			labels: [ 'First-time Contributor' ],
+		} );
+		expect( octokit.issues.createComment ).not.toHaveBeenCalled();
+	} );
+
+	it( 'aborts if the request to retrieve WordPress.org user profile fails', async () => {
+		const octokit = {
+			search: {
+				commits: jest.fn( () =>
+					Promise.resolve( {
+						data: {
+							total_count: 0,
+						},
+					} )
+				),
+			},
+			issues: {
+				addLabels: jest.fn(),
+				createComment: jest.fn(),
+			},
+		};
+
+		got.mockImplementation( () => {
+			throw new Error( 'Whoops!' );
+		} );
+
+		await addFirstTimeContributorLabel( payload, octokit );
+
+		expect( octokit.search.commits ).toHaveBeenCalledWith( {
+			q: 'repo:WordPress/gutenberg+author:ghost',
+		} );
+		expect( octokit.issues.addLabels ).toHaveBeenCalledWith( {
+			owner: 'WordPress',
+			repo: 'gutenberg',
+			issue_number: 123,
+			labels: [ 'First-time Contributor' ],
+		} );
+		expect( octokit.issues.createComment ).not.toHaveBeenCalled();
+	} );
+
+	it( 'prompts the user to link their GitHub account to their WordPress.org profile', async () => {
+		const octokit = {
+			search: {
+				commits: jest.fn( () =>
+					Promise.resolve( {
+						data: {
+							total_count: 0,
+						},
+					} )
+				),
+			},
+			issues: {
+				addLabels: jest.fn(),
+				createComment: jest.fn(),
+			},
+		};
+
+		got.mockReturnValue(
+			Promise.resolve( {
+				body: {
+					code: 'user_not_linked',
+					message: 'Github Account not linked.',
+					data: {
+						status: 404,
+					},
+				},
+			} )
+		);
+
+		await addFirstTimeContributorLabel( payload, octokit );
+
+		expect( octokit.search.commits ).toHaveBeenCalledWith( {
+			q: 'repo:WordPress/gutenberg+author:ghost',
+		} );
+		expect( octokit.issues.addLabels ).toHaveBeenCalledWith( {
+			owner: 'WordPress',
+			repo: 'gutenberg',
+			issue_number: 123,
+			labels: [ 'First-time Contributor' ],
+		} );
+		expect( octokit.issues.createComment ).toHaveBeenCalledWith( {
+			owner: 'WordPress',
+			repo: 'gutenberg',
+			issue_number: 123,
+			body: expect.stringMatching( /^Congratulations/ ),
 		} );
 	} );
 } );

--- a/packages/project-management-automation/lib/test/add-milestone.js
+++ b/packages/project-management-automation/lib/test/add-milestone.js
@@ -63,7 +63,7 @@ describe( 'addMilestone', () => {
 		expect( octokit.issues.get ).toHaveBeenCalledWith( {
 			owner: 'WordPress',
 			repo: 'gutenberg',
-			issue_number: '123',
+			issue_number: 123,
 		} );
 		expect( octokit.issues.createMilestone ).not.toHaveBeenCalled();
 		expect( octokit.issues.listMilestonesForRepo ).not.toHaveBeenCalled();
@@ -124,7 +124,7 @@ describe( 'addMilestone', () => {
 		expect( octokit.issues.get ).toHaveBeenCalledWith( {
 			owner: 'WordPress',
 			repo: 'gutenberg',
-			issue_number: '123',
+			issue_number: 123,
 		} );
 		expect( octokit.repos.getContents ).toHaveBeenCalledWith( {
 			owner: 'WordPress',
@@ -144,7 +144,7 @@ describe( 'addMilestone', () => {
 		expect( octokit.issues.update ).toHaveBeenCalledWith( {
 			owner: 'WordPress',
 			repo: 'gutenberg',
-			issue_number: '123',
+			issue_number: 123,
 			milestone: 12,
 		} );
 	} );
@@ -202,7 +202,7 @@ describe( 'addMilestone', () => {
 		expect( octokit.issues.get ).toHaveBeenCalledWith( {
 			owner: 'WordPress',
 			repo: 'gutenberg',
-			issue_number: '123',
+			issue_number: 123,
 		} );
 		expect( octokit.repos.getContents ).toHaveBeenCalledWith( {
 			owner: 'WordPress',
@@ -222,7 +222,7 @@ describe( 'addMilestone', () => {
 		expect( octokit.issues.update ).toHaveBeenCalledWith( {
 			owner: 'WordPress',
 			repo: 'gutenberg',
-			issue_number: '123',
+			issue_number: 123,
 			milestone: 12,
 		} );
 	} );

--- a/packages/project-management-automation/lib/test/first-time-contributor.js
+++ b/packages/project-management-automation/lib/test/first-time-contributor.js
@@ -1,12 +1,12 @@
 /**
  * Internal dependencies
  */
-import addFirstTimeContributorLabel from '../add-first-time-contributor-label';
+import firstTimeContributor from '../first-time-contributor';
 import hasWordPressProfile from '../has-wordpress-profile';
 
 jest.mock( '../has-wordpress-profile', () => jest.fn() );
 
-describe( 'addFirstTimeContributorLabel', () => {
+describe( 'firstTimeContributor', () => {
 	beforeEach( () => {
 		hasWordPressProfile.mockReset();
 	} );
@@ -44,7 +44,7 @@ describe( 'addFirstTimeContributorLabel', () => {
 			},
 		};
 
-		await addFirstTimeContributorLabel( payloadForBranchPush, octokit );
+		await firstTimeContributor( payloadForBranchPush, octokit );
 
 		expect( octokit.repos.listCommits ).not.toHaveBeenCalled();
 	} );
@@ -70,7 +70,7 @@ describe( 'addFirstTimeContributorLabel', () => {
 			},
 		};
 
-		await addFirstTimeContributorLabel( payloadDirectToMaster, octokit );
+		await firstTimeContributor( payloadDirectToMaster, octokit );
 
 		expect( octokit.repos.listCommits ).not.toHaveBeenCalled();
 	} );
@@ -92,7 +92,7 @@ describe( 'addFirstTimeContributorLabel', () => {
 			},
 		};
 
-		await addFirstTimeContributorLabel( payload, octokit );
+		await firstTimeContributor( payload, octokit );
 
 		expect( octokit.repos.listCommits ).toHaveBeenCalledWith( {
 			owner: 'WordPress',
@@ -121,7 +121,7 @@ describe( 'addFirstTimeContributorLabel', () => {
 
 		hasWordPressProfile.mockReturnValue( Promise.resolve( true ) );
 
-		await addFirstTimeContributorLabel( payload, octokit );
+		await firstTimeContributor( payload, octokit );
 
 		expect( octokit.repos.listCommits ).toHaveBeenCalledWith( {
 			owner: 'WordPress',
@@ -158,7 +158,7 @@ describe( 'addFirstTimeContributorLabel', () => {
 			return Promise.reject( new Error( 'Whoops!' ) );
 		} );
 
-		await addFirstTimeContributorLabel( payload, octokit );
+		await firstTimeContributor( payload, octokit );
 
 		expect( octokit.repos.listCommits ).toHaveBeenCalledWith( {
 			owner: 'WordPress',
@@ -193,7 +193,7 @@ describe( 'addFirstTimeContributorLabel', () => {
 
 		hasWordPressProfile.mockReturnValue( Promise.resolve( false ) );
 
-		await addFirstTimeContributorLabel( payload, octokit );
+		await firstTimeContributor( payload, octokit );
 
 		expect( octokit.repos.listCommits ).toHaveBeenCalledWith( {
 			owner: 'WordPress',

--- a/packages/project-management-automation/lib/test/get-associated-pull-request.js
+++ b/packages/project-management-automation/lib/test/get-associated-pull-request.js
@@ -1,0 +1,37 @@
+/**
+ * Internal dependencies
+ */
+import getAssociatedPullRequest from '../get-associated-pull-request';
+
+/** @typedef {import('../get-associated-pull-request').WebhookPayloadPushCommit} WebhookPayloadPushCommit */
+
+/**
+ * An example commit which can be associated with a pull request, e.g. a pull
+ * request merge commit.
+ *
+ * @type {WebhookPayloadPushCommit}
+ */
+const VALID_COMMIT = {
+	message:
+		'Components: SlotFill: Guard property access to possibly-undefined slot (#21205)',
+};
+
+/**
+ * An example commit which cannot be associated with a pull request, e.g. when
+ * someone commits directly to master.
+ *
+ * @type {WebhookPayloadPushCommit}
+ */
+const INVALID_COMMIT = {
+	message: 'Add basic placeholder content to post title, content, and date.',
+};
+
+describe( 'getAssociatedPullRequest', () => {
+	it( 'should return the pull request number associated with a commit', () => {
+		expect( getAssociatedPullRequest( VALID_COMMIT ) ).toBe( 21205 );
+	} );
+
+	it( 'should return null if a pull request cannot be determined', () => {
+		expect( getAssociatedPullRequest( INVALID_COMMIT ) ).toBeNull();
+	} );
+} );

--- a/packages/project-management-automation/lib/test/has-wordpress-profile.js
+++ b/packages/project-management-automation/lib/test/has-wordpress-profile.js
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import nock from 'nock';
+
+/**
+ * Internal dependencies
+ */
+import hasWordPressProfile from '../has-wordpress-profile';
+
+describe( 'hasWordPressProfile', () => {
+	it( 'resolves as false for missing profile', async () => {
+		nock( 'https://profiles.wordpress.org' )
+			.intercept( '/wp-json/wporg-github/v1/lookup/ghost', 'HEAD' )
+			.reply( 404 );
+
+		const result = await hasWordPressProfile( 'ghost' );
+
+		expect( result ).toBe( false );
+	} );
+
+	it( 'resolves as true for known profile', async () => {
+		nock( 'https://profiles.wordpress.org' )
+			.intercept( '/wp-json/wporg-github/v1/lookup/m', 'HEAD' )
+			.reply( 200 );
+
+		const result = await hasWordPressProfile( 'm' );
+
+		expect( result ).toBe( true );
+	} );
+} );

--- a/packages/project-management-automation/package.json
+++ b/packages/project-management-automation/package.json
@@ -21,8 +21,7 @@
 	"dependencies": {
 		"@actions/core": "^1.0.0",
 		"@actions/github": "^1.0.0",
-		"@babel/runtime": "^7.8.3",
-		"got": "^10.7.0"
+		"@babel/runtime": "^7.8.3"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/project-management-automation/package.json
+++ b/packages/project-management-automation/package.json
@@ -21,7 +21,8 @@
 	"dependencies": {
 		"@actions/core": "^1.0.0",
 		"@actions/github": "^1.0.0",
-		"@babel/runtime": "^7.8.3"
+		"@babel/runtime": "^7.8.3",
+		"got": "^10.7.0"
 	},
 	"publishConfig": {
 		"access": "public"


### PR DESCRIPTION
Related:

- #21013
- https://github.com/WordPress/gutenberg/projects/24#card-34839803
- https://meta.trac.wordpress.org/ticket/4447
- https://make.wordpress.org/core/2020/03/19/associating-github-accounts-with-wordpress-org-profiles/

This pull request seeks to fix and enhance the existing "First Time Contributor" project management automation to prompt the user to link their GitHub account to their WordPress.org profile if necessary for release props credit.

Currently, the prompt is:

> Congratulations on your first merged pull request! We'd like to credit you for your contribution in the post announcing the next WordPress release, but we can't find a WordPress.org profile associated with your GitHub account. When you have a moment, visit the following URL and click "link your GitHub account" under "GitHub Username" to link your accounts:
> 
> https://profiles.wordpress.org/me/profile/edit/
> 
> And if you don't have a WordPress.org account, you can create one on this page:
> 
> https://login.wordpress.org/register
>
> Kudos!

<details><summary>(Click to expand for initial prompt proposed)</summary>
>Congratulations on your first merged pull request! We would like to give you credit for your contribution in the next WordPress release, but we were unable to find a WordPress.org profile associated with your GitHub account. At your convenience, please visit the following URL and click "link your GitHub account" under "GitHub Username" to initiate the process to link your accounts:
>
>https://profiles.wordpress.org/me/profile/edit/
>
>If you do not have a WordPress.org account, you can create one at the following page:
>
>https://login.wordpress.org/register
</details>

~Feedback is very welcome for adjustments to the phrasing (I've also applied "Needs Copy Review" label to this pull request).~ Reviewed at https://github.com/WordPress/gutenberg/pull/21221#issuecomment-605945989.

The prompt is presented under the following conditions:

- This is the first commit merged for the user.
- A WordPress.org user profile is not known to be associated with their GitHub account.

As noted, this also _fixes_ the "First Time Contributor" task, which was intended to be applying [the "First Time Contributor" label](https://github.com/WordPress/gutenberg/issues?q=is%3Aopen+is%3Aissue+label%3A%22First-time+Contributor%22) to a pull request opened by a new contributor. Unfortunately, due to [permission constraints](https://help.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token#permissions-for-the-github_token) of GitHub Actions, labels cannot be applied by actions if the originating repository is a fork of Gutenberg. Since the vast majority of new contributors will not have branching permissions of this repository, this made the task near-useless. This is resolved by adopting a similar approach of #20058 : The task is run on _commit to master_, where full permissions are granted. This means that the label is only applied after merge, which is not perfect, but certainly an improvement. Coincidentally, this complements the goal of prompting the user to link their accounts upon merge.

**Testing Instructions:**

There are unit tests:

```
npm run test-unit packages/project-management-automation/lib/test/add-first-time-contributor-label.js
```

But the most accurate test won't be 'til we can have it running live 😅 