### PR TITLE
Add inserter previews to more blocks.

### DIFF
--- a/packages/block-library/src/archives/index.js
+++ b/packages/block-library/src/archives/index.js
@@ -20,5 +20,6 @@ export const settings = {
 		align: true,
 		html: false,
 	},
+	example: {},
 	edit,
 };

--- a/packages/block-library/src/categories/index.js
+++ b/packages/block-library/src/categories/index.js
@@ -20,5 +20,6 @@ export const settings = {
 		align: true,
 		html: false,
 	},
+	example: {},
 	edit,
 };

--- a/packages/block-library/src/latest-comments/index.js
+++ b/packages/block-library/src/latest-comments/index.js
@@ -21,5 +21,6 @@ export const settings = {
 		align: true,
 		html: false,
 	},
+	example: {},
 	edit,
 };

--- a/packages/block-library/src/latest-posts/index.js
+++ b/packages/block-library/src/latest-posts/index.js
@@ -23,6 +23,7 @@ export const settings = {
 		align: true,
 		html: false,
 	},
+	example: {},
 	edit,
 	deprecated,
 };

--- a/packages/block-library/src/tag-cloud/index.js
+++ b/packages/block-library/src/tag-cloud/index.js
@@ -20,5 +20,6 @@ export const settings = {
 		html: false,
 		align: true,
 	},
+	example: {},
 	edit,
 };


### PR DESCRIPTION
## Description
Adds inserter previews to the following blocks:

- Archives
- Categories
- Latest Comments
- Latest Posts
- Tag Cloud

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
