### PR TITLE
Rnmobile/fix font size breakage

### DIFF
--- a/packages/block-editor/src/hooks/index.native.js
+++ b/packages/block-editor/src/hooks/index.native.js
@@ -5,3 +5,4 @@ import './custom-class-name';
 import './generated-class-name';
 import './style';
 import './color';
+import './font-size';

--- a/packages/block-editor/src/hooks/line-height.js
+++ b/packages/block-editor/src/hooks/line-height.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { Platform } from '@wordpress/element';
 import { hasBlockSupport } from '@wordpress/blocks';
 
 /**
@@ -41,13 +40,10 @@ export function LineHeightEdit( props ) {
 			style: cleanEmptyObject( newStyle ),
 		} );
 	};
-	return Platform.select( {
-		web: (
-			<LineHeightControl
-				value={ style?.typography?.lineHeight }
-				onChange={ onChange }
-			/>
-		),
-		native: null,
-	} );
+	return (
+		<LineHeightControl
+			value={ style?.typography?.lineHeight }
+			onChange={ onChange }
+		/>
+	);
 }

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -11,6 +11,7 @@ import { hasBlockSupport } from '@wordpress/blocks';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { PanelBody } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { Platform } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -144,7 +145,7 @@ export const withBlockControls = createHigherOrderComponent(
 		);
 
 		return [
-			hasTypographySupport && (
+			Platform.OS === 'web' && hasTypographySupport && (
 				<InspectorControls key="typography">
 					<PanelBody title={ __( 'Typography' ) }>
 						<FontSizeEdit { ...props } />


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

Fix font size breakage that was created because mobile Gutenberg doesn't yet support editing of typography attributes.

The breakage can be seen by selecting a paragraph control and then tapping on the settings icon (cog).

Before the typography settings consisted only on the line size, but now they were expanded to have font size, and joined together in a single Panel called Typography.

This PR hides the full typography panel in RN GB-mobile instead of just the line-size attribute.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

This can be tested using this PR in GB-mobile: https://github.com/wordpress-mobile/gutenberg-mobile/pull/2149

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
