### PR TITLE
uuid: Update to v7.0.2, fix imports

### DIFF
--- a/bin/commander.js
+++ b/bin/commander.js
@@ -16,7 +16,7 @@ const SimpleGit = require( 'simple-git/promise' );
 const childProcess = require( 'child_process' );
 const Octokit = require( '@octokit/rest' );
 const os = require( 'os' );
-const uuid = require( 'uuid/v4' );
+const { v4: uuid } = require( 'uuid' );
 
 // Config
 const gitRepoOwner = 'WordPress';

--- a/package-lock.json
+++ b/package-lock.json
@@ -10442,7 +10442,7 @@
 				"@wordpress/rich-text": "file:packages/rich-text",
 				"lodash": "^4.17.15",
 				"rememo": "^3.0.0",
-				"uuid": "^3.3.2"
+				"uuid": "^7.0.2"
 			}
 		},
 		"@wordpress/api-fetch": {
@@ -10631,7 +10631,7 @@
 				"showdown": "^1.8.6",
 				"simple-html-tokenizer": "^0.5.7",
 				"tinycolor2": "^1.4.1",
-				"uuid": "^3.3.2"
+				"uuid": "^7.0.2"
 			}
 		},
 		"@wordpress/browserslist-config": {
@@ -10673,7 +10673,7 @@
 				"reakit": "^1.0.0-rc.0",
 				"rememo": "^3.0.0",
 				"tinycolor2": "^1.4.1",
-				"uuid": "^3.3.2"
+				"uuid": "^7.0.2"
 			}
 		},
 		"@wordpress/compose": {
@@ -10941,7 +10941,7 @@
 				"chalk": "^2.4.2",
 				"expect-puppeteer": "^4.3.0",
 				"lodash": "^4.17.15",
-				"uuid": "^3.3.2"
+				"uuid": "^7.0.2"
 			}
 		},
 		"@wordpress/edit-navigation": {
@@ -11258,8 +11258,7 @@
 						"qs": "~6.5.2",
 						"safe-buffer": "^5.1.2",
 						"tough-cookie": "~2.5.0",
-						"tunnel-agent": "^0.6.0",
-						"uuid": "^3.3.2"
+						"tunnel-agent": "^0.6.0"
 					}
 				},
 				"restore-cursor": {
@@ -30351,6 +30350,14 @@
 						"tough-cookie": "~2.4.3",
 						"tunnel-agent": "^0.6.0",
 						"uuid": "^3.3.2"
+					},
+					"dependencies": {
+						"uuid": {
+							"version": "3.4.0",
+							"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+							"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+							"dev": true
+						}
 					}
 				},
 				"strip-ansi": {
@@ -36066,6 +36073,12 @@
 					"requires": {
 						"mime-db": "1.40.0"
 					}
+				},
+				"uuid": {
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+					"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+					"dev": true
 				}
 			}
 		},
@@ -39064,6 +39077,12 @@
 					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
 					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
 					"dev": true
+				},
+				"uuid": {
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+					"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+					"dev": true
 				}
 			}
 		},
@@ -40497,9 +40516,9 @@
 			"dev": true
 		},
 		"uuid": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.2.tgz",
+			"integrity": "sha512-vy9V/+pKG+5ZTYKf+VcphF5Oc6EFiu3W8Nv3P3zIh0EqVI80ZxOzuPfe9EHjkFNvf8+xuTHVeei4Drydlx4zjw=="
 		},
 		"v8-compile-cache": {
 			"version": "2.1.0",
@@ -41361,6 +41380,12 @@
 					"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.4.tgz",
 					"integrity": "sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA==",
 					"dev": true
+				},
+				"uuid": {
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+					"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+					"dev": true
 				}
 			}
 		},
@@ -41813,6 +41838,14 @@
 			"requires": {
 				"simple-plist": "^1.0.0",
 				"uuid": "^3.3.2"
+			},
+			"dependencies": {
+				"uuid": {
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+					"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+					"dev": true
+				}
 			}
 		},
 		"xml": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11258,7 +11258,8 @@
 						"qs": "~6.5.2",
 						"safe-buffer": "^5.1.2",
 						"tough-cookie": "~2.5.0",
