### PR TITLE
ESLint Plugin: New Rule: no-unsafe-optional-chaining-negation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9038,6 +9038,22 @@
 			"resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
 			"integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
 		},
+		"@types/eslint": {
+			"version": "6.8.0",
+			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-6.8.0.tgz",
+			"integrity": "sha512-hqzmggoxkOubpgTdcOltkfc5N8IftRJqU70d1jbOISjjZVPvjcr+CLi2CI70hx1SUIRkLgpglTy9w28nGe2Hsw==",
+			"dev": true,
+			"requires": {
+				"@types/estree": "*",
+				"@types/json-schema": "*"
+			}
+		},
+		"@types/estree": {
+			"version": "0.0.44",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.44.tgz",
+			"integrity": "sha512-iaIVzr+w2ZJ5HkidlZ3EJM8VTZb2MJLCjw3V+505yVts0gRC4UMvjw0d1HPtGqI/HQC/KdsYtayfzl+AXY2R8g==",
+			"dev": true
+		},
 		"@types/events": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -89,6 +89,8 @@
 		"@storybook/react": "5.3.2",
 		"@testing-library/react": "10.0.2",
 		"@types/classnames": "2.2.10",
+		"@types/eslint": "6.8.0",
+		"@types/estree": "0.0.44",
 		"@types/lodash": "4.14.149",
 		"@types/prettier": "1.19.0",
 		"@types/qs": "6.9.1",

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -4,7 +4,12 @@
 
 ### Breaking Changes
 
