### PR TITLE
Add package-lock change to fix e2e tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35375,9 +35375,9 @@
 					}
 				},
 				"tar-fs": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.0.1.tgz",
-					"integrity": "sha512-6tzWDMeroL87uF/+lin46k+Q+46rAJ0SyPGz7OW7wTgblI273hsBqk2C1j0/xNadNLKDTUL9BukSjB7cwgmlPA==",
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.0.tgz",
+					"integrity": "sha512-9uW5iDvrIMCVpvasdFHW0wJPez0K4JnMZtsuIeDI7HyMGJNxmDZDOCQROr7lXyS+iL/QMpj07qcjGYTSdRFXUg==",
 					"dev": true,
 					"requires": {
 						"chownr": "^1.1.1",


### PR DESCRIPTION
## Description
A package-lock update was not mereged to master, causing the build artifact step to fail.