### PR TITLE
Improve the performance of the BlockPreview component

### DIFF
--- a/packages/block-editor/src/components/block-preview/auto.js
+++ b/packages/block-editor/src/components/block-preview/auto.js
@@ -2,12 +2,15 @@
  * WordPress dependencies
  */
 import { Disabled } from '@wordpress/components';
-import { useResizeObserver } from '@wordpress/compose';
+import { useResizeObserver, pure } from '@wordpress/compose';
 
 /**
  * Internal dependencies
  */
 import BlockList from '../block-list';
+
+// This is used to avoid rendering the block list if the sizes change.
+const MemoizedBlockList = pure( BlockList );
 
 function AutoBlockPreview( { viewportWidth, __experimentalPadding } ) {
 	const [
@@ -43,7 +46,7 @@ function AutoBlockPreview( { viewportWidth, __experimentalPadding } ) {
 				className="block-editor-block-preview__content"
 			>
 				{ containtResizeListener }
-				<BlockList />
+				<MemoizedBlockList />
 			</Disabled>
 		</div>
 	);

--- a/packages/block-editor/src/components/block-preview/index.js
+++ b/packages/block-editor/src/components/block-preview/index.js
@@ -7,7 +7,7 @@ import { castArray } from 'lodash';
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { useLayoutEffect, useReducer, useMemo } from '@wordpress/element';
+import { useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -35,18 +35,12 @@ export function BlockPreview( {
 		select( 'core/block-editor' ).getSettings()
 	);
 	const renderedBlocks = useMemo( () => castArray( blocks ), [ blocks ] );
-	const [ recompute, triggerRecompute ] = useReducer(
-		( state ) => state + 1,
-		0
-	);
-	useLayoutEffect( triggerRecompute, [ blocks ] );
 	if ( ! blocks || blocks.length === 0 ) {
 		return null;
 	}
 	return (
 		<BlockEditorProvider value={ renderedBlocks } settings={ settings }>
 			<AutoHeightBlockPreview
-				key={ recompute }
 				viewportWidth={ viewportWidth }
 				__experimentalPadding={ __experimentalPadding }
 			/>


### PR DESCRIPTION
closes #21567

This PR fixes a performance issue on the BlockPreview component where it was being rerendered too often causing lags.

The issue was an old trick we were using with to recompute the preview, but that trick was only needed with the old implementation of the component.

**Testing instructions**

 - Type on a button block with the sidebar open
 - It shouldn't lag.