### PR TITLE
Lower spacer  and cover block step values

### DIFF
--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -390,7 +390,7 @@ function CoverEdit( {
 									}
 									min={ 0 }
 									max={ 100 }
-									step={ 10 }
+									step={ 1 }
 									required
 								/>
 							) }

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -390,7 +390,6 @@ function CoverEdit( {
 									}
 									min={ 0 }
 									max={ 100 }
-									step={ 1 }
 									required
 								/>
 							) }

--- a/packages/block-library/src/spacer/edit.js
+++ b/packages/block-library/src/spacer/edit.js
@@ -71,7 +71,6 @@ const SpacerEdit = ( {
 						max={ Math.max( MAX_SPACER_HEIGHT, height ) }
 						value={ height }
 						onChange={ updateHeight }
-						step={ 1 }
 					/>
 				</PanelBody>
 			</InspectorControls>

--- a/packages/block-library/src/spacer/edit.js
+++ b/packages/block-library/src/spacer/edit.js
@@ -11,7 +11,6 @@ import { InspectorControls } from '@wordpress/block-editor';
 import { PanelBody, ResizableBox, RangeControl } from '@wordpress/components';
 import { compose, withInstanceId } from '@wordpress/compose';
 import { withDispatch } from '@wordpress/data';
-import { Platform } from '@wordpress/element';
 
 const MIN_SPACER_HEIGHT = 20;
 const MAX_SPACER_HEIGHT = 500;
@@ -72,7 +71,7 @@ const SpacerEdit = ( {
 						max={ Math.max( MAX_SPACER_HEIGHT, height ) }
 						value={ height }
 						onChange={ updateHeight }
-						step={ Platform.OS === 'web' ? 10 : 1 }
+						step={ 1 }
 					/>
 				</PanelBody>
 			</InspectorControls>


### PR DESCRIPTION
## Description
Fixes #22166 This lowers the step value of the spacer and cover block slider controls.

### Before
When using the `RangeControl` input, the user could not set a value between 1 and 10 px either by using the slider or with the text input. 

### After
By lowering the step value to 1 (by removing it), the user can enter specific values.

### Additional thoughts
I believe the issue of not being able to enter any specific pixel value into the `RangeControl` when a step larger than 2px is set  (3+) is still a problem. Perhaps @ItsJonQ might have an idea about that.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
