### PR TITLE
[RNMobile] - Layout Template Bottom Sheet Picker

### DIFF
--- a/packages/block-editor/src/components/inserter/menu.native.js
+++ b/packages/block-editor/src/components/inserter/menu.native.js
@@ -1,45 +1,17 @@
 /**
- * External dependencies
- */
-import {
-	FlatList,
-	View,
-	Text,
-	TouchableHighlight,
-	Dimensions,
-} from 'react-native';
-
-/**
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
 import { createBlock } from '@wordpress/blocks';
 import { withDispatch, withSelect } from '@wordpress/data';
-import {
-	withInstanceId,
-	compose,
-	withPreferredColorScheme,
-} from '@wordpress/compose';
-import { BottomSheet, Icon } from '@wordpress/components';
-
-/**
- * Internal dependencies
- */
-import styles from './style.scss';
-
-const MIN_COL_NUM = 3;
+import { withInstanceId, compose } from '@wordpress/compose';
+import { MenuBottomSheet } from '@wordpress/components';
 
 export class InserterMenu extends Component {
 	constructor() {
 		super( ...arguments );
 
 		this.onClose = this.onClose.bind( this );
-		this.onLayout = this.onLayout.bind( this );
-		this.state = {
-			numberOfColumns: MIN_COL_NUM,
-		};
-
-		Dimensions.addEventListener( 'change', this.onLayout );
 	}
 
 	componentDidMount() {
@@ -48,45 +20,6 @@ export class InserterMenu extends Component {
 
 	componentWillUnmount() {
 		this.props.hideInsertionPoint();
-		Dimensions.removeEventListener( 'change', this.onLayout );
-	}
-
-	calculateMinItemWidth( bottomSheetWidth ) {
-		const { paddingLeft, paddingRight } = styles.columnPadding;
-		return (
-			( bottomSheetWidth - 2 * ( paddingLeft + paddingRight ) ) /
-			MIN_COL_NUM
-		);
-	}
-
-	calculateItemWidth() {
-		const {
-			paddingLeft: itemPaddingLeft,
-			paddingRight: itemPaddingRight,
-		} = styles.modalItem;
-		const { width: itemWidth } = styles.modalIconWrapper;
-		return itemWidth + itemPaddingLeft + itemPaddingRight;
-	}
-
-	calculateColumnsProperties() {
-		const bottomSheetWidth = BottomSheet.getWidth();
-		const { paddingLeft, paddingRight } = styles.columnPadding;
-		const itemTotalWidth = this.calculateItemWidth();
-		const containerTotalWidth =
-			bottomSheetWidth - ( paddingLeft + paddingRight );
-		const numofColumns = Math.floor( containerTotalWidth / itemTotalWidth );
-
-		if ( numofColumns < MIN_COL_NUM ) {
-			return {
-				numOfColumns: MIN_COL_NUM,
-				itemWidth: this.calculateMinItemWidth( bottomSheetWidth ),
-				maxWidth: containerTotalWidth / MIN_COL_NUM,
-			};
-		}
-		return {
-			numOfColumns: numofColumns,
-			maxWidth: containerTotalWidth / numofColumns,
-		};
 	}
 
 	onClose() {
@@ -98,92 +31,16 @@ export class InserterMenu extends Component {
 		this.props.onDismiss();
 	}
 
-	onLayout() {
-		const columnProperties = this.calculateColumnsProperties();
-		const numberOfColumns = columnProperties.numOfColumns;
-
-		this.setState( { numberOfColumns } );
-	}
-
 	render() {
-		const { getStylesFromColorScheme, items, onSelect } = this.props;
-		const { numberOfColumns } = this.state;
-
-		const bottomPadding = styles.contentBottomPadding;
-		const modalIconWrapperStyle = getStylesFromColorScheme(
-			styles.modalIconWrapper,
-			styles.modalIconWrapperDark
-		);
-		const modalIconStyle = getStylesFromColorScheme(
-			styles.modalIcon,
-			styles.modalIconDark
-		);
-		const modalItemLabelStyle = getStylesFromColorScheme(
-			styles.modalItemLabel,
-			styles.modalItemLabelDark
-		);
-
-		const columnProperties = this.calculateColumnsProperties();
+		const { items, onSelect } = this.props;
 
 		return (
-			<BottomSheet
+			<MenuBottomSheet
 				isVisible={ true }
+				items={ items }
 				onClose={ this.onClose }
-				contentStyle={ [ styles.content, bottomPadding ] }
-				hideHeader
-			>
-				<TouchableHighlight accessible={ false }>
-					<FlatList
-						onLayout={ this.onLayout }
-						scrollEnabled={ false }
-						key={ `InserterUI-${ numberOfColumns }` } //re-render when numberOfColumns changes
-						keyboardShouldPersistTaps="always"
-						numColumns={ numberOfColumns }
-						data={ items }
-						ItemSeparatorComponent={ () => (
-							<View style={ styles.rowSeparator } />
-						) }
-						keyExtractor={ ( item ) => item.name }
-						renderItem={ ( { item } ) => (
-							<TouchableHighlight
-								style={ styles.touchableArea }
-								underlayColor="transparent"
-								activeOpacity={ 0.5 }
-								accessibilityLabel={ item.title }
-								onPress={ () => onSelect( item ) }
-							>
-								<View
-									style={ [
-										styles.modalItem,
-										{ width: columnProperties.maxWidth },
-									] }
-								>
-									<View
-										style={ [
-											modalIconWrapperStyle,
-											columnProperties.itemWidth && {
-												width:
-													columnProperties.itemWidth,
-											},
-										] }
-									>
-										<View style={ modalIconStyle }>
-											<Icon
-												icon={ item.icon.src }
-												fill={ modalIconStyle.fill }
-												size={ modalIconStyle.width }
-											/>
-										</View>
-									</View>
-									<Text style={ modalItemLabelStyle }>
-										{ item.title }
-									</Text>
-								</View>
-							</TouchableHighlight>
-						) }
-					/>
-				</TouchableHighlight>
-			</BottomSheet>
+				onSelect={ onSelect }
+			></MenuBottomSheet>
 		);
 	}
 }
@@ -283,6 +140,5 @@ export default compose(
 			},
 		};
 	} ),
