### PR TITLE
Fix: Invalid property value

### DIFF
--- a/packages/block-library/src/buttons/style.scss
+++ b/packages/block-library/src/buttons/style.scss
@@ -6,7 +6,7 @@
 }
 
 .wp-block-buttons.alignright .wp-block-button {
-	margin-right: none;
+	margin-right: 0;
 	margin-left: $grid-unit-10;
 }
 


### PR DESCRIPTION


## Description
The margin-right property was hardcoded with an invalid value of "none".
I've changed this value to 0.