### PR TITLE
Typescript: Exclude native files

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -33,5 +33,13 @@
 
 		"typeRoots": [ "./node_modules/@types" ]
 	},
-	"exclude": [ "**/benchmark", "**/test/**", "**/build/**", "**/build-*/**" ]
+	"exclude": [
+		"**/benchmark",
+		"**/test/**",
+		"**/build/**",
+		"**/build-*/**",
+		"**/*.android.js",
+		"**/*.ios.js",
+		"**/*.native.js"
+	]
 }


### PR DESCRIPTION
## Description

Exclude files ending in `.android.js`, `*.ios.js`, and `*.native.js` from TypeScript lookup and compilation.

This is required for PRs such as #21482 that add types to a package that also has a number of `.native.js` files, unless we also add types to those files (which would significantly increase the workload needed to get our packages typed). However, that doesn't seem to make a lot of sense, since the native modules don't seem to be run through any sort of TypeScript build chain anyway. 

## How has this been tested?
```
npm run build:package-types
```

## Checklist:
- [x] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
