### PR TITLE
wp-env: Add command to display Docker container logs

### DIFF
--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### New Feature
 
--   The `wp-env destroy` command for destroy and cleanup environment.
+-   View php and WordPress log output with the new `wp-env logs` command.
+-   Clean up your local environment with the new `wp-env destroy` command.
 -   Expose Docker service for running phpunit commands.
 -   You may now mount local directories to any location within the WordPress install. For example, you may specify `"wp-content/mu-plugins": "./path/to/mu-plugins"` to add mu-plugins.
 

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -244,7 +244,7 @@ wp-env destroy
 Destroy the WordPress environment. Delete docker containers and remove local files.
 ```
 
-### `wp-env logs [environment] [watch]`
+### `wp-env logs [environment]`
 
 ````sh
 wp-env logs
@@ -383,3 +383,4 @@ You can tell `wp-env` to use a custom port number so that your instance does not
 ```
 
 <br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>
+````

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -244,12 +244,22 @@ wp-env destroy
 Destroy the WordPress environment. Delete docker containers and remove local files.
 ```
 
-### `docker logs -f [container_id] >/dev/null`
+### `wp-env logs [environment] [watch]`
 
-```sh
-docker logs -f <container_id> >/dev/null
+````sh
+wp-env logs
 
-Shows the error logs of the specified container in the terminal. The container_id is the one that is visible with `docker ps -a`
+displays PHP and Docker logs for given WordPress environment.
+
+Positionals:
+  environment  Which environment to display the logs from.
+      [string] [choices: "development", "tests", "all"] [default: "development"]
+
+Options:
+  --help     Show help                                                 [boolean]
+  --version  Show version number                                       [boolean]
+  --debug    Enable debug output.                     [boolean] [default: false]
+  --watch    Watch for logs as they happen.            [boolean] [default: true]
 ```
 
 ## .wp-env.json
@@ -373,3 +383,4 @@ You can tell `wp-env` to use a custom port number so that your instance does not
 ```
 
 <br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>
