### PR TITLE
Navigation Link block: add RichText split-at-end/merge/remove behavior

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -57,6 +57,9 @@ function NavigationLinkEdit( {
 	saveEntityRecord,
 	selectedBlockHasDescendants,
 	userCanCreatePages = false,
+	insertBlocksAfter,
+	mergeBlocks,
+	onReplace,
 } ) {
 	const { label, opensInNewTab, url, nofollow, description } = attributes;
 	const link = {
@@ -221,10 +224,18 @@ function NavigationLinkEdit( {
 				<div className="wp-block-navigation-link__content">
 					<RichText
 						ref={ ref }
+						identifier="label"
 						className="wp-block-navigation-link__label"
 						value={ label }
 						onChange={ ( labelValue ) =>
 							setAttributes( { label: labelValue } )
+						}
+						onMerge={ mergeBlocks }
+						onReplace={ onReplace }
+						__unstableOnSplitAtEnd={ () =>
+							insertBlocksAfter(
+								createBlock( 'core/navigation-link' )
+							)
 						}
 						placeholder={ itemLabelPlaceholder }
 						keepPlaceholderOnFocus

--- a/packages/block-library/src/navigation-link/index.js
+++ b/packages/block-library/src/navigation-link/index.js
@@ -12,17 +12,20 @@ import edit from './edit';
 import save from './save';
 
 const { name } = metadata;
+
 export { metadata, name };
 
 export const settings = {
 	title: __( 'Navigation Link' ),
-
 	icon,
-
 	description: __( 'Add a page, link, or another item to your navigation.' ),
-
 	__experimentalLabel: ( { label } ) => label,
-
+	merge( leftAttributes, { label: rightLabel = '' } ) {
+		return {
+			...leftAttributes,
+			label: leftAttributes.label + rightLabel,
+		};
+	},
 	edit,
 	save,
 };


### PR DESCRIPTION
## Description
Closes #21743.
Closes #18208.

This PR adds several RichText behavior enhancements to Navigation Link blocks. It introduces the following behaviors:
- Removing an empty Navigation Link using <kbd>Backspace</kbd> or <kbd>Delete</kbd>.
- Creating a new Navigation Link by pressing <kbd>Enter</kbd> at the end of an existing one.
- Merging two adjacent Navigation Links by pressing <kbd>Backspace</kbd> or <kbd>Delete</kbd>. The labels are merged; all other attributes are kept as they are on the first block while those on the second are discarded. Children of the first block are kept, but children of the second block are lost. (No idea how to change this; ideally, I would want all the children to be moved under the first block.)

Notably, the ability to split an existing Navigation Link into two has been omitted, since this would cause a loss of all its children. I have no idea how to add this behavior and preserve children; I suspect it may not be possible to fix without improvements to the RichText APIs.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
