### PR TITLE
Update npm-package-json-lint from 4.0.3 to 5.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10072,6 +10072,12 @@
 			"integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
 			"dev": true
 		},
+		"@types/minimist": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.0.tgz",
+			"integrity": "sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY=",
+			"dev": true
+		},
 		"@types/node": {
 			"version": "12.7.11",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.11.tgz",
@@ -11512,7 +11518,7 @@
 				"markdownlint": "^0.18.0",
 				"markdownlint-cli": "^0.21.0",
 				"minimist": "^1.2.0",
-				"npm-package-json-lint": "^4.0.3",
+				"npm-package-json-lint": "^5.0.0",
 				"prettier": "npm:wp-prettier@1.19.1",
 				"puppeteer": "^2.0.0",
 				"read-pkg-up": "^1.0.1",
@@ -22710,6 +22716,12 @@
 				"har-schema": "^2.0.0"
 			}
 		},
+		"hard-rejection": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
+			"integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==",
+			"dev": true
+		},
 		"has": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -24079,12 +24091,6 @@
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
 			"integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
-			"dev": true
-		},
-		"irregular-plurals": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-2.0.0.tgz",
-			"integrity": "sha512-Y75zBYLkh0lJ9qxeHlMjQ7bSbyiSqNW/UOPWDmzC7cXskL1hekSITh1Oc6JV0XCWWZ9DE8VYSB71xocLk3gmGw==",
 			"dev": true
 		},
 		"is-absolute-url": {
@@ -33567,24 +33573,26 @@
 			}
 		},
 		"npm-package-json-lint": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/npm-package-json-lint/-/npm-package-json-lint-4.0.3.tgz",
-			"integrity": "sha512-cuvTR2l5dOjjlRR3a1CCp+mh2A2HyQRxydwdcYi0Z77NRlADpf7wF3Jf8XFLGZM7J6afXNRBofBjQ1UWFyOtKA==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/npm-package-json-lint/-/npm-package-json-lint-5.0.0.tgz",
+			"integrity": "sha512-a7meq98EnSqniPWNhTj0TMJbTFKr8SPEkQep3iPCQVJWfhQ8fKI5+bUSgNyEbYfzfIrIjMTb0r/tCkX7FX+bYQ==",
 			"dev": true,
 			"requires": {
-				"ajv": "^6.10.2",
+				"ajv": "^6.12.0",
 				"ajv-errors": "^1.0.1",
-				"chalk": "^2.4.2",
-				"cosmiconfig": "^5.2.1",
+				"chalk": "^4.0.0",
+				"cosmiconfig": "^6.0.0",
 				"debug": "^4.1.1",
-				"globby": "^10.0.1",
+				"globby": "^11.0.0",
 				"ignore": "^5.1.4",
-				"is-plain-obj": "^2.0.0",
+				"is-plain-obj": "^2.1.0",
+				"jsonc-parser": "^2.2.1",
 				"log-symbols": "^3.0.0",
-				"meow": "^5.0.0",
-				"plur": "^3.1.1",
-				"semver": "^6.3.0",
-				"strip-json-comments": "^3.0.1"
+				"meow": "^6.1.0",
+				"plur": "^4.0.0",
+				"semver": "^7.2.2",
+				"slash": "^3.0.0",
+				"strip-json-comments": "^3.1.0"
 			},
 			"dependencies": {
 				"@nodelib/fs.stat": {
@@ -33592,6 +33600,18 @@
 					"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
 					"integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
 					"dev": true
+				},
+				"ajv": {
+					"version": "6.12.0",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
+					"integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
+					"dev": true,
+					"requires": {
+						"fast-deep-equal": "^3.1.1",
+						"fast-json-stable-stringify": "^2.0.0",
+						"json-schema-traverse": "^0.4.1",
+						"uri-js": "^4.2.2"
+					}
 				},
 				"array-union": {
 					"version": "2.1.0",
@@ -33608,27 +33628,34 @@
 						"fill-range": "^7.0.1"
 					}
 				},
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+				"camelcase": {
+					"version": "5.3.1",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+					"dev": true
+				},
+				"camelcase-keys": {
+					"version": "6.2.2",
+					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
+					"integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
+						"camelcase": "^5.3.1",
+						"map-obj": "^4.0.0",
+						"quick-lru": "^4.0.1"
 					}
 				},
 				"cosmiconfig": {
-					"version": "5.2.1",
-					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
-					"integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
+					"integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
 					"dev": true,
 					"requires": {
-						"import-fresh": "^2.0.0",
-						"is-directory": "^0.3.1",
-						"js-yaml": "^3.13.1",
-						"parse-json": "^4.0.0"
+						"@types/parse-json": "^4.0.0",
+						"import-fresh": "^3.1.0",
+						"parse-json": "^5.0.0",
+						"path-type": "^4.0.0",
+						"yaml": "^1.7.2"
 					}
 				},
 				"debug": {
@@ -33640,14 +33667,11 @@
 						"ms": "^2.1.1"
 					}
 				},
