### PR TITLE
Delete menus in nav menus screen

### DIFF
--- a/docs/designers-developers/developers/data/data-core.md
+++ b/docs/designers-developers/developers/data/data-core.md
@@ -459,6 +459,16 @@ _Returns_
 
 -   `Object`: Action object.
 
+<a name="deleteEntityRecord" href="#deleteEntityRecord">#</a> **deleteEntityRecord**
+
+Action triggered to delete an entity record.
+
+_Parameters_
+
+-   _kind_ `string`: Kind of the received entity.
+-   _name_ `string`: Name of the received entity.
+-   _recordId_ `Object`: The recordId to be deleted.
+
 <a name="editEntityRecord" href="#editEntityRecord">#</a> **editEntityRecord**
 
 Returns an action object that triggers an

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -54,6 +54,16 @@ _Returns_
 
 -   `Object`: Action object.
 
+<a name="deleteEntityRecord" href="#deleteEntityRecord">#</a> **deleteEntityRecord**
+
+Action triggered to delete an entity record.
+
+_Parameters_
+
+-   _kind_ `string`: Kind of the received entity.
+-   _name_ `string`: Name of the received entity.
+-   _recordId_ `Object`: The recordId to be deleted.
+
 <a name="editEntityRecord" href="#editEntityRecord">#</a> **editEntityRecord**
 
 Returns an action object that triggers an

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -233,6 +233,28 @@ export function __unstableCreateUndoLevel() {
 }
 
 /**
+ * Action triggered to delete an entity record.
+ *
+ * @param {string} kind      Kind of the received entity.
+ * @param {string} name      Name of the received entity.
+ * @param {Object} recordId  The recordId to be deleted.
+ */
+export function* deleteEntityRecord( kind, name, recordId ) {
+	const entities = yield getKindEntities( kind );
+	const entity = find( entities, { kind, name } );
+	if ( ! entity ) {
+		return;
+	}
+	const path = `${ entity.baseURL + '/' + recordId + '?force=true' }`;
+	yield apiFetch( {
+		path,
+		method: 'DELETE',
+	} );
+	const entityRecords = select( 'getEntityRecords', kind, name );
+	yield receiveEntityRecords( kind, name, entityRecords, undefined, true );
+}
+
+/**
  * Action triggered to save an entity record.
  *
  * @param {string} kind    Kind of the received entity.

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -250,7 +250,7 @@ export function* deleteEntityRecord( kind, name, recordId ) {
 		path,
 		method: 'DELETE',
 	} );
-	const entityRecords = select( 'getEntityRecords', kind, name );
+	const entityRecords = yield select( 'getEntityRecords', kind, name );
 	yield receiveEntityRecords( kind, name, entityRecords, undefined, true );
 }
 

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -248,34 +248,21 @@ export function* deleteEntityRecord( kind, name, recordId ) {
 		return;
 	}
 
-	yield {
-		type: 'DELETE_ENTITY_RECORD_START',
-		kind,
-		name,
-		recordId,
-	};
-
 	const deletedRecord = yield apiFetch( {
 		path,
 		method: 'DELETE',
 	} );
-
-	const oldRecords = yield select( 'getEntityRecords', kind, name );
-
-	const newRecords = remove( oldRecords, ( record ) => {
+	
+	/* eslint-disable prefer-const */
+	let records = yield select( 'getEntityRecords', kind, name );
+	remove( records, ( record ) => {
 		return record.id === deletedRecord.previous.id;
 	} );
+	/* eslint-enable prefer-const */
 
-	yield receiveEntityRecords( kind, name, newRecords, undefined, true );
+	yield receiveEntityRecords( kind, name, records, undefined, true );
 
