### PR TITLE
Tag Cloud block: use block.json.

### DIFF
--- a/packages/block-library/src/tag-cloud/block.json
+++ b/packages/block-library/src/tag-cloud/block.json
@@ -1,0 +1,21 @@
+{
+	"name": "core/tag-cloud",
+	"category": "widgets",
+	"attributes": {
+		"align": {
+			"type": "string",
+			"enum": [ "left", "center", "right", "wide", "full" ]
+		},
+		"className": {
+			"type": "string"
+		},
+		"taxonomy": {
+			"type": "string",
+			"default": "post_tag"
+		},
+		"showTagCounts": {
+			"type": "boolean",
+			"default": false
+		}
+	}
+}

--- a/packages/block-library/src/tag-cloud/index.js
+++ b/packages/block-library/src/tag-cloud/index.js
@@ -7,15 +7,17 @@ import { tag as icon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
+import metadata from './block.json';
 import edit from './edit';
 
-export const name = 'core/tag-cloud';
+const { name } = metadata;
+
+export { metadata, name };
 
 export const settings = {
 	title: __( 'Tag Cloud' ),
 	description: __( 'A cloud of your most used tags.' ),
 	icon,
-	category: 'widgets',
 	supports: {
 		html: false,
 		align: true,

--- a/packages/block-library/src/tag-cloud/index.php
+++ b/packages/block-library/src/tag-cloud/index.php
@@ -51,26 +51,9 @@ function render_block_core_tag_cloud( $attributes ) {
  * Registers the `core/tag-cloud` block on server.
  */
 function register_block_core_tag_cloud() {
-	register_block_type(
-		'core/tag-cloud',
+	register_block_type_from_metadata(
+		__DIR__ . '/tag-cloud',
 		array(
-			'attributes'      => array(
-				'align'         => array(
-					'type' => 'string',
-					'enum' => array( 'left', 'center', 'right', 'wide', 'full' ),
-				),
-				'className'     => array(
-					'type' => 'string',
-				),
-				'taxonomy'      => array(
-					'type'    => 'string',
-					'default' => 'post_tag',
-				),
-				'showTagCounts' => array(
-					'type'    => 'boolean',
-					'default' => false,
-				),
-			),
 			'render_callback' => 'render_block_core_tag_cloud',
 		)
 	);


### PR DESCRIPTION
## Description
Updates Tag Cloud block to use a `block.json` file.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
