### PR TITLE
Asynchronously load tinyMCE the first time a classic block is edited

### DIFF
--- a/packages/block-library/src/classic/edit.js
+++ b/packages/block-library/src/classic/edit.js
@@ -5,6 +5,11 @@ import { Component } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
 import { BACKSPACE, DELETE, F10 } from '@wordpress/keycodes';
 
+/**
+ * Internal dependencies
+ */
+import LazyLoad from './lazy';
+
 const { wp } = window;
 
 function isTmceEmpty( editor ) {
@@ -23,7 +28,7 @@ function isTmceEmpty( editor ) {
 	return /^\n?$/.test( body.innerText || body.textContent );
 }
 
-export default class ClassicEdit extends Component {
+class ClassicEdit extends Component {
 	constructor( props ) {
 		super( props );
 		this.initialize = this.initialize.bind( this );
@@ -216,3 +221,16 @@ export default class ClassicEdit extends Component {
 		/* eslint-enable jsx-a11y/no-static-element-interactions */
 	}
 }
+
+const LazyClassicEdit = ( props ) => (
+	<LazyLoad
+		scripts={ [ 'wp-tinymce' ] }
+		styles={ [ 'wp-tinymce' ] }
+		onLoaded={ () => window.wpMceTranslation() }
+		placeholder={ <div>Loading...</div> }
+	>
+		<ClassicEdit { ...props } />
+	</LazyLoad>
+);
+
+export default LazyClassicEdit;

--- a/packages/block-library/src/classic/lazy.js
+++ b/packages/block-library/src/classic/lazy.js
@@ -1,0 +1,89 @@
+/**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
+
+/**
+ * External dependencies
+ */
+import { noop } from 'lodash';
+
+export default class LazyLoad extends Component {
+	static loadedScripts = new Set();
+	static loadedStyles = new Set();
+	static defaultProps = {
+		scripts: [],
+		styles: [],
+		placeholder: null,
+		onLoaded: () => Promise.resolve(),
+		onError: noop,
+	};
+
+	state = {
+		loaded: false,
+	};
+
+	loadScripts = async () => {
+		const scriptsToLoad = this.props.scripts.filter(
+			( script ) => ! this.loadedScripts.has( script )
+		);
+
+		if ( scriptsToLoad.length === 0 ) {
+			return Promise.resolve();
+		}
+
+		await new Promise( ( resolve, reject ) => {
+			const scriptElement = document.createElement( 'script' );
+			// can't use load-scripts.php, so this would need to be replaced
+			scriptElement.src = `/wp-admin/load-scripts.php?load=${ scriptsToLoad.join(
+				','
+			) }`;
+			scriptElement.onload = resolve;
+			scriptElement.onerror = reject;
+			document.head.appendChild( scriptElement );
+		} );
+
+		scriptsToLoad.forEach( ( script ) => this.loadedScripts.add( script ) );
+	};
+
+	loadStyles = async () => {
+		const stylesToLoad = this.props.styles.filter(
+			( style ) => ! this.loadedStyles.has( style )
+		);
+
+		if ( stylesToLoad.length === 0 ) {
+			return Promise.resolve();
+		}
+
+		await new Promise( ( resolve, reject ) => {
+			const linkElement = document.createElement( 'link' );
+			linkElement.rel = 'stylesheet';
+			// can't use load-styles.php, so this would need to be replaced
+			linkElement.href = `/wp-admin/load-styles.php?load=${ stylesToLoad.join(
+				','
+			) }`;
+			linkElement.onload = resolve;
+			linkElement.onerror = reject;
+			document.head.appendChild( linkElement );
+		} );
+
+		stylesToLoad.forEach( ( style ) => this.loadedStyles.add( style ) );
+	};
+
+	componentDidMount() {
+		Promise.all( [ this.loadScripts(), this.loadStyles() ] )
+			.then( this.props.onLoaded )
+			.then( () => {
+				this.setState( { loaded: true } );
+			} )
+			.catch( this.props.onError );
+	}
+
+	render() {
+		if ( this.state.loaded ) {
+			return this.props.children;
+		}
+
+		return this.props.placeholder;
+	}
+}


### PR DESCRIPTION
## Description

Added `LazyLoad` component. This component allows us to wrap existing components and delay them until required 3rd party scripts and styles are asynchronously loaded. It also provides a hook for post-load setup that resolves before the children are rendered, guaranteeing that the children aren't active until the world around them is set up correctly.

I've then wrapped `ClassicEdit` in `LazyLoad`. This 100% does not work and is just a proof of concept.

A related PR: https://github.com/WordPress/gutenberg/pull/21244

We'd replace `load-scripts/styles` in the current code here with requests to those endpoints.

## Types of changes
New feature

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
