### PR TITLE
Revert "add align class to pull quote in editor (#21756)"

### DIFF
--- a/packages/block-library/src/pullquote/edit.js
+++ b/packages/block-library/src/pullquote/edit.js
@@ -105,7 +105,7 @@ class PullQuoteEdit extends Component {
 			className,
 		} = this.props;
 
-		const { value, citation, align } = attributes;
+		const { value, citation } = attributes;
 
 		const isSolidColorStyle = includes( className, SOLID_COLOR_CLASS );
 		const figureStyles = isSolidColorStyle
@@ -115,7 +115,6 @@ class PullQuoteEdit extends Component {
 		const figureClasses = classnames( className, {
 			'has-background': isSolidColorStyle && mainColor.color,
 			[ mainColor.class ]: isSolidColorStyle && mainColor.class,
-			[ `align${ align }` ]: align,
 		} );
 
 		const blockquoteStyles = {


### PR DESCRIPTION
This reverts commit a80541073802a53b5f9b1da515898f638548514d.

## Description
According to @youknowriad 's [comment here](https://github.com/WordPress/gutenberg/pull/21756#issuecomment-621797886) we should revert this, close #12853 and focus on fixing #20650

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
