### PR TITLE
rnmobile/enabling alignment from aztec android

### DIFF
--- a/packages/block-library/src/heading/edit.js
+++ b/packages/block-library/src/heading/edit.js
@@ -26,11 +26,6 @@ import { Platform } from '@wordpress/element';
 function HeadingEdit( { attributes, setAttributes, mergeBlocks, onReplace } ) {
 	const { align, content, level, placeholder, style } = attributes;
 	const tagName = 'h' + level;
-	const isAndroid = Platform.select( {
-		android: true,
-		native: false,
-		web: false,
-	} );
 
 	const styles = {
 		color: style && style.color && style.color.text,
@@ -47,14 +42,12 @@ function HeadingEdit( { attributes, setAttributes, mergeBlocks, onReplace } ) {
 						setAttributes( { level: newLevel } )
 					}
 				/>
-				{ ! isAndroid && (
-					<AlignmentToolbar
-						value={ align }
-						onChange={ ( nextAlign ) => {
-							setAttributes( { align: nextAlign } );
-						} }
-					/>
-				) }
+				<AlignmentToolbar
+					value={ align }
+					onChange={ ( nextAlign ) => {
+						setAttributes( { align: nextAlign } );
+					} }
+				/>
 			</BlockControls>
 			{ Platform.OS === 'web' && (
 				<InspectorControls>

--- a/packages/block-library/src/quote/edit.js
+++ b/packages/block-library/src/quote/edit.js
@@ -71,6 +71,7 @@ export default function QuoteEdit( {
 					__unstableOnSplitMiddle={ () =>
 						createBlock( 'core/paragraph' )
 					}
+					textAlign={ align }
 				/>
 				{ ( ! RichText.isEmpty( citation ) || isSelected ) && (
 					<RichText
@@ -87,6 +88,7 @@ export default function QuoteEdit( {
 							__( 'Write citation…' )
 						}
 						className="wp-block-quote__citation"
+						textAlign={ align }
 					/>
 				) }
 			</BlockQuotation>

--- a/packages/block-library/src/verse/edit.js
+++ b/packages/block-library/src/verse/edit.js
@@ -46,6 +46,7 @@ export default function VerseEdit( {
 					[ `has-text-align-${ textAlign }` ]: textAlign,
 				} ) }
 				onMerge={ mergeBlocks }
+				textAlign={ textAlign }
 			/>
 		</>
 	);


### PR DESCRIPTION
Enabling alignment for the heading block for Android and for the Verse and Quote blocks on both platforms.

Further description in the related gutenberg-mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/2006

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [X] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
