### PR TITLE
Block API: Support optional block category

### DIFF
--- a/docs/designers-developers/developers/data/data-core-blocks.md
+++ b/docs/designers-developers/developers/data/data-core-blocks.md
@@ -83,7 +83,7 @@ _Parameters_
 
 _Returns_
 
--   `Array`: Categories list.
+-   `Array<WPBlockTypeCategory>`: Categories array.
 
 <a name="getChildBlockNames" href="#getChildBlockNames">#</a> **getChildBlockNames**
 

--- a/docs/designers-developers/developers/data/data-core-blocks.md
+++ b/docs/designers-developers/developers/data/data-core-blocks.md
@@ -85,6 +85,20 @@ _Returns_
 
 -   `Array<WPBlockTypeCategory>`: Categories array.
 
+<a name="getCategory" href="#getCategory">#</a> **getCategory**
+
+Returns a single category by slug. Canonicalizes category by slug, using
+internal mapping of legacy category slugs to their updated normal form.
+
+_Parameters_
+
+-   _state_ `Object`: Blocks state.
+-   _slug_ `string`: Category slug.
+
+_Returns_
+
+-   `(WPBlockTypeCategory|undefined)`: Block category, if exists.
+
 <a name="getChildBlockNames" href="#getChildBlockNames">#</a> **getChildBlockNames**
 
 Returns an array with the child blocks of a given block.

--- a/docs/designers-developers/developers/data/data-core-blocks.md
+++ b/docs/designers-developers/developers/data/data-core-blocks.md
@@ -153,6 +153,18 @@ _Returns_
 
 -   `?WPBlockVariation`: The default block variation.
 
+<a name="getDefaultCategory" href="#getDefaultCategory">#</a> **getDefaultCategory**
+
+Returns the default block category.
+
+_Parameters_
+
+-   _state_ `Object`: Blocks state.
+
+_Returns_
+
+-   `(WPBlockTypeCategory|undefined)`: Default block category.
+
 <a name="getFreeformFallbackBlockName" href="#getFreeformFallbackBlockName">#</a> **getFreeformFallbackBlockName**
 
 Returns the name of the block for handling non-block content.

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -233,3 +233,25 @@ function gutenberg_render_block_with_assigned_block_context( $pre_render, $parse
 	return $block->render();
 }
 add_filter( 'pre_render_block', 'gutenberg_render_block_with_assigned_block_context', 9, 2 );
+
+/**
+ * Appends the "Uncategorized" block category to the default set of block
+ * categories.
+ *
+ * This can be removed when plugin support requires WordPress 5.5.0+.
+ *
+ * @see Trac Ticket TBD
+ *
+ * @param array $categories Block categories.
+ *
+ * @return array Block categories with "Uncategorized" block category.
+ */
+function gutenberg_append_default_block_category( $categories ) {
+	$categories[] = array(
+		'slug'  => 'uncategorized',
+		'title' => __( 'Uncategorized' ),
+	);
+
+	return $categories;
+}
+add_filter( 'block_categories', 'gutenberg_append_default_block_category' );

