### PR TITLE
Enable the verse block for mobile

### DIFF
--- a/packages/block-library/src/index.native.js
+++ b/packages/block-library/src/index.native.js
@@ -158,7 +158,7 @@ export const registerCoreBlocks = () => {
 		shortcode,
 		buttons,
 		latestPosts,
-		devOnly( verse ),
+		verse,
 		cover,
 		pullquote,
 	].forEach( registerBlock );

--- a/packages/block-library/src/verse/edit.js
+++ b/packages/block-library/src/verse/edit.js
@@ -34,6 +34,7 @@ export default function VerseEdit( {
 			</BlockControls>
 			<RichText
 				tagName={ Block.pre }
+				identifier='content'
 				preserveWhiteSpace
 				value={ content }
 				onChange={ ( nextContent ) => {

--- a/packages/block-library/src/verse/edit.js
+++ b/packages/block-library/src/verse/edit.js
@@ -34,7 +34,7 @@ export default function VerseEdit( {
 			</BlockControls>
 			<RichText
 				tagName={ Block.pre }
-				identifier='content'
+				identifier="content"
 				preserveWhiteSpace
 				value={ content }
 				onChange={ ( nextContent ) => {

--- a/packages/block-library/src/verse/test/edit.native.js
+++ b/packages/block-library/src/verse/test/edit.native.js
@@ -1,0 +1,34 @@
+/**
+ * External dependencies
+ */
+import renderer from 'react-test-renderer';
+
+/**
+ * Internal dependencies
+ */
+import Verse from '../edit';
+
+/**
+ * WordPress dependencies
+ */
+import { RichText } from '@wordpress/block-editor';
+
+describe( 'Verse Block', () => {
+	it( 'renders without crashing', () => {
+		const component = renderer.create(
+			<Verse attributes={ { content: '' } } />
+		);
+		const rendered = component.toJSON();
+		expect( rendered ).toBeTruthy();
+	} );
+
+	it( 'renders given text without crashing', () => {
+		const component = renderer.create(
+			<Verse attributes={ { content: 'sample text' } } />
+		);
+		const testInstance = component.root;
+		const richText = testInstance.findByType( RichText );
+		expect( richText ).toBeTruthy();
+		expect( richText.props.value ).toBe( 'sample text' );
+	} );
+} );


### PR DESCRIPTION
Addresses: https://github.com/wordpress-mobile/gutenberg-mobile/issues/1886
Related: https://github.com/wordpress-mobile/gutenberg-mobile/pull/2185

## Description
Enable the verse block for production builds.

## How has this been tested?

1. Download the test build for iOS: https://github.com/wordpress-mobile/WordPress-iOS/pull/14004
2. Perform the test cases for the Verse block from https://github.com/wordpress-mobile/test-cases/pull/28
   - TC001: Tapping return key creates a new line within the block
   - TC002: Setting text alignment works as expected 
   - TC003: Whitespace is preserved when applying formatting options (bold, italics, etc)
   - TC004: The verse block can be merged with the paragraph block
3. Create and publish a verse block on mobile and ensure it's viewable on the web and on the user's site itself
4. Create and publish a verse block on the web and ensure it appears in the app
5. Repeat steps 1 to 4 for the test build for Android: https://github.com/wordpress-mobile/WordPress-Android/pull/11763


## Demo <!-- if applicable -->

| | iOS | Android |
| -- | -- | -- |
| Preview | <img width="250" src="https://user-images.githubusercontent.com/1898325/80324556-5b83dc80-87ff-11ea-8556-a90daf949209.gif"> | <img width="250" src="https://user-images.githubusercontent.com/1898325/80325594-ce8f5200-8803-11ea-9a69-228c158daf3d.gif"> |

## Types of changes

New feature: verse block for mobile

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
