### PR TITLE
Migrate the font size classes to use CSS variables

### DIFF
--- a/packages/block-library/src/paragraph/style.scss
+++ b/packages/block-library/src/paragraph/style.scss
@@ -6,19 +6,19 @@
 }
 
 .is-small-text {
-	font-size: 14px;
+	--wp--typography--font-size: 14px;
 }
 
 .is-regular-text {
-	font-size: 16px;
+	--wp--typography--font-size: 16px;
 }
 
 .is-large-text {
-	font-size: 36px;
+	--wp--typography--font-size: 36px;
 }
 
 .is-larger-text {
-	font-size: 48px;
+	--wp--typography--font-size: 48px;
 }
 
 // Don't show the drop cap when editing the paragraph's content. It causes a

--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -219,25 +219,25 @@
 // Font sizes.
 :root {
 	.has-small-font-size {
-		font-size: 13px;
+		--wp--typography--font-size: 13px;
 	}
 
 	.has-regular-font-size, // Not used now, kept because of backward compatibility.
 	.has-normal-font-size {
-		font-size: 16px;
+		--wp--typography--font-size: 16px;
 	}
 
 	.has-medium-font-size {
-		font-size: 20px;
+		--wp--typography--font-size: 20px;
 	}
 
 	.has-large-font-size {
-		font-size: 36px;
+		--wp--typography--font-size: 36px;
 	}
 
 	.has-larger-font-size, // Not used now, kept because of backward compatibility.
 	.has-huge-font-size {
-		font-size: 42px;
+		--wp--typography--font-size: 42px;
 	}
 }
 


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/21153/files#r404193920

This PR migrates the font classes to use the CSS variables instead of using the font-size property directly.