### PR TITLE
Build Tools: Validate package-lock.json for "resolved" errors

### DIFF
--- a/bin/tsconfig.json
+++ b/bin/tsconfig.json
@@ -17,5 +17,6 @@
 		"./api-docs/update-api-docs.js",
 		"./check-latest-npm.js",
 		"./changelog.js",
+		"./validate-package-lock.js",
 	]
 }

--- a/bin/validate-package-lock.js
+++ b/bin/validate-package-lock.js
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * External dependencies
+ */
+const { red, yellow } = require( 'chalk' );
+
+/**
+ * Internal dependencies
+ */
+const packageLock = require( '../package-lock' );
+
+const dependencies = Object.entries( packageLock.dependencies );
+for ( const [ name, dependency ] of dependencies ) {
+	if ( dependency.resolved === false ) {
+		console.log(
+			`Invalid resolved dependency in package-lock.json.
+
+${ red( JSON.stringify( { [ name ]: dependency }, null, '\t' ) ) }
+
+To fix, try removing the node_modules directory, then run ${ yellow(
+				'npm install'
+			) }.
+`
+		);
+
+		process.exit( 1 );
+	}
+
+	if ( dependency.dependencies ) {
+		dependencies.push( ...Object.entries( dependency.dependencies ) );
+	}
+}

--- a/bin/validate-package-lock.js
+++ b/bin/validate-package-lock.js
@@ -1,6 +1,13 @@
 #!/usr/bin/env node
 'use strict';
 
+// This script validates `package-lock.json` to avoid the introduction of an
+// erroneous `"resolved": false` value. It appears to be related to an upstream
+// unresolved issue with NPM. If the upstream issue is resolved, this script
+// should no longer be necessary.
+//
+// See: https://github.com/npm/cli/issues/1138
+
 /**
  * External dependencies
  */

--- a/bin/validate-package-lock.js
+++ b/bin/validate-package-lock.js
@@ -16,6 +16,8 @@ const { red, yellow } = require( 'chalk' );
 /**
  * Internal dependencies
  */
+// Ignore reason: `package-lock.json` exists outside `bin` `rootDir`.
+// @ts-ignore
 const packageLock = require( '../package-lock' );
 
 const dependencies = Object.entries( packageLock.dependencies );

--- a/package.json
+++ b/package.json
@@ -206,12 +206,13 @@
 		"fixtures:generate": "npm run fixtures:server-registered && cross-env GENERATE_MISSING_FIXTURES=y npm run test-unit",
 		"fixtures:regenerate": "npm run fixtures:clean && npm run fixtures:generate",
 		"format-js": "wp-scripts format-js",
-		"lint": "concurrently \"npm run lint-js\" \"npm run lint-pkg-json\" \"npm run lint-css\"",
+		"lint": "concurrently \"npm run lint-lockfile\" \"npm run lint-js\" \"npm run lint-pkg-json\" \"npm run lint-css\"",
 		"lint-js": "wp-scripts lint-js",
 		"lint-js:fix": "npm run lint-js -- --fix",
 		"prelint-php": "npm run wp-env run composer install -- --no-interaction",
 		"lint-php": "npm run wp-env run composer run-script lint",
 		"lint-pkg-json": "wp-scripts lint-pkg-json . 'packages/*/package.json'",
+		"lint-lockfile": "node ./bin/validate-package-lock.js",
 		"lint-css": "wp-scripts lint-style '**/*.scss'",
 		"lint-css:fix": "npm run lint-css -- --fix",
 		"lint:md-js": "wp-scripts lint-md-js",
@@ -255,6 +256,7 @@
 	},
 	"lint-staged": {
 		"package-lock.json": [
+			"npm run lint-lockfile",
 			"node ./bin/check-latest-npm.js"
 		],
 		"packages/*/package.json": [


### PR DESCRIPTION
Related Slack discussion ([link requires registration](https://make.wordpress.org/chat/)): https://wordpress.slack.com/archives/C02QB2JS7/p1588692036240600
Related upstream issue: https://github.com/npm/cli/issues/1138
Previously:
- https://github.com/WordPress/gutenberg/issues/16157#issuecomment-599589261
- https://github.com/WordPress/gutenberg/pull/21873#discussion_r418234268
- https://github.com/WordPress/gutenberg/pull/21424#discussion_r404778909
- https://github.com/WordPress/gutenberg/pull/20555#discussion_r402991541
- https://github.com/WordPress/gutenberg/pull/21306

This pull request seeks to add a pre-commit and continuous integration build step for validating the contents of `package-lock.json`. Notably, this is intended to try to capture issues where an invalid `resolved` value becomes introduced in `package-lock.json`. The script `bin/validate-package-lock.js` will deeply check the contents of the lockfile for any `resolved: false`.

The idea for this change proposal was inspired by @adamziel 's comment at https://github.com/WordPress/gutenberg/pull/21873#discussion_r419915579.

**Testing Instructions:**

Introduce `"resolved": false` in a dependency in `package-lock.json` (manually) and attempt to commit the change. Observe an error.

```
Found invalid resolved dependency in package-lock.json.

{
	"semver": {
		"version": "5.7.1",
		"resolved": false,
		"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
	}
}

To fix, try removing the node_modules directory, then run npm install.
```