### PR TITLE
Plugins: Add scoping to PluginArea

### DIFF
--- a/packages/plugins/README.md
+++ b/packages/plugins/README.md
@@ -32,6 +32,10 @@ _Returns_
 
 Returns all registered plugins.
 
+_Parameters_
+
+-   _scope_ `string`: Plugin scope.
+
 _Returns_
 
 -   `Array<WPPlugin>`: Plugin settings.
@@ -147,6 +151,7 @@ _Parameters_
 
 -   _name_ `string`: A string identifying the plugin.Must be unique across all registered plugins.
 -   _settings_ `WPPlugin`: The settings for this plugin.
+-   _scope_ `string`: The scope for this plugin.
 
 _Returns_
 

--- a/packages/plugins/src/api/index.js
+++ b/packages/plugins/src/api/index.js
@@ -40,6 +40,7 @@ const plugins = {};
  * @param {string}   name     A string identifying the plugin.Must be
  *                            unique across all registered plugins.
  * @param {WPPlugin} settings The settings for this plugin.
+ * @param {string}   scope    The scope for this plugin.
  *
  * @example
  * <caption>ES5</caption>
@@ -111,19 +112,28 @@ const plugins = {};
  *
  * @return {WPPlugin} The final plugin settings object.
  */
-export function registerPlugin( name, settings ) {
+export function registerPlugin( name, settings, scope ) {
 	if ( typeof settings !== 'object' ) {
 		console.error( 'No settings object provided!' );
 		return null;
 	}
+	const charactersErrorMsg =
+		'Plugin names and scopes must include only lowercase alphanumeric characters or dashes, and start with a letter. Example: "my-plugin".';
+	const stringsErrorMsg = 'Plugin names and scopes must be strings.';
 	if ( typeof name !== 'string' ) {
-		console.error( 'Plugin names must be strings.' );
+		console.error( stringsErrorMsg );
 		return null;
 	}
 	if ( ! /^[a-z][a-z0-9-]*$/.test( name ) ) {
-		console.error(
-			'Plugin names must include only lowercase alphanumeric characters or dashes, and start with a letter. Example: "my-plugin".'
-		);
+		console.error( charactersErrorMsg );
+		return null;
+	}
+	if ( scope && typeof scope !== 'string' ) {
+		console.error( stringsErrorMsg );
+		return null;
+	}
+	if ( ! /^[a-z][a-z0-9-]*$/.test( scope ) ) {
+		console.error( charactersErrorMsg );
 		return null;
 	}
 	if ( plugins[ name ] ) {
@@ -142,6 +152,7 @@ export function registerPlugin( name, settings ) {
 	plugins[ name ] = {
 		name,
 		icon: pluginsIcon,
+		scope,
 		...settings,
 	};
 
@@ -203,8 +214,12 @@ export function getPlugin( name ) {
 /**
  * Returns all registered plugins.
  *
+ * @param {string} scope Plugin scope.
+ *
  * @return {WPPlugin[]} Plugin settings.
  */
-export function getPlugins() {
-	return Object.values( plugins );
+export function getPlugins( scope ) {
+	return Object.values( plugins ).filter( ( plugin ) => {
+		return scope ? plugin.scope === scope : true;
+	} );
 }

--- a/packages/plugins/src/api/test/index.js
+++ b/packages/plugins/src/api/test/index.js
@@ -121,3 +121,35 @@ describe( 'registerPlugin', () => {
 		);
 	} );
 } );
+
+describe( 'getPlugins', () => {
+	beforeEach( () => {
+		const Component = () => 'plugin content';
+		const icon = 'smiley';
+		registerPlugin( 'unscoped', {
+			render: Component,
+			icon,
+		} );
+		registerPlugin( 'scoped', {
+			render: Component,
+			icon,
+			scope: 'my-scope',
+		} );
+	} );
+
+	afterEach( () => {
+		getPlugins().forEach( ( plugin ) => {
+			unregisterPlugin( plugin.name );
+		} );
+	} );
+
+	it( 'returns all plugins', () => {
+		expect( getPlugins() ).toHaveLength( 2 );
+	} );
+
+	it( 'returns all plugins of a given scope', () => {
+		const scopedPlugins = getPlugins( 'my-scope' );
+		expect( scopedPlugins ).toHaveLength( 1 );
+		expect( scopedPlugins[ 0 ].name ).toBe( 'scoped' );
+	} );
+} );

--- a/packages/plugins/src/api/test/index.js
+++ b/packages/plugins/src/api/test/index.js
@@ -27,6 +27,29 @@ describe( 'registerPlugin', () => {
 		} );
 	} );
 
+	it( 'successfully registers a plugin with a scope', () => {
+		const name = 'plugin';
+		const icon = 'smiley';
+		const Component = () => 'plugin content';
+		const scope = 'scope';
+
+		registerPlugin(
+			name,
+			{
+				render: Component,
+				icon,
+			},
+			scope
+		);
+
+		expect( getPlugin( name ) ).toEqual( {
+			name,
+			render: Component,
+			icon,
+			scope,
+		} );
+	} );
+
 	it( 'fails to register a plugin without a settings object', () => {
 		registerPlugin();
 		expect( console ).toHaveErroredWith( 'No settings object provided!' );
@@ -37,7 +60,7 @@ describe( 'registerPlugin', () => {
 			render: () => {},
 		} );
 		expect( console ).toHaveErroredWith(
-			'Plugin names must include only lowercase alphanumeric characters or dashes, and start with a letter. Example: "my-plugin".'
+			'Plugin names and scopes must include only lowercase alphanumeric characters or dashes, and start with a letter. Example: "my-plugin".'
 		);
 	} );
 
@@ -48,7 +71,9 @@ describe( 'registerPlugin', () => {
 				render: () => {},
 			}
 		);
-		expect( console ).toHaveErroredWith( 'Plugin names must be strings.' );
+		expect( console ).toHaveErroredWith(
+			'Plugin names and scopes must be strings.'
+		);
 	} );
 
 	it( 'fails to register a plugin without a render function', () => {
@@ -67,6 +92,32 @@ describe( 'registerPlugin', () => {
 		} );
 		expect( console ).toHaveErroredWith(
 			'Plugin "plugin" is already registered.'
+		);
+	} );
+
+	it( 'fails to register a plugin with a non-string scope', () => {
+		registerPlugin(
+			'plugin',
+			{
+				render: () => {},
+			},
+			{}
+		);
+		expect( console ).toHaveErroredWith(
+			'Plugin names and scopes must be strings.'
+		);
+	} );
+
+	it( 'fails to register a plugin with special character in the scope', () => {
+		registerPlugin(
+			'plugin',
+			{
+				render: () => {},
+			},
+			'plugin/scope/with/special/characters'
+		);
+		expect( console ).toHaveErroredWith(
+			'Plugin names and scopes must include only lowercase alphanumeric characters or dashes, and start with a letter. Example: "my-plugin".'
 		);
 	} );
 } );

