### PR TITLE
Block: add copy action

### DIFF
--- a/packages/block-editor/src/components/block-actions/index.js
+++ b/packages/block-editor/src/components/block-actions/index.js
@@ -21,6 +21,7 @@ function BlockActions( {
 	onInsertBefore,
 	onRemove,
 	onUngroup,
+	blocks,
 } ) {
 	return children( {
 		canDuplicate,
@@ -32,6 +33,7 @@ function BlockActions( {
 		onInsertBefore,
 		onRemove,
 		onUngroup,
+		blocks,
 	} );
 }
 

--- a/packages/block-editor/src/components/block-settings-menu/index.js
+++ b/packages/block-editor/src/components/block-settings-menu/index.js
@@ -13,9 +13,12 @@ import {
 	DropdownMenu,
 	MenuGroup,
 	MenuItem,
+	ClipboardButton,
 } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { moreHorizontal } from '@wordpress/icons';
+import { useState } from '@wordpress/element';
+import { serialize } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -56,6 +59,8 @@ export function BlockSettingsMenu( { clientIds } ) {
 		};
 	}, [] );
 
+	const [ hasCopied, setHasCopied ] = useState();
+
 	return (
 		<BlockActions clientIds={ clientIds }>
 			{ ( {
@@ -66,6 +71,7 @@ export function BlockSettingsMenu( { clientIds } ) {
 				onInsertAfter,
 				onInsertBefore,
 				onRemove,
+				blocks,
 			} ) => (
 				<ToolbarGroup>
 					<ToolbarItem>
@@ -98,6 +104,21 @@ export function BlockSettingsMenu( { clientIds } ) {
 													}
 												/>
 											) }
+											<ClipboardButton
+												text={ serialize( blocks ) }
+												role="menuitem"
+												className="components-menu-item__button"
+												onCopy={ () => {
+													setHasCopied( true );
+												} }
+												onFinishCopy={ () =>
+													setHasCopied( false )
+												}
+											>
+												{ hasCopied
+													? __( 'Copied!' )
+													: __( 'Copy' ) }
+											</ClipboardButton>
 											{ canDuplicate && (
 												<MenuItem
 													onClick={ flow(

--- a/packages/block-editor/src/components/block-settings-menu/index.js
+++ b/packages/block-editor/src/components/block-settings-menu/index.js
@@ -105,7 +105,9 @@ export function BlockSettingsMenu( { clientIds } ) {
 												/>
 											) }
 											<ClipboardButton
-												text={ serialize( blocks ) }
+												text={ () =>
+													serialize( blocks )
+												}
 												role="menuitem"
 												className="components-menu-item__button"
 												onCopy={ () => {


### PR DESCRIPTION
## Description

Small quality of life improvement for touchscreen users or users who don't use keyboard shortcuts. This PR adds a button to the collapsed block actions (next to duplicate etc.) to copy the selected block(s). Quite similar to the "Copy all blocks", but then for the selected block.

<img width="412" alt="Screenshot 2020-05-08 at 11 27 06" src="https://user-images.githubusercontent.com/4710635/81392396-e4174c80-911e-11ea-8a32-d21bb142f6be.png">

I think it could be useful to add the shortcut in the block menu, but I'm planning to refactor ClipboardButton first because that component cannot be used for any button component. So I'll add it in a follow up, but I think this by itself is already useful.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
