### PR TITLE
Block Directory: Only support an array of assets when injecting assets.

### DIFF
--- a/packages/block-directory/src/store/controls.js
+++ b/packages/block-directory/src/store/controls.js
@@ -146,15 +146,6 @@ const controls = {
 						loadStyle( asset );
 					}
 				} );
-			} else {
-				loadScript(
-					assets.editor_script,
-					() => {
-						return resolve( 0 );
-					},
-					reject
-				);
-				loadStyle( assets.style );
 			}
 		} );
 	},


### PR DESCRIPTION
## Description
When the initial PR was merged, there was an expectation that the api could return either an `Array` or an `object`.

The api does not return an `object`. This code path will not be triggered.
 

## How has this been tested?
- Search for a block
- Add block
- Expect that it is added
  - There is an api issue where some blocks don't have assets and will trigger an error.


## Types of changes
1. Remove the else case when determining if we have assets

Note: I left the `if( Array.isArray( assets ) )` check. It's probably best to make that check in case the api returns undefined.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
