### PR TITLE
Latest Posts: Fix selected category on existing blocks

### DIFF
--- a/packages/block-library/src/latest-posts/block.json
+++ b/packages/block-library/src/latest-posts/block.json
@@ -10,7 +10,10 @@
 			"type": "string"
 		},
 		"categories": {
-			"type": "array"
+			"type": "array",
+			"items": {
+				"type": "object"
+			}
 		},
 		"postsToShow": {
 			"type": "number",

--- a/packages/block-library/src/latest-posts/deprecated.js
+++ b/packages/block-library/src/latest-posts/deprecated.js
@@ -1,0 +1,31 @@
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+
+const { attributes } = metadata;
+
+export default [
+	{
+		attributes: {
+			...attributes,
+			categories: {
+				type: 'string',
+			},
+		},
+		supports: {
+			align: true,
+			html: false,
+		},
+		migrate: ( oldAttributes ) => {
+			// This needs the full category object, not just the ID.
+			return {
+				...oldAttributes,
+				categories: [ { id: Number( oldAttributes.categories ) } ],
+			};
+		},
+		isEligible: ( { categories } ) =>
+			categories && 'string' === typeof categories,
+		save: () => null,
+	},
+];

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -104,13 +104,6 @@ class LatestPostsEdit extends Component {
 			featuredImageSizeWidth,
 			featuredImageSizeHeight,
 		} = attributes;
-		const suggestions = categoriesList.reduce(
-			( accumulator, category ) => ( {
-				...accumulator,
-				[ category.name ]: category,
-			} ),
-			{}
-		);
 		const categorySuggestions = categoriesList.reduce(
 			( accumulator, category ) => ( {
 				...accumulator,
@@ -120,7 +113,8 @@ class LatestPostsEdit extends Component {
 		);
 		const selectCategories = ( tokens ) => {
 			const hasNoSuggestion = tokens.some(
-				( token ) => typeof token === 'string' && ! suggestions[ token ]
+				( token ) =>
+					typeof token === 'string' && ! categorySuggestions[ token ]
 			);
 			if ( hasNoSuggestion ) {
 				return;
@@ -128,7 +122,9 @@ class LatestPostsEdit extends Component {
 			// Categories that are already will be objects, while new additions will be strings (the name).
 			// allCategories nomalizes the array so that they are all objects.
 			const allCategories = tokens.map( ( token ) => {
-				return typeof token === 'string' ? suggestions[ token ] : token;
+				return typeof token === 'string'
+					? categorySuggestions[ token ]
+					: token;
 			} );
 			// We do nothing if the category is not selected
 			// from suggestions.

--- a/packages/block-library/src/latest-posts/index.js
+++ b/packages/block-library/src/latest-posts/index.js
@@ -7,6 +7,7 @@ import { postList as icon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
+import deprecated from './deprecated';
 import edit from './edit';
 import metadata from './block.json';
 
@@ -23,4 +24,5 @@ export const settings = {
 		html: false,
 	},
 	edit,
+	deprecated,
 };

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -47,7 +47,11 @@ function render_block_core_latest_posts( $attributes ) {
 	add_filter( 'excerpt_length', 'block_core_latest_posts_get_excerpt_length', 20 );
 
 	if ( isset( $attributes['categories'] ) ) {
-		$args['category__in'] = array_column( $attributes['categories'], 'id' );
+		if ( is_array( $attributes['categories'] ) ) {
+			$args['category__in'] = array_column( $attributes['categories'], 'id' );
+		} else {
+			$args['category__in'] = (array) $attributes['categories'];
+		}
 	}
 
 	$recent_posts = get_posts( $args );

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -193,7 +193,7 @@ add_action( 'init', 'register_block_core_latest_posts' );
 function block_core_latest_posts_migrate_categories( $block ) {
 	if (
 		'core/latest-posts' === $block['blockName'] &&
-		isset( $block['attrs']['categories'] ) &&
+		! empty( $block['attrs']['categories'] ) &&
 		is_string( $block['attrs']['categories'] )
 	) {
 		$block['attrs']['categories'] = array(


### PR DESCRIPTION
## Description

Fixes #21357 — The selected category attribute in Latest Posts was changed to an array, but no upgrade path was added for existing blocks. This caused problems on the frontend and in the editor, so this PR attempts to fix those. For the frontend, add an `array` check before using the categories attribute, and handle the non-array case. For the editor, I've added a deprecation that should kick in if categories is a string, which will convert categories into the array-of-objects format it expects.

This migration ideally needs the whole category object, as right now it displays the selected category as an empty token — would appreciate suggestions on this.
![Screen Shot 2020-04-02 at 12 32 46 PM](https://user-images.githubusercontent.com/541093/78275242-54f39500-74df-11ea-8f17-0be61c2a908a.png)

## To test

1. Add a Latest Posts block with GB 7.7.1 or below, then check out & build this branch
2. View your post, it should show only that category of posts
3. Switch to the editor, again it should only show that category of posts in the preview
4. Click the block, and look at the selected categories — it should have a token (though empty now, see above)

## Types of changes

Bug fix (non-breaking change which fixes an issue)
