### PR TITLE
Fix the Buttons block margins

### DIFF
--- a/packages/block-library/src/buttons/style.scss
+++ b/packages/block-library/src/buttons/style.scss
@@ -1,7 +1,14 @@
 .wp-block-buttons .wp-block-button {
 	display: inline-block;
-	margin: $grid-unit-05;
+	margin-right: $grid-unit-10;
+	margin-bottom: $grid-unit-10;
 }
+
+.wp-block-button.alignright .wp-block-button {
+	margin-right: none;
+	margin-left: $grid-unit-10;
+}
+
 .wp-block-buttons.aligncenter {
 	text-align: center;
 }

--- a/packages/block-library/src/buttons/style.scss
+++ b/packages/block-library/src/buttons/style.scss
@@ -4,7 +4,7 @@
 	margin-bottom: $grid-unit-10;
 }
 
-.wp-block-button.alignright .wp-block-button {
+.wp-block-buttons.alignright .wp-block-button {
 	margin-right: none;
 	margin-left: $grid-unit-10;
 }


### PR DESCRIPTION
closes #21293

The buttons block is misaligned because of the margins applied between its inner blocks. This is not a perfect solution but it solves the most important breakage. It alignes the buttons (left or right depending on the block alignment) while still avoiding the trailing margins.

Other ideas welcome. I thought about grid positioning + grid gp but it's very hard with the current editor markup, maybe as a future iteration