### PR TITLE
[Button Block] Remove Fallback Text Color

### DIFF
--- a/packages/block-library/src/button/style.scss
+++ b/packages/block-library/src/button/style.scss
@@ -28,7 +28,7 @@ $blocks-button__height: 56px;
 	&:focus,
 	&:active,
 	&:visited {
-		color: var(--wp--color--text, $white);
+		color: var(--wp--color--text);
 	}
 }
 


### PR DESCRIPTION
Fixes #21561.

**Before**
<img width="350" alt="Screen Shot 2020-04-13 at 5 11 17 PM" src="https://user-images.githubusercontent.com/5375500/79161919-5019c580-7daa-11ea-9049-91f24c131a8e.png">

**After**
<img width="340" alt="Screen Shot 2020-04-13 at 5 07 11 PM" src="https://user-images.githubusercontent.com/5375500/79161943-5b6cf100-7daa-11ea-9607-b3e02aec4ee9.png">


Tested using the [Gutenberg Starter Theme](https://github.com/WordPress/gutenberg-starter-theme), macOS 10.15.3, Chrome 81.0.4044.92