### PR TITLE
ESLint Plugin: Fix dependency group checking for CommonJS

### DIFF
--- a/bin/api-docs/are-api-docs-unstaged.js
+++ b/bin/api-docs/are-api-docs-unstaged.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * Node dependencies.
+ * External dependencies
  */
 const { extname } = require( 'path' );
 const chalk = require( 'chalk' );

--- a/bin/generate-public-grammar.js
+++ b/bin/generate-public-grammar.js
@@ -1,5 +1,13 @@
 #!/usr/bin/env node
+
+/**
+ * Internal dependencies
+ */
 const parser = require( '../node_modules/pegjs/lib/parser.js' );
+
+/**
+ * External dependencies
+ */
 const fs = require( 'fs' );
 const path = require( 'path' );
 const grammarSource = fs.readFileSync(

--- a/bin/plugin/commands/changelog.js
+++ b/bin/plugin/commands/changelog.js
@@ -1,10 +1,10 @@
-/*
+/**
  * External dependencies
  */
 const { groupBy } = require( 'lodash' );
 const Octokit = require( '@octokit/rest' );
 
-/*
+/**
  * Internal dependencies
  */
 const { getNextMajorVersion } = require( '../lib/version' );

--- a/bin/plugin/commands/common.js
+++ b/bin/plugin/commands/common.js
@@ -5,7 +5,7 @@ const fs = require( 'fs' );
 const rimraf = require( 'rimraf' );
 const semver = require( 'semver' );
 
-/*
+/**
  * Internal dependencies
  */
 const { log, formats } = require( '../lib/logger' );

--- a/bin/plugin/lib/utils.js
+++ b/bin/plugin/lib/utils.js
@@ -9,7 +9,7 @@ const { v4: uuid } = require( 'uuid' );
 const path = require( 'path' );
 const os = require( 'os' );
 
-/*
+/**
  * Internal dependencies
  */
 const { log, formats } = require( './logger' );

--- a/docs/tool/index.js
+++ b/docs/tool/index.js
@@ -1,5 +1,5 @@
 /**
- * Node dependencies
+ * External dependencies
  */
 const fs = require( 'fs' );
 const path = require( 'path' );

--- a/docs/tool/manifest.js
+++ b/docs/tool/manifest.js
@@ -1,5 +1,5 @@
 /**
- * Node dependencies
+ * External dependencies
  */
 const { camelCase, nth, upperFirst } = require( 'lodash' );
 const fs = require( 'fs' );

--- a/package-lock.json
+++ b/package-lock.json
@@ -9071,6 +9071,22 @@
 			"resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
 			"integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
 		},
+		"@types/eslint": {
+			"version": "6.8.0",
+			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-6.8.0.tgz",
+			"integrity": "sha512-hqzmggoxkOubpgTdcOltkfc5N8IftRJqU70d1jbOISjjZVPvjcr+CLi2CI70hx1SUIRkLgpglTy9w28nGe2Hsw==",
+			"dev": true,
+			"requires": {
+				"@types/estree": "*",
+				"@types/json-schema": "*"
+			}
+		},
+		"@types/estree": {
+			"version": "0.0.44",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.44.tgz",
+			"integrity": "sha512-iaIVzr+w2ZJ5HkidlZ3EJM8VTZb2MJLCjw3V+505yVts0gRC4UMvjw0d1HPtGqI/HQC/KdsYtayfzl+AXY2R8g==",
+			"dev": true
+		},
 		"@types/events": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -89,6 +89,8 @@
 		"@storybook/react": "5.3.2",
 		"@testing-library/react": "10.0.2",
 		"@types/classnames": "2.2.10",
+		"@types/eslint": "6.8.0",
+		"@types/estree": "0.0.44",
 		"@types/lodash": "4.14.149",
 		"@types/prettier": "1.19.0",
 		"@types/qs": "6.9.1",

--- a/packages/block-serialization-spec-parser/bin/create-php-parser.js
+++ b/packages/block-serialization-spec-parser/bin/create-php-parser.js
@@ -1,5 +1,8 @@
 #!/usr/bin/env node
 
+/**
+ * External dependencies
+ */
 const pegjs = require( 'pegjs' );
 const phpegjs = require( 'phpegjs' );
 const fs = require( 'fs' );

--- a/packages/custom-templated-path-webpack-plugin/test/fixtures/webpack.config.js
+++ b/packages/custom-templated-path-webpack-plugin/test/fixtures/webpack.config.js
@@ -1,13 +1,11 @@
 /**
  * External dependencies
  */
