### PR TITLE
Fix the JSDoc return type for getEntityRecords

### DIFF
--- a/docs/designers-developers/developers/data/data-core.md
+++ b/docs/designers-developers/developers/data/data-core.md
@@ -200,7 +200,7 @@ _Parameters_
 
 _Returns_
 
--   `Array`: Records.
+-   `?Array`: Records.
 
 <a name="getLastEntitySaveError" href="#getLastEntitySaveError">#</a> **getLastEntitySaveError**
 

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -413,7 +413,7 @@ _Parameters_
 
 _Returns_
 
--   `Array`: Records.
+-   `?Array`: Records.
 
 <a name="getLastEntitySaveError" href="#getLastEntitySaveError">#</a> **getLastEntitySaveError**
 

--- a/packages/core-data/src/selectors.js
+++ b/packages/core-data/src/selectors.js
@@ -179,7 +179,7 @@ export const getRawEntityRecord = createSelector(
  * @param {string}  name   Entity name.
  * @param {?Object} query  Optional terms query.
  *
- * @return {Array} Records.
+ * @return {?Array} Records.
  */
 export function getEntityRecords( state, kind, name, query ) {
 	const queriedState = get( state.entities.data, [


### PR DESCRIPTION
## Description
`getEntityRecords` can actually return null based on the return type
of `getQueriedItems` which it calls. I can confirm it behaves this
way in the implementation so its a bug with JSDoc type for
`getEntityRecords`.

I did wonder if this would be desired behaviour though. Since
`getEntityRecords` is a selector I think it could make more sense
for it to always return an empty array to represent its empty state.

## How has this been tested?
I didn't test it, but the case where `getQueriedItems` returns null is covered in the tests here: 
https://github.com/WordPress/gutenberg/blob/master/packages/core-data/src/queried-data/test/selectors.js#L7

## Screenshots 

n/a

## Types of changes
Just a JSDoc change, no actual functional changes

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