+````

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -383,4 +383,3 @@ You can tell `wp-env` to use a custom port number so that your instance does not
 ```
 
 <br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>
-````

--- a/packages/env/lib/cli.js
+++ b/packages/env/lib/cli.js
@@ -117,6 +117,28 @@ module.exports = function cli() {
 		withSpinner( env.clean )
 	);
 	yargs.command(
+		'logs',
+		'displays PHP and Docker logs for given WordPress environment.',
+		( args ) => {
+			args.positional( 'environment', {
+				type: 'string',
+				describe: 'Which environment to display the logs from.',
+				choices: [ 'development', 'tests', 'all' ],
+				default: 'development',
+			} );
+			args.option( 'watch', {
+				type: 'boolean',
+				default: true,
+				describe: 'Watch for logs as they happen.',
+			} );
+		},
+		withSpinner( env.logs )
+	);
+	yargs.example(
+		'$0 logs --no-watch --environment=tests',
+		'Displays the latest logs for the e2e test environment without watching.'
+	);
+	yargs.command(
 		'run <container> [command..]',
 		"Runs an arbitrary command in one of the underlying Docker containers, for example it's useful for running wp cli commands.",
 		( args ) => {

--- a/packages/env/lib/cli.js
+++ b/packages/env/lib/cli.js
@@ -153,6 +153,10 @@ module.exports = function cli() {
 		},
 		withSpinner( env.run )
 	);
+	yargs.example(
+		'$0 run cli wp user list',
+		'Runs `wp user list` wp-cli command which lists WordPress users.'
+	);
 	yargs.command(
 		'destroy',
 		wpRed(
@@ -160,10 +164,6 @@ module.exports = function cli() {
 		),
 		() => {},
 		withSpinner( env.destroy )
-	);
-	yargs.example(
-		'$0 run cli wp user list',
-		'Runs `wp user list` wp-cli command which lists WordPress users.'
 	);
 
 	return yargs;

--- a/packages/env/lib/commands/index.js
+++ b/packages/env/lib/commands/index.js
@@ -6,6 +6,7 @@ const stop = require( './stop' );
 const clean = require( './clean' );
 const run = require( './run' );
 const destroy = require( './destroy' );
+const logs = require( './logs' );
 
 module.exports = {
 	start,
@@ -13,4 +14,5 @@ module.exports = {
 	clean,
 	run,
 	destroy,
+	logs,
 };

--- a/packages/env/lib/commands/logs.js
+++ b/packages/env/lib/commands/logs.js
@@ -1,0 +1,73 @@
+/**
+ * External dependencies
+ */
+const dockerCompose = require( 'docker-compose' );
+
+/**
+ * Internal dependencies
+ */
+const initConfig = require( '../init-config' );
+
+/**
+ * Displays the Docker & PHP logs on the given environment.
+ *
+ * @param {Object}  options
+ * @param {Object}  options.environment The environment to run the command in (develop or tests).
+ * @param {Object}  options.watch       If true, follow along with log output.
+ * @param {Object}  options.spinner     A CLI spinner which indicates progress.
+ * @param {boolean} options.debug       True if debug mode is enabled.
+ */
+module.exports = async function logs( { environment, watch, spinner, debug } ) {
+	const config = await initConfig( { spinner, debug } );
+
+	// If we show text while watching the logs, it will continue showing up every
+	// few lines in the logs as they happen, which isn't a good look. So only
+	// show the message if we are not watching the logs.
+	if ( ! watch ) {
+		spinner.text = `Showing logs for the ${ environment } environment.`;
+	}
+
+	const servicesToWatch =
+		environment === 'all'
+			? [ 'tests-wordpress', 'wordpress' ]
+			: [ 'tests' ? 'tests-wordpress' : 'wordpress' ];
+
+	const output = await Promise.all( [
+		...servicesToWatch.map( ( service ) =>
+			dockerCompose.logs( service, {
+				config: config.dockerComposeConfigPath,
+				log: watch, // Must log inline if we are watching the log output.
+				commandOptions: watch ? [ '--follow' ] : [],
+			} )
+		),
+	] );
+
+	// Combine the results from each docker output.
+	const result = output.reduce(
+		( acc, current ) => {
+			if ( current.out ) {
+				acc.out = acc.out.concat( current.out );
+			}
+			if ( current.err ) {
+				acc.err = acc.err.concat( current.err );
+			}
+			return acc;
+		},
+		{ out: '', err: '' }
+	);
+
+	if ( result.out.length ) {
+		// eslint-disable-next-line no-console
+		console.log(
+			process.stdout.isTTY ? `\n\n${ result.out }\n\n` : result.out
+		);
+	} else if ( result.err.length ) {
+		// eslint-disable-next-line no-console
+		console.error(
+			process.stdout.isTTY ? `\n\n${ result.err }\n\n` : result.err
+		);
+		throw result.err;
+	}
+
+	spinner.text = 'Finished showing logs.';
+};


### PR DESCRIPTION
## Description
Adds a command to display logs for the given WordPress environment.

```sh
# Watches for and displays the latest logs on the
# development WordPress instance as they happen.
wp-env log
```

Also accepts `--environment=tests` (to display logs for the testing environment) and `--watch=false` (to only show the logs once without watching).

cc @glendaviesnz & @noisysocks 

## How has this been tested?
1. Checkout this branch in Gutenberg repo locally
2. From the root of gutenberg, run `./packages/env/bin/wp-env start`
3. Then run `./packages/env/bin/wp-env log`
4. Visit localhost:8888 and verify that log output displays in the terminal from step 3.

## Screenshots <!-- if applicable -->
<img width="1400" alt="Screen Shot 2020-04-20 at 11 55 03 AM" src="https://user-images.githubusercontent.com/6265975/79789552-3ffc6b80-82ff-11ea-8e13-ab1b71d79d3b.png">


## Types of changes
New feature

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
