### PR TITLE
Legacy Widget block: use block.json.

### DIFF
--- a/packages/block-library/src/legacy-widget/block.json
+++ b/packages/block-library/src/legacy-widget/block.json
@@ -1,0 +1,21 @@
+{
+	"name": "core/legacy-widget",
+	"category": "widgets",
+	"attributes": {
+		"widgetClass": {
+			"type": "string"
+		},
+		"id": {
+			"type": "string"
+		},
+		"idBase": {
+			"type": "string"
+		},
+		"number": {
+			"type": "number"
+		},
+		"instance": {
+			"type": "object"
+		}
+	}
+}

--- a/packages/block-library/src/legacy-widget/index.js
+++ b/packages/block-library/src/legacy-widget/index.js
@@ -1,21 +1,23 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { widget as icon } from '@wordpress/icons';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import metadata from './block.json';
 import edit from './edit';
 
-export const name = 'core/legacy-widget';
+const { name } = metadata;
+
+export { metadata, name };
 
 export const settings = {
 	title: __( 'Legacy Widget (Experimental)' ),
 	description: __( 'Display a legacy widget.' ),
 	icon,
-	category: 'widgets',
 	supports: {
 		html: false,
 		customClassName: false,

--- a/packages/block-library/src/legacy-widget/index.php
+++ b/packages/block-library/src/legacy-widget/index.php
@@ -101,26 +101,9 @@ function render_block_core_legacy_widget( $attributes ) {
  * Register legacy widget block.
  */
 function register_block_core_legacy_widget() {
-	register_block_type(
-		'core/legacy-widget',
+	register_block_type_from_metadata(
+		__DIR__ . '/legacy-widget',
 		array(
-			'attributes'      => array(
-				'widgetClass' => array(
-					'type' => 'string',
-				),
-				'id'          => array(
-					'type' => 'string',
-				),
-				'idBase'      => array(
-					'type' => 'string',
-				),
-				'number'      => array(
-					'type' => 'number',
-				),
-				'instance'    => array(
-					'type' => 'object',
-				),
-			),
 			'render_callback' => 'render_block_core_legacy_widget',
 		)
 	);


### PR DESCRIPTION
## Description
Updates Legacy Widget block to use a `block.json` file.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
