### PR TITLE
Icons: Add types

### DIFF
--- a/packages/icons/CHANGELOG.md
+++ b/packages/icons/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Master
 
+Include TypeScript type declarations ([#21487](https://github.com/WordPress/gutenberg/pull/21487))
+
 ## 1.0.0 (2020-02-04)
 
 Initial release.

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -22,6 +22,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"react-native": "src/index",
+	"types": "build-types",
 	"dependencies": {
 		"@babel/runtime": "^7.9.2",
 		"@wordpress/element": "../element",

--- a/packages/icons/src/icon/index.js
+++ b/packages/icons/src/icon/index.js
@@ -3,6 +3,22 @@
  */
 import { cloneElement } from '@wordpress/element';
 
+// Disable reason: JSDoc linter doesn't seem to parse the union (`&`) correctly.
+/* eslint-disable jsdoc/valid-types */
+/** @typedef {import('@wordpress/primitives').ComponentPropsWithoutRef<'SVG'>} SVGProps */
+/** @typedef {{icon: string} & {size?: number} & import('@wordpress/primitives').ComponentPropsWithoutRef<'SVG'>} IconProps */
+/* eslint-enable jsdoc/valid-types */
+
+/**
+ * Return an SVG icon.
+ *
+ * @param {IconProps} props        Icon component props
+ * @param {string}    props.icon   Icon name
+ * @param {number}    [props.size] Icon size in pixels
+ * @param {SVGProps}  props.props  Other props will be passed to wrapped SVG component
+ *
+ * @return {JSX.Element}  Icon component
+ */
 function Icon( { icon, size = 24, ...props } ) {
 	return cloneElement( icon, {
 		width: size,

--- a/packages/icons/src/icon/index.js
+++ b/packages/icons/src/icon/index.js
@@ -5,17 +5,15 @@ import { cloneElement } from '@wordpress/element';
 
 // Disable reason: JSDoc linter doesn't seem to parse the union (`&`) correctly.
 /* eslint-disable jsdoc/valid-types */
-/** @typedef {import('@wordpress/primitives').ComponentPropsWithoutRef<'SVG'>} SVGProps */
 /** @typedef {{icon: string} & {size?: number} & import('@wordpress/primitives').ComponentPropsWithoutRef<'SVG'>} IconProps */
 /* eslint-enable jsdoc/valid-types */
 
 /**
  * Return an SVG icon.
  *
- * @param {IconProps} props        Icon component props
- * @param {string}    props.icon   Icon name
- * @param {number}    [props.size] Icon size in pixels
- * @param {SVGProps}  props.props  Other props will be passed to wrapped SVG component
+ * @param {IconProps} props icon is a string specifying which icon to render
+ *                          size is a number specifiying the icon size in pixels
+ *                          Other props will be passed to wrapped SVG component
  *
  * @return {JSX.Element}  Icon component
  */

--- a/packages/icons/src/icon/index.js
+++ b/packages/icons/src/icon/index.js
@@ -5,13 +5,13 @@ import { cloneElement } from '@wordpress/element';
 
 // Disable reason: JSDoc linter doesn't seem to parse the union (`&`) correctly.
 /* eslint-disable jsdoc/valid-types */
-/** @typedef {{icon: string} & {size?: number} & import('@wordpress/primitives').ComponentPropsWithoutRef<'SVG'>} IconProps */
+/** @typedef {{icon: JSX.Element} & {size?: number} & import('react').ComponentPropsWithoutRef<'SVG'>} IconProps */
 /* eslint-enable jsdoc/valid-types */
 
 /**
  * Return an SVG icon.
  *
- * @param {IconProps} props icon is a string specifying which icon to render
+ * @param {IconProps} props icon is the SVG component to render
  *                          size is a number specifiying the icon size in pixels
  *                          Other props will be passed to wrapped SVG component
  *

--- a/packages/icons/src/icon/index.js
+++ b/packages/icons/src/icon/index.js
@@ -5,7 +5,7 @@ import { cloneElement } from '@wordpress/element';
 
 // Disable reason: JSDoc linter doesn't seem to parse the union (`&`) correctly.
 /* eslint-disable jsdoc/valid-types */
-/** @typedef {{icon: JSX.Element} & {size?: number} & import('react').ComponentPropsWithoutRef<'SVG'>} IconProps */
+/** @typedef {{icon: JSX.Element, size?: number} & import('react').ComponentPropsWithoutRef<'SVG'>} IconProps */
 /* eslint-enable jsdoc/valid-types */
 
 /**

--- a/packages/icons/src/icon/stories/index.js
+++ b/packages/icons/src/icon/stories/index.js
@@ -42,7 +42,7 @@ export const _default = () => {
 
 const LibraryExample = () => {
 	const [ filter, setFilter ] = useState( '' );
-	const filteredIcons = omitBy( availableIcons, ( icon, name ) => {
+	const filteredIcons = omitBy( availableIcons, ( _icon, name ) => {
 		return name.indexOf( filter ) === -1;
 	} );
 	return (

--- a/packages/icons/tsconfig.json
+++ b/packages/icons/tsconfig.json
@@ -1,0 +1,10 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"rootDir": "src",
+		"declarationDir": "build-types",
+
+		"noImplicitAny": false,
+	},
+	"include": [ "src/**/*" ]
+}

--- a/packages/icons/tsconfig.json
+++ b/packages/icons/tsconfig.json
@@ -2,9 +2,8 @@
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",
-		"declarationDir": "build-types",
-
-		"noImplicitAny": false,
+		"declarationDir": "build-types"
 	},
-	"include": [ "src/**/*" ]
+	"include": [ "src/**/*" ],
+	"references": [ { "path": "../primitives" } ]
 }

--- a/packages/primitives/src/svg/index.js
+++ b/packages/primitives/src/svg/index.js
@@ -10,7 +10,7 @@ import { createElement } from '@wordpress/element';
 
 // Disable reason: JSDoc linter doesn't seem to parse the union (`&`) correctly.
 /* eslint-disable jsdoc/valid-types */
-/** @typedef {{isPressed: boolean} & import('react').ComponentPropsWithoutRef<'svg'>} SVGProps */
+/** @typedef {{isPressed?: boolean} & import('react').ComponentPropsWithoutRef<'svg'>} SVGProps */
 /* eslint-enable jsdoc/valid-types */
 
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
 		{ "path": "packages/escape-html" },
 		{ "path": "packages/html-entities" },
 		{ "path": "packages/i18n" },
+		{ "path": "packages/icons" },
 		{ "path": "packages/is-shallow-equal" },
 		{ "path": "packages/prettier-config" },
 		{ "path": "packages/primitives" },


### PR DESCRIPTION
## Description
Taking notes from #21248. Depends on #21482. Part of #18838.

Includes a fix to `@wordpress/primitives` to make `SVG`'s `isPressed` prop optional (oversight in #21482).

## How has this been tested?

```
npm run build:package-types
```

## Types of changes
Add types.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->

cc/ @sirreal 