### PR TITLE
Fix sibling inserter being unclickable.

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -315,7 +315,7 @@
 	cursor: grab;
 }
 
-// Insertion point (includes inbetween inserter and insertion indicator)
+// Insertion point (includes inbetween/sibling inserter and insertion indicator)
 .block-editor-block-list__insertion-point {
 	position: relative;
 	z-index: z-index(".block-editor-block-list__insertion-point");
@@ -390,27 +390,18 @@
 		animation: block-editor-inserter__toggle__fade-in-animation-delayed 1.2s ease;
 		animation-fill-mode: forwards;
 		@include reduce-motion("animation");
-
-		&:hover {
-			animation: block-editor-inserter__toggle__fade-in-animation 0.1s ease;
-			animation-fill-mode: forwards;
-			@include reduce-motion("animation");
-		}
 	}
 }
 
 @keyframes block-editor-inserter__toggle__fade-in-animation-delayed {
 	0% {
 		opacity: 0;
-		transform: scale(0);
 	}
 	80% {
 		opacity: 0;
-		transform: scale(0);
 	}
 	100% {
 		opacity: 1;
-		transform: scale(1);
 	}
 }
 


### PR DESCRIPTION
The Sibling Inserter — the plus that appears when you hover between two blocks for a second — is broken in master. When you hover the button in the center, it disappears and becomes unclickable.

This behavior regressed here: https://github.com/WordPress/gutenberg/pull/21142/files#diff-ee2ed3adbe2578628039530c717a9a93R443 — where I had added a rule to scale it down. Sorry about that. 

This PR fixes it:

![sibling](https://user-images.githubusercontent.com/1204802/77823681-38311900-70fd-11ea-8cb1-a4c58bd7f38d.gif)

To test:

- Verify that the sibling inserter works
- Verify all inserters that are in-canvas haven't regressed.
- Verify that the inserter that appears after an image block inside a columns or group block, still work.