### PR TITLE
Build Tooling: Configure Webpack to watch only build files

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -189,7 +189,7 @@ module.exports = {
 		new DependencyExtractionWebpackPlugin( { injectPolyfill: true } ),
 	],
 	watchOptions: {
-		ignored: '!packages/**/(build|build-module)/**/*',
+		ignored: '!packages/*/!(src)/**/*',
 	},
 	devtool,
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -188,5 +188,8 @@ module.exports = {
 		] ),
 		new DependencyExtractionWebpackPlugin( { injectPolyfill: true } ),
 	],
+	watchOptions: {
+		ignored: '!packages/**/(build|build-module)/**/*',
+	},
 	devtool,
 };


### PR DESCRIPTION
This pull request seeks to revise the Webpack configuration to instruct the watcher to ignore all files which are outside a package's build output directories. The project is built in such a way that Webpack is responsible only for the part of the build where package output is transformed to be run in a browser. The package build (Babel, etc) is handled separately, where the output is directed to a package's `build`, `build-module`, and `build-style` folder, and then "handed off" to Webpack. Thus, it should be safe to assume that Webpack is only concerned with changes within these files.

The intention with these changes is to resolve cases where an operating system may have limited resources to watch files, either hitting a limit or maxing processor usage.

Related:

- https://webpack.js.org/configuration/watch/#not-enough-watchers
- https://gist.github.com/tombigel/d503800a282fcadbee14b537735d202c

**Implementation Notes:**

Credit to @draganescu for identifying `watchOptions.ignored` as the configuration for addressing the underlying issue.

Webpack uses `anymatch` under the hood, which in turn uses `micromatch`. Refer to documentation for more detail about the syntax of the glob patterns:

- https://github.com/micromatch/anymatch
- https://github.com/micromatch/micromatch

**Testing Instructions:**

Verify there are no regressions in watch behavior. Changing a source file within a package should trigger a Webpack rebuild.