### PR TITLE
Expose presets declared via add_theme_support in global styles

### DIFF
--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -153,14 +153,35 @@ function gutenberg_experimental_global_styles_get_core() {
 }
 
 /**
- * Return theme's Global Styles.
+ * Return theme's Global Styles. It also fetches the editor palettes
+ * declared via add_theme_support.
  *
  * @return array Global Styles tree.
  */
 function gutenberg_experimental_global_styles_get_theme() {
-	return gutenberg_experimental_global_styles_get_from_file(
+	$global_styles_theme = gutenberg_experimental_global_styles_get_from_file(
 		locate_template( 'experimental-theme.json' )
 	);
+
+	// Take colors from declared theme support.
+	$theme_colors = get_theme_support( 'editor-color-palette' )[ 0 ];
+	foreach( $theme_colors as $color ) {
+		$global_styles_theme['theme']['color'][ $color['slug'] ] = $color['color'];
+	}
+
+	// Take gradients from declared theme support.
+	$theme_gradients = get_theme_support( 'editor-gradient-presets' )[ 0 ];
+	foreach( $theme_gradients as $gradient ) {
+		$global_styles_theme['theme']['gradient'][ $gradient['slug'] ] = $gradient['gradient'];
+	}
+
+	// Take font-sizes from declared theme support.
+	$theme_font_sizes = get_theme_support( 'editor-font-sizes' )[ 0 ];
+	foreach( $theme_font_sizes as $font_size ) {
+		$global_styles_theme['theme']['font-size'][ $font_size['slug'] ] = $font_size['size'];
+	}
+
+	return $global_styles_theme;
 }
 
 /**

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -165,20 +165,26 @@ function gutenberg_experimental_global_styles_get_theme() {
 
 	// Take colors from declared theme support.
 	$theme_colors = get_theme_support( 'editor-color-palette' )[ 0 ];
-	foreach( $theme_colors as $color ) {
-		$global_styles_theme['theme']['color'][ $color['slug'] ] = $color['color'];
+	if ( is_array( $theme_colors ) ) {
+		foreach( $theme_colors as $color ) {
+			$global_styles_theme['theme']['color'][ $color['slug'] ] = $color['color'];
+		}
 	}
 
 	// Take gradients from declared theme support.
 	$theme_gradients = get_theme_support( 'editor-gradient-presets' )[ 0 ];
-	foreach( $theme_gradients as $gradient ) {
-		$global_styles_theme['theme']['gradient'][ $gradient['slug'] ] = $gradient['gradient'];
+	if( is_array( $theme_gradients ) ) {
+		foreach( $theme_gradients as $gradient ) {
+			$global_styles_theme['theme']['gradient'][ $gradient['slug'] ] = $gradient['gradient'];
+		}
 	}
 
 	// Take font-sizes from declared theme support.
 	$theme_font_sizes = get_theme_support( 'editor-font-sizes' )[ 0 ];
-	foreach( $theme_font_sizes as $font_size ) {
-		$global_styles_theme['theme']['font-size'][ $font_size['slug'] ] = $font_size['size'];
+	if( is_array( $theme_font_sizes ) ) {
+		foreach( $theme_font_sizes as $font_size ) {
+			$global_styles_theme['theme']['font-size'][ $font_size['slug'] ] = $font_size['size'];
+		}
 	}
 
 	return $global_styles_theme;

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -161,25 +161,25 @@ function gutenberg_experimental_global_styles_get_core() {
 function gutenberg_experimental_global_styles_get_theme() {
 	$theme_supports = array();
 	// Take colors from declared theme support.
-	$theme_colors = get_theme_support( 'editor-color-palette' )[ 0 ];
+	$theme_colors = get_theme_support( 'editor-color-palette' )[0];
 	if ( is_array( $theme_colors ) ) {
-		foreach( $theme_colors as $color ) {
+		foreach ( $theme_colors as $color ) {
 			$theme_supports['preset']['color'][ $color['slug'] ] = $color['color'];
 		}
 	}
 
 	// Take gradients from declared theme support.
-	$theme_gradients = get_theme_support( 'editor-gradient-presets' )[ 0 ];
-	if( is_array( $theme_gradients ) ) {
-		foreach( $theme_gradients as $gradient ) {
+	$theme_gradients = get_theme_support( 'editor-gradient-presets' )[0];
+	if ( is_array( $theme_gradients ) ) {
+		foreach ( $theme_gradients as $gradient ) {
 			$theme_supports['preset']['gradient'][ $gradient['slug'] ] = $gradient['gradient'];
 		}
 	}
 
 	// Take font-sizes from declared theme support.
-	$theme_font_sizes = get_theme_support( 'editor-font-sizes' )[ 0 ];
-	if( is_array( $theme_font_sizes ) ) {
-		foreach( $theme_font_sizes as $font_size ) {
+	$theme_font_sizes = get_theme_support( 'editor-font-sizes' )[0];
+	if ( is_array( $theme_font_sizes ) ) {
+		foreach ( $theme_font_sizes as $font_size ) {
 			$theme_supports['preset']['font-size'][ $font_size['slug'] ] = $font_size['size'];
 		}
 	}

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -159,15 +159,12 @@ function gutenberg_experimental_global_styles_get_core() {
  * @return array Global Styles tree.
  */
 function gutenberg_experimental_global_styles_get_theme() {
-	$global_styles_theme = gutenberg_experimental_global_styles_get_from_file(
-		locate_template( 'experimental-theme.json' )
-	);
-
+	$theme_supports = array();
 	// Take colors from declared theme support.
 	$theme_colors = get_theme_support( 'editor-color-palette' )[ 0 ];
 	if ( is_array( $theme_colors ) ) {
 		foreach( $theme_colors as $color ) {
-			$global_styles_theme['theme']['color'][ $color['slug'] ] = $color['color'];
+			$theme_supports['preset']['color'][ $color['slug'] ] = $color['color'];
 		}
 	}
 
@@ -175,7 +172,7 @@ function gutenberg_experimental_global_styles_get_theme() {
 	$theme_gradients = get_theme_support( 'editor-gradient-presets' )[ 0 ];
 	if( is_array( $theme_gradients ) ) {
 		foreach( $theme_gradients as $gradient ) {
-			$global_styles_theme['theme']['gradient'][ $gradient['slug'] ] = $gradient['gradient'];
+			$theme_supports['preset']['gradient'][ $gradient['slug'] ] = $gradient['gradient'];
 		}
 	}
 
@@ -183,11 +180,30 @@ function gutenberg_experimental_global_styles_get_theme() {
 	$theme_font_sizes = get_theme_support( 'editor-font-sizes' )[ 0 ];
 	if( is_array( $theme_font_sizes ) ) {
 		foreach( $theme_font_sizes as $font_size ) {
-			$global_styles_theme['theme']['font-size'][ $font_size['slug'] ] = $font_size['size'];
+			$theme_supports['preset']['font-size'][ $font_size['slug'] ] = $font_size['size'];
 		}
 	}
 
-	return $global_styles_theme;
+	/*
+	 * We want the presets declared in theme.json
+	 * to take precedence over the ones declared via add_theme_support.
+	 *
+	 * However, at the moment, it's not clear how we're going to declare them
+	 * in theme.json until we resolve issues related to i18n and
+	 * unfold the proper theme.json hierarchy. See:
+	 *
+	 * https://github.com/wp-cli/i18n-command/pull/210
+	 * https://github.com/WordPress/gutenberg/issues/20588
+	 *
+	 * Hence, for simplicity, we take here the existing presets
+	 * from the add_theme_support, if any.
+	 */
+	return array_merge(
+		gutenberg_experimental_global_styles_get_from_file(
+			locate_template( 'experimental-theme.json' )
+		),
+		$theme_supports
+	);
 }
 
 /**


### PR DESCRIPTION
This PR exposes theme supported style presets (colors, gradients, font-sizes) declared via `add_theme_support` ([see](https://developer.wordpress.org/block-editor/developers/themes/theme-support/)) in global styles so they can be used by themes directly in the `theme.json`.

## Example

**Input** from `theme.json`:

```json
{
    "color": {
        "background": "var(--wp--preset--color--secondary)",
        "text": "var(--wp--preset--color--primary)"
    },
    "typography": {
        "line-height": "calc(1.4 * var(--wp--preset--font-size--small))"
    }
}
```

**Input** from declared theme support via `functions.php`:

```php
add_theme_support( 'editor-color-palette', array(
    array(
        'name'  => __( 'Primary', 'global-styles' ),
        'slug'  => 'primary',
        'color' => '#0073AA',
    ),
    array(
        'name'  => __( 'Secondary', 'global-styles' ),
        'slug'  => 'secondary',
        'color' => '#005177',
    ),
) );

add_theme_support( 'editor-gradient-presets', array(
    array(
        'name'     => __( 'Vivid cyan blue to vivid purple', 'global-styles' ),
        'gradient' => 'linear-gradient(135deg,rgba(6,147,227,1) 0%,rgb(155,81,224) 100%)',
        'slug'     => 'vivid-cyan-blue-to-vivid-purple'
    ),
    array(
        'name'     => __( 'Vivid green cyan to vivid cyan blue', 'global-styles' ),
        'gradient' => 'linear-gradient(135deg,rgba(0,208,132,1) 0%,rgba(6,147,227,1) 100%)',
        'slug'     =>  'vivid-green-cyan-to-vivid-cyan-blue',
    ),
) );

add_theme_support( 'editor-font-sizes', array(
    array(
        'name' => __( 'Small', 'global-styles' ),
        'size' => 12,
        'slug' => 'small'
    ),
    array(
        'name' => __( 'Huge', 'global-styles' ),
        'size' => 50,
        'slug' => 'huge'
    )
) );
```

**Output:**

```css
:root {
    --wp--color--background: var(--wp--preset--color--secondary);
    --wp--color--text: var(--wp--preset--color--primary);
    --wp--typography--line-height: calc(1.4 * var(--wp--preset--font-size--small));
    --wp--preset--color--primary: #0073AA;
    --wp--preset--color--secondary: #005177;
    --wp--preset--gradient--vivid-cyan-blue-to-vivid-purple: linear-gradient(135deg,rgba(6,147,227,1) 0%,rgb(155,81,224) 100%);
    --wp--preset--gradient--vivid-green-cyan-to-vivid-cyan-blue: linear-gradient(135deg,rgba(0,208,132,1) 0%,rgba(6,147,227,1) 100%);
    --wp--preset--font-size--small: 12;
    --wp--preset--font-size--huge: 50;
}
```

## Considerations

- Each preset value is converted to a CSS custom property whose prefix is `--wp--preset--[feature]--[slug]`. Examples: `--wp--preset--color-primary`, `--wp--preset--font-size--small`, etc.

- In the future, we may be able to declare these presets directly in the `theme.json`. While we get there, this brings us a ready-to-use solution that theme authors can count on. It may be the case that, even if we are able to declare presets via `theme.json`, we may want to support the previous configuration mechanism.

## Testing

- Download, install, and activate [this testing theme](https://github.com/nosolosw/global-styles-theme/pull/6) (or create your own).
- Enable the FSE experiment and visit the Site Editor.
- Make sure the embedded stylesheet with ID `global-styles-inline-css` has the proper CSS custom properties (if the testing theme was used, it should have the same contents as in the example section above).
