### PR TITLE
WIP - entities 'save as' feature

### DIFF
--- a/packages/editor/src/components/entities-saved-states/index.js
+++ b/packages/editor/src/components/entities-saved-states/index.js
@@ -23,6 +23,7 @@ import {
 	grid,
 	blockDefault,
 } from '@wordpress/icons';
+import { cleanForSlug } from '@wordpress/url';
 
 const ENTITY_NAME_ICONS = {
 	site: layout,
@@ -100,6 +101,32 @@ function EntityRecordState( { record, checked, onChange, closePanel } ) {
 		[ slug, theme ]
 	);
 
+	const editedEntity = useSelect(
+		( select ) => select( 'core' ).getEditedEntityRecord( kind, name, key ),
+		[]
+	);
+
+	// Saving goo.
+	const { saveEntityRecord } = useDispatch( 'core' );
+	const [ help, setHelp ] = useState();
+	const createNew = useCallback( async () => {
+		// Create a new template part.
+		try {
+			const cleanSlug = cleanForSlug( slug );
+			const templatePart = await saveEntityRecord( 'postType', name, {
+				title: cleanSlug,
+				status: 'publish',
+				slug: cleanSlug,
+				meta: { theme },
+				// Nahh, this doesn't work.. maybe we need to create/ add to editor/ then insert blocks and save?
+				blocks: [ ...editedEntity.blocks ],
+			} );
+			// templatePart.id => new id
+		} catch ( err ) {
+			setHelp( __( 'Error adding template.' ) );
+		}
+	}, [ slug, theme, editedEntity ] );
+
 	return (
 		<>
 			<PanelRow>
@@ -149,7 +176,7 @@ function EntityRecordState( { record, checked, onChange, closePanel } ) {
 						placeholder={ __( 'header' ) }
 						value={ slug }
 						onChange={ setSlug }
-						// help={ help }
+						help={ help }
 						className="wp-block-template-part__placeholder-input"
 					/>
 					<TextControl
@@ -172,7 +199,7 @@ function EntityRecordState( { record, checked, onChange, closePanel } ) {
 					<PanelRow>
 						<Button
 							disabled={ comboInUse }
-							onClick={ toggleSavingAs }
+							onClick={ createNew }
 							isPrimary
 							className="entities-saved-states__save-as-button"
 						>

--- a/packages/editor/src/components/entities-saved-states/index.js
+++ b/packages/editor/src/components/entities-saved-states/index.js
@@ -128,20 +128,39 @@ function EntityRecordState( { record, checked, onChange, closePanel } ) {
 				) : null }
 			</PanelRow>
 			<PanelRow>
-				{ canSaveAs ? (
+				{ canSaveAs && ! savingAs && (
 					<Button
 						onClick={ toggleSavingAs }
 						className="entities-saved-states__save-as"
 					>
 						{ __( 'Save as…' ) }
 					</Button>
-				) : null }
+				) }
 			</PanelRow>
 			{ savingAs && (
 				<>
 					<PanelRow>
+						{ slug && theme ? (
+							<>
+								{ comboInUse ? (
+									<h3>{ __( 'Slug/Theme combo in use' ) }</h3>
+								) : (
+									<h3>
+										{ __( 'Slug/Theme combo Available!' ) }
+									</h3>
+								) }
+							</>
+						) : (
+							<h3>
+								{ __(
+									'Enter a new Slug and Theme combo to save as new:'
+								) }
+							</h3>
+						) }
+					</PanelRow>
+					<PanelRow>
 						<TextControl
-							label={ __( 'Slug' ) }
+							label={ __( 'New Slug' ) }
 							placeholder={ __( 'header' ) }
 							value={ slug }
 							onChange={ setSlug }
@@ -161,25 +180,16 @@ function EntityRecordState( { record, checked, onChange, closePanel } ) {
 							disabled={ comboInUse }
 							onClick={ toggleSavingAs }
 							isPrimary
-							className="entities-saved-states__save-as"
+							className="entities-saved-states__save-as-button"
 						>
 							{ __( 'Save as…' ) }
 						</Button>
-					</PanelRow>
-					<PanelRow>
-						{ slug && theme ? (
-							<>
-								{ comboInUse ? (
-									<h3>{ __( 'Slug/Theme combo in use' ) }</h3>
-								) : (
-									<h3>
-										{ __( 'Slug/Theme combo Available!' ) }
-									</h3>
-								) }
-							</>
-						) : (
-							<h3>{ __( 'Enter a Slug and Theme combo.' ) }</h3>
-						) }
+						<Button
+							onClick={ toggleSavingAs }
+							className="entities-saved-states__cancel-save-as-button"
+						>
+							{ __( 'Cancel' ) }
+						</Button>
 					</PanelRow>
 				</>
 			) }

--- a/packages/editor/src/components/entities-saved-states/index.js
+++ b/packages/editor/src/components/entities-saved-states/index.js
@@ -121,6 +121,7 @@ function EntityRecordState( { record, checked, onChange, closePanel } ) {
 				// Nahh, this doesn't work.. maybe we need to create/ add to editor/ then insert blocks and save?
 				blocks: [ ...editedEntity.blocks ],
 			} );
+			toggleSavingAs();
 			// templatePart.id => new id
 		} catch ( err ) {
 			setHelp( __( 'Error adding template.' ) );

--- a/packages/editor/src/components/entities-saved-states/index.js
+++ b/packages/editor/src/components/entities-saved-states/index.js
@@ -139,42 +139,36 @@ function EntityRecordState( { record, checked, onChange, closePanel } ) {
 			</PanelRow>
 			{ savingAs && (
 				<>
-					<PanelRow>
-						{ slug && theme ? (
-							<>
-								{ comboInUse ? (
-									<h3>{ __( 'Slug/Theme combo in use' ) }</h3>
-								) : (
-									<h3>
-										{ __( 'Slug/Theme combo Available!' ) }
-									</h3>
-								) }
-							</>
-						) : (
-							<h3>
-								{ __(
-									'Enter a new Slug and Theme combo to save as new:'
-								) }
-							</h3>
-						) }
-					</PanelRow>
-					<PanelRow>
-						<TextControl
-							label={ __( 'New Slug' ) }
-							placeholder={ __( 'header' ) }
-							value={ slug }
-							onChange={ setSlug }
-							// help={ help }
-							className="wp-block-template-part__placeholder-input"
-						/>
-						<TextControl
-							label={ __( 'Theme' ) }
-							placeholder={ __( 'twentytwenty' ) }
-							value={ theme }
-							onChange={ setTheme }
-							className="wp-block-template-part__placeholder-input"
-						/>
-					</PanelRow>
+					<hr />
+					<h3>
+						{ __( 'Enter a new Slug and Theme combo to save as:' ) }
+					</h3>
+
+					<TextControl
+						label={ __( 'New Slug' ) }
+						placeholder={ __( 'header' ) }
+						value={ slug }
+						onChange={ setSlug }
+						// help={ help }
+						className="wp-block-template-part__placeholder-input"
+					/>
+					<TextControl
+						label={ __( 'Theme' ) }
+						placeholder={ __( 'twentytwenty' ) }
+						value={ theme }
+						onChange={ setTheme }
+						className="wp-block-template-part__placeholder-input"
+					/>
+
+					{ slug && theme && (
+						<>
+							{ comboInUse ? (
+								<h3>{ __( 'Slug/Theme combo in use' ) }</h3>
+							) : (
+								<h3>{ __( 'Slug/Theme combo Available!' ) }</h3>
+							) }
+						</>
+					) }
 					<PanelRow>
 						<Button
 							disabled={ comboInUse }


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
WIP for a 'save as' feature.  Currently adds UI, but will need to do more work to get proper save as functionality working.  This will need a bit of refactoring as well.  (This may not get much progress in the next 2 weeks as I may be a bit distracted elsewhere.  If anyone wants to jump in.. feel free!)

![closes-inputs](https://user-images.githubusercontent.com/28742426/80843226-bdfb2500-8bd1-11ea-9a61-e35f4eeb1161.gif)


 As of now clicking 'save' will save a new entity with the new slug/theme name, but with no content or replacement to the editor. 
## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Locally in both site and post editors.


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
