### PR TITLE
Add a method for publishing patches to the lerna scripts.

### DIFF
--- a/package.json
+++ b/package.json
@@ -219,7 +219,7 @@
 		"publish:check": "lerna updated",
 		"publish:dev": "npm run clean:package-types && npm run build:packages && lerna publish --dist-tag next",
 		"publish:legacy": "npm run clean:package-types && npm run build:packages && lerna publish --dist-tag legacy",
-		"publish:path": "npm run clean:package-types && npm run build:packages && lerna publish --dist-tag patch",
+		"publish:patch": "npm run clean:package-types && npm run build:packages && lerna publish --dist-tag patch",
 		"publish:prod": "npm run clean:package-types && npm run build:packages && lerna publish",
 		"test": "npm run lint && npm run test-unit",
 		"test-e2e": "wp-scripts test-e2e --config packages/e2e-tests/jest.config.js",

--- a/package.json
+++ b/package.json
@@ -218,7 +218,6 @@
 		"pot-to-php": "./bin/pot-to-php.js",
 		"publish:check": "lerna updated",
 		"publish:dev": "npm run clean:package-types && npm run build:packages && lerna publish --dist-tag next",
-		"publish:legacy": "npm run clean:package-types && npm run build:packages && lerna publish --dist-tag legacy",
 		"publish:patch": "npm run clean:package-types && npm run build:packages && lerna publish --dist-tag patch",
 		"publish:prod": "npm run clean:package-types && npm run build:packages && lerna publish",
 		"test": "npm run lint && npm run test-unit",

--- a/package.json
+++ b/package.json
@@ -219,6 +219,7 @@
 		"publish:check": "lerna updated",
 		"publish:dev": "npm run clean:package-types && npm run build:packages && lerna publish --dist-tag next",
 		"publish:legacy": "npm run clean:package-types && npm run build:packages && lerna publish --dist-tag legacy",
+		"publish:path": "npm run clean:package-types && npm run build:packages && lerna publish --dist-tag patch",
 		"publish:prod": "npm run clean:package-types && npm run build:packages && lerna publish",
 		"test": "npm run lint && npm run test-unit",
 		"test-e2e": "wp-scripts test-e2e --config packages/e2e-tests/jest.config.js",

--- a/packages/README.md
+++ b/packages/README.md
@@ -186,7 +186,7 @@ To release a patch for the older major or minor version of packages, run the fol
 npm run publish:patch
 ```
 
-This is usually necessary when adding bug fixes or security patches to the earlier versions of WordPress.
+This is usually necessary when adding bug fixes or security patches to the earlier versions of WordPress. This will publish only a patch version of the built packages. This is useful for backpublishing certain packages to WordPress.
 
 ## TypeScript
 

--- a/packages/README.md
+++ b/packages/README.md
@@ -183,7 +183,7 @@ Choose the correct version based on `CHANGELOG.md` files, confirm your choices a
 To release a patch for the older major or minor version of packages, run the following command:
 
 ```bash
-npm run publish:legacy
+npm run publish:patch
 ```
 
 This is usually necessary when adding bug fixes or security patches to the earlier versions of WordPress.


### PR DESCRIPTION
## Description

If you are trying to publish a patch, for back-compatibility, you need to pass the `--dist-tag patch` argument into the `lerna` argument. This is a little helper for that.

## How has this been tested?

Yes, just tested this for the 5.4.1 backports.

## Checklist:
- [x] My code is tested.
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
