### PR TITLE
Process: Add checklist item about API changes in a PR

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,5 +19,6 @@
 - [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
 - [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
 - [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
+- [ ] My code adds or changes API interaction. <!-- If it is changed the PR needs a status: Changes API -->
 - [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
 - [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->


### PR DESCRIPTION
## Description

To avoid situations where data corruption can be a result of changing API (see #18616 which started storing escaped titles in the database), we need to better aware of such changes. Most API changes will be without side-effects but without awareness of potential breaking changes, those that do have side-effects might be recognized too late.

By flagging API changes, they can be reviewed in bulk before a release, and the correct measures can be taken, for examply by adding a Changelog entry.

## Types of changes
Adds a new checklist item to the PR template:

[ ] My code adds or changes API interaction.

## Checklist:
(none apply since this is not a code change)

## Proposal in change of process
We should create a new status label `Changes API` so that we can review API changes before releases. There should also be new labels `Requires Changelog Entry` and `Has Changelog Entry` which can be used in such a case but might be useful in further scenarios when we want to ensure that important changes are not forgotten in changelogs.