### PR TITLE
Template Part block: only declare attributes in block.json.

### DIFF
--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -52,20 +52,9 @@ function render_block_core_template_part( $attributes ) {
  * Registers the `core/template-part` block on the server.
  */
 function register_block_core_template_part() {
-	register_block_type(
-		'core/template-part',
+	register_block_type_from_metadata(
+		__DIR__ . '/template-part',
 		array(
-			'attributes'      => array(
-				'postId' => array(
-					'type' => 'number',
-				),
-				'slug'   => array(
-					'type' => 'string',
-				),
-				'theme'  => array(
-					'type' => 'string',
-				),
-			),
 			'render_callback' => 'render_block_core_template_part',
 		)
 	);


### PR DESCRIPTION
## Description
Updates Template Part block to remove duplicated attributes definition in PHP, since they're already defined in a `block.json` file.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
