### PR TITLE
Group block: match front end in editor

### DIFF
--- a/packages/block-library/src/group/edit.js
+++ b/packages/block-library/src/group/edit.js
@@ -20,15 +20,17 @@ function GroupEdit( { attributes, className, clientId } ) {
 
 	return (
 		<BlockWrapper className={ className }>
-			<div className="wp-block-group__inner-container">
-				<InnerBlocks
-					renderAppender={
-						hasInnerBlocks
-							? undefined
-							: () => <InnerBlocks.ButtonBlockAppender />
-					}
-				/>
-			</div>
+			<InnerBlocks
+				renderAppender={
+					hasInnerBlocks
+						? undefined
+						: () => <InnerBlocks.ButtonBlockAppender />
+				}
+				__experimentalTagName="div"
+				__experimentalPassedProps={ {
+					className: 'wp-block-group__inner-container',
+				} }
+			/>
 		</BlockWrapper>
 	);
 }

--- a/packages/block-library/src/group/editor.scss
+++ b/packages/block-library/src/group/editor.scss
@@ -16,7 +16,7 @@
 
 	// Full Width Blocks
 	// specificity required to only target immediate child Blocks of a Group
-	> .wp-block-group__inner-container > .wp-block[data-align="full"] {
+	> .wp-block-group__inner-container > [data-align="full"] {
 		margin-left: auto;
 		margin-right: auto;
 		padding-left: $block-padding*2;
@@ -29,7 +29,7 @@
 	}
 
 	// Full Width Blocks with a background (ie: has padding)
-	&.has-background > .wp-block-group__inner-container > .wp-block[data-align="full"] {
+	&.has-background > .wp-block-group__inner-container > [data-align="full"] {
 		// note: using position `left` causes hoz scrollbars so
 		// we opt to use margin instead
 		// the 30px matches the hoz padding applied in `theme.scss`
@@ -46,11 +46,11 @@
 /**
  * Group: Full Width Alignment
  */
-.wp-block[data-type="core/group"][data-align="full"] {
+[data-align="full"] .wp-block[data-type="core/group"] {
 
 	// Full Width Blocks
 	// specificity required to only target immediate child Blocks of Group
-	> .wp-block-group__inner-container > .wp-block[data-align="full"] {
+	> .wp-block-group__inner-container > [data-align="full"] {
 		padding-right: 0;
 		padding-left: 0;
 		left: 0;
@@ -60,7 +60,7 @@
 
 	// Full Width Blocks with a background (ie: has padding)
 	// note: also duplicated above for all Group widths
-	&.has-background > .wp-block-group__inner-container > .wp-block[data-align="full"] {
+	&.has-background > .wp-block-group__inner-container > [data-align="full"] {
 		width: calc(100% + 60px);
 	}
 }

--- a/packages/block-library/src/group/editor.scss
+++ b/packages/block-library/src/group/editor.scss
@@ -14,15 +14,9 @@
 		right: 0;
 	}
 
-	// Only applied when background is added to cancel out padding
-	> div > .wp-block-group.has-background > .wp-block-group__inner-container > .block-editor-inner-blocks {
-		margin-top: -#{$block-padding*2 + $block-spacing};
-		margin-bottom: -#{$block-padding*2 + $block-spacing};
-	}
-
 	// Full Width Blocks
 	// specificity required to only target immediate child Blocks of a Group
-	> div > .wp-block-group > .wp-block-group__inner-container > .block-editor-inner-blocks > .block-editor-block-list__layout > .wp-block[data-align="full"] {
+	> .wp-block-group__inner-container > .wp-block[data-align="full"] {
 		margin-left: auto;
 		margin-right: auto;
 		padding-left: $block-padding*2;
@@ -35,7 +29,7 @@
 	}
 
 	// Full Width Blocks with a background (ie: has padding)
-	> div > .wp-block-group.has-background > .wp-block-group__inner-container > .block-editor-inner-blocks > .block-editor-block-list__layout > .wp-block[data-align="full"] {
+	&.has-background > .wp-block-group__inner-container > .wp-block[data-align="full"] {
 		// note: using position `left` causes hoz scrollbars so
 		// we opt to use margin instead
 		// the 30px matches the hoz padding applied in `theme.scss`
@@ -52,24 +46,11 @@
 /**
  * Group: Full Width Alignment
  */
-.wp-block[data-align="full"] .wp-block-group {
-
-	// First tier of InnerBlocks must act like the container of the standard canvas
-	> div > .wp-block-group > .wp-block-group__inner-container > .block-editor-inner-blocks {
-		margin-left: auto;
-		margin-right: auto;
-		padding-left: 0;
-		padding-right: 0;
-
-		> .block-editor-block-list__layout {
-			margin-left: 0;
-			margin-right: 0;
-		}
-	}
+.wp-block[data-type="core/group"][data-align="full"] {
 
 	// Full Width Blocks
 	// specificity required to only target immediate child Blocks of Group
-	> div > .wp-block-group > .wp-block-group__inner-container > .block-editor-inner-blocks > .block-editor-block-list__layout > .wp-block[data-align="full"] {
+	> .wp-block-group__inner-container > .wp-block[data-align="full"] {
 		padding-right: 0;
 		padding-left: 0;
 		left: 0;
@@ -79,7 +60,7 @@
 
 	// Full Width Blocks with a background (ie: has padding)
 	// note: also duplicated above for all Group widths
-	> div > .wp-block-group.has-background > .wp-block-group__inner-container > .block-editor-inner-blocks > .block-editor-block-list__layout > .wp-block[data-align="full"] {
+	&.has-background > .wp-block-group__inner-container > .wp-block[data-align="full"] {
 		width: calc(100% + 60px);
 	}
 }


### PR DESCRIPTION
## Description

Currently the block is not fully adjusted to match the front end. Additionally, alignments are broken. This PR tries to fix these issue, while also getting rid of the huge selectors.

<!-- Please describe what you have changed or added -->
Before:

<img width="679" alt="Screenshot 2020-04-24 at 14 55 35" src="https://user-images.githubusercontent.com/4710635/80214864-d4d2d200-863b-11ea-8836-3f474a445bf2.png">

After:

<img width="695" alt="Screenshot 2020-04-24 at 14 53 13" src="https://user-images.githubusercontent.com/4710635/80214856-d1d7e180-863b-11ea-96d3-e7d03f8d14cd.png">


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
