### PR TITLE
Combine Calendar Help and Close buttons in DateTimePicker

### DIFF
--- a/packages/components/src/date-time/index.js
+++ b/packages/components/src/date-time/index.js
@@ -149,37 +149,30 @@ export class DateTimePicker extends Component {
 									) }
 								</li>
 							</ul>
-
-							<Button
-								isSmall
-								onClick={ this.onClickDescriptionToggle }
-							>
-								{ __( 'Close' ) }
-							</Button>
 						</div>
 					</>
 				) }
 
-				{ ! this.state.calendarHelpIsVisible && (
-					<div className="components-datetime__buttons">
-						{ currentDate && (
-							<Button
-								className="components-datetime__date-reset-button"
-								isLink
-								onClick={ () => onChange( null ) }
-							>
-								{ __( 'Reset' ) }
-							</Button>
-						) }
+				<div className="components-datetime__buttons">
+					{ ! this.state.calendarHelpIsVisible && currentDate && (
 						<Button
-							className="components-datetime__date-help-button"
+							className="components-datetime__date-reset-button"
 							isLink
-							onClick={ this.onClickDescriptionToggle }
+							onClick={ () => onChange( null ) }
 						>
-							{ __( 'Calendar Help' ) }
+							{ __( 'Reset' ) }
 						</Button>
-					</div>
-				) }
+					) }
+					<Button
+						className="components-datetime__date-help-toggle"
+						isLink
+						onClick={ this.onClickDescriptionToggle }
+					>
+						{ this.state.calendarHelpIsVisible
+							? __( 'Close' )
+							: __( 'Calendar Help' ) }
+					</Button>
+				</div>
 			</div>
 		);
 	}

--- a/packages/components/src/date-time/style.scss
+++ b/packages/components/src/date-time/style.scss
@@ -20,7 +20,7 @@
 		justify-content: space-between;
 	}
 
-	.components-datetime__date-help-button {
+	.components-datetime__date-help-toggle {
 		display: block;
 		margin-left: auto;
 	}
@@ -108,8 +108,7 @@
 		}
 	}
 
-	&.is-description-visible .DayPicker,
-	&.is-description-visible .components-datetime__date-help-button {
+	&.is-description-visible .DayPicker {
 		visibility: hidden;
 	}
 }


### PR DESCRIPTION
## Description
After merging #20914 and then browsing old issues, I came across #10621. 

This is a quick fix that combines the separately rendered help/close buttons into a single toggle. It preserves focus when toggling the help text and is always rendered. This also resolves #21098

Fixes: #10621, #21098

## Screenshots <!-- if applicable -->
<img src="https://user-images.githubusercontent.com/4267290/81304192-bbbe1e00-904a-11ea-868f-5205f806f1b7.gif" width="400" />

I have a slight design change here, so I'm also flagging `Needs Design Feedback` to get some thoughts. Basically since it becomes a toggle I'm keeping it in the same location within the window. It's also retaining more of the standard button/link appearance to make it clear that it's a button. I couldn't find any original designs for this item in its current form. Found one older one with a regular style bordered button, but none as a link. 

Old:
<img width="275" alt="Screen Shot 2020-05-07 at 10 18 52 AM" src="https://user-images.githubusercontent.com/4267290/81305441-566b2c80-904c-11ea-94ca-31a5407d766b.png">

New
<img width="281" alt="Screen Shot 2020-05-07 at 10 09 31 AM" src="https://user-images.githubusercontent.com/4267290/81305455-59feb380-904c-11ea-9eba-cd9e3b18b03f.png">

