### PR TITLE
Update diff to 4.0.2 and work around tree-shaking issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9827,7 +9827,7 @@
 				"@wordpress/wordcount": "file:packages/wordcount",
 				"classnames": "^2.2.5",
 				"css-mediaquery": "^0.1.2",
-				"diff": "^3.5.0",
+				"diff": "^4.0.2",
 				"dom-scroll-into-view": "^1.2.1",
 				"inherits": "^2.0.3",
 				"lodash": "^4.17.15",
@@ -16821,9 +16821,9 @@
 			}
 		},
 		"diff": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
 		},
 		"diff-sequences": {
 			"version": "25.2.6",

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -47,7 +47,7 @@
 		"@wordpress/wordcount": "file:../wordcount",
 		"classnames": "^2.2.5",
 		"css-mediaquery": "^0.1.2",
-		"diff": "^3.5.0",
+		"diff": "^4.0.2",
 		"dom-scroll-into-view": "^1.2.1",
 		"inherits": "^2.0.3",
 		"lodash": "^4.17.15",

--- a/packages/block-editor/src/components/block-compare/index.js
+++ b/packages/block-editor/src/components/block-compare/index.js
@@ -3,7 +3,9 @@
  */
 import classnames from 'classnames';
 import { castArray } from 'lodash';
-import { diffChars } from 'diff';
+// diff doesn't tree-shake correctly, so we import from the individual
+// module here, to avoid including too much of the library
+import { diffChars } from 'diff/lib/diff/character';
 
 /**
  * WordPress dependencies


### PR DESCRIPTION
## Description
Update the `diff` dependency to `4.0.2` or later, as the 3.x.x version range is no longer getting any updates.

The PR also works around tree-shaking issues in the library, which results in a substantial improvement in bundle size. Bumping the version will also allow for the Gutenboarding project in Calypso to not require its own copy of `diff`.

## How has this been tested?
Unit tests and ad-hoc testing of this functionality. To test:
- Create e.g. a paragraph block,
- Edit it as HTML,
- Modify the HTML tags to something invalid,
- Click "Resolve" when the error dialog is displayed,
- Verify that a diff of changes is shown, and that it matches what is shown for a similar sequence of steps before this change.

## Types of changes
Dependency update only; no code changes.

## Checklist:
- [X] My code is tested.
