### PR TITLE
New hook: useCopyOnClick

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9948,7 +9948,6 @@
 				"@wordpress/rich-text": "file:packages/rich-text",
 				"@wordpress/warning": "file:packages/warning",
 				"classnames": "^2.2.5",
-				"clipboard": "^2.0.1",
 				"dom-scroll-into-view": "^1.2.1",
 				"downshift": "^4.0.5",
 				"gradient-parser": "^0.1.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9970,6 +9970,7 @@
 				"@babel/runtime": "^7.9.2",
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/is-shallow-equal": "file:packages/is-shallow-equal",
+				"clipboard": "^2.0.1",
 				"lodash": "^4.17.15",
 				"mousetrap": "^1.6.2",
 				"react-resize-aware": "^3.0.0"

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -43,7 +43,6 @@
 		"@wordpress/rich-text": "file:../rich-text",
 		"@wordpress/warning": "file:../warning",
 		"classnames": "^2.2.5",
-		"clipboard": "^2.0.1",
 		"dom-scroll-into-view": "^1.2.1",
 		"downshift": "^4.0.5",
 		"gradient-parser": "^0.1.5",

--- a/packages/components/src/menu-item/index.js
+++ b/packages/components/src/menu-item/index.js
@@ -7,7 +7,7 @@ import { isString } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { cloneElement } from '@wordpress/element';
+import { cloneElement, forwardRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -18,18 +18,23 @@ import Button from '../button';
 /**
  * Renders a generic menu item for use inside the more menu.
  *
+ * @param {Object} ref Ref
+ *
  * @return {WPComponent} The component to be rendered.
  */
-export function MenuItem( {
-	children,
-	info,
-	className,
-	icon,
-	shortcut,
-	isSelected,
-	role = 'menuitem',
-	...props
-} ) {
+export function MenuItem(
+	{
+		children,
+		info,
+		className,
+		icon,
+		shortcut,
+		isSelected,
+		role = 'menuitem',
+		...props
+	},
+	ref
+) {
 	className = classnames( 'components-menu-item__button', className );
 
 	if ( info ) {
@@ -49,6 +54,7 @@ export function MenuItem( {
 
 	return (
 		<Button
+			ref={ ref }
 			icon={ icon }
 			// Make sure aria-checked matches spec https://www.w3.org/TR/wai-aria-1.1/#aria-checked
 			aria-checked={
@@ -69,4 +75,4 @@ export function MenuItem( {
 	);
 }
 
-export default MenuItem;
+export default forwardRef( MenuItem );

--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -121,7 +121,17 @@ _Returns_
 
 <a name="useCopyOnClick" href="#useCopyOnClick">#</a> **useCopyOnClick**
 
-Undocumented declaration.
+Copies the text to the clipboard when the element is clicked.
+
+_Parameters_
+
+-   _ref_ `Object`: Reference with the element.
+-   _text_ `(string|Function)`: The text to copy.
+-   _timeout_ `number`: Optional timeout to reset the returned state. 4 seconds by default.
+
+_Returns_
+
+-   `boolean`: Whether or not the text has been copied. Resets after the timeout.
 
 <a name="useInstanceId" href="#useInstanceId">#</a> **useInstanceId**
 

--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -119,6 +119,10 @@ _Returns_
 
 -   `WPComponent`: Component class with generated display name assigned.
 
+<a name="useCopyOnClick" href="#useCopyOnClick">#</a> **useCopyOnClick**
+
+Undocumented declaration.
+
 <a name="useInstanceId" href="#useInstanceId">#</a> **useInstanceId**
 
 Provides a unique instance ID.

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -26,6 +26,7 @@
 		"@babel/runtime": "^7.9.2",
 		"@wordpress/element": "file:../element",
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
+		"clipboard": "^2.0.1",
 		"lodash": "^4.17.15",
 		"mousetrap": "^1.6.2",
 		"react-resize-aware": "^3.0.0"

--- a/packages/compose/src/hooks/use-copy-on-click/index.js
+++ b/packages/compose/src/hooks/use-copy-on-click/index.js
@@ -26,6 +26,7 @@ export default function useCopyOnClick( ref, text, timeout = 4000 ) {
 	useEffect( () => {
 		let timeoutId;
 
+		// Clipboard listens to click events.
 		clipboard.current = new Clipboard( ref.current, {
 			text: () => ( typeof text === 'function' ? text() : text ),
 			container: ref.current,

--- a/packages/compose/src/hooks/use-copy-on-click/index.js
+++ b/packages/compose/src/hooks/use-copy-on-click/index.js
@@ -24,10 +24,6 @@ export default function useCopyOnClick( ref, text, timeout = 4000 ) {
 	const [ hasCopied, setHasCopied ] = useState( false );
 
 	useEffect( () => {
-		if ( ! clipboard.current ) {
-			return;
-		}
-
 		let timeoutId;
 
 		// Clipboard listens to click events.

--- a/packages/compose/src/hooks/use-copy-on-click/index.js
+++ b/packages/compose/src/hooks/use-copy-on-click/index.js
@@ -1,0 +1,43 @@
+/**
+ * External dependencies
+ */
+import Clipboard from 'clipboard';
+
+/**
+ * WordPress dependencies
+ */
+import { useRef, useEffect, useState } from '@wordpress/element';
+
+export default function useCopyOnClick( ref, text, timeout = 4000 ) {
+	const clipboard = useRef();
+	const [ hasCopied, setHasCopied ] = useState( false );
+
+	useEffect( () => {
+		let timeoutId;
+
+		clipboard.current = new Clipboard( ref.current, {
+			text: () => ( typeof text === 'function' ? text() : text ),
+			container: ref.current,
+		} );
+
+		clipboard.current.on( 'success', ( { clearSelection } ) => {
+			// Clearing selection will move focus back to the triggering button,
+			// ensuring that it is not reset to the body, and further that it is
+			// kept within the rendered node.
+			clearSelection();
+
+			if ( timeout ) {
+				setHasCopied( true );
+				clearTimeout( timeoutId );
+				timeoutId = setTimeout( () => setHasCopied( false ), timeout );
+			}
+		} );
+
+		return () => {
+			clipboard.current.destroy();
+			clearTimeout( timeoutId );
+		};
+	}, [ text, timeout, setHasCopied ] );
+
+	return hasCopied;
+}

--- a/packages/compose/src/hooks/use-copy-on-click/index.js
+++ b/packages/compose/src/hooks/use-copy-on-click/index.js
@@ -8,6 +8,17 @@ import Clipboard from 'clipboard';
  */
 import { useRef, useEffect, useState } from '@wordpress/element';
 
+/**
+ * Copies the text to the clipboard when the element is clicked.
+ *
+ * @param {Object}          ref     Reference with the element.
+ * @param {string|Function} text    The text to copy.
+ * @param {number}          timeout Optional timeout to reset the returned
+ *                                  state. 4 seconds by default.
+ *
+ * @return {boolean} Whether or not the text has been copied. Resets after the
+ *                   timeout.
+ */
 export default function useCopyOnClick( ref, text, timeout = 4000 ) {
 	const clipboard = useRef();
 	const [ hasCopied, setHasCopied ] = useState( false );

--- a/packages/compose/src/hooks/use-copy-on-click/index.js
+++ b/packages/compose/src/hooks/use-copy-on-click/index.js
@@ -24,6 +24,10 @@ export default function useCopyOnClick( ref, text, timeout = 4000 ) {
 	const [ hasCopied, setHasCopied ] = useState( false );
 
 	useEffect( () => {
+		if ( ! clipboard.current ) {
+			return;
+		}
+
 		let timeoutId;
 
 		// Clipboard listens to click events.

--- a/packages/compose/src/index.js
+++ b/packages/compose/src/index.js
@@ -13,6 +13,7 @@ export { default as withSafeTimeout } from './higher-order/with-safe-timeout';
 export { default as withState } from './higher-order/with-state';
 
 // Hooks
+export { default as useCopyOnClick } from './hooks/use-copy-on-click';
 export { default as __experimentalUseDragging } from './hooks/use-dragging';
 export { default as useInstanceId } from './hooks/use-instance-id';
 export { default as useKeyboardShortcut } from './hooks/use-keyboard-shortcut';

--- a/packages/edit-post/src/plugins/copy-content-menu-item/index.js
+++ b/packages/edit-post/src/plugins/copy-content-menu-item/index.js
@@ -4,7 +4,7 @@
 import { MenuItem } from '@wordpress/components';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { useCopyOnClick, compose } from '@wordpress/compose';
+import { useCopyOnClick, compose, ifCondition } from '@wordpress/compose';
 import { useRef, useEffect } from '@wordpress/element';
 
 function CopyContentMenuItem( { createNotice, editedPostContent } ) {
@@ -23,11 +23,9 @@ function CopyContentMenuItem( { createNotice, editedPostContent } ) {
 	}, [ hasCopied ] );
 
 	return (
-		editedPostContent.length > 0 && (
-			<MenuItem ref={ ref }>
-				{ hasCopied ? __( 'Copied!' ) : __( 'Copy all content' ) }
-			</MenuItem>
-		)
+		<MenuItem ref={ ref }>
+			{ hasCopied ? __( 'Copied!' ) : __( 'Copy all content' ) }
+		</MenuItem>
 	);
 }
 
@@ -43,5 +41,6 @@ export default compose(
 		return {
 			createNotice,
 		};
-	} )
+	} ),
+	ifCondition( ( { editedPostContent } ) => editedPostContent.length > 0 )
 )( CopyContentMenuItem );

--- a/packages/edit-post/src/plugins/copy-content-menu-item/index.js
+++ b/packages/edit-post/src/plugins/copy-content-menu-item/index.js
@@ -1,34 +1,32 @@
 /**
  * WordPress dependencies
  */
-import { ClipboardButton } from '@wordpress/components';
+import { MenuItem } from '@wordpress/components';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { withState, compose } from '@wordpress/compose';
+import { useCopyOnClick, compose } from '@wordpress/compose';
+import { useRef, useEffect } from '@wordpress/element';
 
-function CopyContentMenuItem( {
-	createNotice,
-	editedPostContent,
-	hasCopied,
-	setState,
-} ) {
+function CopyContentMenuItem( { createNotice, editedPostContent } ) {
+	const ref = useRef();
+	const hasCopied = useCopyOnClick( ref, editedPostContent );
+
+	useEffect( () => {
+		if ( ! hasCopied ) {
+			return;
+		}
+
+		createNotice( 'info', __( 'All content copied.' ), {
+			isDismissible: true,
+			type: 'snackbar',
+		} );
+	}, [ hasCopied ] );
+
 	return (
 		editedPostContent.length > 0 && (
-			<ClipboardButton
-				text={ editedPostContent }
-				role="menuitem"
-				className="components-menu-item__button"
-				onCopy={ () => {
-					setState( { hasCopied: true } );
-					createNotice( 'info', __( 'All content copied.' ), {
-						isDismissible: true,
-						type: 'snackbar',
-					} );
-				} }
-				onFinishCopy={ () => setState( { hasCopied: false } ) }
-			>
+			<MenuItem ref={ ref }>
 				{ hasCopied ? __( 'Copied!' ) : __( 'Copy all content' ) }
-			</ClipboardButton>
+			</MenuItem>
 		)
 	);
 }
@@ -45,6 +43,5 @@ export default compose(
 		return {
 			createNotice,
 		};
-	} ),
-	withState( { hasCopied: false } )
+	} )
 )( CopyContentMenuItem );


### PR DESCRIPTION
## Description

This is meant to replace `ClipboardButton`, which now also uses this hook.

```jsx
const ref = useRef();
const hasCopied = useCopyOnClick( ref, () => text );

return <Button ref={ ref }>{ hasCopied ? 'Copied!' : 'Copy' }</Button>;
```

Why?

Because it's currently only possible to render a button. With a hook, the behaviour could be added to _any_ component. This is handy if you want to use it for a menu item for example.

It also enables us to absorb some common logic by all of the `ClipboardButton` implementations. They all have to implement a `hasCopied` state, because the component cannot pass it to the parent. With a hook, you can easily pass state.

I converted the "copy all content" menu item as a demonstration.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
