### PR TITLE
Revert "Fix: Remove unrequired margins from the columns block"

### DIFF
--- a/packages/block-library/src/columns/edit.js
+++ b/packages/block-library/src/columns/edit.js
@@ -234,7 +234,7 @@ const ColumnsEdit = ( props ) => {
 	}
 
 	return (
-		<Block.div>
+		<Block.div className="has-placeholder">
 			<__experimentalBlockVariationPicker
 				icon={ get( blockType, [ 'icon', 'src' ] ) }
 				label={ get( blockType, [ 'title' ] ) }

--- a/packages/block-library/src/columns/editor.scss
+++ b/packages/block-library/src/columns/editor.scss
@@ -4,6 +4,14 @@
 	max-width: none;
 }
 
+// Ideally this shouldn't be necessary. There should be no default margins in
+// the editor.
+.editor-styles-wrapper .block-editor-block-list__block.wp-block-column,
+.editor-styles-wrapper .block-editor-block-list__block.wp-block-columns {
+	margin-top: 0;
+	margin-bottom: 0;
+}
+
 // To do: remove horizontal margin override by the editor.
 @include break-small() {
 	.editor-styles-wrapper

--- a/packages/block-library/src/columns/editor.scss
+++ b/packages/block-library/src/columns/editor.scss
@@ -7,7 +7,7 @@
 // Ideally this shouldn't be necessary. There should be no default margins in
 // the editor.
 .editor-styles-wrapper .block-editor-block-list__block.wp-block-column,
-.editor-styles-wrapper .block-editor-block-list__block.wp-block-columns {
+.editor-styles-wrapper .block-editor-block-list__block.wp-block-columns:not(.has-placeholder) {
 	margin-top: 0;
 	margin-bottom: 0;
 }


### PR DESCRIPTION
Reverts WordPress/gutenberg#21615

See https://github.com/WordPress/gutenberg/pull/21615#issuecomment-618339041.

I added a commit here applying margins to the placeholder.