### PR TITLE
Try: Always full-height code editor

### DIFF
--- a/packages/edit-post/src/components/text-editor/style.scss
+++ b/packages/edit-post/src/components/text-editor/style.scss
@@ -3,10 +3,13 @@
 	width: 100%;
 	background-color: $white;
 	flex-grow: 1;
+	display: flex;
+	flex-direction: column;
 
 	// Always show outlines in code editor
 	.wp-block.editor-post-title {
 		max-width: none;
+		width: 100%;
 
 		textarea {
 			border: $border-width solid $light-gray-secondary;
@@ -22,19 +25,16 @@
 			padding: 0;
 		}
 	}
-
-	// Make room for toolbar.
-	padding-top: $block-toolbar-height + $grid-unit-10;
 }
 
 // Exit code editor toolbar.
 .edit-post-text-editor__toolbar {
-	position: absolute;
-	top: 0;
-	left: 0;
-	right: 0;
-	padding: $grid-unit-15;
 	display: flex;
+	padding: $grid-unit-05 $grid-unit-15;
+
+	@include break-small() {
+		padding: $grid-unit-15;
+	}
 
 	@include break-large() {
 		padding: $grid-unit-15 $grid-unit-30;
@@ -54,13 +54,15 @@
 
 .edit-post-text-editor__body {
 	width: 100%;
-	padding: $grid-unit-20 $grid-unit-15 $grid-unit-60 $grid-unit-15;
+	padding: 0 $grid-unit-15 $grid-unit-15 $grid-unit-15;
 	max-width: $break-wide;
 	margin-left: auto;
 	margin-right: auto;
+	display: flex;
+	flex-direction: column;
 
 	@include break-large() {
-		padding: $grid-unit-20 $grid-unit-30 #{ $grid-unit-60 * 2 } $grid-unit-30;
+		padding: 0 $grid-unit-30 $grid-unit-30 $grid-unit-30;
 	}
 
 	// This needs specificity to change the title block appearance on the code editor.

--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -129,8 +129,12 @@ export function initializeEditor(
 					editorScrollContainer.scrollTop =
 						editorScrollContainer.scrollTop + window.scrollY;
 				}
-				//Undo unwanted scroll on html element
-				window.scrollTo( 0, 0 );
+				// Undo unwanted scroll on html element, but only in the visual editor.
+				if (
+					! document.getElementsByClassName( 'is-mode-text' )[ 0 ]
+				) {
+					window.scrollTo( 0, 0 );
+				}
 			}
 		} );
 	}

