### PR TITLE
Remove default icon from PluginBlockSettingsMenuItem

### DIFF
--- a/packages/edit-post/src/components/block-settings-menu/plugin-block-settings-menu-item.js
+++ b/packages/edit-post/src/components/block-settings-menu/plugin-block-settings-menu-item.js
@@ -9,7 +9,6 @@ import { difference } from 'lodash';
 import { BlockSettingsMenuControls } from '@wordpress/block-editor';
 import { MenuItem } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
-import { plugins } from '@wordpress/icons';
 
 const isEverySelectedBlockAllowed = ( selected, allowed ) =>
 	difference( selected, allowed ).length === 0;
@@ -98,7 +97,7 @@ const PluginBlockSettingsMenuItem = ( {
 			return (
 				<MenuItem
 					onClick={ compose( onClick, onClose ) }
-					icon={ icon || plugins }
+					icon={ icon }
 					label={ small ? label : undefined }
 					role={ role }
 				>


### PR DESCRIPTION
## Description
Remove default icon from PluginBlockSettingMenuItem as the new Gutenberg UI
doesn't have icons by default. Closes https://github.com/WordPress/gutenberg/issues/21390

## How has this been tested?
Tested with a plugin that uses PluginBlockSettingMenuItem with and without passing the icon.

## Types of changes
<!-- What types of changes does your code introduce?  -->
Enhancement: If someone uses PluginBlockSettingMenuItem without an icon, their menu item will stop displaying the default Plugin icon.

## Checklist:
- [ x ] My code is tested.
- [ x ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ x ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ x ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ x ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ x ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
