### PR TITLE
Add the storybook story for the CustomGradientPicker component

### DIFF
--- a/packages/components/src/custom-gradient-picker/stories/index.js
+++ b/packages/components/src/custom-gradient-picker/stories/index.js
@@ -1,0 +1,29 @@
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import CustomGradientPicker from '../';
+
+export default {
+	title: 'Components/CustomGradientPicker',
+	component: CustomGradientPicker,
+};
+
+const CustomGradientPickerWithState = ( props ) => {
+	const [ gradient, setGradient ] = useState();
+	return (
+		<CustomGradientPicker
+			{ ...props }
+			value={ gradient }
+			onChange={ setGradient }
+		/>
+	);
+};
+
+export const _default = () => {
+	return <CustomGradientPickerWithState />;
+};


### PR DESCRIPTION
## Description
Adds a storybook story for the CustomGradientPicker component as part of #17973

## How has this been tested?
* run `npm run storybook:dev`
* See the new CustomGradientPicker story under components

## Screenshots
![Components___CustomGradientPicker_-_Default_⋅_Storybook](https://user-images.githubusercontent.com/6653970/79293250-37d8a200-7ea1-11ea-988d-5ea6cf045fcb.png)

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
