### PR TITLE
Fix reusable block horizontal padding regression.

### DIFF
--- a/packages/block-library/src/block/edit-panel/editor.scss
+++ b/packages/block-library/src/block/edit-panel/editor.scss
@@ -48,11 +48,9 @@
 }
 
 .is-navigate-mode .is-selected .reusable-block-edit-panel {
-	border-color: $blue-medium-focus;
-	border-style: solid;
-	border-bottom: 0;
+	box-shadow: 0 0 0 $border-width $blue-medium-focus;
 
 	.is-dark-theme & {
-		border-color: $blue-medium-focus;
+		box-shadow: 0 0 0 $border-width $blue-medium-focus;
 	}
 }

--- a/packages/block-library/src/block/editor.scss
+++ b/packages/block-library/src/block/editor.scss
@@ -1,3 +1,11 @@
-.edit-post-visual-editor .block-library-block__reusable-block-container .block-editor-writing-flow__click-redirect {
-	min-height: auto;
+.edit-post-visual-editor .block-library-block__reusable-block-container {
+	.block-editor-writing-flow__click-redirect {
+		min-height: auto;
+	}
+
+	// Unset the padding that root containers get when they're actually root containers.
+	.is-root-container {
+		padding-left: 0;
+		padding-right: 0;
+	}
 }


### PR DESCRIPTION
https://github.com/WordPress/gutenberg/pull/21099/files#diff-ee2ed3adbe2578628039530c717a9a93R640 introduced a padding attached to the is-root-container. But a reusable block is also a root container.

This PR unsets that.

Before:

<img width="848" alt="Screenshot 2020-04-01 at 09 23 59" src="https://user-images.githubusercontent.com/1204802/78110074-b3931300-73fa-11ea-9f69-c5d3ca31861b.png">

After:

<img width="1017" alt="Screenshot 2020-04-01 at 09 23 48" src="https://user-images.githubusercontent.com/1204802/78110081-b5f56d00-73fa-11ea-97bf-646850182e56.png">
