### PR TITLE
Fix the TS used for the GB-Mobile project.

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -31,7 +31,7 @@
 		"esModuleInterop": false,
 		"resolveJsonModule": true,
 
-		"typeRoots":["./node_modules/@types"]
+		"typeRoots": [ "./node_modules/@types" ]
 	},
 	"exclude": [ "**/benchmark", "**/test/**", "**/build/**", "**/build-*/**" ]
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -31,7 +31,7 @@
 		"esModuleInterop": false,
 		"resolveJsonModule": true,
 
-		"types": [ "node" ]
+		"typeRoots": [ "./node_modules/@types" ]
 	},
 	"exclude": [ "**/benchmark", "**/test/**", "**/build/**", "**/build-*/**" ]
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -31,7 +31,7 @@
 		"esModuleInterop": false,
 		"resolveJsonModule": true,
 
-		"typeRoots": [ "./node_modules/@types" ]
+		"types": [ "node" ]
 	},
 	"exclude": [ "**/benchmark", "**/test/**", "**/build/**", "**/build-*/**" ]
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -29,7 +29,9 @@
 
 		/* This needs to be false so our types are possible to consume without setting this */
 		"esModuleInterop": false,
-		"resolveJsonModule": true
+		"resolveJsonModule": true,
+
+		"typeRoots":["./node_modules/@types"]
 	},
 	"exclude": [ "**/benchmark", "**/test/**", "**/build/**", "**/build-*/**" ]
 }


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

Make sure only types inside node_modules/@types are used.

This avoids TS to find the ../node_modules/@types inside the gb-mobile
repo that lives one path level up of gutenberg root.


@sirreal does this have impact on the Gutenberg TS checks?

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
