### PR TITLE
Template Parts: Improve resolution and saving behavior.

### DIFF
--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -84,34 +84,60 @@ function create_auto_draft_for_template_part_block( $block ) {
 	global $_wp_current_template_part_ids;
 
 	if ( 'core/template-part' === $block['blockName'] ) {
-		if ( ! isset( $block['attrs']['postId'] ) ) {
-			$template_part_file_path =
-				get_stylesheet_directory() . '/block-template-parts/' . $block['attrs']['slug'] . '.html';
-			if ( ! file_exists( $template_part_file_path ) ) {
-				if ( gutenberg_is_experiment_enabled( 'gutenberg-full-site-editing-demo' ) ) {
-					$template_part_file_path =
-						dirname( __FILE__ ) . '/demo-block-template-parts/' . $block['attrs']['slug'] . '.html';
-					if ( ! file_exists( $template_part_file_path ) ) {
-						return;
-					}
-				} else {
-					return;
-				}
-			}
-			$template_part_id = wp_insert_post(
+		if ( isset( $block['attrs']['postId'] ) ) {
+			// Template part is customized.
+			$template_part_id = $block['attrs']['postId'];
+		} else {
+			// A published post might already exist if this template part
+			// was customized elsewhere or if it's part of a customized
+			// template. We also check if an auto-draft was already created
+			// because preloading can make this run twice, so, different code
+			// paths can end up with different posts for the same template part.
+			// E.g. The server could send back post ID 1 to the client, preload,
+			// and create another auto-draft. So, if the client tries to resolve the
+			// post ID from the slug and theme, it won't match with what the server sent.
+			$template_part_query = new WP_Query(
 				array(
-					'post_content' => file_get_contents( $template_part_file_path ),
-					'post_title'   => $block['attrs']['slug'],
-					'post_status'  => 'auto-draft',
-					'post_type'    => 'wp_template_part',
-					'post_name'    => $block['attrs']['slug'],
-					'meta_input'   => array(
-						'theme' => $block['attrs']['theme'],
-					),
+					'post_type'      => 'wp_template_part',
+					'post_status'    => array( 'publish', 'auto-draft' ),
+					'name'           => $block['attrs']['slug'],
+					'meta_key'       => 'theme',
+					'meta_value'     => $block['attrs']['theme'],
+					'posts_per_page' => 1,
+					'no_found_rows'  => true,
 				)
 			);
-		} else {
-			$template_part_id = $block['attrs']['postId'];
+			$template_part_post  = $template_part_query->have_posts() ? $template_part_query->next_post() : null;
+			if ( $template_part_post ) {
+				$template_part_id = $template_part_post->ID;
+			} else {
+				// Template part is not customized, get it from a file and make an auto-draft for it.
+				$template_part_file_path =
+				get_stylesheet_directory() . '/block-template-parts/' . $block['attrs']['slug'] . '.html';
+				if ( ! file_exists( $template_part_file_path ) ) {
+					if ( gutenberg_is_experiment_enabled( 'gutenberg-full-site-editing-demo' ) ) {
+						$template_part_file_path =
+							dirname( __FILE__ ) . '/demo-block-template-parts/' . $block['attrs']['slug'] . '.html';
+						if ( ! file_exists( $template_part_file_path ) ) {
+							return;
+						}
+					} else {
+						return;
+					}
+				}
+				$template_part_id = wp_insert_post(
+					array(
+						'post_content' => file_get_contents( $template_part_file_path ),
+						'post_title'   => $block['attrs']['slug'],
+						'post_status'  => 'auto-draft',
+						'post_type'    => 'wp_template_part',
+						'post_name'    => $block['attrs']['slug'],
+						'meta_input'   => array(
+							'theme' => $block['attrs']['theme'],
+						),
+					)
+				);
+			}
 		}
 
 		if ( isset( $_wp_current_template_part_ids ) ) {

--- a/lib/template-parts.php
+++ b/lib/template-parts.php
@@ -69,6 +69,26 @@ function gutenberg_register_template_part_post_type() {
 add_action( 'init', 'gutenberg_register_template_part_post_type' );
 
 /**
+ * Filters `wp_template_part` posts slug resolution to bypass deduplication logic as
+ * template part slugs should be unique.
+ *
+ * @param string $slug          The resolved slug (post_name).
+ * @param int    $post_ID       Post ID.
+ * @param string $post_status   No uniqueness checks are made if the post is still draft or pending.
+ * @param string $post_type     Post type.
+ * @param int    $post_parent   Post parent ID.
+ * @param int    $original_slug The desired slug (post_name).
+ * @return string The original, desired slug.
+ */
+function gutenberg_filter_wp_template_part_wp_unique_post_slug( $slug, $post_ID, $post_status, $post_type, $post_parent, $original_slug ) {
+	if ( 'wp_template_part' === $post_type ) {
+		return $original_slug;
+	}
+	return $slug;
+}
+add_filter( 'wp_unique_post_slug', 'gutenberg_filter_wp_template_part_wp_unique_post_slug', 10, 6 );
+
+/**
  * Fixes the label of the 'wp_template_part' admin menu entry.
  */
 function gutenberg_fix_template_part_admin_menu_entry() {

--- a/packages/block-library/src/template-part/edit/use-template-part-post.js
+++ b/packages/block-library/src/template-part/edit/use-template-part-post.js
@@ -26,20 +26,25 @@ export default function useTemplatePartPost( postId, slug, theme ) {
 					'postType',
 					'wp_template_part',
 					{
-						status: 'auto-draft',
+						status: [ 'publish', 'auto-draft' ],
 						slug,
 						meta: { theme },
 					}
 				);
+				const foundPosts = posts?.filter(
+					( post ) =>
+						post.slug === slug &&
+						post.meta &&
+						post.meta.theme === theme
+				);
+				// A published post might already exist if this template part was customized elsewhere
+				// or if it's part of a customized template.
 				const foundPost =
-					posts &&
-					posts.find(
-						( post ) =>
-							post.slug === slug &&
-							post.meta &&
-							post.meta.theme === theme
+					foundPosts?.find( ( post ) => post.status === 'publish' ) ||
+					foundPosts?.find(
+						( post ) => post.status === 'auto-draft'
 					);
-				return foundPost && foundPost.id;
+				return foundPost?.id;
 			}
 		},
 		[ postId, slug, theme ]

--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -24,7 +24,7 @@ function render_block_core_template_part( $attributes ) {
 			array(
 				'post_type'      => 'wp_template_part',
 				'post_status'    => 'publish',
-				'post_name'      => $attributes['slug'],
+				'name'           => $attributes['slug'],
 				'meta_key'       => 'theme',
 				'meta_value'     => $attributes['theme'],
 				'posts_per_page' => 1,

--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -20,11 +20,29 @@ function render_block_core_template_part( $attributes ) {
 		// is user-customized, render the corresponding post content.
 		$content = get_post( $attributes['postId'] )->post_content;
 	} elseif ( wp_get_theme()->get( 'TextDomain' ) === $attributes['theme'] ) {
-		// Else, if the template part was provided by the active theme,
-		// render the corresponding file content.
-		$template_part_file_path = get_stylesheet_directory() . '/block-template-parts/' . $attributes['slug'] . '.html';
-		if ( 0 === validate_file( $template_part_file_path ) && file_exists( $template_part_file_path ) ) {
-			$content = file_get_contents( $template_part_file_path );
+		$template_part_query = new WP_Query(
+			array(
+				'post_type'      => 'wp_template_part',
+				'post_status'    => 'publish',
+				'post_name'      => $attributes['slug'],
+				'meta_key'       => 'theme',
+				'meta_value'     => $attributes['theme'],
+				'posts_per_page' => 1,
+				'no_found_rows'  => true,
+			)
+		);
+		$template_part_post  = $template_part_query->have_posts() ? $template_part_query->next_post() : null;
+		if ( $template_part_post ) {
+			// A published post might already exist if this template part was customized elsewhere
+			// or if it's part of a customized template.
+			$content = $template_part_post->post_content;
+		} else {
+			// Else, if the template part was provided by the active theme,
+			// render the corresponding file content.
+			$template_part_file_path = get_stylesheet_directory() . '/block-template-parts/' . $attributes['slug'] . '.html';
+			if ( 0 === validate_file( $template_part_file_path ) && file_exists( $template_part_file_path ) ) {
+				$content = file_get_contents( $template_part_file_path );
+			}
 		}
 	}
 


### PR DESCRIPTION
Closes #21512

## Description

Template part resolution works by looking for a `postId` attribute on the block and falling back to looking for the theme's provided template part `.html` file using the `theme` and `slug` attributes. The `postId` is only added to a template part instance after it is customized and saved. This meant that after customizing a template part, templates that referenced it only by `slug` and `theme` would not resolve to the customized template part.

This was fixed by adding an intermediate check between the `postId` and `.html` file lookup where we check for a published template part for the appropriate `theme` and `slug`.

Additionally, there was an issue wherein customizing a template part sometimes the API appended counters (`-2`) to slugs. This was fixed by using the `wp_unique_post_slug` filter, just like for templates.

## How to test this?

- Activate the full site editing experiment and demo templates.
- Edit and save the `header` template part in isolation.
- Verify that the `front-page` template now renders the edited `header` both in the editor and front end.

## Types of Changes

*Bug Fix:* Template part resolution now works as expected in templates referencing customized template parts.

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->