### PR TITLE
fix: [#20954] Scheduled posts display the correct url

### DIFF
--- a/packages/editor/src/components/post-publish-panel/postpublish.js
+++ b/packages/editor/src/components/post-publish-panel/postpublish.js
@@ -23,6 +23,26 @@ import { decodeEntities } from '@wordpress/html-entities';
  */
 import PostScheduleLabel from '../post-schedule/label';
 
+const POSTNAME = '%postname%';
+
+/**
+ * Returns URL for a future post.
+ *
+ * @param {Object} post         Post object.
+ *
+ * @return {string} PostPublish URL.
+ */
+
+const getFuturePostUrl = ( post ) => {
+	const { slug } = post;
+
+	if ( post.permalink_template.includes( POSTNAME ) ) {
+		return post.permalink_template.replace( POSTNAME, slug );
+	}
+
+	return post.permalink_template;
+};
+
 class PostPublishPanelPostpublish extends Component {
 	constructor() {
 		super( ...arguments );
@@ -65,6 +85,8 @@ class PostPublishPanelPostpublish extends Component {
 		const { children, isScheduled, post, postType } = this.props;
 		const postLabel = get( postType, [ 'labels', 'singular_name' ] );
 		const viewPostLabel = get( postType, [ 'labels', 'view_item' ] );
+		const link =
+			post.status === 'future' ? getFuturePostUrl( post ) : post.link;
 
 		const postPublishNonLinkHeader = isScheduled ? (
 			<>
@@ -78,7 +100,7 @@ class PostPublishPanelPostpublish extends Component {
 		return (
 			<div className="post-publish-panel__postpublish">
 				<PanelBody className="post-publish-panel__postpublish-header">
-					<a ref={ this.postLink } href={ post.link }>
+					<a ref={ this.postLink } href={ link }>
 						{ decodeEntities( post.title ) || __( '(no title)' ) }
 					</a>{ ' ' }
 					{ postPublishNonLinkHeader }
@@ -95,19 +117,19 @@ class PostPublishPanelPostpublish extends Component {
 							__( '%s address' ),
 							postLabel
 						) }
-						value={ safeDecodeURIComponent( post.link ) }
+						value={ safeDecodeURIComponent( link ) }
 						onFocus={ this.onSelectInput }
 					/>
 					<div className="post-publish-panel__postpublish-buttons">
 						{ ! isScheduled && (
-							<Button isSecondary href={ post.link }>
+							<Button isSecondary href={ link }>
 								{ viewPostLabel }
 							</Button>
 						) }
 
 						<ClipboardButton
 							isSecondary
-							text={ post.link }
+							text={ link }
 							onCopy={ this.onCopy }
 						>
 							{ this.state.showCopyConfirmation


### PR DESCRIPTION
## Description
Fix #20954
Currently links are set from `link` key from 
```json
api: /wp/v2/posts/:id 

{
   "id":79,
   "guid":{
      "rendered":"http:\/\/localhost:8888\/?p=79",
      "raw":"http:\/\/localhost:8888\/?p=79"
   },
   "slug":"potato-salad",
   "status":"future",
   "link":"http:\/\/localhost:8888\/?p=79",
   "title":{
      "raw":"potato salad",
      "rendered":"potato salad"
   },
   "permalink_template":"http:\/\/localhost:8888\/2020\/04\/17\/%postname%\/",
   "generated_slug":"potato-salad"
}
```
For scheduled posts this does not represent their respective live URLs. Hence, I changed the source post link. For scheduled posts that have postname in the URL the slug is injected. I chose to use `permalink_template` as it corresponds to the setting chosen by the user.
<!-- Please describe what you have changed or added -->

## How has this been tested?
From Settings -> Permalinks -> checked all options under custom structure. When scheduling a post the permalink_template creates the real url and with `%postname%` as a template. 
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->
<img width="274" alt="image" src="https://user-images.githubusercontent.com/17088041/78502257-eaee2080-7768-11ea-8007-c37484f7ab46.png">

![ ](https://user-images.githubusercontent.com/17088041/78683915-88c42580-78f8-11ea-8d55-18c6d842ba78.gif)


## Types of changes
Non-breaking change. Bug fix.
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
