### PR TITLE
Update doc for Windows crlf problem.

### DIFF
--- a/docs/contributors/getting-started.md
+++ b/docs/contributors/getting-started.md
@@ -95,6 +95,14 @@ With the extension installed, ESLint will use the [.eslintrc.js](https://github.
     },
 ```
 
+**Note for Windows users:** In some environments, you'll find a lot of eslint errors even after fresh cloning repo. In many cases, it's because of the line endings. Gutenberg uses `lf`, not `crlf`, Windows default. In this case, you need to:
+
+1. turn off autocrlf option by executing `git config --global core.autocrlf false` on your command prompt.
+2. delete the entire Gutenberg repo and clone it again.
+3. check if files are correctly cloned in `lf` ([how to know it with vscode](https://stackoverflow.com/a/39532890))
+
+If the files in your local repo still uses `crlf`, then check [this StackOverflow answer](https://stackoverflow.com/a/13154031).
+
 ### Prettier
 
 [Prettier](https://prettier.io/) is a tool that allows you to define an opinionated format, and automate fixing the code to match that format. Prettier and ESlint are similar, Prettier is more about formatting and style, while ESlint is for detecting coding errors.

--- a/docs/contributors/getting-started.md
+++ b/docs/contributors/getting-started.md
@@ -95,13 +95,13 @@ With the extension installed, ESLint will use the [.eslintrc.js](https://github.
     },
 ```
 
-**Note for Windows users:** In some environments, you'll find a lot of eslint errors even after fresh cloning repo. In many cases, it's because of the line endings. Gutenberg uses `lf`, not `crlf`, Windows default. In this case, you need to:
+**Note for Windows users:** In some environments, you'll find a lot of ESLint errors even after a fresh clone of the repository. In many cases, it's because of file line endings. Gutenberg uses `lf`, not `crlf` (the Windows default). In this case, you need to:
 
-1. turn off autocrlf option by executing `git config --global core.autocrlf false` on your command prompt.
-2. delete the entire Gutenberg repo and clone it again.
-3. check if files are correctly cloned in `lf` ([how to know it with vscode](https://stackoverflow.com/a/39532890))
+1. Turn off the autocrlf option by executing `git config --global core.autocrlf false` on your command prompt.
+2. Delete the entire Gutenberg repo and clone it again.
+3. Check to see if files are correctly cloned in `lf` ([VSCode instructions](https://stackoverflow.com/a/39532890))
 
-If the files in your local repo still uses `crlf`, then check [this StackOverflow answer](https://stackoverflow.com/a/13154031).
+If the files in your local repo still uses `crlf`, then check [this StackOverflow answer](https://stackoverflow.com/a/13154031) for an alternative solution.
 
 ### Prettier
 


### PR DESCRIPTION
* Closes #7611

## Description

In some Windows environments, git automatically changes `lf` line endings to `crlf`. This causes a lot of unnecessary errors on Windows like below:

![image](https://user-images.githubusercontent.com/8130013/78205084-42289280-74d6-11ea-947f-e55fcf7c768d.png)


This update guides first-time contributors on Windows to avoid this situation.

## How has this been tested?

N/A

## Screenshots <!-- if applicable -->

N/A

## Types of changes

Bug fix

## Checklist:
- [N/A] My code is tested.
- [N/A] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [N/A] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [N/A] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [N/A] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [N/A] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
