### PR TITLE
Blocks: Raw Handling: Find closest PRE by stepping through parents

### DIFF
--- a/packages/blocks/src/api/raw-handling/html-formatting-remover.js
+++ b/packages/blocks/src/api/raw-handling/html-formatting-remover.js
@@ -25,9 +25,21 @@ export default function( node ) {
 		return;
 	}
 
-	// Ignore pre content.
-	if ( node.parentElement.closest( 'pre' ) ) {
-		return;
+	// Ignore pre content. Note that this does not use Element#closest due to
+	// a combination of (a) node may not be Element and (b) node.parentElement
+	// does not have full support in all browsers (Internet Exporer).
+	//
+	// See: https://developer.mozilla.org/en-US/docs/Web/API/Node/parentElement#Browser_compatibility
+
+	/** @type {Node?} */
+	let parent = node;
+	while ( ( parent = parent.parentNode ) ) {
+		if (
+			parent.nodeType === window.Node.ELEMENT_NODE &&
+			parent.nodeName === 'PRE'
+		) {
+			return;
+		}
 	}
 
 	// First, replace any sequence of HTML formatting space with a single space.


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/21276#issuecomment-607588622

This pull request seeks to resolve an error which occurs when pasting text in a RichText field (e.g. paragraph) in Internet Explorer.

As noted by @azaozz at https://github.com/WordPress/gutenberg/issues/21276#issuecomment-607588622 , the issue stems from the fact that `Node#parentElement` is not reliably available in Internet Explorer, depending on the node type.

**Implementation Notes:**

The changes here address this issue by replacing `Element#closest` with a basic `while` loop to step through the ancestry. While `Element#closest` didn't need to be removed, it would still have required at least parts of an implementation like this in order to iterate to the closest element, so I opted to use this as the primary method to get to the closest enclosing `<pre>` tag.

**Testing Instructions:**

Repeat Steps to Reproduce from https://github.com/WordPress/gutenberg/issues/21276#issuecomment-607588622, verifying that pasting text in Internet Explorer succeeds without error.

Note: While pasting does now succeed, there appear to be related bugs with regards to selection placement after the paste. The selection range will incorrectly move to the end of the paragraph text.
