### PR TITLE
ESLint Plugin: Continue considering unused variables after encountering exception

### DIFF
--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -32,7 +32,6 @@ const BlockInspector = ( {
 	showNoBlockSelectedMessage = true,
 } ) => {
 	const slot = useSlot( InspectorAdvancedControls.slotName );
-	const hasFills = Boolean( slot.fills && slot.fills.length );
 
 	if ( count > 1 ) {
 		return <MultiSelectionInspector />;
@@ -59,6 +58,8 @@ const BlockInspector = ( {
 		}
 		return null;
 	}
+
+	const hasFills = Boolean( slot.fills && slot.fills.length );
 
 	return (
 		<div className="block-editor-block-inspector">

--- a/packages/block-editor/src/components/line-height-control/index.js
+++ b/packages/block-editor/src/components/line-height-control/index.js
@@ -17,13 +17,13 @@ import {
 } from './utils';
 
 export default function LineHeightControl( { value: lineHeight, onChange } ) {
-	const isDisabled = useIsLineHeightControlsDisabled();
-	const isDefined = isLineHeightDefined( lineHeight );
-
 	// Don't render the controls if disabled by editor settings
+	const isDisabled = useIsLineHeightControlsDisabled();
 	if ( isDisabled ) {
 		return null;
 	}
+
+	const isDefined = isLineHeightDefined( lineHeight );
 
 	const handleOnKeyDown = ( event ) => {
 		const { keyCode } = event;

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -146,11 +146,6 @@ function Navigation( {
 		selectBlock( clientId );
 	}
 
-	const blockClassNames = classnames( className, {
-		[ `items-justified-${ attributes.itemsJustification }` ]: attributes.itemsJustification,
-		[ fontSize.class ]: fontSize.class,
-		'is-vertical': attributes.orientation === 'vertical',
-	} );
 	const blockInlineStyles = {
 		fontSize: fontSize.size ? fontSize.size + 'px' : undefined,
 	};
@@ -194,6 +189,12 @@ function Navigation( {
 			</Block.div>
 		);
 	}
+
+	const blockClassNames = classnames( className, {
+		[ `items-justified-${ attributes.itemsJustification }` ]: attributes.itemsJustification,
+		[ fontSize.class ]: fontSize.class,
+		'is-vertical': attributes.orientation === 'vertical',
+	} );
 
 	// UI State: rendered Block UI
 	return (

--- a/packages/block-library/src/social-link/edit.js
+++ b/packages/block-library/src/social-link/edit.js
@@ -33,7 +33,11 @@ const SocialLinkEdit = ( { attributes, setAttributes, isSelected } ) => {
 		'wp-social-link__is-incomplete': ! url,
 	} );
 
-	// Import icon.
+	// Disable reason: The rule is currently not considering use as JSX tagName.
+	//
+	// See: https://github.com/WordPress/gutenberg/issues/16418
+
+	// eslint-disable-next-line @wordpress/no-unused-vars-before-return
 	const IconComponent = getIconBySite( service );
 	const socialLinkName = getNameBySite( service );
 

--- a/packages/edit-post/src/components/header/mode-switcher/index.js
+++ b/packages/edit-post/src/components/header/mode-switcher/index.js
@@ -42,16 +42,16 @@ function ModeSwitcher() {
 	);
 	const { switchEditorMode } = useDispatch( 'core/edit-post' );
 
+	if ( ! isRichEditingEnabled || ! isCodeEditingEnabled ) {
+		return null;
+	}
+
 	const choices = MODES.map( ( choice ) => {
 		if ( choice.value !== mode ) {
 			return { ...choice, shortcut };
 		}
 		return choice;
 	} );
-
-	if ( ! isRichEditingEnabled || ! isCodeEditingEnabled ) {
-		return null;
-	}
 
 	return (
 		<MenuGroup label={ __( 'Editor' ) }>

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -23,6 +23,7 @@
 ### Bug Fix
 
 - The `@wordpress/valid-sprintf` rule now detects usage of `sprintf` via `i18n.sprintf` (e.g. when using `import * as i18n from '@wordpress/i18n'`).
+- `@wordpress/no-unused-vars-before-return` will correctly consider other unused variables after encountering an instance of an `excludePattern` option exception.
 
 ## 4.0.0 (2020-02-10)
 

--- a/packages/eslint-plugin/rules/__tests__/no-unused-vars-before-return.js
+++ b/packages/eslint-plugin/rules/__tests__/no-unused-vars-before-return.js
@@ -104,5 +104,24 @@ function example() {
 				},
 			],
 		},
+		{
+			code: `
+function example() {
+	const foo = doSomeCostlyOperation();
+	const bar = anotherCostlyOperation( foo );
+	if ( number > 10 ) {
+		return number + 1;
+	}
+
+	return number + foo + bar;
+}`,
+			options: [ { excludePattern: '^do' } ],
+			errors: [
+				{
+					message:
+						'Variables should not be assigned until just prior its first reference. An early return statement may leave this variable unused.',
+				},
+			],
+		},
 	],
 } );

--- a/packages/eslint-plugin/rules/no-unused-vars-before-return.js
+++ b/packages/eslint-plugin/rules/no-unused-vars-before-return.js
@@ -74,7 +74,7 @@ module.exports = {
 							declaratorCandidate.node.init.callee.name
 						)
 					) {
-						return;
+						continue;
 					}
 
 					// The first entry in `references` is the declaration


### PR DESCRIPTION
Previously: #16737

This pull request seeks to fix an issue with the custom ESLint rule `@wordpress/no-unused-vars-before-return`, where an exception identified by the `excludePattern` will cause all other candidate issues to be skipped, therefore allowing errors to be inadvertently introduced. Notably, this would occur in Gutenberg when React hooks are present. And it was more pronounced because React hooks should always occur at the very beginning of a component's render implementation.

**Implementation notes:**

At the most basic, the issue is that a `continue;` should have been used to skip an exception when iterating candidate issues, but a `return;` was used instead, thus aborting checks of all other candidates of the loop.

Fixes to current issues are included in these changes.

**Testing Instructions:**

Ensure unit tests pass:

```
npm run test-unit packages/eslint-plugin/rules/__tests__/no-unused-vars-before-return.js
```

Ensure lint passes:

```
npm run lint-js
```