### PR TITLE
Update: Use EntityProvider on the widget area.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10210,6 +10210,7 @@
 				"@wordpress/blocks": "file:packages/blocks",
 				"@wordpress/components": "file:packages/components",
 				"@wordpress/compose": "file:packages/compose",
+				"@wordpress/core-data": "file:packages/core-data",
 				"@wordpress/data": "file:packages/data",
 				"@wordpress/data-controls": "file:packages/data-controls",
 				"@wordpress/element": "file:packages/element",
@@ -20764,7 +20765,7 @@
 				},
 				"node-pre-gyp": {
 					"version": "0.12.0",
-					"resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz",
+					"resolved": false,
 					"integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
 					"dev": true,
 					"optional": true,
@@ -20795,7 +20796,7 @@
 				},
 				"nopt": {
 					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
 					"dev": true,
 					"optional": true,

--- a/packages/edit-widgets/package.json
+++ b/packages/edit-widgets/package.json
@@ -27,6 +27,7 @@
 		"@wordpress/blocks": "file:../blocks",
 		"@wordpress/components": "file:../components",
 		"@wordpress/compose": "file:../compose",
+		"@wordpress/core-data": "file:../core-data",
 		"@wordpress/data": "file:../data",
 		"@wordpress/data-controls": "file:../data-controls",
 		"@wordpress/element": "file:../element",


### PR DESCRIPTION
## Description
This PR updates the widget area component to use EntityProvider and useEntityBlockEditor.
The undo/redo was working on a character by character logic on the widget screen. The widget screen had custom onChange and onInput handlers that were not working well. This PR removes the custom onChange and onInput handlers and just uses the ones provided by useEntityBlockEditor. This change ends up implying the code of the widget area component.
The undo/redo still does not work well but now we know that is because of issues on core-data and when fixing the issue there we will affect all the screens.

## How has this been tested?
I verified there were no regressions when the widgets screen, I could still change and save the blocks.
