### PR TITLE
Fix: Remove unrequired margins from the columns block

### DIFF
--- a/packages/block-library/src/columns/editor.scss
+++ b/packages/block-library/src/columns/editor.scss
@@ -4,14 +4,6 @@
 	max-width: none;
 }
 
-// Ideally this shouldn't be necessary. There should be no default margins in
-// the editor.
-.editor-styles-wrapper .block-editor-block-list__block.wp-block-column,
-.editor-styles-wrapper .block-editor-block-list__block.wp-block-columns {
-	margin-top: 0;
-	margin-bottom: 0;
-}
-
 // To do: remove horizontal margin override by the editor.
 @include break-small() {
 	.editor-styles-wrapper


### PR DESCRIPTION
## Description
PR https://github.com/WordPress/gutenberg/pull/19910 cc: @ellatrix, set margins on columns block to 0. This is causing some visual issues when multiple columns are added and on the widgets screen. It seems the columns block margin should be the same as the other blocks.

Before:
![image](https://user-images.githubusercontent.com/11271197/79351468-a153c180-7f30-11ea-80e1-ac8c92880708.png)

![image](https://user-images.githubusercontent.com/11271197/79351529-afa1dd80-7f30-11ea-83c3-91ae95f48eb7.png)


After:
![image](https://user-images.githubusercontent.com/11271197/79351400-88e3a700-7f30-11ea-8a62-d18615c9feb8.png)


![image](https://user-images.githubusercontent.com/11271197/79351410-8bde9780-7f30-11ea-9f75-14ff92852b3d.png)