--- a/packages/editor/src/components/post-text-editor/index.js
+++ b/packages/editor/src/components/post-text-editor/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import Textarea from 'react-autosize-textarea';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -74,7 +69,7 @@ export class PostTextEditor extends Component {
 				>
 					{ __( 'Type text or HTML' ) }
 				</VisuallyHidden>
-				<Textarea
+				<textarea
 					autoComplete="off"
 					dir="auto"
 					value={ value }

--- a/packages/editor/src/components/post-text-editor/style.scss
+++ b/packages/editor/src/components/post-text-editor/style.scss
@@ -1,28 +1,35 @@
-.edit-post-text-editor__body textarea.editor-post-text-editor {
-	border: $border-width solid $light-gray-secondary;
-	display: block;
-	margin: 0;
-	width: 100%;
-	box-shadow: none;
-	resize: none;
+.edit-post-text-editor__body {
+	height: 100%;
 	overflow: hidden;
-	font-family: $editor-html-font;
-	line-height: 150%;
-	border-radius: 0;
-	padding: $grid-unit-20;
-	min-height: 200px;
+	flex: 1;
 
-	/* Fonts smaller than 16px causes mobile safari to zoom. */
-	font-size: $mobile-text-min-font-size !important;
-	@include break-small {
-		font-size: $text-editor-font-size !important;
-	}
-
-	&:focus {
-		border: $border-width solid $dark-gray-primary;
+	textarea.editor-post-text-editor {
+		border: $border-width solid $light-gray-secondary;
+		display: block;
+		flex: 1;
+		margin: 0;
+		width: 100%;
 		box-shadow: none;
+		resize: none;
+		font-family: $editor-html-font;
+		line-height: 150%;
+		border-radius: 0;
+		padding: $grid-unit-20;
+		height: 100%;
+		overflow: auto;
 
-		// Elevate the z-index on focus so the focus style is uncropped.
-		position: relative;
+		/* Fonts smaller than 16px causes mobile safari to zoom. */
+		font-size: $mobile-text-min-font-size !important;
+		@include break-small {
+			font-size: $text-editor-font-size !important;
+		}
+
+		&:focus {
+			border: $border-width solid $dark-gray-primary;
+			box-shadow: none;
+
+			// Elevate the z-index on focus so the focus style is uncropped.
+			position: relative;
+		}
 	}
 }

--- a/packages/editor/src/components/post-text-editor/test/index.js
+++ b/packages/editor/src/components/post-text-editor/test/index.js
@@ -2,24 +2,17 @@
  * External dependencies
  */
 import { create } from 'react-test-renderer';
-import Textarea from 'react-autosize-textarea';
 
 /**
  * Internal dependencies
  */
 import { PostTextEditor } from '../';
 
-// "Downgrade" ReactAutosizeTextarea to a regular textarea. Assumes aligned
-// props interface.
-jest.mock( 'react-autosize-textarea', () => ( props ) => (
-	<textarea { ...props } />
-) );
-
 describe( 'PostTextEditor', () => {
 	it( 'should render via the prop value', () => {
 		const wrapper = create( <PostTextEditor value="Hello World" /> );
 
-		const textarea = wrapper.root.findByType( Textarea );
+		const textarea = wrapper.root.findByType( 'textarea' );
 		expect( textarea.props.value ).toBe( 'Hello World' );
 	} );
 
@@ -29,7 +22,7 @@ describe( 'PostTextEditor', () => {
 			<PostTextEditor value="Hello World" onChange={ onChange } />
 		);
 
-		const textarea = wrapper.root.findByType( Textarea );
+		const textarea = wrapper.root.findByType( 'textarea' );
 		textarea.props.onChange( { target: { value: 'Hello Chicken' } } );
 
 		expect( textarea.props.value ).toBe( 'Hello Chicken' );
@@ -42,7 +35,7 @@ describe( 'PostTextEditor', () => {
 			<PostTextEditor value="Hello World" onChange={ onChange } />
 		);
 
-		const textarea = wrapper.root.findByType( Textarea );
+		const textarea = wrapper.root.findByType( 'textarea' );
 		textarea.props.onChange( { target: { value: 'Hello Chicken' } } );
 
 		wrapper.update(
@@ -59,7 +52,7 @@ describe( 'PostTextEditor', () => {
 			<PostTextEditor value="Hello World" onChange={ onChange } />
 		);
 
-		const textarea = wrapper.root.findByType( Textarea );
+		const textarea = wrapper.root.findByType( 'textarea' );
 		textarea.props.onChange( { target: { value: '' } } );
 
 		wrapper.update(
@@ -80,7 +73,7 @@ describe( 'PostTextEditor', () => {
 			/>
 		);
 
-		const textarea = wrapper.root.findByType( Textarea );
+		const textarea = wrapper.root.findByType( 'textarea' );
 		textarea.props.onChange( { target: { value: '' } } );
 		textarea.props.onBlur();
 
@@ -97,7 +90,7 @@ describe( 'PostTextEditor', () => {
 			/>
 		);
 
-		const textarea = wrapper.root.findByType( Textarea );
+		const textarea = wrapper.root.findByType( 'textarea' );
 		textarea.props.onBlur();
 
 		expect( onPersist ).not.toHaveBeenCalled();
@@ -116,7 +109,7 @@ describe( 'PostTextEditor', () => {
 			/>
 		);
 
-		const textarea = wrapper.root.findByType( Textarea );
+		const textarea = wrapper.root.findByType( 'textarea' );
 		textarea.props.onChange( { target: { value: '' } } );
 
 		wrapper.update(

--- a/packages/editor/src/components/post-title/style.scss
+++ b/packages/editor/src/components/post-title/style.scss
@@ -1,5 +1,7 @@
 .editor-post-title {
 	position: relative;
+	// Don't allow larger than 30% title.
+	max-height: 30%;
 
 	.editor-post-title__input {
 		display: block;
@@ -11,10 +13,11 @@
 		@include reduce-motion("transition");
 		padding: #{ $block-padding + 5px } 0;
 		word-break: keep-all;
+		line-height: $default-line-height;
+		max-height: 100%;
 
 		// Inherit the styles set by the theme.
 		font-family: inherit;
-		line-height: inherit;
 		color: inherit;
 
 		// Stack borders on mobile.


### PR DESCRIPTION
This PR changes the code editor to not use the autosizing textarea component, and instead to scroll independently and be always full-height.

<img width="1232" alt="Screenshot 2020-04-28 at 15 54 52" src="https://user-images.githubusercontent.com/1204802/80496230-31e6c480-8969-11ea-8f2e-c1b9fecdfb55.png">

Part of the reason for this was that the autosizing textarea was potentially slow in Safari. Worth testing and comparing with this branch.