### PR TITLE
fix/[#21440] Copy/cut input values copying entire block

### DIFF
--- a/packages/dom/README.md
+++ b/packages/dom/README.md
@@ -118,6 +118,19 @@ _Returns_
 
 -   `boolean`: True if at the horizontal edge, false if not.
 
+<a name="isNumberInput" href="#isNumberInput">#</a> **isNumberInput**
+
+Check whether the given element is an input field of type number
+and has a valueAsNumber
+
+_Parameters_
+
+-   _element_ `HTMLElement`: The HTML element.
+
+_Returns_
+
+-   `boolean`: True if the element is input and holds a number.
+
 <a name="isTextField" href="#isTextField">#</a> **isTextField**
 
 Check whether the given element is a text field, where text field is defined

--- a/packages/dom/src/dom.js
+++ b/packages/dom/src/dom.js
@@ -470,6 +470,20 @@ export function isTextField( element ) {
 }
 
 /**
+ * Check whether the given element is an input field of type number
+ * and has a valueAsNumber
+ *
+ * @param {HTMLElement} element The HTML element.
+ *
+ * @return {boolean} True if the element is input and holds a number.
+ */
+export function isNumberInput( element ) {
+	const { nodeName, type, valueAsNumber } = element;
+
+	return nodeName === 'INPUT' && type === 'number' && !! valueAsNumber;
+}
+
+/**
  * Check wether the current document has a selection.
  * This checks both for focus in an input field and general text selection.
  *
@@ -477,6 +491,10 @@ export function isTextField( element ) {
  */
 export function documentHasSelection() {
 	if ( isTextField( document.activeElement ) ) {
+		return true;
+	}
+
+	if ( isNumberInput( document.activeElement ) ) {
 		return true;
 	}
 

--- a/packages/dom/src/test/dom.js
+++ b/packages/dom/src/test/dom.js
@@ -6,6 +6,7 @@ import {
 	placeCaretAtHorizontalEdge,
 	isTextField,
 	__unstableStripHTML as stripHTML,
+	isNumberInput,
 } from '../dom';
 
 describe( 'DOM', () => {
@@ -141,6 +142,21 @@ describe( 'DOM', () => {
 			expect( isTextField( document.createElement( 'textarea' ) ) ).toBe(
 				true
 			);
+		} );
+
+		it( 'should return false for empty input element of type number', () => {
+			const input = document.createElement( 'input' );
+			input.type = 'number';
+
+			expect( isNumberInput( input ) ).toBe( false );
+		} );
+
+		it( 'should return true for an input element of type number', () => {
+			const input = document.createElement( 'input' );
+			input.type = 'number';
+			input.valueAsNumber = 23;
+
+			expect( isNumberInput( input ) ).toBe( true );
 		} );
 
 		it( 'should return true for a contenteditable element', () => {


### PR DESCRIPTION
## Description
In `block-editor/src/components/copy-handler/index.js` this check does not pass 
```js
// Let native copy behaviour take over in input fields.
if ( ! hasMultiSelection() && documentHasSelection() ) {
	return;
}
```
because `documentHasSelection()` returns false. Going deeper we see there’s a check if a text fields has a selection 
```js
function documentHasSelection() {
	if ( isTextField( document.activeElement ) ) {
		return true;
	}

	const selection = window.getSelection();
	const range = selection.rangeCount ? selection.getRangeAt( 0 ) : null;

	return range && ! range.collapsed;
}
```
I then stumbled upon [this](https://stackoverflow.com/questions/21177489/selectionstart-selectionend-on-input-type-number-no-longer-allowed-in-chrome). Hence I added a function checking only `<input type="number" />`.

<!-- Please describe what you have changed or added -->

## How has this been tested?
In both Chrome and FF on MacOS. 
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Types of changes
Bug fix (non-breaking change) which fixes #21440 .
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
