### PR TITLE
Writing flow: Copy whole block if no text is selected

### DIFF
--- a/docs/designers-developers/developers/data/data-core-block-editor.md
+++ b/docs/designers-developers/developers/data/data-core-block-editor.md
@@ -972,6 +972,15 @@ _Returns_
 
 -   `Object`: Action object.
 
+<a name="flashBlock" href="#flashBlock">#</a> **flashBlock**
+
+Yields action objects used in signalling that the block corresponding to the
+given clientId should appear to "flash" by rhythmically highlighting it.
+
+_Parameters_
+
+-   _clientId_ `string`: Target block client ID.
+
 <a name="hideInsertionPoint" href="#hideInsertionPoint">#</a> **hideInsertionPoint**
 
 Returns an action object hiding the insertion point.

--- a/packages/block-editor/src/components/copy-handler/index.js
+++ b/packages/block-editor/src/components/copy-handler/index.js
@@ -3,7 +3,7 @@
  */
 import { useRef } from '@wordpress/element';
 import { serialize, pasteHandler } from '@wordpress/blocks';
-import { documentHasTextSelection } from '@wordpress/dom';
+import { documentHasSelection, documentHasTextSelection } from '@wordpress/dom';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { _n, sprintf } from '@wordpress/i18n';
 
@@ -37,9 +37,18 @@ function CopyHandler( { children } ) {
 		}
 
 		// Always handle multiple selected blocks.
