### PR TITLE
Submenu nesting and saving new nested items.

### DIFF
--- a/lib/class-wp-rest-menu-items-controller.php
+++ b/lib/class-wp-rest-menu-items-controller.php
@@ -440,13 +440,13 @@ class WP_REST_Menu_Items_Controller extends WP_REST_Posts_Controller {
 			$menu_items = wp_get_nav_menu_items( $prepared_nav_item['menu-id'], array( 'post_status' => 'publish,draft' ) );
 			if ( 0 === (int) $prepared_nav_item['menu-item-position'] ) {
 				if ( $menu_items ) {
-					$last_item = $menu_items[count( $menu_items ) - 1];
+					$last_item = $menu_items[ count( $menu_items ) - 1 ];
 					if ( $last_item && isset( $last_item->menu_order ) ) {
 						$prepared_nav_item['menu-item-position'] = $last_item->menu_order + 1;
 					} else {
 						$prepared_nav_item['menu-item-position'] = count( $menu_items ) - 1;
 					}
-					array_push($menu_items,$last_item);
+					array_push( $menu_items, $last_item );
 				} else {
 					$prepared_nav_item['menu-item-position'] = 1;
 				}

--- a/lib/class-wp-rest-menu-items-controller.php
+++ b/lib/class-wp-rest-menu-items-controller.php
@@ -440,11 +440,11 @@ class WP_REST_Menu_Items_Controller extends WP_REST_Posts_Controller {
 			$menu_items = wp_get_nav_menu_items( $prepared_nav_item['menu-id'], array( 'post_status' => 'publish,draft' ) );
 			if ( 0 === (int) $prepared_nav_item['menu-item-position'] ) {
 				if ( $menu_items ) {
-					$last_item = array_pop( $menu_items );
+					$last_item = $menu_items[count( $menu_items ) - 1];
 					if ( $last_item && isset( $last_item->menu_order ) ) {
 						$prepared_nav_item['menu-item-position'] = $last_item->menu_order + 1;
 					} else {
-						$prepared_nav_item['menu-item-position'] = count( $menu_items );
+						$prepared_nav_item['menu-item-position'] = count( $menu_items ) - 1;
 					}
 					array_push($menu_items,$last_item);
 				} else {

--- a/lib/class-wp-rest-menu-items-controller.php
+++ b/lib/class-wp-rest-menu-items-controller.php
@@ -446,6 +446,7 @@ class WP_REST_Menu_Items_Controller extends WP_REST_Posts_Controller {
 					} else {
 						$prepared_nav_item['menu-item-position'] = count( $menu_items );
 					}
+					array_push($menu_items,$last_item);
 				} else {
 					$prepared_nav_item['menu-item-position'] = 1;
 				}
@@ -457,7 +458,7 @@ class WP_REST_Menu_Items_Controller extends WP_REST_Posts_Controller {
 				$menu_item_ids[] = $menu_item->ID;
 				if ( $menu_item->ID !== (int) $menu_item_db_id ) {
 					if ( (int) $prepared_nav_item['menu-item-position'] === (int) $menu_item->menu_order ) {
-						return new WP_Error( 'invalid_menu_order', __( 'Invalid menu position.', 'gutenberg' ), array( 'status' => 400 ) );
+						return new WP_Error( 'invalid_menu_order', __( print_r($menu_item).'Invalid menu position.', 'gutenberg' ), array( 'status' => 400 ) );
 					}
 				}
 			}

--- a/lib/class-wp-rest-menu-items-controller.php
+++ b/lib/class-wp-rest-menu-items-controller.php
@@ -458,7 +458,7 @@ class WP_REST_Menu_Items_Controller extends WP_REST_Posts_Controller {
 				$menu_item_ids[] = $menu_item->ID;
 				if ( $menu_item->ID !== (int) $menu_item_db_id ) {
 					if ( (int) $prepared_nav_item['menu-item-position'] === (int) $menu_item->menu_order ) {
-						return new WP_Error( 'invalid_menu_order', __( print_r($menu_item).'Invalid menu position.', 'gutenberg' ), array( 'status' => 400 ) );
+						return new WP_Error( 'invalid_menu_order', __( 'Invalid menu position.', 'gutenberg' ), array( 'status' => 400 ) );
 					}
 				}
 			}

--- a/packages/edit-navigation/src/components/menu-editor/use-navigation-blocks.js
+++ b/packages/edit-navigation/src/components/menu-editor/use-navigation-blocks.js
@@ -80,21 +80,19 @@ export default function useNavigationBlocks( menuId ) {
 
 		const saveNestedBlocks = ( nestedBlocks, parentId ) => {
 			for ( const block of nestedBlocks ) {
-				if ( block.innerBlocks.length ) {
-					saveNestedBlocks( block.innerBlocks, block.clientId );
-				}
 				const menuItem = menuItemsRef.current[ block.clientId ];
 				const parentItemId = menuItemsRef.current[ parentId ]?.id;
+
 				if ( ! menuItem ) {
 					saveMenuItem( {
 						...createMenuItemAttributesFromBlock( block ),
 						menus: menuId,
 						parent: parentItemId || 0,
 					} );
-					continue;
 				}
 
 				if (
+					menuItem &&
 					! isEqual(
 						block.attributes,
 						createBlockFromMenuItem( menuItem ).attributes
@@ -105,6 +103,10 @@ export default function useNavigationBlocks( menuId ) {
 						...createMenuItemAttributesFromBlock( block ),
 						menus: menuId, // Gotta do this because REST API doesn't like receiving an array here. Maybe a bug in the REST API?
 					} );
+				}
+
+				if ( block.innerBlocks.length ) {
+					saveNestedBlocks( block.innerBlocks, block.clientId );
 				}
 			}
 		};

--- a/packages/edit-navigation/src/components/menu-editor/use-navigation-blocks.js
+++ b/packages/edit-navigation/src/components/menu-editor/use-navigation-blocks.js
@@ -89,7 +89,7 @@ export default function useNavigationBlocks( menuId ) {
 						...createMenuItemAttributesFromBlock( block ),
 						menus: menuId,
 						parent: parentId,
-					} ).then( ( result ) => result );
+					} );
 					if ( block.innerBlocks.length ) {
 						currentItemId = savedItem.id;
 					}
@@ -106,6 +106,7 @@ export default function useNavigationBlocks( menuId ) {
 						...menuItem,
 						...createMenuItemAttributesFromBlock( block ),
 						menus: menuId, // Gotta do this because REST API doesn't like receiving an array here. Maybe a bug in the REST API?
+						parent: parentId,
 					} );
 				}
 

