### PR TITLE
Fix cell align when isSelected is used.

### DIFF
--- a/packages/components/src/mobile/bottom-sheet/cell.native.js
+++ b/packages/components/src/mobile/bottom-sheet/cell.native.js
@@ -130,7 +130,7 @@ class BottomSheetCell extends Component {
 			? cellLabelLeftAlignNoIconStyle
 			: cellLabelCenteredStyle;
 		const defaultLabelStyle =
-			showValue || customActionButton
+			showValue || customActionButton || icon
 				? cellLabelStyle
 				: defaultMissingIconAndValue;
 
@@ -319,12 +319,6 @@ class BottomSheetCell extends Component {
 							<Text style={ [ defaultLabelStyle, labelStyle ] }>
 								{ label }
 							</Text>
-							{ isSelected && (
-								<Icon
-									icon={ check }
-									fill={ platformStyles.isSelected.color }
-								/>
-							) }
 						</View>
 						{ customActionButton && (
 							<TouchableOpacity
@@ -337,6 +331,12 @@ class BottomSheetCell extends Component {
 							</TouchableOpacity>
 						) }
 					</View>
+					{ isSelected && (
+						<Icon
+							icon={ check }
+							fill={ platformStyles.isSelected.color }
+						/>
+					) }
 					{ showValue && getValueComponent() }
 					{ children }
 				</View>

--- a/packages/components/src/mobile/bottom-sheet/styles.native.scss
+++ b/packages/components/src/mobile/bottom-sheet/styles.native.scss
@@ -93,6 +93,7 @@
 	flex-direction: row;
 	min-height: 48;
 	align-items: center;
+	justify-content: space-between;
 }
 
 .clipToBounds {


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
Fix the align of items on BottomSheet in the multiple scenarios where they are used.

This previous PR made some modifications to alignment/style options in `cell.native` that broke the bottom sheet used on image picking options.

This PR updates the cell container style to spread items around instead of centring then.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

This can be tested using this GB mobile PR: 

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