-				"dir-glob": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-					"integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-					"dev": true,
-					"requires": {
-						"path-type": "^4.0.0"
-					}
+				"fast-deep-equal": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
+					"integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
+					"dev": true
 				},
 				"fast-glob": {
 					"version": "3.1.1",
@@ -33660,14 +33684,6 @@
 						"glob-parent": "^5.1.0",
 						"merge2": "^1.3.0",
 						"micromatch": "^4.0.2"
-					},
-					"dependencies": {
-						"merge2": {
-							"version": "1.3.0",
-							"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.3.0.tgz",
-							"integrity": "sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==",
-							"dev": true
-						}
 					}
 				},
 				"fill-range": {
@@ -33679,18 +33695,14 @@
 						"to-regex-range": "^5.0.1"
 					}
 				},
-				"glob": {
-					"version": "7.1.6",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-					"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+				"find-up": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
 					"dev": true,
 					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
+						"locate-path": "^5.0.0",
+						"path-exists": "^4.0.0"
 					}
 				},
 				"glob-parent": {
@@ -33703,18 +33715,16 @@
 					}
 				},
 				"globby": {
-					"version": "10.0.2",
-					"resolved": "https://registry.npmjs.org/globby/-/globby-10.0.2.tgz",
-					"integrity": "sha512-7dUi7RvCoT/xast/o/dLN53oqND4yk0nsHkhRgn9w65C4PofCLOoJ39iSOg+qVDdWQPIEj+eszMHQ+aLVwwQSg==",
+					"version": "11.0.0",
+					"resolved": "https://registry.npmjs.org/globby/-/globby-11.0.0.tgz",
+					"integrity": "sha512-iuehFnR3xu5wBBtm4xi0dMe92Ob87ufyu/dHwpDYfbcpYpIbrO5OnS8M1vWvrBhSGEJ3/Ecj7gnX76P8YxpPEg==",
 					"dev": true,
 					"requires": {
-						"@types/glob": "^7.1.1",
 						"array-union": "^2.1.0",
 						"dir-glob": "^3.0.1",
-						"fast-glob": "^3.0.3",
-						"glob": "^7.1.3",
-						"ignore": "^5.1.1",
-						"merge2": "^1.2.3",
+						"fast-glob": "^3.1.1",
+						"ignore": "^5.1.4",
+						"merge2": "^1.3.0",
 						"slash": "^3.0.0"
 					}
 				},
@@ -33724,15 +33734,17 @@
 					"integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
 					"dev": true
 				},
-				"import-fresh": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
-					"integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
-					"dev": true,
-					"requires": {
-						"caller-path": "^2.0.0",
-						"resolve-from": "^3.0.0"
-					}
+				"indent-string": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+					"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+					"dev": true
+				},
+				"irregular-plurals": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-3.2.0.tgz",
+					"integrity": "sha512-YqTdPLfwP7YFN0SsD3QUVCkm9ZG2VzOXv3DOrw5G5mkMbVwptTwVcFv7/C0vOpBmgTxAeTG19XpUs1E522LW9Q==",
+					"dev": true
 				},
 				"is-glob": {
 					"version": "4.0.1",
@@ -33750,10 +33762,25 @@
 					"dev": true
 				},
 				"is-plain-obj": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.0.0.tgz",
-					"integrity": "sha512-EYisGhpgSCwspmIuRHGjROWTon2Xp8Z7U03Wubk/bTL5TTRC5R1rGVgyjzBrk9+ULdH6cRD06KRcw/xfqhVYKQ==",
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+					"integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
 					"dev": true
+				},
+				"jsonc-parser": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.2.1.tgz",
+					"integrity": "sha512-o6/yDBYccGvTz1+QFevz6l6OBZ2+fMVu2JZ9CIhzsYRX4mjaK5IyX9eldUdCmga16zlgQxyrj5pt9kzuj2C02w==",
+					"dev": true
+				},
+				"locate-path": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^4.1.0"
+					}
 				},
 				"log-symbols": {
 					"version": "3.0.0",
@@ -33762,7 +33789,51 @@
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2"
+					},
+					"dependencies": {
+						"chalk": {
+							"version": "2.4.2",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+							"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+							"dev": true,
+							"requires": {
+								"ansi-styles": "^3.2.1",
+								"escape-string-regexp": "^1.0.5",
+								"supports-color": "^5.3.0"
+							}
+						}
 					}
