### PR TITLE
Set font styles from block appender placeholder to inherit

### DIFF
--- a/packages/block-editor/src/components/default-block-appender/style.scss
+++ b/packages/block-editor/src/components/default-block-appender/style.scss
@@ -13,8 +13,6 @@
 	}
 
 	textarea.block-editor-default-block-appender__content { // Needs specificity in order to override input field styles from WP-admin styles.
-		font-family: $editor-font;
-		font-size: $editor-font-size; // It should match the default paragraph size.
 		border: none;
 		background: none;
 		box-shadow: none;

--- a/packages/block-editor/src/components/default-block-appender/style.scss
+++ b/packages/block-editor/src/components/default-block-appender/style.scss
@@ -13,6 +13,8 @@
 	}
 
 	textarea.block-editor-default-block-appender__content { // Needs specificity in order to override input field styles from WP-admin styles.
+		font-family: inherit;
+		font-size: inherit;
 		border: none;
 		background: none;
 		box-shadow: none;


### PR DESCRIPTION
## Description
Fixes #21724.

This PR sets `font-family` and `font-size` properties to `inherit`, so they don't force a specific font style that themes need to overwrite.

## How has this been tested?
Tested how the block appender looks in many themes (Twenty Twenty, Twenty Nineteen, Twenty Seventeen, Twenty Fifteen and Storefront) to verify #21724 is fixed in the themes affected by it and that there are no regressions in the other themes. Tested in Firefox and IE11 to ensure #8654 wasn't reintroduced.

## Screenshots
Using Twenty Seventeen (even though some other themes are affected as well):
_Before:_
![Peek 2020-04-20 12-46](https://user-images.githubusercontent.com/3616980/79743533-06c6fa00-8305-11ea-96ff-b794040e1f20.gif)

_After:_
![Peek 2020-04-20 12-57](https://user-images.githubusercontent.com/3616980/79744326-74bff100-8306-11ea-99f3-d30cbc63df9f.gif)

## Types of changes
CSS bug fix.