### PR TITLE
Restore the missing background color on nested submenus

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -128,22 +128,22 @@
 // Default / Light styles
 .wp-block-navigation .wp-block-navigation__container .wp-block-navigation-link,
 .wp-block-navigation.is-style-light .wp-block-navigation__container .wp-block-navigation-link {
-	&:not(.has-text-color) .wp-block-navigation-link__content {
+	&:not(.has-text-color) {
 		color: $light-style-sub-menu-text-color;
 	}
 }
-.wp-block-navigation:not(.has-background) .wp-block-navigation__container .wp-block-navigation__container,
+.wp-block-navigation:not(.has-background) .wp-block-navigation__container,
 .wp-block-navigation.is-style-light:not(.has-background) .wp-block-navigation__container .wp-block-navigation__container {
 	background-color: $light-style-sub-menu-background-color;
 }
 
 // Dark styles.
 .wp-block-navigation.is-style-dark .wp-block-navigation__container .wp-block-navigation-link {
-	&:not(.has-text-color) .wp-block-navigation-link__content {
+	&:not(.has-text-color) {
 		color: $dark-style-sub-menu-text-color;
 	}
 }
-.wp-block-navigation.is-style-dark:not(.has-background) .wp-block-navigation__container .wp-block-navigation__container {
+.wp-block-navigation.is-style-dark:not(.has-background) .wp-block-navigation__container {
 	background-color: $dark-style-sub-menu-background-color;
 }
 

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -21,6 +21,10 @@
 	position: relative;
 	margin: 0;
 	padding: $grid-unit-10;
+
+	.wp-block-navigation__container:empty {
+		display: none;
+	}
 }
 
 // Styles for submenu flyout
@@ -122,24 +126,24 @@
 }
 
 // Default / Light styles
-.wp-block-navigation .wp-block-navigation-link,
-.wp-block-navigation.is-style-light .wp-block-navigation-link {
+.wp-block-navigation .wp-block-navigation__container .wp-block-navigation-link,
+.wp-block-navigation.is-style-light .wp-block-navigation__container .wp-block-navigation-link {
 	&:not(.has-text-color) .wp-block-navigation-link__content {
 		color: $light-style-sub-menu-text-color;
 	}
 }
-.wp-block-navigation:not(.has-background) .wp-block-navigation__container,
-.wp-block-navigation.is-style-light:not(.has-background) .wp-block-navigation__container {
+.wp-block-navigation:not(.has-background) .wp-block-navigation__container .wp-block-navigation__container,
+.wp-block-navigation.is-style-light:not(.has-background) .wp-block-navigation__container .wp-block-navigation__container {
 	background-color: $light-style-sub-menu-background-color;
 }
 
 // Dark styles.
-.wp-block-navigation.is-style-dark .wp-block-navigation-link {
+.wp-block-navigation.is-style-dark .wp-block-navigation__container .wp-block-navigation-link {
 	&:not(.has-text-color) .wp-block-navigation-link__content {
 		color: $dark-style-sub-menu-text-color;
 	}
 }
-.wp-block-navigation.is-style-dark:not(.has-background) .wp-block-navigation__container {
+.wp-block-navigation.is-style-dark:not(.has-background) .wp-block-navigation__container .wp-block-navigation__container {
 	background-color: $dark-style-sub-menu-background-color;
 }
 

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -126,25 +126,24 @@
 }
 
 // Default / Light styles
-.wp-block-navigation .wp-block-navigation__container .wp-block-navigation-link,
-.wp-block-navigation.is-style-light .wp-block-navigation__container .wp-block-navigation-link {
-	&:not(.has-text-color) {
+.wp-block-navigation,
+.wp-block-navigation.is-style-light {
+	.wp-block-navigation-link:not(.has-text-color) {
 		color: $light-style-sub-menu-text-color;
 	}
-}
-.wp-block-navigation:not(.has-background) .wp-block-navigation__container,
-.wp-block-navigation.is-style-light:not(.has-background) .wp-block-navigation__container .wp-block-navigation__container {
-	background-color: $light-style-sub-menu-background-color;
+	&:not(.has-background) .wp-block-navigation__container {
+		background-color: $light-style-sub-menu-background-color;
+	}
 }
 
 // Dark styles.
-.wp-block-navigation.is-style-dark .wp-block-navigation__container .wp-block-navigation-link {
-	&:not(.has-text-color) {
+.wp-block-navigation.is-style-dark {
+	.wp-block-navigation-link:not(.has-text-color) {
 		color: $dark-style-sub-menu-text-color;
 	}
-}
-.wp-block-navigation.is-style-dark:not(.has-background) .wp-block-navigation__container {
-	background-color: $dark-style-sub-menu-background-color;
+	&:not(.has-background) .wp-block-navigation__container {
+		background-color: $dark-style-sub-menu-background-color;
+	}
 }
 
 // Justification.

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -122,27 +122,28 @@
 }
 
 // Default / Light styles
-.wp-block-navigation-link,
-.is-style-light .wp-block-navigation-link {
+.wp-block-navigation .wp-block-navigation-link,
+.wp-block-navigation.is-style-light .wp-block-navigation-link {
 	&:not(.has-text-color) .wp-block-navigation-link__content {
 		color: $light-style-sub-menu-text-color;
 	}
 }
-.is-style-light:not(.has-background) .wp-block-navigation__container {
+.wp-block-navigation:not(.has-background) .wp-block-navigation__container,
+.wp-block-navigation.is-style-light:not(.has-background) .wp-block-navigation__container {
 	background-color: $light-style-sub-menu-background-color;
 }
 
 // Dark styles.
-.is-style-dark .wp-block-navigation-link {
+.wp-block-navigation.is-style-dark .wp-block-navigation-link {
 	&:not(.has-text-color) .wp-block-navigation-link__content {
 		color: $dark-style-sub-menu-text-color;
 	}
 }
-.is-style-dark:not(.has-background) .wp-block-navigation__container {
+.wp-block-navigation.is-style-dark:not(.has-background) .wp-block-navigation__container {
 	background-color: $dark-style-sub-menu-background-color;
 }
 
-// Jutification.
+// Justification.
 .items-justified-left > ul {
 	justify-content: flex-start;
 }


### PR DESCRIPTION
## Description
This PR ensures nested submenus have a background right after they're added (when the `is-style-light` css class is missing).

## Screenshots

**Before**
<img width="533" alt="Zrzut ekranu 2020-05-8 o 16 39 08" src="https://user-images.githubusercontent.com/205419/81416749-741ebb80-914a-11ea-8117-66e0a4bc6899.png">

**After**
<img width="647" alt="Zrzut ekranu 2020-05-11 o 13 33 17" src="https://user-images.githubusercontent.com/205419/81557277-fd710080-938b-11ea-8641-0a99a9edeb6d.png">

<img width="644" alt="Zrzut ekranu 2020-05-11 o 13 32 26" src="https://user-images.githubusercontent.com/205419/81557209-e03c3200-938b-11ea-8b5e-d72845ef113e.png">


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
