### PR TITLE
Block: move new props to hook

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -39,7 +39,6 @@ function BlockListBlock( {
 	isLocked,
 	clientId,
 	rootClientId,
-	isHighlighted,
 	isSelected,
 	isMultiSelected,
 	isPartOfMultiSelection,
@@ -66,9 +65,13 @@ function BlockListBlock( {
 	// In addition to withSelect, we should favor using useSelect in this
 	// component going forward to avoid leaking new props to the public API
 	// (editor.BlockListBlock filter)
-	const { isDraggingBlocks } = useSelect( ( select ) => {
+	const { isDragging, isHighlighted } = useSelect( ( select ) => {
+		const { isDraggingBlocks, isBlockHighlighted } = select(
+			'core/block-editor'
+		);
 		return {
-			isDraggingBlocks: select( 'core/block-editor' ).isDraggingBlocks(),
+			isDragging: isDraggingBlocks(),
+			isHighlighted: isBlockHighlighted( clientId ),
 		};
 	}, [] );
 
@@ -83,8 +86,6 @@ function BlockListBlock( {
 		false
 	);
 	const isUnregisteredBlock = name === getUnregisteredTypeHandlerName();
-	const isDragging =
-		isDraggingBlocks && ( isSelected || isPartOfMultiSelection );
 
 	// Determine whether the block has props to apply to the wrapper.
 	if ( blockType.getEditWrapperProps ) {
@@ -113,7 +114,8 @@ function BlockListBlock( {
 			'is-highlighted': isHighlighted,
 			'is-multi-selected': isMultiSelected,
 			'is-reusable': isReusableBlock( blockType ),
-			'is-dragging': isDragging,
+			'is-dragging':
+				isDragging && ( isSelected || isPartOfMultiSelection ),
 			'is-typing': isTypingWithinBlock,
 			'is-focused':
 				isFocusMode && ( isSelected || isAncestorOfSelectedBlock ),
@@ -219,7 +221,6 @@ const applyWithSelect = withSelect(
 			getTemplateLock,
 			__unstableGetBlockWithoutInnerBlocks,
 			isNavigationMode,
-			isBlockHighlighted,
 		} = select( 'core/block-editor' );
 		const block = __unstableGetBlockWithoutInnerBlocks( clientId );
 		const isSelected = isBlockSelected( clientId );
@@ -239,8 +240,9 @@ const applyWithSelect = withSelect(
 		// is not correct.
 		const { name, attributes, isValid } = block || {};
 
+		// Do not add new properties here, use `useDispatch` instead to avoid
+		// leaking new props to the public API (editor.BlockListBlock filter).
 		return {
-			isHighlighted: isBlockHighlighted( clientId ),
 			isMultiSelected: isBlockMultiSelected( clientId ),
 			isPartOfMultiSelection:
 				isBlockMultiSelected( clientId ) ||
@@ -287,6 +289,8 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps, { select } ) => {
 		__unstableMarkLastChangeAsPersistent,
 	} = dispatch( 'core/block-editor' );
 
+	// Do not add new properties here, use `useDispatch` instead to avoid
+	// leaking new props to the public API (editor.BlockListBlock filter).
 	return {
 		setAttributes( newAttributes ) {
 			const { clientId } = ownProps;

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -240,7 +240,7 @@ const applyWithSelect = withSelect(
 		// is not correct.
 		const { name, attributes, isValid } = block || {};
 
-		// Do not add new properties here, use `useDispatch` instead to avoid
+		// Do not add new properties here, use `useSelect` instead to avoid
 		// leaking new props to the public API (editor.BlockListBlock filter).
 		return {
 			isMultiSelected: isBlockMultiSelected( clientId ),


### PR DESCRIPTION
## Description

In #20938 a new props was added to the block component, but this should be avoided because any prop added becomes part of the public API through the block component filter. Instead, it's better to use the data hooks.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
