### PR TITLE
Create Block: Simplify the process of defining a config for templates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9997,6 +9997,7 @@
 				"check-node-version": "^3.1.1",
 				"commander": "^4.1.0",
 				"execa": "^4.0.0",
+				"fast-glob": "^2.2.7",
 				"inquirer": "^7.1.0",
 				"lodash": "^4.17.15",
 				"make-dir": "^3.0.0",

--- a/packages/create-block/CHANGELOG.md
+++ b/packages/create-block/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Internal
+
+- Refactored handling of predefined block templates [#22235](https://github.com/WordPress/gutenberg/pull/22235).
+
 ## 0.12.0 (2020-04-30)
 
 ### New Features

--- a/packages/create-block/README.md
+++ b/packages/create-block/README.md
@@ -38,7 +38,7 @@ $ npm init @wordpress/block [options] [slug]
 Options:
 ```
 -V, --version                output the version number
--t, --template <name>        template type name, allowed values: "es5", "esnext" (default: "esnext")
+-t, --template <name>        block template type name, allowed values: "es5", "esnext" (default: "esnext")
 --namespace <value>          internal namespace for the block name
 --title <value>              display title for the block
 --short-description <value>  short description for the block

--- a/packages/create-block/lib/index.js
+++ b/packages/create-block/lib/index.js
@@ -55,7 +55,7 @@ program
 		) => {
 			await checkSystemRequirements( engines );
 			try {
-				const blockTemplate = getBlockTemplate( templateName );
+				const blockTemplate = await getBlockTemplate( templateName );
 				const defaultValues = getDefaultValues( blockTemplate );
 				const optionsValues = pickBy( {
 					category,

--- a/packages/create-block/lib/index.js
+++ b/packages/create-block/lib/index.js
@@ -13,7 +13,11 @@ const CLIError = require( './cli-error' );
 const log = require( './log' );
 const { engines, version } = require( '../package.json' );
 const scaffold = require( './scaffold' );
-const { getDefaultValues, getPrompts } = require( './templates' );
+const {
+	getBlockTemplate,
+	getDefaultValues,
+	getPrompts,
+} = require( './templates' );
 
 const commandName = `wp-create-block`;
 program
@@ -24,13 +28,13 @@ program
 			'it is used as the block slug used for its identification, the output ' +
 			'location for scaffolded files, and the name of the WordPress plugin.' +
 			'The rest of the configuration is set to all default values unless ' +
-			'overriden with some of the options listed below.'
+			'overridden with some of the options listed below.'
 	)
 	.version( version )
 	.arguments( '[slug]' )
 	.option(
 		'-t, --template <name>',
-		'template type name, allowed values: "es5", "esnext"',
+		'block template type name, allowed values: "es5", "esnext"',
 		'esnext'
 	)
 	.option( '--namespace <value>', 'internal namespace for the block name' )
@@ -41,14 +45,21 @@ program
 	.action(
 		async (
 			slug,
-			{ category, namespace, shortDescription, template, title }
+			{
+				category,
+				namespace,
+				shortDescription: description,
+				template: templateName,
+				title,
+			}
 		) => {
 			await checkSystemRequirements( engines );
 			try {
-				const defaultValues = getDefaultValues( template );
+				const blockTemplate = getBlockTemplate( templateName );
+				const defaultValues = getDefaultValues( blockTemplate );
 				const optionsValues = pickBy( {
 					category,
-					description: shortDescription,
+					description,
 					namespace,
 					title,
 				} );
@@ -60,14 +71,14 @@ program
 						title: startCase( slug ),
 						...optionsValues,
 					};
-					await scaffold( template, answers );
+					await scaffold( blockTemplate, answers );
 				} else {
-					const propmpts = getPrompts( template ).filter(
+					const prompts = getPrompts( blockTemplate ).filter(
 						( { name } ) =>
 							! Object.keys( optionsValues ).includes( name )
 					);
-					const answers = await inquirer.prompt( propmpts );
-					await scaffold( template, {
+					const answers = await inquirer.prompt( prompts );
+					await scaffold( blockTemplate, {
 						...defaultValues,
 						...optionsValues,
 						...answers,

--- a/packages/create-block/lib/scaffold.js
+++ b/packages/create-block/lib/scaffold.js
@@ -12,7 +12,7 @@ const { dirname } = require( 'path' );
  */
 const initWPScripts = require( './init-wp-scripts' );
 const { code, info, success } = require( './log' );
-const { hasWPScriptsEnabled, getOutputTemplates } = require( './templates' );
+const { hasWPScriptsEnabled } = require( './templates' );
 
 module.exports = async function(
 	blockTemplate,
@@ -35,6 +35,7 @@ module.exports = async function(
 	info( '' );
 	info( `Creating a new WordPress block in "${ slug }" folder.` );
 
+	const { outputTemplates } = blockTemplate;
 	const view = {
 		namespace,
 		namespaceSnakeCase: snakeCase( namespace ),
@@ -50,7 +51,6 @@ module.exports = async function(
 		licenseURI,
 		textdomain: namespace,
 	};
-	const outputTemplates = await getOutputTemplates( blockTemplate );
 	await Promise.all(
 		Object.keys( outputTemplates ).map( async ( outputFile ) => {
 			// Output files can have names that depend on the slug provided.

--- a/packages/create-block/lib/scaffold.js
+++ b/packages/create-block/lib/scaffold.js
@@ -50,20 +50,17 @@ module.exports = async function(
 		licenseURI,
 		textdomain: namespace,
 	};
+	const outputFiles = await getOutputFiles( templateName );
 	await Promise.all(
-		getOutputFiles( templateName ).map( async ( file ) => {
+		outputFiles.map( async ( file ) => {
 			const template = await readFile(
-				join(
-					__dirname,
-					`templates/${ templateName }/${ file }.mustache`
-				),
+				join( __dirname, `templates/${ templateName }/${ file }` ),
 				'utf8'
 			);
 			// Output files can have names that depend on the slug provided.
-			const outputFilePath = `${ slug }/${ file.replace(
-				/\$slug/g,
-				slug
-			) }`;
+			const outputFilePath = `${ slug }/${ file
+				.replace( /\$slug/g, slug )
+				.replace( '.mustache', '' ) }`;
 			await makeDir( dirname( outputFilePath ) );
 			writeFile( outputFilePath, render( template, view ) );
 		} )

--- a/packages/create-block/lib/scaffold.js
+++ b/packages/create-block/lib/scaffold.js
@@ -1,21 +1,21 @@
 /**
  * External dependencies
  */
-const { dirname, join } = require( 'path' );
-const makeDir = require( 'make-dir' );
-const { readFile, writeFile } = require( 'fs' ).promises;
-const { render } = require( 'mustache' );
+const { writeFile } = require( 'fs' ).promises;
 const { snakeCase } = require( 'lodash' );
+const makeDir = require( 'make-dir' );
+const { render } = require( 'mustache' );
+const { dirname } = require( 'path' );
 
 /**
  * Internal dependencies
  */
 const initWPScripts = require( './init-wp-scripts' );
 const { code, info, success } = require( './log' );
-const { hasWPScriptsEnabled, getOutputFiles } = require( './templates' );
+const { hasWPScriptsEnabled, getOutputTemplates } = require( './templates' );
 
 module.exports = async function(
-	templateName,
+	blockTemplate,
 	{
 		namespace,
 		slug,
@@ -50,23 +50,23 @@ module.exports = async function(
 		licenseURI,
 		textdomain: namespace,
 	};
-	const outputFiles = await getOutputFiles( templateName );
+	const outputTemplates = await getOutputTemplates( blockTemplate );
 	await Promise.all(
-		outputFiles.map( async ( file ) => {
-			const template = await readFile(
-				join( __dirname, `templates/${ templateName }/${ file }` ),
-				'utf8'
-			);
+		Object.keys( outputTemplates ).map( async ( outputFile ) => {
 			// Output files can have names that depend on the slug provided.
-			const outputFilePath = `${ slug }/${ file
-				.replace( /\$slug/g, slug )
-				.replace( '.mustache', '' ) }`;
+			const outputFilePath = `${ slug }/${ outputFile.replace(
+				/\$slug/g,
+				slug
+			) }`;
 			await makeDir( dirname( outputFilePath ) );
-			writeFile( outputFilePath, render( template, view ) );
+			writeFile(
+				outputFilePath,
+				render( outputTemplates[ outputFile ], view )
+			);
 		} )
 	);
 
-	if ( hasWPScriptsEnabled( templateName ) ) {
+	if ( hasWPScriptsEnabled( blockTemplate ) ) {
 		await initWPScripts( view );
 	}
 
@@ -74,7 +74,7 @@ module.exports = async function(
 	success(
 		`Done: block "${ title }" bootstrapped in the "${ slug }" folder.`
 	);
-	if ( hasWPScriptsEnabled( templateName ) ) {
+	if ( hasWPScriptsEnabled( blockTemplate ) ) {
 		info( '' );
 		info( 'Inside that directory, you can run several commands:' );
 		info( '' );

--- a/packages/create-block/lib/templates.js
+++ b/packages/create-block/lib/templates.js
@@ -42,7 +42,7 @@ const getOutputTemplates = async ( name ) => {
 		await Promise.all(
 			outputTemplatesFiles.map( async ( outputTemplateFile ) => {
 				const outputFile = outputTemplateFile.replace(
-					'.mustache',
+					/\.mustache$/,
 					''
 				);
 				const outputTemplate = await readFile(
@@ -93,7 +93,7 @@ const getPrompts = ( blockTemplate ) => {
 };
 
 const hasWPScriptsEnabled = ( blockTemplate ) => {
-	return ! ( blockTemplate.wpScripts === false );
+	return blockTemplate.wpScripts !== false;
 };
 
 module.exports = {

--- a/packages/create-block/lib/templates.js
+++ b/packages/create-block/lib/templates.js
@@ -1,67 +1,34 @@
 /**
+ * External dependencies
+ */
+const glob = require( 'fast-glob' );
+const { join } = require( 'path' );
+
+/**
  * Internal dependencies
  */
 const CLIError = require( './cli-error' );
 const prompts = require( './prompts' );
 
-const namespace = 'create-block';
-const dashicon = 'smiley';
-const category = 'widgets';
-const author = 'The WordPress Contributors';
-const license = 'GPL-2.0-or-later';
-const licenseURI = 'https://www.gnu.org/licenses/gpl-2.0.html';
-const version = '0.1.0';
-
 const templates = {
 	es5: {
 		defaultValues: {
-			namespace,
 			slug: 'es5-example',
 			title: 'ES5 Example',
 			description:
 				'Example block written with ES5 standard and no JSX – no build step required.',
-			dashicon,
-			category,
-			author,
-			license,
-			licenseURI,
-			version,
 		},
-		outputFiles: [
-			'.editorconfig',
-			'editor.css',
-			'index.js',
-			'$slug.php',
-			'style.css',
-			'readme.txt',
-		],
+		templatesPath: './templates/es5',
+		wpScripts: false,
 	},
 	esnext: {
 		defaultValues: {
-			namespace,
 			slug: 'esnext-example',
 			title: 'ESNext Example',
 			description:
 				'Example block written with ESNext standard and JSX support – build step required.',
-			dashicon,
-			category,
-			author,
-			license,
-			licenseURI,
-			version,
 		},
-		outputFiles: [
-			'.editorconfig',
-			'.gitignore',
-			'editor.css',
-			'src/edit.js',
-			'src/index.js',
-			'src/save.js',
-			'$slug.php',
-			'style.css',
-			'readme.txt',
-		],
-		wpScriptsEnabled: true,
+		templatesPath: './templates/esnext',
 	},
 };
 
@@ -77,11 +44,25 @@ const getTemplate = ( templateName ) => {
 };
 
 const getDefaultValues = ( templateName ) => {
-	return getTemplate( templateName ).defaultValues;
+	return {
+		namespace: 'create-block',
+		dashicon: 'smiley',
+		category: 'widgets',
+		author: 'The WordPress Contributors',
+		license: 'GPL-2.0-or-later',
+		licenseURI: 'https://www.gnu.org/licenses/gpl-2.0.html',
+		version: '0.1.0',
+		...getTemplate( templateName ).defaultValues,
+	};
 };
 
-const getOutputFiles = ( templateName ) => {
-	return getTemplate( templateName ).outputFiles;
+const getOutputFiles = async ( templateName ) => {
+	const templatesPath = getTemplate( templateName ).templatesPath;
+
+	return await glob( '**/*.mustache', {
+		cwd: join( __dirname, templatesPath ),
+		dot: true,
+	} );
 };
 
 const getPrompts = ( templateName ) => {
@@ -95,7 +76,7 @@ const getPrompts = ( templateName ) => {
 };
 
 const hasWPScriptsEnabled = ( templateName ) => {
-	return getTemplate( templateName ).wpScriptsEnabled || false;
+	return ! ( getTemplate( templateName ).wpScripts === false );
 };
 
 module.exports = {

--- a/packages/create-block/lib/templates.js
+++ b/packages/create-block/lib/templates.js
@@ -20,7 +20,6 @@ const predefinedBlockTemplates = {
 			description:
 				'Example block written with ES5 standard and no JSX – no build step required.',
 		},
-		templatesPath: './templates/es5',
 		wpScripts: false,
 	},
 	esnext: {
@@ -30,36 +29,11 @@ const predefinedBlockTemplates = {
 			description:
 				'Example block written with ESNext standard and JSX support – build step required.',
 		},
-		templatesPath: './templates/esnext',
 	},
 };
 
-const getBlockTemplate = ( templateName ) => {
-	if ( ! predefinedBlockTemplates[ templateName ] ) {
-		throw new CLIError(
-			`Invalid block template type name. Allowed values: ${ Object.keys(
-				predefinedBlockTemplates
-			).join( ', ' ) }.`
-		);
-	}
-	return predefinedBlockTemplates[ templateName ];
-};
-
-const getDefaultValues = ( blockTemplate ) => {
-	return {
-		namespace: 'create-block',
-		dashicon: 'smiley',
-		category: 'widgets',
-		author: 'The WordPress Contributors',
-		license: 'GPL-2.0-or-later',
-		licenseURI: 'https://www.gnu.org/licenses/gpl-2.0.html',
-		version: '0.1.0',
-		...blockTemplate.defaultValues,
-	};
-};
-
-const getOutputTemplates = async ( blockTemplate ) => {
-	const outputTemplatesPath = join( __dirname, blockTemplate.templatesPath );
+const getOutputTemplates = async ( name ) => {
+	const outputTemplatesPath = join( __dirname, 'templates', name );
 	const outputTemplatesFiles = await glob( '**/*.mustache', {
 		cwd: outputTemplatesPath,
 		dot: true,
@@ -81,6 +55,33 @@ const getOutputTemplates = async ( blockTemplate ) => {
 	);
 };
 
+const getBlockTemplate = async ( templateName ) => {
+	if ( ! predefinedBlockTemplates[ templateName ] ) {
+		throw new CLIError(
+			`Invalid block template type name. Allowed values: ${ Object.keys(
+				predefinedBlockTemplates
+			).join( ', ' ) }.`
+		);
+	}
+	return {
+		...predefinedBlockTemplates[ templateName ],
+		outputTemplates: await getOutputTemplates( templateName ),
+	};
+};
+
+const getDefaultValues = ( blockTemplate ) => {
+	return {
+		namespace: 'create-block',
+		dashicon: 'smiley',
+		category: 'widgets',
+		author: 'The WordPress Contributors',
+		license: 'GPL-2.0-or-later',
+		licenseURI: 'https://www.gnu.org/licenses/gpl-2.0.html',
+		version: '0.1.0',
+		...blockTemplate.defaultValues,
+	};
+};
+
 const getPrompts = ( blockTemplate ) => {
 	const defaultValues = getDefaultValues( blockTemplate );
 	return Object.keys( prompts ).map( ( promptName ) => {
@@ -98,7 +99,6 @@ const hasWPScriptsEnabled = ( blockTemplate ) => {
 module.exports = {
 	getBlockTemplate,
 	getDefaultValues,
-	getOutputTemplates,
 	getPrompts,
 	hasWPScriptsEnabled,
 };

--- a/packages/create-block/package.json
+++ b/packages/create-block/package.json
@@ -34,6 +34,7 @@
 		"check-node-version": "^3.1.1",
 		"commander": "^4.1.0",
 		"execa": "^4.0.0",
+		"fast-glob": "^2.2.7",
 		"inquirer": "^7.1.0",
 		"lodash": "^4.17.15",
 		"make-dir": "^3.0.0",


### PR DESCRIPTION
## Description
Related to efforts started by @fabiankaegy in #22175.

The goal here is to make it simplify the process of defining templates:
- a template can define only overrides for default values provided by the tool for all prompts
- there is no longer need to list all output template files, `glob` detects them based on the file path that is assumed as `lib/templates/${ templateName }` for predefined templates
- `wpScripts` are enabled by default, the template author can disable that by setting to `false`

There was general refactoring performed to process the template and create full configuration first and use such an object to pass to all other helper functions. This way, it's going to be way much easier to handle external templates as explored in #22175.

## How has this been tested?

`npx wp-create-block fun-with-template`
`npx wp-create-block fun-with-template -t es5`

## Types of changes

Refactoring.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [N/A] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [N/A] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [N/A] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
