### PR TITLE
Fix entity selection through save panel

### DIFF
--- a/packages/editor/src/components/entities-saved-states/index.js
+++ b/packages/editor/src/components/entities-saved-states/index.js
@@ -58,9 +58,9 @@ function EntityRecordState( { record, checked, onChange, closePanel } ) {
 	);
 
 	const { selectBlock } = useDispatch( 'core/block-editor' );
-	const selectParentBlock = useCallback( () => {
-		selectBlock( parentBlockId );
-	}, [ parentBlockId ] );
+	const selectParentBlock = useCallback( () => selectBlock( parentBlockId ), [
+		parentBlockId,
+	] );
 
 	const selectAndDismiss = useCallback( () => {
 		selectBlock( parentBlockId );

--- a/packages/editor/src/components/entities-saved-states/index.js
+++ b/packages/editor/src/components/entities-saved-states/index.js
@@ -47,13 +47,27 @@ function EntityRecordState( { record, checked, onChange, closePanel } ) {
 		return parents[ parents.length - 1 ];
 	}, [] );
 
+	const isSelected = useSelect(
+		( select ) => {
+			const selectedBlockId = select(
+				'core/block-editor'
+			).getSelectedBlockClientId();
+			return selectedBlockId === parentBlockId;
+		},
+		[ changesWhenSelected, parentBlockId ]
+	);
+
+	const [ changesWhenSelected, setChangesWhenSelected ] = useState( true );
+
 	const { selectBlock } = useDispatch( 'core/block-editor' );
-	const selectParentBlock = useCallback( () => selectBlock( parentBlockId ), [
-		parentBlockId,
-	] );
+	const selectParentBlock = useCallback( () => {
+		selectBlock( parentBlockId );
+		setChangesWhenSelected( ! changesWhenSelected );
+	}, [ parentBlockId ] );
 
 	const selectAndDismiss = useCallback( () => {
 		selectBlock( parentBlockId );
+		setChangesWhenSelected( ! changesWhenSelected );
 		closePanel();
 	}, [ parentBlockId ] );
 
@@ -69,12 +83,14 @@ function EntityRecordState( { record, checked, onChange, closePanel } ) {
 					<Button
 						onClick={ selectParentBlock }
 						className="entities-saved-states__find-entity"
+						disabled={ isSelected }
 					>
 						{ __( 'Select' ) }
 					</Button>
 					<Button
 						onClick={ selectAndDismiss }
 						className="entities-saved-states__find-entity-small"
+						disabled={ isSelected }
 					>
 						{ __( 'Select' ) }
 					</Button>

--- a/packages/editor/src/components/entities-saved-states/index.js
+++ b/packages/editor/src/components/entities-saved-states/index.js
@@ -54,20 +54,16 @@ function EntityRecordState( { record, checked, onChange, closePanel } ) {
 			).getSelectedBlockClientId();
 			return selectedBlockId === parentBlockId;
 		},
-		[ changesWhenSelected, parentBlockId ]
+		[ parentBlockId ]
 	);
-	// isSelected requires a dep that changes when 'Select' button is clicked.
-	const [ changesWhenSelected, setChangesWhenSelected ] = useState( true );
 
 	const { selectBlock } = useDispatch( 'core/block-editor' );
 	const selectParentBlock = useCallback( () => {
 		selectBlock( parentBlockId );
-		setChangesWhenSelected( ! changesWhenSelected );
 	}, [ parentBlockId ] );
 
 	const selectAndDismiss = useCallback( () => {
 		selectBlock( parentBlockId );
-		setChangesWhenSelected( ! changesWhenSelected );
 		closePanel();
 	}, [ parentBlockId ] );
 

--- a/packages/editor/src/components/entities-saved-states/index.js
+++ b/packages/editor/src/components/entities-saved-states/index.js
@@ -56,7 +56,7 @@ function EntityRecordState( { record, checked, onChange, closePanel } ) {
 		},
 		[ changesWhenSelected, parentBlockId ]
 	);
-
+	// isSelected requires a dep that changes when 'Select' button is clicked.
 	const [ changesWhenSelected, setChangesWhenSelected ] = useState( true );
 
 	const { selectBlock } = useDispatch( 'core/block-editor' );

--- a/packages/editor/src/components/entities-saved-states/index.js
+++ b/packages/editor/src/components/entities-saved-states/index.js
@@ -56,12 +56,11 @@ function EntityRecordState( { record, checked, onChange, closePanel } ) {
 		},
 		[ parentBlockId ]
 	);
-
+	const isSelectedText = isSelected ? __( 'Selected' ) : __( 'Select' );
 	const { selectBlock } = useDispatch( 'core/block-editor' );
 	const selectParentBlock = useCallback( () => selectBlock( parentBlockId ), [
 		parentBlockId,
 	] );
-
 	const selectAndDismiss = useCallback( () => {
 		selectBlock( parentBlockId );
 		closePanel();
@@ -81,14 +80,14 @@ function EntityRecordState( { record, checked, onChange, closePanel } ) {
 						className="entities-saved-states__find-entity"
 						disabled={ isSelected }
 					>
-						{ __( 'Select' ) }
+						{ isSelectedText }
 					</Button>
 					<Button
 						onClick={ selectAndDismiss }
 						className="entities-saved-states__find-entity-small"
 						disabled={ isSelected }
 					>
-						{ __( 'Select' ) }
+						{ isSelectedText }
 					</Button>
 				</>
 			) : null }


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
This PR disables the 'Select' button in the entity save panel when an entity is already selected.

As note by @vindl [here](https://github.com/WordPress/gutenberg/pull/21522#pullrequestreview-403945021), the new 'Select' entity button for the save panel will appear to de-select the entity if it is already selected.  Subsequent clicks do not re-select.  After investigation, it seems the entity does remain 'selected' but the button takes takes focus.  I think it makes the most sense to disable the 'Select' button if the entity is already selected:

![disable-on-selection](https://user-images.githubusercontent.com/28742426/80773554-3c9b8800-8b28-11ea-9549-29d430367d38.gif)



## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Tested locally on post and site editors.


## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
