### PR TITLE
Block Directory: Activate deactivated blocks if already installed 

### DIFF
--- a/lib/class-wp-rest-block-directory-controller.php
+++ b/lib/class-wp-rest-block-directory-controller.php
@@ -109,40 +109,45 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 			)
 		);
 
-		if ( is_wp_error( $api ) ) {
-			return WP_Error( $api->get_error_code(), $api->get_error_message() );
-		}
+		$installed_plugins = get_plugins( '/' . $api->slug );
 
-		$skin     = new WP_Ajax_Upgrader_Skin();
-		$upgrader = new Plugin_Upgrader( $skin );
+		if ( empty( $installed_plugins ) ) {
 
-		$filesystem_method = get_filesystem_method();
-
-		if ( 'direct' !== $filesystem_method ) {
-			return WP_Error( null, 'Only direct FS_METHOD is supported.' );
-		}
-
-		$result = $upgrader->install( $api->download_link );
-
-		if ( is_wp_error( $result ) ) {
-			return WP_Error( $result->get_error_code(), $result->get_error_message() );
-		}
-
-		if ( is_wp_error( $skin->result ) ) {
-			return WP_Error( $skin->$result->get_error_code(), $skin->$result->get_error_message() );
-		}
-
-		if ( $skin->get_errors()->has_errors() ) {
-			return WP_Error( $skin->$result->get_error_code(), $skin->$result->get_error_messages() );
-		}
-
-		if ( is_null( $result ) ) {
-			global $wp_filesystem;
-			// Pass through the error from WP_Filesystem if one was raised.
-			if ( $wp_filesystem instanceof WP_Filesystem_Base && is_wp_error( $wp_filesystem->errors ) && $wp_filesystem->errors->has_errors() ) {
-				return WP_Error( 'unable_to_connect_to_filesystem', esc_html( $wp_filesystem->errors->get_error_message() ) );
+			if ( is_wp_error( $api ) ) {
+				return WP_Error( $api->get_error_code(), $api->get_error_message() );
 			}
-			return WP_Error( 'unable_to_connect_to_filesystem', __( 'Unable to connect to the filesystem. Please confirm your credentials.', 'gutenberg' ) );
+
+			$skin     = new WP_Ajax_Upgrader_Skin();
+			$upgrader = new Plugin_Upgrader( $skin );
+
+			$filesystem_method = get_filesystem_method();
+
+			if ( 'direct' !== $filesystem_method ) {
+				return WP_Error( null, 'Only direct FS_METHOD is supported.' );
+			}
+
+			$result = $upgrader->install( $api->download_link );
+
+			if ( is_wp_error( $result ) ) {
+				return WP_Error( $result->get_error_code(), $result->get_error_message() );
+			}
+
+			if ( is_wp_error( $skin->result ) ) {
+				return WP_Error( $skin->$result->get_error_code(), $skin->$result->get_error_message() );
+			}
+
+			if ( $skin->get_errors()->has_errors() ) {
+				return WP_Error( $skin->$result->get_error_code(), $skin->$result->get_error_messages() );
+			}
+
+			if ( is_null( $result ) ) {
+				global $wp_filesystem;
+				// Pass through the error from WP_Filesystem if one was raised.
+				if ( $wp_filesystem instanceof WP_Filesystem_Base && is_wp_error( $wp_filesystem->errors ) && $wp_filesystem->errors->has_errors() ) {
+					return WP_Error( 'unable_to_connect_to_filesystem', esc_html( $wp_filesystem->errors->get_error_message() ) );
+				}
+				return WP_Error( 'unable_to_connect_to_filesystem', __( 'Unable to connect to the filesystem. Please confirm your credentials.', 'gutenberg' ) );
+			}
 		}
 
 		$install_status = install_plugin_install_status( $api );
@@ -253,10 +258,7 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 		foreach ( $response['plugins'] as $plugin ) {
 			$installed_plugins = get_plugins( '/' . $plugin['slug'] );
 
-			// Only show uninstalled blocks.
-			if ( empty( $installed_plugins ) ) {
-				$result[] = self::parse_block_metadata( $plugin );
-			}
+			$result[] = self::parse_block_metadata( $plugin );
 		}
 
 		return rest_ensure_response( $result );
@@ -273,7 +275,7 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 	private static function parse_block_metadata( $plugin ) {
 		$block = new stdClass();
 
-		// There might be multiple blocks in a plugin. Only the first block is mapped.
+		// There might be multiple blocks in a plugin. Only the firs	t block is mapped.
 		$block_data   = reset( $plugin['blocks'] );
 		$block->name  = $block_data['name'];
 		$block->title = $block_data['title'];

--- a/lib/class-wp-rest-block-directory-controller.php
+++ b/lib/class-wp-rest-block-directory-controller.php
@@ -109,6 +109,7 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 			)
 		);
 
+		// Check if the plugin is already installed but deactivated
 		$installed_plugins = get_plugins( '/' . $api->slug );
 
 		if ( empty( $installed_plugins ) ) {

--- a/lib/class-wp-rest-block-directory-controller.php
+++ b/lib/class-wp-rest-block-directory-controller.php
@@ -276,7 +276,7 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 	private static function parse_block_metadata( $plugin ) {
 		$block = new stdClass();
 
-		// There might be multiple blocks in a plugin. Only the firs	t block is mapped.
+		// There might be multiple blocks in a plugin. Only the first block is mapped.
 		$block_data   = reset( $plugin['blocks'] );
 		$block->name  = $block_data['name'];
 		$block->title = $block_data['title'];

--- a/lib/class-wp-rest-block-directory-controller.php
+++ b/lib/class-wp-rest-block-directory-controller.php
@@ -109,7 +109,7 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 			)
 		);
 
-		// Check if the plugin is already installed but deactivated
+		// Check if the plugin is already installed.
 		$installed_plugins = get_plugins( '/' . $api->slug );
 
 		if ( empty( $installed_plugins ) ) {
@@ -257,8 +257,6 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 		$result = array();
 
 		foreach ( $response['plugins'] as $plugin ) {
-			$installed_plugins = get_plugins( '/' . $plugin['slug'] );
-
 			$result[] = self::parse_block_metadata( $plugin );
 		}
 


### PR DESCRIPTION
## Description
This PR is based on [this discussion](https://github.com/WordPress/block-directory/issues/14). It takes the simplest possible route as a conversation piece. It also addresses #19906. 

#### TL;DR
This PR handles the case where:

1. User installs block (block must be in the block directory)
2. Block is deactivated
3. Sometime later, user searches for block in inserter.
4. Nothing is returned

## Current Issue:
- Since the block is deactivated it doesn't show up in the inserter on page load
- Since the block is installed, the block directory api endpoint does not return the block

## Options:
- The UI does not change, the block is returned as a result (Implemented in this PR)
  - If there is a block that is installed but deactivated, skip install and activate the block.
- [Display to the user that the block is disabled using the same Block Directory layout view](https://github.com/WordPress/block-directory/issues/14#issuecomment-513600259)
- [Custom view for disabled blocks](https://github.com/WordPress/block-directory/issues/14#issuecomment-510521517)

## How has this been tested?
1. Install a block from the block directory
2. Deactivate block via `wp-admin/plugins.php`
3. Search for the same block in the inserter
4. Click `Add block`

**Expect** 
- Block to be injected into document
- Save & reload page -> block is functioning properly


## Types of changes
- Searching for a block also returns installed blocks
  - I decide not to check if its activated because the block directory search wouldn't be triggered otherwise, since it only searches if it doesn't have a registered block.
  - We could also check to see if its activated, not sure if its necessary
- In the `/install` endpoint, check if the block is installed. 
  - If installed jump to activation step.


## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
