### PR TITLE
Revert changes to Nav Block data fetching mechanics

### DIFF
--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -32,8 +32,7 @@ import {
 import { compose } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { menu } from '@wordpress/icons';
-import { addQueryArgs } from '@wordpress/url';
-import { useApiFetch } from '@wordpress/api-fetch';
+
 /**
  * Internal dependencies
  */
@@ -47,6 +46,9 @@ function Navigation( {
 	clientId,
 	fontSize,
 	hasExistingNavItems,
+	hasResolvedPages,
+	isRequestingPages,
+	pages,
 	setAttributes,
 	setFontSize,
 	updateNavItemBlocks,
@@ -55,6 +57,7 @@ function Navigation( {
 	//
 	// HOOKS
 	//
+	/* eslint-disable @wordpress/no-unused-vars-before-return */
 	const ref = useRef();
 	const { selectBlock } = useDispatch( 'core/block-editor' );
 	const { TextColor, BackgroundColor, ColorPanel } = __experimentalUseColors(
@@ -78,35 +81,14 @@ function Navigation( {
 		[ fontSize.size ]
 	);
 
+	/* eslint-enable @wordpress/no-unused-vars-before-return */
 	const { navigatorToolbarButton, navigatorModal } = useBlockNavigator(
 		clientId
 	);
 
-	const baseUrl = '/wp/v2/pages';
-
-	// "view" is required to ensure Pages are returned by REST API
-	// for users with lower capabilities such as "Contributor" otherwise
-	// Pages are not returned in the request if "edit" context is set
-	const context = 'view';
-
-	const filterDefaultPages = {
-		parent: 0,
-		order: 'asc',
-		orderby: 'id',
-		context,
-	};
-
-	const queryPath = addQueryArgs( baseUrl, filterDefaultPages );
-
-	const { isLoading: isRequestingPages, data: pages } = useApiFetch(
-		queryPath
-	);
-
-	const hasPages = !! pages;
-
 	// Builds navigation links from default Pages.
 	const defaultPagesNavigationItems = useMemo( () => {
-		if ( ! hasPages ) {
+		if ( ! pages ) {
 			return null;
 		}
 
@@ -145,6 +127,8 @@ function Navigation( {
 		updateNavItemBlocks( defaultPagesNavigationItems );
 		selectBlock( clientId );
 	}
+
+	const hasPages = hasResolvedPages && pages && pages.length;
 
 	const blockInlineStyles = {
 		fontSize: fontSize.size ? fontSize.size + 'px' : undefined,
@@ -307,8 +291,31 @@ export default compose( [
 	withSelect( ( select, { clientId } ) => {
 		const innerBlocks = select( 'core/block-editor' ).getBlocks( clientId );
 
+		const filterDefaultPages = {
+			parent: 0,
+			order: 'asc',
+			orderby: 'id',
+		};
+
+		const pagesSelect = [
+			'core',
+			'getEntityRecords',
+			[ 'postType', 'page', filterDefaultPages ],
+		];
+
 		return {
 			hasExistingNavItems: !! innerBlocks.length,
+			pages: select( 'core' ).getEntityRecords(
+				'postType',
+				'page',
+				filterDefaultPages
+			),
+			isRequestingPages: select( 'core/data' ).isResolving(
+				...pagesSelect
+			),
+			hasResolvedPages: select( 'core/data' ).hasFinishedResolution(
+				...pagesSelect
+			),
 		};
 	} ),
 	withDispatch( ( dispatch, { clientId } ) => {

--- a/packages/block-library/src/navigation/edit.js
+++ b/packages/block-library/src/navigation/edit.js
@@ -57,7 +57,7 @@ function Navigation( {
 	//
 	// HOOKS
 	//
-	/* eslint-disable @wordpress/no-unused-vars-before-return */
+
 	const ref = useRef();
 	const { selectBlock } = useDispatch( 'core/block-editor' );
 	const { TextColor, BackgroundColor, ColorPanel } = __experimentalUseColors(
@@ -81,7 +81,6 @@ function Navigation( {
 		[ fontSize.size ]
 	);
 
-	/* eslint-enable @wordpress/no-unused-vars-before-return */
 	const { navigatorToolbarButton, navigatorModal } = useBlockNavigator(
 		clientId
 	);


### PR DESCRIPTION
This PR has been extracted from https://github.com/WordPress/gutenberg/pull/21674.

It partially reverts commit f2b677851aed870fa8216861561b3ce0197c03c4 (based on PR https://github.com/WordPress/gutenberg/pull/18669) which changed the data fetching mechanics for the Navigation Block to use `apiFetch` (via a new `useApiFetch` hook).

This PR **only reverts the changes to the Nav Block** to utilise `useApiFetch` Hook. The deprecation of `useApiFetch` will be handled in a separate PR.

**Note this does not solve the issue where Contributor users cannot "Create from top-level Pages"** because of [the `context` parameter being force set to `edit` within the `@wordpress/core-data` package](https://github.com/WordPress/gutenberg/blob/1c7d80b7ad8025b2cead7866e49103911cf4889a/packages/core-data/src/resolvers.js#L97). If this were overridable and could be set to `view` then this issue would be fixed, but that should be addressed in another PR via a change to `core-data` (cc @nerrad ).

See also https://github.com/WordPress/gutenberg/pull/21674#issuecomment-616396963

## Description
Reverted the Nav Block data fetch mechanics back to how it was prior to https://github.com/WordPress/gutenberg/pull/18669.

## How has this been tested?
* Check e2e tests still pass.
* Check Block behaves correctly and without errors in the Editor.


## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
