### PR TITLE
Create Block: Make it easier to provide most popular CLI options

### DIFF
--- a/packages/create-block/CHANGELOG.md
+++ b/packages/create-block/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Master
 
+### New Features
+
+- Add more CLI options: `--namespace`, `--title`, `--description` and `--category`. The goal is to make it easier to override default values used for scaffolding ([#21751](https://github.com/WordPress/gutenberg/pull/21751)).
+
 ### Enhancements
 
 - Update `esnext` template to scaffold 3 JavaScript source files to illustrate how ES modules help to better organize code.

--- a/packages/create-block/CHANGELOG.md
+++ b/packages/create-block/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### New Features
 
-- Add more CLI options: `--namespace`, `--title`, `--description` and `--category`. The goal is to make it easier to override default values used for scaffolding ([#21751](https://github.com/WordPress/gutenberg/pull/21751)).
+- Add more CLI options: `--namespace`, `--title`, `--short-description` and `--category`. The goal is to make it easier to override default values used for scaffolding ([#21751](https://github.com/WordPress/gutenberg/pull/21751)).
 
 ### Enhancements
 

--- a/packages/create-block/README.md
+++ b/packages/create-block/README.md
@@ -33,13 +33,17 @@ The following command generates PHP, JS and CSS code for registering a block.
 $ npm init @wordpress/block [options] [slug]
 ```
 
-`[slug]` is optional. When provided it triggers the quick mode where it is used as the block slug used for its identification, the output location for scaffolded files, and the name of the WordPress plugin. The rest of the configuration is set to all default values.
+`[slug]` is optional. When provided it triggers the quick mode where it is used as the block slug used for its identification, the output location for scaffolded files, and the name of the WordPress plugin. The rest of the configuration is set to all default values unless overriden with some of the options listed below.
 
 Options:
-```bash
--t, --template <name>  template type name, allowed values: "es5", "esnext" (default: "esnext")
--V, --version          output the version number
--h, --help             output usage information
+```
+-V, --version                output the version number
+-t, --template <name>        template type name, allowed values: "es5", "esnext" (default: "esnext")
+--namespace <namespace>      internal namespace for the block name
+--title <title>              display title for the block
+--description <description>  short description for the block
+--category <category>        category name for the block
+-h, --help                   output usage information
 ```
 
 _Please note that `--version` and `--help` options don't work with `npm init`. You have to use `npx` instead, as presented in the examples._

--- a/packages/create-block/README.md
+++ b/packages/create-block/README.md
@@ -39,10 +39,10 @@ Options:
 ```
 -V, --version                output the version number
 -t, --template <name>        template type name, allowed values: "es5", "esnext" (default: "esnext")
---namespace <namespace>      internal namespace for the block name
---title <title>              display title for the block
---description <description>  short description for the block
---category <category>        category name for the block
+--namespace <value>          internal namespace for the block name
+--title <value>              display title for the block
+--short-description <value>  short description for the block
+--category <name>            category name for the block
 -h, --help                   output usage information
 ```
 


### PR DESCRIPTION
## Description

Add more CLI options: `--namespace`, `--title`, `--description` and `--category`. The goal is to make it easier to override default values used for block scaffolding. Full specification:

```
--namespace <value>         internal namespace for the block name
--title <value>             display title for the block
--short-description <value> short description for the block
--category <name>           category name for the block
```

There are more prompts than that but I picked those which are the most important. We probably could support all of them. I'm happy to tackle that in the follow-up PR.

## How has this been tested?

ES5 template + quick mode:

```bash
npx wp-create-block todo-list --template es5 --namespace gziolo --title "To-do List" --short-description "To-do list description" --category widgets
```

![Screen Shot 2020-04-24 at 10 32 40](https://user-images.githubusercontent.com/699132/80192087-f4a3cf00-8616-11ea-99db-45fc2b48c21b.png)


ESNext template + interactive mode where provided options are skipped:

```bash
npx wp-create-block --namespace gziolo --title "To-do List" --short-description "To-do list description" --category widgets
```

![Screen Shot 2020-04-24 at 10 33 37](https://user-images.githubusercontent.com/699132/80192170-143af780-8617-11ea-9508-fdc83a940edb.png)

```bash
npx wp-create-block --help
```

![Screen Shot 2020-04-24 at 10 36 25](https://user-images.githubusercontent.com/699132/80192464-801d6000-8617-11ea-92d1-e7c340a7ade8.png)


## Types of changes
New feature (non-breaking change which adds functionality).

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
