### PR TITLE
wp-env: add mu-plugins support

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,4 +1,5 @@
 {
 	"core": "WordPress/WordPress",
-	"plugins": [ "." ]
+	"plugins": [ "." ],
+	"mu-plugins": [ "./packages/e2e-tests/mu-plugins" ]
 }

--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Feature
+
+-   The `.wp-env.json` coniguration file now accepts "mu-plugins" sources.
+
 ## 1.1.0 (2020-04-01)
 
 ### New Feature

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -210,7 +210,7 @@ Positionals:
             [string] [choices: "all", "development", "tests"] [default: "tests"]
 ```
 
-### `wp-env run [container] [command]` 
+### `wp-env run [container] [command]`
 
 ```sh
 wp-env run <container> [command..]
@@ -236,10 +236,10 @@ ID      user_login      display_name    user_email      user_registered roles
 ✔ Ran `wp user list` in 'cli'. (in 2s 374ms)
 ```
 
-### `docker logs -f [container_id] >/dev/null` 
+### `docker logs -f [container_id] >/dev/null`
 
 ```sh
-docker logs -f <container_id> >/dev/null 
+docker logs -f <container_id> >/dev/null
 
 Shows the error logs of the specified container in the terminal. The container_id is the one that is visible with `docker ps -a`
 ```
@@ -250,23 +250,24 @@ You can customize the WordPress installation, plugins and themes that the develo
 
 `.wp-env.json` supports five fields:
 
-| Field         | Type          | Default                                    | Description                                                                                                               |
-| ------------- | ------------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------- |
-| `"core"`      | `string\|null` | `null`                                     | The WordPress installation to use. If `null` is specified, `wp-env` will use the latest production release of WordPress.  |
-| `"plugins"`   | `string[]`    | `[]`                                       | A list of plugins to install and activate in the environment.                                                             |
-| `"themes"`    | `string[]`    | `[]`                                       | A list of themes to install in the environment. The first theme in the list will be activated.                            |
-| `"port"`      | `integer`      | `8888`                                   | The primary port number to use for the insallation. You'll access the instance through the port: 'http://localhost:8888'. |
-| `"testsPort"` | `integer`      | `8889`                                   | The port number to use for the tests instance.                                                                            |
-| `"config"`    | `Object`      | `"{ WP_DEBUG: true, SCRIPT_DEBUG: true }"` | Mapping of wp-config.php constants to their desired values.                                                               |
+| Field          | Type           | Default                                    | Description                                                                                                               |
+| -------------- | -------------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------- |
+| `"core"`       | `string\|null` | `null`                                     | The WordPress installation to use. If `null` is specified, `wp-env` will use the latest production release of WordPress.  |
+| `"plugins"`    | `string[]`     | `[]`                                       | A list of plugins to install and activate in the environment.                                                             |
+| `"themes"`     | `string[]`     | `[]`                                       | A list of themes to install in the environment. The first theme in the list will be activated.                            |
+| `"mu-plugins"` | `string[]`     | `[]`                                       | A list of mu-plugins to install in the environment.                                                                       |
+| `"port"`       | `integer`      | `8888`                                     | The primary port number to use for the insallation. You'll access the instance through the port: 'http://localhost:8888'. |
+| `"testsPort"`  | `integer`      | `8889`                                     | The port number to use for the tests instance.                                                                            |
+| `"config"`     | `Object`       | `"{ WP_DEBUG: true, SCRIPT_DEBUG: true }"` | Mapping of wp-config.php constants to their desired values.                                                               |
 
 _Note: the port number environment variables (`WP_ENV_PORT` and `WP_ENV_TESTS_PORT`) take precedent over the .wp-env.json values._
 
-Several types of strings can be passed into the `core`, `plugins`, and `themes` fields:
+Several types of strings can be passed into the `core`, `plugins`, `themes`, and `mu-plugins` fields:
 
 | Type              | Format                        | Example(s)                                               |
 | ----------------- | ----------------------------- | -------------------------------------------------------- |
-| Relative path     | `.<path>\|~<path>`             | `"./a/directory"`, `"../a/directory"`, `"~/a/directory"` |
-| Absolute path     | `/<path>\|<letter>:\<path>`    | `"/a/directory"`, `"C:\\a\\directory"`                   |
+| Relative path     | `.<path>\|~<path>`            | `"./a/directory"`, `"../a/directory"`, `"~/a/directory"` |
+| Absolute path     | `/<path>\|<letter>:\<path>`   | `"/a/directory"`, `"C:\\a\\directory"`                   |
 | GitHub repository | `<owner>/<repo>[#<ref>]`      | `"WordPress/WordPress"`, `"WordPress/gutenberg#master"`  |
 | ZIP File          | `http[s]://<host>/<path>.zip` | `"https://wordpress.org/wordpress-5.4-beta2.zip"`        |
 
@@ -323,7 +324,7 @@ This is useful for integration testing: that is, testing how old versions of Wor
 }
 ```
 
-#### Custom Port Numbers
+#### Custom port numbers and custom mu-plugins
 
 You can tell `wp-env` to use a custom port number so that your instance does not conflict with other `wp-env` instances.
 
@@ -331,7 +332,8 @@ You can tell `wp-env` to use a custom port number so that your instance does not
 {
 	"plugins": [ "." ],
 	"port": 4013,
-	"testsPort": 4012
+	"testsPort": 4012,
+	"mu-plugins": [ "./path/to/a/mu-plugin" ]
 }
 ```
 

