### PR TITLE
Edit Site: Add home icon to template switcher.

### DIFF
--- a/lib/edit-site-page.php
+++ b/lib/edit-site-page.php
@@ -189,6 +189,7 @@ function gutenberg_edit_site_init( $hook ) {
 		$template_part_ids = $template_part_ids + $_wp_current_template_part_ids;
 	}
 	$settings['templateId']      = $current_template_post->ID;
+	$settings['homeTemplateId']  = $current_template_post->ID;
 	$settings['templateType']    = 'wp_template';
 	$settings['templateIds']     = array_values( $template_ids );
 	$settings['templatePartIds'] = array_values( $template_part_ids );

--- a/packages/edit-site/src/components/header/index.js
+++ b/packages/edit-site/src/components/header/index.js
@@ -78,6 +78,7 @@ export default function Header( { openEntitiesSavedStates } ) {
 					ids={ settings.templateIds }
 					templatePartIds={ settings.templatePartIds }
 					activeId={ settings.templateId }
+					homeId={ settings.homeTemplateId }
 					isTemplatePart={
 						settings.templateType === 'wp_template_part'
 					}

--- a/packages/edit-site/src/components/template-switcher/index.js
+++ b/packages/edit-site/src/components/template-switcher/index.js
@@ -10,6 +10,8 @@ import {
 	MenuGroup,
 	MenuItemsChoice,
 	MenuItem,
+	SVG,
+	Path,
 } from '@wordpress/components';
 import { plus } from '@wordpress/icons';
 
@@ -20,10 +22,28 @@ import AddTemplate from '../add-template';
 import TemplatePreview from './template-preview';
 import ThemePreview from './theme-preview';
 
-function TemplateLabel( { template } ) {
+const HomeIcon = () => (
+	<SVG
+		width="24"
+		height="24"
+		viewBox="-6 -6 24 24"
+		xmlns="http://www.w3.org/2000/svg"
+	>
+		<Path
+			d="M9.5 4V9.5H6.75V6.25V5.75H6.25H3.75H3.25V6.25V9.5H0.5V4L5 0.625L9.5 4Z"
+			stroke="black"
+		/>
+	</SVG>
+);
+function TemplateLabel( { template, homeId } ) {
 	return (
 		<>
 			{ template.slug }{ ' ' }
+			{ template.id === homeId && (
+				<Tooltip text={ __( 'Home' ) }>
+					<HomeIcon />
+				</Tooltip>
+			) }
 			{ template.status !== 'auto-draft' && (
 				<Tooltip text={ __( 'Customized' ) }>
 					<span className="edit-site-template-switcher__label-customized-dot" />
@@ -37,6 +57,7 @@ export default function TemplateSwitcher( {
 	ids,
 	templatePartIds,
 	activeId,
+	homeId,
 	isTemplatePart,
 	onActiveIdChange,
 	onActiveTemplatePartIdChange,
@@ -72,7 +93,10 @@ export default function TemplateSwitcher( {
 					);
 					return {
 						label: template ? (
-							<TemplateLabel template={ template } />
+							<TemplateLabel
+								template={ template }
+								homeId={ homeId }
+							/>
 						) : (
 							__( 'Loading…' )
 						),
@@ -98,7 +122,7 @@ export default function TemplateSwitcher( {
 				} ),
 			};
 		},
-		[ ids, templatePartIds ]
+		[ ids, templatePartIds, homeId ]
 	);
 	const [ isAddTemplateOpen, setIsAddTemplateOpen ] = useState( false );
 	return (

--- a/packages/edit-site/src/components/template-switcher/index.js
+++ b/packages/edit-site/src/components/template-switcher/index.js
@@ -10,10 +10,8 @@ import {
 	MenuGroup,
 	MenuItemsChoice,
 	MenuItem,
-	SVG,
-	Path,
 } from '@wordpress/components';
-import { plus } from '@wordpress/icons';
+import { Icon, home, plus } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -22,26 +20,15 @@ import AddTemplate from '../add-template';
 import TemplatePreview from './template-preview';
 import ThemePreview from './theme-preview';
 
-const HomeIcon = () => (
-	<SVG
-		width="24"
-		height="24"
-		viewBox="-6 -6 24 24"
-		xmlns="http://www.w3.org/2000/svg"
-	>
-		<Path
-			d="M9.5 4V9.5H6.75V6.25V5.75H6.25H3.75H3.25V6.25V9.5H0.5V4L5 0.625L9.5 4Z"
-			stroke="black"
-		/>
-	</SVG>
-);
 function TemplateLabel( { template, homeId } ) {
 	return (
 		<>
 			{ template.slug }{ ' ' }
 			{ template.id === homeId && (
 				<Tooltip text={ __( 'Home' ) }>
-					<HomeIcon />
+					<div className="edit-site-template-switcher__label-home-icon">
+						<Icon icon={ home } />
+					</div>
 				</Tooltip>
 			) }
 			{ template.status !== 'auto-draft' && (

--- a/packages/edit-site/src/components/template-switcher/style.scss
+++ b/packages/edit-site/src/components/template-switcher/style.scss
@@ -6,6 +6,13 @@
 	position: relative;
 }
 
+.edit-site-template-switcher__label-home-icon {
+	width: 24px;
+	height: 24px;
+	position: absolute;
+	right: 20px;
+}
+
 .edit-site-template-switcher__label-customized-dot {
 	position: absolute;
 	right: 4px;

--- a/packages/icons/src/library/home.js
+++ b/packages/icons/src/library/home.js
@@ -5,7 +5,7 @@ import { SVG, Path } from '@wordpress/primitives';
 
 const home = (
 	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-		<Path d="M20 20H4v-9.5L12 4l8 6.5V20zM12 5.933l-6.5 5.281V18.5h13v-7.286L12 5.933z" />
+		<Path d="M12 4L4 7.9V20h16V7.9L12 4zm6.5 14.5H14V13h-4v5.5H5.5V8.8L12 5.7l6.5 3.1v9.7z" />
 	</SVG>
 );
 


### PR DESCRIPTION
Closes #20788

## Description

This PR adds a home icon to the current home template in the template switcher.

## How has this been tested?

It was verified that the home icon shows for the home template in the site editor's template switcher.

## Screenshots

<img width="335" alt="Screen Shot 2020-04-30 at 11 44 49 AM" src="https://user-images.githubusercontent.com/19157096/80747302-151ccf00-8ad8-11ea-9477-5b3cd91d46cf.png">

## Types of Changes

*New Feature:* The site editor's template switcher now has an icon to show the current home template.

## Checklist:

- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->