### PR TITLE
E2E Test Utils: Fix typo in getJSONResponse object

### DIFF
--- a/packages/e2e-test-utils/src/shared/get-json-response.js
+++ b/packages/e2e-test-utils/src/shared/get-json-response.js
@@ -6,7 +6,7 @@
  */
 export function getJSONResponse( obj ) {
 	return {
-		content: 'application/json',
+		contentType: 'application/json',
 		body: JSON.stringify( obj ),
 	};
 }


### PR DESCRIPTION
## Description
According to the documentation for `request.respond`, the object should use `contentType` for the Content Type header. This appears to be a typo currently, just `content`.

## How has this been tested?
The CI tests should still run & pass

## Types of changes
Bug fix (non-breaking change which fixes an issue) I think, though I don't think this was causing any real bugs.
