### PR TITLE
Deprecate the original slot implementation and refactor usage

### DIFF
--- a/packages/block-editor/src/components/block-settings-menu-controls/index.js
+++ b/packages/block-editor/src/components/block-settings-menu-controls/index.js
@@ -1,12 +1,16 @@
 /**
  * External dependencies
  */
-import { isEmpty, map } from 'lodash';
+import { map } from 'lodash';
 
 /**
  * WordPress dependencies
  */
-import { createSlotFill, MenuGroup } from '@wordpress/components';
+import {
+	createSlotFill,
+	MenuGroup,
+	__experimentalUseSlot as useSlot,
+} from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 
 const { Fill: BlockSettingsMenuControls, Slot } = createSlotFill(
@@ -25,13 +29,20 @@ const BlockSettingsMenuControlsSlot = ( { fillProps } ) => {
 			),
 		};
 	}, [] );
+	const slot = useSlot( 'BlockSettingsMenuControls' );
+	const hasFills = Boolean( slot.fills && slot.fills.length );
+
+	if ( ! hasFills ) {
+		return null;
+	}
 
 	return (
-		<Slot fillProps={ { ...fillProps, selectedBlocks } }>
-			{ ( fills ) =>
-				! isEmpty( fills ) && <MenuGroup>{ fills }</MenuGroup>
-			}
-		</Slot>
+		<MenuGroup>
+			<Slot
+				bubblesVirtually
+				fillProps={ { ...fillProps, selectedBlocks } }
+			/>
+		</MenuGroup>
 	);
 };
 

