### PR TITLE
Fix e2e tests by removing unecessary assertions & properly installing deps in api-fetch package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21368,7 +21368,7 @@
 				},
 				"node-pre-gyp": {
 					"version": "0.12.0",
-					"resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz",
+					"resolved": false,
 					"integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
 					"dev": true,
 					"optional": true,
@@ -21399,7 +21399,7 @@
 				},
 				"nopt": {
 					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
 					"dev": true,
 					"optional": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -10363,7 +10363,7 @@
 			"version": "file:packages/api-fetch",
 			"requires": {
 				"@babel/runtime": "^7.9.2",
-				"@wordpress/deprecated": "^2.8.0",
+				"@wordpress/deprecated": "file:packages/deprecated",
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/i18n": "file:packages/i18n",
 				"@wordpress/url": "file:packages/url"
@@ -21368,7 +21368,7 @@
 				},
 				"node-pre-gyp": {
 					"version": "0.12.0",
-					"resolved": false,
+					"resolved": "",
 					"integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
 					"dev": true,
 					"optional": true,
@@ -21399,7 +21399,7 @@
 				},
 				"nopt": {
 					"version": "4.0.1",
-					"resolved": false,
+					"resolved": "",
 					"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
 					"dev": true,
 					"optional": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -21368,7 +21368,7 @@
 				},
 				"node-pre-gyp": {
 					"version": "0.12.0",
-					"resolved": "",
+					"resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz",
 					"integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
 					"dev": true,
 					"optional": true,
@@ -21399,7 +21399,7 @@
 				},
 				"nopt": {
 					"version": "4.0.1",
-					"resolved": "",
+					"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
 					"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
 					"dev": true,
 					"optional": true,
@@ -43291,9 +43291,9 @@
 			"dev": true
 		},
 		"unbzip2-stream": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.1.tgz",
-			"integrity": "sha512-sgDYfSDPMsA4Hr2/w7vOlrJBlwzmyakk1+hW8ObLvxSp0LA36LcL2XItGvOT3OSblohSdevMuT8FQjLsqyy4sA==",
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.2.tgz",
+			"integrity": "sha512-pZMVAofMrrHX6Ik39hCk470kulCbmZ2SWfQLPmTWqfJV/oUm0gn1CblvHdUu4+54Je6Jq34x8kY6XjTy6dMkOg==",
 			"dev": true,
 			"requires": {
 				"buffer": "^5.2.1",

--- a/packages/api-fetch/CHANGELOG.md
+++ b/packages/api-fetch/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.8.1 (2019-04-22)
+
+- Added deprecation to `useApiFetch` hook.
+- Added `@wordpress/deprecation` package to add deprecation notice to `useApiFetch` hook.
+
 ## 3.8.0 (2019-12-19)
 
 ### Bug Fixes

--- a/packages/api-fetch/package.json
+++ b/packages/api-fetch/package.json
@@ -23,7 +23,7 @@
 	"react-native": "src/index",
 	"dependencies": {
 		"@babel/runtime": "^7.9.2",
-		"@wordpress/deprecated": "^2.8.0",
+		"@wordpress/deprecated": "file:../deprecated",
 		"@wordpress/element": "file:../element",
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/url": "file:../url"

--- a/packages/e2e-tests/specs/experiments/multi-entity-saving.test.js
+++ b/packages/e2e-tests/specs/experiments/multi-entity-saving.test.js
@@ -173,9 +173,7 @@ describe( 'Multi-entity save flow', () => {
 			const enabledButton = await page.waitForSelector(
 				activeSaveSiteSelector
 			);
-			expect( console ).toHaveWarnedWith(
-				'useApiFetch is deprecated and will be removed from Gutenberg in version 8.1.0. Please use apiFetch instead.'
-			);
+
 			expect( enabledButton ).not.toBeNull();
 		} );
 

--- a/packages/e2e-tests/specs/experiments/navigation.test.js
+++ b/packages/e2e-tests/specs/experiments/navigation.test.js
@@ -163,10 +163,6 @@ describe( 'Navigation', () => {
 		);
 		await createFromExistingButton.click();
 
-		expect( console ).toHaveWarnedWith(
-			'useApiFetch is deprecated and will be removed from Gutenberg in version 8.1.0. Please use apiFetch instead.'
-		);
-
 		// Snapshot should contain the mocked pages.
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
@@ -238,10 +234,6 @@ describe( 'Navigation', () => {
 			label: 'Contact',
 			type: 'entity',
 		} );
-
-		expect( console ).toHaveWarnedWith(
-			'useApiFetch is deprecated and will be removed from Gutenberg in version 8.1.0. Please use apiFetch instead.'
-		);
 
 		// Expect a Navigation Block with two Navigation Links in the snapshot.
 		expect( await getEditedPostContent() ).toMatchSnapshot();
@@ -322,10 +314,6 @@ describe( 'Navigation', () => {
 		);
 
 		expect( isInLinkRichText ).toBe( true );
-
-		expect( console ).toHaveWarnedWith(
-			'useApiFetch is deprecated and will be removed from Gutenberg in version 8.1.0. Please use apiFetch instead.'
-		);
 
 		// Expect a Navigation Block with a link for "A really long page name that will not exist".
 		expect( await getEditedPostContent() ).toMatchSnapshot();


### PR DESCRIPTION
This fixes x2 problems that have broken e2e tests:

### 1. Unwanted deprecation notice assertions 

Now that https://github.com/WordPress/gutenberg/pull/21721 has landed [the deprecation notice for `useApiFetch`](https://github.com/WordPress/gutenberg/pull/21674) within the Navigation Block no longer fires for that block (because it no longer uses the hook!).

Therefore we no longer need to add assertions in our e2e tests to `expect` the console to warning about this deprecation. This PR removes those assertions from the e2e tests.

https://github.com/WordPress/gutenberg/blob/8acbb4f9646f6b3ad8687f60e7816bf88c13ae14/packages/e2e-tests/specs/experiments/navigation.test.js#L166-L168

and

https://github.com/WordPress/gutenberg/blob/8acbb4f9646f6b3ad8687f60e7816bf88c13ae14/packages/e2e-tests/specs/experiments/multi-entity-saving.test.js#L176-L178

### 2. Incorrectly installed dependency of @wordpress/api-fetch

Previously the `@wordpress/deprecated` dependency was directly installed into `@wordpress/api-fetch` **without using `lerna`**. This has been corrected.

## How has this been tested?

#### On Master branch

* Run e2e test suite. 
* You should see failures relating to the `useApiFetch` deprecation notice above 

```
 Expected mock function to be called with:
    ["useApiFetch is deprecated and will be removed from Gutenberg in version 8.1.0. Please use apiFetch instead."]
    but it was called with:
      174 | 				activeSaveSiteSelector
      175 | 			);
    > 176 | 			expect( console ).toHaveWarnedWith(
          | 			                  ^
      177 | 				'useApiFetch is deprecated and will be removed from Gutenberg in version 8.1.0. Please use apiFetch instead.'
      178 | 			);
      179 | 			expect( enabledButton ).not.toBeNull();

```

#### On this PR's branch

* Run e2e test suite. 
* You should see no failures relating to the `useApiFetch` hook

## Types of changes
Bug fix (non-breaking change which fixes an issue) 

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
