### PR TITLE
Try: Inset borders.

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -69,10 +69,10 @@
 			z-index: 1;
 			pointer-events: none;
 			content: "";
-			top: 0;
-			bottom: 0;
-			left: 0;
-			right: 0;
+			top: $border-width;
+			bottom: $border-width;
+			left: $border-width;
+			right: $border-width;
 
 			// 2px outside.
 			box-shadow: 0 0 0 $border-width-focus $blue-medium-focus;
@@ -132,10 +132,10 @@
 			z-index: 1;
 			pointer-events: none;
 			content: "";
-			top: 0;
-			bottom: 0;
-			left: 0;
-			right: 0;
+			top: $border-width;
+			bottom: $border-width;
+			left: $border-width;
+			right: $border-width;
 		}
 
 		.is-block-content, // Floats.
@@ -585,10 +585,7 @@
 		.block-editor-block-list__breadcrumb,
 		.block-editor-block-contextual-toolbar {
 			margin-bottom: $grid-unit-15;
-
-			// @todo It should position the block transform dialog as the left margin of a block. It currently
-			// positions instead, the mover control.
-			margin-left: - $block-toolbar-height - $border-width;
+			margin-left: - $block-toolbar-height;
 		}
 
 		.block-editor-block-contextual-toolbar[data-align="full"],

--- a/packages/components/src/placeholder/style.scss
+++ b/packages/components/src/placeholder/style.scss
@@ -20,9 +20,9 @@
 	}
 
 	// Block UI appearance.
-	border-radius: $radius-block-ui - $border-width; // Border is outset, so so subtract the width to achieve correct radius.
+	border-radius: $radius-block-ui;
 	background-color: $white;
-	box-shadow: 0 0 0 $border-width $dark-gray-primary;
+	box-shadow: inset 0 0 0 $border-width $dark-gray-primary;
 	outline: 1px solid transparent; // Shown for Windows 10 High Contrast mode.
 
 	.components-base-control__label {


### PR DESCRIPTION
From the department of "subtle details" comes this PR:

- It changes the stroke around placeholders to be _inset_ rather than _outset_.

And this matters more than you might think. The difference is subtle, but it boils down to this.

- When the block focus rectangle is outset, it doesn't cover even a single pixel of content.
- When the block focus rectangle is inset, it covers a single pixel of content.

The former benefit seems obvious, the latter less so. So why make a change? Because the latter is actually more accurate to the block footprint, and it means no borders are cropped in full-width edge situations. Let me circle back to that in a minute, but first, before:

![before](https://user-images.githubusercontent.com/1204802/78866930-92f13b80-7a40-11ea-8c7a-843b3a113e0b.gif)

After:

![after](https://user-images.githubusercontent.com/1204802/78866938-94baff00-7a40-11ea-8a3f-627c5451d6b2.gif)

Imperceptible here, intentionally so. But what you can observe if you look closely is that the dark left border of both the block toolbar and the placeholder chrome, aligns PERFECTLY with the left margin of the paragraph block above. In the "before" image, it's actually 1px outset. At the cost of covering a pixel of text when in selection mode, of course. But there's another benefit.

One of the G2 efforts was to remove "side UI" — UI that sat left or right of the block itself, so that the block toolbar would never be cropped. This would also benefit full-wide situations. Well I'm working on a separate project where the block is full-wide, and that 1px outset border gets cropped:

<img width="638" alt="Screenshot 2020-04-09 at 08 58 01" src="https://user-images.githubusercontent.com/1204802/78867158-f0858800-7a40-11ea-9fe9-068f3a2761f4.png">

This PR fixes that:

<img width="647" alt="Screenshot 2020-04-09 at 08 55 55" src="https://user-images.githubusercontent.com/1204802/78867172-f54a3c00-7a40-11ea-985d-e0c89c7adb0a.png">

Previously, in the #18667 we intentionally used an outset border so as to not crop captions. However revisiting this, it doesn't feel so bad:

<img width="880" alt="Screenshot 2020-04-09 at 08 54 55" src="https://user-images.githubusercontent.com/1204802/78867215-07c47580-7a41-11ea-9c02-97f9084b82ce.png">

This is also primarily an issue in TwentyTwenty with left-aligned captions, where in most caption situations it's a non issue, like TwentyNineteen:

<img width="721" alt="Screenshot 2020-04-09 at 08 54 29" src="https://user-images.githubusercontent.com/1204802/78867264-1ca10900-7a41-11ea-9d93-4b6ba9f48390.png">

And furthermore — the covering of text is only an issue when the block has focus. 

Your thoughts are welcome!