### PR TITLE
Try to add code to html and reverse transforms

### DIFF
--- a/packages/block-library/src/code/transforms.js
+++ b/packages/block-library/src/code/transforms.js
@@ -11,6 +11,15 @@ const transforms = {
 			transform: () => createBlock( 'core/code' ),
 		},
 		{
+			type: 'block',
+			blocks: [ 'core/html' ],
+			transform: ( { content } ) => {
+				return createBlock( 'core/code', {
+					content,
+				} );
+			},
+		},
+		{
 			type: 'raw',
 			isMatch: ( node ) =>
 				node.nodeName === 'PRE' &&

--- a/packages/block-library/src/html/index.js
+++ b/packages/block-library/src/html/index.js
@@ -10,6 +10,7 @@ import { html as icon } from '@wordpress/icons';
 import edit from './edit';
 import metadata from './block.json';
 import save from './save';
+import transforms from './transforms';
 
 const { name } = metadata;
 
@@ -35,4 +36,5 @@ export const settings = {
 	},
 	edit,
 	save,
+	transforms,
 };

--- a/packages/block-library/src/html/transforms.js
+++ b/packages/block-library/src/html/transforms.js
@@ -1,0 +1,20 @@
+/**
+ * WordPress dependencies
+ */
+import { createBlock } from '@wordpress/blocks';
+
+const transforms = {
+	from: [
+		{
+			type: 'block',
+			blocks: [ 'core/code' ],
+			transform: ( { content } ) => {
+				return createBlock( 'core/html', {
+					content,
+				} );
+			},
+		},
+	],
+};
+
+export default transforms;


### PR DESCRIPTION
## Description
Closes #13935

The problem is when the code block contains some other kind of code, not HTML, this transform is useless. What do you think @kjellr ?

## How has this been tested?
Tested locally by:

- create a post or page
- add a code block
- add some html code
- convert to html block
- add a new html block 
- add some html
- convert to code block

## Types of changes
Non breaking changes that add new transform rules to the code and html blocks.
