### PR TITLE
Writing Flow: fix reverse selection after block deletion from rich text

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -17,7 +17,12 @@ import {
 	getBlockDefaultClassName,
 } from '@wordpress/blocks';
 import { withFilters } from '@wordpress/components';
-import { withDispatch, withSelect, useSelect, useDispatch } from '@wordpress/data';
+import {
+	withDispatch,
+	withSelect,
+	useSelect,
+	useDispatch,
+} from '@wordpress/data';
 import { withViewportMatch } from '@wordpress/viewport';
 import { compose, pure, ifCondition } from '@wordpress/compose';
 

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -17,7 +17,7 @@ import {
 	getBlockDefaultClassName,
 } from '@wordpress/blocks';
 import { withFilters } from '@wordpress/components';
-import { withDispatch, withSelect, useSelect } from '@wordpress/data';
+import { withDispatch, withSelect, useSelect, useDispatch } from '@wordpress/data';
 import { withViewportMatch } from '@wordpress/viewport';
 import { compose, pure, ifCondition } from '@wordpress/compose';
 
@@ -74,6 +74,8 @@ function BlockListBlock( {
 			isHighlighted: isBlockHighlighted( clientId ),
 		};
 	}, [] );
+	const { removeBlock } = useDispatch( 'core/block-editor' );
+	const onRemove = () => removeBlock( clientId );
 
 	// Handling the error state
 	const [ hasError, setErrorState ] = useState( false );
@@ -137,6 +139,7 @@ function BlockListBlock( {
 			setAttributes={ setAttributes }
 			insertBlocksAfter={ isLocked ? undefined : onInsertBlocksAfter }
 			onReplace={ isLocked ? undefined : onReplace }
+			onRemove={ isLocked ? undefined : onRemove }
 			mergeBlocks={ isLocked ? undefined : onMerge }
 			clientId={ clientId }
 			isSelectionEnabled={ isSelectionEnabled }

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1212,6 +1212,8 @@ export function initialPosition( state, action ) {
 		return action.initialPosition;
 	} else if ( action.type === 'REMOVE_BLOCKS' ) {
 		return state;
+	} else if ( action.type === 'START_TYPING' ) {
+		return state;
 	}
 
 	// Reset the state by default (for any action not handled).

--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -94,6 +94,7 @@ function ParagraphBlock( {
 	attributes,
 	mergeBlocks,
 	onReplace,
+	onRemove,
 	setAttributes,
 } ) {
 	const {
@@ -178,7 +179,7 @@ function ParagraphBlock( {
 				} }
 				onMerge={ mergeBlocks }
 				onReplace={ onReplace }
-				onRemove={ onReplace ? () => onReplace( [] ) : undefined }
+				onRemove={ onRemove }
 				aria-label={
 					content
 						? __( 'Paragraph block' )

--- a/packages/e2e-tests/specs/editor/blocks/image.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/image.test.js
@@ -85,4 +85,17 @@ describe( 'Image', () => {
 
 		expect( await getEditedPostContent() ).toBe( '' );
 	} );
+
+	it( 'should place caret at end of caption after merging empty paragraph', async () => {
+		await insertBlock( 'Image' );
+		await upload( '.wp-block-image input[type="file"]' );
+		await page.keyboard.type( '1' );
+		await insertBlock( 'Paragraph' );
+		await page.keyboard.press( 'Backspace' );
+		await page.keyboard.type( '2' );
+
+		expect(
+			await page.evaluate( () => document.activeElement.innerHTML )
+		).toBe( '12' );
+	} );
 } );


### PR DESCRIPTION
## Description

See also #22290.

Currently, when you press Backspace in an empty paragraph that is preceded by an image block (for example), the caret selection ends up at the last text field (caption) but not at end of that field.

It seems that some blocks are passing `onReplace( [] )` as `onRemove` to RichText, which is really strange. Semantically, this should be just `onRemove`, which also handles setting the selection correctly.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
