### PR TITLE
Writing Flow: allow split out of caption on Enter

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -117,6 +117,7 @@ function RichTextWrapper(
 		onRemove,
 		onMerge,
 		onSplit,
+		onSplitAtEnd,
 		__unstableOnSplitMiddle: onSplitMiddle,
 		identifier,
 		// To do: find a better way to implicitly inherit props.
@@ -360,11 +361,17 @@ function RichTextWrapper(
 				} else {
 					onChange( insertLineSeparator( value ) );
 				}
-			} else if ( shiftKey || ! canSplit ) {
+			} else if ( shiftKey ) {
 				if ( ! disableLineBreaks ) {
 					onChange( insert( value, '\n' ) );
 				}
-			} else {
+			} else if ( onSplitAtEnd && ! canSplit ) {
+				const { text, start, end } = value;
+
+				if ( start === end && end === text.length ) {
+					onSplitAtEnd();
+				}
+			} else if ( canSplit ) {
 				splitValue( value );
 			}
 		},

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -117,7 +117,7 @@ function RichTextWrapper(
 		onRemove,
 		onMerge,
 		onSplit,
-		onSplitAtEnd,
+		__unstableOnSplitAtEnd: onSplitAtEnd,
 		__unstableOnSplitMiddle: onSplitMiddle,
 		identifier,
 		// To do: find a better way to implicitly inherit props.
@@ -361,7 +361,7 @@ function RichTextWrapper(
 				} else {
 					onChange( insertLineSeparator( value ) );
 				}
-			} else if ( shiftKey ) {
+			} else if ( shiftKey || ( ! canSplit && ! onSplitAtEnd ) ) {
 				if ( ! disableLineBreaks ) {
 					onChange( insert( value, '\n' ) );
 				}

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -38,6 +38,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { getPath } from '@wordpress/url';
 import { withViewportMatch } from '@wordpress/viewport';
 import { image as icon } from '@wordpress/icons';
+import { createBlock } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -334,6 +335,7 @@ export class ImageEdit extends Component {
 			isRTL,
 			onResizeStart,
 			onResizeStop,
+			insertBlocksAfter,
 		} = this.props;
 		const {
 			url,
@@ -671,6 +673,11 @@ export class ImageEdit extends Component {
 							}
 							isSelected={ this.state.captionFocused }
 							inlineToolbar
+							onSplitAtEnd={ () =>
+								insertBlocksAfter(
+									createBlock( 'core/paragraph' )
+								)
+							}
 						/>
 					) }
 

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -673,7 +673,7 @@ export class ImageEdit extends Component {
 							}
 							isSelected={ this.state.captionFocused }
 							inlineToolbar
-							onSplitAtEnd={ () =>
+							__unstableOnSplitAtEnd={ () =>
 								insertBlocksAfter(
 									createBlock( 'core/paragraph' )
 								)


### PR DESCRIPTION
## Description

Kind of ridiculous that I haven't fixed this earlier. Requires a new RichText prop though because the behaviour is quite different from `onSplit`.

Should it be marked an unstable API at first?
Should `Enter` from the middle of a caption create a new empty paragraph below? Maybe be a nicer experience.

To do: add this to all other blocks with a caption. Which makes me wonder... should we create a figure-caption component to be used in blocks?

To do: on `Backspace` from an empty paragraph, the caret should be placed at the end of the caption, but that's an issue in `master` too.

## How has this been tested?

Place the caret at the end of an image caption and press `Enter`. A new paragraph should be created after the image.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
