### PR TITLE
Allow setting multiple block styles.

### DIFF
--- a/packages/block-editor/src/components/block-styles/index.js
+++ b/packages/block-editor/src/components/block-styles/index.js
@@ -10,6 +10,9 @@ import classnames from 'classnames';
 import { compose } from '@wordpress/compose';
 import { withSelect, withDispatch } from '@wordpress/data';
 import TokenList from '@wordpress/token-list';
+import { Icon } from '@wordpress/components';
+import { check } from '@wordpress/icons';
+
 import { ENTER, SPACE } from '@wordpress/keycodes';
 import { _x } from '@wordpress/i18n';
 import {
@@ -24,14 +27,16 @@ import {
 import BlockPreview from '../block-preview';
 
 /**
- * Returns the active style from the given className.
+ * Returns the active styles from the given className.
  *
- * @param {Array} styles Block style variations.
+ * @param {Array} styles      Block style variations.
  * @param {string} className  Class name
  *
- * @return {Object?} The active style.
+ * @return {Array} The active styles.
  */
-export function getActiveStyle( styles, className ) {
+export function getActiveStyles( styles, className ) {
+	const activeStyles = [];
+
 	for ( const style of new TokenList( className ).values() ) {
 		if ( style.indexOf( 'is-style-' ) === -1 ) {
 			continue;
@@ -40,30 +45,51 @@ export function getActiveStyle( styles, className ) {
 		const potentialStyleName = style.substring( 9 );
 		const activeStyle = find( styles, { name: potentialStyleName } );
 		if ( activeStyle ) {
-			return activeStyle;
+			activeStyles.push( activeStyle );
 		}
 	}
 
-	return find( styles, 'isDefault' );
+	if ( activeStyles.length ) {
+		return activeStyles;
+	}
+
+	const defaultStyle = find( styles, 'isDefault' );
+
+	if ( defaultStyle ) {
+		return [ defaultStyle ];
+	}
+
+	return [];
 }
 
 /**
- * Replaces the active style in the block's className.
+ * Removes the style from the block's className.
  *
  * @param {string}  className   Class name.
- * @param {Object?} activeStyle The replaced style.
- * @param {Object}  newStyle    The replacing style.
+ * @param {Object} style        The style to remove.
  *
  * @return {string} The updated className.
  */
-export function replaceActiveStyle( className, activeStyle, newStyle ) {
+export function removeStyle( className, style ) {
 	const list = new TokenList( className );
 
-	if ( activeStyle ) {
-		list.remove( 'is-style-' + activeStyle.name );
-	}
+	list.remove( 'is-style-' + style.name );
 
-	list.add( 'is-style-' + newStyle.name );
+	return list.value;
+}
+
+/**
+ * Adds the style to the block's className.
+ *
+ * @param {string}  className   Class name.
+ * @param {Object} style        The style to add.
+ *
+ * @return {string} The updated className.
+ */
+export function addStyle( className, style ) {
+	const list = new TokenList( className );
+
+	list.add( 'is-style-' + style.name );
 
 	return list.value;
 }
@@ -92,13 +118,12 @@ function BlockStyles( {
 		];
 	}
 
-	const activeStyle = getActiveStyle( styles, className );
+	const activeStyles = getActiveStyles( styles, className );
+
 	function updateClassName( style ) {
-		const updatedClassName = replaceActiveStyle(
-			className,
-			activeStyle,
-			style
-		);
+		const action = activeStyles.includes( style ) ? removeStyle : addStyle;
+		const updatedClassName = action( className, style );
+
 		onChangeClassName( updatedClassName );
 		onHoverClassName( null );
 		onSwitch();
@@ -107,18 +132,14 @@ function BlockStyles( {
 	return (
 		<div className="block-editor-block-styles">
 			{ styles.map( ( style ) => {
-				const styleClassName = replaceActiveStyle(
-					className,
-					activeStyle,
-					style
-				);
+				const styleClassName = 'is-style-' + style.name;
 				return (
 					<div
 						key={ style.name }
 						className={ classnames(
 							'block-editor-block-styles__item',
 							{
-								'is-active': activeStyle === style,
+								'is-active': activeStyles.includes( style ),
 							}
 						) }
 						onClick={ () => updateClassName( style ) }
@@ -157,6 +178,9 @@ function BlockStyles( {
 										  } )
 								}
 							/>
+							{ activeStyles.includes( style ) ? (
+								<Icon icon={ check } />
+							) : null }
 						</div>
 						<div className="block-editor-block-styles__item-label">
 							{ style.label || style.name }

--- a/packages/block-editor/src/components/block-styles/style.scss
+++ b/packages/block-editor/src/components/block-styles/style.scss
@@ -49,6 +49,17 @@
 	align-items: center;
 	flex-grow: 1;
 	min-height: 80px;
+	position: relative;
+
+	svg {
+		position: absolute;
+		top: 0;
+		right: 0;
+		border-bottom-left-radius: $radius-block-ui;
+		border-left: $border-width solid $dark-gray-primary;
+		border-bottom: $border-width solid $dark-gray-primary;
+		background: #fff;
+	}
 }
 
 .block-editor-block-styles__item-label {

--- a/packages/block-editor/src/components/block-styles/test/index.js
+++ b/packages/block-editor/src/components/block-styles/test/index.js
@@ -1,76 +1,82 @@
 /**
  * Internal dependencies
  */
-import { getActiveStyle, replaceActiveStyle } from '../';
+import { getActiveStyles, removeStyle, addStyle } from '../';
 
-describe( 'getActiveStyle', () => {
-	it( 'Should return the undefined if no active style', () => {
+describe( 'getActiveStyles', () => {
+	it( 'Should return empty array if no active styles', () => {
 		const styles = [ { name: 'small' }, { name: 'big' } ];
 		const className = 'custom-className';
 
-		expect( getActiveStyle( styles, className ) ).toBeUndefined();
+		expect( getActiveStyles( styles, className ) ).toEqual( [] );
 	} );
 
 	it( 'Should return the default style if no active style', () => {
 		const styles = [ { name: 'small' }, { name: 'big', isDefault: true } ];
 		const className = 'custom-className';
 
-		expect( getActiveStyle( styles, className ).name ).toBe( 'big' );
+		expect( getActiveStyles( styles, className ) ).toEqual( [
+			{ name: 'big', isDefault: true },
+		] );
 	} );
 
-	it( 'Should return the active style', () => {
-		const styles = [ { name: 'small' }, { name: 'big', isDefault: true } ];
-		const className = 'this-is-custom is-style-small';
-
-		expect( getActiveStyle( styles, className ).name ).toBe( 'small' );
-	} );
-
-	it( 'Should return the first active style', () => {
+	it( 'Should return all active styles', () => {
 		const styles = [ { name: 'small' }, { name: 'big', isDefault: true } ];
 		const className = 'this-is-custom is-style-small is-style-big';
 
-		expect( getActiveStyle( styles, className ).name ).toBe( 'small' );
+		expect(
+			getActiveStyles( styles, className ).map( ( s ) => s.name )
+		).toEqual( [ 'small', 'big' ] );
 	} );
 } );
 
-describe( 'replaceActiveStyle', () => {
-	it( 'Should add the new style if no active style', () => {
-		const activeStyle = undefined;
-		const newStyle = { name: 'small' };
+describe( 'addStyle', () => {
+	it( 'Should add the new style if no active styles', () => {
+		const style = { name: 'small' };
 		const className = 'custom-class';
 
-		expect( replaceActiveStyle( className, activeStyle, newStyle ) ).toBe(
+		expect( addStyle( className, style ) ).toBe(
 			'custom-class is-style-small'
 		);
 	} );
 
-	it( 'Should add the new style if no active style (no existing class)', () => {
-		const activeStyle = undefined;
-		const newStyle = { name: 'small' };
+	it( 'Should add the new style if no active style or class', () => {
+		const style = { name: 'small' };
 		const className = '';
 
-		expect( replaceActiveStyle( className, activeStyle, newStyle ) ).toBe(
-			'is-style-small'
-		);
+		expect( addStyle( className, style ) ).toBe( 'is-style-small' );
 	} );
 
-	it( 'Should add the new style if no active style (unassigned default)', () => {
-		const activeStyle = { name: 'default' };
-		const newStyle = { name: 'small' };
-		const className = '';
+	it( 'Should not add the new style if it is already active', () => {
+		const style = { name: 'small' };
+		const className = 'custom-class is-style-small';
 
-		expect( replaceActiveStyle( className, activeStyle, newStyle ) ).toBe(
-			'is-style-small'
-		);
-	} );
-
-	it( 'Should replace the previous active style', () => {
-		const activeStyle = { name: 'large' };
-		const newStyle = { name: 'small' };
-		const className = 'custom-class is-style-large';
-
-		expect( replaceActiveStyle( className, activeStyle, newStyle ) ).toBe(
+		expect( addStyle( className, style ) ).toBe(
 			'custom-class is-style-small'
 		);
+	} );
+} );
+
+describe( 'removeStyle', () => {
+	it( 'Should remove the style if it is an active style', () => {
+		const style = { name: 'small' };
+		const className = 'custom-class is-style-small';
+
+		expect( removeStyle( className, style ) ).toBe( 'custom-class' );
+	} );
+
+	it( "Should not do anything if the style isn't active", () => {
+		const style = { name: 'small' };
+		const className = '';
+
+		expect( removeStyle( className, style ) ).toBe( '' );
+	} );
+
+	it( 'Should remove the style if it is defined multiple times', () => {
+		const style = { name: 'small' };
+		const className =
+			'is-style-small custom-class is-style-small is-style-small';
+
+		expect( removeStyle( className, style ) ).toBe( 'custom-class' );
 	} );
 } );


### PR DESCRIPTION
## Description
This PR allows setting multiple active block styles for a block. Closes #14598 .
To better distinguish between active and inactive styles I added a check mark to the top right corner of the style preview (see screenshot). A similar check mark can be seen in the media library when selecting images.

## How has this been tested?
Tested with a fresh wp-env environment. Made sure that setting multiple styles work in the Gutenberg editor and that they are correctly rendered on front end. Passes the entire test suite.

## Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/3417292/79690298-60c2b380-8262-11ea-92d9-4f281436b86d.png)

## Types of changes
This changes the behavior of block styles so that multiple can be active at once. This doesn't break using just a single style and if no styles are selected the default style is still enforced. However since multiple styles can be selected, the user interaction changes a bit: choosing a style no longer disables the previous selected style.

One thing to consider is that this makes it possible to activate styles that conflict with each other. Most of the time it's probably obvious like setting multiple styles that affect background or border, but maybe not in all cases. Unfortunately I can't see any bulletproof solution to this as discussed here https://github.com/WordPress/gutenberg/issues/14598 .

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
