### PR TITLE
wp-env: granular volume mappings

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,7 +1,8 @@
 {
 	"core": "WordPress/WordPress",
-	"plugins": [ ".", "./packages/e2e-tests/plugins" ],
+	"plugins": [ "." ],
 	"mappings": {
-		"wp-content/mu-plugins": "./packages/e2e-tests/mu-plugins"
+		"wp-content/mu-plugins": "./packages/e2e-tests/mu-plugins",
+		"wp-content/plugins/gutenberg-test-plugins": "./packages/e2e-tests/plugins"
 	}
 }

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,4 +1,7 @@
 {
 	"core": "WordPress/WordPress",
-	"plugins": [ "." ]
+	"plugins": [ ".", "./packages/e2e-tests/plugins" ],
+	"mappings": {
+		"wp-content/mu-plugins": "./packages/e2e-tests/mu-plugins"
+	}
 }

--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Feature
+
+-   You may now mount local directories other than single plugin or theme sources to WordPress. For example, you can specify `"wp-content/themes": "./path/to/some/themes"` to directly set the wp-content theme directory.
+
 ## 1.1.0 (2020-04-01)
 
 ### New Feature

--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New Feature
 
--   You may now mount local directories other than single plugin or theme sources to WordPress. For example, you can specify `"wp-content/themes": "./path/to/some/themes"` to directly set the wp-content theme directory.
+-   You may now mount local directories to any location within the WordPress install. For example, you may specify `"wp-content/mu-plugins": "./path/to/mu-plugins"` to add mu-plugins.
 
 ## 1.1.0 (2020-04-01)
 

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -250,19 +250,19 @@ You can customize the WordPress installation, plugins and themes that the develo
 
 `.wp-env.json` supports five fields:
 
-| Field         | Type           | Default                                     | Description                                                                                                               |
-| ------------- | -------------- | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| `"core"`      | `string\|null` | `null`                                      | The WordPress installation to use. If `null` is specified, `wp-env` will use the latest production release of WordPress.  |
-| `"plugins"`   | `string[]`     | `[]`                                        | A list of plugins to install and activate in the environment.                                                             |
-| `"themes"`    | `string[]`     | `[]`                                        | A list of themes to install in the environment. The first theme in the list will be activated.                            |
-| `"port"`      | `integer`      | `8888`                                      | The primary port number to use for the insallation. You'll access the instance through the port: 'http://localhost:8888'. |
-| `"testsPort"` | `integer`      | `8889`                                      | The port number to use for the tests instance.                                                                            |
-| `"config"`    | `Object`       | `"{ WP_DEBUG: true, SCRIPT_DEBUG: true }"`  | Mapping of wp-config.php constants to their desired values.                                                               |
-| `"mappings"`  | `Object`       | `"{ "wp-content/themes: "path/to/themes }"` | Mapping of WordPress directories to local directories to be mounted in the WordPress instance.                            |
+| Field         | Type           | Default                                    | Description                                                                                                               |
+| ------------- | -------------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------- |
+| `"core"`      | `string\|null` | `null`                                     | The WordPress installation to use. If `null` is specified, `wp-env` will use the latest production release of WordPress.  |
+| `"plugins"`   | `string[]`     | `[]`                                       | A list of plugins to install and activate in the environment.                                                             |
+| `"themes"`    | `string[]`     | `[]`                                       | A list of themes to install in the environment. The first theme in the list will be activated.                            |
+| `"port"`      | `integer`      | `8888`                                     | The primary port number to use for the insallation. You'll access the instance through the port: 'http://localhost:8888'. |
+| `"testsPort"` | `integer`      | `8889`                                     | The port number to use for the tests instance.                                                                            |
+| `"config"`    | `Object`       | `"{ WP_DEBUG: true, SCRIPT_DEBUG: true }"` | Mapping of wp-config.php constants to their desired values.                                                               |
+| `"mappings"`  | `Object`       | `"{}"`                                     | Mapping of WordPress directories to local directories to be mounted in the WordPress instance.                            |
 
 _Note: the port number environment variables (`WP_ENV_PORT` and `WP_ENV_TESTS_PORT`) take precedent over the .wp-env.json values._
 
