### PR TITLE
Update bug report template to identify the editor version better

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -23,7 +23,7 @@ If applicable, add screenshots to help explain your problem.
 **Editor version (please complete the following information):**
 - WordPress version: [e.g: 5.3.2]
 - Does the website has Gutenberg plugin installed, or is it using the block editor that comes by default? [e.g: "gutenberg plugin", "default"]
-- If the Gutenberg is installed what the version is: [e.g., 7.6]
+- If the Gutenberg plugin is installed, which version is it? [e.g., 7.6]
 
 **Desktop (please complete the following information):**
  - OS: [e.g. iOS]

--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -20,6 +20,11 @@ A clear and concise description of what you expected to happen.
 **Screenshots**
 If applicable, add screenshots to help explain your problem.
 
+**Editor version (please complete the following information):**
+- WordPress version: [e.g: 5.3.2]
+- Does the website has Gutenberg plugin installed, or is it using the block editor that comes by default? [e.g: "gutenberg plugin", "default"]
+- If the Gutenberg is installed what the version is: [e.g., 7.6]
+
 **Desktop (please complete the following information):**
  - OS: [e.g. iOS]
  - Browser [e.g. chrome, safari]
@@ -32,5 +37,4 @@ If applicable, add screenshots to help explain your problem.
  - Version [e.g. 22]
 
 **Additional context**
-- Please add the version of Gutenberg you are using in the description.
 - To report a security issue, please visit the WordPress HackerOne program: https://hackerone.com/wordpress.


### PR DESCRIPTION
When checking the bugs and understating if they are critical or not, knowing the version that introduces a bug is important. For example, a bug that was introduced three core WordPress versions ago and did not got any comments probably is not that "critical". 

After the first major core WordPress beta version the first beta, we can only include bug fixes for issues that regressed during the "alpha phase" so knowing if a bug affects the last stable release of WordPress is essential. To triage issues.

Currently, our template just asks for the Gutenberg version. Most people just say WordPress 5.x, which is vague because without knowing if they have Gutenberg plugin or not, we can not conclude what versions of WordPress are affected. To improve this situation, I submitted a PR changing the template to ask:
- WordPress Version
- If the user installed the Gutenberg plugin or is using the editor that comes with WordPress
- The Gutenberg version, if the user is using the plugin.
With this information, we can make better conclusions about what versions are affected with less effort.

If users provide this information it will be much easier to make the triage. For example, when someone reports something without Gutenberg on WordPress 5.3.2, if we are after the core beta period, without further tests, it is already possible to conclude that at the stage we are, we will not be able to fix the issue.

