### PR TITLE
Revert introduction of useApiFetch hook and associated changes to Core Navigation block data fetching.

### DIFF
--- a/packages/api-fetch/src/index.js
+++ b/packages/api-fetch/src/index.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useEffect, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -157,42 +156,6 @@ function apiFetch( options ) {
 	} );
 }
 
-/**
- * Function that fetches data using apiFetch, and updates the status.
- *
- * @param {string} path Query path.
- */
-function useApiFetch( path ) {
-	// Indicate the fetching status
-	const [ isLoading, setIsLoading ] = useState( true );
-	const [ data, setData ] = useState( null );
-	const [ error, setError ] = useState( null );
-
-	useEffect( () => {
-		setIsLoading( true );
-		setData( null );
-		setError( null );
-
-		apiFetch( { path } )
-			.then( ( fetchedData ) => {
-				setData( fetchedData );
-				// We've stopped fetching
-				setIsLoading( false );
-			} )
-			.catch( ( err ) => {
-				setError( err );
-				// We've stopped fetching
-				setIsLoading( false );
-			} );
-	}, [ path ] );
-
-	return {
-		isLoading,
-		data,
-		error,
-	};
-}
-
 apiFetch.use = registerMiddleware;
 apiFetch.setFetchHandler = setFetchHandler;
 
@@ -201,7 +164,5 @@ apiFetch.createPreloadingMiddleware = createPreloadingMiddleware;
 apiFetch.createRootURLMiddleware = createRootURLMiddleware;
 apiFetch.fetchAllMiddleware = fetchAllMiddleware;
 apiFetch.mediaUploadMiddleware = mediaUploadMiddleware;
-
-apiFetch.useApiFetch = useApiFetch;
 
 export default apiFetch;

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -32,8 +32,7 @@ import {
 import { compose } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { menu } from '@wordpress/icons';
-import { addQueryArgs } from '@wordpress/url';
-import { useApiFetch } from '@wordpress/api-fetch';
+
 /**
  * Internal dependencies
  */
@@ -47,6 +46,9 @@ function Navigation( {
 	clientId,
 	fontSize,
 	hasExistingNavItems,
+	hasResolvedPages,
+	isRequestingPages,
+	pages,
 	setAttributes,
 	setFontSize,
 	updateNavItemBlocks,
@@ -55,6 +57,7 @@ function Navigation( {
 	//
 	// HOOKS
 	//
+	/* eslint-disable @wordpress/no-unused-vars-before-return */
 	const ref = useRef();
 	const { selectBlock } = useDispatch( 'core/block-editor' );
 	const { TextColor, BackgroundColor, ColorPanel } = __experimentalUseColors(
@@ -78,35 +81,14 @@ function Navigation( {
 		[ fontSize.size ]
 	);
 
+	/* eslint-enable @wordpress/no-unused-vars-before-return */
 	const { navigatorToolbarButton, navigatorModal } = useBlockNavigator(
 		clientId
 	);
 
-	const baseUrl = '/wp/v2/pages';
-
-	// "view" is required to ensure Pages are returned by REST API
-	// for users with lower capabilities such as "Contributor" otherwise
-	// Pages are not returned in the request if "edit" context is set
-	const context = 'view';
-
-	const filterDefaultPages = {
-		parent: 0,
-		order: 'asc',
-		orderby: 'id',
-		context,
-	};
-
-	const queryPath = addQueryArgs( baseUrl, filterDefaultPages );
-
-	const { isLoading: isRequestingPages, data: pages } = useApiFetch(
-		queryPath
-	);
-
-	const hasPages = !! pages;
-
 	// Builds navigation links from default Pages.
 	const defaultPagesNavigationItems = useMemo( () => {
-		if ( ! hasPages ) {
+		if ( ! pages ) {
 			return null;
 		}
 
@@ -145,6 +127,8 @@ function Navigation( {
 		updateNavItemBlocks( defaultPagesNavigationItems );
 		selectBlock( clientId );
 	}
+
+	const hasPages = hasResolvedPages && pages && pages.length;
 
 	const blockInlineStyles = {
 		fontSize: fontSize.size ? fontSize.size + 'px' : undefined,
@@ -307,8 +291,31 @@ export default compose( [
 	withSelect( ( select, { clientId } ) => {
 		const innerBlocks = select( 'core/block-editor' ).getBlocks( clientId );
 
+		const filterDefaultPages = {
+			parent: 0,
+			order: 'asc',
+			orderby: 'id',
+		};
+
+		const pagesSelect = [
+			'core',
+			'getEntityRecords',
+			[ 'postType', 'page', filterDefaultPages ],
+		];
+
 		return {
 			hasExistingNavItems: !! innerBlocks.length,
+			pages: select( 'core' ).getEntityRecords(
+				'postType',
+				'page',
+				filterDefaultPages
+			),
+			isRequestingPages: select( 'core/data' ).isResolving(
+				...pagesSelect
+			),
+			hasResolvedPages: select( 'core/data' ).hasFinishedResolution(
+				...pagesSelect
+			),
 		};
 	} ),
 	withDispatch( ( dispatch, { clientId } ) => {


### PR DESCRIPTION
This reverts commit f2b677851aed870fa8216861561b3ce0197c03c4 which was based on https://github.com/WordPress/gutenberg/pull/18669.

```
# Conflicts:
#	package-lock.json
#	packages/api-fetch/package.json
#	packages/block-library/src/navigation/edit.js
```

## Description

The commit which this PR reverts introduced 

1. (what I believe to be) A regression in the Core Navigation Block data fetching mechanics to prefer `apiFetch` over Core data entities.
2. A new hook  `useApiFetch` which unduly promotes the use of `apiFetch` as a "preferred" API.

The reason this needs to be reverted are:

1. [@aduth feels `apiFetch` should not be promoted as a first class API for data fetching](https://github.com/WordPress/gutenberg/pull/18669#issuecomment-607820349). Therefore we should not make it easy to use via hooks such as `useAPIFetch` which was introduced. @aduth suggested the hook should be removed.
2. The Navigation block's `edit` implementation was re-written to remove all entity based data fetching via Core Data mechanics in favour of `apiFetch`. This should be avoided for [the reasons I set out here](https://github.com/WordPress/gutenberg/pull/18869#issuecomment-607766171).

You can also [read more about why `apiFetch` might not be a good choice for data fetching](https://github.com/WordPress/gutenberg/pull/18669#discussion_r401863653).

The only issue with reverting this PR is that we lose [the fix to the `context` parameter](https://github.com/WordPress/gutenberg/commit/f2b677851aed870fa8216861561b3ce0197c03c4#diff-cfe334a821ad12721a129f61005669c3R95-R98) which you can read about in [the original PR descriptio](https://github.com/WordPress/gutenberg/pull/18669#issue-344046661). We could raise a followup PR to try and restore this functionality if desired.

## How has this been tested?
* Check Nav Block still works as expected (as it does on `master`). This revert should cause no regressions.


## Types of changes
Breaking change (fix or feature that would cause existing functionality to not work as expected).

This **removes a public API** in the `useApiFetch` hook. 

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
