### PR TITLE
Block Editor: Tips feature

### DIFF
--- a/packages/block-editor/src/components/block-card/index.js
+++ b/packages/block-editor/src/components/block-card/index.js
@@ -1,21 +1,39 @@
 /**
+ * WordPress dependencies
+ */
+import { Tip } from '@wordpress/components';
+
+/**
  * Internal dependencies
  */
 import BlockIcon from '../block-icon';
 
-function BlockCard( { blockType } ) {
+// const contextualTip = select( 'core/block-editor' ).__experimentalGetBlockInserterTipByContext( context, true );
+
+// console.log( { __experimentalGetBlockTipByType } );
+
+function BlockCard( { blockType, tip } ) {
 	return (
-		<div className="block-editor-block-card">
-			<BlockIcon icon={ blockType.icon } showColors />
-			<div className="block-editor-block-card__content">
-				<h2 className="block-editor-block-card__title">
-					{ blockType.title }
-				</h2>
-				<span className="block-editor-block-card__description">
-					{ blockType.description }
-				</span>
+		<>
+			<div className="block-editor-block-card">
+				<BlockIcon icon={ blockType.icon } showColors />
+				<div className="block-editor-block-card__content">
+					<h2 className="block-editor-block-card__title">
+						{ blockType.title }
+					</h2>
+					<span className="block-editor-block-card__description">
+						{ blockType.description }
+					</span>
+				</div>
 			</div>
-		</div>
+			{ tip && (
+				<div className="block-editor-block-card">
+					<div className="block-editor-block-card__tip">
+						<Tip>{ tip }</Tip>
+					</div>
+				</div>
+			) }
+		</>
 	);
 }
 

--- a/packages/block-editor/src/components/block-card/index.js
+++ b/packages/block-editor/src/components/block-card/index.js
@@ -8,10 +8,6 @@ import { Tip } from '@wordpress/components';
  */
 import BlockIcon from '../block-icon';
 
-// const contextualTip = select( 'core/block-editor' ).__experimentalGetBlockInserterTipsByContext( context, true );
-
-// console.log( { __experimentalGetBlockTipsByType } );
-
 function BlockCard( { blockType, tip } ) {
 	return (
 		<>

--- a/packages/block-editor/src/components/block-card/index.js
+++ b/packages/block-editor/src/components/block-card/index.js
@@ -8,9 +8,9 @@ import { Tip } from '@wordpress/components';
  */
 import BlockIcon from '../block-icon';
 
-// const contextualTip = select( 'core/block-editor' ).__experimentalGetBlockInserterTipByContext( context, true );
+// const contextualTip = select( 'core/block-editor' ).__experimentalGetBlockInserterTipsByContext( context, true );
 
-// console.log( { __experimentalGetBlockTipByType } );
+// console.log( { __experimentalGetBlockTipsByType } );
 
 function BlockCard( { blockType, tip } ) {
 	return (

--- a/packages/block-editor/src/components/block-card/style.scss
+++ b/packages/block-editor/src/components/block-card/style.scss
@@ -12,6 +12,10 @@
 	width: 36px;
 }
 
+.block-editor-block-card__tip {
+	margin-top: -7px;
+}
+
 .block-editor-block-card__content {
 	flex-grow: 1;
 }

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -154,7 +154,7 @@ function InserterMenu( {
 			</div>
 			{ showInserterHelpPanel && (
 				<div className="block-editor-inserter__tips">
-					<Tips tipContext={ filterValue } />
+					<Tips context={ filterValue } />
 				</div>
 			) }
 		</>

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -154,7 +154,7 @@ function InserterMenu( {
 			</div>
 			{ showInserterHelpPanel && (
 				<div className="block-editor-inserter__tips">
-					<Tips />
+					<Tips tipContext={ filterValue } />
 				</div>
 			) }
 		</>

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -154,7 +154,7 @@ function InserterMenu( {
 			</div>
 			{ showInserterHelpPanel && (
 				<div className="block-editor-inserter__tips">
-					<Tips context={ filterValue } />
+					<Tips filterValue={ filterValue } />
 				</div>
 			) }
 		</>

--- a/packages/block-editor/src/components/inserter/preview-panel.js
+++ b/packages/block-editor/src/components/inserter/preview-panel.js
@@ -8,6 +8,7 @@ import {
 	getBlockType,
 } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
+import { select } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -17,6 +18,8 @@ import BlockPreview from '../block-preview';
 
 function InserterPreviewPanel( { item } ) {
 	const hoveredItemBlockType = getBlockType( item.name );
+	const { __experimentalGetBlockTipByType } = select( 'core/block-editor' );
+
 	return (
 		<div className="block-editor-inserter__menu-preview-panel">
 			<div className="block-editor-inserter__preview">
@@ -50,7 +53,12 @@ function InserterPreviewPanel( { item } ) {
 					</div>
 				) }
 			</div>
-			{ ! isReusableBlock( item ) && <BlockCard blockType={ item } /> }
+			{ ! isReusableBlock( item ) && (
+				<BlockCard
+					blockType={ item }
+					tip={ __experimentalGetBlockTipByType( item.name, true ) }
+				/>
+			) }
 		</div>
 	);
 }

--- a/packages/block-editor/src/components/inserter/preview-panel.js
+++ b/packages/block-editor/src/components/inserter/preview-panel.js
@@ -18,7 +18,7 @@ import BlockPreview from '../block-preview';
 
 function InserterPreviewPanel( { item } ) {
 	const hoveredItemBlockType = getBlockType( item.name );
-	const { __experimentalGetBlockTipByType } = select( 'core/block-editor' );
+	const { __experimentalGetBlockTipsByType } = select( 'core/block-editor' );
 
 	return (
 		<div className="block-editor-inserter__menu-preview-panel">
@@ -56,7 +56,7 @@ function InserterPreviewPanel( { item } ) {
 			{ ! isReusableBlock( item ) && (
 				<BlockCard
 					blockType={ item }
-					tip={ __experimentalGetBlockTipByType( item.name, true ) }
+					tip={ __experimentalGetBlockTipsByType( item.name, true ) }
 				/>
 			) }
 		</div>

--- a/packages/block-editor/src/components/inserter/tips.js
+++ b/packages/block-editor/src/components/inserter/tips.js
@@ -4,6 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { createInterpolateElement, useState } from '@wordpress/element';
 import { Tip } from '@wordpress/components';
+import {context} from "@actions/github/lib/github";
 
 const globalTips = [
 	createInterpolateElement(
@@ -27,6 +28,53 @@ const globalTips = [
 	__( 'Drag files into the editor to automatically insert media blocks.' ),
 	__( "Change a block's type by pressing the block icon on the toolbar." ),
 ];
+
+const contextualTips = {
+	css: createInterpolateElement(
+		__(
+			'CSS - You can visit the <a>the Customizer</a> to edit the CSS on your site.'
+		),
+		{
+			a: <a href="/customize.php?autofocus[section]=custom_css" target="_blank"/>
+		}
+	),
+
+	theme: createInterpolateElement(
+		__(
+			'theme - You can visit the <a>theme directory</a> to select a different design for your site.'
+		),
+		{
+			a: <a href="/themes.php" target="_blank"/>
+		}
+	),
+
+	plugin: createInterpolateElement(
+		__(
+			'plugin - You can visit the <a>plugin directory</a> to install additional plugins.'
+		),
+		{
+			a: <a href="/plugin-install.php" target="_blank"/>
+		}
+	),
+
+	header: createInterpolateElement(
+		__(
+			'header - You can visit the <a>the Customizer</a> to edit your logo and site title.'
+		),
+		{
+			a: <a href="/customize.php?autofocus[section]=title_tagline" target="_blank"/>
+		}
+	),
+
+	colors: createInterpolateElement(
+		__(
+			'colors - You can visit the <a>the Customizer</a> to edit your logo and site title.'
+		),
+		{
+			a: <a href="/customize.php?autofocus[section]=colors" target="_blank"/>
+		}
+	),
+};
 
 function Tips() {
 	const [ randomIndex ] = useState(

--- a/packages/block-editor/src/components/inserter/tips.js
+++ b/packages/block-editor/src/components/inserter/tips.js
@@ -30,9 +30,9 @@ const globalTips = [
 	__( "Change a block's type by pressing the block icon on the toolbar." ),
 ];
 
-function Tips( { context } ) {
+function Tips( { filterValue } ) {
 	// Return a contextual tip when it's appropriate.
-	const contextualTip = select( 'core/block-editor' ).__experimentalGetBlockInserterTipsByContext( context, true );
+	const contextualTip = select( 'core/block-editor' ).__experimentalGetBlockInserterTipsByContext( filterValue, true );
 	if ( contextualTip ) {
 		return <Tip>{ contextualTip }</Tip>;
 	}

--- a/packages/block-editor/src/components/inserter/tips.js
+++ b/packages/block-editor/src/components/inserter/tips.js
@@ -32,7 +32,7 @@ const globalTips = [
 
 function Tips( { context } ) {
 	// Return a contextual tip when it's appropriate.
-	const contextualTip = select( 'core/block-editor' ).__experimentalGetBlockInserterTipByContext( context, true );
+	const contextualTip = select( 'core/block-editor' ).__experimentalGetBlockInserterTipsByContext( context, true );
 	if ( contextualTip ) {
 		return <Tip>{ contextualTip }</Tip>;
 	}

--- a/packages/block-editor/src/components/inserter/tips.js
+++ b/packages/block-editor/src/components/inserter/tips.js
@@ -72,7 +72,7 @@ const contextualTips = {
 
 	colors: createInterpolateElement(
 		__(
-			'colors - You can visit the <a>the Customizer</a> to edit your logo and site title.'
+			'colors - You can visit the <a>the Customizer</a> to edit the colors on your site.'
 		),
 		{
 			a: <a href="/customize.php?autofocus[section]=colors" target="_blank"/>

--- a/packages/block-editor/src/components/inserter/tips.js
+++ b/packages/block-editor/src/components/inserter/tips.js
@@ -1,10 +1,14 @@
 /**
+ * External dependencies
+ */
+import { lowerCase, includes, filter } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { createInterpolateElement, useState } from '@wordpress/element';
 import { Tip } from '@wordpress/components';
-import {context} from "@actions/github/lib/github";
 
 const globalTips = [
 	createInterpolateElement(
@@ -76,9 +80,30 @@ const contextualTips = {
 	),
 };
 
+function getTipByContext( tipContext ) {
+	if ( ! tipContext ) {
+		return;
+	}
+
+	const contextualKeys = filter( Object.keys( contextualTips ), ( key ) =>
+		includes( lowerCase( tipContext ), key )
+	);
+
+	if ( ! contextualKeys.length ) {
+		return;
+	}
+
+	return contextualTips[
+		// eslint-disable-next-line no-restricted-syntax
+		contextualKeys[ Math.floor( Math.random() * contextualKeys.length ) ]
+	];
+}
+
 function Tips( { tipContext } ) {
-	if ( contextualTips[ tipContext ] ) {
-		return <Tip>{ contextualTips[ tipContext ] }</Tip>;
+	// Return a contextual tip when it's appropriate.
+	const contextualTip = getTipByContext( tipContext );
+	if ( contextualTip ) {
+		return <Tip>{ contextualTip }</Tip>;
 	}
 
 	const [ randomIndex ] = useState(

--- a/packages/block-editor/src/components/inserter/tips.js
+++ b/packages/block-editor/src/components/inserter/tips.js
@@ -1,7 +1,3 @@
-/**
- * External dependencies
- */
-import { lowerCase, includes, filter } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -9,6 +5,7 @@ import { lowerCase, includes, filter } from 'lodash';
 import { __ } from '@wordpress/i18n';
 import { createInterpolateElement, useState } from '@wordpress/element';
 import { Tip } from '@wordpress/components';
+import { select } from '@wordpress/data';
 
 const globalTips = [
 	createInterpolateElement(
@@ -33,75 +30,9 @@ const globalTips = [
 	__( "Change a block's type by pressing the block icon on the toolbar." ),
 ];
 
-const contextualTips = {
-	css: createInterpolateElement(
-		__(
-			'CSS - You can visit the <a>the Customizer</a> to edit the CSS on your site.'
-		),
-		{
-			a: <a href="/customize.php?autofocus[section]=custom_css" target="_blank"/>
-		}
-	),
-
-	theme: createInterpolateElement(
-		__(
-			'theme - You can visit the <a>theme directory</a> to select a different design for your site.'
-		),
-		{
-			a: <a href="/themes.php" target="_blank"/>
-		}
-	),
-
-	plugin: createInterpolateElement(
-		__(
-			'plugin - You can visit the <a>plugin directory</a> to install additional plugins.'
-		),
-		{
-			a: <a href="/plugin-install.php" target="_blank"/>
-		}
-	),
-
-	header: createInterpolateElement(
-		__(
-			'header - You can visit the <a>the Customizer</a> to edit your logo and site title.'
-		),
-		{
-			a: <a href="/customize.php?autofocus[section]=title_tagline" target="_blank"/>
-		}
-	),
-
-	colors: createInterpolateElement(
-		__(
-			'colors - You can visit the <a>the Customizer</a> to edit the colors on your site.'
-		),
-		{
-			a: <a href="/customize.php?autofocus[section]=colors" target="_blank"/>
-		}
-	),
-};
-
-function getTipByContext( tipContext ) {
-	if ( ! tipContext ) {
-		return;
-	}
-
-	const contextualKeys = filter( Object.keys( contextualTips ), ( key ) =>
-		includes( lowerCase( tipContext ), key )
-	);
-
-	if ( ! contextualKeys.length ) {
-		return;
-	}
-
-	return contextualTips[
-		// eslint-disable-next-line no-restricted-syntax
-		contextualKeys[ Math.floor( Math.random() * contextualKeys.length ) ]
-	];
-}
-
-function Tips( { tipContext } ) {
+function Tips( { context } ) {
 	// Return a contextual tip when it's appropriate.
-	const contextualTip = getTipByContext( tipContext );
+	const contextualTip = select( 'core/block-editor' ).__experimentalGetBlockInserterTipByContext( context, true );
 	if ( contextualTip ) {
 		return <Tip>{ contextualTip }</Tip>;
 	}

--- a/packages/block-editor/src/components/inserter/tips.js
+++ b/packages/block-editor/src/components/inserter/tips.js
@@ -76,7 +76,11 @@ const contextualTips = {
 	),
 };
 
-function Tips() {
+function Tips( { tipContext } ) {
+	if ( contextualTips[ tipContext ] ) {
+		return <Tip>{ contextualTips[ tipContext ] }</Tip>;
+	}
+
 	const [ randomIndex ] = useState(
 		// Disable Reason: I'm not generating an HTML id.
 		// eslint-disable-next-line no-restricted-syntax

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1010,3 +1010,35 @@ export function toggleBlockHighlight( clientId, isHighlighted ) {
 		isHighlighted,
 	};
 }
+
+export function __experimentalRegisterTip(
+	scope,
+	context,
+	keywords,
+	description
+) {
+	return {
+		type: 'REGISTER_TIP',
+		scope,
+		context,
+		keywords,
+		description,
+	};
+}
+
+export function __experimentalRegisterBlockInserterTip(
+	context,
+	keywords,
+	description
+) {
+	return __experimentalRegisterTip(
+		'blockInserter',
+		context,
+		keywords,
+		description
+	);
+}
+
+export function __experimentalRegisterBlockTip( type, description ) {
+	return __experimentalRegisterTip( type, null, null, description );
+}

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -16,6 +16,7 @@ import {
 	identity,
 	difference,
 	omitBy,
+	uniq,
 } from 'lodash';
 
 /**
@@ -23,6 +24,7 @@ import {
  */
 import { combineReducers } from '@wordpress/data';
 import { isReusableBlock } from '@wordpress/blocks';
+
 /**
  * Internal dependencies
  */
@@ -1479,6 +1481,29 @@ export function highlightedBlock( state, action ) {
 	return state;
 }
 
+export function tips( state, action ) {
+	const { scope, context, keywords, description } = action;
+
+	switch ( action.type ) {
+		case 'REGISTER_TIP':
+			const tipsByScope = state && state[ scope ] ? state[ scope ] : [];
+
+			return {
+				...state,
+				[ scope ]: [
+					...tipsByScope,
+					{
+						context,
+						keywords: uniq( keywords ),
+						description,
+					},
+				],
+			};
+	}
+
+	return state;
+}
+
 export default combineReducers( {
 	blocks,
 	isTyping,
@@ -1499,4 +1524,5 @@ export default combineReducers( {
 	isNavigationMode,
 	automaticChangeStatus,
 	highlightedBlock,
+	tips,
 } );

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1642,7 +1642,7 @@ function getArrayIndex( array, random = true ) {
 	return random ? Math.floor( Math.random() * array.length ) : 0;
 }
 
-export function __experimentalGetBlockInserterTipByContext(
+export function __experimentalGetBlockInserterTipsByContext(
 	state,
 	searchTerm,
 	random = false
@@ -1677,7 +1677,7 @@ export function __experimentalGetBlockInserterTipByContext(
 	return get( foundTips, [ index, 'description' ] );
 }
 
-export function __experimentalGetBlockTipByType( state, type, random = false ) {
+export function __experimentalGetBlockTipsByType( state, type, random = false ) {
 	const tips = get( state, [ 'tips', type ], EMPTY_ARRAY );
 	if ( ! tips.length ) {
 		return null;

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -16,6 +16,9 @@ import {
 	some,
 	find,
 	filter,
+	lowerCase,
+	uniq,
+	deburr,
 } from 'lodash';
 import createSelector from 'rememo';
 
@@ -1632,4 +1635,54 @@ export function didAutomaticChange( state ) {
  */
 export function isBlockHighlighted( state, clientId ) {
 	return state.highlightedBlock === clientId;
+}
+
+function getArrayIndex( array, random = true ) {
+	// eslint-disable-next-line no-restricted-syntax
+	return random ? Math.floor( Math.random() * array.length ) : 0;
+}
+
+export function __experimentalGetBlockInserterTipByContext(
+	state,
+	searchTerm,
+	random = false
+) {
+	if ( ! searchTerm ) {
+		return;
+	}
+
+	const tips = get( state, [ 'tips', 'blockInserter' ], EMPTY_ARRAY );
+	if ( ! tips.length ) {
+		return;
+	}
+
+	const normalizedSearchTerm = deburr( lowerCase( searchTerm ) ).replace(
+		/^\//,
+		''
+	);
+
+	const foundTips = filter(
+		tips,
+		( { keywords } ) =>
+			filter( keywords, ( keyword ) =>
+				includes( normalizedSearchTerm, keyword )
+			).length
+	);
+
+	if ( ! foundTips.length ) {
+		return;
+	}
+
+	const index = getArrayIndex( foundTips, random );
+	return get( foundTips, [ index, 'description' ] );
+}
+
+export function __experimentalGetBlockTipByType( state, type, random = false ) {
+	const tips = get( state, [ 'tips', type ], EMPTY_ARRAY );
+	if ( ! tips.length ) {
+		return null;
+	}
+
+	const index = getArrayIndex( tips, random );
+	return get( tips, [ index, 'description' ] );
 }

--- a/packages/block-library/src/image/index.js
+++ b/packages/block-library/src/image/index.js
@@ -3,6 +3,7 @@
  */
 import { __, _x } from '@wordpress/i18n';
 import { image as icon } from '@wordpress/icons';
+import { dispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -14,6 +15,16 @@ import save from './save';
 import transforms from './transforms';
 
 const { name } = metadata;
+
+// Register Tip.
+const { __experimentalRegisterBlockTip } = dispatch( 'core/block-editor' );
+const tips = [
+	__( 'Add alternative text to your images to make them more accessible.' ),
+	__( 'Use a Cover block to add text on top of your image.' ),
+	__( 'To place two images side by side, convert them to a Gallery.' ),
+];
+
+tips.forEach( ( desc ) => __experimentalRegisterBlockTip( name, desc ) );
 
 export { metadata, name };
 

--- a/packages/block-library/src/video/index.js
+++ b/packages/block-library/src/video/index.js
@@ -3,6 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { video as icon } from '@wordpress/icons';
+import { dispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -13,6 +14,15 @@ import save from './save';
 import transforms from './transforms';
 
 const { name } = metadata;
+
+// Register Tip.
+const { __experimentalRegisterBlockTip } = dispatch( 'core/block-editor' );
+__experimentalRegisterBlockTip(
+	name,
+	__(
+		'The video block accepts uploads in the MP4, M4V, WebM, OGV, WMV, and FLV formats.'
+	)
+);
 
 export { metadata, name };
 

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import memize from 'memize';
-import { size, map, without } from 'lodash';
+import { size, map, without, each } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -28,6 +28,7 @@ import preventEventDiscovery from './prevent-event-discovery';
 import Layout from './components/layout';
 import EditorInitialization from './components/editor-initialization';
 import EditPostSettings from './components/edit-post-settings';
+import inserterContextualTips from './utils/tips';
 
 class Editor extends Component {
 	constructor() {
@@ -36,6 +37,9 @@ class Editor extends Component {
 		this.getEditorSettings = memize( this.getEditorSettings, {
 			maxSize: 1,
 		} );
+
+		// Register Block Inserter Tips.
+		each( inserterContextualTips, this.props.registerBlockInserterTip );
 	}
 
 	getEditorSettings(
@@ -167,8 +171,16 @@ export default compose( [
 	} ),
 	withDispatch( ( dispatch ) => {
 		const { updatePreferredStyleVariations } = dispatch( 'core/edit-post' );
+		const { __experimentalRegisterBlockInserterTip } = dispatch(
+			'core/block-editor'
+		);
+
+		const registerBlockInserterTip = ( args ) =>
+			__experimentalRegisterBlockInserterTip( ...args );
+
 		return {
 			updatePreferredStyleVariations,
+			registerBlockInserterTip,
 		};
 	} ),
 ] )( Editor );

--- a/packages/edit-post/src/utils/tips.js
+++ b/packages/edit-post/src/utils/tips.js
@@ -1,0 +1,71 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { createInterpolateElement } from '@wordpress/element';
+
+export default [
+	[
+		'css',
+		[ 'css', __( 'css' ), 'style', __( 'style' ) ],
+		createInterpolateElement(
+			__(
+				'CSS - You can visit the <a>the Customizer</a> to edit the CSS on your site.'
+			),
+			{
+				a: <a href="/customize.php?autofocus[section]=custom_css" target="_blank"/>
+			}
+		),
+	],
+
+	[
+		'theme',
+		[ 'theme', __( 'theme' ) ],
+		createInterpolateElement(
+			__(
+				'theme - You can visit the <a>theme directory</a> to select a different design for your site.'
+			),
+			{
+				a: <a href="/themes.php" target="_blank"/>
+			}
+		),
+	],
+
+	[
+		'plugin',
+		[ 'plugin', __( 'plugin' ) ],
+		createInterpolateElement(
+			__(
+				'plugin - You can visit the <a>plugin directory</a> to install additional plugins.'
+			),
+			{
+				a: <a href="/plugin-install.php" target="_blank"/>
+			}
+		),
+	],
+
+	[
+		'header',
+		[ 'header', __( 'header' ) ],
+		createInterpolateElement(
+			__(
+				'header - You can visit the <a>the Customizer</a> to edit your logo and site title.'
+			),
+			{
+				a: <a href="/customize.php?autofocus[section]=title_tagline" target="_blank"/>
+			}
+		),
+	],
+	[
+		'colors',
+		[ 'colors', __( 'colors' ) ],
+		createInterpolateElement(
+			__(
+				'colors - You can visit the <a>the Customizer</a> to edit the colors on your site.'
+			),
+			{
+				a: <a href="/customize.php?autofocus[section]=colors" target="_blank"/>
+			}
+		),
+	],
+];

--- a/packages/edit-post/src/utils/tips.js
+++ b/packages/edit-post/src/utils/tips.js
@@ -6,19 +6,6 @@ import { createInterpolateElement } from '@wordpress/element';
 
 export default [
 	[
-		'css',
-		[ 'css', __( 'css' ), 'style', __( 'style' ) ],
-		createInterpolateElement(
-			__(
-				'CSS - You can visit the <a>the Customizer</a> to edit the CSS on your site.'
-			),
-			{
-				a: <a href="/customize.php?autofocus[section]=custom_css" target="_blank"/>
-			}
-		),
-	],
-
-	[
 		'theme',
 		[ 'theme', __( 'theme' ) ],
 		createInterpolateElement(
@@ -26,7 +13,20 @@ export default [
 				'theme - You can visit the <a>theme directory</a> to select a different design for your site.'
 			),
 			{
-				a: <a href="/themes.php" target="_blank"/>
+				a: <a href="./themes.php" target="_blank"/>
+			}
+		),
+	],
+
+	[
+		'css',
+		[ 'css', __( 'css' ), 'style', __( 'style' ) ],
+		createInterpolateElement(
+			__(
+				'CSS - You can visit the the <a>Customizer</a> to edit the CSS on your site.'
+			),
+			{
+				a: <a href="./customize.php?autofocus[section]=custom_css" target="_blank"/>
 			}
 		),
 	],
@@ -39,7 +39,7 @@ export default [
 				'plugin - You can visit the <a>plugin directory</a> to install additional plugins.'
 			),
 			{
-				a: <a href="/plugin-install.php" target="_blank"/>
+				a: <a href="./plugin-install.php" target="_blank"/>
 			}
 		),
 	],
@@ -49,10 +49,10 @@ export default [
 		[ 'header', __( 'header' ) ],
 		createInterpolateElement(
 			__(
-				'header - You can visit the <a>the Customizer</a> to edit your logo and site title.'
+				'header - You can visit the the <a>Customizer</a> to edit your logo and site title.'
 			),
 			{
-				a: <a href="/customize.php?autofocus[section]=title_tagline" target="_blank"/>
+				a: <a href="./customize.php?autofocus[section]=title_tagline" target="_blank"/>
 			}
 		),
 	],
@@ -61,10 +61,10 @@ export default [
 		[ 'colors', __( 'colors' ) ],
 		createInterpolateElement(
 			__(
-				'colors - You can visit the <a>the Customizer</a> to edit the colors on your site.'
+				'colors - You can visit the the <a>Customizer</a> to edit the colors on your site.'
 			),
 			{
-				a: <a href="/customize.php?autofocus[section]=colors" target="_blank"/>
+				a: <a href="./customize.php?autofocus[section]=colors" target="_blank"/>
 			}
 		),
 	],


### PR DESCRIPTION
## Description

This PR tries to tackle how to deal with Tips in a comprehensive way, using the store in order to decentralize access to the API. The goals to achieve are:

* Register Tips globally through the actions.
* Pick up tips from different points of the app, being as specific as possible in order to get the proper ones to show.

Related issues:
* Blocks: Contextual tips tied to specific search queries #20196
* Add rotating block-specific tips to the inserter's help panel #17091
* Compile a list of possible block-specific tips #16595
* Consider adding a rotating Tips area to the block sidebar #16594

## API

Actions and selectors are prefixed with `__experimental`. All data is stored in the `core/block-editor` subtree, under the `tips` key.

### Register Tips (Actions)

#### __experimentalRegisterBlockTip( scope, description )

When registers a tip we need to define its scope and description as a minimum. The simpler case is when we register a Tip for a block type. For instance...

```es6
import { dispatch } from '@wordpress/data';

// Register Tip.
const { __experimentalRegisterBlockTip } = dispatch( 'core/block-editor' );

// Register a core/video tip
__experimentalRegisterBlockTip(
	'core/video',
	__( 'The video block accepts uploads in the MP4, M4V, WebM, OGV, WMV, and FLV formats.' )
);
```

It will populate the store where, in this case, the scope is the block type. We can store more than one tip per scope. For instance, adding three tips to `core/image` block:

```es6
import { dispatch } from '@wordpress/data';

// Register Tips.
const { __experimentalRegisterBlockTip } = dispatch( 'core/block-editor' );
const tips = [
	__( 'Add alternative text to your images to make them more accessible.' ),
	__( 'Use a Cover block to add text on top of your image.' ),
	__( 'To place two images side by side, convert them to a Gallery.' ),
];

tips.forEach( ( desc ) => __experimentalRegisterBlockTip('core/image', desc ) );
```

#### __experimentalRegisterBlockInserterTip( context, keywords, description )

It registers Tips related to the Block Inserter. In #20196, we'd like to show some contextual tips when the user types specific words, such as `CSS`, `header`, `theme`, etc. In this case, the scope is a constant value: `blockInserter`. And also, we can define a set of keywords that will be used to pick up the tip. For instance, we do something like the following:

```es6
import { dispatch } from '@wordpress/data';

__experimentalRegisterBlockInserterTip(
	'CSS',
	[ 'css', 'style' ],
	__( 'CSS - You can visit the the Customizer to edit the CSS on your site.' )
);
```

### Get Tips (Selectors)

#### __experimentalGetBlockInserterTipByContext( state, type, random );

Use this selector when you'd like to get all tips about a specific block type:

```es6
import { select } from '@wordpress/data';

// ...
const { __experimentalGetBlockTipsByType } = select( 'core/block-editor' );

// get tips
const blockTypeTips = __experimentalGetBlockTipsByType( 'core/image', true );
```

It will return the tip description, or `null` if there isn't any tip registered for the block type. Also, if there is more than one tip, and the `random` parameter is `true`, it will return one of those tips randomly. if random is false, it will return the first tip from the tips list.

#### __experimentalGetBlockInserterTipsByContext( state, searchTerm, random )

Use this selector to get block inserter contextual tips. It will return a tip according to the given search term. It also supports the `random` mode whether there is more than one tip for the search term:


```es6
import { select } from '@wordpress/data';

// ...
const { __experimentalGetBlockInserterTipsByContext } = select( 'core/block-editor' );

// get tips
const contextualTip = __experimentalGetBlockInserterTipsByContext( 'css', true );
```

## Adding tips to the interface

### Block Inserter

This PR registers five tips to the block inserter component, in `tips.js`  file of the edit-post package. The following is one item of the tips array:

```e6
[
		'css',
		[ 'css', __( 'css' ), 'style', __( 'style' ) ],
		createInterpolateElement(
			__(
				'CSS - You can visit the <a>the Customizer</a> to edit the CSS on your site.'
			),
			{
				a: <a href="/customize.php?autofocus[section]=custom_css" target="_blank"/>
			}
		),
	],
```

The first element is the context used to register the tip. The second one defines the tip keywords, used to compare and show it where/when it's appropriated. And the third one is the Tip description. It worths noticing that it could be a component. In this case, we'd like to translate the tip description.

These tips are registered in the constructor of the Editor class.

In another hand, the block inserter will try to pick the tip when the user types a search term in the searcher input box. If it matches, it will show one of the registered tips.

<img width="410" alt="Screen Shot 2020-05-06 at 5 04 39 PM" src="https://user-images.githubusercontent.com/77539/81223132-e0b78000-8fbb-11ea-84ac-b45c1dc6913a.png">

This approach defines more than a keyword for the tip. in the case of the `css`, it will be shown with the `style` term as well:

<img width="359" alt="Screen Shot 2020-05-06 at 5 05 29 PM" src="https://user-images.githubusercontent.com/77539/81223217-093f7a00-8fbc-11ea-8ed0-7f113e2915a3.png">

Finally, we are translating some keywords in order to make it work in other languages. For instance, in the following screenshot I typed `cabecera` which is the translation of `header` to Spanish:

<img width="363" alt="Screen Shot 2020-05-06 at 5 08 35 PM" src="https://user-images.githubusercontent.com/77539/81223441-5d4a5e80-8fbc-11ea-86a7-1af060b4c8a9.png">

### Block Preview

This PR also shows a tip in the block preview of the block inserter whether the block type has some tips registered. In this PR we've registered three tips for the `core/image` block, and one for the `core/video` block, picked from [this list](https://github.com/WordPress/gutenberg/issues/16595#issuecomment-518750188).

<img width="500" alt="Screen Shot 2020-05-06 at 5 10 49 PM" src="https://user-images.githubusercontent.com/77539/81223958-4b1cf000-8fbd-11ea-97e3-e0d3bd2b10a4.png">

Since `core/image` [has three tips registered](https://github.com/WordPress/gutenberg/pull/22109/files#diff-96938367d23d602d6690423940454cd0R20-R27) and the selector pass `random` as `true`, it will change the tip every time that the preview is re-rendered:

<img alt="Screen Shot 2020-05-06 at 5 11 21 PM" src="https://user-images.githubusercontent.com/77539/81223881-288ad700-8fbd-11ea-944e-f7034c63a579.png" width="500px" />


## How has this been tested?

TBD

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->