### PR TITLE
Global Styles: use CSS variables to mark block style hooks

### DIFF
--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -243,6 +243,64 @@ function gutenberg_experimental_global_styles_enqueue_assets_editor() {
 }
 
 /**
+ * Converts the block implicit attributes into CSS declarations.
+ *
+ * @return string
+ */
+function gutenberg_experimental_global_styles_output_implicit_attributes( $block_attributes ) {
+	$declaration = '';
+	foreach ( $block_attributes as $att ) {
+		$declaration .= $att . ': var(--wp-' . $att . ');';
+	}
+	return $declaration;
+}
+
+/**
+ * Returns the CSS with the block style hooks
+ *
+ * @return string
+ */
+function gutenberg_experimental_global_styles_block_style_hooks() {
+	// This data should come from the block.json.
+	// We'd need the ability to have many selectors per block
+	// like for heading (core/heading/h1, core/heading/h2, etc)
+	// but potentially for other blocks that have complex layouts
+	// (ex: for gallery we may want to target the wrapper element
+	// and the individual images).
+	//
+	// Having access to this via the block registry
+	// requires block server registration.
+	$block_data = array(
+		'core/paragraph'  => array(
+			'supports' => array( 'line-height', 'font-size', 'color' ),
+			'selector' => 'p',
+		),
+		'core/heading'    => array(
+			'supports' => array( 'line-height', 'font-size', 'color' ),
+			'selector' => 'h1, h2, h3, h4, h5, h6',
+		),
+		'core/columns'    => array(
+			'supports' => array( 'color' ),
+			'selector' => '.wp-block-columns',
+		),
+		'core/group'      => array(
+			'supports' => array( 'color' ),
+			'selector' => '.wp-block-group',
+		),
+		'core/media-text' => array(
+			'supports' => array( 'color' ),
+			'selector' => '.wp-block-media-text',
+		),
+	);
+
+	$block_style_hooks = '';
+	foreach ( $block_data as $block ) {
+		$block_style_hooks .= '' . $block['selector'] . '{' . gutenberg_experimental_global_styles_output_implicit_attributes( $block['supports'] ) . '}';
+	}
+	return $block_style_hooks;
+}
+
+/**
  * Fetches the Global Styles for each level (core, theme, user)
  * and enqueues the resulting CSS custom properties.
  */
@@ -261,10 +319,14 @@ function gutenberg_experimental_global_styles_enqueue_assets() {
 	if ( empty( $inline_style ) ) {
 		return;
 	}
-
 	wp_register_style( 'global-styles', false, array(), true, true );
 	wp_add_inline_style( 'global-styles', $inline_style );
 	wp_enqueue_style( 'global-styles' );
+
+	$block_style_hooks = gutenberg_experimental_global_styles_block_style_hooks();
+	wp_register_style( 'global-styles-block-style-hooks', false, array(), true, true );
+	wp_add_inline_style( 'global-styles-block-style-hooks', $block_style_hooks );
+	wp_enqueue_style( 'global-styles-block-style-hooks' );
 }
 
 /**


### PR DESCRIPTION
Continues work from: #19883 #20047
Alternative to https://github.com/WordPress/gutenberg/pull/20290
See larger picture at #22296

This PR takes a different stance than https://github.com/WordPress/gutenberg/pull/20290 so should be considered an alternative. Note that this is a Proof of Concept, to share direction and gather feedback. The idea is that we take the implicit attributes declared from blocks and make them CSS variables bound to that block. 

**Input**. Let's say the paragraph block declares through its settings that it has support for some implicit attributes and also provides a CSS selector:

```js
__experimentalSelector: 'p',
supports: {
    __experimentalColor: true,
    __experimentalLineHeight: true,
    __experimentalFontSize: true,
},
```

**Output**. We enqueue a new embedded stylesheet for that block that looks like this:

```css
p {
    color: var(--wp-color);
    line-height: var(--wp-line-height);
    font-size: var(--wp-font-size);
}
```

Unlike https://github.com/WordPress/gutenberg/pull/20290 this doesn't try to provide a way to "manage CSS" so it's the theme responsibility to set the values of the variables for the contexts in which a block can be used (top-level document, within a pattern, etc).

A theme should do something along this lines:

```css
p {
  --wp-color: <value>,
  --wp-line-height: <value>
  --wp-font-size: <value>
}

// Different values for a paragraph within the numbered features pattern
.wp-block-column:first-child p {
  --wp-color: <value>,
  --wp-line-height: <value>
  --wp-font-size: <value>
}
```