### PR TITLE
Post title: handle paste as blocks

### DIFF
--- a/packages/editor/src/components/post-title/index.js
+++ b/packages/editor/src/components/post-title/index.js
@@ -14,6 +14,7 @@ import { ENTER } from '@wordpress/keycodes';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { VisuallyHidden } from '@wordpress/components';
 import { withInstanceId, compose } from '@wordpress/compose';
+import { pasteHandler } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -33,6 +34,7 @@ class PostTitle extends Component {
 		this.onSelect = this.onSelect.bind( this );
 		this.onUnselect = this.onUnselect.bind( this );
 		this.onKeyDown = this.onKeyDown.bind( this );
+		this.onPaste = this.onPaste.bind( this );
 
 		this.state = {
 			isSelected: false,
@@ -57,6 +59,57 @@ class PostTitle extends Component {
 		if ( event.keyCode === ENTER ) {
 			event.preventDefault();
 			this.props.onEnterPress();
+		}
+	}
+
+	onPaste( event ) {
+		const { title, onInsertBlockAfter, onUpdate } = this.props;
+		const clipboardData = event.clipboardData;
+
+		let plainText = '';
+		let html = '';
+
+		// IE11 only supports `Text` as an argument for `getData` and will
+		// otherwise throw an invalid argument error, so we try the standard
+		// arguments first, then fallback to `Text` if they fail.
+		try {
+			plainText = clipboardData.getData( 'text/plain' );
+			html = clipboardData.getData( 'text/html' );
+		} catch ( error1 ) {
+			try {
+				html = clipboardData.getData( 'Text' );
+			} catch ( error2 ) {
+				// Some browsers like UC Browser paste plain text by default and
+				// don't support clipboardData at all, so allow default
+				// behaviour.
+				return;
+			}
+		}
+
+		// Allows us to ask for this information when we get a report.
+		window.console.log( 'Received HTML:\n\n', html );
+		window.console.log( 'Received plain text:\n\n', plainText );
+
+		const content = pasteHandler( {
+			HTML: html,
+			plainText,
+		} );
+
+		if ( typeof content !== 'string' && content.length ) {
+			event.preventDefault();
+
+			const [ firstBlock ] = content;
+
+			if (
+				! title &&
+				( firstBlock.name === 'core/heading' ||
+					firstBlock.name === 'core/paragraph' )
+			) {
+				onUpdate( firstBlock.attributes.content );
+				onInsertBlockAfter( content.slice( 1 ) );
+			} else {
+				onInsertBlockAfter( content );
+			}
 		}
 	}
 
@@ -102,6 +155,7 @@ class PostTitle extends Component {
 						onBlur={ this.onUnselect }
 						onKeyDown={ this.onKeyDown }
 						onKeyPress={ this.onUnselect }
+						onPaste={ this.onPaste }
 						/*
 							Only autofocus the title when the post is entirely empty.
 							This should only happen for a new post, which means we
@@ -137,7 +191,7 @@ const applyWithSelect = withSelect( ( select ) => {
 } );
 
 const applyWithDispatch = withDispatch( ( dispatch ) => {
-	const { insertDefaultBlock, clearSelectedBlock } = dispatch(
+	const { insertDefaultBlock, clearSelectedBlock, insertBlocks } = dispatch(
 		'core/block-editor'
 	);
 	const { editPost } = dispatch( 'core/editor' );
@@ -145,6 +199,9 @@ const applyWithDispatch = withDispatch( ( dispatch ) => {
 	return {
 		onEnterPress() {
 			insertDefaultBlock( undefined, undefined, 0 );
+		},
+		onInsertBlockAfter( blocks ) {
+			insertBlocks( blocks, 0 );
 		},
 		onUpdate( title ) {
 			editPost( { title } );


### PR DESCRIPTION
## Description

This PR handles pasting in the post title (post editor) a bit better. Before everything would be pasted inline as the title, now we parse the pasted content as blocks and paste the block after the title. If the first block is a heading or a paragraph AND the title is empty, the content of this first block will be used for the title. I've left out more complex splitting, for example when there would be already text in the title and the selection is in the middle. Ideally we should be using RichText or PlainText version 2 for the post title, which has built in splitting and paste handling, but in order to use this, the post title should be a real block... which I think we plan to do at some point? I recall having run into problems with the post title block a few times now because it's not a real block, especially with writing flow. Cc @youknowriad @mtias.

To do: maybe add some e2e tests.

## How has this been tested?

Paste a few blocks of text from a page into the post title. Also try to paste a small string of text, try with title already filled in etc.

## Screenshots <!-- if applicable -->

## Types of changes

Enhancement

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
