### PR TITLE
[docgen-ts] Move <caption>ES(5|Next)</caption> to next line.

### DIFF
--- a/packages/edit-post/src/components/block-settings-menu/plugin-block-settings-menu-item.js
+++ b/packages/edit-post/src/components/block-settings-menu/plugin-block-settings-menu-item.js
@@ -38,7 +38,8 @@ const shouldRenderItem = ( selectedBlocks, allowedBlocks ) =>
  * @param {string} props.label The menu item text.
  * @param {Function} props.onClick Callback function to be executed when the user click the menu item.
  *
- * @example <caption>ES5</caption>
+ * @example
+ * <caption>ES5</caption>
  * ```js
  * // Using ES5 syntax
  * var __ = wp.i18n.__;
@@ -61,7 +62,8 @@ const shouldRenderItem = ( selectedBlocks, allowedBlocks ) =>
  * }
  * ```
  *
- * @example <caption>ESNext</caption>
+ * @example
+ * <caption>ESNext</caption>
  * ```jsx
  * // Using ESNext syntax
  * import { __ } from wp.i18n;

--- a/packages/edit-post/src/components/header/plugin-more-menu-item/index.js
+++ b/packages/edit-post/src/components/header/plugin-more-menu-item/index.js
@@ -36,7 +36,8 @@ const PluginMoreMenuItem = ( { onClick = noop, ...props } ) => (
  * @param {Function} [props.onClick=noop] The callback function to be executed when the user clicks the menu item.
  * @param {...*} [props.other] Any additional props are passed through to the underlying [MenuItem](/packages/components/src/menu-item/README.md) component.
  *
- * @example <caption>ES5</caption>
+ * @example
+ * <caption>ES5</caption>
  * ```js
  * // Using ES5 syntax
  * var __ = wp.i18n.__;
@@ -59,7 +60,8 @@ const PluginMoreMenuItem = ( { onClick = noop, ...props } ) => (
  * }
  * ```
  *
- * @example <caption>ESNext</caption>
+ * @example
+ * <caption>ESNext</caption>
  * ```jsx
  * // Using ESNext syntax
  * import { __ } from '@wordpress/i18n';

