### PR TITLE
Fix: Legacy widgets visual issues

### DIFF
--- a/packages/block-library/src/legacy-widget/editor.scss
+++ b/packages/block-library/src/legacy-widget/editor.scss
@@ -1,9 +1,3 @@
-.wp-block-legacy-widget__edit-container,
-.wp-block-legacy-widget__preview {
-	padding-left: 2.5em;
-	padding-right: 2.5em;
-}
-
 .wp-block-legacy-widget__edit-container {
 	.widget-inside {
 		border: none;
@@ -21,12 +15,15 @@
 	overflow: auto;
 }
 
+.wp-block-legacy-widget__preview,
+.wp-block-legacy-widget__edit-container,
 .wp-block-legacy-widget__edit-widget-title {
-	margin: 0 -$block-padding 0 -$block-padding+1px 0;
+	padding: $grid-unit-10 $block-padding;
+}
+
+.wp-block-legacy-widget__edit-widget-title {
 	background: $light-gray-100;
 	color: $dark-gray-500;
-	top: -$block-padding+1px;
-	position: relative;
 	font-family: $default-font;
 	font-size: $default-font-size;
 	padding: $grid-unit-10 $block-padding;


### PR DESCRIPTION
## Description
Fix visual issue with the legacy widgets block. It removes lots of styles that are now necessary with G2 and that in fact were breaking the design.

Before:
![image](https://user-images.githubusercontent.com/11271197/79266637-c93f1880-7e8f-11ea-8e69-d7b34d17b965.png)

After:
![image](https://user-images.githubusercontent.com/11271197/79266621-c47a6480-7e8f-11ea-9aea-546da8830e35.png)