-	yield {
-		type: 'DELETE_ENTITY_RECORD_FINISH',
-		kind,
-		name,
-		recordId,
-	};
-
-	return newRecords;
+	return deletedRecord;
 }
 
 /**

--- a/packages/core-data/src/index.js
+++ b/packages/core-data/src/index.js
@@ -49,6 +49,8 @@ const entityActions = defaultEntities.reduce( ( result, entity ) => {
 	const { kind, name } = entity;
 	result[ getMethodName( kind, name, 'save' ) ] = ( key ) =>
 		actions.saveEntityRecord( kind, name, key );
+	result[ getMethodName( kind, name, 'delete' ) ] = ( key ) =>
+		actions.deleteEntityRecord( kind, name, key );
 	return result;
 }, {} );
 

--- a/packages/core-data/src/queried-data/reducer.js
+++ b/packages/core-data/src/queried-data/reducer.js
@@ -36,10 +36,13 @@ export function getMergedItemIds( itemIds, nextItemIds, page, perPage ) {
 
 	// If later page has already been received, default to the larger known
 	// size of the existing array, else calculate as extending the existing.
-	const size = Math.max(
-		itemIds.length,
-		nextItemIdsStartIndex + nextItemIds.length
-	);
+	const size =
+		itemIds.length > nextItemIds.length
+			? nextItemIds.length
+			: Math.max(
+					itemIds.length,
+					nextItemIdsStartIndex + nextItemIds.length
+			  );
 
 	// Preallocate array since size is known.
 	const mergedItemIds = new Array( size );

--- a/packages/core-data/src/reducer.js
+++ b/packages/core-data/src/reducer.js
@@ -39,6 +39,17 @@ export function terms( state = {}, action ) {
 	return state;
 }
 
+export function deleteEntity( state = {}, action ) {
+	switch ( action.type ) {
+		case 'DELETE_ENTITY':
+			return {
+				...state,
+			};
+	}
+
+	return state;
+}
+
 /**
  * Reducer managing authors state. Keyed by id.
  *
@@ -234,19 +245,6 @@ function entity( entityConfig ) {
 								error: action.error,
 								isAutosave: action.isAutosave,
 							},
-						};
-				}
-
-				return state;
-			},
-
-			deleting: ( state = {}, action ) => {
-				switch ( action.type ) {
-					case 'DELETE_ENTITY_RECORD_START':
-					case 'DELETE_ENTITY_RECORD_FINISH':
-						delete state[ action.recordId ];
-						return {
-							...state,
 						};
 				}
 
@@ -514,6 +512,7 @@ export function autosaves( state = {}, action ) {
 
 export default combineReducers( {
 	terms,
+	deleteEntity,
 	users,
 	currentUser,
 	taxonomies,

--- a/packages/core-data/src/reducer.js
+++ b/packages/core-data/src/reducer.js
@@ -239,6 +239,19 @@ function entity( entityConfig ) {
 
 				return state;
 			},
+
+			deleting: ( state = {}, action ) => {
+				switch ( action.type ) {
+					case 'DELETE_ENTITY_RECORD_START':
+					case 'DELETE_ENTITY_RECORD_FINISH':
+						delete state[ action.recordId ];
+						return {
+							...state,
+						};
+				}
+
+				return state;
+			},
 		} )
 	);
 }

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -84,7 +84,8 @@ export function* getEntityRecords( kind, name, query = {} ) {
 
 getEntityRecords.shouldInvalidate = ( action, kind, name ) => {
 	return (
-		action.type === 'RECEIVE_ITEMS' &&
+		( action.type === 'RECEIVE_ITEMS' ||
+			action.type === 'DELETE_ENTITY' ) &&
 		action.invalidateCache &&
 		kind === action.kind &&
 		name === action.name

--- a/packages/edit-navigation/src/components/menu-editor/index.js
+++ b/packages/edit-navigation/src/components/menu-editor/index.js
@@ -11,16 +11,20 @@ import {
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import { Panel, PanelBody, Button } from '@wordpress/components';
-
+import { useDispatch } from '@wordpress/data';
 /**
  * Internal dependencies
  */
 import useNavigationBlocks from './use-navigation-blocks';
 import MenuEditorShortcuts from './shortcuts';
 
-export default function MenuEditor( { menuId, blockEditorSettings } ) {
+export default function MenuEditor( {
+	menuId,
+	blockEditorSettings,
+	onDelete,
+} ) {
 	const [ blocks, setBlocks, saveBlocks ] = useNavigationBlocks( menuId );
-
+	const { deleteMenu } = useDispatch( 'core' );
 	return (
 		<div className="edit-navigation-menu-editor">
 			<BlockEditorKeyboardShortcuts.Register />
@@ -50,15 +54,22 @@ export default function MenuEditor( { menuId, blockEditorSettings } ) {
 						) }
 					</PanelBody>
 				</Panel>
-				<Panel
-					header={
-						<Button isPrimary onClick={ saveBlocks }>
-							{ __( 'Save navigation' ) }
-						</Button>
-					}
-					className="edit-navigation-menu-editor__panel"
-				>
+				<Panel className="edit-navigation-menu-editor__panel">
 					<PanelBody title={ __( 'Navigation menu' ) }>
+						<div className="components-panel__header-actions">
+							<Button isPrimary onClick={ saveBlocks }>
+								{ __( 'Save navigation' ) }
+							</Button>
+							<Button
+								isPrimary
+								onClick={ () => {
+									deleteMenu( menuId );
+									onDelete( menuId );
+								} }
+							>
+								{ __( 'Delete navigation' ) }
+							</Button>
+						</div>
 						<WritingFlow>
 							<ObserveTyping>
 								<BlockList />

--- a/packages/edit-navigation/src/components/menu-editor/style.scss
+++ b/packages/edit-navigation/src/components/menu-editor/style.scss
@@ -3,3 +3,10 @@
 	grid-template-columns: 280px 1fr;
 	grid-column-gap: 10px;
 }
+.components-panel__header-actions {
+	margin-top: $grid-unit-20;
+	margin-bottom: $grid-unit-60;
+	width: 100%;
+	display: flex;
+	justify-content: space-between;
+}

--- a/packages/edit-navigation/src/components/menus-editor/index.js
+++ b/packages/edit-navigation/src/components/menus-editor/index.js
@@ -47,6 +47,7 @@ export default function MenusEditor( { blockEditorSettings } ) {
 				<MenuEditor
 					menuId={ menuId }
 					blockEditorSettings={ blockEditorSettings }
+					onDelete={ () => setMenuId( 0 ) }
 				/>
 			) }
 		</>


### PR DESCRIPTION
## Description
Adds delete button to #21281 

## How has this been tested?
Tested locally by:

1. Enable the menu edit experiment
2. Make sure to use a theme that supports menus
3. Create some menus
4. Go to Gutenberg -> Navigation (beta)
5. Start deleting menus

## Screenshots <!-- if applicable -->

![delete-mystery](https://user-images.githubusercontent.com/107534/78378461-a7b17780-75d9-11ea-97a6-d507d941e88e.gif)

## Types of changes
Possibly breaking other things b/c this required edits in the `getMergedItemIds` function which is handling some parts of entity edits. Except for this:

- updates the menu editor component with delete utilities
- adds a delete action to entities in core/data

## Know issues
- [ ] We need a confirmation
- [ ] We need an empty state

