### PR TITLE
WP-env: Add reference to docker log command to show error logs in terminal

### DIFF
--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -201,12 +201,12 @@ ID      user_login      display_name    user_email      user_registered roles
 ✔ Ran `wp user list` in 'cli'. (in 2s 374ms)
 ```
 
-### `docker logs -f [container] >/dev/null` 
+### `docker logs -f [container_id] >/dev/null` 
 
 ```sh
-docker logs -f <container> >/dev/null 
+docker logs -f <container_id> >/dev/null 
 
-Shows the error logs of the specified container in the terminal
+Shows the error logs of the specified container in the terminal. The container_id is the one that is visible with `docker ps -a`
 ```
 
 ## .wp-env.json

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -206,7 +206,7 @@ ID      user_login      display_name    user_email      user_registered roles
 ```sh
 docker logs -f <container> >/dev/null 
 
-Shows the error logs of the WordPress container in the terminal
+Shows the error logs of the specified container in the terminal
 ```
 
 ## .wp-env.json

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -201,6 +201,14 @@ ID      user_login      display_name    user_email      user_registered roles
 ✔ Ran `wp user list` in 'cli'. (in 2s 374ms)
 ```
 
+### `docker logs -f [container] >/dev/null` 
+
+```sh
+wp-env run docker logs -f <container> >/dev/null 
+
+Shows the error logs of the WordPress container in the terminal
+```
+
 ## .wp-env.json
 
 You can customize the WordPress installation, plugins and themes that the development environment will use by specifying a `.wp-env.json` file in the directory that you run `wp-env` from.

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -204,7 +204,7 @@ ID      user_login      display_name    user_email      user_registered roles
 ### `docker logs -f [container] >/dev/null` 
 
 ```sh
-wp-env run docker logs -f <container> >/dev/null 
+docker logs -f <container> >/dev/null 
 
 Shows the error logs of the WordPress container in the terminal
 ```


### PR DESCRIPTION
## Description
Just adds a readme entry about a docker log command that can be used to easily view WP container php error logs

## How has this been tested?
Tested on local wp-env install


## Types of changes
Minor Readme doc update
