### PR TITLE
Add font size control for heading block

### DIFF
--- a/packages/block-library/src/heading/index.js
+++ b/packages/block-library/src/heading/index.js
@@ -36,6 +36,7 @@ export const settings = {
 		lightBlockWrapper: true,
 		__experimentalColor: true,
 		__experimentalLineHeight: true,
+		__experimentalFontSize: true,
 	},
 	example: {
 		attributes: {


### PR DESCRIPTION
**Depends on** https://github.com/WordPress/gutenberg/pull/21428 which should land first.

This PR adds support for font-sizes at the heading block by leveraging the font size support key recently landed at https://github.com/WordPress/gutenberg/pull/21153

![200408-1047-heading-font-size](https://user-images.githubusercontent.com/583546/78764112-5f51db00-7986-11ea-884c-d7a0f3cb587c.png)

## How to test

- Apply this PR and https://github.com/WordPress/gutenberg/pull/21428
- Add some heading blocks and test that a new font size control is present in the block inspector.
- Test that it works as expected (choose a preset font, custom, check that it works in the front-end, etc).