+				},
+				"map-obj": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.1.0.tgz",
+					"integrity": "sha512-glc9y00wgtwcDmp7GaE/0b0OnxpNJsVf3ael/An6Fe2Q51LLwN1er6sdomLRzz5h0+yMpiYLhWYF5R7HeqVd4g==",
+					"dev": true
+				},
+				"meow": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/meow/-/meow-6.1.0.tgz",
+					"integrity": "sha512-iIAoeI01v6pmSfObAAWFoITAA4GgiT45m4SmJgoxtZfvI0fyZwhV4d0lTwiUXvAKIPlma05Feb2Xngl52Mj5Cg==",
+					"dev": true,
+					"requires": {
+						"@types/minimist": "^1.2.0",
+						"camelcase-keys": "^6.1.1",
+						"decamelize-keys": "^1.1.0",
+						"hard-rejection": "^2.0.0",
+						"minimist-options": "^4.0.1",
+						"normalize-package-data": "^2.5.0",
+						"read-pkg-up": "^7.0.0",
+						"redent": "^3.0.0",
+						"trim-newlines": "^3.0.0",
+						"type-fest": "^0.8.1",
+						"yargs-parser": "^18.1.1"
+					}
+				},
+				"merge2": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.3.0.tgz",
+					"integrity": "sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==",
+					"dev": true
 				},
 				"micromatch": {
 					"version": "4.0.2",
@@ -33774,21 +33845,97 @@
 						"picomatch": "^2.0.5"
 					}
 				},
+				"minimist-options": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.0.2.tgz",
+					"integrity": "sha512-seq4hpWkYSUh1y7NXxzucwAN9yVlBc3Upgdjz8vLCP97jG8kaOmzYrVH/m7tQ1NYD1wdtZbSLfdy4zFmRWuc/w==",
+					"dev": true,
+					"requires": {
+						"arrify": "^1.0.1",
+						"is-plain-obj": "^1.1.0"
+					},
+					"dependencies": {
+						"is-plain-obj": {
+							"version": "1.1.0",
+							"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+							"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+							"dev": true
+						}
+					}
+				},
 				"ms": {
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 					"dev": true
 				},
-				"parse-json": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+				"normalize-package-data": {
+					"version": "2.5.0",
+					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+					"integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
 					"dev": true,
 					"requires": {
-						"error-ex": "^1.3.1",
-						"json-parse-better-errors": "^1.0.1"
+						"hosted-git-info": "^2.1.4",
+						"resolve": "^1.10.0",
+						"semver": "2 || 3 || 4 || 5",
+						"validate-npm-package-license": "^3.0.1"
+					},
+					"dependencies": {
+						"semver": {
+							"version": "5.7.1",
+							"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+							"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+							"dev": true
+						}
 					}
+				},
+				"p-limit": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+					"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+					"dev": true,
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.2.0"
+					}
+				},
+				"p-try": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+					"dev": true
+				},
+				"parse-json": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
+					"integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"error-ex": "^1.3.1",
+						"json-parse-better-errors": "^1.0.1",
+						"lines-and-columns": "^1.1.6"
+					}
+				},
+				"path-exists": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+					"dev": true
+				},
+				"path-parse": {
+					"version": "1.0.6",
+					"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+					"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+					"dev": true
 				},
 				"path-type": {
 					"version": "4.0.0",
@@ -33796,10 +33943,81 @@
 					"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
 					"dev": true
 				},
+				"picomatch": {
+					"version": "2.2.2",
+					"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+					"integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+					"dev": true
+				},
+				"plur": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/plur/-/plur-4.0.0.tgz",
+					"integrity": "sha512-4UGewrYgqDFw9vV6zNV+ADmPAUAfJPKtGvb/VdpQAx25X5f3xXdGdyOEVFwkl8Hl/tl7+xbeHqSEM+D5/TirUg==",
+					"dev": true,
+					"requires": {
+						"irregular-plurals": "^3.2.0"
+					}
+				},
+				"quick-lru": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
+					"integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
+					"dev": true
+				},
+				"read-pkg": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+					"integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+					"dev": true,
+					"requires": {
+						"@types/normalize-package-data": "^2.4.0",
+						"normalize-package-data": "^2.5.0",
+						"parse-json": "^5.0.0",
+						"type-fest": "^0.6.0"
+					},
+					"dependencies": {
+						"type-fest": {
+							"version": "0.6.0",
+							"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+							"integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+							"dev": true
+						}
+					}
+				},
+				"read-pkg-up": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+					"integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+					"dev": true,
+					"requires": {
+						"find-up": "^4.1.0",
+						"read-pkg": "^5.2.0",
+						"type-fest": "^0.8.1"
+					}
+				},
+				"redent": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+					"integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+					"dev": true,
+					"requires": {
+						"indent-string": "^4.0.0",
+						"strip-indent": "^3.0.0"
+					}
+				},
+				"resolve": {
+					"version": "1.15.1",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
+					"integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
+					"dev": true,
+					"requires": {
+						"path-parse": "^1.0.6"
+					}
+				},
 				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"version": "7.3.2",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+					"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
 					"dev": true
 				},
 				"slash": {
@@ -33808,10 +34026,19 @@
 					"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
 					"dev": true
 				},
