### PR TITLE
Skip RTL for Separator spacing

### DIFF
--- a/packages/block-library/src/separator/style.scss
+++ b/packages/block-library/src/separator/style.scss
@@ -22,6 +22,7 @@
 			color: currentColor;
 			font-size: 20px;
 			letter-spacing: 2em;
+			/*rtl:ignore*/
 			padding-left: 2em;
 			font-family: serif;
 		}


### PR DESCRIPTION
This PR removes padding flipping for dots, since they will still render LTR in mobile

Before:
![image](https://user-images.githubusercontent.com/6165348/78938815-d54f6280-7aaa-11ea-9fd2-27d4f3ff5fad.png)

After:
![image](https://user-images.githubusercontent.com/6165348/78938861-e9935f80-7aaa-11ea-9462-04d1e7e4fe9a.png)

Some themes also override this value, and they apply the same style, the styles will now be broken on mobile for them, so a dev note should also be included.

possibly something like this? 
> Dev note: Separator dots spacing and padding is now ignored in RTL.