### PR TITLE
Interface: Prepare the package for publishing to npm

### DIFF
--- a/packages/interface/.npmrc
+++ b/packages/interface/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/packages/interface/CHANGELOG.md
+++ b/packages/interface/CHANGELOG.md
@@ -1,0 +1,3 @@
+## Master
+
+Initial release.

--- a/packages/interface/README.md
+++ b/packages/interface/README.md
@@ -1,8 +1,6 @@
 # (Experimental) Interface
 
-The Interface Package contains the basis the start a modern WordPress screen as "core/edit-post" and "core/edit-site". The package offers a store and a set of components. The store is useful to contain common data required by a screen (e.g., active areas). The information is persisted across screen reloads. The components allow one to implement functionality like a sidebar and allow a screen to be extended by third-party plugins by default.
-
-
+The Interface Package contains the basis the start a new WordPress screen as Edit Post or Edit Site. The package offers a data store and a set of components. The store is useful to contain common data required by a screen (e.g., active areas). The information is persisted across screen reloads. The components allow one to implement functionality like a sidebar or menu items. Third-party plugins by default, can extend them.
 
 ## Installation
 
@@ -19,36 +17,46 @@ _This package assumes that your code will run in an **ES2015+** environment. If 
 
 ### Complementary Areas
 
+This component was named after a [complementatry landmark](https://www.w3.org/TR/wai-aria-practices/examples/landmarks/complementary.html) – a supporting section of the document, designed to be complementary to the main content at a similar level in the DOM hierarchy, but remains meaningful when separated from the main content.
+
 `ComplementaryArea` and `ComplementaryArea.Slot` form a slot fill pair to render complementary areas. Multiple `ComplementaryArea` components representing different complementary areas may be rendered at the same time, but only one appears on the slot depending on which complementary area is enabled.
 
 It is possible to control which complementary is enabled by using the store:
 
 Bellow are some examples of how to control the active complementary area using the store:
 ```js
-wp.data.select('core/interface').getActiveComplementaryArea( 'core/edit-post'); -> "edit-post/document'
+wp.data.select( 'core/interface' ).getActiveComplementaryArea( 'core/edit-post' );
+// -> "edit-post/document"
 
-wp.data.dispatch('core/interface').enableComplementaryArea( 'core/edit-post', 'edit-post/block' );
+wp.data.dispatch( 'core/interface' ).enableComplementaryArea( 'core/edit-post', 'edit-post/block' );
 
-wp.data.select('core/interface').getActiveComplementaryArea( 'core/edit-post'); -> "edit-post/block"
+wp.data.select( 'core/interface' ).getActiveComplementaryArea( 'core/edit-post' );
+// -> "edit-post/block"
 
-wp.data.dispatch('core/interface').disableComplementaryArea( 'core/edit-post' );
+wp.data.dispatch( 'core/interface' ).disableComplementaryArea( 'core/edit-post' );
 
-wp.data.select('core/interface').getActiveComplementaryArea( 'core/edit-post'); -> null
+wp.data.select( 'core/interface' ).getActiveComplementaryArea( 'core/edit-post' );
+// -> null
 ```
 
-### Pinned Areas
+### Pinned Items
 
-`PinnedItems` and `PinnedItems.Slot`form a slot fill pair to render pinned items or areas of "favorites". `ComplementaryArea` component makes use of `PinnedItems` and automatically adds a pinned item for the complementary areas marked as favorite.
+`PinnedItems` and `PinnedItems.Slot` form a slot fill pair to render pinned items (or areas) that act as a list of favorites similar to browser extensions listed in the Chrome Menu.
+
+Example usage: `ComplementaryArea` component makes use of `PinnedItems` and automatically adds a pinned item for the complementary areas marked as a favorite.
 
 ```js
-wp.data.select( 'core/interface' ).isItemPinned( 'core/edit-post', 'edit-post-block-patterns/block-patterns-sidebar' ); -> false
+wp.data.select( 'core/interface' ).isItemPinned( 'core/edit-post', 'edit-post-block-patterns/block-patterns-sidebar' );
+// -> false
 
-wp.data.dispatch('core/interface').pinItem( 'core/edit-post', 'edit-post-block-patterns/block-patterns-sidebar' ); 
+wp.data.dispatch( 'core/interface' ).pinItem( 'core/edit-post', 'edit-post-block-patterns/block-patterns-sidebar' );
 
-wp.data.select( 'core/interface' ).isItemPinned( 'core/edit-post', 'edit-post-block-patterns/block-patterns-sidebar' ); -> true
+wp.data.select( 'core/interface' ).isItemPinned( 'core/edit-post', 'edit-post-block-patterns/block-patterns-sidebar' );
+// -> true
 
-wp.data.dispatch('core/interface').unpinItem( 'core/edit-post', 'edit-post-block-patterns/block-patterns-sidebar' );
+wp.data.dispatch( 'core/interface' ).unpinItem( 'core/edit-post', 'edit-post-block-patterns/block-patterns-sidebar' );
 
 wp.data.select( 'core/interface' ).isItemPinned( 'core/edit-post', 'edit-post-block-patterns/block-patterns-sidebar' ); -> false
 ```
 
+<br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>

--- a/packages/interface/package.json
+++ b/packages/interface/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@wordpress/interface",
 	"version": "0.0.1",
-	"private": true,
 	"description": "Interface module for WordPress. The package contains shared functionality across the modern JavaScript-based WordPress screens.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
## Description
This PR removes the private flag from `@wordpress/interface` package. It's set as a dependency of other public packages so they would break otherwise.

I also added a few tweaks to the README file, added CHANGELOG file, and `.npmrc` file.