### PR TITLE
Fix YouTube Embed block from flickering and crashing in Safari

### DIFF
--- a/packages/components/src/sandbox/index.js
+++ b/packages/components/src/sandbox/index.js
@@ -34,7 +34,7 @@ class Sandbox extends Component {
 	}
 
 	componentDidUpdate( prevProps ) {
-		const forceRerender = ! isHTMLEqual( prevProps.html, this.props.html );
+		const forceRerender = prevProps.html !== this.props.html;
 
 		this.trySandbox( forceRerender );
 	}
@@ -258,29 +258,6 @@ class Sandbox extends Component {
 			/>
 		);
 	}
-}
-
-/**
- * A simple (and perhaps naive) way to compare if two html strings are equal.
- *
- * @param {string} prevHtml The previous HTML string.
- * @param {string} nextHtml The next HTML string.
- * @return {boolean} Whether the HTML strings are equal
- */
-function isHTMLEqual( prevHtml, nextHtml ) {
-	/**
-	 * Convert \" quotes to ". This is due to how React and Safari handle
-	 * storing the incoming props.html value.
-	 *
-	 * Additional details for this can be found here:
-	 * https://github.com/WordPress/gutenberg/issues/20614#issuecomment-605347414
-	 */
-	const escapeQuoteRegex = new RegExp( /\\"/, 'g' );
-
-	return (
-		prevHtml.replace( escapeQuoteRegex, '"' ) ===
-		nextHtml.replace( escapeQuoteRegex, '"' )
-	);
 }
 
 Sandbox = withGlobalEvents( {

--- a/packages/components/src/sandbox/index.js
+++ b/packages/components/src/sandbox/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { isBoolean } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { Component, renderToString, createRef } from '@wordpress/element';
@@ -81,23 +76,10 @@ class Sandbox extends Component {
 			return;
 		}
 
-		/**
-		 * This method is called in the FocusableIframe onLoad callback.
-		 * As such, the incoming argument is NOT a boolean, but rather, a
-		 * (synthetic) event.
-		 *
-		 * We only need to do this check if we're purposefully doing
-		 * a forceRerender. This happens in the componentDidUpdate
-		 * lifecycle hook.
-		 *
-		 * Doing this extra step prevents the iFrame from recursively
-		 * re-rendering itself.
-		 */
-		const shouldRerender = isBoolean( forceRerender ) && forceRerender;
 		const body = this.iframe.current.contentDocument.body;
 
 		if (
-			! shouldRerender &&
+			! forceRerender &&
 			null !== body.getAttribute( 'data-resizable-iframe-connected' )
 		) {
 			return;
@@ -251,7 +233,7 @@ class Sandbox extends Component {
 				title={ title }
 				className="components-sandbox"
 				sandbox="allow-scripts allow-same-origin allow-presentation"
-				onLoad={ this.trySandbox }
+				onLoad={ () => this.trySandbox() }
 				onFocus={ onFocus }
 				width={ Math.ceil( this.state.width ) }
 				height={ Math.ceil( this.state.height ) }

--- a/packages/components/src/sandbox/index.js
+++ b/packages/components/src/sandbox/index.js
@@ -233,7 +233,7 @@ class Sandbox extends Component {
 				title={ title }
 				className="components-sandbox"
 				sandbox="allow-scripts allow-same-origin allow-presentation"
-				onLoad={ () => this.trySandbox() }
+				onLoad={ () => this.trySandbox( false ) }
 				onFocus={ onFocus }
 				width={ Math.ceil( this.state.width ) }
 				height={ Math.ceil( this.state.height ) }


### PR DESCRIPTION
## Description

This update fixes the issue where a YouTube video embed in Safari would flicker (and crash).

This issue is due to the inner `Sandbox` component forcefully re-rendering itself in an loop. This is why there's flickering. This is also why your computer fans may be spinning up (due to requests and stack overflow + memory leaks).

Digging deeper, it appears it has to do with the `onLoad` callback from the `iFrame` component.
The `onLoad` callback provided an `event` argument, which triggered a force rerender... resulting in a render loop.


## How has this been tested?

Tested in local Gutenberg with a YouTube video embed. Both in Chrome and in Safari.

## Types of changes

* Add an additional guard for `forceRerender` checking to ensure it does not get accidentally triggered by the `onLoad` callback.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->

Resolves: https://github.com/WordPress/gutenberg/issues/20614