### PR TITLE
Edit Site: Remove templateIds prop from NavigateToLink

### DIFF
--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -93,7 +93,7 @@ function get_template_hierachy( $template_type ) {
 function gutenberg_override_query_template( $template, $type, array $templates = array() ) {
 	global $_wp_current_template_id, $_wp_current_template_content;
 
-	$current_template = gutenberg_find_template_post_and_parts( basename( $template, '.php' ), $templates );
+	$current_template = gutenberg_find_template_post_and_parts( $type, $templates );
 
 	if ( $current_template ) {
 		$_wp_current_template_id      = $current_template['template_post']->ID;

--- a/lib/templates.php
+++ b/lib/templates.php
@@ -194,10 +194,10 @@ function filter_rest_wp_template_query( $args, $request ) {
 
 			$current_template = gutenberg_find_template_post_and_parts( $template_type );
 			if ( isset( $current_template ) ) {
-				$template_ids[ $current_template['template_post']->post_name ] = $current_template['template_post']->ID;
+				$template_ids[] = $current_template['template_post']->ID;
 			}
 		}
-		$args['post__in'] = array_values( $template_ids );
+		$args['post__in'] = $template_ids;
 	}
 
 	return $args;

--- a/lib/templates.php
+++ b/lib/templates.php
@@ -183,7 +183,7 @@ apply_filters( 'rest_wp_template_collection_params', 'filter_rest_wp_template_co
 function filter_rest_wp_template_query( $args, $request ) {
 	if ( $request['resolved'] ) {
 		$template_ids   = array( 0 ); // Return nothing by default (the 0 is needed for `post__in`).
-		$template_types = $request['slug'] ? array( $request['slug'] ) : get_template_types();
+		$template_types = $request['slug'] ? $request['slug'] : get_template_types();
 
 		foreach ( $template_types as $template_type ) {
 			// Skip 'embed' for now because it is not a regular template type.

--- a/packages/edit-site/src/components/block-editor/index.js
+++ b/packages/edit-site/src/components/block-editor/index.js
@@ -74,16 +74,11 @@ export default function BlockEditor() {
 					( fillProps ) => (
 						<NavigateToLink
 							{ ...fillProps }
-							templateIds={ settings.templateIds }
 							activeId={ settings.templateId }
 							onActiveIdChange={ setActiveTemplateId }
 						/>
 					),
-					[
-						settings.templateIds,
-						settings.templateId,
-						setActiveTemplateId,
-					]
+					[ settings.templateId, setActiveTemplateId ]
 				) }
 			</__experimentalLinkControl.ViewerFill>
 			<Sidebar.InspectorFill>

--- a/packages/edit-site/src/components/navigate-to-link/index.js
+++ b/packages/edit-site/src/components/navigate-to-link/index.js
@@ -28,6 +28,7 @@ export default function NavigateToLink( { url, activeId, onActiveIdChange } ) {
 							'postType',
 							'wp_template',
 							{
+								resolved: true,
 								slug: data.post_name,
 							}
 						)[ 0 ].id;

--- a/packages/edit-site/src/components/navigate-to-link/index.js
+++ b/packages/edit-site/src/components/navigate-to-link/index.js
@@ -12,12 +12,7 @@ import { __ } from '@wordpress/i18n';
  */
 const { fetch } = window;
 
-export default function NavigateToLink( {
-	url,
-	templateIds,
-	activeId,
-	onActiveIdChange,
-} ) {
+export default function NavigateToLink( { url, activeId, onActiveIdChange } ) {
 	const [ templateId, setTemplateId ] = useState();
 	useEffect( () => {
 		const effect = async () => {
@@ -28,14 +23,14 @@ export default function NavigateToLink( {
 				if ( success ) {
 					let newTemplateId = data.ID;
 					if ( newTemplateId === null ) {
-						const { getEntityRecord } = select( 'core' );
-						newTemplateId = templateIds
-							.map( ( id ) =>
-								getEntityRecord( 'postType', 'wp_template', id )
-							)
-							.find(
-								( template ) => template.slug === data.post_name
-							).id;
+						const { getEntityRecords } = select( 'core' );
+						newTemplateId = getEntityRecords(
+							'postType',
+							'wp_template',
+							{
+								slug: data.post_name,
+							}
+						)[ 0 ].id;
 					}
 					setTemplateId( newTemplateId );
 				} else {
@@ -46,7 +41,7 @@ export default function NavigateToLink( {
 			}
 		};
 		effect();
-	}, [ url, templateIds ] );
+	}, [ url ] );
 	const onClick = useMemo( () => {
 		if ( ! templateId || templateId === activeId ) {
 			return null;


### PR DESCRIPTION
## Description

Instead of iterating over `templateIds`, fetching each corresponding template from the REST API, and then locally filtering for the matching template slug, use _one_ network fetch with the slug passed as a query param (You can verify that that works by running `wp.data.select('core').getEntityRecords('postType', 'wp_template', { slug: 'front-page' } )` in the browser console -- twice, to make it resolve properly.)

This is preparatory work for another PR that will decouple `edit-site` even further from the `settings` variable that is at the moment directly passed from PHP, and will use the REST API instead.

**Update 2020-05-13:** This also [fixes](https://github.com/WordPress/gutenberg/pull/21877/files#diff-9ef35a788437d52364a1e2b87b2e9730R186) a bug in #21981, where previously, a matching template (specified via `{ slug: 'front-page'; resolved: true }`) would return an empty array. To verify, try the following (similar to #21981, but including the cases I failed to test for):

We'll compare the results the `wp_template` collections REST API endpoint gives to `$settings['templateIds']`. To that end, apply the following patch and re-build the app (`npm run build`):

```diff
diff --git a/packages/edit-site/src/index.js b/packages/edit-site/src/index.js
index e6dec20771..ea72bee4c9 100644
--- a/packages/edit-site/src/index.js
+++ b/packages/edit-site/src/index.js
@@ -26,6 +26,7 @@ export function initialize( id, settings ) {
        if ( process.env.GUTENBERG_PHASE === 2 ) {
                __experimentalRegisterExperimentalCoreBlocks( settings );
        }
+       console.log( 'settings', settings );
        render( <Editor settings={ settings } />, document.getElementById( id ) );
 }

```

Next, in wp-admin, navigate to the Appearance > Templates section, and create a few dummy templates whose names are **not** actually part of the template hierarchy (e.g. `some-template` etc).

Now go to Full-Site Editing and open your browser console. You should see the output of the `settings` variable there. Compare the `templateIds` property to the output of the following commands you run in the console (twice each!). Icons :heavy_check_mark: and :x: indicate whether the output is expected to match `settings.templateIds`, or not.

- :heavy_check_mark: **(new)** `wp.data.select('core').getEntityRecords('postType', 'wp_template', { slug: 'front-page' } )` should return the `wp_template` CPT whose slug is `front-page`.
- :heavy_check_mark: **(new)** `wp.data.select('core').getEntityRecords('postType', 'wp_template', { slug: 'front-page', resolved: true } )` should _also_ return the `wp_template` CPT whose slug is `front-page`, as it _is_ part of the template hierarchy.
- :x: `wp.data.select('core').getEntityRecords('postType', 'wp_template' )` should return the list of all `wp_template` CPTs, including those that are not part of the template hierarchy.
- :heavy_check_mark: `wp.data.select('core').getEntityRecords('postType', 'wp_template', { resolved: true } )` should return the list of templates that match the template hierarchy.
- :x: `wp.data.select('core').getEntityRecords('postType', 'wp_template', { slug: 'some-template' } )` should return the `wp_template` CPT whose slug is `some-template`.
- :heavy_check_mark: `wp.data.select('core').getEntityRecords('postType', 'wp_template', { slug: 'some-template', resolved: true } )` should return an empty array, as `some-template` is not part of the template hierarchy.

This highlights that we need unit tests for these functions, which we'll hopefully be able to run more easily once #20090 is in :slightly_smiling_face: 

## How has this been tested?

In case you're not familiar with this feature: This is present when editing a template part that contains a link to a URL that's part of the current website. Specifically, it's a button in the link editing popover that takes you to the template that corresponds to that URL. (If that's still confusiong, the instructions and screenshots below should make this clearer.)

- Activate the site editor experiment (and demo templates).
- Navigate to the site editor.
- Add a new `single` template for the current theme. You can add a bit of content there, or just leave it empty.
- Go back to the `front-page` theme.
- In the header template part, add a link to `/`, and one to `/?p=1`.
- In the template switcher, open the header template part for direct editing.
- Highlight each of the links, and click the button in the top right corner.
- Verify that for the `/` link, you're taken back to the `front-page` link, whereas for the `/?p=1` link, you're taken to the `single` template.

## Screenshots <!-- if applicable -->

![navigate-to-link](https://user-images.githubusercontent.com/96308/80238099-1d02ec00-865e-11ea-80db-04037189c111.gif)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
