### PR TITLE
Block Directory: Update layout for smaller inserter width.

### DIFF
--- a/packages/block-directory/src/components/downloadable-block-author-info/style.scss
+++ b/packages/block-directory/src/components/downloadable-block-author-info/style.scss
@@ -1,9 +1,9 @@
 .block-directory-downloadable-block-author-info__content {
 	color: $dark-gray-400;
-	margin-bottom: 4px;
+	font-size: 12px;
 }
 
 .block-directory-downloadable-block-author-info__content-author {
 	margin-bottom: 4px;
-	font-size: 14px;
+	font-size: $default-font-size;
 }

--- a/packages/block-directory/src/components/downloadable-block-info/index.js
+++ b/packages/block-directory/src/components/downloadable-block-info/index.js
@@ -15,24 +15,28 @@ function DownloadableBlockInfo( {
 			<p className="block-directory-downloadable-block-info__content">
 				{ description }
 			</p>
-			<div className="block-directory-downloadable-block-info__row">
-				<div className="block-directory-downloadable-block-info__column">
-					<Icon icon={ chartLine }></Icon>
-					{ sprintf(
-						/* translators: %s: number of active installations. */
-						_n(
-							'%d active installation',
-							'%d active installations',
-							activeInstalls
-						),
+			<div className="block-directory-downloadable-block-info__meta">
+				<Icon
+					className="block-directory-downloadable-block-info__icon"
+					icon={ chartLine }
+				/>
+				{ sprintf(
+					/* translators: %s: number of active installations. */
+					_n(
+						'%d active installation',
+						'%d active installations',
 						activeInstalls
-					) }
-				</div>
-				<div className="block-directory-downloadable-block-info__column">
-					<Icon icon={ update }></Icon>
-					{ // translators: %s: Humanized date of last update e.g: "2 months ago".
-					sprintf( __( 'Updated %s' ), humanizedUpdated ) }
-				</div>
+					),
+					activeInstalls
+				) }
+			</div>
+			<div className="block-directory-downloadable-block-info__meta">
+				<Icon
+					className="block-directory-downloadable-block-info__icon"
+					icon={ update }
+				/>
+				{ // translators: %s: Humanized date of last update e.g: "2 months ago".
+				sprintf( __( 'Updated %s' ), humanizedUpdated ) }
 			</div>
 		</Fragment>
 	);

--- a/packages/block-directory/src/components/downloadable-block-info/style.scss
+++ b/packages/block-directory/src/components/downloadable-block-info/style.scss
@@ -1,4 +1,5 @@
 .block-directory-downloadable-block-info__content {
+	margin: 0 0 $grid-unit-20;
 	font-size: $default-font-size;
 }
 

--- a/packages/block-directory/src/components/downloadable-block-info/style.scss
+++ b/packages/block-directory/src/components/downloadable-block-info/style.scss
@@ -5,7 +5,7 @@
 .block-directory-downloadable-block-info__meta {
 	display: flex;
 	align-items: center;
-	margin-bottom: 4px;
+	margin-bottom: 2px;
 	color: $dark-gray-400;
 	font-size: 12px;
 }

--- a/packages/block-directory/src/components/downloadable-block-info/style.scss
+++ b/packages/block-directory/src/components/downloadable-block-info/style.scss
@@ -2,20 +2,19 @@
 	font-size: $default-font-size;
 }
 
