### PR TITLE
Try switching wordpress install in travis to wp-env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,44 +53,12 @@ install:
   - npm run build
   - |
     if [[ "$INSTALL_WORDPRESS" = "true" ]]; then
-      # Download and unpack WordPress.
-      curl -sL https://github.com/WordPress/WordPress/archive/master.zip -o /tmp/wordpress-latest.zip
-      unzip -q /tmp/wordpress-latest.zip -d /tmp
-      mkdir -p wordpress/src
-      mv /tmp/WordPress-master/* wordpress/src
-
-      # Create the upload directory with permissions that Travis can handle.
-      mkdir -p wordpress/src/wp-content/uploads
-      chmod 767 wordpress/src/wp-content/uploads
-
-      # Grab the tools we need for WordPress' local-env.
-      curl -sL https://github.com/WordPress/wordpress-develop/archive/master.zip -o /tmp/wordpress-develop.zip
-      unzip -q /tmp/wordpress-develop.zip -d /tmp
-      mv \
-        /tmp/wordpress-develop-master/tools \
-        /tmp/wordpress-develop-master/tests \
-        /tmp/wordpress-develop-master/.env \
-        /tmp/wordpress-develop-master/docker-compose.yml \
-        /tmp/wordpress-develop-master/wp-cli.yml \
-        /tmp/wordpress-develop-master/*config-sample.php \
-        /tmp/wordpress-develop-master/package.json wordpress
-
-      # Install WordPress. The additional dependencies are required by the copied `wordpress-develop` tools.
-      cd wordpress
-      npm install dotenv wait-on
-      npm run env:start
-      sleep 10
-      npm run env:install
-      cd ..
-
-      # Connect Gutenberg to WordPress.
-      npm run env connect
-      npm run env cli plugin activate gutenberg
+      npm run wp-env start
     fi
   - |
     if [[ "$E2E_ROLE" = "author" ]]; then
-      npm run env cli -- user create author author@example.com --role=author --user_pass=authpass
-      npm run env cli -- post update 1 --post_author=2
+      npm run wp-env run "wp user create author author@example.com --role=author --user_pass=authpass"
+      npm run wp-env run "wp post update 1 --post_author=2"
     fi
 
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,8 +57,8 @@ install:
     fi
   - |
     if [[ "$E2E_ROLE" = "author" ]]; then
-      npm run wp-env run "wp user create author author@example.com --role=author --user_pass=authpass"
-      npm run wp-env run "wp post update 1 --post_author=2"
+      npm run wp-env run tests-cli "wp user create author author@example.com --role=author --user_pass=authpass"
+      npm run wp-env run tests-cli "wp post update 1 --post_author=2"
     fi
 
 jobs:


### PR DESCRIPTION
## Description
Curious to see if this works and what would need to be changed. I'm using `npm run wp-env...` because I think that uses the local wp-env in the git checkout. So that would help us make sure that wp-env keeps working. 

phpunit tests will probably keep failing. That depends on #20090

I spun this up because all our e2e tests started failing because of an issue in wordpress-develop. 

## How has this been tested?
Travis
