### PR TITLE
Update wp-env docs to reflect current functionality of package

### DIFF
--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -24,7 +24,7 @@ The local environment will be available at http://localhost:8888.
 
 ### Installation as a global package
 
-After confirming that the prerequisits are installed, you can install `wp-env` globally like so:
+After confirming that the prerequisites are installed, you can install `wp-env` globally like so:
 
 ```sh
 $ npm -g i @wordpress/env

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -18,7 +18,7 @@ The local environment will be available at http://localhost:8888.
 
 `wp-env` requires Docker to be installed. There are instructions available for installing Docker on [Windows 10 Pro](https://docs.docker.com/docker-for-windows/install/), [all other versions of Windows](https://docs.docker.com/toolbox/toolbox_install_windows/), [macOS](https://docs.docker.com/docker-for-mac/install/), and [Linux](https://docs.docker.com/v17.12/install/linux/docker-ce/ubuntu/#install-using-the-convenience-script).
 
-`wp-env` is also distributed through NPM (Node Package Manager), so Node.js and NPM are required. The LTS version of Node.js was used to develop `wp-env` and is recommended.
+`wp-env` is also distributed through NPM (Node Package Manager), so Node.js and NPM are required. The latest LTS version of Node.js is used to develop `wp-env` and is recommended.
 
 ## Installation
 

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -34,10 +34,10 @@ You're now ready to use `wp-env`!
 
 ### Installation as a local package
 
-If your project already has a package.json, it's also possible to use `wp-env` as a local package. First install `wp-env` locally:
+If your project already has a package.json, it's also possible to use `wp-env` as a local package. First install `wp-env` locally as a dev dependency:
 
 ```sh
-$ npm i @wordpress/env
+$ npm i @wordpress/env --save-dev
 ```
 
 Then modify your package.json and add an extra command to npm `scripts` (https://docs.npmjs.com/misc/scripts):

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -40,6 +40,14 @@ If your project already has a package.json, it's also possible to use `wp-env` a
 $ npm i @wordpress/env --save-dev
 ```
 
