### PR TITLE
Templates Endpoint: Add `resolved` query arg to return only relevant templates

### DIFF
--- a/lib/edit-site-page.php
+++ b/lib/edit-site-page.php
@@ -152,8 +152,7 @@ function gutenberg_edit_site_init( $hook ) {
 			continue;
 		}
 
-		$template_hierarchy = array_merge( get_template_hierachy( $template_type ), get_template_hierachy( 'index' ) );
-		$current_template   = gutenberg_find_template_post_and_parts( $template_hierarchy );
+		$current_template = gutenberg_find_template_post_and_parts( $template_type );
 		if ( isset( $current_template ) ) {
 			$template_ids[ $current_template['template_post']->post_name ] = $current_template['template_post']->ID;
 			$template_part_ids = $template_part_ids + $current_template['template_part_ids'];

--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -93,7 +93,7 @@ function get_template_hierachy( $template_type ) {
 function gutenberg_override_query_template( $template, $type, array $templates = array() ) {
 	global $_wp_current_template_id, $_wp_current_template_content;
 
-	$current_template = gutenberg_find_template_post_and_parts( $templates );
+	$current_template = gutenberg_find_template_post_and_parts( basename( $template, '.php' ), $templates );
 
 	if ( $current_template ) {
 		$_wp_current_template_id      = $current_template['template_post']->ID;
@@ -191,17 +191,28 @@ function create_auto_draft_for_template_part_block( $block ) {
 }
 
 /**
- * Return the correct 'wp_template' post and template part IDs for the current template hierarchy.
+ * Return the correct 'wp_template' post and template part IDs for the current template.
  *
- * @param string[] $template_hierarchy The current template hierarchy, ordered by priority.
+ * Accepts an optional $template_hierarchy argument as a hint.
+ *
+ * @param string   $template_type The current template type.
+ * @param string[] $template_hierarchy (optional) The current template hierarchy, ordered by priority.
  * @return null|array {
  *  @type WP_Post|null template_post A template post object, or null if none could be found.
  *  @type int[] A list of template parts IDs for the template.
  * }
  */
-function gutenberg_find_template_post_and_parts( $template_hierarchy ) {
-	if ( ! $template_hierarchy ) {
+function gutenberg_find_template_post_and_parts( $template_type, $template_hierarchy = array() ) {
+	if ( ! $template_type ) {
 		return null;
+	}
+
+	if ( empty( $template_hierarchy ) ) {
+		if ( 'index' === $template_type ) {
+			$template_hierarchy = get_template_hierachy( 'index' );
+		} else {
+			$template_hierarchy = array_merge( get_template_hierachy( $template_type ), get_template_hierachy( 'index' ) );
+		}
 	}
 
 	$slugs = array_map(

--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -195,7 +195,7 @@ function create_auto_draft_for_template_part_block( $block ) {
  *
  * Accepts an optional $template_hierarchy argument as a hint.
  *
- * @param string   $template_type The current template type.
+ * @param string   $template_type      The current template type.
  * @param string[] $template_hierarchy (optional) The current template hierarchy, ordered by priority.
  * @return null|array {
  *  @type WP_Post|null template_post A template post object, or null if none could be found.

--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -234,6 +234,10 @@ function gutenberg_find_template_post_and_parts( $template_type, $template_hiera
 
 	$current_template_post = $template_query->have_posts() ? $template_query->next_post() : null;
 
+	// TODO: We could consider moving the following logic to a hook like `posts_results` that is run
+	// after query results have been fetched. That might allow us to absorb filtering logic
+	// (as e.g. found in `filter_rest_wp_template_query`) into the generic querying logic.
+
 	// Build map of template slugs to their priority in the current hierarchy.
 	$slug_priorities = array_flip( $slugs );
 

--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -234,10 +234,6 @@ function gutenberg_find_template_post_and_parts( $template_type, $template_hiera
 
 	$current_template_post = $template_query->have_posts() ? $template_query->next_post() : null;
 
-	// TODO: We could consider moving the following logic to a hook like `posts_results` that is run
-	// after query results have been fetched. That might allow us to absorb filtering logic
-	// (as e.g. found in `filter_rest_wp_template_query`) into the generic querying logic.
-
 	// Build map of template slugs to their priority in the current hierarchy.
 	$slug_priorities = array_flip( $slugs );
 

--- a/lib/templates.php
+++ b/lib/templates.php
@@ -183,9 +183,9 @@ apply_filters( 'rest_wp_template_collection_params', 'filter_rest_wp_template_co
 function filter_rest_wp_template_query( $args, $request ) {
 	if ( $request['resolved'] ) {
 		$template_ids  = array( 0 ); // Return nothing by default (the 0 is needed for `post__in`).
-		$template_type = $request['slug'] ? array( $request['slug'] ) : get_template_types();
+		$template_types = $request['slug'] ? array( $request['slug'] ) : get_template_types();
 
-		foreach ( get_template_types() as $template_type ) {
+		foreach ( $template_types as $template_type ) {
 			// Skip 'embed' for now because it is not a regular template type.
 			// Skip 'index' because it's a fallback that we handle differently.
 			if ( in_array( $template_type, array( 'embed', 'index' ), true ) ) {

--- a/lib/templates.php
+++ b/lib/templates.php
@@ -182,7 +182,7 @@ apply_filters( 'rest_wp_template_collection_params', 'filter_rest_wp_template_co
  */
 function filter_rest_wp_template_query( $args, $request ) {
 	if ( $request['resolved'] ) {
-		$template_ids  = array( 0 ); // Return nothing by default (the 0 is needed for `post__in`).
+		$template_ids   = array( 0 ); // Return nothing by default (the 0 is needed for `post__in`).
 		$template_types = $request['slug'] ? array( $request['slug'] ) : get_template_types();
 
 		foreach ( $template_types as $template_type ) {

--- a/lib/templates.php
+++ b/lib/templates.php
@@ -192,6 +192,10 @@ function filter_rest_wp_template_query( $args, $request ) {
 				continue;
 			}
 
+			// TODO: gutenberg_find_template_post_and_parts() internally performs a query.
+			// This means that there's room for optimization, and we might be able to
+			// generalize the logic found here into something that runs upon every `wp_template`
+			// query (not just those coming from the REST API).
 			$current_template = gutenberg_find_template_post_and_parts( $template_type );
 			if ( isset( $current_template ) ) {
 				$template_ids[ $current_template['template_post']->post_name ] = $current_template['template_post']->ID;

--- a/lib/templates.php
+++ b/lib/templates.php
@@ -155,3 +155,51 @@ function gutenberg_render_template_list_table_column( $column_name, $post_id ) {
 	echo esc_html( $post->post_name );
 }
 add_action( 'manage_wp_template_posts_custom_column', 'gutenberg_render_template_list_table_column', 10, 2 );
+
+/**
+ * Filter for adding a `resolved` parameter to `wp_template` queries.
+ *
+ * @param array $query_params The query parameters.
+ * @return array Filtered $query_params.
+ */
+function filter_rest_wp_template_collection_params( $query_params ) {
+	$query_params += array(
+		'resolved' => array(
+			'description' => __( 'Whether to filter for resolved templates', 'gutenberg' ),
+			'type'        => 'boolean',
+		),
+	);
+	return $query_params;
+}
+apply_filters( 'rest_wp_template_collection_params', 'filter_rest_wp_template_collection_params', 99, 1 );
+
+/**
+ * Filter for supporting the `resolved` parameter in `wp_template` queries.
+ *
+ * @param array           $args    The query arguments.
+ * @param WP_REST_Request $request The request object.
+ * @return array Filtered $args.
+ */
+function filter_rest_wp_template_query( $args, $request ) {
+	if ( $request['resolved'] ) {
+		$template_ids  = array( 0 ); // Return nothing by default (the 0 is needed for `post__in`).
+		$template_type = $request['slug'] ? array( $request['slug'] ) : get_template_types();
+
+		foreach ( get_template_types() as $template_type ) {
+			// Skip 'embed' for now because it is not a regular template type.
+			// Skip 'index' because it's a fallback that we handle differently.
+			if ( in_array( $template_type, array( 'embed', 'index' ), true ) ) {
+				continue;
+			}
+
+			$current_template = gutenberg_find_template_post_and_parts( $template_type );
+			if ( isset( $current_template ) ) {
+				$template_ids[ $current_template['template_post']->post_name ] = $current_template['template_post']->ID;
+			}
+		}
+		$args['post__in'] = array_values( $template_ids );
+	}
+
+	return $args;
+}
+add_filter( 'rest_wp_template_query', 'filter_rest_wp_template_query', 99, 2 );

--- a/lib/templates.php
+++ b/lib/templates.php
@@ -192,10 +192,6 @@ function filter_rest_wp_template_query( $args, $request ) {
 				continue;
 			}
 
-			// TODO: gutenberg_find_template_post_and_parts() internally performs a query.
-			// This means that there's room for optimization, and we might be able to
-			// generalize the logic found here into something that runs upon every `wp_template`
-			// query (not just those coming from the REST API).
 			$current_template = gutenberg_find_template_post_and_parts( $template_type );
 			if ( isset( $current_template ) ) {
 				$template_ids[ $current_template['template_post']->post_name ] = $current_template['template_post']->ID;


### PR DESCRIPTION
## Description
Implements https://github.com/WordPress/gutenberg/pull/21877/files#r416075231 and unblocks #21877.

This PR changes `gutenberg_find_template_post_and_parts()` to accept a `$template_type` arg, and make the `$template_hierarchy` arg optional. `$template_hierarchy` will be used as a hint if it's present (e.g. when called from a `{$type}_template` hook); if it isn't, the template hierarchy will be looked up for `$template_type`.

This allows writing the code in `edit-site-page.php` in a more succinct way. More importantly, it allows us to add a `rest_wp_template_query` filter for the `wp_template` collection endpoint to accept a `resolved` bool arg that will cause the endpoint to reflect the behavior of the template resolution algorithm that's used to populate the `$settings[ 'templateIds' ]` ([see](https://github.com/WordPress/gutenberg/pull/21877/files#r415995080)):

> Published templates are always used first and mean the template was customized. Auto drafts are only used when the templates haven't been customized. We should preferably use the latest ones

## How has this been tested?

As always, make sure that the Full-Site Editing experiment and demo templates are enabled.

We'll compare the results the `wp_template` collections REST API endpoint gives to `$settings['templateIds']`. To that end, apply the following patch and re-build the app (`npm run build`):

```diff
diff --git a/packages/edit-site/src/index.js b/packages/edit-site/src/index.js
index e6dec20771..ea72bee4c9 100644
--- a/packages/edit-site/src/index.js
+++ b/packages/edit-site/src/index.js
@@ -26,6 +26,7 @@ export function initialize( id, settings ) {
        if ( process.env.GUTENBERG_PHASE === 2 ) {
                __experimentalRegisterExperimentalCoreBlocks( settings );
        }
+       console.log( 'settings', settings );
        render( <Editor settings={ settings } />, document.getElementById( id ) );
 }

```

Next, in wp-admin, navigate to the Appearance > Templates section, and create a few dummy templates whose names are **not** actually part of the template hierarchy (e.g. `some-template` etc).

Now go to Full-Site Editing and open your browser console. You should see the output of the `settings` variable there. Compare the `templateIds` property to the output of the following commands you run in the console (twice each!). Icons :heavy_check_mark: and :x: indicate whether the output is expected to match `settings.templateIds`, or not.

- :x: `wp.data.select('core').getEntityRecords('postType', 'wp_template' )` should return the list of all `wp_template` CPTs, including those that are not part of the template hierarchy.
- :heavy_check_mark: `wp.data.select('core').getEntityRecords('postType', 'wp_template', { resolved: true } )` should return the list of templates that match the template hierarchy.
- :x: `wp.data.select('core').getEntityRecords('postType', 'wp_template', { slug: 'some-template' } )` should return the `wp_template` part whose slug is `some-template`.
- :heavy_check_mark: `wp.data.select('core').getEntityRecords('postType', 'wp_template', { slug: 'some-template', resolved: true } )` should return an empty array, as `some-template` is not part of the template hierarchy.

## Types of changes
Add an arg to an existing endpoint; plus a minor refactor.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
