### PR TITLE
[RNMobile] Align plus icon for the iOS Stepper control

### DIFF
--- a/packages/components/src/mobile/bottom-sheet/stepper-cell/stepper.ios.js
+++ b/packages/components/src/mobile/bottom-sheet/stepper-cell/stepper.ios.js
@@ -49,12 +49,7 @@ function Stepper( {
 				onPressOut={ onPressOut }
 				style={ [ buttonStyle, isMaxValue ? { opacity: 0.4 } : null ] }
 			>
-				<Icon
-					icon={ plus }
-					size={ 24 }
-					color={ buttonStyle.color }
-					style={ styles.plus }
-				/>
+				<Icon icon={ plus } size={ 24 } color={ buttonStyle.color } />
 			</TouchableOpacity>
 		</View>
 	);

--- a/packages/components/src/mobile/bottom-sheet/stepper-cell/style.native.scss
+++ b/packages/components/src/mobile/bottom-sheet/stepper-cell/style.native.scss
@@ -64,8 +64,3 @@
 .valueTextDark {
 	color: $light-opacity-200;
 }
-
-.plus {
-	margin-top: 4px;
-	margin-right: 1px;
-}


### PR DESCRIPTION
Fixes: https://github.com/wordpress-mobile/gutenberg-mobile/issues/2026
`gutenberg-mobile:` https://github.com/wordpress-mobile/gutenberg-mobile/pull/2116

## Description
<!-- Please describe what you have changed or added -->
Aligns the ➕ icon on the iOS stepper control to the middle of its container. Note this only applies to iOS as Android uses a chevron. 

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

1. Select a Gallery block with multiple images
2. Open settings with mobile toolbar settings button
3. Check the Stepper buttons

## Screenshots <!-- if applicable -->
<img width="427" alt="Screen Shot 2020-04-06 at 2 01 51 PM" src="https://user-images.githubusercontent.com/3384451/78593159-2db90280-7814-11ea-9562-12e43a67fe8c.png">


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
