### PR TITLE
Build Tools: Disable ESLint `no-console` for bin directory

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -172,5 +172,11 @@ module.exports = {
 				'jest/expect-expect': 'off',
 			},
 		},
+		{
+			files: [ 'bin/**/*.js' ],
+			rules: {
+				'no-console': 'off',
+			},
+		},
 	],
 };

--- a/bin/.eslintrc.json
+++ b/bin/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+	"rules": {
+		"no-console": "off"
+	}
+}

--- a/bin/.eslintrc.json
+++ b/bin/.eslintrc.json
@@ -1,5 +1,0 @@
-{
-	"rules": {
-		"no-console": "off"
-	}
-}

--- a/bin/api-docs/update-api-docs.js
+++ b/bin/api-docs/update-api-docs.js
@@ -223,9 +223,6 @@ glob.stream( [
 					{ shell: true }
 				);
 			} catch ( error ) {
-				// Disable reason: Errors should log to console.
-
-				// eslint-disable-next-line no-console
 				console.error( error );
 				process.exit( 1 );
 			}

--- a/bin/changelog.js
+++ b/bin/changelog.js
@@ -1,8 +1,6 @@
 #!/usr/bin/env node
 'use strict';
 
-/* eslint-disable no-console */
-
 /*
  * External dependencies
  */
@@ -271,5 +269,3 @@ if ( ! module.parent ) {
 /** @type {NodeJS.Module} */ ( module ).exports = {
 	getNormalizedTitle,
 };
-
-/* eslint-enable no-console */

--- a/bin/check-latest-npm.js
+++ b/bin/check-latest-npm.js
@@ -111,9 +111,6 @@ Run ${ yellow(
 		}
 	} )
 	.catch( ( error ) => {
-		// Disable reason: A failure should log to the terminal.
-
-		// eslint-disable-next-line no-console
 		console.error(
 			'Latest NPM check failed!\n\n' + error.toString() + '\n'
 		);

--- a/bin/commander.js
+++ b/bin/commander.js
@@ -1,7 +1,5 @@
 #!/usr/bin/env node
 
-/* eslint-disable no-console */
-
 // Dependencies
 const path = require( 'path' );
 const program = require( 'commander' );
@@ -1136,5 +1134,3 @@ program
 	} );
 
 program.parse( process.argv );
-
-/* eslint-enable no-console */

--- a/bin/packages/build.js
+++ b/bin/packages/build.js
@@ -1,5 +1,3 @@
-/* eslint-disable no-console */
-
 /**
  * External dependencies
  */
@@ -180,5 +178,3 @@ stream
 	)
 	.on( 'end', () => ( ended = true ) )
 	.resume();
-
-/* eslint-enable no-console */

--- a/bin/packages/lint-staged-typecheck.js
+++ b/bin/packages/lint-staged-typecheck.js
@@ -11,8 +11,6 @@ const execa = require( 'execa' );
  */
 require( './validate-typescript-version' );
 
-/* eslint-disable no-console */
-
 const repoRoot = path.join( __dirname, '..', '..' );
 const tscPath = path.join( repoRoot, 'node_modules', '.bin', 'tsc' );
 
@@ -35,5 +33,3 @@ try {
 	console.error( err.stdout );
 	process.exitCode = 1;
 }
-
-/* eslint-enable no-console */

--- a/bin/packages/validate-typescript-version.js
+++ b/bin/packages/validate-typescript-version.js
@@ -9,8 +9,6 @@ const tscDetectedVersion = require( 'typescript' ).version;
 const tscDependencyVersion = require( '../../package.json' ).devDependencies
 	.typescript;
 
-/* eslint-disable no-console */
-
 if ( tscDependencyVersion !== tscDetectedVersion ) {
 	console.error(
 		[
@@ -24,5 +22,3 @@ if ( tscDependencyVersion !== tscDetectedVersion ) {
 	);
 	process.exit( 1 );
 }
-
-/* eslint-enable no-console */

--- a/bin/packages/watch.js
+++ b/bin/packages/watch.js
@@ -52,7 +52,6 @@ getPackages().forEach( ( p ) => {
 
 				const filePath = path.resolve( srcDir, filename );
 				if ( event === 'update' && exists( filePath ) ) {
-					// eslint-disable-next-line no-console
 					console.log(
 						chalk.green( '->' ),
 						`${ event }: ${ filename }`
@@ -95,5 +94,4 @@ setInterval( () => {
 	}
 }, 100 );
 
-// eslint-disable-next-line no-console
 console.log( chalk.red( '->' ), chalk.cyan( 'Watching for changes...' ) );


### PR DESCRIPTION
This pull request seeks to add an ESLint configuration augment to the `bin/` directory to disable the ESLint [`no-console` rule](https://eslint.org/docs/rules/no-console) otherwise active in the project. Most all of these scripts are intended to be used as command-line scripts, and as such are very likely to be outputting to stdout via `console.log`. Until now, we've resorted to adding either inline or file-level overrides. The changes here simply seek to configure it for the entire directory.

Part of me was reluctant to make this change to force it to be a conscious choice to designate where logging occurs, since it may still be possible after these changes that we inadvertently include debugging logging that we'd otherwise want to discourage. I feel that the risk/reward balance still favors disabling the rule, since there's a reasonably high friction here in disabling the rule, and a low likelihood of and low risk inherent in allowing erroneous logging.

Note that ESLint configuration files can be additive this way, where the absence of `"root": true` will allow this configuration to override parts of the root configuration, while still enforcing all other rules.

**Testing Instructions:**

Verify lint passes:

```
npm run lint-js
```

Verify lint still fails for all other rules:

```
echo "\n\n\n" >> bin/changelog.js && npm run lint-js bin/changelog.js
```