### PR TITLE
Polish Custom HTML block

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13876,6 +13876,7 @@
 				"memize": "^1.1.0",
 				"micromodal": "^0.4.6",
 				"moment": "^2.22.1",
+				"react-autosize-textarea": "^7.1.0",
 				"react-easy-crop": "^3.0.0",
 				"tinycolor2": "^1.4.2"
 			}

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -66,6 +66,7 @@
 		"memize": "^1.1.0",
 		"micromodal": "^0.4.6",
 		"moment": "^2.22.1",
+		"react-autosize-textarea": "^7.1.0",
 		"react-easy-crop": "^3.0.0",
 		"tinycolor2": "^1.4.2"
 	},

--- a/packages/block-library/src/html/edit.js
+++ b/packages/block-library/src/html/edit.js
@@ -1,45 +1,51 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+import TextareaAutosize from 'react-autosize-textarea';
+
+/**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
-import { useState } from '@wordpress/element';
 import {
 	BlockControls,
-	PlainText,
 	transformStyles,
 	useBlockProps,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import {
-	ToolbarButton,
 	Disabled,
 	SandBox,
+	ToolbarButton,
 	ToolbarGroup,
 } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
+import { useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+// Default styles used to unset some of the styles
+// that might be inherited from the editor style.
+const DEFAULT_STYLES = `
+	html,body,:root {
+		margin: 0 !important;
+		padding: 0 !important;
+		overflow: visible !important;
+		min-height: auto !important;
+	}
+`;
 
 export default function HTMLEdit( { attributes, setAttributes, isSelected } ) {
-	const [ isPreview, setIsPreview ] = useState();
+	const [ isPreview, setIsPreview ] = useState( false );
 
-	const styles = useSelect( ( select ) => {
-		// Default styles used to unset some of the styles
-		// that might be inherited from the editor style.
-		const defaultStyles = `
-			html,body,:root {
-				margin: 0 !important;
-				padding: 0 !important;
-				overflow: visible !important;
-				min-height: auto !important;
-			}
-		`;
-
-		return [
-			defaultStyles,
+	const styles = useSelect(
+		( select ) => [
+			DEFAULT_STYLES,
 			...transformStyles(
 				select( blockEditorStore ).getSettings().styles
 			),
-		];
-	}, [] );
+		],
+		[]
+	);
 
 	function switchToPreview() {
 		setIsPreview( true );
@@ -49,55 +55,67 @@ export default function HTMLEdit( { attributes, setAttributes, isSelected } ) {
 		setIsPreview( false );
 	}
 
+	const blockProps = useBlockProps( {
+		className: 'block-library-html__edit',
+	} );
+
 	return (
-		<div { ...useBlockProps( { className: 'block-library-html__edit' } ) }>
+		<>
 			<BlockControls>
 				<ToolbarGroup>
 					<ToolbarButton
-						className="components-tab-button"
 						isPressed={ ! isPreview }
 						onClick={ switchToHTML }
 					>
-						<span>HTML</span>
+						HTML
 					</ToolbarButton>
 					<ToolbarButton
-						className="components-tab-button"
 						isPressed={ isPreview }
 						onClick={ switchToPreview }
 					>
-						<span>{ __( 'Preview' ) }</span>
+						{ __( 'Preview' ) }
 					</ToolbarButton>
 				</ToolbarGroup>
 			</BlockControls>
 			<Disabled.Consumer>
 				{ ( isDisabled ) =>
 					isPreview || isDisabled ? (
-						<>
+						<div { ...blockProps }>
 							<SandBox
 								html={ attributes.content }
 								styles={ styles }
 							/>
-							{ /*	
-									An overlay is added when the block is not selected in order to register click events. 
-									Some browsers do not bubble up the clicks from the sandboxed iframe, which makes it 
-									difficult to reselect the block. 
-								*/ }
+							{ /*
+								An overlay is added when the block is not selected in order to register click events.
+								Some browsers do not bubble up the clicks from the sandboxed iframe, which makes it
+								difficult to reselect the block.
+							*/ }
 							{ ! isSelected && (
-								<div className="block-library-html__preview-overlay"></div>
+								<div className="block-library-html__preview-overlay" />
 							) }
-						</>
+						</div>
 					) : (
-						<PlainText
-							value={ attributes.content }
-							onChange={ ( content ) =>
-								setAttributes( { content } )
-							}
-							placeholder={ __( 'Write HTML…' ) }
-							aria-label={ __( 'HTML' ) }
-						/>
+						<div
+							{ ...blockProps }
+							className={ classnames(
+								blockProps.className,
+								'is-html-editor'
+							) }
+						>
+							<TextareaAutosize
+								aria-label={ __( 'HTML' ) }
+								value={ attributes.content }
+								onChange={ ( event ) =>
+									setAttributes( {
+										content: event.target.value,
+									} )
+								}
+								placeholder={ __( 'Write HTML…' ) }
+							/>
+						</div>
 					)
 				}
 			</Disabled.Consumer>
