### PR TITLE
Fix the balance of the WordPress logo and inserter.

### DIFF
--- a/packages/edit-post/src/components/header/header-toolbar/style.scss
+++ b/packages/edit-post/src/components/header/header-toolbar/style.scss
@@ -80,6 +80,11 @@
 	}
 }
 
-.edit-post-header-toolbar__inserter-toggle {
+.edit-post-header-toolbar > .edit-post-header-toolbar__inserter-toggle {
 	margin-right: $grid-unit-10;
+	// Special dimensions for this button.
+	min-width: 32px;
+	width: 32px;
+	height: 32px;
+	padding: 0;
 }

--- a/packages/interface/src/components/admin-menu-toggle/style.scss
+++ b/packages/interface/src/components/admin-menu-toggle/style.scss
@@ -10,7 +10,6 @@
 		border: none;
 		border-radius: 0;
 		height: auto;
-		margin-right: -8px;
 		width: $header-height;
 		background: #23282e; // WP-admin gray.
 		transition: all 0.12s ease-in-out;


### PR DESCRIPTION
These two regressed recently. The margin between the WordPress logo and the inserter button has been balanced to optically match that of the more menu on the right. The Inserter button was set to 32x32 to not be too imposing in the top toolbar, this was unintentionally removed.

Before:

<img width="547" alt="before menu" src="https://user-images.githubusercontent.com/1204802/80076598-b9d56480-854c-11ea-9e5d-a8fa5274e71e.png">

After:

<img width="529" alt="after" src="https://user-images.githubusercontent.com/1204802/80076616-be9a1880-854c-11ea-9b85-5631380566dd.png">
