### PR TITLE
Build Tooling: Configure Webpack to skip Node polyfills

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -41,6 +41,7 @@ const gutenbergPackages = Object.keys( dependencies )
 
 module.exports = {
 	// TODO: Remove when upgrading to webpack v5.
+	// @see https://github.com/WordPress/gutenberg/issues/21647.
 	node: false,
 	optimization: {
 		// Only concatenate modules in production, when not analyzing bundles.

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -40,6 +40,7 @@ const gutenbergPackages = Object.keys( dependencies )
 	.map( ( packageName ) => packageName.replace( WORDPRESS_NAMESPACE, '' ) );
 
 module.exports = {
+	node: false,
 	optimization: {
 		// Only concatenate modules in production, when not analyzing bundles.
 		concatenateModules:

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -40,6 +40,7 @@ const gutenbergPackages = Object.keys( dependencies )
 	.map( ( packageName ) => packageName.replace( WORDPRESS_NAMESPACE, '' ) );
 
 module.exports = {
+	// TODO: Remove when upgrading to webpack v5.
 	node: false,
 	optimization: {
 		// Only concatenate modules in production, when not analyzing bundles.


### PR DESCRIPTION
## Description
Closes https://github.com/WordPress/gutenberg/issues/21647.

> Context:
> 
> Webpack will no longer polyfill Node modules automatically in the upcoming v5 release:
> 
> https://github.com/webpack/changelog-v5/blob/master/README.md#automatic-nodejs-polyfills-removed
> 
> Task:
> 
> Configure default Webpack configurations to disable node polyfills as false:
> 
> https://webpack.js.org/configuration/node/#node
> 
> Motivation:
> 
> Simplify a future upgrade to Webpack 5 by avoiding to put ourselves in the situation of migrating away from the automatic polyfills, by forbidding their introduction in the first place.

## How has this been tested?

`npm run dev` or `npm run build`

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [N/A] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [N/A] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [N/A] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
