### PR TITLE
Block API: Block Context: Assign block global for render_callback

### DIFF
--- a/docs/designers-developers/developers/block-api/block-context.md
+++ b/docs/designers-developers/developers/block-api/block-context.md
@@ -63,13 +63,15 @@ registerBlockType( 'my-plugin/record-title', {
 
 ### PHP
 
-A block's context values are available from the `context` property of the `$block` argument passed to the `render_callback` function.
+Note that in PHP, block context is accessed using the `$block` global which is assigned at the time a block is rendered. This is unlike block attributes or block content, which are provided as arguments to the `render_callback` function. At some point in the future, block context may be integrated into the function arguments signature of `render_callback`, or an alternative block settings configuration may enable a render callback to receive the full block array as its argument.
 
 `record-title/index.php`
 
 ```php
 register_block_type( 'my-plugin/record-title', [
-	'render_callback' => function( $block ) {
+	'render_callback' => function() {
+		global $block;
+
 		return 'The current record ID is: ' . $block->context['my-plugin/recordId'];
 	},
 ] );

--- a/docs/designers-developers/developers/block-api/block-context.md
+++ b/docs/designers-developers/developers/block-api/block-context.md
@@ -63,16 +63,4 @@ registerBlockType( 'my-plugin/record-title', {
 
 ### PHP
 
-Note that in PHP, block context is accessed using the `$block` global which is assigned at the time a block is rendered. This is unlike block attributes or block content, which are provided as arguments to the `render_callback` function. At some point in the future, block context may be integrated into the function arguments signature of `render_callback`, or an alternative block settings configuration may enable a render callback to receive the full block array as its argument.
-
-`record-title/index.php`
-
-```php
-register_block_type( 'my-plugin/record-title', [
-	'render_callback' => function() {
-		global $block;
-
-		return 'The current record ID is: ' . $block->context['my-plugin/recordId'];
-	},
-] );
-```
+_The PHP implementation of block context is currently experimental and subject to breaking changes. It will be documented in the future once the API has stabilized._

--- a/docs/designers-developers/developers/tutorials/block-tutorial/creating-dynamic-blocks.md
+++ b/docs/designers-developers/developers/tutorials/block-tutorial/creating-dynamic-blocks.md
@@ -99,7 +99,7 @@ Because it is a dynamic block it doesn't need to override the default `save` imp
  * Plugin Name: Gutenberg examples dynamic
  */
 
-function gutenberg_examples_dynamic_render_callback( $block, $content ) {
+function gutenberg_examples_dynamic_render_callback( $block_attributes, $content ) {
 	$recent_posts = wp_get_recent_posts( array(
 		'numberposts' => 1,
 		'post_status' => 'publish',
@@ -142,14 +142,6 @@ There are a few things to notice:
 * The `edit` function still shows a representation of the block in the editor's context (this could be very different from the rendered version, it's up to the block's author)
 * The built-in `save` function just returns `null` because the rendering is performed server-side.
 * The server-side rendering is a function taking the block and the block inner content as arguments, and returning the markup (quite similar to shortcodes)
-
-Note that for convenience and for backward-compatibility, the first argument of a `render_callback` function can also be referenced as an associative array of the block's attributes:
-
-```php
-function gutenberg_examples_dynamic_render_callback( $block_attributes ) {
-	return 'The record ID is: ' . esc_html( $block_attributes['recordId'] );
-}
-```
 
 ## Live rendering in the block editor
 

--- a/docs/designers-developers/developers/tutorials/metabox/meta-block-4-use-data.md
+++ b/docs/designers-developers/developers/tutorials/metabox/meta-block-4-use-data.md
@@ -25,7 +25,7 @@ You can also use the post meta data in other blocks. For this example the data i
 In PHP, use the [register_block_type](https://developer.wordpress.org/reference/functions/register_block_type/) function to set a callback when the block is rendered to include the meta value.
 
 ```php
-function myguten_render_paragraph( $block, $content ) {
+function myguten_render_paragraph( $block_attributes, $content ) {
 	$value = get_post_meta( get_the_ID(), 'myguten_meta_block_field', true );
 	// check value is set before outputting
 	if ( $value ) {

--- a/lib/class-wp-block.php
+++ b/lib/class-wp-block.php
@@ -156,7 +156,7 @@ class WP_Block {
 	 * @return string Rendered block output.
 	 */
 	public function render() {
-		global $post, $block;
+		global $post, $_experimental_block;
 
 		$is_dynamic    = $this->name && null !== $this->block_type && $this->block_type->is_dynamic();
 		$block_content = '';
@@ -169,12 +169,12 @@ class WP_Block {
 		}
 
 		if ( $is_dynamic ) {
-			$global_post   = $post;
-			$global_block  = $block;
-			$block         = $this;
-			$block_content = (string) call_user_func( $this->block_type->render_callback, $this->attributes, $block_content );
-			$block         = $global_block;
-			$post          = $global_post;
+			$global_post         = $post;
+			$global_block        = $_experimental_block;
+			$_experimental_block = $this;
+			$block_content       = (string) call_user_func( $this->block_type->render_callback, $this->attributes, $block_content );
+			$_experimental_block = $global_block;
+			$post                = $global_post;
 		}
 
 		return $block_content;

--- a/lib/class-wp-block.php
+++ b/lib/class-wp-block.php
@@ -8,7 +8,7 @@
 /**
  * Class representing a parsed instance of a block.
  */
-class WP_Block implements ArrayAccess {
+class WP_Block {
 
 	/**
 	 * Name of block.
@@ -156,7 +156,7 @@ class WP_Block implements ArrayAccess {
 	 * @return string Rendered block output.
 	 */
 	public function render() {
-		global $post;
+		global $post, $block;
 
 		$is_dynamic    = $this->name && null !== $this->block_type && $this->block_type->is_dynamic();
 		$block_content = '';
@@ -170,71 +170,14 @@ class WP_Block implements ArrayAccess {
 
 		if ( $is_dynamic ) {
 			$global_post   = $post;
-			$block_content = (string) call_user_func( $this->block_type->render_callback, $this, $block_content );
+			$global_block  = $block;
+			$block         = $this;
+			$block_content = (string) call_user_func( $this->block_type->render_callback, $this->attributes, $block_content );
+			$block         = $global_block;
 			$post          = $global_post;
 		}
 
 		return $block_content;
-	}
-
-	/**
-	 * Returns true if an attribute exists by the specified attribute name, or
-	 * false otherwise.
-	 *
-	 * @link https://www.php.net/manual/en/arrayaccess.offsetexists.php
-	 *
-	 * @param string $attribute_name Name of attribute to check.
-	 *
-	 * @return bool Whether attribute exists.
-	 */
-	public function offsetExists( $attribute_name ) {
-		return isset( $this->attributes[ $attribute_name ] );
-	}
-
-	/**
-	 * Returns the value by the specified attribute name.
-	 *
-	 * @link https://www.php.net/manual/en/arrayaccess.offsetget.php
-	 *
-	 * @param string $attribute_name Name of attribute value to retrieve.
-	 *
-	 * @return mixed|null Attribute value if exists, or null.
-	 */
-	public function offsetGet( $attribute_name ) {
-		// This may cause an "Undefined index" notice if the attribute name does
-		// not exist. This is expected, since the purpose of this implementation
-		// is to align exactly to the expectations of operating on an array.
-		return $this->attributes[ $attribute_name ];
-	}
-
-	/**
-	 * Assign an attribute value by the specified attribute name.
-	 *
-	 * @link https://www.php.net/manual/en/arrayaccess.offsetset.php
-	 *
-	 * @param string $attribute_name Name of attribute value to set.
-	 * @param mixed  $value          Attribute value.
-	 */
-	public function offsetSet( $attribute_name, $value ) {
-		if ( is_null( $attribute_name ) ) {
-			// This is not technically a valid use-case for attributes. Since
-			// this implementation is expected to align to expectations of
-			// operating on an array, it is still supported.
-			$this->attributes[] = $value;
-		} else {
-			$this->attributes[ $attribute_name ] = $value;
-		}
-	}
-
-	/**
-	 * Unset an attribute.
-	 *
-	 * @link https://www.php.net/manual/en/arrayaccess.offsetunset.php
-	 *
-	 * @param string $attribute_name Name of attribute value to unset.
-	 */
-	public function offsetUnset( $attribute_name ) {
-		unset( $this->attributes[ $attribute_name ] );
 	}
 
 }

--- a/packages/block-library/src/post-title/index.php
+++ b/packages/block-library/src/post-title/index.php
@@ -8,11 +8,10 @@
 /**
  * Renders the `core/post-title` block on the server.
  *
- * @param WP_Block $block The block instance.
- *
  * @return string Returns the filtered post title for the current post wrapped inside "h1" tags.
  */
-function render_block_core_post_title( $block ) {
+function render_block_core_post_title() {
+	global $block;
 	if ( ! isset( $block->context['postId'] ) ) {
 		return '';
 	}

--- a/packages/block-library/src/post-title/index.php
+++ b/packages/block-library/src/post-title/index.php
@@ -11,12 +11,12 @@
  * @return string Returns the filtered post title for the current post wrapped inside "h1" tags.
  */
 function render_block_core_post_title() {
-	global $block;
-	if ( ! isset( $block->context['postId'] ) ) {
+	global $_experimental_block;
+	if ( ! isset( $_experimental_block->context['postId'] ) ) {
 		return '';
 	}
 
-	return '<h1>' . get_the_title( $block->context['postId'] ) . '</h1>';
+	return '<h1>' . get_the_title( $_experimental_block->context['postId'] ) . '</h1>';
 }
 
 /**

--- a/packages/e2e-tests/plugins/block-context.php
+++ b/packages/e2e-tests/plugins/block-context.php
@@ -49,9 +49,9 @@ function gutenberg_test_register_context_blocks() {
 		array(
 			'context'         => array( 'gutenberg/recordId' ),
 			'render_callback' => function() {
-				global $block;
+				global $_experimental_block;
 
-				$record_id = $block->context['gutenberg/recordId'];
+				$record_id = $_experimental_block->context['gutenberg/recordId'];
 
 				if ( ! is_int( $record_id ) ) {
 					throw new Exception( 'Expected numeric recordId' );

--- a/packages/e2e-tests/plugins/block-context.php
+++ b/packages/e2e-tests/plugins/block-context.php
@@ -48,7 +48,9 @@ function gutenberg_test_register_context_blocks() {
 		'gutenberg/test-context-consumer',
 		array(
 			'context'         => array( 'gutenberg/recordId' ),
-			'render_callback' => function( $block ) {
+			'render_callback' => function() {
+				global $block;
+
 				$record_id = $block->context['gutenberg/recordId'];
 
 				if ( ! is_int( $record_id ) ) {

--- a/phpunit/class-block-context-test.php
+++ b/phpunit/class-block-context-test.php
@@ -104,7 +104,9 @@ class Block_Context_Test extends WP_UnitTestCase {
 					'gutenberg/contextWithAssigned',
 					'gutenberg/contextWithoutDefault',
 				),
-				'render_callback' => function( $block ) use ( &$provided_context ) {
+				'render_callback' => function() use ( &$provided_context ) {
+					global $block;
+
 					$provided_context[] = $block->context;
 
 					return '';

--- a/phpunit/class-block-context-test.php
+++ b/phpunit/class-block-context-test.php
@@ -105,9 +105,9 @@ class Block_Context_Test extends WP_UnitTestCase {
 					'gutenberg/contextWithoutDefault',
 				),
 				'render_callback' => function() use ( &$provided_context ) {
-					global $block;
+					global $_experimental_block;
 
-					$provided_context[] = $block->context;
+					$provided_context[] = $_experimental_block->context;
 
 					return '';
 				},

--- a/phpunit/class-wp-block-test.php
+++ b/phpunit/class-wp-block-test.php
@@ -260,12 +260,12 @@ class WP_Block_Test extends WP_UnitTestCase {
 					),
 				),
 				'render_callback' => function() {
-					global $block;
+					global $_experimental_block;
 
 					return sprintf(
 						'Hello %s%s',
-						$block->attributes['toWhom'],
-						$block->attributes['punctuation']
+						$_experimental_block->attributes['toWhom'],
+						$_experimental_block->attributes['punctuation']
 					);
 				},
 			)

--- a/phpunit/class-wp-block-test.php
+++ b/phpunit/class-wp-block-test.php
@@ -246,7 +246,7 @@ class WP_Block_Test extends WP_UnitTestCase {
 		$this->assertSame( 'abc', $block->render() );
 	}
 
-	function test_render_passes_instance_to_render_callback() {
+	function test_render_assigns_instance_global_for_render_callback() {
 		$this->registry->register(
 			'core/greeting',
 			array(
@@ -259,7 +259,9 @@ class WP_Block_Test extends WP_UnitTestCase {
 						'default' => '!',
 					),
 				),
-				'render_callback' => function( $block ) {
+				'render_callback' => function() {
+					global $block;
+
 					return sprintf(
 						'Hello %s%s',
 						$block->attributes['toWhom'],
@@ -312,7 +314,7 @@ class WP_Block_Test extends WP_UnitTestCase {
 		$this->registry->register(
 			'core/outer',
 			array(
-				'render_callback' => function( $block, $content ) {
+				'render_callback' => function( $block_attributes, $content ) {
 					return $content;
 				},
 			)
@@ -332,39 +334,6 @@ class WP_Block_Test extends WP_UnitTestCase {
 		$block         = new WP_Block( $parsed_block, $context, $this->registry );
 
 		$this->assertSame( 'abc', $block->render() );
-	}
-
-	function test_array_access_attributes() {
-		$this->registry->register(
-			'core/example',
-			array(
-				'attributes' => array(
-					'value' => array(
-						'type' => 'string',
-					),
-				),
-			)
-		);
-		$parsed_block = array(
-			'blockName' => 'core/example',
-			'attrs'     => array( 'value' => 'ok' ),
-		);
-		$context      = array();
-		$block        = new WP_Block( $parsed_block, $context, $this->registry );
-
-		$this->assertTrue( isset( $block['value'] ) );
-		$this->assertFalse( isset( $block['nonsense'] ) );
-		$this->assertEquals( 'ok', $block['value'] );
-
-		$block['value'] = 'changed';
-		$this->assertEquals( 'changed', $block['value'] );
-		$this->assertEquals( 'changed', $block->attributes['value'] );
-
-		unset( $block['value'] );
-		$this->assertFalse( isset( $block['value'] ) );
-
-		$block[] = 'invalid, but still supported';
-		$this->assertEquals( 'invalid, but still supported', $block[0] );
 	}
 
 }


### PR DESCRIPTION
Previously: #21467
Temporary resolution for: #21797

This pull request seeks to revert changes to the PHP `render_callback` signature introduced in #21467. In order to provide block context, it now assigns a `$block` global with the current block instance immediately before a block type's `render_callback` is invoked. This restores an initial implementation of #21467, where there are some justifications for use of a global in the original comment (~strikethrough~ text) and https://github.com/WordPress/gutenberg/pull/21467#issuecomment-611120382.

**Testing Instructions:**

Repeat testing instructions from #21467. Optionally, it was made easier to test in later development of #21467, using the "Gutenberg Test Block Context" plugin included in the [default development environment](https://github.com/WordPress/gutenberg/blob/master/docs/contributors/getting-started.md), via the associated "Test Context Provider" block.

There are also a number of automated tests to verify:

```
npm run test-e2e packages/e2e-tests/specs/editor/plugins/block-context.test.js
```

```
npm run test-unit-php "/var/www/src/wp-content/plugins/gutenberg/phpunit/class-wp-block-test.php"
```

```
npm run test-unit-php "/var/www/src/wp-content/plugins/gutenberg/phpunit/class-block-context-test.php"
```

(If you have trouble getting PHP unit tests running, try referring to guidance at https://github.com/WordPress/gutenberg/pull/21467#issuecomment-613581931)