### PR TITLE
Optimize BlockStyles by using hooks and React.memo (instead of HOCs)

### DIFF
--- a/packages/block-editor/src/components/block-styles/index.js
+++ b/packages/block-editor/src/components/block-styles/index.js
@@ -7,6 +7,8 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
+import isShallowEqual from '@wordpress/is-shallow-equal';
+import { memo } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { withSelect, withDispatch } from '@wordpress/data';
 import TokenList from '@wordpress/token-list';
@@ -74,6 +76,8 @@ function BlockStyles( {
 	onChangeClassName,
 	type,
 	block,
+	blockName,
+	useExample,
 	onSwitch = noop,
 	onHoverClassName = noop,
 } ) {
@@ -143,8 +147,8 @@ function BlockStyles( {
 							<BlockPreview
 								viewportWidth={ 500 }
 								blocks={
-									type.example
-										? getBlockFromExample( block.name, {
+									useExample
+										? getBlockFromExample( blockName, {
 												attributes: {
 													...type.example.attributes,
 													className: styleClassName,
@@ -174,13 +178,19 @@ export default compose( [
 		const { getBlockStyles } = select( 'core/blocks' );
 		const block = getBlock( clientId );
 		const blockType = getBlockType( block.name );
+		const useExample = !! blockType.example;
 
-		return {
-			block,
+		const props = {
+			useExample,
+			blockName: block.name,
 			className: block.attributes.className || '',
 			styles: getBlockStyles( block.name ),
 			type: blockType,
 		};
+		if ( ! useExample ) {
+			props.block = block;
+		}
+		return props;
 	} ),
 	withDispatch( ( dispatch, { clientId } ) => {
 		return {
@@ -194,4 +204,4 @@ export default compose( [
 			},
 		};
 	} ),
-] )( BlockStyles );
+] )( memo( BlockStyles, isShallowEqual ) );


### PR DESCRIPTION
## Description

BlockStyles depend on the value of a `block`, which means they're re-rendered every time an attribute is updated. This is pretty slow, especially if it happens after every key stroke (see #21948). This PR leverages `React.memo` and `useSelect` to avoid re-renders in cases where block example is available.

## Test plan
* To test the case where example is available, create a navigation block.
* Select your new block, open block inspector, change style a few times, change background color, confirm the styles are rendered correctly.
* To test the case where example is available, manually remove the example from `packages/block-library/src/navigation/index.js` and repeat previous steps. I think all core blocks come with an example so it seems to be the easiest way to test. In this scenario, confirm that the style preview is updated to reflect all the updates to block attributes - e.g. changing background color should be reflected in the preview right away.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
