### PR TITLE
Chore: Update npm dependencies that warn

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1506,6 +1506,7 @@
 			"version": "10.0.19",
 			"resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.19.tgz",
 			"integrity": "sha512-BoiLlk4vEsGBg2dAqGSJu0vJl/PgVtCYLBFJaEO8RmQzPugXewQCXZJNXTDFaRlfCs0W+quesayav4fvaif5WQ==",
+			"dev": true,
 			"requires": {
 				"@emotion/sheet": "0.9.3",
 				"@emotion/stylis": "0.8.4",
@@ -1514,47 +1515,48 @@
 			}
 		},
 		"@emotion/core": {
-			"version": "10.0.22",
-			"resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.0.22.tgz",
-			"integrity": "sha512-7eoP6KQVUyOjAkE6y4fdlxbZRA4ILs7dqkkm6oZUJmihtHv0UBq98VgPirq9T8F9K2gKu0J/au/TpKryKMinaA==",
+			"version": "10.0.28",
+			"resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.0.28.tgz",
+			"integrity": "sha512-pH8UueKYO5jgg0Iq+AmCLxBsvuGtvlmiDCOuv8fGNYn3cowFpLN98L8zO56U0H1PjDIyAlXymgL3Wu7u7v6hbA==",
 			"requires": {
 				"@babel/runtime": "^7.5.5",
-				"@emotion/cache": "^10.0.17",
-				"@emotion/css": "^10.0.22",
-				"@emotion/serialize": "^0.11.12",
-				"@emotion/sheet": "0.9.3",
-				"@emotion/utils": "0.11.2"
+				"@emotion/cache": "^10.0.27",
+				"@emotion/css": "^10.0.27",
+				"@emotion/serialize": "^0.11.15",
+				"@emotion/sheet": "0.9.4",
+				"@emotion/utils": "0.11.3"
 			},
 			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.7.2",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.2.tgz",
-					"integrity": "sha512-JONRbXbTXc9WQE2mAZd1p0Z3DZ/6vaQIkgYMSTP3KjRCyd7rCZCcfhCyX+YjwcKxcZ82UrxbRD358bpExNgrjw==",
+				"@emotion/cache": {
+					"version": "10.0.29",
+					"resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.29.tgz",
+					"integrity": "sha512-fU2VtSVlHiF27empSbxi1O2JFdNWZO+2NFHfwO0pxgTep6Xa3uGb+3pVKfLww2l/IBGLNEZl5Xf/++A4wAYDYQ==",
 					"requires": {
-						"regenerator-runtime": "^0.13.2"
+						"@emotion/sheet": "0.9.4",
+						"@emotion/stylis": "0.8.5",
+						"@emotion/utils": "0.11.3",
+						"@emotion/weak-memoize": "0.2.5"
 					}
 				},
-				"@emotion/css": {
-					"version": "10.0.22",
-					"resolved": "https://registry.npmjs.org/@emotion/css/-/css-10.0.22.tgz",
-					"integrity": "sha512-8phfa5mC/OadBTmGpMpwykIVH0gFCbUoO684LUkyixPq4F1Wwri7fK5Xlm8lURNBrd2TuvTbPUGxFsGxF9UacA==",
-					"requires": {
-						"@emotion/serialize": "^0.11.12",
-						"@emotion/utils": "0.11.2",
-						"babel-plugin-emotion": "^10.0.22"
-					}
+				"@emotion/sheet": {
+					"version": "0.9.4",
+					"resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-0.9.4.tgz",
+					"integrity": "sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA=="
 				},
-				"@emotion/serialize": {
-					"version": "0.11.14",
-					"resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.11.14.tgz",
-					"integrity": "sha512-6hTsySIuQTbDbv00AnUO6O6Xafdwo5GswRlMZ5hHqiFx+4pZ7uGWXUQFW46Kc2taGhP89uXMXn/lWQkdyTosPA==",
-					"requires": {
-						"@emotion/hash": "0.7.3",
-						"@emotion/memoize": "0.7.3",
-						"@emotion/unitless": "0.7.4",
-						"@emotion/utils": "0.11.2",
-						"csstype": "^2.5.7"
-					}
+				"@emotion/stylis": {
+					"version": "0.8.5",
+					"resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
+					"integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ=="
+				},
+				"@emotion/utils": {
+					"version": "0.11.3",
+					"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.3.tgz",
+					"integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw=="
+				},
+				"@emotion/weak-memoize": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
+					"integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
 				}
 			}
 		},
