### PR TITLE
[Optimize] Move memo() from BlockStyles to BlockPreview

### DIFF
--- a/packages/block-editor/src/components/block-preview/index.js
+++ b/packages/block-editor/src/components/block-preview/index.js
@@ -7,7 +7,7 @@ import { castArray } from 'lodash';
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { useMemo } from '@wordpress/element';
+import { memo, useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -48,4 +48,4 @@ export function BlockPreview( {
 	);
 }
 
-export default BlockPreview;
+export default memo( BlockPreview );

--- a/packages/block-editor/src/components/block-preview/index.js
+++ b/packages/block-editor/src/components/block-preview/index.js
@@ -15,17 +15,6 @@ import { memo, useMemo } from '@wordpress/element';
 import BlockEditorProvider from '../provider';
 import AutoHeightBlockPreview from './auto';
 
-/**
- * BlockPreview renders a preview of a block or array of blocks.
- *
- * @see https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/block-preview/README.md
- *
- * @param {Object} preview options for how the preview should be shown
- * @param {Array|Object} preview.blocks A block instance (object) or an array of blocks to be previewed.
- * @param {number} preview.viewportWidth Width of the preview container in pixels. Controls at what size the blocks will be rendered inside the preview. Default: 700.
- *
- * @return {WPComponent} The component to be rendered.
- */
 export function BlockPreview( {
 	blocks,
 	__experimentalPadding = 0,
@@ -48,4 +37,15 @@ export function BlockPreview( {
 	);
 }
 
+/**
+ * BlockPreview renders a preview of a block or array of blocks.
+ *
+ * @see https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/block-preview/README.md
+ *
+ * @param {Object} preview options for how the preview should be shown
+ * @param {Array|Object} preview.blocks A block instance (object) or an array of blocks to be previewed.
+ * @param {number} preview.viewportWidth Width of the preview container in pixels. Controls at what size the blocks will be rendered inside the preview. Default: 700.
+ *
+ * @return {WPComponent} The component to be rendered.
+ */
 export default memo( BlockPreview );

--- a/packages/block-editor/src/components/block-styles/index.js
+++ b/packages/block-editor/src/components/block-styles/index.js
@@ -119,17 +119,6 @@ function BlockStyles( { clientId, onSwitch = noop, onHoverClassName = noop } ) {
 	}
 
 	const activeStyle = getActiveStyle( styles, className );
-	function updateClassName( style ) {
-		const updatedClassName = replaceActiveStyle(
-			className,
-			activeStyle,
-			style
-		);
-		onChangeClassName( updatedClassName );
-		onHoverClassName( null );
-		onSwitch();
-	}
-
 	return (
 		<div className="block-editor-block-styles">
 			{ styles.map( ( style ) => {
@@ -145,7 +134,11 @@ function BlockStyles( { clientId, onSwitch = noop, onHoverClassName = noop } ) {
 						isActive={ activeStyle === style }
 						key={ style.name }
 						onHoverClassName={ onHoverClassName }
-						onSelect={ () => updateClassName( style ) }
+						onSelect={ () => {
+							onChangeClassName( styleClassName );
+							onHoverClassName( null );
+							onSwitch();
+						} }
 						onBlur={ () => onHoverClassName( null ) }
 						onHover={ () => onHoverClassName( styleClassName ) }
 						style={ style }

--- a/packages/block-editor/src/components/block-styles/index.js
+++ b/packages/block-editor/src/components/block-styles/index.js
@@ -167,6 +167,7 @@ function BlockStyles( { clientId, onSwitch = noop, onHoverClassName = noop } ) {
 								blockName={ blockName }
 								useExample={ useExample }
 								styleClassName={ styleClassName }
+								viewportWidth={ 500 }
 							/>
 						</div>
 						<div className="block-editor-block-styles__item-label">
@@ -185,6 +186,7 @@ function BlockStylePreview( {
 	block,
 	blockName,
 	styleClassName,
+	viewportWidth,
 } ) {
 	let factory, deps;
 	if ( useExample ) {
@@ -207,7 +209,12 @@ function BlockStylePreview( {
 
 	const previewBlocks = useMemo( factory, deps );
 
-	return <BlockPreview viewportWidth={ 500 } blocks={ previewBlocks } />;
+	return (
+		<BlockPreview
+			viewportWidth={ viewportWidth }
+			blocks={ previewBlocks }
+		/>
+	);
 }
 
 export default BlockStyles;

--- a/packages/block-editor/src/components/block-styles/index.js
+++ b/packages/block-editor/src/components/block-styles/index.js
@@ -94,7 +94,7 @@ function BlockStyles( { clientId, onSwitch = noop, onHoverClassName = noop } ) {
 		};
 	};
 
-	const { styles, block, type, className, ...rest } = useSelect( selector, [
+	const { styles, block, type, className } = useSelect( selector, [
 		clientId,
 	] );
 
@@ -133,7 +133,6 @@ function BlockStyles( { clientId, onSwitch = noop, onHoverClassName = noop } ) {
 						className={ className }
 						isActive={ activeStyle === style }
 						key={ style.name }
-						onHoverClassName={ onHoverClassName }
 						onSelect={ () => {
 							onChangeClassName( styleClassName );
 							onHoverClassName( null );
@@ -143,8 +142,6 @@ function BlockStyles( { clientId, onSwitch = noop, onHoverClassName = noop } ) {
 						onHover={ () => onHoverClassName( styleClassName ) }
 						style={ style }
 						styleClassName={ styleClassName }
-						type={ type }
-						{ ...rest }
 					/>
 				);
 			} ) }

--- a/packages/block-editor/src/components/block-styles/index.js
+++ b/packages/block-editor/src/components/block-styles/index.js
@@ -85,14 +85,9 @@ function BlockStyles( { clientId, onSwitch = noop, onHoverClassName = noop } ) {
 		};
 	};
 
-	const {
-		useExample,
-		blockName,
-		className,
-		styles,
-		type,
-		block,
-	} = useSelect( selector, [ clientId ] );
+	const { styles, type, className, ...rest } = useSelect( selector, [
+		clientId,
+	] );
 
 	const { updateBlockAttributes } = useDispatch( 'core/block-editor' );
 	const onChangeClassName = useCallback(
@@ -127,67 +122,35 @@ function BlockStyles( { clientId, onSwitch = noop, onHoverClassName = noop } ) {
 
 	return (
 		<div className="block-editor-block-styles">
-			{ styles.map( ( style ) => {
-				const styleClassName = replaceActiveStyle(
-					className,
-					activeStyle,
-					style
-				);
-				return (
-					<div
-						key={ style.name }
-						className={ classnames(
-							'block-editor-block-styles__item',
-							{
-								'is-active': activeStyle === style,
-							}
-						) }
-						onClick={ () => updateClassName( style ) }
-						onKeyDown={ ( event ) => {
-							if (
-								ENTER === event.keyCode ||
-								SPACE === event.keyCode
-							) {
-								event.preventDefault();
-								updateClassName( style );
-							}
-						} }
-						onMouseEnter={ () =>
-							onHoverClassName( styleClassName )
-						}
-						onMouseLeave={ () => onHoverClassName( null ) }
-						role="button"
-						tabIndex="0"
-						aria-label={ style.label || style.name }
-					>
-						<div className="block-editor-block-styles__item-preview">
-							<BlockStylePreview
-								type={ type }
-								block={ block }
-								blockName={ blockName }
-								useExample={ useExample }
-								styleClassName={ styleClassName }
-								viewportWidth={ 500 }
-							/>
-						</div>
-						<div className="block-editor-block-styles__item-label">
-							{ style.label || style.name }
-						</div>
-					</div>
-				);
-			} ) }
+			{ styles.map( ( style ) => (
+				<BlockStyleItem
+					activeStyle={ activeStyle }
+					className={ className }
+					key={ style.name }
+					onHoverClassName={ onHoverClassName }
+					style={ style }
+					type={ type }
+					updateClassName={ updateClassName }
+					{ ...rest }
+				/>
+			) ) }
 		</div>
 	);
 }
 
-function BlockStylePreview( {
-	useExample,
+function BlockStyleItem( {
 	type,
 	block,
 	blockName,
-	styleClassName,
-	viewportWidth,
+	useExample,
+	style,
+	activeStyle,
+	updateClassName,
+	className,
+	onHoverClassName,
 } ) {
+	const styleClassName = replaceActiveStyle( className, activeStyle, style );
+
 	let factory, deps;
 	if ( useExample ) {
 		factory = () =>
@@ -206,14 +169,34 @@ function BlockStylePreview( {
 			} );
 		deps = [ block, styleClassName ];
 	}
-
 	const previewBlocks = useMemo( factory, deps );
 
 	return (
-		<BlockPreview
-			viewportWidth={ viewportWidth }
-			blocks={ previewBlocks }
-		/>
+		<div
+			key={ style.name }
+			className={ classnames( 'block-editor-block-styles__item', {
+				'is-active': activeStyle === style,
+			} ) }
+			onClick={ () => updateClassName( style ) }
+			onKeyDown={ ( event ) => {
+				if ( ENTER === event.keyCode || SPACE === event.keyCode ) {
+					event.preventDefault();
+					updateClassName( style );
+				}
+			} }
+			onMouseEnter={ () => onHoverClassName( styleClassName ) }
+			onMouseLeave={ () => onHoverClassName( null ) }
+			role="button"
+			tabIndex="0"
+			aria-label={ style.label || style.name }
+		>
+			<div className="block-editor-block-styles__item-preview">
+				<BlockPreview viewportWidth={ 500 } blocks={ previewBlocks } />
+			</div>
+			<div className="block-editor-block-styles__item-label">
+				{ style.label || style.name }
+			</div>
+		</div>
 	);
 }
 

--- a/packages/block-editor/src/components/block-styles/index.js
+++ b/packages/block-editor/src/components/block-styles/index.js
@@ -122,18 +122,26 @@ function BlockStyles( { clientId, onSwitch = noop, onHoverClassName = noop } ) {
 
 	return (
 		<div className="block-editor-block-styles">
-			{ styles.map( ( style ) => (
-				<BlockStyleItem
-					activeStyle={ activeStyle }
-					className={ className }
-					key={ style.name }
-					onHoverClassName={ onHoverClassName }
-					style={ style }
-					type={ type }
-					updateClassName={ updateClassName }
-					{ ...rest }
-				/>
-			) ) }
+			{ styles.map( ( style ) => {
+				const styleClassName = replaceActiveStyle(
+					className,
+					activeStyle,
+					style
+				);
+				return (
+					<BlockStyleItem
+						className={ className }
+						isActive={ activeStyle === style }
+						key={ style.name }
+						onHoverClassName={ onHoverClassName }
+						style={ style }
+						styleClassName={ styleClassName }
+						type={ type }
+						updateClassName={ updateClassName }
+						{ ...rest }
+					/>
+				);
+			} ) }
 		</div>
 	);
 }
@@ -144,13 +152,11 @@ function BlockStyleItem( {
 	blockName,
 	useExample,
 	style,
-	activeStyle,
+	isActive,
 	updateClassName,
-	className,
+	styleClassName,
 	onHoverClassName,
 } ) {
-	const styleClassName = replaceActiveStyle( className, activeStyle, style );
-
 	let factory, deps;
 	if ( useExample ) {
 		factory = () =>
@@ -175,7 +181,7 @@ function BlockStyleItem( {
 		<div
 			key={ style.name }
 			className={ classnames( 'block-editor-block-styles__item', {
-				'is-active': activeStyle === style,
+				'is-active': isActive,
 			} ) }
 			onClick={ () => updateClassName( style ) }
 			onKeyDown={ ( event ) => {

--- a/packages/block-editor/src/components/block-styles/index.js
+++ b/packages/block-editor/src/components/block-styles/index.js
@@ -77,7 +77,7 @@ const useGenericPreviewBlock = ( block, type ) =>
 						innerBlocks: type.example.innerBlocks,
 				  } )
 				: cloneBlock( block ),
-		[ block.name, type ]
+		[ block, type ]
 	);
 
 function BlockStyles( { clientId, onSwitch = noop, onHoverClassName = noop } ) {

--- a/packages/block-editor/src/components/block-styles/index.js
+++ b/packages/block-editor/src/components/block-styles/index.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { useCallback, memo } from '@wordpress/element';
+import { useCallback, useMemo } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import TokenList from '@wordpress/token-list';
 import { ENTER, SPACE } from '@wordpress/keycodes';
@@ -161,22 +161,12 @@ function BlockStyles( { clientId, onSwitch = noop, onHoverClassName = noop } ) {
 						aria-label={ style.label || style.name }
 					>
 						<div className="block-editor-block-styles__item-preview">
-							<BlockPreview
-								viewportWidth={ 500 }
-								blocks={
-									useExample
-										? getBlockFromExample( blockName, {
-												attributes: {
-													...type.example.attributes,
-													className: styleClassName,
-												},
-												innerBlocks:
-													type.example.innerBlocks,
-										  } )
-										: cloneBlock( block, {
-												className: styleClassName,
-										  } )
-								}
+							<BlockPreviewPure
+								type={ type }
+								block={ block }
+								blockName={ blockName }
+								useExample={ useExample }
+								styleClassName={ styleClassName }
 							/>
 						</div>
 						<div className="block-editor-block-styles__item-label">
@@ -189,4 +179,35 @@ function BlockStyles( { clientId, onSwitch = noop, onHoverClassName = noop } ) {
 	);
 }
 
-export default memo( BlockStyles );
+function BlockPreviewPure( {
+	useExample,
+	type,
+	block,
+	blockName,
+	styleClassName,
+} ) {
+	let factory, deps;
+	if ( useExample ) {
+		factory = () =>
+			getBlockFromExample( blockName, {
+				attributes: {
+					...type.example.attributes,
+					className: styleClassName,
+				},
+				innerBlocks: type.example.innerBlocks,
+			} );
+		deps = [ useExample, type, blockName, styleClassName ];
+	} else {
+		factory = () =>
+			cloneBlock( block, {
+				className: styleClassName,
+			} );
+		deps = [ block, styleClassName ];
+	}
+
+	const previewBlocks = useMemo( factory, deps );
+
+	return <BlockPreview viewportWidth={ 500 } blocks={ previewBlocks } />;
+}
+
+export default BlockStyles;

--- a/packages/block-editor/src/components/block-styles/index.js
+++ b/packages/block-editor/src/components/block-styles/index.js
@@ -134,10 +134,10 @@ function BlockStyles( { clientId, onSwitch = noop, onHoverClassName = noop } ) {
 						isActive={ activeStyle === style }
 						key={ style.name }
 						onHoverClassName={ onHoverClassName }
+						onSelect={ () => updateClassName( style ) }
 						style={ style }
 						styleClassName={ styleClassName }
 						type={ type }
-						updateClassName={ updateClassName }
 						{ ...rest }
 					/>
 				);
@@ -153,7 +153,7 @@ function BlockStyleItem( {
 	useExample,
 	style,
 	isActive,
-	updateClassName,
+	onSelect,
 	styleClassName,
 	onHoverClassName,
 } ) {
@@ -183,11 +183,11 @@ function BlockStyleItem( {
 			className={ classnames( 'block-editor-block-styles__item', {
 				'is-active': isActive,
 			} ) }
-			onClick={ () => updateClassName( style ) }
+			onClick={ () => onSelect() }
 			onKeyDown={ ( event ) => {
 				if ( ENTER === event.keyCode || SPACE === event.keyCode ) {
 					event.preventDefault();
-					updateClassName( style );
+					onSelect();
 				}
 			} }
 			onMouseEnter={ () => onHoverClassName( styleClassName ) }

--- a/packages/block-editor/src/components/block-styles/index.js
+++ b/packages/block-editor/src/components/block-styles/index.js
@@ -161,7 +161,7 @@ function BlockStyles( { clientId, onSwitch = noop, onHoverClassName = noop } ) {
 						aria-label={ style.label || style.name }
 					>
 						<div className="block-editor-block-styles__item-preview">
-							<BlockPreviewPure
+							<BlockStylePreview
 								type={ type }
 								block={ block }
 								blockName={ blockName }
@@ -179,7 +179,7 @@ function BlockStyles( { clientId, onSwitch = noop, onHoverClassName = noop } ) {
 	);
 }
 
-function BlockPreviewPure( {
+function BlockStylePreview( {
 	useExample,
 	type,
 	block,

--- a/packages/block-editor/src/components/block-styles/index.js
+++ b/packages/block-editor/src/components/block-styles/index.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { useCallback, useMemo } from '@wordpress/element';
+import { useMemo } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import TokenList from '@wordpress/token-list';
 import { ENTER, SPACE } from '@wordpress/keycodes';
@@ -99,11 +99,6 @@ function BlockStyles( { clientId, onSwitch = noop, onHoverClassName = noop } ) {
 	] );
 
 	const { updateBlockAttributes } = useDispatch( 'core/block-editor' );
-	const onChangeClassName = useCallback(
-		( newClassName ) =>
-			updateBlockAttributes( clientId, { className: newClassName } ),
-		[ updateBlockAttributes, clientId ]
-	);
 	const genericPreviewBlock = useGenericPreviewBlock( block, type );
 
 	if ( ! styles || styles.length === 0 ) {
@@ -134,7 +129,9 @@ function BlockStyles( { clientId, onSwitch = noop, onHoverClassName = noop } ) {
 						isActive={ activeStyle === style }
 						key={ style.name }
 						onSelect={ () => {
-							onChangeClassName( styleClassName );
+							updateBlockAttributes( clientId, {
+								className: styleClassName,
+							} );
 							onHoverClassName( null );
 							onSwitch();
 						} }


### PR DESCRIPTION
## Description
https://github.com/WordPress/gutenberg/pull/21973 optimized `<BlockStyles />` to avoid unnecessary re-renders, specifically it replaced HOC with hooks, and added a `memo()` around the component. As discussed in https://github.com/WordPress/gutenberg/pull/21990#issuecomment-621793896, `<BlockPreview />` seems to be a much better candidate for `memo()` - especially since it's reused in other places. This PR moves the `memo()`, while keeping the performance boost we got in #21973.

## How has this been tested?
Tested locally with the same test plan as in #21973

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
