### PR TITLE
eslint-plugin: fix: Cannot find module '../utils'

### DIFF
--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -20,6 +20,7 @@
 	"files": [
 		"configs",
 		"rules",
+		"utils",
 		"index.js"
 	],
 	"main": "index.js",


### PR DESCRIPTION
## Description
Added `utils` to package.json "files" list. Without this, `utils` folder is missing, and you get an error when trying to run eslint: `Error: Failed to load plugin '@wordpress/eslint-plugin' declared in '.eslintrc.js': Cannot find module '../utils'`

Fixes #21610