### PR TITLE
Polish code editor and fix iPhone issue

### DIFF
--- a/packages/base-styles/_variables.scss
+++ b/packages/base-styles/_variables.scss
@@ -11,7 +11,7 @@ $editor-font: "Noto Serif", serif;
 $editor-html-font: Menlo, Consolas, monaco, monospace;
 $editor-font-size: 16px;
 $default-block-margin: 28px; // This value provides a consistent, contiguous spacing between blocks (it's 2x $block-padding).
-$text-editor-font-size: 14px;
+$text-editor-font-size: 15px;
 $editor-line-height: 1.8;
 $big-font-size: 18px;
 $mobile-text-min-font-size: 16px; // Any font size below 16px will cause Mobile Safari to "zoom in"

--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -12,6 +12,7 @@ $z-layers: (
 	".components-form-toggle__input": 1,
 	".components-panel__header.edit-post-sidebar__panel-tabs": -1,
 	".edit-post-sidebar .components-panel": -2,
+	".edit-post-text-editor__toolbar": 1,
 	".block-editor-inserter__tabs": 1,
 	".block-editor-inserter__tab.is-active": 1,
 	".components-panel__header": 1,

--- a/packages/edit-post/src/components/text-editor/style.scss
+++ b/packages/edit-post/src/components/text-editor/style.scss
@@ -4,14 +4,25 @@
 	background-color: $white;
 	flex-grow: 1;
 
-	// Always show outlines in code editor
+	// Post title.
 	.wp-block.editor-post-title {
 		max-width: none;
+		line-height: $default-line-height;
 
-		textarea {
+		// This needs specificity to change the title block appearance on the code editor.
+		.editor-post-title__input.editor-post-title__input.editor-post-title__input {
+			font-family: $editor-html-font;
+			font-size: 2.5em;
+			font-weight: normal;
+		}
+
+		// Always show outlines in code editor
+		.editor-post-title__input {
 			border: $border-width solid $light-gray-secondary;
 			margin-bottom: -$border-width;
-			padding: $grid-unit-20;
+
+			// Same padding as body.
+			padding: $grid-unit-30;
 
 			&:focus {
 				border: $border-width solid $dark-gray-primary;
@@ -22,6 +33,20 @@
 			padding: 0;
 		}
 	}
+}
+
+.edit-post-text-editor__body {
+	width: 100%;
+	padding: 0 $grid-unit-15 $grid-unit-15 $grid-unit-15;
+	max-width: $break-xlarge;
+	margin-left: auto;
+	margin-right: auto;
+
+	@include break-large() {
+		padding: $grid-unit-20 $grid-unit-30 #{ $grid-unit-60 * 2 } $grid-unit-30;
+		padding: 0 $grid-unit-30 $grid-unit-30 $grid-unit-30;
+	}
+
 }
 
 // Exit code editor toolbar.
@@ -51,25 +76,5 @@
 
 	.components-button svg {
 		order: 1;
-	}
-}
-
-.edit-post-text-editor__body {
-	width: 100%;
-	padding: 0 $grid-unit-15 $grid-unit-15 $grid-unit-15;
-	max-width: $break-xlarge;
-	margin-left: auto;
-	margin-right: auto;
-
-	@include break-large() {
-		padding: $grid-unit-20 $grid-unit-30 #{ $grid-unit-60 * 2 } $grid-unit-30;
-		padding: 0 $grid-unit-30 $grid-unit-30 $grid-unit-30;
-	}
-
-	// This needs specificity to change the title block appearance on the code editor.
-	.editor-post-title__input.editor-post-title__input.editor-post-title__input {
-		font-family: $editor-html-font;
-		font-size: 2.5em;
-		font-weight: normal;
 	}
 }

--- a/packages/edit-post/src/components/text-editor/style.scss
+++ b/packages/edit-post/src/components/text-editor/style.scss
@@ -22,22 +22,24 @@
 			padding: 0;
 		}
 	}
