### PR TITLE
ClipboardButton: remove wrapper span

### DIFF
--- a/packages/components/src/clipboard-button/index.js
+++ b/packages/components/src/clipboard-button/index.js
@@ -27,7 +27,7 @@ class ClipboardButton extends Component {
 		const { getText, onCopy } = this;
 		const container = this.containerRef.current;
 
-		this.clipboard = new Clipboard( container.firstChild, {
+		this.clipboard = new Clipboard( container, {
 			text: getText,
 			container,
 		} );
@@ -95,11 +95,14 @@ class ClipboardButton extends Component {
 		};
 
 		return (
-			<span ref={ this.containerRef } onCopy={ focusOnCopyEventTarget }>
-				<Button { ...buttonProps } className={ classes }>
-					{ children }
-				</Button>
-			</span>
+			<Button
+				{ ...buttonProps }
+				className={ classes }
+				ref={ this.containerRef }
+				onCopy={ focusOnCopyEventTarget }
+			>
+				{ children }
+			</Button>
 		);
 	}
 }


### PR DESCRIPTION
## Description

This wrapper was introduced in #2948, specifically 45864c7260aa151994faec64635f9f39db779b4b.

I'm not quite sure _why_ this was added. Reading more about the `container` option:

https://github.com/zenorocha/clipboard.js#advanced-options

> For use in Bootstrap Modals or with any other library that changes the focus you'll want to set the focused element as the `container` value.

It's hard to test, since the button to copy the title is gone. I don't see any reason why the button itself can't act as the container to append the `textarea` to. By default, `clipboard` uses the document body to append the `textarea` to. In our component, we append it to the button wrapper, but this can also be the button itself.

<img width="751" alt="Screenshot 2020-05-08 at 12 08 15" src="https://user-images.githubusercontent.com/4710635/81396707-2c863880-9126-11ea-8589-722fca0fd7e0.png">

Why do I want to remove this? I'm thinking of creating a new `useClipboard` hook that could be used on any component's ref. In order for this hook to be used by the `ClipboardButton` component, it should only render a single button component. It's also much cleaner.

If we ever restore the copy title button, and this solution doesn't work properly, we can look for a fix then.

## How has this been tested?

I tested the clipboard buttons and everything works fine. I also tested this the Safari fix added in #7622, which also still works.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
