### PR TITLE
Adds a min size for custom text size

### DIFF
--- a/packages/components/src/font-size-picker/index.js
+++ b/packages/components/src/font-size-picker/index.js
@@ -124,6 +124,7 @@ export default function FontSizePicker( {
 							id={ fontSizePickerNumberId }
 							className="components-font-size-picker__number"
 							type="number"
+							min={ 0 }
 							onChange={ onChangeValue }
 							aria-label={ __( 'Custom' ) }
 							value={ value || '' }

--- a/packages/components/src/font-size-picker/index.js
+++ b/packages/components/src/font-size-picker/index.js
@@ -124,7 +124,7 @@ export default function FontSizePicker( {
 							id={ fontSizePickerNumberId }
 							className="components-font-size-picker__number"
 							type="number"
-							min={ 0 }
+							min={ 1 }
 							onChange={ onChangeValue }
 							aria-label={ __( 'Custom' ) }
 							value={ value || '' }


### PR DESCRIPTION
## Description
Closes #15082

## How has this been tested?
Tested locally by:

- add a new post or page
- add a paragraph with some text in it
- open the inspector
- in the font size panel try to set custom to lower than 1px
- should not be possible

## Screenshots <!-- if applicable -->

![min-font-size](https://user-images.githubusercontent.com/107534/80085481-ee531b80-8560-11ea-9b47-25865ffd510c.gif)


## Types of changes
I think this is a non breaking change.
