### PR TITLE
Add InserterPanel around block directory results.

### DIFF
--- a/packages/block-directory/src/components/downloadable-blocks-panel/style.scss
+++ b/packages/block-directory/src/components/downloadable-blocks-panel/style.scss
@@ -2,7 +2,6 @@
 .block-directory-downloadable-blocks-panel__description {
 	font-style: italic;
 	padding: 0;
-	margin-top: 0;
 	text-align: left;
 	color: $dark-gray-400;
 }

--- a/packages/block-editor/src/components/inserter/block-list.js
+++ b/packages/block-editor/src/components/inserter/block-list.js
@@ -281,7 +281,13 @@ function InserterBlockList( {
 			>
 				{ ( fills ) => {
 					if ( fills.length ) {
-						return fills;
+						return (
+							<InserterPanel
+								title={ _x( 'Search Results', 'blocks' ) }
+							>
+								{ fills }
+							</InserterPanel>
+						);
 					}
 					if ( ! hasItems ) {
 						return (


### PR DESCRIPTION
## Description
This PR addresses #21746 using the `InserterPanel` component. 

## How has this been tested?
Manual test by turning on Block Directory Experiment and searching for `Boxer`.

## Screenshots 
### With Blocks:
![Screenshot](https://d.pr/i/ZDeTy8.png)

### Without Blocks:
![Screenshot](https://d.pr/i/kmnXp0.png)

## Types of changes
This PR reestablishes the padding around the container but introduces **1** change. By using the `InserterPanel` component, a title had to be provided. I believe this helps in creating a consistent experiment but the copy should be scrutinized: `Search Results`.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