--- a/packages/block-editor/src/components/block-settings-menu/index.js
+++ b/packages/block-editor/src/components/block-settings-menu/index.js
@@ -78,6 +78,7 @@ export function BlockSettingsMenu( { clientIds } ) {
 							<>
 								<MenuGroup>
 									<__experimentalBlockSettingsMenuFirstItem.Slot
+										bubblesVirtually
 										fillProps={ { onClose } }
 									/>
 									{ count === 1 && (

--- a/packages/block-editor/src/components/inserter-menu-extension/index.js
+++ b/packages/block-editor/src/components/inserter-menu-extension/index.js
@@ -8,5 +8,7 @@ const { Fill: __experimentalInserterMenuExtension, Slot } = createSlotFill(
 );
 
 __experimentalInserterMenuExtension.Slot = Slot;
+__experimentalInserterMenuExtension.Slot.slotName =
+	'__experimentalInserterMenuExtension';
 
 export default __experimentalInserterMenuExtension;

--- a/packages/block-editor/src/components/inserter/block-list.js
+++ b/packages/block-editor/src/components/inserter/block-list.js
@@ -16,7 +16,10 @@ import {
  * WordPress dependencies
  */
 import { __, _x, _n, sprintf } from '@wordpress/i18n';
-import { withSpokenMessages } from '@wordpress/components';
+import {
+	withSpokenMessages,
+	__experimentalUseSlot as useSlot,
+} from '@wordpress/components';
 import { addQueryArgs } from '@wordpress/url';
 import { controlsRepeat } from '@wordpress/icons';
 import { speak } from '@wordpress/a11y';
@@ -187,6 +190,10 @@ function InserterBlockList( {
 
 	const hasItems = ! isEmpty( filteredItems );
 	const hasChildItems = childItems.length > 0;
+	const slot = { fills: [ 'test' ] }; //useSlot( __experimentalInserterMenuExtension.Slot.slotName );
+	const hasInserterExtensionFills = Boolean(
+		slot.fills && slot.fills.length
+	);
 
 	return (
 		<div>
@@ -272,28 +279,23 @@ function InserterBlockList( {
 				</InserterPanel>
 			) }
 
-			<__experimentalInserterMenuExtension.Slot
-				fillProps={ {
-					onSelect: onSelectItem,
-					onHover,
-					filterValue,
-					hasItems,
-				} }
-			>
-				{ ( fills ) => {
-					if ( fills.length ) {
-						return (
-							<InserterPanel title={ __( 'Search Results' ) }>
-								{ fills }
-							</InserterPanel>
-						);
-					}
-					if ( ! hasItems ) {
-						return <InserterNoResults />;
-					}
-					return null;
-				} }
-			</__experimentalInserterMenuExtension.Slot>
+			{ hasInserterExtensionFills && ! hasItems && (
+				<InserterPanel title={ __( 'Search Results' ) }>
+					<__experimentalInserterMenuExtension.Slot
+						bubblesVirtually
+						fillProps={ {
+							onSelect: onSelectItem,
+							onHover,
+							filterValue,
+							hasItems,
+						} }
+					/>
+				</InserterPanel>
+			) }
+
+			{ ! hasInserterExtensionFills && ! hasItems && (
+				<InserterNoResults />
+			) }
 		</div>
 	);
 }

--- a/packages/block-editor/src/components/inserter/block-list.js
+++ b/packages/block-editor/src/components/inserter/block-list.js
@@ -24,7 +24,7 @@ import { addQueryArgs } from '@wordpress/url';
 import { controlsRepeat } from '@wordpress/icons';
 import { speak } from '@wordpress/a11y';
 import { createBlock } from '@wordpress/blocks';
-import { useMemo, useEffect } from '@wordpress/element';
+import { useMemo, useEffect, useCallback } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 
@@ -100,22 +100,25 @@ function InserterBlockList( {
 		}
 	}, [] );
 
-	const onSelectItem = ( item ) => {
-		const { name, title, initialAttributes, innerBlocks } = item;
-		const insertedBlock = createBlock(
-			name,
-			initialAttributes,
-			createBlocksFromInnerBlocksTemplate( innerBlocks )
-		);
+	const onSelectItem = useCallback(
+		( item ) => {
+			const { name, title, initialAttributes, innerBlocks } = item;
+			const insertedBlock = createBlock(
+				name,
+				initialAttributes,
+				createBlocksFromInnerBlocksTemplate( innerBlocks )
+			);
 
-		onInsert( insertedBlock );
+			onInsert( insertedBlock );
 
-		if ( ! selectBlockOnInsert ) {
-			// translators: %s: the name of the block that has been added
-			const message = sprintf( __( '%s block added' ), title );
-			speak( message );
-		}
-	};
+			if ( ! selectBlockOnInsert ) {
+				// translators: %s: the name of the block that has been added
+				const message = sprintf( __( '%s block added' ), title );
+				speak( message );
+			}
+		},
+		[ onInsert, selectBlockOnInsert ]
+	);
 
 	const filteredItems = useMemo( () => {
 		return searchBlockItems( items, categories, collections, filterValue );
@@ -190,7 +193,7 @@ function InserterBlockList( {
 
 	const hasItems = ! isEmpty( filteredItems );
 	const hasChildItems = childItems.length > 0;
-	const slot = { fills: [ 'test' ] }; //useSlot( __experimentalInserterMenuExtension.Slot.slotName );
+	const slot = useSlot( __experimentalInserterMenuExtension.Slot.slotName );
 	const hasInserterExtensionFills = Boolean(
 		slot.fills && slot.fills.length
 	);

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -6,7 +6,7 @@ import { includes, pick } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { useState } from '@wordpress/element';
+import { useState, useCallback } from '@wordpress/element';
 import { LEFT, RIGHT, UP, DOWN, BACKSPACE, ENTER } from '@wordpress/keycodes';
 import { TabPanel } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -91,7 +91,7 @@ function InserterMenu( {
 	// Since it's a function only called when the event handlers are called,
 	// it's fine to extract it.
 	// eslint-disable-next-line no-restricted-syntax
-	function getInsertionIndex() {
+	const getInsertionIndex = useCallback( () => {
 		// If the clientId is defined, we insert at the position of the block.
 		if ( clientId ) {
 			return getBlockIndex( clientId, destinationRootClientId );
@@ -105,37 +105,48 @@ function InserterMenu( {
 
 		// Otherwise, we insert at the end of the current rootClientId
 		return getBlockOrder( destinationRootClientId ).length;
-	}
+	}, [ isAppender, clientId, destinationRootClientId ] );
 
-	const onInsertBlocks = ( blocks ) => {
-		const selectedBlock = getSelectedBlock();
-		if (
-			! isAppender &&
-			selectedBlock &&
-			isUnmodifiedDefaultBlock( selectedBlock )
-		) {
-			replaceBlocks( selectedBlock.clientId, blocks );
-		} else {
-			insertBlocks(
-				blocks,
-				getInsertionIndex(),
-				destinationRootClientId,
-				__experimentalSelectBlockOnInsert
-			);
-		}
+	const onInsertBlocks = useCallback(
+		( blocks ) => {
+			const selectedBlock = getSelectedBlock();
+			if (
+				! isAppender &&
+				selectedBlock &&
+				isUnmodifiedDefaultBlock( selectedBlock )
+			) {
+				replaceBlocks( selectedBlock.clientId, blocks );
+			} else {
+				insertBlocks(
+					blocks,
+					getInsertionIndex(),
+					destinationRootClientId,
+					__experimentalSelectBlockOnInsert
+				);
+			}
 
-		onSelect();
-	};
+			onSelect();
+		},
+		[
+			isAppender,
+			getInsertionIndex,
+			destinationRootClientId,
+			__experimentalSelectBlockOnInsert,
+		]
+	);
 
-	const onHover = ( item ) => {
-		setHoveredItem( item );
-		if ( item ) {
-			const index = getInsertionIndex();
-			showInsertionPoint( destinationRootClientId, index );
-		} else {
-			hideInsertionPoint();
-		}
-	};
+	const onHover = useCallback(
+		( item ) => {
+			setHoveredItem( item );
+			if ( item ) {
+				const index = getInsertionIndex();
+				showInsertionPoint( destinationRootClientId, index );
+			} else {
+				hideInsertionPoint();
+			}
+		},
+		[ getInsertionIndex, destinationRootClientId ]
+	);
 
 	const blocksTab = (
 		<>

--- a/packages/block-editor/src/components/rich-text/format-toolbar/index.js
+++ b/packages/block-editor/src/components/rich-text/format-toolbar/index.js
@@ -1,20 +1,16 @@
 /**
- * External dependencies
- */
-
-import { orderBy } from 'lodash';
-
-/**
  * WordPress dependencies
  */
-
 import { __ } from '@wordpress/i18n';
 import {
 	Toolbar,
 	Slot,
-	DropdownMenu,
+	Dropdown,
+	Button,
+	NavigableMenu,
 	__experimentalUseSlot as useSlot,
 } from '@wordpress/components';
+import { DOWN } from '@wordpress/keycodes';
 import { chevronDown } from '@wordpress/icons';
 
 const POPOVER_PROPS = {
@@ -25,7 +21,6 @@ const POPOVER_PROPS = {
 const FormatToolbar = () => {
 	const slot = useSlot( 'RichText.ToolbarControls' );
 	const hasFills = Boolean( slot.fills && slot.fills.length );
-	// This still needs to be fixed.
 
 	return (
 		<div className="block-editor-format-toolbar">
@@ -40,11 +35,41 @@ const FormatToolbar = () => {
 					)
 				) }
 				{ hasFills && (
-					<DropdownMenu
-						icon={ chevronDown }
-						label={ __( 'More rich text controls' ) }
-						controls={ [] }
+					<Dropdown
 						popoverProps={ POPOVER_PROPS }
+						renderToggle={ ( { isOpen, onToggle } ) => {
+							const openOnArrowDown = ( event ) => {
+								if ( ! isOpen && event.keyCode === DOWN ) {
+									event.preventDefault();
+									event.stopPropagation();
+									onToggle();
+								}
+							};
+
+							return (
+								<Button
+									icon={ chevronDown }
+									onClick={ onToggle }
+									onKeyDown={ openOnArrowDown }
+									aria-haspopup="true"
+									aria-expanded={ isOpen }
+									label={ __( 'More rich text controls' ) }
+									showTooltip
+								/>
+							);
+						} }
+						renderContent={ ( { onClose } ) => (
+							<NavigableMenu
+								aria-label={ __( 'More rich text controls' ) }
+								role="menu"
+							>
+								<Slot
+									name="RichText.ToolbarControls"
+									bubblesVirtually
+									fillProps={ { onClose } }
+								/>
+							</NavigableMenu>
+						) }
 					/>
 				) }
 			</Toolbar>

--- a/packages/block-editor/src/components/rich-text/format-toolbar/index.js
+++ b/packages/block-editor/src/components/rich-text/format-toolbar/index.js
@@ -9,7 +9,12 @@ import { orderBy } from 'lodash';
  */
 
 import { __ } from '@wordpress/i18n';
-import { Toolbar, Slot, DropdownMenu } from '@wordpress/components';
+import {
+	Toolbar,
+	Slot,
+	DropdownMenu,
+	__experimentalUseSlot as useSlot,
+} from '@wordpress/components';
 import { chevronDown } from '@wordpress/icons';
 
 const POPOVER_PROPS = {
@@ -18,6 +23,10 @@ const POPOVER_PROPS = {
 };
 
 const FormatToolbar = () => {
+	const slot = useSlot( 'RichText.ToolbarControls' );
+	const hasFills = Boolean( slot.fills && slot.fills.length );
+	// This still needs to be fixed.
+
 	return (
 		<div className="block-editor-format-toolbar">
 			<Toolbar>
@@ -26,24 +35,18 @@ const FormatToolbar = () => {
 						<Slot
 							name={ `RichText.ToolbarControls.${ format }` }
 							key={ format }
+							bubblesVirtually
 						/>
 					)
 				) }
-				<Slot name="RichText.ToolbarControls">
-					{ ( fills ) =>
-						fills.length !== 0 && (
-							<DropdownMenu
-								icon={ chevronDown }
-								label={ __( 'More rich text controls' ) }
-								controls={ orderBy(
-									fills.map( ( [ { props } ] ) => props ),
-									'title'
-								) }
-								popoverProps={ POPOVER_PROPS }
-							/>
-						)
-					}
-				</Slot>
+				{ hasFills && (
+					<DropdownMenu
+						icon={ chevronDown }
+						label={ __( 'More rich text controls' ) }
+						controls={ [] }
+						popoverProps={ POPOVER_PROPS }
+					/>
+				) }
 			</Toolbar>
 		</div>
 	);

--- a/packages/block-editor/src/components/rich-text/format-toolbar/index.native.js
+++ b/packages/block-editor/src/components/rich-text/format-toolbar/index.native.js
@@ -11,6 +11,7 @@ const FormatToolbar = () => {
 				<Slot
 					name={ `RichText.ToolbarControls.${ format }` }
 					key={ format }
+					bubblesVirtually
 				/>
 			) ) }
 			<Slot name="RichText.ToolbarControls" />

--- a/packages/block-editor/src/components/rich-text/style.scss
+++ b/packages/block-editor/src/components/rich-text/style.scss
@@ -64,3 +64,9 @@ figcaption.block-editor-rich-text__editable [data-rich-text-placeholder]::before
 		padding-right: $grid-unit-15;
 	}
 }
+
+
+.block-editor-rich-text__advanced-toolbar-button {
+	display: flex;
+	width: 100%;
+}

--- a/packages/block-editor/src/components/rich-text/toolbar-button.js
+++ b/packages/block-editor/src/components/rich-text/toolbar-button.js
@@ -1,7 +1,12 @@
 /**
+ * External dependencies
+ */
+import { omit } from 'lodash';
+
+/**
  * WordPress dependencies
  */
-import { Fill, ToolbarButton } from '@wordpress/components';
+import { Fill, ToolbarButton, Button } from '@wordpress/components';
 import { displayShortcut } from '@wordpress/keycodes';
 
 export function RichTextToolbarButton( {
@@ -21,9 +26,31 @@ export function RichTextToolbarButton( {
 		shortcut = displayShortcut[ shortcutType ]( shortcutCharacter );
 	}
 
+	if ( name ) {
+		return (
+			<Fill name={ fillName }>
+				<ToolbarButton { ...props } shortcut={ shortcut } />
+			</Fill>
+		);
+	}
+
 	return (
 		<Fill name={ fillName }>
-			<ToolbarButton { ...props } shortcut={ shortcut } />
+			{ ( { onClose } ) => (
+				<Button
+					className="block-editor-rich-text__advanced-toolbar-button"
+					role="menuitem"
+					{ ...omit( props, [ 'title', 'onClick' ] ) }
+					onClick={ ( event ) => {
+						if ( props.onClick ) {
+							props.onClick( event );
+						}
+						onClose();
+					} }
+				>
+					{ props.title }
+				</Button>
+			) }
 		</Fill>
 	);
 }

--- a/packages/components/src/slot-fill/bubbles-virtually/slot.js
+++ b/packages/components/src/slot-fill/bubbles-virtually/slot.js
@@ -33,6 +33,7 @@ export default function Slot( {
 
 	// fillProps may be an update that interact with the layout, so
 	// we useLayoutEffect
+	// Make sure to memoize your fill Props to avoid infinite loops.
 	useLayoutEffect( () => {
 		if ( slot.fillProps && ! isShallowEqual( slot.fillProps, fillProps ) ) {
 			registry.updateSlot( name, ref, fillProps );

--- a/packages/components/src/slot-fill/index.js
+++ b/packages/components/src/slot-fill/index.js
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import deprecated from '@wordpress/deprecated';
+
+/**
  * Internal dependencies
  */
 import BaseSlot from './slot';
@@ -12,6 +17,13 @@ export function Slot( { bubblesVirtually, ...props } ) {
 	if ( bubblesVirtually ) {
 		return <BubblesVirtuallySlot { ...props } />;
 	}
+
+	deprecated( 'Slots without event bubbling', {
+		hint:
+			"Set the bubblesVirtually prop to true for your slot and make sure it doesn't regress. On future versions, this prop will be enabled by default. Your slot name: " +
+			props.name,
+	} );
+
 	return <BaseSlot { ...props } />;
 }
 

--- a/packages/edit-post/src/components/header/plugins-more-menu-group/index.js
+++ b/packages/edit-post/src/components/header/plugins-more-menu-group/index.js
@@ -1,26 +1,32 @@
 /**
- * External dependencies
- */
-import { isEmpty } from 'lodash';
-
-/**
  * WordPress dependencies
  */
-import { createSlotFill, MenuGroup } from '@wordpress/components';
+import {
+	createSlotFill,
+	MenuGroup,
+	__experimentalUseSlot as useSlot,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 const { Fill: PluginsMoreMenuGroup, Slot } = createSlotFill(
 	'PluginsMoreMenuGroup'
 );
 
-PluginsMoreMenuGroup.Slot = ( { fillProps } ) => (
-	<Slot fillProps={ fillProps }>
-		{ ( fills ) =>
-			! isEmpty( fills ) && (
-				<MenuGroup label={ __( 'Plugins' ) }>{ fills }</MenuGroup>
-			)
-		}
-	</Slot>
-);
+function PluginsMoreMenuGroupSlot( { fillProps } ) {
+	const slot = useSlot( 'PluginsMoreMenuGroup' );
+	const hasFills = Boolean( slot.fills && slot.fills.length );
+
+	if ( ! hasFills ) {
+		return null;
+	}
+
+	return (
+		<MenuGroup label={ __( 'Plugins' ) }>
+			<Slot fillProps={ fillProps } bubblesVirtually />
+		</MenuGroup>
+	);
+}
+
+PluginsMoreMenuGroup.Slot = PluginsMoreMenuGroupSlot;
 
 export default PluginsMoreMenuGroup;

--- a/packages/edit-post/src/components/header/tools-more-menu-group/index.js
+++ b/packages/edit-post/src/components/header/tools-more-menu-group/index.js
@@ -1,26 +1,32 @@
 /**
- * External dependencies
- */
-import { isEmpty } from 'lodash';
-
-/**
  * WordPress dependencies
  */
-import { createSlotFill, MenuGroup } from '@wordpress/components';
+import {
+	createSlotFill,
+	MenuGroup,
+	__experimentalUseSlot as useSlot,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 const { Fill: ToolsMoreMenuGroup, Slot } = createSlotFill(
 	'ToolsMoreMenuGroup'
 );
 
-ToolsMoreMenuGroup.Slot = ( { fillProps } ) => (
-	<Slot fillProps={ fillProps }>
-		{ ( fills ) =>
-			! isEmpty( fills ) && (
-				<MenuGroup label={ __( 'Tools' ) }>{ fills }</MenuGroup>
-			)
-		}
-	</Slot>
-);
+function ToolsMoreMenuGroupSlot( { fillProps } ) {
+	const slot = useSlot( 'ToolsMoreMenuGroup' );
+	const hasFills = Boolean( slot.fills && slot.fills.length );
+
+	if ( ! hasFills ) {
+		return null;
+	}
+
+	return (
+		<MenuGroup label={ __( 'Tools' ) }>
+			<Slot fillProps={ fillProps } bubblesVirtually />
+		</MenuGroup>
+	);
+}
+
+ToolsMoreMenuGroup.Slot = ToolsMoreMenuGroupSlot;
 
 export default ToolsMoreMenuGroup;

--- a/packages/edit-post/src/components/options-modal/index.js
+++ b/packages/edit-post/src/components/options-modal/index.js
@@ -49,7 +49,7 @@ export function OptionsModal( { isModalActive, isViewable, closeModal } ) {
 				/>
 			</Section>
 			<Section title={ __( 'Document panels' ) }>
-				<EnablePluginDocumentSettingPanelOption.Slot />
+				<EnablePluginDocumentSettingPanelOption.Slot bubblesVirtually />
 				{ isViewable && (
 					<EnablePanelOption
 						label={ __( 'Permalink' ) }

--- a/packages/edit-post/src/components/sidebar/plugin-post-status-info/test/index.js
+++ b/packages/edit-post/src/components/sidebar/plugin-post-status-info/test/index.js
@@ -20,7 +20,7 @@ describe( 'PluginPostStatusInfo', () => {
 				<PluginPostStatusInfo className="my-plugin-post-status-info">
 					My plugin post status info
 				</PluginPostStatusInfo>
-				<PluginPostStatusInfo.Slot />
+				<PluginPostStatusInfo.Slot bubblesVirtually />
 			</SlotFillProvider>
 		).toJSON();
 

--- a/packages/edit-post/src/components/sidebar/post-status/index.js
+++ b/packages/edit-post/src/components/sidebar/post-status/index.js
@@ -32,21 +32,15 @@ function PostStatus( { isOpened, onTogglePanel } ) {
 			opened={ isOpened }
 			onToggle={ onTogglePanel }
 		>
-			<PluginPostStatusInfo.Slot>
-				{ ( fills ) => (
-					<>
-						<PostVisibility />
-						<PostSchedule />
-						<PostFormat />
-						<PostSticky />
-						<PostPendingStatus />
-						<PostSlug />
-						<PostAuthor />
-						{ fills }
-						<PostTrash />
-					</>
-				) }
-			</PluginPostStatusInfo.Slot>
+			<PostVisibility />
+			<PostSchedule />
+			<PostFormat />
+			<PostSticky />
+			<PostPendingStatus />
+			<PostSlug />
+			<PostAuthor />
+			<PluginPostStatusInfo.Slot bubblesVirtually />
+			<PostTrash />
 		</PanelBody>
 	);
 }

--- a/packages/edit-post/src/components/sidebar/settings-sidebar/index.js
+++ b/packages/edit-post/src/components/sidebar/settings-sidebar/index.js
@@ -45,7 +45,7 @@ const SettingsSidebar = () => {
 			{ sidebarName === 'edit-post/document' && (
 				<>
 					<PostStatus />
-					<PluginDocumentSettingPanel.Slot />
+					<PluginDocumentSettingPanel.Slot bubblesVirtually />
 					<LastRevision />
 					<PostLink />
 					<PostTaxonomies />

--- a/packages/interface/src/components/complementary-area/index.js
+++ b/packages/interface/src/components/complementary-area/index.js
@@ -19,7 +19,13 @@ import ComplementaryAreaHeader from '../complementary-area-header';
 import PinnedItems from '../pinned-items';
 
 function ComplementaryAreaSlot( { scope, ...props } ) {
-	return <Slot name={ `ComplementaryArea/${ scope }` } { ...props } />;
+	return (
+		<Slot
+			name={ `ComplementaryArea/${ scope }` }
+			bubblesVirtually
+			{ ...props }
+		/>
+	);
 }
 
 function ComplementaryAreaFill( { scope, children, className } ) {

--- a/packages/interface/src/components/pinned-items/index.js
+++ b/packages/interface/src/components/pinned-items/index.js
@@ -15,7 +15,7 @@ function PinnedItems( { scope, ...props } ) {
 
 function PinnedItemsSlot( { scope, className, ...props } ) {
 	return (
-		<Slot name={ `PinnedItems/${ scope }` } { ...props }>
+		<Slot name={ `PinnedItems/${ scope }` } bubblesVirtually { ...props }>
 			{ ( fills ) =>
 				! isEmpty( fills ) && (
 					<div


### PR DESCRIPTION
The original implementation of Slot (without bubblesVirtually) suffers from a number of issues, Important one being the lack of React context support. We've been slowing moving out from its usage but we forget sometimes to use  `bubblesVirtually` when we add a new Slot. 

This PR deprecates the old implementation officially (deprecation message) and  updates the existing usage.