### PR TITLE
[RNMobile] remove clear all settings button from Image block

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35400,9 +35400,9 @@
 					}
 				},
 				"ws": {
-					"version": "7.2.5",
-					"resolved": "https://registry.npmjs.org/ws/-/ws-7.2.5.tgz",
-					"integrity": "sha512-C34cIU4+DB2vMyAbmEKossWq2ZQDr6QEyuuCzWrM9zfw1sGc0mYiJ0UnG9zzNykt49C2Fi34hvr2vssFQRS6EA==",
+					"version": "7.3.0",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-7.3.0.tgz",
+					"integrity": "sha512-iFtXzngZVXPGgpTlP1rBqsUK82p9tKqsWRPg5L56egiljujJT3vGAYnHANvFxBieXrTFavhzhxW52jnaWV+w2w==",
 					"dev": true
 				},
 				"yauzl": {

--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -25,7 +25,6 @@ import {
 	CycleSelectControl,
 	Icon,
 	PanelBody,
-	PanelActions,
 	TextControl,
 	ToggleControl,
 	ToolbarButton,
@@ -63,11 +62,7 @@ import SvgIconRetry from './icon-retry';
 import SvgIconCustomize from './icon-customize';
 import { getUpdatedLinkTargetSettings } from './utils';
 
-import {
-	LINK_DESTINATION_CUSTOM,
-	LINK_DESTINATION_NONE,
-	DEFAULT_SIZE_SLUG,
-} from './constants';
+import { LINK_DESTINATION_CUSTOM, DEFAULT_SIZE_SLUG } from './constants';
 
 const ICON_TYPE = {
 	PLACEHOLDER: 'placeholder',
@@ -107,7 +102,6 @@ export class ImageEdit extends React.Component {
 		this.onSetNewTab = this.onSetNewTab.bind( this );
 		this.onSetSizeSlug = this.onSetSizeSlug.bind( this );
 		this.onImagePressed = this.onImagePressed.bind( this );
-		this.onClearSettings = this.onClearSettings.bind( this );
 		this.onFocusCaption = this.onFocusCaption.bind( this );
 		this.updateAlignment = this.updateAlignment.bind( this );
 	}
@@ -277,17 +271,6 @@ export class ImageEdit extends React.Component {
 		} );
 	}
 
-	onClearSettings() {
-		this.props.setAttributes( {
-			alt: '',
-			linkDestination: LINK_DESTINATION_NONE,
-			href: undefined,
-			linkTarget: undefined,
-			sizeSlug: DEFAULT_SIZE_SLUG,
-			rel: undefined,
-		} );
-	}
-
 	onSelectMediaUploadOption( media ) {
 		const { id, url } = this.props.attributes;
 
@@ -362,13 +345,6 @@ export class ImageEdit extends React.Component {
 			sizeSlug,
 		} = attributes;
 
-		const actions = [
-			{
-				label: __( 'Clear All Settings' ),
-				onPress: this.onClearSettings,
-			},
-		];
-
 		const sizeOptions = map( imageSizes, ( { name, slug } ) => ( {
 			value: slug,
 			name,
@@ -432,7 +408,6 @@ export class ImageEdit extends React.Component {
 						onChangeValue={ this.updateAlt }
 					/>
 				</PanelBody>
-				<PanelActions actions={ actions } />
 			</InspectorControls>
 		);
 


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
This PR removes `Clear all settings` button from Image block BottomSheet settings according to [this issue](https://github.com/wordpress-mobile/gutenberg-mobile/issues/2243)

Please also refer to:
[Related gutenberg-mobile PR](https://github.com/wordpress-mobile/gutenberg-mobile/pull/2250)
[Related gutenberg-mobile issue](https://github.com/wordpress-mobile/gutenberg-mobile/issues/2243)

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

1. Use default `initial-html`
2 Expect BottomSheet settings in Image block do not have `Clear all settings` action on the bottom

## Screenshots <!-- if applicable -->
before | after
-- | --
<img width="250" src="https://user-images.githubusercontent.com/21242757/81568301-dd4a3d00-939d-11ea-854c-dc1fb4a85951.png"> | <img width="250" src="https://user-images.githubusercontent.com/21242757/81568287-d8858900-939d-11ea-8356-530a9d771493.png">


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Refactor

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->

