### PR TITLE
Add default publish button setting

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -454,6 +454,7 @@ _Properties_
 -   _isRTL_ `boolean`: Whether the editor is in RTL mode
 -   _bodyPlaceholder_ `string`: Empty post placeholder
 -   _titlePlaceholder_ `string`: Empty title placeholder
+-   _publishActionText_ `string`: Text signaling the "Publish" action
 -   _codeEditingEnabled_ `boolean`: Whether or not the user can switch to the code editor
 -   _\_\_experimentalCanUserUseUnfilteredHTML_ `boolean`: Whether the user should be able to use unfiltered HTML or the HTML should be filtered e.g., to remove elements considered insecure like iframes.
 -   _\_\_experimentalEnableLegacyWidgetBlock_ `boolean`: Whether the user has enabled the Legacy Widget Block

--- a/packages/block-editor/src/store/defaults.js
+++ b/packages/block-editor/src/store/defaults.js
@@ -27,6 +27,7 @@ export const PREFERENCES_DEFAULTS = {
  * @property {boolean} isRTL Whether the editor is in RTL mode
  * @property {string} bodyPlaceholder Empty post placeholder
  * @property {string} titlePlaceholder Empty title placeholder
+ * @property {string} publishActionText Text signaling the "Publish" action
  * @property {boolean} codeEditingEnabled Whether or not the user can switch to the code editor
  * @property {boolean} __experimentalCanUserUseUnfilteredHTML Whether the user should be able to use unfiltered HTML or the HTML should be filtered e.g., to remove elements considered insecure like iframes.
  * @property {boolean} __experimentalEnableLegacyWidgetBlock Whether the user has enabled the Legacy Widget Block
@@ -225,4 +226,7 @@ export const SETTINGS_DEFAULTS = {
 			slug: 'midnight',
 		},
 	],
+
+	// Text signaling the "Publish" action.
+	publishActionText: __( 'Publish' ),
 };

--- a/packages/edit-post/src/components/sidebar/post-schedule/index.js
+++ b/packages/edit-post/src/components/sidebar/post-schedule/index.js
@@ -1,19 +1,19 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { PanelRow, Dropdown, Button } from '@wordpress/components';
 import {
 	PostSchedule as PostScheduleForm,
 	PostScheduleLabel,
 	PostScheduleCheck,
 } from '@wordpress/editor';
+import { withSelect } from '@wordpress/data';
 
