### PR TITLE
Avoid recomputing the scrollble container on selection change

### DIFF
--- a/packages/block-editor/src/components/block-list/moving-animation.js
+++ b/packages/block-editor/src/components/block-list/moving-animation.js
@@ -69,12 +69,10 @@ function useMovingAnimation(
 	} );
 
 	const previous = ref.current ? getAbsolutePosition( ref.current ) : null;
-	const scrollContainer = useMemo( () => {
-		if ( ! adjustScrolling ) {
-			return false;
-		}
-		return getScrollContainer( ref.current );
-	}, [ adjustScrolling ] );
+	const scrollContainer = useMemo(
+		() => getScrollContainer( ref.current ),
+		[]
+	);
 
 	useLayoutEffect( () => {
 		if ( triggeredAnimation ) {


### PR DESCRIPTION
Related #21230 

There's no need to recompute the scrollable container each time the block gets selected (this can be costfull).

