### PR TITLE
[RNMobile] Merge release branch back to master for v1.27.1

### DIFF
--- a/packages/block-editor/src/components/page-template-picker/templates/about.native.js
+++ b/packages/block-editor/src/components/page-template-picker/templates/about.native.js
@@ -94,11 +94,16 @@ const About = {
 			},
 		},
 		{
-			name: 'core/button',
-			attributes: {
-				// translators: sample content for "About" page template
-				text: __( 'Get in Touch' ),
-			},
+			name: 'core/buttons',
+			innerBlocks: [
+				{
+					name: 'core/button',
+					attributes: {
+						// translators: sample content for "About" page template
+						text: __( 'Get in Touch' ),
+					},
+				},
+			],
 		},
 		{
 			name: 'core/spacer',

--- a/packages/block-editor/src/components/page-template-picker/templates/blog.native.js
+++ b/packages/block-editor/src/components/page-template-picker/templates/blog.native.js
@@ -44,43 +44,6 @@ const Blog = {
 			name: 'core/separator',
 			attributes: {},
 		},
-		{
-			name: 'core/spacer',
-			attributes: {
-				height: 24,
-			},
-		},
-		{
-			name: 'core/heading',
-			attributes: {
-				align: 'center',
-				// translators: sample content for "Blog" page template
-				content: __( 'Follow our Blog' ),
-				level: 2,
-			},
-		},
-		{
-			name: 'core/buttons',
-			innerBlocks: [
-				{
-					name: 'core/button',
-					attributes: {
-						// translators: sample content for "Blog" page template
-						text: __( 'Subscribe' ),
-					},
-				},
-			],
-		},
-		{
-			name: 'core/spacer',
-			attributes: {
-				height: 24,
-			},
-		},
-		{
-			name: 'core/separator',
-			attributes: {},
-		},
 	],
 };
 

--- a/packages/block-editor/src/components/page-template-picker/templates/blog.native.js
+++ b/packages/block-editor/src/components/page-template-picker/templates/blog.native.js
@@ -60,11 +60,16 @@ const Blog = {
 			},
 		},
 		{
-			name: 'core/button',
-			attributes: {
-				// translators: sample content for "Blog" page template
-				text: __( 'Subscribe' ),
-			},
+			name: 'core/buttons',
+			innerBlocks: [
+				{
+					name: 'core/button',
+					attributes: {
+						// translators: sample content for "Blog" page template
+						text: __( 'Subscribe' ),
+					},
+				},
+			],
 		},
 		{
 			name: 'core/spacer',

--- a/packages/block-editor/src/components/page-template-picker/templates/portfolio.native.js
+++ b/packages/block-editor/src/components/page-template-picker/templates/portfolio.native.js
@@ -175,15 +175,20 @@ const Portfolio = {
 			},
 		},
 		{
-			name: 'core/button',
-			attributes: {
-				url: '',
-				// translators: sample content for "Portfolio" page template
-				text: __( 'Get in touch!' ),
-				linkTarget: '',
-				rel: '',
-				className: 'aligncenter',
-			},
+			name: 'core/buttons',
+			innerBlocks: [
+				{
+					name: 'core/button',
+					attributes: {
+						url: '',
+						// translators: sample content for "Portfolio" page template
+						text: __( 'Get in touch!' ),
+						linkTarget: '',
+						rel: '',
+						className: 'aligncenter',
+					},
+				},
+			],
 		},
 		{
 			name: 'core/spacer',

--- a/packages/block-editor/src/components/page-template-picker/templates/services.native.js
+++ b/packages/block-editor/src/components/page-template-picker/templates/services.native.js
@@ -139,11 +139,16 @@ const Services = {
 			},
 		},
 		{
-			name: 'core/button',
-			attributes: {
-				// translators: sample content for "Services" page template
-				text: __( 'Get in Touch' ),
-			},
+			name: 'core/buttons',
+			innerBlocks: [
+				{
+					name: 'core/button',
+					attributes: {
+						// translators: sample content for "Services" page template
+						text: __( 'Get in Touch' ),
+					},
+				},
+			],
 		},
 		{
 			name: 'core/spacer',

--- a/packages/block-editor/src/components/page-template-picker/templates/team.native.js
+++ b/packages/block-editor/src/components/page-template-picker/templates/team.native.js
@@ -225,14 +225,19 @@ const Team = {
 			},
 		},
 		{
-			name: 'core/button',
-			attributes: {
-				url: '',
-				// translators: sample content for "Team" page template
-				text: __( 'Get in Touch!' ),
-				borderRadius: 4,
-				className: 'aligncenter',
-			},
+			name: 'core/buttons',
+			innerBlocks: [
+				{
+					name: 'core/button',
+					attributes: {
+						url: '',
+						// translators: sample content for "Team" page template
+						text: __( 'Get in Touch!' ),
+						borderRadius: 4,
+						className: 'aligncenter',
+					},
+				},
+			],
 		},
 		{
 			name: 'core/spacer',


### PR DESCRIPTION
`Gutenberg Mobile PR` ->

This PR brings rnmobile/release-1.27.1 to master for v1.27.1.

To test:

Automated tests should pass.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
