### PR TITLE
Gallery block: Make gallery-image figure focusable

### DIFF
--- a/packages/block-library/src/gallery/gallery-image.js
+++ b/packages/block-library/src/gallery/gallery-image.js
@@ -184,12 +184,15 @@ class GalleryImage extends Component {
 			'is-selected': isSelected,
 			'is-transient': isBlobURL( url ),
 		} );
-
+		// Safari: give the figure a tab index to make it focusable,
+		// so that the blur event is canceled when a child inside it is focused (see this.onFocus)
+		// see: https://github.com/Automattic/wp-calypso/issues/40531#issuecomment-617384307
 		return (
 			<figure
 				className={ className }
 				onBlur={ this.onBlur }
 				onFocus={ this.onFocus }
+				tabIndex="0"
 			>
 				{ href ? <a href={ href }>{ img }</a> : img }
 				<div className="block-library-gallery-item__move-menu">


### PR DESCRIPTION
_This is a fix for https://github.com/Automattic/wp-calypso/issues/40531._

## Description
Currently, when you try to move images around the gallery block, the arrow buttons fail in Safari, this is because the arrow icons are unfocusable, i.e having ([`focusable=false`](https://github.com/WordPress/dashicons/pull/241)). Meaning a blur event is fired when you click on the arrow icons, this blur event disables the buttons thus canceling the click event. This diagnosis is a bit speculative and I'm not 100% confident about it. But it holds true for the suggested fix here.

## How has this been tested?
I tested this change in Safari (where the issue is), is Chrome, and Firefox. All latest versions and desktop.


## Types of changes
This is a bugfix for https://github.com/Automattic/wp-calypso/issues/40531.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. _Please let me know if I have to do this. I don't think this is an issue in native._
