### PR TITLE
Fix block duplication using keyboard shortcut

### DIFF
--- a/packages/block-editor/src/components/block-list/use-multi-selection.js
+++ b/packages/block-editor/src/components/block-list/use-multi-selection.js
@@ -105,8 +105,9 @@ export default function useMultiSelection( ref ) {
 				);
 
 				if (
-					! blockNode.contains( startContainer ) ||
-					! blockNode.contains( endContainer )
+					!! blockNode &&
+					( ! blockNode.contains( startContainer ) ||
+						! blockNode.contains( endContainer ) )
 				) {
 					selection.removeAllRanges();
 				}

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/duplicating-blocks.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/duplicating-blocks.test.js.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Duplicating blocks should duplicate blocks using the block settings menu 1`] = `
+"<!-- wp:paragraph -->
+<p>Clone me</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Clone me</p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`Duplicating blocks should duplicate blocks using the keyboard shortcut 1`] = `
+"<!-- wp:paragraph -->
+<p>Clone me</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Clone me</p>
+<!-- /wp:paragraph -->"
+`;

--- a/packages/e2e-tests/specs/editor/various/duplicating-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/duplicating-blocks.test.js
@@ -1,0 +1,49 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	createNewPost,
+	insertBlock,
+	getEditedPostContent,
+	clickBlockToolbarButton,
+	pressKeyWithModifier,
+} from '@wordpress/e2e-test-utils';
+
+describe( 'Duplicating blocks', () => {
+	beforeEach( async () => {
+		await createNewPost();
+	} );
+
+	it( 'should duplicate blocks using the block settings menu', async () => {
+		await insertBlock( 'Paragraph' );
+		await page.keyboard.type( 'Clone me' );
+
+		// Select the test we just typed
+		// This doesn't do anything but we previously had a duplicationi bug
+		// When the selection was not collapsed
+		await pressKeyWithModifier( 'primary', 'a' );
+
+		await clickBlockToolbarButton( 'More options' );
+		const duplicateButton = await page.waitForXPath(
+			'//button[text()="Duplicate"]'
+		);
+		await duplicateButton.click();
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'should duplicate blocks using the keyboard shortcut', async () => {
+		await insertBlock( 'Paragraph' );
+		await page.keyboard.type( 'Clone me' );
+
+		// Select the test we just typed
+		// This doesn't do anything but we previously had a duplicationi bug
+		// When the selection was not collapsed
+		await pressKeyWithModifier( 'primary', 'a' );
+
+		// Duplicate using the keyboard shortccut
+		await pressKeyWithModifier( 'primaryShift', 'd' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+} );


### PR DESCRIPTION
closes #21307

**Testing instructions**

 - Select some text in a paragraph block
 - Press "command + shift + enter" 
 - The block should be duplicated properly.