### PR TITLE
Block Editor: Rename block context in BlockListBlock

### DIFF
--- a/packages/block-editor/src/components/block-list/block-wrapper.js
+++ b/packages/block-editor/src/components/block-list/block-wrapper.js
@@ -26,7 +26,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { isInsideRootBlock } from '../../utils/dom';
 import useMovingAnimation from './moving-animation';
 import { Context, BlockNodes } from './root-container';
-import { BlockContext } from './block';
+import { BlockListBlockContext } from './block';
 import ELEMENTS from './block-elements';
 
 const BlockComponent = forwardRef(
@@ -50,7 +50,7 @@ const BlockComponent = forwardRef(
 			mode,
 			blockTitle,
 			wrapperProps,
-		} = useContext( BlockContext );
+		} = useContext( BlockListBlockContext );
 		const { initialPosition } = useSelect(
 			( select ) => {
 				if ( ! isSelected ) {

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -31,7 +31,7 @@ import BlockCrashBoundary from './block-crash-boundary';
 import BlockHtml from './block-html';
 import { Block } from './block-wrapper';
 
-export const BlockContext = createContext();
+export const BlockListBlockContext = createContext();
 
 function BlockListBlock( {
 	mode,
@@ -167,7 +167,7 @@ function BlockListBlock( {
 	const memoizedValue = useMemo( () => value, Object.values( value ) );
 
 	return (
-		<BlockContext.Provider value={ memoizedValue }>
+		<BlockListBlockContext.Provider value={ memoizedValue }>
 			<BlockCrashBoundary onError={ onBlockError }>
 				{ isValid && lightBlockWrapper && (
 					<>
@@ -199,7 +199,7 @@ function BlockListBlock( {
 					<BlockCrashWarning />
 				</Block.div>
 			) }
-		</BlockContext.Provider>
+		</BlockListBlockContext.Provider>
 	);
 }
 


### PR DESCRIPTION
## Description

Fixes #21664.

> As of #21467, there are now three React Context objects related to blocks:
> 
> - [`BlockContext`](https://github.com/WordPress/gutenberg/blob/533d43beb379ad4a1b28d2f89afd22c562175311/packages/block-editor/src/components/block-list/block.js#L34) in `block-editor/src/components/block-list/block.js`
> - [`BlockEditContext`](https://github.com/WordPress/gutenberg/blob/533d43beb379ad4a1b28d2f89afd22c562175311/packages/block-editor/src/components/block-edit/context.js#L12-L18) in `block-editor/src/components/block-edit/context.js`
> - `BlockContext` in `block-editor/src/components/block/context/index.js`
> 
> For fear of potential confusion, these should each have distinct names. Currently, there is conflict between the two "BlockContext" objects. The latter of these is responsible for managing the feature of the same name ("Block Context", implemented in #21467). The former is specific to the context of a block within the block list. As such, it is more easily renamed.
> 
> **Task:**
> 
> Rename `BlockContext` in `block-list/block.js` to `BlockListContext` or `BlockListBlockContext`.