### PR TITLE
Quote block: use light block wrapper.

### DIFF
--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -43,6 +43,7 @@
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
 		"@wordpress/keyboard-shortcuts": "file:../keyboard-shortcuts",
 		"@wordpress/keycodes": "file:../keycodes",
+		"@wordpress/primitives": "file:../primitives",
 		"@wordpress/priority-queue": "file:../priority-queue",
 		"@wordpress/rich-text": "file:../rich-text",
 		"@wordpress/shortcode": "file:../shortcode",

--- a/packages/block-editor/src/components/block-list/block-wrapper-elements.js
+++ b/packages/block-editor/src/components/block-list/block-wrapper-elements.js
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import { BlockQuotation } from '@wordpress/primitives';
+
+/**
  * HTML elements that can be used as a block wrapper.
  */
 const ELEMENTS = [
@@ -21,6 +26,7 @@ const ELEMENTS = [
 	'aside',
 	'footer',
 	'main',
+	BlockQuotation,
 ];
 
 export default ELEMENTS;

--- a/packages/block-library/src/quote/block.json
+++ b/packages/block-library/src/quote/block.json
@@ -18,5 +18,8 @@
 		"align": {
 			"type": "string"
 		}
+	},
+	"supports": {
+		"lightBlockWrapper": true
 	}
 }

--- a/packages/block-library/src/quote/edit.js
+++ b/packages/block-library/src/quote/edit.js
@@ -6,14 +6,17 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import {
 	AlignmentToolbar,
+	__experimentalBlock as Block,
 	BlockControls,
 	RichText,
 } from '@wordpress/block-editor';
-import { BlockQuotation } from '@wordpress/components';
 import { createBlock } from '@wordpress/blocks';
+import { __ } from '@wordpress/i18n';
+import { BlockQuotation } from '@wordpress/primitives';
+
+const BlockWrapper = Block[ BlockQuotation ];
 
 export default function QuoteEdit( {
 	attributes,
@@ -35,7 +38,7 @@ export default function QuoteEdit( {
 					} }
 				/>
 			</BlockControls>
-			<BlockQuotation
+			<BlockWrapper
 				className={ classnames( className, {
 					[ `has-text-align-${ align }` ]: align,
 				} ) }
@@ -91,7 +94,7 @@ export default function QuoteEdit( {
 						textAlign={ align }
 					/>
 				) }
-			</BlockQuotation>
+			</BlockWrapper>
 		</>
 	);
 }


### PR DESCRIPTION
## Description
This PR updates the Quote block to use a light block wrapper.

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
