### PR TITLE
Use theme color for focus.

### DIFF
--- a/packages/base-styles/_colors.scss
+++ b/packages/base-styles/_colors.scss
@@ -32,8 +32,8 @@ $light-gray-ui: #949494;		// Meets 3:1 UI contrast.
 $light-gray-secondary: #ccc;
 $light-gray-tertiary: #e7e8e9;
 $theme-color: theme(button);
-$blue-medium-focus: #007cba;	// @todo: Currently being used as "spot" color. Needs to be considered in context of themes.
-$blue-medium-focus-dark: #fff;
+$blue-medium-focus: theme(button);
+$blue-medium-focus-dark: $white;
 
 // Dark opacities, for use with light themes.
 $dark-opacity-900: rgba(#000510, 0.9);


### PR DESCRIPTION
Extracting a small bit from #20460, which uses the theme color to color selection styles. Before:

<img width="1537" alt="Screenshot 2020-05-11 at 12 21 19" src="https://user-images.githubusercontent.com/1204802/81551394-107ed300-9382-11ea-8dde-249c64b24006.png">

After:

<img width="1224" alt="Screenshot 2020-05-11 at 12 19 17" src="https://user-images.githubusercontent.com/1204802/81551401-12489680-9382-11ea-92f5-d87511c3665f.png">

This theme color is already used for focus styles and other things. I think we should redo all the color themes, and even how things are styled, but that's separate. This is just removing a hardcoded color. 