### PR TITLE
Use for...of loops more often.

### DIFF
--- a/packages/autop/src/index.js
+++ b/packages/autop/src/index.js
@@ -95,8 +95,7 @@ function replaceInHtmlTags( haystack, replacePairs ) {
 
 	// Loop through delimiters (elements) only.
 	for ( let i = 1; i < textArr.length; i += 2 ) {
-		for ( let j = 0; j < needles.length; j++ ) {
-			const needle = needles[ j ];
+		for ( const needle of needles ) {
 			if ( -1 !== textArr[ i ].indexOf( needle ) ) {
 				textArr[ i ] = textArr[ i ].replace(
 					new RegExp( needle, 'g' ),

--- a/packages/block-editor/src/components/inserter/use-async-list.js
+++ b/packages/block-editor/src/components/inserter/use-async-list.js
@@ -14,8 +14,7 @@ import { createQueue } from '@wordpress/priority-queue';
 function getFirstItemsPresentInState( list, state ) {
 	const firstItems = [];
 
-	for ( let i = 0; i < list.length; i++ ) {
-		const item = list[ i ];
+	for ( const item of list ) {
 		if ( ! state.includes( item ) ) {
 			break;
 		}

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -309,8 +309,7 @@ export function* replaceBlocks(
 		first( clientIds )
 	);
 	// Replace is valid if the new blocks can be inserted in the root block.
-	for ( let index = 0; index < blocks.length; index++ ) {
-		const block = blocks[ index ];
+	for ( const block of blocks ) {
 		const canInsertBlock = yield select(
 			'core/block-editor',
 			'canInsertBlockType',

--- a/packages/block-library/src/embed/util.js
+++ b/packages/block-library/src/embed/util.js
@@ -147,12 +147,7 @@ export function getClassNames(
 		const aspectRatioClassNames = {
 			'wp-has-aspect-ratio': false,
 		};
-		for (
-			let ratioIndex = 0;
-			ratioIndex < ASPECT_RATIOS.length;
-			ratioIndex++
-		) {
-			const aspectRatioToRemove = ASPECT_RATIOS[ ratioIndex ];
+		for ( const aspectRatioToRemove of ASPECT_RATIOS ) {
 			aspectRatioClassNames[ aspectRatioToRemove.className ] = false;
 		}
 		return classnames( existingClassNames, aspectRatioClassNames );

--- a/packages/blocks/src/api/children.js
+++ b/packages/blocks/src/api/children.js
@@ -60,10 +60,9 @@ function getChildrenArray( children ) {
  */
 export function concat( ...blockNodes ) {
 	const result = [];
-	for ( let i = 0; i < blockNodes.length; i++ ) {
-		const blockNode = castArray( blockNodes[ i ] );
-		for ( let j = 0; j < blockNode.length; j++ ) {
-			const child = blockNode[ j ];
+	for ( const blockNode of blockNodes ) {
+		const blockNodeAsArray = castArray( blockNode );
+		for ( const child of blockNodeAsArray ) {
 			const canConcatToPreviousString =
 				typeof child === 'string' &&
 				typeof result[ result.length - 1 ] === 'string';
@@ -89,9 +88,9 @@ export function concat( ...blockNodes ) {
  */
 export function fromDOM( domNodes ) {
 	const result = [];
-	for ( let i = 0; i < domNodes.length; i++ ) {
+	for ( const domNode of domNodes ) {
 		try {
-			result.push( node.fromDOM( domNodes[ i ] ) );
+			result.push( node.fromDOM( domNode ) );
 		} catch ( error ) {
 			// Simply ignore if DOM node could not be converted.
 		}

--- a/packages/blocks/src/api/matchers.js
+++ b/packages/blocks/src/api/matchers.js
@@ -23,11 +23,8 @@ export function html( selector, multilineTag ) {
 
 		if ( multilineTag ) {
 			let value = '';
-			const length = match.children.length;
 
-			for ( let index = 0; index < length; index++ ) {
-				const child = match.children[ index ];
-
+			for ( const child of match.children ) {
 				if ( child.nodeName.toLowerCase() !== multilineTag ) {
 					continue;
 				}

--- a/packages/blocks/src/api/node.js
+++ b/packages/blocks/src/api/node.js
@@ -44,8 +44,7 @@ function isNodeOfType( node, type ) {
  */
 export function getNamedNodeMapAsObject( nodeMap ) {
 	const result = {};
-	for ( let i = 0; i < nodeMap.length; i++ ) {
-		const { name, value } = nodeMap[ i ];
+	for ( const { name, value } of nodeMap ) {
 		result[ name ] = value;
 	}
 

--- a/packages/blocks/src/api/parser.js
+++ b/packages/blocks/src/api/parser.js
@@ -331,11 +331,11 @@ export function getMigratedBlock( block, parsedAttributes ) {
 
 	const { originalContent, innerBlocks } = block;
 
-	for ( let i = 0; i < deprecatedDefinitions.length; i++ ) {
+	for ( const definition of deprecatedDefinitions ) {
 		// A block can opt into a migration even if the block is valid by
 		// defining isEligible on its deprecation. If the block is both valid
 		// and does not opt to migrate, skip.
-		const { isEligible = stubFalse } = deprecatedDefinitions[ i ];
+		const { isEligible = stubFalse } = definition;
 		if ( block.isValid && ! isEligible( parsedAttributes, innerBlocks ) ) {
 			continue;
 		}
@@ -345,7 +345,7 @@ export function getMigratedBlock( block, parsedAttributes ) {
 		// and must be explicitly provided.
 		const deprecatedBlockType = Object.assign(
 			omit( blockType, DEPRECATED_ENTRY_KEYS ),
-			deprecatedDefinitions[ i ]
+			definition
 		);
 
 		let migratedAttributes = getBlockAttributes(

--- a/packages/blocks/src/api/validation/index.js
+++ b/packages/blocks/src/api/validation/index.js
@@ -305,9 +305,7 @@ export function isEquivalentTextTokens(
 	let actualChars = actual.chars;
 	let expectedChars = expected.chars;
 
-	for ( let i = 0; i < TEXT_NORMALIZATIONS.length; i++ ) {
-		const normalize = TEXT_NORMALIZATIONS[ i ];
-
+	for ( const normalize of TEXT_NORMALIZATIONS ) {
 		actualChars = normalize( actualChars );
 		expectedChars = normalize( expectedChars );
 
@@ -420,13 +418,12 @@ export function isEqualTagAttributePairs(
 	// actual attributes, first convert the set of expected attribute values to
 	// an object, for lookup by key.
 	const expectedAttributes = {};
-	for ( let i = 0; i < expected.length; i++ ) {
-		expectedAttributes[ expected[ i ][ 0 ].toLowerCase() ] =
-			expected[ i ][ 1 ];
+	for ( const attributeTuple of expected ) {
+		expectedAttributes[ attributeTuple[ 0 ].toLowerCase() ] =
+			attributeTuple[ 1 ];
 	}
 
-	for ( let i = 0; i < actual.length; i++ ) {
-		const [ name, actualValue ] = actual[ i ];
+	for ( const [ name, actualValue ] of actual ) {
 		const nameLower = name.toLowerCase();
 
 		// As noted above, if missing member in B, assume different

--- a/packages/components/src/autocomplete/index.js
+++ b/packages/components/src/autocomplete/index.js
@@ -112,9 +112,7 @@ import withSpokenMessages from '../higher-order/with-spoken-messages';
 
 function filterOptions( search, options = [], maxResults = 10 ) {
 	const filtered = [];
-	for ( let i = 0; i < options.length; i++ ) {
-		const option = options[ i ];
-
+	for ( const option of options ) {
 		// Merge label into keywords
 		let { keywords = [] } = option;
 		if ( 'string' === typeof option.label ) {

--- a/packages/core-data/src/queried-data/get-query-parts.js
+++ b/packages/core-data/src/queried-data/get-query-parts.js
@@ -41,8 +41,7 @@ export function getQueryParts( query ) {
 	// Ensure stable key by sorting keys. Also more efficient for iterating.
 	const keys = Object.keys( query ).sort();
 
-	for ( let i = 0; i < keys.length; i++ ) {
-		const key = keys[ i ];
+	for ( const key of keys ) {
 		const value = query[ key ];
 
 		switch ( key ) {

--- a/packages/custom-templated-path-webpack-plugin/index.js
+++ b/packages/custom-templated-path-webpack-plugin/index.js
@@ -43,8 +43,7 @@ class CustomTemplatedPathPlugin {
 				compilation.mainTemplate.hooks.assetPath.tap(
 					'CustomTemplatedPathPlugin',
 					( path, data ) => {
-						for ( let i = 0; i < this.handlers.length; i++ ) {
-							const [ regexp, handler ] = this.handlers[ i ];
+						for ( const [ regexp, handler ] of this.handlers ) {
 							if ( regexp.test( path ) ) {
 								path = path.replace(
 									regexp,

--- a/packages/e2e-test-utils/src/mocks/set-up-response-mocking.js
+++ b/packages/e2e-test-utils/src/mocks/set-up-response-mocking.js
@@ -41,8 +41,7 @@ export async function setUpResponseMocking( mocks ) {
 		interceptionInitialized = true;
 		await page.setRequestInterception( true );
 		page.on( 'request', async ( request ) => {
-			for ( let i = 0; i < requestMocks.length; i++ ) {
-				const mock = requestMocks[ i ];
+			for ( const mock of requestMocks ) {
 				if ( mock.match( request ) ) {
 					await mock.onRequestMatch( request );
 					return;

--- a/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
@@ -305,10 +305,10 @@ class HierarchicalTermSelector extends Component {
 			.filter( ( term ) => term );
 		const getResultCount = ( terms ) => {
 			let count = 0;
-			for ( let i = 0; i < terms.length; i++ ) {
+			for ( const term of terms ) {
 				count++;
-				if ( undefined !== terms[ i ].children ) {
-					count += getResultCount( terms[ i ].children );
+				if ( undefined !== term.children ) {
+					count += getResultCount( term.children );
 				}
 			}
 			return count;

--- a/packages/element/src/serialize.js
+++ b/packages/element/src/serialize.js
@@ -538,9 +538,7 @@ function renderChildren( children, context, legacyContext = {} ) {
 
 	children = castArray( children );
 
-	for ( let i = 0; i < children.length; i++ ) {
-		const child = children[ i ];
-
+	for ( const child of children ) {
 		result += renderElement( child, context, legacyContext );
 	}
 

--- a/packages/eslint-plugin/rules/dependency-group.js
+++ b/packages/eslint-plugin/rules/dependency-group.js
@@ -118,10 +118,7 @@ module.exports = {
 		function getDependencyBlockCorrection( node, locality ) {
 			const value = getCommentValue( locality );
 
-			let comment;
-			for ( let i = 0; i < comments.length; i++ ) {
-				comment = comments[ i ];
-
+			for ( const comment of comments ) {
 				if ( ! isBefore( comment, node ) ) {
 					// Exhausted options.
 					break;

--- a/packages/rich-text/src/create.js
+++ b/packages/rich-text/src/create.js
@@ -331,11 +331,7 @@ function createFromElement( {
 		return accumulator;
 	}
 
-	const length = element.childNodes.length;
-
-	// Optimise for speed.
-	for ( let index = 0; index < length; index++ ) {
-		const node = element.childNodes[ index ];
+	for ( const node of element.childNodes ) {
 		const type = node.nodeName.toLowerCase();
 
 		if ( node.nodeType === node.TEXT_NODE ) {
@@ -548,13 +544,9 @@ function getAttributes( { element } ) {
 		return;
 	}
 
-	const length = element.attributes.length;
 	let accumulator;
 
-	// Optimise for speed.
-	for ( let i = 0; i < length; i++ ) {
-		const { name, value } = element.attributes[ i ];
-
+	for ( const { name, value } of element.attributes ) {
 		if ( name.indexOf( 'data-rich-text-' ) === 0 ) {
 			continue;
 		}

--- a/packages/rich-text/src/is-format-equal.js
+++ b/packages/rich-text/src/is-format-equal.js
@@ -41,12 +41,7 @@ export function isFormatEqual( format1, format2 ) {
 		return false;
 	}
 
-	const length = keys1.length;
-
-	// Optimise for speed.
-	for ( let i = 0; i < length; i++ ) {
-		const name = keys1[ i ];
-
+	for ( const name of keys1 ) {
 		if ( attributes1[ name ] !== attributes2[ name ] ) {
 			return false;
 		}

--- a/packages/rich-text/src/to-dom.js
+++ b/packages/rich-text/src/to-dom.js
@@ -226,9 +226,7 @@ export function applyValue( future, current ) {
 				}
 
 				if ( futureAttributes ) {
-					for ( let ii = 0; ii < futureAttributes.length; ii++ ) {
-						const { name, value } = futureAttributes[ ii ];
-
+					for ( const { name, value } of futureAttributes ) {
 						if ( currentChild.getAttribute( name ) !== value ) {
 							currentChild.setAttribute( name, value );
 						}


### PR DESCRIPTION
## Description
JavaScript [`for...of` loops](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...of) are a lot easier to comprehend than classic `for` loops. ~And when we eventually drop IE11 support and stop transpiling them, they should also be a bit faster.~ This PR replaces classic `for` loops with `for...of` loops in every situation where it makes sense.

Side note: maybe we should consider adding a recommendation in the docs to prefer `for...of` loops where it makes sense to use them?