### PR TITLE
Try: output float clearing for all centered blocks.

### DIFF
--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -260,3 +260,8 @@
 #end-resizable-editor-section {
 	display: none;
 }
+
+// Block alignments.
+.aligncenter {
+	clear: both;
+}


### PR DESCRIPTION
This PR needs feedback. It is a replacement for #16780.

What it does is output a simple float-clearing rule for any block that is aligned center.

To test, insert two images. The first one you float left, the 2nd one you align center.

Before:

<img width="935" alt="Screenshot 2020-04-15 at 13 46 21" src="https://user-images.githubusercontent.com/1204802/79334646-f4be1380-7f20-11ea-9d4a-892ecf2eb116.png">

After:

<img width="904" alt="Screenshot 2020-04-15 at 13 46 28" src="https://user-images.githubusercontent.com/1204802/79334670-00a9d580-7f21-11ea-8827-7f00968b5856.png">

**To be perfectly clear, this is output in the editor and on the frontend**. 

In the past, this has been the purview of the theme itself, but lately there has been some discussion on how much or how little the editor should "help" here. That's why this PR needs discussion.

- Either we do it, and helps #10299. 
- Or, we choose to not do it, and #10299 will be the de-facto solution to float clearing. 

