### PR TITLE
CustomSelectControl: set aria-hidden to empty option list

### DIFF
--- a/packages/components/src/custom-select-control/index.js
+++ b/packages/components/src/custom-select-control/index.js
@@ -127,9 +127,9 @@ export default function CustomSelectControl( {
 					className="components-custom-select-control__button-icon"
 				/>
 			</Button>
-			<ul { ...menuProps }>
-				{ isOpen &&
-					items.map( ( item, index ) => (
+			{ isOpen && (
+				<ul { ...menuProps }>
+					{ items.map( ( item, index ) => (
 						// eslint-disable-next-line react/jsx-key
 						<li
 							{ ...getItemProps( {
@@ -155,7 +155,8 @@ export default function CustomSelectControl( {
 							{ item.name }
 						</li>
 					) ) }
-			</ul>
+				</ul>
+			) }
 		</div>
 	);
 }

--- a/packages/components/src/custom-select-control/index.js
+++ b/packages/components/src/custom-select-control/index.js
@@ -79,6 +79,7 @@ export default function CustomSelectControl( {
 
 	const menuProps = getMenuProps( {
 		className: 'components-custom-select-control__menu',
+		'aria-hidden': ! isOpen,
 	} );
 	// We need this here, because the null active descendant is not
 	// fully ARIA compliant.
@@ -127,9 +128,9 @@ export default function CustomSelectControl( {
 					className="components-custom-select-control__button-icon"
 				/>
 			</Button>
-			{ isOpen && (
-				<ul { ...menuProps }>
-					{ items.map( ( item, index ) => (
+			<ul { ...menuProps }>
+				{ isOpen &&
+					items.map( ( item, index ) => (
 						// eslint-disable-next-line react/jsx-key
 						<li
 							{ ...getItemProps( {
@@ -155,8 +156,7 @@ export default function CustomSelectControl( {
 							{ item.name }
 						</li>
 					) ) }
-				</ul>
-			) }
+			</ul>
 		</div>
 	);
 }


### PR DESCRIPTION
## Description
`CustomSelectControl` renders the listbox containing the options even when the control is not open. That's causing Orca (Linux screen reader) to read _Blank_ every time it's navigated through.

In parallel, using an a11y audit tool like AXE, shows an error because of that:
![imatge](https://user-images.githubusercontent.com/3616980/78055835-670cf080-7384-11ea-90d1-f0539dd1b186.png)

This PR adds `aria-hidden={ true }` to the options list when it's empty, so it's ignored by assistive technologies.

## How has this been tested?
* In the storybook, I navigated through the CustomSelectControl with the screen reader to verify there were no regressions and it didn't read _Blank_.
* I did the same with the Font Size Picker.