### PR TITLE
Documentation: Improve the way CHANGELOG files are maintained

### DIFF
--- a/bin/commander.js
+++ b/bin/commander.js
@@ -977,8 +977,9 @@ async function updatePackageChangelogs( minimumVersionBump, abortMessage ) {
 			let changesDetected = false;
 			let versionBump = null;
 			for await ( const line of lines ) {
+				const lineNormalized = line.toLowerCase();
 				// Detect unpublished changes first.
-				if ( line.startsWith( '## Master' ) ) {
+				if ( lineNormalized.startsWith( '## unreleased' ) ) {
 					changesDetected = true;
 					continue;
 				}
@@ -989,27 +990,31 @@ async function updatePackageChangelogs( minimumVersionBump, abortMessage ) {
 				}
 
 				// A previous published version detected. Stop processing.
-				if ( line.startsWith( '## ' ) ) {
+				if ( lineNormalized.startsWith( '## ' ) ) {
 					break;
 				}
 
 				// A major version bump required. Stop processing.
-				if ( line.startsWith( '### Breaking Change' ) ) {
+				if ( lineNormalized.startsWith( '### breaking change' ) ) {
 					versionBump = 'major';
 					break;
 				}
 
 				// A minor version bump required. Proceed to the next line.
 				if (
-					line.startsWith( '### New Feature' ) ||
-					line.startsWith( '### Deprecation' )
+					lineNormalized.startsWith( '### deprecation' ) ||
+					lineNormalized.startsWith( '### enhancement' ) ||
+					lineNormalized.startsWith( '### new feature' )
 				) {
 					versionBump = 'minor';
 					continue;
 				}
 
 				// A version bump required. Found new changelog section.
-				if ( versionBump !== 'minor' && line.startsWith( '### ' ) ) {
+				if (
+					versionBump !== 'minor' &&
+					lineNormalized.startsWith( '### ' )
+				) {
 					versionBump = minimumVersionBump;
 				}
 			}
@@ -1057,8 +1062,8 @@ async function updatePackageChangelogs( minimumVersionBump, abortMessage ) {
 				await fs.promises.writeFile(
 					changelogFile,
 					content.replace(
-						'## Master',
-						`## Master\n\n## ${ nextVersion } (${ publishDate })`
+						'## Unreleased',
+						`## Unreleased\n\n## ${ nextVersion } (${ publishDate })`
 					)
 				);
 				console.log(

--- a/packages/README.md
+++ b/packages/README.md
@@ -10,7 +10,7 @@ When creating a new package, you need to provide at least the following:
     ```json
     {
     	"name": "@wordpress/package-name",
-    	"version": "1.0.0-beta.0",
+    	"version": "1.0.0-pre",
     	"description": "Package description.",
     	"author": "The WordPress Contributors",
     	"license": "GPL-2.0-or-later",
@@ -45,6 +45,14 @@ When creating a new package, you need to provide at least the following:
     - Installation details
     - Usage example
     - `Code is Poetry` logo (`<br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>`)
+4. `CHANGELOG.md` file containing at least:
+    ```
+    <!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+	## Unreleased
+
+	Initial release.
+    ```
 
 ## Managing Dependencies
 
@@ -106,14 +114,16 @@ This commands adds the latest version of `glob` as a development dependency to t
 
 ## Maintaining Changelogs
 
-In maintaining dozens of npm packages, it can be tough to keep track of changes. To simplify the release process, each package includes a `CHANGELOG.md` file which details all published releases and the unreleased ("Master") changes, if any exist.
+In maintaining dozens of npm packages, it can be tough to keep track of changes. To simplify the release process, each package includes a `CHANGELOG.md` file which details all published releases and the unreleased ("Unreleased") changes, if any exist.
 
-For each pull request, you should always include relevant changes in a "Master" heading at the top of the file. You should add the heading if it doesn't already exist.
+For each pull request, you should always include relevant changes in a "Unreleased" heading at the top of the file. You should add the heading if it doesn't already exist.
 
 _Example:_
 
 ```md
-## Master
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
 
 ### Bug Fix
 
@@ -123,7 +133,7 @@ _Example:_
 There are a number of common release subsections you can follow. Each is intended to align to a specific meaning in the context of the [Semantic Versioning (`semver`) specification](https://semver.org/) the project adheres to. It is important that you describe your changes accurately, since this is used in the packages release process to help determine the version of the next release.
 
 -   "Breaking Change" - A backwards-incompatible change which requires specific attention of the impacted developers to reconcile (requires a major version bump).
--   "New Feature" - The addition of a new backwards-compatible function or feature to the existing public API (requires a minor verison bump).
+-   "New Feature" - The addition of a new backwards-compatible function or feature to the existing public API (requires a minor version bump).
 -   "Enhancement" - Backwards-compatible improvements to existing functionality (requires a minor version bump).
 -   "Bug Fix" - Resolutions to existing buggy behavior (requires a patch version bump).
 -   "Internal" - Changes which do not have an impact on the public interface or behavior of the module (requires a patch version bump).

--- a/packages/README.md
+++ b/packages/README.md
@@ -10,7 +10,7 @@ When creating a new package, you need to provide at least the following:
     ```json
     {
     	"name": "@wordpress/package-name",
-    	"version": "1.0.0-pre",
+    	"version": "1.0.0-prerelease",
     	"description": "Package description.",
     	"author": "The WordPress Contributors",
     	"license": "GPL-2.0-or-later",

--- a/packages/a11y/CHANGELOG.md
+++ b/packages/a11y/CHANGELOG.md
@@ -1,4 +1,6 @@
-## Master
+## Unreleased
+
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
 
 ## 2.9.0 (2020-04-15)
 

--- a/packages/a11y/CHANGELOG.md
+++ b/packages/a11y/CHANGELOG.md
@@ -1,6 +1,6 @@
-## Unreleased
-
 <!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
 
 ## 2.9.0 (2020-04-15)
 

--- a/packages/annotations/CHANGELOG.md
+++ b/packages/annotations/CHANGELOG.md
@@ -1,3 +1,7 @@
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
+
 ## 1.0.5 (2019-01-03)
 
 ## 1.0.4 (2018-12-12)

--- a/packages/api-fetch/CHANGELOG.md
+++ b/packages/api-fetch/CHANGELOG.md
@@ -1,3 +1,7 @@
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
+
 ## 3.8.1 (2019-04-22)
 
 - Added deprecation to `useApiFetch` hook.

--- a/packages/autop/CHANGELOG.md
+++ b/packages/autop/CHANGELOG.md
@@ -1,4 +1,6 @@
-## Master
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
 
 ## 2.7.0 (2020-04-15)
 

--- a/packages/babel-plugin-import-jsx-pragma/CHANGELOG.md
+++ b/packages/babel-plugin-import-jsx-pragma/CHANGELOG.md
@@ -1,3 +1,7 @@
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
+
 ## 2.2.0 (2019-05-21)
 
 ### New Feature

--- a/packages/babel-plugin-makepot/CHANGELOG.md
+++ b/packages/babel-plugin-makepot/CHANGELOG.md
@@ -1,3 +1,7 @@
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
+
 ## 2.2.0 (2019-03-06)
 
 ### Bug Fix

--- a/packages/babel-preset-default/CHANGELOG.md
+++ b/packages/babel-preset-default/CHANGELOG.md
@@ -1,4 +1,6 @@
-## Master
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
 
 ## 4.12.0 (2020-04-15)
 

--- a/packages/base-styles/CHANGELOG.md
+++ b/packages/base-styles/CHANGELOG.md
@@ -1,3 +1,7 @@
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
+
 ## 1.2.0 (2020-01-13)
 
 ### Bug Fix

--- a/packages/blob/CHANGELOG.md
+++ b/packages/blob/CHANGELOG.md
@@ -1,4 +1,6 @@
-## Master
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
 
 ## 2.8.0 (2020-04-15)
 

--- a/packages/block-directory/CHANGELOG.md
+++ b/packages/block-directory/CHANGELOG.md
@@ -1,3 +1,7 @@
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
+
 ## 1.0.0 (2019-09-16)
 
 -   Initial release.

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -1,4 +1,6 @@
-## Master
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
 
 ## 3.7.0 (2020-02-10)
 

--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -1,3 +1,7 @@
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
+
 ## 2.12.0 (2020-01-13)
 
 ### Bug Fixes

--- a/packages/block-serialization-default-parser/CHANGELOG.md
+++ b/packages/block-serialization-default-parser/CHANGELOG.md
@@ -1,3 +1,7 @@
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
+
 ## 2.0.3 (2019-01-03)
 
 ## 2.0.2 (2018-12-12)

--- a/packages/block-serialization-spec-parser/CHANGELOG.md
+++ b/packages/block-serialization-spec-parser/CHANGELOG.md
@@ -1,3 +1,7 @@
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
+
 ## 3.0.0 (2019-03-06)
 
 ## Breaking Change

--- a/packages/blocks/CHANGELOG.md
+++ b/packages/blocks/CHANGELOG.md
@@ -1,4 +1,6 @@
-## Master
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
 
 ## 6.13.0 (2020-04-01)
 

--- a/packages/browserslist-config/CHANGELOG.md
+++ b/packages/browserslist-config/CHANGELOG.md
@@ -1,3 +1,7 @@
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
+
 ## 2.2.0 (2018-07-12)
 
 ### Internal

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,4 +1,6 @@
-## Master
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
 
 ## 9.2.0 (2020-02-10)
 

--- a/packages/compose/CHANGELOG.md
+++ b/packages/compose/CHANGELOG.md
@@ -1,8 +1,12 @@
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
+
 ## 3.4.0 (2019-06-12)
 
 ### New Features
 
-- Add the `useMediaQuery` and `useReducedMotion` hooks. 
+- Add the `useMediaQuery` and `useReducedMotion` hooks.
 
 ## 3.0.0 (2018-11-15)
 

--- a/packages/core-data/CHANGELOG.md
+++ b/packages/core-data/CHANGELOG.md
@@ -1,6 +1,11 @@
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
+
 ## 2.3.0 (2019-05-21)
 
 ### New features
+
 - The `getAutosave`, `getAutosaves` and `getCurrentUser` selectors have been added.
 - The `receiveAutosaves` and `receiveCurrentUser` actions have been added.
 

--- a/packages/create-block/CHANGELOG.md
+++ b/packages/create-block/CHANGELOG.md
@@ -1,4 +1,6 @@
-## Master
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
 
 ## 0.12.0 (2020-04-30)
 

--- a/packages/custom-templated-path-webpack-plugin/CHANGELOG.md
+++ b/packages/custom-templated-path-webpack-plugin/CHANGELOG.md
@@ -1,3 +1,7 @@
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
+
 ## 1.4.0 (2019-06-12)
 
 ### Bug Fixes

--- a/packages/data-controls/CHANGELOG.md
+++ b/packages/data-controls/CHANGELOG.md
@@ -1,3 +1,7 @@
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
+
 ## 1.4.0 (2019-11-14)
 
 ### Documentation

--- a/packages/data/CHANGELOG.md
+++ b/packages/data/CHANGELOG.md
@@ -1,3 +1,7 @@
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
+
 ## 4.6.0 (2019-06-12)
 
 ### New Feature
@@ -16,7 +20,7 @@
 
 - Restore functionality of action-generators returning a Promise.  Clarify intent and behaviour for `wp.data.dispatch` behaviour. Dispatch actions now always
  return a promise ([#14830](https://github.com/WordPress/gutenberg/pull/14830)
- 
+
 ### Enhancements
 
 - Expose `hasResolver` property on returned selectors indicating whether the selector has a corresponding resolver.

--- a/packages/date/CHANGELOG.md
+++ b/packages/date/CHANGELOG.md
@@ -1,3 +1,7 @@
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
+
 ## 3.0.1 (2018-12-12)
 
 ## 3.0.0 (2018-11-15)

--- a/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
+++ b/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
@@ -1,4 +1,6 @@
-## Master
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
 
 ## 2.5.0 (2020-04-01)
 

--- a/packages/deprecated/CHANGELOG.md
+++ b/packages/deprecated/CHANGELOG.md
@@ -1,3 +1,7 @@
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
+
 ## 2.6.0 (2019-08-29)
 
 ### Bug Fix

--- a/packages/docgen/CHANGELOG.md
+++ b/packages/docgen/CHANGELOG.md
@@ -1,4 +1,6 @@
-## Master
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
 
 ## 1.7.0 (2020-02-04)
 

--- a/packages/dom-ready/CHANGELOG.md
+++ b/packages/dom-ready/CHANGELOG.md
@@ -1,4 +1,6 @@
-## Master
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
 
 ## 2.9.0 (2020-04-15)
 

--- a/packages/dom/CHANGELOG.md
+++ b/packages/dom/CHANGELOG.md
@@ -1,3 +1,7 @@
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
+
 ## 2.1.0 (2019-03-06)
 
 ### Bug Fix

--- a/packages/e2e-test-utils/CHANGELOG.md
+++ b/packages/e2e-test-utils/CHANGELOG.md
@@ -1,4 +1,6 @@
-## Master
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
 
 ## 4.5.0 (2020-04-15)
 

--- a/packages/e2e-tests/CHANGELOG.md
+++ b/packages/e2e-tests/CHANGELOG.md
@@ -1,3 +1,7 @@
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
+
 ## 1.9.1 (2020-01-01)
 
 ## 1.9.0 (2019-12-19)

--- a/packages/edit-navigation/CHANGELOG.md
+++ b/packages/edit-navigation/CHANGELOG.md
@@ -1,7 +1,3 @@
 <!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
 
 ## Unreleased
-
-## 1.0.0 (2020-02-04)
-
-Initial release.

--- a/packages/edit-post/CHANGELOG.md
+++ b/packages/edit-post/CHANGELOG.md
@@ -1,4 +1,6 @@
-## Master
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
 
 ## 3.13.0 (2020-02-10)
 

--- a/packages/edit-site/CHANGELOG.md
+++ b/packages/edit-site/CHANGELOG.md
@@ -1,3 +1,7 @@
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
+
 ## 1.0.0 (2020-01-13)
 
 ### New Feature

--- a/packages/edit-widgets/CHANGELOG.md
+++ b/packages/edit-widgets/CHANGELOG.md
@@ -1,3 +1,7 @@
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
+
 ## 0.1.0 (2019-03-06)
 
 ### New Features

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -1,3 +1,7 @@
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
+
 ## 9.4.0 (2019-06-12)
 
 ### Deprecations

--- a/packages/element/CHANGELOG.md
+++ b/packages/element/CHANGELOG.md
@@ -1,4 +1,6 @@
-## Master
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
 
 ### New Feature
 

--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -1,4 +1,6 @@
-## Master
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
 
 ## 1.1.0 (2020-04-01)
 

--- a/packages/escape-html/CHANGELOG.md
+++ b/packages/escape-html/CHANGELOG.md
@@ -1,4 +1,6 @@
-## Master
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
 
 ## 1.8.0 (2020-04-15)
 

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -1,4 +1,6 @@
-## Master
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
 
 ### Breaking Changes
 

--- a/packages/format-library/CHANGELOG.md
+++ b/packages/format-library/CHANGELOG.md
@@ -1,3 +1,7 @@
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
+
 ## 1.8.0 (2019-08-29)
 
 ### Internal

--- a/packages/hooks/CHANGELOG.md
+++ b/packages/hooks/CHANGELOG.md
@@ -1,3 +1,7 @@
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
+
 ## 2.6.0 (2019-08-29)
 
 ### New Feature

--- a/packages/html-entities/CHANGELOG.md
+++ b/packages/html-entities/CHANGELOG.md
@@ -1,4 +1,6 @@
-## Master
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
 
 ## 2.7.0 (2020-04-15)
 

--- a/packages/i18n/CHANGELOG.md
+++ b/packages/i18n/CHANGELOG.md
@@ -1,4 +1,6 @@
-## Master
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
 
 ## 3.12.0 (2020-04-30)
 

--- a/packages/icons/CHANGELOG.md
+++ b/packages/icons/CHANGELOG.md
@@ -1,4 +1,6 @@
-## Master
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
 
 ### Breaking change
 

--- a/packages/interface/CHANGELOG.md
+++ b/packages/interface/CHANGELOG.md
@@ -1,3 +1,5 @@
-## Master
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
 
 Initial release.

--- a/packages/is-shallow-equal/CHANGELOG.md
+++ b/packages/is-shallow-equal/CHANGELOG.md
@@ -1,4 +1,6 @@
-## Master
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
 
 ## 2.0.0 (2020-04-15)
 

--- a/packages/jest-console/CHANGELOG.md
+++ b/packages/jest-console/CHANGELOG.md
@@ -1,3 +1,7 @@
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
+
 ## 3.0.0 (2019-03-06)
 
 ### Breaking Changes

--- a/packages/jest-preset-default/CHANGELOG.md
+++ b/packages/jest-preset-default/CHANGELOG.md
@@ -1,4 +1,6 @@
-## Master
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
 
 ## 6.0.0 (2020-04-15)
 

--- a/packages/jest-puppeteer-axe/CHANGELOG.md
+++ b/packages/jest-puppeteer-axe/CHANGELOG.md
@@ -1,4 +1,6 @@
-## Master
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
 
 ## New Features
 

--- a/packages/keycodes/CHANGELOG.md
+++ b/packages/keycodes/CHANGELOG.md
@@ -1,4 +1,6 @@
-## Master
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
 
 ## 2.12.0 (2020-04-30)
 

--- a/packages/library-export-default-webpack-plugin/CHANGELOG.md
+++ b/packages/library-export-default-webpack-plugin/CHANGELOG.md
@@ -1,3 +1,7 @@
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
+
 ## 1.3.0 (2019-06-12)
 
 ### Internal

--- a/packages/list-reusable-blocks/CHANGELOG.md
+++ b/packages/list-reusable-blocks/CHANGELOG.md
@@ -1,3 +1,7 @@
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
+
 ## 1.1.18 (2019-01-03)
 
 ## 1.1.17 (2018-12-12)

--- a/packages/media-utils/CHANGELOG.md
+++ b/packages/media-utils/CHANGELOG.md
@@ -1,3 +1,7 @@
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
+
 ## 0.1.0 (2019-01-03)
 
 ### New Features

--- a/packages/notices/CHANGELOG.md
+++ b/packages/notices/CHANGELOG.md
@@ -1,4 +1,6 @@
-## Master
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
 
 ## 2.0.0 (2020-02-10)
 

--- a/packages/npm-package-json-lint-config/CHANGELOG.md
+++ b/packages/npm-package-json-lint-config/CHANGELOG.md
@@ -1,4 +1,6 @@
-## Master
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
 
 ## 3.0.0 (2020-04-15)
 
@@ -10,7 +12,7 @@
 
 ### Breaking Change
 
-- Added `type` and `react-native` to the order of preferred properties. 
+- Added `type` and `react-native` to the order of preferred properties.
 
 ## 1.2.0 (2019-03-06)
 

--- a/packages/nux/CHANGELOG.md
+++ b/packages/nux/CHANGELOG.md
@@ -1,4 +1,8 @@
-# 3.1.0 (Unreleased)
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
+
+# 3.1.0 (2019-06-03)
 
 - The `@wordpress/nux` package has been deprecated. Please use the `Guide` component in `@wordpress/components` to show a user guide.
 

--- a/packages/plugins/CHANGELOG.md
+++ b/packages/plugins/CHANGELOG.md
@@ -1,3 +1,7 @@
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
+
 ## 2.0.10 (2019-01-03)
 
 ## 2.0.9 (2018-11-15)

--- a/packages/postcss-themes/CHANGELOG.md
+++ b/packages/postcss-themes/CHANGELOG.md
@@ -1,3 +1,7 @@
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
+
 ## 2.0.0 (2019-03-06)
 
 ### Breaking change

--- a/packages/prettier-config/CHANGELOG.md
+++ b/packages/prettier-config/CHANGELOG.md
@@ -1,4 +1,6 @@
-## Master
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
 
 ## 0.1.0 (2020-04-01)
 

--- a/packages/primitives/CHANGELOG.md
+++ b/packages/primitives/CHANGELOG.md
@@ -1,4 +1,6 @@
-## Master
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
 
 ### New Feature
 

--- a/packages/priority-queue/CHANGELOG.md
+++ b/packages/priority-queue/CHANGELOG.md
@@ -1,4 +1,6 @@
-## Master
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
 
 ## 1.6.0 (2020-04-15)
 

--- a/packages/project-management-automation/CHANGELOG.md
+++ b/packages/project-management-automation/CHANGELOG.md
@@ -1,4 +1,6 @@
-## Master
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
 
 ## 1.4.0 (2020-04-15)
 

--- a/packages/redux-routine/CHANGELOG.md
+++ b/packages/redux-routine/CHANGELOG.md
@@ -1,4 +1,6 @@
-## Master
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
 
 ## 3.7.0 (2020-02-04)
 

--- a/packages/rich-text/CHANGELOG.md
+++ b/packages/rich-text/CHANGELOG.md
@@ -1,3 +1,7 @@
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
+
 ## 3.3.0 (2019-05-21)
 
 ### Internal

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -1,4 +1,6 @@
-## Master
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
 
 ### Enhancements
 - Bundle analysis in `build` script now runs with module concatenation disabled. This represents the size of individual modules more accurately, at the cost of not providing an exact byte-for-byte match to the final size in the production chunk.

--- a/packages/server-side-render/CHANGELOG.md
+++ b/packages/server-side-render/CHANGELOG.md
@@ -1,4 +1,6 @@
-## Master
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
 
 ## 1.7.0 (2020-02-04)
 

--- a/packages/shortcode/CHANGELOG.md
+++ b/packages/shortcode/CHANGELOG.md
@@ -1,3 +1,7 @@
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
+
 ## 2.0.1 (2018-09-30)
 
 ### Bug Fixes

--- a/packages/token-list/CHANGELOG.md
+++ b/packages/token-list/CHANGELOG.md
@@ -1,4 +1,6 @@
-## Master
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
 
 ## 1.10.0 (2020-04-15)
 

--- a/packages/url/CHANGELOG.md
+++ b/packages/url/CHANGELOG.md
@@ -1,4 +1,6 @@
-## Master
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
 
 ## 2.14.0 (2020-04-30)
 

--- a/packages/viewport/CHANGELOG.md
+++ b/packages/viewport/CHANGELOG.md
@@ -1,3 +1,7 @@
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
+
 ## 2.1.0 (2019-01-03)
 
 ### Improvements

--- a/packages/warning/CHANGELOG.md
+++ b/packages/warning/CHANGELOG.md
@@ -1,4 +1,6 @@
-## Master
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
 
 ## 1.1.0 (2020-04-15)
 

--- a/packages/wordcount/CHANGELOG.md
+++ b/packages/wordcount/CHANGELOG.md
@@ -1,3 +1,7 @@
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
+
+## Unreleased
+
 ## 2.0.3 (2018-10-29)
 
 ### Polish


### PR DESCRIPTION
## Description

This PR aims to improve the way CHANGELOG files and version bumps are maintained for all npm packages. The changes proposed include:
1. All packages will have `CHANGELOG.md` file that starts with:
    ```md
    <!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/master/packages#maintaining-changelogs. -->
    
    ## Unreleased
    ```
    The updated title (`Unreleased`) follows the recommendation shared at https://keepachangelog.com/en/1.0.0/:
    > Keep an Unreleased section at the top to track upcoming changes.
    > This serves two purposes:
    > - People can see what changes they might expect in upcoming releases
    > - At release time, you can move the Unreleased section changes into a new release version section.
    
    We follow that process now.
2. The recommended version for the newly created package becomes `1.0.0-pre` to leave the room for Lerna to bump to `1.0.0`.

All related docs were updated to reflect these changes.

In addition, the script that automates npm prerelease process was updated to work with the new `## Unreleased` heading. I also included some relaxed checks for the version bump detection to reflect the fact that contributors use lowercase for title of headings.