### PR TITLE
Group: Zero out the intrinsic margin set to the Group block

### DIFF
--- a/packages/block-library/src/group/editor.scss
+++ b/packages/block-library/src/group/editor.scss
@@ -2,7 +2,7 @@
  * Group: All Alignment Settings
  */
 
-.wp-block[data-type="core/group"] {
+.wp-block-group {
 	// Zero out the baseline margin that is set for every block in the editor.
 	margin-top: 0;
 	margin-bottom: 0;

--- a/packages/block-library/src/group/editor.scss
+++ b/packages/block-library/src/group/editor.scss
@@ -1,7 +1,11 @@
 /**
  * Group: All Alignment Settings
  */
+
 .wp-block[data-type="core/group"] {
+	// Zero out the baseline margin that is set for every block in the editor.
+	margin-top: 0;
+	margin-bottom: 0;
 
 	// Ensure not rendering outside the element
 	// as -1px causes overflow-x scrollbars


### PR DESCRIPTION
This PR is a much smaller alternative to #22208. It sets the top and bottom margin of a group block to zero, in the editor only, to unset the margins that are otherwise inherited by the baseline margin that every block in the editor has.

This helps a great deal for when people create block patterns, where you might have several groups in a row, that should not have additional margin above and below.

Important also to remember that the margins of contents inside the group can still "bleed out" of the group, and even collapse with adjacent margins.

It would be nice to not have to unset these margins, and simply not have any margins in the first place. But per the discussions in #22208 removing those is nontrivial.

Editor, before:

<img width="524" alt="before editor" src="https://user-images.githubusercontent.com/1204802/81385883-664e4380-9114-11ea-8326-4c26c9edf970.png">

Editor: after, after:

<img width="623" alt="after editor" src="https://user-images.githubusercontent.com/1204802/81385895-6c442480-9114-11ea-9f68-e4cc8194ea17.png">

Frontend before:

<img width="614" alt="before frontend" src="https://user-images.githubusercontent.com/1204802/81385905-6f3f1500-9114-11ea-9c4f-7f8179423ba8.png">

Frontend, after:

<img width="691" alt="after frontend" src="https://user-images.githubusercontent.com/1204802/81385923-736b3280-9114-11ea-902e-42379dc9c7e3.png">

2 appenders in a row before:

<img width="724" alt="before" src="https://user-images.githubusercontent.com/1204802/81385935-7b2ad700-9114-11ea-8975-4b9a895c1633.png">

After:

<img width="678" alt="after" src="https://user-images.githubusercontent.com/1204802/81385946-7d8d3100-9114-11ea-81ba-78c50e72360a.png">
