### PR TITLE
Import the interface stylesheet into the widgets page

### DIFF
--- a/packages/edit-widgets/src/style.scss
+++ b/packages/edit-widgets/src/style.scss
@@ -1,3 +1,5 @@
+@import "../../interface/src/style.scss";
+
 @import "./components/customizer-edit-widgets-initializer/style.scss";
 @import "./components/header/style.scss";
 @import "./components/layout/style.scss";


### PR DESCRIPTION
The EditorSkeleton component has been extracted to the new interface package but we forgot to import the stylesheet into the widgets page causing the widgets page to be completely broken design wise.
