### PR TITLE
Fix inserter search input classname

### DIFF
--- a/packages/e2e-test-utils/src/search-for-block.js
+++ b/packages/e2e-test-utils/src/search-for-block.js
@@ -11,7 +11,7 @@ import { pressKeyWithModifier } from './press-key-with-modifier';
  */
 export async function searchForBlock( searchTerm ) {
 	await openGlobalBlockInserter();
-	await page.focus( '.block-editor-inserter__search-input' );
+	await page.focus( '.block-editor-inserter__search' );
 	await pressKeyWithModifier( 'primary', 'a' );
 	await page.keyboard.type( searchTerm );
 }


### PR DESCRIPTION
Replace the old inserter search input classname from `block-editor-inserter__search-input` to `block-editor-inserter__search` so the e2e utilities can select it again and e2e tests can run.

## Description
Replace the old inserter search input classname to the one used by the new markup so the e2e tests can run.

## How has this been tested?
The performance test didn't run, after applying this fix, the performance test runs

## Types of changes
Bug fix (non breaking as it was already broken)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