--  The severity of the rule, `jsdoc/no-undefined-types`, has been increased from `warn` to `error`. In addition, `JSX` has been added to the default list of defined types.
+- The severity of the rule, `jsdoc/no-undefined-types`, has been increased from `warn` to `error`. In addition, `JSX` has been added to the default list of defined types.
+- The new [`@wordpress/no-unsafe-optional-chaining-negation` rule](https://github.com/WordPress/gutenberg/blob/master/packages/eslint-plugin/docs/rules/no-unsafe-optional-chaining-negation.md) is now part of the recommended ruleset.
+
+### New Features
+
+- New Rule: [`@wordpress/no-unsafe-optional-chaining-negation`](https://github.com/WordPress/gutenberg/blob/master/packages/eslint-plugin/docs/rules/no-unsafe-optional-chaining-negation.md)
 
 ### Improvements
 

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -69,6 +69,7 @@ Rule|Description|Recommended
 [i18n-no-variables](/packages/eslint-plugin/docs/rules/i18n-no-variables.md)|Enforce string literals as translation function arguments|✓
 [i18n-text-domain](/packages/eslint-plugin/docs/rules/i18n-text-domain.md)|Enforce passing valid text domains|✓
 [i18n-translator-comments](/packages/eslint-plugin/docs/rules/i18n-translator-comments.md)|Enforce adding translator comments|✓
+[no-unsafe-optional-chaining-negation](/packages/eslint-plugin/docs/rules/no-unsafe-optional-chaining-negation.md)| Disallow unsafe optional chaining negation|✓
 
 ### Legacy
 

--- a/packages/eslint-plugin/configs/custom.js
+++ b/packages/eslint-plugin/configs/custom.js
@@ -4,6 +4,7 @@ module.exports = {
 		'@wordpress/no-unused-vars-before-return': 'error',
 		'@wordpress/no-base-control-with-label-without-id': 'error',
 		'@wordpress/no-unguarded-get-range-at': 'error',
+		'@wordpress/no-unsafe-optional-chaining-negation': 'error',
 	},
 	overrides: [
 		{

--- a/packages/eslint-plugin/docs/rules/no-unsafe-optional-chaining-negation.md
+++ b/packages/eslint-plugin/docs/rules/no-unsafe-optional-chaining-negation.md
@@ -1,0 +1,23 @@
+# Avoid unsafe optional chaining negation (no-unsafe-optional-chaining-negation)
+
+Negating the result of an [optional chaining expression](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) is likely to produce an unexpected `true` value if the expression short-circuits on a nullish value.
+
+The following code would would evaluate to `true` if there is no active (focused) element, which is most likely not the expected result:
+
+```js
+const hasEnabledFocus = ! document.activeElement?.disabled;
+```
+
+## Rule details
+
+Example of **incorrect** code for this rule:
+
+```js
+const hasEnabledFocus = ! document.activeElement?.disabled;
+```
+
+Example of **correct** code for this rule:
+
+```js
+const hasEnabledFocus = document.activeElement && ! document.activeElement.disabled;
+```

--- a/packages/eslint-plugin/rules/__tests__/no-unsafe-optional-chaining-negation.js
+++ b/packages/eslint-plugin/rules/__tests__/no-unsafe-optional-chaining-negation.js
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+import { RuleTester } from 'eslint';
+
+/**
+ * Internal dependencies
+ */
+import rule from '../no-unsafe-optional-chaining-negation';
+
+const ruleTester = new RuleTester( {
+	parser: require.resolve( 'babel-eslint' ),
+	parserOptions: {
+		ecmaVersion: 6,
+		ecmaFeatures: {
+			jsx: true,
+		},
+	},
+} );
+
+ruleTester.run( 'no-unsafe-optional-chaining-negation', rule, {
+	valid: [
+		{
+			code: `foo?.bar`,
+		},
+	],
+	invalid: [
+		{
+			code: `! foo.bar?.baz`,
+			errors: [ { messageId: 'unsafeNegation' } ],
+		},
+	],
+} );

--- a/packages/eslint-plugin/rules/__tests__/no-unsafe-optional-chaining-negation.js
+++ b/packages/eslint-plugin/rules/__tests__/no-unsafe-optional-chaining-negation.js
@@ -23,10 +23,17 @@ ruleTester.run( 'no-unsafe-optional-chaining-negation', rule, {
 		{
 			code: `foo?.bar`,
 		},
+		{
+			code: `!! foo?.bar`,
+		},
 	],
 	invalid: [
 		{
 			code: `! foo.bar?.baz`,
+			errors: [ { messageId: 'unsafeNegation' } ],
+		},
+		{
+			code: `!!! foo.bar?.baz`,
 			errors: [ { messageId: 'unsafeNegation' } ],
 		},
 	],

--- a/packages/eslint-plugin/rules/no-unsafe-optional-chaining-negation.js
+++ b/packages/eslint-plugin/rules/no-unsafe-optional-chaining-negation.js
@@ -1,0 +1,28 @@
+module.exports = /** @type {import('eslint').Rule.RuleModule} */ ( {
+	meta: {
+		type: 'problem',
+		messages: {
+			unsafeNegation:
+				'Avoid unsafe negation of optional chaining expression',
+		},
+	},
+	create( context ) {
+		return {
+			/**
+			 * @param {import('estree').UnaryExpression} node Matched node.
+			 */
+			UnaryExpression( node ) {
+				if (
+					node.operator === '!' &&
+					// Ignore reason: Technically it's not a valid ESTree node,
+					// since it's a result from `babel-eslint` parse including
+					// newer language feature support.
+					// @ts-ignore
+					node.argument.type === 'OptionalMemberExpression'
+				) {
+					context.report( { node, messageId: 'unsafeNegation' } );
+				}
+			},
+		};
+	},
+} );

--- a/packages/eslint-plugin/rules/no-unsafe-optional-chaining-negation.js
+++ b/packages/eslint-plugin/rules/no-unsafe-optional-chaining-negation.js
@@ -7,20 +7,37 @@ module.exports = /** @type {import('eslint').Rule.RuleModule} */ ( {
 		},
 	},
 	create( context ) {
+		/**
+		 * Map of UnaryExpression nodes skip for consideration, in case of a
+		 * double-negation.
+		 *
+		 * @type {WeakMap<import('estree').UnaryExpression,boolean>}
+		 */
+		const skippedNodes = new WeakMap();
+
 		return {
 			/**
 			 * @param {import('estree').UnaryExpression} node Matched node.
 			 */
 			UnaryExpression( node ) {
-				if (
-					node.operator === '!' &&
+				if ( node.operator !== '!' || skippedNodes.has( node ) ) {
+					return;
+				}
+
+				switch ( node.argument.type ) {
 					// Ignore reason: Technically it's not a valid ESTree node,
 					// since it's a result from `babel-eslint` parse including
 					// newer language feature support.
 					// @ts-ignore
-					node.argument.type === 'OptionalMemberExpression'
-				) {
-					context.report( { node, messageId: 'unsafeNegation' } );
+					case 'OptionalMemberExpression':
+						context.report( { node, messageId: 'unsafeNegation' } );
+						break;
+
+					case 'UnaryExpression':
+						if ( node.argument.operator === '!' ) {
+							skippedNodes.set( node.argument, true );
+						}
+						break;
 				}
 			},
 		};

--- a/packages/eslint-plugin/tsconfig.json
+++ b/packages/eslint-plugin/tsconfig.json
@@ -1,0 +1,13 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"rootDir": "rules",
+		"declarationDir": "build-types"
+	},
+	// NOTE: This package is being progressively typed. You are encouraged to
+	// expand this array with files which can be type-checked. At some point in
+	// the future, this can be simplified to an `includes` of `src/**/*`.
+	"files": [
+		"rules/no-unsafe-optional-chaining-negation.js"
+	]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
 		{ "path": "packages/element" },
 		{ "path": "packages/dom-ready" },
 		{ "path": "packages/escape-html" },
+		{ "path": "packages/eslint-plugin" },
 		{ "path": "packages/html-entities" },
 		{ "path": "packages/i18n" },
 		{ "path": "packages/icons" },


### PR DESCRIPTION
Closes #21984

This pull request seeks to propose a new custom rule for `@wordpress/eslint-plugin`: `@wordpress/no-unsafe-optional-chaining-negation`.

Justification for the rule can be found at #21984, and in the included documentation:

>Negating the result of an [optional chaining expression](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) is likely to produce an unexpected `true` value if the expression short-circuits on a nullish value.
>
>The following code would would evaluate to `true` if there is no active (focused) element, which is most likely not the expected result:
>
>```js
>const hasEnabledFocus = ! document.activeElement?.disabled;
>```

**Testing Instructions:**

Verify unit tests pass:

```
npm run test-unit packages/eslint-plugin
```

Verify type-checking passes:

```
npm run build:package-types
```

Since this is marked as a recommended rule, verify its enforcement:

```
echo "console.log( ! module?.parent );" >> bin/changelog.js && npm run lint-js bin/changelog.js
```

```
/Users/andrew/Documents/Code/gutenberg/bin/changelog.js
  272:14  error  Avoid unsafe negation of optional chaining expression  @wordpress/no-unsafe-optional-chaining-negation

✖ 1 problem (1 error, 0 warnings)
```