### PR TITLE
 Adds a default text label to the block appender when it can only insert a single block type

### DIFF
--- a/packages/block-editor/src/components/button-block-appender/index.js
+++ b/packages/block-editor/src/components/button-block-appender/index.js
@@ -16,13 +16,6 @@ import { Icon, create } from '@wordpress/icons';
  */
 import Inserter from '../inserter';
 
-function AddTooltipForIconButton( { hasTooltip, tooltipLabel, button } ) {
-	if ( hasTooltip ) {
-		return <Tooltip text={ tooltipLabel }> { button } </Tooltip>;
-	}
-	return button;
-}
-
 function ButtonBlockAppender(
 	{
 		rootClientId,
@@ -60,7 +53,7 @@ function ButtonBlockAppender(
 				}
 				const isToggleButton = ! hasSingleBlockType;
 
-				const inserterButton = (
+				let inserterButton = (
 					<Button
 						ref={ ref }
 						onFocus={ onFocus }
@@ -79,16 +72,20 @@ function ButtonBlockAppender(
 							<VisuallyHidden as="span">{ label }</VisuallyHidden>
 						) }
 						<Icon icon={ create } />
-						{ hasSingleBlockType && <span>{ label } </span> }
+						{ hasSingleBlockType && (
+							<span className="block-editor-button-block-appender__label">
+								{ label }{ ' ' }
+							</span>
+						) }
 					</Button>
 				);
-				return (
-					<AddTooltipForIconButton
-						hasTooltip={ ! hasSingleBlockType }
-						tooltipLabel={ label }
-						button={ inserterButton }
-					/>
-				);
+
+				if ( isToggleButton ) {
+					inserterButton = (
+						<Tooltip text={ label }> { inserterButton } </Tooltip>
+					);
+				}
+				return inserterButton;
 			} }
 			isAppender
 		/>

--- a/packages/block-editor/src/components/button-block-appender/index.js
+++ b/packages/block-editor/src/components/button-block-appender/index.js
@@ -16,6 +16,13 @@ import { Icon, create } from '@wordpress/icons';
  */
 import Inserter from '../inserter';
 
+function AddTooltipForIconButton( { hasTooltip, tooltipLabel, button } ) {
+	if ( hasTooltip ) {
+		return <Tooltip text={ tooltipLabel }> { button } </Tooltip>;
+	}
+	return button;
+}
+
 function ButtonBlockAppender(
 	{
 		rootClientId,
@@ -52,30 +59,35 @@ function ButtonBlockAppender(
 					);
 				}
 				const isToggleButton = ! hasSingleBlockType;
-				return (
-					<Tooltip text={ label }>
-						<Button
-							ref={ ref }
-							onFocus={ onFocus }
-							tabIndex={ tabIndex }
-							className={ classnames(
-								className,
-								'block-editor-button-block-appender'
-							) }
-							onClick={ onToggle }
-							aria-haspopup={
-								isToggleButton ? 'true' : undefined
-							}
-							aria-expanded={
-								isToggleButton ? isOpen : undefined
-							}
-							disabled={ disabled }
-							label={ label }
-						>
+
+				const inserterButton = (
+					<Button
+						ref={ ref }
+						onFocus={ onFocus }
+						tabIndex={ tabIndex }
+						className={ classnames(
+							className,
+							'block-editor-button-block-appender'
+						) }
+						onClick={ onToggle }
+						aria-haspopup={ isToggleButton ? 'true' : undefined }
+						aria-expanded={ isToggleButton ? isOpen : undefined }
+						disabled={ disabled }
+						label={ label }
+					>
+						{ ! hasSingleBlockType && (
 							<VisuallyHidden as="span">{ label }</VisuallyHidden>
-							<Icon icon={ create } />
-						</Button>
-					</Tooltip>
+						) }
+						<Icon icon={ create } />
+						{ hasSingleBlockType && <span>{ label } </span> }
+					</Button>
+				);
+				return (
+					<AddTooltipForIconButton
+						hasTooltip={ ! hasSingleBlockType }
+						tooltipLabel={ label }
+						button={ inserterButton }
+					/>
 				);
 			} }
 			isAppender

--- a/packages/block-editor/src/components/button-block-appender/style.scss
+++ b/packages/block-editor/src/components/button-block-appender/style.scss
@@ -41,7 +41,7 @@
 			color: $white;
 		}
 
-		& > span {
+		.block-editor-button-block-appender__label {
 			display: block;
 			margin-left: $grid-unit-10;
 		}

--- a/packages/block-editor/src/components/button-block-appender/style.scss
+++ b/packages/block-editor/src/components/button-block-appender/style.scss
@@ -23,16 +23,27 @@
 
 	// This variant is used in inline situations, like Buttons, Social Links, Navigation Menu.
 	&.block-list-appender__toggle {
-		background: $dark-gray-primary;
-		color: $white;
+		display: flex;
+		flex-direction: row;
+		color: $dark-gray-primary;
 		box-shadow: none;
-		width: 24px;
 		height: 24px;
 		padding: 0;
 		margin-left: $grid-unit-10;
 
 		&:active {
 			color: $white;
+		}
+
+		& > svg {
+			width: 24px;
+			background-color: $dark-gray-primary;
+			color: $white;
+		}
+
+		& > span {
+			display: block;
+			margin-left: $grid-unit-10;
 		}
 	}
 }


### PR DESCRIPTION
## Description
Closes #20728
Adds a default text label to the block appender when it can only insert a single block type.

## How has this been tested?
Tested locally by:

1. Add a new post
2. Insert a Navigation block, a Buttons block and a Columns block
3. Verify that:
a) for the Navigation / Buttons block when selected the appender shows when the block is selected
b) for the Navigation / Buttons block when selected the appender has a label specifying the kind of block to add when the parent block is selected
c) for the columns block the default appender (after inserting a paragraph) does not show a label, but does show a tooltip with the text "Add block"

## Screenshots <!-- if applicable -->

![new-appender](https://user-images.githubusercontent.com/107534/81674048-4476f880-9455-11ea-9c30-692f21536c99.gif)


## Types of changes
Non breaking change that reuses the text for the existing tool tip of the appender to show a default label next to the icon.

## Issues
As can be seen in the GIF above, there are a few issues:

* the appender flows to the next line much faster
* in some contexts it is too big
* it gets displayed weirdly when space constrained

A separate issue is that is appears that blocks don't use the same appender. E.g. the social icons block does not show the "Add block" tooltip as you'd expect. neither is shows another tooltip at all, which means it uses a custom appender. 
