### PR TITLE
Docs: Add section in block RFC about register_block_type_from_metadata

### DIFF
--- a/lib/compat.php
+++ b/lib/compat.php
@@ -12,7 +12,7 @@ if ( ! function_exists( 'register_block_type_from_metadata' ) ) {
 	/**
 	 * Registers a block type from metadata stored in the `block.json` file.
 	 *
-	 * @since 7.8.0
+	 * @since 7.9.0
 	 *
 	 * @param string $path Path to the folder where the `block.json` file is located.
 	 * @param array  $args {


### PR DESCRIPTION
## Description
Follow-up for #20794.

Related comment https://github.com/WordPress/gutenberg/pull/20794#issuecomment-601014451:

> My first idea was to omit the documentation part until we reach WordPress 5.5 release cycle to avoid all the confusion for those who browse https://developer.wordpress.org/block-editor/ and can't use this new block registration utility with WordPress core. We also miss support for two features proposed in Block Registration RFC:
> - [assets integration](https://github.com/WordPress/gutenberg/blob/master/docs/rfc/block-registration.md#assets)
> - [internatiolization](https://github.com/WordPress/gutenberg/blob/master/docs/rfc/block-registration.md#internationalization)
> 
> I think it might be a good idea to add a section in this RFC document as a follow-up (plus refresh the document in general) that would describe how this is going to work moving forward. If you agree I'm happy to open a follow-up PR.

This PR documents new PHP API proposed: `register_block_type_from_metadata`.
