### PR TITLE
Chore: Update is-promise package to the latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10055,7 +10055,7 @@
 				"@wordpress/priority-queue": "file:packages/priority-queue",
 				"@wordpress/redux-routine": "file:packages/redux-routine",
 				"equivalent-key-map": "^0.2.2",
-				"is-promise": "^2.1.0",
+				"is-promise": "^4.0.0",
 				"lodash": "^4.17.15",
 				"memize": "^1.1.0",
 				"redux": "^4.0.0",
@@ -10574,7 +10574,7 @@
 			"version": "file:packages/redux-routine",
 			"requires": {
 				"@babel/runtime": "^7.9.2",
-				"is-promise": "^2.1.0",
+				"is-promise": "^4.0.0",
 				"lodash": "^4.17.15",
 				"rungen": "^0.3.2"
 			}
@@ -22963,6 +22963,14 @@
 					"dev": true,
 					"requires": {
 						"is-promise": "^2.1.0"
+					},
+					"dependencies": {
+						"is-promise": {
+							"version": "2.2.2",
+							"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+							"integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
+							"dev": true
+						}
 					}
 				},
 				"rxjs": {
@@ -23499,9 +23507,9 @@
 			"dev": true
 		},
 		"is-promise": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+			"integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="
 		},
 		"is-regex": {
 			"version": "1.0.4",
@@ -28257,6 +28265,14 @@
 			"requires": {
 				"is-promise": "^2.0.0",
 				"promise": "^7.0.1"
+			},
+			"dependencies": {
+				"is-promise": {
+					"version": "2.2.2",
+					"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+					"integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
+					"dev": true
+				}
 			}
 		},
 		"jsx-ast-utils": {
@@ -28721,6 +28737,12 @@
 				"rxjs": "^6.3.3"
 			},
 			"dependencies": {
+				"is-promise": {
+					"version": "2.2.2",
+					"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+					"integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
+					"dev": true
+				},
 				"p-map": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
@@ -38151,6 +38173,14 @@
 			"dev": true,
 			"requires": {
 				"is-promise": "^2.1.0"
+			},
+			"dependencies": {
+				"is-promise": {
+					"version": "2.2.2",
+					"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+					"integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
+					"dev": true
+				}
 			}
 		},
 		"run-node": {

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -30,7 +30,7 @@
 		"@wordpress/priority-queue": "file:../priority-queue",
 		"@wordpress/redux-routine": "file:../redux-routine",
 		"equivalent-key-map": "^0.2.2",
-		"is-promise": "^2.1.0",
+		"is-promise": "^4.0.0",
 		"lodash": "^4.17.15",
 		"memize": "^1.1.0",
 		"redux": "^4.0.0",

--- a/packages/redux-routine/package.json
+++ b/packages/redux-routine/package.json
@@ -25,7 +25,7 @@
 	"sideEffects": false,
 	"dependencies": {
 		"@babel/runtime": "^7.9.2",
-		"is-promise": "^2.1.0",
+		"is-promise": "^4.0.0",
 		"lodash": "^4.17.15",
 		"rungen": "^0.3.2"
 	},


### PR DESCRIPTION
## Description
An alternative to #21934.

We have some issues with `is-promise` dependency when trying to update React Native to the latest version. Let's see it bumping `is-promise` to the latest version would help.