### PR TITLE
Remove protocol in LinkControl suggestiosn

### DIFF
--- a/packages/block-editor/src/components/link-control/search-item.js
+++ b/packages/block-editor/src/components/link-control/search-item.js
@@ -46,7 +46,11 @@ export const LinkControlSearchItem = ( {
 					aria-hidden={ ! isURL }
 					className="block-editor-link-control__search-item-info"
 				>
-					{ ! isURL && ( safeDecodeURI( suggestion.url ) || '' ) }
+					{ ! isURL &&
+						( safeDecodeURI(
+							suggestion.url.replace( /http(s?):\/\//, '' )
+						) ||
+							'' ) }
 					{ isURL && __( 'Press ENTER to add this link' ) }
 				</span>
 			</span>


### PR DESCRIPTION
## Description
Closes #19670. Props @sainthkh, copied test from #20350

## How has this been tested?
Tested locally by:

0. Make sure you have some posts and pages
1. Add a post
2. Add a navigation block
3. Add a navigation item and search for something
4. The internal links for suggested posts or pages should not display protocol
5. The links should be saved with protocol

## Types of changes
Non breaking change to display of links in `LinkControl` suggestion list.

