### PR TITLE
Light blocks: social links

### DIFF
--- a/packages/block-library/src/social-link/edit.js
+++ b/packages/block-library/src/social-link/edit.js
@@ -10,6 +10,7 @@ import {
 	InspectorControls,
 	URLPopover,
 	URLInput,
+	__experimentalBlock as Block,
 } from '@wordpress/block-editor';
 import { Fragment, useState } from '@wordpress/element';
 import {
@@ -61,36 +62,38 @@ const SocialLinkEdit = ( { attributes, setAttributes, isSelected } ) => {
 					</PanelRow>
 				</PanelBody>
 			</InspectorControls>
-			<Button className={ classes } onClick={ () => setPopover( true ) }>
-				<IconComponent />
-				{ isSelected && showURLPopover && (
-					<URLPopover onClose={ () => setPopover( false ) }>
-						<form
-							className="block-editor-url-popover__link-editor"
-							onSubmit={ ( event ) => {
-								event.preventDefault();
-								setPopover( false );
-							} }
-						>
-							<div className="block-editor-url-input">
-								<URLInput
-									value={ url }
-									onChange={ ( nextURL ) =>
-										setAttributes( { url: nextURL } )
-									}
-									placeholder={ __( 'Enter address' ) }
-									disableSuggestions={ true }
+			<Block.li className={ classes }>
+				<Button onClick={ () => setPopover( true ) }>
+					<IconComponent />
+					{ isSelected && showURLPopover && (
+						<URLPopover onClose={ () => setPopover( false ) }>
+							<form
+								className="block-editor-url-popover__link-editor"
+								onSubmit={ ( event ) => {
+									event.preventDefault();
+									setPopover( false );
+								} }
+							>
+								<div className="block-editor-url-input">
+									<URLInput
+										value={ url }
+										onChange={ ( nextURL ) =>
+											setAttributes( { url: nextURL } )
+										}
+										placeholder={ __( 'Enter address' ) }
+										disableSuggestions={ true }
+									/>
+								</div>
+								<Button
+									icon={ keyboardReturn }
+									label={ __( 'Apply' ) }
+									type="submit"
 								/>
-							</div>
-							<Button
-								icon={ keyboardReturn }
-								label={ __( 'Apply' ) }
-								type="submit"
-							/>
-						</form>
-					</URLPopover>
-				) }
-			</Button>
+							</form>
+						</URLPopover>
+					) }
+				</Button>
+			</Block.li>
 		</Fragment>
 	);
 };

--- a/packages/block-library/src/social-link/editor.scss
+++ b/packages/block-library/src/social-link/editor.scss
@@ -1,10 +1,9 @@
-.wp-social-link {
-	// Frontend outputs a link, backend a button. Both should have the same padding.
-	// Therefore, the following exactly matches the padding on the frontend link.
+.wp-block-social-links .wp-social-link button {
+	color: currentColor;
 	padding: 6px;
 }
 
-.wp-block-social-links.is-style-pill-shape .wp-social-link {
+.wp-block-social-links.is-style-pill-shape .wp-social-link button {
 	padding-left: 16px;
 	padding-right: 16px;
 }

--- a/packages/block-library/src/social-link/index.js
+++ b/packages/block-library/src/social-link/index.js
@@ -21,6 +21,7 @@ export const settings = {
 	supports: {
 		reusable: false,
 		html: false,
+		lightBlockWrapper: true,
 	},
 	icon,
 	edit,

--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -2,7 +2,10 @@
  * WordPress dependencies
  */
 
-import { InnerBlocks } from '@wordpress/block-editor';
+import {
+	InnerBlocks,
+	__experimentalBlock as Block,
+} from '@wordpress/block-editor';
 
 const ALLOWED_BLOCKS = [ 'core/social-link' ];
 
@@ -19,16 +22,16 @@ const TEMPLATE = [
 	[ 'core/social-link', { service: 'youtube' } ],
 ];
 
-export const SocialLinksEdit = function( { className } ) {
+export const SocialLinksEdit = function() {
 	return (
-		<div className={ className }>
-			<InnerBlocks
-				allowedBlocks={ ALLOWED_BLOCKS }
-				templateLock={ false }
-				template={ TEMPLATE }
-				__experimentalMoverDirection={ 'horizontal' }
-			/>
-		</div>
+		<InnerBlocks
+			allowedBlocks={ ALLOWED_BLOCKS }
+			templateLock={ false }
+			template={ TEMPLATE }
+			__experimentalMoverDirection={ 'horizontal' }
+			__experimentalTagName={ Block.ul }
+			__experimentalAppenderTagName="li"
+		/>
 	);
 };
 

--- a/packages/block-library/src/social-links/editor.scss
+++ b/packages/block-library/src/social-links/editor.scss
@@ -4,21 +4,18 @@
 		display: inline-block;
 		margin-left: $grid-unit-10;
 	}
-
-	.block-editor-block-list__layout {
-		display: flex;
-		justify-content: flex-start;
-	}
 }
 
 // Reduce the paddings, margins, and UI of inner-blocks.
 // @todo: eventually we may add a feature that lets a parent container absorb the block UI of a child block.
 // When that happens, leverage that instead of the following overrides.
-[data-type="core/social-links"] {
-	.wp-block-social-links > .block-editor-inner-blocks > .block-editor-block-list__layout > .wp-block {
-		margin-top: 0;
-		margin-bottom: 0;
-	}
+.editor-styles-wrapper .wp-block-social-link {
+	margin: 0;
+	margin-right: 8px;
+}
+
+.editor-styles-wrapper .wp-block-social-links {
+	padding: 0;
 }
 
 // Polish the Appender.

--- a/packages/block-library/src/social-links/index.js
+++ b/packages/block-library/src/social-links/index.js
@@ -23,6 +23,7 @@ export const settings = {
 	keywords: [ _x( 'links', 'block keywords' ) ],
 	supports: {
 		align: [ 'left', 'center', 'right' ],
+		lightBlockWrapper: true,
 	},
 	example: {
 		innerBlocks: [


### PR DESCRIPTION
## Description

Makes the social links block a lighter block.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