+Then modify your package.json and add an extra command to npm `scripts` (https://docs.npmjs.com/misc/scripts):
+
+```json
+"scripts": {
+	"wp-env": "packages/env/bin/wp-env"
+}
+```
+
 When installing `wp-env` in this way, all `wp-env` commands detailed in these docs must be prefixed with `npm run`, for example:
 
 ```sh

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -18,7 +18,7 @@ The local environment will be available at http://localhost:8888.
 
 `wp-env` requires Docker to be installed. There are instructions available for installing Docker on [Windows 10 Pro](https://docs.docker.com/docker-for-windows/install/), [all other versions of Windows](https://docs.docker.com/toolbox/toolbox_install_windows/), [macOS](https://docs.docker.com/docker-for-mac/install/), and [Linux](https://docs.docker.com/v17.12/install/linux/docker-ce/ubuntu/#install-using-the-convenience-script).
 
-`wp-env` is also distributed through NPM (Node Package Manager), so Node.js and NPM are required. The latest LTS version of Node.js is used to develop `wp-env` and is recommended.
+Node.js and NPM are required. The latest LTS version of Node.js is used to develop `wp-env` and is recommended.
 
 ## Installation
 

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -60,7 +60,9 @@ instead of:
 $ wp-env start
 ```
 
-## Starting the environment
+## Usage
+
+### Starting the environment
 
 First, ensure that Docker is running. You can do this by clicking on the Docker icon in the system tray or menu bar.
 
@@ -78,7 +80,7 @@ $ wp-env start
 
 Finally, navigate to http://localhost:8888 in your web browser to see WordPress running with the local WordPress plugin or theme running and activated. Default login credentials are username: `admin` password: `password`.
 
-## Stopping the environment
+### Stopping the environment
 
 To stop the local environment:
 

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -40,14 +40,6 @@ If your project already has a package.json, it's also possible to use `wp-env` a
 $ npm i @wordpress/env --save-dev
 ```
 
-Then modify your package.json and add an extra command to npm `scripts` (https://docs.npmjs.com/misc/scripts):
-
-```json
-"scripts": {
-	"wp-env": "packages/env/bin/wp-env"
-}
-```
-
 When installing `wp-env` in this way, all `wp-env` commands detailed in these docs must be prefixed with `npm run`, for example:
 
 ```sh

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -44,7 +44,7 @@ Then modify your package.json and add an extra command to npm `scripts` (https:/
 
 ```json
 "scripts": {
-	"wp-env": "packages/env/bin/wp-env"
+	"wp-env": "wp-env"
 }
 ```
 

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -43,12 +43,12 @@ $ npm i @wordpress/env
 Then modify your package.json and add an extra command to npm `scripts` (https://docs.npmjs.com/misc/scripts):
 
 ```json
-	"scripts": {
-		"wp-env": "packages/env/bin/wp-env"
-	}
+"scripts": {
+	"wp-env": "packages/env/bin/wp-env"
+}
 ```
 
-When installing `wp-env` in this way, all commands detailed in these docs must be prefixed with `npm run`, for example:
+When installing `wp-env` in this way, all `wp-env` commands detailed in these docs must be prefixed with `npm run`, for example:
 
 ```sh
 $ npm run wp-env start

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -8,18 +8,23 @@ Ensure that Docker is running, then:
 
 ```sh
 $ cd /path/to/a/wordpress/plugin
-$ npx wp-env start
+$ npm -g i @wordpress/env
+$ wp-env start
 ```
 
 The local environment will be available at http://localhost:8888.
 
-## Instructions
-
-### Installation
+## Prerequisites
 
 `wp-env` requires Docker to be installed. There are instructions available for installing Docker on [Windows 10 Pro](https://docs.docker.com/docker-for-windows/install/), [all other versions of Windows](https://docs.docker.com/toolbox/toolbox_install_windows/), [macOS](https://docs.docker.com/docker-for-mac/install/), and [Linux](https://docs.docker.com/v17.12/install/linux/docker-ce/ubuntu/#install-using-the-convenience-script).
 
-After confirming that Docker is installed, you can install `wp-env` globally like so:
+`wp-env` is also distributed through NPM (Node Package Manager), so Node.js and NPM are required. The LTS version of Node.js was used to develop `wp-env` and is recommended.
+
+## Installation
+
+### Installation as a global package
+
+After confirming that the prerequisits are installed, you can install `wp-env` globally like so:
 
 ```sh
 $ npm -g i @wordpress/env
@@ -27,7 +32,35 @@ $ npm -g i @wordpress/env
 
 You're now ready to use `wp-env`!
 
-### Starting the environment
+### Installation as a local package
+
+If your project already has a package.json, it's also possible to use `wp-env` as a local package. First install `wp-env` locally:
+
+```sh
+$ npm i @wordpress/env
+```
+
+Then modify your package.json and add an extra command to npm `scripts` (https://docs.npmjs.com/misc/scripts):
+
+```json
+	"scripts": {
+		"wp-env": "packages/env/bin/wp-env"
+	}
+```
+
+When installing `wp-env` in this way, all commands detailed in these docs must be prefixed with `npm run`, for example:
+
+```sh
+$ npm run wp-env start
+```
+
+instead of:
+
+```sh
+$ wp-env start
+```
+
+## Starting the environment
 
 First, ensure that Docker is running. You can do this by clicking on the Docker icon in the system tray or menu bar.
 
@@ -45,7 +78,7 @@ $ wp-env start
 
 Finally, navigate to http://localhost:8888 in your web browser to see WordPress running with the local WordPress plugin or theme running and activated. Default login credentials are username: `admin` password: `password`.
 
-### Stopping the environment
+## Stopping the environment
 
 To stop the local environment:
 


### PR DESCRIPTION
Fixes #20923


## Description
@ajitbohra mentioned on slack that some of the instructions in the wp-env README either didn't work or weren't clear enough.

This PR updates those docs:
- Quick start instructions didn't previously work as this depends on wp-env being published on NPM as the `wp-env` package, but it's published instead as `@wordpress/env`.
- Instructions centered around installing `wp-env` globally. This update makes it clear that `wp-env` can also be used locally (as it's used in Gutenberg).
- The README now also mentions that `wp-env` is intended to be used with the latest LTS version of Node.

## Types of changes
Documentation