### PR TITLE
Fix buttons styling for old markup

### DIFF
--- a/packages/block-library/src/button/style.scss
+++ b/packages/block-library/src/button/style.scss
@@ -1,6 +1,8 @@
 $blocks-button__height: 56px;
 
-.wp-block-button {
+// Prefer the link selector instead of the regular button classname
+// to support the previous markup in addition to the new one.
+.wp-block-button__link {
 	color: $white;
 	background-color: $dark-gray-700;
 	border: none;
@@ -32,15 +34,22 @@ $blocks-button__height: 56px;
 	}
 }
 
-.wp-block-button.is-style-squared {
+// the first selector is required for old buttons markup
+.wp-block-button.is-style-squared,
+.wp-block-button__link.wp-block-button.is-style-squared {
 	border-radius: 0;
 }
 
-.wp-block-button.no-border-radius {
+
+// the first selector is required for old buttons markup
+
+.wp-block-button.no-border-radius,
+.wp-block-button__link.wp-block-button.no-border-radius {
 	border-radius: 0 !important;
 }
 
-.wp-block-button.is-style-outline {
+.wp-block-button.is-style-outline,
+.wp-block-button__link.is-style-outline {
 	color: $dark-gray-700;
 	background-color: transparent;
 	border: 2px solid;


### PR DESCRIPTION
closes #21624

This PR makes sure the styling of the buttons stay correct even if applied on the previous buttons markup.

**Testing instructions**

 - Insert a button block with the plugin disabled, publish the post
 - Enable the plugin and this PR
 - Make sure the button shows up properly on the frontend.