--- a/packages/block-editor/src/components/inserter/block-list.js
+++ b/packages/block-editor/src/components/inserter/block-list.js
@@ -62,6 +62,7 @@ function InserterBlockList( {
 } ) {
 	const {
 		categories,
+		defaultCategory,
 		collections,
 		items,
 		rootChildBlocks,
@@ -73,6 +74,7 @@ function InserterBlockList( {
 			);
 			const {
 				getCategories,
+				getDefaultCategory,
 				getCollections,
 				getChildBlockNames,
 			} = select( 'core/blocks' );
@@ -81,6 +83,7 @@ function InserterBlockList( {
 
 			return {
 				categories: getCategories(),
+				defaultCategory: getDefaultCategory(),
 				collections: getCollections(),
 				rootChildBlocks: getChildBlockNames( rootBlockName ),
 				items: getInserterItems( rootClientId ),
@@ -209,7 +212,12 @@ function InserterBlockList( {
 
 			{ ! hasChildItems &&
 				map( categories, ( category ) => {
-					const categoryItems = itemsPerCategory[ category.slug ];
+					const categoryItems =
+						itemsPerCategory[
+							category === defaultCategory
+								? undefined
+								: category.slug
+						];
 					if ( ! categoryItems || ! categoryItems.length ) {
 						return null;
 					}

--- a/packages/blocks/CHANGELOG.md
+++ b/packages/blocks/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+- Added a new function `getCategory` to retrieve a single category object by slug.
+
 ## 6.13.0 (2020-04-01)
 
 ### New Feature

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -356,6 +356,18 @@ _Returns_
 
 -   `Array<WPBlockTypeCategory>`: Block categories.
 
+<a name="getCategory" href="#getCategory">#</a> **getCategory**
+
+Returns a single category by slug.
+
+_Parameters_
+
+-   _slug_ `string`: Category slug.
+
+_Returns_
+
+-   `(WPBlockTypeCategory|undefined)`: Block category, if exists.
+
 <a name="getChildBlockNames" href="#getChildBlockNames">#</a> **getChildBlockNames**
 
 Returns an array with the child blocks of a given block.

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -354,7 +354,7 @@ Returns all the block categories.
 
 _Returns_
 
--   `Array<Object>`: Block categories.
+-   `Array<WPBlockTypeCategory>`: Block categories.
 
 <a name="getChildBlockNames" href="#getChildBlockNames">#</a> **getChildBlockNames**
 
@@ -687,7 +687,7 @@ Sets the block categories.
 
 _Parameters_
 
--   _categories_ `Array<Object>`: Block categories.
+-   _categories_ `Array<WPBlockTypeCategory>`: Block categories.
 
 <a name="setDefaultBlockName" href="#setDefaultBlockName">#</a> **setDefaultBlockName**
 
@@ -789,7 +789,7 @@ Updates a category.
 _Parameters_
 
 -   _slug_ `string`: Block category slug.
--   _category_ `Object`: Object containing the category properties that should be updated.
+-   _category_ `WPBlockTypeCategory`: Object containing the category properties that should be updated.
 
 <a name="withBlockContentContext" href="#withBlockContentContext">#</a> **withBlockContentContext**
 

--- a/packages/blocks/src/api/categories.js
+++ b/packages/blocks/src/api/categories.js
@@ -15,6 +15,17 @@ export function getCategories() {
 }
 
 /**
+ * Returns a single category by slug.
+ *
+ * @param {string} slug Category slug.
+ *
+ * @return {WPBlockTypeCategory|undefined} Block category, if exists.
+ */
+export function getCategory( slug ) {
+	return select( 'core/blocks' ).getCategory( slug );
+}
+
+/**
  * Sets the block categories.
  *
  * @param {WPBlockTypeCategory[]} categories Block categories.

--- a/packages/blocks/src/api/categories.js
+++ b/packages/blocks/src/api/categories.js
@@ -3,10 +3,12 @@
  */
 import { dispatch, select } from '@wordpress/data';
 
+/** @typedef {import('../store/reducer').WPBlockTypeCategory} WPBlockTypeCategory */
+
 /**
  * Returns all the block categories.
  *
- * @return {Object[]} Block categories.
+ * @return {WPBlockTypeCategory[]} Block categories.
  */
 export function getCategories() {
 	return select( 'core/blocks' ).getCategories();
@@ -15,7 +17,7 @@ export function getCategories() {
 /**
  * Sets the block categories.
  *
- * @param {Object[]} categories Block categories.
+ * @param {WPBlockTypeCategory[]} categories Block categories.
  */
 export function setCategories( categories ) {
 	dispatch( 'core/blocks' ).setCategories( categories );
@@ -24,8 +26,9 @@ export function setCategories( categories ) {
 /**
  * Updates a category.
  *
- * @param {string} slug          Block category slug.
- * @param {Object} category Object containing the category properties that should be updated.
+ * @param {string}              slug     Block category slug.
+ * @param {WPBlockTypeCategory} category Object containing the category
+ *                                       properties that should be updated.
  */
 export function updateCategory( slug, category ) {
 	dispatch( 'core/blocks' ).updateCategory( slug, category );

--- a/packages/blocks/src/api/index.js
+++ b/packages/blocks/src/api/index.js
@@ -26,7 +26,12 @@ export {
 	getSaveContent,
 } from './serializer';
 export { isValidBlockContent } from './validation';
-export { getCategories, setCategories, updateCategory } from './categories';
+export {
+	getCategory,
+	getCategories,
+	setCategories,
+	updateCategory,
+} from './categories';
 export {
 	registerBlockType,
 	registerBlockCollection,

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -94,7 +94,7 @@ import { DEPRECATED_ENTRY_KEYS } from './constants';
  * @property {string}             name         Block type's namespaced name.
  * @property {string}             title        Human-readable block type label.
  * @property {string}             description  A detailed block type description.
- * @property {string}             category     Block type category classification,
+ * @property {string}             [category]   Block type category classification,
  *                                             used in search interfaces to arrange
  *                                             block types by category.
  * @property {WPBlockTypeIcon}    [icon]       Block type icon.
@@ -201,10 +201,6 @@ export function registerBlockType( name, settings ) {
 	}
 	if ( 'edit' in settings && ! isFunction( settings.edit ) ) {
 		console.error( 'The "edit" property must be a valid function.' );
-		return;
-	}
-	if ( ! ( 'category' in settings ) ) {
-		console.error( 'The block "' + name + '" must have a category.' );
 		return;
 	}
 	if (

--- a/packages/blocks/src/api/test/registration.js
+++ b/packages/blocks/src/api/test/registration.js
@@ -173,22 +173,6 @@ describe( 'blocks', () => {
 			expect( block ).toBeUndefined();
 		} );
 
-		it( 'should reject blocks without category', () => {
-			const blockType = {
-					settingName: 'settingValue',
-					save: noop,
-					title: 'block title',
-				},
-				block = registerBlockType(
-					'my-plugin/fancy-block-8',
-					blockType
-				);
-			expect( console ).toHaveErroredWith(
-				'The block "my-plugin/fancy-block-8" must have a category.'
-			);
-			expect( block ).toBeUndefined();
-		} );
-
 		it( 'should reject blocks with non registered category.', () => {
 			const blockType = {
 					save: noop,

--- a/packages/blocks/src/store/reducer.js
+++ b/packages/blocks/src/store/reducer.js
@@ -27,6 +27,16 @@ import { __ } from '@wordpress/i18n';
  */
 
 /**
+ * Default category, used in absence of any assigned category for block type.
+ *
+ * @type {WPBlockTypeCategory}
+ */
+export const DEFAULT_CATEGORY = {
+	slug: 'uncategorized',
+	title: __( 'Uncategorized' ),
+};
+
+/**
  * Default set of block type categories.
  *
  * @type {WPBlockTypeCategory[]}
@@ -38,6 +48,7 @@ export const DEFAULT_CATEGORIES = [
 	{ slug: 'widgets', title: __( 'Widgets' ) },
 	{ slug: 'embed', title: __( 'Embeds' ) },
 	{ slug: 'reusable', title: __( 'Reusable blocks' ) },
+	DEFAULT_CATEGORY,
 ];
 
 /**
@@ -238,6 +249,17 @@ export function categories( state = DEFAULT_CATEGORIES, action ) {
 	return state;
 }
 
+/**
+ * Reducer managing the default category slug.
+ *
+ * @param {string} state Current state.
+ *
+ * @return {string} Updated state.
+ */
+export function defaultCategory( state = DEFAULT_CATEGORY.slug ) {
+	return state;
+}
+
 export function collections( state = {}, action ) {
 	switch ( action.type ) {
 		case 'ADD_BLOCK_COLLECTION':
@@ -263,5 +285,6 @@ export default combineReducers( {
 	unregisteredFallbackBlockName,
 	groupingBlockName,
 	categories,
+	defaultCategory,
 	collections,
 } );

--- a/packages/blocks/src/store/reducer.js
+++ b/packages/blocks/src/store/reducer.js
@@ -20,7 +20,16 @@ import { combineReducers } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
 /**
- * Module Constants
+ * @typedef WPBlockTypeCategory
+ *
+ * @property {string} slug  Unique identifier.
+ * @property {string} title Human-readable label.
+ */
+
+/**
+ * Default set of block type categories.
+ *
+ * @type {WPBlockTypeCategory[]}
  */
 export const DEFAULT_CATEGORIES = [
 	{ slug: 'common', title: __( 'Common blocks' ) },
@@ -199,10 +208,10 @@ export const groupingBlockName = createBlockNameSetterReducer(
 /**
  * Reducer managing the categories
  *
- * @param {Object} state  Current state.
- * @param {Object} action Dispatched action.
+ * @param {WPBlockTypeCategory[]} state  Current state.
+ * @param {Object}                action Dispatched action.
  *
- * @return {Object} Updated state.
+ * @return {WPBlockTypeCategory[]} Updated state.
  */
 export function categories( state = DEFAULT_CATEGORIES, action ) {
 	switch ( action.type ) {

--- a/packages/blocks/src/store/selectors.js
+++ b/packages/blocks/src/store/selectors.js
@@ -15,8 +15,8 @@ import {
 } from 'lodash';
 
 /** @typedef {import('../api/registration').WPBlockVariation} WPBlockVariation */
-
 /** @typedef {import('../api/registration').WPBlockVariationScope} WPBlockVariationScope */
+/** @typedef {import('./reducer').WPBlockTypeCategory} WPBlockTypeCategory */
 
 /**
  * Given a block name or block type object, returns the corresponding
@@ -117,7 +117,7 @@ export function getDefaultBlockVariation( state, blockName, scope ) {
  *
  * @param {Object} state Data state.
  *
- * @return {Array} Categories list.
+ * @return {WPBlockTypeCategory[]} Categories array.
  */
 export function getCategories( state ) {
 	return state.categories;

--- a/packages/blocks/src/store/selectors.js
+++ b/packages/blocks/src/store/selectors.js
@@ -138,6 +138,17 @@ export function getCategory( state, slug ) {
 }
 
 /**
+ * Returns the default block category.
+ *
+ * @param {Object} state Blocks state.
+ *
+ * @return {WPBlockTypeCategory|undefined} Default block category.
+ */
+export function getDefaultCategory( state ) {
+	return getCategory( state, state.defaultCategory );
+}
+
+/**
  * Returns all the available collections.
  *
  * @param {Object} state Data state.
@@ -287,7 +298,7 @@ export function isMatchingSearchTerm( state, nameOrType, searchTerm ) {
 	return (
 		isSearchMatch( blockType.title ) ||
 		some( blockType.keywords, isSearchMatch ) ||
-		isSearchMatch( blockType.category )
+		Boolean( blockType.category && isSearchMatch( blockType.category ) )
 	);
 }
 

--- a/packages/blocks/src/store/selectors.js
+++ b/packages/blocks/src/store/selectors.js
@@ -12,6 +12,7 @@ import {
 	includes,
 	map,
 	some,
+	find,
 } from 'lodash';
 
 /** @typedef {import('../api/registration').WPBlockVariation} WPBlockVariation */
@@ -121,6 +122,19 @@ export function getDefaultBlockVariation( state, blockName, scope ) {
  */
 export function getCategories( state ) {
 	return state.categories;
+}
+
+/**
+ * Returns a single category by slug. Canonicalizes category by slug, using
+ * internal mapping of legacy category slugs to their updated normal form.
+ *
+ * @param {Object} state Blocks state.
+ * @param {string} slug  Category slug.
+ *
+ * @return {WPBlockTypeCategory|undefined} Block category, if exists.
+ */
+export function getCategory( state, slug ) {
+	return find( getCategories( state ), { slug } );
 }
 
 /**

--- a/packages/blocks/src/store/test/selectors.js
+++ b/packages/blocks/src/store/test/selectors.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { omit } from 'lodash';
 import deepFreeze from 'deep-freeze';
 
 /**
@@ -269,6 +270,7 @@ describe( 'selectors', () => {
 		describe.each( [
 			[ 'name', name ],
 			[ 'block type', blockType ],
+			[ 'block type without category', omit( blockType, 'category' ) ],
 		] )( 'by %s', ( label, nameOrType ) => {
 			it( 'should return false if not match', () => {
 				const result = isMatchingSearchTerm(
@@ -330,15 +332,17 @@ describe( 'selectors', () => {
 				expect( result ).toBe( true );
 			} );
 
-			it( 'should return true if match using the categories', () => {
-				const result = isMatchingSearchTerm(
-					state,
-					nameOrType,
-					'COMMON'
-				);
+			if ( nameOrType.category ) {
+				it( 'should return true if match using the categories', () => {
+					const result = isMatchingSearchTerm(
+						state,
+						nameOrType,
+						'COMMON'
+					);
 
-				expect( result ).toBe( true );
-			} );
+					expect( result ).toBe( true );
+				} );
+			}
 		} );
 	} );
 

--- a/packages/blocks/src/store/test/selectors.js
+++ b/packages/blocks/src/store/test/selectors.js
@@ -11,9 +11,19 @@ import {
 	getDefaultBlockVariation,
 	getGroupingBlockName,
 	isMatchingSearchTerm,
+	getCategories,
 } from '../selectors';
 
 describe( 'selectors', () => {
+	describe( 'getCategories', () => {
+		it( 'returns categories state', () => {
+			const categories = [ { slug: 'text', text: 'Text' } ];
+			const state = deepFreeze( { categories } );
+
+			expect( getCategories( state ) ).toEqual( categories );
+		} );
+	} );
+
 	describe( 'getChildBlockNames', () => {
 		it( 'should return an empty array if state is empty', () => {
 			const state = {};

--- a/packages/blocks/src/store/test/selectors.js
+++ b/packages/blocks/src/store/test/selectors.js
@@ -12,6 +12,7 @@ import {
 	getGroupingBlockName,
 	isMatchingSearchTerm,
 	getCategories,
+	getCategory,
 } from '../selectors';
 
 describe( 'selectors', () => {
@@ -21,6 +22,21 @@ describe( 'selectors', () => {
 			const state = deepFreeze( { categories } );
 
 			expect( getCategories( state ) ).toEqual( categories );
+		} );
+	} );
+
+	describe( 'getCategory', () => {
+		it( 'returns a single category by slug', () => {
+			const category = { slug: 'text', text: 'Text' };
+			const state = deepFreeze( { categories: [ category ] } );
+
+			expect( getCategory( state, 'text' ) ).toBe( category );
+		} );
+
+		it( 'returns undefined for a category which does not exist', () => {
+			const state = deepFreeze( { categories: [] } );
+
+			expect( getCategory( state, 'nonsense' ) ).toBe( undefined );
 		} );
 	} );
 

--- a/packages/edit-post/src/components/manage-blocks-modal/manager.js
+++ b/packages/edit-post/src/components/manage-blocks-modal/manager.js
@@ -21,6 +21,7 @@ function BlockManager( {
 	setState,
 	blockTypes,
 	categories,
+	defaultCategory,
 	hasBlockSupport,
 	isMatchingSearchTerm,
 	numberOfHiddenBlocks,
@@ -77,9 +78,14 @@ function BlockManager( {
 					<BlockManagerCategory
 						key={ category.slug }
 						category={ category }
-						blockTypes={ filter( blockTypes, {
-							category: category.slug,
-						} ) }
+						blockTypes={ filter(
+							blockTypes,
+							( blockType ) =>
+								blockType.category ===
+								( category === defaultCategory
+									? undefined
+									: category.slug )
+						) }
 					/>
 				) ) }
 			</div>
@@ -93,6 +99,7 @@ export default compose( [
 		const {
 			getBlockTypes,
 			getCategories,
+			getDefaultCategory,
 			hasBlockSupport,
 			isMatchingSearchTerm,
 		} = select( 'core/blocks' );
@@ -104,6 +111,7 @@ export default compose( [
 		return {
 			blockTypes: getBlockTypes(),
 			categories: getCategories(),
+			defaultCategory: getDefaultCategory(),
 			hasBlockSupport,
 			isMatchingSearchTerm,
 			numberOfHiddenBlocks,


### PR DESCRIPTION
Related (partially extracted from): #19279

This pull request seeks to allow for the omission of a category for a registered block type. The effort at #19279 has demonstrated a need to be able to anticipate cases where block types may be registering to categories which do not exist. The requirement of a block category can be seen as unnecessarily restrictive, especially in contrast with many other block settings which are not required (icon, etc), and in observance of the many unit tests which were difficult to implement due to the need to satisfy this arbitrary requirement.

**Note:** This is being submitted as "In Progress" in order to invite early feedback. It is largely functionally complete, but implementation details may be subject to change.

I considered that there are many ways that this could be approached:

- "Uncategorized" could be assigned at the time of block registration, so that a block type would always have a category assigned.
   - Downside: There may be value in being able to identify blocks which have no category assigned in differentiating on the value type of the category (i.e. `undefined` vs. `string`), which would not be possible if we forcibly assign a category.
   - Downside: Technically, the set of block categories can change over time. Assigning a default category during registration would not be durable to these sorts of changes, as it would only remain valid as to the default category at the time of registration. By contrast, with the current proposed implementation, combining the absence of a category and the availability of a dedicated "default category" state allows for more robustness to this scenario.
- "Uncategorized" could at least be merged into block type as part of a `getBlockType` selector.
   - This is slightly better, but still suffers mostly from the problem of not being able to differentiate category assignment by type.
- As categories are already objects (`slug`, `title`), a "default" category could be assigned by a separate property `isDefault`, so that there wouldn't need to be separate state between `categories` and `defaultCategory`.
   - Downside: In considering strong typing, ideally `isDefault` would always be assigned as a boolean, which becomes cumbersome to either normalize or require from a consumer to always pass `isDefault: false` for every non-default category.
   - Downside: There's already strong precedent for this sort of separation within the same store. See also: `defaultBlockName`.
- "Uncategorized" may not need to be an _actual_ block category, but instead handled in user interfaces where absence of category is handled.
   - This may actually be good! I'm only now considering it as I write the pull request comment. I do foresee a couple minor downsides.
   - Downside: It becomes a risk for duplication and syncing issues if each handling of the "Uncategorized" behavior needs to behave consistently. For example, both the Block Inserter and Block Manager would separately need to implement a (_hopefully_ consistent) "Uncategorized" label. "Hoping" is always a risk, and we could avoid it by treating the default category as a specially-handled case.

**Implementation Notes:**

Currently, the proposed implementation is as follows:

- "Uncategorized" is added as a new block type category.
- "Default category" becomes a new state of `core/blocks`, and can be selected by `getDefaultCategory`
- Block types can be registered without a category, and are left as `category: undefined`
- It's up to the UI implementations to handle `category: undefined` as intending to map to the default category

