### PR TITLE
Site Editor: bring back more menu

### DIFF
--- a/packages/edit-site/src/components/header/index.js
+++ b/packages/edit-site/src/components/header/index.js
@@ -10,6 +10,7 @@ import { PinnedItems } from '@wordpress/interface';
  */
 import { useEditorContext } from '../editor';
 import FullscreenModeClose from './fullscreen-mode-close';
+import MoreMenu from './more-menu';
 import TemplateSwitcher from '../template-switcher';
 import SaveButton from '../save-button';
 
@@ -63,6 +64,7 @@ export default function Header() {
 			<div className="edit-site-header__actions">
 				<SaveButton />
 				<PinnedItems.Slot scope="core/edit-site" />
+				<MoreMenu />
 			</div>
 		</div>
 	);


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

Brings back the Site Editor more menu that was likely lost as a result of a rebase in a https://github.com/WordPress/gutenberg/pull/20698. See https://github.com/WordPress/gutenberg/pull/20698#discussion_r400721230.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Open the Site Editor and verify that the more menu is present and that the toggle works.

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
