### PR TITLE
Add gradients support to Group, columns and media & text blocks

### DIFF
--- a/packages/block-library/src/columns/index.js
+++ b/packages/block-library/src/columns/index.js
@@ -27,7 +27,7 @@ export const settings = {
 		align: [ 'wide', 'full' ],
 		html: false,
 		lightBlockWrapper: true,
-		__experimentalColor: true,
+		__experimentalColor: { gradients: true },
 	},
 	variations,
 	example: {

--- a/packages/block-library/src/group/index.js
+++ b/packages/block-library/src/group/index.js
@@ -92,7 +92,7 @@ export const settings = {
 		anchor: true,
 		html: false,
 		lightBlockWrapper: true,
-		__experimentalColor: true,
+		__experimentalColor: { gradients: true },
 	},
 	transforms: {
 		from: [

--- a/packages/block-library/src/media-text/index.js
+++ b/packages/block-library/src/media-text/index.js
@@ -25,7 +25,7 @@ export const settings = {
 	supports: {
 		align: [ 'wide', 'full' ],
 		html: false,
-		__experimentalColor: true,
+		__experimentalColor: { gradients: true },
 	},
 	example: {
 		attributes: {


### PR DESCRIPTION
Based on #21266

closes #21055 

The paragraph and heading blocks also use the same hook so it's just as easy to add the gradients support there but I left them out cause gradient might not be that useful on textual blocks. That said, if you think we should just do it and be consistent, I'm happy to update the PR.

Everything is in the title.