### PR TITLE
Project Management: Sync CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,6 +8,7 @@
 /packages/core-data                             @youknowriad @nerrad
 /packages/data                                  @youknowriad @nerrad @coderkevin
 /packages/redux-routine                         @youknowriad @nerrad
+/packages/data-controls                         @nerrad @aduth
 
 # Blocks
 /packages/block-library                         @Soean @ajitbohra @jorgefilipecosta @talldan
@@ -26,9 +27,19 @@
 /packages/editor
 /packages/list-reusable-blocks                  @youknowriad @noisysocks
 /packages/shortcode
+/packages/block-directory
+/packages/interface
+/packages/media-utils
+/packages/server-side-render
 
 # Widgets
 /packages/edit-widgets                          @youknowriad
+
+# Navigation
+/packages/edit-navigation
+
+# Full Site Editing
+/packages/edit-site
 
 # Tooling
 /bin                                            @ntwb @nerrad @ajitbohra
@@ -51,6 +62,8 @@
 /packages/npm-package-json-lint-config          @gziolo @ntwb @nerrad @ajitbohra
 /packages/postcss-themes                        @youknowriad @ntwb @nerrad @ajitbohra
 /packages/scripts                               @youknowriad @gziolo @ntwb @nerrad @ajitbohra
+/packages/dependency-extraction-webpack-plugin  @gziolo
+/packages/prettier-config                       @ntwb @gziolo @aduth
 
 # UI Components
 /packages/components                            @youknowriad @ajitbohra @jaymanpandya @jorgefilipecosta @chrisvanpatten
@@ -59,6 +72,9 @@
 /packages/notices                               @ajitbohra @jaymanpandya @jorgefilipecosta
 /packages/nux                                   @ajitbohra @jaymanpandya @jorgefilipecosta @noisysocks
 /packages/viewport                              @youknowriad @ajitbohra @jaymanpandya @jorgefilipecosta
+/packages/base-styles
+/packages/icons
+/packages/primitives
 
 # Utilities
 /packages/a11y                                  @youknowriad @aduth
@@ -76,6 +92,8 @@
 /packages/token-list                            @aduth
 /packages/url                                   @talldan @aduth
 /packages/wordcount                             @aduth
+/packages/warning
+/packages/keyboard-shortcuts
 
 # Extensibility
 /packages/hooks                                 @gziolo @adamsilverstein
@@ -85,6 +103,10 @@
 /packages/format-library                        @ellatrix @jorgefilipecosta @daniloercoli @sergioestevao @etoledom
 /packages/rich-text                             @ellatrix @jorgefilipecosta @daniloercoli @sergioestevao @etoledom
 /packages/block-editor/src/components/rich-text @ellatrix @jorgefilipecosta @daniloercoli @sergioestevao @etoledom
+
+# Project Management
+/.github                                        @youknowriad @mapk @karmatosed
+/packages/project-management-automation         @aduth
 
 # wp-env
 /packages/env                                   @epiqueras @noahtallen @noisysocks
@@ -99,6 +121,3 @@
 *.native.scss                                   @ghost
 *.android.scss                                  @ghost
 *.ios.scss                                      @ghost
-
-# Project Management
-/.github                                        @youknowriad @mapk @karmatosed


### PR DESCRIPTION
This pull request seeks to update `CODEOWNERS` to sync available entries with the current state of the packages directory. Since it was last updated, a number of new packages have been created, and were not included here.

I've proactively added a few people who I know to have been directly related with instigating the creation of the associated package. Let me know (or make direct edits) if you'd prefer to opt out.

>/packages/data-controls                         @nerrad @aduth
>/packages/dependency-extraction-webpack-plugin  @gziolo
>/packages/prettier-config                       @ntwb @gziolo @aduth
>/packages/project-management-automation         @aduth