### PR TITLE
Try a fixed toolbar in the navigation page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11113,6 +11113,7 @@
 				"@wordpress/keyboard-shortcuts": "file:packages/keyboard-shortcuts",
 				"@wordpress/media-utils": "file:packages/media-utils",
 				"@wordpress/notices": "file:packages/notices",
+				"classnames": "^2.2.5",
 				"lodash": "^4.17.15",
 				"rememo": "^3.0.0"
 			}

--- a/packages/edit-navigation/package.json
+++ b/packages/edit-navigation/package.json
@@ -36,6 +36,7 @@
 		"@wordpress/keyboard-shortcuts": "file:../keyboard-shortcuts",
 		"@wordpress/media-utils": "file:../media-utils",
 		"@wordpress/notices": "file:../notices",
+		"classnames": "^2.2.5",
 		"lodash": "^4.17.15",
 		"rememo": "^3.0.0"
 	},

--- a/packages/edit-navigation/src/components/layout/index.js
+++ b/packages/edit-navigation/src/components/layout/index.js
@@ -23,7 +23,6 @@ export default function Layout( { blockEditorSettings } ) {
 				<DropZoneProvider>
 					<FocusReturnProvider>
 						{ /* <Notices /> */ }
-						<Popover.Slot name="block-toolbar" />
 						<TabPanel
 							className="edit-navigation-layout__tab-panel"
 							tabs={ [

--- a/packages/edit-navigation/src/components/menu-editor/block-editor-panel.js
+++ b/packages/edit-navigation/src/components/menu-editor/block-editor-panel.js
@@ -1,0 +1,51 @@
+/**
+ * WordPress dependencies
+ */
+import { useDispatch } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
+
+import {
+	BlockList,
+	BlockToolbar,
+	NavigableToolbar,
+	ObserveTyping,
+	WritingFlow,
+} from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
+import { Button, Panel, PanelBody } from '@wordpress/components';
+
+export default function BlockEditorPanel( { menuId, saveBlocks } ) {
+	const { clearSelectedBlock } = useDispatch( 'core/block-editor' );
+
+	// Clear the selected block when the menu is changed.
+	// Block selection isn't cleared implicity by the block-editor store.
+	// Dispatching this action fixes an issue where the toolbar
+	// for a block continues to be displayed after it no longer exists.
+	useEffect( () => {
+		clearSelectedBlock();
+	}, [ menuId ] );
+
+	return (
+		<Panel
+			header={
+				<Button isPrimary onClick={ saveBlocks }>
+					{ __( 'Save navigation' ) }
+				</Button>
+			}
+		>
+			<PanelBody title={ __( 'Navigation menu' ) }>
+				<NavigableToolbar
+					className="edit-navigation-menu-editor__block-editor-toolbar"
+					aria-label={ __( 'Block tools' ) }
+				>
+					<BlockToolbar hideDragHandle />
+				</NavigableToolbar>
+				<WritingFlow>
+					<ObserveTyping>
+						<BlockList />
+					</ObserveTyping>
+				</WritingFlow>
+			</PanelBody>
+		</Panel>
+	);
+}

--- a/packages/edit-navigation/src/components/menu-editor/block-editor-panel.js
+++ b/packages/edit-navigation/src/components/menu-editor/block-editor-panel.js
@@ -12,7 +12,7 @@ import {
 	WritingFlow,
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
-import { Button, Panel, PanelBody } from '@wordpress/components';
+import { Button, Panel, PanelBody, Popover } from '@wordpress/components';
 
 export default function BlockEditorPanel( { menuId, saveBlocks } ) {
 	const { clearSelectedBlock } = useDispatch( 'core/block-editor' );
@@ -40,6 +40,7 @@ export default function BlockEditorPanel( { menuId, saveBlocks } ) {
 				>
 					<BlockToolbar hideDragHandle />
 				</NavigableToolbar>
+				<Popover.Slot name="block-toolbar" />
 				<WritingFlow>
 					<ObserveTyping>
 						<BlockList />

--- a/packages/edit-navigation/src/components/menu-editor/block-editor-panel.js
+++ b/packages/edit-navigation/src/components/menu-editor/block-editor-panel.js
@@ -1,7 +1,12 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
 
 import {
@@ -16,6 +21,10 @@ import { Button, Panel, PanelBody, Popover } from '@wordpress/components';
 
 export default function BlockEditorPanel( { menuId, saveBlocks } ) {
 	const { clearSelectedBlock } = useDispatch( 'core/block-editor' );
+	const isNavigationModeActive = useSelect(
+		( select ) => select( 'core/block-editor' ).isNavigationMode(),
+		[]
+	);
 
 	// Clear the selected block when the menu is changed.
 	// Block selection isn't cleared implicity by the block-editor store.
@@ -35,7 +44,12 @@ export default function BlockEditorPanel( { menuId, saveBlocks } ) {
 		>
 			<PanelBody title={ __( 'Navigation menu' ) }>
 				<NavigableToolbar
-					className="edit-navigation-menu-editor__block-editor-toolbar"
+					className={ classnames(
+						'edit-navigation-menu-editor__block-editor-toolbar',
+						{
+							'is-hidden': isNavigationModeActive,
+						}
+					) }
 					aria-label={ __( 'Block tools' ) }
 				>
 					<BlockToolbar hideDragHandle />

--- a/packages/edit-navigation/src/components/menu-editor/block-editor-panel.js
+++ b/packages/edit-navigation/src/components/menu-editor/block-editor-panel.js
@@ -6,9 +6,6 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { useDispatch, useSelect } from '@wordpress/data';
-import { useEffect } from '@wordpress/element';
-
 import {
 	BlockList,
 	BlockToolbar,
@@ -16,23 +13,24 @@ import {
 	ObserveTyping,
 	WritingFlow,
 } from '@wordpress/block-editor';
-import { __ } from '@wordpress/i18n';
 import { Button, Panel, PanelBody, Popover } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
 
-export default function BlockEditorPanel( { menuId, saveBlocks } ) {
-	const { clearSelectedBlock } = useDispatch( 'core/block-editor' );
-	const isNavigationModeActive = useSelect(
-		( select ) => select( 'core/block-editor' ).isNavigationMode(),
+export default function BlockEditorPanel( { saveBlocks } ) {
+	const { isNavigationModeActive, hasSelectedBlock } = useSelect(
+		( select ) => {
+			const { isNavigationMode, getSelectedBlock } = select(
+				'core/block-editor'
+			);
+
+			return {
+				isNavigationModeActive: isNavigationMode(),
+				hasSelectedBlock: !! getSelectedBlock(),
+			};
+		},
 		[]
 	);
-
-	// Clear the selected block when the menu is changed.
-	// Block selection isn't cleared implicity by the block-editor store.
-	// Dispatching this action fixes an issue where the toolbar
-	// for a block continues to be displayed after it no longer exists.
-	useEffect( () => {
-		clearSelectedBlock();
-	}, [ menuId ] );
 
 	return (
 		<Panel
@@ -52,7 +50,7 @@ export default function BlockEditorPanel( { menuId, saveBlocks } ) {
 					) }
 					aria-label={ __( 'Block tools' ) }
 				>
-					<BlockToolbar hideDragHandle />
+					{ hasSelectedBlock && <BlockToolbar hideDragHandle /> }
 				</NavigableToolbar>
 				<Popover.Slot name="block-toolbar" />
 				<WritingFlow>

--- a/packages/edit-navigation/src/components/menu-editor/block-editor-panel.js
+++ b/packages/edit-navigation/src/components/menu-editor/block-editor-panel.js
@@ -20,13 +20,19 @@ import { __ } from '@wordpress/i18n';
 export default function BlockEditorPanel( { saveBlocks } ) {
 	const { isNavigationModeActive, hasSelectedBlock } = useSelect(
 		( select ) => {
-			const { isNavigationMode, getSelectedBlock } = select(
-				'core/block-editor'
-			);
+			const {
+				isNavigationMode,
+				getBlockSelectionStart,
+				getBlock,
+			} = select( 'core/block-editor' );
+
+			const selectionStartClientId = getBlockSelectionStart();
 
 			return {
 				isNavigationModeActive: isNavigationMode(),
-				hasSelectedBlock: !! getSelectedBlock(),
+				hasSelectedBlock:
+					!! selectionStartClientId &&
+					!! getBlock( selectionStartClientId ),
 			};
 		},
 		[]

--- a/packages/edit-navigation/src/components/menu-editor/index.js
+++ b/packages/edit-navigation/src/components/menu-editor/index.js
@@ -4,26 +4,18 @@
 import {
 	BlockEditorKeyboardShortcuts,
 	BlockEditorProvider,
-	BlockList,
-	BlockToolbar,
-	NavigableToolbar,
-	ObserveTyping,
-	WritingFlow,
-	__experimentalBlockNavigationList,
 } from '@wordpress/block-editor';
-import { __ } from '@wordpress/i18n';
-import { useViewportMatch } from '@wordpress/compose';
-import { Button, Panel, PanelBody } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import useNavigationBlocks from './use-navigation-blocks';
 import MenuEditorShortcuts from './shortcuts';
+import BlockEditorPanel from './block-editor-panel';
+import NavigationStructurePanel from './navigation-structure-panel';
 
 export default function MenuEditor( { menuId, blockEditorSettings } ) {
 	const [ blocks, setBlocks, saveBlocks ] = useNavigationBlocks( menuId );
-	const isLargeViewport = useViewportMatch( 'medium' );
 
 	return (
 		<div className="edit-navigation-menu-editor">
@@ -42,43 +34,8 @@ export default function MenuEditor( { menuId, blockEditorSettings } ) {
 			>
 				<BlockEditorKeyboardShortcuts />
 				<MenuEditorShortcuts saveBlocks={ saveBlocks } />
-				<Panel>
-					<PanelBody
-						title={ __( 'Navigation structure' ) }
-						initialOpen={ isLargeViewport }
-					>
-						{ !! blocks.length && (
-							<__experimentalBlockNavigationList
-								blocks={ blocks }
-								selectedBlockClientId={ blocks[ 0 ].clientId }
-								selectBlock={ () => {} }
-								showNestedBlocks
-								showAppender
-							/>
-						) }
-					</PanelBody>
-				</Panel>
-				<Panel
-					header={
-						<Button isPrimary onClick={ saveBlocks }>
-							{ __( 'Save navigation' ) }
-						</Button>
-					}
-				>
-					<PanelBody title={ __( 'Navigation menu' ) }>
-						<NavigableToolbar
-							className="edit-navigation-menu-editor__toolbar"
-							aria-label={ __( 'Block tools' ) }
-						>
-							<BlockToolbar hideDragHandle />
-						</NavigableToolbar>
-						<WritingFlow>
-							<ObserveTyping>
-								<BlockList />
-							</ObserveTyping>
-						</WritingFlow>
-					</PanelBody>
-				</Panel>
+				<NavigationStructurePanel blocks={ blocks } />
+				<BlockEditorPanel menuId={ menuId } saveBlocks={ saveBlocks } />
 			</BlockEditorProvider>
 		</div>
 	);

--- a/packages/edit-navigation/src/components/menu-editor/index.js
+++ b/packages/edit-navigation/src/components/menu-editor/index.js
@@ -5,13 +5,15 @@ import {
 	BlockEditorKeyboardShortcuts,
 	BlockEditorProvider,
 	BlockList,
+	BlockToolbar,
+	NavigableToolbar,
 	ObserveTyping,
 	WritingFlow,
 	__experimentalBlockNavigationList,
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import { useViewportMatch } from '@wordpress/compose';
-import { Button, Panel, PanelBody, Popover } from '@wordpress/components';
+import { Button, Panel, PanelBody } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -35,11 +37,12 @@ export default function MenuEditor( { menuId, blockEditorSettings } ) {
 				settings={ {
 					...blockEditorSettings,
 					templateLock: 'all',
+					hasFixedToolbar: true,
 				} }
 			>
 				<BlockEditorKeyboardShortcuts />
 				<MenuEditorShortcuts saveBlocks={ saveBlocks } />
-				<Panel className="edit-navigation-menu-editor__panel">
+				<Panel>
 					<PanelBody
 						title={ __( 'Navigation structure' ) }
 						initialOpen={ isLargeViewport }
@@ -61,10 +64,14 @@ export default function MenuEditor( { menuId, blockEditorSettings } ) {
 							{ __( 'Save navigation' ) }
 						</Button>
 					}
-					className="edit-navigation-menu-editor__panel"
 				>
 					<PanelBody title={ __( 'Navigation menu' ) }>
-						<Popover.Slot name="block-toolbar" />
+						<NavigableToolbar
+							className="edit-navigation-menu-editor__toolbar"
+							aria-label={ __( 'Block tools' ) }
+						>
+							<BlockToolbar hideDragHandle />
+						</NavigableToolbar>
 						<WritingFlow>
 							<ObserveTyping>
 								<BlockList />

--- a/packages/edit-navigation/src/components/menu-editor/index.js
+++ b/packages/edit-navigation/src/components/menu-editor/index.js
@@ -5,6 +5,7 @@ import {
 	BlockEditorKeyboardShortcuts,
 	BlockEditorProvider,
 } from '@wordpress/block-editor';
+import { useViewportMatch } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -16,6 +17,7 @@ import NavigationStructurePanel from './navigation-structure-panel';
 
 export default function MenuEditor( { menuId, blockEditorSettings } ) {
 	const [ blocks, setBlocks, saveBlocks ] = useNavigationBlocks( menuId );
+	const isLargeViewport = useViewportMatch( 'medium' );
 
 	return (
 		<div className="edit-navigation-menu-editor">
@@ -34,7 +36,10 @@ export default function MenuEditor( { menuId, blockEditorSettings } ) {
 			>
 				<BlockEditorKeyboardShortcuts />
 				<MenuEditorShortcuts saveBlocks={ saveBlocks } />
-				<NavigationStructurePanel blocks={ blocks } />
+				<NavigationStructurePanel
+					blocks={ blocks }
+					initialOpen={ isLargeViewport }
+				/>
 				<BlockEditorPanel menuId={ menuId } saveBlocks={ saveBlocks } />
 			</BlockEditorProvider>
 		</div>

--- a/packages/edit-navigation/src/components/menu-editor/index.js
+++ b/packages/edit-navigation/src/components/menu-editor/index.js
@@ -10,8 +10,8 @@ import {
 	__experimentalBlockNavigationList,
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
-import { Panel, PanelBody, Button } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
+import { Button, Panel, PanelBody, Popover } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -64,6 +64,7 @@ export default function MenuEditor( { menuId, blockEditorSettings } ) {
 					className="edit-navigation-menu-editor__panel"
 				>
 					<PanelBody title={ __( 'Navigation menu' ) }>
+						<Popover.Slot name="block-toolbar" />
 						<WritingFlow>
 							<ObserveTyping>
 								<BlockList />

--- a/packages/edit-navigation/src/components/menu-editor/index.js
+++ b/packages/edit-navigation/src/components/menu-editor/index.js
@@ -40,7 +40,7 @@ export default function MenuEditor( { menuId, blockEditorSettings } ) {
 					blocks={ blocks }
 					initialOpen={ isLargeViewport }
 				/>
-				<BlockEditorPanel menuId={ menuId } saveBlocks={ saveBlocks } />
+				<BlockEditorPanel saveBlocks={ saveBlocks } />
 			</BlockEditorProvider>
 		</div>
 	);

--- a/packages/edit-navigation/src/components/menu-editor/navigation-structure-panel.js
+++ b/packages/edit-navigation/src/components/menu-editor/navigation-structure-panel.js
@@ -3,17 +3,14 @@
  */
 import { __experimentalBlockNavigationList } from '@wordpress/block-editor';
 import { Panel, PanelBody } from '@wordpress/components';
-import { useViewportMatch } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 
-export default function NavigationStructurePanel( { blocks } ) {
-	const isLargeViewport = useViewportMatch( 'medium' );
-
+export default function NavigationStructurePanel( { blocks, initialOpen } ) {
 	return (
 		<Panel>
 			<PanelBody
 				title={ __( 'Navigation structure' ) }
-				initialOpen={ isLargeViewport }
+				initialOpen={ initialOpen }
 			>
 				{ !! blocks.length && (
 					<__experimentalBlockNavigationList

--- a/packages/edit-navigation/src/components/menu-editor/navigation-structure-panel.js
+++ b/packages/edit-navigation/src/components/menu-editor/navigation-structure-panel.js
@@ -1,0 +1,30 @@
+/**
+ * WordPress dependencies
+ */
+import { __experimentalBlockNavigationList } from '@wordpress/block-editor';
+import { Panel, PanelBody } from '@wordpress/components';
+import { useViewportMatch } from '@wordpress/compose';
+import { __ } from '@wordpress/i18n';
+
+export default function NavigationStructurePanel( { blocks } ) {
+	const isLargeViewport = useViewportMatch( 'medium' );
+
+	return (
+		<Panel>
+			<PanelBody
+				title={ __( 'Navigation structure' ) }
+				initialOpen={ isLargeViewport }
+			>
+				{ !! blocks.length && (
+					<__experimentalBlockNavigationList
+						blocks={ blocks }
+						selectedBlockClientId={ blocks[ 0 ].clientId }
+						selectBlock={ () => {} }
+						showNestedBlocks
+						showAppender
+					/>
+				) }
+			</PanelBody>
+		</Panel>
+	);
+}

--- a/packages/edit-navigation/src/components/menu-editor/style.scss
+++ b/packages/edit-navigation/src/components/menu-editor/style.scss
@@ -5,4 +5,23 @@
 	@include break-medium {
 		grid-template-columns: 280px 1fr;
 	}
+
+	// Make the block list take up the full width of the panel.
+	.block-editor-block-list__layout.is-root-container {
+		padding: 0;
+	}
+}
+	
+.edit-navigation-menu-editor__toolbar {
+	height: 46px;
+	margin-bottom: 16px;
+	border: 1px solid #e2e4e7;
+
+	// Buttons in a fixed top toolbar seem to need their styles overriden.
+	.components-button {
+		height: 48px;
+		min-width: 42px;
+		padding-left: 11px;
+		padding-right: 6px;
+	}
 }

--- a/packages/edit-navigation/src/components/menu-editor/style.scss
+++ b/packages/edit-navigation/src/components/menu-editor/style.scss
@@ -11,8 +11,8 @@
 		padding: 0;
 	}
 }
-	
-.edit-navigation-menu-editor__toolbar {
+
+.edit-navigation-menu-editor__block-editor-toolbar {
 	height: 46px;
 	margin-bottom: 16px;
 	border: 1px solid #e2e4e7;

--- a/packages/edit-navigation/src/components/menu-editor/style.scss
+++ b/packages/edit-navigation/src/components/menu-editor/style.scss
@@ -14,7 +14,7 @@
 
 .edit-navigation-menu-editor__block-editor-toolbar {
 	height: 46px;
-	margin-bottom: 16px;
+	margin-bottom: 12px;
 	border: 1px solid #e2e4e7;
 
 	// Borders around toolbar segments.
@@ -33,5 +33,16 @@
 
 		// Add a border after item groups to show as separator in the block toolbar.
 		border-right: $border-width solid $light-gray-500;
+	}
+
+
+	// When entering navigation mode, hide the toolbar, but do so in a way where the
+	// outer container retains its height to avoid the blocks moving upwards.
+	&.is-hidden {
+		border-color: transparent;
+
+		.block-editor-block-toolbar {
+			display: none;
+		}
 	}
 }

--- a/packages/edit-navigation/src/components/menu-editor/style.scss
+++ b/packages/edit-navigation/src/components/menu-editor/style.scss
@@ -17,11 +17,21 @@
 	margin-bottom: 16px;
 	border: 1px solid #e2e4e7;
 
-	// Buttons in a fixed top toolbar seem to need their styles overriden.
-	.components-button {
-		height: 48px;
-		min-width: 42px;
-		padding-left: 11px;
-		padding-right: 6px;
+	// Borders around toolbar segments.
+	.components-toolbar {
+		background: none;
+		// IE11 has thick paddings without this.
+		line-height: 0;
+
+		// These margins make the buttons themselves overlap the chrome of the toolbar.
+		// This helps make them square, and maximize the hit area.
+		margin-top: -$border-width;
+		margin-bottom: -$border-width;
+
+		// The component is born with a border, but we only need some of them.
+		border: 0;
+
+		// Add a border after item groups to show as separator in the block toolbar.
+		border-right: $border-width solid $light-gray-500;
 	}
 }


### PR DESCRIPTION
## Description
There are a couple of issues with the toolbar in the navigation page at the moment:
- The tab order is incorrect, the toolbar can't be tabbed to from the block (this is a pretty easy fix, the slot that renders the toolbar needs to be moved to a more appropriate place).
- The toolbar overlaps the top of the panel. While we can make space for it, it looks unusual having empty space when the toolbar hides when typing.

This PR tries using a fixed top toolbar to solve those issues. This toolbar might also become useful for other functionality (undo, redo) on this page in the future.

The negatives of this are that if someone is creating a long nav menu they might have to scroll up to access the toolbar. The empty menu also looks unusual when no block is selected.

## How has this been tested?
1. Open the nav menu page
2. Try editing a nav block
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->
#### Before
<img width="918" alt="Screenshot 2020-04-02 at 10 47 11 am" src="https://user-images.githubusercontent.com/677833/78205760-9714da80-74cf-11ea-80f7-467903f36a37.png">

#### Initially I tried adding some empty space for the toolbar, but it results in this empty space when typing
<img width="913" alt="Screenshot 2020-04-02 at 10 47 47 am" src="https://user-images.githubusercontent.com/677833/78205737-88c6be80-74cf-11ea-882f-da6fbb5c7901.png">

#### This PR, using a fixed toolbar, it doesn't hide when typing (but is empty when no block is selected)
<img width="921" alt="Screenshot 2020-04-02 at 10 38 58 am" src="https://user-images.githubusercontent.com/677833/78205778-a1cf6f80-74cf-11ea-81ca-3af39d67b5f4.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
