### PR TITLE
Fix: Media Text padding on inner blocks

### DIFF
--- a/packages/block-library/src/media-text/editor.scss
+++ b/packages/block-library/src/media-text/editor.scss
@@ -42,7 +42,7 @@
 	grid-row: 1;
 }
 
-.wp-block-media-text .block-editor-inner-blocks {
+.wp-block-media-text > .block-editor-inner-blocks {
 	word-break: break-word;
 	grid-column: 2;
 	grid-row: 1;


### PR DESCRIPTION
## Description
Media text was applying some styles to inner blocks e.g: some padding. These styles should only affect direct InnerBlocks and not the InnerBlocks of descendent InnerBlocks.

Fixes: https://github.com/WordPress/gutenberg/issues/21067

Before:

![image](https://user-images.githubusercontent.com/11271197/79344286-8892de00-7f27-11ea-9b53-9f1fdacbc7ce.png)


After:
![image](https://user-images.githubusercontent.com/11271197/79344144-55504f00-7f27-11ea-9874-9c88bb2c85c1.png)
