### PR TITLE
Bump dependencies for WordPress 5.2

### DIFF
--- a/packages/block-library/src/rss/index.php
+++ b/packages/block-library/src/rss/index.php
@@ -80,7 +80,7 @@ function render_block_core_rss( $attributes ) {
 	}
 
 	$classes           = 'grid' === $attributes['blockLayout'] ? ' is-grid columns-' . $attributes['columns'] : '';
-	$list_items_markup = "<ul class='wp-block-rss{$classes}'>{$list_items}</ul>";
+	$list_items_markup = sprintf( "<ul class='%s'>%s</ul>", esc_attr( $class ), $list_items );
 
 	// PHP 5.2 compatibility. See: http://simplepie.org/wiki/faq/i_m_getting_memory_leaks.
 	$rss->__destruct();

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -46,7 +46,7 @@ function render_block_core_search( $attributes ) {
 
 	return sprintf(
 		'<form class="%s" role="search" method="get" action="%s">%s</form>',
-		$class,
+		esc_attr( $class ),
 		esc_url( home_url( '/' ) ),
 		$label_markup . $input_markup . $button_markup
 	);


### PR DESCRIPTION
## Description
This was missed when we released 5.4.1 and subsequent backports a week ago. We patched the core WordPress core files but missed bumping the dependencies for Gutenberg.