@@ -1673,7 +1675,8 @@
 		"@emotion/sheet": {
 			"version": "0.9.3",
 			"resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-0.9.3.tgz",
-			"integrity": "sha512-c3Q6V7Df7jfwSq5AzQWbXHa5soeE4F5cbqi40xn0CzXxWW9/6Mxq48WJEtqfWzbZtW9odZdnRAkwCQwN12ob4A=="
+			"integrity": "sha512-c3Q6V7Df7jfwSq5AzQWbXHa5soeE4F5cbqi40xn0CzXxWW9/6Mxq48WJEtqfWzbZtW9odZdnRAkwCQwN12ob4A==",
+			"dev": true
 		},
 		"@emotion/styled": {
 			"version": "10.0.23",
@@ -1720,7 +1723,8 @@
 		"@emotion/stylis": {
 			"version": "0.8.4",
 			"resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.4.tgz",
-			"integrity": "sha512-TLmkCVm8f8gH0oLv+HWKiu7e8xmBIaokhxcEKPh1m8pXiV/akCiq50FvYgOwY42rjejck8nsdQxZlXZ7pmyBUQ=="
+			"integrity": "sha512-TLmkCVm8f8gH0oLv+HWKiu7e8xmBIaokhxcEKPh1m8pXiV/akCiq50FvYgOwY42rjejck8nsdQxZlXZ7pmyBUQ==",
+			"dev": true
 		},
 		"@emotion/unitless": {
 			"version": "0.7.4",
@@ -1735,7 +1739,8 @@
 		"@emotion/weak-memoize": {
 			"version": "0.2.4",
 			"resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.4.tgz",
-			"integrity": "sha512-6PYY5DVdAY1ifaQW6XYTnOMihmBVT27elqSjEoodchsGjzYlEsTQMcEhSud99kVawatyTZRTiVkJ/c6lwbQ7nA=="
+			"integrity": "sha512-6PYY5DVdAY1ifaQW6XYTnOMihmBVT27elqSjEoodchsGjzYlEsTQMcEhSud99kVawatyTZRTiVkJ/c6lwbQ7nA==",
+			"dev": true
 		},
 		"@evocateur/libnpmaccess": {
 			"version": "3.1.2",
@@ -11323,7 +11328,7 @@
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.9.2",
-				"axe-puppeteer": "^1.0.0"
+				"axe-puppeteer": "^1.1.0"
 			}
 		},
 		"@wordpress/keyboard-shortcuts": {
@@ -12805,18 +12810,18 @@
 			"dev": true
 		},
 		"axe-core": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.4.0.tgz",
-			"integrity": "sha512-5C0OdgxPv/DrQguO6Taj5F1dY5OlkWg4SVmZIVABFYKWlnAc5WTLPzG+xJSgIwf2fmY+NiNGiZXhXx2qT0u/9Q==",
+			"version": "3.5.3",
+			"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.5.3.tgz",
+			"integrity": "sha512-HZpLE7xu05+8AbpqXITGdxp1Xwk8ysAXrg7MiKRY27py3DAyEJpoJQo1727pWF3F+O79V3r+cTWhOzfB49P89w==",
 			"dev": true
 		},
 		"axe-puppeteer": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/axe-puppeteer/-/axe-puppeteer-1.0.0.tgz",
-			"integrity": "sha512-hTF3u4mtatgTN7fsLVyVgbRdNc15ngjDcTEuqhn9A7ugqLhLCryJWp9fzqZkNlrW8awPcxugyTwLPR7mRdPZmA==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/axe-puppeteer/-/axe-puppeteer-1.1.0.tgz",
+			"integrity": "sha512-VS17Y1rDQe6A0PdeTPxwOSBfmOdj6efgxyre9cN1du1snnVilczSDtQsgifBKBlzoL/3DKfGpgIi+N+zrzODOg==",
 			"dev": true,
 			"requires": {
-				"axe-core": "^3.1.2"
+				"axe-core": "^3.5.3"
 			}
 		},
 		"axobject-query": {

--- a/packages/e2e-tests/config/setup-test-framework.js
+++ b/packages/e2e-tests/config/setup-test-framework.js
@@ -228,6 +228,7 @@ async function runAxeTestsForBlockEditor() {
 			'dlitem',
 			'duplicate-id',
 			'label',
+			'landmark-one-main',
 			'link-name',
 			'listitem',
 			'region',

--- a/packages/jest-puppeteer-axe/CHANGELOG.md
+++ b/packages/jest-puppeteer-axe/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Master
+
+## New Features
+
+- The `axe-puppeteer` dependency has been updated from requiring `^1.0.0` to requiring `^1.1.0`.
+
 ## 1.1.0 (2019-05-21)
 
 ### New Feature

--- a/packages/jest-puppeteer-axe/package.json
+++ b/packages/jest-puppeteer-axe/package.json
@@ -31,7 +31,7 @@
 	"module": "build-module/index.js",
 	"dependencies": {
 		"@babel/runtime": "^7.9.2",
-		"axe-puppeteer": "^1.0.0"
+		"axe-puppeteer": "^1.1.0"
 	},
 	"peerDependencies": {
 		"jest": ">=24",


### PR DESCRIPTION
## Description

Updated "@emotion/core" to the latest patch version.

Updated "axe-puppeteer" to the next minor version.

This removes a few warnings that are printed during `npm install`.

