### PR TITLE
Avoid using inline RichText element for navigation link

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36148,18 +36148,18 @@
 					}
 				},
 				"mime-db": {
-					"version": "1.43.0",
-					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
-					"integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ==",
+					"version": "1.44.0",
+					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
+					"integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
 					"dev": true
 				},
 				"mime-types": {
-					"version": "2.1.26",
-					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
-					"integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
+					"version": "2.1.27",
+					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
+					"integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
 					"dev": true,
 					"requires": {
-						"mime-db": "1.43.0"
+						"mime-db": "1.44.0"
 					}
 				},
 				"ms": {

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -212,7 +212,6 @@ function NavigationLinkEdit( {
 				<div className="wp-block-navigation-link__content">
 					<RichText
 						ref={ ref }
-						tagName="span"
 						className="wp-block-navigation-link__label"
 						value={ label }
 						onChange={ ( labelValue ) =>


### PR DESCRIPTION
## Description
This switches the Navigation Link block's label to the default `div` instead of a `span` in the editor.

This change is to avoid a console warning triggered by RichText when an inline element is used:
```
RichText cannot be used with an inline container. Please use a different tagName.
```

This label element is a flex item, so the layout shouldn't be affected. This may also improve some elements of editing the labels that are the reason that warning exists, but it's hard to say what.

## How has this been tested?
1. Add a navigation block with several navigation links
2. Observe the layout is still the same
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
