### PR TITLE
Moving animation: only set transform origin on animation

### DIFF
--- a/packages/block-editor/src/components/block-list/moving-animation.js
+++ b/packages/block-editor/src/components/block-list/moving-animation.js
@@ -82,7 +82,6 @@ function useMovingAnimation(
 			if ( adjustScrolling && scrollContainer.current && previous ) {
 				// if the animation is disabled and the scroll needs to be adjusted,
 				// just move directly to the final scroll position
-				ref.current.style.transform = 'none';
 				const destination = getAbsolutePosition( ref.current );
 				scrollContainer.current.scrollTop =
 					scrollContainer.current.scrollTop -
@@ -92,7 +91,6 @@ function useMovingAnimation(
 
 			return;
 		}
-		ref.current.style.transform = 'none';
 		const destination = getAbsolutePosition( ref.current );
 		const newTransform = {
 			x: previous ? previous.left - destination.left : 0,
@@ -141,7 +139,10 @@ function useMovingAnimation(
 	return prefersReducedMotion
 		? {}
 		: {
-				transformOrigin: 'center',
+				transformOrigin: interpolate(
+					[ animationProps.x, animationProps.y ],
+					( x, y ) => ( x === 0 && y === 0 ? undefined : 'center' )
+				),
 				transform: interpolate(
 					[ animationProps.x, animationProps.y ],
 					( x, y ) =>


### PR DESCRIPTION
## Description

Like the other style properties, `transform-origin: center` should only be set when combined with `transform`.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
