### PR TITLE
Site Editor: fix default editor background

### DIFF
--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -114,6 +114,7 @@ function Editor( { settings: _settings } ) {
 										}
 										content={
 											<BlockSelectionClearer
+												className="edit-site-visual-editor"
 												style={ inlineStyles }
 											>
 												<Notices />

--- a/packages/edit-site/src/components/editor/style.scss
+++ b/packages/edit-site/src/components/editor/style.scss
@@ -21,3 +21,7 @@
 		bottom: 0;
 	}
 }
+
+.edit-site-visual-editor {
+	background-color: $white;
+}


### PR DESCRIPTION
## Description

Fixes the gray background that was showing on older themes that didn't declare their editor styling.

## How has this been tested?
1. Switch to Twenty Nineteen theme.
2. Verify that the site editor background is now white.
3. Toggle device preview to tablet or mobile view.
4. The editor background color should be white, while the surrounding area should remain gray.
5. Switch theme to Twenty Twenty.
6. Verify that the custom theme background is used in the editor.

## Screenshots <!-- if applicable -->

| Before | After |
|-|-|
|<img width="1679" alt="Screenshot 2020-05-07 at 19 08 26" src="https://user-images.githubusercontent.com/1182160/81324105-c56d7300-9096-11ea-8525-2df2d3964352.png">|<img width="1678" alt="Screenshot 2020-05-07 at 19 09 10" src="https://user-images.githubusercontent.com/1182160/81324255-fbaaf280-9096-11ea-80f7-a7d5f7baede4.png">|

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
