### PR TITLE
Implement initial styling of navigation menu screen

### DIFF
--- a/packages/edit-navigation/src/components/layout/index.js
+++ b/packages/edit-navigation/src/components/layout/index.js
@@ -25,6 +25,7 @@ export default function Layout( { blockEditorSettings } ) {
 						{ /* <Notices /> */ }
 						<Popover.Slot name="block-toolbar" />
 						<TabPanel
+							className="edit-navigation-layout__tab-panel"
 							tabs={ [
 								{
 									name: 'menus',

--- a/packages/edit-navigation/src/components/layout/style.scss
+++ b/packages/edit-navigation/src/components/layout/style.scss
@@ -1,0 +1,8 @@
+.edit-navigation-layout__tab-panel {
+	// Matches the padding-left applied by default to the `#wpcontent` element.
+	margin-right: 20px;
+
+	.components-tab-panel__tabs {
+		margin-bottom: 10px;
+	}
+}

--- a/packages/edit-navigation/src/components/menu-editor/index.js
+++ b/packages/edit-navigation/src/components/menu-editor/index.js
@@ -49,7 +49,7 @@ export default function MenuEditor( { menuId, blockEditorSettings } ) {
 				<Panel
 					header={
 						<Button isPrimary onClick={ saveBlocks }>
-							{ __( 'Save Navigation' ) }
+							{ __( 'Save navigation' ) }
 						</Button>
 					}
 					className="edit-navigation-menu-editor__panel"

--- a/packages/edit-navigation/src/components/menu-editor/index.js
+++ b/packages/edit-navigation/src/components/menu-editor/index.js
@@ -10,7 +10,7 @@ import {
 	__experimentalBlockNavigationList,
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
-import { Button } from '@wordpress/components';
+import { Panel, PanelBody, Button } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -23,9 +23,7 @@ export default function MenuEditor( { menuId, blockEditorSettings } ) {
 	return (
 		<div className="edit-navigation-menu-editor">
 			<BlockEditorKeyboardShortcuts.Register />
-			<Button isPrimary onClick={ saveBlocks }>
-				{ __( 'Save' ) }
-			</Button>
+
 			<BlockEditorProvider
 				value={ blocks }
 				onInput={ ( updatedBlocks ) => setBlocks( updatedBlocks ) }
@@ -35,24 +33,35 @@ export default function MenuEditor( { menuId, blockEditorSettings } ) {
 					templateLock: 'all',
 				} }
 			>
-				<div className="edit-navigation-menu-editor__panel">
-					{ !! blocks.length && (
-						<__experimentalBlockNavigationList
-							blocks={ blocks }
-							selectedBlockClientId={ blocks[ 0 ].clientId }
-							selectBlock={ () => {} }
-							showNestedBlocks
-							showAppender
-						/>
-					) }
-				</div>
-				<div className="edit-navigation-menu-editor__panel">
-					<WritingFlow>
-						<ObserveTyping>
-							<BlockList />
-						</ObserveTyping>
-					</WritingFlow>
-				</div>
+				<Panel className="edit-navigation-menu-editor__panel">
+					<PanelBody title={ __( 'Navigation Structure' ) }>
+						{ !! blocks.length && (
+							<__experimentalBlockNavigationList
+								blocks={ blocks }
+								selectedBlockClientId={ blocks[ 0 ].clientId }
+								selectBlock={ () => {} }
+								showNestedBlocks
+								showAppender
+							/>
+						) }
+					</PanelBody>
+				</Panel>
+				<Panel
+					header={
+						<Button isPrimary onClick={ saveBlocks }>
+							{ __( 'Save Navigation' ) }
+						</Button>
+					}
+					className="edit-navigation-menu-editor__panel"
+				>
+					<PanelBody title={ __( 'Navigation Menu' ) }>
+						<WritingFlow>
+							<ObserveTyping>
+								<BlockList />
+							</ObserveTyping>
+						</WritingFlow>
+					</PanelBody>
+				</Panel>
 			</BlockEditorProvider>
 		</div>
 	);

--- a/packages/edit-navigation/src/components/menu-editor/index.js
+++ b/packages/edit-navigation/src/components/menu-editor/index.js
@@ -34,7 +34,7 @@ export default function MenuEditor( { menuId, blockEditorSettings } ) {
 				} }
 			>
 				<Panel className="edit-navigation-menu-editor__panel">
-					<PanelBody title={ __( 'Navigation Structure' ) }>
+					<PanelBody title={ __( 'Navigation structure' ) }>
 						{ !! blocks.length && (
 							<__experimentalBlockNavigationList
 								blocks={ blocks }
@@ -54,7 +54,7 @@ export default function MenuEditor( { menuId, blockEditorSettings } ) {
 					}
 					className="edit-navigation-menu-editor__panel"
 				>
-					<PanelBody title={ __( 'Navigation Menu' ) }>
+					<PanelBody title={ __( 'Navigation menu' ) }>
 						<WritingFlow>
 							<ObserveTyping>
 								<BlockList />

--- a/packages/edit-navigation/src/components/menu-editor/style.scss
+++ b/packages/edit-navigation/src/components/menu-editor/style.scss
@@ -1,5 +1,5 @@
 .edit-navigation-menu-editor {
 	display: grid;
-	grid-template-columns: 1fr 2fr;
+	grid-template-columns: 280px 1fr;
 	grid-column-gap: 10px;
 }

--- a/packages/edit-navigation/src/components/menu-editor/style.scss
+++ b/packages/edit-navigation/src/components/menu-editor/style.scss
@@ -1,8 +1,5 @@
 .edit-navigation-menu-editor {
-	border: 1px solid #000;
-}
-
-.edit-navigation-menu-editor__panel {
-	border: 1px solid #000;
-	padding: 10px;
+	display: grid;
+	grid-template-columns: 1fr 2fr;
+	grid-column-gap: 10px;
 }

--- a/packages/edit-navigation/src/components/menus-editor/index.js
+++ b/packages/edit-navigation/src/components/menus-editor/index.js
@@ -3,7 +3,7 @@
  */
 import { useSelect } from '@wordpress/data';
 import { useState, useEffect } from '@wordpress/element';
-import { Spinner, SelectControl } from '@wordpress/components';
+import { Card, CardBody, Spinner, SelectControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -28,14 +28,21 @@ export default function MenusEditor( { blockEditorSettings } ) {
 
 	return (
 		<>
-			<SelectControl
-				label={ __( 'Select navigation to edit:' ) }
-				options={ menus.map( ( menu ) => ( {
-					value: menu.id,
-					label: menu.name,
-				} ) ) }
-				onChange={ ( selectedMenuId ) => setMenuId( selectedMenuId ) }
-			/>
+			<Card className="edit-navigation-menus-editor__menu-selection-card">
+				<CardBody>
+					<SelectControl
+						className="edit-navigation-menus-editor__menu-select-control"
+						label={ __( 'Select navigation to edit:' ) }
+						options={ menus.map( ( menu ) => ( {
+							value: menu.id,
+							label: menu.name,
+						} ) ) }
+						onChange={ ( selectedMenuId ) =>
+							setMenuId( selectedMenuId )
+						}
+					/>
+				</CardBody>
+			</Card>
 			{ !! menuId && (
 				<MenuEditor
 					menuId={ menuId }

--- a/packages/edit-navigation/src/components/menus-editor/style.scss
+++ b/packages/edit-navigation/src/components/menus-editor/style.scss
@@ -1,0 +1,16 @@
+.edit-navigation-menus-editor__menu-selection-card {
+	margin-bottom: 10px;
+}
+
+.edit-navigation-menus-editor__menu-select-control {
+	.components-base-control__field {
+		display: flex;
+		flex-direction: row;
+		align-items: baseline;
+		margin-bottom: 0;
+	}
+
+	.components-base-control__label {
+		margin-right: 1ch;
+	}
+}

--- a/packages/edit-navigation/src/style.scss
+++ b/packages/edit-navigation/src/style.scss
@@ -1,1 +1,3 @@
+@import "./components/layout/style.scss";
 @import "./components/menu-editor/style.scss";
+@import "./components/menus-editor/style.scss";


### PR DESCRIPTION
## Description
Closes #21284

I've implemented this using `@wordpress/components` components, some of which look different from #21284, just because of the styles of the components.

We'd have to decide if we want to create variations of the styles those components offer or just stick with the out of the box styles.

There's also a question over whether some of the layout makes semantic sense. E.g. a Save Button in a Panel title.

These things can be iterated on. 

## How has this been tested?
1. Visit the Navigation Menu page.
2. Observe the styled page.

## Screenshots <!-- if applicable -->
<img width="860" alt="Screenshot 2020-04-01 at 4 48 25 pm" src="https://user-images.githubusercontent.com/677833/78117773-a6951480-7438-11ea-95a5-c03fe77ea9e7.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
