### PR TITLE
Block API: Add Block Context support

### DIFF
--- a/docs/designers-developers/developers/block-api/block-context.md
+++ b/docs/designers-developers/developers/block-api/block-context.md
@@ -12,19 +12,21 @@ Block context is defined in the registered settings of a block. A block can prov
 
 ### Providing Block Context
 
-A block can provide a context value by assigning a `providesContext` property in its registered settings. This is an array of the attribute names which will be made available to descendent blocks via context. Currently, block context only supports values derived from the block's own attributes. This could be enhanced in the future to support additional sources of context values.
+A block can provide a context value by assigning a `providesContext` property in its registered settings. This is an object which maps a context name to one of the block's own attribute. The value corresponding to that attribute value is made available to descendent blocks and can be referenced by the same context name. Currently, block context only supports values derived from the block's own attributes. This could be enhanced in the future to support additional sources of context values.
 
-_block.json_
+`record/block.json`
 
 ```json
 {
-	"name": "core/post",
+	"name": "my-plugin/record",
 	"attributes": {
-		"postId": {
+		"recordId": {
 			"type": "number"
 		}
 	},
-	"providesContext": [ "postId" ]
+	"providesContext": {
+		"my-plugin/recordId": "recordId"
+	}
 }
 ```
 
@@ -32,12 +34,12 @@ _block.json_
 
 A block can inherit a context value from an ancestor provider by assigning a `context` property in its registered settings. This should be assigned as an array of the context names the block seeks to inherit.
 
-_block.json_
+`record-title/block.json`
 
 ```json
 {
-	"name": "core/post-excerpt",
-	"context": [ "postId" ]
+	"name": "my-plugin/record-title",
+	"context": [ "my-plugin/recordId" ]
 }
 ```
 
@@ -47,11 +49,11 @@ Once a block has defined the context it seeks to inherit, this can be accessed i
 
 ### JavaScript
 
-_post-excerpt/edit.js_
+`record-title/edit.js`
 
 ```js
 function edit( { context } ) {
-	return 'The current post ID is: ' + context.postId;
+	return 'The current record ID is: ' + context[ 'my-plugin/recordId' ];
 }
 ```
 
@@ -59,12 +61,12 @@ function edit( { context } ) {
 
 Note that in PHP, block context is accessed using the `$block` global which is assigned at the time a block is registered. This is unlike block attributes or block content, which are provided as arguments to the `render_callback` function. At some point in the future, block context may be integrated into the function arguments signature of `render_callback`, or an alternative block settings configuration may enable a render callback to receive the full block array as its argument.
 
-_post-excerpt/index.php_
+`record-title/index.php`
 
 ```js
-function render_block_core_post_excerpt() {
+function my_plugin_render_block_record_title() {
 	global $block;
 
-	return 'The current post ID is: ' . $block['context']['postId'];
+	return 'The current record ID is: ' . $block['context']['my-plugin/recordId'];
 }
 ```

--- a/docs/designers-developers/developers/block-api/block-context.md
+++ b/docs/designers-developers/developers/block-api/block-context.md
@@ -30,6 +30,8 @@ A block can provide a context value by assigning a `providesContext` property in
 }
 ```
 
+As seen in the above example, it is recommended that you include a namespace as part of the name of the context key so as to avoid potential conflicts with other plugins or default context values provided by WordPress. The context namespace should be specific to your plugin, and in most cases can be the same as used in the name of the block itself.
+
 ### Consuming Block Context
 
 A block can inherit a context value from an ancestor provider by assigning a `context` property in its registered settings. This should be assigned as an array of the context names the block seeks to inherit.

--- a/docs/designers-developers/developers/block-api/block-context.md
+++ b/docs/designers-developers/developers/block-api/block-context.md
@@ -14,7 +14,9 @@ Block context is defined in the registered settings of a block. A block can prov
 
 A block can provide a context value by assigning a `providesContext` property in its registered settings. This is an array of the attribute names which will be made available to descendent blocks via context. Currently, block context only supports values derived from the block's own attributes. This could be enhanced in the future to support additional sources of context values.
 
-_block.json_
+Note that when context is assigned, names of context keys provided by a block are automatically namespaced using the same namespace defined in the block's name. For the core set of blocks defined by WordPress, the namespace is omitted.
+
+`post/block.json`
 
 ```json
 {
@@ -28,16 +30,46 @@ _block.json_
 }
 ```
 
+`record/block.json`
+
+```json
+{
+	"name": "my-plugin/record",
+	"attributes": {
+		"recordId": {
+			"type": "number"
+		}
+	},
+	"providesContext": [ "recordId" ]
+}
+```
+
 ### Consuming Block Context
 
 A block can inherit a context value from an ancestor provider by assigning a `context` property in its registered settings. This should be assigned as an array of the context names the block seeks to inherit.
 
-_block.json_
+Note that when context is assigned, names of context keys provided by a block are automatically namespaced using the same namespace defined in the block's name. For the core set of blocks defined by WordPress, the namespace is omitted.
+
+`post-title/block.json`
 
 ```json
 {
 	"name": "core/post-excerpt",
 	"context": [ "postId" ]
+}
+```
+
+`record-title/block.json`
+
+```json
+{
+	"name": "my-plugin/record-title",
+	"attributes": {
+		"recordId": {
+			"type": "number"
+		}
+	},
+	"context": [ "my-plugin/recordId" ]
 }
 ```
 

--- a/docs/designers-developers/developers/block-api/block-context.md
+++ b/docs/designers-developers/developers/block-api/block-context.md
@@ -12,7 +12,7 @@ Block context is defined in the registered settings of a block. A block can prov
 
 ### Providing Block Context
 
-A block can provide a context value by assigning a `providesContext` property in its registered settings. This should be assigned as an array of the attribute names for attribute values to assign as context. Currently, block context only supports values derived from the block's own attributes. This could be enhanced in the future to support additional sources of context values.
+A block can provide a context value by assigning a `providesContext` property in its registered settings. This is an array of the attribute names which will be made available to descendent blocks via context. Currently, block context only supports values derived from the block's own attributes. This could be enhanced in the future to support additional sources of context values.
 
 _block.json_
 

--- a/docs/designers-developers/developers/block-api/block-context.md
+++ b/docs/designers-developers/developers/block-api/block-context.md
@@ -1,10 +1,10 @@
 # Block Context
 
-Block context is a feature which enables ancestor blocks to provide values which can be consumed by descendent blocks within its own hierarchy. Those descendent blocks can inherit this value without resorting to hard-coded values, or without an explicit awareness of the block which provides those values.
+Block context is a feature which enables ancestor blocks to provide values which can be consumed by descendent blocks within its own hierarchy. Those descendent blocks can inherit these values without resorting to hard-coded values and without an explicit awareness of the block which provides those values.
 
-This is especially useful in full-site editing where, for example, the contents of a block may depend on the context of the post in which it is relevant. A blogroll template may show excerpts of many different posts. Using block context, there can still be one single "Post Excerpt" block which displays the contents of the post based on an inherited post ID.
+This is especially useful in full-site editing where, for example, the contents of a block may depend on the context of the post in which it is displayed. A blogroll template may show excerpts of many different posts. Using block context, there can still be one single "Post Excerpt" block which displays the contents of the post based on an inherited post ID.
 
-If you are familiar with [React Context](https://reactjs.org/docs/context.html), the idea is very similar. In fact, the client-side block editor implementation of block context is a very simple application of React Context. Block context is also supported in server-side `render_callback` implementations, demonstrated in the examples below.
+If you are familiar with [React Context](https://reactjs.org/docs/context.html), block context adopts many of the same ideas. In fact, the client-side block editor implementation of block context is a very simple application of React Context. Block context is also supported in server-side `render_callback` implementations, demonstrated in the examples below.
 
 ## Defining Block Context
 

--- a/docs/designers-developers/developers/block-api/block-context.md
+++ b/docs/designers-developers/developers/block-api/block-context.md
@@ -14,9 +14,7 @@ Block context is defined in the registered settings of a block. A block can prov
 
 A block can provide a context value by assigning a `providesContext` property in its registered settings. This is an array of the attribute names which will be made available to descendent blocks via context. Currently, block context only supports values derived from the block's own attributes. This could be enhanced in the future to support additional sources of context values.
 
-Note that when context is assigned, names of context keys provided by a block are automatically namespaced using the same namespace defined in the block's name. For the core set of blocks defined by WordPress, the namespace is omitted.
-
-`post/block.json`
+_block.json_
 
 ```json
 {
@@ -30,46 +28,16 @@ Note that when context is assigned, names of context keys provided by a block ar
 }
 ```
 
-`record/block.json`
-
-```json
-{
-	"name": "my-plugin/record",
-	"attributes": {
-		"recordId": {
-			"type": "number"
-		}
-	},
-	"providesContext": [ "recordId" ]
-}
-```
-
 ### Consuming Block Context
 
 A block can inherit a context value from an ancestor provider by assigning a `context` property in its registered settings. This should be assigned as an array of the context names the block seeks to inherit.
 
-Note that when context is assigned, names of context keys provided by a block are automatically namespaced using the same namespace defined in the block's name. For the core set of blocks defined by WordPress, the namespace is omitted.
-
-`post-title/block.json`
+_block.json_
 
 ```json
 {
 	"name": "core/post-excerpt",
 	"context": [ "postId" ]
-}
-```
-
-`record-title/block.json`
-
-```json
-{
-	"name": "my-plugin/record-title",
-	"attributes": {
-		"recordId": {
-			"type": "number"
-		}
-	},
-	"context": [ "my-plugin/recordId" ]
 }
 ```
 

--- a/docs/designers-developers/developers/block-api/block-context.md
+++ b/docs/designers-developers/developers/block-api/block-context.md
@@ -1,0 +1,70 @@
+# Block Context
+
+Block context is a feature which enables ancestor blocks to provide values which can be consumed by descendent blocks within its own hierarchy. Those descendent blocks can inherit this value without resorting to hard-coded values, or without an explicit awareness of the block which provides those values.
+
+This is especially useful in full-site editing where, for example, the contents of a block may depend on the context of the post in which it is relevant. A blogroll template may show excerpts of many different posts. Using block context, there can still be one single "Post Excerpt" block which displays the contents of the post based on an inherited post ID.
+
+If you are familiar with [React Context](https://reactjs.org/docs/context.html), the idea is very similar. In fact, the client-side block editor implementation of block context is a very simple application of React Context. Block context is also supported in server-side `render_callback` implementations, demonstrated in the examples below.
+
+## Defining Block Context
+
+Block context is defined in the registered settings of a block. A block can provide a context value, or consume a value it seeks to inherit.
+
+### Providing Block Context
+
+A block can provide a context value by assigning a `providesContext` property in its registered settings. This should be assigned as an array of the attribute names for attribute values to assign as context. Currently, block context only supports values derived from the block's own attributes. This could be enhanced in the future to support additional sources of context values.
+
+_block.json_
+
+```json
+{
+	"name": "core/post",
+	"attributes": {
+		"postId": {
+			"type": "number"
+		}
+	},
+	"providesContext": [ "postId" ]
+}
+```
+
+### Consuming Block Context
+
+A block can inherit a context value from an ancestor provider by assigning a `context` property in its registered settings. This should be assigned as an array of the context names the block seeks to inherit.
+
+_block.json_
+
+```json
+{
+	"name": "core/post-excerpt",
+	"context": [ "postId" ]
+}
+```
+
+## Using Block Context
+
+Once a block has defined the context it seeks to inherit, this can be accessed in the implementation of `edit` (JavaScript) and `render_callback` (PHP). It is provided as an object (JavaScript) or associative array (PHP) of the context values which have been defined for the block. Note that even if there is an ancestor which provides a context value, the value will only be made available if the block explicitly defines a desire to inherit that value.
+
+### JavaScript
+
+_post-excerpt/edit.js_
+
+```js
+function edit( { context } ) {
+	return 'The current post ID is: ' + context.postId;
+}
+```
+
+### PHP
+
+Note that in PHP, block context is accessed using the `$block` global which is assigned at the time a block is registered. This is unlike block attributes or block content, which are provided as arguments to the `render_callback` function. At some point in the future, block context may be integrated into the function arguments signature of `render_callback`, or an alternative block settings configuration may enable a render callback to receive the full block array as its argument.
+
+_post-excerpt/index.php_
+
+```js
+function render_block_core_post_excerpt() {
+	global $block;
+
+	return 'The current post ID is: ' . $block['context']['postId'];
+}
+```

--- a/docs/designers-developers/developers/block-api/block-context.md
+++ b/docs/designers-developers/developers/block-api/block-context.md
@@ -47,28 +47,30 @@ A block can inherit a context value from an ancestor provider by assigning a `co
 
 ## Using Block Context
 
-Once a block has defined the context it seeks to inherit, this can be accessed in the implementation of `edit` (JavaScript) and `render_callback` (PHP). It is provided as an object (JavaScript) or associative array (PHP) of the context values which have been defined for the block. Note that even if there is an ancestor which provides a context value, the value will only be made available if the block explicitly defines a desire to inherit that value.
+Once a block has defined the context it seeks to inherit, this can be accessed in the implementation of `edit` (JavaScript) and `render_callback` (PHP). It is provided as an object (JavaScript) or associative array (PHP) of the context values which have been defined for the block. Note that a context value will only be made available if the block explicitly defines a desire to inherit that value.
 
 ### JavaScript
 
-`record-title/edit.js`
+`record-title/index.js`
 
 ```js
-function edit( { context } ) {
-	return 'The current record ID is: ' + context[ 'my-plugin/recordId' ];
-}
+registerBlockType( 'my-plugin/record-title', {
+	edit( { context } ) {
+		return 'The current record ID is: ' + context[ 'my-plugin/recordId' ];
+	},
+} );
 ```
 
 ### PHP
 
-Note that in PHP, block context is accessed using the `$block` global which is assigned at the time a block is registered. This is unlike block attributes or block content, which are provided as arguments to the `render_callback` function. At some point in the future, block context may be integrated into the function arguments signature of `render_callback`, or an alternative block settings configuration may enable a render callback to receive the full block array as its argument.
+A block's context values are available from the `context` property of the `$block` argument passed to the `render_callback` function.
 
 `record-title/index.php`
 
-```js
-function my_plugin_render_block_record_title() {
-	global $block;
-
-	return 'The current record ID is: ' . $block['context']['my-plugin/recordId'];
-}
+```php
+register_block_type( 'my-plugin/record-title', [
+	'render_callback' => function( $block ) {
+		return 'The current record ID is: ' . $block->context['my-plugin/recordId'];
+	},
+] );
 ```

--- a/docs/designers-developers/developers/tutorials/block-tutorial/creating-dynamic-blocks.md
+++ b/docs/designers-developers/developers/tutorials/block-tutorial/creating-dynamic-blocks.md
@@ -99,7 +99,7 @@ Because it is a dynamic block it doesn't need to override the default `save` imp
  * Plugin Name: Gutenberg examples dynamic
  */
 
-function gutenberg_examples_dynamic_render_callback( $attributes, $content ) {
+function gutenberg_examples_dynamic_render_callback( $block, $content ) {
 	$recent_posts = wp_get_recent_posts( array(
 		'numberposts' => 1,
 		'post_status' => 'publish',
@@ -141,7 +141,15 @@ There are a few things to notice:
 
 * The `edit` function still shows a representation of the block in the editor's context (this could be very different from the rendered version, it's up to the block's author)
 * The built-in `save` function just returns `null` because the rendering is performed server-side.
-* The server-side rendering is a function taking the block attributes and the block inner content as arguments, and returning the markup (quite similar to shortcodes)
+* The server-side rendering is a function taking the block and the block inner content as arguments, and returning the markup (quite similar to shortcodes)
+
+Note that for convenience and for backward-compatibility, the first argument of a `render_callback` function can also be referenced as an associative array of the block's attributes:
+
+```php
+function gutenberg_examples_dynamic_render_callback( $block_attributes ) {
+	return 'The record ID is: ' . esc_html( $block_attributes['recordId'] );
+}
+```
 
 ## Live rendering in the block editor
 

--- a/docs/designers-developers/developers/tutorials/metabox/meta-block-4-use-data.md
+++ b/docs/designers-developers/developers/tutorials/metabox/meta-block-4-use-data.md
@@ -25,7 +25,7 @@ You can also use the post meta data in other blocks. For this example the data i
 In PHP, use the [register_block_type](https://developer.wordpress.org/reference/functions/register_block_type/) function to set a callback when the block is rendered to include the meta value.
 
 ```php
