### PR TITLE
Env: Swap out deprecated dep `request`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6722,9 +6722,15 @@
 			}
 		},
 		"@sheerun/mutationobserver-shim": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.2.tgz",
-			"integrity": "sha512-vTCdPp/T/Q3oSqwHmZ5Kpa9oI7iLtGl3RQaA/NyLHikvcrPxACkkKVr/XzkSPJWXHRhKGzVvb0urJsbMlRxi1Q==",
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.3.tgz",
+			"integrity": "sha512-DetpxZw1fzPD5xUBrIAoplLChO2VB8DlL5Gg+I1IR9b2wPqYIca2WSUxL5g1vLeR4MsQq1NeWriXAVffV+U1Fw==",
+			"dev": true
+		},
+		"@sindresorhus/is": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-2.1.0.tgz",
+			"integrity": "sha512-lXKXfypKo644k4Da4yXkPCrwcvn6SlUW2X2zFbuflKHNjf0w9htru01bo26uMhleMXsDmnZ12eJLdrAZa9MANg==",
 			"dev": true
 		},
 		"@storybook/addon-a11y": {
@@ -9896,6 +9902,15 @@
 				}
 			}
 		},
+		"@szmarczak/http-timer": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.5.tgz",
+			"integrity": "sha512-PyRA9sm1Yayuj5OIoJ1hGt2YISX45w9WcFbh6ddT0Z/0yaFxOtGLInr4jUfU1EAFVs0Yfyfev4RNwBlUaHdlDQ==",
+			"dev": true,
+			"requires": {
+				"defer-to-connect": "^2.0.0"
+			}
+		},
 		"@tannin/compile": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@tannin/compile/-/compile-1.1.0.tgz",
@@ -10044,6 +10059,18 @@
 				"@types/babel-types": "*"
 			}
 		},
+		"@types/cacheable-request": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.1.tgz",
+			"integrity": "sha512-ykFq2zmBGOCbpIXtoVbz4SKY5QriWPh3AjyU4G74RYbtt5yOc5OfaY75ftjg7mikMOla1CTGpX3lLbuJh8DTrQ==",
+			"dev": true,
+			"requires": {
+				"@types/http-cache-semantics": "*",
+				"@types/keyv": "*",
+				"@types/node": "*",
+				"@types/responselike": "*"
+			}
+		},
 		"@types/color-name": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
@@ -10071,6 +10098,12 @@
 			"version": "4.7.4",
 			"resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.4.tgz",
 			"integrity": "sha512-+o2igcuZA3xtOoFH56s+MCZVidwlJNcJID57DSCyawS2i910yG9vkwehCjJNZ6ImhCR5S9DbvIJKyYHcMyOfMw==",
