### PR TITLE
Add storybook story for the FocusableIframe component

### DIFF
--- a/packages/components/src/focusable-iframe/stories/index.js
+++ b/packages/components/src/focusable-iframe/stories/index.js
@@ -1,0 +1,19 @@
+/**
+ * External dependencies
+ */
+import { text } from '@storybook/addon-knobs';
+
+/**
+ * Internal dependencies
+ */
+import FocusableIframe from '../';
+
+export default {
+	title: 'Components/FocusableIframe',
+	component: FocusableIframe,
+};
+
+export const _default = () => {
+	const source = text( 'iFrame Source', './' );
+	return <FocusableIframe src={ source } />;
+};


### PR DESCRIPTION
## Description
Adds a storybook story for the FocusableIframe component as part of #17973

The accessibility checks in storybook pointed out that this component should have a title, I will follow up with a separate issue to address that.

## How has this been tested?
* run `npm run storybook:dev`
* See the new FocusableIframe story under components

## Screenshots
![Components___FocusableIframe_-_Default_⋅_Storybook_and_Add_the_storybook_story_for_the_GradientPicker_component_by_brentswisher_·_Pull_Request__21588_·_WordPress_gutenberg](https://user-images.githubusercontent.com/6653970/81834241-b101fe00-950e-11ea-9637-22c0d4ff665a.png)


## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/master/docs/contributors/native-mobile.md -->
