### PR TITLE
Site editor: Updated template content

### DIFF
--- a/lib/demo-block-template-parts/header.html
+++ b/lib/demo-block-template-parts/header.html
@@ -1,3 +1,9 @@
-<!-- wp:paragraph -->
-<p>Header Template Part</p>
-<!-- /wp:paragraph -->
+<!-- wp:site-title /-->
+
+<!-- wp:navigation {"itemsJustification":"center"} -->
+<!-- wp:navigation-link {"label":"About","url":"https://wordpress.org/gutenberg/"} /-->
+
+<!-- wp:navigation-link {"label":"Full site editing","url":"Products"} /-->
+
+<!-- wp:navigation-link {"label":"Try it out","url":"#"} /-->
+<!-- /wp:navigation -->

--- a/lib/demo-block-templates/front-page.html
+++ b/lib/demo-block-templates/front-page.html
@@ -1,66 +1,19 @@
 <!-- wp:template-part {"slug":"header","theme":"twentytwenty"} /-->
-<!-- wp:columns {"align":"wide"} -->
-<div class="wp-block-columns alignwide">
-	<!-- wp:column -->
-	<div class="wp-block-column">
-		<!-- wp:site-title /-->
-	</div>
-	<!-- /wp:column -->
 
-	<!-- wp:column {"verticalAlignment":"center"} -->
-	<div class="wp-block-column is-vertically-aligned-center">
-		<!-- wp:navigation {"customTextColor":"#353fff"} -->
-			<!-- wp:navigation-link {"label":"One"} /-->
-			<!-- wp:navigation-link {"label":"Two"} -->
-				<!-- wp:navigation-link {"label":"Sub 1"} /-->
-				<!-- wp:navigation-link {"label":"Sub 2"} /-->
-			<!-- /wp:navigation-link -->
-			<!-- wp:navigation-link {"label":"Three"} /-->
-		<!-- /wp:navigation -->
-	</div>
-	<!-- /wp:column -->
-</div>
-<!-- /wp:columns -->
+<!-- wp:cover {"minHeight":360,"customGradient":"linear-gradient(253deg,rgba(6,147,227,1) 0%,rgb(84,121,221) 100%)","align":"full"} -->
+<div class="wp-block-cover alignfull has-background-dim has-background-gradient" style="background:linear-gradient(253deg,rgba(6,147,227,1) 0%,rgb(84,121,221) 100%);min-height:360px"><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
+<p class="has-text-align-center has-large-font-size">Say Hello to the New <em>New</em> Editor</p>
+<!-- /wp:paragraph -->
 
-<!-- wp:image {"sizeSlug":"large"} -->
-<figure class="wp-block-image size-large"><img src="https://cldup.com/0BNcqkoMdq.jpg" alt=""/></figure>
-<!-- /wp:image -->
+<!-- wp:paragraph {"align":"center"} -->
+<p class="has-text-align-center"><em>Now you can edit your entire site!</em></p>
+<!-- /wp:paragraph --></div></div>
+<!-- /wp:cover -->
 
-<!-- wp:columns -->
-<div class="wp-block-columns">
-	<!-- wp:column -->
-	<div class="wp-block-column"></div>
-	<!-- /wp:column -->
+<!-- wp:spacer {"height":20} -->
+<div style="height:20px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
 
-	<!-- wp:column -->
-	<div class="wp-block-column">
-		<!-- wp:paragraph {"customTextColor":"#66717e","fontSize":"large"} -->
-		<p style="color:#66717e" class="has-text-color has-large-font-size">With full-site editing you can modify all visual aspects of the site using the block editor.</p>
-		<!-- /wp:paragraph -->
-	</div>
-	<!-- /wp:column -->
-
-	<!-- wp:column -->
-	<div class="wp-block-column"></div>
-	<!-- /wp:column -->
-</div>
-<!-- /wp:columns -->
-
-<!-- wp:group -->
-<div class="wp-block-group">
-  <div class="wp-block-group__inner-container">
-    <!-- wp:post-title /-->
-    <!-- wp:post-content /-->
-  </div>
-</div>
-<!-- /wp:group -->
-
-<!-- wp:group -->
-<div class="wp-block-group">
-  <div class="wp-block-group__inner-container">
-    <!-- wp:heading -->
-    <h2>Footer</h2>
-    <!-- /wp:heading -->
-  </div>
-</div>
-<!-- /wp:group -->
+<!-- wp:paragraph {"align":"left"} -->
+<p class="has-text-align-left">Rebuilding the entire editing experience pages and posts was just the start. We have expanded what is possible within the editor by making <em>every</em> part of your site customizable right in the editor. Customize your site navigation. Change your site title. Customize your footer. If you can imagine it, you can build it.</p>
+<!-- /wp:paragraph -->

--- a/packages/e2e-tests/specs/experiments/template-part.test.js
+++ b/packages/e2e-tests/specs/experiments/template-part.test.js
@@ -6,7 +6,6 @@ import {
 	insertBlock,
 	disablePrePublishChecks,
 	visitAdminPage,
-	pressKeyWithModifier,
 } from '@wordpress/e2e-test-utils';
 import { addQueryArgs } from '@wordpress/url';
 
@@ -58,9 +57,8 @@ describe( 'Template Part', () => {
 			await switchToHeaderTemplatePartButton.click();
 
 			// Edit it.
-			await page.click( '*[data-type="core/paragraph"]' );
-			await pressKeyWithModifier( 'primary', 'ArrowRight' );
-			await page.keyboard.type( '123' );
+			await insertBlock( 'Paragraph' );
+			await page.keyboard.type( 'Header Template Part 123' );
 
 			// Save it, without saving the front page template.
 			await page.click( '.edit-site-save-button__button' );


### PR DESCRIPTION
## Before
![image](https://user-images.githubusercontent.com/1123119/80844573-3529bc80-8bc4-11ea-9465-d283012b92dd.png)

## After
<img width="1509" alt="image" src="https://user-images.githubusercontent.com/1123119/80844668-7326e080-8bc4-11ea-9832-131df15f84c0.png">

Notes:
* The white background is specific to a theme and isn't a change.
* I did have to completely rebuild my dev environment to see changes.