### PR TITLE
Hide stepper arrows in cover height control (Firefox)

### DIFF
--- a/packages/components/src/unit-control/styles/unit-control-styles.js
+++ b/packages/components/src/unit-control/styles/unit-control-styles.js
@@ -56,6 +56,7 @@ const sizeStyles = ( { size } ) => {
 export const ValueInput = styled( NumberControl )`
 	&&& {
 		appearance: none;
+		-moz-appearance: textfield;
 		box-sizing: border-box;
 		border: 1px solid ${color( 'ui.border' )};
 		border-radius: 2px;

--- a/storybook/test/__snapshots__/index.js.snap
+++ b/storybook/test/__snapshots__/index.js.snap
@@ -9393,6 +9393,7 @@ exports[`Storyshots Components/UnitControl Default 1`] = `
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
+  -moz-appearance: textfield;
   box-sizing: border-box;
   border: 1px solid #000;
   border-radius: 2px;


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/pull/20888/files#r407598412 by which stepper arrows are shown in the cover height control for Firefox.

Before this change:

![2020-04-14-104039-cover-height-control-firefox-before](https://user-images.githubusercontent.com/583546/79204268-91f34c00-7e3c-11ea-9114-99ede36fbaea.png)

After this change:

![2020-04-14-104243-cover-height-control-after](https://user-images.githubusercontent.com/583546/79204347-b6e7bf00-7e3c-11ea-9571-e93586ae85ec.png)
