### PR TITLE
Block API: WP_Block: Document attributes class property

### DIFF
--- a/lib/class-wp-block.php
+++ b/lib/class-wp-block.php
@@ -7,6 +7,8 @@
 
 /**
  * Class representing a parsed instance of a block.
+ *
+ * @property array $attributes
  */
 class WP_Block {
 


### PR DESCRIPTION
Previously: https://github.com/WordPress/gutenberg/pull/21925#issuecomment-624462262

This pull request seeks to add a `@property` tag to the class docblock for `WP_Block`, describing the `$attributes` property accessible only through the `__get` magic method.

Reference: https://docs.phpdoc.org/latest/references/phpdoc/tags/property.html
Prior art: https://github.com/WordPress/wordpress-develop/blob/0d72442/src/wp-includes/class-wp-post.php#L15

**Testing Instructions:**

The changes only impact lines of text within a docblock comment, and should have no impact on the runtime behavior of the application.