### PR TITLE
i18n: Relax sprintf arguments type

### DIFF
--- a/packages/i18n/CHANGELOG.md
+++ b/packages/i18n/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Master
 
+### Bug Fix
+
+- Relax type of `sprintf` arguments type ([#21919](https://github.com/WordPress/gutenberg/pull/21919))
+
 ## 3.11.0 (2020-04-15)
 
 ### New Features

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -79,7 +79,7 @@ _Related_
 _Parameters_
 
 -   _format_ `string`: The format of the string to generate.
--   _args_ `...string`: Arguments to apply to the format.
+-   _args_ `...*`: Arguments to apply to the format.
 
 _Returns_
 

--- a/packages/i18n/src/sprintf.js
+++ b/packages/i18n/src/sprintf.js
@@ -18,7 +18,7 @@ const logErrorOnce = memoize( console.error ); // eslint-disable-line no-console
  * original format string is returned.
  *
  * @param {string}    format The format of the string to generate.
- * @param {...string} args   Arguments to apply to the format.
+ * @param {...*} args Arguments to apply to the format.
  *
  * @see http://www.diveintojavascript.com/projects/javascript-sprintf
  *

--- a/packages/i18n/src/test/sprintf.js
+++ b/packages/i18n/src/test/sprintf.js
@@ -23,5 +23,11 @@ describe( 'i18n', () => {
 
 			expect( result ).toBe( 'bonjour Riad' );
 		} );
+
+		it( 'replaces named placeholders', () => {
+			const result = sprintf( 'bonjour %(name)s', { name: 'Riad' } );
+
+			expect( result ).toBe( 'bonjour Riad' );
+		} );
 	} );
 } );


### PR DESCRIPTION
## Description

Sprintf accepts a number of different inputs. The named object of replacements seems particularly important:

```js
sprintf( "hello %(target)s", { target: "world" } );
```

This is currently unsupported by the type `( format: string, ...args: string[] ) => string`, which requires a 0 or more _strings_ to be passed after the format.

Additionally, replacements may be a value for interpolation or a nullary function that returns a value for interpolation.

Remove the `string` restriction on replacement args. This aligns with what's [currently on DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/d1f959f20ce9cc180b9c7ae558b78befb9bca70e/types/sprintf-js/index.d.ts#L84).

## Other considerations

With TypeScript function overloads, we can write the following:

```ts
import { sprintf as sprintfjs } from "sprintf-js";

type ReplacementValue = string | number; // We could accept more types, this is questionable.
type Replacement = ReplacementValue | (() => ReplacementValue);

function sprintf(format: string, ...replacements: Replacement[]): string;
function sprintf(
  format: string,
  replacementMap: Record<string, Replacement>
): string;
function sprintf(
  format: string,
  ...replacements: Replacement[] | [Record<string, Replacement>]
): string {
  return sprintfjs(format, ...replacements);
}
// Demo
console.log("=== These work fine ===");
console.log(sprintf("%s %s", "hello", "world"));
console.log(sprintf("%2$s %1$s", () => "world", "hello"));
console.log(sprintf("hello %(target)s", { target: "world" }));
console.log(sprintf("It's over %1$d!", () => 9000));
console.log(sprintf("It's over %(power)f!", { power: () => 9000 }));

console.log("=== Type errors ===");
console.log(sprintf("Hello %s", "world", { bad: "map" }));
console.log(sprintf("Hello %s", null));
console.log(sprintf("Hello %s", false));
console.log(sprintf("Hello %s", undefined));
console.log(sprintf("hello %(target)s", { target: "world" }, "extra-string"));
console.log(sprintf("It's over %1$d!", () => null));
console.log(sprintf("It's over %(power)s!", { power: () => undefined }));

// This is questionable, but not a type error.
console.log(sprintf("Hello %s")); // We can't actually prevent this empty `...args`
```

However, this seems to be poorly supported in TypeScript declarations via JSDoc: https://github.com/microsoft/TypeScript/issues/25590

Here's my JSDoc translation, but it errors saying the function type must match the function signature:

```js
/**
 * @typedef { string | number } ReplacementValue
 * @typedef { ReplacementValue | ( () => ReplacementValue) } Replacement
 * @typedef { ( format: string, ...replacements: Replacement[] ) => string } SprintFPositional
 * @typedef { ( format: string, replacementMap: Record<string,Replacement>, ...rest: never[] ) => string } SprintFNamed
 */

/**
 * Returns a formatted string. If an error occurs in applying the format, the
 * original format string is returned.
 *
 * @type { SprintFPositional & SprintFNamed }
 * @param {  string} format
 * @param {...any} args
 * @return {string}
 */
function sprintf() { /* snip */ }
```

Noticed in https://github.com/Automattic/wp-calypso/pull/41207.


## Types of changes

Bug fix: Relax rest args type of `sprintf` to `any[]`.

