### PR TITLE
Use interface on widgets screen sidebar

### DIFF
--- a/packages/edit-widgets/src/components/header/index.js
+++ b/packages/edit-widgets/src/components/header/index.js
@@ -4,6 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { NavigableMenu } from '@wordpress/components';
 import { BlockNavigationDropdown, Inserter } from '@wordpress/block-editor';
+import { PinnedItems } from '@wordpress/interface';
 
 /**
  * Internal dependencies
@@ -32,6 +33,7 @@ function Header() {
 			</h1>
 			<div className="edit-widgets-header__actions">
 				<SaveButton />
+				<PinnedItems.Slot scope="core/edit-widgets" />
 			</div>
 		</div>
 	);

--- a/packages/edit-widgets/src/components/header/style.scss
+++ b/packages/edit-widgets/src/components/header/style.scss
@@ -11,3 +11,7 @@
 	padding: 0 20px;
 	margin: 0;
 }
+
+.edit-widgets-header__actions {
+	display: flex;
+}

--- a/packages/edit-widgets/src/components/layout/index.js
+++ b/packages/edit-widgets/src/components/layout/index.js
@@ -1,15 +1,15 @@
 /**
  * WordPress dependencies
  */
-import { Popover, Panel } from '@wordpress/components';
-import { BlockInspector } from '@wordpress/block-editor';
+import { Popover } from '@wordpress/components';
+import { InterfaceSkeleton, ComplementaryArea } from '@wordpress/interface';
 import { useViewportMatch } from '@wordpress/compose';
-import { InterfaceSkeleton } from '@wordpress/interface';
-import { __ } from '@wordpress/i18n';
+
 /**
  * Internal dependencies
  */
 import Header from '../header';
+import Sidebar from '../sidebar';
 import WidgetAreasBlockEditorProvider from '../widget-areas-block-editor-provider';
 import WidgetAreasBlockEditorContent from '../widget-areas-block-editor-content';
 
@@ -24,13 +24,10 @@ function Layout( { blockEditorSettings } ) {
 				header={ <Header /> }
 				sidebar={
 					! isMobile && (
-						<div className="edit-widgets-sidebar">
-							<Panel header={ __( 'Block Areas' ) }>
-								<BlockInspector
-									showNoBlockSelectedMessage={ false }
-								/>
-							</Panel>
-						</div>
+						<>
+							<ComplementaryArea.Slot scope="core/edit-widgets" />
+							<Sidebar />
+						</>
 					)
 				}
 				content={ <WidgetAreasBlockEditorContent /> }

--- a/packages/edit-widgets/src/components/sidebar/index.js
+++ b/packages/edit-widgets/src/components/sidebar/index.js
@@ -1,0 +1,22 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { ComplementaryArea } from '@wordpress/interface';
+import { BlockInspector } from '@wordpress/block-editor';
+import { cog } from '@wordpress/icons';
+
+export default function Sidebar() {
+	return (
+		<ComplementaryArea
+			className="edit-widgets-sidebar"
+			smallScreenTitle={ __( 'Widget Areas' ) }
+			scope="core/edit-widgets"
+			complementaryAreaIdentifier="edit-widgets/block-inspector"
+			title={ __( 'Block' ) }
+			icon={ cog }
+		>
+			<BlockInspector showNoBlockSelectedMessage={ false } />
+		</ComplementaryArea>
+	);
+}

--- a/packages/edit-widgets/src/style.scss
+++ b/packages/edit-widgets/src/style.scss
@@ -53,43 +53,12 @@ body.gutenberg_page_gutenberg-widgets {
 	}
 }
 
-/**
- * Animations
- */
-
-// These keyframes should not be part of the _animations.scss mixins file.
-// Because keyframe animations can't be defined as mixins properly, they are duplicated.
-// Since hey are intended only for the editor, we add them here instead.
-@keyframes edit-post__fade-in-animation {
-	from {
-		opacity: 0;
-	}
-	to {
-		opacity: 1;
-	}
-}
-
-.edit-widgets-sidebar {
-	width: $sidebar-width;
-
-	> .components-panel {
-		margin-top: -1px;
-		margin-bottom: -1px;
-		border-left: 0;
-		border-right: 0;
-
-		> .components-panel__header {
-			background: $light-gray-200;
-		}
-	}
-
-	.block-editor-block-inspector__card {
-		margin: 0;
-	}
-}
-
 .blocks-widgets-container .editor-style-wrapper {
 	max-width: $widget-area-width;
 	margin: auto;
+}
+
+.edit-widgets-sidebar .components-button.interface-complementary-area__pin-unpin-item {
+	display: none;
 }
 

--- a/packages/interface/src/store/defaults.js
+++ b/packages/interface/src/store/defaults.js
@@ -4,6 +4,7 @@ export const DEFAULTS = {
 			complementaryArea: {
 				'core/edit-site': 'edit-site/block-inspector',
 				'core/edit-post': 'edit-post/document',
+				'core/edit-widgets': 'edit-widgets/block-inspector',
 			},
 		},
 	},


### PR DESCRIPTION
## Description
Branched from https://github.com/WordPress/gutenberg/pull/22140.

This PR adds the complementary area mechanism from the WordPress interface package into the widgets screen.
This allows the sidebar to be toggled on and off like in the other screens.

