### PR TITLE
Update the block wrapper properly when the alignment changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9834,6 +9834,7 @@
 				"lodash": "^4.17.15",
 				"memize": "^1.1.0",
 				"react-autosize-textarea": "^3.0.2",
+				"react-merge-refs": "^1.0.0",
 				"react-spring": "^8.0.19",
 				"redux-multi": "^0.1.12",
 				"refx": "^3.0.0",
@@ -36160,6 +36161,11 @@
 			"resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
 			"integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
 			"dev": true
+		},
+		"react-merge-refs": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/react-merge-refs/-/react-merge-refs-1.0.0.tgz",
+			"integrity": "sha512-VkvWuCR5VoTjb+VYUcOjkFo66HDv1Hw8VjKcwQtWr2lJnT8g7epRRyfz8+Zkl2WhwqNeqR0gIe0XYrBa9ePeXg=="
 		},
 		"react-moment-proptypes": {
 			"version": "1.6.0",

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -54,6 +54,7 @@
 		"lodash": "^4.17.15",
 		"memize": "^1.1.0",
 		"react-autosize-textarea": "^3.0.2",
+		"react-merge-refs": "^1.0.0",
 		"react-spring": "^8.0.19",
 		"redux-multi": "^0.1.12",
 		"refx": "^3.0.0",

--- a/packages/block-editor/src/components/block-list/block-popover.js
+++ b/packages/block-editor/src/components/block-list/block-popover.js
@@ -64,7 +64,7 @@ function BlockPopover( {
 	const isLargeViewport = useViewportMatch( 'medium' );
 	const [ isToolbarForced, setIsToolbarForced ] = useState( false );
 	const [ isInserterShown, setIsInserterShown ] = useState( false );
-	const [ blockNodes ] = useContext( BlockNodes );
+	const blockNodes = useContext( BlockNodes );
 
 	const showEmptyBlockSideInserter =
 		! isNavigationMode && isEmptyDefaultBlock && isValid;

--- a/packages/block-editor/src/components/block-list/block-wrapper.js
+++ b/packages/block-editor/src/components/block-list/block-wrapper.js
@@ -19,14 +19,14 @@ import { useSelect, useDispatch } from '@wordpress/data';
  */
 import { isInsideRootBlock } from '../../utils/dom';
 import useMovingAnimation from './moving-animation';
-import { Context, BlockNodes } from './root-container';
+import { Context, SetBlockNodes } from './root-container';
 import { BlockListBlockContext } from './block';
 import ELEMENTS from './block-elements';
 
 const BlockComponent = forwardRef(
 	( { children, tagName = 'div', __unstableIsHtml, ...props }, wrapper ) => {
 		const onSelectionStart = useContext( Context );
-		const [ , setBlockNodes ] = useContext( BlockNodes );
+		const setBlockNodes = useContext( SetBlockNodes );
 		const {
 			clientId,
 			rootClientId,

--- a/packages/block-editor/src/components/block-list/block-wrapper.js
+++ b/packages/block-editor/src/components/block-list/block-wrapper.js
@@ -68,7 +68,13 @@ const BlockComponent = forwardRef(
 		// Provide the selected node so it can be used to position the contextual block toolbar.
 		// The wrapper changes when the alignment class changes.
 		useEffect( () => {
-			const id = window.requestIdleCallback( () => {
+			const {
+				requestAnimationFrame,
+				cancelAnimationFrame,
+				requestIdleCallback = requestAnimationFrame,
+				cancelIdleCallback = cancelAnimationFrame,
+			} = window;
+			const id = requestIdleCallback( () => {
 				setBlockNodes( ( nodes ) => ( {
 					...nodes,
 					[ clientId ]: wrapper.current,
@@ -76,7 +82,7 @@ const BlockComponent = forwardRef(
 			} );
 
 			return () => {
-				window.cancelIdleCallback( id );
+				cancelIdleCallback( id );
 				setBlockNodes( ( nodes ) => omit( nodes, clientId ) );
 			};
 		}, [ isAligned ] );

--- a/packages/block-editor/src/components/block-list/block-wrapper.js
+++ b/packages/block-editor/src/components/block-list/block-wrapper.js
@@ -68,11 +68,17 @@ const BlockComponent = forwardRef(
 		// Provide the selected node so it can be used to position the contextual block toolbar.
 		// The wrapper changes when the alignment class changes.
 		useEffect( () => {
-			setBlockNodes( ( nodes ) => ( {
-				...nodes,
-				[ clientId ]: wrapper.current,
-			} ) );
-			return () => setBlockNodes( ( nodes ) => omit( nodes, clientId ) );
+			const id = window.requestIdleCallback( () => {
+				setBlockNodes( ( nodes ) => ( {
+					...nodes,
+					[ clientId ]: wrapper.current,
+				} ) );
+			} );
+
+			return () => {
+				window.cancelIdleCallback( id );
+				setBlockNodes( ( nodes ) => omit( nodes, clientId ) );
+			};
 		}, [ isAligned ] );
 
 		// translators: %s: Type of block (i.e. Text, Image etc)

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -44,7 +44,6 @@ function BlockListBlock( {
 	isMultiSelected,
 	isPartOfMultiSelection,
 	isFirstMultiSelected,
-	isLastMultiSelected,
 	isTypingWithinBlock,
 	isAncestorOfSelectedBlock,
 	isSelectionEnabled,
@@ -151,7 +150,6 @@ function BlockListBlock( {
 		rootClientId,
 		isSelected,
 		isFirstMultiSelected,
-		isLastMultiSelected,
 		isMultiSelecting,
 		isNavigationMode,
 		isPartOfMultiSelection,
@@ -210,7 +208,6 @@ const applyWithSelect = withSelect(
 			isAncestorMultiSelected,
 			isBlockMultiSelected,
 			isFirstMultiSelectedBlock,
-			getLastMultiSelectedBlockClientId,
 			isTyping,
 			getBlockMode,
 			isSelectionEnabled,
@@ -246,8 +243,6 @@ const applyWithSelect = withSelect(
 				isBlockMultiSelected( clientId ) ||
 				isAncestorMultiSelected( clientId ),
 			isFirstMultiSelected: isFirstMultiSelectedBlock( clientId ),
-			isLastMultiSelected:
-				getLastMultiSelectedBlockClientId() === clientId,
 
 			// We only care about this prop when the block is selected
 			// Thus to avoid unnecessary rerenders we avoid updating the prop if

--- a/packages/block-editor/src/components/block-list/root-container.js
+++ b/packages/block-editor/src/components/block-list/root-container.js
@@ -21,6 +21,7 @@ import BlockPopover from './block-popover';
 
 export const Context = createContext();
 export const BlockNodes = createContext();
+export const SetBlockNodes = createContext();
 
 function selector( select ) {
 	const {
@@ -79,6 +80,8 @@ function RootContainer( { children, className }, ref ) {
 		}
 	}
 
+	const [ blockNodes, setBlockNodes ] = useState( {} );
+
 	return (
 		<InsertionPoint
 			isMultiSelecting={ isMultiSelecting }
@@ -86,8 +89,10 @@ function RootContainer( { children, className }, ref ) {
 			selectedBlockClientId={ selectedBlockClientId }
 			containerRef={ ref }
 		>
-			<BlockNodes.Provider value={ useState( {} ) }>
+			<BlockNodes.Provider value={ blockNodes }>
 				<BlockPopover />
+			</BlockNodes.Provider>
+			<SetBlockNodes.Provider value={ setBlockNodes }>
 				<div
 					ref={ ref }
 					className={ classnames( className, 'is-root-container' ) }
@@ -98,7 +103,7 @@ function RootContainer( { children, className }, ref ) {
 						{ children }
 					</Context.Provider>
 				</div>
-			</BlockNodes.Provider>
+			</SetBlockNodes.Provider>
 		</InsertionPoint>
 	);
 }

--- a/packages/e2e-tests/specs/editor/plugins/align-hook.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/align-hook.test.js
@@ -95,14 +95,15 @@ describe( 'Align Hook Works As Expected', () => {
 				'.components-dropdown-menu__menu button.is-active';
 			// set the specified alignment.
 			await insertBlock( blockName );
-			const element = await page.waitForSelector(
-				CHANGE_ALIGNMENT_BUTTON_SELECTOR
-			);
-			await element.click();
+			await (
+				await page.waitForSelector( CHANGE_ALIGNMENT_BUTTON_SELECTOR )
+			 ).click();
 			await ( await page.$x( BUTTON_XPATH ) )[ 0 ].click();
 
 			// verify the button of the specified alignment is pressed.
-			await page.click( CHANGE_ALIGNMENT_BUTTON_SELECTOR );
+			await (
+				await page.waitForSelector( CHANGE_ALIGNMENT_BUTTON_SELECTOR )
+			 ).click();
 			let pressedButtons = await page.$$( BUTTON_PRESSED_SELECTOR );
 			expect( pressedButtons ).toHaveLength( 1 );
 
@@ -119,11 +120,15 @@ describe( 'Align Hook Works As Expected', () => {
 			);
 
 			// remove the alignment.
-			await page.click( CHANGE_ALIGNMENT_BUTTON_SELECTOR );
+			await (
+				await page.waitForSelector( CHANGE_ALIGNMENT_BUTTON_SELECTOR )
+			 ).click();
 			await ( await page.$x( BUTTON_XPATH ) )[ 0 ].click();
 
 			// verify no alignment button is in pressed state.
-			await page.click( CHANGE_ALIGNMENT_BUTTON_SELECTOR );
+			await (
+				await page.waitForSelector( CHANGE_ALIGNMENT_BUTTON_SELECTOR )
+			 ).click();
 			pressedButtons = await page.$$( BUTTON_PRESSED_SELECTOR );
 			expect( pressedButtons ).toHaveLength( 0 );
 
@@ -139,7 +144,9 @@ describe( 'Align Hook Works As Expected', () => {
 			);
 
 			// verify no alignment button is in pressed state after parsing the block.
-			await page.click( CHANGE_ALIGNMENT_BUTTON_SELECTOR );
+			await (
+				await page.waitForSelector( CHANGE_ALIGNMENT_BUTTON_SELECTOR )
+			 ).click();
 			pressedButtons = await page.$$( BUTTON_PRESSED_SELECTOR );
 			expect( pressedButtons ).toHaveLength( 0 );
 		} );

--- a/packages/e2e-tests/specs/editor/plugins/cpt-locking.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/cpt-locking.test.js
@@ -43,9 +43,10 @@ describe( 'cpt locking', () => {
 			'.block-editor-rich-text__editable[data-type="core/paragraph"]'
 		);
 		// Hover the block switcher to show the movers
-		await page.hover(
+		const button = await page.waitForSelector(
 			'.block-editor-block-toolbar .block-editor-block-toolbar__block-switcher-wrapper'
 		);
+		await button.hover();
 		expect( await page.$( 'button[aria-label="Move up"]' ) ).not.toBeNull();
 		await page.click( 'button[aria-label="Move up"]' );
 		await page.type(

--- a/packages/e2e-tests/specs/editor/various/adding-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/adding-blocks.test.js
@@ -127,9 +127,11 @@ describe( 'adding blocks', () => {
 	it( 'should not allow transfer of focus outside of the block-insertion menu once open', async () => {
 		// Enter the default block and click the inserter toggle button to the left of it.
 		await page.keyboard.press( 'ArrowDown' );
-		await page.click(
-			'.block-editor-block-list__empty-block-inserter .block-editor-inserter__toggle'
-		);
+		await (
+			await page.waitForSelector(
+				'.block-editor-block-list__empty-block-inserter .block-editor-inserter__toggle'
+			)
+		 ).click();
 
 		// Expect the inserter search input to be the active element.
 		let activeElementClassList = await page.evaluate(


### PR DESCRIPTION
on master, when we update block alignment from not aligned to any alignment (left, right,....) or the opposite, the block toolbar disappears and don't appear only after deselecting/reselecting the block.

This PR fixes the behavior.

**Testing instructions**

 - Make sure that applying alignments don't hide the toolbar.