### PR TITLE
Try: Remove canvas padding.

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -694,31 +694,3 @@
 .is-dragging-components-draggable .components-tooltip {
 	display: none;
 }
-
-
-// Add side padding for the canvas, currently edit-post-visual-editor.
-// The purpose of this padding is to ensure that on small viewports, there is
-// room for the block border that sits 14px ($block-padding) offset from the
-// block footprint.
-// These paddings and margins are removed from the BlockPreview component's style
-// Any change need to be reflected there.
-.block-editor-block-list__layout.is-root-container {
-	padding-left: $block-padding;
-	padding-right: $block-padding;
-
-	@include break-small() {
-		padding-left: $block-side-ui-width;
-		padding-right: $block-side-ui-width;
-	}
-
-	// Full-wide. (to account for the paddings added above)
-	> .wp-block[data-align="full"] {
-		margin-left: -$block-padding;
-		margin-right: -$block-padding;
-
-		@include break-small() {
-			margin-left: -$block-side-ui-width;
-			margin-right: -$block-side-ui-width;
-		}
-	}
-}

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/rtl.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/rtl.test.js.snap
@@ -8,11 +8,11 @@ exports[`RTL should arrow navigate 1`] = `
 
 exports[`RTL should arrow navigate between blocks 1`] = `
 "<!-- wp:paragraph -->
-<p>٠<br>١</p>
+<p>٠</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>٠<br>١<br>٢</p>
+<p><br>١١٠<br><br>٢</p>
 <!-- /wp:paragraph -->"
 `;
 
@@ -24,7 +24,11 @@ exports[`RTL should merge backward 1`] = `
 
 exports[`RTL should merge forward 1`] = `
 "<!-- wp:paragraph -->
-<p>٠١</p>
+<p>٠</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p></p>
 <!-- /wp:paragraph -->"
 `;
 

--- a/packages/e2e-tests/specs/editor/various/typewriter.test.js
+++ b/packages/e2e-tests/specs/editor/various/typewriter.test.js
@@ -21,6 +21,9 @@ describe( 'TypeWriter', () => {
 		// Create first block.
 		await page.keyboard.press( 'Enter' );
 
+		// Create second block.
+		await page.keyboard.press( 'Enter' );
+
 		const initialPosition = await getCaretPosition();
 
 		// The page shouldn't be scrolled when it's being filled.
@@ -118,7 +121,10 @@ describe( 'TypeWriter', () => {
 		await page.keyboard.press( 'Enter' );
 		// Create second block.
 		await page.keyboard.press( 'Enter' );
+		// Create third block.
+		await page.keyboard.press( 'Enter' );
 		// Move to first block.
+		await page.keyboard.press( 'ArrowUp' );
 		await page.keyboard.press( 'ArrowUp' );
 
 		const initialPosition = await getCaretPosition();

--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -45,19 +45,10 @@
 	height: 0;
 }
 
-// Ideally this wrapper div is not needed but if we waant to match the positionning of blocks
+// Ideally this wrapper div is not needed but if we want to match the positioning of blocks
 // .block-editor-block-list__layout and block-editor-block-list__block
 // We need to have two DOM elements.
 .edit-post-visual-editor__post-title-wrapper {
-	// This padding is needed to match the block root container padding
-	padding-left: $block-padding;
-	padding-right: $block-padding;
-
-	@include break-small() {
-		padding-left: $block-side-ui-width;
-		padding-right: $block-side-ui-width;
-	}
-
 	.editor-post-title {
 		// Center.
 		margin-left: auto;

--- a/packages/editor/src/editor-styles.scss
+++ b/packages/editor/src/editor-styles.scss
@@ -13,7 +13,15 @@ body {
 	font-size: $editor-font-size;
 	line-height: $editor-line-height;
 	color: $dark-gray-primary;
+	padding: 10px;
 }
+
+// For full-wide blocks, we compensate for these 10px.
+.block-editor-block-list__layout.is-root-container > .wp-block[data-align="full"] {
+	margin-left: -10px;
+	margin-right: -10px;
+}
+
 
 /* Headings */
 // These follow a Major Third type scale


### PR DESCRIPTION
This PR removes the 14px on mobile, 36px on desktop breakpoints padding that is applied to the root container.

In the previous iteration of the editor, this padding was necessary to:

- on mobile, show the 14px block border that sat 14px outside of the selected block.
- on desktop breakpoints, show both the 14px block padding, and make room for the side UI (movers)

Because both of those elements are no longer present, we can remove this padding. This benefits themes that try to style the editor as best possible to match the frontend.

These screenshots show a theme that loads an editor style that goes almost edge to edge — Hello World _should_ sit 10px from the edge:

<img width="812" alt="Screenshot 2020-05-08 at 10 43 49" src="https://user-images.githubusercontent.com/1204802/81389150-a95ee580-9119-11ea-8564-f599aad72006.png">

Same on mobile:

<img width="467" alt="Screenshot 2020-05-08 at 10 43 58" src="https://user-images.githubusercontent.com/1204802/81389158-ae239980-9119-11ea-8406-6c9a3ce71556.png">

Full-wide blocks compensated for this, I have removed that compensation, and it works as intended:

<img width="717" alt="Screenshot 2020-05-08 at 10 45 43" src="https://user-images.githubusercontent.com/1204802/81389321-ef1bae00-9119-11ea-8c2b-0e2bf204d1ac.png">

Those 10px are intended from the theme, and compare with how that theme looks in master:

<img width="787" alt="Screenshot 2020-05-08 at 10 53 48" src="https://user-images.githubusercontent.com/1204802/81389517-3f930b80-911a-11ea-9cbe-f7e6b7615f5d.png">

It still works fine in the editor when no editor style is loaded:

<img width="1257" alt="Screenshot 2020-05-08 at 10 47 46" src="https://user-images.githubusercontent.com/1204802/81389397-0e1a4000-911a-11ea-8478-2cb8f9f46e06.png">

This PR does not appear to have negative effects in TwentyTwenty:

<img width="1262" alt="Screenshot 2020-05-08 at 10 51 07" src="https://user-images.githubusercontent.com/1204802/81389372-0064ba80-911a-11ea-9bdb-85537d49e7c0.png">

There's an issue in TwentyNineteen:

<img width="1279" alt="Screenshot 2020-05-08 at 10 51 24" src="https://user-images.githubusercontent.com/1204802/81389445-21c5a680-911a-11ea-842c-233215dee459.png">

There's also an issue with TwentyNineteen in master, but as you can see from the scroll distance, it's been made slightly worse with this PR:

<img width="1279" alt="Screenshot 2020-05-08 at 10 54 34" src="https://user-images.githubusercontent.com/1204802/81389630-710bd700-911a-11ea-9e9e-b52290bd265c.png">

I think it's an important code quality improvement to make, so worth fixing in TwentyNineteen, which probably double-compensates for margins that we are removing here. 