### PR TITLE
Add block selection performance test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10926,7 +10926,7 @@
 				"@wordpress/jest-puppeteer-axe": "file:packages/jest-puppeteer-axe",
 				"@wordpress/scripts": "file:packages/scripts",
 				"@wordpress/url": "file:packages/url",
-				"chalk": "2.4.2",
+				"chalk": "^2.4.2",
 				"expect-puppeteer": "^4.3.0",
 				"lodash": "^4.17.15",
 				"uuid": "^3.3.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10926,6 +10926,7 @@
 				"@wordpress/jest-puppeteer-axe": "file:packages/jest-puppeteer-axe",
 				"@wordpress/scripts": "file:packages/scripts",
 				"@wordpress/url": "file:packages/url",
+				"chalk": "2.4.2",
 				"expect-puppeteer": "^4.3.0",
 				"lodash": "^4.17.15",
 				"uuid": "^3.3.2"

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
 		"babel-plugin-require-context-hook": "1.0.0",
 		"benchmark": "2.1.4",
 		"browserslist": "4.9.1",
-		"chalk": "2.4.2",
+		"chalk": "^2.4.2",
 		"commander": "4.1.0",
 		"concurrently": "3.5.0",
 		"copy-webpack-plugin": "4.5.2",

--- a/packages/e2e-tests/config/performance-reporter.js
+++ b/packages/e2e-tests/config/performance-reporter.js
@@ -1,4 +1,5 @@
 const { readFileSync, existsSync } = require( 'fs' );
+const chalk = require( 'chalk' );
 
 function average( array ) {
 	return array.reduce( ( a, b ) => a + b ) / array.length;
@@ -9,6 +10,9 @@ function round( number, decimalPlaces = 2 ) {
 	return Math.round( number * factor ) / factor;
 }
 
+const title = chalk.bold;
+const success = chalk.bold.green;
+
 class PerformanceReporter {
 	onRunComplete() {
 		const path = __dirname + '/../specs/performance/results.json';
@@ -18,16 +22,46 @@ class PerformanceReporter {
 		}
 
 		const results = readFileSync( path, 'utf8' );
-		const { load, domcontentloaded, type } = JSON.parse( results );
+		const { load, domcontentloaded, type, focus } = JSON.parse( results );
+
+		if ( load && load.length ) {
+			// eslint-disable-next-line no-console
+			console.log( `
+${ title( 'Loading Time:' ) }
+Average time to load: ${ success( round( average( load ) ) + 'ms' ) }
+Average time to DOM content load: ${ success(
+				round( average( domcontentloaded ) ) + 'ms'
+			) }` );
+		}
+
+		if ( type && type.length ) {
+			// eslint-disable-next-line no-console
+			console.log( `
+${ title( 'Typing Performance:' ) }
+Average time to type character: ${ success( round( average( type ) ) + 'ms' ) }
+Slowest time to type character: ${ success(
+				round( Math.max( ...type ) ) + 'ms'
+			) }
+Fastest time to type character: ${ success(
+				round( Math.min( ...type ) ) + 'ms'
+			) }` );
+		}
+
+		if ( focus && focus.length ) {
+			// eslint-disable-next-line no-console
+			console.log( `
+${ title( 'Block Selection Performance:' ) }
+Average time to select a block: ${ success( round( average( focus ) ) + 'ms' ) }
+Slowest time to select a block: ${ success(
+				round( Math.max( ...focus ) ) + 'ms'
+			) }
+Fastest time to select a block: ${ success(
+				round( Math.min( ...focus ) ) + 'ms'
+			) }` );
+		}
 
 		// eslint-disable-next-line no-console
-		console.log( `
-Average time to load: ${ round( average( load ) ) }ms
-Average time to DOM content load: ${ round( average( domcontentloaded ) ) }ms
-Average time to type character: ${ round( average( type ) ) }ms
-Slowest time to type character: ${ round( Math.max( ...type ) ) }ms
-Fastest time to type character: ${ round( Math.min( ...type ) ) }ms
-		` );
+		console.log( '' );
 	}
 }
 

--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -27,7 +27,7 @@
 		"@wordpress/jest-puppeteer-axe": "file:../jest-puppeteer-axe",
 		"@wordpress/scripts": "file:../scripts",
 		"@wordpress/url": "file:../url",
-		"chalk": "2.4.2",
+		"chalk": "^2.4.2",
 		"expect-puppeteer": "^4.3.0",
 		"lodash": "^4.17.15",
 		"uuid": "^3.3.2"

--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -27,6 +27,7 @@
 		"@wordpress/jest-puppeteer-axe": "file:../jest-puppeteer-axe",
 		"@wordpress/scripts": "file:../scripts",
 		"@wordpress/url": "file:../url",
+		"chalk": "2.4.2",
 		"expect-puppeteer": "^4.3.0",
 		"lodash": "^4.17.15",
 		"uuid": "^3.3.2"


### PR DESCRIPTION
I’ve been playing a bit with performance work today and one of the interactions that take time and that we don’t monitor or address properly is “block selection”.  On long posts, each time the selected block changes (click, insertion, removal), you notice lags. With this PR, I'm adding some metrics to the performance tests so we can start monitoring this interaction.

<img width="320" alt="Capture d’écran 2020-03-28 à 11 36 56 AM" src="https://user-images.githubusercontent.com/272444/77821185-72dc8680-70e8-11ea-8d15-154e1398ede2.png">
