### PR TITLE
Change default to 100 menu items in the REST API.

### DIFF
--- a/lib/class-wp-rest-menu-items-controller.php
+++ b/lib/class-wp-rest-menu-items-controller.php
@@ -974,6 +974,8 @@ class WP_REST_Menu_Items_Controller extends WP_REST_Posts_Controller {
 				'menu_order',
 			),
 		);
+		// Change default to 100 items.
+		$query_params['per_page']['default'] = 100;
 
 		return $query_params;
 	}


### PR DESCRIPTION
## Description
Change default to 100 menu items in the REST API.

Fixes https://github.com/WordPress/gutenberg/issues/21212
Original PR  https://github.com/WP-API/menus-endpoints/pull/46