### PR TITLE
added default value in link destination in media-text block

### DIFF
--- a/packages/block-library/src/media-text/block.json
+++ b/packages/block-library/src/media-text/block.json
@@ -30,7 +30,8 @@
 			"type": "string"
 		},
 		"linkDestination": {
-			"type": "string"
+			"type": "string",
+		  	"default": "none"
 		},
 		"linkTarget": {
 			"type": "string",


### PR DESCRIPTION
## Description
I have added a default none value in 
                      "linkDestination": {
			"type": "string",
		  	"default": "none"
		       },

not having this value i can not able to change this value from js by extending block settings.

