### PR TITLE
wp-env: Correctly parse basename for wporg zip sources

### DIFF
--- a/packages/env/lib/config.js
+++ b/packages/env/lib/config.js
@@ -293,9 +293,25 @@ function parseSourceString( sourceString, { workDirectoryPath } ) {
 		};
 	}
 
+	const wpOrgFields = sourceString.match(
+		/^https?:\/\/downloads\.wordpress\.org\/(plugin|theme)\/([^\s\.]*)([^\s]*)?\.zip$/
+	);
+	if ( wpOrgFields ) {
+		return {
+			type: 'zip',
+			url: sourceString,
+			path: path.resolve(
+				workDirectoryPath,
+				encodeURIComponent( wpOrgFields[ 2 ] )
+			),
+			basename: encodeURIComponent( wpOrgFields[ 2 ] ),
+		};
+	}
+
 	const zipFields = sourceString.match(
 		/^https?:\/\/([^\s$.?#].[^\s]*)\.zip$/
 	);
+
 	if ( zipFields ) {
 		return {
 			type: 'zip',

--- a/packages/env/lib/config.js
+++ b/packages/env/lib/config.js
@@ -293,34 +293,22 @@ function parseSourceString( sourceString, { workDirectoryPath } ) {
 		};
 	}
 
-	const wpOrgFields = sourceString.match(
-		/^https?:\/\/downloads\.wordpress\.org\/(?:plugin|theme)\/([^\s\.]*)([^\s]*)?\.zip$/
-	);
-	if ( wpOrgFields ) {
-		return {
-			type: 'zip',
-			url: sourceString,
-			path: path.resolve(
-				workDirectoryPath,
-				encodeURIComponent( wpOrgFields[ 1 ] )
-			),
-			basename: encodeURIComponent( wpOrgFields[ 1 ] ),
-		};
-	}
-
 	const zipFields = sourceString.match(
 		/^https?:\/\/([^\s$.?#].[^\s]*)\.zip$/
 	);
 
 	if ( zipFields ) {
+		const wpOrgFields = sourceString.match(
+			/^https?:\/\/downloads\.wordpress\.org\/(?:plugin|theme)\/([^\s\.]*)([^\s]*)?\.zip$/
+		);
+		const basename = wpOrgFields
+			? encodeURIComponent( wpOrgFields[ 1 ] )
+			: encodeURIComponent( zipFields[ 1 ] );
 		return {
 			type: 'zip',
 			url: sourceString,
-			path: path.resolve(
-				workDirectoryPath,
-				encodeURIComponent( zipFields[ 1 ] )
-			),
-			basename: encodeURIComponent( zipFields[ 1 ] ),
+			path: path.resolve( workDirectoryPath, basename ),
+			basename,
 		};
 	}
 

--- a/packages/env/lib/config.js
+++ b/packages/env/lib/config.js
@@ -294,17 +294,17 @@ function parseSourceString( sourceString, { workDirectoryPath } ) {
 	}
 
 	const wpOrgFields = sourceString.match(
-		/^https?:\/\/downloads\.wordpress\.org\/(plugin|theme)\/([^\s\.]*)([^\s]*)?\.zip$/
+		/^https?:\/\/downloads\.wordpress\.org\/(?:plugin|theme)\/([^\s\.]*)([^\s]*)?\.zip$/
 	);
 	if ( wpOrgFields ) {
 		return {
-			type: 'wporg-' + wpOrgFields[ 1 ],
+			type: 'zip',
 			url: sourceString,
 			path: path.resolve(
 				workDirectoryPath,
-				encodeURIComponent( wpOrgFields[ 2 ] )
+				encodeURIComponent( wpOrgFields[ 1 ] )
 			),
-			basename: encodeURIComponent( wpOrgFields[ 2 ] ),
+			basename: encodeURIComponent( wpOrgFields[ 1 ] ),
 		};
 	}
 

--- a/packages/env/lib/config.js
+++ b/packages/env/lib/config.js
@@ -298,7 +298,7 @@ function parseSourceString( sourceString, { workDirectoryPath } ) {
 	);
 	if ( wpOrgFields ) {
 		return {
-			type: 'zip',
+			type: 'wporg-' + wpOrgFields[ 1 ],
 			url: sourceString,
 			path: path.resolve(
 				workDirectoryPath,

--- a/packages/env/lib/download-source.js
+++ b/packages/env/lib/download-source.js
@@ -35,10 +35,6 @@ module.exports = async function downloadSource( source, options ) {
 		await downloadGitSource( source, options );
 	} else if ( source.type === 'zip' ) {
 		await downloadZipSource( source, options );
-	} else if ( source.type === 'wporg-theme' ) {
-		await downloadZipSource( source, options );
-	} else if ( source.type === 'wporg-plugin' ) {
-		await downloadZipSource( source, options );
 	}
 };
 

--- a/packages/env/lib/download-source.js
+++ b/packages/env/lib/download-source.js
@@ -35,6 +35,10 @@ module.exports = async function downloadSource( source, options ) {
 		await downloadGitSource( source, options );
 	} else if ( source.type === 'zip' ) {
 		await downloadZipSource( source, options );
+	} else if ( source.type === 'wporg-theme' ) {
+		await downloadZipSource( source, options );
+	} else if ( source.type === 'wporg-plugin' ) {
+		await downloadZipSource( source, options );
 	}
 };
 

--- a/packages/env/test/config.js
+++ b/packages/env/test/config.js
@@ -211,6 +211,8 @@ describe( 'readConfig', () => {
 					plugins: [
 						'https://downloads.wordpress.org/plugin/gutenberg.zip',
 						'https://downloads.wordpress.org/plugin/gutenberg.8.1.0.zip',
+						'https://downloads.wordpress.org/theme/twentytwenty.zip',
+						'https://downloads.wordpress.org/theme/twentytwenty.1.3.zip',
 					],
 				} )
 			)
@@ -230,6 +232,20 @@ describe( 'readConfig', () => {
 						'https://downloads.wordpress.org/plugin/gutenberg.8.1.0.zip',
 					path: expect.stringMatching( /^\/.*gutenberg$/ ),
 					basename: 'gutenberg',
+				},
+				{
+					type: 'zip',
+					url:
+						'https://downloads.wordpress.org/theme/twentytwenty.zip',
+					path: expect.stringMatching( /^\/.*twentytwenty$/ ),
+					basename: 'twentytwenty',
+				},
+				{
+					type: 'zip',
+					url:
+						'https://downloads.wordpress.org/theme/twentytwenty.1.3.zip',
+					path: expect.stringMatching( /^\/.*twentytwenty$/ ),
+					basename: 'twentytwenty',
 				},
 			],
 		} );

--- a/packages/env/test/config.js
+++ b/packages/env/test/config.js
@@ -204,6 +204,37 @@ describe( 'readConfig', () => {
 		} );
 	} );
 
+	it( 'should parse wordpress.org sources', async () => {
+		readFile.mockImplementation( () =>
+			Promise.resolve(
+				JSON.stringify( {
+					plugins: [
+						'https://downloads.wordpress.org/plugin/gutenberg.zip',
+						'https://downloads.wordpress.org/plugin/gutenberg.8.1.0.zip',
+					],
+				} )
+			)
+		);
+		const config = await readConfig( '.wp-env.json' );
+		expect( config ).toMatchObject( {
+			pluginSources: [
+				{
+					type: 'zip',
+					url: 'https://downloads.wordpress.org/plugin/gutenberg.zip',
+					path: expect.stringMatching( /^\/.*gutenberg$/ ),
+					basename: 'gutenberg',
+				},
+				{
+					type: 'zip',
+					url:
+						'https://downloads.wordpress.org/plugin/gutenberg.8.1.0.zip',
+					path: expect.stringMatching( /^\/.*gutenberg$/ ),
+					basename: 'gutenberg',
+				},
+			],
+		} );
+	} );
+
 	it( 'should throw a validaton error if there is an unknown source', async () => {
 		readFile.mockImplementation( () =>
 			Promise.resolve( JSON.stringify( { plugins: [ 'invalid' ] } ) )


### PR DESCRIPTION
## Description
In the case of plugin/theme from downloads.wordpress.org,  use the directory name as the name of the plugin/theme.


``` wp-env.json
{
	"plugins": [
		"https://downloads.wordpress.org/plugin/wordpress-importer.0.7.zip"
	],
}
```

before
```
downloads.wordpress.org%2Fplugin%2Fwordpress-importer.0.7
```

after
```
wordpress-importer
```

## How has this been tested?

config wp-env.json

```
{
	"core": "WordPress/WordPress",
	"plugins": [
		".",
		"https://downloads.wordpress.org/plugin/wordpress-importer.zip",
		"https://downloads.wordpress.org/plugin/debug-bar.1.0.zip"
	],
	"themes": [
		"https://downloads.wordpress.org/theme/go.zip",
		"https://downloads.wordpress.org/theme/chaplin.2.4.2.zip"
	]
}
```

run ` ./packages/env/bin/wp-env start`


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
