### PR TITLE
Docs: Add changelog entry for debugging support for `test-unit-js`

### DIFF
--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - The bundled `puppeteer` (`^2.0.0`) dependency has been replaced with `puppeteer-core` in version `3.0.0`. Puppeteer uses Chromium v81 instead of Chromium v79. See the [full list of changes](https://github.com/puppeteer/puppeteer/releases/tag/v3.0.0). It also allowed preventing Chromium installation together with `@wordpress/scripts`. It happens now on-demand when running `test-e2e` script, and it re-triggers only when a new version is required.
 
+### New Features
+
+- Add debugging support for `test-unit-js` script ([#21631](https://github.com/WordPress/gutenberg/pull/21631)). Tests can be debugged by any [inspector client](https://nodejs.org/en/docs/guides/debugging-getting-started/#inspector-clients) that supports the [Chrome DevTools Protocol](https://chromedevtools.github.io/devtools-protocol/).
+
 ### Bug fix
 
 - The bundled `npm-package-json-lint` dependency has been updated from requiring `^4.0.3` to requiring `^5.0.0` ([#21597](https://github.com/WordPress/gutenberg/pull/21597)). [Breaking changes](https://npmpackagejsonlint.org/docs/en/v4-to-v5) don't break anything in this package. It fixes the abrupt shutdown when `"description"` field in `package.json` is empty.

--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -462,11 +462,11 @@ A breakpoint will be set at the first line of the script (this is done to give y
 
 ##### Debugging in Visual Studio Code
 
-Debugging NPM scripts is supported out of the box for Visual Studio Code as of [version 1.23](https://code.visualstudio.com/blogs/2018/07/12/introducing-logpoints-and-auto-attach#_npm-scripts-and-debugging) and can be used to debug Jest unit tests.
+Debugging npm scripts is supported out of the box for Visual Studio Code as of [version 1.23](https://code.visualstudio.com/blogs/2018/07/12/introducing-logpoints-and-auto-attach#_npm-scripts-and-debugging) and can be used to debug Jest unit tests.
 
 First, set a breakpoint in your tests by clicking on a line in the editor's left margin by the line numbers.
 
-Then open NPM Scripts in the Explorer or run `Explorer: Focus on NPM Scripts View` in the command palette to see the NPM scripts. To start the tests, click the debug icon next to `test:unit:debug`.
+Then open npm scripts in the explorer or run `Explorer: Focus on NPM Scripts View` in the command palette to see the npm scripts. To start the tests, click the debug icon next to `test:unit:debug`.
 
 The tests will start running, and execution will pause on your selected line so you can inspect the current scope and call stack within the editor.
 


### PR DESCRIPTION
## Description
Follow-up for #21631.

It adds missing changelog entry.

It also changes NPM to npm as it is used on the official website https://docs.npmjs.com/misc/scripts. It aligns with other places in the docs and with the general approach to trademarks we follow.

/cc @ajlende 
