### PR TITLE
Make navigation block submenus usable on mobile.

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -228,11 +228,6 @@ function NavigationLinkEdit( {
 							'core/strikethrough',
 						] }
 					/>
-					{ showSubmenuIcon && (
-						<span className="wp-block-navigation-link__submenu-icon">
-							<ItemSubmenuIcon />
-						</span>
-					) }
 					{ isLinkOpen && (
 						<Popover
 							position="bottom center"
@@ -285,6 +280,11 @@ function NavigationLinkEdit( {
 						</Popover>
 					) }
 				</div>
+				{ showSubmenuIcon && (
+					<span className="wp-block-navigation-link__submenu-icon">
+						<ItemSubmenuIcon />
+					</span>
+				) }
 				<InnerBlocks
 					allowedBlocks={ [ 'core/navigation-link' ] }
 					renderAppender={

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -255,6 +255,9 @@ function block_core_navigation_build_html( $attributes, $block, $colors, $font_s
 
 		$html .= '</span>';
 
+		$html .= '</a>';
+		// End anchor tag content.
+
 		// Append submenu icon to top-level item.
 		// it shows the icon as default, when 'showSubmenuIcon' is not set,
 		// or when it's set and also not False.
@@ -267,9 +270,6 @@ function block_core_navigation_build_html( $attributes, $block, $colors, $font_s
 		) {
 			$html .= '<span class="wp-block-navigation-link__submenu-icon">' . block_core_navigation_render_submenu_icon() . '</span>';
 		}
-
-		$html .= '</a>';
-		// End anchor tag content.
 
 		if ( $has_submenu ) {
 			$html .= block_core_navigation_build_html( $attributes, $block, $colors, $font_sizes );

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -1,51 +1,57 @@
-$navigation-menu-height: $grid-unit-10 * 7;
-$navigation-sub-menu-height: $grid-unit-10 * 5;
-$navigation-sub-menu-width: $grid-unit-10 * 25;
-
-/*
-* Reset the default list styles
-*/
-
-.wp-block-navigation > ul {
-	display: block;
+.wp-block-navigation__container {
+	// Reset the default list styles
 	list-style: none;
 	margin: 0;
 	padding-left: 0;
 
-	@include break-small {
-		display: flex;
-		flex-wrap: wrap;
-	}
+	// Horizontal layout
+	display: flex;
+	flex-wrap: wrap;
 
-	// Submenu
-	ul {
-		list-style: none;
-		padding-left: 0;
-		margin-top: 0;
-		margin-left: 0;
+	// Vertical layout
 
-		li {
-			margin: 0;
-		}
+	.is-vertical & {
+		display: block;
 	}
 }
 
-/*
-* Styles for submenu flyout
-*/
+.wp-block-navigation-link {
+	display: flex;
+	align-items: center;
+	position: relative;
+	margin: 0;
+	padding: $grid-unit-10;
+}
 
-.wp-block-navigation > ul {
-	li {
-		&:hover,
-		&:focus-within {
-			cursor: pointer;
+// Styles for submenu flyout
+.has-child {
+	.wp-block-navigation__container {
+		border: $border-width solid rgba(0, 0, 0, 0.15);
+		padding: $grid-unit-10 * 0.75 $grid-unit-10 * 2;
+		background-color: inherit;
+		color: inherit;
+		position: absolute;
+		left: 0;
+		top: 100%;
+		z-index: 1;
+		opacity: 0;
+		transition: opacity 0.1s linear;
+		visibility: hidden;
+
+		// Nested submenus sit to the left on large breakpoints
+		@include break-medium {
+			.wp-block-navigation__container {
+				left: 100%;
+				top: -$border-width;
+			}
 		}
+	}
+	// Separating out hover and focus-within so hover works again on IE: https://davidwalsh.name/css-focus-within#comment-513401
+	// We will need to replace focus-within with a JS solution for IE keyboard support.
+	&:hover {
+		cursor: pointer;
 
-		// Submenu Display
-		&:hover > ul,
-		&:focus-within > ul,
-		& ul:hover,
-		& ul:focus {
+		> .wp-block-navigation__container {
 			visibility: visible;
 			opacity: 1;
 			display: flex;
@@ -53,224 +59,74 @@ $navigation-sub-menu-width: $grid-unit-10 * 25;
 		}
 	}
 
-	& > li ul {
-		position: absolute;
-		left: 0;
-		top: 100%;
-		min-width: $navigation-sub-menu-width;
-		max-width: $navigation-sub-menu-width;
-		opacity: 0;
-		transition: opacity 0.1s linear;
-		visibility: hidden;
+	&:focus-within {
+		cursor: pointer;
+
+		> .wp-block-navigation__container {
+			visibility: visible;
+			opacity: 1;
+			display: flex;
+			flex-direction: column;
+		}
 	}
 }
 
-/*
-* Styles shared between editor and frontend
-*/
-.wp-block-navigation,
-.wp-block-navigation .block-editor-block-list__layout {
-	display: flex;
-	flex-wrap: wrap;
+// All links
+.wp-block-navigation-link__content {
+	padding: $grid-unit-10 * 0.75 $grid-unit-10 * 2;
+
+	@include break-small {
+		width: max-content;
+	}
+
+	.has-text-color & {
+		color: inherit;
+	}
 }
 
-.wp-block-navigation {
+.wp-block-navigation-link__submenu-icon {
+	padding: $grid-unit-10 * 0.75 $grid-unit-10 * 2;
 
-	// set a width on the editor submenus
-	.block-editor-block-list__layout .block-editor-block-list__layout {
-		width: $navigation-sub-menu-width;
-	}
+	svg {
+		fill: currentColor;
 
-	&,
-	> .wp-block-navigation__container {
-		align-items: center;
-		width: 100%;
-
-		> .wp-block-navigation-link {
-			display: flex;
-			margin-top: 0;
-			margin-bottom: 0;
-		}
-	}
-
-	&.is-vertical ul {
-		display: flex;
-		flex-direction: column;
-		li {
-			text-align: left;
-		}
-	}
-
-	&.is-vertical > .wp-block-navigation__container {
-		align-items: flex-start;
-	}
-
-	// Main menu
-	.wp-block-navigation-link {
-		position: relative;
-		margin: 0;
-		min-height: $navigation-menu-height;
-		display: flex;
-		line-height: 1.4;
-
-		// Sub menus
-		.wp-block,
-		.wp-block-navigation-link {
-			min-height: auto; // reset the min-height and rely on padding
-			padding: 0;
-		}
-
-		// Sub menus (editor canvas)
-		.wp-block .wp-block-navigation-link {
-			margin: 0;
-		}
-
-		&.has-child > .wp-block-navigation__container {
-			// Box model
-			display: flex;
-			border: $border-width solid rgba(0, 0, 0, 0.15);
-
-			// Position (first level)
-			position: absolute;
-			z-index: 1;
-			top: 100%;
-			left: 0; // just under the main menu item.
-
-			// Position (nested levels)
-			.block-editor-inner-blocks,
-			.wp-block-navigation__container {
-				left: 100%;
-				top: - $border-width;
-			}
-		}
-
-		// Inherit colors from menu
-		.wp-block-navigation__container {
-			background-color: inherit;
-			color: inherit;
-		}
-
-		// All links
-		.wp-block-navigation-link__content {
-			display: flex;
-			align-items: center;
-			width: max-content;
-			padding: $grid-unit-10 * 0.75 $grid-unit-10 * 2;
-		}
-
-		// Submenu links only
-		.wp-block-navigation-link {
-
-			&:first-child:not(:only-child) .wp-block-navigation-link__content {
-				padding-top: $grid-unit-10;
-			}
-
-			&:last-child .wp-block-navigation-link__content {
-				padding-bottom: $grid-unit-10;
-			}
-		}
-
-		&.has-child .wp-block-navigation-link__content {
-			padding-right: $grid-unit-10 * 4;
-			position: relative;
-		}
-
-		.wp-block-navigation-link__submenu-icon {
-			position: absolute;
-			right: $grid-unit-10 * 2;
-
-			svg {
-				fill: currentColor;
-			}
-		}
-
-		// reset rotation of submenu indicator icons on nested levels
-		.wp-block-navigation-link svg {
+		@include break-medium {
+			// reset rotation of submenu indicator icons on nested levels
 			transform: rotate(0);
 		}
-
-		&.has-text-color .wp-block-navigation-link__content {
-			color: inherit;
-		}
 	}
 }
 
-// Styles
-.wp-block-navigation {
-
-	// Default / Light styles
-	.wp-block-navigation-link,
-	&.is-style-light .wp-block-navigation-link {
-		//  No text color
-		&:not(.has-text-color) > .wp-block-navigation__container {
-			color: $light-style-sub-menu-text-color;
-		}
-
-		// No background color
-		&:not(.has-background) > .wp-block-navigation__container {
-			background-color: $light-style-sub-menu-background-color;
-		}
-	}
-
-	// Dark styles.
-	&.is-style-dark .wp-block-navigation-link {
-		// No text color
-		&:not(.has-text-color) > .wp-block-navigation__container {
-			color: $dark-style-sub-menu-text-color;
-		}
-
-		// No background color
-		&:not(.has-background) > .wp-block-navigation__container {
-			background-color: $dark-style-sub-menu-background-color;
-		}
+// Default / Light styles
+.wp-block-navigation-link,
+.is-style-light .wp-block-navigation-link {
+	&:not(.has-text-color) .wp-block-navigation-link__content {
+		color: $light-style-sub-menu-text-color;
 	}
 }
-
-/*
-* Non-shared styles & overrides
-*/
-
-.wp-block-navigation {
-
-	.wp-block-navigation-link.has-child > .wp-block-navigation__container {
-		display: flex;
-		flex-direction: column;
-		padding: 0;
-	}
+.is-style-light:not(.has-background) .wp-block-navigation__container {
+	background-color: $light-style-sub-menu-background-color;
 }
 
-/*
-* TODO: organize/untangle styles below this line
-*/
-
-.wp-block-navigation {
-
-	& > ul {
-		& > li {
-			& > a {
-				display: flex;
-				align-items: center;
-			}
-
-			&:first-of-type > a {
-				padding-left: 0;
-			}
-
-			&:last-of-type > a {
-				padding-right: 0;
-			}
-		}
+// Dark styles.
+.is-style-dark .wp-block-navigation-link {
+	&:not(.has-text-color) .wp-block-navigation-link__content {
+		color: $dark-style-sub-menu-text-color;
 	}
+}
+.is-style-dark:not(.has-background) .wp-block-navigation__container {
+	background-color: $dark-style-sub-menu-background-color;
+}
 
-	&.items-justified-left > ul {
-		justify-content: flex-start;
-	}
+// Jutification.
+.items-justified-left > ul {
+	justify-content: flex-start;
+}
 
-	&.items-justified-center > ul {
-		justify-content: center;
-	}
+.items-justified-center > ul {
+	justify-content: center;
+}
 
-	&.items-justified-right > ul {
-		justify-content: flex-end;
-	}
+.items-justified-right > ul {
+	justify-content: flex-end;
 }

--- a/packages/block-library/src/navigation/theme.scss
+++ b/packages/block-library/src/navigation/theme.scss
@@ -4,3 +4,8 @@
 		list-style: none;
 	}
 }
+
+// Overrides generic ".entry-content li" styles on the front end.
+.wp-block-navigation-link.wp-block-navigation-link {
+	margin: 0;
+}


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

Navigation submenus are currently broken on mobile:

* Their layout assumes a large screen and causes a horizontal scroll on phones;
* On the front end, it's nearly impossible to open a submenu without clicking through to the parent menu link.

This PR adjusts submenu size and placement for small screens, and introduces text wrapping, to avoid horizontal scrolling. It also places the submenu indicator icon outside the menu item link, so that it is possible to open it on a touchscreen without activating the link.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Tested on multiple browsers and mobile simulators.

## Screenshots <!-- if applicable -->

<img width="375" alt="Screen Shot 2020-04-08 at 4 09 02 pm" src="https://user-images.githubusercontent.com/8096000/78750312-54fa0600-79b3-11ea-8d51-a2c77ca5fd21.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
