### PR TITLE
Template Switcher: Add current theme

### DIFF
--- a/docs/designers-developers/developers/data/data-core.md
+++ b/docs/designers-developers/developers/data/data-core.md
@@ -71,6 +71,18 @@ _Returns_
 
 -   `?Array`: An array of autosaves for the post, or undefined if there is none.
 
+<a name="getCurrentTheme" href="#getCurrentTheme">#</a> **getCurrentTheme**
+
+Return the current theme.
+
+_Parameters_
+
+-   _state_ `Object`: Data state.
+
+_Returns_
+
+-   `Object`: The current theme.
+
 <a name="getCurrentUser" href="#getCurrentUser">#</a> **getCurrentUser**
 
 Returns the current user.
@@ -486,6 +498,18 @@ _Parameters_
 
 -   _postId_ `number`: The id of the post that is parent to the autosave.
 -   _autosaves_ `(Array|Object)`: An array of autosaves or singular autosave object.
+
+_Returns_
+
+-   `Object`: Action object.
+
+<a name="receiveCurrentTheme" href="#receiveCurrentTheme">#</a> **receiveCurrentTheme**
+
+Returns an action object used in signalling that the current theme has been received.
+
+_Parameters_
+
+-   _currentTheme_ `Object`: The current theme.
 
 _Returns_
 

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -52,7 +52,38 @@ function gutenberg_filter_oembed_result( $response, $handler, $request ) {
 }
 add_filter( 'rest_request_after_callbacks', 'gutenberg_filter_oembed_result', 10, 3 );
 
+/**
+ * Add fields required for site editing to the /themes endpoint.
+ *
+ * @todo Remove once https://core.trac.wordpress.org/ticket/49906 is fixed.
+ * @see https://github.com/WordPress/wordpress-develop/pull/222
+ *
+ */
+function gutenberg_filter_rest_prepare_theme( $response, $theme, $data ) {
+	$data = $response->get_data();
+	$field_mappings    = array(
+		'author'      => 'Author',
+		'author_name' => 'Author Name',
+		'author_uri'  => 'Author URI',
+		'description' => 'Description',
+		'name'        => 'Name',
+		'stylesheet'  => 'Stylesheet',
+		'template'    => 'Template',
+		'theme_uri'   => 'Theme URI',
+		'version'     => 'Version',
+	);
 
+	foreach ( $field_mappings as $field => $theme_field ) {
+		$data[ $field ] = $theme[ $theme_field ];
+	}
+
+	// Using $theme->get_screenshot() with no args to get absolute URL.
+	$data['screenshot'] = $theme->get_screenshot();
+
+	$response->set_data( $data );
+	return $response;
+}
+add_filter( 'rest_prepare_theme', 'gutenberg_filter_rest_prepare_theme', 10, 3 );
 
 /**
  * Start: Include for phase 2

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -57,8 +57,12 @@ add_filter( 'rest_request_after_callbacks', 'gutenberg_filter_oembed_result', 10
  *
  * @todo Remove once https://core.trac.wordpress.org/ticket/49906 is fixed.
  * @see https://github.com/WordPress/wordpress-develop/pull/222
+ *
+ * @param WP_REST_Response $response The response object.
+ * @param WP_Theme         $theme    Theme object used to create response.
+ * @param WP_REST_Request  $request  Request object.
  */
