### PR TITLE
Fix the button outline style for the old button markup

### DIFF
--- a/packages/block-library/src/button/style.scss
+++ b/packages/block-library/src/button/style.scss
@@ -48,7 +48,7 @@ $blocks-button__height: 56px;
 	border-radius: 0 !important;
 }
 
-.wp-block-button.is-style-outline,
+.wp-block-button.is-style-outline .wp-block-button__link,
 .wp-block-button__link.is-style-outline {
 	color: $dark-gray-700;
 	background-color: transparent;


### PR DESCRIPTION
closes #21747

The outline styles for the old button markup were not right. This PR fixes the styling to avoid the extra borders.

**Testing instructions**

 - Create buttons with the outline style with an  old version (WP 5.4)
 - enable the plugin and this PR and check that buttons show up right on multiple themes.