### PR TITLE
Block Library: Fix React does not recognize isSelected prop in Spacer block

### DIFF
--- a/packages/block-library/src/spacer/edit.js
+++ b/packages/block-library/src/spacer/edit.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import classnames from 'classnames';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -33,12 +28,7 @@ const SpacerEdit = ( {
 	return (
 		<>
 			<ResizableBox
-				className={ classnames(
-					'block-library-spacer__resize-container',
-					{
-						'is-selected': isSelected,
-					}
-				) }
+				className="block-library-spacer__resize-container"
 				size={ {
 					height,
 				} }
@@ -53,7 +43,6 @@ const SpacerEdit = ( {
 					bottomLeft: false,
 					topLeft: false,
 				} }
-				isSelected={ isSelected }
 				onResizeStart={ onResizeStart }
 				onResizeStop={ ( event, direction, elt, delta ) => {
 					onResizeStop();
@@ -63,6 +52,7 @@ const SpacerEdit = ( {
 					);
 					updateHeight( spacerHeight );
 				} }
+				showHandle={ isSelected }
 			/>
 			<InspectorControls>
 				<PanelBody title={ __( 'Spacer settings' ) }>

--- a/packages/block-library/src/spacer/edit.js
+++ b/packages/block-library/src/spacer/edit.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -28,7 +33,12 @@ const SpacerEdit = ( {
 	return (
 		<>
 			<ResizableBox
-				className="block-library-spacer__resize-container"
+				className={ classnames(
+					'block-library-spacer__resize-container',
+					{
+						'is-selected': isSelected,
+					}
+				) }
 				size={ {
 					height,
 				} }

--- a/packages/block-library/src/spacer/editor.scss
+++ b/packages/block-library/src/spacer/editor.scss
@@ -1,4 +1,4 @@
-.block-library-spacer__resize-container.is-selected {
+.block-library-spacer__resize-container.has-show-handle {
 	background: $light-gray-200;
 
 	.is-dark-theme & {

--- a/packages/components/src/resizable-box/index.native.js
+++ b/packages/components/src/resizable-box/index.native.js
@@ -12,7 +12,7 @@ import { withPreferredColorScheme } from '@wordpress/compose';
 import styles from './style.scss';
 
 function ResizableBox( props ) {
-	const { size, isSelected, getStylesFromColorScheme } = props;
+	const { size, showHandle, getStylesFromColorScheme } = props;
 	const { height } = size;
 	const defaultStyle = getStylesFromColorScheme(
 		styles.staticSpacer,
@@ -22,7 +22,7 @@ function ResizableBox( props ) {
 		<View
 			style={ [
 				defaultStyle,
-				isSelected && styles.selectedSpacer,
+				showHandle && styles.selectedSpacer,
 				{ height },
 			] }
 		></View>

--- a/packages/components/src/resizable-box/style.scss
+++ b/packages/components/src/resizable-box/style.scss
@@ -8,9 +8,7 @@ $resize-handler-container-size: $resize-handler-size + ($grid-unit-05 * 2); // M
 	width: $resize-handler-container-size;
 	height: $resize-handler-container-size;
 
-	// Show the resize handle when selected OR
 	// Show the resize handle if set in props
-	.components-resizable-box__container.is-selected &,
 	.components-resizable-box__container.has-show-handle & {
 		display: block;
 	}


### PR DESCRIPTION
## Description

Fixes #21495.

> That error appears in Firefox's JS console when adding the Spacer block.
> 
> It doesn't show up in Core 5.4, but does in the plugin as of d85ea0c.
> 
> Reproduce
> 
> 1. Open Firefox and its dev console
> 2. Browse to the editor, add a Spacer block
> 3. This will appear in the console:
> 
> ```
> Warning: React does not recognize the `isSelected` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `isselected` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
>     in div (created by t)
>     in t (created by Qi)
>     ...
> ```

I replaced `isSelected` with the existing `showHandle` prop. `isSelected` was introduced in https://github.com/WordPress/gutenberg/pull/20746.

## Testing
1. Open Firefox and its dev console
2. Browse to the editor, add a Spacer block
3. There should be no React warning on JS console related to `isSelected` prop. 
4. Ensure that you can still change the height of the Spacer block.