### PR TITLE
[ Navigation ] Adds orientation class on front for navigation

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -157,11 +157,6 @@ function render_block_core_navigation( $content, $block ) {
 		return '';
 	}
 
-	$orientation_class_name = '';
-	if ( isset( $attributes['orientation'] ) && 'vertical' === $attributes['orientation'] ) {
-		$orientation_class_name = 'is-vertical';
-	}
-
 	$colors          = block_core_navigation_build_css_colors( $attributes );
 	$font_sizes      = block_core_navigation_build_css_font_sizes( $attributes );
 	$classes         = array_merge(

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -157,7 +157,7 @@ function render_block_core_navigation( $content, $block ) {
 		return '';
 	}
 
-	$orientation_class_name = 'is-horizontal';
+	$orientation_class_name = '';
 	if ( isset( $attributes['orientation'] ) && 'vertical' === $attributes['orientation'] ) {
 		$orientation_class_name = 'is-vertical';
 	}

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -157,6 +157,11 @@ function render_block_core_navigation( $content, $block ) {
 		return '';
 	}
 
+	$orientation_class_name = 'is-horizontal';
+	if ( isset( $attributes['orientation'] ) && 'vertical' === $attributes['orientation'] ) {
+		$orientation_class_name = 'is-vertical';
+	}
+
 	$colors          = block_core_navigation_build_css_colors( $attributes );
 	$font_sizes      = block_core_navigation_build_css_font_sizes( $attributes );
 	$classes         = array_merge(
@@ -164,6 +169,7 @@ function render_block_core_navigation( $content, $block ) {
 		$font_sizes['css_classes'],
 		array( 'wp-block-navigation' ),
 		isset( $attributes['className'] ) ? array( $attributes['className'] ) : array(),
+		array( $orientation_class_name ),
 		isset( $attributes['itemsJustification'] ) ? array( 'items-justified-' . $attributes['itemsJustification'] ) : array(),
 		isset( $attributes['align'] ) ? array( 'align' . $attributes['align'] ) : array()
 	);

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -169,7 +169,7 @@ function render_block_core_navigation( $content, $block ) {
 		$font_sizes['css_classes'],
 		array( 'wp-block-navigation' ),
 		isset( $attributes['className'] ) ? array( $attributes['className'] ) : array(),
-		array( $orientation_class_name ),
+		( isset( $attributes['orientation'] ) && 'vertical' === $attributes['orientation'] ) ? array( 'is-vertical' ) : array(),
 		isset( $attributes['itemsJustification'] ) ? array( 'items-justified-' . $attributes['itemsJustification'] ) : array(),
 		isset( $attributes['align'] ) ? array( 'align' . $attributes['align'] ) : array()
 	);


### PR DESCRIPTION
## Description
Fixes #21890 

## How has this been tested?
Tested locally by:

1. Go to a new post
2. Using the inserter add a horizontal menu and add some items in it
3. Using the inserter add a vertical menu and add some items in it
4. Save the post
5. Check that the rendered front post has one vertical and one horizontal looking menu.

## Screenshots

<img width="612" alt="Screenshot 2020-05-11 at 19 24 44" src="https://user-images.githubusercontent.com/107534/81585616-16de7080-93bd-11ea-8bd4-59d3d5867b5c.png">

## Types of changes
Non breaking change that adds a class name to the rendered navigation menu. It adds both `is-horizontal` as a default and `is-vertical` as a variant.