-function myguten_render_paragraph( $attributes, $content ) {
+function myguten_render_paragraph( $block, $content ) {
 	$value = get_post_meta( get_the_ID(), 'myguten_meta_block_field', true );
 	// check value is set before outputting
 	if ( $value ) {

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -72,6 +72,12 @@
 		"parent": "block-api"
 	},
 	{
+		"title": "Block Context",
+		"slug": "block-context",
+		"markdown_source": "../docs/designers-developers/developers/block-api/block-context.md",
+		"parent": "block-api"
+	},
+	{
 		"title": "Deprecated Blocks",
 		"slug": "block-deprecation",
 		"markdown_source": "../docs/designers-developers/developers/block-api/block-deprecation.md",

--- a/docs/toc.json
+++ b/docs/toc.json
@@ -13,7 +13,8 @@
 			{ "docs/designers-developers/developers/block-api/block-registration.md": [] },
 			{ "docs/designers-developers/developers/block-api/block-edit-save.md": [] },
 			{ "docs/designers-developers/developers/block-api/block-attributes.md": [] },
-			{"docs/designers-developers/developers/block-api/block-deprecation.md": [] },
+			{ "docs/designers-developers/developers/block-api/block-context.md": [] },
+			{ "docs/designers-developers/developers/block-api/block-deprecation.md": [] },
 			{ "docs/designers-developers/developers/block-api/block-templates.md": [] },
 			{ "docs/designers-developers/developers/block-api/block-patterns.md": [] },
 			{ "docs/designers-developers/developers/block-api/block-annotations.md": [] }

--- a/lib/class-wp-block.php
+++ b/lib/class-wp-block.php
@@ -120,7 +120,7 @@ class WP_Block implements ArrayAccess {
 
 		$prepared_attributes = $this->attributes;
 		if ( ! is_null( $block_type ) ) {
-			$prepared_attributes = $block_type->prepare_attributes_for_render( $this->attributes );
+			$prepared_attributes = $block_type->prepare_attributes_for_render( $prepared_attributes );
 		}
 
 		/* phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase */

--- a/lib/class-wp-block.php
+++ b/lib/class-wp-block.php
@@ -1,0 +1,215 @@
+<?php
+/**
+ * Blocks API: WP_Block class
+ *
+ * @package Gutenberg
+ */
+
+/**
+ * Class representing a parsed instance of a block.
+ */
+class WP_Block implements ArrayAccess {
+
+	/**
+	 * Name of block.
+	 *
+	 * @example "core/paragraph"
+	 *
+	 * @var string
+	 */
+	public $name;
+
+	/**
+	 * Block type context values.
+	 *
+	 * @var array
+	 */
+	public $context = [];
+
+	/**
+	 * Block type attribute values.
+	 *
+	 * @var array
+	 */
+	public $attributes = [];
+
+	/**
+	 * List of inner blocks (of this same class)
+	 *
+	 * @var WP_Block[]
+	 */
+	public $inner_blocks = [];
+
+	/**
+	 * Resultant HTML from inside block comment delimiters after removing inner
+	 * blocks.
+	 *
+	 * @example "...Just <!-- wp:test /--> testing..." -> "Just testing..."
+	 *
+	 * @var string
+	 */
+	public $inner_html = '';
+
+	/**
+	 * List of string fragments and null markers where inner blocks were found
+	 *
+	 * @example array(
+	 *   'inner_html'    => 'BeforeInnerAfter',
+	 *   'inner_blocks'  => array( block, block ),
+	 *   'inner_content' => array( 'Before', null, 'Inner', null, 'After' ),
+	 * )
+	 *
+	 * @var array
+	 */
+	public $inner_content = [];
+
+	/**
+	 * Constructor.
+	 *
+	 * Populates object properties from the provided block instance argument.
+	 *
+	 * @param array $block Array of parsed block properties.
+	 */
+	public function __construct( $block ) {
+		$this->name = $block['blockName'];
+
+		if ( ! empty( $block['attrs'] ) ) {
+			$this->attributes = $block['attrs'];
+		}
+
+		if ( ! empty( $block['innerBlocks'] ) ) {
+			$this->inner_blocks = array_map(
+				function( $inner_block ) {
+					return new WP_Block( $inner_block );
+				},
+				$block['innerBlocks']
+			);
+		}
+
+		if ( ! empty( $block['innerHTML'] ) ) {
+			$this->inner_html = $block['innerHTML'];
+		}
+
+		if ( ! empty( $block['innerContent'] ) ) {
+			$this->inner_content = $block['innerContent'];
+		}
+	}
+
+	/**
+	 * Generates the render output for the block.
+	 *
+	 * @return string Rendered block output.
+	 */
+	public function render() {
+		global $post, $_block_context;
+
+		$block_type    = WP_Block_Type_Registry::get_instance()->get_registered( $this->name );
+		$is_dynamic    = $this->name && null !== $block_type && $block_type->is_dynamic();
+		$block_content = '';
+		$index         = 0;
+
+		$block_context_before = $_block_context;
+
+		if ( ! isset( $_block_context ) ) {
+			$_block_context = array();
+		}
+
+		if ( ! isset( $_block_context['postId'] ) || $post->ID !== $_block_context['postId'] ) {
+			$_block_context['postId'] = $post->ID;
+		}
+
+		$prepared_attributes = $this->attributes;
+		if ( ! is_null( $block_type ) ) {
+			$prepared_attributes = $block_type->prepare_attributes_for_render( $this->attributes );
+		}
+
+		/* phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase */
+		if ( ! empty( $block_type->providesContext ) && is_array( $block_type->providesContext ) ) {
+			foreach ( $block_type->providesContext as $context_name => $attribute_name ) {
+				if ( isset( $prepared_attributes[ $attribute_name ] ) ) {
+					$_block_context[ $context_name ] = $prepared_attributes[ $attribute_name ];
+				}
+			}
+		}
+		/* phpcs:enable */
+
+		if ( $is_dynamic ) {
+			if ( isset( $block_type->context ) && is_array( $block_type->context ) ) {
+				foreach ( $block_type->context as $context_name ) {
+					if ( array_key_exists( $context_name, $_block_context ) ) {
+						$this->context[ $context_name ] = $_block_context[ $context_name ];
+					}
+				}
+			}
+
+			$global_post   = $post;
+			$block_content = (string) call_user_func( $block_type->render_callback, $this, $block_content );
+			$post          = $global_post;
+		} else {
+			foreach ( $this->inner_content as $chunk ) {
+				$block_content .= is_string( $chunk ) ?
+					$chunk :
+					$this->inner_blocks[ $index++ ]->render();
+			}
+		}
+
+		$_block_context = $block_context_before;
+
+		return $block_content;
+	}
+
+	/**
+	 * Returns true if an attribute exists by the specified attribute name, or
+	 * false otherwise.
+	 *
+	 * @link https://www.php.net/manual/en/arrayaccess.offsetexists.php
+	 *
+	 * @param string $attribute_name Name of attribute to check.
+	 *
+	 * @return bool Whether attribute exists.
+	 */
+	public function offsetExists( $attribute_name ) {
+		return isset( $this->attributes[ $attribute_name ] );
+	}
+
+	/**
+	 * Returns the value by the specified attribute name.
+	 *
+	 * @link https://www.php.net/manual/en/arrayaccess.offsetget.php
+	 *
+	 * @param string $attribute_name Name of attribute value to retrieve.
+	 *
+	 * @return mixed|null Attribute value if exists, or null.
+	 */
+	public function offsetGet( $attribute_name ) {
+		return isset( $this->attributes[ $attribute_name ] ) ?
+			$this->attributes[ $attribute_name ] :
+			null;
+	}
+
+	/**
+	 * Assign an attribute value by the specified attribute name.
+	 *
+	 * @link https://www.php.net/manual/en/arrayaccess.offsetset.php
+	 *
+	 * @param string $attribute_name Name of attribute value to set.
+	 * @param mixed  $value          Attribute value.
+	 */
+	public function offsetSet( $attribute_name, $value ) {
+		if ( ! is_null( $attribute_name ) ) {
+			$this->attributes[ $attribute_name ] = $value;
+		}
+	}
+
+	/**
+	 * Unset an attribute.
+	 *
+	 * @link https://www.php.net/manual/en/arrayaccess.offsetunset.php
+	 *
+	 * @param string $attribute_name Name of attribute value to unset.
+	 */
+	public function offsetUnset( $attribute_name ) {
+		unset( $this->attributes[ $attribute_name ] );
+	}
+
+}

--- a/lib/class-wp-block.php
+++ b/lib/class-wp-block.php
@@ -201,9 +201,10 @@ class WP_Block implements ArrayAccess {
 	 * @return mixed|null Attribute value if exists, or null.
 	 */
 	public function offsetGet( $attribute_name ) {
-		return isset( $this->attributes[ $attribute_name ] ) ?
-			$this->attributes[ $attribute_name ] :
-			null;
+		// This may cause an "Undefined index" notice if the attribute name does
+		// not exist. This is expected, since the purpose of this implementation
+		// is to align exactly to the expectations of operating on an array.
+		return $this->attributes[ $attribute_name ];
 	}
 
 	/**
@@ -215,7 +216,12 @@ class WP_Block implements ArrayAccess {
 	 * @param mixed  $value          Attribute value.
 	 */
 	public function offsetSet( $attribute_name, $value ) {
-		if ( ! is_null( $attribute_name ) ) {
+		if ( is_null( $attribute_name ) ) {
+			// This is not technically a valid use-case for attributes. Since
+			// this implementation is expected to align to expectations of
+			// operating on an array, it is still supported.
+			$this->attributes[] = $value;
+		} else {
 			$this->attributes[ $attribute_name ] = $value;
 		}
 	}

--- a/lib/class-wp-block.php
+++ b/lib/class-wp-block.php
@@ -89,11 +89,11 @@ class WP_Block implements ArrayAccess {
 	 * property. Only values which are configured to consumed by the block via
 	 * its registered type will be assigned to the block's `context` property.
 	 *
-	 * @param array                  $block    Array of parsed block properties.
-	 * @param array                  $context  Optional array of ancestry context values.
-	 * @param WP_Block_Type_Registry $registry Optional block type registry.
+	 * @param array                  $block             Array of parsed block properties.
+	 * @param array                  $available_context Optional array of ancestry context values.
+	 * @param WP_Block_Type_Registry $registry          Optional block type registry.
 	 */
-	public function __construct( $block, $context = array(), $registry = null ) {
+	public function __construct( $block, $available_context = array(), $registry = null ) {
 		$this->name = $block['blockName'];
 
 		if ( is_null( $registry ) ) {
@@ -110,7 +110,7 @@ class WP_Block implements ArrayAccess {
 			$this->attributes = $this->block_type->prepare_attributes_for_render( $this->attributes );
 		}
 
-		$this->available_context = $context;
+		$this->available_context = $available_context;
 
 		if ( ! empty( $this->block_type->context ) ) {
 			foreach ( $this->block_type->context as $context_name ) {

--- a/lib/class-wp-block.php
+++ b/lib/class-wp-block.php
@@ -31,7 +31,7 @@ class WP_Block implements ArrayAccess {
 	 *
 	 * @var array
 	 */
-	public $context = [];
+	public $context = array();
 
 	/**
 	 * All available context of the current hierarchy.
@@ -46,14 +46,14 @@ class WP_Block implements ArrayAccess {
 	 *
 	 * @var array
 	 */
-	public $attributes = [];
+	public $attributes = array();
 
 	/**
 	 * List of inner blocks (of this same class)
 	 *
 	 * @var WP_Block[]
 	 */
-	public $inner_blocks = [];
+	public $inner_blocks = array();
 
 	/**
 	 * Resultant HTML from inside block comment delimiters after removing inner
@@ -76,7 +76,7 @@ class WP_Block implements ArrayAccess {
 	 *
 	 * @var array
 	 */
-	public $inner_content = [];
+	public $inner_content = array();
 
 	/**
 	 * Constructor.
@@ -93,7 +93,7 @@ class WP_Block implements ArrayAccess {
 	 * @param array                  $context  Optional array of ancestry context values.
 	 * @param WP_Block_Type_Registry $registry Optional block type registry.
 	 */
-	public function __construct( $block, $context = [], $registry = null ) {
+	public function __construct( $block, $context = array(), $registry = null ) {
 		$this->name = $block['blockName'];
 
 		if ( is_null( $registry ) ) {

--- a/lib/class-wp-block.php
+++ b/lib/class-wp-block.php
@@ -126,7 +126,7 @@ class WP_Block implements ArrayAccess {
 			/* phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase */
 			if ( ! empty( $this->block_type->providesContext ) ) {
 				foreach ( $this->block_type->providesContext as $context_name => $attribute_name ) {
-					if ( isset( $this->attributes[ $attribute_name ] ) ) {
+					if ( array_key_exists( $attribute_name, $this->attributes ) ) {
 						$child_context[ $context_name ] = $this->attributes[ $attribute_name ];
 					}
 				}

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -207,10 +207,6 @@ function gutenberg_provide_render_callback_with_block_object( $pre_render, $next
 	}
 
 	if ( ! empty( $block_type->providesContext ) && is_array( $block_type->providesContext ) ) {
-		if ( ! isset( $_block_context ) ) {
-			$_block_context = array();
-		}
-
 		foreach ( $block_type->providesContext as $attribute_name ) {
 			if ( isset( $block['attrs'][ $attribute_name ] ) ) {
 				$_block_context[ $attribute_name ] = $block['attrs'][ $attribute_name ];

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -170,24 +170,28 @@ function gutenberg_get_post_from_context() {
  *
  * @see (TBD Trac Link)
  *
- * @param string|null $pre_render The pre-rendered content. Defaults to null.
- * @param array       $block      The block being rendered.
+ * @param string|null $pre_render   The pre-rendered content. Defaults to null.
+ * @param array       $parsed_block The parsed block being rendered.
  *
  * @return string String of rendered HTML.
  */
-function gutenberg_render_block_with_assigned_block_context( $pre_render, $block ) {
+function gutenberg_render_block_with_assigned_block_context( $pre_render, $parsed_block ) {
+	global $post;
+
 	// If a non-null value is provided, a filter has run at an earlier priority
 	// and has already handled custom rendering and should take precedence.
 	if ( null !== $pre_render ) {
 		return $pre_render;
 	}
 
-	$source_block = $block;
+	$source_block = $parsed_block;
 
 	/** This filter is documented in src/wp-includes/blocks.php */
-	$block = new WP_Block( apply_filters( 'render_block_data', $block, $source_block ) );
+	$parsed_block = apply_filters( 'render_block_data', $parsed_block, $source_block );
+	$context      = [ 'postId' => $post->ID ];
+	$block        = new WP_Block( $parsed_block, $context );
 
 	/** This filter is documented in src/wp-includes/blocks.php */
-	return apply_filters( 'render_block', $block->render(), $block );
+	return apply_filters( 'render_block', $block->render(), $parsed_block );
 }
 add_filter( 'pre_render_block', 'gutenberg_render_block_with_assigned_block_context', 9, 2 );

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -162,33 +162,6 @@ function gutenberg_get_post_from_context() {
 	return get_post();
 }
 
-if ( ! function_exists( 'get_namespaced_block_context_name' ) ) {
-	/**
-	 * Returns a namespaced string to use as key for context object, deriving
-	 * namespace from the given block name.
-	 *
-	 * This can be removed when plugin support requires WordPress 5.5.0+.
-	 *
-	 * @see (TBD Trac Link)
-	 *
-	 * @param string $block_name   Block name.
-	 * @param string $context_name Name of provided context.
-	 *
-	 * @return string Namespaced context name.
-	 */
-	function get_namespaced_block_context_name( $block_name, $context_name ) {
-		$normalized_block_name = strip_core_block_namespace( $block_name );
-		$slash_index           = strpos( $normalized_block_name, '/' );
-
-		if ( false !== $slash_index ) {
-			$namespace = substr( $normalized_block_name, 0, $slash_index );
-			$context_name = $namespace . '/' . $context_name;
-		}
-
-		return $context_name;
-	}
-}
-
 /**
  * Shim that hooks into `pre_render_block` so as to override `render_block` with
  * a function that assigns block context.
@@ -242,8 +215,7 @@ function gutenberg_provide_render_callback_with_block_object( $pre_render, $next
 	if ( ! empty( $block_type->providesContext ) && is_array( $block_type->providesContext ) ) {
 		foreach ( $block_type->providesContext as $attribute_name ) {
 			if ( isset( $block['attrs'][ $attribute_name ] ) ) {
-				$context_key = get_namespaced_block_context_name( $block['blockName'], $attribute_name );
-				$_block_context[ $context_key ] = $block['attrs'][ $attribute_name ];
+				$_block_context[ $attribute_name ] = $block['attrs'][ $attribute_name ];
 			}
 		}
 	}

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -176,7 +176,7 @@ function gutenberg_get_post_from_context() {
  * @return string String of rendered HTML.
  */
 function gutenberg_provide_render_callback_with_block_object( $pre_render, $next_block ) {
-	global $post, $block, $block_context;
+	global $post, $block, $_block_context;
 
 	$source_block = $next_block;
 
@@ -196,24 +196,24 @@ function gutenberg_provide_render_callback_with_block_object( $pre_render, $next
 		$block['context'] = array();
 	}
 
-	$block_context_before = $block_context;
+	$block_context_before = $_block_context;
 
-	if ( ! isset( $block_context ) ) {
-		$block_context = array();
+	if ( ! isset( $_block_context ) ) {
+		$_block_context = array();
 	}
 
-	if ( ! isset( $block_context['postId'] ) || $post->ID !== $block_context['postId'] ) {
-		$block_context['postId'] = $post->ID;
+	if ( ! isset( $_block_context['postId'] ) || $post->ID !== $_block_context['postId'] ) {
+		$_block_context['postId'] = $post->ID;
 	}
 
 	if ( ! empty( $block_type->providesContext ) && is_array( $block_type->providesContext ) ) {
-		if ( ! isset( $block_context ) ) {
-			$block_context = array();
+		if ( ! isset( $_block_context ) ) {
+			$_block_context = array();
 		}
 
 		foreach ( $block_type->providesContext as $attribute_name ) {
 			if ( isset( $block['attrs'][ $attribute_name ] ) ) {
-				$block_context[ $attribute_name ] = $block['attrs'][ $attribute_name ];
+				$_block_context[ $attribute_name ] = $block['attrs'][ $attribute_name ];
 			}
 		}
 	}
@@ -227,8 +227,8 @@ function gutenberg_provide_render_callback_with_block_object( $pre_render, $next
 	if ( $is_dynamic ) {
 		if ( isset( $block_type->context ) && is_array( $block_type->context ) ) {
 			foreach ( $block_type->context as $context_name ) {
-				if ( array_key_exists( $context_name, $block_context ) ) {
-					$block['context'][ $context_name ] = $block_context[ $context_name ];
+				if ( array_key_exists( $context_name, $_block_context ) ) {
+					$block['context'][ $context_name ] = $_block_context[ $context_name ];
 				}
 			}
 		}
@@ -238,7 +238,7 @@ function gutenberg_provide_render_callback_with_block_object( $pre_render, $next
 		$post          = $global_post;
 	}
 
-	$block_context = $block_context_before;
+	$_block_context = $block_context_before;
 
 	/** This filter is documented in src/wp-includes/blocks.php */
 	return apply_filters( 'render_block', $block_content, $block );

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -175,7 +175,7 @@ function gutenberg_get_post_from_context() {
  *
  * @return string String of rendered HTML.
  */
-function gutenberg_provide_render_callback_with_block_object( $pre_render, $next_block ) {
+function gutenberg_render_block_with_assigned_block_context( $pre_render, $next_block ) {
 	global $post, $block, $_block_context;
 
 	// If a non-null value is provided, a filter has run at an earlier priority
@@ -230,7 +230,7 @@ function gutenberg_provide_render_callback_with_block_object( $pre_render, $next
 
 		$block_content .= is_string( $chunk ) ?
 			$chunk :
-			gutenberg_provide_render_callback_with_block_object( null, $block['innerBlocks'][ $index++ ] );
+			gutenberg_render_block_with_assigned_block_context( null, $block['innerBlocks'][ $index++ ] );
 
 		$block = $global_block;
 	}
@@ -254,4 +254,4 @@ function gutenberg_provide_render_callback_with_block_object( $pre_render, $next
 	/** This filter is documented in src/wp-includes/blocks.php */
 	return apply_filters( 'render_block', $block_content, $block );
 }
-add_filter( 'pre_render_block', 'gutenberg_provide_render_callback_with_block_object', 9, 2 );
+add_filter( 'pre_render_block', 'gutenberg_render_block_with_assigned_block_context', 9, 2 );

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -198,6 +198,14 @@ function gutenberg_provide_render_callback_with_block_object( $pre_render, $next
 
 	$block_context_before = $block_context;
 
+	if ( ! isset( $block_context ) ) {
+		$block_context = array();
+	}
+
+	if ( ! isset( $block_context['postId'] ) || $post->ID !== $block_context['postId'] ) {
+		$block_context['postId'] = $post->ID;
+	}
+
 	if ( ! empty( $block_type->providesContext ) && is_array( $block_type->providesContext ) ) {
 		if ( ! isset( $block_context ) ) {
 			$block_context = array();
@@ -217,7 +225,7 @@ function gutenberg_provide_render_callback_with_block_object( $pre_render, $next
 	}
 
 	if ( $is_dynamic ) {
-		if ( isset( $block_context ) && isset( $block_type->context ) && is_array( $block_type->context ) ) {
+		if ( isset( $block_type->context ) && is_array( $block_type->context ) ) {
 			foreach ( $block_type->context as $context_name ) {
 				if ( array_key_exists( $context_name, $block_context ) ) {
 					$block['context'][ $context_name ] = $block_context[ $context_name ];

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -162,6 +162,33 @@ function gutenberg_get_post_from_context() {
 	return get_post();
 }
 
+if ( ! function_exists( 'get_namespaced_block_context_name' ) ) {
+	/**
+	 * Returns a namespaced string to use as key for context object, deriving
+	 * namespace from the given block name.
+	 *
+	 * This can be removed when plugin support requires WordPress 5.5.0+.
+	 *
+	 * @see (TBD Trac Link)
+	 *
+	 * @param string $block_name   Block name.
+	 * @param string $context_name Name of provided context.
+	 *
+	 * @return string Namespaced context name.
+	 */
+	function get_namespaced_block_context_name( $block_name, $context_name ) {
+		$normalized_block_name = strip_core_block_namespace( $block_name );
+		$slash_index           = strpos( $normalized_block_name, '/' );
+
+		if ( false !== $slash_index ) {
+			$namespace = substr( $normalized_block_name, 0, $slash_index );
+			$context_name = $namespace . '/' . $context_name;
+		}
+
+		return $context_name;
+	}
+}
+
 /**
  * Shim that hooks into `pre_render_block` so as to override `render_block` with
  * a function that assigns block context.
@@ -215,7 +242,8 @@ function gutenberg_provide_render_callback_with_block_object( $pre_render, $next
 	if ( ! empty( $block_type->providesContext ) && is_array( $block_type->providesContext ) ) {
 		foreach ( $block_type->providesContext as $attribute_name ) {
 			if ( isset( $block['attrs'][ $attribute_name ] ) ) {
-				$_block_context[ $attribute_name ] = $block['attrs'][ $attribute_name ];
+				$context_key = get_namespaced_block_context_name( $block['blockName'], $attribute_name );
+				$_block_context[ $context_key ] = $block['attrs'][ $attribute_name ];
 			}
 		}
 	}

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -170,13 +170,19 @@ function gutenberg_get_post_from_context() {
  *
  * @see (TBD Trac Link)
  *
- * @param string $pre_render The pre-rendered content. Defaults to null.
- * @param array  $next_block The block being rendered.
+ * @param string|null $pre_render The pre-rendered content. Defaults to null.
+ * @param array       $next_block The block being rendered.
  *
  * @return string String of rendered HTML.
  */
 function gutenberg_provide_render_callback_with_block_object( $pre_render, $next_block ) {
 	global $post, $block, $_block_context;
+
+	// If a non-null value is provided, a filter has run at an earlier priority
+	// and has already handled custom rendering and should take precedence.
+	if ( null !== $pre_render ) {
+		return $pre_render;
+	}
 
 	$source_block = $next_block;
 
@@ -239,4 +245,4 @@ function gutenberg_provide_render_callback_with_block_object( $pre_render, $next
 	/** This filter is documented in src/wp-includes/blocks.php */
 	return apply_filters( 'render_block', $block_content, $block );
 }
-add_filter( 'pre_render_block', 'gutenberg_provide_render_callback_with_block_object', 10, 2 );
+add_filter( 'pre_render_block', 'gutenberg_provide_render_callback_with_block_object', 9, 2 );

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -214,9 +214,10 @@ function gutenberg_render_block_with_assigned_block_context( $pre_render, $next_
 
 	/* phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase */
 	if ( ! empty( $block_type->providesContext ) && is_array( $block_type->providesContext ) ) {
+		$prepared_attributes = $block_type->prepare_attributes_for_render( $block['attrs'] );
 		foreach ( $block_type->providesContext as $context_name => $attribute_name ) {
-			if ( isset( $block['attrs'][ $attribute_name ] ) ) {
-				$_block_context[ $context_name ] = $block['attrs'][ $attribute_name ];
+			if ( isset( $prepared_attributes[ $attribute_name ] ) ) {
+				$_block_context[ $context_name ] = $prepared_attributes[ $attribute_name ];
 			}
 		}
 	}

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -213,9 +213,9 @@ function gutenberg_provide_render_callback_with_block_object( $pre_render, $next
 	}
 
 	if ( ! empty( $block_type->providesContext ) && is_array( $block_type->providesContext ) ) {
-		foreach ( $block_type->providesContext as $attribute_name ) {
+		foreach ( $block_type->providesContext as $context_name => $attribute_name ) {
 			if ( isset( $block['attrs'][ $attribute_name ] ) ) {
-				$_block_context[ $attribute_name ] = $block['attrs'][ $attribute_name ];
+				$_block_context[ $context_name ] = $block['attrs'][ $attribute_name ];
 			}
 		}
 	}

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -223,9 +223,16 @@ function gutenberg_provide_render_callback_with_block_object( $pre_render, $next
 	/* phpcs:enable */
 
 	foreach ( $block['innerContent'] as $chunk ) {
+		// Since the inner `render_block` is expected to assign the `$block`
+		// global for its own render, store a reference to restore after the
+		// child has finished rendering.
+		$global_block = $block;
+
 		$block_content .= is_string( $chunk ) ?
 			$chunk :
 			gutenberg_provide_render_callback_with_block_object( null, $block['innerBlocks'][ $index++ ] );
+
+		$block = $global_block;
 	}
 
 	if ( $is_dynamic ) {

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -212,6 +212,7 @@ function gutenberg_provide_render_callback_with_block_object( $pre_render, $next
 		$_block_context['postId'] = $post->ID;
 	}
 
+	/* phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase */
 	if ( ! empty( $block_type->providesContext ) && is_array( $block_type->providesContext ) ) {
 		foreach ( $block_type->providesContext as $context_name => $attribute_name ) {
 			if ( isset( $block['attrs'][ $attribute_name ] ) ) {
@@ -219,6 +220,7 @@ function gutenberg_provide_render_callback_with_block_object( $pre_render, $next
 			}
 		}
 	}
+	/* phpcs:enable */
 
 	foreach ( $block['innerContent'] as $chunk ) {
 		$block_content .= is_string( $chunk ) ?

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -188,7 +188,7 @@ function gutenberg_render_block_with_assigned_block_context( $pre_render, $parse
 
 	/** This filter is documented in src/wp-includes/blocks.php */
 	$parsed_block = apply_filters( 'render_block_data', $parsed_block, $source_block );
-	$context      = [ 'postId' => $post->ID ];
+	$context      = array( 'postId' => $post->ID );
 	$block        = new WP_Block( $parsed_block, $context );
 
 	/** This filter is documented in src/wp-includes/blocks.php */

--- a/lib/load.php
+++ b/lib/load.php
@@ -63,6 +63,10 @@ if ( ! class_exists( 'WP_Patterns_Registry' ) ) {
 	require dirname( __FILE__ ) . '/class-wp-patterns-registry.php';
 }
 
+if ( ! class_exists( 'WP_Block' ) ) {
+	require dirname( __FILE__ ) . '/class-wp-block.php';
+}
+
 require dirname( __FILE__ ) . '/compat.php';
 
 require dirname( __FILE__ ) . '/blocks.php';

--- a/package-lock.json
+++ b/package-lock.json
@@ -10591,6 +10591,7 @@
 				"@wordpress/api-fetch": "file:packages/api-fetch",
 				"@wordpress/blocks": "file:packages/blocks",
 				"@wordpress/data": "file:packages/data",
+				"@wordpress/data-controls": "file:packages/data-controls",
 				"@wordpress/deprecated": "file:packages/deprecated",
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/i18n": "file:packages/i18n",

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -93,6 +93,18 @@ _Returns_
 
 -   `WPElement`: Block Breadcrumb.
 
+<a name="BlockContextProvider" href="#BlockContextProvider">#</a> **BlockContextProvider**
+
+Component which merges passed value with current consumed block context.
+
+_Related_
+
+-   <https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/block-context/README.md>
+
+_Parameters_
+
+-   _props_ `BlockContextProviderProps`: 
+
 <a name="BlockControls" href="#BlockControls">#</a> **BlockControls**
 
 Undocumented declaration.

--- a/packages/block-editor/src/components/block-context/README.md
+++ b/packages/block-editor/src/components/block-context/README.md
@@ -1,0 +1,57 @@
+Block Context
+=============
+
+Block Context is a React implementation of WordPress's block context. Block context, much like [React's context](https://reactjs.org/docs/context.html), is a method for passing and inheriting values deeply through a hierarchy of blocks. Because of the similarities with React's context, the client-side implementation here is quite minimal. It is complemented by equivalent behaviors in the server-side rendering of a block.
+
+Note that the implementation of Block Context is distinct from [the `BlockEdit` context](../block-edit). While it is true that both provide context relevant for the editing of a block, Block Context is implemented separately so as to prioritize it as most identifiable amongst the machinery of block context, and not amongst other client-side editing context of a block.
+
+## Usage
+
+Currently, only the [Provider component](https://reactjs.org/docs/context.html#contextprovider) is made availble on the public interface of the `@wordpress/block-editor` module. This can be used to add or override context which can then be consumed by blocks rendered within that context.
+
+```js
+import { BlockContextProvider } from '@wordpress/block-editor';
+
+function MyCustomPostEditor() {
+	return (
+		<BlockContextProvider value={ { postId: 1, postType: 'post' } }>
+			<BlockEditorProvider { /* ... */ } />
+		</BlockContextProvider>
+	);
+}
+```
+
+Internal to the `@wordpress/block-editor` module, a component can access the [full Context object](https://reactjs.org/docs/context.html#api), typically for use in combination with [`useContext`](https://reactjs.org/docs/hooks-reference.html#usecontext).
+
+```js
+import { useContext } from '@wordpress/element';
+
+// Only available internally within `@wordpress/block-editor`!
+import BlockContext from '../block-context';
+
+function MyBlockComponent() {
+	const { postId } = useContext( BlockContext );
+
+	return 'The current post ID is: ' + postId;
+}
+```
+
+The reason `BlockContext` is only internally available within the `@wordpress/block-editor` module is to reinforce the expectation that external consumption of values from block context should be declared on the block registration using the `context` property.
+
+## Props
+
+`BlockContextProvider` behaves like a standard [Provider component](https://reactjs.org/docs/context.html#contextprovider). It receives `value` and `children` props. The `value` is merged with the current block context value.
+
+### `value`
+
+- Type: `Record<string,*>`
+- Required: Yes
+
+Context value to merge with current value.
+
+### `children`
+
+- Type: `ReactNode`
+- Required: Yes
+
+Component children.

--- a/packages/block-editor/src/components/block-context/README.md
+++ b/packages/block-editor/src/components/block-context/README.md
@@ -7,7 +7,7 @@ Note that the implementation of Block Context is distinct from [the `BlockEdit` 
 
 ## Usage
 
-Currently, only the [Provider component](https://reactjs.org/docs/context.html#contextprovider) is made availble on the public interface of the `@wordpress/block-editor` module. This can be used to add or override context which can then be consumed by blocks rendered within that context.
+Currently, only the [Provider component](https://reactjs.org/docs/context.html#contextprovider) is made available on the public interface of the `@wordpress/block-editor` module. This can be used to add or override context which can then be consumed by blocks rendered within that context in the block editor.
 
 ```js
 import { BlockContextProvider } from '@wordpress/block-editor';

--- a/packages/block-editor/src/components/block-context/README.md
+++ b/packages/block-editor/src/components/block-context/README.md
@@ -40,7 +40,7 @@ The reason `BlockContext` is only internally available within the `@wordpress/bl
 
 ## Props
 
-`BlockContextProvider` behaves like a standard [Provider component](https://reactjs.org/docs/context.html#contextprovider). It receives `value` and `children` props. The `value` is merged with the current block context value.
+`BlockContextProvider` behaves like a standard [`Context.Provider` component](https://reactjs.org/docs/context.html#contextprovider). It receives `value` and `children` props. The `value` is merged with the current block context value.
 
 ### `value`
 

--- a/packages/block-editor/src/components/block-context/index.js
+++ b/packages/block-editor/src/components/block-context/index.js
@@ -1,0 +1,37 @@
+/**
+ * WordPress dependencies
+ */
+import { createContext, useContext } from '@wordpress/element';
+
+/** @typedef {import('react').ReactNode} ReactNode */
+
+/**
+ * @typedef BlockContextProviderProps
+ *
+ * @property {Record<string,*>} value    Context value to merge with current
+ *                                       value.
+ * @property {ReactNode}        children Component children.
+ */
+
+/** @type {import('react').Context<Record<string,*>>} */
+const Context = createContext( {} );
+
+/**
+ * Component which merges passed value with current consumed block context.
+ *
+ * @see https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/block-context/README.md
+ *
+ * @param {BlockContextProviderProps} props
+ */
+export function BlockContextProvider( { value, children } ) {
+	const context = useContext( Context );
+
+	return (
+		<Context.Provider
+			value={ { ...context, ...value } }
+			children={ children }
+		/>
+	);
+}
+
+export default Context;

--- a/packages/block-editor/src/components/block-context/index.js
+++ b/packages/block-editor/src/components/block-context/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { createContext, useContext } from '@wordpress/element';
+import { createContext, useContext, useMemo } from '@wordpress/element';
 
 /** @typedef {import('react').ReactNode} ReactNode */
 
@@ -25,13 +25,12 @@ const Context = createContext( {} );
  */
 export function BlockContextProvider( { value, children } ) {
 	const context = useContext( Context );
+	const nextValue = useMemo( () => ( { ...context, ...value } ), [
+		context,
+		value,
+	] );
 
-	return (
-		<Context.Provider
-			value={ { ...context, ...value } }
-			children={ children }
-		/>
-	);
+	return <Context.Provider value={ nextValue } children={ children } />;
 }
 
 export default Context;

--- a/packages/block-editor/src/components/block-edit/edit.js
+++ b/packages/block-editor/src/components/block-edit/edit.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
+import { pick } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -12,10 +13,27 @@ import {
 	hasBlockSupport,
 	getBlockType,
 } from '@wordpress/blocks';
+import { useContext } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import BlockContext from '../block-context';
+
+/**
+ * Default value used for blocks which do not define their own context needs,
+ * used to guarantee that a block's `context` prop will always be an object. It
+ * is assigned as a constant since it is always expected to be an empty object,
+ * and in order to avoid unnecessary React reconciliations of a changing object.
+ *
+ * @type {{}}
+ */
+const DEFAULT_BLOCK_CONTEXT = {};
 
 export const Edit = ( props ) => {
 	const { attributes = {}, name } = props;
 	const blockType = getBlockType( name );
+	const blockContext = useContext( BlockContext );
 
 	if ( ! blockType ) {
 		return null;
@@ -41,7 +59,14 @@ export const Edit = ( props ) => {
 		: null;
 	const className = classnames( generatedClassName, attributes.className );
 
-	return <Component { ...props } className={ className } />;
+	// Assign context values using the block type's declared context needs.
+	const context = blockType.context
+		? pick( blockContext, blockType.context )
+		: DEFAULT_BLOCK_CONTEXT;
+
+	return (
+		<Component { ...props } context={ context } className={ className } />
+	);
 };
 
 export default withFilters( 'editor.BlockEdit' )( Edit );

--- a/packages/block-editor/src/components/block-edit/edit.js
+++ b/packages/block-editor/src/components/block-edit/edit.js
@@ -13,7 +13,7 @@ import {
 	hasBlockSupport,
 	getBlockType,
 } from '@wordpress/blocks';
-import { useContext } from '@wordpress/element';
+import { useContext, useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -35,6 +35,15 @@ export const Edit = ( props ) => {
 	const blockType = getBlockType( name );
 	const blockContext = useContext( BlockContext );
 
+	// Assign context values using the block type's declared context needs.
+	const context = useMemo(
+		() =>
+			blockType && blockType.context
+				? pick( blockContext, blockType.context )
+				: DEFAULT_BLOCK_CONTEXT,
+		[ blockType, blockContext ]
+	);
+
 	if ( ! blockType ) {
 		return null;
 	}
@@ -50,7 +59,7 @@ export const Edit = ( props ) => {
 	);
 
 	if ( lightBlockWrapper ) {
-		return <Component { ...props } />;
+		return <Component { ...props } context={ context } />;
 	}
 
 	// Generate a class name for the block's editable form
@@ -58,11 +67,6 @@ export const Edit = ( props ) => {
 		? getBlockDefaultClassName( name )
 		: null;
 	const className = classnames( generatedClassName, attributes.className );
-
-	// Assign context values using the block type's declared context needs.
-	const context = blockType.context
-		? pick( blockContext, blockType.context )
-		: DEFAULT_BLOCK_CONTEXT;
 
 	return (
 		<Component { ...props } context={ context } className={ className } />

--- a/packages/block-editor/src/components/block-edit/test/edit.js
+++ b/packages/block-editor/src/components/block-edit/test/edit.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import { noop } from 'lodash';
 
 /**
@@ -17,6 +17,7 @@ import {
  * Internal dependencies
  */
 import { Edit } from '../edit';
+import { BlockContextProvider } from '../../block-context';
 
 describe( 'Edit', () => {
 	afterEach( () => {
@@ -78,5 +79,48 @@ describe( 'Edit', () => {
 			true
 		);
 		expect( wrapper.find( edit ).hasClass( 'my-class' ) ).toBe( true );
+	} );
+
+	it( 'should assign context', () => {
+		const edit = ( { context } ) => context.value;
+		registerBlockType( 'core/test-block', {
+			category: 'common',
+			title: 'block title',
+			context: [ 'value' ],
+			edit,
+			save: noop,
+		} );
+
+		const wrapper = mount(
+			<BlockContextProvider value={ { value: 'Ok' } }>
+				<Edit name="core/test-block" />
+			</BlockContextProvider>
+		);
+
+		expect( wrapper.html() ).toBe( 'Ok' );
+	} );
+
+	describe( 'light wrapper', () => {
+		it( 'should assign context', () => {
+			const edit = ( { context } ) => context.value;
+			registerBlockType( 'core/test-block', {
+				category: 'common',
+				title: 'block title',
+				context: [ 'value' ],
+				supports: {
+					lightBlockWrapper: true,
+				},
+				edit,
+				save: noop,
+			} );
+
+			const wrapper = mount(
+				<BlockContextProvider value={ { value: 'Ok' } }>
+					<Edit name="core/test-block" />
+				</BlockContextProvider>
+			);
+
+			expect( wrapper.html() ).toBe( 'Ok' );
+		} );
 	} );
 } );

--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -9,6 +9,7 @@ export { default as AlignmentToolbar } from './alignment-toolbar';
 export { default as Autocomplete } from './autocomplete';
 export { default as BlockAlignmentToolbar } from './block-alignment-toolbar';
 export { default as BlockBreadcrumb } from './block-breadcrumb';
+export { BlockContextProvider } from './block-context';
 export { default as BlockControls } from './block-controls';
 export { default as BlockEdit, useBlockEditContext } from './block-edit';
 export { default as BlockFormatControls } from './block-format-controls';

--- a/packages/block-editor/src/components/index.native.js
+++ b/packages/block-editor/src/components/index.native.js
@@ -1,5 +1,6 @@
 // Block Creation Components
 export { default as BlockAlignmentToolbar } from './block-alignment-toolbar';
+export { BlockContextProvider } from './block-context';
 export { default as BlockControls } from './block-controls';
 export { default as BlockEdit, useBlockEditContext } from './block-edit';
 export { default as BlockFormatControls } from './block-format-controls';

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { pick, isEqual } from 'lodash';
+import { mapKeys, pick, isEqual } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -40,6 +40,24 @@ import { withBlockEditContext } from '../block-edit/context';
 const BLOCK_CONTEXT_CACHE = new WeakMap();
 
 /**
+ * Returns a namespaced string to use as key for context object, deriving
+ * namespace from the given block name.
+ *
+ * @param {string} blockName   Block name.
+ * @param {string} contextName Name of provided context.
+ *
+ * @return {string} Namespaced context name.
+ */
+export function getNamespacedBlockContextName( blockName, contextName ) {
+	const [ namespace ] = blockName.split( '/' );
+	if ( namespace !== 'core' ) {
+		contextName = namespace + '/' + contextName;
+	}
+
+	return contextName;
+}
+
+/**
  * Returns a cached context object value for a given set of attributes for the
  * block type.
  *
@@ -55,7 +73,12 @@ function getBlockContext( attributes, blockType ) {
 
 	const blockTypeCache = BLOCK_CONTEXT_CACHE.get( blockType );
 	if ( ! blockTypeCache.has( attributes ) ) {
-		const context = pick( attributes, blockType.providesContext );
+		const context = mapKeys(
+			pick( attributes, blockType.providesContext ),
+			( value, key ) =>
+				getNamespacedBlockContextName( blockType.name, key )
+		);
+
 		blockTypeCache.set( attributes, context );
 	}
 

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -175,7 +175,7 @@ class InnerBlocks extends Component {
 
 		// Wrap context provider if (and only if) block has context to provide.
 		const blockType = getBlockType( block.name );
-		if ( blockType && blockType.providesContext ) {
+		if ( blockType?.providesContext ) {
 			const context = pick( block.attributes, blockType.providesContext );
 
 			blockList = (

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { pick, isEqual } from 'lodash';
+import { mapValues, pick, isEqual } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -55,9 +55,9 @@ function getBlockContext( attributes, blockType ) {
 
 	const blockTypeCache = BLOCK_CONTEXT_CACHE.get( blockType );
 	if ( ! blockTypeCache.has( attributes ) ) {
-		const context = pick(
-			attributes,
-			Object.keys( blockType.providesContext )
+		const context = mapValues(
+			blockType.providesContext,
+			( attributeName ) => attributes[ attributeName ]
 		);
 
 		blockTypeCache.set( attributes, context );

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -11,6 +11,7 @@ import { withViewportMatch } from '@wordpress/viewport';
 import { Component, forwardRef, useRef } from '@wordpress/element';
 import { withSelect, withDispatch } from '@wordpress/data';
 import {
+	getBlockType,
 	synchronizeBlocksWithTemplate,
 	withBlockContentContext,
 } from '@wordpress/blocks';
@@ -27,6 +28,7 @@ import DefaultBlockAppender from './default-block-appender';
  * Internal dependencies
  */
 import BlockList from '../block-list';
+import { BlockContextProvider } from '../block-context';
 import { withBlockEditContext } from '../block-edit/context';
 
 class InnerBlocks extends Component {
@@ -148,6 +150,7 @@ class InnerBlocks extends Component {
 			hasOverlay,
 			__experimentalCaptureToolbars: captureToolbars,
 			forwardedRef,
+			block,
 			...props
 		} = this.props;
 		const { templateInProcess } = this.state;
@@ -161,7 +164,7 @@ class InnerBlocks extends Component {
 			'is-capturing-toolbar': captureToolbars,
 		} );
 
-		const blockList = (
+		let blockList = (
 			<BlockList
 				{ ...props }
 				ref={ forwardedRef }
@@ -169,6 +172,18 @@ class InnerBlocks extends Component {
 				className={ classes }
 			/>
 		);
+
+		// Wrap context provider if (and only if) block has context to provide.
+		const blockType = getBlockType( block.name );
+		if ( blockType && blockType.providesContext ) {
+			const context = pick( block.attributes, blockType.providesContext );
+
+			blockList = (
+				<BlockContextProvider value={ context }>
+					{ blockList }
+				</BlockContextProvider>
+			);
+		}
 
 		if ( props.__experimentalTagName ) {
 			return blockList;

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { mapKeys, pick, isEqual } from 'lodash';
+import { pick, isEqual } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -40,24 +40,6 @@ import { withBlockEditContext } from '../block-edit/context';
 const BLOCK_CONTEXT_CACHE = new WeakMap();
 
 /**
- * Returns a namespaced string to use as key for context object, deriving
- * namespace from the given block name.
- *
- * @param {string} blockName   Block name.
- * @param {string} contextName Name of provided context.
- *
- * @return {string} Namespaced context name.
- */
-export function getNamespacedBlockContextName( blockName, contextName ) {
-	const [ namespace ] = blockName.split( '/' );
-	if ( namespace !== 'core' ) {
-		contextName = namespace + '/' + contextName;
-	}
-
-	return contextName;
-}
-
-/**
  * Returns a cached context object value for a given set of attributes for the
  * block type.
  *
@@ -73,12 +55,7 @@ function getBlockContext( attributes, blockType ) {
 
 	const blockTypeCache = BLOCK_CONTEXT_CACHE.get( blockType );
 	if ( ! blockTypeCache.has( attributes ) ) {
-		const context = mapKeys(
-			pick( attributes, blockType.providesContext ),
-			( value, key ) =>
-				getNamespacedBlockContextName( blockType.name, key )
-		);
-
+		const context = pick( attributes, blockType.providesContext );
 		blockTypeCache.set( attributes, context );
 	}
 

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -55,7 +55,11 @@ function getBlockContext( attributes, blockType ) {
 
 	const blockTypeCache = BLOCK_CONTEXT_CACHE.get( blockType );
 	if ( ! blockTypeCache.has( attributes ) ) {
-		const context = pick( attributes, blockType.providesContext );
+		const context = pick(
+			attributes,
+			Object.keys( blockType.providesContext )
+		);
+
 		blockTypeCache.set( attributes, context );
 	}
 

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -210,7 +210,7 @@ class InnerBlocks extends Component {
 
 		// Wrap context provider if (and only if) block has context to provide.
 		const blockType = getBlockType( block.name );
-		if ( blockType?.providesContext ) {
+		if ( blockType && blockType.providesContext ) {
 			const context = getBlockContext( block.attributes, blockType );
 
 			blockList = (

--- a/packages/block-editor/src/components/inner-blocks/test/index.js
+++ b/packages/block-editor/src/components/inner-blocks/test/index.js
@@ -14,27 +14,7 @@ import { renderToString } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import InnerBlocks, { getNamespacedBlockContextName } from '../';
-
-describe( 'getNamespacedBlockContextName', () => {
-	it( 'omits namespace for core blocks', () => {
-		const contextName = getNamespacedBlockContextName(
-			'core/post-title',
-			'postId'
-		);
-
-		expect( contextName ).toBe( 'postId' );
-	} );
-
-	it( 'includes namespace for non-core blocks', () => {
-		const contextName = getNamespacedBlockContextName(
-			'my-plugin/example-block',
-			'recordId'
-		);
-
-		expect( contextName ).toBe( 'my-plugin/recordId' );
-	} );
-} );
+import InnerBlocks from '../';
 
 describe( 'InnerBlocks', () => {
 	afterEach( () => {

--- a/packages/block-editor/src/components/inner-blocks/test/index.js
+++ b/packages/block-editor/src/components/inner-blocks/test/index.js
@@ -14,7 +14,27 @@ import { renderToString } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import InnerBlocks from '../';
+import InnerBlocks, { getNamespacedBlockContextName } from '../';
+
+describe( 'getNamespacedBlockContextName', () => {
+	it( 'omits namespace for core blocks', () => {
+		const contextName = getNamespacedBlockContextName(
+			'core/post-title',
+			'postId'
+		);
+
+		expect( contextName ).toBe( 'postId' );
+	} );
+
+	it( 'includes namespace for non-core blocks', () => {
+		const contextName = getNamespacedBlockContextName(
+			'my-plugin/example-block',
+			'recordId'
+		);
+
+		expect( contextName ).toBe( 'my-plugin/recordId' );
+	} );
+} );
 
 describe( 'InnerBlocks', () => {
 	afterEach( () => {

--- a/packages/block-editor/tsconfig.json
+++ b/packages/block-editor/tsconfig.json
@@ -8,6 +8,7 @@
 	// expand this array with files which can be type-checked. At some point in
 	// the future, this can be simplified to an `includes` of `src/**/*`.
 	"files": [
+		"src/components/block-context/index.js",
 		"src/utils/dom.js"
 	]
 }

--- a/packages/block-editor/tsconfig.json
+++ b/packages/block-editor/tsconfig.json
@@ -8,7 +8,6 @@
 	// expand this array with files which can be type-checked. At some point in
 	// the future, this can be simplified to an `includes` of `src/**/*`.
 	"files": [
-		"src/components/block-context/index.js",
 		"src/utils/dom.js"
 	]
 }

--- a/packages/block-library/src/post-title/block.json
+++ b/packages/block-library/src/post-title/block.json
@@ -1,4 +1,5 @@
 {
 	"name": "core/post-title",
-	"category": "layout"
+	"category": "layout",
+	"context": [ "postId", "postType" ]
 }

--- a/packages/block-library/src/post-title/edit.js
+++ b/packages/block-library/src/post-title/edit.js
@@ -6,18 +6,13 @@ import { useSelect } from '@wordpress/data';
 export default function PostTitleEdit( { context } ) {
 	const { postType, postId } = context;
 
-	// The unused `getEntityRecord` is necessary to trigger the default resolver
-	// behavior to fetch the post if not already known. Ideally this is built-in
-	// to `getEditedEntityRecord`, which derives using `getEntityRecord`.
-	const [ post ] = useSelect(
-		( select ) => [
+	const post = useSelect(
+		( select ) =>
 			select( 'core' ).getEditedEntityRecord(
 				'postType',
 				postType,
 				postId
 			),
-			select( 'core' ).getEntityRecord( 'postType', postType, postId ),
-		],
 		[ 'postType', 'postId' ]
 	);
 

--- a/packages/block-library/src/post-title/edit.js
+++ b/packages/block-library/src/post-title/edit.js
@@ -13,7 +13,7 @@ export default function PostTitleEdit( { context } ) {
 				postType,
 				postId
 			),
-		[ 'postType', 'postId' ]
+		[ postType, postId ]
 	);
 
 	if ( ! post ) {

--- a/packages/block-library/src/post-title/edit.js
+++ b/packages/block-library/src/post-title/edit.js
@@ -5,8 +5,14 @@ import { useSelect } from '@wordpress/data';
 
 export default function PostTitleEdit( { context } ) {
 	const { postType, postId } = context;
-	const post = useSelect( ( select ) =>
-		select( 'core' ).getEditedEntityRecord( 'postType', postType, postId )
+	const post = useSelect(
+		( select ) =>
+			select( 'core' ).getEditedEntityRecord(
+				'postType',
+				postType,
+				postId
+			),
+		[ 'postType', 'postId' ]
 	);
 
 	if ( ! post ) {

--- a/packages/block-library/src/post-title/edit.js
+++ b/packages/block-library/src/post-title/edit.js
@@ -5,13 +5,19 @@ import { useSelect } from '@wordpress/data';
 
 export default function PostTitleEdit( { context } ) {
 	const { postType, postId } = context;
-	const post = useSelect(
-		( select ) =>
+
+	// The unused `getEntityRecord` is necessary to trigger the default resolver
+	// behavior to fetch the post if not already known. Ideally this is built-in
+	// to `getEditedEntityRecord`, which derives using `getEntityRecord`.
+	const [ post ] = useSelect(
+		( select ) => [
 			select( 'core' ).getEditedEntityRecord(
 				'postType',
 				postType,
 				postId
 			),
+			select( 'core' ).getEntityRecord( 'postType', postType, postId ),
+		],
 		[ 'postType', 'postId' ]
 	);
 

--- a/packages/block-library/src/post-title/edit.js
+++ b/packages/block-library/src/post-title/edit.js
@@ -1,3 +1,17 @@
-export default function PostTitleEdit() {
-	return <h2>{ 'Hello world!' }</h2>;
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+
+export default function PostTitleEdit( { context } ) {
+	const { postType, postId } = context;
+	const post = useSelect( ( select ) =>
+		select( 'core' ).getEditedEntityRecord( 'postType', postType, postId )
+	);
+
+	if ( ! post ) {
+		return null;
+	}
+
+	return <h2>{ post.title }</h2>;
 }

--- a/packages/block-library/src/post-title/index.php
+++ b/packages/block-library/src/post-title/index.php
@@ -11,11 +11,13 @@
  * @return string Returns the filtered post title for the current post wrapped inside "h1" tags.
  */
 function render_block_core_post_title() {
-	$post = gutenberg_get_post_from_context();
-	if ( ! $post ) {
+	global $block;
+
+	if ( ! isset( $block['context']['postId'] ) ) {
 		return '';
 	}
-	return '<h1>' . get_the_title( $post ) . '</h1>';
+
+	return '<h1>' . get_the_title( $block['context']['postId'] ) . '</h1>';
 }
 
 /**

--- a/packages/block-library/src/post-title/index.php
+++ b/packages/block-library/src/post-title/index.php
@@ -10,14 +10,12 @@
  *
  * @return string Returns the filtered post title for the current post wrapped inside "h1" tags.
  */
-function render_block_core_post_title() {
-	global $block;
-
-	if ( ! isset( $block['context']['postId'] ) ) {
+function render_block_core_post_title( $block ) {
+	if ( ! isset( $block->context['postId'] ) ) {
 		return '';
 	}
 
-	return '<h1>' . get_the_title( $block['context']['postId'] ) . '</h1>';
+	return '<h1>' . get_the_title( $block->context['postId'] ) . '</h1>';
 }
 
 /**

--- a/packages/block-library/src/post-title/index.php
+++ b/packages/block-library/src/post-title/index.php
@@ -8,6 +8,8 @@
 /**
  * Renders the `core/post-title` block on the server.
  *
+ * @param WP_Block $block The block instance.
+ *
  * @return string Returns the filtered post title for the current post wrapped inside "h1" tags.
  */
 function render_block_core_post_title( $block ) {

--- a/packages/core-data/package.json
+++ b/packages/core-data/package.json
@@ -26,6 +26,7 @@
 		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/blocks": "file:../blocks",
 		"@wordpress/data": "file:../data",
+		"@wordpress/data-controls": "file:../data-controls",
 		"@wordpress/deprecated": "file:../deprecated",
 		"@wordpress/element": "file:../element",
 		"@wordpress/i18n": "file:../i18n",

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -24,6 +24,7 @@ import {
 } from './actions';
 import { getKindEntities } from './entities';
 import { apiFetch, resolveSelect } from './controls';
+import { ifNotResolved } from './utils';
 
 /**
  * Requests authors from the REST API.
@@ -65,12 +66,18 @@ export function* getEntityRecord( kind, name, key = '' ) {
 /**
  * Requests an entity's record from the REST API.
  */
-export const getRawEntityRecord = getEntityRecord;
+export const getRawEntityRecord = ifNotResolved(
+	getEntityRecord,
+	'getEntityRecord'
+);
 
 /**
  * Requests an entity's record from the REST API.
  */
-export const getEditedEntityRecord = getRawEntityRecord;
+export const getEditedEntityRecord = ifNotResolved(
+	getRawEntityRecord,
+	'getRawEntityRecord'
+);
 
 /**
  * Requests the entity's records from the REST API.

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -63,6 +63,16 @@ export function* getEntityRecord( kind, name, key = '' ) {
 }
 
 /**
+ * Requests an entity's record from the REST API.
+ */
+export const getRawEntityRecord = getEntityRecord;
+
+/**
+ * Requests an entity's record from the REST API.
+ */
+export const getEditedEntityRecord = getRawEntityRecord;
+
+/**
  * Requests the entity's records from the REST API.
  *
  * @param {string}  kind   Entity kind.

--- a/packages/core-data/src/utils/if-not-resolved.js
+++ b/packages/core-data/src/utils/if-not-resolved.js
@@ -1,0 +1,34 @@
+/**
+ * WordPress dependencies
+ */
+import { select } from '@wordpress/data-controls';
+
+/**
+ * Higher-order function which invokes the given resolver only if it has not
+ * already been resolved with the arguments passed to the enhanced function.
+ *
+ * This only considers resolution state, and notably does not support resolver
+ * custom `isFulfilled` behavior.
+ *
+ * @template {Function} R
+ *
+ * @param {R}      resolver     Original resolver.
+ * @param {string} selectorName Selector name associated with resolver.
+ *
+ * @return {R} Enhanced resolver.
+ */
+const ifNotResolved = ( resolver, selectorName ) =>
+	function* resolveIfNotResolved( ...args ) {
+		const hasStartedResolution = yield select(
+			'core',
+			'hasStartedResolution',
+			selectorName,
+			args
+		);
+
+		if ( ! hasStartedResolution ) {
+			yield* resolver( ...args );
+		}
+	};
+
+export default ifNotResolved;

--- a/packages/core-data/src/utils/if-not-resolved.js
+++ b/packages/core-data/src/utils/if-not-resolved.js
@@ -10,14 +10,15 @@ import { select } from '@wordpress/data-controls';
  * This only considers resolution state, and notably does not support resolver
  * custom `isFulfilled` behavior.
  *
- * @template {Function} R
+ * @param {Function} resolver     Original resolver.
+ * @param {string}   selectorName Selector name associated with resolver.
  *
- * @param {R}      resolver     Original resolver.
- * @param {string} selectorName Selector name associated with resolver.
- *
- * @return {R} Enhanced resolver.
+ * @return {Function} Enhanced resolver.
  */
 const ifNotResolved = ( resolver, selectorName ) =>
+	/**
+	 * @param {...any} args Original resolver arguments.
+	 */
 	function* resolveIfNotResolved( ...args ) {
 		const hasStartedResolution = yield select(
 			'core',

--- a/packages/core-data/src/utils/index.js
+++ b/packages/core-data/src/utils/index.js
@@ -1,5 +1,6 @@
 export { default as conservativeMapItem } from './conservative-map-item';
 export { default as ifMatchingAction } from './if-matching-action';
+export { default as ifNotResolved } from './if-not-resolved';
 export { default as onSubKey } from './on-sub-key';
 export { default as replaceAction } from './replace-action';
 export { default as withWeakMapCache } from './with-weak-map-cache';

--- a/packages/core-data/src/utils/test/if-not-resolved.js
+++ b/packages/core-data/src/utils/test/if-not-resolved.js
@@ -1,0 +1,69 @@
+/**
+ * WordPress dependencies
+ */
+import { select } from '@wordpress/data-controls';
+
+/**
+ * Internal dependencies
+ */
+import ifNotResolved from '../if-not-resolved';
+
+jest.mock( '@wordpress/data-controls', () => ( {
+	select: jest.fn(),
+} ) );
+
+describe( 'ifNotResolved', () => {
+	beforeEach( () => {
+		select.mockReset();
+	} );
+
+	it( 'returns a new function', () => {
+		const originalResolver = () => {};
+
+		const resolver = ifNotResolved( originalResolver, 'originalResolver' );
+
+		expect( resolver ).toBeInstanceOf( Function );
+	} );
+
+	it( 'triggers original resolver if not already resolved', () => {
+		select.mockImplementation( ( _storeKey, selectorName ) => ( {
+			_nextValue:
+				selectorName === 'hasStartedResolution' ? false : undefined,
+		} ) );
+
+		const originalResolver = jest.fn().mockImplementation( function*() {} );
+
+		const resolver = ifNotResolved( originalResolver, 'originalResolver' );
+
+		const runResolver = resolver();
+
+		let next, nextValue;
+		do {
+			next = runResolver.next( nextValue );
+			nextValue = next.value?._nextValue;
+		} while ( ! next.done );
+
+		expect( originalResolver ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'does not trigger original resolver if already resolved', () => {
+		select.mockImplementation( ( _storeKey, selectorName ) => ( {
+			_nextValue:
+				selectorName === 'hasStartedResolution' ? true : undefined,
+		} ) );
+
+		const originalResolver = jest.fn().mockImplementation( function*() {} );
+
+		const resolver = ifNotResolved( originalResolver, 'originalResolver' );
+
+		const runResolver = resolver();
+
+		let next, nextValue;
+		do {
+			next = runResolver.next( nextValue );
+			nextValue = next.value?._nextValue;
+		} while ( ! next.done );
+
+		expect( originalResolver ).toHaveBeenCalledTimes( 0 );
+	} );
+} );

--- a/packages/e2e-tests/plugins/block-context.php
+++ b/packages/e2e-tests/plugins/block-context.php
@@ -48,10 +48,8 @@ function gutenberg_test_register_context_blocks() {
 		'gutenberg/test-context-consumer',
 		[
 			'context'         => [ 'gutenberg/recordId' ],
-			'render_callback' => function() {
-				global $block;
-
-				$record_id = $block['context']['gutenberg/recordId'];
+			'render_callback' => function( $block ) {
+				$record_id = $block->context['gutenberg/recordId'];
 
 				if ( ! is_int( $record_id ) ) {
 					throw new Exception( 'Expected numeric recordId' );

--- a/packages/e2e-tests/plugins/block-context.php
+++ b/packages/e2e-tests/plugins/block-context.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Plugin Name: Gutenberg Test Block Context
+ * Plugin URI: https://github.com/WordPress/gutenberg
+ * Author: Gutenberg Team
+ *
+ * @package gutenberg-test-block-context
+ */
+
+/**
+ * Enqueues a custom script for the plugin.
+ */
+function gutenberg_test_enqueue_block_context_script() {
+	wp_enqueue_script(
+		'gutenberg-test-block-context',
+		plugins_url( 'block-context/index.js', __FILE__ ),
+		[
+			'wp-block-editor',
+			'wp-blocks',
+			'wp-element',
+		],
+		filemtime( plugin_dir_path( __FILE__ ) . 'block-context/index.js' ),
+		true
+	);
+}
+add_action( 'init', 'gutenberg_test_enqueue_block_context_script' );
+
+/**
+ * Registers plugin test context blocks.
+ */
+function gutenberg_test_register_context_blocks() {
+	register_block_type(
+		'gutenberg/test-context-provider',
+		[
+			'attributes'      => [
+				'recordId' => [
+					'type'    => 'number',
+					'default' => 0,
+				],
+			],
+			'providesContext' => [
+				'gutenberg/recordId' => 'recordId',
+			],
+		]
+	);
+
+	register_block_type(
+		'gutenberg/test-context-consumer',
+		[
+			'context'         => [ 'gutenberg/recordId' ],
+			'render_callback' => function() {
+				global $block;
+
+				$record_id = $block['context']['gutenberg/recordId'];
+
+				if ( ! is_int( $record_id ) ) {
+					throw new Exception( 'Expected numeric recordId' );
+				}
+
+				return 'The record ID is: ' . filter_var( $record_id, FILTER_VALIDATE_INT );
+			},
+		]
+	);
+}
+add_action( 'init', 'gutenberg_test_register_context_blocks' );

--- a/packages/e2e-tests/plugins/block-context.php
+++ b/packages/e2e-tests/plugins/block-context.php
@@ -14,11 +14,11 @@ function gutenberg_test_enqueue_block_context_script() {
 	wp_enqueue_script(
 		'gutenberg-test-block-context',
 		plugins_url( 'block-context/index.js', __FILE__ ),
-		[
+		array(
 			'wp-block-editor',
 			'wp-blocks',
 			'wp-element',
-		],
+		),
 		filemtime( plugin_dir_path( __FILE__ ) . 'block-context/index.js' ),
 		true
 	);
@@ -31,23 +31,23 @@ add_action( 'init', 'gutenberg_test_enqueue_block_context_script' );
 function gutenberg_test_register_context_blocks() {
 	register_block_type(
 		'gutenberg/test-context-provider',
-		[
-			'attributes'      => [
-				'recordId' => [
+		array(
+			'attributes'      => array(
+				'recordId' => array(
 					'type'    => 'number',
 					'default' => 0,
-				],
-			],
-			'providesContext' => [
+				),
+			),
+			'providesContext' => array(
 				'gutenberg/recordId' => 'recordId',
-			],
-		]
+			),
+		)
 	);
 
 	register_block_type(
 		'gutenberg/test-context-consumer',
-		[
-			'context'         => [ 'gutenberg/recordId' ],
+		array(
+			'context'         => array( 'gutenberg/recordId' ),
 			'render_callback' => function( $block ) {
 				$record_id = $block->context['gutenberg/recordId'];
 
@@ -57,7 +57,7 @@ function gutenberg_test_register_context_blocks() {
 
 				return 'The record ID is: ' . filter_var( $record_id, FILTER_VALIDATE_INT );
 			},
-		]
+		)
 	);
 }
 add_action( 'init', 'gutenberg_test_register_context_blocks' );

--- a/packages/e2e-tests/plugins/block-context/index.js
+++ b/packages/e2e-tests/plugins/block-context/index.js
@@ -1,0 +1,60 @@
+( function() {
+	const { createElement: el, Fragment } = wp.element;
+	const { registerBlockType } = wp.blocks;
+	const { InnerBlocks } = wp.blockEditor;
+
+	registerBlockType( 'gutenberg/test-context-provider', {
+		title: 'Test Context Provider',
+
+		// TODO: While redundant with server-side registration, it's required
+		// to assign this value since it is not picked in the implementation of
+		// `get_block_editor_server_block_settings`.
+		providesContext: {
+			'gutenberg/recordId': 'recordId',
+		},
+
+		category: 'common',
+
+		edit( { attributes, setAttributes } ) {
+			return el(
+				Fragment,
+				null,
+				el( 'input', {
+					value: attributes.recordId,
+					onChange( event ) {
+						setAttributes( {
+							recordId: Number( event.currentTarget.value ),
+						} );
+					},
+				} ),
+				el( InnerBlocks, {
+					template: [ [ 'gutenberg/test-context-consumer', {} ] ],
+					templateLock: 'all',
+				} )
+			);
+		},
+
+		save() {
+			return el( InnerBlocks.Content );
+		},
+	} );
+
+	registerBlockType( 'gutenberg/test-context-consumer', {
+		title: 'Test Context Consumer',
+
+		// TODO: While redundant with server-side registration, it's required
+		// to assign this value since it is not picked in the implementation of
+		// `get_block_editor_server_block_settings`.
+		context: [ 'gutenberg/recordId' ],
+
+		category: 'common',
+
+		edit( { context } ) {
+			return 'The record ID is: ' + context[ 'gutenberg/recordId' ];
+		},
+
+		save() {
+			return null;
+		},
+	} );
+} )();

--- a/packages/e2e-tests/specs/editor/plugins/block-context.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/block-context.test.js
@@ -1,0 +1,108 @@
+/**
+ * External dependencies
+ */
+import { last } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import {
+	activatePlugin,
+	createNewPost,
+	deactivatePlugin,
+	insertBlock,
+	saveDraft,
+} from '@wordpress/e2e-test-utils';
+
+async function openPreviewPage( editorPage ) {
+	let openTabs = await browser.pages();
+	const expectedTabsCount = openTabs.length + 1;
+	await editorPage.click( '.editor-post-preview__button-toggle' );
+	await editorPage.waitFor( '.editor-post-preview__button-external' );
+	await editorPage.click( '.editor-post-preview__button-external' );
+
+	// Wait for the new tab to open.
+	while ( openTabs.length < expectedTabsCount ) {
+		await editorPage.waitFor( 1 );
+		openTabs = await browser.pages();
+	}
+
+	const previewPage = last( openTabs );
+	// Wait for the preview to load. We can't do interstitial detection here,
+	// because it might load too quickly for us to pick up, so we wait for
+	// the preview to load by waiting for the content to appear.
+	await previewPage.waitForSelector( '.entry-content' );
+	return previewPage;
+}
+
+describe( 'Block context', () => {
+	beforeAll( async () => {
+		await activatePlugin( 'gutenberg-test-block-context' );
+	} );
+
+	beforeEach( async () => {
+		await createNewPost();
+	} );
+
+	afterAll( async () => {
+		await deactivatePlugin( 'gutenberg-test-block-context' );
+	} );
+
+	test( 'Block context propagates to inner blocks', async () => {
+		await insertBlock( 'Test Context Provider' );
+
+		// Inserting the context provider block should select the first inner
+		// block of the template. Verify the contents of the consumer.
+		let innerBlockText = await page.evaluate(
+			() => document.activeElement.textContent
+		);
+		expect( innerBlockText ).toBe( 'The record ID is: 0' );
+
+		// Change the attribute value associated with the context.
+		await page.keyboard.press( 'ArrowUp' );
+		await page.keyboard.type( '123' );
+
+		// Verify propagated context changes.
+		await page.keyboard.press( 'ArrowDown' );
+		innerBlockText = await page.evaluate(
+			() => document.activeElement.textContent
+		);
+		expect( innerBlockText ).toBe( 'The record ID is: 123' );
+	} );
+
+	test( 'Block context is reflected in the preview', async () => {
+		await insertBlock( 'Test Context Provider' );
+		const editorPage = page;
+		const previewPage = await openPreviewPage( editorPage );
+
+		// Check default context values are populated.
+		let content = await previewPage.$eval(
+			'.entry-content',
+			( contentWrapper ) => contentWrapper.textContent.trim()
+		);
+		expect( content ).toBe( 'The record ID is: 0' );
+
+		// Return to editor to change context value to non-default.
+		await editorPage.bringToFront();
+		await editorPage.focus(
+			'[data-type="gutenberg/test-context-provider"] input'
+		);
+		await editorPage.keyboard.press( 'ArrowRight' );
+		await editorPage.keyboard.type( '123' );
+		await editorPage.waitForSelector( '.editor-post-save-draft' ); // TODO: Why is Save not available immediately?
+		await saveDraft();
+
+		// Check non-default context values are populated.
+		await previewPage.bringToFront();
+		await previewPage.reload();
+		content = await previewPage.$eval(
+			'.entry-content',
+			( contentWrapper ) => contentWrapper.textContent.trim()
+		);
+		expect( content ).toBe( 'The record ID is: 123' );
+
+		// Clean up
+		await editorPage.bringToFront();
+		await previewPage.close();
+	} );
+} );

--- a/packages/e2e-tests/specs/editor/plugins/block-context.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/block-context.test.js
@@ -89,7 +89,7 @@ describe( 'Block context', () => {
 		);
 		await editorPage.keyboard.press( 'ArrowRight' );
 		await editorPage.keyboard.type( '123' );
-		await editorPage.waitForSelector( '.editor-post-save-draft' ); // TODO: Why is Save not available immediately?
+		await editorPage.waitForSelector( '.editor-post-save-draft' ); // Not entirely clear why it's asynchronous, but likely React scheduling prioritizing keyboard event and deferring the UI update.
 		await saveDraft();
 
 		// Check non-default context values are populated.

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -14,6 +14,7 @@ import { __ } from '@wordpress/i18n';
 import { EntityProvider } from '@wordpress/core-data';
 import {
 	BlockEditorProvider,
+	BlockContextProvider,
 	__unstableEditorStyles as EditorStyles,
 } from '@wordpress/block-editor';
 import apiFetch from '@wordpress/api-fetch';
@@ -194,19 +195,26 @@ class EditorProvider extends Component {
 						type={ post.type }
 						id={ post.id }
 					>
-						<BlockEditorProvider
-							value={ blocks }
-							onInput={ resetEditorBlocksWithoutUndoLevel }
-							onChange={ resetEditorBlocks }
-							selectionStart={ selectionStart }
-							selectionEnd={ selectionEnd }
-							settings={ editorSettings }
-							useSubRegistry={ false }
+						<BlockContextProvider
+							value={ {
+								postId: post.id,
+								postType: post.type,
+							} }
 						>
-							{ children }
-							<ReusableBlocksButtons />
-							<ConvertToGroupButtons />
-						</BlockEditorProvider>
+							<BlockEditorProvider
+								value={ blocks }
+								onInput={ resetEditorBlocksWithoutUndoLevel }
+								onChange={ resetEditorBlocks }
+								selectionStart={ selectionStart }
+								selectionEnd={ selectionEnd }
+								settings={ editorSettings }
+								useSubRegistry={ false }
+							>
+								{ children }
+								<ReusableBlocksButtons />
+								<ConvertToGroupButtons />
+							</BlockEditorProvider>
+						</BlockContextProvider>
 					</EntityProvider>
 				</EntityProvider>
 			</>

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -54,6 +54,10 @@ class EditorProvider extends Component {
 			maxSize: 1,
 		} );
 
+		this.getDefaultBlockContext = memize( this.getDefaultBlockContext, {
+			maxSize: 1,
+		} );
+
 		// Assume that we don't need to initialize in the case of an error recovery.
 		if ( props.recovery ) {
 			return;
@@ -139,6 +143,10 @@ class EditorProvider extends Component {
 		};
 	}
 
+	getDefaultBlockContext( postId, postType ) {
+		return { postId, postType };
+	}
+
 	componentDidMount() {
 		this.props.updateEditorSettings( this.props.settings );
 	}
@@ -186,6 +194,11 @@ class EditorProvider extends Component {
 			isPostTitleSelected
 		);
 
+		const defaultBlockContext = this.getDefaultBlockContext(
+			post.id,
+			post.type
+		);
+
 		return (
 			<>
 				<EditorStyles styles={ settings.styles } />
@@ -195,12 +208,7 @@ class EditorProvider extends Component {
 						type={ post.type }
 						id={ post.id }
 					>
-						<BlockContextProvider
-							value={ {
-								postId: post.id,
-								postType: post.type,
-							} }
-						>
+						<BlockContextProvider value={ defaultBlockContext }>
 							<BlockEditorProvider
 								value={ blocks }
 								onInput={ resetEditorBlocksWithoutUndoLevel }

--- a/packages/eslint-plugin/configs/jsdoc.js
+++ b/packages/eslint-plugin/configs/jsdoc.js
@@ -17,6 +17,7 @@ const temporaryWordPressInternalTypes = [
 	'WPBlockSerializationOptions',
 	'WPBlock',
 	'WPBlockPattern',
+	'WPBlockType',
 	'WPBlockTypeIcon',
 	'WPBlockTypeIconRender',
 	'WPBlockTypeIconDescriptor',

--- a/phpunit/class-block-context-test.php
+++ b/phpunit/class-block-context-test.php
@@ -104,9 +104,8 @@ class Block_Context_Test extends WP_UnitTestCase {
 					'gutenberg/contextWithAssigned',
 					'gutenberg/contextWithoutDefault',
 				],
-				'render_callback' => function() use ( &$provided_context ) {
-					global $block;
-					$provided_context[] = $block['context'];
+				'render_callback' => function( $block ) use ( &$provided_context ) {
+					$provided_context[] = $block->context;
 
 					return '';
 				},
@@ -128,47 +127,6 @@ class Block_Context_Test extends WP_UnitTestCase {
 			],
 			$provided_context[0]
 		);
-	}
-
-	/**
-	 * Tests that a block render assigns the block global, bottom-up, and resets
-	 * it for each new block.
-	 */
-	function test_sets_and_resets_block_global() {
-		$block_globals = [];
-
-		$this->register_block_type(
-			'gutenberg/test-parent',
-			[
-				'render_callback' => function() use ( &$block_globals ) {
-					global $block;
-					$block_globals[] = $block;
-				},
-			]
-		);
-		$this->register_block_type(
-			'gutenberg/test-child',
-			[
-				'render_callback' => function() use ( &$block_globals ) {
-					global $block;
-					$block_globals[] = $block;
-				},
-			]
-		);
-
-		$parsed_blocks = parse_blocks(
-			'<!-- wp:gutenberg/test-parent -->' .
-			'<!-- wp:gutenberg/test-child /-->' .
-			'<!-- wp:gutenberg/test-child /-->' .
-			'<!-- /wp:gutenberg/test-parent -->'
-		);
-
-		render_block( $parsed_blocks[0] );
-
-		$this->assertCount( 3, $block_globals );
-		$this->assertEquals( 'gutenberg/test-child', $block_globals[0]['blockName'] );
-		$this->assertEquals( 'gutenberg/test-child', $block_globals[1]['blockName'] );
-		$this->assertEquals( 'gutenberg/test-parent', $block_globals[2]['blockName'] );
 	}
 
 }

--- a/phpunit/class-block-context-test.php
+++ b/phpunit/class-block-context-test.php
@@ -1,0 +1,174 @@
+<?php
+/**
+ * Test block context.
+ *
+ * @package Gutenberg
+ */
+
+class Block_Context_Test extends WP_UnitTestCase {
+
+	/**
+	 * Registered block names.
+	 *
+	 * @var string[]
+	 */
+	private $registered_block_names = [];
+
+	/**
+	 * Sets up each test method.
+	 */
+	public function setUp() {
+		global $post;
+
+		parent::setUp();
+
+		$args = array(
+			'post_content' => 'example',
+			'post_excerpt' => '',
+		);
+
+		$post = $this->factory()->post->create_and_get( $args );
+		setup_postdata( $post );
+	}
+
+	/**
+	 * Tear down each test method.
+	 */
+	public function tearDown() {
+		parent::tearDown();
+
+		while ( ! empty( $this->registered_block_names ) ) {
+			$block_name = array_pop( $this->registered_block_names );
+			unregister_block_type( $block_name );
+		}
+	}
+
+	/**
+	 * Registers a block type.
+	 *
+	 * @param string|WP_Block_Type $name Block type name including namespace, or alternatively a
+	 *                                   complete WP_Block_Type instance. In case a WP_Block_Type
+	 *                                   is provided, the $args parameter will be ignored.
+	 * @param array                $args {
+	 *     Optional. Array of block type arguments. Any arguments may be defined, however the
+	 *     ones described below are supported by default. Default empty array.
+	 *
+	 *     @type callable $render_callback Callback used to render blocks of this block type.
+	 * }
+	 */
+	protected function register_block_type( $name, $args ) {
+		register_block_type( $name, $args );
+
+		$this->registered_block_names[] = $name;
+	}
+
+	/**
+	 * Tests that a block which provides context makes that context available to
+	 * its inner blocks.
+	 */
+	function test_provides_block_context() {
+		$provided_context = [];
+
+		$this->register_block_type(
+			'gutenberg/test-context-provider',
+			[
+				'attributes'      => [
+					'contextWithAssigned'   => [
+						'type' => 'number',
+					],
+					'contextWithDefault'    => [
+						'type'    => 'number',
+						'default' => 0,
+					],
+					'contextWithoutDefault' => [
+						'type' => 'number',
+					],
+					'contextNotRequested'   => [
+						'type' => 'number',
+					],
+				],
+				'providesContext' => [
+					'gutenberg/contextWithAssigned'   => 'contextWithAssigned',
+					'gutenberg/contextWithDefault'    => 'contextWithDefault',
+					'gutenberg/contextWithoutDefault' => 'contextWithoutDefault',
+					'gutenberg/contextNotRequested'   => 'contextNotRequested',
+				],
+			]
+		);
+
+		$this->register_block_type(
+			'gutenberg/test-context-consumer',
+			[
+				'context'         => [
+					'gutenberg/contextWithDefault',
+					'gutenberg/contextWithAssigned',
+					'gutenberg/contextWithoutDefault',
+				],
+				'render_callback' => function() use ( &$provided_context ) {
+					global $block;
+					$provided_context[] = $block['context'];
+
+					return '';
+				},
+			]
+		);
+
+		$parsed_blocks = parse_blocks(
+			'<!-- wp:gutenberg/test-context-provider {"contextWithAssigned":10} -->' .
+			'<!-- wp:gutenberg/test-context-consumer /-->' .
+			'<!-- /wp:gutenberg/test-context-provider -->'
+		);
+
+		render_block( $parsed_blocks[0] );
+
+		$this->assertEquals(
+			[
+				'gutenberg/contextWithDefault'  => 0,
+				'gutenberg/contextWithAssigned' => 10,
+			],
+			$provided_context[0]
+		);
+	}
+
+	/**
+	 * Tests that a block render assigns the block global, bottom-up, and resets
+	 * it for each new block.
+	 */
+	function test_sets_and_resets_block_global() {
+		$block_globals = [];
+
+		$this->register_block_type(
+			'gutenberg/test-parent',
+			[
+				'render_callback' => function() use ( &$block_globals ) {
+					global $block;
+					$block_globals[] = $block;
+				},
+			]
+		);
+		$this->register_block_type(
+			'gutenberg/test-child',
+			[
+				'render_callback' => function() use ( &$block_globals ) {
+					global $block;
+					$block_globals[] = $block;
+				},
+			]
+		);
+
+		$parsed_blocks = parse_blocks(
+			'<!-- wp:gutenberg/test-parent -->' .
+			'<!-- wp:gutenberg/test-child /-->' .
+			'<!-- wp:gutenberg/test-child /-->' .
+			'<!-- /wp:gutenberg/test-parent -->'
+		);
+
+		render_block( $parsed_blocks[0] );
+
+		$this->assertCount( 3, $block_globals );
+		$this->assertEquals( 'gutenberg/test-child', $block_globals[0]['blockName'] );
+		$this->assertEquals( 'gutenberg/test-child', $block_globals[1]['blockName'] );
+		$this->assertEquals( 'gutenberg/test-parent', $block_globals[2]['blockName'] );
+	}
+
+}

--- a/phpunit/class-block-context-test.php
+++ b/phpunit/class-block-context-test.php
@@ -12,7 +12,7 @@ class Block_Context_Test extends WP_UnitTestCase {
 	 *
 	 * @var string[]
 	 */
-	private $registered_block_names = [];
+	private $registered_block_names = array();
 
 	/**
 	 * Sets up each test method.
@@ -67,49 +67,49 @@ class Block_Context_Test extends WP_UnitTestCase {
 	 * its inner blocks.
 	 */
 	function test_provides_block_context() {
-		$provided_context = [];
+		$provided_context = array();
 
 		$this->register_block_type(
 			'gutenberg/test-context-provider',
-			[
-				'attributes'      => [
-					'contextWithAssigned'   => [
+			array(
+				'attributes'      => array(
+					'contextWithAssigned'   => array(
 						'type' => 'number',
-					],
-					'contextWithDefault'    => [
+					),
+					'contextWithDefault'    => array(
 						'type'    => 'number',
 						'default' => 0,
-					],
-					'contextWithoutDefault' => [
+					),
+					'contextWithoutDefault' => array(
 						'type' => 'number',
-					],
-					'contextNotRequested'   => [
+					),
+					'contextNotRequested'   => array(
 						'type' => 'number',
-					],
-				],
-				'providesContext' => [
+					),
+				),
+				'providesContext' => array(
 					'gutenberg/contextWithAssigned'   => 'contextWithAssigned',
 					'gutenberg/contextWithDefault'    => 'contextWithDefault',
 					'gutenberg/contextWithoutDefault' => 'contextWithoutDefault',
 					'gutenberg/contextNotRequested'   => 'contextNotRequested',
-				],
-			]
+				),
+			)
 		);
 
 		$this->register_block_type(
 			'gutenberg/test-context-consumer',
-			[
-				'context'         => [
+			array(
+				'context'         => array(
 					'gutenberg/contextWithDefault',
 					'gutenberg/contextWithAssigned',
 					'gutenberg/contextWithoutDefault',
-				],
+				),
 				'render_callback' => function( $block ) use ( &$provided_context ) {
 					$provided_context[] = $block->context;
 
 					return '';
 				},
-			]
+			)
 		);
 
 		$parsed_blocks = parse_blocks(
@@ -121,10 +121,10 @@ class Block_Context_Test extends WP_UnitTestCase {
 		render_block( $parsed_blocks[0] );
 
 		$this->assertEquals(
-			[
+			array(
 				'gutenberg/contextWithDefault'  => 0,
 				'gutenberg/contextWithAssigned' => 10,
-			],
+			),
 			$provided_context[0]
 		);
 	}

--- a/phpunit/class-wp-block-test.php
+++ b/phpunit/class-wp-block-test.php
@@ -1,0 +1,296 @@
+<?php
+/**
+ * Test WP_Block class.
+ *
+ * @package Gutenberg
+ */
+
+class WP_Block_Test extends WP_UnitTestCase {
+
+	/**
+	 * Fake block type registry.
+	 *
+	 * @var WP_Block_Type_Registry
+	 */
+	private $registry = null;
+
+	/**
+	 * Set up each test method.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->registry = new WP_Block_Type_Registry();
+	}
+
+	/**
+	 * Tear down each test method.
+	 */
+	public function tearDown() {
+		parent::tearDown();
+
+		$this->registry = null;
+	}
+
+	function test_constructor_assigns_properties_from_parsed_block() {
+		$this->registry->register( 'core/example', [] );
+
+		$parsed_blocks = parse_blocks( '<!-- wp:example {"ok":true} -->a<!-- wp:example /-->b<!-- /wp:example -->' );
+		$parsed_block  = $parsed_blocks[0];
+		$context       = [];
+		$block         = new WP_Block( $parsed_block, $context, $this->registry );
+
+		$this->assertEquals( $parsed_block['blockName'], $block->name );
+		$this->assertEquals( $parsed_block['attrs'], $block->attributes );
+		$this->assertEquals( $parsed_block['innerContent'], $block->inner_content );
+		$this->assertEquals( $parsed_block['innerHTML'], $block->inner_html );
+	}
+
+	function test_constructor_assigns_block_type_from_registry() {
+		$block_type_settings = [
+			'attributes' => [
+				'defaulted' => [
+					'type'    => 'number',
+					'default' => 10,
+				],
+			],
+		];
+		$this->registry->register( 'core/example', $block_type_settings );
+
+		$parsed_block = [ 'blockName' => 'core/example' ];
+		$context      = [];
+		$block        = new WP_Block( $parsed_block, $context, $this->registry );
+
+		$this->assertInstanceOf( WP_Block_Type::class, $block->block_type );
+		$this->assertEquals(
+			$block_type_settings['attributes'],
+			$block->block_type->attributes
+		);
+	}
+
+	function test_constructor_assigns_attributes_with_defaults() {
+		$this->registry->register(
+			'core/example',
+			[
+				'attributes' => [
+					'defaulted' => [
+						'type'    => 'number',
+						'default' => 10,
+					],
+				],
+			]
+		);
+
+		$parsed_block = [
+			'blockName' => 'core/example',
+			'attrs'     => [
+				'explicit' => 20,
+			],
+		];
+		$context      = [];
+		$block        = new WP_Block( $parsed_block, $context, $this->registry );
+
+		$this->assertEquals(
+			[
+				'defaulted' => 10,
+				'explicit'  => 20,
+			],
+			$block->attributes
+		);
+	}
+
+	function test_constructor_assigns_attributes_with_only_defaults() {
+		$this->registry->register(
+			'core/example',
+			[
+				'attributes' => [
+					'defaulted' => [
+						'type'    => 'number',
+						'default' => 10,
+					],
+				],
+			]
+		);
+
+		$parsed_block = [
+			'blockName' => 'core/example',
+			'attrs'     => [],
+		];
+		$context      = [];
+		$block        = new WP_Block( $parsed_block, $context, $this->registry );
+
+		$this->assertEquals( [ 'defaulted' => 10 ], $block->attributes );
+	}
+
+	function test_constructor_assigns_context_from_block_type() {
+		$this->registry->register(
+			'core/example',
+			[
+				'context' => [ 'requested' ],
+			]
+		);
+
+		$parsed_block = [ 'blockName' => 'core/example' ];
+		$context      = [
+			'requested'   => 'included',
+			'unrequested' => 'not included',
+		];
+		$block        = new WP_Block( $parsed_block, $context, $this->registry );
+
+		$this->assertEquals( [ 'requested' => 'included' ], $block->context );
+	}
+
+	function test_constructor_maps_inner_blocks() {
+		$this->registry->register( 'core/example', [] );
+
+		$parsed_blocks = parse_blocks( '<!-- wp:example {"ok":true} -->a<!-- wp:example /-->b<!-- /wp:example -->' );
+		$parsed_block  = $parsed_blocks[0];
+		$context       = [];
+		$block         = new WP_Block( $parsed_block, $context, $this->registry );
+
+		$this->assertCount( 1, $block->inner_blocks );
+		$this->assertInstanceOf( WP_Block::class, $block->inner_blocks[0] );
+		$this->assertEquals( 'core/example', $block->inner_blocks[0]->name );
+	}
+
+	function test_constructor_prepares_context_for_inner_blocks() {
+		$this->registry->register(
+			'core/outer',
+			[
+				'attributes'      => [
+					'recordId' => [
+						'type' => 'number',
+					],
+				],
+				'providesContext' => [
+					'core/recordId' => 'recordId',
+				],
+			]
+		);
+		$this->registry->register(
+			'core/inner',
+			[
+				'context' => [ 'core/recordId' ],
+			]
+		);
+
+		$parsed_blocks = parse_blocks( '<!-- wp:outer {"recordId":10} --><!-- wp:inner /--><!-- /wp:outer -->' );
+		$parsed_block  = $parsed_blocks[0];
+		$context       = [ 'unrequested' => 'not included' ];
+		$block         = new WP_Block( $parsed_block, $context, $this->registry );
+
+		$this->assertCount( 0, $block->context );
+		$this->assertEquals(
+			[ 'core/recordId' => 10 ],
+			$block->inner_blocks[0]->context
+		);
+	}
+
+	function test_render_static_block_type_returns_own_content() {
+		$this->registry->register( 'core/static', [] );
+		$this->registry->register(
+			'core/dynamic',
+			[
+				'render_callback' => function() {
+					return 'b';
+				},
+			]
+		);
+
+		$parsed_blocks = parse_blocks( '<!-- wp:static -->a<!-- wp:dynamic /-->c<!-- /wp:static -->' );
+		$parsed_block  = $parsed_blocks[0];
+		$context       = [];
+		$block         = new WP_Block( $parsed_block, $context, $this->registry );
+
+		$this->assertSame( 'abc', $block->render() );
+	}
+
+	function test_render_passes_instance_to_render_callback() {
+		$this->registry->register(
+			'core/greeting',
+			[
+				'attributes'      => [
+					'toWhom'      => [
+						'type' => 'string',
+					],
+					'punctuation' => [
+						'type'    => 'string',
+						'default' => '!',
+					],
+				],
+				'render_callback' => function( $block ) {
+					return sprintf(
+						'Hello %s%s',
+						$block->attributes['toWhom'],
+						$block->attributes['punctuation']
+					);
+				},
+			]
+		);
+
+		$parsed_blocks = parse_blocks( '<!-- wp:greeting {"toWhom":"world"} /-->' );
+		$parsed_block  = $parsed_blocks[0];
+		$context       = [];
+		$block         = new WP_Block( $parsed_block, $context, $this->registry );
+
+		$this->assertSame( 'Hello world!', $block->render() );
+	}
+
+	function test_passes_attributes_to_render_callback() {
+		$this->registry->register(
+			'core/greeting',
+			[
+				'attributes'      => [
+					'toWhom'      => [
+						'type' => 'string',
+					],
+					'punctuation' => [
+						'type'    => 'string',
+						'default' => '!',
+					],
+				],
+				'render_callback' => function( $block_attributes ) {
+					return sprintf(
+						'Hello %s%s',
+						$block_attributes['toWhom'],
+						$block_attributes['punctuation']
+					);
+				},
+			]
+		);
+
+		$parsed_blocks = parse_blocks( '<!-- wp:greeting {"toWhom":"world"} /-->' );
+		$parsed_block  = $parsed_blocks[0];
+		$context       = [];
+		$block         = new WP_Block( $parsed_block, $context, $this->registry );
+
+		$this->assertSame( 'Hello world!', $block->render() );
+	}
+
+	function test_passes_content_to_render_callback() {
+		$this->registry->register(
+			'core/outer',
+			[
+				'render_callback' => function( $block, $content ) {
+					return $content;
+				},
+			]
+		);
+		$this->registry->register(
+			'core/inner',
+			[
+				'render_callback' => function() {
+					return 'b';
+				},
+			]
+		);
+
+		$parsed_blocks = parse_blocks( '<!-- wp:outer -->a<!-- wp:inner /-->c<!-- /wp:outer -->' );
+		$parsed_block  = $parsed_blocks[0];
+		$context       = [];
+		$block         = new WP_Block( $parsed_block, $context, $this->registry );
+
+		$this->assertSame( 'abc', $block->render() );
+	}
+
+}

--- a/phpunit/class-wp-block-test.php
+++ b/phpunit/class-wp-block-test.php
@@ -186,6 +186,47 @@ class WP_Block_Test extends WP_UnitTestCase {
 		);
 	}
 
+	function test_constructor_assigns_merged_context() {
+		$this->registry->register(
+			'core/example',
+			array(
+				'attributes'      => array(
+					'value' => array(
+						'type' => array( 'string', 'null' ),
+					),
+				),
+				'providesContext' => array(
+					'core/value' => 'value',
+				),
+				'context'         => array( 'core/value' ),
+			)
+		);
+
+		$parsed_blocks = parse_blocks(
+			'<!-- wp:example {"value":"merged"} -->' .
+			'<!-- wp:example {"value":null} -->' .
+			'<!-- wp:example /-->' .
+			'<!-- /wp:example -->' .
+			'<!-- /wp:example -->'
+		);
+		$parsed_block  = $parsed_blocks[0];
+		$context       = array( 'core/value' => 'original' );
+		$block         = new WP_Block( $parsed_block, $context, $this->registry );
+
+		$this->assertEquals(
+			array( 'core/value' => 'original' ),
+			$block->context
+		);
+		$this->assertEquals(
+			array( 'core/value' => 'merged' ),
+			$block->inner_blocks[0]->context
+		);
+		$this->assertEquals(
+			array( 'core/value' => null ),
+			$block->inner_blocks[0]->inner_blocks[0]->context
+		);
+	}
+
 	function test_render_static_block_type_returns_own_content() {
 		$this->registry->register( 'core/static', array() );
 		$this->registry->register(

--- a/phpunit/class-wp-block-test.php
+++ b/phpunit/class-wp-block-test.php
@@ -334,4 +334,37 @@ class WP_Block_Test extends WP_UnitTestCase {
 		$this->assertSame( 'abc', $block->render() );
 	}
 
+	function test_array_access_attributes() {
+		$this->registry->register(
+			'core/example',
+			array(
+				'attributes' => array(
+					'value' => array(
+						'type' => 'string',
+					),
+				),
+			)
+		);
+		$parsed_block = array(
+			'blockName' => 'core/example',
+			'attrs'     => array( 'value' => 'ok' ),
+		);
+		$context      = array();
+		$block        = new WP_Block( $parsed_block, $context, $this->registry );
+
+		$this->assertTrue( isset( $block['value'] ) );
+		$this->assertFalse( isset( $block['nonsense'] ) );
+		$this->assertEquals( 'ok', $block['value'] );
+
+		$block['value'] = 'changed';
+		$this->assertEquals( 'changed', $block['value'] );
+		$this->assertEquals( 'changed', $block->attributes['value'] );
+
+		unset( $block['value'] );
+		$this->assertFalse( isset( $block['value'] ) );
+
+		$block[] = 'invalid, but still supported';
+		$this->assertEquals( 'invalid, but still supported', $block[0] );
+	}
+
 }

--- a/phpunit/class-wp-block-test.php
+++ b/phpunit/class-wp-block-test.php
@@ -33,11 +33,11 @@ class WP_Block_Test extends WP_UnitTestCase {
 	}
 
 	function test_constructor_assigns_properties_from_parsed_block() {
-		$this->registry->register( 'core/example', [] );
+		$this->registry->register( 'core/example', array() );
 
 		$parsed_blocks = parse_blocks( '<!-- wp:example {"ok":true} -->a<!-- wp:example /-->b<!-- /wp:example -->' );
 		$parsed_block  = $parsed_blocks[0];
-		$context       = [];
+		$context       = array();
 		$block         = new WP_Block( $parsed_block, $context, $this->registry );
 
 		$this->assertEquals( $parsed_block['blockName'], $block->name );
@@ -47,18 +47,18 @@ class WP_Block_Test extends WP_UnitTestCase {
 	}
 
 	function test_constructor_assigns_block_type_from_registry() {
-		$block_type_settings = [
-			'attributes' => [
-				'defaulted' => [
+		$block_type_settings = array(
+			'attributes' => array(
+				'defaulted' => array(
 					'type'    => 'number',
 					'default' => 10,
-				],
-			],
-		];
+				),
+			),
+		);
 		$this->registry->register( 'core/example', $block_type_settings );
 
-		$parsed_block = [ 'blockName' => 'core/example' ];
-		$context      = [];
+		$parsed_block = array( 'blockName' => 'core/example' );
+		$context      = array();
 		$block        = new WP_Block( $parsed_block, $context, $this->registry );
 
 		$this->assertInstanceOf( WP_Block_Type::class, $block->block_type );
@@ -71,30 +71,30 @@ class WP_Block_Test extends WP_UnitTestCase {
 	function test_constructor_assigns_attributes_with_defaults() {
 		$this->registry->register(
 			'core/example',
-			[
-				'attributes' => [
-					'defaulted' => [
+			array(
+				'attributes' => array(
+					'defaulted' => array(
 						'type'    => 'number',
 						'default' => 10,
-					],
-				],
-			]
+					),
+				),
+			)
 		);
 
-		$parsed_block = [
+		$parsed_block = array(
 			'blockName' => 'core/example',
-			'attrs'     => [
+			'attrs'     => array(
 				'explicit' => 20,
-			],
-		];
-		$context      = [];
+			),
+		);
+		$context      = array();
 		$block        = new WP_Block( $parsed_block, $context, $this->registry );
 
 		$this->assertEquals(
-			[
+			array(
 				'defaulted' => 10,
 				'explicit'  => 20,
-			],
+			),
 			$block->attributes
 		);
 	}
@@ -102,50 +102,50 @@ class WP_Block_Test extends WP_UnitTestCase {
 	function test_constructor_assigns_attributes_with_only_defaults() {
 		$this->registry->register(
 			'core/example',
-			[
-				'attributes' => [
-					'defaulted' => [
+			array(
+				'attributes' => array(
+					'defaulted' => array(
 						'type'    => 'number',
 						'default' => 10,
-					],
-				],
-			]
+					),
+				),
+			)
 		);
 
-		$parsed_block = [
+		$parsed_block = array(
 			'blockName' => 'core/example',
-			'attrs'     => [],
-		];
-		$context      = [];
+			'attrs'     => array(),
+		);
+		$context      = array();
 		$block        = new WP_Block( $parsed_block, $context, $this->registry );
 
-		$this->assertEquals( [ 'defaulted' => 10 ], $block->attributes );
+		$this->assertEquals( array( 'defaulted' => 10 ), $block->attributes );
 	}
 
 	function test_constructor_assigns_context_from_block_type() {
 		$this->registry->register(
 			'core/example',
-			[
-				'context' => [ 'requested' ],
-			]
+			array(
+				'context' => array( 'requested' ),
+			)
 		);
 
-		$parsed_block = [ 'blockName' => 'core/example' ];
-		$context      = [
+		$parsed_block = array( 'blockName' => 'core/example' );
+		$context      = array(
 			'requested'   => 'included',
 			'unrequested' => 'not included',
-		];
+		);
 		$block        = new WP_Block( $parsed_block, $context, $this->registry );
 
-		$this->assertEquals( [ 'requested' => 'included' ], $block->context );
+		$this->assertEquals( array( 'requested' => 'included' ), $block->context );
 	}
 
 	function test_constructor_maps_inner_blocks() {
-		$this->registry->register( 'core/example', [] );
+		$this->registry->register( 'core/example', array() );
 
 		$parsed_blocks = parse_blocks( '<!-- wp:example {"ok":true} -->a<!-- wp:example /-->b<!-- /wp:example -->' );
 		$parsed_block  = $parsed_blocks[0];
-		$context       = [];
+		$context       = array();
 		$block         = new WP_Block( $parsed_block, $context, $this->registry );
 
 		$this->assertCount( 1, $block->inner_blocks );
@@ -156,50 +156,50 @@ class WP_Block_Test extends WP_UnitTestCase {
 	function test_constructor_prepares_context_for_inner_blocks() {
 		$this->registry->register(
 			'core/outer',
-			[
-				'attributes'      => [
-					'recordId' => [
+			array(
+				'attributes'      => array(
+					'recordId' => array(
 						'type' => 'number',
-					],
-				],
-				'providesContext' => [
+					),
+				),
+				'providesContext' => array(
 					'core/recordId' => 'recordId',
-				],
-			]
+				),
+			)
 		);
 		$this->registry->register(
 			'core/inner',
-			[
-				'context' => [ 'core/recordId' ],
-			]
+			array(
+				'context' => array( 'core/recordId' ),
+			)
 		);
 
 		$parsed_blocks = parse_blocks( '<!-- wp:outer {"recordId":10} --><!-- wp:inner /--><!-- /wp:outer -->' );
 		$parsed_block  = $parsed_blocks[0];
-		$context       = [ 'unrequested' => 'not included' ];
+		$context       = array( 'unrequested' => 'not included' );
 		$block         = new WP_Block( $parsed_block, $context, $this->registry );
 
 		$this->assertCount( 0, $block->context );
 		$this->assertEquals(
-			[ 'core/recordId' => 10 ],
+			array( 'core/recordId' => 10 ),
 			$block->inner_blocks[0]->context
 		);
 	}
 
 	function test_render_static_block_type_returns_own_content() {
-		$this->registry->register( 'core/static', [] );
+		$this->registry->register( 'core/static', array() );
 		$this->registry->register(
 			'core/dynamic',
-			[
+			array(
 				'render_callback' => function() {
 					return 'b';
 				},
-			]
+			)
 		);
 
 		$parsed_blocks = parse_blocks( '<!-- wp:static -->a<!-- wp:dynamic /-->c<!-- /wp:static -->' );
 		$parsed_block  = $parsed_blocks[0];
-		$context       = [];
+		$context       = array();
 		$block         = new WP_Block( $parsed_block, $context, $this->registry );
 
 		$this->assertSame( 'abc', $block->render() );
@@ -208,16 +208,16 @@ class WP_Block_Test extends WP_UnitTestCase {
 	function test_render_passes_instance_to_render_callback() {
 		$this->registry->register(
 			'core/greeting',
-			[
-				'attributes'      => [
-					'toWhom'      => [
+			array(
+				'attributes'      => array(
+					'toWhom'      => array(
 						'type' => 'string',
-					],
-					'punctuation' => [
+					),
+					'punctuation' => array(
 						'type'    => 'string',
 						'default' => '!',
-					],
-				],
+					),
+				),
 				'render_callback' => function( $block ) {
 					return sprintf(
 						'Hello %s%s',
@@ -225,12 +225,12 @@ class WP_Block_Test extends WP_UnitTestCase {
 						$block->attributes['punctuation']
 					);
 				},
-			]
+			)
 		);
 
 		$parsed_blocks = parse_blocks( '<!-- wp:greeting {"toWhom":"world"} /-->' );
 		$parsed_block  = $parsed_blocks[0];
-		$context       = [];
+		$context       = array();
 		$block         = new WP_Block( $parsed_block, $context, $this->registry );
 
 		$this->assertSame( 'Hello world!', $block->render() );
@@ -239,16 +239,16 @@ class WP_Block_Test extends WP_UnitTestCase {
 	function test_passes_attributes_to_render_callback() {
 		$this->registry->register(
 			'core/greeting',
-			[
-				'attributes'      => [
-					'toWhom'      => [
+			array(
+				'attributes'      => array(
+					'toWhom'      => array(
 						'type' => 'string',
-					],
-					'punctuation' => [
+					),
+					'punctuation' => array(
 						'type'    => 'string',
 						'default' => '!',
-					],
-				],
+					),
+				),
 				'render_callback' => function( $block_attributes ) {
 					return sprintf(
 						'Hello %s%s',
@@ -256,12 +256,12 @@ class WP_Block_Test extends WP_UnitTestCase {
 						$block_attributes['punctuation']
 					);
 				},
-			]
+			)
 		);
 
 		$parsed_blocks = parse_blocks( '<!-- wp:greeting {"toWhom":"world"} /-->' );
 		$parsed_block  = $parsed_blocks[0];
-		$context       = [];
+		$context       = array();
 		$block         = new WP_Block( $parsed_block, $context, $this->registry );
 
 		$this->assertSame( 'Hello world!', $block->render() );
@@ -270,24 +270,24 @@ class WP_Block_Test extends WP_UnitTestCase {
 	function test_passes_content_to_render_callback() {
 		$this->registry->register(
 			'core/outer',
-			[
+			array(
 				'render_callback' => function( $block, $content ) {
 					return $content;
 				},
-			]
+			)
 		);
 		$this->registry->register(
 			'core/inner',
-			[
+			array(
 				'render_callback' => function() {
 					return 'b';
 				},
-			]
+			)
 		);
 
 		$parsed_blocks = parse_blocks( '<!-- wp:outer -->a<!-- wp:inner /-->c<!-- /wp:outer -->' );
 		$parsed_block  = $parsed_blocks[0];
-		$context       = [];
+		$context       = array();
 		$block         = new WP_Block( $parsed_block, $context, $this->registry );
 
 		$this->assertSame( 'abc', $block->render() );


### PR DESCRIPTION
Closes #19685
Closes #4671
Previously: #19572
WordPress Trac ticket: https://core.trac.wordpress.org/ticket/49927.

This pull request seeks to implement the means for a block to provide and consume contextual values. In many ways, it is based on the earlier work of #19572, but there are some key differences in the specifics of how context is defined. I've included a fair bit of documentation here as well, which was useful for me in validating (["rubber duck"-ing](https://en.wikipedia.org/wiki/Rubber_duck_debugging)) the underlying implementation. This documentation should prove useful for understanding what it is, how it works, and why it's proposed to be implemented the way it is.

Differences from #19572:

- Providing context occurs separately from the block's `attributes` schema, as its own `providesContext` property.
- There's no association from the consumer of where a context value is assumed to be defined. Instead, a provider grants a value via a key corresponding to the name of one of its own attributes, and a consumer references it by name.
   - For more information, granted downsides, and possible future enhancements, refer to the comment at https://github.com/WordPress/gutenberg/issues/19685#issuecomment-603848589 .
- ~Server-side, the implementation proposed here does not modify the function signatures of either `render_block` or a block's `render_callback`. Instead, both the block context of the current hierarchy and the block itself are assigned as globals which can be referenced in the `render_callback`.~ In later revisions of this pull request, an enhancement was achieved where the full `$block` instance is passed as an argument to `render_callback`, retaining backward compatibility by implementing `ArrayAccess` where the instance's array members are short-hand to its own attributes. See https://github.com/WordPress/gutenberg/pull/21467#issuecomment-613635022 for more information.
   - [See documentation](https://github.com/WordPress/gutenberg/blob/c6ea48219de1ffacd0016226051691ce3828cb57/docs/designers-developers/developers/block-api/block-context.md#using-block-context)
   - For more information and granted downsides, refer to the comment at https://github.com/WordPress/gutenberg/issues/19685#issuecomment-603867889 .
   - ~This is future-compatible with revisions to the function signatures, if there's a desire to go this route. I did not feel that this decision should block the implementation. I've remarked to the future possibility of revised function signatures in the above-referenced documentation.~ Later changes of the pull request implemented said future-compatible revisions.
   - ~This also solves requirements where some developers have sought to access other properties of `$block` while within `render_callback`, avoiding needing to resort to workarounds using `render_block` hook (e.g. #19991).~ Later changes of the pull request serve as a solution to this need.
- Block context is assigned from a provider only from the point of `InnerBlocks`, as an optimization to avoid establishing a context unnecessarily if there are no children to consume from it.
- It does not implement any new blocks. For demonstration purposes, the existing Post Title block has been updated to use block context. This was also the case in #19572, but currently it is only a static representation of the title, and does not yet support editing.

**Open Questions:**

- "Default" context: Is it reasonable to establish the default "post" context? There is certainly prior art for this, given that `render_block` already manipulates and assigns the `$post` global. I'd worry if this might lead to a situation where there's not clear expectations around what should or shouldn't be available by default. "Post" is a particularly special case and may be fine to assume it would be unique in this regard.
- Does context need to be available to `save` ? I've assumed not, given that this may lead to unintended invalidations, and that at least for the current set of use-cases, context would be evaluated server-side in a `render_callback`.
- The comment at https://github.com/WordPress/gutenberg/issues/19685#issuecomment-603848589 left open the question about whether these keys ought to be namespaced to avoid conflict. While this is still a possibility and the proposed implementation may be overly simplistic (i.e. naive), it may also be fair to say that context will be reserved for very specific usages, and not widely applied enough so as to have high risk for conflict.
- Minor: Does it make sense that a `context` object always be provided, even when the block does not define any context to consume? My decision to pass an empty object is largely for developer experience, anticipating potential errors if a developer were to assume that the object is present and attempt unguarded access to properties on that (possibly-undefined) value.

**In Progress:**

- ~I am observing PHP warning notices in the "Site Editor" page related to these changes, which I've yet to resolve. They appear to be related to the assignment of the `$block` global in the overridden `render_block` implementation.~ Fixed, see https://github.com/WordPress/gutenberg/pull/21467#issuecomment-612944434.

**Testing Instructions:**

Given that this pull request only ports the Post Title experimental full-site editing block, testing can be a bit cumbersome at the moment, especially if you've not yet defined templates for full-site editing mode.

My recommendation for testing is as follows:

1. Navigate to Gutenberg > Experiments
2. Enable "Full Site Editing" and click "Save Changes"
3. Navigate to Posts > Add New
4. Insert a Post Title block
5. Observe that the block inherits the title of the post and updates if you change the title
6. Preview the post in a separate tab
   - Note: If you don't have templates on your site, you may see a message "No template found". This is expected, and can be disregarded for now.
7. Navigate to Gutenberg > Experiments
8. Disable "Full Site Editing" and click "Save Changes"
9. In your separate preview tab, refresh the page.
10. Observe that the Post Title block displays the title of the current post