### PR TITLE
Fix: Default attribute on audio preload

### DIFF
--- a/packages/block-library/src/audio/edit.js
+++ b/packages/block-library/src/audio/edit.js
@@ -170,15 +170,15 @@ class AudioEdit extends Component {
 						/>
 						<SelectControl
 							label={ __( 'Preload' ) }
-							value={ undefined !== preload ? preload : 'none' }
+							value={ preload || '' }
 							// `undefined` is required for the preload attribute to be unset.
 							onChange={ ( value ) =>
 								setAttributes( {
-									preload:
-										'none' !== value ? value : undefined,
+									preload: value || undefined,
 								} )
 							}
 							options={ [
+								{ value: '', label: __( 'Browser default' ) },
 								{ value: 'auto', label: __( 'Auto' ) },
 								{ value: 'metadata', label: __( 'Metadata' ) },
 								{ value: 'none', label: __( 'None' ) },


### PR DESCRIPTION
## Description
Fixes: https://github.com/WordPress/gutenberg/issues/13802

Currently, the audio block assumes "none" as the default for the audio block preload attribute. This is problematic because the default is browser-specific and the default recommendation is "metadata" not none as documented in https://developer.mozilla.org/en-US/docs/Web/HTML/Element/audio.

This difference may make preloading happen even when it was explicitly set to none as https://github.com/WordPress/gutenberg/issues/13802. documents.

This PR proposes the introduction of a default preloading option called "Browser default" that uses the default on each browser, and then it allows the user to explicitly set any value.

## How has this been tested?
I created an audio block in the master version of Gutenberg with all the three values for preload.
I reloaded the editor on this branch and verified all the blocks are valid.
I verified when I select the "Browser default" option the markup does not contain a preloading attribute (it uses the browser default) all the other options are explicitly saved in the markup.
