### PR TITLE
Full-width to avoid text clipping due to text size/weight

### DIFF
--- a/packages/block-editor/src/components/media-placeholder/styles.native.scss
+++ b/packages/block-editor/src/components/media-placeholder/styles.native.scss
@@ -32,6 +32,7 @@
 }
 
 .emptyStateDescription {
+	width: 100%;
 	text-align: center;
 	color: $blue-wordpress;
 	font-size: 14;


### PR DESCRIPTION
(Trying to fix https://github.com/wordpress-mobile/gutenberg-mobile/issues/2136 on the gutenberg-mobile side.)

## Description
This is an experimental fix, not sure if it will help on the OnePlus devices. Not personally owning such a device to test.

## How has this been tested?
Using this gutenberg-mobile PR : https://github.com/wordpress-mobile/gutenberg-mobile/pull/2151

## Types of changes
Expanding the "instructions" text/link on the media placeholder to always be full-width, instead of having it adjust to the text length.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
