### PR TITLE
Replace espree with babel.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10769,6 +10769,30 @@
 				"negotiator": "0.6.1"
 			}
 		},
+		"acorn": {
+			"version": "6.4.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
+			"integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
+			"dev": true
+		},
+		"acorn-globals": {
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.4.tgz",
+			"integrity": "sha512-clfQEh21R+D0leSbUdWf3OcfqyaCSAQ8Ryq00bofSekfr9W8u1jyYZo6ir0xu9Gtcf7BjcHJpnbZH7JOCpP60A==",
+			"dev": true,
+			"requires": {
+				"acorn": "^6.0.1",
+				"acorn-walk": "^6.0.1"
+			},
+			"dependencies": {
+				"acorn-walk": {
+					"version": "6.2.0",
+					"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz",
+					"integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==",
+					"dev": true
+				}
+			}
+		},
 		"acorn-walk": {
 			"version": "7.1.1",
 			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.1.1.tgz",
@@ -19201,6 +19225,11 @@
 			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
 			"integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
 			"dev": true
+		},
+		"esprima": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
 		},
 		"esquery": {
 			"version": "1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10098,8 +10098,8 @@
 			"version": "file:packages/docgen",
 			"dev": true,
 			"requires": {
+				"@babel/parser": "^7.9.2",
 				"doctrine": "^2.1.0",
-				"espree": "^4.0.0",
 				"lodash": "^4.17.15",
 				"mdast-util-inject": "1.1.0",
 				"optionator": "0.8.2",
@@ -10767,45 +10767,6 @@
 			"requires": {
 				"mime-types": "~2.1.18",
 				"negotiator": "0.6.1"
-			}
-		},
-		"acorn": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.1.tgz",
-			"integrity": "sha512-d+nbxBUGKg7Arpsvbnlq61mc12ek3EY8EQldM3GPAhWJ1UVxC6TDGbIvUMNU6obBX3i1+ptCIzV4vq0gFPEGVQ==",
-			"dev": true
-		},
-		"acorn-globals": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.4.tgz",
-			"integrity": "sha512-clfQEh21R+D0leSbUdWf3OcfqyaCSAQ8Ryq00bofSekfr9W8u1jyYZo6ir0xu9Gtcf7BjcHJpnbZH7JOCpP60A==",
-			"dev": true,
-			"requires": {
-				"acorn": "^6.0.1",
-				"acorn-walk": "^6.0.1"
-			},
-			"dependencies": {
-				"acorn": {
-					"version": "6.4.1",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
-					"integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
-					"dev": true
-				},
-				"acorn-walk": {
-					"version": "6.2.0",
-					"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz",
-					"integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==",
-					"dev": true
-				}
-			}
-		},
-		"acorn-jsx": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-4.1.1.tgz",
-			"integrity": "sha512-JY+iV6r+cO21KtntVvFkD+iqjtdpRUpGqKWgfkCdZq1R+kbreEl8EcdcJR4SmiIgsIQT33s6QzheQ9a275Q8xw==",
-			"dev": true,
-			"requires": {
-				"acorn": "^5.0.3"
 			}
 		},
 		"acorn-walk": {
@@ -19240,21 +19201,6 @@
 			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
 			"integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
 			"dev": true
-		},
-		"espree": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-4.0.0.tgz",
-			"integrity": "sha512-kapdTCt1bjmspxStVKX6huolXVV5ZfyZguY1lcfhVVZstce3bqxH9mcLzNn3/mlgW6wQ732+0fuG9v7h0ZQoKg==",
-			"dev": true,
-			"requires": {
-				"acorn": "^5.6.0",
-				"acorn-jsx": "^4.1.1"
-			}
-		},
-		"esprima": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
 		},
 		"esquery": {
 			"version": "1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10098,7 +10098,7 @@
 			"version": "file:packages/docgen",
 			"dev": true,
 			"requires": {
-				"@babel/parser": "^7.9.2",
+				"@babel/core": "^7.9.0",
 				"doctrine": "^2.1.0",
 				"lodash": "^4.17.15",
 				"mdast-util-inject": "1.1.0",

--- a/packages/docgen/README.md
+++ b/packages/docgen/README.md
@@ -38,6 +38,12 @@ This command will generate a file named `entry-point-api.md` containing all the 
 * **--use-token** `(String)`: This options allows you to customize the string between the tokens. For example, `--use-token my-api` will look up for the start token <code>&lt;!-- START TOKEN(my-api) --&gt;</code> and the end token <code>&lt;!-- END TOKEN(my-api) --&gt;</code>. Depends on `--to-token`.
 * **--debug**: Run in debug mode, which outputs some intermediate files useful for debugging.
 
+### Babel Configuration
+
+`@wordpress/docgen` follows the default [project-wide configuration of Babel](https://babeljs.io/docs/en/next/config-files#project-wide-configuration). Like Babel, it will automatically search for a `babel.config.json` file, or an equivalent one using the [supported extensions](https://babeljs.io/docs/en/next/config-files#supported-file-extensions), in the project root directory.
+
+Without it, `@wordpress/docgen` runs with the default option. In other words, it cannot parse JSX or other advanced syntaxes.
+
 ## Examples
 
 ### Default export

--- a/packages/docgen/package.json
+++ b/packages/docgen/package.json
@@ -23,7 +23,7 @@
 	},
 	"dependencies": {
 		"doctrine": "^2.1.0",
-		"espree": "^4.0.0",
+		"@babel/parser": "^7.9.2",
 		"lodash": "^4.17.15",
 		"mdast-util-inject": "1.1.0",
 		"optionator": "0.8.2",

--- a/packages/docgen/package.json
+++ b/packages/docgen/package.json
@@ -22,8 +22,8 @@
 		"docgen": "./bin/cli.js"
 	},
 	"dependencies": {
-		"doctrine": "^2.1.0",
 		"@babel/parser": "^7.9.2",
+		"doctrine": "^2.1.0",
 		"lodash": "^4.17.15",
 		"mdast-util-inject": "1.1.0",
 		"optionator": "0.8.2",

--- a/packages/docgen/package.json
+++ b/packages/docgen/package.json
@@ -22,7 +22,7 @@
 		"docgen": "./bin/cli.js"
 	},
 	"dependencies": {
-		"@babel/parser": "^7.9.2",
+		"@babel/core": "^7.9.0",
 		"doctrine": "^2.1.0",
 		"lodash": "^4.17.15",
 		"mdast-util-inject": "1.1.0",

--- a/packages/docgen/src/engine.js
+++ b/packages/docgen/src/engine.js
@@ -8,18 +8,12 @@ const { flatten } = require( 'lodash' );
  * Internal dependencies.
  */
 const getIntermediateRepresentation = require( './get-intermediate-representation' );
-const babelConfig = require( '../../../babel.config' );
 
 const getAST = ( source ) => {
-	const { presets, plugins } = babelConfig( {
-		cache: () => {}, // To bypass api.cache is not a function error.
-	} );
-
 	return babel.parse( source || '', {
-		presets,
-		plugins: [ ...plugins, 'jsx' ],
+		plugins: [ 'jsx' ],
 		sourceType: 'module',
-	} ).program; // unlike espree, the root of babel AST is File, not Program.
+	} ).program;
 };
 
 const getExportTokens = ( ast ) =>

--- a/packages/docgen/src/engine.js
+++ b/packages/docgen/src/engine.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies.
  */
-const babel = require( '@babel/parser' );
+const babel = require( '@babel/core' );
 const { flatten } = require( 'lodash' );
 
 /**
@@ -10,10 +10,7 @@ const { flatten } = require( 'lodash' );
 const getIntermediateRepresentation = require( './get-intermediate-representation' );
 
 const getAST = ( source ) => {
-	return babel.parse( source || '', {
-		plugins: [ 'jsx' ],
-		sourceType: 'module',
-	} ).program;
+	return babel.parse( source || '' ).program;
 };
 
 const getExportTokens = ( ast ) =>

--- a/packages/docgen/src/engine.js
+++ b/packages/docgen/src/engine.js
@@ -15,7 +15,7 @@ const getAST = ( source ) => {
 		cache: () => {}, // To bypass api.cache is not a function error.
 	} );
 
-	return babel.parse( source, {
+	return babel.parse( source || '', {
 		presets,
 		plugins: [ ...plugins, 'jsx' ],
 		sourceType: 'module',

--- a/packages/docgen/src/engine.js
+++ b/packages/docgen/src/engine.js
@@ -1,24 +1,26 @@
 /**
  * External dependencies.
  */
-const espree = require( 'espree' );
+const babel = require( '@babel/parser' );
 const { flatten } = require( 'lodash' );
 
 /**
  * Internal dependencies.
  */
 const getIntermediateRepresentation = require( './get-intermediate-representation' );
+const babelConfig = require( '../../../babel.config' );
 
-const getAST = ( source ) =>
-	espree.parse( source, {
-		attachComment: true,
-		loc: true,
-		ecmaVersion: 2018,
-		ecmaFeatures: {
-			jsx: true,
-		},
-		sourceType: 'module',
+const getAST = ( source ) => {
+	const { presets, plugins } = babelConfig( {
+		cache: () => {}, // To bypass api.cache is not a function error.
 	} );
+
+	return babel.parse( source, {
+		presets,
+		plugins: [ ...plugins, 'jsx' ],
+		sourceType: 'module',
+	} ).program; // unlike espree, the root of babel AST is File, not Program.
+};
 
 const getExportTokens = ( ast ) =>
 	ast.body.filter( ( node ) =>


### PR DESCRIPTION
## Description

Replaced `espree` with `babel`. Fixes https://github.com/WordPress/gutenberg/issues/19952

## How has this been tested?

Ran `npm run docs:build` and found no change.

## Screenshots <!-- if applicable -->

N/A

## Types of changes

Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [N/A] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [N/A] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [N/A] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [N/A] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
