### PR TITLE
Block Library: Post Author: Reference attributes by argument

### DIFF
--- a/packages/block-library/src/post-author/index.php
+++ b/packages/block-library/src/post-author/index.php
@@ -88,13 +88,11 @@ function post_author_build_css_font_sizes( $attributes ) {
 /**
  * Renders the `core/post-author` block on the server.
  *
- * @param  Object $block The block to render.
+ * @param array $attributes Block attributes.
+ *
  * @return string Returns the rendered author block.
  */
-function render_block_core_post_author( $block ) {
-
-	$attributes = $block->attributes;
-
+function render_block_core_post_author( $attributes ) {
 	if ( empty( $attributes ) ) {
 		return '';
 	}


### PR DESCRIPTION
Fixes #22100

This pull request seeks to resolve a warning which can occur when a Post Author full-site editing block is part of the current page's template.

**Implementation Notes:**

As noted at https://github.com/WordPress/gutenberg/issues/22100#issuecomment-624031398, there was a rapid series of changes which occurred where a `WP_Block` `$block` was at one point the first argument provided to a `render_callback`. This was later reverted.

As best I can tell, the only property of the block which was used in this function is the attributes, which were and still remain the first argument as an array. The `WP_Block` instance is still available now as the third argument of `render_callback` if needed (as of #21925), but it doesn't appear to currently be needed.

**Testing Instructions:**

1. Verify that you have sufficient [error log level](https://www.php.net/manual/en/function.error-reporting.php) such that warnings are emitted. This should be configured by default using the [default development environment](https://github.com/WordPress/gutenberg/blob/master/docs/contributors/getting-started.md).
2. (Prerequisite) Enable the Full Site Editing experiment from Gutenberg > Experiments
3. (Prerequisite) From the "Site Editor" screen, create a template (e.g. `single`) which includes a Post Author block
4. Navigate to Posts > Add New
5. Enter a title
6. Preview the post in a separate tab
7. Verify there are no warnings