### PR TITLE
Block Library: Update FSE blocks to use block context

### DIFF
--- a/docs/designers-developers/developers/backward-compatibility/deprecations.md
+++ b/docs/designers-developers/developers/backward-compatibility/deprecations.md
@@ -2,6 +2,10 @@
 
 For features included in the Gutenberg plugin, the deprecation policy is intended to support backward compatibility for two minor plugin releases, when possible. Features and code included in a stable release of WordPress are not included in this deprecation timeline, and are instead subject to the [versioning policies of the WordPress project](https://make.wordpress.org/core/handbook/about/release-cycle/version-numbering/). The current deprecations are listed below and are grouped by _the version at which they will be removed completely_. If your plugin depends on these behaviors, you must update to the recommended alternative before the noted version.
 
+## 8.3.0
+
+- The PHP function `gutenberg_get_post_from_context` has been removed. Use [Block Context](https://github.com/WordPress/gutenberg/blob/master/docs/designers-developers/developers/block-api/block-context.md) instead.
+
 ## 5.5.0
 
 - The PHP function `gutenberg_init` has been removed.

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -207,7 +207,8 @@ function gutenberg_render_block_with_assigned_block_context( $pre_render, $parse
 
 	/** This filter is documented in src/wp-includes/blocks.php */
 	$parsed_block = apply_filters( 'render_block_data', $parsed_block, $source_block );
-	$context      = array(
+
+	$context = array(
 		'postId'   => $post->ID,
 
 		/*
@@ -218,7 +219,16 @@ function gutenberg_render_block_with_assigned_block_context( $pre_render, $parse
 		 */
 		'postType' => $post->post_type,
 	);
-	$block        = new WP_Block( $parsed_block, $context );
+
+	/**
+	 * Filters the default context provided to a rendered block.
+	 *
+	 * @param array $context      Default context.
+	 * @param array $parsed_block Block being rendered, filtered by `render_block_data`.
+	 */
+	$context = apply_filters( 'render_block_context', $context, $parsed_block );
+
+	$block = new WP_Block( $parsed_block, $context );
 
 	return $block->render();
 }

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -169,6 +169,9 @@ function gutenberg_get_post_from_context() {
 	if ( is_admin() || defined( 'REST_REQUEST' ) ) {
 		return null;
 	}
+
+	_deprecated_function( __FUNCTION__, '8.1.0' );
+
 	if ( ! in_the_loop() ) {
 		rewind_posts();
 		the_post();

--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -383,3 +383,27 @@ function gutenberg_template_loader_filter_block_editor_settings( $settings ) {
 	return $settings;
 }
 add_filter( 'block_editor_settings', 'gutenberg_template_loader_filter_block_editor_settings' );
+
+/**
+ * Removes post details from block context when rendering a block template.
+ *
+ * @param array $context Default context.
+ *
+ * @return array Filtered context.
+ */
+function gutenberg_template_render_without_post_block_context( $context ) {
+	/*
+	 * Blocks rendered for a template should be treated as if there is no
+	 * current post, since the purpose of a template is in prescribing how
+	 * blocks appear for any post which matches the template. The post is
+	 * assigned only once the template is used in rendering a post.
+	 */
+	if ( isset( $context['postType'] ) &&
+			( 'wp_template' === $context['postType'] || 'wp_template_part' === $context['postType'] ) ) {
+		unset( $context['postId'] );
+		unset( $context['postType'] );
+	}
+
+	return $context;
+}
+add_filter( 'render_block_context', 'gutenberg_template_render_without_post_block_context' );

--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -393,10 +393,11 @@ add_filter( 'block_editor_settings', 'gutenberg_template_loader_filter_block_edi
  */
 function gutenberg_template_render_without_post_block_context( $context ) {
 	/*
-	 * Blocks rendered for a template should be treated as if there is no
-	 * current post, since the purpose of a template is in prescribing how
-	 * blocks appear for any post which matches the template. The post is
-	 * assigned only once the template is used in rendering a post.
+	 * When loading a template or template part directly and not through a page
+	 * that resolves it, the top-level post ID and type context get set to that
+	 * of the template part. Templates are just the structure of a site, and
+	 * they should not be available as post context because blocks like Post
+	 * Content would recurse infinitely.
 	 */
 	if ( isset( $context['postType'] ) &&
 			( 'wp_template' === $context['postType'] || 'wp_template_part' === $context['postType'] ) ) {

--- a/packages/block-library/src/post-author/block.json
+++ b/packages/block-library/src/post-author/block.json
@@ -29,5 +29,6 @@
 		"customTextColor": {
 			"type": "string"
 		}
-	}
+	},
+	"context": [ "postId" ]
 }

--- a/packages/block-library/src/post-author/index.php
+++ b/packages/block-library/src/post-author/index.php
@@ -133,8 +133,8 @@ function render_block_core_post_author( $attributes, $content, $block ) {
 		( $attributes['showAvatar'] ? '<div class="wp-block-post-author__avatar">' . $avatar . '</div>' : '' ) .
 		'<div class="wp-block-post-author__content">' .
 			( ! empty( $byline ) ? '<p class="wp-block-post-author__byline">' . $byline . '</p>' : '' ) .
-			'<p class="wp-block-post-author__name">' . get_the_author_meta( 'display_name' ) . '</p>' .
-			( ! empty( $attributes['showBio'] ) ? '<p class="wp-block-post-author__bio">' . get_the_author_meta( 'user_description' ) . '</p>' : '' ) .
+			'<p class="wp-block-post-author__name">' . get_the_author_meta( 'display_name', $author_id ) . '</p>' .
+			( ! empty( $attributes['showBio'] ) ? '<p class="wp-block-post-author__bio">' . get_the_author_meta( 'user_description', $author_id ) . '</p>' : '' ) .
 		'</div>' .
 	'</div>';
 }

--- a/packages/block-library/src/post-author/index.php
+++ b/packages/block-library/src/post-author/index.php
@@ -88,23 +88,27 @@ function post_author_build_css_font_sizes( $attributes ) {
 /**
  * Renders the `core/post-author` block on the server.
  *
- * @param array $attributes Block attributes.
- *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
  * @return string Returns the rendered author block.
  */
-function render_block_core_post_author( $attributes ) {
+function render_block_core_post_author( $attributes, $content, $block ) {
 	if ( empty( $attributes ) ) {
 		return '';
 	}
 
-	$post = gutenberg_get_post_from_context();
+	if ( ! isset( $block->context['postId'] ) ) {
+		return '';
+	}
 
-	if ( ! $post ) {
+	$author_id = get_post_field( 'post_author', $block->context['postId'] );
+	if ( empty( $author_id ) ) {
 		return '';
 	}
 
 	$avatar = ! empty( $attributes['avatarSize'] ) ? get_avatar(
-		$post->post_author,
+		$author_id,
 		$attributes['avatarSize']
 	) : null;
 

--- a/packages/block-library/src/post-comments-count/block.json
+++ b/packages/block-library/src/post-comments-count/block.json
@@ -1,4 +1,5 @@
 {
 	"name": "core/post-comments-count",
-	"category": "layout"
+	"category": "layout",
+	"context": [ "postId" ]
 }

--- a/packages/block-library/src/post-comments-count/index.php
+++ b/packages/block-library/src/post-comments-count/index.php
@@ -8,23 +8,25 @@
 /**
  * Renders the `core/post-comments-count` block on the server.
  *
- * @param array $attributes The block attributes.
- *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
  * @return string Returns the filtered post comments count for the current post.
  */
-function render_block_core_post_comments_count( $attributes ) {
-	$post = gutenberg_get_post_from_context();
-	if ( ! $post ) {
+function render_block_core_post_comments_count( $attributes, $content, $block ) {
+	if ( ! isset( $block->context['postId'] ) ) {
 		return '';
 	}
+
 	$class = 'wp-block-post-comments-count';
 	if ( isset( $attributes['className'] ) ) {
 		$class .= ' ' . $attributes['className'];
 	}
+
 	return sprintf(
 		'<span class="%1$s">%2$s</span>',
 		esc_attr( $class ),
-		get_comments_number( $post )
+		get_comments_number( $block->context['postId'] )
 	);
 }
 

--- a/packages/block-library/src/post-comments-form/block.json
+++ b/packages/block-library/src/post-comments-form/block.json
@@ -1,4 +1,5 @@
 {
 	"name": "core/post-comments-form",
-	"category": "layout"
+	"category": "layout",
+	"context": [ "postId" ]
 }

--- a/packages/block-library/src/post-comments-form/index.php
+++ b/packages/block-library/src/post-comments-form/index.php
@@ -8,15 +8,18 @@
 /**
  * Renders the `core/post-comments-form` block on the server.
  *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
  * @return string Returns the filtered post comments form for the current post.
  */
-function render_block_core_post_comments_form() {
-	$post = gutenberg_get_post_from_context();
-	if ( ! $post ) {
+function render_block_core_post_comments_form( $attributes, $content, $block ) {
+	if ( ! isset( $block->context['postId'] ) ) {
 		return '';
 	}
+
 	ob_start();
-	comment_form( array(), $post->ID );
+	comment_form( array(), $block->context['postId'] );
 	$form = ob_get_clean();
 
 	return $form;

--- a/packages/block-library/src/post-comments/block.json
+++ b/packages/block-library/src/post-comments/block.json
@@ -1,4 +1,5 @@
 {
 	"name": "core/post-comments",
-	"category": "layout"
+	"category": "layout",
+	"context": [ "postId" ]
 }

--- a/packages/block-library/src/post-comments/index.php
+++ b/packages/block-library/src/post-comments/index.php
@@ -8,18 +8,28 @@
 /**
  * Renders the `core/post-comments` block on the server.
  *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
  * @return string Returns the filtered post comments for the current post wrapped inside "p" tags.
  */
-function render_block_core_post_comments() {
-	$post = gutenberg_get_post_from_context();
-	if ( ! $post ) {
+function render_block_core_post_comments( $attributes, $content, $block ) {
+	global $post;
+
+	if ( ! isset( $block->context['postId'] ) ) {
 		return '';
 	}
+
+	$post_before = $post;
+
+	$post = get_post( $block->context['postId'] );
+	setup_postdata( $post );
 
 	// This generates a deprecate message.
 	// Ideally this deprecation is removed.
 	ob_start();
 	comments_template();
+	$post = $post_before;
 	return ob_get_clean();
 }
 

--- a/packages/block-library/src/post-content/block.json
+++ b/packages/block-library/src/post-content/block.json
@@ -1,4 +1,5 @@
 {
 	"name": "core/post-content",
-	"category": "layout"
+	"category": "layout",
+	"context": [ "postId" ]
 }

--- a/packages/block-library/src/post-content/index.php
+++ b/packages/block-library/src/post-content/index.php
@@ -8,16 +8,19 @@
 /**
  * Renders the `core/post-content` block on the server.
  *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
  * @return string Returns the filtered post content of the current post.
  */
-function render_block_core_post_content() {
-	$post = gutenberg_get_post_from_context();
-	if ( ! $post ) {
+function render_block_core_post_content( $attributes, $content, $block ) {
+	if ( ! isset( $block->context['postId'] ) ) {
 		return '';
 	}
+
 	return (
 		'<div class="entry-content">' .
-			apply_filters( 'the_content', str_replace( ']]>', ']]&gt;', get_the_content( $post ) ) ) .
+			apply_filters( 'the_content', str_replace( ']]>', ']]&gt;', get_the_content( $block->context['postId'] ) ) ) .
 		'</div>'
 	);
 }

--- a/packages/block-library/src/post-content/index.php
+++ b/packages/block-library/src/post-content/index.php
@@ -20,7 +20,7 @@ function render_block_core_post_content( $attributes, $content, $block ) {
 
 	return (
 		'<div class="entry-content">' .
-			apply_filters( 'the_content', str_replace( ']]>', ']]&gt;', get_the_content( $block->context['postId'] ) ) ) .
+			apply_filters( 'the_content', str_replace( ']]>', ']]&gt;', get_the_content( null, false, $block->context['postId'] ) ) ) .
 		'</div>'
 	);
 }

--- a/packages/block-library/src/post-date/block.json
+++ b/packages/block-library/src/post-date/block.json
@@ -5,5 +5,6 @@
 		"format": {
 			"type": "string"
 		}
-	}
+	},
+	"context": [ "postId" ]
 }

--- a/packages/block-library/src/post-date/index.php
+++ b/packages/block-library/src/post-date/index.php
@@ -8,18 +8,19 @@
 /**
  * Renders the `core/post-date` block on the server.
  *
- * @param array $attributes The block attributes.
- *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
  * @return string Returns the filtered post date for the current post wrapped inside "time" tags.
  */
-function render_block_core_post_date( $attributes ) {
-	$post = gutenberg_get_post_from_context();
-	if ( ! $post ) {
+function render_block_core_post_date( $attributes, $content, $block ) {
+	if ( ! isset( $block->context['postId'] ) ) {
 		return '';
 	}
+
 	return '<time datetime="'
-		. get_the_date( 'c', $post ) . '">'
-		. get_the_date( isset( $attributes['format'] ) ? $attributes['format'] : '', $post )
+		. get_the_date( 'c', $block->context['postId'] ) . '">'
+		. get_the_date( isset( $attributes['format'] ) ? $attributes['format'] : '', $block->context['postId'] )
 		. '</time>';
 }
 

--- a/packages/block-library/src/post-excerpt/block.json
+++ b/packages/block-library/src/post-excerpt/block.json
@@ -13,5 +13,6 @@
 			"type": "boolean",
 			"default": true
 		}
-	}
+	},
+	"context": [ "postId" ]
 }

--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -8,17 +8,17 @@
 /**
  * Renders the `core/post-excerpt` block on the server.
  *
- * @param array $attributes The block attributes.
- *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
  * @return string Returns the filtered post excerpt for the current post wrapped inside "p" tags.
  */
-function render_block_core_post_excerpt( $attributes ) {
-	$post = gutenberg_get_post_from_context();
-	if ( ! $post ) {
+function render_block_core_post_excerpt( $attributes, $content, $block ) {
+	if ( ! isset( $block->context['postId'] ) ) {
 		return '';
 	}
 
-	$more_text = isset( $attributes['moreText'] ) ? '<a href="' . esc_url( get_the_permalink( $post ) ) . '">' . $attributes['moreText'] . '</a>' : '';
+	$more_text = isset( $attributes['moreText'] ) ? '<a href="' . esc_url( get_the_permalink( $block->context['postId'] ) ) . '">' . $attributes['moreText'] . '</a>' : '';
 
 	$filter_excerpt_length = function() use ( $attributes ) {
 		return isset( $attributes['wordCount'] ) ? $attributes['wordCount'] : 55;
@@ -28,7 +28,7 @@ function render_block_core_post_excerpt( $attributes ) {
 		$filter_excerpt_length
 	);
 
-	$output = '<p>' . get_the_excerpt( $post );
+	$output = '<p>' . get_the_excerpt( $block->context['postId'] );
 	if ( ! isset( $attributes['showMoreOnNewLine'] ) || $attributes['showMoreOnNewLine'] ) {
 		$output .= '</p>' . '<p>' . $more_text . '</p>';
 	} else {

--- a/packages/block-library/src/post-featured-image/block.json
+++ b/packages/block-library/src/post-featured-image/block.json
@@ -1,4 +1,5 @@
 {
 	"name": "core/post-featured-image",
-	"category": "layout"
+	"category": "layout",
+	"context": [ "postId" ]
 }

--- a/packages/block-library/src/post-featured-image/index.php
+++ b/packages/block-library/src/post-featured-image/index.php
@@ -8,14 +8,17 @@
 /**
  * Renders the `core/post-featured-image` block on the server.
  *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
  * @return string Returns the featured image for the current post.
  */
-function render_block_core_post_featured_image() {
-	$post = gutenberg_get_post_from_context();
-	if ( ! $post ) {
+function render_block_core_post_featured_image( $attributes, $content, $block ) {
+	if ( ! isset( $block->context['postId'] ) ) {
 		return '';
 	}
-	return '<p>' . get_the_post_thumbnail( $post ) . '</p>';
+
+	return '<p>' . get_the_post_thumbnail( $block->context['postId'] ) . '</p>';
 }
 
 /**

--- a/packages/block-library/src/post-tags/block.json
+++ b/packages/block-library/src/post-tags/block.json
@@ -1,4 +1,5 @@
 {
 	"name": "core/post-tags",
-	"category": "layout"
+	"category": "layout",
+	"context": [ "postId" ]
 }

--- a/packages/block-library/src/post-tags/index.php
+++ b/packages/block-library/src/post-tags/index.php
@@ -8,14 +8,17 @@
 /**
  * Renders the `core/post-tags` block on the server.
  *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
  * @return string Returns the filtered post tags for the current post wrapped inside "a" tags.
  */
-function render_block_core_post_tags() {
-	$post = gutenberg_get_post_from_context();
-	if ( ! $post ) {
+function render_block_core_post_tags( $attributes, $content, $block ) {
+	if ( ! isset( $block->context['postId'] ) ) {
 		return '';
 	}
-	$post_tags = get_the_tags();
+
+	$post_tags = get_the_tags( $block->context['postId'] );
 	if ( ! empty( $post_tags ) ) {
 		$output = '';
 		foreach ( $post_tags as $tag ) {

--- a/packages/e2e-tests/plugins/block-context.php
+++ b/packages/e2e-tests/plugins/block-context.php
@@ -47,15 +47,19 @@ function gutenberg_test_register_context_blocks() {
 	register_block_type(
 		'gutenberg/test-context-consumer',
 		array(
-			'context'         => array( 'gutenberg/recordId' ),
+			'context'         => array(
+				'gutenberg/recordId',
+				'postId',
+				'postType',
+			),
 			'render_callback' => function( $attributes, $content, $block ) {
-				$record_id = $block->context['gutenberg/recordId'];
+				$ordered_context = array(
+					$block->context['gutenberg/recordId'],
+					$block->context['postId'],
+					$block->context['postType'],
+				);
 
-				if ( ! is_int( $record_id ) ) {
-					throw new Exception( 'Expected numeric recordId' );
-				}
-
-				return 'The record ID is: ' . filter_var( $record_id, FILTER_VALIDATE_INT );
+				return implode( ',', $ordered_context );
 			},
 		)
 	);

--- a/packages/e2e-tests/specs/editor/plugins/block-context.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/block-context.test.js
@@ -70,12 +70,7 @@ describe( 'Block context', () => {
 		expect( innerBlockText ).toBe( 'The record ID is: 123' );
 	} );
 
-	// Disable reason: Block context PHP implementation is temporarily reverted.
-	// This will be unskipped once the implementation is restored. Skipping was
-	// the most direct option for revert given time constraints.
-
-	/* eslint-disable-next-line jest/no-disabled-tests */
-	test.skip( 'Block context is reflected in the preview', async () => {
+	test( 'Block context is reflected in the preview', async () => {
 		await insertBlock( 'Test Context Provider' );
 		const editorPage = page;
 		const previewPage = await openPreviewPage( editorPage );
@@ -85,7 +80,7 @@ describe( 'Block context', () => {
 			'.entry-content',
 			( contentWrapper ) => contentWrapper.textContent.trim()
 		);
-		expect( content ).toBe( 'The record ID is: 0' );
+		expect( content ).toMatch( /^0,\d+,post$/ );
 
 		// Return to editor to change context value to non-default.
 		await editorPage.bringToFront();
@@ -104,7 +99,7 @@ describe( 'Block context', () => {
 			'.entry-content',
 			( contentWrapper ) => contentWrapper.textContent.trim()
 		);
-		expect( content ).toBe( 'The record ID is: 123' );
+		expect( content ).toMatch( /^123,\d+,post$/ );
 
 		// Clean up
 		await editorPage.bringToFront();

--- a/phpunit/class-block-context-test.php
+++ b/phpunit/class-block-context-test.php
@@ -163,4 +163,38 @@ class Block_Context_Test extends WP_UnitTestCase {
 		);
 	}
 
+	/**
+	 * Tests that default block context can be filtered.
+	 */
+	function test_default_context_is_filterable() {
+		$provided_context = array();
+
+		$this->register_block_type(
+			'gutenberg/test-context-consumer',
+			array(
+				'context'         => array( 'example' ),
+				'render_callback' => function( $attributes, $content, $block ) use ( &$provided_context ) {
+					$provided_context[] = $block->context;
+
+					return '';
+				},
+			)
+		);
+
+		$filter_block_context = function( $context ) {
+			$context['example'] = 'ok';
+			return $context;
+		};
+
+		$parsed_blocks = parse_blocks( '<!-- wp:gutenberg/test-context-consumer /-->' );
+
+		add_filter( 'render_block_context', $filter_block_context );
+
+		render_block( $parsed_blocks[0] );
+
+		remove_filter( 'render_block_context', $filter_block_context );
+
+		$this->assertEquals( array( 'example' => 'ok' ), $provided_context[0] );
+	}
+
 }


### PR DESCRIPTION
Closes #21662
Closes #21665

This pull request seeks to update existing full-site editing blocks to use the block context feature implemented in #21467 in place of the existing `gutenberg_get_post_from_context` for accessing the "current" post. In so doing, the `gutenberg_get_post_from_context` function has been deprecated.

It does **not** seek to make any other improvements to these blocks. Existing functionality is retained.

**Testing Instructions:**

Verify all affected blocks behave as expected:

- `core/post-content`
- `core/post-author`
- `core/post-comments`
- `core/post-comments-count`
- `core/post-comments-form`
- `core/post-date`
- `core/post-excerpt`
- `core/post-featured-image`
- `core/post-tags`
- `core/site-title`
- `core/template-part`

This requires to create a template using the Full Site Editing feature, enabled under Gutenberg > Experiments. The easiest way to do this is to create a new template `single`, add each of these as a block somewhere in the template, then navigate to the preview of an existing post on the site.

Ideally there are automated tests for these blocks. I will create a separate tracking task for this.