### PR TITLE
Revert "Add prop to force fullscreen preview for videos. (#20436)"

### DIFF
--- a/packages/block-editor/src/components/video-player/index.native.js
+++ b/packages/block-editor/src/components/video-player/index.native.js
@@ -25,6 +25,7 @@ class Video extends Component {
 		super( ...arguments );
 		this.isIOS = Platform.OS === 'ios';
 		this.state = {
+			isFullScreen: false,
 			videoContainerHeight: 0,
 		};
 		this.onPressPlay = this.onPressPlay.bind( this );
@@ -83,12 +84,8 @@ class Video extends Component {
 	}
 
 	render() {
-		const {
-			isSelected,
-			style,
-			forceFullscreen = ! this.isIOS,
-		} = this.props;
-		const { videoContainerHeight } = this.state;
+		const { isSelected, style } = this.props;
+		const { isFullScreen, videoContainerHeight } = this.state;
 		const showPlayButton = videoContainerHeight > 0;
 
 		return (
@@ -98,12 +95,21 @@ class Video extends Component {
 					ref={ ( ref ) => {
 						this.player = ref;
 					} }
-					pointerEvents={ isSelected ? undefined : 'none' }
-					controls={ ! forceFullscreen }
+					// Using built-in player controls is messing up the layout on iOS.
+					// So we are setting controls=false and adding a play button that
+					// will trigger presentFullscreenPlayer()
+					controls={ false }
 					ignoreSilentSwitch={ 'ignore' }
+					paused={ ! isFullScreen }
 					onLayout={ this.onVideoLayout }
+					onFullscreenPlayerWillPresent={ () => {
+						this.setState( { isFullScreen: true } );
+					} }
+					onFullscreenPlayerDidDismiss={ () => {
+						this.setState( { isFullScreen: false } );
+					} }
 				/>
-				{ showPlayButton && forceFullscreen && (
+				{ showPlayButton && (
 					// If we add the play icon as a subview to VideoPlayer then react-native-video decides to show control buttons
 					// even if we set controls={ false }, so we are adding our play button as a sibling overlay view.
 					<TouchableOpacity


### PR DESCRIPTION
This reverts commit e19b804e69e1f1ebc9f1879ee249ff6f9304db9f.

On iOS the display of the native controls is causing a layout issue. I tried different alternative like:
 - Only display the controls after loading the video
 - Only display the controls after press play on the video

But none of them worked correctly so I decided to revert the original change.

## Description
<!-- Please describe what you have changed or added -->

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

This can be tested on this GB-mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/2173

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
