### PR TITLE
Template Loader: Get rid of _wp_current_template_part_ids globals

### DIFF
--- a/lib/edit-site-page.php
+++ b/lib/edit-site-page.php
@@ -152,8 +152,8 @@ function gutenberg_edit_site_init( $hook ) {
 			continue;
 		}
 
-		$template_hierarchy    = array_merge( get_template_hierachy( $template_type ), get_template_hierachy( 'index' ) );
-		$current_template = gutenberg_find_template_post_and_parts( $template_hierarchy );
+		$template_hierarchy = array_merge( get_template_hierachy( $template_type ), get_template_hierachy( 'index' ) );
+		$current_template   = gutenberg_find_template_post_and_parts( $template_hierarchy );
 		if ( isset( $current_template ) ) {
 			$template_ids[ $current_template['template_post']->post_name ] = $current_template['template_post']->ID;
 			$template_part_ids = $template_part_ids + $current_template['template_part_ids'];

--- a/lib/edit-site-page.php
+++ b/lib/edit-site-page.php
@@ -88,9 +88,7 @@ function gutenberg_get_editor_styles() {
  * @param string $hook Page.
  */
 function gutenberg_edit_site_init( $hook ) {
-	global
-		$_wp_current_template_part_ids,
-		$current_screen;
+	global $current_screen;
 
 	if ( ! gutenberg_is_edit_site_page( $hook ) ) {
 		return;
@@ -157,13 +155,9 @@ function gutenberg_edit_site_init( $hook ) {
 		$template_hierarchy    = array_merge( get_template_hierachy( $template_type ), get_template_hierachy( 'index' ) );
 		$current_template_post = gutenberg_find_template_post( $template_hierarchy );
 		if ( isset( $current_template_post ) ) {
-			$template_ids[ $current_template_post->post_name ] = $current_template_post->ID;
+			$template_ids[ $current_template_post['template_post']->post_name ] = $current_template_post['template_post']->ID;
+			$template_part_ids = $template_part_ids + $current_template_post['template_part_ids'];
 		}
-		if ( isset( $_wp_current_template_part_ids ) ) {
-			$template_part_ids = $template_part_ids + $_wp_current_template_part_ids;
-		}
-
-		$_wp_current_template_part_ids = null;
 	}
 
 	$current_template_id = $template_ids['front-page'];

--- a/lib/edit-site-page.php
+++ b/lib/edit-site-page.php
@@ -153,10 +153,10 @@ function gutenberg_edit_site_init( $hook ) {
 		}
 
 		$template_hierarchy    = array_merge( get_template_hierachy( $template_type ), get_template_hierachy( 'index' ) );
-		$current_template_post = gutenberg_find_template_post_and_parts( $template_hierarchy );
-		if ( isset( $current_template_post ) ) {
-			$template_ids[ $current_template_post['template_post']->post_name ] = $current_template_post['template_post']->ID;
-			$template_part_ids = $template_part_ids + $current_template_post['template_part_ids'];
+		$current_template = gutenberg_find_template_post_and_parts( $template_hierarchy );
+		if ( isset( $current_template ) ) {
+			$template_ids[ $current_template['template_post']->post_name ] = $current_template['template_post']->ID;
+			$template_part_ids = $template_part_ids + $current_template['template_part_ids'];
 		}
 	}
 

--- a/lib/edit-site-page.php
+++ b/lib/edit-site-page.php
@@ -153,7 +153,7 @@ function gutenberg_edit_site_init( $hook ) {
 		}
 
 		$template_hierarchy    = array_merge( get_template_hierachy( $template_type ), get_template_hierachy( 'index' ) );
-		$current_template_post = gutenberg_find_template_post( $template_hierarchy );
+		$current_template_post = gutenberg_find_template_post_and_parts( $template_hierarchy );
 		if ( isset( $current_template_post ) ) {
 			$template_ids[ $current_template_post['template_post']->post_name ] = $current_template_post['template_post']->ID;
 			$template_part_ids = $template_part_ids + $current_template_post['template_part_ids'];

--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -91,11 +91,12 @@ function get_template_hierachy( $template_type ) {
  * @return string The path to the Full Site Editing template canvas file.
  */
 function gutenberg_override_query_template( $template, $type, array $templates = array() ) {
-	global $_wp_current_template_content;
+	global $_wp_current_template_id, $_wp_current_template_content;
 
 	$current_template_post = gutenberg_find_template_post( $templates );
 
 	if ( $current_template_post ) {
+		$_wp_current_template_id      = $current_template_post->ID;
 		$_wp_current_template_content = empty( $current_template_post->post_content ) ? __( 'Empty template.', 'gutenberg' ) : $current_template_post->post_content;
 	}
 
@@ -369,17 +370,15 @@ function gutenberg_strip_php_suffix( $template_file ) {
  * @return array Filtered editor settings.
  */
 function gutenberg_template_loader_filter_block_editor_settings( $settings ) {
-	global $post;
+	global $post, $_wp_current_template_id;
 
 	if ( ! $post || ! post_type_exists( 'wp_template' ) || ! post_type_exists( 'wp_template_part' ) ) {
 		return $settings;
 	}
 
-	$current_template_id = $settings['templateId'];
-
 	// Create template part auto-drafts for the edited post.
-	$post = isset( $current_template_id )
-		? get_post( $current_template_id ) // It's a template.
+	$post = isset( $_wp_current_template_id )
+		? get_post( $_wp_current_template_id ) // It's a template.
 		: get_post(); // It's a post.
 	foreach ( parse_blocks( $post->post_content ) as $block ) {
 		create_auto_draft_for_template_part_block( $block );

--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -91,12 +91,11 @@ function get_template_hierachy( $template_type ) {
  * @return string The path to the Full Site Editing template canvas file.
  */
 function gutenberg_override_query_template( $template, $type, array $templates = array() ) {
-	global $_wp_current_template_id, $_wp_current_template_content;
+	global $_wp_current_template_content;
 
 	$current_template_post = gutenberg_find_template_post( $templates );
 
 	if ( $current_template_post ) {
-		$_wp_current_template_id      = $current_template_post->ID;
 		$_wp_current_template_content = empty( $current_template_post->post_content ) ? __( 'Empty template.', 'gutenberg' ) : $current_template_post->post_content;
 	}
 
@@ -365,15 +364,17 @@ function gutenberg_strip_php_suffix( $template_file ) {
  * @return array Filtered editor settings.
  */
 function gutenberg_template_loader_filter_block_editor_settings( $settings ) {
-	global $post, $_wp_current_template_id;
+	global $post;
 
 	if ( ! $post || ! post_type_exists( 'wp_template' ) || ! post_type_exists( 'wp_template_part' ) ) {
 		return $settings;
 	}
 
+	$current_template_id = $settings['templateId'];
+
 	// Create template part auto-drafts for the edited post.
-	$post = isset( $_wp_current_template_id )
-		? get_post( $_wp_current_template_id ) // It's a template.
+	$post = isset( $current_template_id )
+		? get_post( $current_template_id ) // It's a template.
 		: get_post(); // It's a post.
 	foreach ( parse_blocks( $post->post_content ) as $block ) {
 		create_auto_draft_for_template_part_block( $block );

--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -93,7 +93,7 @@ function get_template_hierachy( $template_type ) {
 function gutenberg_override_query_template( $template, $type, array $templates = array() ) {
 	global $_wp_current_template_id, $_wp_current_template_content;
 
-	$current_template_post = gutenberg_find_template_post( $templates );
+	$current_template_post = gutenberg_find_template_post_and_parts( $templates );
 
 	if ( $current_template_post ) {
 		$_wp_current_template_id      = $current_template_post['template_post']->ID;
@@ -199,7 +199,7 @@ function create_auto_draft_for_template_part_block( $block ) {
  *  @type int[] A list of template parts IDs for the template.
  * }
  */
-function gutenberg_find_template_post( $template_hierarchy ) {
+function gutenberg_find_template_post_and_parts( $template_hierarchy ) {
 	if ( ! $template_hierarchy ) {
 		return null;
 	}

--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -97,7 +97,7 @@ function gutenberg_override_query_template( $template, $type, array $templates =
 
 	if ( $current_template ) {
 		$_wp_current_template_id      = $current_template['template_post']->ID;
-		$_wp_current_template_content = $current_template['template_post']->post_content ?: __( 'Empty template.', 'gutenberg' );
+		$_wp_current_template_content = empty( $current_template['template_post']->post_content ) ? __( 'Empty template.', 'gutenberg' ) : $current_template['template_post']->post_content;
 	}
 
 	// Add hooks for template canvas.

--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -97,7 +97,7 @@ function gutenberg_override_query_template( $template, $type, array $templates =
 
 	if ( $current_template ) {
 		$_wp_current_template_id      = $current_template['template_post']->ID;
-		$_wp_current_template_content = empty( $current_template['template_post']->post_content ) ? __( 'Empty template.', 'gutenberg' ) : $current_template['template_post']->post_content;
+		$_wp_current_template_content = $current_template['template_post']->post_content ?: __( 'Empty template.', 'gutenberg' );
 	}
 
 	// Add hooks for template canvas.

--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -96,8 +96,8 @@ function gutenberg_override_query_template( $template, $type, array $templates =
 	$current_template_post = gutenberg_find_template_post( $templates );
 
 	if ( $current_template_post ) {
-		$_wp_current_template_id      = $current_template_post->ID;
-		$_wp_current_template_content = empty( $current_template_post->post_content ) ? __( 'Empty template.', 'gutenberg' ) : $current_template_post->post_content;
+		$_wp_current_template_id      = $current_template_post['template_post']->ID;
+		$_wp_current_template_content = empty( $current_template_post['template_post']->post_content ) ? __( 'Empty template.', 'gutenberg' ) : $current_template_post['template_post']->post_content;
 	}
 
 	// Add hooks for template canvas.
@@ -194,7 +194,7 @@ function create_auto_draft_for_template_part_block( $block ) {
  * Return the correct 'wp_template' post and template part IDs for the current template hierarchy.
  *
  * @param string[] $template_hierarchy The current template hierarchy, ordered by priority.
- * @return array {
+ * @return null|array {
  *  @type WP_Post|null template_post A template post object, or null if none could be found.
  *  @type int[] A list of template parts IDs for the template.
  * }

--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -93,11 +93,11 @@ function get_template_hierachy( $template_type ) {
 function gutenberg_override_query_template( $template, $type, array $templates = array() ) {
 	global $_wp_current_template_id, $_wp_current_template_content;
 
-	$current_template_post = gutenberg_find_template_post_and_parts( $templates );
+	$current_template = gutenberg_find_template_post_and_parts( $templates );
 
-	if ( $current_template_post ) {
-		$_wp_current_template_id      = $current_template_post['template_post']->ID;
-		$_wp_current_template_content = empty( $current_template_post['template_post']->post_content ) ? __( 'Empty template.', 'gutenberg' ) : $current_template_post['template_post']->post_content;
+	if ( $current_template ) {
+		$_wp_current_template_id      = $current_template['template_post']->ID;
+		$_wp_current_template_content = empty( $current_template['template_post']->post_content ) ? __( 'Empty template.', 'gutenberg' ) : $current_template['template_post']->post_content;
 	}
 
 	// Add hooks for template canvas.

--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -118,84 +118,85 @@ function gutenberg_override_query_template( $template, $type, array $templates =
  * @access private
  *
  * @param array $block The root block to start traversing from.
+ * @return int[] A list of template parts IDs for the given block.
  */
 function create_auto_draft_for_template_part_block( $block ) {
-	global $_wp_current_template_part_ids;
+	if ( 'core/template-part' !== $block['blockName'] ) {
+		return array();
+	}
 
-	if ( 'core/template-part' === $block['blockName'] ) {
-		if ( isset( $block['attrs']['postId'] ) ) {
-			// Template part is customized.
-			$template_part_id = $block['attrs']['postId'];
+	if ( isset( $block['attrs']['postId'] ) ) {
+		// Template part is customized.
+		$template_part_id = $block['attrs']['postId'];
+	} else {
+		// A published post might already exist if this template part
+		// was customized elsewhere or if it's part of a customized
+		// template. We also check if an auto-draft was already created
+		// because preloading can make this run twice, so, different code
+		// paths can end up with different posts for the same template part.
+		// E.g. The server could send back post ID 1 to the client, preload,
+		// and create another auto-draft. So, if the client tries to resolve the
+		// post ID from the slug and theme, it won't match with what the server sent.
+		$template_part_query = new WP_Query(
+			array(
+				'post_type'      => 'wp_template_part',
+				'post_status'    => array( 'publish', 'auto-draft' ),
+				'name'           => $block['attrs']['slug'],
+				'meta_key'       => 'theme',
+				'meta_value'     => $block['attrs']['theme'],
+				'posts_per_page' => 1,
+				'no_found_rows'  => true,
+			)
+		);
+		$template_part_post  = $template_part_query->have_posts() ? $template_part_query->next_post() : null;
+		if ( $template_part_post ) {
+			$template_part_id = $template_part_post->ID;
 		} else {
-			// A published post might already exist if this template part
-			// was customized elsewhere or if it's part of a customized
-			// template. We also check if an auto-draft was already created
-			// because preloading can make this run twice, so, different code
-			// paths can end up with different posts for the same template part.
-			// E.g. The server could send back post ID 1 to the client, preload,
-			// and create another auto-draft. So, if the client tries to resolve the
-			// post ID from the slug and theme, it won't match with what the server sent.
-			$template_part_query = new WP_Query(
-				array(
-					'post_type'      => 'wp_template_part',
-					'post_status'    => array( 'publish', 'auto-draft' ),
-					'name'           => $block['attrs']['slug'],
-					'meta_key'       => 'theme',
-					'meta_value'     => $block['attrs']['theme'],
-					'posts_per_page' => 1,
-					'no_found_rows'  => true,
-				)
-			);
-			$template_part_post  = $template_part_query->have_posts() ? $template_part_query->next_post() : null;
-			if ( $template_part_post ) {
-				$template_part_id = $template_part_post->ID;
-			} else {
-				// Template part is not customized, get it from a file and make an auto-draft for it.
-				$template_part_file_path =
-				get_stylesheet_directory() . '/block-template-parts/' . $block['attrs']['slug'] . '.html';
-				if ( ! file_exists( $template_part_file_path ) ) {
-					if ( gutenberg_is_experiment_enabled( 'gutenberg-full-site-editing-demo' ) ) {
-						$template_part_file_path =
-							dirname( __FILE__ ) . '/demo-block-template-parts/' . $block['attrs']['slug'] . '.html';
-						if ( ! file_exists( $template_part_file_path ) ) {
-							return;
-						}
-					} else {
+			// Template part is not customized, get it from a file and make an auto-draft for it.
+			$template_part_file_path =
+			get_stylesheet_directory() . '/block-template-parts/' . $block['attrs']['slug'] . '.html';
+			if ( ! file_exists( $template_part_file_path ) ) {
+				if ( gutenberg_is_experiment_enabled( 'gutenberg-full-site-editing-demo' ) ) {
+					$template_part_file_path =
+						dirname( __FILE__ ) . '/demo-block-template-parts/' . $block['attrs']['slug'] . '.html';
+					if ( ! file_exists( $template_part_file_path ) ) {
 						return;
 					}
+				} else {
+					return;
 				}
-				$template_part_id = wp_insert_post(
-					array(
-						'post_content' => file_get_contents( $template_part_file_path ),
-						'post_title'   => $block['attrs']['slug'],
-						'post_status'  => 'auto-draft',
-						'post_type'    => 'wp_template_part',
-						'post_name'    => $block['attrs']['slug'],
-						'meta_input'   => array(
-							'theme' => $block['attrs']['theme'],
-						),
-					)
-				);
 			}
-		}
-
-		if ( isset( $_wp_current_template_part_ids ) ) {
-			$_wp_current_template_part_ids[ $block['attrs']['slug'] ] = $template_part_id;
-		} else {
-			$_wp_current_template_part_ids = array( $block['attrs']['slug'] => $template_part_id );
+			$template_part_id = wp_insert_post(
+				array(
+					'post_content' => file_get_contents( $template_part_file_path ),
+					'post_title'   => $block['attrs']['slug'],
+					'post_status'  => 'auto-draft',
+					'post_type'    => 'wp_template_part',
+					'post_name'    => $block['attrs']['slug'],
+					'meta_input'   => array(
+						'theme' => $block['attrs']['theme'],
+					),
+				)
+			);
 		}
 	}
+
+	$template_part_ids = array( $block['attrs']['slug'] => $template_part_id );
 
 	foreach ( $block['innerBlocks'] as $inner_block ) {
-		create_auto_draft_for_template_part_block( $inner_block );
+		$template_part_ids = array_merge( $template_part_ids, create_auto_draft_for_template_part_block( $inner_block ) );
 	}
+	return $template_part_ids;
 }
 
 /**
- * Return the correct 'wp_template' post for the current template hierarchy.
+ * Return the correct 'wp_template' post and template part IDs for the current template hierarchy.
  *
  * @param string[] $template_hierarchy The current template hierarchy, ordered by priority.
- * @return WP_Post|null A template post object, or null if none could be found.
+ * @return array {
+ *  @type WP_Post|null template_post A template post object, or null if none could be found.
+ *  @type int[] A list of template parts IDs for the template.
+ * }
  */
 function gutenberg_find_template_post( $template_hierarchy ) {
 	if ( ! $template_hierarchy ) {
@@ -286,12 +287,16 @@ function gutenberg_find_template_post( $template_hierarchy ) {
 	}
 
 	if ( $current_template_post ) {
+		$template_part_ids = array();
 		if ( is_admin() ) {
 			foreach ( parse_blocks( $current_template_post->post_content ) as $block ) {
-				create_auto_draft_for_template_part_block( $block );
+				$template_part_ids = array_merge( $template_part_ids, create_auto_draft_for_template_part_block( $block ) );
 			}
 		}
-		return $current_template_post;
+		return array(
+			'template_post'     => $current_template_post,
+			'template_part_ids' => $template_part_ids,
+		);
 	}
 	return null;
 }


### PR DESCRIPTION
## Description
Final piece of a refactor that started with #21959 and #21980.

This PR changes:
1. ~The `gutenberg_template_loader_filter_block_editor_settings` filter to infer the current template ID from the `$settings` array it is given as an arg, allowing us to drop the `$_wp_current_template_id` global.~ _Edit: I reverted this commit since it caused issues outside of FSE._
2. The `create_auto_draft_for_template_part_block` function to return a list of template part IDs, and the `gutenberg_find_template_post` function to include that information in its return value, allowing us to drop the `$_wp_current_template_part_ids` global.

There's one commit for each change which should make reviewing a bit easier.

## How has this been tested?
Verify that Full Site Editing still works as before.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
