### PR TITLE
Fix editor shortcuts in Nav Menus page.

### DIFF
--- a/packages/edit-navigation/src/components/menu-editor/index.js
+++ b/packages/edit-navigation/src/components/menu-editor/index.js
@@ -33,6 +33,7 @@ export default function MenuEditor( { menuId, blockEditorSettings } ) {
 					templateLock: 'all',
 				} }
 			>
+				<BlockEditorKeyboardShortcuts />
 				<Panel className="edit-navigation-menu-editor__panel">
 					<PanelBody title={ __( 'Navigation structure' ) }>
 						{ !! blocks.length && (


### PR DESCRIPTION
## Description
Renders the `BlockEditorKeyboardShortcuts` component to ensure editor keyboard shortcuts work in the nav menus page.

## How has this been tested?
1. Navigate to the nav menu page
2. Select a navigation link block
3. Try using the duplicate or delete shortcuts (see the block more menu for the shortcuts)
4. The shortcuts should work

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
