### PR TITLE
Components: Add test on SlotFill

### DIFF
--- a/packages/components/src/slot-fill/bubbles-virtually/slot-fill-provider.js
+++ b/packages/components/src/slot-fill/bubbles-virtually/slot-fill-provider.js
@@ -25,11 +25,10 @@ function useSlotRegistry() {
 
 	const unregisterSlot = useCallback( ( name, ref ) => {
 		setSlots( ( prevSlots ) => {
-			// eslint-disable-next-line no-unused-vars
 			const { [ name ]: slot, ...nextSlots } = prevSlots;
 			// Make sure we're not unregistering a slot registered by another element
 			// See https://github.com/WordPress/gutenberg/pull/19242#issuecomment-590295412
-			if ( slot?.ref === ref ) {
+			if ( slot.ref === ref ) {
 				return nextSlots;
 			}
 			return prevSlots;

--- a/packages/components/src/slot-fill/bubbles-virtually/slot-fill-provider.js
+++ b/packages/components/src/slot-fill/bubbles-virtually/slot-fill-provider.js
@@ -28,7 +28,7 @@ function useSlotRegistry() {
 			const { [ name ]: slot, ...nextSlots } = prevSlots;
 			// Make sure we're not unregistering a slot registered by another element
 			// See https://github.com/WordPress/gutenberg/pull/19242#issuecomment-590295412
-			if ( slot.ref === ref ) {
+			if ( slot?.ref === ref ) {
 				return nextSlots;
 			}
 			return prevSlots;

--- a/packages/components/src/slot-fill/test/__snapshots__/slot.js.snap
+++ b/packages/components/src/slot-fill/test/__snapshots__/slot.js.snap
@@ -26,6 +26,8 @@ Array [
 ]
 `;
 
+exports[`Slot bubblesVirtually false should unmount two slots with the same name 1`] = `"<div data-position=\\"first\\"></div><div data-position=\\"second\\"></div>"`;
+
 exports[`Slot bubblesVirtually true should subsume another slot by the same name 1`] = `
 Array [
   <div
@@ -53,6 +55,8 @@ Array [
   </div>,
 ]
 `;
+
+exports[`Slot bubblesVirtually true should unmount two slots with the same name 1`] = `"<div data-position=\\"first\\"></div><div data-position=\\"second\\"></div>"`;
 
 exports[`Slot should re-render Slot when not bubbling virtually 1`] = `
 Array [

--- a/packages/components/src/slot-fill/test/slot.js
+++ b/packages/components/src/slot-fill/test/slot.js
@@ -3,6 +3,8 @@
  */
 import { isEmpty } from 'lodash';
 import ReactTestRenderer from 'react-test-renderer';
+import { render, unmountComponentAtNode } from 'react-dom';
+import { act } from 'react-dom/test-utils';
 
 /**
  * Internal dependencies
@@ -35,6 +37,20 @@ class Filler extends Component {
 		];
 	}
 }
+
+let container = null;
+beforeEach( () => {
+	// setup a DOM element as a render target
+	container = document.createElement( 'div' );
+	document.body.appendChild( container );
+} );
+
+afterEach( () => {
+	// cleanup on exiting
+	unmountComponentAtNode( container );
+	container.remove();
+	container = null;
+} );
 
 describe( 'Slot', () => {
 	it( 'should render empty Fills', () => {
@@ -259,6 +275,55 @@ describe( 'Slot', () => {
 				);
 
 				expect( testRenderer.toJSON() ).toMatchSnapshot();
+			} );
+
+			it( 'should unmount two slots with the same name', () => {
+				act( () => {
+					render(
+						<Provider>
+							<div data-position="first">
+								<Slot
+									name="egg"
+									bubblesVirtually={ bubblesVirtually }
+								/>
+							</div>
+							<div data-position="second">
+								<Slot
+									name="egg"
+									bubblesVirtually={ bubblesVirtually }
+								/>
+							</div>
+							<Fill name="egg">Content</Fill>
+						</Provider>,
+						container
+					);
+				} );
+				act( () => {
+					render(
+						<Provider>
+							<div data-position="first">
+								<Slot
+									name="egg"
+									bubblesVirtually={ bubblesVirtually }
+								/>
+							</div>
+							<div data-position="second" />
+							<Fill name="egg">Content</Fill>
+						</Provider>,
+						container
+					);
+				} );
+				act( () => {
+					render(
+						<Provider>
+							<div data-position="first" />
+							<div data-position="second" />
+							<Fill name="egg">Content</Fill>
+						</Provider>,
+						container
+					);
+				} );
+				expect( container.innerHTML ).toMatchSnapshot();
 			} );
 		}
 	);


### PR DESCRIPTION
## Description

This PR is a follow-up of #21205. It adds a test to confirm that removing a Slot that has been already removed doesn't throw an error.

I had to use `react-dom` and `react-dom/test-utils` because `react-test-renderer` doesn't support React Portal (related: #20428).

## How has this been tested?

`npm run test-unit`

The first commit in this PR shows the failing case.
https://travis-ci.com/github/WordPress/gutenberg/jobs/306589748#L4704