### PR TITLE
Add "black" and "white" color options to default color palette.

### DIFF
--- a/packages/block-editor/src/store/defaults.js
+++ b/packages/block-editor/src/store/defaults.js
@@ -38,6 +38,21 @@ export const SETTINGS_DEFAULTS = {
 	alignWide: false,
 	colors: [
 		{
+			name: __( 'Black' ),
+			slug: 'black',
+			color: '#000000',
+		},
+		{
+			name: __( 'Cyan bluish gray' ),
+			slug: 'cyan-bluish-gray',
+			color: '#abb8c3',
+		},
+		{
+			name: __( 'White' ),
+			slug: 'white',
+			color: '#ffffff',
+		},
+		{
 			name: __( 'Pale pink' ),
 			slug: 'pale-pink',
 			color: '#f78da7',
@@ -77,21 +92,6 @@ export const SETTINGS_DEFAULTS = {
 			name: __( 'Vivid purple' ),
 			slug: 'vivid-purple',
 			color: '#9b51e0',
-		},
-		{
-			name: __( 'Very light gray' ),
-			slug: 'very-light-gray',
-			color: '#eeeeee',
-		},
-		{
-			name: __( 'Cyan bluish gray' ),
-			slug: 'cyan-bluish-gray',
-			color: '#abb8c3',
-		},
-		{
-			name: __( 'Very dark gray' ),
-			slug: 'very-dark-gray',
-			color: '#313131',
 		},
 	],
 

--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -76,6 +76,11 @@
 		background-color: #9b51e0;
 	}
 
+	.has-white-background-color {
+		background-color: #fff;
+	}
+
+	// Deprecated from UI, kept for back-compat
 	.has-very-light-gray-background-color {
 		background-color: #eee;
 	}
@@ -84,8 +89,13 @@
 		background-color: #abb8c3;
 	}
 
+	// Deprecated from UI, kept for back-compat
 	.has-very-dark-gray-background-color {
 		background-color: #313131;
+	}
+
+	.has-black-background-color {
+		background-color: #000;
 	}
 
 	// Foreground colors.
@@ -126,6 +136,11 @@
 		color: #9b51e0;
 	}
 
+	.has-white-color {
+		color: #fff;
+	}
+
+	// Deprecated from UI, kept for back-compat
 	.has-very-light-gray-color {
 		color: #eee;
 	}
@@ -134,8 +149,13 @@
 		color: #abb8c3;
 	}
 
+	// Deprecated from UI, kept for back-compat
 	.has-very-dark-gray-color {
 		color: #313131;
+	}
+
+	.has-black-color {
+		color: #000;
 	}
 
 	// Gradients


### PR DESCRIPTION
Let's add black and white as default color options since they have ubiquitous use and value for more accessible color contrast with the widest variety of colors:

![image](https://user-images.githubusercontent.com/548849/80982060-0feab780-8e2b-11ea-89e0-3bff2c9e9230.png)

To keep the palette balanced this change also drops some of the intermediary grays from the UI — they are kept, though, in the CSS declaration to ensure the CSS can still be applied. Need to revise if a former class being set causes any issues in the UI when loaded again cc @jorgefilipecosta 