### PR TITLE
Block API: Allow block registration without category

### DIFF
--- a/packages/block-editor/src/components/inserter/block-list.js
+++ b/packages/block-editor/src/components/inserter/block-list.js
@@ -234,7 +234,7 @@ function InserterBlockList( {
 					);
 				} ) }
 
-			{ ! hasChildItems && uncategorizedItems.length && (
+			{ ! hasChildItems && !! uncategorizedItems.length && (
 				<InserterPanel
 					className="block-editor-inserter__uncategorized-blocks-panel"
 					title={ __( 'Uncategorized' ) }

--- a/packages/block-editor/src/components/inserter/block-list.js
+++ b/packages/block-editor/src/components/inserter/block-list.js
@@ -135,6 +135,10 @@ function InserterBlockList( {
 		return filter( filteredItems, { category: 'reusable' } );
 	}, [ filteredItems ] );
 
+	const uncategorizedItems = useMemo( () => {
+		return filter( filteredItems, ( item ) => ! item.category );
+	}, [ filteredItems ] );
+
 	const itemsPerCategory = useMemo( () => {
 		const getCategoryIndex = ( item ) => {
 			return findIndex(
@@ -145,7 +149,10 @@ function InserterBlockList( {
 
 		return flow(
 			( itemList ) =>
-				filter( itemList, ( item ) => item.category !== 'reusable' ),
+				filter(
+					itemList,
+					( item ) => item.category && item.category !== 'reusable'
+				),
 			( itemList ) => sortBy( itemList, getCategoryIndex ),
 			( itemList ) => groupBy( itemList, 'category' )
 		)( filteredItems );
@@ -227,6 +234,19 @@ function InserterBlockList( {
 						</InserterPanel>
 					);
 				} ) }
+
+			{ ! hasChildItems && uncategorizedItems.length && (
+				<InserterPanel
+					className="block-editor-inserter__uncategorized-blocks-panel"
+					title={ __( 'Uncategorized' ) }
+				>
+					<BlockTypesList
+						items={ uncategorizedItems }
+						onSelect={ onSelectItem }
+						onHover={ onHover }
+					/>
+				</InserterPanel>
+			) }
 
 			{ ! hasChildItems &&
 				map( collections, ( collection, namespace ) => {

--- a/packages/block-editor/src/components/inserter/block-list.js
+++ b/packages/block-editor/src/components/inserter/block-list.js
@@ -4,7 +4,6 @@
 import {
 	map,
 	includes,
-	filter,
 	findIndex,
 	flow,
 	sortBy,
@@ -119,24 +118,25 @@ function InserterBlockList( {
 	}, [ filterValue, items, categories, collections ] );
 
 	const childItems = useMemo( () => {
-		return filter( filteredItems, ( { name } ) =>
+		return filteredItems.filter( ( { name } ) =>
 			includes( rootChildBlocks, name )
 		);
 	}, [ filteredItems, rootChildBlocks ] );
 
 	const suggestedItems = useMemo( () => {
-		return filter( items, ( item ) => item.utility > 0 ).slice(
-			0,
-			MAX_SUGGESTED_ITEMS
-		);
+		return items
+			.filter( ( item ) => item.utility > 0 )
+			.slice( 0, MAX_SUGGESTED_ITEMS );
 	}, [ items ] );
 
 	const reusableItems = useMemo( () => {
-		return filter( filteredItems, { category: 'reusable' } );
+		return filteredItems.filter(
+			( { category } ) => category === 'reusable'
+		);
 	}, [ filteredItems ] );
 
 	const uncategorizedItems = useMemo( () => {
-		return filter( filteredItems, ( item ) => ! item.category );
+		return filteredItems.filter( ( item ) => ! item.category );
 	}, [ filteredItems ] );
 
 	const itemsPerCategory = useMemo( () => {
@@ -149,8 +149,7 @@ function InserterBlockList( {
 
 		return flow(
 			( itemList ) =>
-				filter(
-					itemList,
+				itemList.filter(
 					( item ) => item.category && item.category !== 'reusable'
 				),
 			( itemList ) => sortBy( itemList, getCategoryIndex ),

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -1,4 +1,4 @@
-/* eslint no-console: [ 'error', { allow: [ 'error' ] } ] */
+/* eslint no-console: [ 'error', { allow: [ 'error', 'warn' ] } ] */
 
 /**
  * External dependencies
@@ -203,20 +203,20 @@ export function registerBlockType( name, settings ) {
 		console.error( 'The "edit" property must be a valid function.' );
 		return;
 	}
-	if ( ! ( 'category' in settings ) ) {
-		console.error( 'The block "' + name + '" must have a category.' );
-		return;
-	}
 	if (
 		'category' in settings &&
 		! some( select( 'core/blocks' ).getCategories(), {
 			slug: settings.category,
 		} )
 	) {
-		console.error(
-			'The block "' + name + '" must have a registered category.'
+		console.warn(
+			'The block "' +
+				name +
+				'" is registered with an invalid category "' +
+				settings.category +
+				'".'
 		);
-		return;
+		delete settings.category;
 	}
 	if ( ! ( 'title' in settings ) || settings.title === '' ) {
 		console.error( 'The block "' + name + '" must have a title.' );

--- a/packages/blocks/src/api/test/registration.js
+++ b/packages/blocks/src/api/test/registration.js
@@ -173,23 +173,7 @@ describe( 'blocks', () => {
 			expect( block ).toBeUndefined();
 		} );
 
-		it( 'should reject blocks without category', () => {
-			const blockType = {
-					settingName: 'settingValue',
-					save: noop,
-					title: 'block title',
-				},
-				block = registerBlockType(
-					'my-plugin/fancy-block-8',
-					blockType
-				);
-			expect( console ).toHaveErroredWith(
-				'The block "my-plugin/fancy-block-8" must have a category.'
-			);
-			expect( block ).toBeUndefined();
-		} );
-
-		it( 'should reject blocks with non registered category.', () => {
+		it( 'should unset category of blocks with non registered category.', () => {
 			const blockType = {
 					save: noop,
 					category: 'custom-category-slug',
@@ -199,10 +183,11 @@ describe( 'blocks', () => {
 					'my-plugin/fancy-block-9',
 					blockType
 				);
-			expect( console ).toHaveErroredWith(
-				'The block "my-plugin/fancy-block-9" must have a registered category.'
+			expect( console ).toHaveWarnedWith(
+				'The block "my-plugin/fancy-block-9" is registered with an invalid category "custom-category-slug".'
 			);
-			expect( block ).toBeUndefined();
+			expect( block ).not.toBeUndefined();
+			expect( block.category ).toBeUndefined();
 		} );
 
 		it( 'should reject blocks without title', () => {

--- a/packages/blocks/src/store/test/selectors.js
+++ b/packages/blocks/src/store/test/selectors.js
@@ -1,6 +1,8 @@
 /**
  * External dependencies
  */
+import { omit } from 'lodash';
+
 import deepFreeze from 'deep-freeze';
 
 /**
@@ -243,6 +245,7 @@ describe( 'selectors', () => {
 		describe.each( [
 			[ 'name', name ],
 			[ 'block type', blockType ],
+			[ 'block type without category', omit( blockType, 'category' ) ],
 		] )( 'by %s', ( label, nameOrType ) => {
 			it( 'should return false if not match', () => {
 				const result = isMatchingSearchTerm(
@@ -304,15 +307,17 @@ describe( 'selectors', () => {
 				expect( result ).toBe( true );
 			} );
 
-			it( 'should return true if match using the categories', () => {
-				const result = isMatchingSearchTerm(
-					state,
-					nameOrType,
-					'COMMON'
-				);
+			if ( nameOrType.category ) {
+				it( 'should return true if match using the categories', () => {
+					const result = isMatchingSearchTerm(
+						state,
+						nameOrType,
+						'COMMON'
+					);
 
-				expect( result ).toBe( true );
-			} );
+					expect( result ).toBe( true );
+				} );
+			}
 		} );
 	} );
 

--- a/packages/edit-post/src/components/manage-blocks-modal/category.js
+++ b/packages/edit-post/src/components/manage-blocks-modal/category.js
@@ -19,7 +19,7 @@ import EditPostSettings from '../edit-post-settings';
 
 function BlockManagerCategory( {
 	instanceId,
-	category,
+	title,
 	blockTypes,
 	hiddenBlockTypes,
 	toggleVisible,
@@ -70,7 +70,7 @@ function BlockManagerCategory( {
 				onChange={ toggleAllVisible }
 				className="edit-post-manage-blocks-modal__category-title"
 				aria-checked={ ariaChecked }
-				label={ <span id={ titleId }>{ category.title }</span> }
+				label={ <span id={ titleId }>{ title }</span> }
 			/>
 			<BlockTypesChecklist
 				blockTypes={ filteredBlockTypes }

--- a/packages/edit-post/src/components/manage-blocks-modal/manager.js
+++ b/packages/edit-post/src/components/manage-blocks-modal/manager.js
@@ -76,12 +76,19 @@ function BlockManager( {
 				{ categories.map( ( category ) => (
 					<BlockManagerCategory
 						key={ category.slug }
-						category={ category }
+						title={ category.title }
 						blockTypes={ filter( blockTypes, {
 							category: category.slug,
 						} ) }
 					/>
 				) ) }
+				<BlockManagerCategory
+					title={ __( 'Uncategorized' ) }
+					blockTypes={ filter(
+						blockTypes,
+						( { category } ) => ! category
+					) }
+				/>
 			</div>
 		</div>
 	);


### PR DESCRIPTION
Alternative to: #22192

This pull request seeks to update block registration to allow for the omission of a category in block settings. This differs from #22192 in that it avoids treating "Uncategorized" as a formalized, default category for blocks. Instead, it simply allows blocks to lack a `category` property value. The "downside" here is that it then relies on each individual UI of the editor to account for the potential absence of category. Currently, this appears to affect only the Inserter and the Block Manager components. Note that changes would be required in #22192 as well for these components, so there's not a significant difference between the approaches in this regard.

~Status: In Progress. Remaining tasks:~

- [x] Update Block Manager to include "Uncategorized" section.
   - **Edit:** Updated in 043ebc5.
- [x] Validate or incorporate fix for missing category in search ([see change from #22192](https://github.com/WordPress/gutenberg/pull/22192/commits/a28d026b51c23a0327aa3a3000323e8386611126#diff-4e302c362c07ad0b65925c3de0b9bec3L290-R301))
   - **Edit:** Added a test case in bf5f678. The implementation appears to handle it okay. The test case should at least help assure there's no regressions in the future.

**Testing Instructions:**

To test, you need to register a block type which does not have an assigned category, or which has an invalid category. The easiest way I found to do this was to locally modify the settings of a core block, e.g. [the paragraph block](https://github.com/WordPress/gutenberg/blob/master/packages/block-library/src/paragraph/block.json), to remove or alter the "category" field.

Then, verify that the block is shown under the "Uncategorized" categorizations within the block inserter and Block Manager modal.

*Inserter:*

1. Navigate to Posts > Add New
2. Toggle the block inserter
3. Observe block under "Uncategorized"
4. Confirm that you can still search for the block

*Block Manager:*

1. Navigate to Posts > Add New
2. Toggle the "More Tools & Options" menu in the top-right corner
3. Click "Block Manager"
4. Observe block under "Uncategorized"
5. Confirm that you can still search for the block

Ensure unit tests pass:

```
npm run test-unit
```