### PR TITLE
Categories block: use block.json.

### DIFF
--- a/packages/block-library/src/categories/block.json
+++ b/packages/block-library/src/categories/block.json
@@ -1,0 +1,25 @@
+{
+	"name": "core/categories",
+	"category": "widgets",
+	"attributes": {
+		"align": {
+			"type": "string",
+			"enum": [ "left", "center", "right", "wide", "full" ]
+		},
+		"className": {
+			"type": "string"
+		},
+		"displayAsDropdown": {
+			"type": "boolean",
+			"default": false
+		},
+		"showHierarchy": {
+			"type": "boolean",
+			"default": false
+		},
+		"showPostCounts": {
+			"type": "boolean",
+			"default": false
+		}
+	}
+}

--- a/packages/block-library/src/categories/index.js
+++ b/packages/block-library/src/categories/index.js
@@ -1,21 +1,23 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { category as icon } from '@wordpress/icons';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import metadata from './block.json';
 import edit from './edit';
 
-export const name = 'core/categories';
+const { name } = metadata;
+
+export { metadata, name };
 
 export const settings = {
 	title: __( 'Categories' ),
 	description: __( 'Display a list of all categories.' ),
 	icon,
-	category: 'widgets',
 	supports: {
 		align: true,
 		html: false,

--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -89,30 +89,9 @@ function build_dropdown_script_block_core_categories( $dropdown_id ) {
  * Registers the `core/categories` block on server.
  */
 function register_block_core_categories() {
-	register_block_type(
-		'core/categories',
+	register_block_type_from_metadata(
+		__DIR__ . '/categories',
 		array(
-			'attributes'      => array(
-				'align'             => array(
-					'type' => 'string',
-					'enum' => array( 'left', 'center', 'right', 'wide', 'full' ),
-				),
-				'className'         => array(
-					'type' => 'string',
-				),
-				'displayAsDropdown' => array(
-					'type'    => 'boolean',
-					'default' => false,
-				),
-				'showHierarchy'     => array(
-					'type'    => 'boolean',
-					'default' => false,
-				),
-				'showPostCounts'    => array(
-					'type'    => 'boolean',
-					'default' => false,
-				),
-			),
 			'render_callback' => 'render_block_core_categories',
 		)
 	);


### PR DESCRIPTION
## Description
Updates Categories block to use a `block.json` file.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
