### PR TITLE
Reinitialize the iframe after the parent block is moved around

### DIFF
--- a/packages/components/src/sandbox/index.js
+++ b/packages/components/src/sandbox/index.js
@@ -26,12 +26,24 @@ class Sandbox extends Component {
 
 	componentDidMount() {
 		this.trySandbox();
+		this.trySandboxWithoutRerender = () => {
+			this.trySandbox( false );
+		};
+		// This used to be registered using <iframe onLoad={} />, but it made the iframe blank
+		// after reordering the containing block. See these two issues for more details:
+		// https://github.com/WordPress/gutenberg/issues/6146
+		// https://github.com/facebook/react/issues/18752
+		this.iframe.current.addEventListener( "load", this.trySandboxWithoutRerender, false );
 	}
 
 	componentDidUpdate( prevProps ) {
 		const forceRerender = prevProps.html !== this.props.html;
 
 		this.trySandbox( forceRerender );
+	}
+
+	componentWillUnmount() {
+		this.iframe.current.removeEventListener( "load", this.trySandboxWithoutRerender );
 	}
 
 	isFrameAccessible() {
@@ -233,7 +245,6 @@ class Sandbox extends Component {
 				title={ title }
 				className="components-sandbox"
 				sandbox="allow-scripts allow-same-origin allow-presentation"
-				onLoad={ () => this.trySandbox( false ) }
 				onFocus={ onFocus }
 				width={ Math.ceil( this.state.width ) }
 				height={ Math.ceil( this.state.height ) }

--- a/packages/components/src/sandbox/index.js
+++ b/packages/components/src/sandbox/index.js
@@ -33,7 +33,11 @@ class Sandbox extends Component {
 		// after reordering the containing block. See these two issues for more details:
 		// https://github.com/WordPress/gutenberg/issues/6146
 		// https://github.com/facebook/react/issues/18752
-		this.iframe.current.addEventListener( "load", this.trySandboxWithoutRerender, false );
+		this.iframe.current.addEventListener(
+			'load',
+			this.trySandboxWithoutRerender,
+			false
+		);
 	}
 
 	componentDidUpdate( prevProps ) {
@@ -43,7 +47,10 @@ class Sandbox extends Component {
 	}
 
 	componentWillUnmount() {
-		this.iframe.current.removeEventListener( "load", this.trySandboxWithoutRerender );
+		this.iframe.current.removeEventListener(
+			'load',
+			this.trySandboxWithoutRerender
+		);
 	}
 
 	isFrameAccessible() {


### PR DESCRIPTION
## Description

As reported in #6146, YouTube block becomes blank when the block is moved down (reordered). The root cause of this issue is the fact that browsers tend to reload the iframe if it's moved around in the DOM Tree, and the fact that React does not correctly dispatch the onLoad event in that case (see https://github.com/facebook/react/issues/18752).

This PR changes the way we register the iframe sandbox initialization callback from `onLoad=` to `iframe.addEventListener`. This skips the React event dispatching machinery and keeps the code running.

**Before:**
![before](https://user-images.githubusercontent.com/205419/80371013-7bfc7700-8891-11ea-8284-17b45897db27.gif)

**After:**
![after](https://user-images.githubusercontent.com/205419/80371021-7e5ed100-8891-11ea-9f5d-a94641d61731.gif)

Fixes #6146

## How has this been tested?
Tested locally

## Types of changes
Non-breaking changes

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
