### PR TITLE
Fix/Remove edit gallery from media library modal

### DIFF
--- a/packages/media-utils/src/components/media-upload/index.js
+++ b/packages/media-utils/src/components/media-upload/index.js
@@ -90,36 +90,39 @@ const getGalleryDetailsMediaFrame = () => {
 	 */
 	return wp.media.view.MediaFrame.Post.extend( {
 		/**
-		 * Set up gallery toolbar.
+		 * Set up gallery add toolbar.
 		 *
 		 * @return {void}
 		 */
-		galleryToolbar() {
-			const editing = this.state().get( 'editing' );
+		galleryAddToolbar() {
 			this.toolbar.set(
 				new wp.media.view.Toolbar( {
 					controller: this,
 					items: {
 						insert: {
 							style: 'primary',
-							text: editing
-								? wp.media.view.l10n.updateGallery
-								: wp.media.view.l10n.insertGallery,
+							text: wp.media.view.l10n.addToGallery,
 							priority: 80,
-							requires: { library: true },
+							requires: { selection: true },
 
 							/**
 							 * @fires wp.media.controller.State#update
 							 */
 							click() {
 								const controller = this.controller,
-									state = controller.state();
+									galleryAddSelection = controller
+										.state()
+										.get( 'selection' ),
+									galleryLibrary = controller
+										.state( 'gallery-edit' )
+										.get( 'library' );
+
+								galleryLibrary.add(
+									galleryAddSelection.models
+								);
 
 								controller.close();
-								state.trigger(
-									'update',
-									state.get( 'library' )
-								);
+								controller.trigger( 'update', galleryLibrary );
 
 								// Restore and reset the default state.
 								controller.setState( controller.options.state );
@@ -156,7 +159,6 @@ const getGalleryDetailsMediaFrame = () => {
 		 * @return {void}
 		 */
 		createStates: function createStates() {
-			this.on( 'toolbar:create:main-gallery', this.galleryToolbar, this );
 			this.on( 'content:render:edit-image', this.editState, this );
 
 			this.states.add( [

--- a/packages/media-utils/src/components/media-upload/index.js
+++ b/packages/media-utils/src/components/media-upload/index.js
@@ -185,7 +185,6 @@ const getGalleryDetailsMediaFrame = () => {
 				new wp.media.controller.GalleryEdit( {
 					library: this.options.selection,
 					editing: this.options.editing,
-					menu: 'gallery',
 					displaySettings: false,
 					multiple: true,
 				} ),


### PR DESCRIPTION
## Description
Remove edit-gallery feature from modal.
Closes #21413 

## How has this been tested?
Click tested on my local.

## Screenshots

![Apr-09-2020 21-35-46](https://user-images.githubusercontent.com/971886/78900995-3cb8e280-7aaa-11ea-8464-370c0ba5c3c9.gif)


## Types of changes
Bug fix, but possibly a breaking change as we are removing a workflow.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
