### PR TITLE
Update: Widgets screen show disabled inserter 

### DIFF
--- a/packages/edit-widgets/src/components/header/index.js
+++ b/packages/edit-widgets/src/components/header/index.js
@@ -16,7 +16,7 @@ function Header() {
 	return (
 		<div className="edit-widgets-header">
 			<NavigableMenu>
-				<Inserter.Slot />
+				<Inserter.Slot className="edit-widgets-inserter" />
 				<UndoButton />
 				<RedoButton />
 			</NavigableMenu>

--- a/packages/edit-widgets/src/components/header/style.scss
+++ b/packages/edit-widgets/src/components/header/style.scss
@@ -6,6 +6,10 @@
 	padding: 0 $grid-unit-20;
 }
 
+.edit-widgets-inserter {
+	display: inline-block;
+}
+
 .edit-widgets-header__title {
 	font-size: 16px;
 	padding: 0 20px;

--- a/packages/edit-widgets/src/components/inserter/index.js
+++ b/packages/edit-widgets/src/components/inserter/index.js
@@ -9,6 +9,8 @@ const { Fill: BlockInserterFill, Slot: BlockInserterSlot } = createSlotFill(
 
 const Inserter = BlockInserterFill;
 
-Inserter.Slot = BlockInserterSlot;
+Inserter.Slot = function( props ) {
+	return <BlockInserterSlot bubblesVirtually { ...props } />;
+};
 
 export default Inserter;

--- a/packages/edit-widgets/src/components/layout/index.js
+++ b/packages/edit-widgets/src/components/layout/index.js
@@ -8,7 +8,10 @@ import {
 	FocusReturnProvider,
 } from '@wordpress/components';
 import { useState } from '@wordpress/element';
-import { BlockEditorKeyboardShortcuts } from '@wordpress/block-editor';
+import {
+	BlockEditorKeyboardShortcuts,
+	Inserter as BlockEditorInserter,
+} from '@wordpress/block-editor';
 import { useViewportMatch } from '@wordpress/compose';
 import { InterfaceSkeleton } from '@wordpress/interface';
 
@@ -20,6 +23,9 @@ import Sidebar from '../sidebar';
 import WidgetAreas from '../widget-areas';
 import Notices from '../notices';
 import KeyboardShortcuts from '../keyboard-shortcuts';
+import Inserter from '../inserter';
+
+const disabledInserterToggleProps = { isPrimary: true, disabled: true };
 
 function Layout( { blockEditorSettings } ) {
 	const [ selectedArea, setSelectedArea ] = useState( null );
@@ -55,6 +61,15 @@ function Layout( { blockEditorSettings } ) {
 											}
 										/>
 									</div>
+									{ selectedArea === null && (
+										<Inserter>
+											<BlockEditorInserter
+												toggleProps={
+													disabledInserterToggleProps
+												}
+											/>
+										</Inserter>
+									) }
 								</>
 							}
 						/>


### PR DESCRIPTION
This PR makes the widget screen shows a disabled inserter when there is no widget area selected. On master, we don't show an inserter at all in that case. This change makes sure the inserter is always visible similar to what happen in other screens.
