### PR TITLE
Columns. Remove top and bottom margin from individual column blocks.

### DIFF
--- a/packages/block-library/src/columns/editor.scss
+++ b/packages/block-library/src/columns/editor.scss
@@ -19,12 +19,10 @@
 	}
 }
 
-// This is the style used on the front-end, which ideally should be loaded in
-// the editor too.
-.wp-block-column > *:first-child {
-	margin-top: 0 !important;
-}
-
-.wp-block-column > *:last-child {
-	margin-bottom: 0 !important;
+// Individual columns do not have top and bottom margins on the frontend.
+// So we make the editor match that.
+// Needs specificity.
+.block-editor-block-list__block.wp-block-column.wp-block-column {
+	margin-top: 0;
+	margin-bottom: 0;
 }


### PR DESCRIPTION
The columns block has margins. Content inside has margins. But individual column blocks should not add additional margins.

This PR fixes that.

Alternative to #21824. 

Before:

<img width="796" alt="Screenshot 2020-05-01 at 09 30 53" src="https://user-images.githubusercontent.com/1204802/80790790-098cdf00-8b90-11ea-8c82-8695eeef9115.png">

<img width="788" alt="Screenshot 2020-05-01 at 09 31 05" src="https://user-images.githubusercontent.com/1204802/80790801-0bef3900-8b90-11ea-9092-bc3dd764a588.png">

<img width="751" alt="Screenshot 2020-05-01 at 09 34 34" src="https://user-images.githubusercontent.com/1204802/80790804-0e519300-8b90-11ea-9a4d-3777bcbbcad8.png">

Compare that with the frontend before:

<img width="756" alt="Screenshot 2020-05-01 at 09 34 38" src="https://user-images.githubusercontent.com/1204802/80790815-17dafb00-8b90-11ea-8eeb-3c35eafc5311.png">

After (editor first, then frontend):

<img width="780" alt="Screenshot 2020-05-01 at 09 39 09" src="https://user-images.githubusercontent.com/1204802/80790819-1ad5eb80-8b90-11ea-9055-702793a72446.png">

<img width="743" alt="Screenshot 2020-05-01 at 09 39 12" src="https://user-images.githubusercontent.com/1204802/80790824-1c071880-8b90-11ea-8da5-5b421f87d3a6.png">
