### PR TITLE
Framework: Exit with non-zero status on docgen failed parse

### DIFF
--- a/bin/api-docs/update-api-docs.js
+++ b/bin/api-docs/update-api-docs.js
@@ -203,16 +203,31 @@ glob.stream( [
 		// so the tokens must be replaced in sequence to prevent the processes
 		// from overriding each other.
 		for ( const [ token, path ] of tokens ) {
-			await execa(
-				join( __dirname, '..', '..', 'node_modules', '.bin', 'docgen' ),
-				[
-					relative( ROOT_DIR, resolve( dirname( file ), path ) ),
-					`--output ${ output }`,
-					'--to-token',
-					`--use-token "${ token }"`,
-					'--ignore "/unstable|experimental/i"',
-				],
-				{ shell: true }
-			);
+			try {
+				await execa(
+					join(
+						__dirname,
+						'..',
+						'..',
+						'node_modules',
+						'.bin',
+						'docgen'
+					),
+					[
+						relative( ROOT_DIR, resolve( dirname( file ), path ) ),
+						`--output ${ output }`,
+						'--to-token',
+						`--use-token "${ token }"`,
+						'--ignore "/unstable|experimental/i"',
+					],
+					{ shell: true }
+				);
+			} catch ( error ) {
+				// Disable reason: Errors should log to console.
+
+				// eslint-disable-next-line no-console
+				console.error( error );
+				process.exit( 1 );
+			}
 		}
 	} );


### PR DESCRIPTION
Previously: #18840 (https://github.com/WordPress/gutenberg/pull/18840#issuecomment-602876433), https://github.com/WordPress/gutenberg/pull/21467#discussion_r410403049

This pull request seeks to resolve an issue where child process failures occurring during `bin/api-docs/update-api-docs.js` do not result in a non-zero exit code. As seen at https://github.com/WordPress/gutenberg/pull/21467#discussion_r410403049, this can result in false positives where errors exist. The changes consist of a revert of the commit 4179376ee273dfe05962100c3957a82d11d888f7 from #18840.

**Testing Instructions:**

Verify `update-api-docs.js` succeeds:

```
node bin/api-docs/update-api-docs.js
echo $?
# 0
```

Verify `update-api-docs.js` fails when parse error occurs:

```diff
diff --git a/packages/editor/src/store/selectors.js b/packages/editor/src/store/selectors.js
index 5a06ba465..2c1a413b2 100644
--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -217 +217 @@ export function getCurrentPostType( state ) {
-	return state.postType;
+	return state?.postType;
```

```
node bin/api-docs/update-api-docs.js
# SyntaxError: Unexpected token .
echo $?
# 1
```