-
-	// Make room for toolbar.
-	padding-top: $block-toolbar-height + $grid-unit-10;
 }
 
 // Exit code editor toolbar.
 .edit-post-text-editor__toolbar {
-	position: absolute;
+	position: sticky;
 	top: 0;
 	left: 0;
 	right: 0;
 	display: flex;
+	background: $white;
 	padding: $grid-unit-05 $grid-unit-15;
 
 	@include break-small() {
 		padding: $grid-unit-15;
+	}
+
+	@include break-large() {
+		padding: $grid-unit-15 $grid-unit-30;
 	}
 
 	h2 {
@@ -67,6 +69,7 @@
 	// This needs specificity to change the title block appearance on the code editor.
 	.editor-post-title__input.editor-post-title__input.editor-post-title__input {
 		font-family: $editor-html-font;
-		font-size: 2em;
+		font-size: 2.5em;
+		font-weight: normal;
 	}
 }

--- a/packages/edit-post/src/components/text-editor/style.scss
+++ b/packages/edit-post/src/components/text-editor/style.scss
@@ -60,7 +60,7 @@
 	left: 0;
 	right: 0;
 	display: flex;
-	background: $white;
+	background: rgba($white, 0.8);
 	padding: $grid-unit-05 $grid-unit-15;
 
 	@include break-small() {

--- a/packages/edit-post/src/components/text-editor/style.scss
+++ b/packages/edit-post/src/components/text-editor/style.scss
@@ -22,7 +22,10 @@
 			margin-bottom: -$border-width;
 
 			// Same padding as body.
-			padding: $grid-unit-30;
+			padding: $grid-unit-20;
+			@include break-small() {
+				padding: $grid-unit-30;
+			}
 
 			&:focus {
 				border: $border-width solid $dark-gray-primary;
@@ -52,6 +55,7 @@
 // Exit code editor toolbar.
 .edit-post-text-editor__toolbar {
 	position: sticky;
+	z-index: z-index(".edit-post-text-editor__toolbar");
 	top: 0;
 	left: 0;
 	right: 0;

--- a/packages/edit-post/src/components/text-editor/style.scss
+++ b/packages/edit-post/src/components/text-editor/style.scss
@@ -33,11 +33,11 @@
 	top: 0;
 	left: 0;
 	right: 0;
-	padding: $grid-unit-15;
 	display: flex;
+	padding: $grid-unit-05 $grid-unit-15;
 
-	@include break-large() {
-		padding: $grid-unit-15 $grid-unit-30;
+	@include break-small() {
+		padding: $grid-unit-15;
 	}
 
 	h2 {
@@ -54,13 +54,14 @@
 
 .edit-post-text-editor__body {
 	width: 100%;
-	padding: $grid-unit-20 $grid-unit-15 $grid-unit-60 $grid-unit-15;
-	max-width: $break-wide;
+	padding: 0 $grid-unit-15 $grid-unit-15 $grid-unit-15;
+	max-width: $break-xlarge;
 	margin-left: auto;
 	margin-right: auto;
 
 	@include break-large() {
 		padding: $grid-unit-20 $grid-unit-30 #{ $grid-unit-60 * 2 } $grid-unit-30;
+		padding: 0 $grid-unit-30 $grid-unit-30 $grid-unit-30;
 	}
 
 	// This needs specificity to change the title block appearance on the code editor.

--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -131,7 +131,7 @@ export function initializeEditor(
 				}
 				// Undo unwanted scroll on html element, but only in the visual editor.
 				if (
-					! document.getElementsByClassName( 'is-mode-text' )[ 0 ]
+					document.getElementsByClassName( 'is-mode-visual' )[ 0 ]
 				) {
 					window.scrollTo( 0, 0 );
 				}

--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -129,8 +129,12 @@ export function initializeEditor(
 					editorScrollContainer.scrollTop =
 						editorScrollContainer.scrollTop + window.scrollY;
 				}
-				//Undo unwanted scroll on html element
-				window.scrollTo( 0, 0 );
+				// Undo unwanted scroll on html element, but only in the visual editor.
+				if (
+					! document.getElementsByClassName( 'is-mode-text' )[ 0 ]
+				) {
+					window.scrollTo( 0, 0 );
+				}
 			}
 		} );
 	}

--- a/packages/editor/src/components/post-text-editor/style.scss
+++ b/packages/editor/src/components/post-text-editor/style.scss
@@ -12,7 +12,10 @@
 	min-height: 200px;
 
 	// Same padding as title.
-	padding: $grid-unit-30;
+	padding: $grid-unit-20;
+	@include break-small() {
+		padding: $grid-unit-30;
+	}
 
 	/* Fonts smaller than 16px causes mobile safari to zoom. */
 	font-size: $mobile-text-min-font-size !important;

--- a/packages/editor/src/components/post-text-editor/style.scss
+++ b/packages/editor/src/components/post-text-editor/style.scss
@@ -7,7 +7,7 @@
 	resize: none;
 	overflow: hidden;
 	font-family: $editor-html-font;
-	line-height: 150%;
+	line-height: 2.4;
 	border-radius: 0;
 	padding: $grid-unit-20;
 	min-height: 200px;

--- a/packages/editor/src/components/post-text-editor/style.scss
+++ b/packages/editor/src/components/post-text-editor/style.scss
@@ -9,8 +9,10 @@
 	font-family: $editor-html-font;
 	line-height: 2.4;
 	border-radius: 0;
-	padding: $grid-unit-20;
 	min-height: 200px;
+
+	// Same padding as title.
+	padding: $grid-unit-30;
 
 	/* Fonts smaller than 16px causes mobile safari to zoom. */
 	font-size: $mobile-text-min-font-size !important;

--- a/packages/editor/src/components/post-title/style.scss
+++ b/packages/editor/src/components/post-title/style.scss
@@ -11,10 +11,10 @@
 		@include reduce-motion("transition");
 		padding: #{ $block-padding + 5px } 0;
 		word-break: keep-all;
+		line-height: $default-line-height;
 
 		// Inherit the styles set by the theme.
 		font-family: inherit;
-		line-height: inherit;
 		color: inherit;
 
 		// Stack borders on mobile.

--- a/packages/editor/src/components/post-title/style.scss
+++ b/packages/editor/src/components/post-title/style.scss
@@ -11,10 +11,10 @@
 		@include reduce-motion("transition");
 		padding: #{ $block-padding + 5px } 0;
 		word-break: keep-all;
-		line-height: $default-line-height;
 
 		// Inherit the styles set by the theme.
 		font-family: inherit;
+		line-height: inherit;
 		color: inherit;
 
 		// Stack borders on mobile.


### PR DESCRIPTION
This is an alternative to #21950. But it takes a different approach. The other PR was intended to fix an observed performance issue in Safari, but I haven't been able to fully reproduce it. Originally it felt like the auto-sizing textarea was the cause of the issue, but I'm not sure that's actually the case.

Additionally, removing the auto-sizing textarea has some compounding effects on the structure and layout. Immediately, it means the textarea has to be full-height, and scroll itself. That means the layout of the page should be flexed instead. It also means the still-autosizing title block needs a max-height. And then I discovered there were some issues with Mobile Safari and some of the JS we wrote to improve the visual aspects.

All of the issues above are fixed and addressed in #21950. However I still think this branch is the better one.

- It keeps the autosizing textarea, which means the same container as before scrolls.
- It fixes the iPhone jittering issue with the same fix as before.
- It contains the same (and a few more) visual and code quality fixes to the general files.

It seems worth comparing the two branches side by side, not only to get a feel for the changes, but to note any perceived Safari performance issues in either. 

This branch goes a little further in that it also polishes the visuals a bit more:

- Non bold title font
- Not quite as wide max-width
- Fixed position top toolbar that scrolls with you down the page
- Relaxed line height and input field paddings

Screens:

<img width="1747" alt="Screenshot 2020-05-01 at 11 51 39" src="https://user-images.githubusercontent.com/1204802/80798161-fdab1800-8ba3-11ea-8250-e2de26ab9282.png">

<img width="442" alt="Screenshot 2020-05-01 at 11 53 07" src="https://user-images.githubusercontent.com/1204802/80798166-ff74db80-8ba3-11ea-9fc3-22efd2e2c461.png">
