### PR TITLE
List block: add color controls

### DIFF
--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -23,6 +23,7 @@
 @import "./latest-comments/editor.scss";
 @import "./latest-posts/editor.scss";
 @import "./legacy-widget/editor.scss";
+@import "./list/editor.scss";
 @import "./media-text/editor.scss";
 @import "./more/editor.scss";
 @import "./navigation/editor.scss";

--- a/packages/block-library/src/list/block.json
+++ b/packages/block-library/src/list/block.json
@@ -11,10 +11,7 @@
 			"source": "html",
 			"selector": "ol,ul",
 			"multiline": "li",
-			"__unstableMultilineWrapperTags": [
-				"ol",
-				"ul"
-			],
+			"__unstableMultilineWrapperTags": [ "ol", "ul" ],
 			"default": ""
 		},
 		"type": {
@@ -30,6 +27,9 @@
 	"supports": {
 		"anchor": true,
 		"className": false,
+		"__experimentalColor": {
+			"gradients": true
+		},
 		"__unstablePasteTextInline": true,
 		"lightBlockWrapper": true
 	}

--- a/packages/block-library/src/list/editor.scss
+++ b/packages/block-library/src/list/editor.scss
@@ -1,0 +1,7 @@
+// Extra specificity required to override default editor styles, which are
+// loaded after core block styles. If the load order changes, this rule can be
+// removed. See https://github.com/WordPress/gutenberg/issues/24011.
+ol.has-background.has-background,
+ul.has-background.has-background {
+	padding: $block-bg-padding--v $block-bg-padding--h;
+}

--- a/packages/block-library/src/list/style.scss
+++ b/packages/block-library/src/list/style.scss
@@ -1,0 +1,4 @@
+ol.has-background,
+ul.has-background {
+	padding: $block-bg-padding--v $block-bg-padding--h;
+}

--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -17,6 +17,7 @@
 @import "./image/style.scss";
 @import "./latest-comments/style.scss";
 @import "./latest-posts/style.scss";
+@import "./list/style.scss";
 @import "./media-text/style.scss";
 @import "./navigation/style.scss";
 @import "./navigation-link/style.scss";


### PR DESCRIPTION
## Description
Adds color controls to the List block. If the Paragraph and Headings blocks are going to have color controls, then so should this one. Closes #9016.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
