### PR TITLE
[RNMobile] Correct colors usage in Button

### DIFF
--- a/packages/block-library/src/button/edit.native.js
+++ b/packages/block-library/src/button/edit.native.js
@@ -152,12 +152,27 @@ class ButtonEdit extends Component {
 	}
 
 	getBackgroundColor() {
-		const { backgroundColor } = this.props;
-		if ( backgroundColor.color ) {
-			// `backgroundColor` which should be set when we are able to resolve it
+		const { backgroundColor, attributes } = this.props;
+		const { style } = attributes;
+
+		if ( style && style.color && style.color.background ) {
+			return style.color.background;
+		} else if ( backgroundColor.color ) {
 			return backgroundColor.color;
 		}
 		return styles.fallbackButton.backgroundColor;
+	}
+
+	getTextColor() {
+		const { textColor, attributes } = this.props;
+		const { style } = attributes;
+
+		if ( style && style.color && style.color.text ) {
+			return style.color.text;
+		} else if ( textColor.color ) {
+			return textColor.color;
+		}
+		return styles.fallbackButton.color;
 	}
 
 	onChangeText( value ) {
@@ -293,13 +308,7 @@ class ButtonEdit extends Component {
 	}
 
 	render() {
-		const {
-			attributes,
-			textColor,
-			isSelected,
-			clientId,
-			onReplace,
-		} = this.props;
+		const { attributes, isSelected, clientId, onReplace } = this.props;
 		const {
 			placeholder,
 			text,
@@ -365,7 +374,7 @@ class ButtonEdit extends Component {
 						onChange={ this.onChangeText }
 						style={ {
 							...richTextStyle.richText,
-							color: textColor.color || '#fff',
+							color: this.getTextColor(),
 						} }
 						textAlign="center"
 						placeholderTextColor={
@@ -382,7 +391,11 @@ class ButtonEdit extends Component {
 							this.onToggleButtonFocus( true )
 						}
 						__unstableMobileNoFocusOnMount={ ! isSelected }
-						selectionColor={ textColor.color || '#fff' }
+						onBlur={ () => {
+							this.onToggleButtonFocus( false );
+							this.onSetMaxWidth();
+						} }
+						selectionColor={ this.getTextColor() }
 						onReplace={ onReplace }
 						onRemove={ () => onReplace( [] ) }
 					/>

--- a/packages/block-library/src/button/edit.native.js
+++ b/packages/block-library/src/button/edit.native.js
@@ -391,10 +391,6 @@ class ButtonEdit extends Component {
 							this.onToggleButtonFocus( true )
 						}
 						__unstableMobileNoFocusOnMount={ ! isSelected }
-						onBlur={ () => {
-							this.onToggleButtonFocus( false );
-							this.onSetMaxWidth();
-						} }
 						selectionColor={ this.getTextColor() }
 						onReplace={ onReplace }
 						onRemove={ () => onReplace( [] ) }

--- a/packages/block-library/src/button/edit.native.js
+++ b/packages/block-library/src/button/edit.native.js
@@ -155,24 +155,22 @@ class ButtonEdit extends Component {
 		const { backgroundColor, attributes } = this.props;
 		const { style } = attributes;
 
-		if ( style && style.color && style.color.background ) {
-			return style.color.background;
-		} else if ( backgroundColor.color ) {
-			return backgroundColor.color;
-		}
-		return styles.fallbackButton.backgroundColor;
+		return (
+			( style && style.color && style.color.background ) ||
+			backgroundColor.color ||
+			styles.fallbackButton.backgroundColor
+		);
 	}
 
 	getTextColor() {
 		const { textColor, attributes } = this.props;
 		const { style } = attributes;
 
-		if ( style && style.color && style.color.text ) {
-			return style.color.text;
-		} else if ( textColor.color ) {
-			return textColor.color;
-		}
-		return styles.fallbackButton.color;
+		return (
+			( style && style.color && style.color.text ) ||
+			textColor.color ||
+			styles.fallbackButton.color
+		);
 	}
 
 	onChangeText( value ) {

--- a/packages/block-library/src/button/editor.native.scss
+++ b/packages/block-library/src/button/editor.native.scss
@@ -30,6 +30,7 @@
 
 .fallbackButton {
 	background-color: $button-fallback-bg;
+	color: $white;
 }
 
 .clearLinkButton {


### PR DESCRIPTION
## Description

Correct colors usage in `Button` after web changes.

ref to gb-mobile: https://github.com/wordpress-mobile/gutenberg-mobile/pull/2155
## How has this been tested?

Testing HTML:

```
<!-- wp:button {"customBackgroundColor":"#325766"} -->
<div class="wp-block-button"><a class="wp-block-button__link has-background" style="background-color:#325766">CUSTOM</a></div>
<!-- /wp:button -->

<!-- wp:button {"gradient":"luminous-dusk"} -->
<div class="wp-block-button"><a class="wp-block-button__link has-background has-luminous-dusk-gradient-background">GRADIENT</a></div>
<!-- /wp:button -->

<!-- wp:button {"backgroundColor":"secondary"} -->
<div class="wp-block-button"><a class="wp-block-button__link has-background has-secondary-background-color">PALETTE</a></div>
<!-- /wp:button -->

<!-- wp:button {"customTextColor":"#90318f"} -->
<div class="wp-block-button"><a class="wp-block-button__link has-text-color" style="color:#90318f">TEXT CUSTOM</a></div>
<!-- /wp:button -->

<!-- wp:button {"textColor":"background"} -->
<div class="wp-block-button"><a class="wp-block-button__link has-text-color has-background-color">TEXT PALETTE</a></div>
<!-- /wp:button -->
```

Paste that HTML on the mobile editor and compare it with that screenshot:
<img width="497" alt="Screenshot 2020-04-15 at 11 05 15" src="https://user-images.githubusercontent.com/22746080/79321021-009edb00-7f0b-11ea-8839-6dab95353233.png">

Another way to test:

1. Open post on web
2. Add Buttons block and create a couple of Buttons inside:
	- Button with custom background color
	- Button with color from palette color
	- Button with gradient color
	- Button with text custom color 
	- Button with text color from palette color
3. Open HTML view
4. Remove `Buttons` container to have separated list of Button
5. Save draft
6. Open post on mobile app
7. Expect:
	- Button with custom background color - button should have the same background color
	- Button with color from palette - button should have gray fallback color
	- Button with gradient color - button should have a gradient color
	- Button with text custom color - button text should have text custom color
	- Button with text color from palette - button text should have white text


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
