### PR TITLE
Allow editing of new menu items from the block inspector

### DIFF
--- a/packages/block-editor/src/components/block-navigation/block-contents.js
+++ b/packages/block-editor/src/components/block-navigation/block-contents.js
@@ -96,51 +96,41 @@ const BlockNavigationBlockSelectButton = forwardRef( ( props, ref ) => (
 
 const getSlotName = ( clientId ) => `BlockNavigationBlock-${ clientId }`;
 
-const BlockNavigationBlockSlot = forwardRef(
-	(
-		{ block, isSelected, onClick, position, siblingCount, level, ...props },
-		ref
-	) => {
-		const { clientId } = block;
+const noop = () => null;
+const BlockNavigationBlockSlot = forwardRef( ( props, ref ) => {
+	const { clientId } = props.block;
 
-		return (
-			<Slot name={ getSlotName( clientId ) }>
-				{ ( fills ) => {
-					if ( ! fills.length ) {
-						return (
-							<BlockNavigationBlockSelectButton
-								ref={ ref }
-								block={ block }
-								onClick={ onClick }
-								isSelected={ isSelected }
-								position={ position }
-								siblingCount={ siblingCount }
-								level={ level }
-								{ ...props }
-							/>
-						);
-					}
-
+	return (
+		<Slot name={ getSlotName( clientId ) }>
+			{ ( fills ) => {
+				if ( ! fills.length ) {
 					return (
-						<BlockNavigationBlockContentWrapper as="div">
-							{ Children.map( fills, ( fill ) =>
-								cloneElement( fill, {
-									...{
-										block,
-										isSelected,
-										onClick,
-										...props,
-									},
-									...fill.props,
-								} )
-							) }
-						</BlockNavigationBlockContentWrapper>
+						<BlockNavigationBlockSelectButton
+							ref={ ref }
+							{ ...props }
+						/>
 					);
-				} }
-			</Slot>
-		);
-	}
-);
+				}
+
+				return (
+					<BlockNavigationBlockContentWrapper
+						as="div"
+						{ ...props }
+						// Fills should implement onClick on their own
+						onClick={ noop }
+					>
+						{ Children.map( fills, ( fill ) =>
+							cloneElement( fill, {
+								...{ props },
+								...fill.props,
+							} )
+						) }
+					</BlockNavigationBlockContentWrapper>
+				);
+			} }
+		</Slot>
+	);
+} );
 
 export const BlockNavigationBlockFill = ( props ) => {
 	const { clientId } = useContext( BlockListBlockContext );

--- a/packages/block-editor/src/components/block-navigation/editor.js
+++ b/packages/block-editor/src/components/block-navigation/editor.js
@@ -13,7 +13,6 @@ export default function BlockNavigationEditor( { value, onChange } ) {
 	return (
 		<BlockNavigationBlockFill>
 			<RichText
-				className="wp-block-navigation-link__label"
 				value={ value }
 				onChange={ onChange }
 				placeholder={ __( 'Navigation item' ) }

--- a/packages/block-editor/src/components/block-navigation/editor.js
+++ b/packages/block-editor/src/components/block-navigation/editor.js
@@ -1,0 +1,31 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { RichText } from '../';
+import { BlockNavigationBlockFill } from './block-contents';
+
+export default function BlockNavigationEditor( { value, onChange } ) {
+	return (
+		<BlockNavigationBlockFill>
+			<RichText
+				className="wp-block-navigation-link__label"
+				value={ value }
+				onChange={ onChange }
+				placeholder={ __( 'Navigation item' ) }
+				keepPlaceholderOnFocus
+				withoutInteractiveFormatting
+				allowedFormats={ [
+					'core/bold',
+					'core/italic',
+					'core/image',
+					'core/strikethrough',
+				] }
+			/>
+		</BlockNavigationBlockFill>
+	);
+}

--- a/packages/block-editor/src/components/block-styles/index.js
+++ b/packages/block-editor/src/components/block-styles/index.js
@@ -77,7 +77,7 @@ const useGenericPreviewBlock = ( block, type ) =>
 						innerBlocks: type.example.innerBlocks,
 				  } )
 				: cloneBlock( block ),
-		[ block, type ]
+		[ type.example ? block.name : block, type ]
 	);
 
 function BlockStyles( { clientId, onSwitch = noop, onHoverClassName = noop } ) {

--- a/packages/block-editor/src/components/block-styles/index.js
+++ b/packages/block-editor/src/components/block-styles/index.js
@@ -77,7 +77,7 @@ const useGenericPreviewBlock = ( block, type ) =>
 						innerBlocks: type.example.innerBlocks,
 				  } )
 				: cloneBlock( block ),
-		[ type.example ? block.name : block, type ]
+		[ block, type ]
 	);
 
 function BlockStyles( { clientId, onSwitch = noop, onHoverClassName = noop } ) {

--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -18,6 +18,7 @@ export { default as BlockFormatControls } from './block-format-controls';
 export { default as BlockIcon } from './block-icon';
 export { default as BlockNavigationDropdown } from './block-navigation/dropdown';
 export { BlockNavigationBlockFill as __experimentalBlockNavigationBlockFill } from './block-navigation/block-contents';
+export { default as __experimentalBlockNavigationEditor } from './block-navigation/editor';
 export { default as __experimentalBlockNavigationTree } from './block-navigation/tree';
 export { default as __experimentalBlockVariationPicker } from './block-variation-picker';
 export { default as BlockVerticalAlignmentToolbar } from './block-vertical-alignment-toolbar';

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -29,8 +29,7 @@ import {
 	RichText,
 	__experimentalLinkControl as LinkControl,
 	__experimentalBlock as Block,
-	__experimentalBlockNavigationListItem as BlockNavigationListItem,
-	__experimentalBlockNavigationListItemFill as BlockNavigationListItemFill,
+	__experimentalBlockNavigationEditor as BlockNavigationEditor,
 } from '@wordpress/block-editor';
 import { isURL, prependHTTP } from '@wordpress/url';
 import {
@@ -38,7 +37,6 @@ import {
 	useState,
 	useEffect,
 	useRef,
-	cloneElement,
 } from '@wordpress/element';
 import { placeCaretAtHorizontalEdge } from '@wordpress/dom';
 import { link as linkIcon } from '@wordpress/icons';
@@ -47,8 +45,6 @@ import { link as linkIcon } from '@wordpress/icons';
  * Internal dependencies
  */
 import { ToolbarSubmenuIcon, ItemSubmenuIcon } from './icons';
-
-const noop = () => {};
 
 function NavigationLinkEdit( {
 	attributes,
@@ -141,25 +137,6 @@ function NavigationLinkEdit( {
 		};
 	}
 
-	const editField = (
-		<RichText
-			className="wp-block-navigation-link__label"
-			value={ label }
-			onChange={ ( labelValue ) =>
-				setAttributes( { label: labelValue } )
-			}
-			placeholder={ itemLabelPlaceholder }
-			keepPlaceholderOnFocus
-			withoutInteractiveFormatting
-			allowedFormats={ [
-				'core/bold',
-				'core/italic',
-				'core/image',
-				'core/strikethrough',
-			] }
-		/>
-	);
-
 	return (
 		<Fragment>
 			<BlockControls>
@@ -224,14 +201,12 @@ function NavigationLinkEdit( {
 					/>
 				</PanelBody>
 			</InspectorControls>
-			<BlockNavigationListItemFill>
-				<BlockNavigationListItem
-					wrapperComponent="div"
-					onClick={ noop }
-				>
-					{ editField }
-				</BlockNavigationListItem>
-			</BlockNavigationListItemFill>
+			<BlockNavigationEditor
+				value={ label }
+				onChange={ ( labelValue ) =>
+					setAttributes( { label: labelValue } )
+				}
+			/>
 			<Block.li
 				className={ classnames( {
 					'is-editing': isSelected || isParentOfSelectedBlock,
@@ -249,7 +224,23 @@ function NavigationLinkEdit( {
 				} }
 			>
 				<div className="wp-block-navigation-link__content">
-					{ cloneElement( editField, { ref } ) }
+					<RichText
+						ref={ ref }
+						className="wp-block-navigation-link__label"
+						value={ label }
+						onChange={ ( labelValue ) =>
+							setAttributes( { label: labelValue } )
+						}
+						placeholder={ itemLabelPlaceholder }
+						keepPlaceholderOnFocus
+						withoutInteractiveFormatting
+						allowedFormats={ [
+							'core/bold',
+							'core/italic',
+							'core/image',
+							'core/strikethrough',
+						] }
+					/>
 					{ isLinkOpen && (
 						<Popover
 							position="bottom center"

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -29,9 +29,17 @@ import {
 	RichText,
 	__experimentalLinkControl as LinkControl,
 	__experimentalBlock as Block,
+	__experimentalBlockNavigationListItem as BlockNavigationListItem,
+	__experimentalBlockNavigationListItemFill as BlockNavigationListItemFill,
 } from '@wordpress/block-editor';
 import { isURL, prependHTTP } from '@wordpress/url';
-import { Fragment, useState, useEffect, useRef } from '@wordpress/element';
+import {
+	Fragment,
+	useState,
+	useEffect,
+	useRef,
+	cloneElement,
+} from '@wordpress/element';
 import { placeCaretAtHorizontalEdge } from '@wordpress/dom';
 import { link as linkIcon } from '@wordpress/icons';
 
@@ -39,6 +47,8 @@ import { link as linkIcon } from '@wordpress/icons';
  * Internal dependencies
  */
 import { ToolbarSubmenuIcon, ItemSubmenuIcon } from './icons';
+
+const noop = () => {};
 
 function NavigationLinkEdit( {
 	attributes,
@@ -131,6 +141,25 @@ function NavigationLinkEdit( {
 		};
 	}
 
+	const editField = (
+		<RichText
+			className="wp-block-navigation-link__label"
+			value={ label }
+			onChange={ ( labelValue ) =>
+				setAttributes( { label: labelValue } )
+			}
+			placeholder={ itemLabelPlaceholder }
+			keepPlaceholderOnFocus
+			withoutInteractiveFormatting
+			allowedFormats={ [
+				'core/bold',
+				'core/italic',
+				'core/image',
+				'core/strikethrough',
+			] }
+		/>
+	);
+
 	return (
 		<Fragment>
 			<BlockControls>
@@ -195,6 +224,14 @@ function NavigationLinkEdit( {
 					/>
 				</PanelBody>
 			</InspectorControls>
+			<BlockNavigationListItemFill>
+				<BlockNavigationListItem
+					wrapperComponent="div"
+					onClick={ noop }
+				>
+					{ editField }
+				</BlockNavigationListItem>
+			</BlockNavigationListItemFill>
 			<Block.li
 				className={ classnames( {
 					'is-editing': isSelected || isParentOfSelectedBlock,
@@ -212,23 +249,7 @@ function NavigationLinkEdit( {
 				} }
 			>
 				<div className="wp-block-navigation-link__content">
-					<RichText
-						ref={ ref }
-						className="wp-block-navigation-link__label"
-						value={ label }
-						onChange={ ( labelValue ) =>
-							setAttributes( { label: labelValue } )
-						}
-						placeholder={ itemLabelPlaceholder }
-						keepPlaceholderOnFocus
-						withoutInteractiveFormatting
-						allowedFormats={ [
-							'core/bold',
-							'core/italic',
-							'core/image',
-							'core/strikethrough',
-						] }
-					/>
+					{ cloneElement( editField, { ref } ) }
 					{ isLinkOpen && (
 						<Popover
 							position="bottom center"

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -32,12 +32,7 @@ import {
 	__experimentalBlockNavigationEditor as BlockNavigationEditor,
 } from '@wordpress/block-editor';
 import { isURL, prependHTTP } from '@wordpress/url';
-import {
-	Fragment,
-	useState,
-	useEffect,
-	useRef,
-} from '@wordpress/element';
+import { Fragment, useState, useEffect, useRef } from '@wordpress/element';
 import { placeCaretAtHorizontalEdge } from '@wordpress/dom';
 import { link as linkIcon } from '@wordpress/icons';
 


### PR DESCRIPTION
## Description

This is a follow-up to https://github.com/WordPress/gutenberg/pull/21948
Fixes https://github.com/WordPress/gutenberg/issues/20748.

It plugs RichText editor into those slots `navigation-link/edit.js`. As a result, it's possible to edit the label from the `BlockNavigationList` itself.

## How has this been tested?

1. Apply this PR and https://github.com/WordPress/gutenberg/pull/22355

### On experimental nav-menus page:

1. Go to `/wp-admin/admin.php?page=gutenberg-navigation`
1. Edit the text from the navigation structure panel like on the gif below:

1. Try with both top-level and nested navigation items

### In posts editor:

1. Go to posts > add new
1. Add navigation block with some nested items
1. Try editing titles through the navigator in block inspector (slow! performance fix: #21973):
<img width="840" alt="Zrzut ekranu 2020-04-29 o 13 35 11" src="https://user-images.githubusercontent.com/205419/80591654-53ee4e80-8a1e-11ea-882e-774f5cc6700f.png">

1. Make sure to use rich formatting like pressing enter or using keyboard shortcuts (e.g. cmd+b on mac to bold selected text).

1. Try editing titles through the navigator in modal:
<img width="847" alt="Zrzut ekranu 2020-04-29 o 13 35 17" src="https://user-images.githubusercontent.com/205419/80591648-52248b00-8a1e-11ea-96d8-725b9b41bba1.png">

1. Confirm global block navigation remains non-editable and only allows block selection on click:

<img width="752" alt="Zrzut ekranu 2020-04-29 o 13 36 15" src="https://user-images.githubusercontent.com/205419/80591719-72544a00-8a1e-11ea-8c9b-152867159ab0.png">

## Screenshots
![2020-04-28 16-01-11 2020-04-28 16_01_34](https://user-images.githubusercontent.com/205419/80496483-8ee27a80-8969-11ea-835a-f84b445d807d.gif)

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
