### PR TITLE
Clear selection state when RESET_BLOCKS action is dispatched

### DIFF
--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1094,6 +1094,8 @@ function selection( state = {}, action ) {
 
 			return { clientId: blockToSelect.clientId };
 		}
+		case 'RESET_BLOCKS':
+			return {};
 	}
 
 	return state;

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -2306,6 +2306,19 @@ describe( 'state', () => {
 			expect( state1 ).toEqual( original );
 			expect( state2 ).toEqual( original );
 		} );
+
+		it( 'should remove selection when blocks are reset', () => {
+			const original = deepFreeze( { clientId: 'chicken' } );
+			const action = {
+				type: 'RESET_BLOCKS',
+				blocks: [],
+			};
+			const state1 = selectionStart( original, action );
+			const state2 = selectionEnd( original, action );
+
+			expect( state1 ).toEqual( {} );
+			expect( state2 ).toEqual( {} );
+		} );
 	} );
 
 	describe( 'preferences()', () => {


### PR DESCRIPTION
## Description
In #21340 a fix toolbar is used for the new Navigation Menus page that's being developed as an experimental feature.

@draganescu noticed an issue when testing this and changing between menus (https://github.com/WordPress/gutenberg/pull/21340#pullrequestreview-386228844), which seems to be due to block selection state not being reset when `RESET_BLOCKS` is dispatched by the new menu selection.

## How has this been tested?
This can fairly easily be reproduced in the post editor:
1. Enable the Top Toolbar option
2. Add a paragraph with some text to a post and ensure it stays selected so that the block toolbar is shown at the top
3. In the browser dev tools open up the console and execute the following to reset blocks: `wp.data.dispatch('core/block-editor').resetBlocks([]);`
4. Observe in the top toolbar the block movers and more menu are no longer displayed. (In `master` they're displayed and clicking on the more menu causes the editor to throw an error.)

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
