### PR TITLE
URL: addQueryArgs optional arguments

### DIFF
--- a/packages/url/CHANGELOG.md
+++ b/packages/url/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Master
 
+### Bug fix
+
+- `addQueryArgs` arguments are optional ([#21926](https://github.com/WordPress/gutenberg/pull/21926))
+
 ## 2.13.0 (2020-04-15)
 
 ### New feature

--- a/packages/url/README.md
+++ b/packages/url/README.md
@@ -31,7 +31,7 @@ const newURL = addQueryArgs( 'https://google.com', { q: 'test' } ); // https://g
 _Parameters_
 
 -   _url_ `[string]`: URL to which arguments should be appended. If omitted, only the resulting querystring is returned.
--   _args_ `Object`: Query arguments to apply to URL.
+-   _args_ `[Object]`: Query arguments to apply to URL.
 
 _Returns_
 

--- a/packages/url/src/add-query-args.js
+++ b/packages/url/src/add-query-args.js
@@ -10,7 +10,7 @@ import { parse, stringify } from 'qs';
  *
  * @param {string} [url='']  URL to which arguments should be appended. If omitted,
  *                           only the resulting querystring is returned.
- * @param {Object} args      Query arguments to apply to URL.
+ * @param {Object} [args]    Query arguments to apply to URL.
  *
  * @example
  * ```js

--- a/packages/url/tsconfig.json
+++ b/packages/url/tsconfig.json
@@ -2,10 +2,7 @@
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",
-		"declarationDir": "build-types",
-
-		// This is required because the `react-native-url-polyfill` dependency lacks types
-		"noImplicitAny": false
+		"declarationDir": "build-types"
 	},
 	"include": [ "src/**/*" ]
 }


### PR DESCRIPTION
## Description
Make both `addQueryArgs` arguments optional.

TypeScript prohibits optional arguments from preceding non-optional arguments. It's easy to see why:

```js
function absurd( optional, nonOptional ) {}
absurd( , 'non-optional' ); // 😕 can't write that
```

Surprisingly, when producing types from JSDoc, it appears to happily produce a declaration that violates this, as we have for [`addQueryArgs`](https://unpkg.com/browse/@wordpress/url@2.13.0/build-types/add-query-args.d.ts):

```ts
export function addQueryArgs(url?: string | undefined, args: any): string;
```

The correct signature (according to the implementation) is to make both argument optional as is done in this PR.

Noticed in https://github.com/Automattic/wp-calypso/pull/41207
Related TypeScript bug report: https://github.com/microsoft/TypeScript/issues/37703