### PR TITLE
Allow title and button-based appender to inherit styles.

### DIFF
--- a/packages/block-editor/src/components/default-block-appender/style.scss
+++ b/packages/block-editor/src/components/default-block-appender/style.scss
@@ -55,7 +55,7 @@
 .block-editor-block-list__empty-block-inserter.block-editor-block-list__empty-block-inserter, // Empty paragraph, needs specificity to override inherited popover styles.
 .block-editor-default-block-appender .block-editor-inserter { // Empty appender.
 	position: absolute;
-	top: 2px; // Centers it in the default paragraph height.
+	top: 0;
 	height: $button-size-small + $grid-unit-10;
 
 	.block-editor-inserter__toggle {

--- a/packages/editor/src/components/post-title/style.scss
+++ b/packages/editor/src/components/post-title/style.scss
@@ -1,6 +1,5 @@
 .editor-post-title {
 	position: relative;
-	font-size: $editor-font-size;
 
 	.editor-post-title__input {
 		display: block;
@@ -8,13 +7,15 @@
 		margin: 0;
 		box-shadow: none;
 		background: transparent;
-		font-family: $editor-font;
-		line-height: $default-line-height;
-		color: $dark-gray-900;
 		transition: border 0.1s ease-out, box-shadow 0.1s linear;
 		@include reduce-motion("transition");
 		padding: #{ $block-padding + 5px } 0;
 		word-break: keep-all;
+
+		// Inherit the styles set by the theme.
+		font-family: inherit;
+		line-height: inherit;
+		color: inherit;
 
 		// Stack borders on mobile.
 		border: $border-width solid transparent;
@@ -31,7 +32,7 @@
 
 		// Match h1 heading.
 		font-size: 2.44em;
-		font-weight: 600;
+		font-weight: bold;
 
 		// Large text needs a 3:1 contrast ratio.
 		&::-webkit-input-placeholder {


### PR DESCRIPTION
File under "should've probably done this sooner", this PR allows the title field and the initial appender to inherit the theme styles defined by an editor style.

In the past this wasn't possible due to how things were structured. But as it is, those styles are inherited by what is applied to the `editor-styles-wrapper`, which means this works both for themes that don't register and editor style — it looks like before — but now it also works for themes that do.

Before, vanilla style:

<img width="724" alt="before" src="https://user-images.githubusercontent.com/1204802/79849576-f2493700-83c2-11ea-827c-15dad59e417f.png">

After, vanilla style:

<img width="703" alt="vanilla" src="https://user-images.githubusercontent.com/1204802/79849607-f9704500-83c2-11ea-84fc-36a649bfd2a0.png">

After, with the following CSS registered as an editor style:

```
body {
	font-family: "Muli", sans-serif;
	font-size: 18px;
}
```

<img width="695" alt="customized" src="https://user-images.githubusercontent.com/1204802/79849672-0e4cd880-83c3-11ea-964b-f88788134254.png">

Because the title is not inside an `h1` element, we can't yet inherit font sizes and weights there. But this will be fixed once the title element becomes an actual block.