+				"strip-indent": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+					"integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+					"dev": true,
+					"requires": {
+						"min-indent": "^1.0.0"
+					}
+				},
 				"strip-json-comments": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
-					"integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.0.tgz",
+					"integrity": "sha512-e6/d0eBu7gHtdCqFt0xJr642LdToM5/cN4Qb9DbHjVx1CP5RyeM+zH7pbecEmDv/lBqb0QH+6Uqq75rxFPkM0w==",
 					"dev": true
 				},
 				"to-regex-range": {
@@ -33821,6 +34048,28 @@
 					"dev": true,
 					"requires": {
 						"is-number": "^7.0.0"
+					}
+				},
+				"trim-newlines": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.0.tgz",
+					"integrity": "sha512-C4+gOpvmxaSMKuEf9Qc134F1ZuOHVXKRbtEflf4NTtuuJDEIJ9p5PXsalL8SkeRw+qit1Mo+yuvMPAKwWg/1hA==",
+					"dev": true
+				},
+				"type-fest": {
+					"version": "0.8.1",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+					"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+					"dev": true
+				},
+				"yargs-parser": {
+					"version": "18.1.2",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.2.tgz",
+					"integrity": "sha512-hlIPNR3IzC1YuL1c2UwwDKpXlNFBqD1Fswwh1khz5+d8Cq/8yc/Mn0i+rQXduu8hcrFKvO7Eryk+09NecTQAAQ==",
+					"dev": true,
+					"requires": {
+						"camelcase": "^5.0.0",
+						"decamelize": "^1.2.0"
 					}
 				}
 			}
@@ -34778,15 +35027,6 @@
 					"integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ=",
 					"dev": true
 				}
-			}
-		},
-		"plur": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/plur/-/plur-3.1.1.tgz",
-			"integrity": "sha512-t1Ax8KUvV3FFII8ltczPn2tJdjqbd1sIzu6t4JL7nQ3EyeL/lTrj5PWKb06ic5/6XYDr65rQ4uzQEGN70/6X5w==",
-			"dev": true,
-			"requires": {
-				"irregular-plurals": "^2.0.0"
 			}
 		},
 		"pn": {

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Master
 
+### Bug fix
+
+- The bundled `npm-package-json-lint` dependency has been updated from requiring `^4.0.3` to requiring `^5.0.0` ([#21597](https://github.com/WordPress/gutenberg/pull/21597)). [Breaking changes](https://npmpackagejsonlint.org/docs/en/v4-to-v5) don't break anything in this package. It fixes the abrupt shutdown when `"description"` field in `package.json` is empty. 
+
 ## 8.0.0 (2020-04-15)
 
 ### Breaking Changes

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -58,7 +58,7 @@
 		"markdownlint": "^0.18.0",
 		"markdownlint-cli": "^0.21.0",
 		"minimist": "^1.2.0",
-		"npm-package-json-lint": "^4.0.3",
+		"npm-package-json-lint": "^5.0.0",
 		"prettier": "npm:wp-prettier@1.19.1",
 		"puppeteer": "^2.0.0",
 		"read-pkg-up": "^1.0.1",


### PR DESCRIPTION
## Description

In #21528, [lint mysteriously failed](https://travis-ci.com/github/WordPress/gutenberg/jobs/319456033) with the message, 'Cannot read property 'toUpperCase' of undefined'. This PR fixes this problem.

The cause was the empty `"description"` field in `package.json` file. Check tclindner/npm-package-json-lint#163.

## How has this been tested?

Manually tested. [And it now passes.](https://travis-ci.com/github/WordPress/gutenberg/jobs/319498574)

## Screenshots <!-- if applicable -->

N/A

## Types of changes

Bug fix

## Checklist:
- [x] My code is tested.
- [N/A] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [N/A] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [N/A] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [N/A] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [N/A] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
