### PR TITLE
AlignmentMatrixControl: Icon: Fix dot alignment rendering

### DIFF
--- a/packages/components/src/alignment-matrix-control/styles/alignment-matrix-control-icon-styles.js
+++ b/packages/components/src/alignment-matrix-control/styles/alignment-matrix-control-icon-styles.js
@@ -14,11 +14,11 @@ import {
 } from './alignment-matrix-control-styles';
 
 const rootSize = () => {
-	const padding = 2;
+	const padding = 1.5;
 	const size = 24;
 
 	return css( {
-		gridTemplateRows: `repeat( 3, calc( ${ size - 2 }px / 3))`,
+		gridTemplateRows: `repeat( 3, calc( ${ size - padding * 2 }px / 3))`,
 		padding,
 		maxHeight: size,
 		maxWidth: size,


### PR DESCRIPTION
## Description

<img width="302" alt="Screen Shot 2020-05-13 at 11 04 02 AM" src="https://user-images.githubusercontent.com/2322354/81831964-f4a73880-950b-11ea-8cbb-43fda8d07ef1.png">

This update fixes the alignment rendering of the 9 dots that appear in the
AlignmentMatrixControl icon. The solution was to adjust the values to
have something divisible by 3 (for the grid columns).

This solution has been tested on both high DPI displays (Retina) and
regular DPI displays.

Before:
![image](https://user-images.githubusercontent.com/2322354/81832012-012b9100-950c-11ea-91c2-8f01c98a3684.png)

(Does not always occur. It depends on browser size/screen)

After:
<img width="302" alt="Screen Shot 2020-05-13 at 11 04 02 AM" src="https://user-images.githubusercontent.com/2322354/81831991-fb35b000-950b-11ea-9991-1d82c0849e81.png">

(More consistent rendering)


## How has this been tested?
* Tested in local Gutenberg on various displays


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
