### PR TITLE
[RNMobile] - Block list - Autoscroll to text components within InnerBlocks

### DIFF
--- a/packages/block-editor/src/components/block-list/index.native.js
+++ b/packages/block-editor/src/components/block-list/index.native.js
@@ -7,7 +7,7 @@ import { View, Platform, TouchableWithoutFeedback } from 'react-native';
 /**
  * WordPress dependencies
  */
-import { Component } from '@wordpress/element';
+import { Component, createContext } from '@wordpress/element';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { compose, withPreferredColorScheme } from '@wordpress/compose';
 import { createBlock } from '@wordpress/blocks';
@@ -24,6 +24,8 @@ import styles from './style.scss';
 import BlockListBlock from './block';
 import BlockListAppender from '../block-list-appender';
 import BlockInsertionPoint from './insertion-point';
+
+const BlockListContext = createContext();
 
 export class BlockList extends Component {
 	constructor() {
@@ -91,6 +93,25 @@ export class BlockList extends Component {
 	}
 
 	render() {
+		const { isRootList } = this.props;
+
+		// Use of Context to propagate the main scroll ref to its children e.g InnerBlocks
+		return isRootList ? (
+			<BlockListContext.Provider value={ this.scrollViewRef }>
+				{ this.renderList() }
+			</BlockListContext.Provider>
+		) : (
+			<BlockListContext.Consumer>
+				{ ( ref ) =>
+					this.renderList( {
+						parentScrollRef: ref,
+					} )
+				}
+			</BlockListContext.Consumer>
+		);
+	}
+
+	renderList( extraProps = {} ) {
 		const {
 			clearSelectedBlock,
 			blockClientIds,
@@ -106,6 +127,7 @@ export class BlockList extends Component {
 			isStackedHorizontally,
 			horizontalAlignment,
 		} = this.props;
+		const { parentScrollRef } = extraProps;
 
 		const { blockToolbar, blockBorder, headerToolbar } = styles;
 
@@ -130,7 +152,9 @@ export class BlockList extends Component {
 						: {} ) } // Disable clipping on Android to fix focus losing. See https://github.com/wordpress-mobile/gutenberg-mobile/pull/741#issuecomment-472746541
 					accessibilityLabel="block-list"
 					autoScroll={ this.props.autoScroll }
-					innerRef={ this.scrollViewInnerRef }
+					innerRef={ ( ref ) => {
+						this.scrollViewInnerRef( parentScrollRef || ref );
+					} }
 					extraScrollHeight={
 						blockToolbar.height + blockBorder.width
 					}


### PR DESCRIPTION
`Gutenberg Mobile PR` -> https://github.com/wordpress-mobile/gutenberg-mobile/pull/2171

## Description
An issue [was reported](https://github.com/wordpress-mobile/gutenberg-mobile/issues/2157) about the autoscroll feature for text components not working when they are nested within InnerBlocks.

After some investigating, it turns out the main scroll reference of the `BlockList` is not being passed down when another `BlockList` is within the main one (InnerBlocks).

After some tests, I ended up using Context to solve this issue. There isn't much code change so the idea is for the `RootList` it will render the `Provider` and for the different `BlockList` within the root one, it will render a `Consumer` that we'll look up in the tree for the value of its main `Provider`, in this case, the scroll reference.

## How has this been tested?

- Open the app with metro running
- Add a Group block
- Add a Paragraph Block
- Make sure that you are very near the bottom of the screen to test the autoscroll.
- Start writing lines in the Paragraph block
- **Expect** that the autoscroll works when you start typing outside the visible area of the screen. It should scroll down to be able to see the text you're typing.
- Add another Paragraph block outside the Group block
- Start typing text and adding new lines
- **Expect** the autoscroll to focus on the newly added lines that were outside of the visible area of the screen.

## Screenshots

<details><summary>iOS AutoScroll</summary>

InnerBlocks | Root level
-|-
<img src="https://user-images.githubusercontent.com/4885740/79861382-9edfe480-83d4-11ea-9a96-5c1243c4fae5.gif" width="250" /> | <img src="https://user-images.githubusercontent.com/4885740/79861587-ebc3bb00-83d4-11ea-8b60-50ee0541a996.gif" width="250" />

</details>

<details><summary>Android AutoScroll</summary>

InnerBlocks | Root level
-|-
<img src="https://user-images.githubusercontent.com/4885740/79861755-2c233900-83d5-11ea-88c2-c443718d64d9.gif" width="250" /> | <img src="https://user-images.githubusercontent.com/4885740/79861769-2e859300-83d5-11ea-871c-7a079c8ae6e6.gif" width="250" />

</details>

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
