### PR TITLE
Fix/calendar focus

### DIFF
--- a/packages/components/src/date-time/style.scss
+++ b/packages/components/src/date-time/style.scss
@@ -54,11 +54,22 @@
 		font-size: $default-font-size;
 	}
 
+	// Seperate borders so that border respect border radius
+	.CalendarMonth_table {
+		border-collapse: separate;
+		border-spacing: 2px;
+	}
+
 	.CalendarDay {
 		font-size: $default-font-size;
-		border: 1px solid transparent;
+		border: none;
 		border-radius: $radius-round;
 		text-align: center;
+
+		&:focus {
+			box-shadow: inset 0 0 0 $border-width-focus theme(primary), inset 0 0 0 #{ $border-width-focus + $border-width } $white;
+			outline: none;
+		}
 	}
 
 	.CalendarDay__selected {

--- a/packages/components/src/date-time/style.scss
+++ b/packages/components/src/date-time/style.scss
@@ -68,15 +68,20 @@
 
 		&:focus {
 			box-shadow: inset 0 0 0 $border-width-focus theme(primary), inset 0 0 0 #{ $border-width-focus + $border-width } $white;
-			outline: none;
+			outline: 2px solid transparent; // Shown in Windows 10 high contrast mode.
 		}
 	}
 
 	.CalendarDay__selected {
 		background: theme(primary);
+		border: 2px solid transparent; // This indicates selection in Windows 10 high contrast mode.
 
 		&:hover {
 			background: color(theme(primary) shade(15%));
+		}
+
+		&:focus {
+			box-shadow: inset 0 0 0 $border-width $white;
 		}
 	}
 


### PR DESCRIPTION
Fixes #15929.

Alternative to #15962. 

This PR adds a better focus style to calendar days, and ensures that it works in Windows 10 high contrast mode:

![styles](https://user-images.githubusercontent.com/1204802/79319202-4d34e700-7f08-11ea-874d-86230fdb3792.gif)
