### PR TITLE
Update/fix timepicker styling

### DIFF
--- a/packages/components/src/date-time/stories/index.js
+++ b/packages/components/src/date-time/stories/index.js
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import { withKnobs, boolean } from '@storybook/addon-knobs';
+
+/**
+ * Internal dependencies
+ */
+import { DatePicker, TimePicker, DateTimePicker } from '../';
+
+export default {
+	title: 'Components/DateTimePicker',
+	component: DateTimePicker,
+	decorators: [ withKnobs ],
+};
+
+export const _default = () => {
+	const is12Hour = boolean( 'is12Hour', true );
+	return <DateTimePicker is12Hour={ is12Hour } />;
+};
+
+export const timeOnly = () => {
+	const is12Hour = boolean( 'is12Hour', true );
+	return <TimePicker is12Hour={ is12Hour } />;
+};
+
+export const calendarOnly = () => {
+	const is12Hour = boolean( 'is12Hour', true );
+	return <DatePicker is12Hour={ is12Hour } />;
+};

--- a/packages/components/src/date-time/style.scss
+++ b/packages/components/src/date-time/style.scss
@@ -35,7 +35,10 @@
 	input {
 		@include input-style__neutral();
 	}
+}
 
+.components-datetime,
+.components-datetime__time {
 	// Override inherited conflicting styles to be consistent.
 	select,
 	input[type="number"],

--- a/packages/components/src/date-time/style.scss
+++ b/packages/components/src/date-time/style.scss
@@ -37,18 +37,6 @@
 	}
 }
 
-.components-datetime,
-.components-datetime__time {
-	// Override inherited conflicting styles to be consistent.
-	select,
-	input[type="number"],
-	.components-button {
-		height: 30px;
-		margin-top: 0;
-		margin-bottom: 0;
-	}
-}
-
 .components-datetime__date {
 	min-height: 236px;
 	border-top: 1px solid $gray-200;
@@ -173,6 +161,15 @@
 					margin: 0;
 				}
 			}
+		}
+
+		// Override inherited conflicting styles to be consistent.
+		select,
+		input[type="number"],
+		.components-button {
+			height: 30px;
+			margin-top: 0;
+			margin-bottom: 0;
 		}
 	}
 


### PR DESCRIPTION
## Description
The height of the AM/PM buttons when using the standalone `TimePicker` is higher than the rest of the input controls than when it is used in the full `DateTimePicker` component. This PR fixes the scss definition so the existing height override is also applied to the `TimePicker` when used on its own.

Stories were also added to the component so it can be viewed in Storybook.

## How has this been tested?
This was tested in Storybook to ensure the changes render correctly, as well existing uses of the component (the DateTime picker when choosing a publish time for a post) were tested to ensure their look has not changed.

Test environment used was `npx wp-env start`

## Screenshots
**BEFORE**
_in InspectorControl usage_
<img width="298" alt="Screen Shot 2020-04-29 at 4 32 41 PM" src="https://user-images.githubusercontent.com/4081020/80843123-77a5c600-8bd1-11ea-873c-9bd43e8805d3.png">


_in storybook_
<img width="305" alt="Screen Shot 2020-05-01 at 5 22 53 PM" src="https://user-images.githubusercontent.com/4081020/80842775-7fb13600-8bd0-11ea-9f6c-1fcea936d1d9.png">



**AFTER**
_in storybook_
<img width="304" alt="Screen Shot 2020-05-01 at 5 18 59 PM" src="https://user-images.githubusercontent.com/4081020/80842797-8b046180-8bd0-11ea-8675-186eb53fa96f.png">


**Editor Use Of full DateTimePicker Control Unchanged**
<img width="382" alt="Screen Shot 2020-05-01 at 5 22 35 PM" src="https://user-images.githubusercontent.com/4081020/80842783-863fad80-8bd0-11ea-9c67-871374b3df1a.png">


## Types of changes
Bug fix (styling change)
New feature (introduce Storybook stories)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
