### PR TITLE
Fix: Remove insert validation from the convert to regular blocks operation

### DIFF
--- a/packages/block-editor/src/store/test/actions.js
+++ b/packages/block-editor/src/store/test/actions.js
@@ -131,6 +131,15 @@ describe( 'actions', () => {
 
 			expect( replaceBlockGenerator.next().value ).toEqual( {
 				args: [ 'chicken' ],
+				selectorName: 'getBlockName',
+				storeName: 'core/block-editor',
+				type: 'SELECT',
+			} );
+
+			expect(
+				replaceBlockGenerator.next( 'core/test-chicken' ).value
+			).toEqual( {
+				args: [ 'chicken' ],
 				selectorName: 'getBlockRootClientId',
 				storeName: 'core/block-editor',
 				type: 'SELECT',
@@ -165,6 +174,59 @@ describe( 'actions', () => {
 	} );
 
 	describe( 'replaceBlocks', () => {
+		it( 'should not validate the insertion if a reusable block is being inserted', () => {
+			const blocks = [
+				{
+					clientId: 'ribs',
+					name: 'core/test-ribs',
+				},
+				{
+					clientId: 'chicken',
+					name: 'core/block',
+				},
+			];
+
+			const replaceBlockGenerator = replaceBlocks(
+				[ 'chicken' ],
+				blocks
+			);
+
+			expect( replaceBlockGenerator.next().value ).toEqual( {
+				args: [],
+				selectorName: 'getSettings',
+				storeName: 'core/block-editor',
+				type: 'SELECT',
+			} );
+
+			expect( replaceBlockGenerator.next().value ).toEqual( {
+				args: [ 'chicken' ],
+				selectorName: 'getBlockName',
+				storeName: 'core/block-editor',
+				type: 'SELECT',
+			} );
+
+			expect( replaceBlockGenerator.next( 'core/block' ).value ).toEqual(
+				{
+					type: 'REPLACE_BLOCKS',
+					clientIds: [ 'chicken' ],
+					blocks,
+					time: expect.any( Number ),
+				}
+			);
+
+			expect( replaceBlockGenerator.next().value ).toEqual( {
+				args: [],
+				selectorName: 'getBlockCount',
+				storeName: 'core/block-editor',
+				type: 'SELECT',
+			} );
+
+			expect( replaceBlockGenerator.next( 1 ) ).toEqual( {
+				value: undefined,
+				done: true,
+			} );
+		} );
+
 		it( 'should not yield the REPLACE_BLOCKS action if the replacement is not possible', () => {
 			const blocks = [
 				{
@@ -190,6 +252,15 @@ describe( 'actions', () => {
 			} );
 
 			expect( replaceBlockGenerator.next().value ).toEqual( {
+				args: [ 'chicken' ],
+				selectorName: 'getBlockName',
+				storeName: 'core/block-editor',
+				type: 'SELECT',
+			} );
+
+			expect(
+				replaceBlockGenerator.next( 'core/test-chicken' ).value
+			).toEqual( {
 				args: [ 'chicken' ],
 				selectorName: 'getBlockRootClientId',
 				storeName: 'core/block-editor',
@@ -237,6 +308,15 @@ describe( 'actions', () => {
 			replaceBlockGenerator.next();
 
 			expect( replaceBlockGenerator.next().value ).toEqual( {
+				args: [ 'chicken' ],
+				selectorName: 'getBlockName',
+				storeName: 'core/block-editor',
+				type: 'SELECT',
+			} );
+
+			expect(
+				replaceBlockGenerator.next( 'core/test-chicken' ).value
+			).toEqual( {
 				args: [ 'chicken' ],
 				selectorName: 'getBlockRootClientId',
 				storeName: 'core/block-editor',


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/21579

When an action to replace blocks is dispatched we validate if the blocks to insert can in fact be inserted in that context.
In the convert to regular blocks mechanism, we don't want that validation so this PR changes the replace action to not apply any validation when a reusable block is replaced. It is not a clean solution but it seems to be simplest option we have.