-		// Let native copy behaviour take over in input fields.
-		if ( ! hasMultiSelection() && documentHasTextSelection() ) {
-			return;
+		if ( ! hasMultiSelection() ) {
+			// If copying, only consider actual text selection as selection.
+			// Otherwise, any focus on an input field is considered.
+			const hasSelection =
+				event.type === 'copy' || event.type === 'cut'
+					? documentHasTextSelection()
+					: documentHasSelection();
+
+			// Let native copy behaviour take over in input fields.
+			if ( hasSelection ) {
+				return;
+			}
 		}
 
 		if ( ! containerRef.current.contains( event.target ) ) {

--- a/packages/block-editor/src/components/copy-handler/index.js
+++ b/packages/block-editor/src/components/copy-handler/index.js
@@ -3,8 +3,9 @@
  */
 import { useRef } from '@wordpress/element';
 import { serialize, pasteHandler } from '@wordpress/blocks';
-import { documentHasSelection } from '@wordpress/dom';
+import { documentHasTextSelection } from '@wordpress/dom';
 import { useDispatch, useSelect } from '@wordpress/data';
+import { _n, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -22,6 +23,7 @@ function CopyHandler( { children } ) {
 	} = useSelect( ( select ) => select( 'core/block-editor' ), [] );
 
 	const { removeBlocks, replaceBlocks } = useDispatch( 'core/block-editor' );
+	const { createSuccessNotice } = useDispatch( 'core/notices' );
 
 	const {
 		__experimentalCanUserUseUnfilteredHTML: canUserUseUnfilteredHTML,
@@ -36,7 +38,7 @@ function CopyHandler( { children } ) {
 
 		// Always handle multiple selected blocks.
 		// Let native copy behaviour take over in input fields.
-		if ( ! hasMultiSelection() && documentHasSelection() ) {
+		if ( ! hasMultiSelection() && documentHasTextSelection() ) {
 			return;
 		}
 
@@ -46,6 +48,20 @@ function CopyHandler( { children } ) {
 		event.preventDefault();
 
 		if ( event.type === 'copy' || event.type === 'cut' ) {
+			createSuccessNotice(
+				sprintf(
+					// Translators: Number of blocks being copied
+					_n(
+						'Copied %d block to clipboard',
+						'Copied %d blocks to clipboard',
+						selectedBlockClientIds.length
+					),
+					selectedBlockClientIds.length
+				),
+				{
+					type: 'snackbar',
+				}
+			);
 			const blocks = getBlocksByClientId( selectedBlockClientIds );
 			const serialized = serialize( blocks );
 

--- a/packages/block-editor/src/components/copy-handler/index.js
+++ b/packages/block-editor/src/components/copy-handler/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useCallback, useEffect, useRef } from '@wordpress/element';
+import { useCallback, useRef } from '@wordpress/element';
 import { serialize, pasteHandler } from '@wordpress/blocks';
 import { documentHasSelection, documentHasTextSelection } from '@wordpress/dom';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -11,29 +11,6 @@ import { __, sprintf } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { getPasteEventData } from '../../utils/get-paste-event-data';
-
-function useFlashBlock() {
-	const { toggleBlockHighlight } = useDispatch( 'core/block-editor' );
-	const timeouts = useRef( [] );
-	const flashBlock = useCallback(
-		( clientId ) => {
-			toggleBlockHighlight( clientId, true );
-			const timeout = setTimeout( () => {
-				toggleBlockHighlight( clientId, false );
-			}, 150 );
-			timeouts.current.push( timeout );
-		},
-		[ toggleBlockHighlight ]
-	);
-	useEffect( () => {
-		return () => {
-			timeouts.current.forEach( ( timeout ) => {
-				clearTimeout( timeout );
-			} );
-		};
-	}, [] );
-	return flashBlock;
-}
 
 function useNotifyCopy() {
 	const { getBlockName } = useSelect(
@@ -93,9 +70,10 @@ function CopyHandler( { children } ) {
 		getSettings,
 	} = useSelect( ( select ) => select( 'core/block-editor' ), [] );
 
-	const { removeBlocks, replaceBlocks } = useDispatch( 'core/block-editor' );
+	const { flashBlock, removeBlocks, replaceBlocks } = useDispatch(
+		'core/block-editor'
+	);
 
-	const flashBlock = useFlashBlock();
 	const notifyCopy = useNotifyCopy();
 
 	const {

--- a/packages/block-editor/src/components/copy-handler/index.js
+++ b/packages/block-editor/src/components/copy-handler/index.js
@@ -20,7 +20,7 @@ function useFlashBlock() {
 			toggleBlockHighlight( clientId, true );
 			const timeout = setTimeout( () => {
 				toggleBlockHighlight( clientId, false );
-			}, 1000 );
+			}, 150 );
 			timeouts.current.push( timeout );
 		},
 		[ toggleBlockHighlight ]
@@ -55,12 +55,12 @@ function useNotifyCopy() {
 				eventType === 'copy'
 					? sprintf(
 							// Translators: Name of the block being copied, e.g. "Paragraph"
-							__( 'Copied block "%s" to clipboard.' ),
+							__( 'Copied "%s" to clipboard.' ),
 							title
 					  )
 					: sprintf(
 							// Translators: Name of the block being cut, e.g. "Paragraph"
-							__( 'Cut block "%s" to clipboard.' ),
+							__( 'Moved "%s" to clipboard.' ),
 							title
 					  );
 		} else {
@@ -73,7 +73,7 @@ function useNotifyCopy() {
 					  )
 					: sprintf(
 							// Translators: Number of blocks being cut
-							__( 'Cut %d blocks to clipboard.' ),
+							__( 'Moved %d blocks to clipboard.' ),
 							selectedBlockClientIds.length
 					  );
 		}

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1012,6 +1012,21 @@ export function toggleBlockHighlight( clientId, isHighlighted ) {
 }
 
 /**
+ * Yields action objects used in signalling that the block corresponding to the
+ * given clientId should appear to "flash" by rhythmically highlighting it.
+ *
+ * @param {string} clientId Target block client ID.
+ */
+export function* flashBlock( clientId ) {
+	yield toggleBlockHighlight( clientId, true );
+	yield {
+		type: 'SLEEP',
+		duration: 150,
+	};
+	yield toggleBlockHighlight( clientId, false );
+}
+
+/**
  * Returns an action object that sets whether the block has controlled innerblocks.
  *
  * @param {string} clientId The block's clientId.

--- a/packages/block-editor/src/store/controls.js
+++ b/packages/block-editor/src/store/controls.js
@@ -27,6 +27,11 @@ const controls = {
 			return registry.select( storeName )[ selectorName ]( ...args );
 		}
 	),
+	SLEEP( { duration } ) {
+		return new Promise( ( resolve ) => {
+			setTimeout( resolve, duration );
+		} );
+	},
 };
 
 export default controls;

--- a/packages/dom/CHANGELOG.md
+++ b/packages/dom/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Feature
+
+- Add `documentHasTextSelection` to inquire specifically about ranges of selected text, in addition to the existing `documentHasSelection`.
+
 ## 2.1.0 (2019-03-06)
 
 ### Bug Fix

--- a/packages/dom/README.md
+++ b/packages/dom/README.md
@@ -24,8 +24,16 @@ _Returns_
 
 <a name="documentHasSelection" href="#documentHasSelection">#</a> **documentHasSelection**
 
-Check wether the current document has a selection.
-This checks both for focus in an input field and general text selection.
+Check whether the current document has a selection. This checks for both
+focus in an input field and general text selection.
+
+_Returns_
+
+-   `boolean`: True if there is selection, false if not.
+
+<a name="documentHasTextSelection" href="#documentHasTextSelection">#</a> **documentHasTextSelection**
+
+Check whether the current document has selected text.
 
 _Returns_
 

--- a/packages/dom/src/dom.js
+++ b/packages/dom/src/dom.js
@@ -484,24 +484,28 @@ export function isNumberInput( element ) {
 }
 
 /**
- * Check wether the current document has a selection.
- * This checks both for focus in an input field and general text selection.
+ * Check whether the current document has selected text.
+ *
+ * @return {boolean} True if there is selection, false if not.
+ */
+export function documentHasTextSelection() {
+	const selection = window.getSelection();
+	const range = selection.rangeCount ? selection.getRangeAt( 0 ) : null;
+	return range && ! range.collapsed;
+}
+
+/**
+ * Check whether the current document has a selection. This checks for both
+ * focus in an input field and general text selection.
  *
  * @return {boolean} True if there is selection, false if not.
  */
 export function documentHasSelection() {
-	if ( isTextField( document.activeElement ) ) {
-		return true;
-	}
-
-	if ( isNumberInput( document.activeElement ) ) {
-		return true;
-	}
-
-	const selection = window.getSelection();
-	const range = selection.rangeCount ? selection.getRangeAt( 0 ) : null;
-
-	return range && ! range.collapsed;
+	return (
+		isTextField( document.activeElement ) ||
+		isNumberInput( document.activeElement ) ||
+		documentHasTextSelection()
+	);
 }
 
 /**

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/copy-cut-paste-whole-blocks.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/copy-cut-paste-whole-blocks.test.js.snap
@@ -1,0 +1,73 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Multi-block selection should copy and paste individual blocks 1`] = `
+"<!-- wp:paragraph -->
+<p>Here is a unique string so we can test copying.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>2</p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`Multi-block selection should copy and paste individual blocks 2`] = `
+"<!-- wp:paragraph -->
+<p>Here is a unique string so we can test copying.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>2</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Here is a unique string so we can test copying.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p></p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`Multi-block selection should cut and paste individual blocks 1`] = `
+"<!-- wp:paragraph -->
+<p>2</p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`Multi-block selection should cut and paste individual blocks 2`] = `
+"<!-- wp:paragraph -->
+<p>2</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Yet another unique string.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p></p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`Multi-block selection should respect inline copy when text is selected 1`] = `
+"<!-- wp:paragraph -->
+<p>First block</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Second block</p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`Multi-block selection should respect inline copy when text is selected 2`] = `
+"<!-- wp:paragraph -->
+<p>First block</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>ck</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Second block</p>
+<!-- /wp:paragraph -->"
+`;

--- a/packages/e2e-tests/specs/editor/various/copy-cut-paste-whole-blocks.test.js
+++ b/packages/e2e-tests/specs/editor/various/copy-cut-paste-whole-blocks.test.js
@@ -1,0 +1,66 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	clickBlockAppender,
+	createNewPost,
+	pressKeyWithModifier,
+	getEditedPostContent,
+} from '@wordpress/e2e-test-utils';
+
+describe( 'Multi-block selection', () => {
+	beforeEach( async () => {
+		await createNewPost();
+	} );
+
+	it( 'should copy and paste individual blocks', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type(
+			'Here is a unique string so we can test copying.'
+		);
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '2' );
+		await page.keyboard.press( 'ArrowUp' );
+
+		await pressKeyWithModifier( 'primary', 'c' );
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+
+		await page.keyboard.press( 'ArrowDown' );
+		await pressKeyWithModifier( 'primary', 'v' );
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'should cut and paste individual blocks', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( 'Yet another unique string.' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '2' );
+		await page.keyboard.press( 'ArrowUp' );
+
+		await pressKeyWithModifier( 'primary', 'x' );
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'ArrowDown' );
+		await pressKeyWithModifier( 'primary', 'v' );
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'should respect inline copy when text is selected', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( 'First block' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'Second block' );
+		await page.keyboard.press( 'ArrowUp' );
+		await pressKeyWithModifier( 'shift', 'ArrowLeft' );
+		await pressKeyWithModifier( 'shift', 'ArrowLeft' );
+
+		await pressKeyWithModifier( 'primary', 'c' );
+		await page.keyboard.press( 'ArrowRight' );
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+
+		await page.keyboard.press( 'Enter' );
+		await pressKeyWithModifier( 'primary', 'v' );
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+} );


### PR DESCRIPTION
## Description

* Allow a single block to be copied or cut as a whole via the browser's _copy_ and _cut_ actions.

That is, when a single block is selected but no text is selected, copying (such as using <kbd>CTRL-C</kbd>) and cutting (<kbd>CTRL-X</kbd>) now grab the entire block. This is an extension of the behaviour that was in place for selections of multiple blocks.

Subsequently added: 
* Flash block(s) when copied.
* Show snackbar notifications for copy and cut actions, whether one or many blocks are copied.

![copy-flash-and-cut-notifications](https://user-images.githubusercontent.com/150562/81698101-6e341d80-945d-11ea-9bfb-b20781f55033.gif)

## Questions

I extended this to _cut_ (<kbd>CTRL-X</kbd>) to see how it feels. Does it make sense?

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
