### PR TITLE
Prevent typing on a Popover from closing the block toolbar

### DIFF
--- a/packages/block-editor/src/components/observe-typing/index.js
+++ b/packages/block-editor/src/components/observe-typing/index.js
@@ -43,6 +43,7 @@ function isKeyDownEligibleForStartTyping( event ) {
 }
 
 function ObserveTyping( { children, setTimeout: setSafeTimeout } ) {
+	const typingContainer = useRef();
 	const lastMouseMove = useRef();
 	const isTyping = useSelect( ( select ) =>
 		select( 'core/block-editor' ).isTyping()
@@ -130,11 +131,11 @@ function ObserveTyping( { children, setTimeout: setSafeTimeout } ) {
 
 		// Abort early if already typing, or key press is incurred outside a
 		// text field (e.g. arrow-ing through toolbar buttons).
-		// Ignore typing in a block toolbar
+		// Ignore typing if outside the current DOM container
 		if (
 			isTyping ||
 			! isTextField( target ) ||
-			target.closest( '.block-editor-block-toolbar' )
+			! typingContainer.current.contains( target )
 		) {
 			return;
 		}
@@ -176,6 +177,7 @@ function ObserveTyping( { children, setTimeout: setSafeTimeout } ) {
 	/* eslint-disable jsx-a11y/no-static-element-interactions */
 	return (
 		<div
+			ref={ typingContainer }
 			onFocus={ stopTypingOnNonTextField }
 			onKeyPress={ startTypingInTextField }
 			onKeyDown={ over( [

--- a/packages/e2e-tests/specs/editor/various/is-typing.test.js
+++ b/packages/e2e-tests/specs/editor/various/is-typing.test.js
@@ -1,0 +1,99 @@
+/**
+ * WordPress dependencies
+ */
+import { clickBlockAppender, createNewPost } from '@wordpress/e2e-test-utils';
+
+describe( 'isTyping', () => {
+	beforeEach( async () => {
+		await createNewPost();
+	} );
+
+	it( 'should hide the toolbar when typing', async () => {
+		const blockToolbarSelector = '.block-editor-block-toolbar';
+
+		await clickBlockAppender();
+
+		// Type in a paragraph
+		await page.keyboard.type( 'Type' );
+
+		// Toolbar is hidden
+		let blockToolbar = await page.$( blockToolbarSelector );
+		expect( blockToolbar ).toBe( null );
+
+		// Moving the mouse shows the toolbar
+		await page.mouse.move( 0, 0 );
+		await page.mouse.move( 10, 10 );
+
+		// Toolbar is visible
+		blockToolbar = await page.$( blockToolbarSelector );
+		expect( blockToolbar ).not.toBe( null );
+
+		// Typing again hides the toolbar
+		await page.keyboard.type( ' and continue' );
+
+		// Toolbar is hidden again
+		blockToolbar = await page.$( blockToolbarSelector );
+		expect( blockToolbar ).toBe( null );
+	} );
+
+	it( 'should not close the dropdown when typing in it', async () => {
+		// Adds a Dropdown with an input to all blocks
+		await page.evaluate( () => {
+			const { Dropdown, Button, Fill } = wp.components;
+			const { createElement: el, Fragment } = wp.element;
+			function AddDropdown( BlockListBlock ) {
+				return ( props ) => {
+					return el(
+						Fragment,
+						{},
+						el(
+							Fill,
+							{ name: 'BlockControls' },
+							el( Dropdown, {
+								renderToggle: ( { onToggle } ) =>
+									el(
+										Button,
+										{
+											onClick: onToggle,
+											className: 'dropdown-open',
+										},
+										'Open Dropdown'
+									),
+								renderContent: () =>
+									el( 'input', {
+										className: 'dropdown-input',
+									} ),
+							} )
+						),
+						el( BlockListBlock, props )
+					);
+				};
+			}
+
+			wp.hooks.addFilter(
+				'editor.BlockListBlock',
+				'e2e-test/add-dropdown',
+				AddDropdown
+			);
+		} );
+
+		await clickBlockAppender();
+
+		// Type in a paragraph
+		await page.keyboard.type( 'Type' );
+
+		// Show Toolbar
+		await page.mouse.move( 0, 0 );
+		await page.mouse.move( 10, 10 );
+
+		// Open the dropdown
+		await page.click( '.dropdown-open' );
+
+		// Type inside the dropdown's input
+		await page.type( '.dropdown-input', 'Random' );
+
+		// The input should still be visible
+		const input = await page.$( '.dropdown-input' );
+		expect( input ).not.toBe( null );
+	} );
+} );


### PR DESCRIPTION
closes #14890
closes #21402 

the isTyping flag should only be triggered when we type on the canvas. This can be achieved constantly by checking the DOM event (and not the React event bubbling)

**Testing instructions**

 - The added e2e tests fails on master but not this branch.