### PR TITLE
Import from individual react-dates component

### DIFF
--- a/packages/components/src/date-time/date.js
+++ b/packages/components/src/date-time/date.js
@@ -2,7 +2,9 @@
  * External dependencies
  */
 import moment from 'moment';
-import { DayPickerSingleDateController } from 'react-dates';
+// react-dates doesn't tree-shake correctly, so we import from the individual
+// component here, to avoid including too much of the library
+import DayPickerSingleDateController from 'react-dates/lib/components/DayPickerSingleDateController';
 
 /**
  * WordPress dependencies


### PR DESCRIPTION
## Description
There is only one `react-dates` component in use in Gutenberg, which is currently being imported with a named import:

```js
import { DayPickerSingleDateController } from 'react-dates';
```

This PR changes that to importing the internal library component directly:

```js
import DayPickerSingleDateController from 'react-dates/lib/components/DayPickerSingleDateController';
```

This is more fragile with regards to library updates, since it uses knowledge of package internals, but it avoids the tree-shaking issues in `react-dates` that end up causing too much of the library to be imported when importing from the index.

This should **save around 96KB** on the components chunk, or 19KB over the wire, although the GitHub action will have the final say.

I believe the trade-off is worth it, since it basically only involves some extra vigilance when updating `react-date` versions.

Partially works towards resolving #21820.

## How has this been tested?
Ran unit tests, performed build, and performed some ad-hoc testing of date picker functionality.

## Types of changes
This is essentially a bug fix, in that it works around what I'd consider a bug in `react-dates`: that it doesn't tree-shake correctly.

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
