### PR TITLE
Try better inserter toggle styling.

### DIFF
--- a/packages/edit-post/src/components/header/header-toolbar/style.scss
+++ b/packages/edit-post/src/components/header/header-toolbar/style.scss
@@ -80,7 +80,7 @@
 	}
 }
 
-.edit-post-header-toolbar > .edit-post-header-toolbar__inserter-toggle {
+.edit-post-header-toolbar .edit-post-header-toolbar__inserter-toggle {
 	margin-right: $grid-unit-10;
 	// Special dimensions for this button.
 	min-width: 32px;


### PR DESCRIPTION
One letter CSS change that allows better inheritance of this particular inserter style.

Before:

<img width="340" alt="Screenshot 2020-05-01 at 08 47 46" src="https://user-images.githubusercontent.com/1204802/80788160-a0559d80-8b88-11ea-8436-8416de03cc54.png">

After:

<img width="344" alt="Screenshot 2020-05-01 at 08 48 14" src="https://user-images.githubusercontent.com/1204802/80788165-a2b7f780-8b88-11ea-86c8-83466a38332d.png">

We still need to revisit #21870, this is not in place of that, it's merely a small code quality change that benefits gutenberg contexts that exist outside of wp-admin.
