### PR TITLE
Only allow ECMAScript stage 4 features

### DIFF
--- a/packages/babel-preset-default/CHANGELOG.md
+++ b/packages/babel-preset-default/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## Breaking Changes
+
+- Revert enabling the `shippedProposals` flag. That flag enables the use of stage-3 proposals, but the goal of this preset is to only support stage-4 features. [#22083](https://github.com/WordPress/gutenberg/pull/22083)
+
 ## 4.12.0 (2020-04-15)
 
 ### New Features

--- a/packages/babel-preset-default/index.js
+++ b/packages/babel-preset-default/index.js
@@ -16,9 +16,7 @@ module.exports = function( api ) {
 	} );
 
 	const getPresetEnv = () => {
-		const opts = {
-			shippedProposals: true,
-		};
+		const opts = {};
 
 		if ( isTestEnv ) {
 			opts.targets = {

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -18,6 +18,12 @@
 
 - `env` script was marked as deprecated. We recommend using `@wordpress/env` package instead that lets you easily set up a local WordPress environment for building and testing plugins and themes.
 
+## 10.0.0 (xxxx-xx-xx)
+
+### Breaking Changes
+
+- Revert the activation of shippedProposals in the default babel config, which enables stage-3 syntax. [#22083](https://github.com/WordPress/gutenberg/pull/22083)
+
 ## 9.0.0 (2020-04-30)
 
 ### Breaking Changes

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -8,6 +8,10 @@
 - New `--webpack-bundle-analyzer` flag added to `build` and `start` scripts. It enables visualization for the size of webpack output files with an interactive zoomable treemap ([#22310](https://github.com/WordPress/gutenberg/pull/22310)).
 - New `--webpack--devtool` flag added to `start` script. It controls how source maps are generated. See options at https://webpack.js.org/configuration/devtool/#devtool ([#22310](https://github.com/WordPress/gutenberg/pull/22310)).
 
+### Breaking Changes
+
+- The default babel configuration has changed to only support stage-4 proposals. This affects the `build` and `start` commands that use the bundled babel configuration; if a project provides its own, this change doesn't affect it. [#22083](https://github.com/WordPress/gutenberg/pull/22083)
+
 ## 9.1.0 (2020-05-14)
 
 ### Enhancements
@@ -17,12 +21,6 @@
 ### Deprecations
 
 - `env` script was marked as deprecated. We recommend using `@wordpress/env` package instead that lets you easily set up a local WordPress environment for building and testing plugins and themes.
-
-## 10.0.0 (xxxx-xx-xx)
-
-### Breaking Changes
-
-- Revert the activation of shippedProposals in the default babel config, which enables stage-3 syntax. [#22083](https://github.com/WordPress/gutenberg/pull/22083)
 
 ## 9.0.0 (2020-04-30)
 


### PR DESCRIPTION
While reviewing https://github.com/WordPress/gutenberg/pull/22030#discussion_r418607329, I realized that we're allowing to write code in ECMAScript stage-3 and above, and not only stage-4.

This was enabled by switching on `shippedProposals` in https://github.com/WordPress/gutenberg/pull/19065. At the time, it looks like the thought was that enabling this, will make babel to list feature proposals that were part of stage-4 and already shipped by browsers. However, `shippedProposals` _may_ add [stage-3](https://tc39.es/process-document/) as [per the docs](https://babeljs.io/docs/en/babel-preset-env#shippedproposals). For example, at the moment, we could theoretically use [the numeric separator](https://github.com/tc39/proposal-numeric-separator) feature, which is on stage-3.

This disables the `shippedProposals` so we only use stage-4.