### PR TITLE
fix(block-patterns): expose the registered pattern slugs in get_all_registered

### DIFF
--- a/lib/class-wp-patterns-registry.php
+++ b/lib/class-wp-patterns-registry.php
@@ -37,7 +37,10 @@ final class WP_Patterns_Registry {
 			return false;
 		}
 
-		$this->registered_patterns[ $pattern_name ] = $pattern_properties;
+		$this->registered_patterns[ $pattern_name ] = array_merge(
+			$pattern_properties,
+			array( 'name' => $pattern_name )
+		);
 
 		return true;
 	}
@@ -82,7 +85,7 @@ final class WP_Patterns_Registry {
 	 *               and per style.
 	 */
 	public function get_all_registered() {
-		return $this->registered_patterns;
+		return array_values( $this->registered_patterns );
 	}
 
 	/**

--- a/lib/class-wp-patterns-registry.php
+++ b/lib/class-wp-patterns-registry.php
@@ -82,7 +82,7 @@ final class WP_Patterns_Registry {
 	 *               and per style.
 	 */
 	public function get_all_registered() {
-		return array_values( $this->registered_patterns );
+		return $this->registered_patterns;
 	}
 
 	/**

--- a/packages/block-editor/src/components/block-patterns/index.js
+++ b/packages/block-editor/src/components/block-patterns/index.js
@@ -82,7 +82,7 @@ function BlockPatterns( { patterns } ) {
 
 	return (
 		<div className="block-editor-patterns">
-			{ Object.values( patterns ).map( ( pattern, index ) =>
+			{ patterns.map( ( pattern, index ) =>
 				currentShownPatterns[ index ] === pattern ? (
 					<BlockPattern
 						key={ index }

--- a/packages/block-editor/src/components/block-patterns/index.js
+++ b/packages/block-editor/src/components/block-patterns/index.js
@@ -82,7 +82,7 @@ function BlockPatterns( { patterns } ) {
 
 	return (
 		<div className="block-editor-patterns">
-			{ patterns.map( ( pattern, index ) =>
+			{ Object.values( patterns ).map( ( pattern, index ) =>
 				currentShownPatterns[ index ] === pattern ? (
 					<BlockPattern
 						key={ index }


### PR DESCRIPTION
## Description

Currently, the output of `WP_Pattern_Registry->get_all_registered()` does not include the slugs of the registered patterns. This is problematic in cases where theme or plugin developers want to unregister either all patterns wholesale, or patterns whose slugs begin with a certain prefix (e.g. `core`).

The only way to be able to unregister patterns before these changes would be to know all of the patterns by name beforehand, which doesn't scale very well.

This PR modifies the output of `get_all_registered` to include the registered slugs so that patterns can be programatically unregistered.

## How has this been tested?

This hasn't been tested very thoroughly locally because I had some trouble getting `wp-env` to work on my machine. However, I'll test on gutenberg.run when this PR posts.

## Screenshots <!-- if applicable -->

N/A

## Types of changes

Bug fix (ish)

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->