### PR TITLE
Editor: Account for null postId/postType in getCurrentPost

### DIFF
--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -190,13 +190,16 @@ export const getCurrentPost = createRegistrySelector(
 		const postId = getCurrentPostId( state );
 		const postType = getCurrentPostType( state );
 
-		const post = select( 'core' ).getRawEntityRecord(
-			'postType',
-			postType,
-			postId
-		);
-		if ( post ) {
-			return post;
+		if ( postId !== null && postType !== null ) {
+			const post = select( 'core' ).getRawEntityRecord(
+				'postType',
+				postType,
+				postId
+			);
+
+			if ( post ) {
+				return post;
+			}
 		}
 
 		// This exists for compatibility with the previous selector behavior


### PR DESCRIPTION
Related: https://github.com/WordPress/gutenberg/pull/21467#issuecomment-613512341

This pull request seeks to resolve an issue where `getCurrentPost` attempts to select an entity record with invalid arguments. Currently, the implementation does not account for the fact that `getCurrentPostId` and `getCurrentPostType` can return `null` values. Notably, this occurs in the first render of the editor [during this selector call](https://github.com/WordPress/gutenberg/blob/9185073697053612e855309d8090bdc93ed6e578/packages/editor/src/components/provider/index.js#L231) before the state is set to values relevant for the edited post. The `getRawEntityRecord` selector should not be called with a `null` value for `postId` or `postType`, and should instead be skipped.

Aside: This would be validated in automated testing with the changes necessary for #18838.

**Testing Instructions:**

_Work in Progress:_ I still need to decide on a good way to test this in the unit tests for the selectors. The current tests stub `getRawEntityRecord` in such a way that it's not clear how best to approach a test for the error cases.