### PR TITLE
Only scroll page for multi-selections

### DIFF
--- a/packages/block-editor/src/components/multi-select-scroll-into-view/index.js
+++ b/packages/block-editor/src/components/multi-select-scroll-into-view/index.js
@@ -21,19 +21,25 @@ import { getBlockDOMNode } from '../../utils/dom';
  */
 export default function MultiSelectScrollIntoView() {
 	const selector = ( select ) => {
-		const { getBlockSelectionEnd, isMultiSelecting } = select(
-			'core/block-editor'
-		);
+		const {
+			getBlockSelectionEnd,
+			hasMultiSelection,
+			isMultiSelecting,
+		} = select( 'core/block-editor' );
 
 		return {
 			selectionEnd: getBlockSelectionEnd(),
+			isMultiSelection: hasMultiSelection(),
 			isMultiSelecting: isMultiSelecting(),
 		};
 	};
-	const { selectionEnd, isMultiSelecting } = useSelect( selector, [] );
+	const { isMultiSelection, selectionEnd, isMultiSelecting } = useSelect(
+		selector,
+		[]
+	);
 
 	useEffect( () => {
-		if ( ! selectionEnd || isMultiSelecting ) {
+		if ( ! selectionEnd || isMultiSelecting || ! isMultiSelection ) {
 			return;
 		}
 
@@ -54,7 +60,7 @@ export default function MultiSelectScrollIntoView() {
 		scrollIntoView( extentNode, scrollContainer, {
 			onlyScrollIfNeeded: true,
 		} );
-	}, [ selectionEnd, isMultiSelecting ] );
+	}, [ isMultiSelection, selectionEnd, isMultiSelecting ] );
 
 	return null;
 }


### PR DESCRIPTION
closes #19682
closes #21432 

It seems that this component "MultiSelectScrollIntoView" has been refactored during the WP 5.4 lifecycle and it was triggering for simple selections too.

I'm not 100% certain this is the right fix but right now it only triggers for multi selections fixing this important bug #19682 
