### PR TITLE
Polish code editor.

### DIFF
--- a/packages/edit-post/src/components/text-editor/index.js
+++ b/packages/edit-post/src/components/text-editor/index.js
@@ -11,17 +11,16 @@ import { withDispatch, withSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { displayShortcut } from '@wordpress/keycodes';
 import { compose } from '@wordpress/compose';
-import { close } from '@wordpress/icons';
 
 function TextEditor( { onExit, isRichEditingEnabled } ) {
 	return (
 		<div className="edit-post-text-editor">
 			{ isRichEditingEnabled && (
 				<div className="edit-post-text-editor__toolbar">
-					<h2>{ __( 'Editing Code' ) }</h2>
+					<h2>{ __( 'Editing code' ) }</h2>
 					<Button
+						isTertiary
 						onClick={ onExit }
-						icon={ close }
 						shortcut={ displayShortcut.secondary( 'm' ) }
 					>
 						{ __( 'Exit code editor' ) }

--- a/packages/edit-post/src/components/text-editor/style.scss
+++ b/packages/edit-post/src/components/text-editor/style.scss
@@ -5,7 +5,7 @@
 	flex-grow: 1;
 
 	// Always show outlines in code editor
-	.editor-post-title {
+	.wp-block.editor-post-title {
 		max-width: none;
 
 		textarea {
@@ -13,9 +13,8 @@
 			margin-bottom: -$border-width;
 			padding: $grid-unit-20;
 
-			&:focus,
-			&:hover {
-				border: $border-width solid $black;
+			&:focus {
+				border: $border-width solid $dark-gray-primary;
 			}
 		}
 
@@ -55,16 +54,17 @@
 
 .edit-post-text-editor__body {
 	width: 100%;
-	padding: $grid-unit-20;
+	padding: $grid-unit-20 $grid-unit-20 $grid-unit-60 $grid-unit-20;
 	max-width: $break-wide;
 	margin-left: auto;
 	margin-right: auto;
 
 	@include break-large() {
-		padding: $grid-unit-20 $grid-unit-60;
+		padding: $grid-unit-20 $grid-unit-60 #{ $grid-unit-60 * 2 } $grid-unit-60;
 	}
 
-	.editor-post-title__input {
+	// This needs specificity to change the title block appearance on the code editor.
+	.editor-post-title__input.editor-post-title__input.editor-post-title__input {
 		font-family: $editor-html-font;
 		font-size: 2em;
 	}

--- a/packages/edit-post/src/components/text-editor/style.scss
+++ b/packages/edit-post/src/components/text-editor/style.scss
@@ -6,10 +6,12 @@
 
 	// Always show outlines in code editor
 	.editor-post-title {
+		max-width: none;
+
 		textarea {
-			border: $border-width solid $light-gray-500;
-			margin-bottom: $block-spacing;
-			padding: $block-padding;
+			border: $border-width solid $light-gray-secondary;
+			margin-bottom: -$border-width;
+			padding: $grid-unit-20;
 
 			&:focus,
 			&:hover {
@@ -29,18 +31,21 @@
 // Exit code editor toolbar.
 .edit-post-text-editor__toolbar {
 	position: absolute;
-	top: $grid-unit-10;
+	top: 0;
 	left: 0;
 	right: 0;
-	height: $block-toolbar-height;
-	line-height: $block-toolbar-height;
-	padding: 0 $grid-unit-10 0 $grid-unit-20;
+	padding: $grid-unit-15 $grid-unit-30;
 	display: flex;
 
+	@include break-large() {
+		padding: $grid-unit-15 $grid-unit-60;
+	}
+
 	h2 {
+		line-height: $button-size;
 		margin: 0 auto 0 0;
 		font-size: $default-font-size;
-		color: $dark-gray-500;
+		color: $dark-gray-primary;
 	}
 
 	.components-button svg {
@@ -49,14 +54,18 @@
 }
 
 .edit-post-text-editor__body {
-	max-width: calc(100% - #{$grid-unit-20 * 2});
-	margin-left: $grid-unit-20;
-	margin-right: $grid-unit-20;
-	padding-top: $grid-unit-50;
+	width: 100%;
+	padding: $grid-unit-20;
+	max-width: $break-wide;
+	margin-left: auto;
+	margin-right: auto;
 
-	@include break-small() {
-		max-width: $content-width;
-		margin-left: auto;
-		margin-right: auto;
+	@include break-large() {
+		padding: $grid-unit-20 $grid-unit-60;
+	}
+
+	.editor-post-title__input {
+		font-family: $editor-html-font;
+		font-size: 2em;
 	}
 }

--- a/packages/edit-post/src/components/text-editor/style.scss
+++ b/packages/edit-post/src/components/text-editor/style.scss
@@ -33,11 +33,11 @@
 	top: 0;
 	left: 0;
 	right: 0;
-	padding: $grid-unit-15 $grid-unit-30;
+	padding: $grid-unit-15;
 	display: flex;
 
 	@include break-large() {
-		padding: $grid-unit-15 $grid-unit-60;
+		padding: $grid-unit-15 $grid-unit-30;
 	}
 
 	h2 {
@@ -54,13 +54,13 @@
 
 .edit-post-text-editor__body {
 	width: 100%;
-	padding: $grid-unit-20 $grid-unit-20 $grid-unit-60 $grid-unit-20;
+	padding: $grid-unit-20 $grid-unit-15 $grid-unit-60 $grid-unit-15;
 	max-width: $break-wide;
 	margin-left: auto;
 	margin-right: auto;
 
 	@include break-large() {
-		padding: $grid-unit-20 $grid-unit-60 #{ $grid-unit-60 * 2 } $grid-unit-60;
+		padding: $grid-unit-20 $grid-unit-30 #{ $grid-unit-60 * 2 } $grid-unit-30;
 	}
 
 	// This needs specificity to change the title block appearance on the code editor.

--- a/packages/editor/src/components/post-text-editor/style.scss
+++ b/packages/editor/src/components/post-text-editor/style.scss
@@ -18,7 +18,6 @@
 		font-size: $text-editor-font-size !important;
 	}
 
-	&:hover,
 	&:focus {
 		border: $border-width solid $dark-gray-primary;
 		box-shadow: none;

--- a/packages/editor/src/components/post-text-editor/style.scss
+++ b/packages/editor/src/components/post-text-editor/style.scss
@@ -1,14 +1,16 @@
-.editor-post-text-editor {
-	border: $border-width solid $light-gray-500 !important;
+.edit-post-text-editor__body textarea.editor-post-text-editor {
+	border: $border-width solid $light-gray-secondary;
 	display: block;
-	margin: 0 0 2em;
+	margin: 0;
 	width: 100%;
 	box-shadow: none;
 	resize: none;
 	overflow: hidden;
-	font-family: $editor-html-font !important;
+	font-family: $editor-html-font;
 	line-height: 150%;
-	border-radius: 0 !important;
+	border-radius: 0;
+	padding: $grid-unit-20;
+	min-height: 200px;
 
 	/* Fonts smaller than 16px causes mobile safari to zoom. */
 	font-size: $mobile-text-min-font-size !important;
@@ -18,54 +20,10 @@
 
 	&:hover,
 	&:focus {
-		border: $border-width solid $dark-gray-primary !important;
-		box-shadow: none !important;
-		// Emulate the effect used on the post title.
-		outline-offset: -2px !important;
+		border: $border-width solid $dark-gray-primary;
+		box-shadow: none;
+
+		// Elevate the z-index on focus so the focus style is uncropped.
+		position: relative;
 	}
-}
-
-.editor-post-text-editor__toolbar {
-	display: flex;
-	flex-direction: row;
-	flex-wrap: wrap;
-
-	button {
-		height: 30px;
-		background: none;
-		padding: 0 8px;
-		margin: 3px 4px;
-		text-align: center;
-		cursor: pointer;
-		font-family: $editor-html-font;
-		color: $dark-gray-500;
-		border: $border-width solid transparent;
-
-		&:first-child {
-			margin-left: 0;
-		}
-
-		&:hover,
-		&:focus {
-			outline: none;
-			border: $border-width solid $dark-gray-500;
-		}
-	}
-}
-
-.editor-post-text-editor__bold {
-	font-weight: 600;
-}
-
-.editor-post-text-editor__italic {
-	font-style: italic;
-}
-
-.editor-post-text-editor__link {
-	text-decoration: underline;
-	color: theme(primary);
-}
-
-.editor-post-text-editor__del {
-	text-decoration: line-through;
 }

--- a/packages/editor/src/components/post-title/index.js
+++ b/packages/editor/src/components/post-title/index.js
@@ -72,6 +72,7 @@ class PostTitle extends Component {
 		const { isSelected } = this.state;
 
 		// The wp-block className is important for editor styles.
+		// This same block is used in both the visual and the code editor.
 		const className = classnames(
 			'wp-block editor-post-title editor-post-title__block',
 			{


### PR DESCRIPTION
Fixes #21576.

This PR improves the code editor by embracing what it is, a code editor. That means a code font also for the title, and an editor that resizes to the viewport.

Before:

<img width="1021" alt="Screenshot 2020-04-16 at 12 57 52" src="https://user-images.githubusercontent.com/1204802/79448549-e683fc00-7fe1-11ea-9b95-9e87236256d0.png">

After:

![after](https://user-images.githubusercontent.com/1204802/79448556-e8e65600-7fe1-11ea-8ae9-e38bf347e4b9.gif)

It also removes a bunch of dead code.