### PR TITLE
Blocks: Register FSE blocks if experiment enabled

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -17,19 +17,19 @@ function gutenberg_reregister_core_block_types() {
 	}
 
 	$block_names = array(
-		'archives.php'            => 'core/archives',
-		'block.php'               => 'core/block',
-		'calendar.php'            => 'core/calendar',
-		'categories.php'          => 'core/categories',
-		'latest-comments.php'     => 'core/latest-comments',
-		'latest-posts.php'        => 'core/latest-posts',
-		'legacy-widget.php'       => 'core/legacy-widget',
-		'navigation.php'          => 'core/navigation',
-		'rss.php'                 => 'core/rss',
-		'shortcode.php'           => 'core/shortcode',
-		'search.php'              => 'core/search',
-		'social-link.php'         => 'core/social-link',
-		'tag-cloud.php'           => 'core/tag-cloud',
+		'archives.php'        => 'core/archives',
+		'block.php'           => 'core/block',
+		'calendar.php'        => 'core/calendar',
+		'categories.php'      => 'core/categories',
+		'latest-comments.php' => 'core/latest-comments',
+		'latest-posts.php'    => 'core/latest-posts',
+		'legacy-widget.php'   => 'core/legacy-widget',
+		'navigation.php'      => 'core/navigation',
+		'rss.php'             => 'core/rss',
+		'shortcode.php'       => 'core/shortcode',
+		'search.php'          => 'core/search',
+		'social-link.php'     => 'core/social-link',
+		'tag-cloud.php'       => 'core/tag-cloud',
 	);
 
 	if ( gutenberg_is_experiment_enabled( 'gutenberg-full-site-editing' ) ) {

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -30,19 +30,27 @@ function gutenberg_reregister_core_block_types() {
 		'search.php'              => 'core/search',
 		'social-link.php'         => 'core/social-link',
 		'tag-cloud.php'           => 'core/tag-cloud',
-		'site-title.php'          => 'core/site-title',
-		'template-part.php'       => 'core/template-part',
-		'post-title.php'          => 'core/post-title',
-		'post-content.php'        => 'core/post-content',
-		'post-author.php'         => 'core/post-author',
-		'post-comments.php'       => 'core/post-comments',
-		'post-comments-count.php' => 'core/post-comments-count',
-		'post-comments-form.php'  => 'core/post-comments-form',
-		'post-date.php'           => 'core/post-date',
-		'post-excerpt.php'        => 'core/post-excerpt',
-		'post-featured-image.php' => 'core/post-featured-image',
-		'post-tags.php'           => 'core/post-tags',
 	);
+
+	if ( gutenberg_is_experiment_enabled( 'gutenberg-full-site-editing' ) ) {
+		$block_names = array_merge(
+			$block_names,
+			array(
+				'post-title.php'          => 'core/post-title',
+				'post-content.php'        => 'core/post-content',
+				'post-author.php'         => 'core/post-author',
+				'post-comments.php'       => 'core/post-comments',
+				'post-comments-count.php' => 'core/post-comments-count',
+				'post-comments-form.php'  => 'core/post-comments-form',
+				'post-date.php'           => 'core/post-date',
+				'post-excerpt.php'        => 'core/post-excerpt',
+				'post-featured-image.php' => 'core/post-featured-image',
+				'post-tags.php'           => 'core/post-tags',
+				'site-title.php'          => 'core/site-title',
+				'template-part.php'       => 'core/template-part',
+			)
+		);
+	}
 
 	$registry = WP_Block_Type_Registry::get_instance();
 


### PR DESCRIPTION
This pull request seeks to update server-side block registration to register full-site editing blocks in the condition that the associated experiment "Enable Full Site Editing" is enabled. This matches [corresponding block editor behavior](https://github.com/WordPress/gutenberg/blob/319a8fcdbf89dd001532c68e7ce7d82a6b69ee0a/packages/block-library/src/index.js#L195-L211). It was observed in #21467 that the implementations of these blocks are loaded regardless of the setting value.

**Testing Instructions:**

Verify there are no regressions in the behavior of full-site editing blocks as long the "Enable Full Site Editing" experiment feature is enabled.

This is found under Gutenberg > Experiments.

Blocks include:

- `core/post-title`
- `core/post-content`
- `core/post-author`
- `core/post-comments`
- `core/post-comments-count`
- `core/post-comments-form`
- `core/post-date`
- `core/post-excerpt`
- `core/post-featured-image`
- `core/post-tags`
- `core/site-title`
- `core/template-part`