### PR TITLE
Unify how editor alignments are applied across blocks

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -46,8 +46,8 @@ $z-layers: (
 	".components-drop-zone": 40,
 	".components-drop-zone__content": 50,
 
-	// The block mover for floats should overlap the controls of adjacent blocks.
-	".block-editor-block-list__block {core/image aligned left or right}": 21,
+	// The floated blocks should be above the other blocks to allow selection.
+	".wp-block {core/image aligned left or right}": 21,
 
 	// Small screen inner blocks overlay must be displayed above drop zone,
 	// settings menu, and movers.

--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -47,7 +47,7 @@ $z-layers: (
 	".components-drop-zone__content": 50,
 
 	// The floated blocks should be above the other blocks to allow selection.
-	".wp-block {core/image aligned left or right}": 21,
+	"{core/image aligned left or right} .wp-block": 21,
 
 	// Small screen inner blocks overlay must be displayed above drop zone,
 	// settings menu, and movers.

--- a/packages/block-editor/src/components/block-list/block-wrapper.js
+++ b/packages/block-editor/src/components/block-list/block-wrapper.js
@@ -209,30 +209,20 @@ const BlockComponent = forwardRef(
 		const blockElementId = `block-${ clientId }${ htmlSuffix }`;
 		const Animated = animated[ tagName ];
 
-		// For aligned blocks, provide a wrapper element so the block can be
-		// positioned relative to the block column. This is enabled with the
-		// .is-block-content className.
-		const blockEdit = isAligned ? (
-			<div { ...props } className="is-block-content">
-				{ children }
-			</div>
-		) : (
-			children
-		);
-
-		return (
+		const blockWrapper = (
 			<Animated
 				// Overrideable props.
 				aria-label={ blockLabel }
 				role="group"
-				{ ...wrapperProps }
-				{ ...( ! isAligned ? props : {} ) }
+				{ ...omit( wrapperProps, [ 'data-align' ] ) }
+				{ ...props }
 				id={ blockElementId }
 				ref={ wrapper }
 				className={ classnames(
 					className,
 					props.className,
-					wrapperProps && wrapperProps.className
+					wrapperProps && wrapperProps.className,
+					! isAligned && 'wp-block'
 				) }
 				data-block={ clientId }
 				data-type={ name }
@@ -248,9 +238,25 @@ const BlockComponent = forwardRef(
 					...animationStyle,
 				} }
 			>
-				{ blockEdit }
+				{ children }
 			</Animated>
 		);
+
+		// For aligned blocks, provide a wrapper element so the block can be
+		// positioned relative to the block column. This is enabled with the
+		// .is-block-content className.
+		if ( isAligned ) {
+			const alignmentWrapperProps = {
+				'data-align': wrapperProps[ 'data-align' ],
+			};
+			return (
+				<div className="wp-block" { ...alignmentWrapperProps }>
+					{ blockWrapper }
+				</div>
+			);
+		}
+
+		return blockWrapper;
 	}
 );
 

--- a/packages/block-editor/src/components/block-list/block-wrapper.js
+++ b/packages/block-editor/src/components/block-list/block-wrapper.js
@@ -30,16 +30,7 @@ import { BlockContext } from './block';
 import ELEMENTS from './block-elements';
 
 const BlockComponent = forwardRef(
-	(
-		{
-			children,
-			tagName = 'div',
-			__unstableIsHtml,
-			wrapperProps: parentWrapperProps,
-			...props
-		},
-		wrapper
-	) => {
+	( { children, tagName = 'div', __unstableIsHtml, ...props }, wrapper ) => {
 		const onSelectionStart = useContext( Context );
 		const [ , setBlockNodes ] = useContext( BlockNodes );
 		const {
@@ -58,7 +49,7 @@ const BlockComponent = forwardRef(
 			name,
 			mode,
 			blockTitle,
-			wrapperProps: contextWrapperProps,
+			wrapperProps,
 		} = useContext( BlockContext );
 		const { initialPosition } = useSelect(
 			( select ) => {
@@ -78,10 +69,6 @@ const BlockComponent = forwardRef(
 			'core/block-editor'
 		);
 		const fallbackRef = useRef();
-		const wrapperProps = {
-			...contextWrapperProps,
-			...parentWrapperProps,
-		};
 		const isAligned = wrapperProps && !! wrapperProps[ 'data-align' ];
 		wrapper = wrapper || fallbackRef;
 

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -107,7 +107,7 @@ function BlockListBlock( {
 	const wrapperClassName = classnames(
 		generatedClassName,
 		customClassName,
-		'wp-block block-editor-block-list__block',
+		'block-editor-block-list__block',
 		{
 			'has-warning': ! isValid || !! hasError || isUnregisteredBlock,
 			'is-selected': isSelected,

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -144,13 +144,6 @@ function BlockListBlock( {
 		/>
 	);
 
-	// For aligned blocks, provide a wrapper element so the block can be
-	// positioned relative to the block column. This is enabled with the
-	// .is-block-content className.
-	if ( ! lightBlockWrapper && isAligned ) {
-		blockEdit = <div className="is-block-content">{ blockEdit }</div>;
-	}
-
 	if ( mode !== 'visual' ) {
 		blockEdit = <div style={ { display: 'none' } }>{ blockEdit }</div>;
 	}

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -138,7 +138,6 @@
 			right: $border-width;
 		}
 
-		// .is-block-content, // Floats.
 		&::after { // Everything else.
 			// 2px outside.
 			box-shadow: 0 0 0 $border-width-focus $blue-medium-focus;

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -264,9 +264,6 @@
 	// Alignments.
 	&[data-align="left"],
 	&[data-align="right"] {
-		// Without z-index, won't be clickable as "above" adjacent content.
-		z-index: z-index(".wp-block {core/image aligned left or right}");
-
 		width: 100%;
 
 		// When images are floated, the block itself should collapse to zero height.
@@ -275,6 +272,12 @@
 		&::before {
 			content: none;
 		}
+	}
+
+	&[data-align="left"] > *,
+	&[data-align="right"] > * {
+		// Without z-index, won't be clickable as "above" adjacent content.
+		z-index: z-index("{core/image aligned left or right} .wp-block");
 	}
 
 	// Left.

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -1,8 +1,3 @@
-.block-editor-block-list__block {
-	margin-left: auto;
-	margin-right: auto;
-}
-
 .block-editor-block-list__layout .block-editor-block-list__block { // Needs specificity to override inherited styles.
 	// While block is being dragged, dim the slot dragged from, and hide some UI.
 	&.is-dragging {
@@ -143,7 +138,7 @@
 			right: $border-width;
 		}
 
-		.is-block-content, // Floats.
+		// .is-block-content, // Floats.
 		&::after { // Everything else.
 			// 2px outside.
 			box-shadow: 0 0 0 $border-width-focus $blue-medium-focus;
@@ -248,53 +243,6 @@
 		cursor: default;
 	}
 
-	.alignleft,
-	.alignright {
-		// Without z-index, won't be clickable as "above" adjacent content.
-		z-index: z-index(".block-editor-block-list__block {core/image aligned left or right}");
-	}
-
-	// Alignments.
-	&[data-align="left"],
-	&[data-align="right"] {
-		// Without z-index, won't be clickable as "above" adjacent content.
-		z-index: z-index(".block-editor-block-list__block {core/image aligned left or right}");
-		width: 100%;
-
-		// When images are floated, the block itself should collapse to zero height.
-		height: 0;
-
-		&::before {
-			content: none;
-		}
-	}
-
-	// Left.
-	&[data-align="left"] > .is-block-content {
-		// This is in the editor only; the image should be floated on the frontend.
-		/*!rtl:begin:ignore*/
-		float: left;
-		margin-right: 2em;
-		/*!rtl:end:ignore*/
-	}
-
-	// Right.
-	&[data-align="right"] > .is-block-content {
-		// Right: This is in the editor only; the image should be floated on the frontend.
-		/*!rtl:begin:ignore*/
-		float: right;
-		margin-left: 2em;
-		/*!rtl:end:ignore*/
-	}
-
-	// Wide and full-wide.
-	&[data-align="full"],
-	&[data-align="wide"],
-	&.alignfull,
-	&.alignwide {
-		clear: both;
-	}
-
 	// Clear floats.
 	&[data-clear="true"] {
 		float: none;
@@ -307,6 +255,51 @@
 			left: auto;
 			right: $grid-unit-10;
 		}
+	}
+}
+
+.wp-block {
+	margin-left: auto;
+	margin-right: auto;
+
+	// Alignments.
+	&[data-align="left"],
+	&[data-align="right"] {
+		// Without z-index, won't be clickable as "above" adjacent content.
+		z-index: z-index(".wp-block {core/image aligned left or right}");
+
+		width: 100%;
+
+		// When images are floated, the block itself should collapse to zero height.
+		height: 0;
+
+		&::before {
+			content: none;
+		}
+	}
+
+	// Left.
+	&[data-align="left"] > * {
+		// This is in the editor only; the image should be floated on the frontend.
+		/*!rtl:begin:ignore*/
+		float: left;
+		margin-right: 2em;
+		/*!rtl:end:ignore*/
+	}
+
+	// Right.
+	&[data-align="right"] > * {
+		// Right: This is in the editor only; the image should be floated on the frontend.
+		/*!rtl:begin:ignore*/
+		float: right;
+		margin-left: 2em;
+		/*!rtl:end:ignore*/
+	}
+
+	// Wide and full-wide.
+	&[data-align="full"],
+	&[data-align="wide"] {
+		clear: both;
 	}
 }
 
@@ -624,12 +617,8 @@
 		padding-right: $block-side-ui-width;
 	}
 
-	// Full-wide. (to account for the padddings added above)
-	// The first two rules account for the alignment wrapper div for the image block.
-	> div:not(.block-editor-block-list__block) > .block-editor-block-list__block[data-align="full"],
-	> div:not(.block-editor-block-list__block) > .block-editor-block-list__block.alignfull,
-	> .block-editor-block-list__block[data-align="full"],
-	> .block-editor-block-list__block.alignfull {
+	// Full-wide. (to account for the paddings added above)
+	> .wp-block[data-align="full"] {
 		margin-left: -$block-padding;
 		margin-right: -$block-padding;
 

--- a/packages/block-editor/src/components/block-preview/style.scss
+++ b/packages/block-editor/src/components/block-preview/style.scss
@@ -44,10 +44,7 @@
 		padding-left: 0;
 		padding-right: 0;
 
-		> div:not(.block-editor-block-list__block) > .block-editor-block-list__block[data-align="full"],
-		> div:not(.block-editor-block-list__block) > .block-editor-block-list__block.alignfull,
-		> .block-editor-block-list__block[data-align="full"],
-		> .block-editor-block-list__block.alignfull {
+		> .wp-block[data-align="full"] {
 			margin-left: 0;
 			margin-right: 0;
 		}

--- a/packages/block-library/src/button/editor.scss
+++ b/packages/block-library/src/button/editor.scss
@@ -1,14 +1,12 @@
-.block-editor-block-list__block[data-type="core/button"] {
-	&[data-align="center"] {
-		text-align: center;
-		margin-left: auto;
-		margin-right: auto;
-	}
+.wp-block[data-align="center"] .wp-block-button {
+	text-align: center;
+	margin-left: auto;
+	margin-right: auto;
+}
 
-	&[data-align="right"] {
-		/*!rtl:ignore*/
-		text-align: right;
-	}
+.wp-block[data-align="right"] .wp-block-button {
+	/*!rtl:ignore*/
+	text-align: right;
 }
 
 .wp-block-button {

--- a/packages/block-library/src/button/index.js
+++ b/packages/block-library/src/button/index.js
@@ -32,6 +32,7 @@ export const settings = {
 	},
 	supports: {
 		align: true,
+		alignWide: false,
 		reusable: false,
 		lightBlockWrapper: true,
 		__experimentalColor: { gradients: true },

--- a/packages/block-library/src/button/index.js
+++ b/packages/block-library/src/button/index.js
@@ -32,7 +32,6 @@ export const settings = {
 	},
 	supports: {
 		align: true,
-		alignWide: false,
 		reusable: false,
 		lightBlockWrapper: true,
 		__experimentalColor: { gradients: true },

--- a/packages/block-library/src/button/style.scss
+++ b/packages/block-library/src/button/style.scss
@@ -11,7 +11,6 @@ $blocks-button__height: 56px;
 	cursor: pointer;
 	display: inline-block;
 	font-size: $big-font-size;
-	margin: 0;
 	padding: 12px 24px;
 	text-align: center;
 	text-decoration: none;

--- a/packages/block-library/src/buttons/edit.js
+++ b/packages/block-library/src/buttons/edit.js
@@ -4,6 +4,7 @@
 import {
 	__experimentalAlignmentHookSettingsProvider as AlignmentHookSettingsProvider,
 	InnerBlocks,
+	__experimentalBlock as Block,
 } from '@wordpress/block-editor';
 
 /**
@@ -19,9 +20,9 @@ const alignmentHooksSetting = {
 	isEmbedButton: true,
 };
 
-function ButtonsEdit( { className } ) {
+function ButtonsEdit() {
 	return (
-		<div className={ className }>
+		<Block.div>
 			<AlignmentHookSettingsProvider value={ alignmentHooksSetting }>
 				<InnerBlocks
 					allowedBlocks={ ALLOWED_BLOCKS }
@@ -29,7 +30,7 @@ function ButtonsEdit( { className } ) {
 					__experimentalMoverDirection="horizontal"
 				/>
 			</AlignmentHookSettingsProvider>
-		</div>
+		</Block.div>
 	);
 }
 

--- a/packages/block-library/src/buttons/editor.scss
+++ b/packages/block-library/src/buttons/editor.scss
@@ -4,19 +4,19 @@
 }
 
 .wp-block-buttons {
-	&[data-align="center"] .block-editor-block-list__layout {
+	&[data-align="center"] > .is-block-content {
 		display: flex;
 		align-items: center;
 		flex-wrap: wrap;
 		justify-content: center;
 	}
 
-	&[data-align="right"] .block-editor-block-list__layout {
+	&[data-align="right"] > .is-block-content {
 		display: flex;
 		justify-content: flex-end;
 	}
 
-	.block-editor-block-list__layout > div:last-child {
+	.block-list-appender {
 		display: inline-block;
 	}
 }

--- a/packages/block-library/src/buttons/editor.scss
+++ b/packages/block-library/src/buttons/editor.scss
@@ -3,20 +3,18 @@
 	width: auto;
 }
 
-.wp-block-buttons {
-	&[data-align="center"] > .is-block-content {
-		display: flex;
-		align-items: center;
-		flex-wrap: wrap;
-		justify-content: center;
-	}
+.wp-block[data-align="center"] > .wp-block-buttons {
+	display: flex;
+	align-items: center;
+	flex-wrap: wrap;
+	justify-content: center;
+}
 
-	&[data-align="right"] > .is-block-content {
-		display: flex;
-		justify-content: flex-end;
-	}
+.wp-block[data-align="right"] > .wp-block-buttons {
+	display: flex;
+	justify-content: flex-end;
+}
 
-	.block-list-appender {
-		display: inline-block;
-	}
+.wp-block-buttons .block-list-appender {
+	display: inline-block;
 }

--- a/packages/block-library/src/buttons/index.js
+++ b/packages/block-library/src/buttons/index.js
@@ -26,6 +26,7 @@ export const settings = {
 	supports: {
 		align: true,
 		alignWide: false,
+		lightBlockWrapper: true,
 	},
 	transforms,
 	edit,

--- a/packages/block-library/src/cover/editor.scss
+++ b/packages/block-library/src/cover/editor.scss
@@ -1,6 +1,5 @@
 .wp-block-cover-image,
 .wp-block-cover {
-
 	&.components-placeholder h2 {
 		color: inherit;
 	}
@@ -23,13 +22,14 @@
 	.wp-block-cover__placeholder-background-options {
 		width: 100%;
 	}
+}
 
-	// Apply max-width to floated items that have no intrinsic width.
-	[data-align="left"] &,
-	[data-align="right"] & {
-		max-width: $content-width / 2;
-		width: 100%;
-	}
+[data-align="left"] > .wp-block-cover,
+[data-align="right"] > .wp-block-cover,
+[data-align="left"] > .wp-block-cover-image,
+[data-align="right"] > .wp-block-cover-image {
+	max-width: $content-width / 2;
+	width: 100%;
 }
 
 .block-library-cover__reset-button {

--- a/packages/block-library/src/embed/style.scss
+++ b/packages/block-library/src/embed/style.scss
@@ -1,6 +1,6 @@
 // Apply max-width to floated items that have no intrinsic width
-.block-editor-block-list__block[data-type*="core-embed"][data-align="left"] .is-block-content,
-.block-editor-block-list__block[data-type*="core-embed"][data-align="right"] .is-block-content,
+.wp-block[data-align="left"] > .wp-block-embed,
+.wp-block[data-align="right"] > .wp-block-embed,
 .wp-block-embed.alignleft,
 .wp-block-embed.alignright {
 	// Instagram widgets have a min-width of 326px, so go a bit beyond that.

--- a/packages/block-library/src/group/editor.scss
+++ b/packages/block-library/src/group/editor.scss
@@ -48,7 +48,7 @@
 /**
  * Group: Full Width Alignment
  */
-.wp-block[data-type="core/group"][data-align="full"] {
+.wp-block[data-align="full"] .wp-block-group {
 
 	// First tier of InnerBlocks must act like the container of the standard canvas
 	> div > .wp-block-group > .wp-block-group__inner-container > .block-editor-inner-blocks {

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -352,6 +352,9 @@ export class ImageEdit extends Component {
 			sizeSlug,
 		} = attributes;
 
+		const wrapperProps = {
+			'data-align': align,
+		};
 		const isExternal = isExternalImage( id, url );
 		const controls = (
 			<BlockControls>
@@ -399,9 +402,6 @@ export class ImageEdit extends Component {
 				src={ url }
 			/>
 		);
-		const needsAlignmentWrapper = [ 'center', 'left', 'right' ].includes(
-			align
-		);
 
 		const mediaPlaceholder = (
 			<MediaPlaceholder
@@ -422,19 +422,8 @@ export class ImageEdit extends Component {
 			return (
 				<>
 					{ controls }
-					<Block.div
-						className={ classnames( className, {
-							[ `align${ align }` ]:
-								! needsAlignmentWrapper && align,
-						} ) }
-					>
-						{ needsAlignmentWrapper ? (
-							<div className={ `align${ align }` }>
-								{ mediaPlaceholder }
-							</div>
-						) : (
-							mediaPlaceholder
-						) }
+					<Block.div wrapperProps={ wrapperProps }>
+						{ mediaPlaceholder }
 					</Block.div>
 				</>
 			);
@@ -445,7 +434,6 @@ export class ImageEdit extends Component {
 			'is-resized': !! width || !! height,
 			'is-focused': isSelected,
 			[ `size-${ sizeSlug }` ]: sizeSlug,
-			[ `align${ align }` ]: align,
 		} );
 
 		const isResizable =
@@ -514,198 +502,188 @@ export class ImageEdit extends Component {
 		return (
 			<>
 				{ controls }
-				<div
-					className={
-						// Ideally these classes are not needed, and ideally, we
-						// provide an alignment wrapper component that the block
-						// can wrap around the block or we build it into
-						// Block.*.
-						needsAlignmentWrapper
-							? 'wp-block block-editor-block-list__block'
-							: undefined
-					}
+				<Block.figure
+					className={ classes }
+					wrapperProps={ wrapperProps }
 				>
-					<Block.figure className={ classes }>
-						<ImageSize src={ url } dirtynessTrigger={ align }>
-							{ ( sizes ) => {
-								const {
-									imageWidthWithinContainer,
-									imageHeightWithinContainer,
-									imageWidth,
-									imageHeight,
-								} = sizes;
+					<ImageSize src={ url } dirtynessTrigger={ align }>
+						{ ( sizes ) => {
+							const {
+								imageWidthWithinContainer,
+								imageHeightWithinContainer,
+								imageWidth,
+								imageHeight,
+							} = sizes;
 
-								const filename = this.getFilename( url );
-								let defaultedAlt;
-								if ( alt ) {
-									defaultedAlt = alt;
-								} else if ( filename ) {
-									defaultedAlt = sprintf(
-										/* translators: %s: file name */
-										__(
-											'This image has an empty alt attribute; its file name is %s'
-										),
-										filename
-									);
-								} else {
-									defaultedAlt = __(
-										'This image has an empty alt attribute'
-									);
-								}
-
-								const img = (
-									// Disable reason: Image itself is not meant to be interactive, but
-									// should direct focus to block.
-									/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
-									<>
-										<img
-											src={ url }
-											alt={ defaultedAlt }
-											onClick={ this.onImageClick }
-											onError={ () =>
-												this.onImageError( url )
-											}
-										/>
-										{ isBlobURL( url ) && <Spinner /> }
-									</>
-									/* eslint-enable jsx-a11y/no-noninteractive-element-interactions */
+							const filename = this.getFilename( url );
+							let defaultedAlt;
+							if ( alt ) {
+								defaultedAlt = alt;
+							} else if ( filename ) {
+								defaultedAlt = sprintf(
+									/* translators: %s: file name */
+									__(
+										'This image has an empty alt attribute; its file name is %s'
+									),
+									filename
 								);
+							} else {
+								defaultedAlt = __(
+									'This image has an empty alt attribute'
+								);
+							}
 
-								if (
-									! isResizable ||
-									! imageWidthWithinContainer
-								) {
-									return (
-										<>
-											{ getInspectorControls(
-												imageWidth,
-												imageHeight
-											) }
-											<div style={ { width, height } }>
-												{ img }
-											</div>
-										</>
-									);
-								}
+							const img = (
+								// Disable reason: Image itself is not meant to be interactive, but
+								// should direct focus to block.
+								/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
+								<>
+									<img
+										src={ url }
+										alt={ defaultedAlt }
+										onClick={ this.onImageClick }
+										onError={ () =>
+											this.onImageError( url )
+										}
+									/>
+									{ isBlobURL( url ) && <Spinner /> }
+								</>
+								/* eslint-enable jsx-a11y/no-noninteractive-element-interactions */
+							);
 
-								const currentWidth =
-									width || imageWidthWithinContainer;
-								const currentHeight =
-									height || imageHeightWithinContainer;
-
-								const ratio = imageWidth / imageHeight;
-								const minWidth =
-									imageWidth < imageHeight
-										? MIN_SIZE
-										: MIN_SIZE * ratio;
-								const minHeight =
-									imageHeight < imageWidth
-										? MIN_SIZE
-										: MIN_SIZE / ratio;
-
-								// With the current implementation of ResizableBox, an image needs an explicit pixel value for the max-width.
-								// In absence of being able to set the content-width, this max-width is currently dictated by the vanilla editor style.
-								// The following variable adds a buffer to this vanilla style, so 3rd party themes have some wiggleroom.
-								// This does, in most cases, allow you to scale the image beyond the width of the main column, though not infinitely.
-								// @todo It would be good to revisit this once a content-width variable becomes available.
-								const maxWidthBuffer = maxWidth * 2.5;
-
-								let showRightHandle = false;
-								let showLeftHandle = false;
-
-								/* eslint-disable no-lonely-if */
-								// See https://github.com/WordPress/gutenberg/issues/7584.
-								if ( align === 'center' ) {
-									// When the image is centered, show both handles.
-									showRightHandle = true;
-									showLeftHandle = true;
-								} else if ( isRTL ) {
-									// In RTL mode the image is on the right by default.
-									// Show the right handle and hide the left handle only when it is aligned left.
-									// Otherwise always show the left handle.
-									if ( align === 'left' ) {
-										showRightHandle = true;
-									} else {
-										showLeftHandle = true;
-									}
-								} else {
-									// Show the left handle and hide the right handle only when the image is aligned right.
-									// Otherwise always show the right handle.
-									if ( align === 'right' ) {
-										showLeftHandle = true;
-									} else {
-										showRightHandle = true;
-									}
-								}
-								/* eslint-enable no-lonely-if */
-
+							if (
+								! isResizable ||
+								! imageWidthWithinContainer
+							) {
 								return (
 									<>
 										{ getInspectorControls(
 											imageWidth,
 											imageHeight
 										) }
-										<ResizableBox
-											size={ {
-												width,
-												height,
-											} }
-											minWidth={ minWidth }
-											maxWidth={ maxWidthBuffer }
-											minHeight={ minHeight }
-											maxHeight={ maxWidthBuffer / ratio }
-											lockAspectRatio
-											enable={ {
-												top: false,
-												right: showRightHandle,
-												bottom: true,
-												left: showLeftHandle,
-											} }
-											onResizeStart={ onResizeStart }
-											onResizeStop={ (
-												event,
-												direction,
-												elt,
-												delta
-											) => {
-												onResizeStop();
-												setAttributes( {
-													width: parseInt(
-														currentWidth +
-															delta.width,
-														10
-													),
-													height: parseInt(
-														currentHeight +
-															delta.height,
-														10
-													),
-												} );
-											} }
-										>
+										<div style={ { width, height } }>
 											{ img }
-										</ResizableBox>
+										</div>
 									</>
 								);
-							} }
-						</ImageSize>
-						{ ( ! RichText.isEmpty( caption ) || isSelected ) && (
-							<RichText
-								tagName="figcaption"
-								placeholder={ __( 'Write caption…' ) }
-								value={ caption }
-								unstableOnFocus={ this.onFocusCaption }
-								onChange={ ( value ) =>
-									setAttributes( { caption: value } )
-								}
-								isSelected={ this.state.captionFocused }
-								inlineToolbar
-							/>
-						) }
+							}
 
-						{ mediaPlaceholder }
-					</Block.figure>
-				</div>
+							const currentWidth =
+								width || imageWidthWithinContainer;
+							const currentHeight =
+								height || imageHeightWithinContainer;
+
+							const ratio = imageWidth / imageHeight;
+							const minWidth =
+								imageWidth < imageHeight
+									? MIN_SIZE
+									: MIN_SIZE * ratio;
+							const minHeight =
+								imageHeight < imageWidth
+									? MIN_SIZE
+									: MIN_SIZE / ratio;
+
+							// With the current implementation of ResizableBox, an image needs an explicit pixel value for the max-width.
+							// In absence of being able to set the content-width, this max-width is currently dictated by the vanilla editor style.
+							// The following variable adds a buffer to this vanilla style, so 3rd party themes have some wiggleroom.
+							// This does, in most cases, allow you to scale the image beyond the width of the main column, though not infinitely.
+							// @todo It would be good to revisit this once a content-width variable becomes available.
+							const maxWidthBuffer = maxWidth * 2.5;
+
+							let showRightHandle = false;
+							let showLeftHandle = false;
+
+							/* eslint-disable no-lonely-if */
+							// See https://github.com/WordPress/gutenberg/issues/7584.
+							if ( align === 'center' ) {
+								// When the image is centered, show both handles.
+								showRightHandle = true;
+								showLeftHandle = true;
+							} else if ( isRTL ) {
+								// In RTL mode the image is on the right by default.
+								// Show the right handle and hide the left handle only when it is aligned left.
+								// Otherwise always show the left handle.
+								if ( align === 'left' ) {
+									showRightHandle = true;
+								} else {
+									showLeftHandle = true;
+								}
+							} else {
+								// Show the left handle and hide the right handle only when the image is aligned right.
+								// Otherwise always show the right handle.
+								if ( align === 'right' ) {
+									showLeftHandle = true;
+								} else {
+									showRightHandle = true;
+								}
+							}
+							/* eslint-enable no-lonely-if */
+
+							return (
+								<>
+									{ getInspectorControls(
+										imageWidth,
+										imageHeight
+									) }
+									<ResizableBox
+										size={ {
+											width,
+											height,
+										} }
+										minWidth={ minWidth }
+										maxWidth={ maxWidthBuffer }
+										minHeight={ minHeight }
+										maxHeight={ maxWidthBuffer / ratio }
+										lockAspectRatio
+										enable={ {
+											top: false,
+											right: showRightHandle,
+											bottom: true,
+											left: showLeftHandle,
+										} }
+										onResizeStart={ onResizeStart }
+										onResizeStop={ (
+											event,
+											direction,
+											elt,
+											delta
+										) => {
+											onResizeStop();
+											setAttributes( {
+												width: parseInt(
+													currentWidth + delta.width,
+													10
+												),
+												height: parseInt(
+													currentHeight +
+														delta.height,
+													10
+												),
+											} );
+										} }
+									>
+										{ img }
+									</ResizableBox>
+								</>
+							);
+						} }
+					</ImageSize>
+					{ ( ! RichText.isEmpty( caption ) || isSelected ) && (
+						<RichText
+							tagName="figcaption"
+							placeholder={ __( 'Write caption…' ) }
+							value={ caption }
+							unstableOnFocus={ this.onFocusCaption }
+							onChange={ ( value ) =>
+								setAttributes( { caption: value } )
+							}
+							isSelected={ this.state.captionFocused }
+							inlineToolbar
+						/>
+					) }
+
+					{ mediaPlaceholder }
+				</Block.figure>
 			</>
 		);
 		/* eslint-enable jsx-a11y/click-events-have-key-events */

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -352,9 +352,6 @@ export class ImageEdit extends Component {
 			sizeSlug,
 		} = attributes;
 
-		const wrapperProps = {
-			'data-align': align,
-		};
 		const isExternal = isExternalImage( id, url );
 		const controls = (
 			<BlockControls>
@@ -422,9 +419,7 @@ export class ImageEdit extends Component {
 			return (
 				<>
 					{ controls }
-					<Block.div wrapperProps={ wrapperProps }>
-						{ mediaPlaceholder }
-					</Block.div>
+					<Block.div>{ mediaPlaceholder }</Block.div>
 				</>
 			);
 		}
@@ -502,10 +497,7 @@ export class ImageEdit extends Component {
 		return (
 			<>
 				{ controls }
-				<Block.figure
-					className={ classes }
-					wrapperProps={ wrapperProps }
-				>
+				<Block.figure className={ classes }>
 					<ImageSize src={ url } dirtynessTrigger={ align }>
 						{ ( sizes ) => {
 							const {

--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -68,3 +68,8 @@ figure.wp-block-image:not(.wp-block) {
 	margin-top: 0.5em;
 	margin-bottom: 0.5em;
 }
+
+.wp-block[data-align="center"] > .wp-block-image {
+	margin-left: auto;
+	margin-right: auto;
+}

--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -17,19 +17,6 @@
 		margin-top: -9px;
 		margin-left: -9px;
 	}
-
-	// These need specificity to override an inherited left/right block margin in the editor.
-	&.wp-block-image.alignleft {
-		margin-right: 1em;
-		margin-top: 0.5em;
-		margin-bottom: 0.5em;
-	}
-
-	&.wp-block-image.alignright {
-		margin-left: 1em;
-		margin-top: 0.5em;
-		margin-bottom: 0.5em;
-	}
 }
 
 // This is necessary for the editor resize handles to accurately work on a non-floated, non-resized, small image.
@@ -48,18 +35,6 @@
 	display: block;
 }
 
-.block-editor-block-list__block[data-type="core/image"][data-align="center"] {
-	.wp-block-image {
-		margin-left: auto;
-		margin-right: auto;
-	}
-
-	&[data-resized="false"] .wp-block-image > div {
-		margin-left: auto;
-		margin-right: auto;
-	}
-}
-
 .block-editor-block-list__block[data-type="core/image"] .block-editor-block-toolbar .block-editor-url-input__button-modal {
 	position: absolute;
 	left: 0;
@@ -71,26 +46,21 @@
 	}
 }
 
-// Although the float markup is different in the editor compared to the frontend,
-// this CSS uses the same technique to allow floats in a wide images context.
-// That is, the block retains its centering and max-width, and a child inside
-// is floated instead of the block itself.
-[data-type="core/image"][data-align="center"],
-[data-type="core/image"][data-align="left"],
-[data-type="core/image"][data-align="right"] {
-	figure {
-		margin: 0;
-	}
-}
-
 [data-type="core/image"][data-align="wide"],
 [data-type="core/image"][data-align="full"] {
-	figure img {
+	img {
 		width: 100%;
 	}
 }
 
-// This is similar to above but for resized unfloated images only, where the markup is different.
-[data-type="core/image"] figure.is-resized {
-	margin: 0;
+[data-type="core/image"][data-align="left"] .is-block-content {
+	margin-right: 1em;
+	margin-top: 0.5em;
+	margin-bottom: 0.5em;
+}
+
+[data-type="core/image"][data-align="right"] .is-block-content {
+	margin-left: 1em;
+	margin-top: 0.5em;
+	margin-bottom: 0.5em;
 }

--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -59,12 +59,14 @@ figure.wp-block-image:not(.wp-block) {
 
 .wp-block[data-align="left"] > .wp-block-image {
 	margin-right: 1em;
+	margin-left: 0;
 	margin-top: 0.5em;
 	margin-bottom: 0.5em;
 }
 
 .wp-block[data-align="right"] > .wp-block-image {
 	margin-left: 1em;
+	margin-right: 0;
 	margin-top: 0.5em;
 	margin-bottom: 0.5em;
 }

--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -1,3 +1,7 @@
+figure.wp-block-image:not(.wp-block) {
+	margin: 0;
+}
+
 .wp-block-image {
 	position: relative;
 
@@ -46,20 +50,20 @@
 	}
 }
 
-[data-type="core/image"][data-align="wide"],
-[data-type="core/image"][data-align="full"] {
+[data-align="wide"] > .wp-block-image,
+[data-align="full"] > .wp-block-image {
 	img {
 		width: 100%;
 	}
 }
 
-[data-type="core/image"][data-align="left"] .is-block-content {
+.wp-block[data-align="left"] > .wp-block-image {
 	margin-right: 1em;
 	margin-top: 0.5em;
 	margin-bottom: 0.5em;
 }
 
-[data-type="core/image"][data-align="right"] .is-block-content {
+.wp-block[data-align="right"] > .wp-block-image {
 	margin-left: 1em;
 	margin-top: 0.5em;
 	margin-bottom: 0.5em;

--- a/packages/block-library/src/image/index.js
+++ b/packages/block-library/src/image/index.js
@@ -61,6 +61,11 @@ export const settings = {
 			return alt + ( caption ? '. ' + caption : '' );
 		}
 	},
+	getEditWrapperProps( attributes ) {
+		return {
+			'data-align': attributes.align,
+		};
+	},
 	transforms,
 	edit,
 	save,

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -16,6 +16,20 @@
 		width: 100%;
 	}
 
+	&.is-resized {
+		display: table;
+
+		// The figure is born with left and right margin.
+		// We remove this by default, and then customize it for left, right, and center.
+		margin-left: 0;
+		margin-right: 0;
+
+		> figcaption {
+			display: table-caption;
+			caption-side: bottom;
+		}
+	}
+
 	.alignleft {
 		/*rtl:ignore*/
 		float: left;

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -16,24 +16,6 @@
 		width: 100%;
 	}
 
-	// Floats get an extra wrapping <div> element, so the <figure> becomes a child.
-	.alignleft,
-	.alignright,
-	.aligncenter,
-	&.is-resized {
-		display: table;
-
-		// The figure is born with left and right margin.
-		// We remove this by default, and then customize it for left, right, and center.
-		margin-left: 0;
-		margin-right: 0;
-
-		> figcaption {
-			display: table-caption;
-			caption-side: bottom;
-		}
-	}
-
 	.alignleft {
 		/*rtl:ignore*/
 		float: left;

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -22,11 +22,6 @@
 	&.is-resized {
 		display: table;
 
-		// The figure is born with left and right margin.
-		// We remove this by default, and then customize it for left, right, and center.
-		margin-left: 0;
-		margin-right: 0;
-
 		> figcaption {
 			display: table-caption;
 			caption-side: bottom;
@@ -37,6 +32,7 @@
 		/*rtl:ignore*/
 		float: left;
 		/*rtl:ignore*/
+		margin-left: 0;
 		margin-right: 1em;
 		margin-top: 0.5em;
 		margin-bottom: 0.5em;
@@ -46,6 +42,7 @@
 		/*rtl:ignore*/
 		float: right;
 		/*rtl:ignore*/
+		margin-right: 0;
 		margin-left: 1em;
 		margin-top: 0.5em;
 		margin-bottom: 0.5em;

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -16,6 +16,9 @@
 		width: 100%;
 	}
 
+	.alignleft,
+	.alignright,
+	.aligncenter,
 	&.is-resized {
 		display: table;
 

--- a/packages/block-library/src/pullquote/editor.scss
+++ b/packages/block-library/src/pullquote/editor.scss
@@ -1,9 +1,7 @@
-.block-editor-block-list__block[data-type="core/pullquote"] {
-	&[data-align="left"],
-	&[data-align="right"] {
-		& p {
-			font-size: 20px;
-		}
+.wp-block[data-align="left"] > .wp-block-pullquote,
+.wp-block[data-align="right"] > .wp-block-pullquote {
+	& p {
+		font-size: 20px;
 	}
 }
 

--- a/packages/block-library/src/social-links/editor.scss
+++ b/packages/block-library/src/social-links/editor.scss
@@ -29,7 +29,7 @@
 }
 
 // Center flex items. This has an equivalent in style.scss.
-[data-type="core/social-links"][data-align="center"] .wp-block-social-links {
+.wp-block[data-align="center"] > .wp-block-social-links {
 	justify-content: center;
 }
 

--- a/packages/block-library/src/table/editor.scss
+++ b/packages/block-library/src/table/editor.scss
@@ -1,7 +1,7 @@
-.block-editor-block-list__block[data-type="core/table"] {
-	&[data-align="left"],
-	&[data-align="right"],
-	&[data-align="center"] {
+.wp-block-table {
+	.wp-block[data-align="left"] > &,
+	.wp-block[data-align="right"] > &,
+	.wp-block[data-align="center"] > & {
 		// Stop table block from collapsing when tables are floated.
 		height: auto;
 
@@ -16,7 +16,7 @@
 		}
 	}
 
-	&[data-align="center"] {
+	.wp-block[data-align="center"] > & {
 		text-align: initial;
 
 		table {

--- a/packages/block-library/src/video/editor.scss
+++ b/packages/block-library/src/video/editor.scss
@@ -1,4 +1,4 @@
-.block-editor-block-list__block[data-align="center"] {
+.wp-block[data-align="center"] > .wp-block-video {
 	text-align: center;
 }
 

--- a/packages/edit-post/src/style.scss
+++ b/packages/edit-post/src/style.scss
@@ -102,13 +102,11 @@ body.block-editor-page {
 .wp-block {
 	max-width: $content-width;
 
-	&[data-align="wide"],
-	&.alignwide {
+	&[data-align="wide"] {
 		max-width: 1100px;
 	}
 
-	&[data-align="full"],
-	&.alignfull {
+	&[data-align="full"] {
 		max-width: none;
 	}
 }

--- a/packages/edit-site/src/components/block-editor/style.scss
+++ b/packages/edit-site/src/components/block-editor/style.scss
@@ -6,8 +6,7 @@
 	padding-right: $block-padding;
 
 	// Full-wide. (to account for the padddings added above)
-	.block-editor-block-list__block[data-align="full"],
-	.block-editor-block-list__block.alignfull {
+	.wp-block[data-align="full"] {
 		margin-left: -$block-padding;
 		margin-right: -$block-padding;
 	}


### PR DESCRIPTION
While working on the `lightBlockWrapper` API, we experimented on the Image block about how we can keep the frontend similar to the backend for alignments. It worked for this particular block but it's not something we can generalize yet to all blocks (especially the ones relying on the align hook).

This PR partially reverts the image block alignments change and at the same time updates the "align" hook to support the new "lightBlockWrapper" behavior. This means lightBlockWrapper doesn't mean we're consistent with frontend for aligned blocks but it also means that all blocks in the editor behaves consistently when it comes to alignment (fixes #21685) 

So this is an intermediate step before the bigger alignments rethinking that is happening separately. 