### PR TITLE
Build Tooling: Check Latest NPM: Advise additional npm install

### DIFF
--- a/bin/check-latest-npm.js
+++ b/bin/check-latest-npm.js
@@ -102,7 +102,11 @@ Promise.all( [ getLatestNPMVersion(), getLocalNPMVersion() ] )
 
 It is required that you have the latest version of NPM installed in order to commit a change to the package-lock.json file.
 
-Run ${ yellow( 'npm install --global npm@latest' ) }, then try again.`
+Run ${ yellow(
+					'npm install --global npm@latest'
+				) } to install the latest version of NPM. Before retrying your commit, run ${ yellow(
+					'npm install'
+				) } once more to ensure the package-lock.json contents are correct. If there are any changes to the file, they should be included in your commit.`
 			);
 		}
 	} )


### PR DESCRIPTION
Previously: #21306 (https://github.com/WordPress/gutenberg/pull/21306#discussion_r405955176)

This pull request seeks to adjust the messaging of the pre-commit error message introduced in #21306, shown when a contributor attempts to commit a change to `package-lock.json` while running an old version of NPM. The proposed changes enhance the messaging to instruct the contributor that they should run `npm install` once more before retrying the commit. This is necessary because the intended purpose of forcing contributors to run the latest NPM is to guarantee consistency in how each NPM version generates `package-lock.json`. Thus, if the contributor had been running an older version of NPM while attempting to commit a change to this file, they must regenerate it after upgrading to the latest version, and before retrying their commit.

<table><thead><tr><th>Before</th><th>After</th></tr></thead><tbody><tr><td width="50%" valign="top">Latest NPM check failed!<br><br>

Error: The local NPM version does not match the expected latest version. Expected 6.14.4, found 6.14.3.

It is required that you have the latest version of NPM installed in order to commit a change to the package-lock.json file.

Run `npm install --global npm@latest`, then try again.</td><td width="50%" valign="top">Latest NPM check failed!

Error: The local NPM version does not match the expected latest version. Expected 6.14.4, found 6.14.3.

It is required that you have the latest version of NPM installed in order to commit a change to the package-lock.json file.

Run `npm install --global npm@latest` to install the latest version of NPM. Before retrying your commit, run `npm install` once more to ensure the package-lock.json contents are correct. If there are any changes to the file, they should be included in your commit.</td></tr></tbody></table>

**Testing Instructions:**

Repeat testing instructions from #21306