### PR TITLE
[docgen-ts] Add getExportStatement()

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10912,6 +10912,7 @@
 				"optionator": "0.8.2",
 				"remark": "10.0.1",
 				"remark-parse": "6.0.3",
+				"typescript": "3.8.3",
 				"unified": "7.1.0"
 			}
 		},

--- a/packages/docgen/package.json
+++ b/packages/docgen/package.json
@@ -29,6 +29,7 @@
 		"optionator": "0.8.2",
 		"remark": "10.0.1",
 		"remark-parse": "6.0.3",
+		"typescript": "3.8.3",
 		"unified": "7.1.0"
 	},
 	"publishConfig": {

--- a/packages/docgen/src/get-export-statements.js
+++ b/packages/docgen/src/get-export-statements.js
@@ -1,0 +1,50 @@
+/**
+ * External dependencies
+ */
+const { SourceFile, SyntaxKind } = require( 'typescript' );
+
+/**
+ * Internal dependencies
+ */
+const { hasExportModifier } = require( './has-modifier' );
+
+/**
+ * ExportAssignment
+ *   - export default 3
+ *   - export default ClassDeclaration;
+ *   - export default fnDeclaration;
+ *
+ * ExportDeclaration:
+ *   - export { a, b } from 'c'
+ *   - export { myDeclaration };
+ *   - export * from './module';
+ *   - export { default as moduleName } from './module-code';
+ *   - export { bar as quux, myDefault as default }
+ *
+ * hasExportModifier
+ *   - export const x = 42
+ *   - export default class {}
+ *   - export default class ClassDeclaration {}
+ *   - export default function() {}
+ *   - export default function myDeclaration() {}
+ *   - export class MyDeclaration {}
+ *   - export function myDeclaration() {}
+ *
+ * @param {SourceFile} sourceFile
+ */
+function getExportStatements( sourceFile ) {
+	return sourceFile.statements.filter( ( statement ) => {
+		if (
+			statement.kind === SyntaxKind.ExportAssignment ||
+			statement.kind === SyntaxKind.ExportDeclaration
+		) {
+			return true;
+		}
+
+		return hasExportModifier( statement );
+	} );
+}
+
+module.exports = {
+	getExportStatements,
+};

--- a/packages/docgen/src/has-modifier.js
+++ b/packages/docgen/src/has-modifier.js
@@ -1,0 +1,38 @@
+const { Statement, SyntaxKind } = require( 'typescript' );
+
+/**
+ *
+ * @param {Statement} statement
+ */
+function hasExportModifier( statement ) {
+	if ( statement.modifiers ) {
+		return (
+			statement.modifiers.filter(
+				( modifier ) => modifier.kind === SyntaxKind.ExportKeyword
+			).length > 0
+		);
+	}
+
+	return false;
+}
+
+/**
+ *
+ * @param {Statement} statement
+ */
+function hasDefaultModifier( statement ) {
+	if ( statement.modifiers ) {
+		return (
+			statement.modifiers.filter(
+				( modifier ) => modifier.kind === SyntaxKind.DefaultKeyword
+			).length > 0
+		);
+	}
+
+	return false;
+}
+
+module.exports = {
+	hasExportModifier,
+	hasDefaultModifier,
+};

--- a/packages/docgen/src/test/fixtures/new-syntax/code.js
+++ b/packages/docgen/src/test/fixtures/new-syntax/code.js
@@ -1,0 +1,12 @@
+/**
+ * A function that tests new syntaxes (ES2020)
+ */
+export const g = () => {
+	const x = {};
+
+	try {
+		process.stdout.write( x?.text() );
+	} catch {
+		process.stdout.write( `it didn't work.` );
+	}
+};

--- a/packages/docgen/src/test/fixtures/tags-ts-definition/code.js
+++ b/packages/docgen/src/test/fixtures/tags-ts-definition/code.js
@@ -1,0 +1,9 @@
+/**
+ * Function invoking callback after delay with current timestamp in milliseconds
+ * since epoch.
+ *
+ * @param {(timestamp:number)=>void} callback Callback function.
+ */
+export default function invokeCallbackAfterDelay( callback ) {
+	setTimeout( () => callback( Date.now() ), 1000 );
+}

--- a/packages/docgen/src/test/get-export-statements.js
+++ b/packages/docgen/src/test/get-export-statements.js
@@ -1,0 +1,64 @@
+/**
+ * External dependencies
+ */
+import ts from 'typescript';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+/**
+ * Internal dependencies
+ */
+import { getExportStatements } from '../get-export-statements';
+
+const fixturesDir = join( __dirname, './fixtures' );
+
+const parse = ( dirname ) => {
+	const filename = join( fixturesDir, dirname, 'code.js' );
+
+	return ts.createSourceFile(
+		filename,
+		readFileSync( filename ).toString(),
+		ts.ScriptTarget.ESNext
+	);
+};
+
+describe( 'export in different ways', () => {
+	const testExport = ( dirname, tokensLength = 1 ) => {
+		it( dirname, () => {
+			const sourceFile = parse( dirname );
+			const tokens = getExportStatements( sourceFile );
+
+			expect( tokens.length ).toBe( tokensLength );
+		} );
+	};
+
+	testExport( 'default-class-anonymous' );
+	testExport( 'default-class-named' );
+	testExport( 'default-function-anonymous' );
+	testExport( 'default-function-named' );
+	testExport( 'default-identifier' );
+	testExport( 'default-import-default' );
+	testExport( 'default-import-named' );
+	testExport( 'default-named-export', 2 );
+	testExport( 'default-undocumented-nocomments' );
+	testExport( 'default-undocumented-oneliner' );
+	testExport( 'default-variable' );
+	testExport( 'named-class' );
+	testExport( 'named-default' );
+	testExport( 'named-default-exported' );
+	testExport( 'named-function' );
+	testExport( 'named-identifier' );
+	testExport( 'named-identifier-destructuring' );
+	testExport( 'named-identifiers' );
+	testExport( 'named-identifiers-and-inline', 2 );
+	testExport( 'named-import-named' );
+	testExport( 'named-import-namespace' );
+	testExport( 'named-variable' );
+	testExport( 'named-variables' );
+	testExport( 'namespace' );
+	testExport( 'namespace-commented' );
+	testExport( 'new-syntax' );
+	testExport( 'tags-function' );
+	testExport( 'tags-ts-definition' );
+	testExport( 'tags-variable' );
+} );


### PR DESCRIPTION
* Part of #21238

## Description

Extract export statements from a JavaScript file.

## How has this been tested?

Unit testing.

## Screenshots <!-- if applicable -->

N/A

## Types of changes

Breakdown of #21238.

## Note

To incorporate type system, the AST of TypeScript is very different from other JS parsers.

To solve that problem, the simple `getExportTokens()` had to be re-written in this way.

https://github.com/WordPress/gutenberg/blob/fe0d10cb821b6a325da11500bbf8cad8d00e458a/packages/docgen/src/engine.js#L23-L30

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [N/A] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [N/A] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [N/A] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
