### PR TITLE
WordCount: Add types

### DIFF
--- a/packages/wordcount/README.md
+++ b/packages/wordcount/README.md
@@ -30,8 +30,8 @@ const numberOfWords = count( 'Words to count', 'words', {} )
 _Parameters_
 
 -   _text_ `string`: The text being processed
--   _type_ `WordCountStrategy`: The type of count. Accepts 'words', 'characters_excluding_spaces', or 'characters_including_spaces'.
--   _userSettings_ `WordCountSettings`: Custom settings object.
+-   _type_ `WPWordCountStrategy`: The type of count. Accepts 'words', 'characters_excluding_spaces', or 'characters_including_spaces'.
+-   _userSettings_ `WPWordCountSettings`: Custom settings object.
 
 _Returns_
 

--- a/packages/wordcount/README.md
+++ b/packages/wordcount/README.md
@@ -31,7 +31,7 @@ _Parameters_
 
 -   _text_ `string`: The text being processed
 -   _type_ `WPWordCountStrategy`: The type of count. Accepts 'words', 'characters_excluding_spaces', or 'characters_including_spaces'.
--   _userSettings_ `WPWordCountSettings`: Custom settings object.
+-   _userSettings_ `WPWordCountUserSettings`: Custom settings object.
 
 _Returns_
 

--- a/packages/wordcount/README.md
+++ b/packages/wordcount/README.md
@@ -29,8 +29,8 @@ const numberOfWords = count( 'Words to count', 'words', {} )
 
 _Parameters_
 
--   _text_ `string`: The text being processed
--   _type_ `string`: The type of count. Accepts ;words', 'characters_excluding_spaces', or 'characters_including_spaces'.
+-   _text_ `[string]`: The text being processed
+-   _type_ `[WordCountStrategy]`: The type of count. Accepts 'words', 'characters_excluding_spaces', or 'characters_including_spaces'.
 -   _userSettings_ `Object`: Custom settings object.
 
 _Returns_

--- a/packages/wordcount/README.md
+++ b/packages/wordcount/README.md
@@ -29,9 +29,9 @@ const numberOfWords = count( 'Words to count', 'words', {} )
 
 _Parameters_
 
--   _text_ `[string]`: The text being processed.
--   _type_ `[WordCountStrategy]`: The type of count. Accepts 'words', 'characters_excluding_spaces', or 'characters_including_spaces'.
--   _userSettings_ `[WordCountSettings]`: Custom settings object.
+-   _text_ `string`: The text being processed
+-   _type_ `WordCountStrategy`: The type of count. Accepts 'words', 'characters_excluding_spaces', or 'characters_including_spaces'.
+-   _userSettings_ `WordCountSettings`: Custom settings object.
 
 _Returns_
 

--- a/packages/wordcount/README.md
+++ b/packages/wordcount/README.md
@@ -29,9 +29,9 @@ const numberOfWords = count( 'Words to count', 'words', {} )
 
 _Parameters_
 
--   _text_ `[string]`: The text being processed
+-   _text_ `[string]`: The text being processed.
 -   _type_ `[WordCountStrategy]`: The type of count. Accepts 'words', 'characters_excluding_spaces', or 'characters_including_spaces'.
--   _userSettings_ `Object`: Custom settings object.
+-   _userSettings_ `[WordCountSettings]`: Custom settings object.
 
 _Returns_
 

