### PR TITLE
Implement Block Navigator selection on Nav Menus page

### DIFF
--- a/packages/edit-navigation/src/components/menu-editor/navigation-structure-panel.js
+++ b/packages/edit-navigation/src/components/menu-editor/navigation-structure-panel.js
@@ -3,9 +3,16 @@
  */
 import { __experimentalBlockNavigationList } from '@wordpress/block-editor';
 import { Panel, PanelBody } from '@wordpress/components';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
 export default function NavigationStructurePanel( { blocks, initialOpen } ) {
+	const selectedBlockClientIds = useSelect(
+		( select ) => select( 'core/block-editor' ).getSelectedBlockClientIds(),
+		[]
+	);
+	const { selectBlock } = useDispatch( 'core/block-editor' );
+
 	return (
 		<Panel className="edit-navigation-menu-editor__navigation-structure-panel">
 			<PanelBody
@@ -15,8 +22,8 @@ export default function NavigationStructurePanel( { blocks, initialOpen } ) {
 				{ !! blocks.length && (
 					<__experimentalBlockNavigationList
 						blocks={ blocks }
-						selectedBlockClientId={ blocks[ 0 ].clientId }
-						selectBlock={ () => {} }
+						selectedBlockClientId={ selectedBlockClientIds[ 0 ] }
+						selectBlock={ selectBlock }
 						showNestedBlocks
 						showAppender
 					/>


### PR DESCRIPTION
## Description
The block navigator in the experimental `nav-menus` page shows blocks but can't be interacted with, as it was never fully implemented.

This PR implements the `selectedBlockClientId` and `selectBlock` props to get it working.

## How has this been tested?
1. Ensure you have an existing menu saved using the Menus page in the customiser
2. Visit wp-admin/admin.php?page=gutenberg-navigation
3. Click on blocks in the navigator on the left and notice they're selected
4. Click on blocks in the block editor and notice they show as selected in the navigator

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
