### PR TITLE
Fullscreen Mode: Fix scrolling of the wp-admin sidebar when toggled.

### DIFF
--- a/packages/interface/src/components/fullscreen-mode/style.scss
+++ b/packages/interface/src/components/fullscreen-mode/style.scss
@@ -27,10 +27,14 @@ body.is-fullscreen-mode {
 			bottom: 0;
 		}
 
-		// Hides the admin menu
-		// This prevents keyboard navigation from accessing inner links
-		#adminmenuwrap {
-			//display: none;
+		// Allow the menu to scroll on smaller viewports.
+		#adminmenu {
+			position: fixed;
+			top: 0;
+			bottom: 0;
+			overflow-y: auto;
+			margin: 0;
+			padding-bottom: 16px; // Clear some room for browser UI, like Chrome's floating URL tooltip.
 		}
 
 		.interface-interface-skeleton__body,


### PR DESCRIPTION
Fixes #21875 

You should now be able to scroll the wp-admin menu when the browser window is short:

![wp-admin menu scroll fix](https://user-images.githubusercontent.com/191598/80249967-d3f06f00-8640-11ea-895f-45b46219983f.gif)
