### PR TITLE
Docs: Add location for components style.css

### DIFF
--- a/docs/designers-developers/developers/platform/README.md
+++ b/docs/designers-developers/developers/platform/README.md
@@ -29,7 +29,6 @@ function MyApp() {
 
 Many components include CSS to add style, you will need to include for the components to appear correctly. The component stylesheet can be found in `node_modules/@wordpress/components/build-style/style.css`, you can link directly or copy and include it in your project.
 
-
 ## Development Scripts
 
 The [wp-scripts package](https://developer.wordpress.org/block-editor/packages/packages-scripts/) is a collection of reusable scripts for JavaScript development — includes scripts for building, linting, and testing — all with no additional configuration files.

--- a/docs/designers-developers/developers/platform/README.md
+++ b/docs/designers-developers/developers/platform/README.md
@@ -27,6 +27,9 @@ function MyApp() {
 }
 ```
 
+Many components include CSS to add style, you will need to include for the components to appear correctly. The component stylesheet can be found in `node_modules/@wordpress/components/build-style/style.css`, you can link directly or copy and include it in your project.
+
+
 ## Development Scripts
 
 The [wp-scripts package](https://developer.wordpress.org/block-editor/packages/packages-scripts/) is a collection of reusable scripts for JavaScript development — includes scripts for building, linting, and testing — all with no additional configuration files.

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -27,6 +27,8 @@ export default function MyButton() {
 }
 ```
 
-Many components also include styles which will need to be output in order to appear correctly. Within WordPress, you can [add the `wp-components` stylesheet as a dependency of your plugin's stylesheet](https://developer.wordpress.org/reference/functions/wp_enqueue_style/#parameters). In other projects, you can link to the `build-style/style.css` file directly.
+Many components include CSS to add style, you will need to add in order to appear correctly. Within WordPress, add the `wp-components` stylesheet as a dependency of your plugin's stylesheet. See [wp_enqueue_style documentation](https://developer.wordpress.org/reference/functions/wp_enqueue_style/#parameters) for how to specify dependencies.
+
+In non-WordPress projects, link to the `build-style/style.css` file directly, it is located at `node_modules/@wordpress/components/build-style/style.css`.
 
 <br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>


### PR DESCRIPTION
## Description

The documentation mentions linking to the `build-style/style.css` but did not specify where this file could be found. This PR adds the file location within node_modules, and adds the additional information to the Gutenberg as a Platform document.


## Types of changes

Documentation.
