### PR TITLE
Build Tooling: Run packages build before lint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -98,6 +98,12 @@ jobs:
     - name: Lint
       install:
         - npm ci
+        # eslint-plugin-import/no-extraneous-dependencies relies on modules to
+        # be "installed", which in practice requires that packages be built,
+        # presumably so that pkg.main can be resolved.
+        #
+        # See: https://github.com/benmosher/eslint-plugin-import/blob/92caa35/resolvers/node/index.js
+        - node ./bin/packages/build.js
       script:
         - npm run lint
 


### PR DESCRIPTION
Related: https://github.com/WordPress/gutenberg/pull/21864#discussion_r419604128
Related ([link requires registration](https://make.wordpress.org/chat/)): https://wordpress.slack.com/archives/C5UNMSU4R/p1588614936461800

This pull request seeks to resolve an issue where the `eslint-plugin-import/no-extraneous-dependencies` rule will fail to execute correctly in Travis, leading to false negatives where a missing dependency may be introduced (see https://github.com/WordPress/gutenberg/pull/21864#discussion_r419604128, #22086).

**Implementation Notes:**

From some further debugging, it appears that `eslint-plugin-import` may depend on `package.json`'s `main` field to be resolveable:

- https://github.com/benmosher/eslint-plugin-import#resolvers
- https://github.com/benmosher/eslint-plugin-import/blob/master/resolvers/node/index.js
- https://www.npmjs.com/package/resolve

Prior to these changes, there was no build being run. Each package typically defines it entrypoint as `"main": "build/index.js"`, which _does not exist_ prior to a build in a clean installation.

For future consideration: Ideally we don't need to run the build as part of the lint installation step, since it does add some time to the job's runtime. If we can find some other way to satisfy the ESLint plugin's resolver behavior which doesn't require resolving the built file, it would help to reduce the overall Travis build time.

**Testing Instructions:**

~I have **temporarily** included a revert of the commit ab4166f in order to test these changes.~ **Edit:** Removed after verification at https://github.com/WordPress/gutenberg/pull/22088#issuecomment-623725658.

Testing consists of:

1. ~Verifying that Travis _fails_ as expected, while the commit is left to remain in the branch history.~~ **Edit:** Verified at https://github.com/WordPress/gutenberg/pull/22088#issuecomment-623725658.
2. Verifying locally that lint _passes_ (unexpectedly) in a clean installation, but fails once the minimal build is run:

```
git revert ab4166f
npm run clean:packages
npm run lint-js packages/block-editor/src/components/rich-text/index.js
# No errors
node ./bin/packages/build.js
npm run lint-js packages/block-editor/src/components/rich-text/index.js
# error  '@wordpress/shortcode' should be listed in the project's dependencies.
```