### PR TITLE
[RNMobile] - Layout Picker - Keyboard visibility improvements

### DIFF
--- a/packages/block-editor/src/components/page-template-picker/picker.native.js
+++ b/packages/block-editor/src/components/page-template-picker/picker.native.js
@@ -54,16 +54,17 @@ const __experimentalPageTemplatePicker = ( {
 	}, [ visible ] );
 
 	const onKeyboardDidShow = () => {
-		onKeyboardChange();
+		if ( visible ) {
+			setPickerVisible( shouldShowPicker() );
+			onPickerAnimation();
+		}
 	};
 
 	const onKeyboardDidHide = () => {
-		onKeyboardChange();
-	};
-
-	const onKeyboardChange = () => {
-		setPickerVisible( shouldShowPicker() );
-		onPickerAnimation();
+		if ( visible ) {
+			setPickerVisible( true );
+			onPickerAnimation();
+		}
 	};
 
 	const shouldShowPicker = () => {

--- a/packages/block-editor/src/components/page-template-picker/picker.native.js
+++ b/packages/block-editor/src/components/page-template-picker/picker.native.js
@@ -36,13 +36,13 @@ const __experimentalPageTemplatePicker = ( {
 
 	const [ templatePreview, setTemplatePreview ] = useState();
 	const [ pickerVisible, setPickerVisible ] = useState( visible );
-	const contentOpacity = useRef( new Animated.Value( 0 ) );
+	const contentOpacity = useRef( new Animated.Value( 0 ) ).current;
 
 	useEffect( () => {
 		if ( shouldShowPicker() && visible && ! pickerVisible ) {
 			setPickerVisible( true );
 		}
-		onPickerAnimation();
+		startPickerAnimation( visible );
 
 		Keyboard.addListener( 'keyboardDidShow', onKeyboardDidShow );
 		Keyboard.addListener( 'keyboardDidHide', onKeyboardDidHide );
@@ -55,15 +55,14 @@ const __experimentalPageTemplatePicker = ( {
 
 	const onKeyboardDidShow = () => {
 		if ( visible ) {
-			setPickerVisible( shouldShowPicker() );
-			onPickerAnimation();
+			startPickerAnimation( shouldShowPicker() );
 		}
 	};
 
 	const onKeyboardDidHide = () => {
 		if ( visible ) {
 			setPickerVisible( true );
-			onPickerAnimation();
+			startPickerAnimation( true );
 		}
 	};
 
@@ -85,14 +84,14 @@ const __experimentalPageTemplatePicker = ( {
 		setTemplatePreview( undefined );
 	};
 
-	const onPickerAnimation = () => {
-		Animated.timing( contentOpacity.current, {
-			toValue: visible ? 1 : 0,
+	const startPickerAnimation = ( isVisible ) => {
+		Animated.timing( contentOpacity, {
+			toValue: isVisible ? 1 : 0,
 			duration: 300,
 			useNativeDriver: true,
 		} ).start( () => {
-			if ( ! visible ) {
-				setPickerVisible( false );
+			if ( ! isVisible ) {
+				setPickerVisible( isVisible );
 			}
 		} );
 	};
@@ -102,7 +101,7 @@ const __experimentalPageTemplatePicker = ( {
 	}
 
 	return (
-		<Animated.View style={ [ { opacity: contentOpacity.current } ] }>
+		<Animated.View style={ [ { opacity: contentOpacity } ] }>
 			<Container>
 				{ templates.map( ( template ) => (
 					<Button

--- a/packages/block-editor/src/components/page-template-picker/picker.native.js
+++ b/packages/block-editor/src/components/page-template-picker/picker.native.js
@@ -8,7 +8,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
  * External dependencies
  */
 import { logUserEvent, userEvents } from 'react-native-gutenberg-bridge';
-import { Animated } from 'react-native';
+import { Animated, Dimensions, Keyboard } from 'react-native';
 
 /**
  * Internal dependencies
@@ -17,6 +17,9 @@ import Button from './button';
 import Container from './container';
 import getDefaultTemplates from './default-templates';
 import Preview from './preview';
+
+// Used to hide the picker if there's no enough space in the window
+const PICKER_HEIGHT_OFFSET = 150;
 
 const __experimentalPageTemplatePicker = ( {
 	templates = getDefaultTemplates(),
@@ -36,8 +39,39 @@ const __experimentalPageTemplatePicker = ( {
 	const contentOpacity = useRef( new Animated.Value( 0 ) );
 
 	useEffect( () => {
+		if ( shouldShowPicker() && visible && ! pickerVisible ) {
+			setPickerVisible( true );
+		}
 		onPickerAnimation();
+
+		Keyboard.addListener( 'keyboardDidShow', onKeyboardDidShow );
+		Keyboard.addListener( 'keyboardDidHide', onKeyboardDidHide );
+
+		return () => {
+			Keyboard.removeListener( 'keyboardDidShow', onKeyboardDidShow );
+			Keyboard.removeListener( 'keyboardDidHide', onKeyboardDidHide );
+		};
 	}, [ visible ] );
+
+	const onKeyboardDidShow = () => {
+		onKeyboardChange();
+	};
+
+	const onKeyboardDidHide = () => {
+		onKeyboardChange();
+	};
+
+	const onKeyboardChange = () => {
+		setPickerVisible( shouldShowPicker() );
+		onPickerAnimation();
+	};
+
+	const shouldShowPicker = () => {
+		// On smaller devices on landscape we hide the picker
+		// so it doesn't overlap with the editor's content
+		const windowHeight = Dimensions.get( 'window' ).height;
+		return PICKER_HEIGHT_OFFSET < windowHeight / 3;
+	};
 
 	const onApply = () => {
 		editPost( {
@@ -51,10 +85,6 @@ const __experimentalPageTemplatePicker = ( {
 	};
 
 	const onPickerAnimation = () => {
-		if ( visible && ! pickerVisible ) {
-			setPickerVisible( true );
-		}
-
 		Animated.timing( contentOpacity.current, {
 			toValue: visible ? 1 : 0,
 			duration: 300,


### PR DESCRIPTION
`Gutenberg Mobile PR`-> https://github.com/wordpress-mobile/gutenberg-mobile/pull/2123

## Description
While [testing the picker functionality](https://github.com/wordpress-mobile/gutenberg-mobile/issues/2088) it was found that on some smaller devices the picker would cover part of the editor.

It was agreed to tweak the visibility of the picker depending on:

- If the keyboard is closed: Display the template picker buttons normally
- If the keyboard is open: Check if window height is enough(detect a good enough threshold), if not, just hide the buttons.

From https://github.com/wordpress-mobile/gutenberg-mobile/issues/2088#issuecomment-608526655

## Screenshots 

<details><summary>iPhone 6S</summary>

<img src="https://user-images.githubusercontent.com/4885740/78684603-f4a29000-78f0-11ea-90f1-b3e3aeec79fd.gif" width="500" />

</details>

<details><summary>iPhone 11</summary>

<img src="https://user-images.githubusercontent.com/4885740/78684769-29aee280-78f1-11ea-9ec2-125d8f0b02f9.gif" width="500" />

</details>

<details><summary>iPad</summary>

<img src="https://user-images.githubusercontent.com/4885740/78684836-3b908580-78f1-11ea-9c06-e286ecadb3af.gif" width="500" />

</details>

<details><summary>Android</summary>

<img src="https://user-images.githubusercontent.com/4885740/78684891-506d1900-78f1-11ea-9389-b39d2af8d4c6.gif" width="300" />

</details>

## How has this been tested?

### On a mobile device

- Open the WordPress app with metro running
- Double check that you have the keyboard turned on in the simulator
- With the device on Portrait, go to pages and create a new one
- Tap on the first Paragraph block
- **Expect** to see the layout template picker
- Rotate the simulator to landscape
- **Expect** to **not** see the layout template picker
- Hide the keyboard with the toolbar button
- **Expect** to see the layout picker to be visible
- Tap on the paragraph block
- **Expect** to **not** see the layout picker

### On a tablet

- Open the WordPress app with metro running
- Double check that you have the keyboard turned on in the simulator
- With the device on Portrait, go to pages and create a new one
- Tap on the first Paragraph block
- **Expect** to see the layout template picker
- Rotate the simulator to landscape
- **Expect** to see the buttons
- Hide the keyboard with the toolbar button
- **Expect** to see the layout picker to be visible
- Tap on the paragraph block
- **Expect** to see the layout picker

Note: While on portrait the only time the picker should be hidden is when there is content in the editor. E.g the first Paragraph block with some text.

## Types of changes
Improvement

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
