### PR TITLE
ESLint Plugin: Introduce rule `json-schema-no-plain-object-types`

### DIFF
--- a/packages/eslint-plugin/docs/rules/json-schema-no-plain-object-types.md
+++ b/packages/eslint-plugin/docs/rules/json-schema-no-plain-object-types.md
@@ -1,0 +1,88 @@
+# Require all "object" types within a block's attributes to define their expected properties (json-schema-no-plain-object-types)
+
+Block attributes must conform to types as specified in the [WordPress REST API documentation](https://developer.wordpress.org/rest-api/extending-the-rest-api/schema/), a behavior based on [JSON Schema](http://json-schema.org/). This schema is used to validate attribute data not only in the REST API, but [also in the block editor](https://developer.wordpress.org/block-editor/developers/block-api/block-attributes/#attribute-type-validation).
+
+This rule requires that any declaration of an `object` type specify the exact properties that make up the object. This applies to the type of attributes themselves as well as any data within an attribute, such as when an attribute of type `array` expects values of type `object`.
+
+## Rule details
+
+Examples of **incorrect** code for this rule:
+
+```js
+{
+    "name": "my/gallery",
+    "category": "widgets",
+    "attributes": {
+        "images": {
+            "type": "object"
+        }
+    }
+}
+```
+
+```js
+{
+    "name": "my/gallery",
+    "category": "widgets",
+    "attributes": {
+        "images": {
+            "type": "array",
+            "items": {
+                "type": "object"
+            }
+        }
+    }
+}
+```
+
+Examples of **correct** code for this rule:
+
+```js
+{
+    "name": "my/gallery",
+    "category": "widgets",
+    "attributes": {
+        "images": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "number"
+                    },
+                    "width": {
+                        "type": "number"
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+```js
+{
+    "name": "my/gallery",
+    "category": "widgets",
+    "attributes": {
+        "images": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "number"
+                    },
+                    "width": {
+                        "type": "number"
+                    }
+                },
+                "required": [
+                    "id", "width"
+                ],
+                "additionalProperties": false
+            }
+        }
+    }
+}
+```

--- a/packages/eslint-plugin/rules/__tests__/json-schema-no-plain-object-types.js
+++ b/packages/eslint-plugin/rules/__tests__/json-schema-no-plain-object-types.js
@@ -1,0 +1,129 @@
+/**
+ * External dependencies
+ */
+import { RuleTester } from 'eslint';
+
+/**
+ * Internal dependencies
+ */
+import rule from '../json-schema-no-plain-object-types';
+
+const ruleTester = new RuleTester( {
+	parserOptions: {
+		ecmaVersion: 6,
+	},
+} );
+
+const UNSPECIFIED_OBJECT_ERROR =
+	"Any object within a block's attributes must have its properties defined.";
+
+ruleTester.run( 'json-schema-no-plain-object-types', rule, {
+	valid: [
+		{
+			code: `
+( {
+    "name": "my/gallery",
+    "category": "widgets",
+    "attributes": {
+        "images": {
+			"type": "object",
+			"properties": {
+				"id": {
+					"type": "number"
+				},
+				"width": {
+					"type": "number"
+				}
+			}
+        }
+    }
+} )
+`,
+		},
+		{
+			code: `
+( {
+    "name": "my/gallery",
+    "category": "widgets",
+    "attributes": {
+        "images": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "number"
+                    },
+                    "width": {
+                        "type": "number"
+                    }
+                }
+            }
+        }
+    }
+} )
+`,
+		},
+		{
+			code: `
+( {
+    "name": "my/gallery",
+    "category": "widgets",
+    "attributes": {
+        "images": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "number"
+                    },
+                    "width": {
+                        "type": "number"
+                    }
+                },
+                "required": [
+                    "id", "width"
+                ],
+                "additionalProperties": false
+            }
+        }
+    }
+} )
+`,
+		},
+	],
+	invalid: [
+		{
+			code: `
+( {
+    "name": "my/gallery",
+    "category": "widgets",
+    "attributes": {
+        "images": {
+            "type": "array",
+            "items": {
+                "type": "object"
+            }
+        }
+    }
+} )
+`,
+			errors: [ { message: UNSPECIFIED_OBJECT_ERROR } ],
+		},
+		{
+			code: `
+( {
+    "name": "my/gallery",
+    "category": "widgets",
+    "attributes": {
+        "images": {
+            "type": "object"
+        }
+    }
+} )
+`,
+			errors: [ { message: UNSPECIFIED_OBJECT_ERROR } ],
+		},
+	],
+} );

--- a/packages/eslint-plugin/rules/json-schema-no-plain-object-types.js
+++ b/packages/eslint-plugin/rules/json-schema-no-plain-object-types.js
@@ -1,0 +1,85 @@
+const UNSPECIFIED_OBJECT_ERROR =
+	"Any object within a block's attributes must have its properties defined.";
+
+/**
+ * Traverse up through the chain of parent AST nodes returning the first parent
+ * the predicate returns a truthy value for.
+ *
+ * @param {Object}   sourceNode The AST node to search from.
+ * @param {Function} predicate  A predicate invoked for each parent.
+ *
+ * @return {?Object } The first encountered parent node where the predicate
+ *                    returns a truthy value.
+ */
+function findParent( sourceNode, predicate ) {
+	if ( ! sourceNode.parent ) {
+		return;
+	}
+
+	if ( predicate( sourceNode.parent ) ) {
+		return sourceNode.parent;
+	}
+
+	return findParent( sourceNode.parent, predicate );
+}
+
+/**
+ * Please edit me
+ *
+ * @param {Object} node    The ObjectExpression containing a `type` property.
+ * @param {Object} context The eslint context object.
+ */
+function testIsNotPlainObjectType( node, context ) {
+	const jsonSchemaPropertiesDeclaration = node.properties.find(
+		( candidate ) =>
+			candidate.key.type === 'Literal' &&
+			candidate.key.value === 'properties'
+	);
+
+	if ( ! jsonSchemaPropertiesDeclaration ) {
+		context.report( node, UNSPECIFIED_OBJECT_ERROR );
+	}
+}
+
+module.exports = {
+	meta: {
+		type: 'problem',
+		schema: [],
+	},
+	create( context ) {
+		return {
+			Literal( node ) {
+				// Bypass any object property that isn't `type: 'object'`.
+				if (
+					node.value !== 'object' ||
+					! ( node.parent && node.parent.type === 'Property' ) ||
+					! (
+						node.parent.key.type === 'Literal' &&
+						node.parent.key.value === 'type'
+					)
+				) {
+					return;
+				}
+
+				// Capture the object expression in which property `type:
+				// 'object'` was found.
+				const attributeObjectExpression = node.parent.parent;
+
+				// Bypass any object expression that isn't nested in the value of
+				// a property of key `attributes`.
+				const attributesPropertyAncestor = findParent(
+					attributeObjectExpression,
+					( candidate ) =>
+						candidate.type === 'Property' &&
+						candidate.key.type === 'Literal' &&
+						candidate.key.value === 'attributes'
+				);
+				if ( ! attributesPropertyAncestor ) {
+					return;
+				}
+
+				testIsNotPlainObjectType( attributeObjectExpression, context );
+			},
+		};
+	},
+};


### PR DESCRIPTION
## Description

Require all "object" types within a block's attributes to define their expected properties (`json-schema-no-plain-object-types`).

Block attributes must conform to types as specified in the [WordPress REST API documentation](https://developer.wordpress.org/rest-api/extending-the-rest-api/schema/), a behavior based on [JSON Schema](http://json-schema.org/). This schema is used to validate attribute data not only in the REST API, but [also in the block editor](https://developer.wordpress.org/block-editor/developers/block-api/block-attributes/#attribute-type-validation).

This rule requires that any declaration of an `object` type specify the exact properties that make up the object. This applies to the type of attributes themselves as well as any data within an attribute, such as when an attribute of type `array` expects values of type `object`.

## Status

This is an early exploration and not necessarily something to carry through. However, I think the conversation around how strictly we encourage blocks to specify their data models is important. A recent conversation in https://github.com/WordPress/gutenberg/pull/21359#issuecomment-614023626 with @aduth sparked this PR. The question of whether violations of this rule should be seen as errors is up for discussion too.

As I haven't written rules for `eslint-plugin` before, I am sure I am forgetting things in this PR. So far:

- [ ] Update package changelog

## How has this been tested?

Addition of rule-specific unit tests.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
