### PR TITLE
Insert post title instead of URL, when adding a link to an existing post

### DIFF
--- a/packages/e2e-tests/specs/editor/various/links.test.js
+++ b/packages/e2e-tests/specs/editor/various/links.test.js
@@ -54,12 +54,12 @@ describe( 'Links', () => {
 
 		await page.keyboard.press( 'Enter' );
 
-		const actualTitleText = await page.evaluate(
+		const actualText = await page.evaluate(
 			() =>
 				document.querySelector( '.block-editor-rich-text__editable a' )
 					.textContent
 		);
-		expect( actualTitleText ).toBe( titleText );
+		expect( actualText ).toBe( titleText );
 	} );
 
 	it( 'can be created by selecting text and clicking Link', async () => {

--- a/packages/e2e-tests/specs/editor/various/links.test.js
+++ b/packages/e2e-tests/specs/editor/various/links.test.js
@@ -26,6 +26,42 @@ describe( 'Links', () => {
 		);
 	};
 
+	it( 'will use Post title as link text if link to existing post is created without any text selected', async () => {
+		const titleText = 'Post to create a link to';
+		await createPostWithTitle( titleText );
+
+		await createNewPost();
+		await clickBlockAppender();
+
+		// Now in a new post and try to create a link from an autocomplete suggestion using the keyboard.
+		await page.keyboard.type( 'Here comes a link: ' );
+
+		// Press Cmd+K to insert a link
+		await pressKeyWithModifier( 'primary', 'K' );
+
+		// Wait for the URL field to auto-focus
+		await waitForAutoFocus();
+		expect(
+			await page.$(
+				'.components-popover__content .block-editor-link-control'
+			)
+		).not.toBeNull();
+
+		// Trigger the autocomplete suggestion list and select the first suggestion.
+		await page.keyboard.type( titleText.substr( 0, titleText.length - 2 ) );
+		await page.waitForSelector( '.block-editor-link-control__search-item' );
+		await page.keyboard.press( 'ArrowDown' );
+
+		await page.keyboard.press( 'Enter' );
+
+		const actualTitleText = await page.evaluate(
+			() =>
+				document.querySelector( '.block-editor-rich-text__editable a' )
+					.textContent
+		);
+		expect( actualTitleText ).toBe( titleText );
+	} );
+
 	it( 'can be created by selecting text and clicking Link', async () => {
 		// Create a block with some text
 		await clickBlockAppender();

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -119,16 +119,12 @@ function InlineLinkUI( {
 		} );
 
 		if ( isCollapsed( value ) && ! isActive ) {
-			const newText =
-				nextValue.hasOwnProperty( 'title' ) && nextValue.title !== ''
-					? nextValue.title
-					: newUrl;
-
+			const newText = nextValue.title || newUrl;
 			const toInsert = applyFormat(
 				create( { text: newText } ),
 				format,
 				0,
-				newUrl.length
+				newText.length
 			);
 			onChange( insert( value, toInsert ) );
 		} else {

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -119,8 +119,13 @@ function InlineLinkUI( {
 		} );
 
 		if ( isCollapsed( value ) && ! isActive ) {
+			const newText =
+				nextValue.hasOwnProperty( 'title' ) && nextValue.title !== ''
+					? nextValue.title
+					: newUrl;
+
 			const toInsert = applyFormat(
-				create( { text: newUrl } ),
+				create( { text: newText } ),
 				format,
 				0,
 				newUrl.length


### PR DESCRIPTION
Fixes #11930
Make the link anchor also retrieve the title of the post/page

## Description
- New behavior: If you insert a new link to an existing post via the inline-link modal, the post title is automatically inserted as link text.
- Previous behavior: If you insert a new link to an existing post via the inline-link modal, the actual URL is inserted as the link text.

## How has this been tested?
Tested on local development server. Tested the following cases:
- [x] insert new link with modal --> start typing --> select post from list. Result: Post title is inserted as link text
- [x] select some text --> insert link with modal --> link remains unchanged
- [x] insert new link with modal --> insert a link to an extarnal page --> The actual URL is inserted as link text

## Screenshots
![Fix for issue 11930](https://bdwm.be/wp-content/uploads/2020/03/11930.gif)

## Types of changes
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. (I think the code is obvious by itself) <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
