### PR TITLE
Template Switcher: Add theme preview

### DIFF
--- a/packages/edit-site/src/components/template-switcher/index.js
+++ b/packages/edit-site/src/components/template-switcher/index.js
@@ -17,7 +17,7 @@ import { plus } from '@wordpress/icons';
  * Internal dependencies
  */
 import AddTemplate from '../add-template';
-import TemplatePreview from './preview';
+import TemplatePreview from './template-preview';
 import ThemePreview from './theme-preview';
 
 function TemplateLabel( { template } ) {

--- a/packages/edit-site/src/components/template-switcher/index.js
+++ b/packages/edit-site/src/components/template-switcher/index.js
@@ -18,6 +18,7 @@ import { plus } from '@wordpress/icons';
  */
 import AddTemplate from '../add-template';
 import TemplatePreview from './preview';
+import ThemePreview from './theme-preview';
 
 function TemplateLabel( { template } ) {
 	return (
@@ -42,12 +43,22 @@ export default function TemplateSwitcher( {
 	onAddTemplateId,
 } ) {
 	const [ hoveredTemplate, setHoveredTemplate ] = useState();
+	const [ themePreviewVisible, setThemePreviewVisible ] = useState( false );
+
 	const onHoverTemplate = ( id ) => {
 		setHoveredTemplate( { id, type: 'template' } );
 	};
 	const onHoverTemplatePart = ( id ) => {
 		setHoveredTemplate( { id, type: 'template-part' } );
 	};
+
+	const onMouseEnterTheme = () => {
+		setThemePreviewVisible( () => true );
+	};
+	const onMouseLeaveTheme = () => {
+		setThemePreviewVisible( () => false );
+	};
+
 	const { currentTheme, templates, templateParts } = useSelect(
 		( select ) => {
 			const { getCurrentTheme, getEntityRecord } = select( 'core' );
@@ -136,10 +147,18 @@ export default function TemplateSwitcher( {
 							/>
 						</MenuGroup>
 						<MenuGroup label={ __( 'Current theme' ) }>
-							<MenuItem>{ currentTheme.name }</MenuItem>
+							<MenuItem
+								onMouseEnter={ onMouseEnterTheme }
+								onMouseLeave={ onMouseLeaveTheme }
+							>
+								{ currentTheme.name }
+							</MenuItem>
 						</MenuGroup>
 						{ !! hoveredTemplate?.id && (
 							<TemplatePreview item={ hoveredTemplate } />
+						) }
+						{ themePreviewVisible && (
+							<ThemePreview theme={ currentTheme } />
 						) }
 						<div className="edit-site-template-switcher__footer" />
 					</>

--- a/packages/edit-site/src/components/template-switcher/style.scss
+++ b/packages/edit-site/src/components/template-switcher/style.scss
@@ -54,7 +54,7 @@
 }
 
 .edit-site-template-switcher__theme-preview-screenshot {
-	margin-bottom: 1em;
-	margin-top: 1em;
+	margin-bottom: $grid-unit-15;
+	margin-top: $grid-unit-15;
 	max-width: 100%;
 }

--- a/packages/edit-site/src/components/template-switcher/style.scss
+++ b/packages/edit-site/src/components/template-switcher/style.scss
@@ -30,7 +30,7 @@
 	margin-bottom: -$grid-unit-15;
 }
 
-.edit-site-template-switcher__preview,
+.edit-site-template-switcher__template-preview,
 .edit-site-template-switcher__theme-preview {
 	display: none;
 	border: $border-width solid $light-gray-secondary;

--- a/packages/edit-site/src/components/template-switcher/style.scss
+++ b/packages/edit-site/src/components/template-switcher/style.scss
@@ -30,7 +30,8 @@
 	margin-bottom: -$grid-unit-15;
 }
 
-.edit-site-template-switcher__preview {
+.edit-site-template-switcher__preview,
+.edit-site-template-switcher__theme-preview {
 	display: none;
 	border: $border-width solid $light-gray-secondary;
 	width: 300px;
@@ -45,4 +46,15 @@
 	@include break-medium {
 		display: block;
 	}
+}
+
+.edit-site-template-switcher__theme-preview-name {
+	font-weight: 500;
+	font-size: 140%;
+}
+
+.edit-site-template-switcher__theme-preview-screenshot {
+	margin-bottom: 1em;
+	margin-top: 1em;
+	max-width: 100%;
 }

--- a/packages/edit-site/src/components/template-switcher/style.scss
+++ b/packages/edit-site/src/components/template-switcher/style.scss
@@ -50,7 +50,7 @@
 
 .edit-site-template-switcher__theme-preview-name {
 	font-weight: 500;
-	font-size: 140%;
+	font-size: $big-font-size;
 }
 
 .edit-site-template-switcher__theme-preview-screenshot {

--- a/packages/edit-site/src/components/template-switcher/template-preview.js
+++ b/packages/edit-site/src/components/template-switcher/template-preview.js
@@ -22,7 +22,7 @@ function TemplatePreview( { item } ) {
 		[ template ]
 	);
 	return (
-		<div className="edit-site-template-switcher__preview">
+		<div className="edit-site-template-switcher__template-preview">
 			{ !! blocks && (
 				<BlockPreview blocks={ blocks } viewportWidth={ 1200 } />
 			) }

--- a/packages/edit-site/src/components/template-switcher/theme-preview.js
+++ b/packages/edit-site/src/components/template-switcher/theme-preview.js
@@ -1,0 +1,55 @@
+/**
+ * External dependencies
+ */
+import { truncate } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import { createInterpolateElement } from '@wordpress/element';
+
+function ThemePreview( {
+	theme: {
+		author_name: authorName,
+		author_uri: authorUri,
+		description,
+		name,
+		screenshot,
+		version,
+	},
+} ) {
+	return (
+		<div className="edit-site-template-switcher__theme-preview">
+			<span className="edit-site-template-switcher__theme-preview-name">
+				{ name }
+			</span>{ ' ' }
+			<span className="edit-site-template-switcher__theme-preview-version">
+				{ 'v' + version }
+			</span>
+			<div className="edit-site-template-switcher__theme-preview-byline">
+				{ createInterpolateElement(
+					// translators: %s: theme author name.
+					sprintf( __( 'By <a>%s</a>' ), [ authorName ] ),
+					{
+						// eslint-disable-next-line jsx-a11y/anchor-has-content
+						a: <a href={ authorUri } />,
+					}
+				) }
+			</div>
+			<img
+				className="edit-site-template-switcher__theme-preview-screenshot"
+				src={ screenshot }
+				alt={ 'Theme Preview' }
+			/>
+			<div className="edit-site-template-switcher__theme-preview-description">
+				{ truncate( description, {
+					length: 120,
+					separator: /\. +/,
+				} ) }
+			</div>
+		</div>
+	);
+}
+
+export default ThemePreview;

--- a/packages/edit-site/src/components/template-switcher/theme-preview.js
+++ b/packages/edit-site/src/components/template-switcher/theme-preview.js
@@ -7,17 +7,9 @@ import { truncate } from 'lodash';
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { createInterpolateElement } from '@wordpress/element';
 
 function ThemePreview( {
-	theme: {
-		author_name: authorName,
-		author_uri: authorUri,
-		description,
-		name,
-		screenshot,
-		version,
-	},
+	theme: { author_name: authorName, description, name, screenshot, version },
 } ) {
 	return (
 		<div className="edit-site-template-switcher__theme-preview">
@@ -28,14 +20,8 @@ function ThemePreview( {
 				{ 'v' + version }
 			</span>
 			<div className="edit-site-template-switcher__theme-preview-byline">
-				{ createInterpolateElement(
-					// translators: %s: theme author name.
-					sprintf( __( 'By <a>%s</a>' ), [ authorName ] ),
-					{
-						// eslint-disable-next-line jsx-a11y/anchor-has-content
-						a: <a href={ authorUri } />,
-					}
-				) }
+				{ // translators: %s: theme author name.
+				sprintf( __( 'By %s' ), [ authorName ] ) }
 			</div>
 			<img
 				className="edit-site-template-switcher__theme-preview-screenshot"


### PR DESCRIPTION
## Description
Add on-hover theme preview to site editor's template switcher (see [mockups](https://github.com/WordPress/gutenberg/issues/20469#issuecomment-597806801)).

Fixes #20469.

## How has this been tested?
- If you haven't done yet, enable the site editor (and the demo templates) in Gutenberg > Experiments.
- Go to the Site Editor menu.
- Click on the template switcher.
- Hover over the theme name (last entry in the template switcher)

## Screenshots 

![image](https://user-images.githubusercontent.com/96308/79901605-5b0ad080-8410-11ea-94ed-eb72d9b9baa6.png)

## Types of changes
Extends existing feature.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
