### PR TITLE
Fix API doc-building pre-commit hook issue.

### DIFF
--- a/packages/docgen/src/markdown/index.js
+++ b/packages/docgen/src/markdown/index.js
@@ -55,7 +55,7 @@ module.exports = function(
 				if ( err ) {
 					throw err;
 				}
-				fs.writeFileSync( doc, file );
+				fs.writeFileSync( doc, file.toString() );
 			} );
 	} else {
 		const output = formatter( processDir, doc, filteredIR, headingTitle );


### PR DESCRIPTION
## Description
I've been having an issue with several PRs where trying to commit JS changes would result in a pre-commit hook error. After discussing it on Slack, the issue was traced to having something to do with a `VFile` not being converted to a string when it should. For reference, [here's the Slack discussion](https://wordpress.slack.com/archives/C02QB2JS7/p1588703610258500).

This PR fixes the issue, as suggested by @aduth. I'm not an expert in this area of the code, so I'd appreciate any review to make sure nothing's broken by this change.

Notably, aduth was unable to reproduce the issue himself.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
