### PR TITLE
Document the old patterns API deprecation

### DIFF
--- a/docs/designers-developers/developers/backward-compatibility/deprecations.md
+++ b/docs/designers-developers/developers/backward-compatibility/deprecations.md
@@ -5,6 +5,7 @@ For features included in the Gutenberg plugin, the deprecation policy is intende
 ## 8.3.0
 
 - The PHP function `gutenberg_get_post_from_context` has been removed. Use [Block Context](https://github.com/WordPress/gutenberg/blob/master/docs/designers-developers/developers/block-api/block-context.md) instead.
+- The old Block Pattern APIs `register_pattern`/`unregister_pattern` have been removed. Use the [new functions](https://github.com/WordPress/gutenberg/blob/master/docs/designers-developers/developers/block-api/block-patterns.md#register_block_pattern) instead. 
 
 ## 5.5.0
 

--- a/lib/class-wp-block-patterns-registry.php
+++ b/lib/class-wp-block-patterns-registry.php
@@ -176,6 +176,6 @@ function register_pattern( $pattern_name, $pattern_properties ) {
  * @return boolean True if the pattern was unregistered with success and false otherwise.
  */
 function unregister_pattern( $pattern_name ) {
-	_deprecated_function( __FUNCTION__, 'Gutenberg 8.3.0', 'unregister_block_pattern()' );
+	_deprecated_function( __FUNCTION__, 'Gutenberg 8.1.0', 'unregister_block_pattern()' );
 	return unregister_block_pattern( $pattern_name );
 }


### PR DESCRIPTION
Follow up to #21970 addresses https://github.com/WordPress/gutenberg/pull/21970#discussion_r420965307