### PR TITLE
Unset the inherit for links.

### DIFF
--- a/packages/editor/src/editor-styles.scss
+++ b/packages/editor/src/editor-styles.scss
@@ -146,7 +146,8 @@ ol ul {
 }
 
 a {
-	color: inherit;
+	// This inherits the blue link color set by wp-admin, which is unfortunate.
+	// However both inherit and unset properties set the color to black.
 	transition: none;
 }
 


### PR DESCRIPTION
Mitigates and closes #22139.

The better fix would be to not set any styles for the editing canvas, this can be fixed if we are able to bring the editing canvas into an iframe.

<img width="622" alt="Screenshot 2020-05-07 at 09 18 05" src="https://user-images.githubusercontent.com/1204802/81265611-b0b3bf80-9043-11ea-9d31-fedce77f822e.png">

In the mean time, this removes the "inherit" property. That means link colors are now the same color as links in wp-admin because that color bleeds in. While the bleed is undesirable, I was  unable to find a different fix that enables the vanilla editor styles to have blue links. Both `inherit`, `initial` and `unset` appear to keep the link color black. The only other fix would be to find a new blue color, and set it here, which would simply add specificity.

Themes that provide custom editor styles can, and should, style the link color. But this PR at least ensures that those that don't, have blue links.
