### PR TITLE
Block API: Block Context: Filter content, prepare attributes at render, pass block to render

### DIFF
--- a/docs/designers-developers/developers/block-api/block-context.md
+++ b/docs/designers-developers/developers/block-api/block-context.md
@@ -63,4 +63,14 @@ registerBlockType( 'my-plugin/record-title', {
 
 ### PHP
 
-_The PHP implementation of block context is currently experimental and subject to breaking changes. It will be documented in the future once the API has stabilized._
+A block's context values are available from the `context` property of the `$block` argument passed as the third argument to the `render_callback` function.
+
+`record-title/index.php`
+
+```php
+register_block_type( 'my-plugin/record-title', array(
+	'render_callback' => function( $attributes, $content, $block ) {
+		return 'The current record ID is: ' . $block->context['my-plugin/recordId'];
+	},
+) );
+```

--- a/lib/class-wp-block-list.php
+++ b/lib/class-wp-block-list.php
@@ -44,11 +44,13 @@ class WP_Block_List implements Iterator, ArrayAccess {
 	 * @param WP_Block_Type_Registry $registry          Optional block type registry.
 	 */
 	public function __construct( $blocks, $available_context = array(), $registry = null ) {
+		if ( is_null( $registry ) ) {
+			$registry = WP_Block_Type_Registry::get_instance();
+		}
+
 		$this->blocks            = $blocks;
 		$this->available_context = $available_context;
-		$this->registry          = is_null( $registry ) ?
-			WP_Block_Type_Registry::get_instance() :
-			$registry;
+		$this->registry          = $registry;
 	}
 
 	/*

--- a/lib/class-wp-block-list.php
+++ b/lib/class-wp-block-list.php
@@ -1,0 +1,171 @@
+<?php
+/**
+ * Blocks API: WP_Block_List class
+ *
+ * @package Gutenberg
+ */
+
+/**
+ * Class representing a list of block instances.
+ */
+class WP_Block_List implements Iterator, ArrayAccess {
+
+	/**
+	 * Original array of parsed block data.
+	 *
+	 * @var array|WP_Block[]
+	 * @access protected
+	 */
+	protected $blocks;
+
+	/**
+	 * All available context of the current hierarchy.
+	 *
+	 * @var array
+	 * @access protected
+	 */
+	protected $available_context;
+
+	/**
+	 * Block type registry to use in constructing block instances.
+	 *
+	 * @var WP_Block_Type_Registry
+	 * @access protected
+	 */
+	protected $registry;
+
+	/**
+	 * Constructor.
+	 *
+	 * Populates object properties from the provided block instance argument.
+	 *
+	 * @param array|WP_Block[]       $blocks            Array of parsed block data, or block instances.
+	 * @param array                  $available_context Optional array of ancestry context values.
+	 * @param WP_Block_Type_Registry $registry          Optional block type registry.
+	 */
+	public function __construct( $blocks, $available_context = array(), $registry = null ) {
+		$this->blocks            = $blocks;
+		$this->available_context = $available_context;
+		$this->registry          = is_null( $registry ) ?
+			WP_Block_Type_Registry::get_instance() :
+			$registry;
+	}
+
+	/*
+	 * ArrayAccess interface methods.
+	 */
+
+	/**
+	 * Returns true if a block exists by the specified block index, or false
+	 * otherwise.
+	 *
+	 * @link https://www.php.net/manual/en/arrayaccess.offsetexists.php
+	 *
+	 * @param string $index Index of block to check.
+	 *
+	 * @return bool Whether block exists.
+	 */
+	public function offsetExists( $index ) {
+		return isset( $this->blocks[ $index ] );
+	}
+
+	/**
+	 * Returns the value by the specified block index.
+	 *
+	 * @link https://www.php.net/manual/en/arrayaccess.offsetget.php
+	 *
+	 * @param string $index Index of block value to retrieve.
+	 *
+	 * @return mixed|null Block value if exists, or null.
+	 */
+	public function offsetGet( $index ) {
+		$block = $this->blocks[ $index ];
+
+		if ( isset( $block ) && is_array( $block ) ) {
+			$block = new WP_Block( $block, $this->available_context, $this->registry );
+		}
+
+		return $block;
+	}
+
+	/**
+	 * Assign a block value by the specified block index.
+	 *
+	 * @link https://www.php.net/manual/en/arrayaccess.offsetset.php
+	 *
+	 * @param string $index Index of block value to set.
+	 * @param mixed  $value Block value.
+	 */
+	public function offsetSet( $index, $value ) {
+		if ( is_null( $index ) ) {
+			$this->blocks[] = $value;
+		} else {
+			$this->blocks[ $index ] = $value;
+		}
+	}
+
+	/**
+	 * Unset a block.
+	 *
+	 * @link https://www.php.net/manual/en/arrayaccess.offsetunset.php
+	 *
+	 * @param string $index Index of block value to unset.
+	 */
+	public function offsetUnset( $index ) {
+		unset( $this->blocks[ $index ] );
+	}
+
+	/*
+	 * Iterator interface methods.
+	 */
+
+	/**
+	 * Rewinds back to the first element of the Iterator.
+	 *
+	 * @link https://www.php.net/manual/en/iterator.rewind.php
+	 */
+	public function rewind() {
+		reset( $this->blocks );
+	}
+
+	/**
+	 * Returns the current element of the block list.
+	 *
+	 * @link https://www.php.net/manual/en/iterator.current.php
+	 *
+	 * @return mixed Current element.
+	 */
+	public function current() {
+		return $this->offsetGet( $this->key() );
+	}
+
+	/**
+	 * Returns the key of the current element of the block list.
+	 *
+	 * @link https://www.php.net/manual/en/iterator.key.php
+	 *
+	 * @return mixed Key of the current element.
+	 */
+	public function key() {
+		return key( $this->blocks );
+	}
+
+	/**
+	 * Moves the current position of the block list to the next element.
+	 *
+	 * @link https://www.php.net/manual/en/iterator.next.php
+	 */
+	public function next() {
+		next( $this->blocks );
+	}
+
+	/**
+	 * Checks if current position is valid.
+	 *
+	 * @link https://www.php.net/manual/en/iterator.valid.php
+	 */
+	public function valid() {
+		return null !== key( $this->blocks );
+	}
+
+}

--- a/lib/class-wp-block-list.php
+++ b/lib/class-wp-block-list.php
@@ -84,7 +84,8 @@ class WP_Block_List implements Iterator, ArrayAccess {
 		$block = $this->blocks[ $index ];
 
 		if ( isset( $block ) && is_array( $block ) ) {
-			$block = new WP_Block( $block, $this->available_context, $this->registry );
+			$block                  = new WP_Block( $block, $this->available_context, $this->registry );
+			$this->blocks[ $index ] = $block;
 		}
 
 		return $block;

--- a/lib/class-wp-block-list.php
+++ b/lib/class-wp-block-list.php
@@ -8,7 +8,7 @@
 /**
  * Class representing a list of block instances.
  */
-class WP_Block_List implements Iterator, ArrayAccess {
+class WP_Block_List implements Iterator, ArrayAccess, Countable {
 
 	/**
 	 * Original array of parsed block data.
@@ -169,6 +169,21 @@ class WP_Block_List implements Iterator, ArrayAccess {
 	 */
 	public function valid() {
 		return null !== key( $this->blocks );
+	}
+
+	/*
+	 * Countable interface methods.
+	 */
+
+	/**
+	 * Returns the count of blocks in the list.
+	 *
+	 * @link https://www.php.net/manual/en/countable.count.php
+	 *
+	 * @return int Block count.
+	 */
+	public function count() {
+		return count( $this->blocks );
 	}
 
 }

--- a/lib/class-wp-block.php
+++ b/lib/class-wp-block.php
@@ -160,7 +160,7 @@ class WP_Block {
 	 * @return string Rendered block output.
 	 */
 	public function render() {
-		global $post, $_experimental_block;
+		global $post;
 
 		$is_dynamic    = $this->name && null !== $this->block_type && $this->block_type->is_dynamic();
 		$block_content = '';
@@ -178,12 +178,9 @@ class WP_Block {
 				$attributes = $this->block_type->prepare_attributes_for_render( $attributes );
 			}
 
-			$global_post         = $post;
-			$global_block        = $_experimental_block;
-			$_experimental_block = $this;
-			$block_content       = (string) call_user_func( $this->block_type->render_callback, $attributes, $block_content );
-			$_experimental_block = $global_block;
-			$post                = $global_post;
+			$global_post   = $post;
+			$block_content = (string) call_user_func( $this->block_type->render_callback, $attributes, $block_content, $this );
+			$post          = $global_post;
 		}
 
 		/** This filter is documented in src/wp-includes/blocks.php */

--- a/lib/class-wp-block.php
+++ b/lib/class-wp-block.php
@@ -11,6 +11,13 @@
 class WP_Block {
 
 	/**
+	 * Original parsed array representation of block.
+	 *
+	 * @var array
+	 */
+	public $parsed_block;
+
+	/**
 	 * Name of block.
 	 *
 	 * @example "core/paragraph"
@@ -94,7 +101,8 @@ class WP_Block {
 	 * @param WP_Block_Type_Registry $registry          Optional block type registry.
 	 */
 	public function __construct( $block, $available_context = array(), $registry = null ) {
-		$this->name = $block['blockName'];
+		$this->parsed_block = $block;
+		$this->name         = $block['blockName'];
 
 		if ( is_null( $registry ) ) {
 			$registry = WP_Block_Type_Registry::get_instance();
@@ -177,7 +185,8 @@ class WP_Block {
 			$post                = $global_post;
 		}
 
-		return $block_content;
+		/** This filter is documented in src/wp-includes/blocks.php */
+		return apply_filters( 'render_block', $block_content, $this->parsed_block );
 	}
 
 }

--- a/lib/class-wp-block.php
+++ b/lib/class-wp-block.php
@@ -114,10 +114,6 @@ class WP_Block {
 			$this->attributes = $block['attrs'];
 		}
 
-		if ( ! is_null( $this->block_type ) ) {
-			$this->attributes = $this->block_type->prepare_attributes_for_render( $this->attributes );
-		}
-
 		$this->available_context = $available_context;
 
 		if ( ! empty( $this->block_type->context ) ) {
@@ -177,10 +173,15 @@ class WP_Block {
 		}
 
 		if ( $is_dynamic ) {
+			$attributes = $this->attributes;
+			if ( ! is_null( $this->block_type ) ) {
+				$attributes = $this->block_type->prepare_attributes_for_render( $attributes );
+			}
+
 			$global_post         = $post;
 			$global_block        = $_experimental_block;
 			$_experimental_block = $this;
-			$block_content       = (string) call_user_func( $this->block_type->render_callback, $this->attributes, $block_content );
+			$block_content       = (string) call_user_func( $this->block_type->render_callback, $attributes, $block_content );
 			$_experimental_block = $global_block;
 			$post                = $global_post;
 		}

--- a/lib/class-wp-block.php
+++ b/lib/class-wp-block.php
@@ -151,7 +151,7 @@ class WP_Block {
 	 * @return array|null Prepared attributes, or null.
 	 */
 	public function __get( $name ) {
-		if ( 'attributes' === $name && ! isset( $this->attributes ) ) {
+		if ( 'attributes' === $name ) {
 			$this->attributes = isset( $this->parsed_block['attrs'] ) ?
 				$this->parsed_block['attrs'] :
 				array();

--- a/lib/class-wp-block.php
+++ b/lib/class-wp-block.php
@@ -126,12 +126,7 @@ class WP_Block {
 			}
 			/* phpcs:enable */
 
-			$this->inner_blocks = array_map(
-				function( $inner_block ) use ( $child_context, $registry ) {
-					return new WP_Block( $inner_block, $child_context, $registry );
-				},
-				$block['innerBlocks']
-			);
+			$this->inner_blocks = new WP_Block_List( $block['innerBlocks'], $child_context, $registry );
 		}
 
 		if ( ! empty( $block['innerHTML'] ) ) {

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -175,3 +175,36 @@ function gutenberg_get_post_from_context() {
 	}
 	return get_post();
 }
+
+/**
+ * Shim that hooks into `pre_render_block` so as to override `render_block` with
+ * a function that assigns block context.
+ *
+ * This can be removed when plugin support requires WordPress 5.5.0+.
+ *
+ * @see https://core.trac.wordpress.org/ticket/49927
+ *
+ * @param string|null $pre_render   The pre-rendered content. Defaults to null.
+ * @param array       $parsed_block The parsed block being rendered.
+ *
+ * @return string String of rendered HTML.
+ */
+function gutenberg_render_block_with_assigned_block_context( $pre_render, $parsed_block ) {
+	global $post;
+
+	// If a non-null value is provided, a filter has run at an earlier priority
+	// and has already handled custom rendering and should take precedence.
+	if ( null !== $pre_render ) {
+		return $pre_render;
+	}
+
+	$source_block = $parsed_block;
+
+	/** This filter is documented in src/wp-includes/blocks.php */
+	$parsed_block = apply_filters( 'render_block_data', $parsed_block, $source_block );
+	$context      = array( 'postId' => $post->ID );
+	$block        = new WP_Block( $parsed_block, $context );
+
+	return $block->render();
+}
+add_filter( 'pre_render_block', 'gutenberg_render_block_with_assigned_block_context', 9, 2 );

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -206,6 +206,7 @@ function gutenberg_render_block_with_assigned_block_context( $pre_render, $parse
 	$parsed_block = apply_filters( 'render_block_data', $parsed_block, $source_block );
 	$context      = array(
 		'postId'   => $post->ID,
+
 		/*
 		 * The `postType` context is largely unnecessary server-side, since the
 		 * ID is usually sufficient on its own. That being said, since a block's

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -192,8 +192,10 @@ function gutenberg_get_post_from_context() {
 function gutenberg_render_block_with_assigned_block_context( $pre_render, $parsed_block ) {
 	global $post;
 
-	// If a non-null value is provided, a filter has run at an earlier priority
-	// and has already handled custom rendering and should take precedence.
+	/*
+	 * If a non-null value is provided, a filter has run at an earlier priority
+	 * and has already handled custom rendering and should take precedence.
+	 */
 	if ( null !== $pre_render ) {
 		return $pre_render;
 	}

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -208,8 +208,8 @@ function gutenberg_render_block_with_assigned_block_context( $pre_render, $parse
 		'postId'   => $post->ID,
 		/*
 		 * The `postType` context is largely unnecessary server-side, since the
-		 * ID is usually sufficient on its own. That being said, since a block
-		 * manifests is expected to be shared between the server and the client,
+		 * ID is usually sufficient on its own. That being said, since a block's
+		 * manifest is expected to be shared between the server and the client,
 		 * it should be included to consistently fulfill the expectation.
 		 */
 		'postType' => $post->post_type,

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -204,7 +204,16 @@ function gutenberg_render_block_with_assigned_block_context( $pre_render, $parse
 
 	/** This filter is documented in src/wp-includes/blocks.php */
 	$parsed_block = apply_filters( 'render_block_data', $parsed_block, $source_block );
-	$context      = array( 'postId' => $post->ID );
+	$context      = array(
+		'postId'   => $post->ID,
+		/*
+		 * The `postType` context is largely unnecessary server-side, since the
+		 * ID is usually sufficient on its own. That being said, since a block
+		 * manifests is expected to be shared between the server and the client,
+		 * it should be included to consistently fulfill the expectation.
+		 */
+		'postType' => $post->post_type,
+	);
 	$block        = new WP_Block( $parsed_block, $context );
 
 	return $block->render();

--- a/lib/load.php
+++ b/lib/load.php
@@ -67,6 +67,10 @@ if ( ! class_exists( 'WP_Block' ) ) {
 	require dirname( __FILE__ ) . '/class-wp-block.php';
 }
 
+if ( ! class_exists( 'WP_Block_List' ) ) {
+	require dirname( __FILE__ ) . '/class-wp-block-list.php';
+}
+
 require dirname( __FILE__ ) . '/compat.php';
 
 require dirname( __FILE__ ) . '/blocks.php';

--- a/packages/block-library/src/post-title/index.php
+++ b/packages/block-library/src/post-title/index.php
@@ -8,6 +8,10 @@
 /**
  * Renders the `core/post-title` block on the server.
  *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
+ *
  * @return string Returns the filtered post title for the current post wrapped inside "h1" tags.
  */
 function render_block_core_post_title( $attributes, $content, $block ) {

--- a/packages/block-library/src/post-title/index.php
+++ b/packages/block-library/src/post-title/index.php
@@ -10,13 +10,12 @@
  *
  * @return string Returns the filtered post title for the current post wrapped inside "h1" tags.
  */
-function render_block_core_post_title() {
-	$post = gutenberg_get_post_from_context();
-	if ( ! $post ) {
+function render_block_core_post_title( $attributes, $content, $block ) {
+	if ( ! isset( $block->context['postId'] ) ) {
 		return '';
 	}
 
-	return '<h1>' . get_the_title( $post ) . '</h1>';
+	return '<h1>' . get_the_title( $block->context['postId'] ) . '</h1>';
 }
 
 /**

--- a/packages/e2e-tests/plugins/block-context.php
+++ b/packages/e2e-tests/plugins/block-context.php
@@ -47,7 +47,16 @@ function gutenberg_test_register_context_blocks() {
 	register_block_type(
 		'gutenberg/test-context-consumer',
 		array(
-			'context' => array( 'gutenberg/recordId' ),
+			'context'         => array( 'gutenberg/recordId' ),
+			'render_callback' => function( $attributes, $content, $block ) {
+				$record_id = $block->context['gutenberg/recordId'];
+
+				if ( ! is_int( $record_id ) ) {
+					throw new Exception( 'Expected numeric recordId' );
+				}
+
+				return 'The record ID is: ' . filter_var( $record_id, FILTER_VALIDATE_INT );
+			},
 		)
 	);
 }

--- a/phpunit/class-block-context-test.php
+++ b/phpunit/class-block-context-test.php
@@ -141,7 +141,7 @@ class Block_Context_Test extends WP_UnitTestCase {
 		$this->register_block_type(
 			'gutenberg/test-context-consumer',
 			array(
-				'context' => array( 'postId', 'postType' ),
+				'context'         => array( 'postId', 'postType' ),
 				'render_callback' => function( $attributes, $content, $block ) use ( &$provided_context ) {
 					$provided_context[] = $block->context;
 

--- a/phpunit/class-block-context-test.php
+++ b/phpunit/class-block-context-test.php
@@ -67,8 +67,6 @@ class Block_Context_Test extends WP_UnitTestCase {
 	 * its inner blocks.
 	 */
 	function test_provides_block_context() {
-		$this->markTestSkipped();
-
 		$provided_context = array();
 
 		$this->register_block_type(

--- a/phpunit/class-block-context-test.php
+++ b/phpunit/class-block-context-test.php
@@ -129,4 +129,38 @@ class Block_Context_Test extends WP_UnitTestCase {
 		);
 	}
 
+	/**
+	 * Tests that a block can receive default-provided context through
+	 * render_block.
+	 */
+	function test_provides_default_context() {
+		global $post;
+
+		$provided_context = array();
+
+		$this->register_block_type(
+			'gutenberg/test-context-consumer',
+			array(
+				'context' => array( 'postId', 'postType' ),
+				'render_callback' => function( $attributes, $content, $block ) use ( &$provided_context ) {
+					$provided_context[] = $block->context;
+
+					return '';
+				},
+			)
+		);
+
+		$parsed_blocks = parse_blocks( '<!-- wp:gutenberg/test-context-consumer /-->' );
+
+		render_block( $parsed_blocks[0] );
+
+		$this->assertEquals(
+			array(
+				'postId'   => $post->ID,
+				'postType' => $post->post_type,
+			),
+			$provided_context[0]
+		);
+	}
+
 }

--- a/phpunit/class-block-context-test.php
+++ b/phpunit/class-block-context-test.php
@@ -106,10 +106,8 @@ class Block_Context_Test extends WP_UnitTestCase {
 					'gutenberg/contextWithAssigned',
 					'gutenberg/contextWithoutDefault',
 				),
-				'render_callback' => function() use ( &$provided_context ) {
-					global $_experimental_block;
-
-					$provided_context[] = $_experimental_block->context;
+				'render_callback' => function( $attributes, $content, $block ) use ( &$provided_context ) {
+					$provided_context[] = $block->context;
 
 					return '';
 				},

--- a/phpunit/class-wp-block-list-test.php
+++ b/phpunit/class-wp-block-list-test.php
@@ -33,6 +33,56 @@ class WP_Block_List_Test extends WP_UnitTestCase {
 		$this->registry = null;
 	}
 
+	function test_array_access() {
+		$parsed_blocks = parse_blocks( '<!-- wp:example /-->' );
+		$context       = array();
+		$blocks        = new WP_Block_List( $parsed_blocks, $context, $this->registry );
+
+		// Test "offsetExists".
+		$this->assertTrue( isset( $blocks[0] ) );
+
+		// Test "offsetGet".
+		$this->assertEquals( 'core/example', $blocks[0]->name );
+
+		// Test "offsetSet".
+		$parsed_blocks[0]['blockName'] = 'core/updated';
+		$blocks[0]                     = new WP_Block( $parsed_blocks[0], $context, $this->registry );
+		$this->assertEquals( 'core/updated', $blocks[0]->name );
+
+		// Test "offsetUnset".
+		unset( $blocks[0] );
+		$this->assertFalse( isset( $blocks[0] ) );
+	}
+
+	function test_iterable() {
+		$parsed_blocks = parse_blocks( '<!-- wp:example --><!-- wp:example /--><!-- /wp:example -->' );
+		$context       = array();
+		$blocks        = new WP_Block_List( $parsed_blocks, $context, $this->registry );
+		$assertions    = 0;
+
+		foreach ( $blocks as $block ) {
+			$this->assertEquals( 'core/example', $block->name );
+			$assertions++;
+			foreach ( $block->inner_blocks as $inner_block ) {
+				$this->assertEquals( 'core/example', $inner_block->name );
+				$assertions++;
+			}
+		}
+
+		$blocks->rewind();
+		while ( $blocks->valid() ) {
+			$key   = $blocks->key();
+			$block = $blocks->current();
+			$this->assertEquals( 0, $key );
+			$assertions++;
+			$this->assertEquals( 'core/example', $block->name );
+			$assertions++;
+			$blocks->next();
+		}
+
+		$this->assertEquals( 4, $assertions );
+	}
+
 	function test_countable() {
 		$parsed_blocks = parse_blocks( '<!-- wp:example /-->' );
 		$context       = array();

--- a/phpunit/class-wp-block-list-test.php
+++ b/phpunit/class-wp-block-list-test.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Test WP_Block_List class.
+ *
+ * @package Gutenberg
+ */
+
+class WP_Block_List_Test extends WP_UnitTestCase {
+
+	/**
+	 * Fake block type registry.
+	 *
+	 * @var WP_Block_Type_Registry
+	 */
+	private $registry = null;
+
+	/**
+	 * Set up each test method.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->registry = new WP_Block_Type_Registry();
+		$this->registry->register( 'core/example', array() );
+	}
+
+	/**
+	 * Tear down each test method.
+	 */
+	public function tearDown() {
+		parent::tearDown();
+
+		$this->registry = null;
+	}
+
+	function test_countable() {
+		$parsed_blocks = parse_blocks( '<!-- wp:example /-->' );
+		$context       = array();
+		$blocks        = new WP_Block_List( $parsed_blocks, $context, $this->registry );
+
+		$this->assertEquals( 1, count( $blocks ) );
+	}
+
+}

--- a/phpunit/class-wp-block-test.php
+++ b/phpunit/class-wp-block-test.php
@@ -40,6 +40,7 @@ class WP_Block_Test extends WP_UnitTestCase {
 		$context       = array();
 		$block         = new WP_Block( $parsed_block, $context, $this->registry );
 
+		$this->assertSame( $parsed_block, $block->parsed_block );
 		$this->assertEquals( $parsed_block['blockName'], $block->name );
 		$this->assertEquals( $parsed_block['attrs'], $block->attributes );
 		$this->assertEquals( $parsed_block['innerContent'], $block->inner_content );

--- a/phpunit/class-wp-block-test.php
+++ b/phpunit/class-wp-block-test.php
@@ -227,14 +227,12 @@ class WP_Block_Test extends WP_UnitTestCase {
 		$this->assertSame( 'abc', $block->render() );
 	}
 
-	function test_render_assigns_instance_global_for_render_callback() {
+	function test_render_passes_block_for_render_callback() {
 		$this->registry->register(
 			'core/greeting',
 			array(
-				'render_callback' => function() {
-					global $_experimental_block;
-
-					return sprintf( 'Hello from %s', $_experimental_block->name );
+				'render_callback' => function( $attributes, $content, $block ) {
+					return sprintf( 'Hello from %s', $block->name );
 				},
 			)
 		);

--- a/phpunit/class-wp-block-test.php
+++ b/phpunit/class-wp-block-test.php
@@ -69,6 +69,60 @@ class WP_Block_Test extends WP_UnitTestCase {
 		);
 	}
 
+	function test_lazily_assigns_attributes_with_defaults() {
+		$this->registry->register(
+			'core/example',
+			array(
+				'attributes' => array(
+					'defaulted' => array(
+						'type'    => 'number',
+						'default' => 10,
+					),
+				),
+			)
+		);
+
+		$parsed_block = array(
+			'blockName' => 'core/example',
+			'attrs'     => array(
+				'explicit' => 20,
+			),
+		);
+		$context      = array();
+		$block        = new WP_Block( $parsed_block, $context, $this->registry );
+
+		$this->assertEquals(
+			array(
+				'defaulted' => 10,
+				'explicit'  => 20,
+			),
+			$block->attributes
+		);
+	}
+
+	function test_lazily_assigns_attributes_with_only_defaults() {
+		$this->registry->register(
+			'core/example',
+			array(
+				'attributes' => array(
+					'defaulted' => array(
+						'type'    => 'number',
+						'default' => 10,
+					),
+				),
+			)
+		);
+
+		$parsed_block = array(
+			'blockName' => 'core/example',
+			'attrs'     => array(),
+		);
+		$context      = array();
+		$block        = new WP_Block( $parsed_block, $context, $this->registry );
+
+		$this->assertEquals( array( 'defaulted' => 10 ), $block->attributes );
+	}
+
 	function test_constructor_assigns_context_from_block_type() {
 		$this->registry->register(
 			'core/example',
@@ -172,40 +226,6 @@ class WP_Block_Test extends WP_UnitTestCase {
 			array( 'core/value' => null ),
 			$block->inner_blocks[0]->inner_blocks[0]->context
 		);
-	}
-
-	function test_render_assigns_attributes_with_defaults() {
-		$this->registry->register(
-			'core/example',
-			array(
-				'attributes'      => array(
-					'defaulted' => array(
-						'type'    => 'number',
-						'default' => 10,
-					),
-				),
-				'render_callback' => function( $attributes ) {
-					return json_encode(
-						array(
-							'explicit'  => $attributes['explicit'],
-							'defaulted' => $attributes['defaulted'],
-						)
-					);
-				}
-			)
-		);
-
-		$parsed_block = array(
-			'blockName' => 'core/example',
-			'attrs'     => array(
-				'explicit' => 20,
-			),
-		);
-		$context      = array();
-		$block        = new WP_Block( $parsed_block, $context, $this->registry );
-		$content      = $block->render();
-
-		$this->assertEquals( '{"explicit":20,"defaulted":10}', $content );
 	}
 
 	function test_render_static_block_type_returns_own_content() {

--- a/phpunit/class-wp-block-test.php
+++ b/phpunit/class-wp-block-test.php
@@ -125,6 +125,8 @@ class WP_Block_Test extends WP_UnitTestCase {
 		$block        = new WP_Block( $parsed_block, $context, $this->registry );
 
 		$this->assertEquals( array( 'defaulted' => 10 ), $block->attributes );
+		// Intentionally call a second time, to ensure property was assigned.
+		$this->assertEquals( array( 'defaulted' => 10 ), $block->attributes );
 	}
 
 	function test_constructor_assigns_context_from_block_type() {


### PR DESCRIPTION
Related: #21921
Closes #21797

~_Note:_ This pull request is intended to be exploratory, related to discussion In #21797 in how best to make available block context and block values in general.~ **Edit:** Stability achieved after continued iteration and feedback cycles.

This pull request seeks to explore a few ideas related to block rendering and the provided block value, which is particularly impactful for ongoing work around block context.

It...

- Runs `render_block` filter in `WP_Block::render`, intended to address the bug separately addressed in #21921
   - >#21467 inadvertently regressed the behavior of render_block on inner blocks. The filter is only being run on the top-level blocks of a post content.
   - Observation: Would we expect filters to be run in these otherwise-generic classes? How else could we run a "callback" on the recursive rendered result.
   - Observation: This requires the instance to track its original parsed value, required for backward compatibility since the filter receives it. This may not be necessary if the previous point can be addressed with an alternative implementation.
- Prepares attributes only at time of rendering for a dynamic block.
   - Related to the "overhead" worry described in https://github.com/WordPress/gutenberg/issues/21797#issuecomment-619954657
   - Observation: You can see even by the tests that this introduces some uncertainty around using values from the `$block` value, since `$block->attributes` will be the attributes _as parsed_, not including any defaults. I haven't yet experimented with it, but the [`__get` magic method](https://www.php.net/manual/en/language.oop5.overloading.php#object.get) usage described in https://github.com/WordPress/gutenberg/issues/21797#issuecomment-619954657 could be a reasonable compromise here.
   - Observation: _As named_, it makes some sense that the attributes defaulting behavior contained in `prepare_attributes_for_render` is only called when a block is rendered. However, the proposed benefits of the changes in #21467 were partly to soft-deprecate this, and intentionally change to a behavior which was more "predictable" as far as attributes always being defaulted once the class instance is constructed.
   - Observation: Inner blocks mapping, the other constructed logic noted in https://github.com/WordPress/gutenberg/issues/21797#issuecomment-619954657, was not included as part of these changes. It would probably be necessary to keep this in the constructor, at least given how context is currently prepared and passed to descendants using constructor arguments.
- Passes the `$block` class instance as a third argument of `render_callback`
   - Observation: It works reasonably well, aside from the above-noted caveat about attributes defaulting if `prepare_attributes_for_render` is deferred to the point that the block is rendered.

**Testing Instructions:**

Repeat testing instructions from #21921.

Ensure unit tests pass:

```
npm run test-unit-php
```