### PR TITLE
Delete editor-styles that are no longer needed

### DIFF
--- a/packages/editor/src/editor-styles.scss
+++ b/packages/editor/src/editor-styles.scss
@@ -42,17 +42,6 @@ h6 {
 	font-size: 0.8em;
 }
 
-// Adjust line spacing for larger headings.
-h1,
-h2,
-h3 {
-	line-height: 1.4;
-}
-
-h4 {
-	line-height: 1.5;
-}
-
 // Default margins.
 h1 {
 	margin-top: 0.67em;
@@ -82,15 +71,6 @@ h5 {
 h6 {
 	margin-top: 2.33em;
 	margin-bottom: 2.33em;
-}
-
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
-	color: inherit;
 }
 
 p {


### PR DESCRIPTION
Extracted from https://github.com/WordPress/gutenberg/pull/20530#discussion_r401096364

These styles were used to prevent wp-admin styles from leaking to the editor. Now that the paragraph & heading blocks add their own variables for these properties, we need to remove them so global styles are applied.

## How to test

Test that it works:

- Create a new post with six heading blocks, representing each of the h1 to h6 elements.
- Install [this demo theme](https://github.com/nosolosw/global-styles-theme/pull/3) or add somewhere in your CSS these styles:

```css
:root {
	--wp--color--background: pink;
	--wp--color--text: yellow;
	--wp--typography--line-height: 5;
}

body {
    background-color: var(--wp--color--background);
}
```
- Verify that the colors and line-height are properly applied to the headings.

Now, test that it doesn't work without these changes:

- Remove the last commit in this branch (`git reset --hard HEAD~1`) and compile again (`npm run build`).
- Reload the editor and verify that:
  - the heading blocks don't have the color applied
  - h1-h4 blocks don't have the line-height applied