### PR TITLE
Build Tools: Changelog: Normalize entry to end with period

### DIFF
--- a/bin/changelog.js
+++ b/bin/changelog.js
@@ -75,6 +75,22 @@ function getIssueType( issue ) {
 }
 
 /**
+ * Given an issue title, returns the title with normalization transforms
+ * applied.
+ *
+ * @param {string} title Original title.
+ *
+ * @return {string} Normalized title.
+ */
+function getNormalizedTitle( title ) {
+	if ( ! title.endsWith( '.' ) ) {
+		title = title + '.';
+	}
+
+	return title;
+}
+
+/**
  * Returns a formatted changelog entry for a given issue object.
  *
  * @param {IssuesListForRepoResponseItem} issue Issue object.
@@ -82,23 +98,8 @@ function getIssueType( issue ) {
  * @return {string} Formatted changelog entry.
  */
 function getEntry( issue ) {
-	let title;
-	if ( /### Changelog\r\n\r\n> /.test( issue.body ) ) {
-		const bodyParts = issue.body.split( '### Changelog\r\n\r\n> ' );
-		const note = bodyParts[ bodyParts.length - 1 ];
-		title = note
-			// Remove comment prompt
-			.replace( /<!---(.*)--->/gm, '' )
-			// Remove new lines and whitespace
-			.trim();
-		if ( ! title.length ) {
-			title = `${ issue.title }`;
-		} else {
-			title = `${ title }`;
-		}
-	} else {
-		title = `${ issue.title }`;
-	}
+	const title = getNormalizedTitle( issue.title );
+
 	return `- ${ title } ([${ issue.number }](${ issue.html_url }))`;
 }
 
@@ -255,12 +256,20 @@ async function createChangelog( settings ) {
 	console.log( changelog );
 }
 
-createChangelog( {
-	owner: 'WordPress',
-	repo: 'gutenberg',
-	token: GITHUB_TOKEN,
-	milestone:
-		MILESTONE === undefined ? getMilestone( manifest.version ) : MILESTONE,
-} );
+if ( ! module.parent ) {
+	createChangelog( {
+		owner: 'WordPress',
+		repo: 'gutenberg',
+		token: GITHUB_TOKEN,
+		milestone:
+			MILESTONE === undefined
+				? getMilestone( manifest.version )
+				: MILESTONE,
+	} );
+}
+
+/** @type {NodeJS.Module} */ ( module ).exports = {
+	getNormalizedTitle,
+};
 
 /* eslint-enable no-console */

--- a/bin/test/changelog.js
+++ b/bin/test/changelog.js
@@ -1,0 +1,20 @@
+/**
+ * Internal dependencies
+ */
+import { getNormalizedTitle } from '../changelog';
+
+describe( 'getNormalizedTitle', () => {
+	describe( 'ends in period', () => {
+		it( 'adds a period if missing', () => {
+			const result = getNormalizedTitle( 'Fixes a bug' );
+
+			expect( result ).toBe( 'Fixes a bug.' );
+		} );
+
+		it( 'does not add a period if already present', () => {
+			const result = getNormalizedTitle( 'Fixes a bug.' );
+
+			expect( result ).toBe( 'Fixes a bug.' );
+		} );
+	} );
+} );


### PR DESCRIPTION
This pull request seeks to expand on the effort started in #19866 for automating generated changelog. The changes in this pull request normalize the title of a changelog entry to always end in a period, if they don't already.

It also includes a few minor revisions:

- Detect if the script is being used via the command-line, to allow for exporting named exports.
- To this end, setting up a pattern for unit testing.
- Remove changelog override behavior. We don't document this, and it's not clear right now if we'd want this or not.

**Testing Instructions:**

Ensure unit tests pass:

```
npm run test-unit bin/test/changelog.js
```

Check that the generated output has periods ending each title:

```
npm run changelog
```