### PR TITLE
Try: Remove all baseline margins.

### DIFF
--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -59,13 +59,6 @@
  * This allows us to create normalization styles that are easily overridden by editor styles.
  */
 
-// Provide every block with a default base margin. This margin provides a consistent spacing
-// between blocks in the editor.
-.block-editor-block-list__block {
-	margin-top: $default-block-margin;
-	margin-bottom: $default-block-margin;
-}
-
 // This tag marks the end of the styles that apply to editing canvas contents and need to be manipulated when we resize the editor.
 #end-resizable-editor-section {
 	display: none;

--- a/packages/editor/src/editor-styles.scss
+++ b/packages/editor/src/editor-styles.scss
@@ -96,8 +96,6 @@ h6 {
 p {
 	font-size: inherit;
 	line-height: inherit;
-	margin-top: $default-block-margin;
-	margin-bottom: $default-block-margin;
 }
 
 ul,


### PR DESCRIPTION
**This PR is a proof of concept, intended to start a conversation. It should probably not be merged as-is.**

The block editor has something we refer to as a "baseline margin". This:

```
.block-editor-block-list__block {
    margin-top: 28px;
    margin-bottom: 28px;
}
```

What it does, is add margin above and below _every single block_. The purpose is two-fold:

1. To override CSS bleed that is inherited from wp-admin.
2. To provide the vanilla editor styles with some vertical rhythm that provides a better editing experience for themes that do not provide editor styles.

**This baseline margin is editor only, it is not output on the frontend.**

There are many downsides to this baseline margin:

- It's provided to every block, including pure-layout blocks such as the _column_ block that exists inside the _columns_ block. 
- It is, for example in the case of the column block above, compensated for. This adds complexity to the block editor style CSS.
- Due to how margins can collapse, it's often hard to debug where that extra spacing comes from.

This PR tries to remove that baseline margin entirely. Before:

<img width="747" alt="before" src="https://user-images.githubusercontent.com/1204802/81383939-381b3480-9111-11ea-8bf8-9fbb0c4b4621.png">

After:

<img width="748" alt="after" src="https://user-images.githubusercontent.com/1204802/81383944-3a7d8e80-9111-11ea-8fd0-74641bca2b79.png">

Observe how in the "after" image, the margin between paragraphs is smaller. That's because now it inherits this from the Paragraph rules set by wp-admin:

<img width="316" alt="Screenshot 2020-05-08 at 09 50 19" src="https://user-images.githubusercontent.com/1204802/81384013-58e38a00-9111-11ea-82d7-85d75dd07d86.png">

In principle, this sucks, because it's a rule designed for an entirely different context. 

**So why remove the baseline margin?**

Because it will benefit themes that _do_ provide an editor style, and it will simplify the CSS that blocks have to write to work in the editor. Right now even blocks containing of a `div` elements that are born without margins, have margins applied to them by this baseline margin. 

Notably, it's means that the editor looks different from the frontend in many cases; a block that does not have a margin registered won't have margin on the frontend, but it will on the backend. 

A better example is the Cover block, which is a `div` that has no margin. Before:

<img width="698" alt="Screenshot 2020-05-08 at 09 43 06" src="https://user-images.githubusercontent.com/1204802/81384423-f17a0a00-9111-11ea-9192-4df542b5918d.png">

After:

<img width="672" alt="Screenshot 2020-05-08 at 09 42 52" src="https://user-images.githubusercontent.com/1204802/81384442-f50d9100-9111-11ea-98cd-2f1a620f9bce.png">

This might not look good in the editor, but it would be accurate to what is rendered on the frontend.

**Is there something else we can do, that allows the editor to look more like the frontend, and still provide a good baseline editing experience for themes that don't?**

A couple of ideas:

1. Iframe the editing canvas. Difficult, potentially impossible, but a proof of concept has been created: #21102 — this would at least prevent blocks from inheriting random rules set by wp-admin.
2. Provide a stylesheet that is loaded _only for the editor when no editor styles are registered_. 

1 would solve many problems with regards to front and backend consistency, but is not something we should count on landing soon, possibly ever.

2 would allow us to create a good baseline editor style when the theme doesn't provide one. It might even be an opportunity to revisit what the editor looks like without editor styles — Noto Serif hasn't aged well.

Penny for your thoughts?