### PR TITLE
Add support for named orientations and literal colors on custom gradients

### DIFF
--- a/packages/components/src/custom-gradient-picker/serializer.js
+++ b/packages/components/src/custom-gradient-picker/serializer.js
@@ -4,6 +4,9 @@
 import { compact, get } from 'lodash';
 
 export function serializeGradientColor( { type, value } ) {
+	if ( type === 'literal' ) {
+		return value;
+	}
 	return `${ type }(${ value.join( ',' ) })`;
 }
 

--- a/packages/components/src/custom-gradient-picker/utils.js
+++ b/packages/components/src/custom-gradient-picker/utils.js
@@ -240,6 +240,21 @@ export function getLinearGradientRepresentationOfARadial( gradientAST ) {
 	} );
 }
 
+const DIRECTIONAL_ORIENTATION_ANGLE_MAP = {
+	top: 0,
+	'top right': 45,
+	'right top': 45,
+	right: 90,
+	'right bottom': 135,
+	'bottom right': 135,
+	bottom: 180,
+	'bottom left': 225,
+	'left bottom': 225,
+	left: 270,
+	'top left': 315,
+	'left top': 315,
+};
+
 export function getGradientParsed( value ) {
 	let hasGradient = !! value;
 	// gradientAST will contain the gradient AST as parsed by gradient-parser npm module.
@@ -255,6 +270,15 @@ export function getGradientParsed( value ) {
 		gradientValue = DEFAULT_GRADIENT;
 	}
 
+	if (
+		gradientAST.orientation &&
+		gradientAST.orientation.type === 'directional'
+	) {
+		gradientAST.orientation.type = 'angular';
+		gradientAST.orientation.value = DIRECTIONAL_ORIENTATION_ANGLE_MAP[
+			gradientAST.orientation.value
+		].toString();
+	}
 	return {
 		hasGradient,
 		gradientAST,


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/21831

This PR makes sure the custom gradient picker is able to parse and correctly display gradients with named orientations instead of an explicit angle (e.g. to right) and gradients with explicit colors (e.g: red).

## How has this been tested?
I added this preset gradient:
```
add_theme_support( 
  'editor-gradient-presets', 
  array(
    array(
      'name'     => __( 'My gradient', 'en'  ),
      'gradient' => 'linear-gradient(to bottom, red 50%, white 100%)',
      'slug'     => 'my-gradient'
    )
  )
);
```

I selected the preset as the background of a button and I verified I could customize the gradient on the custom gradient picker.