### PR TITLE
Extract block mover buttons so that they can be individually imported

### DIFF
--- a/packages/block-editor/src/components/block-mover/button.js
+++ b/packages/block-editor/src/components/block-mover/button.js
@@ -1,0 +1,174 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+import { castArray, first, last, partial } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { getBlockType } from '@wordpress/blocks';
+import { Button } from '@wordpress/components';
+import { useInstanceId } from '@wordpress/compose';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { forwardRef } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { leftArrow, rightArrow } from './icons';
+import { chevronUp, chevronDown } from '@wordpress/icons';
+import { getBlockMoverDescription } from './mover-description';
+
+const getArrowIcon = ( direction, orientation, isRTL ) => {
+	if ( direction === 'up' ) {
+		if ( orientation === 'horizontal' ) {
+			return isRTL ? rightArrow : leftArrow;
+		}
+		return chevronUp;
+	} else if ( direction === 'down' ) {
+		if ( orientation === 'horizontal' ) {
+			return isRTL ? leftArrow : rightArrow;
+		}
+		return chevronDown;
+	}
+	return null;
+};
+
+const getMovementDirectionLabel = ( moveDirection, orientation, isRTL ) => {
+	if ( moveDirection === 'up' ) {
+		if ( orientation === 'horizontal' ) {
+			return isRTL ? __( 'Move right' ) : __( 'Move left' );
+		}
+		return __( 'Move up' );
+	} else if ( moveDirection === 'down' ) {
+		if ( orientation === 'horizontal' ) {
+			return isRTL ? __( 'Move left' ) : __( 'Move right' );
+		}
+		return __( 'Move down' );
+	}
+	return null;
+};
+
+const BlockMoverButton = forwardRef(
+	(
+		{
+			clientIds,
+			direction,
+			__experimentalOrientation: orientation,
+			...props
+		},
+		ref
+	) => {
+		const instanceId = useInstanceId( BlockMoverButton );
+		const blocksCount = castArray( clientIds ).length;
+
+		const {
+			blockType,
+			isDisabled,
+			rootClientId,
+			isFirst,
+			isLast,
+			firstIndex,
+			isRTL,
+			moverOrientation,
+		} = useSelect(
+			( select ) => {
+				const {
+					getBlockIndex,
+					getBlockRootClientId,
+					getBlockOrder,
+					getBlock,
+					getSettings,
+					getBlockListSettings,
+				} = select( 'core/block-editor' );
+				const normalizedClientIds = castArray( clientIds );
+				const firstClientId = first( normalizedClientIds );
+				const blockRootClientId = getBlockRootClientId( firstClientId );
+				const firstBlockIndex = getBlockIndex(
+					firstClientId,
+					blockRootClientId
+				);
+				const lastBlockIndex = getBlockIndex(
+					last( normalizedClientIds ),
+					blockRootClientId
+				);
+				const blockOrder = getBlockOrder( blockRootClientId );
+				const block = getBlock( firstClientId );
+				const isFirstBlock = firstBlockIndex === 0;
+				const isLastBlock = lastBlockIndex === blockOrder.length - 1;
+				const { __experimentalMoverDirection = 'vertical' } =
+					getBlockListSettings( blockRootClientId ) || {};
+
+				return {
+					blockType: block ? getBlockType( block.name ) : null,
+					isDisabled: direction === 'up' ? isFirstBlock : isLastBlock,
+					rootClientId: blockRootClientId,
+					firstIndex: firstBlockIndex,
+					isFirst: isFirstBlock,
+					isLast: isLastBlock,
+					isRTL: getSettings().isRTL,
+					moverOrientation:
+						orientation || __experimentalMoverDirection,
+				};
+			},
+			[ clientIds, direction ]
+		);
+
+		const { moveBlocksDown, moveBlocksUp } = useDispatch(
+			'core/block-editor'
+		);
+		const moverFunction =
+			direction === 'up' ? moveBlocksUp : moveBlocksDown;
+		const onClick = isDisabled
+			? null
+			: partial( moverFunction, clientIds, rootClientId );
+		const descriptionId = `block-editor-block-mover-button__description-${ instanceId }`;
+
+		return (
+			<>
+				<Button
+					ref={ ref }
+					className={ classnames(
+						'block-editor-block-mover-button',
+						`is-${ direction }-button`
+					) }
+					icon={ getArrowIcon( direction, moverOrientation, isRTL ) }
+					label={ getMovementDirectionLabel(
+						direction,
+						moverOrientation,
+						isRTL
+					) }
+					aria-describedby={ descriptionId }
+					onClick={ onClick }
+					aria-disabled={ isDisabled }
+					{ ...props }
+				/>
+				<span
+					id={ descriptionId }
+					className="block-editor-block-mover-button__description"
+				>
+					{ getBlockMoverDescription(
+						blocksCount,
+						blockType && blockType.title,
+						firstIndex,
+						isFirst,
+						isLast,
+						direction === 'up' ? -1 : 1,
+						moverOrientation,
+						isRTL
+					) }
+				</span>
+			</>
+		);
+	}
+);
+
+export const MoveUpButton = forwardRef( ( props, ref ) => {
+	return <BlockMoverButton direction="up" ref={ ref } { ...props } />;
+} );
+
+export const MoveDownButton = forwardRef( ( props, ref ) => {
+	return <BlockMoverButton direction="down" ref={ ref } { ...props } />;
+} );

