### PR TITLE
Add truncation for image URLs

### DIFF
--- a/packages/url/src/filter-url-for-display.js
+++ b/packages/url/src/filter-url-for-display.js
@@ -19,5 +19,14 @@ export function filterURLForDisplay( url ) {
 		return filteredURL.replace( '/', '' );
 	}
 
+	// Prettify image urls
+	const mediaRegexp = /([\w|:])*\.(?:jpg|jpeg|gif|png|svg)/g;
+	if ( filteredURL.match( mediaRegexp ) ) {
+		const tokens = filteredURL.split( '/' );
+		const prettifiedImageURL =
+			tokens[ 0 ] + '...' + tokens[ tokens.length - 1 ];
+		return prettifiedImageURL;
+	}
+
 	return filteredURL;
 }

--- a/packages/url/src/filter-url-for-display.js
+++ b/packages/url/src/filter-url-for-display.js
@@ -21,10 +21,22 @@ export function filterURLForDisplay( url ) {
 
 	// Prettify image urls
 	const mediaRegexp = /([\w|:])*\.(?:jpg|jpeg|gif|png|svg)/g;
+	const colon = ':';
+	const period = '.';
+	const query = '?';
 	if ( filteredURL.match( mediaRegexp ) ) {
-		const tokens = filteredURL.split( '/' );
-		const prettifiedImageURL =
-			tokens[ 0 ] + '...' + tokens[ tokens.length - 1 ];
+		let tokens = filteredURL.split( '/' );
+		let imageToken = tokens[ tokens.length - 1 ];
+		if ( imageToken.includes( query ) ) {
+			imageToken = imageToken.split( query )[ 0 ];
+		}
+		if ( tokens[ 0 ].includes( colon ) ) {
+			tokens = tokens[ 0 ].split( colon );
+		}
+		if ( tokens[ 0 ].includes( period ) ) {
+			tokens = tokens[ 0 ].split( period );
+		}
+		const prettifiedImageURL = tokens[ 0 ] + '...' + imageToken;
 		return prettifiedImageURL;
 	}
 

--- a/packages/url/src/test/index.test.js
+++ b/packages/url/src/test/index.test.js
@@ -663,16 +663,32 @@ describe( 'filterURLForDisplay', () => {
 		expect( url ).toBe( 'wordpress.org/something' );
 	} );
 	it( 'should truncate image URLs in the middle', () => {
-		const url = filterURLForDisplay(
-			'https://i1.wp.com/example.com/wp-content/uploads/2020/03/prague-landscape.jpg'
-		);
-		expect( url ).toBe( 'i1.wp.com...prague-landscape.jpg' );
+		const url = filterURLForDisplay( 'https://www.example.com/hello.jpg' );
+		expect( url ).toBe( 'example...hello.jpg' );
 	} );
 	it( 'should truncate image URLs hosted on localhost', () => {
 		const url = filterURLForDisplay(
-			'http://localhost:8888/wp-content/uploads/2020/03/cactus-field.jpg'
+			'http://localhost:8888/wp-content/uploads/2020/03/hello.jpg'
 		);
-		expect( url ).toBe( 'localhost:8888...cactus-field.jpg' );
+		expect( url ).toBe( 'localhost...hello.jpg' );
+	} );
+	it( 'should truncate complex image URLs', () => {
+		const url = filterURLForDisplay(
+			'https://gallery.google.co.uk:80/hello.jpg'
+		);
+		expect( url ).toBe( 'gallery...hello.jpg' );
+	} );
+	it( 'should truncate image URLs from CDN', () => {
+		const url = filterURLForDisplay(
+			'https://i1.wp.com/example.com/wp-content/uploads/2020/03/prague.jpg'
+		);
+		expect( url ).toBe( 'i1...prague.jpg' );
+	} );
+	it( 'should truncate query from image URL', () => {
+		const url = filterURLForDisplay(
+			'https://www.example.com/prague.jpg?w=1200&ssl=1'
+		);
+		expect( url ).toBe( 'example...prague.jpg' );
 	} );
 	it( 'should not truncate images URLs with no extension', () => {
 		const url = filterURLForDisplay(

--- a/packages/url/src/test/index.test.js
+++ b/packages/url/src/test/index.test.js
@@ -662,6 +662,26 @@ describe( 'filterURLForDisplay', () => {
 		const url = filterURLForDisplay( 'http://www.wordpress.org/something' );
 		expect( url ).toBe( 'wordpress.org/something' );
 	} );
+	it( 'should truncate image URLs in the middle', () => {
+		const url = filterURLForDisplay(
+			'https://i1.wp.com/example.com/wp-content/uploads/2020/03/prague-landscape.jpg'
+		);
+		expect( url ).toBe( 'i1.wp.com...prague-landscape.jpg' );
+	} );
+	it( 'should truncate image URLs hosted on localhost', () => {
+		const url = filterURLForDisplay(
+			'http://localhost:8888/wp-content/uploads/2020/03/cactus-field.jpg'
+		);
+		expect( url ).toBe( 'localhost:8888...cactus-field.jpg' );
+	} );
+	it( 'should not truncate images URLs with no extension', () => {
+		const url = filterURLForDisplay(
+			'https://images.unsplash.com/photo-123-auto=format&fit=crop&w=1650&q=80'
+		);
+		expect( url ).toBe(
+			'images.unsplash.com/photo-123-auto=format&fit=crop&w=1650&q=80'
+		);
+	} );
 } );
 
 describe( 'cleanForSlug', () => {


### PR DESCRIPTION
## Description
Fixes #21100
Truncate displayed media urls as outlined in [Issue 21100](https://github.com/WordPress/gutenberg/issues/21100)

![image](https://user-images.githubusercontent.com/9280665/77854671-e4512d80-71eb-11ea-8978-0db3f9df8591.png)

## How has this been tested?
- Additional tests were added to the tests for filterURLForDisplay.
- The testing environment is the default one with jest. I ran `npm run test-unit`

## Does this change affect other areas of code?
**If a link links directly to an image, the link displayed will be truncated**

![image](https://user-images.githubusercontent.com/9280665/77854710-1d899d80-71ec-11ea-830a-840d7b3449bd.png)

**Display of non-image links are not affected**

![image](https://user-images.githubusercontent.com/9280665/77854717-2bd7b980-71ec-11ea-92b4-9617af463fe4.png)

## Types of changes
- This change is an update/ enchancement

## Checklist:
- [ x ] My code is tested.
- [ x ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ x ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