--- a/packages/edit-post/src/components/header/plugin-sidebar-more-menu-item/index.js
+++ b/packages/edit-post/src/components/header/plugin-sidebar-more-menu-item/index.js
@@ -36,7 +36,8 @@ const PluginSidebarMoreMenuItem = ( {
  * @param {string} props.target A string identifying the target sidebar you wish to be activated by this menu item. Must be the same as the `name` prop you have given to that sidebar.
  * @param {WPBlockTypeIconRender} [props.icon=inherits from the plugin] The [Dashicon](https://developer.wordpress.org/resource/dashicons/) icon slug string, or an SVG WP element, to be rendered to the left of the menu item label.
  *
- * @example <caption>ES5</caption>
+ * @example
+ * <caption>ES5</caption>
  * ```js
  * // Using ES5 syntax
  * var __ = wp.i18n.__;
@@ -55,7 +56,8 @@ const PluginSidebarMoreMenuItem = ( {
  * }
  * ```
  *
- * @example <caption>ESNext</caption>
+ * @example
+ * <caption>ESNext</caption>
  * ```jsx
  * // Using ESNext syntax
  * import { __ } from '@wordpress/i18n';

--- a/packages/edit-post/src/components/sidebar/plugin-document-setting-panel/index.js
+++ b/packages/edit-post/src/components/sidebar/plugin-document-setting-panel/index.js
@@ -59,7 +59,8 @@ const PluginDocumentSettingFill = ( {
  * @param {string} [props.title] The title of the panel
  * @param {WPBlockTypeIconRender} [props.icon=inherits from the plugin] The [Dashicon](https://developer.wordpress.org/resource/dashicons/) icon slug string, or an SVG WP element, to be rendered when the sidebar is pinned to toolbar.
  *
- * @example <caption>ES5</caption>
+ * @example
+ * <caption>ES5</caption>
  * ```js
  * // Using ES5 syntax
  * var el = wp.element.createElement;
@@ -83,7 +84,8 @@ const PluginDocumentSettingFill = ( {
  * } );
  * ```
  *
- * @example <caption>ESNext</caption>
+ * @example
+ * <caption>ESNext</caption>
  * ```jsx
  * // Using ESNext syntax
  * const { registerPlugin } = wp.plugins;

--- a/packages/edit-post/src/components/sidebar/plugin-post-publish-panel/index.js
+++ b/packages/edit-post/src/components/sidebar/plugin-post-publish-panel/index.js
@@ -35,7 +35,8 @@ const PluginPostPublishPanelFill = ( {
  * @param {boolean} [props.initialOpen=false] Whether to have the panel initially opened. When no title is provided it is always opened.
  * @param {WPBlockTypeIconRender} [props.icon=inherits from the plugin] The [Dashicon](https://developer.wordpress.org/resource/dashicons/) icon slug string, or an SVG WP element, to be rendered when the sidebar is pinned to toolbar.
  *
- * @example <caption>ES5</caption>
+ * @example
+ * <caption>ES5</caption>
  * ```js
  * // Using ES5 syntax
  * var __ = wp.i18n.__;
@@ -54,7 +55,8 @@ const PluginPostPublishPanelFill = ( {
  * }
  * ```
  *
- * @example <caption>ESNext</caption>
+ * @example
+ * <caption>ESNext</caption>
  * ```jsx
  * // Using ESNext syntax
  * const { __ } = wp.i18n;

--- a/packages/edit-post/src/components/sidebar/plugin-post-status-info/index.js
+++ b/packages/edit-post/src/components/sidebar/plugin-post-status-info/index.js
@@ -17,7 +17,8 @@ export const { Fill, Slot } = createSlotFill( 'PluginPostStatusInfo' );
  * @param {Object} props Component properties.
  * @param {string} [props.className] An optional class name added to the row.
  *
- * @example <caption>ES5</caption>
+ * @example
+ * <caption>ES5</caption>
  * ```js
  * // Using ES5 syntax
  * var __ = wp.i18n.__;
@@ -34,7 +35,8 @@ export const { Fill, Slot } = createSlotFill( 'PluginPostStatusInfo' );
  * }
  * ```
  *
- * @example <caption>ESNext</caption>
+ * @example
+ * <caption>ESNext</caption>
  * ```jsx
  * // Using ESNext syntax
  * const { __ } = wp.i18n;

--- a/packages/edit-post/src/components/sidebar/plugin-pre-publish-panel/index.js
+++ b/packages/edit-post/src/components/sidebar/plugin-pre-publish-panel/index.js
@@ -38,7 +38,8 @@ const PluginPrePublishPanelFill = ( {
  *                                                                      icon slug string, or an SVG WP element, to be rendered when
  *                                                                      the sidebar is pinned to toolbar.
  *
- * @example <caption>ES5</caption>
+ * @example
+ * <caption>ES5</caption>
  * ```js
  * // Using ES5 syntax
  * var __ = wp.i18n.__;
@@ -57,7 +58,8 @@ const PluginPrePublishPanelFill = ( {
  * }
  * ```
  *
- * @example <caption>ESNext</caption>
+ * @example
+ * <caption>ESNext</caption>
  * ```jsx
  * // Using ESNext syntax
  * const { __ } = wp.i18n;

--- a/packages/edit-post/src/components/sidebar/plugin-sidebar/index.js
+++ b/packages/edit-post/src/components/sidebar/plugin-sidebar/index.js
@@ -22,7 +22,8 @@ import { __ } from '@wordpress/i18n';
  * @param {boolean} [props.isPinnable=true] Whether to allow to pin sidebar to toolbar.
  * @param {WPBlockTypeIconRender} [props.icon=inherits from the plugin] The [Dashicon](https://developer.wordpress.org/resource/dashicons/) icon slug string, or an SVG WP element, to be rendered when the sidebar is pinned to toolbar.
  *
- * @example <caption>ES5</caption>
+ * @example
+ * <caption>ES5</caption>
  * ```js
  * // Using ES5 syntax
  * var __ = wp.i18n.__;
@@ -48,7 +49,8 @@ import { __ } from '@wordpress/i18n';
  * }
  * ```
  *
- * @example <caption>ESNext</caption>
+ * @example
+ * <caption>ESNext</caption>
  * ```jsx
  * // Using ESNext syntax
  * import { __ } from '@wordpress/i18n';

--- a/packages/plugins/src/api/index.js
+++ b/packages/plugins/src/api/index.js
@@ -41,7 +41,8 @@ const plugins = {};
  *                            unique across all registered plugins.
  * @param {WPPlugin} settings The settings for this plugin.
  *
- * @example <caption>ES5</caption>
+ * @example
+ * <caption>ES5</caption>
  * ```js
  * // Using ES5 syntax
  * var el = wp.element.createElement;
@@ -78,7 +79,8 @@ const plugins = {};
  * } );
  * ```
  *
- * @example <caption>ESNext</caption>
+ * @example
+ * <caption>ESNext</caption>
  * ```js
  * // Using ESNext syntax
  * import { PluginSidebar, PluginSidebarMoreMenuItem } from '@wordpress/edit-post';
@@ -153,7 +155,8 @@ export function registerPlugin( name, settings ) {
  *
  * @param {string} name Plugin name.
  *
- * @example <caption>ES5</caption>
+ * @example
+ * <caption>ES5</caption>
  * ```js
  * // Using ES5 syntax
  * var unregisterPlugin = wp.plugins.unregisterPlugin;
@@ -161,7 +164,8 @@ export function registerPlugin( name, settings ) {
  * unregisterPlugin( 'plugin-name' );
  * ```
  *
- * @example <caption>ESNext</caption>
+ * @example
+ * <caption>ESNext</caption>
  * ```js
  * // Using ESNext syntax
  * const { unregisterPlugin } = wp.plugins;

--- a/packages/plugins/src/components/plugin-area/index.js
+++ b/packages/plugins/src/components/plugin-area/index.js
@@ -18,7 +18,8 @@ import { getPlugins } from '../../api';
 /**
  * A component that renders all plugin fills in a hidden div.
  *
- * @example <caption>ES5</caption>
+ * @example
+ * <caption>ES5</caption>
  * ```js
  * // Using ES5 syntax
  * var el = wp.element.createElement;
@@ -34,7 +35,8 @@ import { getPlugins } from '../../api';
  * }
  * ```
  *
- * @example <caption>ESNext</caption>
+ * @example
+ * <caption>ESNext</caption>
  * ```js
  * // Using ESNext syntax
  * const { PluginArea } = wp.plugins;


### PR DESCRIPTION
* Part of #21238

## Description

TypeScript cannot parse `<caption>` tag right next to `@example`. So, they're moved to the next line.

## How has this been tested?

N/A

## Screenshots 

N/A

## Types of changes

Bug fix

## Checklist:
- [N/A] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [N/A] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [N/A] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [N/A] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [N/A] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