-	withInstanceId,
-	withPreferredColorScheme
+	withInstanceId
 )( InserterMenu );

--- a/packages/block-editor/src/components/inserter/style.native.scss
+++ b/packages/block-editor/src/components/inserter/style.native.scss
@@ -1,80 +1,9 @@
 /** @format */
 
-.touchableArea {
-	border-radius: 8px 8px 8px 8px;
-}
-
-.content {
-	padding: 0 0 0 0;
-	align-items: center;
-}
-
-.contentBottomPadding {
-	padding-bottom: 20px;
-}
-
-.rowSeparator {
-	height: 12px;
-}
-
-.modalItem {
-	flex-direction: column;
-	justify-content: flex-start;
-	align-items: center;
-	padding-left: $panel-padding / 2;
-	padding-right: $panel-padding / 2;
-	padding-top: 0;
-	padding-bottom: 0;
-}
-
-.modalIconWrapper {
-	width: 104px;
-	height: 64px;
-	background-color: $gray-light; //#f3f6f8
-	border-radius: 8px 8px 8px 8px;
-	justify-content: center;
-	align-items: center;
-}
-
-.modalIconWrapperDark {
-	background-color: rgba($white, 0.07);
-}
-
-.modalIcon {
-	width: 32px;
-	height: 32px;
-	justify-content: center;
-	align-items: center;
-	fill: $gray-dark;
-}
-
-.modalIconDark {
-	fill: $white;
-}
-
-.modalItemLabel {
-	background-color: transparent;
-	padding-left: 2;
-	padding-right: 2;
-	padding-top: 4;
-	padding-bottom: 0;
-	justify-content: center;
-	font-size: 12;
-	color: $gray-dark;
-}
-
-.modalItemLabelDark {
-	color: $white;
-}
-
 .addBlockButton {
 	color: $blue-wordpress;
 }
 
 .addBlockButtonDark {
 	color: $blue-30;
-}
-
-.columnPadding {
-	padding: $panel-padding;
 }

