### PR TITLE
Block API: Block Context: Remove block filter

### DIFF
--- a/lib/compat.php
+++ b/lib/compat.php
@@ -175,39 +175,3 @@ function gutenberg_get_post_from_context() {
 	}
 	return get_post();
 }
-
-/**
- * Shim that hooks into `pre_render_block` so as to override `render_block` with
- * a function that assigns block context.
- *
- * This can be removed when plugin support requires WordPress 5.5.0+.
- *
- * @see (TBD Trac Link)
- *
- * @param string|null $pre_render   The pre-rendered content. Defaults to null.
- * @param array       $parsed_block The parsed block being rendered.
- *
- * @return string String of rendered HTML.
- */
-function gutenberg_render_block_with_assigned_block_context( $pre_render, $parsed_block ) {
-	global $post;
-
-	// If a non-null value is provided, a filter has run at an earlier priority
-	// and has already handled custom rendering and should take precedence.
-	if ( null !== $pre_render ) {
-		return $pre_render;
-	}
-
-	$source_block = $parsed_block;
-
-	/** This filter is documented in src/wp-includes/blocks.php */
-	$parsed_block = apply_filters( 'render_block_data', $parsed_block, $source_block );
-	$context      = array( 'postId' => $post->ID );
-	$block        = new WP_Block( $parsed_block, $context );
-
-	/** This filter is documented in src/wp-includes/blocks.php */
-	return apply_filters( 'render_block', $block->render(), $parsed_block );
-}
-// TODO: Normally, commented code would not be left lingering. However, due to
-// time constraints, this was the most direct approach for a last-minute revert.
-// add_filter( 'pre_render_block', 'gutenberg_render_block_with_assigned_block_context', 9, 2 );

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -208,4 +208,6 @@ function gutenberg_render_block_with_assigned_block_context( $pre_render, $parse
 	/** This filter is documented in src/wp-includes/blocks.php */
 	return apply_filters( 'render_block', $block->render(), $parsed_block );
 }
-add_filter( 'pre_render_block', 'gutenberg_render_block_with_assigned_block_context', 9, 2 );
+// TODO: Normally, commented code would not be left lingering. However, due to
+// time constraints, this was the most direct approach for a last-minute revert.
+// add_filter( 'pre_render_block', 'gutenberg_render_block_with_assigned_block_context', 9, 2 );

