### PR TITLE
Fix flaky test: <a> tag "target" attribute.

### DIFF
--- a/packages/e2e-tests/specs/editor/various/links.test.js
+++ b/packages/e2e-tests/specs/editor/various/links.test.js
@@ -510,6 +510,11 @@ describe( 'Links', () => {
 		await page.keyboard.press( 'Tab' );
 		await page.keyboard.press( 'Enter' );
 
+		// Wait for Gutenberg to finish the job.
+		await page.waitForXPath(
+			'//a[contains(@href,"w.org") and @target="_blank"]'
+		);
+
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 
 		// Regression Test: This verifies that the UI is updated according to
@@ -545,6 +550,11 @@ describe( 'Links', () => {
 		await page.keyboard.press( 'Tab' );
 		// Uncheck the checkbox.
 		await page.keyboard.press( 'Space' );
+
+		// Wait for Gutenberg to finish the job.
+		await page.waitForXPath(
+			'//a[contains(@href,"wordpress.org") and not(@target)]'
+		);
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );


### PR DESCRIPTION
* Closes #21320

## Description

Fix a flaky test caused by a racing condition between asserting snapshot and Gutenberg's updating DOM.

This test became really less flaky since #17126. But it was still possible.

## How has this been tested?

Manually running the tests.

## Screenshots 

N/A

## Types of changes

Bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [N/A] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [N/A] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [N/A] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [N/A] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
