### PR TITLE
Use default appender at the bottom of full site editor

### DIFF
--- a/packages/edit-site/src/components/block-editor/index.js
+++ b/packages/edit-site/src/components/block-editor/index.js
@@ -13,7 +13,7 @@ import {
 	WritingFlow,
 	ObserveTyping,
 	BlockList,
-	ButtonBlockerAppender,
+	DefaultBlockAppender,
 } from '@wordpress/block-editor';
 
 /**
@@ -94,7 +94,7 @@ export default function BlockEditor() {
 					<ObserveTyping>
 						<BlockList
 							className="edit-site-block-editor__block-list"
-							renderAppender={ ButtonBlockerAppender }
+							renderAppender={ DefaultBlockAppender }
 						/>
 					</ObserveTyping>
 				</WritingFlow>


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

This resolves #22036 by replacing the `ButtonBlockerAppender` at the bottom of the Full Site Editor with `DefaultBlockAppender`.  This brings the appender style in line with the post editor.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Tested in the browser, and ran automated tests locally.

## Screenshots <!-- if applicable -->

Before:
<img width="1377" alt="Screen Shot 2020-05-09 at 5 47 36 PM" src="https://user-images.githubusercontent.com/9020968/81486819-2fb02000-921d-11ea-8c20-66fae72bc580.png">

After:
<img width="1005" alt="Screen Shot 2020-05-09 at 5 45 07 PM" src="https://user-images.githubusercontent.com/9020968/81486826-39398800-921d-11ea-87ca-a7ba015ffbaf.png">


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Replaced one component with another inside an existing feature. Non-breaking change.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
