### PR TITLE
i18n: Enable noImplicitAny type checking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9886,31 +9886,31 @@
 			}
 		},
 		"@tannin/compile": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@tannin/compile/-/compile-1.0.3.tgz",
-			"integrity": "sha512-OkPHvaM/hIHdSco3+ZO1hzkOtfEddn5a0veWft2aDLvKnbdj9VusiLKNdEE9by3hCZIIcb9aWF+iBorhfrQOfw==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@tannin/compile/-/compile-1.1.0.tgz",
+			"integrity": "sha512-n8m9eNDfoNZoxdvWiTfW/hSPhehzLJ3zW7f8E7oT6mCROoMNWCB4TYtv041+2FMAxweiE0j7i1jubQU4MEC/Gg==",
 			"requires": {
-				"@tannin/evaluate": "^1.1.1",
-				"@tannin/postfix": "^1.0.2"
+				"@tannin/evaluate": "^1.2.0",
+				"@tannin/postfix": "^1.1.0"
 			}
 		},
 		"@tannin/evaluate": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@tannin/evaluate/-/evaluate-1.1.1.tgz",
-			"integrity": "sha512-ALuSZHjrLHGnw0WxsHDHde74FJ2WW0Ck4rg3QBxFBCmxd6Wsac+e0HXfJ++Qion15LIOCmFhyVpWzawMgeBA8Q=="
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@tannin/evaluate/-/evaluate-1.2.0.tgz",
+			"integrity": "sha512-3ioXvNowbO/wSrxsDG5DKIMxC81P0QrQTYai8zFNY+umuoHWRPbQ/TuuDEOju9E+jQDXmj6yI5GyejNuh8I+eg=="
 		},
 		"@tannin/plural-forms": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@tannin/plural-forms/-/plural-forms-1.0.3.tgz",
-			"integrity": "sha512-IUr9+FiCnzCiB9aRio3FVNR8TNL9SmX2zkV6tmfWWwSclX4uTCykoGsDhTGKK+sZnMrdPCTmb/OxbtGNdVyV4g==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@tannin/plural-forms/-/plural-forms-1.1.0.tgz",
+			"integrity": "sha512-xl9R2mDZO/qiHam1AgMnAES6IKIg7OBhcXqy6eDsRCdXuxAFPcjrej9HMjyCLE0DJ/8cHf0i5OQTstuBRhpbHw==",
 			"requires": {
-				"@tannin/compile": "^1.0.3"
+				"@tannin/compile": "^1.1.0"
 			}
 		},
 		"@tannin/postfix": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@tannin/postfix/-/postfix-1.0.2.tgz",
-			"integrity": "sha512-Nggtk7/ljfNPpAX8CjxxLkMKuO6u2gH1ozmTvGclWF2pNcxTf6YGghYNYNWZRKrimXGhQ8yZqvAHep7h80K04g=="
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@tannin/postfix/-/postfix-1.1.0.tgz",
+			"integrity": "sha512-oocsqY7g0cR+Gur5jRQLSrX2OtpMLMse1I10JQBm8CdGMrDkh1Mg2gjsiquMHRtBs4Qwu5wgEp5GgIYHk4SNPw=="
 		},
 		"@types/babel-types": {
 			"version": "7.0.7",
@@ -38808,11 +38808,11 @@
 			}
 		},
 		"tannin": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/tannin/-/tannin-1.1.0.tgz",
-			"integrity": "sha512-LxhcXqpMHEOVeVKmuG5aCPPsTXFlO373vrWkqN7FSJBVLS6lFOAg8ZGzIyGhrOf7Ho3xB4jdGedY1gi/8J1FCA==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/tannin/-/tannin-1.2.0.tgz",
+			"integrity": "sha512-U7GgX/RcSeUETbV7gYgoz8PD7Ni4y95pgIP/Z6ayI3CfhSujwKEBlGFTCRN+Aqnuyf4AN2yHL+L8x+TCGjb9uA==",
 			"requires": {
-				"@tannin/plural-forms": "^1.0.3"
+				"@tannin/plural-forms": "^1.1.0"
 			}
 		},
 		"tapable": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10536,7 +10536,7 @@
 				"dom-scroll-into-view": "^1.2.1",
 				"inherits": "^2.0.3",
 				"lodash": "^4.17.15",
