### PR TITLE
Avoid rerenders of the entire BlockInspector when block attributes change

### DIFF
--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -31,8 +31,6 @@ const BlockInspector = ( {
 	selectedBlockName,
 	showNoBlockSelectedMessage = true,
 } ) => {
-	const slot = useSlot( InspectorAdvancedControls.slotName );
-
 	if ( count > 1 ) {
 		return <MultiSelectionInspector />;
 	}
@@ -59,8 +57,6 @@ const BlockInspector = ( {
 		return null;
 	}
 
-	const hasFills = Boolean( slot.fills && slot.fills.length );
-
 	return (
 		<div className="block-editor-block-inspector">
 			<BlockCard blockType={ blockType } />
@@ -80,18 +76,31 @@ const BlockInspector = ( {
 			) }
 			<InspectorControls.Slot bubblesVirtually />
 			<div>
-				{ hasFills && (
-					<PanelBody
-						className="block-editor-block-inspector__advanced"
-						title={ __( 'Advanced' ) }
-						initialOpen={ false }
-					>
-						<InspectorAdvancedControls.Slot bubblesVirtually />
-					</PanelBody>
-				) }
+				<AdvancedControls
+					slotName={ InspectorAdvancedControls.slotName }
+				/>
 			</div>
 			<SkipToSelectedBlock key="back" />
 		</div>
+	);
+};
+
+const AdvancedControls = ( { slotName } ) => {
+	const slot = useSlot( slotName );
+	const hasFills = Boolean( slot.fills && slot.fills.length );
+
+	if ( ! hasFills ) {
+		return;
+	}
+
+	return (
+		<PanelBody
+			className="block-editor-block-inspector__advanced"
+			title={ __( 'Advanced' ) }
+			initialOpen={ false }
+		>
+			<InspectorAdvancedControls.Slot bubblesVirtually />
+		</PanelBody>
 	);
 };
 

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -90,7 +90,7 @@ const AdvancedControls = ( { slotName } ) => {
 	const hasFills = Boolean( slot.fills && slot.fills.length );
 
 	if ( ! hasFills ) {
-		return;
+		return null;
 	}
 
 	return (


### PR DESCRIPTION
## Description
`BlockInspector` uses `useSlot( InspectorAdvancedControls.slotName )`. Whenever any fill is updated, the entire BlockInspector is re-rendered. This causes performance problems like the ones described in https://github.com/WordPress/gutenberg/pull/21973. This PR extracts the `InspectorAdvancedControls` fills into a sub-component to avoid re-rendering the entire inspector.

## How has this been tested?
For some reason, my react dev tools fail to capture the re-render of `BlockInspector`. This makes testing a little bit harder, but not impossible:

1. Start without applying this PR
1. Add `console.log("BlockInspector rendered")` as a first statement in the `BlockInspector` component
1. Open post editor and add a navigation block with some menu items.
1. Select the entire block and change the background.
1. Confirm that `BlockInspector rendered` was logged about 10 times.
1. Apply this PR and keep the console.log in place
1. Repeat steps 3-4
1. Confirm that `BlockInspector rendered` was not logged in response to changing the background

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
