### PR TITLE
Move caret to the end of pasted content

### DIFF
--- a/docs/designers-developers/developers/data/data-core-block-editor.md
+++ b/docs/designers-developers/developers/data/data-core-block-editor.md
@@ -1124,7 +1124,7 @@ _Parameters_
 -   _clientIds_ `(string|Array<string>)`: Block client ID(s) to replace.
 -   _blocks_ `(Object|Array<Object>)`: Replacement block(s).
 -   _indexToSelect_ `number`: Index of replacement block to select.
--   _initialPosition_ `bool`: Index of caret after in the selected block after the operation.
+-   _initialPosition_ `number`: Index of caret after in the selected block after the operation.
 
 <a name="replaceInnerBlocks" href="#replaceInnerBlocks">#</a> **replaceInnerBlocks**
 

--- a/docs/designers-developers/developers/data/data-core-block-editor.md
+++ b/docs/designers-developers/developers/data/data-core-block-editor.md
@@ -1124,6 +1124,7 @@ _Parameters_
 -   _clientIds_ `(string|Array<string>)`: Block client ID(s) to replace.
 -   _blocks_ `(Object|Array<Object>)`: Replacement block(s).
 -   _indexToSelect_ `number`: Index of replacement block to select.
+-   _initialPosition_ `bool`: Index of caret after in the selected block after the operation.
 
 <a name="replaceInnerBlocks" href="#replaceInnerBlocks">#</a> **replaceInnerBlocks**
 

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -322,14 +322,19 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps, { select } ) => {
 				}
 			}
 		},
-		onReplace( blocks, indexToSelect ) {
+		onReplace( blocks, indexToSelect, initialPosition ) {
 			if (
 				blocks.length &&
 				! isUnmodifiedDefaultBlock( blocks[ blocks.length - 1 ] )
 			) {
 				__unstableMarkLastChangeAsPersistent();
 			}
-			replaceBlocks( [ ownProps.clientId ], blocks, indexToSelect );
+			replaceBlocks(
+				[ ownProps.clientId ],
+				blocks,
+				indexToSelect,
+				initialPosition
+			);
 		},
 		toggleSelection( selectionEnabled ) {
 			toggleSelection( selectionEnabled );

--- a/packages/block-editor/src/components/copy-handler/index.js
+++ b/packages/block-editor/src/components/copy-handler/index.js
@@ -64,7 +64,7 @@ function CopyHandler( { children } ) {
 				canUserUseUnfilteredHTML,
 			} );
 
-			replaceBlocks( selectedBlockClientIds, blocks );
+			replaceBlocks( selectedBlockClientIds, blocks, blocks.length - 1, -1 );
 		}
 	};
 

--- a/packages/block-editor/src/components/copy-handler/index.js
+++ b/packages/block-editor/src/components/copy-handler/index.js
@@ -64,7 +64,12 @@ function CopyHandler( { children } ) {
 				canUserUseUnfilteredHTML,
 			} );
 
-			replaceBlocks( selectedBlockClientIds, blocks, blocks.length - 1, -1 );
+			replaceBlocks(
+				selectedBlockClientIds,
+				blocks,
+				blocks.length - 1,
+				-1
+			);
 		}
 	};
 

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -315,7 +315,11 @@ function RichTextWrapper(
 			// Otherwise, set the selection to the second block.
 			const indexToSelect = hasPastedBlocks ? blocks.length - 1 : 1;
 
-			onReplace( blocks, indexToSelect );
+			// If there are pasted blocks, move the caret to the end of the selected block
+			// Otherwise, retain the default value.
+			const initialPosition = hasPastedBlocks ? -1 : null;
+
+			onReplace( blocks, indexToSelect, initialPosition );
 		},
 		[ onReplace, onSplit, multilineTag, onSplitMiddle ]
 	);
