### PR TITLE
Popover: Fix closest().parentNode null error

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Bug Fix
+
+- Fix and issue that would cause the `Popover` component to throw an error under certain
+  circumstances ([#22264](https://github.com/WordPress/gutenberg/pull/22264)).
+
 ## 9.2.0 (2020-02-10)
 
 ### Enhancements

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -331,7 +331,7 @@ const Popover = ( {
 			if ( __unstableBoundaryParent ) {
 				boundaryElement = containerRef.current.closest(
 					'.popover-slot'
-				).parentNode;
+				)?.parentNode;
 			}
 
 			const {


### PR DESCRIPTION
## Description

Fix an issue in Popover that may throw an error under certain conditions.

Change the `.closest( '.popover-slot' ).parentNode` to use an optional chain `?.parentNode`, which will keep the `boundaryElement` as `undefined` if no closest element is found.

---

https://github.com/WordPress/gutenberg/pull/19322 (merged to master via https://github.com/WordPress/gutenberg/pull/19344) introduced a chained call that may get `parentNode` of `null`, causing an error:

https://github.com/WordPress/gutenberg/blob/f6a401be500bb24c60bb6e5ccd9833fcd9fa2c5c/packages/components/src/popover/index.js#L330-L335

`closest` may return `null` if no matching element is found. See the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/Element/closest#Syntax) for details.

I'm unfamiliar with the `__unstableBoundaryParent` feature, so I'd appreciate specific testing in Gutenberg or instructions on how to reproduce a minimal test case. It's simple to confirm the logic behind this fix works as expected in a browser:

```html
<html>
	<body>
		<div class="foo">
			<div class="bar"></div>
		</div>
	</body>
</html>
```
```js
document.querySelector('.bar').closest('.foo')?.parentNode
// <body></body>
document.querySelector('.bar').closest('.quux')?.parentNode
// undefined

// Without the optional chain, this is an error:
document.querySelector('.bar').closest('.quux').parentNode
// 💥 Uncaught TypeError: Cannot read property 'parentNode' of null 
```

## How has this been tested?

- Manually modifying code in `node_modules` fixes error in https://github.com/Automattic/wp-calypso/pull/41994
- Light browser testing

# Types of changes

Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
