### PR TITLE
fix: [#21777] Prevent focusing of FireFox address bar

### DIFF
--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -71,6 +71,9 @@ function URLPicker( {
 	const [ isURLPickerOpen, setIsURLPickerOpen ] = useState( false );
 	const openLinkControl = () => {
 		setIsURLPickerOpen( true );
+
+		// prevents default behaviour for event
+		return false;
 	};
 	const linkControl = isURLPickerOpen && (
 		<Popover


### PR DESCRIPTION
## Description
Fixes #21777.
Using 'META + K' to add a link to the button block triggers FireFox's focus on address bar.
<!-- Please describe what you have changed or added -->


## How has this been tested?
The problem is resolved by preventing the default behavior of that keyboard shortcut.
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Types of changes
Bug fix (non-breaking change which fixes an issue).
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->