### PR TITLE
Use optional chaining, optional catch binding.

### DIFF
--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -326,9 +326,9 @@ function LinkControl( {
 	 * the next render, if focus was within the wrapper when editing finished.
 	 */
 	function stopEditing() {
-		isEndingEditWithFocus.current =
-			!! wrapperNode.current &&
-			wrapperNode.current.contains( document.activeElement );
+		isEndingEditWithFocus.current = wrapperNode.current?.contains(
+			document.activeElement
+		);
 
 		setIsEditingLink( false );
 	}

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -326,7 +326,7 @@ function LinkControl( {
 	 * the next render, if focus was within the wrapper when editing finished.
 	 */
 	function stopEditing() {
-		isEndingEditWithFocus.current = wrapperNode.current?.contains(
+		isEndingEditWithFocus.current = !! wrapperNode.current?.contains(
 			document.activeElement
 		);
 

--- a/packages/url/src/is-url.js
+++ b/packages/url/src/is-url.js
@@ -19,7 +19,7 @@ export function isURL( url ) {
 	try {
 		new URL( url );
 		return true;
-	} catch ( error ) {
+	} catch {
 		return false;
 	}
 }


### PR DESCRIPTION
## Description

Now that docgen parser has been changed to babel (#21853), we can freely use ES2020 features! 🎉

## How has this been tested?

`npm run docs:build` doesn't fail.

## Screenshots

N/A

## Types of changes

Bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [N/A] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [N/A] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [N/A] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [N/A] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
