### PR TITLE
Add save shortcut for navigation menu screen

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10959,6 +10959,7 @@
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/hooks": "file:packages/hooks",
 				"@wordpress/i18n": "file:packages/i18n",
+				"@wordpress/keyboard-shortcuts": "file:packages/keyboard-shortcuts",
 				"@wordpress/media-utils": "file:packages/media-utils",
 				"@wordpress/notices": "file:packages/notices",
 				"lodash": "^4.17.15",

--- a/packages/edit-navigation/package.json
+++ b/packages/edit-navigation/package.json
@@ -33,6 +33,7 @@
 		"@wordpress/element": "file:../element",
 		"@wordpress/hooks": "file:../hooks",
 		"@wordpress/i18n": "file:../i18n",
+		"@wordpress/keyboard-shortcuts": "file:../keyboard-shortcuts",
 		"@wordpress/media-utils": "file:../media-utils",
 		"@wordpress/notices": "file:../notices",
 		"lodash": "^4.17.15",

--- a/packages/edit-navigation/src/components/menu-editor/index.js
+++ b/packages/edit-navigation/src/components/menu-editor/index.js
@@ -16,6 +16,7 @@ import { Panel, PanelBody, Button } from '@wordpress/components';
  * Internal dependencies
  */
 import useNavigationBlocks from './use-navigation-blocks';
+import MenuEditorShortcuts from './shortcuts';
 
 export default function MenuEditor( { menuId, blockEditorSettings } ) {
 	const [ blocks, setBlocks, saveBlocks ] = useNavigationBlocks( menuId );
@@ -23,6 +24,7 @@ export default function MenuEditor( { menuId, blockEditorSettings } ) {
 	return (
 		<div className="edit-navigation-menu-editor">
 			<BlockEditorKeyboardShortcuts.Register />
+			<MenuEditorShortcuts.Register />
 
 			<BlockEditorProvider
 				value={ blocks }
@@ -34,6 +36,7 @@ export default function MenuEditor( { menuId, blockEditorSettings } ) {
 				} }
 			>
 				<BlockEditorKeyboardShortcuts />
+				<MenuEditorShortcuts saveBlocks={ saveBlocks } />
 				<Panel className="edit-navigation-menu-editor__panel">
 					<PanelBody title={ __( 'Navigation structure' ) }>
 						{ !! blocks.length && (

--- a/packages/edit-navigation/src/components/menu-editor/shortcuts.js
+++ b/packages/edit-navigation/src/components/menu-editor/shortcuts.js
@@ -1,0 +1,44 @@
+/**
+ * WordPress dependencies
+ */
+import { useEffect, useCallback } from '@wordpress/element';
+import { useDispatch } from '@wordpress/data';
+import { useShortcut } from '@wordpress/keyboard-shortcuts';
+import { __ } from '@wordpress/i18n';
+
+function MenuEditorShortcuts( { saveBlocks } ) {
+	useShortcut(
+		'core/edit-navigation/save-menu',
+		useCallback( ( event ) => {
+			event.preventDefault();
+			saveBlocks();
+		} ),
+		{
+			bindGlobal: true,
+			preventDefault: true,
+		}
+	);
+
+	return null;
+}
+
+function RegisterMenuEditorShortcuts() {
+	const { registerShortcut } = useDispatch( 'core/keyboard-shortcuts' );
+	useEffect( () => {
+		registerShortcut( {
+			name: 'core/edit-navigation/save-menu',
+			category: 'global',
+			description: __( 'Save the menu currently being edited.' ),
+			keyCombination: {
+				modifier: 'primary',
+				character: 's',
+			},
+		} );
+	}, [ registerShortcut ] );
+
+	return null;
+}
+
+MenuEditorShortcuts.Register = RegisterMenuEditorShortcuts;
+
+export default MenuEditorShortcuts;

--- a/packages/edit-navigation/src/components/menu-editor/shortcuts.js
+++ b/packages/edit-navigation/src/components/menu-editor/shortcuts.js
@@ -15,7 +15,6 @@ function MenuEditorShortcuts( { saveBlocks } ) {
 		} ),
 		{
 			bindGlobal: true,
-			preventDefault: true,
 		}
 	);
 


### PR DESCRIPTION
## Description
Related #21338

Adds a save shortcut for the navigation menu screen.

It does this via a `MenuEditorShortcuts` component that might be useful for registering any other shortcuts.

## How has this been tested?
1. Edit a menu on the Navigation Menu page.
2. Press Cmd+S
3. Reload the page and observe that change is present

Note - when saving there's no success/error notifications. I've created #21344 to track that.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