+			"dev": true
+		},
+		"@types/http-cache-semantics": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.0.tgz",
+			"integrity": "sha512-c3Xy026kOF7QOTn00hbIllV1dLR9hG9NkSrLQgCVs8NF6sBU+VGWjD3wLPhmh1TYAc7ugCFsvHYMN4VcBN1U1A==",
 			"dev": true
 		},
 		"@types/is-function": {
@@ -10127,6 +10160,15 @@
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.3.tgz",
 			"integrity": "sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==",
 			"dev": true
+		},
+		"@types/keyv": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.1.tgz",
+			"integrity": "sha512-MPtoySlAZQ37VoLaPcTHCu1RWJ4llDkULYZIzOYxlhxBqYPB0RsRlmMU0R6tahtFe27mIdkHV+551ZWV4PLmVw==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*"
+			}
 		},
 		"@types/lodash": {
 			"version": "4.14.149",
@@ -10242,6 +10284,15 @@
 			"resolved": "https://registry.npmjs.org/@types/requestidlecallback/-/requestidlecallback-0.3.1.tgz",
 			"integrity": "sha512-BnnRkgWYijCIndUn+LgoqKHX/hNpJC5G03B9y7mZya/C2gUQTSn75fEj3ZP1/Rl2E6EYeXh2/7/8UNEZ4X7HuQ==",
 			"dev": true
+		},
+		"@types/responselike": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
+			"integrity": "sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*"
+			}
 		},
 		"@types/sprintf-js": {
 			"version": "1.1.2",
@@ -11208,12 +11259,11 @@
 				"copy-dir": "^1.2.0",
 				"docker-compose": "^0.22.2",
 				"extract-zip": "^1.6.7",
+				"got": "^10.7.0",
 				"inquirer": "^7.0.4",
 				"js-yaml": "^3.13.1",
 				"nodegit": "^0.26.2",
 				"ora": "^4.0.2",
-				"request": "^2.88.2",
-				"request-progress": "^3.0.0",
 				"rimraf": "^3.0.2",
 				"terminal-link": "^2.0.0",
 				"yargs": "^14.0.0"
@@ -11302,14 +11352,12 @@
 				"mime-db": {
 					"version": "1.43.0",
 					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
-					"integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ==",
-					"dev": true
+					"integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
 				},
 				"mime-types": {
 					"version": "2.1.26",
 					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
 					"integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
-					"dev": true,
 					"requires": {
 						"mime-db": "1.43.0"
 					}
@@ -11339,7 +11387,6 @@
 					"version": "2.88.2",
 					"resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
 					"integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-					"dev": true,
 					"requires": {
 						"aws-sign2": "~0.7.0",
 						"aws4": "^1.8.0",
@@ -11434,7 +11481,6 @@
 					"version": "2.5.0",
 					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
 					"integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-					"dev": true,
 					"requires": {
 						"psl": "^1.1.28",
 						"punycode": "^2.1.1"
@@ -11449,8 +11495,7 @@
 				"uuid": {
 					"version": "3.4.0",
 					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-					"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-					"dev": true
+					"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
 				}
 			}
 		},
@@ -11748,6 +11793,7 @@
 				"dir-glob": "^3.0.1",
 				"eslint": "^6.1.0",
 				"eslint-plugin-markdown": "1.0.1",
+				"got": "^10.7.0",
 				"jest": "^24.9.0",
 				"jest-puppeteer": "^4.3.0",
 				"js-yaml": "^3.13.1",
@@ -12138,7 +12184,6 @@
 			"version": "6.10.2",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
 			"integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
-			"dev": true,
 			"requires": {
 				"fast-deep-equal": "^2.0.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -12864,8 +12909,7 @@
 		"asn1": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-			"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-			"dev": true
+			"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
 		},
 		"asn1.js": {
 			"version": "4.10.1",
@@ -12908,8 +12952,7 @@
 		"assert-plus": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-			"dev": true
+			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
 		},
 		"assign-symbols": {
 			"version": "1.0.0",
@@ -12965,8 +13008,7 @@
 		"asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-			"dev": true
+			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
 		},
 		"atob": {
 			"version": "2.1.1",
@@ -13037,14 +13079,12 @@
 		"aws-sign2": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-			"dev": true
+			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
 		},
 		"aws4": {
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-			"integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
-			"dev": true
+			"integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
 		},
 		"axe-core": {
 			"version": "3.4.0",
@@ -14261,7 +14301,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
 			"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-			"dev": true,
 			"optional": true,
 			"requires": {
 				"tweetnacl": "^0.14.3"
@@ -14951,6 +14990,64 @@
 				"unset-value": "^1.0.0"
 			}
 		},
+		"cacheable-lookup": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-2.0.1.tgz",
+			"integrity": "sha512-EMMbsiOTcdngM/K6gV/OxF2x0t07+vMOWxZNSCRQMjO2MY2nhZQ6OYhOOpyQrbhqsgtvKGI7hcq6xjnA92USjg==",
+			"dev": true,
+			"requires": {
+				"@types/keyv": "^3.1.1",
+				"keyv": "^4.0.0"
+			}
+		},
+		"cacheable-request": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.1.tgz",
+			"integrity": "sha512-lt0mJ6YAnsrBErpTMWeu5kl/tg9xMAWjavYTN6VQXM1A/teBITuNcccXsCxF0tDQQJf9DfAaX5O4e0zp0KlfZw==",
+			"dev": true,
+			"requires": {
+				"clone-response": "^1.0.2",
+				"get-stream": "^5.1.0",
+				"http-cache-semantics": "^4.0.0",
+				"keyv": "^4.0.0",
+				"lowercase-keys": "^2.0.0",
+				"normalize-url": "^4.1.0",
+				"responselike": "^2.0.0"
+			},
+			"dependencies": {
+				"get-stream": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+					"integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+					"dev": true,
+					"requires": {
+						"pump": "^3.0.0"
+					}
+				},
+				"http-cache-semantics": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
+					"integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
+					"dev": true
+				},
+				"normalize-url": {
+					"version": "4.5.0",
+					"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
+					"integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==",
+					"dev": true
+				},
+				"pump": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+					"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+					"dev": true,
+					"requires": {
+						"end-of-stream": "^1.1.0",
+						"once": "^1.3.1"
+					}
+				}
+			}
+		},
 		"call-me-maybe": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
