### PR TITLE
Remove the style CSS class when the default style variation is chosen

### DIFF
--- a/packages/block-editor/src/components/block-styles/index.js
+++ b/packages/block-editor/src/components/block-styles/index.js
@@ -63,7 +63,9 @@ export function replaceActiveStyle( className, activeStyle, newStyle ) {
 		list.remove( 'is-style-' + activeStyle.name );
 	}
 
-	list.add( 'is-style-' + newStyle.name );
+	if ( ! newStyle.isDefault ) {
+		list.add( 'is-style-' + newStyle.name );
+	}
 
 	return list.value;
 }


### PR DESCRIPTION
## Description

See the following GIF:

![2020-05-11 16-15-21 2020-05-11 16_17_44](https://user-images.githubusercontent.com/205419/81573971-7c266780-93a5-11ea-8fb4-7218b20f98b8.gif)

When a new navigation block is added, the CSS class `is-style-light` reflecting it's default style variation is not added (this was a deliberate design decision). However, if you change the style to dark, `is-style-dark` is added. If you change the style back to light (default), `is-style-dark` will be replaced with `is-style-light`. This means that the the class may or may not be there when the default style variation is used. It's confusing and also leads to more verbose CSS code.

I think we should choose one way and stick to it.

This PR is an attempt at the latter and also an open invitation to discuss what the right behavior should be. 

In https://github.com/WordPress/gutenberg/pull/22167 I explored the other way, which is to make sure the CSS class is always there. The key benefit to that alternative approach is that the style variation is always expressed explicitly which allows the block developer to switch the default style variation without breaking existing instances of the block.

## How has this been tested?
![2020-05-11 16-09-02 2020-05-11 16_15_07](https://user-images.githubusercontent.com/205419/81573978-7df02b00-93a5-11ea-89ce-019a50fca7d7.gif)

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
