### PR TITLE
Try: Reduced specificity base block margins.

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -17,7 +17,7 @@
 
 // This remove the margins set here: https://github.com/WordPress/gutenberg/blob/17e5c2d870d84fb6de48dcd5bc3c38cd0c0fb0d0/packages/block-library/src/editor.scss#L56
 // It removes the margins around blocks when a BlockPreview is rendered in the block style selector
-.block-editor-block-styles .editor-styles-wrapper .block-editor-block-list__block {
+.block-editor-block-styles .block-editor-block-list__block {
 	margin: 0;
 }
 

--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -61,7 +61,7 @@
 
 // Provide every block with a default base margin. This margin provides a consistent spacing
 // between blocks in the editor.
-.editor-styles-wrapper .block-editor-block-list__block {
+.block-editor-block-list__block {
 	margin-top: $default-block-margin;
 	margin-bottom: $default-block-margin;
 }


### PR DESCRIPTION
This is a simple change that benefits themes. It reduces the specificity of the rule that provides a baseline block margin.

The baseline block margin is the margin above and below every block, which these blocks are born with.

In master, this rule is so specific that it overrides many editor styles that should work.

Before:

<img width="720" alt="before" src="https://user-images.githubusercontent.com/1204802/80909392-2eb45580-8d28-11ea-88b8-fe1328b2a079.png">

After:

<img width="398" alt="Screenshot 2020-05-03 at 10 19 46" src="https://user-images.githubusercontent.com/1204802/80909399-3e339e80-8d28-11ea-90c1-4949952e02db.png">

Note how this theme provides 1em margins through the following editor style:

```
p {
	margin-top: 1em;
	margin-bottom: 1em;
}
```

<img width="1246" alt="Screenshot 2020-05-03 at 10 19 00" src="https://user-images.githubusercontent.com/1204802/80909401-47bd0680-8d28-11ea-9303-dcec1d5cf8b4.png">

This overrides the baseline rule, as it should:

<img width="341" alt="Screenshot 2020-05-03 at 10 19 40" src="https://user-images.githubusercontent.com/1204802/80909412-5c010380-8d28-11ea-8afe-c81c132e29bf.png">

It also seems to work fine for TwentyTwenty and TwentyNineteen:

<img width="876" alt="Screenshot 2020-05-03 at 10 20 48" src="https://user-images.githubusercontent.com/1204802/80909418-68855c00-8d28-11ea-9b8b-3ecf15ec5eaf.png">

<img width="891" alt="Screenshot 2020-05-03 at 10 21 04" src="https://user-images.githubusercontent.com/1204802/80909420-69b68900-8d28-11ea-8572-bb278fb77060.png">
