### PR TITLE
Remove import of inexistant component

### DIFF
--- a/packages/editor/src/components/deprecated.js
+++ b/packages/editor/src/components/deprecated.js
@@ -45,7 +45,6 @@ import {
 	MediaPlaceholder as RootMediaPlaceholder,
 	MediaUpload as RootMediaUpload,
 	MediaUploadCheck as RootMediaUploadCheck,
-	MultiBlocksSwitcher as RootMultiBlocksSwitcher,
 	MultiSelectScrollIntoView as RootMultiSelectScrollIntoView,
 	NavigableToolbar as RootNavigableToolbar,
 	ObserveTyping as RootObserveTyping,
@@ -208,10 +207,6 @@ export const MediaUpload = deprecateComponent( 'MediaUpload', RootMediaUpload );
 export const MediaUploadCheck = deprecateComponent(
 	'MediaUploadCheck',
 	RootMediaUploadCheck
-);
-export const MultiBlocksSwitcher = deprecateComponent(
-	'MultiBlocksSwitcher',
-	RootMultiBlocksSwitcher
 );
 export const MultiSelectScrollIntoView = deprecateComponent(
 	'MultiSelectScrollIntoView',


### PR DESCRIPTION
closes #22102

Tiny PR to fix npm usage of edit-post package. This didn't trigger any error on WordPress because of the externals.
