### PR TITLE
Element: Add types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10139,6 +10139,15 @@
 				"@types/react": "*"
 			}
 		},
+		"@types/react-dom": {
+			"version": "16.9.5",
+			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.5.tgz",
+			"integrity": "sha512-BX6RQ8s9D+2/gDhxrj8OW+YD4R+8hj7FEM/OJHGNR0KipE1h1mSsf39YeyC81qafkq+N3rU3h3RFbLSwE5VqUg==",
+			"dev": true,
+			"requires": {
+				"@types/react": "*"
+			}
+		},
 		"@types/react-syntax-highlighter": {
 			"version": "11.0.2",
 			"resolved": "https://registry.npmjs.org/@types/react-syntax-highlighter/-/react-syntax-highlighter-11.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
 		"@types/lodash": "4.14.149",
 		"@types/prettier": "1.19.0",
 		"@types/qs": "6.9.1",
+		"@types/react-dom": "16.9.5",
 		"@types/requestidlecallback": "0.3.1",
 		"@types/sprintf-js": "1.1.2",
 		"@wordpress/babel-plugin-import-jsx-pragma": "file:packages/babel-plugin-import-jsx-pragma",

--- a/packages/element/CHANGELOG.md
+++ b/packages/element/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Master
 
+-   Include TypeScript type declarations ([#21248](https://github.com/WordPress/gutenberg/pull/21248))
 -   Graduated `__experimentalCreateInterpolateElement` function to stable api: `createInterpolateElement` (see [20699](https://github.com/WordPress/gutenberg/pull/20699))
 
 ## 2.10.0 (2019-12-19)

--- a/packages/element/README.md
+++ b/packages/element/README.md
@@ -289,13 +289,11 @@ aside from `children` are passed.
 
 _Parameters_
 
--   _props_ `Object`: 
--   _props.children_ `string`: HTML to render.
--   _props.props_ `Object`: Any additonal props to be set on the containing div.
+-   _props_ `RawHTMLProps`: 
 
 _Returns_
 
--   `WPComponent`: Dangerously-rendering component.
+-   `JSX.Element`: Dangerously-rendering component.
 
 <a name="render" href="#render">#</a> **render**
 

--- a/packages/element/README.md
+++ b/packages/element/README.md
@@ -180,7 +180,7 @@ _Related_
 
 _Parameters_
 
--   _child_ `WPElement`: Any renderable child, such as an element, string, or fragment.
+-   _child_ (unknown type): Any renderable child, such as an element, string, or fragment.
 -   _container_ `HTMLElement`: DOM node into which element should be rendered.
 
 <a name="createRef" href="#createRef">#</a> **createRef**
@@ -199,7 +199,7 @@ Finds the dom node of a React component.
 
 _Parameters_
 
--   _component_ `WPComponent`: Component's instance.
+-   _component_ (unknown type): Component's instance.
 
 <a name="forwardRef" href="#forwardRef">#</a> **forwardRef**
 
@@ -301,7 +301,7 @@ Renders a given element into the target DOM node.
 
 _Parameters_
 
--   _element_ `WPElement`: Element to render.
+-   _element_ (unknown type): Element to render.
 -   _target_ `HTMLElement`: DOM node into which element should be rendered.
 
 <a name="renderToString" href="#renderToString">#</a> **renderToString**
@@ -310,9 +310,9 @@ Serializes a React element to string.
 
 _Parameters_
 
--   _element_ `WPElement`: Element to serialize.
--   _context_ `?Object`: Context object.
--   _legacyContext_ `?Object`: Legacy context object.
+-   _element_ (unknown type): Element to serialize.
+-   _context_ `[Object]`: Context object.
+-   _legacyContext_ `[Object]`: Legacy context object.
 
 _Returns_
 

--- a/packages/element/README.md
+++ b/packages/element/README.md
@@ -289,7 +289,7 @@ aside from `children` are passed.
 
 _Parameters_
 
--   _props_ `RawHTMLProps`: 
+-   _props_ `RawHTMLProps`: Children should be a string of HTML. Other props will be passed through to div wrapper.
 
 _Returns_
 

--- a/packages/element/package.json
+++ b/packages/element/package.json
@@ -21,6 +21,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"react-native": "src/index",
+	"types": "build-types",
 	"sideEffects": false,
 	"dependencies": {
 		"@babel/runtime": "^7.8.3",

--- a/packages/element/src/create-interpolate-element.js
+++ b/packages/element/src/create-interpolate-element.js
@@ -25,6 +25,8 @@ let indoc, offset, output, stack;
 const tokenizer = /<(\/)?(\w+)\s*(\/)?>/g;
 
 /**
+ * The stack frame tracking parse progress.
+ *
  * @typedef Frame
  *
  * @property {WPElement} element            A parent element which may still have

--- a/packages/element/src/create-interpolate-element.js
+++ b/packages/element/src/create-interpolate-element.js
@@ -3,6 +3,8 @@
  */
 import { createElement, cloneElement, Fragment, isValidElement } from 'react';
 
+/** @typedef {import('./react').WPElement} WPElement */
+
 let indoc, offset, output, stack;
 
 /**
@@ -23,27 +25,43 @@ let indoc, offset, output, stack;
 const tokenizer = /<(\/)?(\w+)\s*(\/)?>/g;
 
 /**
+ * @typedef Frame
+ *
+ * @property {WPElement} element            A parent element which may still have
+ * @property {number}    tokenStart         Offset at which parent element first
+ *                                          appears.
+ * @property {number}    tokenLength        Length of string marking start of parent
+ *                                          element.
+ * @property {number}    [prevOffset]       Running offset at which parsing should
+ *                                          continue.
+ * @property {number}    [leadingTextStart] Offset at which last closing element
+ *                                          finished, used for finding text between
+ *                                          elements.
+ * @property {WPElement[]} children         Children.
+ */
+
+/**
  * Tracks recursive-descent parse state.
  *
  * This is a Stack frame holding parent elements until all children have been
  * parsed.
  *
  * @private
- * @param {WPElement} element          A parent element which may still have
- *                                     nested children not yet parsed.
- * @param {number}    tokenStart       Offset at which parent element first
- *                                     appears.
- * @param {number}    tokenLength      Length of string marking start of parent
- *                                     element.
- * @param {number}    prevOffset       Running offset at which parsing should
- *                                     continue.
- * @param {number}    leadingTextStart Offset at which last closing element
- *                                     finished, used for finding text between
- *                                     elements
+ * @param {WPElement} element            A parent element which may still have
+ *                                       nested children not yet parsed.
+ * @param {number}    tokenStart         Offset at which parent element first
+ *                                       appears.
+ * @param {number}    tokenLength        Length of string marking start of parent
+ *                                       element.
+ * @param {number}    [prevOffset]       Running offset at which parsing should
+ *                                       continue.
+ * @param {number}    [leadingTextStart] Offset at which last closing element
+ *                                       finished, used for finding text between
+ *                                       elements.
  *
  * @return {Frame} The stack frame tracking parse progress.
  */
-function Frame(
+function createFrame(
 	element,
 	tokenStart,
 	tokenLength,
@@ -175,14 +193,14 @@ function proceed( conversionMap ) {
 
 			// otherwise we found an inner element
 			addChild(
-				new Frame( conversionMap[ name ], startOffset, tokenLength )
+				createFrame( conversionMap[ name ], startOffset, tokenLength )
 			);
 			offset = startOffset + tokenLength;
 			return true;
 
 		case 'opener':
 			stack.push(
-				new Frame(
+				createFrame(
 					conversionMap[ name ],
 					startOffset,
 					tokenLength,
@@ -210,7 +228,7 @@ function proceed( conversionMap ) {
 			);
 			stackTop.children.push( text );
 			stackTop.prevOffset = startOffset + tokenLength;
-			const frame = new Frame(
+			const frame = createFrame(
 				stackTop.element,
 				stackTop.tokenStart,
 				stackTop.tokenLength,

--- a/packages/element/src/raw-html.js
+++ b/packages/element/src/raw-html.js
@@ -3,17 +3,20 @@
  */
 import { createElement } from './react';
 
+// Disable reason: JSDoc linter doesn't seem to parse the union (`&`) correctly.
+/* eslint-disable jsdoc/valid-types */
+/** @typedef {{children: string} & import('react').ComponentPropsWithoutRef<'div'>} RawHTMLProps */
+/* eslint-enable jsdoc/valid-types */
+
 /**
  * Component used as equivalent of Fragment with unescaped HTML, in cases where
  * it is desirable to render dangerous HTML without needing a wrapper element.
  * To preserve additional props, a `div` wrapper _will_ be created if any props
  * aside from `children` are passed.
  *
- * @param {Object} props
- * @param {string} props.children HTML to render.
- * @param {Object} props.props    Any additonal props to be set on the containing div.
+ * @param {RawHTMLProps} props
  *
- * @return {WPComponent} Dangerously-rendering component.
+ * @return {JSX.Element} Dangerously-rendering component.
  */
 export default function RawHTML( { children, ...props } ) {
 	// The DIV wrapper will be stripped by serializer, unless there are

--- a/packages/element/src/raw-html.js
+++ b/packages/element/src/raw-html.js
@@ -14,7 +14,8 @@ import { createElement } from './react';
  * To preserve additional props, a `div` wrapper _will_ be created if any props
  * aside from `children` are passed.
  *
- * @param {RawHTMLProps} props
+ * @param {RawHTMLProps} props Children should be a string of HTML. Other props
+ *                             will be passed through to div wrapper.
  *
  * @return {JSX.Element} Dangerously-rendering component.
  */

--- a/packages/element/src/react-platform.js
+++ b/packages/element/src/react-platform.js
@@ -13,7 +13,7 @@ import {
  *
  * @see https://github.com/facebook/react/issues/10309#issuecomment-318433235
  *
- * @param {WPElement}   child     Any renderable child, such as an element,
+ * @param {import('./react').WPElement}   child     Any renderable child, such as an element,
  *                                string, or fragment.
  * @param {HTMLElement} container DOM node into which element should be rendered.
  */
@@ -22,14 +22,14 @@ export { createPortal };
 /**
  * Finds the dom node of a React component.
  *
- * @param {WPComponent} component Component's instance.
+ * @param {import('./react').WPComponent} component Component's instance.
  */
 export { findDOMNode };
 
 /**
  * Renders a given element into the target DOM node.
  *
- * @param {WPElement}   element Element to render.
+ * @param {import('./react').WPElement}   element Element to render.
  * @param {HTMLElement} target  DOM node into which element should be rendered.
  */
 export { render };

--- a/packages/element/src/react.js
+++ b/packages/element/src/react.js
@@ -37,7 +37,7 @@ import { isString } from 'lodash';
 /**
  * Object containing a React component.
  *
- * @typedef {import('react').Component} WPComponent
+ * @typedef {import('react').ComponentType} WPComponent
  */
 
 /**

--- a/packages/element/src/serialize.js
+++ b/packages/element/src/serialize.js
@@ -527,9 +527,9 @@ export function renderComponent(
 /**
  * Serializes an array of children to string.
  *
- * @param {import('react').ReactNodeArray}  children        Children to serialize.
- * @param {Object} [context]       Context object.
- * @param {Object} [legacyContext] Legacy context object.
+ * @param {import('react').ReactNodeArray} children        Children to serialize.
+ * @param {Object}                         [context]       Context object.
+ * @param {Object}                         [legacyContext] Legacy context object.
  *
  * @return {string} Serialized children.
  */

--- a/packages/element/src/serialize.js
+++ b/packages/element/src/serialize.js
@@ -52,7 +52,9 @@ import {
 import { createContext, Fragment, StrictMode, forwardRef } from './react';
 import RawHTML from './raw-html';
 
-const { Provider, Consumer } = createContext();
+/** @typedef {import('./react').WPElement} WPElement */
+
+const { Provider, Consumer } = createContext( undefined );
 const ForwardRef = forwardRef( () => {
 	return null;
 } );
@@ -269,7 +271,7 @@ function isInternalAttribute( attribute ) {
  * @param {string} attribute Attribute name.
  * @param {*}      value     Non-normalized attribute value.
  *
- * @return {string} Normalized attribute value.
+ * @return {*} Normalized attribute value.
  */
 function getNormalAttributeValue( attribute, value ) {
 	switch ( attribute ) {
@@ -346,9 +348,9 @@ function getNormalStylePropertyValue( property, value ) {
 /**
  * Serializes a React element to string.
  *
- * @param {WPElement} element       Element to serialize.
- * @param {?Object}   context       Context object.
- * @param {?Object}   legacyContext Legacy context object.
+ * @param {import('react').ReactNode} element         Element to serialize.
+ * @param {Object}                    [context]       Context object.
+ * @param {Object}                    [legacyContext] Legacy context object.
  *
  * @return {string} Serialized element.
  */
@@ -369,7 +371,10 @@ export function renderElement( element, context, legacyContext = {} ) {
 			return element.toString();
 	}
 
-	const { type, props } = element;
+	const {
+		type,
+		props,
+	} = /** @type {{type?: any, props?: any}} */ ( element );
 
 	switch ( type ) {
 		case StrictMode:
@@ -434,11 +439,11 @@ export function renderElement( element, context, legacyContext = {} ) {
 /**
  * Serializes a native component type to string.
  *
- * @param {?string} type          Native component type to serialize, or null if
- *                                rendering as fragment of children content.
- * @param {Object}  props         Props object.
- * @param {?Object} context       Context object.
- * @param {?Object} legacyContext Legacy context object.
+ * @param {?string} type            Native component type to serialize, or null if
+ *                                  rendering as fragment of children content.
+ * @param {Object}  props           Props object.
+ * @param {Object}  [context]       Context object.
+ * @param {Object}  [legacyContext] Legacy context object.
  *
  * @return {string} Serialized element.
  */
@@ -478,13 +483,15 @@ export function renderNativeComponent(
 	return '<' + type + attributes + '>' + content + '</' + type + '>';
 }
 
+/** @typedef {import('./react').WPComponent} WPComponent */
+
 /**
  * Serializes a non-native component type to string.
  *
- * @param {Function} Component     Component type to serialize.
- * @param {Object}   props         Props object.
- * @param {?Object}  context       Context object.
- * @param {?Object}  legacyContext Legacy context object.
+ * @param {WPComponent} Component       Component type to serialize.
+ * @param {Object}      props           Props object.
+ * @param {Object}      [context]       Context object.
+ * @param {Object}      [legacyContext] Legacy context object.
  *
  * @return {string} Serialized element
  */
@@ -494,10 +501,22 @@ export function renderComponent(
 	context,
 	legacyContext = {}
 ) {
-	const instance = new Component( props, legacyContext );
+	const instance = new /** @type {import('react').ComponentClass} */ ( Component )(
+		props,
+		legacyContext
+	);
 
-	if ( typeof instance.getChildContext === 'function' ) {
-		Object.assign( legacyContext, instance.getChildContext() );
+	if (
+		typeof (
+			// Ignore reason: Current prettier reformats parens and mangles type assertion
+			// prettier-ignore
+			/** @type {{getChildContext?: () => unknown}} */ ( instance ).getChildContext
+		) === 'function'
+	) {
+		Object.assign(
+			legacyContext,
+			/** @type {{getChildContext?: () => unknown}} */ ( instance ).getChildContext()
+		);
 	}
 
 	const html = renderElement( instance.render(), context, legacyContext );
@@ -508,9 +527,9 @@ export function renderComponent(
 /**
  * Serializes an array of children to string.
  *
- * @param {Array}   children      Children to serialize.
- * @param {?Object} context       Context object.
- * @param {?Object} legacyContext Legacy context object.
+ * @param {import('react').ReactNodeArray}  children        Children to serialize.
+ * @param {Object} [context]       Context object.
+ * @param {Object} [legacyContext] Legacy context object.
  *
  * @return {string} Serialized children.
  */

--- a/packages/element/src/serialize.js
+++ b/packages/element/src/serialize.js
@@ -60,14 +60,14 @@ const ForwardRef = forwardRef( () => {
 /**
  * Valid attribute types.
  *
- * @type {Set}
+ * @type {Set<string>}
  */
 const ATTRIBUTES_TYPES = new Set( [ 'string', 'boolean', 'number' ] );
 
 /**
  * Element tags which can be self-closing.
  *
- * @type {Set}
+ * @type {Set<string>}
  */
 const SELF_CLOSING_TAGS = new Set( [
 	'area',
@@ -101,7 +101,7 @@ const SELF_CLOSING_TAGS = new Set( [
  *         [ tr.firstChild.textContent.trim() ]: true
  *     } ), {} ) ).sort();
  *
- * @type {Set}
+ * @type {Set<string>}
  */
 const BOOLEAN_ATTRIBUTES = new Set( [
 	'allowfullscreen',
@@ -152,7 +152,7 @@ const BOOLEAN_ATTRIBUTES = new Set( [
  *
  *  - `alt`: https://blog.whatwg.org/omit-alt
  *
- * @type {Set}
+ * @type {Set<string>}
  */
 const ENUMERATED_ATTRIBUTES = new Set( [
 	'autocapitalize',
@@ -195,7 +195,7 @@ const ENUMERATED_ATTRIBUTES = new Set( [
  *     .map( ( [ key ] ) => key )
  *     .sort();
  *
- * @type {Set}
+ * @type {Set<string>}
  */
 const CSS_PROPERTIES_SUPPORTS_UNITLESS = new Set( [
 	'animation',

--- a/packages/element/tsconfig.json
+++ b/packages/element/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"rootDir": "src",
+		"declarationDir": "build-types"
+	},
+	"references": [ { "path": "../escape-html" } ],
+	"include": [ "src/**/*" ]
+}

--- a/packages/element/tsconfig.json
+++ b/packages/element/tsconfig.json
@@ -2,7 +2,10 @@
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",
-		"declarationDir": "build-types"
+		"declarationDir": "build-types",
+
+		"noImplicitAny": false,
+		"strictNullChecks": false
 	},
 	"references": [ { "path": "../escape-html" } ],
 	"include": [ "src/**/*" ]

--- a/packages/eslint-plugin/configs/jsdoc.js
+++ b/packages/eslint-plugin/configs/jsdoc.js
@@ -59,6 +59,8 @@ const typescriptUtilityTypes = [
 	'Required',
 	'ReturnType',
 	'ThisType',
+	'unknown',
+	'never',
 ];
 
 module.exports = {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
 		{ "path": "packages/autop" },
 		{ "path": "packages/blob" },
 		{ "path": "packages/block-editor" },
+		{ "path": "packages/element" },
 		{ "path": "packages/dom-ready" },
 		{ "path": "packages/escape-html" },
 		{ "path": "packages/html-entities" },


### PR DESCRIPTION
## Description

Add types/typechecking to `@wordpress/element`. Many other packages that would be extremely valuable to type, namely `@wordpress/data` and `@wordpress/components`, depend on this package. Typing it unblocks a lot of work on other package typings.

- Improve internal JSDoc/TypeScript typings.
- Add published types.

Add [`unknown`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-0.html#new-unknown-top-type) and [`never`](https://www.typescriptlang.org/docs/handbook/basic-types.html#never) TypeScript types to allowed JSDoc types.

✅ ~Includes squash-merged #20669, necessary for some required types.~

Part of #18838

## How has this been tested?

`npm run build:package-types` passes.

## Screenshots <!-- if applicable -->

## Types of changes

New feature: Add types

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
