### PR TITLE
Prevent template switcher jumpiness

### DIFF
--- a/packages/edit-site/src/components/template-switcher/index.js
+++ b/packages/edit-site/src/components/template-switcher/index.js
@@ -137,6 +137,7 @@ export default function TemplateSwitcher( {
 						{ !! hoveredTemplate?.id && (
 							<TemplatePreview item={ hoveredTemplate } />
 						) }
+						<div className="edit-site-template-switcher__footer" />
 					</>
 				) }
 			</DropdownMenu>

--- a/packages/edit-site/src/components/template-switcher/style.scss
+++ b/packages/edit-site/src/components/template-switcher/style.scss
@@ -22,6 +22,14 @@
 	width: 100%;
 }
 
+/*
+ * This doesn't contain anything but it's needed because of dropdown jumpiness
+ * when there's a div after the last menu group.
+ */
+.edit-site-template-switcher__footer {
+	margin-bottom: -$grid-unit-15;
+}
+
 .edit-site-template-switcher__preview {
 	display: none;
 	border: $border-width solid $light-gray-secondary;
@@ -33,7 +41,6 @@
 	position: absolute;
 	top: -$border-width;
 	left: calc(100% + #{$grid-unit-15});
-
 
 	@include break-medium {
 		display: block;


### PR DESCRIPTION
closes #21213 

This trick is needed to keep the generic DropdownMenu use-case where there's nothing after menu groups.