### PR TITLE
Block Directory: Remove the author rating when none exist

### DIFF
--- a/packages/block-directory/src/components/downloadable-block-author-info/index.js
+++ b/packages/block-directory/src/components/downloadable-block-author-info/index.js
@@ -19,16 +19,26 @@ function DownloadableBlockAuthorInfo( {
 				) }
 			</span>
 			<span className="block-directory-downloadable-block-author-info__content">
-				{ sprintf(
-					/* translators: 1: number of blocks. 2: average rating. */
-					_n(
-						'This author has %1$d block, with an average rating of %2$d.',
-						'This author has %1$d blocks, with an average rating of %2$d.',
-						authorBlockCount
-					),
-					authorBlockCount,
-					authorBlockRating
-				) }
+				{ authorBlockRating > 0
+					? sprintf(
+							/* translators: 1: number of blocks. 2: average rating. */
+							_n(
+								'This author has %1$d block, with an average rating of %2$d.',
+								'This author has %1$d blocks, with an average rating of %2$d.',
+								authorBlockCount
+							),
+							authorBlockCount,
+							authorBlockRating
+					  )
+					: sprintf(
+							/* translators: 1: number of blocks. */
+							_n(
+								'This author has %1$d block.',
+								'This author has %1$d blocks.',
+								authorBlockCount
+							),
+							authorBlockCount
+					  ) }
 			</span>
 		</Fragment>
 	);


### PR DESCRIPTION
## Description
A `0` rating means there have been no reviews submitted, but currently it looks like a negative rating. This removes the rating part of the string in that case.

See #17440 & [comment](https://github.com/WordPress/gutenberg/pull/16524/files#r324271407)

## How to test
- Turn on the Block Directory Experiment
- Search for a block that isn't installed & has no reviews yet, ex: `whatever`
- No "average rating" should show up in the author data
- Search for a block that isn't installed & has reviews, ex: `streamshare`
- It should show average author rating

## Screenshots 

No reviews:
![Screen Shot 2020-05-07 at 1 23 00 PM](https://user-images.githubusercontent.com/541093/81325954-18c7cd00-9067-11ea-9611-08ad1df5514c.png)

With reviews:
![Screen Shot 2020-05-07 at 1 33 52 PM](https://user-images.githubusercontent.com/541093/81326150-67756700-9067-11ea-99b8-3abe28945ec5.png)
