### PR TITLE
Remove nested breakpoint in fullscreen-mode CSS

### DIFF
--- a/packages/interface/src/components/fullscreen-mode/style.scss
+++ b/packages/interface/src/components/fullscreen-mode/style.scss
@@ -3,12 +3,8 @@ body.js.is-fullscreen-mode {
 	@include break-medium {
 		// Reset the html.wp-topbar padding.
 		// Because this uses negative margins, we have to compensate for the height.
-		margin-top: -$admin-bar-height-big;
-		height: calc(100% + #{ $admin-bar-height-big });
-		@include break-medium() {
-			margin-top: -$admin-bar-height;
-			height: calc(100% + #{ $admin-bar-height });
-		}
+		margin-top: -$admin-bar-height;
+		height: calc(100% + #{ $admin-bar-height });
 
 		#adminmenumain,
 		#wpadminbar {


### PR DESCRIPTION
With a `break-medium` mixin inside a previous `break-medium`, the stylesheet compiles with extra media queries and an unused value of 46px. So WordPress 5.4's stylesheet contains this:

```
@media (min-width:782px){body.js.is-fullscreen-mode{margin-top:-46px;height:calc(100% + 46px)}}@media (min-width:782px) and (min-width:782px){body.js.is-fullscreen-mode{margin-top:-32px;height:calc(100% + 32px)}}@media (min-width:782px){
```

Because those `$admin-bar-height-big` values originally specified for narrower screen sizes are no longer used since pull request https://github.com/WordPress/gutenberg/pull/13425, this edit removes those styles and the redundant media queries.

(I edited the file within GitHub, so the change still could use some testing. Thanks!)