### PR TITLE
[RNMobile] remove additional padding from first paragraph block

### DIFF
--- a/packages/block-editor/src/components/default-block-appender/index.native.js
+++ b/packages/block-editor/src/components/default-block-appender/index.native.js
@@ -39,7 +39,10 @@ export function DefaultBlockAppender( {
 	return (
 		<TouchableWithoutFeedback onPress={ onAppend }>
 			<View
-				style={ [ styles.blockHolder, containerStyle ] }
+				style={ [
+					styles.blockHolder,
+					showSeparator && containerStyle,
+				] }
 				pointerEvents="box-only"
 			>
 				{ showSeparator ? (

--- a/packages/edit-post/src/components/visual-editor/style.native.scss
+++ b/packages/edit-post/src/components/visual-editor/style.native.scss
@@ -5,8 +5,6 @@
 	border-right-width: $block-selected-border-width;
 	border-radius: 4px;
 	border-style: solid;
-	margin-left: $block-selected-margin;
-	margin-right: $block-selected-margin;
 }
 
 .blockHolderFocused {


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
PR brings fix to avoid extra space in first `Paragraph` block after open new post.
I have also noticed that additional `3px` margin is not necessary in `Post Title` and remove it as well

Please also refer to:
[Related gutenberg-mobile PR](https://github.com/wordpress-mobile/gutenberg-mobile/pull/2095)
[Related gutenberg-mobile issue](https://github.com/wordpress-mobile/gutenberg-mobile/issues/2077)

**To Reproduce**
Steps to reproduce the behaviour:

1. Start a brand new post
2. See the empty paragraph block placeholder text has too much padding.

**Expected behaviour:**
The placeholder text should be aligned to the same `16px` key line as other blocks.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

1. Create new post
2. See if additional space do not appear on first `Paragraph` block

## Screenshots <!-- if applicable -->

**BEFORE / AFTER:**

<img width="250" src="https://user-images.githubusercontent.com/21242757/78144201-96c50280-742f-11ea-878e-0e00588e5167.png"><img width="250" src="https://user-images.githubusercontent.com/21242757/78144271-acd2c300-742f-11ea-8783-e2a814ad21c6.png">

<img width="250" src="https://user-images.githubusercontent.com/21242757/78144294-b78d5800-742f-11ea-92ed-9a8078f63a9c.png"><img width="250" src="https://user-images.githubusercontent.com/21242757/78144356-c8d66480-742f-11ea-8b60-7f9c6684b3b7.png">

<img width="250" src="https://user-images.githubusercontent.com/21242757/78144317-bceaa280-742f-11ea-89b4-10f4bcd55a90.png"><img width="235" src="https://user-images.githubusercontent.com/21242757/78144337-c4aa4700-742f-11ea-83c4-866ce3a4dd26.png">


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Bug fix:
- remove extra padding from first `Paragraph` block after open new post
- remove additional padding from post title

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
