### PR TITLE
Site Editor: add block breadcrumb

### DIFF
--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -16,6 +16,7 @@ import {
 } from '@wordpress/components';
 import { EntityProvider } from '@wordpress/core-data';
 import {
+	BlockBreadcrumb,
 	__experimentalEditorSkeleton as EditorSkeleton,
 	__experimentalFullscreenMode as FullscreenMode,
 	__unstableEditorStyles as EditorStyles,
@@ -84,6 +85,7 @@ function Editor( { settings: _settings } ) {
 												<BlockEditor />
 											</>
 										}
+										footer={ <BlockBreadcrumb /> }
 									/>
 									<Popover.Slot />
 								</FocusReturnProvider>


### PR DESCRIPTION
## Description

In its present state it's hard for me to determine whether you are inserting blocks in the template part or the surrounding content area due to lack of visual indicators. Adding block breadcrumbs should hopefully make that easier.

## How has this been tested?

Navigate to Site Editor and make sure that block breadcrumb works as expected. Check various screen sizes.

## Screenshots <!-- if applicable -->

<img width="386" alt="Screenshot 2020-03-31 at 01 18 53" src="https://user-images.githubusercontent.com/1182160/77971217-6fb2e780-72ee-11ea-83b9-caba0c370236.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality) 
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
