### PR TITLE
Testing: Include Prettier Config package in root type checking

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
 		{ "path": "packages/html-entities" },
 		{ "path": "packages/i18n" },
 		{ "path": "packages/is-shallow-equal" },
+		{ "path": "packages/prettier-config" },
 		{ "path": "packages/priority-queue" },
 		{ "path": "packages/project-management-automation" },
 		{ "path": "packages/token-list" },


### PR DESCRIPTION
Previously: https://github.com/WordPress/gutenberg/pull/21362#issuecomment-608490667, #21053

This pull request seeks to include `@wordpress/prettier-config` in the root types-checking configuration. This was missed in #21053, and should be part of introduction of types checking for any package ([see documentation](https://github.com/WordPress/gutenberg/blob/master/packages/README.md#typescript)).

**Testing Instructions:**

Verify types build succeeds:

```
npm run build:package-types
```

Verify the introduction of an error and subsequent re-run of the above would result in failure:

```diff
diff --git a/packages/prettier-config/lib/index.js b/packages/prettier-config/lib/index.js
index 08854b5775..5ceb98cae2 100644
--- a/packages/prettier-config/lib/index.js
+++ b/packages/prettier-config/lib/index.js
@@ -23,6 +23,7 @@ const config = {
 	jsxBracketSameLine: false,
 	semi: true,
 	arrowParens: 'always',
+	nonsense: true,
 };
 
 module.exports = config;
```

```
 ⇒ npm run build:package-types

> gutenberg@7.8.1 build:package-types /Users/andrew/Documents/Code/gutenberg
> node ./bin/packages/validate-typescript-version.js && tsc --build

packages/prettier-config/lib/index.js:26:2 - error TS2322: Type '{ useTabs: true; tabWidth: number; printWidth: number; singleQuote: true; trailingComma: "es5"; bracketSpacing: true; parenSpacing: true; jsxBracketSameLine: false; semi: true; arrowParens: "always"; nonsense: boolean; }' is not assignable to type 'Options & WPPrettierOptions'.
  Object literal may only specify known properties, and 'nonsense' does not exist in type 'Options & WPPrettierOptions'.

26  nonsense: true,
    ~~~~~~~~~~~~~~

Found 1 error.
```