### PR TITLE
ImageSize: rewrite with hooks

### DIFF
--- a/packages/block-library/src/image/image-size.js
+++ b/packages/block-library/src/image/image-size.js
@@ -40,6 +40,10 @@ function ImageSize( { src, dirtynessTrigger, children } ) {
 		};
 
 		image.src = src;
+
+		return () => {
+			image.onload = undefined;
+		};
 	}, [ src, dirtynessTrigger ] );
 
 	return <div ref={ ref }>{ children( state ) }</div>;

--- a/packages/block-library/src/image/image-size.js
+++ b/packages/block-library/src/image/image-size.js
@@ -1,87 +1,48 @@
 /**
- * External dependencies
- */
-import { noop } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { withGlobalEvents } from '@wordpress/compose';
-import { Component } from '@wordpress/element';
+import { useRef, useState, useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import { calculatePreferedImageSize } from './utils';
 
-class ImageSize extends Component {
-	constructor() {
-		super( ...arguments );
-		this.state = {
-			width: undefined,
-			height: undefined,
-		};
-		this.bindContainer = this.bindContainer.bind( this );
-		this.calculateSize = this.calculateSize.bind( this );
-	}
+function ImageSize( { src, dirtynessTrigger, children } ) {
+	const ref = useRef();
+	const [ state, setState ] = useState( {
+		imageWidth: null,
+		imageHeight: null,
+		containerWidth: null,
+		containerHeight: null,
+		imageWidthWithinContainer: null,
+		imageHeightWithinContainer: null,
+	} );
 
-	bindContainer( ref ) {
-		this.container = ref;
-	}
+	useEffect( () => {
+		const image = new window.Image();
 
-	componentDidUpdate( prevProps ) {
-		if ( this.props.src !== prevProps.src ) {
-			this.setState( {
-				width: undefined,
-				height: undefined,
+		image.onload = () => {
+			const { width, height } = calculatePreferedImageSize(
+				image,
+				ref.current
+			);
+
+			setState( {
+				imageWidth: image.width,
+				imageHeight: image.height,
+				containerWidth: ref.current.clientWidth,
+				containerHeight: ref.current.clientHeight,
+				imageWidthWithinContainer: width,
+				imageHeightWithinContainer: height,
 			} );
-			this.fetchImageSize();
-		}
-
-		if ( this.props.dirtynessTrigger !== prevProps.dirtynessTrigger ) {
-			this.calculateSize();
-		}
-	}
-
-	componentDidMount() {
-		this.fetchImageSize();
-	}
-
-	componentWillUnmount() {
-		if ( this.image ) {
-			this.image.onload = noop;
-		}
-	}
-
-	fetchImageSize() {
-		this.image = new window.Image();
-		this.image.onload = this.calculateSize;
-		this.image.src = this.props.src;
-	}
-
-	calculateSize() {
-		const { width, height } = calculatePreferedImageSize(
-			this.image,
-			this.container
-		);
-		this.setState( { width, height } );
-	}
-
-	render() {
-		const sizes = {
-			imageWidth: this.image && this.image.width,
-			imageHeight: this.image && this.image.height,
-			containerWidth: this.container && this.container.clientWidth,
-			containerHeight: this.container && this.container.clientHeight,
-			imageWidthWithinContainer: this.state.width,
-			imageHeightWithinContainer: this.state.height,
 		};
-		return (
-			<div ref={ this.bindContainer }>
-				{ this.props.children( sizes ) }
-			</div>
-		);
-	}
+
+		image.src = src;
+	}, [ src, dirtynessTrigger ] );
+
+	return <div ref={ ref }>{ children( state ) }</div>;
 }
 
 export default withGlobalEvents( {


### PR DESCRIPTION
## Description

This is a small step towards reducing the extra divs in the image block (edit).
Everything should work as before.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
