### PR TITLE
Fix extra tab stop on Modal component

### DIFF
--- a/packages/components/src/modal/frame.js
+++ b/packages/components/src/modal/frame.js
@@ -9,7 +9,6 @@ import classnames from 'classnames';
 
 import { Component, createRef } from '@wordpress/element';
 import { ESCAPE } from '@wordpress/keycodes';
-import { focus } from '@wordpress/dom';
 import { compose } from '@wordpress/compose';
 
 /**
@@ -27,7 +26,6 @@ class ModalFrame extends Component {
 		this.containerRef = createRef();
 		this.handleKeyDown = this.handleKeyDown.bind( this );
 		this.handleFocusOutside = this.handleFocusOutside.bind( this );
-		this.focusFirstTabbable = this.focusFirstTabbable.bind( this );
 	}
 
 	/**
@@ -36,17 +34,7 @@ class ModalFrame extends Component {
 	componentDidMount() {
 		// Focus on mount
 		if ( this.props.focusOnMount ) {
-			this.focusFirstTabbable();
-		}
-	}
-
-	/**
-	 * Focuses the first tabbable element.
-	 */
-	focusFirstTabbable() {
-		const tabbables = focus.tabbable.find( this.containerRef.current );
-		if ( tabbables.length ) {
-			tabbables[ 0 ].focus();
+			this.containerRef.current.focus();
 		}
 	}
 

--- a/packages/components/src/modal/frame.js
+++ b/packages/components/src/modal/frame.js
@@ -144,6 +144,6 @@ class ModalFrame extends Component {
 
 export default compose( [
 	withFocusReturn,
-	withConstrainedTabbing,
 	withFocusOutside,
+	withConstrainedTabbing,
 ] )( ModalFrame );

--- a/packages/components/src/modal/frame.js
+++ b/packages/components/src/modal/frame.js
@@ -132,6 +132,6 @@ class ModalFrame extends Component {
 
 export default compose( [
 	withFocusReturn,
-	withFocusOutside,
 	withConstrainedTabbing,
+	withFocusOutside,
 ] )( ModalFrame );

--- a/packages/components/src/modal/index.js
+++ b/packages/components/src/modal/index.js
@@ -136,11 +136,7 @@ class Modal extends Component {
 				} }
 				{ ...otherProps }
 			>
-				<div
-					className={ 'components-modal__content' }
-					tabIndex="0"
-					role="document"
-				>
+				<div className={ 'components-modal__content' } role="document">
 					<ModalHeader
 						closeLabel={ closeButtonLabel }
 						headingId={ headingId }


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

Fixes #11631.

~~Currently, on VoiceOver with Safari, pressing arrow keys inside a modal will cause the modal to close, because focus is moved outside the modal. Changing the order of the HOCs wrapping `ModalFrame` so that `withConstrainedTabbing` is inside of `withFocusOutside` fixes the issue.~~

Update: the fix for focus moving outside the modal on VoiceOver wasn't working properly so I'm focusing this PR on fixing the extra tab stop issue. Thanks @talldan for helping debug this 😄 

This PR removes the `tabindex=0` from `components-modal__content` and directs focus to land on `components-modal__frame` instead, as it already has a `tabindex=-1` and it is labelled by the modal header, so is more informative to screen readers. The element with `tabindex=0` was causing an extra, unidentified tab stop between the last focusable element of the modal and the first, when tabbing through cyclically.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Checked on Safari + VoiceOver on Mac, Firefox + NVDA on Windows, and checked just the keyboard interaction across several browsers. 

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
