### PR TITLE
Navigation Tool: Show keyboard shortcut and adjust help string

### DIFF
--- a/packages/block-editor/src/components/tool-selector/index.js
+++ b/packages/block-editor/src/components/tool-selector/index.js
@@ -75,7 +75,9 @@ function ToolSelector() {
 											{ __( 'Edit' ) }
 										</>
 									),
-									shortcut: isNavigationTool ? __( 'Enter' ) : '',
+									shortcut: isNavigationTool
+										? __( 'Enter' )
+										: '',
 								},
 								{
 									value: 'select',
@@ -85,7 +87,9 @@ function ToolSelector() {
 											{ __( 'Select' ) }
 										</>
 									),
-									shortcut: isNavigationTool ? '' : __( 'Escape' ),
+									shortcut: isNavigationTool
+										? ''
+										: __( 'Escape' ),
 								},
 							] }
 						/>

--- a/packages/block-editor/src/components/tool-selector/index.js
+++ b/packages/block-editor/src/components/tool-selector/index.js
@@ -75,7 +75,7 @@ function ToolSelector() {
 											{ __( 'Edit' ) }
 										</>
 									),
-									shortcut: isNavigationTool ? 'Enter' : '',
+									shortcut: isNavigationTool ? __( 'Enter' ) : '',
 								},
 								{
 									value: 'select',
@@ -85,7 +85,7 @@ function ToolSelector() {
 											{ __( 'Select' ) }
 										</>
 									),
-									shortcut: isNavigationTool ? '' : 'Escape',
+									shortcut: isNavigationTool ? '' : __( 'Escape' ),
 								},
 							] }
 						/>

--- a/packages/block-editor/src/components/tool-selector/index.js
+++ b/packages/block-editor/src/components/tool-selector/index.js
@@ -75,6 +75,7 @@ function ToolSelector() {
 											{ __( 'Edit' ) }
 										</>
 									),
+									shortcut: isNavigationTool ? 'Enter' : '',
 								},
 								{
 									value: 'select',
@@ -84,13 +85,14 @@ function ToolSelector() {
 											{ __( 'Select' ) }
 										</>
 									),
+									shortcut: isNavigationTool ? '' : 'Escape',
 								},
 							] }
 						/>
 					</NavigableMenu>
 					<div className="block-editor-tool-selector__help">
 						{ __(
-							'Tools offer different interactions for block selection & editing. To select, press Escape, to go back to editing, press Enter.'
+							'Choose a navigation tool for interacting with blocks in your content.'
 						) }
 					</div>
 				</>


### PR DESCRIPTION
## Description
Starts #19447

* Shows keyboard shortcut in `MenuItemsChoice` when tool is inactive

EDIT: This is still being discussed on #19447 and isn't intended for merge right now.

## Screenshots
![Preview of Block Editor Navigation Tools toggle with Keyboard Shortcut in the menu choice](https://user-images.githubusercontent.com/9565066/78846591-1e2aec80-79c1-11ea-880b-792e3cfd2a7d.gif)


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
