### PR TITLE
Fix: Legacy widgets z-index issue

### DIFF
--- a/packages/block-library/src/legacy-widget/editor.scss
+++ b/packages/block-library/src/legacy-widget/editor.scss
@@ -10,6 +10,10 @@
 		display: block;
 		box-shadow: none;
 	}
+	// Reset z-index set on https://github.com/WordPress/wordpress-develop/commit/f26d4d37351a55fd1fc5dad0f5fef8f0f964908c.
+	.widget.open {
+		z-index: 0;
+	}
 }
 
 .wp-block-legacy-widget__update-button {


### PR DESCRIPTION
## Description

This PR resets a z-index issue that was added into core recently https://github.com/WordPress/wordpress-develop/commit/f26d4d37351a55fd1fc5dad0f5fef8f0f964908c. and as a side effect legacy widgets stopped working as expected.
In the new widgets screen, we don't need the z-index change for the widgets container so this PR sets the z-index back to 0.

Before:
![image](https://user-images.githubusercontent.com/11271197/79267811-aa418600-7e91-11ea-9a78-8f6a2d3b43cc.png)


After:
![image](https://user-images.githubusercontent.com/11271197/79267555-461ec200-7e91-11ea-9fea-f90b7ac6477a.png)

