### PR TITLE
Add explanatory text before the a11y.speak aria-live regions.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9718,7 +9718,8 @@
 			"version": "file:packages/a11y",
 			"requires": {
 				"@babel/runtime": "^7.9.2",
-				"@wordpress/dom-ready": "file:packages/dom-ready"
+				"@wordpress/dom-ready": "file:packages/dom-ready",
+				"@wordpress/i18n": "file:packages/i18n"
 			}
 		},
 		"@wordpress/annotations": {

--- a/packages/a11y/package.json
+++ b/packages/a11y/package.json
@@ -24,7 +24,8 @@
 	"types": "build-types",
 	"dependencies": {
 		"@babel/runtime": "^7.9.2",
-		"@wordpress/dom-ready": "file:../dom-ready"
+		"@wordpress/dom-ready": "file:../dom-ready",
+		"@wordpress/i18n": "file:../i18n"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/a11y/src/add-intro-text.js
+++ b/packages/a11y/src/add-intro-text.js
@@ -14,7 +14,7 @@ import { __ } from '@wordpress/i18n';
 export default function addIntroText() {
 	const introText = document.createElement( 'p' );
 
-	introText.id = `a11y-speak-intro-text`;
+	introText.id = 'a11y-speak-intro-text';
 	introText.className = 'a11y-speak-intro-text';
 	introText.textContent = __( 'Notifications' );
 

--- a/packages/a11y/src/add-intro-text.js
+++ b/packages/a11y/src/add-intro-text.js
@@ -1,0 +1,43 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Build the explanatory text to be placed before the aria live regions.
+ *
+ * This text is initially hidden from assistive technologies by using a `hidden`
+ * HTML attribute which is then removed once a message fills the aria-live regions.
+ *
+ * @return {HTMLParagraphElement} The explanatory text HTML element.
+ */
+export default function addIntroText() {
+	const introText = document.createElement( 'p' );
+
+	introText.id = `a11y-speak-intro-text`;
+	introText.className = 'a11y-speak-intro-text';
+	introText.textContent = __( 'Notifications' );
+
+	introText.setAttribute(
+		'style',
+		'position: absolute;' +
+			'margin: -1px;' +
+			'padding: 0;' +
+			'height: 1px;' +
+			'width: 1px;' +
+			'overflow: hidden;' +
+			'clip: rect(1px, 1px, 1px, 1px);' +
+			'-webkit-clip-path: inset(50%);' +
+			'clip-path: inset(50%);' +
+			'border: 0;' +
+			'word-wrap: normal !important;'
+	);
+	introText.setAttribute( 'hidden', 'hidden' );
+
+	const { body } = document;
+	if ( body ) {
+		body.appendChild( introText );
+	}
+
+	return introText;
+}

--- a/packages/a11y/src/clear.js
+++ b/packages/a11y/src/clear.js
@@ -1,10 +1,16 @@
 /**
- * Clear the a11y-speak-region elements.
+ * Clears the a11y-speak-region elements and hides the explanatory text.
  */
 export default function clear() {
 	const regions = document.getElementsByClassName( 'a11y-speak-region' );
+	const introText = document.getElementById( 'a11y-speak-intro-text' );
 
 	for ( let i = 0; i < regions.length; i++ ) {
 		regions[ i ].textContent = '';
+	}
+
+	// Make sure the explanatory text is hidden from assistive technologies.
+	if ( introText ) {
+		introText.setAttribute( 'hidden', 'hidden' );
 	}
 }

--- a/packages/a11y/src/filter-message.js
+++ b/packages/a11y/src/filter-message.js
@@ -17,6 +17,10 @@ export default function filterMessage( message ) {
 	 */
 	message = message.replace( /<[^<>]+>/g, ' ' );
 
+	/*
+	 * Safari + VoiceOver don't announce repeated, identical strings. We use
+	 * a `no-break space` to force them to think identical strings are different.
+	 */
 	if ( previousMessage === message ) {
 		message += '\u00A0';
 	}

--- a/packages/a11y/src/index.js
+++ b/packages/a11y/src/index.js
@@ -6,6 +6,7 @@ import domReady from '@wordpress/dom-ready';
 /**
  * Internal dependencies
  */
+import addIntroText from './add-intro-text';
 import addContainer from './add-container';
 import clear from './clear';
 import filterMessage from './filter-message';
@@ -14,14 +15,20 @@ import filterMessage from './filter-message';
  * Create the live regions.
  */
 export function setup() {
+	const introText = document.getElementById( 'a11y-speak-intro-text' );
 	const containerAssertive = document.getElementById(
 		'a11y-speak-assertive'
 	);
 	const containerPolite = document.getElementById( 'a11y-speak-polite' );
 
+	if ( introText === null ) {
+		addIntroText();
+	}
+
 	if ( containerAssertive === null ) {
 		addContainer( 'assertive' );
 	}
+
 	if ( containerPolite === null ) {
 		addContainer( 'polite' );
 	}
@@ -51,11 +58,15 @@ domReady( setup );
  * ```
  */
 export function speak( message, ariaLive ) {
-	// Clear previous messages to allow repeated strings being read out.
+	/*
+	 * Clear previous messages to allow repeated strings being read out and hide
+	 * the explanatory text from assistive technologies.
+	 */
 	clear();
 
 	message = filterMessage( message );
 
+	const introText = document.getElementById( 'a11y-speak-intro-text' );
 	const containerAssertive = document.getElementById(
 		'a11y-speak-assertive'
 	);
@@ -65,5 +76,13 @@ export function speak( message, ariaLive ) {
 		containerAssertive.textContent = message;
 	} else if ( containerPolite ) {
 		containerPolite.textContent = message;
+	}
+
+	/*
+	 * Make the explanatory text available to assistive technologies by removing
+	 * the 'hidden' HTML attribute.
+	 */
+	if ( introText ) {
+		introText.removeAttribute( 'hidden' );
 	}
 }

--- a/packages/a11y/tsconfig.json
+++ b/packages/a11y/tsconfig.json
@@ -4,6 +4,9 @@
 		"rootDir": "src",
 		"declarationDir": "build-types"
 	},
-	"references": [ { "path": "../dom-ready" } ],
+	"references": [
+		{ "path": "../dom-ready" },
+		{ "path": "../i18n" },
+	],
 	"include": [ "src/**/*" ]
 }


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
Fixes https://core.trac.wordpress.org/ticket/47156 which was in turn split out from https://github.com/WordPress/gutenberg/issues/15296

Please refer to the Trac ticket for more details.

The rationale on the Trac ticket is that, instead of clearing out the aria live regions (which can't be done in a reliable way), we add a visually hidden text to let screen reader users understand what the a11y.speak messages left in the DOM are about.

## How has this been tested?
Tested on latest macOS Chrome, Firefox, and Safari + VoiceOver.

The explanatory text is placed before the live regions. It's initially hidden from assistive technologies and made available only when `a11y.speak` runs.

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix: solves a bug where text was "inadvertently rendered by assistive technologies".

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
Not applicable: to my understanding, the native version of a11y.speak is still to implement. See inline comment `//TODO: Use native module to speak message`.