-Several types of strings can be passed into the `core`, `plugins`, `themes`, and `mappings` fields. _Note that the `mappings` config only accepts relative and absolute sources as values._
+Several types of strings can be passed into the `core`, `plugins`, `themes`, and `mappings` fields.
 
 | Type              | Format                        | Example(s)                                               |
 | ----------------- | ----------------------------- | -------------------------------------------------------- |
@@ -324,19 +324,34 @@ This is useful for integration testing: that is, testing how old versions of Wor
 }
 ```
 
-#### Override wp-content directories
+#### Add mu-plugins
 
-This is useful if you need to specify wp-content directories directly:
+You can add mu-plugins via the mapping config. The mapping config also allows you to mount a directory to any location in the wordpress install, so you could even mount a subdirectory.
 
-````json
+```json
 {
 	"plugins": [ "." ],
 	"themes": [ "WordPress/theme-experiments" ],
 	"mappings": {
-		"wp-content/uploads": "./path/to/local/uploads",
+		"wp-content/mu-plugins": "./path/to/local/mu-plugins",
 		"wp-content/themes": "./path/to/local/themes",
+		"wp-content/themes/specific-theme": "./path/to/local/theme"
 	}
 }
+```
+
+#### Avoid activating plugins on the instance
+
+Since all plugins in the `plugins` key are activated by default, you should use the `mappings` key to avoid this behavior. This might be helpful if you have a test plugin that should not be activated all the time.
+
+```json
+{
+	"plugins": [ "." ],
+	"mappings": {
+		"wp-content/plugins/my-test-plugin": "./path/to/test/plugin"
+	}
+}
+```
 
 #### Custom Port Numbers
 
@@ -348,6 +363,6 @@ You can tell `wp-env` to use a custom port number so that your instance does not
 	"port": 4013,
 	"testsPort": 4012
 }
-````
+```
 
 <br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -210,7 +210,7 @@ Positionals:
             [string] [choices: "all", "development", "tests"] [default: "tests"]
 ```
 
-### `wp-env run [container] [command]` 
+### `wp-env run [container] [command]`
 
 ```sh
 wp-env run <container> [command..]
@@ -236,10 +236,10 @@ ID      user_login      display_name    user_email      user_registered roles
 ✔ Ran `wp user list` in 'cli'. (in 2s 374ms)
 ```
 
-### `docker logs -f [container_id] >/dev/null` 
+### `docker logs -f [container_id] >/dev/null`
 
 ```sh
