### PR TITLE
Reusable block: use block.json.

### DIFF
--- a/packages/block-library/src/block/block.json
+++ b/packages/block-library/src/block/block.json
@@ -1,0 +1,9 @@
+{
+	"name": "core/block",
+	"category": "reusable",
+	"attributes": {
+		"ref": {
+			"type": "number"
+		}
+	}
+}

--- a/packages/block-library/src/block/index.js
+++ b/packages/block-library/src/block/index.js
@@ -6,13 +6,15 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import metadata from './block.json';
 import edit from './edit';
 
-export const name = 'core/block';
+const { name } = metadata;
+
+export { metadata, name };
 
 export const settings = {
 	title: __( 'Reusable Block' ),
-	category: 'reusable',
 	description: __(
 		'Create and save content to reuse across your site. Update the block, and the changes apply everywhere it’s used.'
 	),

--- a/packages/block-library/src/block/index.php
+++ b/packages/block-library/src/block/index.php
@@ -33,14 +33,9 @@ function render_block_core_block( $attributes ) {
  * Registers the `core/block` block.
  */
 function register_block_core_block() {
-	register_block_type(
-		'core/block',
+	register_block_type_from_metadata(
+		__DIR__ . '/block',
 		array(
-			'attributes'      => array(
-				'ref' => array(
-					'type' => 'number',
-				),
-			),
 			'render_callback' => 'render_block_core_block',
 		)
 	);


### PR DESCRIPTION
## Description
This PR updates `core/block` (the Reusable Blocks block) to use a `block.json` file.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
