### PR TITLE
Env: Add support activating/deactivating plugins

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,5 +1,5 @@
 {
 	"core": "WordPress/WordPress",
-	"plugins": [ ".", "./packages/e2e-tests/plugins" ],
+	"plugins": [ ".", { "source": "./packages/e2e-tests/plugins", "active": false } ],
 	"mu-plugins": "./packages/e2e-tests/mu-plugins"
 }

--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 -   The `.wp-env.json` coniguration file now accepts "mu-plugins" sources.
 -   Themes, plugins, and mu-plugins directories may now be mounted directly as the corresponding wp-content subdirectory.
+-   You may now specify if a certain plugin source should be deactivated on the WP instance. Previously, wp-env activated all plugins it knew about. This includes support for deactivating or activating a mapped directory of plugins.
 
 ## 1.1.0 (2020-04-01)
 

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -218,27 +218,29 @@ You can customize the WordPress installation, plugins and themes that the develo
 | Field         | Type           | Default                                       | Description                                                                                                               |
 | ------------- | -------------- | --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
 | `"core"`      | `string\|null` | `null`      | The WordPress installation to use. If `null` is specified, `wp-env` will use the latest production release of WordPress.  |
-| `"plugins"`   | `string[]\|string` | `[]`    | A list of plugins to install and activate in the environment. To mount a directory as `wp-content/plugins`, the value should be a path to the applicable directory instead of an array. |
-| `"mu-plugins"`    | `string[]\|string`| `[]` | A list of mu-plugins to install in the environment. To mount a directory as `wp-content/mu-plugins`, the value should be a path to the applicable directory instead of an array. |
-| `"themes"`    | `string[]\|string` | `[]`    | A list of themes to install in the environment. The first theme in the list will be activated. To mount a directory as `wp-content/themes`, the value should be a path to the applicable directory instead of an array. |
+| `"plugins"`   | `SingleSource\|SingleSource[]` | `[]`    | A list of plugins to install and activate in the environment. To mount a directory as `wp-content/plugins`, the value should be a path to the applicable directory instead of an array. |
+| `"mu-plugins"`    | `SingleSource\|SingleSource[]`| `[]` | A list of mu-plugins to install in the environment. To mount a directory as `wp-content/mu-plugins`, the value should be a path to the applicable directory instead of an array. |
+| `"themes"`    | `SingleSource\|SingleSource[]` | `[]`    | A list of themes to install in the environment. The first theme in the list will be activated. To mount a directory as `wp-content/themes`, the value should be a path to the applicable directory instead of an array. |
 | `"port"`      | `integer`      | `8888`      | The primary port number to use for the insallation. You'll access the instance through the port: 'http://localhost:8888'. |
 | `"testsPort"` | `integer`      | `8889`      | The port number to use for the tests instance.                                                                            |
 | `"config"`    | `Object`       | `{ "WP_DEBUG": true, "SCRIPT_DEBUG": true }"` | Mapping of wp-config.php constants to their desired values.                             |
 
 _Note: the port number environment variables (`WP_ENV_PORT` and `WP_ENV_TESTS_PORT`) take precedent over the .wp-env.json values._
 
-Several types of strings can be passed into the `core`, `plugins`, `mu-plugins`, and `themes` fields:
+Adding plugins, themes and mu-pllugins to the WordPress instance is done with just one `SingleSource`, or an array of `SingleSource`. To clarify, the `SingleSource` type is `SourceString|{ source: SourceString, active?: boolean }`. For the most part, you can specify all your sources as strings, but the object format is useful for individual sources which should not be activated by default on the WordPress instance. **By default, every specified plugin is activated each time you run `wp-env start`.**
+
+The `SourceString` is just a plain string which supports different types of local and remote sources:
 
 | Type              | Format                        | Example(s)                                               |
 | ----------------- | ----------------------------- | -------------------------------------------------------- |
