### PR TITLE
Remove (optional) from value entry field in RangeControl docs

### DIFF
--- a/packages/components/src/range-control/README.md
+++ b/packages/components/src/range-control/README.md
@@ -22,7 +22,7 @@ A RangeControl can contain the following elements:
 
 1. **Track**: The track shows the range available for user selection. For left-to-right (LTR) languages, the smallest value appears on the far left, and the largest value on the far right. For right-to-left (RTL) languages this orientation is reversed, with the smallest value on the far right and the largest value on the far left.
 2. **Thumb**: The thumb slides along the track, displaying the selected value through its position.
-3. **Value entry field** (optional): The value entry field displays the currently selected, specific numerical value.
+3. **Value entry field**: The value entry field displays the currently selected, specific numerical value.
 4. **Icon** (optional): An icon can be displayed before or after the slider.
 5. **Tick mark** (optional): Tick marks represent predetermined values to which the user can move the slider.
 
@@ -44,8 +44,8 @@ Possible selections may be organized through the use of tick marks, which a thum
 - **Click jump**: The slider is controlled by clicking the track.
 - **Click and arrow**: The slider is controlled by clicking the thumb, then using arrow keys to move it.
 - **Tab and arrow**: The slider is controlled by using the tab key to select the thumb of the desired slider, then using arrow keys to move it.
+- **Value entry field**: Discrete sliders have value entry fields. After a text entry is made, the slider position automatically updates to reflect the new value.
 - **Tick marks** (Optional) Discrete sliders can use evenly spaced tick marks along the slider track, and the thumb will snap to them. Each tick mark should change the setting in increments that are discernible to the user.
-- **Value entry field** (Optional): Discrete sliders have value entry fields. After a text entry is made, the slider position automatically updates to reflect the new value.
 
 ### Usage
 


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

Fixes WordPress#15931

> For now, the recommended usage is to always have a number field coupled with the range control. Removal of the number field shouldn't be allowed.

The RangeControl code already enforces having the value entry field (by not providing an option to hide it), so only the documentation change was required to reflect that.

<!-- ## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

<!-- ## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Documentation

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->

cc @melchoyce 