### PR TITLE
Fix overly verbose aria-label in Social Link block

### DIFF
--- a/packages/block-library/src/social-link/index.php
+++ b/packages/block-library/src/social-link/index.php
@@ -15,10 +15,7 @@
 function render_block_core_social_link( $attributes ) {
 	$service = ( isset( $attributes['service'] ) ) ? $attributes['service'] : 'Icon';
 	$url     = ( isset( $attributes['url'] ) ) ? $attributes['url'] : false;
-	$label   = ( isset( $attributes['label'] ) ) ?
-		$attributes['label'] :
-		/* translators: %s: Social Link service name */
-		sprintf( __( 'Link to %s' ), block_core_social_link_get_name( $service ) );
+	$label   = ( isset( $attributes['label'] ) ) ? $attributes['label'] : block_core_social_link_get_name( $service );
 	$class_name = isset( $attributes['className'] ) ? ' ' . $attributes['className'] : false;
 
 	// Don't render a link if there is no URL set.

--- a/packages/block-library/src/social-link/index.php
+++ b/packages/block-library/src/social-link/index.php
@@ -13,9 +13,9 @@
  * @return string Rendered HTML of the referenced block.
  */
 function render_block_core_social_link( $attributes ) {
-	$service = ( isset( $attributes['service'] ) ) ? $attributes['service'] : 'Icon';
-	$url     = ( isset( $attributes['url'] ) ) ? $attributes['url'] : false;
-	$label   = ( isset( $attributes['label'] ) ) ? $attributes['label'] : block_core_social_link_get_name( $service );
+	$service    = ( isset( $attributes['service'] ) ) ? $attributes['service'] : 'Icon';
+	$url        = ( isset( $attributes['url'] ) ) ? $attributes['url'] : false;
+	$label      = ( isset( $attributes['label'] ) ) ? $attributes['label'] : block_core_social_link_get_name( $service );
 	$class_name = isset( $attributes['className'] ) ? ' ' . $attributes['className'] : false;
 
 	// Don't render a link if there is no URL set.


### PR DESCRIPTION
## Description
Fixes #20665.

This simplifies the a11y-compatibility [added to the Social Link block](https://github.com/WordPress/gutenberg/pull/18651), removes [a confusing translatable string](https://github.com/WordPress/gutenberg/pull/18651#discussion_r377275288) and provides an improved experience for screen reader users.

Screen readers announce anchors as links, so having "Link to" was redundant.

## How has this been tested?
* I've navigated a document containing Social Link blocks using VoiceOver on macOS (see screenshots below).

## Screenshots

Before:
<img width="604" alt="Example of a11y bug in Social Link block. Screenshot of rendered icons with VoiceOver saying 'Link, Link to Instagram'" src="https://user-images.githubusercontent.com/9565066/78314229-2d67f100-750e-11ea-9f8e-2a17b40988e6.png">

After:
<img width="358" alt="Patch in this PR for Social Link block. Screenshot of rendered icons with VoiceOver saying 'Link, Instagram'" src="https://user-images.githubusercontent.com/9565066/78314252-3f499400-750e-11ea-8edc-9e35e792e2ed.png">

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
