### PR TITLE
Fall back to default block styles when a new block is being inserted

### DIFF
--- a/docs/designers-developers/developers/data/data-core-blocks.md
+++ b/docs/designers-developers/developers/data/data-core-blocks.md
@@ -122,6 +122,19 @@ _Returns_
 
 -   `?string`: Default block name.
 
+<a name="getDefaultBlockStyle" href="#getDefaultBlockStyle">#</a> **getDefaultBlockStyle**
+
+Returns default block style by block name.
+
+_Parameters_
+
+-   _state_ `Object`: Data state.
+-   _name_ `string`: Block type name.
+
+_Returns_
+
+-   `?Array`: Block Styles.
+
 <a name="getDefaultBlockVariation" href="#getDefaultBlockVariation">#</a> **getDefaultBlockVariation**
 
 Returns the default block variation for the given block type.

--- a/docs/designers-developers/developers/data/data-core-blocks.md
+++ b/docs/designers-developers/developers/data/data-core-blocks.md
@@ -133,7 +133,7 @@ _Parameters_
 
 _Returns_
 
--   `?Array`: Block Styles.
+-   `?Object`: Block Styles.
 
 <a name="getDefaultBlockVariation" href="#getDefaultBlockVariation">#</a> **getDefaultBlockVariation**
 

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -292,11 +292,14 @@ function getBlocksWithDefaultStylesApplied(
 function* computeDefaultStyleVariations( blocks ) {
 	const defaultStyles = {};
 	for ( const block of blocks ) {
-		defaultStyles[ block.name ] = ( yield select(
+		const defaultStyle = yield select(
 			'core/blocks',
 			'getDefaultBlockStyle',
 			block.name
-		) ).name;
+		);
+		if ( defaultStyle ) {
+			defaultStyles[ block.name ] = defaultStyle.name;
+		}
 	}
 	return defaultStyles;
 }

--- a/packages/blocks/src/store/selectors.js
+++ b/packages/blocks/src/store/selectors.js
@@ -81,10 +81,10 @@ export function getBlockStyles( state, name ) {
  * @param {Object} state Data state.
  * @param {string} name  Block type name.
  *
- * @return {Array?} Block Styles.
+ * @return {Object?} Block Styles.
  */
 export function getDefaultBlockStyle( state, name ) {
-	return getBlockStyles( state, name ).filter(
+	return getBlockStyles( state, name )?.filter(
 		( style ) => style.isDefault
 	)[ 0 ];
 }

--- a/packages/blocks/src/store/selectors.js
+++ b/packages/blocks/src/store/selectors.js
@@ -76,6 +76,20 @@ export function getBlockStyles( state, name ) {
 }
 
 /**
+ * Returns default block style by block name.
+ *
+ * @param {Object} state Data state.
+ * @param {string} name  Block type name.
+ *
+ * @return {Array?} Block Styles.
+ */
+export function getDefaultBlockStyle( state, name ) {
+	return getBlockStyles( state, name ).filter(
+		( style ) => style.isDefault
+	)[ 0 ];
+}
+
+/**
  * Returns block variations by block name.
  *
  * @param {Object}                state     Data state.


### PR DESCRIPTION
## Description

When you call `insertBlocks` or `replaceBlocks`, they would add default styles to all the blocks being inserted. At the moment, only preferredStyleVariations are considered, and if those are missing then no style variation is set at all. This PR makes sure we fall back to default style variation from the block definition.

For example, the navigation block has the following style variations:

https://github.com/WordPress/gutenberg/blob/05c39310f05cbd107166e0d27ebf45ec16f4c4ed/packages/block-library/src/navigation/index.js#L80-L83

Without this PR, a new navigation block would get no variation assigned even though `light` is supposed to be the default one - so the background ends up being transparent.

**Before**
![2020-05-07 12-55-10 2020-05-07 12_55_41](https://user-images.githubusercontent.com/205419/81287116-83c2d500-9062-11ea-919c-e485fc8951f5.gif)

**After**
![2020-05-07 12-56-00 2020-05-07 12_56_45](https://user-images.githubusercontent.com/205419/81287119-84f40200-9062-11ea-9e6a-09c935d08b68.gif)

## How has this been tested?
1. Without this PR: Add a new navigation block with some navigation items. Confirm the background is transparent.
1. Without this PR: Add a new navigation block with some navigation items. Confirm the background is white.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
