### PR TITLE
Restore floated image margins.

### DIFF
--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -21,6 +21,19 @@
 		margin-top: -9px;
 		margin-left: -9px;
 	}
+
+	// These need specificity to override an inherited left/right block margin in the editor.
+	&.wp-block-image.alignleft {
+		margin-right: 1em;
+		margin-top: 0.5em;
+		margin-bottom: 0.5em;
+	}
+
+	&.wp-block-image.alignright {
+		margin-left: 1em;
+		margin-top: 0.5em;
+		margin-bottom: 0.5em;
+	}
 }
 
 // This is necessary for the editor resize handles to accurately work on a non-floated, non-resized, small image.

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -39,6 +39,8 @@
 		float: left;
 		/*rtl:ignore*/
 		margin-right: 1em;
+		margin-top: 0.5em;
+		margin-bottom: 0.5em;
 	}
 
 	.alignright {
@@ -46,6 +48,8 @@
 		float: right;
 		/*rtl:ignore*/
 		margin-left: 1em;
+		margin-top: 0.5em;
+		margin-bottom: 0.5em;
 	}
 
 	.aligncenter {


### PR DESCRIPTION
The image block regressed in a recent refactor of left/right block margins. The margins for floated images were removed:

<img width="771" alt="Screenshot 2020-04-09 at 11 31 25" src="https://user-images.githubusercontent.com/1204802/78881074-968fbd00-7a56-11ea-87f0-84e3bcccc04b.png">

This PR restores them. Editor:

<img width="706" alt="Screenshot 2020-04-09 at 11 36 11" src="https://user-images.githubusercontent.com/1204802/78881085-9bed0780-7a56-11ea-8ddc-266846306a7d.png">

Frontend:

<img width="817" alt="Screenshot 2020-04-09 at 11 36 17" src="https://user-images.githubusercontent.com/1204802/78881095-9ee7f800-7a56-11ea-9372-08a9bbb27350.png">

Additionally, it adds a top and bottom margin, which was also present in the classic editor:

```
	.alignright {
		/*rtl:ignore*/
		float: right;
		/*rtl:ignore*/
		margin: 0.5em 0 0.5em 1em;
	}

	.alignleft {
		/*rtl:ignore*/
		float: left;
		/*rtl:ignore*/
		margin: 0.5em 1em 0.5em 0;
	}
```

But what about the Cover block, and other blocks that have alignments?

Those receive margins through this CSS:

```
.block-editor-block-list__layout .block-editor-block-list__block[data-align="left"] > .is-block-content {
    float: left;
    margin-right: 2em;
}
```

I'm open to advice on a more generic approach to this, but it seems worth fixing.