### PR TITLE
Fix issue where resetBlocks can result in an incorrect block selection

### DIFF
--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -370,7 +370,7 @@ export function getBlockCount( state, rootClientId ) {
  * @return {WPBlockSelection} Selection start information.
  */
 export function getSelectionStart( state ) {
-	return state.selectionStart;
+	return state.selection.selectionStart;
 }
 
 /**
@@ -382,7 +382,7 @@ export function getSelectionStart( state ) {
  * @return {WPBlockSelection} Selection end information.
  */
 export function getSelectionEnd( state ) {
-	return state.selectionEnd;
+	return state.selection.selectionEnd;
 }
 
 /**
@@ -395,7 +395,7 @@ export function getSelectionEnd( state ) {
  * @return {?string} Client ID of block selection start.
  */
 export function getBlockSelectionStart( state ) {
-	return state.selectionStart.clientId;
+	return state.selection.selectionStart.clientId;
 }
 
 /**
@@ -408,7 +408,7 @@ export function getBlockSelectionStart( state ) {
  * @return {?string} Client ID of block selection end.
  */
 export function getBlockSelectionEnd( state ) {
-	return state.selectionEnd.clientId;
+	return state.selection.selectionEnd.clientId;
 }
 
 /**
@@ -426,7 +426,7 @@ export function getSelectedBlockCount( state ) {
 		return multiSelectedBlockCount;
 	}
 
-	return state.selectionStart.clientId ? 1 : 0;
+	return state.selection.selectionStart.clientId ? 1 : 0;
 }
 
 /**
@@ -437,7 +437,7 @@ export function getSelectedBlockCount( state ) {
  * @return {boolean} Whether a single block is selected.
  */
 export function hasSelectedBlock( state ) {
-	const { selectionStart, selectionEnd } = state;
+	const { selectionStart, selectionEnd } = state.selection;
 	return (
 		!! selectionStart.clientId &&
 		selectionStart.clientId === selectionEnd.clientId
@@ -453,7 +453,7 @@ export function hasSelectedBlock( state ) {
  * @return {?string} Selected block client ID.
  */
 export function getSelectedBlockClientId( state ) {
-	const { selectionStart, selectionEnd } = state;
+	const { selectionStart, selectionEnd } = state.selection;
 	const { clientId } = selectionStart;
 
 	if ( ! clientId || clientId !== selectionEnd.clientId ) {
@@ -709,7 +709,7 @@ export function getSelectedBlocksInitialCaretPosition( state ) {
  */
 export const getSelectedBlockClientIds = createSelector(
 	( state ) => {
-		const { selectionStart, selectionEnd } = state;
+		const { selectionStart, selectionEnd } = state.selection;
 
 		if (
 			selectionStart.clientId === undefined ||
@@ -745,8 +745,8 @@ export const getSelectedBlockClientIds = createSelector(
 	},
 	( state ) => [
 		state.blocks.order,
-		state.selectionStart.clientId,
-		state.selectionEnd.clientId,
+		state.selection.selectionStart.clientId,
+		state.selection.selectionEnd.clientId,
 	]
 );
 
@@ -759,7 +759,7 @@ export const getSelectedBlockClientIds = createSelector(
  * @return {Array} Multi-selected block client IDs.
  */
 export function getMultiSelectedBlockClientIds( state ) {
-	const { selectionStart, selectionEnd } = state;
+	const { selectionStart, selectionEnd } = state.selection;
 
 	if ( selectionStart.clientId === selectionEnd.clientId ) {
 		return EMPTY_ARRAY;
@@ -870,8 +870,8 @@ export const isAncestorMultiSelected = createSelector(
 	},
 	( state ) => [
 		state.blocks.order,
-		state.selectionStart.clientId,
-		state.selectionEnd.clientId,
+		state.selection.selectionStart.clientId,
+		state.selection.selectionEnd.clientId,
 	]
 );
 /**
@@ -887,7 +887,7 @@ export const isAncestorMultiSelected = createSelector(
  * @return {?string} Client ID of block beginning multi-selection.
  */
 export function getMultiSelectedBlocksStartClientId( state ) {
-	const { selectionStart, selectionEnd } = state;
+	const { selectionStart, selectionEnd } = state.selection;
 
 	if ( selectionStart.clientId === selectionEnd.clientId ) {
 		return null;
@@ -909,7 +909,7 @@ export function getMultiSelectedBlocksStartClientId( state ) {
  * @return {?string} Client ID of block ending multi-selection.
  */
 export function getMultiSelectedBlocksEndClientId( state ) {
-	const { selectionStart, selectionEnd } = state;
+	const { selectionStart, selectionEnd } = state.selection;
 
 	if ( selectionStart.clientId === selectionEnd.clientId ) {
 		return null;
@@ -956,7 +956,7 @@ export function getBlockIndex( state, clientId, rootClientId ) {
  * @return {boolean} Whether block is selected and multi-selection exists.
  */
 export function isBlockSelected( state, clientId ) {
-	const { selectionStart, selectionEnd } = state;
+	const { selectionStart, selectionEnd } = state.selection;
 
 	if ( selectionStart.clientId !== selectionEnd.clientId ) {
 		return false;
@@ -1014,7 +1014,7 @@ export function isBlockWithinSelection( state, clientId ) {
  * @return {boolean} Whether multi-selection has been made.
  */
 export function hasMultiSelection( state ) {
-	const { selectionStart, selectionEnd } = state;
+	const { selectionStart, selectionEnd } = state.selection;
 	return selectionStart.clientId !== selectionEnd.clientId;
 }
 
@@ -1157,7 +1157,10 @@ export function isCaretWithinFormattedText( state ) {
 export function getBlockInsertionPoint( state ) {
 	let rootClientId, index;
 
-	const { insertionPoint, selectionEnd } = state;
+	const {
+		insertionPoint,
+		selection: { selectionEnd },
+	} = state;
 	if ( insertionPoint !== null ) {
 		return insertionPoint;
 	}
@@ -1944,8 +1947,8 @@ export const __experimentalGetActiveBlockIdByBlockNames = createSelector(
 		return null;
 	},
 	( state, validBlockNames ) => [
-		state.selectionStart.clientId,
-		state.selectionEnd.clientId,
+		state.selection.selectionStart.clientId,
+		state.selection.selectionEnd.clientId,
 		validBlockNames,
 	]
 );

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -23,8 +23,7 @@ import {
 	isTyping,
 	draggedBlocks,
 	isCaretWithinFormattedText,
-	selectionStart,
-	selectionEnd,
+	selection,
 	initialPosition,
 	isMultiSelecting,
 	preferences,
@@ -2181,18 +2180,17 @@ describe( 'state', () => {
 		} );
 	} );
 
-	describe( 'selectionStart() and selectionEnd()', () => {
+	describe( 'selection()', () => {
 		it( 'should set multi selection', () => {
 			const action = {
 				type: 'MULTI_SELECT',
 				start: 'ribs',
 				end: 'chicken',
 			};
-			const state1 = selectionStart( undefined, action );
-			const state2 = selectionEnd( undefined, action );
+			const state = selection( undefined, action );
 
-			expect( state1 ).toEqual( { clientId: 'ribs' } );
-			expect( state2 ).toEqual( { clientId: 'chicken' } );
+			expect( state.selectionStart ).toEqual( { clientId: 'ribs' } );
+			expect( state.selectionEnd ).toEqual( { clientId: 'chicken' } );
 		} );
 
 		it( 'should reset selection', () => {
@@ -2203,11 +2201,10 @@ describe( 'state', () => {
 				selectionStart: start,
 				selectionEnd: end,
 			};
-			const state1 = selectionStart( undefined, action );
-			const state2 = selectionEnd( undefined, action );
+			const state = selection( undefined, action );
 
-			expect( state1 ).toEqual( start );
-			expect( state2 ).toEqual( end );
+			expect( state.selectionStart ).toEqual( start );
+			expect( state.selectionEnd ).toEqual( end );
 		} );
 
 		it( 'should change selection', () => {
@@ -2218,15 +2215,14 @@ describe( 'state', () => {
 				startOffset: 1,
 				endOffset: 2,
 			};
-			const state1 = selectionStart( undefined, action );
-			const state2 = selectionEnd( undefined, action );
+			const state = selection( undefined, action );
 
-			expect( state1 ).toEqual( {
+			expect( state.selectionStart ).toEqual( {
 				clientId: 'a',
 				attributeKey: 'content',
 				offset: 1,
 			} );
-			expect( state2 ).toEqual( {
+			expect( state.selectionEnd ).toEqual( {
 				clientId: 'a',
 				attributeKey: 'content',
 				offset: 2,
@@ -2238,51 +2234,58 @@ describe( 'state', () => {
 				type: 'SELECT_BLOCK',
 				clientId: 'kumquat',
 			};
-			const state1 = selectionStart( undefined, action );
-			const state2 = selectionEnd( undefined, action );
+			const state = selection( undefined, action );
 			const expected = { clientId: 'kumquat' };
 
-			expect( state1 ).toEqual( expected );
-			expect( state2 ).toEqual( expected );
+			expect( state.selectionStart ).toEqual( expected );
+			expect( state.selectionEnd ).toEqual( expected );
 		} );
 
 		it( 'should not update the state if the block is already selected', () => {
-			const original = deepFreeze( { clientId: 'ribs' } );
+			const clientId = 'ribs';
+			const original = deepFreeze( {
+				selectionStart: { clientId },
+				selectionEnd: { clientId },
+			} );
 			const action = {
 				type: 'SELECT_BLOCK',
-				clientId: 'ribs',
+				clientId,
 			};
-			const state1 = selectionStart( original, action );
-			const state2 = selectionEnd( original, action );
+			const state = selection( original, action );
 
-			expect( state1 ).toBe( original );
-			expect( state2 ).toBe( original );
+			expect( state.selectionStart ).toBe( original.selectionStart );
+			expect( state.selectionEnd ).toBe( original.selectionEnd );
 		} );
 
 		it( 'should unset selection', () => {
-			const original = deepFreeze( { clientId: 'ribs' } );
+			const clientId = 'ribs';
+			const original = deepFreeze( {
+				selectionStart: { clientId },
+				selectionEnd: { clientId },
+			} );
 			const action = {
 				type: 'CLEAR_SELECTED_BLOCK',
 			};
 
-			const state1 = selectionStart( original, action );
-			const state2 = selectionEnd( original, action );
+			const state = selection( original, action );
 
-			expect( state1 ).toEqual( {} );
-			expect( state2 ).toEqual( {} );
+			expect( state.selectionStart ).toEqual( {} );
+			expect( state.selectionEnd ).toEqual( {} );
 		} );
 
 		it( 'should return same reference if clearing selection but no selection', () => {
-			const original = deepFreeze( {} );
+			const original = deepFreeze( {
+				selectionStart: {},
+				selectionEnd: {},
+			} );
 			const action = {
 				type: 'CLEAR_SELECTED_BLOCK',
 			};
 
-			const state1 = selectionStart( original, action );
-			const state2 = selectionEnd( original, action );
+			const state = selection( original, action );
 
-			expect( state1 ).toBe( original );
-			expect( state2 ).toBe( original );
+			expect( state.selectionStart ).toBe( original.selectionStart );
+			expect( state.selectionEnd ).toBe( original.selectionEnd );
 		} );
 
 		it( 'should select inserted block', () => {
@@ -2291,172 +2294,259 @@ describe( 'state', () => {
 				blocks: [ { clientId: 'ribs' } ],
 				updateSelection: true,
 			};
-			const state1 = selectionStart( undefined, action );
-			const state2 = selectionEnd( undefined, action );
+			const state = selection( undefined, action );
 			const expected = { clientId: 'ribs' };
 
-			expect( state1 ).toEqual( expected );
-			expect( state2 ).toEqual( expected );
+			expect( state.selectionStart ).toEqual( expected );
+			expect( state.selectionEnd ).toEqual( expected );
 		} );
 
 		it( 'should not select inserted block if updateSelection flag is false', () => {
-			const original = deepFreeze( { clientId: 'a' } );
+			const original = deepFreeze( {
+				selectionStart: { clientId: 'a' },
+				selectionEnd: { clientId: 'a' },
+			} );
 			const action = {
 				type: 'INSERT_BLOCKS',
 				blocks: [ { clientId: 'ribs' } ],
 				updateSelection: false,
 			};
-			const state1 = selectionStart( original, action );
-			const state2 = selectionEnd( original, action );
+			const state = selection( original, action );
 
-			expect( state1 ).toBe( original );
-			expect( state2 ).toBe( original );
+			expect( state.selectionStart ).toBe( original.selectionStart );
+			expect( state.selectionEnd ).toBe( original.selectionEnd );
 		} );
 
 		it( 'should not update the state if the block moved is already selected', () => {
-			const original = deepFreeze( { clientId: 'ribs' } );
+			const original = deepFreeze( {
+				selectionStart: { clientId: 'ribs' },
+				selectionEnd: { clientId: 'ribs' },
+			} );
 			const action = {
 				type: 'MOVE_BLOCKS_UP',
 				clientIds: [ 'ribs' ],
 			};
 
-			const state1 = selectionStart( original, action );
-			const state2 = selectionEnd( original, action );
+			const state = selection( original, action );
 
-			expect( state1 ).toBe( original );
-			expect( state2 ).toBe( original );
+			expect( state.selectionStart ).toBe( original.selectionStart );
+			expect( state.selectionEnd ).toBe( original.selectionEnd );
 		} );
 
 		it( 'should replace the selected block', () => {
-			const original = deepFreeze( { clientId: 'chicken' } );
+			const original = deepFreeze( {
+				selectionStart: { clientId: 'chicken' },
+				selectionEnd: { clientId: 'chicken' },
+			} );
 			const action = {
 				type: 'REPLACE_BLOCKS',
 				clientIds: [ 'chicken' ],
 				blocks: [ { clientId: 'wings' } ],
 			};
-			const state1 = selectionStart( original, action );
-			const state2 = selectionEnd( original, action );
-			const expected = { clientId: 'wings' };
+			const state = selection( original, action );
+			const expected = {
+				selectionStart: { clientId: 'wings' },
+				selectionEnd: { clientId: 'wings' },
+			};
 
-			expect( state1 ).toEqual( expected );
-			expect( state2 ).toEqual( expected );
+			expect( state.selectionStart ).toEqual( expected.selectionStart );
+			expect( state.selectionEnd ).toEqual( expected.selectionEnd );
 		} );
 
 		it( 'should not replace the selected block if we keep it at the end when replacing blocks', () => {
-			const original = deepFreeze( { clientId: 'wings' } );
+			const original = deepFreeze( {
+				selectionStart: { clientId: 'wings' },
+				selectionEnd: { clientId: 'wings' },
+			} );
 			const action = {
 				type: 'REPLACE_BLOCKS',
 				clientIds: [ 'wings' ],
 				blocks: [ { clientId: 'chicken' }, { clientId: 'wings' } ],
 			};
-			const state1 = selectionStart( original, action );
-			const state2 = selectionEnd( original, action );
+			const state = selection( original, action );
 
-			expect( state1 ).toBe( original );
-			expect( state2 ).toBe( original );
+			expect( state.selectionStart ).toBe( original.selectionStart );
+			expect( state.selectionEnd ).toBe( original.selectionEnd );
 		} );
 
 		it( 'should replace the selected block if we keep it not at the end when replacing blocks', () => {
-			const original = deepFreeze( { clientId: 'chicken' } );
+			const original = deepFreeze( {
+				selectionStart: { clientId: 'chicken' },
+				selectionEnd: { clientId: 'chicken' },
+			} );
 			const action = {
 				type: 'REPLACE_BLOCKS',
 				clientIds: [ 'chicken' ],
 				blocks: [ { clientId: 'chicken' }, { clientId: 'wings' } ],
 			};
-			const state1 = selectionStart( original, action );
-			const state2 = selectionEnd( original, action );
-			const expected = { clientId: 'wings' };
+			const state = selection( original, action );
+			const expected = {
+				selectionStart: { clientId: 'wings' },
+				selectionEnd: { clientId: 'wings' },
+			};
 
-			expect( state1 ).toEqual( expected );
-			expect( state2 ).toEqual( expected );
+			expect( state.selectionStart ).toEqual( expected.selectionStart );
+			expect( state.selectionEnd ).toEqual( expected.selectionEnd );
 		} );
 
 		it( 'should reset if replacing with empty set', () => {
-			const original = deepFreeze( { clientId: 'chicken' } );
+			const original = deepFreeze( {
+				selectionStart: { clientId: 'chicken' },
+				selectionEnd: { clientId: 'chicken' },
+			} );
 			const action = {
 				type: 'REPLACE_BLOCKS',
 				clientIds: [ 'chicken' ],
 				blocks: [],
 			};
 
-			const state1 = selectionStart( original, action );
-			const state2 = selectionEnd( original, action );
+			const state = selection( original, action );
 
-			expect( state1 ).toEqual( {} );
-			expect( state2 ).toEqual( {} );
+			expect( state.selectionStart ).toEqual( {} );
+			expect( state.selectionEnd ).toEqual( {} );
 		} );
 
 		it( 'should keep the selected block', () => {
-			const original = deepFreeze( { clientId: 'chicken' } );
+			const original = deepFreeze( {
+				selectionStart: { clientId: 'chicken' },
+				selectionEnd: { clientId: 'chicken' },
+			} );
 			const action = {
 				type: 'REPLACE_BLOCKS',
 				clientIds: [ 'ribs' ],
 				blocks: [ { clientId: 'wings' } ],
 			};
-			const state1 = selectionStart( original, action );
-			const state2 = selectionEnd( original, action );
+			const state = selection( original, action );
 
-			expect( state1 ).toBe( original );
-			expect( state2 ).toBe( original );
+			expect( state.selectionStart ).toBe( original.selectionStart );
+			expect( state.selectionEnd ).toBe( original.selectionEnd );
 		} );
 
 		it( 'should remove the selection if we are removing the selected block', () => {
-			const original = deepFreeze( { clientId: 'chicken' } );
+			const original = deepFreeze( {
+				selectionStart: { clientId: 'chicken' },
+				selectionEnd: { clientId: 'chicken' },
+			} );
 			const action = {
 				type: 'REMOVE_BLOCKS',
 				clientIds: [ 'chicken' ],
 			};
 
-			const state1 = selectionStart( original, action );
-			const state2 = selectionEnd( original, action );
+			const state = selection( original, action );
 
-			expect( state1 ).toEqual( {} );
-			expect( state2 ).toEqual( {} );
+			expect( state.selectionStart ).toEqual( {} );
+			expect( state.selectionEnd ).toEqual( {} );
 		} );
 
 		it( 'should keep the selection if we are not removing the selected block', () => {
-			const original = deepFreeze( { clientId: 'chicken' } );
+			const original = deepFreeze( {
+				selectionStart: { clientId: 'chicken' },
+				selectionEnd: { clientId: 'chicken' },
+			} );
 			const action = {
 				type: 'REMOVE_BLOCKS',
 				clientIds: [ 'ribs' ],
 			};
 
-			const state1 = selectionStart( original, action );
-			const state2 = selectionEnd( original, action );
+			const state = selection( original, action );
 
-			expect( state1 ).toEqual( original );
-			expect( state2 ).toEqual( original );
+			expect( state.selectionStart ).toEqual( original.selectionStart );
+			expect( state.selectionEnd ).toEqual( original.selectionEnd );
 		} );
 
 		it( 'should update the selection on inner blocks replace if updateSelection is true', () => {
-			const original = deepFreeze( { clientId: 'chicken' } );
+			const original = deepFreeze( {
+				selectionStart: { clientId: 'chicken' },
+				selectionEnd: { clientId: 'chicken' },
+			} );
 			const action = {
 				type: 'REPLACE_INNER_BLOCKS',
 				blocks: [ { clientId: 'another-block' } ],
 				rootClientId: 'parent',
 				updateSelection: true,
 			};
-			const state1 = selectionStart( original, action );
-			const state2 = selectionEnd( original, action );
-			const expected = { clientId: 'another-block' };
+			const state = selection( original, action );
+			const expected = {
+				selectionStart: { clientId: 'another-block' },
+				selectionEnd: { clientId: 'another-block' },
+			};
 
-			expect( state1 ).toEqual( expected );
-			expect( state2 ).toEqual( expected );
+			expect( state.selectionStart ).toEqual( expected.selectionStart );
+			expect( state.selectionEnd ).toEqual( expected.selectionEnd );
 		} );
 
 		it( 'should not update the selection on inner blocks replace if updateSelection is false', () => {
-			const original = deepFreeze( { clientId: 'chicken' } );
+			const original = deepFreeze( {
+				selectionStart: { clientId: 'chicken' },
+				selectionEnd: { clientId: 'chicken' },
+			} );
 			const action = {
 				type: 'REPLACE_INNER_BLOCKS',
 				blocks: [ { clientId: 'another-block' } ],
 				rootClientId: 'parent',
 				updateSelection: false,
 			};
-			const state1 = selectionStart( original, action );
-			const state2 = selectionEnd( original, action );
+			const state = selection( original, action );
 
-			expect( state1 ).toEqual( original );
-			expect( state2 ).toEqual( original );
+			expect( state.selectionStart ).toEqual( original.selectionStart );
+			expect( state.selectionEnd ).toEqual( original.selectionEnd );
+		} );
+
+		it( 'should keep the same selection on RESET_BLOCKS if the selected blocks continue to exist', () => {
+			const original = deepFreeze( {
+				selectionStart: { clientId: 'chicken' },
+				selectionEnd: { clientId: 'cow' },
+			} );
+			const action = {
+				type: 'RESET_BLOCKS',
+				blocks: [
+					{ clientId: 'another-block' },
+					{ clientId: 'chicken' },
+					{ clientId: 'this-is-a-block-too' },
+					{ clientId: 'cow' },
+				],
+			};
+			const state = selection( original, action );
+
+			expect( state.selectionStart ).toEqual( original.selectionStart );
+			expect( state.selectionEnd ).toEqual( original.selectionEnd );
+		} );
+
+		it( 'should collapse the selection on RESET_BLOCKS if the selection start exists, but the end does not', () => {
+			const original = deepFreeze( {
+				selectionStart: { clientId: 'chicken' },
+				selectionEnd: { clientId: 'cow' },
+			} );
+			const action = {
+				type: 'RESET_BLOCKS',
+				blocks: [
+					{ clientId: 'another-block' },
+					{ clientId: 'chicken' },
+					{ clientId: 'this-is-a-block-too' },
+				],
+			};
+			const state = selection( original, action );
+
+			expect( state.selectionStart ).toEqual( original.selectionStart );
+			expect( state.selectionEnd ).toEqual( original.selectionStart );
+		} );
+
+		it( 'should clear the selection on RESET_BLOCKS if the blocks currently selected are removed', () => {
+			const original = deepFreeze( {
+				selectionStart: { clientId: 'chicken' },
+				selectionEnd: { clientId: 'cow' },
+			} );
+			const action = {
+				type: 'RESET_BLOCKS',
+				blocks: [
+					{ clientId: 'another-block' },
+					{ clientId: 'this-is-a-block-too' },
+				],
+			};
+			const state = selection( original, action );
+
+			expect( state.selectionStart ).toEqual( {} );
+			expect( state.selectionEnd ).toEqual( {} );
 		} );
 	} );
 

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -807,8 +807,10 @@ describe( 'selectors', () => {
 	describe( 'hasSelectedBlock', () => {
 		it( 'should return false if no selection', () => {
 			const state = {
-				selectionStart: {},
-				selectionEnd: {},
+				selection: {
+					selectionStart: {},
+					selectionEnd: {},
+				},
 			};
 
 			expect( hasSelectedBlock( state ) ).toBe( false );
@@ -816,11 +818,13 @@ describe( 'selectors', () => {
 
 		it( 'should return false if multi-selection', () => {
 			const state = {
-				selectionStart: {
-					clientId: 'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1',
-				},
-				selectionEnd: {
-					clientId: '9db792c6-a25a-495d-adbd-97d56a4c4189',
+				selection: {
+					selectionStart: {
+						clientId: 'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1',
+					},
+					selectionEnd: {
+						clientId: '9db792c6-a25a-495d-adbd-97d56a4c4189',
+					},
 				},
 			};
 
@@ -829,11 +833,13 @@ describe( 'selectors', () => {
 
 		it( 'should return true if singular selection', () => {
 			const state = {
-				selectionStart: {
-					clientId: 'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1',
-				},
-				selectionEnd: {
-					clientId: 'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1',
+				selection: {
+					selectionStart: {
+						clientId: 'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1',
+					},
+					selectionEnd: {
+						clientId: 'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1',
+					},
 				},
 			};
 
@@ -891,8 +897,10 @@ describe( 'selectors', () => {
 	describe( 'getSelectedBlockClientId', () => {
 		it( 'should return null if no block is selected', () => {
 			const state = {
-				selectionStart: {},
-				selectionEnd: {},
+				selection: {
+					selectionStart: {},
+					selectionEnd: {},
+				},
 			};
 
 			expect( getSelectedBlockClientId( state ) ).toBe( null );
@@ -900,8 +908,10 @@ describe( 'selectors', () => {
 
 		it( 'should return null if there is multi selection', () => {
 			const state = {
-				selectionStart: { clientId: 23 },
-				selectionEnd: { clientId: 123 },
+				selection: {
+					selectionStart: { clientId: 23 },
+					selectionEnd: { clientId: 123 },
+				},
 			};
 
 			expect( getSelectedBlockClientId( state ) ).toBe( null );
@@ -916,8 +926,10 @@ describe( 'selectors', () => {
 						},
 					},
 				},
-				selectionStart: { clientId: 23 },
-				selectionEnd: { clientId: 23 },
+				selection: {
+					selectionStart: { clientId: 23 },
+					selectionEnd: { clientId: 23 },
+				},
 			};
 
 			expect( getSelectedBlockClientId( state ) ).toEqual( 23 );
@@ -946,8 +958,10 @@ describe( 'selectors', () => {
 						123: '',
 					},
 				},
-				selectionStart: {},
-				selectionEnd: {},
+				selection: {
+					selectionStart: {},
+					selectionEnd: {},
+				},
 			};
 
 			expect( getSelectedBlock( state ) ).toBe( null );
@@ -974,8 +988,10 @@ describe( 'selectors', () => {
 						23: '',
 					},
 				},
-				selectionStart: { clientId: 23 },
-				selectionEnd: { clientId: 123 },
+				selection: {
+					selectionStart: { clientId: 23 },
+					selectionEnd: { clientId: 123 },
+				},
 			};
 
 			expect( getSelectedBlock( state ) ).toBe( null );
@@ -1006,8 +1022,10 @@ describe( 'selectors', () => {
 					},
 					controlledInnerBlocks: {},
 				},
-				selectionStart: { clientId: 23 },
-				selectionEnd: { clientId: 23 },
+				selection: {
+					selectionStart: { clientId: 23 },
+					selectionEnd: { clientId: 23 },
+				},
 			};
 
 			expect( getSelectedBlock( state ) ).toEqual( {
@@ -1116,8 +1134,10 @@ describe( 'selectors', () => {
 						23: '',
 					},
 				},
-				selectionStart: {},
-				selectionEnd: {},
+				selection: {
+					selectionStart: {},
+					selectionEnd: {},
+				},
 			};
 
 			expect( getSelectedBlockClientIds( state ) ).toEqual( [] );
@@ -1137,8 +1157,10 @@ describe( 'selectors', () => {
 						5: '',
 					},
 				},
-				selectionStart: { clientId: 2 },
-				selectionEnd: { clientId: 2 },
+				selection: {
+					selectionStart: { clientId: 2 },
+					selectionEnd: { clientId: 2 },
+				},
 			};
 
 			expect( getSelectedBlockClientIds( state ) ).toEqual( [ 2 ] );
@@ -1158,8 +1180,10 @@ describe( 'selectors', () => {
 						5: '',
 					},
 				},
-				selectionStart: { clientId: 2 },
-				selectionEnd: { clientId: 4 },
+				selection: {
+					selectionStart: { clientId: 2 },
+					selectionEnd: { clientId: 4 },
+				},
 			};
 
 			expect( getSelectedBlockClientIds( state ) ).toEqual( [ 4, 3, 2 ] );
@@ -1184,8 +1208,10 @@ describe( 'selectors', () => {
 						9: 4,
 					},
 				},
-				selectionStart: { clientId: 7 },
-				selectionEnd: { clientId: 9 },
+				selection: {
+					selectionStart: { clientId: 7 },
+					selectionEnd: { clientId: 9 },
+				},
 			};
 
 			expect( getSelectedBlockClientIds( state ) ).toEqual( [ 9, 8, 7 ] );
@@ -1204,8 +1230,10 @@ describe( 'selectors', () => {
 						123: '',
 					},
 				},
-				selectionStart: {},
-				selectionEnd: {},
+				selection: {
+					selectionStart: {},
+					selectionEnd: {},
+				},
 			};
 
 			expect( getMultiSelectedBlockClientIds( state ) ).toEqual( [] );
@@ -1225,8 +1253,10 @@ describe( 'selectors', () => {
 						5: '',
 					},
 				},
-				selectionStart: { clientId: 2 },
-				selectionEnd: { clientId: 4 },
+				selection: {
+					selectionStart: { clientId: 2 },
+					selectionEnd: { clientId: 4 },
+				},
 			};
 
 			expect( getMultiSelectedBlockClientIds( state ) ).toEqual( [
@@ -1255,8 +1285,10 @@ describe( 'selectors', () => {
 						9: 4,
 					},
 				},
-				selectionStart: { clientId: 7 },
-				selectionEnd: { clientId: 9 },
+				selection: {
+					selectionStart: { clientId: 7 },
+					selectionEnd: { clientId: 9 },
+				},
 			};
 
 			expect( getMultiSelectedBlockClientIds( state ) ).toEqual( [
@@ -1276,8 +1308,10 @@ describe( 'selectors', () => {
 					order: {},
 					parents: {},
 				},
-				selectionStart: {},
-				selectionEnd: {},
+				selection: {
+					selectionStart: {},
+					selectionEnd: {},
+				},
 			};
 
 			expect( getMultiSelectedBlocks( state ) ).toBe(
@@ -1289,8 +1323,10 @@ describe( 'selectors', () => {
 	describe( 'getMultiSelectedBlocksStartClientId', () => {
 		it( 'returns null if there is no multi selection', () => {
 			const state = {
-				selectionStart: {},
-				selectionEnd: {},
+				selection: {
+					selectionStart: {},
+					selectionEnd: {},
+				},
 			};
 
 			expect( getMultiSelectedBlocksStartClientId( state ) ).toBeNull();
@@ -1298,8 +1334,10 @@ describe( 'selectors', () => {
 
 		it( 'returns multi selection start', () => {
 			const state = {
-				selectionStart: { clientId: 2 },
-				selectionEnd: { clientId: 4 },
+				selection: {
+					selectionStart: { clientId: 2 },
+					selectionEnd: { clientId: 4 },
+				},
 			};
 
 			expect( getMultiSelectedBlocksStartClientId( state ) ).toBe( 2 );
@@ -1309,8 +1347,10 @@ describe( 'selectors', () => {
 	describe( 'getMultiSelectedBlocksEndClientId', () => {
 		it( 'returns null if there is no multi selection', () => {
 			const state = {
-				selectionStart: {},
-				selectionEnd: {},
+				selection: {
+					selectionStart: {},
+					selectionEnd: {},
+				},
 			};
 
 			expect( getMultiSelectedBlocksEndClientId( state ) ).toBeNull();
@@ -1318,8 +1358,10 @@ describe( 'selectors', () => {
 
 		it( 'returns multi selection end', () => {
 			const state = {
-				selectionStart: { clientId: 2 },
-				selectionEnd: { clientId: 4 },
+				selection: {
+					selectionStart: { clientId: 2 },
+					selectionEnd: { clientId: 4 },
+				},
 			};
 
 			expect( getMultiSelectedBlocksEndClientId( state ) ).toBe( 4 );
@@ -1548,8 +1590,10 @@ describe( 'selectors', () => {
 	describe( 'isBlockSelected', () => {
 		it( 'should return true if the block is selected', () => {
 			const state = {
-				selectionStart: { clientId: 123 },
-				selectionEnd: { clientId: 123 },
+				selection: {
+					selectionStart: { clientId: 123 },
+					selectionEnd: { clientId: 123 },
+				},
 			};
 
 			expect( isBlockSelected( state, 123 ) ).toBe( true );
@@ -1557,8 +1601,10 @@ describe( 'selectors', () => {
 
 		it( 'should return false if a multi-selection range exists', () => {
 			const state = {
-				selectionStart: { clientId: 123 },
-				selectionEnd: { clientId: 124 },
+				selection: {
+					selectionStart: { clientId: 123 },
+					selectionEnd: { clientId: 124 },
+				},
 			};
 
 			expect( isBlockSelected( state, 123 ) ).toBe( false );
@@ -1566,8 +1612,10 @@ describe( 'selectors', () => {
 
 		it( 'should return false if the block is not selected', () => {
 			const state = {
-				selectionStart: {},
-				selectionEnd: {},
+				selection: {
+					selectionStart: {},
+					selectionEnd: {},
+				},
 			};
 
 			expect( isBlockSelected( state, 23 ) ).toBe( false );
@@ -1577,8 +1625,10 @@ describe( 'selectors', () => {
 	describe( 'hasSelectedInnerBlock', () => {
 		it( 'should return false if the selected block is a child of the given ClientId', () => {
 			const state = {
-				selectionStart: { clientId: 5 },
-				selectionEnd: { clientId: 5 },
+				selection: {
+					selectionStart: { clientId: 5 },
+					selectionEnd: { clientId: 5 },
+				},
 				blocks: {
 					order: {
 						4: [ 3, 2, 1 ],
@@ -1596,8 +1646,10 @@ describe( 'selectors', () => {
 
 		it( 'should return true if the selected block is a child of the given ClientId', () => {
 			const state = {
-				selectionStart: { clientId: 3 },
-				selectionEnd: { clientId: 3 },
+				selection: {
+					selectionStart: { clientId: 3 },
+					selectionEnd: { clientId: 3 },
+				},
 				blocks: {
 					order: {
 						4: [ 3, 2, 1 ],
@@ -1627,8 +1679,10 @@ describe( 'selectors', () => {
 						5: 6,
 					},
 				},
-				selectionStart: { clientId: 2 },
-				selectionEnd: { clientId: 4 },
+				selection: {
+					selectionStart: { clientId: 2 },
+					selectionEnd: { clientId: 4 },
+				},
 			};
 			expect( hasSelectedInnerBlock( state, 6 ) ).toBe( true );
 		} );
@@ -1647,8 +1701,10 @@ describe( 'selectors', () => {
 						5: 6,
 					},
 				},
-				selectionStart: { clientId: 5 },
-				selectionEnd: { clientId: 4 },
+				selection: {
+					selectionStart: { clientId: 5 },
+					selectionEnd: { clientId: 4 },
+				},
 			};
 			expect( hasSelectedInnerBlock( state, 3 ) ).toBe( false );
 		} );
@@ -1657,8 +1713,10 @@ describe( 'selectors', () => {
 	describe( 'isBlockWithinSelection', () => {
 		it( 'should return true if the block is selected but not the last', () => {
 			const state = {
-				selectionStart: { clientId: 5 },
-				selectionEnd: { clientId: 3 },
+				selection: {
+					selectionStart: { clientId: 5 },
+					selectionEnd: { clientId: 3 },
+				},
 				blocks: {
 					order: {
 						'': [ 5, 4, 3, 2, 1 ],
@@ -1678,8 +1736,10 @@ describe( 'selectors', () => {
 
 		it( 'should return false if the block is the last selected', () => {
 			const state = {
-				selectionStart: { clientId: 5 },
-				selectionEnd: { clientId: 3 },
+				selection: {
+					selectionStart: { clientId: 5 },
+					selectionEnd: { clientId: 3 },
+				},
 				blocks: {
 					order: {
 						'': [ 5, 4, 3, 2, 1 ],
@@ -1699,8 +1759,10 @@ describe( 'selectors', () => {
 
 		it( 'should return false if the block is not selected', () => {
 			const state = {
-				selectionStart: { clientId: 5 },
-				selectionEnd: { clientId: 3 },
+				selection: {
+					selectionStart: { clientId: 5 },
+					selectionEnd: { clientId: 3 },
+				},
 				blocks: {
 					order: {
 						'': [ 5, 4, 3, 2, 1 ],
@@ -1720,8 +1782,10 @@ describe( 'selectors', () => {
 
 		it( 'should return false if there is no selection', () => {
 			const state = {
-				selectionStart: {},
-				selectionEnd: {},
+				selection: {
+					selectionStart: {},
+					selectionEnd: {},
+				},
 				blocks: {
 					order: {
 						'': [ 5, 4, 3, 2, 1 ],
@@ -1743,8 +1807,10 @@ describe( 'selectors', () => {
 	describe( 'hasMultiSelection', () => {
 		it( 'should return false if no selection', () => {
 			const state = {
-				selectionStart: {},
-				selectionEnd: {},
+				selection: {
+					selectionStart: {},
+					selectionEnd: {},
+				},
 			};
 
 			expect( hasMultiSelection( state ) ).toBe( false );
@@ -1752,11 +1818,13 @@ describe( 'selectors', () => {
 
 		it( 'should return false if singular selection', () => {
 			const state = {
-				selectionStart: {
-					clientId: 'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1',
-				},
-				selectionEnd: {
-					clientId: 'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1',
+				selection: {
+					selectionStart: {
+						clientId: 'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1',
+					},
+					selectionEnd: {
+						clientId: 'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1',
+					},
 				},
 			};
 
@@ -1765,11 +1833,13 @@ describe( 'selectors', () => {
 
 		it( 'should return true if multi-selection', () => {
 			const state = {
-				selectionStart: {
-					clientId: 'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1',
-				},
-				selectionEnd: {
-					clientId: '9db792c6-a25a-495d-adbd-97d56a4c4189',
+				selection: {
+					selectionStart: {
+						clientId: 'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1',
+					},
+					selectionEnd: {
+						clientId: '9db792c6-a25a-495d-adbd-97d56a4c4189',
+					},
 				},
 			};
 
@@ -1791,8 +1861,10 @@ describe( 'selectors', () => {
 					5: '',
 				},
 			},
-			selectionStart: { clientId: 2 },
-			selectionEnd: { clientId: 4 },
+			selection: {
+				selectionStart: { clientId: 2 },
+				selectionEnd: { clientId: 4 },
+			},
 		};
 
 		it( 'should return true if the block is multi selected', () => {
@@ -1818,8 +1890,10 @@ describe( 'selectors', () => {
 					5: '',
 				},
 			},
-			selectionStart: { clientId: 2 },
-			selectionEnd: { clientId: 4 },
+			selection: {
+				selectionStart: { clientId: 2 },
+				selectionEnd: { clientId: 4 },
+			},
 		};
 
 		it( 'should return true if the block is first in multi selection', () => {
@@ -1998,8 +2072,10 @@ describe( 'selectors', () => {
 	describe( 'getBlockInsertionPoint', () => {
 		it( 'should return the explicitly assigned insertion point', () => {
 			const state = {
-				selectionStart: { clientId: 'clientId2' },
-				selectionEnd: { clientId: 'clientId2' },
+				selection: {
+					selectionStart: { clientId: 'clientId2' },
+					selectionEnd: { clientId: 'clientId2' },
+				},
 				blocks: {
 					byClientId: {
 						clientId1: { clientId: 'clientId1' },
@@ -2033,8 +2109,10 @@ describe( 'selectors', () => {
 
 		it( 'should return an object for the selected block', () => {
 			const state = {
-				selectionStart: { clientId: 'clientId1' },
-				selectionEnd: { clientId: 'clientId1' },
+				selection: {
+					selectionStart: { clientId: 'clientId1' },
+					selectionEnd: { clientId: 'clientId1' },
+				},
 				blocks: {
 					byClientId: {
 						clientId1: { clientId: 'clientId1' },
@@ -2061,8 +2139,10 @@ describe( 'selectors', () => {
 
 		it( 'should return an object for the nested selected block', () => {
 			const state = {
-				selectionStart: { clientId: 'clientId2' },
-				selectionEnd: { clientId: 'clientId2' },
+				selection: {
+					selectionStart: { clientId: 'clientId2' },
+					selectionEnd: { clientId: 'clientId2' },
+				},
 				blocks: {
 					byClientId: {
 						clientId1: { clientId: 'clientId1' },
@@ -2093,8 +2173,10 @@ describe( 'selectors', () => {
 
 		it( 'should return an object for the last multi selected clientId', () => {
 			const state = {
-				selectionStart: { clientId: 'clientId1' },
-				selectionEnd: { clientId: 'clientId2' },
+				selection: {
+					selectionStart: { clientId: 'clientId1' },
+					selectionEnd: { clientId: 'clientId2' },
+				},
 				blocks: {
 					byClientId: {
 						clientId1: { clientId: 'clientId1' },
@@ -2125,8 +2207,10 @@ describe( 'selectors', () => {
 
 		it( 'should return an object for the last block if no selection', () => {
 			const state = {
-				selectionStart: {},
-				selectionEnd: {},
+				selection: {
+					selectionStart: {},
+					selectionEnd: {},
+				},
 				blocks: {
 					byClientId: {
 						clientId1: { clientId: 'clientId1' },
@@ -3106,8 +3190,10 @@ describe( 'selectors', () => {
 		it( 'should not be defined if there is no block selected', () => {
 			const state = {
 				blocks,
-				selectionStart: {},
-				selectionEnd: {},
+				selection: {
+					selectionStart: {},
+					selectionEnd: {},
+				},
 			};
 
 			expect(
@@ -3118,8 +3204,10 @@ describe( 'selectors', () => {
 		it( 'should not be defined if selected block has no parent', () => {
 			const state = {
 				blocks,
-				selectionStart: { clientId: 'b' },
-				selectionEnd: { clientId: 'b' },
+				selection: {
+					selectionStart: { clientId: 'b' },
+					selectionEnd: { clientId: 'b' },
+				},
 			};
 
 			expect(
@@ -3130,8 +3218,10 @@ describe( 'selectors', () => {
 		it( 'should not be defined if selected block has no common parent with given block', () => {
 			const state = {
 				blocks,
-				selectionStart: { clientId: 'd' },
-				selectionEnd: { clientId: 'd' },
+				selection: {
+					selectionStart: { clientId: 'd' },
+					selectionEnd: { clientId: 'd' },
+				},
 			};
 
 			expect(
@@ -3142,8 +3232,10 @@ describe( 'selectors', () => {
 		it( 'should return block id if selected block is ancestor of given block', () => {
 			const state = {
 				blocks,
-				selectionStart: { clientId: 'c' },
-				selectionEnd: { clientId: 'c' },
+				selection: {
+					selectionStart: { clientId: 'c' },
+					selectionEnd: { clientId: 'c' },
+				},
 			};
 
 			expect(
@@ -3154,8 +3246,10 @@ describe( 'selectors', () => {
 		it( 'should return block id if selected block is nested child of given block', () => {
 			const state = {
 				blocks,
-				selectionStart: { clientId: 'e' },
-				selectionEnd: { clientId: 'e' },
+				selection: {
+					selectionStart: { clientId: 'e' },
+					selectionEnd: { clientId: 'e' },
+				},
 			};
 
 			expect(
@@ -3166,8 +3260,10 @@ describe( 'selectors', () => {
 		it( 'should return block id if selected block has common parent with given block', () => {
 			const state = {
 				blocks,
-				selectionStart: { clientId: 'e' },
-				selectionEnd: { clientId: 'e' },
+				selection: {
+					selectionStart: { clientId: 'e' },
+					selectionEnd: { clientId: 'e' },
+				},
 			};
 
 			expect(
@@ -3178,11 +3274,13 @@ describe( 'selectors', () => {
 
 	describe( 'getActiveBlockIdByBlockName', () => {
 		const state = {
-			selectionStart: {
-				clientId: 'client-id-04',
-			},
-			selectionEnd: {
-				clientId: 'client-id-04',
+			selection: {
+				selectionStart: {
+					clientId: 'client-id-04',
+				},
+				selectionEnd: {
+					clientId: 'client-id-04',
+				},
 			},
 			blocks: {
 				parents: {
@@ -3242,7 +3340,7 @@ describe( 'selectors', () => {
 			).toEqual( 'client-id-02' );
 		} );
 		it( 'Should return first active matching block with (excluding self) when multi selected', () => {
-			state.selectionEnd.clientId = 'client-id-05';
+			state.selection.selectionEnd.clientId = 'client-id-05';
 
 			expect(
 				getActiveBlockIdByBlockNames( state, [


### PR DESCRIPTION
## Description
Fixes #21445. Alternative to #21371. Bug discovered while working on #21340.

When RESET_BLOCKS is dispatched and results in the selected blocks being replaced, selection state in the store is not cleared, which can cause the top toolbar to be shown for a block that no longer exists.

<strike>This PR converts the resetBlocks action into a generator action, and adds additional logic for resetting selection when needed.</strike>

This PR adds a higher order reducer for selection that updates the selection state as necessary when RESET_BLOCKS is dispatched.

## How has this been tested?
Unit tests added.

Steps to reproduce:
1. Enable the Top Toolbar option
2. Add a paragraph with some text to a post and ensure it stays selected so that the block toolbar is shown at the top
3. In the browser dev tools open up the console and execute the following to reset blocks: 
```js
wp.data.dispatch('core/block-editor').resetBlocks([]);
```
4. Observe in the top toolbar the block toolbar is no longer displayed. Previously the movers and more menu were displayed and clicking the more menu caused the editor to crash.

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
