### PR TITLE
Fix panel collapsing in navigation page

### DIFF
--- a/packages/edit-navigation/src/components/menu-editor/block-editor-panel.js
+++ b/packages/edit-navigation/src/components/menu-editor/block-editor-panel.js
@@ -40,6 +40,7 @@ export default function BlockEditorPanel( { saveBlocks } ) {
 
 	return (
 		<Panel
+			className="edit-navigation-menu-editor__block-editor-panel"
 			header={
 				<Button isPrimary onClick={ saveBlocks }>
 					{ __( 'Save navigation' ) }

--- a/packages/edit-navigation/src/components/menu-editor/index.js
+++ b/packages/edit-navigation/src/components/menu-editor/index.js
@@ -36,15 +36,11 @@ export default function MenuEditor( { menuId, blockEditorSettings } ) {
 			>
 				<BlockEditorKeyboardShortcuts />
 				<MenuEditorShortcuts saveBlocks={ saveBlocks } />
-				<div>
-					<NavigationStructurePanel
-						blocks={ blocks }
-						initialOpen={ isLargeViewport }
-					/>
-				</div>
-				<div>
-					<BlockEditorPanel saveBlocks={ saveBlocks } />
-				</div>
+				<NavigationStructurePanel
+					blocks={ blocks }
+					initialOpen={ isLargeViewport }
+				/>
+				<BlockEditorPanel saveBlocks={ saveBlocks } />
 			</BlockEditorProvider>
 		</div>
 	);

--- a/packages/edit-navigation/src/components/menu-editor/index.js
+++ b/packages/edit-navigation/src/components/menu-editor/index.js
@@ -36,11 +36,15 @@ export default function MenuEditor( { menuId, blockEditorSettings } ) {
 			>
 				<BlockEditorKeyboardShortcuts />
 				<MenuEditorShortcuts saveBlocks={ saveBlocks } />
-				<NavigationStructurePanel
-					blocks={ blocks }
-					initialOpen={ isLargeViewport }
-				/>
-				<BlockEditorPanel saveBlocks={ saveBlocks } />
+				<div>
+					<NavigationStructurePanel
+						blocks={ blocks }
+						initialOpen={ isLargeViewport }
+					/>
+				</div>
+				<div>
+					<BlockEditorPanel saveBlocks={ saveBlocks } />
+				</div>
 			</BlockEditorProvider>
 		</div>
 	);

--- a/packages/edit-navigation/src/components/menu-editor/navigation-structure-panel.js
+++ b/packages/edit-navigation/src/components/menu-editor/navigation-structure-panel.js
@@ -7,7 +7,7 @@ import { __ } from '@wordpress/i18n';
 
 export default function NavigationStructurePanel( { blocks, initialOpen } ) {
 	return (
-		<Panel>
+		<Panel className="edit-navigation-menu-editor__navigation-structure-panel">
 			<PanelBody
 				title={ __( 'Navigation structure' ) }
 				initialOpen={ initialOpen }

--- a/packages/edit-navigation/src/components/menu-editor/style.scss
+++ b/packages/edit-navigation/src/components/menu-editor/style.scss
@@ -47,3 +47,19 @@
 		}
 	}
 }
+
+.edit-navigation-menu-editor__navigation-structure-panel {
+	// IE11 requires the column to be explicity declared.
+	grid-column: 1;
+
+	// Make panels collapsible in IE. The IE analogue of align-items: self-start;.
+	-ms-grid-row-align: start;
+}
+
+.edit-navigation-menu-editor__block-editor-panel {
+	// IE11 requires the column to be explicity declared.
+	grid-column: 2;
+
+	// Make panels collapsible in IE. The IE analogue of align-items: self-start;.
+	-ms-grid-row-align: start;
+}

--- a/packages/edit-navigation/src/components/menu-editor/style.scss
+++ b/packages/edit-navigation/src/components/menu-editor/style.scss
@@ -1,5 +1,6 @@
 .edit-navigation-menu-editor {
 	display: grid;
+	align-items: self-start;
 	grid-gap: 10px;
 
 	@include break-medium {


### PR DESCRIPTION
## Description
Currently on the navigation page (at desktop breakpoints), when collapsing a panel, instead of the panel completely collapsing, only the content collapses and the panel itself remains the height of its grid row.

The reason for this is that the `Panel` components are currently displayed as grid columns, and in the grid the columns are always the same height, so if there's content in the right hand panel, the left hand panel assumes the same height.

This PR fixes things by wrapping the panels in a `<div>`. These `div`s become the grid columns allowing the `Panels` to collapse if needed.

There might be a better way to do this without resorting to extra `div`s, I'm open to ideas 😄 .

## How has this been tested?
1. Open the Navigation Page and select a menu with lots of content
2. Collapse one of the panels while leaving the other open
3. Observe that panel collapses correctly
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->
#### Before
<img width="823" alt="Screenshot 2020-04-16 at 12 18 47 pm" src="https://user-images.githubusercontent.com/677833/79414205-9a828880-7fdc-11ea-8bc3-f626c8c66c8f.png">

#### After
<img width="828" alt="Screenshot 2020-04-16 at 12 19 22 pm" src="https://user-images.githubusercontent.com/677833/79414194-935b7a80-7fdc-11ea-9bfa-b726b3ddc459.png">


## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