-						"tunnel-agent": "^0.6.0"
+						"tunnel-agent": "^0.6.0",
+						"uuid": "^3.3.2"
 					}
 				},
 				"restore-cursor": {
@@ -11342,6 +11343,12 @@
 					"version": "0.8.1",
 					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
 					"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+					"dev": true
+				},
+				"uuid": {
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+					"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
 					"dev": true
 				}
 			}

--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
 		"style-loader": "1.0.0",
 		"stylelint-config-wordpress": "13.1.0",
 		"typescript": "3.8.3",
-		"uuid": "3.3.2",
+		"uuid": "7.0.2",
 		"webpack": "4.42.0",
 		"worker-farm": "1.7.0"
 	},

--- a/packages/annotations/package.json
+++ b/packages/annotations/package.json
@@ -28,7 +28,7 @@
 		"@wordpress/rich-text": "file:../rich-text",
 		"lodash": "^4.17.15",
 		"rememo": "^3.0.0",
-		"uuid": "^3.3.2"
+		"uuid": "^7.0.2"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/annotations/src/store/actions.js
+++ b/packages/annotations/src/store/actions.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import uuid from 'uuid/v4';
+import { v4 as uuid } from 'uuid';
 
 /**
  * Adds an annotation to a block.

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -41,7 +41,7 @@
 		"showdown": "^1.8.6",
 		"simple-html-tokenizer": "^0.5.7",
 		"tinycolor2": "^1.4.1",
-		"uuid": "^3.3.2"
+		"uuid": "^7.0.2"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import uuid from 'uuid/v4';
+import { v4 as uuid } from 'uuid';
 import {
 	every,
 	reduce,

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -56,7 +56,7 @@
 		"reakit": "^1.0.0-rc.0",
 		"rememo": "^3.0.0",
 		"tinycolor2": "^1.4.1",
-		"uuid": "^3.3.2"
+		"uuid": "^7.0.2"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/components/src/higher-order/with-notices/index.js
+++ b/packages/components/src/higher-order/with-notices/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import uuid from 'uuid/v4';
+import { v4 as uuid } from 'uuid';
 
 /**
  * WordPress dependencies

--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -30,7 +30,7 @@
 		"chalk": "^2.4.2",
 		"expect-puppeteer": "^4.3.0",
 		"lodash": "^4.17.15",
-		"uuid": "^3.3.2"
+		"uuid": "^7.0.2"
 	},
 	"peerDependencies": {
 		"jest": ">=24",

--- a/packages/e2e-tests/specs/editor/blocks/classic.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/classic.test.js
@@ -4,7 +4,7 @@
 import path from 'path';
 import fs from 'fs';
 import os from 'os';
-import uuid from 'uuid/v4';
+import { v4 as uuid } from 'uuid';
 
 /**
  * WordPress dependencies

--- a/packages/e2e-tests/specs/editor/blocks/image.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/image.test.js
@@ -4,7 +4,7 @@
 import path from 'path';
 import fs from 'fs';
 import os from 'os';
-import uuid from 'uuid/v4';
+import { v4 as uuid } from 'uuid';
 
 /**
  * WordPress dependencies

--- a/packages/e2e-tests/specs/editor/various/adding-inline-tokens.test.js
+++ b/packages/e2e-tests/specs/editor/various/adding-inline-tokens.test.js
@@ -4,7 +4,7 @@
 import path from 'path';
 import fs from 'fs';
 import os from 'os';
-import uuid from 'uuid/v4';
+import { v4 as uuid } from 'uuid';
 
 /**
  * WordPress dependencies


### PR DESCRIPTION
## Description
Janitorial, similar to https://github.com/Automattic/wp-calypso/pull/39827.

See [v7 breaking changes](https://github.com/uuidjs/uuid/blob/master/CHANGELOG.md#-breaking-changes).

## How has this been tested?

Smoke tested. Also watch for e2e tests in CI.

## Types of changes

Dependency update, import fixes.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
