### PR TITLE
Embed: use same SmugMug URL regex as core.

### DIFF
--- a/packages/block-library/src/embed/core-embeds.js
+++ b/packages/block-library/src/embed/core-embeds.js
@@ -315,7 +315,7 @@ export const others = [
 			icon: embedPhotoIcon,
 			description: __( 'Embed SmugMug content.' ),
 		},
-		patterns: [ /^https?:\/\/(www\.)?smugmug\.com\/.+/i ],
+		patterns: [ /^https?:\/\/(.+\.)?smugmug\.com\/.*/i ],
 	},
 	{
 		// Deprecated in favour of the core-embed/speaker-deck block.


### PR DESCRIPTION
## Description
Makes SmugMug embed URL regex [consistent with core](https://github.com/WordPress/wordpress-develop/blob/master/src/wp-includes/class-wp-oembed.php#L61). Extracted from #13755; see [this comment](https://github.com/WordPress/gutenberg/pull/13755/files#r395026947).