### PR TITLE
[Fix] Image center alignment behavior

### DIFF
--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -74,4 +74,5 @@ figure.wp-block-image:not(.wp-block) {
 .wp-block[data-align="center"] > .wp-block-image {
 	margin-left: auto;
 	margin-right: auto;
+	text-align: center;
 }


### PR DESCRIPTION
## Description
This PR tries to close #21885 which reports an error in the center-alignment behaviour in the image block, most likely introduced in [#21822](https://github.com/WordPress/gutenberg/pull/21822).

## How has this been tested?
This PR has been tested by going through the following steps:

1. Started a new post using the Gutenberg editor.
2. Added the "Image" block.
3. Changed the alignment of the image to the center.
4. Made sure the image shows up at the center in the editor.

## Screenshots <!-- if applicable -->
![gif-21885](https://user-images.githubusercontent.com/20284937/80355066-68550e80-8899-11ea-9fdf-96917588a172.gif)

## Types of changes
This PR just adds a `text-align: center` property to the `figure` element when the block's `data-align` is set to `center`.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
