### PR TITLE
[RNMobile] - Portfolio template - Missing Gallery block ids

### DIFF
--- a/packages/block-editor/src/components/page-template-picker/templates/portfolio.native.js
+++ b/packages/block-editor/src/components/page-template-picker/templates/portfolio.native.js
@@ -41,28 +41,35 @@ const Portfolio = {
 					{
 						url:
 							'https://a8ctm1.files.wordpress.com/2019/08/scatter-1.jpg?w=640',
+						id: '658',
 					},
 					{
 						url:
 							'https://a8ctm1.files.wordpress.com/2019/08/redcylinder-1.jpg?w=640',
+						id: '659',
 					},
 					{
 						url:
 							'https://a8ctm1.files.wordpress.com/2019/08/redbox.jpg?w=640',
+						id: '660',
 					},
 					{
 						url:
 							'https://a8ctm1.files.wordpress.com/2019/08/crab-1.jpg?w=640',
+						id: '661',
 					},
 					{
 						url:
 							'https://a8ctm1.files.wordpress.com/2019/08/cat.jpg?w=640',
+						id: '662',
 					},
 					{
 						url:
 							'https://a8ctm1.files.wordpress.com/2019/08/bluebox.jpg?w=640',
+						id: '663',
 					},
 				],
+				ids: [ 658, 659, 660, 661, 662, 663 ],
 				caption: '',
 				imageCrop: true,
 				linkTo: 'none',
@@ -111,28 +118,35 @@ const Portfolio = {
 					{
 						url:
 							'https://a8ctm1.files.wordpress.com/2019/08/scatter-1.jpg?w=640',
+						id: '658',
 					},
 					{
 						url:
 							'https://a8ctm1.files.wordpress.com/2019/08/redcylinder-1.jpg?w=640',
+						id: '659',
 					},
 					{
 						url:
 							'https://a8ctm1.files.wordpress.com/2019/08/redbox.jpg?w=640',
+						id: '660',
 					},
 					{
 						url:
 							'https://a8ctm1.files.wordpress.com/2019/08/crab-1.jpg?w=640',
+						id: '661',
 					},
 					{
 						url:
 							'https://a8ctm1.files.wordpress.com/2019/08/cat.jpg?w=640',
+						id: '662',
 					},
 					{
 						url:
 							'https://a8ctm1.files.wordpress.com/2019/08/bluebox.jpg?w=640',
+						id: '663',
 					},
 				],
+				ids: [ 658, 659, 660, 661, 662, 663 ],
 				caption: '',
 				imageCrop: true,
 				linkTo: 'none',


### PR DESCRIPTION
`Gutenberg Mobile PR` -> https://github.com/wordpress-mobile/gutenberg-mobile/pull/2257

## Description
Adds missing ids to the galleries to avoid images disappearing when adding new ones.

## How has this been tested?
- Open the app with metro running.
- Go to Pages.
- Add a new page.
- Select the Portfolio template in the picker.
- Apply the template.
- Go to the gallery block and append new images.
- **Expect** to see the old images and the new ones.

## Screenshots
![Kapture 2020-05-13 at 16 56 04](https://user-images.githubusercontent.com/4885740/81828957-aeb59900-953a-11ea-9c23-c4e7af23a8ed.gif)

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
