### PR TITLE
Correct slider step accordingly to the platform

### DIFF
--- a/packages/block-library/src/spacer/edit.js
+++ b/packages/block-library/src/spacer/edit.js
@@ -11,6 +11,7 @@ import { InspectorControls } from '@wordpress/block-editor';
 import { PanelBody, ResizableBox, RangeControl } from '@wordpress/components';
 import { compose, withInstanceId } from '@wordpress/compose';
 import { withDispatch } from '@wordpress/data';
+import { Platform } from '@wordpress/element';
 
 const MIN_SPACER_HEIGHT = 20;
 const MAX_SPACER_HEIGHT = 500;
@@ -72,7 +73,7 @@ const SpacerEdit = ( {
 						separatorType={ 'none' }
 						value={ height }
 						onChange={ updateHeight }
-						step={ 10 }
+						step={ Platform.OS === 'web' ? 10 : 1 }
 					/>
 				</PanelBody>
 			</InspectorControls>


### PR DESCRIPTION
## Description

Fixes: https://github.com/wordpress-mobile/gutenberg-mobile/issues/2117
Ref to gb-mobile:

Setting the slider step in `RangeControl` accordingly to the platform:
* web - 10
* mobile - 1

<!-- Please describe what you have changed or added -->

## How has this been tested?

1. Open mobile app
2. Add spacer block
3. Open spacer settings
4. Move slider
5. Expect that step value is 1

## Screenshots <!-- if applicable -->

![slider-step](https://user-images.githubusercontent.com/22746080/78656515-d07e8900-78c7-11ea-8a52-1fd1edf15cf9.gif)


## Types of changes

Used `Platform` from `@wordpress/element`
Add condition in step prop

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
