### PR TITLE
env: Expose port 3306 of mysql container

### DIFF
--- a/packages/env/lib/build-docker-compose-config.js
+++ b/packages/env/lib/build-docker-compose-config.js
@@ -109,6 +109,7 @@ module.exports = function buildDockerComposeConfig( config ) {
 		services: {
 			mysql: {
 				image: 'mariadb',
+				ports: [ '3306' ],
 				environment: {
 					MYSQL_ALLOW_EMPTY_PASSWORD: 'yes',
 				},


### PR DESCRIPTION
This only defines the container port to allow docker to choose an ephemeral host port.

Fixes #21544.

**Testing Instructions:**
* Start an (existing ) env setup
* Open `docker-compose.yml` and verify that 
  ```yml
    ports:
      - '3306'
   ```
   exists
* Optional: Run `docker-compose port mysql 3306` to get the port number.