### PR TITLE
Increase specificity when inside a placeholder.

### DIFF
--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -1,7 +1,6 @@
 .components-button {
 	display: inline-flex;
 	text-decoration: none;
-	font-size: $default-font-size;
 	margin: 0;
 	border: 0;
 	cursor: pointer;
@@ -12,10 +11,15 @@
 	height: $button-size;
 	align-items: center;
 	box-sizing: border-box;
-	padding: 6px 12px;
 	overflow: hidden;
 	border-radius: $radius-block-ui;
 	color: $dark-gray-primary;
+
+	// Inside a placeholder, these properties need higher than usual specificity.
+	.components-placeholder & {
+		font-size: $default-font-size;
+		padding: 6px 12px;
+	}
 
 	&[aria-expanded="true"],
 	&:hover {


### PR DESCRIPTION
The `button` element is very commonly styled by themes & editor styles.

Right now, if you style the `button` element in your editor style, it affects buttons inside the placeholder component.

<img width="1039" alt="Screenshot 2020-05-11 at 12 33 28" src="https://user-images.githubusercontent.com/1204802/81553158-f5fa2900-9384-11ea-8ee9-45cfab3088d4.png">

This PR adds specificity for the button in that particular case, which fixes this:

<img width="1034" alt="Screenshot 2020-05-11 at 12 40 22" src="https://user-images.githubusercontent.com/1204802/81553170-fa264680-9384-11ea-8b12-985eaa69cf75.png">