--- a/packages/plugins/src/components/plugin-area/index.js
+++ b/packages/plugins/src/components/plugin-area/index.js
@@ -60,8 +60,9 @@ class PluginArea extends Component {
 	}
 
 	getCurrentPluginsState() {
+		const { scope } = this.props;
 		return {
-			plugins: map( getPlugins(), ( { icon, name, render } ) => {
+			plugins: map( getPlugins( scope ), ( { icon, name, render } ) => {
 				return {
 					Plugin: render,
 					context: {


### PR DESCRIPTION
## Description

This PR introduces scoping such that `<PluginArea />` can designate its area only for plugins registered in a particular scope, ie `<PluginArea scope="woocommerce-admin" />`.

Currently extensions can use slotFill to add components to various places in the editor. The HTML rendered by those added components is inserted into the DOM by the `<PluginArea />` component and the slotFill logic handles insertion in the appropriate place. This is a nice clean way for extensions to add React components.

When a 3rd party would like to reuse `registerPlugins` and `<PluginArea />` to establish a similar slotFill pattern, the `<PluginArea />` will render any registered plugin's component, even if it has nothing to do with the current screen. I imagine this issue may present itself as Gutenberg expands to Full Site Editing and would like to include only registered plugins with interest in the page being rendered. By scoping whats included in the plugin area, we can limit unnecessary components rendered in the DOM, including their javascript logic.

## Quesitons and Unfinished Items

Before flushing out this PR completely, I'd love to know if this solution is worthwhile? Maybe there is a better solution or maybe the verdict is that it is unnecessary? If not, here are some items left to do here:

- [ ] Unit test PluginArea.
- [ ] Update documentation and examples.
- [ ] Update changelog.

## How has this been tested?
* Updated unit tests
* Sample application (not included)

## Types of changes

Adds an argument to `wp.plugins.registerPlugin` called `scope` that can be optionally used to filter the returned values of `getPlugins`. `<PluginArea />` accepts a `scope` prop to make use of this ability to filter its rendered output.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