@@ -15073,8 +15170,7 @@
 		"caseless": {
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-			"dev": true
+			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
 		},
 		"ccount": {
 			"version": "1.0.3",
@@ -15470,6 +15566,23 @@
 				"is-supported-regexp-flag": "^1.0.0"
 			}
 		},
+		"clone-response": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
+			"integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
+			"dev": true,
+			"requires": {
+				"mimic-response": "^1.0.0"
+			},
+			"dependencies": {
+				"mimic-response": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+					"integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+					"dev": true
+				}
+			}
+		},
 		"co": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -15590,7 +15703,6 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
 			"integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
-			"dev": true,
 			"requires": {
 				"delayed-stream": "~1.0.0"
 			}
@@ -17071,7 +17183,6 @@
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0"
 			}
@@ -17163,6 +17274,15 @@
 			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
 			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
 			"dev": true
+		},
+		"decompress-response": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-5.0.0.tgz",
+			"integrity": "sha512-TLZWWybuxWgoW7Lykv+gq9xvzOsUjQ9tF09Tj6NSTYGMTCHNXzrPnD6Hi+TgZq19PyTAGH4Ll/NIM/eTGglnMw==",
+			"dev": true,
+			"requires": {
+				"mimic-response": "^2.0.0"
+			}
 		},
 		"decompress-zip": {
 			"version": "0.2.2",
@@ -17270,6 +17390,12 @@
 			"requires": {
 				"clone": "^1.0.2"
 			}
+		},
+		"defer-to-connect": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.0.tgz",
+			"integrity": "sha512-bYL2d05vOSf1JEZNx5vSAtPuBMkX8K9EUutg7zlKvTqKXHt7RhWJFbmd7qakVuf13i+IkGmp6FwSsONOf6VYIg==",
+			"dev": true
 		},
 		"define-properties": {
 			"version": "1.1.2",
@@ -17507,8 +17633,7 @@
 		"delayed-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-			"dev": true
+			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
 		},
 		"delegate": {
 			"version": "3.2.0",
@@ -17845,6 +17970,12 @@
 			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
 			"dev": true
 		},
+		"duplexer3": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+			"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
+			"dev": true
+		},
 		"duplexify": {
 			"version": "3.6.0",
 			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.0.tgz",
@@ -17861,7 +17992,6 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
 			"integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-			"dev": true,
 			"optional": true,
 			"requires": {
 				"jsbn": "~0.1.0"
@@ -19815,8 +19945,7 @@
 		"extend": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-			"dev": true
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
 		},
 		"extend-shallow": {
 			"version": "3.0.2",
@@ -19952,8 +20081,7 @@
 		"extsprintf": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-			"dev": true
+			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
 		},
 		"fancy-log": {
 			"version": "1.3.3",
@@ -19975,8 +20103,7 @@
 		"fast-deep-equal": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-			"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-			"dev": true
+			"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
 		},
 		"fast-diff": {
 			"version": "1.2.0",
@@ -20001,8 +20128,7 @@
 		"fast-json-stable-stringify": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-			"dev": true
+			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
 		},
 		"fast-levenshtein": {
 			"version": "2.0.6",
@@ -20579,8 +20705,7 @@
 		"forever-agent": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-			"dev": true
+			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
 		},
 		"fork-ts-checker-webpack-plugin": {
 			"version": "1.5.0",
@@ -20610,7 +20735,6 @@
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
 			"integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
-			"dev": true,
 			"requires": {
 				"asynckit": "^0.4.0",
 				"combined-stream": "1.0.6",
@@ -21051,7 +21175,6 @@
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0"
 			}
@@ -21545,6 +21668,56 @@
 				"delegate": "^3.1.2"
 			}
 		},