-		</div>
+		</>
 	);
 }

--- a/packages/block-library/src/html/editor.scss
+++ b/packages/block-library/src/html/editor.scss
@@ -1,5 +1,37 @@
 .block-library-html__edit {
-	margin-bottom: $default-block-margin;
+	&.is-html-editor {
+		border-radius: $radius-block-ui;
+		box-shadow: inset 0 0 0 $border-width $gray-900;
+		/* Padding to prevent the textarea's scroll bar from overlapping the
+		border. This also makes it easier to overlap the block wrapper's
+		box-shadow with the textarea's focus box-shadow. */
+		padding: 1px;
+
+		> textarea {
+			display: block;
+			font-family: $editor-html-font;
+			background-color: $white;
+			color: $gray-900;
+			padding: $grid-unit-15;
+			border: none;
+			border-radius: $radius-block-ui;
+			max-height: 250px;
+			width: 100%;
+			overflow-y: auto;
+
+			// Fonts smaller than 16px causes mobile safari to zoom.
+			font-size: $mobile-text-min-font-size;
+
+			&:focus {
+				box-shadow: 0 0 0 $border-width-focus var(--wp-admin-theme-color);
+
+				// Show a light color for dark themes.
+				.is-dark-theme & {
+					box-shadow: 0 0 0 $border-width-focus $dark-theme-focus;
+				}
+			}
+		}
+	}
 
 	.block-library-html__preview-overlay {
 		position: absolute;
@@ -7,24 +39,5 @@
 		height: 100%;
 		top: 0;
 		left: 0;
-	}
-
-	.block-editor-plain-text {
-		font-family: $editor-html-font;
-		color: $gray-900;
-		padding: 0.8em 1em;
-		border: 1px solid $gray-300;
-		border-radius: 4px;
-		max-height: 250px;
-
-		/* Fonts smaller than 16px causes mobile safari to zoom. */
-		font-size: $mobile-text-min-font-size;
-		@include break-small {
-			font-size: $default-font-size;
-		}
-
-		&:focus {
-			box-shadow: none;
-		}
 	}
 }

--- a/packages/block-library/src/html/index.js
+++ b/packages/block-library/src/html/index.js
@@ -1,14 +1,14 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { html as icon } from '@wordpress/icons';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import edit from './edit';
 import metadata from './block.json';
+import edit from './edit';
 import save from './save';
 import transforms from './transforms';
 


### PR DESCRIPTION
## Description
This PR polishes the Custom HTML block. Notable changes:

- Switch from `PlainText` v1 to using `TextareaAutosize` directly.
- Refresh UI and increase font size to match the latest Edit as HTML style introduced in #25539.
- Move `defaultStyles` into a constant defined outside of the component, so it doesn't get recreated every time the `useSelect` callback runs.
- Rename `wp-block-html` CSS class to `block-library-html`.
- Remove usage of `components-tab-button` CSS class that appears to have no visible effect or purpose.
- Remove unnecessary `margin-bottom` editor style.
- Reorder imports alphabetically.

## Screenshots

### Unselected

#### Before
![image](https://user-images.githubusercontent.com/19592990/94698649-22e0b580-02ff-11eb-873e-6681b0e0ce0a.png)

#### After
![image](https://user-images.githubusercontent.com/19592990/94700002-98995100-0300-11eb-990d-f8bdf2d8f936.png)

### Selected; textarea NOT focused

#### Before
![image](https://user-images.githubusercontent.com/19592990/94700805-8370f200-0301-11eb-92fe-851bca5bad39.png)

#### After
![image](https://user-images.githubusercontent.com/19592990/94700179-cf6f6700-0300-11eb-9643-62822373462b.png)

### Selected; textarea focused

#### Before
![image](https://user-images.githubusercontent.com/19592990/94698538-09d80480-02ff-11eb-92c3-04593cef94a7.png)

#### After
![image](https://user-images.githubusercontent.com/19592990/94700028-a222b900-0300-11eb-9180-0fae63eae951.png)

### Navigation mode AKA select tool

#### Before
![image](https://user-images.githubusercontent.com/19592990/94698602-16f4f380-02ff-11eb-9bee-0d9c75b9f002.png)

#### After
![image](https://user-images.githubusercontent.com/19592990/94700284-e57d2780-0300-11eb-974f-13f50449dd9c.png)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
