### PR TITLE
Block Directory: Check if the found block can be inserted

### DIFF
--- a/packages/block-directory/src/components/downloadable-blocks-list/index.js
+++ b/packages/block-directory/src/components/downloadable-blocks-list/index.js
@@ -59,13 +59,14 @@ function DownloadableBlocksList( {
 }
 
 export default compose(
-	withDispatch( ( dispatch, props ) => {
+	withDispatch( ( dispatch, props, { select } ) => {
 		const { installBlock, downloadBlock } = dispatch(
 			'core/block-directory'
 		);
 		const { createErrorNotice, removeNotice } = dispatch( 'core/notices' );
 		const { removeBlocks } = dispatch( 'core/block-editor' );
-		const { onSelect } = props;
+		const { canInsertBlockType } = select( 'core/block-editor' );
+		const { onSelect, rootClientId } = props;
 
 		return {
 			downloadAndInstallBlock: ( item ) => {
@@ -89,6 +90,17 @@ export default compose(
 				};
 
 				const onSuccess = () => {
+					if ( ! canInsertBlockType( item.name, rootClientId ) ) {
+						createErrorNotice(
+							__( 'You can’t add that block here.' ),
+							{
+								id: INSTALL_ERROR_NOTICE_ID,
+							}
+						);
+						return;
+					}
+
+					// Insert block.
 					const createdBlock = onSelect( item );
 
 					const onInstallBlockError = () => {

--- a/packages/block-directory/src/components/downloadable-blocks-list/index.js
+++ b/packages/block-directory/src/components/downloadable-blocks-list/index.js
@@ -97,6 +97,7 @@ export default compose(
 								id: INSTALL_ERROR_NOTICE_ID,
 							}
 						);
+						unregisterBlockType( item.name );
 						return;
 					}
 

--- a/packages/block-directory/src/components/downloadable-blocks-panel/index.js
+++ b/packages/block-directory/src/components/downloadable-blocks-panel/index.js
@@ -20,6 +20,7 @@ function DownloadableBlocksPanel( {
 	isLoading,
 	isWaiting,
 	debouncedSpeak,
+	rootClientId,
 } ) {
 	if ( ! hasPermission ) {
 		debouncedSpeak(
@@ -76,6 +77,7 @@ function DownloadableBlocksPanel( {
 				items={ downloadableItems }
 				onSelect={ onSelect }
 				onHover={ onHover }
+				rootClientId={ rootClientId }
 			/>
 		</Fragment>
 	);

--- a/packages/block-directory/src/plugins/inserter-menu-downloadable-blocks-panel/index.js
+++ b/packages/block-directory/src/plugins/inserter-menu-downloadable-blocks-panel/index.js
@@ -21,7 +21,13 @@ function InserterMenuDownloadableBlocksPanel() {
 
 	return (
 		<__experimentalInserterMenuExtension>
-			{ ( { onSelect, onHover, filterValue, hasItems } ) => {
+			{ ( {
+				onSelect,
+				onHover,
+				filterValue,
+				hasItems,
+				rootClientId,
+			} ) => {
 				if ( hasItems || ! filterValue ) {
 					return null;
 				}
@@ -36,6 +42,7 @@ function InserterMenuDownloadableBlocksPanel() {
 						onHover={ onHover }
 						filterValue={ debouncedFilterValue }
 						isWaiting={ filterValue !== debouncedFilterValue }
+						rootClientId={ rootClientId }
 					/>
 				);
 			} }

--- a/packages/block-editor/src/components/inserter/block-list.js
+++ b/packages/block-editor/src/components/inserter/block-list.js
@@ -278,6 +278,7 @@ function InserterBlockList( {
 					onHover,
 					filterValue,
 					hasItems,
+					rootClientId,
 				} }
 			>
 				{ ( fills ) => {


### PR DESCRIPTION
## Description
Some blocks (or post types) have a restricted list of what can be added (`allowedBlocks`), and we might not be able to add a new block to those containers. Before trying to add & install the plugin, this checks if the block is allowed.

I tried filtering through `downloadableItems`, so we could only show allowed blocks, but unfortunately `canInsertBlockType` needs the block to be registered first. So instead, we'll show an error and abort the install process.

## How to test

I made a quick plugin that restricted blocks for all content, and when I tried to search for & add a block, I get the error.
```php
<?php
add_filter(
	'allowed_block_types',
	function() {
		return array(
			'core/paragraph',
			'core/heading',
		);
	}
);
```

You can add a block from the block directory to that array (ex, `card-block/main`), and then try to use it, and it should work. It should also still work for unrestricted editors.

## Screenshots

The error (copy could be improved for sure 🙂 )

![Screen Shot 2020-05-08 at 5 55 48 PM](https://user-images.githubusercontent.com/541093/81452544-26f41700-9155-11ea-9d3c-df143ece5f2a.png)

