### PR TITLE
[RNMobile][FIX] Cover block background when there's a video is totally black

### DIFF
--- a/packages/block-library/src/cover/edit.native.js
+++ b/packages/block-library/src/cover/edit.native.js
@@ -31,7 +31,7 @@ import {
 } from '@wordpress/block-editor';
 import { compose, withPreferredColorScheme } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
-import { useEffect } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 import { cover as icon, replace } from '@wordpress/icons';
 
 /**
@@ -119,6 +119,21 @@ const Cover = ( {
 		setAttributes( { dimRatio: value } );
 	};
 
+	const [ isVideoLoading, setIsVideoLoading ] = useState( true );
+
+	const onVideoLoadStart = () => {
+		setIsVideoLoading( true );
+	};
+
+	const onVideoLoad = () => {
+		setIsVideoLoading( false );
+	};
+
+	const backgroundColor = getStylesFromColorScheme(
+		styles.backgroundSolid,
+		styles.backgroundSolidDark
+	);
+
 	const overlayStyles = [
 		styles.overlay,
 		url && { opacity: dimRatio / 100 },
@@ -129,12 +144,7 @@ const Cover = ( {
 				styles.overlay.color,
 		},
 		// While we don't support theme colors we add a default bg color
-		! overlayColor.color && ! url
-			? getStylesFromColorScheme(
-					styles.backgroundSolid,
-					styles.backgroundSolidDark
-			  )
-			: {},
+		! overlayColor.color && ! url ? backgroundColor : {},
 	];
 
 	const placeholderIconStyle = getStylesFromColorScheme(
@@ -194,7 +204,7 @@ const Cover = ( {
 			onLongPress={ openMediaOptions }
 			disabled={ ! isParentSelected }
 		>
-			<View style={ styles.background }>
+			<View style={ [ styles.background, backgroundColor ] }>
 				{ getMediaOptions() }
 				{ isParentSelected && toolbarControls( openMediaOptions ) }
 				<MediaUploadProgress
@@ -224,7 +234,13 @@ const Cover = ( {
 									repeat
 									resizeMode={ 'cover' }
 									source={ { uri: url } }
-									style={ styles.background }
+									onLoad={ onVideoLoad }
+									onLoadStart={ onVideoLoadStart }
+									style={ [
+										styles.background,
+										// Hide Video component since it has black background while loading the source
+										{ opacity: isVideoLoading ? 0 : 1 },
+									] }
 								/>
 							) }
 						</>


### PR DESCRIPTION
## Description
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/2104

Gutenberg-mobile PR - https://github.com/wordpress-mobile/gutenberg-mobile/pull/2146

The Video component from `react-native-video` has a black background on Android even if i set the `backgroundColor` in style. In this PR I hide the Video component until the video is loaded.

## How has this been tested?
- Run Wordpress-Android with the packager
- Add a cover block and set video as a background
- the background should be set to the same as a placeholder until the video is loaded

## Screenshots <!-- if applicable -->
before | after
---|---
![cover-video-dark-mode-too-black](https://user-images.githubusercontent.com/1032913/78357976-17fcd080-75bb-11ea-95f8-73d0a0535274.gif) | ![coverandroidfixx](https://user-images.githubusercontent.com/16336501/78917736-96f87a00-7a8f-11ea-96d7-4d36d79c6cc4.gif)

## Types of changes
Fix black background while the video is loading

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
