### PR TITLE
Fix: Gradient picker bug onToggle

### DIFF
--- a/packages/components/src/custom-gradient-picker/control-points.js
+++ b/packages/components/src/custom-gradient-picker/control-points.js
@@ -214,7 +214,11 @@ export default function ControlPoints( {
 								) {
 									return;
 								}
-								onStartControlPointChange();
+								if ( isOpen ) {
+									onStopControlPointChange();
+								} else {
+									onStartControlPointChange();
+								}
 								onToggle();
 							} }
 							onMouseDown={ () => {

--- a/packages/components/src/custom-gradient-picker/custom-gradient-bar.js
+++ b/packages/components/src/custom-gradient-picker/custom-gradient-bar.js
@@ -51,8 +51,12 @@ function InsertPoint( {
 				<Button
 					aria-expanded={ isOpen }
 					onClick={ () => {
-						setAlreadyInsertedPoint( false );
-						onOpenInserter();
+						if ( isOpen ) {
+							onCloseInserter();
+						} else {
+							setAlreadyInsertedPoint( false );
+							onOpenInserter();
+						}
 						onToggle();
 					} }
 					className="components-custom-gradient-picker__insert-point"


### PR DESCRIPTION
The custom gradient picker stops working after a double click on a control point. This PR fixes the issue by adding a case to the control point-click events that check if the control point popover is already open.

Fixes: https://github.com/WordPress/gutenberg/issues/20779

## How has this been tested?
I repeated the steps described in https://github.com/WordPress/gutenberg/issues/20779 and verified the bug does not happen anymore.