### PR TITLE
Remove subscription button from blog template

### DIFF
--- a/packages/block-editor/src/components/page-template-picker/templates/blog.native.js
+++ b/packages/block-editor/src/components/page-template-picker/templates/blog.native.js
@@ -44,43 +44,6 @@ const Blog = {
 			name: 'core/separator',
 			attributes: {},
 		},
-		{
-			name: 'core/spacer',
-			attributes: {
-				height: 24,
-			},
-		},
-		{
-			name: 'core/heading',
-			attributes: {
-				align: 'center',
-				// translators: sample content for "Blog" page template
-				content: __( 'Follow our Blog' ),
-				level: 2,
-			},
-		},
-		{
-			name: 'core/buttons',
-			innerBlocks: [
-				{
-					name: 'core/button',
-					attributes: {
-						// translators: sample content for "Blog" page template
-						text: __( 'Subscribe' ),
-					},
-				},
-			],
-		},
-		{
-			name: 'core/spacer',
-			attributes: {
-				height: 24,
-			},
-		},
-		{
-			name: 'core/separator',
-			attributes: {},
-		},
 	],
 };
 


### PR DESCRIPTION
This was brought up during beta testing. Subscription Button doesn't have any functionality so we are removing it from the Blog template.

gutenberg-mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/2219

Before:

<img width="250" alt="Screen Shot 2020-05-06 at 10 48 02" src="https://user-images.githubusercontent.com/5032900/81149671-548b6580-8f87-11ea-92ab-7064e38076c2.jpeg">

After:
<img width="250" alt="Screen Shot 2020-05-06 at 10 48 02" src="https://user-images.githubusercontent.com/5032900/81149634-3e7da500-8f87-11ea-9c96-91e275fc6735.png">


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
