### PR TITLE
Disable align button on the heading block for Android

### DIFF
--- a/packages/block-library/src/heading/edit.js
+++ b/packages/block-library/src/heading/edit.js
@@ -38,12 +38,14 @@ function HeadingEdit( { attributes, setAttributes, mergeBlocks, onReplace } ) {
 						setAttributes( { level: newLevel } )
 					}
 				/>
-				<AlignmentToolbar
-					value={ align }
-					onChange={ ( nextAlign ) => {
-						setAttributes( { align: nextAlign } );
-					} }
-				/>
+				{ Platform.OS !== 'android' && (
+					<AlignmentToolbar
+						value={ align }
+						onChange={ ( nextAlign ) => {
+							setAttributes( { align: nextAlign } );
+						} }
+					/>
+				) }
 			</BlockControls>
 			{ Platform.OS === 'web' && (
 				<InspectorControls>

--- a/packages/block-library/src/heading/edit.js
+++ b/packages/block-library/src/heading/edit.js
@@ -26,7 +26,11 @@ import { Platform } from '@wordpress/element';
 function HeadingEdit( { attributes, setAttributes, mergeBlocks, onReplace } ) {
 	const { align, content, level, placeholder } = attributes;
 	const tagName = 'h' + level;
-
+	const isAndroid = Platform.select( {
+		android: true,
+		native: false,
+		web: false,
+	} );
 	return (
 		<>
 			<BlockControls>
@@ -38,7 +42,7 @@ function HeadingEdit( { attributes, setAttributes, mergeBlocks, onReplace } ) {
 						setAttributes( { level: newLevel } )
 					}
 				/>
-				{ Platform.OS !== 'android' && (
+				{ ! isAndroid && (
 					<AlignmentToolbar
 						value={ align }
 						onChange={ ( nextAlign ) => {


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

This PR disables the align controls in the Heading block for Android.
We are disabling it because Aztec for Android is still not ready to support this functionality.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

This can be tested using this GB mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/2084
## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