-docker logs -f <container_id> >/dev/null 
+docker logs -f <container_id> >/dev/null
 
 Shows the error logs of the specified container in the terminal. The container_id is the one that is visible with `docker ps -a`
 ```
@@ -250,23 +250,24 @@ You can customize the WordPress installation, plugins and themes that the develo
 
 `.wp-env.json` supports five fields:
 
-| Field         | Type          | Default                                    | Description                                                                                                               |
-| ------------- | ------------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------- |
-| `"core"`      | `string\|null` | `null`                                     | The WordPress installation to use. If `null` is specified, `wp-env` will use the latest production release of WordPress.  |
-| `"plugins"`   | `string[]`    | `[]`                                       | A list of plugins to install and activate in the environment.                                                             |
-| `"themes"`    | `string[]`    | `[]`                                       | A list of themes to install in the environment. The first theme in the list will be activated.                            |
-| `"port"`      | `integer`      | `8888`                                   | The primary port number to use for the insallation. You'll access the instance through the port: 'http://localhost:8888'. |
-| `"testsPort"` | `integer`      | `8889`                                   | The port number to use for the tests instance.                                                                            |
-| `"config"`    | `Object`      | `"{ WP_DEBUG: true, SCRIPT_DEBUG: true }"` | Mapping of wp-config.php constants to their desired values.                                                               |
+| Field         | Type           | Default                                     | Description                                                                                                               |
+| ------------- | -------------- | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `"core"`      | `string\|null` | `null`                                      | The WordPress installation to use. If `null` is specified, `wp-env` will use the latest production release of WordPress.  |
+| `"plugins"`   | `string[]`     | `[]`                                        | A list of plugins to install and activate in the environment.                                                             |
+| `"themes"`    | `string[]`     | `[]`                                        | A list of themes to install in the environment. The first theme in the list will be activated.                            |
+| `"port"`      | `integer`      | `8888`                                      | The primary port number to use for the insallation. You'll access the instance through the port: 'http://localhost:8888'. |
+| `"testsPort"` | `integer`      | `8889`                                      | The port number to use for the tests instance.                                                                            |
+| `"config"`    | `Object`       | `"{ WP_DEBUG: true, SCRIPT_DEBUG: true }"`  | Mapping of wp-config.php constants to their desired values.                                                               |
+| `"mappings"`  | `Object`       | `"{ "wp-content/themes: "path/to/themes }"` | Mapping of WordPress directories to local directories to be mounted in the WordPress instance.                            |
 
 _Note: the port number environment variables (`WP_ENV_PORT` and `WP_ENV_TESTS_PORT`) take precedent over the .wp-env.json values._
 
-Several types of strings can be passed into the `core`, `plugins`, and `themes` fields:
+Several types of strings can be passed into the `core`, `plugins`, `themes`, and `mappings` fields. _Note that the `mappings` config only accepts relative and absolute sources as values._
 
 | Type              | Format                        | Example(s)                                               |
 | ----------------- | ----------------------------- | -------------------------------------------------------- |
-| Relative path     | `.<path>\|~<path>`             | `"./a/directory"`, `"../a/directory"`, `"~/a/directory"` |
-| Absolute path     | `/<path>\|<letter>:\<path>`    | `"/a/directory"`, `"C:\\a\\directory"`                   |
+| Relative path     | `.<path>\|~<path>`            | `"./a/directory"`, `"../a/directory"`, `"~/a/directory"` |
+| Absolute path     | `/<path>\|<letter>:\<path>`   | `"/a/directory"`, `"C:\\a\\directory"`                   |
 | GitHub repository | `<owner>/<repo>[#<ref>]`      | `"WordPress/WordPress"`, `"WordPress/gutenberg#master"`  |
 | ZIP File          | `http[s]://<host>/<path>.zip` | `"https://wordpress.org/wordpress-5.4-beta2.zip"`        |
 
@@ -323,6 +324,20 @@ This is useful for integration testing: that is, testing how old versions of Wor
 }
 ```
 
+#### Override wp-content directories
+
+This is useful if you need to specify wp-content directories directly:
+
+````json
+{
+	"plugins": [ "." ],
+	"themes": [ "WordPress/theme-experiments" ],
+	"mappings": {
+		"wp-content/uploads": "./path/to/local/uploads",
+		"wp-content/themes": "./path/to/local/themes",
+	}
+}
+
 #### Custom Port Numbers
 
 You can tell `wp-env` to use a custom port number so that your instance does not conflict with other `wp-env` instances.
@@ -333,6 +348,6 @@ You can tell `wp-env` to use a custom port number so that your instance does not
 	"port": 4013,
 	"testsPort": 4012
 }
-```
+````
 
 <br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -324,25 +324,24 @@ This is useful for integration testing: that is, testing how old versions of Wor
 }
 ```
 
-#### Add mu-plugins
+#### Add mu-plugins and other mapped directories
 
-You can add mu-plugins via the mapping config. The mapping config also allows you to mount a directory to any location in the wordpress install, so you could even mount a subdirectory.
+You can add mu-plugins via the mapping config. The mapping config also allows you to mount a directory to any location in the wordpress install, so you could even mount a subdirectory. Note here that theme-1, will not be activated, despite being the "first" mapped theme.
 
 ```json
 {
 	"plugins": [ "." ],
-	"themes": [ "WordPress/theme-experiments" ],
 	"mappings": {
 		"wp-content/mu-plugins": "./path/to/local/mu-plugins",
 		"wp-content/themes": "./path/to/local/themes",
-		"wp-content/themes/specific-theme": "./path/to/local/theme"
+		"wp-content/themes/specific-theme": "./path/to/local/theme-1"
 	}
 }
 ```
 
-#### Avoid activating plugins on the instance
+#### Avoid activating plugins or themes on the instance
 
-Since all plugins in the `plugins` key are activated by default, you should use the `mappings` key to avoid this behavior. This might be helpful if you have a test plugin that should not be activated all the time.
+Since all plugins in the `plugins` key are activated by default, you should use the `mappings` key to avoid this behavior. This might be helpful if you have a test plugin that should not be activated all the time. The same applies for a theme which should not be activated.
 
 ```json
 {

--- a/packages/env/lib/build-docker-compose-config.js
+++ b/packages/env/lib/build-docker-compose-config.js
@@ -4,7 +4,6 @@
  */
 const fs = require( 'fs' );
 const path = require( 'path' );
-const { map } = require( 'lodash' );
 
 /**
  * @typedef {import('./config').Config} Config
@@ -19,9 +18,8 @@ const { map } = require( 'lodash' );
  */
 module.exports = function buildDockerComposeConfig( config ) {
 	// Top-level WordPress directory mounts (like wp-content/themes)
-	const directoryMounts = map(
-		config.mappings,
-		( source, wpDir ) => `${ source.path }:/var/www/html/${ wpDir }`
+	const directoryMounts = Object.entries( config.mappings ).map(
+		( [ wpDir, source ] ) => `${ source.path }:/var/www/html/${ wpDir }`
 	);
 
 	const pluginMounts = config.pluginSources.map(

--- a/packages/env/lib/build-docker-compose-config.js
+++ b/packages/env/lib/build-docker-compose-config.js
@@ -4,6 +4,7 @@
  */
 const fs = require( 'fs' );
 const path = require( 'path' );
+const { map } = require( 'lodash' );
 
 /**
  * @typedef {import('./config').Config} Config
@@ -17,30 +18,29 @@ const path = require( 'path' );
  * @return {Object} A docker-compose config object, ready to serialize into YAML.
  */
 module.exports = function buildDockerComposeConfig( config ) {
-	const pluginMounts = config.pluginSources.flatMap( ( source ) => [
-		`${ source.path }:/var/www/html/wp-content/plugins/${ source.basename }`,
+	// Top-level WordPress directory mounts (like wp-content/themes)
+	const directoryMounts = map(
+		config.mappings,
+		( source, wpDir ) => `${ source.path }:/var/www/html/${ wpDir }`
+	);
 
-		// If this is is the Gutenberg plugin, then mount its E2E test plugins.
-		// TODO: Implement an API that lets Gutenberg mount test plugins without this workaround.
-		...( fs.existsSync( path.resolve( source.path, 'gutenberg.php' ) )
-			? [
-					`${ source.path }/packages/e2e-tests/plugins:/var/www/html/wp-content/plugins/gutenberg-test-plugins`,
-					`${ source.path }/packages/e2e-tests/mu-plugins:/var/www/html/wp-content/mu-plugins`,
-			  ]
-			: [] ),
-	] );
+	const pluginMounts = config.pluginSources.map(
+		( source ) =>
+			`${ source.path }:/var/www/html/wp-content/plugins/${ source.basename }`
+	);
 
 	const themeMounts = config.themeSources.map(
 		( source ) =>
 			`${ source.path }:/var/www/html/wp-content/themes/${ source.basename }`
 	);
 
+	const localMounts = [ ...directoryMounts, ...pluginMounts, ...themeMounts ];
+
 	const developmentMounts = [
 		`${
 			config.coreSource ? config.coreSource.path : 'wordpress'
 		}:/var/www/html`,
-		...pluginMounts,
-		...themeMounts,
+		...localMounts,
 	];
 
 	let testsMounts;
@@ -83,15 +83,10 @@ module.exports = function buildDockerComposeConfig( config ) {
 						)
 				: [] ),
 
-			...pluginMounts,
-			...themeMounts,
+			...localMounts,
 		];
 	} else {
-		testsMounts = [
-			'tests-wordpress:/var/www/html',
-			...pluginMounts,
-			...themeMounts,
-		];
+		testsMounts = [ 'tests-wordpress:/var/www/html', ...localMounts ];
 	}
 
 	// Set the default ports based on the config values.

--- a/packages/env/lib/config.js
+++ b/packages/env/lib/config.js
@@ -235,11 +235,6 @@ module.exports = {
 					if ( ! source ) {
 						return result;
 					}
-					if ( source.type !== 'local' ) {
-						throw new ValidationError(
-							`The mapping for "${ wpDir }" must be a local source.`
-						);
-					}
 					result[ wpDir ] = source;
 					return result;
 				},

--- a/packages/env/lib/config.js
+++ b/packages/env/lib/config.js
@@ -6,7 +6,6 @@ const fs = require( 'fs' ).promises;
 const path = require( 'path' );
 const os = require( 'os' );
 const crypto = require( 'crypto' );
-const { reduce } = require( 'lodash' );
 
 /**
  * Internal dependencies
@@ -194,6 +193,14 @@ module.exports = {
 			);
 		}
 
+		for ( const [ wpDir, localDir ] of Object.entries( config.mappings ) ) {
+			if ( ! localDir || typeof localDir !== 'string' ) {
+				throw new ValidationError(
+					`Invalid .wp-env.json: "mapping.${ wpDir }" should be a string.`
+				);
+			}
+		}
+
 		const workDirectoryPath = path.resolve(
 			getHomeDirectory(),
 			md5( configPath )
@@ -226,15 +233,11 @@ module.exports = {
 				} )
 			),
 			config: config.config,
-			mappings: reduce(
-				config.mappings,
-				( result, localDir, wpDir ) => {
+			mappings: Object.entries( config.mappings ).reduce(
+				( result, [ wpDir, localDir ] ) => {
 					const source = parseSourceString( localDir, {
 						workDirectoryPath,
 					} );
-					if ( ! source ) {
-						return result;
-					}
 					result[ wpDir ] = source;
 					return result;
 				},

--- a/packages/env/test/build-docker-compose-config.js
+++ b/packages/env/test/build-docker-compose-config.js
@@ -1,0 +1,73 @@
+/**
+ * Internal dependencies
+ */
+const buildDockerComposeConfig = require( '../lib/build-docker-compose-config' );
+
+// The basic config keys which build docker compose config requires.
+const CONFIG = {
+	mappings: {},
+	pluginSources: [],
+	themeSources: [],
+	port: 8888,
+	testsPort: 8889,
+	configDirectoryPath: '/path/to/config',
+};
+
+describe( 'buildDockerComposeConfig', () => {
+	it( 'should map directories before individual sources', () => {
+		const envConfig = {
+			...CONFIG,
+			mappings: {
+				'wp-content/plugins': {
+					path: '/path/to/wp-plugins',
+				},
+			},
+			pluginSources: [
+				{ path: '/path/to/local/plugin', basename: 'test-name' },
+			],
+		};
+		const dockerConfig = buildDockerComposeConfig( envConfig );
+		const { volumes } = dockerConfig.services.wordpress;
+		expect( volumes ).toEqual( [
+			'wordpress:/var/www/html', // WordPress root
+			'/path/to/wp-plugins:/var/www/html/wp-content/plugins', // Mapped plugins root
+			'/path/to/local/plugin:/var/www/html/wp-content/plugins/test-name', // Mapped plugin
+		] );
+	} );
+
+	it( 'should add all specified sources to tests, dev, and cli services', () => {
+		const envConfig = {
+			...CONFIG,
+			mappings: {
+				'wp-content/plugins': {
+					path: '/path/to/wp-plugins',
+				},
+			},
+			pluginSources: [
+				{ path: '/path/to/local/plugin', basename: 'test-name' },
+			],
+			themeSources: [
+				{ path: '/path/to/local/theme', basename: 'test-theme' },
+			],
+		};
+		const dockerConfig = buildDockerComposeConfig( envConfig );
+		const devVolumes = dockerConfig.services.wordpress.volumes;
+		const cliVolumes = dockerConfig.services.cli.volumes;
+		expect( devVolumes ).toEqual( cliVolumes );
+
+		const testsVolumes = dockerConfig.services[ 'tests-wordpress' ].volumes;
+		const testsCliVolumes = dockerConfig.services[ 'tests-cli' ].volumes;
+		expect( testsVolumes ).toEqual( testsCliVolumes );
+
+		const localSources = [
+			'/path/to/wp-plugins:/var/www/html/wp-content/plugins',
+			'/path/to/local/plugin:/var/www/html/wp-content/plugins/test-name',
+			'/path/to/local/theme:/var/www/html/wp-content/themes/test-theme',
+		];
+
+		expect( devVolumes ).toEqual( expect.arrayContaining( localSources ) );
+		expect( testsVolumes ).toEqual(
+			expect.arrayContaining( localSources )
+		);
+	} );
+} );

--- a/packages/env/test/config.js
+++ b/packages/env/test/config.js
@@ -222,7 +222,12 @@ describe( 'readConfig', () => {
 	it( 'should parse mappings into sources', async () => {
 		readFile.mockImplementation( () =>
 			Promise.resolve(
-				JSON.stringify( { mappings: { test: './relative' } } )
+				JSON.stringify( {
+					mappings: {
+						test: './relative',
+						test2: 'WordPress/gutenberg#master',
+					},
+				} )
 			)
 		);
 		const { mappings } = await readConfig( '.wp-env.json' );
@@ -231,6 +236,11 @@ describe( 'readConfig', () => {
 				type: 'local',
 				path: expect.stringMatching( /^\/.*relative$/ ),
 				basename: 'relative',
+			},
+			test2: {
+				type: 'git',
+				path: expect.stringMatching( /^\/.*gutenberg$/ ),
+				basename: 'gutenberg',
 			},
 		} );
 	} );
@@ -250,25 +260,6 @@ describe( 'readConfig', () => {
 		}
 	} );
 
-	it( 'should throw a validaton error if there is a non-local mapping source', async () => {
-		readFile.mockImplementation( () =>
-			Promise.resolve(
-				JSON.stringify( {
-					mappings: { test: 'WordPress/gutenberg#master' },
-				} )
-			)
-		);
-		expect.assertions( 2 );
-		try {
-			await readConfig( '.wp-env.json' );
-		} catch ( error ) {
-			expect( error ).toBeInstanceOf( ValidationError );
-			expect( error.message ).toContain(
-				'The mapping for "test" must be a local source.'
-			);
-		}
-	} );
-
 	it( 'excludes undefined sources', async () => {
 		readFile.mockImplementation( () =>
 			Promise.resolve(
@@ -278,7 +269,7 @@ describe( 'readConfig', () => {
 			)
 		);
 		const { mappings } = await readConfig( '.wp-env.json' );
-		expect( mappings ).toMatchObject( {
+		expect( mappings ).toEqual( {
 			test1: {
 				type: 'local',
 				path: expect.stringMatching( /^\/.*relative$/ ),

--- a/packages/env/test/config.js
+++ b/packages/env/test/config.js
@@ -260,22 +260,23 @@ describe( 'readConfig', () => {
 		}
 	} );
 
-	it( 'excludes undefined sources', async () => {
+	it( 'throws an error if a mapping is badly formatted', async () => {
 		readFile.mockImplementation( () =>
 			Promise.resolve(
 				JSON.stringify( {
-					mappings: { test1: './relative', test2: null },
+					mappings: { test: null },
 				} )
 			)
 		);
-		const { mappings } = await readConfig( '.wp-env.json' );
-		expect( mappings ).toEqual( {
-			test1: {
-				type: 'local',
-				path: expect.stringMatching( /^\/.*relative$/ ),
-				basename: 'relative',
-			},
-		} );
+		expect.assertions( 2 );
+		try {
+			await readConfig( '.wp-env.json' );
+		} catch ( error ) {
+			expect( error ).toBeInstanceOf( ValidationError );
+			expect( error.message ).toContain(
+				'Invalid .wp-env.json: "mapping.test" should be a string.'
+			);
+		}
 	} );
 
 	it( 'throws an error if mappings is not an object', async () => {


### PR DESCRIPTION
## Description
Adds support for granular WordPress directory mappings. For example, you can do the following in `.wp-env.json`:

```json
{
  "mappings": {
    "wp-content/plugins": "./path/to/lots-of-plugins"
  }
}
```

For the time being, I have only permitted local directory sources as values here. If folks want, though, it would be very easy to add git/zip source support to this as well.

## How has this been tested?
Tested running wp-env start locally with these changes. I made sure that the mapped directory was mounted in WordPress, and that the plugins I expected to see also showed up in the plugins list. I also tested with themes.


## Types of changes
New feature.


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
