### PR TITLE
Fix flaky test in rich text.

### DIFF
--- a/packages/e2e-tests/specs/editor/various/rich-text.test.js
+++ b/packages/e2e-tests/specs/editor/various/rich-text.test.js
@@ -256,6 +256,9 @@ describe( 'RichText', () => {
 	it( 'should handle Home and End keys', async () => {
 		await page.keyboard.press( 'Enter' );
 
+		// Wait for rich text editor to load.
+		await page.waitForSelector( '.block-editor-rich-text__editable' );
+
 		await pressKeyWithModifier( 'primary', 'b' );
 		await page.keyboard.type( '12' );
 		await pressKeyWithModifier( 'primary', 'b' );


### PR DESCRIPTION
* Closes #22201

## Description

It seems that there's a racing condition between:

* loading a new rich text editor.
* pressing ctrl + b

I've resolved this by waiting for loading a new rich text editor. 

## How has this been tested?

Manually running it. 

## Screenshots <!-- if applicable -->

N/A

## Types of changes

Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [N/A] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [N/A] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [N/A] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [N/A] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
