### PR TITLE
Edit Site: Extract gutenberg_find_template_post helper, use in edit-site-page

### DIFF
--- a/lib/edit-site-page.php
+++ b/lib/edit-site-page.php
@@ -183,7 +183,7 @@ function gutenberg_edit_site_init( $hook ) {
 	}
 	get_front_page_template();
 	get_index_template();
-	$current_template_post = gutenberg_find_template_post( $_wp_current_template_hierarchy );
+	$current_template_post                             = gutenberg_find_template_post( $_wp_current_template_hierarchy );
 	$template_ids[ $current_template_post->post_name ] = $current_template_post->ID;
 	if ( isset( $_wp_current_template_part_ids ) ) {
 		$template_part_ids = $template_part_ids + $_wp_current_template_part_ids;

--- a/lib/edit-site-page.php
+++ b/lib/edit-site-page.php
@@ -89,9 +89,6 @@ function gutenberg_get_editor_styles() {
  */
 function gutenberg_edit_site_init( $hook ) {
 	global
-		$_wp_current_template_id,
-		$_wp_current_template_name,
-		$_wp_current_template_content,
 		$_wp_current_template_hierarchy,
 		$_wp_current_template_part_ids,
 		$current_screen;
@@ -171,30 +168,30 @@ function gutenberg_edit_site_init( $hook ) {
 	$template_ids      = array();
 	$template_part_ids = array();
 	foreach ( $template_getters as $template_getter ) {
-		call_user_func( $template_getter );
-		apply_filters( 'template_include', null );
-		if ( isset( $_wp_current_template_id ) ) {
-			$template_ids[ $_wp_current_template_name ] = $_wp_current_template_id;
+		call_user_func( $template_getter ); // This sets $_wp_current_template_hierarchy
+
+		$current_template_post = gutenberg_find_template_post( $_wp_current_template_hierarchy );
+		if ( isset( $current_template_post ) ) {
+			$template_ids[ $current_template_post->post_name ] = $current_template_post->ID;
 		}
 		if ( isset( $_wp_current_template_part_ids ) ) {
 			$template_part_ids = $template_part_ids + $_wp_current_template_part_ids;
 		}
-		$_wp_current_template_id        = null;
-		$_wp_current_template_name      = null;
-		$_wp_current_template_content   = null;
+
 		$_wp_current_template_hierarchy = null;
 		$_wp_current_template_part_ids  = null;
 	}
 	get_front_page_template();
 	get_index_template();
-	apply_filters( 'template_include', null );
-	$template_ids[ $_wp_current_template_name ] = $_wp_current_template_id;
+	$current_template_post = gutenberg_find_template_post( $_wp_current_template_hierarchy );
+	$template_ids[ $current_template_post->post_name ] = $current_template_post->ID;
 	if ( isset( $_wp_current_template_part_ids ) ) {
 		$template_part_ids = $template_part_ids + $_wp_current_template_part_ids;
 	}
-	$settings['templateId']      = $_wp_current_template_id;
+	$settings['templateId']      = $current_template_post->ID;
 	$settings['templateType']    = 'wp_template';
 	$settings['templateIds']     = array_values( $template_ids );
+	$settings['templateIdsAll']  = $template_ids;
 	$settings['templatePartIds'] = array_values( $template_part_ids );
 	$settings['styles']          = gutenberg_get_editor_styles();
 
@@ -210,7 +207,7 @@ function gutenberg_edit_site_init( $hook ) {
 		'/wp/v2/types?context=edit',
 		'/wp/v2/taxonomies?per_page=-1&context=edit',
 		'/wp/v2/themes?status=active',
-		sprintf( '/wp/v2/templates/%s?context=edit', $_wp_current_template_id ),
+		sprintf( '/wp/v2/templates/%s?context=edit', $current_template_post->ID ),
 		array( '/wp/v2/media', 'OPTIONS' ),
 	);
 	$preload_data  = array_reduce(

--- a/lib/edit-site-page.php
+++ b/lib/edit-site-page.php
@@ -168,7 +168,7 @@ function gutenberg_edit_site_init( $hook ) {
 	$template_ids      = array();
 	$template_part_ids = array();
 	foreach ( $template_getters as $template_getter ) {
-		call_user_func( $template_getter ); // This sets $_wp_current_template_hierarchy
+		call_user_func( $template_getter ); // This sets $_wp_current_template_hierarchy.
 
 		$current_template_post = gutenberg_find_template_post( $_wp_current_template_hierarchy );
 		if ( isset( $current_template_post ) ) {

--- a/lib/edit-site-page.php
+++ b/lib/edit-site-page.php
@@ -191,7 +191,6 @@ function gutenberg_edit_site_init( $hook ) {
 	$settings['templateId']      = $current_template_post->ID;
 	$settings['templateType']    = 'wp_template';
 	$settings['templateIds']     = array_values( $template_ids );
-	$settings['templateIdsAll']  = $template_ids;
 	$settings['templatePartIds'] = array_values( $template_part_ids );
 	$settings['styles']          = gutenberg_get_editor_styles();
 

--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -188,7 +188,7 @@ function gutenberg_template_include_filter( $template_file ) {
  * Return the correct 'wp_template' post for the current template hierarchy.
  *
  * @param string[] $template_hierarchy The current template hierarchy, ordered by priority.
- * @return WP_Post|null         A template post object, or null if none could be found.
+ * @return WP_Post|null A template post object, or null if none could be found.
  */
 function gutenberg_find_template_post( $template_hierarchy ) {
 	if ( ! $template_hierarchy ) {

--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -43,7 +43,7 @@ function gutenberg_add_template_loader_filters() {
 		add_filter( $template_type . '_template', 'gutenberg_override_query_template', 20, 3 );
 	}
 
-	add_filter( 'template_include', 'gutenberg_find_template', 20 );
+	add_filter( 'template_include', 'gutenberg_template_include_filter', 20 );
 }
 add_action( 'wp_loaded', 'gutenberg_add_template_loader_filters' );
 
@@ -53,7 +53,7 @@ add_action( 'wp_loaded', 'gutenberg_add_template_loader_filters' );
  * The method returns an empty result for every template so that a 'wp_template' post
  * is used instead.
  *
- * @see gutenberg_find_template
+ * @see gutenberg_template_include_filter
  *
  * @param string $template  Path to the template. See locate_template().
  * @param string $type      Sanitized filename without extension.
@@ -159,7 +159,7 @@ function create_auto_draft_for_template_part_block( $block ) {
  * @param string $template_file Original template file. Will be overridden.
  * @return string Path to the canvas file to include.
  */
-function gutenberg_find_template( $template_file ) {
+function gutenberg_template_include_filter( $template_file ) {
 	global $_wp_current_template_id, $_wp_current_template_name, $_wp_current_template_content, $_wp_current_template_hierarchy;
 
 	// Bail if no relevant template hierarchy was determined, or if the template file
@@ -172,6 +172,34 @@ function gutenberg_find_template( $template_file ) {
 		'gutenberg_strip_php_suffix',
 		$_wp_current_template_hierarchy
 	);
+
+	$current_template_post = gutenberg_find_template_post( $slugs );
+
+	if ( $current_template_post ) {
+		$_wp_current_template_id      = $current_template_post->ID;
+		$_wp_current_template_name    = $current_template_post->post_name;
+		$_wp_current_template_content = empty( $current_template_post->post_content ) ? __( 'Empty template.', 'gutenberg' ) : $current_template_post->post_content;
+	}
+
+	// Add extra hooks for template canvas.
+	add_action( 'wp_head', 'gutenberg_viewport_meta_tag', 0 );
+	remove_action( 'wp_head', '_wp_render_title_tag', 1 );
+	add_action( 'wp_head', 'gutenberg_render_title_tag', 1 );
+
+	// This file will be included instead of the theme's template file.
+	return gutenberg_dir_path() . 'lib/template-canvas.php';
+}
+
+/**
+ * Return the correct 'wp_template' post for the current hierarchy of template slugs.
+ *
+ * @param  string[]     $slugs  A list of candidate template slugs, ordered by priority in the current template hierarchy.
+ * @return WP_Post|null         A template post object, or null if none could be found.
+ */
+function gutenberg_find_template_post( $slugs ) {
+	if ( ! $slugs ) {
+		return null;
+	}
 
 	// Find most specific 'wp_template' post matching the hierarchy.
 	$template_query = new WP_Query(
@@ -257,18 +285,9 @@ function gutenberg_find_template( $template_file ) {
 				create_auto_draft_for_template_part_block( $block );
 			}
 		}
-		$_wp_current_template_id      = $current_template_post->ID;
-		$_wp_current_template_name    = $current_template_post->post_name;
-		$_wp_current_template_content = empty( $current_template_post->post_content ) ? __( 'Empty template.', 'gutenberg' ) : $current_template_post->post_content;
+		return $current_template_post;
 	}
-
-	// Add extra hooks for template canvas.
-	add_action( 'wp_head', 'gutenberg_viewport_meta_tag', 0 );
-	remove_action( 'wp_head', '_wp_render_title_tag', 1 );
-	add_action( 'wp_head', 'gutenberg_render_title_tag', 1 );
-
-	// This file will be included instead of the theme's template file.
-	return gutenberg_dir_path() . 'lib/template-canvas.php';
+	return null;
 }
 
 /**

--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -160,7 +160,7 @@ function create_auto_draft_for_template_part_block( $block ) {
  * @return string Path to the canvas file to include.
  */
 function gutenberg_template_include_filter( $template_file ) {
-	global $_wp_current_template_id, $_wp_current_template_name, $_wp_current_template_content, $_wp_current_template_hierarchy;
+	global $_wp_current_template_id, $_wp_current_template_content, $_wp_current_template_hierarchy;
 
 	// Bail if no relevant template hierarchy was determined, or if the template file
 	// was overridden another way.
@@ -168,16 +168,10 @@ function gutenberg_template_include_filter( $template_file ) {
 		return $template_file;
 	}
 
-	$slugs = array_map(
-		'gutenberg_strip_php_suffix',
-		$_wp_current_template_hierarchy
-	);
-
-	$current_template_post = gutenberg_find_template_post( $slugs );
+	$current_template_post = gutenberg_find_template_post( $_wp_current_template_hierarchy );
 
 	if ( $current_template_post ) {
 		$_wp_current_template_id      = $current_template_post->ID;
-		$_wp_current_template_name    = $current_template_post->post_name;
 		$_wp_current_template_content = empty( $current_template_post->post_content ) ? __( 'Empty template.', 'gutenberg' ) : $current_template_post->post_content;
 	}
 
@@ -191,15 +185,20 @@ function gutenberg_template_include_filter( $template_file ) {
 }
 
 /**
- * Return the correct 'wp_template' post for the current hierarchy of template slugs.
+ * Return the correct 'wp_template' post for the current template hierarchy.
  *
- * @param  string[]     $slugs  A list of candidate template slugs, ordered by priority in the current template hierarchy.
+ * @param  string[]     $slugs  The current template hierarchy, ordered by priority.
  * @return WP_Post|null         A template post object, or null if none could be found.
  */
-function gutenberg_find_template_post( $slugs ) {
-	if ( ! $slugs ) {
+function gutenberg_find_template_post( $template_hierarchy ) {
+	if ( ! $template_hierarchy ) {
 		return null;
 	}
+
+	$slugs = array_map(
+		'gutenberg_strip_php_suffix',
+		$template_hierarchy
+	);
 
 	// Find most specific 'wp_template' post matching the hierarchy.
 	$template_query = new WP_Query(

--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -187,7 +187,7 @@ function gutenberg_template_include_filter( $template_file ) {
 /**
  * Return the correct 'wp_template' post for the current template hierarchy.
  *
- * @param  string[]     $slugs  The current template hierarchy, ordered by priority.
+ * @param string[] $template_hierarchy The current template hierarchy, ordered by priority.
  * @return WP_Post|null         A template post object, or null if none could be found.
  */
 function gutenberg_find_template_post( $template_hierarchy ) {


### PR DESCRIPTION
## Description
Extract a `gutenberg_find_template_post` helper function from `gutenberg_find_template`, and rename the latter to `gutenberg_template_include_filter`. Unlike the original function, `gutenberg_find_template_post` makes no references to globals, and can thus be used in `edit-site-page.php` without resorting to as many globals as before. (I've previously found the code in `edit-site-page.php` somewhat hard to read, since it wasn't immediately clear where those globals where coming from.)

This is a preparatory step to better encapsulate the logic that determines the relevant template post for a given page, so it can be more easily reused. Specifically, it's meant as a preparation for implementing an endpoint flag that would make the `wp_template` collection endpoint return only relevant templates, as discussed [here](https://github.com/WordPress/gutenberg/pull/21877/files#r416069139).

(In a follow-up, I might try to get rid of some other `$_wp_current_template_*` globals.)

## How has this been tested?
Verify that Full Site Editing still works as before. Specifically, verify that the template switcher still holds the same templates as on `master`, and that loading them (both front-end and editor) still works.

## Types of changes
Small refactor.

## Checklist:
- [x] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
