### PR TITLE
fix: [#21810] Allow default pasting behaviour in FontSizePicker

### DIFF
--- a/packages/block-editor/src/components/copy-handler/index.js
+++ b/packages/block-editor/src/components/copy-handler/index.js
@@ -1,77 +1,83 @@
 /**
  * WordPress dependencies
  */
+import { useRef } from '@wordpress/element';
 import { serialize, pasteHandler } from '@wordpress/blocks';
 import { documentHasSelection } from '@wordpress/dom';
-import { withDispatch } from '@wordpress/data';
-import { compose } from '@wordpress/compose';
+import { useDispatch, useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import { getPasteEventData } from '../../utils/get-paste-event-data';
 
-function CopyHandler( { children, handler } ) {
+function CopyHandler( { children } ) {
+	const containerRef = useRef();
+
+	const {
+		getBlocksByClientId,
+		getSelectedBlockClientIds,
+		hasMultiSelection,
+		getSettings,
+	} = useSelect( ( select ) => select( 'core/block-editor' ), [] );
+
+	const { removeBlocks, replaceBlocks } = useDispatch( 'core/block-editor' );
+
+	const {
+		__experimentalCanUserUseUnfilteredHTML: canUserUseUnfilteredHTML,
+	} = getSettings();
+
+	const handler = ( event ) => {
+		const selectedBlockClientIds = getSelectedBlockClientIds();
+
+		if ( selectedBlockClientIds.length === 0 ) {
+			return;
+		}
+
+		// Always handle multiple selected blocks.
+		// Let native copy behaviour take over in input fields.
+		if ( ! hasMultiSelection() && documentHasSelection() ) {
+			return;
+		}
+
+		if ( ! containerRef.current.contains( event.target ) ) {
+			return;
+		}
+		event.preventDefault();
+
+		if ( event.type === 'copy' || event.type === 'cut' ) {
+			const blocks = getBlocksByClientId( selectedBlockClientIds );
+			const serialized = serialize( blocks );
+
+			event.clipboardData.setData( 'text/plain', serialized );
+			event.clipboardData.setData( 'text/html', serialized );
+		}
+
+		if ( event.type === 'cut' ) {
+			removeBlocks( selectedBlockClientIds );
+		} else if ( event.type === 'paste' ) {
+			const { plainText, html } = getPasteEventData( event );
+			const blocks = pasteHandler( {
+				HTML: html,
+				plainText,
+				mode: 'BLOCKS',
+				canUserUseUnfilteredHTML,
+			} );
+
+			replaceBlocks( selectedBlockClientIds, blocks );
+		}
+	};
+
 	return (
-		<div onCopy={ handler } onCut={ handler } onPaste={ handler }>
+		<div
+			ref={ containerRef }
+			onCopy={ handler }
+			onCut={ handler }
+			onPaste={ handler }
+		>
 			{ children }
 		</div>
 	);
 }
 
-export default compose( [
-	withDispatch( ( dispatch, ownProps, { select } ) => {
-		const {
-			getBlocksByClientId,
-			getSelectedBlockClientIds,
-			hasMultiSelection,
-			getSettings,
-		} = select( 'core/block-editor' );
-		const { removeBlocks, replaceBlocks } = dispatch( 'core/block-editor' );
-		const {
-			__experimentalCanUserUseUnfilteredHTML: canUserUseUnfilteredHTML,
-		} = getSettings();
-
-		return {
-			handler( event ) {
-				const selectedBlockClientIds = getSelectedBlockClientIds();
-
-				if ( selectedBlockClientIds.length === 0 ) {
-					return;
-				}
-
-				// Always handle multiple selected blocks.
-				// Let native copy behaviour take over in input fields.
-				if ( ! hasMultiSelection() && documentHasSelection() ) {
-					return;
-				}
-
-				event.preventDefault();
-
-				if ( event.type === 'copy' || event.type === 'cut' ) {
-					const blocks = getBlocksByClientId(
-						selectedBlockClientIds
-					);
-					const serialized = serialize( blocks );
-
-					event.clipboardData.setData( 'text/plain', serialized );
-					event.clipboardData.setData( 'text/html', serialized );
-				}
-
-				if ( event.type === 'cut' ) {
-					removeBlocks( selectedBlockClientIds );
-				} else if ( event.type === 'paste' ) {
-					const { plainText, html } = getPasteEventData( event );
-					const blocks = pasteHandler( {
-						HTML: html,
-						plainText,
-						mode: 'BLOCKS',
-						canUserUseUnfilteredHTML,
-					} );
-
-					replaceBlocks( selectedBlockClientIds, blocks );
-				}
-			},
-		};
-	} ),
-] )( CopyHandler );
+export default CopyHandler;


### PR DESCRIPTION
## Description
Fixes: #21810
Default paste behavior is not allowed for input fields. 
<!-- Please describe what you have changed or added -->

## Types of changes
Bug fix, non-breaking change.
Handling the case when you want to paste in an input field. 
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
