### PR TITLE
Template Loader: Drop `$_wp_current_template_id`

### DIFF
--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -421,10 +421,14 @@ function gutenberg_template_loader_filter_block_editor_settings( $settings ) {
 		return $settings;
 	}
 
-	// Create template part auto-drafts for the edited post.
-	$post = isset( $settings['templateId'] )
-		? get_post( $settings['templateId'] ) // It's a template.
-		: get_post(); // It's a post.
+	// If this is the Site Editor, auto-drafts for template parts have already been generated
+	// through `gutenberg_find_template_post_and_parts` in `gutenberg_edit_site_init`.
+	if ( isset( $settings['editSiteInitialState'] ) ) {
+		return $settings;
+	}
+
+	// Otherwise, create template part auto-drafts for the edited post.
+	$post = get_post();
 	foreach ( parse_blocks( $post->post_content ) as $block ) {
 		create_auto_draft_for_template_part_block( $block );
 	}

--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -421,11 +421,9 @@ function gutenberg_template_loader_filter_block_editor_settings( $settings ) {
 		return $settings;
 	}
 
-	$current_template_id = $settings['templateId'];
-
 	// Create template part auto-drafts for the edited post.
-	$post = isset( $current_template_id )
-		? get_post( $current_template_id ) // It's a template.
+	$post = isset( $settings['templateId'] )
+		? get_post( $settings['templateId'] ) // It's a template.
 		: get_post(); // It's a post.
 	foreach ( parse_blocks( $post->post_content ) as $block ) {
 		create_auto_draft_for_template_part_block( $block );

--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -91,12 +91,11 @@ function get_template_hierarchy( $template_type ) {
  * @return string The path to the Full Site Editing template canvas file.
  */
 function gutenberg_override_query_template( $template, $type, array $templates = array() ) {
-	global $_wp_current_template_id, $_wp_current_template_content;
+	global $_wp_current_template_content;
 
 	$current_template = gutenberg_find_template_post_and_parts( $type, $templates );
 
 	if ( $current_template ) {
-		$_wp_current_template_id      = $current_template['template_post']->ID;
 		$_wp_current_template_content = empty( $current_template['template_post']->post_content ) ? __( 'Empty template.', 'gutenberg' ) : $current_template['template_post']->post_content;
 
 		if ( isset( $_GET['_wp-find-template'] ) ) {
@@ -416,15 +415,17 @@ function gutenberg_strip_php_suffix( $template_file ) {
  * @return array Filtered editor settings.
  */
 function gutenberg_template_loader_filter_block_editor_settings( $settings ) {
-	global $post, $_wp_current_template_id;
+	global $post;
 
 	if ( ! $post || ! post_type_exists( 'wp_template' ) || ! post_type_exists( 'wp_template_part' ) ) {
 		return $settings;
 	}
 
+	$current_template_id = $settings['templateId'];
+
 	// Create template part auto-drafts for the edited post.
-	$post = isset( $_wp_current_template_id )
-		? get_post( $_wp_current_template_id ) // It's a template.
+	$post = isset( $current_template_id )
+		? get_post( $current_template_id ) // It's a template.
 		: get_post(); // It's a post.
 	foreach ( parse_blocks( $post->post_content ) as $block ) {
 		create_auto_draft_for_template_part_block( $block );


### PR DESCRIPTION
## Description
Final piece of a refactor that started with #21959, #21980, and #22143.

This PR changes the `gutenberg_template_loader_filter_block_editor_settings` filter to detect if we're dealing with the Site Editor from the `$settings` array, allowing us to drop the `$_wp_current_template_id` global.

## How has this been tested?
Verify that Full Site Editing still works as before.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
