### PR TITLE
CustomSelectControl: read currently selected value on focus

### DIFF
--- a/packages/components/src/custom-select-control/index.js
+++ b/packages/components/src/custom-select-control/index.js
@@ -7,7 +7,10 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
+import { speak } from '@wordpress/a11y';
+import { __, sprintf } from '@wordpress/i18n';
 import { Icon, check, chevronDown } from '@wordpress/icons';
+
 /**
  * Internal dependencies
  */
@@ -119,6 +122,20 @@ export default function CustomSelectControl( {
 					'aria-labelledby': undefined,
 					className: 'components-custom-select-control__button',
 					isSmall: true,
+					onFocus: ( event ) => {
+						if (
+							event?.relatedTarget?.tagName !== 'UL' &&
+							selectedItem
+						) {
+							speak(
+								sprintf(
+									/* translators: %s: currently selected value in the select control. */
+									__( '%s currently selected' ),
+									itemToString( selectedItem )
+								)
+							);
+						}
+					},
 				} ) }
 			>
 				{ itemToString( selectedItem ) }


### PR DESCRIPTION
Fixes #21459.

## Description

In WooCommerce Blocks we are using the `CustomSelectControl` component to allow the user to select a Country. We noticed when focusing it, the currently selected value is not presented to the user if they use a screen reader. (See https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/2040).

## How has this been tested?
I tested the `CustomSelectControl` component in the story book and in the _Preset Size_ option of the _Typography_ panel of the paragraph block. Basically testing that navigating to it with a screen reader presents the selected option to the user (ie: `Large currently selected`).

## Types of changes
a11y improvement

## Checklist:
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
