### PR TITLE
Increase the severity of `jsdoc/no-undefined-types`. 

### DIFF
--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Master
 
+### Breaking Changes
+
+-  The severity of the rule, `jsdoc/no-undefined-types`, has been increased from `warn` to `error`. In addition, `JSX` has been added to the default list of defined types.
+
 ### Improvements
 
 - `'AsyncIterableIterator'` is now whitelisted as a valid TypeScript utility type.

--- a/packages/eslint-plugin/configs/jsdoc.js
+++ b/packages/eslint-plugin/configs/jsdoc.js
@@ -81,7 +81,7 @@ module.exports = {
 	},
 	rules: {
 		'jsdoc/no-undefined-types': [
-			'warn',
+			'error',
 			{
 				definedTypes: [
 					// Required to reference browser types because we don't have the `browser` environment enabled for the project.
@@ -94,6 +94,7 @@ module.exports = {
 					...temporaryWordPressInternalTypes,
 					...temporaryExternalTypes,
 					'void',
+					'JSX',
 				],
 			},
 		],


### PR DESCRIPTION
## Description

Increase the severity of `jsdoc/no-undefined-types`. 

## How has this been tested?

No warnings at lint.

## Screenshots

N/A

## Types of changes

Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [N/A] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [N/A] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [N/A] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [N/A] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