+		"got": {
+			"version": "10.7.0",
+			"resolved": "https://registry.npmjs.org/got/-/got-10.7.0.tgz",
+			"integrity": "sha512-aWTDeNw9g+XqEZNcTjMMZSy7B7yE9toWOFYip7ofFTLleJhvZwUxxTxkTpKvF+p1SAA4VHmuEy7PiHTHyq8tJg==",
+			"dev": true,
+			"requires": {
+				"@sindresorhus/is": "^2.0.0",
+				"@szmarczak/http-timer": "^4.0.0",
+				"@types/cacheable-request": "^6.0.1",
+				"cacheable-lookup": "^2.0.0",
+				"cacheable-request": "^7.0.1",
+				"decompress-response": "^5.0.0",
+				"duplexer3": "^0.1.4",
+				"get-stream": "^5.0.0",
+				"lowercase-keys": "^2.0.0",
+				"mimic-response": "^2.1.0",
+				"p-cancelable": "^2.0.0",
+				"p-event": "^4.0.0",
+				"responselike": "^2.0.0",
+				"to-readable-stream": "^2.0.0",
+				"type-fest": "^0.10.0"
+			},
+			"dependencies": {
+				"get-stream": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+					"integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+					"dev": true,
+					"requires": {
+						"pump": "^3.0.0"
+					}
+				},
+				"pump": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+					"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+					"dev": true,
+					"requires": {
+						"end-of-stream": "^1.1.0",
+						"once": "^1.3.1"
+					}
+				},
+				"type-fest": {
+					"version": "0.10.0",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.10.0.tgz",
+					"integrity": "sha512-EUV9jo4sffrwlg8s0zDhP0T2WD3pru5Xi0+HTE3zTUmBaZNhfkite9PdSJwdXLwPVW0jnAHT56pZHIOYckPEiw==",
+					"dev": true
+				}
+			}
+		},
 		"graceful-fs": {
 			"version": "4.1.11",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
@@ -21620,14 +21793,12 @@
 		"har-schema": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-			"dev": true
+			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
 		},
 		"har-validator": {
 			"version": "5.1.3",
 			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
 			"integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
-			"dev": true,
 			"requires": {
 				"ajv": "^6.5.5",
 				"har-schema": "^2.0.0"
@@ -22074,7 +22245,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
 			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0",
 				"jsprim": "^1.2.2",
@@ -23355,8 +23525,7 @@
 		"is-typedarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-			"dev": true
+			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
 		},
 		"is-utf8": {
 			"version": "0.2.1",
@@ -23416,8 +23585,7 @@
 		"isstream": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-			"dev": true
+			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
 		},
 		"istanbul-lib-coverage": {
 			"version": "2.0.3",
@@ -26677,7 +26845,6 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
 			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-			"dev": true,
 			"optional": true
 		},
 		"jsc-android": {
@@ -26828,6 +26995,12 @@
 			"integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
 			"dev": true
 		},
+		"json-buffer": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+			"integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+			"dev": true
+		},
 		"json-parse-better-errors": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -26836,14 +27009,12 @@
 		"json-schema": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-			"dev": true
+			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
 		},
 		"json-schema-traverse": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-			"dev": true
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
 		},
 		"json-stable-stringify": {
 			"version": "1.0.1",
@@ -26863,8 +27034,7 @@
 		"json-stringify-safe": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-			"dev": true
+			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
 		},
 		"json2php": {
 			"version": "0.0.4",
@@ -26915,7 +27085,6 @@
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
 			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-			"dev": true,
 			"requires": {
 				"assert-plus": "1.0.0",
 				"extsprintf": "1.3.0",
@@ -26952,6 +27121,15 @@
 				"pako": "~1.0.2",
 				"readable-stream": "~2.3.6",
 				"set-immediate-shim": "~1.0.1"
+			}
+		},
+		"keyv": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.0.0.tgz",
+			"integrity": "sha512-U7ioE8AimvRVLfw4LffyOIRhL2xVgmE8T22L6i0BucSnBUyv4w+I7VN/zVZwRKHOI6ZRUcdMdWHQ8KSUvGpEog==",
+			"dev": true,
+			"requires": {
+				"json-buffer": "3.0.1"
 			}
 		},
 		"kind-of": {
@@ -27945,6 +28123,12 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
 			"integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
+			"dev": true
+		},
+		"lowercase-keys": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+			"integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
 			"dev": true
 		},
 		"lowlight": {
@@ -29479,14 +29663,12 @@
 		"mime-db": {
 			"version": "1.33.0",
 			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
-			"integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
-			"dev": true
+			"integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
 		},
 		"mime-types": {
 			"version": "2.1.18",
 			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
 			"integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
-			"dev": true,
 			"requires": {
 				"mime-db": "~1.33.0"
 			}
@@ -29495,6 +29677,12 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
 			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+		},
+		"mimic-response": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
+			"integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
+			"dev": true
 		},
 		"min-document": {
 			"version": "2.19.0",
@@ -31133,8 +31321,7 @@
 		"oauth-sign": {
 			"version": "0.9.0",
 			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-			"dev": true
+			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
 		},
 		"ob1": {
 			"version": "0.55.0",
@@ -31529,6 +31716,12 @@
 				"os-tmpdir": "^1.0.0"
 			}
 		},