@@ -436,7 +440,7 @@ function RichTextWrapper(
 				onChange( insert( value, valueToInsert ) );
 			} else if ( content.length > 0 ) {
 				if ( onReplace && isEmpty( value ) ) {
-					onReplace( content );
+					onReplace( content, content.length - 1, -1 );
 				} else {
 					splitValue( value, content );
 				}

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -274,6 +274,7 @@ function RichTextWrapper(
 			const blocks = [];
 			const [ before, after ] = split( record );
 			const hasPastedBlocks = pastedBlocks.length > 0;
+			let lastPastedBlockIndex = -1;
 
 			// Create a block with the content before the caret if there's no pasted
 			// blocks, or if there are pasted blocks and the value is not empty.
@@ -288,10 +289,12 @@ function RichTextWrapper(
 						} )
 					)
 				);
+				lastPastedBlockIndex += 1;
 			}
 
 			if ( hasPastedBlocks ) {
 				blocks.push( ...pastedBlocks );
+				lastPastedBlockIndex += pastedBlocks.length;
 			} else if ( onSplitMiddle ) {
 				blocks.push( onSplitMiddle() );
 			}
@@ -313,7 +316,7 @@ function RichTextWrapper(
 
 			// If there are pasted blocks, set the selection to the last one.
 			// Otherwise, set the selection to the second block.
-			const indexToSelect = hasPastedBlocks ? blocks.length - 1 : 1;
+			const indexToSelect = hasPastedBlocks ? lastPastedBlockIndex : 1;
 
 			// If there are pasted blocks, move the caret to the end of the selected block
 			// Otherwise, retain the default value.

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -287,12 +287,17 @@ function getBlocksWithDefaultStylesApplied( blocks, blockEditorSettings ) {
  *
  * @param {(string|string[])} clientIds     Block client ID(s) to replace.
  * @param {(Object|Object[])} blocks        Replacement block(s).
- * @param {number}            indexToSelect Index of replacement block to
- *                                          select.
+ * @param {number}            indexToSelect Index of replacement block to select.
+ * @param {bool}              initialPosition Index of caret after in the selected block after the operation.
  *
  * @yield {Object} Action object.
  */
-export function* replaceBlocks( clientIds, blocks, indexToSelect ) {
+export function* replaceBlocks(
+	clientIds,
+	blocks,
+	indexToSelect,
+	initialPosition
+) {
 	clientIds = castArray( clientIds );
 	blocks = getBlocksWithDefaultStylesApplied(
 		castArray( blocks ),
@@ -322,6 +327,7 @@ export function* replaceBlocks( clientIds, blocks, indexToSelect ) {
 		blocks,
 		time: Date.now(),
 		indexToSelect,
+		initialPosition,
 	};
 	yield* ensureDefaultBlock();
 }

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -288,7 +288,7 @@ function getBlocksWithDefaultStylesApplied( blocks, blockEditorSettings ) {
  * @param {(string|string[])} clientIds     Block client ID(s) to replace.
  * @param {(Object|Object[])} blocks        Replacement block(s).
  * @param {number}            indexToSelect Index of replacement block to select.
- * @param {bool}              initialPosition Index of caret after in the selected block after the operation.
+ * @param {number}            initialPosition Index of caret after in the selected block after the operation.
  *
  * @yield {Object} Action object.
  */

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1093,7 +1093,7 @@ function selection( state = {}, action ) {
 			}
 
 			const newState = { clientId: blockToSelect.clientId };
-			if ( typeof action.initialPosition === "number" ) {
+			if ( typeof action.initialPosition === 'number' ) {
 				newState.initialPosition = action.initialPosition;
 			}
 			return newState;

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1092,7 +1092,11 @@ function selection( state = {}, action ) {
 				return state;
 			}
 
-			return { clientId: blockToSelect.clientId, initialPosition: -1 };
+			const newState = { clientId: blockToSelect.clientId };
+			if ( typeof action.initialPosition === "number" ) {
+				newState.initialPosition = action.initialPosition;
+			}
+			return newState;
 		}
 	}
 
@@ -1189,9 +1193,9 @@ export function isSelectionEnabled( state = true, action ) {
 /**
  * Reducer returning the intial block selection.
  *
- * Currently this in only used to restore the selection after block deletion.
- * This reducer should eventually be removed in favour of setting selection
- * directly.
+ * Currently this in only used to restore the selection after block deletion and
+ * pasting new content.This reducer should eventually be removed in favour of setting
+ * selection directly.
  *
  * @param {boolean} state  Current state.
  * @param {Object}  action Dispatched action.

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1092,7 +1092,7 @@ function selection( state = {}, action ) {
 				return state;
 			}
 
-			return { clientId: blockToSelect.clientId };
+			return { clientId: blockToSelect.clientId, initialPosition: -1 };
 		}
 	}
 
@@ -1199,7 +1199,12 @@ export function isSelectionEnabled( state = true, action ) {
  * @return {?number} Initial position: -1 or undefined.
  */
 export function initialPosition( state, action ) {
-	if ( action.type === 'SELECT_BLOCK' ) {
+	if (
+		action.type === 'REPLACE_BLOCKS' &&
+		typeof action.initialPosition === 'number'
+	) {
+		return action.initialPosition;
+	} else if ( action.type === 'SELECT_BLOCK' ) {
 		return action.initialPosition;
 	} else if ( action.type === 'REMOVE_BLOCKS' ) {
 		return state;

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/multi-block-selection.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/multi-block-selection.test.js.snap
@@ -62,6 +62,48 @@ exports[`Multi-block selection should only trigger multi-selection when at the e
 <!-- /wp:paragraph -->"
 `;
 
+exports[`Multi-block selection should place the caret at the end of last pasted paragraph (paste mid-block) 1`] = `
+"<!-- wp:paragraph -->
+<p>first paragra</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>first paragraph</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>second paragrap</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>ph</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>second paragraph</p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`Multi-block selection should place the caret at the end of last pasted paragraph (paste to empty editor) 1`] = `
+"<!-- wp:paragraph -->
+<p>first paragraph</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>second paragrap</p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`Multi-block selection should place the caret at the end of last pasted paragraph (replace) 1`] = `
+"<!-- wp:paragraph -->
+<p>first paragraph</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>second paragrap</p>
+<!-- /wp:paragraph -->"
+`;
+
 exports[`Multi-block selection should preserve dragged selection on move 1`] = `
 "<!-- wp:paragraph -->
 <p>2</p>

--- a/packages/e2e-tests/specs/editor/various/multi-block-selection.test.js
+++ b/packages/e2e-tests/specs/editor/various/multi-block-selection.test.js
@@ -491,4 +491,56 @@ describe( 'Multi-block selection', () => {
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
+
+	it( 'should place the caret at the end of last pasted paragraph (paste to empty editor)', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( 'first paragraph' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'second paragraph' );
+		await pressKeyWithModifier( 'primary', 'a' );
+		await pressKeyWithModifier( 'primary', 'a' );
+		await pressKeyWithModifier( 'primary', 'c' );
+		await page.keyboard.press( 'Backspace' );
+		await pressKeyWithModifier( 'primary', 'v' );
+		await page.keyboard.press( 'Backspace' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'should place the caret at the end of last pasted paragraph (paste mid-block)', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( 'first paragraph' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'second paragraph' );
+		await pressKeyWithModifier( 'primary', 'a' );
+		await pressKeyWithModifier( 'primary', 'a' );
+		await pressKeyWithModifier( 'primary', 'c' );
+
+		await page.keyboard.press( 'ArrowRight' );
+		await page.keyboard.press( 'ArrowLeft' );
+		await page.keyboard.press( 'ArrowLeft' );
+		await page.keyboard.press( 'ArrowLeft' );
+
+		await pressKeyWithModifier( 'primary', 'v' );
+		await page.keyboard.press( 'Backspace' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+		// This code path triggers an unrelated React warning. Without the check below,
+		// this test would fail. Let's remove it below once the warning is fixed.
+		expect( console ).toHaveErroredWith( "Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in %s.%s the componentWillUnmount method \n    in r (created by Context.Consumer)\n    in v (created by S)\n    in S (created by Ql)\n    in div (created by Qa)\n    in Qa (created by ei)\n    in ei (created by Ss)\n    in Ss (created by Ql)\n    in div (created by Ql)\n    in Ql (created by es)\n    in D (created by C)\n    in C (created by BlockFormatControlsFill)\n    in BlockFormatControlsFill (created by Context.Consumer)\n    in IfBlockEditSelected(BlockFormatControlsFill) (created by es)\n    in es (created by n)" );
+	} );
+
+	it( 'should place the caret at the end of last pasted paragraph (replace)', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( 'first paragraph' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'second paragraph' );
+		await pressKeyWithModifier( 'primary', 'a' );
+		await pressKeyWithModifier( 'primary', 'a' );
+		await pressKeyWithModifier( 'primary', 'c' );
+		await pressKeyWithModifier( 'primary', 'v' );
+		await page.keyboard.press( 'Backspace' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
 } );

--- a/packages/e2e-tests/specs/editor/various/multi-block-selection.test.js
+++ b/packages/e2e-tests/specs/editor/various/multi-block-selection.test.js
@@ -527,7 +527,9 @@ describe( 'Multi-block selection', () => {
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 		// This code path triggers an unrelated React warning. Without the check below,
 		// this test would fail. Let's remove it below once the warning is fixed.
-		expect( console ).toHaveErroredWith( "Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in %s.%s the componentWillUnmount method \n    in r (created by Context.Consumer)\n    in v (created by S)\n    in S (created by Ql)\n    in div (created by Qa)\n    in Qa (created by ei)\n    in ei (created by Ss)\n    in Ss (created by Ql)\n    in div (created by Ql)\n    in Ql (created by es)\n    in D (created by C)\n    in C (created by BlockFormatControlsFill)\n    in BlockFormatControlsFill (created by Context.Consumer)\n    in IfBlockEditSelected(BlockFormatControlsFill) (created by es)\n    in es (created by n)" );
+		expect( console ).toHaveErroredWith(
+			"Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in %s.%s the componentWillUnmount method \n    in r (created by Context.Consumer)\n    in v (created by S)\n    in S (created by Ql)\n    in div (created by Qa)\n    in Qa (created by ei)\n    in ei (created by Ss)\n    in Ss (created by Ql)\n    in div (created by Ql)\n    in Ql (created by es)\n    in D (created by C)\n    in C (created by BlockFormatControlsFill)\n    in BlockFormatControlsFill (created by Context.Consumer)\n    in IfBlockEditSelected(BlockFormatControlsFill) (created by es)\n    in es (created by n)"
+		);
 	} );
 
 	it( 'should place the caret at the end of last pasted paragraph (replace)', async () => {

--- a/packages/e2e-tests/specs/editor/various/multi-block-selection.test.js
+++ b/packages/e2e-tests/specs/editor/various/multi-block-selection.test.js
@@ -525,11 +525,6 @@ describe( 'Multi-block selection', () => {
 		await page.keyboard.press( 'Backspace' );
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
-		// This code path triggers an unrelated React warning. Without the check below,
-		// this test would fail. Let's remove it below once the warning is fixed.
-		expect( console ).toHaveErroredWith(
-			"Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in %s.%s the componentWillUnmount method \n    in r (created by Context.Consumer)\n    in v (created by S)\n    in S (created by Ql)\n    in div (created by Qa)\n    in Qa (created by ei)\n    in ei (created by Ss)\n    in Ss (created by Ql)\n    in div (created by Ql)\n    in Ql (created by es)\n    in D (created by C)\n    in C (created by BlockFormatControlsFill)\n    in BlockFormatControlsFill (created by Context.Consumer)\n    in IfBlockEditSelected(BlockFormatControlsFill) (created by es)\n    in es (created by n)"
-		);
 	} );
 
 	it( 'should place the caret at the end of last pasted paragraph (replace)', async () => {


### PR DESCRIPTION
## Description

When you paste a couple paragraphs into Gutenberg, your cursor remains at the beginning of the last paragraph you pasted. I expect it to be at the end of the last paragraph pasted. This PR updates initialPosition to -1 which, in turn, moves the caret to the end of the paragraph.

Solves #5317

## How has this been tested?
Tested locally:

1. Open the editor
1. Paste two paragraphs of content
1. Confirm that with this PR the caret is at the end of the last paragraph

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
