### PR TITLE
Block Editor: Skip focusTabbable if no active element

### DIFF
--- a/packages/block-editor/src/components/block-list/block-wrapper.js
+++ b/packages/block-editor/src/components/block-list/block-wrapper.js
@@ -98,6 +98,10 @@ const BlockComponent = forwardRef(
 		 * When a block becomes selected, transition focus to an inner tabbable.
 		 */
 		const focusTabbable = () => {
+			if ( ! document.activeElement ) {
+				return;
+			}
+
 			// Focus is captured by the wrapper node, so while focus transition
 			// should only consider tabbables within editable display, since it
 			// may be the wrapper itself or a side control which triggered the

--- a/packages/block-editor/src/components/block-list/block-wrapper.js
+++ b/packages/block-editor/src/components/block-list/block-wrapper.js
@@ -98,15 +98,12 @@ const BlockComponent = forwardRef(
 		 * When a block becomes selected, transition focus to an inner tabbable.
 		 */
 		const focusTabbable = () => {
-			if ( ! document.activeElement ) {
-				return;
-			}
-
 			// Focus is captured by the wrapper node, so while focus transition
 			// should only consider tabbables within editable display, since it
 			// may be the wrapper itself or a side control which triggered the
 			// focus event, don't unnecessary transition to an inner tabbable.
 			if (
+				document.activeElement &&
 				isInsideRootBlock( wrapper.current, document.activeElement )
 			) {
 				return;


### PR DESCRIPTION
Fixes #21276

This pull request seeks to resolve an error which occurs in Internet Explorer when pressing <kbd>Enter</kbd> whilst a block is selected in Select interaction mode.

For full debugging details, see comment at https://github.com/WordPress/gutenberg/issues/21276#issuecomment-608039276 .

**Implementation notes:**

The changes as proposed follow the second of the two proposed fixes from https://github.com/WordPress/gutenberg/issues/21276#issuecomment-608039276 .

**Testing Instructions:**

Repeat Steps to Reproduce from #21276, verifying that no crash occurs in Internet Explorer.