### PR TITLE
Clarify attribute type documentation

### DIFF
--- a/docs/designers-developers/developers/block-api/block-attributes.md
+++ b/docs/designers-developers/developers/block-api/block-attributes.md
@@ -1,5 +1,21 @@
 # Attributes
 
+## Type Validation
+
+The only required field for an attribute is the `type` field. It indicates the type of data that is stored within the attribute.
+
+Accepted values in the `type` field MUST be one of the following:
+
+* null
+* boolean
+* object
+* array
+* number
+* string
+* integer
+
+See [WordPress's REST API documentation](https://developer.wordpress.org/rest-api/extending-the-rest-api/schema/) for additional details.
+
 ## Common Sources
 
 Attribute sources are used to define how the block attribute values are extracted from saved post content. They provide a mechanism to map from the saved markup to a JavaScript representation of a block.
@@ -33,19 +49,33 @@ _Example_: Extract the `src` attribute from an image found in the block's markup
 // { "url": "https://lorempixel.com/1200/800/" }
 ```
 
-#### `attribute` Type Validation
+Most attributes from markup will be of type `string`. Numeric attributes in HTML are still stored as strings, and are not converted automatically.
 
-Accepted values in the `type` field of an `attribute` MUST be one of the following:
+```js
+{
+	width: {
+		type: 'string',
+		source: 'attribute',
+		selector: 'img',
+		attribute: 'width',
+	}
+}
+// { "width": "50" }
+```
 
-* null
-* boolean
-* object
-* array
-* number
-* string
-* integer
+The only exception is when checking for the existence of an attribute (for example, the `disabled` attribute on a `button`). In that case type `boolean` can be used and the stored value will be a boolean.
 
-See [WordPress's REST API documentation](https://developer.wordpress.org/rest-api/extending-the-rest-api/schema/) for additional details.
+```js
+{
+	disabled: {
+		type: 'boolean',
+		source: 'attribute',
+		selector: 'button',
+		attribute: 'disabled',
+	}
+}
+// { "disabled": true }
+```
 
 ### `text`
 


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

Fixes WordPress#16999

> The documentation on attributes is incomplete to the point of being misleading. Since no type coercion is taking place… anything but a type: 'string' being stored in an HTML element attribute will result in a validation error on page load

- Moved the Type Validation section to a level 2 heading since it applies to all attributes.
- Added clarification about the current state of `attribute` source types. (As an aside, is there any reason that type coercion isn't happening for integers and numbers like it is for booleans?)

<!-- ## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

<!-- ## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Documentation change

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
