### PR TITLE
Template Part: Add extra validation when loading template parts

### DIFF
--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -22,9 +22,8 @@ function render_block_core_template_part( $attributes ) {
 	} elseif ( wp_get_theme()->get( 'TextDomain' ) === $attributes['theme'] ) {
 		// Else, if the template part was provided by the active theme,
 		// render the corresponding file content.
-		$template_part_file_path =
-				get_stylesheet_directory() . '/block-template-parts/' . $attributes['slug'] . '.html';
-		if ( file_exists( $template_part_file_path ) ) {
+		$template_part_file_path = get_stylesheet_directory() . '/block-template-parts/' . $attributes['slug'] . '.html';
+		if ( 0 === validate_file( $template_part_file_path ) && file_exists( $template_part_file_path ) ) {
 			$content = file_get_contents( $template_part_file_path );
 		}
 	}


### PR DESCRIPTION
## Description
Adds some extra validation when the Template Part block loads template part files.

## How has this been tested?

1. Enable the Gutenberg full site editing experiment.
1. Add the following files to your active theme's folder:

   `/block-templates/single.html`:
   ```html
   <!-- wp:template-part {"slug":"header","theme":"twentytwenty"} /-->
   <!-- wp:paragraph -->
   <p>Single Template</p>
   <!-- /wp:paragraph -->
   ```

   `/block-template-parts/header.html`:
   ```html
   <!-- wp:paragraph -->
   <p>Header TwentyTwenty Template Part</p>
   <!-- /wp:paragraph -->
   ```
1. Create a post and insert a Template Part block with `slug` set to `header` and theme set to `twentytwenty`
1. View the post

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
