### PR TITLE
Scripts: Mark `env` script as deprecated

### DIFF
--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -1,7 +1,12 @@
 ## Master
 
 ### Enhancements
+
 - Bundle analysis in `build` script now runs with module concatenation disabled. This represents the size of individual modules more accurately, at the cost of not providing an exact byte-for-byte match to the final size in the production chunk.
+
+### Deprecations
+
+- `env` script was marked as deprecated. We recommend using `@wordpress/env` package instead that lets you easily set up a local WordPress environment for building and testing plugins and themes.
 
 ## 9.0.0 (2020-04-30)
 

--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -123,7 +123,9 @@ _Flags_:
 - `--gpl2`: Validates against [GPLv2 license compatibility](https://www.gnu.org/licenses/license-list.en.html)
 - `--ignore=a,b,c`: A comma-separated set of package names to ignore for validation. This is intended to be used primarily in cases where a dependency’s `license` field is malformed. It’s assumed that any `ignored` package argument would be manually vetted for compatibility by the project owner.
 
-### `env`
+### `env` (deprecated)
+
+> _This script is no longer maintained and it’s going to be removed in one of the future releases. We recommend using [`@wordpress/env`](/packages/env/README.md) package instead that lets you easily set up a local WordPress environment for building and testing plugins and themes._
 
 `env` is a family of scripts for setting up a local Docker-based development environment that plugin contributors can work in.
 
@@ -162,14 +164,14 @@ In the `wp-env` config block, each entry can be configured like so:
 #### Available Sub-Scripts
 
 - `install`: Automatically downloads, builds, and installs a copy of WordPress to work with. This will be installed in the `wordpress` folder inside your project. You should add `wordpress` to your `.gitignore` file.
-- `connect`: For contributors that have a WordPress respository already, they can define the `WP_DEVELOP_DIR` environment variable with the path to their repository, then run this command to add your plugin to it.
+- `connect`: For contributors that have a WordPress repository already, they can define the `WP_DEVELOP_DIR` environment variable with the path to their repository, then run this command to add your plugin to it.
 - `start`: Starts the Docker containers.
 - `stop`: Stops the Docker containers.
 - `update`: For contributors that used `npm run env install` to setup WordPress, running this command will update it to the latest checkout.
 - `reinstall`: Resets the database and re-configures WordPress again.
 - `cli`: Runs WP-CLI commands against the WordPress install.
 - `lint-php`: Run PHPCS linting on your plugin. You will need to have `composer.json` configured to install PHPCS, with a `lint` script that runs your linting. You will also need to have an appropriately configured `phpcs.xml.dist` file.
-- `test-php`: Runs your plugin's PHPUnit tests. You will need to have an appropriately configured `phpunit.xml.dist` file.
+- `test-php`: Runs your plugin’s PHPUnit tests. You will need to have an appropriately configured `phpunit.xml.dist` file.
 - `docker-run`: For more advanced debugging, contributors may sometimes need to run commands in the Docker containers. This is the equivalent of running `docker-compose run` within the WordPress directory.
 
 ### `format-js`
@@ -482,7 +484,7 @@ Debugging npm scripts is supported out of the box for Visual Studio Code as of [
 
 Make sure `wp-scripts --inspect-brk test-unit-js --runInBand --no-cache` is saved as `test:unit:debug` in your `package.json` file to run tests in Visual Studio Code.
 
-When debugging, set a breakpoint in your tests by clicking on a line in the editor's left margin by the line numbers.
+When debugging, set a breakpoint in your tests by clicking on a line in the editor’s left margin by the line numbers.
 
 Then open npm scripts in the explorer or run `Explorer: Focus on NPM Scripts View` in the command palette to see the npm scripts. To start the tests, click the debug icon next to `test:unit:debug`.
 
@@ -553,4 +555,5 @@ module.exports = {
 ```
 
 If you follow this approach, please, be aware that future versions of this package may change what webpack and Babel plugins we bundle, default configs, etc. Should those changes be necessary, they will be registered in the [package’s CHANGELOG](https://github.com/WordPress/gutenberg/blob/master/packages/scripts/CHANGELOG.md), so make sure to read it before upgrading.
+
 <br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>


### PR DESCRIPTION
## Description

`env` script from `@wordpress/script` was marked as deprecated (in the docs only). We should recommend using `@wordpress/env` package instead wherever possible :)

View the updated section: https://github.com/WordPress/gutenberg/blob/edcd0086729ccb6b13a371e173e67aeea6dddac3/packages/scripts/README.md#env-deprecated