### PR TITLE
E2E Test Utils: Automate database upgrade

### DIFF
--- a/packages/e2e-test-utils/README.md
+++ b/packages/e2e-test-utils/README.md
@@ -304,7 +304,7 @@ Checks if current URL is a WordPress path.
 _Parameters_
 
 -   _WPPath_ `string`: String to be serialized as pathname.
--   _query_ `?string`: String to be serialized as query portion of URL.
+-   _query_ `[string]`: Optional string to be serialized as query portion of URL. If omitted, any querystring is allowed.
 
 _Returns_
 

--- a/packages/e2e-test-utils/src/is-current-url.js
+++ b/packages/e2e-test-utils/src/is-current-url.js
@@ -6,8 +6,10 @@ import { createURL } from './create-url';
 /**
  * Checks if current URL is a WordPress path.
  *
- * @param {string} WPPath String to be serialized as pathname.
- * @param {?string} query String to be serialized as query portion of URL.
+ * @param {string} WPPath  String to be serialized as pathname.
+ * @param {string} [query] Optional string to be serialized as query portion of
+ *                         URL. If omitted, any querystring is allowed.
+ *
  * @return {boolean} Boolean represents whether current URL is or not a WordPress path.
  */
 export function isCurrentURL( WPPath, query = '' ) {

--- a/packages/e2e-test-utils/src/visit-admin-page.js
+++ b/packages/e2e-test-utils/src/visit-admin-page.js
@@ -12,6 +12,24 @@ import { loginUser } from './login-user';
 import { getPageError } from './get-page-error';
 
 /**
+ * Runs database upgrade, assuming that the browser has been redirected to the
+ * database upgrade page `wp-admin/upgrade.php`.
+ */
+async function runDatabaseUpgrade() {
+	// Click "Update WordPress Database" at Step 1
+	await Promise.all( [
+		page.waitForNavigation(),
+		page.click( 'a.button-primary' ),
+	] );
+
+	// Click "Continue" at Step 2
+	await Promise.all( [
+		page.waitForNavigation(),
+		page.click( 'a.button-large' ),
+	] );
+}
+
+/**
  * Visits admin page; if user is not logged in then it logging in it first, then visits admin page.
  *
  * @param {string} adminPath String to be serialized as pathname.
@@ -19,6 +37,10 @@ import { getPageError } from './get-page-error';
  */
 export async function visitAdminPage( adminPath, query ) {
 	await page.goto( createURL( join( 'wp-admin', adminPath ), query ) );
+
+	if ( isCurrentURL( 'wp-admin/upgrade.php' ) ) {
+		await runDatabaseUpgrade();
+	}
 
 	if ( isCurrentURL( 'wp-login.php' ) ) {
 		await loginUser();


### PR DESCRIPTION
This pull request seeks to improve end-to-end test utilities to gracefully handle database upgrades, in a pattern similar to the existing login handling. This can be especially problematic when using a test site for a long period of time, as upgrades to the test site may require a database upgrade. Currently, end-to-end tests do not handle this, and will fail with very difficult-to-debug errors:

```
  ● Block context › Block context propagates to inner blocks

    No node found for selector: tr[data-slug="gutenberg-test-plugin-disables-the-css-animations"] .activate a

      at assert (../../node_modules/puppeteer/lib/helper.js:269:15)
      at DOMWorld.click (../../node_modules/puppeteer/lib/DOMWorld.js:325:9)
        -- ASYNC --
      at Frame.<anonymous> (../../node_modules/puppeteer/lib/helper.js:105:23)
      at Page.page [as click] (../../node_modules/puppeteer/lib/Page.js:956:33)
      at _callee$ (../e2e-test-utils/build/@wordpress/e2e-test-utils/src/activate-plugin.js:23:8)
      at tryCatch (../../node_modules/@babel/runtime/node_modules/regenerator-runtime/runtime.js:45:40)
      at Generator.invoke [as _invoke] (../../node_modules/@babel/runtime/node_modules/regenerator-runtime/runtime.js:274:22)
      at Generator.prototype.<computed> [as next] (../../node_modules/@babel/runtime/node_modules/regenerator-runtime/runtime.js:97:21)
      at asyncGeneratorStep (../../node_modules/@babel/runtime/helpers/asyncToGenerator.js:3:24)
      at _next (../../node_modules/@babel/runtime/helpers/asyncToGenerator.js:25:9)
```

**Testing Instructions:**

It's not simple to test, since database upgrades only occur when the site is deemed in an "old" state. You can emulate this, however, via the following command:

```
npm run wp-env run tests-cli option set db_version 47596
```

This sets the database version to one not equal to the current version ([`47597` at the time of writing](https://github.com/WordPress/wordpress-develop/blob/055d1c6749a248f93575964494fad2c283b5edbf/src/wp-includes/version.php#L23)), thus [triggering the upgrade flow](https://github.com/WordPress/wordpress-develop/blob/055d1c6749a248f93575964494fad2c283b5edbf/src/wp-admin/admin.php#L48).

Then, proceed to test any end-to-end test suite:

```
npm run test-e2e packages/e2e-tests/specs/editor/plugins/block-context.test.js
```

You should observe that the tests pass normally. In `master`, the above test run would fail, since the test run would get stuck at the database upgrade screen.