### PR TITLE
Framework: WP_Block: Use reflected type hint for render_callback

### DIFF
--- a/docs/designers-developers/developers/block-api/block-context.md
+++ b/docs/designers-developers/developers/block-api/block-context.md
@@ -69,7 +69,7 @@ A block's context values are available from the `context` property of the `$bloc
 
 ```php
 register_block_type( 'my-plugin/record-title', [
-	'render_callback' => function( $block ) {
+	'render_callback' => function( WP_Block $block ) {
 		return 'The current record ID is: ' . $block->context['my-plugin/recordId'];
 	},
 ] );

--- a/docs/designers-developers/developers/tutorials/block-tutorial/creating-dynamic-blocks.md
+++ b/docs/designers-developers/developers/tutorials/block-tutorial/creating-dynamic-blocks.md
@@ -99,7 +99,7 @@ Because it is a dynamic block it doesn't need to override the default `save` imp
  * Plugin Name: Gutenberg examples dynamic
  */
 
-function gutenberg_examples_dynamic_render_callback( $block, $content ) {
+function gutenberg_examples_dynamic_render_callback( $block_attributes, $content ) {
 	$recent_posts = wp_get_recent_posts( array(
 		'numberposts' => 1,
 		'post_status' => 'publish',
@@ -143,11 +143,11 @@ There are a few things to notice:
 * The built-in `save` function just returns `null` because the rendering is performed server-side.
 * The server-side rendering is a function taking the block and the block inner content as arguments, and returning the markup (quite similar to shortcodes)
 
-Note that for convenience and for backward-compatibility, the first argument of a `render_callback` function can also be referenced as an associative array of the block's attributes:
+By default, the first argument of `render_callback` receives an associative array of the block's attributes. If you need access to the block instance itself, you can provide a [type declaration](https://www.php.net/manual/en/functions.arguments.php#functions.arguments.type-declaration) in the function arguments as a hint that the render callback should receive the block.
 
 ```php
