### PR TITLE
Basic responsive styles for navigation screen

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -171,7 +171,6 @@ $navigation-sub-menu-width: $grid-unit-10 * 25;
 		}
 
 		&.has-child .wp-block-navigation-link__content {
-			min-width: 100%;
 			padding-right: $grid-unit-10 * 4;
 			position: relative;
 		}

--- a/packages/edit-navigation/src/components/layout/style.scss
+++ b/packages/edit-navigation/src/components/layout/style.scss
@@ -1,6 +1,10 @@
 .edit-navigation-layout__tab-panel {
 	// Matches the padding-left applied by default to the `#wpcontent` element.
-	margin-right: 20px;
+	margin-right: 10px;
+
+	@include break-medium {
+		margin-right: 20px;
+	}
 
 	.components-tab-panel__tabs {
 		margin-bottom: 10px;

--- a/packages/edit-navigation/src/components/menu-editor/index.js
+++ b/packages/edit-navigation/src/components/menu-editor/index.js
@@ -11,6 +11,7 @@ import {
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import { Panel, PanelBody, Button } from '@wordpress/components';
+import { useViewportMatch } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -20,6 +21,7 @@ import MenuEditorShortcuts from './shortcuts';
 
 export default function MenuEditor( { menuId, blockEditorSettings } ) {
 	const [ blocks, setBlocks, saveBlocks ] = useNavigationBlocks( menuId );
+	const isLargeViewport = useViewportMatch( 'medium' );
 
 	return (
 		<div className="edit-navigation-menu-editor">
@@ -38,7 +40,10 @@ export default function MenuEditor( { menuId, blockEditorSettings } ) {
 				<BlockEditorKeyboardShortcuts />
 				<MenuEditorShortcuts saveBlocks={ saveBlocks } />
 				<Panel className="edit-navigation-menu-editor__panel">
-					<PanelBody title={ __( 'Navigation structure' ) }>
+					<PanelBody
+						title={ __( 'Navigation structure' ) }
+						initialOpen={ isLargeViewport }
+					>
 						{ !! blocks.length && (
 							<__experimentalBlockNavigationList
 								blocks={ blocks }

--- a/packages/edit-navigation/src/components/menu-editor/style.scss
+++ b/packages/edit-navigation/src/components/menu-editor/style.scss
@@ -1,5 +1,8 @@
 .edit-navigation-menu-editor {
 	display: grid;
-	grid-template-columns: 280px 1fr;
-	grid-column-gap: 10px;
+	grid-gap: 10px;
+
+	@include break-medium {
+		grid-template-columns: 280px 1fr;
+	}
 }

--- a/packages/edit-navigation/src/components/menus-editor/style.scss
+++ b/packages/edit-navigation/src/components/menus-editor/style.scss
@@ -3,14 +3,15 @@
 }
 
 .edit-navigation-menus-editor__menu-select-control {
-	.components-base-control__field {
-		display: flex;
-		flex-direction: row;
-		align-items: baseline;
-		margin-bottom: 0;
-	}
-
-	.components-base-control__label {
-		margin-right: 1ch;
+	@include break-small {
+		.components-base-control__field {
+			display: flex;
+			flex-direction: row;
+			align-items: baseline;
+			margin-bottom: 0;
+		}
+		.components-base-control__label {
+			margin-right: 1ch;
+		}
 	}
 }


### PR DESCRIPTION
## Description

Addresses #21337.

Changed CSS to make layout single column on small to medium screens.

I haven't touched the block toolbar here, because #21340 will make it work out of the box. 

## How has this been tested?

Tested in browser.

## Screenshots <!-- if applicable -->

<img width="454" alt="Screen Shot 2020-04-06 at 11 25 33 am" src="https://user-images.githubusercontent.com/8096000/78515475-5ed80980-77f9-11ea-8fa0-66864601a602.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