-export function PostSchedule() {
+export function PostSchedule( { publishActionText } ) {
 	return (
 		<PostScheduleCheck>
 			<PanelRow className="edit-post-post-schedule">
-				<span>{ __( 'Publish' ) }</span>
+				<span>{ publishActionText }</span>
 				<Dropdown
 					position="bottom left"
 					contentClassName="edit-post-post-schedule__dialog"
@@ -36,4 +36,10 @@ export function PostSchedule() {
 	);
 }
 
-export default PostSchedule;
+export default withSelect( ( select ) => {
+	const { getSettings } = select( 'core/block-editor' );
+	const { publishActionText } = getSettings();
+	return {
+		publishActionText,
+	};
+} )( PostSchedule );

--- a/packages/editor/src/components/post-publish-button/index.js
+++ b/packages/editor/src/components/post-publish-button/index.js
@@ -95,6 +95,7 @@ export class PostPublishButton extends Component {
 			onToggle,
 			visibility,
 			hasNonPostEntityChanges,
+			publishActionText,
 		} = this.props;
 		const { entitiesSavedStatesCallback } = this.state;
 
@@ -158,7 +159,7 @@ export class PostPublishButton extends Component {
 
 		const toggleChildren = isBeingScheduled
 			? __( 'Schedule…' )
-			: __( 'Publish' );
+			: publishActionText;
 		const buttonChildren = (
 			<PublishButtonLabel
 				forceIsSaving={ forceIsSaving }
@@ -207,6 +208,8 @@ export default compose( [
 			getCurrentPostId,
 			hasNonPostEntityChanges,
 		} = select( 'core/editor' );
+		const { getSettings } = select( 'core/block-editor' );
+		const { publishActionText } = getSettings();
 		return {
 			isSaving: isSavingPost(),
 			isBeingScheduled: isEditedPostBeingScheduled(),
@@ -223,6 +226,7 @@ export default compose( [
 			postType: getCurrentPostType(),
 			postId: getCurrentPostId(),
 			hasNonPostEntityChanges: hasNonPostEntityChanges(),
+			publishActionText,
 		};
 	} ),
 	withDispatch( ( dispatch ) => {

--- a/packages/editor/src/components/post-publish-button/label.js
+++ b/packages/editor/src/components/post-publish-button/label.js
@@ -18,6 +18,7 @@ export function PublishButtonLabel( {
 	hasPublishAction,
 	isAutosaving,
 	hasNonPostEntityChanges,
+	publishActionText,
 } ) {
 	if ( isPublishing ) {
 		return __( 'Publishing…' );
@@ -37,7 +38,7 @@ export function PublishButtonLabel( {
 		return hasNonPostEntityChanges ? __( 'Schedule…' ) : __( 'Schedule' );
 	}
 
-	return __( 'Publish' );
+	return publishActionText;
 }
 
 export default compose( [
@@ -51,6 +52,8 @@ export default compose( [
 			getCurrentPostType,
 			isAutosavingPost,
 		} = select( 'core/editor' );
+		const { getSettings } = select( 'core/block-editor' );
+		const { publishActionText } = getSettings();
 		return {
 			isPublished: isCurrentPostPublished(),
 			isBeingScheduled: isEditedPostBeingScheduled(),
@@ -63,6 +66,7 @@ export default compose( [
 			),
 			postType: getCurrentPostType(),
 			isAutosaving: isAutosavingPost(),
+			publishActionText,
 		};
 	} ),
 ] )( PublishButtonLabel );

--- a/packages/editor/src/components/post-publish-button/test/label.js
+++ b/packages/editor/src/components/post-publish-button/test/label.js
@@ -31,12 +31,14 @@ describe( 'PublishButtonLabel', () => {
 	} );
 
 	it( 'should show publish if not published and saving in progress', () => {
+		const publishActionText = 'Publish';
 		const label = PublishButtonLabel( {
 			hasPublishAction: true,
 			isPublished: false,
 			isSaving: true,
+			publishActionText,
 		} );
-		expect( label ).toBe( 'Publish' );
+		expect( label ).toBe( publishActionText );
 	} );
 
 	it( 'should show submit for review for contributor', () => {
@@ -61,7 +63,11 @@ describe( 'PublishButtonLabel', () => {
 	} );
 
 	it( 'should show publish otherwise', () => {
-		const label = PublishButtonLabel( { hasPublishAction: true } );
-		expect( label ).toBe( 'Publish' );
+		const publishActionText = 'Publish';
+		const label = PublishButtonLabel( {
+			hasPublishAction: true,
+			publishActionText,
+		} );
+		expect( label ).toBe( publishActionText );
 	} );
 } );

--- a/packages/editor/src/components/post-publish-panel/prepublish.js
+++ b/packages/editor/src/components/post-publish-panel/prepublish.js
@@ -24,6 +24,7 @@ function PostPublishPanelPrepublish( {
 	hasPublishAction,
 	isBeingScheduled,
 	children,
+	publishActionText,
 } ) {
 	let prePublishTitle, prePublishBodyText;
 
@@ -69,7 +70,7 @@ function PostPublishPanelPrepublish( {
 					<PanelBody
 						initialOpen={ false }
 						title={ [
-							__( 'Publish:' ),
+							`${ publishActionText }:`,
 							<span
 								className="editor-post-publish-panel__link"
 								key="label"
@@ -93,6 +94,8 @@ export default withSelect( ( select ) => {
 	const { getCurrentPost, isEditedPostBeingScheduled } = select(
 		'core/editor'
 	);
+	const { getSettings } = select( 'core/block-editor' );
+	const { publishActionText } = getSettings();
 	return {
 		hasPublishAction: get(
 			getCurrentPost(),
@@ -100,5 +103,6 @@ export default withSelect( ( select ) => {
 			false
 		),
 		isBeingScheduled: isEditedPostBeingScheduled(),
+		publishActionText,
 	};
 } )( PostPublishPanelPrepublish );


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

This adds a `publishActionText` setting. This way a plugin or a theme can change the "Publish" text on elements referring to the post publishing action.

**Use case**: a plugin or a theme adding a `publish_` hook and performing custom additional actions on post publishing.
**Example**: a newsletter authoring plugin which sends a campaign on post publishing.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

1. I've checked that the action displays "Publish" by default in:
  - primary button in editor's top bar
  - "Status & visibility" panel of the sidebar
  - primary button in pre-publish checks sidebar
  - publishing date setting panel in  pre-publish checks sidebar

2. I've then updated the default setting:

```js
dispatch( 'core/block-editor' ).updateSettings( {
	publishActionText: __( 'Send Campaign', 'newspack-newsletters' ),
} );
```

And verified that it is updated in the locations listed in pt. 1

## Screenshots <!-- if applicable -->

Custom publish action text in top bar & sidebar:

![image](https://user-images.githubusercontent.com/7383192/79208018-cc131c80-7e41-11ea-979b-d4ed52b3397d.png)

Custom publish action text in pre-publish checks sidebar:

![image](https://user-images.githubusercontent.com/7383192/79208696-b0f4dc80-7e42-11ea-97eb-bcaf804976bb.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
