### PR TITLE
Block API: WP_Block implements JsonSerializable, Serializable, IteratorAggregate, Countable

### DIFF
--- a/lib/class-wp-block.php
+++ b/lib/class-wp-block.php
@@ -201,9 +201,11 @@ class WP_Block implements ArrayAccess {
 	 * @return mixed|null Attribute value if exists, or null.
 	 */
 	public function offsetGet( $attribute_name ) {
-		// This may cause an "Undefined index" notice if the attribute name does
-		// not exist. This is expected, since the purpose of this implementation
-		// is to align exactly to the expectations of operating on an array.
+		/*
+		 * This may cause an "Undefined index" notice if the attribute name does
+		 * not exist. This is expected, since the purpose of this implementation
+		 * is to align exactly to the expectations of operating on an array.
+		 */
 		return $this->attributes[ $attribute_name ];
 	}
 
@@ -217,9 +219,11 @@ class WP_Block implements ArrayAccess {
 	 */
 	public function offsetSet( $attribute_name, $value ) {
 		if ( is_null( $attribute_name ) ) {
-			// This is not technically a valid use-case for attributes. Since
-			// this implementation is expected to align to expectations of
-			// operating on an array, it is still supported.
+			/*
+			 * This is not technically a valid use-case for attributes. Since
+			 * this implementation is expected to align to expectations of
+			 * operating on an array, it is still supported.
+			 */
 			$this->attributes[] = $value;
 		} else {
 			$this->attributes[ $attribute_name ] = $value;

--- a/lib/class-wp-block.php
+++ b/lib/class-wp-block.php
@@ -8,7 +8,7 @@
 /**
  * Class representing a parsed instance of a block.
  */
-class WP_Block implements ArrayAccess, JsonSerializable, IteratorAggregate {
+class WP_Block implements ArrayAccess, JsonSerializable, Serializable, IteratorAggregate {
 
 	/**
 	 * Name of block.
@@ -243,6 +243,33 @@ class WP_Block implements ArrayAccess, JsonSerializable, IteratorAggregate {
 	 */
 	public function offsetUnset( $attribute_name ) {
 		unset( $this->attributes[ $attribute_name ] );
+	}
+
+	/*
+	 * Serializable interface methods.
+	 */
+
+	/**
+	 * Returns the string representation of the block attributes.
+	 *
+	 * @link https://www.php.net/manual/en/serializable.serialize.php
+	 *
+	 * @return string String representation of the block attributes.
+	 */
+	public function serialize() {
+		return serialize( $this->attributes );
+	}
+
+	/**
+	 * Constructs the object from a serialized representation of block
+	 * attributes.
+	 *
+	 * @link https://www.php.net/manual/en/serializable.unserialize.php
+	 *
+	 * @param string The string representation of the block attributes.
+	 */
+	public function unserialize( $serialized ) {
+		$this->attributes = unserialize( $serialized );
 	}
 
 	/*

--- a/lib/class-wp-block.php
+++ b/lib/class-wp-block.php
@@ -8,7 +8,7 @@
 /**
  * Class representing a parsed instance of a block.
  */
-class WP_Block implements ArrayAccess, JsonSerializable {
+class WP_Block implements ArrayAccess, JsonSerializable, Iterator {
 
 	/**
 	 * Name of block.
@@ -259,6 +259,59 @@ class WP_Block implements ArrayAccess, JsonSerializable {
 	 */
 	public function jsonSerialize() {
 		return $this->attributes;
+	}
+
+	/*
+	 * Iterator interface methods.
+	 */
+
+	/**
+	 * Rewinds back to the first element of the Iterator.
+	 *
+	 * @link https://www.php.net/manual/en/iterator.rewind.php
+	 */
+	public function rewind() {
+		reset( $this->attributes );
+	}
+
+	/**
+	 * Returns the current element of the attributes array.
+	 *
+	 * @link https://www.php.net/manual/en/iterator.current.php
+	 *
+	 * @return mixed Current element.
+	 */
+	public function current() {
+		return current( $this->attributes );
+	}
+
+	/**
+	 * Returns the key of the current element of the attributes array.
+	 *
+	 * @link https://www.php.net/manual/en/iterator.key.php
+	 *
+	 * @return mixed Key of the current element.
+	 */
+	public function key() {
+		return key( $this->attributes );
+	}
+
+	/**
+	 * Moves the current position of the attributes array to the next element.
+	 *
+	 * @link https://www.php.net/manual/en/iterator.next.php
+	 */
+	public function next() {
+		next( $this->attributes );
+	}
+
+	/**
+	 * Checks if current position is valid.
+	 *
+	 * @link https://www.php.net/manual/en/iterator.valid.php
+	 */
+	public function valid() {
+		return null !== key( $this->attributes );
 	}
 
 }

--- a/lib/class-wp-block.php
+++ b/lib/class-wp-block.php
@@ -8,7 +8,7 @@
 /**
  * Class representing a parsed instance of a block.
  */
-class WP_Block implements ArrayAccess, JsonSerializable, Iterator {
+class WP_Block implements ArrayAccess, JsonSerializable, IteratorAggregate {
 
 	/**
 	 * Name of block.
@@ -262,56 +262,18 @@ class WP_Block implements ArrayAccess, JsonSerializable, Iterator {
 	}
 
 	/*
-	 * Iterator interface methods.
+	 * IteratorAggregate interface methods.
 	 */
 
 	/**
-	 * Rewinds back to the first element of the Iterator.
+	 * Returns an iterator of the block attributes.
 	 *
-	 * @link https://www.php.net/manual/en/iterator.rewind.php
+	 * @link https://www.php.net/manual/en/iteratoraggregate.getiterator.php
+	 *
+	 * @return Traversable Attributes iterator.
 	 */
-	public function rewind() {
-		reset( $this->attributes );
-	}
-
-	/**
-	 * Returns the current element of the attributes array.
-	 *
-	 * @link https://www.php.net/manual/en/iterator.current.php
-	 *
-	 * @return mixed Current element.
-	 */
-	public function current() {
-		return current( $this->attributes );
-	}
-
-	/**
-	 * Returns the key of the current element of the attributes array.
-	 *
-	 * @link https://www.php.net/manual/en/iterator.key.php
-	 *
-	 * @return mixed Key of the current element.
-	 */
-	public function key() {
-		return key( $this->attributes );
-	}
-
-	/**
-	 * Moves the current position of the attributes array to the next element.
-	 *
-	 * @link https://www.php.net/manual/en/iterator.next.php
-	 */
-	public function next() {
-		next( $this->attributes );
-	}
-
-	/**
-	 * Checks if current position is valid.
-	 *
-	 * @link https://www.php.net/manual/en/iterator.valid.php
-	 */
-	public function valid() {
-		return null !== key( $this->attributes );
+	public function getIterator() {
+		return new ArrayIterator( $this->attributes );
 	}
 
 }

--- a/lib/class-wp-block.php
+++ b/lib/class-wp-block.php
@@ -8,7 +8,7 @@
 /**
  * Class representing a parsed instance of a block.
  */
-class WP_Block implements ArrayAccess {
+class WP_Block implements ArrayAccess, JsonSerializable {
 
 	/**
 	 * Name of block.
@@ -177,6 +177,10 @@ class WP_Block implements ArrayAccess {
 		return $block_content;
 	}
 
+	/*
+	 * ArrayAccess interface methods.
+	 */
+
 	/**
 	 * Returns true if an attribute exists by the specified attribute name, or
 	 * false otherwise.
@@ -239,6 +243,22 @@ class WP_Block implements ArrayAccess {
 	 */
 	public function offsetUnset( $attribute_name ) {
 		unset( $this->attributes[ $attribute_name ] );
+	}
+
+	/*
+	 * JsonSerializable interface methods.
+	 */
+
+	/**
+	 * Serializes the object to an array of attributes that can be serialized
+	 * natively by json_encode().
+	 *
+	 * @link https://www.php.net/manual/en/jsonserializable.jsonserialize.php
+	 *
+	 * @return array Array data which can be serialized by json_encode().
+	 */
+	public function jsonSerialize() {
+		return $this->attributes;
 	}
 
 }

--- a/lib/class-wp-block.php
+++ b/lib/class-wp-block.php
@@ -8,7 +8,7 @@
 /**
  * Class representing a parsed instance of a block.
  */
-class WP_Block implements ArrayAccess, JsonSerializable, Serializable, IteratorAggregate {
+class WP_Block implements ArrayAccess, JsonSerializable, Serializable, IteratorAggregate, Countable {
 
 	/**
 	 * Name of block.
@@ -301,6 +301,21 @@ class WP_Block implements ArrayAccess, JsonSerializable, Serializable, IteratorA
 	 */
 	public function getIterator() {
 		return new ArrayIterator( $this->attributes );
+	}
+
+	/*
+	 * Countable interface methods.
+	 */
+
+	/**
+	 * Returns the count of the block attributes.
+	 *
+	 * @link https://www.php.net/manual/en/countable.count.php
+	 *
+	 * @return int Count of the block attributes.
+	 */
+	public function count() {
+		return count( $this->attributes );
 	}
 
 }

--- a/phpunit/class-wp-block-test.php
+++ b/phpunit/class-wp-block-test.php
@@ -389,4 +389,29 @@ class WP_Block_Test extends WP_UnitTestCase {
 		$this->assertEquals( '{"value":"ok"}', $result );
 	}
 
+	function test_iterable_as_attributes_array() {
+		$this->registry->register(
+			'core/example',
+			array(
+				'attributes' => array(
+					'value' => array(
+						'type'    => 'string',
+						'default' => 'ok',
+					),
+				),
+			)
+		);
+
+		$parsed_block = array( 'blockName' => 'core/example' );
+		$context      = array();
+		$block        = new WP_Block( $parsed_block, $context, $this->registry );
+
+		$result_attributes = array();
+		foreach ( $block as $key => $value ) {
+			$result_attributes[ $key ] = $value;
+		}
+
+		$this->assertEquals( array( 'value' => 'ok' ), $result_attributes );
+	}
+
 }

--- a/phpunit/class-wp-block-test.php
+++ b/phpunit/class-wp-block-test.php
@@ -367,6 +367,28 @@ class WP_Block_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'invalid, but still supported', $block[0] );
 	}
 
+	function test_block_serializable_as_attributes_array() {
+		$this->registry->register(
+			'core/example',
+			array(
+				'attributes' => array(
+					'value' => array(
+						'type'    => 'string',
+						'default' => 'ok',
+					),
+				),
+			)
+		);
+
+		$parsed_block = array( 'blockName' => 'core/example' );
+		$context      = array();
+		$block        = new WP_Block( $parsed_block, $context, $this->registry );
+
+		$result = serialize( $block );
+
+		$this->assertEquals( 'C:8:"WP_Block":27:{a:1:{s:5:"value";s:2:"ok";}}', $result );
+	}
+
 	function test_block_json_serializable_as_attributes_array() {
 		$this->registry->register(
 			'core/example',

--- a/phpunit/class-wp-block-test.php
+++ b/phpunit/class-wp-block-test.php
@@ -436,4 +436,26 @@ class WP_Block_Test extends WP_UnitTestCase {
 		$this->assertEquals( array( 'value' => 'ok' ), $result_attributes );
 	}
 
+	function test_countable_as_attributes_array() {
+		$this->registry->register(
+			'core/example',
+			array(
+				'attributes' => array(
+					'value' => array(
+						'type'    => 'string',
+						'default' => 'ok',
+					),
+				),
+			)
+		);
+
+		$parsed_block = array( 'blockName' => 'core/example' );
+		$context      = array();
+		$block        = new WP_Block( $parsed_block, $context, $this->registry );
+
+		$result = count( $block );
+
+		$this->assertEquals( 1, $result );
+	}
+
 }

--- a/phpunit/class-wp-block-test.php
+++ b/phpunit/class-wp-block-test.php
@@ -367,4 +367,26 @@ class WP_Block_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'invalid, but still supported', $block[0] );
 	}
 
+	function test_block_json_serializable_as_attributes_array() {
+		$this->registry->register(
+			'core/example',
+			array(
+				'attributes' => array(
+					'value' => array(
+						'type'    => 'string',
+						'default' => 'ok',
+					),
+				),
+			)
+		);
+
+		$parsed_block = array( 'blockName' => 'core/example' );
+		$context      = array();
+		$block        = new WP_Block( $parsed_block, $context, $this->registry );
+
+		$result = json_encode( $block );
+
+		$this->assertEquals( '{"value":"ok"}', $result );
+	}
+
 }


### PR DESCRIPTION
Previously: #21467
Related: #21797

This pull request seeks to enhance the existing `WP_Block` class to implement a number of other default PHP interfaces, in an effort to more faithfully preserve the behaviors of an array in backward-compatible usage of `render_callback`'s first argument as an array of block attributes.

**NOTE:** This pull request is largely intended for demonstration or future reference. Pending a decision at #21797, these changes may or may not be needed.