### PR TITLE
Reduce re-renders from block nodes context

### DIFF
--- a/packages/block-editor/src/components/block-list/block-popover.js
+++ b/packages/block-editor/src/components/block-list/block-popover.js
@@ -64,7 +64,7 @@ function BlockPopover( {
 	const isLargeViewport = useViewportMatch( 'medium' );
 	const [ isToolbarForced, setIsToolbarForced ] = useState( false );
 	const [ isInserterShown, setIsInserterShown ] = useState( false );
-	const [ blockNodes ] = useContext( BlockNodes );
+	const blockNodes = useContext( BlockNodes );
 
 	const showEmptyBlockSideInserter =
 		! isNavigationMode && isEmptyDefaultBlock && isValid;

--- a/packages/block-editor/src/components/block-list/block-wrapper.js
+++ b/packages/block-editor/src/components/block-list/block-wrapper.js
@@ -19,14 +19,14 @@ import { useSelect, useDispatch } from '@wordpress/data';
  */
 import { isInsideRootBlock } from '../../utils/dom';
 import useMovingAnimation from './moving-animation';
-import { Context, BlockNodes } from './root-container';
+import { Context, SetBlockNodes } from './root-container';
 import { BlockListBlockContext } from './block';
 import ELEMENTS from './block-elements';
 
 const BlockComponent = forwardRef(
 	( { children, tagName = 'div', __unstableIsHtml, ...props }, wrapper ) => {
 		const onSelectionStart = useContext( Context );
-		const [ , setBlockNodes ] = useContext( BlockNodes );
+		const setBlockNodes = useContext( SetBlockNodes );
 		const {
 			clientId,
 			rootClientId,

--- a/packages/block-editor/src/components/block-list/root-container.js
+++ b/packages/block-editor/src/components/block-list/root-container.js
@@ -21,6 +21,7 @@ import BlockPopover from './block-popover';
 
 export const Context = createContext();
 export const BlockNodes = createContext();
+export const SetBlockNodes = createContext();
 
 function selector( select ) {
 	const {
@@ -79,6 +80,8 @@ function RootContainer( { children, className }, ref ) {
 		}
 	}
 
+	const [ blockNodes, setBlockNodes ] = useState( {} );
+
 	return (
 		<InsertionPoint
 			isMultiSelecting={ isMultiSelecting }
@@ -86,8 +89,10 @@ function RootContainer( { children, className }, ref ) {
 			selectedBlockClientId={ selectedBlockClientId }
 			containerRef={ ref }
 		>
-			<BlockNodes.Provider value={ useState( {} ) }>
+			<BlockNodes.Provider value={ blockNodes }>
 				<BlockPopover />
+			</BlockNodes.Provider>
+			<SetBlockNodes.Provider value={ setBlockNodes }>
 				<div
 					ref={ ref }
 					className={ classnames( className, 'is-root-container' ) }
@@ -98,7 +103,7 @@ function RootContainer( { children, className }, ref ) {
 						{ children }
 					</Context.Provider>
 				</div>
-			</BlockNodes.Provider>
+			</SetBlockNodes.Provider>
 		</InsertionPoint>
 	);
 }

--- a/packages/block-editor/src/components/block-list/root-container.js
+++ b/packages/block-editor/src/components/block-list/root-container.js
@@ -91,19 +91,19 @@ function RootContainer( { children, className }, ref ) {
 		>
 			<BlockNodes.Provider value={ blockNodes }>
 				<BlockPopover />
-			</BlockNodes.Provider>
-			<SetBlockNodes.Provider value={ setBlockNodes }>
 				<div
 					ref={ ref }
 					className={ classnames( className, 'is-root-container' ) }
 					onFocus={ onFocus }
 					onDragStart={ onDragStart }
 				>
-					<Context.Provider value={ onSelectionStart }>
-						{ children }
-					</Context.Provider>
+					<SetBlockNodes.Provider value={ setBlockNodes }>
+						<Context.Provider value={ onSelectionStart }>
+							{ children }
+						</Context.Provider>
+					</SetBlockNodes.Provider>
 				</div>
-			</SetBlockNodes.Provider>
+			</BlockNodes.Provider>
 		</InsertionPoint>
 	);
 }


### PR DESCRIPTION
## Description

This should be better for performance. Need to confirm it in combination with #22099.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
