### PR TITLE
Storybook: Add DateTimePicker

### DIFF
--- a/packages/components/src/date-time/stories/index.js
+++ b/packages/components/src/date-time/stories/index.js
@@ -18,9 +18,9 @@ export default {
 	component: DateTimePicker,
 };
 
-const DateTimePickerWithState = () => {
+const DateTimePickerWithState = ( { is12Hour } ) => {
 	const [ date, setDate ] = useState();
-	const is12Hour = boolean( 'Is 12 hour (shows AM/PM)', false );
+
 	return (
 		<DateTimePicker
 			currentDate={ date }
@@ -31,5 +31,6 @@ const DateTimePickerWithState = () => {
 };
 
 export const _default = () => {
-	return <DateTimePickerWithState />;
+	const is12Hour = boolean( 'Is 12 hour (shows AM/PM)', false );
+	return <DateTimePickerWithState is12Hour={ is12Hour } />;
 };

--- a/packages/components/src/date-time/stories/index.js
+++ b/packages/components/src/date-time/stories/index.js
@@ -1,0 +1,35 @@
+/**
+ * External dependencies
+ */
+import { boolean } from '@storybook/addon-knobs';
+
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { DateTimePicker } from '../';
+
+export default {
+	title: 'Components/DateTimePicker',
+	component: DateTimePicker,
+};
+
+const DateTimePickerWithState = () => {
+	const [ date, setDate ] = useState();
+	const is12Hour = boolean( 'Is 12 hour (shows AM/PM)', false );
+	return (
+		<DateTimePicker
+			currentDate={ date }
+			onChange={ setDate }
+			is12Hour={ is12Hour }
+		/>
+	);
+};
+
+export const _default = () => {
+	return <DateTimePickerWithState />;
+};


### PR DESCRIPTION
## Description
Adds a simple story for the `DateTimePicker`. 

## How has this been tested?
In the storybook, `npm run storybook:dev`

## Screenshots
<img width="896" alt="Screenshot 2020-05-01 at 12 50 15" src="https://user-images.githubusercontent.com/156676/80800675-5aa9cc80-8baa-11ea-803e-59f311f7df5e.png">

## Types of changes
New feature (non-breaking change which adds functionality)