+		"p-cancelable": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.0.0.tgz",
+			"integrity": "sha512-wvPXDmbMmu2ksjkB4Z3nZWTSkJEb9lqVdMaCKpZUGJG9TMiNp9XcbG3fn9fPKjem04fJMJnXoyFPk2FmgiaiNg==",
+			"dev": true
+		},
 		"p-defer": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
@@ -31542,6 +31735,15 @@
 			"dev": true,
 			"requires": {
 				"p-reduce": "^1.0.0"
+			}
+		},
+		"p-event": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/p-event/-/p-event-4.1.0.tgz",
+			"integrity": "sha512-4vAd06GCsgflX4wHN1JqrMzBh/8QZ4j+rzp0cd2scXRwuBEv+QR3wrVA5aLhWDLw4y2WgDKvzWF3CCLmVM1UgA==",
+			"dev": true,
+			"requires": {
+				"p-timeout": "^2.0.1"
 			}
 		},
 		"p-finally": {
@@ -31609,6 +31811,15 @@
 			"resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-1.0.0.tgz",
 			"integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo=",
 			"dev": true
+		},
+		"p-timeout": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
+			"integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
+			"dev": true,
+			"requires": {
+				"p-finally": "^1.0.0"
+			}
 		},
 		"p-try": {
 			"version": "1.0.0",
@@ -31838,8 +32049,7 @@
 		"performance-now": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-			"dev": true
+			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
 		},
 		"phpegjs": {
 			"version": "1.0.0-beta7",
@@ -33283,8 +33493,7 @@
 		"psl": {
 			"version": "1.1.28",
 			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.28.tgz",
-			"integrity": "sha512-+AqO1Ae+N/4r7Rvchrdm432afjT9hqJRyBN3DQv9At0tPz4hIFSGKbq64fN9dVoCow4oggIIax5/iONx0r9hZw==",
-			"dev": true
+			"integrity": "sha512-+AqO1Ae+N/4r7Rvchrdm432afjT9hqJRyBN3DQv9At0tPz4hIFSGKbq64fN9dVoCow4oggIIax5/iONx0r9hZw=="
 		},
 		"public-encrypt": {
 			"version": "4.0.3",
@@ -33498,8 +33707,7 @@
 		"punycode": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-			"dev": true
+			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
 		},
 		"puppeteer": {
 			"version": "2.0.0",
@@ -36190,15 +36398,6 @@
 				}
 			}
 		},
-		"request-progress": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/request-progress/-/request-progress-3.0.0.tgz",
-			"integrity": "sha1-TKdUCBx/7GP1BeT6qCWqBs1mnb4=",
-			"dev": true,
-			"requires": {
-				"throttleit": "^1.0.0"
-			}
-		},
 		"request-promise-core": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
@@ -36325,6 +36524,15 @@
 			"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
 			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
 			"dev": true