-.block-directory-downloadable-block-info__row {
+.block-directory-downloadable-block-info__meta {
 	display: flex;
-	justify-content: space-between;
+	align-items: center;
+	margin-bottom: 4px;
 	color: $dark-gray-400;
-	margin-top: $grid-unit-10;
 	font-size: 12px;
+}
 
-	.block-directory-downloadable-block-info__column {
-		display: flex;
-		align-items: center;
+.block-directory-downloadable-block-info__meta:last-child {
+	margin-bottom: 0;
+}
 
-		.dashicon {
-			font-size: 16px;
-			margin-right: 4px;
-		}
-	}
+.block-directory-downloadable-block-info__icon {
+	margin-right: 4px;
+	fill: $dark-gray-400;
 }

--- a/packages/block-directory/src/components/downloadable-block-list-item/style.scss
+++ b/packages/block-directory/src/components/downloadable-block-list-item/style.scss
@@ -10,7 +10,6 @@
 	justify-content: center;
 	background: transparent;
 	word-break: break-word;
-	border-radius: $radius-block-ui;
 	border-top: $border-width solid $light-gray-500;
 	border-bottom: $border-width solid $light-gray-500;
 	transition: all 0.05s ease-in-out;

--- a/packages/block-directory/src/components/downloadable-block-list-item/style.scss
+++ b/packages/block-directory/src/components/downloadable-block-list-item/style.scss
@@ -1,7 +1,7 @@
 .block-directory-downloadable-block-list-item {
 	width: 100%;
 	padding: 0;
-	margin: 0 0 12px;
+	margin: 0;
 	display: flex;
 	flex-direction: row;
 	font-size: $default-font-size;
@@ -11,12 +11,17 @@
 	background: transparent;
 	word-break: break-word;
 	border-radius: $radius-block-ui;
-	border: $border-width solid $light-gray-500;
+	border-top: $border-width solid $light-gray-500;
+	border-bottom: $border-width solid $light-gray-500;
 	transition: all 0.05s ease-in-out;
 	@include reduce-motion("transition");
 	position: relative;
 	text-align: left;
 	overflow: hidden;
+}
+
+.block-directory-downloadable-block-list-item:last-child:not(:only-of-type) {
+	border-top: 0;
 }
 
 .block-directory-downloadable-block-list-item__panel {
@@ -28,19 +33,19 @@
 .block-directory-downloadable-block-list-item__header {
 	display: flex;
 	flex-direction: column;
-	padding: 12px 12px 0;
+	padding: $grid-unit-20 $grid-unit-20 0;
 }
 
 .block-directory-downloadable-block-list-item__body {
 	display: flex;
 	flex-direction: column;
-	padding: 12px;
+	padding: $grid-unit-20;
 }
 
 .block-directory-downloadable-block-list-item__footer {
 	display: flex;
 	flex-direction: column;
-	padding: 12px;
+	padding: $grid-unit-20;
 	background-color: $light-gray-200;
 }
 

--- a/packages/block-directory/src/components/downloadable-blocks-list/style.scss
+++ b/packages/block-directory/src/components/downloadable-blocks-list/style.scss
@@ -1,6 +1,6 @@
 .block-directory-downloadable-blocks-list {
 	list-style: none;
-	padding: 2px 0;
+	margin: 0;
 	overflow: hidden;
 	display: flex;
 	flex-wrap: wrap;

--- a/packages/block-directory/src/components/downloadable-blocks-panel/style.scss
+++ b/packages/block-directory/src/components/downloadable-blocks-panel/style.scss
@@ -1,7 +1,8 @@
 
 .block-directory-downloadable-blocks-panel__description {
 	font-style: italic;
-	padding: 0;
+	padding: $grid-unit-20;
+	margin: 0;
 	text-align: left;
 	color: $dark-gray-400;
 }

--- a/packages/block-editor/src/components/inserter/block-list.js
+++ b/packages/block-editor/src/components/inserter/block-list.js
@@ -282,11 +282,7 @@ function InserterBlockList( {
 			>
 				{ ( fills ) => {
 					if ( fills.length ) {
-						return (
-							<InserterPanel title={ __( 'Search Results' ) }>
-								{ fills }
-							</InserterPanel>
-						);
+						return fills;
 					}
 					if ( ! hasItems ) {
 						return <InserterNoResults />;


### PR DESCRIPTION
## Description
Addresses: #21963 

**Summary**: 
Fixes awkwardness in block directory tile layouts.

See ticket for more details.

## How has this been tested?
1. Turn on Gutenberg Block Directory Experiment
2. Search for a block (IE: `whatever`)
3. Expect Designs to match (https://github.com/WordPress/gutenberg/issues/21963#issuecomment-621346589)

## Screenshots <!-- if applicable -->
| Before | After  |
--- | --- |
|  ![Actual](https://d.pr/i/s7hDxD.png)  | ![New Screenshot](https://d.pr/i/B6Zf4V.png)  |


## Types of changes
1. Normalize padding to match Block Editor defaults `16px`
2. Change icon columns to row format
3. Update icon color to match text (regression introduced with `@wordpress\icons`)
4. Normalize 'sub copy' to be `13px` for icon text and copy below author.

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
