### PR TITLE
Prevent the cover block from overriding the children blocks colors

### DIFF
--- a/packages/block-library/src/cover/editor.scss
+++ b/packages/block-library/src/cover/editor.scss
@@ -9,10 +9,6 @@
 		width: 100%;
 	}
 
-	.block-editor-block-list__block {
-		color: $light-gray-100;
-	}
-
 	// The .wp-block-cover class is used just to increase selector specificity.
 	.wp-block-cover__inner-container {
 		// Avoid text align inherit from cover image align.


### PR DESCRIPTION
I'm not really sure what was the purpose of this style. cc @jorgefilipecosta 

**Testing instructions**

 - Insert the "abc" pattern and notice that the text color is dark blue.