### PR TITLE
Components: Create a separate .native entry for ToolbarItem

### DIFF
--- a/packages/components/src/toolbar-item/index.native.js
+++ b/packages/components/src/toolbar-item/index.native.js
@@ -1,0 +1,17 @@
+/**
+ * WordPress dependencies
+ */
+import { forwardRef } from '@wordpress/element';
+import warning from '@wordpress/warning';
+
+function ToolbarItem( { children, ...props }, ref ) {
+	if ( typeof children !== 'function' ) {
+		warning(
+			'`ToolbarItem` is a generic headless component that accepts only function children props'
+		);
+		return null;
+	}
+	return children( { ...props, ref } );
+}
+
+export default forwardRef( ToolbarItem );


### PR DESCRIPTION
This file was removed on #20008

Re-adding it here to make sure React Native is not affected by #20008 changes.