### PR TITLE
Types: Improve project setup

### DIFF
--- a/packages/priority-queue/tsconfig.json
+++ b/packages/priority-queue/tsconfig.json
@@ -2,7 +2,8 @@
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",
-		"declarationDir": "build-types"
+		"declarationDir": "build-types",
+		"types": [ "requestidlecallback" ]
 	},
 	"include": [ "src/**/*" ]
 }

--- a/packages/project-management-automation/tsconfig.json
+++ b/packages/project-management-automation/tsconfig.json
@@ -3,6 +3,7 @@
 	"compilerOptions": {
 		"rootDir": "lib",
 		"declarationDir": "build-types",
+		"types": [ "node" ],
 
 		// This is required due to a type error coming from missing types in @actions/github
 		"noImplicitAny": false

--- a/packages/warning/tsconfig.json
+++ b/packages/warning/tsconfig.json
@@ -2,7 +2,8 @@
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",
-		"declarationDir": "build-types"
+		"declarationDir": "build-types",
+		"types": [ "gutenberg-env" ]
 	},
 	"include": [ "src/**/*" ]
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -16,8 +16,6 @@
 
 		/* Strict Type-Checking Options */
 		"strict": true,
-		"strictNullChecks": true,
-		"noImplicitAny": true,
 
 		/* Additional Checks */
 		"noUnusedLocals": true,

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -30,6 +30,7 @@
 		"esModuleInterop": false,
 		"resolveJsonModule": true,
 
+		"typeRoots": [ "./typings", "./node_modules/@types" ],
 		"types": []
 	},
 	"exclude": [

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -30,7 +30,7 @@
 		"esModuleInterop": false,
 		"resolveJsonModule": true,
 
-		"typeRoots": [ "./node_modules/@types" ]
+		"types": []
 	},
 	"exclude": [
 		"**/benchmark",

--- a/typings/gutenberg-env/index.d.ts
+++ b/typings/gutenberg-env/index.d.ts
@@ -1,0 +1,7 @@
+interface Environment {
+	NODE_ENV?: unknown;
+}
+interface Process {
+	env?: Environment;
+}
+declare var process: Process;


### PR DESCRIPTION
## Description

This PR improves the project-wide TypeScript setup.

- Set `types: []` in the base tsconfig. This disables automatic inclusion of all typings found in type roots. The intention is to reduce the inclusion of incorrect types, for example `node` types in a browser package. If desired, extendable tsconfigs could be added for each environment, e.g. `tsconfig.base.node.json`.
- Manually include required types for certain packages, for example `node`.
- Add a `gutenberg-env` typing that can be added to a package's `types` to include bundler-injected variables Gutenberg relies on:
  - `NODE_ENV`
  - `GUTENBERG_PHASE`

> 
[Relevant `types` and `typeRoots` documentation.](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html#types-typeroots-and-types)

Related: #18838

## How has this been tested?
Types builds continue to work as expected.

## Types of changes
Internal

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
