### PR TITLE
Add `analyze-bundles` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -184,6 +184,7 @@
 		"worker-farm": "1.7.0"
 	},
 	"scripts": {
+		"analyze-bundles": "WP_BUNDLE_ANALYZER=true npm run build",
 		"prebuild": "npm run check-engines",
 		"clean:packages": "rimraf \"./packages/*/@(build|build-module|build-style)\"",
 		"clean:package-types": "tsc --build --clean",

--- a/package.json
+++ b/package.json
@@ -184,7 +184,7 @@
 		"worker-farm": "1.7.0"
 	},
 	"scripts": {
-		"analyze-bundles": "WP_BUNDLE_ANALYZER=true npm run build",
+		"analyze-bundles": "cross-env WP_BUNDLE_ANALYZER=true npm run build",
 		"prebuild": "npm run check-engines",
 		"clean:packages": "rimraf \"./packages/*/@(build|build-module|build-style)\"",
 		"clean:package-types": "tsc --build --clean",

--- a/package.json
+++ b/package.json
@@ -184,7 +184,7 @@
 		"worker-farm": "1.7.0"
 	},
 	"scripts": {
-		"analyze-bundles": "cross-env WP_BUNDLE_ANALYZER=true npm run build",
+		"analyze-bundles": "cross-env WP_BUNDLE_ANALYZER=1 npm run build",
 		"prebuild": "npm run check-engines",
 		"clean:packages": "rimraf \"./packages/*/@(build|build-module|build-style)\"",
 		"clean:package-types": "tsc --build --clean",

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Breaking Changes
 
 - The bundled `puppeteer` (`^2.0.0`) dependency has been replaced with `puppeteer-core` in version `3.0.0`. Puppeteer uses Chromium v81 instead of Chromium v79. See the [full list of changes](https://github.com/puppeteer/puppeteer/releases/tag/v3.0.0). It also allowed preventing Chromium installation together with `@wordpress/scripts`. It happens now on-demand when running `test-e2e` script, and it re-triggers only when a new version is required.
+- Bundle analysis now runs with module concatenation disabled. This represents the size of individual modules more accurately, at the cost of not providing an exact byte-for-byte match to the final size in the production chunk.
 
 ### New Features
 

--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -19,6 +19,10 @@ const isProduction = process.env.NODE_ENV === 'production';
 const mode = isProduction ? 'production' : 'development';
 
 const config = {
+	optimization: {
+		// Don't concatenate modules when analyzing bundles.
+		concatenateModules: ! process.env.WP_BUNDLE_ANALYZER,
+	},
 	mode,
 	entry: {
 		index: path.resolve( process.cwd(), 'src', 'index.js' ),
@@ -70,8 +74,8 @@ const config = {
 		],
 	},
 	plugins: [
-		// WP_BUNDLE_ANALYZER global variable enables utility that represents bundle content
-		// as convenient interactive zoomable treemap.
+		// The WP_BUNDLE_ANALYZER global variable enables a utility that represents bundle
+		// content as a convenient interactive zoomable treemap.
 		process.env.WP_BUNDLE_ANALYZER && new BundleAnalyzerPlugin(),
 		// WP_LIVE_RELOAD_PORT global variable changes port on which live reload works
 		// when running watch mode.

--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -20,8 +20,9 @@ const mode = isProduction ? 'production' : 'development';
 
 const config = {
 	optimization: {
-		// Don't concatenate modules when analyzing bundles.
-		concatenateModules: ! process.env.WP_BUNDLE_ANALYZER,
+		// Only concatenate modules in production, when not analyzing bundles.
+		concatenateModules:
+			mode === 'production' && ! process.env.WP_BUNDLE_ANALYZER,
 	},
 	mode,
 	entry: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+const { BundleAnalyzerPlugin } = require( 'webpack-bundle-analyzer' );
 const { DefinePlugin } = require( 'webpack' );
 const CopyWebpackPlugin = require( 'copy-webpack-plugin' );
 const postcss = require( 'postcss' );
@@ -38,7 +39,15 @@ const gutenbergPackages = Object.keys( dependencies )
 	)
 	.map( ( packageName ) => packageName.replace( WORDPRESS_NAMESPACE, '' ) );
 
+const analyzingBundles =
+	process.env.WP_BUNDLE_ANALYZER &&
+	process.env.WP_BUNDLE_ANALYZER !== 'false';
+
 module.exports = {
+	optimization: {
+		// Don't concatenate modules when analyzing bundles.
+		concatenateModules: ! analyzingBundles,
+	},
 	mode,
 	entry: gutenbergPackages.reduce( ( memo, packageName ) => {
 		const name = camelCaseDash( packageName );
@@ -62,6 +71,7 @@ module.exports = {
 		] ),
 	},
 	plugins: [
+		analyzingBundles && new BundleAnalyzerPlugin(),
 		new DefinePlugin( {
 			// Inject the `GUTENBERG_PHASE` global, used for feature flagging.
 			'process.env.GUTENBERG_PHASE': JSON.stringify(
@@ -189,7 +199,7 @@ module.exports = {
 			},
 		] ),
 		new DependencyExtractionWebpackPlugin( { injectPolyfill: true } ),
-	],
+	].filter( Boolean ),
 	watchOptions: {
 		ignored: '!packages/*/!(src)/**/*',
 	},

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -41,8 +41,9 @@ const gutenbergPackages = Object.keys( dependencies )
 
 module.exports = {
 	optimization: {
-		// Don't concatenate modules when analyzing bundles.
-		concatenateModules: ! process.env.WP_BUNDLE_ANALYZER,
+		// Only concatenate modules in production, when not analyzing bundles.
+		concatenateModules:
+			mode === 'production' && ! process.env.WP_BUNDLE_ANALYZER,
 	},
 	mode,
 	entry: gutenbergPackages.reduce( ( memo, packageName ) => {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -39,14 +39,10 @@ const gutenbergPackages = Object.keys( dependencies )
 	)
 	.map( ( packageName ) => packageName.replace( WORDPRESS_NAMESPACE, '' ) );
 
-const analyzingBundles =
-	process.env.WP_BUNDLE_ANALYZER &&
-	process.env.WP_BUNDLE_ANALYZER !== 'false';
-
 module.exports = {
 	optimization: {
 		// Don't concatenate modules when analyzing bundles.
-		concatenateModules: ! analyzingBundles,
+		concatenateModules: ! process.env.WP_BUNDLE_ANALYZER,
 	},
 	mode,
 	entry: gutenbergPackages.reduce( ( memo, packageName ) => {
@@ -71,7 +67,9 @@ module.exports = {
 		] ),
 	},
 	plugins: [
-		analyzingBundles && new BundleAnalyzerPlugin(),
+		// The WP_BUNDLE_ANALYZER global variable enables a utility that represents bundle
+		// content as a convenient interactive zoomable treemap.
+		process.env.WP_BUNDLE_ANALYZER && new BundleAnalyzerPlugin(),
 		new DefinePlugin( {
 			// Inject the `GUTENBERG_PHASE` global, used for feature flagging.
 			'process.env.GUTENBERG_PHASE': JSON.stringify(


### PR DESCRIPTION
This makes it easier to analyse bundles with `webpack-bundle-analyzer`, which is already included as a project dependency.

This generates colourful and helpful graphics like this one:

![image](https://user-images.githubusercontent.com/409615/80091617-54d43b80-8559-11ea-86fe-0441dc5add8e.png)

## Description
Add a new script, `analyze-bundles`, as well as the instrumentation required for it in `webpack.config.js`.

## How has this been tested?
This should not affect any code, only the build process, which appears to still work normally when using any other script.

Test by running `npm run analyze-bundles`.

## Types of changes
New feature involving build changes only.

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
