### PR TITLE
Fix spelling mistake in lib/edit-site-page.php

### DIFF
--- a/lib/edit-site-page.php
+++ b/lib/edit-site-page.php
@@ -32,7 +32,7 @@ function gutenberg_is_edit_site_page( $page ) {
 }
 
 /**
- * Load editor styles (this is copied form edit-form-blocks.php).
+ * Load editor styles (this is copied from edit-form-blocks.php).
  * Ideally the code is extracted into a reusable function.
  *
  * @return array Editor Styles Setting.


### PR DESCRIPTION
## Description
Fixed spelling mistake in [lib/edit-site-page.php](https://github.com/WordPress/gutenberg/blob/master/lib/edit-site-page.php)

## How has this been tested?
It's a spelling mistake/typo issue, testing isn't applicable.


## Types of changes

- Fixed spelling mistake in comment