--- a/packages/block-editor/src/components/block-mover/button.js
+++ b/packages/block-editor/src/components/block-mover/button.js
@@ -165,10 +165,10 @@ const BlockMoverButton = forwardRef(
 	}
 );
 
-export const MoveUpButton = forwardRef( ( props, ref ) => {
+export const BlockMoverUpButton = forwardRef( ( props, ref ) => {
 	return <BlockMoverButton direction="up" ref={ ref } { ...props } />;
 } );
 
-export const MoveDownButton = forwardRef( ( props, ref ) => {
+export const BlockMoverDownButton = forwardRef( ( props, ref ) => {
 	return <BlockMoverButton direction="down" ref={ ref } { ...props } />;
 } );

--- a/packages/block-editor/src/components/block-mover/index.js
+++ b/packages/block-editor/src/components/block-mover/index.js
@@ -16,7 +16,7 @@ import { withSelect } from '@wordpress/data';
  * Internal dependencies
  */
 import BlockDraggable from '../block-draggable';
-import { MoveUpButton, MoveDownButton } from './button';
+import { BlockMoverUpButton, BlockMoverDownButton } from './button';
 
 export class BlockMover extends Component {
 	constructor() {
@@ -73,12 +73,12 @@ export class BlockMover extends Component {
 						onDragEnd={ onDraggableEnd }
 					>
 						<ToolbarGroup>
-							<MoveUpButton
+							<BlockMoverUpButton
 								clientIds={ clientIds }
 								onFocus={ this.onFocus }
 								onBlur={ this.onBlur }
 							/>
-							<MoveDownButton
+							<BlockMoverDownButton
 								clientIds={ clientIds }
 								onFocus={ this.onFocus }
 								onBlur={ this.onBlur }

--- a/packages/block-editor/src/components/block-mover/index.js
+++ b/packages/block-editor/src/components/block-mover/index.js
@@ -1,26 +1,22 @@
 /**
  * External dependencies
  */
-import { first, last, partial } from 'lodash';
+import { first, last, castArray } from 'lodash';
 import classnames from 'classnames';
 
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
-import { Button, ToolbarGroup } from '@wordpress/components';
+import { ToolbarGroup } from '@wordpress/components';
 import { getBlockType } from '@wordpress/blocks';
 import { Component } from '@wordpress/element';
-import { withSelect, withDispatch } from '@wordpress/data';
-import { withInstanceId, compose } from '@wordpress/compose';
+import { withSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
-import { getBlockMoverDescription } from './mover-description';
-import { leftArrow, rightArrow } from './icons';
-import { chevronUp, chevronDown } from '@wordpress/icons';
 import BlockDraggable from '../block-draggable';
+import { MoveUpButton, MoveDownButton } from './button';
 
 export class BlockMover extends Component {
 	constructor() {
@@ -46,56 +42,19 @@ export class BlockMover extends Component {
 
 	render() {
 		const {
-			onMoveUp,
-			onMoveDown,
-			__experimentalOrientation: orientation,
-			isRTL,
 			isFirst,
 			isLast,
 			clientIds,
-			blockType,
-			firstIndex,
 			isLocked,
-			instanceId,
 			isHidden,
 			rootClientId,
 			hideDragHandle,
+			__experimentalOrientation: orientation,
 		} = this.props;
 		const { isFocused } = this.state;
-		const blocksCount = clientIds.length;
 		if ( isLocked || ( isFirst && isLast && ! rootClientId ) ) {
 			return null;
 		}
-
-		const getArrowIcon = ( moveDirection ) => {
-			if ( moveDirection === 'up' ) {
-				if ( orientation === 'horizontal' ) {
-					return isRTL ? rightArrow : leftArrow;
-				}
-				return chevronUp;
-			} else if ( moveDirection === 'down' ) {
-				if ( orientation === 'horizontal' ) {
-					return isRTL ? leftArrow : rightArrow;
-				}
-				return chevronDown;
-			}
-			return null;
-		};
-
-		const getMovementDirectionLabel = ( moveDirection ) => {
-			if ( moveDirection === 'up' ) {
-				if ( orientation === 'horizontal' ) {
-					return isRTL ? __( 'Move right' ) : __( 'Move left' );
-				}
-				return __( 'Move up' );
-			} else if ( moveDirection === 'down' ) {
-				if ( orientation === 'horizontal' ) {
-					return isRTL ? __( 'Move left' ) : __( 'Move right' );
-				}
-				return __( 'Move down' );
-			}
-			return null;
-		};
 
 		// We emulate a disabled state because forcefully applying the `disabled`
 		// attribute on the buttons while it has focus causes the screen to change
@@ -114,57 +73,16 @@ export class BlockMover extends Component {
 						onDragEnd={ onDraggableEnd }
 					>
 						<ToolbarGroup>
-							<Button
-								className="block-editor-block-mover__control block-editor-block-mover__control-up"
-								onClick={ isFirst ? null : onMoveUp }
-								icon={ getArrowIcon( 'up' ) }
-								label={ getMovementDirectionLabel( 'up' ) }
-								aria-describedby={ `block-editor-block-mover__up-description-${ instanceId }` }
-								aria-disabled={ isFirst }
+							<MoveUpButton
+								clientIds={ clientIds }
 								onFocus={ this.onFocus }
 								onBlur={ this.onBlur }
 							/>
-
-							<Button
-								className="block-editor-block-mover__control block-editor-block-mover__control-down"
-								onClick={ isLast ? null : onMoveDown }
-								icon={ getArrowIcon( 'down' ) }
-								label={ getMovementDirectionLabel( 'down' ) }
-								aria-describedby={ `block-editor-block-mover__down-description-${ instanceId }` }
-								aria-disabled={ isLast }
+							<MoveDownButton
+								clientIds={ clientIds }
 								onFocus={ this.onFocus }
 								onBlur={ this.onBlur }
 							/>
-							<span
-								id={ `block-editor-block-mover__up-description-${ instanceId }` }
-								className="block-editor-block-mover__description"
-							>
-								{ getBlockMoverDescription(
-									blocksCount,
-									blockType && blockType.title,
-									firstIndex,
-									isFirst,
-									isLast,
-									-1,
-									orientation,
-									isRTL
-								) }
-							</span>
-							<span
-								id={ `block-editor-block-mover__down-description-${ instanceId }` }
-								className="block-editor-block-mover__description"
-							>
-								{ getBlockMoverDescription(
-									blocksCount,
-									blockType && blockType.title,
-									firstIndex,
-									isFirst,
-									isLast,
-									1,
-									orientation,
-									isRTL
-								) }
-							</span>
 						</ToolbarGroup>
 					</div>
 				) }
@@ -173,42 +91,33 @@ export class BlockMover extends Component {
 	}
 }
 
-export default compose(
-	withSelect( ( select, { clientIds } ) => {
-		const {
-			getBlock,
-			getBlockIndex,
-			getTemplateLock,
-			getBlockRootClientId,
-			getBlockOrder,
-		} = select( 'core/block-editor' );
-		const firstClientId = first( clientIds );
-		const block = getBlock( firstClientId );
-		const rootClientId = getBlockRootClientId( first( clientIds ) );
-		const blockOrder = getBlockOrder( rootClientId );
-		const firstIndex = getBlockIndex( firstClientId, rootClientId );
-		const lastIndex = getBlockIndex( last( clientIds ), rootClientId );
-		const { getSettings } = select( 'core/block-editor' );
-		const { isRTL } = getSettings();
+export default withSelect( ( select, { clientIds } ) => {
+	const {
+		getBlock,
+		getBlockIndex,
+		getTemplateLock,
+		getBlockOrder,
+		getBlockRootClientId,
+	} = select( 'core/block-editor' );
+	const normalizedClientIds = castArray( clientIds );
+	const firstClientId = first( normalizedClientIds );
+	const block = getBlock( firstClientId );
+	const rootClientId = getBlockRootClientId( first( normalizedClientIds ) );
+	const firstIndex = getBlockIndex( firstClientId, rootClientId );
+	const lastIndex = getBlockIndex(
+		last( normalizedClientIds ),
+		rootClientId
+	);
+	const blockOrder = getBlockOrder( rootClientId );
+	const isFirst = firstIndex === 0;
+	const isLast = lastIndex === blockOrder.length - 1;
 
-		return {
-			blockType: block ? getBlockType( block.name ) : null,
-			isLocked: getTemplateLock( rootClientId ) === 'all',
-			rootClientId,
-			firstIndex,
-			isRTL,
-			isFirst: firstIndex === 0,
-			isLast: lastIndex === blockOrder.length - 1,
-		};
-	} ),
-	withDispatch( ( dispatch, { clientIds, rootClientId } ) => {
-		const { moveBlocksDown, moveBlocksUp } = dispatch(
-			'core/block-editor'
-		);
-		return {
-			onMoveDown: partial( moveBlocksDown, clientIds, rootClientId ),
-			onMoveUp: partial( moveBlocksUp, clientIds, rootClientId ),
-		};
-	} ),
-	withInstanceId
-)( BlockMover );
+	return {
+		blockType: block ? getBlockType( block.name ) : null,
+		isLocked: getTemplateLock( rootClientId ) === 'all',
+		rootClientId,
+		firstIndex,
+		isFirst,
+		isLast,
+	};
+} )( BlockMover );

--- a/packages/block-editor/src/components/block-mover/style.scss
+++ b/packages/block-editor/src/components/block-mover/style.scss
@@ -3,11 +3,11 @@
 	flex-direction: row;
 }
 
-.block-editor-block-mover__description {
+.block-editor-block-mover-button__description {
 	display: none;
 }
 
-.block-editor-block-mover__control.has-icon {
+.block-editor-block-mover-button.has-icon {
 	padding: 0;
 }
 
@@ -21,12 +21,12 @@
 		flex-direction: row;
 	}
 
-	.block-editor-block-mover__control {
+	.block-editor-block-mover-button {
 		height: $block-toolbar-height/2;
 	}
 
 	// Position the icons correctly.
-	.components-toolbar .block-editor-block-mover__control-up {
+	.components-toolbar .block-editor-block-mover-button.is-up-button {
 		svg {
 			margin-bottom: -$grid-unit-10;
 		}
@@ -38,7 +38,7 @@
 		}
 	}
 
-	.components-toolbar .block-editor-block-mover__control-down {
+	.components-toolbar .block-editor-block-mover-button.is-down-button {
 		svg {
 			margin-top: -$grid-unit-10;
 		}
@@ -52,7 +52,7 @@
 
 	// Mover is horizontal.
 	&.is-horizontal {
-		.block-editor-block-mover__control.has-icon {
+		.block-editor-block-mover-button.has-icon {
 			height: $block-toolbar-height;
 			width: $block-toolbar-height/2 !important;
 			min-width: $grid-unit-30;
@@ -70,7 +70,7 @@
 		}
 
 		// Position the icons correctly.
-		.block-editor-block-mover__control-up.has-icon {
+		.block-editor-block-mover-button.is-up-button.has-icon {
 			svg {
 				margin-left: 0;
 				margin-right: -$grid-unit-10;
@@ -84,7 +84,7 @@
 			}
 		}
 
-		.block-editor-block-mover__control-down.has-icon {
+		.block-editor-block-mover-button.is-down-button.has-icon {
 			svg {
 				margin-left: -$grid-unit-10;
 				margin-right: 0;


### PR DESCRIPTION
## Description
The Block mover buttons are exported as a single component. This PR allows the up and down buttons to be individually imported. 

This change is required as part of #18014, which manages focus on the buttons using a roving tab index within the block navigator.

## How has this been tested?
This is just a refactor, so no changes. Block movers should continue to look and work as they currently do.
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Types of changes
Refactor
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
