### PR TITLE
Env: Await test result of testPortNumberValidation

### DIFF
--- a/packages/env/test/config.js
+++ b/packages/env/test/config.js
@@ -221,11 +221,11 @@ describe( 'readConfig', () => {
 
 	it( 'should throw a validaton error if the ports are not numbers', async () => {
 		expect.assertions( 10 );
-		testPortNumberValidation( 'port', 'string' );
-		testPortNumberValidation( 'testsPort', [] );
-		testPortNumberValidation( 'port', {} );
-		testPortNumberValidation( 'testsPort', false );
-		testPortNumberValidation( 'port', null );
+		await testPortNumberValidation( 'port', 'string' );
+		await testPortNumberValidation( 'testsPort', [] );
+		await testPortNumberValidation( 'port', {} );
+		await testPortNumberValidation( 'testsPort', false );
+		await testPortNumberValidation( 'port', null );
 	} );
 
 	it( 'should throw a validaton error if the ports are the same', async () => {


### PR DESCRIPTION
This pull request seeks to correct an ineffective test case in `@wordpress/env`, where the test case does not await the completion of promised tasks.

There are two pressing issues:

1. The tests currently log to `stdout` with an error, despite the test case being considered as passing ([example](https://travis-ci.com/github/WordPress/gutenberg/jobs/313779122))
2. Related to this, `testPortNumberValidation` could be throwing an error and we'd not catch it

This passes:

```diff
diff --git a/packages/env/test/config.js b/packages/env/test/config.js
index 1de18dd3df..f77dc488f9 100644
--- a/packages/env/test/config.js
+++ b/packages/env/test/config.js
@@ -413,5 +413,6 @@ async function testPortNumberValidation( portName, value ) {
 			`Invalid .wp-env.json: "${ portName }" must be an integer.`
 		);
 	}
+	throw new Error();
 	jest.clearAllMocks();
 }
```

The errors being logged are not in-fact errors. I expect the issue is that without awaiting the result of the previous, the subsequent mock will interfere with the results of others.

It's simply enough to await completion.

Alternatives to consider:

1. Create separate test cases, rather than delegate this to a utility (using `it.each`)
2. Find some way to parallelize these test cases, not run serialize. It's not possible currently because each test must mock the same `readFile` implementation.

Example `it.each`:

```js
it.each(
    [ 'string', [], {}, false, null ].flatMap( ( value ) => [
        [ 'port', value ],
        [ 'testsPort', value ],
    ] )
)(
    'should throw a validaton error if the ports are not numbers (%s, %s)',
    async ( portName, value ) => {
        expect.assertions( 2 );
        readFile.mockImplementation( () =>
            Promise.resolve( JSON.stringify( { [ portName ]: value } ) )
        );
        try {
            await readConfig( '.wp-env.json' );
        } catch ( error ) {
            expect( error ).toBeInstanceOf( ValidationError );
            expect( error.message ).toContain(
                `Invalid .wp-env.json: "${ portName }" must be an integer.`
            );
        }
    }
);
```

See also: https://jestjs.io/docs/en/api#testeachtablename-fn-timeout

**Testing Instruction:**

Ensure unit tests pass, **and there is no extra logged output**:

```
npm run test-unit packages/env/test/config.js 
```