### PR TITLE
Allow reusable block top and bottom paddings to collapse.

### DIFF
--- a/packages/block-library/src/block/editor.scss
+++ b/packages/block-library/src/block/editor.scss
@@ -8,4 +8,9 @@
 		padding-left: 0;
 		padding-right: 0;
 	}
+
+	// Allow vertical paddings to collapse to better fit the flow.
+	.block-editor-writing-flow {
+		display: block;
+	}
 }


### PR DESCRIPTION
This is a followup and addition to #21312. It's separate because it's not a regression.

The code here (props @MichaelArestad ) allows the margins of the first and last blocks inside a reusable block container to collapse. The end is that reusable blocks do not suddenly get double top and bottom margins, which they do currently. Before:

<img width="973" alt="Screenshot 2020-04-08 at 08 47 07" src="https://user-images.githubusercontent.com/1204802/78753665-7c7ead80-7976-11ea-87e0-0ff236de1649.png">

After:

<img width="941" alt="Screenshot 2020-04-08 at 08 45 14" src="https://user-images.githubusercontent.com/1204802/78753671-7f799e00-7976-11ea-9dab-74baebc910c3.png">

Note that this PR is an enhancement and not a regression fix. It also needs slightly more testing to verify the display property doesn't break an aspect of reusable blocks.

The horizontal padding you see in the above screenshots is fixed in #21312, which _is_ a regression.