### PR TITLE
Build Tools: Install Composer dependencies as pre-lint step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ env:
     - PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
     - WP_DEVELOP_DIR: ./wordpress
     - LOCAL_SCRIPT_DEBUG: false
-    - INSTALL_COMPOSER: false
     - INSTALL_WORDPRESS: true
 
 # Make sure NodeGit gets the correct C libs.
@@ -88,10 +87,6 @@ install:
       # Connect Gutenberg to WordPress.
       npm run env connect
       npm run env cli plugin activate gutenberg
-    fi
-  - |
-    if [[ "$INSTALL_COMPOSER" = "true" ]]; then
-      npm run env docker-run -- php composer install --no-interaction
     fi
   - |
     if [[ "$E2E_ROLE" = "author" ]]; then
@@ -159,12 +154,11 @@ jobs:
         - npm run test-unit:native -- --ci --maxWorkers=2 --cacheDirectory="$HOME/.jest-cache"
 
     - name: PHP unit tests
-      env: INSTALL_COMPOSER=true
       script:
         - npm run test-php && npm run test-unit-php-multisite
 
     - name: PHP unit tests (PHP 5.6)
-      env: INSTALL_COMPOSER=true LOCAL_PHP=5.6-fpm
+      env: LOCAL_PHP=5.6-fpm
       script:
         - npm run test-php && npm run test-unit-php-multisite
 

--- a/package.json
+++ b/package.json
@@ -207,6 +207,7 @@
 		"lint": "concurrently \"npm run lint-js\" \"npm run lint-pkg-json\" \"npm run lint-css\"",
 		"lint-js": "wp-scripts lint-js",
 		"lint-js:fix": "npm run lint-js -- --fix",
+		"prelint-php": "npm run wp-env run composer install -- --no-interaction",
 		"lint-php": "npm run wp-env run composer run-script lint",
 		"lint-pkg-json": "wp-scripts lint-pkg-json . 'packages/*/package.json'",
 		"lint-css": "wp-scripts lint-style '**/*.scss'",


### PR DESCRIPTION
Related:

- #21118
- https://wordpress.slack.com/archives/C02QB2JS7/p1586530859214100 ([link requires registration](https://make.wordpress.org/chat/))

This pull request seeks to install Composer dependencies as part of the PHP lint script. This is intended to improve the developer experience, where a default installation of the development environment would not allow for `npm run lint-php` to be run. This script assumes Composer dependencies to already have been installed. Unless the contributor explicitly installs these dependencies via the (undocumented) `npm run wp-env run composer install` command, they cannot run the tests locally.

These changes bring uniformity to how lint testing occurs between a contributor's environment and in Travis. Previously, our Travis environment was "privileged" to have these setup tasks run, but these setup tasks are not made available to standard contributors, nor are they documented.

**Implementation Notes:**

Very important to note: This changes Composer installation in Travis from using the (legacy?) "env" setup, to the new "wp-env" setup. It's most important in considering the potential impact of reintroducing the issue intended to have been addressed in #21118. Fortunately, it should be relatively obvious if there are any issues, since the Travis build would pass only if working correctly.

As illustrated by the above-referenced Slack discussion, I'm not particularly attached to this approach, but I do fear the developer experience is currently very lacking. It took me quite some time to figure out how to run PHP linting successfully. While this implementation can be "wasteful" in that it runs the composer install step even if dependencies are already installed, an alternative was not clear in how to reduce friction for contributors to run tests.

It should be relatively safe that this only applies to linting, since all of the Composer dependencies are specific to linting ([source](https://github.com/WordPress/gutenberg/blob/319a8fcdbf89dd001532c68e7ce7d82a6b69ee0a/composer.json#L13-L22)).

Possible alternatives could include:

- Put responsibility on the developer to install Composer dependencies as part of preparing their local environment, not much unlike an expectation that a developer should be running `npm install` before starting development work.
   - This must be clearly documented, and it is not currently.
- Something in the implementation of the `wp-env` scripts could infer based on an incoming command whether it should need to prepare the environment to be able to run the command.
- Add messaging to the failed test run if dependencies are absent, instructing the developer actions to take before trying again.
   - There is some prior art to this with the `npm run test-php` script:

>Please ensure the WP_DEVELOP_DIR environment variable is set to your WordPress Development directory before running this script.
>
>If you don't have a WordPress Development directory to use, run `npm run env install` to automatically configure one!

**Testing Instructions:**

1. Prepare a _fresh_ development environment, following the ["Getting Started"](https://github.com/WordPress/gutenberg/blob/master/docs/contributors/getting-started.md) guide.
2. Run `npm run lint-php`.
3. Observe that it passes successfully.