+		},
+		"responselike": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.0.tgz",
+			"integrity": "sha512-xH48u3FTB9VsZw7R+vvgaKeLKzT6jOogbQhEe/jewwnZgzPcnyWui2Av6JpoYZF/91uueC+lqhWqeURw5/qhCw==",
+			"dev": true,
+			"requires": {
+				"lowercase-keys": "^2.0.0"
+			}
 		},
 		"restore-cursor": {
 			"version": "2.0.0",
@@ -37665,7 +37873,6 @@
 			"version": "1.14.2",
 			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
 			"integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
-			"dev": true,
 			"requires": {
 				"asn1": "~0.2.3",
 				"assert-plus": "^1.0.0",
@@ -39706,12 +39913,6 @@
 			"integrity": "sha512-AOvyNahXQuU7NN+VVvOOX+uW6FPaWdAOdRP5HfwYxAfCzXTFKRMoIMk+n+po318+ktcChx+F1Dd91G3YHeMKyg==",
 			"dev": true
 		},
-		"throttleit": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz",
-			"integrity": "sha1-nnhYNtr0Z0MUWlmEtiaNgoUorGw=",
-			"dev": true
-		},
 		"through": {
 			"version": "2.3.8",
 			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -39824,6 +40025,12 @@
 					}
 				}
 			}
+		},
+		"to-readable-stream": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-2.1.0.tgz",
+			"integrity": "sha512-o3Qa6DGg1CEXshSdvWNX2sN4QHqg03SPq7U6jPXRahlQdl5dK8oXjkU/2/sGrnOZKeGV1zLSO8qPwyKklPPE7w==",
+			"dev": true
 		},
 		"to-regex": {
 			"version": "3.0.2",
@@ -40014,7 +40221,6 @@
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
 			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-			"dev": true,
 			"requires": {
 				"safe-buffer": "^5.0.1"
 			}
@@ -40028,7 +40234,6 @@
 			"version": "0.14.5",
 			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
 			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-			"dev": true,
 			"optional": true
 		},
 		"type-check": {
@@ -40457,7 +40662,6 @@
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
 			"integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
-			"dev": true,
 			"requires": {
 				"punycode": "^2.1.0"
 			}
@@ -40669,7 +40873,6 @@
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0",
 				"core-util-is": "1.0.2",

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -36,12 +36,11 @@
 		"copy-dir": "^1.2.0",
 		"docker-compose": "^0.22.2",
 		"extract-zip": "^1.6.7",
+		"got": "^10.7.0",
 		"inquirer": "^7.0.4",
 		"js-yaml": "^3.13.1",
 		"nodegit": "^0.26.2",
 		"ora": "^4.0.2",
-		"request": "^2.88.2",
-		"request-progress": "^3.0.0",
 		"rimraf": "^3.0.2",
 		"terminal-link": "^2.0.0",
 		"yargs": "^14.0.0"

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -50,6 +50,7 @@
 		"dir-glob": "^3.0.1",
 		"eslint": "^6.1.0",
 		"eslint-plugin-markdown": "1.0.1",
+		"got": "^10.7.0",
 		"jest": "^24.9.0",
 		"jest-puppeteer": "^4.3.0",
 		"js-yaml": "^3.13.1",

--- a/packages/scripts/utils/env.js
+++ b/packages/scripts/utils/env.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 const { isPlainObject } = require( 'lodash' );
-const request = require( 'request' );
+const got = require( 'got' );
 const DecompressZip = require( 'decompress-zip' );
 const chalk = require( 'chalk' );
 const { sprintf } = require( 'sprintf-js' );
@@ -95,10 +95,9 @@ function downloadWordPressZip() {
 
 		stdout.write( 'Downloading...\n' );
 		// Download the archive.
-		request
-			.get(
-				'https://github.com/WordPress/wordpress-develop/archive/master.zip'
-			)
+		got.stream(
+			'https://github.com/WordPress/wordpress-develop/archive/master.zip'
+		)
 			.on( 'error', ( error ) => {
 				stdout.write( "ERROR: The zip file couldn't be downloaded.\n" );
 				stdout.write( error.toString() );


### PR DESCRIPTION
## Description
The NodeJS module `request` is deprecated, replace with `got`.
Fixes #21336.

## How has this been tested?
I have tested this locally by manually running the two involved functions `downloadZipSource` and `downloadWordPressZip`.

## Screenshots
![Screen Shot 2020-04-04 at 7 10 41 pm](https://user-images.githubusercontent.com/971886/78450215-a6527e80-76af-11ea-8e05-64a141e7ec25.png)

## Types of changes
Bug Fix: Replacing a dep for the env package, shouldn't be end-user facing.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