-
 const { basename } = require( 'path' );
 
 /**
- * Internal dependencies
+ * WordPress dependencies
  */
-
 const CustomTemplatedPathPlugin = require( '@wordpress/custom-templated-path-webpack-plugin' );
 
 module.exports = {

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/combine-assets/webpack.config.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/combine-assets/webpack.config.js
@@ -1,3 +1,6 @@
+/**
+ * Internal dependencies
+ */
 const DependencyExtractionWebpackPlugin = require( '../../..' );
 
 module.exports = {

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/dynamic-import/webpack.config.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/dynamic-import/webpack.config.js
@@ -1,3 +1,6 @@
+/**
+ * Internal dependencies
+ */
 const DependencyExtractionWebpackPlugin = require( '../../..' );
 
 module.exports = {

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/function-output-filename/webpack.config.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/function-output-filename/webpack.config.js
@@ -1,3 +1,6 @@
+/**
+ * Internal dependencies
+ */
 const DependencyExtractionWebpackPlugin = require( '../../..' );
 
 module.exports = {

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/no-default/webpack.config.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/no-default/webpack.config.js
@@ -1,3 +1,6 @@
+/**
+ * Internal dependencies
+ */
 const DependencyExtractionWebpackPlugin = require( '../../..' );
 
 module.exports = {

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/no-deps/webpack.config.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/no-deps/webpack.config.js
@@ -1,3 +1,6 @@
+/**
+ * Internal dependencies
+ */
 const DependencyExtractionWebpackPlugin = require( '../../..' );
 
 module.exports = {

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/output-format-json/webpack.config.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/output-format-json/webpack.config.js
@@ -1,3 +1,6 @@
+/**
+ * Internal dependencies
+ */
 const DependencyExtractionWebpackPlugin = require( '../../..' );
 
 module.exports = {

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/overrides/webpack.config.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/overrides/webpack.config.js
@@ -1,3 +1,6 @@
+/**
+ * Internal dependencies
+ */
 const DependencyExtractionWebpackPlugin = require( '../../..' );
 
 module.exports = {

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/with-externs/webpack.config.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/with-externs/webpack.config.js
@@ -1,3 +1,6 @@
+/**
+ * Internal dependencies
+ */
 const DependencyExtractionWebpackPlugin = require( '../../..' );
 
 module.exports = {

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/wordpress-require/webpack.config.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/wordpress-require/webpack.config.js
@@ -1,3 +1,6 @@
+/**
+ * Internal dependencies
+ */
 const DependencyExtractionWebpackPlugin = require( '../../..' );
 
 module.exports = {

--- a/packages/docgen/bin/cli.js
+++ b/packages/docgen/bin/cli.js
@@ -1,5 +1,8 @@
 #!/usr/bin/env node
 
+/**
+ * Internal dependencies
+ */
 const docgen = require( '../src' );
 
 const optionator = require( 'optionator' )( {

--- a/packages/docgen/src/engine.js
+++ b/packages/docgen/src/engine.js
@@ -1,11 +1,11 @@
 /**
- * External dependencies.
+ * External dependencies
  */
 const babel = require( '@babel/core' );
 const { flatten } = require( 'lodash' );
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 const getIntermediateRepresentation = require( './get-intermediate-representation' );
 

--- a/packages/docgen/src/get-intermediate-representation.js
+++ b/packages/docgen/src/get-intermediate-representation.js
@@ -1,10 +1,10 @@
 /**
- * External dependencies.
+ * External dependencies
  */
 const { get } = require( 'lodash' );
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 const getExportEntries = require( './get-export-entries' );
 const getJSDocFromToken = require( './get-jsdoc-from-token' );

--- a/packages/docgen/src/get-jsdoc-from-token.js
+++ b/packages/docgen/src/get-jsdoc-from-token.js
@@ -1,10 +1,10 @@
 /**
- * External dependencies.
+ * External dependencies
  */
 const doctrine = require( 'doctrine' );
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 const getLeadingComments = require( './get-leading-comments' );
 const getTypeAsString = require( './get-type-as-string' );

--- a/packages/docgen/src/get-leading-comments.js
+++ b/packages/docgen/src/get-leading-comments.js
@@ -1,5 +1,5 @@
 /**
- * External dependencies.
+ * External dependencies
  */
 const { last } = require( 'lodash' );
 

--- a/packages/docgen/src/markdown/index.js
+++ b/packages/docgen/src/markdown/index.js
@@ -1,5 +1,5 @@
 /**
- * External dependencies.
+ * External dependencies
  */
 const remark = require( 'remark' );
 const unified = require( 'unified' );
@@ -8,7 +8,7 @@ const inject = require( 'mdast-util-inject' );
 const fs = require( 'fs' );
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 const formatter = require( './formatter' );
 const embed = require( './embed' );

--- a/packages/docgen/src/test/engine.js
+++ b/packages/docgen/src/test/engine.js
@@ -1,5 +1,5 @@
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 const engine = require( '../engine' );
 

--- a/packages/docgen/src/test/formatter-markdown.js
+++ b/packages/docgen/src/test/formatter-markdown.js
@@ -1,5 +1,5 @@
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 const formatter = require( '../markdown/formatter' );
 

--- a/packages/docgen/src/test/get-export-entries.js
+++ b/packages/docgen/src/test/get-export-entries.js
@@ -1,11 +1,11 @@
 /**
- * Node dependencies.
+ * External dependencies
  */
 const fs = require( 'fs' );
 const path = require( 'path' );
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 const getExportEntries = require( '../get-export-entries' );
 

--- a/packages/docgen/src/test/get-intermediate-representation.js
+++ b/packages/docgen/src/test/get-intermediate-representation.js
@@ -1,11 +1,11 @@
 /**
- * Node dependencies.
+ * External dependencies
  */
 const fs = require( 'fs' );
 const path = require( 'path' );
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 const getIntermediateRepresentation = require( '../get-intermediate-representation' );
 

--- a/packages/docgen/src/test/get-jsdoc-from-token.js
+++ b/packages/docgen/src/test/get-jsdoc-from-token.js
@@ -1,5 +1,5 @@
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 const getJSDocFromToken = require( '../get-jsdoc-from-token' );
 

--- a/packages/docgen/src/test/get-type-as-string.js
+++ b/packages/docgen/src/test/get-type-as-string.js
@@ -1,5 +1,5 @@
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 const getType = require( '../get-type-as-string' );
 

--- a/packages/e2e-tests/config/performance-reporter.js
+++ b/packages/e2e-tests/config/performance-reporter.js
@@ -1,3 +1,6 @@
+/**
+ * External dependencies
+ */
 const { readFileSync, existsSync } = require( 'fs' );
 const chalk = require( 'chalk' );
 

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -6,7 +6,11 @@
 
 ### Breaking Changes
 
--  The severity of the rule, `jsdoc/no-undefined-types`, has been increased from `warn` to `error`. In addition, `JSX` has been added to the default list of defined types.
+- The severity of the rule, `jsdoc/no-undefined-types`, has been increased from `warn` to `error`. In addition, `JSX` has been added to the default list of defined types.
+
+### Bug Fixes
+
+- `@wordpress/dependency-group` will now correctly identify issues associated with CommonJS (`require`) module imports.
 
 ### Improvements
 

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -2,15 +2,15 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- `@wordpress/dependency-group` will now correctly identify issues associated with CommonJS (`require`) module imports.
+
 ## 6.0.0 (2020-05-14)
 
 ### Breaking Changes
 
 - The severity of the rule, `jsdoc/no-undefined-types`, has been increased from `warn` to `error`. In addition, `JSX` has been added to the default list of defined types.
-
-### Bug Fixes
-
-- `@wordpress/dependency-group` will now correctly identify issues associated with CommonJS (`require`) module imports.
 
 ### Improvements
 

--- a/packages/eslint-plugin/rules/__tests__/dependency-group.js
+++ b/packages/eslint-plugin/rules/__tests__/dependency-group.js
@@ -35,6 +35,24 @@ import { Component } from '@wordpress/element';
  */
 import edit from './edit';`,
 		},
+		{
+			code: `
+/**
+ * External dependencies
+ */
+const { get } = require( 'lodash' );
+const classnames = require( 'classnames' );
+
+/**
+ * WordPress dependencies
+ */
+const { Component } = require( '@wordpress/element' );
+
+/**
+ * Internal dependencies
+ */
+const edit = require( './edit' );`,
+		},
 	],
 	invalid: [
 		{
@@ -74,6 +92,44 @@ import { Component } from '@wordpress/element';
  * Internal dependencies
  */
 import edit from './edit';`,
+		},
+		{
+			code: `
+const { get } = require( 'lodash' );
+const classnames = require( 'classnames' );
+/*
+ * wordpress dependencies.
+ */
+const { Component } = require( '@wordpress/element' );
+const edit = require( './edit' );`,
+			errors: [
+				{
+					message:
+						'Expected preceding "External dependencies" comment block',
+				},
+				{
+					message:
+						'Expected preceding "WordPress dependencies" comment block',
+				},
+				{
+					message:
+						'Expected preceding "Internal dependencies" comment block',
+				},
+			],
+			output: `
+/**
+ * External dependencies
+ */
+const { get } = require( 'lodash' );
+const classnames = require( 'classnames' );
+/**
+ * WordPress dependencies
+ */
+const { Component } = require( '@wordpress/element' );
+/**
+ * Internal dependencies
+ */
+const edit = require( './edit' );`,
 		},
 	],
 } );

--- a/packages/eslint-plugin/rules/dependency-group.js
+++ b/packages/eslint-plugin/rules/dependency-group.js
@@ -1,4 +1,7 @@
-module.exports = {
+/** @typedef {import('estree').Comment} Comment */
+/** @typedef {import('estree').Node} Node */
+
+module.exports = /** @type {import('eslint').Rule.RuleModule} */ ( {
 	meta: {
 		type: 'layout',
 		docs: {
@@ -7,7 +10,7 @@ module.exports = {
 				'https://github.com/WordPress/gutenberg/blob/master/packages/eslint-plugin/docs/rules/dependency-group.md',
 		},
 		schema: [],
-		fixable: true,
+		fixable: 'code',
 	},
 	create( context ) {
 		const comments = context.getSourceCode().getAllComments();
@@ -22,11 +25,11 @@ module.exports = {
 		/**
 		 * Object describing a dependency block correction to be made.
 		 *
-		 * @property {?espree.Node} comment Comment node on which to replace
-		 *                                  value, if one can be salvaged.
-		 * @property {string}       value   Expected comment node value.
+		 * @typedef WPDependencyBlockCorrection
 		 *
-		 * @typedef {Object} WPDependencyBlockCorrection
+		 * @property {Comment} [comment] Comment node on which to replace value,
+		 *                               if one can be salvaged.
+		 * @property {string}  value     Expected comment node value.
 		 */
 
 		/**
@@ -63,7 +66,7 @@ module.exports = {
 		 * Returns true if the given comment node satisfies a desired locality,
 		 * or false otherwise.
 		 *
-		 * @param {espree.Node}       node     Comment node to check.
+		 * @param {Comment}           node     Comment node to check.
 		 * @param {WPPackageLocality} locality Desired package locality.
 		 *
 		 * @return {boolean} Whether comment node satisfies locality.
@@ -95,13 +98,17 @@ module.exports = {
 		 * Returns true if the given node occurs prior in code to a reference,
 		 * or false otherwise.
 		 *
-		 * @param {espree.Node} node      Node to test being before reference.
-		 * @param {espree.Node} reference Node against which to compare.
+		 * @param {Comment} node      Node to test being before reference.
+		 * @param {Node}    reference Node against which to compare.
 		 *
 		 * @return {boolean} Whether node occurs before reference.
 		 */
 		function isBefore( node, reference ) {
-			return node.start < reference.start;
+			if ( ! node.range || ! reference.range ) {
+				return false;
+			}
+
+			return node.range[ 0 ] < reference.range[ 0 ];
 		}
 
 		/**
@@ -110,10 +117,10 @@ module.exports = {
 		 * updates, the function returns undefined. Otherwise, it will return
 		 * a WPDependencyBlockCorrection object describing a correction.
 		 *
-		 * @param {espree.Node}       node     Node to test.
+		 * @param {Node}              node     Node to test.
 		 * @param {WPPackageLocality} locality Desired package locality.
 		 *
-		 * @return {?WPDependencyBlockCorrection} Correction, if applicable.
+		 * @return {WPDependencyBlockCorrection=} Correction, if applicable.
 		 */
 		function getDependencyBlockCorrection( node, locality ) {
 			const value = getCommentValue( locality );
@@ -146,6 +153,9 @@ module.exports = {
 		}
 
 		return {
+			/**
+			 * @param {import('estree').Program} node Program node.
+			 */
 			Program( node ) {
 				/**
 				 * The set of package localities which have been reported for
@@ -157,36 +167,58 @@ module.exports = {
 				 */
 				const verified = new Set();
 
+				/**
+				 * Nodes to check for violations associated with module import,
+				 * an array of tuples of the node and its import source string.
+				 *
+				 * @type {Array<[Node,string]>}
+				 */
+				const candidates = [];
+
 				// Since we only care to enforce imports which occur at the
 				// top-level scope, match on Program and test its children,
 				// rather than matching the import nodes directly.
 				node.body.forEach( ( child ) => {
+					/** @type {string} */
 					let source;
 					switch ( child.type ) {
 						case 'ImportDeclaration':
-							source = child.source.value;
+							source =
+								/** @type {string} */ ( child.source.value );
+							candidates.push( [ child, source ] );
 							break;
 
-						case 'CallExpression':
-							const { callee, arguments: args } = child;
-							if (
-								callee.name === 'require' &&
-								args.length === 1 &&
-								args[ 0 ].type === 'Literal' &&
-								typeof args[ 0 ].value === 'string'
-							) {
-								source = args[ 0 ].value;
-							}
-							break;
-					}
+						case 'VariableDeclaration':
+							child.declarations.forEach( ( declaration ) => {
+								const { init } = declaration;
+								if (
+									! init ||
+									init.type !== 'CallExpression' ||
+									/** @type {import('estree').CallExpression} */ ( init )
+										.callee.type !== 'Identifier' ||
+									/** @type {import('estree').Identifier} */ ( init
+										.callee ).name !== 'require'
+								) {
+									return;
+								}
 
-					if ( ! source ) {
-						return;
+								const { arguments: args } = init;
+								if (
+									args.length === 1 &&
+									args[ 0 ].type === 'Literal' &&
+									typeof args[ 0 ].value === 'string'
+								) {
+									source = args[ 0 ].value;
+									candidates.push( [ child, source ] );
+								}
+							} );
 					}
+				} );
 
+				for ( const [ child, source ] of candidates ) {
 					const locality = getPackageLocality( source );
 					if ( verified.has( locality ) ) {
-						return;
+						continue;
 					}
 
 					// Avoid verifying any other imports for the locality,
@@ -199,7 +231,7 @@ module.exports = {
 						locality
 					);
 					if ( ! correction ) {
-						return;
+						continue;
 					}
 
 					context.report( {
@@ -208,15 +240,18 @@ module.exports = {
 						fix( fixer ) {
 							const { comment, value } = correction;
 							const text = `/*${ value }*/`;
-							if ( comment ) {
-								return fixer.replaceText( comment, text );
+							if ( comment && comment.range ) {
+								return fixer.replaceTextRange(
+									comment.range,
+									text
+								);
 							}
 
 							return fixer.insertTextBefore( child, text + '\n' );
 						},
 					} );
-				} );
+				}
 			},
 		};
 	},
-};
+} );

--- a/packages/eslint-plugin/tsconfig.json
+++ b/packages/eslint-plugin/tsconfig.json
@@ -1,0 +1,13 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"rootDir": "rules",
+		"declarationDir": "build-types"
+	},
+	// NOTE: This package is being progressively typed. You are encouraged to
+	// expand this array with files which can be type-checked. At some point in
+	// the future, this can be simplified to an `includes` of `src/**/*`.
+	"files": [
+		"rules/dependency-group.js"
+	]
+}

--- a/packages/eslint-plugin/utils/index.js
+++ b/packages/eslint-plugin/utils/index.js
@@ -1,3 +1,6 @@
+/**
+ * Internal dependencies
+ */
 const {
 	TRANSLATION_FUNCTIONS,
 	REGEXP_SPRINTF_PLACEHOLDER,

--- a/packages/hooks/benchmark/index.js
+++ b/packages/hooks/benchmark/index.js
@@ -1,4 +1,11 @@
+/**
+ * External dependencies
+ */
 const Benchmark = require( 'benchmark' );
+
+/**
+ * Internal dependencies
+ */
 const hooks = require( '../' );
 
 const suite = new Benchmark.Suite();

--- a/packages/i18n/benchmark/index.js
+++ b/packages/i18n/benchmark/index.js
@@ -1,4 +1,11 @@
+/**
+ * External dependencies
+ */
 const Benchmark = require( 'benchmark' );
+
+/**
+ * Internal dependencies
+ */
 const { __ } = require( '../' );
 
 const suite = new Benchmark.Suite();

--- a/packages/i18n/tools/pot-to-php.js
+++ b/packages/i18n/tools/pot-to-php.js
@@ -1,5 +1,8 @@
 #!/usr/bin/env node
 
+/**
+ * External dependencies
+ */
 const gettextParser = require( 'gettext-parser' );
 const { isEmpty } = require( 'lodash' );
 const fs = require( 'fs' );

--- a/packages/library-export-default-webpack-plugin/test/fixtures/webpack.config.js
+++ b/packages/library-export-default-webpack-plugin/test/fixtures/webpack.config.js
@@ -1,5 +1,5 @@
 /**
- * Internal dependencies
+ * WordPress dependencies
  */
 const LibraryExportDefaultPlugin = require( '@wordpress/library-export-default-webpack-plugin' );
 

--- a/packages/project-management-automation/lib/index.js
+++ b/packages/project-management-automation/lib/index.js
@@ -1,5 +1,5 @@
 /**
- * GitHub dependencies
+ * External dependencies
  */
 const { setFailed, getInput } = require( '@actions/core' );
 const { context, GitHub } = require( '@actions/github' );

--- a/packages/scripts/scripts/env/cli.js
+++ b/packages/scripts/scripts/env/cli.js
@@ -1,5 +1,5 @@
 /**
- * Node dependencies.
+ * External dependencies
  */
 const { execSync } = require( 'child_process' );
 const { env } = require( 'process' );

--- a/packages/scripts/scripts/env/docker-run.js
+++ b/packages/scripts/scripts/env/docker-run.js
@@ -1,5 +1,5 @@
 /**
- * Node dependencies.
+ * External dependencies
  */
 const { execSync } = require( 'child_process' );
 const { env } = require( 'process' );

--- a/packages/scripts/scripts/env/lint-php.js
+++ b/packages/scripts/scripts/env/lint-php.js
@@ -1,5 +1,5 @@
 /**
- * Node dependencies.
+ * External dependencies
  */
 const { execSync } = require( 'child_process' );
 const { env } = require( 'process' );

--- a/packages/scripts/scripts/env/reinstall.js
+++ b/packages/scripts/scripts/env/reinstall.js
@@ -1,5 +1,5 @@
 /**
- * Node dependencies.
+ * External dependencies
  */
 const { execSync } = require( 'child_process' );
 

--- a/packages/scripts/scripts/env/stop.js
+++ b/packages/scripts/scripts/env/stop.js
@@ -1,5 +1,5 @@
 /**
- * Node dependencies.
+ * External dependencies
  */
 const { execSync } = require( 'child_process' );
 const { env } = require( 'process' );

--- a/packages/scripts/scripts/env/test-php.js
+++ b/packages/scripts/scripts/env/test-php.js
@@ -1,5 +1,5 @@
 /**
- * Node dependencies.
+ * External dependencies
  */
 const { execSync } = require( 'child_process' );
 const { env } = require( 'process' );

--- a/packages/scripts/scripts/format-js.js
+++ b/packages/scripts/scripts/format-js.js
@@ -1,5 +1,5 @@
 /**
- * Node dependencies
+ * External dependencies
  */
 const { exit, stdout } = require( 'process' );
 

--- a/test/unit/scripts/babel-transformer.js
+++ b/test/unit/scripts/babel-transformer.js
@@ -1,3 +1,6 @@
+/**
+ * External dependencies
+ */
 const fs = require( 'fs' );
 const babelJest = require( 'babel-jest' );
 const babelJestTransformer = babelJest.createTransformer();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
 		{ "path": "packages/element" },
 		{ "path": "packages/dom-ready" },
 		{ "path": "packages/escape-html" },
+		{ "path": "packages/eslint-plugin" },
 		{ "path": "packages/html-entities" },
 		{ "path": "packages/i18n" },
 		{ "path": "packages/icons" },


### PR DESCRIPTION
Previously: https://github.com/WordPress/gutenberg/pull/22003#discussion_r421493240

This pull request seeks to resolve an error in the ESLint plugin `dependency-group` custom rule, where it does not currently enforce dependency groups for CommonJS `require` module imports. This was always intended, and there was logic which existed for it. However, it was not properly unit tested and didn't work.

**Implementation Notes:**

The underlying issue is that the logic was testing for child nodes of the `Program` node matching `CallExpression`. `CallExpression` is not a valid child of `Program`. This was made evident in the course of adding type-checking for this file:

![image](https://user-images.githubusercontent.com/1779930/81422604-2d689b80-9121-11ea-93f6-0acd603e7e83.png)

The new implementation tests _variable declarations_ which are children of the `Program` node. This requires a minimal restructuring of the logic, since variable declarations can have multiple declarators.

**Testing Instructions:**

Ensure unit tests pass:

```
npm run test-unit packages/eslint-plugin/rules/__tests__/dependency-group.js
```

Ensure lint reports no errors:

```
npm run lint-js
```

Ensure type checking passes:

```
npm run build:package-types
```