### PR TITLE
Try: Add social links option to inherit colors.

### DIFF
--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -1,8 +1,15 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 
-import { InnerBlocks } from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
+import { InnerBlocks, InspectorControls } from '@wordpress/block-editor';
+import { PanelBody, ToggleControl } from '@wordpress/components';
 
 const ALLOWED_BLOCKS = [ 'core/social-link' ];
 
@@ -19,16 +26,39 @@ const TEMPLATE = [
 	[ 'core/social-link', { service: 'youtube' } ],
 ];
 
-export const SocialLinksEdit = function( { className } ) {
+export const SocialLinksEdit = function( {
+	className,
+	attributes,
+	setAttributes,
+} ) {
+	const { inheritColors } = attributes;
+
 	return (
-		<div className={ className }>
-			<InnerBlocks
-				allowedBlocks={ ALLOWED_BLOCKS }
-				templateLock={ false }
-				template={ TEMPLATE }
-				__experimentalMoverDirection={ 'horizontal' }
-			/>
-		</div>
+		<>
+			<div
+				className={ classnames( className, {
+					'has-inherited-color': inheritColors,
+				} ) }
+			>
+				<InnerBlocks
+					allowedBlocks={ ALLOWED_BLOCKS }
+					templateLock={ false }
+					template={ TEMPLATE }
+					__experimentalMoverDirection={ 'horizontal' }
+				/>
+			</div>
+			<InspectorControls>
+				<PanelBody title={ __( 'Social Links settings' ) }>
+					<ToggleControl
+						label={ __( 'Inherit colors' ) }
+						checked={ !! inheritColors }
+						onChange={ () =>
+							setAttributes( { inheritColors: ! inheritColors } )
+						}
+					/>
+				</PanelBody>
+			</InspectorControls>
+		</>
 	);
 };
 

--- a/packages/block-library/src/social-links/save.js
+++ b/packages/block-library/src/social-links/save.js
@@ -1,9 +1,20 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { InnerBlocks } from '@wordpress/block-editor';
 
-export default function save( { className } ) {
+export default function save( { attributes } ) {
+	const { inheritColors } = attributes;
+
+	const className = classnames( className, {
+		'has-inherited-color': inheritColors,
+	} );
+
 	return (
 		<ul className={ className }>
 			<InnerBlocks.Content />

--- a/packages/block-library/src/social-links/style.scss
+++ b/packages/block-library/src/social-links/style.scss
@@ -414,3 +414,26 @@
 		padding-right: 16px;
 	}
 }
+
+// Inherit colors when checked.
+.wp-block-social-links.has-inherited-color {
+	// This then passes on the color inheritance.
+	.wp-social-link {
+		color: currentColor;
+		background-color: currentColor;
+
+		svg {
+			filter: invert(1);
+		}
+	}
+
+	&.is-style-logos-only {
+		.wp-social-link {
+			background: none;
+
+			svg {
+				filter: invert(0);
+			}
+		}
+	}
+}


### PR DESCRIPTION
This is incomplete, but a proof of concept to fixing #21605. 

It adds a toggle to the Social Links block, which allows it to inherit the text color of the theme. GIF:

![inherit colors](https://user-images.githubusercontent.com/1204802/79441130-2691b180-7fd7-11ea-9414-1408a15cfff0.gif)

It uses the trick that `currentColor` can inherit the colors of the text. In doing so, when this toggle is enabled, social links are monochrome colored according to the theme.

But it is only a proof of concept, there are some limitations:

- I did not manage to properly save the `inheritColors` attribute, so it's partially reset on a reload.
- `currentColor` only inherits the text color, and we obviously need to set the color of the SVG as well. For the time being, I simply chose to use `invert(1)` to take a dark color and make it light. But this is not desirable as it's not always a good color and definitely not contrasty.

However as a PR, this could probably be easily commandeered to add color support. Simply rename the "inherit colors" toggle to "custom colors", then let that toggle unlock a customizable foreground and background color. The CSS to colorize the SVGs should be easy! 

Any volunteer adopters? @gziolo want to work with me on this?