### PR TITLE
Fullscreen Mode: Add a new keyboard shortcut to toggle Fullscreen Mode.

### DIFF
--- a/packages/edit-post/src/components/keyboard-shortcuts/index.js
+++ b/packages/edit-post/src/components/keyboard-shortcuts/index.js
@@ -30,6 +30,7 @@ function KeyboardShortcuts() {
 		switchEditorMode,
 		openGeneralSidebar,
 		closeGeneralSidebar,
+		toggleFeature,
 	} = useDispatch( 'core/edit-post' );
 	const { registerShortcut } = useDispatch( 'core/keyboard-shortcuts' );
 
@@ -41,6 +42,16 @@ function KeyboardShortcuts() {
 			keyCombination: {
 				modifier: 'secondary',
 				character: 'm',
+			},
+		} );
+
+		registerShortcut( {
+			name: 'core/edit-post/toggle-fullscreen',
+			category: 'global',
+			description: __( 'Toggle fullscreen mode.' ),
+			keyCombination: {
+				modifier: 'secondary',
+				character: 'f',
 			},
 		} );
 
@@ -117,6 +128,16 @@ function KeyboardShortcuts() {
 		{
 			bindGlobal: true,
 			isDisabled: ! richEditingEnabled || ! codeEditingEnabled,
+		}
+	);
+
+	useShortcut(
+		'core/edit-post/toggle-fullscreen',
+		() => {
+			toggleFeature( 'fullscreenMode' );
+		},
+		{
+			bindGlobal: true,
 		}
 	);
 


### PR DESCRIPTION
This PR aims to resolve #20626 by adding a keyboard shortcut to toggle Fullscreen Mode.

In my first attempt, cmd+option+shift+F will toggle Fullscreen Mode.