### PR TITLE
Remove obsolete editor alignment classes

### DIFF
--- a/packages/block-editor/src/components/block-list/block-popover.js
+++ b/packages/block-editor/src/components/block-list/block-popover.js
@@ -111,11 +111,6 @@ function BlockPopover( {
 		return null;
 	}
 
-	// A block may specify a different target element for the toolbar.
-	if ( node.classList.contains( 'is-block-collapsed' ) ) {
-		node = node.querySelector( '.is-block-content' ) || node;
-	}
-
 	let anchorRef = node;
 
 	if ( hasMultiSelection ) {

--- a/packages/block-editor/src/components/block-list/block-wrapper.js
+++ b/packages/block-editor/src/components/block-list/block-wrapper.js
@@ -230,8 +230,7 @@ const BlockComponent = forwardRef(
 		);
 
 		// For aligned blocks, provide a wrapper element so the block can be
-		// positioned relative to the block column. This is enabled with the
-		// .is-block-content className.
+		// positioned relative to the block column.
 		if ( isAligned ) {
 			const alignmentWrapperProps = {
 				'data-align': wrapperProps[ 'data-align' ],

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -94,7 +94,6 @@ function BlockListBlock( {
 		};
 	}
 
-	const isAligned = wrapperProps && wrapperProps[ 'data-align' ];
 	const generatedClassName =
 		lightBlockWrapper && hasBlockSupport( blockType, 'className', true )
 			? getBlockDefaultClassName( name )
@@ -120,7 +119,6 @@ function BlockListBlock( {
 				isFocusMode && ( isSelected || isAncestorOfSelectedBlock ),
 			'is-focus-mode': isFocusMode,
 			'has-child-selected': isAncestorOfSelectedBlock,
-			'is-block-collapsed': isAligned,
 		},
 		className
 	);

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -161,12 +161,6 @@
 			}
 		}
 	}
-
-	// Hide the focus indicator for collapsed blocks.
-	// These serve as only as column containers for floated blocks.
-	.block-editor-block-list__block.is-block-collapsed::after {
-		content: none;
-	}
 }
 
 


### PR DESCRIPTION
## Description

Follow-up to #21822. Removes the `is-block-content` and `is-block-collapsed` classes for positioning block popovers for aligned blocks. This is no longer necessary because the wrapper is now outside of `Block.*`, whose reference is used for the popover.

## How has this been tested?

Test left/right alignment on some blocks and ensure the toolbar is positioned at correctly at the block.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
