### PR TITLE
ESLint Plugin: Relax check for i18n-text-domain rule

### DIFF
--- a/packages/eslint-plugin/rules/__tests__/i18n-text-domain.js
+++ b/packages/eslint-plugin/rules/__tests__/i18n-text-domain.js
@@ -17,6 +17,12 @@ const ruleTester = new RuleTester( {
 ruleTester.run( 'i18n-text-domain', rule, {
 	valid: [
 		{
+			code: `_x( 'Hello World' )`,
+		},
+		{
+			code: `_x( 'Hello World', 'random' )`,
+		},
+		{
 			code: `__( 'Hello World' )`,
 			options: [ { allowedTextDomain: 'default' } ],
 		},

--- a/packages/eslint-plugin/rules/i18n-text-domain.js
+++ b/packages/eslint-plugin/rules/i18n-text-domain.js
@@ -48,7 +48,6 @@ module.exports = {
 							},
 							{
 								type: 'string',
-								default: 'default',
 							},
 						],
 					},
@@ -68,12 +67,14 @@ module.exports = {
 	},
 	create( context ) {
 		const options = context.options[ 0 ] || {};
-		const { allowedTextDomain = 'default' } = options;
+		const { allowedTextDomain } = options;
 		const allowedTextDomains = Array.isArray( allowedTextDomain )
 			? allowedTextDomain
-			: [ allowedTextDomain ];
+			: [ allowedTextDomain ].filter( ( value ) => value );
 		const canFixTextDomain = allowedTextDomains.length === 1;
-		const allowDefault = allowedTextDomains.includes( 'default' );
+		const allowDefault =
+			allowedTextDomains.length === 0 ||
+			allowedTextDomains.includes( 'default' );
 
 		return {
 			CallExpression( node ) {
@@ -134,7 +135,10 @@ module.exports = {
 					return;
 				}
 
-				if ( ! allowedTextDomains.includes( value ) ) {
+				if (
+					allowedTextDomains.length &&
+					! allowedTextDomains.includes( value )
+				) {
 					const replaceTextDomain = ( fixer ) => {
 						return fixer.replaceTextRange(
 							// account for quotes.


### PR DESCRIPTION
## Description
Fixes #21920.

Tries the approach suggested by @swissspidy:

> I think the easiest solution would be to remove the default text domain:
> 
> https://github.com/WordPress/gutenberg/blob/3b8965e197ba5bbcc24d9b8dfa1f759601416a52/packages/eslint-plugin/rules/i18n-text-domain.js#L51
> 
> https://github.com/WordPress/gutenberg/blob/3b8965e197ba5bbcc24d9b8dfa1f759601416a52/packages/eslint-plugin/rules/i18n-text-domain.js#L71
> 
> So when the text domain is not explicitly specified (`allowedTextDomain === undefined`), the rule would do **nothing** 

Now that I read it again, I want to double-check if we can bail early when the `allowedTextDomain` is not provided ... 🤣 

## How has this been tested?

`npm run lint-js` still works with Gutenberg – it uses local override

`npm run lint-js` doesn't fail when a random text domain is added to translations when the local override is removed.

`npm run test-unit` works with newly added unit tests.