### PR TITLE
Update e2e test for multi-entity saving in site editor

### DIFF
--- a/packages/e2e-test-utils/src/open-global-block-inserter.js
+++ b/packages/e2e-test-utils/src/open-global-block-inserter.js
@@ -2,7 +2,10 @@
  * Opens the global block inserter.
  */
 export async function openGlobalBlockInserter() {
-	await page.click( '.edit-post-header [aria-label="Add block"]' );
+	await page.click(
+		'.edit-post-header [aria-label="Add block"], .edit-site-header [aria-label="Add block"]'
+	);
+
 	// Waiting here is necessary because sometimes the inserter takes more time to
 	// render than Puppeteer takes to complete the 'click' action
 	await page.waitForSelector( '.block-editor-inserter__menu' );

--- a/packages/e2e-tests/config/setup-test-framework.js
+++ b/packages/e2e-tests/config/setup-test-framework.js
@@ -16,6 +16,7 @@ import {
 	switchUserToTest,
 	visitAdminPage,
 } from '@wordpress/e2e-test-utils';
+import { addQueryArgs } from '@wordpress/url';
 
 /**
  * Timeout, in seconds, that the test should be allowed to run.
@@ -69,12 +70,17 @@ async function setupBrowser() {
 /**
  * Navigates to the post listing screen and bulk-trashes any posts which exist.
  *
+ * @param {string} postType - String slug for type of post to trash.
+ *
  * @return {Promise} Promise resolving once posts have been trashed.
  */
-async function trashExistingPosts() {
+export async function trashExistingPosts( postType = 'post' ) {
 	await switchUserToAdmin();
 	// Visit `/wp-admin/edit.php` so we can see a list of posts and delete them.
-	await visitAdminPage( 'edit.php' );
+	const query = addQueryArgs( '', {
+		postType,
+	} ).slice( 1 );
+	await visitAdminPage( 'edit.php', query );
 
 	// If this selector doesn't exist there are no posts for us to delete.
 	const bulkSelector = await page.$( '#bulk-action-selector-top' );

--- a/packages/e2e-tests/config/setup-test-framework.js
+++ b/packages/e2e-tests/config/setup-test-framework.js
@@ -78,7 +78,7 @@ export async function trashExistingPosts( postType = 'post' ) {
 	await switchUserToAdmin();
 	// Visit `/wp-admin/edit.php` so we can see a list of posts and delete them.
 	const query = addQueryArgs( '', {
-		postType,
+		post_type: postType,
 	} ).slice( 1 );
 	await visitAdminPage( 'edit.php', query );
 

--- a/packages/e2e-tests/specs/experiments/multi-entity-saving.test.js
+++ b/packages/e2e-tests/specs/experiments/multi-entity-saving.test.js
@@ -136,7 +136,7 @@ describe( 'Multi-entity save flow', () => {
 		} );
 	} );
 
-	describe.skip( 'Site Editor', () => {
+	describe( 'Site Editor', () => {
 		async function assertSaveDisabled() {
 			const disabledButton = await page.waitForSelector(
 				`${ saveSiteSelector }[aria-disabled=true]`
@@ -156,6 +156,15 @@ describe( 'Multi-entity save flow', () => {
 		} );
 
 		it( 'Should be enabled after edits', async () => {
+			// Ensure we are on 'front-page' demo template.
+			await page.click(
+				'.components-dropdown-menu__toggle[aria-label="Switch Template"]'
+			);
+			const [ demoTemplateButton ] = await page.$x(
+				'//button[contains(., "front-page")]'
+			);
+			await demoTemplateButton.click();
+
 			await page.click( templatePartSelector );
 			await page.keyboard.type( 'some words...' );
 			const enabledButton = await page.waitForSelector(

--- a/packages/e2e-tests/specs/experiments/multi-entity-saving.test.js
+++ b/packages/e2e-tests/specs/experiments/multi-entity-saving.test.js
@@ -38,7 +38,7 @@ describe( 'Multi-entity save flow', () => {
 	const templatePartSelector = '*[data-type="core/template-part"]';
 	const activatedTemplatePartSelector = `${ templatePartSelector } .block-editor-inner-blocks`;
 
-	// Re-usable assertiosn across Post/Site editors.
+	// Reusable assertions across Post/Site editors.
 	const assertAllBoxesChecked = async () => {
 		const checkedBoxes = await page.$$( checkedBoxSelector );
 		const checkboxInputs = await page.$$( checkboxInputSelector );

--- a/packages/e2e-tests/specs/experiments/multi-entity-saving.test.js
+++ b/packages/e2e-tests/specs/experiments/multi-entity-saving.test.js
@@ -175,6 +175,11 @@ describe( 'Multi-entity save flow', () => {
 			await page.keyboard.press( 'Tab' );
 			await page.keyboard.press( 'Enter' );
 
+			// Wait to ensure template part is created/inserted before saving.
+			await new Promise( ( resolve ) => {
+				setTimeout( resolve, 1000 );
+			} );
+
 			const enabledButton = await page.waitForSelector(
 				activeSaveSiteSelector
 			);

--- a/packages/e2e-tests/specs/experiments/multi-entity-saving.test.js
+++ b/packages/e2e-tests/specs/experiments/multi-entity-saving.test.js
@@ -153,28 +153,6 @@ describe( 'Multi-entity save flow', () => {
 	} );
 
 	describe( 'Site Editor', () => {
-		// Site Editor specific cleanup.
-		// afterAll( async () => {
-		// 	// Delete uninitiated template part.
-		// 	const [ uninitiatedTemplatePart ] = await page.$x(
-		// 		uninitiatedTemplatePartSelector
-		// 	);
-		// 	await uninitiatedTemplatePart.click();
-		// 	await page.waitForSelector( selectedTemplatePartSelector );
-		// 	await page.keyboard.press( 'Backspace' );
-
-		// 	// Save again now that it is gone.
-		// 	const enabledButton = await page.waitForSelector(
-		// 		activeSaveSiteSelector
-		// 	);
-		// 	await enabledButton.click();
-
-		// 	const saveButton = await page.waitForSelector(
-		// 		entitiesSaveSelector
-		// 	);
-		// 	await saveButton.click();
-		// } );
-
 		it( 'Should be enabled after edits', async () => {
 			// Navigate to site editor.
 			const query = addQueryArgs( '', {

--- a/packages/e2e-tests/specs/experiments/multi-entity-saving.test.js
+++ b/packages/e2e-tests/specs/experiments/multi-entity-saving.test.js
@@ -17,6 +17,7 @@ import {
 	enableExperimentalFeatures,
 	disableExperimentalFeatures,
 } from '../../experimental-features';
+import { trashExistingPosts } from '../../config/setup-test-framework';
 
 describe( 'Multi-entity save flow', () => {
 	// Selectors.
@@ -51,6 +52,8 @@ describe( 'Multi-entity save flow', () => {
 	];
 	beforeAll( async () => {
 		await enableExperimentalFeatures( requiredExperiments );
+		await trashExistingPosts( 'wp_template' );
+		await trashExistingPosts( 'wp_template_part' );
 	} );
 	afterAll( async () => {
 		await disableExperimentalFeatures( requiredExperiments );
@@ -164,8 +167,14 @@ describe( 'Multi-entity save flow', () => {
 			);
 			await demoTemplateButton.click();
 
-			await page.click( templatePartSelector );
-			await page.keyboard.type( 'some words...' );
+			// Insert a new template part.
+			await insertBlock( 'Template Part' );
+			await page.keyboard.type( 'test-template-part2' );
+			await page.keyboard.press( 'Tab' );
+			await page.keyboard.type( 'test-theme' );
+			await page.keyboard.press( 'Tab' );
+			await page.keyboard.press( 'Enter' );
+
 			const enabledButton = await page.waitForSelector(
 				activeSaveSiteSelector
 			);

--- a/packages/e2e-tests/specs/experiments/multi-entity-saving.test.js
+++ b/packages/e2e-tests/specs/experiments/multi-entity-saving.test.js
@@ -38,10 +38,6 @@ describe( 'Multi-entity save flow', () => {
 		'.components-dropdown-menu__toggle[aria-label="Switch Template"]';
 	const templatePartSelector = '*[data-type="core/template-part"]';
 	const activatedTemplatePartSelector = `${ templatePartSelector } .block-editor-inner-blocks`;
-	const selectedTemplatePartSelector =
-		'.is-selected[data-type="core/template-part"]';
-	const uninitiatedTemplatePartSelector =
-		'//div[contains(@class, "components-placeholder")]/div[contains(., "Choose a template part by slug and theme")]';
 
 	// Reusable assertions across Post/Site editors.
 	const assertAllBoxesChecked = async () => {
@@ -158,26 +154,26 @@ describe( 'Multi-entity save flow', () => {
 
 	describe( 'Site Editor', () => {
 		// Site Editor specific cleanup.
-		afterAll( async () => {
-			// Delete uninitiated template part.
-			const [ uninitiatedTemplatePart ] = await page.$x(
-				uninitiatedTemplatePartSelector
-			);
-			await uninitiatedTemplatePart.click();
-			await page.waitForSelector( selectedTemplatePartSelector );
-			await page.keyboard.press( 'Backspace' );
+		// afterAll( async () => {
+		// 	// Delete uninitiated template part.
+		// 	const [ uninitiatedTemplatePart ] = await page.$x(
+		// 		uninitiatedTemplatePartSelector
+		// 	);
+		// 	await uninitiatedTemplatePart.click();
+		// 	await page.waitForSelector( selectedTemplatePartSelector );
+		// 	await page.keyboard.press( 'Backspace' );
 
-			// Save again now that it is gone.
-			const enabledButton = await page.waitForSelector(
-				activeSaveSiteSelector
-			);
-			await enabledButton.click();
+		// 	// Save again now that it is gone.
+		// 	const enabledButton = await page.waitForSelector(
+		// 		activeSaveSiteSelector
+		// 	);
+		// 	await enabledButton.click();
 
-			const saveButton = await page.waitForSelector(
-				entitiesSaveSelector
-			);
-			await saveButton.click();
-		} );
+		// 	const saveButton = await page.waitForSelector(
+		// 		entitiesSaveSelector
+		// 	);
+		// 	await saveButton.click();
+		// } );
 
 		it( 'Should be enabled after edits', async () => {
 			// Navigate to site editor.


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
Fixes skipped e2e tests regarding multi-entity saving in the site editor as added in: https://github.com/WordPress/gutenberg/pull/21159#issuecomment-607725131

Things Changed:
* Removed 1 assertion.  This was an inaccurate assertion on its own and was failing as a result.  
* Insured the test uses the `front-page` demo template as the template to make changes to.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Running e2e tests for multi-entity-saving locally and via travis CI.

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
