### PR TITLE
Docs: Update triage links to new document

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ To learn all about contributing to the Gutenberg project, see the [Contributor G
 
 - Documentation? See the [documentation section](/docs/contributors/document.md).
 
-- Triage? We need help reviewing existing issues to make sure they’re relevant and actionable. Triage is an important contribution because it allows us to work on the highest priority issues. To learn more, please see the [triaging issues section](docs/contributors/repository-management.md#triaging-issues).
+- Triage? We need help reviewing existing issues to make sure they’re relevant and actionable. Triage is an important contribution because it allows us to work on the highest priority issues. To learn more, please see the [triaging issues section](docs/contributors/triage.md).
 
 ## Guidelines
 

--- a/docs/contributors/readme.md
+++ b/docs/contributors/readme.md
@@ -14,7 +14,7 @@ Find the section below based on what you are looking to contribute:
 
 - **Documentation?** See the [documentation section](/docs/contributors/document.md)
 
-- **Triage Support?** See the [triaging issues section](/docs/contributors/repository-management/#triaging-issues)
+- **Triage Support?** See the [triaging issues section](/docs/contributors/triage.md)
 
 - **Internationalization?** See the [localizing and translating section](/docs/contributors/localizing.md)
 

--- a/docs/contributors/repository-management.md
+++ b/docs/contributors/repository-management.md
@@ -23,7 +23,7 @@ Any issues that are irrelevant or not actionable should be closed, because they 
 
 ### Labels
 
-All issues should have [one or more labels](https://github.com/WordPress/gutenberg/labels). 
+All issues should have [one or more labels](https://github.com/WordPress/gutenberg/labels).
 
 Workflow labels start with “Needs” and may be applied as needed. Ideally, each workflow label will have a group that follows it, such as the Accessibility Team for `Needs Accessibility Feedback`, the Testing Team for `Needs Testing`, etc.
 
@@ -60,32 +60,7 @@ To keep the issue list healthy, it needs to be triaged regularly. *Triage* is th
 
 Anyone can help triage, although you’ll need contributor permission on the Gutenberg repository to modify an issue’s labels or edit its title.
 
-To start simply choose from one of these filtered lists of issues:
-
-- [All Gutenberg issues without an assigned label](https://github.com/wordpress/gutenberg/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-asc+no%3Alabel). Triaging by simply adding labels helps people focused on certain aspects of Gutenberg find relevant issues easier and start working on them.
-- [The least recently updated Gutenberg issues](https://github.com/WordPress/gutenberg/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-asc). Triaging issues that are getting old and possibly out of date keeps important work from being overlooked.
-- [All Gutenberg issues with no comments](https://github.com/WordPress/gutenberg/issues?q=is%3Aopen+is%3Aissue+sort%3Acomments-asc) Triaging this list helps make sure all issues are acknowledged, and can help identify issues that may need more information or discussion before they are actionable.
-- [The least commented on issues](https://github.com/WordPress/gutenberg/issues?q=is%3Aopen+is%3Aissue+sort%3Acomments-asc) Triaging this list helps the community figure out things like traction for certain proposals. 
-
-You can also create your own custom set of filters on GitHub. If you have a filter you think might be useful for the community, feel free to submit a PR to add it to this list.
-
-When triaging, either one of the lists above or issues in general, here are some steps you can perform:
-
-- First search for duplicates. If the issue is duplicate, close it by commenting with “Duplicate of #<original-id>” and add any relevant new details to the existing issue.
-- If the issue is missing labels, add some to better categorize it (requires proper permissions).
-- If the title doesn’t communicate the issue, edit it for clarity (requires proper permissions).
-- If it’s a bug report, test to confirm the report or add the `Needs Testing` label. If there is not enough information to confirm the report, add the `[Status] Needs More Info` label and ask for the details needed.
-- Remove the `[Status] Needs More Info` if the author of the issue has responded with enough details.
-- Close the issue with a note if it has a `[Status] Needs More Info` label but the author didn't respond in 2+ weeks.
-- If there was conversation on the issue but no actionable steps identified, follow up with the participants to see what’s actionable.
-- If you feel comfortable triaging the issue further, then you can also:
-  - Check that the bug report is valid by debugging it to see if you can track down the technical specifics.
-  - Check if the issue is missing some detail and see if you can fill in those details. For instance, if a bug report is missing visual detail, it’s helpful to reproduce the issue locally and upload a screenshot or GIF.
-
-For triaging there are some labels which are very useful:
-- `Needs Technical Feedback` - you can apply them when you see new features or API changes proposed
-- `Needs More Info` - when it’s not clear what the issue is or it would help to provide additional details
-- `Needs Testing` - it’s useful for old bugs where it seems like they are no longer relevant
+See the [Triage Contributors guide](/docs/contributors/triage.md) for details.
 
 ## Pull Requests
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -384,6 +384,12 @@
 		"parent": "document"
 	},
 	{
+		"title": "Triage",
+		"slug": "triage",
+		"markdown_source": "../docs/contributors/triage.md",
+		"parent": "contributors"
+	},
+	{
 		"title": "Localizing Gutenberg Plugin",
 		"slug": "localizing",
 		"markdown_source": "../docs/contributors/localizing.md",

--- a/docs/toc.json
+++ b/docs/toc.json
@@ -77,6 +77,7 @@
 		{ "docs/contributors/document.md": [
 			{ "docs/contributors/copy-guide.md": [] }
 		] },
+		{ "docs/contributors/triage.md": [] },
 		{ "docs/contributors/localizing.md": [] },
 		{ "docs/contributors/repository-management.md": [] }
 	] },


### PR DESCRIPTION
## Description

#21350 introduced a new Triage Contributors guide document. This PR adds additional links to this new document from the CONTRIBUTING page, the Repository management page, and the front page of the Contributor's Guide.

Additionally it adds the Triage document to the table-of-contents on the left under Contributors guide.

Related: #18634 


## Types of changes

Documentation. Confirm links work.