-function gutenberg_filter_rest_prepare_theme( $response, $theme, $data ) {
+function gutenberg_filter_rest_prepare_theme( $response, $theme, $request ) {
 	$data           = $response->get_data();
 	$field_mappings = array(
 		'author'      => 'Author',

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -57,11 +57,10 @@ add_filter( 'rest_request_after_callbacks', 'gutenberg_filter_oembed_result', 10
  *
  * @todo Remove once https://core.trac.wordpress.org/ticket/49906 is fixed.
  * @see https://github.com/WordPress/wordpress-develop/pull/222
- *
  */
 function gutenberg_filter_rest_prepare_theme( $response, $theme, $data ) {
-	$data = $response->get_data();
-	$field_mappings    = array(
+	$data           = $response->get_data();
+	$field_mappings = array(
 		'author'      => 'Author',
 		'author_name' => 'Author Name',
 		'author_uri'  => 'Author URI',

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -86,6 +86,18 @@ _Returns_
 
 -   `Object`: Action object.
 
+<a name="receiveCurrentTheme" href="#receiveCurrentTheme">#</a> **receiveCurrentTheme**
+
+Returns an action object used in signalling that the current theme has been received.
+
+_Parameters_
+
+-   _currentTheme_ `Object`: The current theme.
+
+_Returns_
+
+-   `Object`: Action object.
+
 <a name="receiveCurrentUser" href="#receiveCurrentUser">#</a> **receiveCurrentUser**
 
 Returns an action used in signalling that the current user has been received.
@@ -283,6 +295,18 @@ _Parameters_
 _Returns_
 
 -   `?Array`: An array of autosaves for the post, or undefined if there is none.
+
+<a name="getCurrentTheme" href="#getCurrentTheme">#</a> **getCurrentTheme**
+
+Return the current theme.
+
+_Parameters_
+
+-   _state_ `Object`: Data state.
+
+_Returns_
+
+-   `Object`: The current theme.
 
 <a name="getCurrentUser" href="#getCurrentUser">#</a> **getCurrentUser**
 

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -95,6 +95,20 @@ export function receiveEntityRecords(
 }
 
 /**
+ * Returns an action object used in signalling that the current theme has been received.
+ *
+ * @param {Object} currentTheme The current theme.
+ *
+ * @return {Object} Action object.
+ */
+export function receiveCurrentTheme( currentTheme ) {
+	return {
+		type: 'RECEIVE_CURRENT_THEME',
+		currentTheme,
+	};
+}
+
+/**
  * Returns an action object used in signalling that the index has been received.
  *
  * @param {Object} themeSupports Theme support for the current theme.

--- a/packages/core-data/src/reducer.js
+++ b/packages/core-data/src/reducer.js
@@ -105,15 +105,35 @@ export function taxonomies( state = [], action ) {
 /**
  * Reducer managing the current theme.
  *
+ * @param {string} state  Current state.
+ * @param {Object} action Dispatched action.
+ *
+ * @return {string} Updated state.
+ */
+export function currentTheme( state = undefined, action ) {
+	switch ( action.type ) {
+		case 'RECEIVE_CURRENT_THEME':
+			return action.currentTheme.stylesheet;
+	}
+
+	return state;
+}
+
+/**
+ * Reducer managing installed themes.
+ *
  * @param {Object} state  Current state.
  * @param {Object} action Dispatched action.
  *
  * @return {Object} Updated state.
  */
-export function currentTheme( state = {}, action ) {
+export function themes( state = {}, action ) {
 	switch ( action.type ) {
 		case 'RECEIVE_CURRENT_THEME':
-			return action.currentTheme;
+			return {
+				...state,
+				[ action.currentTheme.stylesheet ]: action.currentTheme,
+			};
 	}
 
 	return state;
@@ -522,6 +542,7 @@ export default combineReducers( {
 	currentTheme,
 	currentUser,
 	taxonomies,
+	themes,
 	themeSupports,
 	entities,
 	undo,

--- a/packages/core-data/src/reducer.js
+++ b/packages/core-data/src/reducer.js
@@ -103,6 +103,23 @@ export function taxonomies( state = [], action ) {
 }
 
 /**
+ * Reducer managing the current theme.
+ *
+ * @param {Object} state  Current state.
+ * @param {Object} action Dispatched action.
+ *
+ * @return {Object} Updated state.
+ */
+export function currentTheme( state = {}, action ) {
+	switch ( action.type ) {
+		case 'RECEIVE_CURRENT_THEME':
+			return action.currentTheme;
+	}
+
+	return state;
+}
+
+/**
  * Reducer managing theme supports data.
  *
  * @param {Object} state  Current state.
@@ -502,6 +519,7 @@ export function autosaves( state = {}, action ) {
 export default combineReducers( {
 	terms,
 	users,
+	currentTheme,
 	currentUser,
 	taxonomies,
 	themeSupports,

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -14,6 +14,7 @@ import deprecated from '@wordpress/deprecated';
  */
 import {
 	receiveUserQuery,
+	receiveCurrentTheme,
 	receiveCurrentUser,
 	receiveEntityRecords,
 	receiveThemeSupports,
@@ -90,6 +91,16 @@ getEntityRecords.shouldInvalidate = ( action, kind, name ) => {
 		name === action.name
 	);
 };
+
+/**
+ * Requests the current theme.
+ */
+export function* getCurrentTheme() {
+	const activeThemes = yield apiFetch( {
+		path: '/wp/v2/themes?status=active',
+	} );
+	yield receiveCurrentTheme( activeThemes[ 0 ] );
+}
 
 /**
  * Requests theme supports data from the index.

--- a/packages/core-data/src/selectors.js
+++ b/packages/core-data/src/selectors.js
@@ -450,6 +450,17 @@ export function hasRedo( state ) {
 }
 
 /**
+ * Return the current theme.
+ *
+ * @param {Object} state Data state.
+ *
+ * @return {Object}      The current theme.
+ */
+export function getCurrentTheme( state ) {
+	return state.currentTheme;
+}
+
+/**
  * Return theme supports data in the index.
  *
  * @param {Object} state Data state.

--- a/packages/core-data/src/selectors.js
+++ b/packages/core-data/src/selectors.js
@@ -457,7 +457,7 @@ export function hasRedo( state ) {
  * @return {Object}      The current theme.
  */
 export function getCurrentTheme( state ) {
-	return state.currentTheme;
+	return state.themes[ state.currentTheme ];
 }
 
 /**

--- a/packages/edit-site/src/components/template-switcher/index.js
+++ b/packages/edit-site/src/components/template-switcher/index.js
@@ -48,10 +48,11 @@ export default function TemplateSwitcher( {
 	const onHoverTemplatePart = ( id ) => {
 		setHoveredTemplate( { id, type: 'template-part' } );
 	};
-	const { templates, templateParts } = useSelect(
+	const { currentTheme, templates, templateParts } = useSelect(
 		( select ) => {
-			const { getEntityRecord } = select( 'core' );
+			const { getCurrentTheme, getEntityRecord } = select( 'core' );
 			return {
+				currentTheme: getCurrentTheme(),
 				templates: ids.map( ( id ) => {
 					const template = getEntityRecord(
 						'postType',
@@ -133,6 +134,9 @@ export default function TemplateSwitcher( {
 								onSelect={ onActiveTemplatePartIdChange }
 								onHover={ onHoverTemplatePart }
 							/>
+						</MenuGroup>
+						<MenuGroup label={ __( 'Current theme' ) }>
+							<MenuItem>{ currentTheme.name }</MenuItem>
 						</MenuGroup>
 						{ !! hoveredTemplate?.id && (
 							<TemplatePreview item={ hoveredTemplate } />


### PR DESCRIPTION
## Description
Display the current theme name in the template selector of `edit-site`.

Since the `/themes` endpoint currently only exposes the `theme_supports` field for each theme, this PR adds a number of additional fields to it, using the `rest_prepare_theme` hook. (I also filed a https://github.com/WordPress/wordpress-develop/pull/222 against Core to extend the, err, upstream endpoint accordingly so that we can eventually drop the filter.)

In addition, this PR adds a new `getCurrentTheme` selector and related reducer/resolver/action to `core-data` (including a `themes` reducer for better normalization).

Finally, that selector is used to render the theme name in `edit-site`'s template selector.

The fields I've chosen to add should be sufficient to implement the on-hover previews seen at https://github.com/WordPress/gutenberg/issues/20469#issuecomment-597806801:

<img width="626" alt="image" src="https://user-images.githubusercontent.com/191598/76452488-9b097d00-63a7-11ea-9ecd-23f573246ea3.png">

However, this PR doesn't implement those previews yet, since we need to implement the underlying fly-out menu component first (see #20470).

Fixes part of #20469.

## How has this been tested?
- If you haven't done yet, enable the site editor (and the demo templates) in Gutenberg > Experiments.
- Go to the Site Editor menu.
- Click on the template switcher.

## Screenshots

![image](https://user-images.githubusercontent.com/96308/79265541-91879f00-7e96-11ea-9218-ae3831b42852.png)

## Types of changes

New feature

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