--- a/packages/env/lib/build-docker-compose-config.js
+++ b/packages/env/lib/build-docker-compose-config.js
@@ -25,7 +25,6 @@ module.exports = function buildDockerComposeConfig( config ) {
 		...( fs.existsSync( path.resolve( source.path, 'gutenberg.php' ) )
 			? [
 					`${ source.path }/packages/e2e-tests/plugins:/var/www/html/wp-content/plugins/gutenberg-test-plugins`,
-					`${ source.path }/packages/e2e-tests/mu-plugins:/var/www/html/wp-content/mu-plugins`,
 			  ]
 			: [] ),
 	] );
@@ -35,12 +34,18 @@ module.exports = function buildDockerComposeConfig( config ) {
 			`${ source.path }:/var/www/html/wp-content/themes/${ source.basename }`
 	);
 
+	const muPluginsMounts = config.muPluginsSources.map(
+		( source ) =>
+			`${ source.path }:/var/www/html/wp-content/mu-plugins/${ source.basename }`
+	);
+
 	const developmentMounts = [
 		`${
 			config.coreSource ? config.coreSource.path : 'wordpress'
 		}:/var/www/html`,
 		...pluginMounts,
 		...themeMounts,
+		...muPluginsMounts,
 	];
 
 	let testsMounts;
@@ -85,12 +90,14 @@ module.exports = function buildDockerComposeConfig( config ) {
 
 			...pluginMounts,
 			...themeMounts,
+			...muPluginsMounts,
 		];
 	} else {
 		testsMounts = [
 			'tests-wordpress:/var/www/html',
 			...pluginMounts,
 			...themeMounts,
+			...muPluginsMounts,
 		];
 	}
 

--- a/packages/env/lib/commands/start.js
+++ b/packages/env/lib/commands/start.js
@@ -67,6 +67,13 @@ module.exports = async function start( { spinner, debug } ) {
 				.join( '\n' );
 	};
 
+	const getDownloader = ( source ) =>
+		downloadSource( source, {
+			onProgress: getProgressSetter( source.basename ),
+			spinner,
+			debug: config.debug,
+		} );
+
 	await Promise.all( [
 		// Preemptively start the database while we wait for sources to download.
 		dockerCompose.upOne( 'mysql', {
@@ -88,21 +95,9 @@ module.exports = async function start( { spinner, debug } ) {
 			}
 		} )(),
 
-		...config.pluginSources.map( ( source ) =>
-			downloadSource( source, {
-				onProgress: getProgressSetter( source.basename ),
-				spinner,
-				debug: config.debug,
-			} )
-		),
-
-		...config.themeSources.map( ( source ) =>
-			downloadSource( source, {
-				onProgress: getProgressSetter( source.basename ),
-				spinner,
-				debug: config.debug,
-			} )
-		),
+		...config.pluginSources.map( getDownloader ),
+		...config.pluginSources.map( getDownloader ),
+		...config.muPluginsSources.map( getDownloader ),
 	] );
 
 	spinner.text = 'Starting WordPress.';

--- a/packages/env/test/config.js
+++ b/packages/env/test/config.js
@@ -120,6 +120,54 @@ describe( 'readConfig', () => {
 		}
 	} );
 
+	it( 'should accept mu-plugins as a source type', async () => {
+		readFile.mockImplementation( () =>
+			Promise.resolve(
+				JSON.stringify( {
+					'mu-plugins': [ './relative' ],
+				} )
+			)
+		);
+		const config = await readConfig( '.wp-env.json' );
+		expect( config ).toMatchObject( {
+			muPluginsSources: [
+				{
+					type: 'local',
+					path: expect.stringMatching( /^\/.*relative$/ ),
+					basename: 'relative',
+				},
+			],
+		} );
+	} );
+
+	it( 'should throw a validation error if a mu-plugins source is invalid', async () => {
+		readFile.mockImplementation( () =>
+			Promise.resolve(
+				JSON.stringify( { 'mu-plugins': [ 'test', 123 ] } )
+			)
+		);
+		expect.assertions( 2 );
+		try {
+			await readConfig( '.wp-env.json' );
+		} catch ( error ) {
+			expect( error ).toBeInstanceOf( ValidationError );
+			expect( error.message ).toContain( 'must be an array of strings' );
+		}
+	} );
+
+	it( 'should throw a validation error if mu-plugins is invalid', async () => {
+		readFile.mockImplementation( () =>
+			Promise.resolve( JSON.stringify( { 'mu-plugins': false } ) )
+		);
+		expect.assertions( 2 );
+		try {
+			await readConfig( '.wp-env.json' );
+		} catch ( error ) {
+			expect( error ).toBeInstanceOf( ValidationError );
+			expect( error.message ).toContain( 'must be an array of strings' );
+		}
+	} );
+
 	it( 'should parse local sources', async () => {
 		readFile.mockImplementation( () =>
 			Promise.resolve(


### PR DESCRIPTION
## Description
Adds support to .wp-env.json for mu-plugins. (Accepted sources work the same as themes & plugins.)

## How has this been tested?
Locally and with unit tests

## Types of changes
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
