### PR TITLE
font-size presets: fix specificity in editor

### DIFF
--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -216,23 +216,32 @@
 
 
 // Font sizes.
+// The reason we add the editor class wrapper here is
+// to avoid enqueing the classes twice: here and in ./editor.scss
+.editor-styles-wrapper .has-small-font-size,
 .has-small-font-size {
 	font-size: 13px;
 }
 
+.editor-styles-wrapper .has-regular-font-size,
+.editor-styles-wrapper .has-normal-font-size,
 .has-regular-font-size, // Not used now, kept because of backward compatibility.
 .has-normal-font-size {
 	font-size: 16px;
 }
 
+.editor-styles-wrapper .has-medium-font-size,
 .has-medium-font-size {
 	font-size: 20px;
 }
 
+.editor-styles-wrapper .has-large-font-size,
 .has-large-font-size {
 	font-size: 36px;
 }
 
+.editor-styles-wrapper .has-larger-font-size,
+.editor-styles-wrapper .has-huge-font-size,
 .has-larger-font-size, // Not used now, kept because of backward compatibility.
 .has-huge-font-size {
 	font-size: 42px;

--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -216,30 +216,27 @@
 
 
 // Font sizes.
-:root {
-	.has-small-font-size {
-		font-size: 13px;
-	}
-
-	.has-regular-font-size, // Not used now, kept because of backward compatibility.
-	.has-normal-font-size {
-		font-size: 16px;
-	}
-
-	.has-medium-font-size {
-		font-size: 20px;
-	}
-
-	.has-large-font-size {
-		font-size: 36px;
-	}
-
-	.has-larger-font-size, // Not used now, kept because of backward compatibility.
-	.has-huge-font-size {
-		font-size: 42px;
-	}
+.has-small-font-size {
+	font-size: 13px;
 }
 
+.has-regular-font-size, // Not used now, kept because of backward compatibility.
+.has-normal-font-size {
+	font-size: 16px;
+}
+
+.has-medium-font-size {
+	font-size: 20px;
+}
+
+.has-large-font-size {
+	font-size: 36px;
+}
+
+.has-larger-font-size, // Not used now, kept because of backward compatibility.
+.has-huge-font-size {
+	font-size: 42px;
+}
 
 // Text alignments.
 .has-text-align-center {


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/21759

This is a leftover of an experiment where we introduced [font-size declarations in the blocks by default](https://github.com/WordPress/gutenberg/pull/21153) that we reverted [later](https://github.com/WordPress/gutenberg/pull/21428).