-| Relative path     | `.<path>\|~<path>`             | `"./a/directory"`, `"../a/directory"`, `"~/a/directory"` |
-| Absolute path     | `/<path>\|<letter>:\<path>`    | `"/a/directory"`, `"C:\\a\\directory"`                   |
+| Relative path     | `.<path>\|~<path>`            | `"./a/directory"`, `"../a/directory"`, `"~/a/directory"` |
+| Absolute path     | `/<path>\|<letter>:\<path>`   | `"/a/directory"`, `"C:\\a\\directory"`                   |
 | GitHub repository | `<owner>/<repo>[#<ref>]`      | `"WordPress/WordPress"`, `"WordPress/gutenberg#master"`  |
 | ZIP File          | `http[s]://<host>/<path>.zip` | `"https://wordpress.org/wordpress-5.4-beta2.zip"`        |
 
 Remote sources will be downloaded into a temporary directory located in `~/.wp-env`.
 
-For plugins, mu-plugins, and themes, you may also specify a single directory which maps directly to the corresponding wp-content directory. To do so, specify a source string instead of an array of source strings. For example, if you set `{ "themes": "../my-themes" }`, then the `my-themes` directory will be mounted to the Docker instance directly as `wp-content/themes`. This might be useful if you are developing an entire directory of themes — you won't have to specify each theme one by one.
+For plugins, mu-plugins, and themes, you may also specify a single directory which maps directly to the corresponding wp-content directory. To do so, specify one `SingleSource` instead of an array of `SingleSource`. For example, if you set `{ "themes": "../my-themes" }`, then the `my-themes` directory will be mounted to the Docker instance directly as `wp-content/themes`. This might be useful if you are developing an entire directory of themes — you won't have to specify each theme one by one.
 
 ## .wp-env.override.json
 
@@ -316,5 +318,25 @@ You can tell `wp-env` to use a custom port number so that your instance does not
 	"testsPort": 4012
 }
 ```
+
+#### Install plugins without activating them
+
+By default, `wp-env` activates all specified plugins on the WordPress instance. Override this with the `active` property for an individual source;
+
+```json
+{
+	"plugins": [
+		".",
+		{
+			"source": "path/to/test-plugins",
+			"active" false
+		}
+	],
+	"port": 4013,
+	"testsPort": 4012
+}
+```
+
+In this scenario, `"path/to/test-plulgins"` is a directory containing many plugins. Since they are test plugins, you don't want them to be active all the time, so you set `active` to false. `wp-env` is smart enough to determine which plugins are in this directory, and makes sure that they are not active when you start the WordPress instance.
 
 <br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>


### PR DESCRIPTION
_Note: I'm basing this on #21229 until it is ready to merge._

## Description
This PR adds support to `.wp-env.json` to determine which plugins should be activated and which should be deactivated.

- In `.wp-env.json` source strings may now also be objects with the shape `{ source: string, active?: boolean }`. If not specified, `active` is set to true.
- When we activate plugins during set up, we now determine which ones should be activated and which ones should be deactivated.

This also supports directories. For example, look at this config:
```json
{
  "plugins": [
    {
      "source": "path/to/my-plugins",
      "active": false
    }
  ]
}
```

This path is a directory containing many plugins. It is mapped to `wp-content/plugins/my-plugins`, so each plugin name from that directory has a name like `my-plugins/a-plugin` in WordPress. I.e. the name itself starts with the basename of the directory. So to determine that each of those plugins should be deactivated, we check `pluginName.startsWith( basename )` against any plugin source which is meant to be deactivated. 

This way, we support activating or deactivating entire directories of plugins. There are some issues with this approach:
1. I'm not sure if nested inner directories work with this approach, but that might not work in general (could use clarification on this point)
2. If two mapped directories have the same basename, like "a/path/to/plugins" and "b/path/to/plugins", things get interesting. I think if either of these is set to be deactive, all of the plugins from both directories would be deactivated.

Anyways, I'm not sure if that scenario is supported well by the docker config as it exists, since the both directories are mapped to the basename. It is probably not worth supporting, I imagine.

Theoretically, as the PR stands, the `active` property will be parsed properly if anyone adds it to a theme or mu-plugin, but none of the wp-env internals do anything with that information for the time being. But it might be helpful for future features 🤷 

Todo:
- [x] add documentation
- [ ] add unit tests.

## How has this been tested?
Running wp-env locally with the new Gutenberg config. 
1. run `packages/env/bin/wp-env start` with the mapped plugins directory inactive, and all those plugins will be deactivated in the instance.
2. run the same command, but turn the plugins directory to active. Though there is a PHP error because two of the plugins declare the same function (i.e. these plugins are not meant to all be active at the same time), you will notice that most of the plugins are activated up to that point.

## Types of changes
Enhancement, new feature

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
