### PR TITLE
Change wp_make_content_images_responsive to wp_filter_content_tags

### DIFF
--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -265,7 +265,11 @@ function gutenberg_render_the_template() {
 	$content = $wp_embed->autoembed( $content );
 	$content = do_blocks( $content );
 	$content = wptexturize( $content );
-	$content = wp_filter_content_tags( $content );
+	if ( function_exists( 'wp_filter_content_tags' ) ) {
+		$content = wp_filter_content_tags( $content );
+	} else {
+		$content = wp_make_content_images_responsive( $content );
+	}
 	$content = str_replace( ']]>', ']]&gt;', $content );
 
 	// Wrap block template in .wp-site-blocks to allow for specific descendant styles

--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -265,7 +265,7 @@ function gutenberg_render_the_template() {
 	$content = $wp_embed->autoembed( $content );
 	$content = do_blocks( $content );
 	$content = wptexturize( $content );
-	$content = wp_make_content_images_responsive( $content );
+	$content = wp_filter_content_tags( $content );
 	$content = str_replace( ']]>', ']]&gt;', $content );
 
 	// Wrap block template in .wp-site-blocks to allow for specific descendant styles

--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -39,7 +39,11 @@ function render_block_core_template_part( $attributes ) {
 	$content = convert_smilies( $content );
 	$content = wpautop( $content );
 	$content = shortcode_unautop( $content );
-	$content = wp_filter_content_tags( $content );
+	if ( function_exists( 'wp_filter_content_tags' ) ) {
+		$content = wp_filter_content_tags( $content );
+	} else {
+		$content = wp_make_content_images_responsive( $content );
+	}
 	$content = do_shortcode( $content );
 
 	return str_replace( ']]>', ']]&gt;', $content );

--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -39,7 +39,7 @@ function render_block_core_template_part( $attributes ) {
 	$content = convert_smilies( $content );
 	$content = wpautop( $content );
 	$content = shortcode_unautop( $content );
-	$content = wp_make_content_images_responsive( $content );
+	$content = wp_filter_content_tags( $content );
 	$content = do_shortcode( $content );
 
 	return str_replace( ']]>', ']]&gt;', $content );


### PR DESCRIPTION
Fixes #21514

## Description
Swapped the call to `wp_make_content_images_responsive` for Template Parts to wp_filter_content_tags, in-line with the change to the_content in WordPress Core here:
https://core.trac.wordpress.org/changeset/47554

## How has this been tested?
1. Ensure you are on WordPress trunk
2. Use a Block Based Theme like https://github.com/WordPress/theme-experiments/tree/master/parisienne
3. Notice you see a notice that `wp_make_content_images_responsive` is deprecated since 5.5.0.
4. Switch to branch `try/replace_wp_make_content_images_responsive`
5. Notice the notice is now gone. 

## Types of changes
Bug fix 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