--- a/packages/wordcount/src/defaultSettings.js
+++ b/packages/wordcount/src/defaultSettings.js
@@ -1,7 +1,7 @@
-/** @typedef {import('./index').WordCountStrategy} WordCountStrategy */
+/** @typedef {import('./index').WPWordCountStrategy} WPWordCountStrategy */
 
 /**
- * @typedef {Object} WordCountSettingsFields
+ * @typedef {Object} WPWordCountSettingsFields
  * @property {RegExp} HTMLRegExp Regular expression that matches HTML tags
  * @property {RegExp} HTMLcommentRegExp Regular expression that matches HTML comments
  * @property {RegExp} spaceRegExp Regular expression that matches spaces in HTML
@@ -14,18 +14,18 @@
  * @property {RegExp} characters_including_spacesRegExp Regular expression that matches characters including spaces
  * @property {RegExp} shortcodesRegExp Regular expression that matches WordPress shortcodes
  * @property {string[]} shortcodes List of all shortcodes
- * @property {WordCountStrategy} type Describes what and how are we counting
- * @property {Partial<{type: WordCountStrategy, shortcodes: string[]}>} l10n Object with human translations
+ * @property {WPWordCountStrategy} type Describes what and how are we counting
+ * @property {Partial<{type: WPWordCountStrategy, shortcodes: string[]}>} l10n Object with human translations
  */
 
 /**
  * Lower-level settings for word counting that can be overridden.
  *
- * @typedef {Partial<WordCountSettingsFields>} WordCountSettings
+ * @typedef {Partial<WPWordCountSettingsFields>} WPWordCountSettings
  */
 
 /**
- * @type {WordCountSettings}
+ * @type {WPWordCountSettings}
  */
 export const defaultSettings = {
 	HTMLRegExp: /<\/?[a-z][^>]*?>/gi,

--- a/packages/wordcount/src/defaultSettings.js
+++ b/packages/wordcount/src/defaultSettings.js
@@ -20,15 +20,21 @@
  * @property {WPWordCountL10n}     l10n                              Object with human translations
  */
 
+// Disable reason: JSDoc linter doesn't seem to parse the union (`&`) correctly: https://github.com/jsdoc/jsdoc/issues/1285
+/* eslint-disable jsdoc/valid-types */
 /**
  * Lower-level settings for word counting that can be overridden.
  *
- * @typedef {Partial<WPWordCountSettingsFields>} WPWordCountSettings
+ * @typedef {Partial<WPWordCountSettingsFields>} WPWordCountUserSettings
  */
 
 /**
- * @type {WPWordCountSettings}
+ * Word counting settings that include non-optional values we set if missing
+ *
+ * @typedef {WPWordCountUserSettings & typeof defaultSettings} WPWordCountDefaultSettings
  */
+/* eslint-enable jsdoc/valid-types */
+
 export const defaultSettings = {
 	HTMLRegExp: /<\/?[a-z][^>]*?>/gi,
 	HTMLcommentRegExp: /<!--[\s\S]*?-->/g,

--- a/packages/wordcount/src/defaultSettings.js
+++ b/packages/wordcount/src/defaultSettings.js
@@ -1,5 +1,5 @@
 /**
- * @typedef {import("./index").WordCountStrategy} WordCountStrategy
+ * @typedef {import('./index').WordCountStrategy} WordCountStrategy
  */
 
 /**

--- a/packages/wordcount/src/defaultSettings.js
+++ b/packages/wordcount/src/defaultSettings.js
@@ -1,7 +1,7 @@
 /** @typedef {import('./index').WPWordCountStrategy} WPWordCountStrategy */
 
 /**
- * @typedef {Object} WPWordCountSettingsFields
+ * @typedef WPWordCountSettingsFields
  * @property {RegExp} HTMLRegExp Regular expression that matches HTML tags
  * @property {RegExp} HTMLcommentRegExp Regular expression that matches HTML comments
  * @property {RegExp} spaceRegExp Regular expression that matches spaces in HTML

--- a/packages/wordcount/src/defaultSettings.js
+++ b/packages/wordcount/src/defaultSettings.js
@@ -20,14 +20,14 @@
  * @property {WPWordCountL10n}     l10n                              Object with human translations
  */
 
-// Disable reason: JSDoc linter doesn't seem to parse the union (`&`) correctly: https://github.com/jsdoc/jsdoc/issues/1285
-/* eslint-disable jsdoc/valid-types */
 /**
  * Lower-level settings for word counting that can be overridden.
  *
  * @typedef {Partial<WPWordCountSettingsFields>} WPWordCountUserSettings
  */
 
+// Disable reason: JSDoc linter doesn't seem to parse the union (`&`) correctly: https://github.com/jsdoc/jsdoc/issues/1285
+/* eslint-disable jsdoc/valid-types */
 /**
  * Word counting settings that include non-optional values we set if missing
  *

--- a/packages/wordcount/src/defaultSettings.js
+++ b/packages/wordcount/src/defaultSettings.js
@@ -1,21 +1,23 @@
 /** @typedef {import('./index').WPWordCountStrategy} WPWordCountStrategy */
 
+/** @typedef {Partial<{type: WPWordCountStrategy, shortcodes: string[]}>} WPWordCountL10n */
+
 /**
  * @typedef WPWordCountSettingsFields
- * @property {RegExp} HTMLRegExp Regular expression that matches HTML tags
- * @property {RegExp} HTMLcommentRegExp Regular expression that matches HTML comments
- * @property {RegExp} spaceRegExp Regular expression that matches spaces in HTML
- * @property {RegExp} HTMLEntityRegExp Regular expression that matches HTML entities
- * @property {RegExp} connectorRegExp Regular expression that matches word connectors, like em-dash
- * @property {RegExp} removeRegExp Regular expression that matches various characters to be removed when counting
- * @property {RegExp} astralRegExp Regular expression that matches astral UTF-16 code points
- * @property {RegExp} wordsRegExp Regular expression that matches words
- * @property {RegExp} characters_excluding_spacesRegExp Regular expression that matches characters excluding spaces
- * @property {RegExp} characters_including_spacesRegExp Regular expression that matches characters including spaces
- * @property {RegExp} shortcodesRegExp Regular expression that matches WordPress shortcodes
- * @property {string[]} shortcodes List of all shortcodes
- * @property {WPWordCountStrategy} type Describes what and how are we counting
- * @property {Partial<{type: WPWordCountStrategy, shortcodes: string[]}>} l10n Object with human translations
+ * @property {RegExp}              HTMLRegExp                        Regular expression that matches HTML tags
+ * @property {RegExp}              HTMLcommentRegExp                 Regular expression that matches HTML comments
+ * @property {RegExp}              spaceRegExp                       Regular expression that matches spaces in HTML
+ * @property {RegExp}              HTMLEntityRegExp                  Regular expression that matches HTML entities
+ * @property {RegExp}              connectorRegExp                   Regular expression that matches word connectors, like em-dash
+ * @property {RegExp}              removeRegExp                      Regular expression that matches various characters to be removed when counting
+ * @property {RegExp}              astralRegExp                      Regular expression that matches astral UTF-16 code points
+ * @property {RegExp}              wordsRegExp                       Regular expression that matches words
+ * @property {RegExp}              characters_excluding_spacesRegExp Regular expression that matches characters excluding spaces
+ * @property {RegExp}              characters_including_spacesRegExp Regular expression that matches characters including spaces
+ * @property {RegExp}              shortcodesRegExp                  Regular expression that matches WordPress shortcodes
+ * @property {string[]}            shortcodes                        List of all shortcodes
+ * @property {WPWordCountStrategy} type                              Describes what and how are we counting
+ * @property {WPWordCountL10n}     l10n                              Object with human translations
  */
 
 /**

--- a/packages/wordcount/src/defaultSettings.js
+++ b/packages/wordcount/src/defaultSettings.js
@@ -1,6 +1,4 @@
-/**
- * @typedef {import('./index').WordCountStrategy} WordCountStrategy
- */
+/** @typedef {import('./index').WordCountStrategy} WordCountStrategy */
 
 /**
  * @typedef {Object} WordCountSettingsFields
@@ -21,6 +19,8 @@
  */
 
 /**
+ * Lower-level settings for word counting that can be overridden.
+ *
  * @typedef {Partial<WordCountSettingsFields>} WordCountSettings
  */
 

--- a/packages/wordcount/src/defaultSettings.js
+++ b/packages/wordcount/src/defaultSettings.js
@@ -3,21 +3,21 @@
  */
 
 /**
- * @typedef {object} WordCountSettingsFields
- * @property {RegExp} HTMLRegExp
- * @property {RegExp} HTMLcommentRegExp
- * @property {RegExp} spaceRegExp
- * @property {RegExp} HTMLEntityRegExp
- * @property {RegExp} connectorRegExp
- * @property {RegExp} removeRegExp
- * @property {RegExp} astralRegExp
- * @property {RegExp} wordsRegExp
- * @property {RegExp} characters_excluding_spacesRegExp
- * @property {RegExp} characters_including_spacesRegExp
- * @property {RegExp} shortcodesRegExp
- * @property {string[]} shortcodes
- * @property {WordCountStrategy} type
- * @property {Partial<{type: WordCountStrategy, shortcodes: string[]}>} l10n
+ * @typedef {Object} WordCountSettingsFields
+ * @property {RegExp} HTMLRegExp Regular expression that matches HTML tags
+ * @property {RegExp} HTMLcommentRegExp Regular expression that matches HTML comments
+ * @property {RegExp} spaceRegExp Regular expression that matches spaces in HTML
+ * @property {RegExp} HTMLEntityRegExp Regular expression that matches HTML entities
+ * @property {RegExp} connectorRegExp Regular expression that matches word connectors, like em-dash
+ * @property {RegExp} removeRegExp Regular expression that matches various characters to be removed when counting
+ * @property {RegExp} astralRegExp Regular expression that matches astral UTF-16 code points
+ * @property {RegExp} wordsRegExp Regular expression that matches words
+ * @property {RegExp} characters_excluding_spacesRegExp Regular expression that matches characters excluding spaces
+ * @property {RegExp} characters_including_spacesRegExp Regular expression that matches characters including spaces
+ * @property {RegExp} shortcodesRegExp Regular expression that matches WordPress shortcodes
+ * @property {string[]} shortcodes List of all shortcodes
+ * @property {WordCountStrategy} type Describes what and how are we counting
+ * @property {Partial<{type: WordCountStrategy, shortcodes: string[]}>} l10n Object with human translations
  */
 
 /**

--- a/packages/wordcount/src/defaultSettings.js
+++ b/packages/wordcount/src/defaultSettings.js
@@ -1,3 +1,32 @@
+/**
+ * @typedef {import("./index").WordCountStrategy} WordCountStrategy
+ */
+
+/**
+ * @typedef {object} WordCountSettingsFields
+ * @property {RegExp} HTMLRegExp
+ * @property {RegExp} HTMLcommentRegExp
+ * @property {RegExp} spaceRegExp
+ * @property {RegExp} HTMLEntityRegExp
+ * @property {RegExp} connectorRegExp
+ * @property {RegExp} removeRegExp
+ * @property {RegExp} astralRegExp
+ * @property {RegExp} wordsRegExp
+ * @property {RegExp} characters_excluding_spacesRegExp
+ * @property {RegExp} characters_including_spacesRegExp
+ * @property {RegExp} shortcodesRegExp
+ * @property {string[]} shortcodes
+ * @property {WordCountStrategy} type
+ * @property {Partial<{type: WordCountStrategy, shortcodes: string[]}>} l10n
+ */
+
+/**
+ * @typedef {Partial<WordCountSettingsFields>} WordCountSettings
+ */
+
+/**
+ * @type {WordCountSettings}
+ */
 export const defaultSettings = {
 	HTMLRegExp: /<\/?[a-z][^>]*?>/gi,
 	HTMLcommentRegExp: /<!--[\s\S]*?-->/g,

--- a/packages/wordcount/src/index.js
+++ b/packages/wordcount/src/index.js
@@ -17,16 +17,12 @@ import stripShortcodes from './stripShortcodes';
 import stripSpaces from './stripSpaces';
 import transposeHTMLEntitiesToCountableChars from './transposeHTMLEntitiesToCountableChars';
 
-/**
- * A number, or a string containing a number.
- *
- * @typedef {'words'|'characters_excluding_spaces'|'characters_including_spaces'} WordCountStrategy
- */
+/** @typedef {import('./defaultSettings').WordCountSettings}  WordCountSettings */
 
 /**
- * Lower-level settings for word counting that can be overridden.
+ * Possible ways of counting.
  *
- * @typedef {import('./defaultSettings').WordCountSettings}  WordCountSettings
+ * @typedef {'words'|'characters_excluding_spaces'|'characters_including_spaces'} WordCountStrategy
  */
 
 /**

--- a/packages/wordcount/src/index.js
+++ b/packages/wordcount/src/index.js
@@ -17,21 +17,21 @@ import stripShortcodes from './stripShortcodes';
 import stripSpaces from './stripSpaces';
 import transposeHTMLEntitiesToCountableChars from './transposeHTMLEntitiesToCountableChars';
 
-/** @typedef {import('./defaultSettings').WordCountSettings}  WordCountSettings */
+/** @typedef {import('./defaultSettings').WPWordCountSettings}  WPWordCountSettings */
 
 /**
  * Possible ways of counting.
  *
- * @typedef {'words'|'characters_excluding_spaces'|'characters_including_spaces'} WordCountStrategy
+ * @typedef {'words'|'characters_excluding_spaces'|'characters_including_spaces'} WPWordCountStrategy
  */
 
 /**
  * Private function to manage the settings.
  *
- * @param {WordCountStrategy} type The type of count to be done.
- * @param {WordCountSettings} userSettings Custom settings for the count.
+ * @param {WPWordCountStrategy} type The type of count to be done.
+ * @param {WPWordCountSettings} userSettings Custom settings for the count.
  *
- * @return {WordCountSettings} The combined settings object to be used.
+ * @return {WPWordCountSettings} The combined settings object to be used.
  */
 function loadSettings( type, userSettings ) {
 	const settings = extend( defaultSettings, userSettings );
@@ -62,7 +62,7 @@ function loadSettings( type, userSettings ) {
  *
  * @param {string} text     The text being processed
  * @param {RegExp|undefined} regex    The regular expression pattern being matched
- * @param {WordCountSettings} settings Settings object containing regular expressions for each strip function
+ * @param {WPWordCountSettings} settings Settings object containing regular expressions for each strip function
  *
  * @return {number} The matched string.
  */
@@ -88,7 +88,7 @@ function countWords( text, regex, settings ) {
  *
  * @param {string} text     The text being processed
  * @param {RegExp|undefined} regex    The regular expression pattern being matched
- * @param {WordCountSettings} settings Settings object containing regular expressions for each strip function
+ * @param {WPWordCountSettings} settings Settings object containing regular expressions for each strip function
  *
  * @return {number} Count of characters.
  */
@@ -112,8 +112,8 @@ function countCharacters( text, regex, settings ) {
  * Count some words.
  *
  * @param {string} text The text being processed
- * @param {WordCountStrategy} type	The type of count. Accepts 'words', 'characters_excluding_spaces', or 'characters_including_spaces'.
- * @param {WordCountSettings} userSettings Custom settings object.
+ * @param {WPWordCountStrategy} type	The type of count. Accepts 'words', 'characters_excluding_spaces', or 'characters_including_spaces'.
+ * @param {WPWordCountSettings} userSettings Custom settings object.
  *
  * @example
  * ```js

--- a/packages/wordcount/src/index.js
+++ b/packages/wordcount/src/index.js
@@ -26,7 +26,7 @@ import transposeHTMLEntitiesToCountableChars from './transposeHTMLEntitiesToCoun
 /**
  * Lower-level settings for word counting that can be overridden.
  *
- * @typedef {import("./defaultSettings").WordCountSettings}  WordCountSettings
+ * @typedef {import('./defaultSettings').WordCountSettings}  WordCountSettings
  */
 
 /**

--- a/packages/wordcount/src/index.js
+++ b/packages/wordcount/src/index.js
@@ -109,7 +109,7 @@ function countCharacters( text, regex, settings ) {
  * Count some words.
  *
  * @param {string}                  text         The text being processed
- * @param {WPWordCountStrategy}     type	     The type of count. Accepts 'words', 'characters_excluding_spaces', or 'characters_including_spaces'.
+ * @param {WPWordCountStrategy}     type         The type of count. Accepts 'words', 'characters_excluding_spaces', or 'characters_including_spaces'.
  * @param {WPWordCountUserSettings} userSettings Custom settings object.
  *
  * @example

--- a/packages/wordcount/src/index.js
+++ b/packages/wordcount/src/index.js
@@ -127,17 +127,17 @@ function countCharacters( text, regex, settings ) {
 export function count( text, type, userSettings ) {
 	const settings = loadSettings( type, userSettings );
 	let matchRegExp;
-	if ( settings.type === 'words' ) {
-		matchRegExp = settings.wordsRegExp;
-		return countWords( text, matchRegExp, settings );
+	switch ( settings.type ) {
+		case 'words':
+			matchRegExp = settings.wordsRegExp;
+			return countWords( text, matchRegExp, settings );
+		case 'characters_including_spaces':
+			matchRegExp = settings.characters_including_spacesRegExp;
+			return countCharacters( text, matchRegExp, settings );
+		case 'characters_excluding_spaces':
+			matchRegExp = settings.characters_excluding_spacesRegExp;
+			return countCharacters( text, matchRegExp, settings );
+		default:
+			return 0;
 	}
-	if ( settings.type === 'characters_including_spaces' ) {
-		matchRegExp = settings.characters_including_spacesRegExp;
-		return countCharacters( text, matchRegExp, settings );
-	}
-	if ( settings.type === 'characters_excluding_spaces' ) {
-		matchRegExp = settings.characters_excluding_spacesRegExp;
-		return countCharacters( text, matchRegExp, settings );
-	}
-	return 0;
 }

--- a/packages/wordcount/src/index.js
+++ b/packages/wordcount/src/index.js
@@ -18,10 +18,15 @@ import stripSpaces from './stripSpaces';
 import transposeHTMLEntitiesToCountableChars from './transposeHTMLEntitiesToCountableChars';
 
 /**
+ * A number, or a string containing a number.
+ * @typedef {'words'|'characters_excluding_spaces'|'characters_including_spaces'} WordCountStrategy
+ */
+
+/**
  * Private function to manage the settings.
  *
- * @param {string} type         The type of count to be done.
- * @param {Object} userSettings Custom settings for the count.
+ * @param {WordCountStrategy} type The type of count to be done.
+ * @param {WordCountSettings} userSettings Custom settings for the count.
  *
  * @return {void|Object|*} The combined settings object to be used.
  */
@@ -97,8 +102,8 @@ function matchCharacters( text, regex, settings ) {
 /**
  * Count some words.
  *
- * @param {string} text         The text being processed
- * @param {string} type         The type of count. Accepts ;words', 'characters_excluding_spaces', or 'characters_including_spaces'.
+ * @param {string} text The text being processed
+ * @param {WordCountStrategy} type	The type of count. Accepts 'words', 'characters_excluding_spaces', or 'characters_including_spaces'.
  * @param {Object} userSettings Custom settings object.
  *
  * @example

--- a/packages/wordcount/src/index.js
+++ b/packages/wordcount/src/index.js
@@ -35,12 +35,12 @@ import transposeHTMLEntitiesToCountableChars from './transposeHTMLEntitiesToCoun
  * @param {WordCountStrategy} type The type of count to be done.
  * @param {WordCountSettings} userSettings Custom settings for the count.
  *
- * @return {void|Object|*} The combined settings object to be used.
+ * @return {WordCountSettings} The combined settings object to be used.
  */
 function loadSettings( type, userSettings ) {
 	const settings = extend( defaultSettings, userSettings );
 
-	settings.shortcodes = settings.l10n.shortcodes || {};
+	settings.shortcodes = settings.l10n?.shortcodes ?? [];
 
 	if ( settings.shortcodes && settings.shortcodes.length ) {
 		settings.shortcodesRegExp = new RegExp(
@@ -49,7 +49,7 @@ function loadSettings( type, userSettings ) {
 		);
 	}
 
-	settings.type = type || settings.l10n.type;
+	settings.type = type || settings.l10n?.type;
 
 	if (
 		settings.type !== 'characters_excluding_spaces' &&
@@ -65,8 +65,8 @@ function loadSettings( type, userSettings ) {
  * Match the regex for the type 'words'
  *
  * @param {string} text     The text being processed
- * @param {string} regex    The regular expression pattern being matched
- * @param {Object} settings Settings object containing regular expressions for each strip function
+ * @param {RegExp|undefined} regex    The regular expression pattern being matched
+ * @param {WordCountSettings} settings Settings object containing regular expressions for each strip function
  *
  * @return {Array|{index: number, input: string}} The matched string.
  */
@@ -88,8 +88,8 @@ function matchWords( text, regex, settings ) {
  * Match the regex for either 'characters_excluding_spaces' or 'characters_including_spaces'
  *
  * @param {string} text     The text being processed
- * @param {string} regex    The regular expression pattern being matched
- * @param {Object} settings Settings object containing regular expressions for each strip function
+ * @param {RegExp|undefined} regex    The regular expression pattern being matched
+ * @param {WordCountSettings} settings Settings object containing regular expressions for each strip function
  *
  * @return {Array|{index: number, input: string}} The matched string.
  */
@@ -111,7 +111,7 @@ function matchCharacters( text, regex, settings ) {
  *
  * @param {string} text The text being processed
  * @param {WordCountStrategy} type	The type of count. Accepts 'words', 'characters_excluding_spaces', or 'characters_including_spaces'.
- * @param {Object} userSettings Custom settings object.
+ * @param {WordCountSettings} userSettings Custom settings object.
  *
  * @example
  * ```js

--- a/packages/wordcount/src/index.js
+++ b/packages/wordcount/src/index.js
@@ -19,7 +19,14 @@ import transposeHTMLEntitiesToCountableChars from './transposeHTMLEntitiesToCoun
 
 /**
  * A number, or a string containing a number.
+ *
  * @typedef {'words'|'characters_excluding_spaces'|'characters_including_spaces'} WordCountStrategy
+ */
+
+/**
+ * Lower-level settings for word counting that can be overridden.
+ *
+ * @typedef {import("./defaultSettings").WordCountSettings}  WordCountSettings
  */
 
 /**

--- a/packages/wordcount/src/index.js
+++ b/packages/wordcount/src/index.js
@@ -48,7 +48,7 @@ function loadSettings( type, userSettings ) {
 		);
 	}
 
-	settings.type = type || settings.l10n?.type;
+	settings.type = type;
 
 	if (
 		settings.type !== 'characters_excluding_spaces' &&

--- a/packages/wordcount/src/index.js
+++ b/packages/wordcount/src/index.js
@@ -28,7 +28,7 @@ import transposeHTMLEntitiesToCountableChars from './transposeHTMLEntitiesToCoun
 /**
  * Private function to manage the settings.
  *
- * @param {WPWordCountStrategy} type The type of count to be done.
+ * @param {WPWordCountStrategy} type         The type of count to be done.
  * @param {WPWordCountSettings} userSettings Custom settings for the count.
  *
  * @return {WPWordCountSettings} The combined settings object to be used.
@@ -60,8 +60,8 @@ function loadSettings( type, userSettings ) {
 /**
  * Count the words in text
  *
- * @param {string} text     The text being processed
- * @param {RegExp|undefined} regex    The regular expression pattern being matched
+ * @param {string}              text     The text being processed
+ * @param {RegExp|undefined}    regex    The regular expression pattern being matched
  * @param {WPWordCountSettings} settings Settings object containing regular expressions for each strip function
  *
  * @return {number} The matched string.
@@ -86,8 +86,8 @@ function countWords( text, regex, settings ) {
 /**
  * Count the characters in text
  *
- * @param {string} text     The text being processed
- * @param {RegExp|undefined} regex    The regular expression pattern being matched
+ * @param {string}              text     The text being processed
+ * @param {RegExp|undefined}    regex    The regular expression pattern being matched
  * @param {WPWordCountSettings} settings Settings object containing regular expressions for each strip function
  *
  * @return {number} Count of characters.
@@ -111,8 +111,8 @@ function countCharacters( text, regex, settings ) {
 /**
  * Count some words.
  *
- * @param {string} text The text being processed
- * @param {WPWordCountStrategy} type	The type of count. Accepts 'words', 'characters_excluding_spaces', or 'characters_including_spaces'.
+ * @param {string}              text         The text being processed
+ * @param {WPWordCountStrategy} type	     The type of count. Accepts 'words', 'characters_excluding_spaces', or 'characters_including_spaces'.
  * @param {WPWordCountSettings} userSettings Custom settings object.
  *
  * @example

--- a/packages/wordcount/src/index.js
+++ b/packages/wordcount/src/index.js
@@ -17,7 +17,10 @@ import stripShortcodes from './stripShortcodes';
 import stripSpaces from './stripSpaces';
 import transposeHTMLEntitiesToCountableChars from './transposeHTMLEntitiesToCountableChars';
 
-/** @typedef {import('./defaultSettings').WPWordCountSettings}  WPWordCountSettings */
+/**
+ * @typedef {import('./defaultSettings').WPWordCountDefaultSettings}  WPWordCountSettings
+ * @typedef {import('./defaultSettings').WPWordCountUserSettings}     WPWordCountUserSettings
+ */
 
 /**
  * Possible ways of counting.
@@ -28,8 +31,8 @@ import transposeHTMLEntitiesToCountableChars from './transposeHTMLEntitiesToCoun
 /**
  * Private function to manage the settings.
  *
- * @param {WPWordCountStrategy} type         The type of count to be done.
- * @param {WPWordCountSettings} userSettings Custom settings for the count.
+ * @param {WPWordCountStrategy}     type         The type of count to be done.
+ * @param {WPWordCountUserSettings} userSettings Custom settings for the count.
  *
  * @return {WPWordCountSettings} The combined settings object to be used.
  */
@@ -111,9 +114,9 @@ function countCharacters( text, regex, settings ) {
 /**
  * Count some words.
  *
- * @param {string}              text         The text being processed
- * @param {WPWordCountStrategy} type	     The type of count. Accepts 'words', 'characters_excluding_spaces', or 'characters_including_spaces'.
- * @param {WPWordCountSettings} userSettings Custom settings object.
+ * @param {string}                  text         The text being processed
+ * @param {WPWordCountStrategy}     type	     The type of count. Accepts 'words', 'characters_excluding_spaces', or 'characters_including_spaces'.
+ * @param {WPWordCountUserSettings} userSettings Custom settings object.
  *
  * @example
  * ```js
@@ -123,7 +126,6 @@ function countCharacters( text, regex, settings ) {
  *
  * @return {number} The word or character count.
  */
-
 export function count( text, type, userSettings ) {
 	const settings = loadSettings( type, userSettings );
 	let matchRegExp;

--- a/packages/wordcount/src/index.js
+++ b/packages/wordcount/src/index.js
@@ -37,7 +37,7 @@ import transposeHTMLEntitiesToCountableChars from './transposeHTMLEntitiesToCoun
  * @return {WPWordCountSettings} The combined settings object to be used.
  */
 function loadSettings( type, userSettings ) {
-	const settings = extend( defaultSettings, userSettings );
+	const settings = extend( {}, defaultSettings, userSettings );
 
 	settings.shortcodes = settings.l10n?.shortcodes ?? [];
 

--- a/packages/wordcount/src/index.js
+++ b/packages/wordcount/src/index.js
@@ -64,15 +64,12 @@ function loadSettings( type, userSettings ) {
  * Count the words in text
  *
  * @param {string}              text     The text being processed
- * @param {RegExp|undefined}    regex    The regular expression pattern being matched
+ * @param {RegExp}              regex    The regular expression pattern being matched
  * @param {WPWordCountSettings} settings Settings object containing regular expressions for each strip function
  *
  * @return {number} The matched string.
  */
 function countWords( text, regex, settings ) {
-	if ( typeof regex === 'undefined' ) {
-		return 0;
-	}
 	text = flow(
 		stripTags.bind( null, settings ),
 		stripHTMLComments.bind( null, settings ),
@@ -90,15 +87,12 @@ function countWords( text, regex, settings ) {
  * Count the characters in text
  *
  * @param {string}              text     The text being processed
- * @param {RegExp|undefined}    regex    The regular expression pattern being matched
+ * @param {RegExp}              regex    The regular expression pattern being matched
  * @param {WPWordCountSettings} settings Settings object containing regular expressions for each strip function
  *
  * @return {number} Count of characters.
  */
 function countCharacters( text, regex, settings ) {
-	if ( typeof regex === 'undefined' ) {
-		return 0;
-	}
 	text = flow(
 		stripTags.bind( null, settings ),
 		stripHTMLComments.bind( null, settings ),

--- a/packages/wordcount/src/index.js
+++ b/packages/wordcount/src/index.js
@@ -67,7 +67,7 @@ function loadSettings( type, userSettings ) {
  * @param {RegExp}              regex    The regular expression pattern being matched
  * @param {WPWordCountSettings} settings Settings object containing regular expressions for each strip function
  *
- * @return {number} The matched string.
+ * @return {number} Count of words.
  */
 function countWords( text, regex, settings ) {
 	text = flow(

--- a/packages/wordcount/src/index.js
+++ b/packages/wordcount/src/index.js
@@ -72,13 +72,13 @@ function loadSettings( type, userSettings ) {
  */
 function matchWords( text, regex, settings ) {
 	text = flow(
-		stripTags.bind( this, settings ),
-		stripHTMLComments.bind( this, settings ),
-		stripShortcodes.bind( this, settings ),
-		stripSpaces.bind( this, settings ),
-		stripHTMLEntities.bind( this, settings ),
-		stripConnectors.bind( this, settings ),
-		stripRemovables.bind( this, settings )
+		stripTags.bind( null, settings ),
+		stripHTMLComments.bind( null, settings ),
+		stripShortcodes.bind( null, settings ),
+		stripSpaces.bind( null, settings ),
+		stripHTMLEntities.bind( null, settings ),
+		stripConnectors.bind( null, settings ),
+		stripRemovables.bind( null, settings )
 	)( text );
 	text = text + '\n';
 	return text.match( regex );
@@ -95,12 +95,12 @@ function matchWords( text, regex, settings ) {
  */
 function matchCharacters( text, regex, settings ) {
 	text = flow(
-		stripTags.bind( this, settings ),
-		stripHTMLComments.bind( this, settings ),
-		stripShortcodes.bind( this, settings ),
-		stripSpaces.bind( this, settings ),
-		transposeAstralsToCountableChar.bind( this, settings ),
-		transposeHTMLEntitiesToCountableChars.bind( this, settings )
+		stripTags.bind( null, settings ),
+		stripHTMLComments.bind( null, settings ),
+		stripShortcodes.bind( null, settings ),
+		transposeAstralsToCountableChar.bind( null, settings ),
+		stripSpaces.bind( null, settings ),
+		transposeHTMLEntitiesToCountableChars.bind( null, settings )
 	)( text );
 	text = text + '\n';
 	return text.match( regex );

--- a/packages/wordcount/src/stripConnectors.js
+++ b/packages/wordcount/src/stripConnectors.js
@@ -7,8 +7,5 @@
  * @return {string} The manipulated text.
  */
 export default function stripConnectors( settings, text ) {
-	if ( settings.connectorRegExp ) {
-		return text.replace( settings.connectorRegExp, ' ' );
-	}
-	return text;
+	return text.replace( settings.connectorRegExp, ' ' );
 }

--- a/packages/wordcount/src/stripConnectors.js
+++ b/packages/wordcount/src/stripConnectors.js
@@ -1,7 +1,7 @@
 /**
  * Replaces items matched in the regex with spaces.
  *
- * @param {import('./index').WordCountSettings} settings The main settings object containing regular expressions
+ * @param {import('./index').WPWordCountSettings} settings The main settings object containing regular expressions
  * @param {string} text     The string being counted.
  *
  * @return {string} The manipulated text.

--- a/packages/wordcount/src/stripConnectors.js
+++ b/packages/wordcount/src/stripConnectors.js
@@ -2,7 +2,7 @@
  * Replaces items matched in the regex with spaces.
  *
  * @param {import('./index').WPWordCountSettings} settings The main settings object containing regular expressions
- * @param {string} text     The string being counted.
+ * @param {string}                                text     The string being counted.
  *
  * @return {string} The manipulated text.
  */

--- a/packages/wordcount/src/stripConnectors.js
+++ b/packages/wordcount/src/stripConnectors.js
@@ -1,7 +1,7 @@
 /**
  * Replaces items matched in the regex with spaces.
  *
- * @param {import("./index").WordCountSettings} settings The main settings object containing regular expressions
+ * @param {import('./index').WordCountSettings} settings The main settings object containing regular expressions
  * @param {string} text     The string being counted.
  *
  * @return {string} The manipulated text.

--- a/packages/wordcount/src/stripConnectors.js
+++ b/packages/wordcount/src/stripConnectors.js
@@ -1,7 +1,7 @@
 /**
  * Replaces items matched in the regex with spaces.
  *
- * @param {Object} settings The main settings object containing regular expressions
+ * @param {import("./index").WordCountSettings} settings The main settings object containing regular expressions
  * @param {string} text     The string being counted.
  *
  * @return {string} The manipulated text.

--- a/packages/wordcount/src/stripHTMLComments.js
+++ b/packages/wordcount/src/stripHTMLComments.js
@@ -1,7 +1,7 @@
 /**
  * Removes items matched in the regex.
  *
- * @param {Object} settings The main settings object containing regular expressions
+ * @param {import("./index").WordCountSettings} settings The main settings object containing regular expressions
  * @param {string} text     The string being counted.
  *
  * @return {string} The manipulated text.

--- a/packages/wordcount/src/stripHTMLComments.js
+++ b/packages/wordcount/src/stripHTMLComments.js
@@ -2,7 +2,7 @@
  * Removes items matched in the regex.
  *
  * @param {import('./index').WPWordCountSettings} settings The main settings object containing regular expressions
- * @param {string} text     The string being counted.
+ * @param {string}                                text     The string being counted.
  *
  * @return {string} The manipulated text.
  */

--- a/packages/wordcount/src/stripHTMLComments.js
+++ b/packages/wordcount/src/stripHTMLComments.js
@@ -7,8 +7,5 @@
  * @return {string} The manipulated text.
  */
 export default function stripHTMLComments( settings, text ) {
-	if ( settings.HTMLcommentRegExp ) {
-		return text.replace( settings.HTMLcommentRegExp, '' );
-	}
-	return text;
+	return text.replace( settings.HTMLcommentRegExp, '' );
 }

--- a/packages/wordcount/src/stripHTMLComments.js
+++ b/packages/wordcount/src/stripHTMLComments.js
@@ -1,7 +1,7 @@
 /**
  * Removes items matched in the regex.
  *
- * @param {import("./index").WordCountSettings} settings The main settings object containing regular expressions
+ * @param {import('./index').WordCountSettings} settings The main settings object containing regular expressions
  * @param {string} text     The string being counted.
  *
  * @return {string} The manipulated text.

--- a/packages/wordcount/src/stripHTMLComments.js
+++ b/packages/wordcount/src/stripHTMLComments.js
@@ -1,7 +1,7 @@
 /**
  * Removes items matched in the regex.
  *
- * @param {import('./index').WordCountSettings} settings The main settings object containing regular expressions
+ * @param {import('./index').WPWordCountSettings} settings The main settings object containing regular expressions
  * @param {string} text     The string being counted.
  *
  * @return {string} The manipulated text.

--- a/packages/wordcount/src/stripHTMLEntities.js
+++ b/packages/wordcount/src/stripHTMLEntities.js
@@ -1,7 +1,7 @@
 /**
  * Removes items matched in the regex.
  *
- * @param {Object} settings The main settings object containing regular expressions
+ * @param {import("./index").WordCountSettings} settings The main settings object containing regular expressions
  * @param {string} text     The string being counted.
  *
  * @return {string} The manipulated text.

--- a/packages/wordcount/src/stripHTMLEntities.js
+++ b/packages/wordcount/src/stripHTMLEntities.js
@@ -2,7 +2,7 @@
  * Removes items matched in the regex.
  *
  * @param {import('./index').WPWordCountSettings} settings The main settings object containing regular expressions
- * @param {string} text     The string being counted.
+ * @param {string}                                text     The string being counted.
  *
  * @return {string} The manipulated text.
  */

--- a/packages/wordcount/src/stripHTMLEntities.js
+++ b/packages/wordcount/src/stripHTMLEntities.js
@@ -1,7 +1,7 @@
 /**
  * Removes items matched in the regex.
  *
- * @param {import("./index").WordCountSettings} settings The main settings object containing regular expressions
+ * @param {import('./index').WordCountSettings} settings The main settings object containing regular expressions
  * @param {string} text     The string being counted.
  *
  * @return {string} The manipulated text.

--- a/packages/wordcount/src/stripHTMLEntities.js
+++ b/packages/wordcount/src/stripHTMLEntities.js
@@ -1,7 +1,7 @@
 /**
  * Removes items matched in the regex.
  *
- * @param {import('./index').WordCountSettings} settings The main settings object containing regular expressions
+ * @param {import('./index').WPWordCountSettings} settings The main settings object containing regular expressions
  * @param {string} text     The string being counted.
  *
  * @return {string} The manipulated text.

--- a/packages/wordcount/src/stripHTMLEntities.js
+++ b/packages/wordcount/src/stripHTMLEntities.js
@@ -7,8 +7,5 @@
  * @return {string} The manipulated text.
  */
 export default function stripHTMLEntities( settings, text ) {
-	if ( settings.HTMLEntityRegExp ) {
-		return text.replace( settings.HTMLEntityRegExp, '' );
-	}
-	return text;
+	return text.replace( settings.HTMLEntityRegExp, '' );
 }

--- a/packages/wordcount/src/stripRemovables.js
+++ b/packages/wordcount/src/stripRemovables.js
@@ -7,8 +7,5 @@
  * @return {string} The manipulated text.
  */
 export default function stripRemovables( settings, text ) {
-	if ( settings.removeRegExp ) {
-		return text.replace( settings.removeRegExp, '' );
-	}
-	return text;
+	return text.replace( settings.removeRegExp, '' );
 }

--- a/packages/wordcount/src/stripRemovables.js
+++ b/packages/wordcount/src/stripRemovables.js
@@ -1,7 +1,7 @@
 /**
  * Removes items matched in the regex.
  *
- * @param {Object} settings The main settings object containing regular expressions
+ * @param {import("./index").WordCountSettings} settings The main settings object containing regular expressions
  * @param {string} text     The string being counted.
  *
  * @return {string} The manipulated text.

--- a/packages/wordcount/src/stripRemovables.js
+++ b/packages/wordcount/src/stripRemovables.js
@@ -2,7 +2,7 @@
  * Removes items matched in the regex.
  *
  * @param {import('./index').WPWordCountSettings} settings The main settings object containing regular expressions
- * @param {string} text     The string being counted.
+ * @param {string}                                text     The string being counted.
  *
  * @return {string} The manipulated text.
  */

--- a/packages/wordcount/src/stripRemovables.js
+++ b/packages/wordcount/src/stripRemovables.js
@@ -1,7 +1,7 @@
 /**
  * Removes items matched in the regex.
  *
- * @param {import("./index").WordCountSettings} settings The main settings object containing regular expressions
+ * @param {import('./index').WordCountSettings} settings The main settings object containing regular expressions
  * @param {string} text     The string being counted.
  *
  * @return {string} The manipulated text.

--- a/packages/wordcount/src/stripRemovables.js
+++ b/packages/wordcount/src/stripRemovables.js
@@ -1,7 +1,7 @@
 /**
  * Removes items matched in the regex.
  *
- * @param {import('./index').WordCountSettings} settings The main settings object containing regular expressions
+ * @param {import('./index').WPWordCountSettings} settings The main settings object containing regular expressions
  * @param {string} text     The string being counted.
  *
  * @return {string} The manipulated text.

--- a/packages/wordcount/src/stripShortcodes.js
+++ b/packages/wordcount/src/stripShortcodes.js
@@ -1,7 +1,7 @@
 /**
  * Replaces items matched in the regex with a new line.
  *
- * @param {Object} settings The main settings object containing regular expressions
+ * @param {import("./index").WordCountSettings} settings The main settings object containing regular expressions
  * @param {string} text     The string being counted.
  *
  * @return {string} The manipulated text.

--- a/packages/wordcount/src/stripShortcodes.js
+++ b/packages/wordcount/src/stripShortcodes.js
@@ -1,7 +1,7 @@
 /**
  * Replaces items matched in the regex with a new line.
  *
- * @param {import('./index').WordCountSettings} settings The main settings object containing regular expressions
+ * @param {import('./index').WPWordCountSettings} settings The main settings object containing regular expressions
  * @param {string} text     The string being counted.
  *
  * @return {string} The manipulated text.

--- a/packages/wordcount/src/stripShortcodes.js
+++ b/packages/wordcount/src/stripShortcodes.js
@@ -2,7 +2,7 @@
  * Replaces items matched in the regex with a new line.
  *
  * @param {import('./index').WPWordCountSettings} settings The main settings object containing regular expressions
- * @param {string} text     The string being counted.
+ * @param {string}                                text     The string being counted.
  *
  * @return {string} The manipulated text.
  */

--- a/packages/wordcount/src/stripShortcodes.js
+++ b/packages/wordcount/src/stripShortcodes.js
@@ -1,7 +1,7 @@
 /**
  * Replaces items matched in the regex with a new line.
  *
- * @param {import("./index").WordCountSettings} settings The main settings object containing regular expressions
+ * @param {import('./index').WordCountSettings} settings The main settings object containing regular expressions
  * @param {string} text     The string being counted.
  *
  * @return {string} The manipulated text.

--- a/packages/wordcount/src/stripSpaces.js
+++ b/packages/wordcount/src/stripSpaces.js
@@ -10,4 +10,5 @@ export default function stripSpaces( settings, text ) {
 	if ( settings.spaceRegExp ) {
 		return text.replace( settings.spaceRegExp, ' ' );
 	}
+	return text;
 }

--- a/packages/wordcount/src/stripSpaces.js
+++ b/packages/wordcount/src/stripSpaces.js
@@ -1,7 +1,7 @@
 /**
  * Replaces items matched in the regex with spaces.
  *
- * @param {import('./index').WordCountSettings} settings The main settings object containing regular expressions
+ * @param {import('./index').WPWordCountSettings} settings The main settings object containing regular expressions
  * @param {string} text     The string being counted.
  *
  * @return {string} The manipulated text.

--- a/packages/wordcount/src/stripSpaces.js
+++ b/packages/wordcount/src/stripSpaces.js
@@ -7,8 +7,5 @@
  * @return {string} The manipulated text.
  */
 export default function stripSpaces( settings, text ) {
-	if ( settings.spaceRegExp ) {
-		return text.replace( settings.spaceRegExp, ' ' );
-	}
-	return text;
+	return text.replace( settings.spaceRegExp, ' ' );
 }

--- a/packages/wordcount/src/stripSpaces.js
+++ b/packages/wordcount/src/stripSpaces.js
@@ -2,7 +2,7 @@
  * Replaces items matched in the regex with spaces.
  *
  * @param {import('./index').WPWordCountSettings} settings The main settings object containing regular expressions
- * @param {string} text     The string being counted.
+ * @param {string}                                text     The string being counted.
  *
  * @return {string} The manipulated text.
  */

--- a/packages/wordcount/src/stripSpaces.js
+++ b/packages/wordcount/src/stripSpaces.js
@@ -1,7 +1,7 @@
 /**
  * Replaces items matched in the regex with spaces.
  *
- * @param {import("./index").WordCountSettings} settings The main settings object containing regular expressions
+ * @param {import('./index').WordCountSettings} settings The main settings object containing regular expressions
  * @param {string} text     The string being counted.
  *
  * @return {string} The manipulated text.

--- a/packages/wordcount/src/stripSpaces.js
+++ b/packages/wordcount/src/stripSpaces.js
@@ -1,7 +1,7 @@
 /**
  * Replaces items matched in the regex with spaces.
  *
- * @param {Object} settings The main settings object containing regular expressions
+ * @param {import("./index").WordCountSettings} settings The main settings object containing regular expressions
  * @param {string} text     The string being counted.
  *
  * @return {string} The manipulated text.

--- a/packages/wordcount/src/stripTags.js
+++ b/packages/wordcount/src/stripTags.js
@@ -1,7 +1,7 @@
 /**
  * Replaces items matched in the regex with new line
  *
- * @param {Object} settings The main settings object containing regular expressions
+ * @param {import("./index").WordCountSettings} settings The main settings object containing regular expressions
  * @param {string} text     The string being counted.
  *
  * @return {string} The manipulated text.

--- a/packages/wordcount/src/stripTags.js
+++ b/packages/wordcount/src/stripTags.js
@@ -2,7 +2,7 @@
  * Replaces items matched in the regex with new line
  *
  * @param {import('./index').WPWordCountSettings} settings The main settings object containing regular expressions
- * @param {string} text     The string being counted.
+ * @param {string}                                text     The string being counted.
  *
  * @return {string} The manipulated text.
  */

--- a/packages/wordcount/src/stripTags.js
+++ b/packages/wordcount/src/stripTags.js
@@ -1,7 +1,7 @@
 /**
  * Replaces items matched in the regex with new line
  *
- * @param {import("./index").WordCountSettings} settings The main settings object containing regular expressions
+ * @param {import('./index').WordCountSettings} settings The main settings object containing regular expressions
  * @param {string} text     The string being counted.
  *
  * @return {string} The manipulated text.

--- a/packages/wordcount/src/stripTags.js
+++ b/packages/wordcount/src/stripTags.js
@@ -7,8 +7,5 @@
  * @return {string} The manipulated text.
  */
 export default function stripTags( settings, text ) {
-	if ( settings.HTMLRegExp ) {
-		return text.replace( settings.HTMLRegExp, '\n' );
-	}
-	return text;
+	return text.replace( settings.HTMLRegExp, '\n' );
 }

--- a/packages/wordcount/src/stripTags.js
+++ b/packages/wordcount/src/stripTags.js
@@ -1,7 +1,7 @@
 /**
  * Replaces items matched in the regex with new line
  *
- * @param {import('./index').WordCountSettings} settings The main settings object containing regular expressions
+ * @param {import('./index').WPWordCountSettings} settings The main settings object containing regular expressions
  * @param {string} text     The string being counted.
  *
  * @return {string} The manipulated text.

--- a/packages/wordcount/src/stripTags.js
+++ b/packages/wordcount/src/stripTags.js
@@ -10,4 +10,5 @@ export default function stripTags( settings, text ) {
 	if ( settings.HTMLRegExp ) {
 		return text.replace( settings.HTMLRegExp, '\n' );
 	}
+	return text;
 }

--- a/packages/wordcount/src/transposeAstralsToCountableChar.js
+++ b/packages/wordcount/src/transposeAstralsToCountableChar.js
@@ -1,7 +1,7 @@
 /**
  * Replaces items matched in the regex with character.
  *
- * @param {Object} settings The main settings object containing regular expressions
+ * @param {import("./index").WordCountSettings} settings The main settings object containing regular expressions
  * @param {string} text     The string being counted.
  *
  * @return {string} The manipulated text.

--- a/packages/wordcount/src/transposeAstralsToCountableChar.js
+++ b/packages/wordcount/src/transposeAstralsToCountableChar.js
@@ -1,7 +1,7 @@
 /**
  * Replaces items matched in the regex with character.
  *
- * @param {import('./index').WordCountSettings} settings The main settings object containing regular expressions
+ * @param {import('./index').WPWordCountSettings} settings The main settings object containing regular expressions
  * @param {string} text     The string being counted.
  *
  * @return {string} The manipulated text.

--- a/packages/wordcount/src/transposeAstralsToCountableChar.js
+++ b/packages/wordcount/src/transposeAstralsToCountableChar.js
@@ -2,7 +2,7 @@
  * Replaces items matched in the regex with character.
  *
  * @param {import('./index').WPWordCountSettings} settings The main settings object containing regular expressions
- * @param {string} text     The string being counted.
+ * @param {string}                                text     The string being counted.
  *
  * @return {string} The manipulated text.
  */

--- a/packages/wordcount/src/transposeAstralsToCountableChar.js
+++ b/packages/wordcount/src/transposeAstralsToCountableChar.js
@@ -1,7 +1,7 @@
 /**
  * Replaces items matched in the regex with character.
  *
- * @param {import("./index").WordCountSettings} settings The main settings object containing regular expressions
+ * @param {import('./index').WordCountSettings} settings The main settings object containing regular expressions
  * @param {string} text     The string being counted.
  *
  * @return {string} The manipulated text.

--- a/packages/wordcount/src/transposeAstralsToCountableChar.js
+++ b/packages/wordcount/src/transposeAstralsToCountableChar.js
@@ -7,8 +7,5 @@
  * @return {string} The manipulated text.
  */
 export default function transposeAstralsToCountableChar( settings, text ) {
-	if ( settings.astralRegExp ) {
-		return text.replace( settings.astralRegExp, 'a' );
-	}
-	return text;
+	return text.replace( settings.astralRegExp, 'a' );
 }

--- a/packages/wordcount/src/transposeHTMLEntitiesToCountableChars.js
+++ b/packages/wordcount/src/transposeHTMLEntitiesToCountableChars.js
@@ -1,7 +1,7 @@
 /**
  * Replaces items matched in the regex with a single character.
  *
- * @param {Object} settings The main settings object containing regular expressions
+ * @param {import("./index").WordCountSettings} settings The main settings object containing regular expressions
  * @param {string} text     The string being counted.
  *
  * @return {string} The manipulated text.

--- a/packages/wordcount/src/transposeHTMLEntitiesToCountableChars.js
+++ b/packages/wordcount/src/transposeHTMLEntitiesToCountableChars.js
@@ -1,7 +1,7 @@
 /**
  * Replaces items matched in the regex with a single character.
  *
- * @param {import("./index").WordCountSettings} settings The main settings object containing regular expressions
+ * @param {import('./index').WordCountSettings} settings The main settings object containing regular expressions
  * @param {string} text     The string being counted.
  *
  * @return {string} The manipulated text.

--- a/packages/wordcount/src/transposeHTMLEntitiesToCountableChars.js
+++ b/packages/wordcount/src/transposeHTMLEntitiesToCountableChars.js
@@ -2,7 +2,7 @@
  * Replaces items matched in the regex with a single character.
  *
  * @param {import('./index').WPWordCountSettings} settings The main settings object containing regular expressions
- * @param {string} text     The string being counted.
+ * @param {string}                                text     The string being counted.
  *
  * @return {string} The manipulated text.
  */

--- a/packages/wordcount/src/transposeHTMLEntitiesToCountableChars.js
+++ b/packages/wordcount/src/transposeHTMLEntitiesToCountableChars.js
@@ -1,7 +1,7 @@
 /**
  * Replaces items matched in the regex with a single character.
  *
- * @param {import('./index').WordCountSettings} settings The main settings object containing regular expressions
+ * @param {import('./index').WPWordCountSettings} settings The main settings object containing regular expressions
  * @param {string} text     The string being counted.
  *
  * @return {string} The manipulated text.

--- a/packages/wordcount/src/transposeHTMLEntitiesToCountableChars.js
+++ b/packages/wordcount/src/transposeHTMLEntitiesToCountableChars.js
@@ -10,8 +10,5 @@ export default function transposeHTMLEntitiesToCountableChars(
 	settings,
 	text
 ) {
-	if ( settings.HTMLEntityRegExp ) {
-		return text.replace( settings.HTMLEntityRegExp, 'a' );
-	}
-	return text;
+	return text.replace( settings.HTMLEntityRegExp, 'a' );
 }

--- a/packages/wordcount/tsconfig.json
+++ b/packages/wordcount/tsconfig.json
@@ -1,0 +1,8 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"rootDir": "src",
+		"declarationDir": "build-types"
+	},
+	"include": [ "src/**/*" ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,8 @@
 		{ "path": "packages/project-management-automation" },
 		{ "path": "packages/token-list" },
 		{ "path": "packages/url" },
-		{ "path": "packages/warning" }
+		{ "path": "packages/warning" },
+		{ "path": "packages/wordcount" }
 	],
 	"files": []
 }


### PR DESCRIPTION
Part of #18838.

Add types to `wordcount` package.

**Testing Instructions**

0. Run `npm run build:package-types` –– shouldn't be any errors.
1. Try it in the UI – open the sample post and it should say something around 717 words. And start a new post and it should count words properly.

I am quite new to TypeScript and adding types to Gutenberg, so for the sake of learning, bring all of your nitpicking :-)