### PR TITLE
Template Parts: Support REST API meta queries.

### DIFF
--- a/lib/template-parts.php
+++ b/lib/template-parts.php
@@ -166,10 +166,13 @@ apply_filters( 'rest_wp_template_part_collection_params', 'filter_rest_wp_templa
  */
 function filter_rest_wp_template_part_query( $args, $request ) {
 	if ( $request['theme'] ) {
-		$args += array(
-			'meta_key'   => 'theme',
-			'meta_value' => $request['theme'],
+		$meta_query   = isset( $args['meta_query'] ) ? $args['meta_query'] : array();
+		$meta_query[] = array(
+			'key'   => 'theme',
+			'value' => $request['theme'],
 		);
+
+		$args['meta_query'] = $meta_query;
 	}
 	return $args;
 }

--- a/lib/template-parts.php
+++ b/lib/template-parts.php
@@ -138,3 +138,39 @@ function gutenberg_render_template_part_list_table_column( $column_name, $post_i
 	echo esc_html( $post->post_name );
 }
 add_action( 'manage_wp_template_part_posts_custom_column', 'gutenberg_render_template_part_list_table_column', 10, 2 );
+
+
+/**
+ * Filter for adding a `theme` parameter to `wp_template_part` queries.
+ *
+ * @param array $query_params The query parameters.
+ * @return array Filtered $query_params.
+ */
+function filter_rest_wp_template_part_collection_params( $query_params ) {
+	$query_params += array(
+		'theme' => array(
+			'description' => __( 'The theme slug for the theme that created the template part.', 'gutenberg' ),
+			'type'        => 'string',
+		),
+	);
+	return $query_params;
+}
+apply_filters( 'rest_wp_template_part_collection_params', 'filter_rest_wp_template_part_collection_params', 99, 1 );
+
+/**
+ * Filter for supporting the `theme` parameter in `wp_template_part` queries.
+ *
+ * @param array           $args    The query arguments.
+ * @param WP_REST_Request $request The request object.
+ * @return array Filtered $args.
+ */
+function filter_rest_wp_template_part_query( $args, $request ) {
+	if ( $request['theme'] ) {
+		$args += array(
+			'meta_key'   => 'theme',
+			'meta_value' => $request['theme'],
+		);
+	}
+	return $args;
+}
+add_filter( 'rest_wp_template_part_query', 'filter_rest_wp_template_part_query', 99, 2 );

--- a/packages/block-library/src/template-part/edit/use-template-part-post.js
+++ b/packages/block-library/src/template-part/edit/use-template-part-post.js
@@ -28,7 +28,7 @@ export default function useTemplatePartPost( postId, slug, theme ) {
 					{
 						status: [ 'publish', 'auto-draft' ],
 						slug,
-						meta: { theme },
+						theme,
 					}
 				);
 				const foundPosts = posts?.filter(


### PR DESCRIPTION
## Description

Template Part blocks rely on meta queries, but the REST API does not support them by default. So, they break down when they look for `wp_template_part`s, and the other query arguments don't narrow it down enough to find the correct post on the first page of results.

## How to test this?

Verify that inserting template parts works as expected even when you already have a lot of customized template parts.

## Types of Changes

*Bug Fix:* Template Parts now load correctly when you have a lot of `wp_template_part` posts.

## Checklist:

- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->