### PR TITLE
Apply the custom global styles CSS variables on the server

### DIFF
--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -134,12 +134,6 @@ addFilter(
 );
 
 addFilter(
-	'blocks.getSaveContent.extraProps',
-	'core/style/addSaveProps',
-	addSaveProps
-);
-
-addFilter(
 	'blocks.registerBlockType',
 	'core/style/addEditProps',
 	addEditProps


### PR DESCRIPTION
This PR tries to move the CSS styles variables generation to the server to avoid persisting these in the markup.

Some thoughts so far:

 - I like the fact that the markup stays pure
 - There's some code duplication on the frontend to apply the styles on the editor
 - I don't like that the markup generated by wp.blocks.serialize is a bit less portable.