--- a/packages/edit-navigation/src/components/menu-editor/use-navigation-blocks.js
+++ b/packages/edit-navigation/src/components/menu-editor/use-navigation-blocks.js
@@ -10,11 +10,15 @@ import { createBlock } from '@wordpress/blocks';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useState, useRef, useEffect } from '@wordpress/element';
 
-function createBlockFromMenuItem( menuItem ) {
-	return createBlock( 'core/navigation-link', {
-		label: menuItem.title.raw,
-		url: menuItem.url,
-	} );
+function createBlockFromMenuItem( menuItem, innerBlocks = [] ) {
+	return createBlock(
+		'core/navigation-link',
+		{
+			label: menuItem.title.rendered,
+			url: menuItem.url,
+		},
+		innerBlocks
+	);
 }
 
 function createMenuItemAttributesFromBlock( block ) {
@@ -26,7 +30,8 @@ function createMenuItemAttributesFromBlock( block ) {
 
 export default function useNavigationBlocks( menuId ) {
 	const menuItems = useSelect(
-		( select ) => select( 'core' ).getMenuItems( { menus: menuId } ),
+		( select ) =>
+			select( 'core' ).getMenuItems( { menus: menuId, per_page: -1 } ),
 		[ menuId ]
 	);
 
@@ -41,46 +46,76 @@ export default function useNavigationBlocks( menuId ) {
 			return;
 		}
 
+		const itemIndex = {};
+		menuItems.forEach( ( item ) => {
+			if ( ! itemIndex[ item.parent ] ) {
+				itemIndex[ item.parent ] = [];
+			}
+			itemIndex[ item.parent ].push( item );
+		} );
+
 		menuItemsRef.current = {};
 
-		const innerBlocks = [];
+		const createMenuItemBlocks = ( items ) => {
+			const innerBlocks = [];
+			for ( const item of items ) {
+				let menuItemInnerBlocks = [];
+				if ( itemIndex[ item.id ] && itemIndex[ item.id ].length > 0 ) {
+					menuItemInnerBlocks = createMenuItemBlocks(
+						itemIndex[ item.id ]
+					);
+				}
+				const block = createBlockFromMenuItem(
+					item,
+					menuItemInnerBlocks
+				);
+				menuItemsRef.current[ block.clientId ] = item;
+				innerBlocks.push( block );
+			}
+			return innerBlocks;
+		};
 
-		for ( const menuItem of menuItems ) {
-			const block = createBlockFromMenuItem( menuItem );
-			menuItemsRef.current[ block.clientId ] = menuItem;
-			innerBlocks.push( block );
-		}
-
+		const innerBlocks = createMenuItemBlocks( itemIndex[ 0 ] );
 		setBlocks( [ createBlock( 'core/navigation', {}, innerBlocks ) ] );
 	}, [ menuItems ] );
 
 	const saveBlocks = () => {
-		const { innerBlocks } = blocks[ 0 ];
+		const { clientId, innerBlocks } = blocks[ 0 ];
 
-		for ( const block of innerBlocks ) {
-			const menuItem = menuItemsRef.current[ block.clientId ];
+		const saveNestedBlocks = ( nestedBlocks, parentId ) => {
+			for ( const block of nestedBlocks ) {
+				if ( block.innerBlocks && block.innerBlocks.length > 0 ) {
+					saveNestedBlocks( block.innerBlocks, block.clientId );
+				}
+				const menuItem = menuItemsRef.current[ block.clientId ];
+				const parentItemId =
+					menuItemsRef.current[ parentId ] &&
+					menuItemsRef.current[ parentId ].id;
+				if ( ! menuItem ) {
+					saveMenuItem( {
+						...createMenuItemAttributesFromBlock( block ),
+						menus: menuId,
+						parent: parentItemId || 0,
+					} );
+					continue;
+				}
 
-			if ( ! menuItem ) {
-				saveMenuItem( {
-					...createMenuItemAttributesFromBlock( block ),
-					menus: menuId,
-				} );
-				continue;
+				if (
+					! isEqual(
+						block.attributes,
+						createBlockFromMenuItem( menuItem ).attributes
+					)
+				) {
+					saveMenuItem( {
+						...menuItem,
+						...createMenuItemAttributesFromBlock( block ),
+						menus: menuId, // Gotta do this because REST API doesn't like receiving an array here. Maybe a bug in the REST API?
+					} );
+				}
 			}
+		};
 
-			if (
-				! isEqual(
-					block.attributes,
-					createBlockFromMenuItem( menuItem ).attributes
-				)
-			) {
-				saveMenuItem( {
-					...menuItem,
-					...createMenuItemAttributesFromBlock( block ),
-					menus: menuId, // Gotta do this because REST API doesn't like receiving an array here. Maybe a bug in the REST API?
-				} );
-			}
-		}
+		saveNestedBlocks( innerBlocks, clientId );
 
 		const deletedClientIds = difference(
 			Object.keys( menuItemsRef.current ),
@@ -89,7 +124,7 @@ export default function useNavigationBlocks( menuId ) {
 
 		// Disable reason, this code will eventually be implemented.
 		// eslint-disable-next-line no-unused-vars
-		for ( const clientId of deletedClientIds ) {
+		for ( const deletedClientId of deletedClientIds ) {
 			// TODO - delete menu items.
 		}
 	};


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

Closes #21590 and #21593

Added ability to render submenus as nested, and save nested items, in the experimental navigation page.

TODO:  Render new nested items in the correct order (currently they're appended to the end of the list).

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Tested in browser.

## Screenshots <!-- if applicable -->

<img width="1085" alt="Screen Shot 2020-04-17 at 5 27 03 pm" src="https://user-images.githubusercontent.com/8096000/79543429-c97a2680-80d0-11ea-8962-95ef3bd26581.png">

We might need some styling fixes for this 🙀 :

<img width="1028" alt="Screen Shot 2020-04-17 at 5 27 26 pm" src="https://user-images.githubusercontent.com/8096000/79543466-d860d900-80d0-11ea-91ba-fdf2ddc1df58.png">


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
