### PR TITLE
E2E Tests: Remove unused JSDoc docblock

### DIFF
--- a/packages/e2e-tests/specs/editor/various/links.test.js
+++ b/packages/e2e-tests/specs/editor/various/links.test.js
@@ -9,12 +9,6 @@ import {
 	pressKeyWithModifier,
 } from '@wordpress/e2e-test-utils';
 
-/**
- * The modifier keys needed to invoke a 'select the next word' keyboard shortcut.
- *
- * @type {string}
- */
-
 describe( 'Links', () => {
 	beforeEach( async () => {
 		await createNewPost();


### PR DESCRIPTION
Previously: #11855

This pull request seeks to remove JSDoc from the `links.test.js` file which previously documented a variable that was removed as part of the changed in #11855. With the removal of the variable, the documentation does not serve any purpose.