### PR TITLE
Create the proper shortcode on paste

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -93,6 +93,10 @@ function getAllowedFormats( {
 
 getAllowedFormats.EMPTY_ARRAY = [];
 
+// The given text is considered a shortcode if
+// starts by the [ character and ends by the ] character.
+const isShortcode = ( text ) => new RegExp( '^\\[.*\\]$' ).test( text );
+
 function RichTextWrapper(
 	{
 		children,
@@ -392,6 +396,18 @@ function RichTextWrapper(
 			}
 
 			let mode = onReplace && onSplit ? 'AUTO' : 'INLINE';
+
+			// Force the blocks mode when the user is pasting
+			// on a new line & the content resembles a shortcode.
+			// Otherwise it's going to be detected as inline
+			// and the shortcode won't be replaced.
+			if (
+				mode === 'AUTO' &&
+				isEmpty( value ) &&
+				isShortcode( plainText )
+			) {
+				mode = 'BLOCKS';
+			}
 
 			if (
 				__unstableEmbedURLOnPaste &&

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -39,6 +39,7 @@ import {
 } from '@wordpress/rich-text';
 import deprecated from '@wordpress/deprecated';
 import { isURL } from '@wordpress/url';
+import { regexp } from '@wordpress/shortcode';
 
 /**
  * Internal dependencies
@@ -93,9 +94,7 @@ function getAllowedFormats( {
 
 getAllowedFormats.EMPTY_ARRAY = [];
 
-// The given text is considered a shortcode if
-// starts by the [ character and ends by the ] character.
-const isShortcode = ( text ) => new RegExp( '^\\[.*\\]$' ).test( text );
+const isShortcode = ( text ) => regexp( '.*' ).test( text );
 
 function RichTextWrapper(
 	{

--- a/packages/blocks/src/api/raw-handling/paste-handler.js
+++ b/packages/blocks/src/api/raw-handling/paste-handler.js
@@ -196,18 +196,18 @@ export function pasteHandler( {
 		}
 	}
 
-	// An array of HTML strings and block objects.
-	// The blocks replace matched shortcodes.
+	if ( mode === 'INLINE' ) {
+		return filterInlineHTML( HTML );
+	}
+
+	// An array of HTML strings and block objects. The blocks replace matched
+	// shortcodes.
 	const pieces = shortcodeConverter( HTML );
 
 	// The call to shortcodeConverter will always return more than one element
 	// if shortcodes are matched. The reason is when shortcodes are matched
 	// empty HTML strings are included.
 	const hasShortcodes = pieces.length > 1;
-
-	if ( mode === 'INLINE' && ! hasShortcodes ) {
-		return filterInlineHTML( HTML );
-	}
 
 	if (
 		mode === 'AUTO' &&

--- a/packages/blocks/src/api/raw-handling/paste-handler.js
+++ b/packages/blocks/src/api/raw-handling/paste-handler.js
@@ -196,18 +196,18 @@ export function pasteHandler( {
 		}
 	}
 
-	if ( mode === 'INLINE' ) {
-		return filterInlineHTML( HTML );
-	}
-
-	// An array of HTML strings and block objects. The blocks replace matched
-	// shortcodes.
+	// An array of HTML strings and block objects.
+	// The blocks replace matched shortcodes.
 	const pieces = shortcodeConverter( HTML );
 
 	// The call to shortcodeConverter will always return more than one element
 	// if shortcodes are matched. The reason is when shortcodes are matched
 	// empty HTML strings are included.
 	const hasShortcodes = pieces.length > 1;
+
+	if ( mode === 'INLINE' && ! hasShortcodes ) {
+		return filterInlineHTML( HTML );
+	}
 
 	if (
 		mode === 'AUTO' &&


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/21103

## How to test

- Create a new post
- Paste the following into a paragraph block: `[gallery ids="13,12,14"]` (change these ids for ids of elements in your media library).
- Expected result is that a gallery block should be created.
