### PR TITLE
ESLint Plugin: Add the recommended Prettier config to enforce WP coding styles

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,3 +1,3 @@
 // Import the default config file and expose it in the project root.
 // Useful for editor integrations.
-module.exports = require( '@wordpress/scripts/config/.prettierrc.js' );
+module.exports = require( '@wordpress/prettier-config' );

--- a/package-lock.json
+++ b/package-lock.json
@@ -11215,6 +11215,7 @@
 			"version": "file:packages/eslint-plugin",
 			"dev": true,
 			"requires": {
+				"@wordpress/prettier-config": "file:packages/prettier-config",
 				"babel-eslint": "^10.1.0",
 				"eslint-config-prettier": "^6.10.1",
 				"eslint-plugin-jest": "^23.8.2",

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Master
 
+### Bug Fix
+
+- Added the recommended `Prettier` config that enforces WordPress coding style guidelines ([#21602](https://github.com/WordPress/gutenberg/pull/21602)).
+
 ### Breaking Changes
 
 - There is a new `i18n` ruleset that includes all i18n-related rules and is included in the `recommended` ruleset.
@@ -24,7 +28,6 @@
 
 - The `@wordpress/valid-sprintf` rule now detects usage of `sprintf` via `i18n.sprintf` (e.g. when using `import * as i18n from '@wordpress/i18n'`).
 - `@wordpress/no-unused-vars-before-return` will correctly consider other unused variables after encountering an instance of an `excludePattern` option exception.
-- Added the recommended `Prettier` config that enforces WordPress coding style guidelines ([#21602](https://github.com/WordPress/gutenberg/pull/21602)).
 
 ## 4.0.0 (2020-02-10)
 

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -20,10 +20,11 @@
 - New Rule: [`@wordpress/i18n-ellipsis`](https://github.com/WordPress/gutenberg/blob/master/packages/eslint-plugin/docs/rules/i18n-ellipsis.md)
 - The bundled `eslint-plugin-react` dependency has been updated from requiring `^7.14.3` to requiring `^7.19.0` ([#21424](https://github.com/WordPress/gutenberg/pull/21424)).
 
-### Bug Fix
+### Bug Fixes
 
 - The `@wordpress/valid-sprintf` rule now detects usage of `sprintf` via `i18n.sprintf` (e.g. when using `import * as i18n from '@wordpress/i18n'`).
 - `@wordpress/no-unused-vars-before-return` will correctly consider other unused variables after encountering an instance of an `excludePattern` option exception.
+- Added the recommended `Prettier` config that enforces WordPress coding style guidelines ([#21602](https://github.com/WordPress/gutenberg/pull/21602)).
 
 ## 4.0.0 (2020-02-10)
 

--- a/packages/eslint-plugin/configs/recommended.js
+++ b/packages/eslint-plugin/configs/recommended.js
@@ -1,7 +1,15 @@
+/**
+ * WordPress dependencies
+ */
+const defaultPrettierConfig = require( '@wordpress/prettier-config' );
+
 module.exports = {
 	extends: [
 		require.resolve( './recommended-with-formatting.js' ),
 		'plugin:prettier/recommended',
 		'prettier/react',
 	],
+	rules: {
+		'prettier/prettier': [ 'error', defaultPrettierConfig ],
+	},
 };

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -24,6 +24,7 @@
 	],
 	"main": "index.js",
 	"dependencies": {
+		"@wordpress/prettier-config": "file:../prettier-config",
 		"babel-eslint": "^10.1.0",
 		"eslint-config-prettier": "^6.10.1",
 		"eslint-plugin-jest": "^23.8.2",

--- a/packages/scripts/config/.eslintrc.js
+++ b/packages/scripts/config/.eslintrc.js
@@ -1,9 +1,3 @@
-/**
- * Internal dependencies
- */
-const defaultPrettierConfig = require( './.prettierrc' );
-const { hasPrettierConfig } = require( '../utils' );
-
 const eslintConfig = {
 	root: true,
 	extends: [
@@ -16,17 +10,5 @@ const eslintConfig = {
 		'plugin:@wordpress/eslint-plugin/test-unit',
 	],
 };
-
-if ( ! hasPrettierConfig() ) {
-	eslintConfig.rules = {
-		'prettier/prettier': [
-			'error',
-			defaultPrettierConfig,
-			{
-				usePrettierrc: false,
-			},
-		],
-	};
-}
 
 module.exports = eslintConfig;

--- a/packages/scripts/scripts/format-js.js
+++ b/packages/scripts/scripts/format-js.js
@@ -72,9 +72,11 @@ if ( ! checkResult.success ) {
 // needed for config, otherwise pass in args to default config in packages
 // See: https://prettier.io/docs/en/configuration.html
 let configArgs = [];
-// TODO: once setup, use @wordpress/prettier-config
 if ( ! hasPrettierConfig() ) {
-	configArgs = [ '--config', fromConfigRoot( '.prettierrc.js' ) ];
+	configArgs = [
+		'--config',
+		require.resolve( '@wordpress/prettier-config' ),
+	];
 }
 
 // If `--ignore-path` is not explicitly specified, use the project's or global .eslintignore


### PR DESCRIPTION
## Description
Fixes #20509. An alternative to #21503.

> Hi, I have recently upgraded `@wordpress/eslint-plugin` to version 4.0.0. After the update, eslint is telling me to remove spaces from inside parens, and replace ' with ". AFAIK this goes against WPC

This PR always uses the recommended Prettier config to enforce WordPress coding styles but it respects the Prettier config overrides defined by projects.

It turns out that there is `usePrettierrc` option in `prettier/prettier` rule (https://github.com/prettier/eslint-plugin-prettier#options):

> Enables loading of the Prettier configuration file, (default: `true`). May be useful if you are using multiple tools that conflict with each other, or do not wish to mix your ESLint settings with your Prettier configuration.

This way we could remove the config in `@wordpress/scripts` for Prettier and use `@wordpress/prettier-config` in all places instead.

## How has this been tested?

It's also possible to test the changes applied to the `@wordpress/eslint-config` by removing `.prettierrc.js` file in the root of the project and executing:
`npm run lint-js`

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
