### PR TITLE
Add gap between nested submenus

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -56,8 +56,19 @@
 
 			// Nested submenus sit to the left on large breakpoints
 			.wp-block-navigation__container {
-				left: 100%;
+				left: calc(100% + #{$grid-unit-10});
 				top: -$border-width - $navigation-vertical-padding;
+
+				// Prevent the menu from disappearing when the mouse is over the gap
+				&::before {
+					content: "";
+					position: absolute;
+					right: 100%;
+					height: 100%;
+					display: block;
+					width: $grid-unit-10;
+					background: transparent;
+				}
 			}
 
 			.wp-block-navigation-link__submenu-icon svg {


### PR DESCRIPTION
## Description
Adds a gap between nested submenus (See https://github.com/WordPress/gutenberg/pull/22107)

## Screenshots <!-- if applicable -->

*Before*
<img width="460" alt="Zrzut ekranu 2020-05-8 o 16 22 20" src="https://user-images.githubusercontent.com/205419/81415032-2608b880-9148-11ea-99cc-07b167527889.png">

*After*
<img width="415" alt="Zrzut ekranu 2020-05-8 o 16 21 17" src="https://user-images.githubusercontent.com/205419/81415026-24d78b80-9148-11ea-8ffc-def66fc2a344.png">

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
