### PR TITLE
Add align class to pull quote in editor

### DIFF
--- a/packages/block-library/src/pullquote/edit.js
+++ b/packages/block-library/src/pullquote/edit.js
@@ -105,7 +105,7 @@ class PullQuoteEdit extends Component {
 			className,
 		} = this.props;
 
-		const { value, citation } = attributes;
+		const { value, citation, align } = attributes;
 
 		const isSolidColorStyle = includes( className, SOLID_COLOR_CLASS );
 		const figureStyles = isSolidColorStyle
@@ -115,6 +115,7 @@ class PullQuoteEdit extends Component {
 		const figureClasses = classnames( className, {
 			'has-background': isSolidColorStyle && mainColor.color,
 			[ mainColor.class ]: isSolidColorStyle && mainColor.class,
+			[ `align${ align }` ]: align,
 		} );
 
 		const blockquoteStyles = {


### PR DESCRIPTION
## Description
Fixes #12853

## How has this been tested?
Tested locally by:

- create a post
- add a pullquote block
- use the block toolbar to align left/right/wide
- check with inspector that the figure in the editor has the align* class added

## Types of changes
Non breaking change affecting only the editor.