### PR TITLE
Types: Hide element, primitives, icons declarations

### DIFF
--- a/packages/element/CHANGELOG.md
+++ b/packages/element/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## Master
 
+### Bug Fix
+
+-   Hide TypeScript type declarations ([#21613](https://github.com/WordPress/gutenberg/pull/21613))
+    after they were found to conflict with DefinitelyTyped provided declarations.
+
+## 2.13.0 (2019-04-15)
+
+### New Features
+
 -   Include TypeScript type declarations ([#21248](https://github.com/WordPress/gutenberg/pull/21248))
 -   Graduated `__experimentalCreateInterpolateElement` function to stable api: `createInterpolateElement` (see [20699](https://github.com/WordPress/gutenberg/pull/20699))
 

--- a/packages/element/CHANGELOG.md
+++ b/packages/element/CHANGELOG.md
@@ -5,7 +5,7 @@
 -   Hide TypeScript type declarations ([#21613](https://github.com/WordPress/gutenberg/pull/21613))
     after they were found to conflict with DefinitelyTyped provided declarations.
 
-## 2.13.0 (2019-04-15)
+## 2.13.0 (2020-04-15)
 
 ### New Features
 

--- a/packages/element/package.json
+++ b/packages/element/package.json
@@ -21,7 +21,6 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"react-native": "src/index",
-	"types": "build-types",
 	"sideEffects": false,
 	"dependencies": {
 		"@babel/runtime": "^7.9.2",

--- a/packages/icons/CHANGELOG.md
+++ b/packages/icons/CHANGELOG.md
@@ -1,6 +1,13 @@
 ## Master
 
-Include TypeScript type declarations ([#21487](https://github.com/WordPress/gutenberg/pull/21487))
+### Bug Fix
+
+-   Hide TypeScript type declarations ([#21613](https://github.com/WordPress/gutenberg/pull/21613))
+    after they were found to conflict with DefinitelyTyped provided declarations.
+
+## 1.3.0 (2020-04-15)
+
+- Include TypeScript type declarations ([#21487](https://github.com/WordPress/gutenberg/pull/21487))
 
 ## 1.0.0 (2020-02-04)
 

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -22,7 +22,6 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"react-native": "src/index",
-	"types": "build-types",
 	"dependencies": {
 		"@babel/runtime": "^7.9.2",
 		"@wordpress/element": "../element",

--- a/packages/primitives/CHANGELOG.md
+++ b/packages/primitives/CHANGELOG.md
@@ -1,6 +1,13 @@
 ## Master
 
-Include TypeScript type declarations ([#21482](https://github.com/WordPress/gutenberg/pull/21482))
+### Bug Fix
+
+-   Hide TypeScript type declarations ([#21613](https://github.com/WordPress/gutenberg/pull/21613))
+    after they were found to conflict with DefinitelyTyped provided declarations.
+
+## 1.3.0 (2020-04-15)
+
+- Include TypeScript type declarations ([#21482](https://github.com/WordPress/gutenberg/pull/21482))
 
 ## 1.0.0
 

--- a/packages/primitives/package.json
+++ b/packages/primitives/package.json
@@ -22,7 +22,6 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"sideEffects": false,
-	"types": "build-types",
 	"dependencies": {
 		"@babel/runtime": "^7.9.2",
 		"@wordpress/element": "file:../element",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,20 +5,23 @@
 		{ "path": "packages/autop" },
 		{ "path": "packages/blob" },
 		{ "path": "packages/block-editor" },
-		{ "path": "packages/element" },
 		{ "path": "packages/dom-ready" },
 		{ "path": "packages/escape-html" },
 		{ "path": "packages/html-entities" },
 		{ "path": "packages/i18n" },
-		{ "path": "packages/icons" },
 		{ "path": "packages/is-shallow-equal" },
 		{ "path": "packages/prettier-config" },
-		{ "path": "packages/primitives" },
 		{ "path": "packages/priority-queue" },
 		{ "path": "packages/project-management-automation" },
 		{ "path": "packages/token-list" },
 		{ "path": "packages/url" },
 		{ "path": "packages/warning" }
+
+		// Temporarily disabled due to conflicts with 3rd party DefinitelyTyped types
+		// See https://github.com/WordPress/gutenberg/pull/21613
+		// { "path": "packages/element" },
+		// { "path": "packages/icons" },
+		// { "path": "packages/primitives" }
 	],
 	"files": []
 }


### PR DESCRIPTION
Remove types from pacakge.json to hide the included types. This was
reported to cause conflicts with the current 3rd party typings published
on DefinitelyTyped (DT).

The cause has been identified as:
- DT exports all React typings, which other DT typings depend on.
- Included typings use type aliases (Element -> WPElement) which may
  cause additional conflicts.

The `@wordpress/primitives` and `@wordpress/icons` packages depend on `@wordpress/element`, so their types have been disabled as well.

See https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/wordpress__element/index.d.ts
See https://unpkg.com/browse/@wordpress/element@2.13.0/build-types/react.d.ts

Reported by @dsifford via core-js slack:

https://wordpress.slack.com/archives/C5UNMSU4R/p1586955177257000