### PR TITLE
Docs: Describe tools used in E2E testing

### DIFF
--- a/docs/contributors/testing-overview.md
+++ b/docs/contributors/testing-overview.md
@@ -372,7 +372,9 @@ To locally run the tests in debug mode, follow these steps:
 5. Click on the "Play" button to resume execution
 6. Enjoy debugging the native mobile unit tests!
 
-## End to end Testing
+## End-to-end Testing
+
+End-to-end tests use [Puppeteer](https://github.com/puppeteer/puppeteer) as a headless Chromium driver, and are otherwise still run by a [Jest](https://jestjs.io/) test runner.
 
 If you're using the built-in [local environment](/docs/contributors/getting-started.md#local-environment), you can run the e2e tests locally using this command:
 


### PR DESCRIPTION
Previously: https://github.com/WordPress/gutenberg/pull/21240#issuecomment-606714280

This pull request seeks to update our Testing Overview documentation to include a mention of the Puppeteer tool in use. It is described in the [`wp-scripts test-e2e`](https://github.com/WordPress/gutenberg/blob/master/packages/scripts/README.md#test-e2e), but there is currently no mention of Puppeteer in the Testing Overview.