-				"memize": "^1.0.5",
+				"memize": "^1.1.0",
 				"react-autosize-textarea": "^3.0.2",
 				"react-spring": "^8.0.19",
 				"redux-multi": "^0.1.12",
@@ -10578,7 +10578,7 @@
 				"classnames": "^2.2.5",
 				"fast-average-color": "4.3.0",
 				"lodash": "^4.17.15",
-				"memize": "^1.0.5",
+				"memize": "^1.1.0",
 				"moment": "^2.22.1",
 				"tinycolor2": "^1.4.1"
 			}
@@ -10653,7 +10653,7 @@
 				"downshift": "^4.0.5",
 				"gradient-parser": "^0.1.5",
 				"lodash": "^4.17.15",
-				"memize": "^1.0.5",
+				"memize": "^1.1.0",
 				"moment": "^2.22.1",
 				"re-resizable": "^6.0.0",
 				"react-dates": "^17.1.1",
@@ -10842,7 +10842,7 @@
 				"equivalent-key-map": "^0.2.2",
 				"is-promise": "^2.1.0",
 				"lodash": "^4.17.15",
-				"memize": "^1.0.5",
+				"memize": "^1.1.0",
 				"redux": "^4.0.0",
 				"turbo-combine-reducers": "^1.0.2",
 				"use-memo-one": "^1.1.1"
@@ -10959,7 +10959,7 @@
 				"@wordpress/viewport": "file:packages/viewport",
 				"classnames": "^2.2.5",
 				"lodash": "^4.17.15",
-				"memize": "^1.0.5",
+				"memize": "^1.1.0",
 				"refx": "^3.0.0",
 				"rememo": "^3.0.0"
 			}
@@ -11043,7 +11043,7 @@
 				"@wordpress/wordcount": "file:packages/wordcount",
 				"classnames": "^2.2.5",
 				"lodash": "^4.17.15",
-				"memize": "^1.0.5",
+				"memize": "^1.1.0",
 				"react-autosize-textarea": "^3.0.2",
 				"redux-optimist": "^1.0.0",
 				"refx": "^3.0.0",
@@ -11367,7 +11367,7 @@
 				"@babel/runtime": "^7.8.3",
 				"gettext-parser": "^1.3.1",
 				"lodash": "^4.17.15",
-				"memize": "^1.0.5",
+				"memize": "^1.1.0",
 				"sprintf-js": "^1.1.1",
 				"tannin": "^1.2.0"
 			}
@@ -11554,7 +11554,7 @@
 				"@wordpress/keycodes": "file:packages/keycodes",
 				"classnames": "^2.2.5",
 				"lodash": "^4.17.15",
-				"memize": "^1.0.5",
+				"memize": "^1.1.0",
 				"rememo": "^3.0.0"
 			}
 		},
@@ -11623,7 +11623,7 @@
 			"requires": {
 				"@babel/runtime": "^7.8.3",
 				"lodash": "^4.17.15",
-				"memize": "^1.0.5"
+				"memize": "^1.1.0"
 			}
 		},
 		"@wordpress/token-list": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -28250,9 +28250,9 @@
 			}
 		},
 		"memize": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/memize/-/memize-1.0.5.tgz",
-			"integrity": "sha512-Dm8Jhb5kiC4+ynYsVR4QDXKt+o2dfqGuY4hE2x+XlXZkdndlT80bJxfcMv5QGp/FCy6MhG7f5ElpmKPFKOSEpg=="
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/memize/-/memize-1.1.0.tgz",
+			"integrity": "sha512-K4FcPETOMTwe7KL2LK0orMhpOmWD2wRGwWWpbZy0fyArwsyIKR8YJVz8+efBAh3BO4zPqlSICu4vsLTRRqtFAg=="
 		},
 		"memoize-one": {
 			"version": "5.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11369,7 +11369,7 @@
 				"lodash": "^4.17.15",
 				"memize": "^1.0.5",
 				"sprintf-js": "^1.1.1",
-				"tannin": "^1.1.0"
+				"tannin": "^1.2.0"
 			}
 		},
 		"@wordpress/icons": {

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -50,7 +50,7 @@
 		"dom-scroll-into-view": "^1.2.1",
 		"inherits": "^2.0.3",
 		"lodash": "^4.17.15",
-		"memize": "^1.0.5",
+		"memize": "^1.1.0",
 		"react-autosize-textarea": "^3.0.2",
 		"react-spring": "^8.0.19",
 		"redux-multi": "^0.1.12",

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -53,7 +53,7 @@
 		"classnames": "^2.2.5",
 		"fast-average-color": "4.3.0",
 		"lodash": "^4.17.15",
-		"memize": "^1.0.5",
+		"memize": "^1.1.0",
 		"moment": "^2.22.1",
 		"tinycolor2": "^1.4.1"
 	},

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -48,7 +48,7 @@
 		"downshift": "^4.0.5",
 		"gradient-parser": "^0.1.5",
 		"lodash": "^4.17.15",
