### PR TITLE
Make reusable block e2e tests independent.

### DIFF
--- a/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
@@ -20,6 +20,8 @@ function waitForAndAcceptDialog() {
 async function removeReusableBlocks() {
 	await visitAdminPage( 'edit.php', [ 'post_type=wp_block' ] );
 
+	await page.waitForSelector( '#cb-select-all-1' );
+
 	const checkall = await page.$( '#cb-select-all-1' );
 
 	await checkall.click();

--- a/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
@@ -4,6 +4,7 @@
 import {
 	insertBlock,
 	createNewPost,
+	visitAdminPage,
 	clickBlockToolbarButton,
 	pressKeyWithModifier,
 	searchForBlock,
@@ -16,94 +17,128 @@ function waitForAndAcceptDialog() {
 	} );
 }
 
+async function removeReusableBlocks() {
+	await visitAdminPage( 'edit.php', [ 'post_type=wp_block' ] );
+
+	const checkall = await page.$( '#cb-select-all-1' );
+
+	await checkall.click();
+
+	await page.select( '#bulk-action-selector-top', 'trash' );
+
+	const applyButton = await page.$( '#doaction' );
+
+	await applyButton.click();
+}
+
+const createReusableBlockWithSingleBlock = async ( blockName ) => {
+	// Insert a paragraph block
+	await insertBlock( 'Paragraph' );
+	await page.keyboard.type( 'Hello there!' );
+	await clickBlockToolbarButton( 'More options' );
+	const convertButton = await page.waitForXPath(
+		'//button[text()="Add to Reusable blocks"]'
+	);
+	await convertButton.click();
+	// Wait for creation to finish
+	await page.waitForXPath(
+		'//*[contains(@class, "components-snackbar")]/*[text()="Block created."]'
+	);
+
+	if ( blockName ) {
+		// Select all of the text in the title field.
+		await pressKeyWithModifier( 'primary', 'a' );
+		// Give the reusable block a title
+		await page.keyboard.type( blockName );
+	}
+
+	// Save the reusable block
+	const [ saveButton ] = await page.$x( '//button[text()="Save"]' );
+	await saveButton.click();
+	// Wait for saving to finish
+	await page.waitForXPath( '//button[text()="Edit"]' );
+};
+
+const createReusableBlockWithMultipleBlocks = async ( blockName ) => {
+	// Insert a Two paragraphs block
+	await insertBlock( 'Paragraph' );
+	await page.keyboard.type( 'Hello there!' );
+	await page.keyboard.press( 'Enter' );
+	await page.keyboard.type( 'Second paragraph' );
+
+	// Select all the blocks
+	await pressKeyWithModifier( 'primary', 'a' );
+	await pressKeyWithModifier( 'primary', 'a' );
+
+	// Convert block to a reusable block
+	await clickBlockToolbarButton( 'More options' );
+	const convertButton = await page.waitForXPath(
+		'//button[text()="Add to Reusable blocks"]'
+	);
+	await convertButton.click();
+
+	// Wait for creation to finish
+	await page.waitForXPath(
+		'//*[contains(@class, "components-snackbar")]/*[text()="Block created."]'
+	);
+
+	// Select all of the text in the title field.
+	await pressKeyWithModifier( 'primary', 'a' );
+
+	// Give the reusable block a title
+	await page.keyboard.type( blockName );
+
+	// Save the reusable block
+	const [ saveButton ] = await page.$x( '//button[text()="Save"]' );
+	await saveButton.click();
+
+	// Wait for saving to finish
+	await page.waitForXPath( '//button[text()="Edit"]' );
+};
+
+const clearEditor = async () => {
+	await page.evaluate( () => {
+		const blocks = wp.data.select( 'core/block-editor' ).getBlocks();
+		const clientIds = blocks.map( ( block ) => block.clientId );
+		wp.data.dispatch( 'core/block-editor' ).removeBlocks( clientIds );
+	} );
+};
+
 describe( 'Reusable blocks', () => {
 	beforeAll( async () => {
+		await removeReusableBlocks();
 		await createNewPost();
 	} );
 
 	beforeEach( async () => {
 		// Remove all blocks from the post so that we're working with a clean slate
-		await page.evaluate( () => {
-			const blocks = wp.data.select( 'core/block-editor' ).getBlocks();
-			const clientIds = blocks.map( ( block ) => block.clientId );
-			wp.data.dispatch( 'core/block-editor' ).removeBlocks( clientIds );
-		} );
+		await clearEditor();
 	} );
 
 	it( 'can be created', async () => {
-		// Insert a paragraph block
-		await insertBlock( 'Paragraph' );
-		await page.keyboard.type( 'Hello there!' );
-
-		await clickBlockToolbarButton( 'More options' );
-
-		const convertButton = await page.waitForXPath(
-			'//button[text()="Add to Reusable blocks"]'
-		);
-		await convertButton.click();
-
-		// Wait for creation to finish
-		await page.waitForXPath(
-			'//*[contains(@class, "components-snackbar")]/*[text()="Block created."]'
-		);
-
-		// Select all of the text in the title field.
-		await pressKeyWithModifier( 'primary', 'a' );
-
-		// Give the reusable block a title
-		await page.keyboard.type( 'Greeting block' );
-
-		// Save the reusable block
-		const [ saveButton ] = await page.$x( '//button[text()="Save"]' );
-		await saveButton.click();
-
-		// Wait for saving to finish
-		await page.waitForXPath( '//button[text()="Edit"]' );
+		const blockName = 'Test block';
+		await createReusableBlockWithSingleBlock( blockName );
 
 		// Check that we have a reusable block on the page
 		const block = await page.$(
 			'.block-editor-block-list__block[data-type="core/block"]'
 		);
 		expect( block ).not.toBeNull();
-
 		// Check that its title is displayed
 		const title = await page.$eval(
 			'.reusable-block-edit-panel__info',
 			( element ) => element.innerText
 		);
-		expect( title ).toBe( 'Greeting block' );
+		expect( title ).toBe( blockName );
 	} );
 
 	it( 'can be created with no title', async () => {
-		// Insert a paragraph block
-		await insertBlock( 'Paragraph' );
-		await page.keyboard.type( 'Hello there!' );
+		await createReusableBlockWithSingleBlock();
 
-		await clickBlockToolbarButton( 'More options' );
-
-		const convertButton = await page.waitForXPath(
-			'//button[text()="Add to Reusable blocks"]'
-		);
-		await convertButton.click();
-
-		// Wait for creation to finish
-		await page.waitForXPath(
-			'//*[contains(@class, "components-snackbar")]/*[text()="Block created."]'
-		);
-
-		// Save the reusable block
-		const [ saveButton ] = await page.$x( '//button[text()="Save"]' );
-		await saveButton.click();
-
-		// Wait for saving to finish
-		await page.waitForXPath( '//button[text()="Edit"]' );
-
-		// Check that we have a reusable block on the page
 		const block = await page.$(
 			'.block-editor-block-list__block[data-type="core/block"]'
 		);
 		expect( block ).not.toBeNull();
-
 		// Check that it is untitled
 		const title = await page.$eval(
 			'.reusable-block-edit-panel__info',
@@ -113,9 +148,16 @@ describe( 'Reusable blocks', () => {
 	} );
 
 	it( 'can be inserted and edited', async () => {
-		// Insert the reusable block we created above
-		await insertBlock( 'Greeting block' );
+		// Step 1. Create block
 
+		const blockName = 'Will be edited';
+		await createReusableBlockWithSingleBlock( blockName );
+		await clearEditor();
+
+		// Step 2. Insert and edit it.
+
+		// Insert the reusable block we created above
+		await insertBlock( blockName );
 		// Put the reusable block in edit mode
 		const editButton = await page.waitForXPath(
 			'//button[text()="Edit" and not(@disabled)]'
@@ -143,6 +185,8 @@ describe( 'Reusable blocks', () => {
 		// Wait for saving to finish
 		await page.waitForXPath( '//button[text()="Edit"]' );
 
+		// Step 3. Check
+
 		// Check that we have a reusable block on the page
 		const block = await page.$(
 			'.block-editor-block-list__block[data-type="core/block"]'
@@ -165,40 +209,19 @@ describe( 'Reusable blocks', () => {
 	} );
 
 	it( 'can be inserted after refresh', async () => {
-		// Step 1. Insert a paragraph block
+		// Step 1. Create a new reusable block
+		const blockName = `I am alive`;
+		await createReusableBlockWithSingleBlock( blockName );
 
-		await insertBlock( 'Paragraph' );
-		await page.keyboard.type( 'Awesome Paragraph' );
-
-		await clickBlockToolbarButton( 'More options' );
-
-		const convertButton = await page.waitForXPath(
-			'//button[text()="Add to Reusable blocks"]'
-		);
-		await convertButton.click();
-
-		// Wait for creation to finish
-		await page.waitForXPath(
-			'//*[contains(@class, "components-snackbar")]/*[text()="Block created."]'
-		);
-
-		// Select all of the text in the title field.
-		await pressKeyWithModifier( 'primary', 'a' );
-
-		// Give the reusable block a title
-		await page.keyboard.type( 'Awesome block' );
-
-		// Save the reusable block
-		const [ saveButton ] = await page.$x( '//button[text()="Save"]' );
-		await saveButton.click();
-
-		// Step 2. Create new post.
+		// Step 2. Refresh page by creating a new post.
 
 		await createNewPost();
 
 		// Step 3. Insert the block created in Step 1.
 
-		await insertBlock( 'Awesome block' );
+		await insertBlock( blockName );
+
+		// Step 4. Check
 
 		// Check that we have a reusable block on the page
 		const block = await page.$(
@@ -211,12 +234,16 @@ describe( 'Reusable blocks', () => {
 			'.reusable-block-edit-panel__info',
 			( element ) => element.innerText
 		);
-		expect( title ).toBe( 'Awesome block' );
+		expect( title ).toBe( blockName );
 	} );
 
 	it( 'can be converted to a regular block', async () => {
-		// Insert the reusable block we edited above
-		await insertBlock( 'Surprised greeting block' );
+		const blockName = 'Will be converted';
+		await createReusableBlockWithSingleBlock( blockName );
+		await clearEditor();
+
+		// Insert block
+		await insertBlock( blockName );
 
 		// Convert block to a regular block
 		await clickBlockToolbarButton( 'More options' );
@@ -236,12 +263,16 @@ describe( 'Reusable blocks', () => {
 			'.block-editor-block-list__block[data-type="core/paragraph"]',
 			( element ) => element.innerText
 		);
-		expect( text ).toMatch( 'Oh! Hello there!' );
+		expect( text ).toMatch( 'Hello there!' );
 	} );
 
 	it( 'can be deleted', async () => {
+		const blockName = 'Good bye';
+		await createReusableBlockWithSingleBlock( blockName );
+		await clearEditor();
+
 		// Insert the reusable block we edited above
-		await insertBlock( 'Surprised greeting block' );
+		await insertBlock( blockName );
 
 		// Delete the block and accept the confirmation dialog
 		await clickBlockToolbarButton( 'More options' );
@@ -259,70 +290,39 @@ describe( 'Reusable blocks', () => {
 		expect( await getEditedPostContent() ).toBe( '' );
 
 		// Search for the block in the inserter
-		await searchForBlock( 'Surprised greeting block' );
+		await searchForBlock( blockName );
 
 		// Check that we couldn't find it
 		const items = await page.$$(
-			'.block-editor-block-types-list__item[aria-label="Surprised greeting block"]'
+			`.block-editor-block-types-list__item[aria-label="${ blockName }"]`
 		);
 		expect( items ).toHaveLength( 0 );
 	} );
 
 	it( 'can be created from multiselection', async () => {
-		await createNewPost();
-
-		// Insert a Two paragraphs block
-		await insertBlock( 'Paragraph' );
-		await page.keyboard.type( 'Hello there!' );
-		await page.keyboard.press( 'Enter' );
-		await page.keyboard.type( 'Second paragraph' );
-
-		// Select all the blocks
-		await pressKeyWithModifier( 'primary', 'a' );
-		await pressKeyWithModifier( 'primary', 'a' );
-
-		// Convert block to a reusable block
-		await clickBlockToolbarButton( 'More options' );
-		const convertButton = await page.waitForXPath(
-			'//button[text()="Add to Reusable blocks"]'
-		);
-		await convertButton.click();
-
-		// Wait for creation to finish
-		await page.waitForXPath(
-			'//*[contains(@class, "components-snackbar")]/*[text()="Block created."]'
-		);
-
-		// Select all of the text in the title field.
-		await pressKeyWithModifier( 'primary', 'a' );
-
-		// Give the reusable block a title
-		await page.keyboard.type( 'Multi-selection reusable block' );
-
-		// Save the reusable block
-		const [ saveButton ] = await page.$x( '//button[text()="Save"]' );
-		await saveButton.click();
-
-		// Wait for saving to finish
-		await page.waitForXPath( '//button[text()="Edit"]' );
+		const blockName = 'Multi-selection reusable block';
+		await createReusableBlockWithMultipleBlocks( blockName );
 
 		// Check that we have a reusable block on the page
 		const block = await page.$(
 			'.block-editor-block-list__block[data-type="core/block"]'
 		);
 		expect( block ).not.toBeNull();
-
 		// Check that its title is displayed
 		const title = await page.$eval(
 			'.reusable-block-edit-panel__info',
 			( element ) => element.innerText
 		);
-		expect( title ).toBe( 'Multi-selection reusable block' );
+		expect( title ).toBe( blockName );
 	} );
 
 	it( 'multi-selection reusable block can be converted back to regular blocks', async () => {
+		const blockName = 'All for one. One for all';
+		await createReusableBlockWithMultipleBlocks( blockName );
+		await clearEditor();
+
 		// Insert the reusable block we edited above
-		await insertBlock( 'Multi-selection reusable block' );
+		await insertBlock( blockName );
 
 		// Convert block to a regular block
 		await clickBlockToolbarButton( 'More options' );

--- a/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
@@ -20,18 +20,23 @@ function waitForAndAcceptDialog() {
 async function removeReusableBlocks() {
 	await visitAdminPage( 'edit.php', 'post_type=wp_block' );
 
+	// When no reusable block is registered, return
+	if ( ( await page.$x( '//td[text()="No blocks found."]' ) ) !== null ) {
+		return;
+	}
+
 	// select all reusable blocks
-	await page.waitForSelector( '#cb-select-all-1' );
 	const checkall = await page.$( '#cb-select-all-1' );
 	await checkall.click();
 
+	// bottom select and bottom apply button are used
+	// because top one is not visible in mobile ui.
+
 	// select "Move to trash" option
-	await page.waitForSelector( '#bulk-action-selector-top' );
-	await page.select( '#bulk-action-selector-top', 'trash' );
+	await page.select( '#bulk-action-selector-bottom', 'trash' );
 
 	// click apply button
-	await page.waitForSelector( '#doaction' );
-	const applyButton = await page.$( '#doaction' );
+	const applyButton = await page.$( '#doaction2' );
 	await applyButton.click();
 }
 

--- a/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
@@ -18,7 +18,7 @@ function waitForAndAcceptDialog() {
 }
 
 async function removeReusableBlocks() {
-	await visitAdminPage( 'edit.php', [ 'post_type=wp_block' ] );
+	await visitAdminPage( 'edit.php', 'post_type=wp_block' );
 
 	// select all reusable blocks
 	await page.waitForSelector( '#cb-select-all-1' );

--- a/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/reusable-blocks.test.js
@@ -20,16 +20,18 @@ function waitForAndAcceptDialog() {
 async function removeReusableBlocks() {
 	await visitAdminPage( 'edit.php', [ 'post_type=wp_block' ] );
 
+	// select all reusable blocks
 	await page.waitForSelector( '#cb-select-all-1' );
-
 	const checkall = await page.$( '#cb-select-all-1' );
-
 	await checkall.click();
 
+	// select "Move to trash" option
+	await page.waitForSelector( '#bulk-action-selector-top' );
 	await page.select( '#bulk-action-selector-top', 'trash' );
 
+	// click apply button
+	await page.waitForSelector( '#doaction' );
 	const applyButton = await page.$( '#doaction' );
-
 	await applyButton.click();
 }
 


### PR DESCRIPTION
* Closes #21249

## Description

Made reusable block e2e tests independent.

## How has this been tested?

e2e tested with code.

## Screenshots <!-- if applicable -->

N/A

## Types of changes

Bug fix

## Checklist:
- [x] My code is tested.
- [N/A] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [N/A] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [N/A] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [N/A] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [N/A] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
