### PR TITLE
Async render blocks to improve initial loading time

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9819,7 +9819,6 @@
 				"@wordpress/is-shallow-equal": "file:packages/is-shallow-equal",
 				"@wordpress/keyboard-shortcuts": "file:packages/keyboard-shortcuts",
 				"@wordpress/keycodes": "file:packages/keycodes",
-				"@wordpress/priority-queue": "file:packages/priority-queue",
 				"@wordpress/rich-text": "file:packages/rich-text",
 				"@wordpress/shortcode": "file:packages/shortcode",
 				"@wordpress/token-list": "file:packages/token-list",
@@ -9966,6 +9965,7 @@
 				"@babel/runtime": "^7.9.2",
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/is-shallow-equal": "file:packages/is-shallow-equal",
+				"@wordpress/priority-queue": "file:packages/priority-queue",
 				"lodash": "^4.17.15",
 				"mousetrap": "^1.6.2",
 				"react-resize-aware": "^3.0.0"

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -39,7 +39,6 @@
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
 		"@wordpress/keyboard-shortcuts": "file:../keyboard-shortcuts",
 		"@wordpress/keycodes": "file:../keycodes",
-		"@wordpress/priority-queue": "file:../priority-queue",
 		"@wordpress/rich-text": "file:../rich-text",
 		"@wordpress/shortcode": "file:../shortcode",
 		"@wordpress/token-list": "file:../token-list",

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -8,6 +8,7 @@ import classnames from 'classnames';
  */
 import { AsyncModeProvider, useSelect } from '@wordpress/data';
 import { useRef, forwardRef } from '@wordpress/element';
+import { useAsyncList } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -72,6 +73,7 @@ function BlockList(
 		element: ref,
 		rootClientId,
 	} );
+	const asyncLoadedBlocks = useAsyncList( blockClientIds, { increment: 50 } );
 
 	return (
 		<Container
@@ -83,7 +85,7 @@ function BlockList(
 				__experimentalPassedProps.className
 			) }
 		>
-			{ blockClientIds.map( ( clientId, index ) => {
+			{ asyncLoadedBlocks.map( ( clientId, index ) => {
 				const isBlockInSelection = hasMultiSelection
 					? multiSelectedBlockClientIds.includes( clientId )
 					: selectedBlockClientId === clientId;

--- a/packages/block-editor/src/components/inserter/block-patterns.js
+++ b/packages/block-editor/src/components/inserter/block-patterns.js
@@ -11,12 +11,12 @@ import { parse, cloneBlock } from '@wordpress/blocks';
 import { useDispatch } from '@wordpress/data';
 import { ENTER, SPACE } from '@wordpress/keycodes';
 import { __, sprintf, _x } from '@wordpress/i18n';
+import { useAsyncList } from '@wordpress/compose';
 
 /**
  * Internal dependencies
  */
 import BlockPreview from '../block-preview';
-import useAsyncList from './use-async-list';
 import InserterPanel from './panel';
 import { searchItems } from './search-items';
 import InserterNoResults from './no-results';

--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -119,6 +119,20 @@ _Returns_
 
 -   `WPComponent`: Component class with generated display name assigned.
 
+<a name="useAsyncList" href="#useAsyncList">#</a> **useAsyncList**
+
+React hook returns an array which items get asynchronously appended from a source array.
+This behavior is useful if we want to render a list of items asynchronously for performance reasons.
+
+_Parameters_
+
+-   _list_ `Array`: Source array.
+-   _config_ `Object`: Configuration of the async list.
+
+_Returns_
+
+-   `Array`: Async array.
+
 <a name="useInstanceId" href="#useInstanceId">#</a> **useInstanceId**
 
 Provides a unique instance ID.

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -26,6 +26,7 @@
 		"@babel/runtime": "^7.9.2",
 		"@wordpress/element": "file:../element",
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
+		"@wordpress/priority-queue": "file:../priority-queue",
 		"lodash": "^4.17.15",
 		"mousetrap": "^1.6.2",
 		"react-resize-aware": "^3.0.0"

--- a/packages/compose/src/index.js
+++ b/packages/compose/src/index.js
@@ -14,6 +14,7 @@ export { default as withState } from './higher-order/with-state';
 
 // Hooks
 export { default as __experimentalUseDragging } from './hooks/use-dragging';
+export { default as useAsyncList } from './hooks/use-async-list';
 export { default as useInstanceId } from './hooks/use-instance-id';
 export { default as useKeyboardShortcut } from './hooks/use-keyboard-shortcut';
 export { default as useMediaQuery } from './hooks/use-media-query';

--- a/packages/e2e-tests/specs/performance/performance.test.js
+++ b/packages/e2e-tests/specs/performance/performance.test.js
@@ -122,8 +122,16 @@ describe( 'Performance', () => {
 			);
 		}
 
+		// Wait for all the blocks to be async rendered.
+		// eslint-disable-next-line no-restricted-syntax
+		await page.waitFor( 20000 );
+
 		// Measuring typing performance
 		await insertBlock( 'Paragraph' );
+
+		// eslint-disable-next-line no-restricted-syntax
+		await page.waitFor( 2000 );
+
 		i = 200;
 		const traceFile = __dirname + '/trace.json';
 		await page.tracing.start( {
@@ -164,6 +172,10 @@ describe( 'Performance', () => {
 				.map( () => createBlock( 'core/paragraph' ) );
 			dispatch( 'core/block-editor' ).resetBlocks( blocks );
 		} );
+
+		// Wait for all the blocks to be async rendered.
+		// eslint-disable-next-line no-restricted-syntax
+		await page.waitFor( 20000 );
 
 		const paragraphs = await page.$$( '.wp-block' );
 


### PR DESCRIPTION
This PR uses the same technique used to render the patterns list in the inserter for the actual block list in the canvas. The idea is that if we render the block list asynchronously on load, it will drastically improve the loading time.

And the numbers confirm, the loading time for me moves from **8 to 2 seconds** (for large posts)

**Notes**

 - This has an impact on the UI for posts with more than 50 blocks
 - If a container block (or root canvas) has more than 50 blocks, these will be rendered 50 by 50
 - If you try to insert a block at the end while all the blocks didn't render yet (right after loading the page with a large post), you'll have to wait some seconds to see your block appearing. (main downside)

**Potential improvements**

 - We can show static "placeholders" where a block is yet to be rendered.
 - We can improve the `useAsyncList` hook to support wholes in the list itself, this could allow us, for instance, to force render the selected block even if the previous blocks didn't render yet (this could help solve the third point on the "notes" above)
