### PR TITLE
Fix list block not properly aligned

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -251,10 +251,13 @@
 	}
 }
 
-.wp-block {
+// Extra specificity needed to override default element margins like lists (ul).
+.block-editor-block-list__layout .wp-block {
 	margin-left: auto;
 	margin-right: auto;
+}
 
+.wp-block {
 	// Alignments.
 	&[data-align="left"],
 	&[data-align="right"] {


### PR DESCRIPTION
closes #21961

In #20951 I updated the "centering" of blocks to avoid relying on `editor-*` classNames. The idea is that the blocks should be centered regardless of the context of the block editor. This fixed the issue we had with block previews not centered properly.

But the reduced specificity cause conflicts with editor styles (list), so lists were not aligned properly. This PR restores the level of specificity but keeps the generic styles solving both issues at the same time.

**Testing instructions**

 - Insert list block and make sure it's aligned properly.