### PR TITLE
Fixes overlaping column contents for embeds

### DIFF
--- a/packages/block-library/src/embed/editor.scss
+++ b/packages/block-library/src/embed/editor.scss
@@ -7,17 +7,6 @@
 	// therefore the video doesn't intrinsically clear floats like an image does.
 	clear: both;
 
-	// Apply a min-width, or the embed can collapse when floated.
-	// Instagram widgets have a min-width of 326px, so go a bit beyond that.
-	@include break-small() {
-		width: 100%;
-
-		// The placeholder should not have this min-width.
-		&.components-placeholder {
-			min-width: 0;
-		}
-	}
-
 	&.is-loading {
 		display: flex;
 		flex-direction: column;

--- a/packages/block-library/src/embed/editor.scss
+++ b/packages/block-library/src/embed/editor.scss
@@ -10,7 +10,7 @@
 	// Apply a min-width, or the embed can collapse when floated.
 	// Instagram widgets have a min-width of 326px, so go a bit beyond that.
 	@include break-small() {
-		min-width: 360px;
+		width: 100%;
 
 		// The placeholder should not have this min-width.
 		&.components-placeholder {

--- a/packages/block-library/src/embed/style.scss
+++ b/packages/block-library/src/embed/style.scss
@@ -1,6 +1,6 @@
 // Apply max-width to floated items that have no intrinsic width
-.block-editor-block-list__block[data-type="core/embed"][data-align="left"],
-.block-editor-block-list__block[data-type="core/embed"][data-align="right"],
+.block-editor-block-list__block[data-type*="core-embed"][data-align="left"] .is-block-content,
+.block-editor-block-list__block[data-type*="core-embed"][data-align="right"] .is-block-content,
 .wp-block-embed.alignleft,
 .wp-block-embed.alignright {
 	// Instagram widgets have a min-width of 326px, so go a bit beyond that.


### PR DESCRIPTION
## Description
Closes #12283 

I don't know why the min-width was 360px but setting it to 100% seems to both fix this and not create other issues.

## How has this been tested?
Tested locally by:

1. Add a post
2. Add a columns block with 2 colums
3. In one column add text and in the other add a YouTube embed
4. See that the text is no longer overlapping with the embed

## Screenshots <!-- if applicable -->

<img width="988" alt="Screenshot 2020-04-14 at 11 37 50" src="https://user-images.githubusercontent.com/107534/79203902-62484200-7e44-11ea-81de-8ac6ea8350e9.png">


## Types of changes
Non breaking (from testing) CSS update for the embed block's editor CSS.
