### PR TITLE
Fix mobile layout for navigation menu page

### DIFF
--- a/packages/edit-navigation/src/components/menu-editor/style.scss
+++ b/packages/edit-navigation/src/components/menu-editor/style.scss
@@ -57,8 +57,11 @@
 }
 
 .edit-navigation-menu-editor__block-editor-panel {
-	// IE11 requires the column to be explicity declared.
-	grid-column: 2;
+	@include break-medium {
+		// IE11 requires the column to be explicity declared.
+		// Only shift this into the second column on desktop.
+		grid-column: 2;
+	}
 
 	// Make panels collapsible in IE. The IE analogue of align-items: self-start;.
 	-ms-grid-row-align: start;


### PR DESCRIPTION
## Description
 #21633 accidentally broke the layout of the nav page for mobile devices while trying to apply some IE11 fixes. 😓 

This resolves that issue.

## How has this been tested?
1. Open the nav menu page on a mobile device (or while emulating a mobile device's dimensions)
2. Observe that the panels stack instead of being side-by-side

## Screenshots <!-- if applicable -->
#### Before
<img width="408" alt="Screenshot 2020-04-16 at 4 26 30 pm" src="https://user-images.githubusercontent.com/677833/79432909-0e358d00-7fff-11ea-983c-709734626546.png">

#### After
<img width="415" alt="Screenshot 2020-04-16 at 4 26 14 pm" src="https://user-images.githubusercontent.com/677833/79432916-11307d80-7fff-11ea-9721-dc81e37d67c1.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
