### PR TITLE
Fix: Visual issue on windows with 782px

### DIFF
--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -151,13 +151,13 @@
 	#{$selector} { /* Set left position when auto-fold is not on the body element. */
 		left: 0;
 
-		@include break-medium() {
+		@media (min-width: #{ ($break-medium + 1) }) {
 			left: $admin-sidebar-width;
 		}
 	}
 
 	.auto-fold #{$selector} { /* Auto fold is when on smaller breakpoints, nav menu auto collapses. */
-		@include break-medium() {
+		@media (min-width: #{ ($break-medium + 1) }) {
 			left: $admin-sidebar-width-collapsed;
 		}
 
@@ -170,13 +170,13 @@
 	.folded #{$selector} {
 		left: 0;
 
-		@include break-medium() {
+		@media (min-width: #{ ($break-medium + 1) }) {
 			left: $admin-sidebar-width-collapsed;
 		}
 	}
 
 	/* Mobile menu opened. */
-	@media (max-width: #{ ($break-medium) }) {
+	@media (max-width: #{ ($break-medium + 1) }) {
 		.auto-fold .wp-responsive-open #{$selector} {
 			left: $admin-sidebar-width-big;
 		}

--- a/packages/interface/src/components/interface-skeleton/style.scss
+++ b/packages/interface/src/components/interface-skeleton/style.scss
@@ -24,7 +24,7 @@ html.interface-interface-skeleton__html-container {
 	bottom: 0;
 
 	// Adjust to admin-bar going small.
-	@include break-medium() {
+	@media (min-width: #{ ($break-medium + 1) }) {
 		top: $admin-bar-height;
 
 		.is-fullscreen-mode & {


### PR DESCRIPTION
## Description
Fixes: https://github.com/WordPress/gutenberg/issues/19011

Before:
![image](https://user-images.githubusercontent.com/11271197/79495460-85c5e500-801c-11ea-849b-2105e3292c6f.png)


After:
![image](https://user-images.githubusercontent.com/11271197/79495148-10f2ab00-801c-11ea-9a1d-14696547fc5e.png)


## How has this been tested?
I opened the editor in a 782px window.
I switched to a non-fullscreen mode.
I verified there was no empty space at the left and that the top of the editor looked right.