-function gutenberg_examples_dynamic_render_callback( $block_attributes ) {
-	return 'The record ID is: ' . esc_html( $block_attributes['recordId'] );
+function gutenberg_examples_dynamic_render_callback( WP_Block $block ) {
+	return 'The block name is: ' . esc_html( $block->name );
 }
 ```
 

--- a/docs/designers-developers/developers/tutorials/metabox/meta-block-4-use-data.md
+++ b/docs/designers-developers/developers/tutorials/metabox/meta-block-4-use-data.md
@@ -25,7 +25,7 @@ You can also use the post meta data in other blocks. For this example the data i
 In PHP, use the [register_block_type](https://developer.wordpress.org/reference/functions/register_block_type/) function to set a callback when the block is rendered to include the meta value.
 
 ```php
-function myguten_render_paragraph( $block, $content ) {
+function myguten_render_paragraph( $block_attributes, $content ) {
 	$value = get_post_meta( get_the_ID(), 'myguten_meta_block_field', true );
 	// check value is set before outputting
 	if ( $value ) {

--- a/lib/class-wp-block.php
+++ b/lib/class-wp-block.php
@@ -29,8 +29,8 @@ function gutenberg_block_type_render_callback_receives_block( $block_type ) {
 		return false;
 	}
 
-	$first_arg_type = $params[0]->getType();
-	return $first_arg_type && $first_arg_type->getName() === WP_Block::class;
+	$first_param_class = $params[0]->getClass();
+	return $first_param_class && $first_param_class->name === WP_Block::class;
 }
 
 /**

--- a/lib/class-wp-block.php
+++ b/lib/class-wp-block.php
@@ -30,7 +30,7 @@ function gutenberg_block_type_render_callback_receives_block( $block_type ) {
 	}
 
 	$first_param_class = $params[0]->getClass();
-	return $first_param_class && $first_param_class->name === WP_Block::class;
+	return $first_param_class && WP_Block::class === $first_param_class->name;
 }
 
 /**

--- a/packages/block-library/src/post-title/index.php
+++ b/packages/block-library/src/post-title/index.php
@@ -12,7 +12,7 @@
  *
  * @return string Returns the filtered post title for the current post wrapped inside "h1" tags.
  */
-function render_block_core_post_title( $block ) {
+function render_block_core_post_title( WP_Block $block ) {
 	if ( ! isset( $block->context['postId'] ) ) {
 		return '';
 	}

--- a/packages/e2e-tests/plugins/block-context.php
+++ b/packages/e2e-tests/plugins/block-context.php
@@ -48,7 +48,7 @@ function gutenberg_test_register_context_blocks() {
 		'gutenberg/test-context-consumer',
 		array(
 			'context'         => array( 'gutenberg/recordId' ),
-			'render_callback' => function( $block ) {
+			'render_callback' => function( WP_Block $block ) {
 				$record_id = $block->context['gutenberg/recordId'];
 
 				if ( ! is_int( $record_id ) ) {

--- a/phpunit/class-block-context-test.php
+++ b/phpunit/class-block-context-test.php
@@ -104,7 +104,7 @@ class Block_Context_Test extends WP_UnitTestCase {
 					'gutenberg/contextWithAssigned',
 					'gutenberg/contextWithoutDefault',
 				),
-				'render_callback' => function( $block ) use ( &$provided_context ) {
+				'render_callback' => function( WP_Block $block ) use ( &$provided_context ) {
 					$provided_context[] = $block->context;
 
 					return '';

--- a/phpunit/class-wp-block-test.php
+++ b/phpunit/class-wp-block-test.php
@@ -259,7 +259,7 @@ class WP_Block_Test extends WP_UnitTestCase {
 						'default' => '!',
 					),
 				),
-				'render_callback' => function( $block ) {
+				'render_callback' => function( WP_Block $block ) {
 					return sprintf(
 						'Hello %s%s',
 						$block->attributes['toWhom'],
@@ -312,7 +312,7 @@ class WP_Block_Test extends WP_UnitTestCase {
 		$this->registry->register(
 			'core/outer',
 			array(
-				'render_callback' => function( $block, $content ) {
+				'render_callback' => function( WP_Block $block, $content ) {
 					return $content;
 				},
 			)
@@ -332,39 +332,6 @@ class WP_Block_Test extends WP_UnitTestCase {
 		$block         = new WP_Block( $parsed_block, $context, $this->registry );
 
 		$this->assertSame( 'abc', $block->render() );
-	}
-
-	function test_array_access_attributes() {
-		$this->registry->register(
-			'core/example',
-			array(
-				'attributes' => array(
-					'value' => array(
-						'type' => 'string',
-					),
-				),
-			)
-		);
-		$parsed_block = array(
-			'blockName' => 'core/example',
-			'attrs'     => array( 'value' => 'ok' ),
-		);
-		$context      = array();
-		$block        = new WP_Block( $parsed_block, $context, $this->registry );
-
-		$this->assertTrue( isset( $block['value'] ) );
-		$this->assertFalse( isset( $block['nonsense'] ) );
-		$this->assertEquals( 'ok', $block['value'] );
-
-		$block['value'] = 'changed';
-		$this->assertEquals( 'changed', $block['value'] );
-		$this->assertEquals( 'changed', $block->attributes['value'] );
-
-		unset( $block['value'] );
-		$this->assertFalse( isset( $block['value'] ) );
-
-		$block[] = 'invalid, but still supported';
-		$this->assertEquals( 'invalid, but still supported', $block[0] );
 	}
 
 }


### PR DESCRIPTION
Closes #21797
Previously: #21467

This pull request seeks to revise the implementation of block context. As of #21467, the function signature of `render_callback` was revised in such a way that was intended to be backward-compatible, but which was not always the case in more advanced usage. With the changes proposed in this pull request, a block implementation must explicitly opt-in to receive the full block instance as the argument of `render_callback`. This should be much more durable than the previous implementation, as existing implementations should not be affected at all, since they would in-fact be passed the same value (an array of attributes), not a value intending to simulate the same behavior (a class implementing `ArrayAccess`).

From the block implementer's perspective, the developer can opt to receive the block instance by merely providing `WP_Block` as a [type declaration](https://www.php.net/manual/en/functions.arguments.php#functions.arguments.type-declaration) on the first parameter:

```php
register_block_type( 'my-plugin/example', [
    'render_callback' => function( WP_Block $block ) {
        return 'The block name is: ' . $block->name;
    },
] );
```

Existing use as an array is not impacted:

```php
register_block_type( 'my-plugin/example', [
    'render_callback' => function( $block_attributes ) {
        return 'Has attribute? ' . array_key_exists( 'test', $block_attributes ) ? 'Yes' : 'No';
    },
] );
```

(Notably, the second code example _does not work_ on the current `master` branch)

Internally, the implementation uses [function reflection](https://www.php.net/manual/en/class.reflectionfunction.php) to determine whether the render callback is expecting to receive the instance of the block, or the default associative array of block attributes.

**Testing Instructions:**

Repeat testing instructions from #21467. Optionally, it was made easier to test in later development of #21467, using the "Gutenberg Test Block Context" plugin included in the [default development environment](https://github.com/WordPress/gutenberg/blob/master/docs/contributors/getting-started.md), via the associated "Test Context Provider" block.