-		"memize": "^1.0.5",
+		"memize": "^1.1.0",
 		"moment": "^2.22.1",
 		"re-resizable": "^6.0.0",
 		"react-dates": "^17.1.1",

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -32,7 +32,7 @@
 		"equivalent-key-map": "^0.2.2",
 		"is-promise": "^2.1.0",
 		"lodash": "^4.17.15",
-		"memize": "^1.0.5",
+		"memize": "^1.1.0",
 		"redux": "^4.0.0",
 		"turbo-combine-reducers": "^1.0.2",
 		"use-memo-one": "^1.1.1"

--- a/packages/edit-post/package.json
+++ b/packages/edit-post/package.json
@@ -46,7 +46,7 @@
 		"@wordpress/viewport": "file:../viewport",
 		"classnames": "^2.2.5",
 		"lodash": "^4.17.15",
-		"memize": "^1.0.5",
+		"memize": "^1.1.0",
 		"refx": "^3.0.0",
 		"rememo": "^3.0.0"
 	},

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -52,7 +52,7 @@
 		"@wordpress/wordcount": "file:../wordcount",
 		"classnames": "^2.2.5",
 		"lodash": "^4.17.15",
-		"memize": "^1.0.5",
+		"memize": "^1.1.0",
 		"react-autosize-textarea": "^3.0.2",
 		"redux-optimist": "^1.0.0",
 		"refx": "^3.0.0",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -30,7 +30,7 @@
 		"lodash": "^4.17.15",
 		"memize": "^1.0.5",
 		"sprintf-js": "^1.1.1",
-		"tannin": "^1.1.0"
+		"tannin": "^1.2.0"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -28,7 +28,7 @@
 		"@babel/runtime": "^7.8.3",
 		"gettext-parser": "^1.3.1",
 		"lodash": "^4.17.15",
-		"memize": "^1.0.5",
+		"memize": "^1.1.0",
 		"sprintf-js": "^1.1.1",
 		"tannin": "^1.1.0"
 	},

--- a/packages/i18n/tsconfig.json
+++ b/packages/i18n/tsconfig.json
@@ -1,7 +1,6 @@
 {
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
-		"noImplicitAny": false,
 		"rootDir": "src",
 		"declarationDir": "build-types"
 	},

--- a/packages/rich-text/package.json
+++ b/packages/rich-text/package.json
@@ -31,7 +31,7 @@
 		"@wordpress/keycodes": "file:../keycodes",
 		"classnames": "^2.2.5",
 		"lodash": "^4.17.15",
-		"memize": "^1.0.5",
+		"memize": "^1.1.0",
 		"rememo": "^3.0.0"
 	},
 	"publishConfig": {

--- a/packages/shortcode/package.json
+++ b/packages/shortcode/package.json
@@ -23,7 +23,7 @@
 	"dependencies": {
 		"@babel/runtime": "^7.8.3",
 		"lodash": "^4.17.15",
-		"memize": "^1.0.5"
+		"memize": "^1.1.0"
 	},
 	"publishConfig": {
 		"access": "public"


### PR DESCRIPTION
## Description

With type declarations for `memize` and `tannin`, `i18n` can enable `noImplicitAny` TypeScript compiler option.

Required (merged here):
- closes #21223 - upgrade `memize`
- closes #21222 - upgrade `tannin`

## How has this been tested?

Package types build successfully:

```sh
npm run build:package-types
```

## Types of changes

Internal.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
