### PR TITLE
Close button: extensibility in post editor

### DIFF
--- a/docs/designers-developers/developers/slotfills/main-dashboard-button.md
+++ b/docs/designers-developers/developers/slotfills/main-dashboard-button.md
@@ -7,12 +7,14 @@ the editor in fullscreen mode.
 
 ```js
 import { registerPlugin } from '@wordpress/plugins';
-import { __experimentalMainDashboardButton } from '@wordpress/edit-site';
+import { 
+	__experimentalMainDashboardButton as MainDashboardButton,
+} from '@wordpress/interface';
 
 const MainDashboardButtonTest = () => (
-    <__experimentalMainDashboardButton>
+    <MainDashboardButton>
         Custom main dashboard button content
-    </__experimentalMainDashboardButton>
+    </MainDashboardButton>
 );
 
 registerPlugin( 'main-dashboard-button-test', {
@@ -25,17 +27,19 @@ in the following way:
 
 ```js
 import { registerPlugin } from '@wordpress/plugins';
-import { 
-	__experimentalMainDashboardButton,
-	__experimentalFullscrenModeClose
+import {
+	__experimentalFullscrenModeClose as FullscrenModeClose, 
 } from '@wordpress/edit-site';
+import { 
+	__experimentalMainDashboardButton as MainDashboardButton,
+} from '@wordpress/interface';
 import { close } from '@wordpress/icons';	
 	
 
 const MainDashboardButtonIconTest = () => (
-    <__experimentalMainDashboardButton>
-        <__experimentalFullscrenModeClose icon={ close } />
-    </__experimentalMainDashboardButton>
+    <MainDashboardButton>
+        <FullscrenModeClose icon={ close } />
+    </MainDashboardButton>
 );
 
 registerPlugin( 'main-dashboard-button-icon-test', {

--- a/packages/edit-post/src/components/header/index.js
+++ b/packages/edit-post/src/components/header/index.js
@@ -8,7 +8,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { cog } from '@wordpress/icons';
 import {
 	PinnedItems,
-	__experimentalCloseButtonSlot as CloseButtonSlot,
+	__experimentalMainDashboardButton as MainDashboardButton,
 } from '@wordpress/interface';
 
 /**
@@ -69,9 +69,9 @@ function Header( {
 
 	return (
 		<div className="edit-post-header">
-			<CloseButtonSlot>
+			<MainDashboardButton.Slot>
 				<FullscreenModeClose />
-			</CloseButtonSlot>
+			</MainDashboardButton.Slot>
 			<div className="edit-post-header__toolbar">
 				<HeaderToolbar
 					onToggleInserter={ onToggleInserter }

--- a/packages/edit-post/src/components/header/index.js
+++ b/packages/edit-post/src/components/header/index.js
@@ -6,7 +6,10 @@ import { Button } from '@wordpress/components';
 import { PostSavedState, PostPreviewButton } from '@wordpress/editor';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { cog } from '@wordpress/icons';
-import { PinnedItems } from '@wordpress/interface';
+import {
+	PinnedItems,
+	__experimentalCloseButtonSlot as CloseButtonSlot,
+} from '@wordpress/interface';
 
 /**
  * Internal dependencies
@@ -66,7 +69,9 @@ function Header( {
 
 	return (
 		<div className="edit-post-header">
-			<FullscreenModeClose />
+			<CloseButtonSlot>
+				<FullscreenModeClose />
+			</CloseButtonSlot>
 			<div className="edit-post-header__toolbar">
 				<HeaderToolbar
 					onToggleInserter={ onToggleInserter }

--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -155,3 +155,4 @@ export { default as PluginPostStatusInfo } from './components/sidebar/plugin-pos
 export { default as PluginPrePublishPanel } from './components/sidebar/plugin-pre-publish-panel';
 export { default as PluginSidebar } from './components/sidebar/plugin-sidebar';
 export { default as PluginSidebarMoreMenuItem } from './components/header/plugin-sidebar-more-menu-item';
+export { default as __experimentalFullscreenModeClose } from './components/header/fullscreen-mode-close';

--- a/packages/edit-site/src/components/header/index.js
+++ b/packages/edit-site/src/components/header/index.js
@@ -9,7 +9,10 @@ import {
 	__experimentalPreviewOptions as PreviewOptions,
 } from '@wordpress/block-editor';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { PinnedItems } from '@wordpress/interface';
+import {
+	PinnedItems,
+	__experimentalCloseButtonSlot as CloseButtonSlot,
+} from '@wordpress/interface';
 
 /**
  * Internal dependencies
@@ -20,7 +23,7 @@ import TemplateSwitcher from '../template-switcher';
 import SaveButton from '../save-button';
 import UndoButton from './undo-redo/undo';
 import RedoButton from './undo-redo/redo';
-import { CloseButton } from './main-dashboard-button';
+import FullscreenModeClose from './fullscreen-mode-close';
 
 const inserterToggleProps = { isPrimary: true };
 
@@ -64,7 +67,9 @@ export default function Header( { openEntitiesSavedStates } ) {
 
 	return (
 		<div className="edit-site-header">
-			<CloseButton />
+			<CloseButtonSlot>
+				<FullscreenModeClose />
+			</CloseButtonSlot>
 			<div className="edit-site-header__toolbar">
 				<Inserter
 					position="bottom right"

--- a/packages/edit-site/src/components/header/index.js
+++ b/packages/edit-site/src/components/header/index.js
@@ -11,7 +11,7 @@ import {
 import { useSelect, useDispatch } from '@wordpress/data';
 import {
 	PinnedItems,
-	__experimentalCloseButtonSlot as CloseButtonSlot,
+	__experimentalMainDashboardButton as MainDashboardButton,
 } from '@wordpress/interface';
 
 /**
@@ -67,9 +67,9 @@ export default function Header( { openEntitiesSavedStates } ) {
 
 	return (
 		<div className="edit-site-header">
-			<CloseButtonSlot>
+			<MainDashboardButton.Slot>
 				<FullscreenModeClose />
-			</CloseButtonSlot>
+			</MainDashboardButton.Slot>
 			<div className="edit-site-header__toolbar">
 				<Inserter
 					position="bottom right"

--- a/packages/edit-site/src/index.js
+++ b/packages/edit-site/src/index.js
@@ -29,5 +29,4 @@ export function initialize( id, settings ) {
 	render( <Editor settings={ settings } />, document.getElementById( id ) );
 }
 
-export { default as __experimentalMainDashboardButton } from './components/header/main-dashboard-button';
-export { default as __experimentalFullscrenModeClose } from './components/header/fullscreen-mode-close';
+export { default as __experimentalFullscreenModeClose } from './components/header/fullscreen-mode-close';

--- a/packages/interface/src/components/index.js
+++ b/packages/interface/src/components/index.js
@@ -2,7 +2,4 @@ export { default as ComplementaryArea } from './complementary-area';
 export { default as FullscreenMode } from './fullscreen-mode';
 export { default as InterfaceSkeleton } from './interface-skeleton';
 export { default as PinnedItems } from './pinned-items';
-export {
-	default as __experimentalMainDashboardButton,
-	CloseButtonSlot as __experimentalCloseButtonSlot,
-} from './main-dashboard-button';
+export { default as __experimentalMainDashboardButton } from './main-dashboard-button';

--- a/packages/interface/src/components/index.js
+++ b/packages/interface/src/components/index.js
@@ -2,3 +2,7 @@ export { default as ComplementaryArea } from './complementary-area';
 export { default as FullscreenMode } from './fullscreen-mode';
 export { default as InterfaceSkeleton } from './interface-skeleton';
 export { default as PinnedItems } from './pinned-items';
+export {
+	default as __experimentalMainDashboardButton,
+	CloseButtonSlot as __experimentalCloseButtonSlot,
+} from './main-dashboard-button';

--- a/packages/interface/src/components/main-dashboard-button/index.js
+++ b/packages/interface/src/components/main-dashboard-button/index.js
@@ -6,12 +6,7 @@ import {
 	createSlotFill,
 } from '@wordpress/components';
 
-/**
- * Internal dependencies
- */
-import FullscreenModeClose from '../fullscreen-mode-close';
-
-const name = '__experimentalSiteEditorMainDashboardButton';
+const name = '__experimentalMainDashboardButton';
 
 const { Fill, Slot } = createSlotFill( name );
 
@@ -19,12 +14,12 @@ const MainDashboardButton = Fill;
 MainDashboardButton.Slot = Slot;
 MainDashboardButton.slotName = name;
 
-export const CloseButton = () => {
+export const CloseButtonSlot = ( { children } ) => {
 	const slot = useSlot( MainDashboardButton.slotName );
 	const hasFills = Boolean( slot.fills && slot.fills.length );
 
 	if ( ! hasFills ) {
-		return <FullscreenModeClose />;
+		return children;
 	}
 
 	return <MainDashboardButton.Slot bubblesVirtually />;

--- a/packages/interface/src/components/main-dashboard-button/index.js
+++ b/packages/interface/src/components/main-dashboard-button/index.js
@@ -6,23 +6,23 @@ import {
 	createSlotFill,
 } from '@wordpress/components';
 
-const name = '__experimentalMainDashboardButton';
+const slotName = '__experimentalMainDashboardButton';
 
-const { Fill, Slot } = createSlotFill( name );
+const { Fill, Slot: MainDashboardButtonSlot } = createSlotFill( slotName );
 
 const MainDashboardButton = Fill;
-MainDashboardButton.Slot = Slot;
-MainDashboardButton.slotName = name;
 
-export const CloseButtonSlot = ( { children } ) => {
-	const slot = useSlot( MainDashboardButton.slotName );
+const Slot = ( { children } ) => {
+	const slot = useSlot( slotName );
 	const hasFills = Boolean( slot.fills && slot.fills.length );
 
 	if ( ! hasFills ) {
 		return children;
 	}
 
-	return <MainDashboardButton.Slot bubblesVirtually />;
+	return <MainDashboardButtonSlot bubblesVirtually />;
 };
+
+MainDashboardButton.Slot = Slot;
 
 export default MainDashboardButton;


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

This is a follow up PR to #22001 and #22179. It's addressing the first part of https://github.com/WordPress/gutenberg/issues/20929 issue.

The close button slot introduced for site editor in #22001 is expanded to cover the post editor too. The button can now be replaced in a similar fashion for all editor instances.

- `MainDashboardButton` has been moved to interface package so that the same slot can be reused in `edit-post` and `edit-site`.
- SlotFill docs have been updated to reflect the new changes.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

If you want to replace the whole component:

```javascript
import { registerPlugin } from '@wordpress/plugins';
import { __experimentalMainDashboardButton as MainDashboardButton } from '@wordpress/interface'

registerPlugin( 'main-dashboard-button-test', {
    render() {
        return (
            <MainDashboardButton>
	        <CustomCloseButton />
	    </MainDashboardButton>
        );
    },
} );
```

If you just want to customize the icon:

```javascript
import { registerPlugin } from '@wordpress/plugins';
import { __experimentalFullscrenModeClose as FullscrenModeClose } from '@wordpress/edit-post';
import { __experimentalMainDashboardButton as MainDashboardButton } from '@wordpress/interface'
import { close } from '@wordpress/icons';

registerPlugin( 'main-dashboard-button-test', {
    render() {
        return (
            <MainDashboardButton>
	        <FullscreenModeClose icon={ close } />
	    </MainDashboardButton>
        );
    },
} );
```

In both cases open check the post editor and site editor and make sure that the custom components are shown there.

## Screenshots <!-- if applicable -->

![image](https://user-images.githubusercontent.com/548849/76769084-40539500-679c-11ea-9aa2-8829d2e80b82.png)


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
