### PR TITLE
[RNMobile] Heading block tests

### DIFF
--- a/packages/block-library/src/heading/test/edit.native.js
+++ b/packages/block-library/src/heading/test/edit.native.js
@@ -1,0 +1,111 @@
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+
+/**
+ * WordPress dependencies
+ */
+import * as data from '@wordpress/data';
+import * as blockLibrary from '@wordpress/block-library';
+import * as blocks from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import HeadingToolbar from '../heading-toolbar';
+import HeadingEdit from '../edit';
+
+const blockEditorSelect = data.select( 'core/block-editor' );
+const blockEditorDispatch = data.dispatch( 'core/block-editor' );
+
+const testAttributes = {
+	content: 'Heading block',
+	level: 4,
+	align: 'center',
+	style: { color: { text: '#003fa3' } },
+};
+
+describe( 'Heading', () => {
+	beforeAll( () => {
+		blockLibrary.registerCoreBlocks();
+		gutenbergSetup();
+		blockEditorDispatch.removeBlocks( blockEditorSelect.getBlocks() );
+	} );
+
+	it( 'Serializes all Heading attributes properly', () => {
+		const expectedHTML = `<!-- wp:heading {"align":"center","level":4,"style":{"color":{"text":"#003fa3"}}} -->
+<h4 class="has-text-align-center has-text-color" style="--wp--color--text:#003fa3">Heading block</h4>
+<!-- /wp:heading -->`;
+
+		insertHeadingBlockWithAttributes( testAttributes );
+
+		const finalHTML = blocks.serialize( blockEditorSelect.getBlocks() );
+
+		expect( finalHTML ).toEqual( expect.stringContaining( expectedHTML ) );
+	} );
+
+	it( 'Parse Heading attributes from HTML properly', () => {
+		const expectedHTML = `<!-- wp:heading {"align":"center","level":4,"style":{"color":{"text":"#003fa3"}}} -->
+<h4 class="has-text-align-center has-text-color" style="--wp--color--text:#003fa3">Heading block</h4>
+<!-- /wp:heading -->`;
+
+		const parsedBlocks = blocks.parse( expectedHTML );
+
+		expect( parsedBlocks[ 0 ].attributes ).toEqual( testAttributes );
+	} );
+
+	it( 'Changes Heading level via HeaderToolBar ', () => {
+		const expectedHTML = `<!-- wp:heading {"level":4} -->
+<h4>Heading block</h4>
+<!-- /wp:heading -->`;
+
+		const attributes = {
+			content: 'Heading block',
+		};
+
+		const headingEdit = createHeadingEdit( attributes );
+		headingEdit
+			.find( HeadingToolbar )
+			.props()
+			.onChange( 4 );
+
+		const finalHTML = blocks.serialize( blockEditorSelect.getBlocks() );
+
+		expect( finalHTML ).toEqual( expect.stringContaining( expectedHTML ) );
+	} );
+} );
+
+const gutenbergSetup = () => {
+	const userId = 1;
+	const storageKey = 'WP_DATA_USER_' + userId;
+	data.use( data.plugins.persistence, { storageKey } );
+};
+
+const insertHeadingBlockWithAttributes = ( attributes = {}, index = 0 ) => {
+	const headingBlock = blocks.createBlock( 'core/heading', attributes );
+	blockEditorDispatch.insertBlock( headingBlock, index );
+
+	const renderedBlocks = blockEditorSelect.getBlocks();
+	return renderedBlocks[ index ];
+};
+
+const createHeadingEdit = ( attributes ) => {
+	const renderedHeadingBlock = insertHeadingBlockWithAttributes( attributes );
+
+	const setAttributes = ( attr ) => {
+		blockEditorDispatch.updateBlockAttributes(
+			renderedHeadingBlock.clientId,
+			attr
+		);
+	};
+
+	return shallow(
+		<HeadingEdit
+			attributes={ renderedHeadingBlock.attributes }
+			setAttributes={ setAttributes }
+			onReplace={ jest.fn() }
+			mergeBlocks={ jest.fn() }
+		/>
+	);
+};


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

This PR adds tests for the Heading block:

1.- Serialize a Heading block with the attributes set.
2.- Parse an Heading HTML snippet into a block with the corresponding attributes.
3.- Modifying an attribute (level) via HeadingToolBar.

Most of these tests will test the store code, and most of it is shared (no .native variants). But these kind of tests might help us catch early breakages like the one about colors we had recently.

My original idea was to involve more code from the block and how does it interact with the store  (like the 3rd test) instead of testing the store itself. Any help to achieve this is welcome. 

Does it make sense to have these kind of tests (that look more like integration rather than unit tests) on every block?

cc @hypest @maxme @Tug 