--- a/packages/block-editor/src/components/page-template-picker/button.native.js
+++ b/packages/block-editor/src/components/page-template-picker/button.native.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { TouchableOpacity, Text, View } from 'react-native';
+import { TouchableOpacity, Text, Platform, View } from 'react-native';
 
 /**
  * WordPress dependencies
@@ -38,6 +38,7 @@ const PickerButton = ( { icon, isMoreOption, label, onPress } ) => {
 			styles.buttonIcon,
 			styles.buttonIconDark
 		),
+		Platform.OS === 'android' && { fontSize: 16 },
 		isMoreOption && styles.buttonIconIsMore,
 	];
 

--- a/packages/block-editor/src/components/page-template-picker/button.native.js
+++ b/packages/block-editor/src/components/page-template-picker/button.native.js
@@ -14,19 +14,32 @@ import { usePreferredColorSchemeStyle } from '@wordpress/compose';
  */
 import styles from './styles.scss';
 
-const PickerButton = ( { icon, label, onPress } ) => {
-	const butonWrapperStyles = usePreferredColorSchemeStyle(
-		styles.buttonWrapper,
-		styles.buttonWrapperDark
-	);
-	const buttonStyles = usePreferredColorSchemeStyle(
-		styles.button,
-		styles.buttonDark
-	);
+const PickerButton = ( { icon, isMoreOption, label, onPress } ) => {
+	const butonWrapperStyles = [
+		usePreferredColorSchemeStyle(
+			styles.buttonWrapper,
+			styles.buttonWrapperDark
+		),
+		isMoreOption && styles.buttonWrapperMoreOption,
+	];
+
+	const buttonStyles = [
+		usePreferredColorSchemeStyle( styles.button, styles.buttonDark ),
+		isMoreOption && styles.buttonIsMore,
+	];
+
 	const buttonTextStyles = usePreferredColorSchemeStyle(
 		styles.buttonText,
 		styles.buttonTextDark
 	);
+
+	const buttonIconStyles = [
+		usePreferredColorSchemeStyle(
+			styles.buttonIcon,
+			styles.buttonIconDark
+		),
+		isMoreOption && styles.buttonIconIsMore,
+	];
 
 	return (
 		<TouchableOpacity
@@ -37,7 +50,7 @@ const PickerButton = ( { icon, label, onPress } ) => {
 			style={ butonWrapperStyles }
 		>
 			<View style={ buttonStyles }>
-				<Text style={ styles.buttonIcon }>{ icon }</Text>
+				<Text style={ buttonIconStyles }>{ icon }</Text>
 				<Text style={ buttonTextStyles }>{ label }</Text>
 			</View>
 		</TouchableOpacity>

--- a/packages/block-editor/src/components/page-template-picker/styles.native.scss
+++ b/packages/block-editor/src/components/page-template-picker/styles.native.scss
@@ -38,7 +38,7 @@
 .buttonIsMore {
 	background-color: transparent;
 	border-style: solid;
-	border-width: 2px;
+	border-width: 1px;
 	border-radius: 20px;
 }
 
@@ -53,8 +53,8 @@
 
 .buttonIconIsMore {
 	line-height: 11px;
-	margin-top: 3px;
-	margin-bottom: 3px;
+	margin-top: 4px;
+	margin-bottom: 4px;
 	overflow: hidden;
 	font-weight: 800;
 }

--- a/packages/block-editor/src/components/page-template-picker/styles.native.scss
+++ b/packages/block-editor/src/components/page-template-picker/styles.native.scss
@@ -17,20 +17,46 @@
 	background-color: $black;
 }
 
+.buttonWrapperMoreOption {
+	background-color: transparent;
+	overflow: visible;
+}
+
 .button {
 	background-color: rgba($black, 0.04);
 	padding: 9px 18px 9px 14px;
 	flex-direction: row;
 	align-items: center;
+	border-color: $light-gray-200;
 }
 
 .buttonDark {
 	background-color: rgba($white, 0.08);
+	border-color: #141414;
+}
+
+.buttonIsMore {
+	background-color: transparent;
+	border-style: solid;
+	border-width: 2px;
+	border-radius: 20px;
 }
 
 .buttonIcon {
 	margin-right: 6px;
 	font-size: 18px;
+}
+
+.buttonIconDark {
+	color: $light-opacity-700;
+}
+
+.buttonIconIsMore {
+	line-height: 11px;
+	margin-top: 3px;
+	margin-bottom: 3px;
+	overflow: hidden;
+	font-weight: 800;
 }
 
 .buttonText {

--- a/packages/components/src/index.native.js
+++ b/packages/components/src/index.native.js
@@ -60,3 +60,4 @@ export { default as ReadableContentView } from './mobile/readable-content-view';
 export { default as CycleSelectControl } from './mobile/cycle-select-control';
 export { default as ImageWithFocalPoint } from './mobile/image-with-focalpoint';
 export { default as LinearGradient } from './mobile/linear-gradient';
+export { default as MenuBottomSheet } from './mobile/menu-bottom-sheet';

--- a/packages/components/src/mobile/menu-bottom-sheet/index.native.js
+++ b/packages/components/src/mobile/menu-bottom-sheet/index.native.js
@@ -1,0 +1,179 @@
+/**
+ * External dependencies
+ */
+import {
+	Dimensions,
+	FlatList,
+	Text,
+	TouchableHighlight,
+	View,
+} from 'react-native';
+
+/**
+ * WordPress dependencies
+ */
+import { useEffect, useState } from '@wordpress/element';
+import { BottomSheet, Icon } from '@wordpress/components';
+import { usePreferredColorSchemeStyle } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import styles from './style.scss';
+
+const MIN_COL_NUM = 3;
+
+function calculateMinItemWidth( bottomSheetWidth ) {
+	const { paddingLeft, paddingRight } = styles.columnPadding;
+	return (
+		( bottomSheetWidth - 2 * ( paddingLeft + paddingRight ) ) / MIN_COL_NUM
+	);
+}
+
+function calculateItemWidth() {
+	const {
+		paddingLeft: itemPaddingLeft,
+		paddingRight: itemPaddingRight,
+	} = styles.modalItem;
+	const { width: itemWidth } = styles.modalIconWrapper;
+	return itemWidth + itemPaddingLeft + itemPaddingRight;
+}
+
+function calculateColumnsProperties() {
+	const bottomSheetWidth = BottomSheet.getWidth();
+	const { paddingLeft, paddingRight } = styles.columnPadding;
+	const itemTotalWidth = calculateItemWidth();
+	const containerTotalWidth =
+		bottomSheetWidth - ( paddingLeft + paddingRight );
+	const numofColumns = Math.floor( containerTotalWidth / itemTotalWidth );
+
+	if ( numofColumns < MIN_COL_NUM ) {
+		return {
+			numOfColumns: MIN_COL_NUM,
+			itemWidth: calculateMinItemWidth( bottomSheetWidth ),
+			maxWidth: containerTotalWidth / MIN_COL_NUM,
+		};
+	}
+	return {
+		numOfColumns: numofColumns,
+		maxWidth: containerTotalWidth / numofColumns,
+	};
+}
+
+const MenuBottomSheet = ( { isVisible, items, onClose, onSelect, title } ) => {
+	const [ numberOfColumns, setNumberOfColumns ] = useState( MIN_COL_NUM );
+
+	useEffect( () => {
+		Dimensions.addEventListener( 'change', onLayout );
+
+		return () => {
+			Dimensions.removeEventListener( 'change', onLayout );
+		};
+	}, [] );
+
+	const onLayout = () => {
+		const columnProperties = calculateColumnsProperties();
+		const numColumns = columnProperties.numOfColumns;
+
+		setNumberOfColumns( numColumns );
+	};
+
+	const bottomPadding = styles.contentBottomPadding;
+	const modalIconWrapperStyle = usePreferredColorSchemeStyle(
+		styles.modalIconWrapper,
+		styles.modalIconWrapperDark
+	);
+	const modalIconStyle = usePreferredColorSchemeStyle(
+		styles.modalIcon,
+		styles.modalIconDark
+	);
+	const modalItemLabelStyle = usePreferredColorSchemeStyle(
+		styles.modalItemLabel,
+		styles.modalItemLabelDark
+	);
+	const modalTitleStyle = usePreferredColorSchemeStyle(
+		styles.modalTitle,
+		styles.modalTitleDark
+	);
+
+	const columnProperties = calculateColumnsProperties();
+
+	const headerComponent = () => {
+		return title ? (
+			<View>
+				<Text style={ modalTitleStyle }>{ title }</Text>
+			</View>
+		) : null;
+	};
+
+	return (
+		<BottomSheet
+			isVisible={ isVisible }
+			onClose={ onClose }
+			contentStyle={ [ styles.content, bottomPadding ] }
+			hideHeader
+		>
+			<TouchableHighlight accessible={ false }>
+				<FlatList
+					onLayout={ onLayout }
+					scrollEnabled={ false }
+					key={ `InserterUI-${ numberOfColumns }` } //re-render when numberOfColumns changes
+					keyboardShouldPersistTaps="always"
+					numColumns={ numberOfColumns }
+					data={ items }
+					ItemSeparatorComponent={ () => (
+						<View style={ styles.rowSeparator } />
+					) }
+					ListHeaderComponent={ headerComponent }
+					keyExtractor={ ( item ) => item.name }
+					renderItem={ ( { item } ) => (
+						<TouchableHighlight
+							style={ styles.touchableArea }
+							underlayColor="transparent"
+							activeOpacity={ 0.5 }
+							accessibilityLabel={ item.title }
+							onPress={ () => onSelect( item ) }
+						>
+							<View
+								style={ [
+									styles.modalItem,
+									{ width: columnProperties.maxWidth },
+								] }
+							>
+								<View
+									style={ [
+										modalIconWrapperStyle,
+										columnProperties.itemWidth && {
+											width: columnProperties.itemWidth,
+										},
+									] }
+								>
+									<View style={ modalIconStyle }>
+										{ item.icon.src ? (
+											<Icon
+												icon={ item.icon.src }
+												fill={ modalIconStyle.fill }
+												size={ modalIconStyle.width }
+											/>
+										) : (
+											<Text
+												style={ styles.modalIconText }
+											>
+												{ item.icon }
+											</Text>
+										) }
+									</View>
+								</View>
+								<Text style={ modalItemLabelStyle }>
+									{ item.title }
+								</Text>
+							</View>
+						</TouchableHighlight>
+					) }
+				/>
+			</TouchableHighlight>
+		</BottomSheet>
+	);
+};
+
+export default MenuBottomSheet;

--- a/packages/components/src/mobile/menu-bottom-sheet/style.native.scss
+++ b/packages/components/src/mobile/menu-bottom-sheet/style.native.scss
@@ -1,0 +1,86 @@
+.touchableArea {
+	border-radius: 8px 8px 8px 8px;
+}
+
+.content {
+	padding: 0 0 0 0;
+	align-items: center;
+}
+
+.contentBottomPadding {
+	padding-bottom: 20px;
+}
+
+.rowSeparator {
+	height: 12px;
+}
+
+.modalItem {
+	flex-direction: column;
+	justify-content: flex-start;
+	align-items: center;
+	padding-left: $panel-padding / 2;
+	padding-right: $panel-padding / 2;
+	padding-top: 0;
+	padding-bottom: 0;
+}
+
+.modalIconWrapper {
+	width: 104px;
+	height: 64px;
+	background-color: $gray-light; //#f3f6f8
+	border-radius: 8px 8px 8px 8px;
+	justify-content: center;
+	align-items: center;
+}
+
+.modalIconWrapperDark {
+	background-color: rgba($white, 0.07);
+}
+
+.modalIcon {
+	width: 32px;
+	height: 32px;
+	justify-content: center;
+	align-items: center;
+	fill: $gray-dark;
+}
+
+.modalIconDark {
+	fill: $white;
+}
+
+.modalIconText {
+	font-size: 26px;
+}
+
+.modalItemLabel {
+	background-color: transparent;
+	padding-left: 2;
+	padding-right: 2;
+	padding-top: 4;
+	padding-bottom: 0;
+	justify-content: center;
+	font-size: 12;
+	color: $gray-dark;
+}
+
+.modalItemLabelDark {
+	color: $white;
+}
+
+.modalTitle {
+	font-size: 20px;
+	font-weight: 500;
+	margin-left: 6px;
+	margin-bottom: 17px;
+	color: $gray-dark;
+}
+
+.modalTitleDark {
+	color: $white;
+}
+
+.columnPadding {
+	padding: $panel-padding;
+}


### PR DESCRIPTION
`Gutenberg Mobile PR` -> https://github.com/wordpress-mobile/gutenberg-mobile/pull/2177

## Description
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/1748

This PR adds a `More` button to display more templates in the Layout picker by displaying them in a bottom sheet modal.

To be able to reuse the Inserter's menu I had to extract the UI from it and leave only its logic. I think this file was getting way bigger already so it'd make sense to split it and also with this be able to reuse it in other places, like in the Layout picker for Pages.

## How has this been tested?
<details><summary>Steps to test</summary>

- Open the app with metro running.
- Go to Pages.
- Add a new page.
- Expect to see the layout picker at the bottom.
- Scroll to the right.
- **Expect** to see the new `More` button.
- Tap on it.
- **Expect** to see a Bottom Sheet modal show up with more templates.
- Tap on a template.
- **Expect** the Bottom Sheet menu to be closed and the template preview modal to be visible.
- Tap on Apply.
- **Expect** to see the template in the editor.

</details>

## Screenshots

<details><summary>iOS</summary>

UI Interaction |
-|
<img src="https://user-images.githubusercontent.com/4885740/79997468-ea1ff300-84b9-11ea-9b88-e6362041f6f4.gif" width="250" /> |

More button | More button dark mode
-|-
<img src="https://user-images.githubusercontent.com/4885740/79997097-7847a980-84b9-11ea-8aa4-a80d9d0c8ca0.png" width="250" /> | <img src="https://user-images.githubusercontent.com/4885740/79997167-8b5a7980-84b9-11ea-909b-fb4294b84d9c.png" width="250" />

Modal menu | Modal menu dark mode
-|-
<img src="https://user-images.githubusercontent.com/4885740/79997242-a331fd80-84b9-11ea-98ae-797ff7445631.png" width="250" /> | <img src="https://user-images.githubusercontent.com/4885740/79997385-cfe61500-84b9-11ea-8cc4-91bd484d8de4.png" width="250" />

</details>

<details><summary>Android</summary>

UI Interaction |
-|
<img src="https://user-images.githubusercontent.com/4885740/79997652-176ca100-84ba-11ea-9056-805a6161cb38.gif" width="250" /> |

More button | More button dark mode
-|-
<img src="https://user-images.githubusercontent.com/4885740/79997735-294e4400-84ba-11ea-9bf2-2f109f577120.png" width="250" /> | <img src="https://user-images.githubusercontent.com/4885740/79997760-2fdcbb80-84ba-11ea-8da4-2d3ae4796a71.png" width="250" />

Modal menu | Modal menu dark mode
-|-
<img src="https://user-images.githubusercontent.com/4885740/79997850-46831280-84ba-11ea-869f-3f8e4c6ddcc2.png" width="250" /> | <img src="https://user-images.githubusercontent.com/4885740/79997863-4aaf3000-84ba-11ea-9d08-7157757589d3.png" width="250" />

</details>

<details><summary>iPad</summary>

More button | Modal menu
-|-
<img src="https://user-images.githubusercontent.com/4885740/79998057-83e7a000-84ba-11ea-82b8-68f8a7f985b5.png" width="250" /> | <img src="https://user-images.githubusercontent.com/4885740/79998063-8649fa00-84ba-11ea-838c-0f8f0fbb7571.png" width="250" />

</details>

## Types of changes
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