--- a/packages/block-library/src/post-title/index.php
+++ b/packages/block-library/src/post-title/index.php
@@ -11,12 +11,12 @@
  * @return string Returns the filtered post title for the current post wrapped inside "h1" tags.
  */
 function render_block_core_post_title() {
-	global $_experimental_block;
-	if ( ! isset( $_experimental_block->context['postId'] ) ) {
+	$post = gutenberg_get_post_from_context();
+	if ( ! $post ) {
 		return '';
 	}
 
-	return '<h1>' . get_the_title( $_experimental_block->context['postId'] ) . '</h1>';
+	return '<h1>' . get_the_title( $post ) . '</h1>';
 }
 
 /**

--- a/packages/e2e-tests/plugins/block-context.php
+++ b/packages/e2e-tests/plugins/block-context.php
@@ -47,18 +47,7 @@ function gutenberg_test_register_context_blocks() {
 	register_block_type(
 		'gutenberg/test-context-consumer',
 		array(
-			'context'         => array( 'gutenberg/recordId' ),
-			'render_callback' => function() {
-				global $_experimental_block;
-
-				$record_id = $_experimental_block->context['gutenberg/recordId'];
-
-				if ( ! is_int( $record_id ) ) {
-					throw new Exception( 'Expected numeric recordId' );
-				}
-
-				return 'The record ID is: ' . filter_var( $record_id, FILTER_VALIDATE_INT );
-			},
+			'context' => array( 'gutenberg/recordId' ),
 		)
 	);
 }

--- a/packages/e2e-tests/specs/editor/plugins/block-context.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/block-context.test.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { last } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import {
@@ -6,7 +11,29 @@ import {
 	createNewPost,
 	deactivatePlugin,
 	insertBlock,
+	saveDraft,
 } from '@wordpress/e2e-test-utils';
+
+async function openPreviewPage( editorPage ) {
+	let openTabs = await browser.pages();
+	const expectedTabsCount = openTabs.length + 1;
+	await editorPage.click( '.block-editor-post-preview__button-toggle' );
+	await editorPage.waitFor( '.edit-post-header-preview__button-external' );
+	await editorPage.click( '.edit-post-header-preview__button-external' );
+
+	// Wait for the new tab to open.
+	while ( openTabs.length < expectedTabsCount ) {
+		await editorPage.waitFor( 1 );
+		openTabs = await browser.pages();
+	}
+
+	const previewPage = last( openTabs );
+	// Wait for the preview to load. We can't do interstitial detection here,
+	// because it might load too quickly for us to pick up, so we wait for
+	// the preview to load by waiting for the content to appear.
+	await previewPage.waitForSelector( '.entry-content' );
+	return previewPage;
+}
 
 describe( 'Block context', () => {
 	beforeAll( async () => {
@@ -41,5 +68,46 @@ describe( 'Block context', () => {
 			() => document.activeElement.textContent
 		);
 		expect( innerBlockText ).toBe( 'The record ID is: 123' );
+	} );
+
+	// Disable reason: Block context PHP implementation is temporarily reverted.
+	// This will be unskipped once the implementation is restored. Skipping was
+	// the most direct option for revert given time constraints.
+
+	/* eslint-disable-next-line jest/no-disabled-tests */
+	test.skip( 'Block context is reflected in the preview', async () => {
+		await insertBlock( 'Test Context Provider' );
+		const editorPage = page;
+		const previewPage = await openPreviewPage( editorPage );
+
+		// Check default context values are populated.
+		let content = await previewPage.$eval(
+			'.entry-content',
+			( contentWrapper ) => contentWrapper.textContent.trim()
+		);
+		expect( content ).toBe( 'The record ID is: 0' );
+
+		// Return to editor to change context value to non-default.
+		await editorPage.bringToFront();
+		await editorPage.focus(
+			'[data-type="gutenberg/test-context-provider"] input'
+		);
+		await editorPage.keyboard.press( 'ArrowRight' );
+		await editorPage.keyboard.type( '123' );
+		await editorPage.waitForSelector( '.editor-post-save-draft' ); // Not entirely clear why it's asynchronous, but likely React scheduling prioritizing keyboard event and deferring the UI update.
+		await saveDraft();
+
+		// Check non-default context values are populated.
+		await previewPage.bringToFront();
+		await previewPage.reload();
+		content = await previewPage.$eval(
+			'.entry-content',
+			( contentWrapper ) => contentWrapper.textContent.trim()
+		);
+		expect( content ).toBe( 'The record ID is: 123' );
+
+		// Clean up
+		await editorPage.bringToFront();
+		await previewPage.close();
 	} );
 } );

--- a/packages/e2e-tests/specs/editor/plugins/block-context.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/block-context.test.js
@@ -11,7 +11,6 @@ import {
 	createNewPost,
 	deactivatePlugin,
 	insertBlock,
-	saveDraft,
 } from '@wordpress/e2e-test-utils';
 
 async function openPreviewPage( editorPage ) {
@@ -76,33 +75,10 @@ describe( 'Block context', () => {
 		const previewPage = await openPreviewPage( editorPage );
 
 		// Check default context values are populated.
-		let content = await previewPage.$eval(
+		const content = await previewPage.$eval(
 			'.entry-content',
 			( contentWrapper ) => contentWrapper.textContent.trim()
 		);
 		expect( content ).toBe( 'The record ID is: 0' );
-
-		// Return to editor to change context value to non-default.
-		await editorPage.bringToFront();
-		await editorPage.focus(
-			'[data-type="gutenberg/test-context-provider"] input'
-		);
-		await editorPage.keyboard.press( 'ArrowRight' );
-		await editorPage.keyboard.type( '123' );
-		await editorPage.waitForSelector( '.editor-post-save-draft' ); // Not entirely clear why it's asynchronous, but likely React scheduling prioritizing keyboard event and deferring the UI update.
-		await saveDraft();
-
-		// Check non-default context values are populated.
-		await previewPage.bringToFront();
-		await previewPage.reload();
-		content = await previewPage.$eval(
-			'.entry-content',
-			( contentWrapper ) => contentWrapper.textContent.trim()
-		);
-		expect( content ).toBe( 'The record ID is: 123' );
-
-		// Clean up
-		await editorPage.bringToFront();
-		await previewPage.close();
 	} );
 } );

