### PR TITLE
Fix centered buttons margins

### DIFF
--- a/packages/block-library/src/button/editor.scss
+++ b/packages/block-library/src/button/editor.scss
@@ -1,10 +1,10 @@
-.wp-block[data-align="center"] .wp-block-button {
+.wp-block[data-align="center"] > .wp-block-button {
 	text-align: center;
 	margin-left: auto;
 	margin-right: auto;
 }
 
-.wp-block[data-align="right"] .wp-block-button {
+.wp-block[data-align="right"] > .wp-block-button {
 	/*!rtl:ignore*/
 	text-align: right;
 }


### PR DESCRIPTION
Small regression introduced  by #21822 

The buttons margins were collapsed if the buttons block was centered.

**Testing instructions**

 - Insert the "two buttons" pattern
 - The buttons should be separated with aa small margin. 