### PR TITLE
Block Editor: Add type-checking for block editor (DOM utils only)

### DIFF
--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -21,6 +21,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"react-native": "src/index",
+	"types": "build-types",
 	"dependencies": {
 		"@babel/runtime": "^7.8.3",
 		"@wordpress/a11y": "file:../a11y",

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -21,7 +21,6 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"react-native": "src/index",
-	"types": "build-types",
 	"dependencies": {
 		"@babel/runtime": "^7.8.3",
 		"@wordpress/a11y": "file:../a11y",

--- a/packages/block-editor/src/utils/dom.js
+++ b/packages/block-editor/src/utils/dom.js
@@ -5,12 +5,20 @@
  *
  * @param {string} clientId Block client ID.
  *
- * @return {Element} Block DOM node.
+ * @return {Element?} Block DOM node.
  */
 export function getBlockDOMNode( clientId ) {
 	return document.getElementById( 'block-' + clientId );
 }
 
+/**
+ * Returns the preview container DOM node for a given block client ID, or
+ * undefined if the container cannot be determined.
+ *
+ * @param {string} clientId Block client ID.
+ *
+ * @return {Node|undefined} Preview container DOM node.
+ */
 export function getBlockPreviewContainerDOMNode( clientId ) {
 	const domNode = getBlockDOMNode( clientId );
 
@@ -79,16 +87,21 @@ export function hasInnerBlocksContext( element ) {
 /**
  * Finds the block client ID given any DOM node inside the block.
  *
- * @param {Node} node DOM node.
+ * @param {Node?} node DOM node.
  *
  * @return {string|undefined} Client ID or undefined if the node is not part of a block.
  */
 export function getBlockClientId( node ) {
-	if ( node.nodeType !== node.ELEMENT_NODE ) {
-		node = node.parentElement;
+	while ( node && node.nodeType !== window.Node.ELEMENT_NODE ) {
+		node = node.parentNode;
 	}
 
-	const blockNode = node.closest( '.block-editor-block-list__block' );
+	if ( ! node ) {
+		return;
+	}
+
+	const elementNode = /** @type {Element} */ ( node );
+	const blockNode = elementNode.closest( '.block-editor-block-list__block' );
 
 	if ( ! blockNode ) {
 		return;

--- a/packages/block-editor/src/utils/dom.js
+++ b/packages/block-editor/src/utils/dom.js
@@ -30,10 +30,10 @@ export function getBlockPreviewContainerDOMNode( clientId ) {
 }
 
 /**
- * Returns true if the given HTMLElement is a block focus stop. Blocks without
- * their own text fields rely on the focus stop to be keyboard navigable.
+ * Returns true if the given element is a block focus stop. Blocks without their
+ * own text fields rely on the focus stop to be keyboard navigable.
  *
- * @param {HTMLElement} element Element to test.
+ * @param {Element} element Element to test.
  *
  * @return {boolean} Whether element is a block focus stop.
  */
@@ -44,8 +44,8 @@ export function isBlockFocusStop( element ) {
 /**
  * Returns true if two elements are contained within the same block.
  *
- * @param {HTMLElement} a First element.
- * @param {HTMLElement} b Second element.
+ * @param {Element} a First element.
+ * @param {Element} b Second element.
  *
  * @return {boolean} Whether elements are in the same block.
  */
@@ -57,12 +57,14 @@ export function isInSameBlock( a, b ) {
 }
 
 /**
- * Returns true if an elements is considered part of the block and not its children.
+ * Returns true if an element is considered part of the block and not its
+ * children.
  *
- * @param {HTMLElement} blockElement Block container element.
- * @param {HTMLElement} element      Element.
+ * @param {Element} blockElement Block container element.
+ * @param {Element} element      Element.
  *
- * @return {boolean} Whether element is in the block Element but not its children.
+ * @return {boolean} Whether element is in the block Element but not its
+ *                   children.
  */
 export function isInsideRootBlock( blockElement, element ) {
 	const parentBlock = element.closest( '.block-editor-block-list__block' );
@@ -70,10 +72,10 @@ export function isInsideRootBlock( blockElement, element ) {
 }
 
 /**
- * Returns true if the given HTMLElement contains inner blocks (an InnerBlocks
+ * Returns true if the given element contains inner blocks (an InnerBlocks
  * element).
  *
- * @param {HTMLElement} element Element to test.
+ * @param {Element} element Element to test.
  *
  * @return {boolean} Whether element contains inner blocks.
  */
@@ -89,7 +91,8 @@ export function hasInnerBlocksContext( element ) {
  *
  * @param {Node?} node DOM node.
  *
- * @return {string|undefined} Client ID or undefined if the node is not part of a block.
+ * @return {string|undefined} Client ID or undefined if the node is not part of
+ *                            a block.
  */
 export function getBlockClientId( node ) {
 	while ( node && node.nodeType !== window.Node.ELEMENT_NODE ) {

--- a/packages/block-editor/tsconfig.json
+++ b/packages/block-editor/tsconfig.json
@@ -1,0 +1,13 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"rootDir": "src",
+		"declarationDir": "build-types"
+	},
+	// NOTE: This package is being progressively typed. You are strongly
+	// encouraged to expand this array with files which can be type-checked. At
+	// some point in the future, this can be simplified to `src/**/*`.
+	"include": [
+		"src/utils/dom.js"
+	]
+}

--- a/packages/block-editor/tsconfig.json
+++ b/packages/block-editor/tsconfig.json
@@ -9,28 +9,5 @@
 	// some point in the future, this can be simplified to `src/**/*`.
 	"include": [
 		"src/utils/dom.js"
-	],
-	"references": [
-		{ "path": "../a11y" },
-		{ "path": "../blob" },
-		{ "path": "../blocks" },
-		{ "path": "../components" },
-		{ "path": "../compose" },
-		{ "path": "../data" },
-		{ "path": "../deprecated" },
-		{ "path": "../dom" },
-		{ "path": "../element" },
-		{ "path": "../hooks" },
-		{ "path": "../html-entities" },
-		{ "path": "../i18n" },
-		{ "path": "../icons" },
-		{ "path": "../is-shallow-equal" },
-		{ "path": "../keyboard-shortcuts" },
-		{ "path": "../keycodes" },
-		{ "path": "../rich-text" },
-		{ "path": "../token-list" },
-		{ "path": "../url" },
-		{ "path": "../viewport" },
-		{ "path": "../wordcount" }
 	]
 }

--- a/packages/block-editor/tsconfig.json
+++ b/packages/block-editor/tsconfig.json
@@ -4,10 +4,10 @@
 		"rootDir": "src",
 		"declarationDir": "build-types"
 	},
-	// NOTE: This package is being progressively typed. You are strongly
-	// encouraged to expand this array with files which can be type-checked. At
-	// some point in the future, this can be simplified to `src/**/*`.
-	"include": [
+	// NOTE: This package is being progressively typed. You are encouraged to
+	// expand this array with files which can be type-checked. At some point in
+	// the future, this can be simplified to an `includes` of `src/**/*`.
+	"files": [
 		"src/utils/dom.js"
 	]
 }

--- a/packages/block-editor/tsconfig.json
+++ b/packages/block-editor/tsconfig.json
@@ -9,5 +9,28 @@
 	// some point in the future, this can be simplified to `src/**/*`.
 	"include": [
 		"src/utils/dom.js"
+	],
+	"references": [
+		{ "path": "../a11y" },
+		{ "path": "../blob" },
+		{ "path": "../blocks" },
+		{ "path": "../components" },
+		{ "path": "../compose" },
+		{ "path": "../data" },
+		{ "path": "../deprecated" },
+		{ "path": "../dom" },
+		{ "path": "../element" },
+		{ "path": "../hooks" },
+		{ "path": "../html-entities" },
+		{ "path": "../i18n" },
+		{ "path": "../icons" },
+		{ "path": "../is-shallow-equal" },
+		{ "path": "../keyboard-shortcuts" },
+		{ "path": "../keycodes" },
+		{ "path": "../rich-text" },
+		{ "path": "../token-list" },
+		{ "path": "../url" },
+		{ "path": "../viewport" },
+		{ "path": "../wordcount" }
 	]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
 		{ "path": "packages/a11y" },
 		{ "path": "packages/autop" },
 		{ "path": "packages/blob" },
+		{ "path": "packages/block-editor" },
 		{ "path": "packages/dom-ready" },
 		{ "path": "packages/escape-html" },
 		{ "path": "packages/html-entities" },


### PR DESCRIPTION
Related: #21361
Partially addresses #18838

This pull request proposes to add a minimal TypeScript configuration for the `@wordpress/block-editor` module, with the intention of progressively integrating type-checking into this very large module. As proposed, it currently includes type-checking for a single file, `packages/block-editor/src/utils/dom.js`. This was used to help verify the fix in #21361.

Until more packages opt in to typing, it may not be possible to add type-checking for certain files in this package. The file included here works largely because it has no dependencies. For the purposes of #21361, I tried also to include `src/components/block-list/block-wrapper.js`. However, since this file has many dependencies on other WordPress packages (which aren't necessarily typed), there were many errors. I assumed this may have to do with the fact we need to add type-checking for "leaf" packages before consumers, though I may be mistaken.

**Testing Instructions:**

Verify types build without error:

```
npm run build:package-types
```

cc @sirreal Do you think this is a reasonable way to go about starting to add type details for large packages?