### PR TITLE
Fix inserter popover direction.

### DIFF
--- a/packages/block-editor/src/components/block-list/insertion-point.js
+++ b/packages/block-editor/src/components/block-list/insertion-point.js
@@ -180,7 +180,10 @@ export default function InsertionPoint( {
 								}
 							) }
 						>
-							<Inserter clientId={ inserterClientId } />
+							<Inserter
+								position="bottom center"
+								clientId={ inserterClientId }
+							/>
 						</div>
 					</div>
 				</Popover>

--- a/packages/block-editor/src/components/button-block-appender/index.js
+++ b/packages/block-editor/src/components/button-block-appender/index.js
@@ -22,6 +22,7 @@ function ButtonBlockAppender( {
 } ) {
 	return (
 		<Inserter
+			position="bottom center"
 			rootClientId={ rootClientId }
 			__experimentalSelectBlockOnInsert={ selectBlockOnInsert }
 			renderToggle={ ( {


### PR DESCRIPTION
Followup to #21476, which defaulted popovers to open down and right. This restores the "down and center" behavior for the inserter as used in-canvas.
