### PR TITLE
Calendar block: use block.json.

### DIFF
--- a/packages/block-library/src/calendar/block.json
+++ b/packages/block-library/src/calendar/block.json
@@ -1,0 +1,19 @@
+{
+	"name": "core/calendar",
+	"category": "widgets",
+	"attributes": {
+		"align": {
+			"type": "string",
+			"enum": [ "left", "center", "right", "wide", "full" ]
+		},
+		"className": {
+			"type": "string"
+		},
+		"month": {
+			"type": "integer"
+		},
+		"year": {
+			"type": "integer"
+		}
+	}
+}

--- a/packages/block-library/src/calendar/index.js
+++ b/packages/block-library/src/calendar/index.js
@@ -1,21 +1,23 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { calendar as icon } from '@wordpress/icons';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import metadata from './block.json';
 import edit from './edit';
 
-export const name = 'core/calendar';
+const { name } = metadata;
+
+export { metadata, name };
 
 export const settings = {
 	title: __( 'Calendar' ),
 	description: __( 'A calendar of your site’s posts.' ),
 	icon,
-	category: 'widgets',
 	keywords: [ __( 'posts' ), __( 'archive' ) ],
 	supports: {
 		align: true,

--- a/packages/block-library/src/calendar/index.php
+++ b/packages/block-library/src/calendar/index.php
@@ -52,24 +52,9 @@ function render_block_core_calendar( $attributes ) {
  * Registers the `core/calendar` block on server.
  */
 function register_block_core_calendar() {
-	register_block_type(
-		'core/calendar',
+	register_block_type_from_metadata(
+		__DIR__ . '/calendar',
 		array(
-			'attributes'      => array(
-				'align'     => array(
-					'type' => 'string',
-					'enum' => array( 'left', 'center', 'right', 'wide', 'full' ),
-				),
-				'className' => array(
-					'type' => 'string',
-				),
-				'month'     => array(
-					'type' => 'integer',
-				),
-				'year'      => array(
-					'type' => 'integer',
-				),
-			),
 			'render_callback' => 'render_block_core_calendar',
 		)
 	);


### PR DESCRIPTION
## Description
Updates Calendar block to use a `block.json` file.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