--- a/packages/e2e-tests/specs/editor/plugins/block-context.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/block-context.test.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { last } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import {
@@ -12,27 +7,6 @@ import {
 	deactivatePlugin,
 	insertBlock,
 } from '@wordpress/e2e-test-utils';
-
-async function openPreviewPage( editorPage ) {
-	let openTabs = await browser.pages();
-	const expectedTabsCount = openTabs.length + 1;
-	await editorPage.click( '.block-editor-post-preview__button-toggle' );
-	await editorPage.waitFor( '.edit-post-header-preview__button-external' );
-	await editorPage.click( '.edit-post-header-preview__button-external' );
-
-	// Wait for the new tab to open.
-	while ( openTabs.length < expectedTabsCount ) {
-		await editorPage.waitFor( 1 );
-		openTabs = await browser.pages();
-	}
-
-	const previewPage = last( openTabs );
-	// Wait for the preview to load. We can't do interstitial detection here,
-	// because it might load too quickly for us to pick up, so we wait for
-	// the preview to load by waiting for the content to appear.
-	await previewPage.waitForSelector( '.entry-content' );
-	return previewPage;
-}
 
 describe( 'Block context', () => {
 	beforeAll( async () => {
@@ -67,18 +41,5 @@ describe( 'Block context', () => {
 			() => document.activeElement.textContent
 		);
 		expect( innerBlockText ).toBe( 'The record ID is: 123' );
-	} );
-
-	test( 'Block context is reflected in the preview', async () => {
-		await insertBlock( 'Test Context Provider' );
-		const editorPage = page;
-		const previewPage = await openPreviewPage( editorPage );
-
-		// Check default context values are populated.
-		const content = await previewPage.$eval(
-			'.entry-content',
-			( contentWrapper ) => contentWrapper.textContent.trim()
-		);
-		expect( content ).toBe( 'The record ID is: 0' );
 	} );
 } );

--- a/phpunit/class-block-context-test.php
+++ b/phpunit/class-block-context-test.php
@@ -67,6 +67,8 @@ class Block_Context_Test extends WP_UnitTestCase {
 	 * its inner blocks.
 	 */
 	function test_provides_block_context() {
+		$this->markTestSkipped();
+
 		$provided_context = array();
 
 		$this->register_block_type(


### PR DESCRIPTION
Previously: #21868, #21467

This pull request seeks to revert more of the block context implementation introduced in #21467, effectively bypassing the `pre_render_block` filter introduced in #21467 altogether.

This is being proposed as a combination of:

1. #21467 inadvertently regressed the behavior of `render_block` on inner blocks. The filter is only being run on the top-level blocks of a post content.
   - https://wordpress.slack.com/archives/C02QB2JS7/p1587958680314500 ([link requires registration](https://make.wordpress.org/chat/))
2. Worries about additional overhead in `WP_Block` class construction
   - https://github.com/WordPress/gutenberg/issues/21797#issuecomment-619954657

The pull request is proposed in a way which minimizes the changes necessary to bypass this filter to restore most of the behavior which existed prior to #21467. In doing so, it leaves some lingering unused code. This is done largely due to time constraints, given that Gutenberg 8.0.0RC is proposed to be published today (Monday April 27). It may be possible that this be refined in time for the final release, though it's not strictly necessary to do so.

**Testing Instructions:**

Repeat testing instructions from #21467. Optionally, it was made easier to test in later development of #21467, using the "Gutenberg Test Block Context" plugin included in the [default development environment](https://github.com/WordPress/gutenberg/blob/master/docs/contributors/getting-started.md), via the associated "Test Context Provider" block.

To verify a fix of the issue reported in Slack:

1. Create a post which includes a nested block, like a Group block with a paragraph in it.
2. Preview the post
3. Add a `render_block` filter somewhere in your local environment (see patch below)
4. Verify that the filter is called for both the outer and inner blocks (in the patch example, you should see both "core/group" and "core/paragraph", not just "core/group" like you see in the current `master`).

```diff
diff --git a/lib/compat.php b/lib/compat.php
index e38f339030..cc5686d35e 100644
--- a/lib/compat.php
+++ b/lib/compat.php
@@ -177,0 +178,5 @@ function gutenberg_get_post_from_context() {
+
+add_filter( 'render_block', function( $block_content, $block ) {
+	var_export( $block['blockName'] );
+	return $block_content;
+}, 10, 2 );
```